### PR TITLE
feat: expose active session path to subprocesses

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -380,6 +380,7 @@ These affect where coding-agent stores data and which process-local settings ove
 | `CLAUDE_BASH_NO_LOGIN`     | Legacy alias fallback for `PI_BASH_NO_LOGIN`                                   |
 | `PI_SHELL_PREFIX`          | Optional command prefix wrapper                                                |
 | `CLAUDE_CODE_SHELL_PREFIX` | Legacy alias fallback for `PI_SHELL_PREFIX`                                    |
+| `OMP_SESSION_FILE`          | Active OMP persistent-session JSONL path injected into Bash subprocesses; the session-managed value overrides a caller-supplied value and is not injected for in-memory sessions |
 | `VISUAL`                   | Preferred external editor command                                              |
 | `EDITOR`                   | Fallback external editor command                                               |
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Exposed the active persistent-session JSONL path to Bash subprocesses through `OMP_SESSION_FILE`.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -894,6 +894,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		ctx?: AgentToolContext,
 	): Promise<AgentToolResult<BashToolDetails>> {
 		let command = rawCommand;
+		const sessionFile = this.session.getSessionFile();
 		const env = normalizeBashEnv(rawEnv);
 
 		// Extract leading `cd <path> && ...` into cwd when the model ignores the cwd parameter.
@@ -937,7 +938,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			},
 		};
 		command = await expandInternalUrls(command, { ...internalUrlOptions, ensureLocalParentDirs: true });
-		const resolvedEnv = env
+		let resolvedEnv = env
 			? Object.fromEntries(
 					await Promise.all(
 						Object.entries(env).map(async ([key, value]) => [
@@ -951,6 +952,9 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 					),
 				)
 			: undefined;
+		if (sessionFile !== null) {
+			resolvedEnv = { ...resolvedEnv, OMP_SESSION_FILE: sessionFile };
+		}
 
 		// Resolve protocol URLs (skill://, agent://, etc.) in extracted cwd.
 		if (cwd?.includes("://") || cwd?.includes("local:/")) {

--- a/packages/coding-agent/test/bash-failure-result.test.ts
+++ b/packages/coding-agent/test/bash-failure-result.test.ts
@@ -80,6 +80,61 @@ describe("BashTool execution results", () => {
 		expect(text).not.toContain("Command exited with code");
 	});
 
+	it("exposes the active OMP session file to Bash", async () => {
+		const session = makeSession();
+		session.getSessionFile = () => "/tmp/active-session.jsonl";
+		const tool = new BashTool(session);
+
+		const result = await tool.execute("call-session-file", { command: 'printf "%s" "$OMP_SESSION_FILE"' });
+		const text = result.content.find(c => c.type === "text")?.text ?? "";
+
+		expect(text).toContain("/tmp/active-session.jsonl");
+	});
+
+	it("uses the current session file on each Bash invocation", async () => {
+		let sessionFile = "/tmp/original-session.jsonl";
+		const session = makeSession();
+		session.getSessionFile = () => sessionFile;
+		const tool = new BashTool(session);
+
+		const initialResult = await tool.execute("call-original-session-file", {
+			command: 'printf "%s" "$OMP_SESSION_FILE"',
+		});
+		sessionFile = "/tmp/resumed-session.jsonl";
+		const resumedResult = await tool.execute("call-resumed-session-file", {
+			command: 'printf "%s" "$OMP_SESSION_FILE"',
+		});
+
+		expect(initialResult.content.find(c => c.type === "text")?.text).toContain("/tmp/original-session.jsonl");
+		expect(resumedResult.content.find(c => c.type === "text")?.text).toContain("/tmp/resumed-session.jsonl");
+	});
+
+	it("does not let callers override the active OMP session file", async () => {
+		const session = makeSession();
+		session.getSessionFile = () => "/tmp/authoritative-session.jsonl";
+		const tool = new BashTool(session);
+
+		const result = await tool.execute("call-overridden-session-file", {
+			command: 'printf "%s" "$OMP_SESSION_FILE"',
+			env: { OMP_SESSION_FILE: "/tmp/caller-session.jsonl" },
+		});
+		const text = result.content.find(c => c.type === "text")?.text ?? "";
+
+		expect(text).toContain("/tmp/authoritative-session.jsonl");
+		expect(text).not.toContain("/tmp/caller-session.jsonl");
+	});
+
+	it("does not inject a session file for in-memory sessions", async () => {
+		const tool = new BashTool(makeSession());
+		const result = await tool.execute("call-no-session-file", {
+			command: 'printf "%s" "$OMP_SESSION_FILE"',
+			env: { OMP_SESSION_FILE: "/tmp/inherited-session.jsonl" },
+		});
+		const text = result.content.find(c => c.type === "text")?.text ?? "";
+
+		expect(text).toContain("/tmp/inherited-session.jsonl");
+	});
+
 	it("preserves final-stage output when a pipeline ends in head or tail", async () => {
 		const tool = new BashTool(makeSession());
 


### PR DESCRIPTION
<!-- Motivation, context, or link to issue (fixes #N) -->

## Motivation

Expose the active persisted OMP session JSONL path to Bash subprocesses as `OMP_SESSION_FILE`. This gives hooks and integrations a reliable transcript source across session start, resume, fork, branch, and session switching without depending on terminal breadcrumb heuristics.

The session-managed value deliberately overrides a caller-supplied `OMP_SESSION_FILE`; in-memory sessions omit the variable so stale paths cannot leak into subprocesses.

## Testing

- [x] `bun run check:ts`
- [x] `bun test packages/coding-agent/test/bash-failure-result.test.ts` (9 passed)
- [ ] `bun run check` requires `cargo`, which is not installed on this workstation; its TypeScript checks passed before the Rust check failed.

- [ ] `bun check` passes
- [x] I have added/updated automated tests
- [x] I have tested locally
- [x] I have updated `CHANGELOG.md`
- [x] I have updated documentation (if applicable)
