### PR TITLE
fix(test): gave CLI-spawning tests explicit timeouts

### DIFF
--- a/packages/coding-agent/test/cli/completions.test.ts
+++ b/packages/coding-agent/test/cli/completions.test.ts
@@ -224,5 +224,8 @@ describe("omp completions (integration / drift)", () => {
 		// Hidden/default commands must NOT surface as completable subcommands.
 		expect(stdout).not.toContain("_omp_cmd_launch");
 		expect(stdout).not.toContain("_omp_cmd___complete");
-	});
+		// Spawns the whole CLI entry graph, so the wall time is cold-transpile bound
+		// (~1s warm) rather than an assertion about latency. Bun's 5s default starves
+		// it when CI runs several test chunks in parallel on a shared runner.
+	}, 30_000);
 });

--- a/packages/coding-agent/test/eval/process-entry-import.test.ts
+++ b/packages/coding-agent/test/eval/process-entry-import.test.ts
@@ -60,7 +60,9 @@ it("starts ordinary CLI paths without loading the native computer addon", async 
 		const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
 		expect(exitCode, `${args.at(-1)}: ${stderr}`).toBe(0);
 	}
-});
+	// Two cold CLI spawns (`--version`, `--help`) per run; the assertion is the exit
+	// code, not the wall time.
+}, 30_000);
 
 it("dispatches the computer worker through the CLI host selector in a child process", async () => {
 	const fixture = path.resolve(import.meta.dir, "../fixtures/computer-worker-cli-selector.ts");
@@ -134,4 +136,6 @@ it("keeps non-computer selectors isolated in a compiled single-entry worker host
 	]);
 	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toBe('{"ok":true,"kind":"pong"}\n');
-});
+	// Compiles a standalone binary with `bun build --compile` before running it, so
+	// this needs the same headroom as the other compile-backed tests.
+}, 60_000);

--- a/packages/coding-agent/test/profile-cli.test.ts
+++ b/packages/coding-agent/test/profile-cli.test.ts
@@ -270,7 +270,9 @@ describe("global --profile flag", () => {
 		} finally {
 			await removeWithRetries(root);
 		}
-	});
+		// Spawns a probe that imports the command modules, so the cost is cold
+		// transpile of the CLI graph, not latency under test.
+	}, 30_000);
 
 	it("surfaces an invalid OMP_PROFILE env as a clean error, not an import crash", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-profile-cli-env-bad-"));
@@ -319,5 +321,7 @@ describe("global --profile flag", () => {
 		} finally {
 			await removeWithRetries(root);
 		}
-	});
+		// Same cold-spawn cost as the sibling above; it only escapes Bun's 5s
+		// default because that test warms the transpile cache first.
+	}, 30_000);
 });


### PR DESCRIPTION
## What

I kept running into this issue in my PR #6840, so I decided to look into it. The tests that spawn the CLI had no timeout, so I gave them one.

Adds explicit timeouts to the four tests that start the CLI in a child process. Three test files change, +16/-5, no source changes.

| Test | Work | Timeout |
| --- | --- | --- |
| `completions.test.ts`, zsh drift check | One CLI spawn | `30_000` |
| `profile-cli.test.ts`, both `.env` probes | One CLI spawn each | `30_000` |
| `process-entry-import.test.ts`, addon check | Two CLI spawns | `30_000` |
| `process-entry-import.test.ts`, worker host | `bun build --compile`, then run the binary | `60_000` |

The values match the child-process tests that already set one, such as `read-cli-mcp-resource.test.ts` at `30_000` and `acp-stdout-hygiene.test.ts` at `60_000`.

## Why

These tests declared no timeout, so each one got the Bun default of 5000 ms. Almost all of that budget goes to a cold transpile of the `src/cli.ts` module graph, which the tests do not assert:

| Measurement | Time |
| --- | --- |
| `bun src/cli.ts completions zsh`, warm | 875-907 ms |
| The same command, cold | 3.12 s |
| Bun default per-test timeout | 5000 ms |

A cold spawn uses 62 percent of the budget on an idle 16-core machine. CI runs the native bucket with `OMP_TEST_CONCURRENCY=4` on a slower runner, so the spawn crosses 5000 ms:

```
x packages/coding-agent (native/tooling/browser/unit bucket; 613 files; parallel=1 chunk 7/62) [12.3s]
  x test/cli/completions.test.ts > omp completions (integration / drift) > emits a zsh script ...
killed 1 dangling process
(fail) ... [5000.12ms]
  ^ this test timed out after 5000ms.
 88 pass
 1 fail
```

`killed 1 dangling process` shows the cause. The CLI child process was still alive when the timeout fired, so the test never reached an assertion. A real drift failure reports `expect(stdout).toContain("--model")` instead.

CI named one test. I measured every test that starts the CLI and sets no timeout. Three of six fail under the same load. The other three stay inside the default budget, so this change leaves them alone.

| File | Timeouts at 48 concurrent |
| --- | --- |
| `test/cli/completions.test.ts` | 48 of 48 |
| `test/profile-cli.test.ts` | 48 of 48 |
| `test/eval/process-entry-import.test.ts` | 48 of 48 |
| `test/config-cli.test.ts` | 0 of 48 |
| `test/cli-computer-lazy.test.ts` | 0 of 48 |
| `test/markit-converters.test.ts` | 0 of 48 |

`profile-cli.test.ts` gets a timeout on both child-process tests, although only the first one failed. The first test warms the transpile cache for the second one. That order is incidental, so the second test would fail if the order changed.

## Testing

I reproduced the CI failure first, then confirmed the same reproduction passes after the change.

**Reproduction.** The exact CI command passes alone, so I oversubscribed a 16-core machine to load the runner the same way. At 48 concurrent runs the failure appears with the same signature as CI, including the `killed 1 dangling process` line and the `5000.12 ms` stop.

| Load | Before the change |
| --- | --- |
| Chunk 7 alone, exact CI command | 89 pass, 0 fail |
| 4 concurrent, the value CI sets | 89 pass, 0 fail |
| 16 concurrent, one per core | 16 of 16 runs pass |
| 48 concurrent, 3x oversubscribed | **48 of 48 runs fail, `timed out after 5000ms`** |

Only the child-process tests run out of time. The unit tests in the same file keep passing, which gives 13 pass and 1 fail inside `completions.test.ts`.

**After the change.** The same 48-concurrent load passes. I raised it to 64 concurrent runs of all three files and got 0 timeouts and 0 failures.

**Normal runs.**

- The three files together: 29 pass, 0 fail.
- `bun check` at the repository root: exit 0, 3893 files checked.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing). Not user-facing, tests only.
