### PR TITLE
fix(session): stop repeated mid-turn compaction dead ends

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Fixed mid-turn auto-compaction repeating dead-end rescue work and warnings at every tool boundary within one oversized turn ([#7151](https://github.com/can1357/oh-my-pi/issues/7151)).
 - Fixed remote or LAN local-engine endpoints being ignored during model discovery: the llama.cpp and Ollama probes used timeouts tuned for loopback, so a host reached over the network could exceed them and return no models, while changing `OLLAMA_BASE_URL`/`OLLAMA_HOST` could keep reusing a fresh cache from the previous endpoint. Non-loopback hosts now get a generous discovery timeout, and Ollama cache rows are scoped to the normalized endpoint ([#7087](https://github.com/can1357/oh-my-pi/issues/7087)).
 - Fixed `omp install` failing extension validation for pi extensions that import `createEditTool` or `createWriteTool` (e.g. gentle-pi) — the legacy `@oh-my-pi/pi-coding-agent` shim exported the read/bash/grep/find/ls tool factories but omitted the edit and write ones, so a named import threw Bun's static "Export named X not found" error. Added `createEditTool`/`createEditToolDefinition` and `createWriteTool`/`createWriteToolDefinition` to match the upstream pi surface ([#7094](https://github.com/can1357/oh-my-pi/issues/7094)).
 - Fixed Python eval's loopback tool bridge being routed through macOS system HTTP proxies, which caused `parallel()` tool reads to fail with `ConnectionRefusedError` after a local proxy stopped.

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -268,7 +268,12 @@ export interface SessionMaintenanceHost {
 export class SessionMaintenance {
 	#compactionAbortController: AbortController | undefined;
 	#autoCompactionAbortController: AbortController | undefined;
-	/** Live tool-loop contexts whose mid-turn maintenance reached a no-progress dead end. */
+	/**
+	 * Live tool-loop contexts parked after mid-turn maintenance hit a no-progress
+	 * dead end. Membership suppresses the repeated rescue + warning while no cut
+	 * point exists; {@link maintainContextMidRun} re-arms the entry once a later
+	 * tool result makes `prepareCompaction` viable again.
+	 */
 	readonly #midTurnCompactionDeadEnds = new WeakSet<AgentMessage[]>();
 	#skipPostTurnMaintenanceAssistantTimestamp: number | undefined;
 	readonly #host: SessionMaintenanceHost;
@@ -1034,7 +1039,24 @@ export class SessionMaintenance {
 		) {
 			return;
 		}
-		if (this.#midTurnCompactionDeadEnds.has(activeMessages)) return;
+		if (this.#midTurnCompactionDeadEnds.has(activeMessages)) {
+			// A prior boundary already ran the dead-end rescue and could not reduce
+			// this turn. Re-running the rescue and re-emitting its warning on every
+			// following tool boundary is wasted work while nothing summarizable
+			// exists. But the tool loop keeps appending turns: once a later
+			// (smaller) tool result gives prepareCompaction a cut point before the
+			// now-older oversized turn, compaction can finally make progress and
+			// MUST run rather than stay suppressed until provider overflow (#7153
+			// review). Stay parked only while no cut point is available; re-arm as
+			// soon as one appears.
+			if (
+				!model ||
+				prepareCompaction(this.#host.sessionManager.getBranch(), compactionSettings, model) === undefined
+			) {
+				return;
+			}
+			this.#midTurnCompactionDeadEnds.delete(activeMessages);
+		}
 
 		const lastAssistant = [...activeMessages]
 			.reverse()

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1039,6 +1039,13 @@ export class SessionMaintenance {
 		) {
 			return;
 		}
+
+		const lastAssistant = [...activeMessages]
+			.reverse()
+			.find((message): message is AssistantMessage => message.role === "assistant");
+		if (!lastAssistant || lastAssistant.stopReason === "aborted" || lastAssistant.stopReason === "error") return;
+
+		if (!(await this.#host.persistTurnMessagesForMidRunCompaction(context))) return;
 		if (this.#midTurnCompactionDeadEnds.has(activeMessages)) {
 			// A prior boundary already ran the dead-end rescue and could not reduce
 			// this turn. Re-running the rescue and re-emitting its warning on every
@@ -1057,13 +1064,6 @@ export class SessionMaintenance {
 			}
 			this.#midTurnCompactionDeadEnds.delete(activeMessages);
 		}
-
-		const lastAssistant = [...activeMessages]
-			.reverse()
-			.find((message): message is AssistantMessage => message.role === "assistant");
-		if (!lastAssistant || lastAssistant.stopReason === "aborted" || lastAssistant.stopReason === "error") return;
-
-		if (!(await this.#host.persistTurnMessagesForMidRunCompaction(context))) return;
 
 		const billedContextTokens = calculateContextTokens(lastAssistant.usage);
 		const storedContextTokens = this.#estimateStoredContextTokens();

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -268,6 +268,8 @@ export interface SessionMaintenanceHost {
 export class SessionMaintenance {
 	#compactionAbortController: AbortController | undefined;
 	#autoCompactionAbortController: AbortController | undefined;
+	/** Live tool-loop contexts whose mid-turn maintenance reached a no-progress dead end. */
+	readonly #midTurnCompactionDeadEnds = new WeakSet<AgentMessage[]>();
 	#skipPostTurnMaintenanceAssistantTimestamp: number | undefined;
 	readonly #host: SessionMaintenanceHost;
 
@@ -1032,6 +1034,7 @@ export class SessionMaintenance {
 		) {
 			return;
 		}
+		if (this.#midTurnCompactionDeadEnds.has(activeMessages)) return;
 
 		const lastAssistant = [...activeMessages]
 			.reverse()
@@ -1061,13 +1064,16 @@ export class SessionMaintenance {
 		}
 
 		const messagesBefore = activeMessages.length;
-		await this.runAutoCompaction("threshold", false, false, false, {
+		const result = await this.runAutoCompaction("threshold", false, false, false, {
 			autoContinue: false,
 			suppressContinuation: true,
 			suppressHandoff: true,
 			triggerContextTokens: contextTokens,
 			phase: "mid_turn",
 		});
+		if (result.automaticContinuationBlocked) {
+			this.#midTurnCompactionDeadEnds.add(activeMessages);
+		}
 
 		if (signal?.aborted) return;
 		const compactedMessages = this.#host.agent.state.messages;

--- a/packages/coding-agent/test/agent-session-mid-turn-compaction-dead-end.test.ts
+++ b/packages/coding-agent/test/agent-session-mid-turn-compaction-dead-end.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
+import { z } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const noopSchema = z.object({});
+const noopTool: AgentTool<typeof noopSchema, undefined> = {
+	name: "noop",
+	label: "No-op",
+	description: "Continue the scripted tool loop",
+	parameters: noopSchema,
+	async execute() {
+		return { content: [{ type: "text", text: "continued" }], details: undefined };
+	},
+};
+
+const DEAD_END_WARNING = "Compaction freed too little context to make progress";
+
+describe("AgentSession mid-turn compaction dead-end", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage?.close();
+		await tempDir?.remove();
+		vi.restoreAllMocks();
+	});
+
+	it("attempts and warns once per oversized tool-loop turn", async () => {
+		vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(undefined);
+		tempDir = TempDir.createSync("@pi-mid-turn-compaction-dead-end-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("mock", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [{ type: "toolCall", id: "noop-1", name: "noop", arguments: {} }],
+					usage: { input: 190_000 },
+				},
+				{
+					content: [{ type: "toolCall", id: "noop-2", name: "noop", arguments: {} }],
+					usage: { input: 190_000 },
+				},
+				{ content: ["done"] },
+				{
+					content: [{ type: "toolCall", id: "noop-3", name: "noop", arguments: {} }],
+					usage: { input: 190_000 },
+				},
+				{
+					content: [{ type: "toolCall", id: "noop-4", name: "noop", arguments: {} }],
+					usage: { input: 190_000 },
+				},
+				{ content: ["done again"] },
+			],
+		});
+		vi.spyOn(modelRegistry, "getAvailable").mockReturnValue([mock]);
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: mock,
+				systemPrompt: ["Test"],
+				tools: [noopTool],
+				messages: [],
+			},
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({
+			"compaction.strategy": "context-full",
+			"compaction.thresholdTokens": 100_000,
+			"compaction.midTurnEnabled": true,
+			"compaction.autoContinue": false,
+			"retry.enabled": false,
+			"todo.enabled": false,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			toolRegistry: new Map([[noopTool.name, noopTool]]),
+		});
+		const notices: string[] = [];
+		let compactionStarts = 0;
+		session.subscribe(event => {
+			if (event.type === "notice") notices.push(event.message);
+			if (event.type === "auto_compaction_start") compactionStarts++;
+		});
+
+		await session.prompt("Run both tools before answering");
+
+		expect(mock.calls).toHaveLength(3);
+		expect(notices).toEqual([expect.stringContaining(DEAD_END_WARNING)]);
+		expect(compactionStarts).toBe(1);
+
+		await session.prompt("Run two more tools before answering");
+
+		expect(mock.calls).toHaveLength(6);
+		expect(notices).toEqual([expect.stringContaining(DEAD_END_WARNING), expect.stringContaining(DEAD_END_WARNING)]);
+		expect(compactionStarts).toBe(2);
+	});
+});

--- a/packages/coding-agent/test/agent-session-mid-turn-compaction-dead-end.test.ts
+++ b/packages/coding-agent/test/agent-session-mid-turn-compaction-dead-end.test.ts
@@ -49,6 +49,8 @@ describe("AgentSession mid-turn compaction dead-end", () => {
 		responses: MockResponse[];
 		/** Optional `session_before_compact` short-circuit so a viable compaction makes no LLM call. */
 		shortCircuitCompaction?: boolean;
+		/** Delay message-end hooks so the turn is absent until the persistence barrier resolves. */
+		delayMessageEndPersistence?: boolean;
 	}): Promise<{ notices: string[]; compactionStarts: number[]; compactionResults: number }> {
 		tempDir = TempDir.createSync("@pi-mid-turn-compaction-dead-end-");
 		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
@@ -59,14 +61,16 @@ describe("AgentSession mid-turn compaction dead-end", () => {
 
 		let extensionRunner: ExtensionRunner | undefined;
 		const sessionManager = SessionManager.inMemory(tempDir.path());
-		if (options.shortCircuitCompaction) {
+		if (options.shortCircuitCompaction || options.delayMessageEndPersistence) {
 			const extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
 			fs.mkdirSync(extensionsDir, { recursive: true });
 			const extensionPath = path.join(extensionsDir, "compaction-short-circuit.ts");
-			fs.writeFileSync(
-				extensionPath,
-				[
-					"export default function(pi) {",
+			const extensionLines = ["export default function(pi) {"];
+			if (options.delayMessageEndPersistence) {
+				extensionLines.push('\tpi.on("message_end", async () => {', "\t\tawait Bun.sleep(50);", "\t});");
+			}
+			if (options.shortCircuitCompaction) {
+				extensionLines.push(
 					'\tpi.on("session_before_compact", async (event) => ({',
 					"\t\tcompaction: {",
 					'\t\t\tsummary: "compacted",',
@@ -76,9 +80,10 @@ describe("AgentSession mid-turn compaction dead-end", () => {
 					"\t\t\tdetails: {},",
 					"\t\t},",
 					"\t}));",
-					"}",
-				].join("\n"),
-			);
+				);
+			}
+			extensionLines.push("}");
+			fs.writeFileSync(extensionPath, extensionLines.join("\n"));
 			const loaded = await loadExtensions([extensionPath], tempDir.path());
 			extensionRunner = new ExtensionRunner(
 				loaded.extensions,
@@ -154,15 +159,22 @@ describe("AgentSession mid-turn compaction dead-end", () => {
 		expect(state.compactionStarts).toHaveLength(2);
 	});
 
-	it("re-attempts compaction once a later tool result creates a cut point", async () => {
-		// Reviewer regression (#7153): the live context keeps growing, so a dead end
-		// at the first boundary MUST NOT permanently suppress maintenance. Once a
-		// later, smaller turn lets prepareCompaction cut before the now-older
-		// oversized turn, compaction has to run instead of parking until overflow.
-		let preparable = false;
-		const branch = () => session.sessionManager.getBranch();
-		const fakePreparation = (): compactionModule.CompactionPreparation => {
-			const entries = branch();
+	it("re-attempts after the new tool boundary finishes persisting", async () => {
+		// Reviewer regression (#7153): message_end persistence is fire-and-forget,
+		// so the live loop can reach onTurnEnd while the branch still lacks the
+		// just-finished assistant/toolResult pair. The re-arm probe must wait for
+		// the same persistence barrier as normal compaction; otherwise it sees the
+		// old no-cutpoint branch and sends another over-threshold provider request.
+		let cutPointSeen = false;
+		vi.spyOn(compactionModule, "prepareCompaction").mockImplementation(entries => {
+			const secondBoundaryPersisted = entries.some(
+				entry =>
+					entry.type === "message" &&
+					entry.message.role === "assistant" &&
+					entry.message.content.some(block => block.type === "toolCall" && block.id === "noop-2"),
+			);
+			if (!secondBoundaryPersisted) return undefined;
+			cutPointSeen = true;
 			const firstKeptEntryId = entries[entries.length - 1]?.id;
 			if (!firstKeptEntryId) throw new Error("branch has no entry to keep");
 			return {
@@ -175,18 +187,13 @@ describe("AgentSession mid-turn compaction dead-end", () => {
 				fileOps: { read: new Set(), written: new Set(), edited: new Set() },
 				settings: session.settings.getGroup("compaction"),
 			};
-		};
-		vi.spyOn(compactionModule, "prepareCompaction").mockImplementation(() =>
-			preparable ? fakePreparation() : undefined,
-		);
+		});
 
 		const state = await createSession({
-			responses: [toolTurn("noop-1"), toolTurn("noop-2"), toolTurn("noop-3"), { content: ["done"] }],
+			responses: [toolTurn("noop-1"), toolTurn("noop-2"), { content: ["done"] }],
 			shortCircuitCompaction: true,
+			delayMessageEndPersistence: true,
 		});
-		// The first boundary hits the no-preparation dead end (nothing summarizable
-		// and the elide rescue frees nothing). Once its warning lands, mark the
-		// context "preparable" to model the later cut point appearing.
 		vi.spyOn(session, "shake").mockResolvedValue({
 			mode: "elide",
 			toolResultsDropped: 0,
@@ -194,21 +201,15 @@ describe("AgentSession mid-turn compaction dead-end", () => {
 			tokensFreed: 0,
 		});
 		vi.spyOn(session, "getContextUsage").mockImplementation(() =>
-			preparable
+			cutPointSeen
 				? { tokens: 1_000, contextWindow: 200_000, percent: 0.5 }
 				: { tokens: 190_000, contextWindow: 200_000, percent: 95 },
 		);
-		session.subscribe(event => {
-			if (event.type === "notice" && event.message.includes(DEAD_END_WARNING)) preparable = true;
-		});
 
-		await session.prompt("Run three tools before answering");
+		await session.prompt("Run two tools before answering");
 
-		// First dead end warned once; a later boundary re-attempted (start #2) and,
-		// with a cut point now available, produced a real compaction result instead
-		// of staying parked.
-		expect(state.notices.filter(m => m.includes(DEAD_END_WARNING))).toHaveLength(1);
-		expect(state.compactionStarts.length).toBeGreaterThanOrEqual(2);
-		expect(state.compactionResults).toBeGreaterThanOrEqual(1);
+		expect(state.notices.filter(message => message.includes(DEAD_END_WARNING))).toHaveLength(1);
+		expect(state.compactionStarts).toHaveLength(2);
+		expect(state.compactionResults).toBe(1);
 	});
 });

--- a/packages/coding-agent/test/agent-session-mid-turn-compaction-dead-end.test.ts
+++ b/packages/coding-agent/test/agent-session-mid-turn-compaction-dead-end.test.ts
@@ -1,16 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import { z } from "@oh-my-pi/pi-ai";
-import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 
 const noopSchema = z.object({});
 const noopTool: AgentTool<typeof noopSchema, undefined> = {
@@ -25,6 +28,11 @@ const noopTool: AgentTool<typeof noopSchema, undefined> = {
 
 const DEAD_END_WARNING = "Compaction freed too little context to make progress";
 
+/** One threshold-tripping tool-call turn. */
+function toolTurn(id: string): MockResponse {
+	return { content: [{ type: "toolCall", id, name: "noop", arguments: {} }], usage: { input: 190_000 } };
+}
+
 describe("AgentSession mid-turn compaction dead-end", () => {
 	let tempDir: TempDir;
 	let authStorage: AuthStorage;
@@ -37,43 +45,53 @@ describe("AgentSession mid-turn compaction dead-end", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("attempts and warns once per oversized tool-loop turn", async () => {
-		vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(undefined);
+	async function createSession(options: {
+		responses: MockResponse[];
+		/** Optional `session_before_compact` short-circuit so a viable compaction makes no LLM call. */
+		shortCircuitCompaction?: boolean;
+	}): Promise<{ notices: string[]; compactionStarts: number[]; compactionResults: number }> {
 		tempDir = TempDir.createSync("@pi-mid-turn-compaction-dead-end-");
 		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
 		authStorage.setRuntimeApiKey("mock", "test-key");
 		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
-		const mock = createMockModel({
-			responses: [
-				{
-					content: [{ type: "toolCall", id: "noop-1", name: "noop", arguments: {} }],
-					usage: { input: 190_000 },
-				},
-				{
-					content: [{ type: "toolCall", id: "noop-2", name: "noop", arguments: {} }],
-					usage: { input: 190_000 },
-				},
-				{ content: ["done"] },
-				{
-					content: [{ type: "toolCall", id: "noop-3", name: "noop", arguments: {} }],
-					usage: { input: 190_000 },
-				},
-				{
-					content: [{ type: "toolCall", id: "noop-4", name: "noop", arguments: {} }],
-					usage: { input: 190_000 },
-				},
-				{ content: ["done again"] },
-			],
-		});
+		const mock = createMockModel({ responses: options.responses });
 		vi.spyOn(modelRegistry, "getAvailable").mockReturnValue([mock]);
+
+		let extensionRunner: ExtensionRunner | undefined;
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+		if (options.shortCircuitCompaction) {
+			const extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
+			fs.mkdirSync(extensionsDir, { recursive: true });
+			const extensionPath = path.join(extensionsDir, "compaction-short-circuit.ts");
+			fs.writeFileSync(
+				extensionPath,
+				[
+					"export default function(pi) {",
+					'\tpi.on("session_before_compact", async (event) => ({',
+					"\t\tcompaction: {",
+					'\t\t\tsummary: "compacted",',
+					"\t\t\tshortSummary: undefined,",
+					"\t\t\tfirstKeptEntryId: event.preparation.firstKeptEntryId,",
+					"\t\t\ttokensBefore: event.preparation.tokensBefore,",
+					"\t\t\tdetails: {},",
+					"\t\t},",
+					"\t}));",
+					"}",
+				].join("\n"),
+			);
+			const loaded = await loadExtensions([extensionPath], tempDir.path());
+			extensionRunner = new ExtensionRunner(
+				loaded.extensions,
+				loaded.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+		}
+
 		const agent = new Agent({
 			getApiKey: () => "test-key",
-			initialState: {
-				model: mock,
-				systemPrompt: ["Test"],
-				tools: [noopTool],
-				messages: [],
-			},
+			initialState: { model: mock, systemPrompt: ["Test"], tools: [noopTool], messages: [] },
 			convertToLlm,
 			streamFn: mock.stream,
 		});
@@ -87,28 +105,110 @@ describe("AgentSession mid-turn compaction dead-end", () => {
 		});
 		session = new AgentSession({
 			agent,
-			sessionManager: SessionManager.inMemory(tempDir.path()),
+			sessionManager,
 			settings,
 			modelRegistry,
 			toolRegistry: new Map([[noopTool.name, noopTool]]),
+			extensionRunner,
 		});
+
 		const notices: string[] = [];
-		let compactionStarts = 0;
+		const compactionStarts: number[] = [];
+		const compactionResults = 0;
+		const state = { notices, compactionStarts, compactionResults };
 		session.subscribe(event => {
 			if (event.type === "notice") notices.push(event.message);
-			if (event.type === "auto_compaction_start") compactionStarts++;
+			else if (event.type === "auto_compaction_start") compactionStarts.push(1);
+			else if (event.type === "auto_compaction_end" && event.result) state.compactionResults++;
+		});
+		return state;
+	}
+
+	it("attempts and warns once per oversized tool-loop turn when no cut point ever appears", async () => {
+		// The genuinely-unrecoverable shape: prepareCompaction can never find a cut
+		// point (the whole oversized region is the most recent turn). Re-running the
+		// rescue and re-emitting the warning on every following tool boundary is
+		// wasted work, so it must fire exactly once per turn — and re-arm cleanly
+		// for the next user turn.
+		vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(undefined);
+		const state = await createSession({
+			responses: [
+				toolTurn("noop-1"),
+				toolTurn("noop-2"),
+				{ content: ["done"] },
+				toolTurn("noop-3"),
+				toolTurn("noop-4"),
+				{ content: ["done again"] },
+			],
 		});
 
 		await session.prompt("Run both tools before answering");
-
-		expect(mock.calls).toHaveLength(3);
-		expect(notices).toEqual([expect.stringContaining(DEAD_END_WARNING)]);
-		expect(compactionStarts).toBe(1);
+		expect(state.notices).toEqual([expect.stringContaining(DEAD_END_WARNING)]);
+		expect(state.compactionStarts).toHaveLength(1);
 
 		await session.prompt("Run two more tools before answering");
+		expect(state.notices).toEqual([
+			expect.stringContaining(DEAD_END_WARNING),
+			expect.stringContaining(DEAD_END_WARNING),
+		]);
+		expect(state.compactionStarts).toHaveLength(2);
+	});
 
-		expect(mock.calls).toHaveLength(6);
-		expect(notices).toEqual([expect.stringContaining(DEAD_END_WARNING), expect.stringContaining(DEAD_END_WARNING)]);
-		expect(compactionStarts).toBe(2);
+	it("re-attempts compaction once a later tool result creates a cut point", async () => {
+		// Reviewer regression (#7153): the live context keeps growing, so a dead end
+		// at the first boundary MUST NOT permanently suppress maintenance. Once a
+		// later, smaller turn lets prepareCompaction cut before the now-older
+		// oversized turn, compaction has to run instead of parking until overflow.
+		let preparable = false;
+		const branch = () => session.sessionManager.getBranch();
+		const fakePreparation = (): compactionModule.CompactionPreparation => {
+			const entries = branch();
+			const firstKeptEntryId = entries[entries.length - 1]?.id;
+			if (!firstKeptEntryId) throw new Error("branch has no entry to keep");
+			return {
+				firstKeptEntryId,
+				messagesToSummarize: [{ role: "user", content: "old", timestamp: Date.now() }],
+				turnPrefixMessages: [],
+				recentMessages: [],
+				isSplitTurn: false,
+				tokensBefore: 190_000,
+				fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+				settings: session.settings.getGroup("compaction"),
+			};
+		};
+		vi.spyOn(compactionModule, "prepareCompaction").mockImplementation(() =>
+			preparable ? fakePreparation() : undefined,
+		);
+
+		const state = await createSession({
+			responses: [toolTurn("noop-1"), toolTurn("noop-2"), toolTurn("noop-3"), { content: ["done"] }],
+			shortCircuitCompaction: true,
+		});
+		// The first boundary hits the no-preparation dead end (nothing summarizable
+		// and the elide rescue frees nothing). Once its warning lands, mark the
+		// context "preparable" to model the later cut point appearing.
+		vi.spyOn(session, "shake").mockResolvedValue({
+			mode: "elide",
+			toolResultsDropped: 0,
+			blocksDropped: 0,
+			tokensFreed: 0,
+		});
+		vi.spyOn(session, "getContextUsage").mockImplementation(() =>
+			preparable
+				? { tokens: 1_000, contextWindow: 200_000, percent: 0.5 }
+				: { tokens: 190_000, contextWindow: 200_000, percent: 95 },
+		);
+		session.subscribe(event => {
+			if (event.type === "notice" && event.message.includes(DEAD_END_WARNING)) preparable = true;
+		});
+
+		await session.prompt("Run three tools before answering");
+
+		// First dead end warned once; a later boundary re-attempted (start #2) and,
+		// with a cut point now available, produced a real compaction result instead
+		// of staying parked.
+		expect(state.notices.filter(m => m.includes(DEAD_END_WARNING))).toHaveLength(1);
+		expect(state.compactionStarts.length).toBeGreaterThanOrEqual(2);
+		expect(state.compactionResults).toBeGreaterThanOrEqual(1);
 	});
 });


### PR DESCRIPTION
## Repro
A scripted agent turn issues two tool calls whose reported 190k-token contexts both exceed a 100k compaction threshold while `prepareCompaction` has no earlier turn to summarize. `bun test packages/coding-agent/test/agent-session-mid-turn-compaction-dead-end.test.ts` reproduced two `auto_compaction_start` events where one dead-end episode should attempt once.

## Cause
`SessionMaintenance.maintainContextMidRun()` in `packages/coding-agent/src/session/session-maintenance.ts` awaited `runAutoCompaction()` but discarded its `automaticContinuationBlocked` result, so every continuing tool boundary re-entered the same dead-end rescue and notice path.

## Fix
- Remember dead-ended live agent-loop message contexts in a `WeakSet` and skip subsequent mid-turn maintenance for that context.
- Let a new agent-loop context attempt maintenance normally, making suppression per turn rather than session-wide.
- Add a two-turn regression proving one attempt and warning per oversized tool-loop turn.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/agent-session-mid-turn-compaction-dead-end.test.ts packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts` passed 29 tests with 106 assertions. `bun run check:types` passed in `packages/coding-agent`. The `gh_push_branch` pre-publish `bun run fix` and `bun check` gate also passed. Fixes #7151