### PR TITLE
fix(providers): fixed novita key validation for restricted accounts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Novita login rejecting valid API keys belonging to Developer and Basic team members. Key validation targeted the account billing balance endpoint, which requires a Balance permission those roles do not hold; it now validates against the OpenAI-compatible chat completions endpoint the key is actually used with.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/registry/novita.ts
+++ b/packages/ai/src/registry/novita.ts
@@ -8,10 +8,13 @@ export const loginNovita = createApiKeyLogin({
 	promptMessage: "Paste your Novita API key",
 	placeholder: "sk_...",
 	validation: {
-		kind: "models-endpoint",
+		// Validate against inference, not billing: `/openapi/v1/billing/balance/detail`
+		// requires the account-level Balance permission, which Novita's Developer and
+		// Basic team roles don't hold, so their valid inference keys were rejected.
+		kind: "chat-completions",
 		provider: "Novita",
-		modelsUrl: "https://api.novita.ai/openapi/v1/billing/balance/detail",
-		headers: { "Content-Type": "application/json" },
+		baseUrl: "https://api.novita.ai/openai/v1",
+		model: "moonshotai/kimi-k2.7-code",
 	},
 });
 

--- a/packages/ai/test/novita-login.test.ts
+++ b/packages/ai/test/novita-login.test.ts
@@ -9,7 +9,7 @@ describe("Novita login", () => {
 		expect(provider).toMatchObject({ id: "novita", name: "Novita", available: true });
 	});
 
-	test("validates the pasted key against the authenticated balance endpoint", async () => {
+	test("validates the pasted key against the OpenAI-compatible chat completions endpoint", async () => {
 		const authEvents: Array<{ url: string; instructions?: string }> = [];
 		const prompts: Array<{ message: string; placeholder?: string }> = [];
 		const progress: string[] = [];
@@ -18,6 +18,7 @@ describe("Novita login", () => {
 			method: string | undefined;
 			authorization: string | null;
 			contentType: string | null;
+			body: unknown;
 		}> = [];
 		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
 			const headers = new Headers(init?.headers);
@@ -26,8 +27,9 @@ describe("Novita login", () => {
 				method: init?.method,
 				authorization: headers.get("authorization"),
 				contentType: headers.get("content-type"),
+				body: typeof init?.body === "string" ? JSON.parse(init.body) : init?.body,
 			});
-			return Response.json({ availableBalance: "0" });
+			return Response.json({ choices: [{ message: { role: "assistant", content: "" } }] });
 		});
 
 		const apiKey = await loginNovita({
@@ -51,17 +53,47 @@ describe("Novita login", () => {
 		expect(progress).toEqual(["Validating API key..."]);
 		expect(requests).toEqual([
 			{
-				url: "https://api.novita.ai/openapi/v1/billing/balance/detail",
-				method: "GET",
+				url: "https://api.novita.ai/openai/v1/chat/completions",
+				method: "POST",
 				authorization: "Bearer novita-test-key",
 				contentType: "application/json",
+				body: {
+					model: "moonshotai/kimi-k2.7-code",
+					messages: [{ role: "user", content: "ping" }],
+					max_tokens: 1,
+					temperature: 0,
+				},
 			},
 		]);
 	});
 
+	test("accepts an inference key whose team role cannot read the account balance", async () => {
+		// Novita's Developer/Basic team roles hold no Balance permission, so their
+		// otherwise-valid inference keys are rejected by the billing endpoint.
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request) => {
+			if (String(input).includes("/openapi/v1/billing/")) {
+				return Response.json(
+					{ code: 401, reason: "UNAUTHORIZED", message: "key not found", metadata: {} },
+					{ status: 401 },
+				);
+			}
+			return Response.json({ choices: [{ message: { role: "assistant", content: "" } }] });
+		});
+
+		await expect(
+			loginNovita({
+				onPrompt: async () => "developer-role-key",
+				fetch: fetchMock,
+			}),
+		).resolves.toBe("developer-role-key");
+	});
+
 	test("rejects a key rejected by Novita", async () => {
 		const fetchMock: FetchImpl = vi.fn(async () =>
-			Response.json({ code: 401, reason: "UNAUTHORIZED", message: "key not found", metadata: {} }, { status: 401 }),
+			Response.json(
+				{ code: 401, reason: "FAILED_TO_AUTH", message: "failed to authenticate API key", metadata: {} },
+				{ status: 401 },
+			),
 		);
 
 		await expect(


### PR DESCRIPTION
## What

Novita API key validation now runs against the OpenAI-compatible chat completions endpoint instead of the account billing balance endpoint.

```diff
 validation: {
-	kind: "models-endpoint",
+	kind: "chat-completions",
 	provider: "Novita",
-	modelsUrl: "https://api.novita.ai/openapi/v1/billing/balance/detail",
-	headers: { "Content-Type": "application/json" },
+	baseUrl: "https://api.novita.ai/openai/v1",
+	model: "moonshotai/kimi-k2.7-code",
 },
```

Three files: `packages/ai/src/registry/novita.ts`, `packages/ai/test/novita-login.test.ts`, `packages/ai/CHANGELOG.md`.

## Why

`/login novita` rejected valid API keys for a whole class of users.

Since f79098b9b, key validation issued `GET https://api.novita.ai/openapi/v1/billing/balance/detail` and treated any non-2xx as an invalid key. That endpoint lives on Novita's account-management surface and is gated by the **Balance** permission. Per [Novita's team permission table](https://novita.ai/docs/guides/team), Balance is granted to **Owner, Admin, and Billing** roles only — **Developer** and **Basic** members have no Balance permission at all, while both roles can create API keys and run LLM inference.

So a Developer or Basic team member's key works perfectly for chat completions but failed login with:

```
Novita API key validation failed (401): {"code":401,"reason":"UNAUTHORIZED","message":"key not found"}
```

Personal-account keys were unaffected, which made the failure look intermittent.

The endpoint switch in f79098b9b was itself correct — the previous target, `https://api.novita.ai/openai/v1/models`, is public and returns `200` for a fabricated key, so it validated nothing. This PR keeps the authenticated check but points it at the surface the credential is actually used against, matching how Cerebras, Together, Venice, Fireworks, HuggingFace, and Qianfan already validate.

Cost per login is one `max_tokens: 1` completion.

## Testing

`packages/ai/test/novita-login.test.ts` — updated the request-shape assertion and added a regression test that encodes the bug directly: a fetch mock that returns 401 for `/openapi/v1/billing/*` and serves inference normally. Both tests were confirmed failing against the old implementation before the fix, and pass after.

```
packages/ai            bun test --parallel   3443 pass, 0 fail (337 skipped e2e, no creds)
packages/catalog       novita-provider       2 pass, 0 fail
packages/ai            bun run check         biome clean, tsgo --noEmit clean
```

Model discovery is untouched and still uses the public `/openai/v1/models`; `catalogDiscovery.allowUnauthenticated` stays as-is.

Verified against live Novita endpoints before writing the test:

- `moonshotai/kimi-k2.7-code` is present in `/openai/v1/models` and is `DEFAULT_MODEL_PER_PROVIDER.novita`
- `POST /openai/v1/chat/completions` with a bogus key → `401 FAILED_TO_AUTH`, so the new check genuinely authenticates
- `GET /openai/v1/models` with a bogus key → `200`, confirming why the old pre-f79098b9b check was a no-op

Also built the binary (`bun --cwd=packages/coding-agent run build`) and confirmed `dist/omp` contains no `openapi/v1/billing/balance/detail` string.

Confirmed with a real, local credential.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
