### PR TITLE
feat(input): split steering and follow-up dequeue

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -35,7 +35,8 @@ app.history.search: []
 | `app.thinking.cycle`        | `Shift+Tab`                            | Cycle thinking level                          |
 | `app.editor.external`       | `Ctrl+G`                               | Edit the draft in `$VISUAL` / `$EDITOR`       |
 | `app.message.followUp`      | `Ctrl+Q`, `Ctrl+Enter`                 | Queue a follow-up message                     |
-| `app.message.dequeue`       | `Alt+Up`                               | Dequeue a queued message back into the editor |
+| `app.message.dequeue`       | `Alt+Up`                               | Restore steering messages to the editor       |
+| `app.message.dequeueFollowUp` | `Ctrl+Shift+Up`                      | Restore follow-up messages to the editor      |
 | `app.retry`                 | `Alt+R`                                | Retry the last failed assistant turn          |
 | `app.display.reset`         | `Ctrl+L`                               | Reset terminal display                        |
 | `app.clipboard.copyLine`    | `Alt+Shift+L`                          | Copy the current line                         |

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed `replaceQueues()` to accept `readonly` message arrays; it already copied both arguments, so the mutable parameter type only forced callers into defensive copies.
+
 ## [17.2.0] - 2026-07-30
 
 ### Fixed

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -915,7 +915,7 @@ export class Agent {
 		this.#state.messages = ms.slice();
 	}
 
-	replaceQueues(steering: AgentMessage[], followUp: AgentMessage[]) {
+	replaceQueues(steering: readonly AgentMessage[], followUp: readonly AgentMessage[]) {
 		this.#steeringQueue = steering.slice();
 		this.#followUpQueue = followUp.slice();
 		this.#notifySteeringWaiters();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a separate `Ctrl+Shift+Up` binding that restores only follow-up messages to the editor; the existing dequeue now restores only steering messages, and the pending-message bar labels each group with its own key. `Esc` still restores everything.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -33,6 +33,7 @@ interface AppKeybindings {
 	"app.message.followUp": true;
 	"app.retry": true;
 	"app.message.dequeue": true;
+	"app.message.dequeueFollowUp": true;
 	"app.clipboard.pasteImage": true;
 	"app.clipboard.pasteTextRaw": true;
 	"app.clipboard.copyLine": true;
@@ -140,7 +141,11 @@ export const KEYBINDINGS = {
 	},
 	"app.message.dequeue": {
 		defaultKeys: "alt+up",
-		description: "Dequeue message",
+		description: "Restore steering messages to the editor",
+	},
+	"app.message.dequeueFollowUp": {
+		defaultKeys: "ctrl+shift+up",
+		description: "Restore follow-up messages to the editor",
 	},
 	"app.clipboard.pasteImage": {
 		defaultKeys: getDefaultPasteImageKeys(),

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -35,6 +35,7 @@ type ConfigurableEditorAction = Extract<
 	| "app.editor.external"
 	| "app.history.search"
 	| "app.message.dequeue"
+	| "app.message.dequeueFollowUp"
 	| "app.retry"
 	| "app.clipboard.pasteImage"
 	| "app.clipboard.pasteTextRaw"
@@ -57,6 +58,7 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.editor.external": ["ctrl+g"],
 	"app.history.search": ["ctrl+r"],
 	"app.message.dequeue": ["alt+up"],
+	"app.message.dequeueFollowUp": ["ctrl+shift+up"],
 	"app.retry": ["alt+r"],
 	"app.clipboard.pasteImage": ["ctrl+v"],
 	"app.clipboard.pasteTextRaw": ["ctrl+shift+v", "alt+shift+v"],
@@ -563,8 +565,10 @@ export class CustomEditor extends Editor {
 	onPasteImagePath?: (path: string) => void | Promise<void>;
 	/** Called when the configured raw text-paste shortcut is pressed. */
 	onPasteTextRaw?: () => void;
-	/** Called when the configured dequeue shortcut is pressed. */
+	/** Called when the configured steering-dequeue shortcut is pressed. */
 	onDequeue?: () => void;
+	/** Called when the configured follow-up dequeue shortcut is pressed. */
+	onDequeueFollowUp?: () => void;
 	/** Called when the configured retry shortcut is pressed. */
 	onRetry?: () => void;
 	/** Called when Caps Lock is pressed. */
@@ -954,9 +958,14 @@ export class CustomEditor extends Editor {
 				return;
 			}
 
-			// Intercept configured dequeue shortcut (restore queued message to editor)
+			// Intercept configured dequeue shortcuts (restore queued messages to editor)
 			if (this.#matchesAction(canonical, "app.message.dequeue") && this.onDequeue) {
 				this.onDequeue();
+				return;
+			}
+
+			if (this.#matchesAction(canonical, "app.message.dequeueFollowUp") && this.onDequeueFollowUp) {
+				this.onDequeueFollowUp();
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -459,6 +459,11 @@ export class InputController {
 		this.ctx.editor.onExpandTools = () => this.toggleToolOutputExpansion();
 		this.ctx.editor.setActionKeys("app.message.dequeue", this.ctx.keybindings.getKeys("app.message.dequeue"));
 		this.ctx.editor.onDequeue = () => this.handleDequeue();
+		this.ctx.editor.setActionKeys(
+			"app.message.dequeueFollowUp",
+			this.ctx.keybindings.getKeys("app.message.dequeueFollowUp"),
+		);
+		this.ctx.editor.onDequeueFollowUp = () => this.handleDequeue("followUp");
 		this.ctx.editor.setActionKeys("app.retry", this.ctx.keybindings.getKeys("app.retry"));
 		this.ctx.editor.onRetry = () => void this.handleRetry();
 		this.ctx.editor.clearCustomKeyHandlers();
@@ -1091,12 +1096,13 @@ export class InputController {
 		}
 	}
 
-	handleDequeue(): void {
-		const restored = this.restoreQueuedMessagesToEditor();
+	handleDequeue(queue: "steering" | "followUp" = "steering"): void {
+		const restored = this.restoreQueuedMessagesToEditor({ queue });
+		const noun = queue === "steering" ? "steering" : "follow-up";
 		if (restored === 0) {
-			this.ctx.showStatus("No queued messages to restore");
+			this.ctx.showStatus(`No ${noun} messages to restore`);
 		} else {
-			this.ctx.showStatus(`Restored ${restored} queued message${restored > 1 ? "s" : ""} to editor`);
+			this.ctx.showStatus(`Restored ${restored} ${noun} message${restored > 1 ? "s" : ""} to editor`);
 		}
 	}
 
@@ -1371,24 +1377,42 @@ export class InputController {
 		}
 	}
 
-	restoreQueuedMessagesToEditor(options?: { abort?: boolean; currentText?: string }): number {
+	restoreQueuedMessagesToEditor(options?: {
+		abort?: boolean;
+		currentText?: string;
+		queue?: "steering" | "followUp";
+	}): number {
 		this.ctx.locallySubmittedUserSignatures.clear();
 		// On Esc (abort) drop non-user internal steers so the post-abort drain can't
-		// auto-resume; plain Alt+Up dequeue preserves them for the continuing stream.
-		const { steering, followUp } = this.ctx.session.clearQueue({ forInterrupt: options?.abort });
+		// auto-resume; a plain dequeue preserves them for the continuing stream.
+		const wantSteering = options?.queue !== "followUp";
+		const wantFollowUp = options?.queue !== "steering";
+		const { steering, followUp } = this.ctx.session.clearQueue({
+			forInterrupt: options?.abort,
+			only: options?.queue,
+		});
 		// Messages typed while compacting live in `compactionQueuedMessages`, not the
 		// agent queue `clearQueue()` drains — but the pending bar shows the same
-		// "Alt+Up to edit" hint for them (ui-helpers `updatePendingMessagesDisplay`).
+		// "to edit" hint for them (ui-helpers `updatePendingMessagesDisplay`).
 		// Drain them here too so the dequeue restores every message the hint
 		// advertises; otherwise a skill/text queued during compaction is stranded and
-		// Alt+Up reports "No queued messages to restore".
+		// the dequeue reports "No <queue> messages to restore".
 		const compactionQueued = this.ctx.compactionQueuedMessages;
-		this.ctx.compactionQueuedMessages = [];
+		// Retain the half this dequeue did not claim; a steering dequeue must not
+		// swallow follow-ups typed during compaction. Note the literals differ:
+		// compaction entries use `"steer"`, the queue selector uses `"steering"`.
+		this.ctx.compactionQueuedMessages = compactionQueued.filter(entry =>
+			entry.mode === "steer" ? !wantSteering : !wantFollowUp,
+		);
 		const allQueued = [
-			...steering,
-			...compactionQueued.filter(e => e.mode === "steer").map(e => ({ text: e.text, images: e.images })),
-			...followUp,
-			...compactionQueued.filter(e => e.mode === "followUp").map(e => ({ text: e.text, images: e.images })),
+			...(wantSteering ? steering : []),
+			...(wantSteering
+				? compactionQueued.filter(e => e.mode === "steer").map(e => ({ text: e.text, images: e.images }))
+				: []),
+			...(wantFollowUp ? followUp : []),
+			...(wantFollowUp
+				? compactionQueued.filter(e => e.mode === "followUp").map(e => ({ text: e.text, images: e.images }))
+				: []),
 		];
 		if (allQueued.length === 0) {
 			this.ctx.updatePendingMessagesDisplay();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1382,15 +1382,29 @@ export class InputController {
 		currentText?: string;
 		queue?: "steering" | "followUp";
 	}): number {
-		this.ctx.locallySubmittedUserSignatures.clear();
 		// On Esc (abort) drop non-user internal steers so the post-abort drain can't
 		// auto-resume; a plain dequeue preserves them for the continuing stream.
 		const wantSteering = options?.queue !== "followUp";
 		const wantFollowUp = options?.queue !== "steering";
-		const { steering, followUp } = this.ctx.session.clearQueue({
+		// The pending bar advertises the *viewed* session's queue, so drain that
+		// one — when a subagent is focused `viewSession` diverges from `session`,
+		// and draining the parent can neither restore what the bar shows nor avoid
+		// discarding unrelated parent messages.
+		const { steering, followUp } = this.ctx.viewSession.clearQueue({
 			forInterrupt: options?.abort,
 			only: options?.queue,
 		});
+		// Drop the draft-protection signature only for messages pulled back into
+		// the editor. The retained queue keeps its signatures, so when one of its
+		// messages is later delivered `#handleMessageStart` still finds a match and
+		// leaves the restored draft intact (it clears the editor only when the
+		// signature is absent). A blanket `.clear()` would strand the retained
+		// half's signatures and let the delivery wipe the just-restored draft.
+		// `clearQueue({ only })` returns an empty array for the queue it left alone,
+		// so iterating both covers exactly the restored messages.
+		for (const restored of [...steering, ...followUp]) {
+			this.ctx.locallySubmittedUserSignatures.delete(`${restored.text}\u0000${restored.images?.length ?? 0}`);
+		}
 		// Messages typed while compacting live in `compactionQueuedMessages`, not the
 		// agent queue `clearQueue()` drains — but the pending bar shows the same
 		// "to edit" hint for them (ui-helpers `updatePendingMessagesDisplay`).

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -774,13 +774,19 @@ export class UiHelpers {
 		}
 
 		const groups = [
-			{ label: "Steering", messages: steeringMessages },
-			{ label: "After yield", messages: followUpMessages },
+			{ label: "Steering", messages: steeringMessages, action: "app.message.dequeue" as const },
+			{ label: "After yield", messages: followUpMessages, action: "app.message.dequeueFollowUp" as const },
 		].filter(group => group.messages.length > 0);
 		if (groups.length > 0) {
 			this.ctx.pendingMessagesContainer.addChild(new Spacer(1));
 			for (const group of groups) {
-				const heading = theme.fg("muted", `${group.label}${theme.sep.dot}${group.messages.length}`);
+				// The key rides its own group so the bar never advertises a shortcut
+				// that would answer "no messages to restore".
+				const key = this.ctx.keybindings.getDisplayString(group.action);
+				const label = `${group.label}${theme.sep.dot}${group.messages.length}`;
+				const heading = key
+					? `${theme.fg("muted", label)}${theme.fg("dim", `  ${key} to edit`)}`
+					: theme.fg("muted", label);
 				this.ctx.pendingMessagesContainer.addChild(new TruncatedText(heading, 1, 0));
 				for (let index = 0; index < group.messages.length; index++) {
 					const message = replaceTabs(group.messages[index] ?? "").replace(/\r?\n/g, " ↵ ");
@@ -788,9 +794,6 @@ export class UiHelpers {
 					this.ctx.pendingMessagesContainer.addChild(new TruncatedText(queuedText, 1, 0));
 				}
 			}
-			const dequeueKey = this.ctx.keybindings.getDisplayString("app.message.dequeue") || "Alt+Up";
-			const hintText = theme.fg("dim", `  ${theme.tree.hook} ${dequeueKey} to edit`);
-			this.ctx.pendingMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
 		}
 		this.ctx.ui.requestComponentRender(this.ctx.pendingMessagesContainer);
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5752,19 +5752,25 @@ export class AgentSession {
 	 *  kept (abort()'s #extractQueuedAdvisorCards preserves them as visible advice) and every other
 	 *  non-user steer (hidden goal/plan/budget, IRC/extension asides) is dropped, so abort()'s
 	 *  #drainStrandedQueuedMessages can't auto-resume the run the user just interrupted (the drain only
-	 *  fires while agent.hasQueuedMessages()). Plain Alt+Up dequeue preserves those non-user steers. */
-	clearQueue(options?: { forInterrupt?: boolean }): {
+	 *  fires while agent.hasQueuedMessages()). A plain dequeue preserves those non-user steers.
+	 *  `only` restricts the drain to one queue; the other is returned empty and left untouched. */
+	clearQueue(options?: { forInterrupt?: boolean; only?: "steering" | "followUp" }): {
 		steering: RestoredQueuedMessage[];
 		followUp: RestoredQueuedMessage[];
 	} {
 		const steeringAll = this.agent.peekSteeringQueue();
 		const followUpAll = this.agent.peekFollowUpQueue();
-		const steering = steeringAll.filter(isUserQueuedMessage).map(toRestoredQueuedMessage);
-		const followUp = followUpAll.filter(isUserQueuedMessage).map(toRestoredQueuedMessage);
+		const takeSteering = options?.only !== "followUp";
+		const takeFollowUp = options?.only !== "steering";
+		const steering = takeSteering ? steeringAll.filter(isUserQueuedMessage).map(toRestoredQueuedMessage) : [];
+		const followUp = takeFollowUp ? followUpAll.filter(isUserQueuedMessage).map(toRestoredQueuedMessage) : [];
 		const keep: (m: AgentMessage) => boolean = options?.forInterrupt
 			? isAdvisorCard
 			: m => !isUserQueuedMessage(m) && !isHiddenUserCompanion(m);
-		this.agent.replaceQueues(steeringAll.filter(keep), followUpAll.filter(keep));
+		this.agent.replaceQueues(
+			takeSteering ? steeringAll.filter(keep) : steeringAll,
+			takeFollowUp ? followUpAll.filter(keep) : followUpAll,
+		);
 		return { steering, followUp };
 	}
 

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { CustomEditor } from "@oh-my-pi/pi-coding-agent/modes/components/custom-editor";
 import { getEditorTheme, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
@@ -43,5 +44,10 @@ describe("CustomEditor keybindings", () => {
 
 		expect(onCopyPrompt).toHaveBeenCalledTimes(1);
 		expect(onRetry).not.toHaveBeenCalled();
+	});
+
+	it("binds ctrl+shift+up to the follow-up dequeue", () => {
+		const keybindings = KeybindingsManager.inMemory();
+		expect(keybindings.getKeys("app.message.dequeueFollowUp")).toEqual(["ctrl+shift+up"]);
 	});
 });

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -46,6 +46,25 @@ describe("CustomEditor keybindings", () => {
 		expect(onRetry).not.toHaveBeenCalled();
 	});
 
+	it("routes each dequeue chord to its own handler through handleInput", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onDequeue = vi.fn();
+		const onDequeueFollowUp = vi.fn();
+
+		editor.onDequeue = onDequeue;
+		editor.onDequeueFollowUp = onDequeueFollowUp;
+
+		// ctrl+shift+up must not fall through to the steering dequeue, whose own
+		// binding is checked first in the dispatch chain.
+		editor.handleInput("\x1b[1;6A");
+		expect(onDequeueFollowUp).toHaveBeenCalledTimes(1);
+		expect(onDequeue).not.toHaveBeenCalled();
+
+		editor.handleInput("\x1b[1;3A");
+		expect(onDequeue).toHaveBeenCalledTimes(1);
+		expect(onDequeueFollowUp).toHaveBeenCalledTimes(1);
+	});
+
 	it("binds ctrl+shift+up to the follow-up dequeue", () => {
 		const keybindings = KeybindingsManager.inMemory();
 		expect(keybindings.getKeys("app.message.dequeueFollowUp")).toEqual(["ctrl+shift+up"]);

--- a/packages/coding-agent/test/input-controller-compaction-image.test.ts
+++ b/packages/coding-agent/test/input-controller-compaction-image.test.ts
@@ -61,6 +61,7 @@ function makeCtx(initialQueue: CompactionQueuedMessage[] = []) {
 
 	const ctx = {
 		session,
+		viewSession: session,
 		compactionQueuedMessages: [...initialQueue],
 		pendingMessagesContainer: { clear: () => {}, addChild: () => {}, removeChild: () => {} },
 		editor: {
@@ -214,6 +215,7 @@ describe("restoreQueuedMessagesToEditor image marker alignment", () => {
 		};
 		const ctx = {
 			session,
+			viewSession: session,
 			editor,
 			compactionQueuedMessages: [],
 			locallySubmittedUserSignatures: new Set<string>(),

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -173,6 +173,7 @@ function createContext(): {
 			}),
 		} as unknown as InteractiveModeContext["session"],
 		viewSession: {
+			clearQueue,
 			isCompacting: false,
 			isGeneratingHandoff: false,
 			isRetrying: false,

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -23,6 +23,8 @@ type FakeEditor = {
 	onToggleThinking?: () => void;
 	onExternalEditor?: () => void;
 	onRetry?: () => void;
+	onDequeue?: () => void;
+	onDequeueFollowUp?: () => void;
 	onChange?: (text: string) => void;
 	onSubmit?: (text: string) => Promise<void>;
 	setText(text: string): void;
@@ -85,6 +87,18 @@ async function createContext() {
 	const prompt = vi.fn(async () => {});
 	const retry = vi.fn(async () => true);
 	const abort = vi.fn(async () => {});
+	// Mutable agent-queue fixtures backing the fake `clearQueue`. The test seeds
+	// them; `clearQueue` drains (empties) the claimed side and leaves the other.
+	const steeringQueue: { text: string; images?: ImageContent[] }[] = [];
+	const followUpQueue: { text: string; images?: ImageContent[] }[] = [];
+	const clearQueue = vi.fn((options?: { forInterrupt?: boolean; only?: "steering" | "followUp" }) => {
+		const takeSteering = options?.only !== "followUp";
+		const takeFollowUp = options?.only !== "steering";
+		const steering = takeSteering ? steeringQueue.splice(0) : [];
+		const followUp = takeFollowUp ? followUpQueue.splice(0) : [];
+		return { steering, followUp };
+	});
+
 	const session = {
 		isStreaming: false,
 		isCompacting: false,
@@ -96,6 +110,7 @@ async function createContext() {
 		queuedMessageCount: 0,
 		abort,
 		retry,
+		clearQueue,
 	};
 	const updatePendingMessagesDisplay = vi.fn();
 	const handleBtwBranchKey = vi.fn(async () => true);
@@ -183,6 +198,7 @@ async function createContext() {
 			}
 		},
 		updatePendingMessagesDisplay,
+		compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp"; images?: ImageContent[] }>,
 		isBashMode: false,
 		isPythonMode: false,
 		handleHotkeysCommand: vi.fn(),
@@ -211,6 +227,8 @@ async function createContext() {
 		ctx,
 		editor,
 		customHandlers,
+		steeringQueue,
+		followUpQueue,
 		setFocused(target: unknown) {
 			focused = target;
 		},
@@ -230,6 +248,7 @@ async function createContext() {
 			handleBtwCopyKey,
 			canCopyBtw,
 			showError,
+			clearQueue,
 		},
 	};
 }
@@ -613,5 +632,53 @@ describe("InputController keybinding setup", () => {
 				userInitiated: true,
 			});
 		}
+	});
+	it("restores only the follow-up queue, then the steering queue, on a split dequeue", async () => {
+		const { InputController, ctx, editor, steeringQueue, followUpQueue } = await createContext();
+		steeringQueue.push({ text: "steer one" });
+		followUpQueue.push({ text: "follow one" });
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		expect(editor.onDequeue).toBeDefined();
+		expect(editor.onDequeueFollowUp).toBeDefined();
+
+		// Follow-up dequeue claims only the follow-up message; the steering
+		// message stays queued for a later dequeue.
+		editor.onDequeueFollowUp?.();
+		expect(editor.getText()).toContain("follow one");
+		expect(editor.getText()).not.toContain("steer one");
+		expect(steeringQueue).toHaveLength(1);
+
+		// Steering dequeue then restores the remaining steering message.
+		editor.onDequeue?.();
+		expect(editor.getText()).toContain("steer one");
+	});
+
+	it("drains only the matching compaction half on a steering dequeue and all of it on Esc", async () => {
+		const { InputController, ctx, editor } = await createContext();
+		const seedCompaction = () => {
+			ctx.compactionQueuedMessages = [
+				{ text: "c-steer", mode: "steer" },
+				{ text: "c-follow", mode: "followUp" },
+			];
+		};
+		seedCompaction();
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		// A steering dequeue claims the steer entry and leaves the follow-up
+		// entry behind — the retention filter is the easy part to get backwards.
+		editor.onDequeue?.();
+		expect(editor.getText()).toContain("c-steer");
+		expect(editor.getText()).not.toContain("c-follow");
+		expect(ctx.compactionQueuedMessages).toHaveLength(1);
+		expect(ctx.compactionQueuedMessages[0]?.text).toBe("c-follow");
+
+		// Esc-style restore (no `queue`) drains every compaction half.
+		editor.setText("");
+		seedCompaction();
+		controller.restoreQueuedMessagesToEditor({ abort: true });
+		expect(ctx.compactionQueuedMessages).toHaveLength(0);
 	});
 });

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -681,4 +681,64 @@ describe("InputController keybinding setup", () => {
 		controller.restoreQueuedMessagesToEditor({ abort: true });
 		expect(ctx.compactionQueuedMessages).toHaveLength(0);
 	});
+	it("preserves the retained queue's draft-protection signature on a selective dequeue", async () => {
+		const { InputController, ctx, editor, steeringQueue, followUpQueue } = await createContext();
+		steeringQueue.push({ text: "steer one" });
+		followUpQueue.push({ text: "follow one" });
+		// Both messages were locally submitted when queued, so their draft-protection
+		// signatures live in the set until delivery consumes them (#handleMessageStart
+		// clears the editor only when the delivered signature is absent).
+		ctx.locallySubmittedUserSignatures.add("steer one\u00000");
+		ctx.locallySubmittedUserSignatures.add("follow one\u00000");
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		// Dequeue ONLY the follow-up; the steering message stays queued.
+		editor.onDequeueFollowUp?.();
+
+		// The retained steering message keeps its signature, so delivering it later
+		// still matches and #handleMessageStart leaves the editor alone — the
+		// restored draft survives. Previously a blanket `.clear()` stranded the
+		// retained signature and let the delivery wipe the just-restored draft.
+		expect(ctx.locallySubmittedUserSignatures.has("steer one\u00000")).toBe(true);
+		// The restored follow-up's own signature is removed (it is back in the
+		// editor, no longer pending delivery).
+		expect(ctx.locallySubmittedUserSignatures.has("follow one\u00000")).toBe(false);
+		expect(editor.getText()).toContain("follow one");
+	});
+
+	it("preserves the retained follow-up signature on an empty steering dequeue", async () => {
+		const { InputController, ctx, editor, followUpQueue } = await createContext();
+		// Only a follow-up is queued. A steering dequeue restores nothing, but it
+		// must not strand the follow-up's signature either — else that message's
+		// later delivery would not match and would erase the restored draft.
+		followUpQueue.push({ text: "follow one" });
+		ctx.locallySubmittedUserSignatures.add("follow one\u00000");
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		editor.onDequeue?.();
+
+		expect(ctx.locallySubmittedUserSignatures.has("follow one\u00000")).toBe(true);
+		expect(editor.getText()).toBe("");
+	});
+
+	it("drains the viewed session's queue on dequeue, not the parent session's", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		// Focused subagent: the pending bar reads viewSession, so the dequeue must
+		// drain viewSession too — otherwise it can neither restore what the bar
+		// advertises nor avoid discarding unrelated parent messages.
+		const viewClearQueue = vi.fn(() => ({ steering: [{ text: "view-steer" }], followUp: [] }));
+		(ctx as unknown as { viewSession: { clearQueue: typeof viewClearQueue } }).viewSession = {
+			clearQueue: viewClearQueue,
+		};
+		const controller = new InputController(ctx);
+		controller.setupKeyHandlers();
+
+		editor.onDequeue?.();
+
+		expect(viewClearQueue).toHaveBeenCalledTimes(1);
+		expect(spies.clearQueue).not.toHaveBeenCalled();
+		expect(editor.getText()).toContain("view-steer");
+	});
 });

--- a/packages/coding-agent/test/input-controller-orphan-submit.test.ts
+++ b/packages/coding-agent/test/input-controller-orphan-submit.test.ts
@@ -84,6 +84,9 @@ function createContext(sessionOverride?: InteractiveModeContext["session"]) {
 		editor: editor as unknown as InteractiveModeContext["editor"],
 		ui: { requestRender } as unknown as InteractiveModeContext["ui"],
 		session,
+		// No subagent is focused in these scenarios, so the viewed session is the
+		// session itself — the dequeue reads `viewSession`, matching the pending bar.
+		viewSession: session,
 		sessionManager: { getSessionName: () => "named-session" } as InteractiveModeContext["sessionManager"],
 		compactionQueuedMessages: [] as InteractiveModeContext["compactionQueuedMessages"],
 		fileSlashCommands: new Set<string>(),

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -662,7 +662,7 @@ function createStubInteractiveModeContextForUiHelpers(session: AgentSession) {
 		viewSession: session,
 		compactionQueuedMessages: [],
 		keybindings: {
-			getDisplayString: (_action: string) => "Alt+Up",
+			getDisplayString: (action: string) => (action === "app.message.dequeueFollowUp" ? "Ctrl+Shift+Up" : "Alt+Up"),
 		},
 		updatePendingMessagesDisplay,
 		locallySubmittedUserSignatures: new Set<string>(),
@@ -746,6 +746,32 @@ describe("UiHelpers / InputController against derived queued custom display", ()
 		expect(rendered).toContain("2. run tests");
 		expect(rendered).toContain("3. summarize");
 		expect(rendered).not.toContain("Follow-up:");
+	});
+
+	it("labels each pending group with its own dequeue key", async () => {
+		fixture = await createRealSession();
+		const { session } = fixture;
+		queueUserSteer(session, "steer me");
+		session.agent.followUp({
+			role: "user",
+			content: "later please",
+			attribution: "user",
+			timestamp: Date.now(),
+		});
+
+		const { ctx, pendingMessagesContainer } = createStubInteractiveModeContextForUiHelpers(session);
+		new UiHelpers(ctx).updatePendingMessagesDisplay();
+
+		const lines = Bun.stripANSI(pendingMessagesContainer.render(120).join("\n")).split("\n");
+		const steeringHeading = lines.find(line => line.includes("Steering · 1"));
+		const followUpHeading = lines.find(line => line.includes("After yield · 1"));
+
+		// Each group advertises only the key that restores it, so neither key can
+		// answer "no messages to restore".
+		expect(steeringHeading).toContain("Alt+Up to edit");
+		expect(steeringHeading).not.toContain("Ctrl+Shift+Up");
+		expect(followUpHeading).toContain("Ctrl+Shift+Up to edit");
+		expect(followUpHeading).not.toContain("Alt+Up to edit");
 	});
 
 	it("restores the compact slash form into the editor and clears the queue", async () => {


### PR DESCRIPTION
One key restored both queues at once. Users fill them for different purposes — steering redirects the running turn, follow-ups wait for it to yield — so restoring both to edit one was destructive.

`Ctrl+Shift+Up` now restores follow-ups only; the existing dequeue key restores steering only.

| Key | Restores |
|---|---|
| `Alt+Up` (`app.message.dequeue`) | steering only |
| `Ctrl+Shift+Up` (`app.message.dequeueFollowUp`) | follow-ups only |
| `Esc` | everything, unchanged |

### Selective drain

`clearQueue()` gains an `only?: "steering" \| "followUp"` option rather than a second method. Omitting it reproduces the previous behavior exactly, so the `Esc` path is untouched. The queue that is not claimed passes its unfiltered peek result straight through to `replaceQueues`, matching existing usage there.

### The compaction trap

Messages typed during compaction live in `compactionQueuedMessages`, outside the agent queues, and the pending bar advertises the same key for them — so they must be filtered on the same rule.

The literals differ: compaction entries are tagged `"steer"` while the queue selector is `"steering"`. That makes `entry.mode !== options?.queue` a plausible-looking simplification, and it is wrong in three of six cases — it retains messages already restored into the editor (the next dequeue duplicates them) and stops `Esc` draining the compaction queue at all. A test covers the exact table, and the fix was mutation-tested: substituting the wrong form makes it fail.

### Pending bar

Each group now carries its own key on its heading — `Steering · 2  Alt+Up to edit`, `After yield · 1  Ctrl+Shift+Up to edit`. A group renders only when it has messages, so neither key is advertised where it would answer "nothing to restore". The single trailing hint line is gone.

### `replaceQueues` widened to `readonly`

It already `.slice()`s both arguments, so the mutable parameter type bought nothing and only forced callers into defensive copies. Existing callers are unaffected.

### Verification

- Split behavior: a follow-up dequeue restores only the follow-up and leaves the steering message queued; a steering dequeue then restores the rest.
- Compaction split: a steering dequeue claims the `steer` entry and leaves the `followUp` entry; an `Esc` restore empties the queue entirely.
- Pending bar: each heading carries its own key and not the other's.
- Confirmed in a running TUI — `Shift+Up` reports "No steering messages to restore", `Ctrl+Shift+Up` reports "No follow-up messages to restore".

### Relationship to the other PRs

Independent of #7147, #7148, #7149 and #7154; all five base on `main`. Three of them touch the `app.message.dequeue` region: #7149 adds `shift+up` to its `defaultKeys`, #7154 adds `super+up`, and this PR adds the sibling `dequeueFollowUp` entry and rewords the description. Whichever lands last will conflict there — never take one side wholesale, or a key is dropped. #7154 carries the exact three-way resolved entry; use it verbatim.

