### PR TITLE
test(coding-agent): fix two global-state test defects on main

### DIFF
--- a/packages/coding-agent/test/agent-hub-activate.test.ts
+++ b/packages/coding-agent/test/agent-hub-activate.test.ts
@@ -394,6 +394,7 @@ describe("Agent hub data refresh coalescing", () => {
 	afterEach(() => {
 		vi.useRealTimers();
 		vi.restoreAllMocks();
+		IrcBus.resetGlobalForTests();
 		AgentRegistry.resetGlobalForTests();
 	});
 

--- a/packages/coding-agent/test/modes/controllers/resume-preflight.test.ts
+++ b/packages/coding-agent/test/modes/controllers/resume-preflight.test.ts
@@ -176,7 +176,7 @@ describe("SelectorController.handleResumeSession preflight flush", () => {
 		expect(hide).toHaveBeenCalledTimes(1);
 	});
 
-	it("closes the selector and restores editor focus when switching rejects after preflight", async () => {
+	it("surfaces the error, closes the selector and restores editor focus when switching rejects after preflight", async () => {
 		const session: SessionInfo = {
 			path: "/tmp/rejected-resume.jsonl",
 			id: "rejected-resume",
@@ -220,10 +220,11 @@ describe("SelectorController.handleResumeSession preflight flush", () => {
 
 		selector!.handleInput("\n");
 		expect(selectionPromise).toBeDefined();
-		await expect(selectionPromise!).rejects.toBe(switchError);
+		await selectionPromise!;
 
 		expect(ctx.settings.flush).toHaveBeenCalledTimes(1);
 		expect(switchSession).toHaveBeenCalledWith(session.path);
+		expect(ctx.showError).toHaveBeenCalledWith(switchError.message);
 		expect(hide).toHaveBeenCalledTimes(1);
 		expect(setFocus).toHaveBeenLastCalledWith(editor);
 	});


### PR DESCRIPTION
Two small, independent test-only fixes found while running the full `packages/coding-agent` suite on `f11641d5a`. No product code changes.

## 1. Reset the IRC bus alongside the agent registry

`IrcBus` captures its `AgentRegistry` at construction (`src/irc/bus.ts`), but the hub data-refresh teardown in `test/agent-hub-activate.test.ts` resets only the global registry. The cached global bus stays bound to the discarded instance, so any later file in the same process sends through a bus whose registry no longer knows agents registered after the reset.

Latent at the current file ordering; it surfaces as soon as suite composition changes. Reproduce by running the two files together, which strands the plan-mode side-channel auto-reply until its timeout:

```
bun test packages/coding-agent/test/agent-hub-activate.test.ts \\
         packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
```

The fix pairs the two resets the way `test/advisor/advisor-visibility.test.ts` already does.

## 2. Assert the surfaced error when resume switching rejects

`Test coding-agent UI/TUI (TS)` is currently red on `main` at `f11641d5a`:

```
(fail) SelectorController.handleResumeSession preflight flush >
       closes the selector and restores editor focus when switching rejects after preflight
Expected promise that rejects / Received promise that resolved
```

The `onSelect` callback in `showSessionSelector` now wraps the resume in a catch that reports through `showError`. That looks deliberate: the new foreign-session import path throws (`Selected <source> session is no longer available`, `Failed to persist <source> session`) and `SessionSelectorComponent` invokes `onSelect` fire-and-forget, so a propagated rejection would be unhandled. The pre-existing test still asserted propagation.

The test now asserts the actual contract: the error is surfaced through `showError`, the selector closes, and editor focus is restored. I confirmed the new assertion bites by stubbing the `showError` call out of the catch and watching the test fail.

If you'd rather keep propagation and have the component await/handle it, say so and I'll flip the fix to the product side instead.

## Verification

Bun 1.3.14 (the pinned version), branch = `f11641d5a` + these two commits.

- `bun run check:ts` — exit 0
- `packages/coding-agent/test/modes/controllers/resume-preflight.test.ts` — 5 pass, 0 fail (was 4 pass / 1 fail)
- the two-file IRC repro above — 19 pass, 0 fail (was 18 pass / 1 fail)