### PR TITLE
feat(coding-agent): add percent-escape format strings to contextPct.format

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added percent-escape format strings to `contextPct.format` in status line segment options. Use `%t` for used tokens, `%p` for percent used, `%w` for window size, and `%%` for a literal percent sign. Example: `"%t/%w"` renders as `"500K/1M"`.
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/modes/components/status-line/context-thresholds.ts
+++ b/packages/coding-agent/src/modes/components/status-line/context-thresholds.ts
@@ -56,20 +56,48 @@ export function getContextUsageLevel(contextPercent: number, contextWindow: numb
 }
 
 /**
- * Format context usage as `<percent>%/<window>` when the model window is known.
- * Unknown windows render as `<tokens>/?`, because `0.0%/0` suggests a real
- * empty context instead of missing provider metadata.
+ * Format context usage. When `format` is provided, it is treated as a format
+ * template with percent escapes: `%t` = used tokens, `%p` = percent used,
+ * `%w` = window size, `%%` = literal `%`. Unknown escapes pass through.
+ *
+ * Without a format, renders `<percent>%/<window>` when the window is known,
+ * or `<tokens>/?` when it is not (avoids `0.0%/0` looking like real empty
+ * context instead of missing provider metadata).
  */
 export function formatContextUsage(
 	contextPercent: number | null | undefined,
 	contextWindow: number,
 	usedTokens?: number,
+	format?: string,
 ): string {
-	if (!Number.isFinite(contextWindow) || contextWindow <= 0) {
-		return `${formatNumber(usedTokens ?? 0)}/?`;
+	if (typeof format !== "string" || format.length === 0) {
+		if (!Number.isFinite(contextWindow) || contextWindow <= 0) {
+			return `${formatNumber(usedTokens ?? 0)}/?`;
+		}
+		const pct = contextPercent === null || contextPercent === undefined ? "?" : `${contextPercent.toFixed(1)}%`;
+		return `${pct}/${formatNumber(contextWindow)}`;
 	}
+
 	const pct = contextPercent === null || contextPercent === undefined ? "?" : `${contextPercent.toFixed(1)}%`;
-	return `${pct}/${formatNumber(contextWindow)}`;
+	const tokens = usedTokens !== undefined ? formatNumber(usedTokens) : "?";
+	const window = Number.isFinite(contextWindow) && contextWindow > 0 ? formatNumber(contextWindow) : "?";
+
+	// Single-pass regex replacement to prevent `%p` output from being reinterpreted
+	// by later escapes (e.g. `%pw` should render as `50.0%w`, not `50.01M`).
+	return format.replace(/%(?:%|[tpw])/g, match => {
+		switch (match) {
+			case "%%":
+				return "%";
+			case "%t":
+				return tokens;
+			case "%p":
+				return pct;
+			case "%w":
+				return window;
+			default:
+				return match;
+		}
+	});
 }
 
 export function getContextUsageThemeColor(level: ContextUsageLevel): ThemeColor {

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -457,12 +457,15 @@ const contextPctSegment: StatusLineSegment = {
 	render(ctx) {
 		const pct = ctx.contextPercent;
 		const window = ctx.contextWindow;
+		const format = ctx.options.contextPct?.format;
+
+		const text = sanitizeStatusText(formatContextUsage(pct, window, ctx.contextTokens, format));
 
 		const autoIcon = ctx.autoCompactEnabled && theme.icon.auto ? ` ${theme.icon.auto}` : "";
-		const text = `${formatContextUsage(pct, window, ctx.contextTokens)}${autoIcon}`;
+		const fullText = `${text}${autoIcon}`;
 
 		const color = getContextUsageThemeColor(getContextUsageLevel(pct ?? 0, window));
-		const content = withIcon(theme.icon.context, theme.fg(color, text));
+		const content = withIcon(theme.icon.context, theme.fg(color, fullText));
 
 		return { content, visible: true };
 	},

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -19,6 +19,7 @@ export interface StatusLineSegmentOptions {
 	path?: { abbreviate?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
 	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
 	time?: { format?: "12h" | "24h"; showSeconds?: boolean };
+	contextPct?: { format?: string };
 }
 
 export interface StatusLineSettings {

--- a/packages/coding-agent/test/format-context-usage.test.ts
+++ b/packages/coding-agent/test/format-context-usage.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { formatContextUsage } from "../src/modes/components/status-line/context-thresholds";
+
+describe("formatContextUsage", () => {
+	describe("default behavior (no format string)", () => {
+		test("renders percent/window when window is known", () => {
+			expect(formatContextUsage(50, 1_000_000)).toBe("50.0%/1M");
+		});
+
+		test("renders tokens/? when window is unknown", () => {
+			expect(formatContextUsage(50, 0, 500_000)).toBe("500K/?");
+		});
+
+		test("renders 0/? when window is invalid and no tokens provided", () => {
+			expect(formatContextUsage(50, -1)).toBe("0/?");
+		});
+
+		test("renders ? for percent when contextPercent is null", () => {
+			expect(formatContextUsage(null, 1_000_000)).toBe("?/1M");
+		});
+
+		test("renders ? for percent when contextPercent is undefined", () => {
+			expect(formatContextUsage(undefined, 1_000_000)).toBe("?/1M");
+		});
+	});
+
+	describe("format string with escapes", () => {
+		test("replaces %t with tokens", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "%t")).toBe("500K");
+		});
+
+		test("replaces %p with percent", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "%p")).toBe("50.0%");
+		});
+
+		test("replaces %w with window", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "%w")).toBe("1M");
+		});
+
+		test("replaces %% with literal percent", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "%%")).toBe("%");
+		});
+
+		test("handles multiple escapes", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "%t/%w")).toBe("500K/1M");
+		});
+
+		test("handles mixed text and escapes", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "%p of %w")).toBe("50.0% of 1M");
+		});
+
+		test("handles literal percent with text", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "%% usage: %p")).toBe("% usage: 50.0%");
+		});
+
+		test("passes through unknown escapes", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "%x")).toBe("%x");
+		});
+
+		test("handles null percent in format", () => {
+			expect(formatContextUsage(null, 1_000_000, 500_000, "%p")).toBe("?");
+		});
+
+		test("handles undefined percent in format", () => {
+			expect(formatContextUsage(undefined, 1_000_000, 500_000, "%p")).toBe("?");
+		});
+
+		test("handles invalid window in format", () => {
+			expect(formatContextUsage(50, 0, 500_000, "%w")).toBe("?");
+		});
+
+		test("handles missing tokens in format", () => {
+			expect(formatContextUsage(50, 1_000_000, undefined, "%t")).toBe("?");
+		});
+
+		test("treats empty format string as no format (falls through to default)", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "")).toBe("50.0%/1M");
+		});
+
+		test("handles format with no escapes", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "context")).toBe("context");
+		});
+
+		test("handles consecutive %% escapes", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "%%%%")).toBe("%%");
+		});
+
+		test("handles complex format string", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "%t tokens (%p) of %w")).toBe("500K tokens (50.0%) of 1M");
+		});
+		test("handles %p followed by w without reparsing", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, "%pw")).toBe("50.0%w");
+		});
+
+		test("handles non-string format (falls through to default)", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, undefined as unknown as string)).toBe("50.0%/1M");
+		});
+
+		test("handles number format (falls through to default)", () => {
+			expect(formatContextUsage(50, 1_000_000, 500_000, 123 as unknown as string)).toBe("50.0%/1M");
+		});
+	});
+});


### PR DESCRIPTION
## What

Allows customizing the token usage display on the status line.

You can now use these escape codes in a string to describe how to format the token usage display:

- `%t` = used tokens (eg. 17k)
- `%p` = percent used (eg. 6.7%)
- `%w` = window size (eg. 262k)
- `%%` = literal percent sign

## Why

I didn't like the way token usage was displayed in the default status line and I wanted to customize it.

## Testing

To test this, switch to a status line that has the token use, then add this to your config:

```yaml
statusLine:
  segmentOptions:
    contextPct:
      format: "%p (%t)"
```

Change the `format` string to be what you want. It should update in the omp statusline.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

---

AI usage disclosure:
- What's me:
	- the idea for the feature
	- the idea to use percent escaping, borrowing it from the unix `date` command
	- testing and writing this (entire) description
- What AI was used for:
	- discovering the `segmentOptions` feature
	- writing all code changes and commit message
	- model: `Ornith-1.0-35B-GGUF-Q6_K`
	- agent: omp
