### PR TITLE
feat(coding-agent): add confidential terminal input helper

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -450,6 +450,9 @@
 ### Removed
 
 - Removed the dangling `MCPManager.setOnNotification` single-slot setter, which had no callers in the runtime. Replaced by `MCPManager.addNotificationListener` — multi-listener, per-listener error isolation, returns an unsubscribe function.
+### Added
+
+- Added a reusable confidential terminal-input helper that requires exclusive ownership of a raw-mode TTY, rejects concurrent or shared input consumers, never echoes the entered value, and restores terminal state after submission, cancellation, EOF, or stream failures.
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/coding-agent/src/cli/secret-input.ts
+++ b/packages/coding-agent/src/cli/secret-input.ts
@@ -88,6 +88,9 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 		let promptStarted = false;
 		let settled = false;
 		let awaitingBufferedLineFeed = suppressBufferedLineFeed;
+		let pendingEscape = false;
+		let escapeSequence: "csi" | "ss3" | undefined;
+		let escapeTimer: NodeJS.Timeout | undefined;
 		let value = "";
 
 		const cleanup = (): unknown => {
@@ -96,7 +99,7 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 			input.off("end", onEnd);
 			input.off("close", onEnd);
 			signal?.removeEventListener("abort", onAbort);
-
+			clearTimeout(escapeTimer);
 			let cleanupError: unknown;
 			if (rawModeTouched) {
 				try {
@@ -110,15 +113,23 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 			return cleanupError;
 		};
 
-		const finish = (result: { value: string } | { error: unknown }): void => {
+		const finish = (result: { value: string } | { error: unknown }, remainder?: Buffer): void => {
 			if (settled) return;
 			settled = true;
 			const cleanupError = cleanup();
+			let remainderError: unknown;
+			if (remainder && remainder.length > 0) {
+				try {
+					input.unshift(remainder);
+				} catch (error) {
+					remainderError = error;
+				}
+			}
 			try {
 				if (promptStarted) output.write("\n");
 			} catch (error) {
 				value = "";
-				reject(cleanupError ?? error);
+				reject(cleanupError ?? remainderError ?? error);
 				return;
 			}
 			if ("error" in result && result.error instanceof SecretInputUnavailableError) {
@@ -126,9 +137,9 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 				reject(result.error);
 				return;
 			}
-			if (cleanupError !== undefined) {
+			if (cleanupError !== undefined || remainderError !== undefined) {
 				value = "";
-				reject(cleanupError);
+				reject(cleanupError ?? remainderError);
 				return;
 			}
 			if ("error" in result) {
@@ -141,22 +152,44 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 		};
 
 		function onData(chunk: Buffer | string): void {
-			const text = typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
+			const bytes = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+			const text = decoder.decode(bytes, { stream: true });
 			const characters = Array.from(text);
+			let terminatorSearchStart = 0;
 			for (let index = 0; index < characters.length; index++) {
 				const character = characters[index]!;
 				if (settled) return;
-				if (awaitingBufferedLineFeed) {
-					awaitingBufferedLineFeed = false;
-					if (character === "\n") continue;
-				}
-				if (character === "\r") {
-					if (characters[index + 1] !== "\n") inputsAwaitingLineFeed.add(input);
-					finish({ value });
+				if (pendingEscape) {
+					pendingEscape = false;
+					if (escapeTimer) clearTimeout(escapeTimer);
+					escapeTimer = undefined;
+					if (character === "[" || character === "O") {
+						escapeSequence = character === "[" ? "csi" : "ss3";
+						continue;
+					}
+					finish({ error: new SecretInputCancelledError() }, Buffer.from(characters.slice(index).join("")));
 					return;
 				}
-				if (character === "\n") {
-					finish({ value });
+				if (escapeSequence) {
+					if (escapeSequence === "ss3" || (character >= "@" && character <= "~")) {
+						escapeSequence = undefined;
+					}
+					continue;
+				}
+				if (awaitingBufferedLineFeed) {
+					awaitingBufferedLineFeed = false;
+					if (character === "\n") {
+						terminatorSearchStart = bytes.indexOf(0x0a, terminatorSearchStart) + 1;
+						continue;
+					}
+				}
+				if (character === "\r" || character === "\n") {
+					const terminator = character === "\r" ? 0x0d : 0x0a;
+					const terminatorIndex = bytes.indexOf(terminator, terminatorSearchStart);
+					const hasLineFeed = character === "\r" && bytes[terminatorIndex + 1] === 0x0a;
+					const remainderStart = terminatorIndex + (hasLineFeed ? 2 : 1);
+					if (character === "\r" && remainderStart === bytes.length) inputsAwaitingLineFeed.add(input);
+					finish({ value }, bytes.subarray(remainderStart));
 					return;
 				}
 				if (character === "\b" || character === "\u007f") {
@@ -164,7 +197,22 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 					value = value.slice(0, graphemes.at(-1)?.index ?? 0);
 					continue;
 				}
-				if (character === "\u001b" || character === "\u0003") {
+				if (character === "\u001b") {
+					const sequencePrefix = characters[index + 1];
+					if (sequencePrefix === "[" || sequencePrefix === "O") {
+						escapeSequence = sequencePrefix === "[" ? "csi" : "ss3";
+						index++;
+						continue;
+					}
+					if (sequencePrefix === undefined) {
+						pendingEscape = true;
+						escapeTimer = setTimeout(() => finish({ error: new SecretInputCancelledError() }), 25);
+						continue;
+					}
+					finish({ error: new SecretInputCancelledError() }, Buffer.from(characters.slice(index + 1).join("")));
+					return;
+				}
+				if (character === "\u0003") {
 					finish({ error: new SecretInputCancelledError() });
 					return;
 				}

--- a/packages/coding-agent/src/cli/secret-input.ts
+++ b/packages/coding-agent/src/cli/secret-input.ts
@@ -1,4 +1,5 @@
 const activeSecretInputs = new WeakSet<NodeJS.ReadStream>();
+const inputsAwaitingLineFeed = new WeakSet<NodeJS.ReadStream>();
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 /** Writable terminal surface used by {@link promptSecretInput}. */
@@ -138,9 +139,20 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 
 		function onData(chunk: Buffer | string): void {
 			const text = typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
-			for (const character of text) {
+			const characters = Array.from(text);
+			for (let index = 0; index < characters.length; index++) {
+				const character = characters[index]!;
 				if (settled) return;
-				if (character === "\r" || character === "\n") {
+				if (inputsAwaitingLineFeed.has(input)) {
+					inputsAwaitingLineFeed.delete(input);
+					if (character === "\n") continue;
+				}
+				if (character === "\r") {
+					if (characters[index + 1] !== "\n") inputsAwaitingLineFeed.add(input);
+					finish({ value });
+					return;
+				}
+				if (character === "\n") {
 					finish({ value });
 					return;
 				}

--- a/packages/coding-agent/src/cli/secret-input.ts
+++ b/packages/coding-agent/src/cli/secret-input.ts
@@ -1,4 +1,5 @@
 const activeSecretInputs = new WeakSet<NodeJS.ReadStream>();
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 /** Writable terminal surface used by {@link promptSecretInput}. */
 export interface SecretInputOutput {
@@ -49,6 +50,13 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 
 	if (input.isTTY !== true || typeof input.setRawMode !== "function") {
 		return Promise.reject(new SecretInputUnavailableError());
+	}
+	if (input.readableEncoding !== null) {
+		return Promise.reject(
+			new SecretInputUnavailableError({
+				cause: new Error("Confidential input requires a byte-mode input stream"),
+			}),
+		);
 	}
 	if (signal?.aborted) {
 		return Promise.reject(signal.reason ?? new SecretInputCancelledError());
@@ -109,6 +117,11 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 				reject(cleanupError ?? error);
 				return;
 			}
+			if ("error" in result && result.error instanceof SecretInputUnavailableError) {
+				value = "";
+				reject(result.error);
+				return;
+			}
 			if (cleanupError !== undefined) {
 				value = "";
 				reject(cleanupError);
@@ -132,7 +145,8 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 					return;
 				}
 				if (character === "\b" || character === "\u007f") {
-					value = Array.from(value).slice(0, -1).join("");
+					const graphemes = Array.from(graphemeSegmenter.segment(value));
+					value = value.slice(0, graphemes.at(-1)?.index ?? 0);
 					continue;
 				}
 				if (character === "\u001b" || character === "\u0003") {

--- a/packages/coding-agent/src/cli/secret-input.ts
+++ b/packages/coding-agent/src/cli/secret-input.ts
@@ -1,5 +1,3 @@
-import { BracketedPasteHandler, decodeReencodedPasteControls } from "@oh-my-pi/pi-tui/bracketed-paste";
-
 const activeSecretInputs = new WeakSet<NodeJS.ReadStream>();
 const inputsAwaitingLineFeed = new WeakSet<NodeJS.ReadStream>();
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
@@ -86,7 +84,6 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 		const wasRaw = input.isRaw === true;
 		const wasFlowing = input.readableFlowing === true;
 		const decoder = new TextDecoder();
-		const pasteHandler = new BracketedPasteHandler();
 		let rawModeTouched = false;
 		let promptStarted = false;
 		let settled = false;
@@ -145,20 +142,6 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 
 		function onData(chunk: Buffer | string): void {
 			const text = typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
-			const paste = pasteHandler.process(text);
-			if (paste.handled) {
-				if (paste.pasteContent !== undefined) {
-					value += decodeReencodedPasteControls(paste.pasteContent)
-						.normalize("NFC")
-						.replace(/[\x00-\x1F\x7F]/g, "");
-					if (paste.remaining.length > 0) processCharacters(paste.remaining);
-				}
-				return;
-			}
-			processCharacters(text);
-		}
-
-		function processCharacters(text: string): void {
 			const characters = Array.from(text);
 			for (let index = 0; index < characters.length; index++) {
 				const character = characters[index]!;

--- a/packages/coding-agent/src/cli/secret-input.ts
+++ b/packages/coding-agent/src/cli/secret-input.ts
@@ -1,7 +1,4 @@
-import * as readline from "node:readline";
-
 const activeSecretInputs = new WeakSet<NodeJS.ReadStream>();
-const keypressDataListeners = new WeakMap<NodeJS.ReadStream, Array<(...args: unknown[]) => void>>();
 
 /** Writable terminal surface used by {@link promptSecretInput}. */
 export interface SecretInputOutput {
@@ -71,19 +68,18 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 
 	activeSecretInputs.add(input);
 
-	return new Promise<string>((resolve, reject) => {
+	const { promise, resolve, reject } = Promise.withResolvers<string>();
+	{
 		const wasRaw = input.isRaw === true;
 		const wasFlowing = input.readableFlowing === true;
+		const decoder = new TextDecoder();
 		let rawModeTouched = false;
 		let promptStarted = false;
 		let settled = false;
 		let value = "";
-		let ownedDataListeners = keypressDataListeners.get(input) ?? [];
 
 		const cleanup = (): unknown => {
-			input.off("keypress", onKeypress);
-			for (const listener of ownedDataListeners) input.off("data", listener);
-			ownedDataListeners = [];
+			input.off("data", onData);
 			input.off("error", onError);
 			input.off("end", onEnd);
 			input.off("close", onEnd);
@@ -127,25 +123,29 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 			resolve(result.value);
 		};
 
-		function onKeypress(text: string | undefined, key: readline.Key): void {
-			if (key.name === "return" || key.name === "enter") {
-				finish({ value });
-				return;
+		function onData(chunk: Buffer | string): void {
+			const text = typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
+			for (const character of text) {
+				if (settled) return;
+				if (character === "\r" || character === "\n") {
+					finish({ value });
+					return;
+				}
+				if (character === "\b" || character === "\u007f") {
+					value = Array.from(value).slice(0, -1).join("");
+					continue;
+				}
+				if (character === "\u001b" || character === "\u0003") {
+					finish({ error: new SecretInputCancelledError() });
+					return;
+				}
+				if (character === "\u0004") {
+					finish({ error: new Error("Confidential input ended before submission") });
+					return;
+				}
+				if (character < " ") continue;
+				value += character;
 			}
-			if (key.name === "backspace") {
-				value = Array.from(value).slice(0, -1).join("");
-				return;
-			}
-			if (key.name === "escape" || (key.ctrl === true && key.name === "c")) {
-				finish({ error: new SecretInputCancelledError() });
-				return;
-			}
-			if (key.ctrl === true && key.name === "d") {
-				finish({ error: new Error("Confidential input ended before submission") });
-				return;
-			}
-			if (key.ctrl === true || key.meta === true || text === undefined) return;
-			value += text;
 		}
 
 		function onError(error: Error): void {
@@ -161,13 +161,7 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 		}
 
 		try {
-			for (const listener of ownedDataListeners) input.on("data", listener);
-			readline.emitKeypressEvents(input);
-			input.on("keypress", onKeypress);
-			if (ownedDataListeners.length === 0) {
-				ownedDataListeners = input.rawListeners("data") as Array<(...args: unknown[]) => void>;
-				keypressDataListeners.set(input, ownedDataListeners);
-			}
+			input.on("data", onData);
 			input.once("error", onError);
 			input.once("end", onEnd);
 			input.once("close", onEnd);
@@ -177,13 +171,15 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 				input.setRawMode(true);
 			} catch (cause) {
 				finish({ error: new SecretInputUnavailableError({ cause }) });
-				return;
 			}
-			input.resume();
-			promptStarted = true;
-			output.write(prompt);
+			if (!settled) {
+				input.resume();
+				promptStarted = true;
+				output.write(prompt);
+			}
 		} catch (error) {
 			finish({ error });
 		}
-	});
+	}
+	return promise;
 }

--- a/packages/coding-agent/src/cli/secret-input.ts
+++ b/packages/coding-agent/src/cli/secret-input.ts
@@ -76,6 +76,8 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 	}
 
 	activeSecretInputs.add(input);
+	const suppressBufferedLineFeed = inputsAwaitingLineFeed.has(input) && input.readableLength > 0;
+	inputsAwaitingLineFeed.delete(input);
 
 	const { promise, resolve, reject } = Promise.withResolvers<string>();
 	{
@@ -85,6 +87,7 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 		let rawModeTouched = false;
 		let promptStarted = false;
 		let settled = false;
+		let awaitingBufferedLineFeed = suppressBufferedLineFeed;
 		let value = "";
 
 		const cleanup = (): unknown => {
@@ -143,8 +146,8 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 			for (let index = 0; index < characters.length; index++) {
 				const character = characters[index]!;
 				if (settled) return;
-				if (inputsAwaitingLineFeed.has(input)) {
-					inputsAwaitingLineFeed.delete(input);
+				if (awaitingBufferedLineFeed) {
+					awaitingBufferedLineFeed = false;
 					if (character === "\n") continue;
 				}
 				if (character === "\r") {

--- a/packages/coding-agent/src/cli/secret-input.ts
+++ b/packages/coding-agent/src/cli/secret-input.ts
@@ -1,3 +1,5 @@
+import { BracketedPasteHandler, decodeReencodedPasteControls } from "@oh-my-pi/pi-tui/bracketed-paste";
+
 const activeSecretInputs = new WeakSet<NodeJS.ReadStream>();
 const inputsAwaitingLineFeed = new WeakSet<NodeJS.ReadStream>();
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
@@ -84,6 +86,7 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 		const wasRaw = input.isRaw === true;
 		const wasFlowing = input.readableFlowing === true;
 		const decoder = new TextDecoder();
+		const pasteHandler = new BracketedPasteHandler();
 		let rawModeTouched = false;
 		let promptStarted = false;
 		let settled = false;
@@ -142,6 +145,20 @@ export function promptSecretInput(prompt: string, options: SecretInputOptions = 
 
 		function onData(chunk: Buffer | string): void {
 			const text = typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
+			const paste = pasteHandler.process(text);
+			if (paste.handled) {
+				if (paste.pasteContent !== undefined) {
+					value += decodeReencodedPasteControls(paste.pasteContent)
+						.normalize("NFC")
+						.replace(/[\x00-\x1F\x7F]/g, "");
+					if (paste.remaining.length > 0) processCharacters(paste.remaining);
+				}
+				return;
+			}
+			processCharacters(text);
+		}
+
+		function processCharacters(text: string): void {
 			const characters = Array.from(text);
 			for (let index = 0; index < characters.length; index++) {
 				const character = characters[index]!;

--- a/packages/coding-agent/src/cli/secret-input.ts
+++ b/packages/coding-agent/src/cli/secret-input.ts
@@ -1,0 +1,189 @@
+import * as readline from "node:readline";
+
+const activeSecretInputs = new WeakSet<NodeJS.ReadStream>();
+const keypressDataListeners = new WeakMap<NodeJS.ReadStream, Array<(...args: unknown[]) => void>>();
+
+/** Writable terminal surface used by {@link promptSecretInput}. */
+export interface SecretInputOutput {
+	write(text: string): unknown;
+}
+
+/** Options for reading one confidential line from a terminal. */
+export interface SecretInputOptions {
+	/** TTY to read from. Defaults to `process.stdin`. */
+	input?: NodeJS.ReadStream;
+	/** Destination for the prompt and trailing newline. Defaults to `process.stdout`. */
+	output?: SecretInputOutput;
+	/** Cancels the pending prompt without exposing the partially entered value. */
+	signal?: AbortSignal;
+}
+
+/** Raised when the input stream cannot disable terminal echo. */
+export class SecretInputUnavailableError extends Error {
+	constructor(options?: ErrorOptions) {
+		super("Confidential input requires a TTY with raw-mode support", options);
+		this.name = "SecretInputUnavailableError";
+	}
+}
+
+/** Raised when confidential input is cancelled before submission. */
+export class SecretInputCancelledError extends Error {
+	constructor() {
+		super("Confidential input cancelled");
+		this.name = "SecretInputCancelledError";
+	}
+}
+
+/**
+ * Read one confidential line without echoing entered characters.
+ *
+ * The input must be a real TTY with raw-mode support and no existing data,
+ * keypress, or readable listeners. This exclusive-ownership requirement keeps
+ * other application consumers from receiving the cleartext bytes. The helper
+ * also rejects concurrent prompts on the same stream and never falls back to
+ * an echoed readline prompt. Enter submits, Backspace edits, and Ctrl-C or
+ * Escape cancels. Cleanup restores the original raw mode and does not leave a
+ * previously non-flowing input stream flowing.
+ */
+export function promptSecretInput(prompt: string, options: SecretInputOptions = {}): Promise<string> {
+	const input = options.input ?? process.stdin;
+	const output = options.output ?? process.stdout;
+	const { signal } = options;
+
+	if (input.isTTY !== true || typeof input.setRawMode !== "function") {
+		return Promise.reject(new SecretInputUnavailableError());
+	}
+	if (signal?.aborted) {
+		return Promise.reject(signal.reason ?? new SecretInputCancelledError());
+	}
+	if (
+		activeSecretInputs.has(input) ||
+		input.listenerCount("data") > 0 ||
+		input.listenerCount("keypress") > 0 ||
+		input.listenerCount("readable") > 0
+	) {
+		return Promise.reject(
+			new SecretInputUnavailableError({
+				cause: new Error("Confidential input requires exclusive ownership of the input stream"),
+			}),
+		);
+	}
+
+	activeSecretInputs.add(input);
+
+	return new Promise<string>((resolve, reject) => {
+		const wasRaw = input.isRaw === true;
+		const wasFlowing = input.readableFlowing === true;
+		let rawModeTouched = false;
+		let promptStarted = false;
+		let settled = false;
+		let value = "";
+		let ownedDataListeners = keypressDataListeners.get(input) ?? [];
+
+		const cleanup = (): unknown => {
+			input.off("keypress", onKeypress);
+			for (const listener of ownedDataListeners) input.off("data", listener);
+			ownedDataListeners = [];
+			input.off("error", onError);
+			input.off("end", onEnd);
+			input.off("close", onEnd);
+			signal?.removeEventListener("abort", onAbort);
+
+			let cleanupError: unknown;
+			if (rawModeTouched) {
+				try {
+					input.setRawMode(wasRaw);
+				} catch (error) {
+					cleanupError = error;
+				}
+			}
+			if (!wasFlowing) input.pause();
+			activeSecretInputs.delete(input);
+			return cleanupError;
+		};
+
+		const finish = (result: { value: string } | { error: unknown }): void => {
+			if (settled) return;
+			settled = true;
+			const cleanupError = cleanup();
+			try {
+				if (promptStarted) output.write("\n");
+			} catch (error) {
+				value = "";
+				reject(cleanupError ?? error);
+				return;
+			}
+			if (cleanupError !== undefined) {
+				value = "";
+				reject(cleanupError);
+				return;
+			}
+			if ("error" in result) {
+				value = "";
+				reject(result.error);
+				return;
+			}
+			value = "";
+			resolve(result.value);
+		};
+
+		function onKeypress(text: string | undefined, key: readline.Key): void {
+			if (key.name === "return" || key.name === "enter") {
+				finish({ value });
+				return;
+			}
+			if (key.name === "backspace") {
+				value = Array.from(value).slice(0, -1).join("");
+				return;
+			}
+			if (key.name === "escape" || (key.ctrl === true && key.name === "c")) {
+				finish({ error: new SecretInputCancelledError() });
+				return;
+			}
+			if (key.ctrl === true && key.name === "d") {
+				finish({ error: new Error("Confidential input ended before submission") });
+				return;
+			}
+			if (key.ctrl === true || key.meta === true || text === undefined) return;
+			value += text;
+		}
+
+		function onError(error: Error): void {
+			finish({ error });
+		}
+
+		function onEnd(): void {
+			finish({ error: new Error("Confidential input ended before submission") });
+		}
+
+		function onAbort(): void {
+			finish({ error: signal?.reason ?? new SecretInputCancelledError() });
+		}
+
+		try {
+			for (const listener of ownedDataListeners) input.on("data", listener);
+			readline.emitKeypressEvents(input);
+			input.on("keypress", onKeypress);
+			if (ownedDataListeners.length === 0) {
+				ownedDataListeners = input.rawListeners("data") as Array<(...args: unknown[]) => void>;
+				keypressDataListeners.set(input, ownedDataListeners);
+			}
+			input.once("error", onError);
+			input.once("end", onEnd);
+			input.once("close", onEnd);
+			signal?.addEventListener("abort", onAbort, { once: true });
+			rawModeTouched = true;
+			try {
+				input.setRawMode(true);
+			} catch (cause) {
+				finish({ error: new SecretInputUnavailableError({ cause }) });
+				return;
+			}
+			input.resume();
+			promptStarted = true;
+			output.write(prompt);
+		} catch (error) {
+			finish({ error });
+		}
+	});
+}

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -8,6 +8,7 @@ export { z } from "@oh-my-pi/omptype/zod";
 export { Container, Markdown, Spacer, Text } from "@oh-my-pi/pi-tui";
 // Logging
 export { getAgentDir, logger, VERSION } from "@oh-my-pi/pi-utils";
+export * from "./cli/secret-input";
 export * from "./config/keybindings";
 export * from "./config/model-registry";
 // Prompt templates

--- a/packages/coding-agent/test/cli/secret-input.test.ts
+++ b/packages/coding-agent/test/cli/secret-input.test.ts
@@ -38,10 +38,6 @@ function createOutput(): SecretInputOutput & { text: string } {
 	};
 }
 
-function press(input: NodeJS.ReadStream, text: string | undefined, key: Record<string, unknown>): void {
-	input.emit("keypress", text, key);
-}
-
 describe("promptSecretInput", () => {
 	it("rejects when raw-mode echo suppression is unavailable", async () => {
 		const input = createInput({ isTTY: false });
@@ -86,10 +82,7 @@ describe("promptSecretInput", () => {
 		const output = createOutput();
 		const result = promptSecretInput("Token: ", { input: input.stream, output });
 
-		press(input.stream, "secx", {});
-		press(input.stream, undefined, { name: "backspace" });
-		press(input.stream, "ret", {});
-		press(input.stream, "\r", { name: "return" });
+		input.stream.write("secx\u007fret\r");
 
 		await expect(result).resolves.toBe("secret");
 		expect(output.text).toBe("Token: \n");
@@ -127,8 +120,7 @@ describe("promptSecretInput", () => {
 		const output = createOutput();
 		const result = promptSecretInput("Secret: ", { input: input.stream, output });
 
-		press(input.stream, "value", {});
-		press(input.stream, "\r", { name: "return" });
+		input.stream.write("value\r");
 
 		await expect(result).resolves.toBe("value");
 		expect(input.rawModes).toEqual([true, true]);
@@ -140,13 +132,30 @@ describe("promptSecretInput", () => {
 		const output = createOutput();
 		const result = promptSecretInput("Secret: ", { input: input.stream, output });
 
-		press(input.stream, "partial", {});
-		press(input.stream, "\u0003", { ctrl: true, name: "c" });
+		input.stream.write("partial\u0003");
 
 		await expect(result).rejects.toBeInstanceOf(SecretInputCancelledError);
 		expect(output.text).toBe("Secret: \n");
 		expect(output.text).not.toContain("partial");
 		expect(input.getRawMode()).toBe(false);
+	});
+
+	it("does not carry an incomplete UTF-8 sequence into a later prompt", async () => {
+		const input = createInput();
+		const firstController = new AbortController();
+		const first = promptSecretInput("First: ", {
+			input: input.stream,
+			output: createOutput(),
+			signal: firstController.signal,
+		});
+
+		input.stream.write(Buffer.from([0xe2]));
+		firstController.abort(new Error("operation cancelled"));
+		await expect(first).rejects.toThrow("operation cancelled");
+
+		const second = promptSecretInput("Second: ", { input: input.stream, output: createOutput() });
+		input.stream.write("next\r");
+		await expect(second).resolves.toBe("next");
 	});
 
 	it("restores terminal state when the input reaches EOF or errors", async () => {
@@ -169,7 +178,7 @@ describe("promptSecretInput", () => {
 		const controller = new AbortController();
 		const result = promptSecretInput("Secret: ", { input: input.stream, output, signal: controller.signal });
 
-		press(input.stream, "partial", {});
+		input.stream.write("partial");
 		controller.abort(new Error("operation cancelled"));
 
 		await expect(result).rejects.toThrow("operation cancelled");

--- a/packages/coding-agent/test/cli/secret-input.test.ts
+++ b/packages/coding-agent/test/cli/secret-input.test.ts
@@ -114,6 +114,34 @@ describe("promptSecretInput", () => {
 		expect(input.stream.isPaused()).toBe(true);
 	});
 
+	it("ignores terminal escape sequences but still cancels on bare Escape", async () => {
+		const sequenceInput = createInput();
+		const sequenceResult = promptSecretInput("Token: ", {
+			input: sequenceInput.stream,
+			output: createOutput(),
+		});
+		sequenceInput.stream.write("sec\u001b[Aret\r");
+		await expect(sequenceResult).resolves.toBe("secret");
+
+		const escapeInput = createInput();
+		const escapeResult = promptSecretInput("Token: ", {
+			input: escapeInput.stream,
+			output: createOutput(),
+		});
+		escapeInput.stream.write("\u001b");
+		await expect(escapeResult).rejects.toBeInstanceOf(SecretInputCancelledError);
+	});
+
+	it("preserves bytes received after the submitted line for the next prompt", async () => {
+		const input = createInput();
+		const first = promptSecretInput("First: ", { input: input.stream, output: createOutput() });
+		input.stream.write("first\rsecond\r");
+		await expect(first).resolves.toBe("first");
+
+		const second = promptSecretInput("Second: ", { input: input.stream, output: createOutput() });
+		await expect(second).resolves.toBe("second");
+	});
+
 	it("deletes one complete grapheme on backspace", async () => {
 		const input = createInput();
 		const result = promptSecretInput("Token: ", { input: input.stream, output: createOutput() });
@@ -200,6 +228,21 @@ describe("promptSecretInput", () => {
 		input.stream.write("second\r");
 
 		await expect(second).resolves.toBe("second");
+	});
+
+	it("does not requeue a submitted line after a buffered CRLF suffix", async () => {
+		const input = createInput();
+		const first = promptSecretInput("First: ", { input: input.stream, output: createOutput() });
+		input.stream.write("first\r");
+		await expect(first).resolves.toBe("first");
+
+		input.stream.write("\nsecond\npost");
+		const second = promptSecretInput("Second: ", { input: input.stream, output: createOutput() });
+		await expect(second).resolves.toBe("second");
+
+		const third = promptSecretInput("Third: ", { input: input.stream, output: createOutput() });
+		input.stream.write("\n");
+		await expect(third).resolves.toBe("post");
 	});
 
 	it("accepts a standalone line feed entered after the next prompt begins", async () => {

--- a/packages/coding-agent/test/cli/secret-input.test.ts
+++ b/packages/coding-agent/test/cli/secret-input.test.ts
@@ -214,16 +214,6 @@ describe("promptSecretInput", () => {
 		await expect(second).resolves.toBe("");
 	});
 
-	it("accepts bracketed paste without treating its escape envelope as cancellation", async () => {
-		const input = createInput();
-		const result = promptSecretInput("Secret: ", { input: input.stream, output: createOutput() });
-
-		input.stream.write("\x1b[200~pasted-");
-		input.stream.write("secret\x1b[201~\r");
-
-		await expect(result).resolves.toBe("pasted-secret");
-	});
-
 	it("restores terminal state when the input reaches EOF or errors", async () => {
 		for (const event of ["end", "close", "error"] as const) {
 			const input = createInput();

--- a/packages/coding-agent/test/cli/secret-input.test.ts
+++ b/packages/coding-agent/test/cli/secret-input.test.ts
@@ -189,6 +189,19 @@ describe("promptSecretInput", () => {
 		await expect(second).resolves.toBe("next");
 	});
 
+	it("does not carry a split CRLF line feed into a later prompt", async () => {
+		const input = createInput();
+		const first = promptSecretInput("First: ", { input: input.stream, output: createOutput() });
+		input.stream.write("first\r");
+		await expect(first).resolves.toBe("first");
+
+		input.stream.write("\n");
+		const second = promptSecretInput("Second: ", { input: input.stream, output: createOutput() });
+		input.stream.write("second\r");
+
+		await expect(second).resolves.toBe("second");
+	});
+
 	it("restores terminal state when the input reaches EOF or errors", async () => {
 		for (const event of ["end", "close", "error"] as const) {
 			const input = createInput();

--- a/packages/coding-agent/test/cli/secret-input.test.ts
+++ b/packages/coding-agent/test/cli/secret-input.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "bun:test";
+import { PassThrough } from "node:stream";
+import {
+	promptSecretInput,
+	SecretInputCancelledError,
+	type SecretInputOutput,
+	SecretInputUnavailableError,
+} from "@oh-my-pi/pi-coding-agent/cli/secret-input";
+
+interface FakeInput {
+	stream: PassThrough & NodeJS.ReadStream;
+	rawModes: boolean[];
+	getRawMode(): boolean;
+}
+
+function createInput(options: { isTTY?: boolean; initiallyRaw?: boolean; failRawMode?: boolean } = {}): FakeInput {
+	const stream = new PassThrough() as PassThrough & NodeJS.ReadStream;
+	const rawModes: boolean[] = [];
+	let rawMode = options.initiallyRaw ?? false;
+	Object.defineProperty(stream, "isTTY", { value: options.isTTY ?? true });
+	Object.defineProperty(stream, "isRaw", { get: () => rawMode });
+	stream.setRawMode = (mode: boolean) => {
+		rawModes.push(mode);
+		if (mode && options.failRawMode) throw new Error("raw mode denied");
+		rawMode = mode;
+		return stream;
+	};
+	return { stream, rawModes, getRawMode: () => rawMode };
+}
+
+function createOutput(): SecretInputOutput & { text: string } {
+	return {
+		text: "",
+		write(text: string) {
+			this.text += text;
+			return true;
+		},
+	};
+}
+
+function press(input: NodeJS.ReadStream, text: string | undefined, key: Record<string, unknown>): void {
+	input.emit("keypress", text, key);
+}
+
+describe("promptSecretInput", () => {
+	it("rejects when raw-mode echo suppression is unavailable", async () => {
+		const input = createInput({ isTTY: false });
+		const output = createOutput();
+
+		await expect(promptSecretInput("Token: ", { input: input.stream, output })).rejects.toBeInstanceOf(
+			SecretInputUnavailableError,
+		);
+		expect(output.text).toBe("");
+		expect(input.rawModes).toEqual([]);
+	});
+
+	it("fails closed when another listener can consume the input bytes", async () => {
+		for (const event of ["data", "keypress", "readable"] as const) {
+			const input = createInput();
+			const output = createOutput();
+			const listener = () => {};
+			input.stream.on(event, listener);
+
+			await expect(promptSecretInput("Token: ", { input: input.stream, output })).rejects.toBeInstanceOf(
+				SecretInputUnavailableError,
+			);
+			expect(output.text).toBe("");
+			expect(input.rawModes).toEqual([]);
+			input.stream.off(event, listener);
+		}
+	});
+
+	it("reports raw-mode activation failures as unavailable confidential input", async () => {
+		const input = createInput({ failRawMode: true });
+		const output = createOutput();
+
+		await expect(promptSecretInput("Token: ", { input: input.stream, output })).rejects.toBeInstanceOf(
+			SecretInputUnavailableError,
+		);
+		expect(output.text).toBe("");
+		expect(input.rawModes).toEqual([true, false]);
+	});
+
+	it("collects a line without echoing it and restores terminal state", async () => {
+		const input = createInput();
+		const output = createOutput();
+		const result = promptSecretInput("Token: ", { input: input.stream, output });
+
+		press(input.stream, "secx", {});
+		press(input.stream, undefined, { name: "backspace" });
+		press(input.stream, "ret", {});
+		press(input.stream, "\r", { name: "return" });
+
+		await expect(result).resolves.toBe("secret");
+		expect(output.text).toBe("Token: \n");
+		expect(output.text).not.toContain("secret");
+		expect(input.rawModes).toEqual([true, false]);
+		expect(input.getRawMode()).toBe(false);
+		expect(input.stream.isPaused()).toBe(true);
+	});
+
+	it("rejects concurrent prompts on one stream and releases ownership after completion", async () => {
+		const input = createInput();
+		const firstOutput = createOutput();
+		const secondOutput = createOutput();
+		const first = promptSecretInput("First: ", { input: input.stream, output: firstOutput });
+		const second = promptSecretInput("Second: ", { input: input.stream, output: secondOutput });
+
+		await expect(second).rejects.toBeInstanceOf(SecretInputUnavailableError);
+		expect(secondOutput.text).toBe("");
+		input.stream.write("secret\r");
+		await expect(first).resolves.toBe("secret");
+		expect(input.rawModes).toEqual([true, false]);
+		expect(input.getRawMode()).toBe(false);
+		expect(input.stream.listenerCount("data")).toBe(0);
+
+		const retry = promptSecretInput("Retry: ", { input: input.stream, output: secondOutput });
+		input.stream.write("next\r");
+		await expect(retry).resolves.toBe("next");
+		expect(input.rawModes).toEqual([true, false, true, false]);
+		expect(input.getRawMode()).toBe(false);
+		expect(input.stream.listenerCount("data")).toBe(0);
+	});
+
+	it("restores an input that was already in raw mode", async () => {
+		const input = createInput({ initiallyRaw: true });
+		const output = createOutput();
+		const result = promptSecretInput("Secret: ", { input: input.stream, output });
+
+		press(input.stream, "value", {});
+		press(input.stream, "\r", { name: "return" });
+
+		await expect(result).resolves.toBe("value");
+		expect(input.rawModes).toEqual([true, true]);
+		expect(input.getRawMode()).toBe(true);
+	});
+
+	it("cancels on Ctrl-C without exposing the partial value", async () => {
+		const input = createInput();
+		const output = createOutput();
+		const result = promptSecretInput("Secret: ", { input: input.stream, output });
+
+		press(input.stream, "partial", {});
+		press(input.stream, "\u0003", { ctrl: true, name: "c" });
+
+		await expect(result).rejects.toBeInstanceOf(SecretInputCancelledError);
+		expect(output.text).toBe("Secret: \n");
+		expect(output.text).not.toContain("partial");
+		expect(input.getRawMode()).toBe(false);
+	});
+
+	it("restores terminal state when the input reaches EOF or errors", async () => {
+		for (const event of ["end", "close", "error"] as const) {
+			const input = createInput();
+			const output = createOutput();
+			const result = promptSecretInput("Secret: ", { input: input.stream, output });
+			if (event === "error") input.stream.emit(event, new Error("input failed"));
+			else input.stream.emit(event);
+
+			await expect(result).rejects.toThrow(event === "error" ? "input failed" : "ended before submission");
+			expect(input.getRawMode()).toBe(false);
+			expect(input.rawModes).toEqual([true, false]);
+		}
+	});
+
+	it("restores terminal state when an AbortSignal cancels the prompt", async () => {
+		const input = createInput();
+		const output = createOutput();
+		const controller = new AbortController();
+		const result = promptSecretInput("Secret: ", { input: input.stream, output, signal: controller.signal });
+
+		press(input.stream, "partial", {});
+		controller.abort(new Error("operation cancelled"));
+
+		await expect(result).rejects.toThrow("operation cancelled");
+		expect(output.text).not.toContain("partial");
+		expect(input.getRawMode()).toBe(false);
+	});
+
+	it("restores raw mode when writing the prompt fails", async () => {
+		const input = createInput();
+		let writes = 0;
+		const result = promptSecretInput("Secret: ", {
+			input: input.stream,
+			output: {
+				write() {
+					writes++;
+					throw new Error("output failed");
+				},
+			},
+		});
+
+		await expect(result).rejects.toThrow("output failed");
+		expect(writes).toBe(2);
+		expect(input.getRawMode()).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/cli/secret-input.test.ts
+++ b/packages/coding-agent/test/cli/secret-input.test.ts
@@ -202,6 +202,18 @@ describe("promptSecretInput", () => {
 		await expect(second).resolves.toBe("second");
 	});
 
+	it("accepts a standalone line feed entered after the next prompt begins", async () => {
+		const input = createInput();
+		const first = promptSecretInput("First: ", { input: input.stream, output: createOutput() });
+		input.stream.write("first\r");
+		await expect(first).resolves.toBe("first");
+
+		const second = promptSecretInput("Second: ", { input: input.stream, output: createOutput() });
+		input.stream.write("\n");
+
+		await expect(second).resolves.toBe("");
+	});
+
 	it("restores terminal state when the input reaches EOF or errors", async () => {
 		for (const event of ["end", "close", "error"] as const) {
 			const input = createInput();

--- a/packages/coding-agent/test/cli/secret-input.test.ts
+++ b/packages/coding-agent/test/cli/secret-input.test.ts
@@ -214,6 +214,16 @@ describe("promptSecretInput", () => {
 		await expect(second).resolves.toBe("");
 	});
 
+	it("accepts bracketed paste without treating its escape envelope as cancellation", async () => {
+		const input = createInput();
+		const result = promptSecretInput("Secret: ", { input: input.stream, output: createOutput() });
+
+		input.stream.write("\x1b[200~pasted-");
+		input.stream.write("secret\x1b[201~\r");
+
+		await expect(result).resolves.toBe("pasted-secret");
+	});
+
 	it("restores terminal state when the input reaches EOF or errors", async () => {
 		for (const event of ["end", "close", "error"] as const) {
 			const input = createInput();

--- a/packages/coding-agent/test/cli/secret-input.test.ts
+++ b/packages/coding-agent/test/cli/secret-input.test.ts
@@ -13,7 +13,9 @@ interface FakeInput {
 	getRawMode(): boolean;
 }
 
-function createInput(options: { isTTY?: boolean; initiallyRaw?: boolean; failRawMode?: boolean } = {}): FakeInput {
+function createInput(
+	options: { isTTY?: boolean; initiallyRaw?: boolean; failRawMode?: boolean; failRawModeReset?: boolean } = {},
+): FakeInput {
 	const stream = new PassThrough() as PassThrough & NodeJS.ReadStream;
 	const rawModes: boolean[] = [];
 	let rawMode = options.initiallyRaw ?? false;
@@ -22,6 +24,7 @@ function createInput(options: { isTTY?: boolean; initiallyRaw?: boolean; failRaw
 	stream.setRawMode = (mode: boolean) => {
 		rawModes.push(mode);
 		if (mode && options.failRawMode) throw new Error("raw mode denied");
+		if (!mode && options.failRawModeReset) throw new Error("raw mode reset denied");
 		rawMode = mode;
 		return stream;
 	};
@@ -77,6 +80,25 @@ describe("promptSecretInput", () => {
 		expect(input.rawModes).toEqual([true, false]);
 	});
 
+	it("preserves the unavailable error when raw-mode activation and cleanup both fail", async () => {
+		const input = createInput({ failRawMode: true, failRawModeReset: true });
+
+		await expect(
+			promptSecretInput("Token: ", { input: input.stream, output: createOutput() }),
+		).rejects.toBeInstanceOf(SecretInputUnavailableError);
+		expect(input.rawModes).toEqual([true, false]);
+	});
+
+	it("rejects streams that already decode input into strings", async () => {
+		const input = createInput();
+		input.stream.setEncoding("utf8");
+
+		await expect(
+			promptSecretInput("Token: ", { input: input.stream, output: createOutput() }),
+		).rejects.toBeInstanceOf(SecretInputUnavailableError);
+		expect(input.rawModes).toEqual([]);
+	});
+
 	it("collects a line without echoing it and restores terminal state", async () => {
 		const input = createInput();
 		const output = createOutput();
@@ -90,6 +112,15 @@ describe("promptSecretInput", () => {
 		expect(input.rawModes).toEqual([true, false]);
 		expect(input.getRawMode()).toBe(false);
 		expect(input.stream.isPaused()).toBe(true);
+	});
+
+	it("deletes one complete grapheme on backspace", async () => {
+		const input = createInput();
+		const result = promptSecretInput("Token: ", { input: input.stream, output: createOutput() });
+
+		input.stream.write(`a${"e\u0301"}${"👩‍💻"}\u007f\u007f\r`);
+
+		await expect(result).resolves.toBe("a");
 	});
 
 	it("rejects concurrent prompts on one stream and releases ownership after completion", async () => {


### PR DESCRIPTION
## What

- Add a reusable confidential terminal-input helper for future TUI, setup, and RPC credential flows.
- Require exclusive ownership of a raw-mode TTY and fail closed when echo suppression is unavailable.
- Reject concurrent or shared input consumers, restore terminal mode and stream flow on every exit path, and expose the helper through root and subpath exports.

## Why

#5281 needs a shared no-echo primitive before API-key login can be added consistently across surfaces. This prerequisite keeps terminal state and secret-input guarantees in one implementation without changing any active login flow.

## Testing

- `bun test packages/coding-agent/test/cli/secret-input.test.ts`
- `cd packages/coding-agent && bun run check`
- Exercised two sequential prompts through a real PTY. Only prompt labels and returned lengths appeared in output; entered values did not.

---

- [x] Package-local check passes
- [x] Tested locally
- [x] CHANGELOG updated
