### PR TITLE
fix(collab): start the guest loader when the host reports streaming

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the TUI collab guest never starting its loader when it joins or reconnects mid-turn: every host `state` frame now reconciles liveness in both directions.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the TUI collab guest never starting its loader when it joins or reconnects mid-turn: every host `state` frame now reconciles liveness in both directions.
+- Fixed the TUI collab guest never starting its loader when it joins or reconnects mid-turn: every host `state` frame now reconciles liveness in both directions ([#6996](https://github.com/can1357/oh-my-pi/pull/6996) by [@metaphorics](https://github.com/metaphorics)).
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -119,13 +119,35 @@ export interface GuestSnapshotActivityReconcilerCtx extends GuestIdleReconcilerC
 	 * missed an earlier `agent_start` (a reconnect dropped it mid-stream)
 	 * starts its spinner when the host later reports it is streaming.
 	 */
-	ensureLoadingAnimation: () => void;
+	ensureLoadingAnimation: InteractiveModeContext["ensureLoadingAnimation"];
+	autoCompactionLoader: InteractiveModeContext["autoCompactionLoader"];
+	retryLoader: InteractiveModeContext["retryLoader"];
+}
+
+/** Status-area state which cannot outlive removal of its child components. */
+export interface GuestTransientStatusCtx {
+	statusContainer: Pick<InteractiveModeContext["statusContainer"], "clear">;
+	autoCompactionLoader: InteractiveModeContext["autoCompactionLoader"];
+	retryLoader: InteractiveModeContext["retryLoader"];
+}
+
+/** Stop and forget status-area loaders before detaching their components. */
+export function clearGuestTransientStatus(ctx: GuestTransientStatusCtx): void {
+	if (ctx.autoCompactionLoader) {
+		ctx.autoCompactionLoader.stop();
+		ctx.autoCompactionLoader = undefined;
+	}
+	if (ctx.retryLoader) {
+		ctx.retryLoader.stop();
+		ctx.retryLoader = undefined;
+	}
+	ctx.statusContainer.clear();
 }
 
 export function reconcileGuestSnapshotHostState(ctx: GuestSnapshotActivityReconcilerCtx, isStreaming: boolean): void {
 	if (isStreaming) {
 		ctx.statusLine.markActivityStart();
-		ctx.ensureLoadingAnimation();
+		if (!ctx.autoCompactionLoader && !ctx.retryLoader) ctx.ensureLoadingAnimation();
 		return;
 	}
 	reconcileGuestIdleHostState(ctx, false);
@@ -690,7 +712,7 @@ export class CollabGuestLink {
 
 	#clearTransientUi(): void {
 		this.#clearUiRequests();
-		this.#ctx.statusContainer.clear();
+		clearGuestTransientStatus(this.#ctx);
 		this.#ctx.pendingMessagesContainer.clear();
 		this.#ctx.compactionQueuedMessages = [];
 		this.#ctx.streamingComponent = undefined;

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -91,8 +91,8 @@ export interface GuestIdleReconcilerCtx {
 /**
  * Close the guest UI state held open by an earlier `agent_start` whose
  * matching `agent_end` never reached us — most often because a reconnect
- * dropped the event mid-stream. Triggered from {@link CollabGuestLink}'s
- * `state` reconciler when the host reports `isStreaming === false`:
+ * dropped the event mid-stream. Reached via {@link reconcileGuestSnapshotHostState}
+ * (the live `state`-frame and welcome/resync reconciler) when the host reports `isStreaming === false`:
  * folds the in-flight active-time window into the per-session meter (so
  * `time_spent` stops ticking) and stops the `Working…` loader if one is
  * still animating. No-op when the host is still streaming.
@@ -112,11 +112,20 @@ export function reconcileGuestIdleHostState(ctx: GuestIdleReconcilerCtx, isStrea
 /** Reconcile a welcome/resync snapshot's host activity state into the guest meter. */
 export interface GuestSnapshotActivityReconcilerCtx extends GuestIdleReconcilerCtx {
 	statusLine: GuestIdleReconcilerCtx["statusLine"] & { markActivityStart: () => void };
+	/**
+	 * Start (or re-attach) the live "Working…" loader. Mirrors
+	 * `InteractiveModeContext.ensureLoadingAnimation`, which is what
+	 * `EventController` calls on `agent_start`. Required so a guest that
+	 * missed an earlier `agent_start` (a reconnect dropped it mid-stream)
+	 * starts its spinner when the host later reports it is streaming.
+	 */
+	ensureLoadingAnimation: () => void;
 }
 
 export function reconcileGuestSnapshotHostState(ctx: GuestSnapshotActivityReconcilerCtx, isStreaming: boolean): void {
 	if (isStreaming) {
 		ctx.statusLine.markActivityStart();
+		ctx.ensureLoadingAnimation();
 		return;
 	}
 	reconcileGuestIdleHostState(ctx, false);
@@ -482,7 +491,7 @@ export class CollabGuestLink {
 				this.#applyHostState(frame.state);
 				setSessionTerminalTitle(frame.state.sessionName, frame.state.cwd);
 				this.#updateStatusSegment();
-				reconcileGuestIdleHostState(this.#ctx, frame.state.isStreaming);
+				reconcileGuestSnapshotHostState(this.#ctx, frame.state.isStreaming);
 				this.#ctx.statusLine.invalidate();
 				this.#ctx.ui.requestRender();
 				break;

--- a/packages/coding-agent/test/collab/guest-idle-reconciler.test.ts
+++ b/packages/coding-agent/test/collab/guest-idle-reconciler.test.ts
@@ -131,13 +131,34 @@ describe("reconcileGuestSnapshotHostState", () => {
 		now += 5_000;
 		expect(statusLine.getActiveMs()).toBe(5_000);
 
+		const ensureLoadingAnimation = mock(() => {});
 		const ctx: GuestSnapshotActivityReconcilerCtx = {
 			statusLine,
 			loadingAnimation: undefined,
+			ensureLoadingAnimation,
 		};
 		reconcileGuestSnapshotHostState(ctx, false);
 		const stoppedAt = statusLine.getActiveMs();
 		now += 60_000;
 		expect(statusLine.getActiveMs()).toBe(stoppedAt);
+		expect(ensureLoadingAnimation).not.toHaveBeenCalled();
+	});
+
+	it("starts the working loader when a state frame reports the host streaming", () => {
+		// Regression (F4): a guest that missed the earlier `agent_start` — most
+		// often a reconnect dropped it mid-stream — showed no spinner while the
+		// host kept working, so the loader vanished mid-turn. The host builds
+		// its `state` frame at fire time, so `isStreaming` is never stale here.
+		const statusLine = new StatusLineComponent(makeSession());
+		const markActivityStart = vi.spyOn(statusLine, "markActivityStart");
+		const ensureLoadingAnimation = mock(() => {});
+		const ctx: GuestSnapshotActivityReconcilerCtx = {
+			statusLine,
+			loadingAnimation: undefined,
+			ensureLoadingAnimation,
+		};
+		reconcileGuestSnapshotHostState(ctx, true);
+		expect(markActivityStart).toHaveBeenCalledTimes(1);
+		expect(ensureLoadingAnimation).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/collab/guest-idle-reconciler.test.ts
+++ b/packages/coding-agent/test/collab/guest-idle-reconciler.test.ts
@@ -13,6 +13,7 @@
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it, type Mock, mock, vi } from "bun:test";
 import {
+	clearGuestTransientStatus,
 	type GuestIdleReconcilerCtx,
 	type GuestSnapshotActivityReconcilerCtx,
 	reconcileGuestIdleHostState,
@@ -136,6 +137,8 @@ describe("reconcileGuestSnapshotHostState", () => {
 			statusLine,
 			loadingAnimation: undefined,
 			ensureLoadingAnimation,
+			autoCompactionLoader: undefined,
+			retryLoader: undefined,
 		};
 		reconcileGuestSnapshotHostState(ctx, false);
 		const stoppedAt = statusLine.getActiveMs();
@@ -144,7 +147,7 @@ describe("reconcileGuestSnapshotHostState", () => {
 		expect(ensureLoadingAnimation).not.toHaveBeenCalled();
 	});
 
-	it("starts the working loader when a state frame reports the host streaming", () => {
+	it("starts the working loader for a streaming snapshot when no maintenance loader is active", () => {
 		// Regression (F4): a guest that missed the earlier `agent_start` — most
 		// often a reconnect dropped it mid-stream — showed no spinner while the
 		// host kept working, so the loader vanished mid-turn. The host builds
@@ -156,9 +159,67 @@ describe("reconcileGuestSnapshotHostState", () => {
 			statusLine,
 			loadingAnimation: undefined,
 			ensureLoadingAnimation,
+			autoCompactionLoader: undefined,
+			retryLoader: undefined,
 		};
 		reconcileGuestSnapshotHostState(ctx, true);
 		expect(markActivityStart).toHaveBeenCalledTimes(1);
 		expect(ensureLoadingAnimation).toHaveBeenCalledTimes(1);
+	});
+
+	it("restores an owned working loader when a streaming resync clears a maintenance loader", () => {
+		const staleStop = mock(() => {});
+		const visibleChildren: object[] = [];
+		const staleMaintenanceLoader = { stop: staleStop };
+		visibleChildren.push(staleMaintenanceLoader);
+		const workingLoader = { stop: mock(() => {}) };
+		const ensureLoadingAnimation = mock(() => {
+			ctx.loadingAnimation = workingLoader;
+			visibleChildren.push(workingLoader);
+		});
+		const ctx: GuestSnapshotActivityReconcilerCtx & { statusContainer: { clear: () => void } } = {
+			statusLine: new StatusLineComponent(makeSession()),
+			statusContainer: { clear: () => visibleChildren.splice(0) },
+			loadingAnimation: undefined,
+			ensureLoadingAnimation,
+			autoCompactionLoader:
+				staleMaintenanceLoader as unknown as GuestSnapshotActivityReconcilerCtx["autoCompactionLoader"],
+			retryLoader: undefined,
+		};
+
+		clearGuestTransientStatus(ctx);
+		reconcileGuestSnapshotHostState(ctx, true);
+
+		expect(staleStop).toHaveBeenCalledTimes(1);
+		expect(ctx.autoCompactionLoader).toBeUndefined();
+		expect(ctx.retryLoader).toBeUndefined();
+		expect(ensureLoadingAnimation).toHaveBeenCalledTimes(1);
+		expect(visibleChildren).toEqual([workingLoader]);
+	});
+
+	it("does not start the working loader while a retry loader owns the status area", () => {
+		const ensureLoadingAnimation = mock(() => {});
+		const ctx: GuestSnapshotActivityReconcilerCtx = {
+			statusLine: new StatusLineComponent(makeSession()),
+			loadingAnimation: undefined,
+			ensureLoadingAnimation,
+			autoCompactionLoader: undefined,
+			retryLoader: {} as GuestSnapshotActivityReconcilerCtx["retryLoader"],
+		};
+		reconcileGuestSnapshotHostState(ctx, true);
+		expect(ensureLoadingAnimation).not.toHaveBeenCalled();
+	});
+
+	it("does not start the working loader while an auto-compaction loader owns the status area", () => {
+		const ensureLoadingAnimation = mock(() => {});
+		const ctx: GuestSnapshotActivityReconcilerCtx = {
+			statusLine: new StatusLineComponent(makeSession()),
+			loadingAnimation: undefined,
+			ensureLoadingAnimation,
+			autoCompactionLoader: {} as GuestSnapshotActivityReconcilerCtx["autoCompactionLoader"],
+			retryLoader: undefined,
+		};
+		reconcileGuestSnapshotHostState(ctx, true);
+		expect(ensureLoadingAnimation).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Symptom

The TUI collab guest has the same stuck-idle hole as the web guest (companion PR): joining or reconnecting mid-turn shows no spinner while the host agent is running.

## Root cause (verified)

`reconcileGuestIdleHostState` opens with `if (isStreaming) return;` and only ever stops the loader (`packages/coding-agent/src/collab/guest.ts:103-110`) — and it is what ran on every `state` frame (`guest.ts:485`). Its own docstring names the failure: "an earlier `agent_start` whose matching `agent_end` never reached us — most often because a reconnect dropped the event mid-stream". Only the welcome/resync path was bidirectional, and even that path never started a loader.

## Fix

- `GuestSnapshotActivityReconcilerCtx` gains `ensureLoadingAnimation: () => void`, wired to the existing `InteractiveModeContext.ensureLoadingAnimation` (what `EventController` calls on `agent_start` — no new loader invented).
- `reconcileGuestSnapshotHostState`'s streaming branch calls it after `markActivityStart()`.
- The `state`-frame callsite now routes through `reconcileGuestSnapshotHostState`, so every state frame reconciles both directions. `reconcileGuestIdleHostState` is unchanged (still used by the snapshot reconciler; exported for unit testing).

## Verification

`packages/coding-agent/test/collab/guest-idle-reconciler.test.ts` extended: `state{isStreaming:true}` → loader started (and the idle case asserts the loader is NOT started). 6 pass.