### PR TITLE
fix(web-search): extract duckduckgo result timestamps for date bounds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed DuckDuckGo web search silently ignoring `after:`/`before:` date bounds: DuckDuckGo does not parse date operators, so the provider relies on the shared post-filter to enforce them, but `parseHtmlResults()` discarded the ISO timestamps DuckDuckGo now emits in each result row — every source was treated as undated and passed the filter. The parser now extracts those timestamps into `publishedDate`/`ageSeconds` so date bounds are honored ([#7115](https://github.com/can1357/oh-my-pi/issues/7115)).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/web/search/providers/duckduckgo.ts
+++ b/packages/coding-agent/src/web/search/providers/duckduckgo.ts
@@ -3,7 +3,7 @@ import type { SearchResponse, SearchSource } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import type { QuerySyntax } from "../query";
 import { formatScraperQuery } from "../query";
-import { clampNumResults } from "../utils";
+import { clampNumResults, dateToAgeSeconds } from "../utils";
 import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
 import { browserFetch } from "./browser-page";
@@ -35,6 +35,8 @@ interface ParsedResult {
 	title: string;
 	url: string;
 	snippet?: string;
+	/** ISO timestamp lifted from the result row, when DDG emits one. */
+	publishedDate?: string;
 }
 
 /**
@@ -82,6 +84,21 @@ function unwrapResultUrl(href: string): string | undefined {
 }
 
 /**
+ * Lift a result row's publication timestamp from DDG markup. Recent DDG HTML
+ * renders it as a bare `<span>&nbsp; &nbsp; 2026-07-30T20:19:00.0000000</span>`
+ * inside `result__extras__url`. Other spans in the row (`result__icon`) decode
+ * to non-date text, so we scan every span and keep the first whose decoded
+ * content is an ISO date — undated rows return `undefined`.
+ */
+function extractPublishedDate(block: string): string | undefined {
+	for (const match of block.matchAll(/<span\b[^>]*>([\s\S]*?)<\/span>/gi)) {
+		const text = decodeHtmlText(match[1]);
+		if (/^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}|$)/.test(text)) return text;
+	}
+	return undefined;
+}
+
+/**
  * Walk the HTML page and pull out result blocks in document order.
  *
  * DDG renders each result inside a `<div class="result …">` container with
@@ -106,7 +123,12 @@ function parseHtmlResults(html: string): ParsedResult[] {
 		if (!titleText) continue;
 		const snippet = snippetRe.exec(block);
 		const snippetText = snippet ? decodeHtmlText(snippet[1]) : undefined;
-		results.push({ title: titleText, url, snippet: snippetText || undefined });
+		results.push({
+			title: titleText,
+			url,
+			snippet: snippetText || undefined,
+			publishedDate: extractPublishedDate(block),
+		});
 	}
 	return results;
 }
@@ -187,7 +209,13 @@ export async function searchDuckDuckGo(params: SearchParams): Promise<SearchResp
 	for (const result of parsed) {
 		if (seen.has(result.url)) continue;
 		seen.add(result.url);
-		sources.push({ title: result.title, url: result.url, snippet: result.snippet });
+		sources.push({
+			title: result.title,
+			url: result.url,
+			snippet: result.snippet,
+			publishedDate: result.publishedDate,
+			ageSeconds: dateToAgeSeconds(result.publishedDate),
+		});
 		if (sources.length >= numResults) break;
 	}
 

--- a/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
+++ b/packages/coding-agent/test/tools/web-search-duckduckgo.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "bun:test";
+import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
+import type { SearchParams } from "@oh-my-pi/pi-coding-agent/web/search/providers/base";
+import { searchDuckDuckGo } from "@oh-my-pi/pi-coding-agent/web/search/providers/duckduckgo";
+import { applyQueryConstraints, parseSearchQuery } from "@oh-my-pi/pi-coding-agent/web/search/query";
+
+const fakeAuthStorage = {
+	async getApiKey() {
+		throw new Error("DuckDuckGo search must not request API keys");
+	},
+	resolver() {
+		throw new Error("DuckDuckGo search must not request credential resolvers");
+	},
+	hasAuth() {
+		throw new Error("DuckDuckGo search must not check auth");
+	},
+} as unknown as AuthStorage;
+
+function makeParams(query: string, fetch: FetchImpl): SearchParams {
+	return {
+		query,
+		authStorage: fakeAuthStorage,
+		systemPrompt: "DuckDuckGo search test prompt",
+		fetch,
+	};
+}
+
+/** One result block in the shape DuckDuckGo's no-JS HTML page renders live. */
+function resultBlock(url: string, title: string, snippet: string, timestamp?: string): string {
+	return `
+		<div class="result results_links results_links_deep web-result ">
+			<div class="links_main links_deep result__body">
+				<h2 class="result__title">
+					<a rel="nofollow" class="result__a" href="${url}">${title}</a>
+				</h2>
+				<div class="result__extras">
+					<div class="result__extras__url">
+						<span class="result__icon">
+							<a rel="nofollow" href="${url}"><img class="result__icon__img" width="16" height="16" alt="" src="//external-content.duckduckgo.com/ip3/example.ico" name="i15" /></a>
+						</span>
+						<a class="result__url" href="${url}">${url}</a>
+						${timestamp ? `<span>&nbsp; &nbsp; ${timestamp}</span>` : ""}
+					</div>
+				</div>
+				<a class="result__snippet" href="${url}">${snippet}</a>
+				<div class="clear"></div>
+			</div>
+		</div>`;
+}
+
+function resultsPage(blocks: string): string {
+	return `<!DOCTYPE html><html><body><div id="links" class="results">${blocks}<div class="nav-link"></div></div></body></html>`;
+}
+
+describe("DuckDuckGo web search provider", () => {
+	it("extracts result timestamps into publishedDate/ageSeconds so date bounds can be enforced", async () => {
+		const html = resultsPage(
+			[
+				resultBlock("https://example.com/fresh", "Fresh page", "A recent article.", "2026-07-30T20:19:00.0000000"),
+				resultBlock("https://example.com/undated", "Undated page", "No timestamp here."),
+			].join(""),
+		);
+		const fetchMock: FetchImpl = () => Promise.resolve(new Response(html, { status: 200 }));
+
+		const response = await searchDuckDuckGo(makeParams("weather", fetchMock));
+
+		expect(response.provider).toBe("duckduckgo");
+		expect(response.sources).toHaveLength(2);
+
+		const dated = response.sources[0];
+		expect(dated.url).toBe("https://example.com/fresh");
+		expect(dated.publishedDate).toBe("2026-07-30T20:19:00.0000000");
+		expect(dated.ageSeconds).toBeGreaterThan(0);
+
+		const undated = response.sources[1];
+		expect(undated.url).toBe("https://example.com/undated");
+		expect(undated.publishedDate).toBeUndefined();
+		expect(undated.ageSeconds).toBeUndefined();
+	});
+
+	it("honors after:/before: bounds against DuckDuckGo's extracted timestamps", async () => {
+		const html = resultsPage(
+			[
+				resultBlock(
+					"https://example.com/in-range",
+					"In range",
+					"Within the window.",
+					"2026-07-10T09:00:00.0000000",
+				),
+				resultBlock(
+					"https://example.com/too-new",
+					"Too new",
+					"After the window ends.",
+					"2026-07-30T09:00:00.0000000",
+				),
+				resultBlock("https://example.com/undated", "Undated", "No timestamp, cannot prove violation."),
+			].join(""),
+		);
+		const fetchMock: FetchImpl = () => Promise.resolve(new Response(html, { status: 200 }));
+
+		const query = "weather after:2026-07-01 before:2026-07-15";
+		const response = await searchDuckDuckGo(makeParams(query, fetchMock));
+		const { sources } = applyQueryConstraints(response.sources, parseSearchQuery(query));
+
+		const urls = sources.map(s => s.url);
+		expect(urls).toContain("https://example.com/in-range");
+		expect(urls).toContain("https://example.com/undated");
+		expect(urls).not.toContain("https://example.com/too-new");
+	});
+});


### PR DESCRIPTION
## Repro
`web_search` with the DuckDuckGo provider silently ignores absolute `after:`/`before:` date constraints. Comparing `weather` against `weather after:2026-07-01 before:2026-07-15` yields the same results — the July 30 result is never dropped from a window ending July 15. A provider-level test running `searchDuckDuckGo` over DuckDuckGo's live result markup reproduces it: the returned `SearchSource` has `publishedDate === undefined`.

```
bun test test/tools/web-search-duckduckgo.test.ts
```

## Cause
DuckDuckGo's no-JS HTML frontend does not parse date operators, so `DDG_QUERY_SYNTAX` strips them and the provider relies on the shared lenient post-filter (`applyQueryConstraints` in `web/search/index.ts`) to enforce them. That filter treats a source with no resolvable date as passing any date bound (a missing date can't prove a violation). But `parseHtmlResults()` in `packages/coding-agent/src/web/search/providers/duckduckgo.ts` only extracted title/url/snippet and discarded the ISO timestamp DuckDuckGo now renders in each row as a bare `<span>&nbsp; &nbsp; 2026-07-30T20:19:00.0000000</span>` inside `result__extras__url`. Every source was therefore undated and passed the date filter unconditionally.

## Fix
- Added `extractPublishedDate()` — scans each result block's `<span>` nodes and keeps the first whose decoded content is an ISO date (the `result__icon` span decodes to non-date text and is skipped).
- `parseHtmlResults()` now records `publishedDate` on each `ParsedResult`.
- `searchDuckDuckGo()` maps `publishedDate` and `dateToAgeSeconds(publishedDate)` onto the `SearchSource`, matching every other provider, so `applyQueryConstraints` can honor `after:`/`before:`.

## Verification
`bun test test/tools/web-search-duckduckgo.test.ts` — 2 pass, 11 assertions. One test asserts timestamps land in `publishedDate`/`ageSeconds` (undated rows stay undefined); the other pipes the sources through `applyQueryConstraints` with `after:2026-07-01 before:2026-07-15` and confirms the out-of-range dated result is dropped while in-range and undated sources survive. Markup shape confirmed against live `https://html.duckduckgo.com/html/`. `bun test test/web/search/query.test.ts` and `test/tools/web-search-mojeek.test.ts` still pass. Fixes #7115