### PR TITLE
feat(keybindings): accept shift+up for the steering dequeue

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `Shift+Up` as a second default for the message dequeue, so the shortcut is reachable in macOS Terminal.app where Option is consumed for character composition.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -139,7 +139,9 @@ export const KEYBINDINGS = {
 		description: "Retry last failed assistant turn",
 	},
 	"app.message.dequeue": {
-		defaultKeys: "alt+up",
+		// Shift+Up is listed alongside Alt+Up because macOS Terminal.app consumes Option
+		// for character composition, leaving Alt+Up unreachable there.
+		defaultKeys: ["alt+up", "shift+up"],
 		description: "Dequeue message",
 	},
 	"app.clipboard.pasteImage": {

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -56,7 +56,7 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.thinking.toggle": ["ctrl+t"],
 	"app.editor.external": ["ctrl+g"],
 	"app.history.search": ["ctrl+r"],
-	"app.message.dequeue": ["alt+up"],
+	"app.message.dequeue": ["alt+up", "shift+up"],
 	"app.retry": ["alt+r"],
 	"app.clipboard.pasteImage": ["ctrl+v"],
 	"app.clipboard.pasteTextRaw": ["ctrl+shift+v", "alt+shift+v"],

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { CustomEditor } from "@oh-my-pi/pi-coding-agent/modes/components/custom-editor";
 import { getEditorTheme, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
@@ -43,5 +44,14 @@ describe("CustomEditor keybindings", () => {
 
 		expect(onCopyPrompt).toHaveBeenCalledTimes(1);
 		expect(onRetry).not.toHaveBeenCalled();
+	});
+});
+
+describe("shipped dequeue defaults", () => {
+	it("binds both alt+up and shift+up to the steering dequeue", () => {
+		const keybindings = KeybindingsManager.inMemory();
+		const keys = keybindings.getKeys("app.message.dequeue");
+		expect(keys).toContain("alt+up");
+		expect(keys).toContain("shift+up");
 	});
 });

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -54,4 +54,17 @@ describe("shipped dequeue defaults", () => {
 		expect(keys).toContain("alt+up");
 		expect(keys).toContain("shift+up");
 	});
+	it("routes the shipped shift+up default through DEFAULT_ACTION_KEYS to the dequeue handler", () => {
+		// F12: the registry test above does not cover DEFAULT_ACTION_KEYS, the second
+		// defaults table that custom-editor.ts seeds its match set from. Drive a real
+		// editor without calling setActionKeys, so the shipped entry is the only thing
+		// that can make the shift+up wire form (CSI 1;2A) reach onDequeue.
+		const editor = new CustomEditor(getEditorTheme());
+		const onDequeue = vi.fn();
+
+		editor.onDequeue = onDequeue;
+		editor.handleInput("\x1b[1;2A");
+
+		expect(onDequeue).toHaveBeenCalledTimes(1);
+	});
 });


### PR DESCRIPTION
`Alt+Up` is the only way to pull a queued message back into the editor, and in macOS Terminal.app it never arrives — Option is consumed for character composition. The dequeue is unreachable there.

`Shift+Up` is bound alongside it. Shift is not intercepted, and the key was unbound in the input path.

### Why this key

- Unbound repo-wide in the editor input path.
- The three existing `shift+up` handlers — `scroll-view.ts`, `model-hub.ts`, `debug/log-viewer.ts` — are overlay components that match keys directly rather than through the keybindings manager, so they never see this binding and keep their fast-scroll behavior.
- Verified `\x1b[1;2A` (the `shift+up` wire form) matches with the kitty protocol both active and inactive.

Multi-key defaults are already the established pattern here: `app.message.followUp` ships `["ctrl+q", "ctrl+enter"]` for a similar terminal-compatibility reason.

### Both tables

Defaults live in two places that silently disagree if only one is edited — the registry in `config/keybindings.ts` and `DEFAULT_ACTION_KEYS` in `modes/components/custom-editor.ts`. Both move together here.

No migration entry is needed: the action id is unchanged, so an existing `keybindings.yaml` override still wins.

### Verification

`packages/coding-agent/test/custom-editor-keybindings.test.ts` asserts the resolved keys contain both `alt+up` and `shift+up`. Confirmed in a running TUI that `Shift+Up` reaches the dequeue handler.

### Relationship to the other PRs

Bases on `main`, independent of #7147, #7148, #7150 and #7154. #7154 adds `super+up` to this same `defaultKeys` list and #7150 rewords the entry's description, so whichever lands last will conflict on `app.message.dequeue`. #7154 carries the exact three-way resolved entry — use it verbatim rather than taking one side.

