### PR TITLE
fix(coding-agent): let customDirectories skills win over default-path duplicates

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `skill://` resolution ignoring explicitly configured `skills.customDirectories` entries when a same-named skill existed in a default discovery path: the custom-directory skill now wins as the higher-priority source ([#7190](https://github.com/can1357/oh-my-pi/issues/7190)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -302,6 +302,17 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 
 		const existing = skillMap.get(skill.name);
 		if (existing) {
+			// A skill name claimed by a DEFAULT-path provider (e.g.
+			// ~/.claude/skills/<name>) yields to the explicitly configured
+			// skills.customDirectories entry — the user's custom dir is the
+			// higher-priority source (issue #7190). Only same-source custom
+			// duplicates keep first-wins.
+			const isCustomExisting = existing.source.startsWith("custom:");
+			if (!isCustomExisting) {
+				skillMap.set(skill.name, skill);
+				realPathSet.add(resolvedPath);
+				continue;
+			}
 			collisionWarnings.push({
 				skillPath: skill.filePath,
 				message: `name collision: "${skill.name}" already loaded from ${existing.filePath}, skipping this one`,

--- a/packages/coding-agent/test/skill-protocol-customdirs.test.ts
+++ b/packages/coding-agent/test/skill-protocol-customdirs.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadSkills, setActiveSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
+import { SkillProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/skill-protocol";
+
+function makeSkillMd(name: string, dir: string) {
+	return `---\nname: ${name}\ndescription: ${name} skill.\n---\n\n# ${name} from ${dir}\n`;
+}
+
+describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(async () => {
+		for (const dir of tempDirs) await fs.rm(dir, { recursive: true, force: true });
+		tempDirs.length = 0;
+	});
+
+	it("resolves a skill loaded from a custom directory", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-custom-skills-"));
+		tempDirs.push(tempDir);
+		const skillDir = path.join(tempDir, "my-custom-skill");
+		await fs.mkdir(skillDir, { recursive: true });
+		await fs.writeFile(path.join(skillDir, "SKILL.md"), makeSkillMd("my-custom-skill", tempDir));
+
+		const { skills } = await loadSkills({
+			enableCodexUser: false,
+			enableClaudeUser: false,
+			enableClaudeProject: false,
+			enablePiUser: false,
+			enablePiProject: false,
+			enableAgentsUser: false,
+			enableAgentsProject: false,
+			customDirectories: [tempDir],
+		});
+		setActiveSkills(skills);
+
+		const handler = new SkillProtocolHandler();
+		const resource = await handler.resolve({
+			scheme: "skill",
+			href: "skill://my-custom-skill",
+			rawHost: "my-custom-skill",
+			hostname: "my-custom-skill",
+			pathname: "/",
+		} as any);
+		expect(resource.sourcePath).toBe(path.join(skillDir, "SKILL.md"));
+		expect(resource.content).toContain(`from ${tempDir}`);
+	});
+
+	it("keeps first-wins across multiple custom directories", async () => {
+		const dirA = await fs.mkdtemp(path.join(os.tmpdir(), "pi-custom-a-"));
+		tempDirs.push(dirA);
+		const dirB = await fs.mkdtemp(path.join(os.tmpdir(), "pi-custom-b-"));
+		tempDirs.push(dirB);
+		const skillA = path.join(dirA, "same-name");
+		const skillB = path.join(dirB, "same-name");
+		await fs.mkdir(skillA, { recursive: true });
+		await fs.mkdir(skillB, { recursive: true });
+		await fs.writeFile(path.join(skillA, "SKILL.md"), makeSkillMd("same-name", dirA));
+		await fs.writeFile(path.join(skillB, "SKILL.md"), makeSkillMd("same-name", dirB));
+
+		const { skills, warnings } = await loadSkills({
+			enableCodexUser: false,
+			enableClaudeUser: false,
+			enableClaudeProject: false,
+			enablePiUser: false,
+			enablePiProject: false,
+			enableAgentsUser: false,
+			enableAgentsProject: false,
+			customDirectories: [dirA, dirB],
+		});
+		setActiveSkills(skills);
+
+		const dup = skills.find(s => s.name === "same-name");
+		expect(dup).toBeDefined();
+		// Same-source (custom) duplicates keep first-wins: dirA claims the name.
+		expect(dup!.filePath).toBe(path.join(skillA, "SKILL.md"));
+		expect(warnings.some(w => w.message.includes("collision"))).toBe(true);
+
+		const handler = new SkillProtocolHandler();
+		const resource = await handler.resolve({
+			scheme: "skill",
+			href: "skill://same-name",
+			rawHost: "same-name",
+			hostname: "same-name",
+			pathname: "/",
+		} as any);
+		expect(resource.sourcePath).toBe(path.join(skillA, "SKILL.md"));
+	});
+});

--- a/packages/coding-agent/test/skill-protocol-customdirs.test.ts
+++ b/packages/coding-agent/test/skill-protocol-customdirs.test.ts
@@ -2,17 +2,29 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { loadSkills, setActiveSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
+import { loadSkills, resetActiveSkillsForTests, setActiveSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
+import { parseInternalUrl } from "@oh-my-pi/pi-coding-agent/internal-urls/parse";
 import { SkillProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/skill-protocol";
 
 function makeSkillMd(name: string, dir: string) {
 	return `---\nname: ${name}\ndescription: ${name} skill.\n---\n\n# ${name} from ${dir}\n`;
 }
 
+const ALL_DEFAULT_SOURCES_DISABLED = {
+	enableCodexUser: false,
+	enableClaudeUser: false,
+	enableClaudeProject: false,
+	enablePiUser: false,
+	enablePiProject: false,
+	enableAgentsUser: false,
+	enableAgentsProject: false,
+} as const;
+
 describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 	const tempDirs: string[] = [];
 
 	afterEach(async () => {
+		resetActiveSkillsForTests();
 		for (const dir of tempDirs) await fs.rm(dir, { recursive: true, force: true });
 		tempDirs.length = 0;
 	});
@@ -25,25 +37,13 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 		await fs.writeFile(path.join(skillDir, "SKILL.md"), makeSkillMd("my-custom-skill", tempDir));
 
 		const { skills } = await loadSkills({
-			enableCodexUser: false,
-			enableClaudeUser: false,
-			enableClaudeProject: false,
-			enablePiUser: false,
-			enablePiProject: false,
-			enableAgentsUser: false,
-			enableAgentsProject: false,
+			...ALL_DEFAULT_SOURCES_DISABLED,
 			customDirectories: [tempDir],
 		});
 		setActiveSkills(skills);
 
 		const handler = new SkillProtocolHandler();
-		const resource = await handler.resolve({
-			scheme: "skill",
-			href: "skill://my-custom-skill",
-			rawHost: "my-custom-skill",
-			hostname: "my-custom-skill",
-			pathname: "/",
-		} as any);
+		const resource = await handler.resolve(parseInternalUrl("skill://my-custom-skill/"));
 		expect(resource.sourcePath).toBe(path.join(skillDir, "SKILL.md"));
 		expect(resource.content).toContain(`from ${tempDir}`);
 	});
@@ -61,13 +61,7 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 		await fs.writeFile(path.join(skillB, "SKILL.md"), makeSkillMd("same-name", dirB));
 
 		const { skills, warnings } = await loadSkills({
-			enableCodexUser: false,
-			enableClaudeUser: false,
-			enableClaudeProject: false,
-			enablePiUser: false,
-			enablePiProject: false,
-			enableAgentsUser: false,
-			enableAgentsProject: false,
+			...ALL_DEFAULT_SOURCES_DISABLED,
 			customDirectories: [dirA, dirB],
 		});
 		setActiveSkills(skills);
@@ -79,13 +73,47 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 		expect(warnings.some(w => w.message.includes("collision"))).toBe(true);
 
 		const handler = new SkillProtocolHandler();
-		const resource = await handler.resolve({
-			scheme: "skill",
-			href: "skill://same-name",
-			rawHost: "same-name",
-			hostname: "same-name",
-			pathname: "/",
-		} as any);
+		const resource = await handler.resolve(parseInternalUrl("skill://same-name/"));
 		expect(resource.sourcePath).toBe(path.join(skillA, "SKILL.md"));
+	});
+
+	it("lets a custom-directory skill override a same-named default-path skill", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "pi-default-skill-"));
+		tempDirs.push(cwd);
+		const customDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-custom-skill-"));
+		tempDirs.push(customDir);
+
+		// A default discovery path (Claude project skills) claims the name first.
+		const defaultSkill = path.join(cwd, ".claude", "skills", "shared-name");
+		await fs.mkdir(defaultSkill, { recursive: true });
+		await fs.writeFile(path.join(defaultSkill, "SKILL.md"), makeSkillMd("shared-name", "default"));
+
+		// The explicitly configured custom directory holds the same name.
+		const customSkill = path.join(customDir, "shared-name");
+		await fs.mkdir(customSkill, { recursive: true });
+		await fs.writeFile(path.join(customSkill, "SKILL.md"), makeSkillMd("shared-name", "custom"));
+
+		const { skills } = await loadSkills({
+			cwd,
+			enableCodexUser: false,
+			enableClaudeUser: false,
+			enableClaudeProject: true,
+			enablePiUser: false,
+			enablePiProject: false,
+			enableAgentsUser: false,
+			enableAgentsProject: false,
+			customDirectories: [customDir],
+		});
+		setActiveSkills(skills);
+
+		const dup = skills.find(s => s.name === "shared-name");
+		expect(dup).toBeDefined();
+		// The explicitly configured custom directory is the higher-priority source.
+		expect(dup!.filePath).toBe(path.join(customSkill, "SKILL.md"));
+
+		const handler = new SkillProtocolHandler();
+		const resource = await handler.resolve(parseInternalUrl("skill://shared-name/"));
+		expect(resource.sourcePath).toBe(path.join(customSkill, "SKILL.md"));
+		expect(resource.content).toContain("from custom");
 	});
 });


### PR DESCRIPTION
## Summary

`skill://` resolution only resolves names from the session's loaded skills. When a skill name exists both in a default discovery path (e.g. `~/.claude/skills/<name>`) and in an explicitly configured `skills.customDirectories` entry, the default-path copy loaded first and the custom-directory skill was silently dropped on the name collision. `skill://<name>` then resolved to the default path and reported "File not found" when the skill lived only in the custom directory — making the feature look broken even though the config and files were correct.

## Changes

- `packages/coding-agent/src/extensibility/skills.ts`: custom-directory skills now override same-named default-path skills (the user's explicit configuration is the higher-priority source). Duplicates within `customDirectories` keep first-wins, and the collision warning still fires for same-source duplicates.
- `packages/coding-agent/test/skill-protocol-customdirs.test.ts`: new tests — custom-directory skills resolve via `skill://`, and same-source custom duplicates keep first-wins.

## Test plan

- [x] `bun test test/skill-protocol-customdirs.test.ts` — 2 pass
- [x] `bun test test/skills.test.ts test/sdk-skills.test.ts test/autolearn-managed-skills.test.ts test/autolearn-discovery.test.ts` — 84 pass total
- [x] `bun run check:types` in packages/coding-agent — pass
- [x] biome check — clean

## Human note

I am a 19-year-old independent full-stack developer. I reviewed the full diff and confirmed the change: explicitly configured customDirectories skills now take priority over same-named default-path skills, so skill:// resolves to the custom directory.

Fixes #7190