### PR TITLE
feat(omp): navigate conversation turns in tree

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added Home/End navigation in `/tree` to jump directly to the first/latest user or assistant turn while skipping tool and bookkeeping entries.
+- Added Alt+Up/Alt+Down navigation in `/tree` to traverse previous/next user or assistant turns while skipping tool and bookkeeping entries, plus Home/End shortcuts for the first/latest turn.
 
 
 ## [17.2.1] - 2026-07-30

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Home/End navigation in `/tree` to jump directly to the first/latest user or assistant turn while skipping tool and bookkeeping entries.
+
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added turn-aware `/tree` navigation: Alt+Up/Alt+Down traverses previous/next user or assistant turns while skipping tool and bookkeeping entries, Home/End jumps to the first/latest turn, and PageUp/PageDown moves by a visible page.
+- Added turn-aware `/tree` navigation: Alt+Up/Alt+Down traverses previous/next user or assistant turns while skipping tool and bookkeeping entries, Home/End jumps to the first/last visible item, and PageUp/PageDown moves by a visible page.
 
 
 ## [17.2.1] - 2026-07-30

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added Alt+Up/Alt+Down navigation in `/tree` to traverse previous/next user or assistant turns while skipping tool and bookkeeping entries, plus Home/End shortcuts for the first/latest turn.
+- Added turn-aware `/tree` navigation: Alt+Up/Alt+Down traverses previous/next user or assistant turns while skipping tool and bookkeeping entries, Home/End jumps to the first/latest turn, and PageUp/PageDown moves by a visible page.
 
 
 ## [17.2.1] - 2026-07-30

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -994,7 +994,7 @@ export class TreeSelectorComponent extends Container {
 			new TruncatedText(
 				theme.fg(
 					"muted",
-					"Enter: switch. Alt+↑/↓: previous/next turn. PgUp/PgDn: page. Home/End: first/latest turn. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
+					"Enter: switch. Alt+↑/↓: previous/next turn. PgUp/PgDn (←/→): page. Home/End: first/latest turn. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
 				),
 				0,
 				0,

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -801,33 +801,19 @@ class TreeList implements Component {
 		}
 	}
 
-	#jumpToTurnBoundary(boundary: "first" | "last"): void {
-		const start = boundary === "first" ? 0 : this.#filteredNodes.length - 1;
-		const step = boundary === "first" ? 1 : -1;
-		for (let index = start; index >= 0 && index < this.#filteredNodes.length; index += step) {
-			const entry = this.#filteredNodes[index]?.node.entry;
-			if (entry?.type === "message" && (entry.message.role === "user" || entry.message.role === "assistant")) {
-				this.#selectedIndex = index;
-				return;
-			}
-		}
-	}
-
 	handleInput(keyData: string): void {
-		if (matchesKey(keyData, "alt+up")) {
-			this.#moveToAdjacentTurn(-1);
-		} else if (matchesKey(keyData, "alt+down")) {
-			this.#moveToAdjacentTurn(1);
-		} else if (matchesSelectUp(keyData)) {
+		if (matchesSelectUp(keyData)) {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.#filteredNodes.length - 1 : this.#selectedIndex - 1;
 		} else if (matchesSelectDown(keyData)) {
 			this.#selectedIndex = this.#selectedIndex === this.#filteredNodes.length - 1 ? 0 : this.#selectedIndex + 1;
+		} else if (matchesKey(keyData, "alt+up")) {
+			this.#moveToAdjacentTurn(-1);
+		} else if (matchesKey(keyData, "alt+down")) {
+			this.#moveToAdjacentTurn(1);
 		} else if (matchesKey(keyData, "home")) {
-			// Jump to the earliest actual conversation turn, skipping tool and bookkeeping entries.
-			this.#jumpToTurnBoundary("first");
+			this.#selectedIndex = 0;
 		} else if (matchesKey(keyData, "end")) {
-			// Jump to the latest actual conversation turn, skipping tool and bookkeeping entries.
-			this.#jumpToTurnBoundary("last");
+			this.#selectedIndex = Math.max(0, this.#filteredNodes.length - 1);
 		} else if (matchesSelectPageUp(keyData) || matchesKey(keyData, "left")) {
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - this.maxVisibleLines);
 		} else if (matchesSelectPageDown(keyData) || matchesKey(keyData, "right")) {
@@ -994,7 +980,7 @@ export class TreeSelectorComponent extends Container {
 			new TruncatedText(
 				theme.fg(
 					"muted",
-					"Enter: switch. Alt+↑/↓: previous/next turn. PgUp/PgDn (←/→): page. Home/End: first/latest turn. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
+					"Enter: switch. Alt+↑/↓: previous/next turn. PgUp/PgDn (←/→): page. Home/End: first/last item. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
 				),
 				0,
 				0,

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -781,11 +781,29 @@ class TreeList implements Component {
 		}
 	}
 
+	#jumpToTurnBoundary(boundary: "first" | "last"): void {
+		const start = boundary === "first" ? 0 : this.#filteredNodes.length - 1;
+		const step = boundary === "first" ? 1 : -1;
+		for (let index = start; index >= 0 && index < this.#filteredNodes.length; index += step) {
+			const entry = this.#filteredNodes[index].node.entry;
+			if (entry.type === "message" && (entry.message.role === "user" || entry.message.role === "assistant")) {
+				this.#selectedIndex = index;
+				return;
+			}
+		}
+	}
+
 	handleInput(keyData: string): void {
 		if (matchesSelectUp(keyData)) {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.#filteredNodes.length - 1 : this.#selectedIndex - 1;
 		} else if (matchesSelectDown(keyData)) {
 			this.#selectedIndex = this.#selectedIndex === this.#filteredNodes.length - 1 ? 0 : this.#selectedIndex + 1;
+		} else if (matchesKey(keyData, "home")) {
+			// Jump to the earliest actual conversation turn, skipping tool and bookkeeping entries.
+			this.#jumpToTurnBoundary("first");
+		} else if (matchesKey(keyData, "end")) {
+			// Jump to the latest actual conversation turn, skipping tool and bookkeeping entries.
+			this.#jumpToTurnBoundary("last");
 		} else if (matchesKey(keyData, "left")) {
 			// Page up
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - this.maxVisibleLines);
@@ -954,7 +972,7 @@ export class TreeSelectorComponent extends Container {
 			new TruncatedText(
 				theme.fg(
 					"muted",
-					"Enter: switch. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
+					"Enter: switch. Home/End: first/latest turn. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
 				),
 				0,
 				0,

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -781,12 +781,26 @@ class TreeList implements Component {
 		}
 	}
 
+	#moveToAdjacentTurn(direction: -1 | 1): void {
+		for (
+			let index = this.#selectedIndex + direction;
+			index >= 0 && index < this.#filteredNodes.length;
+			index += direction
+		) {
+			const entry = this.#filteredNodes[index]?.node.entry;
+			if (entry?.type === "message" && (entry.message.role === "user" || entry.message.role === "assistant")) {
+				this.#selectedIndex = index;
+				return;
+			}
+		}
+	}
+
 	#jumpToTurnBoundary(boundary: "first" | "last"): void {
 		const start = boundary === "first" ? 0 : this.#filteredNodes.length - 1;
 		const step = boundary === "first" ? 1 : -1;
 		for (let index = start; index >= 0 && index < this.#filteredNodes.length; index += step) {
-			const entry = this.#filteredNodes[index].node.entry;
-			if (entry.type === "message" && (entry.message.role === "user" || entry.message.role === "assistant")) {
+			const entry = this.#filteredNodes[index]?.node.entry;
+			if (entry?.type === "message" && (entry.message.role === "user" || entry.message.role === "assistant")) {
 				this.#selectedIndex = index;
 				return;
 			}
@@ -794,7 +808,11 @@ class TreeList implements Component {
 	}
 
 	handleInput(keyData: string): void {
-		if (matchesSelectUp(keyData)) {
+		if (matchesKey(keyData, "alt+up")) {
+			this.#moveToAdjacentTurn(-1);
+		} else if (matchesKey(keyData, "alt+down")) {
+			this.#moveToAdjacentTurn(1);
+		} else if (matchesSelectUp(keyData)) {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.#filteredNodes.length - 1 : this.#selectedIndex - 1;
 		} else if (matchesSelectDown(keyData)) {
 			this.#selectedIndex = this.#selectedIndex === this.#filteredNodes.length - 1 ? 0 : this.#selectedIndex + 1;
@@ -972,7 +990,7 @@ export class TreeSelectorComponent extends Container {
 			new TruncatedText(
 				theme.fg(
 					"muted",
-					"Enter: switch. Home/End: first/latest turn. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
+					"Enter: switch. Alt+↑/↓: previous/next turn. Home/End: first/latest turn. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
 				),
 				0,
 				0,

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -13,7 +13,13 @@ import {
 } from "@oh-my-pi/pi-tui";
 import type { TreeFilterMode } from "../../config/settings-schema";
 import { theme } from "../../modes/theme/theme";
-import { matchesAppInterrupt, matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
+import {
+	matchesAppInterrupt,
+	matchesSelectDown,
+	matchesSelectPageDown,
+	matchesSelectPageUp,
+	matchesSelectUp,
+} from "../../modes/utils/keybinding-matchers";
 import type { SessionTreeNode } from "../../session/session-entries";
 import { toPathList } from "../../tools/path-utils";
 import { shortenPath } from "../../tools/render-utils";
@@ -822,11 +828,9 @@ class TreeList implements Component {
 		} else if (matchesKey(keyData, "end")) {
 			// Jump to the latest actual conversation turn, skipping tool and bookkeeping entries.
 			this.#jumpToTurnBoundary("last");
-		} else if (matchesKey(keyData, "left")) {
-			// Page up
+		} else if (matchesSelectPageUp(keyData) || matchesKey(keyData, "left")) {
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - this.maxVisibleLines);
-		} else if (matchesKey(keyData, "right")) {
-			// Page down
+		} else if (matchesSelectPageDown(keyData) || matchesKey(keyData, "right")) {
 			this.#selectedIndex = Math.min(this.#filteredNodes.length - 1, this.#selectedIndex + this.maxVisibleLines);
 		} else if (matchesKey(keyData, "shift+enter") || matchesKey(keyData, "shift+return")) {
 			// Summarize-and-switch: fork with a branch summary without the extra prompt.
@@ -990,7 +994,7 @@ export class TreeSelectorComponent extends Container {
 			new TruncatedText(
 				theme.fg(
 					"muted",
-					"Enter: switch. Alt+↑/↓: previous/next turn. Home/End: first/latest turn. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
+					"Enter: switch. Alt+↑/↓: previous/next turn. PgUp/PgDn: page. Home/End: first/latest turn. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
 				),
 				0,
 				0,

--- a/packages/coding-agent/test/keybindings-selector-navigation.test.ts
+++ b/packages/coding-agent/test/keybindings-selector-navigation.test.ts
@@ -212,6 +212,32 @@ describe("selector navigation keybindings", () => {
 		expect(selected).toEqual(["second-user", "assistant", "first-user", "assistant", "second-user", "first-user"]);
 	});
 
+	it("uses PageUp and PageDown to move by a visible page in the session tree", () => {
+		const root = createMessageNode("node-0", null, "Message 0");
+		let parent = root;
+		for (let index = 1; index <= 25; index++) {
+			const child = createMessageNode(`node-${index}`, parent.entry.id, `Message ${index}`);
+			parent.children.push(child);
+			parent = child;
+		}
+
+		const selected: string[] = [];
+		const selector = new TreeSelectorComponent(
+			[root],
+			"node-0",
+			40,
+			id => selected.push(id),
+			() => {},
+		);
+
+		selector.handleInput("\x1b[6~");
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[5~");
+		selector.handleInput("\n");
+
+		expect(selected).toEqual(["node-20", "node-0"]);
+	});
+
 	it("uses tui.select.up in the user message selector", () => {
 		setKeybindings(TEST_KEYBINDINGS);
 		const selected: string[] = [];

--- a/packages/coding-agent/test/keybindings-selector-navigation.test.ts
+++ b/packages/coding-agent/test/keybindings-selector-navigation.test.ts
@@ -146,7 +146,7 @@ describe("selector navigation keybindings", () => {
 
 		expect(selected).toEqual(["child"]);
 	});
-	it("uses Home and End to jump between actual turns in the session tree", () => {
+	it("traverses actual turns while skipping tool results in the session tree", () => {
 		const firstUser = createMessageNode("first-user", null, "First question");
 		const assistant = createAgentMessageNode("assistant", "first-user", {
 			role: "assistant",
@@ -165,32 +165,51 @@ describe("selector navigation keybindings", () => {
 			stopReason: "toolUse",
 			timestamp: 2,
 		});
-		const toolResult = createAgentMessageNode("tool-result", "assistant", {
+		const firstToolResult = createAgentMessageNode("first-tool-result", "assistant", {
 			role: "toolResult",
 			toolCallId: "call-1",
 			toolName: "read",
-			content: [{ type: "text", text: "file contents" }],
+			content: [{ type: "text", text: "first file contents" }],
 			isError: false,
 			timestamp: 3,
 		});
+		const secondUser = createMessageNode("second-user", "first-tool-result", "Second question");
+		const trailingToolResult = createAgentMessageNode("trailing-tool-result", "second-user", {
+			role: "toolResult",
+			toolCallId: "call-2",
+			toolName: "read",
+			content: [{ type: "text", text: "second file contents" }],
+			isError: false,
+			timestamp: 5,
+		});
 		firstUser.children.push(assistant);
-		assistant.children.push(toolResult);
+		assistant.children.push(firstToolResult);
+		firstToolResult.children.push(secondUser);
+		secondUser.children.push(trailingToolResult);
 
 		const selected: string[] = [];
 		const selector = new TreeSelectorComponent(
 			[firstUser],
-			"tool-result",
+			"trailing-tool-result",
 			40,
 			id => selected.push(id),
 			() => {},
 		);
 
-		selector.handleInput("\x1b[H");
+		selector.handleInput("\x1b[1;3A");
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[1;3A");
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[1;3A");
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[1;3B");
 		selector.handleInput("\n");
 		selector.handleInput("\x1b[F");
 		selector.handleInput("\n");
+		selector.handleInput("\x1b[H");
+		selector.handleInput("\n");
 
-		expect(selected).toEqual(["first-user", "assistant"]);
+		expect(selected).toEqual(["second-user", "assistant", "first-user", "assistant", "second-user", "first-user"]);
 	});
 
 	it("uses tui.select.up in the user message selector", () => {

--- a/packages/coding-agent/test/keybindings-selector-navigation.test.ts
+++ b/packages/coding-agent/test/keybindings-selector-navigation.test.ts
@@ -146,7 +146,7 @@ describe("selector navigation keybindings", () => {
 
 		expect(selected).toEqual(["child"]);
 	});
-	it("traverses actual turns while skipping tool results in the session tree", () => {
+	it("traverses actual turns and jumps to first/last visible tree items", () => {
 		const firstUser = createMessageNode("first-user", null, "First question");
 		const assistant = createAgentMessageNode("assistant", "first-user", {
 			role: "assistant",
@@ -209,7 +209,74 @@ describe("selector navigation keybindings", () => {
 		selector.handleInput("\x1b[H");
 		selector.handleInput("\n");
 
-		expect(selected).toEqual(["second-user", "assistant", "first-user", "assistant", "second-user", "first-user"]);
+		expect(selected).toEqual([
+			"second-user",
+			"assistant",
+			"first-user",
+			"assistant",
+			"trailing-tool-result",
+			"first-user",
+		]);
+	});
+
+	it("honors configured row bindings before Alt+Up and Alt+Down turn traversal", () => {
+		setKeybindings(
+			KeybindingsManager.inMemory({
+				"tui.select.up": "alt+up",
+				"tui.select.down": "alt+down",
+			}),
+		);
+		const firstUser = createMessageNode("first-user", null, "First question");
+		const toolResult = createAgentMessageNode("tool-result", "first-user", {
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "read",
+			content: [{ type: "text", text: "file contents" }],
+			isError: false,
+			timestamp: 2,
+		});
+		const secondUser = createMessageNode("second-user", "tool-result", "Second question");
+		firstUser.children.push(toolResult);
+		toolResult.children.push(secondUser);
+
+		const selected: string[] = [];
+		const selector = new TreeSelectorComponent(
+			[firstUser],
+			"first-user",
+			40,
+			id => selected.push(id),
+			() => {},
+		);
+
+		selector.handleInput("\x1b[1;3B");
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[1;3A");
+		selector.handleInput("\n");
+
+		expect(selected).toEqual(["tool-result", "first-user"]);
+	});
+
+	it("uses rendered tree order for Home and End across branches", () => {
+		const root = createMessageNode("root", null, "Root");
+		const activeBranch = createMessageNode("active-branch", "root", "Active branch");
+		const inactiveBranch = createMessageNode("inactive-branch", "root", "Inactive branch");
+		root.children.push(activeBranch, inactiveBranch);
+
+		const selected: string[] = [];
+		const selector = new TreeSelectorComponent(
+			[root],
+			"active-branch",
+			40,
+			id => selected.push(id),
+			() => {},
+		);
+
+		selector.handleInput("\x1b[F");
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[H");
+		selector.handleInput("\n");
+
+		expect(selected).toEqual(["inactive-branch", "root"]);
 	});
 
 	it("uses PageUp and PageDown to move by a visible page in the session tree", () => {

--- a/packages/coding-agent/test/keybindings-selector-navigation.test.ts
+++ b/packages/coding-agent/test/keybindings-selector-navigation.test.ts
@@ -62,6 +62,18 @@ function createMessageNode(id: string, parentId: string | null, content: string)
 		children: [],
 	};
 }
+function createAgentMessageNode(id: string, parentId: string | null, message: AgentMessage): SessionTreeNode {
+	return {
+		entry: {
+			type: "message",
+			id,
+			parentId,
+			timestamp: "2024-01-01T00:00:00Z",
+			message,
+		},
+		children: [],
+	};
+}
 
 function createExtension(id: string, displayName: string): Extension {
 	return {
@@ -133,6 +145,52 @@ describe("selector navigation keybindings", () => {
 		selector.handleInput("\n");
 
 		expect(selected).toEqual(["child"]);
+	});
+	it("uses Home and End to jump between actual turns in the session tree", () => {
+		const firstUser = createMessageNode("first-user", null, "First question");
+		const assistant = createAgentMessageNode("assistant", "first-user", {
+			role: "assistant",
+			content: [{ type: "text", text: "Working on it" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "test",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: 2,
+		});
+		const toolResult = createAgentMessageNode("tool-result", "assistant", {
+			role: "toolResult",
+			toolCallId: "call-1",
+			toolName: "read",
+			content: [{ type: "text", text: "file contents" }],
+			isError: false,
+			timestamp: 3,
+		});
+		firstUser.children.push(assistant);
+		assistant.children.push(toolResult);
+
+		const selected: string[] = [];
+		const selector = new TreeSelectorComponent(
+			[firstUser],
+			"tool-result",
+			40,
+			id => selected.push(id),
+			() => {},
+		);
+
+		selector.handleInput("\x1b[H");
+		selector.handleInput("\n");
+		selector.handleInput("\x1b[F");
+		selector.handleInput("\n");
+
+		expect(selected).toEqual(["first-user", "assistant"]);
 	});
 
 	it("uses tui.select.up in the user message selector", () => {


### PR DESCRIPTION
## What

Add complete keyboard navigation to `/tree`:

- Alt+Up / Alt+Down selects the previous / next user or assistant message.
- PageUp / PageDown moves by one visible page.
- Home / End selects the first / last visible tree item.
- Configured row-navigation bindings take precedence if they claim Alt+Up or Alt+Down.
- Tool results and bookkeeping entries are skipped by turn traversal without changing tree visibility.
- Left / Right remain page-navigation aliases for compatibility.
- The selector footer advertises the shortcuts.

## Why

Tool-heavy sessions require many ordinary row-navigation keystrokes to move between meaningful turns or across long trees. Turn traversal and standard paging keep the complete tree visible while making both operations direct.

## Testing

- `bun test packages/coding-agent/test/keybindings-selector-navigation.test.ts` (10 pass)
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/modes/components/tree-selector.ts packages/coding-agent/test/keybindings-selector-navigation.test.ts`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

## AI Review Report

Implementation and regression coverage were agent-assisted. Coverage verifies turn traversal across tool results, custom Alt row-binding precedence, first/last visible-item behavior across branches, and one-visible-page PageUp/PageDown movement.

## Security Audit

No new inputs, persistence, network access, subprocesses, or privilege boundaries. The shortcuts only move selection among existing filtered tree nodes.