### PR TITLE
fix(tools): navigate to the requested url when opening an attached browser tab

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the browser tool silently ignoring `url` when opening a new tab on an attached browser (`app.cdp_url` or `app.path`), so the tab now navigates on open exactly as it already did on reuse and in headless mode.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/browser/tab-protocol.ts
+++ b/packages/coding-agent/src/tools/browser/tab-protocol.ts
@@ -59,6 +59,9 @@ export type WorkerInitPayload =
 			safeDir: string;
 			targetId: string;
 			dialogs?: "accept" | "dismiss";
+			url?: string;
+			waitUntil?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
+			timeoutMs: number;
 			/**
 			 * Post-timeout recycle: before adopting the page, dismiss any open JS dialog and
 			 * stop a pending navigation so a blocked target cannot stall worker init (which

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -692,6 +692,9 @@ async function buildInitPayload(browser: PuppeteerBrowserHandle, opts: AcquireTa
 		safeDir,
 		targetId,
 		dialogs: opts.dialogs,
+		url: opts.url,
+		waitUntil: opts.waitUntil,
+		timeoutMs: opts.timeoutMs,
 	};
 }
 
@@ -793,6 +796,7 @@ async function recycleTimedOutWorkerTab(tab: WorkerTabSession, timeoutMs: number
 		// Unblock a wedged page (open JS dialog, hung navigation) before adopting it —
 		// otherwise init stalls, times out, and the tab gets force-killed.
 		recover: true,
+		timeoutMs,
 	};
 	let worker = await spawnTabWorker();
 	try {

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -810,6 +810,13 @@ export class WorkerCore {
 				this.#page = page;
 				this.#observeDialogs();
 				if (payload.dialogs) this.#applyDialogPolicy(payload.dialogs);
+				if (payload.url) {
+					await this.#page.goto(payload.url, {
+						// Same default as the headless arm: dev servers with HMR/WS never reach networkidle.
+						waitUntil: payload.waitUntil ?? "load",
+						timeout: payload.timeoutMs,
+					});
+				}
 			}
 			this.#targetId = await targetIdForPage(this.#page);
 			this.#transport.send({ type: "ready", info: await this.#currentReadyInfo() });


### PR DESCRIPTION
I reviewed the full diff; this makes `browser open` with a `url` actually navigate when the
browser is attached over `app.cdp_url` or `app.path`, which it silently skipped before.

### The defect

`buildInitPayload` (`src/tools/browser/tab-supervisor.ts`) passes `opts.url`, `opts.waitUntil`
and `opts.timeoutMs` in the `mode: "headless"` arm of `WorkerInitPayload`, but the `mode:
"attach"` arm carries no navigation fields at all. The attach branch of `WorkerCore.#init`
adopts the target, installs the dialog policy, and reports ready without ever calling `goto`.

The tool still accepts `url` for those calls and still reports a URL, so the result looks
successful while pointing at whatever the adopted tab already had open.

It is also internally inconsistent: the *reuse* path in `acquireTabImpl` issues
`await tab.goto(...)` for `opts.url`, so opening a tab name for the first time ignores `url`
while opening it a second time honors it.

### The change

Thread `url` / `waitUntil` / `timeoutMs` through the attach arm and `goto` after the page is
adopted and the dialog policy is installed, with the same `waitUntil: "load"` default and the
same comment rationale as the headless arm. `recycleTimedOutWorkerTab` sets `timeoutMs` and
deliberately does not set `url`, so post-timeout recovery re-adopts the page without
re-navigating it.

### Verification

Launched Chrome for Testing with `--remote-debugging-port=9333`, attached through
`acquireBrowser({ kind: "connected", cdpUrl })`, then `acquireTab("repro", browser, { url:
"https://example.com/" })`.

- on `main`: `landed on: about:blank`
- with this change: `landed on: https://example.com/`

`bun run check:types` and `biome check` clean; `bun test test/tools/browser-*.test.ts` passes
(17 tests). No new test: the path needs a live CDP browser and the repo has no attach-mode
test harness.
