### PR TITLE
fix(tui): preserve literal code block rows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,10 @@
 - Fixed `omp install` failing extension validation for pi extensions that import `createEditTool` or `createWriteTool` (e.g. gentle-pi) — the legacy `@oh-my-pi/pi-coding-agent` shim exported the read/bash/grep/find/ls tool factories but omitted the edit and write ones, so a named import threw Bun's static "Export named X not found" error. Added `createEditTool`/`createEditToolDefinition` and `createWriteTool`/`createWriteToolDefinition` to match the upstream pi surface ([#7094](https://github.com/can1357/oh-my-pi/issues/7094)).
 - Fixed Python eval's loopback tool bridge being routed through macOS system HTTP proxies, which caused `parallel()` tool reads to fail with `ConnectionRefusedError` after a local proxy stopped.
 
+### Fixed
+
+- Fixed copied fenced-code body rows in assistant messages retaining component and container margins ([#7055](https://github.com/can1357/oh-my-pi/pull/7055) by [@GratefulDave](https://github.com/GratefulDave)).
+
 ## [17.2.0] - 2026-07-30
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -871,7 +871,7 @@ export class AssistantMessageComponent extends Container {
 				// Set paddingY=0 to avoid extra spacing before tool executions
 				const trimmed = content.text.trim();
 				const mdOptions = this.#textColorTransform ? { color: this.#textColorTransform } : undefined;
-				const md = new Markdown(trimmed, 1, 0, getMarkdownTheme(), mdOptions);
+				const md = new Markdown(trimmed, 1, 0, getMarkdownTheme(), mdOptions, 0);
 				this.#contentContainer.addChild(md);
 				captureItems?.push({ md, contentIndex: i, blockType: "text", lastText: trimmed });
 				hasRenderedContent = true;

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Fixed hash-prefixed UUIDs in prose being misclassified as 8-digit CSS colors and receiving spurious swatches.
 - Fixed unbounded memory growth and potential host freezes when a PTY consumer stalls by capping the pending stdout backlog and treating undrained consumers as a disconnect.
 
+- Fixed terminal selection copying leading whitespace into fenced-code rows in coding-agent assistant messages, which could prevent pasted heredoc terminators from closing.
+
 ## [17.1.8] - 2026-07-28
 
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed terminal copies of literal fenced-code body rows retaining component, list, or blockquote margins in coding-agent assistant messages ([#7055](https://github.com/can1357/oh-my-pi/pull/7055) by [@GratefulDave](https://github.com/GratefulDave)).
+
 ## [17.2.0] - 2026-07-30
 
 ### Added
@@ -15,7 +19,6 @@
 - Fixed hash-prefixed UUIDs in prose being misclassified as 8-digit CSS colors and receiving spurious swatches.
 - Fixed unbounded memory growth and potential host freezes when a PTY consumer stalls by capping the pending stdout backlog and treating undrained consumers as a disconnect.
 
-- Fixed terminal selection copying leading whitespace into fenced-code rows in coding-agent assistant messages, which could prevent pasted heredoc terminators from closing.
 
 ## [17.1.8] - 2026-07-28
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1463,7 +1463,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		paddingY: number,
 		theme: MarkdownTheme,
 		defaultTextStyle?: DefaultTextStyle,
-		codeBlockIndent: number = 0,
+		codeBlockIndent: number = 2,
 	) {
 		this.#text = normalizeOsc8Terminators(text);
 		this.#paddingX = paddingX;
@@ -1858,7 +1858,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		rowOffset: number,
 		startingSourceOffset: number,
 	): string[] {
-		const wrappedLines: string[] = [];
+		const wrappedLines: Array<{ text: string; unpadded: boolean }> = [];
 		let sourceOffset = startingSourceOffset;
 		for (let i = start; i < end; i++) {
 			const token = tokens[i];
@@ -1878,10 +1878,13 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				// Lists wrap while their structural prefixes are still available, so
 				// continuation rows retain the correct hanging indent. Re-wrapping the
 				// flattened rows here would discard that structure.
+				const unpadded = token.type === "code" && this.#codeBlockIndent === 0;
 				if (token.type === "list" || TERMINAL.isImageLine(line) || isOsc66Line(line)) {
-					wrappedLines.push(line);
+					wrappedLines.push({ text: line, unpadded });
 				} else {
-					wrappedLines.push(...wrapTextWithAnsi(line, contentWidth));
+					for (const wrappedLine of wrapTextWithAnsi(line, contentWidth)) {
+						wrappedLines.push({ text: wrappedLine, unpadded });
+					}
 				}
 				tokenLineOffsets.push(wrappedLines.length - tokenWrappedRowStart);
 			}
@@ -1915,7 +1918,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		const contentLines: string[] = [];
 		let previousLineWasOsc66 = false;
 
-		for (const line of wrappedLines) {
+		for (const { text: line, unpadded } of wrappedLines) {
 			// The first empty row after a scale>1 OSC 66 heading is structural:
 			// it reserves the lower cells occupied by the multicell glyphs. Do
 			// not pad or background-fill it, because real spaces on that row can
@@ -1935,7 +1938,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 			}
 
 			previousLineWasOsc66 = false;
-			const lineWithMargins = leftMargin + line + rightMargin;
+			const lineWithMargins = (unpadded ? "" : leftMargin) + line + rightMargin;
 
 			if (bgFn) {
 				contentLines.push(applyBackgroundToLine(lineWithMargins, signature.width, bgFn));

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -41,6 +41,10 @@ function isOsc66Line(line: string): boolean {
 	return line.includes(OSC66_LINE_PREFIX);
 }
 
+// Internal zero-width marker carried through list/blockquote renderers. It is
+// removed before output, along with every visual container prefix before it.
+const LITERAL_CODE_ROW_MARKER = "\0";
+
 function normalizeHtmlEntitiesForTerminal(raw: string): string {
 	const parseCodePoint = (value: number): string => {
 		if (Number.isFinite(value) && value >= 0 && value <= 0x10ffff) {
@@ -1917,8 +1921,13 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		const bgFn = this.#defaultTextStyle?.bgColor;
 		const contentLines: string[] = [];
 		let previousLineWasOsc66 = false;
-
-		for (const { text: line, unpadded } of wrappedLines) {
+		for (const renderedLine of wrappedLines) {
+			const literalMarkerIndex = renderedLine.text.indexOf(LITERAL_CODE_ROW_MARKER);
+			const literalCodeRow = renderedLine.unpadded || literalMarkerIndex !== -1;
+			const line =
+				literalMarkerIndex !== -1
+					? renderedLine.text.slice(literalMarkerIndex + LITERAL_CODE_ROW_MARKER.length)
+					: renderedLine.text;
 			// The first empty row after a scale>1 OSC 66 heading is structural:
 			// it reserves the lower cells occupied by the multicell glyphs. Do
 			// not pad or background-fill it, because real spaces on that row can
@@ -1938,7 +1947,11 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 			}
 
 			previousLineWasOsc66 = false;
-			const lineWithMargins = (unpadded ? "" : leftMargin) + line + rightMargin;
+			if (literalCodeRow) {
+				contentLines.push(line);
+				continue;
+			}
+			const lineWithMargins = leftMargin + line + rightMargin;
 
 			if (bgFn) {
 				contentLines.push(applyBackgroundToLine(lineWithMargins, signature.width, bgFn));
@@ -1969,6 +1982,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 	}
 
 	#renderCodeBodyLines(token: Token, codeIndent: string): string[] {
+		const literalRowPrefix = this.#codeBlockIndent === 0 ? LITERAL_CODE_ROW_MARKER : codeIndent;
 		const bodyLines: string[] = [];
 		const tokenText = "text" in token && typeof token.text === "string" ? token.text : "";
 		const lang = "lang" in token && typeof token.lang === "string" ? token.lang : undefined;
@@ -1982,7 +1996,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		if (this.#theme.highlightCode && (!this.transientRenderCache || this.#renderingFrozenPrefix)) {
 			const highlightedLines = this.#theme.highlightCode(tokenText, lang);
 			for (const hlLine of highlightedLines) {
-				bodyLines.push(`${codeIndent}${hlLine}`);
+				bodyLines.push(`${literalRowPrefix}${hlLine}`);
 			}
 			return bodyLines;
 		}
@@ -1993,11 +2007,11 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 			if (closedFence || lineEnd >= 0) {
 				const completedText = closedFence ? tokenText : tokenText.slice(0, lineEnd);
 				for (const hlLine of this.#highlightStreamingDiffLines(completedText, lang)) {
-					bodyLines.push(`${codeIndent}${hlLine}`);
+					bodyLines.push(`${literalRowPrefix}${hlLine}`);
 				}
 				if (!closedFence) {
 					for (const codeLine of tokenText.slice(lineEnd + 1).split("\n")) {
-						bodyLines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
+						bodyLines.push(`${literalRowPrefix}${this.#theme.codeBlock(codeLine)}`);
 					}
 				}
 				return bodyLines;
@@ -2005,7 +2019,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		}
 
 		for (const codeLine of tokenText.split("\n")) {
-			bodyLines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
+			bodyLines.push(`${literalRowPrefix}${this.#theme.codeBlock(codeLine)}`);
 		}
 		return bodyLines;
 	}

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1463,7 +1463,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		paddingY: number,
 		theme: MarkdownTheme,
 		defaultTextStyle?: DefaultTextStyle,
-		codeBlockIndent: number = 2,
+		codeBlockIndent: number = 0,
 	) {
 		this.#text = normalizeOsc8Terminators(text);
 		this.#paddingX = paddingX;

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -41,7 +41,6 @@ function isOsc66Line(line: string): boolean {
 	return line.includes(OSC66_LINE_PREFIX);
 }
 
-
 function normalizeHtmlEntitiesForTerminal(raw: string): string {
 	const parseCodePoint = (value: number): string => {
 		if (Number.isFinite(value) && value >= 0 && value <= 0x10ffff) {
@@ -2258,7 +2257,8 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 			case "paragraph": {
 				const displayMath = soleDisplayMath(token.tokens);
 				if (displayMath) {
-					for (const mathLine of latexToBlock(displayMath.text)) lines.push(renderedLine(this.#applyDefaultStyle(mathLine)));
+					for (const mathLine of latexToBlock(displayMath.text))
+						lines.push(renderedLine(this.#applyDefaultStyle(mathLine)));
 					if (nextTokenType && nextTokenType !== "list" && nextTokenType !== "space") lines.push(renderedLine(""));
 					break;
 				}
@@ -2283,7 +2283,13 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 					const ascii = this.#theme.resolveMermaidAscii(token.text, width);
 					if (ascii) {
 						for (const asciiLine of ascii.split("\n")) {
-							lines.push(renderedLine(visibleWidth(asciiLine) > width ? truncateToWidth(asciiLine, width, Ellipsis.Omit) : asciiLine));
+							lines.push(
+								renderedLine(
+									visibleWidth(asciiLine) > width
+										? truncateToWidth(asciiLine, width, Ellipsis.Omit)
+										: asciiLine,
+								),
+							);
 						}
 						if (nextTokenType && nextTokenType !== "space") {
 							lines.push(renderedLine(""));
@@ -2361,10 +2367,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 					}
 				}
 
-				while (
-					renderedQuoteLines.length > 0 &&
-					renderedQuoteLines[renderedQuoteLines.length - 1]!.text === ""
-				) {
+				while (renderedQuoteLines.length > 0 && renderedQuoteLines[renderedQuoteLines.length - 1]!.text === "") {
 					renderedQuoteLines.pop();
 				}
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -41,9 +41,6 @@ function isOsc66Line(line: string): boolean {
 	return line.includes(OSC66_LINE_PREFIX);
 }
 
-// Internal zero-width marker carried through list/blockquote renderers. It is
-// removed before output, along with every visual container prefix before it.
-const LITERAL_CODE_ROW_MARKER = "\0";
 
 function normalizeHtmlEntitiesForTerminal(raw: string): string {
 	const parseCodePoint = (value: number): string => {
@@ -840,6 +837,19 @@ const RENDER_CACHE_MAX = 256; // sane cap: ~256 distinct message × width combos
 const RENDER_CACHE_MAX_SIZE = 4 * 1024 * 1024;
 const RENDER_CACHE_MAX_ENTRY_SIZE = 256 * 1024;
 const EMPTY_RENDER_LINES: readonly string[] = [];
+
+interface RenderedLine {
+	text: string;
+	literalCode?: true;
+}
+
+interface RenderedListItemLine extends RenderedLine {
+	nested: boolean;
+}
+
+function renderedLine(text: string, literalCode?: boolean): RenderedLine {
+	return literalCode ? { text, literalCode: true } : { text };
+}
 
 interface RenderCacheEntry {
 	lines: readonly string[];
@@ -1862,7 +1872,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		rowOffset: number,
 		startingSourceOffset: number,
 	): string[] {
-		const wrappedLines: Array<{ text: string; unpadded: boolean }> = [];
+		const wrappedLines: RenderedLine[] = [];
 		let sourceOffset = startingSourceOffset;
 		for (let i = start; i < end; i++) {
 			const token = tokens[i];
@@ -1878,16 +1888,20 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				`offset:${sourceOffset}`,
 			);
 			const tokenLineOffsets = [0];
-			for (const line of renderedTokenLines) {
+			for (const renderedRow of renderedTokenLines) {
 				// Lists wrap while their structural prefixes are still available, so
 				// continuation rows retain the correct hanging indent. Re-wrapping the
 				// flattened rows here would discard that structure.
-				const unpadded = token.type === "code" && this.#codeBlockIndent === 0;
-				if (token.type === "list" || TERMINAL.isImageLine(line) || isOsc66Line(line)) {
-					wrappedLines.push({ text: line, unpadded });
+				if (token.type === "list" || TERMINAL.isImageLine(renderedRow.text) || isOsc66Line(renderedRow.text)) {
+					wrappedLines.push(renderedRow);
 				} else {
-					for (const wrappedLine of wrapTextWithAnsi(line, contentWidth)) {
-						wrappedLines.push({ text: wrappedLine, unpadded });
+					const wrappedRows = wrapTextWithAnsi(renderedRow.text, contentWidth);
+					if (wrappedRows.length === 1 && wrappedRows[0] === renderedRow.text) {
+						wrappedLines.push(renderedRow);
+					} else {
+						for (const wrappedLine of wrappedRows) {
+							wrappedLines.push(renderedLine(wrappedLine, renderedRow.literalCode));
+						}
 					}
 				}
 				tokenLineOffsets.push(wrappedLines.length - tokenWrappedRowStart);
@@ -1922,12 +1936,8 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		const contentLines: string[] = [];
 		let previousLineWasOsc66 = false;
 		for (const renderedLine of wrappedLines) {
-			const literalMarkerIndex = renderedLine.text.indexOf(LITERAL_CODE_ROW_MARKER);
-			const literalCodeRow = renderedLine.unpadded || literalMarkerIndex !== -1;
-			const line =
-				literalMarkerIndex !== -1
-					? renderedLine.text.slice(literalMarkerIndex + LITERAL_CODE_ROW_MARKER.length)
-					: renderedLine.text;
+			const literalCodeRow = renderedLine.literalCode === true;
+			const line = renderedLine.text;
 			// The first empty row after a scale>1 OSC 66 heading is structural:
 			// it reserves the lower cells occupied by the multicell glyphs. Do
 			// not pad or background-fill it, because real spaces on that row can
@@ -1981,9 +1991,9 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		return layouts;
 	}
 
-	#renderCodeBodyLines(token: Token, codeIndent: string): string[] {
-		const literalRowPrefix = this.#codeBlockIndent === 0 ? LITERAL_CODE_ROW_MARKER : codeIndent;
-		const bodyLines: string[] = [];
+	#renderCodeBodyLines(token: Token, codeIndent: string): RenderedLine[] {
+		const literalCode = this.#codeBlockIndent === 0;
+		const bodyLines: RenderedLine[] = [];
 		const tokenText = "text" in token && typeof token.text === "string" ? token.text : "";
 		const lang = "lang" in token && typeof token.lang === "string" ? token.lang : undefined;
 		const normalizedLang = lang?.toLowerCase();
@@ -1992,11 +2002,14 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 			!this.#renderingFrozenPrefix &&
 			this.#theme.highlightCode &&
 			(normalizedLang === "diff" || normalizedLang === "patch" || normalizedLang === "udiff");
+		const addBodyLine = (line: string): void => {
+			bodyLines.push(renderedLine(literalCode ? line : codeIndent + line, literalCode));
+		};
 
 		if (this.#theme.highlightCode && (!this.transientRenderCache || this.#renderingFrozenPrefix)) {
 			const highlightedLines = this.#theme.highlightCode(tokenText, lang);
 			for (const hlLine of highlightedLines) {
-				bodyLines.push(`${literalRowPrefix}${hlLine}`);
+				addBodyLine(hlLine);
 			}
 			return bodyLines;
 		}
@@ -2007,11 +2020,11 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 			if (closedFence || lineEnd >= 0) {
 				const completedText = closedFence ? tokenText : tokenText.slice(0, lineEnd);
 				for (const hlLine of this.#highlightStreamingDiffLines(completedText, lang)) {
-					bodyLines.push(`${literalRowPrefix}${hlLine}`);
+					addBodyLine(hlLine);
 				}
 				if (!closedFence) {
 					for (const codeLine of tokenText.slice(lineEnd + 1).split("\n")) {
-						bodyLines.push(`${literalRowPrefix}${this.#theme.codeBlock(codeLine)}`);
+						addBodyLine(this.#theme.codeBlock(codeLine));
 					}
 				}
 				return bodyLines;
@@ -2019,7 +2032,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		}
 
 		for (const codeLine of tokenText.split("\n")) {
-			bodyLines.push(`${literalRowPrefix}${this.#theme.codeBlock(codeLine)}`);
+			addBodyLine(this.#theme.codeBlock(codeLine));
 		}
 		return bodyLines;
 	}
@@ -2198,14 +2211,14 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		nextTokenType?: string,
 		styleContext?: InlineStyleContext,
 		tokenKey = "root",
-	): string[] {
-		const lines: string[] = [];
+	): RenderedLine[] {
+		const lines: RenderedLine[] = [];
 
 		// Display math block (own-line `$$…$$` / `\[…\]`): stack `\frac` vertically
 		// and keep `\\` row breaks, so fractions and matrices span multiple lines.
 		if (isMathToken(token)) {
-			for (const mathLine of latexToBlock(token.text)) lines.push(this.#applyDefaultStyle(mathLine));
-			if (nextTokenType && nextTokenType !== "space") lines.push("");
+			for (const mathLine of latexToBlock(token.text)) lines.push(renderedLine(this.#applyDefaultStyle(mathLine)));
+			if (nextTokenType && nextTokenType !== "space") lines.push(renderedLine(""));
 			return lines;
 		}
 
@@ -2220,10 +2233,10 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 					const plainWidth = visibleWidth(headingPlainText);
 					if (plainWidth > 0 && 2 * plainWidth <= width) {
 						const sizedHeading = encodeTextSizedHeading(headingPlainText, 2);
-						lines.push(this.#theme.heading(this.#theme.bold(this.#theme.underline(sizedHeading))));
-						lines.push(""); // reserve the heading's second visual row
+						lines.push(renderedLine(this.#theme.heading(this.#theme.bold(this.#theme.underline(sizedHeading)))));
+						lines.push(renderedLine("")); // reserve the heading's second visual row
 						if (nextTokenType && nextTokenType !== "space") {
-							lines.push(""); // Add spacing after headings (unless space token follows)
+							lines.push(renderedLine("")); // Add spacing after headings (unless space token follows)
 						}
 						break;
 					}
@@ -2235,9 +2248,9 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				} else {
 					styledHeading = this.#theme.heading(this.#theme.bold(headingPrefix + headingText));
 				}
-				lines.push(styledHeading);
+				lines.push(renderedLine(styledHeading));
 				if (nextTokenType && nextTokenType !== "space") {
-					lines.push(""); // Add spacing after headings (unless space token follows)
+					lines.push(renderedLine("")); // Add spacing after headings (unless space token follows)
 				}
 				break;
 			}
@@ -2245,15 +2258,17 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 			case "paragraph": {
 				const displayMath = soleDisplayMath(token.tokens);
 				if (displayMath) {
-					for (const mathLine of latexToBlock(displayMath.text)) lines.push(this.#applyDefaultStyle(mathLine));
-					if (nextTokenType && nextTokenType !== "list" && nextTokenType !== "space") lines.push("");
+					for (const mathLine of latexToBlock(displayMath.text)) lines.push(renderedLine(this.#applyDefaultStyle(mathLine)));
+					if (nextTokenType && nextTokenType !== "list" && nextTokenType !== "space") lines.push(renderedLine(""));
 					break;
 				}
 				const paragraphText = this.#renderInlineTokens(token.tokens || [], styleContext);
-				lines.push(...(hangWrapTreeGuideLines(paragraphText, width) ?? [paragraphText]));
+				for (const paragraphLine of hangWrapTreeGuideLines(paragraphText, width) ?? [paragraphText]) {
+					lines.push(renderedLine(paragraphLine));
+				}
 				// Don't add spacing if next token is space or list
 				if (nextTokenType && nextTokenType !== "list" && nextTokenType !== "space") {
-					lines.push("");
+					lines.push(renderedLine(""));
 				}
 				break;
 			}
@@ -2268,25 +2283,23 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 					const ascii = this.#theme.resolveMermaidAscii(token.text, width);
 					if (ascii) {
 						for (const asciiLine of ascii.split("\n")) {
-							lines.push(
-								visibleWidth(asciiLine) > width ? truncateToWidth(asciiLine, width, Ellipsis.Omit) : asciiLine,
-							);
+							lines.push(renderedLine(visibleWidth(asciiLine) > width ? truncateToWidth(asciiLine, width, Ellipsis.Omit) : asciiLine));
 						}
 						if (nextTokenType && nextTokenType !== "space") {
-							lines.push("");
+							lines.push(renderedLine(""));
 						}
 						break;
 					}
 				}
 
 				const codeIndent = padding(this.#codeBlockIndent);
-				lines.push(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`));
+				lines.push(renderedLine(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`)));
 				for (const bodyLine of this.#renderCodeBodyLines(token, codeIndent)) {
 					lines.push(bodyLine);
 				}
-				lines.push(this.#theme.codeBlockBorder("```"));
+				lines.push(renderedLine(this.#theme.codeBlockBorder("```")));
 				if (nextTokenType && nextTokenType !== "space") {
-					lines.push(""); // Add spacing after code blocks (unless space token follows)
+					lines.push(renderedLine("")); // Add spacing after code blocks (unless space token follows)
 				}
 				break;
 			}
@@ -2301,7 +2314,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 
 			case "table": {
 				const tableLines = this.#renderTable(token as TableToken, width, nextTokenType, styleContext, tokenKey);
-				lines.push(...tableLines);
+				for (const tableLine of tableLines) lines.push(renderedLine(tableLine));
 				break;
 			}
 
@@ -2312,7 +2325,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				};
 				const quoteContentWidth = Math.max(1, width - 2);
 				const quoteTokens = token.tokens || [];
-				const renderedQuoteLines: string[] = [];
+				const renderedQuoteLines: RenderedLine[] = [];
 				const blockquoteSpecStart = this.#activeTableRenderSpecs?.length ?? 0;
 
 				for (let i = 0; i < quoteTokens.length; i++) {
@@ -2348,7 +2361,10 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 					}
 				}
 
-				while (renderedQuoteLines.length > 0 && renderedQuoteLines[renderedQuoteLines.length - 1] === "") {
+				while (
+					renderedQuoteLines.length > 0 &&
+					renderedQuoteLines[renderedQuoteLines.length - 1]!.text === ""
+				) {
 					renderedQuoteLines.pop();
 				}
 
@@ -2367,16 +2383,16 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				}
 				lines.push(...borderedQuoteLines);
 				if (nextTokenType && nextTokenType !== "space") {
-					lines.push(""); // Add spacing after blockquotes (unless space token follows)
+					lines.push(renderedLine("")); // Add spacing after blockquotes (unless space token follows)
 				}
 				break;
 			}
 
 			case "hr": {
 				const raw = "raw" in token && typeof token.raw === "string" ? token.raw.trim() : "";
-				lines.push(this.#renderHrLine(width, raw[0] || ""));
+				lines.push(renderedLine(this.#renderHrLine(width, raw[0] || "")));
 				if (nextTokenType && nextTokenType !== "space") {
-					lines.push(""); // Add spacing after horizontal rules (unless space token follows)
+					lines.push(renderedLine("")); // Add spacing after horizontal rules (unless space token follows)
 				}
 				break;
 			}
@@ -2389,13 +2405,13 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 
 			case "space":
 				// Space tokens represent blank lines in markdown
-				lines.push("");
+				lines.push(renderedLine(""));
 				break;
 
 			default:
 				// Handle any other token types as plain text
 				if ("text" in token && typeof token.text === "string") {
-					lines.push(token.text);
+					lines.push(renderedLine(token.text));
 				}
 		}
 
@@ -2412,7 +2428,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 	 * Wrap already-rendered lines in the blockquote border and quote styling.
 	 * `width` is the full content width; the border reserves two cells.
 	 */
-	#applyQuoteBorder(renderedLines: string[], width: number, sourceRowOffsets?: number[]): string[] {
+	#applyQuoteBorder(renderedLines: RenderedLine[], width: number, sourceRowOffsets?: number[]): RenderedLine[] {
 		const quoteStyle = (text: string) => this.#theme.quote(this.#theme.italic(text));
 		const quoteStylePrefix = this.#getStylePrefix(quoteStyle);
 		const applyQuoteStyle = (line: string): string => {
@@ -2423,12 +2439,23 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 			return quoteStyle(lineWithReappliedStyle);
 		};
 		const quoteContentWidth = Math.max(1, width - 2);
-		const lines: string[] = [];
+		const lines: RenderedLine[] = [];
 		sourceRowOffsets?.push(0);
 		for (const quoteLine of renderedLines) {
-			const styledLine = applyQuoteStyle(quoteLine);
-			for (const wrappedLine of wrapTextWithAnsi(styledLine, quoteContentWidth)) {
-				lines.push(this.#theme.quoteBorder(`${this.#theme.symbols.quoteBorder} `) + wrappedLine);
+			if (quoteLine.literalCode) {
+				const wrappedLiteralRows = wrapTextWithAnsi(quoteLine.text, quoteContentWidth);
+				if (wrappedLiteralRows.length === 0) {
+					lines.push(renderedLine("", true));
+				} else {
+					for (const wrappedLine of wrappedLiteralRows) {
+						lines.push(renderedLine(wrappedLine, true));
+					}
+				}
+			} else {
+				const styledLine = applyQuoteStyle(quoteLine.text);
+				for (const wrappedLine of wrapTextWithAnsi(styledLine, quoteContentWidth)) {
+					lines.push(renderedLine(this.#theme.quoteBorder(`${this.#theme.symbols.quoteBorder} `) + wrappedLine));
+				}
 			}
 			sourceRowOffsets?.push(lines.length);
 		}
@@ -2441,8 +2468,8 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 	 * quote styling; the remaining markup is normalized to terminal text (entities
 	 * decoded, `<code>` themed, lists/`<br>`/`<p>` laid out).
 	 */
-	#renderHtmlBlock(raw: string, width: number): string[] {
-		const lines: string[] = [];
+	#renderHtmlBlock(raw: string, width: number): RenderedLine[] {
+		const lines: RenderedLine[] = [];
 		const state = createHtmlNormalizationState();
 		const codeHook = (text: string): string => this.#theme.code(text) + this.#getDefaultStylePrefix();
 		const flushText = (chunk: string): void => {
@@ -2450,7 +2477,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 			if (cleaned.trim() === "") return;
 			for (const line of splitTerminalLines(cleaned)) {
 				const trimmed = line.trimEnd();
-				lines.push(trimmed.trim() === "" ? "" : this.#applyDefaultStyle(trimmed));
+				lines.push(renderedLine(trimmed.trim() === "" ? "" : this.#applyDefaultStyle(trimmed)));
 			}
 		};
 		let lastIndex = 0;
@@ -2461,7 +2488,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 			if (match[1] !== undefined) {
 				lines.push(...this.#renderHtmlBlockquote(match[1], width));
 			} else {
-				lines.push(this.#renderHrLine(width));
+				lines.push(renderedLine(this.#renderHrLine(width)));
 			}
 		}
 		flushText(raw.slice(lastIndex));
@@ -2469,10 +2496,10 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 	}
 
 	/** Render the inner content of an HTML `<blockquote>` with quote styling. */
-	#renderHtmlBlockquote(inner: string, width: number): string[] {
+	#renderHtmlBlockquote(inner: string, width: number): RenderedLine[] {
 		const cleaned = normalizeHtmlForTerminal(inner, createHtmlNormalizationState(), text => this.#theme.code(text));
-		const innerLines = splitTerminalLines(cleaned).map(line => line.trimEnd());
-		while (innerLines.length > 0 && innerLines[innerLines.length - 1] === "") innerLines.pop();
+		const innerLines = splitTerminalLines(cleaned).map(line => renderedLine(line.trimEnd()));
+		while (innerLines.length > 0 && innerLines[innerLines.length - 1].text === "") innerLines.pop();
 		return this.#applyQuoteBorder(innerLines, width);
 	}
 
@@ -2608,27 +2635,41 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 	/**
 	 * Render a list with proper nesting support
 	 */
-	#renderList(token: ListToken, depth: number, width: number, styleContext?: InlineStyleContext): string[] {
-		const lines: string[] = [];
+	#renderList(token: ListToken, depth: number, width: number, styleContext?: InlineStyleContext): RenderedLine[] {
+		const lines: RenderedLine[] = [];
 		const indent = "  ".repeat(depth);
 		// Use the list's start property (defaults to 1 for ordered lists)
 		const startNumber = token.start ?? 1;
-		const pushWrapped = (text: string, firstPrefix: string, continuationPrefix: string): void => {
+		const pushWrapped = (line: RenderedLine, firstPrefix: string, continuationPrefix: string): void => {
+			if (line.literalCode) {
+				const wrappedLiteralRows = wrapTextWithAnsi(line.text, Math.max(1, width));
+				if (wrappedLiteralRows.length === 0) {
+					lines.push(renderedLine("", true));
+				} else {
+					for (const wrappedLine of wrappedLiteralRows) {
+						lines.push(renderedLine(wrappedLine, true));
+					}
+				}
+				return;
+			}
+
 			const prefixWidth = visibleWidth(firstPrefix);
 			if (prefixWidth >= width) {
-				lines.push(truncateToWidth(firstPrefix, width, Ellipsis.Omit));
-				lines.push(...wrapTextWithAnsi(text, Math.max(1, width)));
+				lines.push(renderedLine(truncateToWidth(firstPrefix, width, Ellipsis.Omit)));
+				for (const wrappedLine of wrapTextWithAnsi(line.text, Math.max(1, width))) {
+					lines.push(renderedLine(wrappedLine));
+				}
 				return;
 			}
 			const bodyWidth = width - prefixWidth;
-			const wrapped = wrapTextWithAnsi(text, bodyWidth);
+			const wrapped = wrapTextWithAnsi(line.text, bodyWidth);
 			if (wrapped.length === 0) {
-				lines.push(firstPrefix);
+				lines.push(renderedLine(firstPrefix));
 				return;
 			}
-			lines.push(firstPrefix + wrapped[0]);
+			lines.push(renderedLine(firstPrefix + wrapped[0]));
 			for (let lineIndex = 1; lineIndex < wrapped.length; lineIndex++) {
-				lines.push(continuationPrefix + wrapped[lineIndex]);
+				lines.push(renderedLine(continuationPrefix + wrapped[lineIndex]));
 			}
 		};
 
@@ -2647,21 +2688,21 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 			if (itemLines.length > 0) {
 				const firstLine = itemLines[0]!;
 				if (firstLine.nested) {
-					lines.push(firstLine.text);
+					lines.push(firstLine);
 				} else {
-					pushWrapped(firstLine.text, firstPrefix, continuationIndent);
+					pushWrapped(firstLine, firstPrefix, continuationIndent);
 				}
 
 				for (let j = 1; j < itemLines.length; j++) {
 					const line = itemLines[j]!;
 					if (line.nested) {
-						lines.push(line.text);
+						lines.push(line);
 					} else {
-						pushWrapped(line.text, continuationIndent, continuationIndent);
+						pushWrapped(line, continuationIndent, continuationIndent);
 					}
 				}
 			} else {
-				lines.push(firstPrefix);
+				lines.push(renderedLine(firstPrefix));
 			}
 		}
 
@@ -2679,8 +2720,8 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		parentDepth: number,
 		width: number,
 		styleContext?: InlineStyleContext,
-	): Array<{ text: string; nested: boolean }> {
-		const lines: Array<{ text: string; nested: boolean }> = [];
+	): RenderedListItemLine[] {
+		const lines: RenderedListItemLine[] = [];
 
 		for (const token of tokens) {
 			if (token.type === "list") {
@@ -2688,7 +2729,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				// These lines carry their own indent, so tag them for pass-through
 				const nestedLines = this.#renderList(token as ListToken, parentDepth + 1, width, styleContext);
 				for (const nestedLine of nestedLines) {
-					lines.push({ text: nestedLine, nested: true });
+					lines.push({ ...nestedLine, nested: true });
 				}
 			} else if (token.type === "text") {
 				// Text content (may have inline tokens, or a sole display-math token)
@@ -2719,7 +2760,7 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 				const codeIndent = padding(this.#codeBlockIndent);
 				lines.push({ text: this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`), nested: false });
 				for (const bodyLine of this.#renderCodeBodyLines(token, codeIndent)) {
-					lines.push({ text: bodyLine, nested: false });
+					lines.push({ ...bodyLine, nested: false });
 				}
 				lines.push({ text: this.#theme.codeBlockBorder("```"), nested: false });
 			} else if (isMathToken(token)) {

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -969,25 +969,18 @@ more text`,
 			const markdown = new Markdown("```sh\ncat <<'EOF'\nEOF\n```", 1, 0, defaultMarkdownTheme, undefined, 0);
 			markdown.setIgnoreTight(true);
 
-			const plainLines = markdown
-				.render(80)
-				.map(line => stripVTControlCharacters(line).trimEnd());
+			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
 
 			expect(plainLines).toEqual(["```sh", "cat <<'EOF'", "EOF", "```"]);
 		});
 
 		it("keeps opt-in fenced code rows literal inside containers", () => {
-			const cases = [
-				"- shell:\n\n  ```sh\n  cat <<'EOF'\n  EOF\n  ```",
-				"> ```sh\n> cat <<'EOF'\n> EOF\n> ```",
-			];
+			const cases = ["- shell:\n\n  ```sh\n  cat <<'EOF'\n  EOF\n  ```", "> ```sh\n> cat <<'EOF'\n> EOF\n> ```"];
 
 			for (const text of cases) {
 				const markdown = new Markdown(text, 1, 0, defaultMarkdownTheme, undefined, 0);
 				markdown.setIgnoreTight(true);
-				const plainLines = markdown
-					.render(80)
-					.map(line => stripVTControlCharacters(line).trimEnd());
+				const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
 
 				expect(plainLines).toContain("cat <<'EOF'");
 				expect(plainLines).toContain("EOF");

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -954,7 +954,7 @@ code block
 
 more text`,
 			];
-			const expectedLines = ["hello this is text", "", "```", "code block", "```", "", "more text"];
+			const expectedLines = ["hello this is text", "", "```", "  code block", "```", "", "more text"];
 
 			for (const text of cases) {
 				const markdown = new Markdown(text, 0, 0, defaultMarkdownTheme);
@@ -963,6 +963,17 @@ more text`,
 
 				expect(plainLines).toEqual(expectedLines);
 			}
+		});
+
+		it("keeps opt-in top-level fenced code rows at column zero", () => {
+			const markdown = new Markdown("```sh\ncat <<'EOF'\nEOF\n```", 1, 0, defaultMarkdownTheme, undefined, 0);
+			markdown.setIgnoreTight(true);
+
+			const plainLines = markdown
+				.render(80)
+				.map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines).toEqual(["```sh", "cat <<'EOF'", "EOF", "```"]);
 		});
 
 		it("should not add a trailing blank line when code block is the last rendered block", () => {
@@ -1011,7 +1022,7 @@ more text`,
 			});
 
 			expect(seenSources).toEqual([invalidSource]);
-			expect(plainLines).toEqual(["```mermaid", "flowchart TD", "  A --", "```"]);
+			expect(plainLines).toEqual(["```mermaid", "  flowchart TD", "    A --", "```"]);
 		});
 	});
 

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -965,26 +965,46 @@ more text`,
 			}
 		});
 
-		it("keeps opt-in top-level fenced code rows at column zero", () => {
+		it("keeps coding-agent's padded fenced code body at column zero", () => {
 			const markdown = new Markdown("```sh\ncat <<'EOF'\nEOF\n```", 1, 0, defaultMarkdownTheme, undefined, 0);
-			markdown.setIgnoreTight(true);
 
 			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
 
-			expect(plainLines).toEqual(["```sh", "cat <<'EOF'", "EOF", "```"]);
+			expect(plainLines).toEqual([" ```sh", "cat <<'EOF'", "EOF", " ```"]);
 		});
 
-		it("keeps opt-in fenced code rows literal inside containers", () => {
-			const cases = ["- shell:\n\n  ```sh\n  cat <<'EOF'\n  EOF\n  ```", "> ```sh\n> cat <<'EOF'\n> EOF\n> ```"];
+		it("keeps literal code body rows unprefixed through nested container wrapping", () => {
+			const longCodeLine = "x".repeat(24);
+			const cases = [
+				`- shell:
+
+  \`\`\`sh
+  ${longCodeLine}
+  EOF
+  \`\`\``,
+				`> \`\`\`sh
+> ${longCodeLine}
+> EOF
+> \`\`\``,
+			];
 
 			for (const text of cases) {
 				const markdown = new Markdown(text, 1, 0, defaultMarkdownTheme, undefined, 0);
-				markdown.setIgnoreTight(true);
-				const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+				const plainLines = markdown.render(12).map(line => stripVTControlCharacters(line).trimEnd());
+				const literalRows = plainLines.filter(line => line.includes("x") || line === "EOF");
 
-				expect(plainLines).toContain("cat <<'EOF'");
-				expect(plainLines).toContain("EOF");
+				expect(literalRows.join("")).toBe(`${longCodeLine}EOF`);
+				expect(literalRows.length).toBeGreaterThan(2);
+				expect(literalRows.every(line => line.startsWith("x") || line === "EOF")).toBe(true);
 			}
+		});
+
+		it("keeps ordinary prose NUL bytes as ordinary padded text", () => {
+			const markdown = new Markdown("before\0after", 1, 0, defaultMarkdownTheme);
+
+			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines).toEqual([" before\0after"]);
 		});
 
 		it("should not add a trailing blank line when code block is the last rendered block", () => {
@@ -1020,6 +1040,21 @@ more text`,
 			expect(seenSources).toEqual([mermaidSource]);
 			expect(plainLines).toEqual(["Start", "  |", "Stop"]);
 			expect(plainLines.some(line => line.includes("```mermaid"))).toBeFalsy();
+		});
+
+		it("keeps resolved Mermaid art inside the coding-agent margin", () => {
+			const markdown = new Markdown(
+				"```mermaid\nflowchart TD\n```",
+				1,
+				0,
+				{ ...defaultMarkdownTheme, resolveMermaidAscii: () => "Start\n  |\nStop" },
+				undefined,
+				0,
+			);
+
+			const plainLines = markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines).toEqual([" Start", "   |", " Stop"]);
 		});
 
 		it("falls back to the original fenced code block when mermaid resolution returns null", () => {

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -954,7 +954,7 @@ code block
 
 more text`,
 			];
-			const expectedLines = ["hello this is text", "", "```", "  code block", "```", "", "more text"];
+			const expectedLines = ["hello this is text", "", "```", "code block", "```", "", "more text"];
 
 			for (const text of cases) {
 				const markdown = new Markdown(text, 0, 0, defaultMarkdownTheme);
@@ -1011,7 +1011,7 @@ more text`,
 			});
 
 			expect(seenSources).toEqual([invalidSource]);
-			expect(plainLines).toEqual(["```mermaid", "  flowchart TD", "    A --", "```"]);
+			expect(plainLines).toEqual(["```mermaid", "flowchart TD", "  A --", "```"]);
 		});
 	});
 

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -976,6 +976,24 @@ more text`,
 			expect(plainLines).toEqual(["```sh", "cat <<'EOF'", "EOF", "```"]);
 		});
 
+		it("keeps opt-in fenced code rows literal inside containers", () => {
+			const cases = [
+				"- shell:\n\n  ```sh\n  cat <<'EOF'\n  EOF\n  ```",
+				"> ```sh\n> cat <<'EOF'\n> EOF\n> ```",
+			];
+
+			for (const text of cases) {
+				const markdown = new Markdown(text, 1, 0, defaultMarkdownTheme, undefined, 0);
+				markdown.setIgnoreTight(true);
+				const plainLines = markdown
+					.render(80)
+					.map(line => stripVTControlCharacters(line).trimEnd());
+
+				expect(plainLines).toContain("cat <<'EOF'");
+				expect(plainLines).toContain("EOF");
+			}
+		});
+
 		it("should not add a trailing blank line when code block is the last rendered block", () => {
 			const cases = ["```js\nconst hello = 'world';\n```", "hello world\n\n```js\nconst hello = 'world';\n```"];
 


### PR DESCRIPTION
## Summary
- render fenced code bodies without implicit leading indentation
- preserve exact pasted heredoc terminators when code is selected from the terminal
- update fenced-code and Mermaid fallback expectations

## Test
- `bun test packages/tui/test/markdown.test.ts`