### PR TITLE
fix(build): support Bazel native builds on NixOS ARM64

### DIFF
--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixed
 
 - Fixed a heap corruption crash when opening PulseAudio on Linux ARM64 by shipping target-specific miniaudio Rust layouts for GNU and musl native addons.
-- Fixed local Bazel addon builds on NixOS by exposing system CMake tools to sandboxed build scripts and correctly bundling Opus.
+- Fixed local Bazel addon builds on NixOS by exposing system CMake tools to sandboxed build scripts and correctly bundling Opus ([#7136](https://github.com/can1357/oh-my-pi/pull/7136) by [@olegpulatov](https://github.com/olegpulatov)).
 - Fixed workspace native addon loading to correctly prefer the workspace build over an installed leaf package.
 - Fixed process crashes caused by pathological HTML inputs; conversions that exceed the native-stack DOM depth limit now reject instead of returning silently truncated Markdown.
 


### PR DESCRIPTION
 What

 Fix Bazel native addon builds on NixOS ARM64:

 - Allow sandboxed build scripts to find NixOS system CMake tools.
 - Patch audiopus_sys to install bundled Opus into the lib directory it expects.
 - Regenerate MODULE.bazel.lock.
 - Update the native package changelog.

 Why

 NixOS exposes system tools under /run/current-system/sw/bin, which was absent from the fixed
 Bazel build-script PATH. After resolving CMake, ARM64 builds installed libopus.a under lib64,
 while audiopus_sys only searched under lib.

 These caused local //:natives-linux-arm64 builds to fail.

 Testing

 - Built //:natives-linux-arm64 successfully on NixOS ARM64 via bun run build:native.
 - Confirmed the native addon was installed and passed the runtime smoke test.

 ────────────────────────────────────────────────────────────────────────────────

 - [x] bun check passes
 - [x] Tested locally
 - [x] CHANGELOG updated (if user-facing)