### PR TITLE
feat(catalog): send x-affinity session header for Mistral

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Mistral models now resolve `promptCacheSessionHeader: "x-affinity"`, so requests carry a session-affinity hint that lets Mistral route to a warm backend replica prefix cache.
+
 ## [17.1.8] - 2026-07-28
 
 ### Added

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -583,7 +583,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 			MINIMAX_PROVIDER_OR_ID_PATTERN.test(provider) || MINIMAX_PROVIDER_OR_ID_PATTERN.test(spec.id),
 		emptyLengthFinishIsContextError: provider === "ollama",
 		usesOpenAIToolCallIdLimit: provider === "openai",
-		promptCacheSessionHeader: isGrok ? "x-grok-conv-id" : undefined,
+		promptCacheSessionHeader: isGrok ? "x-grok-conv-id" : isMistral ? "x-affinity" : undefined,
 		dropThinkingWhenReasoningEffort: provider === "fireworks",
 	};
 
@@ -723,7 +723,8 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 			MINIMAX_PROVIDER_OR_ID_PATTERN.test(spec.provider) || (id ? MINIMAX_PROVIDER_OR_ID_PATTERN.test(id) : false),
 		emptyLengthFinishIsContextError: spec.provider === "ollama",
 		usesOpenAIToolCallIdLimit: spec.provider === "openai",
-		promptCacheSessionHeader: spec.provider === "xai-oauth" ? "x-grok-conv-id" : undefined,
+		promptCacheSessionHeader:
+			spec.provider === "xai-oauth" ? "x-grok-conv-id" : spec.provider === "mistral" ? "x-affinity" : undefined,
 		streamFirstEventTimeoutMs: isLocalServingBackend ? 0 : spec.compat?.streamFirstEventTimeoutMs,
 		streamIdleTimeoutMs: isLocalServingBackend
 			? LOCAL_OPENAI_COMPAT_STREAM_IDLE_TIMEOUT_MS

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -302,8 +302,8 @@ export interface OpenAICompat {
 	vercelGatewayRouting?: VercelGatewayRouting;
 	/** Extra fields to include in request body (e.g. gateway routing hints for OpenClaw-style proxies). */
 	extraBody?: Record<string, unknown>;
-	/** Request-session header that should mirror the normalized prompt-cache key. Default: unset. */
-	promptCacheSessionHeader?: "x-grok-conv-id";
+	/** Request-session header that should mirror the normalized prompt-cache key. Default: unset (`x-grok-conv-id` for Grok, `x-affinity` for Mistral). */
+	promptCacheSessionHeader?: "x-grok-conv-id" | "x-affinity";
 	/** Whether chat-completions payloads should include provider-specific prompt-cache markers. */
 	cacheControlFormat?: "anthropic" | undefined;
 	/**

--- a/packages/catalog/test/mistral-affinity-header.test.ts
+++ b/packages/catalog/test/mistral-affinity-header.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { buildOpenAICompat, buildOpenAIResponsesCompat } from "@oh-my-pi/pi-catalog/compat/openai";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+/**
+ * The prompt-cache session header (`promptCacheSessionHeader`) tells the
+ * transport which request header carries the normalized prompt-cache key so
+ * the provider backend can route to a warm prefix-cache replica. Grok uses
+ * `x-grok-conv-id`; Mistral uses `x-affinity`. Every other provider leaves
+ * the header unset.
+ */
+function completionsSpec(provider: string, baseUrl: string): ModelSpec<"openai-completions"> {
+	return {
+		api: "openai-completions",
+		id: "test-model",
+		name: "Test Model",
+		provider,
+		baseUrl,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		maxTokens: 8_000,
+		contextWindow: 128_000,
+		reasoning: false,
+	};
+}
+
+describe("buildOpenAICompat promptCacheSessionHeader", () => {
+	it("resolves x-affinity for mistral-provider models", () => {
+		const compat = buildOpenAICompat(completionsSpec("mistral", "https://api.mistral.ai/v1"));
+		expect(compat.promptCacheSessionHeader).toBe("x-affinity");
+	});
+
+	it("resolves x-grok-conv-id for grok (xai) models", () => {
+		const compat = buildOpenAICompat(completionsSpec("xai", "https://api.x.ai/v1"));
+		expect(compat.promptCacheSessionHeader).toBe("x-grok-conv-id");
+	});
+
+	it("resolves undefined for unrelated providers", () => {
+		const compat = buildOpenAICompat(completionsSpec("openai", "https://api.openai.com/v1"));
+		expect(compat.promptCacheSessionHeader).toBeUndefined();
+	});
+});
+
+describe("buildOpenAIResponsesCompat promptCacheSessionHeader", () => {
+	const responsesSpec = (provider: string) => ({
+		id: "test-model",
+		name: "Test Model",
+		provider,
+		baseUrl: "",
+	});
+
+	it("resolves x-affinity for mistral-provider models", () => {
+		expect(buildOpenAIResponsesCompat(responsesSpec("mistral")).promptCacheSessionHeader).toBe("x-affinity");
+	});
+
+	it("resolves x-grok-conv-id for xai-oauth models", () => {
+		expect(buildOpenAIResponsesCompat(responsesSpec("xai-oauth")).promptCacheSessionHeader).toBe("x-grok-conv-id");
+	});
+
+	it("resolves undefined for unrelated providers", () => {
+		expect(buildOpenAIResponsesCompat(responsesSpec("openai")).promptCacheSessionHeader).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
Mistral chat-completions requests now send the session affinity hint that its prefix cache expects. Existing generic request plumbing carries the prompt-cache session ID as `x-affinity`; Grok continues to use `x-grok-conv-id`.

## Design
- Catalog compatibility metadata resolves the provider-specific header name.
- The change is header-only: it does not add an unverified `prompt_cache_key` body field or regenerate model data.
- Unrelated providers still omit the header.

## Validation
The resolver contract is covered for Mistral, Grok, and an unrelated provider in both compatibility builders. The full catalog suite passes with 523 tests.
