### PR TITLE
fix(coding-agent): require web_search_call in codex search

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex web search silently returning a plain model completion when a GPT-5.6 Responses-Lite model skipped the hosted `web_search` tool; the provider now requires a `web_search_call` event and advances to a searching model or fails clearly instead of accepting a non-search answer ([#6988](https://github.com/can1357/oh-my-pi/issues/6988)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -114,7 +114,28 @@ function getDefaultModelCandidates(): CodexModelCandidate[] {
 	return fallbackModel ? [{ modelId: fallbackModel.id, catalogModel: fallbackModel }] : [{ modelId: FALLBACK_MODEL }];
 }
 
+/**
+ * Raised when Codex produced an answer without invoking the hosted `web_search`
+ * tool. GPT-5.6 Responses-Lite models receive `tool_choice: "auto"` (the forced
+ * hosted choice is invalid under the lite shape — see #5771 / #5772), so the
+ * model may skip searching and return a plain completion. A search command must
+ * not present that as a successful, search-backed result (#6988); this advances
+ * the candidate chain to a model that will search, or surfaces a clear failure
+ * when the model was explicitly configured.
+ */
+class CodexNoWebSearchError extends SearchProviderError {
+	constructor() {
+		super(
+			"codex",
+			"Codex returned a completion without running web search (no web_search_call event); refusing to treat a non-search answer as a search result",
+			502,
+		);
+		this.name = "CodexNoWebSearchError";
+	}
+}
+
 function shouldRetryWithNextDefaultModel(error: unknown): boolean {
+	if (error instanceof CodexNoWebSearchError) return true;
 	if (!(error instanceof SearchProviderError)) return false;
 	if (error.provider !== "codex" || error.status !== 400) return false;
 	return /model is not supported|requested model is not supported|not supported when using codex with a chatgpt account/i.test(
@@ -472,10 +493,18 @@ async function callCodexSearch(
 	let model = requestedModel;
 	let requestId = "";
 	let usage: { inputTokens: number; outputTokens: number; totalTokens: number } | undefined;
+	// Evidence that the hosted web_search tool actually ran. Lite models get
+	// `tool_choice: "auto"` and may answer without searching (#6988); a search
+	// command must reject that rather than return a non-search completion.
+	let webSearchInvoked = false;
 
 	for await (const rawEvent of readSseJson<Record<string, unknown>>(response.body, options.signal)) {
 		const eventType = typeof rawEvent.type === "string" ? rawEvent.type : "";
 		if (!eventType) continue;
+
+		if (eventType.startsWith("response.web_search_call")) {
+			webSearchInvoked = true;
+		}
 
 		if (eventType === "response.output_text.delta") {
 			const delta = typeof rawEvent.delta === "string" ? rawEvent.delta : "";
@@ -485,6 +514,7 @@ async function callCodexSearch(
 		} else if (eventType === "response.output_item.done") {
 			const item = rawEvent.item as CodexResponseItem | undefined;
 			if (!item) continue;
+			if (item.type === "web_search_call") webSearchInvoked = true;
 
 			// Handle text message content and extract sources from annotations
 			if (item.type === "message" && item.content) {
@@ -536,6 +566,10 @@ async function callCodexSearch(
 			const errorMessage = resp?.error?.message ?? "Request failed";
 			throw new SearchProviderError("codex", `Codex request failed: ${errorMessage}`, 500);
 		}
+	}
+
+	if (!webSearchInvoked) {
+		throw new CodexNoWebSearchError();
 	}
 
 	const finalAnswer = answerParts.join("\n\n").trim();

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -12,8 +12,18 @@ type CapturedRequest = {
 
 const originalCodexSearchModel = process.env.PI_CODEX_WEB_SEARCH_MODEL;
 
+// A completed hosted web_search tool call. Real Codex searches always stream a
+// `response.web_search_call.*` event; the provider now requires that evidence
+// (#6988), so every success fixture must include it.
+const WEB_SEARCH_CALL_EVENT = `data: ${JSON.stringify({
+	type: "response.web_search_call.completed",
+	item_id: "ws_test",
+})}`;
+
 function makeSseResponse(model: string): string {
 	return [
+		WEB_SEARCH_CALL_EVENT,
+		"",
 		`data: ${JSON.stringify({
 			type: "response.output_item.done",
 			item: {
@@ -46,6 +56,8 @@ function makeSseResponse(model: string): string {
 
 function makeImagePlaceholderSseResponse(model: string): string {
 	return [
+		WEB_SEARCH_CALL_EVENT,
+		"",
 		`data: ${JSON.stringify({
 			type: "response.output_text.delta",
 			delta: "OpenAI Responses API defaults `store` to false unless you opt in.",
@@ -80,6 +92,8 @@ function makeImagePlaceholderSseResponse(model: string): string {
 
 function makeMarkdownLinkSseResponse(model: string): string {
 	return [
+		WEB_SEARCH_CALL_EVENT,
+		"",
 		`data: ${JSON.stringify({
 			type: "response.output_item.done",
 			item: {
@@ -104,6 +118,8 @@ function makeMarkdownLinkSseResponse(model: string): string {
 
 function makePlainUrlSseResponse(model: string): string {
 	return [
+		WEB_SEARCH_CALL_EVENT,
+		"",
 		`data: ${JSON.stringify({
 			type: "response.output_item.done",
 			item: {
@@ -128,6 +144,8 @@ function makePlainUrlSseResponse(model: string): string {
 
 function makeMarkdownParenthesesSseResponse(model: string): string {
 	return [
+		WEB_SEARCH_CALL_EVENT,
+		"",
 		`data: ${JSON.stringify({
 			type: "response.output_item.done",
 			item: {
@@ -152,6 +170,8 @@ function makeMarkdownParenthesesSseResponse(model: string): string {
 
 function makePlainUrlPunctuationSseResponse(model: string): string {
 	return [
+		WEB_SEARCH_CALL_EVENT,
+		"",
 		`data: ${JSON.stringify({
 			type: "response.output_item.done",
 			item: {
@@ -601,6 +621,8 @@ describe("searchCodex model selection", () => {
 
 	it("throws to advance the chain when both streamed and final answers are image placeholders without sources", async () => {
 		const sse = [
+			WEB_SEARCH_CALL_EVENT,
+			"",
 			`data: ${JSON.stringify({
 				type: "response.output_text.delta",
 				delta: "[Attached image]",
@@ -629,6 +651,8 @@ describe("searchCodex model selection", () => {
 
 	it("drops placeholder prose from the answer but keeps annotation sources when both are placeholders", async () => {
 		const sse = [
+			WEB_SEARCH_CALL_EVENT,
+			"",
 			`data: ${JSON.stringify({
 				type: "response.output_text.delta",
 				delta: "(see attached image)",
@@ -661,5 +685,71 @@ describe("searchCodex model selection", () => {
 		const result = await searchCodex(makeSearchParams("image with sources", fetchMock));
 		expect(result.answer).toBeUndefined();
 		expect(result.sources).toEqual([{ title: "Docs", url: "https://example.com/docs" }]);
+	});
+
+	it("fails a configured Responses-Lite model that answers without running web search (#6988)", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.6-terra";
+		const sse = [
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					content: [
+						{
+							type: "output_text",
+							text: "July 28, 2026 is still in the future, so OpenAI has not announced anything yet.",
+						},
+					],
+				},
+			})}`,
+			"",
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: { id: "resp_no_search", model: "gpt-5.6-terra" },
+			})}`,
+			"",
+		].join("\n");
+		const fetchMock: FetchImpl = () =>
+			Promise.resolve(new Response(sse, { status: 200, headers: { "Content-Type": "text/event-stream" } }));
+
+		await expect(searchCodex(makeSearchParams("no search performed", fetchMock))).rejects.toThrow(
+			/without running web search/,
+		);
+	});
+
+	it("advances to the next default candidate when a lite model skips web search (#6988)", async () => {
+		delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
+		let calls = 0;
+		const noSearchSse = [
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: { type: "message", content: [{ type: "output_text", text: "stale answer, no search" }] },
+			})}`,
+			"",
+			`data: ${JSON.stringify({ type: "response.completed", response: { id: "resp_skip", model: "gpt-5.6-luna" } })}`,
+			"",
+		].join("\n");
+		const fetchMock: FetchImpl = (_url, init) => {
+			calls += 1;
+			const body = init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : null;
+			if (calls === 1) {
+				expect(body?.model).toBe("gpt-5.6-luna");
+				return Promise.resolve(
+					new Response(noSearchSse, { status: 200, headers: { "Content-Type": "text/event-stream" } }),
+				);
+			}
+			expect(body?.model).toBe("gpt-5.6-terra");
+			return Promise.resolve(
+				new Response(makeSseResponse("gpt-5.6-terra"), {
+					status: 200,
+					headers: { "Content-Type": "text/event-stream" },
+				}),
+			);
+		};
+
+		const result = await searchCodex(makeSearchParams("advance past skipped search", fetchMock));
+		expect(calls).toBe(2);
+		expect(result.model).toBe("gpt-5.6-terra");
+		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 });

--- a/packages/coding-agent/test/web/search/codex-broker.test.ts
+++ b/packages/coding-agent/test/web/search/codex-broker.test.ts
@@ -7,6 +7,8 @@ import { searchCodex } from "@oh-my-pi/pi-coding-agent/web/search/providers/code
 
 function makeSseResponse(): string {
 	return [
+		`data: ${JSON.stringify({ type: "response.web_search_call.completed", item_id: "ws_test" })}`,
+		"",
 		`data: ${JSON.stringify({
 			type: "response.output_item.done",
 			item: {


### PR DESCRIPTION
## Repro
With Codex OAuth, `omp search --provider=codex "..."` on a GPT-5.6 Responses-Lite model can return a plain model completion with zero sources and exit 0, indistinguishable from a real search. Drove `searchCodex()` with a fetch mock that streams a `gpt-5.6-terra` completion containing no `response.web_search_call.*` event; it resolved successfully with `sources.length === 0` and the stale answer.

## Cause
For `useResponsesLite` models, `applyCodexResponsesLiteShape()` (`packages/ai/src/providers/openai-codex/request-transformer.ts`) rewrites the forced `tool_choice: { type: "web_search" }` to `"auto"` (PR #5772, fixing the #5771 HTTP 400), so the model is free to skip the tool. `callCodexSearch()` in `packages/coding-agent/src/web/search/providers/codex.ts` never verified that a `web_search_call` occurred — any non-empty answer was accepted, and text URLs promoted to sources.

## Fix
- `callCodexSearch()` now tracks web-search evidence: sets `webSearchInvoked` on any `response.web_search_call.*` event and on a `web_search_call` output item.
- After the stream, throws the new `CodexNoWebSearchError` (extends `SearchProviderError`, status 502) when no web search occurred.
- `shouldRetryWithNextDefaultModel()` treats `CodexNoWebSearchError` as retryable, so default lite candidates advance to a non-lite model that still forces `web_search`; an explicitly-configured model surfaces the error clearly.
- Updated codex search test fixtures to include a `web_search_call` event (real searches always emit one) and added regression tests for the configured-model failure and default-candidate advancement paths.

## Verification
`bun test test/tools/web-search-codex.test.ts test/web/search/codex-broker.test.ts` in `packages/coding-agent` → 22 pass / 0 fail. Repro test (removed after) confirmed the pre-fix silent acceptance. Fixes #6988