### PR TITLE
feat(ai): clamp requested output tokens to remaining context window

### DIFF
--- a/packages/agent/src/tokenizer.ts
+++ b/packages/agent/src/tokenizer.ts
@@ -1,18 +1,15 @@
+import { estimateTextTokens } from "@oh-my-pi/pi-ai/utils/output-budget";
 import { countTokens as countTokensNat } from "@oh-my-pi/pi-natives";
 
 const accurate = process.env.PI_TOKENIZER_ACCURATE === "1" && Bun.env.NODE_ENV !== "test";
-
-function estimateTokens(text: string) {
-	return (Buffer.byteLength(text, "utf-8") + 3) >> 2;
-}
 
 export function countTokens(text: string | string[]): number {
 	if (accurate) {
 		return countTokensNat(text);
 	} else if (Array.isArray(text)) {
-		return text.reduce((sum, t) => sum + estimateTokens(t), 0);
+		return text.reduce((sum, t) => sum + estimateTextTokens(t), 0);
 	} else {
-		return estimateTokens(text);
+		return estimateTextTokens(text);
 	}
 }
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Anthropic and Bedrock requests now clamp the declared max output tokens to the remaining context window (with a 4096-token reserve), reconciling the thinking budget under the clamped value, so prompts that fit the window are no longer rejected because of an oversized output allowance.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -45,6 +45,7 @@ export * from "./usage/zai";
 export * from "./utils/anthropic-auth";
 export * from "./utils/event-stream";
 export * from "./utils/openrouter-headers";
+export * from "./utils/output-budget";
 export * from "./utils/retry";
 export * from "./utils/schema";
 export * from "./utils/thinking-loop";

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -13,6 +13,7 @@ import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import { $env, $flag, fetchWithRetry, parseStreamingJson, parseStreamingJsonThrottled } from "@oh-my-pi/pi-utils";
 import { renderDemotedThinking } from "../dialect/demotion";
 import * as AIError from "../error";
+import { OUTPUT_FALLBACK_BUFFER } from "../stream";
 import type {
 	Api,
 	AssistantMessage,
@@ -39,6 +40,7 @@ import {
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import type { RawHttpRequestDump } from "../utils/http-inspector";
 import { armPreResponseTimeout, getStreamFirstEventTimeoutMs } from "../utils/idle-iterator";
+import { clampMaxTokensToContext, estimatePromptTokens } from "../utils/output-budget";
 import { toolWireSchema } from "../utils/schema/wire";
 import { invalidateAwsCredentialCache, resolveAwsCredentials } from "./aws-credentials";
 import { decodeEventStream } from "./aws-eventstream";
@@ -329,11 +331,30 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 				if (tc.any || tc.tool) additionalModelRequestFields = undefined;
 			}
 
+			const maxTokens =
+				options.maxTokens !== undefined
+					? clampMaxTokensToContext({
+							requestedMaxTokens: options.maxTokens,
+							contextWindow: model.contextWindow ?? undefined,
+							estimatedPromptTokens: estimatePromptTokens(
+								context.systemPrompt?.join("\n"),
+								context.messages,
+								context.tools,
+							),
+						})
+					: undefined;
+			// Anthropic-on-Bedrock rejects thinking.budget_tokens >= maxTokens. The
+			// context-window clamp can shrink maxTokens below the budget, so reconcile
+			// the thinking budget the same way the anthropic transport does.
+			if (maxTokens !== undefined) {
+				additionalModelRequestFields = reconcileBedrockThinkingBudget(additionalModelRequestFields, maxTokens);
+			}
+
 			const commandInput: ConverseStreamRequest = {
 				messages: convertedMessages,
 				system: buildSystemPrompt(context.systemPrompt, promptCachePolicy),
 				inferenceConfig: {
-					maxTokens: options.maxTokens,
+					maxTokens,
 					temperature: options.temperature,
 					topP: options.topP,
 				},
@@ -1035,6 +1056,37 @@ function buildAdditionalModelRequestFields(
 	}
 
 	return result;
+}
+
+/** Minimum viable Bedrock extended-thinking budget; below this the model offers
+ *  no useful reasoning, so the turn is better off with thinking disabled. */
+const MIN_BEDROCK_THINKING_BUDGET_TOKENS = 1024;
+
+/**
+ * Restore the `maxTokens > thinking.budget_tokens` invariant after the
+ * context-window clamp shrinks `inferenceConfig.maxTokens`. Bedrock exposes the
+ * Anthropic thinking budget inside `additionalModelRequestFields.thinking`,
+ * which must stay below `maxTokens` or the request is rejected with HTTP 400.
+ * Uses the same buffer as the anthropic path and disables thinking entirely when
+ * too little headroom remains for a viable budget.
+ */
+function reconcileBedrockThinkingBudget(
+	additionalModelRequestFields: Record<string, unknown> | undefined,
+	maxTokens: number,
+): Record<string, unknown> | undefined {
+	const thinking = additionalModelRequestFields?.thinking as { type?: string; budget_tokens?: number } | undefined;
+	if (thinking?.type !== "enabled") return additionalModelRequestFields;
+	const budgetTokens = thinking.budget_tokens ?? 0;
+	if (budgetTokens + OUTPUT_FALLBACK_BUFFER <= maxTokens) return additionalModelRequestFields;
+	const clampedBudget = maxTokens - OUTPUT_FALLBACK_BUFFER;
+	if (clampedBudget >= MIN_BEDROCK_THINKING_BUDGET_TOKENS) {
+		thinking.budget_tokens = clampedBudget;
+		return additionalModelRequestFields;
+	}
+	// Too little headroom for a viable thinking budget — drop thinking entirely.
+	const next = { ...additionalModelRequestFields };
+	delete next.thinking;
+	return Object.keys(next).length > 0 ? next : undefined;
 }
 
 /**

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -1083,9 +1083,15 @@ function reconcileBedrockThinkingBudget(
 		thinking.budget_tokens = clampedBudget;
 		return additionalModelRequestFields;
 	}
-	// Too little headroom for a viable thinking budget — drop thinking entirely.
+	// Too little headroom for a viable thinking budget — drop thinking entirely,
+	// along with the interleaved-thinking beta that is meaningless without it.
 	const next = { ...additionalModelRequestFields };
 	delete next.thinking;
+	if (Array.isArray(next.anthropic_beta)) {
+		const betas = next.anthropic_beta.filter(beta => beta !== "interleaved-thinking-2025-05-14");
+		if (betas.length > 0) next.anthropic_beta = betas;
+		else delete next.anthropic_beta;
+	}
 	return Object.keys(next).length > 0 ? next : undefined;
 }
 

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -1074,8 +1074,9 @@ const MIN_BEDROCK_THINKING_BUDGET_TOKENS = 1024;
  * which must stay below `maxTokens` or the request is rejected with HTTP 400.
  * Reserves Bedrock's minimum output capacity; optional thinking is disabled when
  * too little headroom remains for a viable budget, while mandatory-thinking
- * models (`thinking.requiresEffort`) retain the largest valid split instead —
- * those endpoints reject omitted/disabled reasoning.
+ * models (`thinking.requiresEffort`) keep Bedrock's 1024-token reasoning
+ * minimum (giving output the remainder), since those endpoints reject both
+ * omitted reasoning and any sub-minimum budget.
  */
 function reconcileBedrockThinkingBudget(
 	additionalModelRequestFields: Record<string, unknown> | undefined,
@@ -1092,15 +1093,17 @@ function reconcileBedrockThinkingBudget(
 		return additionalModelRequestFields;
 	}
 	// Below the minimum viable budget. Mandatory-reasoning endpoints reject
-	// omitted/disabled thinking, so retain the largest valid split (or fail
-	// loudly when no positive budget fits) rather than dropping thinking.
+	// omitted/disabled thinking AND any sub-minimum budget, so prioritize
+	// Bedrock's 1024-token reasoning minimum and give output the remainder
+	// (valid whenever maxTokens still exceeds that minimum); fail loudly only
+	// when even that split cannot fit.
 	if (mandatory) {
-		if (clampedBudget > 0) {
-			thinking.budget_tokens = clampedBudget;
+		if (maxTokens > MIN_BEDROCK_THINKING_BUDGET_TOKENS) {
+			thinking.budget_tokens = MIN_BEDROCK_THINKING_BUDGET_TOKENS;
 			return additionalModelRequestFields;
 		}
 		throw new AIError.ConfigurationError(
-			`Bedrock mandatory thinking requires maxTokens greater than ${MIN_OUTPUT_TOKENS}; got ${maxTokens}`,
+			`Bedrock mandatory thinking requires maxTokens greater than ${MIN_BEDROCK_THINKING_BUDGET_TOKENS}; got ${maxTokens}`,
 		);
 	}
 	// Too little headroom for a viable optional-thinking budget — drop thinking

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -339,7 +339,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 							estimatedPromptTokens: estimatePromptTokens(
 								context.systemPrompt?.join("\n"),
 								context.messages,
-								context.tools,
+								toolConfig ? context.tools : undefined,
 							),
 						})
 					: undefined;
@@ -347,7 +347,11 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 			// context-window clamp can shrink maxTokens below the budget, so reconcile
 			// the thinking budget the same way the anthropic transport does.
 			if (maxTokens !== undefined) {
-				additionalModelRequestFields = reconcileBedrockThinkingBudget(additionalModelRequestFields, maxTokens);
+				additionalModelRequestFields = reconcileBedrockThinkingBudget(
+					additionalModelRequestFields,
+					maxTokens,
+					model.thinking?.requiresEffort === true,
+				);
 			}
 
 			const commandInput: ConverseStreamRequest = {
@@ -1067,12 +1071,15 @@ const MIN_BEDROCK_THINKING_BUDGET_TOKENS = 1024;
  * context-window clamp shrinks `inferenceConfig.maxTokens`. Bedrock exposes the
  * Anthropic thinking budget inside `additionalModelRequestFields.thinking`,
  * which must stay below `maxTokens` or the request is rejected with HTTP 400.
- * Reserves Bedrock's minimum output capacity and disables optional thinking when
- * too little headroom remains for a viable budget.
+ * Reserves Bedrock's minimum output capacity; optional thinking is disabled when
+ * too little headroom remains for a viable budget, while mandatory-thinking
+ * models (`thinking.requiresEffort`) retain the largest valid split instead —
+ * those endpoints reject omitted/disabled reasoning.
  */
 function reconcileBedrockThinkingBudget(
 	additionalModelRequestFields: Record<string, unknown> | undefined,
 	maxTokens: number,
+	mandatory = false,
 ): Record<string, unknown> | undefined {
 	const thinking = additionalModelRequestFields?.thinking as { type?: string; budget_tokens?: number } | undefined;
 	if (thinking?.type !== "enabled") return additionalModelRequestFields;
@@ -1083,8 +1090,20 @@ function reconcileBedrockThinkingBudget(
 		thinking.budget_tokens = clampedBudget;
 		return additionalModelRequestFields;
 	}
-	// Too little headroom for a viable thinking budget — drop thinking entirely,
-	// along with the interleaved-thinking beta that is meaningless without it.
+	// Below the minimum viable budget. Mandatory-reasoning endpoints reject
+	// omitted/disabled thinking, so retain the largest valid split (or fail
+	// loudly when no positive budget fits) rather than dropping thinking.
+	if (mandatory) {
+		if (clampedBudget > 0) {
+			thinking.budget_tokens = clampedBudget;
+			return additionalModelRequestFields;
+		}
+		throw new AIError.ConfigurationError(
+			`Bedrock mandatory thinking requires maxTokens greater than ${MIN_OUTPUT_TOKENS}; got ${maxTokens}`,
+		);
+	}
+	// Too little headroom for a viable optional-thinking budget — drop thinking
+	// entirely, along with the interleaved-thinking beta that is meaningless without it.
 	const next = { ...additionalModelRequestFields };
 	delete next.thinking;
 	if (Array.isArray(next.anthropic_beta)) {

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -340,6 +340,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 								context.systemPrompt?.join("\n"),
 								context.messages,
 								toolConfig ? context.tools : undefined,
+								model,
 							),
 						})
 					: undefined;

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -13,7 +13,7 @@ import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import { $env, $flag, fetchWithRetry, parseStreamingJson, parseStreamingJsonThrottled } from "@oh-my-pi/pi-utils";
 import { renderDemotedThinking } from "../dialect/demotion";
 import * as AIError from "../error";
-import { OUTPUT_FALLBACK_BUFFER } from "../stream";
+import { MIN_OUTPUT_TOKENS } from "../stream";
 import type {
 	Api,
 	AssistantMessage,
@@ -1067,7 +1067,7 @@ const MIN_BEDROCK_THINKING_BUDGET_TOKENS = 1024;
  * context-window clamp shrinks `inferenceConfig.maxTokens`. Bedrock exposes the
  * Anthropic thinking budget inside `additionalModelRequestFields.thinking`,
  * which must stay below `maxTokens` or the request is rejected with HTTP 400.
- * Uses the same buffer as the anthropic path and disables thinking entirely when
+ * Reserves Bedrock's minimum output capacity and disables optional thinking when
  * too little headroom remains for a viable budget.
  */
 function reconcileBedrockThinkingBudget(
@@ -1077,8 +1077,8 @@ function reconcileBedrockThinkingBudget(
 	const thinking = additionalModelRequestFields?.thinking as { type?: string; budget_tokens?: number } | undefined;
 	if (thinking?.type !== "enabled") return additionalModelRequestFields;
 	const budgetTokens = thinking.budget_tokens ?? 0;
-	if (budgetTokens + OUTPUT_FALLBACK_BUFFER <= maxTokens) return additionalModelRequestFields;
-	const clampedBudget = maxTokens - OUTPUT_FALLBACK_BUFFER;
+	if (budgetTokens + MIN_OUTPUT_TOKENS <= maxTokens) return additionalModelRequestFields;
+	const clampedBudget = maxTokens - MIN_OUTPUT_TOKENS;
 	if (clampedBudget >= MIN_BEDROCK_THINKING_BUDGET_TOKENS) {
 		thinking.budget_tokens = clampedBudget;
 		return additionalModelRequestFields;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -59,6 +59,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { isFoundryEnabled } from "../utils/foundry";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
+import { clampMaxTokensToContext, estimatePromptTokens } from "../utils/output-budget";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { COMBINATOR_KEYS, NO_STRICT, toolWireSchema } from "../utils/schema";
 import { spillToDescription } from "../utils/schema/spill";
@@ -3019,14 +3020,11 @@ function createClient(
 	return { client, isOAuthToken: oauthToken };
 }
 
-function disableThinkingIfToolChoiceForced(
-	params: MessageCreateParamsStreaming,
-	model: Model<"anthropic-messages">,
-): void {
-	const toolChoice = params.tool_choice;
-	if (!toolChoice) return;
-	if (toolChoice.type !== "any" && toolChoice.type !== "tool") return;
-
+/** Drop thinking (and its context-management directive) from a request.
+ *  Adaptive-only models can't be switched off by omitting `thinking`, so their
+ *  effort is pinned to the lowest level instead. Shared by the forced-tool-choice
+ *  and thinking-budget reconciliation paths so they disable thinking identically. */
+function disableThinking(params: MessageCreateParamsStreaming, model: Model<"anthropic-messages">): void {
 	delete params.thinking;
 	delete params.context_management;
 
@@ -3047,11 +3045,20 @@ function disableThinkingIfToolChoiceForced(
 
 	const outputConfig = params.output_config as AnthropicOutputConfig | undefined;
 	if (!outputConfig) return;
-
 	delete outputConfig.effort;
 	if (Object.keys(outputConfig).length === 0) {
 		delete params.output_config;
 	}
+}
+
+function disableThinkingIfToolChoiceForced(
+	params: MessageCreateParamsStreaming,
+	model: Model<"anthropic-messages">,
+): void {
+	const toolChoice = params.tool_choice;
+	if (!toolChoice) return;
+	if (toolChoice.type !== "any" && toolChoice.type !== "tool") return;
+	disableThinking(params, model);
 }
 
 function ensureMaxTokensForThinking(params: MessageCreateParamsStreaming, maxAllowedTokens: number): void {
@@ -3077,6 +3084,36 @@ function ensureMaxTokensForThinking(params: MessageCreateParamsStreaming, maxAll
 		);
 	}
 	thinking.budget_tokens = clampedBudget;
+}
+
+/** Minimum viable Anthropic extended-thinking budget; below this the API offers
+ *  no useful reasoning, so the turn is better off with thinking disabled. */
+const MIN_THINKING_BUDGET_TOKENS = 1024;
+
+/**
+ * Restore the `max_tokens > thinking.budget_tokens` invariant after the
+ * context-window clamp shrinks `max_tokens`. {@link ensureMaxTokensForThinking}
+ * guarantees `budget + OUTPUT_FALLBACK_BUFFER <= max` before the clamp runs;
+ * this re-establishes it on the clamped value using the same buffer, reducing
+ * the budget when it still fits and disabling thinking entirely when too little
+ * headroom remains for a viable budget.
+ */
+function reconcileThinkingForClampedMaxTokens(
+	params: MessageCreateParamsStreaming,
+	model: Model<"anthropic-messages">,
+): void {
+	const thinking = params.thinking;
+	if (thinking?.type !== "enabled") return;
+	const maxTokens = params.max_tokens;
+	if (maxTokens === undefined) return;
+	const budgetTokens = thinking.budget_tokens ?? 0;
+	if (budgetTokens + OUTPUT_FALLBACK_BUFFER <= maxTokens) return;
+	const clampedBudget = maxTokens - OUTPUT_FALLBACK_BUFFER;
+	if (clampedBudget >= MIN_THINKING_BUDGET_TOKENS) {
+		thinking.budget_tokens = clampedBudget;
+		return;
+	}
+	disableThinking(params, model);
 }
 
 type CacheControlBlock = {
@@ -3579,6 +3616,13 @@ function buildParams(
 
 	disableThinkingIfToolChoiceForced(params, model);
 	ensureMaxTokensForThinking(params, maxOutputTokens);
+	// Clamp max output tokens so prompt + output stays within the context window.
+	params.max_tokens = clampMaxTokensToContext({
+		requestedMaxTokens: params.max_tokens,
+		contextWindow: model.contextWindow ?? undefined,
+		estimatedPromptTokens: estimatePromptTokens(context.systemPrompt?.join("\n"), context.messages, context.tools),
+	});
+	reconcileThinkingForClampedMaxTokens(params, model);
 	applyPromptCaching(params, cacheControl);
 	enforceCacheControlLimit(params, 4);
 	normalizeCacheControlTtlOrdering(params);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3086,17 +3086,17 @@ function ensureMaxTokensForThinking(params: MessageCreateParamsStreaming, maxAll
 	thinking.budget_tokens = clampedBudget;
 }
 
-/** Minimum viable Anthropic extended-thinking budget; below this the API offers
- *  no useful reasoning, so the turn is better off with thinking disabled. */
+/** Minimum viable optional Anthropic extended-thinking budget; below this the API
+ *  offers no useful reasoning, so the turn is better off with thinking disabled. */
 const MIN_THINKING_BUDGET_TOKENS = 1024;
 
 /**
  * Restore the `max_tokens > thinking.budget_tokens` invariant after the
  * context-window clamp shrinks `max_tokens`. {@link ensureMaxTokensForThinking}
  * guarantees `budget + OUTPUT_FALLBACK_BUFFER <= max` before the clamp runs;
- * this re-establishes it on the clamped value using the same buffer, reducing
- * the budget when it still fits and disabling thinking entirely when too little
- * headroom remains for a viable budget.
+ * this re-establishes it on the clamped value using the same buffer. Optional
+ * thinking is disabled when too little headroom remains for a viable budget,
+ * while mandatory-thinking models retain every positive clamped budget.
  */
 function reconcileThinkingForClampedMaxTokens(
 	params: MessageCreateParamsStreaming,
@@ -3109,6 +3109,15 @@ function reconcileThinkingForClampedMaxTokens(
 	const budgetTokens = thinking.budget_tokens ?? 0;
 	if (budgetTokens + OUTPUT_FALLBACK_BUFFER <= maxTokens) return;
 	const clampedBudget = maxTokens - OUTPUT_FALLBACK_BUFFER;
+	if (model.compat.requiresThinkingEnabled) {
+		if (clampedBudget <= 0) {
+			throw new AIError.ConfigurationError(
+				`Anthropic thinking budget requires max_tokens greater than ${OUTPUT_FALLBACK_BUFFER}; got ${maxTokens}`,
+			);
+		}
+		thinking.budget_tokens = clampedBudget;
+		return;
+	}
 	if (clampedBudget >= MIN_THINKING_BUDGET_TOKENS) {
 		thinking.budget_tokens = clampedBudget;
 		return;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3020,18 +3020,11 @@ function createClient(
 	return { client, isOAuthToken: oauthToken };
 }
 
-type ThinkingParams = {
-	max_tokens?: MessageCreateParamsStreaming["max_tokens"];
-	thinking?: MessageCreateParamsStreaming["thinking"];
-	output_config?: MessageCreateParamsStreaming["output_config"];
-	context_management?: MessageCreateParamsStreaming["context_management"];
-};
-
 /** Drop thinking (and its context-management directive) from a request.
  *  Adaptive-only models can't be switched off by omitting `thinking`, so their
  *  effort is pinned to the lowest level instead. Shared by the forced-tool-choice
  *  and thinking-budget reconciliation paths so they disable thinking identically. */
-function disableThinking(params: ThinkingParams, model: Model<"anthropic-messages">): void {
+function disableThinking(params: MessageCreateParamsStreaming, model: Model<"anthropic-messages">): void {
 	delete params.thinking;
 	delete params.context_management;
 
@@ -3068,7 +3061,7 @@ function disableThinkingIfToolChoiceForced(
 	disableThinking(params, model);
 }
 
-function ensureMaxTokensForThinking(params: ThinkingParams, maxAllowedTokens: number): void {
+function ensureMaxTokensForThinking(params: MessageCreateParamsStreaming, maxAllowedTokens: number): void {
 	const thinking = params.thinking;
 	if (thinking?.type !== "enabled") return;
 
@@ -3105,7 +3098,10 @@ const MIN_THINKING_BUDGET_TOKENS = 1024;
  * thinking is disabled when too little headroom remains for a viable budget,
  * while mandatory-thinking models retain every positive clamped budget.
  */
-function reconcileThinkingForClampedMaxTokens(params: ThinkingParams, model: Model<"anthropic-messages">): void {
+function reconcileThinkingForClampedMaxTokens(
+	params: MessageCreateParamsStreaming,
+	model: Model<"anthropic-messages">,
+): void {
 	const thinking = params.thinking;
 	if (thinking?.type !== "enabled") return;
 	const maxTokens = params.max_tokens;
@@ -3616,8 +3612,6 @@ function buildParams(
 
 	disableThinkingIfToolChoiceForced(params, model);
 	ensureMaxTokensForThinking(params, maxOutputTokens);
-	// Clamp every output budget against the same prompt estimate so each server-side
-	// fallback stays within its own model window.
 	const estimatedPromptTokens = estimatePromptTokens(
 		context.systemPrompt?.join("\n"),
 		context.messages,
@@ -3629,29 +3623,6 @@ function buildParams(
 		estimatedPromptTokens,
 	});
 	reconcileThinkingForClampedMaxTokens(params, model);
-	if (params.fallbacks) {
-		params.fallbacks = params.fallbacks.map(fallback => {
-			const bundledFallbackModel = getBundledModel("anthropic", fallback.model);
-			const fallbackModel =
-				bundledFallbackModel?.api === "anthropic-messages"
-					? (bundledFallbackModel as Model<"anthropic-messages">)
-					: model;
-			const hasMaxTokensOverride = fallback.max_tokens !== undefined;
-			const fallbackParams: FallbackParam = {
-				...fallback,
-				...(fallback.thinking?.type === "enabled" && { thinking: { ...fallback.thinking } }),
-				...(fallback.output_config && { output_config: { ...fallback.output_config } }),
-				max_tokens: clampMaxTokensToContext({
-					requestedMaxTokens: fallback.max_tokens ?? params.max_tokens,
-					contextWindow: fallbackModel.contextWindow ?? model.contextWindow ?? undefined,
-					estimatedPromptTokens,
-				}),
-			};
-			reconcileThinkingForClampedMaxTokens(fallbackParams, fallbackModel);
-			if (!hasMaxTokensOverride && fallbackParams.max_tokens === params.max_tokens) delete fallbackParams.max_tokens;
-			return fallbackParams;
-		});
-	}
 
 	// Opus 4.7+ and Fable/Mythos 5 reject non-default sampling parameters with 400 error.
 	const thinkingType = params.thinking?.type;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3020,11 +3020,18 @@ function createClient(
 	return { client, isOAuthToken: oauthToken };
 }
 
+type ThinkingParams = {
+	max_tokens?: MessageCreateParamsStreaming["max_tokens"];
+	thinking?: MessageCreateParamsStreaming["thinking"];
+	output_config?: MessageCreateParamsStreaming["output_config"];
+	context_management?: MessageCreateParamsStreaming["context_management"];
+};
+
 /** Drop thinking (and its context-management directive) from a request.
  *  Adaptive-only models can't be switched off by omitting `thinking`, so their
  *  effort is pinned to the lowest level instead. Shared by the forced-tool-choice
  *  and thinking-budget reconciliation paths so they disable thinking identically. */
-function disableThinking(params: MessageCreateParamsStreaming, model: Model<"anthropic-messages">): void {
+function disableThinking(params: ThinkingParams, model: Model<"anthropic-messages">): void {
 	delete params.thinking;
 	delete params.context_management;
 
@@ -3061,7 +3068,7 @@ function disableThinkingIfToolChoiceForced(
 	disableThinking(params, model);
 }
 
-function ensureMaxTokensForThinking(params: MessageCreateParamsStreaming, maxAllowedTokens: number): void {
+function ensureMaxTokensForThinking(params: ThinkingParams, maxAllowedTokens: number): void {
 	const thinking = params.thinking;
 	if (thinking?.type !== "enabled") return;
 
@@ -3098,10 +3105,7 @@ const MIN_THINKING_BUDGET_TOKENS = 1024;
  * thinking is disabled when too little headroom remains for a viable budget,
  * while mandatory-thinking models retain every positive clamped budget.
  */
-function reconcileThinkingForClampedMaxTokens(
-	params: MessageCreateParamsStreaming,
-	model: Model<"anthropic-messages">,
-): void {
+function reconcileThinkingForClampedMaxTokens(params: ThinkingParams, model: Model<"anthropic-messages">): void {
 	const thinking = params.thinking;
 	if (thinking?.type !== "enabled") return;
 	const maxTokens = params.max_tokens;
@@ -3569,19 +3573,6 @@ function buildParams(
 		stream: true,
 	};
 
-	// Opus 4.7+ and Fable/Mythos 5 reject non-default sampling parameters with 400 error.
-	const thinkingType = params.thinking?.type;
-	const allowSamplingParams =
-		model.compat.supportsSamplingParams && (thinkingType === undefined || thinkingType === "disabled");
-	if (allowSamplingParams && options?.temperature !== undefined) {
-		params.temperature = options.temperature;
-	}
-	if (allowSamplingParams && options?.topP !== undefined) {
-		params.top_p = options.topP;
-	}
-	if (allowSamplingParams && options?.topK !== undefined) {
-		params.top_k = options.topK;
-	}
 	if (options?.stopSequences?.length) {
 		const seqs = options.stopSequences;
 		if (seqs.length > ANTHROPIC_STOP_SEQUENCES_MAX && !warnedStopSequencesTrim) {
@@ -3625,13 +3616,56 @@ function buildParams(
 
 	disableThinkingIfToolChoiceForced(params, model);
 	ensureMaxTokensForThinking(params, maxOutputTokens);
-	// Clamp max output tokens so prompt + output stays within the context window.
+	// Clamp every output budget against the same prompt estimate so each server-side
+	// fallback stays within its own model window.
+	const estimatedPromptTokens = estimatePromptTokens(
+		context.systemPrompt?.join("\n"),
+		context.messages,
+		context.tools,
+	);
 	params.max_tokens = clampMaxTokensToContext({
 		requestedMaxTokens: params.max_tokens,
 		contextWindow: model.contextWindow ?? undefined,
-		estimatedPromptTokens: estimatePromptTokens(context.systemPrompt?.join("\n"), context.messages, context.tools),
+		estimatedPromptTokens,
 	});
 	reconcileThinkingForClampedMaxTokens(params, model);
+	if (params.fallbacks) {
+		params.fallbacks = params.fallbacks.map(fallback => {
+			const bundledFallbackModel = getBundledModel("anthropic", fallback.model);
+			const fallbackModel =
+				bundledFallbackModel?.api === "anthropic-messages"
+					? (bundledFallbackModel as Model<"anthropic-messages">)
+					: model;
+			const hasMaxTokensOverride = fallback.max_tokens !== undefined;
+			const fallbackParams: FallbackParam = {
+				...fallback,
+				...(fallback.thinking?.type === "enabled" && { thinking: { ...fallback.thinking } }),
+				...(fallback.output_config && { output_config: { ...fallback.output_config } }),
+				max_tokens: clampMaxTokensToContext({
+					requestedMaxTokens: fallback.max_tokens ?? params.max_tokens,
+					contextWindow: fallbackModel.contextWindow ?? model.contextWindow ?? undefined,
+					estimatedPromptTokens,
+				}),
+			};
+			reconcileThinkingForClampedMaxTokens(fallbackParams, fallbackModel);
+			if (!hasMaxTokensOverride && fallbackParams.max_tokens === params.max_tokens) delete fallbackParams.max_tokens;
+			return fallbackParams;
+		});
+	}
+
+	// Opus 4.7+ and Fable/Mythos 5 reject non-default sampling parameters with 400 error.
+	const thinkingType = params.thinking?.type;
+	const allowSamplingParams =
+		model.compat.supportsSamplingParams && (thinkingType === undefined || thinkingType === "disabled");
+	if (allowSamplingParams && options?.temperature !== undefined) {
+		params.temperature = options.temperature;
+	}
+	if (allowSamplingParams && options?.topP !== undefined) {
+		params.top_p = options.topP;
+	}
+	if (allowSamplingParams && options?.topK !== undefined) {
+		params.top_k = options.topK;
+	}
 	applyPromptCaching(params, cacheControl);
 	enforceCacheControlLimit(params, 4);
 	normalizeCacheControlTtlOrdering(params);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -19,7 +19,7 @@ import {
 } from "@oh-my-pi/pi-utils";
 import { renderDemotedThinking } from "../dialect/demotion";
 import * as AIError from "../error";
-import { getEnvApiKey, OUTPUT_FALLBACK_BUFFER } from "../stream";
+import { getEnvApiKey } from "../stream";
 import type {
 	AnthropicFallbackContent,
 	AnthropicServerToolContent,
@@ -59,7 +59,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { isFoundryEnabled } from "../utils/foundry";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
-import { clampMaxTokensToContext, estimatePromptTokens } from "../utils/output-budget";
+import { clampMaxTokensToContext, estimatePromptTokens, OUTPUT_FALLBACK_BUFFER } from "../utils/output-budget";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { COMBINATOR_KEYS, NO_STRICT, toolWireSchema } from "../utils/schema";
 import { spillToDescription } from "../utils/schema/spill";
@@ -3096,7 +3096,8 @@ const MIN_THINKING_BUDGET_TOKENS = 1024;
  * guarantees `budget + OUTPUT_FALLBACK_BUFFER <= max` before the clamp runs;
  * this re-establishes it on the clamped value using the same buffer. Optional
  * thinking is disabled when too little headroom remains for a viable budget,
- * while mandatory-thinking models retain every positive clamped budget.
+ * while mandatory-thinking models (`compat.requiresThinkingEnabled` or
+ * `thinking.requiresEffort`) retain every positive clamped budget.
  */
 function reconcileThinkingForClampedMaxTokens(
 	params: MessageCreateParamsStreaming,
@@ -3109,7 +3110,7 @@ function reconcileThinkingForClampedMaxTokens(
 	const budgetTokens = thinking.budget_tokens ?? 0;
 	if (budgetTokens + OUTPUT_FALLBACK_BUFFER <= maxTokens) return;
 	const clampedBudget = maxTokens - OUTPUT_FALLBACK_BUFFER;
-	if (model.compat.requiresThinkingEnabled) {
+	if (model.compat.requiresThinkingEnabled || model.thinking?.requiresEffort) {
 		if (clampedBudget <= 0) {
 			throw new AIError.ConfigurationError(
 				`Anthropic thinking budget requires max_tokens greater than ${OUTPUT_FALLBACK_BUFFER}; got ${maxTokens}`,

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3617,6 +3617,7 @@ function buildParams(
 		context.systemPrompt?.join("\n"),
 		context.messages,
 		context.tools,
+		model,
 	);
 	params.max_tokens = clampMaxTokensToContext({
 		requestedMaxTokens: params.max_tokens,
@@ -3625,10 +3626,14 @@ function buildParams(
 	});
 	reconcileThinkingForClampedMaxTokens(params, model);
 
-	// Opus 4.7+ and Fable/Mythos 5 reject non-default sampling parameters with 400 error.
+	// Opus 4.7+ and Fable/Mythos 5 reject non-default sampling parameters with a 400.
+	// Adaptive-only models can never switch thinking off — disableThinking deletes
+	// params.thinking but pins output_config.effort, so a forced-tool turn still
+	// reasons. Treat that implicit-on state as active so caller-supplied sampling
+	// params aren't attached to a thinking request (otherwise a provider 400).
 	const thinkingType = params.thinking?.type;
-	const allowSamplingParams =
-		model.compat.supportsSamplingParams && (thinkingType === undefined || thinkingType === "disabled");
+	const thinkingActive = (thinkingType !== undefined && thinkingType !== "disabled") || isAdaptiveOnlyThinking(model);
+	const allowSamplingParams = model.compat.supportsSamplingParams && !thinkingActive;
 	if (allowSamplingParams && options?.temperature !== undefined) {
 		params.temperature = options.temperature;
 	}

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1236,7 +1236,6 @@ function maxTokensWithThinkingBudget(
 	const uncappedMaxTokens = baseMaxTokens === undefined ? OUTPUT_CAP_WHEN_UNKNOWN : baseMaxTokens + thinkingBudget;
 	return Math.min(uncappedMaxTokens, modelMaxTokens ?? Number.POSITIVE_INFINITY);
 }
-export const OUTPUT_FALLBACK_BUFFER = 4000;
 const ANTHROPIC_USE_INTERLEAVED_THINKING = Bun.env.PI_NO_INTERLEAVED_THINKING !== "1";
 
 export const ANTHROPIC_THINKING: Record<Effort, number> = {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1225,7 +1225,7 @@ export async function completeSimple<TApi extends Api>(
 	);
 }
 
-const MIN_OUTPUT_TOKENS = 1024;
+export const MIN_OUTPUT_TOKENS = 1024;
 // Fallback total output cap for models whose catalog entry has no maxTokens.
 const OUTPUT_CAP_WHEN_UNKNOWN = 64_000;
 function maxTokensWithThinkingBudget(

--- a/packages/ai/src/utils/output-budget.ts
+++ b/packages/ai/src/utils/output-budget.ts
@@ -1,0 +1,88 @@
+/**
+ * Request-side output-token budget clamp.
+ *
+ * On APIs where max output tokens is mandatory on the wire (anthropic, bedrock),
+ * a prompt that fits the context window on its own can still be rejected once
+ * the declared output allowance pushes prompt + output past the window. This
+ * module provides a conservative clamp that only ever reduces the requested
+ * max, never raises it, and passes through when the window is unknown.
+ */
+
+import type { Message } from "../types";
+
+/**
+ * Image content has no tokenizer representation; charge a fixed estimate
+ * matching what providers typically bill for inline images.
+ */
+const IMAGE_TOKEN_ESTIMATE = 1200;
+
+/** Default safety reserve subtracted from the remaining window. */
+const DEFAULT_RESERVE_TOKENS = 4096;
+
+/**
+ * Clamp a requested max-output value so that prompt + output stays within the
+ * model's context window. Only ever reduces; never raises or invents a value.
+ *
+ * Returns `requestedMaxTokens` unchanged when `contextWindow` is undefined or
+ * <= 0 (unknown window → pass-through rather than a guess).
+ */
+export function clampMaxTokensToContext(args: {
+	requestedMaxTokens: number;
+	contextWindow: number | undefined;
+	estimatedPromptTokens: number;
+	reserveTokens?: number;
+}): number {
+	const { requestedMaxTokens, contextWindow, estimatedPromptTokens } = args;
+	if (contextWindow === undefined || contextWindow <= 0) return requestedMaxTokens;
+	const reserve = args.reserveTokens ?? DEFAULT_RESERVE_TOKENS;
+	const budget = Math.max(1, contextWindow - estimatedPromptTokens - reserve);
+	return Math.min(requestedMaxTokens, budget);
+}
+
+/**
+ * Estimate prompt token count using the byte heuristic `(bytes + 3) >> 2`
+ * (identical formula to packages/agent/src/tokenizer.ts). Counts the system
+ * prompt, each message's serialized content (text, images, thinking, tool
+ * calls, and tool-result text/images), and serialized tools. Adds a fixed
+ * per-image estimate for image blocks.
+ */
+export function estimatePromptTokens(
+	systemPrompt: string | undefined,
+	messages: readonly Message[],
+	tools?: readonly unknown[],
+): number {
+	let tokens = 0;
+
+	if (systemPrompt) {
+		tokens += estimateTextTokens(systemPrompt);
+	}
+
+	for (const message of messages) {
+		const content = message.content;
+		if (typeof content === "string") {
+			tokens += estimateTextTokens(content);
+		} else if (Array.isArray(content)) {
+			for (const block of content) {
+				if (block.type === "text") {
+					tokens += estimateTextTokens(block.text);
+				} else if (block.type === "image") {
+					tokens += IMAGE_TOKEN_ESTIMATE;
+				} else if (block.type === "thinking") {
+					tokens += estimateTextTokens(block.thinking);
+				} else if (block.type === "toolCall") {
+					tokens += estimateTextTokens(JSON.stringify({ name: block.name, arguments: block.arguments }));
+				}
+			}
+		}
+	}
+
+	if (tools && tools.length > 0) {
+		tokens += estimateTextTokens(JSON.stringify(tools));
+	}
+
+	return tokens;
+}
+
+function estimateTextTokens(text: string): number {
+	return (Buffer.byteLength(text, "utf-8") + 3) >> 2;
+}

--- a/packages/ai/src/utils/output-budget.ts
+++ b/packages/ai/src/utils/output-budget.ts
@@ -6,6 +6,12 @@
  * the declared output allowance pushes prompt + output past the window. This
  * module provides a conservative clamp that only ever reduces the requested
  * max, never raises it, and passes through when the window is unknown.
+ *
+ * It owns the two shared primitives the clamp and the providers agree on:
+ * {@link OUTPUT_FALLBACK_BUFFER} (the safety buffer between thinking budget and
+ * max_tokens, reused as the clamp's reserve) and {@link estimateTextTokens}
+ * (the single source of the byte-heuristic token estimate, reused by
+ * `packages/agent/src/tokenizer.ts`).
  */
 
 import type { Message } from "../types";
@@ -16,8 +22,13 @@ import type { Message } from "../types";
  */
 const IMAGE_TOKEN_ESTIMATE = 1200;
 
-/** Default safety reserve subtracted from the remaining window. */
-const DEFAULT_RESERVE_TOKENS = 4096;
+/**
+ * Safety buffer subtracted from the remaining context window before capping
+ * output, and the gap Anthropic requires between `thinking.budget_tokens` and
+ * `max_tokens`. One constant so the clamp and the thinking reconciliation can
+ * never drift apart.
+ */
+export const OUTPUT_FALLBACK_BUFFER = 4000;
 
 /**
  * Clamp a requested max-output value so that prompt + output stays within the
@@ -34,17 +45,16 @@ export function clampMaxTokensToContext(args: {
 }): number {
 	const { requestedMaxTokens, contextWindow, estimatedPromptTokens } = args;
 	if (contextWindow === undefined || contextWindow <= 0) return requestedMaxTokens;
-	const reserve = args.reserveTokens ?? DEFAULT_RESERVE_TOKENS;
+	const reserve = args.reserveTokens ?? OUTPUT_FALLBACK_BUFFER;
 	const budget = Math.max(1, contextWindow - estimatedPromptTokens - reserve);
 	return Math.min(requestedMaxTokens, budget);
 }
 
 /**
- * Estimate prompt token count using the byte heuristic `(bytes + 3) >> 2`
- * (identical formula to packages/agent/src/tokenizer.ts). Counts the system
- * prompt, each message's serialized content (text, images, thinking, tool
- * calls, and tool-result text/images), and serialized tools. Adds a fixed
- * per-image estimate for image blocks.
+ * Estimate prompt token count using the byte heuristic `(bytes + 3) >> 2`.
+ * Counts the system prompt, every replayed content block (text, images,
+ * thinking, redacted thinking, tool calls, native server-tool results, and
+ * fallback markers), and serialized tools. Adds a fixed per-image estimate.
  */
 export function estimatePromptTokens(
 	systemPrompt: string | undefined,
@@ -73,6 +83,13 @@ export function estimatePromptTokens(
 					tokens += estimateTextTokens(block.data);
 				} else if (block.type === "toolCall") {
 					tokens += estimateTextTokens(JSON.stringify({ name: block.name, arguments: block.arguments }));
+				} else if (block.type === "anthropicServerTool") {
+					// Verbatim server-tool call/result (e.g. web_search_tool_result)
+					// replayed on the wire — potentially large, so charge its
+					// serialized form like the agent's compaction estimator.
+					tokens += estimateTextTokens(JSON.stringify(block.block));
+				} else if (block.type === "fallback") {
+					tokens += estimateTextTokens(JSON.stringify(block));
 				}
 			}
 		}
@@ -85,6 +102,10 @@ export function estimatePromptTokens(
 	return tokens;
 }
 
-function estimateTextTokens(text: string): number {
+/**
+ * Byte heuristic: ~4 bytes per token, rounded up. The single source for this
+ * estimate — `packages/agent/src/tokenizer.ts` reuses it instead of forking it.
+ */
+export function estimateTextTokens(text: string): number {
 	return (Buffer.byteLength(text, "utf-8") + 3) >> 2;
 }

--- a/packages/ai/src/utils/output-budget.ts
+++ b/packages/ai/src/utils/output-budget.ts
@@ -14,7 +14,7 @@
  * `packages/agent/src/tokenizer.ts`).
  */
 
-import type { Message } from "../types";
+import type { Message, Model } from "../types";
 
 /**
  * Image content has no tokenizer representation; charge a fixed estimate
@@ -60,6 +60,7 @@ export function estimatePromptTokens(
 	systemPrompt: string | undefined,
 	messages: readonly Message[],
 	tools?: readonly unknown[],
+	targetModel?: Pick<Model, "api" | "provider">,
 ): number {
 	let tokens = 0;
 
@@ -86,8 +87,13 @@ export function estimatePromptTokens(
 				} else if (block.type === "anthropicServerTool") {
 					// Verbatim server-tool call/result (e.g. web_search_tool_result)
 					// replayed on the wire — potentially large, so charge its
-					// serialized form like the agent's compaction estimator.
-					tokens += estimateTextTokens(JSON.stringify(block.block));
+					// serialized form. It travels only to the anthropic-messages
+					// provider that produced it; every cross-provider target (e.g.
+					// Bedrock after an Anthropic web-search turn) drops it in
+					// transformMessages, so when a target is known, charge nothing
+					// for bytes that never reach the wire.
+					const droppedByTarget = targetModel !== undefined && !replaysAnthropicServerTool(message, targetModel);
+					if (!droppedByTarget) tokens += estimateTextTokens(JSON.stringify(block.block));
 				} else if (block.type === "fallback") {
 					tokens += estimateTextTokens(JSON.stringify(block));
 				}
@@ -108,4 +114,15 @@ export function estimatePromptTokens(
  */
 export function estimateTextTokens(text: string): number {
 	return (Buffer.byteLength(text, "utf-8") + 3) >> 2;
+}
+
+/**
+ * Mirror transformMessages' replay predicate for native server-tool blocks: they
+ * survive on the wire only when the target is the anthropic-messages provider that
+ * produced them. Cross-provider targets drop them, so they add no wire bytes here.
+ */
+function replaysAnthropicServerTool(message: Message, target: Pick<Model, "api" | "provider">): boolean {
+	if (target.api !== "anthropic-messages") return false;
+	if (message.role !== "assistant") return false;
+	return message.provider === target.provider;
 }

--- a/packages/ai/src/utils/output-budget.ts
+++ b/packages/ai/src/utils/output-budget.ts
@@ -81,7 +81,14 @@ export function estimatePromptTokens(
 				} else if (block.type === "thinking") {
 					tokens += estimateTextTokens(block.thinking);
 				} else if (block.type === "redactedThinking") {
-					tokens += estimateTextTokens(block.data);
+					// Opaque encrypted payload. It is native-only: transformMessages
+					// drops it for every target that isn't an anthropic-messages
+					// provider (e.g. a Bedrock turn after an Anthropic one), so when a
+					// target is known, charge nothing for bytes that never reach the
+					// wire — those phantom tokens would otherwise shrink max_tokens.
+					const droppedByTarget =
+						targetModel !== undefined && !replaysAnthropicRedactedThinking(message, targetModel);
+					if (!droppedByTarget) tokens += estimateTextTokens(block.data);
 				} else if (block.type === "toolCall") {
 					tokens += estimateTextTokens(JSON.stringify({ name: block.name, arguments: block.arguments }));
 				} else if (block.type === "anthropicServerTool") {
@@ -125,4 +132,19 @@ function replaysAnthropicServerTool(message: Message, target: Pick<Model, "api" 
 	if (target.api !== "anthropic-messages") return false;
 	if (message.role !== "assistant") return false;
 	return message.provider === target.provider;
+}
+
+/**
+ * Mirror transformMessages' replay predicate for redacted (encrypted) thinking:
+ * the opaque payload is native-only — it survives on the wire solely for an
+ * anthropic-messages target (signed replay, latest same-provider turn, or an
+ * unsigned-thinking-compatible sibling). Every other target (e.g. Bedrock after
+ * an Anthropic turn) drops it in transformMessages, so its bytes add no prompt
+ * tokens here. The gate stays permissive for anthropic-messages targets (those
+ * bytes are still charged even when the richer transform predicate might drop
+ * them): over-counting is safe, while charging dropped bytes is the bug fixed.
+ */
+function replaysAnthropicRedactedThinking(message: Message, target: Pick<Model, "api" | "provider">): boolean {
+	if (target.api !== "anthropic-messages") return false;
+	return message.role === "assistant";
 }

--- a/packages/ai/src/utils/output-budget.ts
+++ b/packages/ai/src/utils/output-budget.ts
@@ -69,6 +69,8 @@ export function estimatePromptTokens(
 					tokens += IMAGE_TOKEN_ESTIMATE;
 				} else if (block.type === "thinking") {
 					tokens += estimateTextTokens(block.thinking);
+				} else if (block.type === "redactedThinking") {
+					tokens += estimateTextTokens(block.data);
 				} else if (block.type === "toolCall") {
 					tokens += estimateTextTokens(JSON.stringify({ name: block.name, arguments: block.arguments }));
 				}

--- a/packages/ai/test/anthropic-fable-request-shaping.test.ts
+++ b/packages/ai/test/anthropic-fable-request-shaping.test.ts
@@ -62,6 +62,9 @@ type CapturedPayload = {
 	thinking?: { type: string };
 	tool_choice?: { type: string };
 	output_config?: { effort?: string };
+	temperature?: number;
+	top_p?: number;
+	top_k?: number;
 };
 
 function capturePayload(
@@ -156,5 +159,36 @@ describe("MiniMax Anthropic adaptive thinking", () => {
 
 		expect(payload.thinking).toEqual({ type: "adaptive" });
 		expect(payload.output_config?.effort).toBeUndefined();
+	});
+});
+
+describe("Anthropic adaptive-only thinking + sampling params", () => {
+	it("withholds sampling params from a forced-tool adaptive-only turn (thinking stays implicitly on)", async () => {
+		// Forced tool choice routes through disableThinking, which deletes
+		// params.thinking but pins output_config.effort="low" for adaptive-only
+		// models — the request still reasons, so caller-supplied sampling params
+		// would trip a provider 400. They must be withheld.
+		const base = makeAnthropicModel("claude-opus-4-8");
+		const model = buildModel({
+			...base,
+			thinking: {
+				mode: "anthropic-adaptive",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			},
+			compat: { ...base.compatConfig, supportsSamplingParams: true },
+		} as ModelSpec<"anthropic-messages">);
+		const payload = await capturePayload(model, {
+			toolChoice: { type: "tool", name: "get_weather" },
+			temperature: 0.7,
+			topP: 0.5,
+			topK: 40,
+		});
+		// disableThinking ran for the forced-tool adaptive-only turn.
+		expect(payload.thinking).toBeUndefined();
+		expect(payload.output_config?.effort).toBe("low");
+		// Still-adaptive request must not carry sampling params.
+		expect(payload.temperature).toBeUndefined();
+		expect(payload.top_p).toBeUndefined();
+		expect(payload.top_k).toBeUndefined();
 	});
 });

--- a/packages/ai/test/output-budget.test.ts
+++ b/packages/ai/test/output-budget.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "bun:test";
+import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type { AssistantMessage, Context, Model, UserMessage } from "@oh-my-pi/pi-ai/types";
+import { clampMaxTokensToContext, estimatePromptTokens } from "@oh-my-pi/pi-ai/utils/output-budget";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+// ─── clampMaxTokensToContext ─────────────────────────────────────────────────
+
+describe("clampMaxTokensToContext", () => {
+	it("passes through when contextWindow is undefined", () => {
+		expect(
+			clampMaxTokensToContext({
+				requestedMaxTokens: 16384,
+				contextWindow: undefined,
+				estimatedPromptTokens: 100000,
+			}),
+		).toBe(16384);
+	});
+
+	it("passes through when contextWindow is zero", () => {
+		expect(
+			clampMaxTokensToContext({
+				requestedMaxTokens: 8192,
+				contextWindow: 0,
+				estimatedPromptTokens: 100,
+			}),
+		).toBe(8192);
+	});
+
+	it("passes through when contextWindow is negative", () => {
+		expect(
+			clampMaxTokensToContext({
+				requestedMaxTokens: 8192,
+				contextWindow: -1,
+				estimatedPromptTokens: 100,
+			}),
+		).toBe(8192);
+	});
+
+	it("is a no-op when the request already fits", () => {
+		// window=200000, prompt=10000, reserve=4096 → budget=185904; requested 8192 fits
+		expect(
+			clampMaxTokensToContext({
+				requestedMaxTokens: 8192,
+				contextWindow: 200_000,
+				estimatedPromptTokens: 10_000,
+			}),
+		).toBe(8192);
+	});
+
+	it("reduces when prompt + requested exceeds the window", () => {
+		// window=200000, prompt=195000, reserve=4096 → budget=max(1, 904)=904
+		expect(
+			clampMaxTokensToContext({
+				requestedMaxTokens: 16384,
+				contextWindow: 200_000,
+				estimatedPromptTokens: 195_000,
+			}),
+		).toBe(904);
+	});
+
+	it("floors at 1 when the budget would be non-positive", () => {
+		// window=100, prompt=200, reserve=4096 → budget=max(1, -4196)=1
+		expect(
+			clampMaxTokensToContext({
+				requestedMaxTokens: 8192,
+				contextWindow: 100,
+				estimatedPromptTokens: 200,
+			}),
+		).toBe(1);
+	});
+
+	it("respects a custom reserveTokens", () => {
+		// window=200000, prompt=190000, reserve=8000 → budget=max(1, 2000)=2000
+		expect(
+			clampMaxTokensToContext({
+				requestedMaxTokens: 16384,
+				contextWindow: 200_000,
+				estimatedPromptTokens: 190_000,
+				reserveTokens: 8000,
+			}),
+		).toBe(2000);
+	});
+});
+
+// ─── estimatePromptTokens ────────────────────────────────────────────────────
+
+const EMPTY_USAGE = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function assistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "test-model",
+		usage: { ...EMPTY_USAGE },
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+describe("estimatePromptTokens", () => {
+	it("returns 0 for empty inputs", () => {
+		expect(estimatePromptTokens(undefined, [])).toBe(0);
+	});
+
+	it("counts system prompt text", () => {
+		const text = "Hello world"; // 11 bytes → (11+3)>>2 = 3
+		expect(estimatePromptTokens(text, [])).toBe((Buffer.byteLength(text, "utf-8") + 3) >> 2);
+	});
+
+	it("counts string message content", () => {
+		const msg: UserMessage = { role: "user", content: "test message", timestamp: 0 };
+		const expected = (Buffer.byteLength("test message", "utf-8") + 3) >> 2;
+		expect(estimatePromptTokens(undefined, [msg])).toBe(expected);
+	});
+
+	it("counts text blocks in array content", () => {
+		const msg: UserMessage = {
+			role: "user",
+			content: [{ type: "text", text: "hello" }],
+			timestamp: 0,
+		};
+		const expected = (Buffer.byteLength("hello", "utf-8") + 3) >> 2;
+		expect(estimatePromptTokens(undefined, [msg])).toBe(expected);
+	});
+
+	it("adds IMAGE_TOKEN_ESTIMATE per image block", () => {
+		const msg: UserMessage = {
+			role: "user",
+			content: [
+				{ type: "text", text: "describe" },
+				{ type: "image", data: "abc", mimeType: "image/png" },
+				{ type: "image", data: "def", mimeType: "image/jpeg" },
+			],
+			timestamp: 0,
+		};
+		const textTokens = (Buffer.byteLength("describe", "utf-8") + 3) >> 2;
+		expect(estimatePromptTokens(undefined, [msg])).toBe(textTokens + 1200 + 1200);
+	});
+
+	it("counts thinking blocks in array content", () => {
+		const thinking = "Let me reason about this step by step.";
+		const msg = assistantMessage([{ type: "thinking", thinking }]);
+		const expected = (Buffer.byteLength(thinking, "utf-8") + 3) >> 2;
+		expect(estimatePromptTokens(undefined, [msg])).toBe(expected);
+	});
+
+	it("counts toolCall blocks in array content", () => {
+		const arguments_ = { command: "ls -la /workspace", cwd: "/home" };
+		const msg = assistantMessage([{ type: "toolCall", id: "call-1", name: "bash", arguments: arguments_ }]);
+		const expected = (Buffer.byteLength(JSON.stringify({ name: "bash", arguments: arguments_ }), "utf-8") + 3) >> 2;
+		expect(estimatePromptTokens(undefined, [msg])).toBe(expected);
+	});
+
+	it("counts serialized tools", () => {
+		const tools = [{ name: "read", description: "Read a file" }];
+		const toolJson = JSON.stringify(tools);
+		const expected = (Buffer.byteLength(toolJson, "utf-8") + 3) >> 2;
+		expect(estimatePromptTokens(undefined, [], tools)).toBe(expected);
+	});
+
+	it("combines system prompt, messages, and tools", () => {
+		const system = "Be concise.";
+		const msg: UserMessage = { role: "user", content: "hi", timestamp: 0 };
+		const tools = [{ name: "bash" }];
+		const expected =
+			((Buffer.byteLength(system, "utf-8") + 3) >> 2) +
+			((Buffer.byteLength("hi", "utf-8") + 3) >> 2) +
+			((Buffer.byteLength(JSON.stringify(tools), "utf-8") + 3) >> 2);
+		expect(estimatePromptTokens(system, [msg], tools)).toBe(expected);
+	});
+});
+
+// ─── Anthropic request-building integration ──────────────────────────────────
+
+function createAbortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function makeModel(contextWindow: number, maxTokens: number): Model<"anthropic-messages"> {
+	return buildModel({
+		id: "claude-sonnet-4-5",
+		name: "Claude Sonnet 4.5",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow,
+		maxTokens,
+	});
+}
+
+/** Reasoning-capable variant so extended-thinking params are built on the wire. */
+function makeThinkingModel(contextWindow: number, maxTokens: number): Model<"anthropic-messages"> {
+	return buildModel({
+		id: "claude-sonnet-4-5",
+		name: "Claude Sonnet 4.5",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow,
+		maxTokens,
+	});
+}
+
+function capturePayload(
+	model: Model<"anthropic-messages">,
+	context: Context,
+	maxTokens?: number,
+	thinking?: { enabled: boolean; budgetTokens?: number },
+): Promise<Record<string, unknown>> {
+	const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
+	streamAnthropic(model, context, {
+		apiKey: "sk-ant-test",
+		signal: createAbortedSignal(),
+		maxTokens,
+		...(thinking && { thinkingEnabled: thinking.enabled, thinkingBudgetTokens: thinking.budgetTokens }),
+		onPayload: payload => resolve(payload as Record<string, unknown>),
+	});
+	return promise;
+}
+
+describe("anthropic output-budget clamp integration", () => {
+	it("shrinks an oversized declared max_tokens to fit the context window", async () => {
+		// contextWindow=10000, maxTokens(model)=8192, requested=8192
+		// A large prompt (~6000 tokens estimated) leaves little room.
+		const model = makeModel(10_000, 8_192);
+		// Build a prompt that estimates to ~6000 tokens: 24000 bytes → (24000+3)>>2 = 6000
+		const bigText = "x".repeat(24_000);
+		const context: Context = {
+			messages: [{ role: "user", content: bigText, timestamp: Date.now() }],
+		};
+		const payload = await capturePayload(model, context, 8192);
+		// budget = max(1, 10000 - 6000 - 4096) = max(1, -96) = 1
+		// clamp: min(8192, 1) = 1
+		expect(payload.max_tokens).toBe(1);
+	});
+
+	it("leaves a fitting max_tokens untouched", async () => {
+		const model = makeModel(200_000, 8_192);
+		const context: Context = {
+			messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+		};
+		const payload = await capturePayload(model, context, 4096);
+		// prompt estimate is tiny; budget >> 4096, so no clamp
+		expect(payload.max_tokens).toBe(4096);
+	});
+
+	it("keeps max_tokens above thinking.budget_tokens after clamping a near-full window", async () => {
+		// contextWindow=16000, prompt≈6000 tokens, requested=8192, thinkingBudget=4000.
+		// clamp budget = max(1, 16000 - 6000 - 4096) = 5904 → max_tokens = min(8192, 5904) = 5904.
+		// reconcile: 4000 + OUTPUT_FALLBACK_BUFFER(4000) = 8000 > 5904 → budget = 5904 - 4000 = 1904.
+		const model = makeThinkingModel(16_000, 8_192);
+		const bigText = "x".repeat(24_000);
+		const context: Context = {
+			messages: [{ role: "user", content: bigText, timestamp: Date.now() }],
+		};
+		const payload = await capturePayload(model, context, 8192, { enabled: true, budgetTokens: 4000 });
+		expect(payload.max_tokens).toBe(5904);
+		expect(payload.thinking).toMatchObject({ type: "enabled", budget_tokens: 1904 });
+		const thinking = payload.thinking as { budget_tokens: number } | undefined;
+		expect((payload.max_tokens as number) > (thinking?.budget_tokens ?? 0)).toBe(true);
+	});
+
+	it("disables thinking when the window is too tight for a viable budget", async () => {
+		// contextWindow=10000, prompt≈6000 tokens, requested=8192, thinkingBudget=4000.
+		// clamp budget = max(1, 10000 - 6000 - 4096) = 1 → max_tokens = 1.
+		// reconcile: clampedBudget = 1 - 4000 < 1024 (MIN) → thinking disabled.
+		const model = makeThinkingModel(10_000, 8_192);
+		const bigText = "x".repeat(24_000);
+		const context: Context = {
+			messages: [{ role: "user", content: bigText, timestamp: Date.now() }],
+		};
+		const payload = await capturePayload(model, context, 8192, { enabled: true, budgetTokens: 4000 });
+		expect(payload.max_tokens).toBe(1);
+		expect(payload.thinking).toBeUndefined();
+	});
+});

--- a/packages/ai/test/output-budget.test.ts
+++ b/packages/ai/test/output-budget.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
 import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
 import type { AssistantMessage, Context, Model, UserMessage } from "@oh-my-pi/pi-ai/types";
 import { clampMaxTokensToContext, estimatePromptTokens } from "@oh-my-pi/pi-ai/utils/output-budget";
@@ -290,5 +291,76 @@ describe("anthropic output-budget clamp integration", () => {
 		const payload = await capturePayload(model, context, 8192, { enabled: true, budgetTokens: 4000 });
 		expect(payload.max_tokens).toBe(1);
 		expect(payload.thinking).toBeUndefined();
+	});
+});
+
+// ─── Bedrock request-building integration ────────────────────────────────────
+
+function makeBedrockModel(contextWindow: number, maxTokens: number): Model<"bedrock-converse-stream"> {
+	return buildModel({
+		id: "anthropic.claude-sonnet-4-5",
+		name: "Claude Sonnet 4.5 (Bedrock)",
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow,
+		maxTokens,
+	});
+}
+
+function captureBedrockPayload(
+	model: Model<"bedrock-converse-stream">,
+	context: Context,
+	options: { maxTokens?: number; reasoning?: "medium"; interleavedThinking?: boolean },
+): Promise<Record<string, unknown>> {
+	const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
+	// The stream is only observed for its onPayload snapshot and then abandoned.
+	// A bearer token keeps the abandoned continuation off the AWS-credentials
+	// path (see bedrock-prompt-cache.test.ts for the unhandled-rejection trap).
+	void streamBedrock(model, context, {
+		apiKey: "test-key",
+		signal: createAbortedSignal(),
+		...options,
+		onPayload: payload => resolve(payload as Record<string, unknown>),
+	});
+	return promise;
+}
+
+describe("bedrock output-budget clamp integration", () => {
+	it("reconciles the thinking budget under the clamped maxTokens", async () => {
+		// contextWindow=16000, prompt≈6000 tokens, requested=8192, effort medium (budget 8192).
+		// clamp: min(8192, max(1, 16000 - 6000 - 4096)) = 5904.
+		// reconcile: 8192 + 4000 > 5904 → budget = 5904 - 4000 = 1904 (≥ 1024 floor).
+		const model = makeBedrockModel(16_000, 8_192);
+		const bigText = "x".repeat(24_000);
+		const context: Context = {
+			messages: [{ role: "user", content: bigText, timestamp: Date.now() }],
+		};
+		const payload = await captureBedrockPayload(model, context, { maxTokens: 8192, reasoning: "medium" });
+		expect(payload.inferenceConfig).toMatchObject({ maxTokens: 5904 });
+		expect(payload.additionalModelRequestFields).toMatchObject({
+			thinking: { type: "enabled", budget_tokens: 1904 },
+		});
+	});
+
+	it("drops thinking and the interleaved beta when the window is too tight", async () => {
+		// contextWindow=10000, prompt≈6000 tokens → clamp to 1.
+		// reconcile: 1 - 4000 < 1024 → thinking dropped; the interleaved beta must
+		// not survive without it, leaving no additional fields at all.
+		const model = makeBedrockModel(10_000, 8_192);
+		const bigText = "x".repeat(24_000);
+		const context: Context = {
+			messages: [{ role: "user", content: bigText, timestamp: Date.now() }],
+		};
+		const payload = await captureBedrockPayload(model, context, {
+			maxTokens: 8192,
+			reasoning: "medium",
+			interleavedThinking: true,
+		});
+		expect(payload.inferenceConfig).toMatchObject({ maxTokens: 1 });
+		expect(payload.additionalModelRequestFields).toBeUndefined();
 	});
 });

--- a/packages/ai/test/output-budget.test.ts
+++ b/packages/ai/test/output-budget.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
 import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type { FallbackParam } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
 import type { AssistantMessage, Context, Model, UserMessage } from "@oh-my-pi/pi-ai/types";
 import { clampMaxTokensToContext, estimatePromptTokens } from "@oh-my-pi/pi-ai/utils/output-budget";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 // ─── clampMaxTokensToContext ─────────────────────────────────────────────────
 
@@ -209,6 +211,7 @@ function makeThinkingModel(
 	contextWindow: number,
 	maxTokens: number,
 	requiresThinkingEnabled = false,
+	supportsSamplingParams = false,
 ): Model<"anthropic-messages"> {
 	return buildModel({
 		id: "claude-sonnet-4-5",
@@ -221,15 +224,26 @@ function makeThinkingModel(
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow,
 		maxTokens,
-		...(requiresThinkingEnabled && { compat: { requiresThinkingEnabled: true } }),
+		compat: {
+			...(requiresThinkingEnabled && { requiresThinkingEnabled: true }),
+			...(supportsSamplingParams && { supportsSamplingParams: true }),
+		},
 	});
 }
+
+type CapturePayloadOptions = {
+	fallbacks?: FallbackParam[];
+	temperature?: number;
+	topP?: number;
+	topK?: number;
+};
 
 function capturePayload(
 	model: Model<"anthropic-messages">,
 	context: Context,
 	maxTokens?: number,
 	thinking?: { enabled: boolean; budgetTokens?: number },
+	payloadOptions?: CapturePayloadOptions,
 ): Promise<Record<string, unknown>> {
 	const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
 	streamAnthropic(model, context, {
@@ -237,6 +251,10 @@ function capturePayload(
 		signal: createAbortedSignal(),
 		maxTokens,
 		...(thinking && { thinkingEnabled: thinking.enabled, thinkingBudgetTokens: thinking.budgetTokens }),
+		...(payloadOptions?.fallbacks && { fallbacks: payloadOptions.fallbacks }),
+		...(payloadOptions?.temperature !== undefined && { temperature: payloadOptions.temperature }),
+		...(payloadOptions?.topP !== undefined && { topP: payloadOptions.topP }),
+		...(payloadOptions?.topK !== undefined && { topK: payloadOptions.topK }),
 		onPayload: payload => resolve(payload as Record<string, unknown>),
 	});
 	return promise;
@@ -309,6 +327,75 @@ describe("anthropic output-budget clamp integration", () => {
 		const payload = await capturePayload(model, context, 8192, { enabled: true, budgetTokens: 4000 });
 		expect(payload.max_tokens).toBe(1);
 		expect(payload.thinking).toBeUndefined();
+	});
+
+	it("clamps an explicit fallback max_tokens override independently", async () => {
+		const model = makeModel(10_000, 8_192);
+		const context: Context = {
+			messages: [{ role: "user", content: "x".repeat(24_000), timestamp: Date.now() }],
+		};
+		const payload = await capturePayload(model, context, 8192, undefined, {
+			fallbacks: [{ model: "unknown-fallback", max_tokens: 8192 }],
+		});
+		expect(payload.fallbacks).toEqual([{ model: "unknown-fallback", max_tokens: 1 }]);
+	});
+
+	it("reconciles fallback thinking against an inherited clamped max_tokens", async () => {
+		const model = makeThinkingModel(16_000, 8_192);
+		const context: Context = {
+			messages: [{ role: "user", content: "x".repeat(24_000), timestamp: Date.now() }],
+		};
+		const payload = await capturePayload(model, context, 8192, undefined, {
+			fallbacks: [{ model: "unknown-fallback", thinking: { type: "enabled", budget_tokens: 4000 } }],
+		});
+		expect(payload.fallbacks).toEqual([
+			{ model: "unknown-fallback", thinking: { type: "enabled", budget_tokens: 1904 } },
+		]);
+	});
+
+	it("restores supported sampling parameters after a tight clamp disables optional thinking", async () => {
+		const model = makeThinkingModel(10_000, 8_192, false, true);
+		const context: Context = {
+			messages: [{ role: "user", content: "x".repeat(24_000), timestamp: Date.now() }],
+		};
+		const payload = await capturePayload(
+			model,
+			context,
+			8192,
+			{ enabled: true, budgetTokens: 4000 },
+			{ temperature: 0.7, topP: 0.9, topK: 42 },
+		);
+		expect(payload).toMatchObject({
+			max_tokens: 1,
+			temperature: 0.7,
+			top_p: 0.9,
+			top_k: 42,
+		});
+		expect(payload.thinking).toBeUndefined();
+	});
+	it("retains a materialized inherited fallback max only when the fallback context window requires a stricter clamp", async () => {
+		const primary = getBundledModel<"anthropic-messages">("anthropic", "claude-fable-5");
+		const fallback = getBundledModel<"anthropic-messages">("anthropic", "claude-haiku-4-5");
+		if (!primary || !fallback) throw new Error("Expected bundled Anthropic models to exist");
+
+		const smallContext: Context = {
+			messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+		};
+		const smallPayload = await capturePayload(primary, smallContext, undefined, undefined, {
+			fallbacks: [{ model: fallback.id }],
+		});
+		expect(smallPayload.max_tokens).toBe(128_000);
+		expect(smallPayload.fallbacks).toEqual([{ model: fallback.id }]);
+
+		const bigText = "x".repeat(280_000);
+		const largeContext: Context = {
+			messages: [{ role: "user", content: bigText, timestamp: Date.now() }],
+		};
+		const largePayload = await capturePayload(primary, largeContext, undefined, undefined, {
+			fallbacks: [{ model: fallback.id }],
+		});
+		expect(largePayload.max_tokens).toBe(128_000);
+		expect(largePayload.fallbacks).toEqual([{ model: fallback.id, max_tokens: 125_904 }]);
 	});
 });
 

--- a/packages/ai/test/output-budget.test.ts
+++ b/packages/ai/test/output-budget.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { Effort } from "@oh-my-pi/pi-ai";
 import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
 import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
 import type { AssistantMessage, Context, Model, UserMessage } from "@oh-my-pi/pi-ai/types";
@@ -39,7 +40,7 @@ describe("clampMaxTokensToContext", () => {
 	});
 
 	it("is a no-op when the request already fits", () => {
-		// window=200000, prompt=10000, reserve=4096 → budget=185904; requested 8192 fits
+		// window=200000, prompt=10000, reserve=4000 → budget=186000; requested 8192 fits
 		expect(
 			clampMaxTokensToContext({
 				requestedMaxTokens: 8192,
@@ -50,18 +51,18 @@ describe("clampMaxTokensToContext", () => {
 	});
 
 	it("reduces when prompt + requested exceeds the window", () => {
-		// window=200000, prompt=195000, reserve=4096 → budget=max(1, 904)=904
+		// window=200000, prompt=195000, reserve=4000 → budget=max(1, 1000)=1000
 		expect(
 			clampMaxTokensToContext({
 				requestedMaxTokens: 16384,
 				contextWindow: 200_000,
 				estimatedPromptTokens: 195_000,
 			}),
-		).toBe(904);
+		).toBe(1000);
 	});
 
 	it("floors at 1 when the budget would be non-positive", () => {
-		// window=100, prompt=200, reserve=4096 → budget=max(1, -4196)=1
+		// window=100, prompt=200, reserve=4000 → budget=max(1, -4100)=1
 		expect(
 			clampMaxTokensToContext({
 				requestedMaxTokens: 8192,
@@ -168,6 +169,17 @@ describe("estimatePromptTokens", () => {
 		expect(estimatePromptTokens(undefined, [msg])).toBe(expected);
 	});
 
+	it("counts anthropicServerTool blocks (web-search replay) in array content", () => {
+		const block = {
+			type: "web_search_tool_result" as const,
+			tool_use_id: "srv_1",
+			content: [{ type: "text", text: "x".repeat(40_000) }],
+		};
+		const msg = assistantMessage([{ type: "anthropicServerTool", block }]);
+		const expected = (Buffer.byteLength(JSON.stringify(block), "utf-8") + 3) >> 2;
+		expect(estimatePromptTokens(undefined, [msg])).toBe(expected);
+	});
+
 	it("counts serialized tools", () => {
 		const tools = [{ name: "read", description: "Read a file" }];
 		const toolJson = JSON.stringify(tools);
@@ -216,6 +228,7 @@ function makeThinkingModel(
 	maxTokens: number,
 	requiresThinkingEnabled = false,
 	supportsSamplingParams = false,
+	requiresEffort = false,
 ): Model<"anthropic-messages"> {
 	return buildModel({
 		id: "claude-sonnet-4-5",
@@ -228,6 +241,9 @@ function makeThinkingModel(
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow,
 		maxTokens,
+		...(requiresEffort && {
+			thinking: { mode: "budget", efforts: [Effort.Low, Effort.Medium, Effort.High], requiresEffort: true },
+		}),
 		compat: {
 			...(requiresThinkingEnabled && { requiresThinkingEnabled: true }),
 			...(supportsSamplingParams && { supportsSamplingParams: true }),
@@ -273,7 +289,7 @@ describe("anthropic output-budget clamp integration", () => {
 			messages: [{ role: "user", content: bigText, timestamp: Date.now() }],
 		};
 		const payload = await capturePayload(model, context, 8192);
-		// budget = max(1, 10000 - 6000 - 4096) = max(1, -96) = 1
+		// budget = max(1, 10000 - 6000 - 4000) = max(1, 0) = 1
 		// clamp: min(8192, 1) = 1
 		expect(payload.max_tokens).toBe(1);
 	});
@@ -290,36 +306,50 @@ describe("anthropic output-budget clamp integration", () => {
 
 	it("keeps max_tokens above thinking.budget_tokens after clamping a near-full window", async () => {
 		// contextWindow=16000, prompt≈6000 tokens, requested=8192, thinkingBudget=4000.
-		// clamp budget = max(1, 16000 - 6000 - 4096) = 5904 → max_tokens = min(8192, 5904) = 5904.
-		// reconcile: 4000 + OUTPUT_FALLBACK_BUFFER(4000) = 8000 > 5904 → budget = 5904 - 4000 = 1904.
+		// clamp budget = max(1, 16000 - 6000 - 4000) = 6000 → max_tokens = min(8192, 6000) = 6000.
+		// reconcile: 4000 + OUTPUT_FALLBACK_BUFFER(4000) = 8000 > 6000 → budget = 6000 - 4000 = 2000.
 		const model = makeThinkingModel(16_000, 8_192);
 		const bigText = "x".repeat(24_000);
 		const context: Context = {
 			messages: [{ role: "user", content: bigText, timestamp: Date.now() }],
 		};
 		const payload = await capturePayload(model, context, 8192, { enabled: true, budgetTokens: 4000 });
-		expect(payload.max_tokens).toBe(5904);
-		expect(payload.thinking).toMatchObject({ type: "enabled", budget_tokens: 1904 });
+		expect(payload.max_tokens).toBe(6000);
+		expect(payload.thinking).toMatchObject({ type: "enabled", budget_tokens: 2000 });
 		const thinking = payload.thinking as { budget_tokens: number } | undefined;
 		expect((payload.max_tokens as number) > (thinking?.budget_tokens ?? 0)).toBe(true);
 	});
 
 	it("keeps mandatory thinking enabled with a sub-floor clamped budget", async () => {
 		// contextWindow=14596, prompt≈6000 tokens, requested=8192.
-		// clamp: min(8192, max(1, 14596 - 6000 - 4096)) = 4500.
-		// Mandatory thinking retains the positive clamped budget: 4500 - 4000 = 500.
+		// clamp: min(8192, max(1, 14596 - 6000 - 4000)) = 4596.
+		// Mandatory thinking retains the positive clamped budget: 4596 - 4000 = 596.
 		const model = makeThinkingModel(14_596, 8_192, true);
 		const context: Context = {
 			messages: [{ role: "user", content: "x".repeat(24_000), timestamp: Date.now() }],
 		};
 		const payload = await capturePayload(model, context, 8192);
-		expect(payload.max_tokens).toBe(4500);
-		expect(payload.thinking).toMatchObject({ type: "enabled", budget_tokens: 500 });
+		expect(payload.max_tokens).toBe(4596);
+		expect(payload.thinking).toMatchObject({ type: "enabled", budget_tokens: 596 });
+	});
+
+	it("preserves thinking for requiresEffort models with a sub-floor clamped budget", async () => {
+		// Same window as the compat.requiresThinkingEnabled case, but reasoning is
+		// mandatory via thinking.requiresEffort. A sub-floor budget (< MIN) is
+		// retained instead of disabling thinking, since the endpoint rejects
+		// omitted reasoning. clamp to 4596; budget = 4596 - 4000 = 596.
+		const model = makeThinkingModel(14_596, 8_192, false, false, true);
+		const context: Context = {
+			messages: [{ role: "user", content: "x".repeat(24_000), timestamp: Date.now() }],
+		};
+		const payload = await capturePayload(model, context, 8192, { enabled: true, budgetTokens: 4000 });
+		expect(payload.max_tokens).toBe(4596);
+		expect(payload.thinking).toMatchObject({ type: "enabled", budget_tokens: 596 });
 	});
 
 	it("disables thinking when the window is too tight for a viable budget", async () => {
 		// contextWindow=10000, prompt≈6000 tokens, requested=8192, thinkingBudget=4000.
-		// clamp budget = max(1, 10000 - 6000 - 4096) = 1 → max_tokens = 1.
+		// clamp budget = max(1, 10000 - 6000 - 4000) = 1 → max_tokens = 1.
 		// reconcile: clampedBudget = 1 - 4000 < 1024 (MIN) → thinking disabled.
 		const model = makeThinkingModel(10_000, 8_192);
 		const bigText = "x".repeat(24_000);
@@ -355,7 +385,11 @@ describe("anthropic output-budget clamp integration", () => {
 
 // ─── Bedrock request-building integration ────────────────────────────────────
 
-function makeBedrockModel(contextWindow: number, maxTokens: number): Model<"bedrock-converse-stream"> {
+function makeBedrockModel(
+	contextWindow: number,
+	maxTokens: number,
+	requiresEffort = false,
+): Model<"bedrock-converse-stream"> {
 	return buildModel({
 		id: "anthropic.claude-sonnet-4-5",
 		name: "Claude Sonnet 4.5 (Bedrock)",
@@ -367,13 +401,16 @@ function makeBedrockModel(contextWindow: number, maxTokens: number): Model<"bedr
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow,
 		maxTokens,
+		...(requiresEffort && {
+			thinking: { mode: "budget", efforts: [Effort.Low, Effort.Medium, Effort.High], requiresEffort: true },
+		}),
 	});
 }
 
 function captureBedrockPayload(
 	model: Model<"bedrock-converse-stream">,
 	context: Context,
-	options: { maxTokens?: number; reasoning?: "medium"; interleavedThinking?: boolean },
+	options: { maxTokens?: number; reasoning?: "medium"; interleavedThinking?: boolean; toolChoice?: "auto" | "none" },
 ): Promise<Record<string, unknown>> {
 	const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
 	// The stream is only observed for its onPayload snapshot and then abandoned.
@@ -391,8 +428,8 @@ function captureBedrockPayload(
 describe("bedrock output-budget clamp integration", () => {
 	it("keeps a viable thinking budget with Bedrock's output reserve", async () => {
 		// contextWindow=14096, prompt≈6000 tokens, requested=8192, effort medium (budget 8192).
-		// clamp: min(8192, max(1, 14096 - 6000 - 4096)) = 4000.
-		// Bedrock reserves 1024 output tokens, so budget becomes 4000 - 1024 = 2976.
+		// clamp: min(8192, max(1, 14096 - 6000 - 4000)) = 4096.
+		// Bedrock reserves 1024 output tokens, so budget becomes 4096 - 1024 = 3072.
 		// Anthropic's 4000-token buffer would instead drop thinking entirely.
 		const model = makeBedrockModel(14_096, 8_192);
 		const bigText = "x".repeat(24_000);
@@ -400,9 +437,9 @@ describe("bedrock output-budget clamp integration", () => {
 			messages: [{ role: "user", content: bigText, timestamp: Date.now() }],
 		};
 		const payload = await captureBedrockPayload(model, context, { maxTokens: 8192, reasoning: "medium" });
-		expect(payload.inferenceConfig).toMatchObject({ maxTokens: 4000 });
+		expect(payload.inferenceConfig).toMatchObject({ maxTokens: 4096 });
 		expect(payload.additionalModelRequestFields).toMatchObject({
-			thinking: { type: "enabled", budget_tokens: 2976 },
+			thinking: { type: "enabled", budget_tokens: 3072 },
 		});
 	});
 
@@ -422,5 +459,43 @@ describe("bedrock output-budget clamp integration", () => {
 		});
 		expect(payload.inferenceConfig).toMatchObject({ maxTokens: 1 });
 		expect(payload.additionalModelRequestFields).toBeUndefined();
+	});
+
+	it("retains thinking for mandatory-reasoning Bedrock models with a sub-floor budget", async () => {
+		// contextWindow=11500, prompt≈6000 → clamp budget = max(1, 11500-6000-4000)=1500.
+		// reconcile: clampedBudget = 1500 - 1024 = 476 (< MIN_BEDROCK 1024). A
+		// mandatory (requiresEffort) model keeps the largest valid split (476)
+		// instead of dropping thinking, which those endpoints would reject.
+		const model = makeBedrockModel(11_500, 8_192, true);
+		const context: Context = {
+			messages: [{ role: "user", content: "x".repeat(24_000), timestamp: Date.now() }],
+		};
+		const payload = await captureBedrockPayload(model, context, { maxTokens: 8192, reasoning: "medium" });
+		expect(payload.inferenceConfig).toMatchObject({ maxTokens: 1500 });
+		expect(payload.additionalModelRequestFields).toMatchObject({
+			thinking: { type: "enabled", budget_tokens: 476 },
+		});
+	});
+
+	it("excludes unsent tools from the prompt estimate (toolChoice none, no tool history)", async () => {
+		// toolChoice "none" with no tool-use history → planToolConfig returns no
+		// toolConfig, so the large tool schema is NOT serialized for the estimate.
+		// contextWindow=10000, prompt "hi" (~1 token), requested 8192:
+		// budget = max(1, 10000 - 1 - 4000) = 5999 → maxTokens 5999.
+		// (Counting the 30KB schema would clamp maxTokens to 1.)
+		const model = makeBedrockModel(10_000, 8_192);
+		const context: Context = {
+			messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			tools: [
+				{
+					name: "big_tool",
+					description: "x".repeat(30_000),
+					parameters: { type: "object", properties: {}, additionalProperties: false },
+				},
+			],
+		};
+		const payload = await captureBedrockPayload(model, context, { maxTokens: 8192, toolChoice: "none" });
+		expect(payload.inferenceConfig).toMatchObject({ maxTokens: 5999 });
+		expect(payload.toolConfig).toBeUndefined();
 	});
 });

--- a/packages/ai/test/output-budget.test.ts
+++ b/packages/ai/test/output-budget.test.ts
@@ -205,7 +205,11 @@ function makeModel(contextWindow: number, maxTokens: number): Model<"anthropic-m
 }
 
 /** Reasoning-capable variant so extended-thinking params are built on the wire. */
-function makeThinkingModel(contextWindow: number, maxTokens: number): Model<"anthropic-messages"> {
+function makeThinkingModel(
+	contextWindow: number,
+	maxTokens: number,
+	requiresThinkingEnabled = false,
+): Model<"anthropic-messages"> {
 	return buildModel({
 		id: "claude-sonnet-4-5",
 		name: "Claude Sonnet 4.5",
@@ -217,6 +221,7 @@ function makeThinkingModel(contextWindow: number, maxTokens: number): Model<"ant
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow,
 		maxTokens,
+		...(requiresThinkingEnabled && { compat: { requiresThinkingEnabled: true } }),
 	});
 }
 
@@ -279,6 +284,19 @@ describe("anthropic output-budget clamp integration", () => {
 		expect((payload.max_tokens as number) > (thinking?.budget_tokens ?? 0)).toBe(true);
 	});
 
+	it("keeps mandatory thinking enabled with a sub-floor clamped budget", async () => {
+		// contextWindow=14596, prompt≈6000 tokens, requested=8192.
+		// clamp: min(8192, max(1, 14596 - 6000 - 4096)) = 4500.
+		// Mandatory thinking retains the positive clamped budget: 4500 - 4000 = 500.
+		const model = makeThinkingModel(14_596, 8_192, true);
+		const context: Context = {
+			messages: [{ role: "user", content: "x".repeat(24_000), timestamp: Date.now() }],
+		};
+		const payload = await capturePayload(model, context, 8192);
+		expect(payload.max_tokens).toBe(4500);
+		expect(payload.thinking).toMatchObject({ type: "enabled", budget_tokens: 500 });
+	});
+
 	it("disables thinking when the window is too tight for a viable budget", async () => {
 		// contextWindow=10000, prompt≈6000 tokens, requested=8192, thinkingBudget=4000.
 		// clamp budget = max(1, 10000 - 6000 - 4096) = 1 → max_tokens = 1.
@@ -330,25 +348,26 @@ function captureBedrockPayload(
 }
 
 describe("bedrock output-budget clamp integration", () => {
-	it("reconciles the thinking budget under the clamped maxTokens", async () => {
-		// contextWindow=16000, prompt≈6000 tokens, requested=8192, effort medium (budget 8192).
-		// clamp: min(8192, max(1, 16000 - 6000 - 4096)) = 5904.
-		// reconcile: 8192 + 4000 > 5904 → budget = 5904 - 4000 = 1904 (≥ 1024 floor).
-		const model = makeBedrockModel(16_000, 8_192);
+	it("keeps a viable thinking budget with Bedrock's output reserve", async () => {
+		// contextWindow=14096, prompt≈6000 tokens, requested=8192, effort medium (budget 8192).
+		// clamp: min(8192, max(1, 14096 - 6000 - 4096)) = 4000.
+		// Bedrock reserves 1024 output tokens, so budget becomes 4000 - 1024 = 2976.
+		// Anthropic's 4000-token buffer would instead drop thinking entirely.
+		const model = makeBedrockModel(14_096, 8_192);
 		const bigText = "x".repeat(24_000);
 		const context: Context = {
 			messages: [{ role: "user", content: bigText, timestamp: Date.now() }],
 		};
 		const payload = await captureBedrockPayload(model, context, { maxTokens: 8192, reasoning: "medium" });
-		expect(payload.inferenceConfig).toMatchObject({ maxTokens: 5904 });
+		expect(payload.inferenceConfig).toMatchObject({ maxTokens: 4000 });
 		expect(payload.additionalModelRequestFields).toMatchObject({
-			thinking: { type: "enabled", budget_tokens: 1904 },
+			thinking: { type: "enabled", budget_tokens: 2976 },
 		});
 	});
 
 	it("drops thinking and the interleaved beta when the window is too tight", async () => {
 		// contextWindow=10000, prompt≈6000 tokens → clamp to 1.
-		// reconcile: 1 - 4000 < 1024 → thinking dropped; the interleaved beta must
+		// reconcile: 1 - 1024 < 1024 → thinking dropped; the interleaved beta must
 		// not survive without it, leaving no additional fields at all.
 		const model = makeBedrockModel(10_000, 8_192);
 		const bigText = "x".repeat(24_000);

--- a/packages/ai/test/output-budget.test.ts
+++ b/packages/ai/test/output-budget.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
 import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
-import type { FallbackParam } from "@oh-my-pi/pi-ai/providers/anthropic-wire";
 import type { AssistantMessage, Context, Model, UserMessage } from "@oh-my-pi/pi-ai/types";
 import { clampMaxTokensToContext, estimatePromptTokens } from "@oh-my-pi/pi-ai/utils/output-budget";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
-import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 // ─── clampMaxTokensToContext ─────────────────────────────────────────────────
 
@@ -238,7 +236,6 @@ function makeThinkingModel(
 }
 
 type CapturePayloadOptions = {
-	fallbacks?: FallbackParam[];
 	temperature?: number;
 	topP?: number;
 	topK?: number;
@@ -257,7 +254,6 @@ function capturePayload(
 		signal: createAbortedSignal(),
 		maxTokens,
 		...(thinking && { thinkingEnabled: thinking.enabled, thinkingBudgetTokens: thinking.budgetTokens }),
-		...(payloadOptions?.fallbacks && { fallbacks: payloadOptions.fallbacks }),
 		...(payloadOptions?.temperature !== undefined && { temperature: payloadOptions.temperature }),
 		...(payloadOptions?.topP !== undefined && { topP: payloadOptions.topP }),
 		...(payloadOptions?.topK !== undefined && { topK: payloadOptions.topK }),
@@ -335,30 +331,6 @@ describe("anthropic output-budget clamp integration", () => {
 		expect(payload.thinking).toBeUndefined();
 	});
 
-	it("clamps an explicit fallback max_tokens override independently", async () => {
-		const model = makeModel(10_000, 8_192);
-		const context: Context = {
-			messages: [{ role: "user", content: "x".repeat(24_000), timestamp: Date.now() }],
-		};
-		const payload = await capturePayload(model, context, 8192, undefined, {
-			fallbacks: [{ model: "unknown-fallback", max_tokens: 8192 }],
-		});
-		expect(payload.fallbacks).toEqual([{ model: "unknown-fallback", max_tokens: 1 }]);
-	});
-
-	it("reconciles fallback thinking against an inherited clamped max_tokens", async () => {
-		const model = makeThinkingModel(16_000, 8_192);
-		const context: Context = {
-			messages: [{ role: "user", content: "x".repeat(24_000), timestamp: Date.now() }],
-		};
-		const payload = await capturePayload(model, context, 8192, undefined, {
-			fallbacks: [{ model: "unknown-fallback", thinking: { type: "enabled", budget_tokens: 4000 } }],
-		});
-		expect(payload.fallbacks).toEqual([
-			{ model: "unknown-fallback", thinking: { type: "enabled", budget_tokens: 1904 } },
-		]);
-	});
-
 	it("restores supported sampling parameters after a tight clamp disables optional thinking", async () => {
 		const model = makeThinkingModel(10_000, 8_192, false, true);
 		const context: Context = {
@@ -378,30 +350,6 @@ describe("anthropic output-budget clamp integration", () => {
 			top_k: 42,
 		});
 		expect(payload.thinking).toBeUndefined();
-	});
-	it("retains a materialized inherited fallback max only when the fallback context window requires a stricter clamp", async () => {
-		const primary = getBundledModel<"anthropic-messages">("anthropic", "claude-fable-5");
-		const fallback = getBundledModel<"anthropic-messages">("anthropic", "claude-haiku-4-5");
-		if (!primary || !fallback) throw new Error("Expected bundled Anthropic models to exist");
-
-		const smallContext: Context = {
-			messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
-		};
-		const smallPayload = await capturePayload(primary, smallContext, undefined, undefined, {
-			fallbacks: [{ model: fallback.id }],
-		});
-		expect(smallPayload.max_tokens).toBe(128_000);
-		expect(smallPayload.fallbacks).toEqual([{ model: fallback.id }]);
-
-		const bigText = "x".repeat(280_000);
-		const largeContext: Context = {
-			messages: [{ role: "user", content: bigText, timestamp: Date.now() }],
-		};
-		const largePayload = await capturePayload(primary, largeContext, undefined, undefined, {
-			fallbacks: [{ model: fallback.id }],
-		});
-		expect(largePayload.max_tokens).toBe(128_000);
-		expect(largePayload.fallbacks).toEqual([{ model: fallback.id, max_tokens: 125_904 }]);
 	});
 });
 

--- a/packages/ai/test/output-budget.test.ts
+++ b/packages/ai/test/output-budget.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { Effort } from "@oh-my-pi/pi-ai";
 import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
 import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
 import type { AssistantMessage, Context, Model, UserMessage } from "@oh-my-pi/pi-ai/types";
 import { clampMaxTokensToContext, estimatePromptTokens } from "@oh-my-pi/pi-ai/utils/output-budget";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 
 // ─── clampMaxTokensToContext ─────────────────────────────────────────────────
 
@@ -178,6 +178,33 @@ describe("estimatePromptTokens", () => {
 		const msg = assistantMessage([{ type: "anthropicServerTool", block }]);
 		const expected = (Buffer.byteLength(JSON.stringify(block), "utf-8") + 3) >> 2;
 		expect(estimatePromptTokens(undefined, [msg])).toBe(expected);
+	});
+
+	it("excludes an anthropicServerTool block a foreign target provider will drop", () => {
+		// transformMessages drops native server-tool blocks for every target that
+		// isn't the anthropic-messages provider that produced them, so a Bedrock
+		// turn after an Anthropic web-search replays nothing for the block. The
+		// estimate must not charge bytes that never reach the wire.
+		const block = {
+			type: "web_search_tool_result" as const,
+			tool_use_id: "srv_1",
+			content: [{ type: "text", text: "x".repeat(100_000) }],
+		};
+		const msg = assistantMessage([{ type: "anthropicServerTool", block }]);
+		const bedrockTarget = makeBedrockModel(200_000, 8_192);
+		expect(estimatePromptTokens(undefined, [msg], undefined, bedrockTarget)).toBe(0);
+	});
+
+	it("counts an anthropicServerTool block for its originating anthropic target", () => {
+		const block = {
+			type: "web_search_tool_result" as const,
+			tool_use_id: "srv_1",
+			content: [{ type: "text", text: "x".repeat(100_000) }],
+		};
+		const msg = assistantMessage([{ type: "anthropicServerTool", block }]);
+		const sameProvider = makeModel(200_000, 8_192);
+		const expected = (Buffer.byteLength(JSON.stringify(block), "utf-8") + 3) >> 2;
+		expect(estimatePromptTokens(undefined, [msg], undefined, sameProvider)).toBe(expected);
 	});
 
 	it("counts serialized tools", () => {

--- a/packages/ai/test/output-budget.test.ts
+++ b/packages/ai/test/output-budget.test.ts
@@ -156,6 +156,12 @@ describe("estimatePromptTokens", () => {
 		const expected = (Buffer.byteLength(thinking, "utf-8") + 3) >> 2;
 		expect(estimatePromptTokens(undefined, [msg])).toBe(expected);
 	});
+	it("counts redactedThinking blocks in array content", () => {
+		const data = "x".repeat(100_000);
+		const msg = assistantMessage([{ type: "redactedThinking", data }]);
+		const expected = (Buffer.byteLength(data, "utf-8") + 3) >> 2;
+		expect(estimatePromptTokens(undefined, [msg])).toBe(expected);
+	});
 
 	it("counts toolCall blocks in array content", () => {
 		const arguments_ = { command: "ls -la /workspace", cwd: "/home" };

--- a/packages/ai/test/output-budget.test.ts
+++ b/packages/ai/test/output-budget.test.ts
@@ -161,6 +161,23 @@ describe("estimatePromptTokens", () => {
 		const expected = (Buffer.byteLength(data, "utf-8") + 3) >> 2;
 		expect(estimatePromptTokens(undefined, [msg])).toBe(expected);
 	});
+	it("excludes a redactedThinking block a foreign target provider will drop", () => {
+		// transformMessages drops redacted (encrypted) thinking for every target
+		// that isn't an anthropic-messages provider, so a Bedrock turn after an
+		// Anthropic turn sends none of the opaque payload. The estimate must not
+		// charge bytes that never reach the wire.
+		const data = "x".repeat(100_000);
+		const msg = assistantMessage([{ type: "redactedThinking", data }]);
+		const bedrockTarget = makeBedrockModel(200_000, 8_192);
+		expect(estimatePromptTokens(undefined, [msg], undefined, bedrockTarget)).toBe(0);
+	});
+	it("counts a redactedThinking block for an anthropic target", () => {
+		const data = "x".repeat(100_000);
+		const msg = assistantMessage([{ type: "redactedThinking", data }]);
+		const sameProvider = makeModel(200_000, 8_192);
+		const expected = (Buffer.byteLength(data, "utf-8") + 3) >> 2;
+		expect(estimatePromptTokens(undefined, [msg], undefined, sameProvider)).toBe(expected);
+	});
 
 	it("counts toolCall blocks in array content", () => {
 		const arguments_ = { command: "ls -la /workspace", cwd: "/home" };
@@ -488,11 +505,12 @@ describe("bedrock output-budget clamp integration", () => {
 		expect(payload.additionalModelRequestFields).toBeUndefined();
 	});
 
-	it("retains thinking for mandatory-reasoning Bedrock models with a sub-floor budget", async () => {
+	it("retains thinking for mandatory-reasoning Bedrock models at the reasoning minimum", async () => {
 		// contextWindow=11500, prompt≈6000 → clamp budget = max(1, 11500-6000-4000)=1500.
 		// reconcile: clampedBudget = 1500 - 1024 = 476 (< MIN_BEDROCK 1024). A
-		// mandatory (requiresEffort) model keeps the largest valid split (476)
-		// instead of dropping thinking, which those endpoints would reject.
+		// mandatory (requiresEffort) model prioritizes Bedrock's 1024-token
+		// reasoning minimum (output takes the 476-token remainder) instead of
+		// emitting an invalid sub-minimum budget those endpoints would reject.
 		const model = makeBedrockModel(11_500, 8_192, true);
 		const context: Context = {
 			messages: [{ role: "user", content: "x".repeat(24_000), timestamp: Date.now() }],
@@ -500,8 +518,32 @@ describe("bedrock output-budget clamp integration", () => {
 		const payload = await captureBedrockPayload(model, context, { maxTokens: 8192, reasoning: "medium" });
 		expect(payload.inferenceConfig).toMatchObject({ maxTokens: 1500 });
 		expect(payload.additionalModelRequestFields).toMatchObject({
-			thinking: { type: "enabled", budget_tokens: 476 },
+			thinking: { type: "enabled", budget_tokens: 1024 },
 		});
+	});
+
+	it("errors when mandatory thinking cannot fit even Bedrock's reasoning minimum", async () => {
+		// contextWindow=11024, prompt≈6000 → clamp = max(1, 11024-6000-4000) = 1024.
+		// reconcile: clampedBudget = 1024 - 1024 = 0; mandatory, and maxTokens (1024)
+		// is not greater than the 1024-token minimum, so no valid split fits. The
+		// reconcile throw surfaces as a stream error; a non-aborted signal keeps it
+		// from being reclassified as an abort.
+		const model = makeBedrockModel(11_024, 8_192, true);
+		const context: Context = {
+			messages: [{ role: "user", content: "x".repeat(24_000), timestamp: Date.now() }],
+		};
+		const stream = streamBedrock(model, context, {
+			apiKey: "test-key",
+			signal: new AbortController().signal,
+			maxTokens: 8192,
+			reasoning: Effort.Medium,
+		});
+		for await (const _ of stream) {
+			// drain
+		}
+		const result = await stream.result();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Bedrock mandatory thinking requires maxTokens");
 	});
 
 	it("excludes unsent tools from the prompt estimate (toolChoice none, no tool history)", async () => {


### PR DESCRIPTION
## Summary
Primary Anthropic and Bedrock requests now reduce declared output allowances when the prompt has already consumed most of the context window. Near-full prompts no longer fail only because the top-level output budget pushes the combined request past the model limit.

## Design
- The shared estimator counts text, images, thinking, redacted thinking, tool calls, tool results, system prompts, and tool schemas.
- Anthropic clamps the primary request, preserves its thinking/output buffer, and decides whether sampling parameters are valid from the final thinking state.
- Bedrock reuses its existing 1024-token output reserve and removes the interleaved-thinking beta whenever optional thinking is dropped.
- Sparse server-side fallback entries remain unchanged. Effective inherited fallback configuration needs a separate state model and is outside this PR.

## Validation
- 35 focused request-build and Bedrock tests pass, including mandatory thinking, optional-thinking cleanup, sampling restoration, and redacted-thinking history.
- The full `packages/ai` suite passes: 3,467 passed, 337 skipped, 0 failed across 328 files.
- `packages/ai` typecheck passes.
