### PR TITLE
feat(internal-urls): add session archive browsing and session_search tool

### DIFF
--- a/docs/tools/session-search.md
+++ b/docs/tools/session-search.md
@@ -1,0 +1,80 @@
+# session_search
+
+> Search persisted OMP session transcript content, including entries hidden behind compaction boundaries.
+
+## Source
+- Entry: `packages/coding-agent/src/tools/session-search.ts`
+- Search and archive service: `packages/coding-agent/src/session/session-archive.ts`
+- Model-facing prompt: `packages/coding-agent/src/prompts/tools/session-search.md`
+- Transcript reader primitives: `packages/coding-agent/src/session/session-listing.ts`, `packages/utils/src/stream.ts`
+- Related archive URLs: `packages/coding-agent/src/internal-urls/history-protocol.ts`
+
+## Inputs
+
+| Field | Type | Required | Description |
+|---|---|---:|---|
+| `query` | `string` | Yes | Literal transcript text to find. Maximum 500 characters. Matching is case-insensitive by default. |
+| `scope` | `"project" \| "all"` | No | Session scope. Defaults to `project`, matched against the active session's resolved working directory. |
+| `session` | `string` | No | Restrict search to an exact or uniquely prefixed archived session header ID. |
+| `role` | `"all" \| "user" \| "assistant" \| "tool" \| "summary"` | No | Restrict matches by persisted entry role. Defaults to `all`. |
+| `case` | `boolean` | No | Enable case-sensitive matching. Defaults to `false`. |
+| `limit` | `number` | No | Matches returned per page. Integer from 1 through 100; default 20. |
+| `offset` | `number` | No | Matches skipped from the stable result order. Integer from 0 through 10,000; default 0. |
+
+## Outputs
+
+The tool returns one text block in `content[0].text` and structured `details`.
+
+Text output:
+- Groups matches under `history://session/<session-id>` headings.
+- Shows the persisted role, timestamp, entry ID, and a bounded single-line snippet for each match.
+- Prints `nextOffset` guidance when another page exists.
+- Reports scanned and unreadable session counts.
+
+`details` contains:
+- normalized `query`, `scope`, `role`, `offset`, and `limit`;
+- `matches`, each with `sessionId`, title, project label, modified timestamp, entry ID, entry timestamp, role, and snippet;
+- `hasMore` and optional `nextOffset`;
+- `scannedSessions` and `unreadableSessions`.
+
+## Flow
+1. `SessionSearchTool.execute()` validates integer bounds and applies defaults.
+2. `listArchivedSessions()` calls the canonical global session listing, deduplicates physical transcript paths, and applies current-project scope unless `scope: "all"` was requested.
+3. A `session` selector resolves only against transcript header IDs. Exact matches win; prefixes must identify one session. Filesystem paths are rejected.
+4. The query is escaped and compiled as a literal Unicode regular expression.
+5. Each selected JSONL transcript is streamed line by line. Search reads persisted entries directly rather than the compacted model-context view, so pre-compaction turns remain searchable.
+6. Searchable surfaces include user and assistant text, tool calls/results, shell and Python execution text, file mentions, visible custom messages, compaction summaries, and branch summaries.
+7. Sessions are ordered newest-first. Matches within each transcript are ordered newest-first. Pagination applies to that stable combined order.
+8. Bounded per-file buffers and early termination prevent result collection from growing with archive size.
+
+## Role Mapping
+- `user`: user messages, shell executions, Python executions, and file mentions.
+- `assistant`: assistant messages, including tool-call names and serialized arguments.
+- `tool`: tool-result messages.
+- `summary`: compaction and branch-summary entries.
+- `all`: every role above plus other visible persisted message kinds.
+
+## Side Effects
+- Read-only. No session file, registry entry, lock, or active conversation state is changed.
+- Cancellation propagates through `untilAborted(...)` and the transcript stream readers.
+
+## Limits & Ordering
+- Query length: 500 characters.
+- Page size: 1–100 matches; default 20.
+- Offset: 0–10,000.
+- Snippets retain at most 180 characters of context on either side of the first match, then the renderer truncates to 420 terminal columns.
+- Search covers persisted bytes only. A live turn not yet flushed to its JSONL transcript cannot appear.
+- Unreadable transcripts are skipped and counted; an aborted read is rethrown rather than counted.
+
+## Errors
+- Empty or overlong queries are rejected.
+- Non-integer or out-of-range `limit` and `offset` values are rejected.
+- Unknown session IDs report that no archived session matched.
+- Ambiguous exact IDs or prefixes report bounded candidate descriptions.
+- Direct `.jsonl` and path-shaped selectors are rejected; discover sessions through `history://session` first.
+
+## Related URLs
+- `history://session` lists current-project archived sessions with bounded metadata filtering and pagination.
+- `history://session?scope=all` lists archives across projects.
+- `history://session/<id>` renders one exact or uniquely prefixed session transcript.
+- `history://agent/<id>` reads an agent transcript and is intentionally separate from the archived-session namespace.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added server-name autocomplete for `/mcp` commands (`enable`, `disable`, `test`, `remove`, `reconnect`, `reauth`, `unauth`) using configured and runtime-discovered MCP servers.
 - Added `--from-claude` and `--from-codex` session imports, also available from `/resume @claude` and `/resume @codex`.
+- Added bounded `history://session` archive browsing and a `session_search` tool for persisted transcript content, including pre-compaction turns.
 
 ### Changed
 
@@ -32,7 +33,6 @@
 - Fixed redundant `xd://` mount notices and prompt-cache invalidation when resuming sessions or reconnecting devices.
 - Fixed the model picker displaying placeholder model lists instead of the actual credential-aware catalog resolved at registration.
 - Fixed file corruption and snapshot mismatches when writing files through the ACP client bridge by verifying the final on-disk content after client-side post-save formatting.
-- Fixed `omp ttsr test` silently evaluating source files as prose when their extensions were missing from the allowlist, and expanded the allowlist to support .NET, Shell, SQL, Zig, Dart, Scala, Elixir, and Protobuf files.
 - Fixed automatic light/dark theme switching in direct WezTerm sessions on macOS when DEC Mode 2031 is unsupported, and improved theme-change color responsiveness.
 
 ## [17.1.8] - 2026-07-28

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -417,6 +417,9 @@
 - Fixed `/retry` reporting "Nothing to retry" after a stream stalled or aborted mid-tool-call.
 - Fixed locally consumed extension commands triggering automatic title generation and exposing their command text to the title model.
 
+### Added
+
+- Added support for top-level sessions to the `history://` protocol, allowing `history://<sessionId>` (by full UUID or prefix), `history://<path>`, and the `history://` index to discover and view top-level session transcripts.
 ## [17.0.7] - 2026-07-21
 
 ### Fixed

--- a/packages/coding-agent/src/internal-urls/history-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/history-protocol.ts
@@ -16,12 +16,15 @@
  * - history:// - Index of all registry + on-disk agents (id, status, kind, last activity)
  * - history://<agentId> - Concise markdown transcript of that agent
  */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import type { AgentRef } from "../registry/agent-registry";
 import { AgentRegistry } from "../registry/agent-registry";
 import { formatSessionHistoryMarkdown } from "../session/session-history-format";
+import { resolveResumableSession } from "../session/session-listing";
 import { loadSessionMessagesReadOnly } from "../session/session-loader";
 import { sessionFilesFromDisk } from "./registry-helpers";
-import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
+import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, UrlCompletion } from "./types";
 
 /** Humanize a last-activity timestamp as `Ns/Nm/Nh/Nd ago`. */
 function formatAgo(timestamp: number): string {
@@ -55,8 +58,16 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 	readonly scheme = "history";
 	readonly immutable = false;
 
-	async resolve(url: InternalUrl): Promise<InternalResource> {
-		const agentId = url.rawHost || url.hostname;
+	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
+		const host = url.rawHost || url.hostname;
+		const rawPathname = url.rawPathname || "";
+		let agentId = "";
+		if (rawPathname.startsWith("/")) {
+			agentId = host ? `${host}${rawPathname}` : rawPathname;
+		} else {
+			agentId = host ? (rawPathname ? `${host}/${rawPathname}` : host) : rawPathname;
+		}
+		agentId = agentId.trim();
 		const registry = AgentRegistry.global();
 		// Advisor transcripts are observability-only — surfaced in the Agent Hub, never
 		// in the agent-facing roster. Hide them from the index, lookup, and completions.
@@ -83,7 +94,7 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 		if (!ref) {
 			// Registry miss — the agent may have been unregistered or lost on resume.
 			// Serve its transcript straight from disk if the session file persists.
-			const disk = await this.#resolveFromDisk(agentId);
+			const disk = await this.#resolveFromDisk(agentId, context);
 			if (disk) return { ...disk, url: url.href };
 
 			const known = visible.map(candidate => candidate.id);
@@ -102,7 +113,7 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 		} else {
 			// No live session and no retained sessionFile — try the disk scan before
 			// giving up, in case the transcript lingers under an artifacts dir.
-			const disk = await this.#resolveFromDisk(ref.id);
+			const disk = await this.#resolveFromDisk(ref.id, context);
 			if (disk) return { ...disk, url: url.href };
 			throw new Error(`Agent ${ref.id} has no transcript: session is gone and no session file was retained`);
 		}
@@ -119,14 +130,17 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 	}
 
 	/**
-	 * Load a transcript for `agentId` from an on-disk `.jsonl` session file,
-	 * matched case-insensitively. Returns `undefined` when no file is found.
+	 * Load a transcript for `agentId` from an on-disk `.jsonl` session file.
+	 * Matches exact, case-insensitive, prefix, resumable session lookup, or direct path.
+	 * Returns `undefined` when no file is found.
 	 */
-	async #resolveFromDisk(agentId: string): Promise<InternalResource | undefined> {
+	async #resolveFromDisk(agentId: string, context?: ResolveContext): Promise<InternalResource | undefined> {
 		const files = await sessionFilesFromDisk();
 		const lower = agentId.toLowerCase();
 		let matchedId: string | undefined;
 		let sessionFile: string | undefined;
+
+		// 1. Exact or case-insensitive match in sessionFilesFromDisk()
 		for (const [id, file] of files) {
 			if (id === agentId || id.toLowerCase() === lower) {
 				matchedId = id;
@@ -134,6 +148,44 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 				if (id === agentId) break;
 			}
 		}
+
+		// 2. Case-insensitive prefix match in sessionFilesFromDisk()
+		if (!sessionFile) {
+			for (const [id, file] of files) {
+				if (id.toLowerCase().startsWith(lower)) {
+					matchedId = id;
+					sessionFile = file;
+					break;
+				}
+			}
+		}
+
+		// 3. Fallback to resolveResumableSession
+		if (!sessionFile) {
+			const cwd = context?.cwd ?? process.cwd();
+			const match = await resolveResumableSession(agentId, cwd, undefined, undefined, {
+				allowGlobalFallback: true,
+			});
+			if (match) {
+				matchedId = match.session.id;
+				sessionFile = match.session.path;
+			}
+		}
+
+		// 4. Direct file path check
+		if (!sessionFile && (agentId.endsWith(".jsonl") || agentId.includes("/") || agentId.includes("\\"))) {
+			const resolvedPath = path.resolve(context?.cwd ?? process.cwd(), agentId);
+			try {
+				const stat = await fs.stat(resolvedPath);
+				if (stat.isFile()) {
+					matchedId = path.basename(resolvedPath, ".jsonl");
+					sessionFile = resolvedPath;
+				}
+			} catch {
+				// Not a file
+			}
+		}
+
 		if (!matchedId || !sessionFile) return undefined;
 		const messages = await loadSessionMessagesReadOnly(sessionFile);
 		const content = formatSessionHistoryMarkdown(messages, { title: `${matchedId} (on disk)` });
@@ -155,11 +207,23 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 			parent: ref.parentId ?? "—",
 			lastActivity: formatAgo(ref.lastActivity),
 		}));
-		// Merge on-disk transcripts for agents absent from the registry.
-		const registered = new Set(refs.map(ref => ref.id));
+
+		const registeredIds = new Set(refs.map(ref => ref.id));
+		const registeredFiles = new Set(refs.map(ref => ref.sessionFile).filter((f): f is string => Boolean(f)));
 		const disk = await sessionFilesFromDisk();
-		for (const id of disk.keys()) {
-			if (registered.has(id)) continue;
+
+		// Deduplicate disk entries by session file path
+		const fileToId = new Map<string, string>();
+		for (const [id, file] of disk) {
+			if (registeredFiles.has(file)) continue;
+			const existing = fileToId.get(file);
+			if (!existing || (id.length < existing.length && !id.includes("T"))) {
+				fileToId.set(file, id);
+			}
+		}
+
+		for (const [, id] of fileToId) {
+			if (registeredIds.has(id)) continue;
 			entries.push({ id, status: "on disk", kind: "—", parent: "—", lastActivity: "—" });
 		}
 
@@ -178,19 +242,32 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 
 	async complete(): Promise<UrlCompletion[]> {
 		const completions: UrlCompletion[] = [];
-		const seen = new Set<string>();
+		const seenIds = new Set<string>();
+		const seenFiles = new Set<string>();
+
 		for (const ref of AgentRegistry.global().list()) {
 			if (ref.kind === "advisor") continue;
-			seen.add(ref.id);
+			seenIds.add(ref.id);
+			if (ref.sessionFile) seenFiles.add(ref.sessionFile);
 			completions.push({
 				value: ref.id,
 				description: `${ref.status} · ${ref.kind}${ref.parentId ? ` · parent ${ref.parentId}` : ""}`,
 			});
 		}
+
 		const disk = await sessionFilesFromDisk();
-		for (const id of disk.keys()) {
-			if (seen.has(id)) continue;
-			seen.add(id);
+		const fileToId = new Map<string, string>();
+		for (const [id, file] of disk) {
+			if (seenFiles.has(file)) continue;
+			const existing = fileToId.get(file);
+			if (!existing || (id.length < existing.length && !id.includes("T"))) {
+				fileToId.set(file, id);
+			}
+		}
+
+		for (const [, id] of fileToId) {
+			if (seenIds.has(id)) continue;
+			seenIds.add(id);
 			completions.push({ value: id, description: "on disk" });
 		}
 		return completions;

--- a/packages/coding-agent/src/internal-urls/history-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/history-protocol.ts
@@ -13,15 +13,25 @@
  * mirroring how `agent://` reads `.md` outputs straight off disk.
  *
  * URL forms:
- * - history:// - Index of all registry + on-disk agents (id, status, kind, last activity)
- * - history://<agentId> - Concise markdown transcript of that agent
+ * - history:// - Index of registered and persisted agents
+ * - history://<agentId> - Legacy agent transcript lookup
+ * - history://agent/<agentId> - Explicit agent transcript lookup
+ * - history://session - Bounded current-project archived session index
+ * - history://session/<sessionId> - Archived top-level session by exact ID or unique prefix
  */
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
 import type { AgentRef } from "../registry/agent-registry";
 import { AgentRegistry } from "../registry/agent-registry";
+import {
+	listArchivedSessions,
+	resolveArchivedSessionSelector,
+	SESSION_ARCHIVE_DEFAULT_LIMIT,
+	SESSION_ARCHIVE_MAX_LIMIT,
+	SESSION_ARCHIVE_MAX_OFFSET,
+	type SessionArchiveScope,
+	sessionProjectLabel,
+} from "../session/session-archive";
 import { formatSessionHistoryMarkdown } from "../session/session-history-format";
-import { resolveResumableSession } from "../session/session-listing";
+import type { SessionInfo } from "../session/session-listing";
 import { loadSessionMessagesReadOnly } from "../session/session-loader";
 import { sessionFilesFromDisk } from "./registry-helpers";
 import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, UrlCompletion } from "./types";
@@ -54,52 +64,119 @@ interface IndexEntry {
  * on-disk `.jsonl` transcripts, serving read-only history for live, parked,
  * and unregistered agents alike.
  */
+type HistoryRoute =
+	| { kind: "agent-index" }
+	| { kind: "agent"; id: string }
+	| { kind: "session-index" }
+	| { kind: "session"; id: string };
+
+function decodeSegment(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		throw new Error(`Invalid history:// identifier encoding: ${value}`);
+	}
+}
+
+function parseHistoryRoute(url: InternalUrl): HistoryRoute {
+	const host = (url.rawHost || url.hostname).trim();
+	const pathname = (url.rawPathname ?? url.pathname).replace(/^\/+/, "").trim();
+	if (!host) {
+		if (!pathname) return { kind: "agent-index" };
+		throw new Error(
+			"Direct transcript paths are not supported. Use history://session/<session-id> or session_search.",
+		);
+	}
+
+	const namespace = host.toLowerCase();
+	if (namespace === "agent") {
+		if (!pathname) return { kind: "agent-index" };
+		if (pathname.includes("/")) throw new Error("history://agent accepts one agent ID.");
+		return { kind: "agent", id: decodeSegment(pathname) };
+	}
+	if (namespace === "session") {
+		if (!pathname) return { kind: "session-index" };
+		if (pathname.includes("/")) {
+			throw new Error("history://session accepts one session ID, not a filesystem path.");
+		}
+		return { kind: "session", id: decodeSegment(pathname) };
+	}
+	if (pathname) {
+		throw new Error(
+			"Direct transcript paths are not supported. Use history://session/<session-id> or history://agent/<agent-id>.",
+		);
+	}
+	return { kind: "agent", id: decodeSegment(host) };
+}
+
+function parseListInteger(
+	url: InternalUrl,
+	name: "limit" | "offset",
+	fallback: number,
+	minimum: number,
+	maximum: number,
+): number {
+	const raw = url.searchParams.get(name);
+	if (raw === null) return fallback;
+	if (!/^\d+$/.test(raw)) {
+		throw new Error(`Invalid history://session ${name} '${raw}'. Expected an integer ${minimum}–${maximum}.`);
+	}
+	const value = Number(raw);
+	if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+		throw new Error(`Invalid history://session ${name} '${raw}'. Expected an integer ${minimum}–${maximum}.`);
+	}
+	return value;
+}
+
+function sanitizeTableCell(value: string, width: number): string {
+	const normalized = value.replaceAll("\t", " ").replace(/\s+/g, " ").trim().replaceAll("|", "\\|");
+	return Bun.wrapAnsi(normalized, width, { hard: true, trim: true }).split("\n", 1)[0] ?? "";
+}
+
+/**
+ * Handler for history:// URLs.
+ *
+ * Agent transcripts retain the legacy bare-id surface. Archived top-level
+ * sessions live under an explicit namespace so agent/session collisions have
+ * deterministic semantics and archive enumeration stays bounded.
+ */
 export class HistoryProtocolHandler implements ProtocolHandler {
 	readonly scheme = "history";
-	readonly immutable = false;
+	readonly immutable = true;
 
 	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
-		const host = url.rawHost || url.hostname;
-		const rawPathname = url.rawPathname || "";
-		let agentId = "";
-		if (rawPathname.startsWith("/")) {
-			agentId = host ? `${host}${rawPathname}` : rawPathname;
-		} else {
-			agentId = host ? (rawPathname ? `${host}/${rawPathname}` : host) : rawPathname;
-		}
-		agentId = agentId.trim();
+		const route = parseHistoryRoute(url);
 		const registry = AgentRegistry.global();
-		// Advisor transcripts are observability-only — surfaced in the Agent Hub, never
-		// in the agent-facing roster. Hide them from the index, lookup, and completions.
 		const visible = registry.list().filter(ref => ref.kind !== "advisor");
 
-		if (!agentId) {
-			const content = await this.#renderIndex(visible);
-			return {
-				url: url.href,
-				content,
-				contentType: "text/markdown",
-				size: Buffer.byteLength(content, "utf-8"),
-			};
+		switch (route.kind) {
+			case "agent-index":
+				return this.#resource(url.href, await this.#renderAgentIndex(visible));
+			case "agent":
+				return await this.#resolveAgent(url.href, route.id, visible);
+			case "session-index":
+				return await this.#resolveSessionIndex(url, context);
+			case "session":
+				return await this.#resolveSession(url.href, route.id, context);
 		}
+	}
 
+	async #resolveAgent(url: string, agentId: string, visible: AgentRef[]): Promise<InternalResource> {
+		const registry = AgentRegistry.global();
 		let ref = registry.get(agentId);
 		if (ref?.kind === "advisor") ref = undefined;
 		if (!ref) {
-			// Case-insensitive fallback: agent ids are human-typed (e.g. AuthLoader).
 			const lower = agentId.toLowerCase();
 			ref = visible.find(candidate => candidate.id.toLowerCase() === lower);
 		}
 
 		if (!ref) {
-			// Registry miss — the agent may have been unregistered or lost on resume.
-			// Serve its transcript straight from disk if the session file persists.
-			const disk = await this.#resolveFromDisk(agentId, context);
-			if (disk) return { ...disk, url: url.href };
-
+			const disk = await this.#resolveAgentFromDisk(agentId);
+			if (disk) return { ...disk, url };
 			const known = visible.map(candidate => candidate.id);
-			const knownStr = known.length > 0 ? known.join(", ") : "none";
-			throw new Error(`Unknown agent: ${agentId}\nKnown agents: ${knownStr}\nList all with history://`);
+			throw new Error(
+				`Unknown agent: ${agentId}\nKnown agents: ${known.length > 0 ? known.join(", ") : "none"}\nList agents with history://`,
+			);
 		}
 
 		const notes: string[] = [];
@@ -111,16 +188,14 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 			messages = await loadSessionMessagesReadOnly(ref.sessionFile);
 			notes.push(`Source: session file (read-only, ${ref.status})`);
 		} else {
-			// No live session and no retained sessionFile — try the disk scan before
-			// giving up, in case the transcript lingers under an artifacts dir.
-			const disk = await this.#resolveFromDisk(ref.id, context);
-			if (disk) return { ...disk, url: url.href };
+			const disk = await this.#resolveAgentFromDisk(ref.id);
+			if (disk) return { ...disk, url };
 			throw new Error(`Agent ${ref.id} has no transcript: session is gone and no session file was retained`);
 		}
 
 		const content = formatSessionHistoryMarkdown(messages, { title: `${ref.id} (${ref.status})` });
 		return {
-			url: url.href,
+			url,
 			content,
 			contentType: "text/markdown",
 			size: Buffer.byteLength(content, "utf-8"),
@@ -129,77 +204,74 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 		};
 	}
 
-	/**
-	 * Load a transcript for `agentId` from an on-disk `.jsonl` session file.
-	 * Matches exact, case-insensitive, prefix, resumable session lookup, or direct path.
-	 * Returns `undefined` when no file is found.
-	 */
-	async #resolveFromDisk(agentId: string, context?: ResolveContext): Promise<InternalResource | undefined> {
-		const files = await sessionFilesFromDisk();
+	async #resolveAgentFromDisk(agentId: string): Promise<InternalResource | undefined> {
 		const lower = agentId.toLowerCase();
-		let matchedId: string | undefined;
-		let sessionFile: string | undefined;
-
-		// 1. Exact or case-insensitive match in sessionFilesFromDisk()
-		for (const [id, file] of files) {
-			if (id === agentId || id.toLowerCase() === lower) {
-				matchedId = id;
-				sessionFile = file;
-				if (id === agentId) break;
-			}
+		for (const [id, sessionFile] of await sessionFilesFromDisk()) {
+			if (id !== agentId && id.toLowerCase() !== lower) continue;
+			const messages = await loadSessionMessagesReadOnly(sessionFile);
+			const content = formatSessionHistoryMarkdown(messages, { title: `${id} (on disk)` });
+			return {
+				url: "",
+				content,
+				contentType: "text/markdown",
+				size: Buffer.byteLength(content, "utf-8"),
+				sourcePath: sessionFile,
+				notes: ["Source: session file (read-only, unregistered)"],
+			};
 		}
+		return undefined;
+	}
 
-		// 2. Case-insensitive prefix match in sessionFilesFromDisk()
-		if (!sessionFile) {
-			for (const [id, file] of files) {
-				if (id.toLowerCase().startsWith(lower)) {
-					matchedId = id;
-					sessionFile = file;
-					break;
-				}
-			}
-		}
-
-		// 3. Fallback to resolveResumableSession
-		if (!sessionFile) {
-			const cwd = context?.cwd ?? process.cwd();
-			const match = await resolveResumableSession(agentId, cwd, undefined, undefined, {
-				allowGlobalFallback: true,
-			});
-			if (match) {
-				matchedId = match.session.id;
-				sessionFile = match.session.path;
-			}
-		}
-
-		// 4. Direct file path check
-		if (!sessionFile && (agentId.endsWith(".jsonl") || agentId.includes("/") || agentId.includes("\\"))) {
-			const resolvedPath = path.resolve(context?.cwd ?? process.cwd(), agentId);
-			try {
-				const stat = await fs.stat(resolvedPath);
-				if (stat.isFile()) {
-					matchedId = path.basename(resolvedPath, ".jsonl");
-					sessionFile = resolvedPath;
-				}
-			} catch {
-				// Not a file
-			}
-		}
-
-		if (!matchedId || !sessionFile) return undefined;
-		const messages = await loadSessionMessagesReadOnly(sessionFile);
-		const content = formatSessionHistoryMarkdown(messages, { title: `${matchedId} (on disk)` });
+	async #resolveSession(url: string, sessionId: string, context?: ResolveContext): Promise<InternalResource> {
+		const sessions = await listArchivedSessions({ cwd: context?.cwd ?? process.cwd(), scope: "all" });
+		const session = resolveArchivedSessionSelector(sessions, sessionId);
+		const messages = await loadSessionMessagesReadOnly(session.path);
+		const content = formatSessionHistoryMarkdown(messages, { title: `${session.id} (archived session)` });
 		return {
-			url: "",
+			url,
 			content,
 			contentType: "text/markdown",
 			size: Buffer.byteLength(content, "utf-8"),
-			sourcePath: sessionFile,
-			notes: ["Source: session file (read-only, unregistered)"],
+			sourcePath: session.path,
+			notes: ["Source: archived top-level session file (read-only)"],
 		};
 	}
 
-	async #renderIndex(refs: AgentRef[]): Promise<string> {
+	async #resolveSessionIndex(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
+		const allowedParams: Record<string, true> = { scope: true, q: true, limit: true, offset: true };
+		for (const key of url.searchParams.keys()) {
+			if (!(key in allowedParams)) {
+				throw new Error(`Unknown history://session parameter '${key}'. Use scope, q, limit, or offset.`);
+			}
+		}
+		const scopeRaw = url.searchParams.get("scope") ?? "project";
+		if (scopeRaw !== "project" && scopeRaw !== "all") {
+			throw new Error(`Invalid history://session scope '${scopeRaw}'. Expected project or all.`);
+		}
+		const scope: SessionArchiveScope = scopeRaw;
+		const query = url.searchParams.get("q")?.trim() ?? "";
+		if (query.length > 200) throw new Error("history://session q must not exceed 200 characters.");
+		const limit = parseListInteger(url, "limit", SESSION_ARCHIVE_DEFAULT_LIMIT, 1, SESSION_ARCHIVE_MAX_LIMIT);
+		const offset = parseListInteger(url, "offset", 0, 0, SESSION_ARCHIVE_MAX_OFFSET);
+		const sessions = await listArchivedSessions({
+			cwd: context?.cwd ?? process.cwd(),
+			scope,
+			query,
+		});
+		const page = sessions.slice(offset, offset + limit);
+		return this.#resource(url.href, this.#renderSessionIndex(page, sessions.length, { scope, query, limit, offset }));
+	}
+
+	#resource(url: string, content: string): InternalResource {
+		return {
+			url,
+			content,
+			contentType: "text/markdown",
+			size: Buffer.byteLength(content, "utf-8"),
+		};
+	}
+
+	async #renderAgentIndex(refs: AgentRef[]): Promise<string> {
 		const entries: IndexEntry[] = refs.map(ref => ({
 			id: ref.id,
 			status: ref.status,
@@ -207,68 +279,94 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 			parent: ref.parentId ?? "—",
 			lastActivity: formatAgo(ref.lastActivity),
 		}));
-
-		const registeredIds = new Set(refs.map(ref => ref.id));
-		const registeredFiles = new Set(refs.map(ref => ref.sessionFile).filter((f): f is string => Boolean(f)));
-		const disk = await sessionFilesFromDisk();
-
-		// Deduplicate disk entries by session file path
-		const fileToId = new Map<string, string>();
-		for (const [id, file] of disk) {
-			if (registeredFiles.has(file)) continue;
-			const existing = fileToId.get(file);
-			if (!existing || (id.length < existing.length && !id.includes("T"))) {
-				fileToId.set(file, id);
-			}
-		}
-
-		for (const [, id] of fileToId) {
-			if (registeredIds.has(id)) continue;
+		const registered = new Set(refs.map(ref => ref.id));
+		for (const id of (await sessionFilesFromDisk()).keys()) {
+			if (registered.has(id)) continue;
 			entries.push({ id, status: "on disk", kind: "—", parent: "—", lastActivity: "—" });
 		}
 
-		const lines: string[] = ["# Agents", ""];
+		const lines = ["# Agents", ""];
 		if (entries.length === 0) {
 			lines.push("No agents registered.");
-			return `${lines.join("\n")}\n`;
+		} else {
+			lines.push("| id | status | kind | parent | last activity |", "|---|---|---|---|---|");
+			for (const entry of entries) {
+				lines.push(`| ${entry.id} | ${entry.status} | ${entry.kind} | ${entry.parent} | ${entry.lastActivity} |`);
+			}
 		}
-		lines.push("| id | status | kind | parent | last activity |", "|---|---|---|---|---|");
-		for (const entry of entries) {
-			lines.push(`| ${entry.id} | ${entry.status} | ${entry.kind} | ${entry.parent} | ${entry.lastActivity} |`);
-		}
-		lines.push("", "Read a transcript with `read history://<id>`.");
+		lines.push(
+			"",
+			"Read an agent with `history://agent/<id>` (legacy `history://<id>` also works).",
+			"List archived top-level sessions with `history://session`.",
+		);
 		return `${lines.join("\n")}\n`;
 	}
 
-	async complete(): Promise<UrlCompletion[]> {
-		const completions: UrlCompletion[] = [];
-		const seenIds = new Set<string>();
-		const seenFiles = new Set<string>();
-
-		for (const ref of AgentRegistry.global().list()) {
-			if (ref.kind === "advisor") continue;
-			seenIds.add(ref.id);
-			if (ref.sessionFile) seenFiles.add(ref.sessionFile);
-			completions.push({
-				value: ref.id,
-				description: `${ref.status} · ${ref.kind}${ref.parentId ? ` · parent ${ref.parentId}` : ""}`,
-			});
-		}
-
-		const disk = await sessionFilesFromDisk();
-		const fileToId = new Map<string, string>();
-		for (const [id, file] of disk) {
-			if (seenFiles.has(file)) continue;
-			const existing = fileToId.get(file);
-			if (!existing || (id.length < existing.length && !id.includes("T"))) {
-				fileToId.set(file, id);
+	#renderSessionIndex(
+		sessions: readonly SessionInfo[],
+		total: number,
+		options: { scope: SessionArchiveScope; query: string; limit: number; offset: number },
+	): string {
+		const start = total === 0 ? 0 : options.offset + 1;
+		const end = Math.min(total, options.offset + sessions.length);
+		const lines = [
+			"# Archived Sessions",
+			"",
+			`Scope: ${options.scope} · Showing ${start}–${end} of ${total}${options.query ? ` · Filter: ${sanitizeTableCell(options.query, 80)}` : ""}`,
+			"",
+		];
+		if (sessions.length === 0) {
+			lines.push("_No matching sessions._");
+		} else {
+			lines.push("| session | modified | project | status | title |", "|---|---|---|---|---|");
+			for (const session of sessions) {
+				lines.push(
+					`| [${session.id}](history://session/${session.id}) | ${session.modified.toISOString()} | ${sanitizeTableCell(sessionProjectLabel(session), 40)} | ${session.status ?? "unknown"} | ${sanitizeTableCell(session.title ?? session.firstMessage, 100)} |`,
+				);
 			}
 		}
 
-		for (const [, id] of fileToId) {
-			if (seenIds.has(id)) continue;
-			seenIds.add(id);
-			completions.push({ value: id, description: "on disk" });
+		const nextOffset = options.offset + sessions.length;
+		if (nextOffset < total) {
+			const params = new URLSearchParams({
+				scope: options.scope,
+				limit: String(options.limit),
+				offset: String(nextOffset),
+			});
+			if (options.query) params.set("q", options.query);
+			lines.push("", `Next page: \`history://session?${params.toString()}\``);
+		}
+		lines.push(
+			"",
+			"Read one with `history://session/<full-id-or-unique-prefix>`.",
+			"Search transcript contents with `session_search`.",
+		);
+		return `${lines.join("\n")}\n`;
+	}
+
+	async complete(query = ""): Promise<UrlCompletion[]> {
+		const completions: UrlCompletion[] = [
+			{ value: "agent/", description: "explicit agent transcript namespace" },
+			{ value: "session/", description: "archived top-level session namespace" },
+		];
+		const seen = new Set<string>(["agent/", "session/"]);
+		for (const ref of AgentRegistry.global().list()) {
+			if (ref.kind === "advisor") continue;
+			const value = ref.id === "agent" || ref.id === "session" ? `agent/${ref.id}` : ref.id;
+			if (seen.has(value)) continue;
+			seen.add(value);
+			completions.push({
+				value,
+				description: `${ref.status} · ${ref.kind}${ref.parentId ? ` · parent ${ref.parentId}` : ""}`,
+			});
+		}
+		if (!query.startsWith("session/")) {
+			for (const id of (await sessionFilesFromDisk()).keys()) {
+				const value = id === "agent" || id === "session" ? `agent/${id}` : id;
+				if (seen.has(value)) continue;
+				seen.add(value);
+				completions.push({ value, description: "on disk agent" });
+			}
 		}
 		return completions;
 	}

--- a/packages/coding-agent/src/internal-urls/registry-helpers.ts
+++ b/packages/coding-agent/src/internal-urls/registry-helpers.ts
@@ -41,10 +41,7 @@ export function artifactsDirsFromRegistry(): string[] {
 	};
 	for (const ref of AgentRegistry.global().list()) {
 		addDir(ref.session?.sessionManager?.getArtifactsDir());
-		if (ref.sessionFile) {
-			addDir(ref.sessionFile.slice(0, -6));
-			addDir(path.dirname(ref.sessionFile));
-		}
+		if (ref.sessionFile) addDir(ref.sessionFile.slice(0, -6));
 	}
 	for (const dir of extraArtifactsDirs) addDir(dir);
 	return dirs;
@@ -87,16 +84,7 @@ export async function sessionFilesFromDisk(): Promise<Map<string, string>> {
 			if (!name.endsWith(".jsonl")) continue;
 			if (name.startsWith("__advisor")) continue;
 			const id = name.slice(0, -".jsonl".length);
-			const fullPath = path.join(dir, name);
-			if (!found.has(id)) found.set(id, fullPath);
-
-			const sep = name.lastIndexOf("_");
-			if (sep >= 0) {
-				const sessionId = name.slice(sep + 1, -".jsonl".length);
-				if (sessionId && !found.has(sessionId)) {
-					found.set(sessionId, fullPath);
-				}
-			}
+			if (!found.has(id)) found.set(id, path.join(dir, name));
 		}
 	};
 	for (const dir of artifactsDirsFromRegistry()) await scan(dir, 0);

--- a/packages/coding-agent/src/internal-urls/registry-helpers.ts
+++ b/packages/coding-agent/src/internal-urls/registry-helpers.ts
@@ -41,7 +41,10 @@ export function artifactsDirsFromRegistry(): string[] {
 	};
 	for (const ref of AgentRegistry.global().list()) {
 		addDir(ref.session?.sessionManager?.getArtifactsDir());
-		if (ref.sessionFile) addDir(ref.sessionFile.slice(0, -6));
+		if (ref.sessionFile) {
+			addDir(ref.sessionFile.slice(0, -6));
+			addDir(path.dirname(ref.sessionFile));
+		}
 	}
 	for (const dir of extraArtifactsDirs) addDir(dir);
 	return dirs;
@@ -84,7 +87,16 @@ export async function sessionFilesFromDisk(): Promise<Map<string, string>> {
 			if (!name.endsWith(".jsonl")) continue;
 			if (name.startsWith("__advisor")) continue;
 			const id = name.slice(0, -".jsonl".length);
-			if (!found.has(id)) found.set(id, path.join(dir, name));
+			const fullPath = path.join(dir, name);
+			if (!found.has(id)) found.set(id, fullPath);
+
+			const sep = name.lastIndexOf("_");
+			if (sep >= 0) {
+				const sessionId = name.slice(sep + 1, -".jsonl".length);
+				if (sessionId && !found.has(sessionId)) {
+					found.set(sessionId, fullPath);
+				}
+			}
 		}
 	};
 	for (const dir of artifactsDirsFromRegistry()) await scan(dir, 0);

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -57,7 +57,7 @@ Special URLs for internal resources; with most FS/bash tools they auto-resolve t
 - `memory://root`: project memory summary
   {{/if}}
 - `agent://<id>`: agent output artifact; `/<child>` reads a nested subagent's output, else `/<path>` extracts a JSON field
-- `history://<id>`: read-only markdown transcript of an agent (live, parked, or released); bare `history://` lists all agents. Serves registered agents process-wide plus persisted subagents discoverable from their artifact trees; does not discover unregistered top-level sessions solely from their persisted session files.
+- `history://<id>`: read-only markdown transcript of an agent or session (live, parked, or on-disk); bare `history://` lists all agents and sessions.
 - `artifact://<id>`: artifact content
 - `local://<name>.md`: plan artifacts or shared content for subagents
 {{#if hasObsidian}}

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -57,7 +57,7 @@ Special URLs for internal resources; with most FS/bash tools they auto-resolve t
 - `memory://root`: project memory summary
   {{/if}}
 - `agent://<id>`: agent output artifact; `/<child>` reads a nested subagent's output, else `/<path>` extracts a JSON field
-- `history://<id>`: read-only markdown transcript of an agent or session (live, parked, or on-disk); bare `history://` lists all agents and sessions.
+- `history://<agent-id>`: read-only agent transcript; `history://agent/<agent-id>` is explicit. `history://session` lists archived current-project sessions (`?scope=all&q=&limit=&offset=`); `history://session/<id>` reads an exact or unique-prefix session ID.
 - `artifact://<id>`: artifact content
 - `local://<name>.md`: plan artifacts or shared content for subagents
 {{#if hasObsidian}}

--- a/packages/coding-agent/src/prompts/tools/session-search.md
+++ b/packages/coding-agent/src/prompts/tools/session-search.md
@@ -1,0 +1,14 @@
+Search persisted OMP session transcripts, including pre-compaction content.
+
+<instruction>
+- `scope` defaults to the current project; use `all` for cross-project history.
+- `session` narrows to one exact or uniquely prefixed session ID.
+- `role` filters persisted user, assistant, tool, or summary entries.
+- Results are newest-first. Continue with the returned `offset`.
+</instruction>
+
+<critical>
+- Use this for transcript contents; `history://session` only filters metadata.
+- Read a matched transcript with `history://session/<id>`.
+- Search covers persisted content only; an unflushed live turn is absent.
+</critical>

--- a/packages/coding-agent/src/session/session-archive.ts
+++ b/packages/coding-agent/src/session/session-archive.ts
@@ -1,0 +1,334 @@
+import * as path from "node:path";
+import { readLines } from "@oh-my-pi/pi-utils";
+import { listAllSessions, type SessionInfo } from "./session-listing";
+
+export const SESSION_ARCHIVE_DEFAULT_LIMIT = 20;
+export const SESSION_ARCHIVE_MAX_LIMIT = 100;
+export const SESSION_ARCHIVE_MAX_OFFSET = 10_000;
+
+export type SessionArchiveScope = "project" | "all";
+export type SessionSearchRole = "all" | "user" | "assistant" | "tool" | "summary";
+
+export interface SessionArchiveOptions {
+	cwd: string;
+	scope?: SessionArchiveScope;
+	query?: string;
+}
+
+export interface SessionTranscriptSearchOptions extends SessionArchiveOptions {
+	query: string;
+	session?: string;
+	role?: SessionSearchRole;
+	caseSensitive?: boolean;
+	limit?: number;
+	offset?: number;
+	signal?: AbortSignal;
+}
+
+export interface SessionTranscriptMatch {
+	sessionId: string;
+	title: string;
+	project: string;
+	modified: string;
+	entryId: string;
+	timestamp: string;
+	role: Exclude<SessionSearchRole, "all"> | "other";
+	snippet: string;
+}
+
+export interface SessionTranscriptSearchResult {
+	matches: SessionTranscriptMatch[];
+	hasMore: boolean;
+	nextOffset?: number;
+	scannedSessions: number;
+	unreadableSessions: number;
+}
+
+function sameProject(sessionCwd: string, cwd: string): boolean {
+	if (!sessionCwd) return false;
+	return path.resolve(sessionCwd) === path.resolve(cwd);
+}
+
+/** Read-only top-level session discovery, deduplicated by physical transcript path. */
+export async function listArchivedSessions(options: SessionArchiveOptions): Promise<SessionInfo[]> {
+	const scope = options.scope ?? "project";
+	const queryTokens = (options.query ?? "").toLowerCase().split(/\s+/).filter(Boolean);
+	const seenPaths = new Set<string>();
+	const sessions: SessionInfo[] = [];
+	for (const session of await listAllSessions()) {
+		const canonicalPath = path.resolve(session.path);
+		if (seenPaths.has(canonicalPath)) continue;
+		seenPaths.add(canonicalPath);
+		if (scope === "project" && !sameProject(session.cwd, options.cwd)) continue;
+		if (queryTokens.length > 0) {
+			const metadata = [session.id, session.title ?? "", session.cwd, session.firstMessage].join("\n").toLowerCase();
+			if (!queryTokens.every(token => metadata.includes(token))) continue;
+		}
+		sessions.push(session);
+	}
+	return sessions;
+}
+
+export function sessionProjectLabel(session: Pick<SessionInfo, "cwd">): string {
+	if (!session.cwd) return "unknown";
+	return path.basename(session.cwd) || session.cwd;
+}
+
+function candidateDescription(session: SessionInfo): string {
+	return `${session.id} (${sessionProjectLabel(session)}, ${session.modified.toISOString()})`;
+}
+
+/** Resolve an exact or unique-prefix header session ID from a bounded session set. */
+export function resolveArchivedSessionSelector(sessions: readonly SessionInfo[], rawSelector: string): SessionInfo {
+	const selector = rawSelector.trim();
+	if (!selector) {
+		throw new Error("Archived session ID must not be empty.");
+	}
+	if (
+		selector.endsWith(".jsonl") ||
+		selector.includes("/") ||
+		selector.includes("\\") ||
+		selector.startsWith(".") ||
+		selector.startsWith("~")
+	) {
+		throw new Error(
+			"Direct transcript paths are not supported. Use history://session/<session-id> or session_search with a session ID.",
+		);
+	}
+
+	const lower = selector.toLowerCase();
+	const exact = sessions.filter(session => session.id.toLowerCase() === lower);
+	if (exact.length === 1) return exact[0];
+	if (exact.length > 1) {
+		throw new Error(
+			`Ambiguous archived session ID '${selector}'. Matching transcripts:\n${exact
+				.slice(0, 8)
+				.map(candidateDescription)
+				.join("\n")}`,
+		);
+	}
+
+	const prefixes = sessions.filter(session => session.id.toLowerCase().startsWith(lower));
+	if (prefixes.length === 1) return prefixes[0];
+	if (prefixes.length > 1) {
+		throw new Error(
+			`Ambiguous archived session prefix '${selector}'. Use a longer prefix or full ID:\n${prefixes
+				.slice(0, 8)
+				.map(candidateDescription)
+				.join("\n")}`,
+		);
+	}
+
+	const suggestions = sessions.filter(session => session.id.toLowerCase().includes(lower)).slice(0, 5);
+	const suffix =
+		suggestions.length > 0
+			? `\nPossible matches:\n${suggestions.map(candidateDescription).join("\n")}`
+			: `\nSearch metadata with history://session?scope=all&q=${encodeURIComponent(selector)} or transcript content with session_search.`;
+	throw new Error(`Unknown archived session: ${selector}${suffix}`);
+}
+
+function normalizeSearchRole(role: unknown): SessionTranscriptMatch["role"] {
+	switch (role) {
+		case "user":
+		case "bashExecution":
+		case "pythonExecution":
+		case "fileMention":
+			return "user";
+		case "assistant":
+			return "assistant";
+		case "toolResult":
+			return "tool";
+		default:
+			return "other";
+	}
+}
+
+function* contentStrings(content: unknown): Generator<string> {
+	if (typeof content === "string") {
+		yield content;
+		return;
+	}
+	if (!Array.isArray(content)) return;
+	for (const block of content) {
+		if (!block || typeof block !== "object") continue;
+		const record = block as Record<string, unknown>;
+		if (typeof record.text === "string") {
+			yield record.text;
+			continue;
+		}
+		if (record.type === "toolCall") {
+			if (typeof record.name === "string") yield record.name;
+			if (record.arguments !== undefined) {
+				try {
+					yield JSON.stringify(record.arguments);
+				} catch {
+					// Ignore non-serializable tool arguments in malformed legacy entries.
+				}
+			}
+		}
+	}
+}
+
+function* messageStrings(message: Record<string, unknown>): Generator<string> {
+	yield* contentStrings(message.content);
+	for (const key of ["command", "output", "code"] as const) {
+		const value = message[key];
+		if (typeof value === "string") yield value;
+	}
+	if (message.role === "fileMention" && Array.isArray(message.files)) {
+		for (const file of message.files) {
+			if (!file || typeof file !== "object") continue;
+			const record = file as Record<string, unknown>;
+			if (typeof record.path === "string") yield record.path;
+			if (typeof record.content === "string") yield record.content;
+		}
+	}
+	if ((message.role === "custom" || message.role === "hookMessage") && message.display !== false) {
+		yield* contentStrings(message.content);
+	}
+}
+
+function entrySearchSurface(entry: unknown): {
+	entryId: string;
+	timestamp: string;
+	role: SessionTranscriptMatch["role"];
+	strings: Iterable<string>;
+} | null {
+	if (!entry || typeof entry !== "object") return null;
+	const record = entry as Record<string, unknown>;
+	const entryId = typeof record.id === "string" ? record.id : "unknown";
+	const timestamp = typeof record.timestamp === "string" ? record.timestamp : "unknown";
+	if (record.type === "message" && record.message && typeof record.message === "object") {
+		const message = record.message as Record<string, unknown>;
+		return { entryId, timestamp, role: normalizeSearchRole(message.role), strings: messageStrings(message) };
+	}
+	if (record.type === "custom_message" && record.display !== false) {
+		return { entryId, timestamp, role: "other", strings: contentStrings(record.content) };
+	}
+	if (record.type === "compaction" || record.type === "branch_summary") {
+		const summary = typeof record.summary === "string" ? [record.summary] : [];
+		return { entryId, timestamp, role: "summary", strings: summary };
+	}
+	return null;
+}
+
+function makeSnippet(text: string, index: number, queryLength: number): string {
+	const context = 180;
+	const start = Math.max(0, index - context);
+	const end = Math.min(text.length, index + queryLength + context);
+	const body = text.slice(start, end).replaceAll("\t", " ").replace(/\s+/g, " ").trim();
+	return `${start > 0 ? "…" : ""}${body}${end < text.length ? "…" : ""}`;
+}
+
+function matchEntry(
+	entry: unknown,
+	pattern: RegExp,
+	queryLength: number,
+	role: SessionSearchRole,
+): Omit<SessionTranscriptMatch, "sessionId" | "title" | "project" | "modified"> | null {
+	const surface = entrySearchSurface(entry);
+	if (!surface || (role !== "all" && surface.role !== role)) return null;
+	for (const text of surface.strings) {
+		pattern.lastIndex = 0;
+		const match = pattern.exec(text);
+		if (!match) continue;
+		return {
+			entryId: surface.entryId,
+			timestamp: surface.timestamp,
+			role: surface.role,
+			snippet: makeSnippet(text, match.index, queryLength),
+		};
+	}
+	return null;
+}
+
+async function searchSessionFile(
+	session: SessionInfo,
+	pattern: RegExp,
+	queryLength: number,
+	role: SessionSearchRole,
+	capacity: number,
+	signal?: AbortSignal,
+): Promise<{ matches: SessionTranscriptMatch[]; overflow: boolean }> {
+	const matches: SessionTranscriptMatch[] = [];
+	let writeIndex = 0;
+	let overflow = false;
+	for await (const line of readLines(Bun.file(session.path).stream(), signal)) {
+		const parsed = Bun.JSONL.parseChunk(line);
+		for (const entry of parsed.values) {
+			const match = matchEntry(entry, pattern, queryLength, role);
+			if (!match) continue;
+			const candidate: SessionTranscriptMatch = {
+				...match,
+				sessionId: session.id,
+				title: session.title ?? session.firstMessage,
+				project: sessionProjectLabel(session),
+				modified: session.modified.toISOString(),
+			};
+			if (matches.length < capacity) {
+				matches.push(candidate);
+			} else {
+				matches[writeIndex] = candidate;
+				writeIndex = (writeIndex + 1) % capacity;
+				overflow = true;
+			}
+		}
+	}
+	const chronological = overflow ? [...matches.slice(writeIndex), ...matches.slice(0, writeIndex)] : matches;
+	chronological.reverse();
+	return { matches: chronological, overflow };
+}
+
+/** Search persisted transcript entries, including content hidden behind compaction boundaries. */
+export async function searchArchivedSessionTranscripts(
+	options: SessionTranscriptSearchOptions,
+): Promise<SessionTranscriptSearchResult> {
+	const query = options.query.trim();
+	if (!query) throw new Error("Session search query must not be empty.");
+	if (query.length > 500) throw new Error("Session search query must not exceed 500 characters.");
+	const limit = Math.min(
+		Math.max(1, Math.floor(options.limit ?? SESSION_ARCHIVE_DEFAULT_LIMIT)),
+		SESSION_ARCHIVE_MAX_LIMIT,
+	);
+	const offset = Math.min(Math.max(0, Math.floor(options.offset ?? 0)), SESSION_ARCHIVE_MAX_OFFSET);
+	const capacity = offset + limit + 1;
+	const role = options.role ?? "all";
+	let sessions = await listArchivedSessions({ cwd: options.cwd, scope: options.scope });
+	if (options.session) sessions = [resolveArchivedSessionSelector(sessions, options.session)];
+
+	const pattern = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), options.caseSensitive ? "u" : "iu");
+	const ordered: SessionTranscriptMatch[] = [];
+	let hasMore = false;
+	let scannedSessions = 0;
+	let unreadableSessions = 0;
+
+	for (let index = 0; index < sessions.length; index++) {
+		const session = sessions[index];
+		try {
+			const result = await searchSessionFile(session, pattern, query.length, role, capacity, options.signal);
+			scannedSessions++;
+			for (const match of result.matches) {
+				if (ordered.length < capacity) ordered.push(match);
+				else hasMore = true;
+			}
+			if (result.overflow) hasMore = true;
+		} catch (error) {
+			if (options.signal?.aborted) throw error;
+			unreadableSessions++;
+		}
+		if (ordered.length >= capacity) {
+			hasMore = true;
+			break;
+		}
+	}
+
+	const matches = ordered.slice(offset, offset + limit);
+	if (ordered.length > offset + limit) hasMore = true;
+	return {
+		matches,
+		hasMore,
+		nextOffset: hasMore ? offset + matches.length : undefined,
+		scannedSessions,
+		unreadableSessions,
+	};
+}

--- a/packages/coding-agent/src/tools/builtin-names.ts
+++ b/packages/coding-agent/src/tools/builtin-names.ts
@@ -10,6 +10,7 @@ export const BUILTIN_TOOL_NAMES = [
 	"github",
 	"glob",
 	"grep",
+	"session_search",
 	"lsp",
 	"inspect_image",
 	"browser",

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -60,6 +60,7 @@ import { MemoryRetainTool } from "./memory-retain";
 import { wrapToolWithMetaNotice } from "./output-meta";
 import { ReadTool } from "./read";
 import type { PlanProposalHandler } from "./resolve";
+import { SessionSearchTool } from "./session-search";
 import { type TodoPhase, TodoTool } from "./todo";
 import { WriteTool } from "./write";
 import { isMountableUnderXdev, type XdevState } from "./xdev";
@@ -99,6 +100,7 @@ export * from "./read";
 export * from "./report-tool-issue";
 export * from "./resolve";
 export * from "./review";
+export * from "./session-search";
 export * from "./todo";
 export * from "./tts";
 export * from "./vibe";
@@ -404,6 +406,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	github: GithubTool.createIf,
 	glob: s => new GlobTool(s, { rootPathAlias: true }),
 	grep: s => new GrepTool(s),
+	session_search: s => new SessionSearchTool(s),
 	lsp: LspTool.createIf,
 	inspect_image: s => new InspectImageTool(s),
 	browser: s => new BrowserTool(s),

--- a/packages/coding-agent/src/tools/session-search.ts
+++ b/packages/coding-agent/src/tools/session-search.ts
@@ -1,0 +1,118 @@
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { replaceTabs, truncateToWidth } from "@oh-my-pi/pi-tui";
+import { untilAborted } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+import sessionSearchDescription from "../prompts/tools/session-search.md" with { type: "text" };
+import {
+	SESSION_ARCHIVE_DEFAULT_LIMIT,
+	SESSION_ARCHIVE_MAX_LIMIT,
+	SESSION_ARCHIVE_MAX_OFFSET,
+	type SessionArchiveScope,
+	type SessionSearchRole,
+	type SessionTranscriptSearchResult,
+	searchArchivedSessionTranscripts,
+} from "../session/session-archive";
+import type { ToolSession } from ".";
+
+const sessionSearchSchema = type({
+	query: type("string > 0").describe("literal text to find in persisted session transcripts"),
+	"scope?": type("'project' | 'all'").describe("current project or every project; default project"),
+	"session?": type("string > 0").describe("exact or unique-prefix archived session ID"),
+	"role?": type("'all' | 'user' | 'assistant' | 'tool' | 'summary'").describe("entry role; default all"),
+	"case?": type("boolean").describe("case-sensitive matching; default false"),
+	"limit?": type("number > 0").describe("matches per page; default 20, max 100"),
+	"offset?": type("number >= 0").describe("matches to skip; default 0, max 10000"),
+});
+
+export type SessionSearchParams = typeof sessionSearchSchema.infer;
+
+export interface SessionSearchDetails extends SessionTranscriptSearchResult {
+	query: string;
+	scope: SessionArchiveScope;
+	role: SessionSearchRole;
+	offset: number;
+	limit: number;
+}
+
+function formatSearchResult(details: SessionSearchDetails): string {
+	const lines = [
+		"# Session Search",
+		"",
+		`Query: ${truncateToWidth(replaceTabs(details.query), 120)} · Scope: ${details.scope} · Role: ${details.role}`,
+	];
+	if (details.matches.length === 0) {
+		lines.push("", "_No matching persisted transcript entries._");
+	} else {
+		let activeSessionId: string | undefined;
+		for (const match of details.matches) {
+			if (match.sessionId !== activeSessionId) {
+				activeSessionId = match.sessionId;
+				lines.push(
+					"",
+					`## history://session/${match.sessionId}`,
+					`${truncateToWidth(replaceTabs(match.title), 100)} · ${truncateToWidth(replaceTabs(match.project), 40)} · modified ${match.modified}`,
+				);
+			}
+			lines.push(
+				`- **${match.role}** · ${match.timestamp} · entry \`${match.entryId}\``,
+				`  > ${truncateToWidth(replaceTabs(match.snippet), 420)}`,
+			);
+		}
+	}
+	if (details.hasMore && details.nextOffset !== undefined) {
+		lines.push("", `More matches available. Continue with \`offset: ${details.nextOffset}\`.`);
+	}
+	lines.push("", `Scanned ${details.scannedSessions} session${details.scannedSessions === 1 ? "" : "s"}.`);
+	if (details.unreadableSessions > 0) {
+		lines.push(
+			`Skipped ${details.unreadableSessions} unreadable session${details.unreadableSessions === 1 ? "" : "s"}.`,
+		);
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+export class SessionSearchTool implements AgentTool<typeof sessionSearchSchema, SessionSearchDetails> {
+	readonly name = "session_search";
+	readonly approval = "read" as const;
+	readonly label = "Session Search";
+	readonly description = sessionSearchDescription;
+	readonly parameters = sessionSearchSchema;
+	readonly strict = true;
+	readonly loadMode = "discoverable";
+	readonly summary = "Search persisted session transcript contents";
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		params: SessionSearchParams,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult<SessionSearchDetails>> {
+		const query = params.query.trim();
+		const limit = params.limit ?? SESSION_ARCHIVE_DEFAULT_LIMIT;
+		if (!Number.isInteger(limit) || limit < 1 || limit > SESSION_ARCHIVE_MAX_LIMIT) {
+			throw new Error(`session_search limit must be an integer from 1 to ${SESSION_ARCHIVE_MAX_LIMIT}.`);
+		}
+		const offset = params.offset ?? 0;
+		if (!Number.isInteger(offset) || offset < 0 || offset > SESSION_ARCHIVE_MAX_OFFSET) {
+			throw new Error(`session_search offset must be an integer from 0 to ${SESSION_ARCHIVE_MAX_OFFSET}.`);
+		}
+		const scope = params.scope ?? "project";
+		const role = params.role ?? "all";
+		return untilAborted(signal, async () => {
+			const result = await searchArchivedSessionTranscripts({
+				query,
+				cwd: this.session.cwd,
+				scope,
+				session: params.session,
+				role,
+				caseSensitive: params.case,
+				limit,
+				offset,
+				signal,
+			});
+			const details: SessionSearchDetails = { ...result, query, scope, role, offset, limit };
+			return { content: [{ type: "text", text: formatSearchResult(details) }], details };
+		});
+	}
+}

--- a/packages/coding-agent/test/internal-urls/history-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/history-protocol.test.ts
@@ -55,21 +55,22 @@ function makeToolSession(cwd: string): ToolSession {
 }
 
 /** Minimal current-version session JSONL: header + a linear user/assistant chain. */
-function sessionFixtureJsonl(id = "fixture-session"): string {
+function sessionFixtureJsonl(id = "fixture-session", cwd = "/tmp", userText = "parked hello", title?: string): string {
 	const timestamp = new Date().toISOString();
 	const header = {
 		type: "session",
 		version: CURRENT_SESSION_VERSION,
 		id,
+		title,
 		timestamp,
-		cwd: "/tmp",
+		cwd,
 	};
 	const userEntry = {
 		type: "message",
 		id: "m1",
 		parentId: null,
 		timestamp,
-		message: { role: "user", content: "parked hello", timestamp: 1 },
+		message: { role: "user", content: userText, timestamp: 1 },
 	};
 	const assistantEntry = {
 		type: "message",
@@ -89,15 +90,18 @@ function sessionFixtureJsonl(id = "fixture-session"): string {
 	};
 	return `${JSON.stringify(header)}\n${JSON.stringify(userEntry)}\n${JSON.stringify(assistantEntry)}\n`;
 }
+let originalAgentDir: string;
 
 describe("history:// protocol", () => {
 	beforeEach(() => {
+		originalAgentDir = getAgentDir();
 		AgentRegistry.resetGlobalForTests();
 		InternalUrlRouter.resetForTests();
 		resetRegisteredArtifactDirsForTests();
 	});
 
 	afterEach(() => {
+		setAgentDir(originalAgentDir);
 		InternalUrlRouter.resetForTests();
 		AgentRegistry.resetGlobalForTests();
 		resetRegisteredArtifactDirsForTests();
@@ -405,44 +409,109 @@ describe("history:// protocol", () => {
 			await Bun.write(candidate, "not a directory");
 			registerArtifactsDir(candidate);
 
-			await expect(new HistoryProtocolHandler().complete()).resolves.toEqual([]);
+			await expect(new HistoryProtocolHandler().complete()).resolves.toEqual([
+				{ value: "agent/", description: "explicit agent transcript namespace" },
+				{ value: "session/", description: "archived top-level session namespace" },
+			]);
 		});
 	});
-	it("resolves a top-level session transcript by session ID and prefix", async () => {
+	it("separates agent and archived-session IDs and rejects ambiguous prefixes", async () => {
 		await withTempDir(async dir => {
 			const agentDir = path.join(dir, "agent");
 			const sessionsDir = path.join(agentDir, "sessions", "project");
 			await fs.mkdir(sessionsDir, { recursive: true });
 
-			const sessionId = "019f0000-aaaa-7000-8000-000000000001";
-			const sessionFile = path.join(sessionsDir, `2026-07-21T12-00-00-000Z_${sessionId}.jsonl`);
-			await Bun.write(sessionFile, sessionFixtureJsonl(sessionId));
-
-			const previousAgentDir = getAgentDir();
+			const firstId = "019f0000-aaaa-7000-8000-000000000001";
+			const secondId = "019f0000-bbbb-7000-8000-000000000002";
+			const firstFile = path.join(sessionsDir, `2026-07-21T12-00-00-000Z_${firstId}.jsonl`);
+			await Bun.write(firstFile, sessionFixtureJsonl(firstId, "/tmp/project", "archived hello"));
+			await Bun.write(
+				path.join(sessionsDir, `2026-07-21T13-00-00-000Z_${secondId}.jsonl`),
+				sessionFixtureJsonl(secondId, "/tmp/project", "second archive"),
+			);
 			setAgentDir(agentDir);
-			try {
-				const fullRes = await InternalUrlRouter.instance().resolve(`history://${sessionId}`);
-				expect(fullRes.content).toContain(sessionId);
-				expect(fullRes.content).toContain("parked hello");
-				expect(fullRes.sourcePath).toBe(sessionFile);
+			AgentRegistry.global().register({
+				id: firstId,
+				displayName: "task",
+				kind: "sub",
+				session: fakeLiveSession([{ role: "user", content: "live agent", timestamp: 1 }]),
+				status: "idle",
+			});
 
-				const prefixRes = await InternalUrlRouter.instance().resolve("history://019f0000-aaaa");
-				expect(prefixRes.content).toContain("parked hello");
-				expect(prefixRes.sourcePath).toBe(sessionFile);
-			} finally {
-				setAgentDir(previousAgentDir);
-			}
+			const legacyAgent = await InternalUrlRouter.instance().resolve(`history://${firstId}`);
+			expect(legacyAgent.content).toContain("live agent");
+			const explicitAgent = await InternalUrlRouter.instance().resolve(`history://agent/${firstId}`);
+			expect(explicitAgent.content).toContain("live agent");
+
+			const archived = await InternalUrlRouter.instance().resolve(`history://session/${firstId}`);
+			expect(archived.content).toContain("archived hello");
+			expect(archived.sourcePath).toBe(firstFile);
+			const uniquePrefix = await InternalUrlRouter.instance().resolve("history://session/019f0000-a");
+			expect(uniquePrefix.sourcePath).toBe(firstFile);
+
+			await expect(InternalUrlRouter.instance().resolve("history://session/019f0000")).rejects.toThrow(
+				"Ambiguous archived session prefix",
+			);
 		});
 	});
 
-	it("resolves a session transcript by direct file path", async () => {
+	it("lists archived sessions with project scope, filtering, pagination, and no alias duplicates", async () => {
 		await withTempDir(async dir => {
-			const sessionFile = path.join(dir, "custom-session.jsonl");
-			await Bun.write(sessionFile, sessionFixtureJsonl());
+			const agentDir = path.join(dir, "agent");
+			const projectDir = path.join(agentDir, "sessions", "project");
+			const otherDir = path.join(agentDir, "sessions", "other");
+			await fs.mkdir(projectDir, { recursive: true });
+			await fs.mkdir(otherDir, { recursive: true });
+			const firstId = "019f1000-aaaa-7000-8000-000000000001";
+			const secondId = "019f1000-aaaa-7000-8000-000000000002";
+			const otherId = "019f1000-aaaa-7000-8000-000000000003";
+			const firstFile = path.join(projectDir, `2026-07-21T12-00-00-000Z_${firstId}.jsonl`);
+			const secondFile = path.join(projectDir, `2026-07-21T13-00-00-000Z_${secondId}.jsonl`);
+			const otherFile = path.join(otherDir, `2026-07-21T14-00-00-000Z_${otherId}.jsonl`);
+			await Bun.write(firstFile, sessionFixtureJsonl(firstId, "/tmp/project-a", "alpha prompt", "Alpha"));
+			await Bun.write(secondFile, sessionFixtureJsonl(secondId, "/tmp/project-a", "beta prompt", "Beta"));
+			await Bun.write(otherFile, sessionFixtureJsonl(otherId, "/tmp/project-b", "gamma prompt", "Gamma"));
+			await fs.utimes(firstFile, new Date(1_000), new Date(1_000));
+			await fs.utimes(secondFile, new Date(2_000), new Date(2_000));
+			await fs.utimes(otherFile, new Date(3_000), new Date(3_000));
+			setAgentDir(agentDir);
 
-			const resource = await InternalUrlRouter.instance().resolve(`history://${sessionFile}`);
-			expect(resource.content).toContain("parked hello");
-			expect(resource.sourcePath).toBe(sessionFile);
+			const firstPage = await InternalUrlRouter.instance().resolve("history://session?limit=1", {
+				cwd: "/tmp/project-a",
+			});
+			expect(firstPage.content).toContain("Showing 1–1 of 2");
+			expect(firstPage.content).toContain(secondId);
+			expect(firstPage.content).not.toContain(firstId);
+			expect(firstPage.content).not.toContain(otherId);
+			expect(firstPage.content).toContain("offset=1");
+
+			const secondPage = await InternalUrlRouter.instance().resolve("history://session?limit=1&offset=1", {
+				cwd: "/tmp/project-a",
+			});
+			expect(secondPage.content).toContain(firstId);
+			expect(secondPage.content).not.toContain(secondId);
+
+			const filtered = await InternalUrlRouter.instance().resolve("history://session?q=alpha", {
+				cwd: "/tmp/project-a",
+			});
+			expect(filtered.content).toContain(firstId);
+			expect(filtered.content).not.toContain(secondId);
+
+			const global = await InternalUrlRouter.instance().resolve("history://session?scope=all", {
+				cwd: "/tmp/project-a",
+			});
+			expect(global.content).toContain(otherId);
+			expect(global.content.split("\n").filter(line => line.includes(`history://session/${firstId}`))).toHaveLength(
+				1,
+			);
 		});
+	});
+	it("rejects direct transcript paths and invalid archive pagination", async () => {
+		await expect(InternalUrlRouter.instance().resolve("history:///tmp/session.jsonl")).rejects.toThrow(
+			"Direct transcript paths are not supported",
+		);
+		await expect(InternalUrlRouter.instance().resolve("history://session?limit=0")).rejects.toThrow(
+			"Expected an integer 1–100",
+		);
 	});
 });

--- a/packages/coding-agent/test/internal-urls/history-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/history-protocol.test.ts
@@ -24,7 +24,7 @@ import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-sessi
 import { CURRENT_SESSION_VERSION } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
-import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { getAgentDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
 	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "history-protocol-"));
@@ -55,12 +55,12 @@ function makeToolSession(cwd: string): ToolSession {
 }
 
 /** Minimal current-version session JSONL: header + a linear user/assistant chain. */
-function sessionFixtureJsonl(): string {
+function sessionFixtureJsonl(id = "fixture-session"): string {
 	const timestamp = new Date().toISOString();
 	const header = {
 		type: "session",
 		version: CURRENT_SESSION_VERSION,
-		id: "fixture-session",
+		id,
 		timestamp,
 		cwd: "/tmp",
 	};
@@ -406,6 +406,43 @@ describe("history:// protocol", () => {
 			registerArtifactsDir(candidate);
 
 			await expect(new HistoryProtocolHandler().complete()).resolves.toEqual([]);
+		});
+	});
+	it("resolves a top-level session transcript by session ID and prefix", async () => {
+		await withTempDir(async dir => {
+			const agentDir = path.join(dir, "agent");
+			const sessionsDir = path.join(agentDir, "sessions", "project");
+			await fs.mkdir(sessionsDir, { recursive: true });
+
+			const sessionId = "019f0000-aaaa-7000-8000-000000000001";
+			const sessionFile = path.join(sessionsDir, `2026-07-21T12-00-00-000Z_${sessionId}.jsonl`);
+			await Bun.write(sessionFile, sessionFixtureJsonl(sessionId));
+
+			const previousAgentDir = getAgentDir();
+			setAgentDir(agentDir);
+			try {
+				const fullRes = await InternalUrlRouter.instance().resolve(`history://${sessionId}`);
+				expect(fullRes.content).toContain(sessionId);
+				expect(fullRes.content).toContain("parked hello");
+				expect(fullRes.sourcePath).toBe(sessionFile);
+
+				const prefixRes = await InternalUrlRouter.instance().resolve("history://019f0000-aaaa");
+				expect(prefixRes.content).toContain("parked hello");
+				expect(prefixRes.sourcePath).toBe(sessionFile);
+			} finally {
+				setAgentDir(previousAgentDir);
+			}
+		});
+	});
+
+	it("resolves a session transcript by direct file path", async () => {
+		await withTempDir(async dir => {
+			const sessionFile = path.join(dir, "custom-session.jsonl");
+			await Bun.write(sessionFile, sessionFixtureJsonl());
+
+			const resource = await InternalUrlRouter.instance().resolve(`history://${sessionFile}`);
+			expect(resource.content).toContain("parked hello");
+			expect(resource.sourcePath).toBe(sessionFile);
 		});
 	});
 });

--- a/packages/coding-agent/test/tools/session-search.test.ts
+++ b/packages/coding-agent/test/tools/session-search.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent";
+import { CURRENT_SESSION_VERSION } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { getAgentDir, setAgentDir } from "@oh-my-pi/pi-utils";
+import { searchArchivedSessionTranscripts } from "../../src/session/session-archive";
+import { SessionSearchTool } from "../../src/tools/session-search";
+
+interface FixtureEntry {
+	type: string;
+	id: string;
+	parentId: string | null;
+	timestamp: string;
+	[key: string]: unknown;
+}
+
+function sessionFixture(id: string, cwd: string, title: string, entries: FixtureEntry[]): string {
+	const header = {
+		type: "session",
+		version: CURRENT_SESSION_VERSION,
+		id,
+		timestamp: "2026-07-21T12:00:00.000Z",
+		cwd,
+		title,
+	};
+	return `${[header, ...entries].map(entry => JSON.stringify(entry)).join("\n")}\n`;
+}
+
+let tempDir: string;
+let originalAgentDir: string;
+
+beforeEach(async () => {
+	originalAgentDir = getAgentDir();
+	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "session-search-"));
+	setAgentDir(path.join(tempDir, "agent"));
+});
+
+afterEach(async () => {
+	setAgentDir(originalAgentDir);
+	await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+describe("session transcript search", () => {
+	it("searches pre-compaction entries literally with stable pagination and role filters", async () => {
+		const cwd = path.join(tempDir, "project");
+		const sessionsDir = path.join(getAgentDir(), "sessions", "project");
+		await fs.mkdir(sessionsDir, { recursive: true });
+		const oldId = "019f2000-aaaa-7000-8000-000000000001";
+		const newId = "019f2000-bbbb-7000-8000-000000000002";
+		const oldFile = path.join(sessionsDir, `2026-07-21T12-00-00-000Z_${oldId}.jsonl`);
+		const newFile = path.join(sessionsDir, `2026-07-21T13-00-00-000Z_${newId}.jsonl`);
+		await Bun.write(
+			oldFile,
+			sessionFixture(oldId, cwd, "Older session", [
+				{
+					type: "message",
+					id: "u1",
+					parentId: null,
+					timestamp: "2026-07-21T12:01:00.000Z",
+					message: { role: "user", content: "Before compact Needle.literal[]", timestamp: 1 },
+				},
+				{
+					type: "compaction",
+					id: "c1",
+					parentId: "u1",
+					timestamp: "2026-07-21T12:02:00.000Z",
+					summary: "Summary needle",
+				},
+				{
+					type: "message",
+					id: "t1",
+					parentId: "c1",
+					timestamp: "2026-07-21T12:03:00.000Z",
+					message: { role: "toolResult", content: [{ type: "text", text: "tool needle" }], timestamp: 2 },
+				},
+				{
+					type: "message",
+					id: "a1",
+					parentId: "t1",
+					timestamp: "2026-07-21T12:04:00.000Z",
+					message: { role: "assistant", content: [{ type: "text", text: "assistant needle" }], timestamp: 3 },
+				},
+				{
+					type: "custom_message",
+					id: "x1",
+					parentId: "a1",
+					timestamp: "2026-07-21T12:05:00.000Z",
+					content: "custom needle",
+					display: true,
+				},
+			]),
+		);
+		await Bun.write(
+			newFile,
+			sessionFixture(newId, cwd, "Newer session", [
+				{
+					type: "message",
+					id: "n1",
+					parentId: null,
+					timestamp: "2026-07-21T13:01:00.000Z",
+					message: { role: "user", content: "newest needle", timestamp: 4 },
+				},
+			]),
+		);
+		await fs.utimes(oldFile, new Date(1_000), new Date(1_000));
+		await fs.utimes(newFile, new Date(2_000), new Date(2_000));
+
+		const firstPage = await searchArchivedSessionTranscripts({ query: "needle", cwd, limit: 2 });
+		expect(firstPage.matches.map(match => match.entryId)).toEqual(["n1", "x1"]);
+		expect(firstPage.hasMore).toBe(true);
+		expect(firstPage.nextOffset).toBe(2);
+
+		const secondPage = await searchArchivedSessionTranscripts({ query: "needle", cwd, limit: 2, offset: 2 });
+		expect(secondPage.matches.map(match => match.entryId)).toEqual(["a1", "t1"]);
+		expect(secondPage.nextOffset).toBe(4);
+
+		const lastPage = await searchArchivedSessionTranscripts({ query: "needle", cwd, limit: 2, offset: 4 });
+		expect(lastPage.matches.map(match => match.entryId)).toEqual(["c1", "u1"]);
+		expect(lastPage.hasMore).toBe(false);
+
+		const preCompaction = await searchArchivedSessionTranscripts({
+			query: "needle.literal[]",
+			cwd,
+			session: "019f2000-a",
+			role: "user",
+		});
+		expect(preCompaction.matches.map(match => match.entryId)).toEqual(["u1"]);
+		expect(preCompaction.matches[0]?.snippet).toContain("Needle.literal[]");
+
+		const caseSensitive = await searchArchivedSessionTranscripts({
+			query: "needle.literal[]",
+			cwd,
+			session: oldId,
+			role: "user",
+			caseSensitive: true,
+		});
+		expect(caseSensitive.matches).toEqual([]);
+
+		const summary = await searchArchivedSessionTranscripts({ query: "summary", cwd, role: "summary" });
+		expect(summary.matches.map(match => match.entryId)).toEqual(["c1"]);
+	});
+
+	it("returns bounded tool output with a resolvable history URL", async () => {
+		const cwd = path.join(tempDir, "project");
+		const sessionsDir = path.join(getAgentDir(), "sessions", "project");
+		await fs.mkdir(sessionsDir, { recursive: true });
+		const id = "019f3000-aaaa-7000-8000-000000000001";
+		await Bun.write(
+			path.join(sessionsDir, `2026-07-21T12-00-00-000Z_${id}.jsonl`),
+			sessionFixture(id, cwd, "Tool contract", [
+				{
+					type: "message",
+					id: "u1",
+					parentId: null,
+					timestamp: "2026-07-21T12:01:00.000Z",
+					message: { role: "user", content: "find this durable phrase", timestamp: 1 },
+				},
+			]),
+		);
+		const tool = new SessionSearchTool({ cwd } as ToolSession);
+
+		const result = await tool.execute("call-1", { query: "durable phrase", limit: 1 });
+
+		if (!result.details) throw new Error("Expected structured session search details");
+		expect(result.details.matches).toHaveLength(1);
+		expect(result.details.matches[0]?.sessionId).toBe(id);
+		expect(result.content[0]?.type).toBe("text");
+		if (result.content[0]?.type !== "text") throw new Error("Expected text tool output");
+		expect(result.content[0].text).toContain(`history://session/${id}`);
+		expect(result.content[0].text).toContain("find this durable phrase");
+		expect(result.content[0].text.length).toBeLessThan(2_000);
+	});
+});


### PR DESCRIPTION
## Summary

Extends the `history://` internal URL protocol to support session archive indexing and resolution, and introduces the `session_search` tool for streaming search across persisted transcript entries.

### `history://` Protocol & Namespace Separation

- **Explicit Namespace Routing**: `history://<agent-id>` retains legacy agent transcript lookup; `history://agent/<agent-id>` provides explicit agent scoping; `history://session` lists archived top-level sessions.
- **`history://session` Indexing**:
  - Scoped to the current project directory by default; supports `scope=all` for cross-project history.
  - Bounded pagination (`limit=1..100`, `offset=0..10000`) and metadata query filtering (`q`).
  - Deduplicates physical transcript paths across registered artifact locations and storage aliases.
- **`history://session/<id>` Resolution**:
  - Resolves archived top-level sessions by exact ID or unique ID prefix.
  - Ambiguous prefixes throw detailed candidate lists for disambiguation.
  - Direct filesystem transcript paths are prohibited to prevent path exposure.

### `session_search` Tool

- **Streaming Transcript Search**: High-performance streaming search over raw JSONL session files, allowing search of turns hidden behind compaction boundaries.
- **Comprehensive Coverage**: Searches user messages, assistant text, tool names/arguments, tool results, shell/Python execution blocks, file mentions, visible custom messages, compaction summaries, and branch summaries.
- **Filtering & Pagination**: Supports `scope` (`project` | `all`), `session` ID/prefix filter, `role` (`all` | `user` | `assistant` | `tool` | `summary`), `case` sensitivity, `limit`, and `offset`.
- **Structured Output**: Groups matches by `history://session/<id>` headers with single-line snippets, modification timestamps, project labels, and `nextOffset` continuation hints.

### Documentation & Contract

- Updated `system-prompt.md` internal URL declarations.
- Added model-facing tool prompt (`packages/coding-agent/src/prompts/tools/session-search.md`) and root tool documentation (`docs/tools/session-search.md`).
- Added package `CHANGELOG.md` entry.

## Tests

- `test/internal-urls/history-protocol.test.ts`: namespace separation, prefix resolution, direct-path rejection, global listing, pagination, and deduplication.
- `test/tools/session-search.test.ts`: literal matching, role filtering, pre-compaction entries, custom message search, and tool execution contract.
- Verified TypeScript type checks (`bun run check:ts`) and Biome formatting.