### PR TITLE
fix(mnemopi): strip reasoning blocks from summaries

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Stripped `<think>…</think>` reasoning blocks from remote LLM output in `cleanOutput`, so reasoning-model responses no longer leak into consolidated memories or corrupt fact extraction (the reasoning wrapper previously survived parsing and every stored fact became reasoning prose). ([#7231](https://github.com/can1357/oh-my-pi/issues/7231))
+
 ## [17.2.2] - 2026-07-31
 
 ### Fixed

--- a/packages/mnemopi/src/core/local-llm.ts
+++ b/packages/mnemopi/src/core/local-llm.ts
@@ -254,7 +254,7 @@ export function cleanOutput(text: string): string {
 		.replaceAll("<|user|>", "")
 		.replaceAll("</s>", "")
 		.trim()
-		.replace(/<think>[\s\S]*?<\/think>/gi, "")
+		.replace(/^(?:\s*<think>[\s\S]*?<\/think>)+\s*/i, "")
 		.replace(/^(Summarize the following memories.*?[.!?:]\s*)/is, "")
 		.replace(/^(Preserve facts.*?[.!?:]\s*)/is, "")
 		.replace(/^Source:.*?\n/im, "")

--- a/packages/mnemopi/src/core/local-llm.ts
+++ b/packages/mnemopi/src/core/local-llm.ts
@@ -254,6 +254,7 @@ export function cleanOutput(text: string): string {
 		.replaceAll("<|user|>", "")
 		.replaceAll("</s>", "")
 		.trim()
+		.replace(/<think>[\s\S]*?<\/think>/gi, "")
 		.replace(/^(Summarize the following memories.*?[.!?:]\s*)/is, "")
 		.replace(/^(Preserve facts.*?[.!?:]\s*)/is, "")
 		.replace(/^Source:.*?\n/im, "")

--- a/packages/mnemopi/test/extraction.test.ts
+++ b/packages/mnemopi/test/extraction.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import type { FetchImpl } from "@oh-my-pi/pi-ai";
 import {
 	buildExtractionPrompt,
 	extractFacts,
@@ -112,6 +113,23 @@ describe("structured extraction", () => {
 		expect(facts).toEqual(["Alex uses Neovim", "Alex dislikes VSCode"]);
 		expect(capturedTemperature).toBe(0);
 		expect(getExtractionStats().by_tier.host.successes).toBe(1);
+	});
+
+	it("strips reasoning wrappers from remote extraction so facts are not reasoning prose", async () => {
+		process.env.MNEMOPI_LLM_ENABLED = "true";
+		process.env.MNEMOPI_HOST_LLM_ENABLED = "false";
+		process.env.MNEMOPI_LLM_BASE_URL = "http://reasoning.invalid/v1";
+		const content =
+			'<think>\nThe user is providing information in English. Let me analyze what qualifies:\n- candidate fact\n</think>\n{"facts":["My preferred shell is zsh"],"instructions":[],"preferences":[],"timelines":[],"kg":[]}';
+		const fetchMock: FetchImpl = async () =>
+			new Response(JSON.stringify({ choices: [{ message: { content } }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+
+		const facts = await extractFacts("I use zsh.", { fetch: fetchMock });
+		expect(facts).toEqual(["My preferred shell is zsh"]);
+		expect(getExtractionStats().by_tier.remote.successes).toBe(1);
 	});
 
 	it("prefers a configured completion with the extraction-prompt override at temperature zero", async () => {

--- a/packages/mnemopi/test/local-llm.test.ts
+++ b/packages/mnemopi/test/local-llm.test.ts
@@ -61,6 +61,28 @@ describe("local LLM TypeScript port", () => {
 		expect(model).toBe("test-model");
 	});
 
+	it("removes leading reasoning blocks from remote summaries", async () => {
+		process.env.MNEMOPI_LLM_BASE_URL = "http://reasoning-llm/v1";
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					choices: [
+						{
+							message: {
+								content:
+									"<think>\nThe user requested a one-sentence summary.\n</think>\nMnemopi uses multilingual-e5-large.",
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+
+		expect(await summarizeMemories(["Mnemopi uses multilingual-e5-large."], "", { fetch: fetchMock })).toBe(
+			"Mnemopi uses multilingual-e5-large.",
+		);
+	});
+
 	it("keeps local GGUF unavailable and returns null for local completion", async () => {
 		expect(localGgufAvailable()).toBe(false);
 		expect(await callLocalLlm("prompt")).toBeNull();

--- a/packages/mnemopi/test/local-llm.test.ts
+++ b/packages/mnemopi/test/local-llm.test.ts
@@ -11,6 +11,7 @@ import {
 	callLocalLlm,
 	callRemoteLlm,
 	chunkMemoriesByBudget,
+	cleanOutput,
 	complete,
 	llmAvailable,
 	localGgufAvailable,
@@ -81,6 +82,10 @@ describe("local LLM TypeScript port", () => {
 		expect(await summarizeMemories(["Mnemopi uses multilingual-e5-large."], "", { fetch: fetchMock })).toBe(
 			"Mnemopi uses multilingual-e5-large.",
 		);
+	});
+
+	it("preserves a literal think tag that follows real content", () => {
+		expect(cleanOutput("The XML tag is <think>keep</think>")).toBe("The XML tag is <think>keep</think>");
 	});
 
 	it("keeps local GGUF unavailable and returns null for local completion", async () => {


### PR DESCRIPTION
## Repro
On current `main`, `bun -e 'import { cleanOutput } from "./packages/mnemopi/src/core/local-llm.ts"; console.log(cleanOutput("<think>reasoning</think>summary"))'` prints `<think>reasoning</think>summary`, demonstrating that a reasoning-model response remains unsanitized. The extraction-routing half of the report is already covered by merged PR #3042 and `packages/mnemopi/test/extraction-wiring.test.ts`.

## Cause
`cleanOutput` in `packages/mnemopi/src/core/local-llm.ts` removed TinyLlama chat-template markers and echoed prompt prefixes, but did not recognize the leading `<think>…</think>` wrapper emitted in `message.content` by MiniMax reasoning models; consolidation therefore treated that reasoning as memory content.

## Fix
- Strip one or more complete leading `<think>…</think>` blocks before the existing summary cleanup.
- Exercise the remote consolidation path with a reasoning-wrapped OpenAI-compatible response.
- Record the behavior change in the Mnemopi changelog.

## Verification
`HOME=/tmp/omp-mnemopi-test-home bun test packages/mnemopi/test/local-llm.test.ts` passed: 9 tests, 0 failures. `HOME=/tmp/omp-mnemopi-test-home bun test packages/mnemopi/test/extraction-wiring.test.ts` passed: 6 tests, 0 failures. `bun --cwd packages/mnemopi run check` passed. The post-fix direct reproduction prints only `"Mnemopi uses multilingual-e5-large."`.

Fixes #7231