### PR TITLE
feat(ai): add China MiniMax Token Plan usage

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Added
 
+- Added China-region MiniMax Token Plan quota reporting for `minimax-code-cn`, using the mainland `api.minimaxi.com` endpoint with credentials and limits independent from the international plan.
 - Added first-class parentTurnId support for nested Codex requests, allowing stream options and metadata helpers to accept and safely propagate the initiating turn's ID.
 - Added preservation of the Codex `encrypted_function_args` plaintext-collaboration marker on replayed function calls, keeping server-marked plaintext tool arguments from being reinterpreted as encrypted on subsequent turns.
 - Added interactive Exa API-key login through `/login exa`, opening the official API-key dashboard and saving pasted keys to the credential store ([#1798](https://github.com/can1357/oh-my-pi/issues/1798)).

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -54,7 +54,7 @@ import { googleGeminiCliUsageProvider } from "./usage/gemini";
 import { githubCopilotUsageProvider } from "./usage/github-copilot";
 import { antigravityRankingStrategy, antigravityUsageProvider } from "./usage/google-antigravity";
 import { kimiUsageProvider } from "./usage/kimi";
-import { minimaxCodeUsageProvider } from "./usage/minimax-code";
+import { minimaxCodeCnUsageProvider, minimaxCodeUsageProvider } from "./usage/minimax-code";
 import { ollamaCloudUsageProvider, ollamaUsageProvider } from "./usage/ollama";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "./usage/openai-codex";
 import {
@@ -655,6 +655,7 @@ const DEFAULT_USAGE_PROVIDERS: UsageProvider[] = [
 	openaiCodexUsageProvider,
 	kimiUsageProvider,
 	minimaxCodeUsageProvider,
+	minimaxCodeCnUsageProvider,
 	antigravityUsageProvider,
 	googleGeminiCliUsageProvider,
 	ollamaUsageProvider,

--- a/packages/ai/src/usage/minimax-code.ts
+++ b/packages/ai/src/usage/minimax-code.ts
@@ -10,7 +10,9 @@ import { isRecord } from "../utils";
 import { toNumber } from "./shared";
 
 const INTL_PROVIDER = "minimax-code";
+const CN_PROVIDER = "minimax-code-cn";
 const INTL_BASE_URL = "https://api.minimax.io";
+const CN_BASE_URL = "https://api.minimaxi.com";
 const REMAINS_PATH = "/v1/token_plan/remains";
 const HOUR_MS = 60 * 60 * 1000;
 /** `current_*_status` enum reported per window: 1 normal, 2 exhausted, 3 unlimited. */
@@ -207,7 +209,7 @@ function buildBucketLimits(provider: string, bucket: TokenPlanBucket, accountId:
 }
 
 /**
- * MiniMax Token Plan usage provider (international, `api.minimax.io`).
+ * MiniMax Token Plan usage providers (international `api.minimax.io` and China `api.minimaxi.com`).
  *
  * `GET /v1/token_plan/remains` returns one `model_remains[]` bucket per plan
  * quota (text, media, …), each carrying a rolling interval window and a weekly
@@ -215,13 +217,14 @@ function buildBucketLimits(provider: string, bucket: TokenPlanBucket, accountId:
  * rejected credentials, so `base_resp.status_code` is the real success signal.
  */
 async function fetchMiniMaxCodeUsage(params: UsageFetchParams, ctx: UsageFetchContext): Promise<UsageReport | null> {
-	if (params.provider !== INTL_PROVIDER) return null;
+	if (params.provider !== INTL_PROVIDER && params.provider !== CN_PROVIDER) return null;
 	const apiKey = params.credential.apiKey;
 	if (params.credential.type !== "api_key" || !apiKey) return null;
 
 	try {
 		const configuredBaseUrl = params.baseUrl?.trim();
-		const baseUrl = configuredBaseUrl ? configuredBaseUrl.replace(/\/+$/, "").replace(/\/v1$/, "") : INTL_BASE_URL;
+		const defaultBaseUrl = params.provider === CN_PROVIDER ? CN_BASE_URL : INTL_BASE_URL;
+		const baseUrl = configuredBaseUrl ? configuredBaseUrl.replace(/\/+$/, "").replace(/\/v1$/, "") : defaultBaseUrl;
 		const response = await ctx.fetch(`${baseUrl}${REMAINS_PATH}`, {
 			headers: { Accept: "application/json", Authorization: `Bearer ${apiKey}` },
 			signal: params.signal,
@@ -288,4 +291,12 @@ export const minimaxCodeUsageProvider: UsageProvider = {
 	fetchUsage: fetchMiniMaxCodeUsage,
 	supports: params =>
 		params.provider === INTL_PROVIDER && params.credential.type === "api_key" && Boolean(params.credential.apiKey),
+};
+
+/** MiniMax Token Plan (China, `api.minimaxi.com`). */
+export const minimaxCodeCnUsageProvider: UsageProvider = {
+	id: CN_PROVIDER,
+	fetchUsage: fetchMiniMaxCodeUsage,
+	supports: params =>
+		params.provider === CN_PROVIDER && params.credential.type === "api_key" && Boolean(params.credential.apiKey),
 };

--- a/packages/ai/test/minimax-token-plan-usage.test.ts
+++ b/packages/ai/test/minimax-token-plan-usage.test.ts
@@ -2,14 +2,17 @@ import { describe, expect, test } from "bun:test";
 import { type AuthCredentialStore, AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
 import type { UsageFetchParams } from "@oh-my-pi/pi-ai/usage";
-import { minimaxCodeUsageProvider } from "@oh-my-pi/pi-ai/usage/minimax-code";
+import { minimaxCodeCnUsageProvider, minimaxCodeUsageProvider } from "@oh-my-pi/pi-ai/usage/minimax-code";
 
 const INTERVAL_START = 1_785_009_600_000;
 const INTERVAL_END = 1_785_024_000_000;
 const WEEKLY_START = 1_784_505_600_000;
 const WEEKLY_END = 1_785_110_400_000;
 
-function params(provider: "minimax-code" = "minimax-code", apiKey = "sk-cp-test"): UsageFetchParams {
+function params(
+	provider: "minimax-code" | "minimax-code-cn" = "minimax-code",
+	apiKey = "sk-cp-test",
+): UsageFetchParams {
 	return { provider, credential: { type: "api_key", apiKey }, accountKey: "account-1" };
 }
 
@@ -176,6 +179,20 @@ describe("MiniMax Token Plan usage", () => {
 		expect(videoWeekly?.notes).toEqual(["Requests: 1/21"]);
 	});
 
+	test("routes China Token Plan credentials to the mainland endpoint", async () => {
+		const requests: { url: string; init?: RequestInit }[] = [];
+		const fetchMock: FetchImpl = (input, init) => {
+			requests.push({ url: String(input), init });
+			return Promise.resolve(Response.json(remainsPayload()));
+		};
+
+		const report = await minimaxCodeCnUsageProvider.fetchUsage(params("minimax-code-cn"), { fetch: fetchMock });
+
+		expect(requests[0]?.url).toBe("https://api.minimaxi.com/v1/token_plan/remains");
+		expect(new Headers(requests[0]?.init?.headers).get("Authorization")).toBe("Bearer sk-cp-test");
+		expect(report?.provider).toBe("minimax-code-cn");
+	});
+
 	test("honors a configured base URL for the quota request", async () => {
 		// One case per trim the provider applies: trailing slash, trailing `/v1`, and both together.
 		for (const configured of ["https://proxy.example", "https://proxy.example/", "https://proxy.example/v1/"]) {
@@ -319,12 +336,12 @@ describe("MiniMax Token Plan usage", () => {
 		expect(await minimaxCodeUsageProvider.fetchUsage(params("minimax-code"), { fetch: fetchMock })).toBeNull();
 	});
 
-	test("registers the Token Plan id in AuthStorage's default usage resolver", async () => {
+	test("registers both regional Token Plan ids in AuthStorage's default usage resolver", async () => {
 		const storage = new AuthStorage(emptyStore());
 		await storage.reload();
 		try {
 			expect(storage.usageProviderFor("minimax-code")).toBe(minimaxCodeUsageProvider);
-			expect(storage.usageProviderFor("minimax-code-cn")).toBeUndefined();
+			expect(storage.usageProviderFor("minimax-code-cn")).toBe(minimaxCodeCnUsageProvider);
 		} finally {
 			storage.close();
 		}


### PR DESCRIPTION
## What

Adds Token Plan usage reporting for the China-region `minimax-code-cn` provider.

- Routes quota requests to `https://api.minimaxi.com/v1/token_plan/remains`.
- Registers `minimax-code-cn` in `AuthStorage`'s default usage providers.
- Reuses the existing MiniMax Token Plan parser and preserves configured base URL overrides.
- Keeps China and international credentials and usage reports independent.

## Why

Follow-up to #6650, which added MiniMax Token Plan usage reporting for the international `minimax-code` provider but intentionally did not cover the China API domain.

China Token Plan accounts use `api.minimaxi.com` and are stored under `minimax-code-cn`, so they currently do not expose quota data through `omp usage` or `/usage`.

## Testing

- `bun run check`
- `cd packages/ai && bun test test/minimax-token-plan-usage.test.ts`
   - 14 tests passed
   - 53 assertions passed
- Live-smoke-tested with a China Token Plan credential:
   - Request reached `api.minimaxi.com/v1/token_plan/remains`
   - Response produced the expected General and Video rolling/weekly quota limits

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
