### PR TITLE
feat(keybindings): render Mac glyph key hints on darwin

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed key hints to render Mac glyphs on macOS, so shortcuts display as ⌥↑ and ⇧⌘↑ instead of Alt+Up and Ctrl+Shift+Up.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -675,13 +675,48 @@ function formatKeyPart(part: string): string {
 	return `${part.charAt(0).toUpperCase()}${part.slice(1)}`;
 }
 
-export function formatKeyHint(key: KeyId): string {
+const MAC_MODIFIER_GLYPHS: Record<string, string> = { ctrl: "⌘", super: "⌘", shift: "⇧", alt: "⌥" };
+
+const MAC_KEY_GLYPHS: Record<string, string> = {
+	up: "↑",
+	down: "↓",
+	left: "←",
+	right: "→",
+	enter: "↩",
+	return: "↩",
+	escape: "⎋",
+	esc: "⎋",
+	tab: "⇥",
+	backspace: "⌫",
+	delete: "⌦",
+	space: "␣",
+	pageup: "⇞",
+	pagedown: "⇟",
+	home: "↖",
+	end: "↘",
+};
+
+/** Mac modifier order. `⌃` is absent by design: ctrl renders as ⌘, because the
+ *  `super` alias in `addKeyAliases` makes Command the reachable modifier on darwin. */
+const MAC_GLYPH_ORDER = ["⌥", "⇧", "⌘"];
+
+function formatKeyHintMac(key: KeyId): string {
+	const parts = key.split("+");
+	const base = parts[parts.length - 1] ?? "";
+	const glyphs = parts.slice(0, -1).map(part => MAC_MODIFIER_GLYPHS[part.toLowerCase()]);
+	const ordered = MAC_GLYPH_ORDER.filter(glyph => glyphs.includes(glyph));
+	const baseLabel = MAC_KEY_GLYPHS[base.toLowerCase()] ?? formatKeyPart(base);
+	return `${ordered.join("")}${baseLabel}`;
+}
+
+export function formatKeyHint(key: KeyId, platform: NodeJS.Platform = process.platform): string {
+	if (platform === "darwin") return formatKeyHintMac(key);
 	return key.split("+").map(formatKeyPart).join("+");
 }
 
-export function formatKeyHints(keys: KeyId | KeyId[]): string {
+export function formatKeyHints(keys: KeyId | KeyId[], platform: NodeJS.Platform = process.platform): string {
 	const list = Array.isArray(keys) ? keys : [keys];
-	return list.map(formatKeyHint).join("/");
+	return list.map(key => formatKeyHint(key, platform)).join("/");
 }
 
 export type { Keybinding, KeybindingsConfig, KeyId };

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -621,9 +621,9 @@ export class KeybindingsManager extends TuiKeybindingsManager {
 	/**
 	 * Get display string for a keybinding (e.g., "ctrl+c/escape").
 	 */
-	getDisplayString(keybinding: Keybinding): string {
+	getDisplayString(keybinding: Keybinding, platform: NodeJS.Platform = process.platform): string {
 		const keys = this.getKeys(keybinding);
-		return formatKeyHints(keys.length === 0 ? [] : keys);
+		return formatKeyHints(keys.length === 0 ? [] : keys, platform);
 	}
 
 	/**
@@ -696,16 +696,46 @@ const MAC_KEY_GLYPHS: Record<string, string> = {
 	end: "↘",
 };
 
-/** Mac modifier order. `⌃` is absent by design: ctrl renders as ⌘, because the
- *  `super` alias in `addKeyAliases` makes Command the reachable modifier on darwin. */
+/** Mac modifier order. `⌃` is absent by design: ctrl renders as ⌘ so that once the
+ *  companion `super` alias in `addKeyAliases` lands (mirroring Ctrl onto Command),
+ *  the hint advertises the modifier that is actually reachable on darwin. */
 const MAC_GLYPH_ORDER = ["⌥", "⇧", "⌘"];
 
+const MAC_MODIFIER_TOKENS = ["ctrl", "shift", "alt", "super"] as const;
+
+/** Consume a leading `modifier+` token. Walks the prefix like `canonicalKeyId` in
+ *  tui/keybindings.ts so a base key that is itself `+` (keypad `ctrl++`) is not
+ *  swallowed by a naive `split("+")`. */
+function startsWithModifier(key: string, offset: number, modifier: string): boolean {
+	const next = offset + modifier.length;
+	if (key.length <= next || key.charCodeAt(next) !== 43) return false;
+	for (let i = 0; i < modifier.length; i++) {
+		const actual = key.charCodeAt(offset + i);
+		const expected = modifier.charCodeAt(i);
+		if (actual !== expected && actual !== expected - 32) return false;
+	}
+	return true;
+}
+
 function formatKeyHintMac(key: KeyId): string {
-	const parts = key.split("+");
-	const base = parts[parts.length - 1] ?? "";
-	const glyphs = parts.slice(0, -1).map(part => MAC_MODIFIER_GLYPHS[part.toLowerCase()]);
-	const ordered = MAC_GLYPH_ORDER.filter(glyph => glyphs.includes(glyph));
+	const modifiers: string[] = [];
+	let offset = 0;
+	let found = true;
+	while (found) {
+		found = false;
+		for (const modifier of MAC_MODIFIER_TOKENS) {
+			if (startsWithModifier(key, offset, modifier)) {
+				modifiers.push(modifier);
+				offset += modifier.length + 1;
+				found = true;
+				break;
+			}
+		}
+	}
+	const base = key.slice(offset);
 	const baseLabel = MAC_KEY_GLYPHS[base.toLowerCase()] ?? formatKeyPart(base);
+	const glyphs = modifiers.map(modifier => MAC_MODIFIER_GLYPHS[modifier]);
+	const ordered = MAC_GLYPH_ORDER.filter(glyph => glyphs.includes(glyph));
 	return `${ordered.join("")}${baseLabel}`;
 }
 

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -746,7 +746,10 @@ export function formatKeyHint(key: KeyId, platform: NodeJS.Platform = process.pl
 
 export function formatKeyHints(keys: KeyId | KeyId[], platform: NodeJS.Platform = process.platform): string {
 	const list = Array.isArray(keys) ? keys : [keys];
-	return list.map(key => formatKeyHint(key, platform)).join("/");
+	// Distinct keys can share one label: on darwin both ctrl and super render as ⌘,
+	// so the ["ctrl+v","super+v"] paste default would otherwise read "⌘V/⌘V".
+	const labels = new Set(list.map(key => formatKeyHint(key, platform)));
+	return [...labels].join("/");
 }
 
 export type { Keybinding, KeybindingsConfig, KeyId };

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -385,8 +385,8 @@ async function executeLegacyBashOperations(
 }
 
 /** Format the active shortcut for legacy extensions that render keybinding hints. */
-export function keyText(action: Keybinding): string {
-	return formatKeyHints(getKeybindings().getKeys(action));
+export function keyText(action: Keybinding, platform: NodeJS.Platform = process.platform): string {
+	return formatKeyHints(getKeybindings().getKeys(action), platform);
 }
 
 /** Parse frontmatter using the historical Pi package-root helper. */

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -242,14 +242,14 @@ function renderCachedPreview(cache: PreviewRenderCache, preview: string, width: 
 }
 
 function pageKeysLabel(): string {
-	const pageUp = editorKey("tui.select.pageUp");
-	const pageDown = editorKey("tui.select.pageDown");
-	return `${pageUp === "pageup" ? "PgUp" : pageUp}/${pageDown === "pagedown" ? "PgDn" : pageDown}`;
+	// `editorKey` formats through `formatKeyHints`, so "pageup" already arrives as
+	// "PgUp"; the local pageup/escape special cases this used to carry are gone.
+	return `${editorKey("tui.select.pageUp")}/${editorKey("tui.select.pageDown")}`;
 }
 
 function cancelKeyLabel(): string {
 	const [key = ""] = editorKey("tui.select.cancel").split("/");
-	return key === "escape" ? "Esc" : key;
+	return key;
 }
 
 function normalizedInlineInput(input: string): string {

--- a/packages/coding-agent/src/modes/components/keybinding-hints.ts
+++ b/packages/coding-agent/src/modes/components/keybinding-hints.ts
@@ -2,16 +2,19 @@
  * Utilities for formatting keybinding hints in the UI.
  */
 import { getKeybindings, type Keybinding, type KeyId } from "@oh-my-pi/pi-tui";
-import type { AppKeybinding, KeybindingsManager } from "../../config/keybindings";
+import { type AppKeybinding, formatKeyHints, type KeybindingsManager } from "../../config/keybindings";
 import { theme } from "../../modes/theme/theme";
 
 /**
- * Format keys array as display string (e.g., ["ctrl+c", "escape"] -> "ctrl+c/escape").
+ * Format keys array as display string (e.g., ["ctrl+c", "escape"] -> "Ctrl+C/Esc").
+ *
+ * Delegates to the central `formatKeyHints` so these hints cannot drift from the
+ * ones `getDisplayString` renders elsewhere — this module used to join raw key ids,
+ * which showed `escape/ctrl+c` in dialogs while other surfaces showed `Esc/Ctrl+C`.
  */
 function formatKeys(keys: KeyId[]): string {
 	if (keys.length === 0) return "";
-	if (keys.length === 1) return keys[0]!;
-	return keys.join("/");
+	return formatKeyHints(keys);
 }
 
 /**

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { getDefaultPasteImageKeys, KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import {
+	formatKeyHint,
+	formatKeyHints,
+	getDefaultPasteImageKeys,
+	KeybindingsManager,
+} from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { keyText } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
 import { getKeybindings, setKeybindings, type KeybindingsManager as TuiKeybindingsManager } from "@oh-my-pi/pi-tui";
 
@@ -61,5 +66,23 @@ describe("getDefaultPasteImageKeys", () => {
 	it("adds the macOS Command key event to Ctrl+V for image paste", () => {
 		expect(getDefaultPasteImageKeys("linux")).toEqual(["ctrl+v"]);
 		expect(getDefaultPasteImageKeys("darwin")).toEqual(["ctrl+v", "super+v"]);
+	});
+});
+
+describe("formatKeyHint / formatKeyHints (Mac glyphs on darwin)", () => {
+	it("renders a multi-binding list with Mac glyphs and the existing separator", () => {
+		expect(formatKeyHints(["alt+up", "shift+up"], "darwin")).toBe("⌥↑/⇧↑");
+	});
+
+	it("renders ctrl+shift+up as ⇧⌘↑ on darwin (ctrl maps to ⌘, ⇧ precedes ⌘)", () => {
+		expect(formatKeyHint("ctrl+shift+up", "darwin")).toBe("⇧⌘↑");
+	});
+
+	it("keeps the non-darwin rendering unchanged", () => {
+		expect(formatKeyHint("ctrl+shift+up", "linux")).toBe("Ctrl+Shift+Up");
+	});
+
+	it("dedupes ctrl and super to a single ⌘ glyph on darwin", () => {
+		expect(formatKeyHint("ctrl+super+o", "darwin")).toBe("⌘O");
 	});
 });

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -14,13 +14,13 @@ describe("KeybindingsManager.getDisplayString", () => {
 			"app.message.dequeue": "alt+up",
 		});
 
-		expect(keybindings.getDisplayString("app.message.dequeue")).toBe("Alt+Up");
+		expect(keybindings.getDisplayString("app.message.dequeue", "linux")).toBe("Alt+Up");
 	});
 
 	it("defaults retry to Alt+R", () => {
 		const keybindings = KeybindingsManager.inMemory();
 
-		expect(keybindings.getDisplayString("app.retry")).toBe("Alt+R");
+		expect(keybindings.getDisplayString("app.retry", "linux")).toBe("Alt+R");
 	});
 
 	it("formats multiple bindings with the existing separator", () => {
@@ -28,7 +28,7 @@ describe("KeybindingsManager.getDisplayString", () => {
 			"app.clipboard.copyPrompt": ["alt+shift+c", "ctrl+shift+c"],
 		});
 
-		expect(keybindings.getDisplayString("app.clipboard.copyPrompt")).toBe("Alt+Shift+C/Ctrl+Shift+C");
+		expect(keybindings.getDisplayString("app.clipboard.copyPrompt", "linux")).toBe("Alt+Shift+C/Ctrl+Shift+C");
 	});
 
 	it("returns an empty string when the action has no binding", () => {
@@ -54,7 +54,7 @@ describe("legacy keyText", () => {
 	it("formats the active binding for legacy extensions", () => {
 		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "alt+e" }));
 
-		expect(keyText("app.tools.expand")).toBe("Alt+E");
+		expect(keyText("app.tools.expand", "linux")).toBe("Alt+E");
 	});
 });
 
@@ -84,5 +84,12 @@ describe("formatKeyHint / formatKeyHints (Mac glyphs on darwin)", () => {
 
 	it("dedupes ctrl and super to a single ⌘ glyph on darwin", () => {
 		expect(formatKeyHint("ctrl+super+o", "darwin")).toBe("⌘O");
+	});
+
+	it("preserves a literal + base key on darwin (keypad ctrl++)", () => {
+		expect(formatKeyHint("+", "darwin")).toBe("+");
+		expect(formatKeyHint("ctrl++", "darwin")).toBe("⌘+");
+		expect(formatKeyHint("shift++", "darwin")).toBe("⇧+");
+		expect(formatKeyHint("ctrl++", "linux")).toBe("Ctrl++");
 	});
 });

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -93,3 +93,17 @@ describe("formatKeyHint / formatKeyHints (Mac glyphs on darwin)", () => {
 		expect(formatKeyHint("ctrl++", "linux")).toBe("Ctrl++");
 	});
 });
+
+describe("formatKeyHints deduplication", () => {
+	it("collapses distinct keys that share one Mac label", () => {
+		// ctrl and super both render as ⌘, and the shipped paste-image default
+		// carries both, so joining without dedupe reads "⌘V/⌘V".
+		expect(formatKeyHints(getDefaultPasteImageKeys("darwin"), "darwin")).toBe("⌘V");
+		expect(formatKeyHints(["ctrl+v", "super+v"], "darwin")).toBe("⌘V");
+	});
+
+	it("keeps genuinely distinct labels", () => {
+		expect(formatKeyHints(["alt+up", "shift+up"], "darwin")).toBe("⌥↑/⇧↑");
+		expect(formatKeyHints(["ctrl+v", "alt+v"], "win32")).toBe("Ctrl+V/Alt+V");
+	});
+});

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -1089,7 +1089,9 @@ describe("AskDialogComponent", () => {
 			expect(out).toContain("PgUp/PgDn");
 			expect(out).toContain("Tab/←/→");
 			expect(out).not.toContain(" tabs");
-			expect(out).toContain("ctrl+g cancel");
+			// Formatted like the PgUp/PgDn and Tab hints above: the raw "ctrl+g" this
+			// used to expect was the odd one out, from hints bypassing formatKeyHints.
+			expect(out).toContain("Ctrl+G cancel");
 			setKeybindings(
 				KeybindingsManager.inMemory({
 					"tui.select.cancel": "ctrl+g",
@@ -1098,8 +1100,8 @@ describe("AskDialogComponent", () => {
 				}),
 			);
 			const remapped = render(component);
-			expect(remapped).toContain("ctrl+u/ctrl+d");
-			expect(remapped).toContain("ctrl+g cancel");
+			expect(remapped).toContain("Ctrl+U/Ctrl+D");
+			expect(remapped).toContain("Ctrl+G cancel");
 		} finally {
 			if (originalRows) Object.defineProperty(process.stdout, "rows", originalRows);
 			else Reflect.deleteProperty(process.stdout, "rows");


### PR DESCRIPTION
Key hints render as `Ctrl+Shift+Up` on every platform, which is not how macOS shortcuts are written. On darwin they now render in the platform's own glyph convention.

| Binding | Before | After (darwin) |
|---|---|---|
| `alt+up` / `shift+up` | `Alt+Up/Shift+Up` | `⌥↑/⇧↑` |
| `ctrl+shift+up` | `Ctrl+Shift+Up` | `⇧⌘↑` |
| `ctrl+super+o` | `Ctrl+Super+O` | `⌘O` |

Non-darwin output is unchanged.

### Why ctrl renders as ⌘ and not ⌃

The companion change (#7147) makes Command mirror Ctrl on darwin, so Command is the modifier that actually reaches the app. Rendering `⌃` would name a key the user is not expected to press. `⌃` is therefore never emitted, and both `ctrl` and `super` map to `⌘` — a binding carrying both dedupes to a single glyph.

Modifiers are ordered `⌥ ⇧ ⌘`, matching the platform convention.

### Scope

`formatKeyHint` / `formatKeyHints` take the platform as a defaulted parameter rather than reading `process.platform` inline, so the behavior is testable without mutating global state. `getDisplayString` needs no change and every hint surface follows automatically: the pending-message bar, `hotkeys-markdown.ts`, `expandKeyHint` in `render-utils.ts`, and `prompt-action-autocomplete.ts`.

### Verification

Four assertions in `packages/coding-agent/test/keybindings-display.test.ts` covering each row of the table above plus the unchanged Linux rendering, each passing the platform explicitly. `process.platform` is never mutated.

### Relationship to the other PRs

Bases on `main`, independent of #7147, #7149, #7150 and #7154. The Command chords #7154 adds (`super+up`, `super+m`, `super+shift+p`, …) render through this same code, so they display as `⌘↑`, `⌘M`, `⇧⌘P` once both land.

