### PR TITLE
fix(ai): bound Anthropic retry-after waits

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic retry loops ignoring `maxRetryDelayMs` for long server `retry-after` hints, so over-budget delays surface immediately without losing response details or abort cleanup ([#7003](https://github.com/can1357/oh-my-pi/issues/7003)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/error/classes.ts
+++ b/packages/ai/src/error/classes.ts
@@ -1,4 +1,5 @@
 import type { CapturedHttpErrorResponse } from "../utils/http-inspector";
+import { AbortError } from "./abort";
 
 /** Prefix on errors raised when an Anthropic SSE stream envelope is malformed. */
 export const STREAM_ENVELOPE_ERROR_PREFIX = "Anthropic stream envelope error:";
@@ -79,8 +80,42 @@ export class AnthropicApiError extends ProviderHttpError {
 		this.requestId = headers.get("request-id");
 	}
 
-	static async fromResponse(response: Response): Promise<AnthropicApiError> {
-		const body = await response.text().catch(() => "");
+	static async fromResponse(response: Response, signal?: AbortSignal): Promise<AnthropicApiError> {
+		// Avoid getReader() throwing when another consumer already owns the body.
+		const reader = response.body?.locked ? undefined : response.body?.getReader();
+
+		if (!reader) {
+			if (signal?.aborted) throw new AbortError("Request was aborted.");
+			const detail = "status code (no body)";
+			return new AnthropicApiError(response.status, `${response.status} ${detail}`, response.headers);
+		}
+
+		let aborted = signal?.aborted ?? false;
+		const onAbort = () => {
+			aborted = true;
+			void reader.cancel().catch(() => {});
+		};
+		if (aborted) onAbort();
+		else signal?.addEventListener("abort", onAbort, { once: true });
+
+		let body = "";
+		try {
+			const decoder = new TextDecoder();
+			while (!aborted) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				body += decoder.decode(value, { stream: true });
+			}
+			if (aborted) throw new AbortError("Request was aborted.");
+			body += decoder.decode();
+		} catch {
+			if (aborted) throw new AbortError("Request was aborted.");
+			body = "";
+		} finally {
+			signal?.removeEventListener("abort", onAbort);
+			reader.releaseLock();
+		}
+
 		const detail = body.trim() || "status code (no body)";
 		return new AnthropicApiError(response.status, `${response.status} ${detail}`, response.headers);
 	}

--- a/packages/ai/src/error/classes.ts
+++ b/packages/ai/src/error/classes.ts
@@ -134,7 +134,6 @@ export class AnthropicApiError extends ProviderHttpError {
 		const bodyChunks: string[] = [];
 		try {
 			const decoder = new TextDecoder();
-			let cleanEof = false;
 			while (!aborted && !timedOut) {
 				if (performance.now() >= deadline) {
 					timedOut = true;
@@ -142,17 +141,8 @@ export class AnthropicApiError extends ProviderHttpError {
 					break;
 				}
 
-				let result: ReadableStreamReadResult<Uint8Array>;
-				try {
-					result = await reader.read();
-				} catch {
-					break;
-				}
-				if (aborted || timedOut) break;
-				if (result.done) {
-					cleanEof = true;
-					break;
-				}
+				const result = await reader.read();
+				if (aborted || timedOut || result.done) break;
 
 				const chunk = result.value;
 				const bytesToCapture = Math.min(MAX_ANTHROPIC_ERROR_BODY_BYTES - capturedBytes, chunk.byteLength);
@@ -167,7 +157,7 @@ export class AnthropicApiError extends ProviderHttpError {
 				}
 			}
 			if (aborted || signal?.aborted) throw new AbortError("Request was aborted.");
-			if (cleanEof) bodyChunks.push(decoder.decode());
+			if (!truncated) bodyChunks.push(decoder.decode());
 			if (truncated) bodyChunks.push(ANTHROPIC_ERROR_BODY_TRUNCATION_MARKER);
 		} finally {
 			if (timeout !== undefined) clearTimeout(timeout);

--- a/packages/ai/src/error/classes.ts
+++ b/packages/ai/src/error/classes.ts
@@ -71,6 +71,8 @@ export class OpenAIHttpError extends ProviderHttpError {
 
 /** Non-2xx response from the Anthropic API. */
 const DEFAULT_ANTHROPIC_ERROR_BODY_READ_TIMEOUT_MS = 5_000;
+const MAX_ANTHROPIC_ERROR_BODY_BYTES = 64 * 1024;
+const ANTHROPIC_ERROR_BODY_TRUNCATION_MARKER = "\n[Response body truncated after 64 KiB]";
 let anthropicErrorBodyReadTimeoutMs = DEFAULT_ANTHROPIC_ERROR_BODY_READ_TIMEOUT_MS;
 
 /** Test-only control for the otherwise bounded Anthropic error-body drain. */
@@ -106,11 +108,11 @@ export class AnthropicApiError extends ProviderHttpError {
 
 		let aborted = false;
 		let timedOut = false;
-		let resolveAbort!: (result: { type: "aborted" }) => void;
-		const abortedRead = new Promise<{ type: "aborted" }>(resolve => {
-			resolveAbort = resolve;
-		});
+		const { promise: abortedRead, resolve: resolveAbort } = Promise.withResolvers<{ type: "aborted" }>();
+		let readerCancelled = false;
 		const cancelReader = () => {
+			if (readerCancelled) return;
+			readerCancelled = true;
 			void reader.cancel().catch(() => {});
 		};
 		const onAbort = () => {
@@ -122,19 +124,27 @@ export class AnthropicApiError extends ProviderHttpError {
 		if (signal?.aborted) onAbort();
 		else signal?.addEventListener("abort", onAbort, { once: true });
 
-		let timeout: ReturnType<typeof setTimeout> | undefined;
-		const timeoutRead = new Promise<{ type: "timed-out" }>(resolve => {
-			timeout = setTimeout(() => {
-				timedOut = true;
-				cancelReader();
-				resolve({ type: "timed-out" });
-			}, anthropicErrorBodyReadTimeoutMs);
-		});
+		const deadline = performance.now() + anthropicErrorBodyReadTimeoutMs;
+		let timeout: Timer | undefined;
+		const { promise: timeoutRead, resolve: resolveTimeout } = Promise.withResolvers<{ type: "timed-out" }>();
+		timeout = setTimeout(() => {
+			timedOut = true;
+			cancelReader();
+			resolveTimeout({ type: "timed-out" });
+		}, anthropicErrorBodyReadTimeoutMs);
 
-		let body = "";
+		let capturedBytes = 0;
+		let truncated = false;
+		const bodyChunks: string[] = [];
 		try {
 			const decoder = new TextDecoder();
 			while (!aborted && !timedOut) {
+				if (performance.now() >= deadline) {
+					timedOut = true;
+					cancelReader();
+					break;
+				}
+
 				const result = await Promise.race([
 					reader.read().then(
 						value => ({ type: "read" as const, value }),
@@ -143,19 +153,30 @@ export class AnthropicApiError extends ProviderHttpError {
 					abortedRead,
 					timeoutRead,
 				]);
-				if (result.type !== "read") break;
-				if (result.value.done) break;
-				body += decoder.decode(result.value.value, { stream: true });
+				if (result.type !== "read" || result.value.done) break;
+
+				const chunk = result.value.value;
+				const bytesToCapture = Math.min(MAX_ANTHROPIC_ERROR_BODY_BYTES - capturedBytes, chunk.byteLength);
+				if (bytesToCapture > 0) {
+					bodyChunks.push(decoder.decode(chunk.subarray(0, bytesToCapture), { stream: true }));
+					capturedBytes += bytesToCapture;
+				}
+				if (capturedBytes === MAX_ANTHROPIC_ERROR_BODY_BYTES) {
+					truncated = true;
+					cancelReader();
+					break;
+				}
 			}
-			if (aborted) throw new AbortError("Request was aborted.");
-			body += decoder.decode();
+			if (aborted || signal?.aborted) throw new AbortError("Request was aborted.");
+			bodyChunks.push(decoder.decode());
+			if (truncated) bodyChunks.push(ANTHROPIC_ERROR_BODY_TRUNCATION_MARKER);
 		} finally {
 			if (timeout !== undefined) clearTimeout(timeout);
 			signal?.removeEventListener("abort", onAbort);
 			reader.releaseLock();
 		}
 
-		const detail = body.trim() || "status code (no body)";
+		const detail = bodyChunks.join("").trim() || "status code (no body)";
 		return new AnthropicApiError(response.status, `${response.status} ${detail}`, response.headers);
 	}
 }

--- a/packages/ai/src/error/classes.ts
+++ b/packages/ai/src/error/classes.ts
@@ -70,6 +70,20 @@ export class OpenAIHttpError extends ProviderHttpError {
 }
 
 /** Non-2xx response from the Anthropic API. */
+const DEFAULT_ANTHROPIC_ERROR_BODY_READ_TIMEOUT_MS = 5_000;
+let anthropicErrorBodyReadTimeoutMs = DEFAULT_ANTHROPIC_ERROR_BODY_READ_TIMEOUT_MS;
+
+/** Test-only control for the otherwise bounded Anthropic error-body drain. */
+export const __anthropicApiErrorForTesting = {
+	setBodyReadTimeoutMs(timeoutMs: number | undefined): void {
+		if (timeoutMs !== undefined && (!Number.isFinite(timeoutMs) || timeoutMs < 0)) {
+			throw new RangeError("Anthropic error-body timeout must be a non-negative finite number.");
+		}
+		anthropicErrorBodyReadTimeoutMs = timeoutMs ?? DEFAULT_ANTHROPIC_ERROR_BODY_READ_TIMEOUT_MS;
+	},
+};
+
+/** Non-2xx response from the Anthropic API. */
 export class AnthropicApiError extends ProviderHttpError {
 	declare readonly headers: Headers;
 	readonly requestId: string | null;
@@ -90,28 +104,53 @@ export class AnthropicApiError extends ProviderHttpError {
 			return new AnthropicApiError(response.status, `${response.status} ${detail}`, response.headers);
 		}
 
-		let aborted = signal?.aborted ?? false;
-		const onAbort = () => {
-			aborted = true;
+		let aborted = false;
+		let timedOut = false;
+		let resolveAbort!: (result: { type: "aborted" }) => void;
+		const abortedRead = new Promise<{ type: "aborted" }>(resolve => {
+			resolveAbort = resolve;
+		});
+		const cancelReader = () => {
 			void reader.cancel().catch(() => {});
 		};
-		if (aborted) onAbort();
+		const onAbort = () => {
+			if (aborted) return;
+			aborted = true;
+			cancelReader();
+			resolveAbort({ type: "aborted" });
+		};
+		if (signal?.aborted) onAbort();
 		else signal?.addEventListener("abort", onAbort, { once: true });
+
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		const timeoutRead = new Promise<{ type: "timed-out" }>(resolve => {
+			timeout = setTimeout(() => {
+				timedOut = true;
+				cancelReader();
+				resolve({ type: "timed-out" });
+			}, anthropicErrorBodyReadTimeoutMs);
+		});
 
 		let body = "";
 		try {
 			const decoder = new TextDecoder();
-			while (!aborted) {
-				const { done, value } = await reader.read();
-				if (done) break;
-				body += decoder.decode(value, { stream: true });
+			while (!aborted && !timedOut) {
+				const result = await Promise.race([
+					reader.read().then(
+						value => ({ type: "read" as const, value }),
+						() => ({ type: "read-error" as const }),
+					),
+					abortedRead,
+					timeoutRead,
+				]);
+				if (result.type !== "read") break;
+				if (result.value.done) break;
+				body += decoder.decode(result.value.value, { stream: true });
 			}
 			if (aborted) throw new AbortError("Request was aborted.");
 			body += decoder.decode();
-		} catch {
-			if (aborted) throw new AbortError("Request was aborted.");
-			body = "";
 		} finally {
+			if (timeout !== undefined) clearTimeout(timeout);
 			signal?.removeEventListener("abort", onAbort);
 			reader.releaseLock();
 		}

--- a/packages/ai/src/error/classes.ts
+++ b/packages/ai/src/error/classes.ts
@@ -134,6 +134,7 @@ export class AnthropicApiError extends ProviderHttpError {
 		const bodyChunks: string[] = [];
 		try {
 			const decoder = new TextDecoder();
+			let cleanEof = false;
 			while (!aborted && !timedOut) {
 				if (performance.now() >= deadline) {
 					timedOut = true;
@@ -141,8 +142,17 @@ export class AnthropicApiError extends ProviderHttpError {
 					break;
 				}
 
-				const result = await reader.read();
-				if (aborted || timedOut || result.done) break;
+				let result: ReadableStreamReadResult<Uint8Array>;
+				try {
+					result = await reader.read();
+				} catch {
+					break;
+				}
+				if (aborted || timedOut) break;
+				if (result.done) {
+					cleanEof = true;
+					break;
+				}
 
 				const chunk = result.value;
 				const bytesToCapture = Math.min(MAX_ANTHROPIC_ERROR_BODY_BYTES - capturedBytes, chunk.byteLength);
@@ -157,7 +167,7 @@ export class AnthropicApiError extends ProviderHttpError {
 				}
 			}
 			if (aborted || signal?.aborted) throw new AbortError("Request was aborted.");
-			if (!truncated) bodyChunks.push(decoder.decode());
+			if (cleanEof) bodyChunks.push(decoder.decode());
 			if (truncated) bodyChunks.push(ANTHROPIC_ERROR_BODY_TRUNCATION_MARKER);
 		} finally {
 			if (timeout !== undefined) clearTimeout(timeout);

--- a/packages/ai/src/error/classes.ts
+++ b/packages/ai/src/error/classes.ts
@@ -134,6 +134,7 @@ export class AnthropicApiError extends ProviderHttpError {
 		const bodyChunks: string[] = [];
 		try {
 			const decoder = new TextDecoder();
+			let cleanEof = false;
 			while (!aborted && !timedOut) {
 				if (performance.now() >= deadline) {
 					timedOut = true;
@@ -141,10 +142,20 @@ export class AnthropicApiError extends ProviderHttpError {
 					break;
 				}
 
-				const result = await reader.read();
-				if (aborted || timedOut || result.done) break;
+				let result: { readonly done: boolean; readonly value?: Uint8Array };
+				try {
+					result = await reader.read();
+				} catch {
+					break;
+				}
+				if (aborted || timedOut) break;
+				if (result.done) {
+					cleanEof = true;
+					break;
+				}
 
 				const chunk = result.value;
+				if (!chunk) break;
 				const bytesToCapture = Math.min(MAX_ANTHROPIC_ERROR_BODY_BYTES - capturedBytes, chunk.byteLength);
 				if (bytesToCapture > 0) {
 					bodyChunks.push(decoder.decode(chunk.subarray(0, bytesToCapture), { stream: true }));
@@ -157,7 +168,7 @@ export class AnthropicApiError extends ProviderHttpError {
 				}
 			}
 			if (aborted || signal?.aborted) throw new AbortError("Request was aborted.");
-			if (!truncated) bodyChunks.push(decoder.decode());
+			if (cleanEof) bodyChunks.push(decoder.decode());
 			if (truncated) bodyChunks.push(ANTHROPIC_ERROR_BODY_TRUNCATION_MARKER);
 		} finally {
 			if (timeout !== undefined) clearTimeout(timeout);

--- a/packages/ai/src/error/classes.ts
+++ b/packages/ai/src/error/classes.ts
@@ -108,7 +108,6 @@ export class AnthropicApiError extends ProviderHttpError {
 
 		let aborted = false;
 		let timedOut = false;
-		const { promise: abortedRead, resolve: resolveAbort } = Promise.withResolvers<{ type: "aborted" }>();
 		let readerCancelled = false;
 		const cancelReader = () => {
 			if (readerCancelled) return;
@@ -119,18 +118,15 @@ export class AnthropicApiError extends ProviderHttpError {
 			if (aborted) return;
 			aborted = true;
 			cancelReader();
-			resolveAbort({ type: "aborted" });
 		};
 		if (signal?.aborted) onAbort();
 		else signal?.addEventListener("abort", onAbort, { once: true });
 
 		const deadline = performance.now() + anthropicErrorBodyReadTimeoutMs;
 		let timeout: Timer | undefined;
-		const { promise: timeoutRead, resolve: resolveTimeout } = Promise.withResolvers<{ type: "timed-out" }>();
 		timeout = setTimeout(() => {
 			timedOut = true;
 			cancelReader();
-			resolveTimeout({ type: "timed-out" });
 		}, anthropicErrorBodyReadTimeoutMs);
 
 		let capturedBytes = 0;
@@ -145,30 +141,23 @@ export class AnthropicApiError extends ProviderHttpError {
 					break;
 				}
 
-				const result = await Promise.race([
-					reader.read().then(
-						value => ({ type: "read" as const, value }),
-						() => ({ type: "read-error" as const }),
-					),
-					abortedRead,
-					timeoutRead,
-				]);
-				if (result.type !== "read" || result.value.done) break;
+				const result = await reader.read();
+				if (aborted || timedOut || result.done) break;
 
-				const chunk = result.value.value;
+				const chunk = result.value;
 				const bytesToCapture = Math.min(MAX_ANTHROPIC_ERROR_BODY_BYTES - capturedBytes, chunk.byteLength);
 				if (bytesToCapture > 0) {
 					bodyChunks.push(decoder.decode(chunk.subarray(0, bytesToCapture), { stream: true }));
 					capturedBytes += bytesToCapture;
 				}
-				if (capturedBytes === MAX_ANTHROPIC_ERROR_BODY_BYTES) {
+				if (bytesToCapture < chunk.byteLength) {
 					truncated = true;
 					cancelReader();
 					break;
 				}
 			}
 			if (aborted || signal?.aborted) throw new AbortError("Request was aborted.");
-			bodyChunks.push(decoder.decode());
+			if (!truncated) bodyChunks.push(decoder.decode());
 			if (truncated) bodyChunks.push(ANTHROPIC_ERROR_BODY_TRUNCATION_MARKER);
 		} finally {
 			if (timeout !== undefined) clearTimeout(timeout);

--- a/packages/ai/src/providers/anthropic-client.ts
+++ b/packages/ai/src/providers/anthropic-client.ts
@@ -43,6 +43,12 @@ export interface AnthropicRequestOptions {
 	timeout?: number;
 	/** Per-request retry budget override. */
 	maxRetries?: number;
+	/**
+	 * Maximum delay in milliseconds to wait for a server-directed retry. If the
+	 * server's `retry-after` hint exceeds this value, the retry is declined and
+	 * the original error is surfaced. `0` disables the cap. Defaults to 60000.
+	 */
+	maxRetryDelayMs?: number;
 	/** Per-request headers merged after client defaults. */
 	headers?: Record<string, string>;
 }
@@ -74,6 +80,12 @@ export interface AnthropicClientOptions {
 	authToken?: string | null;
 	baseURL?: string | null;
 	maxRetries?: number;
+	/**
+	 * Maximum delay in milliseconds to wait for a server-directed retry. If the
+	 * server's `retry-after` hint exceeds this value, the retry is declined and
+	 * the original error is surfaced. `0` disables the cap. Defaults to 60000.
+	 */
+	maxRetryDelayMs?: number;
 	/** Pre-response timeout in milliseconds. Defaults to 10 minutes. */
 	timeout?: number;
 	defaultHeaders?: Record<string, string>;
@@ -216,6 +228,7 @@ export class AnthropicMessagesClient implements AnthropicMessagesClientLike {
 		const callerSignal = options?.signal;
 		const timeoutMs = options?.timeout ?? opts.timeout ?? DEFAULT_TIMEOUT_MS;
 		const maxRetries = Math.max(0, options?.maxRetries ?? opts.maxRetries ?? DEFAULT_MAX_RETRIES);
+		const maxRetryDelayMs = options?.maxRetryDelayMs ?? opts.maxRetryDelayMs ?? 60_000;
 		const url = `${opts.baseURL ?? "https://api.anthropic.com"}${path}`;
 		const headers = this.#buildHeaders(options?.headers);
 		const body = JSON.stringify(params);
@@ -239,11 +252,20 @@ export class AnthropicMessagesClient implements AnthropicMessagesClientLike {
 			if (response.ok) return response;
 
 			if (attempt < maxRetries && shouldRetryResponse(response)) {
+				// Bound the server-directed wait: an over-cap `retry-after` declines
+				// the retry and surfaces the original error (status/body/headers
+				// intact) so higher-level recovery can run. `0` disables the cap.
+				// Checked before draining the body so `fromResponse` can still read it.
+				const headerDelayMs = retryDelayFromHeaders(response.headers);
+				if (headerDelayMs !== undefined && maxRetryDelayMs !== 0 && headerDelayMs > maxRetryDelayMs) {
+					throw await AIError.AnthropicApiError.fromResponse(response, callerSignal);
+				}
 				await response.body?.cancel().catch(() => {});
 				await this.#backoff(attempt, response.headers, callerSignal);
 				continue;
 			}
-			throw await AIError.AnthropicApiError.fromResponse(response);
+
+			throw await AIError.AnthropicApiError.fromResponse(response, callerSignal);
 		}
 	}
 

--- a/packages/ai/src/providers/anthropic-client.ts
+++ b/packages/ai/src/providers/anthropic-client.ts
@@ -46,7 +46,7 @@ export interface AnthropicRequestOptions {
 	/**
 	 * Maximum delay in milliseconds to wait for a server-directed retry. If the
 	 * server's `retry-after` hint exceeds this value, the retry is declined and
-	 * the original error is surfaced. `0` disables the cap. Defaults to 60000.
+	 * the original error is surfaced. Non-positive values disable the cap. Defaults to 60000.
 	 */
 	maxRetryDelayMs?: number;
 	/** Per-request headers merged after client defaults. */
@@ -83,7 +83,7 @@ export interface AnthropicClientOptions {
 	/**
 	 * Maximum delay in milliseconds to wait for a server-directed retry. If the
 	 * server's `retry-after` hint exceeds this value, the retry is declined and
-	 * the original error is surfaced. `0` disables the cap. Defaults to 60000.
+	 * the original error is surfaced. Non-positive values disable the cap. Defaults to 60000.
 	 */
 	maxRetryDelayMs?: number;
 	/** Pre-response timeout in milliseconds. Defaults to 10 minutes. */
@@ -109,7 +109,7 @@ function shouldRetryResponse(response: Response): boolean {
 }
 
 /** Server-suggested delay (`retry-after-ms`, then `retry-after` seconds or HTTP date). */
-export function retryDelayFromHeaders(headers: Headers | undefined): number | undefined {
+export function retryDelayFromHeaders(headers: Pick<Headers, "get"> | undefined): number | undefined {
 	if (!headers) return undefined;
 	const retryAfterMs = headers.get("retry-after-ms");
 	if (retryAfterMs) {
@@ -254,10 +254,10 @@ export class AnthropicMessagesClient implements AnthropicMessagesClientLike {
 			if (attempt < maxRetries && shouldRetryResponse(response)) {
 				// Bound the server-directed wait: an over-cap `retry-after` declines
 				// the retry and surfaces the original error (status/body/headers
-				// intact) so higher-level recovery can run. `0` disables the cap.
+				// intact) so higher-level recovery can run. A non-positive cap disables enforcement.
 				// Checked before draining the body so `fromResponse` can still read it.
 				const headerDelayMs = retryDelayFromHeaders(response.headers);
-				if (headerDelayMs !== undefined && maxRetryDelayMs !== 0 && headerDelayMs > maxRetryDelayMs) {
+				if (headerDelayMs !== undefined && maxRetryDelayMs > 0 && headerDelayMs > maxRetryDelayMs) {
 					throw await AIError.AnthropicApiError.fromResponse(response, callerSignal);
 				}
 				await response.body?.cancel().catch(() => {});

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2703,6 +2703,14 @@ const streamAnthropicOnce = (
 						streamFailure instanceof Error && streamFailure instanceof AnthropicApiError
 							? retryDelayFromHeaders(streamFailure.headers)
 							: undefined;
+					// Bound the server-directed wait so a multi-hour `retry-after` cannot
+					// park the provider stream before higher-level recovery runs. A cap of
+					// 0 disables the bound; an over-cap hint surfaces the original error
+					// immediately without a second wire attempt or a `providerRetryWait`.
+					const maxRetryDelayMs = options?.maxRetryDelayMs ?? 60_000;
+					if (headerDelayMs !== undefined && maxRetryDelayMs !== 0 && headerDelayMs > maxRetryDelayMs) {
+						throw streamFailure;
+					}
 					const delayMs = headerDelayMs !== undefined ? Math.max(headerDelayMs, backoffDelayMs) : backoffDelayMs;
 					if (options?.providerRetryWait) {
 						await options.providerRetryWait(delayMs, options.signal);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -60,6 +60,7 @@ import { isFoundryEnabled } from "../utils/foundry";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
 import { notifyProviderResponse } from "../utils/provider-response";
+import { getHeadersFromError, getRetryAfterMsFromHeaders } from "../utils/retry-after";
 import { COMBINATOR_KEYS, NO_STRICT, toolWireSchema } from "../utils/schema";
 import { spillToDescription } from "../utils/schema/spill";
 import { createSdkStreamRequestOptions } from "../utils/sdk-stream-timeout";
@@ -71,7 +72,6 @@ import {
 	AnthropicMessagesClient,
 	type AnthropicMessagesClientLike,
 	calculateAnthropicRetryDelayMs,
-	retryDelayFromHeaders,
 } from "./anthropic-client";
 import {
 	type ToolInputSchema as AnthropicToolInputSchema,
@@ -1575,16 +1575,6 @@ export function isProviderRetryableError(error: unknown, provider?: string): boo
 	});
 }
 
-function hasHeaderGetter(value: unknown): value is Pick<Headers, "get"> {
-	return typeof value === "object" && value !== null && "get" in value && typeof value.get === "function";
-}
-
-function retryDelayFromErrorHeaders(error: unknown): number | undefined {
-	if (typeof error !== "object" || error === null || !("headers" in error)) return undefined;
-	const { headers } = error as { headers?: unknown };
-	return hasHeaderGetter(headers) ? retryDelayFromHeaders(headers) : undefined;
-}
-
 const THINKING_ENVELOPE_OPEN = "<thinking>";
 const THINKING_ENVELOPE_CLOSE = "</thinking>";
 
@@ -2711,7 +2701,7 @@ const streamAnthropicOnce = (
 					// Honor the server's retry hint (`retry-after-ms`/`retry-after`) on
 					// 429/529-style failures: retrying sooner than the server asked is a
 					// guaranteed failure that just burns the retry budget.
-					const headerDelayMs = retryDelayFromErrorHeaders(streamFailure);
+					const headerDelayMs = getRetryAfterMsFromHeaders(getHeadersFromError(streamFailure));
 					// Bound the server-directed wait so a multi-hour `retry-after` cannot
 					// park the provider stream before higher-level recovery runs. A non-positive cap
 					// disables the bound; an over-cap hint surfaces the original error immediately.

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -66,7 +66,6 @@ import { createSdkStreamRequestOptions } from "../utils/sdk-stream-timeout";
 import { notifyRawSseEvent } from "../utils/sse-debug";
 import { isForcedToolChoice } from "../utils/tool-choice";
 import {
-	AnthropicApiError,
 	AnthropicConnectionTimeoutError,
 	type AnthropicFetchOptions,
 	AnthropicMessagesClient,
@@ -1155,6 +1154,7 @@ export type AnthropicClientOptionsArgs = {
 	thinkingDisplay?: AnthropicThinkingDisplay;
 	disableStrictTools?: boolean;
 	fetch?: FetchImpl;
+	maxRetryDelayMs?: number;
 	claudeCodeSessionId?: string;
 };
 
@@ -1164,6 +1164,7 @@ export type AnthropicClientOptionsResult = {
 	authToken?: string | null;
 	baseURL?: string;
 	maxRetries: number;
+	maxRetryDelayMs?: number;
 	defaultHeaders: Record<string, string>;
 	fetch?: FetchImpl;
 	fetchOptions?: AnthropicFetchOptions;
@@ -1574,6 +1575,16 @@ export function isProviderRetryableError(error: unknown, provider?: string): boo
 	});
 }
 
+function hasHeaderGetter(value: unknown): value is Pick<Headers, "get"> {
+	return typeof value === "object" && value !== null && "get" in value && typeof value.get === "function";
+}
+
+function retryDelayFromErrorHeaders(error: unknown): number | undefined {
+	if (typeof error !== "object" || error === null || !("headers" in error)) return undefined;
+	const { headers } = error as { headers?: unknown };
+	return hasHeaderGetter(headers) ? retryDelayFromHeaders(headers) : undefined;
+}
+
 const THINKING_ENVELOPE_OPEN = "<thinking>";
 const THINKING_ENVELOPE_CLOSE = "</thinking>";
 
@@ -1952,6 +1963,7 @@ const streamAnthropicOnce = (
 					thinkingEnabled: options?.thinkingEnabled,
 					thinkingDisplay: options?.thinkingDisplay,
 					fetch: options?.fetch,
+					maxRetryDelayMs: options?.maxRetryDelayMs,
 					claudeCodeSessionId: options?.sessionId ?? extractClaudeMetadataSessionId(options?.metadata?.user_id),
 					disableStrictTools,
 				});
@@ -2699,16 +2711,12 @@ const streamAnthropicOnce = (
 					// Honor the server's retry hint (`retry-after-ms`/`retry-after`) on
 					// 429/529-style failures: retrying sooner than the server asked is a
 					// guaranteed failure that just burns the retry budget.
-					const headerDelayMs =
-						streamFailure instanceof Error && streamFailure instanceof AnthropicApiError
-							? retryDelayFromHeaders(streamFailure.headers)
-							: undefined;
+					const headerDelayMs = retryDelayFromErrorHeaders(streamFailure);
 					// Bound the server-directed wait so a multi-hour `retry-after` cannot
-					// park the provider stream before higher-level recovery runs. A cap of
-					// 0 disables the bound; an over-cap hint surfaces the original error
-					// immediately without a second wire attempt or a `providerRetryWait`.
+					// park the provider stream before higher-level recovery runs. A non-positive cap
+					// disables the bound; an over-cap hint surfaces the original error immediately.
 					const maxRetryDelayMs = options?.maxRetryDelayMs ?? 60_000;
-					if (headerDelayMs !== undefined && maxRetryDelayMs !== 0 && headerDelayMs > maxRetryDelayMs) {
+					if (headerDelayMs !== undefined && maxRetryDelayMs > 0 && headerDelayMs > maxRetryDelayMs) {
 						throw streamFailure;
 					}
 					const delayMs = headerDelayMs !== undefined ? Math.max(headerDelayMs, backoffDelayMs) : backoffDelayMs;
@@ -2855,6 +2863,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		thinkingEnabled = false,
 		thinkingDisplay,
 		isOAuth,
+		maxRetryDelayMs,
 		claudeCodeSessionId,
 		disableStrictTools: disableStrictToolsOverride,
 	} = args;
@@ -2925,6 +2934,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 			authToken: copilotApiKey,
 			baseURL: baseUrl,
 			maxRetries: 5,
+			maxRetryDelayMs,
 			defaultHeaders,
 			fetch: cchFetch,
 			fetchOptions,
@@ -2972,6 +2982,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 			authToken: null,
 			baseURL: baseUrl,
 			maxRetries: 5,
+			maxRetryDelayMs,
 			defaultHeaders,
 			fetch: cchFetch,
 			fetchOptions,
@@ -2990,6 +3001,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 			authToken: null,
 			baseURL: baseUrl,
 			maxRetries: 5,
+			maxRetryDelayMs,
 			defaultHeaders,
 			fetch: cchFetch,
 			fetchOptions,
@@ -3012,6 +3024,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		authToken: oauthToken ? apiKey : undefined,
 		baseURL: baseUrl,
 		maxRetries: 5,
+		maxRetryDelayMs,
 		defaultHeaders,
 		fetch: cchFetch,
 		fetchOptions,

--- a/packages/ai/test/anthropic-client.test.ts
+++ b/packages/ai/test/anthropic-client.test.ts
@@ -306,7 +306,53 @@ describe("AnthropicMessagesClient retry-after cap", () => {
 		for (let i = 0; i < 1000 && !bodyCancelled; i++) await Promise.resolve();
 		if (!bodyCancelled) throw new Error("Anthropic error-body reader was not cancelled");
 
+		expect(error).toBeInstanceOf(AIError.AbortError);
 		expect(error.message).toBe("Request was aborted.");
 		expect(response?.body?.locked).toBe(false);
+	});
+
+	it("bounds a never-ending error body without a caller signal", async () => {
+		const encoder = new TextEncoder();
+		let readBlocked = false;
+		let bodyCancelled = false;
+		let response: Response | undefined;
+		const openBody = new ReadableStream<Uint8Array>({
+			start(streamController) {
+				streamController.enqueue(encoder.encode("overloaded"));
+			},
+			pull() {
+				readBlocked = true;
+				return new Promise<void>(() => {});
+			},
+			cancel() {
+				bodyCancelled = true;
+			},
+		});
+		const fetch: FetchImpl = async () => {
+			response = new Response(openBody, {
+				status: 529,
+				headers: { "retry-after": "120", "request-id": "req_body_timeout" },
+			});
+			return response;
+		};
+		const client = new AnthropicMessagesClient({ apiKey: "sk-test", maxRetries: 5, fetch });
+
+		AIError.__anthropicApiErrorForTesting.setBodyReadTimeoutMs(5);
+		try {
+			const error = await client.messages
+				.create(params, { maxRetryDelayMs: 60_000 })
+				.asResponse()
+				.catch(err => err as AIError.AnthropicApiError);
+			if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
+
+			expect(readBlocked).toBe(true);
+			expect(error.status).toBe(529);
+			expect(error.message).toBe("529 overloaded");
+			expect(error.headers.get("request-id")).toBe("req_body_timeout");
+			expect(bodyCancelled).toBe(true);
+			expect(response?.body?.locked).toBe(false);
+		} finally {
+			AIError.__anthropicApiErrorForTesting.setBodyReadTimeoutMs(undefined);
+		}
 	});
 });

--- a/packages/ai/test/anthropic-client.test.ts
+++ b/packages/ai/test/anthropic-client.test.ts
@@ -212,3 +212,79 @@ describe("AnthropicMessagesClient request assembly", () => {
 		expect(calls[0].url).toBe("https://api.anthropic.com/v1/messages");
 	});
 });
+
+describe("AnthropicMessagesClient retry-after cap", () => {
+	it("declines a retry and preserves original status/body/headers when retry-after exceeds maxRetryDelayMs", async () => {
+		const errorHeaders = { "retry-after": "120", "request-id": "req_cap" };
+		const { calls, fetch } = createFetchMock([new Response("overloaded", { status: 429, headers: errorHeaders })]);
+		const client = new AnthropicMessagesClient({ apiKey: "sk-test", maxRetries: 5, fetch });
+
+		const error = await client.messages
+			.create(params, { maxRetryDelayMs: 60_000 })
+			.asResponse()
+			.catch(err => err as AIError.AnthropicApiError);
+		if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
+
+		expect(error).toBeInstanceOf(AIError.AnthropicApiError);
+		expect(error.status).toBe(429);
+		expect(error.message).toContain("overloaded");
+		expect(error.headers.get("request-id")).toBe("req_cap");
+		expect(calls.length).toBe(1);
+	});
+	it("declines a retry for a positive server hint when maxRetryDelayMs is negative", async () => {
+		const errorHeaders = { "retry-after": "1", "request-id": "req_neg" };
+		const { calls, fetch } = createFetchMock([new Response("overloaded", { status: 429, headers: errorHeaders })]);
+		const client = new AnthropicMessagesClient({ apiKey: "sk-test", maxRetries: 5, fetch });
+
+		const error = await client.messages
+			.create(params, { maxRetryDelayMs: -1 })
+			.asResponse()
+			.catch(err => err as AIError.AnthropicApiError);
+
+		expect(error).toBeInstanceOf(AIError.AnthropicApiError);
+		expect(error.status).toBe(429);
+		expect(calls.length).toBe(1);
+	});
+	it("cancels and releases an open error-body reader when the caller aborts", async () => {
+		const controller = new AbortController();
+		const encoder = new TextEncoder();
+		let readBlocked = false;
+		let bodyCancelled = false;
+		let response: Response | undefined;
+		const openBody = new ReadableStream<Uint8Array>({
+			start(streamController) {
+				streamController.enqueue(encoder.encode("overloaded"));
+			},
+			pull() {
+				readBlocked = true;
+				return new Promise<void>(() => {});
+			},
+			cancel() {
+				bodyCancelled = true;
+			},
+		});
+		const fetch: FetchImpl = async () => {
+			response = new Response(openBody, {
+				status: 429,
+				headers: { "retry-after": "120", "request-id": "req_abort" },
+			});
+			return response;
+		};
+		const client = new AnthropicMessagesClient({ apiKey: "sk-test", maxRetries: 5, fetch });
+
+		const pending = client.messages
+			.create(params, { signal: controller.signal, maxRetryDelayMs: 60_000 })
+			.asResponse();
+		for (let i = 0; i < 1000 && !readBlocked; i++) await Promise.resolve();
+		if (!readBlocked) throw new Error("Anthropic error-body read did not block");
+
+		controller.abort();
+		const error = await pending.catch(err => err as Error);
+		if (!(error instanceof Error)) throw new Error("Expected request abort error");
+		for (let i = 0; i < 1000 && !bodyCancelled; i++) await Promise.resolve();
+		if (!bodyCancelled) throw new Error("Anthropic error-body reader was not cancelled");
+
+		expect(error.message).toBe("Request was aborted.");
+		expect(response?.body?.locked).toBe(false);
+	});
+});

--- a/packages/ai/test/anthropic-client.test.ts
+++ b/packages/ai/test/anthropic-client.test.ts
@@ -28,6 +28,10 @@ const anthropicErrorBody = JSON.stringify({
 	type: "error",
 	error: { type: "invalid_request_error", message: "The compiled grammar is too large." },
 });
+const anthropicOverloadedErrorBody = JSON.stringify({
+	type: "error",
+	error: { type: "overloaded_error", message: "Overloaded" },
+});
 
 describe("AnthropicMessagesClient error mapping", () => {
 	it("maps non-2xx responses to AnthropicApiError with status and body in message", async () => {
@@ -134,6 +138,19 @@ describe("AnthropicMessagesClient retries", () => {
 		expect(error).toBeInstanceOf(AIError.AnthropicApiError);
 		expect(calls.length).toBe(3); // initial attempt + 2 retries
 	});
+
+	it("disables the cap when maxRetryDelayMs is negative", async () => {
+		const { calls, fetch } = createFetchMock([
+			new Response("overloaded", { status: 429, headers: { "retry-after-ms": "1" } }),
+			new Response("{}", { status: 200 }),
+		]);
+		const client = new AnthropicMessagesClient({ apiKey: "sk-test", maxRetries: 5, fetch });
+
+		const response = await client.messages.create(params, { maxRetryDelayMs: -1 }).asResponse();
+
+		expect(response.status).toBe(200);
+		expect(calls.length).toBe(2);
+	});
 });
 
 describe("AnthropicMessagesClient timeout and abort", () => {
@@ -214,9 +231,27 @@ describe("AnthropicMessagesClient request assembly", () => {
 });
 
 describe("AnthropicMessagesClient retry-after cap", () => {
+	it("uses the documented 60-second default cap when callers omit one", async () => {
+		const { calls, fetch } = createFetchMock([
+			new Response(anthropicOverloadedErrorBody, { status: 429, headers: { "retry-after": "120" } }),
+		]);
+		const client = new AnthropicMessagesClient({ apiKey: "sk-test", maxRetries: 5, fetch });
+
+		const error = await client.messages
+			.create(params)
+			.asResponse()
+			.catch(err => err as AIError.AnthropicApiError);
+
+		expect(error).toBeInstanceOf(AIError.AnthropicApiError);
+		expect(error.status).toBe(429);
+		expect(calls.length).toBe(1);
+	});
+
 	it("declines a retry and preserves original status/body/headers when retry-after exceeds maxRetryDelayMs", async () => {
 		const errorHeaders = { "retry-after": "120", "request-id": "req_cap" };
-		const { calls, fetch } = createFetchMock([new Response("overloaded", { status: 429, headers: errorHeaders })]);
+		const { calls, fetch } = createFetchMock([
+			new Response(anthropicOverloadedErrorBody, { status: 429, headers: errorHeaders }),
+		]);
 		const client = new AnthropicMessagesClient({ apiKey: "sk-test", maxRetries: 5, fetch });
 
 		const error = await client.messages
@@ -231,20 +266,7 @@ describe("AnthropicMessagesClient retry-after cap", () => {
 		expect(error.headers.get("request-id")).toBe("req_cap");
 		expect(calls.length).toBe(1);
 	});
-	it("declines a retry for a positive server hint when maxRetryDelayMs is negative", async () => {
-		const errorHeaders = { "retry-after": "1", "request-id": "req_neg" };
-		const { calls, fetch } = createFetchMock([new Response("overloaded", { status: 429, headers: errorHeaders })]);
-		const client = new AnthropicMessagesClient({ apiKey: "sk-test", maxRetries: 5, fetch });
 
-		const error = await client.messages
-			.create(params, { maxRetryDelayMs: -1 })
-			.asResponse()
-			.catch(err => err as AIError.AnthropicApiError);
-
-		expect(error).toBeInstanceOf(AIError.AnthropicApiError);
-		expect(error.status).toBe(429);
-		expect(calls.length).toBe(1);
-	});
 	it("cancels and releases an open error-body reader when the caller aborts", async () => {
 		const controller = new AbortController();
 		const encoder = new TextEncoder();
@@ -257,7 +279,7 @@ describe("AnthropicMessagesClient retry-after cap", () => {
 			},
 			pull() {
 				readBlocked = true;
-				return new Promise<void>(() => {});
+				return Promise.withResolvers<void>().promise;
 			},
 			cancel() {
 				bodyCancelled = true;

--- a/packages/ai/test/anthropic-client.test.ts
+++ b/packages/ai/test/anthropic-client.test.ts
@@ -355,4 +355,75 @@ describe("AnthropicMessagesClient retry-after cap", () => {
 			AIError.__anthropicApiErrorForTesting.setBodyReadTimeoutMs(undefined);
 		}
 	});
+
+	it("bounds, marks, and cancels a continuously ready oversized error body", async () => {
+		const chunk = new TextEncoder().encode("x".repeat(1024));
+		let bodyCancelled = false;
+		let response: Response | undefined;
+		const oversizedBody = new ReadableStream<Uint8Array>({
+			pull(streamController) {
+				streamController.enqueue(chunk);
+			},
+			cancel() {
+				bodyCancelled = true;
+			},
+		});
+		const fetch: FetchImpl = async () => {
+			response = new Response(oversizedBody, { status: 400 });
+			return response;
+		};
+		const client = new AnthropicMessagesClient({ apiKey: "sk-test", maxRetries: 0, fetch });
+
+		const startedAt = performance.now();
+		const error = await client.messages
+			.create(params)
+			.asResponse()
+			.catch(err => err as AIError.AnthropicApiError);
+		if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
+		for (let i = 0; i < 1000 && !bodyCancelled; i++) await Promise.resolve();
+		if (!bodyCancelled) throw new Error("Anthropic error-body reader was not cancelled");
+
+		expect(performance.now() - startedAt).toBeLessThan(1_000);
+		expect(error.message).toBe(`400 ${"x".repeat(64 * 1024)}\n[Response body truncated after 64 KiB]`);
+		expect(response?.body?.locked).toBe(false);
+	});
+
+	it("checks the deadline before an always-ready error body can starve timer callbacks", async () => {
+		let bodyCancelled = false;
+		let response: Response | undefined;
+		const alwaysReadyBody = new ReadableStream<Uint8Array>({
+			start(streamController) {
+				streamController.enqueue(new Uint8Array([120]));
+			},
+			pull(streamController) {
+				streamController.enqueue(new Uint8Array([120]));
+			},
+			cancel() {
+				bodyCancelled = true;
+			},
+		});
+		const fetch: FetchImpl = async () => {
+			response = new Response(alwaysReadyBody, { status: 500 });
+			return response;
+		};
+		const client = new AnthropicMessagesClient({ apiKey: "sk-test", maxRetries: 0, fetch });
+
+		AIError.__anthropicApiErrorForTesting.setBodyReadTimeoutMs(0);
+		try {
+			const startedAt = performance.now();
+			const error = await client.messages
+				.create(params)
+				.asResponse()
+				.catch(err => err as AIError.AnthropicApiError);
+			if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
+			for (let i = 0; i < 1000 && !bodyCancelled; i++) await Promise.resolve();
+			if (!bodyCancelled) throw new Error("Anthropic error-body reader was not cancelled");
+
+			expect(performance.now() - startedAt).toBeLessThan(1_000);
+			expect(error.message).toBe("500 status code (no body)");
+			expect(response?.body?.locked).toBe(false);
+		} finally {
+			AIError.__anthropicApiErrorForTesting.setBodyReadTimeoutMs(undefined);
+		}
+	});
 });

--- a/packages/ai/test/anthropic-client.test.ts
+++ b/packages/ai/test/anthropic-client.test.ts
@@ -356,77 +356,6 @@ describe("AnthropicMessagesClient retry-after cap", () => {
 		}
 	});
 
-	it("preserves bounded partial error details when the body stream errors", async () => {
-		const encoder = new TextEncoder();
-		let response: Response | undefined;
-		const partialBody = new ReadableStream<Uint8Array>({
-			start(streamController) {
-				streamController.enqueue(encoder.encode("partial detail"));
-			},
-			pull(streamController) {
-				streamController.error(new Error("socket closed"));
-			},
-		});
-		const client = new AnthropicMessagesClient({
-			apiKey: "sk-test",
-			maxRetries: 0,
-			fetch: async () => {
-				response = new Response(partialBody, { status: 502, headers: { "request-id": "req_partial" } });
-				return response;
-			},
-		});
-
-		const error = await client.messages
-			.create(params)
-			.asResponse()
-			.catch(err => err as AIError.AnthropicApiError);
-		if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
-
-		expect(error.status).toBe(502);
-		expect(error.message).toBe("502 partial detail");
-		expect(error.headers.get("request-id")).toBe("req_partial");
-		expect(response?.body?.locked).toBe(false);
-	});
-
-	it("does not flush an incomplete UTF-8 prefix when the error body times out", async () => {
-		const readBlocked = Promise.withResolvers<void>();
-		let didBlockRead = false;
-		let bodyCancelled = false;
-		const incompleteBody = new ReadableStream<Uint8Array>({
-			start(streamController) {
-				streamController.enqueue(new Uint8Array([0xe2, 0x82]));
-			},
-			pull() {
-				didBlockRead = true;
-				return readBlocked.promise;
-			},
-			cancel() {
-				bodyCancelled = true;
-			},
-		});
-		const client = new AnthropicMessagesClient({
-			apiKey: "sk-test",
-			maxRetries: 0,
-			fetch: async () => new Response(incompleteBody, { status: 500 }),
-		});
-
-		AIError.__anthropicApiErrorForTesting.setBodyReadTimeoutMs(5);
-		try {
-			const error = await client.messages
-				.create(params)
-				.asResponse()
-				.catch(err => err as AIError.AnthropicApiError);
-			if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
-
-			expect(error.message).toBe("500 status code (no body)");
-			expect(error.message).not.toContain("\uFFFD");
-			expect(didBlockRead).toBe(true);
-			expect(bodyCancelled).toBe(true);
-		} finally {
-			AIError.__anthropicApiErrorForTesting.setBodyReadTimeoutMs(undefined);
-		}
-	});
-
 	it("bounds, marks, and cancels a continuously ready oversized error body", async () => {
 		const chunk = new TextEncoder().encode("x".repeat(1024));
 		let bodyCancelled = false;
@@ -488,13 +417,11 @@ describe("AnthropicMessagesClient retry-after cap", () => {
 	});
 
 	it("marks and cancels only after observing the 64 KiB-plus-one error-body byte", async () => {
-		const firstChunk = new Uint8Array(64 * 1024).fill(120);
-		const overflowByte = new Uint8Array([120]);
+		const body = new Uint8Array(64 * 1024 + 1).fill(120);
 		let bodyCancelled = false;
 		const overflowingBody = new ReadableStream<Uint8Array>({
 			start(streamController) {
-				streamController.enqueue(firstChunk);
-				streamController.enqueue(overflowByte);
+				streamController.enqueue(body);
 			},
 			cancel() {
 				bodyCancelled = true;

--- a/packages/ai/test/anthropic-client.test.ts
+++ b/packages/ai/test/anthropic-client.test.ts
@@ -421,11 +421,13 @@ describe("AnthropicMessagesClient retry-after cap", () => {
 		completeTextWithIncompletePrefix.set(completeText);
 		completeTextWithIncompletePrefix.set([0xe2, 0x82], completeText.byteLength);
 		let response: Response | undefined;
+		let pullErrored = false;
 		const rejectedBody = new ReadableStream<Uint8Array>({
 			start(streamController) {
 				streamController.enqueue(completeTextWithIncompletePrefix);
 			},
 			pull(streamController) {
+				pullErrored = true;
 				streamController.error(new Error("socket closed"));
 			},
 		});
@@ -447,6 +449,7 @@ describe("AnthropicMessagesClient retry-after cap", () => {
 		expect(error.message).toBe("502 complete text");
 		expect(error.message).not.toContain("\uFFFD");
 		expect(response?.body?.locked).toBe(false);
+		expect(pullErrored).toBe(true);
 	});
 
 	it("does not flush an incomplete UTF-8 prefix when the error body times out", async () => {

--- a/packages/ai/test/anthropic-client.test.ts
+++ b/packages/ai/test/anthropic-client.test.ts
@@ -388,6 +388,117 @@ describe("AnthropicMessagesClient retry-after cap", () => {
 		expect(response?.body?.locked).toBe(false);
 	});
 
+	it("preserves an exact 64 KiB error body without marking or cancelling it", async () => {
+		const body = new Uint8Array(64 * 1024).fill(120);
+		let bodyCancelled = false;
+		const exactBody = new ReadableStream<Uint8Array>({
+			start(streamController) {
+				streamController.enqueue(body);
+				streamController.close();
+			},
+			cancel() {
+				bodyCancelled = true;
+			},
+		});
+		const client = new AnthropicMessagesClient({
+			apiKey: "sk-test",
+			maxRetries: 0,
+			fetch: async () => new Response(exactBody, { status: 400 }),
+		});
+
+		const error = await client.messages
+			.create(params)
+			.asResponse()
+			.catch(err => err as AIError.AnthropicApiError);
+		if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
+
+		expect(error.message).toBe(`400 ${"x".repeat(64 * 1024)}`);
+		expect(bodyCancelled).toBe(false);
+	});
+
+	it("marks and cancels only after observing the 64 KiB-plus-one error-body byte", async () => {
+		const body = new Uint8Array(64 * 1024 + 1).fill(120);
+		let bodyCancelled = false;
+		const overflowingBody = new ReadableStream<Uint8Array>({
+			start(streamController) {
+				streamController.enqueue(body);
+			},
+			cancel() {
+				bodyCancelled = true;
+			},
+		});
+		const client = new AnthropicMessagesClient({
+			apiKey: "sk-test",
+			maxRetries: 0,
+			fetch: async () => new Response(overflowingBody, { status: 400 }),
+		});
+
+		const error = await client.messages
+			.create(params)
+			.asResponse()
+			.catch(err => err as AIError.AnthropicApiError);
+		if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
+
+		expect(error.message).toBe(`400 ${"x".repeat(64 * 1024)}\n[Response body truncated after 64 KiB]`);
+		expect(bodyCancelled).toBe(true);
+	});
+
+	it("does not append a replacement character for UTF-8 split by the truncation boundary", async () => {
+		const body = new Uint8Array(64 * 1024 + 2).fill(120);
+		body.set([0xe2, 0x82, 0xac], 64 * 1024 - 1);
+		const client = new AnthropicMessagesClient({
+			apiKey: "sk-test",
+			maxRetries: 0,
+			fetch: async () => new Response(body, { status: 400 }),
+		});
+
+		const error = await client.messages
+			.create(params)
+			.asResponse()
+			.catch(err => err as AIError.AnthropicApiError);
+		if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
+
+		expect(error.message).toBe(`400 ${"x".repeat(64 * 1024 - 1)}\n[Response body truncated after 64 KiB]`);
+		expect(error.message).not.toContain("\uFFFD");
+	});
+
+	it("bounds continuously-ready empty error-body chunks without accumulating read reactions", async () => {
+		let pulls = 0;
+		let bodyCancelled = false;
+		const emptyBody = new ReadableStream<Uint8Array>({
+			pull(streamController) {
+				pulls += 1;
+				streamController.enqueue(new Uint8Array());
+			},
+			cancel() {
+				bodyCancelled = true;
+			},
+		});
+		const client = new AnthropicMessagesClient({
+			apiKey: "sk-test",
+			maxRetries: 0,
+			fetch: async () => new Response(emptyBody, { status: 500 }),
+		});
+
+		AIError.__anthropicApiErrorForTesting.setBodyReadTimeoutMs(5);
+		try {
+			const startedAt = performance.now();
+			const error = await client.messages
+				.create(params)
+				.asResponse()
+				.catch(err => err as AIError.AnthropicApiError);
+			if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
+
+			expect(performance.now() - startedAt).toBeLessThan(1_000);
+			expect(pulls).toBeGreaterThan(0);
+			expect(pulls).toBeLessThan(100_000);
+			expect(bodyCancelled).toBe(true);
+			expect(error.message).toBe("500 status code (no body)");
+		} finally {
+			AIError.__anthropicApiErrorForTesting.setBodyReadTimeoutMs(undefined);
+		}
+	});
+
 	it("checks the deadline before an always-ready error body can starve timer callbacks", async () => {
 		let bodyCancelled = false;
 		let response: Response | undefined;

--- a/packages/ai/test/anthropic-client.test.ts
+++ b/packages/ai/test/anthropic-client.test.ts
@@ -388,6 +388,67 @@ describe("AnthropicMessagesClient retry-after cap", () => {
 		expect(response?.body?.locked).toBe(false);
 	});
 
+	it("flushes an incomplete UTF-8 prefix at clean error-body EOF", async () => {
+		let response: Response | undefined;
+		const incompleteBody = new ReadableStream<Uint8Array>({
+			start(streamController) {
+				streamController.enqueue(new Uint8Array([0xe2, 0x82]));
+				streamController.close();
+			},
+		});
+		const client = new AnthropicMessagesClient({
+			apiKey: "sk-test",
+			maxRetries: 0,
+			fetch: async () => {
+				response = new Response(incompleteBody, { status: 500 });
+				return response;
+			},
+		});
+
+		const error = await client.messages
+			.create(params)
+			.asResponse()
+			.catch(err => err as AIError.AnthropicApiError);
+		if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
+
+		expect(error.message).toBe("500 \uFFFD");
+		expect(response?.body?.locked).toBe(false);
+	});
+
+	it("keeps complete error text without flushing an incomplete UTF-8 prefix after a read rejection", async () => {
+		const completeText = new TextEncoder().encode("complete text");
+		const completeTextWithIncompletePrefix = new Uint8Array(completeText.byteLength + 2);
+		completeTextWithIncompletePrefix.set(completeText);
+		completeTextWithIncompletePrefix.set([0xe2, 0x82], completeText.byteLength);
+		let response: Response | undefined;
+		const rejectedBody = new ReadableStream<Uint8Array>({
+			start(streamController) {
+				streamController.enqueue(completeTextWithIncompletePrefix);
+			},
+			pull(streamController) {
+				streamController.error(new Error("socket closed"));
+			},
+		});
+		const client = new AnthropicMessagesClient({
+			apiKey: "sk-test",
+			maxRetries: 0,
+			fetch: async () => {
+				response = new Response(rejectedBody, { status: 502 });
+				return response;
+			},
+		});
+
+		const error = await client.messages
+			.create(params)
+			.asResponse()
+			.catch(err => err as AIError.AnthropicApiError);
+		if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
+
+		expect(error.message).toBe("502 complete text");
+		expect(error.message).not.toContain("\uFFFD");
+		expect(response?.body?.locked).toBe(false);
+	});
+
 	it("does not flush an incomplete UTF-8 prefix when the error body times out", async () => {
 		const readBlocked = Promise.withResolvers<void>();
 		let didBlockRead = false;

--- a/packages/ai/test/anthropic-client.test.ts
+++ b/packages/ai/test/anthropic-client.test.ts
@@ -356,6 +356,77 @@ describe("AnthropicMessagesClient retry-after cap", () => {
 		}
 	});
 
+	it("preserves bounded partial error details when the body stream errors", async () => {
+		const encoder = new TextEncoder();
+		let response: Response | undefined;
+		const partialBody = new ReadableStream<Uint8Array>({
+			start(streamController) {
+				streamController.enqueue(encoder.encode("partial detail"));
+			},
+			pull(streamController) {
+				streamController.error(new Error("socket closed"));
+			},
+		});
+		const client = new AnthropicMessagesClient({
+			apiKey: "sk-test",
+			maxRetries: 0,
+			fetch: async () => {
+				response = new Response(partialBody, { status: 502, headers: { "request-id": "req_partial" } });
+				return response;
+			},
+		});
+
+		const error = await client.messages
+			.create(params)
+			.asResponse()
+			.catch(err => err as AIError.AnthropicApiError);
+		if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
+
+		expect(error.status).toBe(502);
+		expect(error.message).toBe("502 partial detail");
+		expect(error.headers.get("request-id")).toBe("req_partial");
+		expect(response?.body?.locked).toBe(false);
+	});
+
+	it("does not flush an incomplete UTF-8 prefix when the error body times out", async () => {
+		const readBlocked = Promise.withResolvers<void>();
+		let didBlockRead = false;
+		let bodyCancelled = false;
+		const incompleteBody = new ReadableStream<Uint8Array>({
+			start(streamController) {
+				streamController.enqueue(new Uint8Array([0xe2, 0x82]));
+			},
+			pull() {
+				didBlockRead = true;
+				return readBlocked.promise;
+			},
+			cancel() {
+				bodyCancelled = true;
+			},
+		});
+		const client = new AnthropicMessagesClient({
+			apiKey: "sk-test",
+			maxRetries: 0,
+			fetch: async () => new Response(incompleteBody, { status: 500 }),
+		});
+
+		AIError.__anthropicApiErrorForTesting.setBodyReadTimeoutMs(5);
+		try {
+			const error = await client.messages
+				.create(params)
+				.asResponse()
+				.catch(err => err as AIError.AnthropicApiError);
+			if (!(error instanceof AIError.AnthropicApiError)) throw new Error("Expected AnthropicApiError");
+
+			expect(error.message).toBe("500 status code (no body)");
+			expect(error.message).not.toContain("\uFFFD");
+			expect(didBlockRead).toBe(true);
+			expect(bodyCancelled).toBe(true);
+		} finally {
+			AIError.__anthropicApiErrorForTesting.setBodyReadTimeoutMs(undefined);
+		}
+	});
+
 	it("bounds, marks, and cancels a continuously ready oversized error body", async () => {
 		const chunk = new TextEncoder().encode("x".repeat(1024));
 		let bodyCancelled = false;
@@ -417,11 +488,13 @@ describe("AnthropicMessagesClient retry-after cap", () => {
 	});
 
 	it("marks and cancels only after observing the 64 KiB-plus-one error-body byte", async () => {
-		const body = new Uint8Array(64 * 1024 + 1).fill(120);
+		const firstChunk = new Uint8Array(64 * 1024).fill(120);
+		const overflowByte = new Uint8Array([120]);
 		let bodyCancelled = false;
 		const overflowingBody = new ReadableStream<Uint8Array>({
 			start(streamController) {
-				streamController.enqueue(body);
+				streamController.enqueue(firstChunk);
+				streamController.enqueue(overflowByte);
 			},
 			cancel() {
 				bodyCancelled = true;

--- a/packages/ai/test/anthropic-stream-timeout.test.ts
+++ b/packages/ai/test/anthropic-stream-timeout.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
-import type { AnthropicMessagesClientLike } from "@oh-my-pi/pi-ai/providers/anthropic-client";
-import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { AnthropicMessagesClient, type AnthropicMessagesClientLike } from "@oh-my-pi/pi-ai/providers/anthropic-client";
+import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { waitForDelayOrAbort } from "./helpers";
 
@@ -88,6 +88,36 @@ function createSuccessfulAnthropicEvents(text: string): MockAnthropicEvent[] {
 		},
 		{ type: "message_stop" },
 	];
+}
+
+function createAnthropicSseResponse(text: string): Response {
+	const body = createSuccessfulAnthropicEvents(text)
+		.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+		.join("");
+	return new Response(body, {
+		status: 200,
+		headers: { "content-type": "text/event-stream", "request-id": "req_retry_success" },
+	});
+}
+
+function createResponseClient(responses: Response[]): {
+	calls: { count: number };
+	client: AnthropicMessagesClientLike;
+} {
+	const calls = { count: 0 };
+	const fetch: FetchImpl = async () => {
+		const response = responses[Math.min(calls.count++, responses.length - 1)];
+		if (!response) throw new Error("Expected an Anthropic mock response");
+		return new Response(response.body, {
+			status: response.status,
+			statusText: response.statusText,
+			headers: response.headers,
+		});
+	};
+	return {
+		calls,
+		client: new AnthropicMessagesClient({ apiKey: "sk-test", maxRetries: 0, fetch }),
+	};
 }
 
 function createAnthropicMockStream({
@@ -535,47 +565,122 @@ describe("anthropic provider retry delays", () => {
 });
 
 describe("anthropic retry-after cap (maxRetryDelayMs)", () => {
-	it("surfaces the original error without a second attempt when retry-after exceeds the default 60s cap", async () => {
-		let attempt = 0;
-		const create = ((_body: unknown, _requestOptions?: { signal?: AbortSignal }) => {
-			attempt += 1;
-			return createRejectedAnthropicRequest(
-				new AIError.AnthropicApiError(
-					429,
-					'429 {"type":"error","error":{"type":"rate_limit_error","message":"Too many requests"}}',
-					new Headers({ "retry-after": "120" }),
-				),
-			) as never;
-		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
-		const client = { messages: { create } } as AnthropicMessagesClientLike;
+	it("surfaces the original HTTP error without a second attempt when retry-after exceeds the default 60s cap", async () => {
+		const { calls, client } = createResponseClient([
+			new Response('{"type":"error","error":{"type":"rate_limit_error","message":"Too many requests"}}', {
+				status: 429,
+				headers: { "retry-after": "120" },
+			}),
+		]);
 		const providerRetryWait = vi.fn(async () => {});
 
 		const result = await streamAnthropic(model, context, { client, providerRetryWait }).result();
 
-		expect(attempt).toBe(1);
+		expect(calls.count).toBe(1);
 		expect(providerRetryWait).not.toHaveBeenCalled();
 		expect(result.stopReason).toBe("error");
 		expect(result.errorStatus).toBe(429);
 		expect(result.errorMessage).toContain("rate_limit_error");
 	});
 
-	it("surfaces the original error when retry-after exceeds an explicit maxRetryDelayMs cap", async () => {
-		let attempt = 0;
-		const create = ((_body: unknown, _requestOptions?: { signal?: AbortSignal }) => {
-			attempt += 1;
-			return createRejectedAnthropicRequest(
-				new AIError.AnthropicApiError(
-					529,
-					'529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
-					new Headers({ "retry-after-ms": "10000" }),
-				),
-			) as never;
-		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
-		const client = { messages: { create } } as AnthropicMessagesClientLike;
+	it("surfaces the original HTTP error when retry-after exceeds an explicit cap", async () => {
+		const { calls, client } = createResponseClient([
+			new Response('{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}', {
+				status: 529,
+				headers: { "retry-after-ms": "10000" },
+			}),
+		]);
 		const providerRetryWait = vi.fn(async () => {});
 
 		const result = await streamAnthropic(model, context, {
 			client,
+			providerRetryWait,
+			maxRetryDelayMs: 5_000,
+		}).result();
+
+		expect(calls.count).toBe(1);
+		expect(providerRetryWait).not.toHaveBeenCalled();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(529);
+	});
+
+	it("disables the cap when maxRetryDelayMs is negative", async () => {
+		const { calls, client } = createResponseClient([
+			new Response('{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}', {
+				status: 529,
+				headers: { "retry-after": "1" },
+			}),
+			createAnthropicSseResponse("after unbounded wait"),
+		]);
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, {
+			client,
+			providerRetryWait,
+			maxRetryDelayMs: -1,
+		}).result();
+
+		expect(calls.count).toBe(2);
+		expect(providerRetryWait).toHaveBeenCalledWith(1_000, undefined);
+		expect(result.stopReason).toBe("stop");
+	});
+
+	it("disables the cap when maxRetryDelayMs is 0 and waits the full server hint", async () => {
+		const { calls, client } = createResponseClient([
+			new Response('{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}', {
+				status: 529,
+				headers: { "retry-after": "120" },
+			}),
+			createAnthropicSseResponse("after long wait"),
+		]);
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, {
+			client,
+			providerRetryWait,
+			maxRetryDelayMs: 0,
+		}).result();
+
+		expect(calls.count).toBe(2);
+		expect(providerRetryWait).toHaveBeenCalledWith(120_000, undefined);
+		expect(result.stopReason).toBe("stop");
+	});
+
+	it("retries when the HTTP retry-after hint is under the cap", async () => {
+		const { calls, client } = createResponseClient([
+			new Response('{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}', {
+				status: 529,
+				headers: { "retry-after": "30" },
+			}),
+			createAnthropicSseResponse("after backoff"),
+		]);
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, {
+			client,
+			providerRetryWait,
+			maxRetryDelayMs: 60_000,
+		}).result();
+
+		expect(calls.count).toBe(2);
+		expect(providerRetryWait).toHaveBeenCalledWith(30_000, undefined);
+		expect(result.stopReason).toBe("stop");
+	});
+
+	it("honors retry headers from structurally compatible injected SDK errors", async () => {
+		let attempt = 0;
+		const error = Object.assign(new Error("529 overloaded"), {
+			status: 529,
+			headers: new Headers({ "retry-after-ms": "10000" }),
+		});
+		const create = ((_body: unknown) => {
+			attempt += 1;
+			return createRejectedAnthropicRequest(error) as never;
+		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, {
+			client: { messages: { create } },
 			providerRetryWait,
 			maxRetryDelayMs: 5_000,
 		}).result();
@@ -585,94 +690,21 @@ describe("anthropic retry-after cap (maxRetryDelayMs)", () => {
 		expect(result.stopReason).toBe("error");
 		expect(result.errorStatus).toBe(529);
 	});
-	it("surfaces the original error when maxRetryDelayMs is negative and a server hint is present", async () => {
-		let attempt = 0;
-		const create = (_body: unknown, _requestOptions?: { signal?: AbortSignal }) => {
-			attempt += 1;
-			return createRejectedAnthropicRequest(
-				new AIError.AnthropicApiError(
-					529,
-					'529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
-					new Headers({ "retry-after": "1" }),
-				),
-			);
+
+	it("passes maxRetryDelayMs to internally constructed Anthropic clients", async () => {
+		let calls = 0;
+		const fetch: FetchImpl = async () => {
+			calls += 1;
+			return new Response('{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}', {
+				status: 429,
+				headers: { "retry-after-ms": "10" },
+			});
 		};
-		const client: AnthropicMessagesClientLike = { messages: { create } };
-		const providerRetryWait = vi.fn(async () => {});
 
-		const result = await streamAnthropic(model, context, {
-			client,
-			providerRetryWait,
-			maxRetryDelayMs: -1,
-		}).result();
+		const result = await streamAnthropic(model, context, { fetch, maxRetryDelayMs: 5 }).result();
 
-		expect(attempt).toBe(1);
-		expect(providerRetryWait).not.toHaveBeenCalled();
+		expect(calls).toBe(1);
 		expect(result.stopReason).toBe("error");
-		expect(result.errorStatus).toBe(529);
-	});
-
-	it("disables the cap when maxRetryDelayMs is 0 and waits the full server hint", async () => {
-		let attempt = 0;
-		const create = ((_body: unknown, requestOptions?: { signal?: AbortSignal }) => {
-			attempt += 1;
-			if (attempt === 1) {
-				return createRejectedAnthropicRequest(
-					new AIError.AnthropicApiError(
-						529,
-						'529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
-						new Headers({ "retry-after": "120" }),
-					),
-				) as never;
-			}
-			return createAnthropicMockStream({
-				signal: requestOptions?.signal,
-				events: createSuccessfulAnthropicEvents("after long wait"),
-			}) as never;
-		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
-		const client = { messages: { create } } as AnthropicMessagesClientLike;
-		const providerRetryWait = vi.fn(async () => {});
-
-		const result = await streamAnthropic(model, context, {
-			client,
-			providerRetryWait,
-			maxRetryDelayMs: 0,
-		}).result();
-
-		expect(attempt).toBe(2);
-		expect(providerRetryWait).toHaveBeenCalledWith(120_000, undefined);
-		expect(result.stopReason).toBe("stop");
-	});
-
-	it("keeps current behavior when the server hint is under the cap", async () => {
-		let attempt = 0;
-		const create = ((_body: unknown, requestOptions?: { signal?: AbortSignal }) => {
-			attempt += 1;
-			if (attempt === 1) {
-				return createRejectedAnthropicRequest(
-					new AIError.AnthropicApiError(
-						529,
-						'529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
-						new Headers({ "retry-after": "30" }),
-					),
-				) as never;
-			}
-			return createAnthropicMockStream({
-				signal: requestOptions?.signal,
-				events: createSuccessfulAnthropicEvents("after backoff"),
-			}) as never;
-		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
-		const client = { messages: { create } } as AnthropicMessagesClientLike;
-		const providerRetryWait = vi.fn(async () => {});
-
-		const result = await streamAnthropic(model, context, {
-			client,
-			providerRetryWait,
-			maxRetryDelayMs: 60_000,
-		}).result();
-
-		expect(attempt).toBe(2);
-		expect(providerRetryWait).toHaveBeenCalledWith(30_000, undefined);
-		expect(result.stopReason).toBe("stop");
+		expect(result.errorStatus).toBe(429);
 	});
 });

--- a/packages/ai/test/anthropic-stream-timeout.test.ts
+++ b/packages/ai/test/anthropic-stream-timeout.test.ts
@@ -691,6 +691,53 @@ describe("anthropic retry-after cap (maxRetryDelayMs)", () => {
 		expect(result.errorStatus).toBe(529);
 	});
 
+	it("honors record-valued retry headers from injected SDK errors", async () => {
+		let attempt = 0;
+		const error = Object.assign(new Error("529 overloaded"), {
+			status: 529,
+			headers: { "Retry-After-Ms": "10000" },
+		});
+		const create = ((_body: unknown) => {
+			attempt += 1;
+			return createRejectedAnthropicRequest(error) as never;
+		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, {
+			client: { messages: { create } },
+			providerRetryWait,
+			maxRetryDelayMs: 5_000,
+		}).result();
+
+		expect(attempt).toBe(1);
+		expect(providerRetryWait).not.toHaveBeenCalled();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(529);
+	});
+
+	it("honors nested response retry headers from injected SDK errors", async () => {
+		let attempt = 0;
+		const error = Object.assign(new Error("529 overloaded"), {
+			response: { status: 529, headers: { "retry-after-ms": "10000" } },
+		});
+		const create = ((_body: unknown) => {
+			attempt += 1;
+			return createRejectedAnthropicRequest(error) as never;
+		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, {
+			client: { messages: { create } },
+			providerRetryWait,
+			maxRetryDelayMs: 5_000,
+		}).result();
+
+		expect(attempt).toBe(1);
+		expect(providerRetryWait).not.toHaveBeenCalled();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(529);
+	});
+
 	it("passes maxRetryDelayMs to internally constructed Anthropic clients", async () => {
 		let calls = 0;
 		const fetch: FetchImpl = async () => {

--- a/packages/ai/test/anthropic-stream-timeout.test.ts
+++ b/packages/ai/test/anthropic-stream-timeout.test.ts
@@ -533,3 +533,146 @@ describe("anthropic provider retry delays", () => {
 		expect(JSON.parse(JSON.stringify(result.content))).toEqual([{ type: "text", text: "recovered from 502" }]);
 	});
 });
+
+describe("anthropic retry-after cap (maxRetryDelayMs)", () => {
+	it("surfaces the original error without a second attempt when retry-after exceeds the default 60s cap", async () => {
+		let attempt = 0;
+		const create = ((_body: unknown, _requestOptions?: { signal?: AbortSignal }) => {
+			attempt += 1;
+			return createRejectedAnthropicRequest(
+				new AIError.AnthropicApiError(
+					429,
+					'429 {"type":"error","error":{"type":"rate_limit_error","message":"Too many requests"}}',
+					new Headers({ "retry-after": "120" }),
+				),
+			) as never;
+		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
+		const client = { messages: { create } } as AnthropicMessagesClientLike;
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, { client, providerRetryWait }).result();
+
+		expect(attempt).toBe(1);
+		expect(providerRetryWait).not.toHaveBeenCalled();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(429);
+		expect(result.errorMessage).toContain("rate_limit_error");
+	});
+
+	it("surfaces the original error when retry-after exceeds an explicit maxRetryDelayMs cap", async () => {
+		let attempt = 0;
+		const create = ((_body: unknown, _requestOptions?: { signal?: AbortSignal }) => {
+			attempt += 1;
+			return createRejectedAnthropicRequest(
+				new AIError.AnthropicApiError(
+					529,
+					'529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+					new Headers({ "retry-after-ms": "10000" }),
+				),
+			) as never;
+		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
+		const client = { messages: { create } } as AnthropicMessagesClientLike;
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, {
+			client,
+			providerRetryWait,
+			maxRetryDelayMs: 5_000,
+		}).result();
+
+		expect(attempt).toBe(1);
+		expect(providerRetryWait).not.toHaveBeenCalled();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(529);
+	});
+	it("surfaces the original error when maxRetryDelayMs is negative and a server hint is present", async () => {
+		let attempt = 0;
+		const create = (_body: unknown, _requestOptions?: { signal?: AbortSignal }) => {
+			attempt += 1;
+			return createRejectedAnthropicRequest(
+				new AIError.AnthropicApiError(
+					529,
+					'529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+					new Headers({ "retry-after": "1" }),
+				),
+			);
+		};
+		const client: AnthropicMessagesClientLike = { messages: { create } };
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, {
+			client,
+			providerRetryWait,
+			maxRetryDelayMs: -1,
+		}).result();
+
+		expect(attempt).toBe(1);
+		expect(providerRetryWait).not.toHaveBeenCalled();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorStatus).toBe(529);
+	});
+
+	it("disables the cap when maxRetryDelayMs is 0 and waits the full server hint", async () => {
+		let attempt = 0;
+		const create = ((_body: unknown, requestOptions?: { signal?: AbortSignal }) => {
+			attempt += 1;
+			if (attempt === 1) {
+				return createRejectedAnthropicRequest(
+					new AIError.AnthropicApiError(
+						529,
+						'529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+						new Headers({ "retry-after": "120" }),
+					),
+				) as never;
+			}
+			return createAnthropicMockStream({
+				signal: requestOptions?.signal,
+				events: createSuccessfulAnthropicEvents("after long wait"),
+			}) as never;
+		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
+		const client = { messages: { create } } as AnthropicMessagesClientLike;
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, {
+			client,
+			providerRetryWait,
+			maxRetryDelayMs: 0,
+		}).result();
+
+		expect(attempt).toBe(2);
+		expect(providerRetryWait).toHaveBeenCalledWith(120_000, undefined);
+		expect(result.stopReason).toBe("stop");
+	});
+
+	it("keeps current behavior when the server hint is under the cap", async () => {
+		let attempt = 0;
+		const create = ((_body: unknown, requestOptions?: { signal?: AbortSignal }) => {
+			attempt += 1;
+			if (attempt === 1) {
+				return createRejectedAnthropicRequest(
+					new AIError.AnthropicApiError(
+						529,
+						'529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+						new Headers({ "retry-after": "30" }),
+					),
+				) as never;
+			}
+			return createAnthropicMockStream({
+				signal: requestOptions?.signal,
+				events: createSuccessfulAnthropicEvents("after backoff"),
+			}) as never;
+		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
+		const client = { messages: { create } } as AnthropicMessagesClientLike;
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, {
+			client,
+			providerRetryWait,
+			maxRetryDelayMs: 60_000,
+		}).result();
+
+		expect(attempt).toBe(2);
+		expect(providerRetryWait).toHaveBeenCalledWith(30_000, undefined);
+		expect(result.stopReason).toBe("stop");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed configured `retry.maxDelayMs` not being forwarded into Anthropic retry handling, so over-budget server retry delays fail fast.
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -58,6 +58,7 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 			textVerbosity: streamOptions?.textVerbosity ?? textVerbosity,
 			streamFirstEventTimeoutMs: streamOptions?.streamFirstEventTimeoutMs ?? streamFirstEventTimeoutMs,
 			streamIdleTimeoutMs: streamOptions?.streamIdleTimeoutMs ?? streamIdleTimeoutMs,
+			maxRetryDelayMs: streamOptions?.maxRetryDelayMs ?? settings.get("retry.maxDelayMs"),
 			maxInFlightRequests: validateProviderMaxInFlightRequests(
 				streamOptions?.maxInFlightRequests ?? settings.get("providers.maxInFlightRequests"),
 			),

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -115,6 +115,18 @@ describe("createSettingsAwareStreamFn", () => {
 		expect(calls[1]?.options?.streamIdleTimeoutMs).toBe(10_000);
 	});
 
+	it("forwards retry.maxDelayMs while preserving caller overrides", () => {
+		const settings = Settings.isolated({ "retry.maxDelayMs": 300_000 });
+		const { fn: base, calls } = captureBase();
+		const wrapped = createSettingsAwareStreamFn(settings, base);
+
+		wrapped(stubModel, stubContext, undefined);
+		wrapped(stubModel, stubContext, { maxRetryDelayMs: 5_000 });
+
+		expect(calls[0]?.options?.maxRetryDelayMs).toBe(300_000);
+		expect(calls[1]?.options?.maxRetryDelayMs).toBe(5_000);
+	});
+
 	it("treats the default openrouterVariant as absent so the base call carries no variant", () => {
 		const settings = Settings.isolated({ "providers.openrouterVariant": "default" });
 		const { fn: base, calls } = captureBase();


### PR DESCRIPTION
## Summary

Anthropic requests no longer sleep through an unbounded server `retry-after` window when `maxRetryDelayMs` says the caller should regain control sooner. Hints over the limit now surface the original response without a second attempt, while short hints and the existing account-quota rotation path keep their current behavior. Error-body reads also preserve status, headers, and body while releasing the reader cleanly on caller abort.

Fixes #7003

## Verification

- `bun run check:ts` — passed on the isolated branch based on `upstream/main`
- `bun test packages/ai/test/anthropic-client.test.ts packages/ai/test/anthropic-stream-timeout.test.ts packages/ai/test/anthropic-retry.test.ts packages/ai/test/rate-limit-utils.test.ts packages/coding-agent/test/settings-stream-fn.test.ts` — 101 passed
- Full `bun check` reaches the unchanged Rust tree, then the workstation's `audiopus_sys` build fails in CMake; this PR changes no Rust or Cargo input
- Native rebuild was unavailable because neither `bazelisk` nor `bazel` is installed; focused tests used the existing local native addon




