### PR TITLE
perf(prompts): streamline tool guidance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Reduced bash, grep, and glob tool guidance while making shell/eval boundaries, broad-search timeout avoidance, and local-only glob routing explicit.
+- Reduced bash, grep, and glob tool guidance while preserving supported internal-URL routes and making shell/eval boundaries and broad-search timeout avoidance explicit.
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced bash, grep, and glob tool guidance while making shell/eval boundaries, broad-search timeout avoidance, and local-only glob routing explicit.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -13,11 +13,11 @@ Use ONLY for one binary or a short pipeline that computes a fact (`wc -l`, `sort
 </instruction>
 
 <critical>
-{{#if hasGrep}}- Search with built-in `grep`, never shell `grep`/`rg`.{{/if}}
-{{#if hasRead}}{{#if hasGlob}}- List directories with `read` and find paths with `glob`; never use `ls`/`find`.{{/if}}{{/if}}
+{{#if hasGrep}}- NEVER use shell `grep`/`rg`; use built-in `grep`.{{/if}}
+{{#if hasRead}}{{#if hasGlob}}- List directories with `read` and find paths with `glob`; NEVER use `ls`/`find`.{{/if}}{{/if}}
 - Avoid `head`, `tail`, and redirection: output is captured, truncated, and linked as `artifact://<id>`.
 {{#if hasLaunch}}- Services, watchers, debuggers, and REPLs MUST use `hub` (`op:"start"`).{{/if}}
 </critical>
 
-{{#if autoBackgroundEnabled}}Long foreground calls may auto-background and deliver later. Need inline? Raise `timeout`{{#if asyncEnabled}} or use `async: true`{{/if}}.{{/if}}
+{{#if autoBackgroundEnabled}}Long foreground calls may auto-background and deliver later. Need inline? Raise `timeout`.{{/if}}
 No truncation footer means the displayed output is complete.

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -1,25 +1,23 @@
-Runs commands in a persistent shell session.
+Runs commands in a persistent shell.
 
-Use ONLY for: single binary call or short pipeline that COMPUTES a fact (`wc -l`, `sort | uniq -c`, `comm`, `diff`).
-{{#if hasLaunch}}Services, watchers, debuggers, REPLs → `hub` (`op:"start"`).{{/if}}
-{{#if hasEval}}Inline scripts, heredocs, shell control flow, `$(…)`, multi-stage pipelines, `&&`-chains, quote/JSON escaping → `eval` cells.{{else}}Inline scripts, heredocs, shell control flow, `$(…)`, multi-stage pipelines, `&&`-chains → purpose-built tool or checked-in script.{{/if}}
+Use ONLY for one binary or a short pipeline that computes a fact (`wc -l`, `sort | uniq -c`, `diff`).
+{{#if hasEval}}Inline scripts, heredocs, `$(…)`, complex control flow/quoting, and non-trivial pipelines → `eval`.{{else}}Inline scripts, heredocs, `$(…)`, and complex control flow → a purpose-built tool or checked-in script.{{/if}}
 
 <instruction>
-- `cwd` sets working dir (not `cd dir && …`). `env: { NAME: "…" }` for multiline/quote-heavy values; `"$NAME"` to expand.
-- `pty: true` only for real terminal needs (`sudo`, `ssh`); default `false`.
-- Multiple calls run concurrently; NEVER split order-dependent commands — chain with `&&` in one call (`;` only to continue past failure).
-- Internal URIs (`skill://`, `agent://`, …) auto-resolve to FS paths.
-{{#if hasShellBuiltins}}- aux utils available: mkdir, head, tail, wc, sort, ls, find, grep, rg, fd, cat, uniq, base64, cmp, md5sum, sha{1,224,256,384,512}sum, b2sum, basename, dirname, readlink, realpath, touch, stat, date, mktemp, seq, yes, printenv, truncate, tac, nproc, uname, whoami, hostname, which, diff, cut, tee, tr, paste, comm, sed, xargs, jq, rm, mv, ln, ts, sponge, ifne, isutf8, combine{{#unless isWindows}}, errno{{/unless}}{{/if}}
-{{#if asyncEnabled}}- `async: true` defers reporting for finite commands needing no later input.{{/if}}
+- Set `cwd` instead of `cd`; use `env: { NAME: "…" }` for multiline/quote-heavy values.
+- `pty: true` only for terminal interaction (`sudo`, `ssh`).
+- Order-dependent commands use `&&` in one call; independent calls may run concurrently.
+- Internal URIs (`skill://`, `agent://`, …) auto-resolve to paths.
+{{#if hasShellBuiltins}}- aux utils available: mkdir, wc, sort, comm, diff, uniq, base64, cmp, md5sum, sha{1,224,256,384,512}sum, b2sum, basename, dirname, readlink, realpath, touch, stat, date, mktemp, seq, yes, printenv, truncate, tac, nproc, uname, whoami, hostname, which, cut, tee, tr, paste, sed, xargs, jq, rm, mv, ln, ts, sponge, ifne, isutf8, combine{{#unless isWindows}}, errno{{/unless}}{{/if}}
+{{#if asyncEnabled}}- `async: true` defers a finite command's result; it does not extend `timeout`.{{/if}}
 </instruction>
 
 <critical>
-{{#if hasGrep}}- NEVER shell out to search: `grep`/`rg` → built-in `grep`.{{/if}}
-{{#if hasRead}}{{#if hasGlob}}- NEVER use `ls` or `find` — `ls` → `read`, `find` → `glob`. NON-NEGOTIABLE.{{/if}}{{/if}}
-- Avoid head/tail/redirections: stderr merged, output auto-truncated, full capture at `artifact://<id>`.
-{{#if hasLaunch}}- NEVER launch daemons/watchers/servers/debuggers/REPLs through bash — use `hub` (`op:"start"`).{{/if}}
+{{#if hasGrep}}- Search with built-in `grep`, never shell `grep`/`rg`.{{/if}}
+{{#if hasRead}}{{#if hasGlob}}- List directories with `read` and find paths with `glob`; never use `ls`/`find`.{{/if}}{{/if}}
+- Avoid `head`, `tail`, and redirection: output is captured, truncated, and linked as `artifact://<id>`.
+{{#if hasLaunch}}- Services, watchers, debuggers, and REPLs MUST use `hub` (`op:"start"`).{{/if}}
 </critical>
 
-{{#if asyncEnabled}}- `timeout`: nonzero clamped 1–3600, killed on elapse. `async: true` defers reporting only, doesn't extend timeout.{{/if}}
-{{#if autoBackgroundEnabled}}- Long foreground calls may auto-background; result arrives as follow-up — NOT a failure. Need inline? Raise timeout{{#if asyncEnabled}} or `async: true`{{/if}}.{{/if}}
-- Long output truncated, test/lint filtered to failures. Footer links full capture. No footer = what you see is exact output.
+{{#if autoBackgroundEnabled}}Long foreground calls may auto-background and deliver later. Need inline? Raise `timeout`{{#if asyncEnabled}} or use `async: true`{{/if}}.{{/if}}
+No truncation footer means the displayed output is complete.

--- a/packages/coding-agent/src/prompts/tools/glob.md
+++ b/packages/coding-agent/src/prompts/tools/glob.md
@@ -1,15 +1,16 @@
-Globs files and directories via fast pattern matching, any codebase size.
+Globs the local filesystem with fast pattern matching.
 
 <instruction>
-- `path`: a glob, file, or directory. Search several at once by passing a semicolon-delimited list (`src/**/*.ts; test/**/*.ts`).
-- `gitignore` (default `true`) hides `.gitignore` matches. Set `gitignore: false` to find `.env*`, `*.log`, fresh build outputs, or anything your repo ignores.
-- `hidden` (default `true`); combine with `gitignore: false` to surface dotfiles also gitignored.
+- `path`: glob, file, or directory; separate targets with `;` (`src/**/*.ts; test/**/*.ts`).
+- Local filesystem only. For `ssh://` paths or internal URI discovery, use `read`; internal URI globs are unsupported.
+- `gitignore` defaults `true`. Set `false` for ignored files such as `.env*`, logs, or build output.
+- `hidden` defaults `true`; pair it with `gitignore: false` for ignored dotfiles.
 </instruction>
 
 <output>
-Matching paths sorted by mtime (newest first), grouped under `# <dir>/` headers with basenames below; directories get a trailing `/`.
+Matches are newest-first and grouped by directory; directories end in `/`.
 </output>
 
 <avoid>
-Open-ended searches needing multiple rounds of globbing/searching: you MUST use the Task tool instead.
+Open-ended multi-round discovery → Task + scout.
 </avoid>

--- a/packages/coding-agent/src/prompts/tools/glob.md
+++ b/packages/coding-agent/src/prompts/tools/glob.md
@@ -1,8 +1,8 @@
-Globs the local filesystem with fast pattern matching.
+Globs files, directories, and path-backed internal URLs with fast pattern matching.
 
 <instruction>
-- `path`: glob, file, or directory; separate targets with `;` (`src/**/*.ts; test/**/*.ts`).
-- Local filesystem only. For `ssh://` paths or internal URI discovery, use `read`; internal URI globs are unsupported.
+- `path`: glob, file, directory, or path-backed internal URL; separate targets with `;` (`src/**/*.ts; test/**/*.ts`).
+- `memory://` glob patterns are supported. `ssh://` has no local path; use `read`. Other internal URLs accept exact paths only.
 - `gitignore` defaults `true`. Set `false` for ignored files such as `.env*`, logs, or build output.
 - `hidden` defaults `true`; pair it with `gitignore: false` for ignored dotfiles.
 </instruction>

--- a/packages/coding-agent/src/prompts/tools/grep.md
+++ b/packages/coding-agent/src/prompts/tools/grep.md
@@ -1,12 +1,13 @@
-Greps files using regex (Rust regex + PCRE2).
+Searches local files with Rust regex plus PCRE2 fallback.
 
 <instruction>
-- `path`: scope to known path (e.g. `src`); pass several as delimited list (`src; tests`).
-  Line selector on one file (`src/foo.ts:50-100`); selectors never choose search root.
-- Cross-line patterns from literal `\n` or `\\n` in `pattern`.
+- Scope `path` to known files/directories; separate roots with `;`.
+- Broad searches can time out; scope them narrowly or use `glob` first.
+- One-file line selector: `src/foo.ts:50-100` (selectors never choose the search root).
+- Literal `\n` or `\\n` enables cross-line patterns.
 </instruction>
 
 <critical>
-- MUST use this over bash when searching!
-- Open-ended multi-round search → Task tool + scout subagent, NOT chained `grep` calls.
+- Use this instead of shell `grep`/`rg`.
+- Open-ended multi-round search → Task + scout, not chained calls.
 </critical>

--- a/packages/coding-agent/src/prompts/tools/grep.md
+++ b/packages/coding-agent/src/prompts/tools/grep.md
@@ -1,13 +1,13 @@
-Searches local files with Rust regex plus PCRE2 fallback.
+Searches files and internal URLs with Rust regex plus PCRE2 fallback.
 
 <instruction>
-- Scope `path` to known files/directories; separate roots with `;`.
+- Scope `path` to known files, directories, globs, or internal URLs; separate roots with `;`.
 - Broad searches can time out; scope them narrowly or use `glob` first.
 - One-file line selector: `src/foo.ts:50-100` (selectors never choose the search root).
 - Literal `\n` or `\\n` enables cross-line patterns.
 </instruction>
 
 <critical>
-- Use this instead of shell `grep`/`rg`.
-- Open-ended multi-round search → Task + scout, not chained calls.
+- MUST use this instead of shell `grep`/`rg`.
+- Open-ended multi-round search MUST use Task + scout, not chained calls.
 </critical>

--- a/packages/coding-agent/test/tool-guidance-efficiency.test.ts
+++ b/packages/coding-agent/test/tool-guidance-efficiency.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import * as prompt from "../../utils/src/prompt";
+import { prompt } from "@oh-my-pi/pi-utils";
 import bashPrompt from "../src/prompts/tools/bash.md" with { type: "text" };
 import globPrompt from "../src/prompts/tools/glob.md" with { type: "text" };
 import grepPrompt from "../src/prompts/tools/grep.md" with { type: "text" };
@@ -25,6 +25,8 @@ describe("tool guidance efficiency", () => {
 	test("routes shell work without contradicting the eval boundary", () => {
 		expect(bash).toMatch(/order-dependent[^\n]*`&&`[^\n]*one call/iu);
 		expect(bash).not.toMatch(/inline scripts[^\n]*`&&`/iu);
+		expect(bash).not.toMatch(/Need inline\?[^\n]*async/iu);
+		expect(bash).toMatch(/\bNEVER\b[^\n]*shell `grep`\/`rg`/u);
 
 		const advertisedUtilities = bash.split("\n").find(line => line.includes("aux utils available"));
 		expect(advertisedUtilities).toBeDefined();
@@ -35,10 +37,14 @@ describe("tool guidance efficiency", () => {
 		expect(grep).toMatch(/broad searches[^\n]*time out[^\n]*(?:narrow|scope)/iu);
 	});
 
-	test("routes remote and internal URI discovery away from glob", () => {
-		expect(glob).toMatch(/local filesystem/iu);
+	test("preserves supported search and glob routes", () => {
+		expect(glob).toMatch(/path-backed internal URLs/iu);
 		expect(glob).toMatch(/`ssh:\/\/`[^\n]*`read`/iu);
-		expect(glob).toMatch(/internal URI/iu);
+		expect(glob).toMatch(/`memory:\/\/`[^\n]*support/iu);
+		expect(glob).not.toMatch(/internal URI globs are unsupported/iu);
+		expect(grep).toMatch(/internal URL/iu);
+		expect(grep).not.toMatch(/^Searches local files/iu);
+		expect(grep).toMatch(/\bMUST\b[^\n]*shell `grep`\/`rg`/u);
 	});
 
 	test("keeps the corrected guidance smaller than the previous prompt set", () => {

--- a/packages/coding-agent/test/tool-guidance-efficiency.test.ts
+++ b/packages/coding-agent/test/tool-guidance-efficiency.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import * as prompt from "../../utils/src/prompt";
+import bashPrompt from "../src/prompts/tools/bash.md" with { type: "text" };
+import globPrompt from "../src/prompts/tools/glob.md" with { type: "text" };
+import grepPrompt from "../src/prompts/tools/grep.md" with { type: "text" };
+
+const bash = prompt.render(bashPrompt, {
+	asyncEnabled: true,
+	autoBackgroundEnabled: true,
+	autoBackgroundThresholdSeconds: 60,
+	hasAstEdit: true,
+	hasAstGrep: true,
+	hasEval: true,
+	hasGlob: true,
+	hasGrep: true,
+	hasLaunch: true,
+	hasRead: true,
+	hasShellBuiltins: true,
+	isWindows: false,
+});
+const glob = prompt.render(globPrompt);
+const grep = prompt.render(grepPrompt);
+
+describe("tool guidance efficiency", () => {
+	test("routes shell work without contradicting the eval boundary", () => {
+		expect(bash).toMatch(/order-dependent[^\n]*`&&`[^\n]*one call/iu);
+		expect(bash).not.toMatch(/inline scripts[^\n]*`&&`/iu);
+
+		const advertisedUtilities = bash.split("\n").find(line => line.includes("aux utils available"));
+		expect(advertisedUtilities).toBeDefined();
+		expect(advertisedUtilities).not.toMatch(/\b(?:fd|find|grep|ls|rg)\b/u);
+	});
+
+	test("prevents broad grep timeouts before execution", () => {
+		expect(grep).toMatch(/broad searches[^\n]*time out[^\n]*(?:narrow|scope)/iu);
+	});
+
+	test("routes remote and internal URI discovery away from glob", () => {
+		expect(glob).toMatch(/local filesystem/iu);
+		expect(glob).toMatch(/`ssh:\/\/`[^\n]*`read`/iu);
+		expect(glob).toMatch(/internal URI/iu);
+	});
+
+	test("keeps the corrected guidance smaller than the previous prompt set", () => {
+		expect(bash.length + grep.length + glob.length).toBeLessThan(3_050);
+	});
+});


### PR DESCRIPTION
## Summary
- remove contradictory bash/eval routing and prohibited helper binaries from the shell descriptor
- add explicit scoping guidance for broad grep searches while preserving supported internal URLs
- preserve `memory://` glob patterns, route `ssh://` discovery through read, and retain RFC 2119 authority markers
- reduce the rendered bash/grep/glob descriptor footprint by 483 characters (15.0%)

## Verification
- focused rendered guidance contract: 4 passed
- `bun run check:ts` passed
- `bun check` reached the Rust build and stopped because the environment lacks CMake for `audiopus_sys`; no TypeScript/test failure