### PR TITLE
feat(ai): rendezvous-hash tie-breaker for session credential affinity

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Credential selection now uses a rendezvous-hash (HRW) tie-breaker among equally-ranked accounts, keeping a session sticky to the same credential (and its warm provider prompt cache) across pool changes. Ranking criteria still dominate; without a session id ordering is unchanged.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1060,6 +1060,19 @@ function compareUsageRankingMetric(left: number, right: number): number {
 	return Math.abs(delta) <= tolerance ? 0 : delta;
 }
 
+/**
+ * Highest-Random-Weight (rendezvous) score for a session/candidate pair.
+ * Higher score wins. Used as the final tie-breaker among equally-ranked
+ * credentials so a pool change reassigns only the sessions that hash to the
+ * changed candidate, preserving prompt-cache warmth for the rest.
+ *
+ * SHA-256 over `${sessionKey}\0${candidateKey}`, first 8 digest bytes
+ * big-endian as an unsigned 64-bit integer.
+ */
+export function rendezvousScore(sessionKey: string, candidateKey: string): bigint {
+	return new Bun.CryptoHasher("sha256").update(`${sessionKey}\0${candidateKey}`).digest().readBigUInt64BE(0);
+}
+
 function resolveDefaultUsageProvider(provider: Provider): UsageProvider | undefined {
 	return DEFAULT_USAGE_PROVIDER_MAP.get(provider);
 }
@@ -1219,6 +1232,8 @@ type UsageRankedCandidate<T extends AuthCredential> = UsageCandidate<T> & {
 	primaryUsed: number;
 	primaryRequiredDrain: number;
 	orderPos: number;
+	/** Rendezvous hash score for session-stable tie-breaking; undefined when no sessionId. */
+	hrwScore: bigint | undefined;
 };
 type RankedOAuthCandidate = UsageRankedCandidate<OAuthCredential>;
 type RankedApiKeyCandidate = UsageRankedCandidate<ApiKeyCredential>;
@@ -1647,6 +1662,19 @@ export class AuthStorage {
 		return order;
 	}
 
+	/**
+	 * Rendezvous-hash tie-break score for a candidate under a given session.
+	 * Returns undefined when no sessionId is available so the comparator falls
+	 * back to orderPos unchanged. The candidateKey is the durable stored-row id
+	 * when present, else `${provider}:${credentialIndex}`.
+	 */
+	#candidateHrwScore(sessionId: string | undefined, provider: string, credentialIndex: number): bigint | undefined {
+		if (!sessionId) return undefined;
+		const stored = this.#getStoredCredentials(provider)[credentialIndex];
+		const candidateKey = stored?.id !== undefined ? String(stored.id) : `${provider}:${credentialIndex}`;
+		return rendezvousScore(sessionId, candidateKey);
+	}
+
 	#toScopedBackoffKey(providerKey: string, blockScope: string | undefined): string {
 		return blockScope ? `${providerKey}\0${blockScope}` : providerKey;
 	}
@@ -1928,6 +1956,7 @@ export class AuthStorage {
 		blockScope?: string;
 		/** Scopes a block may live under for this request; reads honour all of them. */
 		blockScopes?: readonly string[];
+		sessionId?: string;
 	}): Promise<ApiKeyCandidate[]> {
 		const nowMs = Date.now();
 		const { strategy } = args;
@@ -2012,6 +2041,7 @@ export class AuthStorage {
 				primaryUsed: this.#normalizeUsageFraction(primary),
 				primaryRequiredDrain: this.#computeWindowRequiredDrain(primary, nowMs, strategy.windowDefaults.primaryMs),
 				orderPos,
+				hrwScore: this.#candidateHrwScore(args.sessionId, args.provider, selection.index),
 			});
 		}
 		return this.#orderUsageRankedCandidates(ranked, "none");
@@ -2060,6 +2090,7 @@ export class AuthStorage {
 			rankingContext,
 			blockScope,
 			blockScopes,
+			sessionId,
 		});
 		return candidates[0]?.selection ?? fallback;
 	}
@@ -4339,7 +4370,17 @@ export class AuthStorage {
 		planRequirement: OpenAICodexPlanRequirement,
 	): number {
 		const priority = this.#compareUsageRankedCandidatePriority(left, right, planRequirement);
-		return priority !== 0 ? priority : left.orderPos - right.orderPos;
+		if (priority !== 0) return priority;
+		// Session-stable HRW tie-breaker: when a session id was available at rank
+		// time, prefer the candidate with the higher rendezvous score so equal-rank
+		// pools resolve deterministically per session. Pool changes move only the
+		// sessions that hash to the changed candidate. When no session id was
+		// available (hrwScore is undefined) today's orderPos ordering is preserved
+		// byte-for-byte.
+		if (left.hrwScore !== undefined && right.hrwScore !== undefined && left.hrwScore !== right.hrwScore) {
+			return left.hrwScore > right.hrwScore ? -1 : 1;
+		}
+		return left.orderPos - right.orderPos;
 	}
 
 	#orderUsageRankedCandidates<T extends AuthCredential>(
@@ -4366,6 +4407,7 @@ export class AuthStorage {
 		blockScope?: string;
 		/** Scopes a block may live under for this request; reads honour all of them. */
 		blockScopes?: readonly string[];
+		sessionId?: string;
 	}): Promise<OAuthCandidate[]> {
 		const nowMs = Date.now();
 		const { strategy } = args;
@@ -4469,6 +4511,7 @@ export class AuthStorage {
 				primaryUsed: this.#normalizeUsageFraction(primary),
 				primaryRequiredDrain: this.#computeWindowRequiredDrain(primary, nowMs, strategy.windowDefaults.primaryMs),
 				orderPos,
+				hrwScore: this.#candidateHrwScore(args.sessionId, args.provider, selection.index),
 			});
 		}
 		return this.#orderUsageRankedCandidates(ranked, args.planRequirement);
@@ -4568,6 +4611,7 @@ export class AuthStorage {
 					rankingContext,
 					blockScope,
 					blockScopes,
+					sessionId,
 				})
 			: order
 					.map(idx => credentials[idx])

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2046,10 +2046,9 @@ export class AuthStorage {
 				primaryUsed: this.#normalizeUsageFraction(primary),
 				primaryRequiredDrain: this.#computeWindowRequiredDrain(primary, nowMs, strategy.windowDefaults.primaryMs),
 				orderPos,
-				hrwScore:
-					args.sessionId === undefined
-						? undefined
-						: this.#candidateHrwScore(args.sessionId, args.provider, selection.index),
+				hrwScore: args.sessionId
+					? this.#candidateHrwScore(args.sessionId, args.provider, selection.index)
+					: undefined,
 			});
 		}
 		return this.#orderUsageRankedCandidates(ranked, "none");
@@ -4520,10 +4519,9 @@ export class AuthStorage {
 				primaryUsed: this.#normalizeUsageFraction(primary),
 				primaryRequiredDrain: this.#computeWindowRequiredDrain(primary, nowMs, strategy.windowDefaults.primaryMs),
 				orderPos,
-				hrwScore:
-					args.sessionId === undefined
-						? undefined
-						: this.#candidateHrwScore(args.sessionId, args.provider, selection.index),
+				hrwScore: args.sessionId
+					? this.#candidateHrwScore(args.sessionId, args.provider, selection.index)
+					: undefined,
 			});
 		}
 		return this.#orderUsageRankedCandidates(ranked, args.planRequirement);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1069,7 +1069,7 @@ function compareUsageRankingMetric(left: number, right: number): number {
  * SHA-256 over `${sessionKey}\0${candidateKey}`, first 8 digest bytes
  * big-endian as an unsigned 64-bit integer.
  */
-export function rendezvousScore(sessionKey: string, candidateKey: string): bigint {
+function rendezvousScore(sessionKey: string, candidateKey: string): bigint {
 	return new Bun.CryptoHasher("sha256").update(`${sessionKey}\0${candidateKey}`).digest().readBigUInt64BE(0);
 }
 
@@ -1636,25 +1636,32 @@ export class AuthStorage {
 	}
 
 	/**
-	 * FNV-1a hash for deterministic session-to-credential mapping.
-	 * Ensures the same session always starts with the same credential.
+	 * Returns credential indices in priority order for selection. Session-bound
+	 * calls use HRW over durable stored rows; without a session, round-robin
+	 * order remains unchanged.
 	 */
-	#getHashedIndex(sessionId: string, total: number): number {
-		if (total <= 1) return 0;
-		return Bun.hash.xxHash32(sessionId) % total;
-	}
-
-	/**
-	 * Returns credential indices in priority order for selection.
-	 * With sessionId: starts from hashed index (consistent per session).
-	 * Without sessionId: starts from round-robin index (load balancing).
-	 * Order wraps around so all credentials are tried if earlier ones are blocked.
-	 */
-	#getCredentialOrder(providerKey: string, sessionId: string | undefined, total: number): number[] {
+	#getCredentialOrder(
+		providerKey: string,
+		sessionId: string | undefined,
+		provider: string,
+		selections: readonly { index: number }[],
+	): number[] {
+		const total = selections.length;
 		if (total <= 1) return [0];
-		const start = sessionId
-			? this.#getHashedIndex(sessionId, total)
-			: this.#getNextRoundRobinIndex(providerKey, total);
+		if (sessionId) {
+			return selections
+				.map((selection, orderPos) => ({
+					orderPos,
+					hrwScore: this.#candidateHrwScore(sessionId, provider, selection.index),
+				}))
+				.sort((left, right) => {
+					if (left.hrwScore !== right.hrwScore) return left.hrwScore > right.hrwScore ? -1 : 1;
+					return left.orderPos - right.orderPos;
+				})
+				.map(candidate => candidate.orderPos);
+		}
+
+		const start = this.#getNextRoundRobinIndex(providerKey, total);
 		const order: number[] = [];
 		for (let i = 0; i < total; i++) {
 			order.push((start + i) % total);
@@ -1664,12 +1671,10 @@ export class AuthStorage {
 
 	/**
 	 * Rendezvous-hash tie-break score for a candidate under a given session.
-	 * Returns undefined when no sessionId is available so the comparator falls
-	 * back to orderPos unchanged. The candidateKey is the durable stored-row id
-	 * when present, else `${provider}:${credentialIndex}`.
+	 * The candidate key is the durable stored-row id when present, else
+	 * `${provider}:${credentialIndex}`.
 	 */
-	#candidateHrwScore(sessionId: string | undefined, provider: string, credentialIndex: number): bigint | undefined {
-		if (!sessionId) return undefined;
+	#candidateHrwScore(sessionId: string, provider: string, credentialIndex: number): bigint {
 		const stored = this.#getStoredCredentials(provider)[credentialIndex];
 		const candidateKey = stored?.id !== undefined ? String(stored.id) : `${provider}:${credentialIndex}`;
 		return rendezvousScore(sessionId, candidateKey);
@@ -1913,7 +1918,7 @@ export class AuthStorage {
 	/**
 	 * Selects a credential of the specified type for a provider.
 	 * Returns both the credential and its index in the original array (for updates/removal).
-	 * Uses deterministic hashing for session stickiness and skips blocked credentials when possible.
+	 * Uses deterministic HRW session affinity and skips blocked credentials when possible.
 	 */
 	#selectCredentialByType<T extends AuthCredential["type"]>(
 		provider: string,
@@ -1932,7 +1937,7 @@ export class AuthStorage {
 		if (credentials.length === 1) return credentials[0];
 
 		const providerKey = this.#getProviderTypeKey(provider, type);
-		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
+		const order = this.#getCredentialOrder(providerKey, sessionId, provider, credentials);
 		const fallback = credentials[order[0]];
 
 		for (const idx of order) {
@@ -2041,7 +2046,10 @@ export class AuthStorage {
 				primaryUsed: this.#normalizeUsageFraction(primary),
 				primaryRequiredDrain: this.#computeWindowRequiredDrain(primary, nowMs, strategy.windowDefaults.primaryMs),
 				orderPos,
-				hrwScore: this.#candidateHrwScore(args.sessionId, args.provider, selection.index),
+				hrwScore:
+					args.sessionId === undefined
+						? undefined
+						: this.#candidateHrwScore(args.sessionId, args.provider, selection.index),
 			});
 		}
 		return this.#orderUsageRankedCandidates(ranked, "none");
@@ -2064,7 +2072,7 @@ export class AuthStorage {
 		if (credentials.length === 1) return credentials[0];
 
 		const providerKey = this.#getProviderTypeKey(provider, "api_key");
-		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
+		const order = this.#getCredentialOrder(providerKey, sessionId, provider, credentials);
 		const fallback = credentials[order[0]];
 		const strategy = this.#rankingStrategyResolver?.(provider);
 		if (!strategy) {
@@ -2080,10 +2088,11 @@ export class AuthStorage {
 		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
 		const blockScope = strategy.blockScope?.(rankingContext);
 		const blockScopes = strategy.blockScopes?.(rankingContext) ?? (blockScope ? [blockScope] : []);
+		const rankingOrder = sessionId ? credentials.map((_credential, index) => index) : order;
 		const candidates = await this.#rankApiKeySelections({
 			providerKey,
 			provider,
-			order,
+			order: rankingOrder,
 			credentials,
 			options,
 			strategy,
@@ -4511,7 +4520,10 @@ export class AuthStorage {
 				primaryUsed: this.#normalizeUsageFraction(primary),
 				primaryRequiredDrain: this.#computeWindowRequiredDrain(primary, nowMs, strategy.windowDefaults.primaryMs),
 				orderPos,
-				hrwScore: this.#candidateHrwScore(args.sessionId, args.provider, selection.index),
+				hrwScore:
+					args.sessionId === undefined
+						? undefined
+						: this.#candidateHrwScore(args.sessionId, args.provider, selection.index),
 			});
 		}
 		return this.#orderUsageRankedCandidates(ranked, args.planRequirement);
@@ -4547,7 +4559,7 @@ export class AuthStorage {
 		if (credentials.length === 0) return undefined;
 
 		const providerKey = this.#getProviderTypeKey(provider, "oauth");
-		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
+		const order = this.#getCredentialOrder(providerKey, sessionId, provider, credentials);
 		const strategy = this.#rankingStrategyResolver?.(provider);
 		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
 		const blockScope = strategy?.blockScope?.(rankingContext);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1234,6 +1234,12 @@ type UsageRankedCandidate<T extends AuthCredential> = UsageCandidate<T> & {
 	orderPos: number;
 	/** Rendezvous hash score for session-stable tie-breaking; undefined when no sessionId. */
 	hrwScore: bigint | undefined;
+	/**
+	 * True for the session's pinned credential when one is hoisted into the ranking,
+	 * so the pin wins genuine rank ties ahead of HRW. Always false when no session pin
+	 * is in play (new session, plan requirement, or API-key pools).
+	 */
+	isSessionPin: boolean;
 };
 type RankedOAuthCandidate = UsageRankedCandidate<OAuthCredential>;
 type RankedApiKeyCandidate = UsageRankedCandidate<ApiKeyCredential>;
@@ -1962,6 +1968,8 @@ export class AuthStorage {
 		/** Scopes a block may live under for this request; reads honour all of them. */
 		blockScopes?: readonly string[];
 		sessionId?: string;
+		/** Pinned credential index for this session; the matching candidate is flagged so it wins ties. API-key pools never pin, so this stays undefined here. */
+		sessionPreferredIndex?: number;
 	}): Promise<ApiKeyCandidate[]> {
 		const nowMs = Date.now();
 		const { strategy } = args;
@@ -2049,6 +2057,7 @@ export class AuthStorage {
 				hrwScore: args.sessionId
 					? this.#candidateHrwScore(args.sessionId, args.provider, selection.index)
 					: undefined,
+				isSessionPin: args.sessionPreferredIndex !== undefined && selection.index === args.sessionPreferredIndex,
 			});
 		}
 		return this.#orderUsageRankedCandidates(ranked, "none");
@@ -4379,12 +4388,21 @@ export class AuthStorage {
 	): number {
 		const priority = this.#compareUsageRankedCandidatePriority(left, right, planRequirement);
 		if (priority !== 0) return priority;
+		// A session's existing pinned credential stays ahead of the HRW tie-break:
+		// `#resolveOAuthSelection` hoists the pin to the front of the ranking order so
+		// it wins genuine ties, and that preference must survive a sibling whose
+		// rendezvous score happens to be higher once the usage reports equalize —
+		// otherwise an idle-but-still-valid pin silently migrates accounts and loses
+		// its prompt-cache affinity. Only one candidate can be the pin, so this
+		// resolves a pair without falling through. HRW then orders the remaining
+		// equal-rank, non-pinned candidates deterministically per session.
+		if (left.isSessionPin !== right.isSessionPin) return left.isSessionPin ? -1 : 1;
 		// Session-stable HRW tie-breaker: when a session id was available at rank
-		// time, prefer the candidate with the higher rendezvous score so equal-rank
-		// pools resolve deterministically per session. Pool changes move only the
-		// sessions that hash to the changed candidate. When no session id was
-		// available (hrwScore is undefined) today's orderPos ordering is preserved
-		// byte-for-byte.
+		// time and no session pin is competing, prefer the candidate with the higher
+		// rendezvous score so equal-rank pools resolve deterministically per session.
+		// Pool changes move only the sessions that hash to the changed candidate.
+		// When no session id was available (hrwScore is undefined) today's orderPos
+		// ordering is preserved byte-for-byte.
 		if (left.hrwScore !== undefined && right.hrwScore !== undefined && left.hrwScore !== right.hrwScore) {
 			return left.hrwScore > right.hrwScore ? -1 : 1;
 		}
@@ -4416,6 +4434,8 @@ export class AuthStorage {
 		/** Scopes a block may live under for this request; reads honour all of them. */
 		blockScopes?: readonly string[];
 		sessionId?: string;
+		/** Pinned credential index for this session; the matching candidate is flagged `isSessionPin` so it wins genuine ties ahead of HRW. */
+		sessionPreferredIndex?: number;
 	}): Promise<OAuthCandidate[]> {
 		const nowMs = Date.now();
 		const { strategy } = args;
@@ -4522,6 +4542,7 @@ export class AuthStorage {
 				hrwScore: args.sessionId
 					? this.#candidateHrwScore(args.sessionId, args.provider, selection.index)
 					: undefined,
+				isSessionPin: args.sessionPreferredIndex !== undefined && selection.index === args.sessionPreferredIndex,
 			});
 		}
 		return this.#orderUsageRankedCandidates(ranked, args.planRequirement);
@@ -4594,9 +4615,10 @@ export class AuthStorage {
 			!this.#isCredentialBlocked(provider, providerKey, sessionPreferredIndex, blockScopes);
 		const shouldRank = checkUsage && (!sessionPreferredIsAvailable || !sessionPreferredIsWarm || hasPlanRequirement);
 		// When ranking, seed the pinned credential first in the evaluation order so it wins genuine
-		// ties (the ranked comparator falls back to `orderPos`) without overriding a strictly-better
-		// sibling — this respects the residual value of a same-account shared static prefix that other
-		// workspace traffic may have kept warm, while still rotating away from a clearly-worse account.
+		// ties, and flag it `isSessionPin` so the ranked comparator keeps it ahead of the HRW
+		// tie-breaker — without overriding a strictly-better sibling. This respects the residual
+		// value of a same-account shared static prefix that other workspace traffic may have kept
+		// warm, while still rotating away from a clearly-worse account.
 		const baseRankingOrder = credentials.map((_credential, index) => index);
 		let rankingOrder = shouldRank && sessionId ? baseRankingOrder : order;
 		const sessionPreferredRankingPos =
@@ -4609,6 +4631,10 @@ export class AuthStorage {
 				...baseRankingOrder.filter(index => index !== sessionPreferredRankingPos),
 			];
 		}
+		// Surface the pin to the ranked comparator only when it is actually seeded into the
+		// ranking (session id present, a pin exists, no plan requirement). Otherwise the pin is
+		// not competing here and HRW orders the equal-rank pool on its own.
+		const rankedSessionPreferredIndex = sessionPreferredRankingPos >= 0 ? sessionPreferredIndex : undefined;
 		const candidates = shouldRank
 			? await this.#rankOAuthSelections({
 					providerKey,
@@ -4622,6 +4648,7 @@ export class AuthStorage {
 					blockScope,
 					blockScopes,
 					sessionId,
+					sessionPreferredIndex: rankedSessionPreferredIndex,
 				})
 			: order
 					.map(idx => credentials[idx])

--- a/packages/ai/test/auth-storage-claude-fable-fallback.test.ts
+++ b/packages/ai/test/auth-storage-claude-fable-fallback.test.ts
@@ -127,6 +127,13 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 	let store: ObservableStore;
 	let storage: AuthStorage;
 
+	// Every test below drives selection with the session id "session-fable".
+	// Among equal-rank candidates the selector now applies a session-stable
+	// rendezvous-hash tie-breaker, so the winner of an all-equal pool depends
+	// on the session id. "session-fable" rendezvous-maps row ids {1,2,3} to
+	// oat-1 and {2,3} to oat-2, which keeps each test's exact-credential
+	// assertion stable while still exercising the HRW path.
+
 	beforeEach(async () => {
 		store = makeStore([oauthRow(1, "a@example.com"), oauthRow(2, "b@example.com"), oauthRow(3, "c@example.com")]);
 		storage = new AuthStorage(store, {
@@ -142,9 +149,9 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 
 	it("does not block OAuth credentials just because the Fable tier is not reported", async () => {
 		// All three credentials lack a Fable-specific bucket. Unknown headroom is
-		// not treated as exhausted; the selector still picks the first credential
-		// in hashed order and lets the live request decide if the account can
-		// serve Fable.
+		// not treated as exhausted; the selector still picks the session's
+		// rendezvous winner among the equal-rank rows and lets the live request
+		// decide if the account can serve Fable.
 		const reportsByAccess: Record<string, UsageReport> = {
 			"oat-1": baseReport("a@example.com"),
 			"oat-2": baseReport("b@example.com"),
@@ -158,7 +165,7 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 		});
 
 		// Unknown Fable headroom is not a proactive hard block.
-		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+		const key = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 
 		expect(key).toBe("oat-1");
 	});
@@ -177,7 +184,7 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 			return reportsByAccess[access] ?? null;
 		});
 
-		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+		const key = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 
 		expect(key).toBe("oat-2");
 	});
@@ -196,7 +203,7 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 			return reportsByAccess[access] ?? null;
 		});
 
-		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+		const key = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 
 		expect(key).toBe("oat-1");
 	});
@@ -215,7 +222,7 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 			return reportsByAccess[access] ?? null;
 		});
 
-		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+		const key = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 
 		expect(key).toBe("oat-1");
 	});
@@ -234,7 +241,7 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 			return reportsByAccess[access] ?? null;
 		});
 
-		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+		const key = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 
 		expect(key).toBe("oat-1");
 	});
@@ -253,7 +260,7 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 			return reportsByAccess[access] ?? null;
 		});
 
-		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+		const key = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 
 		expect(key).toBe("oat-2");
 	});
@@ -271,7 +278,7 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 			return reportsByAccess[access] ?? null;
 		});
 
-		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+		const key = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 
 		expect(key).toBe("oat-3");
 	});
@@ -289,13 +296,13 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 			return reportsByAccess[access] ?? null;
 		});
 
-		const firstKey = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+		const firstKey = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 		expect(firstKey).toBe("oat-1");
 
-		const result = await storage.markUsageLimitReached("anthropic", "session-3", { modelId: "claude-fable-5" });
+		const result = await storage.markUsageLimitReached("anthropic", "session-fable", { modelId: "claude-fable-5" });
 		expect(result.switched).toBe(true);
 
-		const retryKey = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+		const retryKey = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 		expect(retryKey).not.toBe(firstKey);
 		expect(["oat-2", "oat-3"]).toContain(retryKey as string);
 	});
@@ -317,10 +324,10 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 			return reportsByAccess[access] ?? null;
 		});
 
-		const firstKey = await storage.getApiKey("anthropic", "session-3");
+		const firstKey = await storage.getApiKey("anthropic", "session-fable");
 		expect(firstKey).toBe("oat-1");
 
-		const result = await storage.markUsageLimitReached("anthropic", "session-3", {
+		const result = await storage.markUsageLimitReached("anthropic", "session-fable", {
 			modelId: "claude-fable-5",
 			retryAfterMs: 1_000,
 		});
@@ -330,7 +337,7 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 		store.cache.clear();
 		now = startNow + 60_001;
 
-		const retryKey = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+		const retryKey = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 		expect(retryKey).toBe("oat-2");
 	});
 
@@ -347,7 +354,7 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 			return reportsByAccess[access] ?? null;
 		});
 
-		const key = await storage.getApiKey("anthropic", "session-3", { modelId: "claude-fable-5" });
+		const key = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 
 		expect(key).toBe("oat-3");
 	});

--- a/packages/ai/test/auth-storage-claude-fable-fallback.test.ts
+++ b/packages/ai/test/auth-storage-claude-fable-fallback.test.ts
@@ -128,11 +128,14 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 	let storage: AuthStorage;
 
 	// Every test below drives selection with the session id "session-fable".
-	// Among equal-rank candidates the selector now applies a session-stable
-	// rendezvous-hash tie-breaker, so the winner of an all-equal pool depends
-	// on the session id. "session-fable" rendezvous-maps row ids {1,2,3} to
-	// oat-1 and {2,3} to oat-2, which keeps each test's exact-credential
-	// assertion stable while still exercising the HRW path.
+	// Among equal-rank candidates the selector applies a session-stable
+	// rendezvous-hash tie-breaker, so the winner of an all-equal pool is an
+	// incidental implementation detail. These tests assert the Fable
+	// blocking/fallback CONTRACT (which credentials stay eligible vs. get
+	// hard-blocked, rotation away from a 429'd account) independently of
+	// which equal-rank row the hash happens to pick, so a change to the HRW
+	// mapping, candidate-key encoding, or fixture row ids does not break an
+	// unrelated suite while fallback behavior stays correct.
 
 	beforeEach(async () => {
 		store = makeStore([oauthRow(1, "a@example.com"), oauthRow(2, "b@example.com"), oauthRow(3, "c@example.com")]);
@@ -146,12 +149,11 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 		storage.close();
 		vi.restoreAllMocks();
 	});
-
 	it("does not block OAuth credentials just because the Fable tier is not reported", async () => {
 		// All three credentials lack a Fable-specific bucket. Unknown headroom is
-		// not treated as exhausted; the selector still picks the session's
-		// rendezvous winner among the equal-rank rows and lets the live request
-		// decide if the account can serve Fable.
+		// not treated as exhausted; the selector still picks a valid credential
+		// among the equal-rank rows and lets the live request decide if the
+		// account can serve Fable.
 		const reportsByAccess: Record<string, UsageReport> = {
 			"oat-1": baseReport("a@example.com"),
 			"oat-2": baseReport("b@example.com"),
@@ -164,10 +166,10 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 			return reportsByAccess[access] ?? null;
 		});
 
-		// Unknown Fable headroom is not a proactive hard block.
+		// Unknown Fable headroom is not a proactive hard block: some valid credential is returned.
 		const key = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 
-		expect(key).toBe("oat-1");
+		expect(["oat-1", "oat-2", "oat-3"]).toContain(key as string);
 	});
 
 	it("skips a Fable credential only when the exhausted tier row has a future reset", async () => {
@@ -186,7 +188,8 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 
 		const key = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 
-		expect(key).toBe("oat-2");
+		expect(key).not.toBe("oat-1");
+		expect(["oat-2", "oat-3"]).toContain(key as string);
 	});
 
 	it("keeps a full Fable tier row eligible when the reset timestamp is missing", async () => {
@@ -262,7 +265,8 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 
 		const key = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 
-		expect(key).toBe("oat-2");
+		expect(key).not.toBe("oat-1");
+		expect(["oat-2", "oat-3"]).toContain(key as string);
 	});
 
 	it("uses unconfirmed exhausted Fable tier rows as ranking hints instead of hard blockers", async () => {
@@ -295,16 +299,15 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 			if (!access) return null;
 			return reportsByAccess[access] ?? null;
 		});
-
 		const firstKey = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
-		expect(firstKey).toBe("oat-1");
+		expect(["oat-1", "oat-2", "oat-3"]).toContain(firstKey as string);
 
 		const result = await storage.markUsageLimitReached("anthropic", "session-fable", { modelId: "claude-fable-5" });
 		expect(result.switched).toBe(true);
 
 		const retryKey = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
 		expect(retryKey).not.toBe(firstKey);
-		expect(["oat-2", "oat-3"]).toContain(retryKey as string);
+		expect(["oat-1", "oat-2", "oat-3"]).toContain(retryKey as string);
 	});
 
 	it("extends a live Fable rate-limit block to the confirmed Fable reset", async () => {
@@ -325,11 +328,12 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 		});
 
 		const firstKey = await storage.getApiKey("anthropic", "session-fable");
-		expect(firstKey).toBe("oat-1");
+		expect(["oat-1", "oat-2", "oat-3"]).toContain(firstKey as string);
 
 		const result = await storage.markUsageLimitReached("anthropic", "session-fable", {
 			modelId: "claude-fable-5",
 			retryAfterMs: 1_000,
+			apiKey: "oat-1",
 		});
 		expect(result.switched).toBe(true);
 
@@ -338,7 +342,8 @@ describe("AuthStorage Claude Fable tier fallback", () => {
 		now = startNow + 60_001;
 
 		const retryKey = await storage.getApiKey("anthropic", "session-fable", { modelId: "claude-fable-5" });
-		expect(retryKey).toBe("oat-2");
+		expect(retryKey).not.toBe("oat-1");
+		expect(["oat-2", "oat-3"]).toContain(retryKey as string);
 	});
 
 	it("still blocks OAuth credentials with exhausted shared Anthropic limits", async () => {

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -2528,7 +2528,7 @@ describe("AuthStorage claude oauth ranking", () => {
 		expect(apiKey).toBe("api-acct-clocked");
 	});
 
-	test("resolves equal-priority accounts to one deterministic pick", async () => {
+	test("resolves equal-priority accounts to a deterministic per-session pick", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 
 		await authStorage.set("anthropic", [
@@ -2547,8 +2547,22 @@ describe("AuthStorage claude oauth ranking", () => {
 			);
 		}
 
+		// Equal-rank accounts resolve through the session-stable rendezvous-hash
+		// tie-breaker: each session deterministically maps to exactly one account,
+		// and distinct sessions spread across the pool rather than collapsing onto
+		// a single account.
 		const counts = await countApiKeySelections(authStorage, "anthropic", "weighted-claude-equal", 200);
-		expect(Math.max(countFor(counts, "api-acct-a"), countFor(counts, "api-acct-b"))).toBe(200);
+		expect(countFor(counts, "api-acct-a")).toBeGreaterThan(0);
+		expect(countFor(counts, "api-acct-b")).toBeGreaterThan(0);
+		expect(countFor(counts, "api-acct-a") + countFor(counts, "api-acct-b")).toBe(200);
+
+		// Deterministic per session: the same session id picks the same account
+		// on every call.
+		for (let index = 0; index < 20; index += 1) {
+			const first = await authStorage.getApiKey("anthropic", `weighted-claude-equal-${index}`);
+			const second = await authStorage.getApiKey("anthropic", `weighted-claude-equal-${index}`);
+			expect(second).toBe(first);
+		}
 	});
 
 	test("routes every session to the top-ranked account without weighted spread", async () => {

--- a/packages/ai/test/auth-storage-email-dedupe.test.ts
+++ b/packages/ai/test/auth-storage-email-dedupe.test.ts
@@ -843,8 +843,8 @@ describe("AuthStorage persistent session stickiness", () => {
 		}
 	});
 
-	it("drops persisted session stickiness after a lower-index credential is removed", async () => {
-		const provider = "unit-sticky-invalidation";
+	it("keeps persisted affinity by credential id after a lower-index credential is removed", async () => {
+		const provider = "unit-sticky-index-shift";
 		const mk = (suffix: string): OAuthCredential => ({
 			type: "oauth",
 			refresh: `refresh-${suffix}`,
@@ -853,41 +853,26 @@ describe("AuthStorage persistent session stickiness", () => {
 			projectId: `project-${suffix}`,
 			email: `user-${suffix}@example.com`,
 		});
-		const initialCredentials = [mk("a"), mk("b"), mk("c"), mk("d")];
-		const remainingCredentials = initialCredentials.slice(1);
 
 		let authStorage = new AuthStorage(new SqliteAuthCredentialStore(new Database(dbPath)));
-		await authStorage.set(provider, initialCredentials);
+		await authStorage.set(provider, [mk("a"), mk("b"), mk("c"), mk("d")]);
 		let rows = authStorage.listStoredCredentials(provider);
-
-		const control = new AuthStorage(
-			new SqliteAuthCredentialStore(new Database(path.join(tempDir, "sticky-control.db"))),
-		);
-		await control.set(provider, remainingCredentials);
 		let session: string | undefined;
 		let stuckId = -1;
 		let stuckIndex = -1;
 		let stuckToken: string | undefined;
-		let freshToken: string | undefined;
-		try {
-			for (let i = 0; i < 256 && session === undefined; i++) {
-				const candidate = `sticky-probe-${i}`;
-				const token = await authStorage.getApiKey(provider, candidate);
-				const expectedFreshToken = await control.getApiKey(provider, candidate);
-				const index = rows.findIndex(row => (row.credential as OAuthCredential).access === token);
-				if (index >= 1 && index <= rows.length - 2 && token !== expectedFreshToken) {
-					session = candidate;
-					stuckIndex = index;
-					stuckId = rows[index].id;
-					stuckToken = token;
-					freshToken = expectedFreshToken;
-				}
+		for (let i = 0; i < 256 && session === undefined; i++) {
+			const candidate = `sticky-probe-${i}`;
+			const token = await authStorage.getApiKey(provider, candidate);
+			const index = rows.findIndex(row => row.credential.type === "oauth" && row.credential.access === token);
+			if (index >= 1) {
+				session = candidate;
+				stuckIndex = index;
+				stuckId = rows[index].id;
+				stuckToken = token;
 			}
-		} finally {
-			control.close();
 		}
-		expect(session).toBeDefined();
-		expect(freshToken).toBeDefined();
+		if (!session || !stuckToken) throw new Error("expected a session assigned above the first row");
 
 		expect(await authStorage.removeCredential(provider, rows[0].id)).toBe(true);
 		authStorage.close();
@@ -899,7 +884,6 @@ describe("AuthStorage persistent session stickiness", () => {
 
 		const resolved = await authStorage.getApiKey(provider, session);
 		authStorage.close();
-		expect(resolved).toBe(freshToken);
-		expect(resolved).not.toBe(stuckToken);
+		expect(resolved).toBe(stuckToken);
 	});
 });

--- a/packages/ai/test/auth-storage-hrw-affinity.test.ts
+++ b/packages/ai/test/auth-storage-hrw-affinity.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	type AuthCredentialStore,
+	AuthStorage,
+	rendezvousScore,
+	SqliteAuthCredentialStore,
+} from "@oh-my-pi/pi-ai/auth-storage";
+import type { UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import { removeWithRetries } from "../../utils/src/temp";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * HRW winner among string-keyed candidates — same descending-score order the
+ * comparator uses.
+ */
+function hrwWinner(sessionKey: string, candidates: readonly string[]): string {
+	return [...candidates]
+		.map(c => ({ c, score: rendezvousScore(sessionKey, c) }))
+		.sort((a, b) => (b.score > a.score ? 1 : b.score < a.score ? -1 : 0))[0].c;
+}
+
+// ─── Pure function tests on rendezvousScore ───────────────────────────────
+
+describe("rendezvousScore", () => {
+	test("is deterministic for a given session/candidate pair", () => {
+		const first = rendezvousScore("session-1", "candidate-a");
+		const second = rendezvousScore("session-1", "candidate-a");
+
+		expect(first).toBe(second);
+		expect(typeof first).toBe("bigint");
+	});
+
+	test("produces a stable total order per session across distinct candidates", () => {
+		const session = "session-stable-order";
+		const candidates = ["alpha", "bravo", "charlie", "delta", "echo"];
+
+		const order = [...candidates]
+			.map(c => ({ c, score: rendezvousScore(session, c) }))
+			.sort((a, b) => (b.score > a.score ? 1 : b.score < a.score ? -1 : 0))
+			.map(entry => entry.c);
+
+		const replay = [...candidates]
+			.map(c => ({ c, score: rendezvousScore(session, c) }))
+			.sort((a, b) => (b.score > a.score ? 1 : b.score < a.score ? -1 : 0))
+			.map(entry => entry.c);
+
+		expect(order).toEqual(replay);
+		expect([...order].sort()).toEqual([...candidates].sort());
+	});
+
+	test("distributes distinct sessions across distinct winners", () => {
+		const candidates = ["alpha", "bravo", "charlie", "delta"];
+		const sessions = Array.from({ length: 20 }, (_, index) => `session-${index}`);
+
+		const winners = new Set(sessions.map(session => hrwWinner(session, candidates)));
+		expect(winners.size).toBeGreaterThan(1);
+	});
+});
+
+// ─── Minimal-disruption golden test ───────────────────────────────────────
+
+describe("rendezvousScore minimal disruption", () => {
+	const sessions = ["sess-1", "sess-2", "sess-3", "sess-4", "sess-5", "sess-6"];
+
+	test("adding a candidate moves only sessions that rendezvous-map to it", () => {
+		const before = ["alpha", "bravo", "charlie"];
+		const after = ["alpha", "bravo", "charlie", "delta"];
+
+		const movers: string[] = [];
+		for (const session of sessions) {
+			const oldWinner = hrwWinner(session, before);
+			const newWinner = hrwWinner(session, after);
+			if (oldWinner !== newWinner) {
+				movers.push(session);
+				expect(newWinner).toBe("delta");
+			}
+		}
+		// At least one session should adopt the new candidate — otherwise delta
+		// would be a dead letter, defeating the purpose of HRW.
+		expect(movers.length).toBeGreaterThan(0);
+	});
+
+	test("removing a candidate moves only sessions that were mapped to it", () => {
+		const before = ["alpha", "bravo", "charlie", "delta"];
+		const after = ["alpha", "bravo", "charlie"];
+
+		for (const session of sessions) {
+			const oldWinner = hrwWinner(session, before);
+			const newWinner = hrwWinner(session, after);
+			if (oldWinner !== newWinner) {
+				// Only sessions whose old winner was the removed candidate move.
+				expect(oldWinner).toBe("delta");
+			}
+		}
+	});
+});
+
+// ─── Ranker integration tests ─────────────────────────────────────────────
+
+describe("AuthStorage HRW credential affinity", () => {
+	let tempDir = "";
+	let store: AuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+	const usageByKey = new Map<string, UsageReport>();
+
+	const usageProvider: UsageProvider = {
+		id: "zai",
+		async fetchUsage(params) {
+			const apiKey = params.credential.apiKey;
+			if (!apiKey) return null;
+			return usageByKey.get(apiKey) ?? null;
+		},
+		supports: params => params.provider === "zai" && params.credential.type === "api_key",
+	};
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-hrw-"));
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		authStorage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "zai" ? usageProvider : undefined),
+		});
+		usageByKey.clear();
+	});
+
+	afterEach(async () => {
+		authStorage?.close();
+		store?.close();
+		store = null;
+		authStorage = null;
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+		}
+		tempDir = "";
+	});
+
+	test("selects the same credential for a given session across repeated calls", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("zai", [
+			{ type: "api_key", key: "key-a", source: "login" },
+			{ type: "api_key", key: "key-b", source: "login" },
+			{ type: "api_key", key: "key-c", source: "login" },
+		]);
+
+		const keys: string[] = [];
+		for (let i = 0; i < 5; i++) {
+			const key = await authStorage.getApiKey("zai", "stable-session");
+			if (key) keys.push(key);
+		}
+
+		// HRW must be deterministic: same session → same credential every call.
+		expect(new Set(keys).size).toBe(1);
+	});
+
+	test("distributes distinct sessions across multiple credentials", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("zai", [
+			{ type: "api_key", key: "key-a", source: "login" },
+			{ type: "api_key", key: "key-b", source: "login" },
+			{ type: "api_key", key: "key-c", source: "login" },
+		]);
+
+		const selected = new Set<string>();
+		for (let i = 0; i < 30; i++) {
+			const key = await authStorage.getApiKey("zai", `session-${i}`);
+			if (key) selected.add(key);
+		}
+
+		expect(selected.size).toBeGreaterThan(1);
+	});
+
+	test("round-robins without sessionId — HRW is an exact no-op", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("zai", [
+			{ type: "api_key", key: "key-a", source: "login" },
+			{ type: "api_key", key: "key-b", source: "login" },
+			{ type: "api_key", key: "key-c", source: "login" },
+		]);
+
+		const keys: string[] = [];
+		for (let i = 0; i < 6; i++) {
+			const key = await authStorage.getApiKey("zai");
+			if (key) keys.push(key);
+		}
+
+		// Without sessionId the comparator falls back to orderPos (round-robin),
+		// so successive calls must rotate through distinct credentials.
+		expect(new Set(keys).size).toBeGreaterThan(1);
+	});
+
+	test("never reorders across differing rank tiers", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		const storage = authStorage;
+
+		await storage.set("zai", [
+			{ type: "api_key", key: "key-exhausted", source: "login" },
+			{ type: "api_key", key: "key-fresh", source: "login" },
+		]);
+
+		usageByKey.set("key-exhausted", {
+			provider: "zai",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "zai:requests:5h",
+					label: "ZAI Request Quota",
+					scope: { provider: "zai", windowId: "5h", shared: true },
+					window: {
+						id: "5h",
+						label: "5 Hour",
+						durationMs: 5 * HOUR_MS,
+						resetsAt: Date.now() + HOUR_MS,
+					},
+					amount: {
+						unit: "requests",
+						used: 100,
+						limit: 100,
+						remaining: 0,
+						usedFraction: 1,
+						remainingFraction: 0,
+					},
+					status: "exhausted",
+				},
+			],
+		});
+		usageByKey.set("key-fresh", {
+			provider: "zai",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "zai:requests:5h",
+					label: "ZAI Request Quota",
+					scope: { provider: "zai", windowId: "5h", shared: true },
+					window: {
+						id: "5h",
+						label: "5 Hour",
+						durationMs: 5 * HOUR_MS,
+						resetsAt: Date.now() + 2 * HOUR_MS,
+					},
+					amount: {
+						unit: "requests",
+						used: 20,
+						limit: 100,
+						remaining: 80,
+						usedFraction: 0.2,
+						remainingFraction: 0.8,
+					},
+					status: "ok",
+				},
+			],
+		});
+
+		// Across many sessions, the fresh key must always win — HRW never
+		// overrides the usage-priority ordering.
+		for (let i = 0; i < 20; i++) {
+			const key = await storage.getApiKey("zai", `tier-test-${i}`);
+			expect(key).toBe("key-fresh");
+		}
+	});
+});

--- a/packages/ai/test/auth-storage-hrw-affinity.test.ts
+++ b/packages/ai/test/auth-storage-hrw-affinity.test.ts
@@ -3,103 +3,63 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	type AuthCredential,
 	type AuthCredentialStore,
 	AuthStorage,
-	rendezvousScore,
 	SqliteAuthCredentialStore,
 } from "@oh-my-pi/pi-ai/auth-storage";
 import type { UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import { removeWithRetries } from "../../utils/src/temp";
 
 const HOUR_MS = 60 * 60 * 1000;
+const SESSIONS = Array.from({ length: 128 }, (_value, index) => `hrw-session-${index}`);
 
-/**
- * HRW winner among string-keyed candidates — same descending-score order the
- * comparator uses.
- */
-function hrwWinner(sessionKey: string, candidates: readonly string[]): string {
-	return [...candidates]
-		.map(c => ({ c, score: rendezvousScore(sessionKey, c) }))
-		.sort((a, b) => (b.score > a.score ? 1 : b.score < a.score ? -1 : 0))[0].c;
+async function selectBySession(storage: AuthStorage, provider: string): Promise<Map<string, string>> {
+	const selected = new Map<string, string>();
+	for (const sessionId of SESSIONS) {
+		const apiKey = await storage.getApiKey(provider, sessionId);
+		if (!apiKey) throw new Error(`expected an API key for ${sessionId}`);
+		selected.set(sessionId, apiKey);
+	}
+	return selected;
 }
 
-// ─── Pure function tests on rendezvousScore ───────────────────────────────
+async function assertLiveMutationAffinity(storage: AuthStorage, provider: string): Promise<void> {
+	const existing: AuthCredential[] = [
+		{ type: "api_key", key: "key-a", source: "login" },
+		{ type: "api_key", key: "key-b", source: "login" },
+		{ type: "api_key", key: "key-c", source: "login" },
+	];
+	const added: AuthCredential = { type: "api_key", key: "key-added", source: "login" };
 
-describe("rendezvousScore", () => {
-	test("is deterministic for a given session/candidate pair", () => {
-		const first = rendezvousScore("session-1", "candidate-a");
-		const second = rendezvousScore("session-1", "candidate-a");
+	await storage.set(provider, existing);
+	const before = await selectBySession(storage, provider);
 
-		expect(first).toBe(second);
-		expect(typeof first).toBe("bigint");
-	});
+	await storage.set(provider, [...existing, added]);
+	const afterAddition = await selectBySession(storage, provider);
+	const movedSessions = SESSIONS.filter(sessionId => before.get(sessionId) !== afterAddition.get(sessionId));
+	const stableSessions = SESSIONS.filter(sessionId => before.get(sessionId) === afterAddition.get(sessionId));
 
-	test("produces a stable total order per session across distinct candidates", () => {
-		const session = "session-stable-order";
-		const candidates = ["alpha", "bravo", "charlie", "delta", "echo"];
+	expect(movedSessions.length).toBeGreaterThan(0);
+	expect(stableSessions.length).toBeGreaterThan(0);
+	for (const sessionId of movedSessions) {
+		expect(afterAddition.get(sessionId)).toBe(added.key);
+	}
 
-		const order = [...candidates]
-			.map(c => ({ c, score: rendezvousScore(session, c) }))
-			.sort((a, b) => (b.score > a.score ? 1 : b.score < a.score ? -1 : 0))
-			.map(entry => entry.c);
+	const addedRow = storage
+		.listStoredCredentials(provider)
+		.find(row => row.credential.type === "api_key" && row.credential.key === added.key);
+	if (!addedRow) throw new Error("expected the added credential to have a stored row");
+	expect(await storage.removeCredential(provider, addedRow.id)).toBe(true);
 
-		const replay = [...candidates]
-			.map(c => ({ c, score: rendezvousScore(session, c) }))
-			.sort((a, b) => (b.score > a.score ? 1 : b.score < a.score ? -1 : 0))
-			.map(entry => entry.c);
-
-		expect(order).toEqual(replay);
-		expect([...order].sort()).toEqual([...candidates].sort());
-	});
-
-	test("distributes distinct sessions across distinct winners", () => {
-		const candidates = ["alpha", "bravo", "charlie", "delta"];
-		const sessions = Array.from({ length: 20 }, (_, index) => `session-${index}`);
-
-		const winners = new Set(sessions.map(session => hrwWinner(session, candidates)));
-		expect(winners.size).toBeGreaterThan(1);
-	});
-});
-
-// ─── Minimal-disruption golden test ───────────────────────────────────────
-
-describe("rendezvousScore minimal disruption", () => {
-	const sessions = ["sess-1", "sess-2", "sess-3", "sess-4", "sess-5", "sess-6"];
-
-	test("adding a candidate moves only sessions that rendezvous-map to it", () => {
-		const before = ["alpha", "bravo", "charlie"];
-		const after = ["alpha", "bravo", "charlie", "delta"];
-
-		const movers: string[] = [];
-		for (const session of sessions) {
-			const oldWinner = hrwWinner(session, before);
-			const newWinner = hrwWinner(session, after);
-			if (oldWinner !== newWinner) {
-				movers.push(session);
-				expect(newWinner).toBe("delta");
-			}
-		}
-		// At least one session should adopt the new candidate — otherwise delta
-		// would be a dead letter, defeating the purpose of HRW.
-		expect(movers.length).toBeGreaterThan(0);
-	});
-
-	test("removing a candidate moves only sessions that were mapped to it", () => {
-		const before = ["alpha", "bravo", "charlie", "delta"];
-		const after = ["alpha", "bravo", "charlie"];
-
-		for (const session of sessions) {
-			const oldWinner = hrwWinner(session, before);
-			const newWinner = hrwWinner(session, after);
-			if (oldWinner !== newWinner) {
-				// Only sessions whose old winner was the removed candidate move.
-				expect(oldWinner).toBe("delta");
-			}
-		}
-	});
-});
-
-// ─── Ranker integration tests ─────────────────────────────────────────────
+	const afterRemoval = await selectBySession(storage, provider);
+	for (const sessionId of stableSessions) {
+		expect(afterRemoval.get(sessionId)).toBe(before.get(sessionId));
+	}
+	for (const sessionId of movedSessions) {
+		expect(afterRemoval.get(sessionId)).toBe(before.get(sessionId));
+	}
+}
 
 describe("AuthStorage HRW credential affinity", () => {
 	let tempDir = "";
@@ -137,7 +97,51 @@ describe("AuthStorage HRW credential affinity", () => {
 		tempDir = "";
 	});
 
-	test("selects the same credential for a given session across repeated calls", async () => {
+	test("preserves unranked sessions across live pool mutations", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		await assertLiveMutationAffinity(authStorage, "unit-hrw-unranked");
+	});
+
+	test("preserves unaffected sessions when a filtered pool shifts stored positions", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		const provider = "unit-hrw-index-shift";
+		await authStorage.set(provider, [
+			{ type: "api_key", key: "key-a", source: "login" },
+			{ type: "api_key", key: "non-login-interleave" },
+			{ type: "api_key", key: "key-b", source: "login" },
+			{ type: "api_key", key: "key-c", source: "login" },
+		]);
+
+		const before = await selectBySession(authStorage, provider);
+		const removedSessions = SESSIONS.filter(sessionId => before.get(sessionId) === "key-b");
+		const stableSessions = SESSIONS.filter(sessionId => before.get(sessionId) !== "key-b");
+		expect(removedSessions.length).toBeGreaterThan(0);
+		expect(stableSessions.length).toBeGreaterThan(0);
+		expect([...before.values()]).not.toContain("non-login-interleave");
+
+		const removedRow = authStorage
+			.listStoredCredentials(provider)
+			.find(row => row.credential.type === "api_key" && row.credential.key === "key-b");
+		if (!removedRow) throw new Error("expected the middle login credential to have a stored row");
+		expect(await authStorage.removeCredential(provider, removedRow.id)).toBe(true);
+
+		const after = await selectBySession(authStorage, provider);
+		for (const sessionId of stableSessions) {
+			expect(after.get(sessionId)).toBe(before.get(sessionId));
+		}
+		for (const sessionId of removedSessions) {
+			const selected = after.get(sessionId);
+			if (!selected) throw new Error(`expected an API key for ${sessionId}`);
+			expect(["key-a", "key-c"]).toContain(selected);
+		}
+	});
+
+	test("preserves equal-ranked zai sessions across live pool mutations", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		await assertLiveMutationAffinity(authStorage, "zai");
+	});
+
+	test("round-robins without sessionId in its existing order", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 
 		await authStorage.set("zai", [
@@ -147,51 +151,12 @@ describe("AuthStorage HRW credential affinity", () => {
 		]);
 
 		const keys: string[] = [];
-		for (let i = 0; i < 5; i++) {
-			const key = await authStorage.getApiKey("zai", "stable-session");
-			if (key) keys.push(key);
-		}
-
-		// HRW must be deterministic: same session → same credential every call.
-		expect(new Set(keys).size).toBe(1);
-	});
-
-	test("distributes distinct sessions across multiple credentials", async () => {
-		if (!authStorage) throw new Error("test setup failed");
-
-		await authStorage.set("zai", [
-			{ type: "api_key", key: "key-a", source: "login" },
-			{ type: "api_key", key: "key-b", source: "login" },
-			{ type: "api_key", key: "key-c", source: "login" },
-		]);
-
-		const selected = new Set<string>();
-		for (let i = 0; i < 30; i++) {
-			const key = await authStorage.getApiKey("zai", `session-${i}`);
-			if (key) selected.add(key);
-		}
-
-		expect(selected.size).toBeGreaterThan(1);
-	});
-
-	test("round-robins without sessionId — HRW is an exact no-op", async () => {
-		if (!authStorage) throw new Error("test setup failed");
-
-		await authStorage.set("zai", [
-			{ type: "api_key", key: "key-a", source: "login" },
-			{ type: "api_key", key: "key-b", source: "login" },
-			{ type: "api_key", key: "key-c", source: "login" },
-		]);
-
-		const keys: string[] = [];
-		for (let i = 0; i < 6; i++) {
+		for (let index = 0; index < 6; index += 1) {
 			const key = await authStorage.getApiKey("zai");
 			if (key) keys.push(key);
 		}
 
-		// Without sessionId the comparator falls back to orderPos (round-robin),
-		// so successive calls must rotate through distinct credentials.
-		expect(new Set(keys).size).toBeGreaterThan(1);
+		expect(keys).toEqual(["key-a", "key-b", "key-c", "key-a", "key-b", "key-c"]);
 	});
 
 	test("never reorders across differing rank tiers", async () => {
@@ -202,7 +167,6 @@ describe("AuthStorage HRW credential affinity", () => {
 			{ type: "api_key", key: "key-exhausted", source: "login" },
 			{ type: "api_key", key: "key-fresh", source: "login" },
 		]);
-
 		usageByKey.set("key-exhausted", {
 			provider: "zai",
 			fetchedAt: Date.now(),
@@ -256,11 +220,8 @@ describe("AuthStorage HRW credential affinity", () => {
 			],
 		});
 
-		// Across many sessions, the fresh key must always win — HRW never
-		// overrides the usage-priority ordering.
-		for (let i = 0; i < 20; i++) {
-			const key = await storage.getApiKey("zai", `tier-test-${i}`);
-			expect(key).toBe("key-fresh");
+		for (let index = 0; index < 20; index += 1) {
+			expect(await storage.getApiKey("zai", `tier-test-${index}`)).toBe("key-fresh");
 		}
 	});
 });

--- a/packages/ai/test/auth-storage-hrw-affinity.test.ts
+++ b/packages/ai/test/auth-storage-hrw-affinity.test.ts
@@ -158,6 +158,27 @@ describe("AuthStorage HRW credential affinity", () => {
 
 		expect(keys).toEqual(["key-a", "key-b", "key-c", "key-a", "key-b", "key-c"]);
 	});
+	test("round-robins empty sessionId as sessionless across equal-ranked candidates", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("zai", [
+			{ type: "api_key", key: "key-a", source: "login" },
+			{ type: "api_key", key: "key-b", source: "login" },
+			{ type: "api_key", key: "key-c", source: "login" },
+		]);
+
+		const keys: string[] = [];
+		for (let index = 0; index < 6; index += 1) {
+			const key = await authStorage.getApiKey("zai", "");
+			if (key) keys.push(key);
+		}
+
+		expect(keys.length).toBe(6);
+		expect(new Set(keys).size).toBe(3);
+		for (let index = 0; index < keys.length; index += 1) {
+			expect(keys[index]).toBe(keys[index % 3]);
+		}
+	});
 
 	test("never reorders across differing rank tiers", async () => {
 		if (!authStorage) throw new Error("test setup failed");

--- a/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
+++ b/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
@@ -484,15 +484,7 @@ describe("AuthStorage OAuth refresh race", () => {
 	test("invalidating a session-sticky OAuth credential rotates the retry to another active credential", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 
-		let sessionId = "";
-		for (let index = 0; index < 32; index++) {
-			const candidate = `session-auth-retry-${index}`;
-			if (Bun.hash.xxHash32(candidate) % 2 === 0) {
-				sessionId = candidate;
-				break;
-			}
-		}
-		if (!sessionId) throw new Error("could not find test session id");
+		const sessionId = "session-auth-retry";
 
 		await authStorage.set("unit-oauth-rotation", [
 			{
@@ -516,15 +508,16 @@ describe("AuthStorage OAuth refresh race", () => {
 		});
 
 		const firstKey = await authStorage.getApiKey("unit-oauth-rotation", sessionId);
-		expect(firstKey).toBe("access-a");
+		if (!firstKey) throw new Error("expected an initial OAuth credential");
+		const expectedRetryKey = firstKey === "access-a" ? "access-b" : "access-a";
 
-		const invalidated = await authStorage.invalidateCredentialMatching("unit-oauth-rotation", "access-a", {
+		const invalidated = await authStorage.invalidateCredentialMatching("unit-oauth-rotation", firstKey, {
 			sessionId,
 		});
 		expect(invalidated).toBe(true);
 
 		const retryKey = await authStorage.getApiKey("unit-oauth-rotation", sessionId);
-		expect(retryKey).toBe("access-b");
+		expect(retryKey).toBe(expectedRetryKey);
 	});
 
 	test("persists a refreshed token by id when a concurrent disable shifts indices", async () => {

--- a/packages/coding-agent/test/auth-storage-rotation.test.ts
+++ b/packages/coding-agent/test/auth-storage-rotation.test.ts
@@ -301,8 +301,13 @@ describe("AuthStorage account rotation", () => {
 
 		expect(result).toBe("access-d");
 		expect(attemptedKeys.at(-1)).toBe("access-d");
-		expect([...attemptedKeys].sort()).toEqual(["access-a", "access-b", "access-c", "access-d"]);
-		expect(new Set(attemptedKeys).size).toBe(4);
+		// The HRW session-affinity tie-breaker makes the rotation order session-stable
+		// rather than round-robin, so the healthy sibling can be reached without
+		// exhausting every failing account first. The contract under test is that
+		// rotation still reaches the healthy fourth sibling and stops there, never
+		// re-attempting an account.
+		expect(attemptedKeys).toContain("access-d");
+		expect(new Set(attemptedKeys).size).toBe(attemptedKeys.length);
 	});
 
 	test("provider login invalidates only that provider's persisted session stickiness", async () => {


### PR DESCRIPTION
## Summary
Sessions now keep the same eligible credential as pools change, which preserves provider-side prompt-cache affinity instead of remapping most sessions. Plan tier, usage saturation, and block state still rank candidates first; rendezvous hashing only breaks exact eligible ties.

## Design
- Every non-empty session-bound credential pool uses durable stored-row identity for rendezvous scoring.
- Adding or removing one candidate remaps only sessions owned by that candidate or newly won by it.
- Missing and empty session IDs keep the existing round-robin order, and warm-session reuse remains unchanged.
- The score function stays private to `AuthStorage`.

## Validation
- Stateful SQLite tests add, interleave, and remove credentials through the public API, including non-terminal removals that shift array positions.
- Empty-string session tests prove repeated API-key selection still cycles through equal candidates.
- 100 focused auth-storage tests and the `packages/ai` typecheck pass.
