### PR TITLE
feat(task): stop non-converging repair loops

### DIFF
--- a/packages/ai/src/utils/tool-call-loop-guard.ts
+++ b/packages/ai/src/utils/tool-call-loop-guard.ts
@@ -11,6 +11,11 @@ export interface ToolCallLoopGuardOptions {
 	readonly exemptTools: readonly string[];
 }
 
+/** Normalizes configured repetition thresholds for every tool-loop detector. */
+export function normalizeToolCallLoopThreshold(threshold: number): number {
+	return Number.isFinite(threshold) ? Math.max(1, Math.trunc(threshold)) : 1;
+}
+
 /** A completed assistant turn plus the tool results it produced. */
 export interface ToolCallLoopTurn {
 	readonly message: AssistantMessage;
@@ -26,9 +31,9 @@ export interface RepeatedToolCallDetection {
 	readonly argumentsSummary: string;
 }
 
-function canonicalizeToolCallValue(value: unknown): unknown {
+function canonicalizeToolCallValue(value: unknown, stripIntentFields: boolean): unknown {
 	if (Array.isArray(value)) {
-		return value.map(item => canonicalizeToolCallValue(item));
+		return value.map(item => canonicalizeToolCallValue(item, stripIntentFields));
 	}
 	if (!value || typeof value !== "object") {
 		return value;
@@ -37,10 +42,27 @@ function canonicalizeToolCallValue(value: unknown): unknown {
 	const input = value as Record<string, unknown>;
 	const output: Record<string, unknown> = {};
 	for (const key of Object.keys(input).sort()) {
-		if (key === INTENT_FIELD || key === LEGACY_INTENT_FIELD) continue;
-		output[key] = canonicalizeToolCallValue(input[key]);
+		if (stripIntentFields && (key === INTENT_FIELD || key === LEGACY_INTENT_FIELD)) continue;
+		output[key] = canonicalizeToolCallValue(input[key], stripIntentFields);
 	}
 	return output;
+}
+
+export interface CanonicalizeToolCallJsonOptions {
+	/** Strip harness-only intent fields from tool arguments. Keep false for arbitrary tool results. */
+	stripIntentFields?: boolean;
+}
+
+/** Produces a recursively key-sorted JSON representation shared by tool-loop detectors. */
+export function canonicalizeToolCallJson(
+	value: unknown,
+	options: CanonicalizeToolCallJsonOptions = {},
+): string | undefined {
+	try {
+		return JSON.stringify(canonicalizeToolCallValue(value, options.stripIntentFields === true));
+	} catch {
+		return undefined;
+	}
 }
 
 function summarizeText(text: string, limit: number): string {
@@ -64,7 +86,6 @@ function summarizeToolResult(toolResults: readonly ToolResultMessage[], toolCall
 	return summarizeText(textParts.join("\n"), RESULT_SUMMARY_LIMIT);
 }
 
-/** Detects consecutive identical assistant tool calls across model turns. */
 export class ToolCallLoopGuard {
 	#threshold: number;
 	#exemptTools: ReadonlySet<string>;
@@ -72,7 +93,7 @@ export class ToolCallLoopGuard {
 	#count = 0;
 
 	constructor(options: ToolCallLoopGuardOptions) {
-		this.#threshold = Math.max(1, Math.trunc(options.threshold));
+		this.#threshold = normalizeToolCallLoopThreshold(options.threshold);
 		this.#exemptTools = new Set(options.exemptTools);
 	}
 
@@ -86,7 +107,7 @@ export class ToolCallLoopGuard {
 		}
 
 		const toolCall = toolCalls[0]!;
-		const canonicalArgs = JSON.stringify(canonicalizeToolCallValue(toolCall.arguments));
+		const canonicalArgs = canonicalizeToolCallJson(toolCall.arguments, { stripIntentFields: true }) ?? "";
 		const hash = `${toolCall.name}:${canonicalArgs}`;
 		if (hash === this.#lastHash) {
 			this.#count++;

--- a/packages/ai/src/utils/tool-call-loop-guard.ts
+++ b/packages/ai/src/utils/tool-call-loop-guard.ts
@@ -65,6 +65,82 @@ export function canonicalizeToolCallJson(
 	}
 }
 
+function updateCanonicalToolCallHash(
+	hasher: Bun.CryptoHasher,
+	value: unknown,
+	stripIntentFields: boolean,
+	activeObjects: Set<object>,
+): boolean {
+	if (value === null) {
+		hasher.update("null;");
+		return true;
+	}
+	switch (typeof value) {
+		case "string":
+			hasher.update(`s${value.length}:`);
+			hasher.update(value);
+			return true;
+		case "number":
+			hasher.update(`n${Number.isFinite(value) ? (Object.is(value, -0) ? "0" : String(value)) : "null"};`);
+			return true;
+		case "boolean":
+			hasher.update(value ? "b1;" : "b0;");
+			return true;
+		case "undefined":
+			hasher.update("u;");
+			return true;
+		case "bigint":
+			hasher.update(`i${value};`);
+			return true;
+		case "symbol":
+			hasher.update(`y${String(value.description ?? "")};`);
+			return true;
+		case "function":
+			hasher.update("f;");
+			return true;
+		case "object":
+			break;
+	}
+
+	if (activeObjects.has(value)) return false;
+	activeObjects.add(value);
+	try {
+		if (Array.isArray(value)) {
+			hasher.update(`a${value.length}:`);
+			for (const item of value) {
+				if (!updateCanonicalToolCallHash(hasher, item, stripIntentFields, activeObjects)) return false;
+			}
+			return true;
+		}
+
+		const input = value as Record<string, unknown>;
+		const keys = Object.keys(input)
+			.filter(key => !stripIntentFields || (key !== INTENT_FIELD && key !== LEGACY_INTENT_FIELD))
+			.sort();
+		hasher.update(`o${keys.length}:`);
+		for (const key of keys) {
+			if (!updateCanonicalToolCallHash(hasher, key, false, activeObjects)) return false;
+			if (!updateCanonicalToolCallHash(hasher, input[key], stripIntentFields, activeObjects)) return false;
+		}
+		return true;
+	} finally {
+		activeObjects.delete(value);
+	}
+}
+
+/**
+ * Produces a stable digest without materializing a second payload-sized object
+ * or JSON string. Large tool results are streamed directly into the hasher.
+ */
+export function hashCanonicalToolCallValue(
+	value: unknown,
+	options: CanonicalizeToolCallJsonOptions = {},
+): string | undefined {
+	const hasher = new Bun.CryptoHasher("sha256");
+	if (!updateCanonicalToolCallHash(hasher, value, options.stripIntentFields === true, new Set())) return undefined;
+	return hasher.digest("hex");
+}
+
 function summarizeText(text: string, limit: number): string {
 	let summary = text.replace(/\s+/g, " ").trim();
 	if (summary.length > limit) {

--- a/packages/ai/test/tool-call-loop-guard.test.ts
+++ b/packages/ai/test/tool-call-loop-guard.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { normalizeToolCallLoopThreshold, ToolCallLoopGuard } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
+import {
+	hashCanonicalToolCallValue,
+	normalizeToolCallLoopThreshold,
+	ToolCallLoopGuard,
+} from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 
 const zeroUsage = {
@@ -18,6 +22,22 @@ describe("ToolCallLoopGuard", () => {
 		expect(normalizeToolCallLoopThreshold(Number.POSITIVE_INFINITY)).toBe(1);
 		expect(normalizeToolCallLoopThreshold(0)).toBe(1);
 		expect(normalizeToolCallLoopThreshold(2.9)).toBe(2);
+	});
+
+	test("hashes large result values incrementally and canonically", () => {
+		const largeText = "x".repeat(1_000_000);
+		const first = {
+			content: [{ type: "text", text: largeText }],
+			details: { complete: true, bytes: largeText.length },
+		};
+		const reordered = {
+			details: { bytes: largeText.length, complete: true },
+			content: [{ text: largeText, type: "text" }],
+		};
+		const changed = { ...reordered, details: { ...reordered.details, complete: false } };
+
+		expect(hashCanonicalToolCallValue(first)).toBe(hashCanonicalToolCallValue(reordered));
+		expect(hashCanonicalToolCallValue(changed)).not.toBe(hashCanonicalToolCallValue(first));
 	});
 
 	test("detects the fifth consecutive identical tool call", () => {

--- a/packages/ai/test/tool-call-loop-guard.test.ts
+++ b/packages/ai/test/tool-call-loop-guard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { ToolCallLoopGuard } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
+import { normalizeToolCallLoopThreshold, ToolCallLoopGuard } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 
 const zeroUsage = {
@@ -13,6 +13,13 @@ const zeroUsage = {
 } satisfies AssistantMessage["usage"];
 
 describe("ToolCallLoopGuard", () => {
+	test("normalizes invalid and fractional thresholds consistently", () => {
+		expect(normalizeToolCallLoopThreshold(Number.NaN)).toBe(1);
+		expect(normalizeToolCallLoopThreshold(Number.POSITIVE_INFINITY)).toBe(1);
+		expect(normalizeToolCallLoopThreshold(0)).toBe(1);
+		expect(normalizeToolCallLoopThreshold(2.9)).toBe(2);
+	});
+
 	test("detects the fifth consecutive identical tool call", () => {
 		const guard = new ToolCallLoopGuard({ threshold: 5, exemptTools: ["job", "irc"] });
 		let detection = null;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -340,6 +340,9 @@
 - Fixed the Python RPC client dropping context, compaction, OAuth URL, and terminal-settlement fields.
 - Fixed the browser tool ignoring the url parameter when opening a new tab on an attached browser.
 - Fixed browser automation disrupting attached browsers by adopting the active foreground tab and avoiding raising new tabs during screenshots.
+### Fixed
+
+- Added a convergence guard to subagent execution: four consecutive successful calls to the same tool with identical arguments now stop the run with a non-convergence diagnostic instead of allowing a verify/repair loop to consume the remaining soft request budget.
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -279,6 +279,9 @@
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
+### Fixed
+
+- Added a convergence guard to subagent execution: consecutive successful calls with identical arguments and results now stop at the configured tool-call loop threshold, while disabled guards, exempt tools, failures, and calls that return new progress do not terminate the run.
 
 ## [17.2.3] - 2026-08-01
 
@@ -340,9 +343,6 @@
 - Fixed the Python RPC client dropping context, compaction, OAuth URL, and terminal-settlement fields.
 - Fixed the browser tool ignoring the url parameter when opening a new tab on an attached browser.
 - Fixed browser automation disrupting attached browsers by adopting the active foreground tab and avoiding raising new tabs during screenshots.
-### Fixed
-
-- Added a convergence guard to subagent execution: four consecutive successful calls to the same tool with identical arguments now stop the run with a non-convergence diagnostic instead of allowing a verify/repair loop to consume the remaining soft request budget.
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -8,7 +8,11 @@ import path from "node:path";
 import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
 import { recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
 import type { Api, Model, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
-import { canonicalizeToolCallJson, normalizeToolCallLoopThreshold } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
+import {
+	canonicalizeToolCallJson,
+	hashCanonicalToolCallValue,
+	normalizeToolCallLoopThreshold,
+} from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
 import { logger, popLoopPhase, prompt, pushLoopPhase, untilAborted } from "@oh-my-pi/pi-utils";
 import { AsyncJobManager } from "../async";
 import type { Rule } from "../capability/rule";
@@ -1427,7 +1431,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 				const eventArgs = isRecord(eventRecord) && isRecord(eventRecord.args) ? eventRecord.args : {};
 				const canonicalArgs = pendingToolArguments.get(event.toolCallId);
 				pendingToolArguments.delete(event.toolCallId);
-				const canonicalResult = event.isError ? undefined : canonicalizeToolCallJson(event.result);
+				const canonicalResult = event.isError ? undefined : hashCanonicalToolCallValue(event.result);
 				const convergenceGuardEnabled = settings.get("model.toolCallLoopGuard.enabled") === true;
 				const configuredConvergenceThreshold = settings.get("model.toolCallLoopGuard.threshold");
 				const convergenceThreshold = normalizeToolCallLoopThreshold(configuredConvergenceThreshold);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -116,10 +116,17 @@ export function resolveSoftRequestBudget(agentName: string, configuredBudget: nu
 
 /** Extra requests allowed after a budget stop for the forced yield to land before the run is hard-aborted. */
 export const BUDGET_STOP_GRACE_REQUESTS = 5;
+/** Identical tool signatures that indicate a verify/repair cycle is no longer converging. */
+export const NON_CONVERGENT_TOOL_REPEATS = 4;
 
 /** Steering notice injected when a subagent crosses its soft request budget. */
 export function buildBudgetNotice(requests: number, budget: number): string {
 	return `[budget notice] You have used ${requests} requests in this run (soft budget: ${budget}). Wrap up now: finish the current step and yield your final report. At ${Math.ceil(budget * 1.5)} requests the run is force-stopped and you will be asked to yield whatever you have.`;
+}
+
+/** Diagnostic used when a child repeats the same tool call without yielding. */
+export function buildNonConvergenceError(toolName: string, repeats: number): string {
+	return `Subagent repeated ${toolName} with identical arguments ${repeats} times without yielding; stopping as non-converging.`;
 }
 
 /** Flatten whitespace and clip salvage text for the cancelled-child summary line. */
@@ -1069,6 +1076,8 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 	let budgetStopAbortPromise: Promise<void> | undefined;
 	let terminalError: string | undefined;
 	let consecutiveYieldToolErrors = 0;
+	let repeatedToolSignature: string | undefined;
+	let repeatedToolCount = 0;
 	let lastAssistantSalvageText: string | undefined;
 	let activeSessionAbortPromise: Promise<void> | undefined;
 
@@ -1409,6 +1418,21 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 			}
 
 			case "tool_execution_end": {
+				const eventRecord: unknown = event;
+				const eventArgs = isRecord(eventRecord) && isRecord(eventRecord.args) ? eventRecord.args : {};
+				if (!event.isError && event.toolName !== "yield") {
+					const argsText = JSON.stringify(eventArgs) ?? "";
+					const signature = `${event.toolName}:${argsText}`;
+					if (signature === repeatedToolSignature) {
+						repeatedToolCount++;
+					} else {
+						repeatedToolSignature = signature;
+						repeatedToolCount = 1;
+					}
+					if (repeatedToolCount >= NON_CONVERGENT_TOOL_REPEATS && !abortSent) {
+						failWithError(buildNonConvergenceError(event.toolName, repeatedToolCount));
+					}
+				}
 				if (progress.currentTool) {
 					progress.recentTools.unshift({
 						tool: progress.currentTool,
@@ -1432,8 +1456,6 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 
 				// Check for registered subagent tool handler
 				const handler = subprocessToolRegistry.getHandler(event.toolName);
-				const eventRecord: unknown = event;
-				const eventArgs = isRecord(eventRecord) && isRecord(eventRecord.args) ? eventRecord.args : {};
 				if (handler) {
 					// Extract data using handler
 					if (handler.extractData) {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import type { AgentEvent, AgentIdentity, AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
 import { recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
 import type { Api, Model, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
+import { canonicalizeToolCallJson, normalizeToolCallLoopThreshold } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
 import { logger, popLoopPhase, prompt, pushLoopPhase, untilAborted } from "@oh-my-pi/pi-utils";
 import { AsyncJobManager } from "../async";
 import type { Rule } from "../capability/rule";
@@ -116,8 +117,6 @@ export function resolveSoftRequestBudget(agentName: string, configuredBudget: nu
 
 /** Extra requests allowed after a budget stop for the forced yield to land before the run is hard-aborted. */
 export const BUDGET_STOP_GRACE_REQUESTS = 5;
-/** Identical tool signatures that indicate a verify/repair cycle is no longer converging. */
-export const NON_CONVERGENT_TOOL_REPEATS = 4;
 
 /** Steering notice injected when a subagent crosses its soft request budget. */
 export function buildBudgetNotice(requests: number, budget: number): string {
@@ -126,7 +125,7 @@ export function buildBudgetNotice(requests: number, budget: number): string {
 
 /** Diagnostic used when a child repeats the same tool call without yielding. */
 export function buildNonConvergenceError(toolName: string, repeats: number): string {
-	return `Subagent repeated ${toolName} with identical arguments ${repeats} times without yielding; stopping as non-converging.`;
+	return `Subagent repeated ${toolName} with identical arguments and results ${repeats} times without yielding; stopping as non-converging.`;
 }
 
 /** Flatten whitespace and clip salvage text for the cancelled-child summary line. */
@@ -916,8 +915,8 @@ interface RunMonitorArgs {
 	description?: string;
 	/** Parent model registry for tiny-model label generation; absent → skip labeling. */
 	modelRegistry?: ModelRegistry;
-	/** Parent settings for tiny-model label generation. */
-	settings?: Settings;
+	/** Active session settings used by labeling and convergence detection. */
+	settings: Settings;
 	modelOverride?: string | string[];
 	/** Explicit pre-expansion model role alias selected for this run. */
 	modelRole?: string;
@@ -1015,6 +1014,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		softRequestBudget,
 		softRequestBudgetNotice,
 		maxRuntimeMs,
+		settings,
 	} = args;
 	const startTime = Date.now();
 
@@ -1078,6 +1078,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 	let consecutiveYieldToolErrors = 0;
 	let repeatedToolSignature: string | undefined;
 	let repeatedToolCount = 0;
+	const pendingToolArguments = new Map<string, string>();
 	let lastAssistantSalvageText: string | undefined;
 	let activeSessionAbortPromise: Promise<void> | undefined;
 
@@ -1400,6 +1401,10 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 				} else if (isRecord(event.args)) {
 					startArgs = event.args;
 				}
+				if (event.toolName !== "yield") {
+					const canonicalArgs = canonicalizeToolCallJson(startArgs, { stripIntentFields: true });
+					if (canonicalArgs !== undefined) pendingToolArguments.set(event.toolCallId, canonicalArgs);
+				}
 				progress.currentToolArgs = extractToolArgsPreview(startArgs);
 				progress.currentToolStartMs = now;
 				const intent = event.intent?.trim();
@@ -1420,18 +1425,32 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 			case "tool_execution_end": {
 				const eventRecord: unknown = event;
 				const eventArgs = isRecord(eventRecord) && isRecord(eventRecord.args) ? eventRecord.args : {};
-				if (!event.isError && event.toolName !== "yield") {
-					const argsText = JSON.stringify(eventArgs) ?? "";
-					const signature = `${event.toolName}:${argsText}`;
-					if (signature === repeatedToolSignature) {
+				const canonicalArgs = pendingToolArguments.get(event.toolCallId);
+				pendingToolArguments.delete(event.toolCallId);
+				const canonicalResult = event.isError ? undefined : canonicalizeToolCallJson(event.result);
+				const convergenceGuardEnabled = settings.get("model.toolCallLoopGuard.enabled") === true;
+				const configuredConvergenceThreshold = settings.get("model.toolCallLoopGuard.threshold");
+				const convergenceThreshold = normalizeToolCallLoopThreshold(configuredConvergenceThreshold);
+				const convergenceExemptTools = settings.get("model.toolCallLoopGuard.exemptTools");
+				if (
+					convergenceGuardEnabled &&
+					!convergenceExemptTools.includes(event.toolName) &&
+					canonicalArgs !== undefined &&
+					canonicalResult !== undefined
+				) {
+					const toolSignature = JSON.stringify([event.toolName, canonicalArgs, canonicalResult]);
+					if (toolSignature === repeatedToolSignature) {
 						repeatedToolCount++;
 					} else {
-						repeatedToolSignature = signature;
+						repeatedToolSignature = toolSignature;
 						repeatedToolCount = 1;
 					}
-					if (repeatedToolCount >= NON_CONVERGENT_TOOL_REPEATS && !abortSent) {
+					if (repeatedToolCount >= convergenceThreshold && !abortSent) {
 						failWithError(buildNonConvergenceError(event.toolName, repeatedToolCount));
 					}
+				} else {
+					repeatedToolSignature = undefined;
+					repeatedToolCount = 0;
 				}
 				if (progress.currentTool) {
 					progress.recentTools.unshift({
@@ -2319,6 +2338,7 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 			description: options.description,
 			modelOverride: options.modelOverride,
 			modelRole: options.modelRole,
+			settings: session.settings,
 			eventBus: options.eventBus,
 			parentToolCallId: options.parentToolCallId,
 			detached: true,
@@ -2353,13 +2373,14 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 			const runtimeLimitExceeded = turnMonitor.runtimeLimitExceeded();
 			const aborted = runtimeLimitExceeded || (lastAssistant?.stopReason === "aborted" && !yielded);
 			const error =
-				lastAssistant?.stopReason === "error"
+				turnMonitor.terminalError() ??
+				(lastAssistant?.stopReason === "error"
 					? lastAssistant.errorMessage || "Subagent failed"
 					: turnError !== undefined && !yielded
 						? turnError instanceof Error
 							? turnError.stack || turnError.message
 							: String(turnError)
-						: undefined;
+						: undefined);
 			turnMonitor.finish();
 			try {
 				await finalizeRunResult({
@@ -2549,6 +2570,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		task: message,
 		description: options.description,
 		modelRole: options.modelRole,
+		settings: session.settings,
 		signal,
 		onProgress: options.onProgress,
 		eventBus: options.eventBus,
@@ -2744,7 +2766,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		assignment,
 		description: options.description,
 		modelRegistry: options.modelRegistry,
-		settings,
+		settings: subagentSettings,
 		modelOverride,
 		modelRole,
 		signal,

--- a/packages/coding-agent/test/task/executor-recent-output.test.ts
+++ b/packages/coding-agent/test/task/executor-recent-output.test.ts
@@ -123,7 +123,7 @@ function resetEvent(): AgentSessionEvent {
 
 function toolPair(idx: number): AgentSessionEvent[] {
 	return [
-		{ type: "tool_execution_start", toolCallId: `obs-${idx}`, toolName: "read", args: {} },
+		{ type: "tool_execution_start", toolCallId: `obs-${idx}`, toolName: "read", args: { path: `/tmp/obs-${idx}` } },
 		{
 			type: "tool_execution_end",
 			toolCallId: `obs-${idx}`,

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -37,6 +37,11 @@ interface MockSessionHandle {
 	disposeCalls: () => number;
 }
 
+interface MockSessionOptions {
+	settings?: Settings;
+	onIrcWake?: (params: { emit: (event: AgentSessionEvent) => void; pushMessage: (message: unknown) => void }) => void;
+}
+
 function assistantText(text: string, stopReason: "stop" | "aborted" = "stop") {
 	return { role: "assistant" as const, content: [{ type: "text" as const, text }], stopReason };
 }
@@ -47,6 +52,7 @@ function createMockSession(
 		emit: (event: AgentSessionEvent) => void;
 		pushMessage: (message: unknown) => void;
 	}) => void,
+	options: MockSessionOptions = {},
 ): MockSessionHandle {
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
 	const messages: unknown[] = [];
@@ -68,6 +74,7 @@ function createMockSession(
 		model: { api: "anthropic-messages" } as never,
 		extensionRunner: undefined as never,
 		sessionManager: { appendSessionInit: () => {} } as never,
+		settings: options.settings ?? Settings.isolated(),
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
 		setActiveToolsByName: async () => {},
@@ -101,6 +108,7 @@ function createMockSession(
 				timestamp: msg.ts,
 			};
 			const finishObservation = ircWakeTurnObserver?.([record]);
+			options.onIrcWake?.({ emit, pushMessage: message => messages.push(message) });
 			const yieldMessage = {
 				role: "assistant" as const,
 				content: [
@@ -202,6 +210,61 @@ describe("runSubprocess soft request budget", () => {
 			sessionFile: null,
 			status: "running",
 		});
+	}
+
+	function emitToolExecution(
+		emit: (event: AgentSessionEvent) => void,
+		toolCallId: string,
+		toolName: string,
+		args: Record<string, unknown>,
+		result: unknown,
+		isError = false,
+	): void {
+		emit({ type: "tool_execution_start", toolCallId, toolName, args });
+		emit({ type: "tool_execution_end", toolCallId, toolName, result, isError });
+	}
+
+	function emitSuccessfulYield(
+		emit: (event: AgentSessionEvent) => void,
+		pushMessage: (message: unknown) => void,
+	): void {
+		const toolCallId = "terminal-yield";
+		const args = { result: { data: { report: "completed" } } };
+		pushMessage({
+			role: "assistant",
+			content: [{ type: "toolCall", id: toolCallId, name: "yield", arguments: args }],
+			stopReason: "toolUse",
+		});
+		emit({ type: "tool_execution_start", toolCallId, toolName: "yield", args });
+		emit({
+			type: "tool_execution_end",
+			toolCallId,
+			toolName: "yield",
+			result: {
+				content: [{ type: "text", text: "Result submitted." }],
+				details: { status: "success", data: { report: "completed" } },
+			},
+			isError: false,
+		});
+	}
+
+	function convergenceOptions(
+		id: string,
+		loopGuard: {
+			enabled?: boolean;
+			threshold?: number;
+			exemptTools?: string[];
+		} = {},
+	) {
+		return {
+			...baseOptions(id),
+			settings: Settings.isolated({
+				"task.softRequestBudget": 0,
+				"model.toolCallLoopGuard.enabled": loopGuard.enabled ?? true,
+				"model.toolCallLoopGuard.threshold": loopGuard.threshold ?? 3,
+				"model.toolCallLoopGuard.exemptTools": loopGuard.exemptTools ?? ["hub"],
+			}),
+		};
 	}
 
 	it("a budget stop drives one forced final yield and finishes as a normal completion", async () => {
@@ -363,41 +426,187 @@ describe("runSubprocess soft request budget", () => {
 		expect(receipt.error).toMatch(new RegExp(`history://${id}`));
 	});
 
-	it("stops repeated identical tool calls as non-converging", async () => {
+	it("uses the configured threshold and canonical JSON arguments and results", async () => {
 		const id = "LoopScout";
-		const handle = createMockSession(({ emit, pushMessage }) => {
-			for (let index = 1; index <= 4; index++) {
-				const toolCall = {
-					role: "assistant" as const,
-					content: [
-						{
-							type: "toolCall" as const,
-							id: `tool-${index}`,
-							name: "read",
-							arguments: { path: "/tmp/same.ts" },
-						},
-					],
-					stopReason: "toolUse" as const,
-				};
-				pushMessage(toolCall);
-				emit({ type: "message_end", message: toolCall } as unknown as AgentSessionEvent);
-				emit({
-					type: "tool_execution_end",
-					toolCallId: `tool-${index}`,
-					toolName: "read",
-					args: { path: "/tmp/same.ts" },
-					result: { content: [{ type: "text", text: "same result" }] },
-					isError: false,
-				} as unknown as AgentSessionEvent);
-			}
+		const handle = createMockSession(({ emit }) => {
+			emitToolExecution(
+				emit,
+				"tool-1",
+				"read",
+				{ path: "/tmp/same.ts", options: { offset: 1, limit: 20 } },
+				{ content: [{ type: "text", text: "same result" }], details: { bytes: 20, complete: true } },
+			);
+			emitToolExecution(
+				emit,
+				"tool-2",
+				"read",
+				{ options: { limit: 20, offset: 1 }, path: "/tmp/same.ts" },
+				{ details: { complete: true, bytes: 20 }, content: [{ text: "same result", type: "text" }] },
+			);
+			emitToolExecution(
+				emit,
+				"tool-3",
+				"read",
+				{ path: "/tmp/same.ts", options: { offset: 1, limit: 20 } },
+				{ content: [{ type: "text", text: "same result" }], details: { bytes: 20, complete: true } },
+			);
 		});
 		mockCreateAgentSession(handle.session);
 		registerRunning(id, handle.session);
 
-		const result = await runSubprocess(baseOptions(id));
+		const result = await runSubprocess(convergenceOptions(id, { threshold: 3 }));
 
 		expect(result.exitCode).not.toBe(0);
+		expect(result.error).toContain("identical arguments and results 3 times");
 		expect(result.error).toContain("non-converging");
+	});
+
+	it("uses live session settings and reports autonomous IRC convergence failures", async () => {
+		const id = "IrcLoopScout";
+		const settings = Settings.isolated({
+			"task.softRequestBudget": 0,
+			"model.toolCallLoopGuard.enabled": true,
+			"model.toolCallLoopGuard.threshold": 2,
+			"model.toolCallLoopGuard.exemptTools": ["hub"],
+		});
+		const eventBus = new EventBus();
+		const frames: RpcSubagentFrame[] = [];
+		let resolveWakeTerminal: (() => void) | undefined;
+		const rpcRegistry = new RpcSubagentRegistry(eventBus, frame => {
+			frames.push(frame);
+			if (frame.type === "subagent_lifecycle" && frame.payload.status !== "started") {
+				resolveWakeTerminal?.();
+			}
+		});
+		rpcRegistry.setSubscriptionLevel("progress");
+		const handle = createMockSession(({ emit, pushMessage }) => emitSuccessfulYield(emit, pushMessage), {
+			settings,
+			onIrcWake: ({ emit }) => {
+				const args = { path: "/tmp/same.ts" };
+				const result = { content: [{ type: "text", text: "same result" }] };
+				emitToolExecution(emit, "irc-read-1", "read", args, result);
+				emitToolExecution(emit, "irc-read-2", "read", args, result);
+			},
+		});
+		mockCreateAgentSession(handle.session);
+		registerRunning(id, handle.session);
+		const initial = await runSubprocess({ ...baseOptions(id, eventBus), settings });
+		const abortsBeforeWake = handle.abortCalls();
+		frames.length = 0;
+		const terminal = Promise.withResolvers<void>();
+		resolveWakeTerminal = terminal.resolve;
+
+		const receipt = await new IrcBus().send({ from: "Main", to: id, body: "continue" });
+		await terminal.promise;
+
+		expect(initial.exitCode).toBe(0);
+		expect(receipt.outcome).toBe("woken");
+		expect(handle.abortCalls()).toBe(abortsBeforeWake + 1);
+		expect(frames.at(-1)).toMatchObject({
+			type: "subagent_lifecycle",
+			payload: { id, status: "failed" },
+		});
+		rpcRegistry.dispose();
+	});
+
+	it("does not enforce convergence detection when the centralized guard is disabled", async () => {
+		const id = "DisabledLoopGuardScout";
+		const handle = createMockSession(({ emit, pushMessage }) => {
+			for (let index = 1; index <= 3; index++) {
+				emitToolExecution(
+					emit,
+					`tool-${index}`,
+					"read",
+					{ path: "/tmp/same.ts" },
+					{ content: [{ type: "text", text: "same result" }] },
+				);
+			}
+			emitSuccessfulYield(emit, pushMessage);
+		});
+		mockCreateAgentSession(handle.session);
+		registerRunning(id, handle.session);
+
+		const result = await runSubprocess(convergenceOptions(id, { enabled: false, threshold: 2 }));
+
+		expect(result.exitCode).toBe(0);
+		expect(JSON.parse(result.output)).toEqual({ report: "completed" });
+	});
+
+	it("preserves configured exemptions for repeated polling tools", async () => {
+		const id = "PollingScout";
+		const handle = createMockSession(({ emit, pushMessage }) => {
+			for (let index = 1; index <= 3; index++) {
+				emitToolExecution(
+					emit,
+					`wait-${index}`,
+					"hub",
+					{ op: "wait" },
+					{ content: [{ type: "text", text: "no completed jobs yet" }] },
+				);
+			}
+			emitSuccessfulYield(emit, pushMessage);
+		});
+		mockCreateAgentSession(handle.session);
+		registerRunning(id, handle.session);
+
+		const result = await runSubprocess(convergenceOptions(id, { threshold: 2, exemptTools: ["hub"] }));
+
+		expect(result.exitCode).toBe(0);
+		expect(JSON.parse(result.output)).toEqual({ report: "completed" });
+	});
+
+	it("treats result changes under nested intent-named keys as progress", async () => {
+		const id = "ProgressingScout";
+		const handle = createMockSession(({ emit, pushMessage }) => {
+			for (let index = 1; index <= 3; index++) {
+				emitToolExecution(
+					emit,
+					`read-${index}`,
+					"read",
+					{ path: "/tmp/growing.log" },
+					{
+						content: [{ type: "text", text: "same result" }],
+						details: { progress: { i: `result ${index}` } },
+					},
+				);
+			}
+			emitSuccessfulYield(emit, pushMessage);
+		});
+		mockCreateAgentSession(handle.session);
+		registerRunning(id, handle.session);
+
+		const result = await runSubprocess(convergenceOptions(id, { threshold: 2, exemptTools: [] }));
+
+		expect(result.exitCode).toBe(0);
+		expect(JSON.parse(result.output)).toEqual({ report: "completed" });
+	});
+
+	it("resets the consecutive-success streak after a failed call", async () => {
+		const id = "RecoveringScout";
+		const handle = createMockSession(({ emit, pushMessage }) => {
+			const args = { path: "/tmp/same.ts" };
+			const success = { content: [{ type: "text", text: "same result" }] };
+			emitToolExecution(emit, "success-1", "read", args, success);
+			emitToolExecution(emit, "success-2", "read", args, success);
+			emitToolExecution(
+				emit,
+				"failure",
+				"read",
+				args,
+				{ content: [{ type: "text", text: "temporary failure" }] },
+				true,
+			);
+			emitToolExecution(emit, "success-3", "read", args, success);
+			emitToolExecution(emit, "success-4", "read", args, success);
+			emitSuccessfulYield(emit, pushMessage);
+		});
+		mockCreateAgentSession(handle.session);
+		registerRunning(id, handle.session);
+
+		const result = await runSubprocess(convergenceOptions(id, { threshold: 3, exemptTools: [] }));
+
+		expect(result.exitCode).toBe(0);
+		expect(JSON.parse(result.output)).toEqual({ report: "completed" });
 	});
 });
 

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -362,6 +362,43 @@ describe("runSubprocess soft request budget", () => {
 		expect(receipt.error).toMatch(/hard-aborted/);
 		expect(receipt.error).toMatch(new RegExp(`history://${id}`));
 	});
+
+	it("stops repeated identical tool calls as non-converging", async () => {
+		const id = "LoopScout";
+		const handle = createMockSession(({ emit, pushMessage }) => {
+			for (let index = 1; index <= 4; index++) {
+				const toolCall = {
+					role: "assistant" as const,
+					content: [
+						{
+							type: "toolCall" as const,
+							id: `tool-${index}`,
+							name: "read",
+							arguments: { path: "/tmp/same.ts" },
+						},
+					],
+					stopReason: "toolUse" as const,
+				};
+				pushMessage(toolCall);
+				emit({ type: "message_end", message: toolCall } as unknown as AgentSessionEvent);
+				emit({
+					type: "tool_execution_end",
+					toolCallId: `tool-${index}`,
+					toolName: "read",
+					args: { path: "/tmp/same.ts" },
+					result: { content: [{ type: "text", text: "same result" }] },
+					isError: false,
+				} as unknown as AgentSessionEvent);
+			}
+		});
+		mockCreateAgentSession(handle.session);
+		registerRunning(id, handle.session);
+
+		const result = await runSubprocess(baseOptions(id));
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.error).toContain("non-converging");
+	});
 });
 
 describe("resolveSoftRequestBudget", () => {


### PR DESCRIPTION
## What

Add a convergence guard to subagent execution. Four consecutive successful calls to the same tool with identical arguments stop the run with a non-convergence diagnostic before the child can consume the rest of its soft request budget.

I reviewed this change; it terminates verify/repair loops that are repeating the same action without yielding useful progress.

## Why

The soft budget only fires after many requests, so a child stuck re-running the same verification or repair command can burn a large portion of its allocation while producing no new information. A repeated identical successful call is a precise failure signal and should be reported directly.

## Testing

- `bun test test/task/executor-soft-budget.test.ts`
- `bun --cwd=packages/coding-agent run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)