### PR TITLE
fix(storage): add explicit SQLite salvage candidates

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -6373,8 +6373,21 @@ type SerializedCredentialRecord = {
 	identityKey: string | null;
 };
 
-const AUTH_SCHEMA_VERSION = 6;
+export const AUTH_SCHEMA_VERSION = 6;
 const SQLITE_NOW_EPOCH = "CAST(strftime('%s','now') AS INTEGER)";
+
+/** Tables owned by the authentication subsystem in agent.db. */
+export const AUTH_STORAGE_TABLES = {
+	auth_schema_version: "authoritative",
+	cache: "rebuildable",
+	usage_history: "rebuildable",
+	usage_cost_history: "rebuildable",
+	clients: "authoritative",
+	client_usage: "rebuildable",
+	auth_credentials: "authoritative",
+	auth_credential_blocks: "authoritative",
+	auth_credential_refresh_leases: "rebuildable",
+} as const satisfies Record<string, "authoritative" | "rebuildable">;
 
 /**
  * SQLite's busy result code family — base `SQLITE_BUSY` plus the extended
@@ -6786,6 +6799,33 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		this.#listUsageCostsStmt = this.#db.prepare(
 			"SELECT recorded_at, provider, account_key, cost_usd FROM usage_cost_history WHERE recorded_at >= ? AND (? IS NULL OR provider = ?) AND (? IS NULL OR account_key = ?) ORDER BY recorded_at ASC",
 		);
+	}
+
+	/** Validates auth-owned tables without migrations, backfills, or singleton state. */
+	static validateExactPath(dbPath: string): void {
+		const db = new Database(dbPath, { readonly: true, safeIntegers: true });
+		try {
+			const version = db.prepare("SELECT id, version FROM auth_schema_version ORDER BY id").values();
+			if (version.length !== 1 || version[0]?.[0] !== 1n || version[0]?.[1] !== BigInt(AUTH_SCHEMA_VERSION)) {
+				throw new Error(`Auth storage candidate schema version is not ${AUTH_SCHEMA_VERSION}`);
+			}
+			db.prepare("SELECT key, value, expires_at FROM cache LIMIT 1").get();
+			db.prepare("SELECT * FROM usage_history LIMIT 1").get();
+			db.prepare("SELECT * FROM usage_cost_history LIMIT 1").get();
+			db.prepare("SELECT install_id, hostname, first_seen, last_seen FROM clients LIMIT 1").get();
+			db.prepare("SELECT * FROM client_usage LIMIT 1").get();
+			db.prepare(
+				"SELECT id, provider, credential_type, data, disabled_cause, identity_key, created_at, updated_at FROM auth_credentials LIMIT 1",
+			).get();
+			db.prepare(
+				"SELECT credential_id, provider_key, block_scope, blocked_until_ms, updated_at FROM auth_credential_blocks LIMIT 1",
+			).get();
+			db.prepare(
+				"SELECT credential_id, owner, expires_at_ms, updated_at FROM auth_credential_refresh_leases LIMIT 1",
+			).get();
+		} finally {
+			db.close();
+		}
 	}
 
 	static async open(dbPath: string = getAgentDbPath()): Promise<SqliteAuthCredentialStore> {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added dry-run-first `omp gc --repair-storage agent|history` maintenance to create verified SQLite salvage candidates and byte-exact backups without changing live stores ([#7004](https://github.com/can1357/oh-my-pi/issues/7004)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added dry-run-first `omp gc --repair-storage agent|history` maintenance to create verified SQLite salvage candidates and byte-exact backups without changing live stores ([#7004](https://github.com/can1357/oh-my-pi/issues/7004)).
+- Added dry-run-first `omp gc --repair-storage agent|history` maintenance to create verified SQLite salvage candidates and byte-exact backups without changing live stores; it is an explicit opt-in salvage path, not corruption prevention ([#7004](https://github.com/can1357/oh-my-pi/issues/7004)).
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -962,10 +962,15 @@ function renderText(result: GcResult): string {
 		lines.push(`candidate: ${repair.candidate}${repair.candidatePublished ? " (published)" : ""}`);
 		lines.push(`candidate path trusted: ${repair.candidatePathTrusted}`);
 		if (repair.dataLoss) {
+			const omittedTables = repair.objects
+				.filter(object => object.action === "omitted" && object.kind === "table")
+				.map(object => object.name);
 			lines.push(
 				repair.historySource === "sessions"
 					? "data loss: true (session rebuild retains only session messages; existing history rows and stable row IDs are not preserved)"
-					: "data loss: true (fresh empty history)",
+					: omittedTables.length > 0
+						? `data loss: true (registered rebuildable tables omitted: ${omittedTables.join(", ")})`
+						: "data loss: true (fresh empty history)",
 			);
 		}
 		for (const object of repair.objects) {

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -974,7 +974,9 @@ function renderText(result: GcResult): string {
 			);
 		}
 		for (const checksum of repair.checksums)
-			lines.push(`sha256 ${checksum.sha256} ${checksum.size} ${checksum.path}`);
+			lines.push(
+				`sha256 ${checksum.sha256} ${checksum.size} ${checksum.path}${checksum.ephemeral ? " (ephemeral staging)" : ""}`,
+			);
 		if (repair.refusal) lines.push(`refusal: ${repair.refusal}`);
 		if (repair.warning) lines.push(`warning: ${repair.warning}`);
 		lines.push(`manual next step: ${repair.manualNextStep}`);

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -8,6 +8,12 @@ import { getDefault } from "../config/settings-schema";
 import { BLOB_HASH_RE } from "../session/blob-store";
 import { listSessionsReadOnly, type SessionInfo, type SessionStatus } from "../session/session-listing";
 import { FileSessionStorage } from "../session/session-storage";
+import {
+	type HistoryRepairSource,
+	runStorageRepair,
+	type StorageRepairResult,
+	type StorageRepairTarget,
+} from "./storage-repair-cli";
 
 const BLOB_FILE_RE = /^([a-f0-9]{64})(?:\.[A-Za-z0-9][A-Za-z0-9._-]{0,31})?$/;
 const BLOB_REF_RE = /\bblob:sha256:([a-f0-9]{64})\b/gi;
@@ -31,6 +37,9 @@ export interface GcCommandFlags {
 	coldArchiveAfterDays?: number;
 	retainNewestGlobal?: number;
 	retainNewestPerCwd?: number;
+	repairStorage?: StorageRepairTarget;
+	historySource?: HistoryRepairSource;
+	output?: string;
 }
 
 export interface GcCommandArgs {
@@ -81,6 +90,7 @@ export interface GcResult {
 	blobs?: BlobGcResult;
 	archive?: ArchiveGcResult;
 	wal?: WalGcResult;
+	repair?: StorageRepairResult;
 	lockPath: string;
 }
 
@@ -107,6 +117,9 @@ interface ResolvedGcOptions {
 	coldArchiveAfterDays: number;
 	retainNewestGlobal: number;
 	retainNewestPerCwd: number;
+	repairStorage?: StorageRepairTarget;
+	historySource?: HistoryRepairSource;
+	output?: string;
 }
 
 interface SqliteRunResult {
@@ -140,6 +153,31 @@ function numberSetting(value: number | undefined, fallback: unknown, defaultValu
 
 async function resolveOptions(flags: GcCommandFlags): Promise<ResolvedGcOptions> {
 	const agentDir = path.resolve(flags.agentDir ?? getAgentDir());
+	if (flags.repairStorage) {
+		if (flags.blobs || flags.archive || flags.wal) {
+			throw new Error("--repair-storage cannot run with --blobs, --archive, or --wal");
+		}
+		if (flags.repairStorage === "agent" && flags.historySource !== undefined) {
+			throw new Error("--history-source is only valid with --repair-storage history");
+		}
+		return {
+			apply: flags.apply === true,
+			json: flags.json === true,
+			agentDir,
+			runBlobs: false,
+			runArchive: false,
+			runWal: false,
+			coldArchiveAfterDays: 0,
+			retainNewestGlobal: 0,
+			retainNewestPerCwd: 0,
+			repairStorage: flags.repairStorage,
+			historySource: flags.historySource,
+			output: flags.output,
+		};
+	}
+	if (flags.historySource !== undefined || flags.output !== undefined) {
+		throw new Error("--history-source and --output require --repair-storage");
+	}
 	const selected = flags.blobs === true || flags.archive === true || flags.wal === true;
 	const settings =
 		flags.apply === true ? await Settings.loadIsolated({ agentDir }) : await Settings.loadReadOnly({ agentDir });
@@ -175,6 +213,10 @@ export function collectGcErrors(result: GcResult): string[] {
 	return [
 		...(result.blobs?.errors ?? []).map(error => `blobs: ${error}`),
 		...(result.archive?.errors ?? []).map(error => `archive: ${error}`),
+		...(result.repair?.status === "refused" ? [`repair: ${result.repair.refusal ?? "refused"}`] : []),
+		...(result.repair?.status === "published-with-warning"
+			? [`repair: ${result.repair.warning ?? "published with warning"}`]
+			: []),
 	];
 }
 
@@ -909,6 +951,29 @@ function formatBytes(bytes: number): string {
 
 function renderText(result: GcResult): string {
 	const lines = [`GC ${result.apply ? "applied" : "dry-run"} (${result.agentDir})`];
+	if (result.repair) {
+		const repair = result.repair;
+		lines.push(
+			`storage repair ${repair.status}: ${repair.target}${repair.historySource ? ` (${repair.historySource})` : ""}`,
+		);
+		lines.push("offline: stop every OMP process before using any repair artifact");
+		lines.push(`source: ${repair.source}`);
+		lines.push(`backup: ${repair.backup}${repair.backupCreated ? " (created)" : ""}`);
+		lines.push(`candidate: ${repair.candidate}${repair.candidatePublished ? " (published)" : ""}`);
+		lines.push(`candidate path trusted: ${repair.candidatePathTrusted}`);
+		if (repair.dataLoss) lines.push("data loss: true (fresh empty history)");
+		for (const object of repair.objects) {
+			lines.push(
+				`${object.action}: ${object.kind} ${object.name} [${object.owner}]${object.detail ? ` — ${object.detail}` : ""}`,
+			);
+		}
+		for (const checksum of repair.checksums)
+			lines.push(`sha256 ${checksum.sha256} ${checksum.size} ${checksum.path}`);
+		if (repair.refusal) lines.push(`refusal: ${repair.refusal}`);
+		if (repair.warning) lines.push(`warning: ${repair.warning}`);
+		lines.push(`manual next step: ${repair.manualNextStep}`);
+		return `${lines.join("\n")}\n`;
+	}
 	if (result.blobs) {
 		lines.push(
 			`blobs: ${result.blobs.deleted}/${result.blobs.wouldDelete} files, ${formatBytes(result.blobs.bytes)}, ${result.blobs.referenced} refs`,
@@ -934,6 +999,16 @@ export async function runGcCommand(args: GcCommandArgs): Promise<GcResult> {
 	const archiveRoot = getArchivedSessionsDir(options.agentDir);
 	const result = await withGcLock(options.agentDir, async lockPath => {
 		const next: GcResult = { agentDir: options.agentDir, apply: options.apply, lockPath };
+		if (options.repairStorage) {
+			next.repair = await runStorageRepair({
+				target: options.repairStorage,
+				historySource: options.historySource,
+				output: options.output,
+				apply: options.apply,
+				agentDir: options.agentDir,
+			});
+			return next;
+		}
 		if (options.runBlobs) next.blobs = await runBlobGc(options, archiveRoot);
 		if (options.runArchive) next.archive = await runArchiveGc(options, archiveRoot);
 		if (options.runWal) next.wal = await runWalGc(options);

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -962,14 +962,11 @@ function renderText(result: GcResult): string {
 		lines.push(`candidate: ${repair.candidate}${repair.candidatePublished ? " (published)" : ""}`);
 		lines.push(`candidate path trusted: ${repair.candidatePathTrusted}`);
 		if (repair.dataLoss) {
-			const omittedTables = repair.objects
-				.filter(object => object.action === "omitted" && object.kind === "table")
-				.map(object => object.name);
 			lines.push(
-				repair.historySource === "sessions"
-					? "data loss: true (session rebuild retains only session messages; existing history rows and stable row IDs are not preserved)"
-					: omittedTables.length > 0
-						? `data loss: true (registered rebuildable tables omitted: ${omittedTables.join(", ")})`
+				repair.target === "agent"
+					? `data loss: true (registered rebuildable tables omitted: ${repair.diagnosedOmittedTables.join(", ")})`
+					: repair.historySource === "sessions"
+						? "data loss: true (session rebuild retains only session messages; existing history rows and stable row IDs are not preserved)"
 						: "data loss: true (fresh empty history)",
 			);
 		}

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -961,7 +961,13 @@ function renderText(result: GcResult): string {
 		lines.push(`backup: ${repair.backup}${repair.backupCreated ? " (created)" : ""}`);
 		lines.push(`candidate: ${repair.candidate}${repair.candidatePublished ? " (published)" : ""}`);
 		lines.push(`candidate path trusted: ${repair.candidatePathTrusted}`);
-		if (repair.dataLoss) lines.push("data loss: true (fresh empty history)");
+		if (repair.dataLoss) {
+			lines.push(
+				repair.historySource === "sessions"
+					? "data loss: true (session rebuild retains only session messages; existing history rows and stable row IDs are not preserved)"
+					: "data loss: true (fresh empty history)",
+			);
+		}
 		for (const object of repair.objects) {
 			lines.push(
 				`${object.action}: ${object.kind} ${object.name} [${object.owner}]${object.detail ? ` — ${object.detail}` : ""}`,

--- a/packages/coding-agent/src/cli/storage-repair-agent.ts
+++ b/packages/coding-agent/src/cli/storage-repair-agent.ts
@@ -51,6 +51,11 @@ interface SchemaObjectRow {
 	sql: string | null;
 }
 
+interface SqliteSequence {
+	name: string;
+	seq: bigint;
+}
+
 export interface AgentRepairDiagnosis {
 	expectedSchema: CanonicalSchemaObject[];
 	omitTables: string[];
@@ -287,6 +292,66 @@ function schemaObjects(db: Database) {
 		.all() as SchemaObjectRow[];
 }
 
+function autoincrementTables(db: Database): Set<string> {
+	return new Set(
+		schemaObjects(db)
+			.filter(
+				object =>
+					object.type === "table" && typeof object.sql === "string" && /\bAUTOINCREMENT\b/iu.test(object.sql),
+			)
+			.map(object => object.name),
+	);
+}
+
+function sqliteSequenceRows(db: Database): SqliteSequence[] {
+	if (!db.prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = 'sqlite_sequence'").get()) return [];
+	return sqliteRows(db, "SELECT name, seq FROM sqlite_sequence ORDER BY name").map(row => {
+		assertInvariant(typeof row.name === "string" && typeof row.seq === "bigint", "Invalid sqlite_sequence row");
+		return { name: row.name, seq: row.seq };
+	});
+}
+
+function preservedAutoincrementTables(destination: Database, omitted: readonly string[]): Set<string> {
+	const result = autoincrementTables(destination);
+	for (const table of omitted) result.delete(table);
+	return result;
+}
+
+function expectedSqliteSequences(source: Database, preserved: ReadonlySet<string>): SqliteSequence[] {
+	const sourceAutoincrement = autoincrementTables(source);
+	return sqliteSequenceRows(source).filter(row => sourceAutoincrement.has(row.name) && preserved.has(row.name));
+}
+
+function copySqliteSequences(source: Database, destination: Database, omitted: readonly string[]): void {
+	const preserved = preservedAutoincrementTables(destination, omitted);
+	const expected = expectedSqliteSequences(source, preserved);
+	if (!destination.prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = 'sqlite_sequence'").get()) {
+		assertInvariant(expected.length === 0, "Candidate is missing sqlite_sequence for preserved AUTOINCREMENT tables");
+		return;
+	}
+	destination.exec("DELETE FROM sqlite_sequence");
+	const insert = destination.prepare("INSERT INTO sqlite_sequence(name, seq) VALUES (?, ?)");
+	try {
+		for (const row of expected) insert.run(row.name, row.seq);
+	} finally {
+		insert.finalize();
+	}
+}
+
+function verifySqliteSequences(source: Database, candidate: Database, omitted: readonly string[]): void {
+	const preserved = preservedAutoincrementTables(candidate, omitted);
+	const expected = expectedSqliteSequences(source, preserved);
+	const actual = sqliteSequenceRows(candidate);
+	assertInvariant(
+		actual.every(row => preserved.has(row.name)),
+		"Candidate has sqlite_sequence row for an omitted table",
+	);
+	assertInvariant(
+		stableJson(actual) === stableJson(expected),
+		"Candidate sqlite_sequence differs from preserved source high-water marks",
+	);
+}
+
 function viewOwner(object: SchemaObjectRow) {
 	if (object.type !== "view" || typeof object.sql !== "string") return null;
 	const match = SIMPLE_VIEW_RE.exec(object.sql);
@@ -449,6 +514,7 @@ export function buildAgentCandidate(
 			}
 		}
 		preserveExtensions(source, destination, diagnosis.expectedSchema, results);
+		copySqliteSequences(source, destination, diagnosis.omitTables);
 		assertInvariant(
 			destination.prepare("PRAGMA foreign_key_check").all().length === 0,
 			"Candidate foreign key check failed after assembly",
@@ -459,7 +525,7 @@ export function buildAgentCandidate(
 	}
 }
 
-export function verifyAgentCandidate(candidate: string) {
+export function verifyAgentCandidate(candidate: string, source: Database, omitted: readonly string[]) {
 	AgentStorage.validateExactPath(candidate);
 	validateMemoryStorageExactPath(candidate);
 	checkpointCandidate(candidate);
@@ -473,6 +539,7 @@ export function verifyAgentCandidate(candidate: string) {
 				`Candidate is missing ${table}`,
 			);
 		}
+		verifySqliteSequences(source, db, omitted);
 	} finally {
 		db.close();
 	}

--- a/packages/coding-agent/src/cli/storage-repair-agent.ts
+++ b/packages/coding-agent/src/cli/storage-repair-agent.ts
@@ -286,6 +286,57 @@ function copyTableRows(source: Database, destination: Database, table: string) {
 	}
 }
 
+function equalSqliteValues(source: SqliteValue, candidate: SqliteValue) {
+	if (source instanceof Uint8Array || candidate instanceof Uint8Array) {
+		if (!(source instanceof Uint8Array && candidate instanceof Uint8Array) || source.byteLength !== candidate.byteLength) {
+			return false;
+		}
+		for (let index = 0; index < source.byteLength; index += 1) {
+			if (source[index] !== candidate[index]) return false;
+		}
+		return true;
+	}
+	return source === candidate;
+}
+
+function verifyTableRows(source: Database, candidate: Database, table: string) {
+	const columns = tableColumns(source, table);
+	assertInvariant(
+		columns.every(column => column.hidden === 0n),
+		`Generated or hidden columns are not losslessly supported in ${table}`,
+	);
+	const writable = columns.map(column => column.name);
+	const rowidAlias = selectedRowidAlias(source, table, columns);
+	const sql = transferSql(table, writable, rowidAlias);
+	const sourceSelect = source.prepare(sql.select);
+	const candidateSelect = candidate.prepare(sql.select);
+	try {
+		const sourceRows = sourceSelect.iterate() as Iterator<Record<string, unknown>>;
+		const candidateRows = candidateSelect.iterate() as Iterator<Record<string, unknown>>;
+		for (;;) {
+			const sourceRow = sourceRows.next();
+			const candidateRow = candidateRows.next();
+			if (sourceRow.done || candidateRow.done) {
+				assertInvariant(sourceRow.done && candidateRow.done, `Candidate row count mismatch in ${table}`);
+				return;
+			}
+			if (rowidAlias && sql.rowidProjectionAlias) {
+				const expected = sqliteValue(sourceRow.value[sql.rowidProjectionAlias], table, rowidAlias);
+				const actual = sqliteValue(candidateRow.value[sql.rowidProjectionAlias], table, rowidAlias);
+				assertInvariant(equalSqliteValues(expected, actual), `Candidate row identity mismatch in ${table}`);
+			}
+			for (const column of writable) {
+				const expected = sqliteValue(sourceRow.value[column], table, column);
+				const actual = sqliteValue(candidateRow.value[column], table, column);
+				assertInvariant(equalSqliteValues(expected, actual), `Candidate row value mismatch in ${table}.${column}`);
+			}
+		}
+	} finally {
+		sourceSelect.finalize();
+		candidateSelect.finalize();
+	}
+}
+
 function schemaObjects(db: Database) {
 	return db
 		.prepare("SELECT type, name, tbl_name, sql FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name")
@@ -539,8 +590,18 @@ export function verifyAgentCandidate(candidate: string, source: Database, omitte
 				`Candidate is missing ${table}`,
 			);
 		}
+		for (const table of preservedTableNames(source, omitted)) verifyTableRows(source, db, table);
 		verifySqliteSequences(source, db, omitted);
 	} finally {
 		db.close();
 	}
+}
+
+function preservedTableNames(source: Database, omitted: readonly string[]) {
+	const excluded = new Set(omitted);
+	const tables = new Set(Object.keys(AGENT_TABLES).filter(table => !excluded.has(table)));
+	for (const object of schemaObjects(source)) {
+		if (object.type === "table" && !AGENT_TABLES[object.name]) tables.add(object.name);
+	}
+	return [...tables].sort((left, right) => left.localeCompare(right));
 }

--- a/packages/coding-agent/src/cli/storage-repair-agent.ts
+++ b/packages/coding-agent/src/cli/storage-repair-agent.ts
@@ -6,6 +6,7 @@ import {
 	validateMemoryStorageExactPath,
 } from "../memories/storage";
 import { AGENT_STORAGE_TABLES, AgentStorage, SCHEMA_VERSION } from "../session/agent-storage";
+import type { RawSchemaDefinition } from "./storage-repair-files";
 import {
 	assertInvariant,
 	canonicalSchema,
@@ -13,6 +14,7 @@ import {
 	errorMessage,
 	stableJson,
 	verifyCommonCandidate,
+	verifyRawSchemaDefinitions,
 } from "./storage-repair-files";
 import type { CanonicalSchemaObject, FrozenSqliteSnapshot, StorageRepairObjectResult } from "./storage-repair-types";
 
@@ -579,7 +581,12 @@ export function buildAgentCandidate(
 	}
 }
 
-export function verifyAgentCandidate(candidate: string, source: Database, omitted: readonly string[]) {
+export function verifyAgentCandidate(
+	candidate: string,
+	source: Database,
+	omitted: readonly string[],
+	expectedSchema: readonly RawSchemaDefinition[],
+) {
 	AgentStorage.validateExactPath(candidate);
 	validateMemoryStorageExactPath(candidate);
 	checkpointCandidate(candidate);
@@ -598,6 +605,14 @@ export function verifyAgentCandidate(candidate: string, source: Database, omitte
 	} finally {
 		db.close();
 	}
+	verifyRawSchemaDefinitions(candidate, expectedSchema);
+}
+
+export function verifyPublishedAgentCandidate(candidate: string, expectedSchema: readonly RawSchemaDefinition[]) {
+	AgentStorage.validateExactPath(candidate);
+	validateMemoryStorageExactPath(candidate);
+	verifyCommonCandidate(candidate);
+	verifyRawSchemaDefinitions(candidate, expectedSchema);
 }
 
 function preservedTableNames(source: Database, omitted: readonly string[]) {

--- a/packages/coding-agent/src/cli/storage-repair-agent.ts
+++ b/packages/coding-agent/src/cli/storage-repair-agent.ts
@@ -288,7 +288,10 @@ function copyTableRows(source: Database, destination: Database, table: string) {
 
 function equalSqliteValues(source: SqliteValue, candidate: SqliteValue) {
 	if (source instanceof Uint8Array || candidate instanceof Uint8Array) {
-		if (!(source instanceof Uint8Array && candidate instanceof Uint8Array) || source.byteLength !== candidate.byteLength) {
+		if (
+			!(source instanceof Uint8Array && candidate instanceof Uint8Array) ||
+			source.byteLength !== candidate.byteLength
+		) {
 			return false;
 		}
 		for (let index = 0; index < source.byteLength; index += 1) {

--- a/packages/coding-agent/src/cli/storage-repair-agent.ts
+++ b/packages/coding-agent/src/cli/storage-repair-agent.ts
@@ -1,0 +1,479 @@
+import { Database } from "bun:sqlite";
+import { AUTH_SCHEMA_VERSION, AUTH_STORAGE_TABLES } from "@oh-my-pi/pi-ai";
+import {
+	initializeMemoryStorageExactPath,
+	MEMORY_STORAGE_TABLES,
+	validateMemoryStorageExactPath,
+} from "../memories/storage";
+import { AGENT_STORAGE_TABLES, AgentStorage, SCHEMA_VERSION } from "../session/agent-storage";
+import {
+	assertInvariant,
+	canonicalSchema,
+	checkpointCandidate,
+	errorMessage,
+	stableJson,
+	verifyCommonCandidate,
+} from "./storage-repair-files";
+import type { CanonicalSchemaObject, FrozenSqliteSnapshot, StorageRepairObjectResult } from "./storage-repair-types";
+
+const ROW_BATCH_SIZE = 256;
+const IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]{0,127}$/u;
+const SIMPLE_TABLE_PREFIX_RE =
+	/^CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:"[A-Za-z_][A-Za-z0-9_]{0,127}"|[A-Za-z_][A-Za-z0-9_]{0,127})\s*\(/iu;
+const SIMPLE_VIEW_RE =
+	/^CREATE\s+VIEW\s+([A-Za-z_][A-Za-z0-9_]*)\s+AS\s+SELECT\s+([A-Za-z_][A-Za-z0-9_]*(?:\s*,\s*[A-Za-z_][A-Za-z0-9_]*)*)\s+FROM\s+([A-Za-z_][A-Za-z0-9_]*)\s*;?$/iu;
+const SIMPLE_TRIGGER_RE =
+	/^CREATE\s+TRIGGER\s+([A-Za-z_][A-Za-z0-9_]*)\s+(BEFORE|AFTER)\s+(INSERT|DELETE|UPDATE)\s+ON\s+([A-Za-z_][A-Za-z0-9_]*)\s+BEGIN\s+SELECT\s+(NEW|OLD)\.([A-Za-z_][A-Za-z0-9_]*)\s*;\s*END\s*;?$/iu;
+const SIMPLE_INDEX_PREFIX_RE =
+	/^CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:"[A-Za-z_][A-Za-z0-9_]{0,127}"|[A-Za-z_][A-Za-z0-9_]{0,127})\s+ON\s+(?:"[A-Za-z_][A-Za-z0-9_]{0,127}"|[A-Za-z_][A-Za-z0-9_]{0,127})\s*\(/iu;
+
+type TableDisposition = "authoritative" | "rebuildable";
+type SqliteValue = string | number | bigint | Uint8Array | null;
+
+interface TableOwner {
+	owner: string;
+	disposition: TableDisposition;
+}
+
+interface TableColumn {
+	name: string;
+	type: string;
+	notnull: bigint;
+	dfltValue: unknown;
+	pk: bigint;
+	hidden: bigint;
+}
+
+interface SchemaObjectRow {
+	type: string;
+	name: string;
+	tbl_name: string;
+	sql: string | null;
+}
+
+export interface AgentRepairDiagnosis {
+	expectedSchema: CanonicalSchemaObject[];
+	omitTables: string[];
+}
+
+function ownerTables(owner: string, tables: Readonly<Record<string, TableDisposition>>) {
+	const result: Record<string, TableOwner> = {};
+	for (const [name, disposition] of Object.entries(tables)) result[name] = { owner, disposition };
+	return result;
+}
+
+const AGENT_TABLES: Readonly<Record<string, TableOwner>> = {
+	...ownerTables("agent", AGENT_STORAGE_TABLES),
+	...ownerTables("auth", AUTH_STORAGE_TABLES),
+	...ownerTables("memory", MEMORY_STORAGE_TABLES),
+};
+
+function quoteIdentifier(identifier: string) {
+	assertInvariant(IDENTIFIER_RE.test(identifier), `Unsafe SQLite identifier: ${identifier}`);
+	return `"${identifier}"`;
+}
+
+function sqliteRows(db: Database, sql: string, ...bindings: SqliteValue[]) {
+	return db.prepare(sql).all(...bindings) as Array<Record<string, unknown>>;
+}
+
+function assertSupportedVersions(db: Database) {
+	const schemaRows = sqliteRows(db, "SELECT version FROM schema_version ORDER BY version");
+	assertInvariant(
+		schemaRows.length === 1 && schemaRows[0]?.version === BigInt(SCHEMA_VERSION),
+		`Unsupported agent schema version; expected ${SCHEMA_VERSION}`,
+	);
+	const authRows = sqliteRows(db, "SELECT id, version FROM auth_schema_version ORDER BY id");
+	assertInvariant(
+		authRows.length === 1 && authRows[0]?.id === 1n && authRows[0]?.version === BigInt(AUTH_SCHEMA_VERSION),
+		`Unsupported auth schema version; expected ${AUTH_SCHEMA_VERSION}`,
+	);
+}
+
+function initializeCandidate(candidate: string) {
+	AgentStorage.initializeExactPath(candidate);
+	initializeMemoryStorageExactPath(candidate);
+}
+
+function schemaKey(object: CanonicalSchemaObject) {
+	return `${object.kind}\0${object.name}`;
+}
+
+function assertBuiltInSchema(source: CanonicalSchemaObject[], expected: CanonicalSchemaObject[]) {
+	const sourceByKey = new Map(source.map(object => [schemaKey(object), object]));
+	const expectedKeys = new Set(expected.map(schemaKey));
+	for (const object of expected) {
+		const actual = sourceByKey.get(schemaKey(object));
+		assertInvariant(actual, `Missing built-in schema object: ${object.name}`);
+		assertInvariant(
+			stableJson(actual) === stableJson(object),
+			`Structural drift in built-in schema object: ${object.name}`,
+		);
+	}
+	for (const object of source) {
+		if (AGENT_TABLES[object.table] && !expectedKeys.has(schemaKey(object))) {
+			throw new Error(`Unexpected object attached to built-in table ${object.table}: ${object.name}`);
+		}
+	}
+}
+
+function isSqliteCorruption(error: unknown) {
+	if (typeof error !== "object" || error === null || !("code" in error)) return false;
+	return error.code === "SQLITE_CORRUPT" || error.code === "SQLITE_NOTADB";
+}
+
+function classifyUnreadableTables(source: Database) {
+	const unreadable: string[] = [];
+	for (const [table, inventory] of Object.entries(AGENT_TABLES)) {
+		const columns = tableColumns(source, table);
+		const writable = columns.map(column => column.name);
+		const rowidAlias = selectedRowidAlias(source, table, columns);
+		const statement = source.prepare(transferSql(table, writable, rowidAlias).select);
+		try {
+			for (const _row of statement.iterate()) {
+				// Reading every record proves whether this exact table B-tree is traversable.
+			}
+		} catch (error) {
+			if (!isSqliteCorruption(error)) throw error;
+			if (inventory.disposition === "authoritative") {
+				throw new Error(`Authoritative table ${table} is unreadable: ${errorMessage(error)}`, { cause: error });
+			}
+			unreadable.push(table);
+		} finally {
+			statement.finalize();
+		}
+	}
+	return unreadable;
+}
+
+export function diagnoseAgentSnapshot(snapshot: FrozenSqliteSnapshot, expectedPath: string): AgentRepairDiagnosis {
+	assertSupportedVersions(snapshot.db);
+	initializeCandidate(expectedPath);
+	const expectedDb = new Database(expectedPath, { readonly: true, safeIntegers: true });
+	try {
+		const expectedSchema = canonicalSchema(expectedDb);
+		assertBuiltInSchema(snapshot.schema, expectedSchema);
+		return { expectedSchema, omitTables: classifyUnreadableTables(snapshot.db) };
+	} finally {
+		expectedDb.close();
+	}
+}
+
+function sqliteValue(value: unknown, table: string, column: string): SqliteValue {
+	if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "bigint")
+		return value;
+	if (value instanceof Uint8Array) return value;
+	throw new Error(`Unsupported SQLite storage class in ${table}.${column}`);
+}
+
+function tableColumns(db: Database, table: string): TableColumn[] {
+	return sqliteRows(
+		db,
+		'SELECT name, type, "notnull", dflt_value, pk, hidden FROM pragma_table_xinfo(?) ORDER BY cid',
+		table,
+	).map(row => {
+		assertInvariant(
+			typeof row.name === "string" &&
+				typeof row.type === "string" &&
+				typeof row.notnull === "bigint" &&
+				typeof row.pk === "bigint" &&
+				typeof row.hidden === "bigint",
+			`Invalid column metadata for ${table}`,
+		);
+		return {
+			name: row.name,
+			type: row.type,
+			notnull: row.notnull,
+			dfltValue: row.dflt_value,
+			pk: row.pk,
+			hidden: row.hidden,
+		};
+	});
+}
+
+function tableHasRowid(db: Database, table: string) {
+	const row = db.prepare("SELECT wr FROM pragma_table_list(?) WHERE name = ?").get(table, table) as {
+		wr?: bigint;
+	} | null;
+	assertInvariant(row && typeof row.wr === "bigint", `Missing table metadata for ${table}`);
+	return row.wr === 0n;
+}
+
+function declaredPrimaryKeyAliasesRowid(db: Database, table: string, columns: TableColumn[]) {
+	const primaryKey = columns.filter(column => column.pk !== 0n);
+	if (primaryKey.length !== 1 || primaryKey[0]?.type.trim().toUpperCase() !== "INTEGER") return false;
+	const index = db.prepare("SELECT 1 FROM pragma_index_list(?) WHERE origin = 'pk' LIMIT 1").get(table);
+	return index === null;
+}
+
+function selectedRowidAlias(db: Database, table: string, columns: TableColumn[]) {
+	if (!tableHasRowid(db, table) || declaredPrimaryKeyAliasesRowid(db, table, columns)) return null;
+	const declared = new Set(columns.map(column => column.name.toLowerCase()));
+	const alias = ["rowid", "_rowid_", "oid"].find(candidate => !declared.has(candidate));
+	assertInvariant(alias, `Implicit rowid is shadowed by every addressable alias in ${table}`);
+	return alias;
+}
+
+function transferSql(table: string, columns: string[], rowidAlias: string | null) {
+	const names = rowidAlias ? [rowidAlias, ...columns] : columns;
+	assertInvariant(names.length > 0, `Table ${table} has no writable columns`);
+	let rowidProjectionAlias: string | null = null;
+	if (rowidAlias) {
+		const declared = new Set(columns.map(column => column.toLowerCase()));
+		for (let index = 0; index <= columns.length; index += 1) {
+			const candidate = `__omp_salvage_rowid_${index}`;
+			if (!declared.has(candidate)) {
+				rowidProjectionAlias = candidate;
+				break;
+			}
+		}
+		assertInvariant(rowidProjectionAlias, `Cannot allocate an unambiguous rowid projection for ${table}`);
+	}
+	const projection =
+		rowidAlias && rowidProjectionAlias
+			? [
+					`${quoteIdentifier(rowidAlias)} AS ${quoteIdentifier(rowidProjectionAlias)}`,
+					...columns.map(quoteIdentifier),
+				]
+			: columns.map(quoteIdentifier);
+	return {
+		select: `SELECT ${projection.join(", ")} FROM ${quoteIdentifier(table)}`,
+		insert: `INSERT INTO ${quoteIdentifier(table)} (${names.map(quoteIdentifier).join(", ")}) VALUES (${names.map(() => "?").join(", ")})`,
+		rowidProjectionAlias,
+	};
+}
+
+function clearTable(db: Database, table: string) {
+	db.exec(`DELETE FROM ${quoteIdentifier(table)}`);
+}
+
+function copyTableRows(source: Database, destination: Database, table: string) {
+	const columns = tableColumns(source, table);
+	assertInvariant(
+		columns.every(column => column.hidden === 0n),
+		`Generated or hidden columns are not losslessly supported in ${table}`,
+	);
+	const writable = columns.map(column => column.name);
+	const rowidAlias = selectedRowidAlias(source, table, columns);
+	const sql = transferSql(table, writable, rowidAlias);
+	const select = source.prepare(sql.select);
+	const insert = destination.prepare(sql.insert);
+	let batch: SqliteValue[][] = [];
+	const flush = destination.transaction((rows: SqliteValue[][]) => {
+		for (const values of rows) insert.run(...values);
+	});
+	try {
+		for (const raw of select.iterate() as Iterable<Record<string, unknown>>) {
+			const values: SqliteValue[] = [];
+			if (rowidAlias && sql.rowidProjectionAlias) {
+				values.push(sqliteValue(raw[sql.rowidProjectionAlias], table, rowidAlias));
+			}
+			for (const column of writable) values.push(sqliteValue(raw[column], table, column));
+			batch.push(values);
+			if (batch.length < ROW_BATCH_SIZE) continue;
+			flush(batch);
+			batch = [];
+		}
+		if (batch.length > 0) flush(batch);
+	} finally {
+		select.finalize();
+		insert.finalize();
+	}
+}
+
+function schemaObjects(db: Database) {
+	return db
+		.prepare("SELECT type, name, tbl_name, sql FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name")
+		.all() as SchemaObjectRow[];
+}
+
+function viewOwner(object: SchemaObjectRow) {
+	if (object.type !== "view" || typeof object.sql !== "string") return null;
+	const match = SIMPLE_VIEW_RE.exec(object.sql);
+	return match?.[3] ?? null;
+}
+
+function extensionClosures(source: Database, expected: CanonicalSchemaObject[]) {
+	const expectedKeys = new Set(expected.map(schemaKey));
+	const closures = new Map<string, SchemaObjectRow[]>();
+	for (const object of schemaObjects(source)) {
+		if (expectedKeys.has(`${object.type}\0${object.name}`)) continue;
+		const owner =
+			object.type === "table" ? object.name : object.type === "view" ? viewOwner(object) : object.tbl_name;
+		assertInvariant(owner && IDENTIFIER_RE.test(owner), `Unsafe or ambiguous extension owner: ${object.name}`);
+		const objects = closures.get(owner) ?? [];
+		objects.push(object);
+		closures.set(owner, objects);
+	}
+	for (const owner of closures.keys()) {
+		assertInvariant(
+			closures.get(owner)?.some(object => object.type === "table" && object.name === owner),
+			`Extension closure has no owning table: ${owner}`,
+		);
+	}
+	return closures;
+}
+
+function validateExtensionIndex(source: Database, object: SchemaObjectRow) {
+	assertInvariant(
+		object.sql && SIMPLE_INDEX_PREFIX_RE.test(object.sql) && !/\bwhere\b/iu.test(object.sql),
+		`Unsafe extension index: ${object.name}`,
+	);
+	for (const column of sqliteRows(source, "SELECT * FROM pragma_index_xinfo(?) ORDER BY seqno", object.name)) {
+		if (column.key === 0n) continue;
+		assertInvariant(
+			typeof column.cid === "bigint" && column.cid >= 0n && column.coll === "BINARY",
+			`Unsafe extension index shape: ${object.name}`,
+		);
+	}
+}
+
+function validateExtensionView(owner: string, object: SchemaObjectRow, columns: ReadonlySet<string>) {
+	assertInvariant(typeof object.sql === "string", `Missing extension view SQL: ${object.name}`);
+	const match = SIMPLE_VIEW_RE.exec(object.sql);
+	assertInvariant(match && match[1] === object.name && match[3] === owner, `Unsafe extension view: ${object.name}`);
+	for (const column of match[2]?.split(",").map(value => value.trim()) ?? []) {
+		assertInvariant(columns.has(column), `Extension view ${object.name} references unknown column ${column}`);
+	}
+}
+
+function validateExtensionTrigger(owner: string, object: SchemaObjectRow, columns: ReadonlySet<string>) {
+	assertInvariant(typeof object.sql === "string", `Missing extension trigger SQL: ${object.name}`);
+	const match = SIMPLE_TRIGGER_RE.exec(object.sql);
+	assertInvariant(match && match[1] === object.name && match[4] === owner, `Unsafe extension trigger: ${object.name}`);
+	const event = match[3]?.toUpperCase();
+	const row = match[5]?.toUpperCase();
+	assertInvariant(event !== "INSERT" || row === "NEW", `INSERT trigger ${object.name} may only read NEW`);
+	assertInvariant(event !== "DELETE" || row === "OLD", `DELETE trigger ${object.name} may only read OLD`);
+	assertInvariant(
+		typeof match[6] === "string" && columns.has(match[6]),
+		`Extension trigger ${object.name} references an unknown column`,
+	);
+}
+
+function validateExtension(source: Database, owner: string, objects: SchemaObjectRow[]) {
+	assertInvariant(!AGENT_TABLES[owner], `Extension owner collides with built-in table: ${owner}`);
+	const tables = objects.filter(object => object.type === "table");
+	const table = tables[0];
+	assertInvariant(
+		tables.length === 1 && table?.name === owner && typeof table.sql === "string",
+		`Ambiguous extension ownership for ${owner}`,
+	);
+	assertInvariant(SIMPLE_TABLE_PREFIX_RE.test(table.sql), `Unparsable extension table ${owner}`);
+	assertInvariant(
+		!/\b(?:virtual|using|generated|collate|check|references|constraint|without\s+rowid|strict)\b/iu.test(table.sql),
+		`Unsafe extension table shape: ${owner}`,
+	);
+	const tableColumnList = tableColumns(source, owner);
+	assertInvariant(
+		tableColumnList.every(column => column.hidden === 0n),
+		`Unsafe extension columns: ${owner}`,
+	);
+	assertInvariant(tableHasRowid(source, owner), `Extension WITHOUT ROWID tables are unsupported: ${owner}`);
+	assertInvariant(
+		sqliteRows(source, "SELECT * FROM pragma_foreign_key_list(?)", owner).length === 0,
+		`Extension foreign keys are unsupported: ${owner}`,
+	);
+	const columns = new Set(tableColumnList.map(column => column.name));
+	for (const object of objects) {
+		if (object.type === "table") continue;
+		if (object.type === "index") validateExtensionIndex(source, object);
+		else if (object.type === "view") validateExtensionView(owner, object, columns);
+		else if (object.type === "trigger") validateExtensionTrigger(owner, object, columns);
+		else throw new Error(`Unsupported extension object kind: ${object.type} ${object.name}`);
+	}
+}
+
+function preserveExtensions(
+	source: Database,
+	destination: Database,
+	expected: CanonicalSchemaObject[],
+	results: StorageRepairObjectResult[],
+) {
+	const closures = [...extensionClosures(source, expected)].sort(([left], [right]) => left.localeCompare(right));
+	for (const [owner, objects] of closures) {
+		validateExtension(source, owner, objects);
+		const table = objects.find(object => object.type === "table");
+		assertInvariant(table && typeof table.sql === "string", `Missing extension table SQL: ${owner}`);
+		destination.exec(table.sql);
+		copyTableRows(source, destination, owner);
+		results.push({ name: owner, kind: "table", owner: `extension:${owner}`, action: "preserved" });
+		for (const kind of ["index", "view", "trigger"] as const) {
+			for (const object of objects
+				.filter(entry => entry.type === kind)
+				.sort((left, right) => left.name.localeCompare(right.name))) {
+				assertInvariant(object.sql, `Missing extension ${kind} SQL: ${object.name}`);
+				destination.exec(object.sql);
+				results.push({ name: object.name, kind, owner: `extension:${owner}`, action: "preserved" });
+			}
+		}
+	}
+}
+
+function objectResults(expected: CanonicalSchemaObject[]) {
+	return expected.map(object => {
+		const owner = AGENT_TABLES[object.table];
+		assertInvariant(owner, `Current agent schema object has no authoritative owner: ${object.name}`);
+		return { name: object.name, kind: object.kind, owner: owner.owner, action: "preserved" as const };
+	});
+}
+
+function markOmitted(results: StorageRepairObjectResult[], table: string) {
+	for (const object of results) {
+		if (object.name !== table && !object.name.startsWith(`idx_${table}_`)) continue;
+		object.action = "omitted";
+		object.detail = "registered rebuildable table B-tree is unreadable";
+	}
+}
+
+export function buildAgentCandidate(
+	source: Database,
+	candidate: string,
+	diagnosis: AgentRepairDiagnosis,
+): StorageRepairObjectResult[] {
+	initializeCandidate(candidate);
+	const results: StorageRepairObjectResult[] = objectResults(diagnosis.expectedSchema);
+	const destination = new Database(candidate, { safeIntegers: true });
+	try {
+		destination.exec("PRAGMA foreign_keys = OFF");
+		for (const table of Object.keys(AGENT_TABLES)) clearTable(destination, table);
+		for (const table of Object.keys(AGENT_TABLES)) {
+			if (diagnosis.omitTables.includes(table)) {
+				markOmitted(results, table);
+				continue;
+			}
+			try {
+				copyTableRows(source, destination, table);
+			} catch (error) {
+				throw new Error(`Lossless row transfer failed for ${table}: ${errorMessage(error)}`, { cause: error });
+			}
+		}
+		preserveExtensions(source, destination, diagnosis.expectedSchema, results);
+		assertInvariant(
+			destination.prepare("PRAGMA foreign_key_check").all().length === 0,
+			"Candidate foreign key check failed after assembly",
+		);
+		return results;
+	} finally {
+		destination.close();
+	}
+}
+
+export function verifyAgentCandidate(candidate: string) {
+	AgentStorage.validateExactPath(candidate);
+	validateMemoryStorageExactPath(candidate);
+	checkpointCandidate(candidate);
+	verifyCommonCandidate(candidate);
+	const db = new Database(candidate, { readonly: true, safeIntegers: true });
+	try {
+		assertSupportedVersions(db);
+		for (const table of Object.keys(AGENT_TABLES)) {
+			assertInvariant(
+				db.prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?").get(table),
+				`Candidate is missing ${table}`,
+			);
+		}
+	} finally {
+		db.close();
+	}
+}

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -186,8 +186,6 @@ export async function runStorageRepair(
 				seal,
 				() => {
 					result.candidatePublished = true;
-					candidateChecksum.path = artifacts.candidate;
-					candidateChecksum.ephemeral = false;
 				},
 				{
 					afterLink: hooks.afterCandidatePublication,
@@ -197,6 +195,8 @@ export async function runStorageRepair(
 					onDirectorySync: hooks.onDirectorySync,
 				},
 			);
+			candidateChecksum.path = artifacts.candidate;
+			candidateChecksum.ephemeral = false;
 			candidateStage = null;
 			await sourceStillMatches(snapshot.manifest);
 			result.candidatePathTrusted = true;
@@ -228,7 +228,7 @@ export async function runStorageRepair(
 			cleanupErrors.push(error);
 		}
 		try {
-			if (prompts) await promptManifestStillMatches(prompts);
+			if (historySource === "sessions") await promptManifestStillMatches(prompts);
 		} catch (error) {
 			cleanupErrors.push(error);
 		}

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -171,8 +171,8 @@ export async function runStorageRepair(
 			verifyHistoryCandidate(candidateStage, historySource, prompts);
 		}
 
-		const seal = await sealCandidate(candidateStage);
-		const candidateChecksum = { path: candidateStage, sha256: seal.sha256, size: Number(seal.size), ephemeral: true };
+		const digest = await sealCandidate(candidateStage);
+		const candidateChecksum = { path: candidateStage, ...digest, ephemeral: true };
 		result.checksums.push(candidateChecksum);
 		await sourceStillMatches(snapshot.manifest);
 		if (historySource === "sessions") await promptManifestStillMatches(prompts);
@@ -183,7 +183,6 @@ export async function runStorageRepair(
 			await publishCandidate(
 				candidateStage,
 				artifacts.candidate,
-				seal,
 				() => {
 					result.candidatePublished = true;
 				},

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -129,6 +129,7 @@ export async function runStorageRepair(
 			const expected = await fs.promises.open(expectedPath, "wx", 0o600);
 			await expected.close();
 			diagnosis = diagnoseAgentSnapshot(snapshot.immutable, expectedPath);
+			result.dataLoss = diagnosis.omitTables.length > 0;
 		} else if (historySource === "sessions") {
 			prompts = await freezePromptManifest(snapshot.tempDir, flags.agentDir, hooks.afterSessionManifestParse);
 		}

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -6,7 +6,9 @@ import {
 	buildAgentCandidate,
 	diagnoseAgentSnapshot,
 	verifyAgentCandidate,
+	verifyPublishedAgentCandidate,
 } from "./storage-repair-agent";
+import type { PublishedFile, RawSchemaDefinition } from "./storage-repair-files";
 import {
 	cleanupSnapshot,
 	errorMessage,
@@ -15,11 +17,13 @@ import {
 	preparePristineSnapshot,
 	publishBackup,
 	publishCandidate,
+	rawSchemaDefinitions,
 	removeCandidateSidecars,
 	removeOwnedFile,
 	resolveArtifactPaths,
 	sealCandidate,
 	sourceStillMatches,
+	verifyCandidateSeal,
 } from "./storage-repair-files";
 import {
 	buildHistoryCandidate,
@@ -28,6 +32,7 @@ import {
 	type PromptManifest,
 	promptManifestStillMatches,
 	verifyHistoryCandidate,
+	verifyPublishedHistoryCandidate,
 } from "./storage-repair-history";
 import type {
 	HistoryRepairSource,
@@ -107,12 +112,14 @@ export async function runStorageRepair(
 		candidatePathTrusted: false,
 		checksums: [],
 		objects: [],
-		manualNextStep: manualNextStep(source, planned.candidate, planned.backup),
+		manualNextStep: "",
 	};
 	let snapshot: PristineSnapshot | null = null;
 	let prompts: PromptManifest | null = null;
 	let backupStage: string | null = null;
 	let candidateStage: string | null = null;
+	let expectedSchema: RawSchemaDefinition[] | null = null;
+	let candidateSeal: PublishedFile | null = null;
 	try {
 		if (flags.target === "agent" && flags.historySource !== undefined) {
 			throw new Error("--history-source is only valid with --repair-storage history");
@@ -120,7 +127,6 @@ export async function runStorageRepair(
 		const artifacts = await resolveArtifactPaths(source, flags.output);
 		result.backup = artifacts.backup;
 		result.candidate = artifacts.candidate;
-		result.manualNextStep = manualNextStep(source, artifacts.candidate, artifacts.backup);
 		snapshot = await preparePristineSnapshot(source, flags.target === "agent", hooks.afterPristineCopy);
 
 		let diagnosis: AgentRepairDiagnosis | null = null;
@@ -164,22 +170,41 @@ export async function runStorageRepair(
 		if (flags.target === "agent") {
 			if (!diagnosis || !snapshot.immutable) throw new Error("Agent schema diagnosis is missing");
 			result.objects = buildAgentCandidate(snapshot.immutable.db, candidateStage, diagnosis);
+			expectedSchema = rawSchemaDefinitions(candidateStage);
 			await hooks.beforeCandidateVerification?.();
-			verifyAgentCandidate(candidateStage, snapshot.immutable.db, diagnosis.omitTables);
+			verifyAgentCandidate(candidateStage, snapshot.immutable.db, diagnosis.omitTables, expectedSchema);
 		} else {
 			if (!historySource) throw new Error("History source is missing");
 			result.objects = buildHistoryCandidate(candidateStage, historySource, prompts);
+			expectedSchema = rawSchemaDefinitions(candidateStage);
 			await hooks.beforeCandidateVerification?.();
-			verifyHistoryCandidate(candidateStage, historySource, prompts);
+			verifyHistoryCandidate(candidateStage, historySource, prompts, expectedSchema);
 		}
 
 		const seal = await sealCandidate(candidateStage);
-		const candidateChecksum = { path: candidateStage, sha256: seal.sha256, size: Number(seal.size), ephemeral: true };
+		candidateSeal = seal;
+		if (!expectedSchema) throw new Error("Candidate schema seal is missing");
+		if (flags.target === "agent") {
+			if (!diagnosis || !snapshot.immutable) throw new Error("Agent schema diagnosis is missing");
+			verifyAgentCandidate(candidateStage, snapshot.immutable.db, diagnosis.omitTables, expectedSchema);
+		} else {
+			if (!historySource) throw new Error("History source is missing");
+			verifyHistoryCandidate(candidateStage, historySource, prompts, expectedSchema);
+		}
+		await verifyCandidateSeal(candidateStage, seal);
+		const candidateChecksum = {
+			path: candidateStage,
+			sha256: seal.sha256,
+			size: Number(seal.size),
+			ephemeral: true,
+		};
 		result.checksums.push(candidateChecksum);
 		await sourceStillMatches(snapshot.manifest);
 		if (historySource === "sessions") await promptManifestStillMatches(prompts);
 		if (flags.apply) {
 			await hooks.beforeCandidatePublication?.();
+			if (!candidateStage) throw new Error("Candidate publication stage is missing");
+			await verifyCandidateSeal(candidateStage, seal);
 			await sourceStillMatches(snapshot.manifest);
 			if (historySource === "sessions") await promptManifestStillMatches(prompts);
 			await publishCandidate(
@@ -201,7 +226,6 @@ export async function runStorageRepair(
 			);
 			candidateStage = null;
 			await sourceStillMatches(snapshot.manifest);
-			result.candidatePathTrusted = true;
 		}
 	} catch (error) {
 		if (result.candidatePublished) {
@@ -239,6 +263,20 @@ export async function runStorageRepair(
 		} catch (error) {
 			cleanupErrors.push(error);
 		}
+		if (result.candidatePublished && result.status === "ready" && cleanupErrors.length === 0) {
+			if (!candidateSeal || !expectedSchema) {
+				cleanupErrors.push(new Error("Published candidate verification data is missing"));
+			} else {
+				try {
+					if (flags.target === "agent") verifyPublishedAgentCandidate(result.candidate, expectedSchema);
+					else verifyPublishedHistoryCandidate(result.candidate, expectedSchema);
+					await hooks.beforeFinalCandidateSeal?.();
+					await verifyCandidateSeal(result.candidate, candidateSeal);
+				} catch (error) {
+					cleanupErrors.push(error);
+				}
+			}
+		}
 		if (cleanupErrors.length > 0) {
 			if (result.candidatePublished) {
 				result.status = "published-with-warning";
@@ -251,8 +289,11 @@ export async function runStorageRepair(
 					cleanupInvariant: cleanupErrors.map(errorMessage),
 				})}`;
 			}
+		} else if (result.candidatePublished && result.status === "ready") {
+			result.candidatePathTrusted = true;
 		}
 	}
 	if (result.status === "refused") result.objects.push(refusedObject(result));
+	result.manualNextStep = manualNextStep(result.source, result.candidate, result.backup, result);
 	return result;
 }

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -97,6 +97,7 @@ export async function runStorageRepair(
 		...(historySource ? { historySource } : {}),
 		apply: flags.apply,
 		dataLoss: historySource !== undefined,
+		diagnosedOmittedTables: [],
 		status: "ready",
 		source,
 		backup: planned.backup,
@@ -129,6 +130,7 @@ export async function runStorageRepair(
 			const expected = await fs.promises.open(expectedPath, "wx", 0o600);
 			await expected.close();
 			diagnosis = diagnoseAgentSnapshot(snapshot.immutable, expectedPath);
+			result.diagnosedOmittedTables = diagnosis.omitTables;
 			result.dataLoss = diagnosis.omitTables.length > 0;
 		} else if (historySource === "sessions") {
 			prompts = await freezePromptManifest(snapshot.tempDir, flags.agentDir, hooks.afterSessionManifestParse);

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -273,6 +273,7 @@ export async function runStorageRepair(
 			}
 		} catch (error) {
 			result.backupVerified = false;
+			result.checksums = result.checksums.filter(checksum => checksum.path !== result.backup);
 			cleanupErrors.push(error);
 		}
 		if (result.candidatePublished && result.status === "ready" && cleanupErrors.length === 0) {

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -1,0 +1,237 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getAgentDbPath, getHistoryDbPath } from "@oh-my-pi/pi-utils";
+import {
+	type AgentRepairDiagnosis,
+	buildAgentCandidate,
+	diagnoseAgentSnapshot,
+	verifyAgentCandidate,
+} from "./storage-repair-agent";
+import {
+	cleanupSnapshot,
+	errorMessage,
+	exclusiveStage,
+	manualNextStep,
+	preparePristineSnapshot,
+	publishBackup,
+	publishCandidate,
+	removeCandidateSidecars,
+	removeOwnedFile,
+	resolveArtifactPaths,
+	sealCandidate,
+	sourceStillMatches,
+} from "./storage-repair-files";
+import {
+	buildHistoryCandidate,
+	closePromptManifest,
+	freezePromptManifest,
+	type PromptManifest,
+	verifyHistoryCandidate,
+} from "./storage-repair-history";
+import type {
+	HistoryRepairSource,
+	PristineSnapshot,
+	StorageRepairFlags,
+	StorageRepairResult,
+	StorageRepairTestHooks,
+} from "./storage-repair-types";
+
+export type {
+	HistoryRepairSource,
+	StorageRepairAction,
+	StorageRepairChecksum,
+	StorageRepairFlags,
+	StorageRepairObjectResult,
+	StorageRepairResult,
+	StorageRepairTarget,
+	StorageRepairTestHooks,
+} from "./storage-repair-types";
+
+function initialArtifacts(source: string, output?: string) {
+	const slug = `${new Date().toISOString().replace(/[-:.TZ]/gu, "")}-${crypto.randomUUID().slice(0, 8)}`;
+	return {
+		backup: path.resolve(`${source}.salvage-${slug}.tar`),
+		candidate: path.resolve(output ?? `${source}.salvage-${slug}.db`),
+	};
+}
+
+function refusedObject(result: StorageRepairResult) {
+	return {
+		name: result.target,
+		kind: "repair",
+		owner: result.target,
+		action: "refused" as const,
+		detail: result.refusal,
+	};
+}
+
+async function cleanupOwnedStages(candidateStage: string | null, backupStage: string | null) {
+	await removeOwnedFile(candidateStage);
+	if (candidateStage) await removeCandidateSidecars(candidateStage);
+	await removeOwnedFile(backupStage);
+}
+
+function historySourceFor(flags: StorageRepairFlags): HistoryRepairSource | undefined {
+	return flags.target === "history" ? (flags.historySource ?? "sessions") : undefined;
+}
+
+function publishedWarning(primary: string | undefined, cleanupErrors: unknown[]): string {
+	return `Storage repair published with warning: ${JSON.stringify({
+		primary: primary ?? null,
+		cleanupInvariant: cleanupErrors.map(errorMessage),
+	})}`;
+}
+
+export async function runStorageRepair(
+	flags: StorageRepairFlags,
+	hooks: StorageRepairTestHooks = {},
+): Promise<StorageRepairResult> {
+	const source = path.resolve(
+		flags.target === "agent" ? getAgentDbPath(flags.agentDir) : getHistoryDbPath(flags.agentDir),
+	);
+	const historySource = historySourceFor(flags);
+	const planned = initialArtifacts(source, flags.output);
+	const result: StorageRepairResult = {
+		target: flags.target,
+		...(historySource ? { historySource } : {}),
+		apply: flags.apply,
+		dataLoss: historySource === "fresh",
+		status: "ready",
+		source,
+		backup: planned.backup,
+		candidate: planned.candidate,
+		backupCreated: false,
+		candidatePublished: false,
+		candidatePathTrusted: false,
+		checksums: [],
+		objects: [],
+		manualNextStep: manualNextStep(source, planned.candidate, planned.backup),
+	};
+	let snapshot: PristineSnapshot | null = null;
+	let prompts: PromptManifest | null = null;
+	let backupStage: string | null = null;
+	let candidateStage: string | null = null;
+	try {
+		if (flags.target === "agent" && flags.historySource !== undefined) {
+			throw new Error("--history-source is only valid with --repair-storage history");
+		}
+		const artifacts = await resolveArtifactPaths(source, flags.output);
+		result.backup = artifacts.backup;
+		result.candidate = artifacts.candidate;
+		result.manualNextStep = manualNextStep(source, artifacts.candidate, artifacts.backup);
+		snapshot = await preparePristineSnapshot(source, flags.target === "agent", hooks.afterPristineCopy);
+
+		let diagnosis: AgentRepairDiagnosis | null = null;
+		if (flags.target === "agent") {
+			if (!snapshot.immutable) throw new Error("Agent immutable SQLite snapshot is missing");
+			const expectedPath = path.join(snapshot.tempDir, "expected-agent.db");
+			const expected = await fs.open(expectedPath, "wx", 0o600);
+			await expected.close();
+			diagnosis = diagnoseAgentSnapshot(snapshot.immutable, expectedPath);
+		} else if (historySource === "sessions") {
+			prompts = await freezePromptManifest(snapshot.tempDir, flags.agentDir, hooks.afterSessionManifestParse);
+		}
+
+		if (flags.apply) {
+			backupStage = await exclusiveStage(artifacts.backup, "backup");
+			await hooks.beforeBackupWrite?.();
+			await publishBackup(
+				backupStage,
+				artifacts.backup,
+				snapshot,
+				checksum => {
+					result.checksums.push(checksum);
+					result.backupCreated = true;
+				},
+				hooks.afterBackupLink,
+			);
+			backupStage = null;
+			candidateStage = await exclusiveStage(artifacts.candidate, "candidate");
+		} else {
+			candidateStage = path.join(snapshot.tempDir, "candidate.db");
+			const candidate = await fs.open(candidateStage, "wx", 0o600);
+			await candidate.close();
+		}
+
+		if (flags.target === "agent") {
+			if (!diagnosis || !snapshot.immutable) throw new Error("Agent schema diagnosis is missing");
+			result.objects = buildAgentCandidate(snapshot.immutable.db, candidateStage, diagnosis);
+			await hooks.beforeCandidateVerification?.();
+			verifyAgentCandidate(candidateStage);
+		} else {
+			if (!historySource) throw new Error("History source is missing");
+			result.objects = buildHistoryCandidate(candidateStage, historySource, prompts);
+			await hooks.beforeCandidateVerification?.();
+			verifyHistoryCandidate(candidateStage, historySource, prompts);
+		}
+
+		const digest = await sealCandidate(candidateStage);
+		result.checksums.push({ path: artifacts.candidate, ...digest });
+		await sourceStillMatches(snapshot.manifest);
+		if (flags.apply) {
+			await hooks.beforeCandidatePublication?.();
+			await sourceStillMatches(snapshot.manifest);
+			await publishCandidate(
+				candidateStage,
+				artifacts.candidate,
+				() => {
+					result.candidatePublished = true;
+				},
+				{
+					afterLink: hooks.afterCandidatePublication,
+					beforeStageUnlink: hooks.beforeCandidateStageUnlink,
+					beforeDirectorySync: hooks.beforeCandidateDirectorySync,
+				},
+			);
+			candidateStage = null;
+			await sourceStillMatches(snapshot.manifest);
+			result.candidatePathTrusted = true;
+		}
+	} catch (error) {
+		if (result.candidatePublished) {
+			result.status = "published-with-warning";
+			result.candidatePathTrusted = false;
+			result.warning = errorMessage(error);
+		} else {
+			result.status = "refused";
+			result.refusal = errorMessage(error);
+		}
+	} finally {
+		const cleanupErrors: unknown[] = [];
+		try {
+			await cleanupOwnedStages(candidateStage, backupStage);
+		} catch (error) {
+			cleanupErrors.push(error);
+		}
+		try {
+			closePromptManifest(prompts);
+		} catch (error) {
+			cleanupErrors.push(error);
+		}
+		try {
+			if (snapshot) await sourceStillMatches(snapshot.manifest);
+		} catch (error) {
+			cleanupErrors.push(error);
+		}
+		try {
+			await cleanupSnapshot(snapshot);
+		} catch (error) {
+			cleanupErrors.push(error);
+		}
+		if (cleanupErrors.length > 0) {
+			if (result.candidatePublished) {
+				result.status = "published-with-warning";
+				result.candidatePathTrusted = false;
+				result.warning = publishedWarning(result.warning, cleanupErrors);
+			} else {
+				result.status = "refused";
+				result.refusal = `Storage repair refusal: ${JSON.stringify({
+					primary: result.refusal ?? null,
+					cleanupInvariant: cleanupErrors.map(errorMessage),
+				})}`;
+			}
+		}
+	}
+	if (result.status === "refused") result.objects.push(refusedObject(result));
+	return result;
+}

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -108,6 +108,7 @@ export async function runStorageRepair(
 		backup: planned.backup,
 		candidate: planned.candidate,
 		backupCreated: false,
+		backupVerified: false,
 		candidatePublished: false,
 		candidatePathTrusted: false,
 		checksums: [],
@@ -153,6 +154,7 @@ export async function runStorageRepair(
 					result.backupCreated = true;
 				},
 				checksum => {
+					result.backupVerified = true;
 					result.checksums.push(checksum);
 				},
 				hooks.afterBackupLink,

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -228,7 +228,7 @@ export async function runStorageRepair(
 			cleanupErrors.push(error);
 		}
 		try {
-			if (historySource === "sessions") await promptManifestStillMatches(prompts);
+			if (prompts) await promptManifestStillMatches(prompts);
 		} catch (error) {
 			cleanupErrors.push(error);
 		}

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -23,7 +23,7 @@ import {
 	resolveArtifactPaths,
 	sealCandidate,
 	sourceStillMatches,
-	verifyCandidateSeal,
+	verifyPublishedSeal,
 } from "./storage-repair-files";
 import {
 	buildHistoryCandidate,
@@ -121,6 +121,7 @@ export async function runStorageRepair(
 	let candidateStage: string | null = null;
 	let expectedSchema: RawSchemaDefinition[] | null = null;
 	let candidateSeal: PublishedFile | null = null;
+	let backupSeal: PublishedFile | null = null;
 	try {
 		if (flags.target === "agent" && flags.historySource !== undefined) {
 			throw new Error("--history-source is only valid with --repair-storage history");
@@ -153,9 +154,10 @@ export async function runStorageRepair(
 				() => {
 					result.backupCreated = true;
 				},
-				checksum => {
+				(checksum, seal) => {
 					result.backupVerified = true;
 					result.checksums.push(checksum);
+					backupSeal = seal;
 				},
 				hooks.afterBackupLink,
 				hooks.isWindows,
@@ -193,7 +195,7 @@ export async function runStorageRepair(
 			if (!historySource) throw new Error("History source is missing");
 			verifyHistoryCandidate(candidateStage, historySource, prompts, expectedSchema);
 		}
-		await verifyCandidateSeal(candidateStage, seal);
+		await verifyPublishedSeal(candidateStage, seal);
 		const candidateChecksum = {
 			path: candidateStage,
 			sha256: seal.sha256,
@@ -206,7 +208,7 @@ export async function runStorageRepair(
 		if (flags.apply) {
 			await hooks.beforeCandidatePublication?.();
 			if (!candidateStage) throw new Error("Candidate publication stage is missing");
-			await verifyCandidateSeal(candidateStage, seal);
+			await verifyPublishedSeal(candidateStage, seal);
 			await sourceStillMatches(snapshot.manifest);
 			if (historySource === "sessions") await promptManifestStillMatches(prompts);
 			await publishCandidate(
@@ -265,6 +267,14 @@ export async function runStorageRepair(
 		} catch (error) {
 			cleanupErrors.push(error);
 		}
+		try {
+			if (result.backupCreated && backupSeal) {
+				await verifyPublishedSeal(result.backup, backupSeal);
+			}
+		} catch (error) {
+			result.backupVerified = false;
+			cleanupErrors.push(error);
+		}
 		if (result.candidatePublished && result.status === "ready" && cleanupErrors.length === 0) {
 			if (!candidateSeal || !expectedSchema) {
 				cleanupErrors.push(new Error("Published candidate verification data is missing"));
@@ -273,7 +283,7 @@ export async function runStorageRepair(
 					if (flags.target === "agent") verifyPublishedAgentCandidate(result.candidate, expectedSchema);
 					else verifyPublishedHistoryCandidate(result.candidate, expectedSchema);
 					await hooks.beforeFinalCandidateSeal?.();
-					await verifyCandidateSeal(result.candidate, candidateSeal);
+					await verifyPublishedSeal(result.candidate, candidateSeal);
 				} catch (error) {
 					cleanupErrors.push(error);
 				}

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -186,6 +186,8 @@ export async function runStorageRepair(
 				seal,
 				() => {
 					result.candidatePublished = true;
+					candidateChecksum.path = artifacts.candidate;
+					candidateChecksum.ephemeral = false;
 				},
 				{
 					afterLink: hooks.afterCandidatePublication,
@@ -195,8 +197,6 @@ export async function runStorageRepair(
 					onDirectorySync: hooks.onDirectorySync,
 				},
 			);
-			candidateChecksum.path = artifacts.candidate;
-			candidateChecksum.ephemeral = false;
 			candidateStage = null;
 			await sourceStillMatches(snapshot.manifest);
 			result.candidatePathTrusted = true;

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -186,8 +186,6 @@ export async function runStorageRepair(
 				seal,
 				() => {
 					result.candidatePublished = true;
-					candidateChecksum.path = artifacts.candidate;
-					candidateChecksum.ephemeral = false;
 				},
 				{
 					afterLink: hooks.afterCandidatePublication,
@@ -197,6 +195,8 @@ export async function runStorageRepair(
 					onDirectorySync: hooks.onDirectorySync,
 				},
 			);
+			candidateChecksum.path = artifacts.candidate;
+			candidateChecksum.ephemeral = false;
 			candidateStage = null;
 			await sourceStillMatches(snapshot.manifest);
 			result.candidatePathTrusted = true;

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -143,9 +143,11 @@ export async function runStorageRepair(
 				backupStage,
 				artifacts.backup,
 				snapshot,
+				() => {
+					result.backupCreated = true;
+				},
 				checksum => {
 					result.checksums.push(checksum);
-					result.backupCreated = true;
 				},
 				hooks.afterBackupLink,
 				hooks.isWindows,

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -145,6 +145,8 @@ export async function runStorageRepair(
 					result.backupCreated = true;
 				},
 				hooks.afterBackupLink,
+				hooks.isWindows,
+				hooks.onDirectorySync,
 			);
 			backupStage = null;
 			candidateStage = await exclusiveStage(artifacts.candidate, "candidate");
@@ -158,7 +160,7 @@ export async function runStorageRepair(
 			if (!diagnosis || !snapshot.immutable) throw new Error("Agent schema diagnosis is missing");
 			result.objects = buildAgentCandidate(snapshot.immutable.db, candidateStage, diagnosis);
 			await hooks.beforeCandidateVerification?.();
-			verifyAgentCandidate(candidateStage);
+			verifyAgentCandidate(candidateStage, snapshot.immutable.db, diagnosis.omitTables);
 		} else {
 			if (!historySource) throw new Error("History source is missing");
 			result.objects = buildHistoryCandidate(candidateStage, historySource, prompts);
@@ -167,7 +169,8 @@ export async function runStorageRepair(
 		}
 
 		const digest = await sealCandidate(candidateStage);
-		result.checksums.push({ path: artifacts.candidate, ...digest });
+		const candidateChecksum = { path: candidateStage, ...digest, ephemeral: true };
+		result.checksums.push(candidateChecksum);
 		await sourceStillMatches(snapshot.manifest);
 		if (historySource === "sessions") await promptManifestStillMatches(prompts);
 		if (flags.apply) {
@@ -184,8 +187,12 @@ export async function runStorageRepair(
 					afterLink: hooks.afterCandidatePublication,
 					beforeStageUnlink: hooks.beforeCandidateStageUnlink,
 					beforeDirectorySync: hooks.beforeCandidateDirectorySync,
+					isWindows: hooks.isWindows,
+					onDirectorySync: hooks.onDirectorySync,
 				},
 			);
+			candidateChecksum.path = artifacts.candidate;
+			candidateChecksum.ephemeral = false;
 			candidateStage = null;
 			await sourceStillMatches(snapshot.manifest);
 			result.candidatePathTrusted = true;

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -1,4 +1,4 @@
-import * as fs from "node:fs/promises";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { getAgentDbPath, getHistoryDbPath } from "@oh-my-pi/pi-utils";
 import {
@@ -26,6 +26,7 @@ import {
 	closePromptManifest,
 	freezePromptManifest,
 	type PromptManifest,
+	promptManifestStillMatches,
 	verifyHistoryCandidate,
 } from "./storage-repair-history";
 import type {
@@ -95,7 +96,7 @@ export async function runStorageRepair(
 		target: flags.target,
 		...(historySource ? { historySource } : {}),
 		apply: flags.apply,
-		dataLoss: historySource === "fresh",
+		dataLoss: historySource !== undefined,
 		status: "ready",
 		source,
 		backup: planned.backup,
@@ -125,7 +126,7 @@ export async function runStorageRepair(
 		if (flags.target === "agent") {
 			if (!snapshot.immutable) throw new Error("Agent immutable SQLite snapshot is missing");
 			const expectedPath = path.join(snapshot.tempDir, "expected-agent.db");
-			const expected = await fs.open(expectedPath, "wx", 0o600);
+			const expected = await fs.promises.open(expectedPath, "wx", 0o600);
 			await expected.close();
 			diagnosis = diagnoseAgentSnapshot(snapshot.immutable, expectedPath);
 		} else if (historySource === "sessions") {
@@ -149,7 +150,7 @@ export async function runStorageRepair(
 			candidateStage = await exclusiveStage(artifacts.candidate, "candidate");
 		} else {
 			candidateStage = path.join(snapshot.tempDir, "candidate.db");
-			const candidate = await fs.open(candidateStage, "wx", 0o600);
+			const candidate = await fs.promises.open(candidateStage, "wx", 0o600);
 			await candidate.close();
 		}
 
@@ -168,9 +169,11 @@ export async function runStorageRepair(
 		const digest = await sealCandidate(candidateStage);
 		result.checksums.push({ path: artifacts.candidate, ...digest });
 		await sourceStillMatches(snapshot.manifest);
+		if (historySource === "sessions") await promptManifestStillMatches(prompts);
 		if (flags.apply) {
 			await hooks.beforeCandidatePublication?.();
 			await sourceStillMatches(snapshot.manifest);
+			if (historySource === "sessions") await promptManifestStillMatches(prompts);
 			await publishCandidate(
 				candidateStage,
 				artifacts.candidate,
@@ -210,6 +213,11 @@ export async function runStorageRepair(
 		}
 		try {
 			if (snapshot) await sourceStillMatches(snapshot.manifest);
+		} catch (error) {
+			cleanupErrors.push(error);
+		}
+		try {
+			if (historySource === "sessions") await promptManifestStillMatches(prompts);
 		} catch (error) {
 			cleanupErrors.push(error);
 		}

--- a/packages/coding-agent/src/cli/storage-repair-cli.ts
+++ b/packages/coding-agent/src/cli/storage-repair-cli.ts
@@ -171,8 +171,8 @@ export async function runStorageRepair(
 			verifyHistoryCandidate(candidateStage, historySource, prompts);
 		}
 
-		const digest = await sealCandidate(candidateStage);
-		const candidateChecksum = { path: candidateStage, ...digest, ephemeral: true };
+		const seal = await sealCandidate(candidateStage);
+		const candidateChecksum = { path: candidateStage, sha256: seal.sha256, size: Number(seal.size), ephemeral: true };
 		result.checksums.push(candidateChecksum);
 		await sourceStillMatches(snapshot.manifest);
 		if (historySource === "sessions") await promptManifestStillMatches(prompts);
@@ -183,6 +183,7 @@ export async function runStorageRepair(
 			await publishCandidate(
 				candidateStage,
 				artifacts.candidate,
+				seal,
 				() => {
 					result.candidatePublished = true;
 				},

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -347,7 +347,7 @@ export async function sourceStillMatches(pre: SourceTripletManifest): Promise<vo
 export async function preparePristineSnapshot(
 	source: string,
 	inspectSqlite: boolean,
-	afterPristineCopy?: () => void | Promise<void>,
+	afterPristineCopy?: (tempDir: string) => void | Promise<void>,
 ): Promise<PristineSnapshot> {
 	const manifest = await manifestTriplet(source);
 	const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-storage-repair-"));
@@ -359,7 +359,7 @@ export async function preparePristineSnapshot(
 		await fs.promises.mkdir(workingDir, { mode: 0o700 });
 		const pristine = await copyTriplet(manifest, pristineDir, true);
 		await sealTriplet(manifest, pristine);
-		await afterPristineCopy?.();
+		await afterPristineCopy?.(tempDir);
 		await sourceStillMatches(manifest);
 		const copiedManifest: SourceTripletManifest = {
 			...manifest,

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -273,7 +273,7 @@ async function copyAndHash(
 	source: string,
 	destination: string,
 	sourceNoAtime: boolean,
-): Promise<StorageRepairChecksum> {
+): Promise<{ path: string; sha256: string; size: number }> {
 	const input = sourceNoAtime ? await openSourceNoAtime(source) : await fs.promises.open(source, "r");
 	const output = await fs.promises.open(
 		destination,
@@ -452,7 +452,9 @@ async function syncFile(file: string): Promise<void> {
 	}
 }
 
-async function syncDirectory(dir: string): Promise<void> {
+async function syncDirectory(dir: string, isWindows: () => boolean, onDirectorySync?: () => void): Promise<void> {
+	if (isWindows()) return;
+	onDirectorySync?.();
 	const handle = await fs.promises.open(dir, "r");
 	try {
 		await handle.sync();
@@ -463,9 +465,10 @@ async function syncDirectory(dir: string): Promise<void> {
 
 interface PublicationHooks {
 	afterLink?: () => void | Promise<void>;
-	onLinkedVerified?: () => void;
 	beforeStageUnlink?: () => void | Promise<void>;
 	beforeDirectorySync?: () => void | Promise<void>;
+	isWindows?: () => boolean;
+	onDirectorySync?: () => void;
 }
 
 interface PublishedFile {
@@ -521,6 +524,29 @@ async function verifyFinalFile(finalPath: string, expected: PublishedFile): Prom
 	);
 }
 
+async function runPublicationHook(
+	hook: (() => void | Promise<void>) | undefined,
+	stage: string,
+	finalPath: string,
+	expected: PublishedFile,
+	onPublished: () => void,
+): Promise<void> {
+	try {
+		await hook?.();
+	} catch (error) {
+		try {
+			await verifyPublishedFile(stage, finalPath, expected);
+		} catch (verificationError) {
+			throw new AggregateError(
+				[error, verificationError],
+				"Publication hook failed and changed the output identity",
+			);
+		}
+		onPublished();
+		throw error;
+	}
+}
+
 async function publishNoReplace(
 	stage: string,
 	finalPath: string,
@@ -530,16 +556,19 @@ async function publishNoReplace(
 	const expected = await sealedFile(stage);
 	await fs.promises.link(stage, finalPath);
 	await verifyPublishedFile(stage, finalPath, expected);
-	hooks.onLinkedVerified?.();
-	await hooks.afterLink?.();
+	await runPublicationHook(hooks.afterLink, stage, finalPath, expected, onPublished);
 	await verifyPublishedFile(stage, finalPath, expected);
-	await hooks.beforeStageUnlink?.();
+	await runPublicationHook(hooks.beforeStageUnlink, stage, finalPath, expected, onPublished);
 	await verifyPublishedFile(stage, finalPath, expected);
 	await fs.promises.unlink(stage);
 	onPublished();
 	await hooks.beforeDirectorySync?.();
 	await verifyFinalFile(finalPath, expected);
-	await syncDirectory(path.dirname(finalPath));
+	await syncDirectory(
+		path.dirname(finalPath),
+		hooks.isWindows ?? (() => process.platform === "win32"),
+		hooks.onDirectorySync,
+	);
 	await verifyFinalFile(finalPath, expected);
 }
 
@@ -595,6 +624,8 @@ export async function publishBackup(
 	snapshot: PristineSnapshot,
 	onPublished: (checksum: StorageRepairChecksum) => void,
 	afterLink?: () => void | Promise<void>,
+	isWindows?: () => boolean,
+	onDirectorySync?: () => void,
 ): Promise<StorageRepairChecksum> {
 	const entries: Array<readonly [string, ArchiveMemberContent]> = [
 		[BACKUP_MANIFEST_NAME, backupManifestJson(snapshot.manifest)],
@@ -609,14 +640,14 @@ export async function publishBackup(
 	await verifyBackup(stage, snapshot.manifest, new Set(entries.map(([name]) => name)), snapshot.tempDir);
 	await syncFile(stage);
 	const digest = await hashFile(stage, false);
-	const checksum = { path: backup, ...digest };
+	const checksum = { path: backup, ...digest, ephemeral: false };
 	let reported = false;
 	const report = () => {
 		if (reported) return;
 		reported = true;
 		onPublished(checksum);
 	};
-	await publishNoReplace(stage, backup, report, { afterLink, onLinkedVerified: report });
+	await publishNoReplace(stage, backup, report, { afterLink, isWindows, onDirectorySync });
 	return checksum;
 }
 

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -203,7 +203,6 @@ function inspect(db: Database): SnapshotFingerprint {
 
 function openImmutableSnapshot(workingMain: string): FrozenSqliteSnapshot {
 	const working = new Database(workingMain, { safeIntegers: true });
-	let serialized: Buffer | null = null;
 	let before: SnapshotFingerprint | null = null;
 	try {
 		try {
@@ -222,16 +221,20 @@ function openImmutableSnapshot(workingMain: string): FrozenSqliteSnapshot {
 		}
 		working.exec("PRAGMA wal_checkpoint(TRUNCATE)");
 		working.exec("PRAGMA journal_mode=DELETE");
-		serialized = working.serialize();
 	} finally {
 		working.close();
 	}
-	assertInvariant(serialized && before, "Working SQLite snapshot did not serialize");
-	const immutable = Database.deserialize(serialized, { readonly: true, safeIntegers: true });
+	assertInvariant(before, "Working SQLite snapshot was not inspected");
+	// Reopen the checkpointed working copy read-only so SQLite page-caches it on
+	// demand instead of cloning the entire database into memory (serialize plus
+	// deserialize would hold a full buffer and an in-memory image for all of
+	// diagnosis, row copying, and verification, which can exhaust memory on a
+	// large, unbounded agent database and prevent salvage).
+	const immutable = new Database(workingMain, { readonly: true, safeIntegers: true });
 	const after = inspect(immutable);
 	if (stableJson(before) === stableJson(after)) return { db: immutable, ...after };
 	immutable.close();
-	throw new Error("Serialized SQLite snapshot changed its schema/version/corruption manifest");
+	throw new Error("Checkpointed working copy changed its schema/version/corruption manifest");
 }
 
 async function lstatIfPresent(target: string): Promise<fs.Stats | null> {
@@ -735,7 +738,7 @@ export async function publishBackup(
 	backup: string,
 	snapshot: PristineSnapshot,
 	onLinked: () => void,
-	onVerified: (checksum: StorageRepairChecksum) => void,
+	onVerified: (checksum: StorageRepairChecksum, seal: PublishedFile) => void,
 	afterLink?: () => void | Promise<void>,
 	isWindows?: () => boolean,
 	onDirectorySync?: () => void,
@@ -755,7 +758,7 @@ export async function publishBackup(
 	const seal = await sealedFile(stage);
 	const checksum = { path: backup, sha256: seal.sha256, size: Number(seal.size), ephemeral: false };
 	await publishNoReplace(stage, backup, seal, onLinked, { afterLink, isWindows, onDirectorySync });
-	onVerified(checksum);
+	onVerified(checksum, seal);
 	return checksum;
 }
 
@@ -790,8 +793,8 @@ export async function sealCandidate(candidate: string): Promise<PublishedFile> {
 	return sealedFile(candidate);
 }
 
-export async function verifyCandidateSeal(candidate: string, seal: PublishedFile): Promise<void> {
-	await verifySealedFile(candidate, seal);
+export async function verifyPublishedSeal(file: string, seal: PublishedFile): Promise<void> {
+	await verifySealedFile(file, seal);
 }
 
 export async function publishCandidate(

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -579,45 +579,44 @@ async function verifyFinalFile(finalPath: string, expected: PublishedFile): Prom
 
 async function runPublicationHook(
 	hook: (() => void | Promise<void>) | undefined,
-	stage: string,
-	finalPath: string,
-	expected: PublishedFile,
-	onPublished: () => void,
+	verify: () => Promise<void>,
+	onPublished?: () => void,
 ): Promise<void> {
+	if (!hook) return;
 	try {
-		await hook?.();
+		await hook();
 	} catch (error) {
 		try {
-			await verifyPublishedFile(stage, finalPath, expected);
+			await verify();
 		} catch (verificationError) {
 			throw new AggregateError(
 				[error, verificationError],
 				"Publication hook failed and changed the output identity",
 			);
 		}
-		onPublished();
+		onPublished?.();
 		throw error;
 	}
+	await verify();
 }
 
 async function publishNoReplace(
 	stage: string,
 	finalPath: string,
 	expected: PublishedFile,
-	onPublished: () => void,
+	onLinked: () => void,
+	onPublished?: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
 	await verifySealedFile(stage, expected);
 	await fs.promises.link(stage, finalPath);
+	onLinked();
 	await verifyPublishedFile(stage, finalPath, expected);
-	await runPublicationHook(hooks.afterLink, stage, finalPath, expected, onPublished);
-	await verifyPublishedFile(stage, finalPath, expected);
-	await runPublicationHook(hooks.beforeStageUnlink, stage, finalPath, expected, onPublished);
-	await verifyPublishedFile(stage, finalPath, expected);
+	await runPublicationHook(hooks.afterLink, () => verifyPublishedFile(stage, finalPath, expected), onPublished);
+	await runPublicationHook(hooks.beforeStageUnlink, () => verifyPublishedFile(stage, finalPath, expected), onPublished);
 	await fs.promises.unlink(stage);
-	onPublished();
-	await hooks.beforeDirectorySync?.();
-	await verifyFinalFile(finalPath, expected);
+	onPublished?.();
+	await runPublicationHook(hooks.beforeDirectorySync, () => verifyFinalFile(finalPath, expected), onPublished);
 	await syncDirectory(
 		path.dirname(finalPath),
 		hooks.isWindows ?? (() => process.platform === "win32"),
@@ -710,7 +709,7 @@ export async function publishBackup(
 		reported = true;
 		onPublished(checksum);
 	};
-	await publishNoReplace(stage, backup, seal, report, { afterLink, isWindows, onDirectorySync });
+	await publishNoReplace(stage, backup, seal, report, report, { afterLink, isWindows, onDirectorySync });
 	return checksum;
 }
 
@@ -749,10 +748,10 @@ export async function publishCandidate(
 	stage: string,
 	finalPath: string,
 	seal: PublishedFile,
-	onPublished: () => void,
+	onLinked: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
-	await publishNoReplace(stage, finalPath, seal, onPublished, hooks);
+	await publishNoReplace(stage, finalPath, seal, onLinked, undefined, hooks);
 }
 
 export function manualNextStep(source: string, candidate: string, backup: string): string {

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -407,28 +407,20 @@ export interface ResolveArtifactPathOptions {
 	platform?: () => NodeJS.Platform;
 }
 
-type PathComparisonMode = "posix" | "darwin" | "win32";
-
-function pathComparisonMode(platform: NodeJS.Platform): PathComparisonMode {
-	if (platform === "win32") return "win32";
-	if (platform === "darwin") return "darwin";
-	return "posix";
+function caselessFilesystem(platform: NodeJS.Platform): boolean {
+	return platform === "darwin" || platform === "win32";
 }
 
-function pathComparisonKey(target: string, mode: PathComparisonMode): string {
-	let normalized = normalizePathForComparison(target).normalize("NFC");
-	if (mode === "win32") {
-		// Inputs are canonical: path.resolve plus realpath(parent) means dot parents cannot survive here.
-		normalized = normalized
-			.split(path.sep)
-			.map(component => component.replace(/[. ]+$/u, ""))
-			.join(path.sep);
+function pathsAlias(left: string, right: string, caseless: boolean): boolean {
+	const normalizedLeft = normalizePathForComparison(left).normalize("NFC");
+	const normalizedRight = normalizePathForComparison(right).normalize("NFC");
+	if (caseless) {
+		return (
+			normalizedLeft.toUpperCase().toLowerCase().normalize("NFC") ===
+			normalizedRight.toUpperCase().toLowerCase().normalize("NFC")
+		);
 	}
-	return mode === "posix" ? normalized : normalized.toUpperCase().toLowerCase().normalize("NFC");
-}
-
-function pathsAlias(left: string, right: string, mode: PathComparisonMode): boolean {
-	return pathComparisonKey(left, mode) === pathComparisonKey(right, mode);
+	return normalizedLeft === normalizedRight;
 }
 
 export async function resolveArtifactPaths(
@@ -446,15 +438,15 @@ export async function resolveArtifactPaths(
 		await fs.promises.realpath(path.dirname(sourceAbsolute)),
 		path.basename(sourceAbsolute),
 	);
-	const mode = pathComparisonMode(options.platform?.() ?? process.platform);
+	const caseless = caselessFilesystem(options.platform?.() ?? process.platform);
 	const forbidden = [canonicalSource, `${canonicalSource}-wal`, `${canonicalSource}-shm`];
 	assertInvariant(
 		!forbidden.some(
-			forbiddenPath => pathsAlias(candidate, forbiddenPath, mode) || pathsAlias(backup, forbiddenPath, mode),
+			forbiddenPath => pathsAlias(candidate, forbiddenPath, caseless) || pathsAlias(backup, forbiddenPath, caseless),
 		),
 		"Repair artifact collides with source triplet",
 	);
-	assertInvariant(!pathsAlias(candidate, backup, mode), "Candidate and backup paths collide");
+	assertInvariant(!pathsAlias(candidate, backup, caseless), "Candidate and backup paths collide");
 	return { backup, candidate };
 }
 
@@ -587,44 +579,45 @@ async function verifyFinalFile(finalPath: string, expected: PublishedFile): Prom
 
 async function runPublicationHook(
 	hook: (() => void | Promise<void>) | undefined,
-	verify: () => Promise<void>,
-	onPublished?: () => void,
+	stage: string,
+	finalPath: string,
+	expected: PublishedFile,
+	onPublished: () => void,
 ): Promise<void> {
-	if (!hook) return;
 	try {
-		await hook();
+		await hook?.();
 	} catch (error) {
 		try {
-			await verify();
+			await verifyPublishedFile(stage, finalPath, expected);
 		} catch (verificationError) {
 			throw new AggregateError(
 				[error, verificationError],
 				"Publication hook failed and changed the output identity",
 			);
 		}
-		onPublished?.();
+		onPublished();
 		throw error;
 	}
-	await verify();
 }
 
 async function publishNoReplace(
 	stage: string,
 	finalPath: string,
 	expected: PublishedFile,
-	onLinked: () => void,
-	onPublished?: () => void,
+	onPublished: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
 	await verifySealedFile(stage, expected);
 	await fs.promises.link(stage, finalPath);
-	onLinked();
 	await verifyPublishedFile(stage, finalPath, expected);
-	await runPublicationHook(hooks.afterLink, () => verifyPublishedFile(stage, finalPath, expected), onPublished);
-	await runPublicationHook(hooks.beforeStageUnlink, () => verifyPublishedFile(stage, finalPath, expected), onPublished);
+	await runPublicationHook(hooks.afterLink, stage, finalPath, expected, onPublished);
+	await verifyPublishedFile(stage, finalPath, expected);
+	await runPublicationHook(hooks.beforeStageUnlink, stage, finalPath, expected, onPublished);
+	await verifyPublishedFile(stage, finalPath, expected);
 	await fs.promises.unlink(stage);
-	onPublished?.();
-	await runPublicationHook(hooks.beforeDirectorySync, () => verifyFinalFile(finalPath, expected), onPublished);
+	onPublished();
+	await hooks.beforeDirectorySync?.();
+	await verifyFinalFile(finalPath, expected);
 	await syncDirectory(
 		path.dirname(finalPath),
 		hooks.isWindows ?? (() => process.platform === "win32"),
@@ -717,7 +710,7 @@ export async function publishBackup(
 		reported = true;
 		onPublished(checksum);
 	};
-	await publishNoReplace(stage, backup, seal, report, report, { afterLink, isWindows, onDirectorySync });
+	await publishNoReplace(stage, backup, seal, report, { afterLink, isWindows, onDirectorySync });
 	return checksum;
 }
 
@@ -756,10 +749,10 @@ export async function publishCandidate(
 	stage: string,
 	finalPath: string,
 	seal: PublishedFile,
-	onLinked: () => void,
+	onPublished: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
-	await publishNoReplace(stage, finalPath, seal, onLinked, undefined, hooks);
+	await publishNoReplace(stage, finalPath, seal, onPublished, hooks);
 }
 
 export function manualNextStep(source: string, candidate: string, backup: string): string {

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -808,22 +808,23 @@ export interface ManualRepairState {
 	status: "ready" | "refused" | "published-with-warning";
 	apply: boolean;
 	backupCreated: boolean;
+	backupVerified: boolean;
 	candidatePublished: boolean;
 	candidatePathTrusted: boolean;
 }
 
 export function manualNextStep(source: string, candidate: string, backup: string, state: ManualRepairState): string {
 	if (state.status === "refused") {
-		return `Repair was refused. Do not install ${candidate}.${state.backupCreated ? ` Retain verified backup ${backup}.` : ""}`;
+		return `Repair was refused. Do not install ${candidate}.${state.backupVerified ? ` Retain verified backup ${backup}.` : ""}`;
 	}
 	if (!state.apply) {
 		return `Dry run only: no candidate was published. Do not install ${candidate}; rerun with --apply only after reviewing the refusal-free result.`;
 	}
 	if (!state.candidatePublished) {
-		return `No candidate was published. Do not install ${candidate}.${state.backupCreated ? ` Retain verified backup ${backup}.` : ""}`;
+		return `No candidate was published. Do not install ${candidate}.${state.backupVerified ? ` Retain verified backup ${backup}.` : ""}`;
 	}
 	if (!state.candidatePathTrusted) {
-		return `Published candidate ${candidate} failed final trust checks. Do not install it.${state.backupCreated ? ` Retain verified backup ${backup}.` : ""}`;
+		return `Published candidate ${candidate} failed final trust checks. Do not install it.${state.backupVerified ? ` Retain verified backup ${backup}.` : ""}`;
 	}
 	return [
 		"Stop every OMP process.",

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -1,6 +1,5 @@
 import { Database, constants as sqliteConstants } from "bun:sqlite";
-import { type BigIntStats, constants as fsConstants, type Stats } from "node:fs";
-import * as fs from "node:fs/promises";
+import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { type ArchiveMemberContent, archiveFileMember, extractFileBackedTar, writeArchive } from "../utils/zip";
@@ -188,26 +187,26 @@ function openImmutableSnapshot(workingMain: string): FrozenSqliteSnapshot {
 	throw new Error("Serialized SQLite snapshot changed its schema/version/corruption manifest");
 }
 
-async function lstatIfPresent(target: string): Promise<Stats | null> {
+async function lstatIfPresent(target: string): Promise<fs.Stats | null> {
 	try {
-		return await fs.lstat(target);
+		return await fs.promises.lstat(target);
 	} catch (error) {
 		if (codeOf(error) === "ENOENT") return null;
 		throw error;
 	}
 }
 
-async function openSourceNoAtime(file: string): Promise<fs.FileHandle> {
-	const noAtime = fsConstants.O_NOATIME ?? 0;
+async function openSourceNoAtime(file: string): Promise<fs.promises.FileHandle> {
+	const noAtime = fs.constants.O_NOATIME ?? 0;
 	try {
-		return await fs.open(file, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | noAtime);
+		return await fs.promises.open(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | noAtime);
 	} catch (error) {
 		if (noAtime === 0 || (codeOf(error) !== "EPERM" && codeOf(error) !== "EINVAL")) throw error;
-		return fs.open(file, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+		return fs.promises.open(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
 	}
 }
 
-async function hashHandle(handle: fs.FileHandle): Promise<{ sha256: string; size: number }> {
+async function hashHandle(handle: fs.promises.FileHandle): Promise<{ sha256: string; size: number }> {
 	const hash = new Bun.SHA256();
 	const buffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
 	let position = 0;
@@ -220,7 +219,7 @@ async function hashHandle(handle: fs.FileHandle): Promise<{ sha256: string; size
 }
 
 async function hashFile(file: string, source: boolean): Promise<{ sha256: string; size: number }> {
-	const handle = source ? await openSourceNoAtime(file) : await fs.open(file, "r");
+	const handle = source ? await openSourceNoAtime(file) : await fs.promises.open(file, "r");
 	try {
 		return await hashHandle(handle);
 	} finally {
@@ -233,9 +232,9 @@ async function manifestMember(
 	file: string,
 	archiveName: string,
 ): Promise<SourceMemberManifest | null> {
-	let stat: BigIntStats;
+	let stat: fs.BigIntStats;
 	try {
-		stat = await fs.lstat(file, { bigint: true });
+		stat = await fs.promises.lstat(file, { bigint: true });
 	} catch (error) {
 		if (codeOf(error) === "ENOENT") return null;
 		throw error;
@@ -275,8 +274,12 @@ async function copyAndHash(
 	destination: string,
 	sourceNoAtime: boolean,
 ): Promise<StorageRepairChecksum> {
-	const input = sourceNoAtime ? await openSourceNoAtime(source) : await fs.open(source, "r");
-	const output = await fs.open(destination, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL, 0o600);
+	const input = sourceNoAtime ? await openSourceNoAtime(source) : await fs.promises.open(source, "r");
+	const output = await fs.promises.open(
+		destination,
+		fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL,
+		0o600,
+	);
 	const hash = new Bun.SHA256();
 	const buffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
 	let position = 0;
@@ -346,13 +349,13 @@ export async function preparePristineSnapshot(
 	afterPristineCopy?: () => void | Promise<void>,
 ): Promise<PristineSnapshot> {
 	const manifest = await manifestTriplet(source);
-	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-storage-repair-"));
+	const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-storage-repair-"));
 	try {
-		await fs.chmod(tempDir, 0o700);
+		await fs.promises.chmod(tempDir, 0o700);
 		const pristineDir = path.join(tempDir, "pristine");
 		const workingDir = path.join(tempDir, "working");
-		await fs.mkdir(pristineDir, { mode: 0o700 });
-		await fs.mkdir(workingDir, { mode: 0o700 });
+		await fs.promises.mkdir(pristineDir, { mode: 0o700 });
+		await fs.promises.mkdir(workingDir, { mode: 0o700 });
 		const pristine = await copyTriplet(manifest, pristineDir, true);
 		await sealTriplet(manifest, pristine);
 		await afterPristineCopy?.();
@@ -375,7 +378,7 @@ export async function preparePristineSnapshot(
 			immutable: inspectSqlite ? openImmutableSnapshot(working.main) : null,
 		};
 	} catch (error) {
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await fs.promises.rm(tempDir, { recursive: true, force: true });
 		throw error;
 	}
 }
@@ -385,14 +388,14 @@ export async function cleanupSnapshot(snapshot: PristineSnapshot | null): Promis
 	try {
 		snapshot.immutable?.db.close();
 	} finally {
-		await fs.rm(snapshot.tempDir, { recursive: true, force: true });
+		await fs.promises.rm(snapshot.tempDir, { recursive: true, force: true });
 	}
 }
 
 async function canonicalNewPath(target: string): Promise<string> {
 	const absolute = path.resolve(target);
 	assertInvariant((await lstatIfPresent(absolute)) === null, `Repair output already exists: ${absolute}`);
-	const parent = await fs.realpath(path.dirname(absolute));
+	const parent = await fs.promises.realpath(path.dirname(absolute));
 	const canonical = path.join(parent, path.basename(absolute));
 	assertInvariant((await lstatIfPresent(canonical)) === null, `Repair output already exists: ${canonical}`);
 	return canonical;
@@ -405,7 +408,7 @@ export async function resolveArtifactPaths(
 	const slug = `${new Date().toISOString().replace(/[-:.TZ]/gu, "")}-${crypto.randomUUID().slice(0, 8)}`;
 	const candidate = await canonicalNewPath(output ?? `${source}.salvage-${slug}.db`);
 	const backup = await canonicalNewPath(`${source}.salvage-${slug}.tar`);
-	const canonicalSource = path.join(await fs.realpath(path.dirname(source)), path.basename(source));
+	const canonicalSource = path.join(await fs.promises.realpath(path.dirname(source)), path.basename(source));
 	const forbidden = [canonicalSource, `${canonicalSource}-wal`, `${canonicalSource}-shm`];
 	assertInvariant(
 		!forbidden.includes(candidate) && !forbidden.includes(backup),
@@ -417,7 +420,11 @@ export async function resolveArtifactPaths(
 
 export async function exclusiveStage(finalPath: string, label: string): Promise<string> {
 	const stage = path.join(path.dirname(finalPath), `.${path.basename(finalPath)}.${label}-${crypto.randomUUID()}.tmp`);
-	const handle = await fs.open(stage, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL, 0o600);
+	const handle = await fs.promises.open(
+		stage,
+		fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL,
+		0o600,
+	);
 	await handle.close();
 	return stage;
 }
@@ -425,7 +432,7 @@ export async function exclusiveStage(finalPath: string, label: string): Promise<
 export async function removeOwnedFile(target: string | null): Promise<void> {
 	if (!target) return;
 	try {
-		await fs.unlink(target);
+		await fs.promises.unlink(target);
 	} catch (error) {
 		if (codeOf(error) !== "ENOENT") throw error;
 	}
@@ -437,7 +444,7 @@ export async function removeCandidateSidecars(candidate: string): Promise<void> 
 }
 
 async function syncFile(file: string): Promise<void> {
-	const handle = await fs.open(file, "r");
+	const handle = await fs.promises.open(file, "r");
 	try {
 		await handle.sync();
 	} finally {
@@ -446,7 +453,7 @@ async function syncFile(file: string): Promise<void> {
 }
 
 async function syncDirectory(dir: string): Promise<void> {
-	const handle = await fs.open(dir, "r");
+	const handle = await fs.promises.open(dir, "r");
 	try {
 		await handle.sync();
 	} finally {
@@ -456,8 +463,62 @@ async function syncDirectory(dir: string): Promise<void> {
 
 interface PublicationHooks {
 	afterLink?: () => void | Promise<void>;
+	onLinkedVerified?: () => void;
 	beforeStageUnlink?: () => void | Promise<void>;
 	beforeDirectorySync?: () => void | Promise<void>;
+}
+
+interface PublishedFile {
+	dev: bigint;
+	ino: bigint;
+	size: bigint;
+	sha256: string;
+}
+
+async function sealedFile(file: string): Promise<PublishedFile> {
+	const stat = await fs.promises.lstat(file, { bigint: true });
+	assertInvariant(stat.isFile() && !stat.isSymbolicLink(), `Publication stage is not a regular file: ${file}`);
+	return { dev: stat.dev, ino: stat.ino, size: stat.size, sha256: (await hashFile(file, false)).sha256 };
+}
+
+async function verifyPublishedFile(stage: string, finalPath: string, expected: PublishedFile): Promise<void> {
+	const [stageStat, finalStat] = await Promise.all([
+		fs.promises.lstat(stage, { bigint: true }),
+		fs.promises.lstat(finalPath, { bigint: true }),
+	]);
+	assertInvariant(
+		stageStat.isFile() &&
+			!stageStat.isSymbolicLink() &&
+			finalStat.isFile() &&
+			!finalStat.isSymbolicLink() &&
+			stageStat.dev === expected.dev &&
+			stageStat.ino === expected.ino &&
+			stageStat.size === expected.size &&
+			finalStat.dev === expected.dev &&
+			finalStat.ino === expected.ino &&
+			finalStat.size === expected.size,
+		`Published output no longer matches staging file: ${finalPath}`,
+	);
+	assertInvariant(
+		(await hashFile(finalPath, false)).sha256 === expected.sha256,
+		`Published output content changed: ${finalPath}`,
+	);
+}
+
+async function verifyFinalFile(finalPath: string, expected: PublishedFile): Promise<void> {
+	const finalStat = await fs.promises.lstat(finalPath, { bigint: true });
+	assertInvariant(
+		finalStat.isFile() &&
+			!finalStat.isSymbolicLink() &&
+			finalStat.dev === expected.dev &&
+			finalStat.ino === expected.ino &&
+			finalStat.size === expected.size,
+		`Published output no longer matches staging file: ${finalPath}`,
+	);
+	assertInvariant(
+		(await hashFile(finalPath, false)).sha256 === expected.sha256,
+		`Published output content changed: ${finalPath}`,
+	);
 }
 
 async function publishNoReplace(
@@ -466,13 +527,20 @@ async function publishNoReplace(
 	onPublished: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
-	await fs.link(stage, finalPath);
-	onPublished();
+	const expected = await sealedFile(stage);
+	await fs.promises.link(stage, finalPath);
+	await verifyPublishedFile(stage, finalPath, expected);
+	hooks.onLinkedVerified?.();
 	await hooks.afterLink?.();
+	await verifyPublishedFile(stage, finalPath, expected);
 	await hooks.beforeStageUnlink?.();
-	await fs.unlink(stage);
+	await verifyPublishedFile(stage, finalPath, expected);
+	await fs.promises.unlink(stage);
+	onPublished();
 	await hooks.beforeDirectorySync?.();
+	await verifyFinalFile(finalPath, expected);
 	await syncDirectory(path.dirname(finalPath));
+	await verifyFinalFile(finalPath, expected);
 }
 
 function backupManifestJson(manifest: SourceTripletManifest): string {
@@ -497,14 +565,14 @@ async function verifyBackup(
 	names: Set<string>,
 	tempDir: string,
 ): Promise<void> {
-	const verificationDir = await fs.mkdtemp(path.join(tempDir, "backup-verify-"));
+	const verificationDir = await fs.promises.mkdtemp(path.join(tempDir, "backup-verify-"));
 	try {
-		const archiveStat = await fs.stat(stage);
+		const archiveStat = await fs.promises.stat(stage);
 		const extracted = await extractFileBackedTar(stage, archiveStat.size, verificationDir);
 		assertInvariant(extracted === names.size, "Backup archive contains unexpected members");
 		const manifestPath = path.join(verificationDir, BACKUP_MANIFEST_NAME);
 		assertInvariant(
-			(await fs.readFile(manifestPath, "utf8")) === backupManifestJson(manifest),
+			(await fs.promises.readFile(manifestPath, "utf8")) === backupManifestJson(manifest),
 			"Backup manifest verification failed",
 		);
 		for (const role of ["main", "wal", "shm"] as const) {
@@ -517,7 +585,7 @@ async function verifyBackup(
 			);
 		}
 	} finally {
-		await fs.rm(verificationDir, { recursive: true, force: true });
+		await fs.promises.rm(verificationDir, { recursive: true, force: true });
 	}
 }
 
@@ -537,12 +605,18 @@ export async function publishBackup(
 		if (member && file) entries.push([member.archiveName, archiveFileMember(file, member.size)]);
 	}
 	await writeArchive(stage, "tar", entries);
-	await fs.chmod(stage, 0o600);
+	await fs.promises.chmod(stage, 0o600);
 	await verifyBackup(stage, snapshot.manifest, new Set(entries.map(([name]) => name)), snapshot.tempDir);
 	await syncFile(stage);
 	const digest = await hashFile(stage, false);
 	const checksum = { path: backup, ...digest };
-	await publishNoReplace(stage, backup, () => onPublished(checksum), { afterLink });
+	let reported = false;
+	const report = () => {
+		if (reported) return;
+		reported = true;
+		onPublished(checksum);
+	};
+	await publishNoReplace(stage, backup, report, { afterLink, onLinkedVerified: report });
 	return checksum;
 }
 
@@ -572,7 +646,7 @@ export function verifyCommonCandidate(candidate: string): void {
 
 export async function sealCandidate(candidate: string): Promise<{ sha256: string; size: number }> {
 	await removeCandidateSidecars(candidate);
-	await fs.chmod(candidate, 0o600);
+	await fs.promises.chmod(candidate, 0o600);
 	await syncFile(candidate);
 	return hashFile(candidate, false);
 }

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -402,8 +402,6 @@ async function canonicalNewPath(target: string): Promise<string> {
 	return canonical;
 }
 
-
-
 export interface ResolveArtifactPathOptions {
 	artifactSlug?: () => string;
 	platform?: () => NodeJS.Platform;
@@ -505,7 +503,7 @@ interface PublicationHooks {
 	onDirectorySync?: () => void;
 }
 
-interface PublishedFile {
+export interface PublishedFile {
 	dev: bigint;
 	ino: bigint;
 	size: bigint;
@@ -515,7 +513,28 @@ interface PublishedFile {
 async function sealedFile(file: string): Promise<PublishedFile> {
 	const stat = await fs.promises.lstat(file, { bigint: true });
 	assertInvariant(stat.isFile() && !stat.isSymbolicLink(), `Publication stage is not a regular file: ${file}`);
-	return { dev: stat.dev, ino: stat.ino, size: stat.size, sha256: (await hashFile(file, false)).sha256 };
+	const digest = await hashFile(file, false);
+	const confirmed = await fs.promises.lstat(file, { bigint: true });
+	assertInvariant(
+		confirmed.isFile() &&
+			!confirmed.isSymbolicLink() &&
+			confirmed.dev === stat.dev &&
+			confirmed.ino === stat.ino &&
+			confirmed.size === stat.size,
+		`Publication stage changed while sealing: ${file}`,
+	);
+	return { dev: stat.dev, ino: stat.ino, size: stat.size, sha256: digest.sha256 };
+}
+
+async function verifySealedFile(file: string, expected: PublishedFile): Promise<void> {
+	const actual = await sealedFile(file);
+	assertInvariant(
+		actual.dev === expected.dev &&
+			actual.ino === expected.ino &&
+			actual.size === expected.size &&
+			actual.sha256 === expected.sha256,
+		`Publication stage changed after verification: ${file}`,
+	);
 }
 
 async function verifyPublishedFile(stage: string, finalPath: string, expected: PublishedFile): Promise<void> {
@@ -584,10 +603,11 @@ async function runPublicationHook(
 async function publishNoReplace(
 	stage: string,
 	finalPath: string,
+	expected: PublishedFile,
 	onPublished: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
-	const expected = await sealedFile(stage);
+	await verifySealedFile(stage, expected);
 	await fs.promises.link(stage, finalPath);
 	await verifyPublishedFile(stage, finalPath, expected);
 	await runPublicationHook(hooks.afterLink, stage, finalPath, expected, onPublished);
@@ -682,15 +702,15 @@ export async function publishBackup(
 	await fs.promises.chmod(stage, 0o600);
 	await verifyBackup(stage, snapshot.manifest, new Set(entries.map(([name]) => name)), snapshot.tempDir);
 	await syncFile(stage);
-	const digest = await hashFile(stage, false);
-	const checksum = { path: backup, ...digest, ephemeral: false };
+	const seal = await sealedFile(stage);
+	const checksum = { path: backup, sha256: seal.sha256, size: Number(seal.size), ephemeral: false };
 	let reported = false;
 	const report = () => {
 		if (reported) return;
 		reported = true;
 		onPublished(checksum);
 	};
-	await publishNoReplace(stage, backup, report, { afterLink, isWindows, onDirectorySync });
+	await publishNoReplace(stage, backup, seal, report, { afterLink, isWindows, onDirectorySync });
 	return checksum;
 }
 
@@ -718,20 +738,21 @@ export function verifyCommonCandidate(candidate: string): void {
 	}
 }
 
-export async function sealCandidate(candidate: string): Promise<{ sha256: string; size: number }> {
+export async function sealCandidate(candidate: string): Promise<PublishedFile> {
 	await removeCandidateSidecars(candidate);
 	await fs.promises.chmod(candidate, 0o600);
 	await syncFile(candidate);
-	return hashFile(candidate, false);
+	return sealedFile(candidate);
 }
 
 export async function publishCandidate(
 	stage: string,
 	finalPath: string,
+	seal: PublishedFile,
 	onPublished: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
-	await publishNoReplace(stage, finalPath, onPublished, hooks);
+	await publishNoReplace(stage, finalPath, seal, onPublished, hooks);
 }
 
 export function manualNextStep(source: string, candidate: string, backup: string): string {

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -588,7 +588,6 @@ async function verifyFinalFile(finalPath: string, expected: PublishedFile): Prom
 async function runPublicationHook(
 	hook: (() => void | Promise<void>) | undefined,
 	verify: () => Promise<void>,
-	onPublished?: () => void,
 ): Promise<void> {
 	if (!hook) return;
 	try {
@@ -602,7 +601,6 @@ async function runPublicationHook(
 				"Publication hook failed and changed the output identity",
 			);
 		}
-		onPublished?.();
 		throw error;
 	}
 	await verify();
@@ -613,22 +611,16 @@ async function publishNoReplace(
 	finalPath: string,
 	expected: PublishedFile,
 	onLinked: () => void,
-	onPublished?: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
 	await verifySealedFile(stage, expected);
 	await fs.promises.link(stage, finalPath);
 	onLinked();
 	await verifyPublishedFile(stage, finalPath, expected);
-	await runPublicationHook(hooks.afterLink, () => verifyPublishedFile(stage, finalPath, expected), onPublished);
-	await runPublicationHook(
-		hooks.beforeStageUnlink,
-		() => verifyPublishedFile(stage, finalPath, expected),
-		onPublished,
-	);
+	await runPublicationHook(hooks.afterLink, () => verifyPublishedFile(stage, finalPath, expected));
+	await runPublicationHook(hooks.beforeStageUnlink, () => verifyPublishedFile(stage, finalPath, expected));
 	await fs.promises.unlink(stage);
-	onPublished?.();
-	await runPublicationHook(hooks.beforeDirectorySync, () => verifyFinalFile(finalPath, expected), onPublished);
+	await runPublicationHook(hooks.beforeDirectorySync, () => verifyFinalFile(finalPath, expected));
 	await syncDirectory(
 		path.dirname(finalPath),
 		hooks.isWindows ?? (() => process.platform === "win32"),
@@ -696,7 +688,8 @@ export async function publishBackup(
 	stage: string,
 	backup: string,
 	snapshot: PristineSnapshot,
-	onPublished: (checksum: StorageRepairChecksum) => void,
+	onLinked: () => void,
+	onVerified: (checksum: StorageRepairChecksum) => void,
 	afterLink?: () => void | Promise<void>,
 	isWindows?: () => boolean,
 	onDirectorySync?: () => void,
@@ -715,13 +708,8 @@ export async function publishBackup(
 	await syncFile(stage);
 	const seal = await sealedFile(stage);
 	const checksum = { path: backup, sha256: seal.sha256, size: Number(seal.size), ephemeral: false };
-	let reported = false;
-	const report = () => {
-		if (reported) return;
-		reported = true;
-		onPublished(checksum);
-	};
-	await publishNoReplace(stage, backup, seal, report, report, { afterLink, isWindows, onDirectorySync });
+	await publishNoReplace(stage, backup, seal, onLinked, { afterLink, isWindows, onDirectorySync });
+	onVerified(checksum);
 	return checksum;
 }
 
@@ -763,7 +751,7 @@ export async function publishCandidate(
 	onLinked: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
-	await publishNoReplace(stage, finalPath, seal, onLinked, undefined, hooks);
+	await publishNoReplace(stage, finalPath, seal, onLinked, hooks);
 }
 
 export function manualNextStep(source: string, candidate: string, backup: string): string {

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -402,21 +402,17 @@ async function canonicalNewPath(target: string): Promise<string> {
 	return canonical;
 }
 
-
+export type ArtifactPathComparisonMode = "platform" | "case-insensitive";
 
 export interface ResolveArtifactPathOptions {
+	comparisonMode?: ArtifactPathComparisonMode;
 	artifactSlug?: () => string;
-	platform?: () => NodeJS.Platform;
 }
 
-function caselessFilesystem(platform: NodeJS.Platform): boolean {
-	return platform === "darwin" || platform === "win32";
-}
-
-function pathsAlias(left: string, right: string, caseless: boolean): boolean {
+function pathsAlias(left: string, right: string, comparisonMode: ArtifactPathComparisonMode): boolean {
 	const normalizedLeft = normalizePathForComparison(left).normalize("NFC");
 	const normalizedRight = normalizePathForComparison(right).normalize("NFC");
-	if (caseless) {
+	if (comparisonMode === "case-insensitive" || (comparisonMode === "platform" && process.platform === "darwin")) {
 		return (
 			normalizedLeft.toUpperCase().toLowerCase().normalize("NFC") ===
 			normalizedRight.toUpperCase().toLowerCase().normalize("NFC")
@@ -440,15 +436,16 @@ export async function resolveArtifactPaths(
 		await fs.promises.realpath(path.dirname(sourceAbsolute)),
 		path.basename(sourceAbsolute),
 	);
-	const caseless = caselessFilesystem(options.platform?.() ?? process.platform);
+	const comparisonMode = options.comparisonMode ?? "platform";
 	const forbidden = [canonicalSource, `${canonicalSource}-wal`, `${canonicalSource}-shm`];
 	assertInvariant(
 		!forbidden.some(
-			forbiddenPath => pathsAlias(candidate, forbiddenPath, caseless) || pathsAlias(backup, forbiddenPath, caseless),
+			forbiddenPath =>
+				pathsAlias(candidate, forbiddenPath, comparisonMode) || pathsAlias(backup, forbiddenPath, comparisonMode),
 		),
 		"Repair artifact collides with source triplet",
 	);
-	assertInvariant(!pathsAlias(candidate, backup, caseless), "Candidate and backup paths collide");
+	assertInvariant(!pathsAlias(candidate, backup, comparisonMode), "Candidate and backup paths collide");
 	return { backup, candidate };
 }
 
@@ -505,36 +502,17 @@ interface PublicationHooks {
 	onDirectorySync?: () => void;
 }
 
-export interface PublishedFile { dev: bigint;
+interface PublishedFile {
+	dev: bigint;
 	ino: bigint;
 	size: bigint;
-	sha256: string; }
+	sha256: string;
+}
 
 async function sealedFile(file: string): Promise<PublishedFile> {
 	const stat = await fs.promises.lstat(file, { bigint: true });
 	assertInvariant(stat.isFile() && !stat.isSymbolicLink(), `Publication stage is not a regular file: ${file}`);
-	const digest = await hashFile(file, false);
-	const confirmed = await fs.promises.lstat(file, { bigint: true });
-	assertInvariant(
-		confirmed.isFile() &&
-			!confirmed.isSymbolicLink() &&
-			confirmed.dev === stat.dev &&
-			confirmed.ino === stat.ino &&
-			confirmed.size === stat.size,
-		`Publication stage changed while sealing: ${file}`,
-	);
-	return { dev: stat.dev, ino: stat.ino, size: stat.size, sha256: digest.sha256 };
-}
-
-async function verifySealedFile(file: string, expected: PublishedFile): Promise<void> {
-	const actual = await sealedFile(file);
-	assertInvariant(
-		actual.dev === expected.dev &&
-			actual.ino === expected.ino &&
-			actual.size === expected.size &&
-			actual.sha256 === expected.sha256,
-		`Publication stage changed after verification: ${file}`,
-	);
+	return { dev: stat.dev, ino: stat.ino, size: stat.size, sha256: (await hashFile(file, false)).sha256 };
 }
 
 async function verifyPublishedFile(stage: string, finalPath: string, expected: PublishedFile): Promise<void> {
@@ -603,11 +581,10 @@ async function runPublicationHook(
 async function publishNoReplace(
 	stage: string,
 	finalPath: string,
-	expected: PublishedFile,
 	onPublished: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
-	await verifySealedFile(stage, expected);
+	const expected = await sealedFile(stage);
 	await fs.promises.link(stage, finalPath);
 	await verifyPublishedFile(stage, finalPath, expected);
 	await runPublicationHook(hooks.afterLink, stage, finalPath, expected, onPublished);
@@ -702,15 +679,15 @@ export async function publishBackup(
 	await fs.promises.chmod(stage, 0o600);
 	await verifyBackup(stage, snapshot.manifest, new Set(entries.map(([name]) => name)), snapshot.tempDir);
 	await syncFile(stage);
-	const seal = await sealedFile(stage);
-	const checksum = { path: backup, sha256: seal.sha256, size: Number(seal.size), ephemeral: false };
+	const digest = await hashFile(stage, false);
+	const checksum = { path: backup, ...digest, ephemeral: false };
 	let reported = false;
 	const report = () => {
 		if (reported) return;
 		reported = true;
 		onPublished(checksum);
 	};
-	await publishNoReplace(stage, backup, seal, report, { afterLink, isWindows, onDirectorySync });
+	await publishNoReplace(stage, backup, report, { afterLink, isWindows, onDirectorySync });
 	return checksum;
 }
 
@@ -738,21 +715,20 @@ export function verifyCommonCandidate(candidate: string): void {
 	}
 }
 
-export async function sealCandidate(candidate: string): Promise<PublishedFile> {
+export async function sealCandidate(candidate: string): Promise<{ sha256: string; size: number }> {
 	await removeCandidateSidecars(candidate);
 	await fs.promises.chmod(candidate, 0o600);
 	await syncFile(candidate);
-	return sealedFile(candidate);
+	return hashFile(candidate, false);
 }
 
 export async function publishCandidate(
 	stage: string,
 	finalPath: string,
-	seal: PublishedFile,
 	onPublished: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
-	await publishNoReplace(stage, finalPath, seal, onPublished, hooks);
+	await publishNoReplace(stage, finalPath, onPublished, hooks);
 }
 
 export function manualNextStep(source: string, candidate: string, backup: string): string {

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -2,6 +2,7 @@ import { Database, constants as sqliteConstants } from "bun:sqlite";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { normalizePathForComparison } from "@oh-my-pi/pi-utils";
 import { type ArchiveMemberContent, archiveFileMember, extractFileBackedTar, writeArchive } from "../utils/zip";
 import type {
 	CanonicalSchemaObject,
@@ -401,20 +402,50 @@ async function canonicalNewPath(target: string): Promise<string> {
 	return canonical;
 }
 
+export type ArtifactPathComparisonMode = "platform" | "case-insensitive";
+
+export interface ResolveArtifactPathOptions {
+	comparisonMode?: ArtifactPathComparisonMode;
+	artifactSlug?: () => string;
+}
+
+function pathsAlias(left: string, right: string, comparisonMode: ArtifactPathComparisonMode): boolean {
+	const normalizedLeft = normalizePathForComparison(left).normalize("NFC");
+	const normalizedRight = normalizePathForComparison(right).normalize("NFC");
+	if (comparisonMode === "case-insensitive" || (comparisonMode === "platform" && process.platform === "darwin")) {
+		return (
+			normalizedLeft.toUpperCase().toLowerCase().normalize("NFC") ===
+			normalizedRight.toUpperCase().toLowerCase().normalize("NFC")
+		);
+	}
+	return normalizedLeft === normalizedRight;
+}
+
 export async function resolveArtifactPaths(
 	source: string,
 	output?: string,
+	options: ResolveArtifactPathOptions = {},
 ): Promise<{ backup: string; candidate: string }> {
-	const slug = `${new Date().toISOString().replace(/[-:.TZ]/gu, "")}-${crypto.randomUUID().slice(0, 8)}`;
+	const slug =
+		options.artifactSlug?.() ??
+		`${new Date().toISOString().replace(/[-:.TZ]/gu, "")}-${crypto.randomUUID().slice(0, 8)}`;
 	const candidate = await canonicalNewPath(output ?? `${source}.salvage-${slug}.db`);
 	const backup = await canonicalNewPath(`${source}.salvage-${slug}.tar`);
-	const canonicalSource = path.join(await fs.promises.realpath(path.dirname(source)), path.basename(source));
+	const sourceAbsolute = path.resolve(source);
+	const canonicalSource = path.join(
+		await fs.promises.realpath(path.dirname(sourceAbsolute)),
+		path.basename(sourceAbsolute),
+	);
+	const comparisonMode = options.comparisonMode ?? "platform";
 	const forbidden = [canonicalSource, `${canonicalSource}-wal`, `${canonicalSource}-shm`];
 	assertInvariant(
-		!forbidden.includes(candidate) && !forbidden.includes(backup),
+		!forbidden.some(
+			forbiddenPath =>
+				pathsAlias(candidate, forbiddenPath, comparisonMode) || pathsAlias(backup, forbiddenPath, comparisonMode),
+		),
 		"Repair artifact collides with source triplet",
 	);
-	assertInvariant(candidate !== backup, "Candidate and backup paths collide");
+	assertInvariant(!pathsAlias(candidate, backup, comparisonMode), "Candidate and backup paths collide");
 	return { backup, candidate };
 }
 

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -612,7 +612,16 @@ function backupManifestJson(manifest: SourceTripletManifest): string {
 				const member = manifest.members[role];
 				return [
 					role,
-					member ? { archiveName: member.archiveName, size: member.size, sha256: member.sha256 } : null,
+					member
+						? {
+								archiveName: member.archiveName,
+								size: member.size,
+								mode: member.mode,
+								uid: member.uid,
+								gid: member.gid,
+								sha256: member.sha256,
+							}
+						: null,
 				];
 			}),
 		),
@@ -728,6 +737,7 @@ export function manualNextStep(source: string, candidate: string, backup: string
 		`Move ${source}, ${source}-wal, and ${source}-shm together into a retained quarantine directory.`,
 		"Verify no old sidecar remains at the live basename.",
 		`Copy ${candidate} to an exclusively created mode-0600 sibling staging file, verify its checksum, fsync it, atomically no-replace-rename it to the now-vacant live main path, and sync the parent directory.`,
+		`If manually restoring ${backup}, extract every source member and apply its manifest.json recorded uid, gid, and mode; if ownership cannot be restored, use mode 0600 for that member instead.`,
 		`Keep the candidate, backup tar ${backup}, and quarantine until a normal reopen succeeds; the tar manifest documents byte-exact source restoration if needed. Never stream-copy directly into the live basename.`,
 	].join(" ");
 }

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -505,17 +505,36 @@ interface PublicationHooks {
 	onDirectorySync?: () => void;
 }
 
-interface PublishedFile {
-	dev: bigint;
+export interface PublishedFile { dev: bigint;
 	ino: bigint;
 	size: bigint;
-	sha256: string;
-}
+	sha256: string; }
 
 async function sealedFile(file: string): Promise<PublishedFile> {
 	const stat = await fs.promises.lstat(file, { bigint: true });
 	assertInvariant(stat.isFile() && !stat.isSymbolicLink(), `Publication stage is not a regular file: ${file}`);
-	return { dev: stat.dev, ino: stat.ino, size: stat.size, sha256: (await hashFile(file, false)).sha256 };
+	const digest = await hashFile(file, false);
+	const confirmed = await fs.promises.lstat(file, { bigint: true });
+	assertInvariant(
+		confirmed.isFile() &&
+			!confirmed.isSymbolicLink() &&
+			confirmed.dev === stat.dev &&
+			confirmed.ino === stat.ino &&
+			confirmed.size === stat.size,
+		`Publication stage changed while sealing: ${file}`,
+	);
+	return { dev: stat.dev, ino: stat.ino, size: stat.size, sha256: digest.sha256 };
+}
+
+async function verifySealedFile(file: string, expected: PublishedFile): Promise<void> {
+	const actual = await sealedFile(file);
+	assertInvariant(
+		actual.dev === expected.dev &&
+			actual.ino === expected.ino &&
+			actual.size === expected.size &&
+			actual.sha256 === expected.sha256,
+		`Publication stage changed after verification: ${file}`,
+	);
 }
 
 async function verifyPublishedFile(stage: string, finalPath: string, expected: PublishedFile): Promise<void> {
@@ -584,10 +603,11 @@ async function runPublicationHook(
 async function publishNoReplace(
 	stage: string,
 	finalPath: string,
+	expected: PublishedFile,
 	onPublished: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
-	const expected = await sealedFile(stage);
+	await verifySealedFile(stage, expected);
 	await fs.promises.link(stage, finalPath);
 	await verifyPublishedFile(stage, finalPath, expected);
 	await runPublicationHook(hooks.afterLink, stage, finalPath, expected, onPublished);
@@ -682,15 +702,15 @@ export async function publishBackup(
 	await fs.promises.chmod(stage, 0o600);
 	await verifyBackup(stage, snapshot.manifest, new Set(entries.map(([name]) => name)), snapshot.tempDir);
 	await syncFile(stage);
-	const digest = await hashFile(stage, false);
-	const checksum = { path: backup, ...digest, ephemeral: false };
+	const seal = await sealedFile(stage);
+	const checksum = { path: backup, sha256: seal.sha256, size: Number(seal.size), ephemeral: false };
 	let reported = false;
 	const report = () => {
 		if (reported) return;
 		reported = true;
 		onPublished(checksum);
 	};
-	await publishNoReplace(stage, backup, report, { afterLink, isWindows, onDirectorySync });
+	await publishNoReplace(stage, backup, seal, report, { afterLink, isWindows, onDirectorySync });
 	return checksum;
 }
 
@@ -718,20 +738,21 @@ export function verifyCommonCandidate(candidate: string): void {
 	}
 }
 
-export async function sealCandidate(candidate: string): Promise<{ sha256: string; size: number }> {
+export async function sealCandidate(candidate: string): Promise<PublishedFile> {
 	await removeCandidateSidecars(candidate);
 	await fs.promises.chmod(candidate, 0o600);
 	await syncFile(candidate);
-	return hashFile(candidate, false);
+	return sealedFile(candidate);
 }
 
 export async function publishCandidate(
 	stage: string,
 	finalPath: string,
+	seal: PublishedFile,
 	onPublished: () => void,
 	hooks: PublicationHooks = {},
 ): Promise<void> {
-	await publishNoReplace(stage, finalPath, onPublished, hooks);
+	await publishNoReplace(stage, finalPath, seal, onPublished, hooks);
 }
 
 export function manualNextStep(source: string, candidate: string, backup: string): string {

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -402,17 +402,21 @@ async function canonicalNewPath(target: string): Promise<string> {
 	return canonical;
 }
 
-export type ArtifactPathComparisonMode = "platform" | "case-insensitive";
+
 
 export interface ResolveArtifactPathOptions {
-	comparisonMode?: ArtifactPathComparisonMode;
 	artifactSlug?: () => string;
+	platform?: () => NodeJS.Platform;
 }
 
-function pathsAlias(left: string, right: string, comparisonMode: ArtifactPathComparisonMode): boolean {
+function caselessFilesystem(platform: NodeJS.Platform): boolean {
+	return platform === "darwin" || platform === "win32";
+}
+
+function pathsAlias(left: string, right: string, caseless: boolean): boolean {
 	const normalizedLeft = normalizePathForComparison(left).normalize("NFC");
 	const normalizedRight = normalizePathForComparison(right).normalize("NFC");
-	if (comparisonMode === "case-insensitive" || (comparisonMode === "platform" && process.platform === "darwin")) {
+	if (caseless) {
 		return (
 			normalizedLeft.toUpperCase().toLowerCase().normalize("NFC") ===
 			normalizedRight.toUpperCase().toLowerCase().normalize("NFC")
@@ -436,16 +440,15 @@ export async function resolveArtifactPaths(
 		await fs.promises.realpath(path.dirname(sourceAbsolute)),
 		path.basename(sourceAbsolute),
 	);
-	const comparisonMode = options.comparisonMode ?? "platform";
+	const caseless = caselessFilesystem(options.platform?.() ?? process.platform);
 	const forbidden = [canonicalSource, `${canonicalSource}-wal`, `${canonicalSource}-shm`];
 	assertInvariant(
 		!forbidden.some(
-			forbiddenPath =>
-				pathsAlias(candidate, forbiddenPath, comparisonMode) || pathsAlias(backup, forbiddenPath, comparisonMode),
+			forbiddenPath => pathsAlias(candidate, forbiddenPath, caseless) || pathsAlias(backup, forbiddenPath, caseless),
 		),
 		"Repair artifact collides with source triplet",
 	);
-	assertInvariant(!pathsAlias(candidate, backup, comparisonMode), "Candidate and backup paths collide");
+	assertInvariant(!pathsAlias(candidate, backup, caseless), "Candidate and backup paths collide");
 	return { backup, candidate };
 }
 

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -23,6 +23,13 @@ interface SchemaObjectRow {
 	sql: string | null;
 }
 
+export interface RawSchemaDefinition {
+	kind: string;
+	name: string;
+	table: string;
+	sql: string | null;
+}
+
 type SqliteValue = string | number | bigint | Uint8Array | null;
 
 interface SnapshotFingerprint {
@@ -83,8 +90,47 @@ function sqliteRows(db: Database, sql: string, ...bindings: SqliteValue[]): Arra
 
 function schemaObjects(db: Database): SchemaObjectRow[] {
 	return db
-		.prepare("SELECT type, name, tbl_name, sql FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name")
+		.prepare(
+			"SELECT type, name, tbl_name, sql FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY type COLLATE BINARY, name COLLATE BINARY",
+		)
 		.all() as SchemaObjectRow[];
+}
+
+export function rawSchemaDefinitions(candidate: string): RawSchemaDefinition[] {
+	const db = new Database(candidate, { readonly: true, safeIntegers: true });
+	try {
+		return schemaObjects(db).map(object => ({
+			kind: object.type,
+			name: object.name,
+			table: object.tbl_name,
+			sql: object.sql,
+		}));
+	} finally {
+		db.close();
+	}
+}
+
+export function verifyRawSchemaDefinitions(candidate: string, expected: readonly RawSchemaDefinition[]): void {
+	const actual = rawSchemaDefinitions(candidate);
+	const key = (object: RawSchemaDefinition) => JSON.stringify([object.kind, object.name]);
+	const expectedByKey = new Map(expected.map(object => [key(object), object]));
+	const actualByKey = new Map(actual.map(object => [key(object), object]));
+	assertInvariant(expectedByKey.size === expected.length, "Candidate expected sqlite_schema has duplicate objects");
+	assertInvariant(actualByKey.size === actual.length, "Candidate sqlite_schema has duplicate objects");
+	for (const object of expected) {
+		const observed = actualByKey.get(key(object));
+		assertInvariant(observed, `Candidate sqlite_schema is missing ${object.kind} ${object.name}`);
+		assertInvariant(
+			stableJson(observed) === stableJson(object),
+			`Candidate sqlite_schema definition differs for ${object.kind} ${object.name}`,
+		);
+	}
+	for (const object of actual) {
+		assertInvariant(
+			expectedByKey.has(key(object)),
+			`Candidate sqlite_schema has unexpected ${object.kind} ${object.name}`,
+		);
+	}
 }
 
 function canonicalTable(db: Database, object: SchemaObjectRow): CanonicalSchemaObject {
@@ -105,7 +151,7 @@ function canonicalTable(db: Database, object: SchemaObjectRow): CanonicalSchemaO
 			columns: sqliteRows(db, "SELECT * FROM pragma_index_xinfo(?) ORDER BY seqno", name).map(canonicalRow),
 		};
 	});
-	if (object.sql && /\b(?:check|collate|generated|without\s+rowid|strict|using)\b/iu.test(object.sql)) {
+	if (object.sql && /\b(?:check|collate|generated|without\s+rowid|strict|using|autoincrement)\b/iu.test(object.sql)) {
 		item.sql = normalizeSql(object.sql);
 	}
 	return item;
@@ -744,6 +790,10 @@ export async function sealCandidate(candidate: string): Promise<PublishedFile> {
 	return sealedFile(candidate);
 }
 
+export async function verifyCandidateSeal(candidate: string, seal: PublishedFile): Promise<void> {
+	await verifySealedFile(candidate, seal);
+}
+
 export async function publishCandidate(
 	stage: string,
 	finalPath: string,
@@ -754,7 +804,27 @@ export async function publishCandidate(
 	await publishNoReplace(stage, finalPath, seal, onLinked, hooks);
 }
 
-export function manualNextStep(source: string, candidate: string, backup: string): string {
+export interface ManualRepairState {
+	status: "ready" | "refused" | "published-with-warning";
+	apply: boolean;
+	backupCreated: boolean;
+	candidatePublished: boolean;
+	candidatePathTrusted: boolean;
+}
+
+export function manualNextStep(source: string, candidate: string, backup: string, state: ManualRepairState): string {
+	if (state.status === "refused") {
+		return `Repair was refused. Do not install ${candidate}.${state.backupCreated ? ` Retain verified backup ${backup}.` : ""}`;
+	}
+	if (!state.apply) {
+		return `Dry run only: no candidate was published. Do not install ${candidate}; rerun with --apply only after reviewing the refusal-free result.`;
+	}
+	if (!state.candidatePublished) {
+		return `No candidate was published. Do not install ${candidate}.${state.backupCreated ? ` Retain verified backup ${backup}.` : ""}`;
+	}
+	if (!state.candidatePathTrusted) {
+		return `Published candidate ${candidate} failed final trust checks. Do not install it.${state.backupCreated ? ` Retain verified backup ${backup}.` : ""}`;
+	}
 	return [
 		"Stop every OMP process.",
 		`Move ${source}, ${source}-wal, and ${source}-shm together into a retained quarantine directory.`,

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -621,7 +621,11 @@ async function publishNoReplace(
 	onLinked();
 	await verifyPublishedFile(stage, finalPath, expected);
 	await runPublicationHook(hooks.afterLink, () => verifyPublishedFile(stage, finalPath, expected), onPublished);
-	await runPublicationHook(hooks.beforeStageUnlink, () => verifyPublishedFile(stage, finalPath, expected), onPublished);
+	await runPublicationHook(
+		hooks.beforeStageUnlink,
+		() => verifyPublishedFile(stage, finalPath, expected),
+		onPublished,
+	);
 	await fs.promises.unlink(stage);
 	onPublished?.();
 	await runPublicationHook(hooks.beforeDirectorySync, () => verifyFinalFile(finalPath, expected), onPublished);

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -407,20 +407,28 @@ export interface ResolveArtifactPathOptions {
 	platform?: () => NodeJS.Platform;
 }
 
-function caselessFilesystem(platform: NodeJS.Platform): boolean {
-	return platform === "darwin" || platform === "win32";
+type PathComparisonMode = "posix" | "darwin" | "win32";
+
+function pathComparisonMode(platform: NodeJS.Platform): PathComparisonMode {
+	if (platform === "win32") return "win32";
+	if (platform === "darwin") return "darwin";
+	return "posix";
 }
 
-function pathsAlias(left: string, right: string, caseless: boolean): boolean {
-	const normalizedLeft = normalizePathForComparison(left).normalize("NFC");
-	const normalizedRight = normalizePathForComparison(right).normalize("NFC");
-	if (caseless) {
-		return (
-			normalizedLeft.toUpperCase().toLowerCase().normalize("NFC") ===
-			normalizedRight.toUpperCase().toLowerCase().normalize("NFC")
-		);
+function pathComparisonKey(target: string, mode: PathComparisonMode): string {
+	let normalized = normalizePathForComparison(target).normalize("NFC");
+	if (mode === "win32") {
+		// Inputs are canonical: path.resolve plus realpath(parent) means dot parents cannot survive here.
+		normalized = normalized
+			.split(path.sep)
+			.map(component => component.replace(/[. ]+$/u, ""))
+			.join(path.sep);
 	}
-	return normalizedLeft === normalizedRight;
+	return mode === "posix" ? normalized : normalized.toUpperCase().toLowerCase().normalize("NFC");
+}
+
+function pathsAlias(left: string, right: string, mode: PathComparisonMode): boolean {
+	return pathComparisonKey(left, mode) === pathComparisonKey(right, mode);
 }
 
 export async function resolveArtifactPaths(
@@ -438,15 +446,15 @@ export async function resolveArtifactPaths(
 		await fs.promises.realpath(path.dirname(sourceAbsolute)),
 		path.basename(sourceAbsolute),
 	);
-	const caseless = caselessFilesystem(options.platform?.() ?? process.platform);
+	const mode = pathComparisonMode(options.platform?.() ?? process.platform);
 	const forbidden = [canonicalSource, `${canonicalSource}-wal`, `${canonicalSource}-shm`];
 	assertInvariant(
 		!forbidden.some(
-			forbiddenPath => pathsAlias(candidate, forbiddenPath, caseless) || pathsAlias(backup, forbiddenPath, caseless),
+			forbiddenPath => pathsAlias(candidate, forbiddenPath, mode) || pathsAlias(backup, forbiddenPath, mode),
 		),
 		"Repair artifact collides with source triplet",
 	);
-	assertInvariant(!pathsAlias(candidate, backup, caseless), "Candidate and backup paths collide");
+	assertInvariant(!pathsAlias(candidate, backup, mode), "Candidate and backup paths collide");
 	return { backup, candidate };
 }
 

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -347,7 +347,7 @@ export async function sourceStillMatches(pre: SourceTripletManifest): Promise<vo
 export async function preparePristineSnapshot(
 	source: string,
 	inspectSqlite: boolean,
-	afterPristineCopy?: (tempDir: string) => void | Promise<void>,
+	afterPristineCopy?: () => void | Promise<void>,
 ): Promise<PristineSnapshot> {
 	const manifest = await manifestTriplet(source);
 	const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-storage-repair-"));
@@ -359,7 +359,7 @@ export async function preparePristineSnapshot(
 		await fs.promises.mkdir(workingDir, { mode: 0o700 });
 		const pristine = await copyTriplet(manifest, pristineDir, true);
 		await sealTriplet(manifest, pristine);
-		await afterPristineCopy?.(tempDir);
+		await afterPristineCopy?.();
 		await sourceStillMatches(manifest);
 		const copiedManifest: SourceTripletManifest = {
 			...manifest,

--- a/packages/coding-agent/src/cli/storage-repair-files.ts
+++ b/packages/coding-agent/src/cli/storage-repair-files.ts
@@ -1,0 +1,597 @@
+import { Database, constants as sqliteConstants } from "bun:sqlite";
+import { type BigIntStats, constants as fsConstants, type Stats } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type ArchiveMemberContent, archiveFileMember, extractFileBackedTar, writeArchive } from "../utils/zip";
+import type {
+	CanonicalSchemaObject,
+	FrozenSqliteSnapshot,
+	PristineSnapshot,
+	SourceMemberManifest,
+	SourceTripletManifest,
+	StorageRepairChecksum,
+} from "./storage-repair-types";
+
+const COPY_BUFFER_BYTES = 1024 * 1024;
+const BACKUP_MANIFEST_NAME = "manifest.json";
+
+interface SchemaObjectRow {
+	type: string;
+	name: string;
+	tbl_name: string;
+	sql: string | null;
+}
+
+type SqliteValue = string | number | bigint | Uint8Array | null;
+
+interface SnapshotFingerprint {
+	schema: CanonicalSchemaObject[];
+	versions: Record<string, string[]>;
+	corruption: string[];
+}
+
+export function errorMessage(error: unknown): string {
+	if (error instanceof AggregateError) {
+		return `${error.message}: ${error.errors.map(errorMessage).join("; ")}`;
+	}
+	return error instanceof Error ? error.message : String(error);
+}
+
+function codeOf(error: unknown): string | undefined {
+	if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
+	const code = error.code;
+	return typeof code === "string" ? code : undefined;
+}
+
+export function assertInvariant(condition: unknown, message: string): asserts condition {
+	if (!condition) throw new Error(message);
+}
+
+export function stableJson(value: unknown): string {
+	return JSON.stringify(value, (_key, current: unknown) =>
+		typeof current === "bigint" ? current.toString() : current,
+	);
+}
+
+function numberFromBigInt(value: bigint, label: string): number {
+	const result = Number(value);
+	assertInvariant(Number.isSafeInteger(result), `${label} exceeds JavaScript's safe integer range`);
+	return result;
+}
+
+function normalizeSql(sql: string): string {
+	return sql
+		.trim()
+		.replace(/\s+/gu, " ")
+		.replace(/\s*([(),=])\s*/gu, "$1")
+		.toLowerCase();
+}
+
+function canonicalRow(row: Record<string, unknown>): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+	for (const key of Object.keys(row).sort()) {
+		const value = row[key];
+		result[key] = typeof value === "bigint" ? value.toString() : value;
+	}
+	return result;
+}
+
+function sqliteRows(db: Database, sql: string, ...bindings: SqliteValue[]): Array<Record<string, unknown>> {
+	return db.prepare(sql).all(...bindings) as Array<Record<string, unknown>>;
+}
+
+function schemaObjects(db: Database): SchemaObjectRow[] {
+	return db
+		.prepare("SELECT type, name, tbl_name, sql FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name")
+		.all() as SchemaObjectRow[];
+}
+
+function canonicalTable(db: Database, object: SchemaObjectRow): CanonicalSchemaObject {
+	const item: CanonicalSchemaObject = {
+		kind: object.type,
+		name: object.name,
+		table: object.tbl_name,
+		columns: sqliteRows(db, "SELECT * FROM pragma_table_xinfo(?) ORDER BY cid", object.name).map(canonicalRow),
+		foreignKeys: sqliteRows(db, "SELECT * FROM pragma_foreign_key_list(?) ORDER BY id, seq", object.name).map(
+			canonicalRow,
+		),
+	};
+	item.indexes = sqliteRows(db, "SELECT * FROM pragma_index_list(?) ORDER BY name", object.name).map(index => {
+		const name = index.name;
+		assertInvariant(typeof name === "string", `Invalid index metadata for ${object.name}`);
+		return {
+			...canonicalRow(index),
+			columns: sqliteRows(db, "SELECT * FROM pragma_index_xinfo(?) ORDER BY seqno", name).map(canonicalRow),
+		};
+	});
+	if (object.sql && /\b(?:check|collate|generated|without\s+rowid|strict|using)\b/iu.test(object.sql)) {
+		item.sql = normalizeSql(object.sql);
+	}
+	return item;
+}
+
+export function canonicalSchema(db: Database): CanonicalSchemaObject[] {
+	return schemaObjects(db).map(object => {
+		if (object.type === "table") return canonicalTable(db, object);
+		const item: CanonicalSchemaObject = { kind: object.type, name: object.name, table: object.tbl_name };
+		if (object.type === "trigger" || object.type === "view") {
+			assertInvariant(typeof object.sql === "string", `Missing SQL for ${object.type} ${object.name}`);
+			item.sql = normalizeSql(object.sql);
+		} else if (object.type === "index" && object.sql && /\bwhere\b|\([^)]*\([^)]*\)/iu.test(object.sql)) {
+			item.sql = normalizeSql(object.sql);
+		}
+		return item;
+	});
+}
+
+function versionManifest(db: Database): Record<string, string[]> {
+	const result: Record<string, string[]> = {};
+	for (const table of ["schema_version", "auth_schema_version"] as const) {
+		const exists = db.prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?").get(table);
+		if (!exists) continue;
+		const rows =
+			table === "schema_version"
+				? sqliteRows(db, "SELECT version FROM schema_version ORDER BY version")
+				: sqliteRows(db, "SELECT id, version FROM auth_schema_version ORDER BY id");
+		result[table] = rows.map(stableJson);
+	}
+	return result;
+}
+
+function corruptionManifest(db: Database): string[] {
+	try {
+		return db
+			.prepare("PRAGMA integrity_check")
+			.values()
+			.map(row => String(row[0]))
+			.sort();
+	} catch (error) {
+		return [`error: ${errorMessage(error)}`];
+	}
+}
+
+function inspect(db: Database): SnapshotFingerprint {
+	return { schema: canonicalSchema(db), versions: versionManifest(db), corruption: corruptionManifest(db) };
+}
+
+function openImmutableSnapshot(workingMain: string): FrozenSqliteSnapshot {
+	const working = new Database(workingMain, { safeIntegers: true });
+	let serialized: Buffer | null = null;
+	let before: SnapshotFingerprint | null = null;
+	try {
+		try {
+			working.exec("BEGIN");
+			working.prepare("SELECT rootpage FROM sqlite_schema ORDER BY rootpage").all();
+			before = inspect(working);
+			if (working.inTransaction) working.exec("ROLLBACK");
+		} catch (error) {
+			if (!working.inTransaction) throw error;
+			try {
+				working.exec("ROLLBACK");
+			} catch (rollbackError) {
+				throw new AggregateError([error, rollbackError], "Working SQLite snapshot failed and rollback also failed");
+			}
+			throw error;
+		}
+		working.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+		working.exec("PRAGMA journal_mode=DELETE");
+		serialized = working.serialize();
+	} finally {
+		working.close();
+	}
+	assertInvariant(serialized && before, "Working SQLite snapshot did not serialize");
+	const immutable = Database.deserialize(serialized, { readonly: true, safeIntegers: true });
+	const after = inspect(immutable);
+	if (stableJson(before) === stableJson(after)) return { db: immutable, ...after };
+	immutable.close();
+	throw new Error("Serialized SQLite snapshot changed its schema/version/corruption manifest");
+}
+
+async function lstatIfPresent(target: string): Promise<Stats | null> {
+	try {
+		return await fs.lstat(target);
+	} catch (error) {
+		if (codeOf(error) === "ENOENT") return null;
+		throw error;
+	}
+}
+
+async function openSourceNoAtime(file: string): Promise<fs.FileHandle> {
+	const noAtime = fsConstants.O_NOATIME ?? 0;
+	try {
+		return await fs.open(file, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | noAtime);
+	} catch (error) {
+		if (noAtime === 0 || (codeOf(error) !== "EPERM" && codeOf(error) !== "EINVAL")) throw error;
+		return fs.open(file, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+	}
+}
+
+async function hashHandle(handle: fs.FileHandle): Promise<{ sha256: string; size: number }> {
+	const hash = new Bun.SHA256();
+	const buffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
+	let position = 0;
+	for (;;) {
+		const { bytesRead } = await handle.read(buffer, 0, buffer.byteLength, position);
+		if (bytesRead === 0) return { sha256: hash.digest("hex"), size: position };
+		hash.update(buffer.subarray(0, bytesRead));
+		position += bytesRead;
+	}
+}
+
+async function hashFile(file: string, source: boolean): Promise<{ sha256: string; size: number }> {
+	const handle = source ? await openSourceNoAtime(file) : await fs.open(file, "r");
+	try {
+		return await hashHandle(handle);
+	} finally {
+		await handle.close();
+	}
+}
+
+async function manifestMember(
+	role: "main" | "wal" | "shm",
+	file: string,
+	archiveName: string,
+): Promise<SourceMemberManifest | null> {
+	let stat: BigIntStats;
+	try {
+		stat = await fs.lstat(file, { bigint: true });
+	} catch (error) {
+		if (codeOf(error) === "ENOENT") return null;
+		throw error;
+	}
+	assertInvariant(stat.isFile() && !stat.isSymbolicLink(), `Source ${role} is not a regular file: ${file}`);
+	const digest = await hashFile(file, true);
+	assertInvariant(digest.size === numberFromBigInt(stat.size, `${role} size`), `Source ${role} changed while hashing`);
+	return {
+		role,
+		path: file,
+		archiveName,
+		dev: stat.dev.toString(),
+		ino: stat.ino.toString(),
+		size: digest.size,
+		mtimeNs: stat.mtimeNs.toString(),
+		ctimeNs: stat.ctimeNs.toString(),
+		mode: Number(stat.mode & 0o7777n),
+		uid: stat.uid.toString(),
+		gid: stat.gid.toString(),
+		sha256: digest.sha256,
+	};
+}
+
+async function manifestTriplet(source: string): Promise<SourceTripletManifest> {
+	const basename = path.basename(source);
+	const members = {
+		main: await manifestMember("main", source, `source/${basename}`),
+		wal: await manifestMember("wal", `${source}-wal`, `source/${basename}-wal`),
+		shm: await manifestMember("shm", `${source}-shm`, `source/${basename}-shm`),
+	};
+	assertInvariant(members.main, `Storage source does not exist: ${source}`);
+	return { version: 1, source, members };
+}
+
+async function copyAndHash(
+	source: string,
+	destination: string,
+	sourceNoAtime: boolean,
+): Promise<StorageRepairChecksum> {
+	const input = sourceNoAtime ? await openSourceNoAtime(source) : await fs.open(source, "r");
+	const output = await fs.open(destination, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL, 0o600);
+	const hash = new Bun.SHA256();
+	const buffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
+	let position = 0;
+	try {
+		for (;;) {
+			const { bytesRead } = await input.read(buffer, 0, buffer.byteLength, position);
+			if (bytesRead === 0) break;
+			const chunk = buffer.subarray(0, bytesRead);
+			let written = 0;
+			while (written < bytesRead) {
+				const result = await output.write(chunk, written, bytesRead - written, position + written);
+				assertInvariant(result.bytesWritten > 0, `Short write while copying ${source}`);
+				written += result.bytesWritten;
+			}
+			hash.update(chunk);
+			position += bytesRead;
+		}
+		await output.sync();
+	} finally {
+		await output.close();
+		await input.close();
+	}
+	return { path: destination, sha256: hash.digest("hex"), size: position };
+}
+
+async function copyTriplet(
+	manifest: SourceTripletManifest,
+	destinationDir: string,
+	sourceNoAtime: boolean,
+): Promise<Record<"main" | "wal" | "shm", string | null>> {
+	const result: Record<"main" | "wal" | "shm", string | null> = { main: null, wal: null, shm: null };
+	for (const role of ["main", "wal", "shm"] as const) {
+		const member = manifest.members[role];
+		if (!member) continue;
+		const destination = path.join(destinationDir, path.basename(member.path));
+		const copied = await copyAndHash(member.path, destination, sourceNoAtime);
+		assertInvariant(copied.sha256 === member.sha256 && copied.size === member.size, `Unstable ${role} snapshot`);
+		result[role] = destination;
+	}
+	return result;
+}
+
+async function sealTriplet(
+	manifest: SourceTripletManifest,
+	paths: Record<"main" | "wal" | "shm", string | null>,
+): Promise<void> {
+	for (const role of ["main", "wal", "shm"] as const) {
+		const member = manifest.members[role];
+		const file = paths[role];
+		assertInvariant((member === null) === (file === null), `Snapshot ${role} membership mismatch`);
+		if (!member || !file) continue;
+		const digest = await hashFile(file, false);
+		assertInvariant(digest.sha256 === member.sha256 && digest.size === member.size, `Snapshot ${role} seal mismatch`);
+	}
+}
+
+export async function sourceStillMatches(pre: SourceTripletManifest): Promise<void> {
+	assertInvariant(
+		stableJson(pre) === stableJson(await manifestTriplet(pre.source)),
+		"Live source triplet changed during storage repair",
+	);
+}
+
+export async function preparePristineSnapshot(
+	source: string,
+	inspectSqlite: boolean,
+	afterPristineCopy?: () => void | Promise<void>,
+): Promise<PristineSnapshot> {
+	const manifest = await manifestTriplet(source);
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-storage-repair-"));
+	try {
+		await fs.chmod(tempDir, 0o700);
+		const pristineDir = path.join(tempDir, "pristine");
+		const workingDir = path.join(tempDir, "working");
+		await fs.mkdir(pristineDir, { mode: 0o700 });
+		await fs.mkdir(workingDir, { mode: 0o700 });
+		const pristine = await copyTriplet(manifest, pristineDir, true);
+		await sealTriplet(manifest, pristine);
+		await afterPristineCopy?.();
+		await sourceStillMatches(manifest);
+		const copiedManifest: SourceTripletManifest = {
+			...manifest,
+			members: {
+				main: manifest.members.main ? { ...manifest.members.main, path: pristine.main ?? "" } : null,
+				wal: manifest.members.wal ? { ...manifest.members.wal, path: pristine.wal ?? "" } : null,
+				shm: manifest.members.shm ? { ...manifest.members.shm, path: pristine.shm ?? "" } : null,
+			},
+		};
+		const working = await copyTriplet(copiedManifest, workingDir, false);
+		await sealTriplet(manifest, working);
+		assertInvariant(working.main, "Working main database is missing");
+		return {
+			tempDir,
+			manifest,
+			paths: pristine,
+			immutable: inspectSqlite ? openImmutableSnapshot(working.main) : null,
+		};
+	} catch (error) {
+		await fs.rm(tempDir, { recursive: true, force: true });
+		throw error;
+	}
+}
+
+export async function cleanupSnapshot(snapshot: PristineSnapshot | null): Promise<void> {
+	if (!snapshot) return;
+	try {
+		snapshot.immutable?.db.close();
+	} finally {
+		await fs.rm(snapshot.tempDir, { recursive: true, force: true });
+	}
+}
+
+async function canonicalNewPath(target: string): Promise<string> {
+	const absolute = path.resolve(target);
+	assertInvariant((await lstatIfPresent(absolute)) === null, `Repair output already exists: ${absolute}`);
+	const parent = await fs.realpath(path.dirname(absolute));
+	const canonical = path.join(parent, path.basename(absolute));
+	assertInvariant((await lstatIfPresent(canonical)) === null, `Repair output already exists: ${canonical}`);
+	return canonical;
+}
+
+export async function resolveArtifactPaths(
+	source: string,
+	output?: string,
+): Promise<{ backup: string; candidate: string }> {
+	const slug = `${new Date().toISOString().replace(/[-:.TZ]/gu, "")}-${crypto.randomUUID().slice(0, 8)}`;
+	const candidate = await canonicalNewPath(output ?? `${source}.salvage-${slug}.db`);
+	const backup = await canonicalNewPath(`${source}.salvage-${slug}.tar`);
+	const canonicalSource = path.join(await fs.realpath(path.dirname(source)), path.basename(source));
+	const forbidden = [canonicalSource, `${canonicalSource}-wal`, `${canonicalSource}-shm`];
+	assertInvariant(
+		!forbidden.includes(candidate) && !forbidden.includes(backup),
+		"Repair artifact collides with source triplet",
+	);
+	assertInvariant(candidate !== backup, "Candidate and backup paths collide");
+	return { backup, candidate };
+}
+
+export async function exclusiveStage(finalPath: string, label: string): Promise<string> {
+	const stage = path.join(path.dirname(finalPath), `.${path.basename(finalPath)}.${label}-${crypto.randomUUID()}.tmp`);
+	const handle = await fs.open(stage, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL, 0o600);
+	await handle.close();
+	return stage;
+}
+
+export async function removeOwnedFile(target: string | null): Promise<void> {
+	if (!target) return;
+	try {
+		await fs.unlink(target);
+	} catch (error) {
+		if (codeOf(error) !== "ENOENT") throw error;
+	}
+}
+
+export async function removeCandidateSidecars(candidate: string): Promise<void> {
+	await removeOwnedFile(`${candidate}-wal`);
+	await removeOwnedFile(`${candidate}-shm`);
+}
+
+async function syncFile(file: string): Promise<void> {
+	const handle = await fs.open(file, "r");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+async function syncDirectory(dir: string): Promise<void> {
+	const handle = await fs.open(dir, "r");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+interface PublicationHooks {
+	afterLink?: () => void | Promise<void>;
+	beforeStageUnlink?: () => void | Promise<void>;
+	beforeDirectorySync?: () => void | Promise<void>;
+}
+
+async function publishNoReplace(
+	stage: string,
+	finalPath: string,
+	onPublished: () => void,
+	hooks: PublicationHooks = {},
+): Promise<void> {
+	await fs.link(stage, finalPath);
+	onPublished();
+	await hooks.afterLink?.();
+	await hooks.beforeStageUnlink?.();
+	await fs.unlink(stage);
+	await hooks.beforeDirectorySync?.();
+	await syncDirectory(path.dirname(finalPath));
+}
+
+function backupManifestJson(manifest: SourceTripletManifest): string {
+	return `${stableJson({
+		formatVersion: 1,
+		source: manifest.source,
+		members: Object.fromEntries(
+			(["main", "wal", "shm"] as const).map(role => {
+				const member = manifest.members[role];
+				return [
+					role,
+					member ? { archiveName: member.archiveName, size: member.size, sha256: member.sha256 } : null,
+				];
+			}),
+		),
+	})}\n`;
+}
+
+async function verifyBackup(
+	stage: string,
+	manifest: SourceTripletManifest,
+	names: Set<string>,
+	tempDir: string,
+): Promise<void> {
+	const verificationDir = await fs.mkdtemp(path.join(tempDir, "backup-verify-"));
+	try {
+		const archiveStat = await fs.stat(stage);
+		const extracted = await extractFileBackedTar(stage, archiveStat.size, verificationDir);
+		assertInvariant(extracted === names.size, "Backup archive contains unexpected members");
+		const manifestPath = path.join(verificationDir, BACKUP_MANIFEST_NAME);
+		assertInvariant(
+			(await fs.readFile(manifestPath, "utf8")) === backupManifestJson(manifest),
+			"Backup manifest verification failed",
+		);
+		for (const role of ["main", "wal", "shm"] as const) {
+			const member = manifest.members[role];
+			if (!member) continue;
+			const digest = await hashFile(path.join(verificationDir, member.archiveName), false);
+			assertInvariant(
+				digest.size === member.size && digest.sha256 === member.sha256,
+				`Backup member verification failed: ${member.archiveName}`,
+			);
+		}
+	} finally {
+		await fs.rm(verificationDir, { recursive: true, force: true });
+	}
+}
+
+export async function publishBackup(
+	stage: string,
+	backup: string,
+	snapshot: PristineSnapshot,
+	onPublished: (checksum: StorageRepairChecksum) => void,
+	afterLink?: () => void | Promise<void>,
+): Promise<StorageRepairChecksum> {
+	const entries: Array<readonly [string, ArchiveMemberContent]> = [
+		[BACKUP_MANIFEST_NAME, backupManifestJson(snapshot.manifest)],
+	];
+	for (const role of ["main", "wal", "shm"] as const) {
+		const member = snapshot.manifest.members[role];
+		const file = snapshot.paths[role];
+		if (member && file) entries.push([member.archiveName, archiveFileMember(file, member.size)]);
+	}
+	await writeArchive(stage, "tar", entries);
+	await fs.chmod(stage, 0o600);
+	await verifyBackup(stage, snapshot.manifest, new Set(entries.map(([name]) => name)), snapshot.tempDir);
+	await syncFile(stage);
+	const digest = await hashFile(stage, false);
+	const checksum = { path: backup, ...digest };
+	await publishNoReplace(stage, backup, () => onPublished(checksum), { afterLink });
+	return checksum;
+}
+
+export function checkpointCandidate(candidate: string): void {
+	const db = new Database(candidate);
+	try {
+		db.fileControl(sqliteConstants.SQLITE_FCNTL_PERSIST_WAL, 0);
+		db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+	} finally {
+		db.close();
+	}
+}
+
+export function verifyCommonCandidate(candidate: string): void {
+	const db = new Database(candidate, { readonly: true, safeIntegers: true });
+	try {
+		const integrity = db.prepare("PRAGMA integrity_check").values();
+		assertInvariant(
+			integrity.length === 1 && integrity[0]?.[0] === "ok",
+			`Candidate integrity_check failed: ${stableJson(integrity)}`,
+		);
+		assertInvariant(db.prepare("PRAGMA foreign_key_check").all().length === 0, "Candidate foreign_key_check failed");
+	} finally {
+		db.close();
+	}
+}
+
+export async function sealCandidate(candidate: string): Promise<{ sha256: string; size: number }> {
+	await removeCandidateSidecars(candidate);
+	await fs.chmod(candidate, 0o600);
+	await syncFile(candidate);
+	return hashFile(candidate, false);
+}
+
+export async function publishCandidate(
+	stage: string,
+	finalPath: string,
+	onPublished: () => void,
+	hooks: PublicationHooks = {},
+): Promise<void> {
+	await publishNoReplace(stage, finalPath, onPublished, hooks);
+}
+
+export function manualNextStep(source: string, candidate: string, backup: string): string {
+	return [
+		"Stop every OMP process.",
+		`Move ${source}, ${source}-wal, and ${source}-shm together into a retained quarantine directory.`,
+		"Verify no old sidecar remains at the live basename.",
+		`Copy ${candidate} to an exclusively created mode-0600 sibling staging file, verify its checksum, fsync it, atomically no-replace-rename it to the now-vacant live main path, and sync the parent directory.`,
+		`Keep the candidate, backup tar ${backup}, and quarantine until a normal reopen succeeds; the tar manifest documents byte-exact source restoration if needed. Never stream-copy directly into the live basename.`,
+	].join(" ");
+}

--- a/packages/coding-agent/src/cli/storage-repair-history.ts
+++ b/packages/coding-agent/src/cli/storage-repair-history.ts
@@ -2,14 +2,13 @@ import { Database } from "bun:sqlite";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as readline from "node:readline";
-import { getSessionsDir } from "@oh-my-pi/pi-utils";
+import { getSessionsDir, parseJsonlLenient } from "@oh-my-pi/pi-utils";
 import { HistoryStorage } from "../session/history-storage";
 import { CURRENT_SESSION_VERSION, SESSION_TITLE_SLOT_BYTES } from "../session/session-entries";
 import { parseTitleSlotLine } from "../session/session-title-slot";
 import {
 	assertInvariant,
 	checkpointCandidate,
-	errorMessage,
 	stableJson,
 	verifyCommonCandidate,
 } from "./storage-repair-files";
@@ -113,12 +112,8 @@ async function manifestSessions(root: string) {
 }
 
 function parseJsonRecord(line: string, file: string, ordinal: number) {
-	let value: unknown;
-	try {
-		value = JSON.parse(line);
-	} catch (error) {
-		throw new Error(`Malformed JSONL record ${ordinal} in ${file}: ${errorMessage(error)}`, { cause: error });
-	}
+	const [value] = parseJsonlLenient<unknown>(`${line}\n`);
+	if (value === undefined) return null;
 	assertInvariant(
 		typeof value === "object" && value !== null && !Array.isArray(value),
 		`Invalid JSONL record ${ordinal} in ${file}`,
@@ -189,6 +184,7 @@ async function parseSession(file: SessionFileManifest, promptDb: Database) {
 				if (parseTitleSlotLine(line)) continue;
 			}
 			const record = parseJsonRecord(line, file.path, physicalLine);
+			if (!record) continue;
 			if (!header) {
 				header = validateHeader(record, file.path);
 				continue;

--- a/packages/coding-agent/src/cli/storage-repair-history.ts
+++ b/packages/coding-agent/src/cli/storage-repair-history.ts
@@ -1,0 +1,399 @@
+import { Database } from "bun:sqlite";
+import { createReadStream, type Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as readline from "node:readline";
+import { getSessionsDir } from "@oh-my-pi/pi-utils";
+import { HistoryStorage } from "../session/history-storage";
+import { CURRENT_SESSION_VERSION, SESSION_TITLE_SLOT_BYTES } from "../session/session-entries";
+import { parseTitleSlotLine } from "../session/session-title-slot";
+import {
+	assertInvariant,
+	checkpointCandidate,
+	errorMessage,
+	stableJson,
+	verifyCommonCandidate,
+} from "./storage-repair-files";
+import type { HistoryRepairSource, StorageRepairObjectResult, StorageRepairTestHooks } from "./storage-repair-types";
+
+const COPY_BUFFER_BYTES = 1024 * 1024;
+const ROW_BATCH_SIZE = 256;
+
+interface SessionFileManifest {
+	path: string;
+	canonicalPath: string;
+	dev: string;
+	ino: string;
+	size: number;
+	mtimeNs: string;
+	ctimeNs: string;
+	sha256: string;
+}
+
+interface PromptRow {
+	entry_ms: bigint;
+	canonical_path: string;
+	ordinal: bigint;
+	prompt: string;
+	cwd: string;
+	session_id: string;
+}
+
+export interface PromptManifest {
+	db: Database;
+	path: string;
+	count: number;
+}
+
+function codeOf(error: unknown) {
+	if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
+	return typeof error.code === "string" ? error.code : undefined;
+}
+
+async function sessionFiles(root: string) {
+	const result: string[] = [];
+	async function visit(dir: string): Promise<void> {
+		let entries: Dirent[];
+		try {
+			entries = await fs.readdir(dir, { withFileTypes: true });
+		} catch (error) {
+			if (codeOf(error) === "ENOENT" && dir === root) return;
+			throw error;
+		}
+		for (const entry of entries) {
+			const file = path.join(dir, entry.name);
+			assertInvariant(!entry.isSymbolicLink(), `Session manifest refuses symbolic link: ${file}`);
+			if (entry.isDirectory()) await visit(file);
+			else if (entry.isFile() && entry.name.endsWith(".jsonl")) result.push(file);
+		}
+	}
+	await visit(root);
+	return result.sort();
+}
+
+async function hashSession(file: string) {
+	const handle = await fs.open(file, "r");
+	const hash = new Bun.SHA256();
+	const buffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
+	let position = 0;
+	try {
+		for (;;) {
+			const { bytesRead } = await handle.read(buffer, 0, buffer.byteLength, position);
+			if (bytesRead === 0) return { sha256: hash.digest("hex"), size: position };
+			hash.update(buffer.subarray(0, bytesRead));
+			position += bytesRead;
+		}
+	} finally {
+		await handle.close();
+	}
+}
+
+async function manifestSessions(root: string) {
+	const manifests: SessionFileManifest[] = [];
+	for (const file of await sessionFiles(root)) {
+		const stat = await fs.lstat(file, { bigint: true });
+		assertInvariant(stat.isFile() && !stat.isSymbolicLink(), `Session is not a regular file: ${file}`);
+		const canonicalPath = await fs.realpath(file);
+		const digest = await hashSession(file);
+		assertInvariant(BigInt(digest.size) === stat.size, `Session changed while hashing: ${file}`);
+		manifests.push({
+			path: file,
+			canonicalPath,
+			dev: stat.dev.toString(),
+			ino: stat.ino.toString(),
+			size: digest.size,
+			mtimeNs: stat.mtimeNs.toString(),
+			ctimeNs: stat.ctimeNs.toString(),
+			sha256: digest.sha256,
+		});
+	}
+	return manifests.sort((left, right) => left.canonicalPath.localeCompare(right.canonicalPath));
+}
+
+function parseJsonRecord(line: string, file: string, ordinal: number) {
+	let value: unknown;
+	try {
+		value = JSON.parse(line);
+	} catch (error) {
+		throw new Error(`Malformed JSONL record ${ordinal} in ${file}: ${errorMessage(error)}`, { cause: error });
+	}
+	assertInvariant(
+		typeof value === "object" && value !== null && !Array.isArray(value),
+		`Invalid JSONL record ${ordinal} in ${file}`,
+	);
+	return value as Record<string, unknown>;
+}
+
+function parsedTimestamp(value: unknown, label: string) {
+	assertInvariant(typeof value === "string", `Missing timestamp in ${label}`);
+	const parsed = Date.parse(value);
+	assertInvariant(Number.isFinite(parsed), `Invalid timestamp in ${label}: ${value}`);
+	return parsed;
+}
+
+function promptContent(content: unknown, label: string) {
+	if (typeof content === "string") return content;
+	assertInvariant(Array.isArray(content), `Invalid user message content in ${label}`);
+	let text = "";
+	for (const block of content) {
+		assertInvariant(
+			typeof block === "object" && block !== null && !Array.isArray(block),
+			`Invalid content block in ${label}`,
+		);
+		const record = block as Record<string, unknown>;
+		if (record.type === "text") {
+			assertInvariant(typeof record.text === "string", `Invalid text block in ${label}`);
+			text += record.text;
+		} else if (record.type === "image") {
+			assertInvariant(
+				typeof record.data === "string" && typeof record.mimeType === "string",
+				`Invalid image block in ${label}`,
+			);
+		} else {
+			throw new Error(`Unsupported content block in ${label}`);
+		}
+	}
+	return text;
+}
+
+function validateHeader(record: Record<string, unknown>, file: string) {
+	assertInvariant(record.type === "session", `Missing session header in ${file}`);
+	assertInvariant(typeof record.id === "string" && record.id.length > 0, `Invalid session id in ${file}`);
+	assertInvariant(typeof record.cwd === "string" && record.cwd.length > 0, `Invalid session cwd in ${file}`);
+	parsedTimestamp(record.timestamp, `session header ${file}`);
+	const version = record.version ?? 1;
+	assertInvariant(
+		typeof version === "number" && Number.isInteger(version) && version >= 1 && version <= CURRENT_SESSION_VERSION,
+		`Unsupported session version in ${file}`,
+	);
+	return { id: record.id, cwd: record.cwd };
+}
+
+async function parseSession(file: SessionFileManifest, promptDb: Database) {
+	const input = createReadStream(file.path, { encoding: "utf8" });
+	const lines = readline.createInterface({ input, crlfDelay: Infinity });
+	const insert = promptDb.prepare(
+		"INSERT INTO prompts(entry_ms, canonical_path, ordinal, prompt, cwd, session_id) VALUES (?, ?, ?, ?, ?, ?)",
+	);
+	let physicalLine = 0;
+	let recordOrdinal = 0;
+	let header: { id: string; cwd: string } | null = null;
+	let inserted = 0;
+	try {
+		for await (const line of lines) {
+			physicalLine += 1;
+			if (physicalLine === 1) {
+				assertInvariant(
+					Buffer.byteLength(`${line}\n`, "utf8") === SESSION_TITLE_SLOT_BYTES && parseTitleSlotLine(line),
+					`Invalid fixed title slot in ${file.path}`,
+				);
+				continue;
+			}
+			const record = parseJsonRecord(line, file.path, physicalLine);
+			if (physicalLine === 2) {
+				header = validateHeader(record, file.path);
+				continue;
+			}
+			recordOrdinal += 1;
+			const timestamp = parsedTimestamp(record.timestamp, `record ${physicalLine} in ${file.path}`);
+			if (record.type !== "message") continue;
+			const message = record.message;
+			assertInvariant(
+				typeof message === "object" && message !== null && !Array.isArray(message),
+				`Invalid message in ${file.path}:${physicalLine}`,
+			);
+			const typed = message as Record<string, unknown>;
+			if (typed.role !== "user" || typed.attribution === "agent" || typed.steering === true) continue;
+			assertInvariant(header, `Session header state missing for ${file.path}`);
+			const prompt = promptContent(typed.content, `${file.path}:${physicalLine}`).trim();
+			if (prompt.length === 0) continue;
+			insert.run(BigInt(timestamp), file.canonicalPath, BigInt(recordOrdinal), prompt, header.cwd, header.id);
+			inserted += 1;
+		}
+		assertInvariant(physicalLine >= 2 && header, `Incomplete session file: ${file.path}`);
+		return inserted;
+	} finally {
+		insert.finalize();
+		lines.close();
+		input.destroy();
+	}
+}
+
+export async function freezePromptManifest(
+	tempDir: string,
+	agentDir: string,
+	hook?: StorageRepairTestHooks["afterSessionManifestParse"],
+): Promise<PromptManifest> {
+	const root = getSessionsDir(agentDir);
+	const first = await manifestSessions(root);
+	const dbPath = path.join(tempDir, "prompts.sqlite");
+	const db = new Database(dbPath, { safeIntegers: true });
+	db.exec(
+		"CREATE TABLE prompts(entry_ms INTEGER NOT NULL, canonical_path TEXT NOT NULL, ordinal INTEGER NOT NULL, prompt TEXT NOT NULL, cwd TEXT NOT NULL, session_id TEXT NOT NULL)",
+	);
+	let count = 0;
+	try {
+		for (const file of first) count += await parseSession(file, db);
+		await hook?.();
+		assertInvariant(
+			stableJson(first) === stableJson(await manifestSessions(root)),
+			"Session directory changed while rebuilding history manifest",
+		);
+		return { db, path: dbPath, count };
+	} catch (error) {
+		db.close();
+		throw error;
+	}
+}
+
+function sortedPrompts(manifest: Database) {
+	return manifest
+		.prepare(
+			"SELECT entry_ms, canonical_path, ordinal, prompt, cwd, session_id FROM prompts ORDER BY entry_ms ASC, canonical_path ASC, ordinal ASC",
+		)
+		.iterate() as Iterable<PromptRow>;
+}
+
+export function buildHistoryCandidate(
+	candidate: string,
+	source: HistoryRepairSource,
+	manifest: PromptManifest | null,
+): StorageRepairObjectResult[] {
+	HistoryStorage.initializeExactPath(candidate);
+	const db = new Database(candidate, { safeIntegers: true });
+	let inserted = 0;
+	try {
+		db.exec("DELETE FROM history");
+		if (source === "sessions") inserted = insertPrompts(db, manifest);
+		db.exec("INSERT INTO history_fts(history_fts) VALUES('rebuild')");
+	} finally {
+		db.close();
+	}
+	return [
+		{
+			name: "history",
+			kind: "table",
+			owner: "history",
+			action: "rebuilt",
+			detail: `${inserted} rows`,
+		},
+		{ name: "idx_history_created_at", kind: "index", owner: "history", action: "rebuilt" },
+		{ name: "history_fts", kind: "virtual table", owner: "history", action: "rebuilt" },
+		{ name: "history_ai", kind: "trigger", owner: "history", action: "rebuilt" },
+	];
+}
+
+function insertPrompts(db: Database, manifest: PromptManifest | null) {
+	assertInvariant(manifest, "Missing frozen session manifest");
+	const insert = db.prepare("INSERT INTO history(prompt, created_at, cwd, session_id) VALUES (?, ?, ?, ?)");
+	const flush = db.transaction((rows: PromptRow[]) => {
+		for (const row of rows) insert.run(row.prompt, row.entry_ms / 1000n, row.cwd, row.session_id);
+	});
+	let batch: PromptRow[] = [];
+	let previous: string | null = null;
+	let inserted = 0;
+	try {
+		for (const row of sortedPrompts(manifest.db)) {
+			if (row.prompt === previous) continue;
+			previous = row.prompt;
+			batch.push(row);
+			if (batch.length < ROW_BATCH_SIZE) continue;
+			flush(batch);
+			inserted += batch.length;
+			batch = [];
+		}
+		if (batch.length > 0) {
+			flush(batch);
+			inserted += batch.length;
+		}
+		return inserted;
+	} finally {
+		insert.finalize();
+	}
+}
+
+function verifyRows(candidate: Database, manifest: PromptManifest | null, source: HistoryRepairSource) {
+	const actual = candidate
+		.prepare("SELECT id, prompt, created_at, cwd, session_id FROM history ORDER BY id ASC")
+		.iterate() as Iterable<Record<string, unknown>>;
+	const iterator = actual[Symbol.iterator]();
+	if (source === "fresh") {
+		assertInvariant(iterator.next().done === true, "Fresh history candidate is not empty");
+		return;
+	}
+	assertInvariant(manifest, "Missing prompt manifest during history verification");
+	let expectedId = 0n;
+	let previous: string | null = null;
+	for (const row of sortedPrompts(manifest.db)) {
+		if (row.prompt === previous) continue;
+		previous = row.prompt;
+		expectedId += 1n;
+		const next = iterator.next();
+		assertInvariant(!next.done, `History candidate is missing expected row ${expectedId}`);
+		const value = next.value;
+		assertInvariant(
+			value.id === expectedId &&
+				value.prompt === row.prompt &&
+				value.created_at === row.entry_ms / 1000n &&
+				value.cwd === row.cwd &&
+				value.session_id === row.session_id,
+			`History candidate row ${expectedId} differs from frozen manifest`,
+		);
+	}
+	assertInvariant(iterator.next().done === true, "History candidate has unexpected extra rows");
+}
+
+function tokenize(text: string) {
+	return text
+		.toLowerCase()
+		.split(/[^\p{L}\p{N}]+/u)
+		.filter(Boolean);
+}
+
+function verifyRepresentativeSearches(db: Database) {
+	const samples = db
+		.prepare("SELECT prompt FROM history ORDER BY id ASC LIMIT 8")
+		.values()
+		.map(row => String(row[0]));
+	for (const prompt of samples) {
+		const token = tokenize(prompt).find(part => part.length > 1);
+		if (!token) continue;
+		const expected: unknown[] = [];
+		for (const row of db
+			.prepare("SELECT id, prompt FROM history ORDER BY created_at DESC, id DESC")
+			.iterate() as Iterable<{ id: bigint; prompt: string }>) {
+			if (tokenize(row.prompt).includes(token)) expected.push(row.id);
+			if (expected.length === 128) break;
+		}
+		const actual = db
+			.prepare(
+				"SELECT h.id FROM history_fts f JOIN history h ON h.id = f.rowid WHERE history_fts MATCH ? ORDER BY h.created_at DESC, h.id DESC LIMIT 128",
+			)
+			.values(token)
+			.map(row => row[0]);
+		assertInvariant(stableJson(actual) === stableJson(expected), `Representative FTS query mismatch for ${token}`);
+	}
+}
+
+export function verifyHistoryCandidate(
+	candidate: string,
+	source: HistoryRepairSource,
+	manifest: PromptManifest | null,
+) {
+	HistoryStorage.validateExactPath(candidate);
+	checkpointCandidate(candidate);
+	const db = new Database(candidate, { safeIntegers: true });
+	try {
+		verifyRows(db, manifest, source);
+		db.exec("INSERT INTO history_fts(history_fts, rank) VALUES('integrity-check', 1)");
+		verifyRepresentativeSearches(db);
+	} finally {
+		db.close();
+	}
+	checkpointCandidate(candidate);
+	verifyCommonCandidate(candidate);
+}
+
+export function closePromptManifest(manifest: PromptManifest | null) {
+	manifest?.db.close();
+}

--- a/packages/coding-agent/src/cli/storage-repair-history.ts
+++ b/packages/coding-agent/src/cli/storage-repair-history.ts
@@ -6,7 +6,14 @@ import { getSessionsDir, parseJsonlLenient } from "@oh-my-pi/pi-utils";
 import { HistoryStorage } from "../session/history-storage";
 import { CURRENT_SESSION_VERSION, SESSION_TITLE_SLOT_BYTES } from "../session/session-entries";
 import { parseTitleSlotLine } from "../session/session-title-slot";
-import { assertInvariant, checkpointCandidate, stableJson, verifyCommonCandidate } from "./storage-repair-files";
+import type { RawSchemaDefinition } from "./storage-repair-files";
+import {
+	assertInvariant,
+	checkpointCandidate,
+	stableJson,
+	verifyCommonCandidate,
+	verifyRawSchemaDefinitions,
+} from "./storage-repair-files";
 import type { HistoryRepairSource, StorageRepairObjectResult, StorageRepairTestHooks } from "./storage-repair-types";
 
 const COPY_BUFFER_BYTES = 1024 * 1024;
@@ -30,6 +37,19 @@ interface PromptRow {
 	prompt: string;
 	cwd: string;
 	session_id: string;
+}
+
+interface SessionHeader {
+	id: string;
+	cwd: string;
+	timestamp: number;
+	parentSession: string | null;
+}
+
+interface SessionMember {
+	file: SessionFileManifest;
+	header: SessionHeader;
+	family: number;
 }
 
 export interface PromptManifest {
@@ -148,28 +168,143 @@ function promptContent(content: unknown, label: string) {
 	return text;
 }
 
-function validateHeader(record: Record<string, unknown>, file: string) {
+function validateHeader(record: Record<string, unknown>, file: string): SessionHeader {
 	assertInvariant(record.type === "session", `Missing session header in ${file}`);
 	assertInvariant(typeof record.id === "string" && record.id.length > 0, `Invalid session id in ${file}`);
 	assertInvariant(typeof record.cwd === "string" && record.cwd.length > 0, `Invalid session cwd in ${file}`);
-	parsedTimestamp(record.timestamp, `session header ${file}`);
+	const timestamp = parsedTimestamp(record.timestamp, `session header ${file}`);
 	const version = record.version ?? 1;
 	assertInvariant(
 		typeof version === "number" && Number.isInteger(version) && version >= 1 && version <= CURRENT_SESSION_VERSION,
 		`Unsupported session version in ${file}`,
 	);
-	return { id: record.id, cwd: record.cwd };
+	return {
+		id: record.id,
+		cwd: record.cwd,
+		timestamp,
+		parentSession:
+			typeof record.parentSession === "string" && record.parentSession.length > 0 ? record.parentSession : null,
+	};
 }
 
-async function parseSession(file: SessionFileManifest, promptDb: Database) {
+async function readSessionHeader(file: SessionFileManifest): Promise<SessionHeader> {
+	const input = fs.createReadStream(file.path, { encoding: "utf8" });
+	const lines = readline.createInterface({ input, crlfDelay: Infinity });
+	let physicalLine = 0;
+	try {
+		for await (const line of lines) {
+			physicalLine += 1;
+			if (physicalLine === 1 && Buffer.byteLength(`${line}\n`, "utf8") === SESSION_TITLE_SLOT_BYTES) {
+				if (parseTitleSlotLine(line)) continue;
+			}
+			const record = parseJsonRecord(line, file.path, physicalLine);
+			if (!record) continue;
+			return validateHeader(record, file.path);
+		}
+		throw new Error(`Incomplete session file: ${file.path}`);
+	} finally {
+		lines.close();
+		input.destroy();
+	}
+}
+
+class SessionUnionFind {
+	readonly #parents: number[];
+	readonly #ranks: number[];
+
+	constructor(size: number) {
+		this.#parents = Array.from({ length: size }, (_, index) => index);
+		this.#ranks = Array<number>(size).fill(0);
+	}
+
+	find(index: number): number {
+		let root = index;
+		while (this.#parents[root] !== root) root = this.#parents[root]!;
+		while (this.#parents[index] !== index) {
+			const parent = this.#parents[index]!;
+			this.#parents[index] = root;
+			index = parent;
+		}
+		return root;
+	}
+
+	union(left: number, right: number): void {
+		let leftRoot = this.find(left);
+		let rightRoot = this.find(right);
+		if (leftRoot === rightRoot) return;
+		if (this.#ranks[leftRoot]! < this.#ranks[rightRoot]!) [leftRoot, rightRoot] = [rightRoot, leftRoot];
+		this.#parents[rightRoot] = leftRoot;
+		if (this.#ranks[leftRoot] === this.#ranks[rightRoot]) this.#ranks[leftRoot] = this.#ranks[leftRoot]! + 1;
+	}
+}
+
+function addReference(map: Map<string, number[]>, reference: string, index: number): void {
+	const matches = map.get(reference);
+	if (matches) matches.push(index);
+	else map.set(reference, [index]);
+}
+
+function isPathReference(reference: string): boolean {
+	return (
+		path.isAbsolute(reference) || reference.includes("/") || reference.includes("\\") || reference.endsWith(".jsonl")
+	);
+}
+
+function resolvedParentIndex(
+	member: SessionMember,
+	byId: Map<string, number[]>,
+	byPath: Map<string, number[]>,
+): number | null {
+	const reference = member.header.parentSession;
+	if (!reference) return null;
+	if (!isPathReference(reference)) {
+		const matches = byId.get(reference) ?? [];
+		return matches.length === 1 ? matches[0]! : null;
+	}
+	const matches = new Set<number>();
+	for (const candidate of [path.resolve(reference), path.resolve(path.dirname(member.file.path), reference)]) {
+		for (const index of byPath.get(candidate) ?? []) matches.add(index);
+	}
+	return matches.size === 1 ? [...matches][0]! : null;
+}
+
+async function sessionFamilies(files: SessionFileManifest[]): Promise<SessionMember[]> {
+	const members: SessionMember[] = [];
+	for (const file of files) members.push({ file, header: await readSessionHeader(file), family: -1 });
+	const byId = new Map<string, number[]>();
+	const byPath = new Map<string, number[]>();
+	for (const [index, member] of members.entries()) {
+		addReference(byId, member.header.id, index);
+		addReference(byPath, path.resolve(member.file.path), index);
+		addReference(byPath, path.resolve(member.file.canonicalPath), index);
+	}
+	const families = new SessionUnionFind(members.length);
+	for (const [index, member] of members.entries()) {
+		const parent = resolvedParentIndex(member, byId, byPath);
+		if (parent !== null) families.union(index, parent);
+	}
+	for (const [index, member] of members.entries()) member.family = families.find(index);
+	return members;
+}
+
+function validInnerTimestamp(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function recordSha256(line: string): string {
+	return new Bun.SHA256().update(Buffer.from(line, "utf8")).digest("hex");
+}
+
+async function parseSession(member: SessionMember, promptDb: Database) {
+	const { file, header, family } = member;
 	const input = fs.createReadStream(file.path, { encoding: "utf8" });
 	const lines = readline.createInterface({ input, crlfDelay: Infinity });
 	const insert = promptDb.prepare(
-		"INSERT INTO prompts(entry_ms, canonical_path, ordinal, prompt, cwd, session_id) VALUES (?, ?, ?, ?, ?, ?)",
+		"INSERT INTO prompts(entry_ms, header_ms, canonical_path, ordinal, record_sha256, family, prompt, cwd, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
 	);
 	let physicalLine = 0;
 	let recordOrdinal = 0;
-	let header: { id: string; cwd: string } | null = null;
+	let foundHeader = false;
 	let inserted = 0;
 	promptDb.exec("BEGIN");
 	try {
@@ -180,12 +315,17 @@ async function parseSession(file: SessionFileManifest, promptDb: Database) {
 			}
 			const record = parseJsonRecord(line, file.path, physicalLine);
 			if (!record) continue;
-			if (!header) {
-				header = validateHeader(record, file.path);
+			if (!foundHeader) {
+				const parsed = validateHeader(record, file.path);
+				assertInvariant(
+					parsed.id === header.id && parsed.timestamp === header.timestamp && parsed.cwd === header.cwd,
+					`Session header changed while parsing: ${file.path}`,
+				);
+				foundHeader = true;
 				continue;
 			}
 			recordOrdinal += 1;
-			const timestamp = parsedTimestamp(record.timestamp, `record ${physicalLine} in ${file.path}`);
+			const outerTimestamp = parsedTimestamp(record.timestamp, `record ${physicalLine} in ${file.path}`);
 			if (record.type !== "message") continue;
 			const message = record.message;
 			assertInvariant(
@@ -193,15 +333,24 @@ async function parseSession(file: SessionFileManifest, promptDb: Database) {
 				`Invalid message in ${file.path}:${physicalLine}`,
 			);
 			const typed = message as Record<string, unknown>;
-			if (typed.role !== "user" || typed.attribution === "agent" || typed.synthetic === true) {
-				continue;
-			}
+			if (typed.role !== "user" || typed.attribution === "agent" || typed.synthetic === true) continue;
 			const prompt = promptContent(typed.content, `${file.path}:${physicalLine}`).trim();
 			if (prompt.length === 0) continue;
-			insert.run(BigInt(timestamp), file.canonicalPath, BigInt(recordOrdinal), prompt, header.cwd, header.id);
+			const entryTimestamp = validInnerTimestamp(typed.timestamp) ? typed.timestamp : outerTimestamp;
+			insert.run(
+				BigInt(entryTimestamp),
+				BigInt(header.timestamp),
+				file.canonicalPath,
+				BigInt(recordOrdinal),
+				recordSha256(line),
+				BigInt(family),
+				prompt,
+				header.cwd,
+				header.id,
+			);
 			inserted += 1;
 		}
-		assertInvariant(physicalLine >= 1 && header, `Incomplete session file: ${file.path}`);
+		assertInvariant(physicalLine >= 1 && foundHeader, `Incomplete session file: ${file.path}`);
 		promptDb.exec("COMMIT");
 		return inserted;
 	} catch (error) {
@@ -228,12 +377,12 @@ export async function freezePromptManifest(
 	const dbPath = path.join(tempDir, "prompts.sqlite");
 	const db = new Database(dbPath, { safeIntegers: true });
 	db.exec(
-		"CREATE TABLE prompts(entry_ms INTEGER NOT NULL, canonical_path TEXT NOT NULL, ordinal INTEGER NOT NULL, prompt TEXT NOT NULL, cwd TEXT NOT NULL, session_id TEXT NOT NULL)",
+		"CREATE TABLE prompts(entry_ms INTEGER NOT NULL, header_ms INTEGER NOT NULL, canonical_path TEXT NOT NULL, ordinal INTEGER NOT NULL, record_sha256 TEXT NOT NULL, family INTEGER NOT NULL, prompt TEXT NOT NULL, cwd TEXT NOT NULL, session_id TEXT NOT NULL)",
 	);
 	const fingerprint = stableJson(first);
 	let count = 0;
 	try {
-		for (const file of first) count += await parseSession(file, db);
+		for (const member of await sessionFamilies(first)) count += await parseSession(member, db);
 		await hook?.();
 		assertInvariant(
 			fingerprint === stableJson(await manifestSessions(root)),
@@ -256,9 +405,26 @@ export async function promptManifestStillMatches(manifest: PromptManifest | null
 
 function sortedPrompts(manifest: Database) {
 	return manifest
-		.prepare(
-			"SELECT entry_ms, canonical_path, ordinal, prompt, cwd, session_id FROM prompts ORDER BY entry_ms ASC, canonical_path ASC, ordinal ASC",
-		)
+		.prepare(`
+			WITH family_representatives AS (
+				SELECT
+					entry_ms,
+					canonical_path,
+					ordinal,
+					prompt,
+					cwd,
+					session_id,
+					ROW_NUMBER() OVER (
+						PARTITION BY family, record_sha256
+						ORDER BY header_ms ASC, canonical_path COLLATE BINARY ASC, ordinal ASC
+					) AS representative
+				FROM prompts
+			)
+			SELECT entry_ms, canonical_path, ordinal, prompt, cwd, session_id
+			FROM family_representatives
+			WHERE representative = 1
+			ORDER BY entry_ms ASC, canonical_path COLLATE BINARY ASC, ordinal ASC
+		`)
 		.iterate() as Iterable<PromptRow>;
 }
 
@@ -298,12 +464,9 @@ function insertPrompts(db: Database, manifest: PromptManifest | null) {
 		for (const row of rows) insert.run(row.prompt, row.entry_ms / 1000n, row.cwd, row.session_id);
 	});
 	let batch: PromptRow[] = [];
-	let previous: string | null = null;
 	let inserted = 0;
 	try {
 		for (const row of sortedPrompts(manifest.db)) {
-			if (row.prompt === previous) continue;
-			previous = row.prompt;
 			batch.push(row);
 			if (batch.length < ROW_BATCH_SIZE) continue;
 			flush(batch);
@@ -331,10 +494,7 @@ function verifyRows(candidate: Database, manifest: PromptManifest | null, source
 	}
 	assertInvariant(manifest, "Missing prompt manifest during history verification");
 	let expectedId = 0n;
-	let previous: string | null = null;
 	for (const row of sortedPrompts(manifest.db)) {
-		if (row.prompt === previous) continue;
-		previous = row.prompt;
 		expectedId += 1n;
 		const next = iterator.next();
 		assertInvariant(!next.done, `History candidate is missing expected row ${expectedId}`);
@@ -355,6 +515,7 @@ export function verifyHistoryCandidate(
 	candidate: string,
 	source: HistoryRepairSource,
 	manifest: PromptManifest | null,
+	expectedSchema: readonly RawSchemaDefinition[],
 ) {
 	HistoryStorage.validateExactPath(candidate);
 	checkpointCandidate(candidate);
@@ -367,6 +528,13 @@ export function verifyHistoryCandidate(
 	}
 	checkpointCandidate(candidate);
 	verifyCommonCandidate(candidate);
+	verifyRawSchemaDefinitions(candidate, expectedSchema);
+}
+
+export function verifyPublishedHistoryCandidate(candidate: string, expectedSchema: readonly RawSchemaDefinition[]) {
+	HistoryStorage.validateExactPath(candidate);
+	verifyCommonCandidate(candidate);
+	verifyRawSchemaDefinitions(candidate, expectedSchema);
 }
 
 export function closePromptManifest(manifest: PromptManifest | null) {

--- a/packages/coding-agent/src/cli/storage-repair-history.ts
+++ b/packages/coding-agent/src/cli/storage-repair-history.ts
@@ -1,6 +1,5 @@
 import { Database } from "bun:sqlite";
-import { createReadStream, type Dirent } from "node:fs";
-import * as fs from "node:fs/promises";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import * as readline from "node:readline";
 import { getSessionsDir } from "@oh-my-pi/pi-utils";
@@ -43,6 +42,8 @@ export interface PromptManifest {
 	db: Database;
 	path: string;
 	count: number;
+	root: string;
+	fingerprint: string;
 }
 
 function codeOf(error: unknown) {
@@ -53,9 +54,9 @@ function codeOf(error: unknown) {
 async function sessionFiles(root: string) {
 	const result: string[] = [];
 	async function visit(dir: string): Promise<void> {
-		let entries: Dirent[];
+		let entries: fs.Dirent[];
 		try {
-			entries = await fs.readdir(dir, { withFileTypes: true });
+			entries = await fs.promises.readdir(dir, { withFileTypes: true });
 		} catch (error) {
 			if (codeOf(error) === "ENOENT" && dir === root) return;
 			throw error;
@@ -72,7 +73,7 @@ async function sessionFiles(root: string) {
 }
 
 async function hashSession(file: string) {
-	const handle = await fs.open(file, "r");
+	const handle = await fs.promises.open(file, "r");
 	const hash = new Bun.SHA256();
 	const buffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
 	let position = 0;
@@ -91,9 +92,9 @@ async function hashSession(file: string) {
 async function manifestSessions(root: string) {
 	const manifests: SessionFileManifest[] = [];
 	for (const file of await sessionFiles(root)) {
-		const stat = await fs.lstat(file, { bigint: true });
+		const stat = await fs.promises.lstat(file, { bigint: true });
 		assertInvariant(stat.isFile() && !stat.isSymbolicLink(), `Session is not a regular file: ${file}`);
-		const canonicalPath = await fs.realpath(file);
+		const canonicalPath = await fs.promises.realpath(file);
 		const digest = await hashSession(file);
 		assertInvariant(BigInt(digest.size) === stat.size, `Session changed while hashing: ${file}`);
 		manifests.push({
@@ -170,7 +171,7 @@ function validateHeader(record: Record<string, unknown>, file: string) {
 }
 
 async function parseSession(file: SessionFileManifest, promptDb: Database) {
-	const input = createReadStream(file.path, { encoding: "utf8" });
+	const input = fs.createReadStream(file.path, { encoding: "utf8" });
 	const lines = readline.createInterface({ input, crlfDelay: Infinity });
 	const insert = promptDb.prepare(
 		"INSERT INTO prompts(entry_ms, canonical_path, ordinal, prompt, cwd, session_id) VALUES (?, ?, ?, ?, ?, ?)",
@@ -182,15 +183,11 @@ async function parseSession(file: SessionFileManifest, promptDb: Database) {
 	try {
 		for await (const line of lines) {
 			physicalLine += 1;
-			if (physicalLine === 1) {
-				assertInvariant(
-					Buffer.byteLength(`${line}\n`, "utf8") === SESSION_TITLE_SLOT_BYTES && parseTitleSlotLine(line),
-					`Invalid fixed title slot in ${file.path}`,
-				);
-				continue;
+			if (physicalLine === 1 && Buffer.byteLength(`${line}\n`, "utf8") === SESSION_TITLE_SLOT_BYTES) {
+				if (parseTitleSlotLine(line)) continue;
 			}
 			const record = parseJsonRecord(line, file.path, physicalLine);
-			if (physicalLine === 2) {
+			if (!header) {
 				header = validateHeader(record, file.path);
 				continue;
 			}
@@ -204,13 +201,12 @@ async function parseSession(file: SessionFileManifest, promptDb: Database) {
 			);
 			const typed = message as Record<string, unknown>;
 			if (typed.role !== "user" || typed.attribution === "agent" || typed.steering === true) continue;
-			assertInvariant(header, `Session header state missing for ${file.path}`);
 			const prompt = promptContent(typed.content, `${file.path}:${physicalLine}`).trim();
 			if (prompt.length === 0) continue;
 			insert.run(BigInt(timestamp), file.canonicalPath, BigInt(recordOrdinal), prompt, header.cwd, header.id);
 			inserted += 1;
 		}
-		assertInvariant(physicalLine >= 2 && header, `Incomplete session file: ${file.path}`);
+		assertInvariant(physicalLine >= 1 && header, `Incomplete session file: ${file.path}`);
 		return inserted;
 	} finally {
 		insert.finalize();
@@ -231,19 +227,28 @@ export async function freezePromptManifest(
 	db.exec(
 		"CREATE TABLE prompts(entry_ms INTEGER NOT NULL, canonical_path TEXT NOT NULL, ordinal INTEGER NOT NULL, prompt TEXT NOT NULL, cwd TEXT NOT NULL, session_id TEXT NOT NULL)",
 	);
+	const fingerprint = stableJson(first);
 	let count = 0;
 	try {
 		for (const file of first) count += await parseSession(file, db);
 		await hook?.();
 		assertInvariant(
-			stableJson(first) === stableJson(await manifestSessions(root)),
+			fingerprint === stableJson(await manifestSessions(root)),
 			"Session directory changed while rebuilding history manifest",
 		);
-		return { db, path: dbPath, count };
+		return { db, path: dbPath, count, root, fingerprint };
 	} catch (error) {
 		db.close();
 		throw error;
 	}
+}
+
+export async function promptManifestStillMatches(manifest: PromptManifest | null): Promise<void> {
+	assertInvariant(manifest, "Missing frozen session manifest");
+	assertInvariant(
+		manifest.fingerprint === stableJson(await manifestSessions(manifest.root)),
+		"Session directory changed during storage repair",
+	);
 }
 
 function sortedPrompts(manifest: Database) {
@@ -343,38 +348,6 @@ function verifyRows(candidate: Database, manifest: PromptManifest | null, source
 	assertInvariant(iterator.next().done === true, "History candidate has unexpected extra rows");
 }
 
-function tokenize(text: string) {
-	return text
-		.toLowerCase()
-		.split(/[^\p{L}\p{N}]+/u)
-		.filter(Boolean);
-}
-
-function verifyRepresentativeSearches(db: Database) {
-	const samples = db
-		.prepare("SELECT prompt FROM history ORDER BY id ASC LIMIT 8")
-		.values()
-		.map(row => String(row[0]));
-	for (const prompt of samples) {
-		const token = tokenize(prompt).find(part => part.length > 1);
-		if (!token) continue;
-		const expected: unknown[] = [];
-		for (const row of db
-			.prepare("SELECT id, prompt FROM history ORDER BY created_at DESC, id DESC")
-			.iterate() as Iterable<{ id: bigint; prompt: string }>) {
-			if (tokenize(row.prompt).includes(token)) expected.push(row.id);
-			if (expected.length === 128) break;
-		}
-		const actual = db
-			.prepare(
-				"SELECT h.id FROM history_fts f JOIN history h ON h.id = f.rowid WHERE history_fts MATCH ? ORDER BY h.created_at DESC, h.id DESC LIMIT 128",
-			)
-			.values(token)
-			.map(row => row[0]);
-		assertInvariant(stableJson(actual) === stableJson(expected), `Representative FTS query mismatch for ${token}`);
-	}
-}
-
 export function verifyHistoryCandidate(
 	candidate: string,
 	source: HistoryRepairSource,
@@ -386,7 +359,6 @@ export function verifyHistoryCandidate(
 	try {
 		verifyRows(db, manifest, source);
 		db.exec("INSERT INTO history_fts(history_fts, rank) VALUES('integrity-check', 1)");
-		verifyRepresentativeSearches(db);
 	} finally {
 		db.close();
 	}

--- a/packages/coding-agent/src/cli/storage-repair-history.ts
+++ b/packages/coding-agent/src/cli/storage-repair-history.ts
@@ -79,9 +79,14 @@ async function sessionFiles(root: string) {
 		assertInvariant(!project.isSymbolicLink(), `Session manifest refuses symbolic link: ${projectPath}`);
 		if (!project.isDirectory()) continue;
 		for (const file of await fs.promises.readdir(projectPath, { withFileTypes: true })) {
+			// Only actual session candidates (*.jsonl) are subject to the
+			// no-symlink policy — production discovery scans only */*.jsonl,
+			// so an unrelated symlink in a session directory must not refuse
+			// the whole sessions-based repair. Filter before enforcing it.
+			if (!file.name.endsWith(".jsonl")) continue;
 			const filePath = path.join(projectPath, file.name);
 			assertInvariant(!file.isSymbolicLink(), `Session manifest refuses symbolic link: ${filePath}`);
-			if (file.isFile() && file.name.endsWith(".jsonl")) result.push(filePath);
+			if (file.isFile()) result.push(filePath);
 		}
 	}
 	return result.sort();
@@ -291,8 +296,13 @@ function validInnerTimestamp(value: unknown): value is number {
 	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
-function recordSha256(line: string): string {
-	return new Bun.SHA256().update(Buffer.from(line, "utf8")).digest("hex");
+function messageKey(entryMs: number, prompt: string): string {
+	// Semantic identity over migration-stable fields. forkFrom's
+	// migrateToCurrentVersion adds generated id/parentId to inherited copies
+	// (changing the raw JSONL line) but leaves the prompt and message timestamp
+	// intact, so timestamp+prompt identifies the same inherited user turn across
+	// a family instead of hashing volatile serialized line bytes.
+	return new Bun.SHA256().update(Buffer.from(`${entryMs}\0${prompt}`, "utf8")).digest("hex");
 }
 
 async function parseSession(member: SessionMember, promptDb: Database) {
@@ -300,7 +310,7 @@ async function parseSession(member: SessionMember, promptDb: Database) {
 	const input = fs.createReadStream(file.path, { encoding: "utf8" });
 	const lines = readline.createInterface({ input, crlfDelay: Infinity });
 	const insert = promptDb.prepare(
-		"INSERT INTO prompts(entry_ms, header_ms, canonical_path, ordinal, record_sha256, family, prompt, cwd, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		"INSERT INTO prompts(entry_ms, header_ms, canonical_path, ordinal, message_key, family, prompt, cwd, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
 	);
 	let physicalLine = 0;
 	let recordOrdinal = 0;
@@ -342,7 +352,7 @@ async function parseSession(member: SessionMember, promptDb: Database) {
 				BigInt(header.timestamp),
 				file.canonicalPath,
 				BigInt(recordOrdinal),
-				recordSha256(line),
+				messageKey(entryTimestamp, prompt),
 				BigInt(family),
 				prompt,
 				header.cwd,
@@ -377,7 +387,7 @@ export async function freezePromptManifest(
 	const dbPath = path.join(tempDir, "prompts.sqlite");
 	const db = new Database(dbPath, { safeIntegers: true });
 	db.exec(
-		"CREATE TABLE prompts(entry_ms INTEGER NOT NULL, header_ms INTEGER NOT NULL, canonical_path TEXT NOT NULL, ordinal INTEGER NOT NULL, record_sha256 TEXT NOT NULL, family INTEGER NOT NULL, prompt TEXT NOT NULL, cwd TEXT NOT NULL, session_id TEXT NOT NULL)",
+		"CREATE TABLE prompts(entry_ms INTEGER NOT NULL, header_ms INTEGER NOT NULL, canonical_path TEXT NOT NULL, ordinal INTEGER NOT NULL, message_key TEXT NOT NULL, family INTEGER NOT NULL, prompt TEXT NOT NULL, cwd TEXT NOT NULL, session_id TEXT NOT NULL)",
 	);
 	const fingerprint = stableJson(first);
 	let count = 0;
@@ -415,7 +425,7 @@ function sortedPrompts(manifest: Database) {
 					cwd,
 					session_id,
 					ROW_NUMBER() OVER (
-						PARTITION BY family, record_sha256
+						PARTITION BY family, message_key
 						ORDER BY header_ms ASC, canonical_path COLLATE BINARY ASC, ordinal ASC
 					) AS representative
 				FROM prompts

--- a/packages/coding-agent/src/cli/storage-repair-history.ts
+++ b/packages/coding-agent/src/cli/storage-repair-history.ts
@@ -202,12 +202,7 @@ async function parseSession(file: SessionFileManifest, promptDb: Database) {
 				`Invalid message in ${file.path}:${physicalLine}`,
 			);
 			const typed = message as Record<string, unknown>;
-			if (
-				typed.role !== "user" ||
-				typed.attribution === "agent" ||
-				typed.steering === true ||
-				typed.synthetic === true
-			) {
+			if (typed.role !== "user" || typed.attribution === "agent" || typed.synthetic === true) {
 				continue;
 			}
 			const prompt = promptContent(typed.content, `${file.path}:${physicalLine}`).trim();

--- a/packages/coding-agent/src/cli/storage-repair-history.ts
+++ b/packages/coding-agent/src/cli/storage-repair-history.ts
@@ -180,6 +180,7 @@ async function parseSession(file: SessionFileManifest, promptDb: Database) {
 	let recordOrdinal = 0;
 	let header: { id: string; cwd: string } | null = null;
 	let inserted = 0;
+	promptDb.exec("BEGIN");
 	try {
 		for await (const line of lines) {
 			physicalLine += 1;
@@ -200,14 +201,29 @@ async function parseSession(file: SessionFileManifest, promptDb: Database) {
 				`Invalid message in ${file.path}:${physicalLine}`,
 			);
 			const typed = message as Record<string, unknown>;
-			if (typed.role !== "user" || typed.attribution === "agent" || typed.steering === true) continue;
+			if (
+				typed.role !== "user" ||
+				typed.attribution === "agent" ||
+				typed.steering === true ||
+				typed.synthetic === true
+			) {
+				continue;
+			}
 			const prompt = promptContent(typed.content, `${file.path}:${physicalLine}`).trim();
 			if (prompt.length === 0) continue;
 			insert.run(BigInt(timestamp), file.canonicalPath, BigInt(recordOrdinal), prompt, header.cwd, header.id);
 			inserted += 1;
 		}
 		assertInvariant(physicalLine >= 1 && header, `Incomplete session file: ${file.path}`);
+		promptDb.exec("COMMIT");
 		return inserted;
+	} catch (error) {
+		try {
+			promptDb.exec("ROLLBACK");
+		} catch (rollbackError) {
+			throw new AggregateError([error, rollbackError], `Prompt manifest rollback failed for ${file.path}`);
+		}
+		throw error;
 	} finally {
 		insert.finalize();
 		lines.close();

--- a/packages/coding-agent/src/cli/storage-repair-history.ts
+++ b/packages/coding-agent/src/cli/storage-repair-history.ts
@@ -52,24 +52,23 @@ function codeOf(error: unknown) {
 }
 
 async function sessionFiles(root: string) {
-	let projects: fs.Dirent[];
-	try {
-		projects = await fs.promises.readdir(root, { withFileTypes: true });
-	} catch (error) {
-		if (codeOf(error) === "ENOENT") return [];
-		throw error;
-	}
 	const result: string[] = [];
-	for (const project of projects) {
-		const projectPath = path.join(root, project.name);
-		assertInvariant(!project.isSymbolicLink(), `Session manifest refuses symbolic link: ${projectPath}`);
-		if (!project.isDirectory()) continue;
-		for (const file of await fs.promises.readdir(projectPath, { withFileTypes: true })) {
-			const filePath = path.join(projectPath, file.name);
-			assertInvariant(!file.isSymbolicLink(), `Session manifest refuses symbolic link: ${filePath}`);
-			if (file.isFile() && file.name.endsWith(".jsonl")) result.push(filePath);
+	async function visit(dir: string): Promise<void> {
+		let entries: fs.Dirent[];
+		try {
+			entries = await fs.promises.readdir(dir, { withFileTypes: true });
+		} catch (error) {
+			if (codeOf(error) === "ENOENT" && dir === root) return;
+			throw error;
+		}
+		for (const entry of entries) {
+			const file = path.join(dir, entry.name);
+			assertInvariant(!entry.isSymbolicLink(), `Session manifest refuses symbolic link: ${file}`);
+			if (entry.isDirectory()) await visit(file);
+			else if (entry.isFile() && entry.name.endsWith(".jsonl")) result.push(file);
 		}
 	}
+	await visit(root);
 	return result.sort();
 }
 
@@ -202,7 +201,14 @@ async function parseSession(file: SessionFileManifest, promptDb: Database) {
 				`Invalid message in ${file.path}:${physicalLine}`,
 			);
 			const typed = message as Record<string, unknown>;
-			if (typed.role !== "user" || typed.attribution === "agent" || typed.synthetic === true) { continue; }
+			if (
+				typed.role !== "user" ||
+				typed.attribution === "agent" ||
+				typed.steering === true ||
+				typed.synthetic === true
+			) {
+				continue;
+			}
 			const prompt = promptContent(typed.content, `${file.path}:${physicalLine}`).trim();
 			if (prompt.length === 0) continue;
 			insert.run(BigInt(timestamp), file.canonicalPath, BigInt(recordOrdinal), prompt, header.cwd, header.id);

--- a/packages/coding-agent/src/cli/storage-repair-history.ts
+++ b/packages/coding-agent/src/cli/storage-repair-history.ts
@@ -6,12 +6,7 @@ import { getSessionsDir, parseJsonlLenient } from "@oh-my-pi/pi-utils";
 import { HistoryStorage } from "../session/history-storage";
 import { CURRENT_SESSION_VERSION, SESSION_TITLE_SLOT_BYTES } from "../session/session-entries";
 import { parseTitleSlotLine } from "../session/session-title-slot";
-import {
-	assertInvariant,
-	checkpointCandidate,
-	stableJson,
-	verifyCommonCandidate,
-} from "./storage-repair-files";
+import { assertInvariant, checkpointCandidate, stableJson, verifyCommonCandidate } from "./storage-repair-files";
 import type { HistoryRepairSource, StorageRepairObjectResult, StorageRepairTestHooks } from "./storage-repair-types";
 
 const COPY_BUFFER_BYTES = 1024 * 1024;

--- a/packages/coding-agent/src/cli/storage-repair-history.ts
+++ b/packages/coding-agent/src/cli/storage-repair-history.ts
@@ -202,14 +202,7 @@ async function parseSession(file: SessionFileManifest, promptDb: Database) {
 				`Invalid message in ${file.path}:${physicalLine}`,
 			);
 			const typed = message as Record<string, unknown>;
-			if (
-				typed.role !== "user" ||
-				typed.attribution === "agent" ||
-				typed.steering === true ||
-				typed.synthetic === true
-			) {
-				continue;
-			}
+			if (typed.role !== "user" || typed.attribution === "agent" || typed.synthetic === true) { continue; }
 			const prompt = promptContent(typed.content, `${file.path}:${physicalLine}`).trim();
 			if (prompt.length === 0) continue;
 			insert.run(BigInt(timestamp), file.canonicalPath, BigInt(recordOrdinal), prompt, header.cwd, header.id);

--- a/packages/coding-agent/src/cli/storage-repair-history.ts
+++ b/packages/coding-agent/src/cli/storage-repair-history.ts
@@ -52,23 +52,24 @@ function codeOf(error: unknown) {
 }
 
 async function sessionFiles(root: string) {
+	let projects: fs.Dirent[];
+	try {
+		projects = await fs.promises.readdir(root, { withFileTypes: true });
+	} catch (error) {
+		if (codeOf(error) === "ENOENT") return [];
+		throw error;
+	}
 	const result: string[] = [];
-	async function visit(dir: string): Promise<void> {
-		let entries: fs.Dirent[];
-		try {
-			entries = await fs.promises.readdir(dir, { withFileTypes: true });
-		} catch (error) {
-			if (codeOf(error) === "ENOENT" && dir === root) return;
-			throw error;
-		}
-		for (const entry of entries) {
-			const file = path.join(dir, entry.name);
-			assertInvariant(!entry.isSymbolicLink(), `Session manifest refuses symbolic link: ${file}`);
-			if (entry.isDirectory()) await visit(file);
-			else if (entry.isFile() && entry.name.endsWith(".jsonl")) result.push(file);
+	for (const project of projects) {
+		const projectPath = path.join(root, project.name);
+		assertInvariant(!project.isSymbolicLink(), `Session manifest refuses symbolic link: ${projectPath}`);
+		if (!project.isDirectory()) continue;
+		for (const file of await fs.promises.readdir(projectPath, { withFileTypes: true })) {
+			const filePath = path.join(projectPath, file.name);
+			assertInvariant(!file.isSymbolicLink(), `Session manifest refuses symbolic link: ${filePath}`);
+			if (file.isFile() && file.name.endsWith(".jsonl")) result.push(filePath);
 		}
 	}
-	await visit(root);
 	return result.sort();
 }
 

--- a/packages/coding-agent/src/cli/storage-repair-types.ts
+++ b/packages/coding-agent/src/cli/storage-repair-types.ts
@@ -1,0 +1,104 @@
+import type { Database } from "bun:sqlite";
+
+export type StorageRepairTarget = "agent" | "history";
+export type HistoryRepairSource = "sessions" | "fresh";
+export type StorageRepairAction = "preserved" | "rebuilt" | "omitted" | "refused";
+
+export interface StorageRepairFlags {
+	target: StorageRepairTarget;
+	historySource?: HistoryRepairSource;
+	output?: string;
+	apply: boolean;
+	agentDir: string;
+}
+
+export interface StorageRepairObjectResult {
+	name: string;
+	kind: string;
+	owner: string;
+	action: StorageRepairAction;
+	detail?: string;
+}
+
+export interface StorageRepairChecksum {
+	path: string;
+	sha256: string;
+	size: number;
+}
+
+export interface StorageRepairResult {
+	target: StorageRepairTarget;
+	historySource?: HistoryRepairSource;
+	apply: boolean;
+	dataLoss: boolean;
+	status: "ready" | "refused" | "published-with-warning";
+	source: string;
+	backup: string;
+	candidate: string;
+	backupCreated: boolean;
+	candidatePublished: boolean;
+	candidatePathTrusted: boolean;
+	checksums: StorageRepairChecksum[];
+	objects: StorageRepairObjectResult[];
+	refusal?: string;
+	warning?: string;
+	manualNextStep: string;
+}
+
+/** Fault and race seams used only by focused storage-repair tests. */
+export interface StorageRepairTestHooks {
+	afterPristineCopy?: () => void | Promise<void>;
+	afterSessionManifestParse?: () => void | Promise<void>;
+	beforeBackupWrite?: () => void | Promise<void>;
+	afterBackupLink?: () => void | Promise<void>;
+	beforeCandidateVerification?: () => void | Promise<void>;
+	beforeCandidatePublication?: () => void | Promise<void>;
+	afterCandidatePublication?: () => void | Promise<void>;
+	beforeCandidateStageUnlink?: () => void | Promise<void>;
+	beforeCandidateDirectorySync?: () => void | Promise<void>;
+}
+
+export interface SourceMemberManifest {
+	role: "main" | "wal" | "shm";
+	path: string;
+	archiveName: string;
+	dev: string;
+	ino: string;
+	size: number;
+	mtimeNs: string;
+	ctimeNs: string;
+	mode: number;
+	uid: string;
+	gid: string;
+	sha256: string;
+}
+
+export interface SourceTripletManifest {
+	version: 1;
+	source: string;
+	members: Record<"main" | "wal" | "shm", SourceMemberManifest | null>;
+}
+
+export interface CanonicalSchemaObject {
+	kind: string;
+	name: string;
+	table: string;
+	columns?: unknown[];
+	indexes?: unknown[];
+	foreignKeys?: unknown[];
+	sql?: string;
+}
+
+export interface FrozenSqliteSnapshot {
+	db: Database;
+	schema: CanonicalSchemaObject[];
+	versions: Record<string, string[]>;
+	corruption: string[];
+}
+
+export interface PristineSnapshot {
+	tempDir: string;
+	manifest: SourceTripletManifest;
+	paths: Record<"main" | "wal" | "shm", string | null>;
+	immutable: FrozenSqliteSnapshot | null;
+}

--- a/packages/coding-agent/src/cli/storage-repair-types.ts
+++ b/packages/coding-agent/src/cli/storage-repair-types.ts
@@ -32,6 +32,7 @@ export interface StorageRepairResult {
 	historySource?: HistoryRepairSource;
 	apply: boolean;
 	dataLoss: boolean;
+	diagnosedOmittedTables: string[];
 	status: "ready" | "refused" | "published-with-warning";
 	source: string;
 	backup: string;

--- a/packages/coding-agent/src/cli/storage-repair-types.ts
+++ b/packages/coding-agent/src/cli/storage-repair-types.ts
@@ -58,6 +58,7 @@ export interface StorageRepairTestHooks {
 	afterCandidatePublication?: () => void | Promise<void>;
 	beforeCandidateStageUnlink?: () => void | Promise<void>;
 	beforeCandidateDirectorySync?: () => void | Promise<void>;
+	beforeFinalCandidateSeal?: () => void | Promise<void>;
 	isWindows?: () => boolean;
 	onDirectorySync?: () => void;
 }

--- a/packages/coding-agent/src/cli/storage-repair-types.ts
+++ b/packages/coding-agent/src/cli/storage-repair-types.ts
@@ -38,6 +38,7 @@ export interface StorageRepairResult {
 	backup: string;
 	candidate: string;
 	backupCreated: boolean;
+	backupVerified: boolean;
 	candidatePublished: boolean;
 	candidatePathTrusted: boolean;
 	checksums: StorageRepairChecksum[];

--- a/packages/coding-agent/src/cli/storage-repair-types.ts
+++ b/packages/coding-agent/src/cli/storage-repair-types.ts
@@ -24,6 +24,7 @@ export interface StorageRepairChecksum {
 	path: string;
 	sha256: string;
 	size: number;
+	ephemeral: boolean;
 }
 
 export interface StorageRepairResult {
@@ -56,6 +57,8 @@ export interface StorageRepairTestHooks {
 	afterCandidatePublication?: () => void | Promise<void>;
 	beforeCandidateStageUnlink?: () => void | Promise<void>;
 	beforeCandidateDirectorySync?: () => void | Promise<void>;
+	isWindows?: () => boolean;
+	onDirectorySync?: () => void;
 }
 
 export interface SourceMemberManifest {

--- a/packages/coding-agent/src/cli/storage-repair-types.ts
+++ b/packages/coding-agent/src/cli/storage-repair-types.ts
@@ -48,7 +48,7 @@ export interface StorageRepairResult {
 
 /** Fault and race seams used only by focused storage-repair tests. */
 export interface StorageRepairTestHooks {
-	afterPristineCopy?: () => void | Promise<void>;
+	afterPristineCopy?: (tempDir: string) => void | Promise<void>;
 	afterSessionManifestParse?: () => void | Promise<void>;
 	beforeBackupWrite?: () => void | Promise<void>;
 	afterBackupLink?: () => void | Promise<void>;

--- a/packages/coding-agent/src/cli/storage-repair-types.ts
+++ b/packages/coding-agent/src/cli/storage-repair-types.ts
@@ -48,7 +48,7 @@ export interface StorageRepairResult {
 
 /** Fault and race seams used only by focused storage-repair tests. */
 export interface StorageRepairTestHooks {
-	afterPristineCopy?: (tempDir: string) => void | Promise<void>;
+	afterPristineCopy?: () => void | Promise<void>;
 	afterSessionManifestParse?: () => void | Promise<void>;
 	beforeBackupWrite?: () => void | Promise<void>;
 	afterBackupLink?: () => void | Promise<void>;

--- a/packages/coding-agent/src/commands/gc.ts
+++ b/packages/coding-agent/src/commands/gc.ts
@@ -14,6 +14,15 @@ export default class Gc extends Command {
 		blobs: Flags.boolean({ description: "Sweep unreferenced blobs" }),
 		archive: Flags.boolean({ description: "Archive cold sessions" }),
 		wal: Flags.boolean({ description: "Checkpoint history/model database WAL files" }),
+		"repair-storage": Flags.string({
+			description: "Build an offline salvage candidate for agent or history storage",
+			options: ["agent", "history"],
+		}),
+		"history-source": Flags.string({
+			description: "History rebuild source: sessions (default) or fresh",
+			options: ["sessions", "fresh"],
+		}),
+		output: Flags.string({ description: "Candidate output path (repair only)" }),
 		"cold-archive-after-days": Flags.integer({ description: "Minimum session age before archiving" }),
 		"retain-newest-global": Flags.integer({ description: "Always keep this many newest sessions active" }),
 		"retain-newest-per-cwd": Flags.integer({ description: "Always keep this many newest sessions per cwd active" }),
@@ -21,6 +30,14 @@ export default class Gc extends Command {
 
 	async run(): Promise<void> {
 		const { flags } = await this.parse(Gc);
+		const repairStorage = flags["repair-storage"];
+		if (repairStorage !== undefined && repairStorage !== "agent" && repairStorage !== "history") {
+			throw new Error(`Invalid storage repair target: ${repairStorage}`);
+		}
+		const historySource = flags["history-source"];
+		if (historySource !== undefined && historySource !== "sessions" && historySource !== "fresh") {
+			throw new Error(`Invalid history repair source: ${historySource}`);
+		}
 		const cmd: GcCommandArgs = {
 			flags: {
 				apply: flags.apply,
@@ -29,6 +46,9 @@ export default class Gc extends Command {
 				blobs: flags.blobs,
 				archive: flags.archive,
 				wal: flags.wal,
+				repairStorage,
+				historySource,
+				output: flags.output,
 				coldArchiveAfterDays: flags["cold-archive-after-days"],
 				retainNewestGlobal: flags["retain-newest-global"],
 				retainNewestPerCwd: flags["retain-newest-per-cwd"],

--- a/packages/coding-agent/src/memories/storage.ts
+++ b/packages/coding-agent/src/memories/storage.ts
@@ -36,6 +36,13 @@ const STAGE1_KIND = "memory_stage1";
 const GLOBAL_KIND = "memory_consolidate_global";
 const DEFAULT_RETRY_REMAINING = 3;
 
+/** Tables owned by the memory subsystem in agent.db. */
+export const MEMORY_STORAGE_TABLES = {
+	threads: "authoritative",
+	stage1_outputs: "authoritative",
+	jobs: "rebuildable",
+} as const satisfies Record<string, "authoritative" | "rebuildable">;
+
 /**
  * Per-project job key so Phase 2 consolidation is isolated to a single cwd.
  * Previously a single "global" key caused cross-project memory contamination.
@@ -91,6 +98,25 @@ CREATE TABLE IF NOT EXISTS jobs (
 
 export function closeMemoryDb(db: Database): void {
 	db.close();
+}
+
+/** Initializes memory schema in one caller-owned candidate. */
+export function initializeMemoryStorageExactPath(dbPath: string): void {
+	closeMemoryDb(openMemoryDb(dbPath));
+}
+
+/** Validates memory-owned tables through a read-only exact-path handle. */
+export function validateMemoryStorageExactPath(dbPath: string): void {
+	const db = new Database(dbPath, { readonly: true, safeIntegers: true });
+	try {
+		db.prepare("SELECT id, updated_at, rollout_path, cwd, source_kind FROM threads LIMIT 1").get();
+		db.prepare(
+			"SELECT thread_id, source_updated_at, raw_memory, rollout_summary, rollout_slug, generated_at FROM stage1_outputs LIMIT 1",
+		).get();
+		db.prepare("SELECT * FROM jobs LIMIT 1").get();
+	} finally {
+		db.close();
+	}
 }
 
 export function clearMemoryData(db: Database): void {

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -119,6 +119,15 @@ function normalizeModelPerfSample(modelKey: string, sample: ModelPerfSample): Mo
 export const SCHEMA_VERSION = 6;
 const SQLITE_NOW_EPOCH = "CAST(strftime('%s','now') AS INTEGER)";
 
+/** Tables owned directly by AgentStorage in agent.db. */
+export const AGENT_STORAGE_TABLES = {
+	model_usage: "authoritative",
+	model_perf: "rebuildable",
+	meta: "rebuildable",
+	schema_version: "authoritative",
+	settings: "authoritative",
+} as const satisfies Record<string, "authoritative" | "rebuildable">;
+
 /** Singleton instances per database path */
 const instances = new Map<string, AgentStorage>();
 
@@ -387,6 +396,35 @@ FROM model_usage_legacy
 			{ cause: lastError },
 		);
 	}
+	/**
+	 * Initializes a candidate at one exact path without registering a singleton.
+	 * The path must be owned by the caller; normal startup continues to use open().
+	 */
+	static initializeExactPath(dbPath: string): void {
+		const storage = new AgentStorage(dbPath);
+		storage.#close();
+	}
+
+	/** Validates owner tables through a read-only, non-singleton exact-path handle. */
+	static validateExactPath(dbPath: string): void {
+		const db = new Database(dbPath, { readonly: true, safeIntegers: true });
+		try {
+			const version = db.prepare("SELECT version FROM schema_version ORDER BY version").values();
+			if (version.length !== 1 || version[0]?.[0] !== BigInt(SCHEMA_VERSION)) {
+				throw new Error(`AgentStorage candidate schema version is not ${SCHEMA_VERSION}`);
+			}
+			db.prepare("SELECT model_key, last_used_at FROM model_usage LIMIT 1").get();
+			db.prepare(
+				"SELECT model_key, samples, output_tokens, gen_ms, ttft_samples, ttft_ms, updated_at FROM model_perf LIMIT 1",
+			).get();
+			db.prepare("SELECT key, value FROM meta LIMIT 1").get();
+			db.prepare("SELECT key, value, updated_at FROM settings LIMIT 1").get();
+		} finally {
+			db.close();
+		}
+		SqliteAuthCredentialStore.validateExactPath(dbPath);
+	}
+
 	/** @internal Reset all singletons and close their databases — test-only. */
 	static resetInstance(): void {
 		for (const storage of instances.values()) storage.#close();

--- a/packages/coding-agent/src/session/history-storage.ts
+++ b/packages/coding-agent/src/session/history-storage.ts
@@ -22,6 +22,14 @@ type HistoryRow = {
 
 const SQLITE_NOW_EPOCH = "CAST(strftime('%s','now') AS INTEGER)";
 
+/** Current history.db objects; FTS shadow objects are owned by history_fts. */
+export const HISTORY_STORAGE_OBJECTS = {
+	history: "authoritative",
+	idx_history_created_at: "authoritative",
+	history_fts: "derived",
+	history_ai: "derived",
+} as const satisfies Record<string, "authoritative" | "derived">;
+
 // Escape LIKE wildcards so user input is treated as literal text.
 // Matches the `ESCAPE '\\'` clause used by substring-search statements.
 function escapeLikePattern(text: string): string {
@@ -109,6 +117,29 @@ CREATE TRIGGER IF NOT EXISTS history_ai AFTER INSERT ON history BEGIN
 			HistoryStorage.#instance = new HistoryStorage(dbPath);
 		}
 		return HistoryStorage.#instance;
+	}
+
+	/** Initializes a caller-owned candidate without registering the singleton. */
+	static initializeExactPath(dbPath: string): void {
+		const storage = new HistoryStorage(dbPath);
+		storage.#close();
+	}
+
+	/** Validates current history/FTS objects through a read-only exact-path handle. */
+	static validateExactPath(dbPath: string): void {
+		const db = new Database(dbPath, { readonly: true, safeIntegers: true });
+		try {
+			db.prepare("SELECT id, prompt, created_at, cwd, session_id FROM history LIMIT 1").get();
+			db.prepare("SELECT rowid, prompt FROM history_fts LIMIT 1").get();
+			const objects = db
+				.prepare(
+					"SELECT name FROM sqlite_schema WHERE name IN ('history', 'idx_history_created_at', 'history_fts', 'history_ai')",
+				)
+				.values();
+			if (objects.length !== 4) throw new Error("History storage candidate schema is incomplete");
+		} finally {
+			db.close();
+		}
 	}
 
 	/** @internal Reset the singleton and close its database — test-only. */

--- a/packages/coding-agent/src/utils/zip.ts
+++ b/packages/coding-agent/src/utils/zip.ts
@@ -951,13 +951,35 @@ export async function writeArchive(
 }
 
 /**
+ * Index an archive's file members for extraction. tar/tar.gz opened from a
+ * filesystem path are read through an mmap'd, file-backed byte view (matching
+ * {@link extractFileBackedTar}) so the archive is never duplicated into the JS
+ * heap; member bodies stay lazy `File` references streamed to disk by the
+ * caller. In-memory sources and ZIP fall back to {@link readArchiveEntries}.
+ */
+async function readExtractableEntries(source: ArchiveSource): Promise<Map<string, ArchiveMemberContent>> {
+	if (typeof source === "string") {
+		const format = archiveFormatFromPath(source);
+		if (format === "tar" || format === "tar.gz") {
+			const bytes = mapArchiveFile(archiveFileMember(source, Bun.file(source).size));
+			const entries = new Map<string, ArchiveMemberContent>();
+			for (const [name, file] of await new Bun.Archive(bytes).files()) {
+				entries.set(name.replace(/\\/g, "/"), file);
+			}
+			return entries;
+		}
+	}
+	return readArchiveEntries(source);
+}
+
+/**
  * Extract every file member to `destDir`, creating parent directories as
  * needed. Entries that would escape `destDir` (via `..` or an absolute path)
  * are rejected. Returns the number of files written.
  */
 export async function extractArchive(source: ArchiveSource, destDir: string): Promise<number> {
 	const extractRoot = path.resolve(destDir);
-	const entries = await readArchiveEntries(source);
+	const entries = await readExtractableEntries(source);
 	let count = 0;
 	for (const [name, content] of entries) {
 		if (name.endsWith("/")) continue;

--- a/packages/coding-agent/src/utils/zip.ts
+++ b/packages/coding-agent/src/utils/zip.ts
@@ -970,7 +970,7 @@ export async function extractArchive(source: ArchiveSource, destDir: string): Pr
 		if (!outputPath.startsWith(extractRoot + path.sep)) {
 			throw new ToolError(`Archive entry escapes extraction dir: ${name}`);
 		}
-		await Bun.write(outputPath, await memberToBytes(content));
+		await Bun.write(outputPath, isArchiveFileMember(content) ? Bun.file(content.path) : content);
 		count++;
 	}
 	return count;

--- a/packages/coding-agent/src/utils/zip.ts
+++ b/packages/coding-agent/src/utils/zip.ts
@@ -70,8 +70,20 @@ export type ArchiveFormat = "zip" | "tar" | "tar.gz";
  */
 export type ArchiveSource = string | { bytes: Uint8Array; format: ArchiveFormat };
 
+/** Content for a filesystem-backed tar member. */
+export interface ArchiveFileMember {
+	kind: "file";
+	path: string;
+	size: number;
+}
+
 /** Content for a member when packing or extracting an archive. */
-export type ArchiveMemberContent = string | Uint8Array | Blob;
+export type ArchiveMemberContent = string | Uint8Array | Blob | ArchiveFileMember;
+
+/** Describe a file-backed member without eagerly reading it. */
+export function archiveFileMember(filePath: string, size: number): ArchiveFileMember {
+	return { kind: "file", path: filePath, size };
+}
 
 export interface ArchivePathCandidate {
 	archivePath: string;
@@ -849,10 +861,26 @@ async function resolveArchiveBytes(source: ArchiveSource): Promise<{ bytes: Uint
 	return { bytes: await Bun.file(source).bytes(), format };
 }
 
+function isArchiveFileMember(content: ArchiveMemberContent): content is ArchiveFileMember {
+	return !(typeof content === "string" || content instanceof Uint8Array || content instanceof Blob);
+}
+
+function mapArchiveFile(member: ArchiveFileMember): Uint8Array {
+	if (!Number.isSafeInteger(member.size) || member.size < 0) {
+		throw new ToolError(`Invalid archive member size: ${member.path}`);
+	}
+	const bytes = member.size === 0 ? new Uint8Array() : Bun.mmap(member.path);
+	if (bytes.byteLength !== member.size) {
+		throw new ToolError(`Archive member changed while being opened: ${member.path}`);
+	}
+	return bytes;
+}
+
 async function memberToBytes(content: ArchiveMemberContent): Promise<Uint8Array> {
 	if (typeof content === "string") return ENCODER.encode(content);
 	if (content instanceof Uint8Array) return content;
-	return new Uint8Array(await content.arrayBuffer());
+	if (content instanceof Blob) return new Uint8Array(await content.arrayBuffer());
+	return Bun.file(content.path).bytes();
 }
 
 /**
@@ -878,6 +906,21 @@ export async function readArchiveEntries(source: ArchiveSource): Promise<Map<str
 	return entries;
 }
 
+/** Open tar members through Bun's native archive parser. */
+export async function readTarArchiveFiles(source: Blob): Promise<Map<string, File>> {
+	return new Bun.Archive(await source.bytes()).files();
+}
+
+/**
+ * Extract a tar from a file-backed mapping. Bun 1.3.14 materializes
+ * `Bun.Archive(Bun.file(...))` incorrectly, while a mapped byte view remains
+ * file-backed and is accepted by the native parser.
+ */
+export async function extractFileBackedTar(sourcePath: string, size: number, destDir: string): Promise<number> {
+	const bytes = mapArchiveFile(archiveFileMember(sourcePath, size));
+	return new Bun.Archive(bytes).extract(destDir);
+}
+
 /**
  * Serialize `entries` into an archive of `format` and write it to `destPath`.
  * ZIP is framed in memory, tar / tar.gz via `Bun.Archive` (gzip for tar.gz).
@@ -897,9 +940,17 @@ export async function writeArchive(
 		return;
 	}
 
-	const record: Record<string, ArchiveMemberContent> = {};
+	const record: Record<string, string | Uint8Array | Blob> = {};
+	const mappings: Uint8Array[] = [];
 	for (const [name, content] of entries) {
-		record[name.replace(/\\/g, "/")] = content;
+		const normalized = name.replace(/\\/g, "/");
+		if (isArchiveFileMember(content)) {
+			const mapping = mapArchiveFile(content);
+			mappings.push(mapping);
+			record[normalized] = mapping;
+		} else {
+			record[normalized] = content;
+		}
 	}
 	await Bun.Archive.write(destPath, record, format === "tar.gz" ? { compress: "gzip" } : undefined);
 }
@@ -919,7 +970,7 @@ export async function extractArchive(source: ArchiveSource, destDir: string): Pr
 		if (!outputPath.startsWith(extractRoot + path.sep)) {
 			throw new ToolError(`Archive entry escapes extraction dir: ${name}`);
 		}
-		await Bun.write(outputPath, content);
+		await Bun.write(outputPath, await memberToBytes(content));
 		count++;
 	}
 	return count;

--- a/packages/coding-agent/src/utils/zip.ts
+++ b/packages/coding-agent/src/utils/zip.ts
@@ -906,11 +906,6 @@ export async function readArchiveEntries(source: ArchiveSource): Promise<Map<str
 	return entries;
 }
 
-/** Open tar members through Bun's native archive parser. */
-export async function readTarArchiveFiles(source: Blob): Promise<Map<string, File>> {
-	return new Bun.Archive(await source.bytes()).files();
-}
-
 /**
  * Extract a tar from a file-backed mapping. Bun 1.3.14 materializes
  * `Bun.Archive(Bun.file(...))` incorrectly, while a mapped byte view remains

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -549,6 +549,71 @@ describe("offline SQLite salvage", () => {
 		expect(result.objects).toContainEqual(expect.objectContaining({ name: "ext_notes_touch", action: "preserved" }));
 	});
 
+	test("pre-verification built-in row rewrites and deletions refuse the candidate", async () => {
+		const dbPath = await createAgentSource();
+		const sourceBefore = await fingerprintTriplet(dbPath);
+		for (const [kind, mutate, expectedRefusal] of [
+			[
+				"rewrite",
+				(db: Database) => db.prepare("UPDATE settings SET value = ? WHERE key = ?").run('"light"', "theme"),
+				"Candidate row value mismatch in settings.value",
+			],
+			[
+				"deletion",
+				(db: Database) => db.prepare("DELETE FROM settings WHERE key = ?").run("theme"),
+				"Candidate row count mismatch in settings",
+			],
+		] as const) {
+			const candidate = path.join(root, `candidate-built-in-${kind}.db`);
+			const result = await runStorageRepair(
+				{ target: "agent", apply: true, agentDir: root, output: candidate },
+				{
+					beforeCandidateVerification: async () => {
+						const stage = requireValue((await stageArtifacts(candidate, "candidate")).at(0), "candidate stage");
+						const stagedDb = new Database(path.join(root, stage), { safeIntegers: true });
+						try {
+							mutate(stagedDb);
+						} finally {
+							closeWal(stagedDb);
+						}
+					},
+				},
+			);
+			expect(result.status).toBe("refused");
+			expect(result.refusal).toContain(expectedRefusal);
+			expect(result.candidatePublished).toBe(false);
+			expect(await Bun.file(candidate).exists()).toBe(false);
+			expect(await stageArtifacts(candidate, "candidate")).toEqual([]);
+			expect(await fingerprintTriplet(dbPath)).toEqual(sourceBefore);
+		}
+	});
+
+	test("pre-verification extension BLOB mutation refuses the candidate", async () => {
+		const dbPath = await createAgentSource();
+		const sourceBefore = await fingerprintTriplet(dbPath);
+		const candidate = path.join(root, "candidate-extension-row.db");
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root, output: candidate },
+			{
+				beforeCandidateVerification: async () => {
+					const stage = requireValue((await stageArtifacts(candidate, "candidate")).at(0), "candidate stage");
+					const stagedDb = new Database(path.join(root, stage), { safeIntegers: true });
+					try {
+						stagedDb.prepare("UPDATE ext_notes SET payload = ? WHERE key = ?").run(new Uint8Array([255, 1, 0]), "note");
+					} finally {
+						closeWal(stagedDb);
+					}
+				},
+			},
+		);
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("Candidate row value mismatch in ext_notes.payload");
+		expect(result.candidatePublished).toBe(false);
+		expect(await Bun.file(candidate).exists()).toBe(false);
+		expect(await stageArtifacts(candidate, "candidate")).toEqual([]);
+		expect(await fingerprintTriplet(dbPath)).toEqual(sourceBefore);
+	});
+
 	test("agent repair preserves AUTOINCREMENT high-water marks after the highest row is deleted", async () => {
 		const dbPath = await createAgentSource();
 		const source = new Database(dbPath, { safeIntegers: true });

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -713,9 +713,13 @@ describe("offline SQLite salvage", () => {
 	test("injected backup, verification, and no-replace publication failures clean staging and retain valid backup", async () => {
 		const dbPath = await createAgentSource();
 		const before = await fingerprint(dbPath);
+		let snapshotTempDir: string | undefined;
 		let result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root },
 			{
+				afterPristineCopy: tempDir => {
+					snapshotTempDir = tempDir;
+				},
 				beforeBackupWrite: () => {
 					throw new Error("backup injection");
 				},
@@ -724,10 +728,17 @@ describe("offline SQLite salvage", () => {
 		expect(result.status).toBe("refused");
 		expect(result.backupCreated).toBe(false);
 		expect(await fingerprint(dbPath)).toEqual(before);
+		await expect(fs.promises.lstat(requireValue(snapshotTempDir, "backup snapshot directory"))).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 
+		snapshotTempDir = undefined;
 		result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root },
 			{
+				afterPristineCopy: tempDir => {
+					snapshotTempDir = tempDir;
+				},
 				beforeCandidateVerification: () => {
 					throw new Error("verification injection");
 				},
@@ -737,6 +748,9 @@ describe("offline SQLite salvage", () => {
 		expect(result.backupCreated).toBe(true);
 		expect(result.candidatePublished).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
+		await expect(fs.promises.lstat(requireValue(snapshotTempDir, "verification snapshot directory"))).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 
 		const racedCandidate = path.join(root, "raced-candidate.db");
 		let racerIdentity: FileFingerprint | undefined;
@@ -765,9 +779,15 @@ describe("offline SQLite salvage", () => {
 	test("late source mismatch after candidate link publishes an untrusted sealed candidate", async () => {
 		const dbPath = await createAgentSource();
 		const candidate = path.join(root, "publication-race.db");
+		let snapshotTempDir: string | undefined;
 		const result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root, output: candidate },
-			{ afterCandidatePublication: () => fs.promises.appendFile(dbPath, "publication race") },
+			{
+				afterPristineCopy: tempDir => {
+					snapshotTempDir = tempDir;
+				},
+				afterCandidatePublication: () => fs.promises.appendFile(dbPath, "publication race"),
+			},
 		);
 		expect(result.status).toBe("published-with-warning");
 		expect(result.warning).toContain("Live source triplet changed during storage repair");
@@ -776,6 +796,9 @@ describe("offline SQLite salvage", () => {
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 		expect(await Bun.file(candidate).exists()).toBe(true);
+		await expect(fs.promises.lstat(requireValue(snapshotTempDir, "published warning snapshot directory"))).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 		const sealed = requireValue(
 			result.checksums.find(checksum => checksum.path === candidate && !checksum.ephemeral),
 			"published candidate checksum",

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -713,9 +713,13 @@ describe("offline SQLite salvage", () => {
 	test("injected backup, verification, and no-replace publication failures clean staging and retain valid backup", async () => {
 		const dbPath = await createAgentSource();
 		const before = await fingerprint(dbPath);
+		let snapshotTempDir: string | undefined;
 		let result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root },
 			{
+				afterPristineCopy: tempDir => {
+					snapshotTempDir = tempDir;
+				},
 				beforeBackupWrite: () => {
 					throw new Error("backup injection");
 				},
@@ -724,10 +728,19 @@ describe("offline SQLite salvage", () => {
 		expect(result.status).toBe("refused");
 		expect(result.backupCreated).toBe(false);
 		expect(await fingerprint(dbPath)).toEqual(before);
+		await expect(fs.promises.lstat(requireValue(snapshotTempDir, "backup snapshot directory"))).rejects.toMatchObject(
+			{
+				code: "ENOENT",
+			},
+		);
 
+		snapshotTempDir = undefined;
 		result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root },
 			{
+				afterPristineCopy: tempDir => {
+					snapshotTempDir = tempDir;
+				},
 				beforeCandidateVerification: () => {
 					throw new Error("verification injection");
 				},
@@ -737,6 +750,11 @@ describe("offline SQLite salvage", () => {
 		expect(result.backupCreated).toBe(true);
 		expect(result.candidatePublished).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
+		await expect(
+			fs.promises.lstat(requireValue(snapshotTempDir, "verification snapshot directory")),
+		).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 
 		const racedCandidate = path.join(root, "raced-candidate.db");
 		let racerIdentity: FileFingerprint | undefined;
@@ -765,9 +783,15 @@ describe("offline SQLite salvage", () => {
 	test("late source mismatch after candidate link publishes an untrusted sealed candidate", async () => {
 		const dbPath = await createAgentSource();
 		const candidate = path.join(root, "publication-race.db");
+		let snapshotTempDir: string | undefined;
 		const result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root, output: candidate },
-			{ afterCandidatePublication: () => fs.promises.appendFile(dbPath, "publication race") },
+			{
+				afterPristineCopy: tempDir => {
+					snapshotTempDir = tempDir;
+				},
+				afterCandidatePublication: () => fs.promises.appendFile(dbPath, "publication race"),
+			},
 		);
 		expect(result.status).toBe("published-with-warning");
 		expect(result.warning).toContain("Live source triplet changed during storage repair");
@@ -776,6 +800,11 @@ describe("offline SQLite salvage", () => {
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 		expect(await Bun.file(candidate).exists()).toBe(true);
+		await expect(
+			fs.promises.lstat(requireValue(snapshotTempDir, "published warning snapshot directory")),
+		).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 		const sealed = requireValue(
 			result.checksums.find(checksum => checksum.path === candidate && !checksum.ephemeral),
 			"published candidate checksum",

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -516,6 +516,41 @@ describe("offline SQLite salvage", () => {
 		expect(result.refusal).toContain("database disk image is malformed");
 	});
 
+	test("refusal before candidate retains diagnosed omitted tables in result, JSON, and text", async () => {
+		const dbPath = await createAgentSource();
+		const db = new Database(dbPath);
+		db.prepare("INSERT INTO cache(key, value, expires_at) VALUES (?, ?, ?)").run("broken", "value", 1);
+		closeWal(db);
+		await corruptTablePage(dbPath, "cache");
+
+		const originalOpen = fs.promises.open;
+		const openSpy = spyOn(fs.promises, "open").mockImplementation(async (file, flags, mode) => {
+			if (typeof file === "string" && file.includes(".backup-") && file.endsWith(".tmp")) {
+				throw new Error("backup injection");
+			}
+			return originalOpen(file, flags, mode);
+		});
+		try {
+			const jsonResult = await runGcCommand({
+				flags: { agentDir: root, repairStorage: "agent", apply: true, json: true },
+			});
+			expect(jsonResult.repair).toMatchObject({
+				status: "refused",
+				dataLoss: true,
+				diagnosedOmittedTables: ["cache"],
+			});
+			expect(JSON.parse(stdout.join("")).repair.diagnosedOmittedTables).toEqual(["cache"]);
+
+			stdout = [];
+			const textResult = await runGcCommand({ flags: { agentDir: root, repairStorage: "agent", apply: true } });
+			expect(textResult.repair?.diagnosedOmittedTables).toEqual(["cache"]);
+			expect(stdout.join("")).toContain("registered rebuildable tables omitted: cache");
+			expect(stdout.join("")).not.toContain("fresh empty history");
+		} finally {
+			openSpy.mockRestore();
+		}
+	});
+
 	test("an impossible snapshot transition reports both rollback failures", async () => {
 		await createAgentSource();
 		const originalExec = Database.prototype.exec;

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -800,9 +800,13 @@ describe("offline SQLite salvage", () => {
 
 		const racedCandidate = path.join(root, "raced-candidate.db");
 		let racerIdentity: FileFingerprint | undefined;
+		snapshotTempDir = undefined;
 		result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root, output: racedCandidate },
 			{
+				afterPristineCopy: tempDir => {
+					snapshotTempDir = tempDir;
+				},
 				beforeCandidatePublication: async () => {
 					await Bun.write(racedCandidate, "racer");
 					racerIdentity = await fingerprint(racedCandidate);
@@ -821,6 +825,11 @@ describe("offline SQLite salvage", () => {
 		expect(staged.path).not.toBe(result.candidate);
 		expect(await fingerprint(racedCandidate)).toEqual(requireValue(racerIdentity, "racer identity"));
 		expect(await stageArtifacts(result.candidate, "candidate")).toEqual([]);
+		await expect(
+			fs.promises.lstat(requireValue<string>(snapshotTempDir, "no-replace publication snapshot directory")),
+		).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 	});
 
 	test("late source mismatch after candidate link publishes an untrusted sealed candidate", async () => {

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -257,7 +257,6 @@ describe("offline SQLite salvage", () => {
 		}
 	});
 
-
 	test("rejects Win32 trailing-dot and trailing-space source-triplet aliases", async () => {
 		const source = path.join(root, "agent.db");
 		await fs.promises.writeFile(source, "source");
@@ -789,7 +788,6 @@ describe("offline SQLite salvage", () => {
 		expect(result.refusal).toContain("Session directory changed");
 	});
 
-
 	test("a primary session discovery access error refuses without publishing artifacts", async () => {
 		const dbPath = await createHistorySource();
 		const sourceBefore = await fingerprint(dbPath);
@@ -798,12 +796,10 @@ describe("offline SQLite salvage", () => {
 		const candidate = path.join(root, "discovery-refused.db");
 		const accessError = Object.assign(new Error("session project access denied"), { code: "EACCES" });
 		const originalReaddir = fs.promises.readdir;
-		const readdirSpy = spyOn(fs.promises, "readdir").mockImplementation(
-			((directory, options) => {
-				if (directory === project) return Promise.reject(accessError);
-				return Reflect.apply(originalReaddir, fs.promises, [directory, options]);
-			}) as typeof fs.promises.readdir,
-		);
+		const readdirSpy = spyOn(fs.promises, "readdir").mockImplementation(((directory, options) => {
+			if (directory === project) return Promise.reject(accessError);
+			return Reflect.apply(originalReaddir, fs.promises, [directory, options]);
+		}) as typeof fs.promises.readdir);
 		try {
 			const result = await runStorageRepair({
 				target: "history",
@@ -1018,7 +1014,6 @@ describe("offline SQLite salvage", () => {
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 	});
 
-
 	test("candidate post-link same-inode same-size mutation fails the SHA proof", async () => {
 		await createAgentSource();
 		const candidate = path.join(root, "candidate-sha-only.db");
@@ -1191,7 +1186,6 @@ describe("offline SQLite salvage", () => {
 		expect(await fingerprint(result.backup)).toEqual(requireValue(replacementIdentity, "replacement identity"));
 	});
 
-
 	test("backup post-link same-inode same-size mutation fails the SHA proof", async () => {
 		await createAgentSource();
 		let mutation: { before: FileFingerprint; after: FileFingerprint } | undefined;
@@ -1200,7 +1194,10 @@ describe("offline SQLite salvage", () => {
 			{
 				afterBackupLink: async () => {
 					const directory = path.dirname(getAgentDbPath(root));
-					const name = requireValue((await fs.promises.readdir(directory)).find(entry => entry.endsWith(".tar")), "linked backup");
+					const name = requireValue(
+						(await fs.promises.readdir(directory)).find(entry => entry.endsWith(".tar")),
+						"linked backup",
+					);
 					const backup = path.join(directory, name);
 					const before = await fingerprint(backup);
 					const bytes = await Bun.file(backup).bytes();
@@ -1233,7 +1230,10 @@ describe("offline SQLite salvage", () => {
 			{
 				afterBackupLink: async () => {
 					const directory = path.dirname(getAgentDbPath(root));
-					const name = requireValue((await fs.promises.readdir(directory)).find(entry => entry.endsWith(".tar")), "linked backup");
+					const name = requireValue(
+						(await fs.promises.readdir(directory)).find(entry => entry.endsWith(".tar")),
+						"linked backup",
+					);
 					const backup = path.join(directory, name);
 					const before = await fingerprint(backup);
 					const bytes = await Bun.file(backup).bytes();

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -1775,6 +1775,9 @@ describe("offline SQLite salvage", () => {
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(result.warning).toContain("changed after verification");
 		expect(result.manualNextStep).not.toContain("Retain verified backup");
+		const backupChecksums = result.checksums.filter(checksum => checksum.path === result.backup);
+		expect(backupChecksums).toHaveLength(0);
+		expect(result.checksums.some(checksum => checksum.path === result.candidate)).toBe(true);
 	});
 
 	test("primary refusal and cleanup invariant failures retain both causes in deterministic order", async () => {

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -1,0 +1,744 @@
+import { Database, constants as sqliteConstants } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { collectGcErrors, runGcCommand } from "@oh-my-pi/pi-coding-agent/cli/gc-cli";
+import { runStorageRepair, type StorageRepairResult } from "@oh-my-pi/pi-coding-agent/cli/storage-repair-cli";
+import { initializeMemoryStorageExactPath } from "@oh-my-pi/pi-coding-agent/memories/storage";
+import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import { HistoryStorage } from "@oh-my-pi/pi-coding-agent/session/history-storage";
+import { CURRENT_SESSION_VERSION } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { serializeTitleSlot } from "@oh-my-pi/pi-coding-agent/session/session-title-slot";
+import { getAgentDbPath, getHistoryDbPath, getSessionsDir } from "@oh-my-pi/pi-utils";
+
+let root: string;
+let stdout: string[];
+let stdoutSpy: { mockRestore(): void } | undefined;
+
+function requireValue<T>(value: T | undefined, label: string): T {
+	if (value === undefined) throw new Error(`Missing ${label}`);
+	return value;
+}
+
+beforeEach(async () => {
+	root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-storage-repair-test-"));
+	stdout = [];
+	stdoutSpy = spyOn(process.stdout, "write").mockImplementation(chunk => {
+		stdout.push(String(chunk));
+		return true;
+	});
+});
+
+afterEach(async () => {
+	stdoutSpy?.mockRestore();
+	stdoutSpy = undefined;
+	await fs.rm(root, { recursive: true, force: true });
+});
+
+function closeWal(db: Database) {
+	db.fileControl(sqliteConstants.SQLITE_FCNTL_PERSIST_WAL, 0);
+	db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+	db.close();
+}
+
+function closeWithPhysicalWal(db: Database) {
+	db.fileControl(sqliteConstants.SQLITE_FCNTL_PERSIST_WAL, 1);
+	db.close();
+}
+
+async function createAgentSource() {
+	const dbPath = getAgentDbPath(root);
+	AgentStorage.initializeExactPath(dbPath);
+	initializeMemoryStorageExactPath(dbPath);
+	const initialized = new Database(dbPath);
+	closeWal(initialized);
+	Bun.gc(true);
+	const db = new Database(dbPath, { safeIntegers: true });
+	db.prepare("INSERT INTO settings(key, value, updated_at) VALUES (?, ?, ?)").run("theme", '"dark"', 11n);
+	db.prepare("INSERT INTO model_usage(model_key, last_used_at) VALUES (?, ?)").run("openai/gpt", 12n);
+	db.prepare("INSERT INTO clients(install_id, hostname, first_seen, last_seen) VALUES (?, ?, ?, ?)").run(
+		"install-1",
+		"host",
+		13n,
+		14n,
+	);
+	db.prepare("INSERT INTO threads(id, updated_at, rollout_path, cwd, source_kind) VALUES (?, ?, ?, ?, ?)").run(
+		"thread-1",
+		15n,
+		"/tmp/rollout.jsonl",
+		"/tmp",
+		"session",
+	);
+	db.prepare(
+		"INSERT INTO stage1_outputs(thread_id, source_updated_at, raw_memory, rollout_summary, rollout_slug, generated_at) VALUES (?, ?, ?, ?, ?, ?)",
+	).run("thread-1", 15n, "raw", "summary", null, 16n);
+	db.exec("CREATE TABLE ext_notes(key TEXT PRIMARY KEY, large_int INTEGER, payload BLOB)");
+	db.exec("CREATE INDEX ext_notes_large_int ON ext_notes(large_int)");
+	db.exec("CREATE VIEW ext_notes_view AS SELECT key, large_int FROM ext_notes");
+	db.exec("CREATE TRIGGER ext_notes_touch AFTER UPDATE ON ext_notes BEGIN SELECT NEW.key; END");
+	db.exec(
+		"CREATE TABLE shadowed_rowid(rowid TEXT, __omp_salvage_rowid_0 TEXT, __omp_salvage_rowid_1 TEXT, value TEXT)",
+	);
+	db.prepare(
+		"INSERT INTO shadowed_rowid(_rowid_, rowid, __omp_salvage_rowid_0, __omp_salvage_rowid_1, value) VALUES (?, ?, ?, ?, ?)",
+	).run(77n, "declared", "also-declared", "also-declared-2", "kept");
+	db.exec("CREATE TABLE composite_pk(a INTEGER, b TEXT, PRIMARY KEY(a, b))");
+	db.prepare("INSERT INTO composite_pk(rowid, a, b) VALUES (?, ?, ?)").run(88n, 1n, "b");
+	db.exec("CREATE TABLE rowid_alias(id INTEGER PRIMARY KEY, value TEXT)");
+	db.prepare("INSERT INTO rowid_alias(id, value) VALUES (?, ?)").run(89n, "alias");
+	db.exec("CREATE TABLE integer_primary_key_desc(id INTEGER PRIMARY KEY DESC, value TEXT)");
+	db.prepare("INSERT INTO integer_primary_key_desc(rowid, id, value) VALUES (?, ?, ?)").run(90n, 8n, "desc");
+	db.exec("CREATE TABLE implicit_int_primary_key(id INT PRIMARY KEY, value TEXT)");
+	db.prepare("INSERT INTO implicit_int_primary_key(rowid, id, value) VALUES (?, ?, ?)").run(91n, 9n, "int");
+	db.prepare("INSERT INTO ext_notes(rowid, key, large_int, payload) VALUES (?, ?, ?, ?)").run(
+		41n,
+		"note",
+		9_007_199_254_740_993n,
+		new Uint8Array([0, 1, 255]),
+	);
+	closeWithPhysicalWal(db);
+	Bun.gc(true);
+	return dbPath;
+}
+
+async function createHistorySource() {
+	const dbPath = getHistoryDbPath(root);
+	HistoryStorage.initializeExactPath(dbPath);
+	closeWal(new Database(dbPath));
+	Bun.gc(true);
+	return dbPath;
+}
+
+async function writeSession(project: string, name: string, records: Record<string, unknown>[]) {
+	const dir = path.join(getSessionsDir(root), project);
+	await fs.mkdir(dir, { recursive: true });
+	const file = path.join(dir, `${name}.jsonl`);
+	const header = {
+		type: "session",
+		version: CURRENT_SESSION_VERSION,
+		id: name,
+		timestamp: "2026-01-01T00:00:00.000Z",
+		cwd: `/work/${project}`,
+	};
+	const body = [
+		serializeTitleSlot({ title: name, updatedAt: header.timestamp }),
+		`${JSON.stringify(header)}\n`,
+		...records.map(record => `${JSON.stringify(record)}\n`),
+	].join("");
+	await Bun.write(file, body);
+	return file;
+}
+
+function message(id: string, timestamp: string, content: unknown, extra: Record<string, unknown> = {}) {
+	return {
+		type: "message",
+		id,
+		parentId: null,
+		timestamp,
+		message: { role: "user", content, ...extra },
+	};
+}
+
+async function fingerprint(file: string) {
+	const stat = await fs.lstat(file, { bigint: true });
+	return {
+		dev: stat.dev,
+		ino: stat.ino,
+		size: stat.size,
+		mtimeNs: stat.mtimeNs,
+		ctimeNs: stat.ctimeNs,
+		mode: stat.mode,
+		uid: stat.uid,
+		gid: stat.gid,
+		sha256: new Bun.SHA256().update(await Bun.file(file).bytes()).digest("hex"),
+	};
+}
+
+function sourceTripletPaths(dbPath: string) {
+	return [dbPath, `${dbPath}-wal`, `${dbPath}-shm`] as const;
+}
+
+async function fingerprintTriplet(dbPath: string) {
+	return Promise.all(sourceTripletPaths(dbPath).map(fingerprint));
+}
+
+async function corruptTablePage(dbPath: string, table: string) {
+	const db = new Database(dbPath, { readonly: true, safeIntegers: true });
+	const pageSize = db.prepare("PRAGMA page_size").values()[0]?.[0];
+	const row = db.prepare("SELECT rootpage FROM sqlite_schema WHERE type = 'table' AND name = ?").get(table) as {
+		rootpage?: bigint;
+	} | null;
+	db.close();
+	if (typeof pageSize !== "bigint" || typeof row?.rootpage !== "bigint") throw new Error(`Cannot locate ${table}`);
+	const handle = await fs.open(dbPath, "r+");
+	try {
+		await handle.write(
+			Buffer.alloc(Number(pageSize), 0xa5),
+			0,
+			Number(pageSize),
+			Number((row.rootpage - 1n) * pageSize),
+		);
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+function artifactModes(result: { backup: string; candidate: string }) {
+	return Promise.all([fs.stat(result.backup), fs.stat(result.candidate)]).then(([backup, candidate]) => ({
+		backup: backup.mode & 0o777,
+		candidate: candidate.mode & 0o777,
+	}));
+}
+
+describe("offline SQLite salvage", () => {
+	test("physical corruption fixture reproduces normal owner-open failure", async () => {
+		const dbPath = await createAgentSource();
+		closeWal(new Database(dbPath));
+		const handle = await fs.open(dbPath, "r+");
+		try {
+			await handle.write(Buffer.from("not sqlite"), 0, 10, 0);
+		} finally {
+			await handle.close();
+		}
+		expect(() => AgentStorage.validateExactPath(dbPath)).toThrow();
+	});
+
+	test("history rebuild salvages a source that SQLite cannot open", async () => {
+		const dbPath = await createHistorySource();
+		closeWal(new Database(dbPath));
+		const handle = await fs.open(dbPath, "r+");
+		try {
+			await handle.write(Buffer.from("not sqlite"), 0, 10, 0);
+		} finally {
+			await handle.close();
+		}
+		expect(() => HistoryStorage.validateExactPath(dbPath)).toThrow();
+		const result = await runStorageRepair({
+			target: "history",
+			historySource: "fresh",
+			apply: false,
+			agentDir: root,
+		});
+		expect(result.status).toBe("ready");
+		expect(result.dataLoss).toBe(true);
+	});
+
+	test("dry-run preserves bytes and identity metadata for every physical source triplet member", async () => {
+		const dbPath = await createAgentSource();
+		const before = await fingerprintTriplet(dbPath);
+		const siblings = await fs.readdir(path.dirname(dbPath));
+		const result = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
+		expect(result.status).toBe("ready");
+		expect(result.backupCreated).toBe(false);
+		expect(result.candidatePublished).toBe(false);
+		expect(result.candidatePathTrusted).toBe(false);
+		expect(await fingerprintTriplet(dbPath)).toEqual(before);
+		expect(await fs.readdir(path.dirname(dbPath))).toEqual(siblings);
+	});
+
+	test("a changed physical WAL refuses and leaves every source member at its post-change fingerprint", async () => {
+		const dbPath = await createAgentSource();
+		const before = await fingerprintTriplet(dbPath);
+		let afterMutation = before;
+		const result = await runStorageRepair(
+			{ target: "agent", apply: false, agentDir: root },
+			{
+				afterPristineCopy: async () => {
+					await fs.appendFile(`${dbPath}-wal`, "source-sidecar-change");
+					afterMutation = await fingerprintTriplet(dbPath);
+				},
+			},
+		);
+		expect(afterMutation[1]?.sha256).not.toBe(before[1]?.sha256);
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("Live source triplet changed");
+		expect(await fingerprintTriplet(dbPath)).toEqual(afterMutation);
+	});
+
+	test("a structural refusal preserves bytes and identity metadata for every physical source triplet member", async () => {
+		const dbPath = await createAgentSource();
+		const db = new Database(dbPath);
+		db.exec("ALTER TABLE settings ADD COLUMN drift TEXT");
+		closeWithPhysicalWal(db);
+		const before = await fingerprintTriplet(dbPath);
+		const result = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("Structural drift");
+		expect(await fingerprintTriplet(dbPath)).toEqual(before);
+	});
+
+	test("a live triplet change during the stable copy window refuses without artifacts", async () => {
+		const dbPath = await createAgentSource();
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root },
+			{ afterPristineCopy: () => fs.appendFile(dbPath, "race") },
+		);
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("changed");
+		expect(result.backupCreated).toBe(false);
+		expect(result.candidatePublished).toBe(false);
+		expect(result.candidatePathTrusted).toBe(false);
+	});
+
+	test("apply publishes verified raw tar first and a mode-0600 exact candidate", async () => {
+		const dbPath = await createAgentSource();
+		const sourceDigest = new Bun.SHA256().update(await Bun.file(dbPath).bytes()).digest("hex");
+		const result = await runStorageRepair({ target: "agent", apply: true, agentDir: root });
+		if (result.status !== "ready") throw new Error(result.refusal);
+		expect(result.status).toBe("ready");
+		expect(result.backupCreated).toBe(true);
+		expect(result.candidatePublished).toBe(true);
+		expect(result.candidatePathTrusted).toBe(true);
+		expect(await artifactModes(result)).toEqual({ backup: 0o600, candidate: 0o600 });
+		const archive = new Bun.Archive(await Bun.file(result.backup).bytes());
+		const files = await archive.files();
+		const main = files.get(`source/${path.basename(dbPath)}`);
+		if (!main) throw new Error("Backup main member is missing");
+		expect(new Bun.SHA256().update(await main.bytes()).digest("hex")).toBe(sourceDigest);
+		expect(JSON.parse((await files.get("manifest.json")?.text()) ?? "{}").formatVersion).toBe(1);
+	});
+
+	test("agent candidate preserves authoritative storage classes and a simple extension closure", async () => {
+		await createAgentSource();
+		const result = await runStorageRepair({ target: "agent", apply: true, agentDir: root });
+		expect(result.status).toBe("ready");
+		const db = new Database(result.candidate, { readonly: true, safeIntegers: true });
+		try {
+			expect(db.prepare("SELECT value FROM settings WHERE key = ?").get("theme")).toEqual({ value: '"dark"' });
+			expect(db.prepare("SELECT rowid, large_int, payload FROM ext_notes WHERE key = ?").get("note")).toEqual({
+				rowid: 41n,
+				large_int: 9_007_199_254_740_993n,
+				payload: new Uint8Array([0, 1, 255]),
+			});
+			expect(
+				db.prepare("SELECT name FROM sqlite_schema WHERE type = 'index' AND name = ?").get("ext_notes_large_int"),
+			).toBeDefined();
+			expect(
+				db
+					.prepare(
+						"SELECT _rowid_ AS implicit_rowid, rowid, __omp_salvage_rowid_0, __omp_salvage_rowid_1, value FROM shadowed_rowid",
+					)
+					.get(),
+			).toEqual({
+				implicit_rowid: 77n,
+				rowid: "declared",
+				__omp_salvage_rowid_0: "also-declared",
+				__omp_salvage_rowid_1: "also-declared-2",
+				value: "kept",
+			});
+			expect(db.prepare("SELECT rowid, a, b FROM composite_pk").get()).toEqual({ rowid: 88n, a: 1n, b: "b" });
+			expect(db.prepare("SELECT rowid AS implicit_rowid, id, value FROM rowid_alias").get()).toEqual({
+				implicit_rowid: 89n,
+				id: 89n,
+				value: "alias",
+			});
+			expect(db.prepare("SELECT rowid, id, value FROM integer_primary_key_desc").get()).toEqual({
+				rowid: 90n,
+				id: 8n,
+				value: "desc",
+			});
+			expect(db.prepare("SELECT rowid, id, value FROM implicit_int_primary_key").get()).toEqual({
+				rowid: 91n,
+				id: 9n,
+				value: "int",
+			});
+			expect(db.prepare("SELECT key, large_int FROM ext_notes_view").get()).toEqual({
+				key: "note",
+				large_int: 9_007_199_254_740_993n,
+			});
+		} finally {
+			db.close();
+		}
+		expect(result.objects).toContainEqual(expect.objectContaining({ name: "settings", action: "preserved" }));
+		expect(result.objects).toContainEqual(expect.objectContaining({ name: "ext_notes", action: "preserved" }));
+		expect(result.objects).toContainEqual(expect.objectContaining({ name: "ext_notes_view", action: "preserved" }));
+		expect(result.objects).toContainEqual(expect.objectContaining({ name: "ext_notes_touch", action: "preserved" }));
+	});
+
+	test("only a registered corrupt derived table may be omitted", async () => {
+		const dbPath = await createAgentSource();
+		const db = new Database(dbPath);
+		db.prepare("INSERT INTO cache(key, value, expires_at) VALUES (?, ?, ?)").run("broken", "value", 1);
+		closeWal(db);
+		await corruptTablePage(dbPath, "cache");
+		const result = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
+		expect(result.status).toBe("ready");
+		expect(result.objects).toContainEqual(expect.objectContaining({ name: "cache", action: "omitted" }));
+	});
+
+	test("authoritative page corruption refuses with the SQLite cause", async () => {
+		const dbPath = await createAgentSource();
+		closeWal(new Database(dbPath));
+		await corruptTablePage(dbPath, "settings");
+		const result = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("database disk image is malformed");
+	});
+
+	test("an impossible snapshot transition reports both rollback failures", async () => {
+		await createAgentSource();
+		const originalExec = Database.prototype.exec;
+		let rollbackAttempts = 0;
+		const execSpy = spyOn(Database.prototype, "exec").mockImplementation(function (this: Database, sql: string) {
+			if (sql !== "ROLLBACK") return originalExec.call(this, sql);
+			rollbackAttempts++;
+			throw new Error(rollbackAttempts === 1 ? "snapshot release failed" : "snapshot cleanup failed");
+		});
+		try {
+			const result = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
+			expect(result.status).toBe("refused");
+			expect(result.refusal).toBe(
+				"Working SQLite snapshot failed and rollback also failed: snapshot release failed; snapshot cleanup failed",
+			);
+		} finally {
+			execSpy.mockRestore();
+		}
+	});
+
+	test("core schema drift and unsafe extension constraints refuse", async () => {
+		const dbPath = await createAgentSource();
+		let db = new Database(dbPath);
+		db.exec("ALTER TABLE settings ADD COLUMN drift TEXT");
+		closeWal(db);
+		let result = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("Structural drift");
+
+		await fs.rm(dbPath, { force: true });
+		await fs.rm(`${dbPath}-wal`, { force: true });
+		await fs.rm(`${dbPath}-shm`, { force: true });
+		await createAgentSource();
+		db = new Database(dbPath);
+		db.exec("CREATE TABLE unsafe_extension(value TEXT CHECK(length(value) > 0))");
+		closeWal(db);
+		result = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("Unsafe extension table shape");
+	});
+
+	test("sessions rebuild uses strict global ordering, adjacent deduplication, and FTS rank-1 integrity", async () => {
+		await createHistorySource();
+		await writeSession("b", "session-b", [
+			message("b1", "2026-01-01T00:00:03.900Z", "third prompt"),
+			message("b2", "2026-01-01T00:00:04.000Z", "ignored steering", { steering: true }),
+		]);
+		await writeSession("a", "session-a", [
+			message("a1", "2026-01-01T00:00:01.900Z", [
+				{ type: "text", text: "first " },
+				{ type: "image", data: "x", mimeType: "image/png" },
+				{ type: "text", text: "prompt" },
+			]),
+			message("a2", "2026-01-01T00:00:02.900Z", "first prompt"),
+			message("a3", "2026-01-01T00:00:03.100Z", "agent note", { attribution: "agent" }),
+		]);
+		const result = await runStorageRepair({
+			target: "history",
+			historySource: "sessions",
+			apply: true,
+			agentDir: root,
+		});
+		expect(result.status).toBe("ready");
+		expect(result.objects.find(object => object.name === "history")).toMatchObject({ action: "rebuilt" });
+		const db = new Database(result.candidate, { readonly: true, safeIntegers: true });
+		try {
+			expect(db.prepare("SELECT prompt, created_at, cwd, session_id FROM history ORDER BY id").all()).toEqual([
+				{ prompt: "first prompt", created_at: 1_767_225_601n, cwd: "/work/a", session_id: "session-a" },
+				{ prompt: "third prompt", created_at: 1_767_225_603n, cwd: "/work/b", session_id: "session-b" },
+			]);
+			expect(
+				db
+					.prepare("SELECT h.prompt FROM history_fts f JOIN history h ON h.id = f.rowid WHERE history_fts MATCH ?")
+					.get("third"),
+			).toEqual({ prompt: "third prompt" });
+		} finally {
+			db.close();
+		}
+	});
+
+	test("invalid or changing physical sessions refuse while zero sessions remains valid", async () => {
+		await createHistorySource();
+		let result = await runStorageRepair({
+			target: "history",
+			historySource: "sessions",
+			apply: false,
+			agentDir: root,
+		});
+		expect(result.status).toBe("ready");
+		const file = await writeSession("p", "bad", [message("m", "invalid", "prompt")]);
+		result = await runStorageRepair({ target: "history", historySource: "sessions", apply: false, agentDir: root });
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("Invalid timestamp");
+		await fs.rm(file);
+		const changing = await writeSession("p", "changing", [message("m", "2026-01-01T00:00:01.000Z", "prompt")]);
+		result = await runStorageRepair(
+			{ target: "history", historySource: "sessions", apply: false, agentDir: root },
+			{ afterSessionManifestParse: () => fs.appendFile(changing, "{}\n") },
+		);
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("Session directory changed");
+	});
+
+	test("fresh history is empty and reports explicit data loss", async () => {
+		await createHistorySource();
+		const result = await runStorageRepair({ target: "history", historySource: "fresh", apply: true, agentDir: root });
+		expect(result.status).toBe("ready");
+		expect(result.dataLoss).toBe(true);
+		const db = new Database(result.candidate, { readonly: true });
+		try {
+			expect(db.prepare("SELECT count(*) AS count FROM history").get()).toEqual({ count: 0 });
+		} finally {
+			db.close();
+		}
+	});
+
+	test("injected backup, verification, and no-replace publication failures clean staging and retain valid backup", async () => {
+		const dbPath = await createAgentSource();
+		const before = await fingerprint(dbPath);
+		let result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root },
+			{
+				beforeBackupWrite: () => {
+					throw new Error("backup injection");
+				},
+			},
+		);
+		expect(result.status).toBe("refused");
+		expect(result.backupCreated).toBe(false);
+		expect(await fingerprint(dbPath)).toEqual(before);
+
+		result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root },
+			{
+				beforeCandidateVerification: () => {
+					throw new Error("verification injection");
+				},
+			},
+		);
+		expect(result.status).toBe("refused");
+		expect(result.backupCreated).toBe(true);
+		expect(result.candidatePublished).toBe(false);
+		expect(await Bun.file(result.backup).exists()).toBe(true);
+
+		const racedCandidate = path.join(root, "raced-candidate.db");
+		let racerIdentity: Awaited<ReturnType<typeof fingerprint>> | undefined;
+		result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root, output: racedCandidate },
+			{
+				beforeCandidatePublication: async () => {
+					await Bun.write(racedCandidate, "racer");
+					racerIdentity = await fingerprint(racedCandidate);
+				},
+			},
+		);
+		expect(result.status).toBe("refused");
+		expect(result.backupCreated).toBe(true);
+		expect(result.candidatePublished).toBe(false);
+		expect(result.candidatePathTrusted).toBe(false);
+		expect(await Bun.file(result.candidate).text()).toBe("racer");
+		expect(await fingerprint(racedCandidate)).toEqual(requireValue(racerIdentity, "racer identity"));
+	});
+
+	test("late source mismatch after candidate link publishes an untrusted sealed candidate", async () => {
+		const dbPath = await createAgentSource();
+		const candidate = path.join(root, "publication-race.db");
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root, output: candidate },
+			{ afterCandidatePublication: () => fs.appendFile(dbPath, "publication race") },
+		);
+		expect(result.status).toBe("published-with-warning");
+		expect(result.warning).toContain("Live source triplet changed during storage repair");
+		expect(result.backupCreated).toBe(true);
+		expect(result.candidatePublished).toBe(true);
+		expect(result.candidatePathTrusted).toBe(false);
+		expect(await Bun.file(result.backup).exists()).toBe(true);
+		expect(await Bun.file(candidate).exists()).toBe(true);
+		const sealed = requireValue(
+			result.checksums.find(checksum => checksum.path === candidate),
+			"sealed candidate checksum",
+		);
+		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
+		const entries = await fs.readdir(root);
+		expect(entries.some(name => name.startsWith(`.${path.basename(candidate)}.candidate-`))).toBe(false);
+	});
+
+	test("late source mismatch never disturbs a replacement after candidate link", async () => {
+		const dbPath = await createAgentSource();
+		const candidate = path.join(root, "candidate-replacement.db");
+		const replacement = "replacement bytes must survive";
+		let replacementIdentity: Awaited<ReturnType<typeof fingerprint>> | undefined;
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root, output: candidate },
+			{
+				afterCandidatePublication: async () => {
+					await fs.unlink(candidate);
+					await Bun.write(candidate, replacement);
+					replacementIdentity = await fingerprint(candidate);
+					await fs.appendFile(dbPath, "late invariant refusal");
+				},
+			},
+		);
+		expect(result.status).toBe("published-with-warning");
+		expect(result.candidatePublished).toBe(true);
+		expect(result.candidatePathTrusted).toBe(false);
+		expect(await Bun.file(candidate).text()).toBe(replacement);
+		expect(await fingerprint(candidate)).toEqual(requireValue(replacementIdentity, "replacement identity"));
+		expect(await Bun.file(result.backup).exists()).toBe(true);
+		const sealed = requireValue(
+			result.checksums.find(checksum => checksum.path === candidate),
+			"sealed candidate checksum",
+		);
+		expect(sealed.sha256).not.toBe(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex"));
+	});
+
+	test("candidate stage-unlink failure warns and leaves the published candidate untouched", async () => {
+		await createAgentSource();
+		const candidate = path.join(root, "candidate-stage-unlink.db");
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root, output: candidate },
+			{
+				beforeCandidateStageUnlink: () => {
+					throw new Error("candidate stage-unlink injection");
+				},
+			},
+		);
+		expect(result.status).toBe("published-with-warning");
+		expect(result.warning).toContain("candidate stage-unlink injection");
+		expect(result.candidatePublished).toBe(true);
+		expect(result.candidatePathTrusted).toBe(false);
+		expect(await Bun.file(result.backup).exists()).toBe(true);
+		const sealed = requireValue(
+			result.checksums.find(checksum => checksum.path === candidate),
+			"sealed candidate checksum",
+		);
+		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
+		const entries = await fs.readdir(root);
+		expect(entries.some(name => name.startsWith(`.${path.basename(candidate)}.candidate-`))).toBe(false);
+	});
+
+	test("candidate directory-sync failure warns and leaves the published candidate untouched", async () => {
+		await createAgentSource();
+		const candidate = path.join(root, "candidate-directory-sync.db");
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root, output: candidate },
+			{
+				beforeCandidateDirectorySync: () => {
+					throw new Error("candidate directory-sync injection");
+				},
+			},
+		);
+		expect(result.status).toBe("published-with-warning");
+		expect(result.warning).toContain("candidate directory-sync injection");
+		expect(result.candidatePublished).toBe(true);
+		expect(result.candidatePathTrusted).toBe(false);
+		expect(await Bun.file(result.backup).exists()).toBe(true);
+		const sealed = requireValue(
+			result.checksums.find(checksum => checksum.path === candidate),
+			"sealed candidate checksum",
+		);
+		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
+	});
+
+	test("backup ownership survives a post-link staging-cleanup failure", async () => {
+		await createAgentSource();
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root },
+			{
+				afterBackupLink: () => {
+					throw new Error("backup post-link injection");
+				},
+			},
+		);
+		expect(result.status).toBe("refused");
+		expect(result.backupCreated).toBe(true);
+		expect(result.candidatePublished).toBe(false);
+		expect(await Bun.file(result.candidate).exists()).toBe(false);
+		expect(await Bun.file(result.backup).exists()).toBe(true);
+		const backup = requireValue(
+			result.checksums.find(checksum => checksum.path === result.backup),
+			"backup checksum",
+		);
+		expect(new Bun.SHA256().update(await Bun.file(result.backup).bytes()).digest("hex")).toBe(backup.sha256);
+		expect((await new Bun.Archive(await Bun.file(result.backup).bytes()).files()).get("manifest.json")).toBeDefined();
+		const entries = await fs.readdir(root);
+		expect(entries.some(name => name.startsWith(`.${path.basename(result.backup)}.backup-`))).toBe(false);
+	});
+
+	test("primary refusal and cleanup invariant failures retain both causes in deterministic order", async () => {
+		const dbPath = await createAgentSource();
+		const result = await runStorageRepair(
+			{ target: "agent", apply: false, agentDir: root },
+			{
+				beforeCandidateVerification: async () => {
+					await fs.appendFile(dbPath, "cleanup race");
+					throw new Error("primary verification refusal");
+				},
+			},
+		);
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toBe(
+			'Storage repair refusal: {"primary":"primary verification refusal","cleanupInvariant":["Live source triplet changed during storage repair"]}',
+		);
+		expect(result.objects.at(-1)?.detail).toBe(result.refusal);
+	});
+
+	test("backup publication consumes file-backed members without eager BunFile bytes reads", async () => {
+		await createAgentSource();
+		const originalFile = Bun.file;
+		const fileSpy = spyOn(Bun, "file").mockImplementation(((input, options) => {
+			const file = Reflect.apply(originalFile, Bun, [input, options]) as Bun.BunFile;
+			return new Proxy(file, {
+				get(target, property) {
+					if (property === "bytes") {
+						return () => {
+							throw new Error("eager BunFile.bytes read");
+						};
+					}
+					const value = Reflect.get(target, property, target);
+					return typeof value === "function" ? value.bind(target) : value;
+				},
+			});
+		}) as typeof Bun.file);
+		let result: StorageRepairResult;
+		try {
+			result = await runStorageRepair({ target: "agent", apply: true, agentDir: root });
+		} finally {
+			fileSpy.mockRestore();
+		}
+		expect(result.status).toBe("ready");
+		expect(result.backupCreated).toBe(true);
+		expect(await Bun.file(result.backup).exists()).toBe(true);
+	});
+
+	test("text and JSON reports are structured, nonzero-compatible, and include quarantine instructions", async () => {
+		await createHistorySource();
+		let result = await runGcCommand({
+			flags: { agentDir: root, repairStorage: "history", historySource: "fresh", apply: true },
+		});
+		expect(result.repair?.manualNextStep).toContain("quarantine");
+		expect(stdout.join("")).toContain("manual next step:");
+		expect(stdout.join("")).toContain("data loss: true");
+		expect(stdout.join("")).toContain("candidate: ");
+		expect(stdout.join("")).toContain("(published)");
+		expect(stdout.join("")).toContain("candidate path trusted: true");
+		stdout = [];
+		result = await runGcCommand({
+			flags: { agentDir: root, repairStorage: "history", historySource: "fresh", json: true },
+		});
+		const parsed = JSON.parse(stdout.join(""));
+		expect(parsed.repair.status).toBe("ready");
+		expect(parsed.repair.dataLoss).toBe(true);
+		expect(parsed.repair.candidatePublished).toBe(false);
+		expect(parsed.repair.candidatePathTrusted).toBe(false);
+		expect(parsed.repair.manualNextStep).toContain("quarantine");
+		expect(
+			collectGcErrors({
+				agentDir: root,
+				apply: true,
+				lockPath: path.join(root, "gc.lock"),
+				repair: { ...result.repair!, status: "published-with-warning", warning: "late source mismatch" },
+			}),
+		).toEqual(["repair: late source mismatch"]);
+	});
+});

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -661,6 +661,40 @@ describe("offline SQLite salvage", () => {
 		}
 	});
 
+	test("history rebuild ignores nested subagent and advisor transcripts", async () => {
+		await createHistorySource();
+		await writeSession("primary", "primary", [message("primary", "2026-01-01T00:00:01.000Z", "primary prompt")]);
+		const subagent = await writeSession(
+			path.join("primary", "__subagent"),
+			"nested",
+			[message("nested", "2026-01-01T00:00:02.000Z", "nested prompt")],
+		);
+		const advisor = await writeSession(
+			path.join("primary", "__advisor"),
+			"advisor",
+			[message("advisor", "2026-01-01T00:00:03.000Z", "advisor prompt")],
+		);
+		await fs.promises.appendFile(advisor, "{\"type\":\"message\"");
+
+		const result = await runStorageRepair(
+			{ target: "history", historySource: "sessions", apply: true, agentDir: root },
+			{
+				afterSessionManifestParse: () =>
+					fs.promises.appendFile(
+						subagent,
+						`${JSON.stringify(message("late", "2026-01-01T00:00:04.000Z", "late nested prompt"))}\n`,
+					),
+			},
+		);
+		expect(result.status).toBe("ready");
+		const db = new Database(result.candidate, { readonly: true, safeIntegers: true });
+		try {
+			expect(db.prepare("SELECT prompt FROM history ORDER BY id").all()).toEqual([{ prompt: "primary prompt" }]);
+		} finally {
+			db.close();
+		}
+	});
+
 	test("session manifest changes before publication refuse the candidate", async () => {
 		await createHistorySource();
 		await writeSession("first", "first-session", [message("m", "2026-01-01T00:00:01.000Z", "first")]);

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -220,24 +220,25 @@ async function stageArtifacts(finalPath: string, label: "backup" | "candidate") 
 }
 
 describe("offline SQLite salvage", () => {
-	test("rejects normalized and case-insensitive source-triplet artifact aliases", async () => {
+	test("rejects normalized and mixed-case source-triplet artifact aliases on caseless platforms", async () => {
 		const source = path.join(root, "agent.db");
 		await fs.promises.writeFile(source, "source");
-		const options = { comparisonMode: "case-insensitive" } as const;
 
-		await expect(resolveArtifactPaths(source, path.join(root, "nested", "..", "agent.db"), options)).rejects.toThrow(
-			"Repair output already exists",
-		);
-
-		for (const output of [
-			path.join(root, "nested", "..", "agent.db-wal"),
-			path.join(root, "nested", "..", "agent.db-shm"),
-			path.join(root, "AGENT.DB-WAL"),
-			path.join(root, "AGENT.DB-SHM"),
-		]) {
-			await expect(resolveArtifactPaths(source, output, options)).rejects.toThrow(
-				"Repair artifact collides with source triplet",
-			);
+		for (const platform of ["darwin", "win32"] as const) {
+			const options = { platform: () => platform };
+			await expect(
+				resolveArtifactPaths(source, path.join(root, "nested", "..", "agent.db"), options),
+			).rejects.toThrow("Repair output already exists");
+			for (const output of [
+				path.join(root, "nested", "..", "agent.db-wal"),
+				path.join(root, "nested", "..", "agent.db-shm"),
+				path.join(root, "AGENT.DB-WAL"),
+				path.join(root, "AGENT.DB-SHM"),
+			]) {
+				await expect(resolveArtifactPaths(source, output, options)).rejects.toThrow(
+					"Repair artifact collides with source triplet",
+				);
+			}
 		}
 	});
 
@@ -246,12 +247,14 @@ describe("offline SQLite salvage", () => {
 		const slug = "fixed";
 		await fs.promises.writeFile(source, "source");
 
-		await expect(
-			resolveArtifactPaths(source, path.join(root, "nested", "..", `agent.db.salvage-${slug}.tar`), {
-				comparisonMode: "case-insensitive",
-				artifactSlug: () => slug,
-			}),
-		).rejects.toThrow("Candidate and backup paths collide");
+		for (const platform of ["darwin", "win32"] as const) {
+			await expect(
+				resolveArtifactPaths(source, path.join(root, "nested", "..", `agent.db.salvage-${slug}.tar`), {
+					platform: () => platform,
+					artifactSlug: () => slug,
+				}),
+			).rejects.toThrow("Candidate and backup paths collide");
+		}
 	});
 
 	test("rejects Unicode-normalized source-sidecar and candidate-backup aliases", async () => {
@@ -262,37 +265,31 @@ describe("offline SQLite salvage", () => {
 		const slug = "fixed";
 		await fs.promises.writeFile(source, "source");
 
-		await expect(
-			resolveArtifactPaths(source, `${alias}-wal`, { comparisonMode: "case-insensitive" }),
-		).rejects.toThrow("Repair artifact collides with source triplet");
-		await expect(
-			resolveArtifactPaths(source, `${alias}.salvage-${slug}.tar`, {
-				comparisonMode: "case-insensitive",
-				artifactSlug: () => slug,
-			}),
-		).rejects.toThrow("Candidate and backup paths collide");
-	});
-
-	test("rejects full Unicode casefold source-sidecar and candidate-backup aliases", async () => {
-		const slug = "fixed";
-		for (const { sourceName, aliasName } of [
-			{ sourceName: "agent-ος.db", aliasName: "agent-οσ.db" },
-			{ sourceName: "agent-straße.db", aliasName: "agent-STRASSE.db" },
-		]) {
-			const source = path.join(root, sourceName);
-			const alias = path.join(root, aliasName);
-			await fs.promises.writeFile(source, "source");
-
-			await expect(
-				resolveArtifactPaths(source, `${alias}-shm`, { comparisonMode: "case-insensitive" }),
-			).rejects.toThrow("Repair artifact collides with source triplet");
+		for (const platform of ["darwin", "win32"] as const) {
+			await expect(resolveArtifactPaths(source, `${alias}-wal`, { platform: () => platform })).rejects.toThrow(
+				"Repair artifact collides with source triplet",
+			);
 			await expect(
 				resolveArtifactPaths(source, `${alias}.salvage-${slug}.tar`, {
-					comparisonMode: "case-insensitive",
+					platform: () => platform,
 					artifactSlug: () => slug,
 				}),
 			).rejects.toThrow("Candidate and backup paths collide");
 		}
+	});
+
+	test("rejects full Unicode folds on caseless platforms but not Linux", async () => {
+		const source = path.join(root, "agent-straße.db");
+		const alias = path.join(root, "AGENT-STRASSE.DB");
+		await fs.promises.writeFile(source, "source");
+
+		for (const platform of ["darwin", "win32"] as const) {
+			await expect(resolveArtifactPaths(source, `${alias}-shm`, { platform: () => platform })).rejects.toThrow(
+				"Repair artifact collides with source triplet",
+			);
+		}
+		const artifacts = await resolveArtifactPaths(source, `${alias}-shm`, { platform: () => "linux" });
+		expect(artifacts.candidate).toBe(`${alias}-shm`);
 	});
 
 	test("accepts distinct repair artifact paths", async () => {
@@ -300,7 +297,7 @@ describe("offline SQLite salvage", () => {
 		const candidate = path.join(root, "repaired.db");
 		await fs.promises.writeFile(source, "source");
 
-		const artifacts = await resolveArtifactPaths(source, candidate, { comparisonMode: "case-insensitive" });
+		const artifacts = await resolveArtifactPaths(source, candidate, { platform: () => "linux" });
 		expect(artifacts.candidate).toBe(candidate);
 		expect(artifacts.backup).not.toBe(candidate);
 	});

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -599,7 +599,9 @@ describe("offline SQLite salvage", () => {
 					const stage = requireValue((await stageArtifacts(candidate, "candidate")).at(0), "candidate stage");
 					const stagedDb = new Database(path.join(root, stage), { safeIntegers: true });
 					try {
-						stagedDb.prepare("UPDATE ext_notes SET payload = ? WHERE key = ?").run(new Uint8Array([255, 1, 0]), "note");
+						stagedDb
+							.prepare("UPDATE ext_notes SET payload = ? WHERE key = ?")
+							.run(new Uint8Array([255, 1, 0]), "note");
 					} finally {
 						closeWal(stagedDb);
 					}

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -570,7 +570,7 @@ describe("offline SQLite salvage", () => {
 				{
 					beforeCandidateVerification: async () => {
 						const stage = requireValue(
-							(await stageArtifacts(candidate, "candidate")).find(name => name.endsWith(".stage")),
+							(await stageArtifacts(candidate, "candidate")).find(name => name.endsWith(".tmp")),
 							"candidate database stage",
 						);
 						const stagedDb = new Database(path.join(root, stage), { safeIntegers: true });
@@ -600,7 +600,7 @@ describe("offline SQLite salvage", () => {
 			{
 				beforeCandidateVerification: async () => {
 					const stage = requireValue(
-						(await stageArtifacts(candidate, "candidate")).find(name => name.endsWith(".stage")),
+						(await stageArtifacts(candidate, "candidate")).find(name => name.endsWith(".tmp")),
 						"candidate database stage",
 					);
 					const stagedDb = new Database(path.join(root, stage), { safeIntegers: true });

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -661,6 +661,36 @@ describe("offline SQLite salvage", () => {
 		}
 	});
 
+	test("history rebuild ignores nested subagent and advisor transcripts", async () => {
+		await createHistorySource();
+		await writeSession("primary", "primary", [message("primary", "2026-01-01T00:00:01.000Z", "primary prompt")]);
+		const subagent = await writeSession(path.join("primary", "__subagent"), "nested", [
+			message("nested", "2026-01-01T00:00:02.000Z", "nested prompt"),
+		]);
+		const advisor = await writeSession(path.join("primary", "__advisor"), "advisor", [
+			message("advisor", "2026-01-01T00:00:03.000Z", "advisor prompt"),
+		]);
+		await fs.promises.appendFile(advisor, '{"type":"message"');
+
+		const result = await runStorageRepair(
+			{ target: "history", historySource: "sessions", apply: true, agentDir: root },
+			{
+				afterSessionManifestParse: () =>
+					fs.promises.appendFile(
+						subagent,
+						`${JSON.stringify(message("late", "2026-01-01T00:00:04.000Z", "late nested prompt"))}\n`,
+					),
+			},
+		);
+		expect(result.status).toBe("ready");
+		const db = new Database(result.candidate, { readonly: true, safeIntegers: true });
+		try {
+			expect(db.prepare("SELECT prompt FROM history ORDER BY id").all()).toEqual([{ prompt: "primary prompt" }]);
+		} finally {
+			db.close();
+		}
+	});
+
 	test("session manifest changes before publication refuse the candidate", async () => {
 		await createHistorySource();
 		await writeSession("first", "first-session", [message("m", "2026-01-01T00:00:01.000Z", "first")]);

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -1738,6 +1738,45 @@ describe("offline SQLite salvage", () => {
 		expect(result.refusal).toContain("Published output no longer matches staging file");
 	});
 
+	test("backup mutation after publication downgrades backupVerified on final revalidation", async () => {
+		await createAgentSource();
+		let mutation: { before: FileFingerprint; after: FileFingerprint } | undefined;
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root },
+			{
+				beforeCandidatePublication: async () => {
+					const directory = path.dirname(getAgentDbPath(root));
+					const name = requireValue(
+						(await fs.promises.readdir(directory)).find(entry => entry.endsWith(".tar")),
+						"published backup",
+					);
+					const backup = path.join(directory, name);
+					const before = await fingerprint(backup);
+					const bytes = await Bun.file(backup).bytes();
+					bytes[0] ^= 0xff;
+					const handle = await fs.promises.open(backup, "r+");
+					try {
+						await handle.write(bytes, 0, bytes.byteLength, 0);
+						await handle.sync();
+					} finally {
+						await handle.close();
+					}
+					mutation = { before, after: await fingerprint(backup) };
+				},
+			},
+		);
+		const { before, after } = requireValue(mutation, "backup post-publication mutation");
+		expect(after).toMatchObject({ dev: before.dev, ino: before.ino, size: before.size });
+		expect(after.sha256).not.toBe(before.sha256);
+		expect(result.backupCreated).toBe(true);
+		expect(result.candidatePublished).toBe(true);
+		expect(result.backupVerified).toBe(false);
+		expect(result.status).toBe("published-with-warning");
+		expect(result.candidatePathTrusted).toBe(false);
+		expect(result.warning).toContain("changed after verification");
+		expect(result.manualNextStep).not.toContain("Retain verified backup");
+	});
+
 	test("primary refusal and cleanup invariant failures retain both causes in deterministic order", async () => {
 		const dbPath = await createAgentSource();
 		const result = await runStorageRepair(

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -36,6 +36,15 @@ function requireValue<T>(value: T | undefined, label: string): T {
 	return value;
 }
 
+function checksumPathCounts(result: StorageRepairResult): Record<string, number> {
+	return Object.fromEntries(
+		result.checksums.reduce((counts, checksum) => {
+			counts.set(checksum.path, (counts.get(checksum.path) ?? 0) + 1);
+			return counts;
+		}, new Map<string, number>()),
+	);
+}
+
 beforeEach(async () => {
 	root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-storage-repair-test-"));
 	stdout = [];
@@ -440,6 +449,7 @@ describe("offline SQLite salvage", () => {
 		expect(result.backupCreated).toBe(true);
 		expect(result.candidatePublished).toBe(true);
 		expect(result.candidatePathTrusted).toBe(true);
+		expect(checksumPathCounts(result)).toEqual({ [result.backup]: 1, [result.candidate]: 1 });
 		expect(await artifactModes(result)).toEqual({ backup: 0o600, candidate: 0o600 });
 		const archive = new Bun.Archive(await Bun.file(result.backup).bytes());
 		const files = await archive.files();
@@ -1004,6 +1014,7 @@ describe("offline SQLite salvage", () => {
 		expect(result.warning).toContain("Published output no longer matches staging file");
 		expect(result.candidatePublished).toBe(true);
 		expect(result.candidatePathTrusted).toBe(false);
+		expect(checksumPathCounts(result)).toEqual({ [result.backup]: 1, [candidate]: 1 });
 		expect(await Bun.file(candidate).text()).toBe(replacement);
 		expect(await fingerprint(candidate)).toEqual(requireValue(replacementIdentity, "replacement identity"));
 		const sealed = requireValue(
@@ -1136,7 +1147,7 @@ describe("offline SQLite salvage", () => {
 		expect(await fingerprint(candidate)).toEqual(requireValue(replacementIdentity, "replacement identity"));
 	});
 
-	test("backup ownership survives a post-link staging-cleanup failure", async () => {
+	test("backup post-link hook failure records the link without a verified checksum", async () => {
 		await createAgentSource();
 		const result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root },
@@ -1149,14 +1160,9 @@ describe("offline SQLite salvage", () => {
 		expect(result.status).toBe("refused");
 		expect(result.backupCreated).toBe(true);
 		expect(result.candidatePublished).toBe(false);
+		expect(checksumPathCounts(result)).toEqual({});
 		expect(await Bun.file(result.candidate).exists()).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
-		const backup = requireValue(
-			result.checksums.find(checksum => checksum.path === result.backup),
-			"backup checksum",
-		);
-		expect(new Bun.SHA256().update(await Bun.file(result.backup).bytes()).digest("hex")).toBe(backup.sha256);
-		expect((await new Bun.Archive(await Bun.file(result.backup).bytes()).files()).get("manifest.json")).toBeDefined();
 		const entries = await fs.promises.readdir(root);
 		expect(entries.some(name => name.startsWith(`.${path.basename(result.backup)}.backup-`))).toBe(false);
 	});
@@ -1181,7 +1187,7 @@ describe("offline SQLite salvage", () => {
 		);
 		expect(result.status).toBe("refused");
 		expect(result.backupCreated).toBe(true);
-		expect(result.checksums.some(checksum => checksum.path === result.backup)).toBe(true);
+		expect(checksumPathCounts(result)).toEqual({});
 		expect(await Bun.file(result.backup).text()).toBe(replacement);
 		expect(await fingerprint(result.backup)).toEqual(requireValue(replacementIdentity, "replacement identity"));
 	});
@@ -1219,6 +1225,7 @@ describe("offline SQLite salvage", () => {
 		expect(result.status).toBe("refused");
 		expect(result.backupCreated).toBe(true);
 		expect(result.candidatePublished).toBe(false);
+		expect(checksumPathCounts(result)).toEqual({});
 		expect(result.refusal).toContain("Published output content changed");
 	});
 
@@ -1249,6 +1256,7 @@ describe("offline SQLite salvage", () => {
 		expect(result.status).toBe("refused");
 		expect(result.backupCreated).toBe(true);
 		expect(result.candidatePublished).toBe(false);
+		expect(checksumPathCounts(result)).toEqual({});
 		expect(result.refusal).toContain("Published output no longer matches staging file");
 	});
 

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -338,6 +338,7 @@ describe("offline SQLite salvage", () => {
 		const siblings = await fs.promises.readdir(path.dirname(dbPath));
 		const result = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
 		expect(result.status).toBe("ready");
+		expect(result.dataLoss).toBe(false);
 		expect(result.backupCreated).toBe(false);
 		expect(result.candidatePublished).toBe(false);
 		expect(result.candidatePathTrusted).toBe(false);
@@ -498,7 +499,12 @@ describe("offline SQLite salvage", () => {
 		await corruptTablePage(dbPath, "cache");
 		const result = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
 		expect(result.status).toBe("ready");
+		expect(result.dataLoss).toBe(true);
 		expect(result.objects).toContainEqual(expect.objectContaining({ name: "cache", action: "omitted" }));
+
+		const gcResult = await runGcCommand({ flags: { agentDir: root, repairStorage: "agent" } });
+		expect(gcResult.repair?.dataLoss).toBe(true);
+		expect(stdout.join("")).toContain("registered rebuildable tables omitted: cache");
 	});
 
 	test("authoritative page corruption refuses with the SQLite cause", async () => {

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -569,7 +569,10 @@ describe("offline SQLite salvage", () => {
 				{ target: "agent", apply: true, agentDir: root, output: candidate },
 				{
 					beforeCandidateVerification: async () => {
-						const stage = requireValue((await stageArtifacts(candidate, "candidate")).at(0), "candidate stage");
+						const stage = requireValue(
+							(await stageArtifacts(candidate, "candidate")).find(name => name.endsWith(".stage")),
+							"candidate database stage",
+						);
 						const stagedDb = new Database(path.join(root, stage), { safeIntegers: true });
 						try {
 							mutate(stagedDb);
@@ -596,7 +599,10 @@ describe("offline SQLite salvage", () => {
 			{ target: "agent", apply: true, agentDir: root, output: candidate },
 			{
 				beforeCandidateVerification: async () => {
-					const stage = requireValue((await stageArtifacts(candidate, "candidate")).at(0), "candidate stage");
+					const stage = requireValue(
+						(await stageArtifacts(candidate, "candidate")).find(name => name.endsWith(".stage")),
+						"candidate database stage",
+					);
 					const stagedDb = new Database(path.join(root, stage), { safeIntegers: true });
 					try {
 						stagedDb

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -378,6 +378,32 @@ describe("offline SQLite salvage", () => {
 		expect(result.objects).toContainEqual(expect.objectContaining({ name: "ext_notes_touch", action: "preserved" }));
 	});
 
+	test("agent repair preserves AUTOINCREMENT high-water marks after the highest row is deleted", async () => {
+		const dbPath = await createAgentSource();
+		const source = new Database(dbPath, { safeIntegers: true });
+		source.exec("CREATE TABLE ext_autoincrement(id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT)");
+		const insert = source.prepare("INSERT INTO ext_autoincrement(value) VALUES (?)");
+		insert.run("first");
+		insert.run("second");
+		insert.run("deleted-high-water");
+		insert.finalize();
+		source.exec("DELETE FROM ext_autoincrement WHERE id = 3");
+		closeWithPhysicalWal(source);
+
+		const result = await runStorageRepair({ target: "agent", apply: true, agentDir: root });
+		expect(result.status).toBe("ready");
+		const candidate = new Database(result.candidate, { safeIntegers: true });
+		try {
+			expect(candidate.prepare("SELECT seq FROM sqlite_sequence WHERE name = ?").get("ext_autoincrement")).toEqual({
+				seq: 3n,
+			});
+			candidate.prepare("INSERT INTO ext_autoincrement(value) VALUES (?)").run("next");
+			expect(candidate.prepare("SELECT id FROM ext_autoincrement WHERE value = ?").get("next")).toEqual({ id: 4n });
+		} finally {
+			candidate.close();
+		}
+	});
+
 	test("only a registered corrupt derived table may be omitted", async () => {
 		const dbPath = await createAgentSource();
 		const db = new Database(dbPath);
@@ -484,7 +510,10 @@ describe("offline SQLite salvage", () => {
 		await writeSession(
 			"legacy",
 			"legacy-session",
-			[message("m", "2026-01-01T00:00:01.000Z", "東京 café résumé")],
+			[
+				message("synthetic", "2026-01-01T00:00:00.000Z", "synthetic legacy prompt", { synthetic: true }),
+				message("m", "2026-01-01T00:00:01.000Z", "東京 café résumé"),
+			],
 			"legacy-slotless",
 		);
 		const result = await runStorageRepair({
@@ -497,7 +526,7 @@ describe("offline SQLite salvage", () => {
 		expect(result.dataLoss).toBe(true);
 		const db = new Database(result.candidate, { readonly: true, safeIntegers: true });
 		try {
-			expect(db.prepare("SELECT prompt FROM history").get()).toEqual({ prompt: "東京 café résumé" });
+			expect(db.prepare("SELECT prompt FROM history ORDER BY id").all()).toEqual([{ prompt: "東京 café résumé" }]);
 		} finally {
 			db.close();
 		}
@@ -559,6 +588,23 @@ describe("offline SQLite salvage", () => {
 		expect(result.refusal).toContain("Session directory changed");
 	});
 
+	test("Windows publication skips directory fsync without weakening file verification", async () => {
+		await createAgentSource();
+		let directorySyncs = 0;
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root },
+			{
+				isWindows: () => true,
+				onDirectorySync: () => {
+					directorySyncs += 1;
+				},
+			},
+		);
+		expect(result.status).toBe("ready");
+		expect(result.candidatePathTrusted).toBe(true);
+		expect(directorySyncs).toBe(0);
+	});
+
 	test("fresh history is empty and reports explicit data loss", async () => {
 		await createHistorySource();
 		const result = await runStorageRepair({ target: "history", historySource: "fresh", apply: true, agentDir: root });
@@ -616,6 +662,11 @@ describe("offline SQLite salvage", () => {
 		expect(result.candidatePublished).toBe(false);
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(result.candidate).text()).toBe("racer");
+		const staged = requireValue(
+			result.checksums.find(checksum => checksum.ephemeral),
+			"staged candidate checksum",
+		);
+		expect(staged.path).not.toBe(result.candidate);
 		expect(await fingerprint(racedCandidate)).toEqual(requireValue(racerIdentity, "racer identity"));
 	});
 
@@ -634,9 +685,10 @@ describe("offline SQLite salvage", () => {
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 		expect(await Bun.file(candidate).exists()).toBe(true);
 		const sealed = requireValue(
-			result.checksums.find(checksum => checksum.path === candidate),
-			"sealed candidate checksum",
+			result.checksums.find(checksum => checksum.path === candidate && !checksum.ephemeral),
+			"published candidate checksum",
 		);
+		expect(sealed.ephemeral).toBe(false);
 		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
 		const entries = await fs.promises.readdir(root);
 		expect(entries.some(name => name.startsWith(`.${path.basename(candidate)}.candidate-`))).toBe(false);
@@ -667,7 +719,7 @@ describe("offline SQLite salvage", () => {
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 	});
 
-	test("candidate stage-unlink failure refuses an output that could not be proven through cleanup", async () => {
+	test("candidate stage-unlink failure warns after proving the linked output", async () => {
 		await createAgentSource();
 		const candidate = path.join(root, "candidate-stage-unlink.db");
 		const result = await runStorageRepair(
@@ -678,9 +730,9 @@ describe("offline SQLite salvage", () => {
 				},
 			},
 		);
-		expect(result.status).toBe("refused");
-		expect(result.refusal).toContain("candidate stage-unlink injection");
-		expect(result.candidatePublished).toBe(false);
+		expect(result.status).toBe("published-with-warning");
+		expect(result.warning).toContain("candidate stage-unlink injection");
+		expect(result.candidatePublished).toBe(true);
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 		expect(await Bun.file(candidate).exists()).toBe(true);
@@ -703,9 +755,10 @@ describe("offline SQLite salvage", () => {
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 		const sealed = requireValue(
-			result.checksums.find(checksum => checksum.path === candidate),
+			result.checksums.find(checksum => checksum.ephemeral),
 			"sealed candidate checksum",
 		);
+		expect(sealed.path).not.toBe(candidate);
 		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
 	});
 
@@ -755,6 +808,31 @@ describe("offline SQLite salvage", () => {
 		expect((await new Bun.Archive(await Bun.file(result.backup).bytes()).files()).get("manifest.json")).toBeDefined();
 		const entries = await fs.promises.readdir(root);
 		expect(entries.some(name => name.startsWith(`.${path.basename(result.backup)}.backup-`))).toBe(false);
+	});
+
+	test("backup post-link replacement refuses without claiming the replacement as verified", async () => {
+		await createAgentSource();
+		const replacement = "backup replacement must survive";
+		let replacementIdentity: FileFingerprint | undefined;
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root },
+			{
+				afterBackupLink: async () => {
+					const directory = path.dirname(getAgentDbPath(root));
+					const name = (await fs.promises.readdir(directory)).find(entry => entry.endsWith(".tar"));
+					if (!name) throw new Error("Linked backup is missing");
+					const backup = path.join(directory, name);
+					await fs.promises.unlink(backup);
+					await Bun.write(backup, replacement);
+					replacementIdentity = await fingerprint(backup);
+				},
+			},
+		);
+		expect(result.status).toBe("refused");
+		expect(result.backupCreated).toBe(false);
+		expect(result.checksums.some(checksum => checksum.path === result.backup)).toBe(false);
+		expect(await Bun.file(result.backup).text()).toBe(replacement);
+		expect(await fingerprint(result.backup)).toEqual(requireValue(replacementIdentity, "replacement identity"));
 	});
 
 	test("primary refusal and cleanup invariant failures retain both causes in deterministic order", async () => {
@@ -843,5 +921,35 @@ describe("offline SQLite salvage", () => {
 		expect(result.repair?.dataLoss).toBe(true);
 		expect(stdout.join("")).toContain("session rebuild retains only session messages");
 		expect(stdout.join("")).toContain("stable row IDs are not preserved");
+	});
+
+	test("dry-run and published candidates report distinct checksum lifecycles", async () => {
+		await createAgentSource();
+		const dryRun = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
+		const staged = requireValue(
+			dryRun.checksums.find(checksum => checksum.ephemeral),
+			"staged candidate checksum",
+		);
+		expect(staged.path).not.toBe(dryRun.candidate);
+		expect(staged.ephemeral).toBe(true);
+
+		const published = await runStorageRepair({ target: "agent", apply: true, agentDir: root });
+		const candidate = requireValue(
+			published.checksums.find(checksum => checksum.path === published.candidate),
+			"published candidate checksum",
+		);
+		expect(candidate.ephemeral).toBe(false);
+	});
+
+	test("text and JSON reports label staged candidate digests as ephemeral", async () => {
+		await createAgentSource();
+		await runGcCommand({ flags: { agentDir: root, repairStorage: "agent" } });
+		expect(stdout.join("")).toContain("(ephemeral staging)");
+		stdout = [];
+		await runGcCommand({ flags: { agentDir: root, repairStorage: "agent", json: true } });
+		const parsed = JSON.parse(stdout.join(""));
+		const staged = parsed.repair.checksums.find((checksum: { ephemeral: boolean }) => checksum.ephemeral);
+		expect(staged.path).not.toBe(parsed.repair.candidate);
+		expect(staged.ephemeral).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -713,13 +713,9 @@ describe("offline SQLite salvage", () => {
 	test("injected backup, verification, and no-replace publication failures clean staging and retain valid backup", async () => {
 		const dbPath = await createAgentSource();
 		const before = await fingerprint(dbPath);
-		let snapshotTempDir: string | undefined;
 		let result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root },
 			{
-				afterPristineCopy: tempDir => {
-					snapshotTempDir = tempDir;
-				},
 				beforeBackupWrite: () => {
 					throw new Error("backup injection");
 				},
@@ -728,17 +724,10 @@ describe("offline SQLite salvage", () => {
 		expect(result.status).toBe("refused");
 		expect(result.backupCreated).toBe(false);
 		expect(await fingerprint(dbPath)).toEqual(before);
-		await expect(fs.promises.lstat(requireValue(snapshotTempDir, "backup snapshot directory"))).rejects.toMatchObject({
-			code: "ENOENT",
-		});
 
-		snapshotTempDir = undefined;
 		result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root },
 			{
-				afterPristineCopy: tempDir => {
-					snapshotTempDir = tempDir;
-				},
 				beforeCandidateVerification: () => {
 					throw new Error("verification injection");
 				},
@@ -748,9 +737,6 @@ describe("offline SQLite salvage", () => {
 		expect(result.backupCreated).toBe(true);
 		expect(result.candidatePublished).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
-		await expect(fs.promises.lstat(requireValue(snapshotTempDir, "verification snapshot directory"))).rejects.toMatchObject({
-			code: "ENOENT",
-		});
 
 		const racedCandidate = path.join(root, "raced-candidate.db");
 		let racerIdentity: FileFingerprint | undefined;
@@ -779,15 +765,9 @@ describe("offline SQLite salvage", () => {
 	test("late source mismatch after candidate link publishes an untrusted sealed candidate", async () => {
 		const dbPath = await createAgentSource();
 		const candidate = path.join(root, "publication-race.db");
-		let snapshotTempDir: string | undefined;
 		const result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root, output: candidate },
-			{
-				afterPristineCopy: tempDir => {
-					snapshotTempDir = tempDir;
-				},
-				afterCandidatePublication: () => fs.promises.appendFile(dbPath, "publication race"),
-			},
+			{ afterCandidatePublication: () => fs.promises.appendFile(dbPath, "publication race") },
 		);
 		expect(result.status).toBe("published-with-warning");
 		expect(result.warning).toContain("Live source triplet changed during storage repair");
@@ -796,9 +776,6 @@ describe("offline SQLite salvage", () => {
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 		expect(await Bun.file(candidate).exists()).toBe(true);
-		await expect(fs.promises.lstat(requireValue(snapshotTempDir, "published warning snapshot directory"))).rejects.toMatchObject({
-			code: "ENOENT",
-		});
 		const sealed = requireValue(
 			result.checksums.find(checksum => checksum.path === candidate && !checksum.ephemeral),
 			"published candidate checksum",

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -220,25 +220,24 @@ async function stageArtifacts(finalPath: string, label: "backup" | "candidate") 
 }
 
 describe("offline SQLite salvage", () => {
-	test("rejects normalized and mixed-case source-triplet artifact aliases on caseless platforms", async () => {
+	test("rejects normalized and case-insensitive source-triplet artifact aliases", async () => {
 		const source = path.join(root, "agent.db");
 		await fs.promises.writeFile(source, "source");
+		const options = { comparisonMode: "case-insensitive" } as const;
 
-		for (const platform of ["darwin", "win32"] as const) {
-			const options = { platform: () => platform };
-			await expect(resolveArtifactPaths(source, path.join(root, "nested", "..", "agent.db"), options)).rejects.toThrow(
-				"Repair output already exists",
+		await expect(resolveArtifactPaths(source, path.join(root, "nested", "..", "agent.db"), options)).rejects.toThrow(
+			"Repair output already exists",
+		);
+
+		for (const output of [
+			path.join(root, "nested", "..", "agent.db-wal"),
+			path.join(root, "nested", "..", "agent.db-shm"),
+			path.join(root, "AGENT.DB-WAL"),
+			path.join(root, "AGENT.DB-SHM"),
+		]) {
+			await expect(resolveArtifactPaths(source, output, options)).rejects.toThrow(
+				"Repair artifact collides with source triplet",
 			);
-			for (const output of [
-				path.join(root, "nested", "..", "agent.db-wal"),
-				path.join(root, "nested", "..", "agent.db-shm"),
-				path.join(root, "AGENT.DB-WAL"),
-				path.join(root, "AGENT.DB-SHM"),
-			]) {
-				await expect(resolveArtifactPaths(source, output, options)).rejects.toThrow(
-					"Repair artifact collides with source triplet",
-				);
-			}
 		}
 	});
 
@@ -247,14 +246,12 @@ describe("offline SQLite salvage", () => {
 		const slug = "fixed";
 		await fs.promises.writeFile(source, "source");
 
-		for (const platform of ["darwin", "win32"] as const) {
-			await expect(
-				resolveArtifactPaths(source, path.join(root, "nested", "..", `agent.db.salvage-${slug}.tar`), {
-					platform: () => platform,
-					artifactSlug: () => slug,
-				}),
-			).rejects.toThrow("Candidate and backup paths collide");
-		}
+		await expect(
+			resolveArtifactPaths(source, path.join(root, "nested", "..", `agent.db.salvage-${slug}.tar`), {
+				comparisonMode: "case-insensitive",
+				artifactSlug: () => slug,
+			}),
+		).rejects.toThrow("Candidate and backup paths collide");
 	});
 
 	test("rejects Unicode-normalized source-sidecar and candidate-backup aliases", async () => {
@@ -265,31 +262,37 @@ describe("offline SQLite salvage", () => {
 		const slug = "fixed";
 		await fs.promises.writeFile(source, "source");
 
-		for (const platform of ["darwin", "win32"] as const) {
+		await expect(
+			resolveArtifactPaths(source, `${alias}-wal`, { comparisonMode: "case-insensitive" }),
+		).rejects.toThrow("Repair artifact collides with source triplet");
+		await expect(
+			resolveArtifactPaths(source, `${alias}.salvage-${slug}.tar`, {
+				comparisonMode: "case-insensitive",
+				artifactSlug: () => slug,
+			}),
+		).rejects.toThrow("Candidate and backup paths collide");
+	});
+
+	test("rejects full Unicode casefold source-sidecar and candidate-backup aliases", async () => {
+		const slug = "fixed";
+		for (const { sourceName, aliasName } of [
+			{ sourceName: "agent-ος.db", aliasName: "agent-οσ.db" },
+			{ sourceName: "agent-straße.db", aliasName: "agent-STRASSE.db" },
+		]) {
+			const source = path.join(root, sourceName);
+			const alias = path.join(root, aliasName);
+			await fs.promises.writeFile(source, "source");
+
 			await expect(
-				resolveArtifactPaths(source, `${alias}-wal`, { platform: () => platform }),
+				resolveArtifactPaths(source, `${alias}-shm`, { comparisonMode: "case-insensitive" }),
 			).rejects.toThrow("Repair artifact collides with source triplet");
 			await expect(
 				resolveArtifactPaths(source, `${alias}.salvage-${slug}.tar`, {
-					platform: () => platform,
+					comparisonMode: "case-insensitive",
 					artifactSlug: () => slug,
 				}),
 			).rejects.toThrow("Candidate and backup paths collide");
 		}
-	});
-
-	test("rejects full Unicode folds on caseless platforms but not Linux", async () => {
-		const source = path.join(root, "agent-straße.db");
-		const alias = path.join(root, "AGENT-STRASSE.DB");
-		await fs.promises.writeFile(source, "source");
-
-		for (const platform of ["darwin", "win32"] as const) {
-			await expect(
-				resolveArtifactPaths(source, `${alias}-shm`, { platform: () => platform }),
-			).rejects.toThrow("Repair artifact collides with source triplet");
-		}
-		const artifacts = await resolveArtifactPaths(source, `${alias}-shm`, { platform: () => "linux" });
-		expect(artifacts.candidate).toBe(`${alias}-shm`);
 	});
 
 	test("accepts distinct repair artifact paths", async () => {
@@ -297,7 +300,7 @@ describe("offline SQLite salvage", () => {
 		const candidate = path.join(root, "repaired.db");
 		await fs.promises.writeFile(source, "source");
 
-		const artifacts = await resolveArtifactPaths(source, candidate, { platform: () => "linux" });
+		const artifacts = await resolveArtifactPaths(source, candidate, { comparisonMode: "case-insensitive" });
 		expect(artifacts.candidate).toBe(candidate);
 		expect(artifacts.backup).not.toBe(candidate);
 	});
@@ -598,8 +601,7 @@ describe("offline SQLite salvage", () => {
 		await createHistorySource();
 		await writeSession("b", "session-b", [
 			message("b1", "2026-01-01T00:00:03.900Z", "third prompt"),
-			message("b2", "2026-01-01T00:00:04.000Z", "user steering", { steering: true, attribution: "user" }),
-			message("b3", "2026-01-01T00:00:04.100Z", "agent steering", { steering: true, attribution: "agent" }),
+			message("b2", "2026-01-01T00:00:04.000Z", "ignored steering", { steering: true }),
 		]);
 		await writeSession("a", "session-a", [
 			message("a1", "2026-01-01T00:00:01.900Z", [
@@ -624,7 +626,6 @@ describe("offline SQLite salvage", () => {
 			expect(db.prepare("SELECT prompt, created_at, cwd, session_id FROM history ORDER BY id").all()).toEqual([
 				{ prompt: "first prompt", created_at: 1_767_225_601n, cwd: "/work/a", session_id: "session-a" },
 				{ prompt: "third prompt", created_at: 1_767_225_603n, cwd: "/work/b", session_id: "session-b" },
-				{ prompt: "user steering", created_at: 1_767_225_604n, cwd: "/work/b", session_id: "session-b" },
 			]);
 			expect(
 				db
@@ -658,40 +659,6 @@ describe("offline SQLite salvage", () => {
 		const db = new Database(result.candidate, { readonly: true, safeIntegers: true });
 		try {
 			expect(db.prepare("SELECT prompt FROM history ORDER BY id").all()).toEqual([{ prompt: "東京 café résumé" }]);
-		} finally {
-			db.close();
-		}
-	});
-
-	test("history rebuild ignores nested subagent and advisor transcripts", async () => {
-		await createHistorySource();
-		await writeSession("primary", "primary", [message("primary", "2026-01-01T00:00:01.000Z", "primary prompt")]);
-		const subagent = await writeSession(
-			path.join("primary", "__subagent"),
-			"nested",
-			[message("nested", "2026-01-01T00:00:02.000Z", "nested prompt")],
-		);
-		const advisor = await writeSession(
-			path.join("primary", "__advisor"),
-			"advisor",
-			[message("advisor", "2026-01-01T00:00:03.000Z", "advisor prompt")],
-		);
-		await fs.promises.appendFile(advisor, "{\"type\":\"message\"");
-
-		const result = await runStorageRepair(
-			{ target: "history", historySource: "sessions", apply: true, agentDir: root },
-			{
-				afterSessionManifestParse: () =>
-					fs.promises.appendFile(
-						subagent,
-						`${JSON.stringify(message("late", "2026-01-01T00:00:04.000Z", "late nested prompt"))}\n`,
-					),
-			},
-		);
-		expect(result.status).toBe("ready");
-		const db = new Database(result.candidate, { readonly: true, safeIntegers: true });
-		try {
-			expect(db.prepare("SELECT prompt FROM history ORDER BY id").all()).toEqual([{ prompt: "primary prompt" }]);
 		} finally {
 			db.close();
 		}
@@ -898,25 +865,6 @@ describe("offline SQLite salvage", () => {
 		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
 		const entries = await fs.promises.readdir(root);
 		expect(entries.some(name => name.startsWith(`.${path.basename(candidate)}.candidate-`))).toBe(false);
-	});
-
-	test("candidate stage mutation between sealing and publication is refused", async () => {
-		await createAgentSource();
-		const candidate = path.join(root, "stage-mutation.db");
-		const result = await runStorageRepair(
-			{ target: "agent", apply: true, agentDir: root, output: candidate },
-			{
-				beforeCandidatePublication: async () => {
-					const stage = requireValue((await stageArtifacts(candidate, "candidate")).at(0), "candidate stage");
-					await fs.promises.appendFile(path.join(root, stage), "tampered after sealing");
-				},
-			},
-		);
-		expect(result.status).toBe("refused");
-		expect(result.refusal).toContain("Publication stage changed after verification");
-		expect(result.candidatePublished).toBe(false);
-		expect(await Bun.file(candidate).exists()).toBe(false);
-		expect(await stageArtifacts(candidate, "candidate")).toEqual([]);
 	});
 
 	test("post-link candidate replacement refuses publication without deleting the replacement", async () => {

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -888,12 +888,10 @@ describe("offline SQLite salvage", () => {
 		});
 		const sealed = requireValue(
 			result.checksums.find(checksum => checksum.path === candidate && !checksum.ephemeral),
-			"published candidate checksum",
+			"linked candidate checksum",
 		);
 		expect(sealed.ephemeral).toBe(false);
 		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
-		const entries = await fs.promises.readdir(root);
-		expect(entries.some(name => name.startsWith(`.${path.basename(candidate)}.candidate-`))).toBe(false);
 	});
 
 	test("candidate stage mutation between sealing and publication is refused", async () => {
@@ -915,7 +913,7 @@ describe("offline SQLite salvage", () => {
 		expect(await stageArtifacts(candidate, "candidate")).toEqual([]);
 	});
 
-	test("post-link candidate replacement refuses publication without deleting the replacement", async () => {
+	test("post-link candidate replacement warns without deleting the replacement", async () => {
 		const dbPath = await createAgentSource();
 		const candidate = path.join(root, "candidate-replacement.db");
 		const replacement = "replacement bytes must survive";
@@ -931,13 +929,75 @@ describe("offline SQLite salvage", () => {
 				},
 			},
 		);
-		expect(result.status).toBe("refused");
-		expect(result.refusal).toContain("Published output no longer matches staging file");
-		expect(result.candidatePublished).toBe(false);
+		expect(result.status).toBe("published-with-warning");
+		expect(result.warning).toContain("Published output no longer matches staging file");
+		expect(result.candidatePublished).toBe(true);
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(candidate).text()).toBe(replacement);
 		expect(await fingerprint(candidate)).toEqual(requireValue(replacementIdentity, "replacement identity"));
+		const sealed = requireValue(
+			result.checksums.find(checksum => checksum.path === candidate && !checksum.ephemeral),
+			"linked candidate checksum",
+		);
+		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).not.toBe(sealed.sha256);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
+	});
+
+
+	test("candidate post-link same-inode same-size mutation fails the SHA proof", async () => {
+		await createAgentSource();
+		const candidate = path.join(root, "candidate-sha-only.db");
+		let mutation: { before: FileFingerprint; after: FileFingerprint } | undefined;
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root, output: candidate },
+			{
+				afterCandidatePublication: async () => {
+					const before = await fingerprint(candidate);
+					const bytes = await Bun.file(candidate).bytes();
+					bytes[0] ^= 0xff;
+					const handle = await fs.promises.open(candidate, "r+");
+					try {
+						await handle.write(bytes, 0, bytes.byteLength, 0);
+						await handle.sync();
+					} finally {
+						await handle.close();
+					}
+					mutation = { before, after: await fingerprint(candidate) };
+				},
+			},
+		);
+		const { before, after } = requireValue(mutation, "candidate SHA-only mutation");
+		expect(after).toMatchObject({ dev: before.dev, ino: before.ino, size: before.size });
+		expect(after.sha256).not.toBe(before.sha256);
+		expect(result.status).toBe("published-with-warning");
+		expect(result.candidatePublished).toBe(true);
+		expect(result.candidatePathTrusted).toBe(false);
+		expect(result.warning).toContain("Published output content changed");
+	});
+
+	test("candidate post-link byte-identical replacement fails the inode proof", async () => {
+		await createAgentSource();
+		const candidate = path.join(root, "candidate-inode-only.db");
+		let mutation: { before: FileFingerprint; after: FileFingerprint } | undefined;
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root, output: candidate },
+			{
+				afterCandidatePublication: async () => {
+					const before = await fingerprint(candidate);
+					const bytes = await Bun.file(candidate).bytes();
+					await fs.promises.unlink(candidate);
+					await Bun.write(candidate, bytes);
+					mutation = { before, after: await fingerprint(candidate) };
+				},
+			},
+		);
+		const { before, after } = requireValue(mutation, "candidate inode-only mutation");
+		expect(after).toMatchObject({ dev: before.dev, size: before.size, sha256: before.sha256 });
+		expect(after.ino).not.toBe(before.ino);
+		expect(result.status).toBe("published-with-warning");
+		expect(result.candidatePublished).toBe(true);
+		expect(result.candidatePathTrusted).toBe(false);
+		expect(result.warning).toContain("Published output no longer matches staging file");
 	});
 
 	test("candidate stage-unlink failure warns after proving the linked output", async () => {
@@ -976,10 +1036,10 @@ describe("offline SQLite salvage", () => {
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 		const sealed = requireValue(
-			result.checksums.find(checksum => checksum.ephemeral),
-			"sealed candidate checksum",
+			result.checksums.find(checksum => checksum.path === candidate && !checksum.ephemeral),
+			"linked candidate checksum",
 		);
-		expect(sealed.path).not.toBe(candidate);
+		expect(sealed.ephemeral).toBe(false);
 		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
 	});
 
@@ -1050,10 +1110,71 @@ describe("offline SQLite salvage", () => {
 			},
 		);
 		expect(result.status).toBe("refused");
-		expect(result.backupCreated).toBe(false);
-		expect(result.checksums.some(checksum => checksum.path === result.backup)).toBe(false);
+		expect(result.backupCreated).toBe(true);
+		expect(result.checksums.some(checksum => checksum.path === result.backup)).toBe(true);
 		expect(await Bun.file(result.backup).text()).toBe(replacement);
 		expect(await fingerprint(result.backup)).toEqual(requireValue(replacementIdentity, "replacement identity"));
+	});
+
+
+	test("backup post-link same-inode same-size mutation fails the SHA proof", async () => {
+		await createAgentSource();
+		let mutation: { before: FileFingerprint; after: FileFingerprint } | undefined;
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root },
+			{
+				afterBackupLink: async () => {
+					const directory = path.dirname(getAgentDbPath(root));
+					const name = requireValue((await fs.promises.readdir(directory)).find(entry => entry.endsWith(".tar")), "linked backup");
+					const backup = path.join(directory, name);
+					const before = await fingerprint(backup);
+					const bytes = await Bun.file(backup).bytes();
+					bytes[0] ^= 0xff;
+					const handle = await fs.promises.open(backup, "r+");
+					try {
+						await handle.write(bytes, 0, bytes.byteLength, 0);
+						await handle.sync();
+					} finally {
+						await handle.close();
+					}
+					mutation = { before, after: await fingerprint(backup) };
+				},
+			},
+		);
+		const { before, after } = requireValue(mutation, "backup SHA-only mutation");
+		expect(after).toMatchObject({ dev: before.dev, ino: before.ino, size: before.size });
+		expect(after.sha256).not.toBe(before.sha256);
+		expect(result.status).toBe("refused");
+		expect(result.backupCreated).toBe(true);
+		expect(result.candidatePublished).toBe(false);
+		expect(result.refusal).toContain("Published output content changed");
+	});
+
+	test("backup post-link byte-identical replacement fails the inode proof", async () => {
+		await createAgentSource();
+		let mutation: { before: FileFingerprint; after: FileFingerprint } | undefined;
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root },
+			{
+				afterBackupLink: async () => {
+					const directory = path.dirname(getAgentDbPath(root));
+					const name = requireValue((await fs.promises.readdir(directory)).find(entry => entry.endsWith(".tar")), "linked backup");
+					const backup = path.join(directory, name);
+					const before = await fingerprint(backup);
+					const bytes = await Bun.file(backup).bytes();
+					await fs.promises.unlink(backup);
+					await Bun.write(backup, bytes);
+					mutation = { before, after: await fingerprint(backup) };
+				},
+			},
+		);
+		const { before, after } = requireValue(mutation, "backup inode-only mutation");
+		expect(after).toMatchObject({ dev: before.dev, size: before.size, sha256: before.sha256 });
+		expect(after.ino).not.toBe(before.ino);
+		expect(result.status).toBe("refused");
+		expect(result.backupCreated).toBe(true);
+		expect(result.candidatePublished).toBe(false);
+		expect(result.refusal).toContain("Published output no longer matches staging file");
 	});
 
 	test("primary refusal and cleanup invariant failures retain both causes in deterministic order", async () => {

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -294,6 +294,39 @@ describe("offline SQLite salvage", () => {
 		).rejects.toThrow("Candidate and backup paths collide");
 	});
 
+	test("rejects Win32 aliases in an existing intermediate parent component", async () => {
+		const sourceParent = path.join(root, "artifacts");
+		const aliasParent = `${sourceParent}. `;
+		const source = path.join(sourceParent, "agent.db");
+		const sourceSidecarAlias = path.join(aliasParent, "agent.db-wal");
+		const slug = "fixed";
+		const candidateBackupAlias = path.join(aliasParent, `agent.db.salvage-${slug}.tar`);
+		await Promise.all([fs.promises.mkdir(sourceParent), fs.promises.mkdir(aliasParent)]);
+		await fs.promises.writeFile(source, "source");
+
+		await expect(resolveArtifactPaths(source, sourceSidecarAlias, { platform: () => "win32" })).rejects.toThrow(
+			"Repair artifact collides with source triplet",
+		);
+		await expect(
+			resolveArtifactPaths(source, candidateBackupAlias, {
+				platform: () => "win32",
+				artifactSlug: () => slug,
+			}),
+		).rejects.toThrow("Candidate and backup paths collide");
+
+		for (const platform of ["darwin", "linux"] as const) {
+			const sidecarArtifacts = await resolveArtifactPaths(source, sourceSidecarAlias, {
+				platform: () => platform,
+			});
+			expect(sidecarArtifacts.candidate).toBe(sourceSidecarAlias);
+			const backupArtifacts = await resolveArtifactPaths(source, candidateBackupAlias, {
+				platform: () => platform,
+				artifactSlug: () => slug,
+			});
+			expect(backupArtifacts.candidate).toBe(candidateBackupAlias);
+		}
+	});
+
 	test("keeps trailing-dot and trailing-space artifact paths distinct on Darwin and Linux", async () => {
 		const source = path.join(root, "agent.db");
 		const output = path.join(root, "AGENT.DB-WAL. ");

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -864,6 +864,25 @@ describe("offline SQLite salvage", () => {
 		expect(entries.some(name => name.startsWith(`.${path.basename(candidate)}.candidate-`))).toBe(false);
 	});
 
+	test("candidate stage mutation between sealing and publication is refused", async () => {
+		await createAgentSource();
+		const candidate = path.join(root, "stage-mutation.db");
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root, output: candidate },
+			{
+				beforeCandidatePublication: async () => {
+					const stage = requireValue((await stageArtifacts(candidate, "candidate")).at(0), "candidate stage");
+					await fs.promises.appendFile(path.join(root, stage), "tampered after sealing");
+				},
+			},
+		);
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("Publication stage changed after verification");
+		expect(result.candidatePublished).toBe(false);
+		expect(await Bun.file(candidate).exists()).toBe(false);
+		expect(await stageArtifacts(candidate, "candidate")).toEqual([]);
+	});
+
 	test("post-link candidate replacement refuses publication without deleting the replacement", async () => {
 		const dbPath = await createAgentSource();
 		const candidate = path.join(root, "candidate-replacement.db");

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -257,6 +257,46 @@ describe("offline SQLite salvage", () => {
 		}
 	});
 
+
+	test("rejects Win32 trailing-dot and trailing-space source-triplet aliases", async () => {
+		const source = path.join(root, "agent.db");
+		await fs.promises.writeFile(source, "source");
+
+		for (const output of [
+			path.join(root, "AGENT.DB. "),
+			path.join(root, "AGENT.DB-WAL. "),
+			path.join(root, "AGENT.DB-SHM. "),
+		]) {
+			await expect(resolveArtifactPaths(source, output, { platform: () => "win32" })).rejects.toThrow(
+				"Repair artifact collides with source triplet",
+			);
+		}
+	});
+
+	test("rejects a Win32 trailing-dot candidate alias of the backup", async () => {
+		const source = path.join(root, "agent.db");
+		const slug = "fixed";
+		await fs.promises.writeFile(source, "source");
+
+		await expect(
+			resolveArtifactPaths(source, path.join(root, `agent.db.salvage-${slug}.tar. `), {
+				platform: () => "win32",
+				artifactSlug: () => slug,
+			}),
+		).rejects.toThrow("Candidate and backup paths collide");
+	});
+
+	test("keeps trailing-dot and trailing-space artifact paths distinct on Darwin and Linux", async () => {
+		const source = path.join(root, "agent.db");
+		const output = path.join(root, "AGENT.DB-WAL. ");
+		await fs.promises.writeFile(source, "source");
+
+		for (const platform of ["darwin", "linux"] as const) {
+			const artifacts = await resolveArtifactPaths(source, output, { platform: () => platform });
+			expect(artifacts.candidate).toBe(output);
+		}
+	});
+
 	test("rejects Unicode-normalized source-sidecar and candidate-backup aliases", async () => {
 		const sourceName = "agent-é.db";
 		const normalizedAlias = "agent-e\u0301.db";

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -713,13 +713,9 @@ describe("offline SQLite salvage", () => {
 	test("injected backup, verification, and no-replace publication failures clean staging and retain valid backup", async () => {
 		const dbPath = await createAgentSource();
 		const before = await fingerprint(dbPath);
-		let snapshotTempDir: string | undefined;
 		let result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root },
 			{
-				afterPristineCopy: tempDir => {
-					snapshotTempDir = tempDir;
-				},
 				beforeBackupWrite: () => {
 					throw new Error("backup injection");
 				},
@@ -728,19 +724,10 @@ describe("offline SQLite salvage", () => {
 		expect(result.status).toBe("refused");
 		expect(result.backupCreated).toBe(false);
 		expect(await fingerprint(dbPath)).toEqual(before);
-		await expect(fs.promises.lstat(requireValue(snapshotTempDir, "backup snapshot directory"))).rejects.toMatchObject(
-			{
-				code: "ENOENT",
-			},
-		);
 
-		snapshotTempDir = undefined;
 		result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root },
 			{
-				afterPristineCopy: tempDir => {
-					snapshotTempDir = tempDir;
-				},
 				beforeCandidateVerification: () => {
 					throw new Error("verification injection");
 				},
@@ -750,11 +737,6 @@ describe("offline SQLite salvage", () => {
 		expect(result.backupCreated).toBe(true);
 		expect(result.candidatePublished).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
-		await expect(
-			fs.promises.lstat(requireValue(snapshotTempDir, "verification snapshot directory")),
-		).rejects.toMatchObject({
-			code: "ENOENT",
-		});
 
 		const racedCandidate = path.join(root, "raced-candidate.db");
 		let racerIdentity: FileFingerprint | undefined;
@@ -783,15 +765,9 @@ describe("offline SQLite salvage", () => {
 	test("late source mismatch after candidate link publishes an untrusted sealed candidate", async () => {
 		const dbPath = await createAgentSource();
 		const candidate = path.join(root, "publication-race.db");
-		let snapshotTempDir: string | undefined;
 		const result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root, output: candidate },
-			{
-				afterPristineCopy: tempDir => {
-					snapshotTempDir = tempDir;
-				},
-				afterCandidatePublication: () => fs.promises.appendFile(dbPath, "publication race"),
-			},
+			{ afterCandidatePublication: () => fs.promises.appendFile(dbPath, "publication race") },
 		);
 		expect(result.status).toBe("published-with-warning");
 		expect(result.warning).toContain("Live source triplet changed during storage repair");
@@ -800,11 +776,6 @@ describe("offline SQLite salvage", () => {
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 		expect(await Bun.file(candidate).exists()).toBe(true);
-		await expect(
-			fs.promises.lstat(requireValue(snapshotTempDir, "published warning snapshot directory")),
-		).rejects.toMatchObject({
-			code: "ENOENT",
-		});
 		const sealed = requireValue(
 			result.checksums.find(checksum => checksum.path === candidate && !checksum.ephemeral),
 			"published candidate checksum",

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -5,6 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { collectGcErrors, runGcCommand } from "@oh-my-pi/pi-coding-agent/cli/gc-cli";
 import { runStorageRepair, type StorageRepairResult } from "@oh-my-pi/pi-coding-agent/cli/storage-repair-cli";
+import { resolveArtifactPaths } from "@oh-my-pi/pi-coding-agent/cli/storage-repair-files";
 import { initializeMemoryStorageExactPath } from "@oh-my-pi/pi-coding-agent/memories/storage";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { HistoryStorage } from "@oh-my-pi/pi-coding-agent/session/history-storage";
@@ -214,6 +215,91 @@ function artifactModes(result: { backup: string; candidate: string }) {
 }
 
 describe("offline SQLite salvage", () => {
+	test("rejects normalized and case-insensitive source-triplet artifact aliases", async () => {
+		const source = path.join(root, "agent.db");
+		await fs.promises.writeFile(source, "source");
+		const options = { comparisonMode: "case-insensitive" } as const;
+
+		await expect(resolveArtifactPaths(source, path.join(root, "nested", "..", "agent.db"), options)).rejects.toThrow(
+			"Repair output already exists",
+		);
+
+		for (const output of [
+			path.join(root, "nested", "..", "agent.db-wal"),
+			path.join(root, "nested", "..", "agent.db-shm"),
+			path.join(root, "AGENT.DB-WAL"),
+			path.join(root, "AGENT.DB-SHM"),
+		]) {
+			await expect(resolveArtifactPaths(source, output, options)).rejects.toThrow(
+				"Repair artifact collides with source triplet",
+			);
+		}
+	});
+
+	test("rejects a normalized candidate alias of the backup before publication", async () => {
+		const source = path.join(root, "agent.db");
+		const slug = "fixed";
+		await fs.promises.writeFile(source, "source");
+
+		await expect(
+			resolveArtifactPaths(source, path.join(root, "nested", "..", `agent.db.salvage-${slug}.tar`), {
+				comparisonMode: "case-insensitive",
+				artifactSlug: () => slug,
+			}),
+		).rejects.toThrow("Candidate and backup paths collide");
+	});
+
+	test("rejects Unicode-normalized source-sidecar and candidate-backup aliases", async () => {
+		const sourceName = "agent-é.db";
+		const normalizedAlias = "agent-e\u0301.db";
+		const source = path.join(root, sourceName);
+		const alias = path.join(root, normalizedAlias);
+		const slug = "fixed";
+		await fs.promises.writeFile(source, "source");
+
+		await expect(
+			resolveArtifactPaths(source, `${alias}-wal`, { comparisonMode: "case-insensitive" }),
+		).rejects.toThrow("Repair artifact collides with source triplet");
+		await expect(
+			resolveArtifactPaths(source, `${alias}.salvage-${slug}.tar`, {
+				comparisonMode: "case-insensitive",
+				artifactSlug: () => slug,
+			}),
+		).rejects.toThrow("Candidate and backup paths collide");
+	});
+
+	test("rejects full Unicode casefold source-sidecar and candidate-backup aliases", async () => {
+		const slug = "fixed";
+		for (const { sourceName, aliasName } of [
+			{ sourceName: "agent-ος.db", aliasName: "agent-οσ.db" },
+			{ sourceName: "agent-straße.db", aliasName: "agent-STRASSE.db" },
+		]) {
+			const source = path.join(root, sourceName);
+			const alias = path.join(root, aliasName);
+			await fs.promises.writeFile(source, "source");
+
+			await expect(
+				resolveArtifactPaths(source, `${alias}-shm`, { comparisonMode: "case-insensitive" }),
+			).rejects.toThrow("Repair artifact collides with source triplet");
+			await expect(
+				resolveArtifactPaths(source, `${alias}.salvage-${slug}.tar`, {
+					comparisonMode: "case-insensitive",
+					artifactSlug: () => slug,
+				}),
+			).rejects.toThrow("Candidate and backup paths collide");
+		}
+	});
+
+	test("accepts distinct repair artifact paths", async () => {
+		const source = path.join(root, "agent.db");
+		const candidate = path.join(root, "repaired.db");
+		await fs.promises.writeFile(source, "source");
+
+		const artifacts = await resolveArtifactPaths(source, candidate, { comparisonMode: "case-insensitive" });
+		expect(artifacts.candidate).toBe(candidate);
+		expect(artifacts.backup).not.toBe(candidate);
+	});
+
 	test("physical corruption fixture reproduces normal owner-open failure", async () => {
 		const dbPath = await createAgentSource();
 		closeWal(new Database(dbPath));

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -139,6 +139,7 @@ async function writeSession(
 	name: string,
 	records: Record<string, unknown>[],
 	format: SessionFormat = "title-slot",
+	headerExtra: Record<string, unknown> = {},
 ) {
 	const dir = path.join(getSessionsDir(root), project);
 	await fs.promises.mkdir(dir, { recursive: true });
@@ -149,6 +150,7 @@ async function writeSession(
 		id: name,
 		timestamp: "2026-01-01T00:00:00.000Z",
 		cwd: `/work/${project}`,
+		...headerExtra,
 	};
 	const body = [
 		...(format === "title-slot" ? [serializeTitleSlot({ title: name, updatedAt: header.timestamp })] : []),
@@ -226,6 +228,14 @@ function artifactModes(result: { backup: string; candidate: string }) {
 async function stageArtifacts(finalPath: string, label: "backup" | "candidate") {
 	const prefix = `.${path.basename(finalPath)}.${label}-`;
 	return (await fs.promises.readdir(path.dirname(finalPath))).filter(name => name.startsWith(prefix));
+}
+
+async function candidateStagePath(finalPath: string): Promise<string> {
+	const stage = requireValue(
+		(await stageArtifacts(finalPath, "candidate")).find(name => name.endsWith(".tmp")),
+		"candidate database stage",
+	);
+	return path.join(path.dirname(finalPath), stage);
 }
 
 describe("offline SQLite salvage", () => {
@@ -648,6 +658,82 @@ describe("offline SQLite salvage", () => {
 		}
 	});
 
+	test("raw agent and history sqlite_schema definitions reject trigger, index, and view SQL tampering", async () => {
+		const tamperSql: Record<string, string> = {
+			ext_notes_large_int:
+				"DROP INDEX ext_notes_large_int; CREATE INDEX ext_notes_large_int ON ext_notes(large_int DESC)",
+			ext_notes_view: "DROP VIEW ext_notes_view; CREATE VIEW ext_notes_view AS SELECT key FROM ext_notes",
+			ext_notes_touch:
+				"DROP TRIGGER ext_notes_touch; CREATE TRIGGER ext_notes_touch AFTER UPDATE ON ext_notes BEGIN SELECT NEW.large_int; END",
+			idx_history_created_at:
+				"DROP INDEX idx_history_created_at; CREATE INDEX idx_history_created_at ON history(created_at ASC)",
+			history_ai:
+				"DROP TRIGGER history_ai; CREATE TRIGGER history_ai AFTER INSERT ON history BEGIN INSERT INTO history_fts(rowid, prompt) VALUES (new.id, new.prompt || ''); END",
+		};
+		const tamper = (db: Database, name: string) =>
+			db.exec(requireValue(tamperSql[name], `schema mutation for ${name}`));
+
+		await createAgentSource();
+		for (const name of ["ext_notes_large_int", "ext_notes_view", "ext_notes_touch"]) {
+			const candidate = path.join(root, `agent-schema-${name}.db`);
+			const result = await runStorageRepair(
+				{ target: "agent", apply: true, agentDir: root, output: candidate },
+				{
+					beforeCandidateVerification: async () => {
+						const db = new Database(await candidateStagePath(candidate), { safeIntegers: true });
+						try {
+							tamper(db, name);
+						} finally {
+							closeWal(db);
+						}
+					},
+				},
+			);
+			expect(result.status).toBe("refused");
+			expect(result.refusal).toContain("Candidate sqlite_schema definition differs");
+		}
+
+		await createHistorySource();
+		for (const name of ["idx_history_created_at", "history_ai"]) {
+			const candidate = path.join(root, `history-schema-${name}.db`);
+			const result = await runStorageRepair(
+				{ target: "history", historySource: "fresh", apply: true, agentDir: root, output: candidate },
+				{
+					beforeCandidateVerification: async () => {
+						const db = new Database(await candidateStagePath(candidate), { safeIntegers: true });
+						try {
+							tamper(db, name);
+						} finally {
+							closeWal(db);
+						}
+					},
+				},
+			);
+			expect(result.status).toBe("refused");
+			expect(result.refusal).toContain("Candidate sqlite_schema definition differs");
+		}
+	});
+
+	test("AUTOINCREMENT-only built-in schema drift refuses repair", async () => {
+		const dbPath = await createAgentSource();
+		const db = new Database(dbPath);
+		try {
+			const versions = db.prepare("SELECT version FROM schema_version").values();
+			db.exec("DROP TABLE schema_version; CREATE TABLE schema_version (version INTEGER PRIMARY KEY AUTOINCREMENT)");
+			const insert = db.prepare("INSERT INTO schema_version(version) VALUES (?)");
+			try {
+				for (const [version] of versions) insert.run(version);
+			} finally {
+				insert.finalize();
+			}
+		} finally {
+			closeWal(db);
+		}
+		const result = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("Structural drift in built-in schema object: schema_version");
+	});
+
 	test("only a registered corrupt derived table may be omitted", async () => {
 		const dbPath = await createAgentSource();
 		const db = new Database(dbPath);
@@ -749,7 +835,124 @@ describe("offline SQLite salvage", () => {
 		expect(result.refusal).toContain("Unsafe extension table shape");
 	});
 
-	test("sessions rebuild uses strict global ordering, adjacent deduplication, and FTS rank-1 integrity", async () => {
+	test("session history uses valid inner timestamps and falls back for invalid or legacy timestamps", async () => {
+		await createHistorySource();
+		await writeSession("timestamps", "timestamps", [
+			message("inner", "2026-01-01T00:00:03.000Z", "inner", { timestamp: 3_000 }),
+			message("invalid", "2026-01-01T00:00:02.000Z", "invalid", { timestamp: -1 }),
+			message("legacy", "2026-01-01T00:00:01.000Z", "legacy"),
+		]);
+		const result = await runStorageRepair({
+			target: "history",
+			historySource: "sessions",
+			apply: true,
+			agentDir: root,
+		});
+		expect(result.status).toBe("ready");
+		const db = new Database(result.candidate, { readonly: true, safeIntegers: true });
+		try {
+			expect(db.prepare("SELECT prompt, created_at FROM history ORDER BY id").all()).toEqual([
+				{ prompt: "inner", created_at: 3n },
+				{ prompt: "legacy", created_at: 1_767_225_601n },
+				{ prompt: "invalid", created_at: 1_767_225_602n },
+			]);
+		} finally {
+			db.close();
+		}
+	});
+
+	test("session families deduplicate only inherited byte-identical records and bound unresolved graphs", async () => {
+		await createHistorySource();
+		const shared = message("shared", "2026-01-01T00:00:05.000Z", "inherited");
+		const parentFile = await writeSession("parent", "parent", [shared], "title-slot", {
+			timestamp: "2026-01-01T00:00:00.000Z",
+		});
+		await writeSession(
+			"child",
+			"child",
+			[shared, message("child-only", "2026-01-01T00:00:06.000Z", "child only")],
+			"title-slot",
+			{
+				timestamp: "2026-01-01T00:00:01.000Z",
+				parentSession: "parent",
+			},
+		);
+		await writeSession("path-child", "path-child", [shared], "title-slot", { parentSession: parentFile });
+
+		const orphan = message("orphan-shared", "2026-01-01T00:00:07.000Z", "orphan stays separate");
+		await writeSession("orphan", "orphan", [orphan], "title-slot", { parentSession: "missing-parent" });
+		await writeSession("unrelated", "unrelated", [orphan]);
+
+		const ambiguous = message("ambiguous-shared", "2026-01-01T00:00:08.000Z", "ambiguous stays separate");
+		await writeSession("ambiguous-a", "duplicate-parent", [ambiguous]);
+		await writeSession("ambiguous-b", "duplicate-parent", [ambiguous]);
+		await writeSession("ambiguous-child", "ambiguous-child", [ambiguous], "title-slot", {
+			parentSession: "duplicate-parent",
+		});
+
+		const cycle = message("cycle-shared", "2026-01-01T00:00:09.000Z", "cycle deduplicates");
+		await writeSession("cycle-a", "cycle-a", [cycle], "title-slot", {
+			timestamp: "2026-01-01T00:00:02.000Z",
+			parentSession: "cycle-b",
+		});
+		await writeSession("cycle-b", "cycle-b", [cycle], "title-slot", {
+			timestamp: "2026-01-01T00:00:03.000Z",
+			parentSession: "cycle-a",
+		});
+
+		const result = await runStorageRepair({
+			target: "history",
+			historySource: "sessions",
+			apply: true,
+			agentDir: root,
+		});
+		expect(result.status).toBe("ready");
+		const db = new Database(result.candidate, { readonly: true, safeIntegers: true });
+		try {
+			expect(db.prepare("SELECT prompt, cwd, session_id FROM history ORDER BY created_at, id").all()).toEqual([
+				{ prompt: "inherited", cwd: "/work/parent", session_id: "parent" },
+				{ prompt: "child only", cwd: "/work/child", session_id: "child" },
+				{ prompt: "orphan stays separate", cwd: "/work/orphan", session_id: "orphan" },
+				{ prompt: "orphan stays separate", cwd: "/work/unrelated", session_id: "unrelated" },
+				{ prompt: "ambiguous stays separate", cwd: "/work/ambiguous-a", session_id: "duplicate-parent" },
+				{ prompt: "ambiguous stays separate", cwd: "/work/ambiguous-b", session_id: "duplicate-parent" },
+				{ prompt: "ambiguous stays separate", cwd: "/work/ambiguous-child", session_id: "ambiguous-child" },
+				{ prompt: "cycle deduplicates", cwd: "/work/cycle-a", session_id: "cycle-a" },
+			]);
+		} finally {
+			db.close();
+		}
+	});
+
+	test("fork families preserve divergent reused entry IDs", async () => {
+		await createHistorySource();
+		await writeSession("parent", "entry-parent", [message("reused", "2026-01-01T00:00:01.000Z", "parent payload")]);
+		await writeSession(
+			"child",
+			"entry-child",
+			[message("reused", "2026-01-01T00:00:01.000Z", "child payload")],
+			"title-slot",
+			{ parentSession: "entry-parent" },
+		);
+		const result = await runStorageRepair({
+			target: "history",
+			historySource: "sessions",
+			apply: true,
+			agentDir: root,
+		});
+		expect(result.status).toBe("ready");
+		const db = new Database(result.candidate, { readonly: true });
+		try {
+			expect(db.prepare("SELECT prompt FROM history ORDER BY id").all()).toEqual([
+				{ prompt: "child payload" },
+				{ prompt: "parent payload" },
+			]);
+		} finally {
+			db.close();
+		}
+	});
+
+	test("sessions rebuild uses strict global ordering, full-record deduplication, and FTS rank-1 integrity", async () => {
 		await createHistorySource();
 		await writeSession("b", "session-b", [
 			message("b1", "2026-01-01T00:00:03.900Z", "third prompt"),
@@ -778,6 +981,7 @@ describe("offline SQLite salvage", () => {
 		try {
 			expect(db.prepare("SELECT prompt, created_at, cwd, session_id FROM history ORDER BY id").all()).toEqual([
 				{ prompt: "first prompt", created_at: 1_767_225_601n, cwd: "/work/a", session_id: "session-a" },
+				{ prompt: "first prompt", created_at: 1_767_225_602n, cwd: "/work/a", session_id: "session-a" },
 				{ prompt: "third prompt", created_at: 1_767_225_603n, cwd: "/work/b", session_id: "session-b" },
 				{ prompt: "user steering", created_at: 1_767_225_604n, cwd: "/work/b", session_id: "session-b" },
 			]);
@@ -864,6 +1068,39 @@ describe("offline SQLite salvage", () => {
 		expect(result.candidatePublished).toBe(false);
 	});
 
+	test("a mutation between verification and sealing is refused by seal-bound revalidation", async () => {
+		await createHistorySource();
+		const originalChmod = fs.promises.chmod;
+		let mutated = false;
+		const chmodSpy = spyOn(fs.promises, "chmod").mockImplementation((async (target, mode) => {
+			if (!mutated && typeof target === "string" && path.basename(target) === "candidate.db") {
+				mutated = true;
+				const db = new Database(target);
+				try {
+					db.exec(
+						"DROP TRIGGER history_ai; CREATE TRIGGER history_ai AFTER INSERT ON history BEGIN INSERT INTO history_fts(rowid, prompt) VALUES (new.id, new.prompt || ''); END",
+					);
+				} finally {
+					closeWal(db);
+				}
+			}
+			return Reflect.apply(originalChmod, fs.promises, [target, mode]);
+		}) as typeof fs.promises.chmod);
+		try {
+			const result = await runStorageRepair({
+				target: "history",
+				historySource: "fresh",
+				apply: false,
+				agentDir: root,
+			});
+			expect(mutated).toBe(true);
+			expect(result.status).toBe("refused");
+			expect(result.refusal).toContain("Candidate sqlite_schema definition differs");
+		} finally {
+			chmodSpy.mockRestore();
+		}
+	});
+
 	test("session manifest changes during final cleanup make a published candidate untrusted", async () => {
 		await createHistorySource();
 		await writeSession("first", "first-session", [message("m", "2026-01-01T00:00:01.000Z", "first")]);
@@ -879,6 +1116,61 @@ describe("offline SQLite salvage", () => {
 		expect(result.warning).toContain("Session directory changed during storage repair");
 		expect(result.candidatePublished).toBe(true);
 		expect(result.candidatePathTrusted).toBe(false);
+		expect(result.manualNextStep).toContain("Do not install");
+	});
+
+	test("final cleanup revalidation rejects a published candidate mutated during snapshot cleanup", async () => {
+		await createAgentSource();
+		const candidate = path.join(root, "cleanup-mutated-candidate.db");
+		let snapshotTempDir: string | undefined;
+		let mutated = false;
+		const originalRm = fs.promises.rm;
+		const rmSpy = spyOn(fs.promises, "rm").mockImplementation((async (target, options) => {
+			if (!mutated && target === snapshotTempDir) {
+				mutated = true;
+				await fs.promises.appendFile(candidate, "mutated during final cleanup");
+			}
+			return Reflect.apply(originalRm, fs.promises, [target, options]);
+		}) as typeof fs.promises.rm);
+		try {
+			const result = await runStorageRepair(
+				{ target: "agent", apply: true, agentDir: root, output: candidate },
+				{
+					afterPristineCopy: tempDir => {
+						snapshotTempDir = tempDir;
+					},
+				},
+			);
+			expect(mutated).toBe(true);
+			expect(result.status).toBe("published-with-warning");
+			expect(result.candidatePublished).toBe(true);
+			expect(result.candidatePathTrusted).toBe(false);
+			expect(result.warning).toContain("Publication stage changed after verification");
+			expect(result.manualNextStep).toContain("Do not install");
+		} finally {
+			rmSpy.mockRestore();
+		}
+	});
+
+	test("the final content seal runs after published schema validation", async () => {
+		await createAgentSource();
+		const candidate = path.join(root, "post-schema-mutation.db");
+		let mutated = false;
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root, output: candidate },
+			{
+				beforeFinalCandidateSeal: async () => {
+					mutated = true;
+					await fs.promises.appendFile(candidate, "mutated after schema validation");
+				},
+			},
+		);
+		expect(mutated).toBe(true);
+		expect(result.status).toBe("published-with-warning");
+		expect(result.candidatePublished).toBe(true);
+		expect(result.candidatePathTrusted).toBe(false);
+		expect(result.warning).toContain("Publication stage changed after verification");
+		expect(result.manualNextStep).toContain("Do not install");
 	});
 
 	test("session rebuild skips blank and malformed JSONL records", async () => {
@@ -1115,8 +1407,7 @@ describe("offline SQLite salvage", () => {
 			{ target: "agent", apply: true, agentDir: root, output: candidate },
 			{
 				beforeCandidatePublication: async () => {
-					const stage = requireValue((await stageArtifacts(candidate, "candidate")).at(0), "candidate stage");
-					await fs.promises.appendFile(path.join(root, stage), "tampered after sealing");
+					await fs.promises.appendFile(await candidateStagePath(candidate), "tampered after sealing");
 				},
 			},
 		);
@@ -1439,7 +1730,7 @@ describe("offline SQLite salvage", () => {
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 	});
 
-	test("text and JSON reports are structured, nonzero-compatible, and include quarantine instructions", async () => {
+	test("text and JSON reports are structured, nonzero-compatible, and include status-aware instructions", async () => {
 		await createHistorySource();
 		let result = await runGcCommand({
 			flags: { agentDir: root, repairStorage: "history", historySource: "fresh", apply: true },
@@ -1459,7 +1750,8 @@ describe("offline SQLite salvage", () => {
 		expect(parsed.repair.dataLoss).toBe(true);
 		expect(parsed.repair.candidatePublished).toBe(false);
 		expect(parsed.repair.candidatePathTrusted).toBe(false);
-		expect(parsed.repair.manualNextStep).toContain("quarantine");
+		expect(parsed.repair.manualNextStep).toContain("Dry run only");
+		expect(parsed.repair.manualNextStep).toContain("Do not install");
 		expect(
 			collectGcErrors({
 				agentDir: root,
@@ -1479,6 +1771,40 @@ describe("offline SQLite salvage", () => {
 		expect(result.repair?.dataLoss).toBe(true);
 		expect(stdout.join("")).toContain("session rebuild retains only session messages");
 		expect(stdout.join("")).toContain("stable row IDs are not preserved");
+	});
+
+	test("manual guidance is status-aware and never installs an absent or untrusted candidate", async () => {
+		const dbPath = await createAgentSource();
+		const dryRun = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
+		expect(dryRun.manualNextStep).toContain("Dry run only");
+		expect(dryRun.manualNextStep).toContain("Do not install");
+
+		const source = new Database(dbPath);
+		source.exec("ALTER TABLE settings ADD COLUMN refusal_drift TEXT");
+		closeWal(source);
+		const refused = await runStorageRepair({ target: "agent", apply: true, agentDir: root });
+		expect(refused.status).toBe("refused");
+		expect(refused.manualNextStep).toContain("Do not install");
+
+		await fs.promises.rm(dbPath, { force: true });
+		await fs.promises.rm(`${dbPath}-wal`, { force: true });
+		await fs.promises.rm(`${dbPath}-shm`, { force: true });
+		await createAgentSource();
+		const warned = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root },
+			{ afterCandidatePublication: () => fs.promises.appendFile(dbPath, "changed after publication") },
+		);
+		expect(warned.status).toBe("published-with-warning");
+		expect(warned.manualNextStep).toContain("Do not install");
+
+		await fs.promises.rm(dbPath, { force: true });
+		await fs.promises.rm(`${dbPath}-wal`, { force: true });
+		await fs.promises.rm(`${dbPath}-shm`, { force: true });
+		await createAgentSource();
+		const trusted = await runStorageRepair({ target: "agent", apply: true, agentDir: root });
+		expect(trusted.status).toBe("ready");
+		expect(trusted.candidatePathTrusted).toBe(true);
+		expect(trusted.manualNextStep).toContain(`Copy ${trusted.candidate}`);
 	});
 
 	test("dry-run and published candidates report distinct checksum lifecycles", async () => {

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -257,46 +257,6 @@ describe("offline SQLite salvage", () => {
 		}
 	});
 
-
-	test("rejects Win32 trailing-dot and trailing-space source-triplet aliases", async () => {
-		const source = path.join(root, "agent.db");
-		await fs.promises.writeFile(source, "source");
-
-		for (const output of [
-			path.join(root, "AGENT.DB. "),
-			path.join(root, "AGENT.DB-WAL. "),
-			path.join(root, "AGENT.DB-SHM. "),
-		]) {
-			await expect(resolveArtifactPaths(source, output, { platform: () => "win32" })).rejects.toThrow(
-				"Repair artifact collides with source triplet",
-			);
-		}
-	});
-
-	test("rejects a Win32 trailing-dot candidate alias of the backup", async () => {
-		const source = path.join(root, "agent.db");
-		const slug = "fixed";
-		await fs.promises.writeFile(source, "source");
-
-		await expect(
-			resolveArtifactPaths(source, path.join(root, `agent.db.salvage-${slug}.tar. `), {
-				platform: () => "win32",
-				artifactSlug: () => slug,
-			}),
-		).rejects.toThrow("Candidate and backup paths collide");
-	});
-
-	test("keeps trailing-dot and trailing-space artifact paths distinct on Darwin and Linux", async () => {
-		const source = path.join(root, "agent.db");
-		const output = path.join(root, "AGENT.DB-WAL. ");
-		await fs.promises.writeFile(source, "source");
-
-		for (const platform of ["darwin", "linux"] as const) {
-			const artifacts = await resolveArtifactPaths(source, output, { platform: () => platform });
-			expect(artifacts.candidate).toBe(output);
-		}
-	});
-
 	test("rejects Unicode-normalized source-sidecar and candidate-backup aliases", async () => {
 		const sourceName = "agent-é.db";
 		const normalizedAlias = "agent-e\u0301.db";
@@ -789,41 +749,6 @@ describe("offline SQLite salvage", () => {
 		expect(result.refusal).toContain("Session directory changed");
 	});
 
-
-	test("a primary session discovery access error refuses without publishing artifacts", async () => {
-		const dbPath = await createHistorySource();
-		const sourceBefore = await fingerprint(dbPath);
-		const project = path.join(getSessionsDir(root), "denied");
-		await writeSession("denied", "session", [message("m", "2026-01-01T00:00:01.000Z", "prompt")]);
-		const candidate = path.join(root, "discovery-refused.db");
-		const accessError = Object.assign(new Error("session project access denied"), { code: "EACCES" });
-		const originalReaddir = fs.promises.readdir;
-		const readdirSpy = spyOn(fs.promises, "readdir").mockImplementation(
-			((directory, options) => {
-				if (directory === project) return Promise.reject(accessError);
-				return Reflect.apply(originalReaddir, fs.promises, [directory, options]);
-			}) as typeof fs.promises.readdir,
-		);
-		try {
-			const result = await runStorageRepair({
-				target: "history",
-				historySource: "sessions",
-				apply: true,
-				agentDir: root,
-				output: candidate,
-			});
-			expect(result.status).toBe("refused");
-			expect(result.refusal).toBe("session project access denied");
-			expect(result.backupCreated).toBe(false);
-			expect(result.candidatePublished).toBe(false);
-			expect(await Bun.file(result.backup).exists()).toBe(false);
-			expect(await Bun.file(result.candidate).exists()).toBe(false);
-			expect(await fingerprint(dbPath)).toEqual(sourceBefore);
-		} finally {
-			readdirSpy.mockRestore();
-		}
-	});
-
 	test("Windows publication skips directory fsync without weakening file verification", async () => {
 		await createAgentSource();
 		let directorySyncs = 0;
@@ -963,10 +888,12 @@ describe("offline SQLite salvage", () => {
 		});
 		const sealed = requireValue(
 			result.checksums.find(checksum => checksum.path === candidate && !checksum.ephemeral),
-			"linked candidate checksum",
+			"published candidate checksum",
 		);
 		expect(sealed.ephemeral).toBe(false);
 		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
+		const entries = await fs.promises.readdir(root);
+		expect(entries.some(name => name.startsWith(`.${path.basename(candidate)}.candidate-`))).toBe(false);
 	});
 
 	test("candidate stage mutation between sealing and publication is refused", async () => {
@@ -988,7 +915,7 @@ describe("offline SQLite salvage", () => {
 		expect(await stageArtifacts(candidate, "candidate")).toEqual([]);
 	});
 
-	test("post-link candidate replacement warns without deleting the replacement", async () => {
+	test("post-link candidate replacement refuses publication without deleting the replacement", async () => {
 		const dbPath = await createAgentSource();
 		const candidate = path.join(root, "candidate-replacement.db");
 		const replacement = "replacement bytes must survive";
@@ -1004,75 +931,13 @@ describe("offline SQLite salvage", () => {
 				},
 			},
 		);
-		expect(result.status).toBe("published-with-warning");
-		expect(result.warning).toContain("Published output no longer matches staging file");
-		expect(result.candidatePublished).toBe(true);
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("Published output no longer matches staging file");
+		expect(result.candidatePublished).toBe(false);
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(candidate).text()).toBe(replacement);
 		expect(await fingerprint(candidate)).toEqual(requireValue(replacementIdentity, "replacement identity"));
-		const sealed = requireValue(
-			result.checksums.find(checksum => checksum.path === candidate && !checksum.ephemeral),
-			"linked candidate checksum",
-		);
-		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).not.toBe(sealed.sha256);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
-	});
-
-
-	test("candidate post-link same-inode same-size mutation fails the SHA proof", async () => {
-		await createAgentSource();
-		const candidate = path.join(root, "candidate-sha-only.db");
-		let mutation: { before: FileFingerprint; after: FileFingerprint } | undefined;
-		const result = await runStorageRepair(
-			{ target: "agent", apply: true, agentDir: root, output: candidate },
-			{
-				afterCandidatePublication: async () => {
-					const before = await fingerprint(candidate);
-					const bytes = await Bun.file(candidate).bytes();
-					bytes[0] ^= 0xff;
-					const handle = await fs.promises.open(candidate, "r+");
-					try {
-						await handle.write(bytes, 0, bytes.byteLength, 0);
-						await handle.sync();
-					} finally {
-						await handle.close();
-					}
-					mutation = { before, after: await fingerprint(candidate) };
-				},
-			},
-		);
-		const { before, after } = requireValue(mutation, "candidate SHA-only mutation");
-		expect(after).toMatchObject({ dev: before.dev, ino: before.ino, size: before.size });
-		expect(after.sha256).not.toBe(before.sha256);
-		expect(result.status).toBe("published-with-warning");
-		expect(result.candidatePublished).toBe(true);
-		expect(result.candidatePathTrusted).toBe(false);
-		expect(result.warning).toContain("Published output content changed");
-	});
-
-	test("candidate post-link byte-identical replacement fails the inode proof", async () => {
-		await createAgentSource();
-		const candidate = path.join(root, "candidate-inode-only.db");
-		let mutation: { before: FileFingerprint; after: FileFingerprint } | undefined;
-		const result = await runStorageRepair(
-			{ target: "agent", apply: true, agentDir: root, output: candidate },
-			{
-				afterCandidatePublication: async () => {
-					const before = await fingerprint(candidate);
-					const bytes = await Bun.file(candidate).bytes();
-					await fs.promises.unlink(candidate);
-					await Bun.write(candidate, bytes);
-					mutation = { before, after: await fingerprint(candidate) };
-				},
-			},
-		);
-		const { before, after } = requireValue(mutation, "candidate inode-only mutation");
-		expect(after).toMatchObject({ dev: before.dev, size: before.size, sha256: before.sha256 });
-		expect(after.ino).not.toBe(before.ino);
-		expect(result.status).toBe("published-with-warning");
-		expect(result.candidatePublished).toBe(true);
-		expect(result.candidatePathTrusted).toBe(false);
-		expect(result.warning).toContain("Published output no longer matches staging file");
 	});
 
 	test("candidate stage-unlink failure warns after proving the linked output", async () => {
@@ -1111,10 +976,10 @@ describe("offline SQLite salvage", () => {
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 		const sealed = requireValue(
-			result.checksums.find(checksum => checksum.path === candidate && !checksum.ephemeral),
-			"linked candidate checksum",
+			result.checksums.find(checksum => checksum.ephemeral),
+			"sealed candidate checksum",
 		);
-		expect(sealed.ephemeral).toBe(false);
+		expect(sealed.path).not.toBe(candidate);
 		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
 	});
 
@@ -1185,71 +1050,10 @@ describe("offline SQLite salvage", () => {
 			},
 		);
 		expect(result.status).toBe("refused");
-		expect(result.backupCreated).toBe(true);
-		expect(result.checksums.some(checksum => checksum.path === result.backup)).toBe(true);
+		expect(result.backupCreated).toBe(false);
+		expect(result.checksums.some(checksum => checksum.path === result.backup)).toBe(false);
 		expect(await Bun.file(result.backup).text()).toBe(replacement);
 		expect(await fingerprint(result.backup)).toEqual(requireValue(replacementIdentity, "replacement identity"));
-	});
-
-
-	test("backup post-link same-inode same-size mutation fails the SHA proof", async () => {
-		await createAgentSource();
-		let mutation: { before: FileFingerprint; after: FileFingerprint } | undefined;
-		const result = await runStorageRepair(
-			{ target: "agent", apply: true, agentDir: root },
-			{
-				afterBackupLink: async () => {
-					const directory = path.dirname(getAgentDbPath(root));
-					const name = requireValue((await fs.promises.readdir(directory)).find(entry => entry.endsWith(".tar")), "linked backup");
-					const backup = path.join(directory, name);
-					const before = await fingerprint(backup);
-					const bytes = await Bun.file(backup).bytes();
-					bytes[0] ^= 0xff;
-					const handle = await fs.promises.open(backup, "r+");
-					try {
-						await handle.write(bytes, 0, bytes.byteLength, 0);
-						await handle.sync();
-					} finally {
-						await handle.close();
-					}
-					mutation = { before, after: await fingerprint(backup) };
-				},
-			},
-		);
-		const { before, after } = requireValue(mutation, "backup SHA-only mutation");
-		expect(after).toMatchObject({ dev: before.dev, ino: before.ino, size: before.size });
-		expect(after.sha256).not.toBe(before.sha256);
-		expect(result.status).toBe("refused");
-		expect(result.backupCreated).toBe(true);
-		expect(result.candidatePublished).toBe(false);
-		expect(result.refusal).toContain("Published output content changed");
-	});
-
-	test("backup post-link byte-identical replacement fails the inode proof", async () => {
-		await createAgentSource();
-		let mutation: { before: FileFingerprint; after: FileFingerprint } | undefined;
-		const result = await runStorageRepair(
-			{ target: "agent", apply: true, agentDir: root },
-			{
-				afterBackupLink: async () => {
-					const directory = path.dirname(getAgentDbPath(root));
-					const name = requireValue((await fs.promises.readdir(directory)).find(entry => entry.endsWith(".tar")), "linked backup");
-					const backup = path.join(directory, name);
-					const before = await fingerprint(backup);
-					const bytes = await Bun.file(backup).bytes();
-					await fs.promises.unlink(backup);
-					await Bun.write(backup, bytes);
-					mutation = { before, after: await fingerprint(backup) };
-				},
-			},
-		);
-		const { before, after } = requireValue(mutation, "backup inode-only mutation");
-		expect(after).toMatchObject({ dev: before.dev, size: before.size, sha256: before.sha256 });
-		expect(after.ino).not.toBe(before.ino);
-		expect(result.status).toBe("refused");
-		expect(result.backupCreated).toBe(true);
-		expect(result.candidatePublished).toBe(false);
-		expect(result.refusal).toContain("Published output no longer matches staging file");
 	});
 
 	test("primary refusal and cleanup invariant failures retain both causes in deterministic order", async () => {

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -808,6 +808,33 @@ describe("offline SQLite salvage", () => {
 		expect(result.candidatePathTrusted).toBe(false);
 	});
 
+	test("session rebuild skips blank and malformed JSONL records", async () => {
+		await createHistorySource();
+		const file = await writeSession("primary", "primary-session", [
+			message("before", "2026-01-01T00:00:01.000Z", "before damage"),
+		]);
+		await fs.promises.appendFile(
+			file,
+			`\n{"type":"message"\n${JSON.stringify(message("after", "2026-01-01T00:00:02.000Z", "after damage"))}\n{"type":"message"`,
+		);
+		const result = await runStorageRepair({
+			target: "history",
+			historySource: "sessions",
+			apply: true,
+			agentDir: root,
+		});
+		expect(result.status).toBe("ready");
+		const db = new Database(result.candidate, { readonly: true, safeIntegers: true });
+		try {
+			expect(db.prepare("SELECT prompt FROM history ORDER BY id").all()).toEqual([
+				{ prompt: "before damage" },
+				{ prompt: "after damage" },
+			]);
+		} finally {
+			db.close();
+		}
+	});
+
 	test("invalid or changing physical sessions refuse while zero sessions remains valid", async () => {
 		await createHistorySource();
 		let result = await runStorageRepair({

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -598,7 +598,8 @@ describe("offline SQLite salvage", () => {
 		await createHistorySource();
 		await writeSession("b", "session-b", [
 			message("b1", "2026-01-01T00:00:03.900Z", "third prompt"),
-			message("b2", "2026-01-01T00:00:04.000Z", "ignored steering", { steering: true }),
+			message("b2", "2026-01-01T00:00:04.000Z", "user steering", { steering: true, attribution: "user" }),
+			message("b3", "2026-01-01T00:00:04.100Z", "agent steering", { steering: true, attribution: "agent" }),
 		]);
 		await writeSession("a", "session-a", [
 			message("a1", "2026-01-01T00:00:01.900Z", [
@@ -623,6 +624,7 @@ describe("offline SQLite salvage", () => {
 			expect(db.prepare("SELECT prompt, created_at, cwd, session_id FROM history ORDER BY id").all()).toEqual([
 				{ prompt: "first prompt", created_at: 1_767_225_601n, cwd: "/work/a", session_id: "session-a" },
 				{ prompt: "third prompt", created_at: 1_767_225_603n, cwd: "/work/b", session_id: "session-b" },
+				{ prompt: "user steering", created_at: 1_767_225_604n, cwd: "/work/b", session_id: "session-b" },
 			]);
 			expect(
 				db

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -1044,4 +1044,31 @@ describe("offline SQLite salvage", () => {
 		expect(staged.path).not.toBe(parsed.repair.candidate);
 		expect(staged.ephemeral).toBe(true);
 	});
+
+	test("backup manifest preserves frozen source member metadata", async () => {
+		const dbPath = await createAgentSource();
+		await Promise.all([
+			fs.promises.chmod(dbPath, 0o640),
+			fs.promises.chmod(`${dbPath}-wal`, 0o620),
+			fs.promises.chmod(`${dbPath}-shm`, 0o600),
+		]);
+		const [main, wal, shm] = await Promise.all(
+			sourceTripletPaths(dbPath).map(async source => {
+				const frozen = await fingerprint(source);
+				return {
+					archiveName: `source/${path.basename(source)}`,
+					size: Number(frozen.size),
+					mode: Number(frozen.mode & 0o7777n),
+					uid: frozen.uid.toString(),
+					gid: frozen.gid.toString(),
+					sha256: frozen.sha256,
+				};
+			}),
+		);
+		const result = await runStorageRepair({ target: "agent", apply: true, agentDir: root });
+		if (result.status !== "ready") throw new Error(result.refusal);
+		const files = await new Bun.Archive(await Bun.file(result.backup).bytes()).files();
+		const manifest = JSON.parse((await files.get("manifest.json")?.text()) ?? "{}");
+		expect(manifest.members).toEqual({ main, wal, shm });
+	});
 });

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -789,6 +789,41 @@ describe("offline SQLite salvage", () => {
 		expect(result.refusal).toContain("Session directory changed");
 	});
 
+
+	test("a primary session discovery access error refuses without publishing artifacts", async () => {
+		const dbPath = await createHistorySource();
+		const sourceBefore = await fingerprint(dbPath);
+		const project = path.join(getSessionsDir(root), "denied");
+		await writeSession("denied", "session", [message("m", "2026-01-01T00:00:01.000Z", "prompt")]);
+		const candidate = path.join(root, "discovery-refused.db");
+		const accessError = Object.assign(new Error("session project access denied"), { code: "EACCES" });
+		const originalReaddir = fs.promises.readdir;
+		const readdirSpy = spyOn(fs.promises, "readdir").mockImplementation(
+			((directory, options) => {
+				if (directory === project) return Promise.reject(accessError);
+				return Reflect.apply(originalReaddir, fs.promises, [directory, options]);
+			}) as typeof fs.promises.readdir,
+		);
+		try {
+			const result = await runStorageRepair({
+				target: "history",
+				historySource: "sessions",
+				apply: true,
+				agentDir: root,
+				output: candidate,
+			});
+			expect(result.status).toBe("refused");
+			expect(result.refusal).toBe("session project access denied");
+			expect(result.backupCreated).toBe(false);
+			expect(result.candidatePublished).toBe(false);
+			expect(await Bun.file(result.backup).exists()).toBe(false);
+			expect(await Bun.file(result.candidate).exists()).toBe(false);
+			expect(await fingerprint(dbPath)).toEqual(sourceBefore);
+		} finally {
+			readdirSpy.mockRestore();
+		}
+	});
+
 	test("Windows publication skips directory fsync without weakening file verification", async () => {
 		await createAgentSource();
 		let directorySyncs = 0;

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -713,9 +713,13 @@ describe("offline SQLite salvage", () => {
 	test("injected backup, verification, and no-replace publication failures clean staging and retain valid backup", async () => {
 		const dbPath = await createAgentSource();
 		const before = await fingerprint(dbPath);
+		let snapshotTempDir: string | undefined;
 		let result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root },
 			{
+				afterPristineCopy: tempDir => {
+					snapshotTempDir = tempDir;
+				},
 				beforeBackupWrite: () => {
 					throw new Error("backup injection");
 				},
@@ -724,10 +728,19 @@ describe("offline SQLite salvage", () => {
 		expect(result.status).toBe("refused");
 		expect(result.backupCreated).toBe(false);
 		expect(await fingerprint(dbPath)).toEqual(before);
+		await expect(
+			fs.promises.lstat(requireValue<string>(snapshotTempDir, "backup snapshot directory")),
+		).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 
+		snapshotTempDir = undefined;
 		result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root },
 			{
+				afterPristineCopy: tempDir => {
+					snapshotTempDir = tempDir;
+				},
 				beforeCandidateVerification: () => {
 					throw new Error("verification injection");
 				},
@@ -737,6 +750,11 @@ describe("offline SQLite salvage", () => {
 		expect(result.backupCreated).toBe(true);
 		expect(result.candidatePublished).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
+		await expect(
+			fs.promises.lstat(requireValue<string>(snapshotTempDir, "verification snapshot directory")),
+		).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 
 		const racedCandidate = path.join(root, "raced-candidate.db");
 		let racerIdentity: FileFingerprint | undefined;
@@ -765,9 +783,15 @@ describe("offline SQLite salvage", () => {
 	test("late source mismatch after candidate link publishes an untrusted sealed candidate", async () => {
 		const dbPath = await createAgentSource();
 		const candidate = path.join(root, "publication-race.db");
+		let snapshotTempDir: string | undefined;
 		const result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root, output: candidate },
-			{ afterCandidatePublication: () => fs.promises.appendFile(dbPath, "publication race") },
+			{
+				afterPristineCopy: tempDir => {
+					snapshotTempDir = tempDir;
+				},
+				afterCandidatePublication: () => fs.promises.appendFile(dbPath, "publication race"),
+			},
 		);
 		expect(result.status).toBe("published-with-warning");
 		expect(result.warning).toContain("Live source triplet changed during storage repair");
@@ -776,6 +800,11 @@ describe("offline SQLite salvage", () => {
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 		expect(await Bun.file(candidate).exists()).toBe(true);
+		await expect(
+			fs.promises.lstat(requireValue<string>(snapshotTempDir, "published warning snapshot directory")),
+		).rejects.toMatchObject({
+			code: "ENOENT",
+		});
 		const sealed = requireValue(
 			result.checksums.find(checksum => checksum.path === candidate && !checksum.ephemeral),
 			"published candidate checksum",

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -220,24 +220,25 @@ async function stageArtifacts(finalPath: string, label: "backup" | "candidate") 
 }
 
 describe("offline SQLite salvage", () => {
-	test("rejects normalized and case-insensitive source-triplet artifact aliases", async () => {
+	test("rejects normalized and mixed-case source-triplet artifact aliases on caseless platforms", async () => {
 		const source = path.join(root, "agent.db");
 		await fs.promises.writeFile(source, "source");
-		const options = { comparisonMode: "case-insensitive" } as const;
 
-		await expect(resolveArtifactPaths(source, path.join(root, "nested", "..", "agent.db"), options)).rejects.toThrow(
-			"Repair output already exists",
-		);
-
-		for (const output of [
-			path.join(root, "nested", "..", "agent.db-wal"),
-			path.join(root, "nested", "..", "agent.db-shm"),
-			path.join(root, "AGENT.DB-WAL"),
-			path.join(root, "AGENT.DB-SHM"),
-		]) {
-			await expect(resolveArtifactPaths(source, output, options)).rejects.toThrow(
-				"Repair artifact collides with source triplet",
+		for (const platform of ["darwin", "win32"] as const) {
+			const options = { platform: () => platform };
+			await expect(resolveArtifactPaths(source, path.join(root, "nested", "..", "agent.db"), options)).rejects.toThrow(
+				"Repair output already exists",
 			);
+			for (const output of [
+				path.join(root, "nested", "..", "agent.db-wal"),
+				path.join(root, "nested", "..", "agent.db-shm"),
+				path.join(root, "AGENT.DB-WAL"),
+				path.join(root, "AGENT.DB-SHM"),
+			]) {
+				await expect(resolveArtifactPaths(source, output, options)).rejects.toThrow(
+					"Repair artifact collides with source triplet",
+				);
+			}
 		}
 	});
 
@@ -246,12 +247,14 @@ describe("offline SQLite salvage", () => {
 		const slug = "fixed";
 		await fs.promises.writeFile(source, "source");
 
-		await expect(
-			resolveArtifactPaths(source, path.join(root, "nested", "..", `agent.db.salvage-${slug}.tar`), {
-				comparisonMode: "case-insensitive",
-				artifactSlug: () => slug,
-			}),
-		).rejects.toThrow("Candidate and backup paths collide");
+		for (const platform of ["darwin", "win32"] as const) {
+			await expect(
+				resolveArtifactPaths(source, path.join(root, "nested", "..", `agent.db.salvage-${slug}.tar`), {
+					platform: () => platform,
+					artifactSlug: () => slug,
+				}),
+			).rejects.toThrow("Candidate and backup paths collide");
+		}
 	});
 
 	test("rejects Unicode-normalized source-sidecar and candidate-backup aliases", async () => {
@@ -262,37 +265,31 @@ describe("offline SQLite salvage", () => {
 		const slug = "fixed";
 		await fs.promises.writeFile(source, "source");
 
-		await expect(
-			resolveArtifactPaths(source, `${alias}-wal`, { comparisonMode: "case-insensitive" }),
-		).rejects.toThrow("Repair artifact collides with source triplet");
-		await expect(
-			resolveArtifactPaths(source, `${alias}.salvage-${slug}.tar`, {
-				comparisonMode: "case-insensitive",
-				artifactSlug: () => slug,
-			}),
-		).rejects.toThrow("Candidate and backup paths collide");
-	});
-
-	test("rejects full Unicode casefold source-sidecar and candidate-backup aliases", async () => {
-		const slug = "fixed";
-		for (const { sourceName, aliasName } of [
-			{ sourceName: "agent-ος.db", aliasName: "agent-οσ.db" },
-			{ sourceName: "agent-straße.db", aliasName: "agent-STRASSE.db" },
-		]) {
-			const source = path.join(root, sourceName);
-			const alias = path.join(root, aliasName);
-			await fs.promises.writeFile(source, "source");
-
+		for (const platform of ["darwin", "win32"] as const) {
 			await expect(
-				resolveArtifactPaths(source, `${alias}-shm`, { comparisonMode: "case-insensitive" }),
+				resolveArtifactPaths(source, `${alias}-wal`, { platform: () => platform }),
 			).rejects.toThrow("Repair artifact collides with source triplet");
 			await expect(
 				resolveArtifactPaths(source, `${alias}.salvage-${slug}.tar`, {
-					comparisonMode: "case-insensitive",
+					platform: () => platform,
 					artifactSlug: () => slug,
 				}),
 			).rejects.toThrow("Candidate and backup paths collide");
 		}
+	});
+
+	test("rejects full Unicode folds on caseless platforms but not Linux", async () => {
+		const source = path.join(root, "agent-straße.db");
+		const alias = path.join(root, "AGENT-STRASSE.DB");
+		await fs.promises.writeFile(source, "source");
+
+		for (const platform of ["darwin", "win32"] as const) {
+			await expect(
+				resolveArtifactPaths(source, `${alias}-shm`, { platform: () => platform }),
+			).rejects.toThrow("Repair artifact collides with source triplet");
+		}
+		const artifacts = await resolveArtifactPaths(source, `${alias}-shm`, { platform: () => "linux" });
+		expect(artifacts.candidate).toBe(`${alias}-shm`);
 	});
 
 	test("accepts distinct repair artifact paths", async () => {
@@ -300,7 +297,7 @@ describe("offline SQLite salvage", () => {
 		const candidate = path.join(root, "repaired.db");
 		await fs.promises.writeFile(source, "source");
 
-		const artifacts = await resolveArtifactPaths(source, candidate, { comparisonMode: "case-insensitive" });
+		const artifacts = await resolveArtifactPaths(source, candidate, { platform: () => "linux" });
 		expect(artifacts.candidate).toBe(candidate);
 		expect(artifacts.backup).not.toBe(candidate);
 	});

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -924,6 +924,60 @@ describe("offline SQLite salvage", () => {
 		}
 	});
 
+	test("session families deduplicate inherited messages whose migrated copies diverge only in generated ids", async () => {
+		await createHistorySource();
+		// Parent and fork share one inherited user turn (identical content and
+		// timestamp), but the fork's migrated copy carries a regenerated entry
+		// id, so the raw JSONL lines differ. Semantic dedup must still collapse
+		// them to a single rebuilt row instead of hashing the volatile bytes.
+		const sharedTimestamp = "2026-01-01T00:00:05.000Z";
+		await writeSession("parent", "parent", [message("orig", sharedTimestamp, "inherited turn")]);
+		await writeSession(
+			"fork",
+			"fork",
+			[message("fork-regenerated", sharedTimestamp, "inherited turn")],
+			"title-slot",
+			{ parentSession: "parent" },
+		);
+		const result = await runStorageRepair({
+			target: "history",
+			historySource: "sessions",
+			apply: true,
+			agentDir: root,
+		});
+		expect(result.status).toBe("ready");
+		const db = new Database(result.candidate, { readonly: true });
+		try {
+			expect(db.prepare("SELECT prompt FROM history ORDER BY id").all()).toEqual([{ prompt: "inherited turn" }]);
+		} finally {
+			db.close();
+		}
+	});
+
+	test("session rebuild ignores non-session symlinks inside a project directory", async () => {
+		await createHistorySource();
+		await writeSession("primary", "primary-session", [message("m1", "2026-01-01T00:00:01.000Z", "primary prompt")]);
+		// An unrelated symlink whose name is not a session file must not refuse
+		// the sessions-based repair; only */*.jsonl candidates are scanned.
+		const projectDir = path.join(getSessionsDir(root), "primary");
+		const linkTarget = path.join(projectDir, "aux-target.txt");
+		await Bun.write(linkTarget, "aux");
+		await fs.promises.symlink(linkTarget, path.join(projectDir, "aux-link"));
+		const result = await runStorageRepair({
+			target: "history",
+			historySource: "sessions",
+			apply: true,
+			agentDir: root,
+		});
+		expect(result.status).toBe("ready");
+		const db = new Database(result.candidate, { readonly: true });
+		try {
+			expect(db.prepare("SELECT prompt FROM history").get()).toEqual({ prompt: "primary prompt" });
+		} finally {
+			db.close();
+		}
+	});
+
 	test("fork families preserve divergent reused entry IDs", async () => {
 		await createHistorySource();
 		await writeSession("parent", "entry-parent", [message("reused", "2026-01-01T00:00:01.000Z", "parent payload")]);

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -1,6 +1,6 @@
 import { Database, constants as sqliteConstants } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import * as fs from "node:fs/promises";
+import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { collectGcErrors, runGcCommand } from "@oh-my-pi/pi-coding-agent/cli/gc-cli";
@@ -16,13 +16,27 @@ let root: string;
 let stdout: string[];
 let stdoutSpy: { mockRestore(): void } | undefined;
 
+interface FileFingerprint {
+	dev: bigint;
+	ino: bigint;
+	size: bigint;
+	mtimeNs: bigint;
+	ctimeNs: bigint;
+	mode: bigint;
+	uid: bigint;
+	gid: bigint;
+	sha256: string;
+}
+
+type SessionFormat = "legacy-slotless" | "title-slot";
+
 function requireValue<T>(value: T | undefined, label: string): T {
 	if (value === undefined) throw new Error(`Missing ${label}`);
 	return value;
 }
 
 beforeEach(async () => {
-	root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-storage-repair-test-"));
+	root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-storage-repair-test-"));
 	stdout = [];
 	stdoutSpy = spyOn(process.stdout, "write").mockImplementation(chunk => {
 		stdout.push(String(chunk));
@@ -33,7 +47,7 @@ beforeEach(async () => {
 afterEach(async () => {
 	stdoutSpy?.mockRestore();
 	stdoutSpy = undefined;
-	await fs.rm(root, { recursive: true, force: true });
+	await fs.promises.rm(root, { recursive: true, force: true });
 });
 
 function closeWal(db: Database) {
@@ -110,9 +124,14 @@ async function createHistorySource() {
 	return dbPath;
 }
 
-async function writeSession(project: string, name: string, records: Record<string, unknown>[]) {
+async function writeSession(
+	project: string,
+	name: string,
+	records: Record<string, unknown>[],
+	format: SessionFormat = "title-slot",
+) {
 	const dir = path.join(getSessionsDir(root), project);
-	await fs.mkdir(dir, { recursive: true });
+	await fs.promises.mkdir(dir, { recursive: true });
 	const file = path.join(dir, `${name}.jsonl`);
 	const header = {
 		type: "session",
@@ -122,7 +141,7 @@ async function writeSession(project: string, name: string, records: Record<strin
 		cwd: `/work/${project}`,
 	};
 	const body = [
-		serializeTitleSlot({ title: name, updatedAt: header.timestamp }),
+		...(format === "title-slot" ? [serializeTitleSlot({ title: name, updatedAt: header.timestamp })] : []),
 		`${JSON.stringify(header)}\n`,
 		...records.map(record => `${JSON.stringify(record)}\n`),
 	].join("");
@@ -140,8 +159,8 @@ function message(id: string, timestamp: string, content: unknown, extra: Record<
 	};
 }
 
-async function fingerprint(file: string) {
-	const stat = await fs.lstat(file, { bigint: true });
+async function fingerprint(file: string): Promise<FileFingerprint> {
+	const stat = await fs.promises.lstat(file, { bigint: true });
 	return {
 		dev: stat.dev,
 		ino: stat.ino,
@@ -171,7 +190,7 @@ async function corruptTablePage(dbPath: string, table: string) {
 	} | null;
 	db.close();
 	if (typeof pageSize !== "bigint" || typeof row?.rootpage !== "bigint") throw new Error(`Cannot locate ${table}`);
-	const handle = await fs.open(dbPath, "r+");
+	const handle = await fs.promises.open(dbPath, "r+");
 	try {
 		await handle.write(
 			Buffer.alloc(Number(pageSize), 0xa5),
@@ -186,17 +205,19 @@ async function corruptTablePage(dbPath: string, table: string) {
 }
 
 function artifactModes(result: { backup: string; candidate: string }) {
-	return Promise.all([fs.stat(result.backup), fs.stat(result.candidate)]).then(([backup, candidate]) => ({
-		backup: backup.mode & 0o777,
-		candidate: candidate.mode & 0o777,
-	}));
+	return Promise.all([fs.promises.stat(result.backup), fs.promises.stat(result.candidate)]).then(
+		([backup, candidate]) => ({
+			backup: backup.mode & 0o777,
+			candidate: candidate.mode & 0o777,
+		}),
+	);
 }
 
 describe("offline SQLite salvage", () => {
 	test("physical corruption fixture reproduces normal owner-open failure", async () => {
 		const dbPath = await createAgentSource();
 		closeWal(new Database(dbPath));
-		const handle = await fs.open(dbPath, "r+");
+		const handle = await fs.promises.open(dbPath, "r+");
 		try {
 			await handle.write(Buffer.from("not sqlite"), 0, 10, 0);
 		} finally {
@@ -208,7 +229,7 @@ describe("offline SQLite salvage", () => {
 	test("history rebuild salvages a source that SQLite cannot open", async () => {
 		const dbPath = await createHistorySource();
 		closeWal(new Database(dbPath));
-		const handle = await fs.open(dbPath, "r+");
+		const handle = await fs.promises.open(dbPath, "r+");
 		try {
 			await handle.write(Buffer.from("not sqlite"), 0, 10, 0);
 		} finally {
@@ -228,14 +249,14 @@ describe("offline SQLite salvage", () => {
 	test("dry-run preserves bytes and identity metadata for every physical source triplet member", async () => {
 		const dbPath = await createAgentSource();
 		const before = await fingerprintTriplet(dbPath);
-		const siblings = await fs.readdir(path.dirname(dbPath));
+		const siblings = await fs.promises.readdir(path.dirname(dbPath));
 		const result = await runStorageRepair({ target: "agent", apply: false, agentDir: root });
 		expect(result.status).toBe("ready");
 		expect(result.backupCreated).toBe(false);
 		expect(result.candidatePublished).toBe(false);
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await fingerprintTriplet(dbPath)).toEqual(before);
-		expect(await fs.readdir(path.dirname(dbPath))).toEqual(siblings);
+		expect(await fs.promises.readdir(path.dirname(dbPath))).toEqual(siblings);
 	});
 
 	test("a changed physical WAL refuses and leaves every source member at its post-change fingerprint", async () => {
@@ -246,7 +267,7 @@ describe("offline SQLite salvage", () => {
 			{ target: "agent", apply: false, agentDir: root },
 			{
 				afterPristineCopy: async () => {
-					await fs.appendFile(`${dbPath}-wal`, "source-sidecar-change");
+					await fs.promises.appendFile(`${dbPath}-wal`, "source-sidecar-change");
 					afterMutation = await fingerprintTriplet(dbPath);
 				},
 			},
@@ -273,7 +294,7 @@ describe("offline SQLite salvage", () => {
 		const dbPath = await createAgentSource();
 		const result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root },
-			{ afterPristineCopy: () => fs.appendFile(dbPath, "race") },
+			{ afterPristineCopy: () => fs.promises.appendFile(dbPath, "race") },
 		);
 		expect(result.status).toBe("refused");
 		expect(result.refusal).toContain("changed");
@@ -406,9 +427,9 @@ describe("offline SQLite salvage", () => {
 		expect(result.status).toBe("refused");
 		expect(result.refusal).toContain("Structural drift");
 
-		await fs.rm(dbPath, { force: true });
-		await fs.rm(`${dbPath}-wal`, { force: true });
-		await fs.rm(`${dbPath}-shm`, { force: true });
+		await fs.promises.rm(dbPath, { force: true });
+		await fs.promises.rm(`${dbPath}-wal`, { force: true });
+		await fs.promises.rm(`${dbPath}-shm`, { force: true });
 		await createAgentSource();
 		db = new Database(dbPath);
 		db.exec("CREATE TABLE unsafe_extension(value TEXT CHECK(length(value) > 0))");
@@ -440,6 +461,7 @@ describe("offline SQLite salvage", () => {
 			agentDir: root,
 		});
 		expect(result.status).toBe("ready");
+		expect(result.dataLoss).toBe(true);
 		expect(result.objects.find(object => object.name === "history")).toMatchObject({ action: "rebuilt" });
 		const db = new Database(result.candidate, { readonly: true, safeIntegers: true });
 		try {
@@ -457,6 +479,63 @@ describe("offline SQLite salvage", () => {
 		}
 	});
 
+	test("slotless sessions with CJK and accented prompts rebuild through SQLite FTS verification", async () => {
+		await createHistorySource();
+		await writeSession(
+			"legacy",
+			"legacy-session",
+			[message("m", "2026-01-01T00:00:01.000Z", "東京 café résumé")],
+			"legacy-slotless",
+		);
+		const result = await runStorageRepair({
+			target: "history",
+			historySource: "sessions",
+			apply: true,
+			agentDir: root,
+		});
+		expect(result.status).toBe("ready");
+		expect(result.dataLoss).toBe(true);
+		const db = new Database(result.candidate, { readonly: true, safeIntegers: true });
+		try {
+			expect(db.prepare("SELECT prompt FROM history").get()).toEqual({ prompt: "東京 café résumé" });
+		} finally {
+			db.close();
+		}
+	});
+
+	test("session manifest changes before publication refuse the candidate", async () => {
+		await createHistorySource();
+		await writeSession("first", "first-session", [message("m", "2026-01-01T00:00:01.000Z", "first")]);
+		const result = await runStorageRepair(
+			{ target: "history", historySource: "sessions", apply: true, agentDir: root },
+			{
+				beforeCandidatePublication: async () => {
+					await writeSession("second", "second-session", [message("m", "2026-01-01T00:00:02.000Z", "second")]);
+				},
+			},
+		);
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("Session directory changed during storage repair");
+		expect(result.candidatePublished).toBe(false);
+	});
+
+	test("session manifest changes during final cleanup make a published candidate untrusted", async () => {
+		await createHistorySource();
+		await writeSession("first", "first-session", [message("m", "2026-01-01T00:00:01.000Z", "first")]);
+		const result = await runStorageRepair(
+			{ target: "history", historySource: "sessions", apply: true, agentDir: root },
+			{
+				afterCandidatePublication: async () => {
+					await writeSession("late", "late-session", [message("m", "2026-01-01T00:00:02.000Z", "late")]);
+				},
+			},
+		);
+		expect(result.status).toBe("published-with-warning");
+		expect(result.warning).toContain("Session directory changed during storage repair");
+		expect(result.candidatePublished).toBe(true);
+		expect(result.candidatePathTrusted).toBe(false);
+	});
+
 	test("invalid or changing physical sessions refuse while zero sessions remains valid", async () => {
 		await createHistorySource();
 		let result = await runStorageRepair({
@@ -470,11 +549,11 @@ describe("offline SQLite salvage", () => {
 		result = await runStorageRepair({ target: "history", historySource: "sessions", apply: false, agentDir: root });
 		expect(result.status).toBe("refused");
 		expect(result.refusal).toContain("Invalid timestamp");
-		await fs.rm(file);
+		await fs.promises.rm(file);
 		const changing = await writeSession("p", "changing", [message("m", "2026-01-01T00:00:01.000Z", "prompt")]);
 		result = await runStorageRepair(
 			{ target: "history", historySource: "sessions", apply: false, agentDir: root },
-			{ afterSessionManifestParse: () => fs.appendFile(changing, "{}\n") },
+			{ afterSessionManifestParse: () => fs.promises.appendFile(changing, "{}\n") },
 		);
 		expect(result.status).toBe("refused");
 		expect(result.refusal).toContain("Session directory changed");
@@ -522,7 +601,7 @@ describe("offline SQLite salvage", () => {
 		expect(await Bun.file(result.backup).exists()).toBe(true);
 
 		const racedCandidate = path.join(root, "raced-candidate.db");
-		let racerIdentity: Awaited<ReturnType<typeof fingerprint>> | undefined;
+		let racerIdentity: FileFingerprint | undefined;
 		result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root, output: racedCandidate },
 			{
@@ -545,7 +624,7 @@ describe("offline SQLite salvage", () => {
 		const candidate = path.join(root, "publication-race.db");
 		const result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root, output: candidate },
-			{ afterCandidatePublication: () => fs.appendFile(dbPath, "publication race") },
+			{ afterCandidatePublication: () => fs.promises.appendFile(dbPath, "publication race") },
 		);
 		expect(result.status).toBe("published-with-warning");
 		expect(result.warning).toContain("Live source triplet changed during storage repair");
@@ -559,40 +638,36 @@ describe("offline SQLite salvage", () => {
 			"sealed candidate checksum",
 		);
 		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
-		const entries = await fs.readdir(root);
+		const entries = await fs.promises.readdir(root);
 		expect(entries.some(name => name.startsWith(`.${path.basename(candidate)}.candidate-`))).toBe(false);
 	});
 
-	test("late source mismatch never disturbs a replacement after candidate link", async () => {
+	test("post-link candidate replacement refuses publication without deleting the replacement", async () => {
 		const dbPath = await createAgentSource();
 		const candidate = path.join(root, "candidate-replacement.db");
 		const replacement = "replacement bytes must survive";
-		let replacementIdentity: Awaited<ReturnType<typeof fingerprint>> | undefined;
+		let replacementIdentity: FileFingerprint | undefined;
 		const result = await runStorageRepair(
 			{ target: "agent", apply: true, agentDir: root, output: candidate },
 			{
 				afterCandidatePublication: async () => {
-					await fs.unlink(candidate);
+					await fs.promises.unlink(candidate);
 					await Bun.write(candidate, replacement);
 					replacementIdentity = await fingerprint(candidate);
-					await fs.appendFile(dbPath, "late invariant refusal");
+					await fs.promises.appendFile(dbPath, "late invariant refusal");
 				},
 			},
 		);
-		expect(result.status).toBe("published-with-warning");
-		expect(result.candidatePublished).toBe(true);
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("Published output no longer matches staging file");
+		expect(result.candidatePublished).toBe(false);
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(candidate).text()).toBe(replacement);
 		expect(await fingerprint(candidate)).toEqual(requireValue(replacementIdentity, "replacement identity"));
 		expect(await Bun.file(result.backup).exists()).toBe(true);
-		const sealed = requireValue(
-			result.checksums.find(checksum => checksum.path === candidate),
-			"sealed candidate checksum",
-		);
-		expect(sealed.sha256).not.toBe(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex"));
 	});
 
-	test("candidate stage-unlink failure warns and leaves the published candidate untouched", async () => {
+	test("candidate stage-unlink failure refuses an output that could not be proven through cleanup", async () => {
 		await createAgentSource();
 		const candidate = path.join(root, "candidate-stage-unlink.db");
 		const result = await runStorageRepair(
@@ -603,18 +678,12 @@ describe("offline SQLite salvage", () => {
 				},
 			},
 		);
-		expect(result.status).toBe("published-with-warning");
-		expect(result.warning).toContain("candidate stage-unlink injection");
-		expect(result.candidatePublished).toBe(true);
+		expect(result.status).toBe("refused");
+		expect(result.refusal).toContain("candidate stage-unlink injection");
+		expect(result.candidatePublished).toBe(false);
 		expect(result.candidatePathTrusted).toBe(false);
 		expect(await Bun.file(result.backup).exists()).toBe(true);
-		const sealed = requireValue(
-			result.checksums.find(checksum => checksum.path === candidate),
-			"sealed candidate checksum",
-		);
-		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
-		const entries = await fs.readdir(root);
-		expect(entries.some(name => name.startsWith(`.${path.basename(candidate)}.candidate-`))).toBe(false);
+		expect(await Bun.file(candidate).exists()).toBe(true);
 	});
 
 	test("candidate directory-sync failure warns and leaves the published candidate untouched", async () => {
@@ -640,6 +709,29 @@ describe("offline SQLite salvage", () => {
 		expect(new Bun.SHA256().update(await Bun.file(candidate).bytes()).digest("hex")).toBe(sealed.sha256);
 	});
 
+	test("candidate directory-sync replacement is reported as untrusted without deleting the replacement", async () => {
+		await createAgentSource();
+		const candidate = path.join(root, "candidate-directory-sync-replacement.db");
+		const replacement = "directory sync replacement must survive";
+		let replacementIdentity: FileFingerprint | undefined;
+		const result = await runStorageRepair(
+			{ target: "agent", apply: true, agentDir: root, output: candidate },
+			{
+				beforeCandidateDirectorySync: async () => {
+					await fs.promises.unlink(candidate);
+					await Bun.write(candidate, replacement);
+					replacementIdentity = await fingerprint(candidate);
+				},
+			},
+		);
+		expect(result.status).toBe("published-with-warning");
+		expect(result.warning).toContain("Published output no longer matches staging file");
+		expect(result.candidatePublished).toBe(true);
+		expect(result.candidatePathTrusted).toBe(false);
+		expect(await Bun.file(candidate).text()).toBe(replacement);
+		expect(await fingerprint(candidate)).toEqual(requireValue(replacementIdentity, "replacement identity"));
+	});
+
 	test("backup ownership survives a post-link staging-cleanup failure", async () => {
 		await createAgentSource();
 		const result = await runStorageRepair(
@@ -661,7 +753,7 @@ describe("offline SQLite salvage", () => {
 		);
 		expect(new Bun.SHA256().update(await Bun.file(result.backup).bytes()).digest("hex")).toBe(backup.sha256);
 		expect((await new Bun.Archive(await Bun.file(result.backup).bytes()).files()).get("manifest.json")).toBeDefined();
-		const entries = await fs.readdir(root);
+		const entries = await fs.promises.readdir(root);
 		expect(entries.some(name => name.startsWith(`.${path.basename(result.backup)}.backup-`))).toBe(false);
 	});
 
@@ -671,7 +763,7 @@ describe("offline SQLite salvage", () => {
 			{ target: "agent", apply: false, agentDir: root },
 			{
 				beforeCandidateVerification: async () => {
-					await fs.appendFile(dbPath, "cleanup race");
+					await fs.promises.appendFile(dbPath, "cleanup race");
 					throw new Error("primary verification refusal");
 				},
 			},
@@ -740,5 +832,16 @@ describe("offline SQLite salvage", () => {
 				repair: { ...result.repair!, status: "published-with-warning", warning: "late source mismatch" },
 			}),
 		).toEqual(["repair: late source mismatch"]);
+	});
+
+	test("session-source text reports warn about irreversible history loss", async () => {
+		await createHistorySource();
+		await writeSession("project", "session", [message("m", "2026-01-01T00:00:01.000Z", "prompt")]);
+		const result = await runGcCommand({
+			flags: { agentDir: root, repairStorage: "history", historySource: "sessions" },
+		});
+		expect(result.repair?.dataLoss).toBe(true);
+		expect(stdout.join("")).toContain("session rebuild retains only session messages");
+		expect(stdout.join("")).toContain("stable row IDs are not preserved");
 	});
 });

--- a/packages/coding-agent/test/storage-repair-cli.test.ts
+++ b/packages/coding-agent/test/storage-repair-cli.test.ts
@@ -214,6 +214,11 @@ function artifactModes(result: { backup: string; candidate: string }) {
 	);
 }
 
+async function stageArtifacts(finalPath: string, label: "backup" | "candidate") {
+	const prefix = `.${path.basename(finalPath)}.${label}-`;
+	return (await fs.promises.readdir(path.dirname(finalPath))).filter(name => name.startsWith(prefix));
+}
+
 describe("offline SQLite salvage", () => {
 	test("rejects normalized and case-insensitive source-triplet artifact aliases", async () => {
 		const source = path.join(root, "agent.db");
@@ -768,6 +773,7 @@ describe("offline SQLite salvage", () => {
 		).rejects.toMatchObject({
 			code: "ENOENT",
 		});
+		expect(await stageArtifacts(result.backup, "backup")).toEqual([]);
 
 		snapshotTempDir = undefined;
 		result = await runStorageRepair(
@@ -790,6 +796,7 @@ describe("offline SQLite salvage", () => {
 		).rejects.toMatchObject({
 			code: "ENOENT",
 		});
+		expect(await stageArtifacts(result.candidate, "candidate")).toEqual([]);
 
 		const racedCandidate = path.join(root, "raced-candidate.db");
 		let racerIdentity: FileFingerprint | undefined;
@@ -813,6 +820,7 @@ describe("offline SQLite salvage", () => {
 		);
 		expect(staged.path).not.toBe(result.candidate);
 		expect(await fingerprint(racedCandidate)).toEqual(requireValue(racerIdentity, "racer identity"));
+		expect(await stageArtifacts(result.candidate, "candidate")).toEqual([]);
 	});
 
 	test("late source mismatch after candidate link publishes an untrusted sealed candidate", async () => {

--- a/packages/coding-agent/test/zip.test.ts
+++ b/packages/coding-agent/test/zip.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { extractArchive } from "@oh-my-pi/pi-coding-agent/utils/zip";
+
+let root: string;
+
+beforeEach(async () => {
+	root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-zip-test-"));
+});
+
+afterEach(async () => {
+	await fs.promises.rm(root, { recursive: true, force: true });
+});
+
+describe("archive extraction", () => {
+	test("streams tar Blob/File members to Bun.write without materializing them", async () => {
+		const archive = path.join(root, "input.tar");
+		await Bun.Archive.write(archive, { "member.txt": "streamed payload" });
+		const arrayBufferSpy = spyOn(Blob.prototype, "arrayBuffer").mockImplementation(() => {
+			throw new Error("eager Blob.arrayBuffer read");
+		});
+		try {
+			expect(await extractArchive(archive, root)).toBe(1);
+		} finally {
+			arrayBufferSpy.mockRestore();
+		}
+		expect(await Bun.file(path.join(root, "member.txt")).text()).toBe("streamed payload");
+	});
+});


### PR DESCRIPTION
## Summary

A malformed `agent.db` or `history.db` no longer leaves users with only unsafe in-place recovery choices. `omp gc --repair-storage agent|history` now diagnoses a stable offline snapshot in dry-run mode and, with `--apply`, publishes a byte-exact backup before a verified salvage candidate without changing the live database triplet.

The repair path preserves readable authoritative data, rebuilds only named derived state, refuses ambiguous loss, and can rebuild prompt history from a frozen set of session files. Candidate publication uses atomic no-replace semantics; once published it is final, so a later sync or source-invariant failure reports `published-with-warning` and never risks deleting a path another process replaced.

Related issue: #7004

## Verification

- `bun run check:ts` — passed on the isolated branch based on `upstream/main`
- `bun test packages/coding-agent/test/storage-repair-cli.test.ts packages/coding-agent/test/gc-cli.test.ts packages/coding-agent/test/zip.test.ts` — 84 passed
- Full `bun check` reaches the unchanged Rust tree, then the workstation's `audiopus_sys` build fails in CMake; this PR changes no Rust or Cargo input
- Native rebuild was unavailable because neither `bazelisk` nor `bazel` is installed; focused tests used the existing local native addon







