### PR TITLE
fix(coding-agent): honor remote llama.cpp/ollama discovery base urls

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ollama model-manager caches being reused after the configured base URL changed by scoping cache namespaces to the normalized discovery endpoint ([#7087](https://github.com/can1357/oh-my-pi/issues/7087)).
+
 ## [17.2.0] - 2026-07-30
 
 ### Added

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Ollama model-manager caches being reused after the configured base URL changed by scoping cache namespaces to the normalized discovery endpoint ([#7087](https://github.com/can1357/oh-my-pi/issues/7087)).
+- Fixed Ollama model-manager caches being reused after the configured base URL changed by scoping cache namespaces to the normalized native discovery endpoint, including reverse-proxy path prefixes ([#7087](https://github.com/can1357/oh-my-pi/issues/7087)).
 
 ## [17.2.0] - 2026-07-30
 

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -5,6 +5,8 @@ export interface ModelCacheProviderIdOptions {
 
 export function getDefaultModelDiscoveryBaseUrl(providerId: string): string | undefined {
 	switch (providerId) {
+		case "ollama":
+			return "http://127.0.0.1:11434";
 		case "litellm":
 			return Bun.env.LITELLM_BASE_URL ?? "http://localhost:4000/v1";
 		case "opencode-go":
@@ -18,9 +20,24 @@ export function getDefaultModelDiscoveryBaseUrl(providerId: string): string | un
 	}
 }
 
+/** Resolve an Ollama model-cache namespace scoped to the normalized discovery endpoint. */
+export function resolveOllamaModelCacheProviderId(providerId: string, baseUrl?: string): string {
+	const defaultBaseUrl = getDefaultModelDiscoveryBaseUrl("ollama")!;
+	let endpoint = defaultBaseUrl;
+	try {
+		const parsed = new URL(baseUrl ?? defaultBaseUrl);
+		endpoint = `${parsed.protocol}//${parsed.host}`;
+	} catch {
+		// Malformed URLs fall back during discovery, so share the default endpoint's cache.
+	}
+	return `${providerId}:ollama-models-v1:${Bun.hash(endpoint).toString(36)}`;
+}
+
 /** Resolve the cache namespace used by a provider's model-manager options without constructing those options. */
 export function resolveModelCacheProviderId(providerId: string, options: ModelCacheProviderIdOptions = {}): string {
 	switch (providerId) {
+		case "ollama":
+			return resolveOllamaModelCacheProviderId(providerId, options.baseUrl);
 		case "cursor":
 			return "cursor:max-mode-v2";
 		case "litellm": {

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -26,7 +26,9 @@ export function resolveOllamaModelCacheProviderId(providerId: string, baseUrl?: 
 	let endpoint = defaultBaseUrl;
 	try {
 		const parsed = new URL(baseUrl ?? defaultBaseUrl);
-		endpoint = `${parsed.protocol}//${parsed.host}`;
+		const trimmedPath = parsed.pathname.replace(/\/+$/g, "");
+		const nativePath = trimmedPath.endsWith("/v1") ? trimmedPath.slice(0, -3) : trimmedPath;
+		endpoint = `${parsed.protocol}//${parsed.host}${nativePath}`;
 	} catch {
 		// Malformed URLs fall back during discovery, so share the default endpoint's cache.
 	}

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2300,6 +2300,7 @@ export function ollamaModelManagerOptions(config?: OllamaModelManagerConfig): Mo
 	const resolveMetadata = createOllamaMetadataResolver(nativeBaseUrl, config?.fetch);
 	return {
 		providerId: "ollama",
+		cacheProviderId: resolveModelCacheProviderId("ollama", { baseUrl }),
 		fetchDynamicModels: async () => {
 			const openAiCompatible = await fetchOpenAICompatibleModels({
 				api: "openai-responses",

--- a/packages/catalog/test/provider-cache-id.test.ts
+++ b/packages/catalog/test/provider-cache-id.test.ts
@@ -24,3 +24,10 @@ test("lightweight cache resolver matches scoped descriptor inputs", () => {
 		expect(resolveModelCacheProviderId(providerId, config)).toBe(options.cacheProviderId ?? providerId);
 	}
 });
+
+test("ollama cache scope preserves reverse-proxy path prefixes", () => {
+	const teamA = resolveModelCacheProviderId("ollama", { baseUrl: "https://proxy.example/team-a/v1/" });
+	expect(teamA).toBe(resolveModelCacheProviderId("ollama", { baseUrl: "https://proxy.example/team-a" }));
+	expect(teamA).toBe(resolveModelCacheProviderId("ollama", { baseUrl: "https://proxy.example/team-a/" }));
+	expect(teamA).not.toBe(resolveModelCacheProviderId("ollama", { baseUrl: "https://proxy.example/team-b/v1" }));
+});

--- a/packages/catalog/test/provider-cache-id.test.ts
+++ b/packages/catalog/test/provider-cache-id.test.ts
@@ -11,6 +11,7 @@ test("lightweight cache resolver matches every descriptor default", () => {
 test("lightweight cache resolver matches scoped descriptor inputs", () => {
 	const cases = [
 		{ providerId: "litellm", baseUrl: "http://litellm.example:4100/v1" },
+		{ providerId: "ollama", baseUrl: "http://ollama.example:11434/v1/" },
 		{ providerId: "opencode-go", baseUrl: "https://opencode.example/go" },
 		{ providerId: "opencode-zen", baseUrl: "https://opencode.example/zen/v1/" },
 		{ providerId: "vllm", baseUrl: "http://vllm.example:8000/v1" },

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a remote or LAN `LLAMA_CPP_BASE_URL` (and `OLLAMA_BASE_URL`/`OLLAMA_HOST`) being ignored during model discovery: the `/models` and `/props` probes used a 250ms timeout tuned for a loopback server, so a host reached over the network exceeded it, discovery returned no models, and the picker fell back to stale `127.0.0.1:8080` entries. Non-loopback hosts now get a generous discovery timeout while the loopback default keeps its fast fail ([#7087](https://github.com/can1357/oh-my-pi/issues/7087)).
+
 ## [17.2.0] - 2026-07-30
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed a remote or LAN `LLAMA_CPP_BASE_URL` (and `OLLAMA_BASE_URL`/`OLLAMA_HOST`) being ignored during model discovery: the `/models` and `/props` probes used a 250ms timeout tuned for a loopback server, so a host reached over the network exceeded it, discovery returned no models, and the picker fell back to stale `127.0.0.1:8080` entries. Non-loopback hosts now get a generous discovery timeout while the loopback default keeps its fast fail ([#7087](https://github.com/can1357/oh-my-pi/issues/7087)).
+- Fixed remote or LAN local-engine endpoints being ignored during model discovery: the llama.cpp and Ollama probes used timeouts tuned for loopback, so a host reached over the network could exceed them and return no models, while changing `OLLAMA_BASE_URL`/`OLLAMA_HOST` could keep reusing a fresh cache from the previous endpoint. Non-loopback hosts now get a generous discovery timeout, and Ollama cache rows are scoped to the normalized endpoint ([#7087](https://github.com/can1357/oh-my-pi/issues/7087)).
 
 ## [17.2.0] - 2026-07-30
 

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -62,6 +62,33 @@ async function withTimeoutSignal<T>(timeoutMs: number, fn: (signal: AbortSignal)
 	}
 }
 
+/** Generous discovery budget for a non-loopback (remote / LAN) inference host. */
+const REMOTE_DISCOVERY_TIMEOUT_MS = 10_000;
+
+/**
+ * Pick a discovery-probe timeout for a local-engine base URL.
+ *
+ * The implicit `127.0.0.1` default probe keeps a tight `loopbackMs` cap so a
+ * busy or foreign service on the default port never stalls startup. But that
+ * cap is far too short for a host reached over the network: a user who points
+ * `LLAMA_CPP_BASE_URL` / `OLLAMA_BASE_URL` / `OLLAMA_HOST` at a remote or LAN
+ * machine has real round-trip latency, and a 250ms cap made that server look
+ * empty (issue #7087). Anything that is not strictly loopback therefore gets
+ * {@link REMOTE_DISCOVERY_TIMEOUT_MS}.
+ */
+export function discoveryProbeTimeoutMs(baseUrl: string, loopbackMs: number): number {
+	let hostname: string;
+	try {
+		hostname = new URL(baseUrl).hostname;
+	} catch {
+		return loopbackMs;
+	}
+	hostname = hostname.replace(/^\[/, "").replace(/\]$/, "");
+	const isLoopback =
+		hostname === "localhost" || hostname === "0.0.0.0" || hostname === "::1" || /^127\./.test(hostname);
+	return isLoopback ? loopbackMs : REMOTE_DISCOVERY_TIMEOUT_MS;
+}
+
 const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434";
 const OLLAMA_HOST_DEFAULT_PORT = "11434";
 
@@ -391,7 +418,7 @@ async function discoverOllamaModelMetadata(
 ): Promise<OllamaDiscoveredModelMetadata | null> {
 	const showUrl = `${endpoint}/api/show`;
 	try {
-		const payload = await withTimeoutSignal(150, async signal => {
+		const payload = await withTimeoutSignal(discoveryProbeTimeoutMs(endpoint, 150), async signal => {
 			const response = await ctx.fetch(showUrl, {
 				method: "POST",
 				headers: { ...(headers ?? {}), "Content-Type": "application/json" },
@@ -444,7 +471,7 @@ export async function discoverOllamaModels(
 	const endpoint = normalizeOllamaBaseUrl(providerConfig.baseUrl);
 	const tagsUrl = `${endpoint}/api/tags`;
 	const headers = { ...(providerConfig.headers ?? {}) };
-	const payload = await withTimeoutSignal(250, async signal => {
+	const payload = await withTimeoutSignal(discoveryProbeTimeoutMs(endpoint, 250), async signal => {
 		const response = await ctx.fetch(tagsUrl, {
 			headers,
 			signal,
@@ -491,7 +518,7 @@ async function discoverLlamaCppServerMetadata(
 ): Promise<LlamaCppDiscoveredServerMetadata | null> {
 	const propsUrl = `${toLlamaCppNativeBaseUrl(baseUrl)}/props`;
 	try {
-		const payload = await withTimeoutSignal(150, async signal => {
+		const payload = await withTimeoutSignal(discoveryProbeTimeoutMs(baseUrl, 150), async signal => {
 			const response = await ctx.fetch(propsUrl, {
 				headers,
 				signal,
@@ -567,7 +594,7 @@ export async function discoverLlamaCppModels(
 	let headers = baseHeaders;
 	const attempt = async (h: Record<string, string>) => {
 		const [payload, metadata] = await Promise.all([
-			withTimeoutSignal(250, async signal => {
+			withTimeoutSignal(discoveryProbeTimeoutMs(baseUrl, 250), async signal => {
 				const response = await ctx.fetch(modelsUrl, {
 					headers: h,
 					signal,
@@ -641,7 +668,7 @@ export async function discoverLlamaCppModelRuntimeMetadata(
 	const baseHeaders: Record<string, string> = { ...(model.headers ?? {}) };
 	const attempt = async (headers: Record<string, string>) => {
 		const [entries, serverMetadata] = await Promise.all([
-			withTimeoutSignal(250, async signal => {
+			withTimeoutSignal(discoveryProbeTimeoutMs(nativeBaseUrl, 250), async signal => {
 				const response = await ctx.fetch(modelsUrl, {
 					headers,
 					signal,

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -27,6 +27,7 @@ import {
 	openaiCodexModelManagerOptions,
 	PROVIDER_DESCRIPTORS,
 	resolveModelCacheProviderId,
+	resolveOllamaModelCacheProviderId,
 } from "@oh-my-pi/pi-catalog/provider-models";
 import {
 	collapseBuiltModelVariants,
@@ -1699,6 +1700,9 @@ export class ModelRegistry {
 	}
 
 	#configuredDiscoveryCacheProviderId(providerConfig: DiscoveryProviderConfig): string {
+		if (providerConfig.discovery.type === "ollama") {
+			return resolveOllamaModelCacheProviderId(providerConfig.provider, providerConfig.baseUrl);
+		}
 		if (providerConfig.discovery.type === "openai-models-list") {
 			return `${providerConfig.provider}:openai-models-list-context-v2`;
 		}

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -8,6 +8,7 @@ import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { resolveOllamaModelCacheProviderId } from "@oh-my-pi/pi-catalog/provider-models";
 import type { ModelSpec, OpenAICompat } from "@oh-my-pi/pi-catalog/types";
 import { applyLlamaCppQwenThinking, discoveryProbeTimeoutMs } from "@oh-my-pi/pi-coding-agent/config/model-discovery";
 import { kNoAuth, ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -74,7 +75,7 @@ describe("ModelRegistry runtime discovery", () => {
 	});
 
 	function writeCachedOllamaModels(models: Model<"openai-completions">[], updatedAt = Date.now()) {
-		writeModelCache("ollama", updatedAt, models, true, "", cacheDbPath);
+		writeModelCache(resolveOllamaModelCacheProviderId("ollama"), updatedAt, models, true, "", cacheDbPath);
 	}
 
 	function getModelsForProvider(registry: ModelRegistry, provider: string) {
@@ -541,6 +542,41 @@ describe("ModelRegistry runtime discovery", () => {
 
 		const model = registry.find("ollama", "phi4-mini");
 		expect(model?.baseUrl).toBe("http://omp-ollama.example:2222/v1");
+	});
+
+	test("refreshes implicit Ollama discovery when the configured endpoint changes", async () => {
+		const requested: string[] = [];
+		{
+			using _baseUrl = withEnv("OLLAMA_BASE_URL", "http://old-ollama.example:11434/v1/");
+			const fetchOld = mockOllamaDiscovery(["old-model"], "http://old-ollama.example:11434");
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, {
+				fetch: async (input, init) => {
+					requested.push(String(input));
+					return fetchOld(input, init);
+				},
+			});
+			await registry.refresh();
+			expect(registry.find("ollama", "old-model")).toBeDefined();
+		}
+
+		{
+			using _baseUrl = withEnv("OLLAMA_BASE_URL", "http://new-ollama.example:11434");
+			const fetchNew = mockOllamaDiscovery(["new-model"], "http://new-ollama.example:11434");
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, {
+				fetch: async (input, init) => {
+					requested.push(String(input));
+					return fetchNew(input, init);
+				},
+			});
+			// The old endpoint has a fresh cache row, but default refresh must
+			// miss that namespace and discover against the new endpoint.
+			await registry.refresh();
+			expect(registry.find("ollama", "old-model")).toBeUndefined();
+			expect(registry.find("ollama", "new-model")?.baseUrl).toBe("http://new-ollama.example:11434/v1");
+		}
+
+		expect(requested).toContain("http://old-ollama.example:11434/api/tags");
+		expect(requested).toContain("http://new-ollama.example:11434/api/tags");
 	});
 
 	test("uses OLLAMA_CONTEXT_LENGTH for implicit ollama context accounting", async () => {

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -9,7 +9,7 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import type { ModelSpec, OpenAICompat } from "@oh-my-pi/pi-catalog/types";
-import { applyLlamaCppQwenThinking } from "@oh-my-pi/pi-coding-agent/config/model-discovery";
+import { applyLlamaCppQwenThinking, discoveryProbeTimeoutMs } from "@oh-my-pi/pi-coding-agent/config/model-discovery";
 import { kNoAuth, ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -1201,6 +1201,36 @@ describe("ModelRegistry runtime discovery", () => {
 		// (meta/status.args/architecture.input_modalities) must stay on /models.
 		expect(requested).toContain("http://127.0.0.1:8080/models");
 		expect(requested).not.toContain("http://127.0.0.1:8080/v1/models");
+	});
+
+	test("discoveryProbeTimeoutMs keeps loopback fast but gives non-loopback hosts a larger budget", () => {
+		// Regression: the loopback-tuned probe timeout was applied to every host,
+		// so a remote/LAN LLAMA_CPP_BASE_URL with normal round-trip latency timed
+		// out and the model list came back empty (#7087). Loopback keeps the tight
+		// budget; anything reached over the network gets a strictly larger one.
+		const loopbackMs = 250;
+		for (const host of [
+			"http://127.0.0.1:8080",
+			"http://127.5.6.7:8080",
+			"http://localhost:8080",
+			"http://[::1]:8080",
+			"http://0.0.0.0:8080",
+		]) {
+			expect(discoveryProbeTimeoutMs(host, loopbackMs)).toBe(loopbackMs);
+		}
+		const remoteBudgets = [
+			"http://remote-llama.test:8080",
+			"http://192.168.1.50:8080",
+			"http://172.18.0.3:8080",
+			"http://10.0.0.4:8080",
+			"http://box.local:8080",
+		].map(host => discoveryProbeTimeoutMs(host, loopbackMs));
+		for (const budget of remoteBudgets) {
+			expect(budget).toBeGreaterThan(loopbackMs);
+		}
+		// A consistent budget for every non-loopback host, independent of the tight cap.
+		expect(new Set(remoteBudgets).size).toBe(1);
+		expect(discoveryProbeTimeoutMs("http://remote-llama.test:8080", 150)).toBe(remoteBudgets[0]);
 	});
 
 	test("llama.cpp discovery marks per-model architecture image modalities as vision-capable", async () => {


### PR DESCRIPTION
## Repro
With a remote or LAN `LLAMA_CPP_BASE_URL`, model discovery returns nothing and the picker falls back to the localhost default. Reproduced against a mock host that answers after 400ms (normal remote round-trip latency):

```
# instant host → discovered
LLAMA_CPP_BASE_URL=http://127.0.0.1:40903 omp models llama.cpp   → llama.cpp (1): remote-model-A
# 400ms non-loopback host → times out
LLAMA_CPP_BASE_URL=http://172.18.0.3:34759 omp models llama.cpp  → No models matching "llama.cpp"
```

When a stale localhost cache exists, the empty result falls back to those entries, which is the `404 on 127.0.0.1:8080` the reporter saw.

## Cause
`packages/coding-agent/src/config/model-discovery.ts` probes `/models` and `/props` for `llama.cpp` (and `/api/tags` + `/api/show` for `ollama`) with a `withTimeoutSignal(250, …)` / `150ms` cap. That budget was tuned for a loopback server but applied to every host, including a user-configured remote/LAN base URL whose round-trip latency exceeds it. `LLAMA_CPP_BASE_URL` is read correctly; the probe just aborts before the response arrives.

## Fix
- Added `discoveryProbeTimeoutMs(baseUrl, loopbackMs)`: strictly-loopback hosts (`127.0.0.0/8`, `localhost`, `::1`, `0.0.0.0`) keep the tight `loopbackMs` fast-fail; any non-loopback host gets `REMOTE_DISCOVERY_TIMEOUT_MS` (10s, matching the OpenAI-models-list / LM Studio discovery budget).
- Routed all five local-engine discovery probes (llama.cpp `/models`, `/props`, runtime-metadata `/models`; ollama `/api/tags`, `/api/show`) through it, preserving each site's existing loopback value.
- Added a deterministic contract test for the timeout selection and a changelog entry.

## Verification
`bun test packages/coding-agent/test/model-discovery.test.ts` → 58 pass. Manually confirmed with a 400ms non-loopback mock host: before the fix `omp models llama.cpp` printed `No models`; after the fix it lists the remote model. Loopback discovery is unchanged. Fixes #7087