### PR TITLE
feat(catalog): add Neuralwatt provider with dynamic model discovery

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a Neuralwatt provider registry entry with interactive API-key login (`/login neuralwatt`), validated against the public `/v1/models` endpoint.
+- Added a Neuralwatt provider registry entry with interactive API-key login (`/login neuralwatt`), validated against the authenticated `/v1/quota` endpoint.
+- Added Neuralwatt subscription energy, PAYG credit balance, subscription-overage capacity, and per-key allowance reporting from the documented `/v1/quota` endpoint.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/ai/src/auth-broker/wire-schema-resource.ts
+++ b/packages/ai/src/auth-broker/wire-schema-resource.ts
@@ -228,7 +228,7 @@ function buildAuthBrokerWireSchemas(): AuthBrokerWireSchemas {
 
 	// ─── Usage ─────────────────────────────────────────────────────────────────
 
-	const usageUnitSchema = type("'percent' | 'tokens' | 'requests' | 'usd' | 'minutes' | 'bytes' | 'unknown'");
+	const usageUnitSchema = type("'percent' | 'tokens' | 'requests' | 'usd' | 'minutes' | 'bytes' | 'kwh' | 'unknown'");
 	const usageStatusSchema = type("'ok' | 'warning' | 'exhausted' | 'unknown'");
 
 	const usageWindowSchema = type({

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -57,6 +57,7 @@ import { githubCopilotUsageProvider } from "./usage/github-copilot";
 import { antigravityRankingStrategy, antigravityUsageProvider } from "./usage/google-antigravity";
 import { kimiUsageProvider } from "./usage/kimi";
 import { minimaxCodeUsageProvider } from "./usage/minimax-code";
+import { neuralwattUsageProvider } from "./usage/neuralwatt";
 import { ollamaCloudUsageProvider, ollamaUsageProvider } from "./usage/ollama";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "./usage/openai-codex";
 import {
@@ -664,6 +665,7 @@ const DEFAULT_USAGE_PROVIDERS: UsageProvider[] = [
 	openaiCodexUsageProvider,
 	kimiUsageProvider,
 	minimaxCodeUsageProvider,
+	neuralwattUsageProvider,
 	antigravityUsageProvider,
 	googleGeminiCliUsageProvider,
 	ollamaUsageProvider,

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -879,8 +879,11 @@ export function resolveOpenAICompatPolicy<TApi extends Api>(
 	const disableMode = compat.reasoningDisableMode;
 	let wireEffort =
 		enabled && requestedEffort !== undefined ? mapOpenAIReasoningEffort(model, compat, requestedEffort) : undefined;
+	// No control surface means native provider behavior, not implicit "off".
+	// Explicit caller disable still uses the configured wire switch below.
 	const disabledWithoutRequest =
 		modelSupported &&
+		model.thinking !== undefined &&
 		requestedEffort === undefined &&
 		!options.disableReasoning &&
 		isImplicitDisableWhenNotRequested(disableMode);

--- a/packages/ai/src/registry/neuralwatt.ts
+++ b/packages/ai/src/registry/neuralwatt.ts
@@ -1,0 +1,22 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+export const loginNeuralwatt = createApiKeyLogin({
+	providerLabel: "Neuralwatt",
+	authUrl: "https://portal.neuralwatt.com/dashboard/keys",
+	instructions: "Create or copy your API key from the Neuralwatt dashboard",
+	promptMessage: "Paste your Neuralwatt API key",
+	placeholder: "sk-...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "Neuralwatt",
+		modelsUrl: "https://api.neuralwatt.com/v1/quota",
+	},
+});
+
+export const neuralwattProvider = {
+	id: "neuralwatt",
+	name: "Neuralwatt",
+	login: (cb: OAuthLoginCallbacks) => loginNeuralwatt(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -40,6 +40,7 @@ import { minimaxCodeCnProvider } from "./minimax-code-cn";
 import { mistralProvider } from "./mistral";
 import { moonshotProvider } from "./moonshot";
 import { nanogptProvider } from "./nanogpt";
+import { neuralwattProvider } from "./neuralwatt";
 import { novitaProvider } from "./novita";
 import { nvidiaProvider } from "./nvidia";
 import { ollamaProvider } from "./ollama";
@@ -124,6 +125,7 @@ const ALL = [
 	fireworksProvider,
 	togetherProvider,
 	nvidiaProvider,
+	neuralwattProvider,
 	novitaProvider,
 	huggingfaceProvider,
 	perplexityProvider,

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -6,7 +6,7 @@
  */
 import { type } from "@oh-my-pi/omptype";
 import type { FetchImpl, Provider } from "./types";
-export type UsageUnit = "percent" | "tokens" | "requests" | "usd" | "minutes" | "bytes" | "unknown";
+export type UsageUnit = "percent" | "tokens" | "requests" | "usd" | "kwh" | "minutes" | "bytes" | "unknown";
 
 export type UsageStatus = "ok" | "warning" | "exhausted" | "unknown";
 
@@ -242,7 +242,9 @@ export interface ClientUsageSummary {
 
 // ─── Zod schemas (wire-shape validation for the broker `/v1/usage` endpoint) ─
 
-export const usageUnitSchema = type("'percent' | 'tokens' | 'requests' | 'usd' | 'minutes' | 'bytes' | 'unknown'");
+export const usageUnitSchema = type(
+	"'percent' | 'tokens' | 'requests' | 'usd' | 'kwh' | 'minutes' | 'bytes' | 'unknown'",
+);
 export const usageStatusSchema = type("'ok' | 'warning' | 'exhausted' | 'unknown'");
 
 export const usageWindowSchema = type({

--- a/packages/ai/src/usage/neuralwatt.ts
+++ b/packages/ai/src/usage/neuralwatt.ts
@@ -1,0 +1,230 @@
+import { ProviderHttpError } from "../error";
+import type {
+	UsageAmount,
+	UsageFetchContext,
+	UsageFetchParams,
+	UsageLimit,
+	UsageProvider,
+	UsageReport,
+} from "../usage";
+import { isRecord } from "../utils";
+import { parseIsoTimestamp, usageStatus } from "./shared";
+
+const PROVIDER = "neuralwatt";
+const DEFAULT_BASE_URL = "https://api.neuralwatt.com/v1";
+const DEFAULT_OVERAGE_LIMIT_USD = 100;
+
+function toFiniteNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function toNonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+function buildUsageAmount(
+	used: number | undefined,
+	limit: number | undefined,
+	remaining: number | undefined,
+	unit: UsageAmount["unit"],
+): UsageAmount | null {
+	if (used === undefined && limit === undefined && remaining === undefined) return null;
+	const resolvedUsed = used ?? (limit !== undefined && remaining !== undefined ? limit - remaining : undefined);
+	const usedFraction =
+		limit !== undefined && limit > 0 ? (resolvedUsed !== undefined ? resolvedUsed / limit : undefined) : undefined;
+	return {
+		...(resolvedUsed !== undefined ? { used: resolvedUsed } : {}),
+		...(limit !== undefined ? { limit } : {}),
+		...(remaining !== undefined ? { remaining } : {}),
+		...(usedFraction !== undefined ? { usedFraction, remainingFraction: Math.max(0, 1 - usedFraction) } : {}),
+		unit,
+	};
+}
+function usageStatusWhileUsable(usedFraction: number | undefined) {
+	const status = usageStatus(usedFraction);
+	return status === "exhausted" ? "warning" : status;
+}
+
+function buildSubscriptionLimit(subscription: Record<string, unknown>): UsageLimit | null {
+	const amount = buildUsageAmount(
+		toFiniteNumber(subscription.kwh_used),
+		toFiniteNumber(subscription.kwh_included),
+		toFiniteNumber(subscription.kwh_remaining),
+		"kwh",
+	);
+	if (!amount) return null;
+	const periodStart = parseIsoTimestamp(subscription.current_period_start);
+	const periodEnd =
+		parseIsoTimestamp(subscription.kwh_reset_date) ?? parseIsoTimestamp(subscription.current_period_end);
+	const durationMs =
+		periodStart !== undefined && periodEnd !== undefined && periodEnd > periodStart
+			? periodEnd - periodStart
+			: undefined;
+	const plan = toNonEmptyString(subscription.plan);
+	const inOverage = subscription.in_overage === true;
+
+	return {
+		id: "neuralwatt:subscription",
+		label: "Subscription Energy",
+		scope: {
+			provider: PROVIDER,
+			...(plan ? { tier: plan } : {}),
+			windowId: "billing",
+			shared: true,
+		},
+		window: {
+			id: "billing",
+			label: "Billing Period",
+			...(durationMs !== undefined ? { durationMs } : {}),
+			...(periodEnd !== undefined ? { resetsAt: periodEnd } : {}),
+		},
+		amount,
+		status: inOverage ? "warning" : usageStatusWhileUsable(amount.usedFraction),
+		...(inOverage
+			? { notes: ["Included energy exhausted; usage continues against credits and overage capacity."] }
+			: {}),
+	};
+}
+function buildCreditsLimit(balance: Record<string, unknown>, subscriptionOverage = false): UsageLimit | null {
+	const amount = buildUsageAmount(
+		toFiniteNumber(balance.credits_used_usd),
+		toFiniteNumber(balance.total_credits_usd),
+		toFiniteNumber(balance.credits_remaining_usd),
+		"usd",
+	);
+	if (!amount) return null;
+	return {
+		id: "neuralwatt:credits",
+		label: subscriptionOverage ? "Credit Balance" : "PAYG Credits",
+		scope: { provider: PROVIDER, shared: true },
+		amount,
+		status: subscriptionOverage
+			? usageStatusWhileUsable(amount.usedFraction)
+			: amount.remaining !== undefined && amount.remaining <= 0
+				? "exhausted"
+				: usageStatus(amount.usedFraction),
+	};
+}
+
+function buildOverageLimit(
+	balance: Record<string, unknown>,
+	rateLimits: Record<string, unknown> | undefined,
+): UsageLimit | null {
+	const creditBalance = toFiniteNumber(balance.credits_remaining_usd);
+	if (creditBalance === undefined) return null;
+	const configuredLimit = toFiniteNumber(rateLimits?.overage_limit_usd);
+	const limit = configuredLimit === undefined ? DEFAULT_OVERAGE_LIMIT_USD : Math.abs(configuredLimit);
+	const used = Math.max(0, -creditBalance);
+	const remaining = limit - used;
+	const amount = buildUsageAmount(used, limit, remaining, "usd");
+	if (!amount) return null;
+	return {
+		id: "neuralwatt:overage",
+		label: "Overage Capacity",
+		scope: { provider: PROVIDER, shared: true },
+		amount,
+		status: creditBalance <= 0 && remaining <= 0 ? "exhausted" : "warning",
+		notes: ["Requests pause when this overage capacity is exhausted."],
+	};
+}
+
+function buildKeyAllowanceLimit(key: Record<string, unknown>): UsageLimit | null {
+	if (!isRecord(key.allowance)) return null;
+	const allowance = key.allowance;
+	const amount = buildUsageAmount(
+		toFiniteNumber(allowance.spent_usd),
+		toFiniteNumber(allowance.limit_usd),
+		toFiniteNumber(allowance.remaining_usd),
+		"usd",
+	);
+	if (!amount) return null;
+	const period = toNonEmptyString(allowance.period);
+	const blocked = allowance.blocked === true;
+	return {
+		id: "neuralwatt:key-allowance",
+		label: "API Key Allowance",
+		scope: { provider: PROVIDER, windowId: period ?? "allowance", shared: true },
+		...(period ? { window: { id: period, label: period.charAt(0).toUpperCase() + period.slice(1) } } : {}),
+		amount,
+		status: blocked ? "exhausted" : usageStatusWhileUsable(amount.usedFraction),
+		...(blocked ? { notes: ["API key is blocked because its spending allowance is exhausted."] } : {}),
+	};
+}
+
+async function fetchNeuralwattUsage(params: UsageFetchParams, ctx: UsageFetchContext): Promise<UsageReport | null> {
+	if (params.provider !== PROVIDER || params.credential.type !== "api_key" || !params.credential.apiKey) return null;
+
+	const baseUrl = (params.baseUrl?.trim() || DEFAULT_BASE_URL).replace(/\/+$/, "");
+	const url = `${baseUrl}/quota`;
+	try {
+		const response = await ctx.fetch(url, {
+			headers: { Accept: "application/json", Authorization: `Bearer ${params.credential.apiKey}` },
+			signal: params.signal,
+		});
+		if (!response.ok) {
+			if (response.status === 401 || response.status === 403) {
+				throw new ProviderHttpError(`Neuralwatt quota endpoint returned ${response.status}`, response.status, {
+					headers: response.headers,
+				});
+			}
+			ctx.logger?.warn("Neuralwatt quota fetch failed", { status: response.status });
+			return null;
+		}
+
+		const payload: unknown = await response.json();
+		if (!isRecord(payload)) return null;
+		const subscriptionRecord = isRecord(payload.subscription) ? payload.subscription : undefined;
+		const balance = isRecord(payload.balance) ? payload.balance : undefined;
+		const key = isRecord(payload.key) ? payload.key : undefined;
+		const rateLimits = isRecord(payload.limits) ? payload.limits : undefined;
+		const limits: UsageLimit[] = [];
+		const subscription = subscriptionRecord ? buildSubscriptionLimit(subscriptionRecord) : null;
+		if (subscription) {
+			limits.push(subscription);
+			if (subscriptionRecord?.in_overage === true && balance) {
+				const credits = buildCreditsLimit(balance, true);
+				if (credits) limits.push(credits);
+				const overage = buildOverageLimit(balance, rateLimits);
+				if (overage) limits.push(overage);
+			}
+		} else if (balance) {
+			const credits = buildCreditsLimit(balance);
+			if (credits) limits.push(credits);
+		}
+		if (key) {
+			const allowance = buildKeyAllowanceLimit(key);
+			if (allowance) limits.push(allowance);
+		}
+		if (limits.length === 0) return null;
+		return {
+			provider: PROVIDER,
+			fetchedAt: Date.now(),
+			limits,
+			metadata: {
+				endpoint: url,
+				snapshotAt: toNonEmptyString(payload.snapshot_at),
+				plan: toNonEmptyString(subscriptionRecord?.plan),
+				status: toNonEmptyString(subscriptionRecord?.status),
+				billingInterval: toNonEmptyString(subscriptionRecord?.billing_interval),
+				autoRenew: typeof subscriptionRecord?.auto_renew === "boolean" ? subscriptionRecord.auto_renew : undefined,
+				accountingMethod: toNonEmptyString(balance?.accounting_method),
+				keyName: toNonEmptyString(key?.name),
+				rateLimitTier: toNonEmptyString(rateLimits?.rate_limit_tier),
+			},
+			raw: payload,
+		};
+	} catch (error) {
+		if (error instanceof ProviderHttpError) throw error;
+		ctx.logger?.warn("Neuralwatt quota request failed", {
+			error: error instanceof Error ? error.name : "unknown",
+		});
+		return null;
+	}
+}
+
+export const neuralwattUsageProvider: UsageProvider = {
+	id: PROVIDER,
+	fetchUsage: fetchNeuralwattUsage,
+	supports: params =>
+		params.provider === PROVIDER && params.credential.type === "api_key" && Boolean(params.credential.apiKey),
+	validatesCredentials: true,
+};

--- a/packages/ai/test/auth-broker-wire-schema-contract.test.ts
+++ b/packages/ai/test/auth-broker-wire-schema-contract.test.ts
@@ -251,6 +251,23 @@ describe("auth-broker public wire schemas", () => {
 		reject(wireSchemas.snapshotStreamEventSchema, { kind: "unknown" });
 	});
 
+	test("accepts kwh usage amounts", () => {
+		accept(wireSchemas.usageResponseSchema, {
+			generatedAt: 2_000,
+			reports: [
+				{
+					...USAGE_REPORT,
+					limits: [
+						{
+							...USAGE_REPORT.limits[0],
+							amount: { ...USAGE_REPORT.limits[0].amount, unit: "kwh" },
+						},
+					],
+				},
+			],
+		});
+	});
+
 	test("preserves usage extensions while rejecting envelope and enum violations", () => {
 		const response = { generatedAt: 2_000, reports: [USAGE_REPORT] };
 		expect(accept(wireSchemas.usageResponseSchema, response)).toEqual(response);

--- a/packages/ai/test/neuralwatt-login.test.ts
+++ b/packages/ai/test/neuralwatt-login.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "bun:test";
+import { getProviderDefinition } from "@oh-my-pi/pi-ai/registry";
+import { getOAuthProviders } from "@oh-my-pi/pi-ai/registry/oauth";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+
+describe("neuralwatt login", () => {
+	it("appears in the login list and validates a normalized key against Neuralwatt", async () => {
+		expect(getOAuthProviders().map(provider => provider.id)).toContain("neuralwatt");
+
+		const login = getProviderDefinition("neuralwatt")?.login;
+		if (!login) throw new Error("Neuralwatt is missing its interactive login callback");
+
+		let authUrl: string | undefined;
+		let promptMessage: string | undefined;
+		let promptPlaceholder: string | undefined;
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			expect(url).toBe("https://api.neuralwatt.com/v1/quota");
+			expect(init?.method).toBe("GET");
+			expect(init?.headers).toEqual({ Authorization: "Bearer sk-neuralwatt-test" });
+			return new Response(JSON.stringify({ object: "list", data: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		const apiKey = await login({
+			onAuth: info => {
+				authUrl = info.url;
+			},
+			onPrompt: async prompt => {
+				promptMessage = prompt.message;
+				promptPlaceholder = prompt.placeholder;
+				return "  sk-neuralwatt-test  ";
+			},
+			fetch: fetchMock,
+		});
+
+		expect(authUrl).toBe("https://portal.neuralwatt.com/dashboard/keys");
+		expect(promptMessage).toBe("Paste your Neuralwatt API key");
+		expect(promptPlaceholder).toBe("sk-...");
+		expect(apiKey).toBe("sk-neuralwatt-test");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects an unauthorized key from the quota validation endpoint", async () => {
+		const login = getProviderDefinition("neuralwatt")?.login;
+		if (!login) throw new Error("Neuralwatt is missing its interactive login callback");
+
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			expect(url).toBe("https://api.neuralwatt.com/v1/quota");
+			expect(init?.method).toBe("GET");
+			expect(init?.headers).toEqual({ Authorization: "Bearer sk-neuralwatt-invalid" });
+			return new Response("Unauthorized", { status: 401 });
+		});
+
+		await expect(
+			login({
+				onAuth: () => {},
+				onPrompt: async () => " sk-neuralwatt-invalid ",
+				fetch: fetchMock,
+			}),
+		).rejects.toThrow("Neuralwatt API key validation failed (401)");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/ai/test/neuralwatt-usage.test.ts
+++ b/packages/ai/test/neuralwatt-usage.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from "bun:test";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { neuralwattUsageProvider } from "../src/usage/neuralwatt";
+
+function quotaPayload(subscription: Record<string, unknown> | null): Record<string, unknown> {
+	return { subscription };
+}
+
+const ACTIVE_SUBSCRIPTION: Record<string, unknown> = {
+	plan: "pro",
+	status: "active",
+	kwh_used: 120.5,
+	kwh_included: 500,
+	kwh_remaining: 379.5,
+	current_period_start: "2026-07-15T00:00:00Z",
+	kwh_reset_date: "2026-08-15T00:00:00Z",
+	in_overage: false,
+};
+
+function fakeFetch(payload: unknown, status = 200): FetchImpl {
+	const fn = async () =>
+		new Response(JSON.stringify(payload), {
+			status,
+			headers: { "content-type": "application/json" },
+		});
+	return fn as unknown as typeof fetch;
+}
+
+function fetchRecorder(calls: Array<{ url: string; authorization?: string }>, payload: unknown): FetchImpl {
+	const fn = async (input: string | URL | Request, init?: RequestInit) => {
+		calls.push({
+			url: String(input),
+			authorization: new Headers(init?.headers).get("Authorization") ?? undefined,
+		});
+		return new Response(JSON.stringify(payload), {
+			status: 200,
+			headers: { "content-type": "application/json" },
+		});
+	};
+	return fn as unknown as typeof fetch;
+}
+
+function fetchUsage(payload: unknown, status = 200) {
+	return neuralwattUsageProvider.fetchUsage(
+		{ provider: "neuralwatt", credential: { type: "api_key", apiKey: "nw-test-key" } },
+		{ fetch: fakeFetch(payload, status) },
+	);
+}
+
+describe("neuralwatt usage provider", () => {
+	it("normalizes the active subscription into a single kwh billing-period limit", async () => {
+		const report = await fetchUsage(quotaPayload(ACTIVE_SUBSCRIPTION));
+
+		expect(report).not.toBeNull();
+		expect(report?.provider).toBe("neuralwatt");
+		expect(report?.limits).toHaveLength(1);
+		const limit = report?.limits[0];
+		expect(limit?.id).toBe("neuralwatt:subscription");
+		expect(limit?.scope).toMatchObject({ provider: "neuralwatt", tier: "pro", windowId: "billing", shared: true });
+		expect(limit?.amount.used).toBe(120.5);
+		expect(limit?.amount.limit).toBe(500);
+		expect(limit?.amount.remaining).toBe(379.5);
+		expect(limit?.amount.usedFraction).toBeCloseTo(120.5 / 500, 10);
+		expect(limit?.amount.remainingFraction).toBeCloseTo(1 - 120.5 / 500, 10);
+		expect(limit?.amount.unit).toBe("kwh");
+		expect(limit?.status).toBe("ok");
+		expect(limit?.window?.id).toBe("billing");
+		expect(limit?.window?.resetsAt).toBe(Date.parse("2026-08-15T00:00:00Z"));
+		expect(limit?.window?.durationMs).toBe(31 * 24 * 60 * 60 * 1000);
+	});
+
+	it("prefers kwh_reset_date over current_period_end for the reset timestamp", async () => {
+		const report = await fetchUsage(
+			quotaPayload({ ...ACTIVE_SUBSCRIPTION, current_period_end: "2026-08-16T00:00:00Z" }),
+		);
+		const limit = report?.limits[0];
+		// The explicit kWh reset date wins when both fields are present.
+		expect(limit?.window?.resetsAt).toBe(Date.parse("2026-08-15T00:00:00Z"));
+
+		const fallback = await fetchUsage(
+			quotaPayload({ ...ACTIVE_SUBSCRIPTION, kwh_reset_date: null, current_period_end: "2026-08-16T00:00:00Z" }),
+		);
+		expect(fallback?.limits[0]?.window?.resetsAt).toBe(Date.parse("2026-08-16T00:00:00Z"));
+	});
+
+	it("derives absolute and fractional usage from remaining when kwh_used is absent", async () => {
+		const report = await fetchUsage(
+			quotaPayload({ plan: "pro", kwh_included: 500, kwh_remaining: 100, kwh_reset_date: "2026-08-15T00:00:00Z" }),
+		);
+		const limit = report?.limits[0];
+		expect(limit?.amount.used).toBe(400);
+		expect(limit?.amount.usedFraction).toBeCloseTo(0.8, 10);
+		expect(limit?.amount.remainingFraction).toBeCloseTo(0.2, 10);
+	});
+
+	it("keeps the account usable while in_overage: subscription warns and credit plus overage limits surface", async () => {
+		// in_overage marks the included kWh as spent, but the account keeps
+		// working off credits and overage capacity — routing must not treat the
+		// subscription as blocked before the overage cap is hit.
+		const report = await fetchUsage({
+			subscription: { ...ACTIVE_SUBSCRIPTION, in_overage: true },
+			balance: { credits_used_usd: 2.5, total_credits_usd: 10, credits_remaining_usd: 7.5 },
+		});
+
+		expect(report).not.toBeNull();
+		expect(report?.limits.map(limit => limit.id)).toEqual([
+			"neuralwatt:subscription",
+			"neuralwatt:credits",
+			"neuralwatt:overage",
+		]);
+
+		const subscription = report?.limits[0];
+		expect(subscription?.status).toBe("warning");
+		expect(subscription?.notes?.some(note => /overage/i.test(note))).toBe(true);
+
+		const credits = report?.limits[1];
+		expect(credits?.label).toBe("Credit Balance");
+		expect(credits?.amount.limit).toBe(10);
+		expect(credits?.amount.remaining).toBe(7.5);
+		// Still 75% remaining: usable, not exhausted.
+		expect(credits?.status).toBe("ok");
+
+		const overage = report?.limits[2];
+		expect(overage?.label).toBe("Overage Capacity");
+		// No overage_limit_usd reported → the documented $100 default applies,
+		// and the positive credit balance means none of it is spent yet.
+		expect(overage?.amount.used).toBe(0);
+		expect(overage?.amount.limit).toBe(100);
+		expect(overage?.amount.remaining).toBe(100);
+		expect(overage?.status).toBe("warning");
+
+		// An explicit `null` cap resolves to the same $100 default as a missing one.
+		const nullCap = await fetchUsage({
+			subscription: { ...ACTIVE_SUBSCRIPTION, in_overage: true },
+			balance: { credits_used_usd: 0, total_credits_usd: 0, credits_remaining_usd: -10 },
+			limits: { overage_limit_usd: null },
+		});
+		const nullCapOverage = nullCap?.limits.find(limit => limit.id === "neuralwatt:overage");
+		expect(nullCapOverage?.amount.limit).toBe(100);
+		expect(nullCapOverage?.amount.remaining).toBe(90);
+	});
+
+	it("does not infer subscription overage from an exhausted kWh balance", async () => {
+		const { in_overage: _inOverage, ...exhaustedSubscription } = ACTIVE_SUBSCRIPTION;
+		const balance = { credits_used_usd: 2.5, total_credits_usd: 10, credits_remaining_usd: 7.5 };
+		for (const subscription of [exhaustedSubscription, { ...exhaustedSubscription, in_overage: false }]) {
+			const report = await fetchUsage({
+				subscription: { ...subscription, kwh_used: 500, kwh_remaining: 0 },
+				balance,
+			});
+			expect(report?.limits.map(limit => limit.id)).toEqual(["neuralwatt:subscription"]);
+		}
+	});
+
+	it("uses the reported limits.overage_limit_usd as the overage cap instead of the $100 default", async () => {
+		const report = await fetchUsage({
+			subscription: { ...ACTIVE_SUBSCRIPTION, in_overage: true },
+			balance: { credits_used_usd: 0, total_credits_usd: 0, credits_remaining_usd: -30 },
+			limits: { overage_limit_usd: 50 },
+		});
+
+		const overage = report?.limits.find(limit => limit.id === "neuralwatt:overage");
+		// $30 of negative balance against a custom $50 cap.
+		expect(overage?.amount.used).toBe(30);
+		expect(overage?.amount.limit).toBe(50);
+		expect(overage?.amount.remaining).toBe(20);
+		// Cap not yet reached: warning keeps the account routed, not exhausted.
+		expect(overage?.status).toBe("warning");
+	});
+
+	it("exhausts overage only when the negative balance reaches the cap", async () => {
+		const report = await fetchUsage({
+			subscription: { ...ACTIVE_SUBSCRIPTION, in_overage: true },
+			balance: { credits_used_usd: 0, total_credits_usd: 0, credits_remaining_usd: -100 },
+		});
+
+		const overage = report?.limits.find(limit => limit.id === "neuralwatt:overage");
+		expect(overage?.amount.used).toBe(100);
+		expect(overage?.amount.limit).toBe(100);
+		expect(overage?.amount.remaining).toBe(0);
+		expect(overage?.status).toBe("exhausted");
+	});
+
+	it("requests <baseUrl>/quota with a Bearer Authorization header", async () => {
+		const calls: Array<{ url: string; authorization?: string }> = [];
+		await neuralwattUsageProvider.fetchUsage(
+			{ provider: "neuralwatt", credential: { type: "api_key", apiKey: "nw-test-key" } },
+			{ fetch: fetchRecorder(calls, quotaPayload(ACTIVE_SUBSCRIPTION)) },
+		);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe("https://api.neuralwatt.com/v1/quota");
+		expect(calls[0]?.authorization).toBe("Bearer nw-test-key");
+
+		const custom: Array<{ url: string; authorization?: string }> = [];
+		await neuralwattUsageProvider.fetchUsage(
+			{
+				provider: "neuralwatt",
+				credential: { type: "api_key", apiKey: "nw-test-key" },
+				baseUrl: "https://neuralwatt.internal:8443/v1/",
+			},
+			{ fetch: fetchRecorder(custom, quotaPayload(ACTIVE_SUBSCRIPTION)) },
+		);
+		expect(custom[0]?.url).toBe("https://neuralwatt.internal:8443/v1/quota");
+	});
+
+	it("supports only api-key credentials for the neuralwatt provider", () => {
+		expect(
+			neuralwattUsageProvider.supports?.({
+				provider: "neuralwatt",
+				credential: { type: "api_key", apiKey: "nw-test-key" },
+			}),
+		).toBe(true);
+		expect(
+			neuralwattUsageProvider.supports?.({ provider: "zai", credential: { type: "api_key", apiKey: "x" } }),
+		).toBe(false);
+		expect(
+			neuralwattUsageProvider.supports?.({
+				provider: "neuralwatt",
+				credential: { type: "oauth", accessToken: "x" },
+			}),
+		).toBe(false);
+		expect(neuralwattUsageProvider.supports?.({ provider: "neuralwatt", credential: { type: "api_key" } })).toBe(
+			false,
+		);
+	});
+
+	it("returns null without contacting the endpoint for the wrong provider or credential type", async () => {
+		let called = 0;
+		const countingFetch: FetchImpl = (async () => {
+			called += 1;
+			return new Response("{}", { status: 200 });
+		}) as unknown as typeof fetch;
+		const wrongProvider = await neuralwattUsageProvider.fetchUsage(
+			{ provider: "zai", credential: { type: "api_key", apiKey: "nw-test-key" } },
+			{ fetch: countingFetch },
+		);
+		const wrongCredential = await neuralwattUsageProvider.fetchUsage(
+			{ provider: "neuralwatt", credential: { type: "oauth", accessToken: "tok" } },
+			{ fetch: countingFetch },
+		);
+		expect(wrongProvider).toBeNull();
+		expect(wrongCredential).toBeNull();
+		expect(called).toBe(0);
+	});
+
+	it("throws on a 401 auth failure so checkCredentials flags the bad key", async () => {
+		await expect(fetchUsage({ message: "invalid api key" }, 401)).rejects.toThrow(/401/);
+	});
+
+	it("throws on a 403 auth failure so checkCredentials flags the bad key", async () => {
+		await expect(fetchUsage({ message: "forbidden" }, 403)).rejects.toThrow(/403/);
+	});
+
+	it("returns null on a transient non-auth HTTP failure (500)", async () => {
+		expect(await fetchUsage({ message: "internal server error" }, 500)).toBeNull();
+	});
+
+	it("returns null when the payload is malformed or carries no subscription", async () => {
+		expect(await fetchUsage("not-an-object")).toBeNull();
+		expect(await fetchUsage(quotaPayload(null))).toBeNull();
+		expect(await fetchUsage(quotaPayload({ status: "none" }))).toBeNull();
+	});
+
+	it("returns null when no subscription, balance, or key allowance is surfaceable", async () => {
+		// A balance/key present but carrying no usable numbers yields no limits.
+		expect(await fetchUsage({ subscription: null, balance: {} })).toBeNull();
+		expect(await fetchUsage({ subscription: null, key: { name: "x" } })).toBeNull();
+		expect(await fetchUsage({ subscription: null, key: { allowance: {} } })).toBeNull();
+		expect(await fetchUsage({ subscription: null, balance: {}, key: {} })).toBeNull();
+	});
+
+	it("returns null when the fetch itself fails (network error)", async () => {
+		const failingFetch: FetchImpl = (async () => {
+			throw new TypeError("fetch failed");
+		}) as unknown as typeof fetch;
+		const report = await neuralwattUsageProvider.fetchUsage(
+			{ provider: "neuralwatt", credential: { type: "api_key", apiKey: "nw-test-key" } },
+			{ fetch: failingFetch },
+		);
+		expect(report).toBeNull();
+	});
+
+	describe("PAYG balance and per-key allowance", () => {
+		it("normalizes a documented PAYG balance into a shared USD credits limit", async () => {
+			const report = await fetchUsage({
+				subscription: null,
+				balance: {
+					credits_used_usd: 12.34,
+					total_credits_usd: 50,
+					credits_remaining_usd: 37.66,
+				},
+			});
+
+			expect(report).not.toBeNull();
+			expect(report?.limits).toHaveLength(1);
+			const limit = report?.limits[0];
+			expect(limit?.id).toBe("neuralwatt:credits");
+			expect(limit?.label).toBe("PAYG Credits");
+			expect(limit?.scope).toMatchObject({ provider: "neuralwatt", shared: true });
+			expect(limit?.amount.used).toBe(12.34);
+			expect(limit?.amount.limit).toBe(50);
+			expect(limit?.amount.remaining).toBe(37.66);
+			expect(limit?.amount.unit).toBe("usd");
+			expect(limit?.amount.usedFraction).toBeCloseTo(12.34 / 50, 10);
+			expect(limit?.amount.remainingFraction).toBeCloseTo(1 - 12.34 / 50, 10);
+			expect(limit?.status).toBe("ok");
+		});
+
+		it("marks a depleted PAYG balance exhausted when remaining credit reaches zero", async () => {
+			const report = await fetchUsage({
+				subscription: null,
+				balance: { credits_used_usd: 50, total_credits_usd: 50, credits_remaining_usd: 0 },
+			});
+			const limit = report?.limits[0];
+			expect(limit?.id).toBe("neuralwatt:credits");
+			expect(limit?.amount.remaining).toBe(0);
+			// remaining of 0 is exhausted even though the fraction math would also say so.
+			expect(limit?.status).toBe("exhausted");
+		});
+
+		it("normalizes a per-key allowance with its reported period window", async () => {
+			const report = await fetchUsage({
+				subscription: null,
+				key: {
+					name: "ci-deploy",
+					allowance: {
+						spent_usd: 3.5,
+						limit_usd: 10,
+						remaining_usd: 6.5,
+						period: "daily",
+					},
+				},
+			});
+
+			expect(report?.limits).toHaveLength(1);
+			const limit = report?.limits[0];
+			expect(limit?.id).toBe("neuralwatt:key-allowance");
+			expect(limit?.label).toBe("API Key Allowance");
+			expect(limit?.scope).toMatchObject({ provider: "neuralwatt", windowId: "daily", shared: true });
+			expect(limit?.window).toMatchObject({ id: "daily", label: "Daily" });
+			expect(limit?.amount.used).toBe(3.5);
+			expect(limit?.amount.limit).toBe(10);
+			expect(limit?.amount.remaining).toBe(6.5);
+			expect(limit?.amount.unit).toBe("usd");
+			expect(limit?.status).toBe("ok");
+			// Key metadata is surfaced on the report.
+			expect(report?.metadata?.keyName).toBe("ci-deploy");
+		});
+
+		it("marks a blocked key allowance exhausted even when spend is below the limit", async () => {
+			const report = await fetchUsage({
+				subscription: null,
+				key: {
+					allowance: { spent_usd: 1, limit_usd: 100, remaining_usd: 99, period: "monthly", blocked: true },
+				},
+			});
+			const limit = report?.limits[0];
+			expect(limit?.id).toBe("neuralwatt:key-allowance");
+			// 1% used is still exhausted once the key is blocked.
+			expect(limit?.status).toBe("exhausted");
+			expect(limit?.notes?.some(note => /blocked/i.test(note))).toBe(true);
+		});
+
+		it("treats an unblocked key as warning, not exhausted, when the allowance remainder hits zero", async () => {
+			// `blocked: true` is the only exhaustion signal for a key allowance. A
+			// zero remainder without it means spend is at the cap but the key still
+			// works — flagging it exhausted would route traffic away from a usable
+			// credential.
+			const report = await fetchUsage({
+				subscription: null,
+				key: { allowance: { spent_usd: 10, limit_usd: 10, remaining_usd: 0, period: "daily", blocked: false } },
+			});
+			const limit = report?.limits[0];
+			expect(limit?.id).toBe("neuralwatt:key-allowance");
+			expect(limit?.status).toBe("warning");
+		});
+
+		it("keeps the kWh subscription limit and drops the separate credit pool while retaining the key allowance", async () => {
+			const report = await fetchUsage({
+				subscription: ACTIVE_SUBSCRIPTION,
+				balance: { credits_used_usd: 5, total_credits_usd: 25, credits_remaining_usd: 20 },
+				key: { allowance: { spent_usd: 1, limit_usd: 10, remaining_usd: 9, period: "daily" } },
+			});
+
+			// Subscription is present, so the PAYG credit pool must NOT appear as a peer.
+			expect(report?.limits).toHaveLength(2);
+			const ids = report?.limits.map(l => l.id);
+			expect(ids).toContain("neuralwatt:subscription");
+			expect(ids).toContain("neuralwatt:key-allowance");
+			expect(ids).not.toContain("neuralwatt:credits");
+			// The subscription limit is still the kWh one.
+			const sub = report?.limits.find(l => l.id === "neuralwatt:subscription");
+			expect(sub?.amount.unit).toBe("kwh");
+		});
+	});
+});

--- a/packages/ai/test/openai-completions-disable-reasoning.test.ts
+++ b/packages/ai/test/openai-completions-disable-reasoning.test.ts
@@ -225,6 +225,50 @@ describe("OpenAI completions disableReasoning and thinking dialects", () => {
 		expect(payload.chat_template_kwargs).toBeUndefined();
 	});
 
+	it("preserves the native-on default for the bundled Neuralwatt no-effort Qwen model when reasoning is not requested", async () => {
+		// Neuralwatt's `qwen3.6-35b` thinks natively and its base disable mode
+		// is `qwen-template-false` — an implicit "off" here would send
+		// `chat_template_kwargs.enable_thinking: false` on every ordinary
+		// request, silently disabling the provider default. An ordinary request
+		// (no effort, no `disableReasoning`) must instead leave every thinking
+		// switch off the wire.
+		const model = getBundledModel<"openai-completions">("neuralwatt", "qwen3.6-35b");
+
+		// Pin the premise so a catalog/discovery regression points at the model
+		// row rather than surfacing as a bare wire-field diff.
+		expect(model.reasoning).toBe(true);
+		expect(model.thinking).toBeUndefined();
+		expect(model.compat.supportsReasoningEffort).toBe(false);
+		expect(model.compat.thinkingFormat).toBe("openai");
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(model, testContext, {
+			apiKey: "test-key",
+			fetch: createMockFetchForQwen(resolve),
+			// no reasoning requested — the provider's native-on default applies
+		});
+		const payload = (await promise) as Record<string, unknown>;
+		expect(payload.enable_thinking).toBeUndefined();
+		expect(payload.chat_template_kwargs).toBeUndefined();
+		expect(payload.reasoning_effort).toBeUndefined();
+		expect(payload.reasoning).toBeUndefined();
+	});
+
+	it("encodes explicit disableReasoning as chat_template_kwargs.enable_thinking: false for the bundled Neuralwatt no-effort model", async () => {
+		// `qwen3.6-35b` reports `reasoning_effort: false`, so there is no
+		// lowest effort to fall back on: Neuralwatt's documented off switch is
+		// the chat-template flag. A `lowest-effort` encoding here would crash
+		// on the empty ladder; silently dropping the caller's off switch would
+		// leave the route thinking.
+		const model = getBundledModel<"openai-completions">("neuralwatt", "qwen3.6-35b");
+
+		const payload = await captureDisableReasoningPayload(model);
+		expect(payload.chat_template_kwargs).toEqual({ enable_thinking: false });
+		expect(payload.enable_thinking).toBeUndefined();
+		expect(payload.reasoning_effort).toBeUndefined();
+		expect(payload.reasoning).toBeUndefined();
+	});
+
 	it("sets Z.AI thinking format and toggles type logically based on forced tool choice", async () => {
 		const model = buildModel({
 			id: "zai-reasoner",

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a Neuralwatt provider (`NEURALWATT_API_KEY`, `https://api.neuralwatt.com/v1`) with API-key authentication and credential-scoped runtime discovery from `/v1/models`; bundled catalog generation always uses the public unauthenticated snapshot. Discovery preserves pricing, vision/reasoning/tool capabilities, context and output limits, deprecated-model filtering, and the provider's exact non-`none` reasoning-effort ladder, default, and optional-thinking state—even for fast routes whose reasoning defaults off—while `none`-only routes expose no inert effort selector. Kimi K2.7 Code uses its documented 32K output ceiling while other explicitly uncapped families stay unknown. Missing prices fall back only to a provider-scoped exact-ID bundled reference; models with unresolved or explicitly TBD pricing are omitted rather than mislabeled Free.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -120,7 +120,9 @@ type CatalogProviderFetchResult = { models: ModelSpec[]; succeeded: boolean };
 async function fetchProviderModelsFromCatalog(
 	descriptor: CatalogProviderDescriptor,
 ): Promise<CatalogProviderFetchResult> {
-	const apiKey = await resolveProviderApiKey(descriptor.providerId, descriptor.catalogDiscovery);
+	const apiKey = descriptor.catalogDiscovery.forceUnauthenticated
+		? undefined
+		: await resolveProviderApiKey(descriptor.providerId, descriptor.catalogDiscovery);
 
 	if (!apiKey && !allowsUnauthenticatedCatalogDiscovery(descriptor)) {
 		console.log(`No ${descriptor.catalogDiscovery.label} credentials found (env or agent.db), using fallback models`);
@@ -208,7 +210,8 @@ function applyGlobalModelsDevFallback(
 		if (
 			providerScopedKeys.has(`${model.provider}/${model.id}`) ||
 			model.provider === "devin" ||
-			model.provider === "baseten"
+			model.provider === "baseten" ||
+			model.provider === "neuralwatt"
 		) {
 			return model;
 		}

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -179,6 +179,7 @@ export function rebakeModelThinking(model: ModelSpec<Api>): void {
 	) {
 		return;
 	}
+	if (model.provider === "neuralwatt" && model.thinking) return;
 	const requiresProviderAuthoredEffort =
 		model.provider === "umans" && (model.thinking?.requiresEffort === true || model.id === "umans-kimi-k2.7");
 	const thinking = resolveModelThinking({ ...model, thinking: undefined }, buildCompat(model));
@@ -288,7 +289,13 @@ export function applyCanonicalLimitFallback(models: ModelSpec<Api>[]): void {
 			if (model.contextWindow === null && reference.contextWindow !== null) {
 				model.contextWindow = reference.contextWindow;
 			}
-			if (model.maxTokens === null && reference.maxTokens !== null) {
+			// Neuralwatt reports real context windows but `null` output limits for
+			// its uncapped models; backfilling those from a family reference would
+			// invent an arbitrary cap (identical uncapped models resolved to
+			// 128K/131K/256K depending on which reseller won the index), so leave
+			// them unknown. Kimi K2.7 Code's 32K recommended ceiling is already set
+			// by its mapper.
+			if (model.provider !== "neuralwatt" && model.maxTokens === null && reference.maxTokens !== null) {
 				model.maxTokens = reference.maxTokens;
 			}
 			if (model.contextWindow !== null && model.maxTokens !== null) {

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -465,7 +465,7 @@ function retainModelIds<TApi extends Api>(
  * arms calling `resolveProviderModels` with the same `staticModels` array)
  * skip the JSON+hash work after the first call.
  */
-const MODEL_CACHE_FINGERPRINT_VERSION = "merge-v3";
+const MODEL_CACHE_FINGERPRINT_VERSION = "merge-v5";
 const kStaticFingerprint = Symbol("model-manager.staticFingerprint");
 type ModelArrayWithFingerprint = readonly Model<Api>[] & { [kStaticFingerprint]?: string };
 function fingerprintStatic<TApi extends Api>(
@@ -486,27 +486,28 @@ function fingerprintStatic<TApi extends Api>(
 }
 
 function mergeDynamicModel<TApi extends Api>(existingModel: Model<TApi>, dynamicModel: Model<TApi>): Model<TApi> {
-	// When discovery resolves the same model id to a different endpoint (e.g.
-	// a GitHub Copilot business/enterprise host), the bundled reference's
-	// capabilities are pinned to another endpoint and no longer apply. Copilot
-	// dynamic discovery also pre-applies the correct image fallback for omitted
-	// `supports.vision`, so its explicit `false` must not be OR-upgraded by the
-	// canonical bundled model.
+	// A different endpoint invalidates the bundled reference's capability flags.
+	// Copilot and Neuralwatt mappers resolve omitted live capabilities against
+	// their own provider references before this merge, so their mapped fields
+	// are authoritative for matching rows.
 	const endpointChanged = existingModel.baseUrl !== dynamicModel.baseUrl;
+	const neuralwattDiscoveryAuthoritative =
+		existingModel.provider === "neuralwatt" && dynamicModel.provider === "neuralwatt";
 	const dynamicInputAuthoritative =
-		endpointChanged || (existingModel.provider === "github-copilot" && dynamicModel.provider === "github-copilot");
+		endpointChanged ||
+		neuralwattDiscoveryAuthoritative ||
+		(existingModel.provider === "github-copilot" && dynamicModel.provider === "github-copilot");
 	const supportsImage = dynamicInputAuthoritative
 		? dynamicModel.input.includes("image")
 		: existingModel.input.includes("image") || dynamicModel.input.includes("image");
-	// Synthetic's discovery is authoritative (`dynamicModelsAuthoritative`) and
-	// its per-model `reasoning_parameters.efforts` vocabulary is the route's
-	// whole truth: when the wire advertises only the `none` off-state the
-	// mapper emits `reasoning: false`, and OR-ing the bundled reference's
-	// stale `reasoning: true` back would re-arm an effort dial the route
-	// doesn't expose. Other providers keep the OR so a bundled reasoning flag
-	// survives a discovery row that simply omits the capability.
+	// Synthetic's per-model `reasoning_parameters.efforts` vocabulary is the
+	// route's whole truth: when it advertises only the `none` off-state, the
+	// mapper emits `reasoning: false`. Neuralwatt's mapper likewise resolves the
+	// live capability before this merge. Do not OR either provider's stale
+	// bundled `true` back into the resolved model.
 	const dynamicReasoningAuthoritative =
-		existingModel.provider === "synthetic" && dynamicModel.provider === "synthetic";
+		neuralwattDiscoveryAuthoritative ||
+		(existingModel.provider === "synthetic" && dynamicModel.provider === "synthetic");
 	const reasoning = dynamicReasoningAuthoritative
 		? dynamicModel.reasoning
 		: existingModel.reasoning || dynamicModel.reasoning;
@@ -518,14 +519,18 @@ function mergeDynamicModel<TApi extends Api>(existingModel: Model<TApi>, dynamic
 		name: preferDiscoveryName(dynamicModel.name, existingModel.name, dynamicModel.id),
 		reasoning,
 		input: supportsImage ? ["text", "image"] : ["text"],
-		cost: {
-			input: preferDiscoveryCost(dynamicModel.cost.input, existingModel.cost.input),
-			output: preferDiscoveryCost(dynamicModel.cost.output, existingModel.cost.output),
-			cacheRead: preferDiscoveryCost(dynamicModel.cost.cacheRead, existingModel.cost.cacheRead),
-			cacheWrite: preferDiscoveryCost(dynamicModel.cost.cacheWrite, existingModel.cost.cacheWrite),
-		},
+		cost: neuralwattDiscoveryAuthoritative
+			? dynamicModel.cost
+			: {
+					input: preferDiscoveryCost(dynamicModel.cost.input, existingModel.cost.input),
+					output: preferDiscoveryCost(dynamicModel.cost.output, existingModel.cost.output),
+					cacheRead: preferDiscoveryCost(dynamicModel.cost.cacheRead, existingModel.cost.cacheRead),
+					cacheWrite: preferDiscoveryCost(dynamicModel.cost.cacheWrite, existingModel.cost.cacheWrite),
+				},
 		contextWindow: preferDiscoveryLimit(dynamicModel.contextWindow, existingModel.contextWindow),
-		maxTokens: preferDiscoveryLimit(dynamicModel.maxTokens, existingModel.maxTokens),
+		maxTokens: neuralwattDiscoveryAuthoritative
+			? dynamicModel.maxTokens
+			: preferDiscoveryLimit(dynamicModel.maxTokens, existingModel.maxTokens),
 		headers: dynamicModel.headers ? { ...existingModel.headers, ...dynamicModel.headers } : existingModel.headers,
 		compat: dynamicModel.compatConfig ?? existingModel.compatConfig,
 		contextPromotionTarget: dynamicModel.contextPromotionTarget ?? existingModel.contextPromotionTarget,

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -38,6 +38,7 @@ import type {
 	CompatOf,
 	Model,
 	ModelSpec,
+	OpenAICompat,
 	ResolvedDevinCompat,
 	ResolvedOpenAICompat,
 	ResolvedOpenAIResponsesCompat,
@@ -125,10 +126,10 @@ const MINIMAX_ANTHROPIC_ADAPTIVE_EFFORT_MAP: Readonly<EffortMap> = {
  * model by `buildModel`, after compat resolution.
  *
  * - Non-reasoning models never carry thinking.
- * - Models that reason natively but reject the wire effort param
- *   (`compat.supportsReasoningEffort: false` on openai-responses*) carry no
- *   thinking either: `reasoning: true, thinking: undefined` IS the encoding
- *   for "thinks, but exposes no control surface".
+ * - Models that reason natively but reject the wire effort param carry no
+ *   thinking either (`openai-responses*` compat, or Neuralwatt's live
+ *   `reasoning_effort: false`): `reasoning: true, thinking: undefined` encodes
+ *   "thinks, but exposes no control surface".
  * - Explicit spec thinking (generator-baked or user-authored) owns the
  *   capability surface (`mode`, `efforts`, `defaultLevel`); the wire facts
  *   (`effortMap`, `supportsDisplay`) are backfilled from identity when not
@@ -141,6 +142,11 @@ export function resolveModelThinking<TApi extends Api>(
 ): ThinkingConfig | undefined {
 	if (!spec.reasoning) return undefined;
 	if (omitsWireReasoningEffort(spec.api, compat)) return undefined;
+	// Neuralwatt's live `reasoning_effort: false` capability means the wire
+	// cannot honor any tier. It overrides stale bundled thinking metadata.
+	if (spec.provider === "neuralwatt" && (spec.compat as OpenAICompat | undefined)?.supportsReasoningEffort === false) {
+		return undefined;
+	}
 	if (spec.thinking && Array.isArray(spec.thinking.efforts) && spec.thinking.efforts.length > 0) {
 		return fillThinkingWireDefaults(spec, compat, spec.thinking);
 	}
@@ -166,7 +172,11 @@ function fillThinkingWireDefaults<TApi extends Api>(
 	thinking: ThinkingConfig,
 ): ThinkingConfig {
 	const parsed = parseKnownModel(spec.id);
-	const normalizedEfforts = getModelDefinedEfforts(spec, compat) ?? thinking.efforts;
+	// Neuralwatt's rich discovery metadata is the route's wire truth. Identity
+	// tables describe model families across hosts and may invent unsupported
+	// lower tiers for provider-specific fast/default-off routes.
+	const normalizedEfforts =
+		spec.provider === "neuralwatt" ? thinking.efforts : (getModelDefinedEfforts(spec, compat) ?? thinking.efforts);
 	const effortsChanged = !sameEffortList(normalizedEfforts, thinking.efforts);
 	const effortMap =
 		thinking.effortMap === undefined || effortsChanged
@@ -178,7 +188,8 @@ function fillThinkingWireDefaults<TApi extends Api>(
 		(spec.api === "anthropic-messages" || spec.api === "bedrock-converse-stream") &&
 		supportsAdaptiveThinkingDisplay(spec.id);
 	const needsRequiresEffort = thinking.requiresEffort === undefined && impliesMandatoryReasoning(parsed, spec.id);
-	const needsDefaultLevel = thinking.defaultLevel === undefined && isKimiK3ModelId(spec.id);
+	const needsDefaultLevel =
+		thinking.defaultLevel === undefined && spec.provider !== "neuralwatt" && isKimiK3ModelId(spec.id);
 	if (!effortsChanged && !shouldReplaceEffortMap && !needsDisplay && !needsRequiresEffort && !needsDefaultLevel) {
 		return thinking;
 	}

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -63312,6 +63312,617 @@
 			}
 		}
 	},
+	"neuralwatt": {
+		"deepseek-ai/DeepSeek-V4-Flash": {
+			"id": "deepseek-ai/DeepSeek-V4-Flash",
+			"name": "DeepSeek V4 Flash 0731 (Canary)",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.028,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048560,
+			"maxTokens": 65536,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				],
+				"requiresEffort": false
+			},
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"supportsReasoningEffort": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"whenThinking": {
+					"reasoningDisableMode": "lowest-effort"
+				}
+			}
+		},
+		"deepseek-v4-flash": {
+			"id": "deepseek-v4-flash",
+			"name": "DeepSeek V4 Flash",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.028,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048560,
+			"maxTokens": 65536,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				],
+				"requiresEffort": false
+			},
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"supportsReasoningEffort": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"whenThinking": {
+					"reasoningDisableMode": "lowest-effort"
+				}
+			}
+		},
+		"deepseek-v4-flash-flex": {
+			"id": "deepseek-v4-flash-flex",
+			"name": "DeepSeek V4 Flash (flex)",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.028,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048560,
+			"maxTokens": 65536,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				],
+				"requiresEffort": false
+			},
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"supportsReasoningEffort": true,
+				"whenThinking": {
+					"reasoningDisableMode": "lowest-effort"
+				}
+			}
+		},
+		"gemma-4-31b": {
+			"id": "gemma-4-31b",
+			"name": "Gemma 4 31B",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.144,
+				"output": 0.42,
+				"cacheRead": 0.0144,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262128,
+			"maxTokens": 16384,
+			"supportsTools": true,
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
+		},
+		"glm-5.2": {
+			"id": "glm-5.2",
+			"name": "GLM-5.2",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.45,
+				"output": 4.5,
+				"cacheRead": 0.145,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048560,
+			"maxTokens": null,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				],
+				"requiresEffort": false,
+				"defaultLevel": "max"
+			},
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"supportsReasoningEffort": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"whenThinking": {
+					"reasoningDisableMode": "lowest-effort"
+				}
+			}
+		},
+		"glm-5.2-fast": {
+			"id": "glm-5.2-fast",
+			"name": "GLM-5.2 (fast)",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.45,
+				"output": 4.5,
+				"cacheRead": 0.145,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048560,
+			"maxTokens": null,
+			"supportsTools": true,
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				],
+				"requiresEffort": false
+			},
+			"compat": {
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"supportsReasoningEffort": true,
+				"whenThinking": {
+					"reasoningDisableMode": "lowest-effort"
+				}
+			}
+		},
+		"glm-5.2-flex": {
+			"id": "glm-5.2-flex",
+			"name": "GLM-5.2 (flex)",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.45,
+				"output": 4.5,
+				"cacheRead": 0.145,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048560,
+			"maxTokens": null,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				],
+				"requiresEffort": false,
+				"defaultLevel": "max"
+			},
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"supportsReasoningEffort": true,
+				"whenThinking": {
+					"reasoningDisableMode": "lowest-effort"
+				}
+			}
+		},
+		"glm-5.2-short": {
+			"id": "glm-5.2-short",
+			"name": "GLM-5.2 (short)",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.45,
+				"output": 4.5,
+				"cacheRead": 0.145,
+				"cacheWrite": 0
+			},
+			"contextWindow": 199984,
+			"maxTokens": 32000,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				],
+				"requiresEffort": false,
+				"defaultLevel": "high"
+			},
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"supportsReasoningEffort": true,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"whenThinking": {
+					"reasoningDisableMode": "lowest-effort"
+				}
+			}
+		},
+		"glm-5.2-short-fast": {
+			"id": "glm-5.2-short-fast",
+			"name": "GLM-5.2 (short, fast)",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.45,
+				"output": 4.5,
+				"cacheRead": 0.145,
+				"cacheWrite": 0
+			},
+			"contextWindow": 199984,
+			"maxTokens": 32000,
+			"supportsTools": true,
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				],
+				"requiresEffort": false
+			},
+			"compat": {
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"supportsReasoningEffort": true,
+				"whenThinking": {
+					"reasoningDisableMode": "lowest-effort"
+				}
+			}
+		},
+		"glm-5.2-short-fast-flex": {
+			"id": "glm-5.2-short-fast-flex",
+			"name": "GLM-5.2 (short, fast, flex)",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.45,
+				"output": 4.5,
+				"cacheRead": 0.145,
+				"cacheWrite": 0
+			},
+			"contextWindow": 199984,
+			"maxTokens": 32000,
+			"supportsTools": true,
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				],
+				"requiresEffort": false
+			},
+			"compat": {
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"supportsReasoningEffort": true,
+				"whenThinking": {
+					"reasoningDisableMode": "lowest-effort"
+				}
+			}
+		},
+		"glm-5.2-short-flex": {
+			"id": "glm-5.2-short-flex",
+			"name": "GLM-5.2 (short, flex)",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.45,
+				"output": 4.5,
+				"cacheRead": 0.145,
+				"cacheWrite": 0
+			},
+			"contextWindow": 199984,
+			"maxTokens": 32000,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				],
+				"requiresEffort": false,
+				"defaultLevel": "high"
+			},
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"supportsReasoningEffort": true,
+				"whenThinking": {
+					"reasoningDisableMode": "lowest-effort"
+				}
+			}
+		},
+		"kimi-k2.7-code": {
+			"id": "kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.095,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262128,
+			"maxTokens": 32768,
+			"supportsTools": true,
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"supportsReasoningEffort": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false"
+			}
+		},
+		"kimi-k2.7-code-fast": {
+			"id": "kimi-k2.7-code-fast",
+			"name": "Kimi K2.7 Code Fast",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.095,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262128,
+			"maxTokens": 32768,
+			"supportsTools": true,
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"supportsReasoningEffort": false
+			}
+		},
+		"kimi-k2.7-code-flex": {
+			"id": "kimi-k2.7-code-flex",
+			"name": "Kimi K2.7 Code (flex)",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.095,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262128,
+			"maxTokens": 32768,
+			"supportsTools": true,
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"supportsReasoningEffort": false
+			}
+		},
+		"kimi-k3": {
+			"id": "kimi-k3",
+			"name": "Kimi K3",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048560,
+			"maxTokens": null,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"requiresEffort": false,
+				"defaultLevel": "max",
+				"effortMap": {
+					"max": "max"
+				}
+			},
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false",
+				"supportsReasoningEffort": true,
+				"whenThinking": {
+					"reasoningDisableMode": "lowest-effort"
+				}
+			}
+		},
+		"kimi-k3-fast": {
+			"id": "kimi-k3-fast",
+			"name": "Kimi K3 Fast",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048560,
+			"maxTokens": null,
+			"supportsTools": true,
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
+		},
+		"qwen3.6-35b": {
+			"id": "qwen3.6-35b",
+			"name": "Qwen3.6 35B",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.29,
+				"output": 1.15,
+				"cacheRead": 0.029,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131056,
+			"maxTokens": null,
+			"supportsTools": true,
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"supportsReasoningEffort": false,
+				"thinkingFormat": "openai",
+				"reasoningDisableMode": "qwen-template-false"
+			}
+		},
+		"qwen3.6-35b-fast": {
+			"id": "qwen3.6-35b-fast",
+			"name": "Qwen3.6 35B Fast",
+			"api": "openai-completions",
+			"provider": "neuralwatt",
+			"baseUrl": "https://api.neuralwatt.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.29,
+				"output": 1.15,
+				"cacheRead": 0.029,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131056,
+			"maxTokens": null,
+			"supportsTools": true,
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
+		}
+	},
 	"novita": {
 		"baichuan/baichuan-m2-32b": {
 			"id": "baichuan/baichuan-m2-32b",

--- a/packages/catalog/src/provider-models/cache-provider-id.ts
+++ b/packages/catalog/src/provider-models/cache-provider-id.ts
@@ -9,6 +9,8 @@ export function getDefaultModelDiscoveryBaseUrl(providerId: string): string | un
 			return "http://127.0.0.1:11434";
 		case "litellm":
 			return Bun.env.LITELLM_BASE_URL ?? "http://localhost:4000/v1";
+		case "neuralwatt":
+			return "https://api.neuralwatt.com/v1";
 		case "opencode-go":
 			return "https://opencode.ai/zen/go/v1";
 		case "opencode-zen":
@@ -47,6 +49,13 @@ export function resolveModelCacheProviderId(providerId: string, options: ModelCa
 		case "litellm": {
 			const baseUrl = options.baseUrl ?? getDefaultModelDiscoveryBaseUrl(providerId)!;
 			return `litellm:rich-v5:${Bun.hash(baseUrl).toString(36)}`;
+		}
+		case "neuralwatt": {
+			const baseUrl = options.baseUrl ?? getDefaultModelDiscoveryBaseUrl(providerId)!;
+			const trimmedBaseUrl = baseUrl.trim();
+			const discoveryBaseUrl = trimmedBaseUrl.endsWith("/") ? trimmedBaseUrl.slice(0, -1) : trimmedBaseUrl;
+			const scope = `${options.apiKey ?? ""}\u0000${discoveryBaseUrl}`;
+			return `neuralwatt:models-v1:${Bun.hash(scope).toString(36)}`;
 		}
 		case "opencode-go":
 		case "opencode-zen": {

--- a/packages/catalog/src/provider-models/descriptor-types.ts
+++ b/packages/catalog/src/provider-models/descriptor-types.ts
@@ -23,6 +23,8 @@ export interface CatalogDiscoveryConfig {
 	oauthProvider?: string;
 	/** When true, catalog discovery proceeds even without credentials. */
 	allowUnauthenticated?: boolean;
+	/** When true, catalog generation never loads or forwards credentials. Implies unauthenticated discovery. */
+	forceUnauthenticated?: boolean;
 }
 
 /** Unified provider descriptor used by both runtime discovery and catalog generation. */
@@ -49,7 +51,10 @@ export function isCatalogDescriptor(d: ProviderDescriptor): d is CatalogProvider
 
 /** Whether catalog discovery may run without provider credentials. */
 export function allowsUnauthenticatedCatalogDiscovery(descriptor: CatalogProviderDescriptor): boolean {
-	return descriptor.catalogDiscovery.allowUnauthenticated ?? descriptor.allowUnauthenticated ?? false;
+	return (
+		descriptor.catalogDiscovery.forceUnauthenticated === true ||
+		(descriptor.catalogDiscovery.allowUnauthenticated ?? descriptor.allowUnauthenticated ?? false)
+	);
 }
 
 /**

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -34,6 +34,7 @@ import {
 	mistralModelManagerOptions,
 	moonshotModelManagerOptions,
 	nanoGptModelManagerOptions,
+	neuralwattModelManagerOptions,
 	novitaModelManagerOptions,
 	nvidiaModelManagerOptions,
 	ollamaModelManagerOptions,
@@ -309,6 +310,15 @@ export const CATALOG_PROVIDERS = [
 		envVars: ["NANO_GPT_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => nanoGptModelManagerOptions(config),
 		catalogDiscovery: { label: "NanoGPT" },
+	},
+	{
+		id: "neuralwatt",
+		defaultModel: "kimi-k2.7-code",
+		envVars: ["NEURALWATT_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => neuralwattModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
+		allowUnauthenticated: true,
+		catalogDiscovery: { label: "Neuralwatt", forceUnauthenticated: true },
 	},
 	{
 		id: "nvidia",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1786,7 +1786,9 @@ export function clampFireworksKimiMaxTokens(modelId: string, candidate: number |
 export const KIMI_K27_CODE_RECOMMENDED_MAX_TOKENS = 32_768;
 
 export function isKimiK27CodeModelId(modelId: string): boolean {
-	return /(?:^|\/)kimi[-._]?k2(?:[._-]?|p)7[-._]?code(?:[-._]?highspeed)?$/i.test(modelId);
+	return /(?:^|\/)kimi[-._]?k2(?:[._-]?|p)7[-._]?code(?:[-._]?(?:fast(?:[-._]?flex)?|flex|highspeed))?$/i.test(
+		modelId,
+	);
 }
 
 export function clampKimiK27CodeMaxTokens(modelId: string, candidate: number): number;
@@ -3593,6 +3595,154 @@ export function basetenModelManagerOptions(
 			};
 		},
 	});
+}
+
+// ---------------------------------------------------------------------------
+// 14.6 Neuralwatt
+// ---------------------------------------------------------------------------
+
+function mapNeuralwattThinking(metadata: Record<string, unknown>): ThinkingConfig | undefined {
+	const reasoning = isRecord(metadata.reasoning) ? metadata.reasoning : undefined;
+	if (!reasoning) return undefined;
+	const supportedEfforts = reasoning.supported_efforts;
+	if (!Array.isArray(supportedEfforts)) return undefined;
+	const efforts = THINKING_EFFORTS.filter(effort => supportedEfforts.includes(effort));
+	if (efforts.length === 0) return undefined;
+	const defaultLevel =
+		typeof reasoning.default_effort === "string"
+			? THINKING_EFFORTS.find(effort => effort === reasoning.default_effort)
+			: undefined;
+	return {
+		mode: "effort",
+		efforts,
+		...(typeof reasoning.mandatory === "boolean" ? { requiresEffort: reasoning.mandatory } : {}),
+		...(defaultLevel !== undefined && efforts.includes(defaultLevel) ? { defaultLevel } : {}),
+	};
+}
+
+export interface NeuralwattModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+export function neuralwattModelManagerOptions(
+	config?: NeuralwattModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? getDefaultModelDiscoveryBaseUrl("neuralwatt")!;
+	const references = createBundledReferenceMap<"openai-completions">("neuralwatt");
+	return {
+		providerId: "neuralwatt",
+		cacheProviderId: resolveModelCacheProviderId("neuralwatt", { apiKey, baseUrl }),
+		dynamicModelsAuthoritative: true,
+		// `/v1/models` is public per Neuralwatt's docs (auth only adds private
+		// models), so discovery runs with or without an API key.
+		fetchDynamicModels: () =>
+			fetchOpenAICompatibleModels({
+				api: "openai-completions",
+				provider: "neuralwatt",
+				baseUrl,
+				apiKey,
+				mapModel: (entry, defaults) => {
+					const reference = references.get(defaults.id);
+					const model = mapWithBundledReference(entry, defaults, reference);
+					const raw = entry as Record<string, unknown> & {
+						max_model_len?: unknown;
+						metadata?: Record<string, unknown>;
+					};
+					const metadata = isRecord(raw.metadata) ? raw.metadata : {};
+					if (metadata.deprecated === true) {
+						return null;
+					}
+					const capabilities = isRecord(metadata.capabilities) ? metadata.capabilities : {};
+					const limits = isRecord(metadata.limits) ? metadata.limits : {};
+					const pricing = isRecord(metadata.pricing) ? metadata.pricing : {};
+
+					const thinking = mapNeuralwattThinking(metadata);
+					const declaredReasoning = toBoolean(capabilities.reasoning);
+					// `capabilities.reasoning` describes the route's default state.
+					// Non-`none` live efforts still expose a real opt-in dial.
+					const reasoning = thinking !== undefined || (declaredReasoning ?? model.reasoning);
+					const vision = toBoolean(capabilities.vision);
+					const contextWindow = toPositiveNumber(
+						limits.max_context_length ?? raw.max_model_len,
+						model.contextWindow,
+					);
+					// An explicit `null` means uncapped. A missing field instead
+					// falls back to the same-provider reference, except that Kimi
+					// K2.7 Code's route family has a documented 32K recommendation.
+					const maxTokens = Object.hasOwn(limits, "max_output_tokens")
+						? (toPositiveNumber(limits.max_output_tokens, null) ??
+							(isKimiK27CodeModelId(defaults.id) ? KIMI_K27_CODE_RECOMMENDED_MAX_TOKENS : null))
+						: toPositiveNumber(entry.max_completion_tokens, model.maxTokens);
+					const effortSupport = toBoolean(capabilities.reasoning_effort) ?? (thinking ? true : undefined);
+					// Neuralwatt controls reasoning with OpenAI's `reasoning_effort`,
+					// while its documented off switch is the chat-template flag.
+					// Effort-capable requests switch back to OpenAI's effort field.
+					const { whenThinking: referenceWhenThinking, ...baseCompat } = model.compat ?? {};
+					const compat: OpenAICompat | undefined = reasoning
+						? {
+								...baseCompat,
+								thinkingFormat: "openai",
+								reasoningDisableMode: "qwen-template-false",
+								...(effortSupport === true
+									? {
+											whenThinking: {
+												...referenceWhenThinking,
+												reasoningDisableMode: "lowest-effort",
+											},
+										}
+									: effortSupport === undefined && referenceWhenThinking !== undefined
+										? { whenThinking: referenceWhenThinking }
+										: {}),
+								...(effortSupport !== undefined ? { supportsReasoningEffort: effortSupport } : {}),
+							}
+						: model.compat;
+
+					// Strip the reference's potentially stale ladder, then replace it
+					// only with the live provider-declared surface.
+					const { thinking: _referenceThinking, ...modelWithoutThinking } = model;
+					// Missing prices may use an exact-ID reference from Neuralwatt's
+					// own bundle. Never borrow another provider's rates: hosting
+					// prices are provider-specific. A live TBD marker invalidates
+					// even that cached reference.
+					if (raw.pricing_tbd === true || metadata.pricing_tbd === true || pricing.pricing_tbd === true) {
+						return null;
+					}
+					const inputCost = toNumber(pricing.input_per_million) ?? reference?.cost.input;
+					const outputCost = toNumber(pricing.output_per_million) ?? reference?.cost.output;
+					const cacheReadCost = toNumber(pricing.cached_input_per_million) ?? reference?.cost.cacheRead ?? 0;
+					if (
+						inputCost === undefined ||
+						outputCost === undefined ||
+						inputCost < 0 ||
+						outputCost < 0 ||
+						cacheReadCost < 0
+					) {
+						return null;
+					}
+					return {
+						...modelWithoutThinking,
+						name: toModelName(metadata.display_name, model.name),
+						reasoning,
+						...(thinking ? { thinking } : {}),
+						input: vision === undefined ? model.input : vision ? ["text", "image"] : ["text"],
+						supportsTools: toBoolean(capabilities.tools) ?? model.supportsTools,
+						cost: {
+							input: inputCost,
+							output: outputCost,
+							cacheRead: cacheReadCost,
+							cacheWrite: 0,
+						},
+						contextWindow,
+						maxTokens,
+						compat,
+					};
+				},
+				fetch: config?.fetch,
+			}),
+	};
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import type { Api, ModelSpec, Provider } from "@oh-my-pi/pi-catalog/types";
 import {
@@ -183,6 +184,37 @@ describe("generated model policies", () => {
 				defaultLevel: Effort.XHigh,
 			},
 		]);
+	});
+
+	it("preserves Neuralwatt provider-authored effort ladders through generation and runtime build", () => {
+		const models = [
+			createSpec({
+				id: "kimi-k3",
+				api: "openai-completions",
+				provider: "neuralwatt",
+				thinking: {
+					mode: "effort",
+					efforts: [Effort.Low, Effort.High, Effort.Max],
+					defaultLevel: Effort.Max,
+					requiresEffort: false,
+				},
+			}),
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models[0]?.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.Low, Effort.High, Effort.Max],
+			defaultLevel: Effort.Max,
+			requiresEffort: false,
+		});
+		expect(buildModel(models[0]!).thinking).toMatchObject({
+			mode: "effort",
+			efforts: [Effort.Low, Effort.High, Effort.Max],
+			defaultLevel: Effort.Max,
+			requiresEffort: false,
+		});
 	});
 
 	it("pins zai glm-5.2 base id to 1M context", () => {

--- a/packages/catalog/test/neuralwatt-provider.test.ts
+++ b/packages/catalog/test/neuralwatt-provider.test.ts
@@ -1,0 +1,864 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { createModelManager } from "@oh-my-pi/pi-catalog/model-manager";
+import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
+import {
+	KIMI_K27_CODE_RECOMMENDED_MAX_TOKENS,
+	neuralwattModelManagerOptions,
+} from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
+
+describe("Neuralwatt provider discovery", () => {
+	test("registers runtime descriptor with unauthenticated public-endpoint discovery", () => {
+		const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === "neuralwatt");
+		expect(descriptor).toBeDefined();
+		// /v1/models is public, so the runtime must construct a manager without an
+		// API key: the entry-level flag is the only source for the resolved
+		// descriptor (a catalogDiscovery-only flag never reaches it).
+		expect(descriptor?.allowUnauthenticated).toBe(true);
+		expect(descriptor?.catalogDiscovery?.forceUnauthenticated).toBe(true);
+		expect(descriptor?.catalogDiscovery?.label).toBe("Neuralwatt");
+		expect(descriptor?.catalogDiscovery?.envVars).toContain("NEURALWATT_API_KEY");
+	});
+
+	test("discovers Neuralwatt models from the metadata envelope", async () => {
+		const calls: Array<{ url: string; authorization: string | null }> = [];
+		const fetchMock: FetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+			const headers = new Headers(init?.headers);
+			calls.push({
+				url: String(input),
+				authorization: headers.get("authorization"),
+			});
+			return new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{
+							id: "kimi-k2.7-code",
+							object: "model",
+							created: 0,
+							owned_by: "neuralwatt",
+							max_model_len: 262128,
+							metadata: {
+								display_name: "Kimi K2.7 Code",
+								pricing: {
+									input_per_million: 0.95,
+									output_per_million: 4,
+									cached_input_per_million: 0.16,
+									currency: "USD",
+								},
+								capabilities: {
+									tools: true,
+									vision: true,
+									reasoning: true,
+									reasoning_effort: false,
+								},
+								limits: {
+									max_context_length: 262128,
+									max_output_tokens: null,
+									max_images: 20,
+								},
+								deprecated: false,
+							},
+						},
+						{
+							id: "glm-5.2-short",
+							object: "model",
+							created: 0,
+							owned_by: "neuralwatt",
+							max_model_len: 199984,
+							metadata: {
+								display_name: "GLM-5.2 (short)",
+								pricing: {
+									input_per_million: 1.45,
+									output_per_million: 6.35,
+									currency: "USD",
+								},
+								capabilities: {
+									tools: true,
+									vision: false,
+									reasoning: true,
+									reasoning_effort: true,
+								},
+								limits: {
+									max_context_length: 199984,
+									max_output_tokens: 32000,
+									max_images: null,
+								},
+								deprecated: false,
+							},
+						},
+						{
+							id: "old-deprecated-model",
+							object: "model",
+							created: 0,
+							owned_by: "neuralwatt",
+							max_model_len: 8192,
+							metadata: {
+								display_name: "Old Model",
+								pricing: { input_per_million: 1, output_per_million: 2, currency: "USD" },
+								capabilities: { tools: true, vision: false, reasoning: false, reasoning_effort: false },
+								limits: { max_context_length: 8192, max_output_tokens: 4096 },
+								deprecated: true,
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		};
+
+		const options = neuralwattModelManagerOptions({ apiKey: "neuralwatt-test-key", fetch: fetchMock });
+		const models = (await options.fetchDynamicModels?.())?.map(spec => buildModel(spec));
+
+		expect(calls).toEqual([
+			{
+				url: "https://api.neuralwatt.com/v1/models",
+				authorization: "Bearer neuralwatt-test-key",
+			},
+		]);
+
+		// Deprecated entries are dropped.
+		expect(models?.some(model => model.id === "old-deprecated-model")).toBe(false);
+
+		const kimi = models?.find(model => model.id === "kimi-k2.7-code");
+		expect(kimi).toBeDefined();
+		expect(kimi).toMatchObject({
+			provider: "neuralwatt",
+			api: "openai-completions",
+			name: "Kimi K2.7 Code",
+			reasoning: true,
+			input: ["text", "image"],
+			contextWindow: 262128,
+			// `null` max_output_tokens means uncapped upstream; the bundled
+			// reference's recommended Kimi K2.7 Code ceiling (32768) wins over a
+			// flat low default.
+			maxTokens: 32768,
+			cost: {
+				input: 0.95,
+				output: 4,
+				cacheRead: 0.16,
+				cacheWrite: 0,
+			},
+		});
+		// reasoning_effort: false → the wire omits the param and no inert effort
+		// selector is exposed.
+		expect(kimi?.compat?.supportsReasoningEffort).toBe(false);
+		expect(kimi?.thinking).toBeUndefined();
+		// With no effort ladder there is no lowest effort to fall back on, so
+		// `disableReasoning` must take the documented chat-template off switch
+		// (`chat_template_kwargs.enable_thinking: false`). The effort-ladder
+		// `lowest-effort` override is reserved for effort-capable thinking
+		// routes and must not leak into this effort-less base compat.
+		expect(kimi?.compat?.reasoningDisableMode).toBe("qwen-template-false");
+		expect(kimi?.compat?.whenThinking?.reasoningDisableMode).toBeUndefined();
+
+		const glm = models?.find(model => model.id === "glm-5.2-short");
+		expect(glm).toBeDefined();
+		expect(glm).toMatchObject({
+			provider: "neuralwatt",
+			api: "openai-completions",
+			name: "GLM-5.2 (short)",
+			reasoning: true,
+			input: ["text"],
+			contextWindow: 199984,
+			maxTokens: 32000,
+			// `cached_input_per_million` absent → falls back to the bundled
+			// reference's cache-read price (never mislabeled as 0/Free).
+			cost: {
+				input: 1.45,
+				output: 6.35,
+				cacheRead: 0.145,
+				cacheWrite: 0,
+			},
+		});
+		// reasoning_effort: true alone (no `metadata.reasoning` block) is
+		// authoritative: the mapped compat installs the effort-encoding
+		// `lowest-effort` selector under `whenThinking` even without live
+		// effort metadata, while the base stays on the documented
+		// chat-template off switch (`qwen-template-false`) — never the other
+		// way around.
+		expect(glm?.thinking).toMatchObject({ mode: "effort" });
+		expect(glm?.compat?.supportsReasoningEffort).toBe(true);
+		expect(glm?.compat?.reasoningDisableMode).toBe("qwen-template-false");
+		expect(glm?.compat?.whenThinking?.reasoningDisableMode).toBe("lowest-effort");
+		// The capability-only route still exposes a real effort ladder: with
+		// no live `supported_efforts` vocabulary, build-time inference supplies
+		// the GLM-5.2 tiers so the requested effort has values to serialize.
+		expect(glm?.thinking?.efforts).toEqual([Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.Max]);
+	});
+
+	test("strips a stale reference whenThinking override when the live route rejects effort", async () => {
+		// The bundled `glm-5.2-short` reference carries a thinking ladder and a
+		// `whenThinking.reasoningDisableMode: "lowest-effort"` override. A live
+		// `reasoning_effort: false` declares the wire cannot honor any effort
+		// tier: the stale override must be dropped (thinking turns would
+		// otherwise serialize an effort the route rejects), the base compat
+		// keeps the chat-template off switch, and no ladder survives.
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{
+							id: "glm-5.2-short",
+							object: "model",
+							max_model_len: 199984,
+							metadata: {
+								display_name: "GLM-5.2 (short)",
+								pricing: {
+									input_per_million: 1.45,
+									output_per_million: 6.35,
+									currency: "USD",
+								},
+								capabilities: { tools: true, vision: false, reasoning: true, reasoning_effort: false },
+								limits: { max_context_length: 199984, max_output_tokens: 32000 },
+								deprecated: false,
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+
+		const models = await neuralwattModelManagerOptions({ apiKey: "k", fetch: fetchMock }).fetchDynamicModels?.();
+		const glm = models?.map(spec => buildModel(spec)).find(model => model.id === "glm-5.2-short");
+		expect(glm).toBeDefined();
+		expect(glm?.reasoning).toBe(true);
+		expect(glm?.thinking).toBeUndefined();
+		expect(glm?.compat?.supportsReasoningEffort).toBe(false);
+		expect(glm?.compat?.reasoningDisableMode).toBe("qwen-template-false");
+		expect(glm?.compat?.whenThinking).toBeUndefined();
+	});
+
+	test("uses the live Neuralwatt effort surface even when reasoning is off by default", async () => {
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{
+							id: "glm-5.2-fast",
+							object: "model",
+							max_model_len: 1048560,
+							metadata: {
+								display_name: "GLM-5.2 Fast",
+								pricing: { input_per_million: 1.45, output_per_million: 4.5 },
+								capabilities: { tools: true, vision: false, reasoning: false, reasoning_effort: true },
+								reasoning: {
+									mandatory: false,
+									default_enabled: false,
+									supported_efforts: ["max", "high", "none"],
+									default_effort: "none",
+								},
+								limits: { max_context_length: 1048560, max_output_tokens: null },
+								deprecated: false,
+							},
+						},
+						{
+							id: "kimi-k3",
+							object: "model",
+							max_model_len: 1048560,
+							metadata: {
+								display_name: "Kimi K3",
+								pricing: { input_per_million: 3, output_per_million: 15 },
+								capabilities: { tools: true, vision: false, reasoning: true, reasoning_effort: true },
+								reasoning: {
+									mandatory: false,
+									default_enabled: true,
+									supported_efforts: ["max", "high", "low", "none"],
+									default_effort: "max",
+								},
+								limits: { max_context_length: 1048560, max_output_tokens: null },
+								deprecated: false,
+							},
+						},
+						{
+							id: "kimi-k3-fast",
+							object: "model",
+							max_model_len: 1048560,
+							metadata: {
+								display_name: "Kimi K3 Fast",
+								pricing: { input_per_million: 0.95, output_per_million: 4 },
+								capabilities: { tools: true, vision: false, reasoning: false, reasoning_effort: true },
+								reasoning: {
+									mandatory: false,
+									default_enabled: false,
+									supported_efforts: ["none"],
+									default_effort: "none",
+								},
+								limits: { max_context_length: 1048560, max_output_tokens: null },
+								deprecated: false,
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+
+		const specs = await neuralwattModelManagerOptions({ apiKey: "k", fetch: fetchMock }).fetchDynamicModels?.();
+		const models = specs?.map(spec => buildModel(spec));
+		const glm = models?.find(model => model.id === "glm-5.2-fast");
+		expect(glm?.reasoning).toBe(true);
+		expect(glm?.thinking?.efforts).toEqual([Effort.High, Effort.Max]);
+		expect(glm?.thinking?.defaultLevel).toBeUndefined();
+		expect(glm?.compat?.reasoningDisableMode).toBe("qwen-template-false");
+		expect(glm?.compat?.whenThinking?.reasoningDisableMode).toBe("lowest-effort");
+
+		const kimiReasoning = models?.find(model => model.id === "kimi-k3");
+		expect(kimiReasoning?.thinking).toMatchObject({
+			efforts: [Effort.Low, Effort.High, Effort.Max],
+			defaultLevel: Effort.Max,
+			requiresEffort: false,
+		});
+
+		const kimi = models?.find(model => model.id === "kimi-k3-fast");
+		expect(kimi?.reasoning).toBe(false);
+		expect(kimi?.thinking).toBeUndefined();
+	});
+
+	test("excludes none from UI efforts: default-off GLM fast is reasoning opt-in, none-only Kimi fast stays off", async () => {
+		// `none` is a wire value, not a user-selectable thinking level. A
+		// default-off GLM fast route whose only real efforts are high/max still
+		// exposes an opt-in reasoning dial with `none` filtered out, while a
+		// none-only Kimi fast route has no real effort and stays non-reasoning.
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{
+							id: "glm-5.2-fast",
+							object: "model",
+							max_model_len: 1048560,
+							metadata: {
+								display_name: "GLM-5.2 Fast",
+								pricing: { input_per_million: 1.45, output_per_million: 4.5 },
+								capabilities: { tools: true, vision: false, reasoning: false, reasoning_effort: true },
+								reasoning: {
+									mandatory: false,
+									default_enabled: false,
+									supported_efforts: ["max", "high", "none"],
+									default_effort: "none",
+								},
+								limits: { max_context_length: 1048560, max_output_tokens: null },
+								deprecated: false,
+							},
+						},
+						{
+							id: "kimi-k3-fast",
+							object: "model",
+							max_model_len: 1048560,
+							metadata: {
+								display_name: "Kimi K3 Fast",
+								pricing: { input_per_million: 0.95, output_per_million: 4 },
+								capabilities: { tools: true, vision: false, reasoning: false, reasoning_effort: true },
+								reasoning: {
+									mandatory: false,
+									default_enabled: false,
+									supported_efforts: ["none"],
+									default_effort: "none",
+								},
+								limits: { max_context_length: 1048560, max_output_tokens: null },
+								deprecated: false,
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+
+		const models = (
+			await neuralwattModelManagerOptions({ apiKey: "k", fetch: fetchMock }).fetchDynamicModels?.()
+		)?.map(spec => buildModel(spec));
+
+		// reasoning=false default-off, but high/max survive: an opt-in dial.
+		const glm = models?.find(model => model.id === "glm-5.2-fast");
+		expect(glm?.reasoning).toBe(true);
+		expect(glm?.thinking?.efforts).toEqual([Effort.High, Effort.Max]);
+
+		// none-only leaves no real effort: no dial, no thinking surface.
+		const kimi = models?.find(model => model.id === "kimi-k3-fast");
+		expect(kimi?.reasoning).toBe(false);
+		expect(kimi?.thinking).toBeUndefined();
+	});
+
+	test("leaves uncapped non-Kimi output limits unknown instead of inventing 32K", async () => {
+		// glm-5.2 (full) reports max_output_tokens: null. Only the Kimi K2.7 Code
+		// family (base and route aliases) has a known 32K recommendation; other
+		// families stay null rather than get a fabricated cap that could truncate
+		// or overstate.
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{
+							id: "glm-5.2",
+							object: "model",
+							max_model_len: 1048560,
+							metadata: {
+								display_name: "GLM-5.2",
+								pricing: { input_per_million: 1.45, output_per_million: 4.5, cached_input_per_million: 0.3625 },
+								capabilities: { tools: true, vision: false, reasoning: true, reasoning_effort: true },
+								limits: { max_context_length: 1048560, max_output_tokens: null },
+								deprecated: false,
+							},
+						},
+						{
+							id: "kimi-k2.7-code",
+							object: "model",
+							max_model_len: 262128,
+							metadata: {
+								display_name: "Kimi K2.7 Code",
+								pricing: { input_per_million: 0.95, output_per_million: 4, cached_input_per_million: 0.16 },
+								capabilities: { tools: true, vision: true, reasoning: true, reasoning_effort: false },
+								limits: { max_context_length: 262128, max_output_tokens: null },
+								deprecated: false,
+							},
+						},
+						{
+							// The route aliases share the base route's recommended 32K
+							// output budget: when upstream reports a null (uncapped)
+							// limit, each resolves to the same recommendation as
+							// `kimi-k2.7-code`.
+							id: "kimi-k2.7-code-fast",
+							object: "model",
+							max_model_len: 262128,
+							metadata: {
+								display_name: "Kimi K2.7 Code Fast",
+								pricing: { input_per_million: 0.95, output_per_million: 4, cached_input_per_million: 0.16 },
+								capabilities: { tools: true, vision: true, reasoning: false, reasoning_effort: false },
+								limits: { max_context_length: 262128, max_output_tokens: null },
+								deprecated: false,
+							},
+						},
+						{
+							// The flex alias is newly exposed by the refreshed public
+							// catalog with the live family shape; discovery still reports
+							// max_output_tokens: null, so the family recommendation must
+							// apply here too rather than dropping the 32K ceiling.
+							id: "kimi-k2.7-code-flex",
+							object: "model",
+							max_model_len: 262128,
+							metadata: {
+								display_name: "Kimi K2.7 Code Flex",
+								pricing: { input_per_million: 0.95, output_per_million: 4, cached_input_per_million: 0.16 },
+								capabilities: { tools: true, vision: true, reasoning: true, reasoning_effort: false },
+								limits: { max_context_length: 262128, max_output_tokens: null },
+								deprecated: false,
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+
+		const models = await neuralwattModelManagerOptions({ apiKey: "k", fetch: fetchMock }).fetchDynamicModels?.();
+		expect(models?.find(model => model.id === "glm-5.2")?.maxTokens ?? null).toBeNull();
+		expect(models?.find(model => model.id === "kimi-k2.7-code")?.maxTokens).toBe(
+			KIMI_K27_CODE_RECOMMENDED_MAX_TOKENS,
+		);
+		expect(models?.find(model => model.id === "kimi-k2.7-code-fast")?.maxTokens).toBe(
+			KIMI_K27_CODE_RECOMMENDED_MAX_TOKENS,
+		);
+		expect(models?.find(model => model.id === "kimi-k2.7-code-flex")?.maxTokens).toBe(
+			KIMI_K27_CODE_RECOMMENDED_MAX_TOKENS,
+		);
+	});
+
+	test("resolves real pricing for discovered models whose metadata omits it", async () => {
+		// Discovery metadata can omit pricing for a listed model (here, kimi-k3
+		// arrives with no pricing row). The exact-ID Neuralwatt bundled reference
+		// must supply it rather than defaulting to Free.
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{
+							id: "kimi-k3",
+							object: "model",
+							max_model_len: 1048560,
+							metadata: {
+								display_name: "Kimi K3",
+								capabilities: { tools: true, vision: false, reasoning: true, reasoning_effort: true },
+								limits: { max_context_length: 1048560, max_output_tokens: null },
+								deprecated: false,
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+
+		const models = await neuralwattModelManagerOptions({ apiKey: "k", fetch: fetchMock }).fetchDynamicModels?.();
+		const k3 = models?.find(model => model.id === "kimi-k3");
+		expect(k3).toBeDefined();
+		// Non-zero, real pricing (not the zero-cost Free mislabel).
+		expect(k3?.cost.input).toBeGreaterThan(0);
+		expect(k3?.cost.output).toBeGreaterThan(0);
+	});
+
+	test("omits discovered models with incomplete or invalid pricing", async () => {
+		// Missing billable rates would undercount usage, while negative rates
+		// would make spend decrease. Neither is a valid model contract.
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{
+							id: "secret-internal-model-x9",
+							object: "model",
+							max_model_len: 131072,
+							metadata: {
+								display_name: "Internal X9",
+								pricing: { input_per_million: 0.2 },
+								capabilities: { tools: true, vision: false, reasoning: true, reasoning_effort: true },
+								limits: { max_context_length: 131072, max_output_tokens: null },
+								deprecated: false,
+							},
+						},
+						{
+							id: "negative-price-model",
+							object: "model",
+							max_model_len: 131072,
+							metadata: {
+								display_name: "Negative Price",
+								pricing: { input_per_million: -0.2, output_per_million: 1 },
+								capabilities: { tools: true, vision: false, reasoning: false },
+								limits: { max_context_length: 131072, max_output_tokens: 8192 },
+								deprecated: false,
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+
+		const models = await neuralwattModelManagerOptions({ apiKey: "k", fetch: fetchMock }).fetchDynamicModels?.();
+		expect(models?.some(model => model.id === "secret-internal-model-x9")).toBe(false);
+		expect(models?.some(model => model.id === "negative-price-model")).toBe(false);
+	});
+
+	test("omits discovered models whose only pricing reference is bundled under another provider", async () => {
+		// `kimi-k2.5` is bundled under Moonshot (0.6/3 USD per 1M) but not under
+		// Neuralwatt. Pricing is provider-specific: with no pricing row and no
+		// same-provider exact-ID reference, the model must be dropped rather than
+		// borrow Moonshot's rates or default to Free.
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{
+							id: "kimi-k2.5",
+							object: "model",
+							max_model_len: 262144,
+							metadata: {
+								display_name: "Kimi K2.5",
+								capabilities: { tools: true, vision: true, reasoning: true, reasoning_effort: false },
+								limits: { max_context_length: 262144, max_output_tokens: null },
+								deprecated: false,
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+
+		const models = await neuralwattModelManagerOptions({ apiKey: "k", fetch: fetchMock }).fetchDynamicModels?.();
+		expect(models?.some(model => model.id === "kimi-k2.5")).toBe(false);
+	});
+
+	test("omits discovered models flagged pricing_tbd even with a stale provider reference", async () => {
+		// Neuralwatt bundles a glm-5.2-short reference with real rates, but a live
+		// `pricing_tbd: true` marker invalidates even that cached reference: the
+		// model must disappear until the route publishes prices rather than ship
+		// stale numbers.
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{
+							id: "glm-5.2-short",
+							object: "model",
+							max_model_len: 199984,
+							metadata: {
+								display_name: "GLM-5.2 (short)",
+								pricing_tbd: true,
+								pricing: { currency: "USD" },
+								limits: { max_context_length: 199984, max_output_tokens: 32000 },
+								deprecated: false,
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+
+		const models = await neuralwattModelManagerOptions({ apiKey: "k", fetch: fetchMock }).fetchDynamicModels?.();
+		expect(models?.some(model => model.id === "glm-5.2-short")).toBe(false);
+	});
+
+	test("preserves bundled reference vision and output limit when live metadata omits them", async () => {
+		// gemma-4-31b's Neuralwatt reference is vision-enabled with a finite
+		// 16384 output cap. When the live listing omits both `vision` and
+		// `max_output_tokens`, omission must inherit the reference — an explicit
+		// `null` output limit (covered by the uncapped-limit tests) would instead
+		// resolve to uncapped, and dropping vision would degrade to text-only.
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{
+							id: "gemma-4-31b",
+							object: "model",
+							max_model_len: 262128,
+							metadata: {
+								display_name: "Gemma 4 31B",
+								pricing: {
+									input_per_million: 0.144,
+									output_per_million: 0.42,
+									cached_input_per_million: 0.0144,
+								},
+								capabilities: { tools: true, reasoning: false },
+								limits: { max_context_length: 262128 },
+								deprecated: false,
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+
+		const models = await neuralwattModelManagerOptions({ apiKey: "k", fetch: fetchMock }).fetchDynamicModels?.();
+		const gemma = models?.find(model => model.id === "gemma-4-31b");
+		expect(gemma).toBeDefined();
+		expect(gemma?.input).toEqual(["text", "image"]);
+		expect(gemma?.maxTokens).toBe(16384);
+	});
+
+	test("keeps live Neuralwatt fields authoritative through the production manager merge", async () => {
+		// The bundled `kimi-k2.7-code` reference bakes positive prices,
+		// `reasoning: true`, and `input: ["text", "image"]`. Explicit live zeros
+		// and disabled capabilities must replace those stale values rather than
+		// being treated as missing.
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-neuralwatt-merge-"));
+		try {
+			const fetchMock: FetchImpl = async () =>
+				new Response(
+					JSON.stringify({
+						object: "list",
+						data: [
+							{
+								id: "kimi-k2.7-code",
+								object: "model",
+								max_model_len: 262128,
+								metadata: {
+									display_name: "Kimi K2.7 Code",
+									pricing: { input_per_million: 0, output_per_million: 0, cached_input_per_million: 0 },
+									capabilities: { tools: true, vision: false, reasoning: false, reasoning_effort: false },
+									limits: { max_context_length: 262128, max_output_tokens: null },
+									deprecated: false,
+								},
+							},
+						],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+
+			const manager = createModelManager({
+				...neuralwattModelManagerOptions({ apiKey: "neuralwatt-test-key", fetch: fetchMock }),
+				cacheDbPath: path.join(tempDir, "models.db"),
+			});
+			const { models } = await manager.refresh("online");
+
+			const kimi = models.find(model => model.id === "kimi-k2.7-code");
+			expect(kimi).toBeDefined();
+			expect(kimi?.reasoning).toBe(false);
+			expect(kimi?.input).toEqual(["text"]);
+			expect(kimi?.thinking).toBeUndefined();
+			expect(kimi?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("keeps a live uncapped Neuralwatt maxTokens null through the manager merge", async () => {
+		// The bundled `glm-5.2-short` reference bakes `maxTokens: 32000`. When the
+		// live route reports the same id with an uncapped limit
+		// (`max_output_tokens: null`, mapped to `null` because glm-5.2-short is not
+		// a Kimi id), the merge must keep that live `null` — falling back to the
+		// stale bundled 32000 would silently truncate generations Neuralwatt does
+		// not cap.
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-neuralwatt-limit-merge-"));
+		try {
+			const fetchMock: FetchImpl = async () =>
+				new Response(
+					JSON.stringify({
+						object: "list",
+						data: [
+							{
+								id: "glm-5.2-short",
+								object: "model",
+								max_model_len: 199984,
+								metadata: {
+									display_name: "GLM-5.2 (short)",
+									pricing: {
+										input_per_million: 1.45,
+										output_per_million: 4.5,
+										cached_input_per_million: 0.3625,
+									},
+									capabilities: { tools: true, vision: false, reasoning: true, reasoning_effort: true },
+									limits: { max_context_length: 199984, max_output_tokens: null },
+									deprecated: false,
+								},
+							},
+						],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+
+			const manager = createModelManager({
+				...neuralwattModelManagerOptions({ apiKey: "neuralwatt-test-key", fetch: fetchMock }),
+				cacheDbPath: path.join(tempDir, "models.db"),
+			});
+			const { models } = await manager.refresh("online");
+
+			const glm = models.find(model => model.id === "glm-5.2-short");
+			expect(glm).toBeDefined();
+			expect(glm?.maxTokens).toBeNull();
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("discovers models without an API key (public endpoint)", async () => {
+		const calls: Array<{ authorization: string | null }> = [];
+		const fetchMock: FetchImpl = async (_input: string | URL | Request, init?: RequestInit) => {
+			const headers = new Headers(init?.headers);
+			calls.push({ authorization: headers.get("authorization") });
+			return new Response(JSON.stringify({ object: "list", data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		};
+
+		const options = neuralwattModelManagerOptions({ fetch: fetchMock });
+		expect(options.fetchDynamicModels).toBeDefined();
+		await options.fetchDynamicModels?.();
+		expect(calls).toEqual([{ authorization: null }]);
+	});
+
+	test("scopes the discovery cache by credentials so an authenticated refresh bypasses the public cache", async () => {
+		// Regression: before credential scoping, both managers defaulted to the
+		// bare `neuralwatt` cache namespace, so an `online-if-uncached`
+		// authenticated refresh against a DB the unauthenticated run just
+		// populated reused that fresh cache — models listed only for the
+		// credential never appeared. The namespace must be derived from the API
+		// key and base URL.
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-neuralwatt-scope-"));
+		try {
+			const cacheDbPath = path.join(tempDir, "models.db");
+			// A synthetic public catalog row with complete metadata and explicit
+			// pricing keeps this cache-scoping regression independent of Neuralwatt's
+			// evolving public catalog and bundled references.
+			const publicModel = {
+				id: "synthetic-public-model",
+				object: "model",
+				max_model_len: 262128,
+				metadata: {
+					display_name: "Synthetic Public Model",
+					pricing: { input_per_million: 0.95, output_per_million: 4, cached_input_per_million: 0.16 },
+					capabilities: { tools: true, vision: true, reasoning: true, reasoning_effort: false },
+					limits: { max_context_length: 262128, max_output_tokens: null },
+					deprecated: false,
+				},
+			};
+
+			const accountPrivateModel = {
+				id: "synthetic-account-private-model",
+				object: "model",
+				max_model_len: 524288,
+				metadata: {
+					display_name: "Synthetic Account-Private Model",
+					pricing: { input_per_million: 1.25, output_per_million: 5, cached_input_per_million: 0.25 },
+					capabilities: { tools: true, vision: false, reasoning: false, reasoning_effort: false },
+					limits: { max_context_length: 524288, max_output_tokens: 32768 },
+					deprecated: false,
+				},
+			};
+
+			const publicFetch: FetchImpl = async () =>
+				new Response(JSON.stringify({ object: "list", data: [publicModel] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			const publicOptions = neuralwattModelManagerOptions({ fetch: publicFetch });
+			const publicManager = createModelManager({ ...publicOptions, cacheDbPath });
+			const publicResult = await publicManager.refresh("online-if-uncached");
+			expect(publicResult.stale).toBe(false);
+			expect(publicResult.models.some(model => model.id === publicModel.id)).toBe(true);
+
+			// Same DB and same default base URL, now with an API key. The
+			// credential-scoped listing adds a synthetic account-private row with
+			// complete metadata and explicit pricing.
+			let authenticatedFetches = 0;
+			const authenticatedFetch: FetchImpl = async () => {
+				authenticatedFetches++;
+				return new Response(
+					JSON.stringify({
+						object: "list",
+						data: [publicModel, accountPrivateModel],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			};
+			const authenticatedKey = "neuralwatt-authenticated-key";
+			const authenticatedOptions = neuralwattModelManagerOptions({
+				apiKey: authenticatedKey,
+				fetch: authenticatedFetch,
+			});
+			const authenticatedManager = createModelManager({ ...authenticatedOptions, cacheDbPath });
+			const authenticatedResult = await authenticatedManager.refresh("online-if-uncached");
+
+			// The authenticated refresh must not reuse the fresh unauthenticated
+			// cache: it fetches the credential-scoped listing and exposes its
+			// account-private row.
+			expect(authenticatedFetches).toBe(1);
+			const discoveredAccountPrivateModel = authenticatedResult.models.find(
+				model => model.id === accountPrivateModel.id,
+			);
+			expect(discoveredAccountPrivateModel).toBeDefined();
+			expect(discoveredAccountPrivateModel?.cost).toEqual({
+				input: 1.25,
+				output: 5,
+				cacheRead: 0.25,
+				cacheWrite: 0,
+			});
+
+			// The namespace differs per credential, stays prefixed with the provider,
+			// and never embeds the raw key. A distinct custom base URL scopes the
+			// same credential to yet another namespace.
+			expect(authenticatedOptions.cacheProviderId).not.toBe(publicOptions.cacheProviderId);
+			expect(authenticatedOptions.cacheProviderId?.startsWith("neuralwatt")).toBe(true);
+			expect(authenticatedOptions.cacheProviderId).not.toContain(authenticatedKey);
+			const customBaseOptions = neuralwattModelManagerOptions({
+				apiKey: authenticatedKey,
+				baseUrl: "https://gateway.internal.example.com/neuralwatt/v1",
+			});
+			expect(customBaseOptions.cacheProviderId).not.toBe(authenticatedOptions.cacheProviderId);
+			expect(customBaseOptions.cacheProviderId).not.toContain(authenticatedKey);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Neuralwatt energy-quota rendering with correctly capitalized kWh units in `omp usage` and `/usage`.
+
+### Fixed
+
+- Fixed anonymous multi-limit usage reports to keep one fallback account label per report instead of renumbering each limit.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -213,6 +213,7 @@ const UNIT_SUFFIX: Record<UsageUnit, string> = {
 	requests: " requests",
 	minutes: " min",
 	bytes: " bytes",
+	kwh: " kWh",
 	percent: "",
 	usd: "",
 	unknown: "",

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1496,6 +1496,11 @@ function formatNumber(value: number, maxFractionDigits = 1): string {
 	return new Intl.NumberFormat("en-US", { maximumFractionDigits: maxFractionDigits }).format(value);
 }
 
+function formatAbsoluteUsageAmount(value: number, unit: UsageLimit["amount"]["unit"]): string {
+	if (unit === "usd") return `$${value.toFixed(2)}`;
+	return `${formatNumber(value, 2)} ${unit === "kwh" ? "kWh" : unit}`;
+}
+
 function resolveProviderAuthMode(authStorage: AuthStorage, provider: string): string {
 	if (authStorage.hasOAuth(provider)) {
 		return "oauth";
@@ -1786,10 +1791,7 @@ function resolveStatusColor(status: UsageLimit["status"]): "success" | "warning"
 function renderUsageBar(limit: UsageLimit, uiTheme: typeof theme, barWidth: number): string {
 	const usedAmount = limit.amount.used;
 	if (usedAmount !== undefined && isUsedOnlyAbsoluteAmount(limit)) {
-		const used =
-			limit.amount.unit === "usd"
-				? `$${usedAmount.toFixed(2)}`
-				: `${formatNumber(usedAmount, 2)} ${limit.amount.unit}`;
+		const used = formatAbsoluteUsageAmount(usedAmount, limit.amount.unit);
 		return uiTheme.fg("dim", truncateJobLabel(`${used} used`, barWidth));
 	}
 	const fraction = resolveUsedFraction(limit);

--- a/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
@@ -22,11 +22,17 @@ function formatWindowSuffix(label: string, windowLabel: string | undefined): str
 
 function formatUsageAmount(limit: UsageLimit): string {
 	const amount = limit.amount;
-	const used = amount.used ?? (amount.usedFraction !== undefined ? amount.usedFraction * 100 : undefined);
+	const used =
+		amount.used ??
+		(amount.limit !== undefined && amount.remaining !== undefined
+			? amount.limit - amount.remaining
+			: amount.unit === "percent" && amount.usedFraction !== undefined
+				? amount.usedFraction * 100
+				: undefined);
 	const remainingFraction =
 		amount.remainingFraction ??
 		(amount.usedFraction !== undefined ? Math.max(0, 1 - amount.usedFraction) : undefined);
-	const unit = amount.unit === "percent" ? "%" : ` ${amount.unit}`;
+	const unit = amount.unit === "percent" ? "%" : amount.unit === "kwh" ? " kWh" : ` ${amount.unit}`;
 	const usedText = used === undefined ? "unknown used" : `${used.toFixed(2)}${unit} used`;
 	const remainingText = remainingFraction === undefined ? "" : ` (${(remainingFraction * 100).toFixed(1)}% left)`;
 	return `${usedText}${remainingText}`;
@@ -88,7 +94,7 @@ function renderUsageReports(
 		const providerNotes = [...new Set(providerReports.flatMap(report => report.notes ?? []))];
 		for (const note of providerNotes)
 			lines.push(`  ${sanitizeText(note.replace(/[\r\n]+/g, " ").replace(/\t/g, "  "))}`);
-		for (const report of providerReports) {
+		for (const [reportIndex, report] of providerReports.entries()) {
 			const inUse = reportMatchesActiveAccount(report, activeAccount);
 			const savedResets = report.resetCredits?.availableCount ?? 0;
 			if (savedResets > 0) {
@@ -134,7 +140,7 @@ function renderUsageReports(
 						: "";
 				lines.push(`- ${limit.label}${tier}${formatWindowSuffix(limit.label, window)}`);
 				lines.push(
-					`  ${formatUsageReportAccount(report, limit, index)}: ${formatUsageAmount(limit)}${inUse ? "  ← in use by this session" : ""}`,
+					`  ${formatUsageReportAccount(report, limit, reportIndex)}: ${formatUsageAmount(limit)}${inUse ? "  ← in use by this session" : ""}`,
 				);
 				lines.push(`  ${renderAsciiBar(limit.amount.usedFraction)}`);
 				if (limit.window?.resetsAt && limit.window.resetsAt > nowMs) {

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -252,19 +252,19 @@ describe("ACP builtin slash commands", () => {
 		expect(output).toEqual(["Next turn forced to use read."]);
 	});
 
-	it("renders provider usage reports when the session can fetch them", async () => {
+	it("renders kWh usage reports when the session can fetch them", async () => {
 		const { output, runtime } = createRuntime();
 		runtime.session.fetchUsageReports = async () => [
 			{
-				provider: "openai-codex",
+				provider: "neuralwatt",
 				fetchedAt: Date.now(),
 				limits: [
 					{
-						id: "codex-5h",
-						label: "5 hours",
-						scope: { provider: "openai-codex", tier: "prolite", accountId: "account-1" },
-						window: { id: "5h", label: "5 hours", resetsAt: Date.now() + 60 * 60 * 1000 },
-						amount: { used: 0.24, usedFraction: 0.24, unit: "unknown" },
+						id: "neuralwatt:subscription",
+						label: "Subscription Energy",
+						scope: { provider: "neuralwatt", tier: "pro", accountId: "account-1" },
+						window: { id: "billing", label: "Billing Period", resetsAt: Date.now() + 60 * 60 * 1000 },
+						amount: { limit: 500, remaining: 100, usedFraction: 0.8, remainingFraction: 0.2, unit: "kwh" },
 					},
 				],
 				metadata: { email: "user@example.com" },
@@ -274,10 +274,54 @@ describe("ACP builtin slash commands", () => {
 		const result = await executeAcpBuiltinSlashCommand("/usage", runtime);
 
 		expect(result).toEqual({ consumed: true });
-		expect(output[0]).toContain("Openai Codex");
-		expect(output[0]).toContain("5 hours (prolite)");
-		expect(output[0]).toContain("user@example.com: 0.24 unknown used (76.0% left)");
+		expect(output[0]).toContain("Neuralwatt");
+		expect(output[0]).toContain("Subscription Energy (pro) — Billing Period");
+		expect(output[0]).toContain("user@example.com: 400.00 kWh used (20.0% left)");
 		expect(output[0]).toContain("resets in");
+	});
+
+	it("uses one fallback account label for every limit from an anonymous report", async () => {
+		const { output, runtime } = createRuntime();
+		const reports: UsageReport[] = [
+			{
+				provider: "neuralwatt",
+				fetchedAt: 0,
+				limits: [
+					{
+						id: "neuralwatt:burst",
+						label: "Burst quota",
+						scope: { provider: "neuralwatt" },
+						amount: { used: 12, limit: 100, usedFraction: 0.12, unit: "kwh" },
+					},
+					{
+						id: "neuralwatt:monthly",
+						label: "Monthly quota",
+						scope: { provider: "neuralwatt" },
+						amount: { used: 34, limit: 100, usedFraction: 0.34, unit: "kwh" },
+					},
+				],
+			},
+			{
+				provider: "neuralwatt",
+				fetchedAt: 0,
+				limits: [
+					{
+						id: "neuralwatt:second-credential",
+						label: "Second credential quota",
+						scope: { provider: "neuralwatt" },
+						amount: { used: 56, limit: 100, usedFraction: 0.56, unit: "kwh" },
+					},
+				],
+			},
+		];
+		runtime.session.fetchUsageReports = async () => reports;
+
+		const result = await executeAcpBuiltinSlashCommand("/usage", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("- Burst quota\n  account 1:");
+		expect(output[0]).toContain("- Monthly quota\n  account 1:");
+		expect(output[0]).toContain("- Second credential quota\n  account 2:");
 	});
 
 	it("suppresses redundant usage window suffixes while retaining legitimate ones", async () => {

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -255,6 +255,20 @@ describe("formatUsageBreakdown", () => {
 		expect(text).not.toContain("%");
 		expect(text).not.toContain("resets");
 	});
+	it("renders kWh energy limits with standard capitalization", () => {
+		const report = makeReport("neuralwatt", "energy@example.test", [
+			{
+				id: "neuralwatt:subscription",
+				label: "Energy",
+				scope: { provider: "neuralwatt", windowId: "billing" },
+				amount: { used: 120.5, limit: 500, unit: "kwh" },
+			},
+		]);
+
+		const text = stripVTControlCharacters(formatUsageBreakdown([report], [], Date.now()));
+
+		expect(text).toContain("kWh");
+	});
 	it("renders every account: reported ones with limits, credential-only ones as no-data rows", () => {
 		const text = stripVTControlCharacters(formatUsageBreakdown(reports, accounts, Date.now()));
 		expect(text).toContain("dummy.primary@example.test");

--- a/packages/coding-agent/test/usage-report-tui-notes.test.ts
+++ b/packages/coding-agent/test/usage-report-tui-notes.test.ts
@@ -139,6 +139,32 @@ describe("renderUsageReports (#3268 TUI aggregate)", () => {
 		expect(text).not.toContain("1 accts");
 	});
 
+	it("renders resetless used-only kWh amounts canonically without warning or exhausted badges", () => {
+		const now = 1_700_000_000_000;
+		const reports: UsageReport[] = [
+			{
+				provider: "anthropic",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "anthropic:energy",
+						label: "Energy Usage",
+						scope: { provider: "anthropic", windowId: "energy" },
+						amount: { used: 0.24, unit: "kwh" },
+					},
+				],
+			},
+		];
+
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, now, 120));
+
+		expect(text).toContain(theme.status.info);
+		expect(text).not.toContain(theme.status.warning);
+		expect(text).not.toContain(theme.status.error);
+		expect(text).toContain("0.24 kWh used");
+		expect(text).not.toContain("0.24 kwh used");
+	});
+
 	it("preserves capped aggregate status when a group mixes capped and used-only amounts", () => {
 		const reports: UsageReport[] = [
 			report("anthropic", "capped@example.test", [


### PR DESCRIPTION
## Summary

Adds [Neuralwatt](https://api.neuralwatt.com/v1) as an API-key `openai-completions` provider. Neuralwatt exposes an OpenAI-compatible endpoint that returns per-model energy metrics alongside standard token usage.

## Changes

- **Catalog discovery** — `neuralwattModelManagerOptions` maps Neuralwatt's `/v1/models` metadata:
  - per-million input, output, and cache-read pricing from `metadata.pricing`; models with unresolved, explicitly TBD, or negative billable pricing are omitted rather than mislabeled Free
  - vision, reasoning, and tool capabilities from `metadata.capabilities`
  - context and output limits from `metadata.limits` plus `max_model_len`; explicit null output limits remain unknown, except Kimi K2.7 Code aliases use the documented 32K recommendation
  - the provider-authored non-`none` effort surface from `metadata.reasoning.supported_efforts` (for example `high`/`max` or `low`/`high`/`max`), including valid default and mandatory-effort metadata; routes with no controllable effort expose no inert selector
  - deprecated models are omitted
- **Runtime model management** — Neuralwatt discovery is authoritative for model IDs, pricing (including explicit zero rates), reasoning/vision capabilities, and explicit uncapped output limits. Cache namespaces include the API key and base URL so public and account-specific catalogs cannot leak across credentials.
- **Catalog generation** — always performs unauthenticated Neuralwatt discovery, preserves provider-authored effort ladders and null output limits, and excludes Neuralwatt's colliding bare IDs from cross-provider models.dev fallback.
- **Provider login** — adds `/login neuralwatt` with API-key validation against the authenticated `https://api.neuralwatt.com/v1/quota` endpoint.
- **Quota reporting** — adds `/v1/quota` normalization for subscription energy in kWh, PAYG credits, subscription-overage capacity, and per-key allowances, deriving used energy from included minus remaining when needed; 401/403 responses invalidate the credential while transient failures remain non-destructive.
- **Auth-broker compatibility** — extends the shared and broker wire schemas with the `kwh` usage unit.
- **Usage rendering** — `omp usage`, `/usage`, and ACP output render `kWh` with standard capitalization and keep one fallback account label across every limit in an anonymous report.
- **Bundled catalog** — regenerates `catalog/models.json` from the unauthenticated public endpoint with 18 models.
- Adds contract coverage for discovery metadata, generated policies, authoritative merging, credential-scoped caches, API-key login, quota normalization, broker transport, and CLI/ACP rendering.
- Updates the `pi-catalog`, `pi-ai`, and coding-agent changelogs under `[Unreleased]`.

## Verification

- Live `/v1/models` probes return 18 public models; the stored test credential currently returns 19 and adds one account-specific row.
- Live `/v1/quota` smoke maps the active subscription to a `kwh` usage limit.
- `catalog` suite: 587/587 pass.
- `pi-ai` suite: 3756/3756 pass (337 environment-dependent skips).
- Focused coding-agent usage rendering: 112/112 pass.
- Workspace `bun check` (Biome + tsgo) passes.
- Workspace Bun tests: 11,971 passed and 404 skipped; the pre-existing session-manager resume-ordering failure persists, while the concurrent collab timeout passed on isolated rerun.
- End-to-end via a local MITM proxy: omp sends the system prompt as a `role: "system"` first message and the request succeeds.

## Note on bundled models

The bundled snapshot is the unauthenticated public 18-model catalog, including the currently public Kimi K3 and flex routes. Catalog generation always forces unauthenticated discovery; runtime discovery uses a credential-scoped cache and may additionally surface account-specific models.