### PR TITLE
fix(coding-agent): reload MCP servers on /reload-plugins

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `/reload-plugins` not reconnecting MCP servers or refreshing the session's MCP tool registry despite listing MCP in its documented reload scope, so `.mcp.json` edits stayed inactive until restart. The TUI reload pipeline now runs the same disconnect/rediscover/`refreshMCPTools` path as `/mcp reload` ([#7189](https://github.com/can1357/oh-my-pi/issues/7189)).
+- Fixed `/reload-plugins` not reconnecting MCP servers or refreshing the session's MCP tool registry despite listing MCP in its documented reload scope, so `.mcp.json` edits stayed inactive until restart. The TUI reload pipeline now runs the same disconnect/rediscover/`refreshMCPTools` path as `/mcp reload`, deriving discovery filters from settings so the reload keeps honoring `mcp.enableProjectConfig: false` instead of starting opted-out project servers ([#7189](https://github.com/can1357/oh-my-pi/issues/7189)).
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/reload-plugins` not reconnecting MCP servers or refreshing the session's MCP tool registry despite listing MCP in its documented reload scope, so `.mcp.json` edits stayed inactive until restart. The TUI reload pipeline now runs the same disconnect/rediscover/`refreshMCPTools` path as `/mcp reload` ([#7189](https://github.com/can1357/oh-my-pi/issues/7189)).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `/reload-plugins` not reconnecting MCP servers or refreshing the session's MCP tool registry despite listing MCP in its documented reload scope, so `.mcp.json` edits stayed inactive until restart. The TUI reload pipeline now runs the same disconnect/rediscover/`refreshMCPTools` path as `/mcp reload`, deriving discovery filters from settings so the reload keeps honoring `mcp.enableProjectConfig: false` instead of starting opted-out project servers ([#7189](https://github.com/can1357/oh-my-pi/issues/7189)).
+- Fixed `/reload-plugins` not reconnecting MCP servers or refreshing the session's MCP tool and prompt-command registries despite listing MCP in its documented reload scope, so `.mcp.json` edits stayed inactive and removed prompt commands remained invocable until restart. The TUI reload pipeline now clears stale MCP prompt commands and runs the same disconnect/rediscover/`refreshMCPTools` path as `/mcp reload`, deriving discovery filters from settings so the reload keeps honoring `mcp.enableProjectConfig: false` instead of starting opted-out project servers ([#7189](https://github.com/can1357/oh-my-pi/issues/7189)).
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1997,6 +1997,10 @@ export class MCPCommandController {
 
 		// Disconnect all existing servers
 		await this.ctx.mcpManager.disconnectAll();
+		// Prompt enrichment is asynchronous. Clear commands before rediscovery so
+		// removed/disabled servers cannot leave stale `/server:prompt` entries;
+		// newly loaded prompts repopulate them through the manager callback.
+		this.ctx.session.setMCPPromptCommands([]);
 
 		// Rediscover and connect, mirroring startup's discovery filters.
 		const result = await this.ctx.mcpManager.discoverAndConnect({

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1985,6 +1985,10 @@ export class MCPCommandController {
 	 * calls `session.refreshMCPTools(...)` so config edits take effect without a
 	 * restart. Public because `/reload-plugins` reuses it alongside `/mcp reload`
 	 * and the config-mutation flows in this controller.
+	 *
+	 * Discovery options are derived from settings so the reload honors the same
+	 * opt-outs as startup — notably `mcp.enableProjectConfig: false`, which must
+	 * keep project `.mcp.json` servers from being started on reload.
 	 */
 	async reloadServers(): Promise<void> {
 		if (!this.ctx.mcpManager) {
@@ -1994,8 +1998,12 @@ export class MCPCommandController {
 		// Disconnect all existing servers
 		await this.ctx.mcpManager.disconnectAll();
 
-		// Rediscover and connect
-		const result = await this.ctx.mcpManager.discoverAndConnect();
+		// Rediscover and connect, mirroring startup's discovery filters.
+		const result = await this.ctx.mcpManager.discoverAndConnect({
+			enableProjectConfig: this.ctx.settings.get("mcp.enableProjectConfig") ?? true,
+			filterExa: true,
+			filterBrowser: this.ctx.settings.get("browser.enabled") ?? false,
+		});
 		await this.ctx.session.refreshMCPTools(this.ctx.mcpManager.getTools());
 
 		this.#showMCPConnectionErrors(result.errors);

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1228,7 +1228,7 @@ export class MCPCommandController {
 			await addMCPServer(filePath, name, config);
 
 			// Reload MCP manager
-			await this.#reloadMCP();
+			await this.reloadServers();
 			const state =
 				config.enabled === false
 					? "disconnected"
@@ -1486,7 +1486,7 @@ export class MCPCommandController {
 			await removeMCPServer(filePath, name);
 
 			// Reload MCP manager
-			await this.#reloadMCP();
+			await this.reloadServers();
 
 			this.#showMessage(["", theme.fg("success", `- Removed server "${name}" from ${scope} config`), ""].join("\n"));
 		} catch (error) {
@@ -1736,7 +1736,7 @@ export class MCPCommandController {
 					);
 					return;
 				}
-				await this.#reloadMCP();
+				await this.reloadServers();
 				this.#showMessage(
 					["", theme.fg("success", `- Cleared auth for "${name}" (${found.scope} config)`), ""].join("\n"),
 				);
@@ -1745,7 +1745,7 @@ export class MCPCommandController {
 
 			const updated = this.#stripOAuthAuth(found.config);
 			await updateMCPServer(found.filePath, name, updated);
-			await this.#reloadMCP();
+			await this.reloadServers();
 
 			this.#showMessage(
 				["", theme.fg("success", `- Cleared auth for "${name}" (${found.scope} config)`), ""].join("\n"),
@@ -1856,7 +1856,7 @@ export class MCPCommandController {
 				await updateMCPServer(found.filePath, name, updatedConfig);
 			}
 			if (options.reload !== false) {
-				await this.#reloadMCP();
+				await this.reloadServers();
 				const state = await this.#waitForServerConnectionWithAnimation(name);
 
 				const lines = [
@@ -1891,7 +1891,7 @@ export class MCPCommandController {
 	async #handleReload(): Promise<void> {
 		try {
 			this.#showMessage(["", theme.fg("muted", "Reloading MCP servers and runtime tools..."), ""].join("\n"));
-			await this.#reloadMCP();
+			await this.reloadServers();
 			const connectedCount = this.ctx.mcpManager?.getConnectedServers().length ?? 0;
 			this.#showMessage(
 				[
@@ -1979,9 +1979,14 @@ export class MCPCommandController {
 	}
 
 	/**
-	 * Reload MCP manager with new configs
+	 * Reconnect every configured MCP server and rebind the session's MCP tools.
+	 *
+	 * Disconnects all live connections, rediscovers `.mcp.json` configs, and
+	 * calls `session.refreshMCPTools(...)` so config edits take effect without a
+	 * restart. Public because `/reload-plugins` reuses it alongside `/mcp reload`
+	 * and the config-mutation flows in this controller.
 	 */
-	async #reloadMCP(): Promise<void> {
+	async reloadServers(): Promise<void> {
 		if (!this.ctx.mcpManager) {
 			return;
 		}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -34,7 +34,7 @@ import {
 import { readMCPConfigFile } from "../mcp/config-writer";
 import { resolveMemoryBackend } from "../memory-backend";
 import { runPauseScreen } from "../modes/components/pause-screen";
-import { collectMcpServerNames } from "../modes/controllers/mcp-command-controller";
+import { collectMcpServerNames, MCPCommandController } from "../modes/controllers/mcp-command-controller";
 import { describeLoopLimitRuntime } from "../modes/loop-limit";
 import { theme } from "../modes/theme/theme";
 import type { InteractiveModeContext } from "../modes/types";
@@ -2628,13 +2628,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			return commandConsumed();
 		},
 		handleTui: async (_command, runtime) => {
-			// Invalidate registry fs caches and the plugin roots cache so
-			// listClaudePluginRoots re-reads from disk on next access.
-			const projectPath = await resolveActiveProjectRegistryPath(runtime.ctx.sessionManager.getCwd());
-			clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-			await runtime.ctx.refreshSkillState();
-			await runtime.ctx.refreshSlashCommandState();
-			resetCapabilities();
+			await reloadTuiPluginState(runtime.ctx);
 			runtime.ctx.showStatus("Plugins reloaded.");
 			runtime.ctx.editor.setText("");
 		},
@@ -3060,6 +3054,24 @@ export function buildTuiBuiltinSlashCommands(runtime: TuiSlashCommandRuntime): R
 export const BUILTIN_SLASH_COMMANDS_INTERNAL: ReadonlyArray<SlashCommandSpec> = BUILTIN_SLASH_COMMAND_REGISTRY;
 
 /**
+ * Reload the interactive session's plugin runtime: invalidate fs/plugin-root
+ * caches, rediscover skills and file slash commands, reset the capability
+ * cache, and reconnect MCP servers (rebinding the session's MCP tools). Shared
+ * by `/reload-plugins`'s TUI handler and the `handle`-adapter's `reloadPlugins`
+ * hook so both honor the command's documented MCP reload scope (#7189).
+ */
+async function reloadTuiPluginState(ctx: InteractiveModeContext): Promise<void> {
+	const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
+	clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
+	await ctx.refreshSkillState();
+	await ctx.refreshSlashCommandState();
+	resetCapabilities();
+	if (ctx.mcpManager) {
+		await new MCPCommandController(ctx).reloadServers();
+	}
+}
+
+/**
  * Execute a builtin slash command in the interactive TUI.
  *
  * Returns `false` when no builtin matched. Returns `true` when a command
@@ -3107,13 +3119,7 @@ export async function executeBuiltinSlashCommand(
 				ctx.showStatus(text);
 			},
 			refreshCommands: () => ctx.refreshSlashCommandState(),
-			reloadPlugins: async () => {
-				const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
-				clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
-				await ctx.refreshSkillState();
-				await ctx.refreshSlashCommandState();
-				resetCapabilities();
-			},
+			reloadPlugins: () => reloadTuiPluginState(ctx),
 		};
 		const result = await command.handle(parsed, adapted);
 		ctx.editor.setText("");

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -69,8 +69,12 @@ function createController(authStorage: AuthStorage, mcpManagerOverrides: Record<
 			pendingProviderId: undefined,
 			tryClaimInput: vi.fn(),
 		},
+		settings: {
+			get: vi.fn((_key: string): unknown => undefined),
+		},
 		session: {
 			refreshMCPTools: vi.fn(),
+			setMCPPromptCommands: vi.fn(),
 			modelRegistry: { authStorage },
 		},
 		mcpManager,

--- a/packages/coding-agent/test/reload-plugins-mcp.test.ts
+++ b/packages/coding-agent/test/reload-plugins-mcp.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression: `/reload-plugins` is documented to reload MCP, so the TUI handler
+ * must reconnect servers and rebind the session's MCP tool registry — not just
+ * reset skill/command/capability caches. Before the fix it silently skipped
+ * MCP, leaving `.mcp.json` edits inactive until process restart (#7189).
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import type { TuiSlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
+import { getProjectDir, removeWithRetries, setProjectDir } from "@oh-my-pi/pi-utils";
+
+const originalProjectDir = getProjectDir();
+
+function createFakeCtx(cwd: string) {
+	const mcpTools = [{ name: "mcp__srv_do" }];
+	const mcpManager = {
+		disconnectAll: vi.fn(async () => {}),
+		discoverAndConnect: vi.fn(async () => ({ errors: new Map<string, string>() })),
+		getTools: vi.fn(() => mcpTools),
+	};
+	const session = {
+		refreshMCPTools: vi.fn(async (_tools: unknown) => {}),
+	};
+	const ctx = {
+		mcpManager,
+		session,
+		sessionManager: { getCwd: () => cwd },
+		refreshSkillState: vi.fn(async () => {}),
+		refreshSlashCommandState: vi.fn(async () => {}),
+		showStatus: vi.fn(() => {}),
+		editor: { setText: vi.fn(() => {}) },
+	} as never as InteractiveModeContext;
+	return { ctx, mcpManager, session, mcpTools };
+}
+
+describe("/reload-plugins MCP reconnect (#7189)", () => {
+	let projectDir = "";
+
+	beforeEach(async () => {
+		projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-reload-plugins-mcp-"));
+		setProjectDir(projectDir);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		setProjectDir(originalProjectDir);
+		await removeWithRetries(projectDir);
+	});
+
+	test("reconnects MCP servers and rebinds session MCP tools", async () => {
+		const { ctx, mcpManager, session, mcpTools } = createFakeCtx(projectDir);
+		const runtime: TuiSlashCommandRuntime = { ctx };
+
+		const result = await executeBuiltinSlashCommand("/reload-plugins", runtime);
+		expect(result).toBe(true);
+		expect(mcpManager.disconnectAll).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverAndConnect).toHaveBeenCalledTimes(1);
+		expect(session.refreshMCPTools).toHaveBeenCalledTimes(1);
+		expect(session.refreshMCPTools).toHaveBeenCalledWith(mcpTools);
+	});
+});

--- a/packages/coding-agent/test/reload-plugins-mcp.test.ts
+++ b/packages/coding-agent/test/reload-plugins-mcp.test.ts
@@ -24,6 +24,7 @@ function createFakeCtx(cwd: string, settingsValues: Record<string, unknown> = {}
 	};
 	const session = {
 		refreshMCPTools: vi.fn(async (_tools: unknown) => {}),
+		setMCPPromptCommands: vi.fn((_commands: unknown) => {}),
 	};
 	const ctx = {
 		mcpManager,
@@ -52,7 +53,7 @@ describe("/reload-plugins MCP reconnect (#7189)", () => {
 		await removeWithRetries(projectDir);
 	});
 
-	test("reconnects MCP servers and rebinds session MCP tools", async () => {
+	test("reconnects MCP servers, rebinds tools, and clears stale prompt commands", async () => {
 		const { ctx, mcpManager, session, mcpTools } = createFakeCtx(projectDir);
 		const runtime: TuiSlashCommandRuntime = { ctx };
 
@@ -62,6 +63,8 @@ describe("/reload-plugins MCP reconnect (#7189)", () => {
 		expect(mcpManager.discoverAndConnect).toHaveBeenCalledTimes(1);
 		expect(session.refreshMCPTools).toHaveBeenCalledTimes(1);
 		expect(session.refreshMCPTools).toHaveBeenCalledWith(mcpTools);
+		expect(session.setMCPPromptCommands).toHaveBeenCalledTimes(1);
+		expect(session.setMCPPromptCommands).toHaveBeenCalledWith([]);
 	});
 
 	test("honors mcp.enableProjectConfig=false so opted-out project servers are not started on reload", async () => {

--- a/packages/coding-agent/test/reload-plugins-mcp.test.ts
+++ b/packages/coding-agent/test/reload-plugins-mcp.test.ts
@@ -15,11 +15,11 @@ import { getProjectDir, removeWithRetries, setProjectDir } from "@oh-my-pi/pi-ut
 
 const originalProjectDir = getProjectDir();
 
-function createFakeCtx(cwd: string) {
+function createFakeCtx(cwd: string, settingsValues: Record<string, unknown> = {}) {
 	const mcpTools = [{ name: "mcp__srv_do" }];
 	const mcpManager = {
 		disconnectAll: vi.fn(async () => {}),
-		discoverAndConnect: vi.fn(async () => ({ errors: new Map<string, string>() })),
+		discoverAndConnect: vi.fn(async (_options?: unknown) => ({ errors: new Map<string, string>() })),
 		getTools: vi.fn(() => mcpTools),
 	};
 	const session = {
@@ -29,6 +29,7 @@ function createFakeCtx(cwd: string) {
 		mcpManager,
 		session,
 		sessionManager: { getCwd: () => cwd },
+		settings: { get: (key: string): unknown => settingsValues[key] },
 		refreshSkillState: vi.fn(async () => {}),
 		refreshSlashCommandState: vi.fn(async () => {}),
 		showStatus: vi.fn(() => {}),
@@ -61,5 +62,17 @@ describe("/reload-plugins MCP reconnect (#7189)", () => {
 		expect(mcpManager.discoverAndConnect).toHaveBeenCalledTimes(1);
 		expect(session.refreshMCPTools).toHaveBeenCalledTimes(1);
 		expect(session.refreshMCPTools).toHaveBeenCalledWith(mcpTools);
+	});
+
+	test("honors mcp.enableProjectConfig=false so opted-out project servers are not started on reload", async () => {
+		const { ctx, mcpManager } = createFakeCtx(projectDir, { "mcp.enableProjectConfig": false });
+		const runtime: TuiSlashCommandRuntime = { ctx };
+
+		await executeBuiltinSlashCommand("/reload-plugins", runtime);
+
+		expect(mcpManager.discoverAndConnect).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverAndConnect).toHaveBeenCalledWith(
+			expect.objectContaining({ enableProjectConfig: false }),
+		);
 	});
 });


### PR DESCRIPTION
## Repro
`/reload-plugins` is documented to reload MCP (`Reload all plugins (skills, commands, hooks, tools, agents, MCP)`), but in the TUI it never reconnects MCP servers or refreshes the session's MCP tool registry, so `.mcp.json` edits stay inactive until process restart. Reproduced with a focused test driving `executeBuiltinSlashCommand("/reload-plugins", runtime)` against a spied MCP manager + session: the command returns `true` (consumed) yet `session.refreshMCPTools` is called 0 times (`bun test test/reload-plugins-mcp.test.ts`).

## Cause
The TUI reload path in `packages/coding-agent/src/slash-commands/builtin-registry.ts` — the `/reload-plugins` `handleTui` handler and the shared `reloadPlugins` closure used by the `handle`-adapter — ran `clearPluginRootsAndCaches` + `refreshSkillState` + `refreshSlashCommandState` + `resetCapabilities`, but never invoked `mcpManager.disconnectAll()` / `discoverAndConnect()` or `session.refreshMCPTools()`. Those three steps are exactly what `/mcp reload` performs via `MCPCommandController.#reloadMCP()`, so MCP was silently omitted from the reload boundary.

## Fix
- Promoted `MCPCommandController.#reloadMCP()` to a public `reloadServers()` (disconnect → rediscover configs → `refreshMCPTools`), updating its internal call sites.
- Added a shared `reloadTuiPluginState(ctx)` helper in `builtin-registry.ts` that performs the existing cache/skill/command reload and then, when an `mcpManager` is present, calls `new MCPCommandController(ctx).reloadServers()`.
- Routed both the `/reload-plugins` `handleTui` handler and the `reloadPlugins` closure through the helper, removing the duplicated inline reload steps.
- Added a regression test (`test/reload-plugins-mcp.test.ts`) and a coding-agent changelog entry.

Scope note: rules/rulebook/TTSR/`rule://`/system-prompt reload is outside `/reload-plugins`' current documented scope and is intentionally left as a separate enhancement, not folded into this fix.

## Verification
`bun test test/reload-plugins-mcp.test.ts` passes (MCP disconnect/rediscover/refresh now invoked); `bun run check:ts` passes clean (biome + tsgo, no fixes). Skipped pre-publish gate: `bun check` fails only on `check:rs`, which panics building `audiopus_sys` because the `cmake` system binary is absent from the environment — a pre-existing, environmental failure unrelated to this TS-only diff.

Fixes #7189