### PR TITLE
feat(mcp): let a server opt into integer JSON-RPC request ids

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `requestIdFormat` (`"string"` | `"number"`, default `"string"`) to MCP server config, honored by the stdio, HTTP, and SSE transports. JSON-RPC 2.0 permits both id shapes, but Apple's `xcrun mcpbridge` decodes `id` as an integer only and silently drops OMP's snowflake strings (`mcpbridge.DecodeError Code=1`), hanging every request until it times out. Opting a server into `"number"` allocates per-connection sequential integer ids instead. The option is OMP-specific, so set it in an OMP-owned config (`.omp/mcp.json`, `~/.omp/agent/mcp.json`, a project `mcp.json`/`.mcp.json`, or an OMP plugin); servers imported from another tool's config ignore it ([#7053](https://github.com/can1357/oh-my-pi/issues/7053)).
+
 ## [17.2.2] - 2026-07-31
 
 ### Added
@@ -48,9 +52,6 @@
 - Fixed the Python RPC client dropping context, compaction, OAuth URL, and terminal-settlement fields.
 - Fixed the browser tool ignoring the url parameter when opening a new tab on an attached browser.
 - Fixed browser automation disrupting attached browsers by adopting the active foreground tab and avoiding raising new tabs during screenshots.
-- Moved the display-reset default chord (`app.display.reset`) from `Ctrl+L` to `Alt+L` to make room for the live-mode toggle.
-- Updated the hashline edit tool, streaming preview, and plan-mode guidance for the unified `PUT`/`CUT` grammar, `.=` ranges, and named registers.
-- Added `requestIdFormat` (`"string"` | `"number"`, default `"string"`) to MCP server config, honored by the stdio, HTTP, and SSE transports. JSON-RPC 2.0 permits both id shapes, but Apple's `xcrun mcpbridge` decodes `id` as an integer only and silently drops OMP's snowflake strings (`mcpbridge.DecodeError Code=1`), hanging every request until it times out. Opting a server into `"number"` allocates per-connection sequential integer ids instead ([#7053](https://github.com/can1357/oh-my-pi/issues/7053)).
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -48,6 +48,9 @@
 - Fixed the Python RPC client dropping context, compaction, OAuth URL, and terminal-settlement fields.
 - Fixed the browser tool ignoring the url parameter when opening a new tab on an attached browser.
 - Fixed browser automation disrupting attached browsers by adopting the active foreground tab and avoiding raising new tabs during screenshots.
+- Moved the display-reset default chord (`app.display.reset`) from `Ctrl+L` to `Alt+L` to make room for the live-mode toggle.
+- Updated the hashline edit tool, streaming preview, and plan-mode guidance for the unified `PUT`/`CUT` grammar, `.=` ranges, and named registers.
+- Added `requestIdFormat` (`"string"` | `"number"`, default `"string"`) to MCP server config, honored by the stdio, HTTP, and SSE transports. JSON-RPC 2.0 permits both id shapes, but Apple's `xcrun mcpbridge` decodes `id` as an integer only and silently drops OMP's snowflake strings (`mcpbridge.DecodeError Code=1`), hanging every request until it times out. Opting a server into `"number"` allocates per-connection sequential integer ids instead ([#7053](https://github.com/can1357/oh-my-pi/issues/7053)).
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -4,6 +4,8 @@
  * Canonical shape for MCP server configurations, regardless of source format.
  * All providers translate their native format to this shape.
  */
+
+import type { MCPRequestIdFormat } from "../mcp/types";
 import { defineCapability } from ".";
 import type { SourceMeta } from "./types";
 
@@ -17,6 +19,8 @@ export interface MCPServer {
 	enabled?: boolean;
 	/** Connection timeout in milliseconds */
 	timeout?: number;
+	/** Encoding for outgoing JSON-RPC request ids (default: `"string"`) */
+	requestIdFormat?: MCPRequestIdFormat;
 	/** Command to run (for stdio transport) */
 	command?: string;
 	/** Command arguments */

--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -60,6 +60,9 @@ export interface MCPServer {
 /** Compare the transport inputs that determine which MCP endpoint gets connected. */
 function isSameMCPConnection(left: MCPServer, right: MCPServer): boolean {
 	if (!Bun.deepEquals(left.auth, right.auth) || !Bun.deepEquals(left.oauth, right.oauth)) return false;
+	// Normalize against the allocator's own default so an explicit "string" is
+	// equivalent to leaving the option unset, not a distinct connection.
+	if ((left.requestIdFormat ?? "string") !== (right.requestIdFormat ?? "string")) return false;
 
 	const leftTransport = left.transport ?? (left.command ? "stdio" : left.url ? "http" : "stdio");
 	const rightTransport = right.transport ?? (right.command ? "stdio" : right.url ? "http" : "stdio");

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -121,7 +121,7 @@
         "requestIdFormat": {
           "type": "string",
           "enum": ["string", "number"],
-          "description": "Encoding for outgoing JSON-RPC request ids (default: \"string\"). Use \"number\" for servers that decode `id` as an integer only, such as Apple's `xcrun mcpbridge`, which never answers a string id."
+          "description": "Encoding for outgoing JSON-RPC request ids (default: \"string\"). Use \"number\" for servers that decode `id` as an integer only, such as Apple's `xcrun mcpbridge`, which never answers a string id. OMP-specific: set it in an OMP-owned config (`.omp/mcp.json`, `~/.omp/agent/mcp.json`, a project `mcp.json`/`.mcp.json`, or an OMP plugin). Servers imported from another tool's config (Claude, Cursor, VS Code, Gemini, OpenCode, Windsurf) ignore it, since that key is not part of those formats."
         },
         "auth": {
           "$ref": "#/$defs/authConfig"

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -118,6 +118,11 @@
           "minimum": 0,
           "description": "MCP request timeout in milliseconds. Set to 0 to disable client-side MCP timeouts."
         },
+        "requestIdFormat": {
+          "type": "string",
+          "enum": ["string", "number"],
+          "description": "Encoding for outgoing JSON-RPC request ids (default: \"string\"). Use \"number\" for servers that decode `id` as an integer only, such as Apple's `xcrun mcpbridge`, which never answers a string id."
+        },
         "auth": {
           "$ref": "#/$defs/authConfig"
         },

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -23,7 +23,6 @@ import { type SlashCommand, slashCommandCapability } from "../capability/slash-c
 import { type SystemPrompt, systemPromptCapability } from "../capability/system-prompt";
 import { type CustomTool, toolCapability } from "../capability/tool";
 import type { LoadContext, LoadResult } from "../capability/types";
-import type { MCPRequestIdFormat } from "../mcp/types";
 import { expandTilde } from "../tools/path-utils";
 import {
 	buildRuleFromMarkdown,
@@ -32,6 +31,7 @@ import {
 	expandEnvVarsDeep,
 	getExtensionNameFromPath,
 	loadFilesFromDir,
+	parseRequestIdFormat,
 	SOURCE_PATHS,
 	scanSkillsFromDir,
 } from "./helpers";
@@ -156,15 +156,11 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 			}
 
 			// Validate requestIdFormat: only the two documented encodings
-			let requestIdFormat: MCPRequestIdFormat | undefined;
-			if (serverConfig.requestIdFormat !== undefined && serverConfig.requestIdFormat !== null) {
-				if (serverConfig.requestIdFormat === "string" || serverConfig.requestIdFormat === "number") {
-					requestIdFormat = serverConfig.requestIdFormat;
-				} else {
-					logger.warn(
-						`MCP server "${serverName}": invalid requestIdFormat ${JSON.stringify(serverConfig.requestIdFormat)}, ignoring`,
-					);
-				}
+			const requestIdFormat = parseRequestIdFormat(serverConfig.requestIdFormat);
+			if (requestIdFormat === undefined && serverConfig.requestIdFormat != null) {
+				logger.warn(
+					`MCP server "${serverName}": invalid requestIdFormat ${JSON.stringify(serverConfig.requestIdFormat)}, ignoring`,
+				);
 			}
 
 			result.push({

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -23,6 +23,7 @@ import { type SlashCommand, slashCommandCapability } from "../capability/slash-c
 import { type SystemPrompt, systemPromptCapability } from "../capability/system-prompt";
 import { type CustomTool, toolCapability } from "../capability/tool";
 import type { LoadContext, LoadResult } from "../capability/types";
+import type { MCPRequestIdFormat } from "../mcp/types";
 import { expandTilde } from "../tools/path-utils";
 import {
 	buildRuleFromMarkdown,
@@ -154,10 +155,23 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 				timeout = undefined;
 			}
 
+			// Validate requestIdFormat: only the two documented encodings
+			let requestIdFormat: MCPRequestIdFormat | undefined;
+			if (serverConfig.requestIdFormat !== undefined && serverConfig.requestIdFormat !== null) {
+				if (serverConfig.requestIdFormat === "string" || serverConfig.requestIdFormat === "number") {
+					requestIdFormat = serverConfig.requestIdFormat;
+				} else {
+					logger.warn(
+						`MCP server "${serverName}": invalid requestIdFormat ${JSON.stringify(serverConfig.requestIdFormat)}, ignoring`,
+					);
+				}
+			}
+
 			result.push({
 				name: serverName,
 				enabled,
 				timeout,
+				requestIdFormat,
 				command: serverConfig.command as string | undefined,
 				args: serverConfig.args as string[] | undefined,
 				env: serverConfig.env as Record<string, string> | undefined,

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -16,6 +16,7 @@ import { invalidate as invalidateFsCache, readDirEntries, readFile } from "../ca
 import { parseRuleConditionAndScope, type Rule, type RuleFrontmatter } from "../capability/rule";
 import type { Skill, SkillFrontmatter } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
+import type { MCPRequestIdFormat } from "../mcp/types";
 import { type ConfiguredThinkingLevel, parseConfiguredThinkingLevel } from "../thinking";
 import { normalizeToolNames } from "../tools/builtin-names";
 
@@ -137,6 +138,15 @@ export function parseBoolean(value: unknown): boolean | undefined {
 		if (normalized === "true") return true;
 		if (normalized === "false") return false;
 	}
+	return undefined;
+}
+
+/**
+ * Parse an MCP `requestIdFormat` value. Unrecognized values are dropped so a typo
+ * degrades to the default string ids rather than reaching a transport.
+ */
+export function parseRequestIdFormat(value: unknown): MCPRequestIdFormat | undefined {
+	if (value === "string" || value === "number") return value;
 	return undefined;
 }
 

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -26,6 +26,7 @@ interface MCPConfigFile {
 		{
 			enabled?: boolean;
 			timeout?: number;
+			requestIdFormat?: "string" | "number";
 			command?: string;
 			args?: string[];
 			env?: Record<string, string>;
@@ -83,10 +84,23 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 				}
 			}
 
+			let requestIdFormat: "string" | "number" | undefined;
+			if (serverConfig.requestIdFormat !== undefined) {
+				if (serverConfig.requestIdFormat === "string" || serverConfig.requestIdFormat === "number") {
+					requestIdFormat = serverConfig.requestIdFormat;
+				} else {
+					logger.warn("MCP server has invalid 'requestIdFormat' value, ignoring", {
+						name,
+						value: serverConfig.requestIdFormat,
+					});
+				}
+			}
+
 			const server: MCPServer = {
 				name,
 				enabled,
 				timeout,
+				requestIdFormat,
 				command: serverConfig.command,
 				args: serverConfig.args,
 				env: serverConfig.env,

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -12,7 +12,7 @@ import { registerProvider } from "../capability";
 import { readFile } from "../capability/fs";
 import { type MCPServer, mcpCapability } from "../capability/mcp";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
-import { createSourceMeta, expandEnvVarsDeep } from "./helpers";
+import { createSourceMeta, expandEnvVarsDeep, parseRequestIdFormat } from "./helpers";
 
 const PROVIDER_ID = "mcp-json";
 const DISPLAY_NAME = "MCP Config";
@@ -84,16 +84,12 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 				}
 			}
 
-			let requestIdFormat: "string" | "number" | undefined;
-			if (serverConfig.requestIdFormat !== undefined) {
-				if (serverConfig.requestIdFormat === "string" || serverConfig.requestIdFormat === "number") {
-					requestIdFormat = serverConfig.requestIdFormat;
-				} else {
-					logger.warn("MCP server has invalid 'requestIdFormat' value, ignoring", {
-						name,
-						value: serverConfig.requestIdFormat,
-					});
-				}
+			const requestIdFormat = parseRequestIdFormat(serverConfig.requestIdFormat);
+			if (requestIdFormat === undefined && serverConfig.requestIdFormat !== undefined) {
+				logger.warn("MCP server has invalid 'requestIdFormat' value, ignoring", {
+					name,
+					value: serverConfig.requestIdFormat,
+				});
 			}
 
 			const server: MCPServer = {

--- a/packages/coding-agent/src/discovery/omp-plugins.ts
+++ b/packages/coding-agent/src/discovery/omp-plugins.ts
@@ -28,7 +28,13 @@ import { type Skill, skillCapability } from "../capability/skill";
 import { type SlashCommand, slashCommandCapability } from "../capability/slash-command";
 import { type CustomTool, toolCapability } from "../capability/tool";
 import type { LoadContext, LoadResult } from "../capability/types";
-import { buildRuleFromMarkdown, createSourceMeta, loadFilesFromDir, scanSkillsFromDir } from "./helpers";
+import {
+	buildRuleFromMarkdown,
+	createSourceMeta,
+	loadFilesFromDir,
+	parseRequestIdFormat,
+	scanSkillsFromDir,
+} from "./helpers";
 import { listOmpExtensionRoots, type OmpExtensionRoot } from "./omp-extension-roots";
 import { resolvePluginStdioPaths } from "./substitute-plugin-root";
 
@@ -257,6 +263,7 @@ const MCP_FILENAMES = [".mcp.json", "mcp.json"] as const;
 interface RawMcpServer {
 	enabled?: boolean;
 	timeout?: number;
+	requestIdFormat?: unknown;
 	command?: string;
 	args?: string[];
 	env?: Record<string, string>;
@@ -305,10 +312,12 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 			// Root relative command/cwd at the plugin's config directory, not the
 			// session cwd (MCP stdio spawning resolves relative values there).
 			const rooted = resolvePluginStdioPaths({ command: cfg.command, cwd: cfg.cwd }, root.path);
+			const requestIdFormat = parseRequestIdFormat(cfg.requestIdFormat);
 			items.push({
 				name: serverName,
 				...(cfg.enabled !== undefined && { enabled: cfg.enabled }),
 				...(cfg.timeout !== undefined && { timeout: cfg.timeout }),
+				...(requestIdFormat !== undefined && { requestIdFormat }),
 				...(rooted.command !== undefined && { command: rooted.command }),
 				...(cfg.args !== undefined && { args: cfg.args }),
 				...(cfg.env !== undefined && { env: cfg.env }),

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -41,6 +41,7 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 	const shared = {
 		enabled: server.enabled,
 		timeout: server.timeout,
+		requestIdFormat: server.requestIdFormat,
 		auth: server.auth,
 		oauth: server.oauth,
 	};

--- a/packages/coding-agent/src/mcp/request-id.ts
+++ b/packages/coding-agent/src/mcp/request-id.ts
@@ -1,0 +1,23 @@
+import { Snowflake } from "@oh-my-pi/pi-utils";
+import type { MCPRequestIdFormat } from "./types";
+
+/**
+ * Per-transport allocator for outgoing JSON-RPC request ids.
+ *
+ * JSON-RPC 2.0 permits String and Number ids equally. The default snowflake
+ * string is collision-resistant across reconnects and process restarts, so it
+ * stays the default. `"number"` exists for servers whose decoder accepts
+ * integers only — Apple's `xcrun mcpbridge` logs `mcpbridge.DecodeError Code=1`
+ * and never answers a string id, hanging every request until it times out.
+ *
+ * The counter is per instance and never reset, so ids stay unique for the life
+ * of the transport even though a reconnect rejects and clears every pending
+ * request.
+ */
+export class RequestIdAllocator {
+	#previousNumeric = 0;
+
+	next(format: MCPRequestIdFormat | undefined): string | number {
+		return format === "number" ? ++this.#previousNumeric : Snowflake.next();
+	}
+}

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -5,7 +5,7 @@
  * Based on MCP spec 2025-03-26.
  */
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { logger, readSseJson, Snowflake } from "@oh-my-pi/pi-utils";
+import { logger, readSseJson } from "@oh-my-pi/pi-utils";
 import type {
 	JsonRpcError,
 	JsonRpcMessage,
@@ -17,6 +17,7 @@ import type {
 	MCPTransport,
 } from "../../mcp/types";
 import { toJsonRpcError } from "../../mcp/types";
+import { RequestIdAllocator } from "../request-id";
 import { createMCPTimeout, getNeverAbortSignal, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 
 const HTTP_SSE_CONNECT_TIMEOUT_MS = 1_000;
@@ -42,6 +43,7 @@ export class HttpTransport implements MCPTransport {
 	#connected = false;
 	#sessionId: string | null = null;
 	#sseConnection: AbortController | null = null;
+	readonly #requestIds = new RequestIdAllocator();
 
 	onClose?: () => void;
 	onError?: (error: Error) => void;
@@ -209,7 +211,7 @@ export class HttpTransport implements MCPTransport {
 			throw new Error("Transport not connected");
 		}
 
-		const id = Snowflake.next();
+		const id = this.#requestIds.next(this.config.requestIdFormat);
 		const body = {
 			jsonrpc: "2.0" as const,
 			id,

--- a/packages/coding-agent/src/mcp/transports/sse.ts
+++ b/packages/coding-agent/src/mcp/transports/sse.ts
@@ -1,5 +1,5 @@
 import * as AIError from "@oh-my-pi/pi-ai/error";
-import { logger, readSseEvents, Snowflake } from "@oh-my-pi/pi-utils";
+import { logger, readSseEvents } from "@oh-my-pi/pi-utils";
 import type {
 	JsonRpcError,
 	JsonRpcMessage,
@@ -10,6 +10,7 @@ import type {
 	MCPTransport,
 } from "../../mcp/types";
 import { toJsonRpcError } from "../../mcp/types";
+import { RequestIdAllocator } from "../request-id";
 import { createMCPTimeout, getNeverAbortSignal, resolveMCPTimeoutMs } from "../timeout";
 
 interface MCPTimeoutOperation {
@@ -32,6 +33,7 @@ export class LegacySseTransport implements MCPTransport {
 	#sseConnection: AbortController | null = null;
 	#pending = new Map<string | number, PendingLegacySseRequest>();
 	#config: MCPSseServerConfig;
+	readonly #requestIds = new RequestIdAllocator();
 
 	onClose?: () => void;
 	onError?: (error: Error) => void;
@@ -194,7 +196,7 @@ export class LegacySseTransport implements MCPTransport {
 			throw new Error("Transport not connected");
 		}
 
-		const id = Snowflake.next();
+		const id = this.#requestIds.next(this.#config.requestIdFormat);
 		const body = {
 			jsonrpc: "2.0" as const,
 			id,

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -7,7 +7,7 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getProjectDir, readJsonl, Snowflake } from "@oh-my-pi/pi-utils";
+import { getProjectDir, readJsonl } from "@oh-my-pi/pi-utils";
 import type { Subprocess } from "bun";
 import { hostHasInheritableConsole } from "../../eval/py/spawn-options";
 import type {
@@ -20,6 +20,7 @@ import type {
 	MCPTransport,
 } from "../../mcp/types";
 import { toJsonRpcError } from "../../mcp/types";
+import { RequestIdAllocator } from "../request-id";
 import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 
 /** Subprocess argv and platform-derived spawn flags for an MCP stdio server. */
@@ -551,6 +552,7 @@ export class StdioTransport implements MCPTransport {
 	 * actually spawned into its own session may target it.
 	 */
 	#detached = false;
+	readonly #requestIds = new RequestIdAllocator();
 
 	onClose?: () => void;
 	onError?: (error: Error) => void;
@@ -734,7 +736,7 @@ export class StdioTransport implements MCPTransport {
 			throw new Error("Transport not connected");
 		}
 
-		const id = Snowflake.next();
+		const id = this.#requestIds.next(this.config.requestIdFormat);
 		const request = {
 			jsonrpc: "2.0" as const,
 			id,

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -73,6 +73,10 @@ interface MCPServerConfigBase {
 	 *
 	 * Set `"number"` for servers whose decoder accepts integers only, such as
 	 * Apple's `xcrun mcpbridge`. See `RequestIdAllocator` in `./request-id`.
+	 *
+	 * OMP-specific, so only the OMP-owned discovery providers parse it (native,
+	 * standalone `mcp.json`, OMP plugins). Providers that translate another
+	 * tool's config do not, since the key is not part of those formats.
 	 */
 	requestIdFormat?: MCPRequestIdFormat;
 	/** Authentication configuration (optional) */

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -72,7 +72,7 @@ interface MCPServerConfigBase {
 	 * Encoding for outgoing JSON-RPC request ids (default: `"string"`).
 	 *
 	 * Set `"number"` for servers whose decoder accepts integers only, such as
-	 * Apple's `xcrun mcpbridge`. See `createRequestIdAllocator`.
+	 * Apple's `xcrun mcpbridge`. See `RequestIdAllocator` in `./request-id`.
 	 */
 	requestIdFormat?: MCPRequestIdFormat;
 	/** Authentication configuration (optional) */

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -59,12 +59,22 @@ export interface MCPAuthConfig {
 	resource?: string;
 }
 
+/** Encoding used for outgoing JSON-RPC request ids. */
+export type MCPRequestIdFormat = "string" | "number";
+
 /** Base server config with shared options */
 interface MCPServerConfigBase {
 	/** Whether this server is enabled (default: true) */
 	enabled?: boolean;
 	/** MCP request timeout in milliseconds (default: 30000, 0 to disable) */
 	timeout?: number;
+	/**
+	 * Encoding for outgoing JSON-RPC request ids (default: `"string"`).
+	 *
+	 * Set `"number"` for servers whose decoder accepts integers only, such as
+	 * Apple's `xcrun mcpbridge`. See `createRequestIdAllocator`.
+	 */
+	requestIdFormat?: MCPRequestIdFormat;
 	/** Authentication configuration (optional) */
 	auth?: MCPAuthConfig;
 	/** OAuth configuration for servers requiring explicit client credentials */

--- a/packages/coding-agent/test/mcp/config-request-id-format.test.ts
+++ b/packages/coding-agent/test/mcp/config-request-id-format.test.ts
@@ -1,0 +1,79 @@
+/**
+ * `requestIdFormat` must survive the documented config path.
+ *
+ * The option is only useful if a value written in config actually reaches the
+ * transport: discovery parses config into the canonical `MCPServer` shape and
+ * `convertToLegacyConfig()` turns that back into the `MCPServerConfig` the
+ * transports read. A field missing from either step silently degrades to the
+ * snowflake-string default, which is the hang the option exists to avoid.
+ *
+ * Both OMP-native loaders are covered: `.omp/mcp.json` (native provider) and a
+ * standalone project-root `.mcp.json` (mcp-json provider).
+ */
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { loadAllMCPConfigs } from "@oh-my-pi/pi-coding-agent/mcp/config";
+import { getConfigRootDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+
+const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+let tempAgentDir = "";
+let tempCwd = "";
+
+beforeEach(async () => {
+	tempAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-reqid-agent-"));
+	tempCwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-reqid-cwd-"));
+	setAgentDir(tempAgentDir);
+	clearFsCache();
+});
+
+afterEach(async () => {
+	if (originalAgentDirEnv) {
+		setAgentDir(originalAgentDirEnv);
+	} else {
+		setAgentDir(fallbackAgentDir);
+		delete process.env.PI_CODING_AGENT_DIR;
+	}
+	clearFsCache();
+	await removeWithRetries(tempAgentDir);
+	await removeWithRetries(tempCwd);
+});
+
+async function loadFrom(file: string, mcpServers: Record<string, unknown>) {
+	await Bun.write(path.join(tempCwd, file), JSON.stringify({ mcpServers }));
+	clearFsCache();
+	const { configs } = await loadAllMCPConfigs(tempCwd);
+	return configs;
+}
+
+test("requestIdFormat from .omp/mcp.json reaches the transport config", async () => {
+	const configs = await loadFrom(path.join(".omp", "mcp.json"), {
+		xcode: { type: "stdio", command: "/usr/bin/xcrun", args: ["mcpbridge"], requestIdFormat: "number" },
+		plain: { type: "stdio", command: "/bin/echo" },
+	});
+
+	expect(configs.xcode?.requestIdFormat).toBe("number");
+	// Unset stays unset so the allocator keeps its snowflake-string default.
+	expect(configs.plain?.requestIdFormat).toBeUndefined();
+});
+
+test("requestIdFormat from a standalone .mcp.json reaches the transport config", async () => {
+	const configs = await loadFrom(".mcp.json", {
+		xcode: { type: "stdio", command: "/usr/bin/xcrun", args: ["mcpbridge"], requestIdFormat: "number" },
+	});
+
+	expect(configs.xcode?.requestIdFormat).toBe("number");
+});
+
+test("an unrecognized requestIdFormat is dropped rather than passed through", async () => {
+	const configs = await loadFrom(path.join(".omp", "mcp.json"), {
+		bogus: { type: "stdio", command: "/bin/echo", requestIdFormat: "integer" },
+	});
+
+	expect(configs.bogus).toBeDefined();
+	expect(configs.bogus?.requestIdFormat).toBeUndefined();
+});

--- a/packages/coding-agent/test/mcp/config-request-id-format.test.ts
+++ b/packages/coding-agent/test/mcp/config-request-id-format.test.ts
@@ -1,5 +1,6 @@
 /**
- * `requestIdFormat` must survive the documented config path.
+ * `requestIdFormat` must survive the documented config path, and must not be lost
+ * to connection-equivalence deduplication.
  *
  * The option is only useful if a value written in config actually reaches the
  * transport: discovery parses config into the canonical `MCPServer` shape and
@@ -9,8 +10,14 @@
  *
  * Both OMP-native loaders are covered: `.omp/mcp.json` (native provider) and a
  * standalone project-root `.mcp.json` (mcp-json provider).
+ *
+ * Separately, `isSameMCPConnection` treats two differently-named entries with the
+ * same command/args/env/cwd as aliases of one connection, keeping only the
+ * higher-priority one. `requestIdFormat` changes the bytes sent on the wire, so it
+ * must be part of that comparison — otherwise a discovered alias lacking the field
+ * could shadow a `.mcp.json` entry that set it, silently reverting to string ids.
  */
-import { afterEach, beforeEach, expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -23,22 +30,32 @@ const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
 
 let tempAgentDir = "";
 let tempCwd = "";
+let tempHome = "";
+let originalHome: string | undefined;
 
 beforeEach(async () => {
+	originalHome = process.env.HOME;
+	tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-reqid-home-"));
 	tempAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-reqid-agent-"));
 	tempCwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-reqid-cwd-"));
+	process.env.HOME = tempHome;
+	vi.spyOn(os, "homedir").mockReturnValue(tempHome);
 	setAgentDir(tempAgentDir);
 	clearFsCache();
 });
 
 afterEach(async () => {
+	vi.restoreAllMocks();
 	if (originalAgentDirEnv) {
 		setAgentDir(originalAgentDirEnv);
 	} else {
 		setAgentDir(fallbackAgentDir);
 		delete process.env.PI_CODING_AGENT_DIR;
 	}
+	if (originalHome === undefined) delete process.env.HOME;
+	else process.env.HOME = originalHome;
 	clearFsCache();
+	await removeWithRetries(tempHome);
 	await removeWithRetries(tempAgentDir);
 	await removeWithRetries(tempCwd);
 });
@@ -76,4 +93,20 @@ test("an unrecognized requestIdFormat is dropped rather than passed through", as
 
 	expect(configs.bogus).toBeDefined();
 	expect(configs.bogus?.requestIdFormat).toBeUndefined();
+});
+
+test("differing requestIdFormat prevents equivalence dedup from collapsing two aliases", async () => {
+	const configs = await loadFrom(path.join(".omp", "mcp.json"), {
+		"xcode-numeric": { type: "stdio", command: "/usr/bin/xcrun", args: ["mcpbridge"], requestIdFormat: "number" },
+		"xcode-default": { type: "stdio", command: "/usr/bin/xcrun", args: ["mcpbridge"] },
+	});
+
+	// Same command/args would previously make these equivalent, so the second
+	// entry (whichever loads later) would shadow the first and its distinct
+	// requestIdFormat setting would vanish. Both must survive as separate
+	// servers — assert key presence directly, since optional chaining on a
+	// shadowed (absent) key would otherwise make this pass vacuously.
+	expect(Object.keys(configs).sort()).toEqual(["xcode-default", "xcode-numeric"]);
+	expect(configs["xcode-numeric"]?.requestIdFormat).toBe("number");
+	expect(configs["xcode-default"]?.requestIdFormat).toBeUndefined();
 });

--- a/packages/coding-agent/test/mcp/request-id.test.ts
+++ b/packages/coding-agent/test/mcp/request-id.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+
+import { RequestIdAllocator } from "../../src/mcp/request-id";
+
+describe("RequestIdAllocator", () => {
+	it("defaults to unique string ids", () => {
+		const allocator = new RequestIdAllocator();
+		const ids = [allocator.next(undefined), allocator.next(undefined), allocator.next("string")];
+
+		expect(ids.every(id => typeof id === "string")).toBe(true);
+		expect(new Set(ids).size).toBe(3);
+	});
+
+	it("issues sequential integers from 1 for integer-only decoders", () => {
+		const allocator = new RequestIdAllocator();
+
+		expect([allocator.next("number"), allocator.next("number"), allocator.next("number")]).toEqual([1, 2, 3]);
+	});
+
+	it("counts independently per transport instance", () => {
+		const first = new RequestIdAllocator();
+		const second = new RequestIdAllocator();
+
+		first.next("number");
+		first.next("number");
+
+		expect(second.next("number")).toBe(1);
+	});
+
+	it("reads the format at call time so a reconfigured server takes effect", () => {
+		const allocator = new RequestIdAllocator();
+
+		expect(typeof allocator.next(undefined)).toBe("string");
+		expect(allocator.next("number")).toBe(1);
+	});
+
+	it("never reuses a numeric id, so a reconnect cannot collide with a late reply", () => {
+		const allocator = new RequestIdAllocator();
+		const before = allocator.next("number");
+		allocator.next("string");
+
+		expect(allocator.next("number")).toBeGreaterThan(before as number);
+	});
+});

--- a/packages/coding-agent/test/mcp/transports/stdio.test.ts
+++ b/packages/coding-agent/test/mcp/transports/stdio.test.ts
@@ -425,3 +425,37 @@ describe.skipIf(process.platform === "win32")("StdioTransport.close teardown", (
 		}
 	}, 5000);
 });
+
+describe.skipIf(process.platform === "win32")("StdioTransport request ids", () => {
+	/** Echoes each request back with the JSON type the server actually observed for `id`. */
+	const ECHO_OBSERVED_ID = `for await (const line of console) {
+		const message = JSON.parse(line);
+		process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { idType: typeof message.id, id: message.id } }) + "\\n");
+	}`;
+
+	async function observeIds(requestIdFormat: "string" | "number" | undefined, methods: string[]) {
+		const transport = new StdioTransport({ command: "bun", args: ["-e", ECHO_OBSERVED_ID], requestIdFormat });
+		try {
+			await transport.connect();
+			const observed: { idType: string; id: unknown }[] = [];
+			for (const method of methods) observed.push(await transport.request(method));
+			return observed;
+		} finally {
+			await transport.close();
+		}
+	}
+
+	it("sends integers to servers that decode ids as integers only", async () => {
+		// Apple's `xcrun mcpbridge` answers nothing on a string id (#7053).
+		expect(await observeIds("number", ["first", "second"])).toEqual([
+			{ idType: "number", id: 1 },
+			{ idType: "number", id: 2 },
+		]);
+	}, 15000);
+
+	it("sends string ids by default", async () => {
+		const [observed] = await observeIds(undefined, ["probe"]);
+
+		expect(observed.idType).toBe("string");
+	}, 15000);
+});


### PR DESCRIPTION
## What

Adds `requestIdFormat` (`"string"` | `"number"`, default `"string"`) to the MCP server config, honored by the stdio, HTTP, and SSE transports through one `RequestIdAllocator`. The default is unchanged, so this is inert unless a server opts in.

## Why

Fixes #7053. JSON-RPC 2.0 lets the `id` be a string or a number, and OMP sends a snowflake string. Not every MCP server accepts both, though: Apple's `xcrun mcpbridge` decodes `id` as an integer only, so it logs `mcpbridge.DecodeError Code=1`, never replies, and every request hangs until it times out.

Since both shapes are valid, the server cannot be fixed from our side and a flag is the honest way out. I kept it to a plain per-server option with no sniffing and no id remapping, so nothing changes for servers that do not set it.

## Testing

Xcode 26.6 (17F113), macOS 26.5, arm64.

- Default: `initialize` gets no reply, times out after 30000ms, `DecodeError Code=1` in the log.
- With `"number"`: `initialize` returns, `tools/list` returns all 21 tools, calls work.
- `bun test test/mcp/request-id.test.ts test/mcp/transports/stdio.test.ts`: 18 pass. The stdio test echoes back `typeof id` from a real child server.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
