### PR TITLE
test(utils): widen the postmortem quit no-drain budget for CI

### DIFF
--- a/packages/utils/test/postmortem-quit.test.ts
+++ b/packages/utils/test/postmortem-quit.test.ts
@@ -14,7 +14,10 @@ describe("postmortem quit", () => {
 			stdout: "pipe",
 			stderr: "pipe",
 		});
-		const timeout = Bun.sleep(500).then(() => "timeout" as const);
+		// The draining path caps out at Bun.sleep(5000), so any budget under 5s still
+		// proves the drain was skipped. 500ms did not cover the child's cold start and
+		// module graph load, so CI intermittently observed "timeout" instead of exit 23.
+		const timeout = Bun.sleep(2500).then(() => "timeout" as const);
 		try {
 			expect(await Promise.race([child.exited, timeout])).toBe(23);
 		} finally {


### PR DESCRIPTION
## Summary

`Test TS workspace fast` is red on `main`. `postmortem-quit.test.ts` races `child.exited` against `Bun.sleep(500)` to prove `quit({ drainStdout: false })` skips the drain. 500ms has to absorb the child's bun cold start plus module-graph import, which the runner doesn't always make — CI observed `"timeout"` instead of exit `23`.

Raised to 2.5s. The budget can't simply be removed: the draining path caps at `Bun.sleep(5000)` (`packages/utils/src/postmortem.ts:338`), so staying under 5s is what makes the assertion meaningful. 2.5s gives 5× headroom while keeping a 2.5s margin below the cap.

Split out of #7047 per review — that PR's other half is an unrelated `coding-agent` fix.

## Testing

- `packages/utils`: `postmortem-quit.test.ts` 1 pass, run 3× consecutively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)