### PR TITLE
feat(ai): best-effort kwarg-stripping retry ladder for provider 400s

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Best-effort kwarg-stripping retry ladder for Anthropic: when a provider 400 rejects an optional parameter named in the error message (temperature, output_config, thinking, forced tool_choice), the request is automatically retried with that parameter stripped instead of failing. The ladder slots into the existing catch-block retry flow alongside the Grammar/FastModeUnsupported handlers and shares the same streaming-safety guard (no retry after replay-unsafe content has been forwarded).
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -1,5 +1,6 @@
 import { isUnexpectedSocketCloseMessage } from "@oh-my-pi/pi-utils";
 import type { Api, AssistantMessage } from "../types";
+import { UNSUPPORTED_KWARG_NAME_PATTERN } from "../utils/kwarg-retry-ladder";
 import { AwsCredentialsError } from "./aws";
 import {
 	AnthropicConnectionError,
@@ -30,6 +31,8 @@ export const Flag = {
 	FastModeUnsupported: 0x2000_0000,
 	/** OAuth refresh failed definitively — the stored grant is dead, re-login required. */
 	OAuthExpiry: 0x4000_0000,
+	/** 400 rejecting an optional best-effort kwarg named in the error message (temperature, thinking/output_config, reasoning_effort, tool_choice). Not auto-retriable; consumed by the per-provider kwarg-stripping ladder. */
+	UnsupportedKwarg: 0x8000_0000,
 } as const;
 
 export type Flag = (typeof Flag)[keyof typeof Flag];
@@ -50,7 +53,8 @@ const KIND_MASK =
 	Flag.Abort |
 	Flag.Grammar |
 	Flag.FastModeUnsupported |
-	Flag.OAuthExpiry;
+	Flag.OAuthExpiry |
+	Flag.UnsupportedKwarg;
 
 const RETRIABLE_KINDS =
 	Flag.Transient | Flag.UsageLimit | Flag.ThinkingLoop | Flag.StaleResponsesItem | Flag.ProviderFinishError;
@@ -129,6 +133,11 @@ const EXTRA_INPUTS_NOT_PERMITTED_PATTERN = /extra inputs? (?:are|is) not permitt
 // because the account lacks the extra-usage entitlement fast mode requires.
 const FAST_MODE_SPEED_PARAM_PATTERN = /\bspeed\b/i;
 const FAST_MODE_NOT_SUPPORTED_PATTERN = /not support/i;
+// 400 rejecting an optional best-effort kwarg: the message names a strippable
+// field (temperature, thinking/output_config, reasoning_effort, tool_choice,
+// speed, …) and uses a generic "unsupported/unknown/extra inputs" envelope.
+const KWARG_REJECTION_PATTERN =
+	/invalid_request_error|extra inputs? (?:are|is) not permitted|is not supported|does(?: not|n'?t) support|unknown (?:parameter|field)|unrecognized (?:parameter|field|request)|unsupported parameter/i;
 const FAST_MODE_RATE_LIMIT_PATTERN = /rate_limit_error/i;
 const FAST_MODE_ENTITLEMENT_PATTERN = /fast mode/i;
 // Definitive OAuth refresh failure — the stored grant/client is dead.
@@ -166,6 +175,20 @@ function matchesFastModeUnsupported(message: string, errorStatus: number | undef
 	return (
 		errorStatus === 429 && FAST_MODE_RATE_LIMIT_PATTERN.test(message) && FAST_MODE_ENTITLEMENT_PATTERN.test(message)
 	);
+}
+
+/**
+ * 400 rejecting an optional best-effort kwarg named in the error message
+ * (temperature, thinking/output_config, reasoning_effort, tool_choice, …).
+ * The message must both use a generic rejection envelope AND name one of the
+ * strippable wire keys, so a context-overflow 400 or a malformed-schema 400
+ * does not classify here. Not auto-retriable; consumed by the per-provider
+ * kwarg-stripping ladder.
+ */
+function matchesUnsupportedKwarg(message: string, errorStatus: number | undefined): boolean {
+	if (errorStatus !== 400) return false;
+	if (!KWARG_REJECTION_PATTERN.test(message)) return false;
+	return UNSUPPORTED_KWARG_NAME_PATTERN.test(message);
 }
 
 /** Whether an OAuth refresh error message means the grant is definitively dead. */
@@ -341,6 +364,7 @@ function classifyText(errorMessage: string | undefined, errorStatus: number | un
 		if (statusClean === 400 && COPILOT_MODEL_NOT_SUPPORTED_PATTERN.test(cleanMessage)) kinds |= Flag.Transient;
 		if (matchesStrictToolsRejection(cleanMessage, statusClean)) kinds |= Flag.Grammar;
 		if (matchesFastModeUnsupported(cleanMessage, statusClean)) kinds |= Flag.FastModeUnsupported;
+		if (matchesUnsupportedKwarg(cleanMessage, statusClean)) kinds |= Flag.UnsupportedKwarg;
 	}
 	if (kinds !== 0) return create(kinds);
 	const fallbackStatus = errorStatus ?? (errorMessage ? status({ message: errorMessage }) : undefined);
@@ -449,6 +473,16 @@ export function isGrammarError(error: unknown): boolean {
  */
 export function isFastModeUnsupported(error: unknown): boolean {
 	return is(classify(error), Flag.FastModeUnsupported);
+}
+
+/**
+ * 400 rejecting an optional best-effort kwarg named in the error message
+ * (temperature, thinking/output_config, reasoning_effort, tool_choice, …).
+ * Accessor for {@link Flag.UnsupportedKwarg}; consumed by the per-provider
+ * kwarg-stripping retry ladder.
+ */
+export function isUnsupportedKwarg(error: unknown): boolean {
+	return is(classify(error), Flag.UnsupportedKwarg);
 }
 
 /**

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -59,6 +59,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { isFoundryEnabled } from "../utils/foundry";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
+import { type KwargRetryLadder, nextKwargStripRung } from "../utils/kwarg-retry-ladder";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { getHeadersFromError, getRetryAfterMsFromHeaders } from "../utils/retry-after";
 import { COMBINATOR_KEYS, NO_STRICT, toolWireSchema } from "../utils/schema";
@@ -476,6 +477,49 @@ function dropAnthropicStrictTools(params: MessageCreateParamsStreaming): void {
 		delete tool.strict;
 	}
 }
+
+/**
+ * Best-effort kwarg-stripping ladder for the Anthropic Messages API. Each
+ * rung targets a 400 that rejects an optional parameter the error message
+ * names, ordered least-disruptive first. Semantics-changing keys (messages,
+ * tools, max_tokens, system) are never stripped. Applied after `prepareParams`
+ * returns, so no sticky build-time state is needed.
+ */
+const anthropicKwargLadder: KwargRetryLadder<MessageCreateParamsStreaming> = [
+	{
+		id: "output_config",
+		matchers: [/\boutput[_-]?config\b/i, /\beffort\b/i],
+		strip: params => {
+			delete params.output_config;
+		},
+	},
+	{
+		id: "thinking",
+		matchers: [/\bthinking\b/i, /\bbudget[_-]?tokens\b/i],
+		strip: params => {
+			delete params.thinking;
+		},
+	},
+	{
+		id: "temperature",
+		matchers: [/\btemperature\b/i, /\btop[_-]?p\b/i, /\btop[_-]?k\b/i],
+		strip: params => {
+			delete params.temperature;
+			delete params.top_p;
+			delete params.top_k;
+		},
+	},
+	{
+		id: "tool_choice_required",
+		matchers: [/tool[_-]?choice.*(?:required|forces tool use|is not compatible)/i],
+		strip: params => {
+			const choice = params.tool_choice;
+			if (choice && (choice.type === "any" || choice.type === "tool")) {
+				params.tool_choice = { type: "auto" };
+			}
+		},
+	},
+];
 
 function getCacheControl(
 	model: Model<"anthropic-messages">,
@@ -1818,6 +1862,7 @@ const streamAnthropicOnce = (
 				(providerSessionState?.strictToolsDisabled ?? false) || (model.compat?.disableStrictTools ?? false);
 			let dropFastMode = providerSessionState?.fastModeDisabled ?? false;
 			let forceDemoteUnsignedThinking = providerSessionState?.replayUnsignedThinkingDisabled ?? false;
+			const appliedKwargRungs = new Set<string>();
 			const mergedCallerHeaders = mergeHeaders(model.headers, options?.headers);
 			const umansGatewayWebSearchHeader = getUmansWebSearchHeader(model, mergedCallerHeaders);
 			// Keep fallback payloads aligned with the top-level Vertex effort gate:
@@ -2673,6 +2718,33 @@ const streamAnthropicOnce = (
 						firstTokenTime = undefined;
 						continue;
 					}
+					if (
+						firstTokenTime === undefined &&
+						!streamedReplayUnsafeContent &&
+						AIError.isUnsupportedKwarg(streamFailure)
+					) {
+						const errorText = streamFailure instanceof Error ? streamFailure.message : String(streamFailure);
+						const rung = nextKwargStripRung(errorText, anthropicKwargLadder, appliedKwargRungs);
+						if (rung) {
+							appliedKwargRungs.add(rung.id);
+							logger.warn(`anthropic: provider rejected optional kwarg, retrying without ${rung.id}`, {
+								model: model.id,
+								error: await finalizeErrorMessage(streamFailure, rawRequestDump),
+							});
+							params = await prepareParams();
+							rung.strip(params);
+							providerRetryAttempt = 0;
+							output.content.length = 0;
+							output.model = model.id;
+							output.responseId = undefined;
+							output.errorMessage = undefined;
+							output.providerPayload = undefined;
+							output.usage = createEmptyUsage(copilotDynamicHeaders?.premiumRequests);
+							output.stopReason = "stop";
+							firstTokenTime = undefined;
+							continue;
+						}
+					}
 					const isTransientEnvelopeFailure =
 						AIError.isTransientStreamParseError(streamFailure) || AIError.isStreamEnvelopeError(streamFailure);
 					const isLocalIdleTimeout =
@@ -2728,6 +2800,9 @@ const streamAnthropicOnce = (
 			}
 			if (forceDemoteUnsignedThinking && model.compat.replayUnsignedThinking) {
 				output.disabledFeatures = [...(output.disabledFeatures ?? []), "unsigned-thinking-replay"];
+			}
+			for (const rungId of appliedKwargRungs) {
+				output.disabledFeatures = [...(output.disabledFeatures ?? []), `kwarg:${rungId}`];
 			}
 			stream.push({ type: "done", reason: output.stopReason, message: output });
 			stream.end();

--- a/packages/ai/src/utils/kwarg-retry-ladder.ts
+++ b/packages/ai/src/utils/kwarg-retry-ladder.ts
@@ -1,0 +1,78 @@
+/**
+ * Best-effort kwarg-stripping retry ladder.
+ *
+ * When a provider returns HTTP 400 rejecting an optional request parameter
+ * (reasoning config, `temperature`, `output_config`, forced `tool_choice`,
+ * …), the error message almost always names the offending field. This module
+ * picks which optional kwarg to strip next so a provider can retry with a
+ * progressively smaller optional envelope. Pure selection only — the provider
+ * owns applying the strip, rebuilding params, and the streaming retry guard
+ * (the retry must happen before any replay-unsafe content is forwarded).
+ *
+ * Semantics-changing keys (`messages`, `tools`, `max_tokens`, `system`) are
+ * never represented here: the ladder only strips the best-effort
+ * sampling/reasoning envelope. A 400 whose message names none of the
+ * registered kwargs returns `undefined` from {@link nextKwargStripRung} and
+ * is not retried by the ladder — unrelated 400s (context overflow, malformed
+ * schema) fall through to the existing error path unchanged.
+ */
+
+/**
+ * Union of wire-key names the ladder can strip across all providers. Kept in
+ * one place so the error classifier (`matchesUnsupportedKwarg` in `flags.ts`)
+ * and the per-provider ladders stay in sync: a 400 only classifies as
+ * `Flag.UnsupportedKwarg` when it names one of these keys. Word-boundary
+ * anchored so `temp` does not match `temperature` and `effort` does not match
+ * inside `reasoning_effort` (the `_` is a word character).
+ */
+export const UNSUPPORTED_KWARG_NAME_PATTERN =
+	/\b(?:temperature|top[_-]?p|top[_-]?k|min[_-]?p|presence[_-]?penalty|repetition[_-]?penalty|thinking|budget[_-]?tokens|output[_-]?config|effort|reasoning(?:[_-]?effort)?|tool[_-]?choice|speed)\b/i;
+
+/**
+ * One rung of the ladder: the names the provider's 400 error message uses to
+ * refer to this rung's keys, and the mutation that removes them from the
+ * provider-specific params object.
+ */
+export interface KwargStripRung<P> {
+	/** Stable id for logging and de-dup of attempts. */
+	readonly id: string;
+	/**
+	 * Substrings matched (case-insensitive) against the flattened 400 error
+	 * text to decide whether THIS rung is the one to apply next. A rung only
+	 * fires when the error names one of its matchers.
+	 */
+	readonly matchers: readonly RegExp[];
+	/**
+	 * Mutate `params` in place to remove this rung's keys. MUST be a no-op
+	 * when the keys are already absent (idempotent), so re-running a
+	 * previously-applied rung is safe. For rungs that downgrade rather than
+	 * delete (e.g. forced `tool_choice` → `auto`), the mutation rewrites the
+	 * value instead of removing it.
+	 */
+	strip: (params: P) => void;
+}
+
+/**
+ * Ordered set of rungs. Order is least-disruptive first: drop the reasoning
+ * envelope before dropping sampling params, so a thinking rejection does not
+ * also throw away the caller's `temperature`.
+ */
+export type KwargRetryLadder<P> = readonly KwargStripRung<P>[];
+
+/**
+ * Pick the next ladder rung whose matchers hit `errorText`, skipping rungs
+ * already in `alreadyApplied`. Returns `undefined` when no remaining rung
+ * matches — the signal that the 400 does not name a strippable kwarg and must
+ * not be retried by the ladder. Pure: no side effects, no param mutation.
+ */
+export function nextKwargStripRung<P>(
+	errorText: string,
+	ladder: KwargRetryLadder<P>,
+	alreadyApplied: ReadonlySet<string>,
+): KwargStripRung<P> | undefined {
+	for (const rung of ladder) {
+		if (alreadyApplied.has(rung.id)) continue;
+		if (rung.matchers.some(re => re.test(errorText))) return rung;
+	}
+	return undefined;
+}

--- a/packages/ai/test/kwarg-retry-ladder.test.ts
+++ b/packages/ai/test/kwarg-retry-ladder.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "bun:test";
+import { ProviderHttpError } from "@oh-my-pi/pi-ai/error";
+import { isUnsupportedKwarg } from "@oh-my-pi/pi-ai/error/flags";
+import {
+	type KwargRetryLadder,
+	type KwargStripRung,
+	nextKwargStripRung,
+	UNSUPPORTED_KWARG_NAME_PATTERN,
+} from "@oh-my-pi/pi-ai/utils/kwarg-retry-ladder";
+
+type Params = {
+	temperature?: number;
+	thinking?: { budget_tokens: number };
+	output_config?: { effort: string };
+	tool_choice?: { type: "auto" | "any" | "tool" };
+};
+
+const ladder: KwargRetryLadder<Params> = [
+	{
+		id: "output_config",
+		matchers: [/\boutput_config\b/i, /\beffort\b/i],
+		strip: p => {
+			delete p.output_config;
+		},
+	},
+	{
+		id: "thinking",
+		matchers: [/\bthinking\b/i, /\bbudget_tokens\b/i],
+		strip: p => {
+			delete p.thinking;
+		},
+	},
+	{
+		id: "temperature",
+		matchers: [/\btemperature\b/i],
+		strip: p => {
+			delete p.temperature;
+		},
+	},
+	{
+		id: "tool_choice_required",
+		matchers: [/tool_choice.*(?:required|is not compatible)/i],
+		strip: p => {
+			if (p.tool_choice && (p.tool_choice.type === "any" || p.tool_choice.type === "tool")) {
+				p.tool_choice = { type: "auto" };
+			}
+		},
+	},
+];
+
+describe("nextKwargStripRung", () => {
+	it("returns the rung whose matcher hits the error text", () => {
+		const rung = nextKwargStripRung("400 temperature is not supported", ladder, new Set());
+		expect(rung?.id).toBe("temperature");
+	});
+
+	it("respects ladder ordering: a message naming both thinking and temperature selects thinking first", () => {
+		const rung = nextKwargStripRung("thinking and temperature are not supported", ladder, new Set());
+		expect(rung?.id).toBe("thinking");
+	});
+
+	it("skips already-applied rungs and advances to the next match", () => {
+		const applied = new Set(["thinking"]);
+		const rung = nextKwargStripRung("thinking and temperature are not supported", ladder, applied);
+		expect(rung?.id).toBe("temperature");
+	});
+
+	it("returns undefined when no remaining rung matches", () => {
+		const rung = nextKwargStripRung("context window exceeded", ladder, new Set());
+		expect(rung).toBeUndefined();
+	});
+
+	it("returns undefined when all matching rungs have been applied (ladder exhausted)", () => {
+		const applied = new Set(["thinking", "temperature"]);
+		const rung = nextKwargStripRung("thinking and temperature are not supported", ladder, applied);
+		expect(rung).toBeUndefined();
+	});
+
+	it("matchers are case-insensitive (Temperature matches, temp does not)", () => {
+		expect(nextKwargStripRung("400 Temperature is not supported", ladder, new Set())?.id).toBe("temperature");
+		expect(nextKwargStripRung("400 temp is not supported", ladder, new Set())).toBeUndefined();
+	});
+
+	it("strip is idempotent: applying a rung twice is a no-op on the second pass", () => {
+		const rung = nextKwargStripRung("400 temperature is not supported", ladder, new Set()) as KwargStripRung<Params>;
+		const params: Params = { temperature: 0.7, thinking: { budget_tokens: 1024 } };
+		rung.strip(params);
+		expect(params.temperature).toBeUndefined();
+		rung.strip(params);
+		expect(params.temperature).toBeUndefined();
+		expect(params.thinking).toEqual({ budget_tokens: 1024 });
+	});
+
+	it("tool_choice rung downgrades forced choice to auto instead of deleting", () => {
+		const rung = ladder.find(r => r.id === "tool_choice_required") as KwargStripRung<Params>;
+		const params: Params = { tool_choice: { type: "any" } };
+		rung.strip(params);
+		expect(params.tool_choice).toEqual({ type: "auto" });
+	});
+});
+
+describe("UNSUPPORTED_KWARG_NAME_PATTERN", () => {
+	it("matches known strippable wire keys", () => {
+		expect(UNSUPPORTED_KWARG_NAME_PATTERN.test("temperature is not supported")).toBe(true);
+		expect(UNSUPPORTED_KWARG_NAME_PATTERN.test("output_config is not supported")).toBe(true);
+		expect(UNSUPPORTED_KWARG_NAME_PATTERN.test("thinking is not supported")).toBe(true);
+		expect(UNSUPPORTED_KWARG_NAME_PATTERN.test("tool_choice is not compatible")).toBe(true);
+		expect(UNSUPPORTED_KWARG_NAME_PATTERN.test("reasoning_effort is not supported")).toBe(true);
+	});
+
+	it("does not match a prefix like 'temp' for 'temperature'", () => {
+		expect(UNSUPPORTED_KWARG_NAME_PATTERN.test("temp is not supported")).toBe(false);
+	});
+
+	it("does not match non-kwarg 400 text", () => {
+		expect(UNSUPPORTED_KWARG_NAME_PATTERN.test("prompt is too long")).toBe(false);
+		expect(UNSUPPORTED_KWARG_NAME_PATTERN.test("compiled grammar too large")).toBe(false);
+	});
+});
+
+describe("isUnsupportedKwarg classifier", () => {
+	it("classifies a 400 invalid_request_error naming temperature as UnsupportedKwarg", () => {
+		const error = new ProviderHttpError(
+			'400 {"type":"error","error":{"type":"invalid_request_error","message":"temperature is not supported when thinking is enabled"}}',
+			400,
+			{ code: "invalid_request_error" },
+		);
+		expect(isUnsupportedKwarg(error)).toBe(true);
+	});
+
+	it("classifies a 400 naming output_config with an unsupported-parameter envelope", () => {
+		const error = new ProviderHttpError('400 {"detail":"Unsupported parameter: output_config"}', 400);
+		expect(isUnsupportedKwarg(error)).toBe(true);
+	});
+
+	it("classifies a 400 naming thinking with an extra-inputs envelope", () => {
+		const error = new ProviderHttpError(
+			'400 {"type":"error","error":{"type":"invalid_request_error","message":"thinking is not supported by this model"}}',
+			400,
+			{ code: "invalid_request_error" },
+		);
+		expect(isUnsupportedKwarg(error)).toBe(true);
+	});
+
+	it("does not classify a context-overflow 400 as UnsupportedKwarg", () => {
+		const error = new ProviderHttpError("400 prompt is too long", 400);
+		expect(isUnsupportedKwarg(error)).toBe(false);
+	});
+
+	it("does not classify a 401 as UnsupportedKwarg", () => {
+		const error = new ProviderHttpError("401 Unauthorized", 401);
+		expect(isUnsupportedKwarg(error)).toBe(false);
+	});
+
+	it("does not classify a 429 as UnsupportedKwarg", () => {
+		const error = new ProviderHttpError(
+			'429 {"type":"error","error":{"type":"rate_limit_error","message":"temperature too many requests"}}',
+			429,
+			{ code: "rate_limit_error" },
+		);
+		expect(isUnsupportedKwarg(error)).toBe(false);
+	});
+
+	it("does not classify a 400 that names no strippable kwarg", () => {
+		const error = new ProviderHttpError(
+			'400 {"type":"error","error":{"type":"invalid_request_error","message":"messages must be non-empty"}}',
+			400,
+			{ code: "invalid_request_error" },
+		);
+		expect(isUnsupportedKwarg(error)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

When a provider returns HTTP 400 rejecting an optional request parameter (temperature, output_config, thinking, forced tool_choice), the error message almost always names the offending field. This PR adds a general mechanism that picks which optional kwarg to strip and retries the request with a progressively smaller optional envelope, instead of failing outright.

## What changed

### New module: `packages/ai/src/utils/kwarg-retry-ladder.ts`
- `KwargStripRung<P>` / `KwargRetryLadder<P>` types — provider-parameterized rungs with id, matchers, and a strip callback
- `nextKwargStripRung(errorText, ladder, alreadyApplied)` — pure selection function returning the first matching un-applied rung, or undefined
- `UNSUPPORTED_KWARG_NAME_PATTERN` — union regex of all strippable wire-key names, shared with the error classifier

### Error classification: `packages/ai/src/error/flags.ts`
- New `Flag.UnsupportedKwarg` (0x8000_0000) — 400-only, gated on error message naming a known strippable wire key
- `matchesUnsupportedKwarg` classifier — requires both a rejection envelope pattern AND a named kwarg from `UNSUPPORTED_KWARG_NAME_PATTERN`
- `isUnsupportedKwarg(error)` accessor — mirrors `isGrammarError` / `isFastModeUnsupported`
- NOT added to `RETRIABLE_KINDS` — consumed explicitly by the provider ladder, not the generic transient retry

### Anthropic provider: `packages/ai/src/providers/anthropic.ts`
- 4-rung ladder (output_config, thinking, temperature, tool_choice_required) declared near `dropAnthropicFastMode`
- Ladder branch in the catch block, after the fast-mode handler and before the transient-retry check
- Shares the existing `firstTokenTime === undefined && !streamedReplayUnsafeContent` streaming-safety guard
- Applies `rung.strip(params)` after `prepareParams()` returns — no sticky build-time booleans needed
- Applied rungs reported in `disabledFeatures` as `kwarg:<id>`

### Tests: `packages/ai/test/kwarg-retry-ladder.test.ts`
- 18 tests across 3 suites: rung selection/ordering/idempotency, word-boundary matching, classifier status gates

## Design notes

The ladder does NOT replace `openai-reasoning-fallback.ts`, which handles reasoning-effort *value* downgrades with per-endpoint memory (parsing allowed-values lists, picking nearest). The ladder handles *full-kwarg stripping* for cases that system does not cover:

- `temperature` rejected at runtime (only static drops exist today)
- `output_config` rejected at runtime (only static Vertex drop exists)
- `thinking` rejected (non-signature — the signature case is already handled)
- `tool_choice: required` rejected at runtime (only static compat-flag downgrade exists)

Semantics-changing keys (messages, tools, max_tokens, system) are never stripped. A 400 whose message names no registered kwarg returns undefined and is not retried — unrelated 400s (context overflow, malformed schema) fall through unchanged.

## Verification
- 18 new tests pass (0 fail)
- `bun check`: zero type errors in changed files
- `bun fmt`: clean