### PR TITLE
fix(tui): prevent UUID prefixes rendering color swatches

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed hash-prefixed UUIDs in prose being misclassified as 8-digit CSS colors and receiving spurious swatches ([#7002](https://github.com/can1357/oh-my-pi/issues/7002)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1284,11 +1284,12 @@ function collapseInlineHtml(tokens: Token[]): Token[] {
 const DEFAULT_COLOR_SWATCH_GLYPH = "■";
 
 // `#` + 3-8 hex digits, not glued to a surrounding word/`#`/`&` (avoids HTML
-// entities like &#9731; and paths like foo#fff) and not trailed by more hex
-// (so over-long runs never produce a misleading swatch). Length/letter rules
-// are enforced in classifyHexColor since the alternation can't express "exactly
-// 3, 6, or 8".
-const HEX_COLOR_REGEX = /(?<![\w#&])#([0-9a-fA-F]{3,8})(?![0-9a-fA-F])/g;
+// entities like &#9731; and paths like foo#fff), not the start of a canonical
+// UUID, and not trailed by more hex (so over-long runs never produce a
+// misleading swatch). Length/letter rules are enforced in classifyHexColor
+// since the alternation can't express "exactly 3, 6, or 8".
+const HEX_COLOR_REGEX =
+	/(?<![\w#&])#(?![0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})([0-9a-fA-F]{3,8})(?![0-9a-fA-F])/g;
 const HEX_COLOR_EXACT_REGEX = /^#([0-9a-fA-F]{3,8})$/;
 
 /**

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1751,6 +1751,21 @@ describe("Inline color swatches", () => {
 		expect(code.includes("■")).toBe(false);
 	});
 
+	it("does not swatch hash-prefixed UUIDs in prose", () => {
+		const uuid = new Markdown(
+			"Use feedback ID #6635765d-4a44-4a5e-a536-a8b72b0395b5 for testing.",
+			0,
+			0,
+			defaultMarkdownTheme,
+		)
+			.render(80)
+			.join("");
+		expect(uuid.includes("■")).toBe(false);
+
+		const color = new Markdown("Use color #6635765d.", 0, 0, defaultMarkdownTheme).render(80).join("");
+		expect(color.includes(swatchFor("6635765d"))).toBeTruthy();
+	});
+
 	it("uses the theme's colorSwatch symbol when provided", () => {
 		const themed = { ...defaultMarkdownTheme, symbols: { ...defaultMarkdownTheme.symbols, colorSwatch: "▢" } };
 		const out = new Markdown("Accent #C5FFD6.", 0, 0, themed).render(80).join("\n");


### PR DESCRIPTION
## Repro

On current `main`, running `bun -e 'import { Markdown } from "@oh-my-pi/pi-tui/components/markdown"; import { defaultMarkdownTheme } from "./packages/tui/test/test-themes.ts"; const out = new Markdown("Use feedback ID #6635765d-4a44-4a5e-a536-a8b72b0395b5 for testing.", 0, 0, defaultMarkdownTheme).render(120).join("\n"); console.log(out.includes("■"));'` prints `true`: the rendered prose inserts a color swatch before the UUID.

## Cause

`HEX_COLOR_REGEX` in `packages/tui/src/components/markdown.ts` accepted the first eight hexadecimal UUID characters as `#RRGGBBAA`; its trailing boundary allowed the following UUID hyphen, so `renderTextWithSwatches()` classified the prefix as a CSS color.

## Fix

- Exclude canonical UUID shapes before matching prose hex colors while preserving standalone 8-digit CSS colors.
- Add a Markdown rendering regression test for a hash-prefixed UUID and the standalone-color boundary.
- Document the fix in the TUI changelog.

## Verification

`bun test packages/tui/test/markdown.test.ts --filter 'Inline color swatches'` passed 138 tests with 0 failures. The post-fix render smoke check returned `{"uuidHasSwatch":false,"colorHasSwatch":true}`.

Fixes #7002