### PR TITLE
fix(coding-agent): report resume failures instead of crashing the session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Fixed a resume failure in the session selector killing the whole session: the picker fires its selection callback without awaiting it, so a rejecting resume escaped as an unhandled rejection instead of being reported ([#7047](https://github.com/can1357/oh-my-pi/pull/7047) by [@k1riiiii](https://github.com/k1riiiii)).
 - Fixed `/tan` agents being unable to read parent-session `local://` attachments by correctly resolving local protocol options against the parent session's artifacts.
 - Fixed Codex web search silently returning plain completions when the hosted web search tool was skipped.
 - Fixed TUI collaboration guest loader not starting when joining or reconnecting mid-turn.

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1465,6 +1465,11 @@ export class SelectorController {
 						this.ctx.ui.requestRender();
 					}
 				} catch (error) {
+					// SessionSelectorComponent invokes this callback without awaiting it, so
+					// nothing consumes a rejection here: it would reach the process-level
+					// unhandledRejection handler and take the whole session down. Both the
+					// native resume and the foreign-session import must surface failures
+					// through showError and close the picker instead.
 					this.ctx.showError(error instanceof Error ? error.message : String(error));
 				} finally {
 					if (!keepOpen) done();

--- a/packages/coding-agent/test/modes/controllers/resume-preflight.test.ts
+++ b/packages/coding-agent/test/modes/controllers/resume-preflight.test.ts
@@ -176,7 +176,7 @@ describe("SelectorController.handleResumeSession preflight flush", () => {
 		expect(hide).toHaveBeenCalledTimes(1);
 	});
 
-	it("closes the selector and restores editor focus when switching rejects after preflight", async () => {
+	it("surfaces the error and closes the selector when switching rejects after preflight", async () => {
 		const session: SessionInfo = {
 			path: "/tmp/rejected-resume.jsonl",
 			id: "rejected-resume",
@@ -220,10 +220,14 @@ describe("SelectorController.handleResumeSession preflight flush", () => {
 
 		selector!.handleInput("\n");
 		expect(selectionPromise).toBeDefined();
-		await expect(selectionPromise!).rejects.toBe(switchError);
+		// SessionSelectorComponent fires this callback without awaiting it, so a
+		// rejection here would reach the process-level unhandledRejection handler
+		// and kill the session. The failure has to settle as showError instead.
+		await expect(selectionPromise!).resolves.toBeUndefined();
 
 		expect(ctx.settings.flush).toHaveBeenCalledTimes(1);
 		expect(switchSession).toHaveBeenCalledWith(session.path);
+		expect(ctx.showError).toHaveBeenCalledWith(switchError.message);
 		expect(hide).toHaveBeenCalledTimes(1);
 		expect(setFocus).toHaveBeenLastCalledWith(editor);
 	});


### PR DESCRIPTION
## Summary

`Test coding-agent UI/TUI` is red on `main`. My first pass at this had the diagnosis backwards; the reviewer was right. Rewritten, and the unrelated `packages/utils` timeout fix is split into #7049.

**What's actually broken:** `SessionSelectorComponent` invokes its selection callback without awaiting the returned promise — all three call sites (`session-selector.ts:326` search submit, `:514` mouse click, `:693` Enter) do a bare `this.onSelect(selected)`, and the declared type is `(session: SessionInfo) => void`. The controller passes an `async` callback, so its promise is discarded.

That means a rejection from the resume path has **no consumer in production**. It reaches the process-level `unhandledRejection` handler in `packages/utils/src/postmortem.ts:212`, which has no interceptor covering this path (`interceptUnhandledRejections` is only registered for JS-eval subprocesses, `cli.ts:181`), and calls `exitAfterFatal(...)` — killing the whole TUI session with exit code 1. A failed resume became a crashed session.

**The test was asserting the crash as if it were a contract.** `resume-preflight.test.ts` reached into a mocked constructor to capture the discarded promise and `await expect(...).rejects.toBe(switchError)`. That assertion **predates** the foreign-import feature:

```
$ git cat-file -e f11641d5a^:packages/coding-agent/test/modes/controllers/resume-preflight.test.ts
$ git show f11641d5a^:...resume-preflight.test.ts | grep -n 'rejects.toBe(switchError)'
223:            await expect(selectionPromise!).rejects.toBe(switchError);
```

And at `f11641d5a^` the implementation had only `try`/`finally` — **no `catch` at all**. So this "rejections propagate" contract only ever held inside the test, via that constructor hack; production was always an unhandled rejection. The `catch` that `f11641d5a` added incidentally *fixed* a latent crash — it just left the stale test behind.

So the fix is in the test, not the implementation. My earlier `if (!source) throw error` would have restored the crash.

## Changes

- `selector-controller.ts`: no behavior change — the unconditional `catch` from `f11641d5a` stays. Added a comment recording *why* it must not rethrow, so the next reader doesn't undo it the way I tried to.
- `resume-preflight.test.ts`: assert the observable contract — the failure surfaces through `showError`, the picker closes (`hide` once), and focus returns to the editor — instead of the discarded promise's rejection.
- `CHANGELOG.md`: entry under `### Fixed`.

Making `onSelect` return `void | Promise<void>` and having the three call sites `void`-handle it would catch this class of bug at the type level, but that's beyond a CI fix — worth a separate PR.

## Testing

- `resume-preflight.test.ts` 5 pass. Verified red→green: temporarily removing the `catch` fails the rewritten test with `Expected promise that resolves / Received promise that rejected`, so it does pin the contract rather than merely passing.
- `test/modes/controllers/` + `test/input-controller-*` 179 pass.
- `foreign-session-stores.test.ts`, `slash-commands/resume.test.ts`, `main-resume-cancel-exit.test.ts`, `main-cross-project-resume.test.ts` 19 pass.
- `bun run check:types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)