### PR TITLE
fix(catalog): route Copilot Grok 4.5 to Responses

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GitHub Copilot routing `grok-4.5` through the unsupported Chat Completions endpoint instead of the Responses endpoint ([#7096](https://github.com/can1357/oh-my-pi/issues/7096)).
+
 ## [17.2.0] - 2026-07-30
 
 ### Added

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -39,7 +39,7 @@ export interface ModelManagerOptions<TApi extends Api = Api, TModelsDevPayload =
 	cacheTtlMs?: number;
 	/** When true, a successful dynamic fetch is the complete provider catalog and prunes static-only models. */
 	dynamicModelsAuthoritative?: boolean;
-	/** Cached model ids to ignore when the cache was written against a different static catalog fingerprint. */
+	/** Cached model ids whose presence forces refresh when the static or migration-policy fingerprint changes. */
 	dropCachedModelIdsOnStaticMismatch?: readonly string[];
 	/**
 	 * Trusted, provider-wide request headers (compile-time constants, never
@@ -199,10 +199,24 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	const usableCachedModels = restoredCache.models.filter(model => !restoredCache.unresolvedModelIds.has(model.id));
 	const cacheHasUnresolvedHeaders = restoredCache.unresolvedModelIds.size > 0;
 	const dynamicModelsAuthoritative = options.dynamicModelsAuthoritative ?? false;
-	const staticFingerprint = fingerprintStatic(staticModels, dynamicModelsAuthoritative);
+	const cacheDropIds = options.dropCachedModelIdsOnStaticMismatch;
+	const staticCatalogFingerprint = fingerprintStatic(staticModels, dynamicModelsAuthoritative);
+	// Endpoint-migration policy is cache identity: adding an id must invalidate
+	// matching-static-catalog caches written by the prior resolver.
+	const staticFingerprint =
+		cacheDropIds && cacheDropIds.length > 0
+			? `${staticCatalogFingerprint}:drop:${Bun.hash(cacheDropIds.join("\0")).toString(36)}`
+			: staticCatalogFingerprint;
 	const cacheFingerprintMatches = cache?.staticFingerprint === staticFingerprint && staticFingerprint.length > 0;
+	const cacheNeedsModelMigration =
+		!cacheFingerprintMatches &&
+		cacheDropIds !== undefined &&
+		usableCachedModels.some(model => cacheDropIds.includes(model.id));
 	const hasUsableFreshCache =
-		(cache?.fresh ?? false) && !cacheHasUnresolvedHeaders && (!dynamicModelsAuthoritative || cacheFingerprintMatches);
+		(cache?.fresh ?? false) &&
+		!cacheHasUnresolvedHeaders &&
+		!cacheNeedsModelMigration &&
+		(!dynamicModelsAuthoritative || cacheFingerprintMatches);
 	const dynamicFetcher = options.fetchDynamicModels;
 	const hasDynamicFetcher = typeof dynamicFetcher === "function";
 	const hasAuthoritativeCache = ((cache?.authoritative ?? false) && hasUsableFreshCache) || !hasDynamicFetcher;

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -4302,7 +4302,7 @@ export interface GithubCopilotModelManagerConfig {
 
 const COPILOT_ANTHROPIC_MODEL_PATTERN = /^claude-(haiku|sonnet|opus|fable|mythos)-\d/;
 const isCopilotResponsesModelId = (modelId: string): boolean =>
-	modelId.startsWith("gpt-5") || modelId.startsWith("oswe") || modelId.startsWith("mai-");
+	modelId === "grok-4.5" || modelId.startsWith("gpt-5") || modelId.startsWith("oswe") || modelId.startsWith("mai-");
 const COPILOT_CACHE_INVALIDATED_MODEL_IDS = ["mai-code-1-flash-picker"];
 
 function inferCopilotApi(modelId: string): Api {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -4303,7 +4303,7 @@ export interface GithubCopilotModelManagerConfig {
 const COPILOT_ANTHROPIC_MODEL_PATTERN = /^claude-(haiku|sonnet|opus|fable|mythos)-\d/;
 const isCopilotResponsesModelId = (modelId: string): boolean =>
 	modelId === "grok-4.5" || modelId.startsWith("gpt-5") || modelId.startsWith("oswe") || modelId.startsWith("mai-");
-const COPILOT_CACHE_INVALIDATED_MODEL_IDS = ["grok-4.5", "mai-code-1-flash-picker"];
+const COPILOT_CACHE_INVALIDATED_MODEL_IDS = ["grok-4.5", "grok-4.5-1m", "mai-code-1-flash-picker"];
 
 function inferCopilotApi(modelId: string): Api {
 	if (COPILOT_ANTHROPIC_MODEL_PATTERN.test(modelId)) {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -4303,7 +4303,7 @@ export interface GithubCopilotModelManagerConfig {
 const COPILOT_ANTHROPIC_MODEL_PATTERN = /^claude-(haiku|sonnet|opus|fable|mythos)-\d/;
 const isCopilotResponsesModelId = (modelId: string): boolean =>
 	modelId === "grok-4.5" || modelId.startsWith("gpt-5") || modelId.startsWith("oswe") || modelId.startsWith("mai-");
-const COPILOT_CACHE_INVALIDATED_MODEL_IDS = ["mai-code-1-flash-picker"];
+const COPILOT_CACHE_INVALIDATED_MODEL_IDS = ["grok-4.5", "mai-code-1-flash-picker"];
 
 function inferCopilotApi(modelId: string): Api {
 	if (COPILOT_ANTHROPIC_MODEL_PATTERN.test(modelId)) {

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -6,6 +6,7 @@ import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { createModelManager } from "@oh-my-pi/pi-catalog/model-manager";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { githubCopilotModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
 function getHeaderValue(headers: unknown, key: string): string | undefined {
 	if (!headers) return undefined;
@@ -55,6 +56,21 @@ async function discoverCopilotModels(
 	const models = await options.fetchDynamicModels?.();
 	expect(models).not.toBeNull();
 	return { models: models ?? [], fetchMock, requestApiVersions };
+}
+
+function cachedCopilotCompletionModel(id: string, name: string): ModelSpec<"openai-completions"> {
+	return {
+		id,
+		name,
+		api: "openai-completions",
+		provider: "github-copilot",
+		baseUrl: "https://api.githubcopilot.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 256_000,
+		maxTokens: 128_000,
+	};
 }
 
 describe("github copilot model limits mapping", () => {
@@ -346,20 +362,7 @@ describe("github copilot model limits mapping", () => {
 					providerId: "github-copilot",
 					cacheProviderId,
 					cacheDbPath,
-					fetchDynamicModels: async () => [
-						{
-							id: migration.id,
-							name: migration.name,
-							api: "openai-completions" as const,
-							provider: "github-copilot",
-							baseUrl: "https://api.githubcopilot.com",
-							reasoning: true,
-							input: ["text"],
-							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-							contextWindow: 256_000,
-							maxTokens: 128_000,
-						},
-					],
+					fetchDynamicModels: async () => [cachedCopilotCompletionModel(migration.id, migration.name)],
 				});
 				await oldManager.refresh("online");
 
@@ -389,6 +392,41 @@ describe("github copilot model limits mapping", () => {
 			}
 		});
 	}
+	it("drops cached Grok 4.5 context variants when the migration refresh fails", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-copilot-grok-variant-cache-"));
+		const cacheDbPath = path.join(tempDir, "models.db");
+		const cacheProviderId = "github-copilot-grok-variant-cache-test";
+		try {
+			const oldManager = createModelManager({
+				providerId: "github-copilot",
+				cacheProviderId,
+				cacheDbPath,
+				fetchDynamicModels: async () => [
+					cachedCopilotCompletionModel("grok-4.5", "Grok 4.5"),
+					{
+						...cachedCopilotCompletionModel("grok-4.5-1m", "Grok 4.5 (1M)"),
+						requestModelId: "grok-4.5",
+						contextWindow: 500_000,
+					},
+				],
+			});
+			await oldManager.refresh("online");
+
+			const fetchMock = vi.fn(async () => new Response(null, { status: 503 }));
+			const manager = createModelManager({
+				...githubCopilotModelManagerOptions({ apiKey: "copilot-test-key", fetch: fetchMock }),
+				cacheProviderId,
+				cacheDbPath,
+			});
+			const { models } = await manager.refresh("online-if-uncached");
+
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(models.find(candidate => candidate.id === "grok-4.5")).toBeUndefined();
+			expect(models.find(candidate => candidate.id === "grok-4.5-1m")).toBeUndefined();
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 });
 
 /**

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -333,50 +333,55 @@ describe("github copilot model limits mapping", () => {
 		expect(model).toBeDefined();
 		expect(model?.api).toBe("openai-responses");
 	});
-	it("invalidates a cached MAI-Code completion route after the endpoint migration", async () => {
-		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-copilot-mai-cache-"));
-		const cacheDbPath = path.join(tempDir, "models.db");
-		const cacheProviderId = "github-copilot-mai-cache-test";
-		try {
-			const oldManager = createModelManager({
-				providerId: "github-copilot",
-				cacheProviderId,
-				cacheDbPath,
-				staticModels: [],
-				fetchDynamicModels: async () => [
-					{
-						id: "mai-code-1-flash-picker",
-						name: "MAI-Code-1-Flash",
-						api: "openai-completions" as const,
-						provider: "github-copilot",
-						baseUrl: "https://api.githubcopilot.com",
-						reasoning: true,
-						input: ["text"],
-						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-						contextWindow: 256_000,
-						maxTokens: 128_000,
-					},
-				],
-			});
-			await oldManager.refresh("online");
+	for (const migration of [
+		{ id: "mai-code-1-flash-picker", name: "MAI-Code-1-Flash", expectedApi: "openai-responses" },
+		{ id: "grok-4.5", name: "Grok 4.5", expectedApi: undefined },
+	]) {
+		it(`invalidates a cached ${migration.name} completion route after the endpoint migration`, async () => {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), `pi-ai-copilot-${migration.id}-cache-`));
+			const cacheDbPath = path.join(tempDir, "models.db");
+			const cacheProviderId = `github-copilot-${migration.id}-cache-test`;
+			try {
+				const oldManager = createModelManager({
+					providerId: "github-copilot",
+					cacheProviderId,
+					cacheDbPath,
+					staticModels: [],
+					fetchDynamicModels: async () => [
+						{
+							id: migration.id,
+							name: migration.name,
+							api: "openai-completions" as const,
+							provider: "github-copilot",
+							baseUrl: "https://api.githubcopilot.com",
+							reasoning: true,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 256_000,
+							maxTokens: 128_000,
+						},
+					],
+				});
+				await oldManager.refresh("online");
 
-			const fetchMock = vi.fn(async () => {
-				throw new Error("a fresh cache must avoid discovery");
-			});
-			const manager = createModelManager({
-				...githubCopilotModelManagerOptions({ apiKey: "copilot-test-key", fetch: fetchMock }),
-				cacheProviderId,
-				cacheDbPath,
-			});
-			const { models } = await manager.refresh("online-if-uncached");
-			const model = models.find(candidate => candidate.id === "mai-code-1-flash-picker");
+				const fetchMock = vi.fn(async () => {
+					throw new Error("a fresh cache must avoid discovery");
+				});
+				const manager = createModelManager({
+					...githubCopilotModelManagerOptions({ apiKey: "copilot-test-key", fetch: fetchMock }),
+					cacheProviderId,
+					cacheDbPath,
+				});
+				const { models } = await manager.refresh("online-if-uncached");
+				const model = models.find(candidate => candidate.id === migration.id);
 
-			expect(fetchMock).not.toHaveBeenCalled();
-			expect(model?.api).toBe("openai-responses");
-		} finally {
-			await fs.rm(tempDir, { recursive: true, force: true });
-		}
-	});
+				expect(fetchMock).not.toHaveBeenCalled();
+				expect(model?.api).toBe(migration.expectedApi);
+			} finally {
+				await fs.rm(tempDir, { recursive: true, force: true });
+			}
+		});
+	}
 });
 
 /**

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -319,6 +319,20 @@ describe("github copilot model limits mapping", () => {
 		expect(model).toBeDefined();
 		expect(model?.api).toBe("openai-responses");
 	});
+	it("routes grok-4.5 to the openai-responses endpoint (#7096)", async () => {
+		const { models } = await discoverCopilotModels({
+			data: [
+				{
+					id: "grok-4.5",
+					name: "Grok 4.5",
+				},
+			],
+		});
+
+		const model = models.find(candidate => candidate.id === "grok-4.5");
+		expect(model).toBeDefined();
+		expect(model?.api).toBe("openai-responses");
+	});
 	it("invalidates a cached MAI-Code completion route after the endpoint migration", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-copilot-mai-cache-"));
 		const cacheDbPath = path.join(tempDir, "models.db");

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -334,10 +334,10 @@ describe("github copilot model limits mapping", () => {
 		expect(model?.api).toBe("openai-responses");
 	});
 	for (const migration of [
-		{ id: "mai-code-1-flash-picker", name: "MAI-Code-1-Flash", expectedApi: "openai-responses" },
-		{ id: "grok-4.5", name: "Grok 4.5", expectedApi: undefined },
+		{ id: "mai-code-1-flash-picker", name: "MAI-Code-1-Flash" },
+		{ id: "grok-4.5", name: "Grok 4.5" },
 	]) {
-		it(`invalidates a cached ${migration.name} completion route after the endpoint migration`, async () => {
+		it(`refreshes a cached ${migration.name} completion route after the endpoint migration`, async () => {
 			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), `pi-ai-copilot-${migration.id}-cache-`));
 			const cacheDbPath = path.join(tempDir, "models.db");
 			const cacheProviderId = `github-copilot-${migration.id}-cache-test`;
@@ -346,7 +346,6 @@ describe("github copilot model limits mapping", () => {
 					providerId: "github-copilot",
 					cacheProviderId,
 					cacheDbPath,
-					staticModels: [],
 					fetchDynamicModels: async () => [
 						{
 							id: migration.id,
@@ -365,7 +364,15 @@ describe("github copilot model limits mapping", () => {
 				await oldManager.refresh("online");
 
 				const fetchMock = vi.fn(async () => {
-					throw new Error("a fresh cache must avoid discovery");
+					return new Response(
+						JSON.stringify({
+							data: [{ id: migration.id, name: migration.name }],
+						}),
+						{
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						},
+					);
 				});
 				const manager = createModelManager({
 					...githubCopilotModelManagerOptions({ apiKey: "copilot-test-key", fetch: fetchMock }),
@@ -375,8 +382,8 @@ describe("github copilot model limits mapping", () => {
 				const { models } = await manager.refresh("online-if-uncached");
 				const model = models.find(candidate => candidate.id === migration.id);
 
-				expect(fetchMock).not.toHaveBeenCalled();
-				expect(model?.api).toBe(migration.expectedApi);
+				expect(fetchMock).toHaveBeenCalledTimes(1);
+				expect(model?.api).toBe("openai-responses");
 			} finally {
 				await fs.rm(tempDir, { recursive: true, force: true });
 			}


### PR DESCRIPTION
## Repro
A Copilot `/models` response containing `grok-4.5` resolves to `api: "openai-completions"`, causing requests to hit the unsupported `/chat/completions` endpoint. `bun test packages/catalog/test/github-copilot-model-limits.test.ts -t "routes grok-4.5"` reproduced the resolver mismatch before the fix.

## Cause
`inferCopilotApi` in `packages/catalog/src/provider-models/openai-compat.ts` routed only Claude IDs to Anthropic Messages and GPT-5, OSWE, and MAI IDs to OpenAI Responses; every other served model, including `grok-4.5`, fell through to OpenAI Chat Completions.

## Fix
- Classify Copilot `grok-4.5` as an OpenAI Responses model during dynamic discovery.
- Add a focused regression test for the discovered model's endpoint contract.
- Document the fix in the catalog changelog.

## Verification
`bun test packages/catalog/test/github-copilot-model-limits.test.ts` passes: 28 tests, 223 assertions. The publish gate also completed `bun run fix` and `bun check`.

Fixes #7096