### PR TITLE
fix(bash): scope shell snapshots per uid so shared-/tmp accounts don't EACCES

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the bash tool failing every command with `EACCES: permission denied, open '/tmp/omp-shell-snapshots/snapshot-bash-<uuid>.sh'` on machines where more than one Unix account runs `omp`. The snapshot directory was a single fixed name under the shared `os.tmpdir()` created 0700, so the first account to run `omp` owned it and every other account's pre-create write was denied; the throw escaped `getOrCreateSnapshot` into `executeBash`, and nothing was cached, so the failure repeated for every command. The directory is now scoped per uid (`omp-shell-snapshots-<uid>`), and an unusable snapshot directory degrades to running without a snapshot instead of failing the command.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/utils/shell-snapshot.ts
+++ b/packages/coding-agent/src/utils/shell-snapshot.ts
@@ -230,32 +230,42 @@ export async function getOrCreateSnapshot(
 
 	const rcFile = getShellConfigFile(shell, env);
 
-	// Create snapshot directory with owner-only perms — the script may inline
-	// env vars referenced by captured functions (#3470) and `os.tmpdir()` is
-	// shared on Linux. `mode: 0o700` applies to a fresh mkdir; an existing dir
-	// keeps its mode, so chmod it defensively. Ignore EPERM (dir owned by
-	// another user on a shared box).
-	const snapshotDir = path.join(os.tmpdir(), "omp-shell-snapshots");
-	fs.mkdirSync(snapshotDir, { recursive: true, mode: 0o700 });
-	try {
-		fs.chmodSync(snapshotDir, 0o700);
-	} catch {
-		// best-effort
-	}
+	// Snapshot dir is per-uid. `os.tmpdir()` is shared between accounts on Linux and
+	// this dir is 0700 because the script may inline env-var values referenced by
+	// captured functions (#3470), so a single shared name hands the first account an
+	// exclusive dir and every other account's pre-create write below fails with
+	// EACCES — which used to escape into `executeBash` and break every bash call.
+	const uid = process.getuid?.();
+	const snapshotDir = path.join(os.tmpdir(), uid === undefined ? "omp-shell-snapshots" : `omp-shell-snapshots-${uid}`);
 
 	// Generate unique snapshot path
 	const shellName = shell.includes("zsh") ? "zsh" : shell.includes("bash") ? "bash" : "sh";
 	const snapshotPath = path.join(snapshotDir, `snapshot-${shellName}-${crypto.randomUUID()}.sh`);
 
-	// Pre-create the snapshot file at 0600 so the shell's `>|` (truncate) and
-	// `>>` (append) redirections inside `generateSnapshotScript` operate on an
-	// existing inode and preserve the private mode, regardless of the umask
-	// state inside the spawned shell. Without this, a `.bashrc` that sets
-	// `umask 022` (the typical interactive default) before the script's first
-	// redirection would create the file world-readable; the JS-side post-spawn
-	// chmod would tighten it, but only after the shell finished writing every
-	// captured env value to disk.
-	fs.writeFileSync(snapshotPath, "", { mode: 0o600 });
+	try {
+		fs.mkdirSync(snapshotDir, { recursive: true, mode: 0o700 });
+		// `mode` only applies to a fresh mkdir; an existing dir keeps its mode, so
+		// chmod it defensively. Ignore EPERM (dir owned by another account).
+		try {
+			fs.chmodSync(snapshotDir, 0o700);
+		} catch {
+			// best-effort
+		}
+		// Pre-create the snapshot file at 0600 so the shell's `>|` (truncate) and
+		// `>>` (append) redirections inside `generateSnapshotScript` operate on an
+		// existing inode and preserve the private mode, regardless of the umask
+		// state inside the spawned shell. Without this, a `.bashrc` that sets
+		// `umask 022` (the typical interactive default) before the script's first
+		// redirection would create the file world-readable; the JS-side post-spawn
+		// chmod would tighten it, but only after the shell finished writing every
+		// captured env value to disk.
+		fs.writeFileSync(snapshotPath, "", { mode: 0o600 });
+	} catch (err) {
+		// Unusable snapshot dir (foreign owner, read-only or full /tmp): run without
+		// a snapshot instead of failing the caller's command.
+		logger.debug("shell-snapshot: snapshot dir unusable", { dir: snapshotDir, err: String(err) });
+		return null;
+	}
 
 	// Generate and execute snapshot script
 	const script = generateSnapshotScript(shell, snapshotPath, rcFile);

--- a/packages/coding-agent/test/shell-snapshot.test.ts
+++ b/packages/coding-agent/test/shell-snapshot.test.ts
@@ -16,6 +16,12 @@ const REAL_BASH = Bun.env.SHELL?.includes("bash") ? Bun.env.SHELL : "/bin/bash";
 // replay fail with `No such file or directory` even though the export landed.
 const REAL_ECHO = Bun.which("echo") ?? "/bin/echo";
 
+/** Mirrors the per-uid snapshot dir name computed in `getOrCreateSnapshot`. */
+function snapshotDirIn(tmpRoot: string): string {
+	const uid = process.getuid?.();
+	return path.join(tmpRoot, uid === undefined ? "omp-shell-snapshots" : `omp-shell-snapshots-${uid}`);
+}
+
 // `sanitizeSnapshotForBrush` is the snapshot-side mitigation for brush's
 // whitespace-only alias expander (`crates/vendor/brush-core/src/interp.rs:1500`,
 // brush issue reubeno/brush#57). Aliases whose body needs real shell parsing
@@ -280,7 +286,7 @@ describe("getOrCreateSnapshot", () => {
 
 		// PR-review hardening: snapshot file must be group/world-unreadable since
 		// it now inlines env-var values. Directory must be 0700 for the same
-		// reason — UUID filenames shouldn't leak via `ls /tmp/omp-shell-snapshots`.
+		// reason — UUID filenames shouldn't leak via `ls /tmp/omp-shell-snapshots-$(id -u)`.
 		const fileStat = await fs.stat(snapshotPath!);
 		expect(fileStat.mode & 0o077).toBe(0);
 		const dirStat = await fs.stat(path.dirname(snapshotPath!));
@@ -325,7 +331,7 @@ describe("getOrCreateSnapshot", () => {
 			await fs.chmod(fakeShell, 0o755);
 
 			const env = { ...process.env, HOME: testRoot };
-			const snapshotDir = path.join(testRoot, "omp-shell-snapshots");
+			const snapshotDir = snapshotDirIn(testRoot);
 
 			const snapshotPath = await getOrCreateSnapshot(fakeShell, env);
 			expect(snapshotPath).toBeNull();
@@ -350,7 +356,7 @@ describe("getOrCreateSnapshot", () => {
 			const fakeShell = path.join(testRoot, "does-not-exist-shell");
 
 			const env = { ...process.env, HOME: testRoot };
-			const snapshotDir = path.join(testRoot, "omp-shell-snapshots");
+			const snapshotDir = snapshotDirIn(testRoot);
 
 			const snapshotPath = await getOrCreateSnapshot(fakeShell, env);
 			expect(snapshotPath).toBeNull();
@@ -377,7 +383,7 @@ describe("getOrCreateSnapshot", () => {
 			await fs.chmod(fakeShell, 0o755);
 
 			const env = { ...process.env, HOME: testRoot };
-			const snapshotDir = path.join(testRoot, "omp-shell-snapshots");
+			const snapshotDir = snapshotDirIn(testRoot);
 
 			const snapshotPath = await getOrCreateSnapshot(fakeShell, env);
 			expect(snapshotPath).toBeNull();
@@ -392,4 +398,55 @@ describe("getOrCreateSnapshot", () => {
 			await fs.rm(testRoot, { recursive: true, force: true });
 		}
 	}, 5000); // increase test timeout to 5s to accommodate the 2s snapshot timeout
+
+	it("keeps snapshots in a uid-scoped dir so accounts sharing /tmp cannot collide", async () => {
+		// Regression: the dir used to be a single fixed `omp-shell-snapshots` name
+		// under the shared `os.tmpdir()`, created 0700. The first account to run omp
+		// owned it and every other account's pre-create write died with EACCES.
+		const realBash = REAL_BASH;
+		if (!existsSync(realBash)) return;
+		const testRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-snap-uid-"));
+		const originalTmpDir = process.env.TMPDIR;
+		process.env.TMPDIR = testRoot;
+		try {
+			const shellLink = path.join(testRoot, "bash-omp-uid");
+			await fs.symlink(realBash, shellLink);
+			const snapshotPath = await getOrCreateSnapshot(shellLink, { ...process.env, HOME: testRoot });
+			expect(snapshotPath).not.toBeNull();
+			expect(path.dirname(snapshotPath!)).toBe(snapshotDirIn(testRoot));
+		} finally {
+			if (originalTmpDir === undefined) delete process.env.TMPDIR;
+			else process.env.TMPDIR = originalTmpDir;
+			await fs.rm(testRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("returns null instead of throwing when the snapshot dir is unusable", async () => {
+		// Regression: `mkdirSync` and the pre-create `writeFileSync` both sat
+		// outside any try/catch, so an unusable snapshot dir threw straight out of
+		// `getOrCreateSnapshot` into `executeBash` and killed every bash tool call
+		// with `EACCES: permission denied, open '.../snapshot-bash-<uuid>.sh'`.
+		// In the field the trigger is a dir owned by another account (chmod then
+		// fails EPERM and is swallowed); ownership can't be faked without root, so
+		// this pins the same guard via an unwritable parent.
+		if (process.getuid?.() === 0) return; // root ignores mode bits
+		const realBash = REAL_BASH;
+		if (!existsSync(realBash)) return;
+		const testRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-snap-eacces-"));
+		const originalTmpDir = process.env.TMPDIR;
+		const shellLink = path.join(testRoot, "bash-omp-eacces");
+		await fs.symlink(realBash, shellLink);
+		process.env.TMPDIR = testRoot;
+		try {
+			await fs.chmod(testRoot, 0o500); // r-x: snapshot dir cannot be created
+			const snapshotPath = await getOrCreateSnapshot(shellLink, { ...process.env, HOME: testRoot });
+			expect(snapshotPath).toBeNull();
+			expect(existsSync(snapshotDirIn(testRoot))).toBe(false);
+		} finally {
+			await fs.chmod(testRoot, 0o700).catch(() => {});
+			if (originalTmpDir === undefined) delete process.env.TMPDIR;
+			else process.env.TMPDIR = originalTmpDir;
+			await fs.rm(testRoot, { recursive: true, force: true });
+		}
+	});
 });


### PR DESCRIPTION
## What

Scope the shell-snapshot directory per uid (`omp-shell-snapshots-<uid>`) and stop an unusable snapshot directory from failing the caller's command — `getOrCreateSnapshot` now returns `null` (run without a snapshot) when the directory cannot be created or the snapshot file cannot be pre-created.

## Why

I run omp from two Unix accounts on the same machine, and every bash tool call in the second account died with:

```
EACCES: permission denied, open '/tmp/omp-shell-snapshots/snapshot-bash-<uuid>.sh'
```

`os.tmpdir()` is shared on Linux, the directory is created 0700 (correctly — snapshots inline env-var values referenced by captured functions, #3470), and `recursive: true` swallows EEXIST while `mode` is ignored for an existing directory. The defensive `chmodSync` fails EPERM on a foreign-owned directory and was already swallowed, so the code walked straight into a directory it could not write.

Both `fs.mkdirSync` and the pre-create `fs.writeFileSync` (added in #4265) sat outside any try/catch, so the error escaped `getOrCreateSnapshot` into `executeBash`. Nothing is cached on failure, so it repeated for every command — a permanently dead bash tool rather than one degraded run. `executeBash` already handles a `null` snapshot, so degrading is the contract the callers expect.

## Testing

`bun test packages/coding-agent/test/shell-snapshot.test.ts` — **24 pass, 0 fail, 76 expect() calls**, including two new tests:

- `keeps snapshots in a uid-scoped dir so accounts sharing /tmp cannot collide`
- `returns null instead of throwing when the snapshot dir is unusable`

Both are genuine regressions. Reverting only `src/utils/shell-snapshot.ts` and re-running the file gives **22 pass, 2 fail**:

```
expect(received).toBe(expected)
Expected: "/tmp/omp-snap-uid-WvlZzs/omp-shell-snapshots-1000"
Received: "/tmp/omp-snap-uid-WvlZzs/omp-shell-snapshots"
(fail) getOrCreateSnapshot > keeps snapshots in a uid-scoped dir so accounts sharing /tmp cannot collide

EACCES: permission denied, mkdir '/tmp/omp-snap-eacces-ULe3Bc/omp-shell-snapshots'
    at getOrCreateSnapshot (packages/coding-agent/src/utils/shell-snapshot.ts:239:5)
(fail) getOrCreateSnapshot > returns null instead of throwing when the snapshot dir is unusable
```

The second failure is the production symptom exactly: the error thrown straight out of `getOrCreateSnapshot` instead of degrading.

Note on the unwritable-directory test: the field trigger is a directory owned by *another account*, where `chmodSync` fails EPERM. A test can't chown without root — and a directory the test process owns is useless here, because the defensive `chmodSync(dir, 0o700)` succeeds and makes it writable again. The test therefore makes the *parent* `r-x` so `mkdirSync` fails, which pins the same guard, and skips under uid 0 since root ignores mode bits.

End-to-end against the real shared `/tmp` (calling the patched `getOrCreateSnapshot` directly):

```
snapshotPath: /tmp/omp-shell-snapshots-1000/snapshot-bash-28bd0be8-c554-40a5-965a-95a0cac912a4.sh
dirname:      /tmp/omp-shell-snapshots-1000
```

— a fresh 0700 `omp-shell-snapshots-1000`, cleanly separate from the pre-existing `omp-shell-snapshots`.

Original bug reproduced against the released binary (omp/17.0.6) with a foreign-owned snapshot directory (root-owned 0700, same failure mode as a second account getting there first): every bash tool call returned the EACCES line above and no command ran. Pointing `TMPDIR` at a per-account path made it work again, which is the same separation this patch does properly.

Checks: `biome check .` and `tsgo -p tsconfig.json --noEmit` — the two commands `bun run check` runs in `packages/coding-agent` — both clean. I ran them directly rather than via `bun run check`; I could not run the repo-root `bun check`, which fans out to `check:rs`, because there is no Rust toolchain on this machine (the diff is TypeScript-only). The native addon needed to load the test file came from the published `@oh-my-pi/pi-natives-linux-x64@17.2.1` prebuilt, not a local bazel build.

---

- [x] `bun check` passes — `biome check .` + `tsgo --noEmit` for `packages/coding-agent`; `check:rs` not run (no Rust toolchain locally, TypeScript-only diff)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
