### PR TITLE
fix(coding-agent): clear bash auto-background threshold timer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Bash auto-background leaving a live `Bun.sleep` threshold timer scheduled after a command completes (or abort/steering wins) first, which could keep the event loop alive and delay SDK/headless shutdown until the threshold expired ([#7235](https://github.com/can1357/oh-my-pi/issues/7235)).
+
 ## [17.2.2] - 2026-07-31
 
 ### Added

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -843,13 +843,18 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			return { kind: "steer" };
 		}
 
+		// Cancellable threshold: a bare Bun.sleep(thresholdMs) leaves a live, ref'd
+		// timer for the full threshold after the command finishes (or abort/steer)
+		// wins the race first — delaying SDK/headless shutdown and accumulating
+		// timers under fast command rates. Settle a withResolvers promise from
+		// setTimeout so the finally can clear it regardless of which waiter wins.
+		const { promise: thresholdPromise, resolve: resolveThreshold } = Promise.withResolvers<{
+			kind: "running";
+		}>();
+		const thresholdTimer = setTimeout(() => resolveThreshold({ kind: "running" }), thresholdMs);
 		const waiters: Array<
 			Promise<ManagedBashJobCompletion | { kind: "running" } | { kind: "steer" } | { kind: "aborted" }>
-		> = [job.completion, Bun.sleep(thresholdMs).then(() => ({ kind: "running" as const }))];
-
-		if (!signal && !steeringSignal) {
-			return await Promise.race(waiters);
-		}
+		> = [job.completion, thresholdPromise];
 
 		const { promise: abortedPromise, resolve: resolveAborted } = Promise.withResolvers<{ kind: "aborted" }>();
 		const onAbort = () => resolveAborted({ kind: "aborted" });
@@ -866,6 +871,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		try {
 			return await Promise.race(waiters);
 		} finally {
+			clearTimeout(thresholdTimer);
 			signal?.removeEventListener("abort", onAbort);
 			steeringSignal?.removeEventListener("abort", onSteer);
 		}

--- a/packages/coding-agent/test/bash-autobg-timer.test.ts
+++ b/packages/coding-agent/test/bash-autobg-timer.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression test for #7235: Bash auto-background must release the threshold
+ * timer once the command finishes first, instead of leaving a live `Bun.sleep`
+ * timer that keeps the event loop alive until the threshold expires (delaying
+ * SDK/headless shutdown). Timer keep-alive is only observable in a child
+ * process, so this spawns the real BashTool auto-background path against a 30s
+ * threshold and asserts the process exits promptly rather than after 30s.
+ */
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+
+const PROBE_PATH = path.join(import.meta.dir, "fixtures", "bash-autobg-exit-probe.ts");
+const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
+// Fixed: probe exits ~0.5s. Buggy: held ~30s by the retained threshold timer.
+const PROMPT_EXIT_MS = 15_000;
+
+describe("bash auto-background threshold timer (#7235)", () => {
+	it("does not keep the event loop alive after a fast command completes", async () => {
+		const start = performance.now();
+		const proc = Bun.spawn([process.execPath, PROBE_PATH], {
+			cwd: REPO_ROOT,
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		// Integration test of real event-loop keep-alive across a process boundary:
+		// the child's wall-clock exit time IS the contract, so fake timers cannot
+		// apply (they cannot control another process's clock). This real-timer
+		// watchdog only bounds a wedged child — a retained threshold timer would
+		// otherwise hold it for the full 30s.
+		const watchdog = setTimeout(() => {
+			try {
+				proc.kill("SIGKILL");
+			} catch {}
+		}, 28_000);
+		try {
+			const [exitCode, stdout, stderr] = await Promise.all([
+				proc.exited,
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+			]);
+			const elapsedMs = performance.now() - start;
+
+			expect(stderr).toBe("");
+			expect(exitCode).toBe(0);
+			expect(JSON.parse(stdout.trim())).toEqual({ done: true, output: "hi" });
+			expect(elapsedMs).toBeLessThan(PROMPT_EXIT_MS);
+		} finally {
+			clearTimeout(watchdog);
+		}
+	}, 30_000);
+});

--- a/packages/coding-agent/test/fixtures/bash-autobg-exit-probe.ts
+++ b/packages/coding-agent/test/fixtures/bash-autobg-exit-probe.ts
@@ -1,0 +1,46 @@
+/**
+ * Child-process probe for #7235: the Bash auto-background threshold race must not
+ * leave a live, ref'd timer after the command finishes first. Runs the real
+ * `BashTool` auto-background path for a fast command against a 30s threshold and
+ * exits without disposing the job manager. A retained threshold timer would keep
+ * the event loop alive until the threshold expires; the fix clears it, so the
+ * process must exit promptly. The parent test measures wall-clock exit time.
+ */
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { BashTool } from "@oh-my-pi/pi-coding-agent/tools/bash";
+
+const THRESHOLD_MS = 30_000;
+
+// retentionMs:0 evicts the completed job immediately; the eviction timer is
+// unref'd regardless, so the only ref'd timer under test is the race threshold.
+const manager = new AsyncJobManager({ retentionMs: 0 });
+
+const session = {
+	cwd: "/tmp",
+	hasUI: false,
+	skills: [],
+	getSessionFile: () => null,
+	getSessionId: () => "autobg-probe",
+	getAgentId: () => null,
+	asyncJobManager: manager,
+	settings: {
+		get(key: string) {
+			if (key === "bash.autoBackground.enabled") return true;
+			if (key === "bash.autoBackground.thresholdMs") return THRESHOLD_MS;
+			return undefined;
+		},
+		getBashInterceptorRules() {
+			return [];
+		},
+	},
+	getClientBridge: () => undefined,
+} as unknown as ToolSession;
+
+const tool = new BashTool(session);
+const result = await tool.execute("autobg-probe-call", { command: "printf hi" });
+const text = result.content.find(c => c.type === "text")?.text ?? "";
+// First line only: the completed-result text carries a dynamic "Wall time" footer.
+const firstLine = text.split("\n", 1)[0]?.trim() ?? "";
+process.stdout.write(`${JSON.stringify({ done: true, output: firstLine })}\n`);
+// Deliberately no manager.dispose(): the process must exit on its own.


### PR DESCRIPTION
## Repro
With `bash.autoBackground.enabled` and an async job manager, `#waitForManagedBashJob()` races `job.completion` against a bare `Bun.sleep(thresholdMs)`. A bare `Bun.sleep` timer cannot be cancelled, so when completion, abort, or steering wins the race the losing timer stays scheduled and ref'd, keeping Bun's event loop alive until the threshold expires. Driving the real `BashTool` auto-background path in a child process (fast `printf hi` command, no manual `dispose()`): against a 5s threshold the buggy build finishes the command in ~48ms yet the process only exits at 5.46s; the fixed build exits in ~0.5s even against a 30s threshold. Repro command: `bun packages/coding-agent/test/fixtures/bash-autobg-exit-probe.ts` from the repo root.

## Cause
`packages/coding-agent/src/tools/bash.ts` `#waitForManagedBashJob()` built its waiter set with `Bun.sleep(thresholdMs).then(...)` and, in the no-signal branch, returned directly from `Promise.race(...)` before any cleanup. The threshold timer therefore outlived the resolved race. The adjacent ACP terminal-timeout path already documents and avoids this exact failure mode with a cancellable `setTimeout` cleared in `finally` (`bash.ts` around the `timeoutTimer` / `clearTimeout(timeoutTimer)` block); the auto-background waiter did not follow suit. The `AsyncJobManager` retention eviction timer is already `unref()`'d (`async/job-manager.ts:623`), confirming the threshold `Bun.sleep` was the sole ref'd timer holding the loop.

## Fix
- Replace the threshold `Bun.sleep(thresholdMs)` with a `Promise.withResolvers()` promise settled by a cancellable `setTimeout`.
- Route every outcome through a single `try`/`finally` — dropping the former no-signal early return — so `clearTimeout(thresholdTimer)` and the abort/steer `removeEventListener` cleanup run regardless of which waiter wins.
- Add `test/fixtures/bash-autobg-exit-probe.ts` + `test/bash-autobg-timer.test.ts`: a child-process regression test that runs the real auto-background path for a fast command against a 30s threshold and asserts prompt process exit (a retained timer would wedge it for the full threshold).

## Verification
`bun test test/bash-autobg-timer.test.ts test/bash-failure-result.test.ts test/bash-acp-terminal.test.ts` (from `packages/coding-agent`) — all pass; the new test exits in ~0.5s. Negative control: temporarily reintroducing the bare `Bun.sleep` made the same test hang for the full threshold (~5.46s against a 5s threshold), confirming it catches the regression. `bun check` passed via the pre-publish gate. Fixes #7235