### PR TITLE
fix(tui): render mid-turn steering skips as info, not errors

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Tool calls skipped mid-batch to service a queued steering/peer interrupt now carry the `SyntheticToolResultDetails` discriminator (`source: "interrupt_skipped"`, `executed: false`), so UI/telemetry consumers can classify them as "call emitted, not executed" instead of a real tool failure ([#7199](https://github.com/can1357/oh-my-pi/issues/7199)).
+- Tool calls skipped mid-batch to service queued steering/peer input now distinguish calls that never entered `tool.execute` (`SyntheticToolResultDetails`, `executed: false`) from in-flight calls that may have performed partial work (`execution: "started"`), allowing UI/telemetry consumers to render normal steering control flow without misreporting execution state ([#7199](https://github.com/can1357/oh-my-pi/issues/7199)).
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Tool calls skipped mid-batch to service a queued steering/peer interrupt now carry the `SyntheticToolResultDetails` discriminator (`source: "interrupt_skipped"`, `executed: false`), so UI/telemetry consumers can classify them as "call emitted, not executed" instead of a real tool failure ([#7199](https://github.com/can1357/oh-my-pi/issues/7199)).
+
 ## [17.2.2] - 2026-07-31
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2723,13 +2723,20 @@ async function executeToolCalls(
  * (#4321): a provider-side stream error after tool-call emission (e.g. Codex
  * websocket close) was surfaced by the CLI as if the local tool had failed.
  *
- * `source` names the assistant-side termination state that prevented
- * execution; `upstreamError` is the provider-reported message when the turn
- * ended with `stopReason === "error"`.
+ * `source` names the state that prevented execution — either an assistant-side
+ * turn termination (`assistant_stop_*`) or a mid-batch interrupt that skipped a
+ * still-pending call to service queued steering/peer input (`interrupt_skipped`).
+ * `upstreamError` is the provider-reported message when the turn ended with
+ * `stopReason === "error"`.
  */
 export interface SyntheticToolResultDetails {
 	__synthetic: true;
-	source: "assistant_stop_aborted" | "assistant_stop_error" | "assistant_stop_skipped" | "assistant_stop_length";
+	source:
+		| "assistant_stop_aborted"
+		| "assistant_stop_error"
+		| "assistant_stop_skipped"
+		| "assistant_stop_length"
+		| "interrupt_skipped";
 	executed: false;
 	upstreamError?: string;
 }
@@ -2844,7 +2851,9 @@ function createToolSignalAbortedResult(signal: AbortSignal): AgentToolResult<unk
 	};
 }
 
-function createSkippedToolResult(source: SteeringInterruptSource | "irc" | undefined): AgentToolResult<any> {
+function createSkippedToolResult(
+	source: SteeringInterruptSource | "irc" | undefined,
+): AgentToolResult<SyntheticToolResultDetails> {
 	let reason = "pending steering message";
 	let blocker = "queued message";
 	if (source === "user") {
@@ -2864,6 +2873,6 @@ function createSkippedToolResult(source: SteeringInterruptSource | "irc" | undef
 				text: `Skipped due to ${reason}. Do not count this skipped result as completed work or verification. After the ${blocker} is handled on the next step, retry the skipped tool if it is still needed.`,
 			},
 		],
-		details: {},
+		details: { __synthetic: true, source: "interrupt_skipped", executed: false },
 	};
 }

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2454,6 +2454,7 @@ async function executeToolCalls(
 		let isError = false;
 		let caughtError: unknown;
 		let completedToolExecution = false;
+		let executionStarted = false;
 
 		await runInActiveSpan(toolSpan, async () => {
 			try {
@@ -2487,6 +2488,7 @@ async function executeToolCalls(
 							providerMetadata: toolCall.providerMetadata,
 						})
 					: undefined;
+				executionStarted = true;
 				const rawResult = await tool.execute(
 					toolCall.id,
 					executionArgs,
@@ -2557,12 +2559,12 @@ async function executeToolCalls(
 		const interrupted = interruptState.triggered;
 		const perToolAborted = record.signal.aborted;
 		const abortedDuringExecution = perToolAborted && isError && !completedToolExecution;
-		if (interrupted && perToolAborted && isError && !completedToolExecution) {
-			// This tool's own signal fired AND it failed to produce a result: `tool.execute()`
-			// never returned (it threw on the abort), so it was genuinely cut off before
-			// producing usable output. Report it as skipped.
+		if (interrupted && abortedDuringExecution) {
+			// This tool's own signal fired AND it failed to produce a result. The
+			// execution may already have performed partial work before throwing on
+			// abort, so preserve that distinction in the placeholder metadata.
 			record.skipped = true;
-			emitToolResult(record, createSkippedToolResult(interruptState.source), true);
+			emitToolResult(record, createSkippedToolResult(interruptState.source, executionStarted), true);
 		} else {
 			// No interrupt on this signal, or the tool finished before the interrupt landed
 			// (`completedToolExecution`) — even if the signal aborted around completion. Keep
@@ -2703,7 +2705,7 @@ async function executeToolCalls(
 				toolName: record.toolCall.name,
 				status: "skipped",
 			});
-			emitToolResult(record, createSkippedToolResult(interruptState.source), true);
+			emitToolResult(record, createSkippedToolResult(interruptState.source, false), true);
 		}
 	}
 
@@ -2739,6 +2741,16 @@ export interface SyntheticToolResultDetails {
 		| "interrupt_skipped";
 	executed: false;
 	upstreamError?: string;
+}
+
+/**
+ * Metadata for an interrupt-aborted call that entered `tool.execute()` but
+ * threw before returning a usable result. It may have performed partial work.
+ */
+interface InterruptedToolResultDetails {
+	__interrupted: true;
+	source: "interrupt_skipped";
+	execution: "started";
 }
 
 /**
@@ -2853,7 +2865,8 @@ function createToolSignalAbortedResult(signal: AbortSignal): AgentToolResult<unk
 
 function createSkippedToolResult(
 	source: SteeringInterruptSource | "irc" | undefined,
-): AgentToolResult<SyntheticToolResultDetails> {
+	executionStarted: boolean,
+): AgentToolResult<SyntheticToolResultDetails | InterruptedToolResultDetails> {
 	let reason = "pending steering message";
 	let blocker = "queued message";
 	if (source === "user") {
@@ -2873,6 +2886,8 @@ function createSkippedToolResult(
 				text: `Skipped due to ${reason}. Do not count this skipped result as completed work or verification. After the ${blocker} is handled on the next step, retry the skipped tool if it is still needed.`,
 			},
 		],
-		details: { __synthetic: true, source: "interrupt_skipped", executed: false },
+		details: executionStarted
+			? { __interrupted: true, source: "interrupt_skipped", execution: "started" }
+			: { __synthetic: true, source: "interrupt_skipped", executed: false },
 	};
 }

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1500,6 +1500,11 @@ describe("agentLoop with AgentMessage", () => {
 		expect(toolEnds.length).toBe(2);
 		expect(toolEnds[0].isError).toBe(false);
 		expect(toolEnds[1].isError).toBe(true);
+		expect(toolEnds[1].result.details).toEqual({
+			__synthetic: true,
+			source: "interrupt_skipped",
+			executed: false,
+		});
 		const skippedContent = toolEnds[1].result.content[0];
 		expect(skippedContent?.type).toBe("text");
 		if (skippedContent?.type !== "text") throw new Error("skipped tool result must be text");
@@ -1690,6 +1695,66 @@ describe("agentLoop with AgentMessage", () => {
 		expect(
 			events.some(e => e.type === "message_start" && e.message.role === "user" && e.message.content === "interrupt"),
 		).toBe(true);
+	});
+
+	it("distinguishes an in-flight abort from a never-executed steering skip", async () => {
+		const toolSchema = type({});
+		let steerReady = false;
+		let drained = false;
+
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "wait",
+			label: "Wait",
+			description: "Starts work, then throws when steering aborts it",
+			parameters: toolSchema,
+			interruptible: true,
+			async execute(_toolCallId, _params, signal) {
+				steerReady = true;
+				if (!signal) throw new Error("missing tool abort signal");
+				const aborted = Promise.withResolvers<void>();
+				if (signal.aborted) {
+					aborted.resolve();
+				} else {
+					signal.addEventListener("abort", () => aborted.resolve(), { once: true });
+				}
+				await aborted.promise;
+				throw new Error("aborted after partial work");
+			},
+		};
+
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "wait", arguments: {} }] },
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasSteeringMessages: () => steerReady && !drained,
+			getSteeringMessages: async () => {
+				if (!steerReady || drained) return [];
+				drained = true;
+				return [createUserMessage("interrupt")];
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		for await (const event of agentLoop([createUserMessage("start")], context, config, undefined, mock.stream)) {
+			events.push(event);
+		}
+
+		const toolEnd = events.find(
+			(event): event is Extract<AgentEvent, { type: "tool_execution_end" }> => event.type === "tool_execution_end",
+		);
+		expect(toolEnd?.result.details).toEqual({
+			__interrupted: true,
+			source: "interrupt_skipped",
+			execution: "started",
+		});
+		expect(toolEnd?.result.details).not.toHaveProperty("executed");
 	});
 
 	it("keeps a completed error result instead of clobbering it into skipped when a steer aborts the signal (#4752)", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed mid-turn steering/peer-interrupt tool skips rendering as errors (red ✘, red border/text) in the TUI; the synthetic skip placeholder now renders as a neutral info card, matching its "call emitted, not executed" meaning ([#7199](https://github.com/can1357/oh-my-pi/issues/7199)).
+- Fixed mid-turn steering/peer-interrupt tool skips rendering as errors (red ✘, red border/text) in the TUI; pending and in-flight interrupt placeholders now render as neutral info cards while preserving whether `tool.execute` started ([#7199](https://github.com/can1357/oh-my-pi/issues/7199)).
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed mid-turn steering/peer-interrupt tool skips rendering as errors (red ✘, red border/text) in the TUI; the synthetic skip placeholder now renders as a neutral info card, matching its "call emitted, not executed" meaning ([#7199](https://github.com/can1357/oh-my-pi/issues/7199)).
+
 ## [17.2.2] - 2026-07-31
 
 ### Added

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -276,6 +276,9 @@ let toolExecutionInstanceSeq = 0;
 export class ToolExecutionComponent extends Container implements NativeScrollbackLiveRegion {
 	#contentBox: Box; // Used for custom tools and bash visual truncation
 	#contentText: WidthAwareText; // Generic fallback (no custom/built-in renderer)
+	// Which container the constructor mounted: bespoke/built-in renderers use
+	// #contentBox, everything else the generic #contentText fallback.
+	#usesContentBox = false;
 	#multiFileBoxes: (Box | Spacer)[] = []; // Extra boxes for multi-file edit results
 	#imageComponents: Image[] = [];
 	#imageSpacers: Spacer[] = [];
@@ -411,26 +414,13 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		// strips PLAIN-blank edges, so framed/minimal blocks (no bg set) drop these
 		// lines and keep their tight spacing — only tinted lines survive.
 		this.#contentBox = new Box(0, 1);
-		this.#contentText = new WidthAwareText(
-			contentWidth =>
-				formatDefaultToolExecution(
-					{
-						label: this.#toolLabel,
-						args: this.#args,
-						result: this.#result ? { output: this.#getTextOutput(), isError: this.#result.isError } : undefined,
-						options: this.#renderState,
-					},
-					contentWidth,
-					theme,
-				),
-			1,
-			1,
-		);
+		this.#contentText = new WidthAwareText(contentWidth => this.#renderDefaultCard(contentWidth), 1, 1);
 
 		// Use Box for custom tools or built-in tools that have renderers
 		const hasRenderer = toolName in toolRenderers;
 		const hasCustomRenderer = !!(tool?.renderCall || tool?.renderResult);
-		if (hasCustomRenderer || hasRenderer) {
+		this.#usesContentBox = hasCustomRenderer || hasRenderer;
+		if (this.#usesContentBox) {
 			this.addChild(this.#contentBox);
 		} else {
 			this.addChild(this.#contentText);
@@ -998,12 +988,21 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 
 		// Non-self-framing tools (custom/extension renderers and the generic
 		// fallback) get a padded, state-tinted block — built-ins that draw their
-		// own frame opt out below via the framed-component mark.
-		const stateBgKey = this.#isPartial ? "toolPendingBg" : this.#result?.isError ? "toolErrorBg" : "toolSuccessBg";
+		// own frame opt out below via the framed-component mark. A benign skip
+		// (steering/peer interrupt aborted a still-pending call) never ran, so it
+		// gets the neutral pending tint rather than the error tint (#7199).
+		const benignSkip = this.#isBenignSkip();
+		const stateBgKey =
+			this.#isPartial || benignSkip ? "toolPendingBg" : this.#result?.isError ? "toolErrorBg" : "toolSuccessBg";
 		const stateBgFn = (t: string) => theme.bg(stateBgKey, t);
 
-		// Check for custom tool rendering
-		if (this.#tool && (this.#tool.renderCall || this.#tool.renderResult)) {
+		// A benign skip is a synthetic placeholder for a call that never executed,
+		// so bypass any bespoke error frame and draw the neutral generic card —
+		// the per-tool ✘/red-border would misread normal mid-turn steering as a
+		// failure (#7199).
+		if (benignSkip) {
+			this.#renderBenignSkipCard(stateBgFn);
+		} else if (this.#tool && (this.#tool.renderCall || this.#tool.renderResult)) {
 			const tool = this.#tool;
 			const mergeCallAndResult = Boolean((tool as { mergeCallAndResult?: boolean }).mergeCallAndResult);
 			// Custom tools use Box for flexible component rendering
@@ -1398,5 +1397,59 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		}
 
 		return output;
+	}
+
+	/**
+	 * Format the generic call/result card at `contentWidth`. Shared by the
+	 * #contentText fallback and the benign-skip path so both render identically.
+	 */
+	#renderDefaultCard(contentWidth: number): string {
+		return formatDefaultToolExecution(
+			{
+				label: this.#toolLabel,
+				args: this.#args,
+				result: this.#result
+					? { output: this.#getTextOutput(), isError: this.#result.isError, skipped: this.#isBenignSkip() }
+					: undefined,
+				options: this.#renderState,
+			},
+			contentWidth,
+			theme,
+		);
+	}
+
+	/**
+	 * True when the settled result is the synthetic placeholder emitted for a
+	 * tool call skipped mid-batch to service queued steering/peer input. Such a
+	 * call never executed, so it must not render as an error (#7199).
+	 */
+	#isBenignSkip(): boolean {
+		if (this.#isPartial || !this.#result) return false;
+		const details = this.#result.details as { __synthetic?: boolean; source?: string } | undefined;
+		return details?.__synthetic === true && details.source === "interrupt_skipped";
+	}
+
+	/**
+	 * Render a benign skip as the neutral generic card, replacing any bespoke
+	 * renderer's error frame. Generic-fallback tools already route through
+	 * {@link #renderDefaultCard} (which emits the info card for a skip); they
+	 * only need the neutral tint. Bespoke-renderer tools get their content box
+	 * swapped for the same neutral card.
+	 */
+	#renderBenignSkipCard(stateBgFn: (text: string) => string): void {
+		if (!this.#usesContentBox) {
+			this.#contentText.setCustomBgFn(stateBgFn);
+			this.#contentText.invalidate();
+			return;
+		}
+		for (const box of this.#multiFileBoxes) {
+			this.removeChild(box);
+		}
+		this.#multiFileBoxes = [];
+		this.#contentBox.setBgFn(undefined);
+		this.#contentBox.clear();
+		this.#contentBox.setPaddingX(1);
+		this.#contentBox.setBgFn(stateBgFn);
+		this.#contentBox.addChild(new WidthAwareText(contentWidth => this.#renderDefaultCard(contentWidth), 0, 0));
 	}
 }

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -1419,14 +1419,18 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	}
 
 	/**
-	 * True when the settled result is the synthetic placeholder emitted for a
-	 * tool call skipped mid-batch to service queued steering/peer input. Such a
-	 * call never executed, so it must not render as an error (#7199).
+	 * True for a steering/peer-interrupt placeholder. A synthetic placeholder
+	 * identifies a call that never entered `tool.execute`; an interrupted
+	 * placeholder identifies one that started but threw before returning usable
+	 * output. Both are normal steering control flow and render neutrally (#7199).
 	 */
 	#isBenignSkip(): boolean {
 		if (this.#isPartial || !this.#result) return false;
-		const details = this.#result.details as { __synthetic?: boolean; source?: string } | undefined;
-		return details?.__synthetic === true && details.source === "interrupt_skipped";
+		const details = this.#result.details as
+			| { __synthetic?: boolean; __interrupted?: boolean; source?: string; execution?: string }
+			| undefined;
+		if (details?.source !== "interrupt_skipped") return false;
+		return details.__synthetic === true || (details.__interrupted === true && details.execution === "started");
 	}
 
 	/**

--- a/packages/coding-agent/src/tools/default-renderer.ts
+++ b/packages/coding-agent/src/tools/default-renderer.ts
@@ -25,6 +25,9 @@ export interface DefaultToolRenderInput {
 	result?: {
 		output: string;
 		isError?: boolean;
+		/** Synthetic placeholder for a call skipped mid-batch to service steering/peer
+		 * input — the tool never ran, so it renders neutral (info) rather than as an error. */
+		skipped?: boolean;
 	};
 	/** Current expansion and lifecycle state. */
 	options: RenderResultOptions;
@@ -42,10 +45,22 @@ export function formatDefaultToolExecution(
 		? options.spinnerFrame !== undefined
 			? "running"
 			: "pending"
-		: result?.isError
-			? "error"
-			: "done";
-	lines.push(renderStatusLine({ icon, spinnerFrame: options.spinnerFrame, title: input.label }, uiTheme));
+		: result?.skipped
+			? "info"
+			: result?.isError
+				? "error"
+				: "done";
+	lines.push(
+		renderStatusLine(
+			{
+				icon,
+				spinnerFrame: options.spinnerFrame,
+				title: input.label,
+				...(result?.skipped ? { titleColor: "muted" as const } : {}),
+			},
+			uiTheme,
+		),
+	);
 
 	const args = isRecord(input.args) ? input.args : undefined;
 	if (!options.expanded && args && Object.keys(args).length > 0) {

--- a/packages/coding-agent/test/steering-skip-render.test.ts
+++ b/packages/coding-agent/test/steering-skip-render.test.ts
@@ -1,0 +1,56 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { getThemeByName, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { formatStatusIcon } from "@oh-my-pi/pi-coding-agent/tools/render-utils";
+import { TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+	await initTheme(false, undefined, undefined, "dark", "light");
+}, 15_000);
+
+const SKIP_TEXT =
+	"Skipped due to pending peer interrupt. Do not count this skipped result as completed work or verification. After the interrupt is handled on the next step, retry the skipped tool if it is still needed.";
+
+function renderSkippedEdit(details: unknown): string {
+	const tui = new TUI(new VirtualTerminal(120, 20));
+	const component = new ToolExecutionComponent("edit", { path: "hub/src/viewer/session.ts" }, {}, undefined, tui);
+	component.updateResult({ content: [{ type: "text", text: SKIP_TEXT }], details, isError: true }, false);
+	return Bun.stripANSI(component.render(120).join("\n"));
+}
+
+describe("mid-turn steering skip rendering", () => {
+	it("renders a synthetic interrupt-skip as info, not an error", async () => {
+		const uiTheme = await getThemeByName("dark");
+		if (!uiTheme) throw new Error("dark theme missing");
+		const errorIcon = Bun.stripANSI(formatStatusIcon("error", uiTheme));
+		const infoIcon = Bun.stripANSI(formatStatusIcon("info", uiTheme));
+
+		const rendered = renderSkippedEdit({
+			__synthetic: true,
+			source: "interrupt_skipped",
+			executed: false,
+		});
+
+		expect(rendered).toContain(infoIcon);
+		expect(rendered).not.toContain(errorIcon);
+		// The bespoke edit error frame must be gone — a skip is not a failure.
+		expect(rendered).not.toContain("╭");
+		expect(rendered).toContain("Skipped due to pending peer interrupt");
+	}, 15_000);
+
+	it("still renders a genuine edit failure as an error", async () => {
+		const uiTheme = await getThemeByName("dark");
+		if (!uiTheme) throw new Error("dark theme missing");
+		const errorIcon = Bun.stripANSI(formatStatusIcon("error", uiTheme));
+
+		// A real tool failure carries no synthetic discriminator and must keep the
+		// error styling — the fix only neutralizes benign interrupt skips.
+		const rendered = renderSkippedEdit({});
+
+		expect(rendered).toContain(errorIcon);
+	}, 15_000);
+});

--- a/packages/coding-agent/test/steering-skip-render.test.ts
+++ b/packages/coding-agent/test/steering-skip-render.test.ts
@@ -23,23 +23,25 @@ function renderSkippedEdit(details: unknown): string {
 }
 
 describe("mid-turn steering skip rendering", () => {
-	it("renders a synthetic interrupt-skip as info, not an error", async () => {
+	it("renders both pending and in-flight interrupt skips as info, not errors", async () => {
 		const uiTheme = await getThemeByName("dark");
 		if (!uiTheme) throw new Error("dark theme missing");
 		const errorIcon = Bun.stripANSI(formatStatusIcon("error", uiTheme));
 		const infoIcon = Bun.stripANSI(formatStatusIcon("info", uiTheme));
+		const skipDetails = [
+			{ __synthetic: true, source: "interrupt_skipped", executed: false },
+			{ __interrupted: true, source: "interrupt_skipped", execution: "started" },
+		];
 
-		const rendered = renderSkippedEdit({
-			__synthetic: true,
-			source: "interrupt_skipped",
-			executed: false,
-		});
+		for (const details of skipDetails) {
+			const rendered = renderSkippedEdit(details);
 
-		expect(rendered).toContain(infoIcon);
-		expect(rendered).not.toContain(errorIcon);
-		// The bespoke edit error frame must be gone — a skip is not a failure.
-		expect(rendered).not.toContain("╭");
-		expect(rendered).toContain("Skipped due to pending peer interrupt");
+			expect(rendered).toContain(infoIcon);
+			expect(rendered).not.toContain(errorIcon);
+			// The bespoke edit error frame must be gone — a skip is not a failure.
+			expect(rendered).not.toContain("╭");
+			expect(rendered).toContain("Skipped due to pending peer interrupt");
+		}
 	}, 15_000);
 
 	it("still renders a genuine edit failure as an error", async () => {


### PR DESCRIPTION
## Repro
When a user (or peer/IRC) submits a mid-turn steering message, the agent aborts the next still-pending tool call so the message can be injected. `packages/coding-agent/test/steering-skip-render.test.ts` renders the resulting placeholder result through `ToolExecutionComponent` for an `edit` call and shows it drawn as a full error card — red `✘`, red frame, red text — identical to a genuine tool failure:

```
╭─── ✘ Edit: 🟦 hub/src/viewer/session.ts ───╮
│Skipped due to pending peer interrupt. …     │
╰─────────────────────────────────────────────╯
```

Run: `cd packages/coding-agent && bun test test/steering-skip-render.test.ts`.

## Cause
`executeToolCalls` in `packages/agent/src/agent-loop.ts` emits a synthetic placeholder (`createSkippedToolResult`) for a call skipped mid-batch, with `isError: true` so the model does not count it as done. The TUI (`ToolExecutionComponent.#rebuildDisplay` and the per-tool renderers / `formatDefaultToolExecution`) keys **all** error styling — background tint, status glyph, and bespoke frames like the edit card — off that `isError` flag, so a normal steering skip is indistinguishable from a real failure. The `SyntheticToolResultDetails` discriminator added in #4322 (which exists precisely so UI can render "call emitted, not executed") was never attached to the skip placeholder nor consumed by the renderer.

## Fix
- `agent-loop.ts`: `createSkippedToolResult` now returns `SyntheticToolResultDetails` (`source: "interrupt_skipped"`, `executed: false`); the `source` union gains `interrupt_skipped`.
- `default-renderer.ts`: `formatDefaultToolExecution` accepts a `skipped` flag → renders the `info` glyph and a muted title instead of the error glyph.
- `tool-execution.ts`: `#isBenignSkip()` detects the discriminator; `#rebuildDisplay` gives benign skips the neutral `toolPendingBg` tint and routes them through `#renderBenignSkipCard`, which replaces any bespoke error frame with the neutral generic card (shared `#renderDefaultCard`). Genuine failures (no discriminator) keep their error styling.

## Verification
- `cd packages/coding-agent && bun test test/steering-skip-render.test.ts` → 2 pass (neutral info render for the skip; genuine edit failure still renders the error icon).
- `cd packages/agent && bun test test/agent-loop.test.ts` → 94 pass.
- `cd packages/coding-agent && bun test test/mcp-render-status.test.ts test/session/session-context.test.ts test/tool-execution*.test.ts` → all pass (no regression to normal/error/success cards or retry lookback).
- `bun run check:types` clean in both packages; pre-publish gate (`bun run fix` + `bun check`) passed.

Fixes #7199