### PR TITLE
test(coding-agent): avoid MCP startup race

### DIFF
--- a/packages/coding-agent/test/mcp-manager-notification-listeners.test.ts
+++ b/packages/coding-agent/test/mcp-manager-notification-listeners.test.ts
@@ -71,8 +71,7 @@ describe("MCPManager notification listeners", () => {
 		expect(typeof unsubscribe).toBe("function");
 
 		try {
-			const result = await manager.connectServers({ alpha: serverConfig() }, {});
-			expect(result.connectedServers).toContain("alpha");
+			await manager.connectServers({ alpha: serverConfig() }, {});
 
 			// Await both the known list_changed and the server-custom frame
 			// independently. Arrival order across the two isn't guaranteed


### PR DESCRIPTION
## Summary
- regenerate `bun.lock` with repository-pinned Bun 1.3.14 so CI can install dependencies
- stop asserting the bounded `connectServers()` startup snapshot in the notification delivery test
- retain assertions for both notification frames, the behavior under test

## Test
- `bun install --frozen-lockfile`
- covered by `ci:test:coding-agent:runtime`