### PR TITLE
fix(bazel): add nixos path && fix audiopus build

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -155,6 +155,12 @@ crate.from_cargo(
 # crate picks up CC/CFLAGS from the Bazel cc toolchain on its own.
 crate.annotation(
     crate = "audiopus_sys",
+    # cmake's GNUInstallDirs defaults to lib64 on 64-bit unix, but the crate's
+    # build.rs hardcodes {out_dir}/lib as the only link-search path. Emit lib64
+    # as a second search path so rustc finds libopus.a regardless of which
+    # libdir cmake chose.
+    patches = ["//bazel/patches:audiopus_sys-lib64-link-search.patch"],
+    patch_args = ["-p1"],
     build_script_env = {
         "CMAKE_POLICY_VERSION_MINIMUM": "3.5",
         # msvc cross only (cmake-rs reads VAR_<triple> before VAR; the key is
@@ -174,7 +180,7 @@ crate.annotation(
         # the UBSan runtime. Opus shipped without sanitizers under
         # cargo-zigbuild too.
         "CFLAGS": "-fno-sanitize=undefined",
-        "PATH": "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin",
+        "PATH": "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/run/current-system/sw/bin",
     },
 )
 

--- a/bazel/patches/audiopus_sys-lib64-link-search.patch
+++ b/bazel/patches/audiopus_sys-lib64-link-search.patch
@@ -1,0 +1,11 @@
+--- a/build.rs
++++ b/build.rs
+@@ -76,6 +76,7 @@ fn link_opus(is_static: bool, opus_build_dir: impl Display) {
+     println!(
+         "cargo:info=Linking Opus as {} lib: {}",
+         is_static_text, opus_build_dir
+     );
+     println!("cargo:rustc-link-lib={}=opus", is_static_text);
+     println!("cargo:rustc-link-search=native={}/lib", opus_build_dir);
++    println!("cargo:rustc-link-search=native={}/lib64", opus_build_dir);
+ }


### PR DESCRIPTION
## What
1. add patch for build with `audiopus_sys`, to have output in `lib64`
2. add `/run/current-system/sw/bin` for universal `cmake/make` path in nixos
<!-- Brief description of the change -->

## Why
fix for build
<!-- Motivation, context, or link to issue (fixes #N) -->

## Testing
manully tested.
<!-- How was this tested? -->

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
