### PR TITLE
feat(antigravity): align Gemini 3.6 and add grounded search

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Gemini 3.6 Flash requests to Antigravity Cloud Code Assist sending `thinkingLevel` instead of the endpoint's required per-tier `thinkingBudget`, which could yield repeated empty responses.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Removed unobserved Antigravity sandbox failover and last-good-endpoint state from Cloud Code Assist generation; google-antigravity now uses the daily endpoint only.
+
 ### Fixed
 
 - Fixed Gemini 3.6 Flash requests to Antigravity Cloud Code Assist sending `thinkingLevel` instead of the endpoint's required per-tier `thinkingBudget`, which could yield repeated empty responses.

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -271,13 +271,10 @@ export interface GoogleGeminiCliOptions extends StreamOptions {
 	 */
 	requestModelId?: string;
 	projectId?: string;
-	/** Antigravity endpoint routing mode: "auto" (default with failover), "production", "sandbox". */
-	antigravityEndpointMode?: "auto" | "production" | "sandbox";
 	providerSessionState?: Map<string, ProviderSessionState>;
 }
 
 export interface AntigravityProviderSessionState extends ProviderSessionState {
-	lastGoodEndpoint?: string;
 	/**
 	 * Per-conversation request-envelope identity that mirrors the real
 	 * Antigravity client. `sessionId` is the signed-decimal session id;
@@ -312,8 +309,6 @@ export function getAntigravityProviderSessionState(
 
 const DEFAULT_ENDPOINT = "https://cloudcode-pa.googleapis.com";
 const ANTIGRAVITY_DAILY_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
-const ANTIGRAVITY_SANDBOX_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
-const ANTIGRAVITY_ENDPOINT_FALLBACKS = [ANTIGRAVITY_DAILY_ENDPOINT, ANTIGRAVITY_SANDBOX_ENDPOINT] as const;
 
 export {
 	ANTIGRAVITY_SYSTEM_INSTRUCTION,
@@ -328,7 +323,7 @@ const BASE_DELAY_MS = 1000;
 const RATE_LIMIT_BUDGET_MS = 5 * 60 * 1000;
 const CLAUDE_THINKING_BETA_HEADER = "interleaved-thinking-2025-05-14";
 const GOOGLE_GEMINI_REFRESH_SKEW_MS = 60_000;
-const ANTIGRAVITY_REFRESH_SKEW_MS = 60_000;
+const ANTIGRAVITY_REFRESH_SKEW_MS = 30_000;
 
 const CLOUD_CODE_OVERSIZED_REQUEST_PATTERN =
 	/\b(?:request|payload)(?:\s+payload)?\s+(?:size\s+)?(?:is\s+)?(?:too\s+large|exceeds?(?:\s+the)?\s+(?:maximum\s+)?(?:size|limit))\b/i;
@@ -565,39 +560,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 				: undefined;
 
 			if (isAntigravity) {
-				const mode = options?.antigravityEndpointMode ?? "auto";
-				if (mode === "sandbox") {
-					endpoints = [ANTIGRAVITY_SANDBOX_ENDPOINT];
-					if (providerState) providerState.lastGoodEndpoint = undefined;
-				} else if (mode === "production") {
-					endpoints = [ANTIGRAVITY_DAILY_ENDPOINT];
-					if (providerState) providerState.lastGoodEndpoint = undefined;
-				} else {
-					// auto mode
-					if (baseUrl) {
-						const cleanUrl = baseUrl.replace(/\/+$/, "");
-						if (cleanUrl !== ANTIGRAVITY_DAILY_ENDPOINT && cleanUrl !== ANTIGRAVITY_SANDBOX_ENDPOINT) {
-							endpoints = [baseUrl];
-							if (providerState) providerState.lastGoodEndpoint = undefined;
-						} else {
-							const defaultFallbacks = [...ANTIGRAVITY_ENDPOINT_FALLBACKS] as string[];
-							const lastGood = providerState?.lastGoodEndpoint;
-							if (lastGood && defaultFallbacks.includes(lastGood)) {
-								endpoints = [lastGood, ...defaultFallbacks.filter(e => e !== lastGood)];
-							} else {
-								endpoints = defaultFallbacks;
-							}
-						}
-					} else {
-						const defaultFallbacks = [...ANTIGRAVITY_ENDPOINT_FALLBACKS] as string[];
-						const lastGood = providerState?.lastGoodEndpoint;
-						if (lastGood && defaultFallbacks.includes(lastGood)) {
-							endpoints = [lastGood, ...defaultFallbacks.filter(e => e !== lastGood)];
-						} else {
-							endpoints = defaultFallbacks;
-						}
-					}
-				}
+				endpoints = [ANTIGRAVITY_DAILY_ENDPOINT];
 			} else {
 				endpoints = baseUrl ? [baseUrl] : [DEFAULT_ENDPOINT];
 			}
@@ -1044,13 +1007,6 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 						);
 					}
 
-					// Succeeded! Break the endpoints loop.
-					if (
-						providerState &&
-						(options?.antigravityEndpointMode === "auto" || !options?.antigravityEndpointMode)
-					) {
-						providerState.lastGoodEndpoint = endpoint;
-					}
 					// Commit after a fully successful attempt (content + finish reason);
 					// used as the next request's last_execution_id. Overwrite even when
 					// undefined so a response without an id can't leave a stale value.

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -325,15 +325,8 @@ const CLAUDE_THINKING_BETA_HEADER = "interleaved-thinking-2025-05-14";
 const GOOGLE_GEMINI_REFRESH_SKEW_MS = 60_000;
 const ANTIGRAVITY_REFRESH_SKEW_MS = 30_000;
 
-const CLOUD_CODE_OVERSIZED_REQUEST_PATTERN =
-	/\b(?:request|payload)(?:\s+payload)?\s+(?:size\s+)?(?:is\s+)?(?:too\s+large|exceeds?(?:\s+the)?\s+(?:maximum\s+)?(?:size|limit))\b/i;
-
 function createCloudCodeApiError(message: string, status: number, headers?: Headers): AIError.GeminiCliApiError {
-	const error = new AIError.GeminiCliApiError(message, status, headers ? { headers } : undefined);
-	if ((status === 400 || status === 413) && CLOUD_CODE_OVERSIZED_REQUEST_PATTERN.test(message)) {
-		AIError.attach(error, AIError.create(AIError.Flag.ContextOverflow));
-	}
-	return error;
+	return new AIError.GeminiCliApiError(message, status, headers ? { headers } : undefined);
 }
 
 function isClaudeModel(modelId: string): boolean {
@@ -559,11 +552,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 				? getAntigravityProviderSessionState(options?.providerSessionState)
 				: undefined;
 
-			if (isAntigravity) {
-				endpoints = [ANTIGRAVITY_DAILY_ENDPOINT];
-			} else {
-				endpoints = baseUrl ? [baseUrl] : [DEFAULT_ENDPOINT];
-			}
+			endpoints = [baseUrl || (isAntigravity ? ANTIGRAVITY_DAILY_ENDPOINT : DEFAULT_ENDPOINT)];
 
 			let requestBody = buildRequest(model, context, projectId, options, isAntigravity);
 			const replacementPayload = await options?.onPayload?.(requestBody, model);

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -330,6 +330,17 @@ const CLAUDE_THINKING_BETA_HEADER = "interleaved-thinking-2025-05-14";
 const GOOGLE_GEMINI_REFRESH_SKEW_MS = 60_000;
 const ANTIGRAVITY_REFRESH_SKEW_MS = 60_000;
 
+const CLOUD_CODE_OVERSIZED_REQUEST_PATTERN =
+	/\b(?:request|payload)(?:\s+payload)?\s+(?:size\s+)?(?:is\s+)?(?:too\s+large|exceeds?(?:\s+the)?\s+(?:maximum\s+)?(?:size|limit))\b/i;
+
+function createCloudCodeApiError(message: string, status: number, headers?: Headers): AIError.GeminiCliApiError {
+	const error = new AIError.GeminiCliApiError(message, status, headers ? { headers } : undefined);
+	if ((status === 400 || status === 413) && CLOUD_CODE_OVERSIZED_REQUEST_PATTERN.test(message)) {
+		AIError.attach(error, AIError.create(AIError.Flag.ContextOverflow));
+	}
+	return error;
+}
+
 function isClaudeModel(modelId: string): boolean {
 	return modelId.toLowerCase().includes("claude");
 }
@@ -764,7 +775,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 						const detail = chunk.error.message || chunk.error.status || "unknown error";
 						const message = `Cloud Code Assist stream error: ${detail}`;
 						throw typeof chunk.error.code === "number" && chunk.error.code >= 400
-							? new AIError.GeminiCliApiError(message, chunk.error.code)
+							? createCloudCodeApiError(message, chunk.error.code)
 							: new AIError.ProviderResponseError(message, { provider: model.provider, kind: "runtime" });
 					}
 					const responseData = chunk.response;
@@ -953,10 +964,10 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 									parsedCredentials.email,
 								)
 							: errorText;
-						throw new AIError.GeminiCliApiError(
+						throw createCloudCodeApiError(
 							`Cloud Code Assist API error (${response.status}): ${errorMessage}`,
 							response.status,
-							{ headers: response.headers },
+							response.headers,
 						);
 					}
 
@@ -989,10 +1000,10 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 
 							if (!currentResponse.ok) {
 								const retryErrorText = await currentResponse.text();
-								throw new AIError.GeminiCliApiError(
+								throw createCloudCodeApiError(
 									`Cloud Code Assist API error (${currentResponse.status}): ${retryErrorText}`,
 									currentResponse.status,
-									{ headers: currentResponse.headers },
+									currentResponse.headers,
 								);
 							}
 						}

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1748,7 +1748,6 @@ function mapOptionsForApi<TApi extends Api>(
 						},
 						hideThinkingSummary: options?.hideThinkingSummary,
 						toolChoice,
-						antigravityEndpointMode: options?.antigravityEndpointMode,
 					});
 				}
 
@@ -1771,7 +1770,6 @@ function mapOptionsForApi<TApi extends Api>(
 						thinking: { enabled: true, budgetTokens: thinkingBudget },
 						hideThinkingSummary: options?.hideThinkingSummary,
 						toolChoice,
-						antigravityEndpointMode: options?.antigravityEndpointMode,
 					});
 				}
 				// Budget clamped to zero — fall through to the thinking-off path.
@@ -1788,7 +1786,6 @@ function mapOptionsForApi<TApi extends Api>(
 				requestModelId: resolveWireModelId(model, undefined),
 				thinking,
 				toolChoice,
-				antigravityEndpointMode: options?.antigravityEndpointMode,
 			});
 		}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -616,8 +616,6 @@ export interface SimpleStreamOptions extends Omit<StreamOptions, "apiKey"> {
 	 * providers ignore it. Callers own the cache lifecycle and compatibility.
 	 */
 	cachedContent?: string;
-	/** Antigravity endpoint routing mode: "auto" (default with failover), "production", "sandbox". */
-	antigravityEndpointMode?: "auto" | "production" | "sandbox";
 	/**
 	 * Anthropic `server-side-fallback-2026-06-01` fallback chain (top-level
 	 * `fallbacks` request field). Opt-in ONLY — leaving this undefined is

--- a/packages/ai/test/fixtures/antigravity-gemini-3.6-flash-thinking.json
+++ b/packages/ai/test/fixtures/antigravity-gemini-3.6-flash-thinking.json
@@ -1,0 +1,14 @@
+{
+  "source": "agy 1.1.7 capture against daily-cloudcode-pa.googleapis.com on 2026-07-29",
+  "model": "gemini-3.6-flash-high",
+  "generationConfig": {
+    "maxOutputTokens": 65536,
+    "thinkingConfig": {
+      "includeThoughts": true,
+      "thinkingBudget": 10000
+    }
+  },
+  "labels": {
+    "model_enum": "MODEL_PLACEHOLDER_M71"
+  }
+}

--- a/packages/ai/test/google-antigravity-compaction.test.ts
+++ b/packages/ai/test/google-antigravity-compaction.test.ts
@@ -63,6 +63,22 @@ describe("Antigravity Cloud Code Assist oversized-request compaction signals", (
 		expect(AIError.isContextOverflow(result, model.contextWindow ?? undefined)).toBe(true);
 	});
 
+	it("uses a configured Antigravity base URL override", async () => {
+		const override = "https://gateway.example.test/cloudcode";
+		const endpoints: string[] = [];
+		const fetch: FetchImpl = async input => {
+			endpoints.push(endpointFromInput(input));
+			return new Response(
+				JSON.stringify({ error: { code: 400, status: "INVALID_ARGUMENT", message: OVERSIZED_REQUEST } }),
+				{ status: 400, headers: { "content-type": "application/json" } },
+			);
+		};
+
+		await streamGoogleGeminiCli({ ...model, baseUrl: override }, context, streamOptions(fetch)).result();
+
+		expect(endpoints).toEqual([`${override}/v1internal:streamGenerateContent?alt=sse`]);
+	});
+
 	it("maps the daily endpoint's SSE oversized-request error without empty-stream retry or sandbox fallback", async () => {
 		const endpoints: string[] = [];
 		const fetch: FetchImpl = async input => {

--- a/packages/ai/test/google-antigravity-compaction.test.ts
+++ b/packages/ai/test/google-antigravity-compaction.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+import * as AIError from "@oh-my-pi/pi-ai/error";
+import { streamGoogleGeminiCli } from "@oh-my-pi/pi-ai/providers/google-gemini-cli";
+import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const DAILY_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
+const SANDBOX_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
+const OVERSIZED_REQUEST = "Request payload size exceeds the limit of 30 MiB.";
+
+const model: Model<"google-gemini-cli"> = buildModel({
+	id: "gemini-3.6-flash",
+	name: "Gemini 3.6 Flash (Antigravity)",
+	api: "google-gemini-cli",
+	provider: "google-antigravity",
+	baseUrl: DAILY_ENDPOINT,
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1_048_576,
+	maxTokens: 32_000,
+});
+
+const context: Context = { messages: [{ role: "user", content: "too much history", timestamp: 1 }] };
+
+function endpointFromInput(input: Parameters<FetchImpl>[0]): string {
+	const url = input instanceof Request ? input.url : input.toString();
+	return url.startsWith(SANDBOX_ENDPOINT) ? SANDBOX_ENDPOINT : DAILY_ENDPOINT;
+}
+
+function sseError(code: number, message: string): Response {
+	return new Response(`data: ${JSON.stringify({ error: { code, status: "INVALID_ARGUMENT", message } })}\n\n`, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function streamOptions(fetch: FetchImpl) {
+	return {
+		apiKey: JSON.stringify({ token: "token", projectId: "project" }),
+		antigravityEndpointMode: "auto" as const,
+		fetch,
+	};
+}
+
+describe("Antigravity Cloud Code Assist oversized-request compaction signals", () => {
+	it("maps the daily endpoint's non-2xx JSON oversized-request error without empty-stream retry or sandbox fallback", async () => {
+		const endpoints: string[] = [];
+		const fetch: FetchImpl = async input => {
+			endpoints.push(endpointFromInput(input));
+			return new Response(
+				JSON.stringify({ error: { code: 400, status: "INVALID_ARGUMENT", message: OVERSIZED_REQUEST } }),
+				{ status: 400, headers: { "content-type": "application/json" } },
+			);
+		};
+
+		const stream = streamGoogleGeminiCli(model, context, streamOptions(fetch));
+		const result = await stream.result();
+
+		expect(endpoints).toEqual([DAILY_ENDPOINT]);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain(OVERSIZED_REQUEST);
+		expect(AIError.is(result.errorId, AIError.Flag.ContextOverflow)).toBe(true);
+		expect(result.errorId).toBe(AIError.create(AIError.Flag.ContextOverflow));
+		expect(AIError.isContextOverflow(result, model.contextWindow)).toBe(true);
+	});
+
+	it("maps the daily endpoint's SSE oversized-request error without empty-stream retry or sandbox fallback", async () => {
+		const endpoints: string[] = [];
+		const fetch: FetchImpl = async input => {
+			endpoints.push(endpointFromInput(input));
+			return sseError(400, OVERSIZED_REQUEST);
+		};
+
+		const stream = streamGoogleGeminiCli(model, context, streamOptions(fetch));
+		const result = await stream.result();
+
+		expect(endpoints).toEqual([DAILY_ENDPOINT]);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain(OVERSIZED_REQUEST);
+		expect(AIError.is(result.errorId, AIError.Flag.ContextOverflow)).toBe(true);
+		expect(result.errorId).toBe(AIError.create(AIError.Flag.ContextOverflow));
+		expect(AIError.isContextOverflow(result, model.contextWindow)).toBe(true);
+	});
+
+	it("fails over for a transient SSE error without misclassifying it as an overflow", async () => {
+		const endpoints: string[] = [];
+		const fetch: FetchImpl = async input => {
+			const endpoint = endpointFromInput(input);
+			endpoints.push(endpoint);
+			return sseError(503, "Cloud Code Assist backend temporarily unavailable.");
+		};
+
+		const stream = streamGoogleGeminiCli(model, context, streamOptions(fetch));
+		const result = await stream.result();
+
+		expect(endpoints).toEqual([DAILY_ENDPOINT, SANDBOX_ENDPOINT]);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("temporarily unavailable");
+		expect(AIError.is(result.errorId, AIError.Flag.Transient)).toBe(true);
+		expect(AIError.is(result.errorId, AIError.Flag.ContextOverflow)).toBe(false);
+		expect(AIError.isContextOverflow(result, model.contextWindow)).toBe(false);
+	});
+});

--- a/packages/ai/test/google-antigravity-compaction.test.ts
+++ b/packages/ai/test/google-antigravity-compaction.test.ts
@@ -5,7 +5,6 @@ import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
 const DAILY_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
-const SANDBOX_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
 const OVERSIZED_REQUEST = "Request payload size exceeds the limit of 30 MiB.";
 
 const model: Model<"google-gemini-cli"> = buildModel({
@@ -25,7 +24,7 @@ const context: Context = { messages: [{ role: "user", content: "too much history
 
 function endpointFromInput(input: Parameters<FetchImpl>[0]): string {
 	const url = input instanceof Request ? input.url : input.toString();
-	return url.startsWith(SANDBOX_ENDPOINT) ? SANDBOX_ENDPOINT : DAILY_ENDPOINT;
+	return url.startsWith(DAILY_ENDPOINT) ? DAILY_ENDPOINT : url;
 }
 
 function sseError(code: number, message: string): Response {
@@ -38,7 +37,6 @@ function sseError(code: number, message: string): Response {
 function streamOptions(fetch: FetchImpl) {
 	return {
 		apiKey: JSON.stringify({ token: "token", projectId: "project" }),
-		antigravityEndpointMode: "auto" as const,
 		fetch,
 	};
 }
@@ -62,7 +60,7 @@ describe("Antigravity Cloud Code Assist oversized-request compaction signals", (
 		expect(result.errorMessage).toContain(OVERSIZED_REQUEST);
 		expect(AIError.is(result.errorId, AIError.Flag.ContextOverflow)).toBe(true);
 		expect(result.errorId).toBe(AIError.create(AIError.Flag.ContextOverflow));
-		expect(AIError.isContextOverflow(result, model.contextWindow)).toBe(true);
+		expect(AIError.isContextOverflow(result, model.contextWindow ?? undefined)).toBe(true);
 	});
 
 	it("maps the daily endpoint's SSE oversized-request error without empty-stream retry or sandbox fallback", async () => {
@@ -80,10 +78,10 @@ describe("Antigravity Cloud Code Assist oversized-request compaction signals", (
 		expect(result.errorMessage).toContain(OVERSIZED_REQUEST);
 		expect(AIError.is(result.errorId, AIError.Flag.ContextOverflow)).toBe(true);
 		expect(result.errorId).toBe(AIError.create(AIError.Flag.ContextOverflow));
-		expect(AIError.isContextOverflow(result, model.contextWindow)).toBe(true);
+		expect(AIError.isContextOverflow(result, model.contextWindow ?? undefined)).toBe(true);
 	});
 
-	it("fails over for a transient SSE error without misclassifying it as an overflow", async () => {
+	it("reports a transient SSE error from the daily endpoint without misclassifying it as an overflow", async () => {
 		const endpoints: string[] = [];
 		const fetch: FetchImpl = async input => {
 			const endpoint = endpointFromInput(input);
@@ -94,11 +92,11 @@ describe("Antigravity Cloud Code Assist oversized-request compaction signals", (
 		const stream = streamGoogleGeminiCli(model, context, streamOptions(fetch));
 		const result = await stream.result();
 
-		expect(endpoints).toEqual([DAILY_ENDPOINT, SANDBOX_ENDPOINT]);
+		expect(endpoints).toEqual([DAILY_ENDPOINT]);
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toContain("temporarily unavailable");
 		expect(AIError.is(result.errorId, AIError.Flag.Transient)).toBe(true);
 		expect(AIError.is(result.errorId, AIError.Flag.ContextOverflow)).toBe(false);
-		expect(AIError.isContextOverflow(result, model.contextWindow)).toBe(false);
+		expect(AIError.isContextOverflow(result, model.contextWindow ?? undefined)).toBe(false);
 	});
 });

--- a/packages/ai/test/google-empty-response-retry.test.ts
+++ b/packages/ai/test/google-empty-response-retry.test.ts
@@ -82,7 +82,6 @@ const cliModel: Model<"google-gemini-cli"> = buildModel({
 });
 
 const ANTIGRAVITY_DAILY_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
-const ANTIGRAVITY_SANDBOX_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
 
 const antigravityModel: Model<"google-gemini-cli"> = buildModel({
 	...cliModel,
@@ -97,7 +96,7 @@ function withResponseUrl(response: Response, endpoint: string): Response {
 
 function endpointFromInput(input: Parameters<FetchImpl>[0]): string {
 	const url = input instanceof Request ? input.url : input.toString();
-	return url.startsWith(ANTIGRAVITY_SANDBOX_ENDPOINT) ? ANTIGRAVITY_SANDBOX_ENDPOINT : ANTIGRAVITY_DAILY_ENDPOINT;
+	return url.startsWith(ANTIGRAVITY_DAILY_ENDPOINT) ? ANTIGRAVITY_DAILY_ENDPOINT : url;
 }
 
 describe("Google empty-response retry (public + Vertex path)", () => {
@@ -297,58 +296,28 @@ describe("Google empty-response retry (Cloud Code Assist path)", () => {
 		expect(events.filter(e => e.type === "toolcall_start")).toHaveLength(1);
 	});
 
-	it("fails over to the sandbox endpoint after daily returns only empty successful streams", async () => {
+	it("keeps empty-response retries on the daily endpoint without sandbox fallback", async () => {
 		const requestedEndpoints: string[] = [];
 		const fetchMock: FetchImpl = async input => {
 			const endpoint = endpointFromInput(input);
 			requestedEndpoints.push(endpoint);
-			const response = endpoint === ANTIGRAVITY_SANDBOX_ENDPOINT ? sse(ccaChunk("Recovered.")) : sse(ccaChunk(""));
-			return withResponseUrl(response, endpoint);
+			return withResponseUrl(sse(ccaChunk("")), endpoint);
 		};
 
 		const stream = streamGoogleGeminiCli(antigravityModel, context, {
 			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
-			antigravityEndpointMode: "auto",
 			fetch: fetchMock,
 		});
-		const { starts } = await drain(stream);
 		const result = await stream.result();
 
 		expect(requestedEndpoints).toEqual([
 			ANTIGRAVITY_DAILY_ENDPOINT,
 			ANTIGRAVITY_DAILY_ENDPOINT,
 			ANTIGRAVITY_DAILY_ENDPOINT,
-			ANTIGRAVITY_SANDBOX_ENDPOINT,
 		]);
-		expect(starts).toBe(1);
-		expect(result.stopReason).toBe("stop");
-		expect(textOf(result)).toBe("Recovered.");
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("empty response");
 	});
-
-	for (const { mode, endpoint } of [
-		{ mode: "production", endpoint: ANTIGRAVITY_DAILY_ENDPOINT },
-		{ mode: "sandbox", endpoint: ANTIGRAVITY_SANDBOX_ENDPOINT },
-	] as const) {
-		it(`keeps empty-response retries on the selected ${mode} endpoint`, async () => {
-			const requestedEndpoints: string[] = [];
-			const fetchMock: FetchImpl = async input => {
-				const requestedEndpoint = endpointFromInput(input);
-				requestedEndpoints.push(requestedEndpoint);
-				return withResponseUrl(sse(ccaChunk("")), requestedEndpoint);
-			};
-
-			const stream = streamGoogleGeminiCli(antigravityModel, context, {
-				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
-				antigravityEndpointMode: mode,
-				fetch: fetchMock,
-			});
-			const result = await stream.result();
-
-			expect(requestedEndpoints).toEqual([endpoint, endpoint, endpoint]);
-			expect(result.stopReason).toBe("error");
-			expect(result.errorMessage).toContain("empty response");
-		});
-	}
 
 	for (const { name, chunk, errorText } of [
 		{
@@ -384,7 +353,6 @@ describe("Google empty-response retry (Cloud Code Assist path)", () => {
 
 			const stream = streamGoogleGeminiCli(antigravityModel, context, {
 				apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
-				antigravityEndpointMode: "auto",
 				fetch: fetchMock,
 			});
 			const result = await stream.result();
@@ -420,7 +388,6 @@ describe("Google empty-response retry (Cloud Code Assist path)", () => {
 
 		const stream = streamGoogleGeminiCli(antigravityModel, context, {
 			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
-			antigravityEndpointMode: "auto",
 			fetch: fetchMock,
 		});
 		const result = await stream.result();
@@ -443,7 +410,6 @@ describe("Google empty-response retry (Cloud Code Assist path)", () => {
 
 		const stream = streamGoogleGeminiCli(antigravityModel, context, {
 			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
-			antigravityEndpointMode: "auto",
 			fetch: fetchMock,
 		});
 		const { starts } = await drain(stream);

--- a/packages/ai/test/google-gemini-cli-3x-thinking.test.ts
+++ b/packages/ai/test/google-gemini-cli-3x-thinking.test.ts
@@ -3,6 +3,9 @@ import { Effort, type FetchImpl } from "@oh-my-pi/pi-ai";
 import { streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { Context, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { applyGeneratedModelPolicies } from "@oh-my-pi/pi-catalog/model-thinking";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import agyGemini36FlashHigh from "./fixtures/antigravity-gemini-3.6-flash-thinking.json" with { type: "json" };
 
 interface GeminiCliThinkingConfig {
 	thinkingLevel?: string;
@@ -15,6 +18,7 @@ interface CapturedRequestBody {
 		generationConfig?: {
 			thinkingConfig?: GeminiCliThinkingConfig;
 		};
+		labels?: { model_enum?: string };
 	};
 }
 
@@ -31,6 +35,37 @@ function createModel(id: string): Model<"google-gemini-cli"> {
 		contextWindow: 1_000_000,
 		maxTokens: 65_536,
 	});
+}
+
+function createAntigravityGemini36FlashModel(): Model<"google-gemini-cli"> {
+	const models: ModelSpec<"google-gemini-cli">[] = [
+		{
+			id: "gemini-3.6-flash",
+			name: "Gemini 3.6 Flash",
+			api: "google-gemini-cli",
+			provider: "google-antigravity",
+			baseUrl: "https://example.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1_048_576,
+			maxTokens: 65_536,
+			requestModelId: "gemini-3.6-flash-low",
+			thinking: {
+				mode: "google-level",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
+				requiresEffort: true,
+				effortRouting: {
+					[Effort.Minimal]: "gemini-3.6-flash-low",
+					[Effort.Low]: "gemini-3.6-flash-low",
+					[Effort.Medium]: "gemini-3.6-flash-medium",
+					[Effort.High]: "gemini-3.6-flash-high",
+				},
+			},
+		},
+	];
+	applyGeneratedModelPolicies(models);
+	return buildModel(models[0]!);
 }
 
 const context: Context = {
@@ -137,5 +172,26 @@ describe("google-gemini-cli Gemini 3.x thinking mapping", () => {
 		const thinking = extractThinking(requestBody);
 		expect(thinking?.thinkingLevel).toBeUndefined();
 		expect(thinking?.thinkingBudget).toBeDefined();
+	});
+
+	it("matches agy's captured Gemini 3.6 Flash high-effort Cloud Code Assist payload", async () => {
+		let requestBody: string | undefined;
+		const fetchMock = createFetchMock(body => {
+			requestBody = body;
+		});
+
+		const stream = streamSimple(createAntigravityGemini36FlashModel(), context, {
+			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+			reasoning: Effort.High,
+			fetch: fetchMock,
+		});
+		await stream.result();
+
+		const request = JSON.parse(requestBody ?? "{}") as CapturedRequestBody;
+		expect(request.request?.generationConfig?.thinkingConfig).toEqual(
+			agyGemini36FlashHigh.generationConfig.thinkingConfig,
+		);
+		expect(request.request?.generationConfig?.thinkingConfig?.thinkingLevel).toBeUndefined();
+		expect(request.request?.labels?.model_enum).toBe(agyGemini36FlashHigh.labels.model_enum);
 	});
 });

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Gemini 3.6 Flash requests to Antigravity Cloud Code Assist sending `thinkingLevel` instead of the endpoint's required per-tier `thinkingBudget`, which could yield repeated empty responses.
+
 ## [17.1.8] - 2026-07-28
 
 ### Added

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -19,6 +19,7 @@ import { ANTIGRAVITY_PRIMARY_ENDPOINT, fetchAntigravityDiscoveryModels } from ".
 import { fetchCodexModels } from "../src/discovery/codex";
 import { buildGitLabDuoWorkflowFallbackModel } from "../src/discovery/gitlab-duo-workflow";
 import { createModelManager } from "../src/model-manager";
+import { applyGeneratedModelPolicies as applyGeneratedThinkingPolicies } from "../src/model-thinking";
 import prevModelsJson from "../src/models.json" with { type: "json" };
 import { toModelSpec } from "../src/provider-models/bundled-references";
 import {
@@ -661,6 +662,7 @@ async function generateModels() {
 	// entries are already collapsed (rebake skips them); this pass folds
 	// previous-snapshot raw members into their logical families.
 	allModels = collapseEffortVariantsAcrossProviders(allModels);
+	applyGeneratedThinkingPolicies(allModels);
 	// Fill remaining null endpoint limits from each model's canonical-family
 	// reference. Runs last so canonical ids and explicit policy limits are final.
 	applyCanonicalLimitFallback(allModels);

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -9,7 +9,9 @@ import type { Api, Model, ModelSpec } from "./types";
 // Rows persist ModelSpec JSON (sparse `compat`, never the resolved record);
 // the model manager rebuilds via `buildModel` on load. Request headers are
 // intentionally omitted: arbitrary provider-defined header names can carry
-// credentials. v12 invalidates Kimi Code rows carrying the blanket
+// credentials. v13 invalidates Antigravity Gemini 3.6 rows that used the
+// Cloud Code Assist-incompatible `thinking.mode: "google-level"`; v12 invalidates
+// Kimi Code rows carrying the blanket
 // maxTokens: 32000 that predate per-family output caps (k3/k3-256k -> 131072,
 // kimi-for-coding[-highspeed] -> 32768, #6711); v11 invalidates rows that may
 // persist derived computer-use
@@ -22,7 +24,7 @@ import type { Api, Model, ModelSpec } from "./types";
 // retired unknown-limit sentinels (222222/8888); v5 invalidated rows predating
 // effort-tier variant collapsing (raw `-low`/`-high`/`-thinking` member ids);
 // v4 dropped the pre-efforts ThinkingConfig shape.
-const CACHE_SCHEMA_VERSION = 12;
+const CACHE_SCHEMA_VERSION = 13;
 const HEADER_RESTORE_VERSION = 1;
 
 interface CacheRow {

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -109,6 +109,13 @@ const MIMO_REASONING_EFFORT_MAP: Readonly<EffortMap> = {
 	[Effort.XHigh]: "high",
 };
 
+const ANTIGRAVITY_GEMINI_36_FLASH_EFFORT_BUDGETS: Readonly<Partial<Record<Effort, number>>> = {
+	[Effort.Minimal]: 1000,
+	[Effort.Low]: 1000,
+	[Effort.Medium]: 4000,
+	[Effort.High]: 10000,
+};
+
 const MINIMAX_ANTHROPIC_ADAPTIVE_EFFORT_MAP: Readonly<EffortMap> = {
 	[Effort.Low]: "adaptive",
 	[Effort.Medium]: "adaptive",
@@ -118,6 +125,23 @@ const MINIMAX_ANTHROPIC_ADAPTIVE_EFFORT_MAP: Readonly<EffortMap> = {
 // ---------------------------------------------------------------------------
 // Build-time derivation (buildModel + catalog generator only)
 // ---------------------------------------------------------------------------
+
+/**
+ * Apply generated thinking policies that depend on the final, collapsed model
+ * identity. This runs after variant collapse so it cannot be overwritten by a
+ * family-level projection.
+ */
+export function applyGeneratedModelPolicies(models: ModelSpec<Api>[]): void {
+	for (const model of models) {
+		if (model.provider !== "google-antigravity" || model.id !== "gemini-3.6-flash") continue;
+		if (!model.thinking) continue;
+		model.thinking = {
+			...model.thinking,
+			mode: "budget",
+			effortBudgets: ANTIGRAVITY_GEMINI_36_FLASH_EFFORT_BUDGETS,
+		};
+	}
+}
 
 /**
  * Resolve the canonical thinking metadata for a spec. Called exactly once per

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -42,6 +42,7 @@ import type {
 	ResolvedOpenAIResponsesCompat,
 	ThinkingConfig,
 } from "./types";
+import { GEMINI_3_FLASH_FAMILY_BUDGETS } from "./variant-collapse";
 
 /**
  * Runtime helpers read baked metadata only, so they accept both pre-build
@@ -109,13 +110,6 @@ const MIMO_REASONING_EFFORT_MAP: Readonly<EffortMap> = {
 	[Effort.XHigh]: "high",
 };
 
-const ANTIGRAVITY_GEMINI_36_FLASH_EFFORT_BUDGETS: Readonly<Partial<Record<Effort, number>>> = {
-	[Effort.Minimal]: 1000,
-	[Effort.Low]: 1000,
-	[Effort.Medium]: 4000,
-	[Effort.High]: 10000,
-};
-
 const MINIMAX_ANTHROPIC_ADAPTIVE_EFFORT_MAP: Readonly<EffortMap> = {
 	[Effort.Low]: "adaptive",
 	[Effort.Medium]: "adaptive",
@@ -138,7 +132,7 @@ export function applyGeneratedModelPolicies(models: ModelSpec<Api>[]): void {
 		model.thinking = {
 			...model.thinking,
 			mode: "budget",
-			effortBudgets: ANTIGRAVITY_GEMINI_36_FLASH_EFFORT_BUDGETS,
+			effortBudgets: GEMINI_3_FLASH_FAMILY_BUDGETS,
 		};
 	}
 }

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -20870,13 +20870,19 @@
 			"maxTokens": 65536,
 			"requestModelId": "gemini-3.6-flash-low",
 			"thinking": {
-				"mode": "google-level",
+				"mode": "budget",
 				"efforts": [
 					"minimal",
 					"low",
 					"medium",
 					"high"
 				],
+				"effortBudgets": {
+					"minimal": 1000,
+					"low": 1000,
+					"medium": 4000,
+					"high": 10000
+				},
 				"requiresEffort": true,
 				"effortRouting": {
 					"minimal": "gemini-3.6-flash-low",

--- a/packages/catalog/src/variant-collapse.ts
+++ b/packages/catalog/src/variant-collapse.ts
@@ -209,12 +209,6 @@ function devinGpt56Families(variant: "luna" | "sol" | "terra", name: string): re
 const GEMINI_3_FLASH_FAMILY_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
 const GEMINI_3_PRO_FAMILY_EFFORTS: readonly Effort[] = [Effort.Low, Effort.High];
 
-/**
- * Antigravity Cloud Code Assist sends an explicit `thinkingBudget` per tier
- * (verified against captured `daily-cloudcode-pa` requests). Flash uses round
- * budgets; Pro offsets every budget by +1. Minimal mirrors Low (the Antigravity
- * UI exposes Low/Medium/High only) so the effort stays selectable.
- */
 const GEMINI_3_FLASH_FAMILY_BUDGETS: Readonly<Partial<Record<Effort, number>>> = {
 	[Effort.Minimal]: 1000,
 	[Effort.Low]: 1000,
@@ -228,11 +222,11 @@ const GEMINI_3_PRO_FAMILY_BUDGETS: Readonly<Partial<Record<Effort, number>>> = {
 
 /**
  * Cloud Code Assist's legacy Gemini 3.5 Flash and 3.1 Pro families use
- * different thinking transports: `google-antigravity` (daily-cloudcode-pa)
- * sends captured `thinkingBudget` values, while `google-gemini-cli`
- * (cloudcode-pa) follows the official Gemini CLI and uses `thinkingLevel`.
- * Gemini 3.6 follows the same endpoint-specific transport: Antigravity uses
- * captured thinking budgets, while the official Gemini CLI uses thinking levels.
+ * different thinking transports. The current Antigravity route is
+ * `daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse`,
+ * which serializes per-tier `thinkingBudget`; the official Gemini CLI's
+ * cloudcode-pa route uses `thinkingLevel`. Gemini 3.6 follows that same
+ * endpoint-specific split.
  */
 function geminiFlashFamily(mode: "budget" | "google-level"): EffortVariantFamily {
 	const budget = mode === "budget";
@@ -265,23 +259,28 @@ function geminiFlashFamily(mode: "budget" | "google-level"): EffortVariantFamily
 	};
 }
 
-const GEMINI_36_FLASH_FAMILY: EffortVariantFamily = {
-	id: "gemini-3.6-flash",
-	name: "Gemini 3.6 Flash",
-	members: ["gemini-3.6-flash-low", "gemini-3.6-flash-medium", "gemini-3.6-flash-high", "gemini-3.6-flash-tiered"],
-	routing: {
-		[Effort.Minimal]: "gemini-3.6-flash-low",
-		[Effort.Low]: "gemini-3.6-flash-low",
-		[Effort.Medium]: "gemini-3.6-flash-medium",
-		[Effort.High]: "gemini-3.6-flash-high",
-	},
-	thinking: {
-		mode: "budget",
-		efforts: GEMINI_3_FLASH_FAMILY_EFFORTS,
-		effortBudgets: GEMINI_3_FLASH_FAMILY_BUDGETS,
-		requiresEffort: true,
-	},
-};
+function gemini36FlashFamily(mode: "budget" | "google-level"): EffortVariantFamily {
+	const budget = mode === "budget";
+	return {
+		id: "gemini-3.6-flash",
+		name: "Gemini 3.6 Flash",
+		members: ["gemini-3.6-flash-low", "gemini-3.6-flash-medium", "gemini-3.6-flash-high", "gemini-3.6-flash-tiered"],
+		routing: {
+			[Effort.Minimal]: "gemini-3.6-flash-low",
+			[Effort.Low]: "gemini-3.6-flash-low",
+			[Effort.Medium]: "gemini-3.6-flash-medium",
+			[Effort.High]: "gemini-3.6-flash-high",
+		},
+		thinking: budget
+			? {
+					mode: "budget",
+					efforts: GEMINI_3_FLASH_FAMILY_EFFORTS,
+					effortBudgets: GEMINI_3_FLASH_FAMILY_BUDGETS,
+					requiresEffort: true,
+				}
+			: { mode: "google-level", efforts: GEMINI_3_FLASH_FAMILY_EFFORTS, requiresEffort: true },
+	};
+}
 
 function geminiProFamily(mode: "budget" | "google-level"): EffortVariantFamily {
 	const budget = mode === "budget";
@@ -365,13 +364,18 @@ const SHARED_CCA_FAMILIES: readonly EffortVariantFamily[] = [
 
 /** `google-antigravity` Gemini families, using each generation's native transport. */
 export const ANTIGRAVITY_VARIANT_COLLAPSE_TABLE: VariantCollapseTable = {
-	families: [GEMINI_36_FLASH_FAMILY, geminiFlashFamily("budget"), geminiProFamily("budget"), ...SHARED_CCA_FAMILIES],
+	families: [
+		gemini36FlashFamily("budget"),
+		geminiFlashFamily("budget"),
+		geminiProFamily("budget"),
+		...SHARED_CCA_FAMILIES,
+	],
 };
 
 /** `google-gemini-cli` Gemini families on the official CLI's level transport. */
 export const GEMINI_CLI_VARIANT_COLLAPSE_TABLE: VariantCollapseTable = {
 	families: [
-		GEMINI_36_FLASH_FAMILY,
+		gemini36FlashFamily("google-level"),
 		geminiFlashFamily("google-level"),
 		geminiProFamily("google-level"),
 		...SHARED_CCA_FAMILIES,

--- a/packages/catalog/src/variant-collapse.ts
+++ b/packages/catalog/src/variant-collapse.ts
@@ -209,7 +209,7 @@ function devinGpt56Families(variant: "luna" | "sol" | "terra", name: string): re
 const GEMINI_3_FLASH_FAMILY_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
 const GEMINI_3_PRO_FAMILY_EFFORTS: readonly Effort[] = [Effort.Low, Effort.High];
 
-const GEMINI_3_FLASH_FAMILY_BUDGETS: Readonly<Partial<Record<Effort, number>>> = {
+export const GEMINI_3_FLASH_FAMILY_BUDGETS: Readonly<Partial<Record<Effort, number>>> = {
 	[Effort.Minimal]: 1000,
 	[Effort.Low]: 1000,
 	[Effort.Medium]: 4000,

--- a/packages/catalog/src/variant-collapse.ts
+++ b/packages/catalog/src/variant-collapse.ts
@@ -231,8 +231,8 @@ const GEMINI_3_PRO_FAMILY_BUDGETS: Readonly<Partial<Record<Effort, number>>> = {
  * different thinking transports: `google-antigravity` (daily-cloudcode-pa)
  * sends captured `thinkingBudget` values, while `google-gemini-cli`
  * (cloudcode-pa) follows the official Gemini CLI and uses `thinkingLevel`.
- * Gemini 3.6 exposes one wire id per level and uses `thinkingLevel` on both
- * endpoints.
+ * Gemini 3.6 follows the same endpoint-specific transport: Antigravity uses
+ * captured thinking budgets, while the official Gemini CLI uses thinking levels.
  */
 function geminiFlashFamily(mode: "budget" | "google-level"): EffortVariantFamily {
 	const budget = mode === "budget";
@@ -276,8 +276,9 @@ const GEMINI_36_FLASH_FAMILY: EffortVariantFamily = {
 		[Effort.High]: "gemini-3.6-flash-high",
 	},
 	thinking: {
-		mode: "google-level",
+		mode: "budget",
 		efforts: GEMINI_3_FLASH_FAMILY_EFFORTS,
+		effortBudgets: GEMINI_3_FLASH_FAMILY_BUDGETS,
 		requiresEffort: true,
 	},
 };

--- a/packages/catalog/src/wire/gemini-headers.ts
+++ b/packages/catalog/src/wire/gemini-headers.ts
@@ -63,6 +63,9 @@ export const ANTIGRAVITY_MODEL_WIRE_PROFILES: Readonly<Record<string, Antigravit
 	"gemini-3-flash-agent": { modelEnum: "MODEL_PLACEHOLDER_M132", maxOutputTokens: 65536 },
 	"gemini-3.1-pro-low": { modelEnum: "MODEL_PLACEHOLDER_M36", maxOutputTokens: 65535 },
 	"gemini-pro-agent": { modelEnum: "MODEL_PLACEHOLDER_M16", maxOutputTokens: 65535 },
+	"gemini-3.6-flash-low": { modelEnum: "MODEL_PLACEHOLDER_M73", maxOutputTokens: 65536 },
+	"gemini-3.6-flash-medium": { modelEnum: "MODEL_PLACEHOLDER_M72", maxOutputTokens: 65536 },
+	"gemini-3.6-flash-high": { modelEnum: "MODEL_PLACEHOLDER_M71", maxOutputTokens: 65536 },
 	// Claude on `daily-cloudcode-pa` rejects `maxOutputTokens > 64000` with a
 	// 400 (`Request contains an invalid argument`). The model_enum label is
 	// untracked for these ids; the backend does not require it.

--- a/packages/catalog/test/variant-collapse.test.ts
+++ b/packages/catalog/test/variant-collapse.test.ts
@@ -150,6 +150,40 @@ describe("collapseEffortVariants", () => {
 		expect(resolveWireModelId(model, Effort.High)).toBe("gemini-3.6-flash-high");
 	});
 
+	it("collapses Gemini 3.6 Flash tiers on the gemini-cli level transport (no effortBudgets)", () => {
+		const out = collapseEffortVariants(
+			[
+				memberSpec("gemini-3.6-flash-high"),
+				memberSpec("gemini-3.6-flash-low"),
+				memberSpec("gemini-3.6-flash-medium"),
+				memberSpec("gemini-3.6-flash-tiered"),
+			],
+			GEMINI_CLI_VARIANT_COLLAPSE_TABLE,
+		);
+
+		expect(out).toHaveLength(1);
+		const flash = out[0];
+		expect(flash?.id).toBe("gemini-3.6-flash");
+		expect(flash?.requestModelId).toBe("gemini-3.6-flash-low");
+		// The official Gemini CLI transport speaks thinkingLevel, not
+		// thinkingBudget, so the collapsed spec carries no effortBudgets.
+		expect(flash?.thinking).toEqual({
+			mode: "google-level",
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
+			requiresEffort: true,
+			effortRouting: {
+				minimal: "gemini-3.6-flash-low",
+				low: "gemini-3.6-flash-low",
+				medium: "gemini-3.6-flash-medium",
+				high: "gemini-3.6-flash-high",
+			},
+		});
+		expect(flash?.thinking?.effortBudgets).toBeUndefined();
+
+		const model = buildModel(flash as ModelSpec<"google-gemini-cli">);
+		expect(resolveWireModelId(model, Effort.High)).toBe("gemini-3.6-flash-high");
+	});
+
 	it("drops routes whose target member is absent", () => {
 		const out = collapseEffortVariants(
 			[memberSpec("gemini-3.5-flash-extra-low")],

--- a/packages/catalog/test/variant-collapse.test.ts
+++ b/packages/catalog/test/variant-collapse.test.ts
@@ -126,8 +126,14 @@ describe("collapseEffortVariants", () => {
 		expect(flash?.name).toBe("Gemini 3.6 Flash");
 		expect(flash?.requestModelId).toBe("gemini-3.6-flash-low");
 		expect(flash?.thinking).toEqual({
-			mode: "google-level",
+			mode: "budget",
 			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
+			effortBudgets: {
+				minimal: 1000,
+				low: 1000,
+				medium: 4000,
+				high: 10000,
+			},
 			requiresEffort: true,
 			effortRouting: {
 				minimal: "gemini-3.6-flash-low",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the independently selectable `antigravity` web-search provider. It uses only google-antigravity OAuth and the captured daily `generateContent` Google Search grounding executor, preserves grounded citations, and defaults to `gemini-3.6-flash-low` (configurable with `providers.webSearchAntigravityModel` or `ANTIGRAVITY_SEARCH_MODEL`).
+
+### Changed
+
+- Separated Gemini and Antigravity web-search credential/model ownership and removed the unobserved Antigravity sandbox endpoint-mode fallback from search, chat, and image routing.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4825,32 +4825,14 @@ export const SETTINGS_SCHEMA = {
 			description: "Model ID for Gemini Google Search grounding. Defaults to gemini-2.5-flash.",
 		},
 	},
-	"providers.antigravityEndpoint": {
-		type: "enum",
-		values: ["auto", "production", "sandbox"] as const,
-		default: "auto",
+	"providers.webSearchAntigravityModel": {
+		type: "string",
+		default: undefined,
 		ui: {
 			tab: "providers",
 			group: "Services",
-			label: "Antigravity Endpoint Mode",
-			description: "Endpoint routing strategy for google-antigravity providers (chat, search, image, discovery)",
-			options: [
-				{
-					value: "auto",
-					label: "Auto",
-					description: "Try production endpoint, fail over to sandbox on 5xx/429",
-				},
-				{
-					value: "production",
-					label: "Production Only",
-					description: "Force production endpoint only",
-				},
-				{
-					value: "sandbox",
-					label: "Sandbox Only",
-					description: "Force sandbox endpoint only",
-				},
-			],
+			label: "Antigravity web_search model",
+			description: "Model ID for Antigravity Google Search grounding. Defaults to gemini-3.6-flash-low.",
 		},
 	},
 	"providers.imageOrder": {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7917,14 +7917,7 @@ export class AgentSession {
 		if (!authStorage.fetchUsageReports) return null;
 		return authStorage.fetchUsageReports({
 			baseUrlResolver: provider => {
-				if (provider === "google-antigravity") {
-					const mode = this.settings.get("providers.antigravityEndpoint");
-					if (mode === "sandbox") {
-						return "https://daily-cloudcode-pa.sandbox.googleapis.com";
-					} else if (mode === "production") {
-						return "https://daily-cloudcode-pa.googleapis.com";
-					}
-				}
+				if (provider === "google-antigravity") return "https://daily-cloudcode-pa.googleapis.com";
 				return this.#modelRegistry.getProviderBaseUrl?.(provider);
 			},
 			signal,

--- a/packages/coding-agent/src/session/session-provider-boundary.ts
+++ b/packages/coding-agent/src/session/session-provider-boundary.ts
@@ -144,13 +144,10 @@ export class SessionProviderBoundary {
 			openrouterRoutingPreset !== "default" && options.openrouterVariant === undefined
 				? openrouterRoutingPreset
 				: undefined;
-		const antigravityEndpointMode =
-			provider === "google-antigravity" ? this.#host.settings.get("providers.antigravityEndpoint") : undefined;
 
 		const preparedOptions: SimpleStreamOptions = {
 			...options,
 			...(openrouterVariant !== undefined && { openrouterVariant }),
-			...(antigravityEndpointMode !== undefined && { antigravityEndpointMode }),
 			maxInFlightRequests: validateProviderMaxInFlightRequests(
 				options.maxInFlightRequests ?? this.#host.settings.get("providers.maxInFlightRequests"),
 			),

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -32,7 +32,6 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 		const openrouterRoutingPreset = settings.get("providers.openrouterVariant");
 		const openrouterVariant =
 			openrouterRoutingPreset && openrouterRoutingPreset !== "default" ? openrouterRoutingPreset : undefined;
-		const antigravityEndpointMode = settings.get("providers.antigravityEndpoint");
 		const textVerbosity =
 			model.api === "openai-codex-responses" || model.api === "openai-responses"
 				? settings.get("textVerbosity")
@@ -54,7 +53,6 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 		const merged: SimpleStreamOptions = {
 			...streamOptions,
 			openrouterVariant: streamOptions?.openrouterVariant ?? openrouterVariant,
-			antigravityEndpointMode: streamOptions?.antigravityEndpointMode ?? antigravityEndpointMode,
 			textVerbosity: streamOptions?.textVerbosity ?? textVerbosity,
 			streamFirstEventTimeoutMs: streamOptions?.streamFirstEventTimeoutMs ?? streamFirstEventTimeoutMs,
 			streamIdleTimeoutMs: streamOptions?.streamIdleTimeoutMs ?? streamIdleTimeoutMs,

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -23,7 +23,6 @@ import {
 import { type } from "arktype";
 import packageJson from "../../package.json" with { type: "json" };
 import { isAuthenticated, type ModelRegistry } from "../config/model-registry";
-import { settings } from "../config/settings";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import { ohMyPiXAIUserAgent, resolveXAIHttpCredentials } from "../lib/xai-http";
 import imageGenDescription from "../prompts/tools/image-gen.md" with { type: "text" };
@@ -41,7 +40,6 @@ const OPENAI_IMAGE_OUTPUT_FORMAT = "webp";
 const OPENAI_IMAGE_MIME_TYPE = "image/webp";
 
 const DEFAULT_ANTIGRAVITY_ENDPOINT_PROD = "https://daily-cloudcode-pa.googleapis.com";
-const DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX = "https://daily-cloudcode-pa.sandbox.googleapis.com";
 const IMAGE_SYSTEM_INSTRUCTION =
 	"You are an AI image generator. Generate images based on user descriptions. Focus on creating high-quality, visually appealing images that match the user's request.";
 
@@ -1233,72 +1231,34 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 									resolvedImages,
 								);
 
-								let endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD, DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
-								try {
-									const mode = settings.get("providers.antigravityEndpoint");
-									if (mode === "production") {
-										endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD];
-									} else if (mode === "sandbox") {
-										endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
-									}
-								} catch {
-									// Ignored
-								}
-
-								let resp: Response | undefined;
-								let lastError: Error | undefined;
-
-								for (let i = 0; i < endpoints.length; i++) {
-									const endpoint = endpoints[i];
-									const isLastEndpoint = i === endpoints.length - 1;
+								const resp = await fetchImpl(
+									`${DEFAULT_ANTIGRAVITY_ENDPOINT_PROD}/v1internal:streamGenerateContent?alt=sse`,
+									{
+										method: "POST",
+										headers: {
+											Authorization: `Bearer ${bearer}`,
+											"Content-Type": "application/json",
+											Accept: "text/event-stream",
+											"User-Agent": getAntigravityUserAgent(),
+										},
+										body: JSON.stringify(requestBody),
+										signal: requestSignal,
+									},
+								);
+								if (!resp.ok) {
+									const errorText = await resp.text();
+									let message = errorText;
 									try {
-										resp = await fetchImpl(`${endpoint}/v1internal:streamGenerateContent?alt=sse`, {
-											method: "POST",
-											headers: {
-												Authorization: `Bearer ${bearer}`,
-												"Content-Type": "application/json",
-												Accept: "text/event-stream",
-												"User-Agent": getAntigravityUserAgent(),
-											},
-											body: JSON.stringify(requestBody),
-											signal: requestSignal,
-										});
-
-										if (resp.ok) {
-											break;
-										}
-
-										const errorText = await resp.text();
-										let message = errorText;
-										try {
-											const parsedErr = JSON.parse(errorText) as { error?: { message?: string } };
-											message = parsedErr.error?.message ?? message;
-										} catch {
-											// Keep raw text.
-										}
-
-										lastError = new ProviderHttpError(
-											`Antigravity image request failed (${resp.status}): ${message}`,
-											resp.status,
-											{ headers: resp.headers },
-										);
-
-										if (resp.status === 429 || (resp.status >= 500 && resp.status < 600)) {
-											if (!isLastEndpoint) {
-												continue;
-											}
-										}
-										break;
-									} catch (error) {
-										lastError = error as Error;
-										if (isLastEndpoint) {
-											break;
-										}
+										const parsedErr = JSON.parse(errorText) as { error?: { message?: string } };
+										message = parsedErr.error?.message ?? message;
+									} catch {
+										// Keep raw text.
 									}
-								}
-
-								if (!resp?.ok) {
-									throw lastError ?? new Error("Antigravity image generation failed");
+									throw new ProviderHttpError(
+										`Antigravity image request failed (${resp.status}): ${message}`,
+										resp.status,
+										{ headers: resp.headers },
+									);
 								}
 
 								return resp;

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -147,21 +147,18 @@ async function executeSearch(
 
 	const parsedQuery = parseSearchQuery(params.query);
 
-	// Invariant across providers; read once and tolerate an uninitialized
-	// Settings singleton (e.g. `omp q ...` CLI path, unit tests) so the
-	// provider-fallback loop never aborts before any provider runs.
-	let antigravityEndpointMode: "auto" | "production" | "sandbox" | undefined;
-	try {
-		antigravityEndpointMode = settings.get("providers.antigravityEndpoint");
-	} catch {
-		antigravityEndpointMode = undefined;
-	}
-
 	let geminiModel: string | undefined;
 	try {
 		geminiModel = settings.get("providers.webSearchGeminiModel");
 	} catch {
 		geminiModel = undefined;
+	}
+
+	let antigravityModel: string | undefined;
+	try {
+		antigravityModel = settings.get("providers.webSearchAntigravityModel");
+	} catch {
+		antigravityModel = undefined;
 	}
 
 	const failures: Array<{ provider: Pick<SearchProvider, "id" | "label">; error: unknown }> = [];
@@ -199,8 +196,8 @@ async function executeSearch(
 				authStorage,
 				modelRegistry,
 				sessionId,
-				antigravityEndpointMode,
 				geminiModel,
+				antigravityModel,
 			});
 
 			// Lenient constraint pass over whatever the provider returned: enforce

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -34,6 +34,11 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: SEARCH_PROVIDER_LABELS.gemini,
 		load: async () => new (await import("./providers/gemini")).GeminiProvider(),
 	},
+	antigravity: {
+		id: "antigravity",
+		label: SEARCH_PROVIDER_LABELS.antigravity,
+		load: async () => new (await import("./providers/antigravity")).AntigravityProvider(),
+	},
 	anthropic: {
 		id: "anthropic",
 		label: SEARCH_PROVIDER_LABELS.anthropic,

--- a/packages/coding-agent/src/web/search/providers/antigravity.ts
+++ b/packages/coding-agent/src/web/search/providers/antigravity.ts
@@ -1,0 +1,183 @@
+import { type AuthStorage, type FetchImpl, withOAuthAccess } from "@oh-my-pi/pi-ai";
+import { ANTIGRAVITY_SYSTEM_INSTRUCTION, getAntigravityUserAgent } from "@oh-my-pi/pi-catalog/wire/gemini-headers";
+import { fetchWithRetry } from "@oh-my-pi/pi-utils";
+import { formatQuery, GOOGLE_QUERY_SYNTAX, parseSearchQuery, type StructuredQuery } from "../query";
+import type { SearchResponse } from "../types";
+import { SearchProviderError } from "../types";
+import type { SearchParams } from "./base";
+import { SearchProvider } from "./base";
+import { type GeminiGroundedResponse, parseGeminiGroundedResponse } from "./gemini-grounding";
+import { classifyProviderHttpError, withHardTimeout } from "./utils";
+
+const ANTIGRAVITY_OAUTH_PROVIDER = "google-antigravity";
+const ANTIGRAVITY_DAILY_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
+const DEFAULT_MODEL = "gemini-3.6-flash-low";
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+const RATE_LIMIT_BUDGET_MS = 5 * 60 * 1000;
+
+export interface AntigravitySearchParams {
+	query: string;
+	parsedQuery?: StructuredQuery;
+	systemPrompt?: string;
+	numResults?: number;
+	signal?: AbortSignal;
+	authStorage: AuthStorage;
+	sessionId?: string;
+	fetch?: FetchImpl;
+	antigravityModel?: string;
+}
+
+function resolveAntigravitySearchModel(configuredModel: string | undefined): string {
+	const envModel = Bun.env.ANTIGRAVITY_SEARCH_MODEL?.trim();
+	if (envModel) return envModel;
+	return configuredModel?.trim() || DEFAULT_MODEL;
+}
+
+function errorMessage(error: unknown): string | undefined {
+	if (typeof error === "string") return error;
+	if (error && typeof error === "object" && "message" in error && typeof error.message === "string")
+		return error.message;
+	return undefined;
+}
+
+async function responseJson(response: Response): Promise<GeminiGroundedResponse & { error?: unknown }> {
+	const bytes = new Uint8Array(await response.arrayBuffer());
+	let text = new TextDecoder().decode(bytes);
+	if (response.headers.get("content-encoding")?.toLowerCase().includes("gzip")) {
+		try {
+			text = await new Response(new Blob([bytes]).stream().pipeThrough(new DecompressionStream("gzip"))).text();
+		} catch {
+			// Fetch implementations may already decode a gzip body while retaining the header.
+		}
+	}
+	try {
+		return JSON.parse(text) as GeminiGroundedResponse & { error?: unknown };
+	} catch {
+		throw new SearchProviderError("antigravity", "Antigravity search returned invalid JSON.", 502);
+	}
+}
+
+async function callAntigravitySearch(
+	accessToken: string,
+	projectId: string,
+	model: string,
+	query: string,
+	systemPrompt: string | undefined,
+	fetchImpl: FetchImpl | undefined,
+	signal: AbortSignal | undefined,
+): Promise<SearchResponse> {
+	const instruction = [ANTIGRAVITY_SYSTEM_INSTRUCTION, systemPrompt?.toWellFormed()].filter(Boolean).join("\n");
+	const request = {
+		systemInstruction: { role: "user", parts: [{ text: instruction }] },
+		contents: [{ role: "user", parts: [{ text: query }] }],
+		generationConfig: { candidateCount: 1 },
+		tools: [{ googleSearch: { enhancedContent: { imageSearch: { maxResultCount: 5 } } } }],
+	};
+	const response = await fetchWithRetry(() => `${ANTIGRAVITY_DAILY_ENDPOINT}/v1internal:generateContent`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			"User-Agent": getAntigravityUserAgent(),
+			"Content-Type": "application/json",
+			"Accept-Encoding": "gzip",
+		},
+		body: JSON.stringify({ model, project: projectId, request, requestType: "agent", userAgent: "antigravity" }),
+		signal: withHardTimeout(signal),
+		fetch: fetchImpl,
+		maxAttempts: MAX_RETRIES + 1,
+		defaultDelayMs: attempt => BASE_DELAY_MS * 2 ** attempt,
+		maxDelayMs: RATE_LIMIT_BUDGET_MS,
+	});
+	if (!response.ok) {
+		const body = await response.text();
+		throw (
+			classifyProviderHttpError("antigravity", response.status, body) ??
+			new SearchProviderError(
+				"antigravity",
+				`Antigravity search API error (${response.status}): ${body}`,
+				response.status,
+			)
+		);
+	}
+
+	const payload = await responseJson(response);
+	const providerError = errorMessage(payload.error);
+	if (providerError) throw new SearchProviderError("antigravity", `Antigravity search error: ${providerError}`, 502);
+	const result = parseGeminiGroundedResponse(payload, model);
+	if (!payload.candidates?.length)
+		throw new SearchProviderError("antigravity", "Antigravity search returned an empty response.", 502);
+	if (result.finishReason?.includes("MAX_TOKENS")) {
+		throw new SearchProviderError(
+			"antigravity",
+			`Antigravity search response overflowed (${result.finishReason}).`,
+			413,
+		);
+	}
+	if (!result.sources.length)
+		throw new SearchProviderError("antigravity", "Antigravity search returned no Google Search grounding.", 502);
+	return {
+		provider: "antigravity",
+		answer: result.answer || undefined,
+		sources: result.sources,
+		citations: result.citations.length ? result.citations : undefined,
+		searchQueries: result.searchQueries.length ? result.searchQueries : undefined,
+		usage: result.usage,
+		model: result.model,
+	};
+}
+
+export async function searchAntigravity(params: AntigravitySearchParams): Promise<SearchResponse> {
+	const model = resolveAntigravitySearchModel(params.antigravityModel);
+	const parsed = params.parsedQuery ?? parseSearchQuery(params.query);
+	const query = parsed.hasDirectives ? formatQuery(parsed, GOOGLE_QUERY_SYNTAX) : params.query;
+	const seed = await params.authStorage.getOAuthAccess(ANTIGRAVITY_OAUTH_PROVIDER, params.sessionId, {
+		signal: params.signal,
+	});
+	if (!seed?.accessToken || !seed.projectId) {
+		throw new SearchProviderError(
+			"antigravity",
+			"Antigravity web search requires google-antigravity OAuth. Run 'omp /login google-antigravity'.",
+		);
+	}
+	const projectId = seed.projectId;
+	const response = await withOAuthAccess(
+		params.authStorage,
+		ANTIGRAVITY_OAUTH_PROVIDER,
+		access =>
+			callAntigravitySearch(
+				access.accessToken,
+				access.projectId ?? projectId,
+				model,
+				query,
+				params.systemPrompt,
+				params.fetch,
+				params.signal,
+			),
+		{ sessionId: params.sessionId, signal: params.signal, seed },
+	);
+	return params.numResults ? { ...response, sources: response.sources.slice(0, params.numResults) } : response;
+}
+
+export class AntigravityProvider extends SearchProvider {
+	readonly id = "antigravity";
+	readonly label = "Antigravity";
+
+	isAvailable(authStorage: AuthStorage): boolean {
+		return authStorage.hasOAuth(ANTIGRAVITY_OAUTH_PROVIDER);
+	}
+
+	search(params: SearchParams): Promise<SearchResponse> {
+		return searchAntigravity({
+			query: params.query,
+			parsedQuery: params.parsedQuery,
+			systemPrompt: params.systemPrompt,
+			numResults: params.numSearchResults ?? params.limit,
+			signal: params.signal,
+			authStorage: params.authStorage,
+			sessionId: params.sessionId,
+			fetch: params.fetch,
+			antigravityModel: params.antigravityModel,
+		});
+	}
+}

--- a/packages/coding-agent/src/web/search/providers/antigravity.ts
+++ b/packages/coding-agent/src/web/search/providers/antigravity.ts
@@ -21,6 +21,8 @@ export interface AntigravitySearchParams {
 	parsedQuery?: StructuredQuery;
 	systemPrompt?: string;
 	numResults?: number;
+	maxOutputTokens?: number;
+	temperature?: number;
 	signal?: AbortSignal;
 	authStorage: AuthStorage;
 	sessionId?: string;
@@ -63,15 +65,17 @@ async function callAntigravitySearch(
 	projectId: string,
 	model: string,
 	query: string,
-	systemPrompt: string | undefined,
-	fetchImpl: FetchImpl | undefined,
-	signal: AbortSignal | undefined,
+	params: Pick<AntigravitySearchParams, "systemPrompt" | "maxOutputTokens" | "temperature" | "fetch" | "signal">,
 ): Promise<SearchResponse> {
-	const instruction = [ANTIGRAVITY_SYSTEM_INSTRUCTION, systemPrompt?.toWellFormed()].filter(Boolean).join("\n");
+	const instruction = [ANTIGRAVITY_SYSTEM_INSTRUCTION, params.systemPrompt?.toWellFormed()].filter(Boolean).join("\n");
 	const request = {
 		systemInstruction: { role: "user", parts: [{ text: instruction }] },
 		contents: [{ role: "user", parts: [{ text: query }] }],
-		generationConfig: { candidateCount: 1 },
+		generationConfig: {
+			candidateCount: 1,
+			...(params.maxOutputTokens !== undefined ? { maxOutputTokens: params.maxOutputTokens } : {}),
+			...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
+		},
 		tools: [{ googleSearch: { enhancedContent: { imageSearch: { maxResultCount: 5 } } } }],
 	};
 	const response = await fetchWithRetry(() => `${ANTIGRAVITY_DAILY_ENDPOINT}/v1internal:generateContent`, {
@@ -83,8 +87,8 @@ async function callAntigravitySearch(
 			"Accept-Encoding": "gzip",
 		},
 		body: JSON.stringify({ model, project: projectId, request, requestType: "agent", userAgent: "antigravity" }),
-		signal: withHardTimeout(signal),
-		fetch: fetchImpl,
+		signal: withHardTimeout(params.signal),
+		fetch: params.fetch,
 		maxAttempts: MAX_RETRIES + 1,
 		defaultDelayMs: attempt => BASE_DELAY_MS * 2 ** attempt,
 		maxDelayMs: RATE_LIMIT_BUDGET_MS,
@@ -144,16 +148,7 @@ export async function searchAntigravity(params: AntigravitySearchParams): Promis
 	const response = await withOAuthAccess(
 		params.authStorage,
 		ANTIGRAVITY_OAUTH_PROVIDER,
-		access =>
-			callAntigravitySearch(
-				access.accessToken,
-				access.projectId ?? projectId,
-				model,
-				query,
-				params.systemPrompt,
-				params.fetch,
-				params.signal,
-			),
+		access => callAntigravitySearch(access.accessToken, access.projectId ?? projectId, model, query, params),
 		{ sessionId: params.sessionId, signal: params.signal, seed },
 	);
 	return params.numResults ? { ...response, sources: response.sources.slice(0, params.numResults) } : response;

--- a/packages/coding-agent/src/web/search/providers/base.ts
+++ b/packages/coding-agent/src/web/search/providers/base.ts
@@ -70,8 +70,8 @@ export interface SearchParams {
 	 * caller's agent session when available; otherwise omit.
 	 */
 	sessionId?: string;
-	antigravityEndpointMode?: "auto" | "production" | "sandbox";
 	geminiModel?: string;
+	antigravityModel?: string;
 }
 
 /** Base class for web search providers. */

--- a/packages/coding-agent/src/web/search/providers/gemini-grounding.ts
+++ b/packages/coding-agent/src/web/search/providers/gemini-grounding.ts
@@ -1,0 +1,110 @@
+import type { SearchCitation, SearchSource } from "../types";
+
+export interface GeminiGroundingChunk {
+	web?: {
+		uri?: string;
+		title?: string;
+	};
+}
+
+export interface GeminiGroundingSupport {
+	segment?: {
+		startIndex?: number;
+		endIndex?: number;
+		text?: string;
+	};
+	groundingChunkIndices?: number[];
+	confidenceScores?: number[];
+}
+
+export interface GeminiGroundingMetadata {
+	groundingChunks?: GeminiGroundingChunk[];
+	groundingSupports?: GeminiGroundingSupport[];
+	webSearchQueries?: string[];
+}
+
+export interface GeminiGroundedResponse {
+	candidates?: Array<{
+		content?: {
+			role?: string;
+			parts?: Array<{ text?: string; thought?: boolean }>;
+		};
+		finishReason?: string;
+		groundingMetadata?: GeminiGroundingMetadata;
+	}>;
+	usageMetadata?: {
+		promptTokenCount?: number;
+		candidatesTokenCount?: number;
+		totalTokenCount?: number;
+	};
+	modelVersion?: string;
+}
+
+export interface GroundedSearchResult {
+	answer: string;
+	sources: SearchSource[];
+	citations: SearchCitation[];
+	searchQueries: string[];
+	model: string;
+	finishReason?: string;
+	usage?: { inputTokens: number; outputTokens: number; totalTokens: number };
+}
+
+/**
+ * Converts a Gemini grounding response into the provider-neutral search result.
+ * Thought parts are model reasoning, not search-answer text; grounding supports
+ * retain their source chunk attribution rather than inferring citations.
+ */
+export function parseGeminiGroundedResponse(
+	response: GeminiGroundedResponse,
+	fallbackModel: string,
+): GroundedSearchResult {
+	const candidate = response.candidates?.[0];
+	const grounding = candidate?.groundingMetadata;
+	const sources: SearchSource[] = [];
+	const citations: SearchCitation[] = [];
+	const searchQueries: string[] = [];
+	const seenUrls = new Set<string>();
+
+	for (const chunk of grounding?.groundingChunks ?? []) {
+		const url = chunk.web?.uri;
+		if (!url || seenUrls.has(url)) continue;
+		seenUrls.add(url);
+		sources.push({ title: chunk.web?.title ?? url, url });
+	}
+
+	for (const support of grounding?.groundingSupports ?? []) {
+		for (const index of support.groundingChunkIndices ?? []) {
+			const web = grounding?.groundingChunks?.[index]?.web;
+			if (!web?.uri) continue;
+			citations.push({
+				url: web.uri,
+				title: web.title ?? web.uri,
+				citedText: support.segment?.text,
+			});
+		}
+	}
+
+	for (const query of grounding?.webSearchQueries ?? []) {
+		if (query && !searchQueries.includes(query)) searchQueries.push(query);
+	}
+
+	return {
+		answer: (candidate?.content?.parts ?? [])
+			.filter(part => !part.thought)
+			.map(part => part.text ?? "")
+			.join(""),
+		sources,
+		citations,
+		searchQueries,
+		model: response.modelVersion ?? fallbackModel,
+		finishReason: candidate?.finishReason,
+		usage: response.usageMetadata
+			? {
+					inputTokens: response.usageMetadata.promptTokenCount ?? 0,
+					outputTokens: response.usageMetadata.candidatesTokenCount ?? 0,
+					totalTokens: response.usageMetadata.totalTokenCount ?? 0,
+				}
+			: undefined,
+	};
+}

--- a/packages/coding-agent/src/web/search/providers/gemini.ts
+++ b/packages/coding-agent/src/web/search/providers/gemini.ts
@@ -1,48 +1,33 @@
-/**
- * Google Gemini Web Search Provider
- *
- * Uses Gemini's Google Search grounding via Cloud Code Assist API.
- * Auth is resolved through `AuthStorage.getOAuthAccess(...)` for both
- * `google-gemini-cli` (stable prod) and `google-antigravity` (daily sandbox)
- * — the broker is the sole refresh authority, so this module never opens a
- * sibling SQLite store and never POSTs the broker sentinel to a Google token
- * endpoint.
- */
+/** Google Gemini Web Search provider (Gemini CLI OAuth or Developer API key). */
 import { type AuthStorage, type FetchImpl, type OAuthAccess, withOAuthAccess } from "@oh-my-pi/pi-ai";
-import {
-	ANTIGRAVITY_SYSTEM_INSTRUCTION,
-	getAntigravityUserAgent,
-	getGeminiCliHeaders,
-} from "@oh-my-pi/pi-catalog/wire/gemini-headers";
+import { getGeminiCliHeaders } from "@oh-my-pi/pi-catalog/wire/gemini-headers";
 import { fetchWithRetry } from "@oh-my-pi/pi-utils";
-
-import type { SearchCitation, SearchResponse, SearchSource } from "../../../web/search/types";
-import { SearchProviderError } from "../../../web/search/types";
 import { formatQuery, GOOGLE_QUERY_SYNTAX, parseSearchQuery, type StructuredQuery } from "../query";
+import type { SearchResponse } from "../types";
+import { SearchProviderError } from "../types";
 import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
+import {
+	type GeminiGroundedResponse,
+	type GroundedSearchResult,
+	parseGeminiGroundedResponse,
+} from "./gemini-grounding";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
 const DEFAULT_ENDPOINT = "https://cloudcode-pa.googleapis.com";
 const DEVELOPER_API_PROVIDER = "google";
 const DEVELOPER_API_ENDPOINT = "https://generativelanguage.googleapis.com/v1beta";
-const ANTIGRAVITY_DAILY_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
-const ANTIGRAVITY_SANDBOX_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
-const ANTIGRAVITY_ENDPOINT_FALLBACKS = [ANTIGRAVITY_DAILY_ENDPOINT, ANTIGRAVITY_SANDBOX_ENDPOINT] as const;
 const DEFAULT_MODEL = "gemini-2.5-flash";
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
 const RATE_LIMIT_BUDGET_MS = 5 * 60 * 1000;
+const GEMINI_OAUTH_PROVIDER = "google-gemini-cli";
 
 function resolveGeminiSearchModel(configuredModel: string | undefined): string {
 	const envModel = Bun.env.GEMINI_SEARCH_MODEL?.trim();
 	if (envModel) return envModel;
-	const model = configuredModel?.trim();
-	return model || DEFAULT_MODEL;
+	return configuredModel?.trim() || DEFAULT_MODEL;
 }
-
-const GEMINI_PROVIDERS = ["google-gemini-cli", "google-antigravity"] as const;
-type GeminiProviderId = (typeof GEMINI_PROVIDERS)[number];
 
 interface GeminiToolParams {
 	google_search?: Record<string, unknown>;
@@ -52,253 +37,102 @@ interface GeminiToolParams {
 
 export interface GeminiSearchParams extends GeminiToolParams {
 	query: string;
-	/** Pre-parsed structured query; falls back to parsing `query` when omitted. */
 	parsedQuery?: StructuredQuery;
 	system_prompt?: string;
 	num_results?: number;
-	/** Maximum output tokens. */
 	max_output_tokens?: number;
-	/** Sampling temperature (0–1). Lower = more focused/factual. */
 	temperature?: number;
 	signal?: AbortSignal;
 	authStorage: AuthStorage;
 	sessionId?: string;
 	fetch?: FetchImpl;
-	antigravityEndpointMode?: "auto" | "production" | "sandbox";
 	geminiModel?: string;
 }
 
 export function buildGeminiRequestTools(params: GeminiToolParams): Array<Record<string, Record<string, unknown>>> {
 	const tools: Array<Record<string, Record<string, unknown>>> = [{ googleSearch: params.google_search ?? {} }];
-	if (params.code_execution !== undefined) {
-		tools.push({ codeExecution: params.code_execution });
-	}
-	if (params.url_context !== undefined) {
-		tools.push({ urlContext: params.url_context });
-	}
+	if (params.code_execution !== undefined) tools.push({ codeExecution: params.code_execution });
+	if (params.url_context !== undefined) tools.push({ urlContext: params.url_context });
 	return tools;
 }
 
-/** Resolved auth for a Gemini API request. */
 interface GeminiAuth {
 	accessToken: string;
 	projectId: string;
-	isAntigravity: boolean;
 }
 
-/** First configured Gemini OAuth provider plus its pre-resolved access. */
 interface GeminiAuthSeed {
-	provider: GeminiProviderId;
 	access: OAuthAccess;
 	projectId: string;
 }
 
-interface GeminiSearchResult {
-	answer: string;
-	sources: SearchSource[];
-	citations: SearchCitation[];
-	searchQueries: string[];
-	model: string;
-	usage?: { inputTokens: number; outputTokens: number; totalTokens: number };
-}
+type GeminiSearchResult = GroundedSearchResult;
 
-/**
- * Walks the configured Gemini OAuth providers in deterministic order and
- * returns the first one that yields a usable access token + projectId via
- * {@link AuthStorage.getOAuthAccess}. AuthStorage handles refresh + broker
- * routing internally; this helper never touches refresh tokens directly.
- * The resolved access seeds `withOAuthAccess` so the happy path resolves once.
- */
+/** Resolves Gemini CLI OAuth only; Antigravity credentials belong to its own provider. */
 export async function findGeminiAuth(
 	authStorage: AuthStorage,
 	sessionId: string | undefined,
 	signal: AbortSignal | undefined,
 ): Promise<GeminiAuthSeed | null> {
-	for (const provider of GEMINI_PROVIDERS) {
-		const access = await authStorage.getOAuthAccess(provider, sessionId, { signal });
-		if (!access?.accessToken || !access.projectId) continue;
-		return { provider, access, projectId: access.projectId };
+	const access = await authStorage.getOAuthAccess(GEMINI_OAUTH_PROVIDER, sessionId, { signal });
+	if (!access?.accessToken || !access.projectId) return null;
+	return { access, projectId: access.projectId };
+}
+
+function mergeResult(target: GeminiSearchResult, chunk: GeminiGroundedResponse, fallbackModel: string): void {
+	const parsed = parseGeminiGroundedResponse(chunk, fallbackModel);
+	target.answer += parsed.answer;
+	for (const source of parsed.sources) {
+		if (!target.sources.some(existing => existing.url === source.url)) target.sources.push(source);
 	}
-	return null;
-}
-
-function hasGeminiOAuth(authStorage: AuthStorage): boolean {
-	return GEMINI_PROVIDERS.some((provider: GeminiProviderId) => authStorage.hasOAuth(provider));
-}
-
-/** Cloud Code Assist API response types */
-interface GeminiGroundingChunk {
-	web?: {
-		uri?: string;
-		title?: string;
-	};
-}
-
-interface GeminiGroundingSupport {
-	segment?: {
-		startIndex?: number;
-		endIndex?: number;
-		text?: string;
-	};
-	groundingChunkIndices?: number[];
-	confidenceScores?: number[];
-}
-
-interface GeminiGroundingMetadata {
-	groundingChunks?: GeminiGroundingChunk[];
-	groundingSupports?: GeminiGroundingSupport[];
-	webSearchQueries?: string[];
-}
-
-interface GeminiModelResponse {
-	candidates?: Array<{
-		content?: {
-			role: string;
-			parts?: Array<{ text?: string }>;
-		};
-		finishReason?: string;
-		groundingMetadata?: GeminiGroundingMetadata;
-	}>;
-	usageMetadata?: {
-		promptTokenCount?: number;
-		candidatesTokenCount?: number;
-		totalTokenCount?: number;
-	};
-	modelVersion?: string;
-}
-
-interface CloudCodeResponseChunk {
-	response?: GeminiModelResponse;
+	target.citations.push(...parsed.citations);
+	for (const query of parsed.searchQueries) {
+		if (!target.searchQueries.includes(query)) target.searchQueries.push(query);
+	}
+	target.model = parsed.model;
+	target.finishReason = parsed.finishReason ?? target.finishReason;
+	target.usage = parsed.usage ?? target.usage;
 }
 
 async function parseGeminiSearchStream(
 	body: ReadableStream<Uint8Array>,
 	fallbackModel: string,
 ): Promise<GeminiSearchResult> {
-	const answerParts: string[] = [];
-	const sources: SearchSource[] = [];
-	const citations: SearchCitation[] = [];
-	const searchQueries: string[] = [];
-	const seenUrls = new Set<string>();
-	let model = fallbackModel;
-	let usage: { inputTokens: number; outputTokens: number; totalTokens: number } | undefined;
-
+	const result: GeminiSearchResult = {
+		answer: "",
+		sources: [],
+		citations: [],
+		searchQueries: [],
+		model: fallbackModel,
+	};
 	const reader = body.getReader();
 	const decoder = new TextDecoder();
 	let buffer = "";
-
 	try {
 		while (true) {
 			const { done, value } = await reader.read();
 			if (done) break;
-
 			buffer += decoder.decode(value, { stream: true });
 			const lines = buffer.split("\n");
-			buffer = lines.pop() || "";
-
+			buffer = lines.pop() ?? "";
 			for (const line of lines) {
 				if (!line.startsWith("data:")) continue;
-
-				const jsonStr = line.slice(5).trim();
-				if (!jsonStr) continue;
-
-				let chunk: CloudCodeResponseChunk & GeminiModelResponse;
 				try {
-					chunk = JSON.parse(jsonStr) as CloudCodeResponseChunk & GeminiModelResponse;
+					const raw = JSON.parse(line.slice(5).trim()) as {
+						response?: GeminiGroundedResponse;
+					} & GeminiGroundedResponse;
+					mergeResult(result, raw.response ?? raw, fallbackModel);
 				} catch {
-					continue;
-				}
-
-				const responseData = chunk.response ?? chunk;
-				const candidate = responseData.candidates?.[0];
-
-				if (candidate?.content?.parts) {
-					for (const part of candidate.content.parts) {
-						if (part.text) {
-							answerParts.push(part.text);
-						}
-					}
-				}
-
-				const groundingMetadata = candidate?.groundingMetadata;
-				if (groundingMetadata) {
-					if (groundingMetadata.groundingChunks) {
-						for (const grChunk of groundingMetadata.groundingChunks) {
-							if (grChunk.web?.uri) {
-								const sourceUrl = grChunk.web.uri;
-								if (!seenUrls.has(sourceUrl)) {
-									seenUrls.add(sourceUrl);
-									sources.push({
-										title: grChunk.web.title ?? sourceUrl,
-										url: sourceUrl,
-									});
-								}
-							}
-						}
-					}
-
-					if (groundingMetadata.groundingSupports && groundingMetadata.groundingChunks) {
-						for (const support of groundingMetadata.groundingSupports) {
-							const citedText = support.segment?.text;
-							const chunkIndices = support.groundingChunkIndices ?? [];
-
-							for (const idx of chunkIndices) {
-								const grChunk = groundingMetadata.groundingChunks[idx];
-								if (grChunk?.web?.uri) {
-									citations.push({
-										url: grChunk.web.uri,
-										title: grChunk.web.title ?? grChunk.web.uri,
-										citedText,
-									});
-								}
-							}
-						}
-					}
-
-					if (groundingMetadata.webSearchQueries) {
-						for (const q of groundingMetadata.webSearchQueries) {
-							if (!searchQueries.includes(q)) {
-								searchQueries.push(q);
-							}
-						}
-					}
-				}
-
-				if (responseData.usageMetadata) {
-					usage = {
-						inputTokens: responseData.usageMetadata.promptTokenCount ?? 0,
-						outputTokens: responseData.usageMetadata.candidatesTokenCount ?? 0,
-						totalTokens: responseData.usageMetadata.totalTokenCount ?? 0,
-					};
-				}
-
-				if (responseData.modelVersion) {
-					model = responseData.modelVersion;
+					// Ignore malformed SSE keep-alives; the final provider response remains authoritative.
 				}
 			}
 		}
 	} finally {
 		reader.releaseLock();
 	}
-
-	return {
-		answer: answerParts.join(""),
-		sources,
-		citations,
-		searchQueries,
-		model,
-		usage,
-	};
+	return result;
 }
 
-/**
- * Calls the Cloud Code Assist API with Google Search grounding enabled.
- *
- * If a request returns a refreshable auth failure (401/403/auth-flavoured 400),
- * we ask AuthStorage to invalidate + refresh the credential and retry once.
- * Provider-direct refresh helpers are intentionally not used: AuthStorage owns
- * the single-flight refresh and broker round-trip.
- */
 async function callGeminiSearch(
 	auth: GeminiAuth,
 	model: string,
@@ -309,126 +143,52 @@ async function callGeminiSearch(
 	toolParams: GeminiToolParams,
 	fetchImpl: FetchImpl | undefined,
 	signal: AbortSignal | undefined,
-	mode?: "auto" | "production" | "sandbox",
 ): Promise<GeminiSearchResult> {
-	let endpoints: string[];
-	if (auth.isAntigravity) {
-		const m = mode ?? "auto";
-		if (m === "sandbox") {
-			endpoints = [ANTIGRAVITY_SANDBOX_ENDPOINT];
-		} else if (m === "production") {
-			endpoints = [ANTIGRAVITY_DAILY_ENDPOINT];
-		} else {
-			endpoints = [...ANTIGRAVITY_ENDPOINT_FALLBACKS];
-		}
-	} else {
-		endpoints = [DEFAULT_ENDPOINT];
-	}
-	const headers = auth.isAntigravity ? { "User-Agent": getAntigravityUserAgent() } : getGeminiCliHeaders();
-
-	const requestMetadata = auth.isAntigravity
-		? {
-				requestType: "agent",
-				userAgent: "antigravity",
-				requestId: `agent-${crypto.randomUUID()}`,
-			}
-		: {
-				userAgent: "pi-coding-agent",
-				requestId: `pi-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
-			};
-
 	const normalizedSystemPrompt = systemPrompt?.toWellFormed();
-	const systemInstructionParts: Array<{ text: string }> = [
-		...(auth.isAntigravity ? [{ text: ANTIGRAVITY_SYSTEM_INSTRUCTION }] : []),
-		...(normalizedSystemPrompt ? [{ text: normalizedSystemPrompt }] : []),
-	];
-
-	const requestBody: Record<string, unknown> = {
-		project: auth.projectId,
-		model,
-		request: {
-			contents: [
-				{
-					role: "user",
-					parts: [{ text: query }],
-				},
-			],
-			tools: buildGeminiRequestTools(toolParams),
-			...(systemInstructionParts.length > 0 && {
-				systemInstruction: {
-					...(auth.isAntigravity ? { role: "user" } : {}),
-					parts: systemInstructionParts,
-				},
-			}),
-		},
-		...requestMetadata,
+	const request: Record<string, unknown> = {
+		contents: [{ role: "user", parts: [{ text: query }] }],
+		tools: buildGeminiRequestTools(toolParams),
+		...(normalizedSystemPrompt ? { systemInstruction: { parts: [{ text: normalizedSystemPrompt }] } } : {}),
 	};
-
 	if (maxOutputTokens !== undefined || temperature !== undefined) {
-		const generationConfig: Record<string, number> = {};
-		if (maxOutputTokens !== undefined) {
-			generationConfig.maxOutputTokens = maxOutputTokens;
-		}
-		if (temperature !== undefined) {
-			generationConfig.temperature = temperature;
-		}
-		(requestBody.request as Record<string, unknown>).generationConfig = generationConfig;
+		request.generationConfig = {
+			...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
+			...(temperature !== undefined ? { temperature } : {}),
+		};
 	}
-	const buildInit = (): RequestInit => ({
+	const response = await fetchWithRetry(() => `${DEFAULT_ENDPOINT}/v1internal:streamGenerateContent?alt=sse`, {
 		method: "POST",
 		headers: {
 			Authorization: `Bearer ${auth.accessToken}`,
 			"Content-Type": "application/json",
 			Accept: "text/event-stream",
-			...headers,
+			...getGeminiCliHeaders(),
 		},
-		body: JSON.stringify(requestBody),
+		body: JSON.stringify({
+			project: auth.projectId,
+			model,
+			request,
+			userAgent: "pi-coding-agent",
+			requestId: `pi-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+		}),
 		signal: withHardTimeout(signal),
+		fetch: fetchImpl,
+		maxAttempts: MAX_RETRIES + 1,
+		defaultDelayMs: attempt => BASE_DELAY_MS * 2 ** attempt,
+		maxDelayMs: RATE_LIMIT_BUDGET_MS,
 	});
-
-	let response: Response | undefined;
-
-	for (let i = 0; i < endpoints.length; i++) {
-		const endpoint = endpoints[i];
-		const isLastEndpoint = i === endpoints.length - 1;
-		try {
-			response = await fetchWithRetry(() => `${endpoint}/v1internal:streamGenerateContent?alt=sse`, {
-				...buildInit(),
-				fetch: fetchImpl,
-				maxAttempts: isLastEndpoint ? MAX_RETRIES + 1 : 1,
-				defaultDelayMs: attempt => BASE_DELAY_MS * 2 ** attempt,
-				maxDelayMs: RATE_LIMIT_BUDGET_MS,
-			});
-
-			if (response.ok) {
-				break;
-			}
-
-			if (response.status === 429 || (response.status >= 500 && response.status < 600)) {
-				if (!isLastEndpoint) {
-					continue;
-				}
-			}
-			break;
-		} catch (error) {
-			if (isLastEndpoint) {
-				throw error;
-			}
-		}
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw (
+			classifyProviderHttpError("gemini", response.status, errorText) ??
+			new SearchProviderError(
+				"gemini",
+				`Gemini Cloud Code API error (${response.status}): ${errorText}`,
+				response.status,
+			)
+		);
 	}
-
-	if (!response?.ok) {
-		const errorText = response ? await response.text() : "Network error";
-		const status = response?.status ?? 502;
-		const classified = classifyProviderHttpError("gemini", status, errorText);
-		if (classified) throw classified;
-		throw new SearchProviderError("gemini", `Gemini Cloud Code API error (${status}): ${errorText}`, status);
-	}
-
-	if (!response.body) {
-		throw new SearchProviderError("gemini", "Gemini API returned no response body", 500);
-	}
-
+	if (!response.body) throw new SearchProviderError("gemini", "Gemini API returned no response body", 500);
 	return parseGeminiSearchStream(response.body, model);
 }
 
@@ -444,42 +204,23 @@ async function callGeminiDeveloperSearch(
 	signal: AbortSignal | undefined,
 ): Promise<GeminiSearchResult> {
 	const normalizedSystemPrompt = systemPrompt?.toWellFormed();
-	const requestBody: Record<string, unknown> = {
-		contents: [
-			{
-				role: "user",
-				parts: [{ text: query }],
-			},
-		],
+	const request: Record<string, unknown> = {
+		contents: [{ role: "user", parts: [{ text: query }] }],
 		tools: buildGeminiRequestTools(toolParams),
-		...(normalizedSystemPrompt && {
-			systemInstruction: {
-				parts: [{ text: normalizedSystemPrompt }],
-			},
-		}),
+		...(normalizedSystemPrompt ? { systemInstruction: { parts: [{ text: normalizedSystemPrompt }] } } : {}),
 	};
-
 	if (maxOutputTokens !== undefined || temperature !== undefined) {
-		const generationConfig: Record<string, number> = {};
-		if (maxOutputTokens !== undefined) {
-			generationConfig.maxOutputTokens = maxOutputTokens;
-		}
-		if (temperature !== undefined) {
-			generationConfig.temperature = temperature;
-		}
-		requestBody.generationConfig = generationConfig;
+		request.generationConfig = {
+			...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
+			...(temperature !== undefined ? { temperature } : {}),
+		};
 	}
-
 	const response = await fetchWithRetry(
 		() => `${DEVELOPER_API_ENDPOINT}/models/${model}:streamGenerateContent?alt=sse`,
 		{
 			method: "POST",
-			headers: {
-				"x-goog-api-key": apiKey,
-				"Content-Type": "application/json",
-				Accept: "text/event-stream",
-			},
-			body: JSON.stringify(requestBody),
+			headers: { "x-goog-api-key": apiKey, "Content-Type": "application/json", Accept: "text/event-stream" },
+			body: JSON.stringify(request),
 			signal: withHardTimeout(signal),
 			fetch: fetchImpl,
 			maxAttempts: MAX_RETRIES + 1,
@@ -487,124 +228,81 @@ async function callGeminiDeveloperSearch(
 			maxDelayMs: RATE_LIMIT_BUDGET_MS,
 		},
 	);
-
 	if (!response.ok) {
 		const errorText = await response.text();
-		const classified = classifyProviderHttpError("gemini", response.status, errorText);
-		if (classified) throw classified;
-		throw new SearchProviderError(
-			"gemini",
-			`Gemini Developer API error (${response.status}): ${errorText}`,
-			response.status,
+		throw (
+			classifyProviderHttpError("gemini", response.status, errorText) ??
+			new SearchProviderError(
+				"gemini",
+				`Gemini Developer API error (${response.status}): ${errorText}`,
+				response.status,
+			)
 		);
 	}
-
-	if (!response.body) {
-		throw new SearchProviderError("gemini", "Gemini API returned no response body", 500);
-	}
-
+	if (!response.body) throw new SearchProviderError("gemini", "Gemini API returned no response body", 500);
 	return parseGeminiSearchStream(response.body, model);
 }
 
-/**
- * Executes a web search using Google Gemini with Google Search grounding.
- */
 export async function searchGemini(params: GeminiSearchParams): Promise<SearchResponse> {
-	const selectedModel = resolveGeminiSearchModel(params.geminiModel);
-	// Gemini's googleSearch grounding forwards the query to Google Search, which
-	// understands the classic operator set natively. Normalize directive aliases
-	// (domain: → site:, since: → after:, …) to canonical Google forms; leave
-	// directive-free queries byte-identical.
+	const model = resolveGeminiSearchModel(params.geminiModel);
 	const parsed = params.parsedQuery ?? parseSearchQuery(params.query);
-	const searchQuery = parsed.hasDirectives ? formatQuery(parsed, GOOGLE_QUERY_SYNTAX) : params.query;
+	const query = parsed.hasDirectives ? formatQuery(parsed, GOOGLE_QUERY_SYNTAX) : params.query;
 	const seed = await findGeminiAuth(params.authStorage, params.sessionId, params.signal);
-	let result: GeminiSearchResult;
-
-	if (seed) {
-		const isAntigravity = seed.provider === "google-antigravity";
-		result = await withOAuthAccess(
-			params.authStorage,
-			seed.provider,
-			access =>
-				// Derive bearer + projectId from the access this attempt received; a
-				// re-resolved access may omit projectId, in which case the seed's
-				// project is still the right tenant for the credential. The
-				// `fetchWithRetry` transport backoff stays INSIDE this attempt — auth
-				callGeminiSearch(
-					{
-						accessToken: access.accessToken,
-						projectId: access.projectId ?? seed.projectId,
-						isAntigravity,
-					},
-					selectedModel,
-					searchQuery,
+	const result = seed
+		? await withOAuthAccess(
+				params.authStorage,
+				GEMINI_OAUTH_PROVIDER,
+				access =>
+					callGeminiSearch(
+						{ accessToken: access.accessToken, projectId: access.projectId ?? seed.projectId },
+						model,
+						query,
+						params.system_prompt,
+						params.max_output_tokens,
+						params.temperature,
+						params,
+						params.fetch,
+						params.signal,
+					),
+				{ sessionId: params.sessionId, signal: params.signal, seed: seed.access },
+			)
+		: await (async () => {
+				const apiKey = await params.authStorage.getApiKey(DEVELOPER_API_PROVIDER, params.sessionId, {
+					signal: params.signal,
+				});
+				if (!apiKey)
+					throw new Error(
+						"No Gemini credentials found. Set GEMINI_API_KEY, configure an API key for provider \"google\", or login with 'omp /login google-gemini-cli' to enable Gemini web search.",
+					);
+				return callGeminiDeveloperSearch(
+					apiKey,
+					model,
+					query,
 					params.system_prompt,
 					params.max_output_tokens,
 					params.temperature,
-					{
-						google_search: params.google_search,
-						code_execution: params.code_execution,
-						url_context: params.url_context,
-					},
+					params,
 					params.fetch,
 					params.signal,
-					params.antigravityEndpointMode,
-				),
-			{ sessionId: params.sessionId, signal: params.signal, seed: seed.access },
-		);
-	} else {
-		const apiKey = await params.authStorage.getApiKey(DEVELOPER_API_PROVIDER, params.sessionId, {
-			signal: params.signal,
-		});
-		if (!apiKey) {
-			throw new Error(
-				"No Gemini credentials found. Set GEMINI_API_KEY, configure an API key for provider \"google\", or login with 'omp /login google-gemini-cli' / 'omp /login google-antigravity' to enable Gemini web search.",
-			);
-		}
-		result = await callGeminiDeveloperSearch(
-			apiKey,
-			selectedModel,
-			searchQuery,
-			params.system_prompt,
-			params.max_output_tokens,
-			params.temperature,
-			{
-				google_search: params.google_search,
-				code_execution: params.code_execution,
-				url_context: params.url_context,
-			},
-			params.fetch,
-			params.signal,
-		);
-	}
-
-	let sources = result.sources;
-
-	if (params.num_results && sources.length > params.num_results) {
-		sources = sources.slice(0, params.num_results);
-	}
-
+				);
+			})();
 	return {
 		provider: "gemini",
 		answer: result.answer || undefined,
-		sources,
-		citations: result.citations.length > 0 ? result.citations : undefined,
-		searchQueries: result.searchQueries.length > 0 ? result.searchQueries : undefined,
+		sources: params.num_results ? result.sources.slice(0, params.num_results) : result.sources,
+		citations: result.citations.length ? result.citations : undefined,
+		searchQueries: result.searchQueries.length ? result.searchQueries : undefined,
 		usage: result.usage,
 		model: result.model,
 	};
 }
 
-/** Search provider for Google Gemini web search. */
 export class GeminiProvider extends SearchProvider {
 	readonly id = "gemini";
 	readonly label = "Gemini";
 
 	isAvailable(authStorage: AuthStorage): boolean {
-		// Cheap, in-memory check — avoids driving the refresh pipeline during
-		// the provider-chain probe. `searchGemini` refreshes OAuth lazily on the
-		// actual request and resolves developer API keys through AuthStorage.
-		return hasGeminiOAuth(authStorage) || authStorage.hasAuth(DEVELOPER_API_PROVIDER);
+		return authStorage.hasOAuth(GEMINI_OAUTH_PROVIDER) || authStorage.hasAuth(DEVELOPER_API_PROVIDER);
 	}
 
 	search(params: SearchParams): Promise<SearchResponse> {

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -18,7 +18,12 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	{
 		value: "gemini",
 		label: "Gemini",
-		description: "Google Search grounding via Gemini (uses google-gemini-cli or google-antigravity OAuth)",
+		description: "Google Search grounding via Gemini (uses Gemini CLI OAuth or a Google Developer API key)",
+	},
+	{
+		value: "antigravity",
+		label: "Antigravity",
+		description: "Google Search grounding via google-antigravity OAuth",
 	},
 	{
 		value: "anthropic",

--- a/packages/coding-agent/test/fixtures/antigravity-search-generate-content.json
+++ b/packages/coding-agent/test/fixtures/antigravity-search-generate-content.json
@@ -1,0 +1,43 @@
+{
+  "request": {
+    "url": "https://daily-cloudcode-pa.googleapis.com/v1internal:generateContent",
+    "headers": {
+      "authorization": "Bearer <redacted>",
+      "user-agent": "antigravity/hub/<redacted>",
+      "content-type": "application/json",
+      "accept-encoding": "gzip"
+    },
+    "body": {
+      "model": "gemini-3.6-flash-low",
+      "project": "<redacted>",
+      "requestType": "agent",
+      "userAgent": "antigravity",
+      "request": {
+        "systemInstruction": { "role": "user", "parts": [{ "text": "<redacted>" }] },
+        "contents": [{ "role": "user", "parts": [{ "text": "<redacted>" }] }],
+        "generationConfig": { "candidateCount": 1 },
+        "tools": [{ "googleSearch": { "enhancedContent": { "imageSearch": { "maxResultCount": 5 } } } }]
+      }
+    }
+  },
+  "response": {
+    "candidates": [{
+      "content": {
+        "role": "model",
+        "parts": [
+          { "text": "<thought-redacted>", "thought": true },
+          { "text": "Grounded answer." }
+        ]
+      },
+      "finishReason": "STOP",
+      "groundingMetadata": {
+        "webSearchQueries": ["<redacted>"],
+        "searchEntryPoint": { "renderedContent": "<redacted>" },
+        "groundingChunks": [{ "web": { "uri": "https://example.test/source", "title": "Source title" } }],
+        "groundingSupports": [{ "segment": { "endIndex": 16, "text": "Grounded answer." }, "groundingChunkIndices": [0] }]
+      }
+    }],
+    "usageMetadata": { "promptTokenCount": 3, "candidatesTokenCount": 4, "totalTokenCount": 7 },
+    "modelVersion": "gemini-3.6-flash-low"
+  }
+}

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -1,6 +1,6 @@
 /**
  * Contract: `createSettingsAwareStreamFn` layers session provider settings
- * (`providers.openrouterVariant`, `providers.antigravityEndpoint`,
+ * (`providers.openrouterVariant`,
  * `providers.stream*TimeoutSeconds`, `providers.maxInFlightRequests`,
  * `model.loopGuard.*`, `textVerbosity` for Responses-family requests)
  * options win — the same wiring the main agent and the advisor agent share so
@@ -32,7 +32,6 @@ describe("createSettingsAwareStreamFn", () => {
 	it("applies provider settings to the forwarded options when caller omits them", () => {
 		const settings = Settings.isolated({
 			"providers.openrouterVariant": "floor",
-			"providers.antigravityEndpoint": "sandbox",
 			"providers.maxInFlightRequests": { openrouter: 4 },
 			"model.loopGuard.enabled": true,
 			"model.loopGuard.checkAssistantContent": true,
@@ -44,7 +43,6 @@ describe("createSettingsAwareStreamFn", () => {
 
 		const options = calls[0]?.options;
 		expect(options?.openrouterVariant).toBe("floor");
-		expect(options?.antigravityEndpointMode).toBe("sandbox");
 		expect(options?.maxInFlightRequests).toEqual({ openrouter: 4 });
 		expect(options?.loopGuard).toEqual({ enabled: true, checkAssistantContent: true });
 		// caller's own option is preserved
@@ -128,7 +126,6 @@ describe("createSettingsAwareStreamFn", () => {
 	it("lets caller-supplied options override the session settings", () => {
 		const settings = Settings.isolated({
 			"providers.openrouterVariant": "floor",
-			"providers.antigravityEndpoint": "sandbox",
 			"providers.maxInFlightRequests": { openrouter: 4 },
 			"model.loopGuard.enabled": true,
 		});
@@ -137,7 +134,6 @@ describe("createSettingsAwareStreamFn", () => {
 
 		wrapped(stubModel, stubContext, {
 			openrouterVariant: "nitro",
-			antigravityEndpointMode: "production",
 			maxInFlightRequests: { openrouter: 1 },
 			loopGuard: { enabled: false },
 			hideThinkingSummary: false,
@@ -145,7 +141,6 @@ describe("createSettingsAwareStreamFn", () => {
 
 		const options = calls[0]?.options;
 		expect(options?.openrouterVariant).toBe("nitro");
-		expect(options?.antigravityEndpointMode).toBe("production");
 		expect(options?.maxInFlightRequests).toEqual({ openrouter: 1 });
 		// Loop guard merges per-field: caller wins on `enabled`, settings fill
 		// the rest (the inline closure the main agent used has the same shape).

--- a/packages/coding-agent/test/tools/web-search-antigravity.test.ts
+++ b/packages/coding-agent/test/tools/web-search-antigravity.test.ts
@@ -94,6 +94,21 @@ describe("Antigravity web search", () => {
 		});
 	});
 
+	it("forwards generation controls", async () => {
+		const requests: CapturedRequest[] = [];
+		await searchAntigravity({
+			query: "captured query",
+			maxOutputTokens: 1234,
+			temperature: 0.25,
+			authStorage: oauthStorage(["google-antigravity"], []),
+			fetch: capture(new Response(JSON.stringify(fixture.response), { status: 200 }), requests),
+		});
+
+		expect(requests[0]?.body).toMatchObject({
+			request: { generationConfig: { candidateCount: 1, maxOutputTokens: 1234, temperature: 0.25 } },
+		});
+	});
+
 	it("keeps Antigravity and Gemini OAuth credential selection isolated", async () => {
 		const antigravityRequested: string[] = [];
 		await searchAntigravity({

--- a/packages/coding-agent/test/tools/web-search-antigravity.test.ts
+++ b/packages/coding-agent/test/tools/web-search-antigravity.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
+import { getAntigravityUserAgent } from "@oh-my-pi/pi-catalog/wire/gemini-headers";
+import { SETTINGS_SCHEMA } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
+import { searchAntigravity } from "@oh-my-pi/pi-coding-agent/web/search/providers/antigravity";
+import { searchGemini } from "@oh-my-pi/pi-coding-agent/web/search/providers/gemini";
+import { SEARCH_PROVIDER_OPTIONS } from "@oh-my-pi/pi-coding-agent/web/search/types";
+import fixture from "../fixtures/antigravity-search-generate-content.json" with { type: "json" };
+
+const originalModel = Bun.env.ANTIGRAVITY_SEARCH_MODEL;
+
+type CapturedRequest = { url: string; headers: Headers; body: Record<string, unknown> };
+
+function oauthStorage(availableProviders: readonly string[], requested: string[]): AuthStorage {
+	return {
+		async getOAuthAccess(provider: string) {
+			requested.push(provider);
+			return availableProviders.includes(provider)
+				? { accessToken: "antigravity-token", projectId: "project-id" }
+				: undefined;
+		},
+		hasOAuth(provider: string) {
+			return availableProviders.includes(provider);
+		},
+	} as AuthStorage;
+}
+
+function capture(response: Response, captured: CapturedRequest[]): FetchImpl {
+	return (url, init) => {
+		captured.push({
+			url: String(url),
+			headers: new Headers(init?.headers),
+			body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+		});
+		return Promise.resolve(response);
+	};
+}
+
+afterEach(() => {
+	if (originalModel === undefined) delete Bun.env.ANTIGRAVITY_SEARCH_MODEL;
+	else Bun.env.ANTIGRAVITY_SEARCH_MODEL = originalModel;
+});
+
+describe("Antigravity web search", () => {
+	it("is independently selectable with its own model setting", () => {
+		expect(SEARCH_PROVIDER_OPTIONS.some(option => option.value === "antigravity")).toBe(true);
+		expect(SETTINGS_SCHEMA["providers.webSearchAntigravityModel"]?.default).toBeUndefined();
+	});
+
+	it("uses the captured daily generateContent envelope and preserves grounded citations", async () => {
+		const requests: CapturedRequest[] = [];
+		const response = await searchAntigravity({
+			query: "captured query",
+			systemPrompt: "test instruction",
+			authStorage: oauthStorage(["google-antigravity"], []),
+			fetch: capture(new Response(JSON.stringify(fixture.response), { status: 200 }), requests),
+		});
+
+		const request = requests[0];
+		expect(request?.url).toBe(fixture.request.url);
+		expect(request?.headers.get("authorization")).toBe("Bearer antigravity-token");
+		expect(request?.headers.get("content-type")).toBe(fixture.request.headers["content-type"]);
+		expect(request?.headers.get("accept-encoding")).toBe(fixture.request.headers["accept-encoding"]);
+		expect(request?.headers.get("user-agent")).toBe(getAntigravityUserAgent());
+		expect(Object.keys(request?.body ?? {}).sort()).toEqual([
+			"model",
+			"project",
+			"request",
+			"requestType",
+			"userAgent",
+		]);
+		const nestedRequest = request?.body.request;
+		if (!nestedRequest || typeof nestedRequest !== "object")
+			throw new Error("captured Antigravity request is missing its nested request");
+		expect(Object.keys(nestedRequest).sort()).toEqual(["contents", "generationConfig", "systemInstruction", "tools"]);
+		expect(request?.body).toMatchObject({
+			model: "gemini-3.6-flash-low",
+			project: "project-id",
+			requestType: "agent",
+			userAgent: "antigravity",
+			request: {
+				systemInstruction: { role: "user" },
+				contents: [{ role: "user", parts: [{ text: "captured query" }] }],
+				generationConfig: { candidateCount: 1 },
+				tools: [{ googleSearch: { enhancedContent: { imageSearch: { maxResultCount: 5 } } } }],
+			},
+		});
+		expect(request?.body).not.toHaveProperty("request.generationConfig.thinkingConfig");
+		expect(response).toMatchObject({
+			answer: "Grounded answer.",
+			sources: [{ title: "Source title", url: "https://example.test/source" }],
+			citations: [{ citedText: "Grounded answer.", title: "Source title", url: "https://example.test/source" }],
+			searchQueries: ["<redacted>"],
+		});
+	});
+
+	it("keeps Antigravity and Gemini OAuth credential selection isolated", async () => {
+		const antigravityRequested: string[] = [];
+		await searchAntigravity({
+			query: "q",
+			authStorage: oauthStorage(["google-antigravity"], antigravityRequested),
+			fetch: capture(new Response(JSON.stringify(fixture.response), { status: 200 }), []),
+		});
+		expect(antigravityRequested).toEqual(["google-antigravity"]);
+
+		const geminiRequested: string[] = [];
+		await searchGemini({
+			query: "q",
+			authStorage: oauthStorage(["google-gemini-cli"], geminiRequested),
+			fetch: capture(
+				new Response('data: {"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}\n\n', { status: 200 }),
+				[],
+			),
+		});
+		expect(geminiRequested).toEqual(["google-gemini-cli"]);
+	});
+
+	it("uses only its own setting and environment model precedence", async () => {
+		const requests: CapturedRequest[] = [];
+		await searchAntigravity({
+			query: "q",
+			antigravityModel: "setting-model",
+			authStorage: oauthStorage(["google-antigravity"], []),
+			fetch: capture(new Response(JSON.stringify(fixture.response), { status: 200 }), requests),
+		});
+		expect(requests[0]?.body.model).toBe("setting-model");
+
+		Bun.env.ANTIGRAVITY_SEARCH_MODEL = "env-model";
+		await searchAntigravity({
+			query: "q",
+			antigravityModel: "setting-model",
+			authStorage: oauthStorage(["google-antigravity"], []),
+			fetch: capture(new Response(JSON.stringify(fixture.response), { status: 200 }), requests),
+		});
+		expect(requests[1]?.body.model).toBe("env-model");
+	});
+
+	it("decodes gzip JSON when the fetch implementation leaves the response compressed", async () => {
+		const compressed = Bun.gzipSync(new TextEncoder().encode(JSON.stringify(fixture.response)));
+		const response = await searchAntigravity({
+			query: "q",
+			authStorage: oauthStorage(["google-antigravity"], []),
+			fetch: capture(new Response(compressed, { status: 200, headers: { "content-encoding": "gzip" } }), []),
+		});
+		expect(response.answer).toBe("Grounded answer.");
+	});
+
+	for (const [name, payload, message] of [
+		["empty", {}, "empty response"],
+		["non-grounded", { candidates: [{ content: { parts: [{ text: "answer" }] } }] }, "no Google Search grounding"],
+		["provider error", { error: { message: "backend error" } }, "backend error"],
+		[
+			"overflow",
+			{
+				candidates: [
+					{ finishReason: "MAX_TOKENS", groundingMetadata: fixture.response.candidates[0].groundingMetadata },
+				],
+			},
+			"overflowed",
+		],
+	] as const) {
+		it(`rejects ${name} responses without fabricating citations`, async () => {
+			await expect(
+				searchAntigravity({
+					query: "q",
+					authStorage: oauthStorage(["google-antigravity"], []),
+					fetch: capture(new Response(JSON.stringify(payload), { status: 200 }), []),
+				}),
+			).rejects.toThrow(message);
+		});
+	}
+
+	it("never tries sandbox when the daily endpoint fails", async () => {
+		const urls: string[] = [];
+		await expect(
+			searchAntigravity({
+				query: "q",
+				authStorage: oauthStorage(["google-antigravity"], []),
+				fetch: url => {
+					urls.push(String(url));
+					return Promise.resolve(
+						new Response("daily unavailable", { status: 503, headers: { "retry-after": "3600" } }),
+					);
+				},
+			}),
+		).rejects.toThrow("503");
+		expect(urls).toHaveLength(1);
+		expect(urls.every(url => url === fixture.request.url)).toBe(true);
+	});
+
+	it("propagates caller cancellation", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		await expect(
+			searchAntigravity({
+				query: "q",
+				signal: controller.signal,
+				authStorage: oauthStorage(["google-antigravity"], []),
+				fetch: () => Promise.reject(new DOMException("Aborted", "AbortError")),
+			}),
+		).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
## Summary

- Aligns Antigravity Gemini 3.6 Flash thinking metadata with captured `agy` 1.1.8 wire contracts, migrating to numeric `thinkingBudget` limits and wire model IDs while keeping standard `thinkingLevel` controls for `google-gemini-cli`.
- Hardens Cloud Code Assist stream handling against empty responses and classifies payload size error responses as context overflow to trigger session compaction.
- Simplifies Antigravity routing to use the daily endpoint (`https://daily-cloudcode-pa.googleapis.com`) exclusively, removing redundant sandbox failover paths and configuration options.
- Adds an independently selectable `antigravity` web-search provider backed by google-antigravity OAuth credentials and stock `generateContent` Google Search grounding envelopes.

## What changed

- **Gemini 3.6 thinking metadata and catalog policies**: Uses budget mode with captured per-effort limits (`minimal`/`low`: 1000, `medium`: 4000, `high`: 10000) and tier-specific `gemini-3.6-flash-*` wire IDs. The generated catalog policy remains separate from `google-gemini-cli` level-based thinking. The SQLite model cache version advances to invalidate stale entries.
- **Empty Stream Handling & Compaction Signals**: Hardened stream parsing for empty Cloud Code Assist responses on the daily endpoint. Updated `createCloudCodeApiError` to match oversized payload errors (status 400/413) and flag `AIError.Flag.ContextOverflow` for session compaction.
- **Daily Endpoint Consolidation**: Removed unobserved sandbox endpoint failover (`daily-cloudcode-pa.sandbox.googleapis.com`) and deprecated `providers.antigravityEndpoint` settings. All Antigravity AI stream, session, and image generation calls now route directly to `https://daily-cloudcode-pa.googleapis.com`.
- **Antigravity Web Search Provider**: Implemented the `antigravity` web search provider in `packages/coding-agent/src/web/search/providers/antigravity.ts` using google-antigravity OAuth authentication and stock `generateContent` Google Search grounding payload formatting. Added the `providers.webSearchAntigravityModel` setting schema.

## Verification

Focused test suites covering this contract:

- `packages/ai/test/google-gemini-cli-3x-thinking.test.ts` (Gemini 3.6 thinking budget payload construction and wire profiles)
- `packages/ai/test/google-antigravity-compaction.test.ts` (Cloud Code Assist oversized request context overflow classification)
- `packages/ai/test/google-empty-response-retry.test.ts` (Empty-response retry behavior on daily endpoint)
- `packages/catalog/test/variant-collapse.test.ts` (Variant collapse and thinking mode separation between Antigravity and Gemini CLI)
- `packages/coding-agent/test/tools/web-search-antigravity.test.ts` (Antigravity web search provider grounding execution)
- `packages/coding-agent/test/settings-stream-fn.test.ts` (Stream function settings resolution)

## Notes

- Enforces numeric `thinkingBudget` for `google-antigravity` while retaining level-based `thinkingLevel` for `google-gemini-cli` calls.
- Catalog SQLite cache schema version bumped to 13 to force invalidation of legacy cached model entries.

## Reversed contract (`agy` 1.1.8)

Everything below was captured from the installed binary (`agy --version` = `1.1.8`, SHA-256 `02a008967b01b078f9d48afb5a149a1b2595a948e6c01a998d96ade94db48e30`) via live minimal probes with a local intercepting proxy. Queries, content, identifiers, URLs, output, and credentials were redacted; only protocol shape and non-secret constants were retained.

### Generation stream

| Field | Captured value |
|---|---|
| Endpoint | `POST https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse` |
| Outer envelope | `{ model, project, request, requestId, requestType, userAgent }` |
| Request type | `agent` |
| Wire model | `gemini-3.6-flash-<tier>` (probe: `gemini-3.6-flash-low`) |
| Thinking | `{ includeThoughts: true, thinkingBudget: <numeric> }` — low `1000`, medium `4000`, high `10000` |
| `thinkingLevel` | absent |
| System instruction | role `user`, `parts: [{ text }]` |
| Framing | request `Content-Type: application/json` + `Transfer-Encoding: chunked`; response HTTP 200 SSE terminating in `finishReason: STOP` |
| Headers sent | `authorization`, `user-agent`, `content-type`, `accept-encoding`, `host`, `transfer-encoding` |

### Endpoint selection

The binary contains `https://daily-cloudcode-pa.googleapis.com` and a separate `https://cloudcode-pa.googleapis.com` literal, but **no** `daily-cloudcode-pa.sandbox.googleapis.com` literal, and `agy --help` exposes no endpoint or sandbox switch. Every observed stream — agent and automatic checkpoint — used the daily origin. Daily-only routing in this PR is therefore the reversed contract, not a preference, and the removed sandbox failover had no observed enabling control.

### Grounding: two negative results and one positive

1. **Prompting alone does not ground.** With an explicit native-Google-Search instruction, stock `agy` did not serialize `tools[].googleSearch`, and the successful SSE carried no `groundingMetadata`, `groundingChunks`, or `groundingSupports`. The binary ships `googleSearch`, `groundingMetadata`, and `GROUNDING_WITH_GOOGLE_SEARCH` schemas, but co-presence is not activation.
2. **A bare native tool is accepted but still does not ground.** A second probe reused the exact captured envelope, auth, endpoint, wire model, and thinking fields, mutating only `request.tools` to `[{ googleSearch: {} }]`. The daily endpoint returned HTTP 200 / SSE / `STOP` with no grounding, chunks, supports, citations, or `error`. Acceptance is proven; invocation is not.
3. **The stock tool path does ground, through a different route.** Static trace resolves `search_web` as `cortex/handlers/search_web_handler.go` → `SearchWebHandler.Handle` → `core/tools/search_web.go` → `SearchWebTool.Execute` → `formatSearchWebResult`. A time-sensitive query made the model emit one `search_web` call with argument schema exactly `{ query, toolAction, toolSummary }`; the result returned as `functionResponse.response: { output }`.

### Stock `search_web` executor

The handler calls no external search backend. It issues an authenticated **non-streaming** request:

`POST https://daily-cloudcode-pa.googleapis.com/v1internal:generateContent`

Envelope `{ model, project, request, requestType, userAgent }`; nested request carries one text content part, a user-role system instruction, and:

```json
{
  "generationConfig": { "candidateCount": 1 },
  "tools": [{ "googleSearch": { "enhancedContent": { "imageSearch": { "maxResultCount": 5 } } } }]
}
```

`generationConfig.thinkingConfig` is **absent**. The response is HTTP 200 gzip JSON proving server-side search ran:

```text
response.candidates[].groundingMetadata = {
  webSearchQueries: [...],
  searchEntryPoint: { renderedContent },
  groundingChunks: [{ web: { uri, title } }],
  groundingSupports: [{ segment: { endIndex, text }, groundingChunkIndices: [...] }]
}
```

Stock then reduces this to `{ output }`, discarding citations at the tool boundary. The provider in this PR calls the same executor route and keeps the grounding metadata instead, which is why it can cite sources the CLI cannot.

### Error surface

No overflow or error payload was observed live. `MODEL_CAPACITY_EXHAUSTED` and `PREFILL_QUEUE_OVERLOADED` exist as static strings in the binary, but their runtime envelope was never observed and is deliberately not inferred here.
