### PR TITLE
fix(coding-agent): re-export compact from legacy pi shim

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp plugin install` failing extension validation for pi extensions that import `compact` from `@earendil-works/pi-coding-agent` (e.g. pi-claude-bridge) — the legacy `@oh-my-pi/pi-coding-agent` shim did not forward `compact` (it lives in `@oh-my-pi/pi-agent-core/compaction`, the same module as the already-bridged `estimateTokens`), so a named import threw Bun's static "Export named 'compact' not found" error. Added the missing `compact` re-export ([#7174](https://github.com/can1357/oh-my-pi/issues/7174)).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -1416,11 +1416,11 @@ export function getPackageDir(): string {
 }
 
 // Legacy pi's `@earendil-works/pi-coding-agent` re-exported `estimateTokens`
-// from its package root (via `./core/compaction/index.ts`). In omp it lives in
-// `@oh-my-pi/pi-agent-core/compaction`, and the coding-agent barrel below does
-// not forward it, so legacy extensions importing it fail Bun's static export
-// check during validation (issue #6583).
-export { estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";
+// and `compact` from its package root (via `./core/compaction/index.ts`). In
+// omp both live in `@oh-my-pi/pi-agent-core/compaction`, and the coding-agent
+// barrel below does not forward them, so legacy extensions importing either
+// fail Bun's static export check during validation (issues #6583, #7174).
+export { compact, estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";
 
 // Same barrel gap for two more legacy package-root exports: pi re-exported the
 // `CONFIG_DIR_NAME` constant and the CLI parser `parseArgs`. In omp

--- a/packages/coding-agent/test/extensibility/legacy-pi-compaction-helpers.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-compaction-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { estimateTokens } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
+import { compact, estimateTokens } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
 
 // Issue #6583: pi extensions import `estimateTokens` from
 // `@earendil-works/pi-coding-agent`, which aliases to this shim. Legacy pi
@@ -15,5 +15,13 @@ describe("legacy shim compaction helpers", () => {
 		expect(typeof estimateTokens).toBe("function");
 		const tokens = estimateTokens({ role: "user", content: "hello world", timestamp: Date.now() });
 		expect(tokens).toBeGreaterThan(0);
+	});
+
+	// Issue #7174: `compact` (same `@oh-my-pi/pi-agent-core/compaction` module as
+	// `estimateTokens`) was likewise absent from the shim surface, so
+	// `omp plugin install npm:pi-claude-bridge` failed with "Export named
+	// 'compact' not found". Pin the callable re-export.
+	it("re-exports compact as a callable function", () => {
+		expect(typeof compact).toBe("function");
 	});
 });


### PR DESCRIPTION
## Repro
Installing a legacy pi extension that imports `compact` from `@earendil-works/pi-coding-agent` (e.g. `omp plugin install npm:pi-claude-bridge`, v0.6.3) fails extension validation on omp 17.2.1 with `Export named 'compact' not found in module '.../legacy-pi-coding-agent-shim.ts'`. Reproduced on the current default branch:

```
$ bun build -e 'import { compact } from "packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts"' --target=bun
error: No matching export in ".../legacy-pi-coding-agent-shim.ts" for import "compact"
```

## Cause
`compact` lives in `@oh-my-pi/pi-agent-core/compaction` (the same module as `estimateTokens`, bridged in #6584). The legacy shim (`packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts`) forwards the package surface via `export * from "../index"`, but the coding-agent barrel does not re-export `compact`, so the symbol never reaches the shim surface and Bun's static export check rejects the named import at validation time. The report also names `keyHint`, but a runtime probe of the shim namespace shows `keyHint` is already present — it reaches `../index` via `modes/components/index.ts` → `keybinding-hints.ts`. Bun aborts on the first unresolved import (`compact`), so the reporter never actually observed a `keyHint` failure.

## Fix
- `legacy-pi-coding-agent-shim.ts`: add `compact` to the existing `@oh-my-pi/pi-agent-core/compaction` re-export line (folded alongside `estimateTokens` since it is the same module) and extend the comment to cover #7174. No `keyHint` change — it already resolves, and an explicit re-export would duplicate the star-forwarded symbol.
- `test/extensibility/legacy-pi-compaction-helpers.test.ts`: pin the `compact` re-export as a callable export through the public shim specifier, mirroring the existing `estimateTokens` coverage.
- `CHANGELOG.md`: add a `### Fixed` entry under `[Unreleased]`.

## Verification
`bun test packages/coding-agent/test/extensibility/legacy-pi-compaction-helpers.test.ts` → 2 pass, 0 fail. Also confirmed manually via a runtime namespace probe that `compact`, `keyHint`, and `estimateTokens` are all now present on the shim surface. Fixes #7174