### PR TITLE
docs: Add link to LSP config docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Ask for a rename and you get a rename. The call goes through workspace/willRenam
 
 ![omp TUI: `LSP references` returns five hits across three files for the symbol `formatBytes`, then `LSP rename` applies the change with edits to format.ts/report.ts/cli.ts, then a `Search formatBytes 0 matches` confirmation. Final line: 'Rename complete. Five edits across three files…'.](https://omp.sh/captures/lsp.webp)
 
+_[Read the LSP config docs](docs/lsp-config.md)_
+
 ### 03 · Drives a real debugger
 
 A C binary segfaults: the agent attaches lldb, steps to the bad pointer, reads the frame. A Go service hangs: it attaches dlv and walks the goroutines. A Python process is wedged: debugpy, pause, inspect, evaluate. Most agents are still sprinkling print statements.


### PR DESCRIPTION
Added a reference to the LSP config documentation in the README.

## What

Link to the LSP docs config from the README

## Why

As a new user seeing "No LSP Servers" in the main UI, I had no idea what to do about it. The README mentions LSP without any links to further reading.

---

- [x] `bun check` passes
- [x] Tested locally