### PR TITLE
fix(coding-agent): share parent local:// root with /tan clone

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/tan` agents being unable to read parent-session `local://` attachments (pasted files, generated references). `TanCommandController` now threads the parent session's `localProtocolOptions` into the tan clone, so `local://` resolves against `<parent-artifacts>/local` instead of the clone-nested `<parent-artifacts>/Tan-<id>/local` root — matching the task-subagent path ([#6971](https://github.com/can1357/oh-my-pi/issues/6971)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `/tan` agents being unable to read parent-session `local://` attachments (pasted files, generated references). `TanCommandController` now threads the parent session's `localProtocolOptions` into the tan clone, so `local://` resolves against `<parent-artifacts>/local` instead of the clone-nested `<parent-artifacts>/Tan-<id>/local` root — matching the task-subagent path ([#6971](https://github.com/can1357/oh-my-pi/issues/6971)).
+- Fixed `/tan` agents being unable to read parent-session `local://` attachments (pasted files, generated references). `TanCommandController` now threads the parent session's `localProtocolOptions` into the tan clone, so `local://` resolves against `<parent-artifacts>/local` instead of the clone-nested `<parent-artifacts>/Tan-<id>/local` root. Subagent local mappings now remain session-bound rather than replacing the process-global override used by active-session suggestions and links ([#6971](https://github.com/can1357/oh-my-pi/issues/6971)).
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -390,8 +390,9 @@ export class LocalProtocolHandler implements ProtocolHandler {
 
 	/**
 	 * Install a process-global override that wins over the AgentRegistry-based
-	 * derivation. Used by SDK consumers that wire `localProtocolOptions` on
-	 * `createAgentSession` and by subagents that share their parent's root.
+	 * derivation. Used by top-level SDK consumers that wire
+	 * `localProtocolOptions` on `createAgentSession`; subagents keep their
+	 * inherited mapping session-bound.
 	 */
 	static setOverride(value: LocalProtocolOptions | undefined): void {
 		LocalProtocolHandler.#override = value;

--- a/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
@@ -80,16 +80,13 @@ export class TanCommandController {
 		const ownerId = session.getAgentId() ?? MAIN_AGENT_ID;
 		const mcpManager = this.ctx.mcpManager;
 		const cwd = this.ctx.sessionManager.getCwd();
-		const parentSessionManager = this.ctx.sessionManager;
-		// Share the parent session's local:// root so the tan can read attachments
-		// (pasted files, generated references) the parent stored under
-		// `<parent-artifacts>/local`. The clone's own session file nests one level
-		// deeper (`<parent-artifacts>/Tan-<id>.jsonl`), so without this its derived
-		// root would be `<parent-artifacts>/Tan-<id>/local` — matching the
-		// task-subagent path, which explicitly inherits the parent's mapping.
+		const parentArtifactsDir = this.ctx.sessionManager.getArtifactsDir();
+		// Snapshot the parent session's local:// mapping when dispatching. The
+		// interactive SessionManager is mutable and may switch transcripts while
+		// this background tan is still running.
 		const localProtocolOptions = {
-			getArtifactsDir: () => parentSessionManager.getArtifactsDir(),
-			getSessionId: () => parentSessionManager.getSessionId(),
+			getArtifactsDir: () => parentArtifactsDir,
+			getSessionId: () => parentSessionId,
 		};
 		// Nest the clone inside the parent's artifact directory (like a subagent
 		// session) rather than as a top-level sibling, so it shares the parent's

--- a/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
@@ -80,6 +80,17 @@ export class TanCommandController {
 		const ownerId = session.getAgentId() ?? MAIN_AGENT_ID;
 		const mcpManager = this.ctx.mcpManager;
 		const cwd = this.ctx.sessionManager.getCwd();
+		const parentSessionManager = this.ctx.sessionManager;
+		// Share the parent session's local:// root so the tan can read attachments
+		// (pasted files, generated references) the parent stored under
+		// `<parent-artifacts>/local`. The clone's own session file nests one level
+		// deeper (`<parent-artifacts>/Tan-<id>.jsonl`), so without this its derived
+		// root would be `<parent-artifacts>/Tan-<id>/local` — matching the
+		// task-subagent path, which explicitly inherits the parent's mapping.
+		const localProtocolOptions = {
+			getArtifactsDir: () => parentSessionManager.getArtifactsDir(),
+			getSessionId: () => parentSessionManager.getSessionId(),
+		};
 		// Nest the clone inside the parent's artifact directory (like a subagent
 		// session) rather than as a top-level sibling, so it shares the parent's
 		// artifacts in place — no copy needed.
@@ -132,6 +143,7 @@ export class TanCommandController {
 							parentAgentId: ownerId,
 							agentRegistry,
 							disableExtensionDiscovery: true,
+							localProtocolOptions,
 						});
 						clone = created.session;
 						clone.sessionManager?.appendSessionInit?.({

--- a/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
@@ -83,10 +83,15 @@ export class TanCommandController {
 		const parentArtifactsDir = this.ctx.sessionManager.getArtifactsDir();
 		// Snapshot the parent session's local:// mapping when dispatching. The
 		// interactive SessionManager is mutable and may switch transcripts while
-		// this background tan is still running.
+		// this background tan is still running. Use the session-manager id (not
+		// `session.sessionId`, which can diverge after `/fresh` or a provider
+		// session override) so the tan resolves the same local root the parent's
+		// large-paste writes and `local://` reads use — notably the Windows
+		// short-root fallback keys `%TEMP%/omp-local/<id>` off this id.
+		const parentLocalSessionId = this.ctx.sessionManager.getSessionId();
 		const localProtocolOptions = {
 			getArtifactsDir: () => parentArtifactsDir,
-			getSessionId: () => parentSessionId,
+			getSessionId: () => parentLocalSessionId,
 		};
 		// Nest the clone inside the parent's artifact directory (like a subagent
 		// session) rather than as a top-level sibling, so it shares the parent's

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1772,7 +1772,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getArtifactsDir,
 			getSessionId: () => sessionManager.getSessionId?.() ?? null,
 		};
-		if (options.localProtocolOptions) {
+		if (options.localProtocolOptions && !options.parentTaskPrefix) {
 			LocalProtocolHandler.setOverride(options.localProtocolOptions);
 		}
 		toolSession.getArtifactsDir = getArtifactsDir;

--- a/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
 import type { AsyncJobRegisterOptions } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resolveLocalRoot } from "@oh-my-pi/pi-coding-agent/internal-urls/local-protocol";
 import { TanCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/tan-command-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
@@ -118,10 +119,13 @@ function createContext(overrides?: {
 			sequence.push("sendCustomMessage");
 		}),
 	} as unknown as InteractiveModeContext["session"];
+	const parentArtifactsDir = parentFile.slice(0, -6);
 	const sessionManager = {
 		getSessionFile: vi.fn(() => parentFile),
 		getCwd: vi.fn(() => tempDir.path()),
 		getSessionDir: vi.fn(() => tempDir.path()),
+		getArtifactsDir: vi.fn(() => parentArtifactsDir),
+		getSessionId: vi.fn(() => "parent-session"),
 		ensureOnDisk: vi.fn(async () => {}),
 		flush: vi.fn(async () => {}),
 	} as unknown as InteractiveModeContext["sessionManager"];
@@ -141,6 +145,7 @@ function createContext(overrides?: {
 	return {
 		tempDir,
 		parentFile,
+		parentArtifactsDir,
 		cloneFile,
 		cloneManager,
 		ctx,
@@ -223,6 +228,31 @@ describe("TanCommandController", () => {
 		);
 		expect(harness.ctx.rebuildChatFromMessages).toHaveBeenCalled();
 		expect(harness.ctx.showStatus).toHaveBeenCalledWith("Dispatched background tan job-123");
+	});
+
+	it("shares the parent session's local:// root with the tan clone", async () => {
+		const harness = createContext();
+		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(harness.cloneManager);
+		const { clone } = createCloneStub({ lastAssistantText: "done" });
+		let capturedOptions: Parameters<typeof sdkModule.createAgentSession>[0] | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: clone } as unknown as CreateAgentSessionResult;
+		});
+		const controller = new TanCommandController(harness.ctx);
+
+		await controller.start("read local://paste-1.md");
+		const capturedRun = harness.capturedRun;
+		if (!capturedRun) throw new Error("run function was not captured");
+		await capturedRun({ jobId: "job-123", signal: new AbortController().signal, reportProgress: async () => {} });
+
+		expect(capturedOptions?.localProtocolOptions).toBeDefined();
+		const opts = capturedOptions?.localProtocolOptions;
+		if (!opts) throw new Error("localProtocolOptions was not passed");
+		// The clone must resolve local:// against the parent's local root, not the
+		// clone-nested `<parent-artifacts>/Tan-<id>/local` it would derive on its own.
+		expect(resolveLocalRoot(opts)).toBe(path.join(harness.parentArtifactsDir, "local"));
+		expect(opts.getSessionId?.()).toBe("parent-session");
 	});
 
 	it("aborts the cloned agent when the background job signal aborts", async () => {

--- a/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
@@ -121,7 +121,7 @@ function createContext(overrides?: {
 	} as unknown as InteractiveModeContext["session"];
 	const parentArtifactsDir = parentFile.slice(0, -6);
 	const getArtifactsDir = vi.fn(() => parentArtifactsDir);
-	const getSessionId = vi.fn(() => "parent-session");
+	const getSessionId = vi.fn(() => "parent-local-session");
 	const sessionManager = {
 		getSessionFile: vi.fn(() => parentFile),
 		getCwd: vi.fn(() => tempDir.path()),
@@ -255,7 +255,9 @@ describe("TanCommandController", () => {
 		const opts = capturedOptions?.localProtocolOptions;
 		if (!opts) throw new Error("localProtocolOptions was not passed");
 		expect(resolveLocalRoot(opts)).toBe(path.join(harness.parentArtifactsDir, "local"));
-		expect(opts.getSessionId?.()).toBe("parent-session");
+		// The local mapping keys off the session-manager id (not `session.sessionId`,
+		// still "parent-session"), matching the parent's large-paste / local:// writes.
+		expect(opts.getSessionId?.()).toBe("parent-local-session");
 	});
 
 	it("aborts the cloned agent when the background job signal aborts", async () => {

--- a/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
@@ -7,7 +7,7 @@ import { resolveLocalRoot } from "@oh-my-pi/pi-coding-agent/internal-urls/local-
 import { TanCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/tan-command-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
-import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -120,12 +120,14 @@ function createContext(overrides?: {
 		}),
 	} as unknown as InteractiveModeContext["session"];
 	const parentArtifactsDir = parentFile.slice(0, -6);
+	const getArtifactsDir = vi.fn(() => parentArtifactsDir);
+	const getSessionId = vi.fn(() => "parent-session");
 	const sessionManager = {
 		getSessionFile: vi.fn(() => parentFile),
 		getCwd: vi.fn(() => tempDir.path()),
 		getSessionDir: vi.fn(() => tempDir.path()),
-		getArtifactsDir: vi.fn(() => parentArtifactsDir),
-		getSessionId: vi.fn(() => "parent-session"),
+		getArtifactsDir,
+		getSessionId,
 		ensureOnDisk: vi.fn(async () => {}),
 		flush: vi.fn(async () => {}),
 	} as unknown as InteractiveModeContext["sessionManager"];
@@ -149,6 +151,8 @@ function createContext(overrides?: {
 		cloneFile,
 		cloneManager,
 		ctx,
+		getArtifactsDir,
+		getSessionId,
 		register,
 		sequence,
 		get capturedRun() {
@@ -230,11 +234,11 @@ describe("TanCommandController", () => {
 		expect(harness.ctx.showStatus).toHaveBeenCalledWith("Dispatched background tan job-123");
 	});
 
-	it("shares the parent session's local:// root with the tan clone", async () => {
+	it("keeps the dispatching session's local:// root after the interactive session switches", async () => {
 		const harness = createContext();
 		vi.spyOn(SessionManager, "forkFrom").mockResolvedValue(harness.cloneManager);
 		const { clone } = createCloneStub({ lastAssistantText: "done" });
-		let capturedOptions: Parameters<typeof sdkModule.createAgentSession>[0] | undefined;
+		let capturedOptions: CreateAgentSessionOptions | undefined;
 		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
 			capturedOptions = options;
 			return { session: clone } as unknown as CreateAgentSessionResult;
@@ -242,15 +246,14 @@ describe("TanCommandController", () => {
 		const controller = new TanCommandController(harness.ctx);
 
 		await controller.start("read local://paste-1.md");
+		harness.getArtifactsDir.mockReturnValue(path.join(harness.tempDir.path(), "other-session"));
+		harness.getSessionId.mockReturnValue("other-session");
 		const capturedRun = harness.capturedRun;
 		if (!capturedRun) throw new Error("run function was not captured");
 		await capturedRun({ jobId: "job-123", signal: new AbortController().signal, reportProgress: async () => {} });
 
-		expect(capturedOptions?.localProtocolOptions).toBeDefined();
 		const opts = capturedOptions?.localProtocolOptions;
 		if (!opts) throw new Error("localProtocolOptions was not passed");
-		// The clone must resolve local:// against the parent's local root, not the
-		// clone-nested `<parent-artifacts>/Tan-<id>/local` it would derive on its own.
 		expect(resolveLocalRoot(opts)).toBe(path.join(harness.parentArtifactsDir, "local"));
 		expect(opts.getSessionId?.()).toBe("parent-session");
 	});

--- a/packages/coding-agent/test/sdk-session-isolation.test.ts
+++ b/packages/coding-agent/test/sdk-session-isolation.test.ts
@@ -7,6 +7,7 @@ import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import type { Rule } from "@oh-my-pi/pi-coding-agent/capability/rule";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { LocalProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/local-protocol";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
@@ -109,6 +110,7 @@ describe("createAgentSession session storage isolation", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
+		LocalProtocolHandler.resetOverrideForTests();
 		for (const tempDir of tempDirs.splice(0)) {
 			removeSyncWithRetries(tempDir);
 		}
@@ -147,6 +149,49 @@ describe("createAgentSession session storage isolation", () => {
 			await session.dispose();
 		}
 	});
+	it("keeps subagent local:// mappings from replacing the process-global override", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-local-override-${Snowflake.next()}-`));
+		tempDirs.push(tempDir);
+		const cwd = path.join(tempDir, "project");
+		fs.mkdirSync(cwd, { recursive: true });
+		const globalOptions = {
+			getArtifactsDir: () => path.join(tempDir, "active-artifacts"),
+			getSessionId: () => "active-session",
+		};
+		const subagentOptions = {
+			getArtifactsDir: () => path.join(tempDir, "parent-artifacts"),
+			getSessionId: () => "parent-session",
+		};
+		LocalProtocolHandler.setOverride(globalOptions);
+
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir: path.join(tempDir, "agent"),
+			modelRegistry: sharedModelRegistry,
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			toolNames: [],
+			enableMCP: false,
+			enableLsp: false,
+			agentRegistry: new AgentRegistry(),
+			agentId: "Tan-local-override-test",
+			agentDisplayName: "tan",
+			parentTaskPrefix: "Tan-local-override-test",
+			parentAgentId: "Main",
+			localProtocolOptions: subagentOptions,
+		});
+
+		try {
+			expect(LocalProtocolHandler.resolveOptions()).toBe(globalOptions);
+		} finally {
+			await session.dispose();
+		}
+	});
+
 	it("does not replace a newer registry generation when creation expected the id to be absent", async () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-generation-cas-${Snowflake.next()}-`));
 		tempDirs.push(tempDir);


### PR DESCRIPTION
## Repro
In a persisted interactive session, attach pasted content as a `local://` file (large-paste menu → Attach as local file), then dispatch `/tan Read local://paste-1.md and report its first line`. The tan agent reports the file missing; reading `local://` inside the tan shows its root is `<parent-artifacts>/Tan-<id>/local` (empty) instead of `<parent-artifacts>/local`. Reproduced directly against `resolveLocalRoot`, confirming the roots diverge:

```
parent local root: <parent-artifacts>/local
tan    local root: <parent-artifacts>/Tan-<id>/local
diverges: true
```

## Cause
`TanCommandController.start` (`packages/coding-agent/src/modes/controllers/tan-command-controller.ts`) nests the clone at `<parent-artifacts>/Tan-<id>.jsonl`, so the clone's `SessionManager` derives artifacts dir `<parent-artifacts>/Tan-<id>` and thus local root `<parent-artifacts>/Tan-<id>/local`. Its `sdk.createAgentSession(...)` call omitted `localProtocolOptions`, so the SDK fell back to deriving the mapping from the clone's own dir (`sdk.ts:1771-1779`). The task-subagent path (`task/structured-subagent.ts`, `task/executor.ts`) explicitly inherits the parent's `localProtocolOptions`; `/tan` did not.

## Fix
- Build `localProtocolOptions` from the parent session manager (`getArtifactsDir`/`getSessionId`) in `TanCommandController.start`.
- Pass it into the `sdk.createAgentSession(...)` call for the tan clone, so `local://` resolves against `<parent-artifacts>/local`.
- Add a regression test asserting the clone's `localProtocolOptions` resolves to the parent local root.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/modes/controllers/tan-command-controller.test.ts` → 9 pass, 0 fail. The new test `shares the parent session's local:// root with the tan clone` fails without the fix (`localProtocolOptions` is undefined). Fixes #6971