### PR TITLE
fix(ai): preserve API-key validation HTTP errors

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- API-key validation now preserves provider HTTP status and retry headers, allowing authentication, rate-limit, and server failures to retain their existing error classification instead of reporting every non-success response as a missing key.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/registry/api-key-validation.ts
+++ b/packages/ai/src/registry/api-key-validation.ts
@@ -1,4 +1,4 @@
-import * as AIError from "../error";
+import { ProviderHttpError } from "../error/classes";
 import type { FetchImpl } from "../types";
 
 type OpenAICompatibleValidationOptions = {
@@ -40,6 +40,20 @@ function resolveValidationHeaders(
 	return typeof headers === "function" ? headers() : headers;
 }
 
+async function createApiKeyValidationError(provider: string, response: Response): Promise<ProviderHttpError> {
+	let details = "";
+	try {
+		details = (await response.text()).trim();
+	} catch {
+		// Ignore body read errors; the HTTP status still preserves the failure category.
+	}
+
+	const message = details
+		? `${provider} API key validation failed (${response.status}): ${details}`
+		: `${provider} API key validation failed (${response.status})`;
+	return new ProviderHttpError(message, response.status, { headers: response.headers });
+}
+
 /**
  * Validate an API key against an OpenAI-compatible chat completions endpoint.
  *
@@ -69,17 +83,7 @@ export async function validateOpenAICompatibleApiKey(options: OpenAICompatibleVa
 		return;
 	}
 
-	let details = "";
-	try {
-		details = (await response.text()).trim();
-	} catch {
-		// ignore body parse errors, status is enough
-	}
-
-	const message = details
-		? `${options.provider} API key validation failed (${response.status}): ${details}`
-		: `${options.provider} API key validation failed (${response.status})`;
-	throw new AIError.ApiKeyRequiredError(message);
+	throw await createApiKeyValidationError(options.provider, response);
 }
 
 /**
@@ -110,17 +114,7 @@ export async function validateAnthropicCompatibleApiKey(options: AnthropicCompat
 		return;
 	}
 
-	let details = "";
-	try {
-		details = (await response.text()).trim();
-	} catch {
-		// ignore body parse errors, status is enough
-	}
-
-	const message = details
-		? `${options.provider} API key validation failed (${response.status}): ${details}`
-		: `${options.provider} API key validation failed (${response.status})`;
-	throw new AIError.ApiKeyRequiredError(message);
+	throw await createApiKeyValidationError(options.provider, response);
 }
 
 /**
@@ -147,15 +141,5 @@ export async function validateApiKeyAgainstModelsEndpoint(options: ModelListVali
 		return;
 	}
 
-	let details = "";
-	try {
-		details = (await response.text()).trim();
-	} catch {
-		// ignore body parse errors, status is enough
-	}
-
-	const message = details
-		? `${options.provider} API key validation failed (${response.status}): ${details}`
-		: `${options.provider} API key validation failed (${response.status})`;
-	throw new AIError.ApiKeyRequiredError(message);
+	throw await createApiKeyValidationError(options.provider, response);
 }

--- a/packages/ai/test/api-key-validation.test.ts
+++ b/packages/ai/test/api-key-validation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import { ApiKeyRequiredError } from "../src/error/auth";
+import { ProviderHttpError } from "../src/error/classes";
+import { classify, Flag, is } from "../src/error/flags";
+import {
+	validateAnthropicCompatibleApiKey,
+	validateApiKeyAgainstModelsEndpoint,
+	validateOpenAICompatibleApiKey,
+} from "../src/registry/api-key-validation";
+import type { FetchImpl } from "../src/types";
+
+type Validator = (fetch: FetchImpl) => Promise<void>;
+
+const validators: ReadonlyArray<readonly [string, Validator]> = [
+	[
+		"OpenAI-compatible chat completions",
+		fetch =>
+			validateOpenAICompatibleApiKey({
+				provider: "test-provider",
+				apiKey: "test-key",
+				baseUrl: "https://example.test/v1",
+				model: "test-model",
+				fetch,
+			}),
+	],
+	[
+		"Anthropic-compatible messages",
+		fetch =>
+			validateAnthropicCompatibleApiKey({
+				provider: "test-provider",
+				apiKey: "test-key",
+				baseUrl: "https://example.test/v1",
+				model: "test-model",
+				fetch,
+			}),
+	],
+	[
+		"models endpoint",
+		fetch =>
+			validateApiKeyAgainstModelsEndpoint({
+				provider: "test-provider",
+				apiKey: "test-key",
+				modelsUrl: "https://example.test/v1/models",
+				fetch,
+			}),
+	],
+];
+
+async function captureError(run: () => Promise<void>): Promise<Error> {
+	try {
+		await run();
+	} catch (error) {
+		if (error instanceof Error) return error;
+		throw new Error("validator rejected with a non-Error value");
+	}
+	throw new Error("validator unexpectedly succeeded");
+}
+
+describe("API key validation HTTP errors", () => {
+	it.each(validators)("preserves HTTP metadata for %s", async (_name, validate) => {
+		const fetchMock: FetchImpl = async () =>
+			new Response('{"error":"rate limited"}', {
+				status: 429,
+				headers: { "Retry-After": "17" },
+			});
+
+		const error = await captureError(() => validate(fetchMock));
+
+		expect(error).toBeInstanceOf(ProviderHttpError);
+		expect(error).not.toBeInstanceOf(ApiKeyRequiredError);
+		const httpError = error as ProviderHttpError;
+		expect(httpError.status).toBe(429);
+		expect(httpError.headers?.get("Retry-After")).toBe("17");
+		expect(httpError.message).toContain('test-provider API key validation failed (429): {"error":"rate limited"}');
+	});
+
+	it.each([
+		{ status: 401, authFailed: true, transient: false },
+		{ status: 403, authFailed: true, transient: false },
+		{ status: 402, authFailed: false, transient: false },
+		{ status: 429, authFailed: false, transient: true },
+		{ status: 503, authFailed: false, transient: true },
+	])("classifies HTTP $status without reporting a missing key", async expectation => {
+		const fetchMock: FetchImpl = async () => new Response("validation failure", { status: expectation.status });
+		const error = await captureError(() => validators[0]![1](fetchMock));
+
+		expect(error).toBeInstanceOf(ProviderHttpError);
+		expect((error as ProviderHttpError).status).toBe(expectation.status);
+		expect(error).not.toBeInstanceOf(ApiKeyRequiredError);
+		const flags = classify(error);
+		expect(is(flags, Flag.AuthFailed)).toBe(expectation.authFailed);
+		expect(is(flags, Flag.Transient)).toBe(expectation.transient);
+	});
+
+	it("propagates network failures without relabeling them as credential failures", async () => {
+		const networkError = new TypeError("fetch failed");
+		const fetchMock: FetchImpl = async () => {
+			throw networkError;
+		};
+
+		const error = await captureError(() => validators[0]![1](fetchMock));
+
+		expect(error).toBe(networkError);
+		expect(error).not.toBeInstanceOf(ProviderHttpError);
+		expect(error).not.toBeInstanceOf(ApiKeyRequiredError);
+	});
+});


### PR DESCRIPTION
## What

- Preserve upstream HTTP status, response body, and headers from all shared API-key validators.
- Keep transport failures unchanged instead of relabeling them as missing credentials.
- Add focused classification coverage for authentication, payment, rate-limit, server, and network failures.

## Why

Validation currently maps every non-success response to `ApiKeyRequiredError`, so throttling and provider outages look like missing credentials. It also drops `Retry-After` metadata used by the existing error classifier. This is a prerequisite for #5281 because future API-key login flows need accurate failure categories.

## Testing

- `bun test packages/ai/test/api-key-validation.test.ts packages/ai/test/openrouter-login.test.ts packages/ai/test/alibaba-token-plan.test.ts packages/ai/test/alibaba-endpoint-selection.test.ts`
- `cd packages/ai && bun run check`

---

- [x] Package-local check passes
- [x] Tested locally
- [x] CHANGELOG updated
