### PR TITLE
fix(web-search): surface xai-oauth support in Grok search provider label

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the web-search provider picker describing xAI/Grok as requiring `XAI_API_KEY`, which hid that the `xai` search provider already accepts a SuperGrok/X Premium+ `xai-oauth` sign-in (via `/login xai-oauth` or `XAI_OAUTH_TOKEN`). The description now matches the OAuth-aware wording used by the Anthropic, OpenAI, and Gemini rows.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -30,7 +30,12 @@ export const SEARCH_PROVIDER_OPTIONS = [
 		label: "OpenAI",
 		description: "OpenAI's native web_search (uses ChatGPT OAuth via /login openai-codex)",
 	},
-	{ value: "xai", label: "xAI", description: "Grok web search via xAI Responses API (requires XAI_API_KEY)" },
+	{
+		value: "xai",
+		label: "xAI",
+		description:
+			"Grok web search via xAI Responses API (uses SuperGrok/X Premium+ OAuth via /login xai-oauth, or XAI_API_KEY)",
+	},
 	{ value: "zai", label: "Z.AI", description: "Calls Z.AI webSearchPrime MCP" },
 	{ value: "exa", label: "Exa", description: "API via /login exa or EXA_API_KEY; explicit keyless fallback via MCP" },
 	{ value: "tinyfish", label: "TinyFish", description: "Requires TINYFISH_API_KEY" },


### PR DESCRIPTION
## What
The web-search provider picker's xAI/Grok row said "requires XAI_API_KEY". Updated it to note the `xai` search provider also accepts a SuperGrok/X Premium+ `xai-oauth` sign-in, matching the OAuth-aware wording of the Anthropic/OpenAI/Gemini rows.

## Why
`resolveXAIWebSearchAuth` in `providers/xai.ts` already prefers the `xai-oauth` credential, so SuperGrok subscribers can use Grok search without an API key — but the picker text implied they couldn't.

## Testing
Set `providers.webSearchOrder: [xai]` with only an `xai-oauth` login (no XAI_API_KEY), restarted, ran a web_search; Grok returned cited results via api.x.ai/v1. `bun run check:ts` passes; setup-wizard (23) and web (107) tests pass.

I reviewed the diff and confirmed Grok search worked over my SuperGrok login with no
 API key set.

- [x] `bun check` passes (check:ts)
- [x] Tested locally
- [x] CHANGELOG updated