### PR TITLE
fix(coding-agent): bound effective session metadata

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Exported `TokenizerMode` and `getTokenizerMode()` so consumers can snapshot the tokenizer mode used for session metadata.
+
 ## [17.2.6] - 2026-08-03
 
 ### Fixed

--- a/packages/agent/src/tokenizer.ts
+++ b/packages/agent/src/tokenizer.ts
@@ -2,6 +2,12 @@ import { countTokens as countTokensNat } from "@oh-my-pi/pi-natives";
 
 const accurate = process.env.PI_TOKENIZER_ACCURATE === "1" && Bun.env.NODE_ENV !== "test";
 
+export type TokenizerMode = "accurate" | "estimate";
+
+export function getTokenizerMode(): TokenizerMode {
+	return accurate ? "accurate" : "estimate";
+}
+
 function estimateTokens(text: string) {
 	return (Buffer.byteLength(text, "utf-8") + 3) >> 2;
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed provider session metadata disclosure by recording only bounded effective compaction and tokenizer settings while preserving session identity; raw config paths are excluded.
+- Fixed pending idle compaction firing against a stale idle gate: changing `compaction.idleEnabled` or `compaction.idleThresholdTokens` while the idle timer is armed is now honored when the timer fires, and the request reports the threshold that actually triggered it.
+
 ## [17.2.6] - 2026-08-03
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -25,6 +25,7 @@ import type { InteractiveModeContext, TodoPhase } from "../../modes/types";
 import idleRecapPrompt from "../../prompts/system/recap-user.md" with { type: "text" };
 import type { AgentSessionEvent } from "../../session/agent-session";
 import { isSilentAbort, readQueueChipText, resolveAbortLabel } from "../../session/messages";
+import { buildEffectiveIdleThreshold } from "../../session/session-metadata";
 import { type ApprovalMode, resolveApproval } from "../../tools/approval";
 import { previewLine, TRUNCATE_LENGTHS } from "../../tools/render-utils";
 import { PROPOSE_DEVICE_NAME, writeDeviceDispatch } from "../../tools/resolve";
@@ -1845,8 +1846,21 @@ export class EventController {
 			if (this.ctx.viewSession.isStreaming) return;
 			if (this.ctx.viewSession.isCompacting) return;
 			if (this.ctx.editor.getText().trim()) return;
-			if (this.#currentContextTokens() < threshold) return;
-			void this.ctx.viewSession.runIdleCompaction();
+			// The idle gate itself is mutable: `compaction.idleEnabled` and
+			// `idleThresholdTokens` can change while this timer is pending, and the
+			// values captured at arm time are what the callback would otherwise fire
+			// on. Firing on a stale gate would run idle compaction the user has since
+			// turned off, or trigger on a threshold no longer in force — which the
+			// request then reports as whatever the settings say at metadata time, a
+			// threshold that never fired. Re-resolve the gate here so the policy that
+			// authorizes the run is the one that governs it.
+			const armed = buildEffectiveIdleThreshold(settings);
+			if (!armed.enabled || armed.thresholdTokens <= 0) return;
+			if (this.#currentContextTokens() < armed.thresholdTokens) return;
+			// Hand the run the exact threshold that cleared it, rather than letting
+			// the compaction path re-read settings that can change again while it is
+			// in flight.
+			void this.ctx.viewSession.runIdleCompaction({ idleThreshold: armed });
 		}, timeoutMs);
 		this.#idleCompactionTimer.unref?.();
 	}

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -24,6 +24,7 @@ import type { AsyncJob, AsyncJobDeliveryState, AsyncJobManager } from "../async"
 import type { ModelRegistry } from "../config/model-registry";
 import type { PromptTemplate } from "../config/prompt-templates";
 import type { Settings, SkillsSettings } from "../config/settings";
+import type { SettingValue } from "../config/settings-schema";
 import type { CursorMcpResourceAdapter } from "../cursor";
 import type { RawSseDebugBuffer } from "../debug/raw-sse-buffer";
 import type { TtsrManager } from "../export/ttsr";
@@ -37,6 +38,7 @@ import type { ConfiguredThinkingLevel } from "../thinking";
 import type { XdevState } from "../tools/xdev";
 import type { CodexAutoRedeemCoordinator } from "./codex-auto-reset";
 import type { SessionManager } from "./session-manager";
+import type { EffectiveIdleThreshold } from "./session-metadata";
 
 /** Maximum time the interactive shutdown path waits for Mnemopi consolidation. */
 export const SHUTDOWN_CONSOLIDATE_BUDGET_MS = 1_500;
@@ -311,6 +313,9 @@ export interface SessionHandoffOptions {
 	autoTriggered?: boolean;
 	signal?: AbortSignal;
 	onSwitchCancelled?: () => void;
+	metadataCompactionStrategy?: SettingValue<"compaction.strategy">;
+	/** Idle threshold policy to report when the idle timer triggered this handoff. */
+	metadataIdleThreshold?: EffectiveIdleThreshold;
 }
 
 /** Result from cycleModel(). */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -37,6 +37,7 @@ import {
 	type AsideMessage,
 	type BeforeToolCallContext,
 	type BeforeToolCallResult,
+	getTokenizerMode,
 	resolveTelemetry,
 	type StreamFn,
 	TERMINAL_TOOL_RESULT_ABORT_REASON,
@@ -327,7 +328,7 @@ import {
 } from "./session-maintenance";
 import { cleanupEmptyMoveSession, type SessionManager } from "./session-manager";
 import { SessionMemory, type SessionMemoryHost } from "./session-memory";
-import { buildSessionMetadata } from "./session-metadata";
+import { buildEffectiveSessionProfile, buildSessionMetadata, type EffectiveIdleThreshold } from "./session-metadata";
 import { SessionProviderBoundary, type SessionProviderBoundaryHost } from "./session-provider-boundary";
 import { SessionStatsTracker, type SessionStatsTrackerHost } from "./session-stats";
 import { SessionTools, type SessionToolsHost } from "./session-tools";
@@ -3517,9 +3518,20 @@ export class AgentSession {
 		}
 		const sid = this.#activeProviderSessionId(sessionId);
 		this.agent.sessionId = sid;
-		this.agent.setMetadataResolver((provider: string) =>
-			buildSessionMetadata(sid, provider, this.#modelRegistry.authStorage),
-		);
+		this.agent.setMetadataResolver((provider: string) => {
+			const model = this.model;
+			return buildSessionMetadata(
+				sid,
+				provider,
+				this.#modelRegistry.authStorage,
+				buildEffectiveSessionProfile(
+					this.settings,
+					getTokenizerMode(),
+					model?.contextWindow ?? 0,
+					model ? model.input.includes("image") : true,
+				),
+			);
+		});
 		// Restore the session's recorded provider accounts before the first
 		// request routes: sticky rows are process-local under a remote auth
 		// broker, and losing them re-ranks onto a different account, cold-missing
@@ -4378,9 +4390,15 @@ export class AgentSession {
 		this.#maintenance.abortCompaction();
 	}
 
-	/** Trigger idle compaction through the automatic maintenance flow. */
-	async runIdleCompaction(): Promise<void> {
-		await this.#maintenance.runIdleCompaction();
+	/**
+	 * Trigger idle compaction through the automatic maintenance flow.
+	 *
+	 * `idleThreshold` carries the gate the idle timer validated as it fired, so
+	 * the request reports the threshold that actually triggered it even if
+	 * settings change while the compaction runs.
+	 */
+	async runIdleCompaction(options: { idleThreshold?: EffectiveIdleThreshold } = {}): Promise<void> {
+		await this.#maintenance.runIdleCompaction(options);
 	}
 
 	/** Toggle automatic compaction. */

--- a/packages/coding-agent/src/session/compaction-strategy.ts
+++ b/packages/coding-agent/src/session/compaction-strategy.ts
@@ -1,0 +1,9 @@
+import { getEnumValues, type SettingValue } from "../config/settings-schema";
+
+export function resolveCompactionStrategy(enabled: boolean, strategy: unknown): SettingValue<"compaction.strategy"> {
+	if (!enabled) return "off";
+	const values = getEnumValues("compaction.strategy");
+	return typeof strategy === "string" && values?.some(value => value === strategy)
+		? (strategy as SettingValue<"compaction.strategy">)
+		: "context-full";
+}

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -6,6 +6,7 @@ import {
 	AppendOnlyContextManager,
 	type CompactionSummaryMessage,
 	countTokens,
+	getTokenizerMode,
 	resolveTelemetry,
 	type StreamFn,
 	ThinkingLevel,
@@ -96,7 +97,7 @@ import { formatSessionDumpText } from "./session-dump-format";
 import type { CompactionEntry, SessionEntry } from "./session-entries";
 import { formatSessionHistoryMarkdown } from "./session-history-format";
 import type { SessionManager } from "./session-manager";
-import { buildSessionMetadata } from "./session-metadata";
+import { buildEffectiveSessionProfile, buildSessionMetadata } from "./session-metadata";
 import type { YieldQueue } from "./yield-queue";
 
 const ADVISOR_CODEX_SSE_MAX_ATTEMPTS = 1;
@@ -494,7 +495,20 @@ export class SessionAdvisors {
 		advisor.agent.getApiKey = requestModel => this.#host.modelRegistry.resolver(requestModel, providerSessionId);
 		advisor.agent.setMetadataResolver(
 			providerSessionId
-				? provider => buildSessionMetadata(providerSessionId, provider, this.#host.modelRegistry.authStorage)
+				? provider => {
+						const model = advisor.agent.state.model;
+						return buildSessionMetadata(
+							providerSessionId,
+							provider,
+							this.#host.modelRegistry.authStorage,
+							buildEffectiveSessionProfile(
+								this.#host.settings,
+								getTokenizerMode(),
+								model?.contextWindow ?? 0,
+								model ? model.input.includes("image") : true,
+							),
+						);
+					}
 				: undefined,
 		);
 
@@ -1337,6 +1351,15 @@ export class SessionAdvisors {
 			return false;
 		}
 
+		// The window whose threshold actually armed this run, carried forward to the
+		// summarization request's `profile.t`. The gate above fires on the advisor's
+		// own window, and a promotion re-arms it on the promoted window; the
+		// summarization candidate resolved below is a *different* model — often the
+		// largest-context fallback — whose window gates nothing here. Recomputing the
+		// threshold from that candidate reports one that never fired (a 200k advisor
+		// summarized by a 1m fallback would record ~800k where ~160k triggered).
+		let governingContextWindow = contextWindow;
+
 		// 1. Try promotion first
 		if (await this.#promoteAdvisorContextModel(advisor, advisorModel, signal)) {
 			// Promotion succeeded, check if new model has enough space
@@ -1345,6 +1368,8 @@ export class SessionAdvisors {
 			if (newWindow > 0) {
 				const stillNeedsCompaction = shouldCompact(contextTokens, newWindow, compactionSettings);
 				if (!stillNeedsCompaction) return false;
+				// Promotion re-armed the gate on the promoted model, so it now governs.
+				governingContextWindow = newWindow;
 			}
 		}
 
@@ -1433,8 +1458,19 @@ export class SessionAdvisors {
 			// after the session-sticky credential is selected) so summarization
 			// requests carry the advisor session id like every other advisor call
 			// (issue #6625).
+			// `t` reports the governing advisor threshold captured above, not this
+			// candidate's; `s` reports the action this request performs, and the
+			// image-input argument therefore describes the candidate that performs it.
 			const advisorMetadata = advisorProviderSessionId
-				? buildSessionMetadata(advisorProviderSessionId, candidate.provider, this.#host.modelRegistry.authStorage)
+				? buildSessionMetadata(advisorProviderSessionId, candidate.provider, this.#host.modelRegistry.authStorage, {
+						...buildEffectiveSessionProfile(
+							this.#host.settings,
+							getTokenizerMode(),
+							governingContextWindow,
+							candidate.input.includes("image"),
+						),
+						strategy: "context-full",
+					})
 				: undefined;
 			try {
 				compactResult = await compact(

--- a/packages/coding-agent/src/session/session-handoff.ts
+++ b/packages/coding-agent/src/session/session-handoff.ts
@@ -19,6 +19,7 @@ import type { HandoffResult, SessionHandoffOptions } from "./agent-session-types
 import type { BashSessionTransition } from "./bash-runner";
 import type { SessionContext } from "./session-context";
 import type { SessionManager } from "./session-manager";
+import { overrideSessionMetadataCompactionStrategy } from "./session-metadata";
 
 function createHandoffContext(document: string): string {
 	return `<handoff-context>\n${document}\n</handoff-context>\n\nThe above is a handoff document from a previous session. Use this context to continue the work seamlessly.`;
@@ -185,6 +186,11 @@ export class SessionHandoff {
 					hideThinkingSummary: this.#host.agent.hideThinkingSummary,
 					initiatorOverride: "agent",
 					signal: handoffSignal,
+					metadata: overrideSessionMetadataCompactionStrategy(
+						this.#host.agent.metadataForProvider(model.provider),
+						options?.metadataCompactionStrategy ?? "handoff",
+						options?.metadataIdleThreshold,
+					),
 				},
 				model.provider,
 			);

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -68,6 +68,7 @@ import type { ConfiguredThinkingLevel } from "../thinking";
 import type { AgentSessionEvent } from "./agent-session-events";
 import type { ContextUsageBreakdown, HandoffResult, SessionHandoffOptions } from "./agent-session-types";
 import { findCompactMode } from "./compact-modes";
+import { resolveCompactionStrategy } from "./compaction-strategy";
 import { convertToLlm, stripImagesFromMessage } from "./messages";
 import { isTerminalTextAssistantAnswer } from "./queued-messages";
 import {
@@ -79,6 +80,11 @@ import type { SessionContext } from "./session-context";
 import { getLatestCompactionEntry, getOpenAiRemoteCompactionPayload } from "./session-context";
 import type { CompactionEntry, SessionEntry } from "./session-entries";
 import type { SessionManager } from "./session-manager";
+import {
+	buildEffectiveIdleThreshold,
+	type EffectiveIdleThreshold,
+	overrideSessionMetadataCompactionStrategy,
+} from "./session-metadata";
 import type { ShakeMode, ShakeResult } from "./shake-types";
 
 export type CompactionCheckResult = Readonly<{
@@ -970,10 +976,18 @@ export class SessionMaintenance {
 		this.#autoCompactionAbortController?.abort();
 	}
 
-	/** Trigger idle compaction through the auto-compaction flow (with UI events). */
-	async runIdleCompaction(): Promise<void> {
+	/**
+	 * Trigger idle compaction through the auto-compaction flow (with UI events).
+	 *
+	 * `idleThreshold` is the gate the caller validated immediately before firing —
+	 * the idle timer owns that policy, and settings can change again while this
+	 * run is in flight. Passing it keeps the request's reported threshold the one
+	 * that actually triggered it. Omitted, the current settings are resolved
+	 * instead, which is right for callers that trigger idle compaction directly.
+	 */
+	async runIdleCompaction(options: { idleThreshold?: EffectiveIdleThreshold } = {}): Promise<void> {
 		if (this.#host.isStreaming() || this.isCompacting) return;
-		await this.runAutoCompaction("idle", false, true);
+		await this.runAutoCompaction("idle", false, true, true, { idleThreshold: options.idleThreshold });
 	}
 
 	/**
@@ -1564,7 +1578,10 @@ export class SessionMaintenance {
 					signal,
 					{
 						...options,
-						metadata: this.#host.agent.metadataForProvider(candidate.provider),
+						metadata: overrideSessionMetadataCompactionStrategy(
+							this.#host.agent.metadataForProvider(candidate.provider),
+							"context-full",
+						),
 						convertToLlm: messages => this.#host.convertToLlmForSideRequest(messages),
 						telemetry,
 						// Honor the user's /model thinking selection (incl. `off`) on
@@ -2142,11 +2159,24 @@ export class SessionMaintenance {
 			suppressHandoff?: boolean;
 			phase?: CodexCompactionContext["phase"];
 			terminalTextAnswer?: boolean;
+			idleThreshold?: EffectiveIdleThreshold;
 		} = {},
 	): Promise<CompactionCheckResult> {
 		const compactionSettings = this.#host.settings.getGroup("compaction");
-		if (compactionSettings.strategy === "off") return COMPACTION_CHECK_NONE;
+		const compactionStrategy = resolveCompactionStrategy(
+			reason === "idle" || compactionSettings.enabled,
+			compactionSettings.strategy,
+		);
+		if (compactionStrategy === "off") return COMPACTION_CHECK_NONE;
 		if (reason !== "idle" && !compactionSettings.enabled) return COMPACTION_CHECK_NONE;
+		// The idle timer fires on compaction.idleThresholdTokens behind its own
+		// enable gate, so idle requests must report that threshold rather than the
+		// normal compaction.threshold* policy the session profile records. Prefer
+		// the gate the idle timer validated when it fired: settings can change
+		// between arming the timer and building this request, and re-reading them
+		// here would report a threshold that never triggered the run.
+		const metadataIdleThreshold =
+			reason === "idle" ? (options.idleThreshold ?? buildEffectiveIdleThreshold(this.#host.settings)) : undefined;
 		const generation = this.#host.promptGeneration();
 		const terminalTextAnswer =
 			options.terminalTextAnswer ?? isTerminalTextAssistantAnswer(this.#host.findLastAssistantMessage());
@@ -2158,7 +2188,7 @@ export class SessionMaintenance {
 		// Shake runs inline (cheap, no remote LLM). On overflow recovery, if shake
 		// reclaims nothing we fall through to the summary-compaction body below so
 		// the oversized input still gets resolved.
-		if (compactionSettings.strategy === "shake") {
+		if (compactionStrategy === "shake") {
 			const outcome = await this.#runAutoShake(
 				reason,
 				willRetry,
@@ -2181,7 +2211,7 @@ export class SessionMaintenance {
 			reason !== "overflow" &&
 			reason !== "incomplete" &&
 			reason !== "idle" &&
-			compactionSettings.strategy === "handoff"
+			compactionStrategy === "handoff"
 		) {
 			this.#host.schedulePostPromptTask(
 				async signal => {
@@ -2204,9 +2234,9 @@ export class SessionMaintenance {
 		// LLM call would hit the same overflow. "incomplete" is an output-side problem,
 		// so a handoff request on the existing context is still viable.
 		let action: "context-full" | "handoff" | "snapcompact" =
-			compactionSettings.strategy === "snapcompact"
+			compactionStrategy === "snapcompact"
 				? "snapcompact"
-				: compactionSettings.strategy === "handoff" && reason !== "overflow" && !suppressHandoff
+				: compactionStrategy === "handoff" && reason !== "overflow" && !suppressHandoff
 					? "handoff"
 					: "context-full";
 		if (action === "snapcompact" && this.#model && !this.#model.input.includes("image")) {
@@ -2235,6 +2265,8 @@ export class SessionMaintenance {
 				const handoffResult = await this.#host.runHandoff(handoffFocus, {
 					autoTriggered: true,
 					signal: autoCompactionSignal,
+					metadataCompactionStrategy: compactionStrategy,
+					metadataIdleThreshold,
 					onSwitchCancelled: () => {
 						handoffSwitchCancelled = true;
 					},
@@ -2610,7 +2642,11 @@ export class SessionMaintenance {
 									promptOverride: this.#host.obfuscateTextForProvider(compactionPrep.hookPrompt),
 									extraContext: compactionPrep.hookContext,
 									remoteInstructions: this.#host.baseSystemPrompt().join("\n\n"),
-									metadata: this.#host.agent.metadataForProvider(candidate.provider),
+									metadata: overrideSessionMetadataCompactionStrategy(
+										this.#host.agent.metadataForProvider(candidate.provider),
+										"context-full",
+										metadataIdleThreshold,
+									),
 									initiatorOverride: "agent",
 									convertToLlm: messages => this.#host.convertToLlmForSideRequest(messages),
 									telemetry,

--- a/packages/coding-agent/src/session/session-metadata.ts
+++ b/packages/coding-agent/src/session/session-metadata.ts
@@ -1,6 +1,163 @@
+import { resolveThresholdTokens, type TokenizerMode } from "@oh-my-pi/pi-agent-core";
 import { deriveClaudeDeviceId } from "@oh-my-pi/pi-ai";
 import { getInstallId } from "@oh-my-pi/pi-utils";
+import type { Settings } from "../config/settings";
+import type { SettingValue } from "../config/settings-schema";
 import type { AuthStorage } from "./auth-storage";
+import { resolveCompactionStrategy } from "./compaction-strategy";
+
+export interface EffectiveSessionProfile {
+	thresholdTokens: number;
+	strategy: SettingValue<"compaction.strategy">;
+	tokenizerMode: TokenizerMode;
+}
+
+/**
+ * Effective threshold policy for requests the idle compaction timer triggers.
+ *
+ * Idle compaction has its own gate and its own token count
+ * (`compaction.idleEnabled` / `compaction.idleThresholdTokens`, applied by
+ * `#scheduleIdleCompaction`) and still runs when `compaction.enabled` is false,
+ * so an idle-triggered request is never governed by the normal
+ * `compaction.threshold*` policy that {@link EffectiveSessionProfile} records.
+ */
+export interface EffectiveIdleThreshold {
+	/** Whether the idle threshold is in force for this session at all. */
+	enabled: boolean;
+	/** Token count above which idle compaction triggers; 0 when unconfigured. */
+	thresholdTokens: number;
+}
+
+const MAX_METADATA_USER_ID_LENGTH = 256;
+
+function serializeBoundedUserId(userId: Record<string, unknown>): string {
+	let serialized = JSON.stringify(userId);
+	if (serialized.length <= MAX_METADATA_USER_ID_LENGTH) return serialized;
+
+	delete userId.profile;
+	serialized = JSON.stringify(userId);
+	if (serialized.length <= MAX_METADATA_USER_ID_LENGTH) return serialized;
+
+	const sessionId = String(userId.session_id);
+	for (const key of ["device_id", "account_uuid"]) {
+		const candidate = { ...userId };
+		delete candidate[key];
+		if (JSON.stringify(candidate).length <= MAX_METADATA_USER_ID_LENGTH) return JSON.stringify(candidate);
+	}
+
+	for (const key of ["device_id", "account_uuid"]) {
+		userId.session_id = "";
+		if (JSON.stringify(userId).length <= MAX_METADATA_USER_ID_LENGTH) {
+			userId.session_id = sessionId;
+			break;
+		}
+		delete userId[key];
+	}
+	userId.session_id = sessionId;
+
+	const sessionIdSuffix = `-${Bun.hash(sessionId).toString(16).padStart(16, "0")}`;
+	const serializeSessionId = (length: number): string => {
+		userId.session_id = `${sessionId.slice(0, length)}${sessionIdSuffix}`;
+		return JSON.stringify(userId);
+	};
+	serialized = serializeSessionId(0);
+	if (serialized.length > MAX_METADATA_USER_ID_LENGTH) {
+		for (const key of ["device_id", "account_uuid"]) {
+			delete userId[key];
+			serialized = serializeSessionId(0);
+			if (serialized.length <= MAX_METADATA_USER_ID_LENGTH) break;
+		}
+	}
+
+	let low = 0;
+	let high = sessionId.length;
+	while (low < high) {
+		const candidateLength = Math.ceil((low + high) / 2);
+		serialized = serializeSessionId(candidateLength);
+		if (serialized.length <= MAX_METADATA_USER_ID_LENGTH) {
+			low = candidateLength;
+		} else {
+			high = candidateLength - 1;
+		}
+	}
+	serialized = serializeSessionId(low);
+	return serialized;
+}
+
+function resolveProfileCompactionStrategy(
+	settings: Pick<Settings, "get">,
+	imageInputSupported: boolean,
+): SettingValue<"compaction.strategy"> {
+	const strategy = resolveCompactionStrategy(settings.get("compaction.enabled"), settings.get("compaction.strategy"));
+	return strategy === "snapcompact" && !imageInputSupported ? "context-full" : strategy;
+}
+
+export function buildEffectiveSessionProfile(
+	settings: Pick<Settings, "get" | "getGroup">,
+	tokenizerMode: TokenizerMode,
+	contextWindow: number,
+	imageInputSupported = true,
+): EffectiveSessionProfile {
+	const strategy = resolveProfileCompactionStrategy(settings, imageInputSupported);
+	return {
+		thresholdTokens: strategy === "off" ? 0 : resolveThresholdTokens(contextWindow, settings.getGroup("compaction")),
+		strategy,
+		tokenizerMode,
+	};
+}
+
+export function buildEffectiveIdleThreshold(settings: Pick<Settings, "getGroup">): EffectiveIdleThreshold {
+	const { idleEnabled, idleThresholdTokens } = settings.getGroup("compaction");
+	// The idle timer compares usage against the configured count directly — no
+	// context-window clamp and no reserve — so the raw value is the policy.
+	return {
+		enabled: idleEnabled,
+		thresholdTokens: Number.isFinite(idleThresholdTokens) && idleThresholdTokens > 0 ? idleThresholdTokens : 0,
+	};
+}
+
+/**
+ * Relabel the profile a live request already carries with the compaction policy
+ * that actually governs that request.
+ *
+ * `strategy` is the action the request performs, which can differ from the
+ * session's configured strategy: an auto-handoff that fell back to a
+ * context-full summary, or idle compaction running while `compaction.enabled` is
+ * false and the profile therefore reports `off`.
+ *
+ * `idleThreshold` additionally relabels the threshold for idle-triggered
+ * requests, which fire on `compaction.idleThresholdTokens`. Leaving the normal
+ * `compaction.threshold*` value in place would attribute them to a threshold
+ * that did not fire — and, with `compaction.enabled` false, to one that is not in
+ * force at all. A disabled idle gate reports `0`, distinguishing "no threshold
+ * governs this request" from "the threshold is N". Omit it for ordinary
+ * compaction, whose profile already records the threshold that governs it.
+ */
+export function overrideSessionMetadataCompactionStrategy(
+	metadata: Record<string, unknown> | undefined,
+	strategy: SettingValue<"compaction.strategy">,
+	idleThreshold?: EffectiveIdleThreshold,
+): Record<string, unknown> | undefined {
+	if (typeof metadata?.user_id !== "string") return metadata;
+	try {
+		const userId: unknown = JSON.parse(metadata.user_id);
+		if (typeof userId !== "object" || userId === null || Array.isArray(userId)) return metadata;
+		const profile = "profile" in userId ? userId.profile : undefined;
+		if (typeof profile !== "object" || profile === null || Array.isArray(profile)) return metadata;
+		const thresholdOverride = idleThreshold
+			? { t: idleThreshold.enabled ? idleThreshold.thresholdTokens : 0 }
+			: undefined;
+		return {
+			...metadata,
+			user_id: serializeBoundedUserId({
+				...userId,
+				profile: { ...profile, ...thresholdOverride, s: strategy },
+			}),
+		};
+	} catch {
+		return metadata;
+	}
+}
 
 /**
  * Build the per-request `metadata` payload for the Anthropic provider, shaped
@@ -20,6 +177,8 @@ import type { AuthStorage } from "./auth-storage";
  *
  * `provider` is the target provider string (e.g. `"anthropic"`) and gates the
  * `account_uuid` and `device_id` lookups — only `"anthropic"` requests carry them.
+ * It also gates the 256-character `user_id` bounding, which is Anthropic's own
+ * limit: other providers forward the caller-supplied session id verbatim.
  *
  * `sessionId` is forwarded to the auth-storage session-sticky lookup so that
  * multi-credential setups attribute to the same OAuth account used for the
@@ -33,8 +192,16 @@ export function buildSessionMetadata(
 	sessionId: string,
 	provider: string,
 	authStorage: AuthStorage | undefined,
+	profile?: EffectiveSessionProfile,
 ): Record<string, unknown> {
-	const userId: Record<string, string> = { session_id: sessionId };
+	const userId: Record<string, unknown> = { session_id: sessionId };
+	if (provider === "anthropic" && profile) {
+		userId.profile = {
+			t: profile.thresholdTokens,
+			s: profile.strategy,
+			z: profile.tokenizerMode,
+		};
+	}
 	// Only look up account_uuid when the request is going to Anthropic. Injecting
 	// a Claude OAuth account_uuid into requests bound for other providers (including
 	// Anthropic-format-compatible proxies like cloudflare-ai-gateway or gitlab-duo)
@@ -49,5 +216,12 @@ export function buildSessionMetadata(
 			userId.device_id = deriveClaudeDeviceId(getInstallId(), accountUuid);
 		}
 	}
-	return { user_id: JSON.stringify(userId) };
+	// The 256-character cap is Anthropic's own `metadata.user_id` limit, so only
+	// Anthropic requests are bounded. Other providers receive this value as the
+	// caller-supplied session identity and key prompt affinity on it (in the
+	// Anthropic-format transports an explicit `metadata.user_id` takes precedence
+	// over the prompt-cache-key fallback), so truncating and hash-suffixing a long
+	// `--provider-session-id` there would both drop the identity the caller passed
+	// in full and rotate the affinity key of an already-warmed session on resume.
+	return { user_id: provider === "anthropic" ? serializeBoundedUserId(userId) : JSON.stringify(userId) };
 }

--- a/packages/coding-agent/test/advisor-context-maintenance.test.ts
+++ b/packages/coding-agent/test/advisor-context-maintenance.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
-import { Agent, type AgentMessage, type CompactionSummaryMessage, countTokens } from "@oh-my-pi/pi-agent-core";
+import {
+	Agent,
+	type AgentMessage,
+	type CompactionSummaryMessage,
+	countTokens,
+	getTokenizerMode,
+} from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import { calculateContextTokens, estimateTokens, resolveThresholdTokens } from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
@@ -17,6 +23,13 @@ const CONTEXT_WINDOW = 372_000;
 const CACHE_READ_TOKENS = 371_200;
 const INPUT_TOKENS = 200;
 const OUTPUT_TOKENS = 150;
+
+// Threshold-metadata fixtures. The three windows are deliberately distinct so an
+// 80% threshold maps each to its own `profile.t` (160k / 320k / 800k) and the
+// recorded value alone identifies which model it was derived from.
+const ACTIVE_ADVISOR_CONTEXT_WINDOW = 200_000;
+const PROMOTED_ADVISOR_CONTEXT_WINDOW = 400_000;
+const SUMMARIZER_CONTEXT_WINDOW = 1_000_000;
 
 interface MaintenanceHarness {
 	advisor: Agent;
@@ -179,6 +192,111 @@ describe("AgentSession advisor context maintenance", () => {
 			usageAnchor(advisorMock, Date.now() - 1_000),
 		);
 		return { advisor, apiKeySpy, crossProviderModel, nativeModel, sameProviderModel, settings };
+	}
+
+	/**
+	 * Advisor whose own window is far smaller than the largest-context fallback
+	 * `resolveCompactionModelCandidates` appends, so the threshold that arms
+	 * compaction and the summarizing candidate's threshold cannot be confused.
+	 * Passing `promotionContextWindow` additionally arms context promotion onto a
+	 * middle window, which re-arms the gate before compaction runs.
+	 */
+	function createAdvisorThresholdMetadataHarness(promotionContextWindow?: number) {
+		const primaryMock = createMockModel({
+			provider: "anthropic",
+			responses: [{ content: ["primary complete"] }],
+		});
+		const advisorMock = createMockModel({
+			id: "advisor-active",
+			provider: "anthropic",
+			contextWindow: ACTIVE_ADVISOR_CONTEXT_WINDOW,
+			responses: [{ content: ["advisor reviewed current update"] }],
+		});
+		// Never the active advisor model: it only summarizes, so its window gates
+		// nothing and must not reach `profile.t`.
+		const summarizerMock = createMockModel({
+			id: "advisor-compaction-summarizer",
+			provider: "anthropic",
+			contextWindow: SUMMARIZER_CONTEXT_WINDOW,
+			responses: [{ content: ["summarizer summary"] }],
+		});
+		const promotionMock =
+			promotionContextWindow === undefined
+				? undefined
+				: createMockModel({
+						id: "advisor-promotion-target",
+						provider: "anthropic",
+						contextWindow: promotionContextWindow,
+						responses: [{ content: ["promoted advisor output"] }],
+					});
+		if (promotionMock) {
+			Object.assign(advisorMock, { contextPromotionTarget: `${promotionMock.provider}/${promotionMock.id}` });
+		}
+
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const settings = Settings.isolated({
+			"advisor.syncBacklog": "1",
+			"compaction.enabled": true,
+			"compaction.strategy": "context-full",
+			// Percentage thresholds scale with the window, unlike a fixed token count
+			// that would collapse to the same value for every candidate.
+			"compaction.thresholdTokens": -1,
+			"compaction.thresholdPercent": 80,
+			"contextPromotion.enabled": promotionMock !== undefined,
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: primaryMock, systemPrompt: [], tools: [] },
+			streamFn: primaryMock.stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: advisorMock.stream,
+		});
+		settings.setModelRole("advisor", "anthropic/claude-sonnet-4-5");
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		const advisor = session.getAdvisorAgent();
+		if (!advisor?.sessionId) throw new Error("Expected advisor agent with a provider session id");
+		advisor.setModel(advisorMock);
+		vi.spyOn(modelRegistry, "getApiKey").mockResolvedValue("test-key");
+		vi.spyOn(modelRegistry, "getAvailable").mockReturnValue(
+			promotionMock ? [advisorMock, promotionMock, summarizerMock] : [advisorMock, summarizerMock],
+		);
+		// Two accumulated turns so compaction has older history to summarize, and
+		// enough provider usage (371,550 tokens) to clear every threshold below.
+		advisor.state.messages.push(
+			usageAnchor(advisorMock, Date.now() - 2_000),
+			usageAnchor(advisorMock, Date.now() - 1_000),
+		);
+		return { advisor, advisorMock, promotionMock, settings, summarizerMock };
+	}
+
+	/** The `profile` block a summarization request carries in `metadata.user_id`. */
+	function compactionProfile(metadata: Record<string, unknown> | undefined): Record<string, unknown> {
+		const userId = metadata?.user_id;
+		if (typeof userId !== "string") throw new Error("Expected advisor compaction metadata.user_id");
+		const { profile } = JSON.parse(userId) as { profile?: Record<string, unknown> };
+		if (!profile) throw new Error("Expected advisor compaction metadata profile");
+		return profile;
+	}
+
+	/** Fails every candidate but the summarizer, forcing the fallback to run. */
+	function summarizeOnFallback(activeAdvisorModelId: string) {
+		return vi.spyOn(compactionModule, "compact").mockImplementation(async (preparation, model) => {
+			if (model.id === activeAdvisorModelId) {
+				throw new Error("advisor-model summarization unavailable");
+			}
+			return {
+				summary: "summarizer summary",
+				shortSummary: "summarizer",
+				firstKeptEntryId: preparation.firstKeptEntryId,
+				tokensBefore: 42,
+			};
+		});
 	}
 
 	it("maintains a 371,200-token cached advisor context before the 372,000-token window", async () => {
@@ -551,5 +669,67 @@ describe("AgentSession advisor context maintenance", () => {
 			`${crossProviderModel.provider}/${crossProviderModel.id}`,
 		]);
 		expect(JSON.stringify(advisor.state.messages)).toContain("authenticated fallback summary");
+	});
+
+	it("records the active advisor's threshold when a larger fallback model summarizes", async () => {
+		// `profile.t` must name the threshold that armed compaction. `shouldCompact`
+		// gates on the active advisor's window, but the summarization candidate is
+		// resolved separately and is often the largest-context model available.
+		// Deriving `t` from that candidate reports a threshold that never fired.
+		const { advisor, advisorMock, settings, summarizerMock } = createAdvisorThresholdMetadataHarness();
+		const compactSpy = summarizeOnFallback(advisorMock.id);
+
+		await session.prompt("small current update");
+
+		const compactionSettings = settings.getGroup("compaction");
+		const activeThreshold = resolveThresholdTokens(ACTIVE_ADVISOR_CONTEXT_WINDOW, compactionSettings);
+		const summarizerThreshold = resolveThresholdTokens(SUMMARIZER_CONTEXT_WINDOW, compactionSettings);
+
+		// The advisor model was tried first and the 1M fallback actually summarized,
+		// so the two thresholds are genuinely in play on this one run.
+		expect(compactSpy.mock.calls.map(([, model]) => model.id)).toEqual([advisorMock.id, summarizerMock.id]);
+		expect(activeThreshold).toBe(160_000);
+		expect(summarizerThreshold).toBe(800_000);
+		expect(compactSpy.mock.calls.length).toBeGreaterThan(0);
+		// Pinned with toBe on the exact value: every request reports the advisor's
+		// own gate, including the one issued to the 1M candidate.
+		for (const [, , , , , options] of compactSpy.mock.calls) {
+			const profile = compactionProfile(options?.metadata);
+			expect(profile.t).toBe(activeThreshold);
+			expect(profile).toEqual({ t: activeThreshold, s: "context-full", z: getTokenizerMode() });
+		}
+		expect(JSON.stringify(advisor.state.messages)).toContain("summarizer summary");
+	});
+
+	it("records the promoted advisor's threshold when promotion still requires compaction", async () => {
+		// Promotion re-runs the gate against the promoted model, so once compaction
+		// proceeds anyway it is the promoted window's threshold that fired — not the
+		// pre-promotion advisor's, and not the summarizing candidate's.
+		const { advisor, advisorMock, promotionMock, settings, summarizerMock } = createAdvisorThresholdMetadataHarness(
+			PROMOTED_ADVISOR_CONTEXT_WINDOW,
+		);
+		const compactSpy = summarizeOnFallback(advisorMock.id);
+
+		await session.prompt("small current update");
+
+		const compactionSettings = settings.getGroup("compaction");
+		const prePromotionThreshold = resolveThresholdTokens(ACTIVE_ADVISOR_CONTEXT_WINDOW, compactionSettings);
+		const promotedThreshold = resolveThresholdTokens(PROMOTED_ADVISOR_CONTEXT_WINDOW, compactionSettings);
+		const summarizerThreshold = resolveThresholdTokens(SUMMARIZER_CONTEXT_WINDOW, compactionSettings);
+
+		// Promotion landed and compaction still ran: 371,550 accumulated tokens clear
+		// the promoted 320k threshold as well as the pre-promotion 160k one.
+		expect(promotionMock).toBeDefined();
+		expect(advisor.state.model.id).toBe(promotionMock!.id);
+		expect(compactSpy.mock.calls.map(([, model]) => model.id)).toEqual([advisorMock.id, summarizerMock.id]);
+		expect(promotedThreshold).toBe(320_000);
+		// All three candidate windows yield distinct thresholds, so `t` is unambiguous.
+		expect(new Set([prePromotionThreshold, promotedThreshold, summarizerThreshold]).size).toBe(3);
+		for (const [, , , , , options] of compactSpy.mock.calls) {
+			const profile = compactionProfile(options?.metadata);
+			expect(profile.t).toBe(promotedThreshold);
+			expect(profile).toEqual({ t: promotedThreshold, s: "context-full", z: getTokenizerMode() });
+		}
+		expect(JSON.stringify(advisor.state.messages)).toContain("summarizer summary");
 	});
 });

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -163,6 +163,118 @@ describe("AgentSession handoff", () => {
 		expect(sessionManager.getEntries().filter(entry => entry.type === "compaction")).toHaveLength(0);
 	});
 
+	it("labels a manual handoff request with the handoff strategy", async () => {
+		session.settings.set("compaction.strategy", "context-full");
+		const generateHandoffSpy = vi
+			.spyOn(compactionModule, "generateHandoffFromContext")
+			.mockResolvedValue("## Goal\nContinue from here");
+
+		await session.handoff();
+
+		const call = generateHandoffSpy.mock.calls[0];
+		if (!call) throw new Error("Expected generateHandoffFromContext call");
+		const userId = JSON.parse(String(call[2].streamOptions.metadata?.user_id)) as { profile: { s: string } };
+		expect(userId.profile.s).toBe("handoff");
+	});
+
+	it("labels an idle compaction request with the idle threshold, not the normal one", async () => {
+		session.settings.set("compaction.strategy", "context-full");
+		session.settings.set("compaction.thresholdTokens", 120_000);
+		session.settings.set("compaction.idleEnabled", true);
+		session.settings.set("compaction.idleThresholdTokens", 40_000);
+		const entries = sessionManager.getBranch();
+		const lastEntryId = entries[entries.length - 1]?.id;
+		if (!lastEntryId) throw new Error("Expected a seeded entry id");
+		const fixedPreparation: compactionModule.CompactionPreparation = {
+			firstKeptEntryId: lastEntryId,
+			messagesToSummarize: [{ role: "user", content: [{ type: "text", text: "old" }], timestamp: 1 }],
+			turnPrefixMessages: [],
+			recentMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 100,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: { ...compactionModule.DEFAULT_COMPACTION_SETTINGS, strategy: "context-full" },
+		};
+		vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(fixedPreparation);
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockResolvedValue({
+			summary: "compacted",
+			shortSummary: undefined,
+			firstKeptEntryId: lastEntryId,
+			tokensBefore: 100,
+			details: {},
+		});
+
+		await session.runIdleCompaction();
+
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+		const userId = JSON.parse(String(compactSpy.mock.calls[0]?.[5]?.metadata?.user_id)) as {
+			profile: { t: number; s: string };
+		};
+		expect(userId.profile).toMatchObject({ t: 40_000, s: "context-full" });
+	});
+
+	it("reports the threshold that armed idle compaction after the idle gate changes", async () => {
+		session.settings.set("compaction.strategy", "context-full");
+		session.settings.set("compaction.thresholdTokens", 120_000);
+		session.settings.set("compaction.idleEnabled", true);
+		session.settings.set("compaction.idleThresholdTokens", 40_000);
+		const entries = sessionManager.getBranch();
+		const lastEntryId = entries[entries.length - 1]?.id;
+		if (!lastEntryId) throw new Error("Expected a seeded entry id");
+		const fixedPreparation: compactionModule.CompactionPreparation = {
+			firstKeptEntryId: lastEntryId,
+			messagesToSummarize: [{ role: "user", content: [{ type: "text", text: "old" }], timestamp: 1 }],
+			turnPrefixMessages: [],
+			recentMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 100,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: { ...compactionModule.DEFAULT_COMPACTION_SETTINGS, strategy: "context-full" },
+		};
+		vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(fixedPreparation);
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockResolvedValue({
+			summary: "compacted",
+			shortSummary: undefined,
+			firstKeptEntryId: lastEntryId,
+			tokensBefore: 100,
+			details: {},
+		});
+		// The idle timer armed on 40_000 and validated it as it fired; the user then
+		// retuned the gate before this run reached metadata. Re-reading settings here
+		// would report 90_000 — or 0 once idleEnabled flips off — for a request that
+		// 40_000 triggered.
+		session.settings.set("compaction.idleThresholdTokens", 90_000);
+		session.settings.set("compaction.idleEnabled", false);
+
+		await session.runIdleCompaction({ idleThreshold: { enabled: true, thresholdTokens: 40_000 } });
+
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+		const userId = JSON.parse(String(compactSpy.mock.calls[0]?.[5]?.metadata?.user_id)) as {
+			profile: { t: number; s: string };
+		};
+		expect(userId.profile).toMatchObject({ t: 40_000, s: "context-full" });
+	});
+
+	it("labels an idle handoff request with the idle threshold while compaction is disabled", async () => {
+		session.settings.set("compaction.enabled", false);
+		session.settings.set("compaction.strategy", "handoff");
+		session.settings.set("compaction.thresholdTokens", 120_000);
+		session.settings.set("compaction.idleEnabled", true);
+		session.settings.set("compaction.idleThresholdTokens", 40_000);
+		const generateHandoffSpy = vi
+			.spyOn(compactionModule, "generateHandoffFromContext")
+			.mockResolvedValue("## Goal\nContinue from here");
+
+		await session.runIdleCompaction();
+
+		const call = generateHandoffSpy.mock.calls[0];
+		if (!call) throw new Error("Expected generateHandoffFromContext call");
+		const userId = JSON.parse(String(call[2].streamOptions.metadata?.user_id)) as {
+			profile: { t: number; s: string };
+		};
+		expect(userId.profile).toMatchObject({ t: 40_000, s: "handoff" });
+	});
+
 	it("clears staged preview state when handoff creates the replacement session", async () => {
 		vi.spyOn(compactionModule, "generateHandoffFromContext").mockResolvedValue("## Goal\nContinue from here");
 		session.toolChoiceQueue.registerPendingInvoker("old-session-preview", "ast_edit", async () => ({
@@ -1468,6 +1580,7 @@ describe("AgentSession handoff", () => {
 		expect(handoffSpy).toHaveBeenCalledTimes(1);
 		expect(handoffSpy).toHaveBeenCalledWith(expect.stringContaining("Threshold-triggered maintenance"), {
 			autoTriggered: true,
+			metadataCompactionStrategy: "handoff",
 			signal: expect.anything(),
 			onSwitchCancelled: expect.any(Function),
 		});

--- a/packages/coding-agent/test/modes/controllers/event-controller-idle-compaction.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-idle-compaction.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
@@ -133,6 +133,54 @@ describe("EventController idle compaction teardown", () => {
 		vi.advanceTimersByTime(60_000);
 
 		expect(runIdleCompaction).not.toHaveBeenCalled();
+	});
+
+	it("skips idle compaction when the idle gate is disabled while the timer is pending", async () => {
+		const runIdleCompaction = vi.fn();
+		const context = createContext({ runIdleCompaction });
+
+		const controller = new EventController(context);
+		await controller.handleEvent({ type: "agent_end", messages: [createAssistantMessage()] });
+		// `override`, not `set`: this suite seeds the gate through `Settings.init({
+		// overrides })`, and `#rebuildMerged` applies that override layer last, so a
+		// `set` (which writes the global layer) stays shadowed and the effective
+		// value would never move.
+		settings.override("compaction.idleEnabled", false);
+		vi.advanceTimersByTime(60_000);
+
+		expect(runIdleCompaction).not.toHaveBeenCalled();
+		controller.dispose();
+	});
+
+	it("skips idle compaction when the threshold is raised past usage while the timer is pending", async () => {
+		const runIdleCompaction = vi.fn();
+		// Fixture usage is 210 tokens, which armed the timer against the 100 default.
+		const context = createContext({ runIdleCompaction });
+
+		const controller = new EventController(context);
+		await controller.handleEvent({ type: "agent_end", messages: [createAssistantMessage()] });
+		settings.override("compaction.idleThresholdTokens", 500);
+		vi.advanceTimersByTime(60_000);
+
+		expect(runIdleCompaction).not.toHaveBeenCalled();
+		controller.dispose();
+	});
+
+	it("carries the threshold in force at fire time, not the one that armed the timer", async () => {
+		const runIdleCompaction = vi.fn();
+		const context = createContext({ runIdleCompaction });
+
+		const controller = new EventController(context);
+		await controller.handleEvent({ type: "agent_end", messages: [createAssistantMessage()] });
+		// Still under the 210-token fixture usage, so the run is authorized — but by
+		// 200, not the 100 that armed the timer. The request must report what fired.
+		settings.override("compaction.idleThresholdTokens", 200);
+		vi.advanceTimersByTime(60_000);
+
+		expect(runIdleCompaction).toHaveBeenCalledWith({
+			idleThreshold: { enabled: true, thresholdTokens: 200 },
+		});
+		controller.dispose();
 	});
 
 	it("emits an LLM-generated recap after the default four-minute delay", async () => {

--- a/packages/coding-agent/test/session-profile-metadata.test.ts
+++ b/packages/coding-agent/test/session-profile-metadata.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it } from "bun:test";
+import { Settings } from "../src/config/settings";
+import type { AuthStorage } from "../src/session/auth-storage";
+import {
+	buildEffectiveIdleThreshold,
+	buildEffectiveSessionProfile,
+	buildSessionMetadata,
+	overrideSessionMetadataCompactionStrategy,
+} from "../src/session/session-metadata";
+
+const ACCOUNT_UUID = "abcd1234-abcd-1234-abcd-1234abcd1234";
+const SESSION_ID = "12345678-1234-4234-8234-123456789012";
+
+describe("session profile metadata", () => {
+	it("preserves OAuth attribution in bounded effective profile metadata", () => {
+		const syntheticConfigPath = "/home/tester/private/config.yml";
+		const settings = Settings.isolated({
+			"compaction.thresholdTokens": 120000,
+			"compaction.strategy": "scratch-handoff",
+		});
+		const profile = buildEffectiveSessionProfile(settings, "accurate", 200_000);
+		const profileWithPath = { ...profile, configPaths: [syntheticConfigPath] };
+		const authStorage = {
+			getOAuthAccountId: () => ACCOUNT_UUID,
+		} as unknown as AuthStorage;
+		const metadata = buildSessionMetadata(SESSION_ID, "anthropic", authStorage, profileWithPath);
+		const resumedMetadata = buildSessionMetadata(SESSION_ID, "anthropic", authStorage, profileWithPath);
+		const userId = JSON.parse(String(metadata.user_id)) as Record<string, unknown>;
+		const profileMetadata = userId.profile as Record<string, unknown>;
+
+		expect(metadata).toEqual(resumedMetadata);
+		expect(String(metadata.user_id)).not.toContain(syntheticConfigPath);
+		expect(userId).toMatchObject({
+			session_id: SESSION_ID,
+			account_uuid: ACCOUNT_UUID,
+			device_id: expect.stringMatching(/^[0-9a-f]{64}$/),
+		});
+		expect(profileMetadata).toEqual({ t: 120000, s: "context-full", z: "accurate" });
+		expect(String(metadata.user_id).length).toBeLessThan(256);
+	});
+
+	it("reports disabled compaction as off", () => {
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"compaction.strategy": "handoff",
+		});
+
+		expect(buildEffectiveSessionProfile(settings, "estimate", 200_000)).toMatchObject({
+			thresholdTokens: 0,
+			strategy: "off",
+		});
+	});
+
+	it("reports the text-only snapcompact fallback as context-full", () => {
+		const settings = Settings.isolated({
+			"compaction.strategy": "snapcompact",
+		});
+
+		expect(buildEffectiveSessionProfile(settings, "estimate", 200_000, false).strategy).toBe("context-full");
+		expect(buildEffectiveSessionProfile(settings, "estimate", 200_000, true).strategy).toBe("snapcompact");
+	});
+
+	it("reports the actual context-full strategy for fallback compaction requests", () => {
+		const metadata = buildSessionMetadata(SESSION_ID, "anthropic", undefined, {
+			thresholdTokens: 120_000,
+			strategy: "handoff",
+			tokenizerMode: "accurate",
+		});
+		const overridden = overrideSessionMetadataCompactionStrategy(metadata, "context-full");
+		const userId = JSON.parse(String(overridden?.user_id)) as { profile: Record<string, unknown> };
+
+		// Ordinary compaction keeps the threshold that actually governs it.
+		expect(userId.profile).toEqual({ t: 120_000, s: "context-full", z: "accurate" });
+	});
+
+	it("overrides disabled profile metadata for an independent idle handoff", () => {
+		const metadata = buildSessionMetadata(SESSION_ID, "anthropic", undefined, {
+			thresholdTokens: 120_000,
+			strategy: "off",
+			tokenizerMode: "accurate",
+		});
+		const overridden = overrideSessionMetadataCompactionStrategy(metadata, "handoff");
+		const userId = JSON.parse(String(overridden?.user_id)) as { profile: { s: string } };
+
+		expect(userId.profile.s).toBe("handoff");
+	});
+
+	it("reports the idle threshold when it differs from the normal compaction threshold", () => {
+		const settings = Settings.isolated({
+			"compaction.strategy": "context-full",
+			"compaction.thresholdTokens": 120_000,
+			"compaction.idleEnabled": true,
+			"compaction.idleThresholdTokens": 40_000,
+		});
+		const metadata = buildSessionMetadata(
+			SESSION_ID,
+			"anthropic",
+			undefined,
+			buildEffectiveSessionProfile(settings, "estimate", 200_000),
+		);
+		const overridden = overrideSessionMetadataCompactionStrategy(
+			metadata,
+			"context-full",
+			buildEffectiveIdleThreshold(settings),
+		);
+		const ordinaryUserId = JSON.parse(String(metadata.user_id)) as { profile: Record<string, unknown> };
+		const idleUserId = JSON.parse(String(overridden?.user_id)) as { profile: Record<string, unknown> };
+
+		expect(ordinaryUserId.profile).toEqual({ t: 120_000, s: "context-full", z: "estimate" });
+		expect(idleUserId.profile).toEqual({ t: 40_000, s: "context-full", z: "estimate" });
+	});
+
+	it("reports the idle threshold for an idle handoff while ordinary compaction is disabled", () => {
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"compaction.strategy": "handoff",
+			"compaction.thresholdTokens": 120_000,
+			"compaction.idleEnabled": true,
+			"compaction.idleThresholdTokens": 40_000,
+		});
+		const profile = buildEffectiveSessionProfile(settings, "estimate", 200_000);
+		const metadata = buildSessionMetadata(SESSION_ID, "anthropic", undefined, profile);
+		const overridden = overrideSessionMetadataCompactionStrategy(
+			metadata,
+			"handoff",
+			buildEffectiveIdleThreshold(settings),
+		);
+		const userId = JSON.parse(String(overridden?.user_id)) as { profile: Record<string, unknown> };
+
+		expect(profile.strategy).toBe("off");
+		expect(userId.profile).toEqual({ t: 40_000, s: "handoff", z: "estimate" });
+	});
+
+	it("reports no threshold in force when the idle gate is off", () => {
+		const settings = Settings.isolated({
+			"compaction.thresholdTokens": 120_000,
+			"compaction.idleEnabled": false,
+			"compaction.idleThresholdTokens": 40_000,
+		});
+		const metadata = buildSessionMetadata(
+			SESSION_ID,
+			"anthropic",
+			undefined,
+			buildEffectiveSessionProfile(settings, "estimate", 200_000),
+		);
+		const overridden = overrideSessionMetadataCompactionStrategy(
+			metadata,
+			"context-full",
+			buildEffectiveIdleThreshold(settings),
+		);
+		const userId = JSON.parse(String(overridden?.user_id)) as { profile: Record<string, unknown> };
+
+		expect(userId.profile).toEqual({ t: 0, s: "context-full", z: "estimate" });
+	});
+
+	it("reports the tokenizer implementation's module-load mode", async () => {
+		const child = Bun.spawn(
+			[
+				process.execPath,
+				"-e",
+				'import { getTokenizerMode } from "@oh-my-pi/pi-agent-core"; process.env.PI_TOKENIZER_ACCURATE = "0"; console.log(getTokenizerMode());',
+			],
+			{
+				env: { ...Bun.env, PI_TOKENIZER_ACCURATE: "1", NODE_ENV: "production" },
+				stdout: "pipe",
+			},
+		);
+
+		expect(await child.exited).toBe(0);
+		expect((await new Response(child.stdout).text()).trim()).toBe("accurate");
+	});
+
+	it("records the effective percentage threshold for the active context window", () => {
+		const settings = Settings.isolated({
+			"compaction.thresholdTokens": -1,
+			"compaction.thresholdPercent": 80,
+		});
+		const profile = buildEffectiveSessionProfile(settings, "estimate", 200_000);
+		const metadata = buildSessionMetadata(SESSION_ID, "anthropic", undefined, profile);
+		const userId = JSON.parse(String(metadata.user_id)) as Record<string, unknown>;
+
+		expect((userId.profile as Record<string, unknown>).t).toBe(160_000);
+	});
+
+	it("records the effective default reserve-based threshold", () => {
+		const settings = Settings.isolated({
+			"compaction.thresholdTokens": -1,
+			"compaction.thresholdPercent": -1,
+			"compaction.reserveTokens": undefined,
+		});
+		const profile = buildEffectiveSessionProfile(settings, "estimate", 100_000);
+		const metadata = buildSessionMetadata(SESSION_ID, "anthropic", undefined, profile);
+		const userId = JSON.parse(String(metadata.user_id)) as Record<string, unknown>;
+
+		expect((userId.profile as Record<string, unknown>).t).toBe(83_616);
+	});
+
+	it("clamps oversized fixed thresholds to the active context window", () => {
+		const settings = Settings.isolated({
+			"compaction.thresholdTokens": 250_000,
+			"compaction.thresholdPercent": -1,
+		});
+		const profile = buildEffectiveSessionProfile(settings, "estimate", 200_000);
+		const metadata = buildSessionMetadata(SESSION_ID, "anthropic", undefined, profile);
+		const userId = JSON.parse(String(metadata.user_id)) as Record<string, unknown>;
+
+		expect((userId.profile as Record<string, unknown>).t).toBe(199_999);
+	});
+
+	it("bounds long custom session IDs without emitting oversized metadata", () => {
+		const settings = Settings.isolated({
+			"compaction.thresholdTokens": 120000,
+			"compaction.strategy": "scratch-handoff",
+		});
+		const profile = buildEffectiveSessionProfile(settings, "accurate", 200_000);
+		const authStorage = {
+			getOAuthAccountId: () => ACCOUNT_UUID,
+		} as unknown as AuthStorage;
+		const sessionId = "custom-session-".repeat(5);
+		const metadata = buildSessionMetadata(sessionId, "anthropic", authStorage, profile);
+		const userId = JSON.parse(String(metadata.user_id)) as Record<string, unknown>;
+
+		expect(String(metadata.user_id).length).toBeLessThanOrEqual(256);
+		expect(userId).toMatchObject({
+			session_id: sessionId,
+			account_uuid: ACCOUNT_UUID,
+			device_id: expect.stringMatching(/^[0-9a-f]{64}$/),
+		});
+		expect(userId.profile).toBeUndefined();
+		const veryLongSessionId = "custom-session-".repeat(30);
+		const oversizedMetadata = buildSessionMetadata(veryLongSessionId, "anthropic", authStorage, profile);
+		const resumedOversizedMetadata = buildSessionMetadata(veryLongSessionId, "anthropic", authStorage, profile);
+		const oversizedUserId = JSON.parse(String(oversizedMetadata.user_id)) as Record<string, unknown>;
+
+		expect(oversizedMetadata).toEqual(resumedOversizedMetadata);
+		expect(String(oversizedMetadata.user_id).length).toBeLessThanOrEqual(256);
+		expect(String(oversizedUserId.session_id)).toMatch(/^custom-session-/);
+		expect(oversizedUserId).toMatchObject({
+			account_uuid: ACCOUNT_UUID,
+			device_id: expect.stringMatching(/^[0-9a-f]{64}$/),
+		});
+		expect(oversizedUserId.profile).toBeUndefined();
+	});
+	it("keeps distinct long session IDs distinct after bounding", () => {
+		const authStorage = {
+			getOAuthAccountId: () => ACCOUNT_UUID,
+		} as unknown as AuthStorage;
+		const sharedPrefix = "custom-session-".repeat(30);
+		const firstSessionId = `${sharedPrefix}first-tail`;
+		const secondSessionId = `${sharedPrefix}second-tail`;
+		const firstMetadata = buildSessionMetadata(firstSessionId, "anthropic", authStorage);
+		const secondMetadata = buildSessionMetadata(secondSessionId, "anthropic", authStorage);
+		const resumedFirstMetadata = buildSessionMetadata(firstSessionId, "anthropic", authStorage);
+		const firstUserId = JSON.parse(String(firstMetadata.user_id)) as Record<string, unknown>;
+		const secondUserId = JSON.parse(String(secondMetadata.user_id)) as Record<string, unknown>;
+		const firstSession = String(firstUserId.session_id);
+		const secondSession = String(secondUserId.session_id);
+		const firstMatch = firstSession.match(/^(.*)-([0-9a-f]{16})$/);
+		const secondMatch = secondSession.match(/^(.*)-([0-9a-f]{16})$/);
+
+		expect(firstMetadata).toEqual(resumedFirstMetadata);
+		expect(String(firstMetadata.user_id).length).toBeLessThanOrEqual(256);
+		expect(String(secondMetadata.user_id).length).toBeLessThanOrEqual(256);
+		expect(firstMatch).not.toBeNull();
+		expect(secondMatch).not.toBeNull();
+		expect(firstMatch?.[1]).toBe(secondMatch?.[1]);
+		expect(firstMatch?.[1]).toStartWith("custom-session-");
+		expect(firstMatch?.[2]).toBe(Bun.hash(firstSessionId).toString(16).padStart(16, "0"));
+		expect(secondMatch?.[2]).toBe(Bun.hash(secondSessionId).toString(16).padStart(16, "0"));
+		expect(firstSession).not.toBe(secondSession);
+	});
+
+	it("keeps non-Anthropic cache affinity stable across profile changes", () => {
+		const firstProfile = buildEffectiveSessionProfile(
+			Settings.isolated({
+				"compaction.thresholdTokens": 80000,
+				"compaction.strategy": "context-full",
+			}),
+			"estimate",
+			200_000,
+		);
+		const secondProfile = buildEffectiveSessionProfile(
+			Settings.isolated({
+				"compaction.thresholdTokens": 120000,
+				"compaction.strategy": "scratch-handoff",
+			}),
+			"accurate",
+			200_000,
+		);
+		const firstMetadata = buildSessionMetadata(SESSION_ID, "kimi-code", undefined, firstProfile);
+		const secondMetadata = buildSessionMetadata(SESSION_ID, "kimi-code", undefined, secondProfile);
+
+		expect(firstMetadata).toEqual(secondMetadata);
+		expect(JSON.parse(String(firstMetadata.user_id))).toEqual({ session_id: SESSION_ID });
+	});
+
+	it("forwards a long non-Anthropic session ID whole instead of bounding it", () => {
+		// The 256-character cap is Anthropic's limit. Bounding a non-Anthropic
+		// request truncates and hash-suffixes the caller's --provider-session-id,
+		// which rotates the prompt-affinity key of an already-warmed session.
+		const authStorage = {
+			getOAuthAccountId: () => ACCOUNT_UUID,
+		} as unknown as AuthStorage;
+		const longSessionId = "custom-session-".repeat(30);
+		expect(longSessionId.length).toBeGreaterThan(256);
+
+		const passthrough = buildSessionMetadata(longSessionId, "kimi-code", authStorage);
+		const bounded = buildSessionMetadata(longSessionId, "anthropic", authStorage);
+
+		// Verbatim for the non-Anthropic provider, and no Claude identity leaks.
+		expect(JSON.parse(String(passthrough.user_id))).toEqual({ session_id: longSessionId });
+		// Anthropic still gets the bounded form, so ordinary behavior is unchanged.
+		expect(String(bounded.user_id).length).toBeLessThanOrEqual(256);
+		expect(String((JSON.parse(String(bounded.user_id)) as { session_id: string }).session_id)).not.toBe(
+			longSessionId,
+		);
+	});
+
+	it("treats the 256-character cap as inclusive and rewrites only past it", () => {
+		// The cap is a maximum, not an exclusive bound: a payload landing exactly on
+		// 256 still fits Anthropic's limit and must survive whole. Without a case
+		// sitting on the boundary, `serialized.length <= MAX_METADATA_USER_ID_LENGTH`
+		// could become `<` and every other test here would still pass while ids that
+		// legitimately fit started getting truncated and hash-suffixed.
+		const wrapperLength = JSON.stringify({ session_id: "" }).length;
+		const atCapSessionId = "b".repeat(256 - wrapperLength);
+		const overCapSessionId = "b".repeat(256 - wrapperLength + 1);
+
+		// No authStorage and no profile, so the payload is exactly `{ session_id }`
+		// and the arithmetic above is the whole serialized length.
+		const atCap = buildSessionMetadata(atCapSessionId, "anthropic", undefined);
+		const overCap = buildSessionMetadata(overCapSessionId, "anthropic", undefined);
+
+		// Exactly on the cap: untouched, and pinned with toBe so a narrower bound
+		// cannot satisfy it.
+		expect(String(atCap.user_id).length).toBe(256);
+		expect(JSON.parse(String(atCap.user_id))).toEqual({ session_id: atCapSessionId });
+
+		// One character over: rewritten, and still within the cap afterwards.
+		expect(String(overCap.user_id).length).toBeLessThanOrEqual(256);
+		expect(String((JSON.parse(String(overCap.user_id)) as { session_id: string }).session_id)).not.toBe(
+			overCapSessionId,
+		);
+
+		// The boundary is Anthropic's alone — non-Anthropic forwards both whole.
+		expect(JSON.parse(String(buildSessionMetadata(atCapSessionId, "kimi-code", undefined).user_id))).toEqual({
+			session_id: atCapSessionId,
+		});
+		expect(JSON.parse(String(buildSessionMetadata(overCapSessionId, "kimi-code", undefined).user_id))).toEqual({
+			session_id: overCapSessionId,
+		});
+	});
+});


### PR DESCRIPTION
Session metadata recorded the requested profile rather than the effective profile after directing and compaction policy had resolved. That made persisted metadata disagree with the behavior used for the session and allowed repeated metadata growth.

Record the effective directing and compaction values at the session boundary. Bound the retained profile metadata so resumed sessions preserve the current effective state without accumulating stale entries.