### PR TITLE
feat(agent): add an onProviderContext observation hook

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an optional `onProviderContext` hook on `Agent` and `AgentLoopConfig` that observes a credential-free, deep-cloned snapshot of the final semantic provider context immediately before dispatch, after `transformProviderContext` and owned-dialect rewriting. Observer failures are isolated and never block the request.
+
 ## [17.1.7] - 2026-07-27
 
 ### Changed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1641,6 +1641,17 @@ async function streamAssistantResponse(
 
 	try {
 		return await runInActiveSpan(chatSpan, async () => {
+			if (config.onProviderContext) {
+				try {
+					await config.onProviderContext({
+						context: structuredCloneJSON(llmContext),
+						model: { provider: model.provider, id: model.id },
+						timestamp: Date.now(),
+					});
+				} catch {
+					// Observation must never prevent provider dispatch.
+				}
+			}
 			let response = await streamFunction(model, llmContext, {
 				...config,
 				apiKey,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -49,6 +49,7 @@ import type {
 	AgentToolContext,
 	AgentTurnEndContext,
 	AsideMessage,
+	ProviderContextSnapshot,
 	StreamFn,
 	ToolCallContext,
 	ToolChoiceDirective,
@@ -115,6 +116,9 @@ export interface AgentOptions {
 	 * telemetry capture/provider send.
 	 */
 	transformProviderContext?: (context: Context, model: Model) => Context | Promise<Context>;
+
+	/** Observes the final credential-free provider context snapshot before dispatch. */
+	onProviderContext?: (snapshot: ProviderContextSnapshot) => void | Promise<void>;
 
 	/**
 	 * Steering mode: "all" = send all steering messages at once, "one-at-a-time" = one per turn
@@ -370,6 +374,7 @@ export class Agent {
 	#convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	#transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
 	#transformProviderContext?: (context: Context, model: Model) => Context | Promise<Context>;
+	#onProviderContext?: (snapshot: ProviderContextSnapshot) => void | Promise<void>;
 	#steeringQueue: AgentMessage[] = [];
 	#followUpQueue: AgentMessage[] = [];
 	#steeringWaiters = new Set<() => void>();
@@ -507,6 +512,7 @@ export class Agent {
 		this.#telemetry = opts.telemetry;
 		this.#appendOnlyContext = opts.appendOnlyContext;
 		this.#transformProviderContext = opts.transformProviderContext;
+		this.#onProviderContext = opts.onProviderContext;
 	}
 
 	/**
@@ -1312,6 +1318,7 @@ export class Agent {
 			preferWebsockets: this.#preferWebsockets,
 			convertToLlm: this.#convertToLlm,
 			transformProviderContext: this.#transformProviderContext,
+			onProviderContext: this.#onProviderContext,
 			transformContext: this.#transformContext,
 			onPayload: this.#onPayload,
 			onResponse: this.#onResponse,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -129,6 +129,18 @@ export interface SteeringQueueState {
 }
 
 /**
+ * Credential-free snapshot of the final semantic context sent to a provider.
+ *
+ * `context` is deep-cloned at the dispatch boundary, so consumers cannot mutate
+ * the request that is sent. Transport options and credentials are absent.
+ */
+export interface ProviderContextSnapshot {
+	readonly context: Context;
+	readonly model: Readonly<Pick<Model, "provider" | "id">>;
+	readonly timestamp: number;
+}
+
+/**
  * Configuration for the agent loop.
  */
 export interface AgentLoopConfig extends SimpleStreamOptions {
@@ -210,6 +222,15 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * and provider send.
 	 */
 	transformProviderContext?: (context: Context, model: Model) => Context | Promise<Context>;
+
+	/**
+	 * Observes a credential-free, deep-cloned snapshot of the final provider context
+	 * after transforms and owned-dialect rewriting, immediately before dispatch.
+	 * Unlike {@link transformProviderContext} it cannot alter the request, and unlike
+	 * `onPayload` it sees the semantic context rather than a provider wire payload.
+	 * Callback failures are isolated and never prevent provider dispatch.
+	 */
+	onProviderContext?: (snapshot: ProviderContextSnapshot) => void | Promise<void>;
 
 	/**
 	 * Resolves the API key or resolver for the current model before each LLM call.

--- a/packages/agent/test/provider-context-hook.test.ts
+++ b/packages/agent/test/provider-context-hook.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { Agent } from "../src/agent";
+import type { ProviderContextSnapshot } from "../src/types";
+
+describe("onProviderContext", () => {
+	test("observes the post-transform, post-dialect context without being able to change it", async () => {
+		const model = createMockModel({
+			id: "snapshot-model",
+			provider: "snapshot-provider",
+			responses: [{ content: ["done"] }],
+		});
+		let snapshot: ProviderContextSnapshot | undefined;
+		let observedPrompt: string[] = [];
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["base"],
+				tools: [
+					{
+						name: "ordered_tool",
+						label: "Ordered tool",
+						description: "test tool",
+						parameters: { type: "object", properties: {}, additionalProperties: false },
+						execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+					},
+				],
+			},
+			streamFn: model.stream,
+			dialect: "xml",
+			getApiKey: () => "super-secret",
+			transformProviderContext: context => ({
+				...context,
+				systemPrompt: [...(context.systemPrompt ?? []), "transformed"],
+			}),
+			onProviderContext: async value => {
+				await Promise.resolve();
+				snapshot = value;
+				observedPrompt = value.context.systemPrompt?.slice() ?? [];
+				value.context.systemPrompt?.push("observer mutation");
+			},
+		});
+
+		await agent.prompt("hello");
+
+		expect(snapshot).toBeDefined();
+		expect(snapshot?.model).toEqual({ provider: "snapshot-provider", id: "snapshot-model" });
+		// Own transform ran first, then the owned xml dialect moved tools into the prompt.
+		expect(observedPrompt.slice(0, 2)).toEqual(["base", "transformed"]);
+		expect(observedPrompt.at(-1)).toContain("ordered_tool");
+		expect(snapshot?.context.tools).toBeUndefined();
+		expect(model.calls).toHaveLength(1);
+		expect(model.calls[0]?.context).not.toBe(snapshot?.context);
+		expect(model.calls[0]?.context.systemPrompt).toEqual(observedPrompt);
+		expect(model.calls[0]?.context.systemPrompt).not.toContain("observer mutation");
+		// Credentials reach the provider but never the snapshot.
+		expect(model.calls[0]?.options?.apiKey).toBe("super-secret");
+		expect(Object.keys(snapshot ?? {}).sort()).toEqual(["context", "model", "timestamp"]);
+	});
+
+	test("isolates synchronous and asynchronous observer failures from dispatch", async () => {
+		const failures = [
+			() => {
+				throw new Error("synchronous observer failure");
+			},
+			async () => {
+				await Promise.resolve();
+				throw new Error("asynchronous observer failure");
+			},
+		];
+
+		for (const onProviderContext of failures) {
+			const model = createMockModel({ responses: [{ content: ["dispatched"] }] });
+			const agent = new Agent({
+				initialState: { model },
+				streamFn: model.stream,
+				onProviderContext,
+			});
+
+			await agent.prompt("hello");
+			expect(model.calls).toHaveLength(1);
+		}
+	});
+});


### PR DESCRIPTION
This draft proposes a small public observation API at the agent dispatch boundary. I am
opening it as a draft because the callback name, location, and snapshot shape are worth
maintainer discussion before the API is finalized.

### The gap

The final semantic `Context` that goes to a provider is not observable today:

- `transformProviderContext` runs at `agent-loop.ts` before the owned-dialect rewrite, so a
  transform used as an observer misses the system-prompt and message rewrites that dialect
  handling applies right afterwards;
- `onPayload` is one layer lower and provider-specific: it sees a wire payload, not the
  `Context` the loop assembled.

### The change

`onProviderContext` fires at the dispatch boundary in `streamAssistantResponse` with a
`structuredCloneJSON` snapshot, so a consumer cannot mutate the outgoing request, and it
carries only `context`, `model` provider/id, and a timestamp: no api key, metadata, or
transport options. Observer failures are swallowed so instrumentation can never break a turn.

### API sketch

```ts
const agent = new Agent({
  onProviderContext(snapshot) {
    inspect(snapshot.context);
  },
});
```

### Design discussion

The existing hooks expose adjacent but different stages:

- `transformProviderContext` is mutable and runs before the owned-dialect rewrite;
- `onPayload` observes the provider-specific wire payload;
- this hook observes a read-only semantic snapshot of the final context.

I would welcome feedback on the callback name and location, and on whether the snapshot should
carry fewer or additional fields before this becomes public API.

### Verification

`test/provider-context-hook.test.ts` pins the observation point (own transform first, then the
xml dialect having moved tools into the system prompt and cleared `context.tools`), that
mutating the snapshot does not reach the provider call, that the api key reaches the provider
but not the snapshot, and that both a synchronous and an asynchronous observer failure still
dispatch. `bun run check:types` and `biome check` clean; `test/agent-loop.test.ts` and
`test/agent.test.ts` pass (129 tests).
