### PR TITLE
fix(ai): honor model.compat.streamIdleTimeoutMs in the Anthropic idle watchdog

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed direct Anthropic provider streams ignoring `model.compat.streamIdleTimeoutMs`. Requests dispatched through `streamAnthropic` can now widen the inter-event idle watchdog or set it to `0` to disable that watchdog; caller options and environment overrides retain precedence. Setting the compat value to `0` disables only the inter-event watchdog and leaves the first-event watchdog enabled; wider idle values continue to floor the first-event budget under the existing timeout contract.
+
 ## [17.2.3] - 2026-08-01
 
 ### Added

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2002,7 +2002,7 @@ const streamAnthropicOnce = (
 				| (AnthropicServerToolContent & { [kStreamingPartialJson]?: string })
 				| (ToolCall & { [kStreamingPartialJson]: string; [kStreamingLastParseLen]?: number })
 			) & { [kStreamingBlockIndex]: number };
-			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs();
+			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs(model.compat.streamIdleTimeoutMs);
 			const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
 			const requestTimeoutMs =
 				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0 ? firstEventTimeoutMs : undefined;

--- a/packages/ai/test/anthropic-stream-timeout.test.ts
+++ b/packages/ai/test/anthropic-stream-timeout.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
 import { AnthropicMessagesClient, type AnthropicMessagesClientLike } from "@oh-my-pi/pi-ai/providers/anthropic-client";
@@ -204,7 +204,37 @@ async function resolveAfterMicrotasks<T>(promise: Promise<T>, errorMessage: stri
 	return outcome.value;
 }
 
+const STREAM_TIMEOUT_ENV_KEYS = [
+	"PI_STREAM_IDLE_TIMEOUT_MS",
+	"PI_OPENAI_STREAM_IDLE_TIMEOUT_MS",
+	"PI_STREAM_FIRST_EVENT_TIMEOUT_MS",
+] as const;
+
+type StreamTimeoutEnvKey = (typeof STREAM_TIMEOUT_ENV_KEYS)[number];
+
+const originalStreamTimeoutEnv: Record<StreamTimeoutEnvKey, string | undefined> = {
+	PI_STREAM_IDLE_TIMEOUT_MS: undefined,
+	PI_OPENAI_STREAM_IDLE_TIMEOUT_MS: undefined,
+	PI_STREAM_FIRST_EVENT_TIMEOUT_MS: undefined,
+};
+
+beforeEach(() => {
+	for (const key of STREAM_TIMEOUT_ENV_KEYS) {
+		originalStreamTimeoutEnv[key] = Bun.env[key];
+		delete Bun.env[key];
+	}
+});
+
 afterEach(() => {
+	for (const key of STREAM_TIMEOUT_ENV_KEYS) {
+		const previous = originalStreamTimeoutEnv[key];
+		if (previous === undefined) {
+			delete Bun.env[key];
+		} else {
+			Bun.env[key] = previous;
+		}
+	}
+
 	vi.useRealTimers();
 	vi.restoreAllMocks();
 });
@@ -457,6 +487,114 @@ describe("anthropic first-event timeout retries", () => {
 				arguments: {},
 			},
 		]);
+	});
+});
+
+describe("anthropic model compat stream idle timeout floor", () => {
+	const baseModel = {
+		id: "claude-sonnet-4-5",
+		name: "Claude Sonnet 4.5",
+		api: "anthropic-messages" as const,
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+	} satisfies Parameters<typeof buildModel>[0];
+
+	function createStalledAfterFirstEventClient(onIteratorStart?: () => void): {
+		attempt: () => number;
+		client: AnthropicMessagesClientLike;
+	} {
+		let attempt = 0;
+		const create = ((_body: unknown, requestOptions?: { signal?: AbortSignal }) => {
+			attempt += 1;
+			return createAnthropicMockStream({
+				signal: requestOptions?.signal,
+				events: [
+					{
+						type: "message_start",
+						message: {
+							id: "msg_compat_stall",
+							usage: {
+								input_tokens: 12,
+								output_tokens: 0,
+								cache_read_input_tokens: 0,
+								cache_creation_input_tokens: 0,
+							},
+						},
+					},
+				],
+				hangAfterEvents: true,
+				onIteratorStart,
+			}) as never;
+		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
+		return { attempt: () => attempt, client: { messages: { create } } as AnthropicMessagesClientLike };
+	}
+
+	it("uses model.compat.streamIdleTimeoutMs as the idle floor when no caller option is set", async () => {
+		const compatModel = buildModel({ ...baseModel, compat: { streamIdleTimeoutMs: 50 } });
+		const { attempt, client } = createStalledAfterFirstEventClient();
+
+		const result = await streamAnthropic(compatModel, context, {
+			client,
+			streamFirstEventTimeoutMs: 5_000,
+		}).result();
+
+		expect(attempt()).toBe(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Anthropic stream stalled while waiting for the next event");
+	});
+
+	it("disables the idle watchdog when model.compat.streamIdleTimeoutMs is 0", async () => {
+		vi.useFakeTimers();
+		const compatModel = buildModel({ ...baseModel, compat: { streamIdleTimeoutMs: 0 } });
+		const controller = new AbortController();
+		let iteratorStarted = false;
+		const { attempt, client } = createStalledAfterFirstEventClient(() => {
+			iteratorStarted = true;
+		});
+
+		let settled = false;
+		const resultPromise = streamAnthropic(compatModel, context, {
+			client,
+			signal: controller.signal,
+			// First-event watchdog stays out of this case's scope: it would need to
+			// be cleared by the mock's first event, and fake-timer advancement can
+			// outrun the microtask that consumes that event under filtered runs.
+			streamFirstEventTimeoutMs: 0,
+		}).result();
+		void resultPromise.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+
+		await drainMicrotasksUntil(
+			() => iteratorStarted,
+			"Anthropic mock stream did not start for the compat-disabled watchdog test",
+		);
+		// Well past the default 300s idle floor: the disabled watchdog must not
+		// classify the post-first-event silence as a stall.
+		vi.advanceTimersByTime(400_000);
+		await drainMicrotasksUntil(
+			() => vi.getTimerCount() === 0,
+			"Anthropic watchdog timer did not drain after advancing past the idle budget",
+		);
+		expect(settled).toBe(false);
+		expect(attempt()).toBe(1);
+
+		controller.abort();
+		const result = await resolveAfterMicrotasks(
+			resultPromise,
+			"Anthropic compat-disabled stream did not settle after the caller aborted",
+		);
+		expect(result.stopReason).toBe("aborted");
 	});
 });
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `AnthropicCompat.streamIdleTimeoutMs` and propagated it through `buildAnthropicCompat` so direct Anthropic provider streams can configure their inter-event idle watchdog.
+
 ## [17.2.3] - 2026-08-01
 
 ### Added

--- a/packages/catalog/src/compat/anthropic.ts
+++ b/packages/catalog/src/compat/anthropic.ts
@@ -172,6 +172,7 @@ export function buildAnthropicCompat(spec: ModelSpec<"anthropic-messages">): Res
 		// id or baseUrl marker.
 		replayUnsignedThinking: !signingEndpoint && (Boolean(spec.reasoning) || modelMatchesHost(spec, "deepseekFamily")),
 		escapeBuiltinToolNames: modelMatchesHost(spec, "umans"),
+		streamIdleTimeoutMs: spec.compat?.streamIdleTimeoutMs,
 	};
 	applyCompatOverrides(compat, spec.compat);
 	return compat;

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -402,6 +402,15 @@ export interface OpenAICompat {
  */
 export interface AnthropicCompat {
 	/**
+	 * Stream-watchdog idle-timeout fallback in ms for slow reasoning hosts.
+	 * Set to 0 to disable the inter-event idle watchdog entirely, matching
+	 * `OpenAICompat.streamIdleTimeoutMs`.
+	 *
+	 * When unset, direct Anthropic streams use `PI_STREAM_IDLE_TIMEOUT_MS`,
+	 * then the legacy `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` alias, then 300s.
+	 */
+	streamIdleTimeoutMs?: number;
+	/**
 	 * Drop the top-level `strict: true` field on tool definitions. Vertex AI's
 	 * Anthropic-compatible endpoint rejects unknown tool fields with
 	 * `tools.<n>.custom.strict: Extra inputs are not permitted`.
@@ -712,7 +721,13 @@ export interface ResolvedOpenAIResponsesCompat extends ResolvedOpenAISharedCompa
 export type ResolvedOpenRouterCompat = ResolvedOpenAICompat & ResolvedOpenAIResponsesCompat;
 
 /** Fully-resolved anthropic-messages compat view (same contract as `ResolvedOpenAICompat`). */
-export type ResolvedAnthropicCompat = Required<AnthropicCompat> & {
+export type ResolvedAnthropicCompat = Required<Omit<AnthropicCompat, "streamIdleTimeoutMs">> & {
+	/**
+	 * Stream-watchdog idle-timeout fallback in ms for slow reasoning hosts; 0 disables the idle watchdog.
+	 * Undefined defers to `PI_STREAM_IDLE_TIMEOUT_MS`, then the legacy
+	 * `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` alias, then 300s.
+	 */
+	streamIdleTimeoutMs?: number;
 	/**
 	 * The configured endpoint is the official first-party Anthropic API
 	 * (https + exact `api.anthropic.com` host; a missing baseUrl counts as


### PR DESCRIPTION
## Problem

Direct Anthropic provider streams (`streamAnthropic`) ignore the model-level
compat idle-timeout knob. Slow relayed Anthropic endpoints therefore remain
subject to the default inter-event idle watchdog even when the model
configured a wider or disabled timeout.

Observed in the wild: `newapi-kiro` (Claude Opus 4.x via a proxy gateway)
stalled once mid-generation — the local watchdog aborted the stream after the
idle budget elapsed while the upstream SSE connection was still alive. The
OpenAI-family paths already honor the same knob
(`openai-responses.ts: getOpenAIStreamIdleTimeoutMs(model.compat.streamIdleTimeoutMs)`),
so an Anthropic-compatible model configures `compat.streamIdleTimeoutMs` and
gets no effect. There is no open GitHub issue/PR covering this gap on the
Anthropic path — the GLM 600s floor (#4594) and Cursor's 120s watchdog
(#6176) are the same mechanism, and #6951 proposes effort-based scaling on
top of it.

## Fix

- `catalog`: add `AnthropicCompat.streamIdleTimeoutMs` (optional, no breaking
  type change); `ResolvedAnthropicCompat` keeps it optional via the
  `Required<Omit<...>>` pattern; `buildAnthropicCompat` propagates it, and
  `applyCompatOverrides` still accepts config overrides on top.
- `ai`: `streamAnthropic` passes it as the fallback to
  `getStreamIdleTimeoutMs`, aligning the Anthropic path with the OpenAI paths.

Resolution order (identical to the existing timeout-helper contract):

```
caller option
> PI_STREAM_IDLE_TIMEOUT_MS
> PI_OPENAI_STREAM_IDLE_TIMEOUT_MS
> model compat
> 300s default
```

`0` disables only the inter-event idle watchdog; the first-event watchdog
stays enabled (still 300s by default). Wider idle values continue to floor
the first-event budget under the existing timeout contract
(`getStreamFirstEventTimeoutMs` does `Math.max(300_000, idle)`).

The pi-native transport is intentionally untouched — it keeps its existing
transport-level timeout policy; this change is scoped to the direct
Anthropic SDK/provider path.

## Tests

- New cases in `packages/ai/test/anthropic-stream-timeout.test.ts`:
  - `uses model.compat.streamIdleTimeoutMs as the idle floor` — a compat
    value below the default wins (real timers).
  - `disables the idle watchdog when model.compat.streamIdleTimeoutMs is 0` —
    well past the 300s default budget, the stream stays open until the caller
    aborts (fake timers; `streamFirstEventTimeoutMs: 0` keeps the case
    independent of first-item microtask timing).
- File-level env isolation: `PI_STREAM_IDLE_TIMEOUT_MS`,
  `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS`, `PI_STREAM_FIRST_EVENT_TIMEOUT_MS` are
  snapshotted/deleted in `beforeEach` and restored in `afterEach`, so the
  suite is robust to a polluted shell environment.
- Verified: full suite 21 pass under clean env and under
  `PI_STREAM_IDLE_TIMEOUT_MS=0` / `=100` / `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS=100`;
  filtered runs pass under the audit's env-contamination scenarios;
  `stream-timeout-defaults.test.ts` 25 pass; `models-config-lazy-validator` 1 pass;
  `bun check` (TS + Rust + tools) green.

## Related

- #6951 — effort-based idle scaling on the same watchdog; complementary, no
  overlap (this PR only wires the existing compat knob through).
- #6176 — Cursor's 120s idle watchdog, same mechanism, background context.
- #4593 / #4594 — GLM 600s floor precedent for the model-level knob.

I use the Kiro API on my newapi relay, and it stalled once mid-generation under the default idle watchdog; after applying this fix locally with `compat.streamIdleTimeoutMs` set on the model, the same long-silence session completed without abort.