### PR TITLE
fix(collab-web): surface terminal auto_retry_end failures

### DIFF
--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the agent appearing to stop silently with no message: terminal `auto_retry_end` failures now surface as an error notice instead of being discarded.
+
 ## [17.1.0] - 2026-07-24
 
 ### Fixed

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the agent appearing to stop silently with no message: terminal `auto_retry_end` failures now surface as an error notice instead of being discarded.
+- Fixed the agent appearing to stop silently with no message: terminal `auto_retry_end` failures now surface as an error notice instead of being discarded. ([#6992](https://github.com/can1357/oh-my-pi/pull/6992) by [@metaphorics](https://github.com/metaphorics))
 
 ## [17.1.0] - 2026-07-24
 

--- a/packages/collab-web/src/lib/client.ts
+++ b/packages/collab-web/src/lib/client.ts
@@ -454,6 +454,9 @@ export class GuestClient {
 			case "auto_retry_start":
 				this.#pushNotice("info", `retry ${event.attempt}/${event.maxAttempts}: ${event.errorMessage}`);
 				break;
+			case "auto_retry_end":
+				if (!event.success) this.#pushNotice("error", event.finalError ?? "retry failed");
+				break;
 			case "auto_compaction_start":
 				this.#pushNotice("info", `compacting context (${event.reason})`);
 				break;

--- a/packages/collab-web/test/client.test.ts
+++ b/packages/collab-web/test/client.test.ts
@@ -234,6 +234,17 @@ describe("GuestClient frame apply", () => {
 		expect(notices[0]).toMatchObject({ level: "error", message: "boom" });
 	});
 
+	it("auto_retry_end failure surfaces an error notice", () => {
+		const client = liveClient();
+		client.applyFrameForTest({
+			t: "event",
+			event: { type: "auto_retry_end", success: false, attempt: 3, finalError: "x" },
+		});
+		const notices = client.getSnapshot().notices;
+		expect(notices).toHaveLength(1);
+		expect(notices[0]).toMatchObject({ level: "error", message: "x" });
+	});
+
 	it("a pre-welcome error (hello rejection, e.g. protocol mismatch) ends the session with the host's reason", () => {
 		const client = new GuestClient(LINK, "tester");
 		client.applyFrameForTest({


### PR DESCRIPTION
## Symptom

"In very rare cases the agent does nothing and just stops — no message or error given." Reported by a heavy mobile (collab-web) user.

## Root cause (verified)

The host does report this failure. At the empty-stop retry cap, `turn-recovery.ts:470-493` emits `{ type: "auto_retry_end", success: false, attempt, finalError }` with an actionable message ("Assistant returned empty stop after retry cap; try switching models or `/shake images` …"). The TUI handles it (`event-controller.ts` `#handleAutoRetryEnd`). The web guest does not: `GuestClient.#applyEvent` handles `auto_retry_start` (`client.ts:454-456`) but `auto_retry_end` fell into `default:` and was silently discarded — which is why the symptom reads as mobile-only.

## Fix

One case beside `auto_retry_start`:

```ts
case "auto_retry_end":
    if (!event.success) this.#pushNotice("error", event.finalError ?? "retry failed");
    break;
```

Nothing is emitted on `success: true` — a recovered retry is already compacted into a dim note by design.

## Verification

New case in `packages/collab-web/test/client.test.ts`: `auto_retry_end{success:false, finalError:"x"}` → exactly one notice with level `error`, message `"x"`. Failing before, passing after.