### PR TITLE
fix(agent): render steering-interrupted tools as neutral instead of red errors

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2740,6 +2740,8 @@ export interface SyntheticToolResultDetails {
 	source: "assistant_stop_aborted" | "assistant_stop_error" | "assistant_stop_skipped" | "assistant_stop_length";
 	executed: false;
 	upstreamError?: string;
+	/** Set for aborted/skipped calls: expected control flow, not a failure the operator caused. */
+	aborted?: boolean;
 }
 
 /**
@@ -2776,6 +2778,7 @@ function syntheticDetailsFor(
 		source,
 		executed: false,
 		...(reason === "error" && errorMessage ? { upstreamError: errorMessage } : {}),
+		...(reason === "aborted" || reason === "skipped" ? { aborted: true } : {}),
 	};
 }
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2510,7 +2510,15 @@ async function executeToolCalls(
 				caughtError = e;
 				result = {
 					content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }],
-					details: {},
+					details: record.signal.aborted
+						? {
+								// The tool was interrupted mid-flight (e.g. a queued
+								// steering message or user interrupt), not a failure
+								// the operator caused. Renderers use this to show a
+								// neutral state instead of an error.
+								aborted: true,
+							}
+						: {},
 				};
 				isError = true;
 			}
@@ -2840,7 +2848,12 @@ function createToolSignalAbortedResult(signal: AbortSignal): AgentToolResult<unk
 	const reason = abortReasonText(signal);
 	return {
 		content: [{ type: "text", text: `Tool was not executed because the run was aborted: ${reason}.` }],
-		details: {},
+		details: {
+			// Distinguishes an interrupted/skipped tool (e.g. mid-turn steering,
+			// user interrupt) from a genuine failure: the tool did not run, which
+			// is expected control flow, not an error the operator caused.
+			aborted: true,
+		},
 	};
 }
 
@@ -2864,6 +2877,11 @@ function createSkippedToolResult(source: SteeringInterruptSource | "irc" | undef
 				text: `Skipped due to ${reason}. Do not count this skipped result as completed work or verification. After the ${blocker} is handled on the next step, retry the skipped tool if it is still needed.`,
 			},
 		],
-		details: {},
+		details: {
+			// The tool was skipped for a queued steering message / peer interrupt —
+			// normal control flow, not a failure the operator caused. Renderers use
+			// this to show a neutral state instead of an error.
+			aborted: true,
+		},
 	};
 }

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1768,6 +1768,73 @@ describe("agentLoop with AgentMessage", () => {
 		).toBe(true);
 	});
 
+	it("marks a steering-interrupted tool result as aborted instead of a plain error (#7199)", async () => {
+		// A steer lands while an interruptible tool is in flight, aborting its
+		// shared signal. The tool observes the abort and throws (the bash tool
+		// path surfaces as a ToolAbortError). The loop must keep `isError` for
+		// the LLM ("the tool did not run") but stamp `details.aborted` so TUI
+		// renderers can show a neutral state instead of a red error.
+		const toolSchema = type({});
+		let steerReady = false;
+		let drained = false;
+
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "waitabort",
+			label: "WaitAbort",
+			description: "Throws when its signal aborts (mimics bash ToolAbortError)",
+			parameters: toolSchema,
+			interruptible: true,
+			async execute(_toolCallId, _params, signal) {
+				steerReady = true;
+				if (!signal?.aborted) {
+					const { promise, resolve } = Promise.withResolvers<void>();
+					signal?.addEventListener("abort", () => resolve(), { once: true });
+					await promise;
+				}
+				throw new Error("Operation aborted");
+			},
+		};
+
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "waitabort", arguments: {} }] },
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasSteeringMessages: () => steerReady && !drained,
+			getSteeringMessages: async () => {
+				if (steerReady && !drained) {
+					drained = true;
+					return [createUserMessage("interrupt")];
+				}
+				return [];
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		for await (const event of agentLoop([createUserMessage("start")], context, config, undefined, mock.stream)) {
+			events.push(event);
+		}
+
+		const toolEnds = events.filter(
+			(e): e is Extract<AgentEvent, { type: "tool_execution_end" }> => e.type === "tool_execution_end",
+		);
+		expect(toolEnds.length).toBe(1);
+		// The LLM still needs to know the tool did not run.
+		expect(toolEnds[0].isError).toBe(true);
+		// Renderers use this to show a neutral (not red/error) state.
+		expect((toolEnds[0].result.details as { aborted?: boolean } | undefined)?.aborted).toBe(true);
+		// The steer is still delivered at the injection boundary.
+		expect(
+			events.some(e => e.type === "message_start" && e.message.role === "user" && e.message.content === "interrupt"),
+		).toBe(true);
+	});
+
 	it("drains queued IRC interrupts by aborting an interruptible tool mid-wait", async () => {
 		const toolSchema = type({});
 		let ircReady = false;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed steering-interrupted tools still rendering as red errors: aborted/skipped Bash results now use a neutral "aborted" block state instead of the error frame, and the GitHub (hub wait) and vibe renderers no longer tint interrupted results red ([#7199](https://github.com/can1357/oh-my-pi/issues/7199)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -999,7 +999,17 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		// Non-self-framing tools (custom/extension renderers and the generic
 		// fallback) get a padded, state-tinted block — built-ins that draw their
 		// own frame opt out below via the framed-component mark.
-		const stateBgKey = this.#isPartial ? "toolPendingBg" : this.#result?.isError ? "toolErrorBg" : "toolSuccessBg";
+		// An aborted/skipped tool (mid-turn steering, user interrupt) is normal
+		// control flow, not an error the operator caused, so it renders with the
+		// neutral pending tint instead of the red error tint.
+		const isAborted = this.#result?.isError === true && this.#result?.details?.aborted === true;
+		const stateBgKey = this.#isPartial
+			? "toolPendingBg"
+			: isAborted
+				? "toolPendingBg"
+				: this.#result?.isError
+					? "toolErrorBg"
+					: "toolSuccessBg";
 		const stateBgFn = (t: string) => theme.bg(stateBgKey, t);
 
 		// Check for custom tool rendering

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -283,6 +283,9 @@ export interface BashToolDetails {
 	exitCode?: number;
 	/** True when the command was killed by its timeout deadline (not a failure). */
 	timedOut?: boolean;
+	/** True when the command was interrupted mid-flight (queued steering
+	 *  message, user interrupt) rather than failing on its own. */
+	aborted?: boolean;
 	terminalId?: string;
 	async?: {
 		state: "running" | "completed" | "failed";
@@ -1562,6 +1565,10 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 			const cmdLines = args ? formatBashCommandLines(renderArgs, uiTheme) : undefined;
 			const isError = result.isError === true;
 			const isPartial = options.isPartial === true;
+			// A tool interrupted mid-flight (queued steering message, user
+			// interrupt) is normal control flow, not a failure the operator
+			// caused — render it with a neutral state instead of an error.
+			const isAborted = isError && result.details?.aborted === true;
 			const success = !isPartial && !isError;
 			const details = result.details;
 			const isTimeout = details?.timedOut === true;
@@ -1575,7 +1582,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 										title: config.resolveTitle(args, options),
 									}
 								: {
-										icon: isPartial ? "pending" : isTimeout ? "warning" : "error",
+										icon: isPartial ? "pending" : isAborted ? "aborted" : isTimeout ? "warning" : "error",
 										title: config.resolveTitle(args, options),
 									},
 							uiTheme,

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1726,7 +1726,15 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 					const framed = outputBlock.render(
 						{
 							header,
-							state: isPartial ? "pending" : isError ? (isTimeout ? "warning" : "error") : "success",
+							state: isPartial
+								? "pending"
+								: isAborted
+									? "aborted"
+									: isError
+										? isTimeout
+											? "warning"
+											: "error"
+										: "success",
 							sections: [
 								{
 									// Viewport-sized tail window in every state — streaming and final

--- a/packages/coding-agent/src/tools/gh-renderer.ts
+++ b/packages/coding-agent/src/tools/gh-renderer.ts
@@ -318,7 +318,7 @@ function extractText(content: Array<{ type: string; text?: string }>): string {
 }
 
 function renderFallbackComponent(
-	result: { content: Array<{ type: string; text?: string }>; isError?: boolean },
+	result: { content: Array<{ type: string; text?: string }>; details?: GhToolDetails; isError?: boolean },
 	options: RenderResultOptions,
 	theme: Theme,
 	args: GithubToolRenderArgs,
@@ -327,6 +327,9 @@ function renderFallbackComponent(
 	const title = formatOpTitle(args.op);
 	const meta = buildOpMeta(args);
 	const isError = result.isError === true;
+	// An interrupted/skipped tool (mid-turn steering, user interrupt) is normal
+	// control flow, not a failure the operator caused — render it neutral.
+	const isAborted = isError && result.details?.aborted === true;
 	const success = !isError && Boolean(text);
 	const header = renderStatusLine(
 		success
@@ -336,18 +339,25 @@ function renderFallbackComponent(
 					titleColor: "accent",
 					meta,
 				}
-			: {
-					icon: isError ? "error" : "warning",
-					title,
-					titleColor: isError ? "error" : "accent",
-					meta,
-				},
+			: isAborted
+				? {
+						icon: "aborted",
+						title,
+						titleColor: "muted",
+						meta,
+					}
+				: {
+						icon: isError ? "error" : "warning",
+						title,
+						titleColor: isError ? "error" : "accent",
+						meta,
+					},
 		theme,
 	);
 
 	if (!text) {
-		const empty = isError ? "request failed" : "no output";
-		return new Text(`${header}\n${theme.fg("dim", empty)}`, 0, 0);
+		const empty = isAborted ? "skipped" : isError ? "request failed" : "no output";
+		return new Text(`${header}\n${theme.fg(isAborted ? "dim" : isError ? "error" : "dim", empty)}`, 0, 0);
 	}
 
 	const allLines = replaceTabs(text).split("\n");
@@ -383,8 +393,8 @@ function renderFallbackComponent(
 		return {
 			header,
 			sections: out.length > 0 ? [{ lines: out }] : [],
-			state: isError ? "error" : "success",
-			borderColor: isError ? "error" : "borderMuted",
+			state: isAborted ? "aborted" : isError ? "error" : "success",
+			borderColor: isAborted ? "dim" : isError ? "error" : "borderMuted",
 			applyBg: false,
 			width,
 		};
@@ -447,14 +457,22 @@ export const githubToolRenderer = {
 		const watch = result.details?.watch;
 		if (watch) {
 			const isError = result.isError === true;
+			const isAborted = isError && result.details?.aborted === true;
 			const header = renderStatusLine(
 				isError
-					? {
-							icon: "error",
-							title: "GitHub Run Watch",
-							titleColor: "error",
-							meta: [getWatchHeader(watch)],
-						}
+					? isAborted
+						? {
+								icon: "aborted",
+								title: "GitHub Run Watch",
+								titleColor: "muted",
+								meta: [getWatchHeader(watch)],
+							}
+						: {
+								icon: "error",
+								title: "GitHub Run Watch",
+								titleColor: "error",
+								meta: [getWatchHeader(watch)],
+							}
 					: {
 							iconOverride: uiTheme.styledSymbol("tool.gh", "accent"),
 							title: "GitHub Run Watch",
@@ -469,8 +487,8 @@ export const githubToolRenderer = {
 				return {
 					header,
 					sections,
-					state: isError ? "error" : "success",
-					borderColor: isError ? "error" : "borderMuted",
+					state: isAborted ? "aborted" : isError ? "error" : "success",
+					borderColor: isAborted ? "dim" : isError ? "error" : "borderMuted",
 					applyBg: false,
 					width,
 				};

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -290,6 +290,8 @@ type GithubInput = typeof githubSchema.infer;
 
 export interface GhToolDetails {
 	meta?: OutputMeta;
+	/** Set when the tool was interrupted/skipped by steering or a user interrupt — normal control flow, not a failure. */
+	aborted?: boolean;
 	artifactId?: string;
 	repo?: string;
 	branch?: string;

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -171,7 +171,10 @@ export function formatStatusIcon(status: ToolUIStatus, theme: Theme, spinnerFram
 			}
 			return theme.styledSymbol("status.running", "accent");
 		case "aborted":
-			return theme.styledSymbol("status.aborted", "error");
+			// An interrupted tool (queued steering message, user interrupt) is
+			// normal control flow, not an error the operator caused — keep it
+			// visually neutral instead of red.
+			return theme.styledSymbol("status.aborted", "muted");
 	}
 }
 

--- a/packages/coding-agent/src/tools/vibe.ts
+++ b/packages/coding-agent/src/tools/vibe.ts
@@ -77,6 +77,8 @@ type VibeOp = "spawn" | "send" | "wait" | "kill" | "list";
 /** Details payload shared by every vibe tool for TUI rendering. */
 export interface VibeToolDetails {
 	op: VibeOp;
+	/** Set when the tool was interrupted/skipped by steering or a user interrupt — normal control flow, not a failure. */
+	aborted?: boolean;
 	/** Live TV-wall snapshot of the owner's worker sessions at (or during) the call. */
 	screens: VibeScreenSnapshot[];
 	spawned?: { id: string; cli: VibeCli; jobId: string };
@@ -510,14 +512,22 @@ export function createVibeToolRenderer(op: VibeOp) {
 			args?: VibeRenderArgs,
 		): Component {
 			const details = result.details;
+			// An interrupted/skipped tool (mid-turn steering, user interrupt) is
+			// normal control flow, not a failure the operator caused — render it
+			// neutral instead of red.
+			const isAborted = result.isError === true && result.details?.aborted === true;
 			if (!details || result.isError) {
 				const fallback = result.content.find(part => part.type === "text")?.text ?? "";
 				const header = renderStatusLine(
-					{ icon: result.isError ? "error" : "done", title: `vibe ${describeCall(op, args)}` },
+					{
+						icon: isAborted ? "aborted" : result.isError ? "error" : "done",
+						title: `vibe ${describeCall(op, args)}`,
+						titleColor: isAborted ? "muted" : undefined,
+					},
 					uiTheme,
 				);
 				const body = fallback
-					? `\n  ${uiTheme.fg(result.isError ? "error" : "dim", frameText(fallback, TV_LINE_MAX))}`
+					? `\n  ${uiTheme.fg(isAborted ? "dim" : result.isError ? "error" : "dim", frameText(fallback, TV_LINE_MAX))}`
 					: "";
 				return new Text(`${header}${body}`, 0, 0);
 			}

--- a/packages/coding-agent/src/tui/types.ts
+++ b/packages/coding-agent/src/tui/types.ts
@@ -3,7 +3,7 @@
  */
 import type { Theme } from "../modes/theme/theme";
 
-export type State = "pending" | "running" | "success" | "error" | "warning";
+export type State = "pending" | "running" | "success" | "error" | "warning" | "aborted";
 
 export interface TreeContext {
 	index: number;

--- a/packages/coding-agent/test/tools/bash-sixel-render.test.ts
+++ b/packages/coding-agent/test/tools/bash-sixel-render.test.ts
@@ -227,6 +227,29 @@ describe("bashToolRenderer", () => {
 		expect(rendered).not.toContain(errorAnsi);
 	});
 
+	it("renders a steering-aborted command with a neutral frame instead of an error frame", async () => {
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+		const uiTheme = theme!;
+		const component = bashToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "[Command aborted]\n" }],
+				details: { aborted: true },
+				isError: true,
+			},
+			{ expanded: false, isPartial: false },
+			uiTheme,
+			{ command: "sleep 3" },
+		);
+		const rendered = component.render(120).join("\n");
+		const errorAnsi = uiTheme.fg("error", "").replace("\x1b[39m", "");
+
+		expect(rendered).not.toContain(errorAnsi);
+		// The neutral frame still renders the aborted status so the operator can
+		// distinguish it from an untouched success block.
+		expect(rendered).toContain("aborted");
+	});
+
 	it("omits the status footer for a successful command", async () => {
 		const theme = await getThemeByName("dark");
 		expect(theme).toBeDefined();

--- a/packages/coding-agent/test/tools/gh-renderer.test.ts
+++ b/packages/coding-agent/test/tools/gh-renderer.test.ts
@@ -1,0 +1,43 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { Settings } from "../../src/config/settings";
+import { getThemeByName, setThemeInstance, type Theme } from "../../src/modes/theme/theme";
+import { githubToolRenderer } from "../../src/tools/gh-renderer";
+
+describe("githubToolRenderer", () => {
+	let uiTheme: Theme;
+
+	beforeAll(async () => {
+		await Settings.init({ inMemory: true });
+		const loaded = await getThemeByName("dark");
+		if (!loaded) throw new Error("theme unavailable");
+		uiTheme = loaded;
+		setThemeInstance(uiTheme);
+	});
+
+	it("renders an aborted run-watch neutrally instead of as an error", () => {
+		const component = githubToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "" }],
+				details: {
+					aborted: true,
+					watch: {
+						mode: "run",
+						state: "watching",
+						repo: "owner/repo",
+						run: { id: 1, workflowName: "test", status: "queued", jobs: [] },
+						runs: [],
+					},
+				},
+				isError: true,
+			},
+			{ expanded: false, isPartial: false },
+			uiTheme,
+			{ op: "run_watch" },
+		);
+		const rendered = component.render(100).join("\n");
+		const errorAnsi = uiTheme.fg("error", "").replace("\x1b[39m", "");
+
+		expect(rendered).not.toContain(errorAnsi);
+		expect(rendered).toContain("GitHub Run Watch");
+	});
+});

--- a/packages/coding-agent/test/tools/vibe-render.test.ts
+++ b/packages/coding-agent/test/tools/vibe-render.test.ts
@@ -207,4 +207,23 @@ describe("vibe tool renderers", () => {
 			expect(line.length).toBeLessThanOrEqual(width);
 		}
 	});
+
+	it("renders an aborted vibe result neutrally instead of as an error", () => {
+		const renderer = createVibeToolRenderer("wait");
+		const component = renderer.renderResult(
+			{
+				content: [{ type: "text", text: "Skipped due to pending steering message." }],
+				details: { op: "wait", screens: [], aborted: true },
+				isError: true,
+			},
+			{ expanded: false, isPartial: false },
+			uiTheme,
+			{ sessions: [] },
+		) as { render(width: number): readonly string[] };
+		const rendered = component.render(100).join("\n");
+		const errorAnsi = uiTheme.fg("error", "").replace("\x1b[39m", "");
+
+		expect(rendered).not.toContain(errorAnsi);
+		expect(rendered).toContain("vibe wait");
+	});
 });


### PR DESCRIPTION
## Summary

When a user submits a mid-turn steering message, the agent interrupts the in-flight (or queued) tool call — this is normal control flow, not a failure the operator caused. The tool result correctly kept `isError: true` for the LLM (the tool did not run), but the TUI rendered every error result with a red ✘, red text and a red border, making an expected interrupt look like a crash.

## Changes

- `packages/agent/src/agent-loop.ts`: stamp `details.aborted: true` on the three interrupt paths that produce tool results (mid-flight abort via catch, pre-start abort via `createToolSignalAbortedResult`, steering skip via `createSkippedToolResult`). `isError` stays `true` so the LLM still sees the tool did not execute.
- `packages/coding-agent/src/tools/render-utils.ts`: `formatStatusIcon("aborted")` uses muted gray instead of error red.
- `packages/coding-agent/src/tools/bash.ts`: bash status line recognizes `details.aborted` and shows the neutral `aborted` state.
- `packages/coding-agent/src/modes/components/tool-execution.ts`: tool block background uses the pending (gray) tint for aborted results instead of the red error tint.
- `packages/agent/test/agent-loop.test.ts`: new test asserting the steering-interrupted tool result carries `details.aborted: true`.

## Test plan

- [x] `bun test test/agent-loop.test.ts` — 95 pass (incl. new #7199 test)
- [x] `bun test test/bash-failure-result.test.ts` — 5 pass
- [x] `bun run check:types` in packages/agent and packages/coding-agent — pass
- [x] biome check on changed files — clean

## Human note

I am a 19-year-old independent full-stack developer. I reviewed the full diff and confirmed the change: interrupted tools now show as neutral instead of red errors.

Fixes #7199