### PR TITLE
fix(compaction): cap the generated summary output budget

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compaction summaries being allowed to grow with the context window: the summary output budget is now capped at `MAX_SUMMARY_TOKENS` (16384), so a large window no longer authorizes a summary big enough to copy the conversation instead of compressing it.
+
 ## [17.1.7] - 2026-07-27
 
 ### Changed

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -186,6 +186,18 @@ export interface CompactionSettings {
 /** Reserve applied when {@link CompactionSettings.reserveTokens} is unset. */
 export const DEFAULT_RESERVE_TOKENS = 16384;
 
+/**
+ * Hard ceiling on a generated compaction summary.
+ *
+ * The summary budget is `floor(0.8 * reserveTokens)`, and the effective reserve is
+ * at least 15% of the declared context window, so a 1M-token window authorizes a
+ * ~120k-token summary. At that size the model copies rather than compresses, and
+ * output is the slowest and most expensive token class. Capping absolutely keeps
+ * the compression ratio improving with window size instead of degrading. The value
+ * mirrors {@link DEFAULT_RESERVE_TOKENS} so this adds no new tuning constant.
+ */
+export const MAX_SUMMARY_TOKENS = 16384;
+
 // reserveTokens is deliberately absent: an unset reserve is what marks it as
 // defaulted, which resolveBudgetReserveTokens needs to distinguish "user never
 // chose a reserve" from "user explicitly configured the default value".
@@ -827,7 +839,7 @@ export async function generateSummary(
 	previousSummary?: string,
 	options?: SummaryOptions,
 ): Promise<string> {
-	const maxTokens = Math.floor(0.8 * reserveTokens);
+	const maxTokens = Math.min(Math.floor(0.8 * reserveTokens), MAX_SUMMARY_TOKENS);
 
 	// Use update prompt if we have a previous summary, otherwise initial prompt
 	let basePrompt = previousSummary ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT;

--- a/packages/agent/test/compaction-summary-cap.test.ts
+++ b/packages/agent/test/compaction-summary-cap.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { generateSummary, MAX_SUMMARY_TOKENS } from "@oh-my-pi/pi-agent-core/compaction";
+import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+import * as ai from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+
+function createAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		timestamp: Date.now(),
+		provider: "mock",
+		model: "mock",
+		api: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+	};
+}
+
+function getModel(): Model {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected built-in anthropic/claude-sonnet-4-5 to exist");
+	return model;
+}
+
+const messages: AgentMessage[] = [
+	{ role: "user", content: "start work", timestamp: 1 },
+	createAssistantMessage("started"),
+];
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("compaction summary output budget", () => {
+	test("caps the summary budget for large reserves", async () => {
+		const spy = vi.spyOn(ai, "completeSimple").mockResolvedValue(createAssistantMessage("summary"));
+		// A 1M-token window yields a 150k reserve, which used to authorize a ~120k-token summary.
+		await generateSummary(messages, getModel(), 150_000, "test-key");
+		expect(spy.mock.calls[0]?.[2]?.maxTokens).toBe(MAX_SUMMARY_TOKENS);
+	});
+
+	test("leaves a reserve smaller than the cap proportional", async () => {
+		const spy = vi.spyOn(ai, "completeSimple").mockResolvedValue(createAssistantMessage("summary"));
+		await generateSummary(messages, getModel(), 10_000, "test-key");
+		expect(spy.mock.calls[0]?.[2]?.maxTokens).toBe(8_000);
+	});
+});


### PR DESCRIPTION
I reviewed the full diff; a large context window was letting compaction ask for a summary big
enough to copy the conversation instead of compressing it.

### The defect

`generateSummary` computes `maxTokens = floor(0.8 * reserveTokens)`, and `effectiveReserveTokens`
is at least 15% of the declared context window. Window size alone therefore decides summary
length: a 1M-token window authorizes roughly 120k tokens of summary. At that size the model
copies rather than compresses, on the slowest and most expensive token class, so compaction
gets *worse* as the window gets bigger.

### The change

Clamp with `MAX_SUMMARY_TOKENS`, set equal to `DEFAULT_RESERVE_TOKENS` (16384) so no new
independent tuning constant is introduced. Reserves below the cap are unaffected.

### Design discussion

The fixed ceiling intentionally equals the existing `DEFAULT_RESERVE_TOKENS` (16384). This
adds no tuning knob while preventing pathological budgets on very large windows. Alternatives
would be a dedicated summary-token setting or a proportional budget with a separate cap. I
would welcome maintainer preference on whether either option better fits the compaction API.

### Verification

`test/compaction-summary-cap.test.ts` spies on `completeSimple` and asserts the requested
`maxTokens`: a 150k reserve (a 1M window) now requests 16384 instead of 120000, and a 10k
reserve still requests 8000. I confirmed the first case fails on `main` before adding the
clamp. `bun run check:types` and `biome check` clean in `packages/agent`.
