### PR TITLE
feat(coding-agent): add per-agent service tiers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### Added
 
+- Added sparse per-agent service-tier overrides through `task.agentServiceTierOverrides`, editable in `/agents`, so selected subagents can use priority processing without enabling fast mode broadly ([#7106](https://github.com/can1357/oh-my-pi/issues/7106)).
 - Added `ExtensionAPI.registerFileWriteFallback(handler)` and `ExtensionAPI.registerFileDeleteFallback(handler)`, letting an extension supply a fallback writer or deleter that is consulted when a native `write`, `edit`, or `apply_patch` byte-write or unlink is denied with a permission error (`EPERM`/`EACCES`/`EROFS`) — for hosts that embed the agent inside a sandbox that denies direct filesystem access but exposes a privileged channel. The brokered path is symlink-resolved so a handler's allowlist sees the real destination, a destination that cannot be resolved is not brokered at all, and `req.sessionId` names the session that issued the mutation so a handler sharing the process-wide registry can enforce policy per session. See [`docs/extensions.md`](../../docs/extensions.md).
+
 ### Fixed
 
 - Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
@@ -549,8 +551,6 @@
 
 - Added an app.live.toggle keybinding (default Ctrl+L) to start or stop live voice mode.
 - Added ctx.invokeTool(params, options?) to extension contexts, allowing wrappers to run native tools while inheriting context, abort signals, and progress updates.
-- Added an `app.live.toggle` keybinding (default `Ctrl+L`) that starts or stops live voice mode, same as `/live`.
-- Added sparse per-agent service-tier overrides through `task.agentServiceTierOverrides`, editable with `T` in `/agents`, so selected subagents can use priority processing without enabling fast mode broadly ([#7106](https://github.com/can1357/oh-my-pi/issues/7106)).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -549,6 +549,8 @@
 
 - Added an app.live.toggle keybinding (default Ctrl+L) to start or stop live voice mode.
 - Added ctx.invokeTool(params, options?) to extension contexts, allowing wrappers to run native tools while inheriting context, abort signals, and progress updates.
+- Added an `app.live.toggle` keybinding (default `Ctrl+L`) that starts or stops live voice mode, same as `/live`.
+- Added sparse per-agent service-tier overrides through `task.agentServiceTierOverrides`, editable with `T` in `/agents`, so selected subagents can use priority processing without enabling fast mode broadly ([#7106](https://github.com/can1357/oh-my-pi/issues/7106)).
 
 ### Changed
 

--- a/packages/coding-agent/src/config/service-tier.ts
+++ b/packages/coding-agent/src/config/service-tier.ts
@@ -50,7 +50,7 @@ export function isServiceTierForFamily(family: string, tier: unknown): tier is S
  * Inherit-capable single value for the subagent/advisor tiers. The chosen tier
  * is broadcast across families and applied to whichever family the spawned
  * model belongs to (clamped to what that family realizes); `"inherit"` defers
- * to the main agent's live per-family selection.
+ * to the parent agent's live per-family selection.
  */
 export const SERVICE_TIER_INHERIT_SETTING_VALUES = [
 	"inherit",
@@ -108,7 +108,7 @@ export const SERVICE_TIER_GOOGLE_OPTIONS: ReadonlyArray<SubmenuOption<ServiceTie
 ];
 
 export const SERVICE_TIER_INHERIT_OPTIONS: ReadonlyArray<SubmenuOption<ServiceTierInheritSettingValue>> = [
-	{ value: "inherit", label: "Inherit", description: "Match the main agent's live per-family tiers" },
+	{ value: "inherit", label: "Inherit", description: "Match the parent agent's live per-family tiers" },
 	{ value: "none", label: "None", description: "Standard processing" },
 	{ value: "auto", label: "Auto", description: "Provider default tier selection (OpenAI family)" },
 	{ value: "default", label: "Default", description: "Standard priority processing (OpenAI family)" },

--- a/packages/coding-agent/src/config/service-tier.ts
+++ b/packages/coding-agent/src/config/service-tier.ts
@@ -64,6 +64,25 @@ export const SERVICE_TIER_INHERIT_SETTING_VALUES = [
 
 export type ServiceTierInheritSettingValue = (typeof SERVICE_TIER_INHERIT_SETTING_VALUES)[number];
 
+/** Whether a runtime value is an inherit-capable subagent service-tier setting. */
+export function isServiceTierInheritSettingValue(value: unknown): value is ServiceTierInheritSettingValue {
+	return typeof value === "string" && (SERVICE_TIER_INHERIT_SETTING_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Resolve one agent's sparse service-tier override. Missing or invalid entries
+ * deliberately use the configured subagent fallback so unvalidated settings
+ * values cannot reach provider configuration.
+ */
+export function resolveAgentServiceTierSetting(
+	agentName: string,
+	overrides: Readonly<Record<string, string>>,
+	fallback: ServiceTierInheritSettingValue,
+): ServiceTierInheritSettingValue {
+	const override = overrides[agentName];
+	return isServiceTierInheritSettingValue(override) ? override : fallback;
+}
+
 export const SERVICE_TIER_OPENAI_OPTIONS: ReadonlyArray<SubmenuOption<ServiceTierOpenAISettingValue>> = [
 	{ value: "none", label: "None", description: "Omit service_tier (standard processing)" },
 	{ value: "auto", label: "Auto", description: "Provider default tier selection" },

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4729,6 +4729,10 @@ export const SETTINGS_SCHEMA = {
 		type: "record",
 		default: DEFAULT_AGENT_MODEL_OVERRIDES,
 	},
+	"task.agentServiceTierOverrides": {
+		type: "record",
+		default: {} as Record<string, string>,
+	},
 	"task.agentPrewalk": {
 		type: "record",
 		default: {} as Record<string, string>,

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -487,6 +487,16 @@ export class Settings {
 	}
 
 	/**
+	 * Get a raw value from only the global settings layer.
+	 *
+	 * Unlike {@link get}, this does not merge project settings, config overlays,
+	 * runtime overrides, or schema defaults.
+	 */
+	getGlobalSetting<P extends SettingPath>(path: P): SettingValue<P> | undefined {
+		return getByPath(this.#global, SETTING_PATH_SEGMENTS[path]) as SettingValue<P> | undefined;
+	}
+
+	/**
 	 * Whether `path` has an explicitly configured value (global config, project
 	 * config, or runtime override) rather than falling back to the schema default.
 	 */

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -42,6 +42,7 @@ import { AUTO_IMAGE_PROVIDER_ORDER, isImageProviderId } from "../tools/image-pro
 import { type EditMode, normalizeEditMode } from "../utils/edit-mode";
 import { INSPECT_IMAGE_MODES } from "../utils/inspect-image-mode";
 import { isSearchProviderId, SEARCH_PROVIDER_ORDER } from "../web/search/types";
+import type { ServiceTierInheritSettingValue } from "./service-tier";
 import {
 	type BashInterceptorRule,
 	type GroupPrefix,
@@ -353,6 +354,8 @@ export class Settings {
 	#modifiedProjectModelRoles = new Set<string>();
 	/** Individual global model roles modified during this session (for partial save) */
 	#modifiedGlobalModelRoles = new Set<string>();
+	/** Individual global per-agent service tiers modified during this session (for partial save) */
+	#modifiedGlobalAgentServiceTierOverrides = new Set<string>();
 	/**
 	 * Original process-wide model-role overrides captured before a project edit
 	 * temporarily replaced them via `#updateRuntimeModelRoleOverride`. Restored
@@ -606,7 +609,11 @@ export class Settings {
 		if (this.#projectSavePromise) {
 			await this.#projectSavePromise;
 		}
-		if (this.#modified.size > 0 || this.#modifiedGlobalModelRoles.size > 0) {
+		if (
+			this.#modified.size > 0 ||
+			this.#modifiedGlobalModelRoles.size > 0 ||
+			this.#modifiedGlobalAgentServiceTierOverrides.size > 0
+		) {
 			await this.#saveNow();
 		}
 		if (this.#modifiedProjectModelRoles.size > 0) {
@@ -779,6 +786,18 @@ export class Settings {
 		return roles;
 	}
 
+	#agentServiceTierOverridesFromLayer(layer: RawSettings): Record<string, string> {
+		const value = getByPath(layer, ["task", "agentServiceTierOverrides"]);
+		if (!isRecord(value)) return {};
+
+		const overrides: Record<string, string> = {};
+		for (const agentName in value) {
+			if (!Object.hasOwn(value, agentName) || typeof value[agentName] !== "string") continue;
+			overrides[agentName] = value[agentName];
+		}
+		return overrides;
+	}
+
 	#modelRoleLayerOwns(layer: RawSettings, role: ModelRole | string): boolean {
 		const value = getByPath(layer, ["modelRoles"]);
 		if (!isRecord(value)) return false;
@@ -921,6 +940,26 @@ export class Settings {
 		}
 		this.#savedRuntimeModelRoleOverrides.delete(role);
 		this.#updateRuntimeModelRoleOverride(role, modelId);
+	}
+
+	/**
+	 * Set one global per-agent service-tier override without replacing sibling
+	 * entries that another process may have written since this instance loaded.
+	 */
+	setAgentServiceTierOverride(agentName: string, setting: ServiceTierInheritSettingValue | undefined): void {
+		const path = "task.agentServiceTierOverrides";
+		const prev = this.get(path);
+		const current = this.#agentServiceTierOverridesFromLayer(this.#global);
+		if (setting === undefined) {
+			delete current[agentName];
+		} else {
+			current[agentName] = setting;
+		}
+		setByPath(this.#global, ["task", "agentServiceTierOverrides"], current);
+		this.#modifiedGlobalAgentServiceTierOverrides.add(agentName);
+		this.#rebuildMerged();
+		this.#queueSave();
+		this.#fireEffectiveSettingChanged(path, this.get(path), prev);
 	}
 
 	/**
@@ -2058,14 +2097,22 @@ export class Settings {
 
 	async #saveNow(): Promise<void> {
 		if (this.#savesCancelled || !this.#persist || !this.#configPath) return;
-		if (this.#modified.size === 0 && this.#modifiedGlobalModelRoles.size === 0) return;
+		if (
+			this.#modified.size === 0 &&
+			this.#modifiedGlobalModelRoles.size === 0 &&
+			this.#modifiedGlobalAgentServiceTierOverrides.size === 0
+		)
+			return;
 
 		const configPath = this.#configPath;
 		const modifiedPaths = [...this.#modified];
 		const modifiedModelRoles = [...this.#modifiedGlobalModelRoles];
 		const globalRolesAtStart = this.#modelRolesFromLayer(this.#global);
+		const modifiedAgentServiceTierOverrides = [...this.#modifiedGlobalAgentServiceTierOverrides];
+		const globalAgentServiceTierOverridesAtStart = this.#agentServiceTierOverridesFromLayer(this.#global);
 		this.#modified.clear();
 		this.#modifiedGlobalModelRoles.clear();
+		this.#modifiedGlobalAgentServiceTierOverrides.clear();
 
 		try {
 			await this.#withYamlWriteLock(configPath, async writePath => {
@@ -2118,6 +2165,46 @@ export class Settings {
 					setByPath(current, ["modelRoles"], mergedRoles);
 				}
 
+				// Merge only the per-agent tier entries captured by this save.
+				// Preserve newer local edits while the async read/lock was pending.
+				const latestGlobalAgentServiceTierOverrides = this.#agentServiceTierOverridesFromLayer(this.#global);
+				const agentServiceTierOverridesToPreserve = new Set(this.#modifiedGlobalAgentServiceTierOverrides);
+				for (const agentName in globalAgentServiceTierOverridesAtStart) {
+					if (
+						globalAgentServiceTierOverridesAtStart[agentName] !== latestGlobalAgentServiceTierOverrides[agentName]
+					) {
+						agentServiceTierOverridesToPreserve.add(agentName);
+					}
+				}
+				for (const agentName in latestGlobalAgentServiceTierOverrides) {
+					if (
+						globalAgentServiceTierOverridesAtStart[agentName] !== latestGlobalAgentServiceTierOverrides[agentName]
+					) {
+						agentServiceTierOverridesToPreserve.add(agentName);
+					}
+				}
+				if (modifiedAgentServiceTierOverrides.length > 0 || agentServiceTierOverridesToPreserve.size > 0) {
+					const currentOverrides = getByPath(current, ["task", "agentServiceTierOverrides"]);
+					const mergedOverrides: Record<string, unknown> = isRecord(currentOverrides)
+						? { ...currentOverrides }
+						: {};
+					for (const agentName of modifiedAgentServiceTierOverrides) {
+						if (Object.hasOwn(globalAgentServiceTierOverridesAtStart, agentName)) {
+							mergedOverrides[agentName] = globalAgentServiceTierOverridesAtStart[agentName];
+						} else {
+							delete mergedOverrides[agentName];
+						}
+					}
+					for (const agentName of agentServiceTierOverridesToPreserve) {
+						if (Object.hasOwn(latestGlobalAgentServiceTierOverrides, agentName)) {
+							mergedOverrides[agentName] = latestGlobalAgentServiceTierOverrides[agentName];
+						} else {
+							delete mergedOverrides[agentName];
+						}
+					}
+					setByPath(current, ["task", "agentServiceTierOverrides"], mergedOverrides);
+				}
+
 				// Update our global with any external changes we preserved
 				this.#global = current;
 				await this.#writeYamlAtomically(writePath, this.#global);
@@ -2130,6 +2217,15 @@ export class Settings {
 						this.#modifiedGlobalModelRoles.delete(role);
 					}
 				}
+				const globalAgentServiceTierOverridesAfterWrite = this.#agentServiceTierOverridesFromLayer(this.#global);
+				for (const agentName of agentServiceTierOverridesToPreserve) {
+					if (
+						latestGlobalAgentServiceTierOverrides[agentName] ===
+						globalAgentServiceTierOverridesAfterWrite[agentName]
+					) {
+						this.#modifiedGlobalAgentServiceTierOverrides.delete(agentName);
+					}
+				}
 			});
 		} catch (error) {
 			logger.warn("Settings: save failed", { error: String(error) });
@@ -2139,6 +2235,9 @@ export class Settings {
 			}
 			for (const role of modifiedModelRoles) {
 				this.#modifiedGlobalModelRoles.add(role);
+			}
+			for (const agentName of modifiedAgentServiceTierOverrides) {
+				this.#modifiedGlobalAgentServiceTierOverrides.add(agentName);
 			}
 			this.#rebuildMerged();
 			throw error;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -135,6 +135,7 @@ const HOST_DEFAULTED_SETTING_PATHS: SettingPath[] = [
 	"task.maxRecursionDepth",
 	"task.disabledAgents",
 	"task.agentModelOverrides",
+	"task.agentServiceTierOverrides",
 	"task.agentPrewalk",
 	"task.agentAdvisor",
 	// Memory subsystems are off-by-default for RPC/ACP hosts; embedders that want

--- a/packages/coding-agent/src/modes/components/agents-hub.ts
+++ b/packages/coding-agent/src/modes/components/agents-hub.ts
@@ -301,7 +301,7 @@ export class AgentsHubComponent implements Component {
 			const overrides = this.#settings.get("task.agentModelOverrides") ?? {};
 			const prewalkOverrides = this.#settings.get("task.agentPrewalk") ?? {};
 			const advisorOverrides = this.#settings.get("task.agentAdvisor") ?? {};
-			const serviceTierOverrides = this.#settings.get("task.agentServiceTierOverrides") ?? {};
+			const serviceTierOverrides = this.#settings.getGlobalSetting("task.agentServiceTierOverrides") ?? {};
 			this.#allAgents = agents
 				.slice()
 				.sort((a, b) => {
@@ -454,7 +454,7 @@ export class AgentsHubComponent implements Component {
 
 	#persistRecord(changedAgent: HubAgent, property: PropertyKind): void {
 		if (property === "serviceTier") {
-			const overrides = { ...this.#settings.get("task.agentServiceTierOverrides") };
+			const overrides = { ...this.#settings.getGlobalSetting("task.agentServiceTierOverrides") };
 			const value = changedAgent.serviceTierOverride;
 			if (isServiceTierInheritSettingValue(value)) {
 				overrides[changedAgent.name] = value;

--- a/packages/coding-agent/src/modes/components/agents-hub.ts
+++ b/packages/coding-agent/src/modes/components/agents-hub.ts
@@ -429,12 +429,7 @@ export class AgentsHubComponent implements Component {
 	} {
 		const fallbackSetting = this.#settings.get("tier.subagent");
 		const fallback = isServiceTierInheritSettingValue(fallbackSetting) ? fallbackSetting : "inherit";
-		const overrides: Record<string, string> = {};
-		for (const entry of this.#allAgents) {
-			if (isServiceTierInheritSettingValue(entry.serviceTierOverride)) {
-				overrides[entry.name] = entry.serviceTierOverride;
-			}
-		}
+		const overrides = this.#settings.get("task.agentServiceTierOverrides") ?? {};
 		return {
 			setting: resolveAgentServiceTierSetting(agent.name, overrides, fallback),
 			source: isServiceTierInheritSettingValue(overrides[agent.name]) ? "override" : "tier.subagent",
@@ -457,7 +452,19 @@ export class AgentsHubComponent implements Component {
 		this.#tui.requestRender();
 	}
 
-	#persistRecord(property: PropertyKind): void {
+	#persistRecord(changedAgent: HubAgent, property: PropertyKind): void {
+		if (property === "serviceTier") {
+			const overrides = { ...this.#settings.get("task.agentServiceTierOverrides") };
+			const value = changedAgent.serviceTierOverride;
+			if (isServiceTierInheritSettingValue(value)) {
+				overrides[changedAgent.name] = value;
+			} else {
+				delete overrides[changedAgent.name];
+			}
+			this.#settings.set("task.agentServiceTierOverrides", overrides);
+			return;
+		}
+
 		const overrides: Record<string, string> = {};
 		for (const agent of this.#allAgents) {
 			const value = this.#overrideFor(agent, property)?.trim();
@@ -468,9 +475,7 @@ export class AgentsHubComponent implements Component {
 				? "task.agentModelOverrides"
 				: property === "prewalk"
 					? "task.agentPrewalk"
-					: property === "advisor"
-						? "task.agentAdvisor"
-						: "task.agentServiceTierOverrides";
+					: "task.agentAdvisor";
 		this.#settings.set(key, overrides);
 	}
 
@@ -503,7 +508,7 @@ export class AgentsHubComponent implements Component {
 				agent.serviceTierOverride = isServiceTierInheritSettingValue(trimmed) ? trimmed : undefined;
 				break;
 		}
-		this.#persistRecord(property);
+		this.#persistRecord(agent, property);
 		this.#notice = this.#describeProperty(agent, property);
 		this.#tui.requestRender();
 	}

--- a/packages/coding-agent/src/modes/components/agents-hub.ts
+++ b/packages/coding-agent/src/modes/components/agents-hub.ts
@@ -436,7 +436,6 @@ export class AgentsHubComponent implements Component {
 		};
 	}
 
-
 	// ═══════════════════════════════════════════════════════════════════════
 	// Mutations
 	// ═══════════════════════════════════════════════════════════════════════
@@ -454,14 +453,11 @@ export class AgentsHubComponent implements Component {
 
 	#persistRecord(changedAgent: HubAgent, property: PropertyKind): void {
 		if (property === "serviceTier") {
-			const overrides = { ...this.#settings.getGlobalSetting("task.agentServiceTierOverrides") };
 			const value = changedAgent.serviceTierOverride;
-			if (isServiceTierInheritSettingValue(value)) {
-				overrides[changedAgent.name] = value;
-			} else {
-				delete overrides[changedAgent.name];
-			}
-			this.#settings.set("task.agentServiceTierOverrides", overrides);
+			this.#settings.setAgentServiceTierOverride(
+				changedAgent.name,
+				isServiceTierInheritSettingValue(value) ? value : undefined,
+			);
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/components/agents-hub.ts
+++ b/packages/coding-agent/src/modes/components/agents-hub.ts
@@ -38,6 +38,12 @@ import {
 	resolveConfiguredModelPatterns,
 	resolveModelOverride,
 } from "../../config/model-resolver";
+import {
+	isServiceTierInheritSettingValue,
+	resolveAgentServiceTierSetting,
+	SERVICE_TIER_INHERIT_SETTING_VALUES,
+	type ServiceTierInheritSettingValue,
+} from "../../config/service-tier";
 import type { Settings } from "../../config/settings";
 import agentCreationArchitectPrompt from "../../prompts/system/agent-creation-architect.md" with { type: "text" };
 import agentCreationUserPrompt from "../../prompts/system/agent-creation-user.md" with { type: "text" };
@@ -66,6 +72,8 @@ interface HubAgent extends AgentDefinition {
 	prewalkOverride?: string;
 	/** `task.agentAdvisor[name]`: "on", "off", or a model pattern. */
 	advisorOverride?: string;
+	/** `task.agentServiceTierOverrides[name]`: a service-tier setting. */
+	serviceTierOverride?: ServiceTierInheritSettingValue;
 }
 
 const SOURCE_LABEL: Record<AgentSource, string> = {
@@ -87,7 +95,7 @@ interface SidebarEntry {
 type ListRow = { kind: "agent"; agent: HubAgent } | { kind: "new" };
 
 /** The per-agent knob a strip or the model browser is editing. */
-type PropertyKind = "model" | "prewalk" | "advisor";
+type PropertyKind = "model" | "prewalk" | "advisor" | "serviceTier";
 
 interface StripChip {
 	label: string;
@@ -293,6 +301,7 @@ export class AgentsHubComponent implements Component {
 			const overrides = this.#settings.get("task.agentModelOverrides") ?? {};
 			const prewalkOverrides = this.#settings.get("task.agentPrewalk") ?? {};
 			const advisorOverrides = this.#settings.get("task.agentAdvisor") ?? {};
+			const serviceTierOverrides = this.#settings.get("task.agentServiceTierOverrides") ?? {};
 			this.#allAgents = agents
 				.slice()
 				.sort((a, b) => {
@@ -302,6 +311,7 @@ export class AgentsHubComponent implements Component {
 				})
 				.map(agent => {
 					const override = overrides[agent.name];
+					const serviceTierOverride = serviceTierOverrides[agent.name];
 					const overrideModel = (Array.isArray(override) ? override.join(",") : (override ?? "")).trim();
 					return {
 						...agent,
@@ -309,6 +319,9 @@ export class AgentsHubComponent implements Component {
 						overrideModel: overrideModel || undefined,
 						prewalkOverride: prewalkOverrides[agent.name]?.trim() || undefined,
 						advisorOverride: advisorOverrides[agent.name]?.trim() || undefined,
+						serviceTierOverride: isServiceTierInheritSettingValue(serviceTierOverride)
+							? serviceTierOverride
+							: undefined,
 					};
 				});
 			this.#buildSidebar();
@@ -410,6 +423,24 @@ export class AgentsHubComponent implements Component {
 		});
 		return selection ? (selection.model ?? "@advisor") : undefined;
 	}
+	#effectiveServiceTier(agent: HubAgent): {
+		setting: ServiceTierInheritSettingValue;
+		source: "override" | "tier.subagent";
+	} {
+		const fallbackSetting = this.#settings.get("tier.subagent");
+		const fallback = isServiceTierInheritSettingValue(fallbackSetting) ? fallbackSetting : "inherit";
+		const overrides: Record<string, string> = {};
+		for (const entry of this.#allAgents) {
+			if (isServiceTierInheritSettingValue(entry.serviceTierOverride)) {
+				overrides[entry.name] = entry.serviceTierOverride;
+			}
+		}
+		return {
+			setting: resolveAgentServiceTierSetting(agent.name, overrides, fallback),
+			source: isServiceTierInheritSettingValue(overrides[agent.name]) ? "override" : "tier.subagent",
+		};
+	}
+
 
 	// ═══════════════════════════════════════════════════════════════════════
 	// Mutations
@@ -437,7 +468,9 @@ export class AgentsHubComponent implements Component {
 				? "task.agentModelOverrides"
 				: property === "prewalk"
 					? "task.agentPrewalk"
-					: "task.agentAdvisor";
+					: property === "advisor"
+						? "task.agentAdvisor"
+						: "task.agentServiceTierOverrides";
 		this.#settings.set(key, overrides);
 	}
 
@@ -449,6 +482,8 @@ export class AgentsHubComponent implements Component {
 				return agent.prewalkOverride;
 			case "advisor":
 				return agent.advisorOverride;
+			case "serviceTier":
+				return agent.serviceTierOverride;
 		}
 	}
 
@@ -463,6 +498,9 @@ export class AgentsHubComponent implements Component {
 				break;
 			case "advisor":
 				agent.advisorOverride = trimmed;
+				break;
+			case "serviceTier":
+				agent.serviceTierOverride = isServiceTierInheritSettingValue(trimmed) ? trimmed : undefined;
 				break;
 		}
 		this.#persistRecord(property);
@@ -487,6 +525,10 @@ export class AgentsHubComponent implements Component {
 				const pattern = this.#effectiveAdvisorPattern(agent);
 				return `${agent.name} advisor: ${pattern ? `on (${pattern})` : "off"}`;
 			}
+			case "serviceTier": {
+				const { setting, source } = this.#effectiveServiceTier(agent);
+				return `${agent.name} service tier: ${setting} (${source})`;
+			}
 		}
 	}
 
@@ -505,6 +547,10 @@ export class AgentsHubComponent implements Component {
 			case "advisor": {
 				const pattern = this.#effectiveAdvisorPattern(agent);
 				return pattern ?? "off";
+			}
+			case "serviceTier": {
+				const { setting, source } = this.#effectiveServiceTier(agent);
+				return `${setting} (${source})`;
 			}
 		}
 	}
@@ -529,7 +575,13 @@ export class AgentsHubComponent implements Component {
 		this.#strip = {
 			kind: "chips",
 			agent,
-			chips: [enabledChip, propertyChip("model"), propertyChip("prewalk"), propertyChip("advisor")],
+			chips: [
+				enabledChip,
+				propertyChip("model"),
+				propertyChip("prewalk"),
+				propertyChip("advisor"),
+				propertyChip("serviceTier"),
+			],
 			index: 1,
 		};
 	}
@@ -556,6 +608,19 @@ export class AgentsHubComponent implements Component {
 					label: "clear override",
 					styled: theme.fg("warning", "clear override"),
 					action: { kind: "set", property, value: undefined },
+				});
+			}
+		} else if (property === "serviceTier") {
+			chips.push({
+				label: "tier.subagent",
+				styled: mark("tier.subagent", current === undefined),
+				action: { kind: "set", property, value: undefined },
+			});
+			for (const setting of SERVICE_TIER_INHERIT_SETTING_VALUES) {
+				chips.push({
+					label: setting,
+					styled: mark(setting, current === setting),
+					action: { kind: "set", property, value: setting },
 				});
 			}
 		} else {
@@ -1278,9 +1343,14 @@ export class AgentsHubComponent implements Component {
 			lines.push(truncateToWidth(` ${modelLine}`, width));
 			const prewalk = this.#effectivePrewalkPattern(agent);
 			const advisor = this.#effectiveAdvisorPattern(agent);
+			const serviceTier = this.#effectiveServiceTier(agent);
 			const flagLine = [
 				`${theme.fg("muted", "prewalk:")} ${prewalk ? theme.fg("success", prewalk) : theme.fg("dim", "off")}`,
 				`${theme.fg("muted", "advisor:")} ${advisor ? theme.fg("success", advisor) : theme.fg("dim", "off")}`,
+				`${theme.fg("muted", "service tier:")} ${theme.fg("success", serviceTier.setting)} ${theme.fg(
+					serviceTier.source === "override" ? "warning" : "dim",
+					`(${serviceTier.source})`,
+				)}`,
 				agent.filePath ? theme.fg("dim", shortenPath(agent.filePath)) : "",
 			]
 				.filter(Boolean)
@@ -1363,7 +1433,12 @@ export class AgentsHubComponent implements Component {
 		if (this.#strip) {
 			if (this.#strip.kind === "pattern") {
 				const property = this.#strip.property;
-				const values = property === "model" ? "a model pattern" : '"on", "off", or a model pattern';
+				const values =
+					property === "model"
+						? "a model pattern"
+						: property === "serviceTier"
+							? "a service-tier override"
+							: '"on", "off", or a model pattern';
 				return `Enter ${values} (role aliases like @smol and :level suffixes work; empty clears) · Esc back`;
 			}
 			return this.#strip.property ? "←/→ choose · Enter apply · Esc back" : "←/→ choose · Enter open · Esc cancel";

--- a/packages/coding-agent/src/session/session-entries.ts
+++ b/packages/coding-agent/src/session/session-entries.ts
@@ -229,6 +229,10 @@ export interface SessionInitEntry extends SessionEntryBase {
 	readSummarize?: boolean;
 	/** Effective advisor for this subagent: `"on"` = advisor-role model, else an explicit model pattern; absent = unadvised. */
 	advisor?: string;
+	/** Explicit per-agent service-tier override; absent means use the current subagent fallback on revival. */
+	serviceTierOverride?: string;
+	/** Immediate parent's effective tiers recorded for faithful `inherit` revival; absent in legacy entries. */
+	parentServiceTier?: ServiceTierByFamily;
 }
 
 /** Mode change entry - tracks agent mode transitions (e.g. plan mode). */

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2214,6 +2214,8 @@ export class SessionManager {
 		spawns?: string;
 		readSummarize?: boolean;
 		advisor?: string;
+		serviceTierOverride?: string;
+		parentServiceTier?: ServiceTierByFamily;
 	}): string {
 		const entry: SessionInitEntry = { type: "session_init", ...this.#freshEntryFields(), ...init };
 		this.#recordEntry(entry);
@@ -2741,6 +2743,8 @@ export class SessionManager {
 			spawns?: string;
 			readSummarize?: boolean;
 			advisor?: string;
+			serviceTierOverride?: string;
+			parentServiceTier?: ServiceTierByFamily;
 		} | null;
 	} | null> {
 		let header: SessionHeader | undefined;
@@ -2757,6 +2761,8 @@ export class SessionManager {
 			spawns?: string;
 			readSummarize?: boolean;
 			advisor?: string;
+			serviceTierOverride?: string;
+			parentServiceTier?: ServiceTierByFamily;
 		} | null = null;
 		const visit = (entry: FileEntry): void => {
 			if (entry.type === "session") {
@@ -2775,6 +2781,8 @@ export class SessionManager {
 					outputSchemaMode: entry.outputSchemaMode,
 					restrictToolNames: entry.restrictToolNames,
 					readSummarize: entry.readSummarize,
+					serviceTierOverride: entry.serviceTierOverride,
+					parentServiceTier: entry.parentServiceTier,
 					spawns: entry.spawns,
 					advisor: entry.advisor,
 				};

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -23,7 +23,13 @@ import {
 	resolveModelOverrideWithAuthFallback,
 } from "../config/model-resolver";
 import type { PromptTemplate } from "../config/prompt-templates";
-import { buildServiceTierByFamily, resolveSubagentServiceTier } from "../config/service-tier";
+import {
+	buildServiceTierByFamily,
+	isServiceTierInheritSettingValue,
+	resolveAgentServiceTierSetting,
+	resolveSubagentServiceTier,
+	type ServiceTierInheritSettingValue,
+} from "../config/service-tier";
 import { Settings } from "../config/settings";
 import { SETTINGS_SCHEMA, type SettingPath } from "../config/settings-schema";
 import type { ToolPathWithSource } from "../extensibility/custom-tools";
@@ -863,15 +869,16 @@ export function createSubagentSettings(
 	baseSettings: Settings,
 	overrides?: Partial<Record<SettingPath, unknown>>,
 	inheritedServiceTier?: ServiceTierByFamily | null,
+	serviceTierSetting: ServiceTierInheritSettingValue = baseSettings.get("tier.subagent"),
 ): Settings {
 	const snapshot: Partial<Record<SettingPath, unknown>> = {};
 	for (const key of Object.keys(SETTINGS_SCHEMA) as SettingPath[]) {
 		snapshot[key] = baseSettings.get(key);
 	}
-	// Resolve the subagent's per-family tiers from `tier.subagent` ("inherit" =
-	// match the parent's live tiers when a live session supplied them, else the
-	// subagent's own configured tier.* settings). The result is stamped back onto
-	// the snapshot so createAgentSession's tier.* reads pick it up.
+	// Resolve the selected subagent tier. It normally comes from
+	// `tier.subagent`, while a per-agent setting can be supplied by the task
+	// executor. `"inherit"` matches the parent's live tiers when a live session
+	// supplied them; otherwise it uses the subagent's configured `tier.*` values.
 	const inheritedTiers =
 		inheritedServiceTier === undefined
 			? buildServiceTierByFamily(
@@ -880,7 +887,7 @@ export function createSubagentSettings(
 					baseSettings.get("tier.google"),
 				)
 			: (inheritedServiceTier ?? {});
-	const subagentTiers = resolveSubagentServiceTier(baseSettings.get("tier.subagent"), inheritedTiers);
+	const subagentTiers = resolveSubagentServiceTier(serviceTierSetting, inheritedTiers);
 	snapshot["tier.openai"] = subagentTiers.openai ?? "none";
 	snapshot["tier.anthropic"] = subagentTiers.anthropic ?? "none";
 	snapshot["tier.google"] = subagentTiers.google ?? "none";
@@ -2708,6 +2715,24 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		settingsOverride: settings.get("task.agentAdvisor")[agent.name],
 		agentAdvisor: agent.advisor,
 	});
+	const serviceTierOverrides = settings.get("task.agentServiceTierOverrides");
+	const configuredServiceTierOverride = serviceTierOverrides[agent.name];
+	const serviceTierOverride = isServiceTierInheritSettingValue(configuredServiceTierOverride)
+		? configuredServiceTierOverride
+		: undefined;
+	const serviceTierSetting = resolveAgentServiceTierSetting(
+		agent.name,
+		serviceTierOverrides,
+		settings.get("tier.subagent"),
+	);
+	const parentServiceTier =
+		options.parentServiceTier === undefined
+			? buildServiceTierByFamily(
+					settings.get("tier.openai"),
+					settings.get("tier.anthropic"),
+					settings.get("tier.google"),
+				)
+			: { ...(options.parentServiceTier ?? {}) };
 	const subagentSettings = createSubagentSettings(
 		settings,
 		{
@@ -2719,7 +2744,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				? { modelRoles: { ...settings.getModelRoles(), advisor: advisorSelection.model } }
 				: undefined),
 		},
-		options.parentServiceTier,
+		parentServiceTier,
+		serviceTierSetting,
 	);
 	const maxRecursionDepth = settings.get("task.maxRecursionDepth") ?? 2;
 	const maxRuntimeMs = Math.max(
@@ -3209,6 +3235,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				spawns: spawnsEnv,
 				readSummarize: agent.readSummarize,
 				advisor: advisorSelection ? (advisorSelection.model ?? "on") : undefined,
+				serviceTierOverride,
+				parentServiceTier,
 				outputSchema,
 				outputSchemaMode: options.outputSchemaMode,
 				restrictToolNames: restrictToolNames || undefined,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2715,7 +2715,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		settingsOverride: settings.get("task.agentAdvisor")[agent.name],
 		agentAdvisor: agent.advisor,
 	});
-	const serviceTierOverrides = settings.get("task.agentServiceTierOverrides");
+	const serviceTierOverrides = settings.get("task.agentServiceTierOverrides") ?? {};
 	const configuredServiceTierOverride = serviceTierOverrides[agent.name];
 	const serviceTierOverride = isServiceTierInheritSettingValue(configuredServiceTierOverride)
 		? configuredServiceTierOverride

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import type { ModelRegistry } from "../config/model-registry";
 import { formatModelRoleAlias } from "../config/model-roles";
+import { isServiceTierInheritSettingValue } from "../config/service-tier";
 import type { Settings } from "../config/settings";
 import { MCPManager } from "../mcp/manager";
 import type { PersistedSubagentReviverFactory } from "../registry/agent-lifecycle";
@@ -79,21 +80,6 @@ export function createPersistedSubagentReviverFactory(
 			taskDepth++;
 			parentId = registry.get(parentId)?.parentId;
 		}
-		// Rebuild the same advisor opt-in the original spawn resolved: `"on"` =
-		// advisor-role model, anything else = the explicit pattern stamped onto
-		// this session's `modelRoles.advisor`. Absent = unadvised (the
-		// createSubagentSettings default).
-		const subagentSettings = createSubagentSettings(ctx.settings, {
-			...(init.readSummarize === false ? { "read.summarize.enabled": false } : undefined),
-			...(init.advisor
-				? {
-						"advisor.enabled": true,
-						...(init.advisor !== "on"
-							? { modelRoles: { ...ctx.settings.getModelRoles(), advisor: init.advisor } }
-							: undefined),
-					}
-				: undefined),
-		});
 		const persistedModelPattern =
 			init.modelRole && init.modelRole !== "default"
 				? [formatModelRoleAlias(init.modelRole), ...(init.resolvedModel ? [init.resolvedModel] : [])]
@@ -111,6 +97,31 @@ export function createPersistedSubagentReviverFactory(
 			const restrictToolNames = init.restrictToolNames === true;
 			const mcpManager = restrictToolNames ? undefined : MCPManager.instance();
 			const mcpProxyTools = mcpManager ? createMCPProxyTools(mcpManager) : [];
+			// New entries snapshot the immediate parent used by `inherit`; legacy
+			// entries retain the prior top-level live-session fallback.
+			const parentServiceTier = init.parentServiceTier ?? ctx.session.serviceTierByFamily;
+			// Rebuild the same advisor opt-in the original spawn resolved: `"on"` =
+			// advisor-role model, anything else = the explicit pattern stamped onto
+			// this session's `modelRoles.advisor`. Absent = unadvised (the
+			// createSubagentSettings default).
+			const subagentSettings = createSubagentSettings(
+				ctx.settings,
+				{
+					...(init.readSummarize === false ? { "read.summarize.enabled": false } : undefined),
+					...(init.advisor
+						? {
+								"advisor.enabled": true,
+								...(init.advisor !== "on"
+									? { modelRoles: { ...ctx.settings.getModelRoles(), advisor: init.advisor } }
+									: undefined),
+							}
+						: undefined),
+				},
+				parentServiceTier,
+				isServiceTierInheritSettingValue(init.serviceTierOverride)
+					? init.serviceTierOverride
+					: ctx.settings.get("tier.subagent"),
+			);
 			const { session } = await createAgentSession({
 				cwd: ctx.session.sessionManager.getCwd(),
 				authStorage: ctx.authStorage,

--- a/packages/coding-agent/test/agents-hub.test.ts
+++ b/packages/coding-agent/test/agents-hub.test.ts
@@ -52,7 +52,7 @@ function mockAgents(): void {
 	});
 }
 
-async function createHub(settings: Settings): Promise<{
+async function createHub(settings: Settings, cwd = tempCwd): Promise<{
 	hub: AgentsHubComponent;
 	strip: () => string;
 	type: (text: string) => void;
@@ -61,7 +61,7 @@ async function createHub(settings: Settings): Promise<{
 	let cancelled = false;
 	const hub = await AgentsHubComponent.create(
 		tuiStub,
-		tempCwd,
+		cwd,
 		settings,
 		{ modelRegistry: registryStub },
 		{ onCancel: () => (cancelled = true) },
@@ -277,6 +277,64 @@ describe("AgentsHub service-tier override", () => {
 		hub.handleInput("\r");
 		expect(settings.get("task.agentServiceTierOverrides")).toEqual({
 			"temporarily-undiscovered-agent": "priority",
+		});
+	});
+
+	test("keeps project and overlay tier overrides out of global settings", async () => {
+		vi.spyOn(discovery, "discoverAgents").mockResolvedValue({
+			projectAgentsDir: null,
+			agents: [{ name: "task", description: "Generic task agent", systemPrompt: "", source: "bundled" }],
+		});
+		const cwd = await fs.mkdtemp(path.join(tempCwd, "tier-scope-"));
+		const agentDir = path.join(cwd, "agent-config");
+		const overlayPath = path.join(cwd, "project-overlay.yml");
+		const globalOnlyCwd = await fs.mkdtemp(path.join(tempCwd, "global-only-"));
+		await Bun.write(
+			path.join(agentDir, "config.yml"),
+			"task:\n  agentServiceTierOverrides:\n    global-only-agent: none\n",
+		);
+		await Bun.write(
+			path.join(cwd, ".omp", "settings.json"),
+			JSON.stringify({
+				task: { agentServiceTierOverrides: { "project-only-agent": "auto", task: "flex" } },
+			}),
+		);
+		await Bun.write(
+			overlayPath,
+			"task:\n  agentServiceTierOverrides:\n    task: priority\n    overlay-only-agent: flex\n",
+		);
+		const settings = await Settings.loadIsolated({ cwd, agentDir, configFiles: [overlayPath] });
+		expect(settings.get("task.agentServiceTierOverrides")).toEqual({
+			"global-only-agent": "none",
+			"project-only-agent": "auto",
+			task: "priority",
+			"overlay-only-agent": "flex",
+		});
+		const { hub, strip } = await createHub(settings, cwd);
+		const openServiceTierStrip = () => {
+			hub.handleInput("\r");
+			for (let i = 0; i < 3; i++) hub.handleInput("\x1b[C");
+			hub.handleInput("\r");
+		};
+
+		openServiceTierStrip();
+		hub.handleInput("\x1b[C");
+		hub.handleInput("\r");
+		expect(strip()).toContain("service tier: priority (override)");
+		await settings.flush();
+		const afterGlobalEdit = await Settings.loadIsolated({ cwd: globalOnlyCwd, agentDir });
+		expect(afterGlobalEdit.get("task.agentServiceTierOverrides")).toEqual({
+			"global-only-agent": "none",
+			task: "inherit",
+		});
+
+		openServiceTierStrip();
+		hub.handleInput("\r");
+		expect(strip()).toContain("service tier: priority (override)");
+		await settings.flush();
+		const afterGlobalClear = await Settings.loadIsolated({ cwd: globalOnlyCwd, agentDir });
+		expect(afterGlobalClear.get("task.agentServiceTierOverrides")).toEqual({
+			"global-only-agent": "none",
 		});
 	});
 });

--- a/packages/coding-agent/test/agents-hub.test.ts
+++ b/packages/coding-agent/test/agents-hub.test.ts
@@ -52,7 +52,10 @@ function mockAgents(): void {
 	});
 }
 
-async function createHub(settings: Settings, cwd = tempCwd): Promise<{
+async function createHub(
+	settings: Settings,
+	cwd = tempCwd,
+): Promise<{
 	hub: AgentsHubComponent;
 	strip: () => string;
 	type: (text: string) => void;
@@ -277,6 +280,32 @@ describe("AgentsHub service-tier override", () => {
 		hub.handleInput("\r");
 		expect(settings.get("task.agentServiceTierOverrides")).toEqual({
 			"temporarily-undiscovered-agent": "priority",
+		});
+	});
+
+	test("preserves external sibling tier overrides when setting an agent", async () => {
+		vi.spyOn(discovery, "discoverAgents").mockResolvedValue({
+			projectAgentsDir: null,
+			agents: [{ name: "task", description: "Generic task agent", systemPrompt: "", source: "bundled" }],
+		});
+		const cwd = await fs.mkdtemp(path.join(tempCwd, "tier-concurrent-"));
+		const agentDir = path.join(cwd, "agent-config");
+		const configPath = path.join(agentDir, "config.yml");
+		const settings = await Settings.loadIsolated({ cwd, agentDir });
+		const { hub } = await createHub(settings, cwd);
+
+		await Bun.write(configPath, "task:\n  agentServiceTierOverrides:\n    concurrently-added-agent: priority\n");
+		hub.handleInput("\r");
+		for (let i = 0; i < 3; i++) hub.handleInput("\x1b[C");
+		hub.handleInput("\r");
+		hub.handleInput("\x1b[C");
+		hub.handleInput("\r");
+		await settings.flush();
+
+		const reloaded = await Settings.loadIsolated({ cwd, agentDir });
+		expect(reloaded.get("task.agentServiceTierOverrides")).toEqual({
+			task: "inherit",
+			"concurrently-added-agent": "priority",
 		});
 	});
 

--- a/packages/coding-agent/test/agents-hub.test.ts
+++ b/packages/coding-agent/test/agents-hub.test.ts
@@ -221,3 +221,35 @@ describe("AgentsHub configuration strips", () => {
 		expect(cancelled()).toBe(false);
 	});
 });
+
+describe("AgentsHub service-tier override", () => {
+	test("cycles service-tier overrides, persists a sparse map, and clears back to the subagent tier", async () => {
+		mockAgents();
+		const settings = Settings.isolated({ "tier.subagent": "scale" });
+		const { hub, strip } = await createHub(settings);
+		const overrides = () => settings.get("task.agentServiceTierOverrides");
+		const openServiceTierStrip = () => {
+			hub.handleInput("\r");
+			for (let i = 0; i < 3; i++) hub.handleInput("\x1b[C");
+			hub.handleInput("\r");
+		};
+
+		expect(overrides()).toEqual({});
+		expect(strip()).toContain("service tier: scale (tier.subagent)");
+
+		for (const [index, tier] of ["inherit", "none", "auto", "default", "flex", "scale", "priority"].entries()) {
+			openServiceTierStrip();
+			for (let i = 0; i <= index; i++) hub.handleInput("\x1b[C");
+			hub.handleInput("\r");
+
+			expect(overrides()).toEqual({ dev: tier });
+			expect(strip()).toContain(`service tier: ${tier} (override)`);
+		}
+
+		openServiceTierStrip();
+		hub.handleInput("\r");
+
+		expect(overrides()).toEqual({});
+		expect(strip()).toContain("service tier: scale (tier.subagent)");
+	});
+});

--- a/packages/coding-agent/test/agents-hub.test.ts
+++ b/packages/coding-agent/test/agents-hub.test.ts
@@ -252,4 +252,31 @@ describe("AgentsHub service-tier override", () => {
 		expect(overrides()).toEqual({});
 		expect(strip()).toContain("service tier: scale (tier.subagent)");
 	});
+
+	test("preserves service-tier overrides for agents omitted from discovery", async () => {
+		mockAgents();
+		const settings = Settings.isolated({
+			"task.agentServiceTierOverrides": { "temporarily-undiscovered-agent": "priority" },
+		});
+		const { hub } = await createHub(settings);
+		const openServiceTierStrip = () => {
+			hub.handleInput("\r");
+			for (let i = 0; i < 3; i++) hub.handleInput("\x1b[C");
+			hub.handleInput("\r");
+		};
+
+		openServiceTierStrip();
+		hub.handleInput("\x1b[C");
+		hub.handleInput("\r");
+		expect(settings.get("task.agentServiceTierOverrides")).toEqual({
+			dev: "inherit",
+			"temporarily-undiscovered-agent": "priority",
+		});
+
+		openServiceTierStrip();
+		hub.handleInput("\r");
+		expect(settings.get("task.agentServiceTierOverrides")).toEqual({
+			"temporarily-undiscovered-agent": "priority",
+		});
+	});
 });

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -137,6 +137,83 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		expect(forwarded?.preloadedCustomToolPaths).toBe(preloadedCustomToolPaths);
 	});
 
+	it("lets a selected agent tier override beat the global fallback while unlisted agents retain it", async () => {
+		const session = yieldEmittingSession();
+		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		const settings = Settings.isolated({
+			"tier.subagent": "none",
+			"task.agentServiceTierOverrides": { selected: "priority" },
+		});
+
+		const selected = await runSubprocess({
+			...baseOptions,
+			agent: { ...baseAgent, name: "selected" },
+			settings,
+		});
+		const unlisted = await runSubprocess({
+			...baseOptions,
+			id: "unlisted-tier-child",
+			agent: { ...baseAgent, name: "unlisted" },
+			settings,
+		});
+
+		expect(selected.exitCode).toBe(0);
+		expect(unlisted.exitCode).toBe(0);
+		expect(spy).toHaveBeenCalledTimes(2);
+		const selectedSettings = spy.mock.calls[0]?.[0]?.settings;
+		expect(selectedSettings?.get("tier.openai")).toBe("priority");
+		expect(selectedSettings?.get("tier.anthropic")).toBe("priority");
+		expect(selectedSettings?.get("tier.google")).toBe("priority");
+		const unlistedSettings = spy.mock.calls[1]?.[0]?.settings;
+		expect(unlistedSettings?.get("tier.openai")).toBe("none");
+		expect(unlistedSettings?.get("tier.anthropic")).toBe("none");
+		expect(unlistedSettings?.get("tier.google")).toBe("none");
+	});
+
+	it("lets an explicit none override disable a priority subagent fallback", async () => {
+		const session = yieldEmittingSession();
+		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		const settings = Settings.isolated({
+			"tier.subagent": "priority",
+			"task.agentServiceTierOverrides": { standard: "none" },
+		});
+
+		const result = await runSubprocess({
+			...baseOptions,
+			agent: { ...baseAgent, name: "standard" },
+			settings,
+		});
+
+		expect(result.exitCode).toBe(0);
+		const childSettings = spy.mock.calls[0]?.[0]?.settings;
+		expect(childSettings?.get("tier.openai")).toBe("none");
+		expect(childSettings?.get("tier.anthropic")).toBe("none");
+		expect(childSettings?.get("tier.google")).toBe("none");
+	});
+
+	it("passes supplied live parent tiers to an agent explicitly configured to inherit", async () => {
+		const session = yieldEmittingSession();
+		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		const settings = Settings.isolated({
+			"tier.subagent": "none",
+			"task.agentServiceTierOverrides": { inheriting: "inherit" },
+		});
+		const parentServiceTier = { openai: "flex" as const, anthropic: "priority" as const, google: "flex" as const };
+
+		const result = await runSubprocess({
+			...baseOptions,
+			agent: { ...baseAgent, name: "inheriting" },
+			settings,
+			parentServiceTier,
+		});
+
+		expect(result.exitCode).toBe(0);
+		const childSettings = spy.mock.calls[0]?.[0]?.settings;
+		expect(childSettings?.get("tier.openai")).toBe(parentServiceTier.openai);
+		expect(childSettings?.get("tier.anthropic")).toBe(parentServiceTier.anthropic);
+		expect(childSettings?.get("tier.google")).toBe(parentServiceTier.google);
+	});
+
 	it("forwards an exact credential resolver without replacing it", async () => {
 		const session = yieldEmittingSession();
 		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -200,6 +200,27 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		expect(childSettings?.get("tier.google")).toBe("none");
 	});
 
+	it("falls back when the per-agent tier setting is null", async () => {
+		const session = yieldEmittingSession();
+		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		const settings = Settings.isolated({
+			"tier.subagent": "none",
+			"task.agentServiceTierOverrides": null,
+		});
+
+		const result = await runSubprocess({
+			...baseOptions,
+			agent: { ...baseAgent, name: "standard" },
+			settings,
+		});
+
+		expect(result.exitCode).toBe(0);
+		const childSettings = spy.mock.calls[0]?.[0]?.settings;
+		expect(childSettings?.get("tier.openai")).toBe("none");
+		expect(childSettings?.get("tier.anthropic")).toBe("none");
+		expect(childSettings?.get("tier.google")).toBe("none");
+	});
+
 	it("passes and records immediate parent tiers for an agent explicitly configured to inherit", async () => {
 		let recordedParentServiceTier: ServiceTierByFamily | undefined;
 		const session = yieldEmittingSession(parentServiceTier => {

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -5,7 +5,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import type { Model } from "@oh-my-pi/pi-ai";
+import type { Model, ServiceTierByFamily } from "@oh-my-pi/pi-ai";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import type { Rule } from "@oh-my-pi/pi-coding-agent/capability/rule";
@@ -21,7 +21,10 @@ import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 
-function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent) => void }) => void): AgentSession {
+function createMockSession(
+	onPrompt: (params: { emit: (event: AgentSessionEvent) => void }) => void,
+	onSessionInit?: (parentServiceTier: ServiceTierByFamily | undefined) => void,
+): AgentSession {
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
 	const emit = (event: AgentSessionEvent) => {
 		for (const listener of listeners) listener(event);
@@ -31,7 +34,11 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 		agent: { state: { systemPrompt: ["test"] } },
 		model: undefined,
 		extensionRunner: undefined,
-		sessionManager: { appendSessionInit: () => {} },
+		sessionManager: {
+			appendSessionInit: (init: { parentServiceTier?: ServiceTierByFamily }) => {
+				onSessionInit?.(init.parentServiceTier);
+			},
+		},
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
 		setActiveToolsByName: async (_toolNames: string[]) => {},
@@ -55,7 +62,9 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 	return session as unknown as AgentSession;
 }
 
-function yieldEmittingSession(): AgentSession {
+function yieldEmittingSession(
+	onSessionInit?: (parentServiceTier: ServiceTierByFamily | undefined) => void,
+): AgentSession {
 	return createMockSession(({ emit }) => {
 		emit({
 			type: "tool_execution_end",
@@ -67,7 +76,7 @@ function yieldEmittingSession(): AgentSession {
 			},
 			isError: false,
 		});
-	});
+	}, onSessionInit);
 }
 
 function createSessionResult(session: AgentSession): CreateAgentSessionResult {
@@ -191,8 +200,11 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		expect(childSettings?.get("tier.google")).toBe("none");
 	});
 
-	it("passes supplied live parent tiers to an agent explicitly configured to inherit", async () => {
-		const session = yieldEmittingSession();
+	it("passes and records immediate parent tiers for an agent explicitly configured to inherit", async () => {
+		let recordedParentServiceTier: ServiceTierByFamily | undefined;
+		const session = yieldEmittingSession(parentServiceTier => {
+			recordedParentServiceTier = parentServiceTier;
+		});
 		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
 		const settings = Settings.isolated({
 			"tier.subagent": "none",
@@ -212,6 +224,7 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		expect(childSettings?.get("tier.openai")).toBe(parentServiceTier.openai);
 		expect(childSettings?.get("tier.anthropic")).toBe(parentServiceTier.anthropic);
 		expect(childSettings?.get("tier.google")).toBe(parentServiceTier.google);
+		expect(recordedParentServiceTier).toEqual(parentServiceTier);
 	});
 
 	it("forwards an exact credential resolver without replacing it", async () => {

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
+import type { ServiceTierByFamily } from "@oh-my-pi/pi-ai";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
@@ -68,6 +69,8 @@ async function createPersistedSession(
 	restrictToolNames?: boolean,
 	modelRole?: string,
 	advisor?: string,
+	serviceTierOverride?: string,
+	parentServiceTier?: ServiceTierByFamily,
 ): Promise<string> {
 	const manager = SessionManager.create(cwd, path.join(cwd, "sessions"));
 	const sessionFile = manager.getSessionFile();
@@ -80,6 +83,8 @@ async function createPersistedSession(
 		modelRole,
 		resolvedModel: modelRole ? "anthropic/claude-sonnet-4-5" : undefined,
 		advisor,
+		serviceTierOverride,
+		parentServiceTier,
 	});
 	manager.appendMessage({
 		role: "assistant",
@@ -102,7 +107,11 @@ async function createPersistedSession(
 	return sessionFile;
 }
 
-function createFactory(cwd: string, eventBus?: EventBus) {
+function createFactory(
+	cwd: string,
+	options: { settings?: Settings; parentServiceTier?: ServiceTierByFamily } = {},
+	eventBus?: EventBus,
+) {
 	const parentSession = {
 		sessionManager: {
 			getCwd: () => cwd,
@@ -111,12 +120,13 @@ function createFactory(cwd: string, eventBus?: EventBus) {
 		get sessionFile() {
 			return path.join(cwd, "parent.jsonl");
 		},
+		serviceTierByFamily: options.parentServiceTier ?? {},
 	} as unknown as AgentSession;
 	return createPersistedSubagentReviverFactory({
 		session: parentSession,
 		authStorage: {} as never,
 		modelRegistry: { authStorage: {} } as ModelRegistry,
-		settings: Settings.isolated(),
+		settings: options.settings ?? Settings.isolated(),
 		enableLsp: true,
 		eventBus,
 	});
@@ -278,7 +288,7 @@ describe("persisted subagent revival", () => {
 			sessionFile,
 			status: "parked",
 		});
-		const reviver = await createFactory(cwd, eventBus)(ref);
+		const reviver = await createFactory(cwd, {}, eventBus)(ref);
 		if (!reviver) throw new Error("Expected a persisted reviver");
 		await reviver(ref);
 
@@ -309,5 +319,108 @@ describe("persisted subagent revival", () => {
 		rpcRegistry.dispose();
 		AgentLifecycleManager.resetGlobalForTests();
 		AgentRegistry.resetGlobalForTests();
+	});
+
+	it("restores a persisted per-agent tier override instead of the global fallback", async () => {
+		const cwd = makeTempDir("@pi-tier-revive-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, undefined, "priority");
+		const settings = Settings.isolated({ "tier.subagent": "none" });
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd, { settings })(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.settings?.get("tier.openai")).toBe("priority");
+		expect(capturedOptions?.settings?.get("tier.anthropic")).toBe("priority");
+		expect(capturedOptions?.settings?.get("tier.google")).toBe("priority");
+	});
+
+	it("falls back to live top-level tiers for a legacy persisted inherit override", async () => {
+		const cwd = makeTempDir("@pi-tier-inherit-revive-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, undefined, "inherit");
+		const settings = Settings.isolated({ "tier.subagent": "none" });
+		const parentServiceTier = { openai: "flex" as const, anthropic: "priority" as const };
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd, { settings, parentServiceTier })(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.settings?.get("tier.openai")).toBe("flex");
+		expect(capturedOptions?.settings?.get("tier.anthropic")).toBe("priority");
+		expect(capturedOptions?.settings?.get("tier.google")).toBe("none");
+	});
+
+	it("resolves a no-override inherit fallback from the recorded immediate parent tiers", async () => {
+		const cwd = makeTempDir("@pi-tier-fallback-inherit-revive-");
+		const immediateParentServiceTier = {
+			openai: "priority" as const,
+			anthropic: "priority" as const,
+			google: "flex" as const,
+		};
+		const sessionFile = await createPersistedSession(
+			cwd,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			immediateParentServiceTier,
+		);
+		const settings = Settings.isolated({ "tier.subagent": "inherit" });
+		const topLevelServiceTier = { openai: "flex" as const };
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd, { settings, parentServiceTier: topLevelServiceTier })(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.settings?.get("tier.openai")).toBe("priority");
+		expect(capturedOptions?.settings?.get("tier.anthropic")).toBe("priority");
+		expect(capturedOptions?.settings?.get("tier.google")).toBe("flex");
+	});
+
+	it("resolves an explicit inherit override from the recorded immediate parent instead of Main", async () => {
+		const cwd = makeTempDir("@pi-tier-nested-inherit-revive-");
+		const immediateParentServiceTier = { openai: "priority" as const };
+		const sessionFile = await createPersistedSession(
+			cwd,
+			undefined,
+			undefined,
+			undefined,
+			"inherit",
+			immediateParentServiceTier,
+		);
+		const settings = Settings.isolated({ "tier.subagent": "none" });
+		const topLevelServiceTier = { openai: "flex" as const };
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd, { settings, parentServiceTier: topLevelServiceTier })(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.settings?.get("tier.openai")).toBe("priority");
+		expect(capturedOptions?.settings?.get("tier.anthropic")).toBe("none");
+		expect(capturedOptions?.settings?.get("tier.google")).toBe("none");
 	});
 });


### PR DESCRIPTION
## What

- add sparse `task.agentServiceTierOverrides` configuration using the existing full service-tier value set
- expose `serviceTier` in the current `/agents` hub property editor and persist raw global per-agent entries without clobbering project/config overlays, hidden agents, or concurrent writers
- resolve a valid per-agent override before `tier.subagent`, while invalid, missing, and null values retain the existing fallback
- preserve live-spawn `inherit` behavior for unlisted agents and record immediate-parent tiers for faithful nested and cold revival
- include protocol-host defaults, regression coverage, and an Unreleased changelog entry

## Why

This allows selected Codex/subagent models to use priority processing without enabling fast mode for the main session or every subagent. Unlisted agents continue to use `tier.subagent`.

Closes #7106

## Testing

- `bun test test/agents-hub.test.ts test/task/executor-pass-through.test.ts test/task/persisted-revive.test.ts` from `packages/coding-agent` — 40 passed, 0 failed
- `bun check` from `packages/coding-agent` — passed
- `bun test scripts/fix-changelogs.test.ts` from the repository root — 8 passed, 0 failed