### PR TITLE
feat(task): cap cumulative child session runtime

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -346,7 +346,7 @@
 
 - Added `task.maxSessionRuntimeMs`, a cumulative wall-clock limit intended for keep-alive subagent sessions. The executor gives it precedence over the per-turn timer when both are configured and reports cumulative expiry distinctly so parked/resumed children cannot disguise total lifetime behind a fresh turn timer.
 
-## [17.2.0] - 2026-07-30
+## [17.2.1] - 2026-07-30
 
 ### Added
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -342,6 +342,11 @@
 - Fixed browser automation disrupting attached browsers by adopting the active foreground tab and avoiding raising new tabs during screenshots.
 
 ## [17.2.1] - 2026-07-30
+### Added
+
+- Added `task.maxSessionRuntimeMs`, a cumulative wall-clock limit intended for keep-alive subagent sessions. The executor gives it precedence over the per-turn timer when both are configured and reports cumulative expiry distinctly so parked/resumed children cannot disguise total lifetime behind a fresh turn timer.
+
+## [17.2.0] - 2026-07-30
 
 ### Added
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4661,6 +4661,25 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"task.maxSessionRuntimeMs": {
+		type: "number",
+		default: 0,
+		ui: {
+			tab: "tasks",
+			group: "Subagents",
+			label: "Max Subagent Session Runtime",
+			description:
+				"Cumulative wall-clock limit for a keep-alive subagent session (ms). Unlike task.maxRuntimeMs, this budget is meant to survive parked/resumed follow-up turns when callers pass the remaining budget. 0 disables it.",
+			options: [
+				{ value: "0", label: "Unlimited", description: "Default" },
+				{ value: "900000", label: "15 minutes" },
+				{ value: "1800000", label: "30 minutes" },
+				{ value: "3600000", label: "1 hour" },
+				{ value: "7200000", label: "2 hours" },
+			],
+		},
+	},
+
 	"task.agentIdleTtlMs": {
 		type: "number",
 		default: 420_000,

--- a/packages/coding-agent/src/eval/agent-bridge.ts
+++ b/packages/coding-agent/src/eval/agent-bridge.ts
@@ -156,6 +156,7 @@ export async function runEvalAgent(args: unknown, options: EvalAgentBridgeOption
 					// `maxRuntimeMs` is intentionally omitted: the executor then inherits
 					// `task.maxRuntimeMs`, matching the task tool. Pinning it to 0 here
 					// silently overrode the user's wall-clock cap for eval fan-outs.
+					maxSessionRuntimeMs: 0,
 					shareEvalSession: false,
 					...(options.signal !== undefined ? { signal: options.signal } : {}),
 					...(options.emitStatus

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -28,6 +28,8 @@ import {
 	type AgentRef,
 	type AgentRefExpectation,
 	AgentRegistry,
+	type AgentRuntimePolicy,
+	type AgentSessionRuntimeLimit,
 	getAgentTombstonePath,
 	MAIN_AGENT_ID,
 	type RegistryEvent,
@@ -54,11 +56,19 @@ async function persistAgentTombstone(sessionFile: string): Promise<void> {
  */
 export type PersistedSubagentReviverFactory = (ref: AgentRef) => Promise<AgentReviver | undefined>;
 
+export type SessionRuntimeLimit = AgentSessionRuntimeLimit;
+
+export function sessionRuntimeExceededReason(limit: SessionRuntimeLimit): string {
+	return `Subagent cumulative runtime limit exceeded (task.maxSessionRuntimeMs=${limit.maxSessionRuntimeMs})`;
+}
+
 export interface AdoptOptions {
 	/** TTL before an idle agent is parked. <= 0 disables parking. */
 	idleTtlMs: number;
 	/** Recreates a live AgentSession from the ref's sessionFile. Absent => not resumable after park (e.g. isolated runs). */
 	revive?: AgentReviver;
+	/** Runtime contract shared by every wake and revival of this child. */
+	runtimePolicy?: AgentRuntimePolicy;
 }
 
 interface AdoptedAgent {
@@ -159,6 +169,7 @@ export class AgentLifecycleManager {
 		}
 		const existing = this.#adopted.get(id);
 		clearTimeout(existing?.timer);
+		if (opts.runtimePolicy) this.#registry.setRuntimePolicy(id, opts.runtimePolicy, ref);
 		const adopted: AdoptedAgent = { ref, idleTtlMs: opts.idleTtlMs, revive: opts.revive };
 		this.#adopted.set(id, adopted);
 		this.#armTimer(id, adopted);
@@ -279,6 +290,7 @@ export class AgentLifecycleManager {
 	 * cancelled (session still live) or awaited to completion before revive.
 	 */
 	async ensureLive(id: string): Promise<AgentSession> {
+		this.#assertSessionRuntimeAvailable(this.#registry.get(id)?.runtimePolicy?.sessionRuntimeLimit);
 		const park = this.#parks.get(id);
 		if (park) {
 			const parked = this.#registry.get(id);
@@ -286,6 +298,7 @@ export class AgentLifecycleManager {
 			// thrashing dispose + revive.
 			if (parked?.session && !park.detached && park.cancel()) {
 				await park.promise;
+				this.#assertSessionRuntimeAvailable(this.#registry.get(id)?.runtimePolicy?.sessionRuntimeLimit);
 				const kept = this.#registry.get(id)?.session;
 				if (kept) {
 					// Park cleared the idle timer; re-arm so TTL park still works.
@@ -297,10 +310,12 @@ export class AgentLifecycleManager {
 				// Already committed to detach (or no live session): wait for park,
 				// then fall through to the revive path.
 				await park.promise;
+				this.#assertSessionRuntimeAvailable(this.#registry.get(id)?.runtimePolicy?.sessionRuntimeLimit);
 			}
 		}
 
 		const ref = this.#registry.get(id);
+		this.#assertSessionRuntimeAvailable(ref?.runtimePolicy?.sessionRuntimeLimit);
 		if (!ref) {
 			throw new Error(
 				`Unknown agent "${id}" — it was never registered or has been released. If a transcript exists, read history://${id}.`,
@@ -411,6 +426,40 @@ export class AgentLifecycleManager {
 		return true;
 	}
 
+	/**
+	 * Remove an exhausted exact ref synchronously so delayed lifecycle events
+	 * cannot restore it. Disposal remains bounded background cleanup.
+	 */
+	terminalRelease(id: string, expected: AgentRef): boolean {
+		const ref = this.#registry.get(id);
+		if (ref !== expected) return false;
+
+		const adopted = this.#adopted.get(id);
+		if (adopted?.ref === ref) {
+			clearTimeout(adopted.timer);
+			this.#adopted.delete(id);
+		}
+		const park = this.#parks.get(id);
+		if (park?.ref === ref) {
+			if (!park.detached) park.cancel();
+			this.#parks.delete(id);
+			void untilAborted(AbortSignal.timeout(AGENT_RELEASE_GRACE_MS), () => park.promise).catch(error => {
+				logger.debug("AgentLifecycleManager: terminal park cleanup timed out", { id, error: String(error) });
+			});
+		}
+		if (this.#revivals.get(id)?.ref === ref) this.#revivals.delete(id);
+
+		const session = ref.session;
+		if (session) this.#registry.detachSession(id, ref);
+		if (!this.#registry.unregister(id, ref)) return false;
+		if (session) {
+			void untilAborted(AbortSignal.timeout(AGENT_RELEASE_GRACE_MS), () => session.dispose()).catch(error => {
+				logger.debug("AgentLifecycleManager: terminal session cleanup timed out", { id, error: String(error) });
+			});
+		}
+		return true;
+	}
+
 	/** Teardown everything (process exit / main session dispose). */
 	async dispose(deadlineAt: number = Date.now() + AGENT_RELEASE_GRACE_MS): Promise<void> {
 		this.#unsubscribe?.();
@@ -469,6 +518,13 @@ export class AgentLifecycleManager {
 			throw new Error(`Agent "${id}" changed before its persisted session became idle.`);
 		}
 		return session;
+	}
+
+	#assertSessionRuntimeAvailable(limit?: SessionRuntimeLimit): void {
+		if (!limit || limit.maxSessionRuntimeMs <= 0) return;
+		if (Date.now() - limit.startedAt >= limit.maxSessionRuntimeMs) {
+			throw new Error(sessionRuntimeExceededReason(limit));
+		}
 	}
 
 	#armTimer(id: string, adopted: AdoptedAgent): void {

--- a/packages/coding-agent/src/registry/agent-registry.ts
+++ b/packages/coding-agent/src/registry/agent-registry.ts
@@ -39,6 +39,19 @@ type AgentDurationKind = "active" | "span" | "unknown";
  */
 export type AgentKind = "main" | "sub" | "advisor";
 
+/** Runtime limits retained by a keep-alive child across wake and revival paths. */
+export interface AgentSessionRuntimeLimit {
+	maxSessionRuntimeMs: number;
+	startedAt: number;
+}
+
+export interface AgentRuntimePolicy {
+	/** Wall-clock cap for each running turn; 0 disables it. */
+	maxRuntimeMs: number;
+	/** Absolute cumulative child budget; absent disables it. */
+	sessionRuntimeLimit?: AgentSessionRuntimeLimit;
+}
+
 /** Persisted per-agent totals reconstructed from the child session transcript. */
 export interface AgentMetricsSummary {
 	tokens: number;
@@ -83,6 +96,8 @@ export interface AgentRef {
 	activity?: string;
 	/** Persisted identity and telemetry restored after the live observer is gone. */
 	history?: AgentHistorySummary;
+	/** Runtime contract for every later wake/revival of this child. */
+	runtimePolicy?: AgentRuntimePolicy;
 }
 
 export type AgentRefExpectation = AgentRef | AgentSession;
@@ -111,6 +126,7 @@ export interface RegisterInput {
 	lastActivity?: number;
 	/** Persisted identity and telemetry restored after the live observer is gone. */
 	history?: AgentHistorySummary;
+	runtimePolicy?: AgentRuntimePolicy;
 }
 
 export class AgentRegistry {
@@ -149,6 +165,7 @@ export class AgentRegistry {
 			lastActivity: input.lastActivity ?? now,
 			activity: input.activity,
 			history: input.history,
+			runtimePolicy: input.runtimePolicy,
 		};
 		this.#refs.set(ref.id, ref);
 		this.#emit({ type: "registered", ref });
@@ -176,6 +193,13 @@ export class AgentRegistry {
 		) as AgentHistorySummary;
 		ref.history = { ...ref.history, ...definedHistory };
 		this.#emit({ type: "metadata_changed", ref });
+		return true;
+	}
+
+	setRuntimePolicy(id: string, runtimePolicy: AgentRuntimePolicy, expected?: AgentRefExpectation): boolean {
+		const ref = this.#refs.get(id);
+		if (!ref || !this.#matchesExpected(ref, expected)) return false;
+		ref.runtimePolicy = runtimePolicy;
 		return true;
 	}
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2318,7 +2318,11 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 				.filter(Boolean)
 				.join("\n\n") || "IRC follow-up";
 		const turnStartTime = Date.now();
-		const sessionFile = AgentRegistry.global().get(id)?.sessionFile ?? options.sessionFile ?? undefined;
+		const ref = AgentRegistry.global().get(id);
+		const maxRuntimeMs =
+			Math.max(0, Math.trunc(Number(options.maxRuntimeMs ?? 0) || 0)) || ref?.runtimePolicy?.maxRuntimeMs || 0;
+		const sessionFile = ref?.sessionFile ?? options.sessionFile ?? undefined;
+		const sessionRuntimeLimit = ref?.runtimePolicy?.sessionRuntimeLimit;
 		const turnMonitor = createSubagentRunMonitor({
 			index,
 			id,
@@ -2552,10 +2556,8 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	const startTime = Date.now();
 	const session = await AgentLifecycleManager.global().ensureLive(id);
 	const ref = AgentRegistry.global().get(id);
-	const maxRuntimeMs = Math.max(
-		0,
-		Math.trunc(Number(ref?.runtimePolicy?.maxRuntimeMs ?? options.maxRuntimeMs ?? 0) || 0),
-	);
+	const configuredMaxRuntimeMs = Math.max(0, Math.trunc(Number(options.maxRuntimeMs ?? 0) || 0));
+	const maxRuntimeMs = configuredMaxRuntimeMs || ref?.runtimePolicy?.maxRuntimeMs || 0;
 	const configuredMaxSessionRuntimeMs = Math.max(0, Math.trunc(Number(options.maxSessionRuntimeMs ?? 0) || 0));
 	const sessionRuntimeLimit =
 		ref?.runtimePolicy?.sessionRuntimeLimit ??

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2552,6 +2552,24 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	const startTime = Date.now();
 	const session = await AgentLifecycleManager.global().ensureLive(id);
 	const ref = AgentRegistry.global().get(id);
+	const maxRuntimeMs = Math.max(
+		0,
+		Math.trunc(Number(ref?.runtimePolicy?.maxRuntimeMs ?? options.maxRuntimeMs ?? 0) || 0),
+	);
+	const configuredMaxSessionRuntimeMs = Math.max(0, Math.trunc(Number(options.maxSessionRuntimeMs ?? 0) || 0));
+	const sessionRuntimeLimit =
+		ref?.runtimePolicy?.sessionRuntimeLimit ??
+		(configuredMaxSessionRuntimeMs > 0
+			? {
+					maxSessionRuntimeMs: configuredMaxSessionRuntimeMs,
+					startedAt: options.sessionRuntimeStartedAt ?? startTime,
+				}
+			: undefined);
+	const maxSessionRuntimeMs = sessionRuntimeLimit?.maxSessionRuntimeMs ?? 0;
+	if (ref) {
+		AgentRegistry.global().setRuntimePolicy(id, { maxRuntimeMs, sessionRuntimeLimit }, ref);
+	}
+	const lifecycle = AgentLifecycleManager.global();
 	const sessionFile = ref?.sessionFile ?? undefined;
 
 	const monitor = createSubagentRunMonitor({

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -37,7 +37,7 @@ import type { MnemopiSessionState } from "../mnemopi/state";
 import subagentAsyncPendingTemplate from "../prompts/system/subagent-async-pending.md" with { type: "text" };
 import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
 import submitReminderTemplate from "../prompts/system/subagent-yield-reminder.md" with { type: "text" };
-import { AgentLifecycleManager, type AgentReviver } from "../registry/agent-lifecycle";
+import { AgentLifecycleManager, type AgentReviver, sessionRuntimeExceededReason } from "../registry/agent-lifecycle";
 import { AgentRegistry } from "../registry/agent-registry";
 import { type CreateAgentSessionOptions, createAgentSession, discoverAuthStorage } from "../sdk";
 import type { AgentSession, AgentSessionEvent, Prewalk } from "../session/agent-session";
@@ -938,6 +938,8 @@ interface RunMonitorArgs {
 	maxSessionRuntimeMs: number;
 	/** Wall-clock creation time retained by the keep-alive child lifecycle. */
 	sessionRuntimeStartedAt?: number;
+	/** Synchronous terminal cutover when the cumulative session cap fires. */
+	onSessionRuntimeLimitExceeded?: () => void;
 }
 
 /**
@@ -1022,6 +1024,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		maxRuntimeMs,
 		maxSessionRuntimeMs,
 		sessionRuntimeStartedAt,
+		onSessionRuntimeLimitExceeded,
 	} = args;
 	const startTime = Date.now();
 
@@ -1192,6 +1195,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 				: undefined;
 	let runtimeTimeoutId: NodeJS.Timeout | undefined;
 	if (runtimeLimit?.delayMs === 0) {
+		if (runtimeLimit.kind === "session") onSessionRuntimeLimitExceeded?.();
 		requestAbort("timeout");
 	} else if (runtimeLimit) {
 		runtimeTimeoutId = setTimeout(() => {
@@ -1203,6 +1207,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 					maxRuntimeMs,
 					maxSessionRuntimeMs,
 				});
+				if (runtimeLimit.kind === "session") onSessionRuntimeLimitExceeded?.();
 				requestAbort("timeout");
 			}
 		}, runtimeLimit.delayMs);
@@ -2304,7 +2309,6 @@ export interface IrcWakeTurnMonitorOptions {
 export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWakeTurnMonitorOptions): void {
 	const { id, agent } = options;
 	const index = options.index ?? 0;
-	const maxRuntimeMs = options.maxRuntimeMs ?? 0;
 	session.setIrcWakeTurnObserver(records => {
 		const ircTask =
 			records
@@ -2320,7 +2324,7 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 		const turnStartTime = Date.now();
 		const ref = AgentRegistry.global().get(id);
 		const maxRuntimeMs =
-			Math.max(0, Math.trunc(Number(options.maxRuntimeMs ?? 0) || 0)) || ref?.runtimePolicy?.maxRuntimeMs || 0;
+			ref?.runtimePolicy?.maxRuntimeMs ?? Math.max(0, Math.trunc(Number(options.maxRuntimeMs ?? 0) || 0));
 		const sessionFile = ref?.sessionFile ?? options.sessionFile ?? undefined;
 		const sessionRuntimeLimit = ref?.runtimePolicy?.sessionRuntimeLimit;
 		const turnMonitor = createSubagentRunMonitor({
@@ -2338,6 +2342,13 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 			softRequestBudget: 0,
 			softRequestBudgetNotice: false,
 			maxRuntimeMs,
+			maxSessionRuntimeMs: sessionRuntimeLimit?.maxSessionRuntimeMs ?? 0,
+			sessionRuntimeStartedAt: sessionRuntimeLimit?.startedAt,
+			onSessionRuntimeLimitExceeded: ref
+				? () => {
+						AgentLifecycleManager.global().terminalRelease(id, ref);
+					}
+				: undefined,
 		});
 
 		if (options.eventBus) {
@@ -2554,24 +2565,52 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	const { id, agent, message, signal } = options;
 	const index = options.index ?? 0;
 	const startTime = Date.now();
-	const session = await AgentLifecycleManager.global().ensureLive(id);
-	const ref = AgentRegistry.global().get(id);
+	const lifecycle = AgentLifecycleManager.global();
+	const initialRef = AgentRegistry.global().get(id);
 	const configuredMaxRuntimeMs = Math.max(0, Math.trunc(Number(options.maxRuntimeMs ?? 0) || 0));
-	const maxRuntimeMs = configuredMaxRuntimeMs || ref?.runtimePolicy?.maxRuntimeMs || 0;
+	const maxRuntimeMs = configuredMaxRuntimeMs || initialRef?.runtimePolicy?.maxRuntimeMs || 0;
 	const configuredMaxSessionRuntimeMs = Math.max(0, Math.trunc(Number(options.maxSessionRuntimeMs ?? 0) || 0));
 	const sessionRuntimeLimit =
-		ref?.runtimePolicy?.sessionRuntimeLimit ??
+		initialRef?.runtimePolicy?.sessionRuntimeLimit ??
 		(configuredMaxSessionRuntimeMs > 0
 			? {
 					maxSessionRuntimeMs: configuredMaxSessionRuntimeMs,
 					startedAt: options.sessionRuntimeStartedAt ?? startTime,
 				}
 			: undefined);
+	if (
+		initialRef &&
+		sessionRuntimeLimit &&
+		sessionRuntimeLimit.maxSessionRuntimeMs > 0 &&
+		Date.now() - sessionRuntimeLimit.startedAt >= sessionRuntimeLimit.maxSessionRuntimeMs
+	) {
+		const reason = sessionRuntimeExceededReason(sessionRuntimeLimit);
+		lifecycle.terminalRelease(id, initialRef);
+		return {
+			index,
+			id,
+			agent: agent.name,
+			agentSource: agent.source,
+			task: message,
+			description: options.description,
+			exitCode: 1,
+			output: "",
+			stderr: reason,
+			truncated: false,
+			durationMs: Date.now() - startTime,
+			tokens: 0,
+			requests: 0,
+			error: reason,
+			aborted: true,
+			abortReason: reason,
+		};
+	}
+	const session = await lifecycle.ensureLive(id);
+	const ref = AgentRegistry.global().get(id);
 	const maxSessionRuntimeMs = sessionRuntimeLimit?.maxSessionRuntimeMs ?? 0;
 	if (ref) {
 		AgentRegistry.global().setRuntimePolicy(id, { maxRuntimeMs, sessionRuntimeLimit }, ref);
 	}
-	const lifecycle = AgentLifecycleManager.global();
 	const sessionFile = ref?.sessionFile ?? undefined;
 
 	const monitor = createSubagentRunMonitor({
@@ -2589,9 +2628,14 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		sessionFile,
 		softRequestBudget: 0,
 		softRequestBudgetNotice: false,
-		maxRuntimeMs: options.maxRuntimeMs ?? 0,
-		maxSessionRuntimeMs: options.maxSessionRuntimeMs ?? 0,
-		sessionRuntimeStartedAt: options.sessionRuntimeStartedAt,
+		maxRuntimeMs,
+		maxSessionRuntimeMs,
+		sessionRuntimeStartedAt: sessionRuntimeLimit?.startedAt,
+		onSessionRuntimeLimitExceeded: ref
+			? () => {
+					lifecycle.terminalRelease(id, ref);
+				}
+			: undefined,
 	});
 
 	if (options.eventBus) {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -391,6 +391,12 @@ export interface ExecutorOptions {
 	 * watchdog is already suspended for the call's duration.
 	 */
 	maxRuntimeMs?: number;
+	/**
+	 * Override the `task.maxSessionRuntimeMs` cumulative wall-clock cap. Unlike
+	 * `maxRuntimeMs`, this budget is intended to survive parked/resumed
+	 * follow-up turns when the caller passes the remaining budget each time.
+	 */
+	maxSessionRuntimeMs?: number;
 	/** Include IRC only when the invocation policy permits collaboration. */
 	enableIrc?: boolean;
 	enableLsp?: boolean;
@@ -924,8 +930,10 @@ interface RunMonitorArgs {
 	softRequestBudget: number;
 	/** Whether crossing the soft budget injects a wrap-up steering notice. */
 	softRequestBudgetNotice: boolean;
-	/** Wall-clock cap in ms; 0 disables the timer. */
+	/** Wall-clock cap in ms for one turn; 0 disables the timer. */
 	maxRuntimeMs: number;
+	/** Cumulative wall-clock cap in ms across follow-up turns; 0 disables the timer. */
+	maxSessionRuntimeMs: number;
 }
 
 /**
@@ -1008,6 +1016,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		softRequestBudget,
 		softRequestBudgetNotice,
 		maxRuntimeMs,
+		maxSessionRuntimeMs,
 	} = args;
 	const startTime = Date.now();
 
@@ -1167,19 +1176,24 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 	// Wall-clock hard limit. Defense-in-depth for the case where a provider stream
 	// hang escapes the inference-layer watchdog (see openai-completions
 	// `isOpenAICompletionsProgressChunk`). Disabled by default; set
-	// `task.maxRuntimeMs > 0` to cap each subagent's lifetime.
+	// `task.maxRuntimeMs > 0` to cap each turn's lifetime. The cumulative
+	// session cap independently bounds total elapsed runtime across resumed
+	// turns, so parking and reviving a child cannot reset its budget.
+	const runtimeCapMs =
+		maxSessionRuntimeMs > 0 ? Math.min(maxRuntimeMs || maxSessionRuntimeMs, maxSessionRuntimeMs) : maxRuntimeMs;
 	let runtimeTimeoutId: NodeJS.Timeout | undefined;
-	if (maxRuntimeMs > 0) {
+	if (runtimeCapMs > 0) {
 		runtimeTimeoutId = setTimeout(() => {
 			if (!resolved) {
 				logger.warn("Subagent runtime limit exceeded; aborting", {
 					id,
 					agent: agent.name,
 					maxRuntimeMs,
+					maxSessionRuntimeMs,
 				});
 				requestAbort("timeout");
 			}
-		}, maxRuntimeMs);
+		}, runtimeCapMs);
 	}
 
 	const resolveSignalAbortReason = (): string => {
@@ -1195,6 +1209,9 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 	};
 	const resolveAbortReasonText = (): string => {
 		if (runtimeLimitExceeded) {
+			if (maxSessionRuntimeMs > 0) {
+				return `Subagent cumulative runtime limit exceeded (task.maxSessionRuntimeMs=${maxSessionRuntimeMs})`;
+			}
 			return `Subagent runtime limit exceeded (task.maxRuntimeMs=${maxRuntimeMs})`;
 		}
 		if (budgetLimitExceeded) {
@@ -2499,6 +2516,8 @@ export interface FollowUpTurnOptions {
 	artifactsDir?: string;
 	/** Wall-clock cap in ms for this turn; 0 disables. */
 	maxRuntimeMs?: number;
+	/** Cumulative wall-clock cap in ms for the child session; 0 disables. */
+	maxSessionRuntimeMs?: number;
 }
 
 /**
@@ -2536,6 +2555,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		softRequestBudget: 0,
 		softRequestBudgetNotice: false,
 		maxRuntimeMs: options.maxRuntimeMs ?? 0,
+		maxSessionRuntimeMs: options.maxSessionRuntimeMs ?? 0,
 	});
 
 	if (options.eventBus) {
@@ -2661,6 +2681,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		0,
 		Math.trunc(Number(options.maxRuntimeMs ?? settings.get("task.maxRuntimeMs") ?? 0) || 0),
 	);
+	const maxSessionRuntimeMs = Math.max(
+		0,
+		Math.trunc(Number(options.maxSessionRuntimeMs ?? settings.get("task.maxSessionRuntimeMs") ?? 0) || 0),
+	);
 	// TTL before an adopted idle subagent is parked by the lifecycle manager.
 	// <= 0 disables parking (the session stays live until process teardown).
 	const agentIdleTtlMs = Math.trunc(Number(settings.get("task.agentIdleTtlMs") ?? 420_000) || 0);
@@ -2734,6 +2758,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		softRequestBudget,
 		softRequestBudgetNotice,
 		maxRuntimeMs,
+		maxSessionRuntimeMs,
 	});
 	const progress = monitor.progress;
 	let unsubscribe: (() => void) | null = null;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -393,10 +393,12 @@ export interface ExecutorOptions {
 	maxRuntimeMs?: number;
 	/**
 	 * Override the `task.maxSessionRuntimeMs` cumulative wall-clock cap. Unlike
-	 * `maxRuntimeMs`, this budget is intended to survive parked/resumed
-	 * follow-up turns when the caller passes the remaining budget each time.
+	 * `maxRuntimeMs`, this budget survives parked/resumed follow-up turns when
+	 * {@link sessionRuntimeStartedAt} is retained by the child lifecycle.
 	 */
 	maxSessionRuntimeMs?: number;
+	/** Wall-clock creation time of a keep-alive child governed by {@link maxSessionRuntimeMs}. */
+	sessionRuntimeStartedAt?: number;
 	/** Include IRC only when the invocation policy permits collaboration. */
 	enableIrc?: boolean;
 	enableLsp?: boolean;
@@ -934,6 +936,8 @@ interface RunMonitorArgs {
 	maxRuntimeMs: number;
 	/** Cumulative wall-clock cap in ms across follow-up turns; 0 disables the timer. */
 	maxSessionRuntimeMs: number;
+	/** Wall-clock creation time retained by the keep-alive child lifecycle. */
+	sessionRuntimeStartedAt?: number;
 }
 
 /**
@@ -1017,6 +1021,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		softRequestBudgetNotice,
 		maxRuntimeMs,
 		maxSessionRuntimeMs,
+		sessionRuntimeStartedAt,
 	} = args;
 	const startTime = Date.now();
 
@@ -1173,27 +1178,34 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		);
 	}
 
-	// Wall-clock hard limit. Defense-in-depth for the case where a provider stream
-	// hang escapes the inference-layer watchdog (see openai-completions
-	// `isOpenAICompletionsProgressChunk`). Disabled by default; set
-	// `task.maxRuntimeMs > 0` to cap each turn's lifetime. The cumulative
-	// session cap independently bounds total elapsed runtime across resumed
-	// turns, so parking and reviving a child cannot reset its budget.
-	const runtimeCapMs =
-		maxSessionRuntimeMs > 0 ? Math.min(maxRuntimeMs || maxSessionRuntimeMs, maxSessionRuntimeMs) : maxRuntimeMs;
+	// Wall-clock hard limits. The per-turn cap starts here; the cumulative cap
+	// starts when the keep-alive child was created and therefore keeps counting
+	// while the child is idle or parked.
+	const sessionElapsedMs =
+		maxSessionRuntimeMs > 0 ? Math.max(0, startTime - (sessionRuntimeStartedAt ?? startTime)) : 0;
+	const sessionRemainingMs = Math.max(0, maxSessionRuntimeMs - sessionElapsedMs);
+	const runtimeLimit =
+		maxSessionRuntimeMs > 0 && (maxRuntimeMs === 0 || sessionRemainingMs <= maxRuntimeMs)
+			? { kind: "session" as const, delayMs: sessionRemainingMs }
+			: maxRuntimeMs > 0
+				? { kind: "turn" as const, delayMs: maxRuntimeMs }
+				: undefined;
 	let runtimeTimeoutId: NodeJS.Timeout | undefined;
-	if (runtimeCapMs > 0) {
+	if (runtimeLimit?.delayMs === 0) {
+		requestAbort("timeout");
+	} else if (runtimeLimit) {
 		runtimeTimeoutId = setTimeout(() => {
 			if (!resolved) {
 				logger.warn("Subagent runtime limit exceeded; aborting", {
 					id,
 					agent: agent.name,
+					limit: runtimeLimit.kind,
 					maxRuntimeMs,
 					maxSessionRuntimeMs,
 				});
 				requestAbort("timeout");
 			}
-		}, runtimeCapMs);
+		}, runtimeLimit.delayMs);
 	}
 
 	const resolveSignalAbortReason = (): string => {
@@ -1209,7 +1221,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 	};
 	const resolveAbortReasonText = (): string => {
 		if (runtimeLimitExceeded) {
-			if (maxSessionRuntimeMs > 0) {
+			if (runtimeLimit?.kind === "session") {
 				return `Subagent cumulative runtime limit exceeded (task.maxSessionRuntimeMs=${maxSessionRuntimeMs})`;
 			}
 			return `Subagent runtime limit exceeded (task.maxRuntimeMs=${maxRuntimeMs})`;
@@ -1885,6 +1897,7 @@ async function driveSessionToYield(
 
 	try {
 		try {
+			checkAbort();
 			await awaitAbortable(session.prompt(task, { attribution: "agent" }));
 			await awaitAbortable(session.waitForIdle());
 		} catch (err) {
@@ -2518,6 +2531,8 @@ export interface FollowUpTurnOptions {
 	maxRuntimeMs?: number;
 	/** Cumulative wall-clock cap in ms for the child session; 0 disables. */
 	maxSessionRuntimeMs?: number;
+	/** Wall-clock creation time retained across every turn of this child session. */
+	sessionRuntimeStartedAt?: number;
 }
 
 /**
@@ -2556,6 +2571,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		softRequestBudgetNotice: false,
 		maxRuntimeMs: options.maxRuntimeMs ?? 0,
 		maxSessionRuntimeMs: options.maxSessionRuntimeMs ?? 0,
+		sessionRuntimeStartedAt: options.sessionRuntimeStartedAt,
 	});
 
 	if (options.eventBus) {
@@ -2759,6 +2775,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		softRequestBudgetNotice,
 		maxRuntimeMs,
 		maxSessionRuntimeMs,
+		sessionRuntimeStartedAt: options.sessionRuntimeStartedAt,
 	});
 	const progress = monitor.progress;
 	let unsubscribe: (() => void) | null = null;

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -660,6 +660,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			enableLsp: (this.session.enableLsp ?? true) && this.session.settings.get("task.enableLsp"),
 			enableIrc: isIrcEnabled(this.session.settings, this.session.taskDepth ?? 0),
 			maxRuntimeMs: this.session.settings.get("task.maxRuntimeMs"),
+			maxSessionRuntimeMs: this.session.settings.get("task.maxSessionRuntimeMs"),
 		});
 	}
 
@@ -1435,6 +1436,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				enableLsp: (this.session.enableLsp ?? true) && this.session.settings.get("task.enableLsp"),
 				enableIrc: isIrcEnabled(this.session.settings, this.session.taskDepth ?? 0),
 				maxRuntimeMs: this.session.settings.get("task.maxRuntimeMs"),
+				maxSessionRuntimeMs: this.session.settings.get("task.maxSessionRuntimeMs"),
 				signal,
 				onProgress: progress => {
 					latestProgress = { ...progress, recentTools: progress.recentTools.slice() };

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -112,6 +112,8 @@ export interface StructuredSubagentRequest {
 	enableIrc?: boolean;
 	/** `0` disables executor wall-clock timeout. Undefined inherits settings. */
 	maxRuntimeMs?: number;
+	/** `0` disables cumulative child-session runtime. Undefined inherits settings. */
+	maxSessionRuntimeMs?: number;
 	signal?: AbortSignal;
 	onProgress?: (progress: AgentProgress) => void;
 }
@@ -420,6 +422,7 @@ function buildExecutorOptions(
 		enableLsp: policy.enableLsp,
 		enableIrc: policy.enableIrc,
 		maxRuntimeMs: request.maxRuntimeMs,
+		maxSessionRuntimeMs: request.maxSessionRuntimeMs,
 		restrictToolNames,
 		keepAlive: request.keepAlive,
 		signal: request.signal,

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -1446,6 +1446,8 @@ export class VibeSessionRegistry {
 			parentEvalSessionId: session.getEvalSessionId?.() ?? undefined,
 			parentAgentId: session.getAgentId?.() ?? MAIN_AGENT_ID,
 			parentServiceTier: session.getServiceTierByFamily ? (session.getServiceTierByFamily() ?? null) : undefined,
+			maxSessionRuntimeMs: session.settings.get("task.maxSessionRuntimeMs"),
+			sessionRuntimeStartedAt: record.createdAt,
 			keepAlive: true,
 		};
 	}
@@ -1514,6 +1516,8 @@ export class VibeSessionRegistry {
 								onProgress,
 								eventBus: session.eventBus,
 								artifactsDir: session.getSessionFile()?.slice(0, -6),
+								maxSessionRuntimeMs: session.settings.get("task.maxSessionRuntimeMs"),
+								sessionRuntimeStartedAt: record.createdAt,
 							});
 					return await this.#settleTurn(session, manager, record, turn, ownJobId, turnIndex, result);
 				} catch (error) {

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -1505,6 +1505,12 @@ export class VibeSessionRegistry {
 					if (record.childSessionFile && !turnStartedPersisted) {
 						throw new ToolError(`Vibe session "${record.id}" changed parent scope before its turn started.`);
 					}
+					const configuredMaxRuntimeMs = Math.max(
+						0,
+						Math.trunc(Number(session.settings.get("task.maxRuntimeMs")) || 0),
+					);
+					const maxRuntimeMs =
+						configuredMaxRuntimeMs || AgentRegistry.global().get(record.id)?.runtimePolicy?.maxRuntimeMs || 0;
 					const result = options.first
 						? await runSubprocess(await this.#buildSpawnOptions(session, record, message, signal, onProgress))
 						: await runSubagentFollowUpTurn({
@@ -1516,6 +1522,7 @@ export class VibeSessionRegistry {
 								onProgress,
 								eventBus: session.eventBus,
 								artifactsDir: session.getSessionFile()?.slice(0, -6),
+								maxRuntimeMs,
 								maxSessionRuntimeMs: session.settings.get("task.maxSessionRuntimeMs"),
 								sessionRuntimeStartedAt: record.createdAt,
 							});

--- a/packages/coding-agent/test/interactive-mode-title-prewarm.test.ts
+++ b/packages/coding-agent/test/interactive-mode-title-prewarm.test.ts
@@ -87,6 +87,7 @@ describe("InteractiveMode tiny-title prewarm", () => {
 		const prewarm = vi.spyOn(tinyTitleClient, "prewarm").mockImplementation(() => {});
 
 		await mode.init();
+		await new Promise<void>(resolve => setImmediate(resolve));
 
 		expect(prewarm).toHaveBeenCalledWith("lfm2-350m");
 	});
@@ -97,6 +98,7 @@ describe("InteractiveMode tiny-title prewarm", () => {
 		const prewarm = vi.spyOn(tinyTitleClient, "prewarm").mockImplementation(() => {});
 
 		await mode.init();
+		await new Promise<void>(resolve => setImmediate(resolve));
 
 		expect(prewarm).not.toHaveBeenCalled();
 	});

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -204,6 +204,25 @@ describe("runSubprocess soft request budget", () => {
 		});
 	}
 
+	it("applies the cumulative session cap as the active runtime timer", async () => {
+		const id = "SessionCapScout";
+		const handle = createMockSession(({ emit, pushMessage }) => {
+			const message = assistantText("still working", "aborted");
+			pushMessage(message);
+			emit({ type: "message_end", message } as unknown as AgentSessionEvent);
+		});
+		mockCreateAgentSession(handle.session);
+		registerRunning(id, handle.session);
+
+		const result = await runSubprocess({
+			...baseOptions(id),
+			settings: Settings.isolated({ "task.maxSessionRuntimeMs": 1 }),
+		});
+
+		expect(result.aborted).toBe(true);
+		expect(result.abortReason).toContain("task.maxSessionRuntimeMs=1");
+	});
+
 	it("a budget stop drives one forced final yield and finishes as a normal completion", async () => {
 		const id = "BudgetScout";
 		let abortCallsAtReminder: number | undefined;

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -12,6 +12,7 @@ import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import {
+	attachIrcWakeTurnMonitor,
 	resolveSoftRequestBudget,
 	runSubagentFollowUpTurn,
 	runSubprocess,
@@ -39,6 +40,9 @@ interface MockSessionHandle {
 	prompts: Array<{ text: string; options?: PromptOptions }>;
 	abortCalls: () => number;
 	disposeCalls: () => number;
+	ircWakeTurnObserver: () =>
+		| ((records: CustomMessage[]) => ((error?: unknown) => void | Promise<void>) | undefined)
+		| undefined;
 }
 
 function assistantText(text: string, stopReason: "stop" | "aborted" = "stop") {
@@ -146,6 +150,7 @@ function createMockSession(
 		session: session as AgentSession,
 		prompts,
 		abortCalls: () => abortCount,
+		ircWakeTurnObserver: () => ircWakeTurnObserver,
 		disposeCalls: () => disposeCount,
 	};
 }
@@ -326,6 +331,118 @@ describe("runSubprocess soft request budget", () => {
 
 		expect(result.aborted).toBe(true);
 		expect(result.abortReason).toContain("task.maxRuntimeMs=20");
+	});
+
+	it("terminal-releases the running follow-up ref before a cumulative-timeout agent_end can restore idle", async () => {
+		vi.useFakeTimers();
+		try {
+			const id = "RunningSessionCapScout";
+			const promptGate = Promise.withResolvers<void>();
+			const handle = createMockSession(async () => {
+				await promptGate.promise;
+			});
+			let idleRestoreAccepted: boolean | undefined;
+			registerRunning(id, handle.session);
+			const ref = AgentRegistry.global().get(id);
+			if (!ref) throw new Error("Expected registered subagent");
+			const startedAt = Date.now();
+			AgentLifecycleManager.global().adopt(
+				id,
+				{
+					idleTtlMs: 0,
+					runtimePolicy: {
+						maxRuntimeMs: 0,
+						sessionRuntimeLimit: { maxSessionRuntimeMs: 20, startedAt },
+					},
+				},
+				ref,
+			);
+			vi.spyOn(handle.session, "abort").mockImplementation(async () => {
+				expect(AgentRegistry.global().get(id)).toBeUndefined();
+				idleRestoreAccepted = AgentRegistry.global().setStatus(id, "idle", ref);
+				promptGate.resolve();
+			});
+
+			const pending = runSubagentFollowUpTurn({
+				id,
+				agent: baseAgent,
+				message: "continue",
+				maxSessionRuntimeMs: 20,
+				sessionRuntimeStartedAt: startedAt,
+			});
+			await Promise.resolve();
+			vi.advanceTimersByTime(20);
+			const result = await pending;
+
+			expect(result.aborted).toBe(true);
+			expect(result.abortReason).toBe("Subagent cumulative runtime limit exceeded (task.maxSessionRuntimeMs=20)");
+			expect(idleRestoreAccepted).toBe(false);
+			expect(AgentRegistry.global().get(id)).toBeUndefined();
+			expect(AgentLifecycleManager.global().has(id, ref)).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("uses the live IRC policy and terminal-releases the exact ref when its cumulative cap fires", async () => {
+		vi.useFakeTimers();
+		try {
+			const id = "IrcSessionCapScout";
+			const handle = createMockSession(async () => {});
+			registerRunning(id, handle.session);
+			const ref = AgentRegistry.global().get(id);
+			if (!ref) throw new Error("Expected registered subagent");
+			AgentRegistry.global().setStatus(id, "idle", ref);
+			const startedAt = Date.now();
+			AgentLifecycleManager.global().adopt(
+				id,
+				{
+					idleTtlMs: 0,
+					runtimePolicy: {
+						maxRuntimeMs: 50,
+						sessionRuntimeLimit: { maxSessionRuntimeMs: 20, startedAt },
+					},
+				},
+				ref,
+			);
+			let idleRestoreAccepted: boolean | undefined;
+			const abortSpy = vi.spyOn(handle.session, "abort").mockImplementation(async () => {
+				expect(AgentRegistry.global().get(id)).toBeUndefined();
+				idleRestoreAccepted = AgentRegistry.global().setStatus(id, "idle", ref);
+			});
+			attachIrcWakeTurnMonitor(handle.session, {
+				id,
+				agent: baseAgent,
+				maxRuntimeMs: 5,
+			});
+			const observer = handle.ircWakeTurnObserver();
+			if (!observer) throw new Error("Expected IRC wake observer");
+			const finishObservation = observer([
+				{
+					role: "custom",
+					customType: "irc:incoming",
+					content: "continue",
+					display: true,
+					details: { message: "continue" },
+					timestamp: Date.now(),
+				},
+			]);
+
+			vi.advanceTimersByTime(5);
+			await Promise.resolve();
+			expect(abortSpy).not.toHaveBeenCalled();
+			expect(AgentRegistry.global().get(id)).toBe(ref);
+
+			vi.advanceTimersByTime(15);
+			await Promise.resolve();
+			expect(abortSpy).toHaveBeenCalledTimes(1);
+			expect(idleRestoreAccepted).toBe(false);
+			expect(AgentRegistry.global().get(id)).toBeUndefined();
+			expect(AgentLifecycleManager.global().has(id, ref)).toBe(false);
+			await finishObservation?.();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("rejects an expired Vibe revival before running the parked session reviver", async () => {

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -11,7 +11,11 @@ import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
-import { resolveSoftRequestBudget, runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
+import {
+	resolveSoftRequestBudget,
+	runSubagentFollowUpTurn,
+	runSubprocess,
+} from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -204,25 +208,68 @@ describe("runSubprocess soft request budget", () => {
 		});
 	}
 
-	it("applies the cumulative session cap as the active runtime timer", async () => {
+	it("keeps the cumulative session cap across follow-up turns", async () => {
 		const id = "SessionCapScout";
-		const promptGate = Promise.withResolvers<void>();
-		const handle = createMockSession(async () => {
-			await promptGate.promise;
+		const followUpGate = Promise.withResolvers<void>();
+		let followUpPending = false;
+		const handle = createMockSession(async ({ promptIndex, emit, pushMessage }) => {
+			if (promptIndex === 1) {
+				const yieldMessage = {
+					role: "assistant" as const,
+					content: [
+						{
+							type: "toolCall" as const,
+							id: "tool-initial-yield",
+							name: "yield",
+							arguments: { result: { data: { report: "first turn complete" } } },
+						},
+					],
+					stopReason: "toolUse" as const,
+				};
+				pushMessage(yieldMessage);
+				emit({ type: "message_end", message: yieldMessage } as unknown as AgentSessionEvent);
+				emit({
+					type: "tool_execution_end",
+					toolCallId: "tool-initial-yield",
+					toolName: "yield",
+					result: {
+						content: [{ type: "text", text: "Result submitted." }],
+						details: { status: "success", data: { report: "first turn complete" } },
+					},
+					isError: false,
+				} as AgentSessionEvent);
+				return;
+			}
+			await followUpGate.promise;
 		});
 		vi.spyOn(handle.session, "abort").mockImplementation(async () => {
-			promptGate.resolve();
+			if (followUpPending) followUpGate.resolve();
 		});
 		mockCreateAgentSession(handle.session);
 		registerRunning(id, handle.session);
 
-		const result = await runSubprocess({
+		const sessionRuntimeStartedAt = Date.now();
+		const first = await runSubprocess({
 			...baseOptions(id),
-			settings: Settings.isolated({ "task.maxSessionRuntimeMs": 1 }),
+			keepAlive: true,
+			maxSessionRuntimeMs: 100,
+			sessionRuntimeStartedAt,
+		});
+		expect(first.aborted).toBe(false);
+
+		await Bun.sleep(110);
+		followUpPending = true;
+		const followUp = await runSubagentFollowUpTurn({
+			id,
+			agent: baseAgent,
+			message: "continue",
+			maxSessionRuntimeMs: 100,
+			sessionRuntimeStartedAt,
 		});
 
-		expect(result.aborted).toBe(true);
-		expect(result.abortReason).toContain("task.maxSessionRuntimeMs=1");
+		expect(handle.prompts).toHaveLength(1);
+		expect(followUp.aborted).toBe(true);
+		expect(followUp.abortReason).toContain("task.maxSessionRuntimeMs=100");
 	});
 
 	it("a budget stop drives one forced final yield and finishes as a normal completion", async () => {

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -46,7 +46,7 @@ function createMockSession(
 		promptIndex: number;
 		emit: (event: AgentSessionEvent) => void;
 		pushMessage: (message: unknown) => void;
-	}) => void,
+	}) => void | Promise<void>,
 ): MockSessionHandle {
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
 	const messages: unknown[] = [];
@@ -81,7 +81,7 @@ function createMockSession(
 		prompt: async (text: string, options?: PromptOptions) => {
 			promptIndex += 1;
 			prompts.push({ text, options });
-			onPrompt({ promptIndex, emit, pushMessage: message => messages.push(message) });
+			await onPrompt({ promptIndex, emit, pushMessage: message => messages.push(message) });
 			return true;
 		},
 		waitForIdle: async () => {},
@@ -206,10 +206,12 @@ describe("runSubprocess soft request budget", () => {
 
 	it("applies the cumulative session cap as the active runtime timer", async () => {
 		const id = "SessionCapScout";
-		const handle = createMockSession(({ emit, pushMessage }) => {
-			const message = assistantText("still working", "aborted");
-			pushMessage(message);
-			emit({ type: "message_end", message } as unknown as AgentSessionEvent);
+		const promptGate = Promise.withResolvers<void>();
+		const handle = createMockSession(async () => {
+			await promptGate.promise;
+		});
+		vi.spyOn(handle.session, "abort").mockImplementation(async () => {
+			promptGate.resolve();
 		});
 		mockCreateAgentSession(handle.session);
 		registerRunning(id, handle.session);

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -248,23 +248,29 @@ describe("runSubprocess soft request budget", () => {
 		mockCreateAgentSession(handle.session);
 		registerRunning(id, handle.session);
 
-		const sessionRuntimeStartedAt = Date.now();
 		const first = await runSubprocess({
 			...baseOptions(id),
 			keepAlive: true,
-			maxSessionRuntimeMs: 100,
-			sessionRuntimeStartedAt,
+			maxSessionRuntimeMs: 5_000,
+			sessionRuntimeStartedAt: Date.now(),
 		});
 		expect(first.aborted).toBe(false);
 
-		await Bun.sleep(110);
+		const ref = AgentRegistry.global().get(id);
+		if (!ref) throw new Error("Expected adopted subagent");
+		AgentRegistry.global().setRuntimePolicy(
+			id,
+			{
+				maxRuntimeMs: ref.runtimePolicy?.maxRuntimeMs ?? 0,
+				sessionRuntimeLimit: { maxSessionRuntimeMs: 100, startedAt: Date.now() - 101 },
+			},
+			ref,
+		);
 		followUpPending = true;
 		const followUp = await runSubagentFollowUpTurn({
 			id,
 			agent: baseAgent,
 			message: "continue",
-			maxSessionRuntimeMs: 100,
-			sessionRuntimeStartedAt,
 		});
 
 		expect(handle.prompts).toHaveLength(1);
@@ -272,6 +278,94 @@ describe("runSubprocess soft request budget", () => {
 		expect(followUp.abortReason).toContain("task.maxSessionRuntimeMs=100");
 	});
 
+	it("preserves a registered per-turn cap when the resumed caller has it disabled", async () => {
+		const id = "RestoredTurnCapScout";
+		const promptGate = Promise.withResolvers<void>();
+		const handle = createMockSession(async () => {
+			await promptGate.promise;
+		});
+		vi.spyOn(handle.session, "abort").mockImplementation(async () => {
+			promptGate.resolve();
+		});
+		registerRunning(id, handle.session);
+		const ref = AgentRegistry.global().get(id);
+		if (!ref) throw new Error("Expected registered subagent");
+		AgentRegistry.global().setRuntimePolicy(id, { maxRuntimeMs: 20 }, ref);
+
+		const result = await runSubagentFollowUpTurn({
+			id,
+			agent: baseAgent,
+			message: "continue",
+			maxRuntimeMs: 0,
+		});
+
+		expect(result.aborted).toBe(true);
+		expect(result.abortReason).toContain("task.maxRuntimeMs=20");
+	});
+
+	it("rejects an expired Vibe revival before running the parked session reviver", async () => {
+		const id = "ExpiredVibe";
+		const reviver = vi.fn(async () => createMockSession(async () => {}).session);
+		const ref = AgentRegistry.global().register({
+			id,
+			displayName: id,
+			kind: "sub",
+			session: null,
+			sessionFile: "/tmp/expired-vibe.jsonl",
+			status: "parked",
+		});
+		const sessionRuntimeStartedAt = Date.now() - 101;
+		AgentLifecycleManager.global().adopt(
+			id,
+			{
+				idleTtlMs: 0,
+				revive: reviver,
+				runtimePolicy: {
+					maxRuntimeMs: 0,
+					sessionRuntimeLimit: { maxSessionRuntimeMs: 100, startedAt: sessionRuntimeStartedAt },
+				},
+			},
+			ref,
+		);
+
+		const result = await runSubagentFollowUpTurn({
+			id,
+			agent: baseAgent,
+			message: "continue",
+			maxSessionRuntimeMs: 100,
+			sessionRuntimeStartedAt,
+		});
+
+		expect(reviver).not.toHaveBeenCalled();
+		expect(result.aborted).toBe(true);
+		expect(result.abortReason).toBe("Subagent cumulative runtime limit exceeded (task.maxSessionRuntimeMs=100)");
+		expect(AgentRegistry.global().get(id)).toBeUndefined();
+		expect(AgentLifecycleManager.global().has(id, ref)).toBe(false);
+	});
+
+	it("reports the per-turn timer when it expires before the cumulative deadline", async () => {
+		const id = "TurnCapScout";
+		const promptGate = Promise.withResolvers<void>();
+		const handle = createMockSession(async () => {
+			await promptGate.promise;
+		});
+		vi.spyOn(handle.session, "abort").mockImplementation(async () => {
+			promptGate.resolve();
+		});
+		mockCreateAgentSession(handle.session);
+		registerRunning(id, handle.session);
+
+		const result = await runSubprocess({
+			...baseOptions(id),
+			keepAlive: false,
+			maxRuntimeMs: 20,
+			maxSessionRuntimeMs: 1_000,
+			sessionRuntimeStartedAt: Date.now(),
+		});
+
+		expect(result.aborted).toBe(true);
+		expect(result.abortReason).toBe("Subagent runtime limit exceeded (task.maxRuntimeMs=20)");
+	});
 	it("a budget stop drives one forced final yield and finishes as a normal completion", async () => {
 		const id = "BudgetScout";
 		let abortCallsAtReminder: number | undefined;

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -303,6 +303,31 @@ describe("runSubprocess soft request budget", () => {
 		expect(result.abortReason).toContain("task.maxRuntimeMs=20");
 	});
 
+	it("uses a positive per-turn cap supplied by the resumed caller", async () => {
+		const id = "UpdatedTurnCapScout";
+		const promptGate = Promise.withResolvers<void>();
+		const handle = createMockSession(async () => {
+			await promptGate.promise;
+		});
+		vi.spyOn(handle.session, "abort").mockImplementation(async () => {
+			promptGate.resolve();
+		});
+		registerRunning(id, handle.session);
+		const ref = AgentRegistry.global().get(id);
+		if (!ref) throw new Error("Expected registered subagent");
+		AgentRegistry.global().setRuntimePolicy(id, { maxRuntimeMs: 1_000 }, ref);
+
+		const result = await runSubagentFollowUpTurn({
+			id,
+			agent: baseAgent,
+			message: "continue",
+			maxRuntimeMs: 20,
+		});
+
+		expect(result.aborted).toBe(true);
+		expect(result.abortReason).toContain("task.maxRuntimeMs=20");
+	});
+
 	it("rejects an expired Vibe revival before running the parked session reviver", async () => {
 		const id = "ExpiredVibe";
 		const reviver = vi.fn(async () => createMockSession(async () => {}).session);


### PR DESCRIPTION
## What

Add `task.maxSessionRuntimeMs` as a cumulative wall-clock limit for keep-alive subagent sessions. When configured, the executor gives it precedence over the per-turn `task.maxRuntimeMs` timer and reports cumulative expiry with a distinct reason. The setting is threaded through task spawns, structured subagent requests, and follow-up turn options.

I reviewed this change; it bounds a child session's total lifetime instead of letting each resumed turn restart the runtime clock.

## Why

`task.maxRuntimeMs` is armed per invocation. A parked or revived child can therefore accumulate unbounded total runtime across follow-up turns while staying under every individual timer. The cumulative setting gives operators a separate control for total child lifetime without changing the default behavior.

## Testing

- `bun test test/task/executor-soft-budget.test.ts`
- `bun --cwd=packages/coding-agent run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)