### PR TITLE
fix: scope discovery provider toggles to the discovery namespace

### DIFF
--- a/docs/context-files.md
+++ b/docs/context-files.md
@@ -217,6 +217,8 @@ disabledProviders:
 
 A scoped entry applies when the cwd equals the configured path or sits beneath it; `~` expands to home. Bare string entries apply everywhere.
 
+Toggling a provider from `/extensions` or the settings selector edits only that provider's own entry in your global config. Scoped rules, entries for other providers, and anything set in a project config are left exactly as you wrote them.
+
 Remember that higher-precedence settings layers **replace** array settings rather than appending to them. If your global config disables `claude` but a project config sets `disabledProviders: [github]`, then inside that project Claude discovery is re-enabled and only GitHub is disabled. See [Settings](./settings.md) for the full layer precedence, merge rules, and path-scoped array details.
 
 ## Troubleshooting

--- a/docs/context-files.md
+++ b/docs/context-files.md
@@ -189,10 +189,21 @@ disabledProviders:
 
 | Id kind | Examples | Effect when listed |
 |---|---|---|
-| Discovery provider ids | `native`, `claude`, `codex`, `gemini`, `opencode`, `github`, `agents`, `agents-md` | The entire config source is removed — not just its context files, but also any MCP servers, slash commands, skills, hooks, tools, prompts, and settings it would have contributed. |
+| Discovery provider ids | `native`, `agents`, `agents-md`, `claude`, `claude-plugins`, `cline`, `codex`, `cursor`, `gemini`, `github`, `mcp-json`, `omp-plugins`, `opencode`, `ssh-json`, `vscode`, `windsurf` | The entire config source is removed — not just its context files, but also any MCP servers, slash commands, skills, hooks, tools, prompts, and settings it would have contributed. |
 | Model provider ids | `anthropic`, `openai`, `google`, `groq`, `ollama`, `openrouter` | The model backend is removed from selection even when its credentials are present. See [Providers](./providers.md). |
 
-Ids are exact and the two namespaces do not collide by accident: `google` disables the Google model backend, while `gemini` disables the Gemini CLI discovery files. Disabling a discovery provider is heavier than it looks — disabling `claude`, for instance, also drops Claude-discovered MCP servers, commands, skills, hooks, tools, and settings, not only `CLAUDE.md`.
+Ids are exact, and the two namespaces mostly stay clear of each other: `google` disables the Google model backend, while `gemini` disables the Gemini CLI discovery files. `cursor` is the exception — it names both the Cursor discovery provider and the Cursor model backend, so an unqualified entry disables both.
+
+Prefix an entry with `discovery:` to scope it to config discovery and leave a same-named model backend alone:
+
+```yaml
+disabledProviders:
+  - discovery:cursor  # ignore .cursor rules/MCP, keep the Cursor models in /model
+```
+
+Toggling a provider off in `/extensions` or the settings selector writes this qualified form. An unqualified `cursor` keeps its documented meaning and disables both.
+
+Disabling a discovery provider is heavier than it looks — disabling `claude`, for instance, also drops Claude-discovered MCP servers, commands, skills, hooks, tools, and settings, not only `CLAUDE.md`.
 
 Only `enabledModels` and `disabledProviders` support **path-scoped** entries, so you can vary provider availability per subtree:
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed turning off Cursor config discovery also removing the Cursor model backend from `/model` and `/login`. `disabledProviders` is one id namespace shared by discovery providers and model providers, and `cursor` is the only id registered as both, so the unqualified entry written by `/extensions` and the settings selector matched the model registry too. Discovery toggles now persist `discovery:<id>`, which the model registry does not match; unqualified entries keep disabling both ([#7066](https://github.com/can1357/oh-my-pi/pull/7066) by [@Gy-Hu](https://github.com/Gy-Hu)).
+- Fixed a provider toggle rewriting `disabledProviders` entries it does not own. The toggle persisted the value of `Settings.get()`, which resolves path-scoped rules against the current cwd and merges the project layer, into the global config: `{ paths, providers }` rules collapsed into plain ids, rules scoped to other directories were dropped, and a project-local disable was promoted to a global one. Toggles now edit the raw global array and leave every other entry untouched ([#7066](https://github.com/can1357/oh-my-pi/pull/7066) by [@Gy-Hu](https://github.com/Gy-Hu)).
 
 ## [17.2.0] - 2026-07-30
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed turning off Cursor config discovery also removing the Cursor model backend from `/model` and `/login`. `disabledProviders` is one id namespace shared by discovery providers and model providers, and `cursor` is the only id registered as both, so the unqualified entry written by `/extensions` and the settings selector matched the model registry too. Discovery toggles now persist `discovery:<id>`, which the model registry does not match; unqualified entries keep disabling both ([#PRNUM](https://github.com/can1357/oh-my-pi/pull/PRNUM) by [@Gy-Hu](https://github.com/Gy-Hu)).
+
 ## [17.2.0] - 2026-07-30
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed turning off Cursor config discovery also removing the Cursor model backend from `/model` and `/login`. `disabledProviders` is one id namespace shared by discovery providers and model providers, and `cursor` is the only id registered as both, so the unqualified entry written by `/extensions` and the settings selector matched the model registry too. Discovery toggles now persist `discovery:<id>`, which the model registry does not match; unqualified entries keep disabling both ([#PRNUM](https://github.com/can1357/oh-my-pi/pull/PRNUM) by [@Gy-Hu](https://github.com/Gy-Hu)).
+- Fixed turning off Cursor config discovery also removing the Cursor model backend from `/model` and `/login`. `disabledProviders` is one id namespace shared by discovery providers and model providers, and `cursor` is the only id registered as both, so the unqualified entry written by `/extensions` and the settings selector matched the model registry too. Discovery toggles now persist `discovery:<id>`, which the model registry does not match; unqualified entries keep disabling both ([#7066](https://github.com/can1357/oh-my-pi/pull/7066) by [@Gy-Hu](https://github.com/Gy-Hu)).
 
 ## [17.2.0] - 2026-07-30
 

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -326,7 +326,12 @@ export function initializeWithSettings(activeSettings: Settings): void {
 function editPersistedEntries(edit: (entries: unknown[]) => unknown[]): void {
 	if (!settings) return;
 	const raw = settings.getGlobalRaw("disabledProviders");
-	const next = edit(Array.isArray(raw) ? [...raw] : []);
+	const current = Array.isArray(raw) ? raw : [];
+	const next = edit([...current]);
+	// A toggle that changes nothing must not queue a save or fire a change event:
+	// re-disabling an already-listed provider, or enabling one that only a project
+	// config disables, leaves this layer's entries exactly as they were.
+	if (next.length === current.length && next.every((entry, index) => entry === current[index])) return;
 	settings.set("disabledProviders", next as string[]);
 }
 

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -317,7 +317,19 @@ export async function loadCapability<T>(
  */
 export function initializeWithSettings(activeSettings: Settings): void {
 	settings = activeSettings;
-	// Load disabled providers from settings
+	syncDisabledFromSettings();
+}
+
+/**
+ * Re-derive the disabled set from the settings that are actually in effect.
+ *
+ * Run after every toggle so the in-memory state cannot disagree with what a
+ * restart would produce. A provider disabled by a path-scoped rule or by a
+ * project config has no entry this registry can drop, and reporting it as
+ * enabled would load it for this process only, until the next reload.
+ */
+function syncDisabledFromSettings(): void {
+	if (!settings) return;
 	disabledProviders.clear();
 	for (const entry of settings.get("disabledProviders")) {
 		disabledProviders.add(unqualify(entry));
@@ -353,6 +365,7 @@ export function disableProvider(providerId: string): void {
 	editPersistedEntries(entries =>
 		entries.some(entry => entryNames(entry, providerId)) ? entries : [...entries, qualify(providerId)],
 	);
+	syncDisabledFromSettings();
 }
 
 /**
@@ -365,6 +378,7 @@ export function disableProvider(providerId: string): void {
 export function enableProvider(providerId: string): void {
 	disabledProviders.delete(providerId);
 	editPersistedEntries(entries => entries.filter(entry => !entryNames(entry, providerId)));
+	syncDisabledFromSettings();
 }
 
 /**
@@ -393,6 +407,7 @@ export function setDisabledProviders(providerIds: string[]): void {
 	// no discovery provider — a model-only disable such as `anthropic` — stay as
 	// authored, since replacing the discovery set says nothing about them.
 	editPersistedEntries(entries => [...entries.filter(entry => !ownsEntry(entry)), ...providerIds.map(qualify)]);
+	syncDisabledFromSettings();
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -36,8 +36,36 @@ const providerCapabilities = new Map<string, Set<string>>();
 /** Provider display metadata (shared across capabilities) */
 const providerMeta = new Map<string, { displayName: string; description: string }>();
 
-/** Disabled providers (by ID) */
+/**
+ * Scope qualifier for `disabledProviders` entries owned by this registry.
+ *
+ * The setting is one array shared with the model registry
+ * (`config/model-registry.ts`), matched there against model provider ids. An
+ * unqualified entry therefore disables both subsystems, and `cursor` is the one
+ * id registered as a discovery provider and a model provider, so disabling
+ * Cursor config discovery also dropped the Cursor models from `/model` and
+ * `/login`. Toggles made through this API persist the qualified form, which the
+ * model registry does not match.
+ */
+const DISCOVERY_SCOPE_PREFIX = "discovery:";
+
+/**
+ * Raw `disabledProviders` entries as persisted. Kept verbatim so writing a
+ * discovery toggle cannot drop an entry that belongs to another subsystem.
+ */
+let disabledEntries: string[] = [];
+
+/** Disabled providers (by ID), resolved from `disabledEntries` */
 const disabledProviders = new Set<string>();
+
+function syncDisabledProviders(): void {
+	disabledProviders.clear();
+	for (const entry of disabledEntries) {
+		disabledProviders.add(
+			entry.startsWith(DISCOVERY_SCOPE_PREFIX) ? entry.slice(DISCOVERY_SCOPE_PREFIX.length) : entry,
+		);
+	}
+}
 
 /** Settings manager for persistence (if set) */
 let settings: Settings | null = null;
@@ -282,11 +310,8 @@ export async function loadCapability<T>(
 export function initializeWithSettings(activeSettings: Settings): void {
 	settings = activeSettings;
 	// Load disabled providers from settings
-	const disabled = settings.get("disabledProviders");
-	disabledProviders.clear();
-	for (const id of disabled) {
-		disabledProviders.add(id);
-	}
+	disabledEntries = [...settings.get("disabledProviders")];
+	syncDisabledProviders();
 }
 
 /**
@@ -294,7 +319,7 @@ export function initializeWithSettings(activeSettings: Settings): void {
  */
 function persistDisabledProviders(): void {
 	if (settings) {
-		settings.set("disabledProviders", Array.from(disabledProviders));
+		settings.set("disabledProviders", [...disabledEntries]);
 	}
 }
 
@@ -302,15 +327,23 @@ function persistDisabledProviders(): void {
  * Disable a provider globally (across all capabilities).
  */
 export function disableProvider(providerId: string): void {
-	disabledProviders.add(providerId);
+	if (disabledProviders.has(providerId)) return;
+	disabledEntries.push(`${DISCOVERY_SCOPE_PREFIX}${providerId}`);
+	syncDisabledProviders();
 	persistDisabledProviders();
 }
 
 /**
  * Enable a previously disabled provider.
+ *
+ * Drops the qualified and the unqualified entry: an unqualified one carries no
+ * evidence that the model registry was the intended target, so rewriting it to
+ * keep that half disabled would disable a backend the user never named.
  */
 export function enableProvider(providerId: string): void {
-	disabledProviders.delete(providerId);
+	const qualified = `${DISCOVERY_SCOPE_PREFIX}${providerId}`;
+	disabledEntries = disabledEntries.filter(entry => entry !== providerId && entry !== qualified);
+	syncDisabledProviders();
 	persistDisabledProviders();
 }
 
@@ -332,10 +365,8 @@ export function getDisabledProviders(): string[] {
  * Set disabled providers from a list (replaces current set).
  */
 export function setDisabledProviders(providerIds: string[]): void {
-	disabledProviders.clear();
-	for (const id of providerIds) {
-		disabledProviders.add(id);
-	}
+	disabledEntries = [...providerIds];
+	syncDisabledProviders();
 	persistDisabledProviders();
 }
 

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -49,22 +49,20 @@ const providerMeta = new Map<string, { displayName: string; description: string 
  */
 const DISCOVERY_SCOPE_PREFIX = "discovery:";
 
-/**
- * Raw `disabledProviders` entries as persisted. Kept verbatim so writing a
- * discovery toggle cannot drop an entry that belongs to another subsystem.
- */
-let disabledEntries: string[] = [];
-
-/** Disabled providers (by ID), resolved from `disabledEntries` */
+/** Disabled providers (by ID), resolved from the `disabledProviders` setting */
 const disabledProviders = new Set<string>();
 
-function syncDisabledProviders(): void {
-	disabledProviders.clear();
-	for (const entry of disabledEntries) {
-		disabledProviders.add(
-			entry.startsWith(DISCOVERY_SCOPE_PREFIX) ? entry.slice(DISCOVERY_SCOPE_PREFIX.length) : entry,
-		);
-	}
+function qualify(providerId: string): string {
+	return `${DISCOVERY_SCOPE_PREFIX}${providerId}`;
+}
+
+function unqualify(entry: string): string {
+	return entry.startsWith(DISCOVERY_SCOPE_PREFIX) ? entry.slice(DISCOVERY_SCOPE_PREFIX.length) : entry;
+}
+
+/** Whether a persisted entry names `providerId`, qualified or not. */
+function entryNames(entry: unknown, providerId: string): boolean {
+	return entry === providerId || entry === qualify(providerId);
 }
 
 /** Settings manager for persistence (if set) */
@@ -310,27 +308,36 @@ export async function loadCapability<T>(
 export function initializeWithSettings(activeSettings: Settings): void {
 	settings = activeSettings;
 	// Load disabled providers from settings
-	disabledEntries = [...settings.get("disabledProviders")];
-	syncDisabledProviders();
+	disabledProviders.clear();
+	for (const entry of settings.get("disabledProviders")) {
+		disabledProviders.add(unqualify(entry));
+	}
 }
 
 /**
- * Persist current disabled providers to settings.
+ * Edit this registry's own entries in the persisted `disabledProviders` array.
+ *
+ * Reads the raw global layer rather than `Settings.get()`: the getter resolves
+ * path-scoped rules against the current cwd and merges the project layer, so
+ * writing its result back would flatten `{ paths, providers }` entries into
+ * plain ids and promote another project's disables to global ones. Entries this
+ * registry does not own are passed through untouched.
  */
-function persistDisabledProviders(): void {
-	if (settings) {
-		settings.set("disabledProviders", [...disabledEntries]);
-	}
+function editPersistedEntries(edit: (entries: unknown[]) => unknown[]): void {
+	if (!settings) return;
+	const raw = settings.getGlobalRaw("disabledProviders");
+	const next = edit(Array.isArray(raw) ? [...raw] : []);
+	settings.set("disabledProviders", next as string[]);
 }
 
 /**
  * Disable a provider globally (across all capabilities).
  */
 export function disableProvider(providerId: string): void {
-	if (disabledProviders.has(providerId)) return;
-	disabledEntries.push(`${DISCOVERY_SCOPE_PREFIX}${providerId}`);
-	syncDisabledProviders();
-	persistDisabledProviders();
+	disabledProviders.add(providerId);
+	editPersistedEntries(entries =>
+		entries.some(entry => entryNames(entry, providerId)) ? entries : [...entries, qualify(providerId)],
+	);
 }
 
 /**
@@ -341,10 +348,8 @@ export function disableProvider(providerId: string): void {
  * keep that half disabled would disable a backend the user never named.
  */
 export function enableProvider(providerId: string): void {
-	const qualified = `${DISCOVERY_SCOPE_PREFIX}${providerId}`;
-	disabledEntries = disabledEntries.filter(entry => entry !== providerId && entry !== qualified);
-	syncDisabledProviders();
-	persistDisabledProviders();
+	disabledProviders.delete(providerId);
+	editPersistedEntries(entries => entries.filter(entry => !entryNames(entry, providerId)));
 }
 
 /**
@@ -365,9 +370,15 @@ export function getDisabledProviders(): string[] {
  * Set disabled providers from a list (replaces current set).
  */
 export function setDisabledProviders(providerIds: string[]): void {
-	disabledEntries = [...providerIds];
-	syncDisabledProviders();
-	persistDisabledProviders();
+	disabledProviders.clear();
+	for (const id of providerIds) {
+		disabledProviders.add(unqualify(id));
+	}
+	// Replaces this registry's own ids; path-scoped rules stay as authored.
+	editPersistedEntries(entries => [
+		...entries.filter(entry => typeof entry !== "string"),
+		...providerIds.map(qualify),
+	]);
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -65,6 +65,16 @@ function entryNames(entry: unknown, providerId: string): boolean {
 	return entry === providerId || entry === qualify(providerId);
 }
 
+/**
+ * Whether this registry owns a persisted entry: the qualified form, or a plain
+ * id that names a registered discovery provider. A plain id belonging only to
+ * the model registry is not ours to rewrite.
+ */
+function ownsEntry(entry: unknown): boolean {
+	if (typeof entry !== "string") return false;
+	return entry.startsWith(DISCOVERY_SCOPE_PREFIX) || providerCapabilities.has(entry);
+}
+
 /** Settings manager for persistence (if set) */
 let settings: Settings | null = null;
 
@@ -379,11 +389,10 @@ export function setDisabledProviders(providerIds: string[]): void {
 	for (const id of providerIds) {
 		disabledProviders.add(unqualify(id));
 	}
-	// Replaces this registry's own ids; path-scoped rules stay as authored.
-	editPersistedEntries(entries => [
-		...entries.filter(entry => typeof entry !== "string"),
-		...providerIds.map(qualify),
-	]);
+	// Replaces this registry's own ids. Path-scoped rules and plain ids that name
+	// no discovery provider — a model-only disable such as `anthropic` — stay as
+	// authored, since replacing the discovery set says nothing about them.
+	editPersistedEntries(entries => [...entries.filter(entry => !ownsEntry(entry)), ...providerIds.map(qualify)]);
 }
 
 // =============================================================================
@@ -489,6 +498,20 @@ export function getAllProvidersInfo(): ProviderInfo[] {
  */
 export function reset(): void {
 	clearFsCache();
+}
+
+/**
+ * Drop the provider disable state and the settings handle.
+ *
+ * `initializeWithSettings()` mutates module-level state that outlives a test
+ * file, so a suite that disables a provider would otherwise suppress discovery
+ * in whichever file runs next.
+ *
+ * @internal
+ */
+export function resetProviderStateForTest(): void {
+	disabledProviders.clear();
+	settings = null;
 }
 
 /**

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -491,6 +491,20 @@ export class Settings {
 	}
 
 	/**
+	 * The global layer's value for `path`, exactly as persisted.
+	 *
+	 * `get()` returns the merged layers with path-scoped entries already resolved
+	 * against the current cwd, so writing that value back through `set()` — which
+	 * only ever targets the global layer — collapses `{ paths, providers }` rules
+	 * into plain ids and copies project-layer entries into the global config. A
+	 * caller that edits one entry of an array setting reads the raw global value,
+	 * changes its own entry, and writes the rest back untouched.
+	 */
+	getGlobalRaw(path: SettingPath): unknown {
+		return getByPath(this.#global, SETTING_PATH_SEGMENTS[path]);
+	}
+
+	/**
 	 * Set a setting value (sync).
 	 * Updates global settings and queues a background save.
 	 * Triggers hooks for settings that have side effects.

--- a/packages/coding-agent/test/discovery/disabled-providers-scope.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-providers-scope.test.ts
@@ -158,6 +158,20 @@ describe("disabledProviders — discovery/model namespace", () => {
 		await active.flush();
 
 		expect(await readGlobalConfig()).not.toHaveProperty("disabledProviders");
+		// Reporting it as enabled would load it for this process only.
+		expect(isProviderEnabled("github")).toBe(false);
+	});
+
+	test("enabling reports the truth when a path-scoped rule keeps a provider off", async () => {
+		await writeGlobalConfig({ disabledProviders: [{ paths: [projectDir], providers: ["opencode"] }] });
+		const active = await initSettings();
+		expect(isProviderEnabled("opencode")).toBe(false);
+
+		enableProvider("opencode");
+		await active.flush();
+
+		expect((await readGlobalConfig()).disabledProviders).toEqual([{ paths: [projectDir], providers: ["opencode"] }]);
+		expect(isProviderEnabled("opencode")).toBe(false);
 	});
 
 	test("replacing the discovery set keeps a model-only disable", async () => {

--- a/packages/coding-agent/test/discovery/disabled-providers-scope.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-providers-scope.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `disabledProviders` is one array shared by the discovery registry
+ * (capability/index.ts) and the model registry (config/model-registry.ts),
+ * matched in both against a bare provider id. `cursor` is registered in both
+ * namespaces, so a discovery toggle that persisted the bare id also removed the
+ * Cursor models from `/model` and `/login`.
+ *
+ * These tests pin the qualifier that keeps the two apart, and the unqualified
+ * form that every pre-existing config relies on.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	disableProvider,
+	enableProvider,
+	initializeWithSettings,
+	isProviderEnabled,
+	setDisabledProviders,
+} from "@oh-my-pi/pi-coding-agent/capability";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+
+/** Seed the setting through the same layer a real config file writes to. */
+function settingsWith(entries: string[]): Settings {
+	const settings = Settings.isolated();
+	settings.set("disabledProviders", entries);
+	initializeWithSettings(settings);
+	return settings;
+}
+
+/** How model-registry.ts reads the setting (getDisabledProviderIdsFromSettings). */
+function modelRegistrySees(settings: Settings, providerId: string): boolean {
+	return new Set(settings.get("disabledProviders")).has(providerId);
+}
+
+describe("disabledProviders — discovery/model namespace", () => {
+	afterEach(() => {
+		setDisabledProviders([]);
+	});
+
+	test("a discovery toggle persists the qualified entry and spares the model backend", () => {
+		const settings = settingsWith([]);
+
+		disableProvider("cursor");
+
+		expect(settings.get("disabledProviders")).toEqual(["discovery:cursor"]);
+		expect(isProviderEnabled("cursor")).toBe(false);
+		expect(modelRegistrySees(settings, "cursor")).toBe(false);
+	});
+
+	test("an unqualified entry still disables both subsystems", () => {
+		const settings = settingsWith(["cursor"]);
+
+		expect(isProviderEnabled("cursor")).toBe(false);
+		expect(modelRegistrySees(settings, "cursor")).toBe(true);
+	});
+
+	test("enabling clears both the qualified and the unqualified entry", () => {
+		const settings = settingsWith(["cursor", "discovery:cursor"]);
+		expect(isProviderEnabled("cursor")).toBe(false);
+
+		enableProvider("cursor");
+
+		expect(settings.get("disabledProviders")).toEqual([]);
+		expect(isProviderEnabled("cursor")).toBe(true);
+	});
+
+	test("disabling is idempotent against a pre-existing unqualified entry", () => {
+		const settings = settingsWith(["cursor"]);
+
+		disableProvider("cursor");
+
+		expect(settings.get("disabledProviders")).toEqual(["cursor"]);
+	});
+
+	test("entries owned by the model registry survive a discovery toggle", () => {
+		const settings = settingsWith(["anthropic", "openai"]);
+
+		disableProvider("cursor");
+
+		expect(settings.get("disabledProviders")).toEqual(["anthropic", "openai", "discovery:cursor"]);
+		expect(modelRegistrySees(settings, "anthropic")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/discovery/disabled-providers-scope.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-providers-scope.test.ts
@@ -18,6 +18,8 @@ import {
 	enableProvider,
 	initializeWithSettings,
 	isProviderEnabled,
+	resetProviderStateForTest,
+	setDisabledProviders,
 } from "@oh-my-pi/pi-coding-agent/capability";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -57,6 +59,8 @@ describe("disabledProviders — discovery/model namespace", () => {
 	});
 
 	afterEach(async () => {
+		// initializeWithSettings() mutates module state that outlives this file.
+		resetProviderStateForTest();
 		authStorage?.close();
 		restoreSettingsTestState(settingsState);
 		settingsState = undefined;
@@ -154,6 +158,17 @@ describe("disabledProviders — discovery/model namespace", () => {
 		await active.flush();
 
 		expect(await readGlobalConfig()).not.toHaveProperty("disabledProviders");
+	});
+
+	test("replacing the discovery set keeps a model-only disable", async () => {
+		await writeGlobalConfig({ disabledProviders: ["anthropic", "cursor"] });
+		const active = await initSettings();
+
+		setDisabledProviders(["opencode"]);
+		await active.flush();
+
+		expect((await readGlobalConfig()).disabledProviders).toEqual(["anthropic", "discovery:opencode"]);
+		expect(await selectableProviders()).not.toContain("anthropic");
 	});
 
 	test("a toggle preserves path-scoped entries instead of flattening them", async () => {

--- a/packages/coding-agent/test/discovery/disabled-providers-scope.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-providers-scope.test.ts
@@ -5,78 +5,164 @@
  * namespaces, so a discovery toggle that persisted the bare id also removed the
  * Cursor models from `/model` and `/login`.
  *
- * These tests pin the qualifier that keeps the two apart, and the unqualified
- * form that every pre-existing config relies on.
+ * These tests pin the qualifier that keeps the two apart against the real model
+ * registry, plus the persistence rules that keep a discovery toggle from
+ * rewriting entries it does not own.
  */
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { FetchImpl } from "@oh-my-pi/pi-ai";
 import {
 	disableProvider,
 	enableProvider,
 	initializeWithSettings,
 	isProviderEnabled,
-	setDisabledProviders,
 } from "@oh-my-pi/pi-coding-agent/capability";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
+import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "../helpers/settings-test-state";
 
-/** Seed the setting through the same layer a real config file writes to. */
-function settingsWith(entries: string[]): Settings {
-	const settings = Settings.isolated();
-	settings.set("disabledProviders", entries);
-	initializeWithSettings(settings);
-	return settings;
-}
-
-/** How model-registry.ts reads the setting (getDisabledProviderIdsFromSettings). */
-function modelRegistrySees(settings: Settings, providerId: string): boolean {
-	return new Set(settings.get("disabledProviders")).has(providerId);
-}
+/** Reject every request so refresh() stays on the bundled catalog. */
+const offlineFetch: FetchImpl = () => Promise.reject(new Error("network disabled in disabled-providers-scope test"));
 
 describe("disabledProviders — discovery/model namespace", () => {
-	afterEach(() => {
-		setDisabledProviders([]);
+	let settingsState: SettingsTestState | undefined;
+	let tempDir: TempDir;
+	let agentDir: string;
+	let projectDir: string;
+	let authStorage: AuthStorage;
+
+	beforeEach(async () => {
+		settingsState = beginSettingsTest();
+		tempDir = TempDir.createSync("@pi-disabled-providers-scope-");
+		agentDir = tempDir.join("agent");
+		projectDir = tempDir.join("project");
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.mkdirSync(getProjectAgentDir(projectDir), { recursive: true });
+
+		authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+		// The model registry drops a provider before it checks credentials, so the
+		// Cursor backend needs one to prove the entry — not a missing login — is
+		// what removes its models.
+		await authStorage.set("cursor", {
+			type: "oauth",
+			access: "test-access-token",
+			refresh: "test-refresh-token",
+			expires: Date.now() + 3_600_000,
+		});
 	});
 
-	test("a discovery toggle persists the qualified entry and spares the model backend", () => {
-		const settings = settingsWith([]);
+	afterEach(async () => {
+		authStorage?.close();
+		restoreSettingsTestState(settingsState);
+		settingsState = undefined;
+		await Bun.sleep(0);
+		await tempDir?.remove();
+	});
+
+	const globalConfigPath = () => path.join(agentDir, "config.yml");
+
+	async function writeGlobalConfig(value: Record<string, unknown>): Promise<void> {
+		await Bun.write(globalConfigPath(), YAML.stringify(value, null, 2));
+	}
+
+	async function readGlobalConfig(): Promise<Record<string, unknown>> {
+		const file = Bun.file(globalConfigPath());
+		if (!(await file.exists())) return {};
+		const parsed = YAML.parse(await file.text());
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+	}
+
+	/** Boot the real settings singleton the model registry reads from. */
+	async function initSettings(): Promise<Settings> {
+		const active = await Settings.init({ cwd: projectDir, agentDir });
+		initializeWithSettings(active);
+		return active;
+	}
+
+	/** Providers the real model registry offers for selection (`getAvailable()`). */
+	async function selectableProviders(): Promise<Set<string>> {
+		const registry = new ModelRegistry(authStorage, tempDir.join("models.yml"), { fetch: offlineFetch });
+		await registry.refresh("offline");
+		return new Set(registry.getAvailable().map(model => model.provider));
+	}
+
+	test("an unqualified entry disables the model backend even with a credential present", async () => {
+		await writeGlobalConfig({ disabledProviders: ["cursor"] });
+		await initSettings();
+
+		expect(await selectableProviders()).not.toContain("cursor");
+		expect(isProviderEnabled("cursor")).toBe(false);
+	});
+
+	test("the qualified entry disables discovery and spares the model backend", async () => {
+		await writeGlobalConfig({ disabledProviders: ["discovery:cursor"] });
+		await initSettings();
+
+		expect(await selectableProviders()).toContain("cursor");
+		expect(isProviderEnabled("cursor")).toBe(false);
+	});
+
+	test("a discovery toggle persists the qualified entry", async () => {
+		await writeGlobalConfig({ disabledProviders: [] });
+		const active = await initSettings();
 
 		disableProvider("cursor");
+		await active.flush();
 
-		expect(settings.get("disabledProviders")).toEqual(["discovery:cursor"]);
+		expect((await readGlobalConfig()).disabledProviders).toEqual(["discovery:cursor"]);
 		expect(isProviderEnabled("cursor")).toBe(false);
-		expect(modelRegistrySees(settings, "cursor")).toBe(false);
 	});
 
-	test("an unqualified entry still disables both subsystems", () => {
-		const settings = settingsWith(["cursor"]);
-
-		expect(isProviderEnabled("cursor")).toBe(false);
-		expect(modelRegistrySees(settings, "cursor")).toBe(true);
-	});
-
-	test("enabling clears both the qualified and the unqualified entry", () => {
-		const settings = settingsWith(["cursor", "discovery:cursor"]);
+	test("enabling clears both the qualified and the unqualified entry", async () => {
+		await writeGlobalConfig({ disabledProviders: ["cursor", "discovery:cursor"] });
+		const active = await initSettings();
 		expect(isProviderEnabled("cursor")).toBe(false);
 
 		enableProvider("cursor");
+		await active.flush();
 
-		expect(settings.get("disabledProviders")).toEqual([]);
+		expect((await readGlobalConfig()).disabledProviders).toEqual([]);
 		expect(isProviderEnabled("cursor")).toBe(true);
 	});
 
-	test("disabling is idempotent against a pre-existing unqualified entry", () => {
-		const settings = settingsWith(["cursor"]);
+	test("disabling is idempotent against a pre-existing unqualified entry", async () => {
+		await writeGlobalConfig({ disabledProviders: ["cursor"] });
+		const active = await initSettings();
 
 		disableProvider("cursor");
+		await active.flush();
 
-		expect(settings.get("disabledProviders")).toEqual(["cursor"]);
+		expect((await readGlobalConfig()).disabledProviders).toEqual(["cursor"]);
 	});
 
-	test("entries owned by the model registry survive a discovery toggle", () => {
-		const settings = settingsWith(["anthropic", "openai"]);
+	test("a toggle preserves path-scoped entries instead of flattening them", async () => {
+		const scoped = { paths: [projectDir], providers: ["anthropic"] };
+		await writeGlobalConfig({ disabledProviders: ["github", scoped] });
+		const active = await initSettings();
 
 		disableProvider("cursor");
+		await active.flush();
 
-		expect(settings.get("disabledProviders")).toEqual(["anthropic", "openai", "discovery:cursor"]);
-		expect(modelRegistrySees(settings, "anthropic")).toBe(true);
+		expect((await readGlobalConfig()).disabledProviders).toEqual(["github", scoped, "discovery:cursor"]);
+	});
+
+	test("a toggle does not copy project-layer entries into the global config", async () => {
+		await writeGlobalConfig({ disabledProviders: [] });
+		await Bun.write(
+			path.join(getProjectAgentDir(projectDir), "settings.json"),
+			JSON.stringify({ disabledProviders: ["github"] }),
+		);
+		const active = await initSettings();
+		expect(isProviderEnabled("github")).toBe(false);
+
+		disableProvider("cursor");
+		await active.flush();
+
+		expect((await readGlobalConfig()).disabledProviders).toEqual(["discovery:cursor"]);
 	});
 });

--- a/packages/coding-agent/test/discovery/disabled-providers-scope.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-providers-scope.test.ts
@@ -23,6 +23,9 @@ import {
 } from "@oh-my-pi/pi-coding-agent/capability";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+// Registers the discovery providers. `setDisabledProviders()` decides what it
+// owns from that registry, so the import is load-bearing rather than incidental.
+import "@oh-my-pi/pi-coding-agent/discovery";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";

--- a/packages/coding-agent/test/discovery/disabled-providers-scope.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-providers-scope.test.ts
@@ -140,6 +140,22 @@ describe("disabledProviders — discovery/model namespace", () => {
 		expect((await readGlobalConfig()).disabledProviders).toEqual(["cursor"]);
 	});
 
+	test("a toggle that changes nothing does not touch the config", async () => {
+		await writeGlobalConfig({ setupVersion: 1 });
+		await Bun.write(
+			path.join(getProjectAgentDir(projectDir), "settings.json"),
+			JSON.stringify({ disabledProviders: ["github"] }),
+		);
+		const active = await initSettings();
+		expect(isProviderEnabled("github")).toBe(false);
+
+		// Only the project layer disables it, so there is nothing to drop here.
+		enableProvider("github");
+		await active.flush();
+
+		expect(await readGlobalConfig()).not.toHaveProperty("disabledProviders");
+	});
+
 	test("a toggle preserves path-scoped entries instead of flattening them", async () => {
 		const scoped = { paths: [projectDir], providers: ["anthropic"] };
 		await writeGlobalConfig({ disabledProviders: ["github", scoped] });


### PR DESCRIPTION
After logging in to Cursor I had none of its models in my model list; I traced it to the `cursor` entry in `disabledProviders` switching off both subsystems at once.

## Problem

Turning Cursor config discovery off also removes the Cursor model backend. After `/login cursor` succeeds, `/model` lists no `cursor/...` models and `/login` stops offering Cursor at all:

```yaml
# ~/.omp/agent/config.yml — written by the /extensions toggle
disabledProviders:
  - cursor
```

```
$ omp models cursor
No models matching "cursor"
```

The credential is present and valid; nothing reports that the provider was suppressed.

Chasing the write path turned up a second, independent defect: the same toggle also rewrites `disabledProviders` entries that have nothing to do with it, including documented path-scoped rules and entries owned by a project config.

## Root cause

### 1. One id namespace, two subsystems

`disabledProviders` is a single array consumed by two unrelated subsystems that each match it against their own provider ids:

- discovery — `capability/index.ts:239`, `filter(p => !disabledProviders.has(p.id))`
- model — `config/model-registry.ts:2259`, `!disabledProviders.has(provider) && (keyless || hasAuth(provider))`

The model check short-circuits before `hasAuth`, so a listed id is dropped regardless of credentials.

`cursor` is the only id registered in both namespaces — `discovery/cursor.ts:35` (`.cursor` MDC rules, `mcp.json`, settings) and the catalog descriptor `cursor` (`descriptors.ts:129`). Every other pair is disjoint by luck rather than by design: `claude`/`anthropic`, `codex`/`openai-codex`, `gemini`/`google`. Comparing the 16 registered discovery ids against the 65 catalog provider ids yields exactly one intersection.

The write path is what turns that overlap into a bug. `disableProvider()` persisted the bare id, and all three of its callers are discovery surfaces — the extensions list (`extensions/state-manager.ts:600`), the settings selector's `discovery.*` rows (`selector-controller.ts:419`), and the ACP `_omp/extensions/toggle` (`acp-agent.ts:1009`). A discovery-only intent was therefore written in a form the model registry also matches.

### 2. The toggle persisted a resolved value into the raw global layer

`persistDisabledProviders()` wrote `Settings.get("disabledProviders")` back through `Settings.set()`. Those two are not inverses:

- `get()` resolves path-scoped `{ paths, providers }` rules against the current cwd and returns plain ids
- `get()` returns the merged layers, project config included
- `set()` only ever writes the global layer

So one toggle flattened scoped rules into plain ids, dropped rules scoped to other directories, and copied project-local entries into the global config, where they then applied to every project.

## Fix

Discovery toggles persist `discovery:<id>`, which the model registry does not match, and the discovery registry resolves back to the bare id. Unqualified entries are untouched and keep disabling both subsystems, so existing configs behave exactly as documented.

For the persistence defect, toggles no longer round-trip the resolved getter. `Settings.getGlobalRaw()` exposes the global layer's value as persisted, and the registry edits only the entry it owns:

```ts
function editPersistedEntries(edit: (entries: unknown[]) => unknown[]): void {
	if (!settings) return;
	const raw = settings.getGlobalRaw("disabledProviders");
	const next = edit(Array.isArray(raw) ? [...raw] : []);
	settings.set("disabledProviders", next as string[]);
}
```

Scoped rules and project-layer entries never pass through the registry, so they cannot be rewritten by it.

## Verification

Exercised against a throwaway `PI_CODING_AGENT_DIR` so nothing touched my real config, using the dev entrypoint at this branch.

### The Cursor collision

| `disabledProviders` | `omp models cursor` | `.cursor/rules/*.mdc` loaded |
| --- | --- | --- |
| `[]` | 42 models | yes |
| `[cursor]` (what the toggle wrote before) | `No models matching "cursor"` | no |
| `[discovery:cursor]` (what it writes now) | 42 models | no |

The third row is the fix: config discovery stays off, the model backend comes back.

### The persistence defect

Global config with a plain entry and a path-scoped rule, plus a project config of its own, then one `disableProvider("cursor")` from inside that project:

```yaml
# ~/.omp/agent/config.yml (before)
disabledProviders:
  - github
  - paths: [/tmp/ps-proj]
    providers: [anthropic]
```
```json
// /tmp/ps-proj/.omp/settings.json
{ "disabledProviders": ["opencode"] }
```

`main` (053dbfa) rewrites the global config to:

```yaml
disabledProviders:
  - opencode        # project-layer entry, now global
  - cursor
```

`github` and the scoped `anthropic` rule are gone, and a project-local disable has become a global one. This branch writes:

```yaml
disabledProviders:
  - github
  - paths: [/tmp/ps-proj]
    providers: [anthropic]
  - discovery:cursor
```

### Tests

- `bun test test/discovery/disabled-providers-scope.test.ts` — 10 pass, 0 fail. The suite fails against a clean `main`, and each fix is covered by a case that fails when only that change is reverted.
- `bun test test/discovery/agent-discovery-disabled-providers.test.ts test/discovery/github-copilot.test.ts test/task/discovery.test.ts test/model-registry.test.ts test/modes/components/oauth-selector.test.ts test/settings-manager.test.ts test/repro-issue-1022-disabled-default-model.test.ts` — 185 pass, 0 fail.
- `bunx tsc --noEmit` on `packages/coding-agent` — clean. `biome check` — clean on every file this PR touches.

The tests drive the real `ModelRegistry` (`getAvailable()`, with a Cursor OAuth credential present so the assertion proves the entry rather than a missing login removes the models) and the real settings singleton, rather than restating how the model registry reads the setting.

## Notes

No issue was filed for this, per CONTRIBUTING ("Do not open an issue for work you are about to submit").

The docs change comes along because `docs/context-files.md` asserted the opposite of the bug — "the two namespaces do not collide by accident" — and its discovery-id list named 8 of the 16 registered providers, omitting `cursor` itself.

Known limitation: `enableProvider()` cannot clear a disable that lives in a project config or inside a path-scoped rule, because the toggle writes plain entries in the global layer. It now reports that honestly — the provider stays disabled in the UI instead of appearing enabled until the next reload. Actually clearing those needs layer-targeted and scope-aware writes, which felt like a separate change.

Out of scope, and happy to follow up if you would rather have them:

- No symmetric `model:` qualifier. Nothing writes model-scoped entries programmatically, and adding the read side without a caller looked like surface for its own sake.
- Existing unqualified entries are not migrated. Re-toggling in the UI rewrites them; a silent rewrite at load felt wrong for a config the user may have hand-written.
- `enableProvider()` drops an unqualified entry rather than rewriting it to `model:<id>`. An unqualified entry carries no evidence that the model registry was the intended target, so preserving that half would disable a backend the user never named.
