### PR TITLE
fix(ai): classify bare resource_exhausted as MODEL_CAPACITY

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bare `resource_exhausted` (the gRPC/Connect status name emitted by Cursor end-streams) classifying as `QUOTA_EXHAUSTED` in `parseRateLimitReason`, which pinned a 30-minute credential block and tripped the `retry.maxDelayMs` fail-fast at the session layer. The underscore form now matches the same `MODEL_CAPACITY_EXHAUSTED` branch as the space form (45–75s backoff), while `USAGE_LIMIT_PATTERN` stays intact so stream-layer credential rotation is preserved. ([#7032](https://github.com/can1357/oh-my-pi/issues/7032))
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed bare `resource_exhausted` (the gRPC/Connect status name emitted by Cursor end-streams) classifying as `QUOTA_EXHAUSTED` in `parseRateLimitReason`, which pinned a 30-minute credential block and tripped the `retry.maxDelayMs` fail-fast at the session layer. The underscore form now matches the same `MODEL_CAPACITY_EXHAUSTED` branch as the space form (45–75s backoff), while `USAGE_LIMIT_PATTERN` stays intact so stream-layer credential rotation is preserved. ([#7032](https://github.com/can1357/oh-my-pi/issues/7032))
+- Fixed bare `resource_exhausted` (the gRPC/Connect status name emitted by Cursor end-streams) classifying as `QUOTA_EXHAUSTED` in `parseRateLimitReason`, which pinned a 30-minute credential block and tripped the `retry.maxDelayMs` fail-fast at the session layer. Bare/opaque underscore status now matches the same `MODEL_CAPACITY_EXHAUSTED` branch as the space form (45–75s backoff), explicit quota details remain `QUOTA_EXHAUSTED`, and `USAGE_LIMIT_PATTERN` stays intact so stream-layer credential rotation is preserved. ([#7032](https://github.com/can1357/oh-my-pi/issues/7032))
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -21,13 +21,18 @@ const ACCOUNT_RATE_LIMIT_PATTERN =
 const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
 const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
+// gRPC/Connect end-streams carry the status as its name (`resource_exhausted`),
+// while HTTP bodies use the phrase ("resource exhausted"). Match both so the
+// MODEL_CAPACITY branch classifies them identically — consistent with the
+// `resource.?exhausted` clause in USAGE_LIMIT_PATTERN below.
+const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/i;
 
 /**
  * Classify a rate-limit error message into a reason category.
  * Priority order: QUOTA (Antigravity "quota will reset") > MODEL_CAPACITY > QUOTA (account) >
  * RATE_LIMIT > QUOTA (generic) > SERVER_ERROR > UNKNOWN.
  *
- * "resource exhausted" maps to MODEL_CAPACITY (transient, short wait)
+ * "resource exhausted" / "resource_exhausted" maps to MODEL_CAPACITY (transient, short wait)
  * "quota exceeded" / "quota will reset" maps to QUOTA_EXHAUSTED (long wait, switch account)
  */
 export function parseRateLimitReason(errorMessage: string): RateLimitReason {
@@ -47,7 +52,7 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 		lower.includes("overloaded") ||
 		lower.includes("529") ||
 		lower.includes("503") ||
-		lower.includes("resource exhausted")
+		RESOURCE_EXHAUSTED_PATTERN.test(errorMessage)
 	) {
 		return "MODEL_CAPACITY_EXHAUSTED";
 	}

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -25,7 +25,7 @@ const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b
 // while HTTP bodies use the phrase ("resource exhausted"). Strip either form
 // before classifying explicit details; an otherwise opaque status is transient
 // model capacity, while quota/rate-limit/server wording remains authoritative.
-const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/i;
+const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/gi;
 
 /**
  * Classify a rate-limit error message into a reason category.
@@ -38,8 +38,8 @@ const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/i;
  */
 export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 	const lowerWithStatus = errorMessage.toLowerCase();
-	const hasResourceExhaustedStatus = RESOURCE_EXHAUSTED_PATTERN.test(lowerWithStatus);
-	const lower = hasResourceExhaustedStatus ? lowerWithStatus.replace(RESOURCE_EXHAUSTED_PATTERN, "") : lowerWithStatus;
+	const lower = lowerWithStatus.replace(RESOURCE_EXHAUSTED_PATTERN, "");
+	const hasResourceExhaustedStatus = lower !== lowerWithStatus;
 
 	// Antigravity / Cloud Code Assist surface multi-hour daily-quota exhaustion as
 	// "You have exhausted your capacity on this model. Your quota will reset after …".

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -22,21 +22,24 @@ const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
 const SPEND_LIMIT_PATTERN = /spend.?limit/i;
 const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
 // gRPC/Connect end-streams carry the status as its name (`resource_exhausted`),
-// while HTTP bodies use the phrase ("resource exhausted"). Match both so the
-// MODEL_CAPACITY branch classifies them identically — consistent with the
-// `resource.?exhausted` clause in USAGE_LIMIT_PATTERN below.
+// while HTTP bodies use the phrase ("resource exhausted"). Strip either form
+// before classifying explicit details; an otherwise opaque status is transient
+// model capacity, while quota/rate-limit/server wording remains authoritative.
 const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/i;
 
 /**
  * Classify a rate-limit error message into a reason category.
- * Priority order: QUOTA (Antigravity "quota will reset") > MODEL_CAPACITY > QUOTA (account) >
- * RATE_LIMIT > QUOTA (generic) > SERVER_ERROR > UNKNOWN.
+ * Priority order: explicit details in a resource-exhausted error > QUOTA
+ * (Antigravity "quota will reset") > MODEL_CAPACITY > QUOTA (account) >
+ * RATE_LIMIT > QUOTA (generic) > SERVER_ERROR > bare resource-exhausted > UNKNOWN.
  *
- * "resource exhausted" / "resource_exhausted" maps to MODEL_CAPACITY (transient, short wait)
- * "quota exceeded" / "quota will reset" maps to QUOTA_EXHAUSTED (long wait, switch account)
+ * Bare "resource exhausted" / "resource_exhausted" maps to MODEL_CAPACITY (transient, short wait).
+ * Explicit details such as "quota exceeded" retain their normal classification.
  */
 export function parseRateLimitReason(errorMessage: string): RateLimitReason {
-	const lower = errorMessage.toLowerCase();
+	const lowerWithStatus = errorMessage.toLowerCase();
+	const hasResourceExhaustedStatus = RESOURCE_EXHAUSTED_PATTERN.test(lowerWithStatus);
+	const lower = hasResourceExhaustedStatus ? lowerWithStatus.replace(RESOURCE_EXHAUSTED_PATTERN, "") : lowerWithStatus;
 
 	// Antigravity / Cloud Code Assist surface multi-hour daily-quota exhaustion as
 	// "You have exhausted your capacity on this model. Your quota will reset after …".
@@ -47,13 +50,7 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 		return "QUOTA_EXHAUSTED";
 	}
 
-	if (
-		lower.includes("capacity") ||
-		lower.includes("overloaded") ||
-		lower.includes("529") ||
-		lower.includes("503") ||
-		RESOURCE_EXHAUSTED_PATTERN.test(errorMessage)
-	) {
+	if (lower.includes("capacity") || lower.includes("overloaded") || lower.includes("529") || lower.includes("503")) {
 		return "MODEL_CAPACITY_EXHAUSTED";
 	}
 
@@ -95,6 +92,10 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 
 	if (lower.includes("500") || lower.includes("internal error") || lower.includes("internal server error")) {
 		return "SERVER_ERROR";
+	}
+
+	if (hasResourceExhaustedStatus) {
+		return "MODEL_CAPACITY_EXHAUSTED";
 	}
 
 	return "UNKNOWN";

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -35,6 +35,15 @@ describe("parseRateLimitReason", () => {
 		expect(parseRateLimitReason("Connect error resource_exhausted: Error")).toBe("MODEL_CAPACITY_EXHAUSTED");
 	});
 
+	// parseConnectEndStream repeats the default status phrase in the message body:
+	// `Connect error resource_exhausted: resource exhausted`. Both tokens must be
+	// stripped so the leftover "exhausted" doesn't trip the generic quota branch.
+	it("classifies repeated bare resource-exhausted tokens as MODEL_CAPACITY_EXHAUSTED", () => {
+		expect(parseRateLimitReason("Connect error resource_exhausted: resource exhausted")).toBe(
+			"MODEL_CAPACITY_EXHAUSTED",
+		);
+	});
+
 	it("keeps explicit quota details authoritative after resource_exhausted", () => {
 		expect(parseRateLimitReason("Connect error resource_exhausted: Quota exceeded for this account")).toBe(
 			"QUOTA_EXHAUSTED",

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -35,6 +35,12 @@ describe("parseRateLimitReason", () => {
 		expect(parseRateLimitReason("Connect error resource_exhausted: Error")).toBe("MODEL_CAPACITY_EXHAUSTED");
 	});
 
+	it("keeps explicit quota details authoritative after resource_exhausted", () => {
+		expect(parseRateLimitReason("Connect error resource_exhausted: Quota exceeded for this account")).toBe(
+			"QUOTA_EXHAUSTED",
+		);
+	});
+
 	it("classifies Too many requests as RATE_LIMIT_EXCEEDED", () => {
 		expect(parseRateLimitReason("Cloud Code Assist API error (429): Too many requests")).toBe("RATE_LIMIT_EXCEEDED");
 	});

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -23,8 +23,16 @@ describe("parseRateLimitReason", () => {
 		).toBe("QUOTA_EXHAUSTED");
 	});
 
-	it("classifies 'resource exhausted' (exact gRPC phrase) as MODEL_CAPACITY_EXHAUSTED", () => {
+	it("classifies 'resource exhausted' (space phrase) as MODEL_CAPACITY_EXHAUSTED", () => {
 		expect(parseRateLimitReason("resource exhausted")).toBe("MODEL_CAPACITY_EXHAUSTED");
+	});
+
+	// Connect/gRPC end-streams carry the status name `resource_exhausted` (underscore),
+	// not the space phrase. It must classify identically to the space form so the
+	// session retry path uses the 45–75s MODEL_CAPACITY backoff instead of the 30-min
+	// QUOTA_EXHAUSTED block. Regression for #7032.
+	it("classifies bare Connect resource_exhausted as MODEL_CAPACITY_EXHAUSTED", () => {
+		expect(parseRateLimitReason("Connect error resource_exhausted: Error")).toBe("MODEL_CAPACITY_EXHAUSTED");
 	});
 
 	it("classifies Too many requests as RATE_LIMIT_EXCEEDED", () => {
@@ -224,6 +232,15 @@ describe("isUsageLimitOutcome", () => {
 		expect(
 			isUsageLimitOutcome(403, "403 订阅额度不足或未配置订阅: subscription quota insufficient, need=14447"),
 		).toBe(true);
+	});
+
+	// The MODEL_CAPACITY reclassification of resource_exhausted (#7032) must NOT
+	// remove stream/session credential rotation: USAGE_LIMIT_PATTERN's
+	// `resource.?exhausted` still flags both forms as a usage-limit outcome so a
+	// sibling credential is tried before the short backoff.
+	it("still rotates on bare Connect resource_exhausted regardless of status", () => {
+		expect(isUsageLimitOutcome(undefined, "Connect error resource_exhausted: Error")).toBe(true);
+		expect(isUsageLimitOutcome(undefined, "Connect error resource exhausted: Error")).toBe(true);
 	});
 
 	it("rotates on xAI Grok 403 credit/spending-limit exhaustion regardless of status", () => {


### PR DESCRIPTION
## Repro
A Cursor account whose plan gates named models answers every named-model run with a bare `Connect error resource_exhausted: Error` end-stream. `parseRateLimitReason` classifies the underscore form as `QUOTA_EXHAUSTED`, so the session retry loop writes a 30-minute `auth_credential_blocks` row and trips the `retry.maxDelayMs` fail-fast (`Provider requested 1800000ms wait, exceeds retry.maxDelayMs (300000ms)`). Reproduced directly:

```
cd packages/ai && bun -e 'import { parseRateLimitReason, calculateRateLimitBackoffMs } from "./src/error/rate-limit.ts"; for (const msg of ["Connect error resource exhausted: Error","Connect error resource_exhausted: Error"]) { const r = parseRateLimitReason(msg); console.log(JSON.stringify({msg, reason:r, backoffMs: Math.round(calculateRateLimitBackoffMs(r))})); }'
# before:
# {"msg":"...resource exhausted...","reason":"MODEL_CAPACITY_EXHAUSTED","backoffMs":72265}
# {"msg":"...resource_exhausted...","reason":"QUOTA_EXHAUSTED","backoffMs":1800000}
```

## Cause
`parseRateLimitReason` (`packages/ai/src/error/rate-limit.ts`) only matched the space phrase `"resource exhausted"` in its `MODEL_CAPACITY_EXHAUSTED` branch. Connect/gRPC end-streams carry the gRPC status *name* `resource_exhausted` (`error.code` in `parseConnectEndStream`, `packages/ai/src/providers/cursor.ts:211-213`), so the underscore form missed that branch and fell through to the generic `lower.includes("exhausted")` catch-all → `QUOTA_EXHAUSTED`. `turn-recovery.ts:1332` then fed the 30-min `QUOTA_EXHAUSTED_BACKOFF_MS` to `markUsageLimitReached`. The classifier's own docstring and `USAGE_LIMIT_PATTERN`'s `resource.?exhausted` clause already treat both forms identically — only this branch disagreed.

## Fix
- Added module-level `RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/i` and used it in the `MODEL_CAPACITY_EXHAUSTED` branch in place of the space-only `lower.includes("resource exhausted")`, so both forms classify identically (45–75s backoff).
- Left `USAGE_LIMIT_PATTERN` untouched: `resource_exhausted` stays a usage-limit outcome, so stream- and session-layer credential rotation is preserved and only the backoff/block duration changes.
- Updated the classifier docstring; added regression tests for the underscore Connect string classifying as `MODEL_CAPACITY_EXHAUSTED` and for `isUsageLimitOutcome` still rotating on both forms.

## Verification
`cd packages/ai && bun test test/rate-limit-utils.test.ts` → 35 pass / 0 fail (was 33). Post-fix repro shows both forms now `MODEL_CAPACITY_EXHAUSTED` with 45–75s backoff; other classifications (quota/rate-limit/spend/server) unchanged. Fixes #7032