### PR TITLE
feat(keybindings): give alt-only app bindings a macOS Command chord

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added macOS Command chords to the alt-only app bindings that the Ctrl mirror cannot reach: dequeue, model select, plan toggle, copy prompt, and copy line. Retry, temporary model select, and the agent hub stay Option-only because a mirrored Ctrl binding already owns their Command chord.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -70,6 +70,15 @@ export function getDefaultPasteImageKeys(platform: NodeJS.Platform = process.pla
 	return ["ctrl+v"];
 }
 
+/** Alt-only bindings get no Command form from the darwin ctrl→super mirror, so the
+ *  Command chord is spelled out here. Deliberately absent: super+r, super+p and
+ *  super+a, which a mirrored ctrl binding (history.search, model.cycleForward,
+ *  cursorLineStart) already claims — retry, selectTemporary and agents.hub stay
+ *  Option-only rather than shadow them. */
+export function withMacCommand(keys: KeyId[], command: KeyId, platform: NodeJS.Platform = process.platform): KeyId[] {
+	return platform === "darwin" ? [...keys, command] : keys;
+}
+
 /**
  * All keybindings definitions: TUI + app-specific.
  */
@@ -112,7 +121,7 @@ export const KEYBINDINGS = {
 		description: "Cycle to previous model",
 	},
 	"app.model.select": {
-		defaultKeys: "alt+m",
+		defaultKeys: withMacCommand(["alt+m"], "super+m"),
 		description: "Select model",
 	},
 	"app.model.selectTemporary": {
@@ -139,7 +148,7 @@ export const KEYBINDINGS = {
 		description: "Retry last failed assistant turn",
 	},
 	"app.message.dequeue": {
-		defaultKeys: "alt+up",
+		defaultKeys: withMacCommand(["alt+up"], "super+up"),
 		description: "Dequeue message",
 	},
 	"app.clipboard.pasteImage": {
@@ -151,11 +160,11 @@ export const KEYBINDINGS = {
 		description: "Paste text from clipboard as raw text (no collapse)",
 	},
 	"app.clipboard.copyLine": {
-		defaultKeys: "alt+shift+l",
+		defaultKeys: withMacCommand(["alt+shift+l"], "super+shift+l"),
 		description: "Copy current line",
 	},
 	"app.clipboard.copyPrompt": {
-		defaultKeys: "alt+shift+c",
+		defaultKeys: withMacCommand(["alt+shift+c"], "super+shift+c"),
 		description: "Copy prompt",
 	},
 	"app.session.new": {
@@ -211,7 +220,7 @@ export const KEYBINDINGS = {
 		description: "Unfold or move down",
 	},
 	"app.plan.toggle": {
-		defaultKeys: "alt+shift+p",
+		defaultKeys: withMacCommand(["alt+shift+p"], "super+shift+p"),
 		description: "Toggle plan mode",
 	},
 	"app.history.search": {

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -11,7 +11,7 @@ import {
 	TUI,
 } from "@oh-my-pi/pi-tui";
 import { BracketedPasteHandler } from "@oh-my-pi/pi-tui/bracketed-paste";
-import type { AppKeybinding } from "../../config/keybindings";
+import { type AppKeybinding, withMacCommand } from "../../config/keybindings";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { imageReferenceHyperlink, PLACEHOLDER_REGEX, renderPlaceholders } from "../image-references";
 import { hasMagicKeyword, highlightMagicKeywords } from "../magic-keywords";
@@ -50,17 +50,17 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.thinking.cycle": ["shift+tab"],
 	"app.model.cycleForward": ["ctrl+p"],
 	"app.model.cycleBackward": ["shift+ctrl+p"],
-	"app.model.select": ["alt+m"],
+	"app.model.select": withMacCommand(["alt+m"], "super+m"),
 	"app.model.selectTemporary": ["alt+p"],
 	"app.tools.expand": ["ctrl+o"],
 	"app.thinking.toggle": ["ctrl+t"],
 	"app.editor.external": ["ctrl+g"],
 	"app.history.search": ["ctrl+r"],
-	"app.message.dequeue": ["alt+up"],
+	"app.message.dequeue": withMacCommand(["alt+up"], "super+up"),
 	"app.retry": ["alt+r"],
 	"app.clipboard.pasteImage": ["ctrl+v"],
 	"app.clipboard.pasteTextRaw": ["ctrl+shift+v", "alt+shift+v"],
-	"app.clipboard.copyPrompt": ["alt+shift+c"],
+	"app.clipboard.copyPrompt": withMacCommand(["alt+shift+c"], "super+shift+c"),
 };
 
 function buildMatchKeys(keys: readonly KeyId[]): Set<string> {

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { getDefaultPasteImageKeys, KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import {
+	getDefaultPasteImageKeys,
+	KeybindingsManager,
+	withMacCommand,
+} from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { keyText } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
 import { getKeybindings, setKeybindings, type KeybindingsManager as TuiKeybindingsManager } from "@oh-my-pi/pi-tui";
 
@@ -61,5 +65,20 @@ describe("getDefaultPasteImageKeys", () => {
 	it("adds the macOS Command key event to Ctrl+V for image paste", () => {
 		expect(getDefaultPasteImageKeys("linux")).toEqual(["ctrl+v"]);
 		expect(getDefaultPasteImageKeys("darwin")).toEqual(["ctrl+v", "super+v"]);
+	});
+});
+
+describe("withMacCommand", () => {
+	it("appends the Command chord only on darwin", () => {
+		expect(withMacCommand(["alt+up"], "super+up", "darwin")).toEqual(["alt+up", "super+up"]);
+		expect(withMacCommand(["alt+up"], "super+up", "linux")).toEqual(["alt+up"]);
+		expect(withMacCommand(["alt+up"], "super+up", "win32")).toEqual(["alt+up"]);
+	});
+
+	it("leaves retry, selectTemporary and agents.hub Option-only so they cannot shadow a mirrored ctrl chord", () => {
+		const keybindings = KeybindingsManager.inMemory();
+		for (const action of ["app.retry", "app.model.selectTemporary", "app.agents.hub"] as const) {
+			expect(keybindings.getKeys(action).some(key => key.startsWith("super+"))).toBe(false);
+		}
 	});
 });


### PR DESCRIPTION
#7147 gives macOS Command a mirror of every `ctrl+X` binding. That only reaches bindings that *have* a `ctrl` form. Ten do not — they are alt-only, so Command reaches none of them.

That includes `app.message.dequeue`, where Option is precisely the modifier macOS Terminal.app consumes for character composition. `Cmd+Up` was unbound and reached nothing.

### What changes

Five alt-only app bindings gain an explicit Command chord on darwin:

| Binding | Before | After (darwin) |
|---|---|---|
| `app.message.dequeue` | `alt+up` | `alt+up`, `super+up` |
| `app.model.select` | `alt+m` | `alt+m`, `super+m` |
| `app.plan.toggle` | `alt+shift+p` | `alt+shift+p`, `super+shift+p` |
| `app.clipboard.copyPrompt` | `alt+shift+c` | `alt+shift+c`, `super+shift+c` |
| `app.clipboard.copyLine` | `alt+shift+l` | `alt+shift+l`, `super+shift+l` |

Non-darwin is byte-identical to before.

### What is deliberately excluded

Three alt-only bindings do **not** get their obvious chord, because a mirrored `ctrl` binding already owns it:

| Wanted | Already claimed by |
|---|---|
| `super+r` for `app.retry` | `app.history.search` (`ctrl+r`), `app.session.rename` |
| `super+p` for `app.model.selectTemporary` | `app.model.cycleForward` (`ctrl+p`), `app.session.togglePath` |
| `super+a` for `app.agents.hub` | `tui.editor.cursorLineStart` (`ctrl+a`) |

Shadowing an existing mapping to satisfy a new one is a worse trade than partial coverage, so these stay Option-only. A test asserts they carry no `super+` key, so a later change cannot quietly introduce the shadow.

The two `tui.editor` readline chords (`yankPop` = `alt+y`, `deleteWordForward` = `alt+d`) are also excluded: `Cmd+Y` and `Cmd+D` carry no readline meaning, and `Cmd+D` is "split/duplicate" in much of macOS.

### Why not extend the mirror instead

An `alt+X → super+X` rule parallel to the `ctrl` one would cover everything in a single clause, but it binds every Command chord invisibly — including the three collisions above, which it would resolve by accident rather than by decision. Explicit per-binding keys keep each Command chord greppable in the registry and individually declinable.

### Gating

`withMacCommand(keys, command, platform = process.platform)` follows the existing `getDefaultPasteImageKeys(platform)` precedent: a defaulted platform parameter, so behavior is testable without mutating `process.platform`. Both default tables move together — the registry and `DEFAULT_ACTION_KEYS` in `custom-editor.ts`, which silently shadows the registry when they disagree.

### Verification

- `withMacCommand` appends the chord on `darwin` and returns the input unchanged on `linux` and `win32`.
- `app.retry`, `app.model.selectTemporary` and `app.agents.hub` carry no `super+` key.
- Confirmed the resolved registry: on Linux all five are unchanged; simulated darwin yields the paired chords in the table above.
- `bun run --cwd packages/coding-agent check` clean.

### Relationship to the other PRs

Bases on `main`, independent of #7147, #7148, #7149 and #7150.

It overlaps #7149 and #7150 on the `app.message.dequeue` entry: #7149 adds `shift+up`, #7150 adds the sibling `dequeueFollowUp` entry and rewords the description, and this PR adds `super+up`. Whichever lands last will conflict there. **The resolved entry with all three merged is:**

```ts
"app.message.dequeue": {
	// Shift+Up is listed alongside Alt+Up because macOS Terminal.app consumes Option
	// for character composition, leaving Alt+Up unreachable there.
	defaultKeys: withMacCommand(["alt+up", "shift+up"], "super+up"),
	description: "Restore steering messages to the editor",
},
"app.message.dequeueFollowUp": {
	defaultKeys: "ctrl+shift+up",
	description: "Restore follow-up messages to the editor",
},
```

and in `DEFAULT_ACTION_KEYS` (`modes/components/custom-editor.ts`):

```ts
"app.message.dequeue": withMacCommand(["alt+up", "shift+up"], "super+up"),
"app.message.dequeueFollowUp": ["ctrl+shift+up"],
```

Taking either side wholesale drops a key.

The collision analysis above assumes #7147 is merged. If #7147 is rejected, the three excluded bindings become free to take their Command chords, and this PR can be revisited.

