### PR TITLE
feat(web-search): migrate Parallel Search to GA v1 + turbo mode

### DIFF
--- a/packages/coding-agent/src/web/parallel.ts
+++ b/packages/coding-agent/src/web/parallel.ts
@@ -3,7 +3,9 @@ import type { AgentStorage } from "../session/agent-storage";
 import { findCredential, withHardTimeout } from "./search/providers/utils";
 
 const PARALLEL_API_URL = "https://api.parallel.ai";
-export const PARALLEL_SEARCH_URL = `${PARALLEL_API_URL}/v1beta/search`;
+/** GA Search API — modes: turbo | basic | advanced (see Parallel search migration guide). */
+export const PARALLEL_SEARCH_URL = `${PARALLEL_API_URL}/v1/search`;
+/** Extract remains on the beta endpoint until a GA extract migration lands. */
 const PARALLEL_EXTRACT_URL = `${PARALLEL_API_URL}/v1beta/extract`;
 export const PARALLEL_BETA_HEADER = "search-extract-2025-10-10";
 
@@ -51,7 +53,11 @@ export interface ParallelExtractResult {
 }
 
 export interface ParallelSearchOptions {
-	mode?: "fast" | "research";
+	/**
+	 * V1 Search mode. Defaults to `turbo` (lowest latency/cost).
+	 * Legacy aliases: `fast` → turbo, `research` → advanced.
+	 */
+	mode?: "turbo" | "basic" | "advanced" | "fast" | "research";
 	maxCharsPerResult?: number;
 	signal?: AbortSignal;
 	fetch?: FetchImpl;
@@ -146,7 +152,20 @@ export function parseParallelErrorResponse(statusCode: number, responseText: str
 	}
 }
 
-function getAuthHeaders(apiKey: string): {
+function getSearchAuthHeaders(apiKey: string): {
+	Accept: string;
+	"Content-Type": string;
+	"x-api-key": string;
+} {
+	// V1 Search does not use the beta header.
+	return {
+		Accept: "application/json",
+		"Content-Type": "application/json",
+		"x-api-key": apiKey,
+	};
+}
+
+function getExtractAuthHeaders(apiKey: string): {
 	Accept: string;
 	"Content-Type": string;
 	"x-api-key": string;
@@ -158,6 +177,16 @@ function getAuthHeaders(apiKey: string): {
 		"x-api-key": apiKey,
 		"parallel-beta": PARALLEL_BETA_HEADER,
 	};
+}
+
+/** Map legacy / public option names onto V1 Search modes. */
+export function resolveParallelSearchMode(
+	mode: ParallelSearchOptions["mode"],
+): "turbo" | "basic" | "advanced" {
+	if (mode === "advanced" || mode === "research") return "advanced";
+	if (mode === "basic") return "basic";
+	// turbo, fast (legacy beta), or default
+	return "turbo";
 }
 
 function parseWarnings(payload: unknown): string[] {
@@ -301,13 +330,15 @@ export async function searchWithParallel(
 	const fetchImpl = options.fetch ?? fetch;
 	const response = await fetchImpl(PARALLEL_SEARCH_URL, {
 		method: "POST",
-		headers: getAuthHeaders(apiKey),
+		headers: getSearchAuthHeaders(apiKey),
 		body: JSON.stringify({
 			objective,
 			search_queries: queries,
-			mode: options.mode === "research" ? "one-shot" : "fast",
-			excerpts: {
-				max_chars_per_result: options.maxCharsPerResult ?? 10_000,
+			mode: resolveParallelSearchMode(options.mode),
+			advanced_settings: {
+				excerpt_settings: {
+					max_chars_per_result: options.maxCharsPerResult ?? 10_000,
+				},
 			},
 		}),
 		signal: withHardTimeout(options.signal),
@@ -335,7 +366,7 @@ export async function extractWithParallel(
 	const fetchImpl = options.fetch ?? fetch;
 	const response = await fetchImpl(PARALLEL_EXTRACT_URL, {
 		method: "POST",
-		headers: getAuthHeaders(apiKey),
+		headers: getExtractAuthHeaders(apiKey),
 		body: JSON.stringify({
 			urls,
 			objective: options.objective,

--- a/packages/coding-agent/src/web/search/providers/parallel.ts
+++ b/packages/coding-agent/src/web/search/providers/parallel.ts
@@ -2,7 +2,6 @@ import { type ApiKey, type AuthStorage, type FetchImpl, getEnvApiKey, withAuth }
 import type { SearchResponse } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import {
-	PARALLEL_BETA_HEADER,
 	PARALLEL_SEARCH_URL,
 	ParallelApiError,
 	type ParallelSearchResult,
@@ -21,7 +20,7 @@ const MAX_NUM_RESULTS = 40;
 /** Query-string caps for Parallel: natural-language objective, no field operators. */
 const PARALLEL_QUERY_SYNTAX = { phrases: true, negation: true, or: true } as const;
 
-/** Parallel `source_policy` (beta Search API): bare-host allow/deny lists + freshness floor. */
+/** Parallel `source_policy` (V1 advanced_settings): bare-host allow/deny lists + freshness floor. */
 interface ParallelSourcePolicy {
 	include_domains?: string[];
 	exclude_domains?: string[];
@@ -86,16 +85,19 @@ async function searchWithAuthStorage(
 					Accept: "application/json",
 					"Content-Type": "application/json",
 					"x-api-key": key,
-					"parallel-beta": PARALLEL_BETA_HEADER,
 				},
 				body: JSON.stringify({
 					objective,
 					search_queries: queries,
-					mode: "fast",
-					excerpts: {
-						max_chars_per_result: 10_000,
+					// V1 Search: turbo is lowest latency/cost (~$1/1k, ~200ms).
+					// Beta `fast`/`one-shot` mapped to basic; turbo is V1-only.
+					mode: "turbo",
+					advanced_settings: {
+						excerpt_settings: {
+							max_chars_per_result: 10_000,
+						},
+						...(sourcePolicy && { source_policy: sourcePolicy }),
 					},
-					...(sourcePolicy && { source_policy: sourcePolicy }),
 				}),
 				signal: withHardTimeout(params.signal),
 			});

--- a/packages/coding-agent/test/tools/web-search-parallel.test.ts
+++ b/packages/coding-agent/test/tools/web-search-parallel.test.ts
@@ -38,9 +38,13 @@ describe("Parallel web search", () => {
 	} as unknown as AuthStorage;
 
 	let capturedRequestBody: unknown;
+	let capturedRequestUrl: string | undefined;
+	let capturedRequestHeaders: HeadersInit | undefined;
 
 	beforeEach(() => {
 		capturedRequestBody = undefined;
+		capturedRequestUrl = undefined;
+		capturedRequestHeaders = undefined;
 		process.env.PARALLEL_API_KEY = "test-parallel-key";
 	});
 
@@ -50,7 +54,9 @@ describe("Parallel web search", () => {
 	});
 
 	function mockFetch(responseBody: unknown, status = 200): FetchImpl {
-		return (_url, init) => {
+		return (url, init) => {
+			capturedRequestUrl = typeof url === "string" ? url : String(url);
+			capturedRequestHeaders = init?.headers;
 			if (typeof init?.body === "string") {
 				capturedRequestBody = JSON.parse(init.body);
 			}
@@ -63,7 +69,7 @@ describe("Parallel web search", () => {
 		};
 	}
 
-	it("sends the expected Parallel search request and parses results", async () => {
+	it("sends the expected Parallel V1 turbo search request and parses results", async () => {
 		const fetchMock = mockFetch({
 			search_id: "search-parallel-1",
 			results: [
@@ -79,11 +85,20 @@ describe("Parallel web search", () => {
 		});
 
 		const result = await searchWithParallel("parallel query", ["parallel query"], { fetch: fetchMock }, fakeStorage);
+		expect(capturedRequestUrl).toBe("https://api.parallel.ai/v1/search");
+		expect(capturedRequestHeaders).toMatchObject({
+			Accept: "application/json",
+			"Content-Type": "application/json",
+			"x-api-key": "test-parallel-key",
+		});
+		expect(capturedRequestHeaders).not.toHaveProperty("parallel-beta");
 		expect(capturedRequestBody).toEqual({
 			objective: "parallel query",
 			search_queries: ["parallel query"],
-			mode: "fast",
-			excerpts: { max_chars_per_result: 10_000 },
+			mode: "turbo",
+			advanced_settings: {
+				excerpt_settings: { max_chars_per_result: 10_000 },
+			},
 		});
 		expect(result).toEqual({
 			requestId: "search-parallel-1",
@@ -143,9 +158,11 @@ describe("Parallel web search", () => {
 		expect(capturedRequestBody).toEqual({
 			objective: "web api",
 			search_queries: ["web api"],
-			mode: "fast",
-			excerpts: { max_chars_per_result: 10_000 },
-			source_policy: { include_domains: ["parallel.ai"] },
+			mode: "turbo",
+			advanced_settings: {
+				excerpt_settings: { max_chars_per_result: 10_000 },
+				source_policy: { include_domains: ["parallel.ai"] },
+			},
 		});
 	});
 
@@ -164,9 +181,11 @@ describe("Parallel web search", () => {
 		expect(capturedRequestBody).toEqual({
 			objective: '"web api" -legacy',
 			search_queries: ['"web api" -legacy'],
-			mode: "fast",
-			excerpts: { max_chars_per_result: 10_000 },
-			source_policy: { exclude_domains: ["reddit.com"], after_date: "2025-06-01" },
+			mode: "turbo",
+			advanced_settings: {
+				excerpt_settings: { max_chars_per_result: 10_000 },
+				source_policy: { exclude_domains: ["reddit.com"], after_date: "2025-06-01" },
+			},
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Move Parallel web search from legacy **beta** `/v1beta/search` to GA **`/v1/search`**.
- Default mode is **`turbo`** (lowest latency/cost; Turbo is V1-only — beta only had `fast` / `one-shot` / `agentic`).
- Nest `excerpts` and `source_policy` under `advanced_settings` per the [migration guide](https://docs.parallel.ai/search/search-migration-guide).
- Drop `parallel-beta` header on **search** requests (extract stays on v1beta + beta header).
- Keep legacy option aliases: `fast` → turbo, `research` → advanced.

## Why
Parallel Search Turbo is not available on the beta endpoint (`mode: turbo` returns 422 there). Shipping turbo requires the GA Search API. This also aligns OMP with Parallel's recommended GA path and the cheaper/faster search tier (~$1/1k, ~200ms).

## Test plan
- [x] `bun test packages/coding-agent/test/tools/web-search-parallel.test.ts` (5 pass)
- [ ] Manual: `PARALLEL_API_KEY=...` + web_search; confirm provider Parallel and results
- [ ] Confirm extract still works on v1beta (unchanged path)

## Notes
Local users currently re-apply this via a dist patch after `omp update`; upstreaming removes that need.