### PR TITLE
fix(ai): recognize Anthropic strict-field rejections

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed direct Anthropic Claude Opus 5 requests failing with HTTP 400 when the endpoint rejected `strict` tool fields; the existing non-strict retry now recognizes `tools.N.custom.strict: Extra inputs are not permitted` responses ([#6976](https://github.com/can1357/oh-my-pi/issues/6976)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -123,6 +123,8 @@ const SCHEMA_COMPILE_PATTERN = /compil/i;
 const INVALID_REQUEST_PATTERN = /invalid_request_error/i;
 const STRUCTURED_OUTPUTS_PATTERN = /structured[_ -]?outputs?/i;
 const FEATURE_NOT_SUPPORTED_PATTERN = /not (?:supported|available|enabled)|unsupported|does(?: not|n'?t) support/i;
+const ANTHROPIC_STRICT_FIELD_PATTERN = /\btools\.\d+\.custom\.strict\b/i;
+const EXTRA_INPUTS_NOT_PERMITTED_PATTERN = /extra inputs? (?:are|is) not permitted/i;
 // Anthropic fast-mode unsupported: 400 rejecting `speed`, or 429 rate_limit_error
 // because the account lacks the extra-usage entitlement fast mode requires.
 const FAST_MODE_SPEED_PARAM_PATTERN = /\bspeed\b/i;
@@ -138,6 +140,9 @@ const OAUTH_HTTP_AUTH_PATTERN = /\b401\b/;
 
 function matchesStrictToolsRejection(message: string, errorStatus: number | undefined): boolean {
 	if (errorStatus !== 400) return false;
+	if (ANTHROPIC_STRICT_FIELD_PATTERN.test(message) && EXTRA_INPUTS_NOT_PERMITTED_PATTERN.test(message)) {
+		return true;
+	}
 	if (STRUCTURED_OUTPUTS_PATTERN.test(message) && FEATURE_NOT_SUPPORTED_PATTERN.test(message)) return true;
 	if (!INVALID_REQUEST_PATTERN.test(message)) return false;
 	const grammarTooLarge = GRAMMAR_TOO_LARGE_PATTERN.test(message) && GRAMMAR_TOO_LARGE_DETAIL_PATTERN.test(message);

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -142,14 +142,6 @@ function createStrictGrammarTooLargeError(): Error {
 	return error;
 }
 
-// Azure Foundry-style rejection: no invalid_request_error wrapper, the gateway
-// just names the missing feature for the hosted model deployment.
-function createStructuredOutputsUnsupportedError(): Error {
-	const error = new Error('400 {"error":{"code":"BadRequest","message":"structured_outputs not supported"}}');
-	(error as Error & { status: number }).status = 400;
-	return error;
-}
-
 function createOtherInvalidRequestError(): Error {
 	const error = new Error(
 		'400 {"type":"error","error":{"type":"invalid_request_error","message":"Some other validation error."},"request_id":"req_test"}',
@@ -1225,7 +1217,23 @@ describe("anthropic stream envelope handling", () => {
 		expect(strictFlags).toEqual([[true], [false], [false]]);
 	});
 
-	it("retries without strict tools when the endpoint rejects structured outputs for the model", async () => {
+	it.each([
+		[
+			"unsupported structured outputs",
+			Object.assign(new Error('400 {"error":{"code":"BadRequest","message":"structured_outputs not supported"}}'), {
+				status: 400,
+			}),
+		],
+		[
+			"an unsupported strict field",
+			Object.assign(
+				new Error(
+					'400 {"error":{"message":"{\\"message\\":\\"tools.2.custom.strict: Extra inputs are not permitted\\"}"}}',
+				),
+				{ status: 400 },
+			),
+		],
+	])("retries without strict tools when the endpoint rejects %s", async (_case, rejection) => {
 		const toolContext: Context = {
 			...context,
 			tools: [
@@ -1244,7 +1252,7 @@ describe("anthropic stream envelope handling", () => {
 			attempt += 1;
 			strictFlags.push(getStrictFlags(params));
 			if (attempt === 1) {
-				return createRejectedMockRequest(createStructuredOutputsUnsupportedError()) as never;
+				return createRejectedMockRequest(rejection) as never;
 			}
 			return createMockRequest(createTextSuccessEvents("recovered")) as never;
 		});


### PR DESCRIPTION
## Repro
On 17.1.8/current `main`, construct the reported HTTP 400 (`tools.2.custom.strict: Extra inputs are not permitted`) and pass it to `isGrammarError()` with `bun -e`; it returns `false`, so `streamAnthropic()` does not enter its existing pre-token retry path and the direct Opus 5 request fails.

## Cause
`packages/ai/src/error/flags.ts` recognized oversized strict grammars and explicit structured-output support errors, but not Anthropic’s Pydantic-style rejection of `tools.N.custom.strict`; `packages/ai/src/providers/anthropic.ts` therefore treated that 400 as terminal even though the outgoing payload contained strict tools.

## Fix
- Classify the exact Anthropic strict-field/extra-input validation shape as a strict-tool rejection.
- Cover both the prior structured-output wording and the Opus 5 wording through the provider-level retry test, asserting the retry removes `strict` and sticks for the session.
- Record the fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/anthropic-stream-envelope.test.ts` — 33 passed, 0 failed. `bun --filter @oh-my-pi/pi-ai check` — passed. Manual classifier smoke now reports `classifiedAsStrictRejection: true`. Fixes #6976