### PR TITLE
fix(ai/providers): drop context-1m beta from Anthropic OAuth requests

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic OAuth (Claude Pro/Max subscription) requests hard-429ing (`Usage credits are required for long context requests`) on every beta-gated 1M model — e.g. `claude-sonnet-4-6`, which the default `task`/`smol`/`scout` subagent roles resolve to — regardless of prompt size, breaking all subagents. The 17.2.1 cowork request profile reintroduced the `context-1m-2025-08-07` beta for any model with a 1M catalog window, but subscription credentials have no long-context credit balance so Anthropic rejects the request outright. The beta is no longer advertised on OAuth requests; subscription accounts transparently get the standard 200k window. ([#7238](https://github.com/can1357/oh-my-pi/issues/7238))
+
 ## [17.2.2] - 2026-07-31
 
 ### Added

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -157,7 +157,6 @@ function mergeAnthropicBetaHeader(callerHeaders: Record<string, string>, beta: s
 const midConversationSystemBeta = "mid-conversation-system-2026-04-07";
 const contextManagementBeta = "context-management-2025-06-27";
 const structuredOutputsBeta = "structured-outputs-2025-12-15";
-const context1mBeta = "context-1m-2025-08-07";
 const thinkingTokenCountBeta = "thinking-token-count-2026-05-13";
 const fallbackCreditBeta = "fallback-credit-2026-06-01";
 const coworkUtilityBetaDefaults = [
@@ -187,15 +186,18 @@ const serverSideFallbackBeta = "server-side-fallback-2026-06-01";
 function buildCoworkBetas(
 	agentRequest: boolean,
 	thinkingRequest: boolean,
-	longContext: boolean,
 	disableStrictTools = false,
 ): readonly string[] {
+	// `context-1m-2025-08-07` is intentionally never advertised. OAuth
+	// subscription credentials have no long-context credit balance, so Anthropic
+	// hard-429s ("Usage credits are required for long context requests") on any
+	// beta-gated 1M model regardless of prompt size (#7238). Natively-1M models
+	// (e.g. claude-sonnet-5) serve their full window without the beta anyway.
 	if (!agentRequest && !disableStrictTools) return coworkUtilityBetaDefaults;
 	const betas: string[] = [];
 	for (const beta of agentRequest ? coworkAgentBetaDefaults : coworkUtilityBetaDefaults) {
 		if (disableStrictTools && beta === structuredOutputsBeta) continue;
 		betas.push(beta);
-		if (agentRequest && longContext && beta === "claude-code-20250219") betas.push(context1mBeta);
 	}
 	if (!agentRequest) return betas;
 	if (thinkingRequest) betas.push(effortBeta);
@@ -245,7 +247,7 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 	// Cowork's beta profile is part of the OAuth fingerprint; API-key requests
 	// default to extras only, matching the streaming path.
 	const betaHeader = buildBetaHeader(
-		options.coworkBetas ?? (oauthToken ? buildCoworkBetas(true, true, false) : []),
+		options.coworkBetas ?? (oauthToken ? buildCoworkBetas(true, true) : []),
 		extraBetas,
 	);
 	const acceptHeader = oauthToken ? "application/json" : stream ? "text/event-stream" : "application/json";
@@ -2949,14 +2951,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		isCloudflareAiGateway: model.provider === "cloudflare-ai-gateway",
 		allowAnthropicHeaderOverrides: model.compat.allowAnthropicHeaderOverrides,
 		claudeCodeSessionId,
-		coworkBetas: oauthToken
-			? buildCoworkBetas(
-					hasTools || thinkingEnabled,
-					thinkingEnabled,
-					(model.contextWindow ?? 0) >= 1_000_000,
-					disableStrictTools,
-				)
-			: [],
+		coworkBetas: oauthToken ? buildCoworkBetas(hasTools || thinkingEnabled, thinkingEnabled, disableStrictTools) : [],
 	});
 
 	if (model.provider === "cloudflare-ai-gateway") {

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -234,7 +234,11 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(hiddenUtility.defaultHeaders["anthropic-beta"]).not.toContain("redact-thinking-2026-02-12");
 	});
 
-	it("adds Cowork's context-1m beta for million-token models", () => {
+	it("never advertises context-1m on OAuth requests for million-token models (#7238)", () => {
+		// OAuth subscription credentials have no long-context credit balance, so
+		// advertising `context-1m-2025-08-07` hard-429s beta-gated 1M models
+		// ("Usage credits are required for long context requests") regardless of
+		// prompt size, breaking every subagent on Claude Pro/Max.
 		const longContextModel = buildModel({
 			...ANTHROPIC_MODEL_SPEC,
 			id: "claude-opus-5",
@@ -250,8 +254,9 @@ describe("Anthropic request fingerprint alignment", () => {
 		});
 
 		expect(options.defaultHeaders["anthropic-beta"]).toBe(
-			"claude-code-20250219,context-1m-2025-08-07,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advanced-tool-use-2025-11-20,effort-2025-11-24,fallback-credit-2026-06-01",
+			"claude-code-20250219,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advanced-tool-use-2025-11-20,effort-2025-11-24,fallback-credit-2026-06-01",
 		);
+		expect(options.defaultHeaders["anthropic-beta"]).not.toContain("context-1m-2025-08-07");
 	});
 
 	it("matches Cowork's system-block layout: billing and instruction uncached, single breakpoint on the last context block", () => {


### PR DESCRIPTION
## Repro
On an Anthropic OAuth (Claude Pro/Max) credential, any request to a beta-gated 1M model — e.g. `anthropic/claude-sonnet-4-6`, which the default `task`/`smol`/`scout` subagent roles resolve to — fails immediately with `429 {"type":"rate_limit_error","message":"Usage credits are required for long context requests."}`, even on a ~30-token prompt, breaking every subagent. Built an OAuth (`sk-ant-oat-*`) request for the 1M model via `buildAnthropicClientOptions` and dumped the outgoing header, which carried `context-1m-2025-08-07`.

## Cause
`buildCoworkBetas(...)` in `packages/ai/src/providers/anthropic.ts` appended `context-1m-2025-08-07` whenever `(model.contextWindow ?? 0) >= 1_000_000`, and that gate was only evaluated on the OAuth path (`coworkBetas: oauthToken ? buildCoworkBetas(...) : []`). Subscription credentials have no long-context credit balance, so Anthropic meters the 1M beta as premium long-context billing and rejects the request outright, independent of prompt size. The 17.2.1 cowork request-profile change reintroduced this beta; 15.9.1 had already removed it for the same reason.

## Fix
- Remove the `context-1m-2025-08-07` push and the now-unused `longContext` parameter from `buildCoworkBetas`, plus the unused `context1mBeta` constant.
- Update both call sites (`buildAnthropicHeaders` default and `buildAnthropicClientOptions`) to drop the `longContext` argument.
- Invert the alignment test `never advertises context-1m on OAuth requests for million-token models (#7238)` into a regression guard.
- Add a `packages/ai` CHANGELOG entry.

Natively-1M models (e.g. `claude-sonnet-5`) serve their full window without the beta, so OAuth subscription accounts transparently get the standard 200k window on beta-gated models instead of a hard 429.

## Verification
`bun test test/anthropic-alignment.test.ts` in `packages/ai` — 92 pass / 0 fail. Manual: the repro request no longer emits `context-1m-2025-08-07` in `anthropic-beta` (`sends context-1m on OAuth subscription request: false`). Fixes #7238