### PR TITLE
fix(ai): refresh expired oauth credential on observed mismatch

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `AuthStorage.refreshStoredOAuthCredential` returning an expired-but-refreshable OAuth credential without refreshing it when the caller's observed credential mismatched the stored row. A concurrent usage-fetch cycle could rotate the in-memory selected credential out from under a request (e.g. plan finalization); the observed-mismatch guard then adopted the stored copy verbatim, and if that copy was itself expired it flowed into `getOAuthApiKey`, which refused it — surfacing as a misleading `No API key found for <provider>`. The mismatch guard now only short-circuits when the stored credential is still fresh; expired stored copies fall through to a normal refresh ([#7179](https://github.com/can1357/oh-my-pi/issues/7179)).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2327,10 +2327,19 @@ export class AuthStorage {
 			if (!current) {
 				return { credential: undefined, refreshed: false, removed: false };
 			}
-			if (options.observedCredential && !authCredentialEquals(current, options.observedCredential)) {
+			const currentIsFresh = Date.now() + refreshSkewMs < current.expires;
+			// A peer rotated the credential out from under the caller's observation.
+			// Adopt the stored copy only when it is still usable; a stored copy that
+			// is itself expired must fall through to a refresh rather than be handed
+			// back and fail the downstream `getOAuthApiKey` expiry precondition.
+			if (
+				options.observedCredential &&
+				!authCredentialEquals(current, options.observedCredential) &&
+				currentIsFresh
+			) {
 				return { credential: current, refreshed: false, removed: false };
 			}
-			if (!options.forceRefresh && Date.now() + refreshSkewMs < current.expires) {
+			if (!options.forceRefresh && currentIsFresh) {
 				return { credential: current, refreshed: false, removed: false };
 			}
 			if (options.canRefresh && !options.canRefresh(current)) {
@@ -2370,10 +2379,17 @@ export class AuthStorage {
 			if (!current) {
 				return { credential: undefined, refreshed: false, removed: false };
 			}
-			if (options.observedCredential && !authCredentialEquals(current, options.observedCredential)) {
+			const currentIsFresh = Date.now() + refreshSkewMs < current.expires;
+			// Re-check after acquiring the lease: only adopt the stored copy on an
+			// observed mismatch when it is still usable, mirroring the pre-lease guard.
+			if (
+				options.observedCredential &&
+				!authCredentialEquals(current, options.observedCredential) &&
+				currentIsFresh
+			) {
 				return { credential: current, refreshed: false, removed: false };
 			}
-			if (!options.forceRefresh && Date.now() + refreshSkewMs < current.expires) {
+			if (!options.forceRefresh && currentIsFresh) {
 				return { credential: current, refreshed: false, removed: false };
 			}
 			if (options.canRefresh && !options.canRefresh(current)) {

--- a/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
+++ b/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
@@ -757,4 +757,96 @@ describe("AuthStorage OAuth refresh race", () => {
 			refresh: "refresh-old",
 		});
 	});
+
+	test("refreshes an expired stored credential even when it mismatches the observed copy", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		const now = Date.parse("2026-07-10T13:00:00.000Z");
+		setSystemTime(new Date(now));
+		await authStorage.set("unit-oauth-observed-mismatch-expired", [
+			{
+				type: "oauth",
+				access: "stored-access-expired",
+				refresh: "stored-refresh",
+				expires: now - 60_000,
+			},
+		]);
+
+		// The caller observed a different (also stale) copy of the credential — the
+		// exact state the finalize path hits when a concurrent usage-fetch cycle
+		// rotates the in-memory credential out from under the request between the
+		// selection sync and the refresh read. Before the fix the observed-mismatch
+		// guard returned the stored copy verbatim without checking whether it was
+		// usable, so the expired token flowed straight into getOAuthApiKey.
+		const observed = {
+			type: "oauth" as const,
+			access: "observed-access-different",
+			refresh: "stored-refresh",
+			expires: now - 120_000,
+		};
+
+		let refreshCalled = false;
+		const result = await authStorage.refreshStoredOAuthCredential("unit-oauth-observed-mismatch-expired", {
+			observedCredential: observed,
+			credentialFromRow: row => row,
+			forceRefresh: false,
+			refresh: async credential => {
+				refreshCalled = true;
+				return {
+					...credential,
+					access: "refreshed-access",
+					refresh: "stored-refresh",
+					expires: now + 60 * 60_000,
+				};
+			},
+		});
+
+		// The expired stored credential must be refreshed, not returned as-is.
+		expect(refreshCalled).toBe(true);
+		expect(result).toMatchObject({ refreshed: true, removed: false });
+		expect(result.credential).toMatchObject({ type: "oauth", access: "refreshed-access" });
+		const stored = store.listAuthCredentials("unit-oauth-observed-mismatch-expired");
+		expect(stored[0]?.credential).toMatchObject({ type: "oauth", access: "refreshed-access" });
+	});
+
+	test("adopts a fresh stored credential without refreshing when it mismatches the observed copy", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		const now = Date.parse("2026-07-10T13:30:00.000Z");
+		setSystemTime(new Date(now));
+		await authStorage.set("unit-oauth-observed-mismatch-fresh", [
+			{
+				type: "oauth",
+				access: "peer-rotated-access",
+				refresh: "peer-rotated-refresh",
+				expires: now + 60 * 60_000,
+			},
+		]);
+
+		// A peer already rotated the row to a fresh token; the caller's observed
+		// copy is stale. The fresh stored copy must be adopted without a redundant
+		// refresh (which would waste a rotation and could invalidate the peer's
+		// token).
+		const observed = {
+			type: "oauth" as const,
+			access: "stale-observed-access",
+			refresh: "stale-observed-refresh",
+			expires: now - 60_000,
+		};
+
+		let refreshCalled = false;
+		const result = await authStorage.refreshStoredOAuthCredential("unit-oauth-observed-mismatch-fresh", {
+			observedCredential: observed,
+			credentialFromRow: row => row,
+			forceRefresh: false,
+			refresh: async credential => {
+				refreshCalled = true;
+				return { ...credential, access: "should-not-be-used", expires: now + 60 * 60_000 };
+			},
+		});
+
+		expect(refreshCalled).toBe(false);
+		expect(result).toMatchObject({ refreshed: false, removed: false });
+		expect(result.credential).toMatchObject({ type: "oauth", access: "peer-rotated-access" });
+	});
 });


### PR DESCRIPTION
## Repro
With a long-running daemon and OAuth credentials (reported for `google-antigravity`), approving a plan aborts with `Failed to finalize approved plan: No API key found for google-antigravity...` even though the stored credentials hold valid refresh tokens — the usage-fetch path refreshes the very same credentials seconds later. The failure races: a concurrent usage-fetch cycle rotates the in-memory selected credential out from under the finalize request so the caller's observed credential no longer matches the persisted row.

Deterministic repro of the offending method:
```
bun test packages/ai/test/auth-storage-oauth-refresh-race.test.ts -t "mismatches the observed copy"
```
Before the fix, `refreshes an expired stored credential even when it mismatches the observed copy` fails: the refresh callback is never invoked (`refreshCalled` stays `false`), and the expired credential is returned as-is.

## Cause
`AuthStorage.refreshStoredOAuthCredential` (`packages/ai/src/auth-storage.ts`) has an observed-credential mismatch guard (present both before and after lease acquisition) intended to adopt a peer-rotated credential without racing to refresh again:
```ts
if (options.observedCredential && !authCredentialEquals(current, options.observedCredential)) {
  return { credential: current, refreshed: false, removed: false };
}
```
It returned `current` without verifying it was usable. When the observed credential differs from the stored row **and the stored row is itself expired**, it handed back the dead token; `getOAuthApiKey` (`packages/ai/src/registry/oauth/index.ts:135-146`) then refused it (`OAuth credential for <provider> is expired and must be refreshed via AuthStorage before getOAuthApiKey is called`), which `#tryOAuthCredential` logs as a non-definitive `OAuth token refresh failed` and returns `undefined` — surfacing to callers as `No API key found`. Note the reporter's `getApiKeyForProvider`/`hasAuth` pointer is off: with 8 stored credentials `hasAuth` returns `true`, so the keyless guard never fires; the defect is entirely in the refresh routine.

## Fix
- Compute `currentIsFresh` (`Date.now() + refreshSkewMs < current.expires`) once per guard block in `refreshStoredOAuthCredential`.
- Gate the observed-mismatch early-return on `currentIsFresh`, so an expired stored copy falls through to the normal refresh path instead of being returned dead. Applied to both the pre-lease (2330) and post-lease (2373) guards; the subsequent not-yet-expired short-circuit reuses the same `currentIsFresh` value.
- Fresh peer-rotated credentials still short-circuit without a redundant refresh (behavior preserved).

## Verification
- `bun test packages/ai/test/auth-storage-oauth-refresh-race.test.ts` — 17 pass (2 new: expired-mismatch now refreshes; fresh-mismatch still adopts without refreshing).
- `bun test packages/ai/test/auth-storage*.test.ts` — 295 pass, 0 fail.
- Pre-publish gate (`bun run fix` + `bun check`) passed on push.

Fixes #7179