### PR TITLE
fix(tui): contain synchronous image conversion failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Kitty terminals crashing while rendering live or restored non-PNG tool-result images when the runtime throws synchronously during PNG conversion ([#7160](https://github.com/can1357/oh-my-pi/issues/7160)).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -15,6 +15,7 @@ import chalk from "chalk";
 import type { AssistantThinkingRenderer } from "../../extensibility/extensions/types";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { expandKeyHint, getPreviewLines, resolveImageOptions, TRUNCATE_LENGTHS } from "../../tools/render-utils";
+import { convertImageToPng } from "../../utils/image-loading";
 import { canonicalizeMessage, formatThinkingForDisplay, hasDisplayableThinking } from "../../utils/thinking-display";
 import { resolveAssistantErrorPresentation } from "../utils/transcript-render-helpers";
 import { type CacheInvalidation, CacheInvalidationMarkerComponent } from "./cache-invalidation-marker";
@@ -607,16 +608,10 @@ export class AssistantMessageComponent extends Container {
 			if (image.mimeType === "image/png") continue;
 			if (this.#convertedKittyImages.has(key) || this.#kittyConversionsInFlight.has(key)) continue;
 			this.#kittyConversionsInFlight.add(key);
-			new Bun.Image(Buffer.from(image.data, "base64"))
-				.png()
-				.toBase64()
-				.then(data => {
+			convertImageToPng(image)
+				.then(converted => {
 					this.#kittyConversionsInFlight.delete(key);
-					this.#convertedKittyImages.set(key, {
-						type: "image",
-						data,
-						mimeType: "image/png",
-					});
+					this.#convertedKittyImages.set(key, converted);
 					if (this.#lastMessage) {
 						this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
 					}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -27,6 +27,7 @@ import { type FirstResultViewportRepaint, toolRenderers } from "../../tools/rend
 import { TODO_STRIKE_TOTAL_FRAMES, type TodoToolDetails } from "../../tools/todo";
 import type { XdevState } from "../../tools/xdev";
 import { isFramedBlockComponent, markFramedBlockComponent, renderStatusLine, WidthAwareText } from "../../tui";
+import { convertImageToPng } from "../../utils/image-loading";
 import { sanitizeWithOptionalSixelPassthrough } from "../../utils/sixel";
 import { renderDiff } from "./diff";
 
@@ -651,11 +652,9 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 
 			// Convert async - catch errors from processing
 			const index = i;
-			new Bun.Image(Buffer.from(img.data, "base64"))
-				.png()
-				.toBase64()
-				.then(data => {
-					this.#convertedImages.set(index, { data, mimeType: "image/png" });
+			convertImageToPng({ type: "image", data: img.data, mimeType: img.mimeType })
+				.then(converted => {
+					this.#convertedImages.set(index, converted);
 					this.#displayInputVersion++;
 					this.#updateDisplay();
 					this.#ui.requestRender();

--- a/packages/coding-agent/src/utils/image-loading.ts
+++ b/packages/coding-agent/src/utils/image-loading.ts
@@ -80,14 +80,19 @@ export class ImageInputTooLargeError extends Error {
 	}
 }
 
+/** Converts an image to PNG, rejecting when the runtime cannot decode or encode it. */
+export async function convertImageToPng(image: ImageContent): Promise<ImageContent> {
+	const bytes = Buffer.from(image.data, "base64");
+	const data = await new Bun.Image(bytes).png().toBase64();
+	return { ...image, data, mimeType: "image/png" };
+}
+
 export async function ensureSupportedImageInput(image: ImageContent): Promise<ImageContent | null> {
 	if (SUPPORTED_INPUT_IMAGE_MIME_TYPES.has(image.mimeType)) {
 		return image;
 	}
 	try {
-		const bytes = Buffer.from(image.data, "base64");
-		const data = await new Bun.Image(bytes).png().toBase64();
-		return { type: "image", data, mimeType: "image/png" };
+		return await convertImageToPng(image);
 	} catch {
 		return null;
 	}

--- a/packages/coding-agent/test/kitty-image-conversion.test.ts
+++ b/packages/coding-agent/test/kitty-image-conversion.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { ImageProtocol, setTerminalImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
+
+const IMAGE: ImageContent = {
+	type: "image",
+	data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+	mimeType: "image/jpeg",
+};
+const originalProtocol = TERMINAL.imageProtocol;
+
+describe("Kitty non-PNG conversion failures", () => {
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	beforeEach(() => {
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		vi.spyOn(Bun.Image.prototype, "png").mockImplementation(() => {
+			throw new TypeError("synchronous image conversion failure");
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		setTerminalImageProtocol(originalProtocol);
+	});
+
+	it("omits restored tool-result images when conversion throws synchronously", () => {
+		let imageUpdates = 0;
+		const component = new AssistantMessageComponent(undefined, false, () => imageUpdates++);
+
+		component.setToolResultImages("restored-read", [IMAGE]);
+		expect(imageUpdates).toBe(0);
+	});
+
+	it("omits live tool-result images when conversion throws synchronously", () => {
+		const requestRender = vi.fn();
+		const component = new ToolExecutionComponent("read", { path: "repro.jpg" }, {}, undefined, {
+			requestRender,
+			requestComponentRender: vi.fn(),
+			resetDisplay: vi.fn(),
+		});
+
+		component.updateResult({ content: [IMAGE] }, false);
+		expect(requestRender).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Repro
On a Kitty-capable render path, replacing `Bun.Image.prototype.png` with a synchronous throw and then executing the current `new Bun.Image(...).png().toBase64().catch(...)` chain exits before `.catch()` runs: `bun -e 'const original = Bun.Image.prototype.png; Bun.Image.prototype.png = () => { throw new TypeError("sync conversion failure"); }; try { new Bun.Image(Buffer.from("jpeg")).png().toBase64().catch(() => console.log("caught asynchronously")); } catch (error) { console.error(`${error.name}: ${error.message}`); process.exitCode = 1; } finally { Bun.Image.prototype.png = original; }'`.

## Cause
`AssistantMessageComponent.#convertImagesForKitty()` in `packages/coding-agent/src/modes/components/assistant-message.ts` and `ToolExecutionComponent.#maybeConvertImagesForKitty()` in `packages/coding-agent/src/modes/components/tool-execution.ts` constructed and transformed `Bun.Image` before the promise returned by `toBase64()` existed, so synchronous constructor/encoder errors escaped their rejection handlers.

## Fix
- Centralize PNG conversion in the async `convertImageToPng()` utility, turning synchronous runtime failures into promise rejections.
- Route restored assistant tool-result images and live tool-result images through that async boundary while preserving each renderer's existing failure fallback.
- Cover both Kitty render paths with synchronous-conversion regression tests and record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/kitty-image-conversion.test.ts packages/coding-agent/test/image-input-normalization.test.ts` passed 6 tests; `bun run check` in `packages/coding-agent` passed; a focused component smoke script printed `restored and live image failures contained` while `Bun.Image.prototype.png()` threw synchronously. Fixes #7160