### PR TITLE
fix(coding-agent): treat streamed visible text as replay-unsafe in turn recovery

### DIFF
--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -205,8 +205,8 @@ export function is(id: number | undefined, flag: Flag): boolean {
 
 export function retriable(id: number | undefined, opts?: { replayUnsafe?: boolean }): boolean {
 	if (is(id, Flag.ContentBlocked)) return false;
-	if (is(id, Flag.MalformedFunctionCall)) return true;
 	if (opts?.replayUnsafe) return false;
+	if (is(id, Flag.MalformedFunctionCall)) return true;
 	return ((id ?? 0) & RETRIABLE_KINDS) !== 0;
 }
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Turn recovery now classifies a failed turn that already streamed visible (non-whitespace) assistant text as replay-unsafe, so credential rotation and model fallback no longer re-stream duplicated output. Thinking-only and whitespace-only partial turns remain retriable.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2596,6 +2596,11 @@ export class AgentSession {
 				return;
 			}
 
+			// Record quota exhaustion before deciding whether this failed turn may be
+			// replayed. Visible/side-effecting output then remains terminal while its
+			// credential is still blocked or rotated exactly once.
+			await this.#recovery.recordUsageLimitOutcome(msg);
+
 			let compactionResult = COMPACTION_CHECK_NONE;
 			let checkedCompaction = false;
 			if (activeGoal) {

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -832,7 +832,7 @@ export class TurnRecovery {
 		if (AIError.isContextOverflow(message, contextWindow)) return false;
 
 		if (this.isClassifierRefusal(message)) return true;
-		return AIError.retriable(id, { replayUnsafe: this.#hasReplayUnsafeToolOutput(message) });
+		return AIError.retriable(id, { replayUnsafe: this.#hasReplayUnsafeOutput(message) });
 	}
 
 	/**
@@ -900,12 +900,19 @@ export class TurnRecovery {
 	}
 	/**
 	 * Retried turns remove the failed assistant message from active context.
-	 * Text/thinking-only partials are safe to discard and replay. Retained
-	 * tool calls are not: a completed tool call may already have emitted its
-	 * tool result after this assistant message, so replaying can duplicate work.
+	 * Thinking-only partials are safe to discard and replay: reasoning models
+	 * routinely stall after long thinking with no visible output, and duplicated
+	 * thinking display is materially lower harm than duplicated final text.
+	 * Whitespace-only text is likewise safe since nothing meaningful reached the
+	 * user. Completed visible text and retained tool calls are NOT safe: visible
+	 * text already reached the user, so replaying the turn duplicates it; a
+	 * completed tool call may already have emitted its tool result after this
+	 * assistant message, so replaying can duplicate work.
 	 */
-	#hasReplayUnsafeToolOutput(message: AssistantMessage): boolean {
-		return message.content.some(block => block.type === "toolCall");
+	#hasReplayUnsafeOutput(message: AssistantMessage): boolean {
+		return message.content.some(
+			block => block.type === "toolCall" || (block.type === "text" && block.text.trim().length > 0),
+		);
 	}
 
 	/**
@@ -1126,7 +1133,7 @@ export class TurnRecovery {
 		const id = this.#classifyRetryMessage(message);
 		if (AIError.is(id, AIError.Flag.Abort) || AIError.is(id, AIError.Flag.UserInterrupt)) return false;
 		if (AIError.isContextOverflow(message, model.contextWindow ?? 0)) return false;
-		if (this.#hasReplayUnsafeToolOutput(message)) return false;
+		if (this.#hasReplayUnsafeOutput(message)) return false;
 		const currentSelector = formatRetryFallbackSelector(model, this.#host.thinkingLevel());
 		const role = this.#activeRetryFallback?.role ?? this.resolveRetryFallbackRole(currentSelector);
 		if (!role) return false;

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -872,8 +872,13 @@ export class TurnRecovery {
 		const contextWindow = this.#host.model()?.contextWindow ?? 0;
 		if (AIError.isContextOverflow(message, contextWindow)) return false;
 
+		// A classifier refusal/sensitivity stop is the model's decision, not a route
+		// failure, but only after we confirm no user-visible output has already been
+		// streamed. Visible text, images, tool calls, or server tools must not be
+		// discarded and replayed.
+		if (this.#hasReplayUnsafeOutput(message)) return false;
 		if (this.isClassifierRefusal(message)) return true;
-		return AIError.retriable(id, { replayUnsafe: this.#hasReplayUnsafeOutput(message) });
+		return AIError.retriable(id);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1094,14 +1094,14 @@ export class TurnRecovery {
 	 * transient overload/5xx or a hard "router/model not found / unsupported" —
 	 * is worth retrying on the base id. Skips failures the base model shares:
 	 * context overflow (compaction's job), usage limits and auth errors (same
-	 * account/key), and turns that already emitted a tool call (replaying would
-	 * duplicate work). Requires the base model to exist in the registry.
+	 * account/key), and turns that already emitted any replay-unsafe output
+	 * (visible text or a tool call). Requires the base model to exist in the registry.
 	 */
 	isFireworksFastFallbackEligible(message: AssistantMessage): boolean {
 		const model = this.#activeFireworksFastModel();
 		if (!model) return false;
 		if (message.stopReason !== "error") return false;
-		if (message.content.some(block => block.type === "toolCall")) return false;
+		if (this.#hasReplayUnsafeOutput(message)) return false;
 		// A content refusal/sensitivity stop is the model's decision, not a route
 		// failure — switching to the base model would just re-trigger it.
 		if (this.isClassifierRefusal(message)) return false;

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -151,6 +151,12 @@ type PendingRecoveredRetryError = {
 	note: string;
 };
 
+type UsageLimitOutcome = {
+	switchedCredential: boolean;
+	retryAfterMs: number;
+	retryAtMs: number | undefined;
+};
+
 /** Owns terminal-stop recovery, automatic retries, and fallback routing. */
 export class TurnRecovery {
 	readonly #host: TurnRecoveryHost;
@@ -160,6 +166,7 @@ export class TurnRecovery {
 	#retryResolve: (() => void) | undefined;
 	#activeRetryFallback: ActiveRetryFallbackState | undefined;
 	#pendingRecoveredRetryErrors: PendingRecoveredRetryError[] = [];
+	#usageLimitOutcomes = new WeakMap<AssistantMessage, Promise<UsageLimitOutcome>>();
 	#emptyStopRetryCount = 0;
 	#unexpectedStopRetryCount = 0;
 	#acceptTerminalEmptyStopForPrompt = false;
@@ -295,6 +302,40 @@ export class TurnRecovery {
 		},
 	): Promise<boolean> {
 		return this.#handleRetryableError(message, options);
+	}
+
+	/**
+	 * Records a usage-limit failure before replay eligibility decides whether the
+	 * failed turn may be discarded. Returns whether credential recovery switched
+	 * the active account.
+	 */
+	async recordUsageLimitOutcome(message: AssistantMessage): Promise<boolean> {
+		if (message.stopReason !== "error") return false;
+		const id = this.#classifyRetryMessage(message);
+		const activeModel = this.#host.model();
+		if (!activeModel || !AIError.is(id, AIError.Flag.UsageLimit)) return false;
+
+		let recorded = this.#usageLimitOutcomes.get(message);
+		if (!recorded) {
+			const errorMessage = message.errorMessage || "Unknown error";
+			const retryAfterMs =
+				this.#parseRetryAfterMsFromError(errorMessage) ??
+				calculateRateLimitBackoffMs(parseRateLimitReason(errorMessage));
+			recorded = (async (): Promise<UsageLimitOutcome> => {
+				const outcome = await this.#host.modelRegistry.authStorage.markUsageLimitReached(
+					activeModel.provider,
+					this.#host.sessionId(),
+					{ retryAfterMs, baseUrl: activeModel.baseUrl, modelId: activeModel.id },
+				);
+				return {
+					switchedCredential: outcome.switched,
+					retryAfterMs,
+					retryAtMs: outcome.retryAtMs,
+				};
+			})();
+			this.#usageLimitOutcomes.set(message, recorded);
+		}
+		return (await recorded).switchedCredential;
 	}
 
 	/** Prompts after transient overlap with a prior agent run. */
@@ -904,14 +945,17 @@ export class TurnRecovery {
 	 * routinely stall after long thinking with no visible output, and duplicated
 	 * thinking display is materially lower harm than duplicated final text.
 	 * Whitespace-only text is likewise safe since nothing meaningful reached the
-	 * user. Completed visible text and retained tool calls are NOT safe: visible
-	 * text already reached the user, so replaying the turn duplicates it; a
-	 * completed tool call may already have emitted its tool result after this
-	 * assistant message, so replaying can duplicate work.
+	 * user. Visible text, generated images, server tools, and retained tool calls
+	 * are NOT safe: each has already rendered or may have side effects, so replaying
+	 * the turn can duplicate user-visible output or work.
 	 */
 	#hasReplayUnsafeOutput(message: AssistantMessage): boolean {
 		return message.content.some(
-			block => block.type === "toolCall" || (block.type === "text" && block.text.trim().length > 0),
+			block =>
+				block.type === "toolCall" ||
+				block.type === "image" ||
+				block.type === "anthropicServerTool" ||
+				(block.type === "text" && block.text.trim().length > 0),
 		);
 	}
 
@@ -1094,8 +1138,8 @@ export class TurnRecovery {
 	 * transient overload/5xx or a hard "router/model not found / unsupported" —
 	 * is worth retrying on the base id. Skips failures the base model shares:
 	 * context overflow (compaction's job), usage limits and auth errors (same
-	 * account/key), and turns that already emitted any replay-unsafe output
-	 * (visible text or a tool call). Requires the base model to exist in the registry.
+	 * account/key), and turns that already emitted any replay-unsafe output.
+	 * Requires the base model to exist in the registry.
 	 */
 	isFireworksFastFallbackEligible(message: AssistantMessage): boolean {
 		const model = this.#activeFireworksFastModel();
@@ -1120,8 +1164,7 @@ export class TurnRecovery {
 	 * model switch cannot fix or must not replay: cancellations (abort-flavored
 	 * errors are not model faults), context overflow (compaction's job),
 	 * classifier refusals (chain consult is handled on the retryable path with
-	 * `pinFallback`), and turns that already emitted a tool call (replaying
-	 * could duplicate work).
+	 * `pinFallback`), and turns that already emitted replay-unsafe output.
 	 */
 	isHardErrorFallbackEligible(message: AssistantMessage): boolean {
 		if (message.stopReason !== "error") return false;
@@ -1315,6 +1358,7 @@ export class TurnRecovery {
 		const errorMessage = message.errorMessage || "Unknown error";
 		const id = this.#classifyRetryMessage(message);
 		const staleOpenAIResponsesReplayError = AIError.is(id, AIError.Flag.StaleResponsesItem);
+		const recordedUsageLimitOutcome = await this.#usageLimitOutcomes.get(message);
 		const parsedRetryAfterMs = this.#parseRetryAfterMsFromError(errorMessage);
 		let delayMs = staleOpenAIResponsesReplayError
 			? 0
@@ -1329,31 +1373,8 @@ export class TurnRecovery {
 			this.#host.resetCurrentResponsesProviderSession("stale replay error");
 		}
 
-		const activeModel = this.#host.model();
-		if (
-			!retryBudgetExhausted &&
-			activeModel &&
-			!staleOpenAIResponsesReplayError &&
-			AIError.is(id, AIError.Flag.UsageLimit)
-		) {
-			const retryAfterMs = parsedRetryAfterMs ?? calculateRateLimitBackoffMs(parseRateLimitReason(errorMessage));
-			const outcome = await this.#host.modelRegistry.authStorage.markUsageLimitReached(
-				activeModel.provider,
-				this.#host.sessionId(),
-				{
-					retryAfterMs,
-					baseUrl: activeModel.baseUrl,
-					modelId: activeModel.id,
-				},
-			);
-			if (outcome.switched) {
-				switchedCredential = true;
-				delayMs = 0;
-			} else if (await this.#host.maybeAutoRedeemCodexReset()) {
-				// A live usage-limit 429 on the active Codex account, with a banked
-				// reset and the opt-in setting on: spend the reset and retry
-				// immediately instead of waiting out the window. Runs after the
-				// free sibling-switch above and before model fallback below.
+		if (!retryBudgetExhausted && !staleOpenAIResponsesReplayError && recordedUsageLimitOutcome) {
+			if (recordedUsageLimitOutcome.switchedCredential || (await this.#host.maybeAutoRedeemCodexReset())) {
 				switchedCredential = true;
 				delayMs = 0;
 			} else {
@@ -1365,9 +1386,10 @@ export class TurnRecovery {
 				// Without this, one short-lived sibling block escalates a
 				// recoverable situation into the provider's multi-hour wait and
 				// trips the fail-fast cap below.
-				usageLimitWaitMs = retryAfterMs;
-				if (outcome.retryAtMs !== undefined) {
-					const siblingWaitMs = Math.max(0, outcome.retryAtMs - Date.now()) + SIBLING_UNBLOCK_BUFFER_MS;
+				usageLimitWaitMs = recordedUsageLimitOutcome.retryAfterMs;
+				if (recordedUsageLimitOutcome.retryAtMs !== undefined) {
+					const siblingWaitMs =
+						Math.max(0, recordedUsageLimitOutcome.retryAtMs - Date.now()) + SIBLING_UNBLOCK_BUFFER_MS;
 					if (siblingWaitMs < usageLimitWaitMs) {
 						usageLimitWaitMs = siblingWaitMs;
 					}
@@ -1405,6 +1427,7 @@ export class TurnRecovery {
 				delayMs = parsedRetryAfterMs;
 			}
 		}
+
 		if (retryBudgetExhausted) {
 			if (!switchedModel) {
 				await this.persistTerminalEmptyErrorTurn(message);

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -784,7 +784,9 @@ describe("AgentSession auto-compaction queue resume", () => {
 
 		const retryableError = {
 			role: "assistant" as const,
-			content: [{ type: "text" as const, text: "Transient provider failure." }],
+			// Thinking-only partial: a committed visible text block would classify the
+			// failed turn as replay-unsafe and suppress the retry this test depends on.
+			content: [{ type: "thinking" as const, thinking: "Transient provider failure." }],
 			api: "anthropic-messages" as const,
 			provider: "anthropic" as const,
 			model: "claude-sonnet-4-5",

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -1164,25 +1164,26 @@ describe("AgentSession retry delay cap", () => {
 
 					if (streamCalls === 1) {
 						const thinking = { type: "thinking" as const, thinking: "partial thought" };
-						const text = { type: "text" as const, text: "partial text" };
+						// No visible text: a committed text block makes the failed turn
+						// replay-unsafe (turn-recovery #hasReplayUnsafeOutput), which would
+						// correctly suppress this retry. The delay-cap contract under test
+						// needs a replay-safe partial turn, so only thinking plus an
+						// incomplete (never toolcall_end'd) tool call is emitted.
 						const toolCall: ToolCall = {
 							type: "toolCall",
 							id: "tc-incomplete",
 							name: "bash",
 							arguments: { command: "bun probe-archive3.ts" },
 						};
-						partial.content.push(thinking, text, toolCall);
+						partial.content.push(thinking, toolCall);
 						stream.push({ type: "start", partial });
 						stream.push({ type: "thinking_start", contentIndex: 0, partial });
 						stream.push({ type: "thinking_delta", contentIndex: 0, delta: thinking.thinking, partial });
 						stream.push({ type: "thinking_end", contentIndex: 0, content: thinking.thinking, partial });
-						stream.push({ type: "text_start", contentIndex: 1, partial });
-						stream.push({ type: "text_delta", contentIndex: 1, delta: text.text, partial });
-						stream.push({ type: "text_end", contentIndex: 1, content: text.text, partial });
-						stream.push({ type: "toolcall_start", contentIndex: 2, partial });
+						stream.push({ type: "toolcall_start", contentIndex: 1, partial });
 						stream.push({
 							type: "toolcall_delta",
-							contentIndex: 2,
+							contentIndex: 1,
 							delta: JSON.stringify(toolCall.arguments),
 							partial,
 						});

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -1484,6 +1484,57 @@ describe("AgentSession retry delay cap", () => {
 		expect(last.content).toContainEqual({ type: "text", text: "partial" });
 	});
 
+	it("records visible-text usage limits without replaying the failed turn", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected bundled Anthropic test model to exist");
+		}
+
+		const usageLimitError =
+			'429 {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account\'s rate limit. Please try again later."}}';
+		const mock = createMockModel({
+			responses: [{ content: ["Already visible"], stopReason: "error", errorMessage: usageLimitError }],
+		});
+		const agent = new Agent({
+			getApiKey: requestedModel => `${requestedModel.provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		const usageLimitSpy = vi.spyOn(authStorage, "markUsageLimitReached").mockResolvedValue({ switched: false });
+		const retryStartEvents: AutoRetryStartEvent[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start") retryStartEvents.push(event);
+		});
+
+		await session.prompt("Trigger visible usage limit");
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(1);
+		expect(usageLimitSpy).toHaveBeenCalledTimes(1);
+		expect(retryStartEvents).toHaveLength(0);
+		const last = lastAssistant(session);
+		expect(last.stopReason).toBe("error");
+		expect(last.content).toContainEqual({ type: "text", text: "Already visible" });
+	});
+
 	it("does not auto-retry empty reasonless aborts once the session is disposing", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -2969,7 +2969,7 @@ describe("AgentSession retry fallback", () => {
 		const errorMessage = "Provider returned error finish_reason";
 		const mock = createMockModel({
 			responses: [
-				{ content: ["partial output before gateway error"], stopReason: "error", errorMessage },
+				{ content: ["   "], stopReason: "error", errorMessage },
 				{ content: ["Recovered after provider finish_reason error"] },
 			],
 		});
@@ -3035,7 +3035,7 @@ describe("AgentSession retry fallback", () => {
 		const errorMessage = "Provider returned error finish_reason";
 		const mock = createMockModel({
 			responses: [
-				{ content: ["partial output before gateway error"], stopReason: "error", errorMessage },
+				{ content: ["   "], stopReason: "error", errorMessage },
 				{ content: ["Recovered after tail rebuild"] },
 			],
 		});

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -1284,7 +1284,7 @@ describe("AgentSession retry fallback", () => {
 				if (model.provider === primaryModel.provider && model.id === primaryModel.id) {
 					primaryAttempts += 1;
 					mock.push({
-						content: ["Classifier declined this turn."],
+						content: [{ type: "thinking", thinking: "Classifier evaluation before refusal." }],
 						stopReason: "error",
 						stopDetails: refusalDetails,
 						errorMessage: "Refusal (cyber): Classifier declined this turn.",

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -2903,10 +2903,7 @@ describe("AgentSession retry fallback", () => {
 		const mock = createMockModel({
 			responses: [
 				{
-					content: [
-						{ type: "thinking", thinking: "Thinking before malformed function call..." },
-						{ type: "text", text: "Text before malformed function call..." },
-					],
+					content: [{ type: "thinking", thinking: "Thinking before malformed function call..." }],
 					stopReason: "error",
 					errorMessage: malformedError,
 				},

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -1,0 +1,160 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import type { Api, Model, Provider, Usage } from "@oh-my-pi/pi-catalog/types";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import {
+	type RecoveryCompactionResult,
+	TurnRecovery,
+	type TurnRecoveryHost,
+} from "@oh-my-pi/pi-coding-agent/session/turn-recovery";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const USAGE: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function makeMessage(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages" as Api,
+		provider: "anthropic" as Provider,
+		model: "claude-sonnet-4-5",
+		usage: { ...USAGE },
+		stopReason: "error",
+		errorMessage: "timeout",
+		timestamp: Date.now(),
+	};
+}
+
+function createHost(
+	model: Model,
+	modelRegistry: ModelRegistry,
+	fallbackChains?: Record<string, string[]>,
+): TurnRecoveryHost {
+	const settings = Settings.isolated(fallbackChains ? { "retry.fallbackChains": fallbackChains } : {});
+	return {
+		agent: undefined as never,
+		sessionManager: undefined as never,
+		settings,
+		modelRegistry,
+		configWarnings: [],
+		model: () => model,
+		thinkingLevel: () => undefined,
+		configuredThinkingLevel: () => undefined,
+		setThinkingLevel: () => {},
+		thinkingLevelCeiling: () => undefined,
+		isDisposed: () => false,
+		isStreaming: () => false,
+		isCompacting: () => false,
+		abortInProgress: () => false,
+		streamingEditAbortTriggered: () => false,
+		promptGeneration: () => 0,
+		sessionId: () => "test-session",
+		emitSessionEvent: async () => {},
+		scheduleAgentContinue: () => {},
+		waitForSessionMessagePersistence: async () => {},
+		appendSessionMessage: () => {},
+		sessionMessageAlreadyPersisted: () => false,
+		setModelWithProviderSessionReset: async () => {},
+		resetCurrentResponsesProviderSession: () => {},
+		maybeAutoRedeemCodexReset: async () => false,
+		runAutoCompaction: async () =>
+			({ deferredHandoff: false, continuationScheduled: false }) as RecoveryCompactionResult,
+		withBashBranchTransition: <T>(operation: () => T): T => operation(),
+	};
+}
+
+describe("TurnRecovery replay-unsafe output classification", () => {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled model claude-sonnet-4-5");
+
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	beforeAll(async () => {
+		tempDir = TempDir.createSync("@pi-turn-recovery-replay-");
+		authStorage = await AuthStorage.create(tempDir.join("testauth.db"));
+		modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("treats a failed turn with partial non-whitespace text as NOT retriable", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage([{ type: "text", text: "Here is the first part of my answer" }]);
+		expect(recovery.isRetryableError(message)).toBe(false);
+	});
+
+	it("finds a replay-safe failed turn fallback-eligible when a fallback chain is configured (positive control)", () => {
+		const recovery = new TurnRecovery(
+			createHost(model, modelRegistry, {
+				[`${model.provider}/${model.id}`]: ["openai/gpt-4o-mini"],
+			}),
+		);
+		// Thinking-only output is replay-safe: nothing visible reached the user.
+		const message = makeMessage([{ type: "thinking", thinking: "safe reasoning before failing" }]);
+		expect(recovery.isHardErrorFallbackEligible(message)).toBe(true);
+	});
+
+	it("excludes a failed turn with partial non-whitespace text from fallback candidates", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage([{ type: "text", text: "partial visible output" }]);
+		expect(recovery.isHardErrorFallbackEligible(message)).toBe(false);
+	});
+
+	it("treats a thinking-only partial turn as still retriable", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage([{ type: "thinking", thinking: "Let me reason about this step by step." }]);
+		expect(recovery.isRetryableError(message)).toBe(true);
+	});
+
+	it("treats a whitespace-only text partial as still retriable", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage([{ type: "text", text: "   \n\n  " }]);
+		expect(recovery.isRetryableError(message)).toBe(true);
+	});
+
+	it("keeps the tool-call case replay-unsafe (no regression)", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage([{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: "ls" } }]);
+		expect(recovery.isRetryableError(message)).toBe(false);
+		expect(recovery.isHardErrorFallbackEligible(message)).toBe(false);
+	});
+
+	it("keeps an empty-content error retriable (baseline)", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage([]);
+		expect(recovery.isRetryableError(message)).toBe(true);
+	});
+
+	it("treats a mix of thinking and text as replay-unsafe (text wins)", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage([
+			{ type: "thinking", thinking: "Reasoning before the visible answer." },
+			{ type: "text", text: "The answer is 42." },
+		]);
+		expect(recovery.isRetryableError(message)).toBe(false);
+	});
+
+	it("treats thinking plus whitespace-only text as replay-safe", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage([
+			{ type: "thinking", thinking: "Long reasoning." },
+			{ type: "text", text: "  " },
+		]);
+		expect(recovery.isRetryableError(message)).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -213,4 +213,26 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		);
 		expect(recovery.isRetryableError(message)).toBe(false);
 	});
+
+	it("keeps replay-safe classifier refusals retriable", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const thinking = makeMessage([{ type: "thinking", thinking: "reasoning before refusal" }], model);
+		thinking.stopDetails = { type: "refusal" };
+		expect(recovery.isRetryableError(thinking)).toBe(true);
+
+		const whitespace = makeMessage([{ type: "text", text: "   \n\n  " }], model);
+		whitespace.stopDetails = { type: "refusal" };
+		expect(recovery.isRetryableError(whitespace)).toBe(true);
+
+		const empty = makeMessage([], model);
+		empty.stopDetails = { type: "refusal" };
+		expect(recovery.isRetryableError(empty)).toBe(true);
+	});
+
+	it("does not retry a classifier refusal after visible text", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage([{ type: "text", text: "Visible refusal output" }], model);
+		message.stopDetails = { type: "refusal" };
+		expect(recovery.isRetryableError(message)).toBe(false);
+	});
 });

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import * as AIError from "@oh-my-pi/pi-ai/error";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import type { Model, Usage } from "@oh-my-pi/pi-catalog/types";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -177,5 +178,39 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 			model,
 		);
 		expect(recovery.isRetryableError(message)).toBe(true);
+	});
+
+	it("does not retry malformed calls after visible text", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage([{ type: "text", text: "Already shown" }], model);
+		message.errorId = AIError.create(AIError.Flag.MalformedFunctionCall);
+		expect(recovery.isRetryableError(message)).toBe(false);
+	});
+
+	it("retries malformed calls with replay-safe output", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage([{ type: "thinking", thinking: "Unshown reasoning" }], model);
+		message.errorId = AIError.create(AIError.Flag.MalformedFunctionCall);
+		expect(recovery.isRetryableError(message)).toBe(true);
+	});
+
+	it("treats generated images as replay-unsafe", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage([{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }], model);
+		expect(recovery.isRetryableError(message)).toBe(false);
+	});
+
+	it("treats Anthropic server tools as replay-unsafe", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry));
+		const message = makeMessage(
+			[
+				{
+					type: "anthropicServerTool",
+					block: { type: "server_tool_use", id: "srv-1", name: "web_search", input: { query: "status" } },
+				},
+			],
+			model,
+		);
+		expect(recovery.isRetryableError(message)).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import type { Api, Model, Provider, Usage } from "@oh-my-pi/pi-catalog/types";
+import type { Model, Usage } from "@oh-my-pi/pi-catalog/types";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -21,13 +21,13 @@ const USAGE: Usage = {
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
 
-function makeMessage(content: AssistantMessage["content"]): AssistantMessage {
+function makeMessage(content: AssistantMessage["content"], model: Model): AssistantMessage {
 	return {
 		role: "assistant",
 		content,
-		api: "anthropic-messages" as Api,
-		provider: "anthropic" as Provider,
-		model: "claude-sonnet-4-5",
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
 		usage: { ...USAGE },
 		stopReason: "error",
 		errorMessage: "timeout",
@@ -94,7 +94,7 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 
 	it("treats a failed turn with partial non-whitespace text as NOT retriable", () => {
 		const recovery = new TurnRecovery(createHost(model, modelRegistry));
-		const message = makeMessage([{ type: "text", text: "Here is the first part of my answer" }]);
+		const message = makeMessage([{ type: "text", text: "Here is the first part of my answer" }], model);
 		expect(recovery.isRetryableError(message)).toBe(false);
 	});
 
@@ -105,56 +105,77 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 			}),
 		);
 		// Thinking-only output is replay-safe: nothing visible reached the user.
-		const message = makeMessage([{ type: "thinking", thinking: "safe reasoning before failing" }]);
+		const message = makeMessage([{ type: "thinking", thinking: "safe reasoning before failing" }], model);
 		expect(recovery.isHardErrorFallbackEligible(message)).toBe(true);
 	});
 
-	it("excludes a failed turn with partial non-whitespace text from fallback candidates", () => {
-		const recovery = new TurnRecovery(createHost(model, modelRegistry));
-		const message = makeMessage([{ type: "text", text: "partial visible output" }]);
-		expect(recovery.isHardErrorFallbackEligible(message)).toBe(false);
+	it("excludes a Fireworks Fast failed turn with partial visible text from Fast→base fallback", () => {
+		const fastModel = getBundledModel("fireworks", "kimi-k2.6-fast");
+		if (!fastModel) throw new Error("Expected bundled model kimi-k2.6-fast");
+		const recovery = new TurnRecovery(createHost(fastModel, modelRegistry));
+		const message = makeMessage([{ type: "text", text: "partial visible output" }], fastModel);
+		expect(recovery.isFireworksFastFallbackEligible(message)).toBe(false);
+	});
+
+	it("keeps a Fireworks Fast empty/whitespace failed turn eligible for Fast→base fallback", () => {
+		const fastModel = getBundledModel("fireworks", "kimi-k2.6-fast");
+		if (!fastModel) throw new Error("Expected bundled model kimi-k2.6-fast");
+		const recovery = new TurnRecovery(createHost(fastModel, modelRegistry));
+		expect(recovery.isFireworksFastFallbackEligible(makeMessage([], fastModel))).toBe(true);
+		expect(recovery.isFireworksFastFallbackEligible(makeMessage([{ type: "text", text: "   \n" }], fastModel))).toBe(
+			true,
+		);
 	});
 
 	it("treats a thinking-only partial turn as still retriable", () => {
 		const recovery = new TurnRecovery(createHost(model, modelRegistry));
-		const message = makeMessage([{ type: "thinking", thinking: "Let me reason about this step by step." }]);
+		const message = makeMessage([{ type: "thinking", thinking: "Let me reason about this step by step." }], model);
 		expect(recovery.isRetryableError(message)).toBe(true);
 	});
 
 	it("treats a whitespace-only text partial as still retriable", () => {
 		const recovery = new TurnRecovery(createHost(model, modelRegistry));
-		const message = makeMessage([{ type: "text", text: "   \n\n  " }]);
+		const message = makeMessage([{ type: "text", text: "   \n\n  " }], model);
 		expect(recovery.isRetryableError(message)).toBe(true);
 	});
 
 	it("keeps the tool-call case replay-unsafe (no regression)", () => {
 		const recovery = new TurnRecovery(createHost(model, modelRegistry));
-		const message = makeMessage([{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: "ls" } }]);
+		const message = makeMessage(
+			[{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: "ls" } }],
+			model,
+		);
 		expect(recovery.isRetryableError(message)).toBe(false);
 		expect(recovery.isHardErrorFallbackEligible(message)).toBe(false);
 	});
 
 	it("keeps an empty-content error retriable (baseline)", () => {
 		const recovery = new TurnRecovery(createHost(model, modelRegistry));
-		const message = makeMessage([]);
+		const message = makeMessage([], model);
 		expect(recovery.isRetryableError(message)).toBe(true);
 	});
 
 	it("treats a mix of thinking and text as replay-unsafe (text wins)", () => {
 		const recovery = new TurnRecovery(createHost(model, modelRegistry));
-		const message = makeMessage([
-			{ type: "thinking", thinking: "Reasoning before the visible answer." },
-			{ type: "text", text: "The answer is 42." },
-		]);
+		const message = makeMessage(
+			[
+				{ type: "thinking", thinking: "Reasoning before the visible answer." },
+				{ type: "text", text: "The answer is 42." },
+			],
+			model,
+		);
 		expect(recovery.isRetryableError(message)).toBe(false);
 	});
 
 	it("treats thinking plus whitespace-only text as replay-safe", () => {
 		const recovery = new TurnRecovery(createHost(model, modelRegistry));
-		const message = makeMessage([
-			{ type: "thinking", thinking: "Long reasoning." },
-			{ type: "text", text: "  " },
-		]);
+		const message = makeMessage(
+			[
+				{ type: "thinking", thinking: "Long reasoning." },
+				{ type: "text", text: "  " },
+			],
+			model,
+		);
 		expect(recovery.isRetryableError(message)).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary
A failed turn that already produced visible output or server-side effects is no longer replayed automatically. Credential retries, model fallback, malformed-call recovery, classifier-refusal recovery, and Fireworks Fast-to-base fallback now share one replay-safety rule.

## Design
- Non-whitespace text, tool calls, generated images, and Anthropic server-tool execution make a turn replay-unsafe.
- Thinking-only, whitespace-only, and empty failed turns remain eligible for safe recovery.
- Replay safety takes precedence over malformed-function-call and classifier-refusal retry, so partial visible output is retained.
- Usage-limit bookkeeping runs once even when the failed turn cannot be replayed, keeping exhausted credentials out of later selections.
- The Fireworks Fast branch uses the same centralized predicate as the other retry and fallback paths.

## Validation
- 61 focused refusal and replay-safety tests pass in the final run; the broader 81-test recovery sweep also passed before the final refusal fix.
- `packages/ai` and `packages/coding-agent` typechecks pass.
