### PR TITLE
fix(coding-agent): reuse effective prompt cache key

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ephemeral side turns and native compaction bypassing an explicit or fork-inherited prompt cache key ([#7218](https://github.com/can1357/oh-my-pi/issues/7218)).
+
 ## [17.2.2] - 2026-07-31
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7018,7 +7018,7 @@ export class AgentSession {
 				// shared provider state map is still required so Codex can allocate
 				// websocket state under that side-channel session id.
 				sessionId: `${cacheSessionId}:side:${Snowflake.next()}`,
-				promptCacheKey: cacheSessionId,
+				promptCacheKey: this.agent.promptCacheKey ?? this.agent.sessionId,
 				preferWebsockets: this.#preferWebsockets,
 				providerSessionState: this.#providerSessionState,
 				reasoning: toReasoningEffort(this.thinkingLevel),

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1539,7 +1539,7 @@ export class SessionMaintenance {
 						thinkingLevel: this.#host.thinkingLevel(),
 						tools: this.#host.agent.state.tools,
 						sessionId: this.#host.sessionId(),
-						promptCacheKey: this.#host.sessionId(),
+						promptCacheKey: this.#host.agent.promptCacheKey ?? this.#host.agent.sessionId,
 						providerSessionState: this.#host.providerSessionState,
 						// Route every summarization HTTP request through the
 						// session's side-stream transport so the provider
@@ -2585,7 +2585,7 @@ export class SessionMaintenance {
 									thinkingLevel: this.#host.thinkingLevel(),
 									tools: this.#host.agent.state.tools,
 									sessionId: this.#host.sessionId(),
-									promptCacheKey: this.#host.sessionId(),
+									promptCacheKey: this.#host.agent.promptCacheKey ?? this.#host.agent.sessionId,
 									providerSessionState: this.#host.providerSessionState,
 									codexCompaction,
 								},

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -744,8 +744,10 @@ describe("AgentSession handoff", () => {
 			details: {},
 			preserveData: { resultState: "keep-result" },
 		});
+		const promptCacheKey = "inherited-parent-cache";
 		const localAgent = new Agent({
 			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			promptCacheKey,
 		});
 		const localSession = new AgentSession({
 			agent: localAgent,
@@ -762,6 +764,7 @@ describe("AgentSession handoff", () => {
 		try {
 			await localSession.runIdleCompaction();
 			expect(compactSpy).toHaveBeenCalledTimes(1);
+			expect(compactSpy.mock.calls[0]?.[5]?.promptCacheKey).toBe(promptCacheKey);
 			const compactionEntry = localSessionManager.getEntries().find(entry => entry.type === "compaction");
 			if (compactionEntry?.type !== "compaction") throw new Error("Expected persisted compaction entry");
 			expect(compactionEntry.preserveData).toEqual({

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -263,8 +263,10 @@ describe("AgentSession message pipeline", () => {
 			contextWindow: 4096,
 			maxTokens: 1024,
 		} as ModelSpec<Api>) as Model<Api>;
+		const promptCacheKey = "inherited-parent-cache";
 		const session = new AgentSession({
 			agent: new Agent({
+				promptCacheKey,
 				initialState: {
 					model,
 					systemPrompt: ["system prompt"],
@@ -283,7 +285,7 @@ describe("AgentSession message pipeline", () => {
 		const result = await session.runEphemeralTurn({ promptText: "Question?" });
 
 		expect(result.replyText).toBe("Answer");
-		expect(capturedOptions?.promptCacheKey).toBe(cacheSessionId);
+		expect(capturedOptions?.promptCacheKey).toBe(promptCacheKey);
 		expect(capturedOptions?.sessionId).toStartWith(`${cacheSessionId}:side:`);
 		expect(capturedOptions?.sessionId).not.toBe(cacheSessionId);
 		expect(capturedOptions?.preferWebsockets).toBe(true);

--- a/packages/coding-agent/test/compaction-prefer-current-model.test.ts
+++ b/packages/coding-agent/test/compaction-prefer-current-model.test.ts
@@ -49,7 +49,9 @@ describe("compaction prefers the current session model over modelRoles.default",
 		const settings = Settings.isolated({ "compaction.keepRecentTokens": 1, "compaction.strategy": "context-full" });
 		settings.setModelRole("default", `${defaultRoleModel.provider}/${defaultRoleModel.id}`);
 
+		const promptCacheKey = "inherited-parent-cache";
 		const agent = new Agent({
+			promptCacheKey,
 			initialState: {
 				model: currentModel,
 				systemPrompt: ["Test"],
@@ -98,6 +100,7 @@ describe("compaction prefers the current session model over modelRoles.default",
 		expect(compactSpy).toHaveBeenCalled();
 		const [, firstCandidate] = compactSpy.mock.calls[0]!;
 		expect(`${firstCandidate.provider}/${firstCandidate.id}`).toBe(`${currentModel.provider}/${currentModel.id}`);
+		expect(compactSpy.mock.calls[0]?.[5]?.promptCacheKey).toBe(promptCacheKey);
 	});
 
 	it("falls back when the authenticated Bedrock candidate cannot resolve AWS credentials", async () => {


### PR DESCRIPTION
## Repro
With an agent configured as `sessionId = <generated UUID>` and `promptCacheKey = inherited-parent-cache`, run `bun test packages/coding-agent/test/agent-session-message-pipeline.test.ts packages/coding-agent/test/compaction-prefer-current-model.test.ts packages/coding-agent/test/agent-session-handoff.test.ts`; before the fix, the side-turn, manual-compaction, and automatic-compaction assertions each received the generated session UUID instead of `inherited-parent-cache` (60 passed, 3 failed).

## Cause
`AgentSession.runEphemeralTurn()` in `packages/coding-agent/src/session/agent-session.ts` and both compaction option builders in `packages/coding-agent/src/session/session-maintenance.ts` populated `promptCacheKey` from session-manager IDs rather than the agent’s effective provider cache identity, bypassing explicit and fork-inherited keys.

## Fix
- Reuse `agent.promptCacheKey ?? agent.sessionId` for ephemeral side turns while retaining their unique routing `sessionId`.
- Forward the same effective key through manual and automatic compaction without changing provider session state or fallback routing.
- Cover all three secondary request paths with divergent cache and session identities.
- Document the fix under the coding-agent changelog’s Unreleased section.

## Verification
`bun test packages/coding-agent/test/agent-session-message-pipeline.test.ts packages/coding-agent/test/compaction-prefer-current-model.test.ts packages/coding-agent/test/agent-session-handoff.test.ts` passes: 63 tests, 0 failures, 240 assertions. The publish gate also completed `bun run fix` and `bun check` successfully. Fixes #7218