### PR TITLE
feat(catalog): add bedrock-mantle provider for OpenAI GPT-5.6 on AWS

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added authentication and region resolution for the new `bedrock-mantle` provider. Requests reuse the existing `openai-responses` transport, with `{region}` in the base URL resolved from the explicit option, `AWS_REGION`, `AWS_DEFAULT_REGION`, then `us-east-1`, and credentials supplied either as a Bedrock API key (`AWS_BEARER_TOKEN_BEDROCK`) or via SigV4 over the standard AWS credential chain.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/registry/amazon-bedrock.ts
+++ b/packages/ai/src/registry/amazon-bedrock.ts
@@ -1,5 +1,5 @@
 import { $env } from "@oh-my-pi/pi-utils";
-import type { ProviderDefinition } from "./types";
+import { AUTHENTICATED_SENTINEL, type ProviderDefinition } from "./types";
 
 export const amazonBedrockProvider = {
 	id: "amazon-bedrock",
@@ -16,7 +16,7 @@ export const amazonBedrockProvider = {
 			hasEcsCredentials ||
 			hasWebIdentity
 		) {
-			return "<authenticated>";
+			return AUTHENTICATED_SENTINEL;
 		}
 	},
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/bedrock-mantle.ts
+++ b/packages/ai/src/registry/bedrock-mantle.ts
@@ -1,5 +1,5 @@
 import { $env } from "@oh-my-pi/pi-utils";
-import type { ProviderDefinition } from "./types";
+import { AUTHENTICATED_SENTINEL, type ProviderDefinition } from "./types";
 
 export const bedrockMantleProvider = {
 	id: "bedrock-mantle",
@@ -18,7 +18,7 @@ export const bedrockMantleProvider = {
 			hasEcsCredentials ||
 			hasWebIdentity
 		) {
-			return "<authenticated>";
+			return AUTHENTICATED_SENTINEL;
 		}
 	},
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/bedrock-mantle.ts
+++ b/packages/ai/src/registry/bedrock-mantle.ts
@@ -1,0 +1,24 @@
+import { $env } from "@oh-my-pi/pi-utils";
+import type { ProviderDefinition } from "./types";
+
+export const bedrockMantleProvider = {
+	id: "bedrock-mantle",
+	name: "Amazon Bedrock Mantle",
+	// Same auth surface as `amazon-bedrock`: bearer tokens, IAM keys, profiles,
+	// ECS/IRSA credential chains. Requests are signed (or bearer-authenticated)
+	// by `createBedrockMantleAuthenticatedFetch` in `stream.ts`.
+	envKeys: () => {
+		const hasEcsCredentials =
+			!!$env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || !!$env.AWS_CONTAINER_CREDENTIALS_FULL_URI;
+		const hasWebIdentity = !!$env.AWS_WEB_IDENTITY_TOKEN_FILE && !!$env.AWS_ROLE_ARN;
+		if (
+			$env.AWS_PROFILE ||
+			($env.AWS_ACCESS_KEY_ID && $env.AWS_SECRET_ACCESS_KEY) ||
+			$env.AWS_BEARER_TOKEN_BEDROCK ||
+			hasEcsCredentials ||
+			hasWebIdentity
+		) {
+			return "<authenticated>";
+		}
+	},
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -6,6 +6,7 @@ import { amazonBedrockProvider } from "./amazon-bedrock";
 import { anthropicProvider } from "./anthropic";
 import { azureProvider } from "./azure";
 import { basetenProvider } from "./baseten";
+import { bedrockMantleProvider } from "./bedrock-mantle";
 import { cerebrasProvider } from "./cerebras";
 import { cloudflareAiGatewayProvider } from "./cloudflare-ai-gateway";
 import { coreWeaveProvider } from "./coreweave";
@@ -152,6 +153,7 @@ const ALL = [
 	mistralProvider,
 	minimaxProvider,
 	amazonBedrockProvider,
+	bedrockMantleProvider,
 ];
 
 export type RegistryDef = (typeof ALL)[number];

--- a/packages/ai/src/registry/types.ts
+++ b/packages/ai/src/registry/types.ts
@@ -19,6 +19,15 @@ import type { OAuthCredentials, OAuthLoginCallbacks } from "./oauth/types";
 export type KeyResolver = string | (() => string | undefined);
 
 /**
+ * `envKeys` result for providers whose credentials are resolved out-of-band (the
+ * AWS credential chain, Vertex ADC) rather than read from an env var. It only
+ * has to be non-empty so the `MissingApiKeyError` gate does not fire; the real
+ * `Authorization` header is set later by the provider's wrapping fetch. Distinct
+ * from `NO_AUTH_SENTINEL` (`"N/A"`), which means "send no Authorization at all".
+ */
+export const AUTHENTICATED_SENTINEL = "<authenticated>";
+
+/**
  * Declarative description of a single provider's auth/login wiring. All
  * fields are optional except `id`/`name`; presence of a field opts the
  * provider into a derived structure:

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -727,7 +727,14 @@ function createBedrockMantleAuthenticatedFetch(options: StreamOptions | undefine
 			query: url.search.replace(/^\?/, ""),
 			body,
 			region,
-			service: "bedrock",
+			// Mantle is its own IAM service, not part of `bedrock`: the Service
+			// Authorization Reference lists it as `service prefix: bedrock-mantle`
+			// with its own `CreateInference` action and `arn:*:bedrock-mantle:*`
+			// resources. A credential scope of `.../bedrock/aws4_request` is rejected
+			// even for a principal holding the Mantle inference policy. The Converse
+			// path stays on `bedrock`.
+			// https://docs.aws.amazon.com/service-authorization/latest/reference/list_bedrock-mantle.html
+			service: "bedrock-mantle",
 			credentials,
 			headers: { "content-type": contentType },
 		});
@@ -1278,6 +1285,14 @@ export function streamSimple<TApi extends Api>(
 		return stream(model, context, providerOptions);
 	} else if (model.api === "bedrock-converse-stream") {
 		// Bedrock doesn't have any API keys instead it sources credentials from standard AWS env variables or from given AWS profile.
+		const providerOptions = mapOptionsForApi(model, requestOptions, undefined);
+		return stream(model, context, providerOptions);
+	} else if (model.provider === "bedrock-mantle") {
+		// Same reason as the Converse branch: credentials come from the AWS chain,
+		// whose `~/.aws/credentials` profiles / SSO / IMDS sources the registry env
+		// probe cannot see. Gating on a key here would fail `completeSimple()` and
+		// the auth-gateway utility calls before `stream()` gets to resolve them.
+		// `mapOptionsForApi` keeps a caller-supplied key when one is present.
 		const providerOptions = mapOptionsForApi(model, requestOptions, undefined);
 		return stream(model, context, providerOptions);
 	}

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1155,6 +1155,18 @@ export function streamSimple<TApi extends Api>(
 		fetch: wrapFetchForProxy(debugOptions.fetch ?? (globalThis.fetch as FetchImpl), model.provider),
 	} as SimpleStreamOptions;
 
+	// `bedrock-mantle` credentials come from the AWS chain, so it must bypass key
+	// resolution entirely — ahead of the resolver block below, not just the static
+	// gate further down. A `ModelRegistry.resolver(...)` (the ordinary
+	// coding-agent / auth-gateway path) returns `undefined` when the only valid
+	// credentials live in `~/.aws/credentials` / SSO / IMDS, which the registry env
+	// probe cannot see, and that would fail before `stream()` ever gets to call
+	// `resolveAwsCredentials`. A caller-supplied static key still flows through
+	// `mapOptionsForApi` and is used as the bearer token.
+	if (model.provider === "bedrock-mantle") {
+		return stream(model, context, mapOptionsForApi(model, requestOptions, undefined));
+	}
+
 	const apiKeyResolver = isApiKeyResolver(requestOptions?.apiKey) ? requestOptions.apiKey : undefined;
 	if (apiKeyResolver) {
 		const outer = new AssistantMessageEventStream();
@@ -1285,14 +1297,6 @@ export function streamSimple<TApi extends Api>(
 		return stream(model, context, providerOptions);
 	} else if (model.api === "bedrock-converse-stream") {
 		// Bedrock doesn't have any API keys instead it sources credentials from standard AWS env variables or from given AWS profile.
-		const providerOptions = mapOptionsForApi(model, requestOptions, undefined);
-		return stream(model, context, providerOptions);
-	} else if (model.provider === "bedrock-mantle") {
-		// Same reason as the Converse branch: credentials come from the AWS chain,
-		// whose `~/.aws/credentials` profiles / SSO / IMDS sources the registry env
-		// probe cannot see. Gating on a key here would fail `completeSimple()` and
-		// the auth-gateway utility calls before `stream()` gets to resolve them.
-		// `mapOptionsForApi` keeps a caller-supplied key when one is present.
 		const providerOptions = mapOptionsForApi(model, requestOptions, undefined);
 		return stream(model, context, providerOptions);
 	}

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -67,6 +67,7 @@ import {
 } from "./providers/register-builtins";
 import { isSyntheticModel, streamSynthetic } from "./providers/synthetic";
 import { PROVIDER_REGISTRY } from "./registry";
+import { AUTHENTICATED_SENTINEL } from "./registry/types";
 import type {
 	Api,
 	AssistantMessage,
@@ -635,15 +636,6 @@ function createVertexAuthenticatedFetch(options: StreamOptions | undefined): Fet
 }
 
 /**
- * Sentinel `apiKey` for providers whose credentials are resolved out-of-band
- * (AWS credential chain) rather than passed as a bearer key. It only has to be
- * non-empty so the `MissingApiKeyError` gate below does not fire; the actual
- * `Authorization` header is set by the wrapping fetch. Distinct from
- * `NO_AUTH_SENTINEL` (`"N/A"`), which means "send no Authorization at all".
- */
-const AWS_AUTHENTICATED_SENTINEL = "<authenticated>";
-
-/**
  * Region for `bedrock-mantle` requests. Mirrors the resolution intent of
  * `resolveBedrockRegion`, minus the Geo/Global inference-profile machinery —
  * the Mantle model ids carry no geo prefix.
@@ -669,16 +661,27 @@ function resolveBedrockMantleRequest(input: string | URL | Request, region: stri
 	return rewriteBedrockMantleUrl(input, region);
 }
 
+/**
+ * SigV4 signs the exact payload bytes, and those same bytes are what gets
+ * re-sent. Anything this cannot read must therefore throw rather than fall back
+ * to an empty buffer: a `ReadableStream`/`Blob`/`FormData` body would otherwise
+ * go out empty under a valid-looking signature — a silent, hard-to-debug
+ * failure. Unreachable today (the `openai-responses` transport always hands over
+ * a JSON string), so the throw exists to fail loudly if that ever changes.
+ */
 async function readBedrockMantleRequestBody(
 	input: string | URL | Request,
 	init: RequestInit | undefined,
 ): Promise<Uint8Array> {
 	if (input instanceof Request) return new Uint8Array(await input.clone().arrayBuffer());
 	const body = init?.body;
+	if (body === undefined || body === null) return new Uint8Array();
 	if (typeof body === "string") return new TextEncoder().encode(body);
 	if (body instanceof Uint8Array) return body;
 	if (body instanceof ArrayBuffer) return new Uint8Array(body);
-	return new Uint8Array();
+	throw new AIError.ConfigurationError(
+		`bedrock-mantle cannot SigV4-sign a ${body.constructor?.name ?? typeof body} request body; expected a string, Uint8Array, or ArrayBuffer`,
+	);
 }
 
 /**
@@ -946,10 +949,10 @@ function streamDispatch<TApi extends Api>(
 					...requestOptions,
 					// A resolver is left for the auth-retry path to unwrap; only a
 					// plain string is a usable Bedrock API key here.
-					apiKey: AWS_AUTHENTICATED_SENTINEL,
+					apiKey: AUTHENTICATED_SENTINEL,
 					fetch: createBedrockMantleAuthenticatedFetch(
 						requestOptions,
-						typeof apiKey === "string" && apiKey !== AWS_AUTHENTICATED_SENTINEL ? apiKey : undefined,
+						typeof apiKey === "string" && apiKey !== AUTHENTICATED_SENTINEL ? apiKey : undefined,
 					),
 				}
 			: { ...requestOptions, apiKey };

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -24,6 +24,13 @@ import { isInvalidatedOAuthTokenError } from "./error/auth-classify";
 import { isUsageLimitOutcome } from "./error/rate-limit";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
+// `bedrock-mantle` signs its own requests inline (see
+// `createBedrockMantleAuthenticatedFetch`), so these must be callable
+// synchronously from the request path. Both modules are dependency-light —
+// `aws-sigv4` imports nothing and `aws-credentials` only node builtins plus
+// pi-utils — so eager import costs the startup parse graph nothing measurable.
+import { resolveAwsCredentials } from "./providers/aws-credentials";
+import { signRequest } from "./providers/aws-sigv4";
 import type { CursorOptions } from "./providers/cursor";
 import type { DevinOptions } from "./providers/devin";
 import { isGitLabDuoModel, streamGitLabDuo } from "./providers/gitlab-duo";
@@ -679,14 +686,20 @@ async function readBedrockMantleRequestBody(
  * way: a Bedrock API key as a bearer token, or SigV4 over the standard
  * credential chain. This wraps the transport's fetch to substitute `{region}`
  * in the base URL and inject the credentials, so no new transport is needed.
+ *
+ * `resolvedApiKey` carries a caller- or storage-supplied Bedrock API key that
+ * arrived through the ordinary `apiKey` path. It takes precedence over the
+ * credential chain the same way `bearerToken` does, so an explicit key is never
+ * silently discarded in favour of SigV4.
  */
-function createBedrockMantleAuthenticatedFetch(options: StreamOptions | undefined): FetchImpl {
+function createBedrockMantleAuthenticatedFetch(options: StreamOptions | undefined, resolvedApiKey?: string): FetchImpl {
 	const baseFetch = options?.fetch ?? (globalThis.fetch as FetchImpl);
 	const region = resolveBedrockMantleRegion(options);
 	const mantleFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
 		const rewritten = resolveBedrockMantleRequest(input, region);
 		const headers = new Headers(init?.headers);
-		const bearerToken = (options as BedrockOptions | undefined)?.bearerToken || $env.AWS_BEARER_TOKEN_BEDROCK;
+		const bearerToken =
+			(options as BedrockOptions | undefined)?.bearerToken || resolvedApiKey || $env.AWS_BEARER_TOKEN_BEDROCK;
 		if (bearerToken) {
 			headers.set("Authorization", `Bearer ${bearerToken}`);
 			return baseFetch(rewritten, { ...init, headers });
@@ -697,12 +710,6 @@ function createBedrockMantleAuthenticatedFetch(options: StreamOptions | undefine
 		const url = new URL(rewritten instanceof Request ? rewritten.url : rewritten.toString());
 		const body = await readBedrockMantleRequestBody(rewritten, init);
 		const method = init?.method ?? (rewritten instanceof Request ? rewritten.method : "POST");
-		// Loaded lazily to keep the AWS credential/signing modules out of the CLI
-		// startup parse graph, matching how the provider streams are imported.
-		const [{ resolveAwsCredentials }, { signRequest }] = await Promise.all([
-			import("./providers/aws-credentials"),
-			import("./providers/aws-sigv4"),
-		]);
 		const credentials = await resolveAwsCredentials({
 			profile: (options as BedrockOptions | undefined)?.profile,
 			region,
@@ -937,8 +944,13 @@ function streamDispatch<TApi extends Api>(
 		: isBedrockMantle
 			? {
 					...requestOptions,
+					// A resolver is left for the auth-retry path to unwrap; only a
+					// plain string is a usable Bedrock API key here.
 					apiKey: AWS_AUTHENTICATED_SENTINEL,
-					fetch: createBedrockMantleAuthenticatedFetch(requestOptions),
+					fetch: createBedrockMantleAuthenticatedFetch(
+						requestOptions,
+						typeof apiKey === "string" && apiKey !== AWS_AUTHENTICATED_SENTINEL ? apiKey : undefined,
+					),
 				}
 			: { ...requestOptions, apiKey };
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -627,6 +627,110 @@ function createVertexAuthenticatedFetch(options: StreamOptions | undefined): Fet
 	return Object.assign(vertexFetch, baseFetch.preconnect ? { preconnect: baseFetch.preconnect } : {});
 }
 
+/**
+ * Sentinel `apiKey` for providers whose credentials are resolved out-of-band
+ * (AWS credential chain) rather than passed as a bearer key. It only has to be
+ * non-empty so the `MissingApiKeyError` gate below does not fire; the actual
+ * `Authorization` header is set by the wrapping fetch. Distinct from
+ * `NO_AUTH_SENTINEL` (`"N/A"`), which means "send no Authorization at all".
+ */
+const AWS_AUTHENTICATED_SENTINEL = "<authenticated>";
+
+/**
+ * Region for `bedrock-mantle` requests. Mirrors the resolution intent of
+ * `resolveBedrockRegion`, minus the Geo/Global inference-profile machinery —
+ * the Mantle model ids carry no geo prefix.
+ */
+function resolveBedrockMantleRegion(options: StreamOptions | undefined): string {
+	const explicit = (options as BedrockOptions | undefined)?.region;
+	return explicit || $env.AWS_REGION || $env.AWS_DEFAULT_REGION || "us-east-1";
+}
+
+function rewriteBedrockMantleUrl(url: string, region: string): string {
+	return url.replaceAll("{region}", encodeURIComponent(region)).replaceAll("%7Bregion%7D", encodeURIComponent(region));
+}
+
+function resolveBedrockMantleRequest(input: string | URL | Request, region: string): string | URL | Request {
+	if (input instanceof Request) {
+		const rewritten = rewriteBedrockMantleUrl(input.url, region);
+		return rewritten === input.url ? input : new Request(rewritten, input);
+	}
+	if (input instanceof URL) {
+		const rewritten = rewriteBedrockMantleUrl(input.toString(), region);
+		return rewritten === input.toString() ? input : new URL(rewritten);
+	}
+	return rewriteBedrockMantleUrl(input, region);
+}
+
+async function readBedrockMantleRequestBody(
+	input: string | URL | Request,
+	init: RequestInit | undefined,
+): Promise<Uint8Array> {
+	if (input instanceof Request) return new Uint8Array(await input.clone().arrayBuffer());
+	const body = init?.body;
+	if (typeof body === "string") return new TextEncoder().encode(body);
+	if (body instanceof Uint8Array) return body;
+	if (body instanceof ArrayBuffer) return new Uint8Array(body);
+	return new Uint8Array();
+}
+
+/**
+ * `bedrock-mantle` speaks the OpenAI Responses API but authenticates the AWS
+ * way: a Bedrock API key as a bearer token, or SigV4 over the standard
+ * credential chain. This wraps the transport's fetch to substitute `{region}`
+ * in the base URL and inject the credentials, so no new transport is needed.
+ */
+function createBedrockMantleAuthenticatedFetch(options: StreamOptions | undefined): FetchImpl {
+	const baseFetch = options?.fetch ?? (globalThis.fetch as FetchImpl);
+	const region = resolveBedrockMantleRegion(options);
+	const mantleFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+		const rewritten = resolveBedrockMantleRequest(input, region);
+		const headers = new Headers(init?.headers);
+		const bearerToken = (options as BedrockOptions | undefined)?.bearerToken || $env.AWS_BEARER_TOKEN_BEDROCK;
+		if (bearerToken) {
+			headers.set("Authorization", `Bearer ${bearerToken}`);
+			return baseFetch(rewritten, { ...init, headers });
+		}
+
+		// SigV4 signs the exact bytes and the exact host/path, so read them off
+		// the already-rewritten request rather than the placeholder original.
+		const url = new URL(rewritten instanceof Request ? rewritten.url : rewritten.toString());
+		const body = await readBedrockMantleRequestBody(rewritten, init);
+		const method = init?.method ?? (rewritten instanceof Request ? rewritten.method : "POST");
+		// Loaded lazily to keep the AWS credential/signing modules out of the CLI
+		// startup parse graph, matching how the provider streams are imported.
+		const [{ resolveAwsCredentials }, { signRequest }] = await Promise.all([
+			import("./providers/aws-credentials"),
+			import("./providers/aws-sigv4"),
+		]);
+		const credentials = await resolveAwsCredentials({
+			profile: (options as BedrockOptions | undefined)?.profile,
+			region,
+			signal: options?.signal,
+			fetch: baseFetch,
+		});
+		const contentType = headers.get("content-type") ?? "application/json";
+		const signed = await signRequest({
+			method,
+			host: url.host,
+			path: url.pathname,
+			query: url.search.replace(/^\?/, ""),
+			body,
+			region,
+			service: "bedrock",
+			credentials,
+			headers: { "content-type": contentType },
+		});
+		for (const [name, value] of Object.entries(signed)) {
+			// `host` is a forbidden request header — fetch derives it from the URL,
+			// which is the same value that was just signed.
+			if (value !== undefined && name !== "host") headers.set(name, value);
+		}
+		return baseFetch(url.toString(), { ...init, method, headers, body });
+	};
+	return Object.assign(mantleFetch, baseFetch.preconnect ? { preconnect: baseFetch.preconnect } : {});
+}
+
 async function readVertexRequestBody(input: string | URL | Request, init: RequestInit | undefined): Promise<string> {
 	if (input instanceof Request) return input.clone().text();
 	const body = init?.body;
@@ -814,8 +918,14 @@ function streamDispatch<TApi extends Api>(
 		return streamBedrock(model as Model<"bedrock-converse-stream">, context, requestOptions as BedrockOptions);
 	}
 
+	// `bedrock-mantle` speaks the OpenAI Responses API but has no API key: the
+	// wrapping fetch resolves credentials from the AWS chain, exactly as the
+	// Converse path above does. The chain reaches sources the registry's env probe
+	// cannot see (`~/.aws/credentials` profiles, SSO, IMDS), so gating on a key
+	// here would reject valid setups — exempt it like `google-vertex`/Bedrock.
+	const isBedrockMantle = model.provider === "bedrock-mantle";
 	const apiKey = requestOptions.apiKey || getEnvApiKey(model.provider);
-	if (!apiKey) {
+	if (!apiKey && !isBedrockMantle) {
 		throw new AIError.MissingApiKeyError(model.provider);
 	}
 	const providerOptions = isGoogleVertexAuthenticatedModel(model)
@@ -824,7 +934,13 @@ function streamDispatch<TApi extends Api>(
 				apiKey: "vertex-adc",
 				fetch: createVertexAuthenticatedFetch(requestOptions),
 			}
-		: { ...requestOptions, apiKey };
+		: isBedrockMantle
+			? {
+					...requestOptions,
+					apiKey: AWS_AUTHENTICATED_SENTINEL,
+					fetch: createBedrockMantleAuthenticatedFetch(requestOptions),
+				}
+			: { ...requestOptions, apiKey };
 
 	const api: Api = model.api;
 	switch (api) {

--- a/packages/ai/test/bedrock-mantle-auth.test.ts
+++ b/packages/ai/test/bedrock-mantle-auth.test.ts
@@ -147,8 +147,9 @@ describe("bedrock-mantle authentication", () => {
 		});
 		const authorization = captured.authorization[0];
 		expect(authorization).toStartWith("AWS4-HMAC-SHA256 Credential=");
-		// Signed for the `bedrock` service in the resolved region — not `bedrock-mantle`.
-		expect(authorization).toContain(`/us-east-1/bedrock/aws4_request`);
+		// Mantle is its own IAM service prefix, so the credential scope is
+		// `bedrock-mantle` — not the `bedrock` the Converse path signs for.
+		expect(authorization).toContain(`/us-east-1/bedrock-mantle/aws4_request`);
 		// The catalog's `Bearer <sentinel>` default must never reach the wire.
 		expect(authorization).not.toContain("<authenticated>");
 	});
@@ -205,6 +206,6 @@ describe("bedrock-mantle authentication", () => {
 			AWS_REGION: "us-west-2",
 		});
 		expect(captured.urls[0]).toStartWith("https://bedrock-mantle.us-west-2.api.aws/openai/v1");
-		expect(captured.authorization[0]).toContain("/us-west-2/bedrock/aws4_request");
+		expect(captured.authorization[0]).toContain("/us-west-2/bedrock-mantle/aws4_request");
 	});
 });

--- a/packages/ai/test/bedrock-mantle-auth.test.ts
+++ b/packages/ai/test/bedrock-mantle-auth.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { clearAwsCredentialCache } from "@oh-my-pi/pi-ai/providers/aws-credentials";
+import { stream } from "@oh-my-pi/pi-ai/stream";
+import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { withEnv } from "./helpers";
+
+// The catalog seeds `{region}` as a placeholder in the base URL; `stream` swaps
+// in the resolved region and injects AWS credentials before the request goes out.
+const mantleModel: Model<"openai-responses"> = buildModel({
+	id: "openai.gpt-5.6-terra",
+	name: "GPT-5.6 Terra",
+	api: "openai-responses",
+	provider: "bedrock-mantle",
+	baseUrl: "https://bedrock-mantle.{region}.api.aws/openai/v1",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 2.75, output: 16.5, cacheRead: 0.28, cacheWrite: 3.44 },
+	contextWindow: 272_000,
+	maxTokens: 128_000,
+	thinking: {
+		mode: "effort",
+		efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+	},
+});
+
+function userContext(): Context {
+	return { messages: [{ role: "user", content: "Say hello", timestamp: 0 }] };
+}
+
+interface Captured {
+	urls: string[];
+	authorization: (string | null)[];
+	securityToken: (string | null)[];
+}
+
+/** Records the outgoing request and fails it, so nothing hits the network. */
+function capturingFetch(captured: Captured): FetchImpl {
+	return Object.assign(
+		async (input: string | URL | Request, init?: RequestInit) => {
+			captured.urls.push(String(input instanceof Request ? input.url : input));
+			const headers = new Headers(input instanceof Request ? input.headers : init?.headers);
+			captured.authorization.push(headers.get("authorization"));
+			captured.securityToken.push(headers.get("x-amz-security-token"));
+			return new Response("nope", { status: 418 });
+		},
+		{ preconnect: fetch.preconnect },
+	);
+}
+
+async function runOnce(env: Record<string, string | undefined>, options: { region?: string } = {}): Promise<Captured> {
+	const captured: Captured = { urls: [], authorization: [], securityToken: [] };
+	await withEnv(env, async () => {
+		clearAwsCredentialCache();
+		await stream(mantleModel, userContext(), {
+			...options,
+			fetch: capturingFetch(captured),
+			maxTokens: 16,
+		}).result();
+	});
+	return captured;
+}
+
+// Clear every AWS variable the resolvers consult, so the host environment (or a
+// developer's real profile) cannot leak into these assertions.
+const CLEAN_AWS_ENV: Record<string, string | undefined> = {
+	AWS_BEARER_TOKEN_BEDROCK: undefined,
+	AWS_ACCESS_KEY_ID: undefined,
+	AWS_SECRET_ACCESS_KEY: undefined,
+	AWS_SESSION_TOKEN: undefined,
+	AWS_PROFILE: undefined,
+	AWS_REGION: undefined,
+	AWS_DEFAULT_REGION: undefined,
+	// The credential chain would otherwise fall through to EC2 IMDS and stall.
+	AWS_EC2_METADATA_DISABLED: "true",
+};
+
+const STATIC_KEYS: Record<string, string> = {
+	AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE",
+	AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+};
+
+describe("bedrock-mantle region rewriting", () => {
+	beforeEach(() => {
+		clearAwsCredentialCache();
+	});
+
+	test("substitutes {region} from AWS_REGION", async () => {
+		const captured = await runOnce({
+			...CLEAN_AWS_ENV,
+			AWS_BEARER_TOKEN_BEDROCK: "test-token",
+			AWS_REGION: "us-west-2",
+		});
+		expect(captured.urls).toHaveLength(1);
+		expect(captured.urls[0]).toStartWith("https://bedrock-mantle.us-west-2.api.aws/openai/v1");
+		expect(captured.urls[0]).not.toContain("{region}");
+		expect(captured.urls[0]).not.toContain("%7Bregion%7D");
+	});
+
+	test("falls back to AWS_DEFAULT_REGION, then to us-east-1", async () => {
+		const viaDefault = await runOnce({
+			...CLEAN_AWS_ENV,
+			AWS_BEARER_TOKEN_BEDROCK: "test-token",
+			AWS_DEFAULT_REGION: "us-east-2",
+		});
+		expect(viaDefault.urls[0]).toStartWith("https://bedrock-mantle.us-east-2.api.aws/openai/v1");
+
+		const viaDefaultRegion = await runOnce({
+			...CLEAN_AWS_ENV,
+			AWS_BEARER_TOKEN_BEDROCK: "test-token",
+		});
+		expect(viaDefaultRegion.urls[0]).toStartWith("https://bedrock-mantle.us-east-1.api.aws/openai/v1");
+	});
+
+	test("an explicit option region wins over the environment", async () => {
+		const captured = await runOnce(
+			{ ...CLEAN_AWS_ENV, AWS_BEARER_TOKEN_BEDROCK: "test-token", AWS_REGION: "us-east-2" },
+			{ region: "us-west-2" },
+		);
+		expect(captured.urls[0]).toStartWith("https://bedrock-mantle.us-west-2.api.aws/openai/v1");
+	});
+});
+
+describe("bedrock-mantle authentication", () => {
+	beforeEach(() => {
+		clearAwsCredentialCache();
+	});
+
+	test("sends AWS_BEARER_TOKEN_BEDROCK as a bearer token, ahead of SigV4", async () => {
+		const captured = await runOnce({
+			...CLEAN_AWS_ENV,
+			...STATIC_KEYS,
+			AWS_BEARER_TOKEN_BEDROCK: "test-token",
+			AWS_REGION: "us-east-1",
+		});
+		// The bearer token must win even though static keys are also present.
+		expect(captured.authorization[0]).toBe("Bearer test-token");
+		expect(captured.securityToken[0]).toBeNull();
+	});
+
+	test("signs with SigV4 when no bearer token is set", async () => {
+		const captured = await runOnce({
+			...CLEAN_AWS_ENV,
+			...STATIC_KEYS,
+			AWS_REGION: "us-east-1",
+		});
+		const authorization = captured.authorization[0];
+		expect(authorization).toStartWith("AWS4-HMAC-SHA256 Credential=");
+		// Signed for the `bedrock` service in the resolved region — not `bedrock-mantle`.
+		expect(authorization).toContain(`/us-east-1/bedrock/aws4_request`);
+		// The catalog's `Bearer <sentinel>` default must never reach the wire.
+		expect(authorization).not.toContain("<authenticated>");
+	});
+
+	test("forwards a session token as x-amz-security-token", async () => {
+		const captured = await runOnce({
+			...CLEAN_AWS_ENV,
+			...STATIC_KEYS,
+			AWS_SESSION_TOKEN: "test-session-token",
+			AWS_REGION: "us-east-1",
+		});
+		expect(captured.authorization[0]).toStartWith("AWS4-HMAC-SHA256 Credential=");
+		expect(captured.securityToken[0]).toBe("test-session-token");
+		expect(captured.authorization[0]).toContain("x-amz-security-token");
+	});
+
+	test("is exempt from the API-key gate and defers to the AWS credential chain", async () => {
+		// The provider has no API key at all. The registry's env probe cannot see
+		// file-based profiles, SSO, or IMDS, so gating on a key here would reject
+		// valid setups: reaching the credential chain (and failing there) is the
+		// correct behavior, not `MissingApiKeyError`.
+		const captured: Captured = { urls: [], authorization: [], securityToken: [] };
+		let caught: unknown;
+		let errorMessage: string | undefined;
+		await withEnv(CLEAN_AWS_ENV, async () => {
+			clearAwsCredentialCache();
+			try {
+				// `MissingApiKeyError` is raised synchronously by the dispatcher, so it
+				// would surface here rather than as a stream error.
+				const result = await stream(mantleModel, userContext(), {
+					fetch: capturingFetch(captured),
+					maxTokens: 16,
+					// A profile that does not exist, so the chain cannot resolve anything.
+					profile: "omp-test-nonexistent-profile",
+					// Bound the wait: resolution may block on slow sources rather than
+					// failing fast, and either outcome proves the key gate was passed.
+					signal: AbortSignal.timeout(500),
+				} as Parameters<typeof stream>[2]).result();
+				errorMessage = result.errorMessage;
+			} catch (error) {
+				caught = error;
+			}
+		});
+		expect(caught).toBeUndefined();
+		expect(errorMessage ?? "").not.toContain("No API key");
+		// It failed while resolving AWS credentials, so no request was attempted.
+		expect(captured.urls).toEqual([]);
+	});
+
+	test("signs the region the request was actually rewritten to", async () => {
+		const captured = await runOnce({
+			...CLEAN_AWS_ENV,
+			...STATIC_KEYS,
+			AWS_REGION: "us-west-2",
+		});
+		expect(captured.urls[0]).toStartWith("https://bedrock-mantle.us-west-2.api.aws/openai/v1");
+		expect(captured.authorization[0]).toContain("/us-west-2/bedrock/aws4_request");
+	});
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `bedrock-mantle` provider for OpenAI's GPT-5.6 Sol/Terra/Luna on AWS. These models are served from AWS's dedicated `bedrock-mantle` endpoint over the OpenAI Responses API (`https://bedrock-mantle.{region}.api.aws/openai/v1`), with AWS-native authentication and per-model AWS pricing. Defaults to Terra.
+
+### Fixed
+
+- Removed the unusable `amazon-bedrock` entries for `openai.gpt-5.6-sol` / `-terra` / `-luna`. AWS's API-compatibility table marks these models as supporting neither Invoke nor Converse, so the generated `bedrock-converse-stream` rows failed on first use; they are now served by the new `bedrock-mantle` provider instead.
+
 ## [17.1.8] - 2026-07-28
 
 ### Added

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -31,6 +31,7 @@ import { PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
 import {
 	ALIBABA_TOKEN_PLAN_STATIC_MODELS,
 	ANTHROPIC_CURATED_FALLBACK_MODELS,
+	BEDROCK_MANTLE_STATIC_MODELS,
 	buildFireworksFastSeed,
 	buildXaiOAuthStaticSeed,
 	clampFireworksKimiMaxTokens,
@@ -53,6 +54,7 @@ import {
 	applyCanonicalLimitFallback,
 	applyGeneratedModelPolicies,
 	CLOUDFLARE_FALLBACK_MODEL,
+	dropBedrockConverseOnlyOpenAIIds,
 	dropUnsupportedBedrockGeoIds,
 	linkOpenAIPromotionTargets,
 } from "./generated-policies";
@@ -553,6 +555,10 @@ async function generateModels() {
 	// Seed Meta's documented Muse model so first-run selection does not depend on
 	// credentials or live discovery.
 	allModels.push(...META_MUSE_STATIC_MODELS);
+	// Seed the OpenAI GPT-5.6 models AWS serves on the `bedrock-mantle` endpoint.
+	// They are absent from models.dev under this provider, and the endpoint has no
+	// list-models discovery we use, so the documented rows are the only source.
+	allModels.push(...BEDROCK_MANTLE_STATIC_MODELS);
 	// Seed Sakana's documented Fugu models so the provider is usable when
 	// catalog generation has no live API key. If live `/v1/models` succeeds,
 	// Sakana is authoritative and stale seed IDs must stay out.
@@ -643,6 +649,7 @@ async function generateModels() {
 	allModels = dropUnusableZaiContextTierIds(allModels);
 	allModels = dropXiaomiAudioOnlyIds(allModels);
 	allModels = dropUnsupportedBedrockGeoIds(allModels);
+	allModels = dropBedrockConverseOnlyOpenAIIds(allModels);
 	allModels = normalizeAntigravityEndpoint(allModels);
 	// Normalize display names: gateway author prefixes ("OpenAI: …"), alias
 	// markers ("(latest)"), provider attribution ("(Antigravity)"), and

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -65,6 +65,31 @@ export function dropUnsupportedBedrockGeoIds(models: readonly ModelSpec[]): Mode
 	return models.filter(model => !(model.provider === "amazon-bedrock" && model.id === "jp.anthropic.claude-opus-5"));
 }
 
+const BEDROCK_CONVERSE_UNSUPPORTED_OPENAI_IDS = new Set([
+	"openai.gpt-5.6-sol",
+	"openai.gpt-5.6-terra",
+	"openai.gpt-5.6-luna",
+]);
+
+/**
+ * `models.dev` lists the OpenAI GPT-5.6 models under `amazon-bedrock`, but AWS's
+ * own API-compatibility table marks them **Invoke = NO, Converse = NO,
+ * Responses = YES**, and the model cards list `bedrock-runtime` as an
+ * unsupported endpoint. The generated `bedrock-converse-stream` rows therefore
+ * 4xx on first use. AWS serves these models on the separate `bedrock-mantle`
+ * endpoint instead, which this catalog covers via `BEDROCK_MANTLE_STATIC_MODELS`
+ * on the `openai-responses` transport — so drop the dead Converse rows rather
+ * than ship selectors that cannot work. Keeping this as a policy (not a
+ * one-time edit) is also what stops the upstream rows reappearing on every regen.
+ * https://docs.aws.amazon.com/bedrock/latest/userguide/models-api-compatibility.html
+ * https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
+ */
+export function dropBedrockConverseOnlyOpenAIIds(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.filter(
+		model => !(model.provider === "amazon-bedrock" && BEDROCK_CONVERSE_UNSUPPORTED_OPENAI_IDS.has(model.id)),
+	);
+}
+
 const CODEX_GPT_5_4_PRIORITY_BY_VARIANT: Partial<Record<OpenAIVariant, number>> = {
 	base: 0,
 	mini: 1,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -10005,96 +10005,6 @@
 			},
 			"contextPromotionTarget": "amazon-bedrock/openai.gpt-5.4"
 		},
-		"openai.gpt-5.6-luna": {
-			"id": "openai.gpt-5.6-luna",
-			"name": "GPT-5.6 Luna",
-			"api": "bedrock-converse-stream",
-			"provider": "amazon-bedrock",
-			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
-			},
-			"contextWindow": 272000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max"
-				]
-			}
-		},
-		"openai.gpt-5.6-sol": {
-			"id": "openai.gpt-5.6-sol",
-			"name": "GPT-5.6 Sol",
-			"api": "bedrock-converse-stream",
-			"provider": "amazon-bedrock",
-			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 5,
-				"output": 30,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
-			},
-			"contextWindow": 272000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max"
-				]
-			}
-		},
-		"openai.gpt-5.6-terra": {
-			"id": "openai.gpt-5.6-terra",
-			"name": "GPT-5.6 Terra",
-			"api": "bedrock-converse-stream",
-			"provider": "amazon-bedrock",
-			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 3.125
-			},
-			"contextWindow": 272000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max"
-				]
-			}
-		},
 		"openai.gpt-oss-120b": {
 			"id": "openai.gpt-oss-120b",
 			"name": "gpt-oss-120b",
@@ -13339,6 +13249,98 @@
 			"maxTokens": 524288,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		}
+	},
+	"bedrock-mantle": {
+		"openai.gpt-5.6-luna": {
+			"id": "openai.gpt-5.6-luna",
+			"name": "GPT-5.6 Luna",
+			"api": "openai-responses",
+			"provider": "bedrock-mantle",
+			"baseUrl": "https://bedrock-mantle.{region}.api.aws/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.1,
+				"output": 6.6,
+				"cacheRead": 0.11,
+				"cacheWrite": 1.38
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
+		},
+		"openai.gpt-5.6-sol": {
+			"id": "openai.gpt-5.6-sol",
+			"name": "GPT-5.6 Sol",
+			"api": "openai-responses",
+			"provider": "bedrock-mantle",
+			"baseUrl": "https://bedrock-mantle.{region}.api.aws/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5.5,
+				"output": 33,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.88
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
+		},
+		"openai.gpt-5.6-terra": {
+			"id": "openai.gpt-5.6-terra",
+			"name": "GPT-5.6 Terra",
+			"api": "openai-responses",
+			"provider": "bedrock-mantle",
+			"baseUrl": "https://bedrock-mantle.{region}.api.aws/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.75,
+				"output": 16.5,
+				"cacheRead": 0.28,
+				"cacheWrite": 3.44
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		}
 	},
 	"cerebras": {

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -99,6 +99,16 @@ export const CATALOG_PROVIDERS = [
 		id: "amazon-bedrock",
 		defaultModel: "us.anthropic.claude-opus-4-8",
 	},
+	// AWS's separate `bedrock-mantle` endpoint, which serves OpenAI's GPT-5.6
+	// models over the OpenAI Responses API. Models come from the static seed, not
+	// discovery. Terra is the default: it is AWS's positioning for general
+	// production work and is available in one more region than Sol. `envVars` is
+	// deliberately omitted — auth is a computed probe over the AWS credential
+	// chain in the pi-ai registry, and a plain name here would be shadowed by it.
+	{
+		id: "bedrock-mantle",
+		defaultModel: "openai.gpt-5.6-terra",
+	},
 	{
 		id: "anthropic",
 		defaultModel: "claude-opus-4-8",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3353,6 +3353,96 @@ export function metaModelManagerOptions(config?: MetaModelManagerConfig): ModelM
 }
 
 // ---------------------------------------------------------------------------
+// 15.76 Amazon Bedrock Mantle (OpenAI GPT-5.6 Sol/Terra/Luna)
+// ---------------------------------------------------------------------------
+
+/**
+ * AWS serves OpenAI's GPT-5.6 models through the dedicated `bedrock-mantle`
+ * endpoint using the OpenAI Responses API — not `bedrock-runtime`/Converse,
+ * which AWS's own API-compatibility table marks unsupported for these models.
+ *
+ * The path is `/openai/v1`, not the `/v1` used by other Responses-API models on
+ * this endpoint; the model card calls this out explicitly and getting it wrong
+ * yields a silent 404. `{region}` is rewritten at request time by
+ * `createBedrockMantleAuthenticatedFetch` in `@oh-my-pi/pi-ai`.
+ *
+ * https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
+ * https://docs.aws.amazon.com/bedrock/latest/userguide/models-api-compatibility.html
+ */
+const BEDROCK_MANTLE_BASE_URL = "https://bedrock-mantle.{region}.api.aws/openai/v1";
+
+/**
+ * Effort ladder matching the sibling first-party `openai` GPT-5.6 rows.
+ * `Effort` has no `none` member — the ladder is minimal…max.
+ */
+const BEDROCK_MANTLE_GPT_5_6_THINKING: ThinkingConfig = {
+	mode: "effort",
+	efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+};
+
+/**
+ * Pricing per 1M tokens for us-east-1/us-east-2, from AWS's Bedrock pricing
+ * page — deliberately **not** OpenAI's first-party numbers. AWS charges ~10%
+ * more, described on that page as parity with OpenAI's data-residency tier.
+ * `cacheWrite` is the 30-minute retention rate.
+ * https://aws.amazon.com/bedrock/pricing/
+ */
+const BEDROCK_MANTLE_GPT_5_6_SOL_COST = { input: 5.5, output: 33, cacheRead: 0.55, cacheWrite: 6.88 } as const;
+const BEDROCK_MANTLE_GPT_5_6_TERRA_COST = { input: 2.75, output: 16.5, cacheRead: 0.28, cacheWrite: 3.44 } as const;
+const BEDROCK_MANTLE_GPT_5_6_LUNA_COST = { input: 1.1, output: 6.6, cacheRead: 0.11, cacheWrite: 1.38 } as const;
+
+/**
+ * Context window (272K), modalities and Standard-only service tier come from the
+ * model cards. `maxTokens` is *not* documented by AWS for these models; 128000
+ * matches every other GPT-5.6 row in this catalog and is an assumption.
+ *
+ * Names carry no provider-attribution suffix: `cleanModelName` strips those
+ * (`"(Antigravity)"` and friends) during generation, so a suffix here would not
+ * survive into the bundle. The provider column disambiguates instead.
+ */
+export const BEDROCK_MANTLE_STATIC_MODELS: readonly ModelSpec<"openai-responses">[] = [
+	{
+		id: "openai.gpt-5.6-sol",
+		name: "GPT-5.6 Sol",
+		api: "openai-responses",
+		provider: "bedrock-mantle",
+		baseUrl: BEDROCK_MANTLE_BASE_URL,
+		reasoning: true,
+		input: ["text", "image"],
+		cost: BEDROCK_MANTLE_GPT_5_6_SOL_COST,
+		contextWindow: 272_000,
+		maxTokens: 128_000,
+		thinking: BEDROCK_MANTLE_GPT_5_6_THINKING,
+	},
+	{
+		id: "openai.gpt-5.6-terra",
+		name: "GPT-5.6 Terra",
+		api: "openai-responses",
+		provider: "bedrock-mantle",
+		baseUrl: BEDROCK_MANTLE_BASE_URL,
+		reasoning: true,
+		input: ["text", "image"],
+		cost: BEDROCK_MANTLE_GPT_5_6_TERRA_COST,
+		contextWindow: 272_000,
+		maxTokens: 128_000,
+		thinking: BEDROCK_MANTLE_GPT_5_6_THINKING,
+	},
+	{
+		id: "openai.gpt-5.6-luna",
+		name: "GPT-5.6 Luna",
+		api: "openai-responses",
+		provider: "bedrock-mantle",
+		baseUrl: BEDROCK_MANTLE_BASE_URL,
+		reasoning: true,
+		input: ["text", "image"],
+		cost: BEDROCK_MANTLE_GPT_5_6_LUNA_COST,
+		contextWindow: 272_000,
+		maxTokens: 128_000,
+		thinking: BEDROCK_MANTLE_GPT_5_6_THINKING,
+	},
+];
+
+// ---------------------------------------------------------------------------
 // 16. Moonshot
 // ---------------------------------------------------------------------------
 

--- a/packages/catalog/test/bedrock-mantle-gpt-5-6.test.ts
+++ b/packages/catalog/test/bedrock-mantle-gpt-5-6.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
+import { BEDROCK_MANTLE_STATIC_MODELS } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import { dropBedrockConverseOnlyOpenAIIds } from "../scripts/generated-policies";
+
+// AWS serves these three OpenAI models on the `bedrock-mantle` endpoint over the
+// OpenAI Responses API. Asserted against the seed/policy source rather than the
+// bundled `models.json`, so the test survives upstream metadata shifts.
+// https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
+const DOCUMENTED_IDS = ["openai.gpt-5.6-sol", "openai.gpt-5.6-terra", "openai.gpt-5.6-luna"];
+
+// Per 1M tokens, us-east-1/us-east-2, from AWS's Bedrock pricing page — not
+// OpenAI's first-party rates. `cacheWrite` is the 30-minute retention rate.
+// https://aws.amazon.com/bedrock/pricing/
+const DOCUMENTED_COST: Record<string, { input: number; output: number; cacheRead: number; cacheWrite: number }> = {
+	"openai.gpt-5.6-sol": { input: 5.5, output: 33, cacheRead: 0.55, cacheWrite: 6.88 },
+	"openai.gpt-5.6-terra": { input: 2.75, output: 16.5, cacheRead: 0.28, cacheWrite: 3.44 },
+	"openai.gpt-5.6-luna": { input: 1.1, output: 6.6, cacheRead: 0.11, cacheWrite: 1.38 },
+};
+
+describe("Bedrock Mantle GPT-5.6", () => {
+	test("seeds exactly the three documented models on the openai-responses transport", () => {
+		expect(BEDROCK_MANTLE_STATIC_MODELS.map(model => model.id)).toEqual(DOCUMENTED_IDS);
+		for (const model of BEDROCK_MANTLE_STATIC_MODELS) {
+			expect(model.provider).toBe("bedrock-mantle");
+			// Converse/Invoke are unsupported for these models; only Responses works.
+			expect(model.api).toBe("openai-responses");
+			// The `/openai/v1` path is specific to these models — the `/v1` path other
+			// Responses-API models on this endpoint use is a silent 404 here. `{region}`
+			// is substituted at request time by pi-ai.
+			expect(model.baseUrl).toBe("https://bedrock-mantle.{region}.api.aws/openai/v1");
+			expect(model.contextWindow).toBe(272_000);
+			expect(model.maxTokens).toBe(128_000);
+			expect(model.reasoning).toBe(true);
+			expect(model.input).toEqual(["text", "image"]);
+			expect(model.cost).toEqual(DOCUMENTED_COST[model.id]);
+			// `Effort` has no `none` member; the ladder matches the sibling `openai` rows.
+			expect(model.thinking).toEqual({
+				mode: "effort",
+				efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+			});
+		}
+	});
+
+	test("names carry no provider-attribution suffix, which generation would strip anyway", () => {
+		expect(BEDROCK_MANTLE_STATIC_MODELS.map(model => model.name)).toEqual([
+			"GPT-5.6 Sol",
+			"GPT-5.6 Terra",
+			"GPT-5.6 Luna",
+		]);
+	});
+
+	test("dropBedrockConverseOnlyOpenAIIds removes only the dead amazon-bedrock GPT-5.6 rows", () => {
+		const bareSpec = (provider: string, id: string): ModelSpec<"bedrock-converse-stream"> => ({
+			id,
+			name: id,
+			api: "bedrock-converse-stream",
+			provider,
+			baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		});
+		const input = [
+			bareSpec("amazon-bedrock", "openai.gpt-5.6-sol"),
+			// Other Bedrock rows — including other OpenAI ones that really do speak
+			// Converse — must survive, and order must be preserved.
+			bareSpec("amazon-bedrock", "us.anthropic.claude-opus-5"),
+			bareSpec("amazon-bedrock", "openai.gpt-5.6-terra"),
+			bareSpec("amazon-bedrock", "openai.gpt-oss-120b"),
+			bareSpec("amazon-bedrock", "openai.gpt-5.6-luna"),
+			bareSpec("amazon-bedrock", "openai.gpt-5.5"),
+			// The same ids under any other provider are served over a working
+			// transport and must not be touched.
+			bareSpec("bedrock-mantle", "openai.gpt-5.6-terra"),
+			bareSpec("openai", "gpt-5.6-terra"),
+		];
+
+		expect(dropBedrockConverseOnlyOpenAIIds(input).map(model => `${model.provider}/${model.id}`)).toEqual([
+			"amazon-bedrock/us.anthropic.claude-opus-5",
+			"amazon-bedrock/openai.gpt-oss-120b",
+			"amazon-bedrock/openai.gpt-5.5",
+			"bedrock-mantle/openai.gpt-5.6-terra",
+			"openai/gpt-5.6-terra",
+		]);
+	});
+
+	test("defaults the provider to Terra", () => {
+		// Terra is AWS's positioning for general production work and is available in
+		// one more region than Sol (us-west-2 in addition to us-east-1/us-east-2).
+		expect(DEFAULT_MODEL_PER_PROVIDER["bedrock-mantle"]).toBe("openai.gpt-5.6-terra");
+		expect(BEDROCK_MANTLE_STATIC_MODELS.some(model => model.id === "openai.gpt-5.6-terra")).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

AWS serves OpenAI's GPT-5.6 Sol/Terra/Luna from a dedicated `bedrock-mantle` endpoint using the OpenAI **Responses** API. oh-my-pi could not reach them:

1. The three ids existed in the catalog under `amazon-bedrock` tagged `api: "bedrock-converse-stream"` — but AWS's own [API-compatibility table](https://docs.aws.amazon.com/bedrock/latest/userguide/models-api-compatibility.html) marks these models **Invoke = NO, Converse = NO, Responses = YES**, and the [Sol model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html) lists `bedrock-runtime` as an unsupported endpoint. Those rows failed on first use.
2. There was no `bedrock-mantle` provider at all, so the working path was unreachable.

This adds a `bedrock-mantle` provider on the existing `openai-responses` transport with AWS-native auth, and removes the three unusable `amazon-bedrock` rows.

## Changes

- **Catalog seed** (`provider-models/openai-compat.ts`): `BEDROCK_MANTLE_STATIC_MODELS` with the three ids, following the `META_MUSE_STATIC_MODELS` precedent. Base URL is `https://bedrock-mantle.{region}.api.aws/openai/v1` — the `openai/v1` path is specific to these models; the `v1` path other Responses-API models on this endpoint use 404s silently. Context window 272K, text+image in.
- **Drop policy** (`scripts/generated-policies.ts`): `dropBedrockConverseOnlyOpenAIIds` removes `amazon-bedrock` × `openai.gpt-5.6-{sol,terra,luna}`. As a policy rather than a one-time edit, it also keeps the models.dev rows from reappearing on regen.
- **Descriptor** (`provider-models/descriptors.ts`): `{ id: "bedrock-mantle", defaultModel: "openai.gpt-5.6-terra" }`. Terra is available in one more region than Sol (adds `us-west-2`). `envVars` is omitted — the auth resolver is computed and would shadow a plain env name anyway.
- **Registry** (`packages/ai/src/registry/bedrock-mantle.ts`): mirrors `amazon-bedrock`'s `envKeys` probe, satisfying the `_CheckRegistryComplete` exhaustiveness gate.
- **Region + auth** (`packages/ai/src/stream.ts`): `createBedrockMantleAuthenticatedFetch`, modeled on `createVertexAuthenticatedFetch`. Substitutes `{region}` from the explicit option → `AWS_REGION` → `AWS_DEFAULT_REGION` → `us-east-1`, and injects either `AWS_BEARER_TOKEN_BEDROCK` as a bearer token or SigV4 headers over the standard credential chain. No new transport, and no `@aws-sdk/*` dependency — the existing `resolveAwsCredentials` / `signRequest` helpers are reused, loaded lazily to stay out of the CLI startup parse graph. The provider is exempt from the `MissingApiKeyError` gate the same way the Converse path is, since its credentials come from the AWS chain rather than an API key.

`DEFAULT_MODEL_PROVIDER_ORDER` is left untouched — `amazon-bedrock` is absent from that list too.

## Pricing and limits

Pricing is from the [Bedrock pricing page](https://aws.amazon.com/bedrock/pricing/), not OpenAI's first-party rates — AWS charges ~10% more for what the page describes as parity with the OpenAI data-residency tier. Per 1M tokens, us-east-1/us-east-2, `cacheWrite` at 30m retention:

| model | input | output | cacheRead | cacheWrite |
|---|---|---|---|---|
| Sol | 5.50 | 33.00 | 0.55 | 6.88 |
| Terra | 2.75 | 16.50 | 0.28 | 3.44 |
| Luna | 1.10 | 6.60 | 0.11 | 1.38 |

`maxTokens: 128000` is not documented by AWS for these models; it matches every other GPT-5.6 row in the catalog.

Model names carry no `(Bedrock Mantle)` suffix because `cleanModelName` strips provider-attribution suffixes during generation; the provider column disambiguates. A test asserts this so it does not silently drift.

## Testing

- New tests: `packages/catalog/test/bedrock-mantle-gpt-5-6.test.ts` and `packages/ai/test/bedrock-mantle-auth.test.ts` (region substitution, bearer-vs-SigV4 selection, session-token forwarding, and the key-gate exemption). Both assert against the seed/policy source rather than the generated `models.json`.
- `bun run check:types` clean in `packages/catalog` and `packages/ai`.
- `bun test` — `packages/catalog`: 521 pass. `packages/ai`: 3449 pass, plus one failure in `proxy.test.ts > normalizes hyphenated provider ids to underscores` that reproduces identically on unmodified `main` (passes when that file is run alone — cross-file env pollution) and is unrelated to this change.
- `models.json` regenerated with `bun run gen:models`; the committed diff is limited to the three added `bedrock-mantle` rows and the three removed `amazon-bedrock` ones.
- Live smoke test, **bearer path**: one turn against `bedrock-mantle/openai.gpt-5.6-terra` in `us-east-1` returned HTTP 200 with streamed output.
- Live smoke test, **SigV4 path**: with `AWS_BEARER_TOKEN_BEDROCK` unset and credentials coming only from a profile in `~/.aws/credentials`, the same turn returned HTTP 200 — exercising `resolveAwsCredentials` + `signRequest` end-to-end over the credential chain.
