### PR TITLE
test(ai,catalog): give spawn-based lazy tests explicit timeouts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed spawn-based lazy-loading tests (`oauth-barrel-import`, `auth-broker-wire-lazy-construction`, `cursor-transport-error`) flaking under CPU contention by giving each an explicit 60s per-test timeout instead of relying on bun's 5s default ([#7018](https://github.com/can1357/oh-my-pi/issues/7018)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/test/auth-broker-wire-lazy-construction.test.ts
+++ b/packages/ai/test/auth-broker-wire-lazy-construction.test.ts
@@ -34,4 +34,4 @@ test("auth-broker wire schemas construct only on first validation", async () => 
 	} finally {
 		await tempDir.remove().catch(() => {});
 	}
-});
+}, 60_000);

--- a/packages/ai/test/cursor-transport-error.test.ts
+++ b/packages/ai/test/cursor-transport-error.test.ts
@@ -20,5 +20,5 @@ describe("Cursor transport errors", () => {
 			eventTypes: ["start", "error"],
 			stopReason: "error",
 		});
-	});
+	}, 60_000);
 });

--- a/packages/ai/test/oauth-barrel-import.test.ts
+++ b/packages/ai/test/oauth-barrel-import.test.ts
@@ -12,5 +12,5 @@ describe("OAuth barrel imports", () => {
 		const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()]);
 
 		expect(exitCode, stderr).toBe(0);
-	});
+	}, 60_000);
 });

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed spawn-based lazy-loading tests (`bundled-reference-laziness`, `models-lazy-provider-cache`) flaking under CPU contention by giving each an explicit 60s per-test timeout instead of relying on bun's 5s default ([#7018](https://github.com/can1357/oh-my-pi/issues/7018)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Added

--- a/packages/catalog/test/bundled-reference-laziness.test.ts
+++ b/packages/catalog/test/bundled-reference-laziness.test.ts
@@ -14,7 +14,7 @@ describe("bundled reference laziness", () => {
 		expect(result.exitCode).toBe(0);
 		const { retainedRssBytes } = JSON.parse(result.stdout.toString()) as { retainedRssBytes: number };
 		expect(retainedRssBytes).toBeLessThan(8 * 1024 * 1024);
-	});
+	}, 60_000);
 
 	test("a provider-local reference hit retains less than 8 MiB of RSS", () => {
 		const result = Bun.spawnSync({
@@ -28,7 +28,7 @@ describe("bundled reference laziness", () => {
 		};
 		expect(resolvedId).not.toBeNull();
 		expect(retainedRssBytes).toBeLessThan(8 * 1024 * 1024);
-	});
+	}, 60_000);
 
 	test("a lazy provider-reference factory initializes on first resolution and only once", () => {
 		const reference = {

--- a/packages/catalog/test/models-lazy-provider-cache.test.ts
+++ b/packages/catalog/test/models-lazy-provider-cache.test.ts
@@ -8,4 +8,4 @@ test("bundled models are enriched one provider at a time", () => {
 		env: process.env,
 	});
 	expect(result.exitCode, result.stderr.toString()).toBe(0);
-});
+}, 60_000);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the spawn-based models config validator laziness test flaking under CPU contention by giving its two sequential probe processes an explicit 60s per-test timeout instead of sharing bun's 5s default ([#7018](https://github.com/can1357/oh-my-pi/issues/7018)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/test/models-config-lazy-validator.test.ts
+++ b/packages/coding-agent/test/models-config-lazy-validator.test.ts
@@ -62,4 +62,4 @@ test("models config validation resources are retained only for a custom config",
 	} finally {
 		await tempDir.remove().catch(() => {});
 	}
-});
+}, 60_000);


### PR DESCRIPTION
## Repro
Spawn-based lazy-loading tests in `packages/ai` and `packages/catalog` spawn a child process (loading the ~2MB `models.json` catalog or the pi-ai barrel) and assert `exitCode === 0`, but set no per-test timeout. Under CPU contention bun's default 5000ms per-test budget kills the child before it finishes, so the assertion reports a dead child rather than an actual regression, flaking `Test TS workspace fast` across unrelated PRs. Reproduced deterministically without relying on contention by forcing a short budget:

```
$ bun test --timeout=1 test/bundled-reference-laziness.test.ts   # cwd: packages/catalog
(fail) bundled reference laziness > constructing bundled model-manager options retains less than 8 MiB of RSS
  ^ this test timed out after 1ms.
expect(result.exitCode).toBe(0) -> Expected: 0, Received: null
```

## Cause
The affected `test(...)`/`it(...)` calls in `bundled-reference-laziness.test.ts`, `models-lazy-provider-cache.test.ts`, `oauth-barrel-import.test.ts`, `auth-broker-wire-lazy-construction.test.ts`, and `cursor-transport-error.test.ts` pass no third-argument timeout, so they inherit bun's 5000ms per-test default. Their cost is dominated by child-process startup, which unrelated bucket slowdown + CPU contention can push past 5s; the `exitCode === 0` assertion then fails on the killed child.

## Fix
- Added an explicit `}, 60_000)` per-test timeout to every spawn-based test in the two fast-workspace packages (6 tests across 5 files), matching the existing precedent in `packages/ai/test/auth-gateway-anthropic-caching.test.ts`.
- The in-process (non-spawn) test in `bundled-reference-laziness.test.ts` is left unchanged.
- Changelog entries under `[Unreleased]` in `packages/ai` and `packages/catalog`.

## Verification
Bun's explicit per-test timeout overrides the CLI `--timeout`, so the same forced-short-budget repro now passes:

```
$ bun test --timeout=1 test/bundled-reference-laziness.test.ts test/models-lazy-provider-cache.test.ts   # catalog -> 4 pass, 0 fail
$ bun test --timeout=1 test/oauth-barrel-import.test.ts test/auth-broker-wire-lazy-construction.test.ts test/cursor-transport-error.test.ts   # ai -> 3 pass, 0 fail
```

And under the reporter's actual trigger, `taskset -c 0 bun test --parallel=8` in `packages/catalog` passed 3/3 (0 fail each run). Fixes #7018