### PR TITLE
test(ai): stop bedrock payload suites from needing ambient AWS auth

### DIFF
--- a/packages/ai/test/bedrock-inference-profile.test.ts
+++ b/packages/ai/test/bedrock-inference-profile.test.ts
@@ -1,9 +1,24 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
 import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { withEnv } from "./helpers";
+
+// These suites capture the request payload from a fire-and-forget stream, so a
+// credential lookup that rejects after the test ends surfaces as an unhandled
+// error against whatever runs next. Skip Bedrock auth: the payload is built
+// before signing and no request leaves the process.
+const originalSkipAuth = process.env.AWS_BEDROCK_SKIP_AUTH;
+
+beforeAll(() => {
+	process.env.AWS_BEDROCK_SKIP_AUTH = "1";
+});
+
+afterAll(() => {
+	if (originalSkipAuth === undefined) delete process.env.AWS_BEDROCK_SKIP_AUTH;
+	else process.env.AWS_BEDROCK_SKIP_AUTH = originalSkipAuth;
+});
 
 const profileArn = "arn:aws:bedrock:us-east-2:1234567890:application-inference-profile/company-opus-48";
 const profileModel: Model<"bedrock-converse-stream"> = buildModel({

--- a/packages/ai/test/bedrock-prompt-cache.test.ts
+++ b/packages/ai/test/bedrock-prompt-cache.test.ts
@@ -1,9 +1,24 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
 import type { Context, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { withEnv } from "./helpers";
+
+// These suites capture the request payload from a fire-and-forget stream, so a
+// credential lookup that rejects after the test ends surfaces as an unhandled
+// error against whatever runs next. Skip Bedrock auth: the payload is built
+// before signing and no request leaves the process.
+const originalSkipAuth = process.env.AWS_BEDROCK_SKIP_AUTH;
+
+beforeAll(() => {
+	process.env.AWS_BEDROCK_SKIP_AUTH = "1";
+});
+
+afterAll(() => {
+	if (originalSkipAuth === undefined) delete process.env.AWS_BEDROCK_SKIP_AUTH;
+	else process.env.AWS_BEDROCK_SKIP_AUTH = originalSkipAuth;
+});
 
 interface CachePoint {
 	cachePoint: { type: "default"; ttl?: "1h" };

--- a/packages/ai/test/bedrock-system-prompt.test.ts
+++ b/packages/ai/test/bedrock-system-prompt.test.ts
@@ -1,7 +1,22 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { streamBedrock } from "@oh-my-pi/pi-ai/providers/amazon-bedrock";
 import type { Context, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+// These suites capture the request payload from a fire-and-forget stream, so a
+// credential lookup that rejects after the test ends surfaces as an unhandled
+// error against whatever runs next. Skip Bedrock auth: the payload is built
+// before signing and no request leaves the process.
+const originalSkipAuth = process.env.AWS_BEDROCK_SKIP_AUTH;
+
+beforeAll(() => {
+	process.env.AWS_BEDROCK_SKIP_AUTH = "1";
+});
+
+afterAll(() => {
+	if (originalSkipAuth === undefined) delete process.env.AWS_BEDROCK_SKIP_AUTH;
+	else process.env.AWS_BEDROCK_SKIP_AUTH = originalSkipAuth;
+});
 
 interface Payload {
 	system?: Array<{ text: string } | { cachePoint: unknown }>;


### PR DESCRIPTION
## What

Set `AWS_BEDROCK_SKIP_AUTH=1` around three Bedrock suites that capture a request payload from a fire-and-forget stream: `bedrock-prompt-cache`, `bedrock-inference-profile`, and `bedrock-system-prompt`. This matches the guard already used by `issue-1373-repro` and `issue-3124-repro`.

## Why

Those suites call `void streamBedrock(...)` with an already-aborted signal and read the payload from `onPayload`. The payload is built before signing, but the credential lookup still runs. On a machine without credentials it rejects after the test has finished, so Bun reports it as `# Unhandled error between tests` and fails whichever unrelated file runs next.

The failure is invisible on developer machines that have ambient AWS credentials, and intermittent in CI because the attribution target depends on scheduling. Observed on `Test TS workspace fast` in unrelated pull requests, landing variously on `openai-responses-omit-max-output-tokens`, `glm-5.2-reasoning-effort`, and `bedrock-prompt-cache` itself:

```
AwsCredentialsError: Unable to resolve AWS credentials.
    at resolveFresh (packages/ai/src/providers/aws-credentials.ts:115:8)
```

## Testing

All runs on a clean `main` worktree with `HOME` pointed at an empty directory and every `AWS_*` variable unset, so no ambient credentials are available:

- Before: `bun test` in `packages/ai` gives 4 fail, 1 error, all `AwsCredentialsError`.
- After: 3628 pass, 337 skip, 0 fail.
- Minimal reproduction, `bun test test/bedrock-inference-profile.test.ts test/api-registry.test.ts test/openai-responses-omit-max-output-tokens.test.ts test/auth-gateway-cache-key.test.ts test/glm-5.2-reasoning-effort.test.ts`: fails on `glm-5.2-reasoning-effort` before, 29 pass after.
- `bun --cwd packages/ai run check` passes.

Test-only change; no product code and no changelog entry.
