### PR TITLE
fix(agent): suppress redundant xd:// mount notice after catalog rebuild

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a fresh session with deferred MCP discovery injecting the newly mounted `xd://` tool catalog twice into the first model request: the post-discovery prompt rebuild already renders the full device catalog, but the pre-user `xdev-mount-notice` re-listed the same names because the rebuild never updated announcement tracking. The rebuild now reports the catalog it exposed and those devices are folded into the announced-mount baseline, so the notice is suppressed for anything the prompt already carries while non-rebuild mount changes and unmount notices still fire ([#7139](https://github.com/can1357/oh-my-pi/issues/7139)).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -184,7 +184,10 @@ export interface AgentSessionConfig {
 	/** Current session message-to-LLM conversion pipeline. */
 	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	/** System prompt builder that can consider tool availability. */
-	rebuildSystemPrompt?: (toolNames: string[], tools: Map<string, AgentTool>) => Promise<{ systemPrompt: string[] }>;
+	rebuildSystemPrompt?: (
+		toolNames: string[],
+		tools: Map<string, AgentTool>,
+	) => Promise<{ systemPrompt: string[]; xdevCatalogNames?: readonly string[] }>;
 	/** Local calendar date provider used by prompt-cache invalidation. */
 	getLocalCalendarDate?: () => string;
 	/** Tools mounted under `xd://`, for `/tools` display. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4039,10 +4039,6 @@ export class AgentSession {
 		return this.#tools.applyActiveToolsByName(toolNames);
 	}
 
-	#takePendingXdevMountNotice(): CustomMessage | undefined {
-		return this.#tools.takePendingXdevMountNotice();
-	}
-
 	/** Rediscovers reloadable skills and refreshes prompt metadata. */
 	refreshSkills(): Promise<void> {
 		return this.#tools.refreshSkills();
@@ -5018,11 +5014,10 @@ export class AgentSession {
 			}
 
 			// A pending xd:// delta accompanies the next user-authored prompt,
-			// never an agent-initiated continuation.
-			const xdevMountNotice = isUserQueuedMessage(message) ? this.#takePendingXdevMountNotice() : undefined;
-			if (xdevMountNotice) {
-				messages.push(xdevMountNotice);
-			}
+			// never an agent-initiated continuation. Reserve its pre-user position,
+			// but consume it only after before_agent_start determines whether the
+			// final provider prompt still carries the base xd:// catalog.
+			const xdevMountNoticeIndex = messages.length;
 			messages.push(message);
 			// Inject any pending "nextTurn" messages as context alongside the user message
 			for (const msg of this.#pendingNextTurnMessages) {
@@ -5053,6 +5048,7 @@ export class AgentSession {
 			if ((this.#isDisposed && !disposingBeforeTransition) || this.#promptGeneration !== generation) return;
 			const beforeAgentStartSystemPrompt = await this.#buildSystemPromptForAgentStart(expandedText);
 
+			let baseXdevCatalogDelivered = true;
 			// Emit before_agent_start extension event
 			if (this.#extensionRunner) {
 				const result = await this.#extensionRunner.emitBeforeAgentStart(
@@ -5087,6 +5083,7 @@ export class AgentSession {
 				}
 
 				if (result?.systemPrompt !== undefined) {
+					baseXdevCatalogDelivered = false;
 					this.agent.setSystemPrompt(result.systemPrompt);
 				} else {
 					this.agent.setSystemPrompt(beforeAgentStartSystemPrompt);
@@ -5109,6 +5106,12 @@ export class AgentSession {
 				if (this.#promptGeneration !== generation) {
 					return;
 				}
+			}
+			const xdevMountNotice = isUserQueuedMessage(message)
+				? this.#tools.takePendingXdevMountNotice(baseXdevCatalogDelivered)
+				: undefined;
+			if (xdevMountNotice) {
+				messages.splice(xdevMountNoticeIndex, 0, xdevMountNotice);
 			}
 
 			await this.#maintenance.runPrePromptCompactionIfNeeded(messages);

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -199,6 +199,14 @@ export class SessionTools {
 	#runtimeSelectedToolNames: ReadonlySet<string> | undefined;
 	#baseSystemPrompt: string[];
 	#lastAppliedToolSignature: string | undefined;
+	/**
+	 * `xd://` device names the current base system prompt renders in its catalog
+	 * (the last rebuild's {@link BuildSystemPromptResult.xdevCatalogNames}). Consulted
+	 * when a pending mount notice is delivered: a device the outgoing prompt already
+	 * lists is recorded as announced without a redundant notice line. Empty when the
+	 * prompt carries no catalog (no mounts, or a custom prompt that omits the section).
+	 */
+	#basePromptXdevNames: ReadonlySet<string> = new Set();
 	#mcpRefreshTail: Promise<void> = Promise.resolve();
 	#promptModelKey: string | undefined;
 	#rebuildSystemPrompt: SessionToolsOptions["rebuildSystemPrompt"];
@@ -654,7 +662,7 @@ export class SessionTools {
 			this.#host.agent.setSystemPrompt(this.#baseSystemPrompt);
 			this.#lastAppliedToolSignature = rebuiltSignature;
 			this.#promptModelKey = this.#currentPromptModelKey();
-			this.#absorbExposedXdevIntoAnnounced(rebuiltXdevCatalogNames);
+			this.#basePromptXdevNames = new Set(rebuiltXdevCatalogNames);
 		}
 	}
 
@@ -698,31 +706,6 @@ export class SessionTools {
 		if (addedNames.length > 0) parts.push(`mounted ${addedNames.join(", ")}`);
 		if (removedNames.length > 0) parts.push(`unmounted ${removedNames.join(", ")}`);
 		this.#host.emitNotice("info", `xd://: ${parts.join("; ")}`, "xdev");
-	}
-
-	/**
-	 * Fold the devices a just-applied prompt rebuild already advertises into the
-	 * announced-mount baseline. `rebuildSystemPrompt` reports the `xd://` catalog it
-	 * rendered ({@link BuildSystemPromptResult.xdevCatalogNames}); those devices are
-	 * now visible in the base prompt every following request carries, so a same-turn
-	 * mount notice would re-list the identical catalog before the first user turn —
-	 * on a fresh deferred-discovery session that double-billed the entire mounted MCP
-	 * inventory (issue #7139). Marking them announced and dropping them from the
-	 * pending delta suppresses that duplicate, while notices for mount changes the
-	 * rebuild did NOT expose (non-MCP churn that keeps the prompt byte-stable, or a
-	 * custom prompt that omits the catalog) and all unmount notices stay intact.
-	 *
-	 * Seeding first lets a fresh rebuild win over any stale history entry that marked
-	 * the device removed, so a currently-exposed device is never treated as unknown.
-	 */
-	#absorbExposedXdevIntoAnnounced(exposedNames: readonly string[] | undefined): void {
-		if (!exposedNames || exposedNames.length === 0) return;
-		this.#ensureAnnouncedMountsSeeded();
-		for (const name of exposedNames) this.#announcedMounts.add(name);
-		const pending = this.#pendingXdevMountDelta;
-		if (!pending) return;
-		for (const name of exposedNames) pending.added.delete(name);
-		this.#pendingXdevMountDelta = pending.added.size > 0 || pending.removed.size > 0 ? pending : undefined;
 	}
 
 	/**
@@ -801,6 +784,16 @@ export class SessionTools {
 		if (!pending) return undefined;
 		this.#pendingXdevMountDelta = undefined;
 		this.#ensureAnnouncedMountsSeeded();
+		// A pending add for a device the outgoing base prompt already lists in its
+		// catalog needs no notice line — but the delivery makes the model aware of
+		// it, so record it announced. Doing this here (at delivery) rather than when
+		// the prompt was rebuilt keeps add/remove coalescing intact: a device mounted
+		// then unmounted before any prompt is sent cancels out in
+		// {@link #notifyXdevMountDelta} and never emits a spurious "No longer mounted"
+		// notice for a device the model never saw (issue #7139 review).
+		for (const name of pending.added) {
+			if (this.#basePromptXdevNames.has(name)) this.#announcedMounts.add(name);
+		}
 		// Only announce a net change relative to what the model already knows (from
 		// this session and persisted history): a re-mount of an already-announced
 		// device — the common resume/reconnect case — and an unmount for a device
@@ -1097,6 +1090,7 @@ export class SessionTools {
 		const built = await this.#rebuildSystemPrompt(activeToolNames, this.#toolRegistry);
 		if (this.#host.isDisposed()) return;
 		this.#baseSystemPrompt = built.systemPrompt;
+		this.#basePromptXdevNames = new Set(built.xdevCatalogNames);
 		this.#host.clearMemoryPromotionSnapshot();
 		if (
 			previousBaseSystemPrompt.length !== this.#baseSystemPrompt.length ||

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -72,7 +72,10 @@ interface SessionToolsOptions {
 	builtInToolNames?: Iterable<string>;
 	presentationPinnedToolNames?: ReadonlySet<string>;
 	ensureWriteRegistered?: () => Promise<boolean>;
-	rebuildSystemPrompt?: (toolNames: string[], tools: Map<string, AgentTool>) => Promise<{ systemPrompt: string[] }>;
+	rebuildSystemPrompt?: (
+		toolNames: string[],
+		tools: Map<string, AgentTool>,
+	) => Promise<{ systemPrompt: string[]; xdevCatalogNames?: readonly string[] }>;
 	getLocalCalendarDate?: () => string;
 	getMcpServerInstructions?: () => Map<string, string> | undefined;
 	xdev?: XdevState;
@@ -619,6 +622,7 @@ export class SessionTools {
 
 		let rebuiltSystemPrompt: string[] | undefined;
 		let rebuiltSignature: string | undefined;
+		let rebuiltXdevCatalogNames: readonly string[] | undefined;
 		try {
 			if (this.#rebuildSystemPrompt) {
 				const signature = this.#computeAppliedToolSignature(validToolNames, tools);
@@ -626,6 +630,7 @@ export class SessionTools {
 					const built = await this.#rebuildSystemPrompt(validToolNames, this.#toolRegistry);
 					rebuiltSystemPrompt = built.systemPrompt;
 					rebuiltSignature = signature;
+					rebuiltXdevCatalogNames = built.xdevCatalogNames;
 				}
 			}
 		} catch (error) {
@@ -649,6 +654,7 @@ export class SessionTools {
 			this.#host.agent.setSystemPrompt(this.#baseSystemPrompt);
 			this.#lastAppliedToolSignature = rebuiltSignature;
 			this.#promptModelKey = this.#currentPromptModelKey();
+			this.#absorbExposedXdevIntoAnnounced(rebuiltXdevCatalogNames);
 		}
 	}
 
@@ -692,6 +698,31 @@ export class SessionTools {
 		if (addedNames.length > 0) parts.push(`mounted ${addedNames.join(", ")}`);
 		if (removedNames.length > 0) parts.push(`unmounted ${removedNames.join(", ")}`);
 		this.#host.emitNotice("info", `xd://: ${parts.join("; ")}`, "xdev");
+	}
+
+	/**
+	 * Fold the devices a just-applied prompt rebuild already advertises into the
+	 * announced-mount baseline. `rebuildSystemPrompt` reports the `xd://` catalog it
+	 * rendered ({@link BuildSystemPromptResult.xdevCatalogNames}); those devices are
+	 * now visible in the base prompt every following request carries, so a same-turn
+	 * mount notice would re-list the identical catalog before the first user turn —
+	 * on a fresh deferred-discovery session that double-billed the entire mounted MCP
+	 * inventory (issue #7139). Marking them announced and dropping them from the
+	 * pending delta suppresses that duplicate, while notices for mount changes the
+	 * rebuild did NOT expose (non-MCP churn that keeps the prompt byte-stable, or a
+	 * custom prompt that omits the catalog) and all unmount notices stay intact.
+	 *
+	 * Seeding first lets a fresh rebuild win over any stale history entry that marked
+	 * the device removed, so a currently-exposed device is never treated as unknown.
+	 */
+	#absorbExposedXdevIntoAnnounced(exposedNames: readonly string[] | undefined): void {
+		if (!exposedNames || exposedNames.length === 0) return;
+		this.#ensureAnnouncedMountsSeeded();
+		for (const name of exposedNames) this.#announcedMounts.add(name);
+		const pending = this.#pendingXdevMountDelta;
+		if (!pending) return;
+		for (const name of exposedNames) pending.added.delete(name);
+		this.#pendingXdevMountDelta = pending.added.size > 0 || pending.removed.size > 0 ? pending : undefined;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -779,20 +779,23 @@ export class SessionTools {
 	}
 
 	/** Consumes the hidden notice for unannounced `xd://` mount changes. */
-	takePendingXdevMountNotice(): CustomMessage<XdevMountNoticeDetails> | undefined {
+	takePendingXdevMountNotice(baseCatalogDelivered: boolean): CustomMessage<XdevMountNoticeDetails> | undefined {
 		const pending = this.#pendingXdevMountDelta;
 		if (!pending) return undefined;
 		this.#pendingXdevMountDelta = undefined;
 		this.#ensureAnnouncedMountsSeeded();
 		// A pending add for a device the outgoing base prompt already lists in its
-		// catalog needs no notice line — but the delivery makes the model aware of
-		// it, so record it announced. Doing this here (at delivery) rather than when
-		// the prompt was rebuilt keeps add/remove coalescing intact: a device mounted
-		// then unmounted before any prompt is sent cancels out in
-		// {@link #notifyXdevMountDelta} and never emits a spurious "No longer mounted"
-		// notice for a device the model never saw (issue #7139 review).
-		for (const name of pending.added) {
-			if (this.#basePromptXdevNames.has(name)) this.#announcedMounts.add(name);
+		// catalog needs no notice line — but only when the final provider prompt
+		// still carries that base catalog. A `before_agent_start` replacement drops
+		// it, so its additions must remain in the notice. Record prompt-carried
+		// devices announced here, after the final prompt is known and immediately
+		// before delivery. The pending delta remains untouched by rebuilds, letting
+		// {@link #notifyXdevMountDelta} cancel a mount followed by an unmount before
+		// any request is sent (issue #7139 reviews).
+		if (baseCatalogDelivered) {
+			for (const name of pending.added) {
+				if (this.#basePromptXdevNames.has(name)) this.#announcedMounts.add(name);
+			}
 		}
 		// Only announce a net change relative to what the model already knows (from
 		// this session and persisted history): a re-mount of an already-announced

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -554,6 +554,14 @@ export interface BuildSystemPromptOptions {
 export interface BuildSystemPromptResult {
 	/** Ordered system prompt blocks. Providers should preserve entries as distinct messages/blocks. */
 	systemPrompt: string[];
+	/**
+	 * Names of `xd://` devices whose catalog/protocol section this prompt renders.
+	 * Empty/undefined when no catalog was emitted (no mounted devices, or a custom
+	 * prompt template that omits the section). Lets the session fold these devices
+	 * into its announced-mount baseline so a same-turn mount notice does not re-list
+	 * a catalog the prompt already carries (issue #7139).
+	 */
+	xdevCatalogNames?: readonly string[];
 }
 
 /** Build the system prompt with tools, guidelines, and context */
@@ -895,5 +903,9 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		systemPrompt.push(activeRepoContextPrompt);
 	}
 
-	return { systemPrompt };
+	// The xd:// protocol section (with its device catalog) is only rendered by the
+	// default template; a resolved custom prompt uses a template that omits it.
+	const xdevCatalogNames =
+		!resolvedCustomPrompt && xdevTools.length > 0 ? xdevTools.map(mounted => mounted.name) : undefined;
+	return { systemPrompt, xdevCatalogNames };
 }

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -1035,6 +1035,27 @@ These tools became available:
 		).toHaveLength(0);
 	});
 
+	it("does not emit an unmount notice for a catalog device unmounted before delivery (#7139)", async () => {
+		const { session } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
+			xdev: createTestXdevState(),
+			responses: [{ content: ["ok"] }],
+			exposeXdevCatalog: true,
+		});
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
+
+		// Deferred discovery mounts the device, then the server disconnects before
+		// the first user prompt is ever sent. Because the pending add is only marked
+		// announced at delivery, the unmount coalesces it away — the model, which
+		// never saw a request carrying the device, must not receive a "No longer
+		// mounted" notice for it.
+		await session.refreshMCPTools([search]);
+		await session.refreshMCPTools([]);
+		await session.prompt("hi");
+		expect(
+			session.agent.state.messages.filter(m => m.role === "custom" && m.customType === "xdev-mount-notice"),
+		).toHaveLength(0);
+	});
+
 	it("re-announces a device after the transcript is replaced by /new", async () => {
 		const xdev = createTestXdevState();
 		const { session } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -5,6 +5,7 @@ import { createMockModel, type MockResponseSource } from "@oh-my-pi/pi-ai/provid
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { CustomTool } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
+import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { type CustomMessage, convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -110,6 +111,8 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		 * path. Existing tests leave this off, so their rebuild carries no catalog.
 		 */
 		exposeXdevCatalog?: boolean;
+		/** Optional per-turn system prompt replacement returned by before_agent_start. */
+		beforeAgentStartSystemPrompt?: string[];
 	}
 
 	function newSession(
@@ -119,6 +122,8 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		session: AgentSession;
 		/** Provider-call message snapshots (LLM-converted), one per model request. */
 		contexts: Message[][];
+		/** Provider-call system prompt snapshots, one per model request. */
+		systemPrompts: string[][];
 		/** Mutable registry shared with the session, for lifecycle-only mount fixtures. */
 		toolRegistry: Map<string, AgentTool>;
 	} {
@@ -131,6 +136,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		if (options.xdev && !options.lazyWrite) toolRegistry.set(writeTool.name, writeTool);
 		const mock = options.responses ? createMockModel({ responses: options.responses }) : undefined;
 		const contexts: Message[][] = [];
+		const systemPrompts: string[][] = [];
 		const agent = new Agent({
 			getApiKey: () => "test-key",
 			initialState: {
@@ -147,6 +153,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 			streamFn: mock
 				? (model, context, streamOptions) => {
 						contexts.push([...context.messages]);
+						systemPrompts.push([...(context.systemPrompt ?? [])]);
 						return mock.stream(model, context, streamOptions);
 					}
 				: undefined,
@@ -163,6 +170,12 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 				if (!toolRegistry.has("write")) toolRegistry.set("write", writeTool);
 				return true;
 			},
+			extensionRunner: options.beforeAgentStartSystemPrompt
+				? ({
+						emitBeforeAgentStart: async () => ({ systemPrompt: options.beforeAgentStartSystemPrompt }),
+						emit: async () => undefined,
+					} as unknown as ExtensionRunner)
+				: undefined,
 			rebuildSystemPrompt: async (toolNames, _tools) => {
 				const base = await rebuildSystemPrompt(toolNames);
 				if (!options.exposeXdevCatalog) return { systemPrompt: [base] };
@@ -174,7 +187,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 			xdev: options.xdev,
 		});
 		sessions.push(session);
-		return { session, contexts, toolRegistry };
+		return { session, contexts, systemPrompts, toolRegistry };
 	}
 
 	it("skips rebuild when an MCP refresh produces an identical tool set", async () => {
@@ -1033,6 +1046,28 @@ These tools became available:
 		expect(
 			session.agent.state.messages.filter(m => m.role === "custom" && m.customType === "xdev-mount-notice"),
 		).toHaveLength(0);
+	});
+
+	it("keeps the mount notice when before_agent_start replaces the catalog prompt (#7139)", async () => {
+		const replacementPrompt = ["extension replacement"];
+		const { session, contexts, systemPrompts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
+			xdev: createTestXdevState(),
+			responses: [{ content: ["ok"] }],
+			exposeXdevCatalog: true,
+			beforeAgentStartSystemPrompt: replacementPrompt,
+		});
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
+
+		// The base prompt rebuild exposes the device, but the per-turn extension
+		// replaces that prompt before the provider call. The mount notice is now
+		// the only channel making the newly mounted device visible on this turn.
+		await session.refreshMCPTools([search]);
+		await session.prompt("hi");
+
+		expect(systemPrompts[0]).toEqual(replacementPrompt);
+		const notices = mountNoticesIn(contexts[0]);
+		expect(notices).toHaveLength(1);
+		expect(notices[0]).toContain("xd://mcp__nucleus_search");
 	});
 
 	it("does not emit an unmount notice for a catalog device unmounted before delivery (#7139)", async () => {

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -104,6 +104,12 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		responses?: MockResponseSource;
 		/** Persisted history seeded into the agent, e.g. to model a resumed session. */
 		initialMessages?: AgentMessage[];
+		/**
+		 * Make the rebuild stub render the mounted xd:// catalog into the prompt and
+		 * report it via `xdevCatalogNames`, modelling the production `xdevDocsAll`
+		 * path. Existing tests leave this off, so their rebuild carries no catalog.
+		 */
+		exposeXdevCatalog?: boolean;
 	}
 
 	function newSession(
@@ -157,9 +163,12 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 				if (!toolRegistry.has("write")) toolRegistry.set("write", writeTool);
 				return true;
 			},
-			rebuildSystemPrompt: async (toolNames, _tools) => ({
-				systemPrompt: [await rebuildSystemPrompt(toolNames)],
-			}),
+			rebuildSystemPrompt: async (toolNames, _tools) => {
+				const base = await rebuildSystemPrompt(toolNames);
+				if (!options.exposeXdevCatalog) return { systemPrompt: [base] };
+				const catalog = options.xdev ? [...options.xdev.mountedNames] : [];
+				return { systemPrompt: [`${base}\nxd:// catalog: ${catalog.join(",")}`], xdevCatalogNames: catalog };
+			},
 			getMcpServerInstructions: options.getMcpServerInstructions,
 			getLocalCalendarDate: options.getLocalCalendarDate,
 			xdev: options.xdev,
@@ -995,6 +1004,35 @@ These tools became available:
 		const fetchText = typeof fetchNotice.content === "string" ? fetchNotice.content : "";
 		expect(fetchText).toContain("xd://mcp__nucleus_fetch");
 		expect(fetchText).not.toContain("xd://mcp__nucleus_search");
+	});
+
+	it("does not re-list catalog devices in a mount notice when the rebuild exposes them (#7139)", async () => {
+		const { session, contexts } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
+			xdev: createTestXdevState(),
+			responses: [{ content: ["ok"] }, { content: ["ok"] }],
+			exposeXdevCatalog: true,
+		});
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
+		const fetch = createMcpCustomTool("mcp__nucleus_fetch", "nucleus", "fetch", "Fetch nucleus");
+
+		// Fresh deferred-discovery session: the post-refresh rebuild renders the
+		// mounted catalog into the base prompt, so a same-turn mount notice would
+		// duplicate the whole catalog verbatim before the first user turn.
+		await session.refreshMCPTools([search]);
+		await session.prompt("hi");
+		expect(session.systemPrompt.join("\n")).toContain("mcp__nucleus_search");
+		expect(
+			session.agent.state.messages.filter(m => m.role === "custom" && m.customType === "xdev-mount-notice"),
+		).toHaveLength(0);
+		expect(mountNoticesIn(contexts[0])).toHaveLength(0);
+
+		// A later device the next rebuild also exposes stays notice-free too.
+		await session.refreshMCPTools([search, fetch]);
+		await session.prompt("again");
+		expect(session.systemPrompt.join("\n")).toContain("mcp__nucleus_fetch");
+		expect(
+			session.agent.state.messages.filter(m => m.role === "custom" && m.customType === "xdev-mount-notice"),
+		).toHaveLength(0);
 	});
 
 	it("re-announces a device after the transcript is replaced by /new", async () => {


### PR DESCRIPTION
## Repro
On a fresh session with deferred interactive MCP discovery, the newly mounted `xd://` tools are injected twice into the first model request: once in the post-discovery system-prompt rebuild (which renders the full device catalog via `xdevDocsAll`), and again in the pre-user `xdev-mount-notice`. With 246 mounted MCP tools the reporter saw a ~29 KB duplicate notice on top of the rebuilt catalog. Reproduced with a session-level test modelling a catalog-carrying rebuild: `bun test test/agent-session-tool-rebuild-skip.test.ts -t "does not re-list catalog devices"` — before the fix the notice fired (`Received length: 1`) even though the system prompt already listed the device.

## Cause
`SessionTools.applyActiveToolsByName` (`packages/coding-agent/src/session/session-tools.ts`) queues the newly mounted names into `#pendingXdevMountDelta` via `#notifyXdevMountDelta`, then applies the rebuilt base prompt — but never updates the `#announcedMounts` baseline for the devices that rebuild already exposed. `#takePendingXdevMountNotice` only suppresses devices already in `#announcedMounts` (seeded from persisted history), so on a fresh start every mounted device is treated as both prompt-visible and still unannounced, and `agent-session.ts` splices the full catalog as a pre-user notice.

## Fix
- `system-prompt.ts`: `BuildSystemPromptResult` gains `xdevCatalogNames` — the `xd://` devices whose catalog/protocol section the built prompt renders. It is populated only for the default template (a resolved custom prompt omits the section) and only when devices are mounted.
- `session/agent-session-types.ts` and `session/session-tools.ts`: widen the `rebuildSystemPrompt` return type to carry `xdevCatalogNames`.
- `session/session-tools.ts`: `applyActiveToolsByName` captures the reported catalog names and, after applying the rebuild, calls the new `#absorbExposedXdevIntoAnnounced` — it seeds the announced baseline, marks the exposed devices announced, and drops them from the pending delta. Notices for mount changes the rebuild did not expose (non-MCP churn, custom-prompt sessions) and all unmount notices are untouched.
- `test/agent-session-tool-rebuild-skip.test.ts`: adds an `exposeXdevCatalog` option to the harness (rebuild renders + reports the mounted catalog, modelling production) and a regression test asserting no duplicate notice when the rebuild exposes the catalog.

## Verification
`bun test test/agent-session-tool-rebuild-skip.test.ts` — 32 pass (new regression test included); related `bun test test/sdk-tool-activation.test.ts test/sdk-generate-image-tool-gating.test.ts` — 39 pass. `bun run check` in `packages/coding-agent` passes (biome + tsgo, exit 0). The repo-root `bun check` also runs `check:rs`, which fails in this environment with `is cmake not installed?` — a missing system tool unrelated to this TS/markdown-only change; skipped the aggregate gate for that pre-existing environmental break. Fixes #7139