### PR TITLE
feat(tui): mirror Ctrl bindings onto Command on macOS

### DIFF
--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -5,6 +5,7 @@ import {
 	canonicalKeyId,
 	Editor,
 	type EditorTheme,
+	getKeybindings,
 	type KeyId,
 	parseKey,
 	parseKittySequence,
@@ -69,6 +70,12 @@ function buildMatchKeys(keys: readonly KeyId[], reserved?: ReadonlySet<string>):
 		addKeyAliases(matchKeys, key, reserved);
 	}
 	return matchKeys;
+}
+
+/** `getResolvedBindings()` returns a single key or a list per action. */
+function normalizeToKeyList(keys: KeyId | KeyId[] | undefined): readonly KeyId[] {
+	if (keys === undefined) return [];
+	return Array.isArray(keys) ? keys : [keys];
 }
 
 /** Explicit chords of the shipped defaults, so the initial match sets get the same
@@ -636,11 +643,19 @@ export class CustomEditor extends Editor {
 
 	/** Rebuilds every action's match set together. One action's explicitly-declared
 	 *  chord must suppress another action's generated Command alias, which is only
-	 *  decidable with all actions in view. Custom handlers count as explicit: an
-	 *  extension registering `super+o` outranks the mirror of a built-in `ctrl+o`,
-	 *  which `handleInput` would otherwise reach first. */
+	 *  decidable with all bindings in view.
+	 *
+	 *  The reservation set spans all three registries this editor dispatches across:
+	 *  the central manager's resolved bindings (which `super.handleInput` serves),
+	 *  this editor's own actions, and custom/extension handlers. Reconstructing only
+	 *  the local two would restore a mirror the manager had already suppressed —
+	 *  `tui.editor.undo: super+o` would lose Command+O to `app.tools.expand`, since
+	 *  `handleInput` intercepts before the base editor ever sees the key. */
 	#rebuildActionMatchKeys(): void {
 		const explicit = new Set<string>();
+		for (const keys of Object.values(getKeybindings().getResolvedBindings())) {
+			for (const key of normalizeToKeyList(keys)) explicit.add(canonicalKeyId(key));
+		}
 		for (const keys of this.#actionKeys.values()) {
 			for (const key of keys) explicit.add(canonicalKeyId(key));
 		}

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -63,13 +63,19 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.clipboard.copyPrompt": ["alt+shift+c"],
 };
 
-function buildMatchKeys(keys: readonly KeyId[]): Set<string> {
+function buildMatchKeys(keys: readonly KeyId[], reserved?: ReadonlySet<string>): Set<string> {
 	const matchKeys = new Set<string>();
 	for (const key of keys) {
-		addKeyAliases(matchKeys, key);
+		addKeyAliases(matchKeys, key, reserved);
 	}
 	return matchKeys;
 }
+
+/** Explicit chords of the shipped defaults, so the initial match sets get the same
+ *  alias precedence `#rebuildActionMatchKeys` applies after any `setActionKeys`. */
+const DEFAULT_EXPLICIT_KEYS: ReadonlySet<string> = new Set(
+	Object.values(DEFAULT_ACTION_KEYS).flatMap(keys => keys.map(key => canonicalKeyId(key))),
+);
 
 function unionOfMatchKeys(matchKeys: ReadonlyMap<ConfigurableEditorAction, ReadonlySet<string>>): Set<string> {
 	const union = new Set<string>();
@@ -616,7 +622,7 @@ export class CustomEditor extends Editor {
 	#actionMatchKeys = new Map<ConfigurableEditorAction, Set<string>>(
 		Object.entries(DEFAULT_ACTION_KEYS).map(([action, keys]) => [
 			action as ConfigurableEditorAction,
-			buildMatchKeys(keys),
+			buildMatchKeys(keys, DEFAULT_EXPLICIT_KEYS),
 		]),
 	);
 	/** Union of every action's match keys: one probe in `handleInput` decides
@@ -625,7 +631,20 @@ export class CustomEditor extends Editor {
 
 	setActionKeys(action: ConfigurableEditorAction, keys: KeyId[]): void {
 		this.#actionKeys.set(action, [...keys]);
-		this.#actionMatchKeys.set(action, buildMatchKeys(keys));
+		this.#rebuildActionMatchKeys();
+	}
+
+	/** Rebuilds every action's match set together. One action's explicitly-declared
+	 *  chord must suppress another action's generated Command alias, which is only
+	 *  decidable with all actions in view. */
+	#rebuildActionMatchKeys(): void {
+		const explicit = new Set<string>();
+		for (const keys of this.#actionKeys.values()) {
+			for (const key of keys) explicit.add(canonicalKeyId(key));
+		}
+		for (const [action, keys] of this.#actionKeys) {
+			this.#actionMatchKeys.set(action, buildMatchKeys(keys, explicit));
+		}
 		this.#actionMatchKeyUnion = unionOfMatchKeys(this.#actionMatchKeys);
 	}
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -636,12 +636,15 @@ export class CustomEditor extends Editor {
 
 	/** Rebuilds every action's match set together. One action's explicitly-declared
 	 *  chord must suppress another action's generated Command alias, which is only
-	 *  decidable with all actions in view. */
+	 *  decidable with all actions in view. Custom handlers count as explicit: an
+	 *  extension registering `super+o` outranks the mirror of a built-in `ctrl+o`,
+	 *  which `handleInput` would otherwise reach first. */
 	#rebuildActionMatchKeys(): void {
 		const explicit = new Set<string>();
 		for (const keys of this.#actionKeys.values()) {
 			for (const key of keys) explicit.add(canonicalKeyId(key));
 		}
+		for (const key of this.#customKeyHandlers.keys()) explicit.add(canonicalKeyId(key));
 		for (const [action, keys] of this.#actionKeys) {
 			this.#actionMatchKeys.set(action, buildMatchKeys(keys, explicit));
 		}
@@ -668,6 +671,9 @@ export class CustomEditor extends Editor {
 	setCustomKeyHandler(key: KeyId, handler: () => void): void {
 		this.#customKeyHandlers.set(key, handler);
 		this.#rebuildCustomMatchKeys();
+		// Custom chords participate in alias precedence, so the action sets must be
+		// rebuilt too: registering `super+o` has to retract the mirror of `ctrl+o`.
+		this.#rebuildActionMatchKeys();
 	}
 
 	/**
@@ -676,6 +682,7 @@ export class CustomEditor extends Editor {
 	removeCustomKeyHandler(key: KeyId): void {
 		this.#customKeyHandlers.delete(key);
 		this.#rebuildCustomMatchKeys();
+		this.#rebuildActionMatchKeys();
 	}
 
 	/**
@@ -684,6 +691,7 @@ export class CustomEditor extends Editor {
 	clearCustomKeyHandlers(): void {
 		this.#customKeyHandlers.clear();
 		this.#rebuildCustomMatchKeys();
+		this.#rebuildActionMatchKeys();
 	}
 
 	#spaceHoldGestureEnabled(): boolean {

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -1,10 +1,15 @@
-import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { CustomEditor } from "@oh-my-pi/pi-coding-agent/modes/components/custom-editor";
 import { getEditorTheme, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { setSuperMirrorsCtrl } from "@oh-my-pi/pi-tui";
 
 describe("CustomEditor keybindings", () => {
 	beforeAll(async () => {
 		await initTheme();
+	});
+
+	afterEach(() => {
+		setSuperMirrorsCtrl(process.platform === "darwin");
 	});
 
 	it("routes the configured retry chord through handleInput", () => {
@@ -16,6 +21,27 @@ describe("CustomEditor keybindings", () => {
 		editor.handleInput("\x1bR");
 
 		expect(onRetry).toHaveBeenCalledTimes(1);
+	});
+
+	it("lets an extension's explicit Command chord outrank a mirrored built-in", () => {
+		// The mirror must be live before the editor builds its match sets.
+		setSuperMirrorsCtrl(true);
+		const editor = new CustomEditor(getEditorTheme());
+		const onExpandTools = vi.fn();
+		const extension = vi.fn();
+
+		editor.onExpandTools = onExpandTools;
+		editor.setActionKeys("app.tools.expand", ["ctrl+o"]);
+		// Without precedence the mirror of ctrl+o also claims super+o, and
+		// handleInput checks the built-in action before custom handlers.
+		editor.setCustomKeyHandler("super+o", extension);
+		editor.handleInput("\x1b[111;9u");
+
+		expect(extension).toHaveBeenCalledTimes(1);
+		expect(onExpandTools).not.toHaveBeenCalled();
+		// The built-in keeps its own real chord.
+		editor.handleInput("\x0f");
+		expect(onExpandTools).toHaveBeenCalledTimes(1);
 	});
 
 	it("lets custom handlers keep precedence over the default retry chord", () => {

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { CustomEditor } from "@oh-my-pi/pi-coding-agent/modes/components/custom-editor";
 import { getEditorTheme, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
-import { setSuperMirrorsCtrl } from "@oh-my-pi/pi-tui";
+import { getKeybindings, setKeybindings, setSuperMirrorsCtrl } from "@oh-my-pi/pi-tui";
 
 describe("CustomEditor keybindings", () => {
 	beforeAll(async () => {
@@ -10,6 +11,28 @@ describe("CustomEditor keybindings", () => {
 
 	afterEach(() => {
 		setSuperMirrorsCtrl(process.platform === "darwin");
+	});
+
+	it("yields Command+O to a TUI binding the central manager already reserved", () => {
+		const previous = getKeybindings();
+		setSuperMirrorsCtrl(true);
+		// The manager reserves super+o for undo, so the mirror of the editor's
+		// ctrl+o must not reclaim it — handleInput would otherwise intercept the
+		// chord before super.handleInput() ever reaches the base editor.
+		setKeybindings(KeybindingsManager.inMemory({ "tui.editor.undo": "super+o" }));
+		try {
+			const editor = new CustomEditor(getEditorTheme());
+			const onExpandTools = vi.fn();
+			editor.onExpandTools = onExpandTools;
+			editor.setActionKeys("app.tools.expand", ["ctrl+o"]);
+			editor.handleInput("\x1b[111;9u");
+
+			expect(onExpandTools).not.toHaveBeenCalled();
+			editor.handleInput("\x0f");
+			expect(onExpandTools).toHaveBeenCalledTimes(1);
+		} finally {
+			setKeybindings(previous);
+		}
 	});
 
 	it("routes the configured retry chord through handleInput", () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added macOS Command as a mirror of every Ctrl keybinding, so shortcuts documented as Ctrl also answer to Command on darwin.
+
 ## [17.2.0] - 2026-07-30
 
 ### Added

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added macOS Command as a mirror of every Ctrl keybinding, so shortcuts documented as Ctrl also answer to Command on darwin.
+- Added macOS Command as a mirror of registry-managed Ctrl keybindings, so those shortcuts also answer to Command on darwin. Ctrl+Alt chords are excluded, and an explicitly bound `super+` chord always wins over a generated mirror. Components that match Ctrl directly rather than through the keybindings manager are unaffected and remain Ctrl-only.
 
 ## [17.2.0] - 2026-07-30
 

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -214,11 +214,24 @@ export function canonicalKeyId(key: string): string {
 	return `${modifiers.join("+")}+${base}`;
 }
 
+let superMirrorsCtrl = process.platform === "darwin";
+
+/** Test seam, mirroring `setKittyProtocolActive` in `keys.ts`. Managers cache their
+ *  match sets at construction, so flip this BEFORE constructing a KeybindingsManager. */
+export function setSuperMirrorsCtrl(enabled: boolean): void {
+	superMirrorsCtrl = enabled;
+}
+
 export function addKeyAliases(keys: Set<string>, key: KeyId): void {
 	const canonical = canonicalKeyId(key);
 	keys.add(canonical);
 	if (SHIFTED_SYMBOL_KEYS.has(canonical)) {
 		keys.add(`shift+${canonical}`);
+	}
+	// macOS: Command mirrors Ctrl. Expand bindings rather than rewriting input —
+	// `super+alt+backspace` and friends are Ghostty's Option wire forms, not Command.
+	if (superMirrorsCtrl && canonical.startsWith("ctrl+")) {
+		keys.add(canonicalKeyId(`super+${canonical.slice("ctrl+".length)}`));
 	}
 }
 

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -222,17 +222,29 @@ export function setSuperMirrorsCtrl(enabled: boolean): void {
 	superMirrorsCtrl = enabled;
 }
 
-export function addKeyAliases(keys: Set<string>, key: KeyId): void {
+/**
+ * Expands `key` into every canonical form that should match it.
+ *
+ * `reserved` holds the canonical keys some binding claims EXPLICITLY. The darwin
+ * Command mirror is a generated alias, so it yields to those: a user who binds
+ * `super+o` keeps it even when a built-in `ctrl+o` would otherwise mirror onto
+ * the same chord. Without this, the generated alias wins by handler order and
+ * `getConflicts()` reports nothing.
+ */
+export function addKeyAliases(keys: Set<string>, key: KeyId, reserved?: ReadonlySet<string>): void {
 	const canonical = canonicalKeyId(key);
 	keys.add(canonical);
 	if (SHIFTED_SYMBOL_KEYS.has(canonical)) {
 		keys.add(`shift+${canonical}`);
 	}
-	// macOS: Command mirrors Ctrl. Expand bindings rather than rewriting input —
-	// `super+alt+backspace` and friends are Ghostty's Option wire forms, not Command.
-	if (superMirrorsCtrl && canonical.startsWith("ctrl+")) {
-		keys.add(canonicalKeyId(`super+${canonical.slice("ctrl+".length)}`));
-	}
+	if (!superMirrorsCtrl || !canonical.startsWith("ctrl+")) return;
+	// Ctrl+Alt chords are excluded: macOS terminals that report Option as
+	// `alt+super` would see the mirror of `ctrl+alt+X` as a plain Option+X press,
+	// so mirroring here would consume ordinary Option input.
+	if (canonical.includes("alt+")) return;
+	const mirrored = canonicalKeyId(`super+${canonical.slice("ctrl+".length)}`);
+	if (reserved?.has(mirrored)) return;
+	keys.add(mirrored);
 }
 
 const normalizeKeyId = (key: KeyId): KeyId => key.toLowerCase() as KeyId;
@@ -286,15 +298,24 @@ export class KeybindingsManager {
 			}
 		}
 
+		// Two passes: every explicitly-declared key is collected first, so the second
+		// pass can suppress a generated Command alias that would shadow one.
+		const resolved: Array<[Keybinding, KeyId[]]> = [];
+		const explicitKeys = new Set<string>();
 		for (const [id, definition] of Object.entries(this.#definitions)) {
 			const userKeys = this.#userBindings[id];
 			const keys = userKeys === undefined ? normalizeKeys(definition.defaultKeys) : normalizeKeys(userKeys);
+			resolved.push([id as Keybinding, keys]);
 			this.#keysById.set(id as Keybinding, keys);
+			for (const key of keys) explicitKeys.add(canonicalKeyId(key));
+		}
+
+		for (const [id, keys] of resolved) {
 			const matchKeys = new Set<string>();
 			for (const key of keys) {
-				addKeyAliases(matchKeys, key);
+				addKeyAliases(matchKeys, key, explicitKeys);
 			}
-			this.#matchKeysById.set(id as Keybinding, matchKeys);
+			this.#matchKeysById.set(id, matchKeys);
 		}
 	}
 

--- a/packages/tui/test/keybindings.test.ts
+++ b/packages/tui/test/keybindings.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "bun:test";
-import { addKeyAliases, canonicalKeyId, KeybindingsManager, parseKey, TUI_KEYBINDINGS } from "@oh-my-pi/pi-tui";
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	addKeyAliases,
+	canonicalKeyId,
+	KeybindingsManager,
+	parseKey,
+	setSuperMirrorsCtrl,
+	TUI_KEYBINDINGS,
+} from "@oh-my-pi/pi-tui";
 
 describe("KeybindingsManager", () => {
 	it("does not evict selector confirm when input submit is rebound", () => {
@@ -72,5 +79,43 @@ describe("KeybindingsManager", () => {
 			expect(aliases.has(canonicalKeyId(parsed))).toBe(true);
 			expect(keybindings.matches(input, "tui.input.copy")).toBe(true);
 		}
+	});
+});
+
+describe("Command mirrors Ctrl on macOS (superMirrorsCtrl)", () => {
+	// Managers cache their match set at construction via addKeyAliases, so the flag
+	// MUST be flipped before the manager is built — constructing first and flipping
+	// after silently tests nothing.
+	afterEach(() => {
+		setSuperMirrorsCtrl(process.platform === "darwin");
+	});
+
+	it("answers the Command wire form when a ctrl binding is mirrored", () => {
+		setSuperMirrorsCtrl(true);
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.copy": "ctrl+up",
+		});
+
+		// "\x1b[1;9A" is the Command+Up wire form; it parses to super+up.
+		expect(keybindings.matches("\x1b[1;9A", "tui.input.copy")).toBe(true);
+	});
+
+	it("does not answer the Command wire form when the mirror is disabled", () => {
+		setSuperMirrorsCtrl(false);
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.copy": "ctrl+up",
+		});
+
+		expect(keybindings.matches("\x1b[1;9A", "tui.input.copy")).toBe(false);
+	});
+
+	it("does not mirror non-Ctrl bindings", () => {
+		setSuperMirrorsCtrl(true);
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.copy": "alt+up",
+		});
+
+		// A binding of alt+up has no ctrl+ twin, so Command+Up must not match it.
+		expect(keybindings.matches("\x1b[1;9A", "tui.input.copy")).toBe(false);
 	});
 });

--- a/packages/tui/test/keybindings.test.ts
+++ b/packages/tui/test/keybindings.test.ts
@@ -118,4 +118,31 @@ describe("Command mirrors Ctrl on macOS (superMirrorsCtrl)", () => {
 		// A binding of alt+up has no ctrl+ twin, so Command+Up must not match it.
 		expect(keybindings.matches("\x1b[1;9A", "tui.input.copy")).toBe(false);
 	});
+
+	it("lets an explicit super binding win over another action's generated mirror", () => {
+		setSuperMirrorsCtrl(true);
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.copy": "ctrl+up",
+			"tui.input.submit": "super+up",
+		});
+
+		// The mirror of ctrl+up would also claim super+up. The explicit binding owns
+		// the chord; the generated alias yields rather than shadowing it by handler order.
+		expect(keybindings.matches("\x1b[1;9A", "tui.input.submit")).toBe(true);
+		expect(keybindings.matches("\x1b[1;9A", "tui.input.copy")).toBe(false);
+		// The mirrored action keeps its own real binding.
+		expect(keybindings.matches("\x1b[1;5A", "tui.input.copy")).toBe(true);
+	});
+
+	it("does not mirror Ctrl+Alt chords onto the Option wire form", () => {
+		setSuperMirrorsCtrl(true);
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.copy": "ctrl+alt+]",
+		});
+
+		// Terminals that report Option as alt+super would deliver a plain Option+]
+		// press as alt+super+]; mirroring ctrl+alt+] there would eat ordinary input.
+		expect(keybindings.matches("\x1b[93;11u", "tui.input.copy")).toBe(false);
+		expect(keybindings.matches("\x1b[93;7u", "tui.input.copy")).toBe(true);
+	});
 });


### PR DESCRIPTION
macOS users reach for Command where the keybindings say Ctrl. This makes every `ctrl+X` binding also answer to `super+X` on darwin.

### Why expansion, not input rewriting

Three real `super+*` bindings already exist — `super+alt+backspace`, `super+alt+delete`, `super+alt+d`. They are two-modifier forms carrying `super` for a reason that predates this change, so rewriting `super` to `ctrl` on the input path would alter them. Expanding the match set at binding time leaves them untouched.

(An earlier draft attributed these to Ghostty's Option encoding. I did not verify that against a terminal, so the claim is withdrawn — the argument for expansion over rewriting stands on the bindings existing, whatever emits them.)

`addKeyAliases()` in `packages/tui/src/keybindings.ts` is the single choke point both the keybindings manager and the editor route through, so one clause covers every consumer. `canonicalKeyId()` re-sorts the modifiers, so `ctrl+shift+up` produces the `shift+super+up` twin that `matches()` actually compares against.

No collision exists in the current binding set: no `super+Y` binding matches the `super+` twin of any `ctrl+Y`.

### Test seam

`setSuperMirrorsCtrl(enabled)` mirrors the existing `setKittyProtocolActive()` pattern in `keys.ts`. Managers cache their match set at construction, so it must be flipped **before** a `KeybindingsManager` is built — the tests do this and restore the flag in `afterEach`.

### Verification

Three tests in `packages/tui/test/keybindings.test.ts`, using the Command+Up wire form `\x1b[1;9A`:

- mirror on → a `ctrl+up` binding matches it
- mirror off → the same binding does not
- mirror on → a non-`ctrl` binding (`alt+up`) does not match it

Confirmed against the real `KeybindingsManager` that `Cmd+O` resolves to `app.tools.expand` with the mirror on, and does not with it off.

### Note

Command only reaches the app through the kitty keyboard protocol; legacy CSI has no Super bit. Terminal.app never forwards it. That is a terminal limitation, not something this change can address — Terminal.app users are served by the separate `shift+up` dequeue binding.

This mirror only reaches bindings that *have* a `ctrl` form. Ten bindings are alt-only and gain nothing from it; #7154 gives five of them an explicit Command chord and documents why the other five are left alone. #7154's collision analysis assumes this PR is merged — if it is rejected, three of those bindings become free to take the Command chords it declines.


