### PR TITLE
fix(ai): keep missing usage windows neutral in ranking

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed usage-based credential ranking treating a missing long-window metric as the short-window metric. Anthropic accounts whose 7-day bucket is not yet reported now keep the missing window neutral instead of letting 5-hour reset urgency shadow a sibling with reported weekly headroom ([#6980](https://github.com/can1357/oh-my-pi/pull/6980) by [@joswha](https://github.com/joswha)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1994,7 +1994,6 @@ export class AuthStorage {
 			const windows = usage ? strategy.findWindowLimits(usage, args.rankingContext) : undefined;
 			const primary = windows?.primary;
 			const secondary = windows?.secondary;
-			const secondaryTarget = secondary ?? primary;
 			ranked.push({
 				selection,
 				usage,
@@ -2003,9 +2002,9 @@ export class AuthStorage {
 				blockedUntil,
 				hasPriorityBoost: strategy.hasPriorityBoost?.(primary) ?? false,
 				planPriority: 0,
-				secondaryUsed: this.#normalizeUsageFraction(secondaryTarget),
+				secondaryUsed: this.#normalizeUsageFraction(secondary),
 				secondaryRequiredDrain: this.#computeWindowRequiredDrain(
-					secondaryTarget,
+					secondary,
 					nowMs,
 					strategy.windowDefaults.secondaryMs,
 				),
@@ -4451,7 +4450,6 @@ export class AuthStorage {
 			const windows = usage ? strategy.findWindowLimits(usage, args.rankingContext) : undefined;
 			const primary = windows?.primary;
 			const secondary = windows?.secondary;
-			const secondaryTarget = secondary ?? primary;
 			ranked.push({
 				selection,
 				usage,
@@ -4460,9 +4458,9 @@ export class AuthStorage {
 				blockedUntil,
 				hasPriorityBoost: strategy.hasPriorityBoost?.(primary) ?? false,
 				planPriority: getOpenAICodexPlanPriority(usage, args.planRequirement),
-				secondaryUsed: this.#normalizeUsageFraction(secondaryTarget),
+				secondaryUsed: this.#normalizeUsageFraction(secondary),
 				secondaryRequiredDrain: this.#computeWindowRequiredDrain(
-					secondaryTarget,
+					secondary,
 					nowMs,
 					strategy.windowDefaults.secondaryMs,
 				),

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -2391,7 +2391,7 @@ function createClaudeLimit(args: {
 function createClaudeUsageReport(args: {
 	accountId: string;
 	primary: { usedFraction: number; resetInMs?: number };
-	secondary: { usedFraction: number; resetInMs?: number };
+	secondary?: { usedFraction: number; resetInMs?: number };
 	fableSecondary?: { usedFraction: number; resetInMs?: number };
 }): UsageReport {
 	const limits = [
@@ -2401,13 +2401,17 @@ function createClaudeUsageReport(args: {
 			usedFraction: args.primary.usedFraction,
 			resetInMs: args.primary.resetInMs,
 		}),
-		createClaudeLimit({
-			key: "7d",
-			durationMs: WEEK_MS,
-			usedFraction: args.secondary.usedFraction,
-			resetInMs: args.secondary.resetInMs,
-		}),
 	];
+	if (args.secondary) {
+		limits.push(
+			createClaudeLimit({
+				key: "7d",
+				durationMs: WEEK_MS,
+				usedFraction: args.secondary.usedFraction,
+				resetInMs: args.secondary.resetInMs,
+			}),
+		);
+	}
 	if (args.fableSecondary) {
 		limits.push(
 			createClaudeLimit({
@@ -2526,6 +2530,36 @@ describe("AuthStorage claude oauth ranking", () => {
 
 		const apiKey = await authStorage.getApiKey("anthropic", "session-claude-clockless");
 		expect(apiKey).toBe("api-acct-clocked");
+	});
+
+	test("does not rank a missing weekly window as the account's 5h window", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("anthropic", [
+			{ type: "oauth", ...createCredential("acct-missing-weekly", "missing@example.com") },
+			{ type: "oauth", ...createCredential("acct-complete", "complete@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-missing-weekly",
+			createClaudeUsageReport({
+				accountId: "acct-missing-weekly",
+				primary: { usedFraction: 0.8, resetInMs: 3 * HOUR_MS },
+			}),
+		);
+		usageByAccount.set(
+			"acct-complete",
+			createClaudeUsageReport({
+				accountId: "acct-complete",
+				primary: { usedFraction: 0 },
+				secondary: { usedFraction: 0 },
+			}),
+		);
+
+		const apiKey = await authStorage.getApiKey("anthropic", "session-claude-missing-weekly", {
+			modelId: "claude-opus-4-8",
+		});
+		expect(apiKey).toBe("api-acct-complete");
 	});
 
 	test("resolves equal-priority accounts to one deterministic pick", async () => {


### PR DESCRIPTION
## What

Stop substituting a provider's primary usage window when its secondary window is absent. Missing secondary metrics now retain the existing neutral score, while providers that expose only one window still rank by their primary metric after the neutral secondary tie. The change applies consistently to OAuth and API-key credential ranking.

Adds an Anthropic regression matching a live account shape: 80% used in the 5-hour window, no shared 7-day row, versus a sibling reporting 0% in both windows.

## Why

`secondary ?? primary` made a missing Anthropic 7-day row borrow the 5-hour row's utilization, duration, and reset clock. The weekly-first comparator then treated 5-hour reset urgency as weekly urgency and selected the 80%-used, missing-weekly account over the fully reported 0%-used sibling.

On omp 17.1.8, `omp dry-balance` reproduced this for Opus in 20/20 samples. Running the source CLI after this fix selects the fully reported sibling in 20/20 samples. Fable selection is intentionally unchanged because Fable has its own reported model-scoped weekly row; Anthropic still provides no shared-weekly value or reset timestamp to display until that window exists, so this does not invent one.

## Testing

- `bun test packages/ai/test/auth-storage-codex-selection.test.ts` — 56 pass
- `bun test packages/ai/test/auth-storage-antigravity-selection.test.ts` — 3 pass
- `bun test packages/ai/test/auth-storage-zai-api-key-selection.test.ts` — 3 pass
- `bun packages/coding-agent/src/cli.ts dry-balance --model anthropic/claude-opus-4-8 --count 20 --concurrency 1 --json` — fully reported sibling selected 20/20
- `bun packages/coding-agent/src/cli.ts dry-balance --model anthropic/claude-fable-5 --count 20 --concurrency 1 --json` — model-scoped Fable ranking unchanged
- `bun run fix`
- `bun check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)