### PR TITLE
feat(coding-agent): add /switch <model> direct session model switch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Fixed remote or LAN local-engine endpoints being ignored during model discovery: the llama.cpp and Ollama probes used timeouts tuned for loopback, so a host reached over the network could exceed them and return no models, while changing `OLLAMA_BASE_URL`/`OLLAMA_HOST` could keep reusing a fresh cache from the previous endpoint. Non-loopback hosts now get a generous discovery timeout, and Ollama cache rows are scoped to the normalized endpoint ([#7087](https://github.com/can1357/oh-my-pi/issues/7087)).
 - Fixed `omp install` failing extension validation for pi extensions that import `createEditTool` or `createWriteTool` (e.g. gentle-pi) — the legacy `@oh-my-pi/pi-coding-agent` shim exported the read/bash/grep/find/ls tool factories but omitted the edit and write ones, so a named import threw Bun's static "Export named X not found" error. Added `createEditTool`/`createEditToolDefinition` and `createWriteTool`/`createWriteToolDefinition` to match the upstream pi surface ([#7094](https://github.com/can1357/oh-my-pi/issues/7094)).
 - Fixed Python eval's loopback tool bridge being routed through macOS system HTTP proxies, which caused `parallel()` tool reads to fail with `ConnectionRefusedError` after a local proxy stopped.
+### Added
+
+- Added `/switch <model>`: passing a model selector (`provider/id`, bare id, configured role, or an explicit `:<thinking>` suffix) switches the session model directly without opening the picker; bare `/switch` keeps the compact session-only selector. The switch stays session-only (same as alt+p) and is never persisted to model settings.
 
 ## [17.2.0] - 2026-07-30
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Fixed Python eval's loopback tool bridge being routed through macOS system HTTP proxies, which caused `parallel()` tool reads to fail with `ConnectionRefusedError` after a local proxy stopped.
 ### Added
 
-- Added `/switch <model>`: passing a model selector (`provider/id`, bare id, configured role, or an explicit `:<thinking>` suffix) switches the session model directly without opening the picker; bare `/switch` keeps the compact session-only selector. The switch stays session-only (same as alt+p) and is never persisted to model settings.
+- Added `/switch <model>`: passing a model selector (`provider/id`, bare id, configured role, or an explicit `:<thinking>` suffix) switches the session model directly without opening the picker; bare `/switch` keeps the compact session-only selector. The switch stays session-only (same as alt+p) and is never persisted to model settings. In sessions scoped by `--models`/`enabledModels`, direct resolution is restricted to the scoped list and rejects models outside it.
 
 ## [17.2.0] - 2026-07-30
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -102,6 +102,7 @@ import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
 import type { SessionObserverRegistry } from "../session-observer-registry";
 import { buildCopyTargets } from "../utils/copy-targets";
+import { applyTemporarySessionModel } from "../utils/interactive-context-helpers";
 
 const MANUAL_LOGIN_PROMPT = "Paste the authorization code (or full redirect URL), then press Enter:";
 
@@ -698,13 +699,7 @@ export class SelectorController {
 			{
 				onPick: async (model, selector) => {
 					try {
-						// Session-only: update agent state but don't persist the model to settings.
-						const roleThinkingLevel = this.ctx.session.resolveTemporaryModelThinkingLevel(model);
-						await this.ctx.session.setModelTemporary(model, roleThinkingLevel);
-						this.ctx.statusLine.invalidate();
-						this.ctx.updateEditorBorderColor();
-						const roleSelectorHint = this.ctx.keybindings.getKeys("app.model.select")[0] ?? "Alt+M";
-						this.ctx.showStatus(`Session-only model: ${selector}. Use ${roleSelectorHint} or /model for roles.`);
+						await applyTemporarySessionModel(this.ctx, model, selector);
 						done();
 					} catch (error) {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));

--- a/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
@@ -3,7 +3,8 @@
  * {@link UiHelpers} and the input/event controllers, so the live chat surfaces
  * construct components and reset editor state identically.
  */
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+import type { ConfiguredThinkingLevel } from "../../thinking";
 import { AssistantMessageComponent } from "../components/assistant-message";
 import type { InteractiveModeContext } from "../types";
 
@@ -27,4 +28,27 @@ export function createAssistantMessageComponent(
 	component.setImagesVisible(ctx.settings.get("terminal.showImages"));
 	component.setExpanded(ctx.toolOutputExpanded);
 	return component;
+}
+
+/**
+ * Apply a session-only model pick (compact picker via alt+p / bare `/switch`,
+ * or `/switch <model>` directly): update agent state without persisting the
+ * model to settings, refresh the chrome, and announce the switch. Both call
+ * paths go through here so the status string and side effects cannot drift.
+ * An explicit `thinkingLevel` (e.g. a `:<thinking>` suffix) wins over the
+ * role-derived fallback.
+ */
+export async function applyTemporarySessionModel(
+	ctx: InteractiveModeContext,
+	model: Model,
+	selector: string,
+	thinkingLevel?: ConfiguredThinkingLevel,
+): Promise<void> {
+	// Session-only: update agent state but don't persist the model to settings.
+	const resolvedThinkingLevel = thinkingLevel ?? ctx.session.resolveTemporaryModelThinkingLevel(model);
+	await ctx.session.setModelTemporary(model, resolvedThinkingLevel);
+	ctx.statusLine.invalidate();
+	ctx.updateEditorBorderColor();
+	const roleSelectorHint = ctx.keybindings.getKeys("app.model.select")[0] ?? "Alt+M";
+	ctx.showStatus(`Session-only model: ${selector}. Use ${roleSelectorHint} or /model for roles.`);
 }

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -578,14 +578,44 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "switch",
-		description: "Switch model for this session (same as alt+p)",
+		description: "Switch model for this session (same as alt+p), optionally naming the model directly",
+		inlineHint: "[model]",
+		allowArgs: true,
 		getTuiAutocompleteDescription: runtime => {
 			const model = runtime.ctx.session.model;
 			return model ? `Model: ${model.provider}/${model.id}` : "Model: none selected";
 		},
-		handleTui: (_command, runtime) => {
-			runtime.ctx.showModelSelector({ temporaryOnly: true });
+		handleTui: async (command, runtime) => {
 			runtime.ctx.editor.setText("");
+			const selectorArg = command.args.trim();
+			if (!selectorArg) {
+				runtime.ctx.showModelSelector({ temporaryOnly: true });
+				return;
+			}
+			const resolved = resolveCliModel({
+				cliModel: selectorArg,
+				modelRegistry: runtime.ctx.session.modelRegistry,
+				settings: runtime.ctx.settings,
+				preferences: getModelMatchPreferences(runtime.ctx.settings),
+			});
+			if (resolved.error || !resolved.model) {
+				runtime.ctx.showError(resolved.error ?? `Model "${selectorArg}" not found.`);
+				return;
+			}
+			try {
+				// Session-only, mirroring the picker: never persist to settings.
+				const thinkingLevel =
+					resolved.thinkingLevel ?? runtime.ctx.session.resolveTemporaryModelThinkingLevel(resolved.model);
+				await runtime.ctx.session.setModelTemporary(resolved.model, thinkingLevel);
+				runtime.ctx.statusLine.invalidate();
+				runtime.ctx.updateEditorBorderColor();
+				const roleSelectorHint = runtime.ctx.keybindings.getKeys("app.model.select")[0] ?? "Alt+M";
+				runtime.ctx.showStatus(
+					`Session-only model: ${resolved.selector ?? formatModelString(resolved.model)}. Use ${roleSelectorHint} or /model for roles.`,
+				);
+			} catch (error) {
+				runtime.ctx.showError(error instanceof Error ? error.message : String(error));
+			}
 		},
 	},
 	{

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
+import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { type AutocompleteItem, Spacer } from "@oh-my-pi/pi-tui";
 import { APP_NAME, getMCPConfigPath, getProjectDir, logger, setProjectDir } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../capability";
@@ -39,6 +40,7 @@ import { describeLoopLimitRuntime } from "../modes/loop-limit";
 import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
 import { extractLastCodeBlock, extractLastCommand } from "../modes/utils/copy-targets";
+import { applyTemporarySessionModel } from "../modes/utils/interactive-context-helpers";
 import type { AgentSession, FreshSessionResult } from "../session/agent-session";
 import type { SessionOAuthAccountList } from "../session/agent-session-types";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
@@ -592,9 +594,14 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				runtime.ctx.showModelSelector({ temporaryOnly: true });
 				return;
 			}
+			// Sessions scoped by --models/enabledModels restrict the picker's
+			// selectable list to the scope; resolve against the same list so the
+			// direct path cannot switch to a model the picker would not offer.
+			const scopedModels = runtime.ctx.session.scopedModels;
 			const resolved = resolveCliModel({
 				cliModel: selectorArg,
 				modelRegistry: runtime.ctx.session.modelRegistry,
+				availableModels: scopedModels.length > 0 ? scopedModels.map(scoped => scoped.model) : undefined,
 				settings: runtime.ctx.settings,
 				preferences: getModelMatchPreferences(runtime.ctx.settings),
 			});
@@ -602,16 +609,19 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				runtime.ctx.showError(resolved.error ?? `Model "${selectorArg}" not found.`);
 				return;
 			}
+			if (scopedModels.length > 0 && !scopedModels.some(scoped => modelsAreEqual(scoped.model, resolved.model))) {
+				const scopedList = scopedModels.map(scoped => formatModelString(scoped.model)).join(", ");
+				runtime.ctx.showError(
+					`Model "${formatModelString(resolved.model)}" is outside this session's model scope (--models). Scoped models: ${scopedList}.`,
+				);
+				return;
+			}
 			try {
-				// Session-only, mirroring the picker: never persist to settings.
-				const thinkingLevel =
-					resolved.thinkingLevel ?? runtime.ctx.session.resolveTemporaryModelThinkingLevel(resolved.model);
-				await runtime.ctx.session.setModelTemporary(resolved.model, thinkingLevel);
-				runtime.ctx.statusLine.invalidate();
-				runtime.ctx.updateEditorBorderColor();
-				const roleSelectorHint = runtime.ctx.keybindings.getKeys("app.model.select")[0] ?? "Alt+M";
-				runtime.ctx.showStatus(
-					`Session-only model: ${resolved.selector ?? formatModelString(resolved.model)}. Use ${roleSelectorHint} or /model for roles.`,
+				await applyTemporarySessionModel(
+					runtime.ctx,
+					resolved.model,
+					resolved.selector ?? formatModelString(resolved.model),
+					resolved.thinkingLevel,
 				);
 			} catch (error) {
 				runtime.ctx.showError(error instanceof Error ? error.message : String(error));

--- a/packages/coding-agent/test/slash-commands/switch.test.ts
+++ b/packages/coding-agent/test/slash-commands/switch.test.ts
@@ -29,6 +29,50 @@ describe("/model slash command", () => {
 	});
 });
 
+const FAKE_MODELS = [
+	{ provider: "anthropic", id: "claude-opus-4-5" },
+	{ provider: "openai", id: "gpt-5.2" },
+];
+
+function createSwitchRuntime(options?: { roleThinkingLevel?: string }) {
+	const showModelSelector = vi.fn();
+	const setText = vi.fn();
+	const showStatus = vi.fn();
+	const showError = vi.fn();
+	const setModelTemporary = vi.fn();
+	const resolveTemporaryModelThinkingLevel = vi.fn(() => options?.roleThinkingLevel);
+	const invalidate = vi.fn();
+	const updateEditorBorderColor = vi.fn();
+	const getKeys = vi.fn(() => ["Alt+P"]);
+	return {
+		showModelSelector,
+		setText,
+		showStatus,
+		showError,
+		setModelTemporary,
+		runtime: {
+			ctx: {
+				editor: { setText } as unknown as InteractiveModeContext["editor"],
+				showModelSelector,
+				showStatus,
+				showError,
+				updateEditorBorderColor,
+				statusLine: { invalidate },
+				keybindings: { getKeys },
+				settings: undefined,
+				session: {
+					modelRegistry: {
+						getAll: () => FAKE_MODELS,
+						getAvailable: () => FAKE_MODELS,
+					},
+					setModelTemporary,
+					resolveTemporaryModelThinkingLevel,
+				},
+			} as unknown as InteractiveModeContext,
+		},
+	};
+}
+
 describe("/switch slash command", () => {
 	it("opens the temporary model selector (mirrors alt+p)", async () => {
 		const harness = createRuntime();
@@ -38,5 +82,46 @@ describe("/switch slash command", () => {
 		expect(handled).toBe(true);
 		expect(harness.showModelSelector).toHaveBeenCalledWith({ temporaryOnly: true });
 		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("switches directly to a named provider/id model without opening the picker", async () => {
+		const harness = createSwitchRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/switch anthropic/claude-opus-4-5", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.showModelSelector).not.toHaveBeenCalled();
+		expect(harness.setModelTemporary).toHaveBeenCalledWith(FAKE_MODELS[0], undefined);
+		expect(harness.showError).not.toHaveBeenCalled();
+		expect(harness.showStatus.mock.calls[0][0]).toContain("Session-only model: anthropic/claude-opus-4-5");
+	});
+
+	it("resolves a bare model id against the authenticated set", async () => {
+		const harness = createSwitchRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/switch gpt-5.2", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.setModelTemporary).toHaveBeenCalledWith(FAKE_MODELS[1], undefined);
+	});
+
+	it("applies an explicit thinking suffix instead of the role-derived level", async () => {
+		const harness = createSwitchRuntime({ roleThinkingLevel: "low" });
+
+		const handled = await executeBuiltinSlashCommand("/switch anthropic/claude-opus-4-5:high", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.setModelTemporary).toHaveBeenCalledWith(FAKE_MODELS[0], "high");
+	});
+
+	it("reports an unknown model without switching", async () => {
+		const harness = createSwitchRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/switch nope/not-a-model", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.setModelTemporary).not.toHaveBeenCalled();
+		expect(harness.showStatus).not.toHaveBeenCalled();
+		expect(harness.showError).toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/slash-commands/switch.test.ts
+++ b/packages/coding-agent/test/slash-commands/switch.test.ts
@@ -34,7 +34,10 @@ const FAKE_MODELS = [
 	{ provider: "openai", id: "gpt-5.2" },
 ];
 
-function createSwitchRuntime(options?: { roleThinkingLevel?: string }) {
+function createSwitchRuntime(options?: {
+	roleThinkingLevel?: string;
+	scopedModels?: ReadonlyArray<{ provider: string; id: string }>;
+}) {
 	const showModelSelector = vi.fn();
 	const setText = vi.fn();
 	const showStatus = vi.fn();
@@ -65,6 +68,7 @@ function createSwitchRuntime(options?: { roleThinkingLevel?: string }) {
 						getAll: () => FAKE_MODELS,
 						getAvailable: () => FAKE_MODELS,
 					},
+					scopedModels: (options?.scopedModels ?? []).map(model => ({ model })),
 					setModelTemporary,
 					resolveTemporaryModelThinkingLevel,
 				},
@@ -123,5 +127,29 @@ describe("/switch slash command", () => {
 		expect(harness.setModelTemporary).not.toHaveBeenCalled();
 		expect(harness.showStatus).not.toHaveBeenCalled();
 		expect(harness.showError).toHaveBeenCalled();
+	});
+
+	it("rejects an out-of-scope model in a scoped session without switching", async () => {
+		const harness = createSwitchRuntime({ scopedModels: [FAKE_MODELS[0]] });
+
+		const handled = await executeBuiltinSlashCommand("/switch openai/gpt-5.2", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.setModelTemporary).not.toHaveBeenCalled();
+		expect(harness.showStatus).not.toHaveBeenCalled();
+		expect(harness.showError.mock.calls[0][0]).toContain(
+			'Model "openai/gpt-5.2" is outside this session\'s model scope (--models)',
+		);
+	});
+
+	it("accepts an in-scope model in a scoped session", async () => {
+		const harness = createSwitchRuntime({ scopedModels: [FAKE_MODELS[0]] });
+
+		const handled = await executeBuiltinSlashCommand("/switch anthropic/claude-opus-4-5", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.setModelTemporary).toHaveBeenCalledWith(FAKE_MODELS[0], undefined);
+		expect(harness.showError).not.toHaveBeenCalled();
+		expect(harness.showStatus.mock.calls[0][0]).toContain("Session-only model: anthropic/claude-opus-4-5");
 	});
 });


### PR DESCRIPTION
## Summary

`/switch` (alt+p) only opened the compact session model picker. This adds an optional argument so a known model can be selected directly:

```
/switch anthropic/claude-opus-4-5
/switch gpt-5.2
/switch smol
/switch kimi-for-coding:high
```

- The selector resolves through `resolveCliModel` (the same machinery CLI flags and `/prewalk` use) with session `settings` wired in, so `provider/id`, bare ids, configured role names / `@role` aliases, and explicit `:<thinking>` suffixes all work. Unknown selectors surface the resolver's error via `showError`.
- The resolved model is applied with `setModelTemporary(model, resolved.thinkingLevel ?? resolveTemporaryModelThinkingLevel(model))` — identical to the picker's `onPick` — preserving `/switch`'s session-only contract: nothing is persisted to model settings, and `/model` remains the surface for role assignment.
- Bare `/switch` still opens the picker. No `handle` is added, so the command stays TUI-only and the ACP command surface is unchanged.

## Test plan

- `bun test test/slash-commands/` — 120/120 pass, including 4 new cases in `switch.test.ts` driving the real `executeBuiltinSlashCommand` dispatch: direct `provider/id` switch, bare-id resolution, explicit thinking suffix beating the role-derived level, and the unknown-model error path (no switch attempted).
- `bun run check:ts` (biome + tsgo across workspaces) — clean.
