### PR TITLE
feat(task): bound child context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -279,6 +279,9 @@
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
+### Added
+
+- Added `task.childContextBudgetTokens` to bound inherited subagent context. When set, child sessions clamp their compaction threshold to the configured token budget so oversized histories trigger maintenance before repeatedly inflating first-token latency.
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -238,6 +238,9 @@
 - Fixed heavily branched conversation trees shifting linear continuations into disconnected columns.
 - Fixed plugin installation validation failures for legacy compatibility shims.
 - Removed hard-coded references to disabled or absent agents in system and tool prompts.
+### Added
+
+- Added `task.childContextBudgetTokens` to bound inherited subagent context. When set, child sessions clamp their compaction threshold to the configured token budget so oversized histories trigger maintenance before repeatedly inflating first-token latency.
 
 ## [17.2.4] - 2026-08-01
 
@@ -279,10 +282,6 @@
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
-### Added
-
-- Added `task.childContextBudgetTokens` to bound inherited subagent context. When set, child sessions clamp their compaction threshold to the configured token budget so oversized histories trigger maintenance before repeatedly inflating first-token latency.
-
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4661,6 +4661,25 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"task.childContextBudgetTokens": {
+		type: "number",
+		default: 0,
+		ui: {
+			tab: "tasks",
+			group: "Subagents",
+			label: "Child Context Budget",
+			description:
+				"Maximum inherited context tokens for a subagent session (0 disables). When set, the child session's compaction threshold is clamped to this budget so oversized inherited context triggers maintenance before it repeatedly inflates first-token latency.",
+			options: [
+				{ value: "0", label: "Disabled", description: "Default" },
+				{ value: "50000", label: "50K tokens" },
+				{ value: "100000", label: "100K tokens" },
+				{ value: "150000", label: "150K tokens" },
+				{ value: "200000", label: "200K tokens" },
+			],
+		},
+	},
+
 	"task.agentIdleTtlMs": {
 		type: "number",
 		default: 420_000,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1456,6 +1456,7 @@ export class AgentSession {
 			providerSessionState: this.#providerSessionState,
 			preferWebsockets: this.#preferWebsockets,
 			model: () => this.model,
+			agentKind: () => this.#agentKind,
 			thinkingLevel: () => this.thinkingLevel,
 			isDisposed: () => this.#isDisposed,
 			isStreaming: () => this.isStreaming,

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1825,7 +1825,9 @@ export class SessionMaintenance {
 	 * When the model/window is unknown we cannot evaluate the band, so we
 	 * optimistically allow the continuation (preserving prior behavior).
 	 */
-	#compactionCreatedHeadroom(compactionSettings = this.#host.settings.getGroup("compaction")): boolean {
+	#compactionCreatedHeadroom(
+		compactionSettings: CompactionSettings = this.#host.settings.getGroup("compaction"),
+	): boolean {
 		const contextWindow = this.#model?.contextWindow ?? 0;
 		if (contextWindow <= 0) return true;
 		const residualTokens = compactionContextTokens(

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -2201,6 +2201,7 @@ export class SessionMaintenance {
 				generation,
 				shouldAutoContinue,
 				terminalTextAnswer,
+				compactionSettings,
 				options.triggerContextTokens,
 				suppressContinuation,
 			);
@@ -2432,6 +2433,9 @@ export class SessionMaintenance {
 						skipped: frameRescueResult === undefined,
 					});
 					let continuationScheduled = false;
+					// Queued messages must remain parked when the child-clamped
+					// recovery band was not reached. Routing them through
+					// agent.continue() here would bypass the pre-prompt child budget gate.
 					if (frameRescueCreatedHeadroom) {
 						continuationScheduled = this.#host.scheduleCompactionContinuation({
 							generation,
@@ -2439,13 +2443,6 @@ export class SessionMaintenance {
 							terminalTextAnswer,
 							suppressContinuation,
 						});
-					} else if (!suppressContinuation && this.#host.agent.hasQueuedMessages()) {
-						this.#host.scheduleAgentContinue({
-							delayMs: 100,
-							generation,
-							shouldContinue: () => this.#host.agent.hasQueuedMessages(),
-						});
-						continuationScheduled = true;
 					}
 					if (deadEndWarning) {
 						this.#host.emitNotice("warning", deadEndWarning, "compaction");
@@ -2987,6 +2984,7 @@ export class SessionMaintenance {
 		generation: number,
 		autoContinue: boolean,
 		terminalTextAnswer: boolean,
+		compactionSettings: CompactionSettings,
 		triggerContextTokens?: number,
 		suppressContinuation = false,
 	): Promise<CompactionCheckResult | "fallback"> {
@@ -3030,11 +3028,6 @@ export class SessionMaintenance {
 			// without that pre-shake savings, shake can fall through to context-full
 			// even though the post-prune history is already inside the recovery band.
 			const contextWindow = this.#model?.contextWindow ?? 0;
-			const configuredCompactionSettings = this.#host.settings.getGroup("compaction");
-			const compactionSettings =
-				reason === "threshold" && contextWindow > 0
-					? this.#withChildContextBudget(contextWindow, configuredCompactionSettings)
-					: configuredCompactionSettings;
 			let stillOverThreshold = false;
 			if (contextWindow > 0) {
 				if (typeof triggerContextTokens === "number" && Number.isFinite(triggerContextTokens)) {

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1825,10 +1825,9 @@ export class SessionMaintenance {
 	 * When the model/window is unknown we cannot evaluate the band, so we
 	 * optimistically allow the continuation (preserving prior behavior).
 	 */
-	#compactionCreatedHeadroom(): boolean {
+	#compactionCreatedHeadroom(compactionSettings = this.#host.settings.getGroup("compaction")): boolean {
 		const contextWindow = this.#model?.contextWindow ?? 0;
 		if (contextWindow <= 0) return true;
-		const compactionSettings = this.#host.settings.getGroup("compaction");
 		const residualTokens = compactionContextTokens(
 			this.#host.getContextUsage({ contextWindow })?.tokens ?? 0,
 			this.#estimateStoredContextTokens(),
@@ -2382,7 +2381,7 @@ export class SessionMaintenance {
 					if (frameRescueResult) {
 						rescueRewroteHistory = true;
 						pathEntriesForCompaction = this.#host.sessionManager.getBranch();
-						frameRescueCreatedHeadroom = this.#compactionCreatedHeadroom();
+						frameRescueCreatedHeadroom = this.#compactionCreatedHeadroom(compactionSettings);
 					}
 					if (!frameRescueCreatedHeadroom) {
 						await this.#rescueCompactionDeadEnd(autoCompactionSignal, {
@@ -2891,11 +2890,11 @@ export class SessionMaintenance {
 				// when auto-continue is disabled, a no-headroom threshold pass must still
 				// block later automatic continuations (todo reminders/session_stop hooks)
 				// from re-entering the same oversized context.
-				hasHeadroom = this.#compactionCreatedHeadroom();
+				hasHeadroom = this.#compactionCreatedHeadroom(compactionSettings);
 				if (!hasHeadroom) {
 					hasHeadroom = await this.#rescueCompactionDeadEnd(autoCompactionSignal, {
 						skipElide: fallbackFromShake,
-						hasProgress: () => this.#compactionCreatedHeadroom(),
+						hasProgress: () => this.#compactionCreatedHeadroom(compactionSettings),
 					});
 				}
 				if (!hasHeadroom) {

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -184,6 +184,7 @@ export interface SessionMaintenanceHost {
 	providerSessionState: Map<string, ProviderSessionState>;
 	preferWebsockets: boolean | undefined;
 	model(): Model | undefined;
+	agentKind(): "main" | "sub";
 	thinkingLevel(): ThinkingLevel | undefined;
 	isDisposed(): boolean;
 	isStreaming(): boolean;
@@ -298,6 +299,25 @@ export class SessionMaintenance {
 
 	constructor(host: SessionMaintenanceHost) {
 		this.#host = host;
+	}
+
+	#childContextBudget(): number {
+		if (this.#host.agentKind() !== "sub") return 0;
+		const configuredBudget = Number(this.#host.settings.get("task.childContextBudgetTokens") ?? 0);
+		return Number.isFinite(configuredBudget) ? Math.max(0, Math.trunc(configuredBudget)) : 0;
+	}
+
+	#withChildContextBudget(contextWindow: number, settings: CompactionSettings): CompactionSettings {
+		const childContextBudget = this.#childContextBudget();
+		if (childContextBudget <= 0 || resolveThresholdTokens(contextWindow, settings) <= childContextBudget) {
+			return settings;
+		}
+		return { ...settings, thresholdTokens: childContextBudget };
+	}
+
+	#exceedsChildContextBudget(contextTokens: number): boolean {
+		const childContextBudget = this.#childContextBudget();
+		return childContextBudget > 0 && contextTokens > childContextBudget;
 	}
 
 	/** Whether manual or automatic context maintenance is active. */
@@ -1014,7 +1034,10 @@ export class SessionMaintenance {
 		if (!model) return;
 		const contextWindow = model.contextWindow ?? 0;
 		if (contextWindow <= 0) return;
-		const compactionSettings = this.#host.settings.getGroup("compaction");
+		const compactionSettings = this.#withChildContextBudget(
+			contextWindow,
+			this.#host.settings.getGroup("compaction"),
+		);
 		const contextTokens = this.#estimatePrePromptContextTokens(messages, contextWindow);
 		const pendingMidTurnDeadEnd = this.#midTurnDeadEndPendingPrePrompt;
 		this.#midTurnDeadEndPendingPrePrompt = false;
@@ -1029,11 +1052,10 @@ export class SessionMaintenance {
 			return;
 		}
 
-		// Auto-promote first: switching to a larger-context model avoids compacting
-		// the history at all. The post-turn threshold path already promotes before
-		// compacting; without this, the pre-prompt path would pre-empt promotion and
-		// compact (snapcompact/summary) a session that should have just been promoted.
-		if (await this.#promoteContextModel()) {
+		// Auto-promote first unless this child is already above its explicit
+		// budget: promotion would preserve the oversized history and bypass the
+		// configured ceiling.
+		if (!this.#exceedsChildContextBudget(contextTokens) && (await this.#promoteContextModel())) {
 			logger.debug("Pre-prompt context promotion avoided compaction", {
 				contextTokens,
 				contextWindow,
@@ -1083,7 +1105,10 @@ export class SessionMaintenance {
 		const contextWindow = model?.contextWindow ?? 0;
 		if (contextWindow <= 0) return;
 
-		const compactionSettings = this.#host.settings.getGroup("compaction");
+		const compactionSettings = this.#withChildContextBudget(
+			contextWindow,
+			this.#host.settings.getGroup("compaction"),
+		);
 		if (
 			!compactionSettings.enabled ||
 			compactionSettings.strategy === "off" ||
@@ -1123,13 +1148,9 @@ export class SessionMaintenance {
 		const contextTokens = compactionContextTokens(billedContextTokens, storedContextTokens);
 		if (!shouldCompact(contextTokens, contextWindow, compactionSettings)) return;
 
-		// Promote to a larger-context sibling before compacting, mirroring the
-		// pre-prompt (runPrePromptCompactionIfNeeded) and post-turn threshold
-		// (checkCompaction) paths. Without this, a long mid-turn tool loop that
-		// crosses the threshold compacts the history (and can hit the no-progress
-		// dead-end on a single oversized turn) on a model that should have just
-		// been promoted to a larger window instead.
-		if (await this.#promoteContextModel()) {
+		// Promote before ordinary threshold compaction. Once a child exceeds its
+		// explicit budget, compact instead because promotion preserves that history.
+		if (!this.#exceedsChildContextBudget(contextTokens) && (await this.#promoteContextModel())) {
 			logger.debug("Mid-run context promotion avoided compaction", {
 				contextTokens,
 				contextWindow,
@@ -1330,7 +1351,8 @@ export class SessionMaintenance {
 		// setting.
 		const supersedeResult = await this.#pruneStaleToolResults();
 
-		const compactionSettings = this.#host.settings.getGroup("compaction");
+		const configuredCompactionSettings = this.#host.settings.getGroup("compaction");
+		const compactionSettings = this.#withChildContextBudget(contextWindow, configuredCompactionSettings);
 		if (!compactionSettings.enabled || compactionSettings.strategy === "off") return COMPACTION_CHECK_NONE;
 
 		// Case 4: Threshold - turn succeeded but context is getting large
@@ -1370,7 +1392,12 @@ export class SessionMaintenance {
 			storedContextTokens,
 		);
 		const thresholdTokens = resolveThresholdTokens(contextWindow, compactionSettings);
-		const shouldThresholdCompact = shouldCompact(contextTokens, contextWindow, compactionSettings);
+		// Preserve the configured threshold's provider-anchored trigger (#3174),
+		// but apply the child ceiling to the next prompt after pruning. Otherwise
+		// bytes already removed can cause a child-only destructive compaction.
+		const shouldThresholdCompact =
+			shouldCompact(contextTokens, contextWindow, configuredCompactionSettings) ||
+			(compactionSettings.enabled && this.#exceedsChildContextBudget(postMaintenanceContextTokens));
 		logger.debug("Auto-compaction threshold decision", {
 			phase: "post-agent-end",
 			goalModeEnabled: this.#goalModeState?.enabled === true,
@@ -1389,8 +1416,11 @@ export class SessionMaintenance {
 			contextPromotionEnabled: this.#host.settings.get("contextPromotion.enabled") === true,
 		});
 		if (shouldThresholdCompact) {
-			// Try promotion first — if a larger model is available, switch instead of compacting
-			const promoted = await this.#tryContextPromotion(assistantMessage);
+			// Promote at an inherited threshold while the child remains within its
+			// budget; compact once the explicit child ceiling is exceeded.
+			const promoted = this.#exceedsChildContextBudget(postMaintenanceContextTokens)
+				? false
+				: await this.#tryContextPromotion(assistantMessage);
 			if (!promoted) {
 				return await this.runAutoCompaction("threshold", false, false, allowDefer, {
 					autoContinue,
@@ -2144,7 +2174,12 @@ export class SessionMaintenance {
 			terminalTextAnswer?: boolean;
 		} = {},
 	): Promise<CompactionCheckResult> {
-		const compactionSettings = this.#host.settings.getGroup("compaction");
+		const configuredCompactionSettings = this.#host.settings.getGroup("compaction");
+		const contextWindow = this.#model?.contextWindow ?? 0;
+		const compactionSettings =
+			reason === "threshold" && contextWindow > 0
+				? this.#withChildContextBudget(contextWindow, configuredCompactionSettings)
+				: configuredCompactionSettings;
 		if (compactionSettings.strategy === "off") return COMPACTION_CHECK_NONE;
 		if (reason !== "idle" && !compactionSettings.enabled) return COMPACTION_CHECK_NONE;
 		const generation = this.#host.promptGeneration();
@@ -2994,7 +3029,11 @@ export class SessionMaintenance {
 			// without that pre-shake savings, shake can fall through to context-full
 			// even though the post-prune history is already inside the recovery band.
 			const contextWindow = this.#model?.contextWindow ?? 0;
-			const compactionSettings = this.#host.settings.getGroup("compaction");
+			const configuredCompactionSettings = this.#host.settings.getGroup("compaction");
+			const compactionSettings =
+				reason === "threshold" && contextWindow > 0
+					? this.#withChildContextBudget(contextWindow, configuredCompactionSettings)
+					: configuredCompactionSettings;
 			let stillOverThreshold = false;
 			if (contextWindow > 0) {
 				if (typeof triggerContextTokens === "number" && Number.isFinite(triggerContextTokens)) {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -876,9 +876,20 @@ export function createSubagentSettings(
 	snapshot["tier.openai"] = subagentTiers.openai ?? "none";
 	snapshot["tier.anthropic"] = subagentTiers.anthropic ?? "none";
 	snapshot["tier.google"] = subagentTiers.google ?? "none";
+	const mergedSettings: Partial<Record<SettingPath, unknown>> = {
+		...snapshot,
+		...overrides,
+	};
+	const configuredChildContextBudget = Number(mergedSettings["task.childContextBudgetTokens"] ?? 0);
+	const childContextBudgetTokens = Number.isFinite(configuredChildContextBudget)
+		? Math.max(0, Math.trunc(configuredChildContextBudget))
+		: 0;
+	// Preserve the inherited fixed/percentage policy. Session maintenance knows
+	// the resolved model window and applies the child ceiling only when stricter.
+	mergedSettings["task.childContextBudgetTokens"] = childContextBudgetTokens;
 	return Settings.isolated(
 		{
-			...snapshot,
+			...mergedSettings,
 			// Async jobs and bash auto-backgrounding are inherited from the parent:
 			// background jobs are owner-routed to the subagent's own session, and
 			// the run driver's quiescence barrier + teardown reap guarantee no
@@ -889,7 +900,6 @@ export function createSubagentSettings(
 			// the parent task approval is the authorization boundary. Use yolo mode
 			// to preserve unattended subagent execution. User `tools.approval` policies still apply.
 			"tools.approvalMode": "yolo",
-			...overrides,
 		},
 		{ storage: baseSettings.getStorage() },
 	);

--- a/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
@@ -117,6 +117,7 @@ describe("AgentSession auto-compaction progress guard", () => {
 			}),
 			modelRegistry,
 			extensionRunner,
+			agentKind: "sub",
 		});
 	});
 
@@ -455,6 +456,36 @@ describe("AgentSession auto-compaction progress guard", () => {
 		expect(promptSpy).toHaveBeenCalledTimes(1);
 		const noProgress = notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes(NO_PROGRESS_FRAGMENT));
 		expect(noProgress.length).toBe(0);
+	});
+
+	it("uses the child ceiling for post-compaction headroom", async () => {
+		activateOngoingGoal("child-headroom");
+		session.settings.set("task.childContextBudgetTokens", 100_000);
+		session.settings.set("compaction.thresholdTokens", 150_000);
+		session.settings.set("compaction.thresholdPercent", -1);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		vi.spyOn(session.agent, "continue").mockResolvedValue();
+		// Below the configured 150k threshold's 120k recovery band, but above
+		// the child ceiling's 80k recovery band.
+		vi.spyOn(session, "getContextUsage").mockReturnValue({ tokens: 90_000, contextWindow: 200_000, percent: 45 });
+
+		const notices = collectNotices();
+		const { promise: compactionDone, resolve: onCompactionDone } = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_end") onCompactionDone();
+		});
+
+		const assistantMsg = highUsageAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await compactionDone;
+		await session.waitForIdle();
+
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes(NO_PROGRESS_FRAGMENT))).toHaveLength(
+			1,
+		);
 	});
 
 	it("rebases the in-flight prompt snapshot so mid-run compaction is not misread as a dead-end", async () => {

--- a/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
@@ -371,7 +371,7 @@ describe("AgentSession auto-compaction progress guard", () => {
 		expect(noProgress.length).toBe(1);
 	});
 
-	it("drains queued messages when no-op threshold compaction pauses automatic maintenance", async () => {
+	it("keeps queued messages gated when no-op threshold compaction creates no headroom", async () => {
 		session.agent.followUp({
 			role: "custom",
 			customType: "test",
@@ -380,9 +380,7 @@ describe("AgentSession auto-compaction progress guard", () => {
 			timestamp: Date.now(),
 		});
 
-		const continueSpy = vi.spyOn(session.agent, "continue").mockImplementation(async () => {
-			session.agent.clearAllQueues();
-		});
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
 		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
 		vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(undefined);
 
@@ -401,8 +399,8 @@ describe("AgentSession auto-compaction progress guard", () => {
 		await session.waitForIdle();
 
 		expect(promptSpy).not.toHaveBeenCalled();
-		expect(continueSpy).toHaveBeenCalledTimes(1);
-		expect(session.agent.hasQueuedMessages()).toBe(false);
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(session.agent.hasQueuedMessages()).toBe(true);
 		const noProgress = notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes(NO_PROGRESS_FRAGMENT));
 		expect(noProgress.length).toBe(1);
 	});
@@ -464,7 +462,7 @@ describe("AgentSession auto-compaction progress guard", () => {
 		session.settings.set("compaction.thresholdTokens", 150_000);
 		session.settings.set("compaction.thresholdPercent", -1);
 		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
-		vi.spyOn(session.agent, "continue").mockResolvedValue();
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
 		// Below the configured 150k threshold's 120k recovery band, but above
 		// the child ceiling's 80k recovery band.
 		vi.spyOn(session, "getContextUsage").mockReturnValue({ tokens: 90_000, contextWindow: 200_000, percent: 45 });
@@ -483,6 +481,7 @@ describe("AgentSession auto-compaction progress guard", () => {
 		await session.waitForIdle();
 
 		expect(promptSpy).not.toHaveBeenCalled();
+		expect(continueSpy).not.toHaveBeenCalled();
 		expect(notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes(NO_PROGRESS_FRAGMENT))).toHaveLength(
 			1,
 		);
@@ -782,10 +781,10 @@ describe("AgentSession auto-compaction progress guard", () => {
 		);
 	});
 
-	it("restores the persisted overflow error before draining queued no-op recovery", async () => {
-		// A queued user turn still deserves a follow-up, but no-op recovery has not
-		// written a compaction summary. Restore the failed assistant before the queue
-		// drains so the transcript keeps the reason recovery stopped.
+	it("restores the persisted overflow error while queued no-op recovery remains parked", async () => {
+		// No-op recovery has not created child-clamped headroom. Restore the failed
+		// assistant for transcript fidelity, but leave the queued turn parked so its
+		// eventual delivery re-enters the pre-prompt child budget gate.
 		session.agent.followUp({
 			role: "custom",
 			customType: "test",
@@ -827,8 +826,8 @@ describe("AgentSession auto-compaction progress guard", () => {
 		await session.waitForIdle();
 
 		expect(promptSpy).not.toHaveBeenCalled();
-		expect(continueSpy).toHaveBeenCalledTimes(1);
-		expect(session.agent.hasQueuedMessages()).toBe(false);
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(session.agent.hasQueuedMessages()).toBe(true);
 		expect(sessionManager.getBranch()).toContainEqual(
 			expect.objectContaining({
 				type: "message",

--- a/packages/coding-agent/test/agent-session-context-promotion.test.ts
+++ b/packages/coding-agent/test/agent-session-context-promotion.test.ts
@@ -8,6 +8,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { createSubagentSettings } from "@oh-my-pi/pi-coding-agent/task/executor";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("AgentSession context promotion", () => {
@@ -22,13 +23,11 @@ describe("AgentSession context promotion", () => {
 		// tests here (tests only read models and add benign extra runtime keys),
 		// so build them once instead of paying ~950ms across the 9 cases.
 		//
-		// The bundled catalog no longer ships a codex model whose configured
-		// promotion target has a strictly larger window (gpt-5.5's bundled target
-		// gpt-5.4 is a same-window no-op the runtime rejects), so pin
-		// gpt-5.5 (272k) -> gpt-5.6-sol (372k) via modelOverrides — the same
-		// mechanism users configure promotion pairs with. gpt-5.4-mini is pinned
-		// text-only so the snapcompact-fallback case has a codex model on which
-		// snapcompact (vision-based) cannot run.
+		// The bundled catalog no longer ships a Codex promotion pair with
+		// increasing windows, so pin gpt-5.6-luna (272k) -> gpt-5.6-terra (372k)
+		// via modelOverrides — the same mechanism users configure promotion pairs
+		// with. Luna's override is text-only, ensuring snapcompact (vision-based)
+		// cannot run.
 		tempDir = TempDir.createSync("@pi-context-promotion-");
 		const modelsConfigPath = path.join(tempDir.path(), "models.json");
 		await Bun.write(
@@ -37,8 +36,11 @@ describe("AgentSession context promotion", () => {
 				providers: {
 					"openai-codex": {
 						modelOverrides: {
-							"gpt-5.5": { contextPromotionTarget: "openai-codex/gpt-5.6-sol" },
-							"gpt-5.4-mini": { input: ["text"] },
+							"gpt-5.6-luna": {
+								contextWindow: 272_000,
+								contextPromotionTarget: "openai-codex/gpt-5.6-terra",
+								input: ["text"],
+							},
 						},
 					},
 				},
@@ -156,8 +158,8 @@ describe("AgentSession context promotion", () => {
 	}
 
 	it("promotes to a larger-context model on overflow and clears codex websocket session state", async () => {
-		const smallModel = modelRegistry.find("openai-codex", "gpt-5.5");
-		const largeModel = modelRegistry.find("openai-codex", "gpt-5.6-sol");
+		const smallModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
+		const largeModel = modelRegistry.find("openai-codex", "gpt-5.6-terra");
 		if (!smallModel || !largeModel) {
 			throw new Error("Expected small and large codex models to exist");
 		}
@@ -200,9 +202,246 @@ describe("AgentSession context promotion", () => {
 		expect(session.providerSessionState.size).toBe(0);
 	});
 
+	it("compacts an oversized child prompt instead of promoting past its context budget", async () => {
+		const smallModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
+		const largeModel = modelRegistry.find("openai-codex", "gpt-5.6-terra");
+		if (!smallModel || !largeModel) {
+			throw new Error("Expected small and large codex models to exist");
+		}
+
+		const settings = createSubagentSettings(
+			Settings.isolated({
+				"task.childContextBudgetTokens": 50,
+				"compaction.enabled": true,
+				"compaction.autoContinue": false,
+				"compaction.strategy": "context-full",
+				"compaction.keepRecentTokens": 1,
+				"contextPromotion.enabled": true,
+			}),
+		);
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage(createUserMessage("old child context ".repeat(120)));
+		sessionManager.appendMessage(createAssistantMessage(smallModel, "old response"));
+
+		const agent = new Agent({
+			initialState: {
+				model: smallModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: sessionManager.buildSessionContext().messages,
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			agentKind: "sub",
+		});
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: "budgeted child summary",
+			shortSummary: undefined,
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+		}));
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockImplementation(async () => {
+			expect(sessionManager.getEntries().some(entry => entry.type === "compaction")).toBe(true);
+		});
+
+		await session.prompt("pending child prompt ".repeat(120));
+
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(session.model?.id).toBe(smallModel.id);
+		expect(session.model?.id).not.toBe(largeModel.id);
+	});
+
+	it("preserves percentage-threshold promotion while a child remains below its looser budget", async () => {
+		const smallModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
+		const largeModel = modelRegistry.find("openai-codex", "gpt-5.6-terra");
+		if (!smallModel || !largeModel) {
+			throw new Error("Expected small and large codex models to exist");
+		}
+
+		const settings = createSubagentSettings(
+			Settings.isolated({
+				"task.childContextBudgetTokens": 100_000,
+				"compaction.thresholdTokens": -1,
+				"compaction.thresholdPercent": 1,
+				"compaction.enabled": true,
+				"compaction.strategy": "context-full",
+				"contextPromotion.enabled": true,
+			}),
+		);
+		const agent = new Agent({
+			initialState: {
+				model: smallModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			agentKind: "sub",
+		});
+		const compactSpy = vi.spyOn(compactionModule, "compact");
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+
+		await session.prompt("pending child prompt ".repeat(2_000));
+
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(compactSpy).not.toHaveBeenCalled();
+		expect(session.model?.provider).toBe(largeModel.provider);
+		expect(session.model?.id).toBe(largeModel.id);
+	});
+
+	it("does not compact or promote when pruning brings a child below its ceiling", async () => {
+		const smallModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
+		const largeModel = modelRegistry.find("openai-codex", "gpt-5.6-terra");
+		if (!smallModel || !largeModel) {
+			throw new Error("Expected small and large codex models to exist");
+		}
+
+		const settings = createSubagentSettings(
+			Settings.isolated({
+				"task.childContextBudgetTokens": 100_000,
+				"compaction.thresholdTokens": 150_000,
+				"compaction.enabled": true,
+				"compaction.strategy": "context-full",
+				"compaction.dropUseless": true,
+				"compaction.keepRecentTokens": 1,
+				"contextPromotion.enabled": true,
+			}),
+		);
+		const sessionManager = SessionManager.inMemory();
+		const now = Date.now();
+		sessionManager.appendMessage(createUserMessage("Investigate everything."));
+		const largeCallId = "call-large-useless";
+		sessionManager.appendMessage({
+			...createAssistantMessage(smallModel),
+			content: [{ type: "toolCall", id: largeCallId, name: "grep", arguments: { pattern: "TODO" } }],
+			stopReason: "toolUse",
+			timestamp: now - 20,
+		});
+		sessionManager.appendMessage({
+			role: "toolResult",
+			toolCallId: largeCallId,
+			toolName: "grep",
+			content: [{ type: "text", text: "match line\n".repeat(20_000) }],
+			isError: false,
+			useless: true,
+			timestamp: now - 19,
+		});
+		for (let index = 0; index < 4; index++) {
+			const callId = `call-small-${index}`;
+			sessionManager.appendMessage({
+				...createAssistantMessage(smallModel),
+				content: [{ type: "toolCall", id: callId, name: "read", arguments: { path: `note-${index}.md` } }],
+				stopReason: "toolUse",
+				timestamp: now - 18 + index * 2,
+			});
+			sessionManager.appendMessage({
+				role: "toolResult",
+				toolCallId: callId,
+				toolName: "read",
+				content: [{ type: "text", text: `tiny note ${index}` }],
+				isError: false,
+				timestamp: now - 17 + index * 2,
+			});
+		}
+
+		const agent = new Agent({
+			initialState: {
+				model: smallModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: sessionManager.buildSessionContext().messages,
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			agentKind: "sub",
+		});
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+			summary: "unexpected child compaction",
+			shortSummary: undefined,
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: preparation.tokensBefore,
+			details: {},
+		}));
+		const finalAssistant = {
+			...createAssistantMessage(smallModel, "continuing"),
+			usage: {
+				input: 120_000,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 120_001,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+		};
+
+		session.agent.emitExternalEvent({ type: "message_end", message: finalAssistant });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [finalAssistant] });
+		await settle();
+
+		expect(compactSpy).not.toHaveBeenCalled();
+		expect(session.model?.provider).toBe(smallModel.provider);
+		expect(session.model?.id).toBe(smallModel.id);
+		expect(session.model?.id).not.toBe(largeModel.id);
+	});
+
+	it("preserves overflow promotion for a budgeted child when compaction is disabled", async () => {
+		const smallModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
+		const largeModel = modelRegistry.find("openai-codex", "gpt-5.6-terra");
+		if (!smallModel || !largeModel) {
+			throw new Error("Expected small and large codex models to exist");
+		}
+
+		const settings = createSubagentSettings(
+			Settings.isolated({
+				"task.childContextBudgetTokens": 50,
+				"compaction.enabled": false,
+				"contextPromotion.enabled": true,
+			}),
+		);
+		const agent = new Agent({
+			initialState: {
+				model: smallModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			agentKind: "sub",
+		});
+
+		const overflowMessage = createOverflowMessage(smallModel);
+		session.agent.emitExternalEvent({ type: "message_end", message: overflowMessage });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [overflowMessage] });
+
+		await waitFor(() => session.model?.id === largeModel.id);
+
+		expect(session.model?.provider).toBe(largeModel.provider);
+		expect(session.model?.id).toBe(largeModel.id);
+	});
+
 	it("promotes on 413 payload-too-large overflow errors", async () => {
-		const smallModel = modelRegistry.find("openai-codex", "gpt-5.5");
-		const largeModel = modelRegistry.find("openai-codex", "gpt-5.6-sol");
+		const smallModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
+		const largeModel = modelRegistry.find("openai-codex", "gpt-5.6-terra");
 		if (!smallModel || !largeModel) {
 			throw new Error("Expected small and large codex models to exist");
 		}
@@ -241,7 +480,7 @@ describe("AgentSession context promotion", () => {
 		expect(session.model?.id).toBe(largeModel.id);
 	});
 	it("clears codex provider session state on manual setModel switch away from codex", async () => {
-		const codexModel = modelRegistry.find("openai-codex", "gpt-5.4");
+		const codexModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
 		const nonCodexModel = modelRegistry.getAll().find(model => model.api !== "openai-codex-responses");
 		if (!codexModel || !nonCodexModel) {
 			throw new Error("Expected codex and non-codex models to exist");
@@ -278,7 +517,7 @@ describe("AgentSession context promotion", () => {
 	});
 
 	it("clears codex provider session state on manual temporary switch into codex", async () => {
-		const codexModel = modelRegistry.find("openai-codex", "gpt-5.4");
+		const codexModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
 		const nonCodexModel = modelRegistry.getAll().find(model => model.api !== "openai-codex-responses");
 		if (!codexModel || !nonCodexModel) {
 			throw new Error("Expected codex and non-codex models to exist");
@@ -315,7 +554,7 @@ describe("AgentSession context promotion", () => {
 	});
 
 	it("clears codex provider session state when branching rewrites history", async () => {
-		const codexModel = modelRegistry.find("openai-codex", "gpt-5.4");
+		const codexModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
 		if (!codexModel) {
 			throw new Error("Expected codex model to exist");
 		}
@@ -356,7 +595,7 @@ describe("AgentSession context promotion", () => {
 	});
 
 	it("clears codex provider session state when tree navigation rewrites history", async () => {
-		const codexModel = modelRegistry.find("openai-codex", "gpt-5.4");
+		const codexModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
 		if (!codexModel) {
 			throw new Error("Expected codex model to exist");
 		}
@@ -397,7 +636,7 @@ describe("AgentSession context promotion", () => {
 	});
 
 	it("does not promote when promotion is disabled", async () => {
-		const smallModel = modelRegistry.find("openai-codex", "gpt-5.5");
+		const smallModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
 		if (!smallModel) {
 			throw new Error("Expected small codex model to exist");
 		}
@@ -441,7 +680,7 @@ describe("AgentSession context promotion", () => {
 	});
 
 	it("does not promote by default", async () => {
-		const smallModel = modelRegistry.find("openai-codex", "gpt-5.5");
+		const smallModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
 		if (!smallModel) {
 			throw new Error("Expected small codex model to exist");
 		}
@@ -473,7 +712,7 @@ describe("AgentSession context promotion", () => {
 	});
 
 	it("falls back to LLM compaction when snapcompact cannot run during overflow recovery", async () => {
-		const model = modelRegistry.find("openai-codex", "gpt-5.4-mini");
+		const model = modelRegistry.find("openai-codex", "gpt-5.6-luna");
 		if (!model) {
 			throw new Error("Expected codex model to exist");
 		}
@@ -534,8 +773,8 @@ describe("AgentSession context promotion", () => {
 	});
 
 	it("promotes to a larger-context model on response.incomplete (length stop)", async () => {
-		const smallModel = modelRegistry.find("openai-codex", "gpt-5.5");
-		const largeModel = modelRegistry.find("openai-codex", "gpt-5.6-sol");
+		const smallModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
+		const largeModel = modelRegistry.find("openai-codex", "gpt-5.6-terra");
 		if (!smallModel || !largeModel) {
 			throw new Error("Expected small and large codex models to exist");
 		}
@@ -575,8 +814,8 @@ describe("AgentSession context promotion", () => {
 		// Switching from a small-context model to a larger one and then receiving a
 		// stale length-stop event for the previous model must NOT trigger promotion
 		// or compaction on the new model — same guard as the overflow path.
-		const smallModel = modelRegistry.find("openai-codex", "gpt-5.5");
-		const largeModel = modelRegistry.find("openai-codex", "gpt-5.6-sol");
+		const smallModel = modelRegistry.find("openai-codex", "gpt-5.6-luna");
+		const largeModel = modelRegistry.find("openai-codex", "gpt-5.6-terra");
 		if (!smallModel || !largeModel) {
 			throw new Error("Expected small and large codex models to exist");
 		}

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -11,7 +11,11 @@ import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
-import { resolveSoftRequestBudget, runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
+import {
+	createSubagentSettings,
+	resolveSoftRequestBudget,
+	runSubprocess,
+} from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -383,5 +387,75 @@ describe("resolveSoftRequestBudget", () => {
 		expect(resolveSoftRequestBudget("scout", 0)).toBe(0);
 		expect(resolveSoftRequestBudget("scout", -5)).toBe(0);
 		expect(resolveSoftRequestBudget("scout", 20.9)).toBe(20);
+	});
+});
+
+describe("createSubagentSettings child context budget", () => {
+	it("leaves inherited compaction settings unchanged when the budget is disabled", () => {
+		expect(
+			createSubagentSettings(
+				Settings.isolated({
+					"task.childContextBudgetTokens": 0,
+					"compaction.thresholdTokens": 25_000,
+				}),
+			).get("compaction.thresholdTokens"),
+		).toBe(25_000);
+		expect(
+			createSubagentSettings(
+				Settings.isolated({
+					"task.childContextBudgetTokens": -1,
+					"compaction.thresholdTokens": 25_000,
+				}),
+			).get("compaction.thresholdTokens"),
+		).toBe(25_000);
+	});
+
+	it("rejects non-finite budgets without changing inherited context policy", () => {
+		for (const budget of [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NaN]) {
+			const settings = createSubagentSettings(
+				Settings.isolated({
+					"task.childContextBudgetTokens": budget,
+					"compaction.thresholdTokens": 25_000,
+					"contextPromotion.enabled": true,
+				}),
+			);
+			expect(settings.get("compaction.thresholdTokens")).toBe(25_000);
+			expect(settings.get("task.childContextBudgetTokens")).toBe(0);
+			expect(settings.get("contextPromotion.enabled")).toBe(true);
+		}
+	});
+
+	it("truncates a positive budget without replacing the inherited threshold policy", () => {
+		const settings = createSubagentSettings(
+			Settings.isolated({
+				"task.childContextBudgetTokens": 64_000.9,
+				"compaction.thresholdTokens": -1,
+				"compaction.thresholdPercent": 10,
+			}),
+		);
+		expect(settings.get("task.childContextBudgetTokens")).toBe(64_000);
+		expect(settings.get("compaction.thresholdTokens")).toBe(-1);
+		expect(settings.get("compaction.thresholdPercent")).toBe(10);
+	});
+
+	it("preserves an inherited positive threshold that is stricter than the child budget", () => {
+		const settings = createSubagentSettings(
+			Settings.isolated({
+				"task.childContextBudgetTokens": 100_000,
+				"compaction.thresholdTokens": 25_000,
+			}),
+		);
+		expect(settings.get("compaction.thresholdTokens")).toBe(25_000);
+	});
+
+	it("preserves an inherited fixed threshold when the child budget is stricter", () => {
+		const settings = createSubagentSettings(
+			Settings.isolated({
+				"task.childContextBudgetTokens": 64_000,
+				"compaction.thresholdTokens": 100_000,
+			}),
+		);
+		expect(settings.get("task.childContextBudgetTokens")).toBe(64_000);
+		expect(settings.get("compaction.thresholdTokens")).toBe(100_000);
 	});
 });

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -95,7 +95,7 @@ async function createPersistedSession(cwd: string, restrictToolNames?: boolean, 
 	return sessionFile;
 }
 
-function createFactory(cwd: string, eventBus?: EventBus) {
+function createFactory(cwd: string, settings = Settings.isolated(), eventBus?: EventBus) {
 	const parentSession = {
 		sessionManager: {
 			getCwd: () => cwd,
@@ -109,7 +109,7 @@ function createFactory(cwd: string, eventBus?: EventBus) {
 		session: parentSession,
 		authStorage: {} as never,
 		modelRegistry: { authStorage: {} } as ModelRegistry,
-		settings: Settings.isolated(),
+		settings,
 		enableLsp: true,
 		eventBus,
 	});
@@ -245,7 +245,7 @@ describe("persisted subagent revival", () => {
 			sessionFile,
 			status: "parked",
 		});
-		const reviver = await createFactory(cwd, eventBus)(ref);
+		const reviver = await createFactory(cwd, undefined, eventBus)(ref);
 		if (!reviver) throw new Error("Expected a persisted reviver");
 		await reviver(ref);
 
@@ -276,5 +276,27 @@ describe("persisted subagent revival", () => {
 		rpcRegistry.dispose();
 		AgentLifecycleManager.resetGlobalForTests();
 		AgentRegistry.resetGlobalForTests();
+	});
+
+	it("keeps the child context budget on a cold-revived session", async () => {
+		const cwd = makeTempDir("@pi-budgeted-revive-");
+		const sessionFile = await createPersistedSession(cwd);
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const settings = Settings.isolated({
+			"task.childContextBudgetTokens": 64_000,
+			"compaction.thresholdTokens": 100_000,
+		});
+		const reviver = await createFactory(cwd, settings)(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.settings?.get("task.childContextBudgetTokens")).toBe(64_000);
+		expect(capturedOptions?.settings?.get("compaction.thresholdTokens")).toBe(100_000);
 	});
 });


### PR DESCRIPTION
## What

Add `task.childContextBudgetTokens` for subagent sessions. A positive value clamps the child compaction threshold to the lower of the inherited threshold and the configured budget. It also gives compaction precedence over context promotion so oversized child history is reduced before the next provider request. `0` leaves the budget disabled.

The policy is applied through the shared child-settings path, covering live task children, cold-revived children, and `/tan` child sessions.

## Why

Large inherited histories can repeatedly inflate child first-token latency. This setting provides an opt-in child-specific ceiling while preserving existing behavior by default.

## Verification

- `bun test packages/coding-agent/test/task/executor-soft-budget.test.ts packages/coding-agent/test/task/persisted-revive.test.ts packages/coding-agent/test/agent-session-context-promotion.test.ts`
- `bun --cwd=packages/coding-agent run check`

- [x] Focused tests pass
- [x] Type check passes
- [x] CHANGELOG updated