### PR TITLE
feat(stats): record tool-call durations

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -39,6 +39,13 @@
 
 - Fixed Codex V2 remote compaction bypassing the provider's live WebSocket transport before trying SSE ([#7198](https://github.com/can1357/oh-my-pi/issues/7198)).
 - Tool calls skipped mid-batch to service queued steering/peer input now distinguish calls that never entered `tool.execute` (`SyntheticToolResultDetails`, `executed: false`) from in-flight calls that may have performed partial work (`execution: "started"`), allowing UI/telemetry consumers to render normal steering control flow without misreporting execution state ([#7199](https://github.com/can1357/oh-my-pi/issues/7199)).
+### Changed
+
+- Tool wrappers can defer execution-start events until internal approval and preflight gates finish.
+
+### Fixed
+
+- Mark provider-stream failure tool results as unexecuted in `tool_execution_start` events.
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -70,6 +70,7 @@ import type {
 	AgentPreModelCallResult,
 	AgentTool,
 	AgentToolCall,
+	AgentToolContext,
 	AgentToolResult,
 	AgentTurnEndContext,
 	AsideMessage,
@@ -2496,10 +2497,22 @@ async function executeToolCalls(
 					: effectiveArgs;
 				record.args = executionArgs;
 
+				const markExecutionStarted = () => {
+					if (record.started) return;
+					executionStarted = true;
+					record.started = true;
+					stream.push({
+						type: "tool_execution_start",
+						toolCallId: toolCall.id,
+						toolName: toolCall.name,
+						args: executionArgs,
+						intent: toolCall.intent,
+						executed: true,
+					});
+				};
+
 				// The cooperative steering signal rides the loop-owned
-				// ToolCallContext (surfacing as `ctx.toolCall.steeringSignal`):
-				// AgentToolContext itself is app-built via declaration merging, so
-				// the loop cannot construct or extend one structurally.
+				// ToolCallContext (surfacing as `ctx.toolCall.steeringSignal`).
 				const toolContext = getToolContext
 					? getToolContext({
 							batchId,
@@ -2510,16 +2523,10 @@ async function executeToolCalls(
 							providerMetadata: toolCall.providerMetadata,
 						})
 					: undefined;
-				executionStarted = true;
-				record.started = true;
-				stream.push({
-					type: "tool_execution_start",
-					toolCallId: toolCall.id,
-					toolName: toolCall.name,
-					args: executionArgs,
-					intent: toolCall.intent,
-					executed: true,
-				});
+				const executionContext = tool.deferExecutionStart
+					? ({ ...toolContext, markExecutionStarted } as AgentToolContext)
+					: toolContext;
+				if (!tool.deferExecutionStart) markExecutionStarted();
 				const rawResult = await tool.execute(
 					toolCall.id,
 					executionArgs,
@@ -2533,7 +2540,7 @@ async function executeToolCalls(
 							partialResult: coerceToolResult(partialResult).result,
 						});
 					},
-					toolContext,
+					executionContext,
 				);
 				completedToolExecution = true;
 				const coerced = coerceToolResult(rawResult);

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2378,6 +2378,7 @@ async function executeToolCalls(
 				toolName: toolCall.name,
 				args: record.args,
 				intent: toolCall.intent,
+				executed: false,
 			});
 		}
 		stream.push({
@@ -2459,14 +2460,6 @@ async function executeToolCalls(
 			emitToolResult(record, createToolSignalAbortedResult(record.signal), true);
 			return;
 		}
-		record.started = true;
-		stream.push({
-			type: "tool_execution_start",
-			toolCallId: toolCall.id,
-			toolName: toolCall.name,
-			args: effectiveArgs,
-			intent: toolCall.intent,
-		});
 
 		const toolSpan = startExecuteToolSpan(telemetry, {
 			tool,
@@ -2518,6 +2511,15 @@ async function executeToolCalls(
 						})
 					: undefined;
 				executionStarted = true;
+				record.started = true;
+				stream.push({
+					type: "tool_execution_start",
+					toolCallId: toolCall.id,
+					toolName: toolCall.name,
+					args: executionArgs,
+					intent: toolCall.intent,
+					executed: true,
+				});
 				const rawResult = await tool.execute(
 					toolCall.id,
 					executionArgs,
@@ -2870,6 +2872,7 @@ function createAbortedToolResult(
 		toolName: toolCall.name,
 		args: toolCall.arguments,
 		intent: toolCall.intent,
+		executed: false,
 	});
 	stream.push({
 		type: "tool_execution_end",

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2497,6 +2497,19 @@ async function executeToolCalls(
 					: effectiveArgs;
 				record.args = executionArgs;
 
+				let pendingExecutionEmitted = false;
+				const markExecutionPending = () => {
+					if (record.started || pendingExecutionEmitted) return;
+					pendingExecutionEmitted = true;
+					stream.push({
+						type: "tool_execution_start",
+						toolCallId: toolCall.id,
+						toolName: toolCall.name,
+						args: executionArgs,
+						intent: toolCall.intent,
+						executed: false,
+					});
+				};
 				const markExecutionStarted = () => {
 					if (record.started) return;
 					executionStarted = true;
@@ -2524,7 +2537,7 @@ async function executeToolCalls(
 						})
 					: undefined;
 				const executionContext = tool.deferExecutionStart
-					? ({ ...toolContext, markExecutionStarted } as AgentToolContext)
+					? ({ ...toolContext, markExecutionPending, markExecutionStarted } as AgentToolContext)
 					: toolContext;
 				if (!tool.deferExecutionStart) markExecutionStarted();
 				const rawResult = await tool.execute(

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1651,6 +1651,7 @@ export class Agent {
 						toolName: block.name,
 						args: block.arguments,
 						intent: block.intent,
+						executed: false,
 					});
 					this.#emit({
 						type: "tool_execution_end",

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -737,6 +737,11 @@ export type ToolApproval = ToolApprovalDecision | ((args: unknown) => ToolApprov
  */
 export interface AgentToolContext {
 	/**
+	 * Emit a non-executed lifecycle boundary while a deferred tool waits for
+	 * approval or another interactive preflight.
+	 */
+	markExecutionPending?: () => void;
+	/**
 	 * Mark the actual implementation boundary for tools that defer execution
 	 * behind approval or another preflight gate.
 	 */

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -870,6 +870,14 @@ export type AgentEvent =
 	| { type: "message_update"; message: AgentMessage; assistantMessageEvent: AssistantMessageEvent }
 	| { type: "message_end"; message: AgentMessage }
 	// Tool execution lifecycle
-	| { type: "tool_execution_start"; toolCallId: string; toolName: string; args: any; intent?: string }
+	| {
+			type: "tool_execution_start";
+			toolCallId: string;
+			toolName: string;
+			args: any;
+			intent?: string;
+			/** False when the event only pairs a tool call with a result and no tool implementation ran. */
+			executed?: boolean;
+	  }
 	| { type: "tool_execution_update"; toolCallId: string; toolName: string; args: any; partialResult: any }
 	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError?: boolean };

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -736,7 +736,11 @@ export type ToolApproval = ToolApprovalDecision | ((args: unknown) => ToolApprov
  * Apps can extend via declaration merging.
  */
 export interface AgentToolContext {
-	// Empty by default - apps extend via declaration merging
+	/**
+	 * Mark the actual implementation boundary for tools that defer execution
+	 * behind approval or another preflight gate.
+	 */
+	markExecutionStarted?: () => void;
 }
 
 export type AgentToolExecFn<TParameters extends TSchema = TSchema, TDetails = any, TTheme = unknown> = (
@@ -770,6 +774,11 @@ export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any
 	concurrency?: "shared" | "exclusive" | ((args: Partial<Static<TParameters>>) => "shared" | "exclusive");
 	/** If true, argument validation errors are non-fatal: raw args are passed to execute() instead of returning an error to the LLM. */
 	lenientArgValidation?: boolean;
+	/**
+	 * Defer the execution-start event until `context.markExecutionStarted()` is
+	 * called. Use only for wrappers with preflight work inside `execute()`.
+	 */
+	deferExecutionStart?: boolean;
 	/**
 	 * Whether the agent loop may abort this tool mid-execution to deliver a
 	 * queued steering message. A function resolves this per call from the raw,

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -4055,6 +4055,7 @@ describe("agentLoopContinue with AgentMessage", () => {
 			deferExecutionStart: true,
 			async execute(_toolCallId, params, _signal, _onUpdate, context) {
 				executionContext = context;
+				context?.markExecutionPending?.();
 				context?.markExecutionStarted?.();
 				return {
 					content: [{ type: "text", text: `echoed: ${params.value}` }],
@@ -4079,8 +4080,9 @@ describe("agentLoopContinue with AgentMessage", () => {
 		for await (const event of stream) events.push(event);
 
 		const starts = events.filter(event => event.type === "tool_execution_start");
-		expect(starts).toHaveLength(1);
-		expect(starts[0]).toMatchObject({ toolCallId: "tool-1", executed: true });
+		expect(starts).toHaveLength(2);
+		expect(starts[0]).toMatchObject({ toolCallId: "tool-1", executed: false });
+		expect(starts[1]).toMatchObject({ toolCallId: "tool-1", executed: true });
 		expect(executionContext).toMatchObject({ sentinel: true });
 		expect(Object.hasOwn(executionContext ?? {}, "sentinel")).toBe(true);
 	});

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -4043,6 +4043,48 @@ describe("agentLoopContinue with AgentMessage", () => {
 		}
 	});
 
+	it("starts deferred tools when their implementation boundary is reached", async () => {
+		const baseToolContext = { sentinel: true } as unknown as AgentToolContext;
+		let executionContext: AgentToolContext | undefined;
+		const toolSchema = type({ value: "string" });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			deferExecutionStart: true,
+			async execute(_toolCallId, params, _signal, _onUpdate, context) {
+				executionContext = context;
+				context?.markExecutionStarted?.();
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }] },
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			getToolContext: () => baseToolContext,
+		};
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, mock.stream);
+		for await (const event of stream) events.push(event);
+
+		const starts = events.filter(event => event.type === "tool_execution_start");
+		expect(starts).toHaveLength(1);
+		expect(starts[0]).toMatchObject({ toolCallId: "tool-1", executed: true });
+		expect(executionContext).toMatchObject({ sentinel: true });
+		expect(Object.hasOwn(executionContext ?? {}, "sentinel")).toBe(true);
+	});
+
 	it("passes beforeToolCall args mutations into tool.execute without revalidation", async () => {
 		const toolSchema = type({ value: "string" });
 		const executed: Array<string | number> = [];

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -4030,6 +4030,11 @@ describe("agentLoopContinue with AgentMessage", () => {
 		}
 
 		expect(executed).toEqual([]);
+		const toolStart = events.find(e => e.type === "tool_execution_start");
+		expect(toolStart).toBeDefined();
+		if (toolStart?.type === "tool_execution_start") {
+			expect(toolStart.executed).toBe(false);
+		}
 		const toolEnd = events.find(e => e.type === "tool_execution_end");
 		expect(toolEnd).toBeDefined();
 		if (toolEnd?.type === "tool_execution_end") {

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -702,6 +702,13 @@ describe("Agent", () => {
 			},
 		});
 
+		const executionStart = events.find(event => event.type === "tool_execution_start");
+		expect(executionStart).toMatchObject({
+			type: "tool_execution_start",
+			toolCallId: "tool-1",
+			executed: false,
+		});
+
 		const turnEnd = events.find(event => event.type === "turn_end");
 		expect(turnEnd).toMatchObject({
 			type: "turn_end",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -293,6 +293,9 @@
 - Fixed ephemeral side turns and native compaction bypassing an explicit or fork-inherited prompt cache key ([#7218](https://github.com/can1357/oh-my-pi/issues/7218)).
 - Fixed the live Ask dialog crashing the whole session with a `replaceTabs` TypeError when a question reached `AskDialogComponent` without a string `question` field; questions are now normalized at dialog entry, mirroring the transcript renderer ([#7211](https://github.com/can1357/oh-my-pi/issues/7211)).
 - Fixed Codex web search collapsing backend errors to `Codex error (): Unknown error`; the SSE error parser now preserves the backend code and message from top-level, nested `error`, and `response.error` envelopes ([#7200](https://github.com/can1357/oh-my-pi/issues/7200)).
+### Changed
+
+- Tool execution timing now begins after approval succeeds, Cursor bridge rejections are marked unexecuted, and extension `tool_execution_start` events expose whether the tool implementation ran.
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -238,6 +238,10 @@
 - Fixed heavily branched conversation trees shifting linear continuations into disconnected columns.
 - Fixed plugin installation validation failures for legacy compatibility shims.
 - Removed hard-coded references to disabled or absent agents in system and tool prompts.
+### Changed
+
+- Tool execution timing now begins after approval succeeds, Cursor bridge rejections are marked unexecuted, and extension `tool_execution_start` events expose whether the tool implementation ran.
+
 
 ## [17.2.4] - 2026-08-01
 
@@ -293,9 +297,6 @@
 - Fixed ephemeral side turns and native compaction bypassing an explicit or fork-inherited prompt cache key ([#7218](https://github.com/can1357/oh-my-pi/issues/7218)).
 - Fixed the live Ask dialog crashing the whole session with a `replaceTabs` TypeError when a question reached `AskDialogComponent` without a string `question` field; questions are now normalized at dialog entry, mirroring the transcript renderer ([#7211](https://github.com/can1357/oh-my-pi/issues/7211)).
 - Fixed Codex web search collapsing backend errors to `Codex error (): Unknown error`; the SSE error parser now preserves the backend code and message from top-level, nested `error`, and `response.error` envelopes ([#7200](https://github.com/can1357/oh-my-pi/issues/7200)).
-### Changed
-
-- Tool execution timing now begins after approval succeeds, Cursor bridge rejections are marked unexecuted, and extension `tool_execution_start` events expose whether the tool implementation ran.
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/coding-agent/src/cursor.ts
+++ b/packages/coding-agent/src/cursor.ts
@@ -226,6 +226,29 @@ function buildToolErrorResult(message: string): AgentToolResult<unknown> {
 	};
 }
 
+function buildUnexecutedToolErrorResult(message: string): AgentToolResult<unknown> {
+	return {
+		content: [{ type: "text", text: message }],
+		details: {
+			__synthetic: true,
+			source: "cursor_bridge_rejected",
+			executed: false,
+		},
+	};
+}
+
+function markUnexecutedToolResult(result: AgentToolResult<unknown>): AgentToolResult<unknown> {
+	const details = result.details;
+	return {
+		...result,
+		details: {
+			...(details && typeof details === "object" && !Array.isArray(details) ? details : {}),
+			__synthetic: true,
+			source: "cursor_bridge_rejected",
+			executed: false,
+		},
+	};
+}
 async function executeTool(
 	options: CursorExecBridgeOptions,
 	toolName: string,
@@ -235,11 +258,21 @@ async function executeTool(
 ): Promise<ToolResultMessage> {
 	const tool = overrideTool ?? options.getExecutableTool?.(toolName) ?? options.tools.get(toolName);
 	if (!tool) {
-		const result = buildToolErrorResult(`Tool "${toolName}" not available`);
+		const result = buildUnexecutedToolErrorResult(`Tool "${toolName}" not available`);
 		return createToolResultMessage(toolCallId, toolName, result, true);
 	}
 
-	options.emitEvent?.({ type: "tool_execution_start", toolCallId, toolName, args });
+	let executionObserved = false;
+	const emitExecutionBoundary = (executed: boolean) => {
+		if (executionObserved) return;
+		executionObserved = true;
+		options.emitEvent?.({ type: "tool_execution_start", toolCallId, toolName, args, executed });
+	};
+	const toolContext = options.getToolContext?.();
+	const executionContext = tool.deferExecutionStart
+		? ({ ...toolContext, markExecutionStarted: () => emitExecutionBoundary(true) } as AgentToolContext)
+		: toolContext;
+	if (!tool.deferExecutionStart) emitExecutionBoundary(true);
 
 	let result: AgentToolResult<unknown>;
 	let isError = false;
@@ -261,19 +294,17 @@ async function executeTool(
 		: undefined;
 
 	try {
-		result = await tool.execute(
-			toolCallId,
-			args as Record<string, unknown>,
-			undefined,
-			onUpdate,
-			options.getToolContext?.(),
-		);
+		result = await tool.execute(toolCallId, args as Record<string, unknown>, undefined, onUpdate, executionContext);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		result = buildToolErrorResult(message);
 		isError = true;
 	}
 	isError ||= result.isError === true;
+	if (!executionObserved) {
+		emitExecutionBoundary(false);
+		result = markUnexecutedToolResult(result);
+	}
 
 	const sanitizedFinalResult: AgentToolResult<unknown> = {
 		content: result.content.map(c => (c.type === "text" ? { ...c, text: sanitizeText(c.text) } : c)),
@@ -313,7 +344,7 @@ async function executeDelete(options: CursorExecBridgeOptions, pathArg: string, 
 	const toolName = "delete";
 
 	if (options.allowDirectFileMutation === false) {
-		const result = buildToolErrorResult(`Tool "${toolName}" not available`);
+		const result = buildUnexecutedToolErrorResult(`Tool "${toolName}" not available`);
 		return createToolResultMessage(toolCallId, toolName, result, true);
 	}
 
@@ -324,7 +355,7 @@ async function executeDelete(options: CursorExecBridgeOptions, pathArg: string, 
 	// this, a configured `deny` or an `always-ask` session still lost the file.
 	const refusal = refuseByWritePolicy(options, toolName, pathArg);
 	if (refusal) {
-		return createToolResultMessage(toolCallId, toolName, buildToolErrorResult(refusal), true);
+		return createToolResultMessage(toolCallId, toolName, buildUnexecutedToolErrorResult(refusal), true);
 	}
 
 	options.emitEvent?.({ type: "tool_execution_start", toolCallId, toolName, args: { path: pathArg } });
@@ -396,14 +427,14 @@ function formatTodoSyncSummary(phases: TodoPhase[]): string {
 /**
  * Persisted result for a server-resolved todo call.
  *
- * `details` is only attached for an authoritative snapshot, and then
- * `details.phases` is load-bearing rather than decoration: `todoToolRenderer`
- * rebuilds the rendered list exclusively from it, so a mirrored update that
- * omitted it would replay as `Todo 0 tasks` after a reload.
+ * `details.phases` is only attached for an authoritative snapshot and is
+ * load-bearing rather than decoration: `todoToolRenderer` rebuilds the rendered
+ * list exclusively from it, so a mirrored update that omitted it would replay
+ * as `Todo 0 tasks` after a reload.
  *
- * A refusal or a server error carries no `details`. Echoing the current phases
- * there would replay a call that changed nothing as if it had re-asserted the
- * whole list — and `event-controller` feeds `details.phases` straight into
+ * A refusal or a server error carries no `details.phases`. Echoing the current
+ * phases there would replay a call that changed nothing as if it had re-asserted
+ * the whole list — and `event-controller` feeds `details.phases` straight into
  * `setTodos`, so a refused `read_todos` would overwrite live UI state.
  */
 function buildTodoSyncResult(
@@ -418,7 +449,12 @@ function buildTodoSyncResult(
 		content: [
 			{ type: "text", text: error ?? (phases ? formatTodoSyncSummary(phases) : "Todo snapshot not mirrored") },
 		],
-		details: phases ? { phases, storage: "session" } : undefined,
+		details: {
+			...(phases ? { phases, storage: "session" } : {}),
+			__synthetic: true,
+			source: "cursor_server_resolved",
+			executed: false,
+		},
 		isError: error !== null,
 		timestamp: Date.now(),
 	};
@@ -439,7 +475,15 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 		const composed = piReadPath(args.path, args.offset, args.limit);
 		// A present `limit: 0` asks for zero lines; no selector expresses that.
 		if (composed === null) {
-			return createToolResultMessage(toolCallId, "read", { content: [{ type: "text", text: "" }] }, false);
+			return createToolResultMessage(
+				toolCallId,
+				"read",
+				{
+					content: [{ type: "text", text: "" }],
+					details: { __synthetic: true, source: "cursor_zero_length_read", executed: false },
+				},
+				false,
+			);
 		}
 		return await executeTool(this.options, "read", toolCallId, { path: composed });
 	}
@@ -504,7 +548,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 		const toolName = "bash";
 		const tool = this.options.tools.get(toolName);
 		if (!tool) {
-			const result = buildToolErrorResult(`Tool "${toolName}" not available`);
+			const result = buildUnexecutedToolErrorResult(`Tool "${toolName}" not available`);
 			return createToolResultMessage(toolCallId, toolName, result, true);
 		}
 
@@ -514,8 +558,17 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 			cwd: args.workingDirectory || undefined,
 			timeout: timeoutSeconds,
 		};
-
-		this.options.emitEvent?.({ type: "tool_execution_start", toolCallId, toolName, args: toolArgs });
+		let executionObserved = false;
+		const emitExecutionBoundary = (executed: boolean) => {
+			if (executionObserved) return;
+			executionObserved = true;
+			this.options.emitEvent?.({ type: "tool_execution_start", toolCallId, toolName, args: toolArgs, executed });
+		};
+		const toolContext = this.options.getToolContext?.();
+		const executionContext = tool.deferExecutionStart
+			? ({ ...toolContext, markExecutionStarted: () => emitExecutionBoundary(true) } as AgentToolContext)
+			: toolContext;
+		if (!tool.deferExecutionStart) emitExecutionBoundary(true);
 
 		let result: AgentToolResult<unknown>;
 		let isError = false;
@@ -560,11 +613,15 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 		};
 
 		try {
-			result = await tool.execute(toolCallId, toolArgs, undefined, onUpdate, this.options.getToolContext?.());
+			result = await tool.execute(toolCallId, toolArgs, undefined, onUpdate, executionContext);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			result = buildToolErrorResult(message);
 			isError = true;
+		}
+		if (!executionObserved) {
+			emitExecutionBoundary(false);
+			result = markUnexecutedToolResult(result);
 		}
 		isError ||= result.isError === true;
 
@@ -628,7 +685,15 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 		// string for it; no `read` selector expresses that, so answer directly
 		// rather than falling back to a whole-file read.
 		if (composed === null) {
-			return createToolResultMessage(call.toolCallId, "read", { content: [{ type: "text", text: "" }] }, false);
+			return createToolResultMessage(
+				call.toolCallId,
+				"read",
+				{
+					content: [{ type: "text", text: "" }],
+					details: { __synthetic: true, source: "cursor_zero_length_read", executed: false },
+				},
+				false,
+			);
 		}
 		return await executeTool(this.options, "read", call.toolCallId, { path: composed });
 	}
@@ -851,9 +916,10 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 	 * A `null` snapshot means nothing may be mirrored — a server `error`, or a
 	 * benign refusal: a filtered, truncated, or empty read, or a snapshot the
 	 * local model cannot represent. Local state is left untouched, and the result
-	 * carries no `details` (text `"Todo snapshot not mirrored"`): `event-controller`
-	 * feeds `details.phases` straight into `setTodos`, so echoing the current list
-	 * back would let a call that changed nothing overwrite live UI state.
+	 * carries no `details.phases` (text `"Todo snapshot not mirrored"`):
+	 * `event-controller` feeds `details.phases` straight into `setTodos`, so
+	 * echoing the current list back would let a call that changed nothing
+	 * overwrite live UI state.
 	 */
 	todoSync(snapshot: CursorTodoSnapshot | null, toolCallId: string, error: string | null = null): ToolResultMessage {
 		const setPhases = this.options.setTodoPhases;
@@ -923,7 +989,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 		if (!tool) {
 			const availableTools = Array.from(this.options.tools.keys()).filter(name => name.startsWith("mcp__"));
 			const message = formatMcpToolErrorMessage(toolName, availableTools);
-			const result = buildToolErrorResult(message);
+			const result = buildUnexecutedToolErrorResult(message);
 			return createToolResultMessage(toolCallId, toolName, result, true);
 		}
 

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -717,12 +717,14 @@ export interface MessageEndEvent {
 	message: AgentMessage;
 }
 
-/** Fired when a tool starts executing */
+/** Fired when a tool call reaches the execution or synthetic-result boundary. */
 export interface ToolExecutionStartEvent {
 	type: "tool_execution_start";
 	toolCallId: string;
 	toolName: string;
 	args: unknown;
+	/** False when no tool implementation ran; absent only for legacy or direct-dispatch emitters. */
+	executed?: boolean;
 	intent?: string;
 }
 

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -315,6 +315,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				pendingSafetyChecks.length > 0
 					? `${basePrompt}\nProvider safety checks:\n${safetyCheckLines(pendingSafetyChecks).join("\n")}`
 					: basePrompt;
+			context?.markExecutionPending?.();
 			let choice: string | undefined;
 			try {
 				choice = await uiContext.select(safetyPrompt, ["Approve", "Deny"]);

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -150,6 +150,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 	declare parameters: TParameters;
 	declare label: string;
 	declare strict: boolean;
+	readonly deferExecutionStart = true;
 
 	constructor(
 		private tool: AgentTool<TParameters, TDetails>,
@@ -337,6 +338,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		let executionError: Error | undefined;
 
 		try {
+			context?.markExecutionStarted?.();
 			result = await this.tool.execute(toolCallId, effectiveParams, signal, onUpdate, context);
 		} catch (err) {
 			executionError = err instanceof Error ? err : new Error(String(err));

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1935,6 +1935,7 @@ export class AgentSession {
 		const data: ToolExecutionStartData = {
 			toolCallId: event.toolCallId,
 			toolName: event.toolName,
+			executed: event.executed !== false,
 			startedAt: new Date().toISOString(),
 		};
 		// The assistant message already persists the full arguments; store only

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3439,6 +3439,7 @@ export class AgentSession {
 				toolCallId: event.toolCallId,
 				toolName: event.toolName,
 				args: event.args,
+				executed: event.executed,
 				intent: event.intent,
 			};
 			await this.#extensionRunner.emit(extensionEvent);

--- a/packages/coding-agent/src/session/exit-diagnostics.ts
+++ b/packages/coding-agent/src/session/exit-diagnostics.ts
@@ -16,11 +16,13 @@ export interface ToolArgumentSummary {
 	path?: string;
 }
 
-/** Persisted marker written before a tool implementation starts running. */
+/** Persisted marker emitted when a tool call reaches its execution boundary. */
 export interface ToolExecutionStartData {
 	toolCallId: string;
 	toolName: string;
 	args?: ToolArgumentSummary;
+	/** False when no tool implementation ran; absent on legacy execution markers. */
+	executed?: boolean;
 	intent?: string;
 	startedAt: string;
 }

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -681,6 +681,42 @@ describe("AgentSession message pipeline", () => {
 		await Bun.sleep(0);
 	});
 
+	it("forwards non-executed tool starts to extensions", async () => {
+		const forwarded = Promise.withResolvers<void>();
+		const extensionEmit = vi.fn(async (event: { type: string }) => {
+			if (event.type === "tool_execution_start") forwarded.resolve();
+		});
+		const session = new AgentSession({
+			agent: createAgent(),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: {} as never,
+			extensionRunner: {
+				hasHandlers: () => true,
+				emit: extensionEmit,
+			} as never,
+		});
+		sessions.push(session);
+
+		session.agent.emitExternalEvent({
+			type: "tool_execution_start",
+			toolCallId: "call-1",
+			toolName: "edit",
+			args: { path: "file.ts" },
+			executed: false,
+		});
+		await forwarded.promise;
+
+		expect(extensionEmit).toHaveBeenCalledWith({
+			type: "tool_execution_start",
+			toolCallId: "call-1",
+			toolName: "edit",
+			args: { path: "file.ts" },
+			executed: false,
+			intent: undefined,
+		});
+	});
+
 	it("keeps first-turn memory in the stable prompt on the next turn", async () => {
 		const api = "test-injected-memory-append-only-cache";
 		const contexts: Context[] = [];

--- a/packages/coding-agent/test/cursor-exec.test.ts
+++ b/packages/coding-agent/test/cursor-exec.test.ts
@@ -699,6 +699,71 @@ describe("CursorExecHandlers error results", () => {
 		const end = events.find(event => event.type === "tool_execution_end");
 		expect(end?.isError).toBe(true);
 	});
+
+	it("marks deferred shell rejections as unexecuted", async () => {
+		const events: AgentEvent[] = [];
+		const deferredTool: AgentTool = {
+			name: "bash",
+			label: "Bash",
+			description: "rejects before execution",
+			parameters: type({}),
+			deferExecutionStart: true,
+			async execute() {
+				throw new Error("approval denied");
+			},
+		};
+		const handlers = new CursorExecHandlers({
+			cwd: ".",
+			tools: new Map([["bash", deferredTool]]),
+			emitEvent: event => events.push(event),
+		});
+
+		const result = await handlers.shellStream(
+			create(ShellArgsSchema, { toolCallId: "call-shell-denied", command: "ignored" }),
+			{ onStdout: () => {}, onStderr: () => {} },
+		);
+
+		expect(result.isError).toBe(true);
+		expect(result.details).toMatchObject({ __synthetic: true, executed: false });
+		expect(events.filter(event => event.type === "tool_execution_start")).toEqual([
+			expect.objectContaining({ toolCallId: "call-shell-denied", executed: false }),
+		]);
+	});
+
+	it("preserves tool context fields for deferred shell execution", async () => {
+		const events: AgentEvent[] = [];
+		let executionContext: AgentToolContext | undefined;
+		const deferredTool: AgentTool = {
+			name: "bash",
+			label: "Bash",
+			description: "starts after preflight",
+			parameters: type({}),
+			deferExecutionStart: true,
+			async execute(_toolCallId, _params, _signal, _onUpdate, context) {
+				executionContext = context;
+				context?.markExecutionStarted?.();
+				return { content: [{ type: "text", text: "ran" }], details: {} };
+			},
+		};
+		const handlers = new CursorExecHandlers({
+			cwd: ".",
+			tools: new Map([["bash", deferredTool]]),
+			emitEvent: event => events.push(event),
+			getToolContext: () => ({ sentinel: true }) as unknown as AgentToolContext,
+		});
+
+		const result = await handlers.shellStream(
+			create(ShellArgsSchema, { toolCallId: "call-shell-started", command: "ignored" }),
+			{ onStdout: () => {}, onStderr: () => {} },
+		);
+
+		expect(result.isError).toBe(false);
+		expect(executionContext).toMatchObject({ sentinel: true });
+		expect(Object.hasOwn(executionContext ?? {}, "sentinel")).toBe(true);
+		expect(events.filter(event => event.type === "tool_execution_start")).toEqual([
+			expect.objectContaining({ toolCallId: "call-shell-started", executed: true }),
+		]);
+	});
 });
 
 describe("CursorExecHandlers mounted tool bridge", () => {
@@ -750,6 +815,7 @@ describe("CursorExecHandlers mounted tool bridge", () => {
 			consumeToolCallEmitted: () => false,
 		} as unknown as ExtensionRunner);
 		const settings = Settings.isolated({ "tools.approval": { ast_edit: "deny" } });
+		const events: AgentEvent[] = [];
 		const handlers = new CursorExecHandlers({
 			cwd: ".",
 			// The canonical map contains the undecorated mounted tool. The execution
@@ -757,6 +823,7 @@ describe("CursorExecHandlers mounted tool bridge", () => {
 			tools: new Map([[device.name, device]]),
 			getExecutableTool: name => (name === device.name ? (wrapped as unknown as AgentTool) : undefined),
 			getToolContext: () => ({ settings }) as AgentToolContext,
+			emitEvent: event => events.push(event),
 		});
 
 		const result = await handlers.mcp({
@@ -771,6 +838,10 @@ describe("CursorExecHandlers mounted tool bridge", () => {
 		expect(result.isError).toBe(true);
 		expect(executed).toBe(false);
 		expect(result.content.find(block => block.type === "text")?.text).toContain("blocked by user policy");
+		expect(result.details).toMatchObject({ __synthetic: true, executed: false });
+		expect(events.filter(event => event.type === "tool_execution_start")).toEqual([
+			expect.objectContaining({ toolCallId: "call-denied", executed: false }),
+		]);
 	});
 
 	it("lists resources from the session's live MCP servers", async () => {
@@ -1333,6 +1404,7 @@ describe("CursorExecHandlers native delete gating (issue #5680)", () => {
 
 		expect(result.isError).toBe(true);
 		expect(result.content).toEqual([{ type: "text", text: 'Tool "delete" not available' }]);
+		expect(result.details).toMatchObject({ __synthetic: true, executed: false });
 		expect(await Bun.file(target).exists()).toBe(true);
 	});
 
@@ -1394,6 +1466,7 @@ describe("CursorExecHandlers native delete gating (issue #5680)", () => {
 		);
 
 		expect(result.isError).toBe(true);
+		expect(result.details).toMatchObject({ __synthetic: true, executed: false });
 		expect(await Bun.file(target).exists()).toBe(true);
 	});
 
@@ -1584,17 +1657,25 @@ describe("CursorExecHandlers Pi frame translation", () => {
 		]);
 	});
 
-	it("answers a present pi_read limit of zero with empty output instead of the whole file", async () => {
+	it("answers present read limits of zero with explicitly unexecuted empty results", async () => {
 		// `limit: 0` is present, not unset: the reference slices zero lines. No
 		// `read` selector expresses an empty range, so treating it as unset would
 		// return the entire file — the opposite of what was asked.
 		const { handlers, calls } = recordingHandlers("read");
 
-		const result = await handlers.piRead({ toolCallId: "c1", args: { path: "a.ts", limit: 0 } } as never);
+		const piResult = await handlers.piRead({ toolCallId: "c1", args: { path: "a.ts", limit: 0 } } as never);
+		const legacyResult = await handlers.read({ toolCallId: "c2", path: "a.ts", limit: 0 } as never);
 
 		expect(calls).toEqual([]);
-		expect(result.isError).toBe(false);
-		expect(result.content).toEqual([{ type: "text", text: "" }]);
+		for (const result of [piResult, legacyResult]) {
+			expect(result.isError).toBe(false);
+			expect(result.content).toEqual([{ type: "text", text: "" }]);
+			expect(result.details).toEqual({
+				__synthetic: true,
+				source: "cursor_zero_length_read",
+				executed: false,
+			});
+		}
 	});
 
 	it("composes the legacy read frame's offset/limit the same way pi_read does", async () => {

--- a/packages/coding-agent/test/cursor-todo-persistence.test.ts
+++ b/packages/coding-agent/test/cursor-todo-persistence.test.ts
@@ -83,7 +83,7 @@ describe("cursor todo persistence", () => {
 		// toolResult, so nothing would otherwise land in the branch and every
 		// reload/rewind/compaction would silently drop the list.
 		const h = newHarness();
-		h.handlers.todoSync(
+		const result = h.handlers.todoSync(
 			{
 				merged: false,
 				todos: [
@@ -104,6 +104,11 @@ describe("cursor todo persistence", () => {
 				],
 			},
 		]);
+		expect(result.details).toMatchObject({
+			__synthetic: true,
+			source: "cursor_server_resolved",
+			executed: false,
+		});
 	});
 
 	it("replays the newest snapshot after repeated updates", () => {
@@ -244,7 +249,11 @@ describe("cursor todo persistence", () => {
 		const settled = events[0];
 		if (settled?.type !== "tool_execution_end") throw new Error("expected a completion event");
 		expect(settled).toMatchObject({ toolCallId: "call-1", toolName: "todo", isError: false });
-		expect(settled.result.details).toBeUndefined();
+		expect(settled.result.details).toEqual({
+			__synthetic: true,
+			source: "cursor_server_resolved",
+			executed: false,
+		});
 	});
 
 	it("settles a refusal without overwriting the live todo list", () => {
@@ -259,7 +268,11 @@ describe("cursor todo persistence", () => {
 		expect(h.current()).toBe(before);
 		expect(h.entries).toEqual([]);
 		expect(h.uiTodos()).toBeNull();
-		expect(result).toMatchObject({ toolCallId: "call-1", isError: false, details: undefined });
+		expect(result).toMatchObject({
+			toolCallId: "call-1",
+			isError: false,
+			details: { __synthetic: true, source: "cursor_server_resolved", executed: false },
+		});
 		expect(h.events).toHaveLength(1);
 		expect(h.events[0]).toMatchObject({ type: "tool_execution_end", toolCallId: "call-1", isError: false });
 	});
@@ -276,7 +289,7 @@ describe("cursor todo persistence", () => {
 			toolCallId: "call-1",
 			isError: true,
 			content: [{ type: "text", text: "boom" }],
-			details: undefined,
+			details: { __synthetic: true, source: "cursor_server_resolved", executed: false },
 		});
 		expect(h.events[0]).toMatchObject({ type: "tool_execution_end", toolCallId: "call-1", isError: true });
 	});

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -506,7 +506,7 @@ describe("ExtensionRunner", () => {
 
 	describe("before_provider_request chaining", () => {
 		it("exposes the request model instead of the primary session model", async () => {
-			const primaryModel = getBundledModel("openai-codex", "gpt-5.6-sol");
+			const primaryModel = getBundledModel("openai-codex", "gpt-5.5");
 			const requestModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 			if (!primaryModel || !requestModel) throw new Error("Expected bundled cross-provider models to exist");
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1775,12 +1775,14 @@ describe("ExtensionRunner", () => {
 				hasQueuedMessages: () => false,
 				abort: () => {},
 				settings: { get: (key: string) => (key === "tools.approvalMode" ? "always-ask" : {}) } as never,
+				markExecutionStarted: () => events.push({ type: "execution_started" }),
 			});
 
 			expect(events).toEqual([
 				{ type: "tool_approval_requested" },
 				{ type: "ui_select" },
 				{ type: "tool_approval_resolved", approved: true },
+				{ type: "execution_started" },
 			]);
 			expect(select).toHaveBeenCalledWith(expect.stringContaining("Allow tool: dangerous_tool"), [
 				"Approve",
@@ -1818,6 +1820,7 @@ describe("ExtensionRunner", () => {
 				modelRegistry,
 			);
 			initializeRunner(runner, async () => "Deny");
+			const markExecutionStarted = vi.fn();
 
 			const wrapper = new ExtensionToolWrapper(approvalTool, runner);
 			await expect(
@@ -1829,6 +1832,7 @@ describe("ExtensionRunner", () => {
 					hasQueuedMessages: () => false,
 					abort: () => {},
 					settings: { get: (key: string) => (key === "tools.approvalMode" ? "always-ask" : {}) } as never,
+					markExecutionStarted,
 				}),
 			).rejects.toThrow("Tool call denied by user: dangerous_tool");
 
@@ -1836,6 +1840,7 @@ describe("ExtensionRunner", () => {
 				{ type: "tool_approval_requested", reason: undefined },
 				{ type: "tool_approval_resolved", approved: false, reason: "denied by user" },
 			]);
+			expect(markExecutionStarted).not.toHaveBeenCalled();
 			delete globalState.__deniedApprovalEvents;
 		});
 		it("emits resolved false when the approval prompt throws", async () => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1775,11 +1775,13 @@ describe("ExtensionRunner", () => {
 				hasQueuedMessages: () => false,
 				abort: () => {},
 				settings: { get: (key: string) => (key === "tools.approvalMode" ? "always-ask" : {}) } as never,
+				markExecutionPending: () => events.push({ type: "execution_pending" }),
 				markExecutionStarted: () => events.push({ type: "execution_started" }),
 			});
 
 			expect(events).toEqual([
 				{ type: "tool_approval_requested" },
+				{ type: "execution_pending" },
 				{ type: "ui_select" },
 				{ type: "tool_approval_resolved", approved: true },
 				{ type: "execution_started" },
@@ -1821,6 +1823,7 @@ describe("ExtensionRunner", () => {
 			);
 			initializeRunner(runner, async () => "Deny");
 			const markExecutionStarted = vi.fn();
+			const markExecutionPending = vi.fn();
 
 			const wrapper = new ExtensionToolWrapper(approvalTool, runner);
 			await expect(
@@ -1833,6 +1836,7 @@ describe("ExtensionRunner", () => {
 					abort: () => {},
 					settings: { get: (key: string) => (key === "tools.approvalMode" ? "always-ask" : {}) } as never,
 					markExecutionStarted,
+					markExecutionPending,
 				}),
 			).rejects.toThrow("Tool call denied by user: dangerous_tool");
 
@@ -1840,6 +1844,7 @@ describe("ExtensionRunner", () => {
 				{ type: "tool_approval_requested", reason: undefined },
 				{ type: "tool_approval_resolved", approved: false, reason: "denied by user" },
 			]);
+			expect(markExecutionPending).toHaveBeenCalledTimes(1);
 			expect(markExecutionStarted).not.toHaveBeenCalled();
 			delete globalState.__deniedApprovalEvents;
 		});

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - Fixed provider usage window stats silently showing no data during SQLite contention by installing a five-second busy timeout on read-only agent database connections ([#7300](https://github.com/can1357/oh-my-pi/issues/7300)).
+- Added tool-call execution duration to `omp stats`: the session parser measures invocation-to-result latency per call, existing databases re-ingest sessions once through `tool_calls_v2`, and the Tools aggregates expose median/p90 latency and observed sample counts alongside token and cost shares.
 
 ## [17.1.2] - 2026-07-24
 

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -31,6 +31,7 @@ import {
 	insertUserMessageStats,
 	markSessionBackfillsComplete,
 	setFileOffset,
+	updateToolInvocations,
 	updateToolResults,
 	updateUserMessageLinks,
 } from "./db";
@@ -77,6 +78,7 @@ function applyParseResult(sessionFile: string, lastModified: number, result: Par
 	if (result.userStats.length > 0) insertUserMessageStats(result.userStats);
 	if (result.userLinks.length > 0) updateUserMessageLinks(result.userLinks);
 	if (result.toolCalls.length > 0) insertToolCalls(result.toolCalls);
+	if (result.toolInvocations.length > 0) updateToolInvocations(result.toolInvocations);
 	if (result.toolResults.length > 0) updateToolResults(result.toolResults);
 	setFileOffset(sessionFile, result.newOffset, lastModified);
 	return result.stats.length + result.userStats.length;

--- a/packages/stats/src/client/routes/ToolsRoute.tsx
+++ b/packages/stats/src/client/routes/ToolsRoute.tsx
@@ -3,7 +3,14 @@ import { Line } from "react-chartjs-2";
 import { getToolDashboardStats } from "../api";
 import { CHART_THEMES, MODEL_COLORS } from "../components/chart-shared";
 import { formatRangeTick, rangeMeta } from "../components/range-meta";
-import { formatCompact, formatCost, formatInteger, formatPercent, formatRelativeTime } from "../data/formatters";
+import {
+	formatCompact,
+	formatCost,
+	formatDurationMs,
+	formatInteger,
+	formatPercent,
+	formatRelativeTime,
+} from "../data/formatters";
 import { useResource } from "../data/useResource";
 import { buildToolRows, type ToolRowView } from "../data/view-models";
 import type { TimeRange, ToolModelStats, ToolTimeSeriesPoint, ToolUsageStats } from "../types";
@@ -297,6 +304,31 @@ function ToolsTable({ byTool }: { byTool: ToolUsageStats[] }) {
 				render: (item: ToolRowView) => <span className="font-mono">{formatCost(item.costShare)}</span>,
 			},
 			{
+				key: "medianMs",
+				header: "Median Time",
+				numeric: true,
+				render: (item: ToolRowView) => (
+					<span
+						className="font-mono"
+						title={`Median execution time over ${formatInteger(item.durationSamples)} timed call(s); p90 ${
+							item.durationSamples > 0 ? formatDurationMs(item.durationMsP90) : "-"
+						}`}
+					>
+						{item.durationSamples > 0 ? formatDurationMs(item.durationMsMedian) : "-"}
+					</span>
+				),
+			},
+			{
+				key: "p90Ms",
+				header: "p90 Time",
+				numeric: true,
+				render: (item: ToolRowView) => (
+					<span className="font-mono" title="90th-percentile execution time">
+						{item.durationSamples > 0 ? formatDurationMs(item.durationMsP90) : "-"}
+					</span>
+				),
+			},
+			{
 				key: "resultChars",
 				header: "Result Text",
 				numeric: true,
@@ -342,6 +374,18 @@ function ToolsTable({ byTool }: { byTool: ToolUsageStats[] }) {
 				<div>
 					<div className="stats-mobile-card-label">Result Text</div>
 					<div className="stats-mobile-card-value font-mono">{formatCompact(item.resultChars)}</div>
+				</div>
+				<div>
+					<div className="stats-mobile-card-label">Median Time</div>
+					<div className="stats-mobile-card-value font-mono">
+						{item.durationSamples > 0 ? formatDurationMs(item.durationMsMedian) : "-"}
+					</div>
+				</div>
+				<div>
+					<div className="stats-mobile-card-label">p90 Time</div>
+					<div className="stats-mobile-card-value font-mono">
+						{item.durationSamples > 0 ? formatDurationMs(item.durationMsP90) : "-"}
+					</div>
 				</div>
 			</div>
 		</div>
@@ -426,6 +470,16 @@ function ToolModelPanel({ byToolModel }: { byToolModel: ToolModelStats[] }) {
 				numeric: true,
 				render: (item: ToolModelStats & { errorRate: number }) => (
 					<span className="font-mono">{formatCost(item.costShare)}</span>
+				),
+			},
+			{
+				key: "medianMs",
+				header: "Median Time",
+				numeric: true,
+				render: (item: ToolModelStats & { errorRate: number }) => (
+					<span className="font-mono" title="Median execution time for this tool under this model">
+						{item.durationSamples > 0 ? formatDurationMs(item.durationMsMedian) : "-"}
+					</span>
 				),
 			},
 		],

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -1649,7 +1649,7 @@ interface ToolAggregateRow {
 
 function durationPercentiles(
 	whereSql: string,
-	params: Array<number | string>,
+	params: Array<number | string | null>,
 	samples: number,
 ): { median: number; p90: number } {
 	if (!db || samples === 0) return { median: 0, p90: 0 };
@@ -1748,9 +1748,11 @@ export function getToolStatsByModel(cutoff?: number): ToolModelStats[] {
 	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as ToolAggregateRow[];
 	const params = hasCutoff ? [cutoff] : [];
 	return rows.map(row => {
+		// `IS` keeps a NULL model/provider group matching its own rows; `=` would
+		// never match and report a zero duration for calls with no recorded model.
 		const duration = durationPercentiles(
-			` AND t.tool_name = ? AND t.model = ? AND t.provider = ?${hasCutoff ? " AND t.timestamp >= ?" : ""}`,
-			[row.tool_name, row.model ?? "", row.provider ?? "", ...params],
+			` AND t.tool_name = ? AND t.model IS ? AND t.provider IS ?${hasCutoff ? " AND t.timestamp >= ?" : ""}`,
+			[row.tool_name, row.model ?? null, row.provider ?? null, ...params],
 			row.duration_samples ?? 0,
 		);
 		return {

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -23,6 +23,7 @@ import type {
 	ProviderTimeSeriesPoint,
 	TimeSeriesPoint,
 	ToolCallStats,
+	ToolInvocationLink,
 	ToolModelStats,
 	ToolResultLink,
 	ToolTimeSeriesPoint,
@@ -162,6 +163,7 @@ export async function initDb(): Promise<Database> {
 			model TEXT NOT NULL,
 			provider TEXT NOT NULL,
 			timestamp INTEGER NOT NULL,
+			started_at INTEGER,
 			agent_type TEXT NOT NULL DEFAULT 'main',
 			calls_in_turn INTEGER NOT NULL DEFAULT 1,
 			args_chars INTEGER NOT NULL DEFAULT 0,
@@ -231,6 +233,9 @@ export async function initDb(): Promise<Database> {
 	const toolCallColumns = db.prepare("PRAGMA table_info(tool_calls)").all() as { name: string }[];
 	if (!toolCallColumns.some(column => column.name === "duration_ms")) {
 		db.run("ALTER TABLE tool_calls ADD COLUMN duration_ms INTEGER");
+	}
+	if (!toolCallColumns.some(column => column.name === "started_at")) {
+		db.run("ALTER TABLE tool_calls ADD COLUMN started_at INTEGER");
 	}
 	const hasStaleColumn =
 		userMessageColumns.length > 0 &&
@@ -1518,9 +1523,9 @@ export function insertToolCalls(calls: ToolCallStats[]): number {
 	const stmt = db.prepare(`
 		INSERT OR IGNORE INTO tool_calls (
 			session_file, entry_id, tool_call_id, folder, tool_name,
-			model, provider, timestamp, agent_type, calls_in_turn, args_chars, duration_ms
+			model, provider, timestamp, agent_type, calls_in_turn, args_chars
 		)
-		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 		WHERE NOT EXISTS (
 			SELECT 1 FROM tool_calls
 			WHERE entry_id = ? AND timestamp = ? AND tool_call_id = ? AND session_file <> ?
@@ -1542,7 +1547,6 @@ export function insertToolCalls(calls: ToolCallStats[]): number {
 				c.agentType,
 				c.callsInTurn,
 				c.argsChars,
-				c.durationMs ?? null,
 				// `WHERE NOT EXISTS` binds: skip when a different session_file
 				// already holds this (entry_id, timestamp, tool_call_id).
 				c.entryId,
@@ -1557,6 +1561,24 @@ export function insertToolCalls(calls: ToolCallStats[]): number {
 	return inserted;
 }
 
+/** Persist the execution-start timestamp for DB-aware incremental result linking. */
+export function updateToolInvocations(links: ToolInvocationLink[]): number {
+	if (!db || links.length === 0) return 0;
+	const stmt = db.prepare(`
+		UPDATE tool_calls
+		SET started_at = ?
+		WHERE session_file = ? AND tool_call_id = ?
+	`);
+	let updated = 0;
+	const apply = db.transaction(() => {
+		for (const link of links) {
+			updated += stmt.run(link.timestamp, link.sessionFile, link.toolCallId).changes;
+		}
+	});
+	apply();
+	return updated;
+}
+
 /**
  * Attach result size / error flag to persisted tool-call rows. Results can
  * land in a later incremental sync pass than the call that produced them, so
@@ -1569,7 +1591,7 @@ export function updateToolResults(links: ToolResultLink[]): number {
 
 	const stmt = db.prepare(`
 		UPDATE tool_calls
-		SET result_chars = ?, duration_ms = COALESCE(?, duration_ms), is_error = ?
+		SET result_chars = ?, duration_ms = MAX(0, ? - COALESCE(started_at, timestamp)), is_error = ?
 		WHERE session_file = ? AND tool_call_id = ? AND result_chars IS NULL
 	`);
 
@@ -1578,7 +1600,7 @@ export function updateToolResults(links: ToolResultLink[]): number {
 		for (const link of links) {
 			const result = stmt.run(
 				link.resultChars,
-				link.durationMs ?? null,
+				link.timestamp,
 				link.isError ? 1 : 0,
 				link.sessionFile,
 				link.toolCallId,
@@ -1625,51 +1647,44 @@ interface ToolAggregateRow {
 	last_used: number;
 }
 
-function countDurationSamples(tableSql: string, params: Array<number | string>): number {
-	if (!db) return 0;
-	const row = db.prepare(`SELECT COUNT(*) AS count FROM (${tableSql})`).get(...params) as { count: number };
-	return row.count;
-}
-
 function durationPercentiles(
 	whereSql: string,
 	params: Array<number | string>,
-): { median: number; p90: number; samples: number } {
-	if (!db) return { median: 0, p90: 0, samples: 0 };
-	const tableSql = `
-		SELECT t.duration_ms
-		FROM tool_calls t
-		WHERE t.duration_ms IS NOT NULL${whereSql}
-	`;
-	const samples = countDurationSamples(tableSql, params);
-	if (samples === 0) return { median: 0, p90: 0, samples: 0 };
-	const fetch = (percentile: number): number => {
-		if (!db) return 0;
-		const row = db
-			.prepare(`
+	samples: number,
+): { median: number; p90: number } {
+	if (!db || samples === 0) return { median: 0, p90: 0 };
+	const medianIndex = (samples - 1) * 0.5;
+	const p90Index = (samples - 1) * 0.9;
+	const ranks = [
+		Math.floor(medianIndex) + 1,
+		Math.ceil(medianIndex) + 1,
+		Math.floor(p90Index) + 1,
+		Math.ceil(p90Index) + 1,
+	];
+	const rows = db
+		.prepare(`
 			WITH ordered AS (
-				SELECT duration_ms,
-					ROW_NUMBER() OVER (ORDER BY duration_ms) AS rank,
-					COUNT(*) OVER () AS count
-				FROM (${tableSql})
+				SELECT t.duration_ms, ROW_NUMBER() OVER (ORDER BY t.duration_ms) AS rank
+				FROM tool_calls t
+				WHERE t.duration_ms IS NOT NULL${whereSql}
 			)
-			SELECT AVG(duration_ms) AS duration_ms
+			SELECT rank, duration_ms
 			FROM ordered
-			WHERE rank IN (
-				1 + CAST((count - 1) * ? AS INTEGER),
-				1 + CAST((count - 1) * ? + 0.999999999 AS INTEGER)
-			)
+			WHERE rank IN (?, ?, ?, ?)
 		`)
-			.get(...params, percentile, percentile) as { duration_ms: number | null } | undefined;
-		return row?.duration_ms ?? 0;
+		.all(...params, ...ranks) as Array<{ rank: number; duration_ms: number }>;
+	const values = new Map(rows.map(row => [row.rank, row.duration_ms]));
+	const interpolate = (index: number): number => {
+		const lowerRank = Math.floor(index) + 1;
+		const upperRank = Math.ceil(index) + 1;
+		const lower = values.get(lowerRank) ?? 0;
+		const upper = values.get(upperRank) ?? lower;
+		return lower + (upper - lower) * (index - Math.floor(index));
 	};
-	return { median: fetch(0.5), p90: fetch(0.9), samples };
+	return { median: interpolate(medianIndex), p90: interpolate(p90Index) };
 }
 
-function rowToToolUsage(
-	row: ToolAggregateRow,
-	duration: { median: number; p90: number; samples: number },
-): ToolUsageStats {
+function rowToToolUsage(row: ToolAggregateRow, duration: { median: number; p90: number }): ToolUsageStats {
 	return {
 		tool: row.tool_name,
 		calls: row.calls,
@@ -1678,7 +1693,7 @@ function rowToToolUsage(
 		resultChars: row.result_chars ?? 0,
 		durationMsMedian: duration.median,
 		durationMsP90: duration.p90,
-		durationSamples: duration.samples,
+		durationSamples: row.duration_samples ?? 0,
 		totalTokensShare: row.total_tokens_share ?? 0,
 		outputTokensShare: row.output_tokens_share ?? 0,
 		costShare: row.cost_share ?? 0,
@@ -1705,10 +1720,11 @@ export function getToolStats(cutoff?: number): ToolUsageStats[] {
 	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as ToolAggregateRow[];
 	const params = hasCutoff ? [cutoff] : [];
 	return rows.map(row => {
-		const duration = durationPercentiles(` AND t.tool_name = ?${hasCutoff ? " AND t.timestamp >= ?" : ""}`, [
-			row.tool_name,
-			...params,
-		]);
+		const duration = durationPercentiles(
+			` AND t.tool_name = ?${hasCutoff ? " AND t.timestamp >= ?" : ""}`,
+			[row.tool_name, ...params],
+			row.duration_samples ?? 0,
+		);
 		return rowToToolUsage(row, duration);
 	});
 }
@@ -1735,6 +1751,7 @@ export function getToolStatsByModel(cutoff?: number): ToolModelStats[] {
 		const duration = durationPercentiles(
 			` AND t.tool_name = ? AND t.model = ? AND t.provider = ?${hasCutoff ? " AND t.timestamp >= ?" : ""}`,
 			[row.tool_name, row.model ?? "", row.provider ?? "", ...params],
+			row.duration_samples ?? 0,
 		);
 		return {
 			...rowToToolUsage(row, duration),

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -177,6 +177,13 @@ export async function initDb(): Promise<Database> {
 		CREATE INDEX IF NOT EXISTS idx_tool_calls_timestamp ON tool_calls(timestamp);
 		CREATE INDEX IF NOT EXISTS idx_tool_calls_tool_timestamp ON tool_calls(tool_name, timestamp);
 
+		CREATE TABLE IF NOT EXISTS pending_tool_invocations (
+			session_file TEXT NOT NULL,
+			tool_call_id TEXT NOT NULL,
+			started_at INTEGER NOT NULL,
+			execution_observed INTEGER NOT NULL,
+			PRIMARY KEY (session_file, tool_call_id)
+		);
 		CREATE TABLE IF NOT EXISTS meta (
 			key TEXT PRIMARY KEY,
 			value TEXT NOT NULL
@@ -1535,6 +1542,21 @@ export function insertToolCalls(calls: ToolCallStats[]): number {
 			WHERE entry_id = ? AND timestamp = ? AND tool_call_id = ? AND session_file <> ?
 		)
 	`);
+	const applyPendingInvocation = db.prepare(`
+		WITH pending AS (
+			SELECT started_at, execution_observed
+			FROM pending_tool_invocations
+			WHERE session_file = ? AND tool_call_id = ?
+		)
+		UPDATE tool_calls
+		SET started_at = (SELECT started_at FROM pending),
+			execution_observed = (SELECT execution_observed FROM pending)
+		WHERE session_file = ? AND tool_call_id = ? AND EXISTS (SELECT 1 FROM pending)
+	`);
+	const deletePendingInvocation = db.prepare(`
+		DELETE FROM pending_tool_invocations
+		WHERE session_file = ? AND tool_call_id = ?
+	`);
 
 	let inserted = 0;
 	const insert = db.transaction(() => {
@@ -1559,6 +1581,8 @@ export function insertToolCalls(calls: ToolCallStats[]): number {
 				c.sessionFile,
 			);
 			if (result.changes > 0) inserted++;
+			applyPendingInvocation.run(c.sessionFile, c.toolCallId, c.sessionFile, c.toolCallId);
+			deletePendingInvocation.run(c.sessionFile, c.toolCallId);
 		}
 	});
 	insert();
@@ -1573,10 +1597,23 @@ export function updateToolInvocations(links: ToolInvocationLink[]): number {
 		SET started_at = ?, execution_observed = ?
 		WHERE session_file = ? AND tool_call_id = ?
 	`);
+	const retain = db.prepare(`
+		INSERT OR REPLACE INTO pending_tool_invocations (
+			session_file, tool_call_id, started_at, execution_observed
+		)
+		VALUES (?, ?, ?, ?)
+	`);
+	const discard = db.prepare(`
+		DELETE FROM pending_tool_invocations
+		WHERE session_file = ? AND tool_call_id = ?
+	`);
 	let updated = 0;
 	const apply = db.transaction(() => {
 		for (const link of links) {
-			updated += stmt.run(link.timestamp, link.executed ? 1 : 0, link.sessionFile, link.toolCallId).changes;
+			retain.run(link.sessionFile, link.toolCallId, link.timestamp, link.executed ? 1 : 0);
+			const changes = stmt.run(link.timestamp, link.executed ? 1 : 0, link.sessionFile, link.toolCallId).changes;
+			updated += changes;
+			if (changes > 0) discard.run(link.sessionFile, link.toolCallId);
 		}
 	});
 	apply();
@@ -1596,8 +1633,10 @@ export function updateToolResults(links: ToolResultLink[]): number {
 	const stmt = db.prepare(`
 		UPDATE tool_calls
 		SET result_chars = ?,
+			execution_observed = COALESCE(?, execution_observed),
 			duration_ms = CASE
-				WHEN execution_observed = 0 THEN NULL
+				WHEN ? = 0 OR execution_observed = 0 THEN NULL
+				WHEN started_at IS NULL AND ? < timestamp THEN NULL
 				ELSE MAX(0, ? - COALESCE(started_at, timestamp))
 			END,
 			is_error = ?
@@ -1609,6 +1648,9 @@ export function updateToolResults(links: ToolResultLink[]): number {
 		for (const link of links) {
 			const result = stmt.run(
 				link.resultChars,
+				link.executed === false ? 0 : null,
+				link.executed === false ? 0 : null,
+				link.timestamp,
 				link.timestamp,
 				link.isError ? 1 : 0,
 				link.sessionFile,

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -62,7 +62,7 @@ const USER_MESSAGE_LINKS_REPAIR_KEY = "user_message_links_v1";
 const PRIORITY_PREMIUM_REQUESTS_BACKFILL_KEY = "premium_requests_priority_v1";
 const AGENT_TYPE_BACKFILL_KEY = "agent_type_v1";
 const FORK_DEDUPE_KEY = "fork_dedupe_v1";
-const TOOL_CALLS_BACKFILL_KEY = "tool_calls_v1";
+const TOOL_CALLS_BACKFILL_KEY = "tool_calls_v2";
 function shouldResetBackfill(value: string | undefined): boolean {
 	return value !== BACKFILL_COMPLETE && value !== BACKFILL_PENDING;
 }
@@ -166,6 +166,7 @@ export async function initDb(): Promise<Database> {
 			calls_in_turn INTEGER NOT NULL DEFAULT 1,
 			args_chars INTEGER NOT NULL DEFAULT 0,
 			result_chars INTEGER,
+			duration_ms INTEGER,
 			is_error INTEGER,
 			UNIQUE(session_file, tool_call_id)
 		);
@@ -227,6 +228,10 @@ export async function initDb(): Promise<Database> {
 	const userMessageColumns = db.prepare("PRAGMA table_info(user_messages)").all() as {
 		name: string;
 	}[];
+	const toolCallColumns = db.prepare("PRAGMA table_info(tool_calls)").all() as { name: string }[];
+	if (!toolCallColumns.some(column => column.name === "duration_ms")) {
+		db.run("ALTER TABLE tool_calls ADD COLUMN duration_ms INTEGER");
+	}
 	const hasStaleColumn =
 		userMessageColumns.length > 0 &&
 		(userMessageColumns.some(column => column.name === "caps_words") ||
@@ -1513,9 +1518,9 @@ export function insertToolCalls(calls: ToolCallStats[]): number {
 	const stmt = db.prepare(`
 		INSERT OR IGNORE INTO tool_calls (
 			session_file, entry_id, tool_call_id, folder, tool_name,
-			model, provider, timestamp, agent_type, calls_in_turn, args_chars
+			model, provider, timestamp, agent_type, calls_in_turn, args_chars, duration_ms
 		)
-		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 		WHERE NOT EXISTS (
 			SELECT 1 FROM tool_calls
 			WHERE entry_id = ? AND timestamp = ? AND tool_call_id = ? AND session_file <> ?
@@ -1537,6 +1542,7 @@ export function insertToolCalls(calls: ToolCallStats[]): number {
 				c.agentType,
 				c.callsInTurn,
 				c.argsChars,
+				c.durationMs ?? null,
 				// `WHERE NOT EXISTS` binds: skip when a different session_file
 				// already holds this (entry_id, timestamp, tool_call_id).
 				c.entryId,
@@ -1563,14 +1569,20 @@ export function updateToolResults(links: ToolResultLink[]): number {
 
 	const stmt = db.prepare(`
 		UPDATE tool_calls
-		SET result_chars = ?, is_error = ?
+		SET result_chars = ?, duration_ms = COALESCE(?, duration_ms), is_error = ?
 		WHERE session_file = ? AND tool_call_id = ? AND result_chars IS NULL
 	`);
 
 	let updated = 0;
 	const apply = db.transaction(() => {
 		for (const link of links) {
-			const result = stmt.run(link.resultChars, link.isError ? 1 : 0, link.sessionFile, link.toolCallId);
+			const result = stmt.run(
+				link.resultChars,
+				link.durationMs ?? null,
+				link.isError ? 1 : 0,
+				link.sessionFile,
+				link.toolCallId,
+			);
 			updated += result.changes;
 		}
 	});
@@ -1588,11 +1600,15 @@ const TOOL_AGGREGATE_COLUMNS = `
 	SUM(CASE WHEN t.is_error = 1 THEN 1 ELSE 0 END) as errors,
 	SUM(t.args_chars) as args_chars,
 	SUM(COALESCE(t.result_chars, 0)) as result_chars,
-	SUM(COALESCE(m.total_tokens, 0) * 1.0 / t.calls_in_turn) as total_tokens_share,
-	SUM(COALESCE(m.output_tokens, 0) * 1.0 / t.calls_in_turn) as output_tokens_share,
-	SUM(COALESCE(m.cost_total, 0) / t.calls_in_turn) as cost_share,
+	COUNT(t.duration_ms) as duration_samples,
 	MAX(t.timestamp) as last_used
 `;
+const TOOL_SHARE_COLUMNS = `
+	SUM(COALESCE(m.total_tokens, 0) * 1.0 / t.calls_in_turn) as total_tokens_share,
+	SUM(COALESCE(m.output_tokens, 0) * 1.0 / t.calls_in_turn) as output_tokens_share,
+	SUM(COALESCE(m.cost_total, 0) / t.calls_in_turn) as cost_share
+`;
+const TOOL_AGGREGATE_SELECT = `${TOOL_AGGREGATE_COLUMNS}, ${TOOL_SHARE_COLUMNS}`;
 
 interface ToolAggregateRow {
 	tool_name: string;
@@ -1602,19 +1618,67 @@ interface ToolAggregateRow {
 	errors: number;
 	args_chars: number | null;
 	result_chars: number | null;
+	duration_samples: number | null;
 	total_tokens_share: number | null;
 	output_tokens_share: number | null;
 	cost_share: number | null;
 	last_used: number;
 }
 
-function rowToToolUsage(row: ToolAggregateRow): ToolUsageStats {
+function countDurationSamples(tableSql: string, params: Array<number | string>): number {
+	if (!db) return 0;
+	const row = db.prepare(`SELECT COUNT(*) AS count FROM (${tableSql})`).get(...params) as { count: number };
+	return row.count;
+}
+
+function durationPercentiles(
+	whereSql: string,
+	params: Array<number | string>,
+): { median: number; p90: number; samples: number } {
+	if (!db) return { median: 0, p90: 0, samples: 0 };
+	const tableSql = `
+		SELECT t.duration_ms
+		FROM tool_calls t
+		WHERE t.duration_ms IS NOT NULL${whereSql}
+	`;
+	const samples = countDurationSamples(tableSql, params);
+	if (samples === 0) return { median: 0, p90: 0, samples: 0 };
+	const fetch = (percentile: number): number => {
+		if (!db) return 0;
+		const row = db
+			.prepare(`
+			WITH ordered AS (
+				SELECT duration_ms,
+					ROW_NUMBER() OVER (ORDER BY duration_ms) AS rank,
+					COUNT(*) OVER () AS count
+				FROM (${tableSql})
+			)
+			SELECT AVG(duration_ms) AS duration_ms
+			FROM ordered
+			WHERE rank IN (
+				1 + CAST((count - 1) * ? AS INTEGER),
+				1 + CAST((count - 1) * ? + 0.999999999 AS INTEGER)
+			)
+		`)
+			.get(...params, percentile, percentile) as { duration_ms: number | null } | undefined;
+		return row?.duration_ms ?? 0;
+	};
+	return { median: fetch(0.5), p90: fetch(0.9), samples };
+}
+
+function rowToToolUsage(
+	row: ToolAggregateRow,
+	duration: { median: number; p90: number; samples: number },
+): ToolUsageStats {
 	return {
 		tool: row.tool_name,
 		calls: row.calls,
 		errors: row.errors,
 		argsChars: row.args_chars ?? 0,
 		resultChars: row.result_chars ?? 0,
+		durationMsMedian: duration.median,
+		durationMsP90: duration.p90,
+		durationSamples: duration.samples,
 		totalTokensShare: row.total_tokens_share ?? 0,
 		outputTokensShare: row.output_tokens_share ?? 0,
 		costShare: row.cost_share ?? 0,
@@ -1630,7 +1694,7 @@ export function getToolStats(cutoff?: number): ToolUsageStats[] {
 
 	const hasCutoff = cutoff !== undefined && cutoff > 0;
 	const stmt = db.prepare(`
-		SELECT t.tool_name, ${TOOL_AGGREGATE_COLUMNS}
+		SELECT t.tool_name, ${TOOL_AGGREGATE_SELECT}
 		FROM tool_calls t
 		LEFT JOIN messages m ON m.session_file = t.session_file AND m.entry_id = t.entry_id
 		${hasCutoff ? "WHERE t.timestamp >= ?" : ""}
@@ -1639,7 +1703,14 @@ export function getToolStats(cutoff?: number): ToolUsageStats[] {
 	`);
 
 	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as ToolAggregateRow[];
-	return rows.map(rowToToolUsage);
+	const params = hasCutoff ? [cutoff] : [];
+	return rows.map(row => {
+		const duration = durationPercentiles(` AND t.tool_name = ?${hasCutoff ? " AND t.timestamp >= ?" : ""}`, [
+			row.tool_name,
+			...params,
+		]);
+		return rowToToolUsage(row, duration);
+	});
 }
 
 /**
@@ -1650,7 +1721,7 @@ export function getToolStatsByModel(cutoff?: number): ToolModelStats[] {
 
 	const hasCutoff = cutoff !== undefined && cutoff > 0;
 	const stmt = db.prepare(`
-		SELECT t.tool_name, t.model, t.provider, ${TOOL_AGGREGATE_COLUMNS}
+		SELECT t.tool_name, t.model, t.provider, ${TOOL_AGGREGATE_SELECT}
 		FROM tool_calls t
 		LEFT JOIN messages m ON m.session_file = t.session_file AND m.entry_id = t.entry_id
 		${hasCutoff ? "WHERE t.timestamp >= ?" : ""}
@@ -1659,11 +1730,18 @@ export function getToolStatsByModel(cutoff?: number): ToolModelStats[] {
 	`);
 
 	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as ToolAggregateRow[];
-	return rows.map(row => ({
-		...rowToToolUsage(row),
-		model: row.model ?? "",
-		provider: row.provider ?? "",
-	}));
+	const params = hasCutoff ? [cutoff] : [];
+	return rows.map(row => {
+		const duration = durationPercentiles(
+			` AND t.tool_name = ? AND t.model = ? AND t.provider = ?${hasCutoff ? " AND t.timestamp >= ?" : ""}`,
+			[row.tool_name, row.model ?? "", row.provider ?? "", ...params],
+		);
+		return {
+			...rowToToolUsage(row, duration),
+			model: row.model ?? "",
+			provider: row.provider ?? "",
+		};
+	});
 }
 
 /**

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -1635,7 +1635,7 @@ export function updateToolResults(links: ToolResultLink[]): number {
 		SET result_chars = ?,
 			execution_observed = COALESCE(?, execution_observed),
 			duration_ms = CASE
-				WHEN ? = 0 OR execution_observed = 0 THEN NULL
+				WHEN ? = 0 OR COALESCE(?, execution_observed) = 0 THEN NULL
 				WHEN started_at IS NULL AND ? < timestamp THEN NULL
 				ELSE MAX(0, ? - COALESCE(started_at, timestamp))
 			END,
@@ -1646,10 +1646,12 @@ export function updateToolResults(links: ToolResultLink[]): number {
 	let updated = 0;
 	const apply = db.transaction(() => {
 		for (const link of links) {
+			const executionObserved = link.executed === false ? 0 : null;
 			const result = stmt.run(
 				link.resultChars,
-				link.executed === false ? 0 : null,
-				link.executed === false ? 0 : null,
+				executionObserved,
+				executionObserved,
+				executionObserved,
 				link.timestamp,
 				link.timestamp,
 				link.isError ? 1 : 0,

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -164,6 +164,7 @@ export async function initDb(): Promise<Database> {
 			provider TEXT NOT NULL,
 			timestamp INTEGER NOT NULL,
 			started_at INTEGER,
+			execution_observed INTEGER,
 			agent_type TEXT NOT NULL DEFAULT 'main',
 			calls_in_turn INTEGER NOT NULL DEFAULT 1,
 			args_chars INTEGER NOT NULL DEFAULT 0,
@@ -236,6 +237,9 @@ export async function initDb(): Promise<Database> {
 	}
 	if (!toolCallColumns.some(column => column.name === "started_at")) {
 		db.run("ALTER TABLE tool_calls ADD COLUMN started_at INTEGER");
+	}
+	if (!toolCallColumns.some(column => column.name === "execution_observed")) {
+		db.run("ALTER TABLE tool_calls ADD COLUMN execution_observed INTEGER");
 	}
 	const hasStaleColumn =
 		userMessageColumns.length > 0 &&
@@ -1561,18 +1565,18 @@ export function insertToolCalls(calls: ToolCallStats[]): number {
 	return inserted;
 }
 
-/** Persist the execution-start timestamp for DB-aware incremental result linking. */
+/** Persist execution-boundary timing and whether the tool implementation ran. */
 export function updateToolInvocations(links: ToolInvocationLink[]): number {
 	if (!db || links.length === 0) return 0;
 	const stmt = db.prepare(`
 		UPDATE tool_calls
-		SET started_at = ?
+		SET started_at = ?, execution_observed = ?
 		WHERE session_file = ? AND tool_call_id = ?
 	`);
 	let updated = 0;
 	const apply = db.transaction(() => {
 		for (const link of links) {
-			updated += stmt.run(link.timestamp, link.sessionFile, link.toolCallId).changes;
+			updated += stmt.run(link.timestamp, link.executed ? 1 : 0, link.sessionFile, link.toolCallId).changes;
 		}
 	});
 	apply();
@@ -1591,7 +1595,12 @@ export function updateToolResults(links: ToolResultLink[]): number {
 
 	const stmt = db.prepare(`
 		UPDATE tool_calls
-		SET result_chars = ?, duration_ms = MAX(0, ? - COALESCE(started_at, timestamp)), is_error = ?
+		SET result_chars = ?,
+			duration_ms = CASE
+				WHEN execution_observed = 0 THEN NULL
+				ELSE MAX(0, ? - COALESCE(started_at, timestamp))
+			END,
+			is_error = ?
 		WHERE session_file = ? AND tool_call_id = ? AND result_chars IS NULL
 	`);
 
@@ -1647,41 +1656,75 @@ interface ToolAggregateRow {
 	last_used: number;
 }
 
-function durationPercentiles(
-	whereSql: string,
-	params: Array<number | string | null>,
-	samples: number,
-): { median: number; p90: number } {
-	if (!db || samples === 0) return { median: 0, p90: 0 };
-	const medianIndex = (samples - 1) * 0.5;
-	const p90Index = (samples - 1) * 0.9;
-	const ranks = [
-		Math.floor(medianIndex) + 1,
-		Math.ceil(medianIndex) + 1,
-		Math.floor(p90Index) + 1,
-		Math.ceil(p90Index) + 1,
-	];
+interface DurationRankRow {
+	tool_name: string;
+	model?: string;
+	provider?: string;
+	duration_ms: number;
+	duration_index: number;
+	duration_samples: number;
+}
+
+interface DurationPercentiles {
+	median: number;
+	p90: number;
+}
+
+const ZERO_DURATION_PERCENTILES: DurationPercentiles = { median: 0, p90: 0 };
+
+function durationGroupKey(row: Pick<DurationRankRow, "tool_name" | "model" | "provider">, byModel: boolean): string {
+	return JSON.stringify(byModel ? [row.tool_name, row.model ?? null, row.provider ?? null] : [row.tool_name]);
+}
+
+function durationPercentilesByGroup(byModel: boolean, cutoff?: number): Map<string, DurationPercentiles> {
+	if (!db) return new Map();
+	const groupColumns = byModel ? "t.tool_name, t.model, t.provider" : "t.tool_name";
+	const selectedGroupColumns = byModel ? "tool_name, model, provider" : "tool_name";
+	const hasCutoff = cutoff !== undefined && cutoff > 0;
 	const rows = db
 		.prepare(`
 			WITH ordered AS (
-				SELECT t.duration_ms, ROW_NUMBER() OVER (ORDER BY t.duration_ms) AS rank
+				SELECT ${groupColumns}, t.duration_ms,
+					ROW_NUMBER() OVER (PARTITION BY ${groupColumns} ORDER BY t.duration_ms) - 1 AS duration_index,
+					COUNT(*) OVER (PARTITION BY ${groupColumns}) AS duration_samples
 				FROM tool_calls t
-				WHERE t.duration_ms IS NOT NULL${whereSql}
+				WHERE t.duration_ms IS NOT NULL${hasCutoff ? " AND t.timestamp >= ?" : ""}
+			),
+			bounds AS (
+				SELECT *,
+					(duration_samples - 1) * 0.5 AS median_index,
+					(duration_samples - 1) * 0.9 AS p90_index
+				FROM ordered
 			)
-			SELECT rank, duration_ms
-			FROM ordered
-			WHERE rank IN (?, ?, ?, ?)
+			SELECT ${selectedGroupColumns}, duration_ms, duration_index, duration_samples
+			FROM bounds
+			WHERE duration_index IN (
+				CAST(median_index AS INTEGER),
+				CAST(median_index AS INTEGER) + (median_index > CAST(median_index AS INTEGER)),
+				CAST(p90_index AS INTEGER),
+				CAST(p90_index AS INTEGER) + (p90_index > CAST(p90_index AS INTEGER))
+			)
+			ORDER BY ${selectedGroupColumns}, duration_index
 		`)
-		.all(...params, ...ranks) as Array<{ rank: number; duration_ms: number }>;
-	const values = new Map(rows.map(row => [row.rank, row.duration_ms]));
-	const interpolate = (index: number): number => {
-		const lowerRank = Math.floor(index) + 1;
-		const upperRank = Math.ceil(index) + 1;
-		const lower = values.get(lowerRank) ?? 0;
-		const upper = values.get(upperRank) ?? lower;
-		return lower + (upper - lower) * (index - Math.floor(index));
-	};
-	return { median: interpolate(medianIndex), p90: interpolate(p90Index) };
+		.all(...(hasCutoff ? [cutoff] : [])) as DurationRankRow[];
+	const grouped = new Map<string, { samples: number; values: Map<number, number> }>();
+	for (const row of rows) {
+		const key = durationGroupKey(row, byModel);
+		const group = grouped.get(key) ?? { samples: row.duration_samples, values: new Map<number, number>() };
+		group.values.set(row.duration_index, row.duration_ms);
+		grouped.set(key, group);
+	}
+	const result = new Map<string, DurationPercentiles>();
+	for (const [key, group] of grouped) {
+		const interpolate = (percentile: number): number => {
+			const index = (group.samples - 1) * percentile;
+			const lower = group.values.get(Math.floor(index)) ?? 0;
+			const upper = group.values.get(Math.ceil(index)) ?? lower;
+			return lower + (upper - lower) * (index - Math.floor(index));
+		};
+		result.set(key, { median: interpolate(0.5), p90: interpolate(0.9) });
+	}
+	return result;
 }
 
 function rowToToolUsage(row: ToolAggregateRow, duration: { median: number; p90: number }): ToolUsageStats {
@@ -1718,15 +1761,10 @@ export function getToolStats(cutoff?: number): ToolUsageStats[] {
 	`);
 
 	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as ToolAggregateRow[];
-	const params = hasCutoff ? [cutoff] : [];
-	return rows.map(row => {
-		const duration = durationPercentiles(
-			` AND t.tool_name = ?${hasCutoff ? " AND t.timestamp >= ?" : ""}`,
-			[row.tool_name, ...params],
-			row.duration_samples ?? 0,
-		);
-		return rowToToolUsage(row, duration);
-	});
+	const durationByGroup = durationPercentilesByGroup(false, cutoff);
+	return rows.map(row =>
+		rowToToolUsage(row, durationByGroup.get(durationGroupKey(row, false)) ?? ZERO_DURATION_PERCENTILES),
+	);
 }
 
 /**
@@ -1746,21 +1784,12 @@ export function getToolStatsByModel(cutoff?: number): ToolModelStats[] {
 	`);
 
 	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as ToolAggregateRow[];
-	const params = hasCutoff ? [cutoff] : [];
-	return rows.map(row => {
-		// `IS` keeps a NULL model/provider group matching its own rows; `=` would
-		// never match and report a zero duration for calls with no recorded model.
-		const duration = durationPercentiles(
-			` AND t.tool_name = ? AND t.model IS ? AND t.provider IS ?${hasCutoff ? " AND t.timestamp >= ?" : ""}`,
-			[row.tool_name, row.model ?? null, row.provider ?? null, ...params],
-			row.duration_samples ?? 0,
-		);
-		return {
-			...rowToToolUsage(row, duration),
-			model: row.model ?? "",
-			provider: row.provider ?? "",
-		};
-	});
+	const durationByGroup = durationPercentilesByGroup(true, cutoff);
+	return rows.map(row => ({
+		...rowToToolUsage(row, durationByGroup.get(durationGroupKey(row, true)) ?? ZERO_DURATION_PERCENTILES),
+		model: row.model ?? "",
+		provider: row.provider ?? "",
+	}));
 }
 
 /**

--- a/packages/stats/src/parser.ts
+++ b/packages/stats/src/parser.ts
@@ -248,6 +248,7 @@ function extractToolCalls(
 	);
 	if (blocks.length === 0) return [];
 
+	const entryTimestamp = coerceEntryTimestamp(msg.timestamp, entry);
 	return blocks.map(block => {
 		let argsChars = 0;
 		try {
@@ -263,7 +264,7 @@ function extractToolCalls(
 			toolName: block.name,
 			model: msg.model,
 			provider: msg.provider,
-			timestamp: coerceEntryTimestamp(msg.timestamp, entry),
+			timestamp: entryTimestamp,
 			agentType,
 			callsInTurn: blocks.length,
 			argsChars,
@@ -275,7 +276,11 @@ function extractToolCalls(
  * Build the result linkage for a `toolResult` entry: text characters fed back
  * into context plus the error flag, keyed to the originating call.
  */
-function extractToolResultLink(sessionFile: string, entry: SessionMessageEntry): ToolResultLink | null {
+function extractToolResultLink(
+	sessionFile: string,
+	entry: SessionMessageEntry,
+	invocationTimestamps: Map<string, number>,
+): ToolResultLink | null {
 	const msg = entry.message as ToolResultMessage;
 	if (msg.role !== "toolResult" || typeof msg.toolCallId !== "string" || msg.toolCallId.length === 0) return null;
 	let resultChars = 0;
@@ -286,10 +291,15 @@ function extractToolResultLink(sessionFile: string, entry: SessionMessageEntry):
 			}
 		}
 	}
+	const resultTimestamp = coerceEntryTimestamp(msg.timestamp, entry);
+	const invocationTimestamp = invocationTimestamps.get(msg.toolCallId);
+	const durationMs =
+		invocationTimestamp === undefined ? undefined : Math.max(0, resultTimestamp - invocationTimestamp);
 	return {
 		sessionFile,
 		toolCallId: msg.toolCallId,
 		resultChars,
+		durationMs,
 		isError: msg.isError === true,
 	};
 }
@@ -344,6 +354,17 @@ function scanLastServiceTier(bytes: Uint8Array): ServiceTierByFamily | undefined
 	});
 	return currentServiceTier;
 }
+
+/** Recover tool invocation timestamps from transcript bytes preceding an incremental offset. */
+function scanToolInvocationTimestamps(bytes: Uint8Array): Map<string, number> {
+	const timestamps = new Map<string, number>();
+	visitSessionEntriesLenient(bytes, entry => {
+		if (!isAssistantMessage(entry)) return;
+		const calls = extractToolCalls("", "", entry, "main");
+		for (const call of calls) timestamps.set(call.toolCallId, call.timestamp);
+	});
+	return timestamps;
+}
 /**
  * Parse a session file and extract all assistant message stats.
  * Uses incremental reading with offset tracking.
@@ -387,6 +408,8 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 	const toolResults: ToolResultLink[] = [];
 	const userByEntryId = new Map<string, UserMessageStats>();
 	const start = Math.max(0, Math.min(fromOffset, bytes.length));
+	const invocationTimestamps =
+		start > 0 ? scanToolInvocationTimestamps(bytes.subarray(0, start)) : new Map<string, number>();
 	const unprocessed = bytes.subarray(start);
 	const { entries, read } = parseSessionEntriesLenient(unprocessed);
 	let currentServiceTier: ServiceTierByFamily | undefined;
@@ -407,14 +430,16 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 			continue;
 		}
 		if (isToolResultMessage(entry)) {
-			const link = extractToolResultLink(sessionPath, entry);
+			const link = extractToolResultLink(sessionPath, entry, invocationTimestamps);
 			if (link) toolResults.push(link);
 			continue;
 		}
 		if (isAssistantMessage(entry)) {
 			const msgStats = extractStats(sessionPath, folder, entry, currentServiceTier, agentType);
 			if (msgStats) stats.push(msgStats);
-			toolCalls.push(...extractToolCalls(sessionPath, folder, entry, agentType));
+			const calls = extractToolCalls(sessionPath, folder, entry, agentType);
+			toolCalls.push(...calls);
+			for (const call of calls) invocationTimestamps.set(call.toolCallId, call.timestamp);
 			// Link assistant's responding model back to the user message it answered.
 			const parentId = (entry as SessionMessageEntry).parentId;
 			if (parentId) {

--- a/packages/stats/src/parser.ts
+++ b/packages/stats/src/parser.ts
@@ -106,7 +106,12 @@ function extractToolInvocationLink(sessionFile: string, entry: SessionEntry): To
 	if (marker.customType !== "tool_execution_start" || typeof marker.data?.toolCallId !== "string") return null;
 	const timestamp = Date.parse(typeof marker.data.startedAt === "string" ? marker.data.startedAt : marker.timestamp);
 	if (!Number.isFinite(timestamp)) return null;
-	return { sessionFile, toolCallId: marker.data.toolCallId, timestamp };
+	return {
+		sessionFile,
+		toolCallId: marker.data.toolCallId,
+		executed: marker.data.executed !== false,
+		timestamp,
+	};
 }
 
 /**

--- a/packages/stats/src/parser.ts
+++ b/packages/stats/src/parser.ts
@@ -303,12 +303,15 @@ function extractToolResultLink(sessionFile: string, entry: SessionMessageEntry):
 			}
 		}
 	}
+	const details = msg.details as { __synthetic?: unknown; executed?: unknown } | undefined;
+	const executed = details?.__synthetic === true && details.executed === false ? false : undefined;
 	return {
 		sessionFile,
 		toolCallId: msg.toolCallId,
 		resultChars,
 		timestamp: coerceEntryTimestamp(msg.timestamp, entry),
 		isError: msg.isError === true,
+		...(executed === false ? { executed } : {}),
 	};
 }
 

--- a/packages/stats/src/parser.ts
+++ b/packages/stats/src/parser.ts
@@ -17,7 +17,9 @@ import type {
 	SessionEntry,
 	SessionMessageEntry,
 	SessionServiceTierChangeEntry,
+	SessionToolExecutionStartEntry,
 	ToolCallStats,
+	ToolInvocationLink,
 	ToolResultLink,
 	UserMessageLink,
 	UserMessageStats,
@@ -96,6 +98,15 @@ function isServiceTierChange(entry: SessionEntry): entry is SessionServiceTierCh
 function isToolResultMessage(entry: SessionEntry): entry is SessionMessageEntry {
 	if (entry.type !== "message") return false;
 	return (entry as SessionMessageEntry).message?.role === "toolResult";
+}
+
+function extractToolInvocationLink(sessionFile: string, entry: SessionEntry): ToolInvocationLink | null {
+	if (entry.type !== "custom") return null;
+	const marker = entry as SessionToolExecutionStartEntry;
+	if (marker.customType !== "tool_execution_start" || typeof marker.data?.toolCallId !== "string") return null;
+	const timestamp = Date.parse(typeof marker.data.startedAt === "string" ? marker.data.startedAt : marker.timestamp);
+	if (!Number.isFinite(timestamp)) return null;
+	return { sessionFile, toolCallId: marker.data.toolCallId, timestamp };
 }
 
 /**
@@ -248,7 +259,7 @@ function extractToolCalls(
 	);
 	if (blocks.length === 0) return [];
 
-	const entryTimestamp = coerceEntryTimestamp(msg.timestamp, entry);
+	const invocationTimestamp = coerceEntryTimestamp(undefined, entry);
 	return blocks.map(block => {
 		let argsChars = 0;
 		try {
@@ -264,7 +275,7 @@ function extractToolCalls(
 			toolName: block.name,
 			model: msg.model,
 			provider: msg.provider,
-			timestamp: entryTimestamp,
+			timestamp: invocationTimestamp,
 			agentType,
 			callsInTurn: blocks.length,
 			argsChars,
@@ -276,11 +287,7 @@ function extractToolCalls(
  * Build the result linkage for a `toolResult` entry: text characters fed back
  * into context plus the error flag, keyed to the originating call.
  */
-function extractToolResultLink(
-	sessionFile: string,
-	entry: SessionMessageEntry,
-	invocationTimestamps: Map<string, number>,
-): ToolResultLink | null {
+function extractToolResultLink(sessionFile: string, entry: SessionMessageEntry): ToolResultLink | null {
 	const msg = entry.message as ToolResultMessage;
 	if (msg.role !== "toolResult" || typeof msg.toolCallId !== "string" || msg.toolCallId.length === 0) return null;
 	let resultChars = 0;
@@ -291,15 +298,11 @@ function extractToolResultLink(
 			}
 		}
 	}
-	const resultTimestamp = coerceEntryTimestamp(msg.timestamp, entry);
-	const invocationTimestamp = invocationTimestamps.get(msg.toolCallId);
-	const durationMs =
-		invocationTimestamp === undefined ? undefined : Math.max(0, resultTimestamp - invocationTimestamp);
 	return {
 		sessionFile,
 		toolCallId: msg.toolCallId,
 		resultChars,
-		durationMs,
+		timestamp: coerceEntryTimestamp(msg.timestamp, entry),
 		isError: msg.isError === true,
 	};
 }
@@ -355,16 +358,6 @@ function scanLastServiceTier(bytes: Uint8Array): ServiceTierByFamily | undefined
 	return currentServiceTier;
 }
 
-/** Recover tool invocation timestamps from transcript bytes preceding an incremental offset. */
-function scanToolInvocationTimestamps(bytes: Uint8Array): Map<string, number> {
-	const timestamps = new Map<string, number>();
-	visitSessionEntriesLenient(bytes, entry => {
-		if (!isAssistantMessage(entry)) return;
-		const calls = extractToolCalls("", "", entry, "main");
-		for (const call of calls) timestamps.set(call.toolCallId, call.timestamp);
-	});
-	return timestamps;
-}
 /**
  * Parse a session file and extract all assistant message stats.
  * Uses incremental reading with offset tracking.
@@ -386,6 +379,7 @@ export interface ParseSessionResult {
 	userStats: UserMessageStats[];
 	userLinks: UserMessageLink[];
 	toolCalls: ToolCallStats[];
+	toolInvocations: ToolInvocationLink[];
 	toolResults: ToolResultLink[];
 	newOffset: number;
 }
@@ -395,7 +389,15 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 		bytes = await Bun.file(sessionPath).bytes();
 	} catch (err) {
 		if (isEnoent(err))
-			return { stats: [], userStats: [], userLinks: [], toolCalls: [], toolResults: [], newOffset: fromOffset };
+			return {
+				stats: [],
+				userStats: [],
+				userLinks: [],
+				toolCalls: [],
+				toolInvocations: [],
+				toolResults: [],
+				newOffset: fromOffset,
+			};
 		throw err;
 	}
 
@@ -406,10 +408,9 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 	const userLinks: UserMessageLink[] = [];
 	const toolCalls: ToolCallStats[] = [];
 	const toolResults: ToolResultLink[] = [];
+	const toolInvocations: ToolInvocationLink[] = [];
 	const userByEntryId = new Map<string, UserMessageStats>();
 	const start = Math.max(0, Math.min(fromOffset, bytes.length));
-	const invocationTimestamps =
-		start > 0 ? scanToolInvocationTimestamps(bytes.subarray(0, start)) : new Map<string, number>();
 	const unprocessed = bytes.subarray(start);
 	const { entries, read } = parseSessionEntriesLenient(unprocessed);
 	let currentServiceTier: ServiceTierByFamily | undefined;
@@ -429,8 +430,13 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 			}
 			continue;
 		}
+		const invocation = extractToolInvocationLink(sessionPath, entry);
+		if (invocation) {
+			toolInvocations.push(invocation);
+			continue;
+		}
 		if (isToolResultMessage(entry)) {
-			const link = extractToolResultLink(sessionPath, entry, invocationTimestamps);
+			const link = extractToolResultLink(sessionPath, entry);
 			if (link) toolResults.push(link);
 			continue;
 		}
@@ -439,7 +445,6 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 			if (msgStats) stats.push(msgStats);
 			const calls = extractToolCalls(sessionPath, folder, entry, agentType);
 			toolCalls.push(...calls);
-			for (const call of calls) invocationTimestamps.set(call.toolCallId, call.timestamp);
 			// Link assistant's responding model back to the user message it answered.
 			const parentId = (entry as SessionMessageEntry).parentId;
 			if (parentId) {
@@ -462,7 +467,7 @@ export async function parseSessionFile(sessionPath: string, fromOffset = 0): Pro
 		}
 	}
 
-	return { stats, userStats, userLinks, toolCalls, toolResults, newOffset: start + read };
+	return { stats, userStats, userLinks, toolCalls, toolInvocations, toolResults, newOffset: start + read };
 }
 
 /**

--- a/packages/stats/src/parser.ts
+++ b/packages/stats/src/parser.ts
@@ -303,8 +303,8 @@ function extractToolResultLink(sessionFile: string, entry: SessionMessageEntry):
 			}
 		}
 	}
-	const details = msg.details as { __synthetic?: unknown; executed?: unknown } | undefined;
-	const executed = details?.__synthetic === true && details.executed === false ? false : undefined;
+	const details = msg.details as { executed?: unknown } | undefined;
+	const executed = details?.executed === false ? false : undefined;
 	return {
 		sessionFile,
 		toolCallId: msg.toolCallId,

--- a/packages/stats/src/shared-types.ts
+++ b/packages/stats/src/shared-types.ts
@@ -291,6 +291,12 @@ export interface ToolUsageStats {
 	argsChars: number;
 	/** Text characters of tool results fed back into context. */
 	resultChars: number;
+	/** Median milliseconds from the invoking assistant turn to the tool result. */
+	durationMsMedian: number;
+	/** 90th-percentile milliseconds from the invoking assistant turn to the tool result. */
+	durationMsP90: number;
+	/** Calls with an observed invocation-to-result duration. */
+	durationSamples: number;
 	/** Total provider tokens of invoking turns, attributed per call share. */
 	totalTokensShare: number;
 	/** Output tokens of invoking turns, attributed per call share. */

--- a/packages/stats/src/shared-types.ts
+++ b/packages/stats/src/shared-types.ts
@@ -291,11 +291,15 @@ export interface ToolUsageStats {
 	argsChars: number;
 	/** Text characters of tool results fed back into context. */
 	resultChars: number;
-	/** Median milliseconds from the invoking assistant turn to the tool result. */
+	/**
+	 * Median milliseconds from the persisted `tool_execution_start` marker to the
+	 * tool result, so model generation latency is excluded. Sessions recorded
+	 * before the marker existed fall back to the invoking turn's timestamp.
+	 */
 	durationMsMedian: number;
-	/** 90th-percentile milliseconds from the invoking assistant turn to the tool result. */
+	/** 90th-percentile milliseconds over the same execution window. */
 	durationMsP90: number;
-	/** Calls with an observed invocation-to-result duration. */
+	/** Calls with an observed execution duration. */
 	durationSamples: number;
 	/** Total provider tokens of invoking turns, attributed per call share. */
 	totalTokensShare: number;

--- a/packages/stats/src/types.ts
+++ b/packages/stats/src/types.ts
@@ -83,6 +83,7 @@ export interface SessionToolExecutionStartEntry {
 	customType: "tool_execution_start";
 	data?: {
 		toolCallId?: unknown;
+		executed?: unknown;
 		startedAt?: unknown;
 	};
 }
@@ -174,10 +175,11 @@ export interface ToolCallStats {
 	argsChars: number;
 }
 
-/** Actual invocation timestamp emitted by a persisted tool-execution marker. */
+/** Execution-boundary marker linked to its persisted tool-call row. */
 export interface ToolInvocationLink {
 	sessionFile: string;
 	toolCallId: string;
+	executed: boolean;
 	timestamp: number;
 }
 

--- a/packages/stats/src/types.ts
+++ b/packages/stats/src/types.ts
@@ -75,7 +75,24 @@ export interface SessionServiceTierChangeEntry {
 	serviceTier: ServiceTierByFamily | ServiceTier | null;
 }
 
-export type SessionEntry = SessionHeader | SessionMessageEntry | SessionServiceTierChangeEntry | { type: string };
+export interface SessionToolExecutionStartEntry {
+	type: "custom";
+	id: string;
+	parentId: string | null;
+	timestamp: string;
+	customType: "tool_execution_start";
+	data?: {
+		toolCallId?: unknown;
+		startedAt?: unknown;
+	};
+}
+
+export type SessionEntry =
+	| SessionHeader
+	| SessionMessageEntry
+	| SessionServiceTierChangeEntry
+	| SessionToolExecutionStartEntry
+	| { type: string };
 
 /**
  * Behavioral stats extracted from a single user message.
@@ -147,7 +164,7 @@ export interface ToolCallStats {
 	model: string;
 	/** Provider name */
 	provider: string;
-	/** Assistant-message timestamp (Unix ms) */
+	/** Fallback invocation boundary from the persisted assistant entry (Unix ms) */
 	timestamp: number;
 	/** Which agent produced the call */
 	agentType: AgentType;
@@ -155,8 +172,13 @@ export interface ToolCallStats {
 	callsInTurn: number;
 	/** Serialized argument characters */
 	argsChars: number;
-	/** Milliseconds from the invoking assistant turn to this result, when known */
-	durationMs?: number;
+}
+
+/** Actual invocation timestamp emitted by a persisted tool-execution marker. */
+export interface ToolInvocationLink {
+	sessionFile: string;
+	toolCallId: string;
+	timestamp: number;
 }
 
 /**
@@ -169,7 +191,7 @@ export interface ToolResultLink {
 	toolCallId: string;
 	/** Text characters fed back into context */
 	resultChars: number;
-	/** Milliseconds from the invoking assistant turn to this result, when known */
-	durationMs?: number;
+	/** Tool-result completion timestamp (Unix ms) */
+	timestamp: number;
 	isError: boolean;
 }

--- a/packages/stats/src/types.ts
+++ b/packages/stats/src/types.ts
@@ -195,7 +195,7 @@ export interface ToolResultLink {
 	resultChars: number;
 	/** Tool-result completion timestamp (Unix ms) */
 	timestamp: number;
-	/** False when a current synthetic result proves no implementation ran. */
+	/** False when result metadata proves no implementation ran. */
 	executed?: boolean;
 	isError: boolean;
 }

--- a/packages/stats/src/types.ts
+++ b/packages/stats/src/types.ts
@@ -195,5 +195,7 @@ export interface ToolResultLink {
 	resultChars: number;
 	/** Tool-result completion timestamp (Unix ms) */
 	timestamp: number;
+	/** False when a current synthetic result proves no implementation ran. */
+	executed?: boolean;
 	isError: boolean;
 }

--- a/packages/stats/src/types.ts
+++ b/packages/stats/src/types.ts
@@ -155,6 +155,8 @@ export interface ToolCallStats {
 	callsInTurn: number;
 	/** Serialized argument characters */
 	argsChars: number;
+	/** Milliseconds from the invoking assistant turn to this result, when known */
+	durationMs?: number;
 }
 
 /**
@@ -167,5 +169,7 @@ export interface ToolResultLink {
 	toolCallId: string;
 	/** Text characters fed back into context */
 	resultChars: number;
+	/** Milliseconds from the invoking assistant turn to this result, when known */
+	durationMs?: number;
 	isError: boolean;
 }

--- a/packages/stats/test/behavior-backfill.test.ts
+++ b/packages/stats/test/behavior-backfill.test.ts
@@ -104,14 +104,14 @@ describe("behavior backfill", () => {
 		const database = new Database(getStatsDbPath(), { readonly: true });
 		const rows = database
 			.query(
-				"SELECT key, value FROM meta WHERE key IN ('user_messages_v8', 'tool_calls_v1', 'user_message_links_v1', 'premium_requests_priority_v1') ORDER BY key",
+				"SELECT key, value FROM meta WHERE key IN ('user_messages_v8', 'tool_calls_v2', 'user_message_links_v1', 'premium_requests_priority_v1') ORDER BY key",
 			)
 			.all() as { key: string; value: string }[];
 		database.close();
 
 		expect(rows).toEqual([
 			{ key: "premium_requests_priority_v1", value: "complete" },
-			{ key: "tool_calls_v1", value: "complete" },
+			{ key: "tool_calls_v2", value: "complete" },
 			{ key: "user_message_links_v1", value: "complete" },
 			{ key: "user_messages_v8", value: "complete" },
 		]);

--- a/packages/stats/test/tool-stats.test.ts
+++ b/packages/stats/test/tool-stats.test.ts
@@ -121,6 +121,7 @@ interface ToolResultOptions {
 	toolName: string;
 	text: string;
 	isError?: boolean;
+	details?: unknown;
 }
 
 function buildToolResultEntry(opts: ToolResultOptions) {
@@ -135,6 +136,7 @@ function buildToolResultEntry(opts: ToolResultOptions) {
 			toolName: opts.toolName,
 			content: [{ type: "text", text: opts.text }],
 			isError: opts.isError ?? false,
+			...(opts.details === undefined ? {} : { details: opts.details }),
 			timestamp: Date.parse(opts.timestamp),
 		},
 	};
@@ -323,6 +325,126 @@ describe("tool usage stats pipeline", () => {
 		expect(read.durationMsP90).toBe(0);
 	});
 
+	it("excludes markerless current synthetic results from duration samples", async () => {
+		await writeSessionFile("session.jsonl", { id: "markerless-synthetic" }, [
+			buildAssistantEntry({
+				entryId: "asst-1",
+				timestamp: TS1,
+				toolCalls: [{ id: "call-1", name: "read", arguments: READ_ARGS }],
+				totalTokens: TURN2_TOTAL_TOKENS,
+				outputTokens: TURN2_OUTPUT_TOKENS,
+				costTotal: TURN2_COST,
+			}),
+			buildToolResultEntry({
+				entryId: "tr-1",
+				parentId: "asst-1",
+				timestamp: TS1_READ_RESULT,
+				toolCallId: "call-1",
+				toolName: "read",
+				text: "Tool not available",
+				isError: true,
+				details: { __synthetic: true, source: "cursor_bridge_rejected", executed: false },
+			}),
+		]);
+		await syncAllSessions({ workers: 1 });
+
+		const [read] = getToolStats();
+		expect(read.calls).toBe(1);
+		expect(read.errors).toBe(1);
+		expect(read.durationSamples).toBe(0);
+	});
+
+	it("excludes markerless current successful Cursor results from duration samples", async () => {
+		await writeSessionFile("session.jsonl", { id: "markerless-current-success" }, [
+			buildAssistantEntry({
+				entryId: "asst-1",
+				timestamp: TS1,
+				toolCalls: [
+					{ id: "call-read", name: "read", arguments: READ_ARGS },
+					{ id: "call-todo", name: "todo", arguments: {} },
+				],
+				totalTokens: TURN2_TOTAL_TOKENS,
+				outputTokens: TURN2_OUTPUT_TOKENS,
+				costTotal: TURN2_COST,
+			}),
+			buildToolResultEntry({
+				entryId: "tr-todo",
+				parentId: "asst-1",
+				timestamp: TS1_GREP_RESULT,
+				toolCallId: "call-todo",
+				toolName: "todo",
+				text: "No todos",
+				details: { __synthetic: true, source: "cursor_server_resolved", executed: false },
+			}),
+			buildToolResultEntry({
+				entryId: "tr-read",
+				parentId: "asst-1",
+				timestamp: TS1_READ_RESULT,
+				toolCallId: "call-read",
+				toolName: "read",
+				text: "",
+				details: { __synthetic: true, source: "cursor_zero_length_read", executed: false },
+			}),
+		]);
+		await syncAllSessions({ workers: 1 });
+
+		const stats = getToolStats();
+		expect(toolRow(stats, "read").durationSamples).toBe(0);
+		expect(toolRow(stats, "todo").durationSamples).toBe(0);
+	});
+
+	it("excludes markerless results completed before their assistant entry was persisted", async () => {
+		const resultTimestamp = new Date(Date.parse(TS1) - 120_000).toISOString();
+		await writeSessionFile("session.jsonl", { id: "markerless-inverted" }, [
+			buildToolResultEntry({
+				entryId: "tr-1",
+				parentId: "asst-1",
+				timestamp: resultTimestamp,
+				toolCallId: "call-1",
+				toolName: "read",
+				text: "",
+			}),
+			buildAssistantEntry({
+				entryId: "asst-1",
+				timestamp: TS1,
+				toolCalls: [{ id: "call-1", name: "read", arguments: READ_ARGS }],
+				totalTokens: TURN2_TOTAL_TOKENS,
+				outputTokens: TURN2_OUTPUT_TOKENS,
+				costTotal: TURN2_COST,
+			}),
+		]);
+		await syncAllSessions({ workers: 1 });
+
+		const [read] = getToolStats();
+		expect(read.durationSamples).toBe(0);
+	});
+
+	it("keeps timing markerless legacy results", async () => {
+		await writeSessionFile("session.jsonl", { id: "markerless-legacy" }, [
+			buildAssistantEntry({
+				entryId: "asst-1",
+				timestamp: TS1,
+				toolCalls: [{ id: "call-1", name: "grep", arguments: GREP_ARGS_1 }],
+				totalTokens: TURN2_TOTAL_TOKENS,
+				outputTokens: TURN2_OUTPUT_TOKENS,
+				costTotal: TURN2_COST,
+			}),
+			buildToolResultEntry({
+				entryId: "tr-1",
+				parentId: "asst-1",
+				timestamp: TS1_GREP_RESULT,
+				toolCallId: "call-1",
+				toolName: "grep",
+				text: GREP_RESULT_1,
+			}),
+		]);
+		await syncAllSessions({ workers: 1 });
+
+		const [grep] = getToolStats();
+		expect(grep.durationSamples).toBe(1);
+		expect(grep.durationMsMedian).toBe(62_000);
+	});
+
 	it("keeps timing legacy execution markers that predate the executed flag", async () => {
 		await writeSessionFile("session.jsonl", { id: "legacy-marker" }, [
 			buildAssistantEntry({
@@ -402,6 +524,41 @@ describe("tool usage stats pipeline", () => {
 		expect(modelA?.durationMsMedian).toBe(2_000);
 		expect(modelB?.durationSamples).toBe(1);
 		expect(modelB?.durationMsMedian).toBe(8_000);
+	});
+
+	it("retains a start marker until its tool call arrives in a later sync pass", async () => {
+		const sessionFile = await writeSessionFile("session.jsonl", { id: "live-turn" }, [
+			buildToolStartEntry("call-1", "grep", TS1),
+		]);
+		await syncAllSessions({ workers: 1 });
+
+		expect(getToolStats()).toEqual([]);
+
+		const assistant = buildAssistantEntry({
+			entryId: "asst-1",
+			timestamp: TS1,
+			toolCalls: [{ id: "call-1", name: "grep", arguments: GREP_ARGS_1 }],
+			totalTokens: TURN2_TOTAL_TOKENS,
+			outputTokens: TURN2_OUTPUT_TOKENS,
+			costTotal: TURN2_COST,
+		});
+		const result = buildToolResultEntry({
+			entryId: "tr-1",
+			parentId: "asst-1",
+			timestamp: TS1_READ_RESULT,
+			toolCallId: "call-1",
+			toolName: "grep",
+			text: GREP_RESULT_1,
+		});
+		await fs.appendFile(sessionFile, `${JSON.stringify(assistant)}\n${JSON.stringify(result)}\n`);
+		const bumped = new Date(Date.now() + 1_000);
+		await fs.utimes(sessionFile, bumped, bumped);
+
+		await syncAllSessions({ workers: 1 });
+
+		const [grep] = getToolStats();
+		expect(grep.durationSamples).toBe(1);
+		expect(grep.durationMsMedian).toBe(4_000);
 	});
 
 	it("links a result that lands in a later sync pass without duplicating the call", async () => {

--- a/packages/stats/test/tool-stats.test.ts
+++ b/packages/stats/test/tool-stats.test.ts
@@ -46,6 +46,8 @@ interface AssistantTurnOptions {
 	entryId: string;
 	parentId?: string | null;
 	timestamp: string;
+	model?: string;
+	provider?: string;
 	toolCalls: ToolCallBlock[];
 	totalTokens: number;
 	outputTokens: number;
@@ -72,8 +74,8 @@ function buildAssistantEntry(opts: AssistantTurnOptions) {
 				})),
 			],
 			api: "openai-responses",
-			provider: PROVIDER,
-			model: MODEL,
+			provider: opts.provider ?? PROVIDER,
+			model: opts.model ?? MODEL,
 			usage: {
 				input: 10,
 				output: opts.outputTokens,
@@ -90,14 +92,24 @@ function buildAssistantEntry(opts: AssistantTurnOptions) {
 	};
 }
 
-function buildToolStartEntry(toolCallId: string, toolName: string, timestamp: string) {
+function buildToolStartEntry(
+	toolCallId: string,
+	toolName: string,
+	timestamp: string,
+	executed: boolean | undefined = true,
+) {
 	return {
 		type: "custom",
 		id: `start-${toolCallId}`,
 		parentId: null,
 		timestamp,
 		customType: "tool_execution_start",
-		data: { toolCallId, toolName, startedAt: timestamp },
+		data: {
+			toolCallId,
+			toolName,
+			...(executed === undefined ? {} : { executed }),
+			startedAt: timestamp,
+		},
 	};
 }
 
@@ -276,6 +288,120 @@ describe("tool usage stats pipeline", () => {
 		expect(seriesCalls.get("read")).toBe(1);
 		expect(seriesErrors.get("grep")).toBe(0);
 		expect(seriesErrors.get("read")).toBe(1);
+	});
+
+	it("excludes tool calls that never reached their implementation from duration samples", async () => {
+		const syntheticResult = "Tool call was rejected before execution";
+		await writeSessionFile("session.jsonl", { id: "synthetic" }, [
+			buildAssistantEntry({
+				entryId: "asst-1",
+				timestamp: TS1,
+				toolCalls: [{ id: "call-1", name: "read", arguments: READ_ARGS }],
+				totalTokens: TURN2_TOTAL_TOKENS,
+				outputTokens: TURN2_OUTPUT_TOKENS,
+				costTotal: TURN2_COST,
+			}),
+			buildToolStartEntry("call-1", "read", TS1, false),
+			buildToolResultEntry({
+				entryId: "tr-1",
+				parentId: "asst-1",
+				timestamp: TS1_READ_RESULT,
+				toolCallId: "call-1",
+				toolName: "read",
+				text: syntheticResult,
+				isError: true,
+			}),
+		]);
+		await syncAllSessions({ workers: 1 });
+
+		const [read] = getToolStats();
+		expect(read.calls).toBe(1);
+		expect(read.errors).toBe(1);
+		expect(read.resultChars).toBe(syntheticResult.length);
+		expect(read.durationSamples).toBe(0);
+		expect(read.durationMsMedian).toBe(0);
+		expect(read.durationMsP90).toBe(0);
+	});
+
+	it("keeps timing legacy execution markers that predate the executed flag", async () => {
+		await writeSessionFile("session.jsonl", { id: "legacy-marker" }, [
+			buildAssistantEntry({
+				entryId: "asst-1",
+				timestamp: TS1,
+				toolCalls: [{ id: "call-1", name: "grep", arguments: GREP_ARGS_1 }],
+				totalTokens: TURN2_TOTAL_TOKENS,
+				outputTokens: TURN2_OUTPUT_TOKENS,
+				costTotal: TURN2_COST,
+			}),
+			buildToolStartEntry("call-1", "grep", TS1, undefined),
+			buildToolResultEntry({
+				entryId: "tr-1",
+				parentId: "asst-1",
+				timestamp: TS1_GREP_RESULT,
+				toolCallId: "call-1",
+				toolName: "grep",
+				text: GREP_RESULT_1,
+			}),
+		]);
+		await syncAllSessions({ workers: 1 });
+
+		const [grep] = getToolStats();
+		expect(grep.durationSamples).toBe(1);
+		expect(grep.durationMsMedian).toBe(2_000);
+		expect(grep.durationMsP90).toBe(2_000);
+	});
+
+	it("keeps duration percentiles isolated by model and provider", async () => {
+		await writeSessionFile("session.jsonl", { id: "model-groups" }, [
+			buildAssistantEntry({
+				entryId: "asst-1",
+				timestamp: TS1,
+				toolCalls: [{ id: "call-1", name: "grep", arguments: GREP_ARGS_1 }],
+				totalTokens: TURN2_TOTAL_TOKENS,
+				outputTokens: TURN2_OUTPUT_TOKENS,
+				costTotal: TURN2_COST,
+				model: "model-a",
+				provider: "provider-a",
+			}),
+			buildToolStartEntry("call-1", "grep", TS1),
+			buildToolResultEntry({
+				entryId: "tr-1",
+				parentId: "asst-1",
+				timestamp: TS1_GREP_RESULT,
+				toolCallId: "call-1",
+				toolName: "grep",
+				text: GREP_RESULT_1,
+			}),
+			buildAssistantEntry({
+				entryId: "asst-2",
+				parentId: "tr-1",
+				timestamp: TS2,
+				toolCalls: [{ id: "call-2", name: "grep", arguments: GREP_ARGS_2 }],
+				totalTokens: TURN2_TOTAL_TOKENS,
+				outputTokens: TURN2_OUTPUT_TOKENS,
+				costTotal: TURN2_COST,
+				model: "model-b",
+				provider: "provider-b",
+			}),
+			buildToolStartEntry("call-2", "grep", TS2),
+			buildToolResultEntry({
+				entryId: "tr-2",
+				parentId: "asst-2",
+				timestamp: TS2_GREP_RESULT,
+				toolCallId: "call-2",
+				toolName: "grep",
+				text: GREP_RESULT_2,
+			}),
+		]);
+		await syncAllSessions({ workers: 1 });
+
+		const rows = getToolStatsByModel();
+		const modelA = rows.find(row => row.model === "model-a" && row.provider === "provider-a");
+		const modelB = rows.find(row => row.model === "model-b" && row.provider === "provider-b");
+		expect(modelA?.durationSamples).toBe(1);
+		expect(modelA?.durationMsMedian).toBe(2_000);
+		expect(modelB?.durationSamples).toBe(1);
+		expect(modelB?.durationMsMedian).toBe(8_000);
 	});
 
 	it("links a result that lands in a later sync pass without duplicating the call", async () => {

--- a/packages/stats/test/tool-stats.test.ts
+++ b/packages/stats/test/tool-stats.test.ts
@@ -52,12 +52,14 @@ interface AssistantTurnOptions {
 	costTotal: number;
 }
 
+// The assistant request begins one minute before the persisted execution-start
+// markers so duration assertions catch accidental model-latency attribution.
 function buildAssistantEntry(opts: AssistantTurnOptions) {
 	return {
 		type: "message",
 		id: opts.entryId,
 		parentId: opts.parentId ?? null,
-		timestamp: opts.timestamp,
+		timestamp: new Date(Date.parse(opts.timestamp) - 60_000).toISOString(),
 		message: {
 			role: "assistant",
 			content: [
@@ -81,10 +83,21 @@ function buildAssistantEntry(opts: AssistantTurnOptions) {
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: opts.costTotal },
 			},
 			stopReason: "toolUse",
-			timestamp: Date.parse(opts.timestamp),
+			timestamp: Date.parse(opts.timestamp) - 60_000,
 			duration: 10,
 			ttft: 5,
 		},
+	};
+}
+
+function buildToolStartEntry(toolCallId: string, toolName: string, timestamp: string) {
+	return {
+		type: "custom",
+		id: `start-${toolCallId}`,
+		parentId: null,
+		timestamp,
+		customType: "tool_execution_start",
+		data: { toolCallId, toolName, startedAt: timestamp },
 	};
 }
 
@@ -153,6 +166,8 @@ function buildStandardEntries(): unknown[] {
 			outputTokens: TURN1_OUTPUT_TOKENS,
 			costTotal: TURN1_COST,
 		}),
+		buildToolStartEntry("call-1", "grep", TS1),
+		buildToolStartEntry("call-2", "read", TS1),
 		buildToolResultEntry({
 			entryId: "tr-1",
 			parentId: "asst-1",
@@ -179,6 +194,7 @@ function buildStandardEntries(): unknown[] {
 			outputTokens: TURN2_OUTPUT_TOKENS,
 			costTotal: TURN2_COST,
 		}),
+		buildToolStartEntry("call-3", "grep", TS2),
 		buildToolResultEntry({
 			entryId: "tr-3",
 			parentId: "asst-2",
@@ -210,14 +226,14 @@ describe("tool usage stats pipeline", () => {
 		expect(grep.resultChars).toBe(GREP_RESULT_1.length + GREP_RESULT_2.length);
 		expect(grep.durationSamples).toBe(2);
 		expect(grep.durationMsMedian).toBe(5_000);
-		expect(grep.durationMsP90).toBe(5_000);
+		expect(grep.durationMsP90).toBe(7_400);
 		expect(grep.argsChars).toBe(JSON.stringify(GREP_ARGS_1).length + JSON.stringify(GREP_ARGS_2).length);
 		// Turn 1's request is split across its two toolCall blocks; turn 2 is
 		// grep's alone: 100/2 + 40 = 90, 20/2 + 8 = 18, 0.01/2 + 0.004 = 0.009.
 		expect(grep.totalTokensShare).toBeCloseTo(90, 6);
 		expect(grep.outputTokensShare).toBeCloseTo(18, 6);
 		expect(grep.costShare).toBeCloseTo(0.009, 8);
-		expect(grep.lastUsed).toBe(Date.parse(TS2));
+		expect(grep.lastUsed).toBe(Date.parse(TS2) - 60_000);
 
 		const read = toolRow(stats, "read");
 		expect(read.calls).toBe(1);
@@ -230,7 +246,7 @@ describe("tool usage stats pipeline", () => {
 		expect(read.totalTokensShare).toBeCloseTo(50, 6);
 		expect(read.outputTokensShare).toBeCloseTo(10, 6);
 		expect(read.costShare).toBeCloseTo(0.005, 8);
-		expect(read.lastUsed).toBe(Date.parse(TS1));
+		expect(read.lastUsed).toBe(Date.parse(TS1) - 60_000);
 
 		// Per-model breakdown carries the fixture model/provider with the same split.
 		const byModel = getToolStatsByModel();
@@ -273,6 +289,7 @@ describe("tool usage stats pipeline", () => {
 				outputTokens: TURN2_OUTPUT_TOKENS,
 				costTotal: TURN2_COST,
 			}),
+			buildToolStartEntry("call-1", "grep", TS1),
 		]);
 		await syncAllSessions({ workers: 1 });
 

--- a/packages/stats/test/tool-stats.test.ts
+++ b/packages/stats/test/tool-stats.test.ts
@@ -14,7 +14,10 @@ const MODEL = "gpt-5.4";
 const PROVIDER = "openai";
 
 const TS1 = "2026-06-24T10:00:00.000Z";
+const TS1_GREP_RESULT = "2026-06-24T10:00:02.000Z";
+const TS1_READ_RESULT = "2026-06-24T10:00:04.000Z";
 const TS2 = "2026-06-24T10:05:00.000Z";
+const TS2_GREP_RESULT = "2026-06-24T10:05:08.000Z";
 
 // Turn 1: two toolCall blocks (grep + read) sharing one provider request.
 const TURN1_TOTAL_TOKENS = 100;
@@ -153,7 +156,7 @@ function buildStandardEntries(): unknown[] {
 		buildToolResultEntry({
 			entryId: "tr-1",
 			parentId: "asst-1",
-			timestamp: TS1,
+			timestamp: TS1_GREP_RESULT,
 			toolCallId: "call-1",
 			toolName: "grep",
 			text: GREP_RESULT_1,
@@ -161,7 +164,7 @@ function buildStandardEntries(): unknown[] {
 		buildToolResultEntry({
 			entryId: "tr-2",
 			parentId: "asst-1",
-			timestamp: TS1,
+			timestamp: TS1_READ_RESULT,
 			toolCallId: "call-2",
 			toolName: "read",
 			text: READ_ERROR_RESULT,
@@ -179,7 +182,7 @@ function buildStandardEntries(): unknown[] {
 		buildToolResultEntry({
 			entryId: "tr-3",
 			parentId: "asst-2",
-			timestamp: TS2,
+			timestamp: TS2_GREP_RESULT,
 			toolCallId: "call-3",
 			toolName: "grep",
 			text: GREP_RESULT_2,
@@ -205,6 +208,9 @@ describe("tool usage stats pipeline", () => {
 		expect(grep.calls).toBe(2);
 		expect(grep.errors).toBe(0);
 		expect(grep.resultChars).toBe(GREP_RESULT_1.length + GREP_RESULT_2.length);
+		expect(grep.durationSamples).toBe(2);
+		expect(grep.durationMsMedian).toBe(5_000);
+		expect(grep.durationMsP90).toBe(5_000);
 		expect(grep.argsChars).toBe(JSON.stringify(GREP_ARGS_1).length + JSON.stringify(GREP_ARGS_2).length);
 		// Turn 1's request is split across its two toolCall blocks; turn 2 is
 		// grep's alone: 100/2 + 40 = 90, 20/2 + 8 = 18, 0.01/2 + 0.004 = 0.009.
@@ -217,6 +223,9 @@ describe("tool usage stats pipeline", () => {
 		expect(read.calls).toBe(1);
 		expect(read.errors).toBe(1);
 		expect(read.resultChars).toBe(READ_ERROR_RESULT.length);
+		expect(read.durationSamples).toBe(1);
+		expect(read.durationMsMedian).toBe(4_000);
+		expect(read.durationMsP90).toBe(4_000);
 		expect(read.argsChars).toBe(JSON.stringify(READ_ARGS).length);
 		expect(read.totalTokensShare).toBeCloseTo(50, 6);
 		expect(read.outputTokensShare).toBeCloseTo(10, 6);
@@ -232,8 +241,10 @@ describe("tool usage stats pipeline", () => {
 		}
 		expect(toolRow(byModel, "grep").calls).toBe(2);
 		expect(toolRow(byModel, "grep").totalTokensShare).toBeCloseTo(90, 6);
+		expect(toolRow(byModel, "grep").durationMsMedian).toBe(5_000);
 		expect(toolRow(byModel, "read").calls).toBe(1);
 		expect(toolRow(byModel, "read").totalTokensShare).toBeCloseTo(50, 6);
+		expect(toolRow(byModel, "read").durationMsMedian).toBe(4_000);
 
 		// Dashboard payload reuses the same aggregates and buckets the calls.
 		const dashboard = await getToolDashboardStats("all");
@@ -277,7 +288,7 @@ describe("tool usage stats pipeline", () => {
 		const lateResult = buildToolResultEntry({
 			entryId: "tr-1",
 			parentId: "asst-1",
-			timestamp: TS2,
+			timestamp: "2026-06-24T10:00:09.000Z",
 			toolCallId: "call-1",
 			toolName: "grep",
 			text: lateResultText,
@@ -297,6 +308,8 @@ describe("tool usage stats pipeline", () => {
 		expect(linked[0].calls).toBe(1);
 		expect(linked[0].resultChars).toBe(lateResultText.length);
 		expect(linked[0].errors).toBe(1);
+		expect(linked[0].durationSamples).toBe(1);
+		expect(linked[0].durationMsMedian).toBe(9_000);
 	});
 
 	it("does not double-count tool calls copied into a forked session file", async () => {

--- a/packages/stats/test/tool-stats.test.ts
+++ b/packages/stats/test/tool-stats.test.ts
@@ -374,7 +374,7 @@ describe("tool usage stats pipeline", () => {
 				toolCallId: "call-todo",
 				toolName: "todo",
 				text: "No todos",
-				details: { __synthetic: true, source: "cursor_server_resolved", executed: false },
+				details: { source: "cursor_server_resolved", executed: false },
 			}),
 			buildToolResultEntry({
 				entryId: "tr-read",
@@ -383,7 +383,7 @@ describe("tool usage stats pipeline", () => {
 				toolCallId: "call-read",
 				toolName: "read",
 				text: "",
-				details: { __synthetic: true, source: "cursor_zero_length_read", executed: false },
+				details: { source: "cursor_zero_length_read", executed: false },
 			}),
 		]);
 		await syncAllSessions({ workers: 1 });
@@ -559,6 +559,40 @@ describe("tool usage stats pipeline", () => {
 		const [grep] = getToolStats();
 		expect(grep.durationSamples).toBe(1);
 		expect(grep.durationMsMedian).toBe(4_000);
+	});
+
+	it("excludes a skipped result that lands after its call row", async () => {
+		const sessionFile = await writeSessionFile("session.jsonl", { id: "late-skipped-result" }, [
+			buildAssistantEntry({
+				entryId: "asst-1",
+				timestamp: TS1,
+				toolCalls: [{ id: "call-1", name: "read", arguments: READ_ARGS }],
+				totalTokens: TURN2_TOTAL_TOKENS,
+				outputTokens: TURN2_OUTPUT_TOKENS,
+				costTotal: TURN2_COST,
+			}),
+		]);
+		await syncAllSessions({ workers: 1 });
+
+		const marker = buildToolStartEntry("call-1", "read", TS1, false);
+		const result = buildToolResultEntry({
+			entryId: "tr-1",
+			parentId: "asst-1",
+			timestamp: TS1_READ_RESULT,
+			toolCallId: "call-1",
+			toolName: "read",
+			text: "",
+			details: { executed: false },
+		});
+		await fs.appendFile(sessionFile, `${JSON.stringify(marker)}\n${JSON.stringify(result)}\n`);
+		const bumped = new Date(Date.now() + 1_000);
+		await fs.utimes(sessionFile, bumped, bumped);
+
+		await syncAllSessions({ workers: 1 });
+
+		const [read] = getToolStats();
+		expect(read.durationSamples).toBe(0);
+		expect(read.durationMsMedian).toBe(0);
 	});
 
 	it("links a result that lands in a later sync pass without duplicating the call", async () => {


### PR DESCRIPTION
## What

Record invocation-to-result duration for each persisted tool call and expose median/p90 latency plus observed sample counts in the Tools aggregates. Existing databases migrate through `tool_calls_v2`, which re-ingests sessions once so historical calls receive duration samples when their result entries are present.

Persist whether the tool implementation ran so validation, policy, abort, and other synthetic results do not count as execution-time samples. Legacy execution markers without this field remain compatible.

## Why

The current statistics retain call counts, payload sizes, token shares, and cost shares, but they cannot distinguish provider time from tool execution time. The duration data makes that attribution explicit without counting calls that never reached `tool.execute`.

## Testing

- `bun test packages/agent/test/agent.test.ts packages/agent/test/agent-loop.test.ts packages/coding-agent/test/agent-session-message-pipeline.test.ts packages/stats/test/tool-stats.test.ts`
- `bun --cwd=packages/agent run check`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/stats run check`

GitHub CI currently fails in unchanged Chromium test fixtures with `ReferenceError: Cannot access 'CHROMIUM_AVAILABLE' before initialization`. The first failing shard reproduces at exact upstream `main` commit `80627462b4e91f46795ba87f3678174bd3c0b907`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
