### PR TITLE
fix(commit): load extension-provided models

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp commit` failing to resolve extension-provided models in both the agentic and legacy pipelines ([#7099](https://github.com/can1357/oh-my-pi/issues/7099)).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/commit/agentic/index.ts
+++ b/packages/coding-agent/src/commit/agentic/index.ts
@@ -9,7 +9,7 @@ import { resolvePrimaryModel, resolveSmolModel } from "../../commit/model-select
 import type { CommitCommandArgs, ConventionalAnalysis, NumstatEntry } from "../../commit/types";
 import { ModelRegistry } from "../../config/model-registry";
 import { Settings } from "../../config/settings";
-import { discoverAuthStorage, discoverContextFiles } from "../../sdk";
+import { discoverAuthStorage, discoverContextFiles, loadCliExtensionProviders } from "../../sdk";
 import * as git from "../../utils/git";
 import { type ExistingChangelogEntries, runCommitAgentSession } from "./agent";
 import { generateFallbackProposal } from "./fallback";
@@ -32,6 +32,7 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<void> {
 	process.stdout.write("● Resolving model...\n");
 	const modelRegistry = new ModelRegistry(authStorage);
 	await modelRegistry.refresh();
+	await loadCliExtensionProviders(modelRegistry, settings, cwd);
 	const stagedFilesPromise = (async () => {
 		let stagedFiles = await git.diff.changedFiles(cwd, { cached: true });
 		if (stagedFiles.length === 0) {

--- a/packages/coding-agent/src/commit/pipeline.ts
+++ b/packages/coding-agent/src/commit/pipeline.ts
@@ -4,7 +4,7 @@ import type { Api, ApiKey, Model } from "@oh-my-pi/pi-ai";
 import { getProjectDir, logger, prompt } from "@oh-my-pi/pi-utils";
 import { ModelRegistry } from "../config/model-registry";
 import { Settings } from "../config/settings";
-import { discoverAuthStorage } from "../sdk";
+import { discoverAuthStorage, loadCliExtensionProviders } from "../sdk";
 import { loadProjectContextFiles } from "../system-prompt";
 import * as git from "../utils/git";
 import { runAgenticCommit } from "./agentic";
@@ -40,11 +40,12 @@ export async function runCommitCommand(args: CommitCommandArgs): Promise<void> {
 
 async function runLegacyCommitCommand(args: CommitCommandArgs): Promise<void> {
 	const cwd = getProjectDir();
-	const settings = await Settings.init();
+	const settings = await Settings.init({ cwd });
 	const commitSettings = settings.getGroup("commit");
 	const authStorage = await discoverAuthStorage();
 	const modelRegistry = new ModelRegistry(authStorage);
 	await modelRegistry.refresh();
+	await loadCliExtensionProviders(modelRegistry, settings, cwd);
 
 	const {
 		model: primaryModel,

--- a/packages/coding-agent/test/commit-extension-providers.test.ts
+++ b/packages/coding-agent/test/commit-extension-providers.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as path from "node:path";
+import { runCommitCommand } from "@oh-my-pi/pi-coding-agent/commit";
+import { getProjectAgentDir, setAgentDir, setProjectDir, TempDir } from "@oh-my-pi/pi-utils";
+import { $ } from "bun";
+import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
+
+const PROVIDER = "commit-extension-fixture";
+const MODEL = "deepseek-v4-flash";
+const SELECTOR = `${PROVIDER}/${MODEL}:high`;
+
+let agentTmp: TempDir;
+let tmp: TempDir;
+let settingsState: SettingsTestState | undefined;
+
+beforeEach(async () => {
+	settingsState = beginSettingsTest();
+	tmp = await TempDir.create("@commit-extension-provider-");
+	agentTmp = await TempDir.create("@commit-extension-provider-agent-");
+	setProjectDir(tmp.path());
+	setAgentDir(agentTmp.path());
+
+	const extensionPath = tmp.join("provider.ts");
+	await Bun.write(
+		extensionPath,
+		`export default function (pi) {
+	pi.registerProvider("${PROVIDER}", {
+		baseUrl: "https://example.invalid/v1",
+		apiKey: "fixture-key",
+		api: "openai-completions",
+		models: [{
+			id: "${MODEL}",
+			name: "DeepSeek V4 Flash",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1000000,
+			maxTokens: 384000,
+		}],
+	});
+}
+`,
+	);
+	await Bun.write(
+		path.join(getProjectAgentDir(tmp.path()), "settings.json"),
+		JSON.stringify({
+			extensions: [extensionPath],
+			modelRoles: { commit: SELECTOR },
+		}),
+	);
+
+	await $`git init --initial-branch=main`.cwd(tmp.path()).quiet();
+	await $`git add -A`.cwd(tmp.path()).quiet();
+	await $`git -c user.name=Fixture -c user.email=fixture@example.invalid commit -m baseline`.cwd(tmp.path()).quiet();
+
+	vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+	vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(async () => {
+	restoreSettingsTestState(settingsState);
+	settingsState = undefined;
+	await tmp.remove();
+	await agentTmp.remove();
+});
+
+describe.serial("commit extension provider resolution", () => {
+	test("agentic pipeline resolves an explicit extension-provided model", async () => {
+		await expect(
+			runCommitCommand({
+				push: false,
+				dryRun: true,
+				noChangelog: true,
+				model: SELECTOR,
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	test("legacy pipeline resolves the project commit role from an extension provider", async () => {
+		await expect(
+			runCommitCommand({
+				push: false,
+				dryRun: true,
+				noChangelog: true,
+				legacy: true,
+			}),
+		).resolves.toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Repro

In a clean temporary git repository, configure project `.omp/settings.json` with an extension that calls `pi.registerProvider("plexus-fixture", ...)` and selects `plexus-fixture/deepseek-v4-flash:high`, then run `bun run-commit.ts` and `bun run-commit.ts --legacy`; before this fix both commands exited 1 from `resolvePrimaryModel()` with `No model available for commit generation`.

## Cause

`runAgenticCommit()` in `src/commit/agentic/index.ts` and `runLegacyCommitCommand()` in `src/commit/pipeline.ts` only called `ModelRegistry.refresh()`, which loads built-in catalogs but never discovers extensions or drains their pending provider registrations. The legacy path also initialized `Settings` without its resolved project cwd.

## Fix

- Load discovered extension providers through `loadCliExtensionProviders()` before either pipeline resolves its primary or smol model.
- Initialize legacy settings with the resolved project cwd.
- Add regression coverage for an explicit agentic selector and a project-local legacy commit role backed by an extension provider.
- Record the fix in the coding-agent changelog.

## Verification

`bun test test/commit-extension-providers.test.ts test/cli-extension-providers.test.ts test/commit-model-selection-role-thinking.test.ts` passed: 4 tests, 10 assertions. `bun check` passed. Manual smoke runs against the original temporary extension fixture now resolve `DeepSeek V4 Flash` and exit 0 with `No changes to commit` in both normal and `--legacy` modes.

Fixes #7099