### PR TITLE
perf(coding-agent): reduce Kimi Code prompt overhead

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ### Changed
 
+- Reduced model input overhead by deriving concise runtime labels for the built-in read, grep, glob, bash, edit, and write tools from their existing arguments instead of requiring a duplicate `i` field.
+- Enabled append-only context automatically for Kimi Code models to keep prompt prefixes stable across turns while preserving explicit `on` and `off` overrides.
 - Improved grouped read-call layout by nesting each request's usage metrics beneath its final path.
 - Improved turn recovery to prevent duplicate output streaming during credential rotation or model fallback when visible text has already been streamed.
 - Optimized tool guidance for bash, grep, and glob to be more concise while clarifying shell boundaries and search timeouts.

--- a/packages/coding-agent/src/config/append-only-context-mode.ts
+++ b/packages/coding-agent/src/config/append-only-context-mode.ts
@@ -54,6 +54,7 @@ function hasLocalLoopbackBaseUrl(baseUrl: string | undefined): boolean {
 function shouldAutoEnableAppendOnlyContext(model: AppendOnlyContextModel | null | undefined): boolean {
 	if (!model) return false;
 	if (model.provider === "deepseek") return true;
+	if (model.provider === "kimi-code") return true;
 	if (LOCAL_INFERENCE_PROVIDERS.has(model.provider)) return true;
 	if (hostMatchesUrl(model.baseUrl, "xiaomi")) return true;
 	if (hasLocalLoopbackBaseUrl(model.baseUrl)) return true;

--- a/packages/coding-agent/src/edit/index.ts
+++ b/packages/coding-agent/src/edit/index.ts
@@ -12,6 +12,7 @@ import patchDescription from "../prompts/tools/patch.md" with { type: "text" };
 import replaceDescription from "../prompts/tools/replace.md" with { type: "text" };
 import type { ToolSession } from "../tools";
 import { truncateForPrompt } from "../tools/approval";
+import { deriveToolIntent } from "../tools/derived-intent";
 import { findUniqueWorkspaceSuffix, isInternalUrlPath } from "../tools/path-utils";
 import { resolvePlanPath } from "../tools/plan-mode-guard";
 import { type EditMode, normalizeEditMode, resolveEditMode } from "../utils/edit-mode";
@@ -389,6 +390,10 @@ export class EditTool implements AgentTool<TInput> {
 	];
 	readonly name = "edit";
 	readonly label = "Edit";
+	readonly intent = (args: unknown) => {
+		const path = extractApprovalPath(args);
+		return deriveToolIntent("Editing", path === "(unknown)" ? undefined : path, "Editing files");
+	};
 	readonly loadMode = "essential";
 	readonly concurrency = "exclusive";
 	readonly strict = true;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -518,6 +518,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		return [`Command: ${truncateForPrompt(command)}`];
 	};
 	readonly label = "Bash";
+	readonly intent = () => "Running shell command";
 	readonly loadMode = "essential";
 	get description(): string {
 		const evalBackends = resolveEvalBackends(this.session);

--- a/packages/coding-agent/src/tools/derived-intent.ts
+++ b/packages/coding-agent/src/tools/derived-intent.ts
@@ -1,0 +1,22 @@
+const MAX_DERIVED_INTENT_LENGTH = 72;
+const MAX_DERIVED_INTENT_WORDS = 6;
+
+/**
+ * Build a concise runtime intent from arguments the model already supplies.
+ *
+ * Function-valued tool intents stay out of provider schemas and tool-call JSON,
+ * while the runtime still emits a useful progress label. Bound both words and
+ * characters so a path, regex, or command cannot become a second payload.
+ */
+export function deriveToolIntent(action: string, detail: unknown, fallback: string): string {
+	if (typeof detail !== "string") return fallback;
+	const normalized = detail.replace(/\s+/g, " ").trim();
+	if (!normalized) return fallback;
+
+	const actionWords = action.trim().split(/\s+/).filter(Boolean);
+	const detailWordLimit = Math.max(1, MAX_DERIVED_INTENT_WORDS - actionWords.length);
+	const boundedDetail = normalized.split(/\s+/).slice(0, detailWordLimit).join(" ");
+	const intent = `${action} ${boundedDetail}`;
+	if (intent.length <= MAX_DERIVED_INTENT_LENGTH) return intent;
+	return `${intent.slice(0, MAX_DERIVED_INTENT_LENGTH - 3).trimEnd()}...`;
+}

--- a/packages/coding-agent/src/tools/glob.ts
+++ b/packages/coding-agent/src/tools/glob.ts
@@ -15,6 +15,7 @@ import globDescription from "../prompts/tools/glob.md" with { type: "text" };
 import { type TruncationResult, truncateHead } from "../session/streaming-output";
 import { Ellipsis, fileHyperlink, renderFileList, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
 import type { ToolSession } from ".";
+import { deriveToolIntent } from "./derived-intent";
 import { applyListLimit } from "./list-limit";
 import { formatFullOutputReference, type OutputMeta } from "./output-meta";
 import {
@@ -106,6 +107,8 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 	readonly approval = "read" as const;
 	readonly loadMode = "essential";
 	readonly label = "Glob";
+	readonly intent = (args: Partial<GlobToolInput>) =>
+		deriveToolIntent("Finding", args.path, "Finding workspace files");
 	readonly description: string;
 	readonly parameters = findSchema;
 

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -36,6 +36,7 @@ import {
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import { type ArchiveReader, type ExtractedArchiveFile, openArchive, parseArchivePathCandidates } from "../utils/zip";
 import type { ToolSession } from ".";
+import { deriveToolIntent } from "./derived-intent";
 import { materializeReadUrlToFile, parseReadUrlTarget } from "./fetch";
 import { createFileRecorder, formatResultPath } from "./file-recorder";
 import { classifyGroupedLines, formatGroupedFiles, groupLineIndicesByBlank } from "./grouped-file-output";
@@ -907,6 +908,11 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 		return toPathList(a.path ?? a.paths).some(pathTargetsSsh) ? "exec" : "read";
 	};
 	readonly label = "Grep";
+	readonly intent = (args: Partial<GrepToolInput>) => {
+		const path = typeof args.path === "string" && args.path.trim() ? args.path : "workspace";
+		const pattern = typeof args.pattern === "string" && args.pattern.trim() ? args.pattern : "matches";
+		return deriveToolIntent("Searching", `${path} for ${pattern}`, "Searching workspace");
+	};
 	readonly loadMode = "discoverable";
 	readonly summary = "Grep file contents using ripgrep (fast regex search)";
 	readonly description: string;

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -81,6 +81,7 @@ import {
 	scanConflictLines,
 	scanFileForConflicts,
 } from "./conflict-detect";
+import { deriveToolIntent } from "./derived-intent";
 import {
 	executeReadUrl,
 	fetchReadUrl,
@@ -862,6 +863,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	readonly approval = (args: unknown): ToolTier =>
 		pathTargetsSsh(String((args as { path?: unknown }).path ?? "")) ? "exec" : "read";
 	readonly label = "Read";
+	readonly intent = (args: Partial<ReadToolInput>) => deriveToolIntent("Reading", args.path, "Reading input");
 	readonly loadMode = "essential";
 	description: string;
 	readonly parameters = readSchema;

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -47,6 +47,7 @@ import {
 	parseConflictUri,
 	spliceConflict,
 } from "./conflict-detect";
+import { deriveToolIntent } from "./derived-intent";
 import { invalidateFsScanAfterWrite } from "./fs-cache-invalidation";
 import { type OutputMeta, outputMeta } from "./output-meta";
 import {
@@ -557,6 +558,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 		return [`Path: ${truncateForPrompt(targetPath)}`, `Content:\n${truncateForPrompt(content)}`];
 	};
 	readonly label = "Write";
+	readonly intent = (args: Partial<WriteToolInput>) => deriveToolIntent("Writing", args.path, "Writing file");
 	readonly description: string;
 	readonly parameters = writeSchema;
 	readonly strict = true;

--- a/packages/coding-agent/test/append-only-context-mode.test.ts
+++ b/packages/coding-agent/test/append-only-context-mode.test.ts
@@ -25,6 +25,14 @@ describe("shouldEnableAppendOnlyContext", () => {
 		);
 	});
 
+	test("auto enables for Kimi Code while explicit settings still win", () => {
+		const model = { provider: "kimi-code", baseUrl: "https://api.kimi.com/coding/v1" };
+		expect(shouldEnableAppendOnlyContext("auto", model)).toBe(true);
+		expect(shouldEnableAppendOnlyContext(undefined, model)).toBe(true);
+		expect(shouldEnableAppendOnlyContext("on", model)).toBe(true);
+		expect(shouldEnableAppendOnlyContext("off", model)).toBe(false);
+	});
+
 	test("auto enables for Xiaomi Token Plan SGLang HiCache endpoints", () => {
 		expect(shouldEnableAppendOnlyContext("auto", XIAOMI_TOKEN_PLAN_ANTHROPIC)).toBe(true);
 	});

--- a/packages/coding-agent/test/tool-intent-token-usage.test.ts
+++ b/packages/coding-agent/test/tool-intent-token-usage.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { countTokens } from "@oh-my-pi/pi-agent-core";
+import { normalizeTools } from "@oh-my-pi/pi-agent-core/agent-loop";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core/types";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { estimateToolSchemaTokens } from "@oh-my-pi/pi-coding-agent/modes/utils/context-usage";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { GlobTool, GrepTool, ReadTool } from "@oh-my-pi/pi-coding-agent/tools";
+import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
+
+function makeSession(): ToolSession {
+	return {
+		cwd: process.cwd(),
+		hasUI: false,
+		settings: Settings.isolated({ "inspect_image.enabled": false }),
+		getSessionFile: () => undefined,
+		getSessionSpawns: () => "*",
+		getArtifactsDir: () => undefined,
+		allocateOutputArtifact: async () => undefined,
+	} as ToolSession;
+}
+
+function requireModelIntent(tool: AgentTool): AgentTool {
+	return {
+		...tool,
+		intent: "require",
+		execute: tool.execute.bind(tool),
+	};
+}
+
+function wireProperties(tool: { parameters: unknown }): Record<string, unknown> {
+	const schema = tool.parameters as { properties?: Record<string, unknown> };
+	return schema.properties ?? {};
+}
+
+function derivedIntent(tool: AgentTool, args: Record<string, unknown>): string {
+	if (typeof tool.intent !== "function")
+		throw new Error(`${tool.name} must derive intent from its existing arguments`);
+	return tool.intent(args as never) ?? "";
+}
+
+function providerFootprint(tools: AgentTool[], sampleCalls: Array<Record<string, unknown>>): number {
+	const normalized = normalizeTools(tools, true) ?? [];
+	return (
+		estimateToolSchemaTokens(normalized) +
+		sampleCalls.reduce((total, call) => total + countTokens(JSON.stringify(call)), 0)
+	);
+}
+
+describe("built-in tool intent token usage", () => {
+	test("iteration 1 derives read/search intents without a provider-generated i field", () => {
+		const tools: AgentTool[] = [
+			new ReadTool(makeSession()),
+			new GrepTool(makeSession()),
+			new GlobTool(makeSession()),
+		];
+		const normalized = normalizeTools(tools, true) ?? [];
+
+		for (const tool of normalized) {
+			expect(wireProperties(tool)).not.toHaveProperty(INTENT_FIELD);
+		}
+		expect(derivedIntent(tools[0], { path: "src/example.ts:1-20" })).toBe("Reading src/example.ts:1-20");
+		expect(derivedIntent(tools[1], { pattern: "TODO", path: "src" })).toBe("Searching src for TODO");
+		expect(derivedIntent(tools[2], { path: "src/**/*.ts" })).toBe("Finding src/**/*.ts");
+
+		const intents = [
+			derivedIntent(tools[0], { path: "src/example.ts:1-20" }),
+			derivedIntent(tools[1], { pattern: "TODO", path: "src" }),
+			derivedIntent(tools[2], { path: "src/**/*.ts" }),
+			derivedIntent(tools[0], { path: `src/${"nested directory ".repeat(20)}file.ts` }),
+		];
+		for (const intent of intents) {
+			expect(intent.length).toBeLessThanOrEqual(72);
+			expect(intent.trim().split(/\s+/).length).toBeLessThanOrEqual(6);
+		}
+
+		const baselineCalls = [
+			{ i: "Reading source file", path: "src/example.ts:1-20" },
+			{ i: "Searching source files", pattern: "TODO", path: "src" },
+			{ i: "Finding TypeScript files", path: "src/**/*.ts" },
+		];
+		const optimizedCalls = baselineCalls.map(({ i: _intent, ...args }) => args);
+		const baseline = providerFootprint(tools.map(requireModelIntent), baselineCalls);
+		const optimized = providerFootprint(tools, optimizedCalls);
+
+		expect(optimized).toBeLessThan(baseline);
+	});
+});

--- a/packages/coding-agent/test/tool-intent-token-usage.test.ts
+++ b/packages/coding-agent/test/tool-intent-token-usage.test.ts
@@ -13,11 +13,15 @@ function makeSession(): ToolSession {
 		cwd: process.cwd(),
 		hasUI: false,
 		settings: Settings.isolated({ "inspect_image.enabled": false }),
-		getSessionFile: () => undefined,
+		getSessionFile: () => null,
 		getSessionSpawns: () => "*",
 		getArtifactsDir: () => undefined,
 		allocateOutputArtifact: async () => undefined,
-	} as ToolSession;
+	} as unknown as ToolSession;
+}
+
+function asAgentTool(tool: unknown): AgentTool {
+	return tool as AgentTool;
 }
 
 function requireModelIntent(tool: AgentTool): AgentTool {
@@ -51,11 +55,9 @@ function providerFootprint(tools: AgentTool[], sampleCalls: Array<Record<string,
 
 describe("built-in tool intent token usage", () => {
 	test("iteration 1 derives read/search intents without a provider-generated i field", () => {
-		const tools: AgentTool[] = [
-			new ReadTool(makeSession()),
-			new GrepTool(makeSession()),
-			new GlobTool(makeSession()),
-		];
+		const tools = [new ReadTool(makeSession()), new GrepTool(makeSession()), new GlobTool(makeSession())].map(
+			asAgentTool,
+		);
 		const normalized = normalizeTools(tools, true) ?? [];
 
 		for (const tool of normalized) {
@@ -90,8 +92,8 @@ describe("built-in tool intent token usage", () => {
 
 	test("iteration 2 derives mutation intents without a provider-generated i field", () => {
 		const session = makeSession();
-		const readTools: AgentTool[] = [new ReadTool(session), new GrepTool(session), new GlobTool(session)];
-		const mutationTools: AgentTool[] = [new BashTool(session), new EditTool(session), new WriteTool(session)];
+		const readTools = [new ReadTool(session), new GrepTool(session), new GlobTool(session)].map(asAgentTool);
+		const mutationTools = [new BashTool(session), new EditTool(session), new WriteTool(session)].map(asAgentTool);
 		const tools = [...readTools, ...mutationTools];
 		const normalized = normalizeTools(tools, true) ?? [];
 

--- a/packages/coding-agent/test/tool-intent-token-usage.test.ts
+++ b/packages/coding-agent/test/tool-intent-token-usage.test.ts
@@ -5,7 +5,7 @@ import type { AgentTool } from "@oh-my-pi/pi-agent-core/types";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { estimateToolSchemaTokens } from "@oh-my-pi/pi-coding-agent/modes/utils/context-usage";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/sdk";
-import { GlobTool, GrepTool, ReadTool } from "@oh-my-pi/pi-coding-agent/tools";
+import { BashTool, EditTool, GlobTool, GrepTool, ReadTool, WriteTool } from "@oh-my-pi/pi-coding-agent/tools";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 
 function makeSession(): ToolSession {
@@ -21,11 +21,13 @@ function makeSession(): ToolSession {
 }
 
 function requireModelIntent(tool: AgentTool): AgentTool {
-	return {
-		...tool,
-		intent: "require",
-		execute: tool.execute.bind(tool),
-	};
+	return new Proxy(tool, {
+		get(target, property) {
+			if (property === "intent") return "require";
+			if (property === "execute") return target.execute.bind(target);
+			return Reflect.get(target, property, target);
+		},
+	});
 }
 
 function wireProperties(tool: { parameters: unknown }): Record<string, unknown> {
@@ -84,5 +86,45 @@ describe("built-in tool intent token usage", () => {
 		const optimized = providerFootprint(tools, optimizedCalls);
 
 		expect(optimized).toBeLessThan(baseline);
+	});
+
+	test("iteration 2 derives mutation intents without a provider-generated i field", () => {
+		const session = makeSession();
+		const readTools: AgentTool[] = [new ReadTool(session), new GrepTool(session), new GlobTool(session)];
+		const mutationTools: AgentTool[] = [new BashTool(session), new EditTool(session), new WriteTool(session)];
+		const tools = [...readTools, ...mutationTools];
+		const normalized = normalizeTools(tools, true) ?? [];
+
+		for (const tool of normalized) {
+			expect(wireProperties(tool)).not.toHaveProperty(INTENT_FIELD);
+		}
+		expect(derivedIntent(mutationTools[0], { command: "bun test packages/coding-agent/test" })).toBe(
+			"Running shell command",
+		);
+		expect(
+			derivedIntent(mutationTools[1], {
+				input: "*** Begin Patch\n*** Update File: src/example.ts\n*** End Patch\n",
+			}),
+		).toBe("Editing src/example.ts");
+		expect(derivedIntent(mutationTools[2], { path: "src/output.ts", content: "result\n" })).toBe(
+			"Writing src/output.ts",
+		);
+
+		const iteration1Calls = [
+			{ path: "src/example.ts:1-20" },
+			{ pattern: "TODO", path: "src" },
+			{ path: "src/**/*.ts" },
+			{ i: "Running focused tests", command: "bun test packages/coding-agent/test" },
+			{
+				i: "Editing source file",
+				input: "*** Begin Patch\n*** Update File: src/example.ts\n*** End Patch\n",
+			},
+			{ i: "Writing output file", path: "src/output.ts", content: "result\n" },
+		];
+		const iteration2Calls = iteration1Calls.map(({ i: _intent, ...args }) => args);
+		const iteration1 = providerFootprint([...readTools, ...mutationTools.map(requireModelIntent)], iteration1Calls);
+		const iteration2 = providerFootprint(tools, iteration2Calls);
+
+		expect(iteration2).toBeLessThan(iteration1);
 	});
 });


### PR DESCRIPTION
## What

- Derive concise runtime intent labels for the built-in read, search, glob, shell, edit, and write tools from arguments they already receive.
- Omit the redundant model-generated `i` field from those six tools' provider schemas and calls while preserving runtime progress labels.
- Enable append-only context automatically for the exact `kimi-code` provider; explicit `on` and `off` settings still take precedence.
- Add token-footprint, normalization, derived-label, length-bound, provider-default, and override regression coverage.

Owner-written scope: “Combine all the improvements from the 3 runs into one upstream PR.”

Implementation and measurement were AI-assisted in an owner-directed session. The results and limitations below are reported without private infrastructure identifiers.

## Why

Tool intent is useful to people observing a run, but these built-ins can produce it deterministically. Asking the model to emit the same metadata spends schema and call tokens on every request. Runtime derivation keeps the UI behavior while removing that repeated provider-facing field.

Append-only context preserves stable prefixes for providers that cache them. Kimi Code now receives that behavior under `auto`, without overriding an explicit user choice.

## Methodology

I compared immutable source builds of OMP 17.2.0 on the same fixed 10-task Terminal Bench 2.1 slice. The model route, high reasoning effort, temperature 1, concurrency 2, context window, compaction settings, retry policy, and task order were held constant. Variants ran sequentially and were not randomized, so end-to-end quality and total-token results are descriptive rather than causal.

Accounted tokens sum `input + cacheRead + cacheWrite + output` from every completed assistant response, adding a termination summary only for an aborted response. First-prompt comparisons pair the first actual assistant request for each task, isolating provider-facing schema changes before task behavior can diverge.

### Deterministic six-tool footprint

| Variant | Change | Schema + representative calls | Delta from prior | Delta from baseline |
|---|---|---:|---:|---:|
| Baseline | Model-generated intent for all six tools | 3,629 tokens | — | — |
| Iteration 1 | Runtime intent for read/search/glob | 3,563 tokens | -66 (-1.82%) | -66 (-1.82%) |
| Iteration 2 | Runtime intent for shell/edit/write | 3,501 tokens | -62 (-1.74%) | -128 (-3.53%) |

### Live first-prompt measurements

- Iteration 1: 9 paired tasks, mean **-43.56 tokens** (**-0.750%**) versus baseline. Individual reductions were 42–44 tokens.
- Iteration 2: 9 tasks paired with iteration 1, mean additional **-41.78 tokens** (**-0.726%**).
- Iteration 2 versus baseline: 10 paired tasks, mean **-85.2 tokens** (**-1.467%**). Individual reductions were 84–86 tokens.

The live prompt deltas closely track the deterministic footprint reduction. They are the causal benchmark result for the tool-schema changes.

### End-to-end observations and limitations

- Baseline: 9/10 clean verifier passes; 1,489,148 accounted tokens.
- Iteration 1: 4/10 clean latest outcomes, 3 verifier failures, 3 cancellations; 1,583,285 accounted tokens over 13 attempts. A benchmark-adapter classification defect retained a recovered transient provider error, triggered redundant attempts, and forced cancellations. This run is operationally censored; its total tokens and pass count are not a valid comparison. Its first-prompt measurements remain valid.
- Iteration 2: 7/10 clean latest outcomes, 2 verifier failures, 1 cancellation; 2,014,424 accounted tokens over 12 attempts. Two attempts failed before producing a model request and one task was cancelled, so the total-token and pass-count result is also censored. First-prompt measurements remain valid.
- Iteration 3 (Kimi Code append-only default): covered by focused regression tests and the full repository check. No isolated live benchmark completed, so this PR does not attribute a measured token reduction to that setting.

An earlier seven-setting composite reduced accounted tokens by 54.58%, but quality fell from 9/10 in the retry-normalized control to 8/10 in treatment. One task passed 2/2 controls and 0/2 treatments, and identical-control token totals had 46.395% median absolute variation. I rejected that bundled result rather than claim it. This PR keeps the independently attributable schema reductions, preserves explicit append-only overrides, and reports no end-to-end savings claim beyond the paired first-prompt measurements.

## Testing

- Focused regression set: **21 tests passed, 79 assertions**.
- Full `bun check`: passed.
- Live Kimi Code evaluation: fixed 10-task baseline plus two sequential isolated iterations; prompt reductions reproduced across every paired task.

- [x] I have performed a self-review of my changes.
- [x] I have added tests that prove the fix is effective or that the feature works.
- [x] New and existing unit tests pass locally with my changes.
