### PR TITLE
fix(coding-agent): normalize ask dialog questions to prevent render crash

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the live Ask dialog crashing the whole session with a `replaceTabs` TypeError when a question reached `AskDialogComponent` without a string `question` field; questions are now normalized at dialog entry, mirroring the transcript renderer ([#7211](https://github.com/can1357/oh-my-pi/issues/7211)).
+
 ## [17.2.2] - 2026-07-31
 
 ### Added

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -15,6 +15,7 @@ import {
 	wrapTextWithAnsi,
 } from "@oh-my-pi/pi-tui";
 import type {
+	ExtensionAskDialogOption,
 	ExtensionAskDialogQuestion,
 	ExtensionAskDialogResultItem,
 	ExtensionAskDialogSubmitResult,
@@ -337,6 +338,45 @@ function renderRowLabel(
 	return lines;
 }
 
+/**
+ * Coerce untrusted dialog questions into a render-safe shape. The live ask
+ * dialog is reached from the public `askDialog` extension surface and from
+ * streamed tool args, where a question entry can arrive with a missing or
+ * non-string `question` field. The render helpers (`replaceTabs`,
+ * `renderQuestionTitle`, `questionTabLabel`) assume strings, so a malformed
+ * entry throws and takes down the whole TUI render loop. Mirrors
+ * `normalizeRenderQuestions` on the transcript path.
+ */
+function normalizeDialogQuestions(questions: ExtensionAskDialogQuestion[]): ExtensionAskDialogQuestion[] {
+	if (!Array.isArray(questions)) return [];
+	const out: ExtensionAskDialogQuestion[] = [];
+	for (const entry of questions) {
+		if (!entry || typeof entry !== "object") continue;
+		const q = entry as Partial<ExtensionAskDialogQuestion>;
+		const options: ExtensionAskDialogOption[] = [];
+		if (Array.isArray(q.options)) {
+			for (const opt of q.options) {
+				if (!opt || typeof opt !== "object") continue;
+				const o = opt as Partial<ExtensionAskDialogOption>;
+				options.push({
+					label: typeof o.label === "string" ? o.label : "",
+					...(typeof o.description === "string" ? { description: o.description } : {}),
+					...(typeof o.preview === "string" ? { preview: o.preview } : {}),
+				});
+			}
+		}
+		out.push({
+			id: typeof q.id === "string" ? q.id : "?",
+			question: typeof q.question === "string" ? q.question : "",
+			...(typeof q.header === "string" ? { header: q.header } : {}),
+			options,
+			...(typeof q.multi === "boolean" ? { multi: q.multi } : {}),
+			...(Number.isInteger(q.recommended) ? { recommended: q.recommended } : {}),
+		});
+	}
+	return out;
+}
+
 export class AskDialogComponent implements Component {
 	#states: QuestionState[];
 	#activeTabIndex = 0;
@@ -352,13 +392,15 @@ export class AskDialogComponent implements Component {
 	#stableHeight: { key: string; total: number } | undefined;
 	#previewCache: PreviewRenderCache = new Map();
 	#overflowLayouts = new WeakMap<ExtensionAskDialogQuestion, Set<string>>();
+	readonly #questions: ExtensionAskDialogQuestion[];
 
 	constructor(
-		private readonly questions: ExtensionAskDialogQuestion[],
+		questions: ExtensionAskDialogQuestion[],
 		private readonly callbacks: AskDialogCallbacks,
 		private readonly options: AskDialogOptions = {},
 	) {
-		this.#states = questions.map(question => {
+		this.#questions = normalizeDialogQuestions(questions);
+		this.#states = this.#questions.map(question => {
 			const recommended = Number.isInteger(question.recommended) ? question.recommended : 0;
 			const maxIndex = Math.max(0, question.options.length - 1);
 			return {
@@ -474,8 +516,8 @@ export class AskDialogComponent implements Component {
 		const tabBarRows = this.#hasSubmitTab() ? 1 : 0;
 		const mdTheme = getMarkdownTheme();
 		let needed = MIN_DIALOG_ROWS;
-		for (let index = 0; index < this.questions.length; index++) {
-			const question = this.questions[index];
+		for (let index = 0; index < this.#questions.length; index++) {
+			const question = this.#questions[index];
 			const state = this.#states[index];
 			if (!question || !state) continue;
 			const headerRows = tabBarRows + renderQuestionTitle(question, width).length;
@@ -493,7 +535,7 @@ export class AskDialogComponent implements Component {
 		if (this.#hasSubmitTab()) {
 			// Warning line + blank, one summary line per question, blank, and
 			// the Submit row; note lines added later scroll within the body.
-			const body = 2 + this.questions.length + 2;
+			const body = 2 + this.#questions.length + 2;
 			needed = Math.max(needed, chrome + tabBarRows + 1 + Math.max(MIN_BODY_ROWS, body));
 		}
 		return Math.min(needed, maxHeight);
@@ -507,11 +549,11 @@ export class AskDialogComponent implements Component {
 		// Multi questions confirm on the Submit tab (Enter toggles, never
 		// submits), so any multi question forces the tab even when there is
 		// only one question.
-		return this.questions.length > 1 || this.questions.some(question => question.multi);
+		return this.#questions.length > 1 || this.#questions.some(question => question.multi);
 	}
 
 	#submitTabIndex(): number {
-		return this.questions.length;
+		return this.#questions.length;
 	}
 
 	#isSubmitTab(): boolean {
@@ -519,7 +561,7 @@ export class AskDialogComponent implements Component {
 	}
 
 	#currentQuestionIndex(): number {
-		return clamp(this.#activeTabIndex, 0, Math.max(0, this.questions.length - 1));
+		return clamp(this.#activeTabIndex, 0, Math.max(0, this.#questions.length - 1));
 	}
 
 	#requestRender(): void {
@@ -530,7 +572,7 @@ export class AskDialogComponent implements Component {
 		const lines: string[] = [];
 		if (this.#hasSubmitTab()) {
 			const tabs: Tab[] = [
-				...this.questions.map((question, index) => ({
+				...this.#questions.map((question, index) => ({
 					id: String(index),
 					label: questionTabLabel(question, index),
 				})),
@@ -545,7 +587,7 @@ export class AskDialogComponent implements Component {
 			return lines;
 		}
 		const questionIndex = this.#currentQuestionIndex();
-		const question = this.questions[questionIndex];
+		const question = this.#questions[questionIndex];
 		if (!question) return lines;
 		lines.push(...renderQuestionTitle(question, width));
 		return lines;
@@ -559,7 +601,7 @@ export class AskDialogComponent implements Component {
 			const scroll = indicator ? ` ${indicator} scroll ·` : "";
 			return `Enter submit · ↑/↓ scroll ·${scroll} ${cancel}`;
 		}
-		const question = this.questions[this.#currentQuestionIndex()];
+		const question = this.#questions[this.#currentQuestionIndex()];
 		const action = question?.multi ? "Space/Enter toggle · n note" : "Enter select · n note";
 		const tabs = this.#hasSubmitTab() ? " · Tab/←/→" : "";
 		if (this.#questionCanPage && indicator) {
@@ -585,7 +627,7 @@ export class AskDialogComponent implements Component {
 	}
 
 	#activeQuestionState(): { question: ExtensionAskDialogQuestion; state: QuestionState } | undefined {
-		const question = this.questions[this.#currentQuestionIndex()];
+		const question = this.#questions[this.#currentQuestionIndex()];
 		const state = this.#states[this.#currentQuestionIndex()];
 		if (!question || !state) return undefined;
 		return { question, state };
@@ -672,18 +714,18 @@ export class AskDialogComponent implements Component {
 	}
 
 	#switchTab(direction: 1 | -1): void {
-		const tabCount = this.questions.length + 1;
+		const tabCount = this.#questions.length + 1;
 		this.#activeTabIndex = (this.#activeTabIndex + direction + tabCount) % tabCount;
 		this.#submitScrollOffset = 0;
 	}
 
 	#advanceAfterQuestion(): void {
 		const current = this.#currentQuestionIndex();
-		if (this.questions.length === 1) {
+		if (this.#questions.length === 1) {
 			this.#finishSubmit();
 			return;
 		}
-		this.#activeTabIndex = current + 1 < this.questions.length ? current + 1 : this.#submitTabIndex();
+		this.#activeTabIndex = current + 1 < this.#questions.length ? current + 1 : this.#submitTabIndex();
 		this.#submitScrollOffset = 0;
 		this.#requestRender();
 	}
@@ -829,8 +871,8 @@ export class AskDialogComponent implements Component {
 			);
 			allLines.push("");
 		}
-		for (let index = 0; index < this.questions.length; index++) {
-			const question = this.questions[index];
+		for (let index = 0; index < this.#questions.length; index++) {
+			const question = this.#questions[index];
 			const state = this.#states[index];
 			if (!question || !state) continue;
 			const label = questionTabLabel(question, index);
@@ -895,8 +937,8 @@ export class AskDialogComponent implements Component {
 
 	#unansweredCount(): number {
 		let count = 0;
-		for (let index = 0; index < this.questions.length; index++) {
-			const question = this.questions[index];
+		for (let index = 0; index < this.#questions.length; index++) {
+			const question = this.#questions[index];
 			const state = this.#states[index];
 			if (!question || !state) continue;
 			if (state.selectedOptions.size === 0 && state.customInput === undefined) count += 1;
@@ -911,8 +953,8 @@ export class AskDialogComponent implements Component {
 			return;
 		}
 		this.options.onTimeout?.();
-		for (let index = 0; index < this.questions.length; index++) {
-			const question = this.questions[index];
+		for (let index = 0; index < this.#questions.length; index++) {
+			const question = this.#questions[index];
 			const state = this.#states[index];
 			if (!question || !state) continue;
 			if (state.selectedOptions.size === 0 && state.customInput === undefined) {
@@ -952,8 +994,8 @@ export class AskDialogComponent implements Component {
 
 	#buildResults(): ExtensionAskDialogResultItem[] {
 		const results: ExtensionAskDialogResultItem[] = [];
-		for (let index = 0; index < this.questions.length; index++) {
-			const question = this.questions[index];
+		for (let index = 0; index < this.#questions.length; index++) {
+			const question = this.#questions[index];
 			const state = this.#states[index];
 			if (!question || !state) continue;
 			const selectedOptions = question.options

--- a/packages/coding-agent/test/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/ask-dialog.test.ts
@@ -1362,4 +1362,26 @@ describe("AskDialogComponent", () => {
 		expect(onSubmit).toHaveBeenCalledTimes(1);
 		expect(onSubmit.mock.calls[0][0].results[0].customInput).toBeUndefined();
 	});
+
+	it("normalizes malformed questions so render and submit do not crash", () => {
+		const onSubmit = vi.fn();
+		// A question entry that reaches the live dialog without a string
+		// `question` field (e.g. via the askDialog extension surface) used to
+		// throw `replaceTabs(undefined)` and take down the whole TUI.
+		const questions = [{ id: "q1", options: [{ label: "Option A" }] }] as unknown as ExtensionAskDialogQuestion[];
+
+		const component = new AskDialogComponent(questions, {
+			onSubmit,
+			onCancel: vi.fn(),
+			onPrompt: vi.fn(),
+		});
+
+		expect(() => render(component)).not.toThrow();
+
+		component.handleInput(ENTER);
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		const result = onSubmit.mock.calls[0][0].results[0];
+		expect(result.question).toBe("");
+		expect(result.selectedOptions).toEqual(["Option A"]);
+	});
 });


### PR DESCRIPTION
## Repro
Constructing the live `AskDialogComponent` with a question entry that omits a string `question` field (reachable via the public `askDialog` extension surface or streamed tool args) and rendering it throws `TypeError: undefined is not an object (evaluating 'text.replaceAll')`, which escapes the TUI render loop and takes down the whole session. Reproduced with `bun test` against `AskDialogComponent` constructed as `{ id, options }` (no `question`) — `component.render(80)` throws.

## Cause
`packages/coding-agent/src/modes/components/ask-dialog.ts` render helpers (`renderQuestionTitle` → `replaceTabs(question.question)` at line 149, plus `questionTabLabel` and `boundPromptTitle` callers) trust `question.question` to be a string. `packages/tui/src/utils.ts` `replaceTabs` calls `text.replaceAll(...)` with no guard. The ask *call* renderer already coerces the same malformed data via `normalizeRenderQuestions` (added in commit `1dc95e7`, "prevent TUI render crashes"), but the live dialog path lacked the equivalent guard.

## Fix
- Add `normalizeDialogQuestions` in `ask-dialog.ts`, coercing each entry's `id`/`question`/option `label` to strings, `options` to a well-formed array, and `header`/`multi`/`recommended` to their expected types — mirroring `normalizeRenderQuestions`.
- Normalize the incoming array once at construction into a new `readonly #questions` field; build `#states` and all render/submit reads from it (renamed the former `questions` parameter property to `#questions`).
- Add a regression test asserting a malformed question renders without throwing and submits with a coerced (`""`) `question`.

## Verification
`bun test test/modes/components/ask-dialog.test.ts` → 38 pass (incl. new regression). `bun test test/tools/ask.test.ts` → 46 pass. `bun test test/modes/controllers/extension-ui-controller.test.ts` → 8 pass. Fixes #7211