### PR TITLE
fix(catalog): disable store field for Google AI Studio openai-compat host

### DIFF
--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -322,10 +322,14 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	const isGrok = modelMatchesHost(hostModel, "xai");
 	const isMistral = modelMatchesHost(hostModel, "mistral");
 	const isOpenCodeHost = modelMatchesHost(hostModel, "opencode");
+	// Google AI Studio's OpenAI-compat shim (`generativelanguage.googleapis.com/v1beta/openai`)
+	// implements a subset of chat-completions and 400s on `store` ("Unknown name \"store\"").
+	const isGoogleAistudioOpenAI = hostMatchesUrl(baseUrl, "googleAistudio");
 	const isNonStandard =
 		isCerebras ||
 		isGrok ||
 		isMistral ||
+		isGoogleAistudioOpenAI ||
 		hostMatchesUrl(baseUrl, "chutes") ||
 		hostMatchesUrl(baseUrl, "deepseekFamily") ||
 		hostMatchesUrl(baseUrl, "fireworks") ||

--- a/packages/catalog/src/hosts.ts
+++ b/packages/catalog/src/hosts.ts
@@ -62,6 +62,8 @@ export const KNOWN_HOSTS = {
 	/** NVIDIA NIM (`integrate.api.nvidia.com`). Qwen NIM endpoints take `chat_template_kwargs.enable_thinking`, never top-level `enable_thinking`. */
 	nvidia: { providers: ["nvidia"], urlMarkers: ["integrate.api.nvidia.com"] },
 	moonshotNative: { providers: ["moonshot", "kimi-code"], urlMarkers: ["api.moonshot.ai", "api.kimi.com"] },
+	/** Google AI Studio's OpenAI-compatible shim (`/v1beta/openai`) — a subset of chat-completions; rejects `store` with a 400. Native Gemini uses `google-generative-ai` api instead. */
+	googleAistudio: { providers: [], urlMarkers: ["generativelanguage.googleapis.com"] },
 	opencode: { providers: ["opencode-go", "opencode-zen"], urlMarkers: ["opencode.ai"] },
 	/** ZenMux's Anthropic-compatible proxy (`zenmux.ai/api/anthropic`) forwards to signature-enforcing Anthropic. */
 	zenmux: { providers: ["zenmux"], urlMarkers: ["zenmux.ai"] },

--- a/packages/catalog/test/google-aistudio-compat.test.ts
+++ b/packages/catalog/test/google-aistudio-compat.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { buildOpenAICompat } from "@oh-my-pi/pi-catalog/compat/openai";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+/**
+ * Google AI Studio's OpenAI-compatible endpoint
+ * (`https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`)
+ * implements a subset of the chat-completions schema and rejects the `store`
+ * field with HTTP 400 (`Invalid JSON payload received. Unknown name "store"`).
+ * The provider must land in the non-standard set so `supportsStore` resolves
+ * false and the wire never carries the field. The native Gemini path
+ * (`google-generative-ai` api) is unaffected — it never emits `store`.
+ */
+
+const baseModel: Omit<ModelSpec<"openai-completions">, "provider" | "baseUrl"> = {
+	api: "openai-completions",
+	id: "gemini-2.5-flash",
+	name: "Gemini 2.5 Flash",
+	input: ["text", "image"],
+	cost: { input: 0.15, output: 0.6, cacheRead: 0.015, cacheWrite: 0 },
+	maxTokens: 65_536,
+	contextWindow: 1_000_000,
+	reasoning: true,
+};
+
+function aistudioByBaseUrl(provider: string): ModelSpec<"openai-completions"> {
+	return {
+		...baseModel,
+		provider,
+		baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+	};
+}
+
+describe("openai-completions compat — Google AI Studio openai-compat shim", () => {
+	it("disables `store` for the generativelanguage openai-compat host", () => {
+		const compat = buildOpenAICompat(aistudioByBaseUrl("gemini"));
+
+		// `isGoogleAistudioOpenAI` participates in the non-standard set, so `store` is off.
+		expect(compat.supportsStore).toBe(false);
+	});
+
+	it("matches regardless of the custom provider id", () => {
+		// users wire the host under arbitrary provider ids (models.yml `gemini`,
+		// `google-aistudio`, …); detection is URL-based, not provider-based.
+		const compat = buildOpenAICompat(aistudioByBaseUrl("my-custom-gemini"));
+
+		expect(compat.supportsStore).toBe(false);
+	});
+
+	it("leaves `store` enabled for standard OpenAI hosts", () => {
+		const compat = buildOpenAICompat({
+			...baseModel,
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+		});
+
+		expect(compat.supportsStore).toBe(true);
+	});
+});


### PR DESCRIPTION
## Problem

Google AI Studio's OpenAI-compatible endpoint (`https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`) implements a subset of the chat-completions schema and rejects the `store` field with HTTP 400:

```
Invalid JSON payload received. Unknown name "store": Cannot find field.
```

OMP unconditionally emits `store: false` in the openai-completions request body whenever the resolved compat has `supportsStore: true` (`packages/ai/src/providers/openai-completions.ts:1553`). Compat resolution (`packages/catalog/src/compat/openai.ts`) derives `supportsStore` from `!isNonStandard`, and the AI Studio host was not in the non-standard set — so **every** request from a custom provider pointed at this host failed before the first token.

This is a common wiring for cheap vision roles: `models.yml` with provider `gemini`, `baseUrl: https://generativelanguage.googleapis.com/v1beta/openai`, model `gemini-2.5-flash`. Reproduced live: the same request succeeds with the field removed and 400s with `"store": false` present. Same failure shape reported in openclaw/openclaw#22704 (auto-closed unfixed).

## Fix

- `packages/catalog/src/hosts.ts`: add a `googleAistudio` host class keyed on the `generativelanguage.googleapis.com` URL marker. URL-marker only (no provider ids), matching the `chutes` precedent — users wire this host under arbitrary provider ids in models.yml.
- `packages/catalog/src/compat/openai.ts`: include `isGoogleAistudioOpenAI` in the `isNonStandard` set so `supportsStore` resolves `false`.

Detection is URL-based, so it covers the host regardless of what the user names the provider. The native Gemini path (`google-generative-ai` api) is unaffected — it never emits `store`.

## Tests

- New `packages/catalog/test/google-aistudio-compat.test.ts` (3 tests):
  - AI Studio openai-compat host → `supportsStore: false`
  - same host under an arbitrary custom provider id → `supportsStore: false` (URL-based detection)
  - standard OpenAI host → `supportsStore: true` (no regression)
- `bun test packages/catalog/test/google-aistudio-compat.test.ts` → 3 pass.
- Full `packages/catalog/test/` suite: 62 fail / 61 errors, but a baseline run on `main` (stash) shows 64 fail / 61 errors — the delta is pre-existing environmental failures (`pi_natives` native addon missing on this machine), and this change fixes 2 of them. Zero regressions.
- `bun run check:tools` (biome) clean.

## Evidence

Captured failing request (from `~/.omp/logs/http-400-requests/`, provider `gemini` → `generativelanguage.googleapis.com/v1beta/openai/chat/completions`):

```json
{"stream": true, "stream_options": {"include_usage": true}, "store": false, "max_completion_tokens": 64000}
```

→ `400 Invalid JSON payload received. Unknown name "store": Cannot find field.`

Same request body minus `store` succeeds (reaches auth, then normal processing).