### PR TITLE
fix(rpc): restore frames for IRC-revived subagents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed RPC hosts receiving no subagent lifecycle or progress frames when an IRC message revives an idle or parked keep-alive subagent ([#7105](https://github.com/can1357/oh-my-pi/issues/7105)).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1608,6 +1608,7 @@ export async function runRootCommand(
 				modelRegistry,
 				settings: settingsInstance,
 				enableLsp: sessionOptions.enableLsp ?? true,
+				eventBus,
 			}),
 			Math.trunc(Number(settingsInstance.get("task.agentIdleTtlMs") ?? 420_000) || 0),
 		);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -749,6 +749,13 @@ export class AgentSession {
 			logger.warn("IRC wake turn observer failed to start", { error: String(error) });
 		}
 		this.#resetPromptMaintenanceState();
+		// Capture the generation before the wake so its post-prompt recovery wait
+		// bails the instant an abort (which bumps #promptGeneration) supersedes
+		// this wake — otherwise the wait would follow a successor turn (a queued
+		// follow-up or another stranded IRC wake started by abort cleanup),
+		// delaying finishObservation and mis-attributing the successor's RPC
+		// progress to this now-dead wake monitor.
+		const generation = this.#promptGeneration;
 		this.#beginInFlight();
 		let turnError: unknown;
 		void this.agent
@@ -759,7 +766,7 @@ export class AgentSession {
 			})
 			.finally(async () => {
 				try {
-					await this.#waitForPostPromptRecovery();
+					await this.#waitForPostPromptRecovery(generation);
 				} catch (error) {
 					turnError ??= error;
 					logger.warn("IRC wake turn recovery failed", { error: String(error) });

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -573,6 +573,7 @@ export class AgentSession {
 	// on `agent_end` can fire its next `prompt` before #promptWithMessage's finally
 	#promptGeneration = 0;
 	#pendingAgentEndEmit: AgentSessionEvent | undefined;
+	#inFlightSettledCallbacks: Array<() => void> = [];
 	#sessionStopContinuationCount = 0;
 	#sessionStopHookActive = false;
 	#obfuscator: SecretObfuscator | undefined;
@@ -638,12 +639,26 @@ export class AgentSession {
 		}
 	}
 
-	#endInFlight(): void {
+	#endInFlight(onSettled?: () => void): void {
+		if (onSettled) this.#inFlightSettledCallbacks.push(onSettled);
 		this.#promptInFlightCount = Math.max(0, this.#promptInFlightCount - 1);
 		if (this.#promptInFlightCount === 0) {
 			this.#releasePowerAssertion();
 			this.#flushPendingAgentEnd();
+			this.#flushInFlightSettledCallbacks();
 			this.#drainStrandedQueuedMessages();
+		}
+	}
+
+	#flushInFlightSettledCallbacks(): void {
+		const callbacks = this.#inFlightSettledCallbacks;
+		this.#inFlightSettledCallbacks = [];
+		for (const callback of callbacks) {
+			try {
+				callback();
+			} catch (error) {
+				logger.warn("In-flight settle callback failed", { error: String(error) });
+			}
 		}
 	}
 
@@ -742,11 +757,12 @@ export class AgentSession {
 				turnError = error;
 				logger.warn("IRC wake turn failed", { error: String(error) });
 			})
-			.finally(() => {
+			.finally(async () => {
 				try {
-					finishObservation?.(turnError);
+					await this.#waitForPostPromptRecovery();
 				} catch (error) {
-					logger.warn("IRC wake turn observer failed to finish", { error: String(error) });
+					turnError ??= error;
+					logger.warn("IRC wake turn recovery failed", { error: String(error) });
 				}
 				if (parkedFollowUps.length > 0) {
 					this.agent.replaceQueues(
@@ -754,7 +770,13 @@ export class AgentSession {
 						[...parkedFollowUps, ...this.agent.peekFollowUpQueue()],
 					);
 				}
-				this.#endInFlight();
+				this.#endInFlight(() => {
+					try {
+						finishObservation?.(turnError);
+					} catch (error) {
+						logger.warn("IRC wake turn observer failed to finish", { error: String(error) });
+					}
+				});
 			});
 	}
 
@@ -795,6 +817,7 @@ export class AgentSession {
 		this.#promptInFlightCount = 0;
 		this.#releasePowerAssertion();
 		this.#flushPendingAgentEnd();
+		this.#flushInFlightSettledCallbacks();
 		this.#drainStrandedQueuedMessages();
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -502,6 +502,7 @@ export class AgentSession {
 	#asyncDeliveryEpoch = 0;
 
 	readonly #irc: IrcBridge;
+	#ircWakeTurnObserver: ((records: CustomMessage[]) => ((error?: unknown) => void) | undefined) | undefined;
 	// Agent identity (registry id) used for IRC routing and job ownership.
 	#agentId: string | undefined;
 	#agentKind: "main" | "sub" = "main";
@@ -726,14 +727,27 @@ export class AgentSession {
 		if (parkedFollowUps.length > 0) {
 			this.agent.replaceQueues([...this.agent.peekSteeringQueue()], []);
 		}
+		let finishObservation: ((error?: unknown) => void) | undefined;
+		try {
+			finishObservation = this.#ircWakeTurnObserver?.(records);
+		} catch (error) {
+			logger.warn("IRC wake turn observer failed to start", { error: String(error) });
+		}
 		this.#resetPromptMaintenanceState();
 		this.#beginInFlight();
+		let turnError: unknown;
 		void this.agent
 			.prompt(records)
 			.catch(error => {
+				turnError = error;
 				logger.warn("IRC wake turn failed", { error: String(error) });
 			})
 			.finally(() => {
+				try {
+					finishObservation?.(turnError);
+				} catch (error) {
+					logger.warn("IRC wake turn observer failed to finish", { error: String(error) });
+				}
 				if (parkedFollowUps.length > 0) {
 					this.agent.replaceQueues(
 						[...this.agent.peekSteeringQueue()],
@@ -6866,6 +6880,13 @@ export class AgentSession {
 	/** Delivers an IRC message into this recipient session. */
 	deliverIrcMessage(msg: IrcMessage, opts?: { expectsReply?: boolean }): Promise<"injected" | "woken"> {
 		return this.#irc.deliver(msg, opts);
+	}
+
+	/** Installs task-executor monitoring around autonomous IRC wake turns. */
+	setIrcWakeTurnObserver(
+		observer: ((records: CustomMessage[]) => ((error?: unknown) => void) | undefined) | undefined,
+	): void {
+		this.#ircWakeTurnObserver = observer;
 	}
 
 	/** Emits an IRC relay observation for UI rendering without persisting it. */

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2544,6 +2544,102 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 		});
 	};
+	const installIrcWakeTurnMonitor = (target: AgentSession): void => {
+		target.setIrcWakeTurnObserver(records => {
+			const ircTask =
+				records
+					.map(record => {
+						const body =
+							record.details && typeof record.details === "object"
+								? Reflect.get(record.details, "message")
+								: undefined;
+						return typeof body === "string" ? body : record.content;
+					})
+					.filter(Boolean)
+					.join("\n\n") || "IRC follow-up";
+			const turnStartTime = Date.now();
+			const sessionFile = AgentRegistry.global().get(id)?.sessionFile ?? subtaskSessionFile ?? undefined;
+			const turnMonitor = createSubagentRunMonitor({
+				index,
+				id,
+				agent,
+				task: ircTask,
+				description: options.description,
+				modelOverride,
+				eventBus: options.eventBus,
+				parentToolCallId: options.parentToolCallId,
+				detached: true,
+				sessionFile,
+				softRequestBudget: 0,
+				softRequestBudgetNotice: false,
+				maxRuntimeMs,
+			});
+
+			if (options.eventBus) {
+				options.eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+					id,
+					agent: agent.name,
+					parentToolCallId: options.parentToolCallId,
+					detached: true,
+					agentSource: agent.source,
+					description: options.description,
+					status: "started",
+					sessionFile,
+					index,
+				});
+			}
+
+			turnMonitor.setActiveSession(target);
+			const unsubscribeTurn = turnMonitor.attach(target);
+			return turnError => {
+				unsubscribeTurn();
+				const activeSession = turnMonitor.takeActiveSession();
+				if (activeSession) turnMonitor.captureSalvage(activeSession);
+				const lastAssistant = target.getLastAssistantMessage();
+				const yielded = turnMonitor.yieldCalled();
+				const runtimeLimitExceeded = turnMonitor.runtimeLimitExceeded();
+				const aborted = runtimeLimitExceeded || (lastAssistant?.stopReason === "aborted" && !yielded);
+				const error =
+					lastAssistant?.stopReason === "error"
+						? lastAssistant.errorMessage || "Subagent failed"
+						: turnError !== undefined && !yielded
+							? turnError instanceof Error
+								? turnError.stack || turnError.message
+								: String(turnError)
+							: undefined;
+				turnMonitor.finish();
+				void finalizeRunResult({
+					monitor: turnMonitor,
+					done: {
+						exitCode: aborted || error ? 1 : 0,
+						error,
+						aborted,
+						abortReason: aborted ? turnMonitor.resolveAbortReasonText() : undefined,
+						durationMs: Date.now() - turnStartTime,
+					},
+					index,
+					id,
+					agent,
+					task: ircTask,
+					modelOverride,
+					outputSchema,
+					outputSchemaMode: options.outputSchemaMode,
+					outputSchemaSource: options.outputSchemaSource,
+					artifactsDir: options.artifactsDir,
+					eventBus: options.eventBus,
+					parentToolCallId: options.parentToolCallId,
+					detached: true,
+					sessionFile,
+					startTime: turnStartTime,
+				}).catch(error => {
+					logger.warn("IRC subagent turn finalization failed", {
+						id,
+						error: error instanceof Error ? error.message : String(error),
+					});
+				});
+			};
+		});
+	};
 
 	const runSubagent = async (): Promise<{
 		exitCode: number;
@@ -2882,6 +2978,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						buildSubagentSessionOptions(reopened, expectedAgentRef),
 					);
 					installRegistryStatusSync(revived);
+					installIrcWakeTurnMonitor(revived);
 					return revived;
 				};
 			}
@@ -3053,6 +3150,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			const session = monitor.takeActiveSession();
 			if (session) {
 				monitor.captureSalvage(session);
+				if (options.keepAlive !== false && worktree === undefined) {
+					installIrcWakeTurnMonitor(session);
+				}
 				await finalizeSubagentLifecycle({
 					id,
 					session,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2200,6 +2200,133 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 	};
 }
 
+/** Inputs for {@link attachIrcWakeTurnMonitor}. */
+export interface IrcWakeTurnMonitorOptions {
+	/** Registry id of the kept-alive subagent whose autonomous IRC wake turns are monitored. */
+	id: string;
+	index?: number;
+	agent: AgentDefinition;
+	description?: string;
+	modelOverride?: string | string[];
+	eventBus?: EventBus;
+	parentToolCallId?: string;
+	/** Fallback session file when the registry ref carries none. */
+	sessionFile?: string;
+	maxRuntimeMs?: number;
+	outputSchema?: unknown;
+	outputSchemaMode?: StructuredSubagentSchemaMode;
+	outputSchemaSource?: StructuredSubagentSchemaSource;
+	artifactsDir?: string;
+}
+
+/**
+ * Bracket a kept-alive subagent's autonomous IRC wake turns with a task run
+ * monitor so RPC/collab subscribers see the same `subagent_lifecycle` /
+ * `subagent_progress` frames a first run emits. Shared by the live executor
+ * reviver and the persisted cold-revive path so a resumed process's parked
+ * subagents are not blind spots. The observer runs after the session has
+ * flushed its post-prompt settle (see {@link AgentSession.setIrcWakeTurnObserver}).
+ */
+export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWakeTurnMonitorOptions): void {
+	const { id, agent } = options;
+	const index = options.index ?? 0;
+	const maxRuntimeMs = options.maxRuntimeMs ?? 0;
+	session.setIrcWakeTurnObserver(records => {
+		const ircTask =
+			records
+				.map(record => {
+					const body =
+						record.details && typeof record.details === "object"
+							? Reflect.get(record.details, "message")
+							: undefined;
+					return typeof body === "string" ? body : record.content;
+				})
+				.filter(Boolean)
+				.join("\n\n") || "IRC follow-up";
+		const turnStartTime = Date.now();
+		const sessionFile = AgentRegistry.global().get(id)?.sessionFile ?? options.sessionFile ?? undefined;
+		const turnMonitor = createSubagentRunMonitor({
+			index,
+			id,
+			agent,
+			task: ircTask,
+			description: options.description,
+			modelOverride: options.modelOverride,
+			eventBus: options.eventBus,
+			parentToolCallId: options.parentToolCallId,
+			detached: true,
+			sessionFile,
+			softRequestBudget: 0,
+			softRequestBudgetNotice: false,
+			maxRuntimeMs,
+		});
+
+		if (options.eventBus) {
+			options.eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+				id,
+				agent: agent.name,
+				parentToolCallId: options.parentToolCallId,
+				detached: true,
+				agentSource: agent.source,
+				description: options.description,
+				status: "started",
+				sessionFile,
+				index,
+			});
+		}
+
+		turnMonitor.setActiveSession(session);
+		const unsubscribeTurn = turnMonitor.attach(session);
+		return turnError => {
+			unsubscribeTurn();
+			const activeSession = turnMonitor.takeActiveSession();
+			if (activeSession) turnMonitor.captureSalvage(activeSession);
+			const lastAssistant = session.getLastAssistantMessage();
+			const yielded = turnMonitor.yieldCalled();
+			const runtimeLimitExceeded = turnMonitor.runtimeLimitExceeded();
+			const aborted = runtimeLimitExceeded || (lastAssistant?.stopReason === "aborted" && !yielded);
+			const error =
+				lastAssistant?.stopReason === "error"
+					? lastAssistant.errorMessage || "Subagent failed"
+					: turnError !== undefined && !yielded
+						? turnError instanceof Error
+							? turnError.stack || turnError.message
+							: String(turnError)
+						: undefined;
+			turnMonitor.finish();
+			void finalizeRunResult({
+				monitor: turnMonitor,
+				done: {
+					exitCode: aborted || error ? 1 : 0,
+					error,
+					aborted,
+					abortReason: aborted ? turnMonitor.resolveAbortReasonText() : undefined,
+					durationMs: Date.now() - turnStartTime,
+				},
+				index,
+				id,
+				agent,
+				task: ircTask,
+				modelOverride: options.modelOverride,
+				outputSchema: options.outputSchema,
+				outputSchemaMode: options.outputSchemaMode,
+				outputSchemaSource: options.outputSchemaSource,
+				artifactsDir: options.artifactsDir,
+				eventBus: options.eventBus,
+				parentToolCallId: options.parentToolCallId,
+				detached: true,
+				sessionFile,
+				startTime: turnStartTime,
+			}).catch(finalizeError => {
+				logger.warn("IRC subagent turn finalization failed", {
+					id,
+					error: finalizeError instanceof Error ? finalizeError.message : String(finalizeError),
+				});
+			});
+		};
+	});
+}
+
 /**
  * Settle a subagent's registry lifecycle after a run: terminal teardown for
  * hard aborts, unregister for one-shot helpers, park for isolated runs, and
@@ -2545,99 +2672,20 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		});
 	};
 	const installIrcWakeTurnMonitor = (target: AgentSession): void => {
-		target.setIrcWakeTurnObserver(records => {
-			const ircTask =
-				records
-					.map(record => {
-						const body =
-							record.details && typeof record.details === "object"
-								? Reflect.get(record.details, "message")
-								: undefined;
-						return typeof body === "string" ? body : record.content;
-					})
-					.filter(Boolean)
-					.join("\n\n") || "IRC follow-up";
-			const turnStartTime = Date.now();
-			const sessionFile = AgentRegistry.global().get(id)?.sessionFile ?? subtaskSessionFile ?? undefined;
-			const turnMonitor = createSubagentRunMonitor({
-				index,
-				id,
-				agent,
-				task: ircTask,
-				description: options.description,
-				modelOverride,
-				eventBus: options.eventBus,
-				parentToolCallId: options.parentToolCallId,
-				detached: true,
-				sessionFile,
-				softRequestBudget: 0,
-				softRequestBudgetNotice: false,
-				maxRuntimeMs,
-			});
-
-			if (options.eventBus) {
-				options.eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
-					id,
-					agent: agent.name,
-					parentToolCallId: options.parentToolCallId,
-					detached: true,
-					agentSource: agent.source,
-					description: options.description,
-					status: "started",
-					sessionFile,
-					index,
-				});
-			}
-
-			turnMonitor.setActiveSession(target);
-			const unsubscribeTurn = turnMonitor.attach(target);
-			return turnError => {
-				unsubscribeTurn();
-				const activeSession = turnMonitor.takeActiveSession();
-				if (activeSession) turnMonitor.captureSalvage(activeSession);
-				const lastAssistant = target.getLastAssistantMessage();
-				const yielded = turnMonitor.yieldCalled();
-				const runtimeLimitExceeded = turnMonitor.runtimeLimitExceeded();
-				const aborted = runtimeLimitExceeded || (lastAssistant?.stopReason === "aborted" && !yielded);
-				const error =
-					lastAssistant?.stopReason === "error"
-						? lastAssistant.errorMessage || "Subagent failed"
-						: turnError !== undefined && !yielded
-							? turnError instanceof Error
-								? turnError.stack || turnError.message
-								: String(turnError)
-							: undefined;
-				turnMonitor.finish();
-				void finalizeRunResult({
-					monitor: turnMonitor,
-					done: {
-						exitCode: aborted || error ? 1 : 0,
-						error,
-						aborted,
-						abortReason: aborted ? turnMonitor.resolveAbortReasonText() : undefined,
-						durationMs: Date.now() - turnStartTime,
-					},
-					index,
-					id,
-					agent,
-					task: ircTask,
-					modelOverride,
-					outputSchema,
-					outputSchemaMode: options.outputSchemaMode,
-					outputSchemaSource: options.outputSchemaSource,
-					artifactsDir: options.artifactsDir,
-					eventBus: options.eventBus,
-					parentToolCallId: options.parentToolCallId,
-					detached: true,
-					sessionFile,
-					startTime: turnStartTime,
-				}).catch(error => {
-					logger.warn("IRC subagent turn finalization failed", {
-						id,
-						error: error instanceof Error ? error.message : String(error),
-					});
-				});
-			};
+		attachIrcWakeTurnMonitor(target, {
+			id,
+			index,
+			agent,
+			description: options.description,
+			modelOverride,
+			eventBus: options.eventBus,
+			parentToolCallId: options.parentToolCallId,
+			sessionFile: subtaskSessionFile,
+			maxRuntimeMs,
+			outputSchema,
+			outputSchemaMode: options.outputSchemaMode,
+			outputSchemaSource: options.outputSchemaSource,
+			artifactsDir: options.artifactsDir,
 		});
 	};
 

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -9,7 +9,9 @@ import { createAgentSession } from "../sdk";
 import type { AgentSession } from "../session/agent-session";
 import type { AuthStorage } from "../session/auth-storage";
 import { SessionManager } from "../session/session-manager";
-import { createMCPProxyTools, createSubagentSettings } from "./executor";
+import type { EventBus } from "../utils/event-bus";
+import { attachIrcWakeTurnMonitor, createMCPProxyTools, createSubagentSettings } from "./executor";
+import type { AgentDefinition } from "./types";
 
 /**
  * Ambient context the reviver needs at revive time. The top-level session is
@@ -24,6 +26,12 @@ export interface PersistedSubagentReviveContext {
 	settings: Settings;
 	/** LSP policy of the top-level session; revived subagents inherit it rather than defaulting on. */
 	enableLsp: boolean;
+	/**
+	 * Shared event bus feeding RPC/collab subagent subscriptions. Passed through
+	 * to the wake-turn monitor so an IRC send to a cold-revived subagent emits
+	 * the same lifecycle/progress frames a live run does.
+	 */
+	eventBus?: EventBus;
 }
 
 /**
@@ -134,6 +142,23 @@ export function createPersistedSubagentReviverFactory(
 			session.subscribe(event => {
 				if (event.type === "agent_start") registry.setStatus(ref.id, "running", session);
 				else if (event.type === "agent_end") registry.setStatus(ref.id, "idle", session);
+			});
+			// Persisted files predate an agent-source field, so cold-revived frames
+			// report the runtime-neutral `user` source; name comes from the ref.
+			const wakeAgent: AgentDefinition = {
+				name: ref.displayName,
+				description: "",
+				systemPrompt: init.systemPrompt,
+				source: "user",
+			};
+			attachIrcWakeTurnMonitor(session, {
+				id: ref.id,
+				agent: wakeAgent,
+				eventBus: ctx.eventBus,
+				sessionFile,
+				outputSchema: init.outputSchema,
+				outputSchemaMode: init.outputSchemaMode,
+				artifactsDir: ctx.session.sessionFile?.slice(0, -6),
 			});
 			return session;
 		};

--- a/packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts
+++ b/packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts
@@ -210,6 +210,19 @@ describe("AgentSession yield empty-stop suppression", () => {
 		expect(mock.calls).toHaveLength(1);
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(0);
 
+		const observerEvents: string[] = [];
+		const observerSettled = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "agent_end") observerEvents.push(`agent_end:${mock.calls.length}`);
+		});
+		session.setIrcWakeTurnObserver(() => {
+			observerEvents.push("started");
+			return () => {
+				observerEvents.push(`finished:${mock.calls.length}`);
+				observerSettled.resolve();
+			};
+		});
+
 		const outcome = await session.deliverIrcMessage({
 			id: "irc-empty-stop-after-yield",
 			from: "peer",
@@ -219,9 +232,11 @@ describe("AgentSession yield empty-stop suppression", () => {
 		} as IrcMessage);
 		expect(outcome).toBe("woken");
 		await session.waitForIdle();
+		await observerSettled.promise;
 
 		expect(mock.calls).toHaveLength(3);
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);
 		expect(assistantText(session.agent.state.messages)).toContain("recovered after IRC retry");
+		expect(observerEvents).toEqual(["started", "agent_end:3", "finished:3"]);
 	});
 });

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -3,11 +3,14 @@ import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-regis
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import { IrcBus } from "@oh-my-pi/pi-coding-agent/irc/bus";
+import { RpcSubagentRegistry } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-subagents";
+import type { RpcSubagentFrame } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-types";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { resolveSoftRequestBudget, runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
@@ -21,7 +24,8 @@ import { TempDir } from "@oh-my-pi/pi-utils";
  *    forced final `yield`, so the run finishes as a normal completion with a
  *    partial report — not as an abort with no output.
  * 2. If the agent still refuses to yield (grace exhausted → hard abort), a
- *    kept-alive agent stays adopted (`idle`), so `irc` can message/resume it.
+ *    kept-alive agent stays adopted (`idle`), so `irc` can message/resume it
+ *    with the same RPC lifecycle/progress frames as the original run.
  * 3. Caller-signal aborts remain terminal, and the irc bus names the aborted
  *    agent precisely instead of claiming it is unknown.
  */
@@ -50,6 +54,7 @@ function createMockSession(
 	let abortCount = 0;
 	let disposeCount = 0;
 	let promptIndex = 0;
+	let ircWakeTurnObserver: ((records: CustomMessage[]) => ((error?: unknown) => void) | undefined) | undefined;
 
 	const emit = (event: AgentSessionEvent) => {
 		for (const listener of [...listeners]) listener(event);
@@ -80,7 +85,49 @@ function createMockSession(
 		waitForIdle: async () => {},
 		getLastAssistantMessage: () => messages[messages.length - 1] as never,
 		sendUserMessage: async () => {},
-		deliverIrcMessage: async () => "woken",
+		setIrcWakeTurnObserver: observer => {
+			ircWakeTurnObserver = observer;
+		},
+		deliverIrcMessage: async msg => {
+			const record: CustomMessage = {
+				role: "custom",
+				customType: "irc:incoming",
+				content: msg.body,
+				display: true,
+				details: { id: msg.id, from: msg.from, message: msg.body },
+				attribution: "agent",
+				timestamp: msg.ts,
+			};
+			const finishObservation = ircWakeTurnObserver?.([record]);
+			const yieldMessage = {
+				role: "assistant" as const,
+				content: [
+					{
+						type: "toolCall" as const,
+						id: "tool-irc-yield",
+						name: "yield",
+						arguments: { result: { data: { report: "resumed findings" } } },
+					},
+				],
+				stopReason: "toolUse" as const,
+			};
+			messages.push(yieldMessage);
+			emit({ type: "agent_start" } as AgentSessionEvent);
+			emit({ type: "message_end", message: yieldMessage } as unknown as AgentSessionEvent);
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-irc-yield",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { report: "resumed findings" } },
+				},
+				isError: false,
+			} as AgentSessionEvent);
+			emit({ type: "agent_end", messages: [yieldMessage] } as unknown as AgentSessionEvent);
+			finishObservation?.();
+			return "woken";
+		},
 		abort: async () => {
 			abortCount += 1;
 		},
@@ -129,7 +176,7 @@ describe("runSubprocess soft request budget", () => {
 		tempDir[Symbol.dispose]();
 	});
 
-	function baseOptions(id: string) {
+	function baseOptions(id: string, eventBus?: EventBus) {
 		return {
 			cwd: "/tmp",
 			agent: baseAgent,
@@ -140,6 +187,7 @@ describe("runSubprocess soft request budget", () => {
 			modelRegistry: { refresh: async () => {} } as unknown as ModelRegistry,
 			enableLsp: false,
 			artifactsDir: tempDir.path(),
+			eventBus,
 		};
 	}
 
@@ -221,6 +269,22 @@ describe("runSubprocess soft request budget", () => {
 
 	it("a budget hard-abort keeps the kept-alive agent adopted and messageable via irc", async () => {
 		const id = "StubbornScout";
+		const eventBus = new EventBus();
+		const frames: RpcSubagentFrame[] = [];
+		let resolveFollowUpTerminal: (() => void) | undefined;
+		const waitForFollowUpTerminal = (): Promise<void> => {
+			const deferred = Promise.withResolvers<void>();
+			resolveFollowUpTerminal = deferred.resolve;
+			return deferred.promise;
+		};
+		const rpcRegistry = new RpcSubagentRegistry(eventBus, frame => {
+			frames.push(frame);
+			if (frame.type !== "subagent_lifecycle" || frame.payload.status === "started") return;
+			const resolve = resolveFollowUpTerminal;
+			resolveFollowUpTerminal = undefined;
+			resolve?.();
+		});
+		rpcRegistry.setSubscriptionLevel("progress");
 		const handle = createMockSession(({ promptIndex, emit, pushMessage }) => {
 			if (promptIndex !== 1) return;
 			// Never yields: budget 2 → stop at 3, grace exhausted at 3 + 5 = 8.
@@ -233,7 +297,7 @@ describe("runSubprocess soft request budget", () => {
 		mockCreateAgentSession(handle.session);
 		registerRunning(id, handle.session);
 
-		const result = await runSubprocess(baseOptions(id));
+		const result = await runSubprocess(baseOptions(id, eventBus));
 
 		expect(result.aborted).toBe(true);
 		expect(result.abortReason).toMatch(/Soft request budget exceeded/);
@@ -242,9 +306,34 @@ describe("runSubprocess soft request budget", () => {
 		expect(AgentLifecycleManager.global().has(id)).toBe(true);
 		expect(handle.disposeCalls()).toBe(0);
 
-		// The whole point: irc can reach the stopped agent to resume it.
-		const receipt = await new IrcBus().send({ from: "Main", to: id, body: "resume your inventory" });
-		expect(receipt.outcome).toBe("woken");
+		const expectRpcTurn = (): void => {
+			expect(frames[0]).toMatchObject({
+				type: "subagent_lifecycle",
+				payload: { id, status: "started" },
+			});
+			expect(frames.some(frame => frame.type === "subagent_progress")).toBe(true);
+			expect(frames.at(-1)).toMatchObject({
+				type: "subagent_lifecycle",
+				payload: { id, status: "completed" },
+			});
+		};
+
+		frames.length = 0;
+		const idleTerminal = waitForFollowUpTerminal();
+		const idleReceipt = await new IrcBus().send({ from: "Main", to: id, body: "resume your inventory" });
+		expect(idleReceipt.outcome).toBe("woken");
+		await idleTerminal;
+		expectRpcTurn();
+
+		await AgentLifecycleManager.global().park(id);
+		expect(AgentRegistry.global().get(id)?.status).toBe("parked");
+		frames.length = 0;
+		const revivedTerminal = waitForFollowUpTerminal();
+		const revivedReceipt = await new IrcBus().send({ from: "Main", to: id, body: "resume after parking" });
+		expect(revivedReceipt.outcome).toBe("revived");
+		await revivedTerminal;
+		expectRpcTurn();
+		rpcRegistry.dispose();
 	});
 
 	it("a caller-signal abort stays terminal and irc names the aborted agent precisely", async () => {

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -3,12 +3,18 @@ import * as path from "node:path";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import { RpcSubagentRegistry } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-subagents";
+import type { RpcSubagentFrame } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-types";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import type { AgentRef } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { createPersistedSubagentReviverFactory } from "@oh-my-pi/pi-coding-agent/task/persisted-revive";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 const tempDirs: TempDir[] = [];
@@ -33,14 +39,27 @@ function createRef(sessionFile: string): AgentRef {
 	};
 }
 
-function createRevivedSession(activeToolNames: string[][]): AgentSession {
-	return {
+type IrcWakeObserver = (records: CustomMessage[]) => ((error?: unknown) => void) | undefined;
+
+interface RevivedSessionHandle {
+	session: AgentSession;
+	observer: () => IrcWakeObserver | undefined;
+}
+
+function createRevivedSession(activeToolNames: string[][]): RevivedSessionHandle {
+	let observer: IrcWakeObserver | undefined;
+	const session = {
 		getMountedXdevToolNames: () => [],
 		setActiveToolsByName: async (names: string[]) => {
 			activeToolNames.push(names);
 		},
 		subscribe: (_listener: (event: AgentSessionEvent) => void) => () => {},
+		setIrcWakeTurnObserver: (next: IrcWakeObserver | undefined) => {
+			observer = next;
+		},
+		getLastAssistantMessage: () => undefined,
 	} as unknown as AgentSession;
+	return { session, observer: () => observer };
 }
 
 async function createPersistedSession(cwd: string, restrictToolNames?: boolean): Promise<string> {
@@ -74,11 +93,14 @@ async function createPersistedSession(cwd: string, restrictToolNames?: boolean):
 	return sessionFile;
 }
 
-function createFactory(cwd: string) {
+function createFactory(cwd: string, eventBus?: EventBus) {
 	const parentSession = {
 		sessionManager: {
 			getCwd: () => cwd,
 			getArtifactManager: () => undefined,
+		},
+		get sessionFile() {
+			return path.join(cwd, "parent.jsonl");
 		},
 	} as unknown as AgentSession;
 	return createPersistedSubagentReviverFactory({
@@ -87,6 +109,7 @@ function createFactory(cwd: string) {
 		modelRegistry: { authStorage: {} } as ModelRegistry,
 		settings: Settings.isolated(),
 		enableLsp: true,
+		eventBus,
 	});
 }
 
@@ -111,7 +134,7 @@ describe("persisted subagent revival", () => {
 			if (options?.preloadedCustomToolPaths === undefined) attemptedDiscovery.push("custom:read");
 			if (options?.mcpManager !== undefined || options?.customTools !== undefined)
 				attemptedDiscovery.push("mcp:read");
-			return { session: createRevivedSession(activeToolNames) } as CreateAgentSessionResult;
+			return { session: createRevivedSession(activeToolNames).session } as CreateAgentSessionResult;
 		});
 
 		const ref = createRef(sessionFile);
@@ -142,7 +165,7 @@ describe("persisted subagent revival", () => {
 		let capturedOptions: CreateAgentSessionOptions | undefined;
 		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
 			capturedOptions = options;
-			return { session: createRevivedSession([]) } as CreateAgentSessionResult;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
 		});
 
 		const ref = createRef(sessionFile);
@@ -154,5 +177,66 @@ describe("persisted subagent revival", () => {
 		expect(capturedOptions?.enableLsp).toBe(true);
 		expect(capturedOptions?.mcpManager).toBe(hostileMcp);
 		expect(capturedOptions?.customTools?.map(tool => tool.name)).toEqual(["mcp__server_read"]);
+	});
+
+	it("installs an IRC wake monitor that emits cold-revive lifecycle frames on the shared bus", async () => {
+		AgentRegistry.resetGlobalForTests();
+		AgentLifecycleManager.resetGlobalForTests();
+		const cwd = makeTempDir("@pi-revive-frames-");
+		const sessionFile = await createPersistedSession(cwd);
+		MCPManager.setInstance({ getTools: () => [] } as unknown as MCPManager);
+		let handle: RevivedSessionHandle | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async () => {
+			handle = createRevivedSession([]);
+			return { session: handle.session } as CreateAgentSessionResult;
+		});
+		const eventBus = new EventBus();
+		const frames: RpcSubagentFrame[] = [];
+		const terminal = Promise.withResolvers<void>();
+		const rpcRegistry = new RpcSubagentRegistry(eventBus, frame => {
+			frames.push(frame);
+			if (frame.type === "subagent_lifecycle" && frame.payload.status !== "started") terminal.resolve();
+		});
+		rpcRegistry.setSubscriptionLevel("progress");
+		const ref = createRef(sessionFile);
+		AgentRegistry.global().register({
+			id: ref.id,
+			displayName: ref.displayName,
+			kind: "sub",
+			session: null,
+			sessionFile,
+			status: "parked",
+		});
+		const reviver = await createFactory(cwd, eventBus)(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		const observer = handle?.observer();
+		expect(observer).toBeDefined();
+		const record: CustomMessage = {
+			role: "custom",
+			customType: "irc:incoming",
+			content: "resume after resume",
+			display: true,
+			details: { id: "irc-1", from: "Main", message: "resume after resume" },
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+		const finish = observer?.([record]);
+		finish?.();
+		await terminal.promise;
+
+		expect(frames[0]).toMatchObject({
+			type: "subagent_lifecycle",
+			payload: { id: ref.id, status: "started" },
+		});
+		const last = frames.at(-1);
+		expect(last?.type).toBe("subagent_lifecycle");
+		if (last?.type !== "subagent_lifecycle") throw new Error("expected terminal lifecycle frame");
+		expect(last.payload.id).toBe(ref.id);
+		expect(last.payload.status).not.toBe("started");
+		rpcRegistry.dispose();
+		AgentLifecycleManager.resetGlobalForTests();
+		AgentRegistry.resetGlobalForTests();
 	});
 });


### PR DESCRIPTION
## Repro
In RPC mode, subscribe with `set_subagent_subscription` at `progress`, let a keep-alive task subagent finish, then send it an IRC message: the delivery reports `woken` or `revived`, but stdout receives no new subagent frames. The regression is exercised by `bun test packages/coding-agent/test/task/executor-soft-budget.test.ts`, covering both a live-idle wake and an idle-TTL parked revival.

## Cause
`AgentSession.#wakeForIrc` started an autonomous `agent.prompt` directly, outside `runSubprocess` and `runSubagentFollowUpTurn`, so no task run monitor emitted `TASK_SUBAGENT_LIFECYCLE_CHANNEL` or `TASK_SUBAGENT_PROGRESS_CHANNEL`. `RpcSubagentRegistry` had already removed the prior terminal snapshot, leaving the host blind for the whole turn.

## Fix
- Add an `AgentSession` IRC-wake observer seam that brackets the autonomous prompt without changing fire-and-forget delivery semantics.
- Install a fresh task run monitor for each IRC wake, emit started/progress/terminal frames, preserve artifacts and structured output finalization, and reinstall the observer on parked-session revival.
- Cover RPC frame delivery for both idle and parked keep-alive subagents and record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/task/executor-soft-budget.test.ts packages/coding-agent/test/rpc-subagents.test.ts` passed (17 tests, 85 assertions); `bun run check` in `packages/coding-agent` passed; the publish gate also completed root `bun check`.

Fixes #7105