### PR TITLE
feat(hindsight): support Basic auth for self-hosted memory servers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added HTTP Basic authentication for Hindsight memory servers: a hindsight.apiToken set to a user:password value is now sent as Basic auth, while any other value keeps using a bearer token.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2883,7 +2883,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "memory",
 			group: "Hindsight",
 			label: "Hindsight API Token",
-			description: "Bearer token for authenticated Hindsight servers",
+			description: "Token for authenticated Hindsight servers (a user:password value uses Basic auth)",
 			condition: "hindsightActive",
 		},
 	},

--- a/packages/coding-agent/src/hindsight/client.ts
+++ b/packages/coding-agent/src/hindsight/client.ts
@@ -35,6 +35,7 @@ export interface HindsightTimeouts {
 
 export interface HindsightApiOptions {
 	baseUrl: string;
+	/** Bearer token, or `user:password` for a deployment behind HTTP Basic auth. */
 	apiKey?: string;
 	userAgent?: string;
 	/** Per-op deadlines; unset entries fall back to built-in defaults. */
@@ -235,6 +236,17 @@ interface RequestOptions {
 	timeoutMs?: number;
 }
 
+/**
+ * Resolve the `Authorization` header for a configured credential. Self-hosted
+ * Hindsight deployments often sit behind HTTP Basic auth, so a `user:password`
+ * value authenticates with Basic; anything else is sent as a bearer token.
+ */
+function authorizationHeader(apiKey: string | undefined): string | undefined {
+	if (!apiKey) return undefined;
+	if (!apiKey.includes(":")) return `Bearer ${apiKey}`;
+	return `Basic ${new TextEncoder().encode(apiKey).toBase64()}`;
+}
+
 export class HindsightApi {
 	#baseUrl: string;
 	#headers: Record<string, string>;
@@ -249,8 +261,9 @@ export class HindsightApi {
 			"User-Agent": options.userAgent ?? DEFAULT_USER_AGENT,
 			"Content-Type": "application/json",
 		};
-		if (options.apiKey) {
-			this.#headers.Authorization = `Bearer ${options.apiKey}`;
+		const authorization = authorizationHeader(options.apiKey);
+		if (authorization) {
+			this.#headers.Authorization = authorization;
 		}
 		const timeouts = options.timeouts;
 		this.#requestTimeoutMs = timeouts?.request ?? DEFAULT_REQUEST_TIMEOUT_MS;

--- a/packages/coding-agent/test/hindsight-client.test.ts
+++ b/packages/coding-agent/test/hindsight-client.test.ts
@@ -14,6 +14,19 @@ function captureRequestBodies(): string[] {
 	return bodies;
 }
 
+function captureAuthorizationHeaders(): (string | undefined)[] {
+	const headers: (string | undefined)[] = [];
+	const fetchMock: typeof globalThis.fetch = Object.assign(
+		async (_input: string | URL | Request, init?: RequestInit | BunFetchRequestInit): Promise<Response> => {
+			headers.push(new Headers(init?.headers).get("Authorization") ?? undefined);
+			return new Response("{}", { status: 200 });
+		},
+		{ preconnect: globalThis.fetch.preconnect },
+	);
+	vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+	return headers;
+}
+
 function firstTimestamp(bodyText: string): string | undefined {
 	const body: unknown = JSON.parse(bodyText);
 	if (typeof body !== "object" || body === null) return undefined;
@@ -56,5 +69,38 @@ describe("HindsightApi timestamp serialization", () => {
 		});
 
 		expect(firstTimestamp(bodies[0] ?? "{}")).toBe("2026-06-12T19:17:00+08:00");
+	});
+});
+
+describe("HindsightApi authorization", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("sends a plain token as a bearer credential", async () => {
+		const headers = captureAuthorizationHeaders();
+		const client = new HindsightApi({ baseUrl: "http://hindsight.local", apiKey: "hs-token" });
+
+		await client.recall("omp", "query");
+
+		expect(headers[0]).toBe("Bearer hs-token");
+	});
+
+	it("sends a user:password credential as HTTP Basic auth", async () => {
+		const headers = captureAuthorizationHeaders();
+		const client = new HindsightApi({ baseUrl: "http://hindsight.local", apiKey: "memory:s3cr3t" });
+
+		await client.recall("omp", "query");
+
+		expect(headers[0]).toBe("Basic bWVtb3J5OnMzY3IzdA==");
+	});
+
+	it("omits the authorization header when no credential is configured", async () => {
+		const headers = captureAuthorizationHeaders();
+		const client = new HindsightApi({ baseUrl: "http://hindsight.local" });
+
+		await client.recall("omp", "query");
+
+		expect(headers[0]).toBeUndefined();
 	});
 });


### PR DESCRIPTION
I reviewed the full diff; this lets the existing Hindsight client reach a self-hosted server
behind an HTTP Basic auth proxy without adding a second authentication setting.

### The defect

`HindsightApi` always emitted `Authorization: Bearer <apiKey>`, so a reverse proxy requiring
HTTP Basic auth rejected the request before it reached Hindsight.

### The change

A `user:password` credential is UTF-8 encoded and sent as `Basic <base64>`; every other
credential keeps the existing Bearer behavior. Scheme inference stays in one constructor-time
resolution point, and the resulting shared header object is used by the client's only request
path. There is no per-request encoding, body re-serialization, or deadline change.

The `hindsight.apiToken` setting description documents the accepted shape. No broader docs
currently describe Hindsight authentication.

### Configuration

```yaml
# ~/.omp/agent/config.yml or <repo>/.omp/config.yml
hindsight:
  apiToken: user:password
```

Do not commit real credentials in project configuration. Prefer `/settings` or the global
configuration file for a real value. Tokens without a colon keep the existing Bearer behavior.

### Verification

`test/hindsight-client.test.ts` pins all three cases: a plain token yields
`Bearer hs-token`, `memory:s3cr3t` yields the literal expected Basic value, and no credential
omits the header. Reverting the client change makes the Basic case fail with a Bearer header.

`bun run check:types` and `biome check` are clean. The focused Hindsight suite passes:
98 tests, 0 failures.
