### PR TITLE
fix(cli): generate titles for positional initial messages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed CLI positional initial messages bypassing automatic session-title generation, which left shell-launched sessions unnamed until a later editor submission ([#7166](https://github.com/can1357/oh-my-pi/issues/7166)).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -504,6 +504,7 @@ async function runInteractiveMode(
 	}
 
 	if (initialMessage !== undefined) {
+		session.maybeStartTitleGeneration(initialMessage);
 		try {
 			using _keepalive = new EventLoopKeepalive();
 			await session.prompt(initialMessage, { images: initialImages });
@@ -514,6 +515,7 @@ async function runInteractiveMode(
 	}
 
 	for (const message of initialMessages) {
+		session.maybeStartTitleGeneration(message);
 		try {
 			using _keepalive = new EventLoopKeepalive();
 			await session.prompt(message);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { type AutocompleteProvider, matchesKey, type SlashCommand } from "@oh-my-pi/pi-tui";
-import { $env, isEnoent, logger, sanitizeText } from "@oh-my-pi/pi-utils";
+import { isEnoent, logger, sanitizeText } from "@oh-my-pi/pi-utils";
 import { isSettingsInitialized, settings } from "../../config/settings";
 import { resolveLocalRoot } from "../../internal-urls";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
@@ -20,7 +20,6 @@ import manualContinuePrompt from "../../prompts/system/manual-continue.md" with 
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
 import { isTinyTitleLocalModelKey } from "../../tiny/models";
-import { isLowSignalTitleInput } from "../../tiny/text";
 import { tinyTitleClient } from "../../tiny/title-client";
 import type { TinyTitleProgressEvent } from "../../tiny/title-protocol";
 import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
@@ -901,12 +900,9 @@ export class InputController {
 	}
 
 	/**
-	 * Kick off session-title generation while the session is still unnamed.
-	 * Invoked AFTER the optimistic user row is painted so the local tiny-title
-	 * worker's subprocess spawn never lands ahead of the first frame (issue #6462).
-	 * Skips slash extension commands (consumed locally by AgentSession.prompt()),
-	 * already-named sessions, PI_NO_TITLE, and low-signal greetings — no model or
-	 * download UI for those.
+	 * Kick off session-title generation after the optimistic user row paints.
+	 * Local extension commands are consumed before reaching the shared session
+	 * title gate and must not name the conversation.
 	 */
 	#maybeStartTitleGeneration(text: string): void {
 		const runner = this.ctx.session.extensionRunner;
@@ -915,32 +911,12 @@ export class InputController {
 			text.startsWith("/") &&
 			runner?.getCommand(extensionCommandSpace === -1 ? text.slice(1) : text.slice(1, extensionCommandSpace)) !==
 				undefined;
-		if (
-			isLocalExtensionCommand ||
-			this.ctx.sessionManager.getSessionName() ||
-			$env.PI_NO_TITLE ||
-			isLowSignalTitleInput(text)
-		) {
+		if (isLocalExtensionCommand) {
 			return;
 		}
-		this.#showTinyTitleDownloadProgress(this.ctx.settings.get("providers.tinyModel"));
-		this.ctx.session
-			.generateTitle(text)
-			.then(async title => {
-				// Re-check: a concurrent attempt for an earlier message may have
-				// already named the session. Don't clobber it. Terminal title and
-				// accent updates fire from the onSessionNameChanged listener.
-				if (title && !this.ctx.sessionManager.getSessionName()) {
-					await this.ctx.sessionManager.setSessionName(title, "auto");
-				}
-			})
-			.catch(err => {
-				logger.warn("title-generator: uncaught auto-title error", {
-					sessionId: this.ctx.session.sessionId,
-					reason: "uncaught-auto-title-error",
-					error: err instanceof Error ? err.message : String(err),
-				});
-			});
+		this.ctx.session.maybeStartTitleGeneration(text, () => {
+			this.#showTinyTitleDownloadProgress(this.ctx.settings.get("providers.tinyModel"));
+		});
 	}
 
 	/** Submit editor text to the focused subagent session (chat-only focus policy). */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -81,6 +81,7 @@ import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { MacOSPowerAssertion } from "@oh-my-pi/pi-natives";
 import {
+	$env,
 	escapeXmlText,
 	formatDuration,
 	getAgentDbPath,
@@ -179,6 +180,7 @@ import {
 	shouldDisableReasoning,
 	toReasoningEffort,
 } from "../thinking";
+import { isLowSignalTitleInput } from "../tiny/text";
 import { shutdownTinyTitleClient } from "../tiny/title-client";
 import { resolveApproval } from "../tools/approval";
 import { type AskToolDetails, type AskToolInput, recoverAskQuestions } from "../tools/ask";
@@ -5878,6 +5880,33 @@ export class AgentSession {
 				}
 			});
 		this.#replanTitleRefreshInFlight = refresh;
+	}
+
+	/**
+	 * Start automatic title generation when the session and input are eligible.
+	 * Interactive and CLI-bootstrap submissions share this gate so every first
+	 * user message persists titles with the same environment and signal policy.
+	 */
+	maybeStartTitleGeneration(firstMessage: string, onStart?: () => void): void {
+		if (this.sessionName || $env.PI_NO_TITLE || isLowSignalTitleInput(firstMessage)) {
+			return;
+		}
+		onStart?.();
+		this.generateTitle(firstMessage)
+			.then(async title => {
+				// Re-check after generation so concurrent attempts cannot replace
+				// the first title that completed.
+				if (title && !this.sessionName) {
+					await this.sessionManager.setSessionName(title, "auto");
+				}
+			})
+			.catch(err => {
+				logger.warn("title-generator: uncaught auto-title error", {
+					sessionId: this.sessionId,
+					reason: "uncaught-auto-title-error",
+					error: err instanceof Error ? err.message : String(err),
+				});
+			});
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5885,10 +5885,17 @@ export class AgentSession {
 	/**
 	 * Start automatic title generation when the session and input are eligible.
 	 * Interactive and CLI-bootstrap submissions share this gate so every first
-	 * user message persists titles with the same environment and signal policy.
+	 * user message persists titles with the same environment, signal, and local
+	 * extension-command policy.
 	 */
 	maybeStartTitleGeneration(firstMessage: string, onStart?: () => void): void {
-		if (this.sessionName || $env.PI_NO_TITLE || isLowSignalTitleInput(firstMessage)) {
+		const extensionCommandSpace = firstMessage.indexOf(" ");
+		const isLocalExtensionCommand =
+			firstMessage.startsWith("/") &&
+			this.#extensionRunner?.getCommand(
+				extensionCommandSpace === -1 ? firstMessage.slice(1) : firstMessage.slice(1, extensionCommandSpace),
+			) !== undefined;
+		if (isLocalExtensionCommand || this.sessionName || $env.PI_NO_TITLE || isLowSignalTitleInput(firstMessage)) {
 			return;
 		}
 		onStart?.();

--- a/packages/coding-agent/test/fixtures/cli-initial-title-probe.ts
+++ b/packages/coding-agent/test/fixtures/cli-initial-title-probe.ts
@@ -1,0 +1,21 @@
+import { AgentSession } from "../../src/session/agent-session";
+
+const outputPath = Bun.env.OMP_TITLE_PROBE_PATH;
+if (!outputPath) {
+	throw new Error("OMP_TITLE_PROBE_PATH is required");
+}
+
+let generatedFrom: string | undefined;
+
+AgentSession.prototype.generateTitle = (firstMessage: string): Promise<string | null> => {
+	generatedFrom = firstMessage;
+	return Promise.resolve("CLI Initial Title");
+};
+
+AgentSession.prototype.prompt = async function (): Promise<boolean> {
+	void Bun.sleep(100).then(async () => {
+		await Bun.write(outputPath, JSON.stringify({ generatedFrom, sessionName: this.sessionName }));
+		process.exit(0);
+	});
+	return true;
+};

--- a/packages/coding-agent/test/input-controller-orphan-submit.test.ts
+++ b/packages/coding-agent/test/input-controller-orphan-submit.test.ts
@@ -300,6 +300,9 @@ describe("InputController orphaned submit", () => {
 			const controller = new InputController(ctx);
 			controller.setupEditorSubmitHandler();
 
+			session.maybeStartTitleGeneration("/widget-status");
+			expect(titleSpy).not.toHaveBeenCalled();
+
 			await editor.onSubmit?.("/widget-status");
 
 			expect(localHandler).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/input-controller-orphan-submit.test.ts
+++ b/packages/coding-agent/test/input-controller-orphan-submit.test.ts
@@ -76,6 +76,7 @@ function createContext(sessionOverride?: InteractiveModeContext["session"]) {
 			extensionRunner: undefined,
 			steer,
 			prompt,
+			maybeStartTitleGeneration: vi.fn(),
 			queuedMessageCount: 0,
 			getQueuedMessages: () => ({ steering: [], followUp: [] }),
 		} as unknown as InteractiveModeContext["session"]);

--- a/packages/coding-agent/test/main-initial-message-title.test.ts
+++ b/packages/coding-agent/test/main-initial-message-title.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+const probeEntry = path.join(import.meta.dir, "fixtures", "cli-initial-title-probe.ts");
+const hasPtyHarness =
+	process.platform === "linux" &&
+	(await Bun.file("/usr/bin/script").exists()) &&
+	(await Bun.file("/usr/bin/timeout").exists());
+
+describe.skipIf(!hasPtyHarness)("CLI initial-message title generation", () => {
+	test("generates a title for the positional initial message", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-cli-title-"));
+		const agentDir = path.join(root, "agent");
+		const outputPath = path.join(root, "probe.json");
+		try {
+			await fs.mkdir(agentDir, { recursive: true });
+			await Bun.write(
+				path.join(agentDir, "config.yml"),
+				"setupVersion: 1\nstartup:\n  setupWizard: false\n  showSplash: false\n  checkUpdate: false\nproviders:\n  tinyModel: online\n",
+			);
+			const command = [
+				JSON.stringify(process.execPath),
+				"--preload",
+				JSON.stringify(probeEntry),
+				JSON.stringify(cliEntry),
+				"--no-session",
+				"--model",
+				"anthropic/claude-sonnet-4-5",
+				JSON.stringify("implement X"),
+			].join(" ");
+			const proc = Bun.spawn(["timeout", "10s", "script", "-q", "-c", command, "/dev/null"], {
+				cwd: repoRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+				env: {
+					...process.env,
+					HOME: root,
+					NO_COLOR: "1",
+					OMP_TITLE_PROBE_PATH: outputPath,
+					PI_CODING_AGENT_DIR: agentDir,
+					PI_NO_TITLE: "",
+					TERM: "xterm-256color",
+				},
+			});
+
+			const [stdout, stderr, exitCode] = await Promise.all([
+				new Response(proc.stdout).arrayBuffer(),
+				new Response(proc.stderr).text(),
+				proc.exited,
+			]);
+
+			expect({ exitCode, stderr, stdoutBytes: stdout.byteLength }).toMatchObject({ exitCode: 0, stderr: "" });
+			expect(await Bun.file(outputPath).text()).toBe(
+				JSON.stringify({ generatedFrom: "implement X", sessionName: "CLI Initial Title" }),
+			);
+		} finally {
+			await removeWithRetries(root);
+		}
+	}, 15_000);
+});


### PR DESCRIPTION
## Repro
Running `omp "implement X"` in interactive mode submits the positional message through `AgentSession.prompt()` but never invokes `AgentSession.generateTitle()`. An isolated preload probe reproduced the missing invocation on current `main`.

## Cause
`runInteractiveMode()` in `packages/coding-agent/src/main.ts` dispatched `initialMessage` and `initialMessages` directly, while the auto-title eligibility and persistence path existed only in `InputController#maybeStartTitleGeneration()` in `packages/coding-agent/src/modes/controllers/input-controller.ts`.

## Fix
- Move shared unnamed-session, environment, low-signal, generation, and persistence behavior into `AgentSession.maybeStartTitleGeneration()`.
- Invoke the shared path from both editor submissions and CLI bootstrap submissions while retaining the editor-only local-extension-command gate.
- Add a PTY CLI regression probe that verifies the positional message produces and persists an automatic title.

## Verification
`bun test packages/coding-agent/test/main-initial-message-title.test.ts packages/coding-agent/test/input-controller-orphan-submit.test.ts` passed: 7 tests, 30 assertions. `bun run check` passed in `packages/coding-agent`. The original CLI preload smoke changed from only `prompt("implement X")` to `generateTitle("implement X")` followed by `prompt("implement X")`. Skipped the pre-publish gate because `bun run fix:rs` fails identically on clean `origin/main`: `audiopus_sys` cannot execute the unavailable `cmake` binary.

Fixes #7166