### PR TITLE
fix(coding-agent): spill oversized read results to artifacts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed the `read` exemption from the centralized artifact spill wrapper. Oversized read results now persist to a recoverable session artifact and return the configured inline head/tail instead of bypassing the threshold shared by other tools.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -674,7 +674,6 @@ async function spillLargeResultToArtifact(
 ): Promise<AgentToolResult> {
 	const sessionManager = context?.sessionManager;
 	if (!sessionManager) return result;
-	if (toolName === "read") return result;
 	const { threshold, tailBytes, tailLines, headBytes } = getSpillConfig(context?.settings);
 
 	// Skip if tool already saved an artifact

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -680,6 +680,17 @@ async function spillLargeResultToArtifact(
 	const existingMeta: OutputMeta | undefined = result.details?.meta;
 	if (existingMeta?.truncation?.artifactId) return result;
 
+	// Reading an artifact already addresses recoverable full output. Spilling that
+	// read would only create a redundant artifact containing another artifact's
+	// page (and can repeat indefinitely on subsequent reads).
+	if (
+		toolName === "read" &&
+		existingMeta?.source?.type === "internal" &&
+		existingMeta.source.value.startsWith("artifact://")
+	) {
+		return result;
+	}
+
 	// Measure total text content
 	const textParts: string[] = [];
 	for (const block of result.content) {
@@ -759,6 +770,7 @@ async function spillLargeResultToArtifact(
 			elidedLines,
 			elidedBytes,
 			artifactId,
+			nextOffset: existingMeta?.truncation?.nextOffset,
 		};
 	} else {
 		const shownStart = truncated.totalLines - outputLines + 1;
@@ -772,6 +784,7 @@ async function spillLargeResultToArtifact(
 			maxBytes: tailBytes,
 			shownRange: { start: shownStart, end: truncated.totalLines },
 			artifactId,
+			nextOffset: existingMeta?.truncation?.nextOffset,
 		};
 	}
 

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -637,6 +637,35 @@ describe("Coding Agent Tools", () => {
 			expect(result.details?.truncation?.outputLines).toBe(defaultLimit);
 		});
 
+		it("should spill oversized read output to an artifact", async () => {
+			const testFile = path.join(testDir, "oversized-read.txt");
+			const line = "0123456789".repeat(20);
+			fs.writeFileSync(testFile, `${Array.from({ length: 600 }, () => line).join("\n")}\n`);
+			const spillSettings = Settings.isolated({
+				"tools.artifactSpillThreshold": 20,
+				"tools.artifactTailBytes": 1,
+				"tools.artifactTailLines": 10,
+				"tools.artifactHeadBytes": 0,
+			});
+			const spillSession = createTestToolSession(testDir, spillSettings);
+			const spillReadTool = wrapToolWithMetaNotice(new ReadTool(spillSession));
+			const context = { ...createTestToolContext(["read"]), settings: spillSettings };
+
+			const result = await spillReadTool.execute(
+				"test-call-read-spill",
+				{ path: testFile },
+				undefined,
+				undefined,
+				context,
+			);
+			const truncation = result.details?.meta?.truncation;
+			const output = getTextOutput(result);
+
+			expect(truncation?.artifactId).toBeDefined();
+			expect(Buffer.byteLength(output, "utf-8")).toBeLessThan(20 * 1024);
+			expect(output).toContain("artifact://");
+		});
+
 		it("should render directories as a two-level tree without capping root entries", async () => {
 			const childDir = path.join(testDir, "child");
 			const base = Date.now() - 60_000;

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -237,7 +237,7 @@ function createTestToolSession(
 		getArtifactsDir: () => sessionDir,
 		allocateOutputArtifact: async (toolType: string) => {
 			fs.mkdirSync(sessionDir, { recursive: true });
-			const id = `artifact-${++artifactCounter}`;
+			const id = String(++artifactCounter);
 			return { id, path: path.join(sessionDir, `${id}.${toolType}.log`) };
 		},
 		settings,
@@ -640,30 +640,60 @@ describe("Coding Agent Tools", () => {
 		it("should spill oversized read output to an artifact", async () => {
 			const testFile = path.join(testDir, "oversized-read.txt");
 			const line = "0123456789".repeat(20);
-			fs.writeFileSync(testFile, `${Array.from({ length: 600 }, () => line).join("\n")}\n`);
+			fs.writeFileSync(testFile, `${Array.from({ length: 3500 }, () => line).join("\n")}\n`);
 			const spillSettings = Settings.isolated({
 				"tools.artifactSpillThreshold": 20,
 				"tools.artifactTailBytes": 1,
 				"tools.artifactTailLines": 10,
 				"tools.artifactHeadBytes": 0,
 			});
-			const spillSession = createTestToolSession(testDir, spillSettings);
+			const defaultLimit = spillSettings.get("read.defaultLimit");
+			const spillManager = SessionManager.create(testDir, path.join(testDir, "spill-sessions"));
+			await spillManager.ensureOnDisk();
+			const spillSession = createTestToolSession(testDir, spillSettings, {
+				getSessionFile: () => spillManager.getSessionFile() ?? null,
+				getArtifactsDir: () => spillManager.getArtifactsDir(),
+				localProtocolOptions: {
+					getArtifactsDir: () => spillManager.getArtifactsDir(),
+					getSessionId: () => spillManager.getSessionId(),
+				},
+			});
 			const spillReadTool = wrapToolWithMetaNotice(new ReadTool(spillSession));
-			const context = { ...createTestToolContext(["read"]), settings: spillSettings };
+			const context = {
+				...createTestToolContext(["read"]),
+				settings: spillSettings,
+				sessionManager: spillManager,
+			};
 
-			const result = await spillReadTool.execute(
-				"test-call-read-spill",
-				{ path: testFile },
-				undefined,
-				undefined,
-				context,
-			);
-			const truncation = result.details?.meta?.truncation;
-			const output = getTextOutput(result);
+			try {
+				const result = await spillReadTool.execute(
+					"test-call-read-spill",
+					{ path: testFile },
+					undefined,
+					undefined,
+					context,
+				);
+				const truncation = result.details?.meta?.truncation;
+				const output = getTextOutput(result);
 
-			expect(truncation?.artifactId).toBeDefined();
-			expect(Buffer.byteLength(output, "utf-8")).toBeLessThan(20 * 1024);
-			expect(output).toContain("artifact://");
+				expect(truncation?.artifactId).toBeDefined();
+				expect(Buffer.byteLength(output, "utf-8")).toBeLessThan(20 * 1024);
+				expect(output).toContain("artifact://");
+				expect(truncation?.nextOffset).toBe(defaultLimit + 1);
+
+				const saveArtifact = vi.spyOn(spillManager, "saveArtifact");
+				const artifactResult = await spillReadTool.execute(
+					"test-call-read-spilled-artifact",
+					{ path: `artifact://${truncation?.artifactId}` },
+					undefined,
+					undefined,
+					context,
+				);
+				expect(getTextOutput(artifactResult)).toContain(line);
+				expect(saveArtifact).not.toHaveBeenCalled();
+			} finally {
+				await spillManager.close();
+			}
 		});
 
 		it("should render directories as a two-level tree without capping root entries", async () => {


### PR DESCRIPTION
## What

Remove the `read` exemption from the centralized artifact spill wrapper. Oversized read results now use the same threshold, head/tail truncation, and recoverable `artifact://` link as other tools.

I reviewed this change; it stops a single large file read from bypassing the configured output budget and consuming an outsized share of model context.

## Why

The wrapper explicitly returned early for `read`, while grep, search, hub, and job results were bounded by the shared spill policy. That made `read` the largest uncontrolled source of tool output and left large file contents inline even after truncation metadata was produced.

## Testing

- `bun test test/tools.test.ts --filter "spill oversized read output"`
- `bun --cwd=packages/coding-agent run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)