### PR TITLE
fix(tui): ignore system sleep in loop watchdog

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the event-loop watchdog reporting system sleep as a synchronous `ui.loop-blocked` stall. A long missed probe interval is now treated as process suspension and suppressed, while shorter real stalls continue to report with their phase attribution.
+
 ## [17.2.0] - 2026-07-30
 
 ### Added

--- a/packages/tui/src/loop-watchdog.ts
+++ b/packages/tui/src/loop-watchdog.ts
@@ -6,6 +6,8 @@ export interface LoopWatchdogOptions {
 	intervalMs?: number;
 	/** A tick later than this past its deadline counts as a block. Default 250. */
 	thresholdMs?: number;
+	/** Overshoot beyond this likely includes system sleep, so it is suppressed. Default 60_000. */
+	sleepMs?: number;
 	/** Monotonic clock source; injectable for tests. Default `performance.now`. */
 	now?: () => number;
 	/** Timer source; injectable for tests. Default `setTimeout`. */
@@ -33,11 +35,15 @@ interface LoopWatchdogTimer {
  * The handle is `unref`'d so the probe never keeps the process alive, and stop()
  * cancels the armed timer when the handle exposes `cancel` (the default
  * `setTimeout` handle does, via `clearTimeout`). The `#generation` guard remains
- * as a fallback for injected handles that cannot cancel.
+ * as a fallback for injected handles that cannot cancel. An overshoot beyond
+ * `sleepMs` is treated as system sleep rather than a synchronous stall: the
+ * process could not have run JS during the missed interval, and one resume
+ * should not produce a multi-minute `ui.loop-blocked` record.
  */
 export class LoopWatchdog {
 	#intervalMs: number;
 	#thresholdMs: number;
+	#sleepMs: number;
 	#now: () => number;
 	#schedule: (cb: () => void, ms: number) => LoopWatchdogTimer;
 	#expected = 0;
@@ -52,6 +58,7 @@ export class LoopWatchdog {
 	constructor(options: LoopWatchdogOptions = {}) {
 		this.#intervalMs = options.intervalMs ?? 250;
 		this.#thresholdMs = options.thresholdMs ?? 250;
+		this.#sleepMs = options.sleepMs ?? 60_000;
 		this.#now = options.now ?? (() => performance.now());
 		this.#schedule =
 			options.schedule ??
@@ -91,7 +98,9 @@ export class LoopWatchdog {
 		// forward to a later, phase-less block.
 		const phase = takeRecentLoopPhase();
 		if (blockedMs > this.#thresholdMs) {
-			if (!this.#wasBlocked) {
+			if (blockedMs > this.#sleepMs) {
+				this.#wasBlocked = false;
+			} else if (!this.#wasBlocked) {
 				this.#wasBlocked = true;
 				logger.warn("ui.loop-blocked", {
 					blockedMs: Math.round(blockedMs),

--- a/packages/tui/test/loop-watchdog.test.ts
+++ b/packages/tui/test/loop-watchdog.test.ts
@@ -15,7 +15,7 @@ import { currentLoopPhase, logger, popLoopPhase, pushLoopPhase, takeRecentLoopPh
  * ticks by hand; firing re-arms via schedule, so the captured callback always
  * advances to the next pending tick.
  */
-function harness(options: Partial<{ intervalMs: number; thresholdMs: number }> = {}) {
+function harness(options: Partial<{ intervalMs: number; thresholdMs: number; sleepMs: number }> = {}) {
 	let nowValue = 0;
 	let scheduled: (() => void) | undefined;
 	const now = () => nowValue;
@@ -87,6 +87,24 @@ describe("LoopWatchdog", () => {
 		fireTick();
 
 		expect(warnSpy).toHaveBeenCalledTimes(1);
+	});
+
+	test("treats a long missed interval as system sleep, not an event-loop block", () => {
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const { wd, setNow, fireTick } = harness({ sleepMs: 5_000 });
+
+		wd.start(); // deadline at 250
+		setNow(10_250); // blockedMs = 10_000 exceeds the sleep cutoff
+		fireTick();
+
+		expect(warnSpy).not.toHaveBeenCalled();
+
+		setNow(10_760); // next deadline is 10_500 → a real 260ms stall still reports
+		fireTick();
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		const [event, ctx] = warnSpy.mock.calls[0] as [string, { blockedMs: number; phase: string }];
+		expect(event).toBe("ui.loop-blocked");
+		expect(ctx.blockedMs).toBe(260);
 	});
 
 	test("emits nothing for a tick that fires after stop()", () => {


### PR DESCRIPTION
## What

Add a 60-second sleep cutoff to `LoopWatchdog`. A missed probe interval beyond that cutoff resets the blocked state without logging `ui.loop-blocked`; shorter overshoots continue to report with phase attribution.

I reviewed this change; it keeps laptop sleep from appearing as a multi-minute synchronous event-loop stall while preserving diagnostics for real UI stalls.

## Why

The watchdog measures deadline overshoot from `performance.now()`, so a suspended process resumes with one huge missed interval even though JavaScript could not have run during it. Those records dominate long-tail stall diagnostics and obscure actual synchronous blocking.

## Testing

- `bun test test/loop-watchdog.test.ts`
- `bun --cwd=packages/tui run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)