### PR TITLE
fix(ai): normalize bare-string systemPrompt in bedrock and devin

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Amazon Bedrock and Devin providers crashing when `Context.systemPrompt` is a bare string (as legacy `@earendil-works/pi-ai` extensions pass it), which surfaced as `stopReason: "error"` with `systemPrompt?.map is not a function`. Both providers now route through the existing `normalizeSystemPrompts()` helper like the other providers ([#7037](https://github.com/can1357/oh-my-pi/issues/7037)).
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -29,7 +29,7 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 } from "../types";
-import { normalizeToolCallId, resolveCacheRetention } from "../utils";
+import { normalizeSystemPrompts, normalizeToolCallId, resolveCacheRetention } from "../utils";
 import {
 	clearStreamingPartialJson,
 	kStreamingBlockIndex,
@@ -752,10 +752,10 @@ function supportsThinkingSignature(model: Model<"bedrock-converse-stream">): boo
 }
 
 function buildSystemPrompt(
-	systemPrompt: readonly string[] | undefined,
+	systemPrompt: readonly string[] | string | undefined,
 	promptCachePolicy: BedrockPromptCachePolicy,
 ): SystemContent[] | undefined {
-	const prompts = systemPrompt?.map(prompt => prompt.toWellFormed()).filter(prompt => prompt.length > 0) ?? [];
+	const prompts = normalizeSystemPrompts(systemPrompt);
 	if (prompts.length === 0) return undefined;
 
 	const blocks: SystemContent[] = prompts.map(prompt => ({ text: prompt }));

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -43,6 +43,7 @@ import type {
 	Tool,
 	ToolCall,
 } from "../types";
+import { normalizeSystemPrompts } from "../utils";
 import { isDemotedThinking } from "../utils/block-symbols";
 import { deterministicUuid } from "../utils/deterministic-id";
 import { AssistantMessageEventStream } from "../utils/event-stream";
@@ -518,7 +519,7 @@ function buildDevinChatRequest(
 			extensionVersion: DEVIN_EXTENSION_VERSION,
 			locale: "en",
 		}),
-		prompt: (context.systemPrompt ?? []).join("\n\n"),
+		prompt: normalizeSystemPrompts(context.systemPrompt).join("\n\n"),
 		chatMessagePrompts: buildChatMessagePrompts(messages, cascadeId, model),
 		chatModelUid: options?.chatModelUid ?? model.requestModelId ?? model.id,
 		requestType: ChatMessageRequestType.CASCADE,

--- a/packages/ai/test/bedrock-system-prompt.test.ts
+++ b/packages/ai/test/bedrock-system-prompt.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+interface Payload {
+	system?: Array<{ text: string } | { cachePoint: unknown }>;
+}
+
+function model(): Model<"bedrock-converse-stream"> {
+	return buildModel({
+		id: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+		name: "haiku",
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+	});
+}
+
+function abortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+// Capture the request payload the provider would send, without a network call:
+// an already-aborted signal short-circuits after `onPayload` fires.
+async function capturePayload(systemPrompt: Context["systemPrompt"]): Promise<Payload> {
+	const context: Context = {
+		systemPrompt,
+		messages: [{ role: "user", content: "hi", timestamp: 0 }],
+	};
+	const { promise, resolve } = Promise.withResolvers<Payload | undefined>();
+	const stream = streamBedrock(model(), context, {
+		signal: abortedSignal(),
+		onPayload: payload => {
+			resolve(payload as Payload);
+		},
+	});
+	// Drain the stream so the request-building path (and thus onPayload) runs.
+	void (async () => {
+		try {
+			for await (const _ of stream) {
+				// ignore events; we only care about the captured payload
+			}
+		} finally {
+			resolve(undefined);
+		}
+	})();
+	const payload = await promise;
+	if (!payload) throw new Error("payload was not captured");
+	return payload;
+}
+
+function textBlocks(payload: Payload): string[] {
+	return (payload.system ?? []).filter((block): block is { text: string } => "text" in block).map(block => block.text);
+}
+
+describe("Bedrock system prompt normalization", () => {
+	// Regression for #7037: legacy pi extensions remapped onto the fork pass
+	// Context.systemPrompt as a bare string, which crashed buildSystemPrompt's
+	// unguarded `.map()`. It must normalize to a single-element system block.
+	test("accepts a bare-string systemPrompt", async () => {
+		const payload = await capturePayload("You are a test." as unknown as string[]);
+		expect(textBlocks(payload)).toEqual(["You are a test."]);
+	});
+
+	test("string and single-element array produce identical system blocks", async () => {
+		const fromString = await capturePayload("You are a test." as unknown as string[]);
+		const fromArray = await capturePayload(["You are a test."]);
+		expect(textBlocks(fromString)).toEqual(textBlocks(fromArray));
+	});
+});


### PR DESCRIPTION
## Repro
Calling a Bedrock model with a bare-string `Context.systemPrompt` fails before the request is built. Legacy extensions published against `@earendil-works/pi-ai` pass `systemPrompt` as a `string` and are deliberately remapped onto this fork by `legacy-pi-compat.ts`, so any such extension (e.g. `@czottmann/pi-automode` with a Bedrock classifier) breaks. Reproduced on `main` by driving `streamBedrock` with a string vs array `systemPrompt` and capturing the built payload via `onPayload` with an already-aborted signal (no network):

```
systemPrompt as string  -> stopReason=error errorMessage="systemPrompt?.map is not a function. (In 'systemPrompt?.map((prompt) => prompt.toWellFormed())', 'systemPrompt?.map' is undefined)"
systemPrompt as string[] -> payload.system=[{text:...},{cachePoint}] built OK
```

## Cause
`buildSystemPrompt` in `packages/ai/src/providers/amazon-bedrock.ts` hand-rolled `systemPrompt?.map(prompt => prompt.toWellFormed())`. Optional chaining does not help: the value is present, just a string, so `A?.map` is `undefined`. `packages/ai/src/providers/devin.ts` has the same latent crash via `(context.systemPrompt ?? []).join("\n\n")` (would throw `.join is not a function`). These are the only two providers that do not route through the existing `normalizeSystemPrompts()` helper in `packages/ai/src/utils.ts`, whose signature already accepts `readonly string[] | string`.

## Fix
- `amazon-bedrock.ts`: import `normalizeSystemPrompts`, widen `buildSystemPrompt`'s parameter to `readonly string[] | string | undefined`, and replace the hand-rolled `.map().filter()` with `normalizeSystemPrompts(systemPrompt)`.
- `devin.ts`: add the `../utils` import and wrap `context.systemPrompt` in `normalizeSystemPrompts(...).join("\n\n")`.
- Added `packages/ai/test/bedrock-system-prompt.test.ts` asserting a bare-string `systemPrompt` produces a single-element `system` block identical to the array form.
- Changelog entry under `[Unreleased]`.

The `pi-native-server.ts` wire boundary keeps its strict `Array.isArray` validation — untouched, as it should be.

## Verification
`bun test packages/ai/test/bedrock-system-prompt.test.ts packages/ai/test/bedrock-prompt-cache.test.ts packages/ai/test/bedrock-inference-profile.test.ts packages/ai/test/devin-*.test.ts` — all pass. The new test fails without the fix (the string case crashes in `buildSystemPrompt` before `onPayload` fires, so no payload is captured).

Fixes #7037