### PR TITLE
fix(tui): format selector keybinding hints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the copy selector and ask dialog rendering raw key IDs instead of human-readable keybinding labels ([#7164](https://github.com/can1357/oh-my-pi/issues/7164)).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/modes/components/keybinding-hints.ts
+++ b/packages/coding-agent/src/modes/components/keybinding-hints.ts
@@ -1,31 +1,22 @@
 /**
  * Utilities for formatting keybinding hints in the UI.
  */
-import { getKeybindings, type Keybinding, type KeyId } from "@oh-my-pi/pi-tui";
-import type { AppKeybinding, KeybindingsManager } from "../../config/keybindings";
+import { getKeybindings, type Keybinding } from "@oh-my-pi/pi-tui";
+import { type AppKeybinding, formatKeyHints, type KeybindingsManager } from "../../config/keybindings";
 import { theme } from "../../modes/theme/theme";
-
-/**
- * Format keys array as display string (e.g., ["ctrl+c", "escape"] -> "ctrl+c/escape").
- */
-function formatKeys(keys: KeyId[]): string {
-	if (keys.length === 0) return "";
-	if (keys.length === 1) return keys[0]!;
-	return keys.join("/");
-}
 
 /**
  * Get display string for an editor action.
  */
 export function editorKey(action: Keybinding): string {
-	return formatKeys(getKeybindings().getKeys(action));
+	return formatKeyHints(getKeybindings().getKeys(action));
 }
 
 /**
  * Get display string for an app action.
  */
 export function appKey(keybindings: KeybindingsManager, action: AppKeybinding): string {
-	return formatKeys(keybindings.getKeys(action));
+	return formatKeyHints(keybindings.getKeys(action));
 }
 
 /**

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -1089,7 +1089,7 @@ describe("AskDialogComponent", () => {
 			expect(out).toContain("PgUp/PgDn");
 			expect(out).toContain("Tab/←/→");
 			expect(out).not.toContain(" tabs");
-			expect(out).toContain("ctrl+g cancel");
+			expect(out).toContain("Ctrl+G cancel");
 			setKeybindings(
 				KeybindingsManager.inMemory({
 					"tui.select.cancel": "ctrl+g",
@@ -1098,8 +1098,8 @@ describe("AskDialogComponent", () => {
 				}),
 			);
 			const remapped = render(component);
-			expect(remapped).toContain("ctrl+u/ctrl+d");
-			expect(remapped).toContain("ctrl+g cancel");
+			expect(remapped).toContain("Ctrl+U/Ctrl+D");
+			expect(remapped).toContain("Ctrl+G cancel");
 		} finally {
 			if (originalRows) Object.defineProperty(process.stdout, "rows", originalRows);
 			else Reflect.deleteProperty(process.stdout, "rows");

--- a/packages/coding-agent/test/modes/components/copy-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/copy-selector.test.ts
@@ -89,6 +89,13 @@ describe("CopySelectorComponent", () => {
 		expect(out).toMatch(/[├└]/);
 	});
 
+	it("renders human-readable keybinding hints in the footer", () => {
+		const out = render(new CopySelectorComponent(makeRoots(), { onPick: vi.fn(), onCancel: vi.fn() }));
+
+		expect(out).toContain("Enter copy");
+		expect(out).toContain("Ctrl+G quit");
+	});
+
 	it("copies the message node itself on Enter", () => {
 		const onPick = vi.fn();
 		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });


### PR DESCRIPTION
## Repro
Running `editorKey` against the default `tui.select.confirm`, `tui.select.cancel`, and `tui.select.pageUp` bindings returned `enter`, `escape/ctrl+c`, and `pageup` instead of `Enter`, `Esc/Ctrl+C`, and `PgUp`. Reproduced with `bun -e` by importing `editorKey` from `packages/coding-agent/src/modes/components/keybinding-hints.ts` and printing those three actions.

## Cause
`packages/coding-agent/src/modes/components/keybinding-hints.ts` used a private `formatKeys` implementation that returned or joined raw `KeyId` values, bypassing the human-readable labels owned by `formatKeyHints` in `config/keybindings.ts`. Both the copy-selector footer and ask-dialog navigation/cancel labels use that module.

## Fix
- Route `editorKey` and `appKey` directly through the shared `formatKeyHints` formatter and remove the duplicate raw formatter.
- Add a copy-selector footer regression assertion and update ask-dialog hint assertions to require formatted labels.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/modes/components/copy-selector.test.ts packages/coding-agent/test/modes/components/ask-dialog.test.ts` passed: 44 tests, 0 failures. `bun run check` in `packages/coding-agent` passed. A post-fix `bun -e` smoke check returned `Enter`, `Esc/Ctrl+C`, and `PgUp`. Skipped the pre-publish gate because `bun run fix` fails identically on a clean `origin/main` worktree: `audiopus_sys` cannot invoke the missing `cmake` binary; the TypeScript formatter completed successfully.

Fixes #7164