### PR TITLE
perf(tui): batch persistence work off the render path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Batched same-turn file-session appends behind the session writer's microtask boundary. Render and tool paths can now record several transcript entries without paying one synchronous file write per entry, while explicit `flush()` and `close()` still make queued lines durable in order.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -870,9 +870,9 @@ export class SessionManager {
 			return;
 		}
 
-		// Hot path: append synchronously so the entry is durable the instant this
-		// returns (file/memory writers perform the write in-body). Never routed
-		// through the async disk chain — durability must hold without a flush().
+		// Hot path: queue the entry directly on the writer, outside the async disk
+		// chain. File writers batch same-turn appends until their microtask
+		// boundary; flush(), flushSync(), and close() drain that batch explicitly.
 		// A mid-close writer leaves `#writer` undefined, so `#appendWriter` simply
 		// opens a fresh append handle and the entry still lands.
 		try {
@@ -1555,6 +1555,7 @@ export class SessionManager {
 		if (this.#atomicEntryBatch) throw new Error("Cannot synchronously flush during an atomic session batch.");
 		if (this.#diskFailure) throw this.#diskFailure;
 		if (this.#fileIsCurrent && !this.#rewriteRequired) {
+			this.#writer?.flushSync?.();
 			const writerError = this.#writer?.getError();
 			if (writerError) throw writerError;
 			return;

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -14,14 +14,17 @@ export interface SessionStorageStat {
 
 export interface SessionStorageWriter {
 	/**
-	 * Append one newline-terminated line. File and memory storage perform the
-	 * write synchronously in-body; indexed backends queue in call order.
+	 * Append one newline-terminated line. File storage batches same-turn appends
+	 * until its microtask boundary; memory storage updates in-body; indexed
+	 * backends queue in call order.
 	 *
 	 * `line` MUST include the trailing newline.
 	 */
 	append(line: string): Promise<void>;
 	/** Resolve once all queued appends complete. No fsync. */
 	flush(): Promise<void>;
+	/** Drain synchronously flushable queued work when the backend supports it. No fsync. */
+	flushSync?(): void;
 	/** False once close() has begun/finished. */
 	isOpen(): boolean;
 	close(): Promise<void>;
@@ -152,6 +155,11 @@ class FileSessionStorageWriter implements SessionStorageWriter {
 		if (this.#error) throw this.#error;
 	}
 
+	flushSync(): void {
+		this.#flushPendingNow();
+		if (this.#error) throw this.#error;
+	}
+
 	isOpen(): boolean {
 		return !this.#closed;
 	}
@@ -167,6 +175,7 @@ class FileSessionStorageWriter implements SessionStorageWriter {
 		} catch {
 			// Ignore close errors
 		}
+		if (this.#error) throw this.#error;
 	}
 
 	getError(): Error | undefined {
@@ -490,6 +499,10 @@ class MemorySessionStorageWriter implements SessionStorageWriter {
 	}
 
 	async flush(): Promise<void> {
+		if (this.#error) throw this.#error;
+	}
+
+	flushSync(): void {
 		if (this.#error) throw this.#error;
 	}
 

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -90,6 +90,8 @@ class FileSessionStorageWriter implements SessionStorageWriter {
 	#closed = false;
 	#error: Error | undefined;
 	#onError: ((err: Error) => void) | undefined;
+	#pending = "";
+	#flushScheduled = false;
 
 	constructor(fpath: string, options?: { flags?: "a" | "w"; onError?: (err: Error) => void }) {
 		this.#onError = options?.onError;
@@ -112,25 +114,41 @@ class FileSessionStorageWriter implements SessionStorageWriter {
 		return error;
 	}
 
-	async append(line: string): Promise<void> {
-		if (this.#closed) throw new Error("Writer closed");
-		if (this.#error) throw this.#error;
-		try {
-			const buf = Buffer.from(line, "utf-8");
-			let offset = 0;
-			while (offset < buf.length) {
-				const written = fs.writeSync(this.#fd, buf, offset, buf.length - offset);
-				if (written === 0) {
-					throw new Error("Short write");
-				}
-				offset += written;
+	#writeNow(line: string): void {
+		const buf = Buffer.from(line, "utf-8");
+		let offset = 0;
+		while (offset < buf.length) {
+			const written = fs.writeSync(this.#fd, buf, offset, buf.length - offset);
+			if (written === 0) {
+				throw new Error("Short write");
 			}
-		} catch (err) {
-			throw this.#recordError(err);
+			offset += written;
 		}
 	}
 
+	#flushPendingNow(): void {
+		this.#flushScheduled = false;
+		if (this.#pending.length === 0) return;
+		const pending = this.#pending;
+		this.#pending = "";
+		try {
+			this.#writeNow(pending);
+		} catch (err) {
+			this.#recordError(err);
+		}
+	}
+
+	async append(line: string): Promise<void> {
+		if (this.#closed) throw new Error("Writer closed");
+		if (this.#error) throw this.#error;
+		this.#pending += line;
+		if (this.#flushScheduled) return;
+		this.#flushScheduled = true;
+		queueMicrotask(() => this.#flushPendingNow());
+	}
+
 	async flush(): Promise<void> {
+		this.#flushPendingNow();
 		if (this.#error) throw this.#error;
 	}
 
@@ -140,6 +158,7 @@ class FileSessionStorageWriter implements SessionStorageWriter {
 
 	async close(): Promise<void> {
 		if (this.#closed) return;
+		this.#flushPendingNow();
 		this.#closed = true;
 		// Unregister from finalization - we're closing properly
 		writerRegistry.unregister(this);

--- a/packages/coding-agent/test/session-manager-immediate-persist.test.ts
+++ b/packages/coding-agent/test/session-manager-immediate-persist.test.ts
@@ -62,8 +62,8 @@ function messageContent(entry: Record<string, unknown>): unknown {
 	return (message as { content?: unknown }).content;
 }
 
-describe("SessionManager immediate JSONL persistence", () => {
-	it("writes the first assistant turn and later entries before appendMessage returns", () => {
+describe("SessionManager batched JSONL persistence", () => {
+	it("writes later entries at the microtask or synchronous flush boundary", async () => {
 		const cwd = makeTempDir("@pi-immediate-cwd-");
 		const sessionDir = path.join(cwd, "sessions");
 		const manager = SessionManager.create(cwd, sessionDir);
@@ -84,9 +84,21 @@ describe("SessionManager immediate JSONL persistence", () => {
 		manager.appendMessage({ role: "user", content: "written immediately", timestamp: Date.now() });
 
 		entries = readJsonl(sessionFile);
+		expect(entries).toHaveLength(3);
+
+		await Promise.resolve();
+		entries = readJsonl(sessionFile);
 		expect(entries).toHaveLength(4);
 		expect(messageRole(entries[3] ?? {})).toBe("user");
 		expect(messageContent(entries[3] ?? {})).toBe("written immediately");
+
+		manager.appendMessage({ role: "user", content: "flushed synchronously", timestamp: Date.now() });
+		manager.flushSync();
+
+		entries = readJsonl(sessionFile);
+		expect(entries).toHaveLength(5);
+		expect(messageRole(entries[4] ?? {})).toBe("user");
+		expect(messageContent(entries[4] ?? {})).toBe("flushed synchronously");
 	});
 
 	it("keeps pre-assistant sessions out of history during shutdown", async () => {

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -97,6 +97,7 @@ describe("FileSessionStorage writer", () => {
 	});
 
 	afterEach(async () => {
+		vi.restoreAllMocks();
 		await fsp.rm(tempDir, { recursive: true, force: true });
 	});
 
@@ -119,6 +120,17 @@ describe("FileSessionStorage writer", () => {
 		await writer.close();
 
 		expect(fs.readFileSync(sessionPath, "utf8")).toBe("one\ntwo\n");
+	});
+
+	it("rejects close when draining a queued append fails", async () => {
+		const sessionPath = path.join(tempDir, "close-error.jsonl");
+		const writer = storage.openWriter(sessionPath, { flags: "w" });
+		void writer.append("one\n");
+		vi.spyOn(fs, "writeSync").mockImplementation(() => {
+			throw new Error("disk full");
+		});
+
+		await expect(writer.close()).rejects.toThrow("disk full");
 	});
 });
 

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -87,6 +87,41 @@ class ControlledTitleUpdateBackend implements SessionStorageBackend {
 		this.#firstUpdate.reject(error);
 	}
 }
+describe("FileSessionStorage writer", () => {
+	let tempDir: string;
+	let storage: FileSessionStorage;
+
+	beforeEach(async () => {
+		tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-session-writer-"));
+		storage = new FileSessionStorage();
+	});
+
+	afterEach(async () => {
+		await fsp.rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("preserves append order through flush and close", async () => {
+		const sessionPath = path.join(tempDir, "batched.jsonl");
+		const writer = storage.openWriter(sessionPath, { flags: "w" });
+		await writer.append("one\n");
+		await writer.append("two\n");
+
+		await writer.flush();
+		expect(fs.readFileSync(sessionPath, "utf8")).toBe("one\ntwo\n");
+		await writer.close();
+	});
+
+	it("flushes queued appends before closing", async () => {
+		const sessionPath = path.join(tempDir, "closed.jsonl");
+		const writer = storage.openWriter(sessionPath, { flags: "w" });
+		await writer.append("one\n");
+		await writer.append("two\n");
+		await writer.close();
+
+		expect(fs.readFileSync(sessionPath, "utf8")).toBe("one\ntwo\n");
+	});
+});
+
 describe("FileSessionStorage.deleteSessionWithArtifacts", () => {
 	let tempDir: string;
 	let storage: FileSessionStorage;


### PR DESCRIPTION
## What

Batch same-turn file-session appends behind the session writer's microtask boundary. Explicit `flush()` and `close()` drain queued lines in order.

## Why

A burst of transcript entries previously paid one synchronous file write per entry on the same call stack that renders UI or finalizes tools. Coalescing those appends reduces main-thread work and write-syscall overhead without changing the persisted byte stream.

## Benchmark

Compared base `4df68d6043` with performance commit `070167dd4a` on the same Linux x86_64 runner (AMD EPYC 9V74, ext4 `/tmp`) using Bun 1.3.14. The harness imported each revision's actual `FileSessionStorage`, appended 531-byte JSONL entries, used 200 warm-up iterations plus 1,000 measured iterations per process, and ran 7 fresh processes per revision. Reported values are the median of the 7 process-level medians.

Each sample measured both (1) time spent on the caller's append stack and (2) end-to-end time through `await writer.flush()`:

| Same-turn burst | Append stack before | Append stack after | Reduction | Through `flush()` before | Through `flush()` after | Reduction |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 0.851 µs | 0.140 µs | 83.5% | 0.982 µs | 1.202 µs | -22.4% |
| 8 | 8.092 µs | 0.131 µs | 98.4% | 8.213 µs | 6.029 µs | 26.6% |
| 32 | 32.168 µs | 0.400 µs | 98.8% | 32.328 µs | 15.703 µs | 51.4% |
| 128 | 97.014 µs | 1.392 µs | 98.6% | 97.164 µs | 35.423 µs | 63.5% |

The append-stack measurement is the render/tool-path impact this change targets. A single append is slightly slower end-to-end through `flush()` because batching has fixed overhead; the end-to-end benefit appears once appends arrive as a burst.

Mechanism check: 10,000 same-turn appends (5.31 MB total) reduced `fs.writeSync` calls from **10,000 to 1** (99.99%). Both revisions produced exactly 5,310,000 bytes with the same SHA-256:

```text
7f7116ab8798dd0c7b036946afdf43f6ccb703bf73762a59e31afea931a56c67
```

The timing loop was:

```ts
const started = performance.now();
for (let i = 0; i < burst; i++) void writer.append(line);
const appended = performance.now();
await writer.flush();
const durable = performance.now();
```

## Testing

- `bun test` on the affected 10-file runtime/session CI chunk - 46 passed, 0 failed
- Focused persistence, flush, close, and rewrite-race coverage - 26 passed, 0 failed
- `bun --cwd=packages/coding-agent run check` - formatting and type check passed
- [GitHub Actions run 30589614887](https://github.com/can1357/oh-my-pi/actions/runs/30589614887) - all PR-relevant shards passed, including runtime/session, native/unit, UI/TUI, lint/typecheck, integration, singleton/global-state, CLI smoke, and install smoke

Durability/error boundaries are covered explicitly: `SessionManager.flushSync()` drains a pending file-writer batch on the same stack, and `close()` rejects when draining a queued write fails.

The run's sole red job is `Test TS workspace fast`, which terminated on an unhandled AWS credential-resolution error in `packages/ai/src/providers/aws-credentials.ts`; this is the same unrelated CI-environment flake seen before the follow-up fixes and requires a maintainer rerun.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)