### PR TITLE
feat(coding-agent): enforce aggregate image-byte budget on provider view

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Outgoing provider requests now enforce a 24 MiB aggregate decoded-image-byte budget on top of the provider image count cap: the newest image is always retained, older images collapse into a transport placeholder. Applies only to the transient provider view; session history is never rewritten.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/provider-image-budget.ts
+++ b/packages/coding-agent/src/session/provider-image-budget.ts
@@ -14,69 +14,174 @@ const TOOL_RESULT_IMAGE_OMISSION: TextContent = {
 	text: "[image omitted: provider image limit]",
 };
 
-function countImages(context: Context): number {
-	let count = 0;
-	for (const message of context.messages) {
-		if (!Array.isArray(message.content)) continue;
-		for (const part of message.content) {
-			if (part.type === "image") count++;
-		}
-	}
-	return count;
+const TRANSPORT_IMAGE_BUDGET_BYTES = 24 * 1024 * 1024;
+
+const TRANSPORT_IMAGE_OMISSION: TextContent = {
+	type: "text",
+	text: "[image omitted: transport image budget]",
+};
+
+interface ImageSlot {
+	messageIndex: number;
+	partIndex: number;
+	bytes: number;
+	/** Assistant-message images are counted but never rewritten. */
+	droppable: boolean;
 }
 
-function clampContent(
+function slotKey(slot: ImageSlot): string {
+	return `${slot.messageIndex}:${slot.partIndex}`;
+}
+
+/** Per-image elision plan resolved from one shared traversal. */
+interface ImageBudgetPlan {
+	/** Oldest → newest, carrying each image's decoded byte size. */
+	slots: ImageSlot[];
+	/** Original part indices dropped so the count fits the provider cap. */
+	countElided: Set<string>;
+	/** Original part indices elided under the aggregate byte budget. */
+	byteElided: Set<string>;
+}
+
+/**
+ * Single traversal collecting both the total image count and per-image slots
+ * (oldest → newest) carrying their decoded byte size. Shared by the count and
+ * byte clamps so neither re-walks the context.
+ */
+function collectImageStats(context: Context): { count: number; slots: ImageSlot[] } {
+	let count = 0;
+	const slots: ImageSlot[] = [];
+	for (let mi = 0; mi < context.messages.length; mi++) {
+		const message = context.messages[mi];
+		if (!Array.isArray(message.content)) continue;
+		const droppable = message.role !== "assistant";
+		for (let pi = 0; pi < message.content.length; pi++) {
+			const part = message.content[pi];
+			if (part.type === "image") {
+				count++;
+				slots.push({ messageIndex: mi, partIndex: pi, bytes: Math.floor((part.data.length * 3) / 4), droppable });
+			}
+		}
+	}
+	return { count, slots };
+}
+
+/** Resolve the count + byte elision sets from one set of slots. The count clamp
+ *  drops the oldest droppable images until the retained total fits the provider
+ *  cap; assistant images count toward the total but are never rewritten, so
+ *  extra droppable images are dropped to compensate (upstream parity). The byte
+ *  clamp walks the survivors newest → oldest, always retaining the newest;
+ *  assistant bytes still accumulate because they upload regardless. */
+function planImageBudget(slots: ImageSlot[], limit: number): ImageBudgetPlan {
+	const countElided = new Set<string>();
+	const dropCount = Math.max(0, slots.length - limit);
+	let drops = 0;
+	for (const slot of slots) {
+		if (drops >= dropCount) break;
+		if (!slot.droppable) continue;
+		countElided.add(slotKey(slot));
+		drops++;
+	}
+
+	const byteElided = new Set<string>();
+	// Only images that survive the count clamp count toward the byte budget.
+	const survivors = slots.filter(s => !countElided.has(slotKey(s)));
+	let accumulated = 0;
+	// Newest (last) → oldest (first); the newest image is always retained.
+	for (let i = survivors.length - 1; i >= 0; i--) {
+		const slot = survivors[i];
+		accumulated += slot.bytes;
+		if (i === survivors.length - 1) continue;
+		if (accumulated > TRANSPORT_IMAGE_BUDGET_BYTES && slot.droppable) {
+			byteElided.add(slotKey(slot));
+		}
+	}
+
+	return { slots, countElided, byteElided };
+}
+
+type ContentMessage = UserMessage | DeveloperMessage | ToolResultMessage;
+
+/** Rewrite one content array per the elision plan. Count-dropped images are
+ *  removed; byte-dropped images collapse into a single transport placeholder. */
+function clampContentBudget(
 	content: readonly (TextContent | ImageContent)[],
-	state: { remainingDrops: number },
+	entry: { count: Set<number>; byte: Set<number> },
 ): (TextContent | ImageContent)[] | undefined {
 	let changed = false;
 	const clamped: (TextContent | ImageContent)[] = [];
-	for (const part of content) {
-		if (part.type === "image" && state.remainingDrops > 0) {
-			state.remainingDrops--;
-			changed = true;
-			continue;
+	for (let i = 0; i < content.length; i++) {
+		const part = content[i];
+		if (part.type === "image") {
+			if (entry.count.has(i)) {
+				changed = true;
+				continue;
+			}
+			if (entry.byte.has(i)) {
+				changed = true;
+				if (clamped[clamped.length - 1] !== TRANSPORT_IMAGE_OMISSION) {
+					clamped.push(TRANSPORT_IMAGE_OMISSION);
+				}
+				continue;
+			}
 		}
 		clamped.push(part);
 	}
 	return changed ? clamped : undefined;
 }
 
-function clampUserMessage(message: UserMessage, state: { remainingDrops: number }): UserMessage {
-	if (!Array.isArray(message.content) || state.remainingDrops <= 0) return message;
-	const content = clampContent(message.content, state);
+function clampContentMessage(
+	message: ContentMessage,
+	entry: { count: Set<number>; byte: Set<number> },
+): ContentMessage {
+	if (message.role === "toolResult") {
+		// toolResult content is always an array of text/image blocks.
+		const content = clampContentBudget(message.content, entry);
+		if (!content) return message;
+		if (content.length > 0) return { ...message, content };
+		// All blocks dropped by the count clamp — keep the result meaningful.
+		return { ...message, content: [TOOL_RESULT_IMAGE_OMISSION] };
+	}
+	if (!Array.isArray(message.content) || (entry.count.size === 0 && entry.byte.size === 0)) return message;
+	const content = clampContentBudget(message.content, entry);
 	return content ? { ...message, content } : message;
 }
 
-function clampDeveloperMessage(message: DeveloperMessage, state: { remainingDrops: number }): DeveloperMessage {
-	if (!Array.isArray(message.content) || state.remainingDrops <= 0) return message;
-	const content = clampContent(message.content, state);
-	return content ? { ...message, content } : message;
-}
-
-function clampToolResultMessage(message: ToolResultMessage, state: { remainingDrops: number }): ToolResultMessage {
-	if (state.remainingDrops <= 0) return message;
-	const content = clampContent(message.content, state);
-	if (!content) return message;
-	return { ...message, content: content.length > 0 ? content : [TOOL_RESULT_IMAGE_OMISSION] };
-}
-
-/** Drops oldest transient image blocks so outgoing vision requests fit the active provider's image cap. */
+/** Drops oldest transient image blocks so outgoing vision requests fit the
+ *  active provider's image cap, then enforces a 24 MiB aggregate decoded-image-
+ *  byte budget on the remaining images. Both clamps share a single traversal. */
 export function clampProviderContextImages(context: Context, model: Model): Context {
 	if (!model.input.includes("image")) return context;
 	const limit = providerImageBudget(model.provider);
-	const totalImages = countImages(context);
-	if (totalImages <= limit) return context;
+	const { count, slots } = collectImageStats(context);
+	// 0-1 images: the byte budget always retains the newest and has nothing
+	// older to elide, and a single image never reaches a provider count cap (>=1).
+	if (count <= 1) return context;
 
-	const state = { remainingDrops: totalImages - limit };
-	const messages = context.messages.map(message => {
+	const { countElided, byteElided } = planImageBudget(slots, limit);
+	if (countElided.size === 0 && byteElided.size === 0) return context;
+
+	const byMessage = new Map<number, { count: Set<number>; byte: Set<number> }>();
+	const note = (key: string, kind: "count" | "byte") => {
+		const [mi, pi] = key.split(":").map(Number);
+		let entry = byMessage.get(mi);
+		if (!entry) {
+			entry = { count: new Set(), byte: new Set() };
+			byMessage.set(mi, entry);
+		}
+		entry[kind].add(pi);
+	};
+	for (const key of countElided) note(key, "count");
+	for (const key of byteElided) note(key, "byte");
+
+	const messages = context.messages.map((message, mi) => {
+		const entry = byMessage.get(mi);
+		if (!entry) return message;
 		switch (message.role) {
 			case "user":
-				return clampUserMessage(message, state);
 			case "developer":
-				return clampDeveloperMessage(message, state);
 			case "toolResult":
-				return clampToolResultMessage(message, state);
+				return clampContentMessage(message, entry);
 			case "assistant":
 				return message;
 		}

--- a/packages/coding-agent/src/session/provider-image-budget.ts
+++ b/packages/coding-agent/src/session/provider-image-budget.ts
@@ -118,20 +118,36 @@ function replayImageSlots(messageIndex: number, items: Array<Record<string, unkn
  * actually serializes: content-array blocks, native computer screenshots
  * (toolResult metadata, uploaded directly as `computer_call_output`), and native
  * replay `input_image`s (providerPayload.items, uploaded unchanged when the
- * payload's provider matches). Assistant content images are counted toward the
- * image cap but contribute zero bytes — provider serializers never re-upload
- * them — so they cannot force elision of real uploaded images.
+ * payload's provider matches) — on both user/developer turns and same-model
+ * assistant snapshot turns, which the Responses serializer replays verbatim.
+ * Assistant content images are counted toward the image cap but contribute zero
+ * bytes — provider serializers never re-upload them — so they cannot force
+ * elision of real uploaded images. A native computer result carries the same
+ * screenshot in both `content` and `providerMetadata.screenshot`; only the
+ * representation the active serializer uploads is collected, so the screenshot
+ * is never double-budgeted.
  */
-function collectImageStats(context: Context, provider: string): { count: number; slots: ImageSlot[] } {
+function collectImageStats(context: Context, model: Model): { count: number; slots: ImageSlot[] } {
+	const provider = model.provider;
+	const nativeComputerUse = model.supportsComputerUse === true;
 	let count = 0;
 	const slots: ImageSlot[] = [];
 	for (let mi = 0; mi < context.messages.length; mi++) {
 		const message = context.messages[mi];
+		// A native computer result duplicates its screenshot in `content` and in
+		// `providerMetadata.screenshot`. The Responses serializer uploads the
+		// screenshot (as `computer_call_output`) and drops the content image on
+		// computer-capable models; every other serializer uploads the content
+		// image and stringifies the screenshot to text. Budget only the one the
+		// active serializer uploads so a single screenshot is never counted twice.
+		const computerScreenshotSerialized =
+			message.role === "toolResult" && message.providerMetadata?.type === "computer" && nativeComputerUse;
 		if (Array.isArray(message.content)) {
 			const droppable = message.role !== "assistant";
 			for (let pi = 0; pi < message.content.length; pi++) {
 				const part = message.content[pi];
 				if (part.type !== "image") continue;
+				if (computerScreenshotSerialized) continue; // content copy is dropped by the serializer
 				count++;
 				slots.push({
 					messageIndex: mi,
@@ -147,7 +163,12 @@ function collectImageStats(context: Context, provider: string): { count: number;
 		}
 		if (message.role === "toolResult") {
 			const screenshot = message.providerMetadata?.screenshot;
-			if (screenshot && typeof screenshot.image_url === "string" && screenshot.image_url.startsWith("data:")) {
+			if (
+				nativeComputerUse &&
+				screenshot &&
+				typeof screenshot.image_url === "string" &&
+				screenshot.image_url.startsWith("data:")
+			) {
 				count++;
 				slots.push({
 					messageIndex: mi,
@@ -159,8 +180,18 @@ function collectImageStats(context: Context, provider: string): { count: number;
 				});
 			}
 		}
-		if (message.role === "user" || message.role === "developer") {
-			const items = getOpenAIResponsesHistoryItems(message.providerPayload, provider);
+		if (message.role === "user" || message.role === "developer" || message.role === "assistant") {
+			// The Responses serializer only replays a same-model assistant snapshot,
+			// passing the assistant's own provider as the payload fallback; mirror
+			// that gate so foreign-model snapshots (re-encoded, not replayed) are not
+			// collected, while still catching historical input_images a full snapshot
+			// splices back into the request.
+			const items =
+				message.role === "assistant"
+					? message.api === model.api && message.model === model.id
+						? getOpenAIResponsesHistoryItems(message.providerPayload, provider, message.provider)
+						: undefined
+					: getOpenAIResponsesHistoryItems(message.providerPayload, provider);
 			if (items) {
 				const replaySlots = replayImageSlots(mi, items);
 				count += replaySlots.length;
@@ -185,7 +216,14 @@ function planImageBudget(slots: ImageSlot[], limit: number): ImageBudgetPlan {
 	let drops = 0;
 	for (let i = 0; i < slots.length; i++) {
 		if (drops >= dropCount) break;
-		if (!slots[i].droppable) continue;
+		const slot = slots[i];
+		if (!slot.droppable) continue;
+		// Screenshots cannot be cleanly removed without breaking the
+		// computer_call/computer_call_output pairing the Responses grammar
+		// requires, and shrinking one to a placeholder does not reduce the image
+		// count the cap measures. Skip them in the count clamp so droppable
+		// content/replay images absorb the overflow instead.
+		if (slot.kind === "screenshot") continue;
 		countElided.add(i);
 		drops++;
 	}
@@ -196,8 +234,13 @@ function planImageBudget(slots: ImageSlot[], limit: number): ImageBudgetPlan {
 	for (let i = slots.length - 1; i >= 0; i--) {
 		if (countElided.has(i)) continue;
 		const slot = slots[i];
+		// Non-serialized images (assistant content blocks, bytes 0) are never
+		// uploaded, so they neither occupy the byte budget nor claim the
+		// unconditional newest-retention slot — otherwise a trailing assistant
+		// display image would let the real newest uploaded image be elided.
+		if (slot.bytes === 0) continue;
 		if (!seenNewest) {
-			// The newest surviving image is always retained.
+			// The newest surviving uploaded image is always retained.
 			accumulated += slot.bytes;
 			seenNewest = true;
 			continue;
@@ -269,28 +312,84 @@ function applyScreenshotElide(message: ProviderMessage): ProviderMessage {
 	};
 }
 
-/** Rewrite a message's native replay payload, replacing elided `input_image`
- *  data URLs with the elision placeholder without touching any other item fields. */
-function applyReplayElide(message: ProviderMessage, elisions: ReplayElision[]): ProviderMessage {
-	if ((message.role !== "user" && message.role !== "developer") || !message.providerPayload) return message;
+/** Rewrite a message's native replay payload. Count-dropped `input_image`s are
+ *  removed — top-level items dropped, nested parts filtered out — so the
+ *  provider image-count cap is actually enforced rather than merely shrinking
+ *  the image to a placeholder that still counts. Byte-dropped `input_image`s
+ *  collapse to the elision placeholder, keeping the surrounding item
+ *  structurally valid. Every matching elision is applied: one `message` item can
+ *  carry several nested `input_image` parts, all of which may be selected. */
+function applyReplayElide(
+	message: ProviderMessage,
+	countElisions: ReplayElision[],
+	byteElisions: ReplayElision[],
+): ProviderMessage {
+	if (
+		(message.role !== "user" && message.role !== "developer" && message.role !== "assistant") ||
+		!message.providerPayload
+	) {
+		return message;
+	}
 	const payload = message.providerPayload;
-	let changed = false;
-	const items = payload.items.map((item, ii) => {
-		const elision = elisions.find(e => e.itemIndex === ii);
-		if (!elision) return item;
-		if (elision.nestedIndex < 0) {
-			changed = true;
-			return { ...item, image_url: ELIDED_IMAGE_DATA_URL };
+	const removedTopLevel = new Set<number>();
+	const removedNested = new Map<number, Set<number>>();
+	const shrunkTopLevel = new Set<number>();
+	const shrunkNested = new Map<number, Set<number>>();
+	const index = (table: Map<number, Set<number>>, itemIndex: number, nestedIndex: number): void => {
+		let set = table.get(itemIndex);
+		if (!set) {
+			set = new Set();
+			table.set(itemIndex, set);
 		}
-		if (item.type !== "message" || !Array.isArray(item.content)) return item;
-		const content = item.content as Array<Record<string, unknown>>;
-		const part = content[elision.nestedIndex];
-		if (!part) return item;
-		changed = true;
-		const nextContent = content.slice();
-		nextContent[elision.nestedIndex] = { ...part, image_url: ELIDED_IMAGE_DATA_URL };
-		return { ...item, content: nextContent };
-	});
+		set.add(nestedIndex);
+	};
+	for (const e of countElisions) {
+		if (e.nestedIndex < 0) removedTopLevel.add(e.itemIndex);
+		else index(removedNested, e.itemIndex, e.nestedIndex);
+	}
+	for (const e of byteElisions) {
+		if (e.nestedIndex < 0) shrunkTopLevel.add(e.itemIndex);
+		else index(shrunkNested, e.itemIndex, e.nestedIndex);
+	}
+
+	let changed = false;
+	const items = payload.items
+		.map((item, ii): Record<string, unknown> | undefined => {
+			if (removedTopLevel.has(ii)) {
+				changed = true;
+				return undefined; // whole input_image item dropped (count cap)
+			}
+			const removedParts = removedNested.get(ii);
+			const shrunkParts = shrunkNested.get(ii);
+			if (shrunkTopLevel.has(ii)) {
+				changed = true;
+				return { ...item, image_url: ELIDED_IMAGE_DATA_URL };
+			}
+			if (!removedParts && !shrunkParts) return item;
+			if (item.type !== "message" || !Array.isArray(item.content)) return item;
+			const content = item.content as Array<Record<string, unknown>>;
+			let rewrote = false;
+			const nextContent: Array<Record<string, unknown>> = [];
+			for (let ci = 0; ci < content.length; ci++) {
+				const part = content[ci];
+				if (removedParts?.has(ci)) {
+					rewrote = true; // nested input_image filtered out (count cap)
+					continue;
+				}
+				if (shrunkParts?.has(ci)) {
+					rewrote = true;
+					nextContent.push({ ...part, image_url: ELIDED_IMAGE_DATA_URL });
+					continue;
+				}
+				nextContent.push(part);
+			}
+			if (!rewrote) return item;
+			changed = true;
+			// A message item emptied of every image by the count clamp carries no
+			// content; drop it rather than emit an empty message item.
+			return nextContent.length > 0 ? { ...item, content: nextContent } : undefined;
+		})
+		.filter((item): item is Record<string, unknown> => item !== undefined);
 	return changed ? { ...message, providerPayload: { ...payload, items } } : message;
 }
 
@@ -303,7 +402,7 @@ function applyReplayElide(message: ProviderMessage, elisions: ReplayElision[]): 
 export function clampProviderContextImages(context: Context, model: Model): Context {
 	if (!model.input.includes("image")) return context;
 	const limit = providerImageBudget(model.provider);
-	const { count, slots } = collectImageStats(context, model.provider);
+	const { count, slots } = collectImageStats(context, model);
 	// 0-1 images: the byte budget always retains the newest and has nothing
 	// older to elide, and a single image never reaches a provider count cap (>=1).
 	if (count <= 1) return context;
@@ -329,7 +428,8 @@ export function clampProviderContextImages(context: Context, model: Model): Cont
 		const contentCount = new Set<number>();
 		const contentByte = new Set<number>();
 		let screenshotElided = false;
-		const replayElided: ReplayElision[] = [];
+		const replayCount: ReplayElision[] = [];
+		const replayByte: ReplayElision[] = [];
 		for (const index of indices) {
 			const slot = slots[index];
 			switch (slot.kind) {
@@ -341,14 +441,17 @@ export function clampProviderContextImages(context: Context, model: Model): Cont
 					screenshotElided = true;
 					break;
 				case "replay":
-					replayElided.push({ itemIndex: slot.partIndex, nestedIndex: slot.nestedIndex });
+					(countElided.has(index) ? replayCount : replayByte).push({
+						itemIndex: slot.partIndex,
+						nestedIndex: slot.nestedIndex,
+					});
 					break;
 			}
 		}
 		let next: ProviderMessage = message;
 		if (contentCount.size > 0 || contentByte.size > 0) next = applyContentClamp(next, contentCount, contentByte);
 		if (screenshotElided) next = applyScreenshotElide(next);
-		if (replayElided.length > 0) next = applyReplayElide(next, replayElided);
+		if (replayCount.length > 0 || replayByte.length > 0) next = applyReplayElide(next, replayCount, replayByte);
 		return next;
 	});
 	return { ...context, messages };

--- a/packages/coding-agent/src/session/provider-image-budget.ts
+++ b/packages/coding-agent/src/session/provider-image-budget.ts
@@ -1,65 +1,170 @@
-import type {
-	Context,
-	DeveloperMessage,
-	ImageContent,
-	Model,
-	TextContent,
-	ToolResultMessage,
-	UserMessage,
-} from "@oh-my-pi/pi-ai";
-import { providerImageBudget } from "@oh-my-pi/snapcompact";
+import type { Context, ImageContent, Model, TextContent } from "@oh-my-pi/pi-ai";
+import { getOpenAIResponsesHistoryItems } from "@oh-my-pi/pi-ai/utils";
+import { PROVIDER_IMAGE_BYTES_BUDGET, providerImageBudget } from "@oh-my-pi/snapcompact";
 
 const TOOL_RESULT_IMAGE_OMISSION: TextContent = {
 	type: "text",
 	text: "[image omitted: provider image limit]",
 };
 
-const TRANSPORT_IMAGE_BUDGET_BYTES = 24 * 1024 * 1024;
-
 const TRANSPORT_IMAGE_OMISSION: TextContent = {
 	type: "text",
 	text: "[image omitted: transport image budget]",
 };
 
+/**
+ * Minimal 1×1 transparent PNG standing in for a native image (computer
+ * screenshot or replay `input_image`) shed under the transport byte budget.
+ * Those slots are opaque metadata/payload fields that cannot carry a text
+ * placeholder, so they collapse to this tiny data URL instead — keeping the
+ * surrounding `computer_call_output` / replay item structurally valid while
+ * shedding the elided image's bytes.
+ */
+const ELIDED_IMAGE_DATA_URL =
+	"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+
+type ProviderMessage = Context["messages"][number];
+
+type ImageSlotKind = "content" | "screenshot" | "replay";
+
 interface ImageSlot {
 	messageIndex: number;
+	kind: ImageSlotKind;
+	/** content: index into message.content; screenshot: 0 (one per message); replay: index into providerPayload.items. */
 	partIndex: number;
+	/** replay only: index into a `message` item's nested content array, or -1 for a top-level `input_image` item. */
+	nestedIndex: number;
 	bytes: number;
-	/** Assistant-message images are counted but never rewritten. */
+	/** Assistant content images are counted toward the cap but never rewritten. */
 	droppable: boolean;
-}
-
-function slotKey(slot: ImageSlot): string {
-	return `${slot.messageIndex}:${slot.partIndex}`;
 }
 
 /** Per-image elision plan resolved from one shared traversal. */
 interface ImageBudgetPlan {
 	/** Oldest → newest, carrying each image's decoded byte size. */
 	slots: ImageSlot[];
-	/** Original part indices dropped so the count fits the provider cap. */
-	countElided: Set<string>;
-	/** Original part indices elided under the aggregate byte budget. */
-	byteElided: Set<string>;
+	/** Indices into {@link ImageBudgetPlan.slots} dropped so the count fits the provider cap. */
+	countElided: Set<number>;
+	/** Indices into {@link ImageBudgetPlan.slots} elided under the aggregate byte budget. */
+	byteElided: Set<number>;
+}
+
+interface ReplayElision {
+	itemIndex: number;
+	nestedIndex: number;
+}
+
+/** Decoded byte size of a base64 string, subtracting `=` padding so the budget
+ *  measures decoded bytes rather than approximating from the encoded length
+ *  (canonical padded base64 overstates the decoded size by one byte per `=`). */
+function decodedBase64Bytes(base64: string): number {
+	const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+	return Math.floor((base64.length * 3) / 4) - padding;
+}
+
+/** Decoded byte size of an image reference: a `data:<mime>;base64,<payload>` URL
+ *  (native screenshot / replay `input_image`) or a raw base64 string (ImageContent.data). */
+function imageDataBytes(value: string): number {
+	const comma = value.indexOf(",");
+	return decodedBase64Bytes(value.startsWith("data:") && comma >= 0 ? value.slice(comma + 1) : value);
+}
+
+function isDataUrlInputImage(
+	record: Record<string, unknown>,
+): record is Record<string, unknown> & { image_url: string } {
+	return record.type === "input_image" && typeof record.image_url === "string" && record.image_url.startsWith("data:");
+}
+
+/** Replay `input_image` slots carried by a message's native history payload. */
+function replayImageSlots(messageIndex: number, items: Array<Record<string, unknown>>): ImageSlot[] {
+	const slots: ImageSlot[] = [];
+	for (let ii = 0; ii < items.length; ii++) {
+		const item = items[ii];
+		if (isDataUrlInputImage(item)) {
+			slots.push({
+				messageIndex,
+				kind: "replay",
+				partIndex: ii,
+				nestedIndex: -1,
+				bytes: imageDataBytes(item.image_url),
+				droppable: true,
+			});
+			continue;
+		}
+		if (item.type === "message" && Array.isArray(item.content)) {
+			const content = item.content as Array<Record<string, unknown>>;
+			for (let ci = 0; ci < content.length; ci++) {
+				const part = content[ci];
+				if (part && isDataUrlInputImage(part)) {
+					slots.push({
+						messageIndex,
+						kind: "replay",
+						partIndex: ii,
+						nestedIndex: ci,
+						bytes: imageDataBytes(part.image_url),
+						droppable: true,
+					});
+				}
+			}
+		}
+	}
+	return slots;
 }
 
 /**
  * Single traversal collecting both the total image count and per-image slots
  * (oldest → newest) carrying their decoded byte size. Shared by the count and
- * byte clamps so neither re-walks the context.
+ * byte clamps so neither re-walks the context. Covers every image a provider
+ * actually serializes: content-array blocks, native computer screenshots
+ * (toolResult metadata, uploaded directly as `computer_call_output`), and native
+ * replay `input_image`s (providerPayload.items, uploaded unchanged when the
+ * payload's provider matches). Assistant content images are counted toward the
+ * image cap but contribute zero bytes — provider serializers never re-upload
+ * them — so they cannot force elision of real uploaded images.
  */
-function collectImageStats(context: Context): { count: number; slots: ImageSlot[] } {
+function collectImageStats(context: Context, provider: string): { count: number; slots: ImageSlot[] } {
 	let count = 0;
 	const slots: ImageSlot[] = [];
 	for (let mi = 0; mi < context.messages.length; mi++) {
 		const message = context.messages[mi];
-		if (!Array.isArray(message.content)) continue;
-		const droppable = message.role !== "assistant";
-		for (let pi = 0; pi < message.content.length; pi++) {
-			const part = message.content[pi];
-			if (part.type === "image") {
+		if (Array.isArray(message.content)) {
+			const droppable = message.role !== "assistant";
+			for (let pi = 0; pi < message.content.length; pi++) {
+				const part = message.content[pi];
+				if (part.type !== "image") continue;
 				count++;
-				slots.push({ messageIndex: mi, partIndex: pi, bytes: Math.floor((part.data.length * 3) / 4), droppable });
+				slots.push({
+					messageIndex: mi,
+					kind: "content",
+					partIndex: pi,
+					nestedIndex: -1,
+					// Assistant image blocks are never re-serialized, so their bytes
+					// do not count toward the transport budget (only the image cap).
+					bytes: droppable ? imageDataBytes(part.data) : 0,
+					droppable,
+				});
+			}
+		}
+		if (message.role === "toolResult") {
+			const screenshot = message.providerMetadata?.screenshot;
+			if (screenshot && typeof screenshot.image_url === "string" && screenshot.image_url.startsWith("data:")) {
+				count++;
+				slots.push({
+					messageIndex: mi,
+					kind: "screenshot",
+					partIndex: 0,
+					nestedIndex: -1,
+					bytes: imageDataBytes(screenshot.image_url),
+					droppable: true,
+				});
+			}
+		}
+		if (message.role === "user" || message.role === "developer") {
+			const items = getOpenAIResponsesHistoryItems(message.providerPayload, provider);
+			if (items) {
+				const replaySlots = replayImageSlots(mi, items);
+				count += replaySlots.length;
+				slots.push(...replaySlots);
 			}
 		}
 	}
@@ -70,37 +175,42 @@ function collectImageStats(context: Context): { count: number; slots: ImageSlot[
  *  drops the oldest droppable images until the retained total fits the provider
  *  cap; assistant images count toward the total but are never rewritten, so
  *  extra droppable images are dropped to compensate (upstream parity). The byte
- *  clamp walks the survivors newest → oldest, always retaining the newest;
- *  assistant bytes still accumulate because they upload regardless. */
+ *  clamp walks the survivors newest → oldest, always retaining the newest; each
+ *  older droppable image is elided — and its bytes skipped — once retaining it
+ *  would cross the budget, so dropping one large image can let smaller older
+ *  images fit again rather than cascading elision past them. */
 function planImageBudget(slots: ImageSlot[], limit: number): ImageBudgetPlan {
-	const countElided = new Set<string>();
+	const countElided = new Set<number>();
 	const dropCount = Math.max(0, slots.length - limit);
 	let drops = 0;
-	for (const slot of slots) {
+	for (let i = 0; i < slots.length; i++) {
 		if (drops >= dropCount) break;
-		if (!slot.droppable) continue;
-		countElided.add(slotKey(slot));
+		if (!slots[i].droppable) continue;
+		countElided.add(i);
 		drops++;
 	}
 
-	const byteElided = new Set<string>();
-	// Only images that survive the count clamp count toward the byte budget.
-	const survivors = slots.filter(s => !countElided.has(slotKey(s)));
+	const byteElided = new Set<number>();
 	let accumulated = 0;
-	// Newest (last) → oldest (first); the newest image is always retained.
-	for (let i = survivors.length - 1; i >= 0; i--) {
-		const slot = survivors[i];
-		accumulated += slot.bytes;
-		if (i === survivors.length - 1) continue;
-		if (accumulated > TRANSPORT_IMAGE_BUDGET_BYTES && slot.droppable) {
-			byteElided.add(slotKey(slot));
+	let seenNewest = false;
+	for (let i = slots.length - 1; i >= 0; i--) {
+		if (countElided.has(i)) continue;
+		const slot = slots[i];
+		if (!seenNewest) {
+			// The newest surviving image is always retained.
+			accumulated += slot.bytes;
+			seenNewest = true;
+			continue;
 		}
+		if (slot.droppable && accumulated + slot.bytes > PROVIDER_IMAGE_BYTES_BUDGET) {
+			byteElided.add(i);
+			continue; // Elided bytes are not accumulated.
+		}
+		accumulated += slot.bytes;
 	}
 
 	return { slots, countElided, byteElided };
 }
-
-type ContentMessage = UserMessage | DeveloperMessage | ToolResultMessage;
 
 /** Rewrite one content array per the elision plan. Count-dropped images are
  *  removed; byte-dropped images collapse into a single transport placeholder. */
@@ -130,30 +240,70 @@ function clampContentBudget(
 	return changed ? clamped : undefined;
 }
 
-function clampContentMessage(
-	message: ContentMessage,
-	entry: { count: Set<number>; byte: Set<number> },
-): ContentMessage {
+/** Apply the content-array elision plan to a content-bearing message. */
+function applyContentClamp(message: ProviderMessage, count: Set<number>, byte: Set<number>): ProviderMessage {
 	if (message.role === "toolResult") {
-		// toolResult content is always an array of text/image blocks.
-		const content = clampContentBudget(message.content, entry);
+		if (count.size === 0 && byte.size === 0) return message;
+		const content = clampContentBudget(message.content, { count, byte });
 		if (!content) return message;
-		if (content.length > 0) return { ...message, content };
 		// All blocks dropped by the count clamp — keep the result meaningful.
-		return { ...message, content: [TOOL_RESULT_IMAGE_OMISSION] };
+		return { ...message, content: content.length > 0 ? content : [TOOL_RESULT_IMAGE_OMISSION] };
 	}
-	if (!Array.isArray(message.content) || (entry.count.size === 0 && entry.byte.size === 0)) return message;
-	const content = clampContentBudget(message.content, entry);
-	return content ? { ...message, content } : message;
+	if (message.role === "user" || message.role === "developer") {
+		if (!Array.isArray(message.content) || (count.size === 0 && byte.size === 0)) return message;
+		const content = clampContentBudget(message.content, { count, byte });
+		return content ? { ...message, content } : message;
+	}
+	return message;
+}
+
+/** Replace a native computer screenshot with the elision placeholder. */
+function applyScreenshotElide(message: ProviderMessage): ProviderMessage {
+	if (message.role !== "toolResult" || message.providerMetadata?.type !== "computer") return message;
+	return {
+		...message,
+		providerMetadata: {
+			...message.providerMetadata,
+			screenshot: { type: "computer_screenshot", image_url: ELIDED_IMAGE_DATA_URL },
+		},
+	};
+}
+
+/** Rewrite a message's native replay payload, replacing elided `input_image`
+ *  data URLs with the elision placeholder without touching any other item fields. */
+function applyReplayElide(message: ProviderMessage, elisions: ReplayElision[]): ProviderMessage {
+	if ((message.role !== "user" && message.role !== "developer") || !message.providerPayload) return message;
+	const payload = message.providerPayload;
+	let changed = false;
+	const items = payload.items.map((item, ii) => {
+		const elision = elisions.find(e => e.itemIndex === ii);
+		if (!elision) return item;
+		if (elision.nestedIndex < 0) {
+			changed = true;
+			return { ...item, image_url: ELIDED_IMAGE_DATA_URL };
+		}
+		if (item.type !== "message" || !Array.isArray(item.content)) return item;
+		const content = item.content as Array<Record<string, unknown>>;
+		const part = content[elision.nestedIndex];
+		if (!part) return item;
+		changed = true;
+		const nextContent = content.slice();
+		nextContent[elision.nestedIndex] = { ...part, image_url: ELIDED_IMAGE_DATA_URL };
+		return { ...item, content: nextContent };
+	});
+	return changed ? { ...message, providerPayload: { ...payload, items } } : message;
 }
 
 /** Drops oldest transient image blocks so outgoing vision requests fit the
- *  active provider's image cap, then enforces a 24 MiB aggregate decoded-image-
- *  byte budget on the remaining images. Both clamps share a single traversal. */
+ *  active provider's image cap, then enforces an aggregate decoded-image-byte
+ *  budget on the remaining images. Both clamps share a single traversal that
+ *  accounts for every image a provider serializes: content-array blocks, native
+ *  computer screenshots, and native replay `input_image`s. The session history
+ *  is untouched — only the throwaway provider view is rewritten. */
 export function clampProviderContextImages(context: Context, model: Model): Context {
 	if (!model.input.includes("image")) return context;
 	const limit = providerImageBudget(model.provider);
-	const { count, slots } = collectImageStats(context);
+	const { count, slots } = collectImageStats(context, model.provider);
 	// 0-1 images: the byte budget always retains the newest and has nothing
 	// older to elide, and a single image never reaches a provider count cap (>=1).
 	if (count <= 1) return context;
@@ -161,31 +311,45 @@ export function clampProviderContextImages(context: Context, model: Model): Cont
 	const { countElided, byteElided } = planImageBudget(slots, limit);
 	if (countElided.size === 0 && byteElided.size === 0) return context;
 
-	const byMessage = new Map<number, { count: Set<number>; byte: Set<number> }>();
-	const note = (key: string, kind: "count" | "byte") => {
-		const [mi, pi] = key.split(":").map(Number);
-		let entry = byMessage.get(mi);
-		if (!entry) {
-			entry = { count: new Set(), byte: new Set() };
-			byMessage.set(mi, entry);
-		}
-		entry[kind].add(pi);
+	// Group elided slot indices by message, then partition by kind so each
+	// rewrite targets the exact field the provider serializes for that image.
+	const elidedByMessage = new Map<number, number[]>();
+	const addElided = (index: number) => {
+		const mi = slots[index].messageIndex;
+		const list = elidedByMessage.get(mi);
+		if (list) list.push(index);
+		else elidedByMessage.set(mi, [index]);
 	};
-	for (const key of countElided) note(key, "count");
-	for (const key of byteElided) note(key, "byte");
+	for (const index of countElided) addElided(index);
+	for (const index of byteElided) addElided(index);
 
 	const messages = context.messages.map((message, mi) => {
-		const entry = byMessage.get(mi);
-		if (!entry) return message;
-		switch (message.role) {
-			case "user":
-			case "developer":
-			case "toolResult":
-				return clampContentMessage(message, entry);
-			case "assistant":
-				return message;
+		const indices = elidedByMessage.get(mi);
+		if (!indices) return message;
+		const contentCount = new Set<number>();
+		const contentByte = new Set<number>();
+		let screenshotElided = false;
+		const replayElided: ReplayElision[] = [];
+		for (const index of indices) {
+			const slot = slots[index];
+			switch (slot.kind) {
+				case "content":
+					if (countElided.has(index)) contentCount.add(slot.partIndex);
+					else contentByte.add(slot.partIndex);
+					break;
+				case "screenshot":
+					screenshotElided = true;
+					break;
+				case "replay":
+					replayElided.push({ itemIndex: slot.partIndex, nestedIndex: slot.nestedIndex });
+					break;
+			}
 		}
-		return message;
+		let next: ProviderMessage = message;
+		if (contentCount.size > 0 || contentByte.size > 0) next = applyContentClamp(next, contentCount, contentByte);
+		if (screenshotElided) next = applyScreenshotElide(next);
+		if (replayElided.length > 0) next = applyReplayElide(next, replayElided);
+		return next;
 	});
 	return { ...context, messages };
 }

--- a/packages/coding-agent/src/session/provider-image-budget.ts
+++ b/packages/coding-agent/src/session/provider-image-budget.ts
@@ -69,10 +69,18 @@ function imageDataBytes(value: string): number {
 	return decodedBase64Bytes(value.startsWith("data:") && comma >= 0 ? value.slice(comma + 1) : value);
 }
 
-function isDataUrlInputImage(
-	record: Record<string, unknown>,
-): record is Record<string, unknown> & { image_url: string } {
-	return record.type === "input_image" && typeof record.image_url === "string" && record.image_url.startsWith("data:");
+function isInputImage(record: Record<string, unknown>): record is Record<string, unknown> & { type: "input_image" } {
+	return record.type === "input_image";
+}
+
+/** Decoded byte size of an `input_image` reference: embedded `data:` URLs occupy
+ *  the transport budget; remote/file references (`https://…`, `file_id`) resolve
+ *  provider-side and carry no payload bytes, so they count toward the image cap
+ *  but never the byte budget. */
+function inputImageBytes(record: Record<string, unknown>): number {
+	return typeof record.image_url === "string" && record.image_url.startsWith("data:")
+		? imageDataBytes(record.image_url)
+		: 0;
 }
 
 /** Replay `input_image` slots carried by a message's native history payload. */
@@ -80,13 +88,13 @@ function replayImageSlots(messageIndex: number, items: Array<Record<string, unkn
 	const slots: ImageSlot[] = [];
 	for (let ii = 0; ii < items.length; ii++) {
 		const item = items[ii];
-		if (isDataUrlInputImage(item)) {
+		if (isInputImage(item)) {
 			slots.push({
 				messageIndex,
 				kind: "replay",
 				partIndex: ii,
 				nestedIndex: -1,
-				bytes: imageDataBytes(item.image_url),
+				bytes: inputImageBytes(item),
 				droppable: true,
 			});
 			continue;
@@ -95,13 +103,13 @@ function replayImageSlots(messageIndex: number, items: Array<Record<string, unkn
 			const content = item.content as Array<Record<string, unknown>>;
 			for (let ci = 0; ci < content.length; ci++) {
 				const part = content[ci];
-				if (part && isDataUrlInputImage(part)) {
+				if (part && isInputImage(part)) {
 					slots.push({
 						messageIndex,
 						kind: "replay",
 						partIndex: ii,
 						nestedIndex: ci,
-						bytes: imageDataBytes(part.image_url),
+						bytes: inputImageBytes(part),
 						droppable: true,
 					});
 				}
@@ -129,6 +137,12 @@ function replayImageSlots(messageIndex: number, items: Array<Record<string, unkn
  */
 function collectImageStats(context: Context, model: Model): { count: number; slots: ImageSlot[] } {
 	const provider = model.provider;
+	// Only these serializers replay openaiResponsesHistory payloads; a matching
+	// provider alone is insufficient after an in-session API switch.
+	const replaysNativeResponsesHistory =
+		model.api === "openai-responses" ||
+		model.api === "openai-codex-responses" ||
+		model.api === "azure-openai-responses";
 	const nativeComputerUse = model.supportsComputerUse === true;
 	let count = 0;
 	const slots: ImageSlot[] = [];
@@ -191,7 +205,9 @@ function collectImageStats(context: Context, model: Model): { count: number; slo
 					? message.api === model.api && message.model === model.id
 						? getOpenAIResponsesHistoryItems(message.providerPayload, provider, message.provider)
 						: undefined
-					: getOpenAIResponsesHistoryItems(message.providerPayload, provider);
+					: replaysNativeResponsesHistory
+						? getOpenAIResponsesHistoryItems(message.providerPayload, provider)
+						: undefined;
 			if (items) {
 				const replaySlots = replayImageSlots(mi, items);
 				count += replaySlots.length;

--- a/packages/coding-agent/test/session/provider-image-budget.test.ts
+++ b/packages/coding-agent/test/session/provider-image-budget.test.ts
@@ -106,4 +106,285 @@ describe("provider context image budgets", () => {
 
 		expect(clampProviderContextImages(context, UMANS_MODEL)).toBe(context);
 	});
+
+	it("compensates for undroppable assistant images by dropping extra droppable ones", () => {
+		// 1 assistant image (oldest) + 11 user images = 12 total, cap 10.
+		// The assistant image cannot be rewritten, so 2 droppable user images
+		// must be dropped to land the retained total exactly at the cap.
+		const assistantUsage = {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{
+					role: "assistant",
+					content: [image("assistant-image")],
+					timestamp: 0,
+					stopReason: "stop",
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "claude-sonnet-4-5",
+					usage: assistantUsage,
+				},
+				...Array.from({ length: 11 }, (_, index) => ({
+					role: "user" as const,
+					content: [image(`image-${index}`)],
+					timestamp: index + 1,
+				})),
+			],
+		};
+
+		const clamped = clampProviderContextImages(context, UMANS_MODEL);
+
+		// Assistant image retained untouched; the 2 oldest user images dropped.
+		expect(clamped.messages[0]).toBe(context.messages[0]);
+		expect(imageData(clamped)).toEqual([
+			"assistant-image",
+			...Array.from({ length: 9 }, (_, index) => `image-${index + 2}`),
+		]);
+	});
+});
+
+const ANTHROPIC_MODEL = buildModel({
+	id: "claude-sonnet-4-20250514",
+	name: "claude-sonnet-4-20250514",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200000,
+	maxTokens: 16384,
+});
+
+/** Create an ImageContent whose decoded byte size (Math.floor(data.length * 3 / 4)) equals `decodedBytes`. */
+function imageOfDecodedBytes(decodedBytes: number): ImageContent {
+	const len = Math.ceil((decodedBytes * 4) / 3);
+	return { type: "image", data: "A".repeat(len), mimeType: "image/png" };
+}
+
+const MIB = 1024 * 1024;
+
+describe("transport image byte budget", () => {
+	it("retains the newest image even when it alone exceeds the 24 MiB budget", () => {
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [{ role: "user", content: [imageOfDecodedBytes(25 * MIB)], timestamp: 1 }],
+		};
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		expect(result).toBe(context);
+	});
+
+	it("elides oldest images first when aggregate exceeds budget", () => {
+		// 3 images × 10 MiB = 30 MiB > 24 MiB budget. Oldest should be elided.
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{ role: "user", content: [text("msg-0"), imageOfDecodedBytes(10 * MIB)], timestamp: 0 },
+				{ role: "user", content: [text("msg-1"), imageOfDecodedBytes(10 * MIB)], timestamp: 1 },
+				{ role: "user", content: [text("msg-2"), imageOfDecodedBytes(10 * MIB)], timestamp: 2 },
+			],
+		};
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+
+		// Oldest image elided, replaced with placeholder.
+		const first = result.messages[0];
+		expect(first?.role).toBe("user");
+		if (first?.role === "user") {
+			expect(first.content).toEqual([
+				text("msg-0"),
+				{ type: "text", text: "[image omitted: transport image budget]" },
+			]);
+		}
+		// Newer images retained.
+		expect(imageData(result).length).toBe(2);
+		// Text preserved.
+		expect(textData(result)).toContain("msg-0");
+		expect(textData(result)).toContain("msg-1");
+		expect(textData(result)).toContain("msg-2");
+	});
+
+	it("counts assistant image bytes toward the budget but never elides them", () => {
+		// user 5 MiB (oldest) + assistant 10 MiB + user 10 MiB (newest) = 25 MiB > 24 MiB.
+		// Without the assistant bytes the total (15 MiB) would fit; with them the
+		// oldest droppable image must be elided, while the assistant image stays.
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{ role: "user", content: [imageOfDecodedBytes(5 * MIB)], timestamp: 0 },
+				{
+					role: "assistant",
+					content: [imageOfDecodedBytes(10 * MIB)],
+					timestamp: 1,
+					stopReason: "stop",
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "claude-sonnet-4-5",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+				},
+				{ role: "user", content: [imageOfDecodedBytes(10 * MIB)], timestamp: 2 },
+			],
+		};
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+
+		const first = result.messages[0];
+		expect(first?.role).toBe("user");
+		if (first?.role === "user") {
+			expect(first.content).toEqual([{ type: "text", text: "[image omitted: transport image budget]" }]);
+		}
+		// Assistant message untouched; newest user image retained.
+		expect(result.messages[1]).toBe(context.messages[1]);
+		expect(imageData(result).length).toBe(2);
+	});
+
+	it("composes count cap and byte cap", () => {
+		// UMANS_MODEL has count cap 10. 12 images × 4 MiB = 48 MiB.
+		// Count clamp drops 2 oldest → 10 remain (40 MiB).
+		// Byte budget: newest to oldest accumulates 4,8,12,16,20,24,28>24 → elides 4 more.
+		// Final: 6 images remain.
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: Array.from({ length: 12 }, (_, i) => ({
+				role: "user" as const,
+				content: [text(`t-${i}`), imageOfDecodedBytes(4 * MIB)],
+				timestamp: i,
+			})),
+		};
+
+		const result = clampProviderContextImages(context, UMANS_MODEL);
+		expect(imageData(result).length).toBe(6);
+		// All text preserved.
+		expect(textData(result).filter(t => t.startsWith("t-")).length).toBe(12);
+	});
+
+	it("collapses consecutive placeholders within one content array", () => {
+		// 3 × 12 MiB in one message + 1 MiB newest elsewhere. Total = 37 MiB > 24 MiB.
+		// Newest (1 MiB) retained; walking older: acc=1, +12=13, +12=25>24 → elided, +12=37>24 → elided.
+		// Two consecutive images in the same message elided → collapse to one placeholder.
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{
+					role: "user",
+					content: [
+						text("before"),
+						imageOfDecodedBytes(12 * MIB),
+						imageOfDecodedBytes(12 * MIB),
+						imageOfDecodedBytes(12 * MIB),
+						text("after"),
+					],
+					timestamp: 0,
+				},
+				{ role: "user", content: [imageOfDecodedBytes(1 * MIB)], timestamp: 1 },
+			],
+		};
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		const first = result.messages[0];
+		expect(first?.role).toBe("user");
+		if (first?.role === "user") {
+			const parts = first.content as (TextContent | ImageContent)[];
+			const placeholders = parts.filter(
+				p => p.type === "text" && p.text === "[image omitted: transport image budget]",
+			);
+			expect(placeholders.length).toBe(1);
+			const images = parts.filter(p => p.type === "image");
+			expect(images.length).toBe(1);
+		}
+	});
+
+	it("leaves non-image content byte-identical", () => {
+		const context: Context = {
+			systemPrompt: ["system prompt"],
+			tools: [],
+			messages: [
+				{ role: "user", content: [text("hello"), text("world")], timestamp: 0 },
+				{
+					role: "assistant",
+					content: [text("response")],
+					timestamp: 1,
+					stopReason: "stop",
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "claude-sonnet-4-5",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+				},
+			],
+		};
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		expect(result).toBe(context);
+	});
+
+	it("returns the same object graph when under budget", () => {
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{ role: "user", content: [imageOfDecodedBytes(5 * MIB)], timestamp: 0 },
+				{ role: "user", content: [imageOfDecodedBytes(5 * MIB)], timestamp: 1 },
+			],
+		};
+		// 10 MiB total < 24 MiB budget.
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		expect(result).toBe(context);
+	});
+
+	it("replaces elided tool-result images with the transport placeholder", () => {
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{
+					role: "toolResult",
+					toolCallId: "call-0",
+					toolName: "inspect_image",
+					content: [imageOfDecodedBytes(20 * MIB)],
+					isError: false,
+					timestamp: 0,
+				},
+				{ role: "user", content: [imageOfDecodedBytes(10 * MIB)], timestamp: 1 },
+			],
+		};
+		// Total: 30 MiB > 24 MiB. Newest = 10 MiB (retained). Oldest = 20 MiB: acc = 10 + 20 = 30 > 24 → elided.
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		const first = result.messages[0];
+		expect(first?.role).toBe("toolResult");
+		if (first?.role === "toolResult") {
+			expect(first.content).toEqual([{ type: "text", text: "[image omitted: transport image budget]" }]);
+		}
+		expect(imageData(result).length).toBe(1);
+	});
 });

--- a/packages/coding-agent/test/session/provider-image-budget.test.ts
+++ b/packages/coding-agent/test/session/provider-image-budget.test.ts
@@ -171,6 +171,12 @@ function imageOfDecodedBytes(decodedBytes: number): ImageContent {
 	return { type: "image", data: "A".repeat(len), mimeType: "image/png" };
 }
 
+/** Create a `data:<mime>;base64,<payload>` URL whose decoded byte size (accounting for padding) equals `decodedBytes`. */
+function dataUrlOfDecodedBytes(decodedBytes: number): string {
+	const len = Math.ceil((decodedBytes * 4) / 3);
+	return `data:image/png;base64,${"A".repeat(len)}`;
+}
+
 const MIB = 1024 * 1024;
 
 describe("transport image byte budget", () => {
@@ -216,10 +222,12 @@ describe("transport image byte budget", () => {
 		expect(textData(result)).toContain("msg-2");
 	});
 
-	it("counts assistant image bytes toward the budget but never elides them", () => {
-		// user 5 MiB (oldest) + assistant 10 MiB + user 10 MiB (newest) = 25 MiB > 24 MiB.
-		// Without the assistant bytes the total (15 MiB) would fit; with them the
-		// oldest droppable image must be elided, while the assistant image stays.
+	it("excludes assistant image bytes from the transport byte budget", () => {
+		// user 5 MiB (oldest) + assistant 20 MiB + user 10 MiB (newest).
+		// Assistant image blocks are never re-serialized by the provider, so their
+		// bytes must not count: only the 15 MiB of real user images is budgeted,
+		// which fits under 24 MiB and elides nothing. (Counting the assistant
+		// bytes would total 35 MiB and wrongly elide the oldest user image.)
 		const context: Context = {
 			systemPrompt: [],
 			tools: [],
@@ -227,7 +235,7 @@ describe("transport image byte budget", () => {
 				{ role: "user", content: [imageOfDecodedBytes(5 * MIB)], timestamp: 0 },
 				{
 					role: "assistant",
-					content: [imageOfDecodedBytes(10 * MIB)],
+					content: [imageOfDecodedBytes(20 * MIB)],
 					timestamp: 1,
 					stopReason: "stop",
 					api: "anthropic-messages",
@@ -247,15 +255,9 @@ describe("transport image byte budget", () => {
 		};
 
 		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
-
-		const first = result.messages[0];
-		expect(first?.role).toBe("user");
-		if (first?.role === "user") {
-			expect(first.content).toEqual([{ type: "text", text: "[image omitted: transport image budget]" }]);
-		}
-		// Assistant message untouched; newest user image retained.
-		expect(result.messages[1]).toBe(context.messages[1]);
-		expect(imageData(result).length).toBe(2);
+		// Nothing elided: assistant bytes are excluded, so the user images fit.
+		expect(result).toBe(context);
+		expect(imageData(result).length).toBe(3);
 	});
 
 	it("composes count cap and byte cap", () => {
@@ -386,5 +388,128 @@ describe("transport image byte budget", () => {
 			expect(first.content).toEqual([{ type: "text", text: "[image omitted: transport image budget]" }]);
 		}
 		expect(imageData(result).length).toBe(1);
+	});
+	it("elides native computer screenshots under the byte budget", () => {
+		// A computer tool result carries its image in providerMetadata.screenshot,
+		// which the Responses serializer uploads directly as computer_call_output
+		// (content is never consulted). The screenshot must count and be elided.
+		const big = dataUrlOfDecodedBytes(20 * MIB);
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{
+					role: "toolResult",
+					toolCallId: "call-0",
+					toolName: "computer",
+					content: [],
+					isError: false,
+					timestamp: 0,
+					providerMetadata: {
+						type: "computer",
+						screenshot: { type: "computer_screenshot", image_url: big },
+						acknowledgedSafetyChecks: [],
+					},
+				},
+				{ role: "user", content: [imageOfDecodedBytes(10 * MIB)], timestamp: 1 },
+			],
+		};
+		// 20 MiB screenshot + 10 MiB user image = 30 MiB > 24 MiB → screenshot elided.
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		const first = result.messages[0];
+		expect(first?.role).toBe("toolResult");
+		if (first?.role === "toolResult" && first.providerMetadata?.type === "computer") {
+			const screenshot = first.providerMetadata.screenshot;
+			expect(typeof screenshot.image_url === "string" && screenshot.image_url).not.toBe(big);
+			// Collapsed to a tiny placeholder, shedding the original payload bytes.
+			if (typeof screenshot.image_url === "string") {
+				expect(screenshot.image_url.length).toBeLessThan(big.length);
+			}
+		}
+		expect(imageData(result).length).toBe(1);
+	});
+
+	it("accounts for base64 padding in the decoded-byte budget", () => {
+		// Two images whose decoded sizes (padding-aware) sit just under the budget,
+		// but whose base64 carries `==` padding so the old floor(len*3/4) math
+		// over-counted them past it. Both must be retained.
+		const oldest = image(`${"A".repeat(33554430)}==`); // 25165822 decoded bytes (2 padding)
+		const newest = image("AA=="); // 1 decoded byte (2 padding)
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{ role: "user", content: [oldest], timestamp: 0 },
+				{ role: "user", content: [newest], timestamp: 1 },
+			],
+		};
+		// Decoded total 25165823 ≤ 25165824 (24 MiB) once padding is subtracted;
+		// the encoded-length estimate (25165827) would have elided the oldest.
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		expect(result).toBe(context);
+	});
+
+	it("counts and elides native replay payload images", () => {
+		// A user turn can store its image only in providerPayload.items (as a
+		// data-URL input_image) while content stays plain text; the Responses
+		// serializer uploads the payload items unchanged, bypassing content.
+		const big = dataUrlOfDecodedBytes(20 * MIB);
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{
+					role: "user",
+					content: "describe this",
+					timestamp: 0,
+					providerPayload: {
+						type: "openaiResponsesHistory",
+						provider: "anthropic",
+						items: [{ type: "input_image", detail: "auto", image_url: big }],
+					},
+				},
+				{ role: "user", content: [imageOfDecodedBytes(10 * MIB)], timestamp: 1 },
+			],
+		};
+		// 20 MiB replay image + 10 MiB content image = 30 MiB > 24 MiB.
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		const first = result.messages[0];
+		expect(first?.role).toBe("user");
+		if (first?.role === "user" && first.providerPayload) {
+			const item = first.providerPayload.items[0] as { image_url?: string; type?: string; detail?: string };
+			expect(item.image_url).not.toBe(big);
+			expect(item.image_url?.length).toBeLessThan(big.length);
+			// Non-image fields preserved.
+			expect(item).toMatchObject({ type: "input_image", detail: "auto" });
+		}
+		expect(imageData(result).length).toBe(1);
+	});
+
+	it("retains smaller older images once a larger one is elided", () => {
+		// oldest → newest: 3 MiB, 3 MiB, 20 MiB, 5 MiB. Adding the 20 MiB image to
+		// the 5 MiB newest would cross the budget, so it is elided; its bytes are
+		// then skipped and the two 3 MiB images fit. The pre-fix accumulator kept
+		// elided bytes, cascading elision past them (only the newest survived).
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{ role: "user", content: [imageOfDecodedBytes(3 * MIB)], timestamp: 0 },
+				{ role: "user", content: [imageOfDecodedBytes(3 * MIB)], timestamp: 1 },
+				{ role: "user", content: [imageOfDecodedBytes(20 * MIB)], timestamp: 2 },
+				{ role: "user", content: [imageOfDecodedBytes(5 * MIB)], timestamp: 3 },
+			],
+		};
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		// Newest (5 MiB) + both 3 MiB images retained (11 MiB); only 20 MiB elided.
+		expect(imageData(result).length).toBe(3);
+		const elided = result.messages[2];
+		if (elided?.role === "user") {
+			expect(elided.content).toEqual([{ type: "text", text: "[image omitted: transport image budget]" }]);
+		}
 	});
 });

--- a/packages/coding-agent/test/session/provider-image-budget.test.ts
+++ b/packages/coding-agent/test/session/provider-image-budget.test.ts
@@ -165,6 +165,20 @@ const ANTHROPIC_MODEL = buildModel({
 	maxTokens: 16384,
 });
 
+const COMPUTER_MODEL = buildModel({
+	id: "gpt-5.4",
+	name: "gpt-5.4",
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://api.openai.com",
+	reasoning: true,
+	input: ["text", "image"],
+	supportsComputerUse: true,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200000,
+	maxTokens: 16384,
+});
+
 /** Create an ImageContent whose decoded byte size (Math.floor(data.length * 3 / 4)) equals `decodedBytes`. */
 function imageOfDecodedBytes(decodedBytes: number): ImageContent {
 	const len = Math.ceil((decodedBytes * 4) / 3);
@@ -390,9 +404,9 @@ describe("transport image byte budget", () => {
 		expect(imageData(result).length).toBe(1);
 	});
 	it("elides native computer screenshots under the byte budget", () => {
-		// A computer tool result carries its image in providerMetadata.screenshot,
-		// which the Responses serializer uploads directly as computer_call_output
-		// (content is never consulted). The screenshot must count and be elided.
+		// A computer tool result duplicates its screenshot in providerMetadata
+		// (uploaded as computer_call_output) and in content (dropped by the
+		// serializer). On a computer-capable model only the screenshot counts.
 		const big = dataUrlOfDecodedBytes(20 * MIB);
 		const context: Context = {
 			systemPrompt: [],
@@ -402,7 +416,7 @@ describe("transport image byte budget", () => {
 					role: "toolResult",
 					toolCallId: "call-0",
 					toolName: "computer",
-					content: [],
+					content: [imageOfDecodedBytes(20 * MIB)],
 					isError: false,
 					timestamp: 0,
 					providerMetadata: {
@@ -414,9 +428,10 @@ describe("transport image byte budget", () => {
 				{ role: "user", content: [imageOfDecodedBytes(10 * MIB)], timestamp: 1 },
 			],
 		};
-		// 20 MiB screenshot + 10 MiB user image = 30 MiB > 24 MiB → screenshot elided.
+		// One 20 MiB screenshot (not double-counted with the content copy) + 10 MiB
+		// user image = 30 MiB > 24 MiB → screenshot elided, content copy untouched.
 
-		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		const result = clampProviderContextImages(context, COMPUTER_MODEL);
 		const first = result.messages[0];
 		expect(first?.role).toBe("toolResult");
 		if (first?.role === "toolResult" && first.providerMetadata?.type === "computer") {
@@ -427,7 +442,12 @@ describe("transport image byte budget", () => {
 				expect(screenshot.image_url.length).toBeLessThan(big.length);
 			}
 		}
-		expect(imageData(result).length).toBe(1);
+		// The duplicated content copy is not budgeted on a computer-capable model,
+		// so it is left byte-identical (not elided) even though the screenshot was.
+		const toolResultMsg = result.messages[0];
+		if (toolResultMsg?.role === "toolResult") {
+			expect(toolResultMsg.content).toEqual([imageOfDecodedBytes(20 * MIB)]);
+		}
 	});
 
 	it("accounts for base64 padding in the decoded-byte budget", () => {
@@ -511,5 +531,205 @@ describe("transport image byte budget", () => {
 		if (elided?.role === "user") {
 			expect(elided.content).toEqual([{ type: "text", text: "[image omitted: transport image budget]" }]);
 		}
+	});
+	it("does not double-budget a single under-budget computer screenshot", () => {
+		// The same 13 MiB screenshot lives in both content and providerMetadata.
+		// Pre-fix it was counted twice (26 MiB > 24 MiB) and one copy was wrongly
+		// elided; only the representation the serializer uploads is counted, so a
+		// single 13 MiB screenshot + 5 MiB user image (18 MiB) fits untouched.
+		const big = dataUrlOfDecodedBytes(13 * MIB);
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{
+					role: "toolResult",
+					toolCallId: "call-0",
+					toolName: "computer",
+					content: [imageOfDecodedBytes(13 * MIB)],
+					isError: false,
+					timestamp: 0,
+					providerMetadata: {
+						type: "computer",
+						screenshot: { type: "computer_screenshot", image_url: big },
+						acknowledgedSafetyChecks: [],
+					},
+				},
+				{ role: "user", content: [imageOfDecodedBytes(5 * MIB)], timestamp: 1 },
+			],
+		};
+
+		const result = clampProviderContextImages(context, COMPUTER_MODEL);
+		expect(result).toBe(context);
+		if (result.messages[0]?.role === "toolResult" && result.messages[0].providerMetadata?.type === "computer") {
+			expect(result.messages[0].providerMetadata.screenshot.image_url).toBe(big);
+		}
+	});
+
+	it("applies every nested replay-image elision within one item", () => {
+		// One replay `message` item carries two nested input_image data URLs.
+		// Both are over budget relative to a newer image, so both must be elided —
+		// pre-fix only the first matching elision was rewritten.
+		const bigA = dataUrlOfDecodedBytes(20 * MIB);
+		const bigB = dataUrlOfDecodedBytes(20 * MIB);
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{
+					role: "user",
+					content: "describe these",
+					timestamp: 0,
+					providerPayload: {
+						type: "openaiResponsesHistory",
+						provider: "anthropic",
+						items: [
+							{
+								type: "message",
+								role: "user",
+								content: [
+									{ type: "input_image", detail: "auto", image_url: bigA },
+									{ type: "input_text", text: "and" },
+									{ type: "input_image", detail: "auto", image_url: bigB },
+								],
+							},
+						],
+					},
+				},
+				{ role: "user", content: [imageOfDecodedBytes(10 * MIB)], timestamp: 1 },
+			],
+		};
+		// Two 20 MiB replay images + 10 MiB content image. Newest (10 MiB)
+		// retained; each 20 MiB image crosses 24 MiB on its own → both elided.
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		const first = result.messages[0];
+		if (first?.role === "user" && first.providerPayload) {
+			const item = first.providerPayload.items[0] as {
+				content?: Array<{ type: string; image_url?: string; text?: string }>;
+			};
+			const nested = item.content ?? [];
+			const images = nested.filter(p => p.type === "input_image");
+			expect(images.length).toBe(2);
+			for (const part of images) {
+				expect(part.image_url).not.toBe(bigA);
+				expect(part.image_url).not.toBe(bigB);
+				expect(part.image_url?.length).toBeLessThan(bigA.length);
+			}
+			// The non-image part between them is preserved.
+			expect(nested.some(p => p.type === "input_text" && p.text === "and")).toBe(true);
+		}
+	});
+
+	it("removes count-dropped replay images instead of shrinking them", () => {
+		// UMANS cap is 10. 12 top-level replay input_image items exceed it; the 2
+		// oldest must be removed (not shrunk to a placeholder that still counts).
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: Array.from({ length: 12 }, (_, i) => ({
+				role: "user" as const,
+				content: `msg-${i}`,
+				timestamp: i,
+				providerPayload: {
+					type: "openaiResponsesHistory" as const,
+					provider: "umans",
+					items: [{ type: "input_image", detail: "auto", image_url: dataUrlOfDecodedBytes(1 * MIB) }],
+				},
+			})),
+		};
+
+		const result = clampProviderContextImages(context, UMANS_MODEL);
+		// The 2 oldest items are dropped entirely; 10 remain.
+		const first = result.messages[0];
+		if (first?.role === "user" && first.providerPayload) {
+			expect(first.providerPayload.items.length).toBe(0);
+		}
+		const survivor = result.messages[2];
+		if (survivor?.role === "user" && survivor.providerPayload) {
+			expect(survivor.providerPayload.items.length).toBe(1);
+		}
+	});
+
+	it("budgets images carried in a same-model assistant snapshot payload", () => {
+		// The Responses serializer replays same-model assistant providerPayload
+		// items verbatim; an input_image data URL in that snapshot must be counted
+		// and elided, not bypass the budget.
+		const big = dataUrlOfDecodedBytes(20 * MIB);
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{
+					role: "assistant",
+					content: [],
+					timestamp: 0,
+					stopReason: "stop",
+					api: "openai-responses",
+					provider: "openai",
+					model: "gpt-5.4",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					providerPayload: {
+						type: "openaiResponsesHistory",
+						provider: "openai",
+						items: [{ type: "input_image", detail: "auto", image_url: big }],
+					},
+				},
+				{ role: "user", content: [imageOfDecodedBytes(10 * MIB)], timestamp: 1 },
+			],
+		};
+		// 20 MiB assistant-snapshot image + 10 MiB user image = 30 MiB > 24 MiB.
+
+		const result = clampProviderContextImages(context, COMPUTER_MODEL);
+		const assistant = result.messages[0];
+		if (assistant?.role === "assistant" && assistant.providerPayload) {
+			const item = assistant.providerPayload.items[0] as { image_url?: string };
+			expect(item.image_url).not.toBe(big);
+			expect(item.image_url?.length).toBeLessThan(big.length);
+		}
+		expect(imageData(result).length).toBe(1);
+	});
+
+	it("does not let a zero-byte assistant image steal the newest-retention slot", () => {
+		// A 25 MiB user image is the only uploaded image; an assistant display
+		// image follows it. Provider serializers never upload the assistant image,
+		// so it must not claim the unconditional newest-retention slot and force
+		// the real 25 MiB image to be elided.
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{ role: "user", content: [imageOfDecodedBytes(25 * MIB)], timestamp: 0 },
+				{
+					role: "assistant",
+					content: [imageOfDecodedBytes(1 * MIB)],
+					timestamp: 1,
+					stopReason: "stop",
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "claude-sonnet-4-5",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+				},
+			],
+		};
+		// Pre-fix the assistant image set seenNewest, so the 25 MiB user image was
+		// elided even though it is the sole uploaded image and fits the budget.
+
+		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		expect(result).toBe(context);
 	});
 });

--- a/packages/coding-agent/test/session/provider-image-budget.test.ts
+++ b/packages/coding-agent/test/session/provider-image-budget.test.ts
@@ -179,6 +179,32 @@ const COMPUTER_MODEL = buildModel({
 	maxTokens: 16384,
 });
 
+const ANTHROPIC_RESPONSES_MODEL = buildModel({
+	id: "anthropic-responses-test",
+	name: "anthropic-responses-test",
+	api: "openai-responses",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200000,
+	maxTokens: 16384,
+});
+
+const UMANS_RESPONSES_MODEL = buildModel({
+	id: "umans-responses-test",
+	name: "umans-responses-test",
+	api: "openai-responses",
+	provider: "umans",
+	baseUrl: "https://api.code.umans.ai",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128000,
+	maxTokens: 4096,
+});
+
 /** Create an ImageContent whose decoded byte size (Math.floor(data.length * 3 / 4)) equals `decodedBytes`. */
 function imageOfDecodedBytes(decodedBytes: number): ImageContent {
 	const len = Math.ceil((decodedBytes * 4) / 3);
@@ -495,7 +521,7 @@ describe("transport image byte budget", () => {
 		};
 		// 20 MiB replay image + 10 MiB content image = 30 MiB > 24 MiB.
 
-		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		const result = clampProviderContextImages(context, ANTHROPIC_RESPONSES_MODEL);
 		const first = result.messages[0];
 		expect(first?.role).toBe("user");
 		if (first?.role === "user" && first.providerPayload) {
@@ -506,6 +532,79 @@ describe("transport image byte budget", () => {
 			expect(item).toMatchObject({ type: "input_image", detail: "auto" });
 		}
 		expect(imageData(result).length).toBe(1);
+	});
+
+	it("counts remote/file-backed replay input_images toward the cap", () => {
+		// A replay input_image referenced by file_id (no data: bytes) is uploaded
+		// unchanged, so it must count toward the image cap even though it carries no
+		// payload bytes. Pre-fix the data:-only predicate never collected these.
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{
+					role: "user",
+					content: "describe these",
+					timestamp: 0,
+					providerPayload: {
+						type: "openaiResponsesHistory",
+						provider: "umans",
+						items: Array.from({ length: 12 }, (_, i) => ({
+							type: "input_image",
+							file_id: `file-${i}`,
+						})),
+					},
+				},
+			],
+		};
+
+		const result = clampProviderContextImages(context, UMANS_RESPONSES_MODEL);
+		const first = result.messages[0];
+		expect(first?.role).toBe("user");
+		if (first?.role === "user" && first.providerPayload) {
+			const items = first.providerPayload.items as Array<{ file_id?: string; image_url?: string }>;
+			// umans cap is 10: the two oldest file_id images are dropped (count cap),
+			// and the survivors are untouched (file refs carry no payload bytes).
+			expect(items.length).toBe(10);
+			expect(items.map(it => it.file_id)).toEqual(Array.from({ length: 10 }, (_, i) => `file-${i + 2}`));
+			expect(items.every(it => it.image_url === undefined)).toBe(true);
+		}
+	});
+
+	it("ignores stale native replay payloads for chat-completions serializers", () => {
+		const chatModel = buildModel({
+			id: "gpt-5.4-chat",
+			name: "gpt-5.4-chat",
+			api: "openai-completions",
+			provider: "openai",
+			baseUrl: "https://api.openai.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200000,
+			maxTokens: 16384,
+		});
+		const context: Context = {
+			systemPrompt: [],
+			tools: [],
+			messages: [
+				{
+					role: "user",
+					content: "previous Responses request",
+					timestamp: 0,
+					providerPayload: {
+						type: "openaiResponsesHistory",
+						provider: "openai",
+						items: Array.from({ length: 200 }, (_, i) => ({ type: "input_image", file_id: `file-${i}` })),
+					},
+				},
+				{ role: "user", content: [image("actual")], timestamp: 1 },
+			],
+		};
+
+		// The stale payload plus one actual image would exceed OpenAI's 200-image
+		// cap if the chat-completions serializer replayed it; it does not.
+		expect(clampProviderContextImages(context, chatModel)).toBe(context);
 	});
 
 	it("retains smaller older images once a larger one is elided", () => {
@@ -602,7 +701,7 @@ describe("transport image byte budget", () => {
 		// Two 20 MiB replay images + 10 MiB content image. Newest (10 MiB)
 		// retained; each 20 MiB image crosses 24 MiB on its own → both elided.
 
-		const result = clampProviderContextImages(context, ANTHROPIC_MODEL);
+		const result = clampProviderContextImages(context, ANTHROPIC_RESPONSES_MODEL);
 		const first = result.messages[0];
 		if (first?.role === "user" && first.providerPayload) {
 			const item = first.providerPayload.items[0] as {
@@ -639,7 +738,7 @@ describe("transport image byte budget", () => {
 			})),
 		};
 
-		const result = clampProviderContextImages(context, UMANS_MODEL);
+		const result = clampProviderContextImages(context, UMANS_RESPONSES_MODEL);
 		// The 2 oldest items are dropped entirely; 10 remain.
 		const first = result.messages[0];
 		if (first?.role === "user" && first.providerPayload) {

--- a/packages/snapcompact/CHANGELOG.md
+++ b/packages/snapcompact/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the exported `PROVIDER_IMAGE_BYTES_BUDGET` constant (24 MiB aggregate decoded-image byte budget) colocated with the per-provider image-count budgets so every provider-image limit lives in one place; the coding-agent clamps its throwaway provider view to it.
+
 ## [17.1.5] - 2026-07-27
 
 ### Fixed

--- a/packages/snapcompact/src/snapcompact.ts
+++ b/packages/snapcompact/src/snapcompact.ts
@@ -497,6 +497,14 @@ export const DEFAULT_PROVIDER_IMAGE_BUDGET = 5;
 export function providerImageBudget(provider: string | undefined): number {
 	return (provider !== undefined ? PROVIDER_IMAGE_BUDGETS[provider] : undefined) ?? DEFAULT_PROVIDER_IMAGE_BUDGET;
 }
+/**
+ * Aggregate decoded-image byte budget for a single provider request. Above
+ * this, provider backends accept the HTTP body but fail mid-stream with opaque
+ * 5xx errors; the coding-agent clamps its throwaway provider view to it. Kept
+ * beside the per-provider count budgets so every provider-image limit lives in
+ * one place.
+ */
+export const PROVIDER_IMAGE_BYTES_BUDGET = 24 * 1024 * 1024;
 
 /** Key under `CompactionEntry.preserveData` holding the frame archive. */
 export const PRESERVE_KEY = "snapcompact";


### PR DESCRIPTION
## Summary
Provider-bound contexts now have a 24 MiB aggregate decoded-image budget in addition to each provider's image-count cap. Large image histories can no longer grow every turn's upload without bound, while the newest user attachment is always retained.

## Design
- Count and byte limits share one image-slot traversal.
- Older droppable images become one omission placeholder once the retained aggregate crosses the budget.
- Assistant images count toward both limits but are never rewritten; older user or tool-result images compensate.
- Clamping applies only to the provider view, so stored session history, replay, and prompt-cache state remain unchanged.

## Validation
Twelve focused tests cover oversized newest images, oldest-first elision, count/byte composition, placeholder collapse, tool results, identity preservation below budget, and assistant-image compensation.
