### PR TITLE
fix(coding-agent): add createEditTool/createWriteTool to legacy pi shim

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp install` failing extension validation for pi extensions that import `createEditTool` or `createWriteTool` (e.g. gentle-pi) — the legacy `@oh-my-pi/pi-coding-agent` shim exported the read/bash/grep/find/ls tool factories but omitted the edit and write ones, so a named import threw Bun's static "Export named X not found" error. Added `createEditTool`/`createEditToolDefinition` and `createWriteTool`/`createWriteToolDefinition` to match the upstream pi surface ([#7094](https://github.com/can1357/oh-my-pi/issues/7094)).
+
 ## [17.2.0] - 2026-07-30
 
 ### Breaking Changes

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -140,6 +140,25 @@ export interface LsToolOptions {
 	operations?: LsOperations;
 }
 
+export interface EditOperations {
+	readFile: (absolutePath: string) => Promise<Buffer>;
+	writeFile: (absolutePath: string, content: string) => Promise<void>;
+	access: (absolutePath: string) => Promise<void>;
+}
+
+export interface EditToolOptions {
+	operations?: EditOperations;
+}
+
+export interface WriteOperations {
+	writeFile: (absolutePath: string, content: string) => Promise<void>;
+	mkdir: (dir: string) => Promise<void>;
+}
+
+export interface WriteToolOptions {
+	operations?: WriteOperations;
+}
+
 const legacyBashSchema = Type.Object({
 	command: Type.String({ description: "Bash command to execute" }),
 	timeout: Type.Optional(Type.Number({ description: "Timeout in seconds" })),
@@ -634,6 +653,40 @@ export function createLsToolDefinition(cwd: string, options?: LsToolOptions): To
 /** Create the legacy ls tool. */
 export function createLsTool(cwd: string, options?: LsToolOptions): ToolDefinition {
 	return createLsToolDefinition(cwd, options);
+}
+
+/** Create the legacy edit tool definition. */
+export function createEditToolDefinition(cwd: string, options?: EditToolOptions): ToolDefinition {
+	if (options?.operations) {
+		throw new Error(
+			"Legacy EditToolOptions.operations is not supported: OMP's built-in edit tool writes the local " +
+				"filesystem natively and exposes no pluggable operations seam. Register a custom edit tool via " +
+				"defineTool() instead of passing operations to createEditTool()/createEditToolDefinition().",
+		);
+	}
+	return legacyBuiltinTool(cwd, "edit");
+}
+
+/** Create the legacy edit tool. */
+export function createEditTool(cwd: string, options?: EditToolOptions): ToolDefinition {
+	return createEditToolDefinition(cwd, options);
+}
+
+/** Create the legacy write tool definition. */
+export function createWriteToolDefinition(cwd: string, options?: WriteToolOptions): ToolDefinition {
+	if (options?.operations) {
+		throw new Error(
+			"Legacy WriteToolOptions.operations is not supported: OMP's built-in write tool writes the local " +
+				"filesystem natively and exposes no pluggable operations seam. Register a custom write tool via " +
+				"defineTool() instead of passing operations to createWriteTool()/createWriteToolDefinition().",
+		);
+	}
+	return legacyBuiltinTool(cwd, "write");
+}
+
+/** Create the legacy write tool. */
+export function createWriteTool(cwd: string, options?: WriteToolOptions): ToolDefinition {
+	return createWriteToolDefinition(cwd, options);
 }
 
 /** Create legacy read, bash, edit, and write tools. */

--- a/packages/coding-agent/test/extensibility/legacy-pi-edit-write-tools.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-edit-write-tools.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import * as shim from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
+
+// Issue #7094: pi extensions import the edit/write tool factories
+// (`createEditTool`, `createEditToolDefinition`, `createWriteTool`,
+// `createWriteToolDefinition`) from `@earendil-works/pi-coding-agent`, which
+// aliases to this shim. The shim exported the other five tool factories
+// (read/bash/grep/find/ls) but omitted edit and write, so a named import of
+// either threw Bun's static "Export named X not found" error and any importing
+// extension (e.g. gentle-pi) failed validation. These pin the factory surface
+// and the tool definitions they build.
+describe("legacy shim edit/write tool factories", () => {
+	it("exports the edit/write factories as callable functions", () => {
+		expect(typeof shim.createEditTool).toBe("function");
+		expect(typeof shim.createEditToolDefinition).toBe("function");
+		expect(typeof shim.createWriteTool).toBe("function");
+		expect(typeof shim.createWriteToolDefinition).toBe("function");
+	});
+
+	it("builds edit and write tool definitions bound to the built-in tools", () => {
+		const edit = shim.createEditTool(process.cwd());
+		expect(edit.name).toBe("edit");
+		expect(typeof edit.execute).toBe("function");
+
+		const write = shim.createWriteTool(process.cwd());
+		expect(write.name).toBe("write");
+		expect(typeof write.execute).toBe("function");
+	});
+
+	it("rejects the unsupported operations seam", () => {
+		expect(() => shim.createEditTool(process.cwd(), { operations: {} as never })).toThrow(
+			/operations is not supported/,
+		);
+		expect(() => shim.createWriteTool(process.cwd(), { operations: {} as never })).toThrow(
+			/operations is not supported/,
+		);
+	});
+});


### PR DESCRIPTION
## Repro
`omp install gentle-pi` fails during extension validation: gentle-pi's `extensions/quiet-tools.ts` imports `createEditTool` and `createWriteTool` from `@earendil-works/pi-coding-agent` (which omp aliases to the legacy shim), and Bun's static export check throws `Export named 'createWriteTool' not found in module`. Reproduced in-repo with `bun -e 'import { createEditTool, createWriteTool } from "<repo>/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim"'` (exit 1, same `SyntaxError`).

## Cause
`packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts` exports factories for five of the seven built-in tools (`createReadTool`, `createBashTool`, `createGrepTool`, `createFindTool`, `createLsTool`, plus their `*Definition` variants) but omits the edit and write factories. Upstream pi `0.83.0` exports `createEditTool`/`createEditToolDefinition`/`createWriteTool`/`createWriteToolDefinition`, so any pi extension importing them fails validation against omp. Same class as #5968, #6583, #3808.

## Fix
- Added `EditOperations`/`EditToolOptions` and `WriteOperations`/`WriteToolOptions` interfaces mirroring the upstream shapes.
- Added `createEditToolDefinition`/`createEditTool` and `createWriteToolDefinition`/`createWriteTool`, building the real built-in tools via `legacyBuiltinTool(cwd, "edit"|"write")` and mirroring the existing sibling factories.
- The unsupported `operations` seam throws a descriptive error, matching the `createGrepTool` precedent (omp's edit/write tools have no pluggable filesystem seam).
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/extensibility/legacy-pi-edit-write-tools.test.ts` → 3 pass / 0 fail. The in-repo repro import now prints `function function` (exit 0). New regression test pins the factory surface, the built tool identities (`edit`/`write`), and the operations-seam rejection.

Fixes #7094