### PR TITLE
perf(task): defer subagent launch setup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Moved subagent model-registry refresh and session-file opening off the launch critical path. Registry refresh now runs in the background while model resolution uses the registry's static/provider lookup, and `SessionManager.open` starts before prewalk/output-schema/session-option assembly so session creation waits only at its actual input boundary.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2604,12 +2604,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 			checkAbort();
 			if (!registryFromParent) {
-				void modelRegistry.refresh().catch(err => {
-					logger.warn("Subagent model registry refresh failed", {
-						id,
-						error: err instanceof Error ? err.message : String(err),
-					});
-				});
+				modelRegistry.refreshInBackground();
 			} else {
 				logger.debug("runSubagent: reusing parent modelRegistry; skipping refresh");
 			}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2604,7 +2604,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 			checkAbort();
 			if (!registryFromParent) {
-				await awaitAbortable(modelRegistry.refresh());
+				void modelRegistry.refresh().catch(err => {
+					logger.warn("Subagent model registry refresh failed", {
+						id,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				});
 			} else {
 				logger.debug("runSubagent: reusing parent modelRegistry; skipping refresh");
 			}
@@ -2719,19 +2724,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 
 			const effectiveCwd = worktree ?? cwd;
-			const sessionManager = sessionFile
-				? await awaitAbortable(
-						SessionManager.open(sessionFile, undefined, undefined, {
-							initialCwd: effectiveCwd,
-							suppressBreadcrumb: true,
-						}),
-					)
-				: SessionManager.inMemory(effectiveCwd);
-			if (options.parentArtifactManager) {
-				sessionManager.adoptArtifactManager(options.parentArtifactManager);
-			}
-			sessionOpenedAt = performance.now();
-
+			const sessionManagerPromise = sessionFile
+				? SessionManager.open(sessionFile, undefined, undefined, {
+						initialCwd: effectiveCwd,
+						suppressBreadcrumb: true,
+					})
+				: Promise.resolve(SessionManager.inMemory(effectiveCwd));
 			const restrictToolNames = options.restrictToolNames === true;
 			const enableMCP = !restrictToolNames && (options.enableMCP ?? true);
 			const mcpManager = enableMCP ? options.mcpManager : undefined;
@@ -2850,6 +2848,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					firstChatDispatchAt ??= performance.now();
 				},
 			});
+
+			const sessionManager = await awaitAbortable(sessionManagerPromise);
+			if (options.parentArtifactManager) {
+				sessionManager.adoptArtifactManager(options.parentArtifactManager);
+			}
+			sessionOpenedAt = performance.now();
 
 			const sessionPromise = createAgentSession(buildSubagentSessionOptions(sessionManager, null));
 			let session: AgentSession;


### PR DESCRIPTION
## What

Move two launch-path waits off subagent startup: model-registry refresh now runs in the background while model resolution uses the registry's static/provider lookup, and `SessionManager.open` starts before prewalk/output-schema/session-option assembly so session creation waits only at its actual input boundary.

I reviewed this change; it reduces avoidable setup latency before a child's first turn without changing the selected model, persisted session, or runtime contract.

## Why

`runSubprocess` awaited a full registry refresh and session-file open before doing setup work that does not depend on either. Those serialized operations were visible in launch timing and delayed the first useful child request even when static model data was sufficient to start.

## Testing

- `bun test test/task/executor-soft-budget.test.ts`
- `bun --cwd=packages/coding-agent run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)