### PR TITLE
feat(coding-agent): add session-durable workflow DAGs

### DIFF
--- a/docs/magic-keywords.md
+++ b/docs/magic-keywords.md
@@ -8,7 +8,7 @@ Magic keywords are standalone words in a user prompt that add a hidden instructi
 |---|---|
 | `ultrathink` | Asks the agent to reason carefully through a multi-step task. When automatic thinking is active, it also selects the highest reasoning effort supported by the current model for that turn. |
 | `orchestrate` | Switches the agent to the multi-agent orchestration contract: scope the full task, delegate substantial independent work in parallel, verify each phase, and continue until the request is complete. |
-| `workflowz` | Asks the agent to build and run a deterministic multi-subagent workflow with the `task` tool. It is intended for broad research, reviews, migrations, or other work that benefits from parallel coverage. The keyword only adds its instruction when `task` is available in the active tool set. |
+| `workflowz` | Asks the agent to build and run a deterministic multi-subagent workflow. It uses the session-durable `workflow` tool for static dependency graphs and `eval` for dynamic one-turn orchestration. It is intended for broad research, reviews, migrations, or other work that benefits from parallel coverage. The keyword only adds its instruction when Task-backed orchestration is available in the active tool set. |
 
 Use the keyword anywhere in the prose of the prompt:
 

--- a/docs/tools/task.md
+++ b/docs/tools/task.md
@@ -7,6 +7,8 @@
 - Model-facing prompt: `packages/coding-agent/src/prompts/tools/task.md`
 - Key collaborators:
   - `packages/coding-agent/src/task/types.ts` — dynamic schema, progress/result types, output caps.
+  - `packages/coding-agent/src/task/dispatch-contract.ts` — shared spawn validation and normalization.
+  - `packages/coding-agent/src/task/dispatch-service.ts` — shared policy preflight plus settled internal dispatch for durable schedulers.
   - `packages/coding-agent/src/task/discovery.ts` — discover project/user/plugin/bundled agents.
   - `packages/coding-agent/src/task/agents.ts` — bundled agent definitions and frontmatter parsing.
   - `packages/coding-agent/src/task/executor.ts` — create child sessions, run subagents, collect output, hand finished sessions to the lifecycle manager.
@@ -77,7 +79,7 @@ Artifacts and side channels:
 
 ## Flow
 1. `TaskTool.create(...)` discovers agents once per cwd through a process-level memo (`discoverAgentsForCreate`) to render the dynamic prompt description.
-2. `execute(...)` repairs raw params (`repairTaskParams`), then validates: `schema` is always rejected; `tasks`/`context` are rejected unless `task.batch` is on; batch calls need a non-empty `tasks` (a `task` per item, unique provided names), a non-empty shared `context`, and no top-level `task` alongside `tasks`; flat calls need `task`. The call is then normalized into its spawn list (`resolveSpawnItems`).
+2. `execute(...)` repairs raw params (`repairTaskParams`), then validates: `schema` is always rejected; `tasks`/`context` are rejected unless `task.batch` is on; batch calls need a non-empty `tasks` (a `task` per item, unique provided names), a non-empty shared `context`, and no top-level `task` alongside `tasks`; flat calls need `task`. The call is then normalized into its spawn list (`resolveSpawnItems`) and all policies are resolved through the session's shared `TaskDispatchService` before any item launches.
 3. Per-item execution split: items whose agent type declares `blocking: true` run inline; the rest become background jobs. The whole call runs sync when `async.enabled=false`, the session has no `AsyncJobManager` (orphaned host), or every item is blocking; inline spawns run through `#executeSync(...)` under the session-scoped semaphore.
 4. Background execution (any non-blocking item with `async.enabled=true` and an `AsyncJobManager`):
    - agent ids are allocated up front via `AgentOutputManager.allocate(...)` — each item's `name`, or a generated AdjectiveNoun name — one per spawn;

--- a/docs/tools/workflow.md
+++ b/docs/tools/workflow.md
@@ -1,0 +1,53 @@
+# workflow
+
+> Validate, persist, and run one static dependency graph in the current parent session.
+
+Use `workflow` when node dependencies and partial completion must survive another turn or a process restart. For dynamic one-turn orchestration that needs ordinary code between calls, use the `eval` helpers `agent()`, `parallel()`, and `pipeline()` instead.
+
+## Operations
+
+| Operation | Required fields | Behavior |
+| --- | --- | --- |
+| `create` | `objective`, `nodes` | Validates the complete DAG and persists it without launching agents. An optional branch-unique `id` may contain letters, numbers, `_`, and `-`. |
+| `get` | — | Returns the latest workflow snapshot from the active session branch. |
+| `run` | — | Runs dependency-ready nodes until the graph succeeds, fails, is interrupted, or is cancelled. |
+| `resume` | — | Uses the same scheduler as `run`; succeeded nodes are never rerun. Independent ready branches continue, while interrupted and failed nodes require `retry`. |
+| `retry` | `node_id` | Resets one failed or interrupted node, unblocks eligible descendants, and continues the graph. |
+| `cancel` | — | Prevents new dispatch and aborts active Task calls through their existing signals. Nodes stopped this way become cancelled. |
+
+Each node has:
+
+```ts
+{
+  id: string;
+  agent: string;             // defaults to "task"
+  task: string;
+  needs?: string[];
+  outputSchema?: unknown;    // JSON Schema object, or a serialized JSON Schema string
+  schemaMode?: "permissive" | "strict";
+  isolated?: boolean;
+}
+```
+
+Definitions are static DAGs with at most 100 nodes. Duplicate ids, missing dependencies, self-dependencies, cycles, unavailable agents, invalid structured-output schemas, and unsupported Task policies are rejected before the definition is persisted or any agent launches.
+
+A workflow definition is immutable after `create`. Its id cannot be reused on the same active session branch; after a terminal workflow, create the next definition under a new id. Session fork/rewind naturally selects the workflow history reachable from that branch.
+
+## Execution and recovery
+
+Before the first node launches, every pending node passes the shared Task preflight. Ready nodes then call the same internal Task dispatch service and therefore share its agent discovery, spawn policy, session concurrency limit, structured-output validation, isolation, lifecycle, and artifacts. The workflow layer does not create a second agent executor.
+
+The parent session appends a `workflow-state` snapshot before each ready set launches and after each node settles. A restart reconstructs the newest valid snapshot on the active branch:
+
+- succeeded, failed, blocked, and cancelled nodes retain their state;
+- a node left running becomes `interrupted`;
+- successful nodes are not automatically rerun;
+- failed or interrupted nodes require an explicit `retry`.
+
+A failed node blocks its descendants, but independent branches continue. Strict output-schema validation failure is a node failure.
+
+Each workflow node keeps its declarative node id and receives a deterministic Task agent id per attempt. The latter remains the one-for-one Agent Registry and Hub identity. Successful and failed executions retain `agent://<agent-id>` output and `history://<agent-id>` transcript references. Downstream prompts receive those references with dependency statuses; full upstream transcripts are not copied into every prompt.
+
+## Limits
+
+Version one does not support conditional edges, cycles, automatic retries, human-approval nodes, replay, reusable workflow catalogs, cross-session execution, or distributed workers.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -111,6 +111,9 @@
 ### Removed
 
 - Removed the dangling `MCPManager.setOnNotification` single-slot setter, which had no callers in the runtime. Replaced by `MCPManager.addNotificationListener` — multi-listener, per-listener error isolation, returns an unsubscribe function.
+### Added
+
+- Added a session-durable `workflow` tool for static dependency graphs, with Task-backed concurrent execution, restart-safe node state, explicit retry, cancellation, and persisted `agent://` / `history://` references ([#6947](https://github.com/can1357/oh-my-pi/issues/6947)).
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/coding-agent/DEVELOPMENT.md
+++ b/packages/coding-agent/DEVELOPMENT.md
@@ -107,7 +107,7 @@ Top-level entry modules: `cli.ts`, `main.ts`, `sdk.ts`, `index.ts` (SDK barrel),
 - Authoring + registry: [custom-tools.md](../../docs/custom-tools.md)
 - Output/artifacts: [blob-artifact-architecture.md](../../docs/blob-artifact-architecture.md)
 - Gating/approval: [approval-mode.md](../../docs/approval-mode.md), [resolve-tool-runtime.md](../../docs/resolve-tool-runtime.md)
-- Per-tool reference: [`docs/tools/`](../../docs/tools/) — `read`, `write`, `edit`, `ast-edit`, `ast-grep`, `grep`, `glob`, `bash`, `eval`, `hub`, `lsp`, `debug`, `task`, `web_search`, `browser`, `github`, `inspect_image`, `ask`, `todo`, `recall`, `retain`, `reflect`, `checkpoint`, `rewind`
+- Per-tool reference: [`docs/tools/`](../../docs/tools/) — `read`, `write`, `edit`, `ast-edit`, `ast-grep`, `grep`, `glob`, `bash`, `eval`, `hub`, `lsp`, `debug`, `task`, `workflow`, `web_search`, `browser`, `github`, `inspect_image`, `ask`, `todo`, `recall`, `retain`, `reflect`, `checkpoint`, `rewind`
 
 ### Execution backends
 - [bash-tool-runtime.md](../../docs/bash-tool-runtime.md), [tools/bash.md](../../docs/tools/bash.md)
@@ -115,7 +115,7 @@ Top-level entry modules: `cli.ts`, `main.ts`, `sdk.ts`, `index.ts` (SDK barrel),
 - [tools/debug.md](../../docs/tools/debug.md), [tools/lsp.md](../../docs/tools/lsp.md), [lsp-config.md](../../docs/lsp-config.md)
 
 ### Task delegation and subagents
-- [task-agent-discovery.md](../../docs/task-agent-discovery.md), [tools/task.md](../../docs/tools/task.md)
+- [task-agent-discovery.md](../../docs/task-agent-discovery.md), [tools/task.md](../../docs/tools/task.md), [tools/workflow.md](../../docs/tools/workflow.md)
 - [collab.md](../../docs/collab.md), [tools/hub.md](../../docs/tools/hub.md)
 
 ### Web I/O and retrieval

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -404,6 +404,7 @@ ${chalk.bold("Available Tools (default-enabled unless noted):")}
   browser       - Browser automation (Puppeteer)
   computer      - Native host desktop capture and input (disabled by default)
   task          - Launch sub-agents for parallel tasks
+  workflow      - Run session-durable dependency graphs through Task
   todo          - Manage todo/task lists
   web_search    - Search the web
   ask           - Ask user questions (interactive mode only)

--- a/packages/coding-agent/src/prompts/system/workflow-node-context.md
+++ b/packages/coding-agent/src/prompts/system/workflow-node-context.md
@@ -1,0 +1,12 @@
+Workflow: {{workflowId}}
+Objective: {{objective}}
+Node: {{nodeId}}
+{{#if hasDependencies}}
+Dependencies:
+{{#each dependencies}}
+- {{id}}: {{status}}{{#if references}} ({{references}}){{/if}}
+{{/each}}
+{{else}}
+Dependencies: none
+{{/if}}
+Use the dependency references for prior results; do not assume their full transcripts were inlined.

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -1,5 +1,7 @@
 <system-notice>
-The user's message above contains the **workflowz** keyword: drive this task as a deterministic multi-subagent workflow. Author the orchestration in the `eval` tool and fan out subagents — to be comprehensive (decompose and cover in parallel), to be confident (independent perspectives and adversarial checks before you commit), or to take on scale one context can't hold (audits, migrations, broad sweeps). This overrides any default tendency to do the whole task inline when fanning out would be more thorough.
+The user's message above contains the **workflowz** keyword: drive this task as a deterministic multi-subagent workflow. Fan out subagents — to be comprehensive (decompose and cover in parallel), to be confident (independent perspectives and adversarial checks before you commit), or to take on scale one context can't hold (audits, migrations, broad sweeps). This overrides any default tendency to do the whole task inline when fanning out would be more thorough.
+
+Use the session-durable `workflow` tool when later nodes have explicit dependencies whose status must survive another turn or a process restart. Use `eval` for one-turn dynamic orchestration, especially when ordinary code needs to inspect, filter, or reshape intermediate results before deciding the next calls. If `workflow` is mounted as a discoverable device, invoke it through `write xd://workflow`.
 
 <when>
 Worth it when the task benefits from decomposition + parallel coverage, or from independent/adversarial cross-checking before you commit. For a quick lookup or single edit, just do it directly — don't spin up agents. Scout inline FIRST (list the files, scope the diff, find the call sites) to discover the work-list, then fan out over it — you don't need to know the shape before the *task*, only before the *fan-out*. Common shapes, each a well-scoped `eval` call you can chain across turns:
@@ -20,7 +22,7 @@ State persists across eval calls, so scout in one call and fan out in the next. 
 - `log(message)` — emit a progress line above the status tree. `phase(title)` — start a phase; the status lines that follow group under it.
 - `budget` — `budget.total` (output-token ceiling, or `None` when none is set), `budget.spent()` (tokens spent this turn — main loop + eval subagents), `budget.remaining()` (`math.inf` when total is `None`), `budget.hard` (whether it's enforced). A ceiling is set by the user: `+Nk` in their message is advisory (you self-limit via `budget.remaining()`), `+Nk!` (or Goal Mode) is hard — `agent()` refuses to spawn once spent reaches it. Gate loops on `budget.total` first, since it's `None` when the user set no budget.
 
-Everything runs INLINE and synchronously inside the eval call — no background mode, no resume, no separate progress app. Each eval call is one well-scoped fan-out; chain several across calls and turns for multi-phase work, reading each result before you decide the next phase.
+Everything in `eval` runs INLINE and synchronously inside the eval call — no background mode, no resume, no separate progress app. Each eval call is one well-scoped fan-out; chain several across calls and turns for dynamic multi-phase work, or materialize a static dependency graph with `workflow` when restart-safe state matters.
 </helpers>
 
 <structure>

--- a/packages/coding-agent/src/prompts/system/workflow-preflight-context.md
+++ b/packages/coding-agent/src/prompts/system/workflow-preflight-context.md
@@ -1,0 +1,4 @@
+Workflow objective: {{objective}}
+Node: {{nodeId}}
+
+This node is being validated before the immutable workflow definition is persisted. Dependencies have not run.

--- a/packages/coding-agent/src/prompts/tools/workflow.md
+++ b/packages/coding-agent/src/prompts/tools/workflow.md
@@ -1,0 +1,9 @@
+Create and control one session-durable static workflow DAG.
+
+Use this tool when dependency state must survive the current turn or process. Use `create` to validate and persist the complete graph before any node launches, then `run` to execute it. Independent ready nodes run concurrently through the existing Task runtime. A node runs only after every `needs` dependency succeeds.
+
+Failure behavior is conservative: a failed node blocks its descendants while independent branches continue. After restart, nodes that were running become interrupted. `resume` never reruns succeeded nodes; use `retry` with `node_id` to explicitly rerun a failed or interrupted node and continue newly unblocked descendants. `cancel` stops new dispatch and interrupts active nodes.
+
+Downstream nodes receive dependency statuses plus `agent://` output and `history://` transcript references, not copied transcripts. Keep graphs static and acyclic. Conditional edges, loops, automatic retries, human approval nodes, and cross-session execution are not supported.
+
+When a node needs structured output, pass `outputSchema` as a JSON Schema object. A string value must contain a serialized JSON Schema document; a type name such as `"string"` is not itself a valid serialized schema.

--- a/packages/coding-agent/src/prompts/tools/workflow.md
+++ b/packages/coding-agent/src/prompts/tools/workflow.md
@@ -2,7 +2,7 @@ Create and control one session-durable static workflow DAG.
 
 Use this tool when dependency state must survive the current turn or process. Use `create` to validate and persist the complete graph before any node launches, then `run` to execute it. Independent ready nodes run concurrently through the existing Task runtime. A node runs only after every `needs` dependency succeeds.
 
-Failure behavior is conservative: a failed node blocks its descendants while independent branches continue. After restart, nodes that were running become interrupted. `resume` never reruns succeeded nodes; use `retry` with `node_id` to explicitly rerun a failed or interrupted node and continue newly unblocked descendants. `cancel` stops new dispatch and interrupts active nodes.
+Failure behavior is conservative: a failed node blocks its descendants while independent branches continue. After restart, nodes that were running become interrupted. `resume` never reruns succeeded nodes; use `retry` with `node_id` to explicitly rerun a failed or interrupted node and continue newly unblocked descendants. `cancel` stops a workflow between runs; while `run` is active, the host operator can stop it with `/workflow cancel`.
 
 Downstream nodes receive dependency statuses plus `agent://` output and `history://` transcript references, not copied transcripts. Keep graphs static and acyclic. Conditional edges, loops, automatic retries, human approval nodes, and cross-session execution are not supported.
 

--- a/packages/coding-agent/src/prompts/tools/workflow.md
+++ b/packages/coding-agent/src/prompts/tools/workflow.md
@@ -2,7 +2,7 @@ Create and control one session-durable static workflow DAG.
 
 Use this tool when dependency state must survive the current turn or process. Use `create` to validate and persist the complete graph before any node launches, then `run` to execute it. Independent ready nodes run concurrently through the existing Task runtime. A node runs only after every `needs` dependency succeeds.
 
-Failure behavior is conservative: a failed node blocks its descendants while independent branches continue. After restart, nodes that were running become interrupted. `resume` never reruns succeeded nodes; use `retry` with `node_id` to explicitly rerun a failed or interrupted node and continue newly unblocked descendants. `cancel` stops a workflow between runs; while `run` is active, the host operator can stop it with `/workflow cancel`.
+Failure behavior is conservative: a failed node blocks its descendants while independent branches continue. After restart, nodes that were running become interrupted. `resume` never reruns succeeded nodes; use `retry` with `node_id` to explicitly rerun a failed or interrupted node and continue newly unblocked descendants. `cancel` stops a workflow between runs; while `run` is active in the interactive TUI, the host operator can stop it with `/workflow cancel`.
 
 Downstream nodes receive dependency statuses plus `agent://` output and `history://` transcript references, not copied transcripts. Keep graphs static and acyclic. Conditional edges, loops, automatic retries, human approval nodes, and cross-session execution are not supported.
 

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -135,7 +135,7 @@ function emptyUsageStatistics(): UsageStatistics {
 	};
 }
 
-function taskUsageFrom(details: unknown): Usage | undefined {
+function nestedToolUsageFrom(details: unknown): Usage | undefined {
 	if (details === null || typeof details !== "object") return undefined;
 	const maybeUsage = (details as Record<string, unknown>).usage;
 	return maybeUsage !== null && typeof maybeUsage === "object" ? (maybeUsage as Usage) : undefined;
@@ -145,7 +145,9 @@ function entryUsage(entry: SessionEntry): Usage | undefined {
 	if (entry.type !== "message") return undefined;
 	const message = entry.message;
 	if (message.role === "assistant") return message.usage;
-	if (message.role === "toolResult" && message.toolName === "task") return taskUsageFrom(message.details);
+	if (message.role === "toolResult" && (message.toolName === "task" || message.toolName === "workflow")) {
+		return nestedToolUsageFrom(message.details);
+	}
 	return undefined;
 }
 

--- a/packages/coding-agent/src/session/session-stats.ts
+++ b/packages/coding-agent/src/session/session-stats.ts
@@ -67,8 +67,8 @@ export class SessionStatsTracker {
 				totalPremiumRequests += assistant.usage.premiumRequests ?? 0;
 				totalCost += assistant.usage.cost.total;
 			}
-			if (message.role === "toolResult" && message.toolName === "task") {
-				const usage = taskToolUsage(message.details);
+			if (message.role === "toolResult" && (message.toolName === "task" || message.toolName === "workflow")) {
+				const usage = nestedToolUsage(message.details);
 				if (!usage) continue;
 				totalInput += usage.input;
 				totalOutput += usage.output;
@@ -274,7 +274,7 @@ export class SessionStatsTracker {
 	}
 }
 
-function taskToolUsage(details: unknown): Usage | undefined {
+function nestedToolUsage(details: unknown): Usage | undefined {
 	if (!details || typeof details !== "object") return undefined;
 	const usage = Reflect.get(details, "usage");
 	return isUsage(usage) ? usage : undefined;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -69,6 +69,7 @@ import { handleSshAcp } from "./helpers/ssh";
 import { launchStatsDashboard, parseStatsDashboardArgs } from "./helpers/stats-dashboard";
 import { handleTodoAcp } from "./helpers/todo";
 import { buildUsageReportText } from "./helpers/usage-report";
+import { handleWorkflowCommand } from "./helpers/workflow";
 import { parseMarketplaceInstallArgs, parsePluginScopeArgs } from "./marketplace-install-parser";
 import type {
 	BuiltinSlashCommand,
@@ -1247,6 +1248,15 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			await runtime.ctx.handleTodoCommand(command.args);
 			runtime.ctx.editor.setText("");
 		},
+	},
+	{
+		name: "workflow",
+		description: "Control the active durable workflow",
+		acpDescription: "Control the active durable workflow",
+		acpInputHint: "cancel",
+		subcommands: [{ name: "cancel", description: "Cancel the active workflow" }],
+		allowArgs: true,
+		handle: handleWorkflowCommand,
 	},
 	{
 		name: "session",

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1251,12 +1251,24 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "workflow",
-		description: "Control the active durable workflow",
-		acpDescription: "Control the active durable workflow",
-		acpInputHint: "cancel",
+		description: "Cancel the active durable workflow",
 		subcommands: [{ name: "cancel", description: "Cancel the active workflow" }],
 		allowArgs: true,
-		handle: handleWorkflowCommand,
+		handleTui: async (command, runtime) => {
+			const ctx = runtime.ctx;
+			await handleWorkflowCommand(command, {
+				session: ctx.session,
+				sessionManager: ctx.sessionManager,
+				settings: ctx.settings,
+				cwd: ctx.sessionManager.getCwd(),
+				output: text => {
+					ctx.showStatus(text);
+				},
+				refreshCommands: () => ctx.refreshSlashCommandState(),
+				reloadPlugins: async () => {},
+			});
+			ctx.editor.setText("");
+		},
 	},
 	{
 		name: "session",

--- a/packages/coding-agent/src/slash-commands/helpers/workflow.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/workflow.ts
@@ -1,0 +1,38 @@
+import type { AgentSession } from "../../session/agent-session";
+import type { WorkflowSnapshot } from "../../workflows";
+import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime } from "../types";
+import { commandConsumed, parseSubcommand, usage } from "./parse";
+
+interface WorkflowCancellationControl {
+	cancelActiveWorkflow(): Promise<WorkflowSnapshot>;
+}
+
+function getWorkflowCancellationControl(session: AgentSession): WorkflowCancellationControl | undefined {
+	const tool = session.getToolByName("workflow");
+	if (
+		typeof tool !== "object" ||
+		tool === null ||
+		!("cancelActiveWorkflow" in tool) ||
+		typeof tool.cancelActiveWorkflow !== "function"
+	) {
+		return undefined;
+	}
+	return tool as WorkflowCancellationControl;
+}
+
+export async function handleWorkflowCommand(
+	command: ParsedSlashCommand,
+	runtime: SlashCommandRuntime,
+): Promise<SlashCommandResult> {
+	const { verb, rest } = parseSubcommand(command.args);
+	if (verb !== "cancel" || rest) return usage("Usage: /workflow cancel", runtime);
+	const control = getWorkflowCancellationControl(runtime.session);
+	if (!control) return usage("No durable workflow is active in this session.", runtime);
+	try {
+		const snapshot = await control.cancelActiveWorkflow();
+		await runtime.output(`Workflow ${snapshot.definition.id}: ${snapshot.status}`);
+		return commandConsumed();
+	} catch (error) {
+		return usage(error instanceof Error ? error.message : String(error), runtime);
+	}
+}

--- a/packages/coding-agent/src/task/dispatch-contract.ts
+++ b/packages/coding-agent/src/task/dispatch-contract.ts
@@ -1,0 +1,83 @@
+import { TASK_EFFORTS, type TaskEffort } from "../thinking";
+import type { TaskItem, TaskParams } from "./types";
+
+/** Reject an out-of-range `effort` selector on internal calls that bypass the wire schema. */
+function validateEffort(effort: TaskEffort | undefined, label: string): string | undefined {
+	if (effort === undefined || TASK_EFFORTS.includes(effort)) return undefined;
+	return `${label} has an invalid \`effort\` value ${JSON.stringify(effort)}. Use "lo", "med", or "hi".`;
+}
+
+export function validateSpawnParams(params: TaskParams, batchEnabled: boolean): string | undefined {
+	const hasTask = typeof params.task === "string" && params.task.trim() !== "";
+	const tasks = params.tasks;
+	if (batchEnabled && tasks !== undefined) {
+		if (!Array.isArray(tasks) || tasks.length === 0) {
+			return "Missing `tasks`. Provide at least one task item ({ name?, agent?, task }).";
+		}
+		if (hasTask) {
+			return "Top-level `task` is not part of the batch shape. Put the work in `tasks[]` items.";
+		}
+		for (let i = 0; i < tasks.length; i++) {
+			const item = tasks[i];
+			if (!item || typeof item.task !== "string" || item.task.trim() === "") {
+				return `Task ${i + 1}${item?.name ? ` (\`${item.name}\`)` : ""} is missing \`task\`. Every task needs complete, self-contained instructions.`;
+			}
+			const effortError = validateEffort(item.effort, `Task ${i + 1}${item.name ? ` (\`${item.name}\`)` : ""}`);
+			if (effortError) return effortError;
+		}
+		const seen = new Map<string, string>();
+		for (const item of tasks) {
+			const name = item.name?.trim();
+			if (!name) continue;
+			const key = name.toLowerCase();
+			const existing = seen.get(key);
+			if (existing !== undefined) {
+				return `Duplicate task name ${existing === name ? `\`${name}\`` : `\`${existing}\` / \`${name}\``}. Provided names must be unique within a call (case-insensitive).`;
+			}
+			seen.set(key, name);
+		}
+		if (typeof params.context !== "string" || params.context.trim() === "") {
+			return "Missing `context`. Provide the shared background for this batch — goal, constraints, and any contract the tasks share.";
+		}
+		return undefined;
+	}
+	if (!hasTask) {
+		return batchEnabled
+			? "Missing `tasks`. Provide a `tasks` array (one subagent per item) with a shared `context`."
+			: "Missing `task`. Provide complete, self-contained instructions for the agent.";
+	}
+	return validateEffort(params.effort, "The call");
+}
+
+/**
+ * Normalize a validated call into its spawn list: the `tasks[]` batch when
+ * provided, otherwise the single top-level spawn.
+ */
+export function resolveSpawnItems(params: TaskParams): TaskItem[] {
+	if (Array.isArray(params.tasks) && params.tasks.length > 0) {
+		return params.tasks;
+	}
+	const item: TaskItem = { name: params.name, agent: params.agent, task: params.task };
+	if ("outputSchema" in params) item.outputSchema = params.outputSchema;
+	if ("schemaMode" in params) item.schemaMode = params.schemaMode;
+	if ("effort" in params) item.effort = params.effort;
+	if ("isolated" in params) item.isolated = params.isolated;
+	return [item];
+}
+
+/** Materialize one item as the flat params consumed by the subagent executor. */
+export function spawnParamsFor(params: TaskParams, item: TaskItem, defaultAgent: string): TaskParams {
+	const spawn: TaskParams = { agent: item.agent?.trim() || defaultAgent };
+	if (item.name !== undefined) spawn.name = item.name;
+	if (item.task !== undefined) spawn.task = item.task;
+	if (params.context !== undefined) spawn.context = params.context;
+	if ("outputSchema" in item) spawn.outputSchema = item.outputSchema;
+	if ("schemaMode" in item) spawn.schemaMode = item.schemaMode;
+	if ("effort" in item) spawn.effort = item.effort;
+	if (item.isolated !== undefined) {
+		spawn.isolated = item.isolated;
+	} else if ("isolated" in params) {
+		spawn.isolated = params.isolated;
+	}
+	return spawn;
+}

--- a/packages/coding-agent/src/task/dispatch-service.ts
+++ b/packages/coding-agent/src/task/dispatch-service.ts
@@ -1,0 +1,151 @@
+import type { AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import { $env } from "@oh-my-pi/pi-utils";
+import type { ToolSession } from "../tools";
+import { isIrcEnabled } from "../tools/hub";
+import { spawnParamsFor, validateSpawnParams } from "./dispatch-contract";
+import { resolveSpawnPolicy } from "./spawn-policy";
+import {
+	type EffectiveSubagentPolicy,
+	resolveEffectiveSubagentPolicy,
+	StructuredSubagentError,
+} from "./structured-subagent";
+import type { TaskItem, TaskParams, TaskToolDetails } from "./types";
+
+export interface SettledTaskSpawn {
+	context: string;
+	item: TaskItem;
+}
+
+export interface TaskDispatchFailure {
+	index: number;
+	error: string;
+}
+
+export type TaskDispatchPreflight =
+	| {
+			ok: true;
+			defaultAgent: string;
+			normalizedSpawnParams: TaskParams[];
+			resolvedAgents: string[];
+			policies: EffectiveSubagentPolicy[];
+	  }
+	| {
+			ok: false;
+			defaultAgent: string;
+			normalizedSpawnParams: TaskParams[];
+			resolvedAgents: string[];
+			failures: TaskDispatchFailure[];
+	  };
+
+export type SettledTaskRunner = (
+	toolCallId: string,
+	params: TaskParams,
+	item: TaskItem,
+	defaultAgent: string,
+	signal?: AbortSignal,
+	onUpdate?: AgentToolUpdateCallback<TaskToolDetails>,
+) => Promise<AgentToolResult<TaskToolDetails>>;
+
+function createTaskDispatchError(text: string): AgentToolResult<TaskToolDetails> {
+	return {
+		content: [{ type: "text", text }],
+		details: { projectAgentsDir: null, results: [], totalDurationMs: 0 },
+	};
+}
+
+export class TaskDispatchService {
+	readonly #session: ToolSession;
+	readonly #runSettled: SettledTaskRunner;
+	readonly #blockedAgent: string | undefined;
+
+	constructor(session: ToolSession, runSettled: SettledTaskRunner) {
+		this.#session = session;
+		this.#runSettled = runSettled;
+		this.#blockedAgent = $env.PI_BLOCKED_AGENT;
+	}
+
+	async preflight(params: TaskParams, spawnItems: TaskItem[]): Promise<TaskDispatchPreflight> {
+		const defaultAgent = resolveSpawnPolicy(this.#session.getSessionSpawns()).defaultAgent;
+		const normalizedSpawnParams = spawnItems.map(item => spawnParamsFor(params, item, defaultAgent));
+		const resolvedAgents = normalizedSpawnParams.map(spawn => spawn.agent ?? defaultAgent);
+		const resolved = await Promise.all(
+			normalizedSpawnParams.map(async spawn => {
+				try {
+					return { policy: await this.#resolveSpawnPreflight(spawn) };
+				} catch (error) {
+					return { error: error instanceof StructuredSubagentError ? error.message : String(error) };
+				}
+			}),
+		);
+		const failures = resolved
+			.map((item, index) => ("error" in item ? { index, error: item.error } : undefined))
+			.filter((failure): failure is TaskDispatchFailure => failure !== undefined);
+		if (failures.length > 0) {
+			return { ok: false, defaultAgent, normalizedSpawnParams, resolvedAgents, failures };
+		}
+		return {
+			ok: true,
+			defaultAgent,
+			normalizedSpawnParams,
+			resolvedAgents,
+			policies: resolved.map(item => item.policy!),
+		};
+	}
+
+	async assertSettledSpawns(spawns: readonly SettledTaskSpawn[]): Promise<void> {
+		const failures = (
+			await Promise.all(
+				spawns.map(async (spawn, index) => {
+					const params: TaskParams = { context: spawn.context, tasks: [spawn.item] };
+					const validationError = validateSpawnParams(params, true);
+					if (validationError) return { index, error: validationError };
+					const preflight = await this.preflight(params, [spawn.item]);
+					return preflight.ok ? undefined : { index, error: preflight.failures[0]!.error };
+				}),
+			)
+		).filter((failure): failure is TaskDispatchFailure => failure !== undefined);
+		if (failures.length === 0) return;
+		throw new Error(
+			failures
+				.map(({ index, error }) => {
+					const item = spawns[index]!.item;
+					return `Task ${item.name?.trim() || `#${index + 1}`} failed preflight: ${error}`;
+				})
+				.join("\n"),
+		);
+	}
+
+	async executeSettledSpawn(
+		toolCallId: string,
+		spawn: SettledTaskSpawn,
+		signal?: AbortSignal,
+		onUpdate?: AgentToolUpdateCallback<TaskToolDetails>,
+	): Promise<AgentToolResult<TaskToolDetails>> {
+		const params: TaskParams = { context: spawn.context, tasks: [spawn.item] };
+		const validationError = validateSpawnParams(params, true);
+		if (validationError) return createTaskDispatchError(validationError);
+		const preflight = await this.preflight(params, [spawn.item]);
+		if (!preflight.ok) {
+			return createTaskDispatchError(`Task execution failed: ${preflight.failures[0]!.error}`);
+		}
+		return this.#runSettled(toolCallId, params, spawn.item, preflight.defaultAgent, signal, onUpdate);
+	}
+
+	#resolveSpawnPreflight(params: TaskParams): Promise<EffectiveSubagentPolicy> {
+		return resolveEffectiveSubagentPolicy({
+			session: this.#session,
+			invocationKind: "task",
+			assignment: (params.task ?? "").trim(),
+			context: params.context?.trim() || undefined,
+			agent: params.agent,
+			...(Object.hasOwn(params, "outputSchema") ? { outputSchema: params.outputSchema } : {}),
+			...(Object.hasOwn(params, "schemaMode") ? { schemaMode: params.schemaMode } : {}),
+			...(params.effort !== undefined ? { effort: params.effort } : {}),
+			...("isolated" in params ? { isolation: { requested: params.isolated } } : {}),
+			blockedAgent: this.#blockedAgent,
+			enableLsp: (this.#session.enableLsp ?? true) && this.#session.settings.get("task.enableLsp"),
+			enableIrc: isIrcEnabled(this.#session.settings, this.#session.taskDepth ?? 0),
+			maxRuntimeMs: this.#session.settings.get("task.maxRuntimeMs"),
+		});
+	}
+}

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -52,50 +52,12 @@ import { mapWithConcurrencyLimitAllSettled, Semaphore } from "./parallel";
 import { renderResult, renderCall as renderTaskCall } from "./render";
 import { repairTaskParams } from "./repair-args";
 import { runStructuredSubagent, StructuredSubagentError } from "./structured-subagent";
+import { addUsageTotals, createUsageTotals } from "./usage";
 
 function renderSubagentUserPrompt(assignment: string): string {
 	return prompt.render(subagentUserPromptTemplate, {
 		assignment: assignment.trim(),
 	});
-}
-
-function createUsageTotals(): Usage {
-	return {
-		input: 0,
-		output: 0,
-		cacheRead: 0,
-		cacheWrite: 0,
-		totalTokens: 0,
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-	};
-}
-
-function addUsageTotals(target: Usage, usage: Partial<Usage>): void {
-	const input = usage.input ?? 0;
-	const output = usage.output ?? 0;
-	const cacheRead = usage.cacheRead ?? 0;
-	const cacheWrite = usage.cacheWrite ?? 0;
-	const totalTokens = usage.totalTokens ?? input + output + cacheRead + cacheWrite;
-	const cost =
-		usage.cost ??
-		({
-			input: 0,
-			output: 0,
-			cacheRead: 0,
-			cacheWrite: 0,
-			total: 0,
-		} satisfies Usage["cost"]);
-
-	target.input += input;
-	target.output += output;
-	target.cacheRead += cacheRead;
-	target.cacheWrite += cacheWrite;
-	target.totalTokens += totalTokens;
-	target.cost.input += cost.input;
-	target.cost.output += cost.output;
-	target.cost.cacheRead += cost.cacheRead;
-	target.cost.cacheWrite += cost.cacheWrite;
-	target.cost.total += cost.total;
 }
 
 // Re-export types and utilities
@@ -119,6 +81,7 @@ export {
 	TASK_SUBAGENT_PROGRESS_CHANNEL,
 	taskSchema,
 } from "./types";
+export { addUsageTotals, createUsageTotals } from "./usage";
 
 // Built-in tools whose approval tier is "read" (see tool classes' `approval`).
 // An agent is read-only iff its declared tools are a non-empty subset of this set.

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -23,7 +23,6 @@ import subagentUserPromptTemplate from "../prompts/system/subagent-user-prompt.m
 import taskDescriptionTemplate from "../prompts/tools/task.md" with { type: "text" };
 import taskAsyncContractTemplate from "../prompts/tools/task-async-contract.md" with { type: "text" };
 import taskSummaryTemplate from "../prompts/tools/task-summary.md" with { type: "text" };
-import { TASK_EFFORTS, type TaskEffort } from "../thinking";
 import { truncateForPrompt } from "../tools/approval";
 import { isIrcEnabled } from "../tools/hub";
 import { formatBytes, formatDuration } from "../tools/render-utils";
@@ -45,12 +44,14 @@ import type { AsyncJobManager } from "../async";
 import { hasResolvableTranscript } from "../internal-urls/registry-helpers";
 import { AgentRegistry } from "../registry/agent-registry";
 import { type DiscoveryResult, discoverAgents } from "./discovery";
+import { resolveSpawnItems, spawnParamsFor, validateSpawnParams } from "./dispatch-contract";
+import { TaskDispatchService } from "./dispatch-service";
 import { generateTaskName } from "./name-generator";
 import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimitAllSettled, Semaphore } from "./parallel";
 import { renderResult, renderCall as renderTaskCall } from "./render";
 import { repairTaskParams } from "./repair-args";
-import { resolveEffectiveSubagentPolicy, runStructuredSubagent, StructuredSubagentError } from "./structured-subagent";
+import { runStructuredSubagent, StructuredSubagentError } from "./structured-subagent";
 
 function renderSubagentUserPrompt(assignment: string): string {
 	return prompt.render(subagentUserPromptTemplate, {
@@ -237,97 +238,6 @@ function validateShapeParams(batchEnabled: boolean, params: TaskParams): string 
  * policy later, in `spawnParamsFor`. Returns a problem description, or
  * undefined when valid.
  */
-
-/** Reject an out-of-range `effort` selector on internal/stale-transcript calls that bypass the wire schema. */
-function validateEffort(effort: TaskEffort | undefined, label: string): string | undefined {
-	if (effort === undefined || TASK_EFFORTS.includes(effort)) return undefined;
-	return `${label} has an invalid \`effort\` value ${JSON.stringify(effort)}. Use "lo", "med", or "hi".`;
-}
-
-function validateSpawnParams(params: TaskParams, batchEnabled: boolean): string | undefined {
-	const hasTask = typeof params.task === "string" && params.task.trim() !== "";
-	const tasks = params.tasks;
-	if (batchEnabled && tasks !== undefined) {
-		if (!Array.isArray(tasks) || tasks.length === 0) {
-			return "Missing `tasks`. Provide at least one task item ({ name?, agent?, task }).";
-		}
-		if (hasTask) {
-			return "Top-level `task` is not part of the batch shape. Put the work in `tasks[]` items.";
-		}
-		for (let i = 0; i < tasks.length; i++) {
-			const item = tasks[i];
-			if (!item || typeof item.task !== "string" || item.task.trim() === "") {
-				return `Task ${i + 1}${item?.name ? ` (\`${item.name}\`)` : ""} is missing \`task\`. Every task needs complete, self-contained instructions.`;
-			}
-			const effortError = validateEffort(item.effort, `Task ${i + 1}${item.name ? ` (\`${item.name}\`)` : ""}`);
-			if (effortError) return effortError;
-		}
-		const seen = new Map<string, string>();
-		for (const item of tasks) {
-			const name = item.name?.trim();
-			if (!name) continue;
-			const key = name.toLowerCase();
-			const existing = seen.get(key);
-			if (existing !== undefined) {
-				return `Duplicate task name ${existing === name ? `\`${name}\`` : `\`${existing}\` / \`${name}\``}. Provided names must be unique within a call (case-insensitive).`;
-			}
-			seen.set(key, name);
-		}
-		if (typeof params.context !== "string" || params.context.trim() === "") {
-			return "Missing `context`. Provide the shared background for this batch — goal, constraints, and any contract the tasks share.";
-		}
-		return undefined;
-	}
-	if (!hasTask) {
-		return batchEnabled
-			? "Missing `tasks`. Provide a `tasks` array (one subagent per item) with a shared `context`."
-			: "Missing `task`. Provide complete, self-contained instructions for the agent.";
-	}
-	return validateEffort(params.effort, "The call");
-}
-
-/**
- * Normalize a validated call into its spawn list: the `tasks[]` batch when
- * provided, otherwise the single top-level spawn. The flat form's `isolated`
- * flag is only materialized when the caller sent one — `#runSpawn`
- * distinguishes an absent key from an explicit value.
- */
-function resolveSpawnItems(params: TaskParams): TaskItem[] {
-	if (Array.isArray(params.tasks) && params.tasks.length > 0) {
-		return params.tasks;
-	}
-	const item: TaskItem = { name: params.name, agent: params.agent, task: params.task };
-	if ("outputSchema" in params) item.outputSchema = params.outputSchema;
-	if ("schemaMode" in params) item.schemaMode = params.schemaMode;
-	if ("effort" in params) item.effort = params.effort;
-	if ("isolated" in params) item.isolated = params.isolated;
-	return [item];
-}
-
-/**
- * Per-spawn params handed to the executor path: top-level call fields with the
- * item's identity substituted in. Each spawn's `agent` resolves here —
- * the item's own value, else `defaultAgent` from the session spawn policy.
- * `tasks` never leaks into a spawn; the shared `context` rides along
- * unchanged. Keys are only materialized when present — `#runSpawn`
- * distinguishes an absent `isolated` from an explicit one. The item's
- * `isolated` (batch form) wins over the top-level flag (flat form).
- */
-function spawnParamsFor(params: TaskParams, item: TaskItem, defaultAgent: string): TaskParams {
-	const spawn: TaskParams = { agent: item.agent?.trim() || defaultAgent };
-	if (item.name !== undefined) spawn.name = item.name;
-	if (item.task !== undefined) spawn.task = item.task;
-	if (params.context !== undefined) spawn.context = params.context;
-	if ("outputSchema" in item) spawn.outputSchema = item.outputSchema;
-	if ("schemaMode" in item) spawn.schemaMode = item.schemaMode;
-	if ("effort" in item) spawn.effort = item.effort;
-	if (item.isolated !== undefined) {
-		spawn.isolated = item.isolated;
-	} else if ("isolated" in params) {
-		spawn.isolated = params.isolated;
-	}
-	return spawn;
-}
 
 /** One sync-executed spawn: its item, position in the original call, and (for mixed calls) a pre-claimed agent id. */
 interface SyncSpawnRef {
@@ -571,6 +481,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	// so the task renders as ONE block that transitions in place — not a pending
 	// call frame stacked above the result frame. Mirrors `taskToolRenderer`.
 	readonly mergeCallAndResult = true;
+	readonly dispatchService: TaskDispatchService;
 	readonly #discoveredAgents: AgentDefinition[];
 	readonly #blockedAgent: string | undefined;
 	/**
@@ -621,6 +532,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	) {
 		this.#blockedAgent = $env.PI_BLOCKED_AGENT;
 		this.#discoveredAgents = discoveredAgents;
+		this.dispatchService = new TaskDispatchService(
+			session,
+			(toolCallId, params, item, defaultAgent, signal, onUpdate) =>
+				this.#executeSyncFanout(toolCallId, params, [{ item, index: 0 }], defaultAgent, signal, onUpdate),
+		);
+		session.taskDispatchService = this.dispatchService;
 	}
 
 	#isBatchEnabled(): boolean {
@@ -642,30 +559,6 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	}
 
 	/**
-	 * Resolve the shared policy before detached work exists. The resulting
-	 * policy intentionally stays local: executor dispatch resolves again from
-	 * normalized task params rather than smuggling internal policy over the
-	 * task wire contract.
-	 */
-	#resolveSpawnPreflight(params: TaskParams) {
-		return resolveEffectiveSubagentPolicy({
-			session: this.session,
-			invocationKind: "task",
-			assignment: (params.task ?? "").trim(),
-			context: this.#isBatchEnabled() ? params.context?.trim() || undefined : undefined,
-			agent: params.agent,
-			...(Object.hasOwn(params, "outputSchema") ? { outputSchema: params.outputSchema } : {}),
-			...(Object.hasOwn(params, "schemaMode") ? { schemaMode: params.schemaMode } : {}),
-			...(params.effort !== undefined ? { effort: params.effort } : {}),
-			...("isolated" in params ? { isolation: { requested: params.isolated } } : {}),
-			blockedAgent: this.#blockedAgent,
-			enableLsp: (this.session.enableLsp ?? true) && this.session.settings.get("task.enableLsp"),
-			enableIrc: isIrcEnabled(this.session.settings, this.session.taskDepth ?? 0),
-			maxRuntimeMs: this.session.settings.get("task.maxRuntimeMs"),
-		});
-	}
-
-	/**
 	 * Create a TaskTool instance with async agent discovery.
 	 */
 	static async create(session: ToolSession): Promise<TaskTool> {
@@ -683,7 +576,6 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		// Schema defaults fill `agent` for model calls, but internal callers
 		// and stale transcripts can bypass arktype. `spawnParamsFor` resolves each
 		// item's agent type against the session's actual default agent.
-		const defaultAgent = resolveSpawnPolicy(this.session.getSessionSpawns()).defaultAgent;
 		const batchEnabled = this.#isBatchEnabled();
 		const validationError = validateShapeParams(batchEnabled, params) ?? validateSpawnParams(params, batchEnabled);
 		if (validationError) {
@@ -691,28 +583,15 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		}
 
 		const spawnItems = resolveSpawnItems(params);
-		const normalizedSpawnParams = spawnItems.map(item => spawnParamsFor(params, item, defaultAgent));
-		const resolvedAgents = normalizedSpawnParams.map(spawn => spawn.agent ?? defaultAgent);
 		// Resolve every item before choosing an execution path. No executor or
 		// job manager may observe a batch unless every effective policy is valid.
-		const preflights = await Promise.all(
-			normalizedSpawnParams.map(async spawn => {
-				try {
-					return { policy: await this.#resolveSpawnPreflight(spawn) };
-				} catch (error) {
-					return { error: error instanceof StructuredSubagentError ? error.message : String(error) };
-				}
-			}),
-		);
-		const preflightFailures = preflights
-			.map((preflight, index) => ("error" in preflight ? { index, error: preflight.error } : undefined))
-			.filter((failure): failure is { index: number; error: string } => failure !== undefined);
-		if (preflightFailures.length > 0) {
+		const preflight = await this.dispatchService.preflight(params, spawnItems);
+		if (!preflight.ok) {
 			if (!batchEnabled) {
-				return createTaskModeError(`Task execution failed: ${preflightFailures[0]!.error}`);
+				return createTaskModeError(`Task execution failed: ${preflight.failures[0]!.error}`);
 			}
 			return createTaskModeError(
-				preflightFailures
+				preflight.failures
 					.map(({ index, error }) => {
 						const item = spawnItems[index]!;
 						return `Task ${item.name?.trim() || `#${index + 1}`} failed preflight: ${error}`;
@@ -720,7 +599,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					.join("\n"),
 			);
 		}
-		const policies = preflights.map(preflight => preflight.policy!);
+		const { defaultAgent, resolvedAgents, policies } = preflight;
 		const itemBlocking = policies.map(policy => policy.effectiveAgent.blocking === true);
 
 		// Execution mode is per item: an item whose agent type declares
@@ -1401,7 +1280,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	): Promise<AgentToolResult<TaskToolDetails>> {
 		const startTime = Date.now();
 		const assignment = (params.task ?? "").trim();
-		const context = this.#isBatchEnabled() ? params.context?.trim() || undefined : undefined;
+		const context = params.context?.trim() || undefined;
 		let latestProgress: AgentProgress | undefined;
 		try {
 			const execution = await runStructuredSubagent({

--- a/packages/coding-agent/src/task/usage.ts
+++ b/packages/coding-agent/src/task/usage.ts
@@ -1,0 +1,40 @@
+import type { Usage } from "@oh-my-pi/pi-ai";
+
+export function createUsageTotals(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+export function addUsageTotals(target: Usage, usage: Partial<Usage>): void {
+	const input = usage.input ?? 0;
+	const output = usage.output ?? 0;
+	const cacheRead = usage.cacheRead ?? 0;
+	const cacheWrite = usage.cacheWrite ?? 0;
+	const totalTokens = usage.totalTokens ?? input + output + cacheRead + cacheWrite;
+	const cost =
+		usage.cost ??
+		({
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			total: 0,
+		} satisfies Usage["cost"]);
+
+	target.input += input;
+	target.output += output;
+	target.cacheRead += cacheRead;
+	target.cacheWrite += cacheWrite;
+	target.totalTokens += totalTokens;
+	target.cost.input += cost.input;
+	target.cost.output += cost.output;
+	target.cost.cacheRead += cost.cacheRead;
+	target.cost.cacheWrite += cost.cacheWrite;
+	target.cost.total += cost.total;
+}

--- a/packages/coding-agent/src/tools/builtin-names.ts
+++ b/packages/coding-agent/src/tools/builtin-names.ts
@@ -18,6 +18,7 @@ export const BUILTIN_TOOL_NAMES = [
 	"rewind",
 	"security_scan",
 	"task",
+	"workflow",
 	"hub",
 	"todo",
 	"web_search",

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -232,7 +232,8 @@ export interface ToolSession {
 	/** Get session file */
 	getSessionFile: () => string | null;
 	/** Parent session journal used by tools that persist runtime lifecycle state. */
-	sessionManager?: Pick<SessionManager, "appendCustomEntry" | "ensureOnDisk" | "flush" | "getBranch" | "getEntries">;
+	sessionManager?: Pick<SessionManager, "appendCustomEntry" | "ensureOnDisk" | "flush" | "getBranch" | "getEntries"> &
+		Partial<Pick<SessionManager, "appendEntriesAtomically">>;
 	/** Get eval kernel owner ID for session-scoped retained-kernel cleanup. */
 	getEvalKernelOwnerId?: () => string | null;
 	/** Reject new eval work once session disposal has started. */

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -29,11 +29,13 @@ import type { UsageStatistics } from "../session/session-entries";
 import type { SessionManager } from "../session/session-manager";
 import type { ToolChoiceQueue } from "../session/tool-choice-queue";
 import { TaskTool } from "../task";
+import type { TaskDispatchService } from "../task/dispatch-service";
 import type { AgentOutputManager } from "../task/output-manager";
 import { canSpawnAtDepth, type StructuredSubagentSchemaMode } from "../task/types";
 import type { EventBus } from "../utils/event-bus";
 import { type InspectImageMode, isInspectImageToolActive } from "../utils/inspect-image-mode";
 import { WebSearchTool } from "../web/search";
+import { WorkflowTool } from "../workflows/tools/workflow-tool";
 import type { WorkspaceTree } from "../workspace-tree";
 import { AskTool } from "./ask";
 import { AstEditTool } from "./ast-edit";
@@ -72,6 +74,7 @@ export * from "../lsp";
 export * from "../session/streaming-output";
 export * from "../task";
 export * from "../web/search";
+export * from "../workflows";
 export * from "./ask";
 export * from "./ast-edit";
 export * from "./ast-grep";
@@ -282,6 +285,8 @@ export interface ToolSession {
 	modelRegistry?: import("../config/model-registry").ModelRegistry;
 	/** Agent output manager for unique agent:// IDs across task invocations */
 	agentOutputManager?: AgentOutputManager;
+	/** Shared Task policy/concurrency/isolation dispatch used by durable internal schedulers. */
+	taskDispatchService?: TaskDispatchService;
 	/**
 	 * Async job manager scoped to this session.
 	 *
@@ -422,6 +427,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	checkpoint: CheckpointTool.createIf,
 	rewind: RewindTool.createIf,
 	task: s => TaskTool.create(s),
+	workflow: WorkflowTool.createIf,
 	hub: s => new HubTool(s),
 	todo: s => new TodoTool(s),
 	web_search: s => new WebSearchTool(s),
@@ -528,6 +534,14 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	// Auto-include AST counterparts when their text-based sibling is present.
 	// Restricted callers own the active list and must not have it widened.
 	if (requestedTools && !restrictToolNames) {
+		if (
+			requestedTools.includes("workflow") &&
+			!requestedTools.includes("task") &&
+			session.sessionManager &&
+			(session.taskDepth ?? 0) === 0
+		) {
+			requestedTools.push("task");
+		}
 		if (goalModeActive && !requestedTools.includes("goal")) {
 			requestedTools.push("goal");
 		}
@@ -626,6 +640,13 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		}
 		if (name === "task") {
 			return canSpawnAtDepth(session.settings.get("task.maxRecursionDepth") ?? 2, session.taskDepth ?? 0);
+		}
+		if (name === "workflow") {
+			return (
+				!restrictToolNames &&
+				(session.taskDepth ?? 0) === 0 &&
+				canSpawnAtDepth(session.settings.get("task.maxRecursionDepth") ?? 2, session.taskDepth ?? 0)
+			);
 		}
 		return true;
 	};

--- a/packages/coding-agent/src/workflows/index.ts
+++ b/packages/coding-agent/src/workflows/index.ts
@@ -1,0 +1,5 @@
+export * from "./runtime";
+export * from "./store";
+export * from "./tools/workflow-tool";
+export * from "./types";
+export * from "./validation";

--- a/packages/coding-agent/src/workflows/runtime.ts
+++ b/packages/coding-agent/src/workflows/runtime.ts
@@ -1,0 +1,427 @@
+import { prompt, Snowflake } from "@oh-my-pi/pi-utils";
+import workflowNodeContextTemplate from "../prompts/system/workflow-node-context.md" with { type: "text" };
+import type { SingleResult } from "../task/types";
+import type { WorkflowStore } from "./store";
+import {
+	cloneWorkflowSnapshot,
+	WORKFLOW_DEFINITION_VERSION,
+	WORKFLOW_FAILURE_POLICY,
+	WORKFLOW_SNAPSHOT_VERSION,
+	type WorkflowDefinition,
+	type WorkflowDraft,
+	type WorkflowNode,
+	type WorkflowNodeRun,
+	type WorkflowSnapshot,
+	type WorkflowStatus,
+} from "./types";
+import { parseWorkflowDefinition } from "./validation";
+
+export interface WorkflowDispatchRequest {
+	nodeId: string;
+	name: string;
+	agent: string;
+	task: string;
+	context: string;
+	outputSchema?: unknown;
+	schemaMode?: "permissive" | "strict";
+	isolated?: boolean;
+}
+
+export type WorkflowDispatchOutcome = { result: SingleResult } | { error: string; status: "failed" | "interrupted" };
+
+export type WorkflowDispatcher = (
+	request: WorkflowDispatchRequest,
+	signal: AbortSignal,
+) => Promise<WorkflowDispatchOutcome>;
+
+export interface WorkflowRunOptions {
+	signal?: AbortSignal;
+	preflight?: (requests: readonly WorkflowDispatchRequest[]) => Promise<void>;
+	onChange?: (snapshot: WorkflowSnapshot) => void | Promise<void>;
+}
+
+export interface WorkflowRuntimeOptions {
+	store: WorkflowStore;
+	now?: () => number;
+	idFactory?: () => string;
+}
+
+const UPSTREAM_BLOCKING_STATUSES: ReadonlySet<WorkflowNodeRun["status"]> = new Set([
+	"failed",
+	"blocked",
+	"interrupted",
+	"cancelled",
+]);
+
+function defaultWorkflowId(): string {
+	return String(Snowflake.next());
+}
+
+function isReplaceable(status: WorkflowStatus): boolean {
+	return status === "succeeded" || status === "cancelled";
+}
+
+function buildAgentName(workflowId: string, nodeId: string, attempt: number): string {
+	const identity = `${workflowId}\0${nodeId}`;
+	const suffix = new Bun.CryptoHasher("sha256").update(identity).digest("hex").slice(0, 8);
+	return `wf-${workflowId.slice(0, 10)}-${nodeId.slice(0, 28)}-${suffix}-a${attempt}`;
+}
+
+function descendantIds(definition: WorkflowDefinition, rootId: string): Set<string> {
+	const descendants = new Set([rootId]);
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (const node of definition.nodes) {
+			if (descendants.has(node.id) || !node.needs?.some(id => descendants.has(id))) continue;
+			descendants.add(node.id);
+			changed = true;
+		}
+	}
+	return descendants;
+}
+
+function buildDependencyContext(snapshot: WorkflowSnapshot, node: WorkflowNode): string {
+	const dependencies = (node.needs ?? []).map(id => {
+		const dependency = snapshot.nodes[id]!;
+		return {
+			id,
+			status: dependency.status,
+			references: [dependency.outputRef, dependency.historyRef].filter(Boolean).join(", "),
+		};
+	});
+	return prompt.render(workflowNodeContextTemplate, {
+		workflowId: snapshot.definition.id,
+		objective: snapshot.definition.objective,
+		nodeId: node.id,
+		hasDependencies: dependencies.length > 0,
+		dependencies,
+	});
+}
+
+function resultError(result: SingleResult): string {
+	return (
+		result.error?.trim() ||
+		result.stderr.trim() ||
+		result.abortReason?.trim() ||
+		`Task exited with code ${result.exitCode}`
+	);
+}
+
+export class WorkflowRuntime {
+	readonly #store: WorkflowStore;
+	readonly #now: () => number;
+	readonly #idFactory: () => string;
+	#snapshot: WorkflowSnapshot | null;
+	#runAbort: AbortController | undefined;
+	#cancelRequested = false;
+	#saveTail: Promise<void> = Promise.resolve();
+
+	private constructor(options: WorkflowRuntimeOptions, snapshot: WorkflowSnapshot | null) {
+		this.#store = options.store;
+		this.#now = options.now ?? Date.now;
+		this.#idFactory = options.idFactory ?? defaultWorkflowId;
+		this.#snapshot = snapshot;
+	}
+
+	static async create(options: WorkflowRuntimeOptions): Promise<WorkflowRuntime> {
+		const snapshot = options.store.load();
+		const runtime = new WorkflowRuntime(options, snapshot);
+		if (snapshot && runtime.#reconcileInterruptedRun()) {
+			await runtime.#persist();
+		}
+		return runtime;
+	}
+
+	getSnapshot(): WorkflowSnapshot | null {
+		return this.#snapshot ? cloneWorkflowSnapshot(this.#snapshot) : null;
+	}
+
+	async createWorkflow(draft: WorkflowDraft): Promise<WorkflowSnapshot> {
+		if (this.#snapshot && !isReplaceable(this.#snapshot.status)) {
+			throw new Error(
+				`Workflow ${this.#snapshot.definition.id} is ${this.#snapshot.status}; complete or cancel it before creating another`,
+			);
+		}
+		const definition = parseWorkflowDefinition({
+			version: WORKFLOW_DEFINITION_VERSION,
+			id: draft.id?.trim() || this.#idFactory(),
+			objective: draft.objective,
+			failurePolicy: WORKFLOW_FAILURE_POLICY,
+			nodes: draft.nodes,
+		});
+		if (this.#store.hasWorkflowId(definition.id)) {
+			throw new Error(`Workflow id "${definition.id}" already exists on this session branch`);
+		}
+		const now = this.#now();
+		const nodes: Record<string, WorkflowNodeRun> = {};
+		for (const node of definition.nodes) {
+			nodes[node.id] = {
+				status: (node.needs?.length ?? 0) === 0 ? "ready" : "pending",
+				attempts: 0,
+			};
+		}
+		this.#snapshot = {
+			version: WORKFLOW_SNAPSHOT_VERSION,
+			revision: 0,
+			definition,
+			status: "created",
+			nodes,
+			createdAt: now,
+			updatedAt: now,
+		};
+		this.#cancelRequested = false;
+		await this.#persist();
+		return cloneWorkflowSnapshot(this.#snapshot);
+	}
+
+	async run(dispatcher: WorkflowDispatcher, options: WorkflowRunOptions = {}): Promise<WorkflowSnapshot> {
+		const snapshot = this.#requireSnapshot();
+		if (this.#runAbort) throw new Error(`Workflow ${snapshot.definition.id} is already running`);
+		if (snapshot.status === "succeeded" || snapshot.status === "cancelled") {
+			return cloneWorkflowSnapshot(snapshot);
+		}
+
+		this.#cancelRequested = false;
+		this.#runAbort = new AbortController();
+		const dispatchSignal = options.signal
+			? AbortSignal.any([options.signal, this.#runAbort.signal])
+			: this.#runAbort.signal;
+		try {
+			this.#refreshPendingStates();
+			const preflightRequests = snapshot.definition.nodes
+				.filter(node => {
+					const status = snapshot.nodes[node.id]?.status;
+					return status === "pending" || status === "ready";
+				})
+				.map(node => this.#dispatchRequest(snapshot.definition, node, snapshot.nodes[node.id]!.attempts + 1));
+			await options.preflight?.(preflightRequests);
+			while (!dispatchSignal.aborted && !this.#cancelRequested) {
+				const ready = snapshot.definition.nodes.filter(node => snapshot.nodes[node.id]?.status === "ready");
+				if (ready.length === 0) break;
+				const startedAt = this.#now();
+				for (const node of ready) {
+					const state = snapshot.nodes[node.id]!;
+					state.status = "running";
+					state.attempts += 1;
+					state.startedAt = startedAt;
+					delete state.finishedAt;
+					delete state.agentId;
+					delete state.outputRef;
+					delete state.historyRef;
+					delete state.error;
+				}
+				snapshot.status = "running";
+				await this.#persist(options.onChange);
+
+				await Promise.all(
+					ready.map(async node => {
+						const state = snapshot.nodes[node.id]!;
+						const request = this.#dispatchRequest(snapshot.definition, node, state.attempts);
+						let outcome: WorkflowDispatchOutcome;
+						try {
+							outcome = await dispatcher(request, dispatchSignal);
+						} catch (error) {
+							outcome = {
+								status: "interrupted",
+								error: error instanceof Error ? error.message : String(error),
+							};
+						}
+						this.#settleNode(node, outcome, options.signal?.aborted === true);
+						this.#refreshPendingStates();
+						this.#reconcileStatus(true);
+						await this.#persist(options.onChange);
+					}),
+				);
+			}
+
+			if (dispatchSignal.aborted) {
+				for (const state of Object.values(snapshot.nodes)) {
+					if (state.status !== "running") continue;
+					state.status = this.#cancelRequested ? "cancelled" : "interrupted";
+					state.error = this.#cancelRequested ? "Workflow cancelled" : "Workflow execution interrupted";
+					state.finishedAt = this.#now();
+				}
+				this.#refreshPendingStates();
+			}
+			this.#reconcileStatus(false);
+			await this.#persist(options.onChange);
+			return cloneWorkflowSnapshot(snapshot);
+		} finally {
+			this.#runAbort = undefined;
+		}
+	}
+
+	async retryNode(nodeId: string): Promise<WorkflowSnapshot> {
+		const snapshot = this.#requireSnapshot();
+		if (this.#runAbort) throw new Error("Cannot retry a node while the workflow is running");
+		const selected = snapshot.nodes[nodeId];
+		if (!selected) throw new Error(`Unknown workflow node "${nodeId}"`);
+		if (selected.status !== "failed" && selected.status !== "interrupted") {
+			throw new Error(
+				`Workflow node "${nodeId}" is ${selected.status}; only failed or interrupted nodes can be retried`,
+			);
+		}
+
+		selected.status = "pending";
+		delete selected.agentId;
+		delete selected.outputRef;
+		delete selected.historyRef;
+		delete selected.error;
+		delete selected.startedAt;
+		delete selected.finishedAt;
+		for (const descendantId of descendantIds(snapshot.definition, nodeId)) {
+			if (descendantId === nodeId) continue;
+			const state = snapshot.nodes[descendantId]!;
+			if (state.status !== "blocked") continue;
+			state.status = "pending";
+			delete state.error;
+			delete state.finishedAt;
+		}
+		this.#cancelRequested = false;
+		this.#refreshPendingStates();
+		this.#reconcileStatus(false);
+		await this.#persist();
+		return cloneWorkflowSnapshot(snapshot);
+	}
+
+	async cancel(): Promise<WorkflowSnapshot> {
+		const snapshot = this.#requireSnapshot();
+		if (snapshot.status === "succeeded" || snapshot.status === "cancelled") {
+			return cloneWorkflowSnapshot(snapshot);
+		}
+		this.#cancelRequested = true;
+		for (const state of Object.values(snapshot.nodes)) {
+			if (state.status === "pending" || state.status === "ready") {
+				state.status = "cancelled";
+				state.error = "Workflow cancelled before dispatch";
+				state.finishedAt = this.#now();
+			}
+		}
+		snapshot.status = Object.values(snapshot.nodes).some(state => state.status === "running")
+			? "cancelling"
+			: "cancelled";
+		this.#runAbort?.abort("Workflow cancelled");
+		await this.#persist();
+		return cloneWorkflowSnapshot(snapshot);
+	}
+
+	#requireSnapshot(): WorkflowSnapshot {
+		if (!this.#snapshot) throw new Error("No workflow exists in this session");
+		return this.#snapshot;
+	}
+
+	#dispatchRequest(definition: WorkflowDefinition, node: WorkflowNode, attempt: number): WorkflowDispatchRequest {
+		const request: WorkflowDispatchRequest = {
+			nodeId: node.id,
+			name: buildAgentName(definition.id, node.id, attempt),
+			agent: node.agent,
+			task: node.task,
+			context: buildDependencyContext(this.#requireSnapshot(), node),
+		};
+		if (Object.hasOwn(node, "outputSchema")) request.outputSchema = node.outputSchema;
+		if (node.schemaMode !== undefined) request.schemaMode = node.schemaMode;
+		if (node.isolated !== undefined) request.isolated = node.isolated;
+		return request;
+	}
+
+	#settleNode(node: WorkflowNode, outcome: WorkflowDispatchOutcome, parentAborted: boolean): void {
+		const state = this.#requireSnapshot().nodes[node.id]!;
+		state.finishedAt = this.#now();
+		if ("error" in outcome) {
+			state.status = this.#cancelRequested ? "cancelled" : parentAborted ? "interrupted" : outcome.status;
+			state.error = outcome.error;
+			return;
+		}
+
+		const result = outcome.result;
+		state.agentId = result.id;
+		state.outputRef = `agent://${result.id}`;
+		state.historyRef = `history://${result.id}`;
+		const strictSchemaFailure =
+			node.schemaMode === "strict" &&
+			Object.hasOwn(node, "outputSchema") &&
+			result.structuredOutput?.status !== "valid";
+		if (this.#cancelRequested) {
+			state.status = "cancelled";
+			state.error = "Workflow cancelled";
+		} else if (result.aborted || parentAborted) {
+			state.status = "interrupted";
+			state.error = resultError(result);
+		} else if (result.exitCode !== 0 || strictSchemaFailure) {
+			state.status = "failed";
+			state.error = strictSchemaFailure
+				? result.structuredOutput?.error || "Strict output schema validation failed"
+				: resultError(result);
+		} else {
+			state.status = "succeeded";
+			delete state.error;
+		}
+	}
+
+	#refreshPendingStates(): void {
+		const snapshot = this.#requireSnapshot();
+		for (const node of snapshot.definition.nodes) {
+			const state = snapshot.nodes[node.id]!;
+			if (state.status !== "pending") continue;
+			const dependencies = (node.needs ?? []).map(id => snapshot.nodes[id]!);
+			if (dependencies.some(dependency => UPSTREAM_BLOCKING_STATUSES.has(dependency.status))) {
+				state.status = "blocked";
+				state.error = "Blocked by an unsuccessful dependency";
+				state.finishedAt = this.#now();
+			} else if (dependencies.every(dependency => dependency.status === "succeeded")) {
+				state.status = "ready";
+			}
+		}
+	}
+
+	#reconcileStatus(active: boolean): void {
+		const snapshot = this.#requireSnapshot();
+		const states = Object.values(snapshot.nodes);
+		if (states.every(state => state.status === "succeeded")) {
+			snapshot.status = "succeeded";
+		} else if (this.#cancelRequested) {
+			snapshot.status = states.some(state => state.status === "running") ? "cancelling" : "cancelled";
+		} else if (
+			states.some(state => state.status === "running") ||
+			(active && states.some(state => state.status === "ready"))
+		) {
+			snapshot.status = "running";
+		} else if (states.some(state => state.status === "interrupted")) {
+			snapshot.status = "interrupted";
+		} else if (states.some(state => state.status === "failed" || state.status === "blocked")) {
+			snapshot.status = "failed";
+		} else if (states.some(state => state.status === "cancelled")) {
+			snapshot.status = "cancelled";
+		} else {
+			snapshot.status = "created";
+		}
+	}
+
+	#reconcileInterruptedRun(): boolean {
+		if (!this.#snapshot) return false;
+		let changed = false;
+		for (const state of Object.values(this.#snapshot.nodes)) {
+			if (state.status !== "running") continue;
+			state.status = "interrupted";
+			state.error = "Interrupted by process restart";
+			state.finishedAt = this.#now();
+			changed = true;
+		}
+		if (!changed) return false;
+		this.#refreshPendingStates();
+		this.#reconcileStatus(false);
+		return true;
+	}
+
+	async #persist(onChange?: (snapshot: WorkflowSnapshot) => void | Promise<void>): Promise<void> {
+		const snapshot = this.#requireSnapshot();
+		snapshot.revision += 1;
+		snapshot.updatedAt = this.#now();
+		const durable = cloneWorkflowSnapshot(snapshot);
+		const operation = this.#saveTail.catch(() => {}).then(() => this.#store.append(durable));
+		this.#saveTail = operation;
+		await operation;
+		await onChange?.(cloneWorkflowSnapshot(durable));
+	}
+}

--- a/packages/coding-agent/src/workflows/runtime.ts
+++ b/packages/coding-agent/src/workflows/runtime.ts
@@ -187,6 +187,7 @@ export class WorkflowRuntime {
 		const dispatchSignal = options.signal
 			? AbortSignal.any([options.signal, this.#runAbort.signal])
 			: this.#runAbort.signal;
+		const inFlight = new Map<string, Promise<void>>();
 		try {
 			this.#refreshPendingStates();
 			const preflightRequests = snapshot.definition.nodes
@@ -198,43 +199,51 @@ export class WorkflowRuntime {
 			await options.preflight?.(preflightRequests);
 			while (!dispatchSignal.aborted && !this.#cancelRequested) {
 				const ready = snapshot.definition.nodes.filter(node => snapshot.nodes[node.id]?.status === "ready");
-				if (ready.length === 0) break;
-				const startedAt = this.#now();
-				for (const node of ready) {
-					const state = snapshot.nodes[node.id]!;
-					state.status = "running";
-					state.attempts += 1;
-					state.startedAt = startedAt;
-					delete state.finishedAt;
-					delete state.agentId;
-					delete state.outputRef;
-					delete state.historyRef;
-					delete state.error;
-				}
-				snapshot.status = "running";
-				await this.#persist(options.onChange);
-
-				await Promise.all(
-					ready.map(async node => {
+				if (ready.length > 0) {
+					const startedAt = this.#now();
+					for (const node of ready) {
 						const state = snapshot.nodes[node.id]!;
-						const request = this.#dispatchRequest(snapshot.definition, node, state.attempts);
-						let outcome: WorkflowDispatchOutcome;
-						try {
-							outcome = await dispatcher(request, dispatchSignal);
-						} catch (error) {
-							outcome = {
-								status: "interrupted",
-								error: error instanceof Error ? error.message : String(error),
-							};
-						}
-						this.#settleNode(node, outcome, options.signal?.aborted === true);
-						this.#refreshPendingStates();
-						this.#reconcileStatus(true);
-						await this.#persist(options.onChange);
-					}),
-				);
+						state.status = "running";
+						state.attempts += 1;
+						state.startedAt = startedAt;
+						delete state.finishedAt;
+						delete state.agentId;
+						delete state.outputRef;
+						delete state.historyRef;
+						delete state.error;
+					}
+					snapshot.status = "running";
+					await this.#persist(options.onChange);
+
+					for (const node of ready) {
+						const execution = (async () => {
+							const state = snapshot.nodes[node.id]!;
+							const request = this.#dispatchRequest(snapshot.definition, node, state.attempts);
+							let outcome: WorkflowDispatchOutcome;
+							try {
+								outcome = await dispatcher(request, dispatchSignal);
+							} catch (error) {
+								outcome = {
+									status: "interrupted",
+									error: error instanceof Error ? error.message : String(error),
+								};
+							}
+							this.#settleNode(node, outcome, options.signal?.aborted === true);
+							this.#refreshPendingStates();
+							this.#reconcileStatus(true);
+							await this.#persist(options.onChange);
+						})().finally(() => {
+							inFlight.delete(node.id);
+						});
+						inFlight.set(node.id, execution);
+					}
+				}
+
+				if (inFlight.size === 0) break;
+				await Promise.race(inFlight.values());
 			}
 
+			await Promise.allSettled(inFlight.values());
 			if (dispatchSignal.aborted) {
 				for (const state of Object.values(snapshot.nodes)) {
 					if (state.status !== "running") continue;

--- a/packages/coding-agent/src/workflows/runtime.ts
+++ b/packages/coding-agent/src/workflows/runtime.ts
@@ -113,6 +113,7 @@ export class WorkflowRuntime {
 	readonly #now: () => number;
 	readonly #idFactory: () => string;
 	#snapshot: WorkflowSnapshot | null;
+	#branchKey: string | null | undefined;
 	#runAbort: AbortController | undefined;
 	#cancelRequested = false;
 	#saveTail: Promise<void> = Promise.resolve();
@@ -122,6 +123,7 @@ export class WorkflowRuntime {
 		this.#now = options.now ?? Date.now;
 		this.#idFactory = options.idFactory ?? defaultWorkflowId;
 		this.#snapshot = snapshot;
+		this.#branchKey = options.store.branchKey?.();
 	}
 
 	static async create(options: WorkflowRuntimeOptions): Promise<WorkflowRuntime> {
@@ -134,10 +136,12 @@ export class WorkflowRuntime {
 	}
 
 	getSnapshot(): WorkflowSnapshot | null {
+		if (!this.#runAbort) this.#syncBranch();
 		return this.#snapshot ? cloneWorkflowSnapshot(this.#snapshot) : null;
 	}
 
 	async createWorkflow(draft: WorkflowDraft): Promise<WorkflowSnapshot> {
+		this.#syncBranch();
 		if (this.#snapshot && !isReplaceable(this.#snapshot.status)) {
 			throw new Error(
 				`Workflow ${this.#snapshot.definition.id} is ${this.#snapshot.status}; complete or cancel it before creating another`,
@@ -176,6 +180,7 @@ export class WorkflowRuntime {
 	}
 
 	async run(dispatcher: WorkflowDispatcher, options: WorkflowRunOptions = {}): Promise<WorkflowSnapshot> {
+		this.#syncBranch();
 		const snapshot = this.#requireSnapshot();
 		if (this.#runAbort) throw new Error(`Workflow ${snapshot.definition.id} is already running`);
 		if (snapshot.status === "succeeded" || snapshot.status === "cancelled") {
@@ -284,6 +289,7 @@ export class WorkflowRuntime {
 	}
 
 	async retryNode(nodeId: string): Promise<WorkflowSnapshot> {
+		this.#syncBranch();
 		const snapshot = this.#requireSnapshot();
 		if (this.#runAbort) throw new Error("Cannot retry a node while the workflow is running");
 		const selected = snapshot.nodes[nodeId];
@@ -317,6 +323,7 @@ export class WorkflowRuntime {
 	}
 
 	async cancel(): Promise<WorkflowSnapshot> {
+		if (!this.#runAbort) this.#syncBranch();
 		const snapshot = this.#requireSnapshot();
 		if (snapshot.status === "succeeded" || snapshot.status === "cancelled") {
 			return cloneWorkflowSnapshot(snapshot);
@@ -379,7 +386,7 @@ export class WorkflowRuntime {
 		} else if (result.aborted || parentAborted) {
 			state.status = "interrupted";
 			state.error = resultError(result);
-		} else if (result.exitCode !== 0 || strictSchemaFailure) {
+		} else if (result.exitCode !== 0 || result.error?.trim() || strictSchemaFailure) {
 			state.status = "failed";
 			state.error = strictSchemaFailure
 				? result.structuredOutput?.error || "Strict output schema validation failed"
@@ -445,7 +452,19 @@ export class WorkflowRuntime {
 		return true;
 	}
 
+	#syncBranch(): void {
+		const branchKey = this.#store.branchKey?.();
+		if (branchKey === undefined || branchKey === this.#branchKey) return;
+		this.#snapshot = this.#store.load();
+		this.#branchKey = branchKey;
+		this.#cancelRequested = false;
+	}
+
 	async #persist(onChange?: (snapshot: WorkflowSnapshot) => void | Promise<void>): Promise<void> {
+		const branchKey = this.#store.branchKey?.();
+		if (branchKey !== undefined && branchKey !== this.#branchKey) {
+			throw new Error("Workflow session branch changed during operation");
+		}
 		const snapshot = this.#requireSnapshot();
 		snapshot.revision += 1;
 		snapshot.updatedAt = this.#now();
@@ -453,6 +472,7 @@ export class WorkflowRuntime {
 		const operation = this.#saveTail.catch(() => {}).then(() => this.#store.append(durable));
 		this.#saveTail = operation;
 		await operation;
+		this.#branchKey = this.#store.branchKey?.();
 		await onChange?.(cloneWorkflowSnapshot(durable));
 	}
 }

--- a/packages/coding-agent/src/workflows/runtime.ts
+++ b/packages/coding-agent/src/workflows/runtime.ts
@@ -461,18 +461,22 @@ export class WorkflowRuntime {
 	}
 
 	async #persist(onChange?: (snapshot: WorkflowSnapshot) => void | Promise<void>): Promise<void> {
-		const branchKey = this.#store.branchKey?.();
-		if (branchKey !== undefined && branchKey !== this.#branchKey) {
-			throw new Error("Workflow session branch changed during operation");
-		}
 		const snapshot = this.#requireSnapshot();
 		snapshot.revision += 1;
 		snapshot.updatedAt = this.#now();
 		const durable = cloneWorkflowSnapshot(snapshot);
-		const operation = this.#saveTail.catch(() => {}).then(() => this.#store.append(durable));
+		const operation = this.#saveTail
+			.catch(() => {})
+			.then(async () => {
+				const branchKey = this.#store.branchKey?.();
+				if (branchKey !== undefined && branchKey !== this.#branchKey) {
+					throw new Error("Workflow session branch changed during operation");
+				}
+				await this.#store.append(durable);
+				this.#branchKey = this.#store.branchKey?.();
+			});
 		this.#saveTail = operation;
 		await operation;
-		this.#branchKey = this.#store.branchKey?.();
 		await onChange?.(cloneWorkflowSnapshot(durable));
 	}
 }

--- a/packages/coding-agent/src/workflows/runtime.ts
+++ b/packages/coding-agent/src/workflows/runtime.ts
@@ -188,6 +188,15 @@ export class WorkflowRuntime {
 			? AbortSignal.any([options.signal, this.#runAbort.signal])
 			: this.#runAbort.signal;
 		const inFlight = new Map<string, Promise<void>>();
+		let hasExecutionError = false;
+		let firstExecutionError: unknown;
+		const recordExecutionError = (error: unknown): void => {
+			if (!hasExecutionError) {
+				hasExecutionError = true;
+				firstExecutionError = error;
+			}
+			this.#runAbort?.abort(error);
+		};
 		try {
 			this.#refreshPendingStates();
 			const preflightRequests = snapshot.definition.nodes
@@ -197,53 +206,61 @@ export class WorkflowRuntime {
 				})
 				.map(node => this.#dispatchRequest(snapshot.definition, node, snapshot.nodes[node.id]!.attempts + 1));
 			await options.preflight?.(preflightRequests);
-			while (!dispatchSignal.aborted && !this.#cancelRequested) {
-				const ready = snapshot.definition.nodes.filter(node => snapshot.nodes[node.id]?.status === "ready");
-				if (ready.length > 0) {
-					const startedAt = this.#now();
-					for (const node of ready) {
-						const state = snapshot.nodes[node.id]!;
-						state.status = "running";
-						state.attempts += 1;
-						state.startedAt = startedAt;
-						delete state.finishedAt;
-						delete state.agentId;
-						delete state.outputRef;
-						delete state.historyRef;
-						delete state.error;
-					}
-					snapshot.status = "running";
-					await this.#persist(options.onChange);
-
-					for (const node of ready) {
-						const execution = (async () => {
+			try {
+				while (!dispatchSignal.aborted && !this.#cancelRequested) {
+					const ready = snapshot.definition.nodes.filter(node => snapshot.nodes[node.id]?.status === "ready");
+					if (ready.length > 0) {
+						const startedAt = this.#now();
+						for (const node of ready) {
 							const state = snapshot.nodes[node.id]!;
-							const request = this.#dispatchRequest(snapshot.definition, node, state.attempts);
-							let outcome: WorkflowDispatchOutcome;
-							try {
-								outcome = await dispatcher(request, dispatchSignal);
-							} catch (error) {
-								outcome = {
-									status: "interrupted",
-									error: error instanceof Error ? error.message : String(error),
-								};
-							}
-							this.#settleNode(node, outcome, options.signal?.aborted === true);
-							this.#refreshPendingStates();
-							this.#reconcileStatus(true);
-							await this.#persist(options.onChange);
-						})().finally(() => {
-							inFlight.delete(node.id);
-						});
-						inFlight.set(node.id, execution);
-					}
-				}
+							state.status = "running";
+							state.attempts += 1;
+							state.startedAt = startedAt;
+							delete state.finishedAt;
+							delete state.agentId;
+							delete state.outputRef;
+							delete state.historyRef;
+							delete state.error;
+						}
+						snapshot.status = "running";
+						await this.#persist(options.onChange);
+						if (dispatchSignal.aborted || this.#cancelRequested) continue;
 
-				if (inFlight.size === 0) break;
-				await Promise.race(inFlight.values());
+						for (const node of ready) {
+							const execution = (async () => {
+								const state = snapshot.nodes[node.id]!;
+								const request = this.#dispatchRequest(snapshot.definition, node, state.attempts);
+								let outcome: WorkflowDispatchOutcome;
+								try {
+									outcome = await dispatcher(request, dispatchSignal);
+								} catch (error) {
+									outcome = {
+										status: "interrupted",
+										error: error instanceof Error ? error.message : String(error),
+									};
+								}
+								this.#settleNode(node, outcome, options.signal?.aborted === true);
+								this.#refreshPendingStates();
+								this.#reconcileStatus(true);
+								await this.#persist(options.onChange);
+							})()
+								.catch(recordExecutionError)
+								.finally(() => {
+									inFlight.delete(node.id);
+								});
+							inFlight.set(node.id, execution);
+						}
+					}
+
+					if (inFlight.size === 0) break;
+					await Promise.race(inFlight.values());
+				}
+			} catch (error) {
+				recordExecutionError(error);
+			} finally {
+				await Promise.allSettled(inFlight.values());
 			}
 
-			await Promise.allSettled(inFlight.values());
 			if (dispatchSignal.aborted) {
 				for (const state of Object.values(snapshot.nodes)) {
 					if (state.status !== "running") continue;
@@ -254,7 +271,12 @@ export class WorkflowRuntime {
 				this.#refreshPendingStates();
 			}
 			this.#reconcileStatus(false);
-			await this.#persist(options.onChange);
+			try {
+				await this.#persist(options.onChange);
+			} catch (error) {
+				recordExecutionError(error);
+			}
+			if (hasExecutionError) throw firstExecutionError;
 			return cloneWorkflowSnapshot(snapshot);
 		} finally {
 			this.#runAbort = undefined;

--- a/packages/coding-agent/src/workflows/runtime.ts
+++ b/packages/coding-agent/src/workflows/runtime.ts
@@ -136,12 +136,16 @@ export class WorkflowRuntime {
 	}
 
 	getSnapshot(): WorkflowSnapshot | null {
-		if (!this.#runAbort) this.#syncBranch();
 		return this.#snapshot ? cloneWorkflowSnapshot(this.#snapshot) : null;
 	}
 
+	async getDurableSnapshot(): Promise<WorkflowSnapshot | null> {
+		if (!this.#runAbort) await this.#syncBranch();
+		return this.getSnapshot();
+	}
+
 	async createWorkflow(draft: WorkflowDraft): Promise<WorkflowSnapshot> {
-		this.#syncBranch();
+		await this.#syncBranch();
 		if (this.#snapshot && !isReplaceable(this.#snapshot.status)) {
 			throw new Error(
 				`Workflow ${this.#snapshot.definition.id} is ${this.#snapshot.status}; complete or cancel it before creating another`,
@@ -180,7 +184,7 @@ export class WorkflowRuntime {
 	}
 
 	async run(dispatcher: WorkflowDispatcher, options: WorkflowRunOptions = {}): Promise<WorkflowSnapshot> {
-		this.#syncBranch();
+		await this.#syncBranch();
 		const snapshot = this.#requireSnapshot();
 		if (this.#runAbort) throw new Error(`Workflow ${snapshot.definition.id} is already running`);
 		if (snapshot.status === "succeeded" || snapshot.status === "cancelled") {
@@ -289,7 +293,7 @@ export class WorkflowRuntime {
 	}
 
 	async retryNode(nodeId: string): Promise<WorkflowSnapshot> {
-		this.#syncBranch();
+		await this.#syncBranch();
 		const snapshot = this.#requireSnapshot();
 		if (this.#runAbort) throw new Error("Cannot retry a node while the workflow is running");
 		const selected = snapshot.nodes[nodeId];
@@ -323,7 +327,7 @@ export class WorkflowRuntime {
 	}
 
 	async cancel(): Promise<WorkflowSnapshot> {
-		if (!this.#runAbort) this.#syncBranch();
+		if (!this.#runAbort) await this.#syncBranch();
 		const snapshot = this.#requireSnapshot();
 		if (snapshot.status === "succeeded" || snapshot.status === "cancelled") {
 			return cloneWorkflowSnapshot(snapshot);
@@ -452,12 +456,13 @@ export class WorkflowRuntime {
 		return true;
 	}
 
-	#syncBranch(): void {
+	async #syncBranch(): Promise<void> {
 		const branchKey = this.#store.branchKey?.();
 		if (branchKey === undefined || branchKey === this.#branchKey) return;
 		this.#snapshot = this.#store.load();
 		this.#branchKey = branchKey;
 		this.#cancelRequested = false;
+		if (this.#reconcileInterruptedRun()) await this.#persist();
 	}
 
 	async #persist(onChange?: (snapshot: WorkflowSnapshot) => void | Promise<void>): Promise<void> {

--- a/packages/coding-agent/src/workflows/store.ts
+++ b/packages/coding-agent/src/workflows/store.ts
@@ -15,6 +15,7 @@ export interface WorkflowStore {
 	load(): WorkflowSnapshot | null;
 	hasWorkflowId(id: string): boolean;
 	append(snapshot: WorkflowSnapshot): Promise<void>;
+	branchKey?(): string | null;
 }
 
 type WorkflowSessionManager = NonNullable<ToolSession["sessionManager"]>;
@@ -108,6 +109,10 @@ export class SessionWorkflowStore implements WorkflowStore {
 
 	constructor(sessionManager: WorkflowSessionManager) {
 		this.#sessionManager = sessionManager;
+	}
+
+	branchKey(): string | null {
+		return this.#sessionManager.getBranch().at(-1)?.id ?? null;
 	}
 
 	load(): WorkflowSnapshot | null {

--- a/packages/coding-agent/src/workflows/store.ts
+++ b/packages/coding-agent/src/workflows/store.ts
@@ -106,9 +106,14 @@ export function parseWorkflowSnapshot(value: unknown): WorkflowSnapshot | undefi
 
 export class SessionWorkflowStore implements WorkflowStore {
 	readonly #sessionManager: WorkflowSessionManager;
+	readonly #appendEntriesAtomically: NonNullable<WorkflowSessionManager["appendEntriesAtomically"]>;
 
 	constructor(sessionManager: WorkflowSessionManager) {
+		if (!sessionManager.appendEntriesAtomically) {
+			throw new Error("Session workflow persistence requires atomic journal appends");
+		}
 		this.#sessionManager = sessionManager;
+		this.#appendEntriesAtomically = sessionManager.appendEntriesAtomically.bind(sessionManager);
 	}
 
 	branchKey(): string | null {
@@ -134,8 +139,8 @@ export class SessionWorkflowStore implements WorkflowStore {
 	}
 
 	async append(snapshot: WorkflowSnapshot): Promise<void> {
-		this.#sessionManager.appendCustomEntry(WORKFLOW_SESSION_CUSTOM_TYPE, cloneWorkflowSnapshot(snapshot));
-		await this.#sessionManager.ensureOnDisk();
-		await this.#sessionManager.flush();
+		await this.#appendEntriesAtomically(() => {
+			this.#sessionManager.appendCustomEntry(WORKFLOW_SESSION_CUSTOM_TYPE, cloneWorkflowSnapshot(snapshot));
+		});
 	}
 }

--- a/packages/coding-agent/src/workflows/store.ts
+++ b/packages/coding-agent/src/workflows/store.ts
@@ -1,0 +1,136 @@
+import { isRecord } from "@oh-my-pi/pi-utils";
+import type { ToolSession } from "../tools";
+import {
+	cloneWorkflowSnapshot,
+	WORKFLOW_SESSION_CUSTOM_TYPE,
+	WORKFLOW_SNAPSHOT_VERSION,
+	type WorkflowNodeRun,
+	type WorkflowNodeStatus,
+	type WorkflowSnapshot,
+	type WorkflowStatus,
+} from "./types";
+import { parseWorkflowDefinition } from "./validation";
+
+export interface WorkflowStore {
+	load(): WorkflowSnapshot | null;
+	hasWorkflowId(id: string): boolean;
+	append(snapshot: WorkflowSnapshot): Promise<void>;
+}
+
+type WorkflowSessionManager = NonNullable<ToolSession["sessionManager"]>;
+
+const NODE_STATUSES: ReadonlySet<WorkflowNodeStatus> = new Set([
+	"pending",
+	"ready",
+	"running",
+	"succeeded",
+	"failed",
+	"blocked",
+	"interrupted",
+	"cancelled",
+]);
+
+const WORKFLOW_STATUSES: ReadonlySet<WorkflowStatus> = new Set([
+	"created",
+	"running",
+	"succeeded",
+	"failed",
+	"interrupted",
+	"cancelling",
+	"cancelled",
+]);
+
+function optionalString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseNodeRun(value: unknown): WorkflowNodeRun | undefined {
+	if (!isRecord(value) || typeof value.status !== "string" || !NODE_STATUSES.has(value.status as WorkflowNodeStatus)) {
+		return undefined;
+	}
+	if (typeof value.attempts !== "number" || !Number.isInteger(value.attempts) || value.attempts < 0) {
+		return undefined;
+	}
+	return {
+		status: value.status as WorkflowNodeStatus,
+		attempts: value.attempts,
+		agentId: optionalString(value.agentId),
+		outputRef: optionalString(value.outputRef),
+		historyRef: optionalString(value.historyRef),
+		error: optionalString(value.error),
+		startedAt: optionalNumber(value.startedAt),
+		finishedAt: optionalNumber(value.finishedAt),
+	};
+}
+
+export function parseWorkflowSnapshot(value: unknown): WorkflowSnapshot | undefined {
+	if (!isRecord(value) || value.version !== WORKFLOW_SNAPSHOT_VERSION) return undefined;
+	if (typeof value.revision !== "number" || !Number.isInteger(value.revision) || value.revision < 0) return undefined;
+	if (typeof value.status !== "string" || !WORKFLOW_STATUSES.has(value.status as WorkflowStatus)) return undefined;
+	if (
+		typeof value.createdAt !== "number" ||
+		!Number.isFinite(value.createdAt) ||
+		typeof value.updatedAt !== "number" ||
+		!Number.isFinite(value.updatedAt) ||
+		!isRecord(value.nodes)
+	) {
+		return undefined;
+	}
+	try {
+		const definition = parseWorkflowDefinition(value.definition);
+		const nodes: Record<string, WorkflowNodeRun> = {};
+		for (const node of definition.nodes) {
+			const run = parseNodeRun(value.nodes[node.id]);
+			if (!run) return undefined;
+			nodes[node.id] = run;
+		}
+		if (Object.keys(value.nodes).some(id => !Object.hasOwn(nodes, id))) return undefined;
+		return {
+			version: WORKFLOW_SNAPSHOT_VERSION,
+			revision: value.revision,
+			definition,
+			status: value.status as WorkflowStatus,
+			nodes,
+			createdAt: value.createdAt,
+			updatedAt: value.updatedAt,
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+export class SessionWorkflowStore implements WorkflowStore {
+	readonly #sessionManager: WorkflowSessionManager;
+
+	constructor(sessionManager: WorkflowSessionManager) {
+		this.#sessionManager = sessionManager;
+	}
+
+	load(): WorkflowSnapshot | null {
+		const entries = this.#sessionManager.getBranch();
+		for (let index = entries.length - 1; index >= 0; index--) {
+			const entry = entries[index]!;
+			if (entry.type !== "custom" || entry.customType !== WORKFLOW_SESSION_CUSTOM_TYPE) continue;
+			const snapshot = parseWorkflowSnapshot(entry.data);
+			if (snapshot) return cloneWorkflowSnapshot(snapshot);
+		}
+		return null;
+	}
+
+	hasWorkflowId(id: string): boolean {
+		return this.#sessionManager.getBranch().some(entry => {
+			if (entry.type !== "custom" || entry.customType !== WORKFLOW_SESSION_CUSTOM_TYPE) return false;
+			return parseWorkflowSnapshot(entry.data)?.definition.id === id;
+		});
+	}
+
+	async append(snapshot: WorkflowSnapshot): Promise<void> {
+		this.#sessionManager.appendCustomEntry(WORKFLOW_SESSION_CUSTOM_TYPE, cloneWorkflowSnapshot(snapshot));
+		await this.#sessionManager.ensureOnDisk();
+		await this.#sessionManager.flush();
+	}
+}

--- a/packages/coding-agent/src/workflows/tools/workflow-tool.ts
+++ b/packages/coding-agent/src/workflows/tools/workflow-tool.ts
@@ -5,6 +5,7 @@ import workflowPreflightContext from "../../prompts/system/workflow-preflight-co
 import workflowDescription from "../../prompts/tools/workflow.md" with { type: "text" };
 import type { SettledTaskSpawn, TaskDispatchService } from "../../task/dispatch-service";
 import type { ToolSession } from "../../tools";
+import { previewLine, replaceTabs, shortenPath, TRUNCATE_LENGTHS } from "../../tools/render-utils";
 import { ToolError } from "../../tools/tool-errors";
 import { type WorkflowDispatchOutcome, type WorkflowDispatchRequest, WorkflowRuntime } from "../runtime";
 import { SessionWorkflowStore } from "../store";
@@ -35,6 +36,11 @@ const workflowSchema = type({
 
 export type WorkflowToolInput = typeof workflowSchema.infer;
 
+function safeSummaryText(text: string): string {
+	const shortened = text.replace(/(?:[A-Za-z]:[\\/]|\/)[^\s'")\]]+/g, match => shortenPath(match));
+	return previewLine(replaceTabs(shortened), TRUNCATE_LENGTHS.LINE);
+}
+
 function summarize(snapshot: WorkflowSnapshot | null): string {
 	if (!snapshot) return "No workflow exists in this session.";
 	const counts = new Map<string, number>();
@@ -47,13 +53,13 @@ function summarize(snapshot: WorkflowSnapshot | null): string {
 		.join(", ");
 	const lines = [
 		`Workflow ${snapshot.definition.id}: ${snapshot.status}`,
-		`Objective: ${snapshot.definition.objective}`,
+		`Objective: ${safeSummaryText(snapshot.definition.objective)}`,
 		`Nodes: ${countText}`,
 	];
 	for (const node of snapshot.definition.nodes) {
 		const state = snapshot.nodes[node.id]!;
 		const refs = [state.outputRef, state.historyRef].filter(Boolean).join(", ");
-		const detail = refs || state.error;
+		const detail = refs || (state.error ? safeSummaryText(state.error) : undefined);
 		lines.push(`- ${node.id}: ${state.status}${detail ? ` — ${detail}` : ""}`);
 	}
 	return lines.join("\n");

--- a/packages/coding-agent/src/workflows/tools/workflow-tool.ts
+++ b/packages/coding-agent/src/workflows/tools/workflow-tool.ts
@@ -66,6 +66,7 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 	readonly description = prompt.render(workflowDescription);
 	readonly parameters = workflowSchema;
 	readonly approval = "exec" as const;
+	readonly concurrency = "exclusive" as const;
 	readonly strict = true;
 	readonly intent = "omit" as const;
 	readonly loadMode = "discoverable" as const;
@@ -78,7 +79,7 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 	}
 
 	static async createIf(session: ToolSession): Promise<WorkflowTool | null> {
-		if (!session.sessionManager || (session.taskDepth ?? 0) !== 0) return null;
+		if (!session.sessionManager || !session.getSessionFile() || (session.taskDepth ?? 0) !== 0) return null;
 		const runtime = await WorkflowRuntime.create({ store: new SessionWorkflowStore(session.sessionManager) });
 		return new WorkflowTool(session, runtime);
 	}

--- a/packages/coding-agent/src/workflows/tools/workflow-tool.ts
+++ b/packages/coding-agent/src/workflows/tools/workflow-tool.ts
@@ -1,9 +1,11 @@
 import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import type { Usage } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import workflowPreflightContext from "../../prompts/system/workflow-preflight-context.md" with { type: "text" };
 import workflowDescription from "../../prompts/tools/workflow.md" with { type: "text" };
 import type { SettledTaskSpawn, TaskDispatchService } from "../../task/dispatch-service";
+import { addUsageTotals, createUsageTotals } from "../../task/usage";
 import type { ToolSession } from "../../tools";
 import { previewLine, replaceTabs, shortenPath, TRUNCATE_LENGTHS } from "../../tools/render-utils";
 import { ToolError } from "../../tools/tool-errors";
@@ -85,8 +87,11 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 	}
 
 	static async createIf(session: ToolSession): Promise<WorkflowTool | null> {
-		if (!session.sessionManager || !session.getSessionFile() || (session.taskDepth ?? 0) !== 0) return null;
-		const runtime = await WorkflowRuntime.create({ store: new SessionWorkflowStore(session.sessionManager) });
+		const sessionManager = session.sessionManager;
+		if (!sessionManager?.appendEntriesAtomically || !session.getSessionFile() || (session.taskDepth ?? 0) !== 0) {
+			return null;
+		}
+		const runtime = await WorkflowRuntime.create({ store: new SessionWorkflowStore(sessionManager) });
 		return new WorkflowTool(session, runtime);
 	}
 
@@ -101,10 +106,17 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 		onUpdate?: AgentToolUpdateCallback<WorkflowToolDetails>,
 	): Promise<AgentToolResult<WorkflowToolDetails>> {
 		let snapshot: WorkflowSnapshot | null;
+		const usage = createUsageTotals();
+		let hasUsage = false;
+		const recordUsage = (nodeUsage: Usage | undefined): void => {
+			if (!nodeUsage) return;
+			addUsageTotals(usage, nodeUsage);
+			hasUsage = true;
+		};
 		const runWorkflow = (): Promise<WorkflowSnapshot> => {
 			const taskDispatch = this.#requireTaskDispatch();
 			return this.#runtime.run(
-				(request, runSignal) => this.#dispatchNode(taskDispatch, toolCallId, request, runSignal),
+				(request, runSignal) => this.#dispatchNode(taskDispatch, toolCallId, request, runSignal, recordUsage),
 				{
 					signal,
 					preflight: requests =>
@@ -112,7 +124,7 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 					onChange: current =>
 						onUpdate?.({
 							content: [{ type: "text", text: summarize(current) }],
-							details: { op: params.op, workflow: current },
+							details: { op: params.op, workflow: current, ...(hasUsage ? { usage } : {}) },
 						}),
 				},
 			);
@@ -145,7 +157,7 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 					nodes: params.nodes,
 				});
 			} else if (params.op === "get") {
-				snapshot = this.#runtime.getSnapshot();
+				snapshot = await this.#runtime.getDurableSnapshot();
 			} else if (params.op === "cancel") {
 				snapshot = await this.cancelActiveWorkflow();
 			} else if (params.op === "retry") {
@@ -162,7 +174,7 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 
 		return {
 			content: [{ type: "text", text: summarize(snapshot) }],
-			details: { op: params.op, workflow: snapshot },
+			details: { op: params.op, workflow: snapshot, ...(hasUsage ? { usage } : {}) },
 		};
 	}
 
@@ -177,6 +189,7 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 		parentToolCallId: string,
 		request: WorkflowDispatchRequest,
 		signal: AbortSignal,
+		recordUsage: (usage: Usage | undefined) => void,
 	): Promise<WorkflowDispatchOutcome> {
 		const result = await taskDispatch.executeSettledSpawn(
 			`${parentToolCallId}:${request.nodeId}`,
@@ -186,7 +199,10 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 		const settled = result.details?.results[0];
 		const content = result.content.find(part => part.type === "text");
 		const error = content?.type === "text" ? content.text : "Task execution failed before producing a settled result";
-		return settled ? { result: settled } : { status: "failed", error };
+		if (!settled) return { status: "failed", error };
+		const usage = settled.usage ?? result.details?.usage;
+		recordUsage(usage);
+		return { result: usage === undefined || settled.usage ? settled : { ...settled, usage } };
 	}
 
 	#settledSpawn(request: WorkflowDispatchRequest): SettledTaskSpawn {

--- a/packages/coding-agent/src/workflows/tools/workflow-tool.ts
+++ b/packages/coding-agent/src/workflows/tools/workflow-tool.ts
@@ -84,6 +84,10 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 		return new WorkflowTool(session, runtime);
 	}
 
+	cancelActiveWorkflow(): Promise<WorkflowSnapshot> {
+		return this.#runtime.cancel();
+	}
+
 	async execute(
 		toolCallId: string,
 		params: WorkflowToolInput,
@@ -137,7 +141,7 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 			} else if (params.op === "get") {
 				snapshot = this.#runtime.getSnapshot();
 			} else if (params.op === "cancel") {
-				snapshot = await this.#runtime.cancel();
+				snapshot = await this.cancelActiveWorkflow();
 			} else if (params.op === "retry") {
 				if (!params.node_id?.trim()) throw new ToolError("node_id is required when op=retry");
 				await this.#runtime.retryNode(params.node_id.trim());

--- a/packages/coding-agent/src/workflows/tools/workflow-tool.ts
+++ b/packages/coding-agent/src/workflows/tools/workflow-tool.ts
@@ -1,0 +1,192 @@
+import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import { prompt } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+import workflowPreflightContext from "../../prompts/system/workflow-preflight-context.md" with { type: "text" };
+import workflowDescription from "../../prompts/tools/workflow.md" with { type: "text" };
+import type { SettledTaskSpawn, TaskDispatchService } from "../../task/dispatch-service";
+import type { ToolSession } from "../../tools";
+import { ToolError } from "../../tools/tool-errors";
+import { type WorkflowDispatchOutcome, type WorkflowDispatchRequest, WorkflowRuntime } from "../runtime";
+import { SessionWorkflowStore } from "../store";
+import type { WorkflowSnapshot, WorkflowToolDetails } from "../types";
+
+const outputSchemaInputSchema = type("object | boolean | string | null");
+const workflowNodeSchema = type({
+	id: "string",
+	agent: "string = 'task'",
+	task: "string",
+	"needs?": "string[]",
+	"outputSchema?": outputSchemaInputSchema.describe(
+		"JSON Schema object for this node's result; a string must contain serialized JSON Schema",
+	),
+	"schemaMode?": '"permissive" | "strict"',
+	"isolated?": "boolean",
+	"+": "delete",
+});
+
+const workflowSchema = type({
+	op: type("'create' | 'get' | 'run' | 'resume' | 'retry' | 'cancel'").describe("workflow operation"),
+	"id?": type("string").describe("optional stable workflow id for create"),
+	"objective?": type("string").describe("workflow objective for create"),
+	"nodes?": workflowNodeSchema.array().describe("complete static DAG for create"),
+	"node_id?": type("string").describe("failed or interrupted node to retry"),
+	"+": "delete",
+});
+
+export type WorkflowToolInput = typeof workflowSchema.infer;
+
+function summarize(snapshot: WorkflowSnapshot | null): string {
+	if (!snapshot) return "No workflow exists in this session.";
+	const counts = new Map<string, number>();
+	for (const state of Object.values(snapshot.nodes)) {
+		counts.set(state.status, (counts.get(state.status) ?? 0) + 1);
+	}
+	const countText = [...counts.entries()]
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([status, count]) => `${count} ${status}`)
+		.join(", ");
+	const lines = [
+		`Workflow ${snapshot.definition.id}: ${snapshot.status}`,
+		`Objective: ${snapshot.definition.objective}`,
+		`Nodes: ${countText}`,
+	];
+	for (const node of snapshot.definition.nodes) {
+		const state = snapshot.nodes[node.id]!;
+		const refs = [state.outputRef, state.historyRef].filter(Boolean).join(", ");
+		const detail = refs || state.error;
+		lines.push(`- ${node.id}: ${state.status}${detail ? ` — ${detail}` : ""}`);
+	}
+	return lines.join("\n");
+}
+
+export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowToolDetails> {
+	readonly name = "workflow";
+	readonly label = "Workflow";
+	readonly summary = "Run a session-durable dependency graph through Task";
+	readonly description = prompt.render(workflowDescription);
+	readonly parameters = workflowSchema;
+	readonly approval = "exec" as const;
+	readonly strict = true;
+	readonly intent = "omit" as const;
+	readonly loadMode = "discoverable" as const;
+	readonly #session: ToolSession;
+	readonly #runtime: WorkflowRuntime;
+
+	private constructor(session: ToolSession, runtime: WorkflowRuntime) {
+		this.#session = session;
+		this.#runtime = runtime;
+	}
+
+	static async createIf(session: ToolSession): Promise<WorkflowTool | null> {
+		if (!session.sessionManager || (session.taskDepth ?? 0) !== 0) return null;
+		const runtime = await WorkflowRuntime.create({ store: new SessionWorkflowStore(session.sessionManager) });
+		return new WorkflowTool(session, runtime);
+	}
+
+	async execute(
+		toolCallId: string,
+		params: WorkflowToolInput,
+		signal?: AbortSignal,
+		onUpdate?: AgentToolUpdateCallback<WorkflowToolDetails>,
+	): Promise<AgentToolResult<WorkflowToolDetails>> {
+		let snapshot: WorkflowSnapshot | null;
+		const runWorkflow = (): Promise<WorkflowSnapshot> => {
+			const taskDispatch = this.#requireTaskDispatch();
+			return this.#runtime.run(
+				(request, runSignal) => this.#dispatchNode(taskDispatch, toolCallId, request, runSignal),
+				{
+					signal,
+					preflight: requests =>
+						taskDispatch.assertSettledSpawns(requests.map(request => this.#settledSpawn(request))),
+					onChange: current =>
+						onUpdate?.({
+							content: [{ type: "text", text: summarize(current) }],
+							details: { op: params.op, workflow: current },
+						}),
+				},
+			);
+		};
+		try {
+			if (params.op === "create") {
+				if (!params.objective?.trim()) throw new ToolError("objective is required when op=create");
+				if (!params.nodes) throw new ToolError("nodes is required when op=create");
+				const taskDispatch = this.#requireTaskDispatch();
+				await taskDispatch.assertSettledSpawns(
+					params.nodes.map(node =>
+						this.#settledSpawn({
+							nodeId: node.id,
+							name: node.id,
+							agent: node.agent,
+							task: node.task,
+							context: prompt.render(workflowPreflightContext, {
+								objective: params.objective,
+								nodeId: node.id,
+							}),
+							...(Object.hasOwn(node, "outputSchema") ? { outputSchema: node.outputSchema } : {}),
+							...(node.schemaMode !== undefined ? { schemaMode: node.schemaMode } : {}),
+							...(node.isolated !== undefined ? { isolated: node.isolated } : {}),
+						}),
+					),
+				);
+				snapshot = await this.#runtime.createWorkflow({
+					id: params.id,
+					objective: params.objective,
+					nodes: params.nodes,
+				});
+			} else if (params.op === "get") {
+				snapshot = this.#runtime.getSnapshot();
+			} else if (params.op === "cancel") {
+				snapshot = await this.#runtime.cancel();
+			} else if (params.op === "retry") {
+				if (!params.node_id?.trim()) throw new ToolError("node_id is required when op=retry");
+				await this.#runtime.retryNode(params.node_id.trim());
+				snapshot = await runWorkflow();
+			} else {
+				snapshot = await runWorkflow();
+			}
+		} catch (error) {
+			if (error instanceof ToolError) throw error;
+			throw new ToolError(error instanceof Error ? error.message : String(error));
+		}
+
+		return {
+			content: [{ type: "text", text: summarize(snapshot) }],
+			details: { op: params.op, workflow: snapshot },
+		};
+	}
+
+	#requireTaskDispatch(): TaskDispatchService {
+		const taskDispatch = this.#session.taskDispatchService;
+		if (!taskDispatch) throw new ToolError("The workflow tool requires the shared Task dispatch service");
+		return taskDispatch;
+	}
+
+	async #dispatchNode(
+		taskDispatch: TaskDispatchService,
+		parentToolCallId: string,
+		request: WorkflowDispatchRequest,
+		signal: AbortSignal,
+	): Promise<WorkflowDispatchOutcome> {
+		const result = await taskDispatch.executeSettledSpawn(
+			`${parentToolCallId}:${request.nodeId}`,
+			this.#settledSpawn(request),
+			signal,
+		);
+		const settled = result.details?.results[0];
+		const content = result.content.find(part => part.type === "text");
+		const error = content?.type === "text" ? content.text : "Task execution failed before producing a settled result";
+		return settled ? { result: settled } : { status: "failed", error };
+	}
+
+	#settledSpawn(request: WorkflowDispatchRequest): SettledTaskSpawn {
+		const item: SettledTaskSpawn["item"] = {
+			name: request.name,
+			agent: request.agent,
+			task: request.task,
+		};
+		if (Object.hasOwn(request, "outputSchema")) item.outputSchema = request.outputSchema;
+		if (request.schemaMode !== undefined) item.schemaMode = request.schemaMode;
+		if (request.isolated !== undefined) item.isolated = request.isolated;
+		return { context: request.context, item };
+	}
+}

--- a/packages/coding-agent/src/workflows/types.ts
+++ b/packages/coding-agent/src/workflows/types.ts
@@ -1,0 +1,79 @@
+import type { StructuredSubagentSchemaMode } from "../task/types";
+
+export const WORKFLOW_DEFINITION_VERSION = 1 as const;
+export const WORKFLOW_SNAPSHOT_VERSION = 1 as const;
+export const WORKFLOW_FAILURE_POLICY = "block-descendants" as const;
+export const WORKFLOW_SESSION_CUSTOM_TYPE = "workflow-state";
+
+export type WorkflowNodeStatus =
+	| "pending"
+	| "ready"
+	| "running"
+	| "succeeded"
+	| "failed"
+	| "blocked"
+	| "interrupted"
+	| "cancelled";
+
+export type WorkflowStatus =
+	| "created"
+	| "running"
+	| "succeeded"
+	| "failed"
+	| "interrupted"
+	| "cancelling"
+	| "cancelled";
+
+export interface WorkflowNode {
+	id: string;
+	agent: string;
+	task: string;
+	needs?: string[];
+	outputSchema?: unknown;
+	schemaMode?: StructuredSubagentSchemaMode;
+	isolated?: boolean;
+}
+
+export interface WorkflowDefinition {
+	version: typeof WORKFLOW_DEFINITION_VERSION;
+	id: string;
+	objective: string;
+	failurePolicy: typeof WORKFLOW_FAILURE_POLICY;
+	nodes: WorkflowNode[];
+}
+
+export interface WorkflowNodeRun {
+	status: WorkflowNodeStatus;
+	attempts: number;
+	agentId?: string;
+	outputRef?: string;
+	historyRef?: string;
+	error?: string;
+	startedAt?: number;
+	finishedAt?: number;
+}
+
+export interface WorkflowSnapshot {
+	version: typeof WORKFLOW_SNAPSHOT_VERSION;
+	revision: number;
+	definition: WorkflowDefinition;
+	status: WorkflowStatus;
+	nodes: Record<string, WorkflowNodeRun>;
+	createdAt: number;
+	updatedAt: number;
+}
+
+export interface WorkflowToolDetails {
+	op: "create" | "get" | "run" | "resume" | "retry" | "cancel";
+	workflow: WorkflowSnapshot | null;
+}
+
+export interface WorkflowDraft {
+	id?: string;
+	objective: string;
+	nodes: WorkflowNode[];
+}
+
+export function cloneWorkflowSnapshot(snapshot: WorkflowSnapshot): WorkflowSnapshot {
+	return structuredClone(snapshot);
+}

--- a/packages/coding-agent/src/workflows/types.ts
+++ b/packages/coding-agent/src/workflows/types.ts
@@ -1,3 +1,4 @@
+import type { Usage } from "@oh-my-pi/pi-ai";
 import type { StructuredSubagentSchemaMode } from "../task/types";
 
 export const WORKFLOW_DEFINITION_VERSION = 1 as const;
@@ -66,6 +67,8 @@ export interface WorkflowSnapshot {
 export interface WorkflowToolDetails {
 	op: "create" | "get" | "run" | "resume" | "retry" | "cancel";
 	workflow: WorkflowSnapshot | null;
+	/** Aggregated usage from Task dispatches performed by this tool call. */
+	usage?: Usage;
 }
 
 export interface WorkflowDraft {

--- a/packages/coding-agent/src/workflows/validation.ts
+++ b/packages/coding-agent/src/workflows/validation.ts
@@ -1,0 +1,142 @@
+import { isRecord } from "@oh-my-pi/pi-utils";
+import {
+	WORKFLOW_DEFINITION_VERSION,
+	WORKFLOW_FAILURE_POLICY,
+	type WorkflowDefinition,
+	type WorkflowNode,
+} from "./types";
+
+export const MAX_WORKFLOW_NODES = 100;
+
+const WORKFLOW_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+
+function requiredString(value: unknown, field: string): string {
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw new Error(`${field} must be a non-empty string`);
+	}
+	return value.trim();
+}
+
+function workflowId(value: unknown, field: string): string {
+	const id = requiredString(value, field);
+	if (!WORKFLOW_ID_PATTERN.test(id)) {
+		throw new Error(
+			`${field} must start with an alphanumeric character and contain at most 64 letters, numbers, "_" or "-"`,
+		);
+	}
+	return id;
+}
+
+function parseNeeds(value: unknown, nodeId: string): string[] | undefined {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value)) {
+		throw new Error(`Workflow node "${nodeId}" needs must be an array of node ids`);
+	}
+	const needs = value.map((dependency, index) =>
+		workflowId(dependency, `Workflow node "${nodeId}" dependency ${index + 1}`),
+	);
+	const duplicate = needs.find((dependency, index) => needs.indexOf(dependency) !== index);
+	if (duplicate) {
+		throw new Error(`Workflow node "${nodeId}" lists dependency "${duplicate}" more than once`);
+	}
+	return needs.length > 0 ? needs : undefined;
+}
+
+function parseNode(value: unknown, index: number): WorkflowNode {
+	if (!isRecord(value)) {
+		throw new Error(`Workflow node ${index + 1} must be an object`);
+	}
+	const id = workflowId(value.id, `Workflow node ${index + 1} id`);
+	const node: WorkflowNode = {
+		id,
+		agent: requiredString(value.agent, `Workflow node "${id}" agent`),
+		task: requiredString(value.task, `Workflow node "${id}" task`),
+	};
+	const needs = parseNeeds(value.needs, id);
+	if (needs) node.needs = needs;
+	if (Object.hasOwn(value, "outputSchema")) node.outputSchema = structuredClone(value.outputSchema);
+	if (value.schemaMode !== undefined) {
+		if (value.schemaMode !== "permissive" && value.schemaMode !== "strict") {
+			throw new Error(`Workflow node "${id}" schemaMode must be "permissive" or "strict"`);
+		}
+		node.schemaMode = value.schemaMode;
+	}
+	if (value.isolated !== undefined) {
+		if (typeof value.isolated !== "boolean") {
+			throw new Error(`Workflow node "${id}" isolated must be a boolean`);
+		}
+		node.isolated = value.isolated;
+	}
+	return node;
+}
+
+function assertAcyclic(nodes: WorkflowNode[]): void {
+	const indegree = new Map(nodes.map(node => [node.id, node.needs?.length ?? 0]));
+	const dependents = new Map<string, string[]>();
+	for (const node of nodes) {
+		for (const dependency of node.needs ?? []) {
+			const existing = dependents.get(dependency) ?? [];
+			existing.push(node.id);
+			dependents.set(dependency, existing);
+		}
+	}
+	const queue = nodes.filter(node => indegree.get(node.id) === 0).map(node => node.id);
+	let visited = 0;
+	for (let index = 0; index < queue.length; index++) {
+		const id = queue[index]!;
+		visited += 1;
+		for (const dependent of dependents.get(id) ?? []) {
+			const next = (indegree.get(dependent) ?? 0) - 1;
+			indegree.set(dependent, next);
+			if (next === 0) queue.push(dependent);
+		}
+	}
+	if (visited !== nodes.length) {
+		const cyclic = nodes.filter(node => (indegree.get(node.id) ?? 0) > 0).map(node => node.id);
+		throw new Error(`Workflow contains a dependency cycle involving: ${cyclic.join(", ")}`);
+	}
+}
+
+export function parseWorkflowDefinition(value: unknown): WorkflowDefinition {
+	if (!isRecord(value)) {
+		throw new Error("Workflow definition must be an object");
+	}
+	if (value.version !== WORKFLOW_DEFINITION_VERSION) {
+		throw new Error(`Workflow definition version must be ${WORKFLOW_DEFINITION_VERSION}`);
+	}
+	if (value.failurePolicy !== WORKFLOW_FAILURE_POLICY) {
+		throw new Error(`Workflow failurePolicy must be "${WORKFLOW_FAILURE_POLICY}"`);
+	}
+	if (!Array.isArray(value.nodes) || value.nodes.length === 0) {
+		throw new Error("Workflow must contain at least one node");
+	}
+	if (value.nodes.length > MAX_WORKFLOW_NODES) {
+		throw new Error(`Workflow cannot contain more than ${MAX_WORKFLOW_NODES} nodes`);
+	}
+
+	const nodes = value.nodes.map(parseNode);
+	const ids = new Set<string>();
+	for (const node of nodes) {
+		if (ids.has(node.id)) throw new Error(`Duplicate workflow node id "${node.id}"`);
+		ids.add(node.id);
+	}
+	for (const node of nodes) {
+		for (const dependency of node.needs ?? []) {
+			if (dependency === node.id) {
+				throw new Error(`Workflow node "${node.id}" cannot depend on itself`);
+			}
+			if (!ids.has(dependency)) {
+				throw new Error(`Workflow node "${node.id}" depends on missing node "${dependency}"`);
+			}
+		}
+	}
+	assertAcyclic(nodes);
+
+	return {
+		version: WORKFLOW_DEFINITION_VERSION,
+		id: workflowId(value.id, "Workflow id"),
+		objective: requiredString(value.objective, "Workflow objective"),
+		failurePolicy: WORKFLOW_FAILURE_POLICY,
+		nodes,
+	};
+}

--- a/packages/coding-agent/test/agent-session-magic-keywords.test.ts
+++ b/packages/coding-agent/test/agent-session-magic-keywords.test.ts
@@ -123,7 +123,7 @@ describe("AgentSession magic keyword settings", () => {
 		]);
 	});
 
-	it("renders the eval-specific workflowz notice", async () => {
+	it("renders the workflowz orchestration notice", async () => {
 		const created = await createMagicKeywordSession(root);
 		session = created.session;
 		authStorage = created.authStorage;
@@ -134,7 +134,8 @@ describe("AgentSession magic keyword settings", () => {
 
 		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ content?: string; customType?: string }>;
 		const notice = promptMessages.find(message => message.customType === "workflow-notice")?.content ?? "";
-		expect(notice).toContain("Author the orchestration in the `eval` tool");
+		expect(notice).toContain("Use the session-durable `workflow` tool");
+		expect(notice).toContain("Use `eval` for one-turn dynamic orchestration");
 		expect(notice).toContain("Every eval call has:");
 		expect(notice).toContain("`parallel(thunks)`");
 		expect(notice).toContain("**Python (`eval`, Python backend):**");

--- a/packages/coding-agent/test/modes/workflow.test.ts
+++ b/packages/coding-agent/test/modes/workflow.test.ts
@@ -65,9 +65,10 @@ describe("workflow keyword highlighting", () => {
 });
 
 describe("workflow notice", () => {
-	it("renders the Workflowz trigger with eval orchestration helper guidance", () => {
+	it("renders the Workflowz trigger with workflow and eval routing guidance", () => {
 		expect(WORKFLOW_NOTICE).toContain("**workflowz** keyword");
-		expect(WORKFLOW_NOTICE).toContain("Author the orchestration in the `eval` tool");
+		expect(WORKFLOW_NOTICE).toContain("Use the session-durable `workflow` tool");
+		expect(WORKFLOW_NOTICE).toContain("Use `eval` for one-turn dynamic orchestration");
 		expect(WORKFLOW_NOTICE).toContain("JavaScript (`eval`, JavaScript backend):");
 		expect(WORKFLOW_NOTICE).toContain("Use ordinary code between calls to flatten/map/filter");
 		expect(WORKFLOW_NOTICE).toContain("State persists across eval calls");
@@ -76,10 +77,11 @@ describe("workflow notice", () => {
 		expect(WORKFLOW_NOTICE).toContain("await budget.remaining()");
 	});
 
-	it("renders the same eval notice when task.batch is disabled", () => {
+	it("renders the same routing notice when task.batch is disabled", () => {
 		const notice = renderWorkflowNotice({ taskBatch: false });
 		expect(notice).toContain("**workflowz** keyword");
-		expect(notice).toContain("Author the orchestration in the `eval` tool");
+		expect(notice).toContain("Use the session-durable `workflow` tool");
+		expect(notice).toContain("Use `eval` for one-turn dynamic orchestration");
 		expect(notice).toContain("JavaScript (`eval`, JavaScript backend):");
 		expect(notice).toContain("State persists across eval calls");
 		expect(notice).toContain("`parallel(thunks)`");

--- a/packages/coding-agent/test/slash-commands/workflow.test.ts
+++ b/packages/coding-agent/test/slash-commands/workflow.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
+import type { InteractiveModeContext } from "../../src/modes/types";
 import type { AgentSession } from "../../src/session/agent-session";
+import { ACP_BUILTIN_SLASH_COMMANDS, executeAcpBuiltinSlashCommand } from "../../src/slash-commands/acp-builtins";
+import { executeBuiltinSlashCommand } from "../../src/slash-commands/builtin-registry";
 import { handleWorkflowCommand } from "../../src/slash-commands/helpers/workflow";
 import type { SlashCommandRuntime } from "../../src/slash-commands/types";
 import type { WorkflowSnapshot } from "../../src/workflows";
@@ -33,6 +36,22 @@ function runtimeWithTool(tool: unknown, output: string[]): SlashCommandRuntime {
 		},
 		refreshCommands: () => {},
 		reloadPlugins: async () => {},
+	};
+}
+
+function tuiRuntime(tool: unknown, output: string[], guest = false) {
+	return {
+		ctx: {
+			session: { isStreaming: true, getToolByName: () => tool },
+			sessionManager: { getCwd: () => "/tmp" },
+			settings: {},
+			showStatus: (text: string) => {
+				output.push(text);
+			},
+			editor: { setText: () => {} },
+			refreshSlashCommandState: () => {},
+			...(guest ? { collabGuest: {} } : {}),
+		} as unknown as InteractiveModeContext,
 	};
 }
 
@@ -76,5 +95,37 @@ describe("/workflow", () => {
 
 		expect(calls).toBe(0);
 		expect(output).toEqual(["Usage: /workflow cancel"]);
+	});
+
+	it("cancels through the real TUI dispatcher while the session is streaming", async () => {
+		const output: string[] = [];
+		let calls = 0;
+		const tool = {
+			cancelActiveWorkflow: async () => {
+				calls += 1;
+				return snapshot("cancelled");
+			},
+		};
+
+		expect(await executeBuiltinSlashCommand("/workflow cancel", tuiRuntime(tool, output))).toBe(true);
+		expect(calls).toBe(1);
+		expect(output).toEqual(["Workflow active-workflow: cancelled"]);
+	});
+
+	it("keeps active cancellation host-only and out of ACP", async () => {
+		const output: string[] = [];
+		let calls = 0;
+		const tool = {
+			cancelActiveWorkflow: async () => {
+				calls += 1;
+				return snapshot("cancelled");
+			},
+		};
+
+		expect(await executeBuiltinSlashCommand("/workflow cancel", tuiRuntime(tool, output, true))).toBe(true);
+		expect(calls).toBe(0);
+		expect(output).toEqual(["/workflow is host-only during a collab session"]);
+		expect(ACP_BUILTIN_SLASH_COMMANDS.some(command => command.name === "workflow")).toBe(false);
+		expect(await executeAcpBuiltinSlashCommand("/workflow cancel", runtimeWithTool(tool, output))).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/slash-commands/workflow.test.ts
+++ b/packages/coding-agent/test/slash-commands/workflow.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentSession } from "../../src/session/agent-session";
+import { handleWorkflowCommand } from "../../src/slash-commands/helpers/workflow";
+import type { SlashCommandRuntime } from "../../src/slash-commands/types";
+import type { WorkflowSnapshot } from "../../src/workflows";
+
+function snapshot(status: WorkflowSnapshot["status"]): WorkflowSnapshot {
+	return {
+		version: 1,
+		revision: 1,
+		definition: {
+			version: 1,
+			id: "active-workflow",
+			objective: "Cancel active work",
+			failurePolicy: "block-descendants",
+			nodes: [{ id: "task", agent: "task", task: "Wait" }],
+		},
+		status,
+		nodes: { task: { status: "cancelled", attempts: 1 } },
+		createdAt: 1,
+		updatedAt: 2,
+	};
+}
+
+function runtimeWithTool(tool: unknown, output: string[]): SlashCommandRuntime {
+	return {
+		session: { getToolByName: () => tool } as unknown as AgentSession,
+		sessionManager: {} as SlashCommandRuntime["sessionManager"],
+		settings: {} as SlashCommandRuntime["settings"],
+		cwd: "/tmp",
+		output: text => {
+			output.push(text);
+		},
+		refreshCommands: () => {},
+		reloadPlugins: async () => {},
+	};
+}
+
+describe("/workflow", () => {
+	it("cancels through the registered live workflow control", async () => {
+		const output: string[] = [];
+		let calls = 0;
+		const result = await handleWorkflowCommand(
+			{ name: "workflow", args: "cancel", text: "workflow cancel" },
+			runtimeWithTool(
+				{
+					cancelActiveWorkflow: async () => {
+						calls += 1;
+						return snapshot("cancelling");
+					},
+				},
+				output,
+			),
+		);
+
+		expect(result).toEqual({ consumed: true });
+		expect(calls).toBe(1);
+		expect(output).toEqual(["Workflow active-workflow: cancelling"]);
+	});
+
+	it("rejects unsupported operations without invoking the live control", async () => {
+		const output: string[] = [];
+		let calls = 0;
+		await handleWorkflowCommand(
+			{ name: "workflow", args: "status", text: "workflow status" },
+			runtimeWithTool(
+				{
+					cancelActiveWorkflow: async () => {
+						calls += 1;
+						return snapshot("cancelled");
+					},
+				},
+				output,
+			),
+		);
+
+		expect(calls).toBe(0);
+		expect(output).toEqual(["Usage: /workflow cancel"]);
+	});
+});

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -596,6 +596,32 @@ describe("task.batch spawning", () => {
 		]);
 	});
 
+	it("settles a programmatic spawn through Task even when model-facing batches are disabled", async () => {
+		mockDiscovery();
+		let capturedContext: string | undefined;
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			capturedContext = options.context;
+			return makeResult(options.id ?? "?");
+		});
+
+		const manager = createManager();
+		const tool = await TaskTool.create(
+			createSession({
+				manager,
+				settings: { "async.enabled": true, "task.batch": false },
+			}),
+		);
+		const result = await tool.dispatchService.executeSettledSpawn("workflow:research", {
+			context: "Durable workflow objective and dependency references.",
+			item: { name: "WorkflowResearch", agent: "task", task: "Research the assigned question." },
+		});
+
+		expect(result.details?.results.map(item => item.id)).toEqual(["WorkflowResearch"]);
+		expect(result.details?.async).toBeUndefined();
+		expect(manager.getJob("WorkflowResearch")).toBeUndefined();
+		expect(capturedContext).toBe("Durable workflow objective and dependency references.");
+	});
+
 	it("settles the batch async aggregate when a queued spawn is cancelled mid-flight", async () => {
 		mockDiscovery();
 		const started: string[] = [];

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { type SettingPath, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createTools, HIDDEN_TOOLS, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import type { SessionEntry } from "../../src/session/session-entries";
 
 Bun.env.PI_PYTHON_SKIP_CHECK = "1";
 
@@ -21,6 +22,29 @@ function createSettingsWithOverrides(overrides: Partial<Record<SettingPath, unkn
 		"bashInterceptor.enabled": true,
 		...overrides,
 	});
+}
+
+function createSessionManager(): NonNullable<ToolSession["sessionManager"]> {
+	const entries: SessionEntry[] = [];
+	let nextId = 0;
+	return {
+		appendCustomEntry: (customType, data) => {
+			const id = `entry-${++nextId}`;
+			entries.push({
+				type: "custom",
+				id,
+				parentId: entries.at(-1)?.id ?? null,
+				timestamp: new Date(nextId).toISOString(),
+				customType,
+				data,
+			});
+			return id;
+		},
+		ensureOnDisk: async () => {},
+		flush: async () => {},
+		getBranch: () => entries,
+		getEntries: () => entries,
+	};
 }
 
 function createActiveGoalState() {
@@ -171,6 +195,22 @@ describe("createTools", () => {
 		const names = tools.map(t => t.name);
 
 		expect(names).toEqual(["yield"]);
+	});
+
+	it("registers workflow only for persistent top-level sessions", async () => {
+		const persistent = createTestSession({ sessionManager: createSessionManager() });
+		expect((await createTools(persistent, ["workflow"])).map(tool => tool.name)).toEqual(["workflow", "task"]);
+
+		const nested = createTestSession({ sessionManager: createSessionManager(), taskDepth: 1 });
+		expect(await createTools(nested, ["workflow"])).toEqual([]);
+
+		const restricted = createTestSession({
+			sessionManager: createSessionManager(),
+			restrictToolNames: true,
+		});
+		expect(await createTools(restricted, ["workflow"])).toEqual([]);
+
+		expect(await createTools(createTestSession(), ["workflow"])).toEqual([]);
 	});
 
 	it("includes yield tool when required", async () => {

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -198,17 +198,24 @@ describe("createTools", () => {
 	});
 
 	it("registers workflow only for persistent top-level sessions", async () => {
-		const persistent = createTestSession({ sessionManager: createSessionManager() });
+		const createPersistentSession = (overrides: Partial<ToolSession> = {}) =>
+			createTestSession({
+				sessionManager: createSessionManager(),
+				getSessionFile: () => "/tmp/test/session.jsonl",
+				...overrides,
+			});
+
+		const persistent = createPersistentSession();
 		expect((await createTools(persistent, ["workflow"])).map(tool => tool.name)).toEqual(["workflow", "task"]);
 
-		const nested = createTestSession({ sessionManager: createSessionManager(), taskDepth: 1 });
+		const nested = createPersistentSession({ taskDepth: 1 });
 		expect(await createTools(nested, ["workflow"])).toEqual([]);
 
-		const restricted = createTestSession({
-			sessionManager: createSessionManager(),
-			restrictToolNames: true,
-		});
+		const restricted = createPersistentSession({ restrictToolNames: true });
 		expect(await createTools(restricted, ["workflow"])).toEqual([]);
+
+		const noSessionFile = createTestSession({ sessionManager: createSessionManager() });
+		expect((await createTools(noSessionFile, ["workflow"])).map(tool => tool.name)).toEqual(["task"]);
 
 		expect(await createTools(createTestSession(), ["workflow"])).toEqual([]);
 	});

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -40,6 +40,7 @@ function createSessionManager(): NonNullable<ToolSession["sessionManager"]> {
 			});
 			return id;
 		},
+		appendEntriesAtomically: async <T>(append: () => T): Promise<T> => append(),
 		ensureOnDisk: async () => {},
 		flush: async () => {},
 		getBranch: () => entries,

--- a/packages/coding-agent/test/workflows/runtime.test.ts
+++ b/packages/coding-agent/test/workflows/runtime.test.ts
@@ -30,6 +30,24 @@ class MemoryWorkflowStore implements WorkflowStore {
 	}
 }
 
+class RejectingCompletionStore extends MemoryWorkflowStore {
+	readonly failureObserved = Promise.withResolvers<void>();
+	rejected = false;
+
+	override async append(snapshot: WorkflowSnapshot): Promise<void> {
+		if (
+			!this.rejected &&
+			snapshot.nodes.other?.status === "succeeded" &&
+			snapshot.nodes.child?.status === "running"
+		) {
+			this.rejected = true;
+			this.failureObserved.resolve();
+			throw new Error("completion persistence failed");
+		}
+		await super.append(snapshot);
+	}
+}
+
 function resultFor(request: WorkflowDispatchRequest, overrides: Partial<SingleResult> = {}): SingleResult {
 	return {
 		index: 0,
@@ -173,6 +191,70 @@ describe("WorkflowRuntime", () => {
 		gates.get("slow")!.resolve({ result: resultFor(gatesRequest("slow")) });
 		const completed = await running;
 		expect(completed.status).toBe("succeeded");
+	});
+
+	it("retains execution persistence failures and drains active dispatches before rejecting", async () => {
+		const store = new RejectingCompletionStore();
+		const runtime = await createRuntime(store);
+		await runtime.createWorkflow({
+			objective: "Do not lose infrastructure failures",
+			nodes: [
+				{ id: "fast", agent: "task", task: "Fast root" },
+				{ id: "child", agent: "task", task: "Fast child", needs: ["fast"] },
+				{ id: "other", agent: "task", task: "Other root" },
+				{ id: "lingering", agent: "task", task: "Lingering root" },
+			],
+		});
+
+		const started: string[] = [];
+		const gates = new Map<string, OutcomeGate>();
+		let lingeringDrained = false;
+		const childStartPersisted = Promise.withResolvers<void>();
+		const releaseChildStart = Promise.withResolvers<void>();
+		const running = runtime.run(
+			(request, signal) => {
+				started.push(request.nodeId);
+				if (request.nodeId === "lingering") {
+					return new Promise(resolve => {
+						signal.addEventListener(
+							"abort",
+							() => {
+								lingeringDrained = true;
+								resolve({ status: "interrupted", error: "aborted" });
+							},
+							{ once: true },
+						);
+					});
+				}
+				const gate = Promise.withResolvers<WorkflowDispatchOutcome>();
+				gates.set(request.nodeId, gate);
+				return gate.promise;
+			},
+			{
+				onChange: async snapshot => {
+					if (snapshot.nodes.child.status !== "running" || snapshot.nodes.other.status !== "running") return;
+					gates.get("other")!.resolve({ result: resultFor(gatesRequest("other")) });
+					childStartPersisted.resolve();
+					await releaseChildStart.promise;
+				},
+			},
+		);
+		await waitFor(() => started.length === 3);
+		gates.get("fast")!.resolve({ result: resultFor(gatesRequest("fast")) });
+		await childStartPersisted.promise;
+		await store.failureObserved.promise;
+		await waitFor(() => lingeringDrained);
+		releaseChildStart.resolve();
+
+		await expect(running).rejects.toThrow("completion persistence failed");
+		expect(started).not.toContain("child");
+		expect(lingeringDrained).toBe(true);
+		const afterReturn = runtime.getSnapshot();
+		await Bun.sleep(5);
+		expect(runtime.getSnapshot()).toEqual(afterReturn);
+		await expect(runtime.run(async request => ({ result: resultFor(request) }))).resolves.toMatchObject({
+			status: "interrupted",
+		});
 	});
 
 	it("blocks failed descendants, continues independent work, and enforces strict schema success", async () => {
@@ -331,6 +413,34 @@ describe("WorkflowRuntime", () => {
 		expect(cancelled.nodes.first.status).toBe("cancelled");
 		expect(cancelled.nodes.second.status).toBe("cancelled");
 		expect(dispatched).toEqual(["first"]);
+	});
+
+	it("does not invoke a dispatcher when cancellation arrives during start persistence", async () => {
+		const runtime = await createRuntime();
+		await runtime.createWorkflow({
+			objective: "Cancel before dispatch",
+			nodes: [
+				{ id: "first", agent: "task", task: "First" },
+				{ id: "second", agent: "task", task: "Second", needs: ["first"] },
+			],
+		});
+		const dispatched: string[] = [];
+		const cancelled = await runtime.run(
+			async request => {
+				dispatched.push(request.nodeId);
+				return { result: resultFor(request) };
+			},
+			{
+				onChange: async snapshot => {
+					if (snapshot.nodes.first.status === "running") await runtime.cancel();
+				},
+			},
+		);
+
+		expect(dispatched).toEqual([]);
+		expect(cancelled.status).toBe("cancelled");
+		expect(cancelled.nodes.first.status).toBe("cancelled");
+		expect(cancelled.nodes.second.status).toBe("cancelled");
 	});
 });
 

--- a/packages/coding-agent/test/workflows/runtime.test.ts
+++ b/packages/coding-agent/test/workflows/runtime.test.ts
@@ -53,6 +53,16 @@ class RejectingCompletionStore extends MemoryWorkflowStore {
 	}
 }
 
+class LeafChangingWorkflowStore extends MemoryWorkflowStore {
+	override async append(snapshot: WorkflowSnapshot): Promise<void> {
+		await super.append(snapshot);
+		this.activeBranch = `leaf-${this.snapshots.length}`;
+		if (Object.values(snapshot.nodes).filter(node => node.status === "succeeded").length === 1) {
+			await Bun.sleep(10);
+		}
+	}
+}
+
 function resultFor(request: WorkflowDispatchRequest, overrides: Partial<SingleResult> = {}): SingleResult {
 	return {
 		index: 0,
@@ -148,6 +158,23 @@ describe("WorkflowRuntime", () => {
 			nodes: [{ id: "only", agent: "task", task: "Second" }],
 		});
 		expect(alternate.definition.id).toBe("alternate");
+	});
+
+	it("serializes branch checks with concurrent workflow saves", async () => {
+		const runtime = await createRuntime(new LeafChangingWorkflowStore());
+		await runtime.createWorkflow({
+			objective: "Persist parallel completions",
+			nodes: [
+				{ id: "left", agent: "task", task: "Left" },
+				{ id: "right", agent: "task", task: "Right" },
+			],
+		});
+
+		const completed = await runtime.run(async request => ({ result: resultFor(request) }));
+
+		expect(completed.status).toBe("succeeded");
+		expect(completed.nodes.left.status).toBe("succeeded");
+		expect(completed.nodes.right.status).toBe("succeeded");
 	});
 
 	it("runs independent roots concurrently and holds a join until both settle", async () => {

--- a/packages/coding-agent/test/workflows/runtime.test.ts
+++ b/packages/coding-agent/test/workflows/runtime.test.ts
@@ -150,7 +150,7 @@ describe("WorkflowRuntime", () => {
 
 		store.activeBranch = "alternate";
 		store.snapshots = [];
-		expect(runtime.getSnapshot()).toBeNull();
+		expect(await runtime.getDurableSnapshot()).toBeNull();
 
 		const alternate = await runtime.createWorkflow({
 			id: "alternate",
@@ -158,6 +158,39 @@ describe("WorkflowRuntime", () => {
 			nodes: [{ id: "only", agent: "task", task: "Second" }],
 		});
 		expect(alternate.definition.id).toBe("alternate");
+	});
+
+	it("reconciles orphaned running nodes when the active branch is reloaded", async () => {
+		const store = new MemoryWorkflowStore();
+		const runtime = await createRuntime(store);
+		const created = await runtime.createWorkflow({
+			id: "main",
+			objective: "Remain on the first branch",
+			nodes: [{ id: "only", agent: "task", task: "First" }],
+		});
+		store.activeBranch = "alternate";
+		store.snapshots = [
+			{
+				...created,
+				status: "running",
+				nodes: { only: { status: "running", attempts: 1, startedAt: 500 } },
+			},
+		];
+
+		const reloaded = await runtime.getDurableSnapshot();
+
+		expect(reloaded?.nodes.only).toMatchObject({
+			status: "interrupted",
+			attempts: 1,
+			error: "Interrupted by process restart",
+		});
+		expect(reloaded?.status).toBe("interrupted");
+		expect(store.snapshots).toHaveLength(2);
+		expect(store.snapshots.at(-1)?.nodes.only.status).toBe("interrupted");
+
+		const restored = await createRuntime(store);
+		expect(restored.getSnapshot()).toEqual(reloaded);
+		expect(store.snapshots).toHaveLength(2);
 	});
 
 	it("serializes branch checks with concurrent workflow saves", async () => {

--- a/packages/coding-agent/test/workflows/runtime.test.ts
+++ b/packages/coding-agent/test/workflows/runtime.test.ts
@@ -144,6 +144,37 @@ describe("WorkflowRuntime", () => {
 		expect(completed.nodes.join.status).toBe("succeeded");
 	});
 
+	it("starts a newly ready descendant before an unrelated root settles", async () => {
+		const runtime = await createRuntime();
+		await runtime.createWorkflow({
+			objective: "Keep the critical path moving",
+			nodes: [
+				{ id: "fast", agent: "task", task: "Fast root" },
+				{ id: "child", agent: "task", task: "Fast child", needs: ["fast"] },
+				{ id: "slow", agent: "task", task: "Slow root" },
+			],
+		});
+
+		const started: string[] = [];
+		const gates = new Map<string, OutcomeGate>();
+		const running = runtime.run(request => {
+			started.push(request.nodeId);
+			const gate = Promise.withResolvers<WorkflowDispatchOutcome>();
+			gates.set(request.nodeId, gate);
+			return gate.promise;
+		});
+		await waitFor(() => started.length === 2);
+
+		gates.get("fast")!.resolve({ result: resultFor(gatesRequest("fast")) });
+		await waitFor(() => started.includes("child"));
+		expect(runtime.getSnapshot()?.nodes.slow.status).toBe("running");
+
+		gates.get("child")!.resolve({ result: resultFor(gatesRequest("child")) });
+		gates.get("slow")!.resolve({ result: resultFor(gatesRequest("slow")) });
+		const completed = await running;
+		expect(completed.status).toBe("succeeded");
+	});
+
 	it("blocks failed descendants, continues independent work, and enforces strict schema success", async () => {
 		const runtime = await createRuntime();
 		await runtime.createWorkflow({
@@ -228,7 +259,6 @@ describe("WorkflowRuntime", () => {
 			nodes: [
 				{ id: "done", agent: "task", task: "Done" },
 				{ id: "inflight", agent: "task", task: "In flight" },
-				{ id: "independent", agent: "task", task: "Independent continuation", needs: ["done"] },
 			],
 		});
 
@@ -252,7 +282,6 @@ describe("WorkflowRuntime", () => {
 		const recovered = restored.getSnapshot()!;
 		expect(recovered.nodes.done.status).toBe("succeeded");
 		expect(recovered.nodes.inflight.status).toBe("interrupted");
-		expect(recovered.nodes.independent.status).toBe("ready");
 		expect(recovered.status).toBe("interrupted");
 
 		const resumedDispatches: string[] = [];
@@ -260,7 +289,7 @@ describe("WorkflowRuntime", () => {
 			resumedDispatches.push(request.nodeId);
 			return { result: resultFor(request) };
 		});
-		expect(resumedDispatches).toEqual(["independent"]);
+		expect(resumedDispatches).toEqual([]);
 		expect(resumed.nodes.done.status).toBe("succeeded");
 		expect(resumed.status).toBe("interrupted");
 
@@ -269,7 +298,7 @@ describe("WorkflowRuntime", () => {
 			resumedDispatches.push(request.nodeId);
 			return { result: resultFor(request) };
 		});
-		expect(resumedDispatches).toEqual(["independent", "inflight"]);
+		expect(resumedDispatches).toEqual(["inflight"]);
 		expect(completed.status).toBe("succeeded");
 
 		controller.abort();

--- a/packages/coding-agent/test/workflows/runtime.test.ts
+++ b/packages/coding-agent/test/workflows/runtime.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from "bun:test";
+import type { SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
+import {
+	type WorkflowDispatchOutcome,
+	type WorkflowDispatchRequest,
+	WorkflowRuntime,
+	type WorkflowSnapshot,
+	type WorkflowStore,
+} from "../../src/workflows";
+
+interface OutcomeGate {
+	promise: Promise<WorkflowDispatchOutcome>;
+	resolve: (value: WorkflowDispatchOutcome | PromiseLike<WorkflowDispatchOutcome>) => void;
+	reject: (reason?: unknown) => void;
+}
+
+class MemoryWorkflowStore implements WorkflowStore {
+	snapshots: WorkflowSnapshot[] = [];
+
+	load(): WorkflowSnapshot | null {
+		return this.snapshots.at(-1) ? structuredClone(this.snapshots.at(-1)!) : null;
+	}
+
+	hasWorkflowId(id: string): boolean {
+		return this.snapshots.some(snapshot => snapshot.definition.id === id);
+	}
+
+	async append(snapshot: WorkflowSnapshot): Promise<void> {
+		this.snapshots.push(structuredClone(snapshot));
+	}
+}
+
+function resultFor(request: WorkflowDispatchRequest, overrides: Partial<SingleResult> = {}): SingleResult {
+	return {
+		index: 0,
+		id: request.name,
+		agent: request.agent,
+		agentSource: "bundled",
+		task: request.task,
+		assignment: request.task,
+		exitCode: 0,
+		output: "done",
+		stderr: "",
+		truncated: false,
+		durationMs: 1,
+		tokens: 0,
+		requests: 1,
+		...overrides,
+	};
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+	for (let attempt = 0; attempt < 200; attempt++) {
+		if (predicate()) return;
+		await Bun.sleep(1);
+	}
+	throw new Error("Timed out waiting for workflow state");
+}
+
+async function createRuntime(store = new MemoryWorkflowStore()): Promise<WorkflowRuntime> {
+	let now = 1_000;
+	return WorkflowRuntime.create({
+		store,
+		idFactory: () => "test-workflow",
+		now: () => now++,
+	});
+}
+
+describe("WorkflowRuntime", () => {
+	it("rejects invalid graphs before dispatching any node", async () => {
+		const runtime = await createRuntime();
+		await expect(
+			runtime.createWorkflow({
+				objective: "Invalid graph",
+				nodes: [
+					{ id: "a", agent: "task", task: "A", needs: ["b"] },
+					{ id: "b", agent: "task", task: "B", needs: ["a"] },
+				],
+			}),
+		).rejects.toThrow("dependency cycle");
+		expect(runtime.getSnapshot()).toBeNull();
+	});
+
+	it("keeps workflow definitions immutable and ids unique on a session branch", async () => {
+		const runtime = await createRuntime();
+		await runtime.createWorkflow({
+			id: "immutable",
+			objective: "First definition",
+			nodes: [{ id: "only", agent: "task", task: "Finish" }],
+		});
+		await runtime.run(async request => ({ result: resultFor(request) }));
+
+		await expect(
+			runtime.createWorkflow({
+				id: "immutable",
+				objective: "Replacement definition",
+				nodes: [{ id: "replacement", agent: "task", task: "Replace" }],
+			}),
+		).rejects.toThrow("already exists on this session branch");
+
+		const next = await runtime.createWorkflow({
+			id: "next",
+			objective: "A new immutable definition",
+			nodes: [{ id: "only", agent: "task", task: "Continue" }],
+		});
+		expect(next.definition.id).toBe("next");
+	});
+
+	it("runs independent roots concurrently and holds a join until both settle", async () => {
+		const runtime = await createRuntime();
+		await runtime.createWorkflow({
+			objective: "Join two findings",
+			nodes: [
+				{ id: "left", agent: "scout", task: "Left" },
+				{ id: "right", agent: "scout", task: "Right" },
+				{ id: "join", agent: "reviewer", task: "Join", needs: ["left", "right"] },
+			],
+		});
+
+		const started: string[] = [];
+		const gates = new Map<string, OutcomeGate>();
+		const running = runtime.run(async request => {
+			started.push(request.nodeId);
+			const gate = Promise.withResolvers<WorkflowDispatchOutcome>();
+			gates.set(request.nodeId, gate);
+			return gate.promise;
+		});
+		await waitFor(() => started.length === 2);
+		expect(new Set(started)).toEqual(new Set(["left", "right"]));
+
+		gates.get("left")!.resolve({ result: resultFor({ ...gatesRequest("left"), name: "LeftAgent" }) });
+		await waitFor(() => runtime.getSnapshot()?.nodes.left.status === "succeeded");
+		expect(started).not.toContain("join");
+
+		gates.get("right")!.resolve({ result: resultFor({ ...gatesRequest("right"), name: "RightAgent" }) });
+		await waitFor(() => started.includes("join"));
+		const joinSnapshot = runtime.getSnapshot()!;
+		expect(joinSnapshot.nodes.left.outputRef).toBe("agent://LeftAgent");
+		expect(joinSnapshot.nodes.right.historyRef).toBe("history://RightAgent");
+		gates.get("join")!.resolve({ result: resultFor({ ...gatesRequest("join"), name: "JoinAgent" }) });
+
+		const completed = await running;
+		expect(completed.status).toBe("succeeded");
+		expect(completed.nodes.join.status).toBe("succeeded");
+	});
+
+	it("blocks failed descendants, continues independent work, and enforces strict schema success", async () => {
+		const runtime = await createRuntime();
+		await runtime.createWorkflow({
+			objective: "Keep independent work moving",
+			nodes: [
+				{
+					id: "strict",
+					agent: "task",
+					task: "Return structured data",
+					outputSchema: { type: "object" },
+					schemaMode: "strict",
+				},
+				{ id: "blocked", agent: "task", task: "Must not run", needs: ["strict"] },
+				{ id: "independent", agent: "task", task: "Still run" },
+			],
+		});
+		const dispatched: string[] = [];
+		const snapshot = await runtime.run(async request => {
+			dispatched.push(request.nodeId);
+			if (request.nodeId === "strict") {
+				return {
+					result: resultFor(request, {
+						structuredOutput: {
+							source: "caller",
+							mode: "strict",
+							status: "invalid",
+							error: "required property missing",
+						},
+					}),
+				};
+			}
+			return { result: resultFor(request) };
+		});
+
+		expect(snapshot.status).toBe("failed");
+		expect(snapshot.nodes.strict.status).toBe("failed");
+		expect(snapshot.nodes.blocked.status).toBe("blocked");
+		expect(snapshot.nodes.independent.status).toBe("succeeded");
+		expect(dispatched).toContain("independent");
+		expect(dispatched).not.toContain("blocked");
+	});
+
+	it("retry reopens only the selected failure's descendant closure", async () => {
+		const runtime = await createRuntime();
+		await runtime.createWorkflow({
+			objective: "Recover one failed branch",
+			nodes: [
+				{ id: "left", agent: "task", task: "Left root" },
+				{ id: "left-child", agent: "task", task: "Left child", needs: ["left"] },
+				{ id: "right", agent: "task", task: "Right root" },
+				{ id: "right-child", agent: "task", task: "Right child", needs: ["right"] },
+			],
+		});
+		await runtime.run(async request =>
+			request.nodeId === "left" || request.nodeId === "right"
+				? { status: "failed", error: `${request.nodeId} failed` }
+				: { result: resultFor(request) },
+		);
+
+		const retried = await runtime.retryNode("left");
+		expect(retried.nodes.left.status).toBe("ready");
+		expect(retried.nodes["left-child"].status).toBe("pending");
+		expect(retried.nodes.right.status).toBe("failed");
+		expect(retried.nodes["right-child"].status).toBe("blocked");
+
+		const dispatched: string[] = [];
+		const resumed = await runtime.run(async request => {
+			dispatched.push(request.nodeId);
+			return { result: resultFor(request) };
+		});
+		expect(dispatched).toEqual(["left", "left-child"]);
+		expect(resumed.nodes["left-child"].status).toBe("succeeded");
+		expect(resumed.nodes["right-child"].status).toBe("blocked");
+		expect(resumed.status).toBe("failed");
+	});
+
+	it("rehydrates orphaned running nodes as interrupted without rerunning successes", async () => {
+		const store = new MemoryWorkflowStore();
+		const runtime = await createRuntime(store);
+		await runtime.createWorkflow({
+			objective: "Recover conservatively",
+			nodes: [
+				{ id: "done", agent: "task", task: "Done" },
+				{ id: "inflight", agent: "task", task: "In flight" },
+				{ id: "independent", agent: "task", task: "Independent continuation", needs: ["done"] },
+			],
+		});
+
+		const controller = new AbortController();
+		const started: string[] = [];
+		const running = runtime.run(
+			async (request, signal) => {
+				started.push(request.nodeId);
+				if (request.nodeId === "done") return { result: resultFor(request) };
+				return new Promise(resolve => {
+					signal.addEventListener("abort", () => resolve({ status: "interrupted", error: "aborted" }), {
+						once: true,
+					});
+				});
+			},
+			{ signal: controller.signal },
+		);
+		await waitFor(() => runtime.getSnapshot()?.nodes.inflight.status === "running");
+
+		const restored = await createRuntime(store);
+		const recovered = restored.getSnapshot()!;
+		expect(recovered.nodes.done.status).toBe("succeeded");
+		expect(recovered.nodes.inflight.status).toBe("interrupted");
+		expect(recovered.nodes.independent.status).toBe("ready");
+		expect(recovered.status).toBe("interrupted");
+
+		const resumedDispatches: string[] = [];
+		const resumed = await restored.run(async request => {
+			resumedDispatches.push(request.nodeId);
+			return { result: resultFor(request) };
+		});
+		expect(resumedDispatches).toEqual(["independent"]);
+		expect(resumed.nodes.done.status).toBe("succeeded");
+		expect(resumed.status).toBe("interrupted");
+
+		await restored.retryNode("inflight");
+		const completed = await restored.run(async request => {
+			resumedDispatches.push(request.nodeId);
+			return { result: resultFor(request) };
+		});
+		expect(resumedDispatches).toEqual(["independent", "inflight"]);
+		expect(completed.status).toBe("succeeded");
+
+		controller.abort();
+		await running;
+	});
+
+	it("cancels active work and prevents dependent dispatch", async () => {
+		const runtime = await createRuntime();
+		await runtime.createWorkflow({
+			objective: "Stop safely",
+			nodes: [
+				{ id: "first", agent: "task", task: "First" },
+				{ id: "second", agent: "task", task: "Second", needs: ["first"] },
+			],
+		});
+		const dispatched: string[] = [];
+		const running = runtime.run(async (request, signal) => {
+			dispatched.push(request.nodeId);
+			return new Promise(resolve => {
+				signal.addEventListener("abort", () => resolve({ status: "interrupted", error: "cancelled" }), {
+					once: true,
+				});
+			});
+		});
+		await waitFor(() => dispatched.includes("first"));
+		await runtime.cancel();
+		const cancelled = await running;
+
+		expect(cancelled.status).toBe("cancelled");
+		expect(cancelled.nodes.first.status).toBe("cancelled");
+		expect(cancelled.nodes.second.status).toBe("cancelled");
+		expect(dispatched).toEqual(["first"]);
+	});
+});
+
+function gatesRequest(nodeId: string): WorkflowDispatchRequest {
+	return {
+		nodeId,
+		name: nodeId,
+		agent: "task",
+		task: nodeId,
+		context: "test",
+	};
+}

--- a/packages/coding-agent/test/workflows/runtime.test.ts
+++ b/packages/coding-agent/test/workflows/runtime.test.ts
@@ -16,6 +16,11 @@ interface OutcomeGate {
 
 class MemoryWorkflowStore implements WorkflowStore {
 	snapshots: WorkflowSnapshot[] = [];
+	activeBranch = "main";
+
+	branchKey(): string {
+		return this.activeBranch;
+	}
 
 	load(): WorkflowSnapshot | null {
 		return this.snapshots.at(-1) ? structuredClone(this.snapshots.at(-1)!) : null;
@@ -124,6 +129,27 @@ describe("WorkflowRuntime", () => {
 		expect(next.definition.id).toBe("next");
 	});
 
+	it("reloads the active branch before reading or mutating workflow state", async () => {
+		const store = new MemoryWorkflowStore();
+		const runtime = await createRuntime(store);
+		await runtime.createWorkflow({
+			id: "abandoned",
+			objective: "Remain on the first branch",
+			nodes: [{ id: "only", agent: "task", task: "First" }],
+		});
+
+		store.activeBranch = "alternate";
+		store.snapshots = [];
+		expect(runtime.getSnapshot()).toBeNull();
+
+		const alternate = await runtime.createWorkflow({
+			id: "alternate",
+			objective: "Belong to the active branch",
+			nodes: [{ id: "only", agent: "task", task: "Second" }],
+		});
+		expect(alternate.definition.id).toBe("alternate");
+	});
+
 	it("runs independent roots concurrently and holds a join until both settle", async () => {
 		const runtime = await createRuntime();
 		await runtime.createWorkflow({
@@ -215,16 +241,16 @@ describe("WorkflowRuntime", () => {
 			(request, signal) => {
 				started.push(request.nodeId);
 				if (request.nodeId === "lingering") {
-					return new Promise(resolve => {
-						signal.addEventListener(
-							"abort",
-							() => {
-								lingeringDrained = true;
-								resolve({ status: "interrupted", error: "aborted" });
-							},
-							{ once: true },
-						);
-					});
+					const gate = Promise.withResolvers<WorkflowDispatchOutcome>();
+					signal.addEventListener(
+						"abort",
+						() => {
+							lingeringDrained = true;
+							gate.resolve({ status: "interrupted", error: "aborted" });
+						},
+						{ once: true },
+					);
+					return gate.promise;
 				}
 				const gate = Promise.withResolvers<WorkflowDispatchOutcome>();
 				gates.set(request.nodeId, gate);
@@ -299,6 +325,32 @@ describe("WorkflowRuntime", () => {
 		expect(dispatched).not.toContain("blocked");
 	});
 
+	it("treats settled Task results with executor errors as failed", async () => {
+		const runtime = await createRuntime();
+		await runtime.createWorkflow({
+			objective: "Do not dispatch after an isolated merge failure",
+			nodes: [
+				{ id: "isolated", agent: "task", task: "Commit changes", isolated: true },
+				{ id: "dependent", agent: "task", task: "Use committed changes", needs: ["isolated"] },
+			],
+		});
+		const dispatched: string[] = [];
+		const snapshot = await runtime.run(async request => {
+			dispatched.push(request.nodeId);
+			return {
+				result: resultFor(request, {
+					error: "Failed to apply isolated worktree changes",
+				}),
+			};
+		});
+
+		expect(snapshot.status).toBe("failed");
+		expect(snapshot.nodes.isolated.status).toBe("failed");
+		expect(snapshot.nodes.isolated.error).toBe("Failed to apply isolated worktree changes");
+		expect(snapshot.nodes.dependent.status).toBe("blocked");
+		expect(dispatched).toEqual(["isolated"]);
+	});
+
 	it("retry reopens only the selected failure's descendant closure", async () => {
 		const runtime = await createRuntime();
 		await runtime.createWorkflow({
@@ -350,11 +402,11 @@ describe("WorkflowRuntime", () => {
 			async (request, signal) => {
 				started.push(request.nodeId);
 				if (request.nodeId === "done") return { result: resultFor(request) };
-				return new Promise(resolve => {
-					signal.addEventListener("abort", () => resolve({ status: "interrupted", error: "aborted" }), {
-						once: true,
-					});
+				const gate = Promise.withResolvers<WorkflowDispatchOutcome>();
+				signal.addEventListener("abort", () => gate.resolve({ status: "interrupted", error: "aborted" }), {
+					once: true,
 				});
+				return gate.promise;
 			},
 			{ signal: controller.signal },
 		);
@@ -399,11 +451,11 @@ describe("WorkflowRuntime", () => {
 		const dispatched: string[] = [];
 		const running = runtime.run(async (request, signal) => {
 			dispatched.push(request.nodeId);
-			return new Promise(resolve => {
-				signal.addEventListener("abort", () => resolve({ status: "interrupted", error: "cancelled" }), {
-					once: true,
-				});
+			const gate = Promise.withResolvers<WorkflowDispatchOutcome>();
+			signal.addEventListener("abort", () => gate.resolve({ status: "interrupted", error: "cancelled" }), {
+				once: true,
 			});
+			return gate.promise;
 		});
 		await waitFor(() => dispatched.includes("first"));
 		await runtime.cancel();

--- a/packages/coding-agent/test/workflows/workflow-tool.test.ts
+++ b/packages/coding-agent/test/workflows/workflow-tool.test.ts
@@ -186,6 +186,15 @@ describe("WorkflowTool", () => {
 			settings: Settings.isolated(),
 		};
 		expect(await WorkflowTool.createIf(session)).toBeNull();
+		const inMemorySession = createPersistentSession([]);
+		inMemorySession.getSessionFile = () => null;
+		expect(await WorkflowTool.createIf(inMemorySession)).toBeNull();
 		expect(await WorkflowTool.createIf({ ...session, taskDepth: 1 })).toBeNull();
+	});
+
+	it("serializes model-facing workflow operations", async () => {
+		const tool = await WorkflowTool.createIf(createPersistentSession([]));
+		if (!tool) throw new Error("Expected workflow tool for a persistent top-level session");
+		expect(tool.concurrency).toBe("exclusive");
 	});
 });

--- a/packages/coding-agent/test/workflows/workflow-tool.test.ts
+++ b/packages/coding-agent/test/workflows/workflow-tool.test.ts
@@ -3,7 +3,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { SingleResult } from "@oh-my-pi/pi-coding-agent/task";
 import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
 import type { SessionEntry } from "../../src/session/session-entries";
-import { TaskDispatchService } from "../../src/task/dispatch-service";
+import { type SettledTaskRunner, TaskDispatchService } from "../../src/task/dispatch-service";
 import type { AgentDefinition, TaskItem } from "../../src/task/types";
 import type { ToolSession } from "../../src/tools";
 import { WorkflowTool } from "../../src/workflows/tools/workflow-tool";
@@ -45,7 +45,7 @@ function taskResult(id: string): SingleResult {
 	};
 }
 
-function createPersistentSession(spawns: RecordedSpawn[]): ToolSession {
+function createPersistentSession(spawns: RecordedSpawn[], runSettled?: SettledTaskRunner): ToolSession {
 	const entries: SessionEntry[] = [];
 	let nextId = 0;
 	const sessionManager: NonNullable<ToolSession["sessionManager"]> = {
@@ -75,14 +75,18 @@ function createPersistentSession(spawns: RecordedSpawn[]): ToolSession {
 		sessionManager,
 		toolRegistry: new Map(),
 	};
-	session.taskDispatchService = new TaskDispatchService(session, async (_toolCallId, params, item) => {
-		spawns.push(structuredClone({ context: params.context ?? "", item }));
-		const id = item.name ?? "unnamed";
-		return {
-			content: [{ type: "text", text: "done" }],
-			details: { projectAgentsDir: null, results: [taskResult(id)], totalDurationMs: 1 },
-		};
-	});
+	session.taskDispatchService = new TaskDispatchService(
+		session,
+		runSettled ??
+			(async (_toolCallId, params, item) => {
+				spawns.push(structuredClone({ context: params.context ?? "", item }));
+				const id = item.name ?? "unnamed";
+				return {
+					content: [{ type: "text", text: "done" }],
+					details: { projectAgentsDir: null, results: [taskResult(id)], totalDurationMs: 1 },
+				};
+			}),
+	);
 	return session;
 }
 
@@ -196,5 +200,51 @@ describe("WorkflowTool", () => {
 		const tool = await WorkflowTool.createIf(createPersistentSession([]));
 		if (!tool) throw new Error("Expected workflow tool for a persistent top-level session");
 		expect(tool.concurrency).toBe("exclusive");
+	});
+
+	it("lets the operator cancel the live runtime while run is blocked", async () => {
+		mockDiscovery();
+		const dispatchStarted = Promise.withResolvers<void>();
+		const session = createPersistentSession([], async (_toolCallId, _params, item, _defaultAgent, signal) => {
+			dispatchStarted.resolve();
+			const aborted = Promise.withResolvers<void>();
+			signal?.addEventListener("abort", () => aborted.resolve(), { once: true });
+			await aborted.promise;
+			const id = item.name ?? "unnamed";
+			return {
+				content: [{ type: "text", text: "cancelled" }],
+				details: {
+					projectAgentsDir: null,
+					results: [{ ...taskResult(id), exitCode: 1, aborted: true, abortReason: "cancelled" }],
+					totalDurationMs: 1,
+				},
+			};
+		});
+		const tool = await WorkflowTool.createIf(session);
+		if (!tool) throw new Error("Expected workflow tool for a persistent top-level session");
+		await tool.execute("workflow-create", {
+			op: "create",
+			id: "operator-cancel",
+			objective: "Stop active work",
+			nodes: [
+				{ id: "active", agent: "task", task: "Wait" },
+				{ id: "downstream", agent: "task", task: "Must not start", needs: ["active"] },
+			],
+		});
+
+		const running = tool.execute("workflow-run", { op: "run" });
+		await dispatchStarted.promise;
+		const cancelling = await tool.cancelActiveWorkflow();
+		expect(["cancelling", "cancelled"]).toContain(cancelling.status);
+
+		const cancelled = await running;
+		expect(cancelled.details?.workflow?.status).toBe("cancelled");
+		expect(cancelled.details?.workflow?.nodes.active.status).toBe("cancelled");
+		expect(cancelled.details?.workflow?.nodes.downstream.status).toBe("cancelled");
+
+		const restored = await WorkflowTool.createIf(session);
+		if (!restored) throw new Error("Expected cancelled workflow to reload");
+		const reloaded = await restored.execute("workflow-get", { op: "get" });
+		expect(reloaded.details?.workflow?.status).toBe("cancelled");
 	});
 });

--- a/packages/coding-agent/test/workflows/workflow-tool.test.ts
+++ b/packages/coding-agent/test/workflows/workflow-tool.test.ts
@@ -62,6 +62,7 @@ function createPersistentSession(spawns: RecordedSpawn[], runSettled?: SettledTa
 			});
 			return id;
 		},
+		appendEntriesAtomically: async append => append(),
 		ensureOnDisk: async () => {},
 		flush: async () => {},
 		getBranch: () => entries,
@@ -180,6 +181,49 @@ describe("WorkflowTool", () => {
 			],
 		});
 		expect(corrected.details?.workflow?.definition.id).toBe("atomic-preflight");
+	});
+
+	it("preserves aggregate usage from workflow node Task dispatches", async () => {
+		mockDiscovery();
+		const usage = {
+			input: 10,
+			output: 2,
+			cacheRead: 3,
+			cacheWrite: 1,
+			totalTokens: 16,
+			cost: { input: 0.1, output: 0.2, cacheRead: 0.03, cacheWrite: 0.01, total: 0.34 },
+		};
+		const session = createPersistentSession([], async (_toolCallId, _params, item) => ({
+			content: [{ type: "text", text: "done" }],
+			details: {
+				projectAgentsDir: null,
+				results: [taskResult(item.name ?? "unnamed")],
+				totalDurationMs: 1,
+				usage,
+			},
+		}));
+		const tool = await WorkflowTool.createIf(session);
+		if (!tool) throw new Error("Expected workflow tool for a persistent top-level session");
+		await tool.execute("workflow-create", {
+			op: "create",
+			id: "usage",
+			objective: "Preserve nested usage",
+			nodes: [
+				{ id: "one", agent: "task", task: "One" },
+				{ id: "two", agent: "task", task: "Two" },
+			],
+		});
+
+		const completed = await tool.execute("workflow-run", { op: "run" });
+
+		expect(completed.details?.usage).toEqual({
+			input: 20,
+			output: 4,
+			cacheRead: 6,
+			cacheWrite: 2,
+			totalTokens: 32,
+			cost: { input: 0.2, output: 0.4, cacheRead: 0.06, cacheWrite: 0.02, total: 0.68 },
+		});
 	});
 
 	it("sanitizes objectives and Task errors in generic tool output", async () => {

--- a/packages/coding-agent/test/workflows/workflow-tool.test.ts
+++ b/packages/coding-agent/test/workflows/workflow-tool.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as os from "node:os";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { SingleResult } from "@oh-my-pi/pi-coding-agent/task";
 import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
@@ -179,6 +180,43 @@ describe("WorkflowTool", () => {
 			],
 		});
 		expect(corrected.details?.workflow?.definition.id).toBe("atomic-preflight");
+	});
+
+	it("sanitizes objectives and Task errors in generic tool output", async () => {
+		mockDiscovery();
+		const session = createPersistentSession([], async (_toolCallId, _params, item) => {
+			const id = item.name ?? "unnamed";
+			return {
+				content: [{ type: "text", text: "failed" }],
+				details: {
+					projectAgentsDir: null,
+					results: [
+						{
+							...taskResult(id),
+							error: `merge failed\tat ${os.homedir()}/private/${"x".repeat(200)}`,
+						},
+					],
+					totalDurationMs: 1,
+				},
+			};
+		});
+		const tool = await WorkflowTool.createIf(session);
+		if (!tool) throw new Error("Expected workflow tool for a persistent top-level session");
+		const created = await tool.execute("workflow-create", {
+			op: "create",
+			id: "safe-output",
+			objective: `Inspect\t${os.homedir()}/secret/${"x".repeat(200)}`,
+			nodes: [{ id: "only", agent: "task", task: "Fail safely" }],
+		});
+		const createdText = created.content.find(part => part.type === "text")?.text ?? "";
+		expect(createdText).not.toContain(os.homedir());
+		expect(createdText).not.toContain("\t");
+
+		const failed = await tool.execute("workflow-run", { op: "run" });
+		const failedText = failed.content.find(part => part.type === "text")?.text ?? "";
+		expect(failedText).not.toContain(os.homedir());
+		expect(failedText).not.toContain("\t");
+		for (const line of failedText.split("\n")) expect(Bun.stringWidth(line)).toBeLessThanOrEqual(140);
 	});
 
 	it("is unavailable without a persistent parent session", async () => {

--- a/packages/coding-agent/test/workflows/workflow-tool.test.ts
+++ b/packages/coding-agent/test/workflows/workflow-tool.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { SingleResult } from "@oh-my-pi/pi-coding-agent/task";
+import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
+import type { SessionEntry } from "../../src/session/session-entries";
+import { TaskDispatchService } from "../../src/task/dispatch-service";
+import type { AgentDefinition, TaskItem } from "../../src/task/types";
+import type { ToolSession } from "../../src/tools";
+import { WorkflowTool } from "../../src/workflows/tools/workflow-tool";
+
+interface RecordedSpawn {
+	context: string;
+	item: TaskItem;
+}
+
+const taskAgent: AgentDefinition = {
+	name: "task",
+	description: "General-purpose task agent",
+	systemPrompt: "You are a task agent.",
+	source: "bundled",
+};
+
+function mockDiscovery(): void {
+	vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+		agents: [taskAgent],
+		projectAgentsDir: null,
+	});
+}
+
+function taskResult(id: string): SingleResult {
+	return {
+		index: 0,
+		id,
+		agent: "task",
+		agentSource: "bundled",
+		task: "task",
+		assignment: "task",
+		exitCode: 0,
+		output: "done",
+		stderr: "",
+		truncated: false,
+		durationMs: 1,
+		tokens: 0,
+		requests: 1,
+	};
+}
+
+function createPersistentSession(spawns: RecordedSpawn[]): ToolSession {
+	const entries: SessionEntry[] = [];
+	let nextId = 0;
+	const sessionManager: NonNullable<ToolSession["sessionManager"]> = {
+		appendCustomEntry: (customType, data) => {
+			const id = `entry-${++nextId}`;
+			entries.push({
+				type: "custom",
+				id,
+				parentId: entries.at(-1)?.id ?? null,
+				timestamp: new Date(nextId).toISOString(),
+				customType,
+				data,
+			});
+			return id;
+		},
+		ensureOnDisk: async () => {},
+		flush: async () => {},
+		getBranch: () => entries,
+		getEntries: () => entries,
+	};
+	const session: ToolSession = {
+		cwd: "/tmp",
+		hasUI: false,
+		getSessionFile: () => "/tmp/session.jsonl",
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+		sessionManager,
+		toolRegistry: new Map(),
+	};
+	session.taskDispatchService = new TaskDispatchService(session, async (_toolCallId, params, item) => {
+		spawns.push(structuredClone({ context: params.context ?? "", item }));
+		const id = item.name ?? "unnamed";
+		return {
+			content: [{ type: "text", text: "done" }],
+			details: { projectAgentsDir: null, results: [taskResult(id)], totalDurationMs: 1 },
+		};
+	});
+	return session;
+}
+
+describe("WorkflowTool", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("persists a graph and dispatches downstream nodes with durable dependency references", async () => {
+		mockDiscovery();
+		const spawns: RecordedSpawn[] = [];
+		const session = createPersistentSession(spawns);
+		const tool = await WorkflowTool.createIf(session);
+		if (!tool) throw new Error("Expected workflow tool for a persistent top-level session");
+
+		const created = await tool.execute("workflow-call", {
+			op: "create",
+			id: "case-study",
+			objective: "Build a verified case study",
+			nodes: [
+				{ id: "research", agent: "task", task: "Research" },
+				{ id: "draft", agent: "task", task: "Draft", needs: ["research"] },
+			],
+		});
+		expect(created.details?.workflow?.status).toBe("created");
+
+		const restored = await WorkflowTool.createIf(session);
+		if (!restored) throw new Error("Expected persisted workflow to reload");
+		const reloaded = await restored.execute("workflow-call", { op: "get" });
+		expect(reloaded.details?.workflow?.definition.id).toBe("case-study");
+
+		const completed = await restored.execute("workflow-call", { op: "run" });
+		expect(completed.details?.workflow?.status).toBe("succeeded");
+		expect(spawns.map(spawn => spawn.item.task)).toEqual(["Research", "Draft"]);
+		const researchAgentId = spawns[0]?.item.name;
+		if (!researchAgentId) throw new Error("Expected a stable research agent id");
+		expect(spawns[1]?.context).toContain("research: succeeded");
+		expect(spawns[1]?.context).toContain(`agent://${researchAgentId}`);
+		expect(spawns[1]?.context).toContain(`history://${researchAgentId}`);
+
+		const finalReload = await WorkflowTool.createIf(session);
+		if (!finalReload) throw new Error("Expected completed workflow to reload");
+		const finalSnapshot = await finalReload.execute("workflow-call", { op: "get" });
+		expect(finalSnapshot.details?.workflow?.nodes.research.outputRef).toBe(`agent://${researchAgentId}`);
+	});
+
+	it("preflights every node before persisting an immutable definition", async () => {
+		mockDiscovery();
+		const spawns: RecordedSpawn[] = [];
+		const session = createPersistentSession(spawns);
+		const tool = await WorkflowTool.createIf(session);
+		if (!tool) throw new Error("Expected workflow tool for a persistent top-level session");
+
+		await expect(
+			tool.execute("workflow-call", {
+				op: "create",
+				id: "atomic-preflight",
+				objective: "Persist nothing if any node is invalid",
+				nodes: [
+					{ id: "root", agent: "task", task: "Would be valid" },
+					{
+						id: "later",
+						agent: "task",
+						task: "Invalid strict schema",
+						needs: ["root"],
+						outputSchema: "string",
+						schemaMode: "strict",
+					},
+				],
+			}),
+		).rejects.toThrow("Invalid strict caller output schema");
+		expect(spawns).toEqual([]);
+		const status = await tool.execute("workflow-call", { op: "get" });
+		expect(status.details?.workflow).toBeNull();
+
+		const corrected = await tool.execute("workflow-call", {
+			op: "create",
+			id: "atomic-preflight",
+			objective: "Persist the corrected definition under the same id",
+			nodes: [
+				{ id: "root", agent: "task", task: "Valid root" },
+				{
+					id: "later",
+					agent: "task",
+					task: "Valid strict schema",
+					needs: ["root"],
+					outputSchema: { type: "string" },
+					schemaMode: "strict",
+				},
+			],
+		});
+		expect(corrected.details?.workflow?.definition.id).toBe("atomic-preflight");
+	});
+
+	it("is unavailable without a persistent parent session", async () => {
+		const session: ToolSession = {
+			cwd: "/tmp",
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated(),
+		};
+		expect(await WorkflowTool.createIf(session)).toBeNull();
+		expect(await WorkflowTool.createIf({ ...session, taskDepth: 1 })).toBeNull();
+	});
+});


### PR DESCRIPTION
## What

- Extract Task validation, policy preflight, and settled programmatic dispatch into a session-scoped `TaskDispatchService` shared by the existing Task tool and the new workflow scheduler.
- Add a model-facing `workflow` tool for immutable static DAGs with concurrent ready-node execution, Task-backed agent identities, append-only session snapshots, restart recovery, explicit retry, and cancellation.
- Keep dependency handoff compact through persisted `agent://` and `history://` references instead of copying upstream transcripts.
- Update workflowz guidance, CLI help, developer/tool documentation, tests, and the coding-agent changelog.

## Why

Related to #6947.

This PR adds durable workflow graphs to OMP so agents can coordinate dependent tasks across turns and restarts. **It's time to start graphmaxxing.**

OMP already has a mature Task execution runtime, but it lacks durable dependency state for graph-shaped work that spans turns or process restarts. This adds that state machine without creating a second agent executor, job identity, or concurrency layer.

## Testing

- `bun test packages/coding-agent/test/workflows/runtime.test.ts packages/coding-agent/test/workflows/workflow-tool.test.ts packages/coding-agent/test/task/task-batch.test.ts packages/coding-agent/test/tools/index.test.ts` — 52 passed.
- `bun check` — passed across the workspace.
- `bun run dev -- --help` — lists the new `workflow` tool.
- Exercised the source CLI end to end with a fresh persisted session and a two-node `root -> child` DAG:
  - an invalid agent selection was rejected during create preflight without reserving the workflow id;
  - the corrected definition was created under the same id;
  - the workflow persisted running and settled snapshots, then finished with both nodes `succeeded`;
  - the root artifact contained `ROOT_OK`;
  - the child received and read the root's `agent://wf-pr-e2e-dag-root-6eb95684-a1` and `history://wf-pr-e2e-dag-root-6eb95684-a1` references, then produced `CHILD_OK`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
