### PR TITLE
fix(coding-agent): keep ExtensionContext.cwd live across /move

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `ExtensionContext.cwd` staying pinned to the directory a session started in, even after it moved: `ExtensionRunner` cached `cwd` from its constructor argument instead of reading the owning session's live directory, so extensions watching `ctx.cwd` (e.g. for git-worktree tracking) kept observing a stale path for the rest of the session — reachable via the interactive `/move` command, a programmatic `AgentSession.moveSession()`/`SessionManager.moveTo()` call, or an SDK/ACP session opened with a `cwd` different from the process's own. `ExtensionRunner.cwd` is now a getter over `this.sessionManager.getCwd()`, the same session-scoped value `moveTo()` updates directly, instead of the process-global project directory.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -410,7 +410,8 @@ export class ExtensionRunner {
 	constructor(
 		private readonly extensions: Extension[],
 		private readonly runtime: ExtensionRuntime,
-		private readonly cwd: string,
+		/** Ignored: `cwd` is always read live via the `cwd` getter below, not cached here. */
+		_initialCwd: string,
 		private readonly sessionManager: SessionManager,
 		private readonly modelRegistry: ModelRegistry,
 		getMemory?: () => MemoryRuntimeContext | undefined,
@@ -421,6 +422,24 @@ export class ExtensionRunner {
 		this.#uiContext = noOpUIContext;
 		this.#getMemoryFn = getMemory;
 		this.#getAsyncJobSnapshotFn = getAsyncJobSnapshot ?? (() => null);
+	}
+
+	/**
+	 * Live session directory, not a session-start snapshot: `/move`
+	 * (`SessionManager.moveTo()`) relocates the owning session by updating
+	 * `sessionManager`'s own `#cwd`, not a process-global. Reading it here
+	 * via the getter — instead of caching the constructor-time value in a
+	 * field — keeps every `ExtensionContext` built below in sync with this
+	 * session's actual, current directory. Deliberately `sessionManager.getCwd()`
+	 * rather than `getProjectDir()`: the latter is a single process-wide value
+	 * that only the interactive TUI's `/move` handler happens to also update
+	 * (`InteractiveModeContext#applyCwdChange`) — an SDK/ACP host running
+	 * several concurrent sessions each with their own `cwd` (see
+	 * `CreateAgentSessionOptions.cwd`) must never have one session's move
+	 * leak into another's `ctx.cwd` by reading a shared global.
+	 */
+	get cwd(): string {
+		return this.sessionManager.getCwd();
 	}
 
 	initialize(

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -99,6 +99,25 @@ describe("ExtensionRunner", () => {
 		expect(runner.createContext().localProtocolOptions).toBe(localProtocolOptions);
 	});
 
+	it("reflects SessionManager.moveTo() changes instead of the constructor-time snapshot (/move)", async () => {
+		const dirA = tempDir.join("dirA");
+		const dirB = tempDir.join("dirB");
+		fs.mkdirSync(dirA, { recursive: true });
+		fs.mkdirSync(dirB, { recursive: true });
+		const movableSessionManager = SessionManager.inMemory(dirA);
+
+		const result = await loadTestExtensions();
+		const runner = new ExtensionRunner(result.extensions, result.runtime, dirA, movableSessionManager, modelRegistry);
+
+		expect(runner.cwd).toBe(dirA);
+		expect(runner.createContext().cwd).toBe(dirA);
+
+		await movableSessionManager.moveTo(dirB);
+
+		expect(runner.cwd).toBe(dirB);
+		expect(runner.createContext().cwd).toBe(dirB);
+	});
+
 	describe("shortcut conflicts", () => {
 		it("warns when extension shortcut conflicts with built-in", async () => {
 			const extCode = `


### PR DESCRIPTION
## What

`ExtensionRunner.cwd` now reads the owning session's live directory (`this.sessionManager.getCwd()`) instead of the constructor-time snapshot.

## Why

`ExtensionRunner` cached `cwd` from its constructor argument, set once at session start. `/move` (`SessionManager.moveTo()`) relocates the active session's directory, but `ExtensionRunner` never re-read it — every `ExtensionContext` built afterwards (tool calls, hooks, slash commands) kept reporting the pre-move directory for the rest of the session. Found this while building an extension that tracks the session's git worktree via `ctx.cwd`.

**Update after review:** the first version of this fix read the process-global `getProjectDir()` instead. [@chatgpt-codex-connector](https://github.com/apps/chatgpt-codex-connector) and [@roboomp](https://github.com/roboomp) both correctly flagged that as wrong: the interactive `/move` handler happens to also `chdir` the process (`command-controller.ts` → `applyCwdChange` → `setProjectDir`), but `SessionManager.moveTo()` itself never touches that global. So a programmatic `AgentSession.moveSession()` / `SessionManager.moveTo()` call, a collab guest adopting a host's session cwd without chdir'ing, or an SDK/ACP session opened via `createAgentSession({ cwd })` with a `cwd` different from the process's own would all still see a stale `ctx.cwd`. `ExtensionRunner` already holds `this.sessionManager` for other purposes, and its `getCwd()` is updated directly by `moveTo()` — reading that instead covers every one of these cases, not just the reported interactive one.

The constructor parameter stays (renamed `_initialCwd`, documented as ignored) so the two existing call sites (`sdk.ts`, `cli/models-cli.ts`) don't need touching.

## Testing

- Regression test in `test/extensions-runner.test.ts`: constructs a real `ExtensionRunner` over an in-memory `SessionManager`, relocates it via `SessionManager.moveTo()`, and asserts both `runner.cwd` and `createContext().cwd` observe the new directory. Confirmed it fails on the pre-fix code and passes after, for both the original `getProjectDir()` version and this corrected `sessionManager.getCwd()` version.
- `bun test test/extensions-runner.test.ts`: 67 pass, 0 fail.
- `bun run check:types` and `biome check` on the changed files: clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
