### PR TITLE
feat(coding-agent): add latency-aware role routing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -238,6 +238,9 @@
 - Fixed heavily branched conversation trees shifting linear continuations into disconnected columns.
 - Fixed plugin installation validation failures for legacy compatibility shims.
 - Removed hard-coded references to disabled or absent agents in system and tool prompts.
+### Added
+
+- Added `task.latencyAwareRouting` to skip session-default inheritance for the `smol`, `slow`, and `designer` agent roles. When enabled, those roles resolve directly from their role priority chains so discovery and design agents can stay on latency-optimized models while the primary session uses a stronger default.
 
 ## [17.2.4] - 2026-08-01
 
@@ -279,10 +282,6 @@
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
-### Added
-
-- Added `task.latencyAwareRouting` to skip session-default inheritance for the `smol`, `slow`, and `designer` agent roles. When enabled, those roles resolve directly from their role priority chains so discovery and design agents can stay on latency-optimized models while the primary session uses a stronger default.
-
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -279,6 +279,9 @@
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
+### Added
+
+- Added `task.latencyAwareRouting` to skip session-default inheritance for the `smol`, `slow`, and `designer` agent roles. When enabled, those roles resolve directly from their role priority chains so discovery and design agents can stay on latency-optimized models while the primary session uses a stronger default.
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -898,6 +898,7 @@ const MODEL_ROLE_ALIAS_PREFIXES = [MODEL_ROLE_ALIAS_PREFIX, LEGACY_MODEL_ROLE_AL
 
 export interface ModelRoleLookup {
 	getModelRole(role: ModelRole | string): string | undefined;
+	get?(path: "task.latencyAwareRouting"): boolean;
 }
 
 function isModelRole(role: string): role is ModelRole {
@@ -965,7 +966,12 @@ function isSessionInheritedAgentPattern(value: string): boolean {
 	);
 }
 
-function shouldInheritDefaultBeforePriority(role: ModelRole): boolean {
+function shouldInheritDefaultBeforePriority(
+	role: ModelRole,
+	settings: ModelRoleLookup | undefined,
+	applyLatencyAwareRouting: boolean,
+): boolean {
+	if (applyLatencyAwareRouting && settings?.get?.("task.latencyAwareRouting")) return false;
 	return role === "smol" || role === "slow" || role === "designer";
 }
 
@@ -995,9 +1001,10 @@ function resolveDefaultInheritedPatterns(
 	configuredDefault: string | undefined,
 	roleDefaults: string[],
 	settings: ModelRoleLookup | undefined,
+	applyLatencyAwareRouting: boolean,
 	visited: Set<string>,
 ): string[] {
-	if (!shouldInheritDefaultBeforePriority(role) || !configuredDefault) return [];
+	if (!shouldInheritDefaultBeforePriority(role, settings, applyLatencyAwareRouting) || !configuredDefault) return [];
 
 	const resolved: string[] = [];
 	for (const pattern of normalizeModelPatternList(configuredDefault)) {
@@ -1019,7 +1026,7 @@ function resolveDefaultInheritedPatterns(
 		if (aliasRole && !visited.has(aliasRole)) {
 			// Cross-role alias (e.g. modelRoles.default = "@slow"): resolve the
 			// concrete model patterns instead of another role alias.
-			const recursed = resolveConfiguredRolePattern(pattern, settings, new Set(visited));
+			const recursed = resolveConfiguredRolePattern(pattern, settings, applyLatencyAwareRouting, new Set(visited));
 			if (recursed && recursed.length > 0) {
 				resolved.push(...recursed);
 				continue;
@@ -1033,6 +1040,7 @@ function resolveDefaultInheritedPatterns(
 function resolveConfiguredRolePattern(
 	value: string,
 	settings?: ModelRoleLookup,
+	applyLatencyAwareRouting = true,
 	visited: Set<string> = new Set(),
 ): string[] | undefined {
 	const normalized = value.trim();
@@ -1054,7 +1062,14 @@ function resolveConfiguredRolePattern(
 	const resolved = configured
 		? normalizeModelPatternList(configured)
 		: isModelRole(role)
-			? resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited)
+			? resolveDefaultInheritedPatterns(
+					role,
+					configuredDefault,
+					roleDefaults,
+					settings,
+					applyLatencyAwareRouting,
+					visited,
+				)
 			: roleDefaults;
 	if (resolved.length === 0) {
 		resolved.push(...roleDefaults);
@@ -1075,7 +1090,7 @@ export function expandRoleAlias(value: string, settings?: ModelRoleLookup): stri
 		return settings?.getModelRole("default") ?? value;
 	}
 
-	const resolved = resolveConfiguredRolePattern(value, settings)?.[0];
+	const resolved = resolveConfiguredRolePattern(value, settings, false)?.[0];
 	return resolved ?? value;
 }
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4691,6 +4691,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"task.latencyAwareRouting": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tasks",
+			group: "Subagents",
+			label: "Latency-Aware Role Routing",
+			description:
+				"Prefer the first available model from each role's priority chain instead of inheriting the session default for the `smol`, `slow`, and `designer` roles. Useful when the default is a stronger but slower reasoning model and discovery agents should stay latency-optimized.",
+		},
+	},
+
 	"task.softRequestBudgetNotice": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -771,6 +771,7 @@ export class ModelHubComponent implements Component {
 				scope === "project"
 					? (this.#settings.getProjectModelRole(scopedRole) ?? this.#settings.getGlobalModelRole(scopedRole))
 					: this.#settings.getGlobalModelRole(scopedRole),
+			get: path => this.#settings.get(path),
 		};
 		return resolveModelRoleValue(roleValue, allModels, { settings: this.#settings, roleLookup });
 	}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -10,6 +10,7 @@ import {
 	type ThinkingLevel,
 } from "@oh-my-pi/pi-agent-core";
 import type {
+	Api,
 	Context,
 	CredentialDisabledEvent,
 	Effort,
@@ -2219,6 +2220,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				? availableModels
 				: allModels;
 			let usageFallbackTriggered = false;
+			let authPreflight: Map<Model<Api>, boolean> | undefined;
 			for (let patternIndex = 0; patternIndex < expandedModelPatterns.length; patternIndex += 1) {
 				const { pattern, retryFallback } = expandedModelPatterns[patternIndex];
 				const primary = parseModelPattern(pattern, resolutionModels, matchPreferences);
@@ -2298,8 +2300,40 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				}
 				let authFallbackUsed = false;
 				if (options.modelPatternAuthFallback) {
-					const primaryKey = await modelRegistry.getApiKey(primary.model);
-					if (primaryKey !== kNoAuth && !isAuthenticated(primaryKey)) {
+					authPreflight ??= new Map<Model<Api>, boolean>();
+					let primaryHasAuth = authPreflight.get(primary.model);
+					if (primaryHasAuth === undefined) {
+						const primaryKey = await modelRegistry.getApiKey(primary.model);
+						primaryHasAuth = primaryKey === kNoAuth || isAuthenticated(primaryKey);
+						authPreflight.set(primary.model, primaryHasAuth);
+					}
+					if (!primaryHasAuth) {
+						// Exhaust the expanded role chain before escalating to the
+						// stronger parent model.
+						let hasAuthenticatedRoleCandidate = false;
+						for (
+							let candidateIndex = patternIndex + 1;
+							candidateIndex < expandedModelPatterns.length;
+							candidateIndex += 1
+						) {
+							const candidateEntry = expandedModelPatterns[candidateIndex];
+							const candidate = parseModelPattern(candidateEntry.pattern, resolutionModels, matchPreferences);
+							if (!candidate.model || (candidateEntry.retryFallback && !hasModelAuth(candidate.model))) {
+								continue;
+							}
+							let candidateHasAuth = authPreflight.get(candidate.model);
+							if (candidateHasAuth === undefined) {
+								const candidateKey = await modelRegistry.getApiKey(candidate.model);
+								candidateHasAuth = candidateKey === kNoAuth || isAuthenticated(candidateKey);
+								authPreflight.set(candidate.model, candidateHasAuth);
+							}
+							if (candidateHasAuth) {
+								hasAuthenticatedRoleCandidate = true;
+								break;
+							}
+						}
+						if (hasAuthenticatedRoleCandidate) continue;
+
 						const fallback = parseModelPattern(
 							options.modelPatternAuthFallback,
 							resolutionModels,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2872,7 +2872,11 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			const retryFallbackRole = installSubagentRetryFallbackChain({
 				settings: subagentSettings,
 				id,
-				candidates: resolveSubagentRetryFallbackCandidates(configuredModelPatterns, modelRegistry, subagentSettings),
+				candidates: resolveSubagentRetryFallbackCandidates(
+					configuredModelPatterns,
+					modelRegistry,
+					subagentSettings,
+				),
 				inheritedFallbackChain: inheritedRetryFallbackChain,
 				model,
 				authFallbackUsed,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2872,7 +2872,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			const retryFallbackRole = installSubagentRetryFallbackChain({
 				settings: subagentSettings,
 				id,
-				candidates: resolveSubagentRetryFallbackCandidates(modelPatterns, modelRegistry, subagentSettings),
+				candidates: resolveSubagentRetryFallbackCandidates(configuredModelPatterns, modelRegistry, subagentSettings),
 				inheritedFallbackChain: inheritedRetryFallbackChain,
 				model,
 				authFallbackUsed,

--- a/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
+++ b/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
@@ -122,6 +122,40 @@ describe("subagent runtime model resolution", () => {
 		expect(result.resolvedModel).toBe("fallback/working-model");
 	});
 
+	it("expands latency-aware role aliases into the child retry fallback chain", async () => {
+		const primary = model("cerebras", "zai-glm-4.7");
+		const fallback = model("cerebras", "zai-glm-4.6");
+		const sessionDefault = model("parent", "strong-model");
+		let childFallbackChains: Record<string, string[]> | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childFallbackChains = options.settings?.get("retry.fallbackChains") as Record<string, string[]> | undefined;
+			return { session: createYieldingSession(), extensionsResult: {}, setToolUIContext: () => {} } as never;
+		});
+
+		const agent: AgentDefinition = { name: "smol", description: "test", systemPrompt: "test", source: "bundled" };
+		await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "latency-aware-role",
+			modelOverride: "@smol",
+			settings: Settings.isolated({
+				"task.latencyAwareRouting": true,
+				modelRoles: { default: "parent/strong-model" },
+			}),
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [primary, fallback, sessionDefault],
+				getApiKey: async () => "test-key",
+			} as never,
+			enableLsp: false,
+		});
+
+		expect(childFallbackChains?.["subagent:latency-aware-role"]).toEqual(["cerebras/zai-glm-4.6"]);
+	});
+
 	it("inherits an explicitly configured default fallback chain for a single subagent model", async () => {
 		const primary = model("lm-studio", "local-reviewer");
 		const fallback = model("openai-codex", "gpt-5.6-sol");

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -6,6 +6,7 @@ import {
 	expandRoleAlias,
 	extractExplicitThinkingSelector,
 	filterAvailableModelsByEnabledPatterns,
+	type ModelRoleLookup,
 	parseModelPattern,
 	parseModelString,
 	pickDefaultAvailableModel,
@@ -14,6 +15,7 @@ import {
 	resolveAgentPrewalkPattern,
 	resolveAllowedModels,
 	resolveCliModel,
+	resolveConfiguredModelPatterns,
 	resolveExplicitModelRole,
 	resolveModelFromString,
 	resolveModelOverride,
@@ -939,6 +941,33 @@ describe("resolveAgentModelPatterns", () => {
 		expect(resolveAgentModelPatterns({ agentModel: "@designer", settings })).toEqual(["local/llama"]);
 	});
 
+	test("latency-aware routing skips default inheritance for smol, slow, and designer roles", () => {
+		const settings = Settings.isolated({
+			"task.latencyAwareRouting": true,
+			modelRoles: { default: "local/llama" },
+		});
+
+		expect(resolveAgentModelPatterns({ agentModel: "@smol", settings })).toContain("cerebras/zai-glm-4.7");
+		expect(resolveAgentModelPatterns({ agentModel: "@smol", settings })).not.toContain("local/llama");
+		expect(resolveAgentModelPatterns({ agentModel: "@slow", settings })).toContain("openai-codex/gpt-5.5");
+		expect(resolveAgentModelPatterns({ agentModel: "@designer", settings })).toContain(
+			"google-gemini-cli/gemini-3.1-pro",
+		);
+	});
+
+	test("carries latency-aware routing through a scoped role lookup", () => {
+		const settings = Settings.isolated({ "task.latencyAwareRouting": true });
+		const roleLookup: ModelRoleLookup = {
+			getModelRole: role => (role === "default" ? "local/llama" : undefined),
+			get: path => settings.get(path),
+		};
+
+		const patterns = resolveConfiguredModelPatterns("@smol", roleLookup);
+
+		expect(patterns).toContain("cerebras/zai-glm-4.7");
+		expect(patterns).not.toContain("local/llama");
+	});
+
 	test("expands cross-role default aliases when inheriting for an unset role", () => {
 		const settings = Settings.isolated({
 			modelRoles: { default: "@slow", slow: "anthropic/claude-sonnet-4-5" },
@@ -953,6 +982,7 @@ describe("resolveAgentModelPatterns", () => {
 				default: "anthropic/claude-sonnet-4-5",
 				designer: "openai/gpt-4o",
 			},
+			"task.latencyAwareRouting": true,
 		});
 
 		const result = resolveAgentModelPatterns({
@@ -1774,6 +1804,15 @@ describe("expandRoleAlias", () => {
 		settings.setModelRole("default", "anthropic/claude-sonnet-4-5");
 
 		expect(expandRoleAlias("@vision", settings)).toBe("@vision");
+	});
+
+	test("preserves default inheritance for single-pattern alias expansion", () => {
+		const settings = Settings.isolated({
+			"task.latencyAwareRouting": true,
+			modelRoles: { default: "local/llama" },
+		});
+
+		expect(expandRoleAlias("@smol", settings)).toBe("local/llama");
 	});
 });
 

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -211,6 +211,45 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		}
 	});
 
+	test("tries an authenticated expanded role candidate before the parent auth fallback", async () => {
+		const parentModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!parentModel) {
+			throw new Error("Expected bundled anthropic parent model");
+		}
+		const settings = Settings.isolated({ "task.latencyAwareRouting": true });
+		settings.setModelRole("task", "runtime-provider/runtime-model,runtime-provider/runtime-reasoning-model");
+		const options = await buildSessionOptions("@task");
+		options.authStorage.setRuntimeApiKey(parentModel.provider, "parent-key");
+		const getApiKeySpy = vi.spyOn(options.modelRegistry, "getApiKey").mockImplementation(async requested => {
+			if (requested.provider === parentModel.provider) return "parent-key";
+			if (requested.id === "runtime-reasoning-model") return "runtime-key";
+			return undefined;
+		});
+
+		const { session, modelFallbackMessage } = await createAgentSession({
+			...options,
+			settings,
+			modelPatternAuthFallback: `${parentModel.provider}/${parentModel.id}`,
+			modelPatternFallbackRole: "subagent:latency-aware",
+			modelPatternDefaultFallbackChain: [`${parentModel.provider}/${parentModel.id}`],
+		});
+
+		try {
+			expect(session.model?.provider).toBe("runtime-provider");
+			expect(session.model?.id).toBe("runtime-reasoning-model");
+			expect(session.settings.getModelRole("subagent:latency-aware")).toBe(
+				"runtime-provider/runtime-reasoning-model",
+			);
+			expect(session.settings.get("retry.fallbackChains")["subagent:latency-aware"]).toEqual([
+				`${parentModel.provider}/${parentModel.id}`,
+			]);
+			expect(modelFallbackMessage).toBeUndefined();
+		} finally {
+			await session.dispose();
+			getApiKeySpy.mockRestore();
+		}
+	});
+
 	test("resolves deferred role-alias modelPattern after extension providers register", async () => {
 		const settings = Settings.isolated();
 		settings.setModelRole("smol", "runtime-provider/runtime-model");


### PR DESCRIPTION
## What

Add `task.latencyAwareRouting`. When enabled, the `smol`, `slow`, and `designer` roles skip session-default inheritance and resolve directly from their role priority chains.

I reviewed this change; it lets discovery and design agents stay on latency-optimized models while the primary session uses a stronger default.

## Why

Those roles currently inherit `modelRoles.default` before their own priority defaults. That is useful when the default is intentionally the desired worker model, but it routes latency-sensitive roles through the same strong model as the main session even when the user wants fast role defaults.

## Testing

- `bun test test/model-resolver.test.ts`
- `bun --cwd=packages/coding-agent run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)