### PR TITLE
fix(advisor): prevent false full replays and preserve cache growth

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -141,6 +141,11 @@
 - Fixed ephemeral side turns and native compaction bypassing an explicit or fork-inherited prompt cache key ([#7218](https://github.com/can1357/oh-my-pi/issues/7218)).
 - Fixed the live Ask dialog crashing the whole session with a `replaceTabs` TypeError when a question reached `AskDialogComponent` without a string `question` field; questions are now normalized at dialog entry, mirroring the transcript renderer ([#7211](https://github.com/can1357/oh-my-pi/issues/7211)).
 - Fixed Codex web search collapsing backend errors to `Codex error (): Unknown error`; the SSE error parser now preserves the backend code and message from top-level, nested `error`, and `response.error` envelopes ([#7200](https://github.com/can1357/oh-my-pi/issues/7200)).
+### Fixed
+
+- Split the advisor Session update delivery into per-source-message user messages (single `Agent.prompt(AgentMessage[])` call) so provider prompt caches grow with the session instead of staying pinned at the instructions/tools boundary; rendering stays byte-identical to the old single-block update.
+- Restore the advisor primary-context dedup map when a failed advisor turn is rolled back, so retried batches re-deliver first-time plan/goal context in full instead of collapsing it to "(unchanged — still in effect)".
+- Include all renderer-read fields (excludeFromContext, bashExecution command, pythonExecution code, branch/compaction summary + fromId, fileMention files) in advisor prefix fingerprints so clones changing only those fields correctly trigger a re-render.
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -141,6 +141,10 @@
 - Fixed ephemeral side turns and native compaction bypassing an explicit or fork-inherited prompt cache key ([#7218](https://github.com/can1357/oh-my-pi/issues/7218)).
 - Fixed the live Ask dialog crashing the whole session with a `replaceTabs` TypeError when a question reached `AskDialogComponent` without a string `question` field; questions are now normalized at dialog entry, mirroring the transcript renderer ([#7211](https://github.com/can1357/oh-my-pi/issues/7211)).
 - Fixed Codex web search collapsing backend errors to `Codex error (): Unknown error`; the SSE error parser now preserves the backend code and message from top-level, nested `error`, and `response.error` envelopes ([#7200](https://github.com/can1357/oh-my-pi/issues/7200)).
+### Added
+
+- Added structured reset-reason logging to advisor context re-primes (issue #7226): every history-rewrite trigger (compact, auto-compaction, compaction-rescue, shake, drop-images, prune-tool-outputs, prune-stale-tool-results, conversation-boundary, context-maintenance) now emits an `advisor context reset` debug event with its reason, so full-transcript replays can be attributed to a concrete path.
+
 ### Fixed
 
 - Split the advisor Session update delivery into per-source-message user messages (single `Agent.prompt(AgentMessage[])` call) so provider prompt caches grow with the session instead of staying pinned at the instructions/tools boundary; rendering stays byte-identical to the old single-block update.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -127,6 +127,15 @@
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
+### Added
+
+- Added structured reset-reason logging to advisor context re-primes (issue #7226): every history-rewrite trigger (compact, auto-compaction, compaction-rescue, shake, drop-images, prune-tool-outputs, prune-stale-tool-results, conversation-boundary, context-maintenance) now emits an `advisor context reset` debug event with its reason, so full-transcript replays can be attributed to a concrete path.
+
+### Fixed
+
+- Split the advisor Session update delivery into per-source-message user messages (single `Agent.prompt(AgentMessage[])` call) so provider prompt caches grow with the session instead of staying pinned at the instructions/tools boundary; rendering stays byte-identical to the old single-block update.
+- Restore the advisor primary-context dedup map when a failed advisor turn is rolled back, so retried batches re-deliver first-time plan/goal context in full instead of collapsing it to "(unchanged — still in effect)".
+- Include all renderer-read fields (excludeFromContext, bashExecution command, pythonExecution code, branch/compaction summary + fromId, fileMention files) in advisor prefix fingerprints so clones changing only those fields correctly trigger a re-render.
 
 ## [17.2.3] - 2026-08-01
 
@@ -141,15 +150,6 @@
 - Fixed ephemeral side turns and native compaction bypassing an explicit or fork-inherited prompt cache key ([#7218](https://github.com/can1357/oh-my-pi/issues/7218)).
 - Fixed the live Ask dialog crashing the whole session with a `replaceTabs` TypeError when a question reached `AskDialogComponent` without a string `question` field; questions are now normalized at dialog entry, mirroring the transcript renderer ([#7211](https://github.com/can1357/oh-my-pi/issues/7211)).
 - Fixed Codex web search collapsing backend errors to `Codex error (): Unknown error`; the SSE error parser now preserves the backend code and message from top-level, nested `error`, and `response.error` envelopes ([#7200](https://github.com/can1357/oh-my-pi/issues/7200)).
-### Added
-
-- Added structured reset-reason logging to advisor context re-primes (issue #7226): every history-rewrite trigger (compact, auto-compaction, compaction-rescue, shake, drop-images, prune-tool-outputs, prune-stale-tool-results, conversation-boundary, context-maintenance) now emits an `advisor context reset` debug event with its reason, so full-transcript replays can be attributed to a concrete path.
-
-### Fixed
-
-- Split the advisor Session update delivery into per-source-message user messages (single `Agent.prompt(AgentMessage[])` call) so provider prompt caches grow with the session instead of staying pinned at the instructions/tools boundary; rendering stays byte-identical to the old single-block update.
-- Restore the advisor primary-context dedup map when a failed advisor turn is rolled back, so retried batches re-deliver first-time plan/goal context in full instead of collapsing it to "(unchanged — still in effect)".
-- Include all renderer-read fields (excludeFromContext, bashExecution command, pythonExecution code, branch/compaction summary + fromId, fileMention files) in advisor prefix fingerprints so clones changing only those fields correctly trigger a re-render.
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -130,6 +130,7 @@
 ### Added
 
 - Added structured reset-reason logging to advisor context re-primes (issue #7226): every history-rewrite trigger (compact, auto-compaction, compaction-rescue, shake, drop-images, prune-tool-outputs, prune-stale-tool-results, conversation-boundary, context-maintenance) now emits an `advisor context reset` debug event with its reason, so full-transcript replays can be attributed to a concrete path.
+- Added `quarantine-recovery` and `quarantine-retry-exhausted` reset reasons to advisor context-reset debug logs, so advisor full re-primes after quarantined output remain attributable without changing quarantine retry semantics (issue #7226).
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,16 @@
 - Fixed install.sh falsely reporting success on musl-based systems (such as Alpine Linux) when the binary fails to start; the installer now smoke-tests the binary, exits non-zero on failure, and provides remediation steps.
 - Fixed Codex config.toml discovery incorrectly importing MCP servers that are configured with enabled = false.
 - Fixed bash.patterns allow rules rejecting valid commands when quoted arguments contained shell metacharacters (such as Cargo benchmark regex filters).
+### Added
+
+- Added structured reset-reason logging to advisor context re-primes (issue #7226): every history-rewrite trigger (compact, auto-compaction, compaction-rescue, shake, drop-images, prune-tool-outputs, prune-stale-tool-results, conversation-boundary, context-maintenance) now emits an `advisor context reset` debug event with its reason, so full-transcript replays can be attributed to a concrete path.
+- Added `quarantine-recovery` and `quarantine-retry-exhausted` reset reasons to advisor context-reset debug logs, so advisor full re-primes after quarantined output remain attributable without changing quarantine retry semantics (issue #7226).
+
+### Fixed
+
+- Split the advisor Session update delivery into per-source-message user messages (single `Agent.prompt(AgentMessage[])` call) so provider prompt caches grow with the session instead of staying pinned at the instructions/tools boundary; rendering stays byte-identical to the old single-block update.
+- Restore the advisor primary-context dedup map when a failed advisor turn is rolled back, so retried batches re-deliver first-time plan/goal context in full instead of collapsing it to "(unchanged — still in effect)".
+- Include all renderer-read fields (excludeFromContext, bashExecution command, pythonExecution code, branch/compaction summary + fromId, fileMention files) in advisor prefix fingerprints so clones changing only those fields correctly trigger a re-render.
 
 ## [17.2.6] - 2026-08-03
 
@@ -127,16 +137,6 @@
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
-### Added
-
-- Added structured reset-reason logging to advisor context re-primes (issue #7226): every history-rewrite trigger (compact, auto-compaction, compaction-rescue, shake, drop-images, prune-tool-outputs, prune-stale-tool-results, conversation-boundary, context-maintenance) now emits an `advisor context reset` debug event with its reason, so full-transcript replays can be attributed to a concrete path.
-- Added `quarantine-recovery` and `quarantine-retry-exhausted` reset reasons to advisor context-reset debug logs, so advisor full re-primes after quarantined output remain attributable without changing quarantine retry semantics (issue #7226).
-
-### Fixed
-
-- Split the advisor Session update delivery into per-source-message user messages (single `Agent.prompt(AgentMessage[])` call) so provider prompt caches grow with the session instead of staying pinned at the instructions/tools boundary; rendering stays byte-identical to the old single-block update.
-- Restore the advisor primary-context dedup map when a failed advisor turn is rolled back, so retried batches re-deliver first-time plan/goal context in full instead of collapsing it to "(unchanged — still in effect)".
-- Include all renderer-read fields (excludeFromContext, bashExecution command, pythonExecution code, branch/compaction summary + fromId, fileMention files) in advisor prefix fingerprints so clones changing only those fields correctly trigger a re-render.
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added structured reset-reason logging to advisor context re-primes (issue #7226): every history-rewrite trigger (compact, auto-compaction, compaction-rescue, shake, drop-images, prune-tool-outputs, prune-stale-tool-results, conversation-boundary, context-maintenance) now emits an `advisor context reset` debug event with its reason, so full-transcript replays can be attributed to a concrete path.
+- Added `quarantine-recovery` and `quarantine-retry-exhausted` reset reasons to advisor context-reset debug logs, so advisor full re-primes after quarantined output remain attributable without changing quarantine retry semantics (issue #7226).
+
+### Fixed
+
+- Split the advisor Session update delivery into per-source-message user messages (single `Agent.prompt(AgentMessage[])` call) so provider prompt caches grow with the session instead of staying pinned at the instructions/tools boundary; rendering stays byte-identical to the old single-block update.
+- Restore the advisor primary-context dedup map when a failed advisor turn is rolled back, so retried batches re-deliver first-time plan/goal context in full instead of collapsing it to "(unchanged — still in effect)".
+- Include all renderer-read fields (excludeFromContext, bashExecution command, pythonExecution code, branch/compaction summary + fromId, fileMention files) in advisor prefix fingerprints so clones changing only those fields correctly trigger a re-render.
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed
@@ -17,16 +28,6 @@
 - Fixed install.sh falsely reporting success on musl-based systems (such as Alpine Linux) when the binary fails to start; the installer now smoke-tests the binary, exits non-zero on failure, and provides remediation steps.
 - Fixed Codex config.toml discovery incorrectly importing MCP servers that are configured with enabled = false.
 - Fixed bash.patterns allow rules rejecting valid commands when quoted arguments contained shell metacharacters (such as Cargo benchmark regex filters).
-### Added
-
-- Added structured reset-reason logging to advisor context re-primes (issue #7226): every history-rewrite trigger (compact, auto-compaction, compaction-rescue, shake, drop-images, prune-tool-outputs, prune-stale-tool-results, conversation-boundary, context-maintenance) now emits an `advisor context reset` debug event with its reason, so full-transcript replays can be attributed to a concrete path.
-- Added `quarantine-recovery` and `quarantine-retry-exhausted` reset reasons to advisor context-reset debug logs, so advisor full re-primes after quarantined output remain attributable without changing quarantine retry semantics (issue #7226).
-
-### Fixed
-
-- Split the advisor Session update delivery into per-source-message user messages (single `Agent.prompt(AgentMessage[])` call) so provider prompt caches grow with the session instead of staying pinned at the instructions/tools boundary; rendering stays byte-identical to the old single-block update.
-- Restore the advisor primary-context dedup map when a failed advisor turn is rolled back, so retried batches re-deliver first-time plan/goal context in full instead of collapsing it to "(unchanged — still in effect)".
-- Include all renderer-read fields (excludeFromContext, bashExecution command, pythonExecution code, branch/compaction summary + fromId, fileMention files) in advisor prefix fingerprints so clones changing only those fields correctly trigger a re-render.
 
 ## [17.2.6] - 2026-08-03
 

--- a/packages/coding-agent/src/advisor/delta-split.ts
+++ b/packages/coding-agent/src/advisor/delta-split.ts
@@ -19,8 +19,17 @@
 // (candidate 3) so a wip/final flip never changes the stable prefix.
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { TextContent, ToolResultMessage } from "@oh-my-pi/pi-ai";
-import type { SecretObfuscator } from "../secrets/obfuscator";
 import { formatSessionHistoryMarkdown } from "../session/session-history-format";
+
+/**
+ * Obfuscation surface the split renderer needs: a single text redaction pass.
+ * Narrowed from the full SecretObfuscator class to the method actually
+ * consumed, so tests can satisfy the contract with a typed helper instead of
+ * an `as any` escape. A SecretObfuscator instance is structurally assignable.
+ */
+export interface AdvisorObfuscator {
+	obfuscate(text: string, sharedRegexSecretValues?: ReadonlySet<string>): string;
+}
 
 /** Render options shared by the advisor single-block and multi-message paths. */
 export const ADVISOR_RENDER_OPTIONS = {
@@ -33,7 +42,7 @@ export const ADVISOR_RENDER_OPTIONS = {
 export interface RenderAdvisorDeltaChunksOptions {
 	wip: boolean;
 	includeThinking: boolean;
-	obfuscator?: SecretObfuscator;
+	obfuscator?: AdvisorObfuscator;
 	advisorRegexSecretValues: ReadonlySet<string>;
 }
 

--- a/packages/coding-agent/src/advisor/delta-split.ts
+++ b/packages/coding-agent/src/advisor/delta-split.ts
@@ -73,12 +73,22 @@ export function renderAdvisorDeltaChunks(
 	// marker append below is a plain field access (no double-cast).
 	const chunks: { role: "user"; content: TextContent[]; timestamp: number }[] = [];
 	for (let i = 0; i < delta.length; i++) {
-		let text = renderChunk([delta[i]]);
+		const text = renderChunk([delta[i]]);
 		if (!text.trim()) continue;
-		if (opts.obfuscator) text = opts.obfuscator.obfuscate(text, opts.advisorRegexSecretValues);
-		if (i === 0) text = `${heading}\n\n${text}`;
 		chunks.push({ role: "user", content: [{ type: "text", text }], timestamp: Date.now() });
 	}
+	if (chunks.length === 0) return null;
+	if (opts.obfuscator) {
+		const fullText = chunks.map(chunk => chunk.content[0].text).join("\n");
+		const individuallyObfuscated = chunks.map(chunk =>
+			opts.obfuscator!.obfuscate(chunk.content[0].text, opts.advisorRegexSecretValues),
+		);
+		if (opts.obfuscator.obfuscate(fullText, opts.advisorRegexSecretValues) !== individuallyObfuscated.join("\n")) {
+			return null;
+		}
+		for (let i = 0; i < chunks.length; i++) chunks[i].content[0].text = individuallyObfuscated[i];
+	}
+	chunks[0].content[0].text = `${heading}\n\n${chunks[0].content[0].text}`;
 	if (chunks.length === 0) return null;
 	if (opts.wip) {
 		const last = chunks[chunks.length - 1];

--- a/packages/coding-agent/src/advisor/delta-split.ts
+++ b/packages/coding-agent/src/advisor/delta-split.ts
@@ -60,23 +60,20 @@ export function renderAdvisorDeltaChunks(
 		});
 
 	const heading = "### Session update";
-	const chunks: AgentMessage[] = [];
+	// Concrete local chunk type: content blocks are minted here, so the WIP
+	// marker append below is a plain field access (no double-cast).
+	const chunks: { role: "user"; content: TextContent[]; timestamp: number }[] = [];
 	for (let i = 0; i < delta.length; i++) {
 		let text = renderChunk([delta[i]]);
 		if (!text.trim()) continue;
 		if (opts.obfuscator) text = opts.obfuscator.obfuscate(text, opts.advisorRegexSecretValues);
 		if (i === 0) text = `${heading}\n\n${text}`;
-		chunks.push({
-			role: "user",
-			content: [{ type: "text", text }],
-			timestamp: Date.now(),
-		} as AgentMessage);
+		chunks.push({ role: "user", content: [{ type: "text", text }], timestamp: Date.now() });
 	}
 	if (chunks.length === 0) return null;
 	if (opts.wip) {
 		const last = chunks[chunks.length - 1];
-		const blocks = (last as { content: unknown }).content as TextContent[];
-		blocks[0].text += `\n\n---\n\n[in progress — more steps follow]`;
+		last.content[0].text += `\n\n---\n\n[in progress — more steps follow]`;
 	}
-	return chunks;
+	return chunks as AgentMessage[];
 }

--- a/packages/coding-agent/src/advisor/delta-split.ts
+++ b/packages/coding-agent/src/advisor/delta-split.ts
@@ -1,0 +1,82 @@
+// Candidate 4 (multi-message split) pure renderer, extracted for direct unit
+// testing. Renders an advisor delta as MULTIPLE user messages — one per source
+// message — instead of one ever-growing user message, so the provider prompt
+// cache can incrementally hit each appended message. Provider caches are
+// prefix-based: a single user message whose text keeps growing invalidates the
+// whole message on every turn, pinning cache_read at the instructions/tools
+// boundary (observed 14491 in production, 11066 in tests). Splitting into
+// per-source user messages grows cache_read with the session (verified
+// experimentally: 11066 → 11091 → 11112).
+//
+// Each source message is rendered INDEPENDENTLY via formatSessionHistoryMarkdown
+// in chunked mode (shared toolResultIndex + consumedToolCallIds + watchedRoleState
+// over the WHOLE delta), so toolCall/toolResult pairings resolve across chunk
+// boundaries and consecutive same-role collapsing is byte-identical to the old
+// single-block render. Concatenating the chunk texts reproduces the old advisor
+// context exactly (equivalence-tested).
+//
+// The heading stays on the FIRST chunk; the WIP marker stays on the LAST chunk
+// (candidate 3) so a wip/final flip never changes the stable prefix.
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { TextContent, ToolResultMessage } from "@oh-my-pi/pi-ai";
+import type { SecretObfuscator } from "../secrets/obfuscator";
+import { formatSessionHistoryMarkdown } from "../session/session-history-format";
+
+/** Render options shared by the advisor single-block and multi-message paths. */
+export const ADVISOR_RENDER_OPTIONS = {
+	includeToolIntent: true,
+	watchedRoles: true,
+	expandPrimaryContext: true,
+	expandEditDiffs: true,
+} as const;
+
+export interface RenderAdvisorDeltaChunksOptions {
+	wip: boolean;
+	includeThinking: boolean;
+	obfuscator?: SecretObfuscator;
+	advisorRegexSecretValues: ReadonlySet<string>;
+}
+
+export function renderAdvisorDeltaChunks(
+	delta: AgentMessage[],
+	opts: RenderAdvisorDeltaChunksOptions,
+): AgentMessage[] | null {
+	if (delta.length === 0) return null;
+
+	const resultsByCallId = new Map<string, ToolResultMessage>();
+	for (const msg of delta) {
+		if (msg.role === "toolResult") resultsByCallId.set(msg.toolCallId, msg);
+	}
+	const consumed = new Set<string>();
+	const watchedRoleState = { lastLabel: undefined as string | undefined };
+
+	const renderChunk = (chunk: AgentMessage[]): string =>
+		formatSessionHistoryMarkdown(chunk, {
+			...ADVISOR_RENDER_OPTIONS,
+			includeThinking: opts.includeThinking,
+			toolResultIndex: resultsByCallId,
+			consumedToolCallIds: consumed,
+			watchedRoleState,
+		});
+
+	const heading = "### Session update";
+	const chunks: AgentMessage[] = [];
+	for (let i = 0; i < delta.length; i++) {
+		let text = renderChunk([delta[i]]);
+		if (!text.trim()) continue;
+		if (opts.obfuscator) text = opts.obfuscator.obfuscate(text, opts.advisorRegexSecretValues);
+		if (i === 0) text = `${heading}\n\n${text}`;
+		chunks.push({
+			role: "user",
+			content: [{ type: "text", text }],
+			timestamp: Date.now(),
+		} as AgentMessage);
+	}
+	if (chunks.length === 0) return null;
+	if (opts.wip) {
+		const last = chunks[chunks.length - 1];
+		const blocks = (last as { content: unknown }).content as TextContent[];
+		blocks[0].text += `\n\n---\n\n[in progress — more steps follow]`;
+	}
+	return chunks;
+}

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -565,7 +565,17 @@ export class AdvisorRuntime {
 	 * post-compaction — transcript, giving the advisor fresh context instead of
 	 * leaving it blind to everything before the rewrite.
 	 */
-	reset(): void {
+	reset(reason = "external"): void {
+		// Step-1 observability (issue #7226): every re-prime logs its trigger so
+		// live investigations can attribute full-transcript replays (cached_tokens
+		// pinned at the instructions/tools boundary) to a concrete path instead of
+		// inferring it from payload markers after the fact.
+		logger.debug("advisor context reset", {
+			reason,
+			lastCount: this.#lastCount,
+			pending: this.#pending.length,
+			backlog: this.#backlog,
+		});
 		this.#iterationAbort?.abort("advisor reset");
 		this.#epoch++;
 		this.#sessionTransitionPaused = false;
@@ -968,6 +978,12 @@ export class AdvisorRuntime {
 					// waiters, latest snapshot, and epoch stay untouched. Re-render only
 					// this already-popped raw batch so active plan/reference bodies are
 					// restored without replaying any older primary transcript.
+					logger.debug("advisor context reset", {
+						reason: "context-maintenance",
+						lastCount: this.#lastCount,
+						pending: this.#pending.length,
+						backlog: this.#backlog,
+					});
 					this.#clearAdvisorContextAtCurrentCursor();
 					const { batch: rerendered, preparedMessages } = this.#prepareBatch(rawMessages, wip, batchText);
 					return {

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -12,6 +12,7 @@ import {
 	formatToolResultErrorPreview,
 	PRIMARY_CONTEXT_CUSTOM_TYPES,
 } from "../session/session-history-format";
+import { ADVISOR_RENDER_OPTIONS, renderAdvisorDeltaChunks } from "./delta-split";
 
 /**
  * Minimal slice of `Agent` the runtime drives — satisfied by pi-agent-core
@@ -20,7 +21,7 @@ import {
  * this field after every prompt to detect a failed turn.
  */
 export interface AdvisorAgent {
-	prompt(input: string): Promise<void>;
+	prompt(input: string | AgentMessage[]): Promise<void>;
 	abort(reason?: unknown): void;
 	reset(): void;
 	/**
@@ -231,13 +232,6 @@ const MAX_COALESCE_ROUNDS = 3;
  */
 const MAX_QUARANTINE_RETRIES = 2;
 
-const ADVISOR_RENDER_OPTIONS = {
-	includeToolIntent: true,
-	watchedRoles: true,
-	expandPrimaryContext: true,
-	expandEditDiffs: true,
-} as const;
-
 interface PendingDelta {
 	text: string;
 	rawMessages: AgentMessage[];
@@ -261,9 +255,29 @@ interface DeliveredMessage {
 
 function fingerprintMessage(message: AgentMessage): bigint | undefined {
 	try {
-		const serialized = JSON.stringify(message);
-		if (serialized === undefined) return undefined;
-		return Bun.hash.wyhash(serialized);
+		// Field-selective fingerprint: hash every top-level field the advisor
+		// renderer actually reads (mirrors AppendOnlyContextManager.#messageDigest,
+		// issue #3406). Unrendered metadata (timestamp, usage, provider internals)
+		// churns on provider round-trips and would otherwise trigger a full
+		// transcript replay for a no-op change. Rendered fields (from
+		// session-history-format.ts): role, content, customType, display, isError,
+		// toolResult: cancelled/exitCode/output, custom: details.
+		const m = message as unknown as Record<string, unknown>;
+		const payload = JSON.stringify({
+			r: m.role ?? null,
+			c: m.content ?? null,
+			toolCallId: m.toolCallId ?? null,
+			toolName: m.toolName ?? null,
+			err: m.isError ?? null,
+			ct: m.customType ?? null,
+			disp: m.display ?? null,
+			cancel: m.cancelled ?? null,
+			exit: m.exitCode ?? null,
+			out: m.output ?? null,
+			det: m.details ?? null,
+		});
+		if (payload === undefined) return undefined;
+		return Bun.hash.wyhash(payload);
 	} catch {
 		return undefined;
 	}
@@ -574,10 +588,123 @@ export class AdvisorRuntime {
 		this.#includeThinking = true;
 	}
 
-	#formatRawDelta(rawMessages: AgentMessage[], wip = false): string | null {
+	// Candidate 4 (multi-message split): render the Session update as MULTIPLE
+	// user messages — one per source message — instead of one ever-growing user
+	// message. Provider prompt caches are prefix-based: a single user message
+	// whose text keeps growing invalidates the whole message on every turn, so
+	// cache_read stays pinned at the instructions/tools boundary (observed
+	// 14491 in production, 11066 in tests). Splitting into per-source user
+	// messages lets the provider cache each appended message (verified
+	// experimentally: cache_read 11066 → 11091 → 11112 vs pinned 11066).
+	//
+	// Each source message is rendered INDEPENDENTLY via
+	// formatSessionHistoryMarkdown in chunked mode (shared toolResultIndex +
+	// consumedToolCallIds over the WHOLE delta), so a toolCall finds its
+	// toolResult across chunk boundaries and consecutive same-role collapsing
+	// is preserved. Concatenating the chunk texts with the same separator the
+	// old single-block render used yields byte-identical advisor context.
+	// Each chunk is delivered as its own user AgentMessage via a SINGLE
+	// Agent.prompt(AgentMessage[]) call, so the advisor model still runs ONCE
+	// per update (no per-message assistant turns).
+	#formatRawDeltaMessageChunks(preparedMessages: AgentMessage[], wip = false): AgentMessage[] | null {
+		// Consumes the ALREADY-prepared view from #prepareBatch: advisor custom
+		// messages are filtered and primary-context dedup is applied there, so
+		// splitting here never double-folds or leaks hidden messages.
+		const delta = preparedMessages;
+		if (delta.length === 0) return null;
+
+		const obfuscator = this.host.obfuscator;
+		// Side effects the pure renderer cannot own: scrub the advisor's own
+		// history and refresh pending placeholder prefixes.
+		let discoveredNewRegexSecretValue = false;
+		const addRegexValues = (text: string): void => {
+			for (const secretValue of obfuscator?.collectRegexSecretValuesForObfuscation(text) ?? []) {
+				if (this.#advisorRegexSecretValues.has(secretValue)) continue;
+				this.#advisorRegexSecretValues.add(secretValue);
+				discoveredNewRegexSecretValue = true;
+			}
+		};
+		const probeMd = formatSessionHistoryMarkdown(delta, {
+			...ADVISOR_RENDER_OPTIONS,
+			includeThinking: this.#includeThinking,
+		});
+		if (obfuscator?.hasSecrets()) {
+			for (const message of delta) {
+				if (
+					message.role === "custom" &&
+					PRIMARY_CONTEXT_CUSTOM_TYPES.has(message.customType) &&
+					typeof message.content === "string"
+				) {
+					addRegexValues(message.content);
+				}
+			}
+			addRegexValues(probeMd);
+			scrubAdvisorHistory(obfuscator, this.agent.state.messages, this.#advisorRegexSecretValues);
+			if (discoveredNewRegexSecretValue) {
+				this.#pending = this.#pending.map(delta => ({
+					...delta,
+					text: obfuscator.stripUnsafeFriendlyPlaceholderPrefixes(delta.text, this.#advisorRegexSecretValues),
+				}));
+			}
+		}
+
+		// Message-level obfuscation mirrors the old #formatRawDelta path EXACTLY:
+		// only primary-context custom messages are mapped (tool args, details.diff,
+		// structured fields), because the old path's contract is whole-delta text
+		// obfuscation as the final pass. Expanding to every role would mint
+		// different placeholders and break byte-equivalence with the old render.
+		const renderDelta =
+			obfuscator?.hasSecrets()
+				? delta.map(message =>
+						message.role === "custom" && PRIMARY_CONTEXT_CUSTOM_TYPES.has(message.customType)
+							? obfuscateAdvisorMessage(obfuscator, message, this.#advisorRegexSecretValues)
+							: message,
+					)
+				: delta;
+
+		const chunks = renderAdvisorDeltaChunks(renderDelta, {
+			wip,
+			includeThinking: this.#includeThinking,
+			obfuscator: obfuscator?.hasSecrets() ? obfuscator : undefined,
+			advisorRegexSecretValues: this.#advisorRegexSecretValues,
+		});
+		return chunks;
+	}
+
+	#formatRawDelta(rawMessages: AgentMessage[], wip = false, updateSeenContext = true): string | null {
 		const delta = rawMessages
 			.filter(message => !(message.role === "custom" && message.customType === "advisor"))
-			.map(message => this.#dedupContextMessage(message));
+			.map(message =>
+				updateSeenContext ? this.#dedupContextMessage(message) : this.#dedupContextMessageReadOnly(message),
+			);
+		return this.#renderPreparedDelta(delta, wip);
+	}
+
+	/**
+	 * Preview variant of #dedupContextMessage: returns the collapse decision
+	 * WITHOUT advancing the live #seenContext map. Used by #renderDelta so the
+	 * preview text does not make the batch's first real delivery look like a
+	 * re-injection.
+	 */
+	#dedupContextMessageReadOnly(msg: AgentMessage): AgentMessage {
+		if (msg.role !== "custom") return msg;
+		if (!PRIMARY_CONTEXT_CUSTOM_TYPES.has(msg.customType)) return msg;
+		if (typeof msg.content !== "string") return msg;
+		if (this.#seenContext.get(msg.customType) === msg.content) {
+			return { ...msg, content: "(unchanged — still in effect)" };
+		}
+		return msg;
+	}
+
+	/**
+	 * Render already-prepared (deduped + advisor-filtered) messages to the
+	 * single-block Session update text. Does NOT dedup again — callers that
+	 * prepared the list must pass it here directly, and callers that prepared
+	 * via #prepareBatch get byte-identical batch text to what the multi-message
+	 * split consumes.
+	 */
+	#renderPreparedDelta(preparedMessages: AgentMessage[], wip = false): string | null {
+		const delta = preparedMessages;
 		if (delta.length === 0) return null;
 		const obfuscator = this.host.obfuscator;
 		let md = formatSessionHistoryMarkdown(delta, {
@@ -621,8 +748,15 @@ export class AdvisorRuntime {
 			);
 			md = obfuscator.obfuscate(md, this.#advisorRegexSecretValues);
 		}
-		const heading = wip ? "### Session update [in progress — more steps follow]" : "### Session update";
-		return `${heading}\n\n${md}`;
+		// Candidate 3: keep the heading byte-identical between wip and final turns
+		// and put the WIP marker at the END of the batch, so a wip/final flip
+		// never changes the batch prefix. The provider prompt cache is
+		// prefix-based; a heading that flips between turns re-prefills the whole
+		// user message on every in-progress turn.
+		const heading = "### Session update";
+		const mdHead = `${heading}\n\n${md}`;
+		if (!wip) return mdHead;
+		return `${mdHead}\n\n---\n\n[in progress — more steps follow]`;
 	}
 
 	#renderDelta(messages?: AgentMessage[], wip = false): Omit<PendingDelta, "turns" | "overflowRecovery"> | null {
@@ -643,12 +777,26 @@ export class AdvisorRuntime {
 				delivered.fingerprint !== fingerprint
 			) {
 				prefixChanged = true;
+				// Full replays are expensive (the whole transcript is re-sent and
+				// the provider prompt cache re-prefills from the system prompt), so
+				// record exactly which delivered message diverged and which
+				// top-level fields changed — without this the trigger is invisible.
+				try {
+					const oldMsg: Record<string, unknown> = delivered.message as unknown as Record<string, unknown>;
+					const newMsg: Record<string, unknown> = current as unknown as Record<string, unknown>;
+					const differingFields: string[] = [];
+					for (const key of new Set([...Object.keys(oldMsg), ...Object.keys(newMsg)])) {
+						if (JSON.stringify(oldMsg[key]) !== JSON.stringify(newMsg[key])) differingFields.push(key);
+					}
+					logger.debug("advisor delivered prefix changed", { index: i, role: newMsg.role, differingFields });
+				} catch {}
 				break;
 			}
 			delivered.message = current;
 		}
 		if (prefixChanged) {
 			this.#epoch++;
+			logger.debug("advisor context reset", { reason: "delivered-prefix-changed", lastCount: this.#lastCount });
 			this.#resetAdvisorContext(true, true);
 		}
 		const rawMessages = all.slice(this.#lastCount);
@@ -658,7 +806,11 @@ export class AdvisorRuntime {
 			this.#deliveredPrefix.push({ message, fingerprint: fingerprintMessage(message) });
 		}
 		this.#lastCount = all.length;
-		const text = this.#formatRawDelta(rawMessages, wip);
+		// Preview render: do NOT advance #seenContext — the batch's real dedup
+		// happens once in #prepareBatch. Advancing here would make the first
+		// real delivery of a re-injected primary-context message collapse to
+		// "(unchanged…)" (double-fold).
+		const text = this.#formatRawDelta(rawMessages, wip, false);
 		return text ? { text, rawMessages, renderRevision: this.#renderRevision, wip } : null;
 	}
 
@@ -747,6 +899,7 @@ export class AdvisorRuntime {
 	): Promise<{
 		batch: string | null;
 		rawMessages: AgentMessage[];
+		preparedMessages: AgentMessage[];
 		finalTurns: number;
 		wip: boolean;
 		resetContext: boolean;
@@ -794,10 +947,11 @@ export class AdvisorRuntime {
 					// this already-popped raw batch so active plan/reference bodies are
 					// restored without replaying any older primary transcript.
 					this.#clearAdvisorContextAtCurrentCursor();
-					const rerendered = this.#formatRawDelta(rawMessages, wip);
+					const { batch: rerendered, preparedMessages } = this.#prepareBatch(rawMessages, wip, batchText);
 					return {
 						batch: rerendered ?? (batchText || null),
 						rawMessages,
+						preparedMessages,
 						finalTurns: turns,
 						wip,
 						resetContext: true,
@@ -826,11 +980,43 @@ export class AdvisorRuntime {
 			wip = late.at(-1)!.wip;
 		}
 
-		const batchObfuscator = this.host.obfuscator;
-		if (batchObfuscator?.hasSecrets()) {
-			batchText = batchObfuscator.stripUnsafeFriendlyPlaceholderPrefixes(batchText, this.#advisorRegexSecretValues);
-		}
-		return { batch: batchText || null, rawMessages, finalTurns: turns, wip, resetContext: false };
+		// Prepare the deduped view AFTER coalescing (rawMessages is complete by
+		// now): filters advisor custom messages and collapses re-injected
+		// primary-context to "(unchanged…)". BOTH the single-block text and the
+		// multi-message split derive from this exact list so they never diverge.
+		const { batch: preparedBatch, preparedMessages } = this.#prepareBatch(rawMessages, wip, batchText);
+		return {
+			batch: preparedBatch ?? (batchText || null),
+			rawMessages,
+			preparedMessages,
+			finalTurns: turns,
+			wip,
+			resetContext: false,
+		};
+	}
+
+	/**
+	 * Single dedup+render pass shared by every batch finalization path (normal
+	 * and context-reset). Filters advisor custom messages, collapses re-injected
+	 * primary-context to "(unchanged…)" via #dedupContextMessage, renders the
+	 * single-block batch text from the SAME prepared list the multi-message
+	 * split consumes, so the two views can never diverge.
+	 */
+	#prepareBatch(
+		rawMessages: AgentMessage[],
+		wip: boolean,
+		fallback: string | null,
+	): { batch: string | null; preparedMessages: AgentMessage[] } {
+		// Dedup against the LIVE #seenContext (populated by previous turns via
+		// #renderDelta -> #formatRawDelta) so re-injected primary context that
+		// was ALREADY shown collapses to "(unchanged…)", while a FIRST delivery
+		// in this batch stays expanded. This pass advances the live map exactly
+		// once per batch — #renderDelta's text is a preview and must not set it.
+		const preparedMessages = rawMessages
+			.filter(message => !(message.role === "custom" && message.customType === "advisor"))
+			.map(message => this.#dedupContextMessage(message));
+		const batch = this.#renderPreparedDelta(preparedMessages, wip);
+		return { batch: batch ?? fallback, preparedMessages };
 	}
 
 	#terminalAssistantFailure(snapshot: number): AssistantMessage | undefined {
@@ -872,8 +1058,11 @@ export class AdvisorRuntime {
 				const epoch = this.#epoch;
 				for (const delta of popped) {
 					if (delta.renderRevision === this.#renderRevision) continue;
-					const refreshed = this.#formatRawDelta(delta.rawMessages, delta.wip);
-					if (refreshed) delta.text = refreshed;
+					// Batch text is finalized by #collectAndMaintainBatch -> #prepareBatch
+					// (single dedup+render pass). Refreshing here would run
+					// #dedupContextMessage a SECOND time and double-fold re-injected
+					// primary-context custom messages ("(unchanged…)" on first
+					// delivery). Mark the revision so the delta is not re-refreshed.
 					delta.renderRevision = this.#renderRevision;
 				}
 				const recoveringOverflow = popped.some(delta => delta.overflowRecovery === true);
@@ -891,7 +1080,7 @@ export class AdvisorRuntime {
 					continue;
 				}
 
-				const { batch, rawMessages, finalTurns, wip, resetContext } = result;
+				const { batch, rawMessages, preparedMessages, finalTurns, wip, resetContext } = result;
 
 				if (this.disposed || batch === null) {
 					this.#backlog = Math.max(0, this.#backlog - finalTurns);
@@ -908,10 +1097,18 @@ export class AdvisorRuntime {
 				const messageSnapshot = this.agent.state.messages.length;
 				const contextWasFresh = resetContext || recoveringOverflow || messageSnapshot === 0;
 				try {
-					// Reset the host's per-update advisor state (one-advise-per-update
-					// gate) and pass through whether this batch reviews partial work.
 					this.host.beginAdvisorUpdate?.(wip);
-					const prompt = this.agent.prompt(batch);
+					// Candidate 4 (multi-message split): deliver the Session update as
+					// multiple user messages so the provider prompt cache can
+					// incrementally hit each appended message (cache_read grows with
+					// the session instead of staying pinned at the instructions/tools
+					// boundary). Falls back to the single-block string when the chunk
+					// renderer cannot split (e.g. empty delta). The split is
+					// byte-equivalent to the old single-block render (equivalence
+					// tested), so the advisor sees identical context.
+					const splitMessages = this.#formatRawDeltaMessageChunks(preparedMessages, wip);
+					const promptInput: string | AgentMessage[] = splitMessages ?? batch;
+					const prompt = this.agent.prompt(promptInput);
 					this.#promptInFlight = prompt;
 					try {
 						await prompt;

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -261,7 +261,10 @@ function fingerprintMessage(message: AgentMessage): bigint | undefined {
 		// churns on provider round-trips and would otherwise trigger a full
 		// transcript replay for a no-op change. Rendered fields (from
 		// session-history-format.ts): role, content, customType, display, isError,
-		// toolResult: cancelled/exitCode/output, custom: details.
+		// toolResult: cancelled/exitCode/output, custom: details, plus the
+		// execution/branch/compaction/file-mention fields the formatter reads:
+		// excludeFromContext, command (bashExecution), code (pythonExecution),
+		// summary + fromId (branch/compaction), files (fileMention).
 		const m = message as unknown as Record<string, unknown>;
 		const payload = JSON.stringify({
 			r: m.role ?? null,
@@ -275,6 +278,12 @@ function fingerprintMessage(message: AgentMessage): bigint | undefined {
 			exit: m.exitCode ?? null,
 			out: m.output ?? null,
 			det: m.details ?? null,
+			xfc: m.excludeFromContext ?? null,
+			cmd: m.command ?? null,
+			code: m.code ?? null,
+			sum: m.summary ?? null,
+			from: m.fromId ?? null,
+			files: m.files ?? null,
 		});
 		if (payload === undefined) return undefined;
 		return Bun.hash.wyhash(payload);
@@ -294,8 +303,17 @@ export class AdvisorRuntime {
 	 *  approved plan). These prompts are re-injected verbatim every primary turn;
 	 *  this lets {@link #renderDelta} collapse an unchanged copy to a one-line
 	 *  marker so the advisor isn't re-fed the full ~1k-token rules each turn.
-	 *  Cleared on every re-prime/seed and when a failed batch is dropped. */
+	/** Cleared on every re-prime/seed and when a failed batch is dropped. */
 	#seenContext = new Map<string, string>();
+	/**
+	 * Snapshot of {@link #seenContext} taken by #prepareBatch before the
+	 * in-flight batch's first dedup mutation. Restored by
+	 * {@link #rollbackFailedTurn} when the turn fails and its rawMessages are
+	 * requeued, so first-time primary-context is re-delivered in full instead
+	 * of collapsing to "(unchanged — still in effect)" against an advisor
+	 * history that no longer contains it. Cleared on turn success.
+	 */
+	#seenContextInFlight: [string, string][] | undefined;
 	/** Incremented whenever the advisor loses context so queued raw deltas are re-rendered against fresh dedupe state. */
 	#renderRevision = 0;
 	/** Regex secret values observed in primary deltas and retained until advisor context resets. */
@@ -467,6 +485,7 @@ export class AdvisorRuntime {
 
 	#clearSeenContext(): void {
 		this.#seenContext.clear();
+		this.#seenContextInFlight = undefined;
 		this.#advisorRegexSecretValues.clear();
 		this.#renderRevision++;
 	}
@@ -597,6 +616,57 @@ export class AdvisorRuntime {
 	// messages lets the provider cache each appended message (verified
 	// experimentally: cache_read 11066 → 11091 → 11112 vs pinned 11066).
 	//
+	/**
+	 * Shared obfuscation side effects for BOTH render paths (single-block
+	 * {@link #renderPreparedDelta} and multi-message
+	 * {@link #formatRawDeltaMessageChunks}): collect regex secret values from
+	 * primary-context custom messages and the rendered markdown, scrub the
+	 * advisor's own history, and refresh pending placeholder prefixes when new
+	 * secrets appear. Returns whether new secret values were discovered.
+	 * Idempotent across the two calls one drain makes for the same prepared
+	 * list: the second call discovers nothing new and skips the strip.
+	 */
+	#collectAdvisorSecrets(obfuscator: SecretObfuscator, delta: AgentMessage[], renderedMd: string): boolean {
+		let discoveredNewRegexSecretValue = false;
+		const addRegexValues = (text: string): void => {
+			for (const secretValue of obfuscator.collectRegexSecretValuesForObfuscation(text) ?? []) {
+				if (this.#advisorRegexSecretValues.has(secretValue)) continue;
+				this.#advisorRegexSecretValues.add(secretValue);
+				discoveredNewRegexSecretValue = true;
+			}
+		};
+		for (const message of delta) {
+			if (
+				message.role === "custom" &&
+				PRIMARY_CONTEXT_CUSTOM_TYPES.has(message.customType) &&
+				typeof message.content === "string"
+			) {
+				addRegexValues(message.content);
+			}
+		}
+		addRegexValues(renderedMd);
+		scrubAdvisorHistory(obfuscator, this.agent.state.messages, this.#advisorRegexSecretValues);
+		if (discoveredNewRegexSecretValue) {
+			this.#pending = this.#pending.map(delta => ({
+				...delta,
+				text: obfuscator.stripUnsafeFriendlyPlaceholderPrefixes(delta.text, this.#advisorRegexSecretValues),
+			}));
+		}
+		return discoveredNewRegexSecretValue;
+	}
+
+	/**
+	 * Map primary-context custom messages through the obfuscator. Shared by
+	 * both render paths so the byte-equivalence contract lives in one place.
+	 */
+	#obfuscatePrimaryContextMessages(obfuscator: SecretObfuscator, delta: AgentMessage[]): AgentMessage[] {
+		return delta.map(message =>
+			message.role === "custom" && PRIMARY_CONTEXT_CUSTOM_TYPES.has(message.customType)
+				? obfuscateAdvisorMessage(obfuscator, message, this.#advisorRegexSecretValues)
+				: message,
+		);
+	}
+
 	// Each source message is rendered INDEPENDENTLY via
 	// formatSessionHistoryMarkdown in chunked mode (shared toolResultIndex +
 	// consumedToolCallIds over the WHOLE delta), so a toolCall finds its
@@ -614,38 +684,16 @@ export class AdvisorRuntime {
 		if (delta.length === 0) return null;
 
 		const obfuscator = this.host.obfuscator;
-		// Side effects the pure renderer cannot own: scrub the advisor's own
-		// history and refresh pending placeholder prefixes.
-		let discoveredNewRegexSecretValue = false;
-		const addRegexValues = (text: string): void => {
-			for (const secretValue of obfuscator?.collectRegexSecretValuesForObfuscation(text) ?? []) {
-				if (this.#advisorRegexSecretValues.has(secretValue)) continue;
-				this.#advisorRegexSecretValues.add(secretValue);
-				discoveredNewRegexSecretValue = true;
-			}
-		};
+		// Side effects the pure renderer cannot own: collect secrets, scrub the
+		// advisor's own history and refresh pending placeholder prefixes (shared
+		// helper — see #collectAdvisorSecrets; idempotent for this drain's
+		// single-block pass over the same prepared list).
 		const probeMd = formatSessionHistoryMarkdown(delta, {
 			...ADVISOR_RENDER_OPTIONS,
 			includeThinking: this.#includeThinking,
 		});
 		if (obfuscator?.hasSecrets()) {
-			for (const message of delta) {
-				if (
-					message.role === "custom" &&
-					PRIMARY_CONTEXT_CUSTOM_TYPES.has(message.customType) &&
-					typeof message.content === "string"
-				) {
-					addRegexValues(message.content);
-				}
-			}
-			addRegexValues(probeMd);
-			scrubAdvisorHistory(obfuscator, this.agent.state.messages, this.#advisorRegexSecretValues);
-			if (discoveredNewRegexSecretValue) {
-				this.#pending = this.#pending.map(delta => ({
-					...delta,
-					text: obfuscator.stripUnsafeFriendlyPlaceholderPrefixes(delta.text, this.#advisorRegexSecretValues),
-				}));
-			}
+			this.#collectAdvisorSecrets(obfuscator, delta, probeMd);
 		}
 
 		// Message-level obfuscation mirrors the old #formatRawDelta path EXACTLY:
@@ -653,14 +701,7 @@ export class AdvisorRuntime {
 		// structured fields), because the old path's contract is whole-delta text
 		// obfuscation as the final pass. Expanding to every role would mint
 		// different placeholders and break byte-equivalence with the old render.
-		const renderDelta =
-			obfuscator?.hasSecrets()
-				? delta.map(message =>
-						message.role === "custom" && PRIMARY_CONTEXT_CUSTOM_TYPES.has(message.customType)
-							? obfuscateAdvisorMessage(obfuscator, message, this.#advisorRegexSecretValues)
-							: message,
-					)
-				: delta;
+		const renderDelta = obfuscator?.hasSecrets() ? this.#obfuscatePrimaryContextMessages(obfuscator, delta) : delta;
 
 		const chunks = renderAdvisorDeltaChunks(renderDelta, {
 			wip,
@@ -713,39 +754,11 @@ export class AdvisorRuntime {
 		});
 		if (!md.trim()) return null;
 		if (obfuscator?.hasSecrets()) {
-			let discoveredNewRegexSecretValue = false;
-			const addRegexValues = (text: string): void => {
-				for (const secretValue of obfuscator.collectRegexSecretValuesForObfuscation(text)) {
-					if (this.#advisorRegexSecretValues.has(secretValue)) continue;
-					this.#advisorRegexSecretValues.add(secretValue);
-					discoveredNewRegexSecretValue = true;
-				}
-			};
-			for (const message of delta) {
-				if (
-					message.role === "custom" &&
-					PRIMARY_CONTEXT_CUSTOM_TYPES.has(message.customType) &&
-					typeof message.content === "string"
-				) {
-					addRegexValues(message.content);
-				}
-			}
-			addRegexValues(md);
-			scrubAdvisorHistory(obfuscator, this.agent.state.messages, this.#advisorRegexSecretValues);
-			if (discoveredNewRegexSecretValue) {
-				this.#pending = this.#pending.map(delta => ({
-					...delta,
-					text: obfuscator.stripUnsafeFriendlyPlaceholderPrefixes(delta.text, this.#advisorRegexSecretValues),
-				}));
-			}
-			md = formatSessionHistoryMarkdown(
-				delta.map(message =>
-					message.role === "custom" && PRIMARY_CONTEXT_CUSTOM_TYPES.has(message.customType)
-						? obfuscateAdvisorMessage(obfuscator, message, this.#advisorRegexSecretValues)
-						: message,
-				),
-				{ ...ADVISOR_RENDER_OPTIONS, includeThinking: this.#includeThinking },
-			);
+			this.#collectAdvisorSecrets(obfuscator, delta, md);
+			md = formatSessionHistoryMarkdown(this.#obfuscatePrimaryContextMessages(obfuscator, delta), {
+				...ADVISOR_RENDER_OPTIONS,
+				includeThinking: this.#includeThinking,
+			});
 			md = obfuscator.obfuscate(md, this.#advisorRegexSecretValues);
 		}
 		// Candidate 3: keep the heading byte-identical between wip and final turns
@@ -858,6 +871,15 @@ export class AdvisorRuntime {
 	 * that hand-roll a minimal facade.
 	 */
 	#rollbackFailedTurn(snapshot: number): void {
+		// Restore the primary-context dedup map to its pre-batch state: the
+		// failed turn never reached the advisor, so first-time context collapsed
+		// to "(unchanged…)" by this batch's #prepareBatch must expand again on
+		// the retry/requeue pass.
+		if (this.#seenContextInFlight) {
+			this.#seenContext.clear();
+			for (const [key, value] of this.#seenContextInFlight) this.#seenContext.set(key, value);
+			this.#seenContextInFlight = undefined;
+		}
 		const messages = this.agent.state.messages;
 		if (messages.length <= snapshot) return;
 		try {
@@ -1012,6 +1034,10 @@ export class AdvisorRuntime {
 		// was ALREADY shown collapses to "(unchanged…)", while a FIRST delivery
 		// in this batch stays expanded. This pass advances the live map exactly
 		// once per batch — #renderDelta's text is a preview and must not set it.
+		// Snapshot the dedup map BEFORE this batch's first mutation so a failed
+		// turn can restore it (see #rollbackFailedTurn). `??=` keeps the first
+		// snapshot across coalescing re-prepares within one in-flight batch.
+		this.#seenContextInFlight ??= [...this.#seenContext];
 		const preparedMessages = rawMessages
 			.filter(message => !(message.role === "custom" && message.customType === "advisor"))
 			.map(message => this.#dedupContextMessage(message));
@@ -1128,6 +1154,7 @@ export class AdvisorRuntime {
 					const turnError = getAdvisorTurnError(this.agent.state.messages.slice(messageSnapshot));
 					if (turnError) throw turnError;
 					success = true;
+					this.#seenContextInFlight = undefined;
 					this.#failing = false;
 					this.#consecutiveFailures = 0;
 					this.#failureNotified = false;

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -501,7 +501,15 @@ export class AdvisorRuntime {
 		} catch {}
 	}
 
-	#resetAdvisorContext(clearBacklog: boolean, wakeWaiters: boolean): void {
+	#resetAdvisorContext(clearBacklog: boolean, wakeWaiters: boolean, reason?: string): void {
+		if (reason) {
+			logger.debug("advisor context reset", {
+				reason,
+				lastCount: this.#lastCount,
+				pending: this.#pending.length,
+				backlog: this.#backlog,
+			});
+		}
 		this.#lastCount = 0;
 		this.#deliveredPrefix = [];
 		this.#pending = [];
@@ -570,12 +578,6 @@ export class AdvisorRuntime {
 		// live investigations can attribute full-transcript replays (cached_tokens
 		// pinned at the instructions/tools boundary) to a concrete path instead of
 		// inferring it from payload markers after the fact.
-		logger.debug("advisor context reset", {
-			reason,
-			lastCount: this.#lastCount,
-			pending: this.#pending.length,
-			backlog: this.#backlog,
-		});
 		this.#iterationAbort?.abort("advisor reset");
 		this.#epoch++;
 		this.#sessionTransitionPaused = false;
@@ -585,7 +587,7 @@ export class AdvisorRuntime {
 		this.#droppedBacklogs = 0;
 		this.#consecutiveQuarantines = 0;
 		this.#failureNotified = false;
-		this.#resetAdvisorContext(true, true);
+		this.#resetAdvisorContext(true, true, reason);
 	}
 
 	/**
@@ -1270,13 +1272,13 @@ export class AdvisorRuntime {
 						if (this.#consecutiveQuarantines >= MAX_QUARANTINE_RETRIES) {
 							this.#notifyFailureOnce(err);
 							this.#consecutiveQuarantines = 0;
-							this.#resetAdvisorContext(true, true);
+							this.#resetAdvisorContext(true, true, "quarantine-retry-exhausted");
 							continue;
 						}
 						const rePrime = this.#pending.length > 0 ? this.#latestMessages : undefined;
 						// Wake catchup waiters only when nothing is re-primed; otherwise the
 						// re-primed turn restores the backlog and waiters resolve on its completion.
-						this.#resetAdvisorContext(true, !rePrime);
+						this.#resetAdvisorContext(true, !rePrime, "quarantine-recovery");
 						if (rePrime) this.onTurnEnd(rePrime);
 						continue;
 					}

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -1221,7 +1221,11 @@ export class AdvisorRuntime {
 					if (classifierRefusal) {
 						if (this.#includeThinking) {
 							this.#includeThinking = false;
-							const strippedBatch = this.#formatRawDelta(rawMessages, wip);
+							// Do NOT advance #seenContext here: the requeued batch is
+							// re-deduped by #prepareBatch on the next drain, so a mutation
+							// now would double-fold first-time primary context into
+							// "(unchanged — still in effect)" on the retry.
+							const strippedBatch = this.#formatRawDelta(rawMessages, wip, false);
 							if (strippedBatch) {
 								this.#pending.unshift({
 									text: strippedBatch,
@@ -1338,7 +1342,10 @@ export class AdvisorRuntime {
 						} else {
 							// Retry once against the fresh advisor context, using only the same
 							// bounded raw batch. Pending updates remain queued behind it.
-							const recoveryBatch = this.#formatRawDelta(rawMessages, wip) ?? batch;
+							// Same double-fold guard as the refusal branch: #prepareBatch
+							// re-dedups on retry, so this preview render must not mutate
+							// #seenContext.
+							const recoveryBatch = this.#formatRawDelta(rawMessages, wip, false) ?? batch;
 							this.#pending.unshift({
 								text: recoveryBatch,
 								rawMessages,

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -882,16 +882,19 @@ export class AdvisorRuntime {
 	 * append-only context); falls back to truncating `state.messages` for tests
 	 * that hand-roll a minimal facade.
 	 */
+	#restoreSeenContextInFlight(): void {
+		if (!this.#seenContextInFlight) return;
+		this.#seenContext.clear();
+		for (const [key, value] of this.#seenContextInFlight) this.#seenContext.set(key, value);
+		this.#seenContextInFlight = undefined;
+	}
+
 	#rollbackFailedTurn(snapshot: number): void {
 		// Restore the primary-context dedup map to its pre-batch state: the
 		// failed turn never reached the advisor, so first-time context collapsed
 		// to "(unchanged…)" by this batch's #prepareBatch must expand again on
 		// the retry/requeue pass.
-		if (this.#seenContextInFlight) {
-			this.#seenContext.clear();
-			for (const [key, value] of this.#seenContextInFlight) this.#seenContext.set(key, value);
-			this.#seenContextInFlight = undefined;
-		}
+		this.#restoreSeenContextInFlight();
 		const messages = this.agent.state.messages;
 		if (messages.length <= snapshot) return;
 		try {
@@ -1102,11 +1105,10 @@ export class AdvisorRuntime {
 				const epoch = this.#epoch;
 				for (const delta of popped) {
 					if (delta.renderRevision === this.#renderRevision) continue;
-					// Batch text is finalized by #collectAndMaintainBatch -> #prepareBatch
-					// (single dedup+render pass). Refreshing here would run
-					// #dedupContextMessage a SECOND time and double-fold re-injected
-					// primary-context custom messages ("(unchanged…)" on first
-					// delivery). Mark the revision so the delta is not re-refreshed.
+					// Context maintenance estimates this preview before #prepareBatch makes
+					// its final deduped render. Rebuild stale text against the new context
+					// so the maintenance budget cannot undercount an expanded re-injection.
+					delta.text = this.#formatRawDelta(delta.rawMessages, delta.wip, false) ?? delta.text;
 					delta.renderRevision = this.#renderRevision;
 				}
 				const recoveringOverflow = popped.some(delta => delta.overflowRecovery === true);
@@ -1120,6 +1122,7 @@ export class AdvisorRuntime {
 				// Epoch was invalidated during batch collection; restart the loop.
 				if (result === null) continue;
 				if (this.#sessionTransitionPaused) {
+					this.#restoreSeenContextInFlight();
 					this.#pending.unshift(...popped);
 					continue;
 				}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1444,7 +1444,7 @@ export class AgentSession {
 				this.#planReferenceSent = false;
 			},
 			syncTodoPhasesFromBranch: () => this.#todo.syncFromBranch(),
-			resetAdvisorRuntimes: () => this.#advisors.resetAllRuntimes(),
+			resetAdvisorRuntimes: (reason?: string) => this.#advisors.resetAllRuntimes(reason),
 			rebaseAfterCompaction: () => this.#stats.rebaseAfterCompaction(),
 			recordAnchoredHistoryRewrite: tokensRemoved => this.#stats.recordAnchoredHistoryRewrite(tokensRemoved),
 			getContextBreakdown: options => this.getContextBreakdown(options),

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -839,7 +839,10 @@ export class SessionAdvisors {
 						currentAdvisorInput = Array.isArray(input)
 							? formatSessionHistoryMarkdown(input, { watchedRoles: true })
 							: input;
-						await (Array.isArray(input) ? advisorAgent.prompt(input) : advisorAgent.prompt(input));
+						// Agent.prompt's overloads accept string OR AgentMessage[] but not
+						// the union, so narrow first; both branches intentionally identical.
+						if (Array.isArray(input)) await advisorAgent.prompt(input);
+						else await advisorAgent.prompt(input);
 						quarantined = quarantinedAdvisorOutput;
 					} finally {
 						quarantinedAdvisorOutput = undefined;

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -832,8 +832,14 @@ export class SessionAdvisors {
 					let quarantined: string | undefined;
 					try {
 						quarantinedAdvisorOutput = undefined;
-						currentAdvisorInput = input;
-						await advisorAgent.prompt(input);
+						// Multi-message input (candidate 4) must serialize deterministically
+						// for quarantine source text; reuse the session history formatter
+						// rather than ad-hoc joins so all message kinds (text/tool/
+						// custom/structured) are preserved exactly as rendered.
+						currentAdvisorInput = Array.isArray(input)
+							? formatSessionHistoryMarkdown(input, { watchedRoles: true })
+							: input;
+						await (Array.isArray(input) ? advisorAgent.prompt(input) : advisorAgent.prompt(input));
 						quarantined = quarantinedAdvisorOutput;
 					} finally {
 						quarantinedAdvisorOutput = undefined;

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -418,8 +418,8 @@ export class SessionAdvisors {
 	}
 
 	/** Re-primes advisor transcript views after an in-conversation history rewrite. */
-	resetAllRuntimes(): void {
-		this.#resetAllAdvisorRuntimes();
+	resetAllRuntimes(reason?: string): void {
+		this.#resetAllAdvisorRuntimes(reason);
 	}
 
 	/** Whether live runtimes still match the resolved advisor configuration. */
@@ -535,7 +535,7 @@ export class SessionAdvisors {
 		for (const a of this.#advisors) {
 			a.agentUnsubscribe?.();
 			a.agentUnsubscribe = undefined;
-			a.runtime.reset();
+			a.runtime.reset("conversation-boundary");
 			a.adviseTool.resetDeliveredNotes();
 			a.emissionGuard.reset();
 			this.#attachAdvisorRecorderFeed(a);
@@ -1066,8 +1066,8 @@ export class SessionAdvisors {
 	}
 
 	/** Re-prime every advisor's transcript view after an in-conversation history rewrite. */
-	#resetAllAdvisorRuntimes(): void {
-		for (const a of this.#advisors) a.runtime.reset();
+	#resetAllAdvisorRuntimes(reason?: string): void {
+		for (const a of this.#advisors) a.runtime.reset(reason);
 	}
 
 	#stopAdvisorRuntime(): void {

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -55,6 +55,14 @@ export interface HistoryFormatOptions {
 	 */
 	toolResultIndex?: ReadonlyMap<string, ToolResultMessage>;
 	consumedToolCallIds?: Set<string>;
+	/**
+	 * Chunked rendering state: a mutable holder for the watched-role label
+	 * (`**user**:` / `**agent**:`) that ended the previous chunk. Lets a caller
+	 * formatting one logical transcript across several calls (advisor
+	 * multi-message split) keep consecutive same-role collapsing byte-identical
+	 * to the single-block render: pass one object across all chunk calls.
+	 */
+	watchedRoleState?: { lastLabel: string | undefined };
 }
 
 /** Max length of the primary-arg summary inside `→ tool(...)` lines. */
@@ -313,7 +321,9 @@ export function formatSessionHistoryMarkdown(messages: unknown[], opts?: History
 	// (the watched agent emits one assistant message per tool call, so otherwise
 	// every call repeats `**agent**:`). Cleared whenever a
 	// non-role-labeled line is emitted so the next turn re-labels.
-	let lastWatchedLabel: string | undefined;
+	// Chunked callers seed the previous chunk's trailing label so collapsing
+	// stays byte-identical to the single-block render.
+	let lastWatchedLabel: string | undefined = opts?.watchedRoleState?.lastLabel;
 	// Emit a watched-mode role label, collapsing consecutive same-role turns
 	// under one label (matching the user/assistant paths). Used for the
 	// user-attributed `!`/`$` execution lines so the advisor never reads them
@@ -453,6 +463,10 @@ export function formatSessionHistoryMarkdown(messages: unknown[], opts?: History
 				break;
 			}
 		}
+	}
+
+	if (opts?.watchedRoleState) {
+		opts.watchedRoleState.lastLabel = lastWatchedLabel;
 	}
 
 	return `${lines.join("\n").trim()}\n`;

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -235,7 +235,7 @@ export interface SessionMaintenanceHost {
 	resetCodexProviderAfterCompaction(compaction: CodexCompactionContext): void;
 	resetPlanReference(): void;
 	syncTodoPhasesFromBranch(): void;
-	resetAdvisorRuntimes(): void;
+	resetAdvisorRuntimes(reason?: string): void;
 	rebaseAfterCompaction(): void;
 	recordAnchoredHistoryRewrite(tokensRemoved: number): void;
 	getContextBreakdown(options?: {
@@ -345,7 +345,7 @@ export class SessionMaintenance {
 		await this.#host.sessionManager.rewriteEntries();
 		const sessionContext = this.#host.buildDisplaySessionContext();
 		this.#host.agent.replaceMessages(sessionContext.messages);
-		this.#host.resetAdvisorRuntimes();
+		this.#host.resetAdvisorRuntimes("prune-tool-outputs");
 		this.#host.syncTodoPhasesFromBranch();
 		this.#host.closeCodexProviderSessionsForHistoryRewrite();
 		return result;
@@ -388,7 +388,7 @@ export class SessionMaintenance {
 		await this.#host.sessionManager.rewriteEntries();
 		const sessionContext = this.#host.buildDisplaySessionContext();
 		this.#host.agent.replaceMessages(sessionContext.messages);
-		this.#host.resetAdvisorRuntimes();
+		this.#host.resetAdvisorRuntimes("prune-stale-tool-results");
 		this.#host.syncTodoPhasesFromBranch();
 		this.#host.closeCodexProviderSessionsForHistoryRewrite();
 		return result;
@@ -439,7 +439,7 @@ export class SessionMaintenance {
 		await this.#host.sessionManager.rewriteEntries();
 		const sessionContext = this.#host.buildDisplaySessionContext();
 		this.#host.agent.replaceMessages(sessionContext.messages);
-		this.#host.resetAdvisorRuntimes();
+		this.#host.resetAdvisorRuntimes("drop-images");
 		this.#host.closeCodexProviderSessionsForHistoryRewrite();
 		return { removed };
 	}
@@ -527,7 +527,7 @@ export class SessionMaintenance {
 		await this.#host.sessionManager.rewriteEntries();
 		const sessionContext = this.#host.buildDisplaySessionContext();
 		this.#host.agent.replaceMessages(sessionContext.messages);
-		this.#host.resetAdvisorRuntimes();
+		this.#host.resetAdvisorRuntimes("shake");
 		this.#host.closeCodexProviderSessionsForHistoryRewrite();
 
 		return {
@@ -879,7 +879,7 @@ export class SessionMaintenance {
 			// plan reference. Clear the sent-flag so #buildPlanReferenceMessage re-reads
 			// the plan from disk and re-injects it on the next turn (issue #1246).
 			this.#host.resetPlanReference();
-			this.#host.resetAdvisorRuntimes();
+			this.#host.resetAdvisorRuntimes("compact");
 			this.#host.syncTodoPhasesFromBranch();
 			if (codexCompaction) {
 				this.#host.resetCodexProviderAfterCompaction(codexCompaction);
@@ -2094,7 +2094,7 @@ export class SessionMaintenance {
 		// and advisor cursors / todo phases were derived from the replaced
 		// history.
 		this.#host.resetPlanReference();
-		this.#host.resetAdvisorRuntimes();
+		this.#host.resetAdvisorRuntimes("compaction-rescue");
 		this.#host.syncTodoPhasesFromBranch();
 		this.#host.closeCodexProviderSessionsForHistoryRewrite();
 		// Extensions must see the entry that is now active, not (only) the one
@@ -2763,7 +2763,7 @@ export class SessionMaintenance {
 			// plan reference. Clear the sent-flag so #buildPlanReferenceMessage re-reads
 			// the plan from disk and re-injects it on the next turn (issue #1246).
 			this.#host.resetPlanReference();
-			this.#host.resetAdvisorRuntimes();
+			this.#host.resetAdvisorRuntimes("auto-compaction");
 			this.#host.syncTodoPhasesFromBranch();
 			if (codexCompaction) {
 				this.#host.resetCodexProviderAfterCompaction(codexCompaction);

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -2581,6 +2581,56 @@ describe("advisor", () => {
 			expect(resetCount).toBe(1);
 		});
 
+		it("does not double-fold first-time primary context on overflow-recovery retry", async () => {
+			// Regression: the recovery render previews the retry batch; if it advances
+			// #seenContext, the retry's #prepareBatch re-dedup would collapse first-time
+			// plan-mode-context to "(unchanged — still in effect)" even though the
+			// advisor history was rolled back — the retry would lose the constraints.
+			const overflowMessage = "context_length_exceeded: Your input exceeds the context window of this model.";
+			const promptInputs: Array<string | AgentMessage[]> = [];
+			const state: { messages: AgentMessage[]; error?: string } = {
+				messages: [{ role: "user", content: "existing advisor context", timestamp: 1 } as AgentMessage],
+			};
+			let promptCalls = 0;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+					promptCalls++;
+					state.error = promptCalls === 1 ? overflowMessage : undefined;
+				},
+				abort: () => {},
+				reset: () => {
+					state.messages.length = 0;
+					state.error = undefined;
+				},
+				state,
+			};
+			const messages: AgentMessage[] = [{ role: "user", content: "seed-primary", timestamp: 1 } as AgentMessage];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+			runtime.seedTo(messages.length);
+
+			const rule =
+				"Plan mode is active. You MUST perform READ-ONLY work only:\n- You NEVER create, edit, or delete files — except the single plan file named below.";
+			messages.push({ role: "user", content: "overflowing-current-update", timestamp: 2 } as AgentMessage);
+			messages.push({
+				role: "custom",
+				customType: "plan-mode-context",
+				content: rule,
+				display: false,
+				timestamp: 3,
+			} as AgentMessage);
+			runtime.onTurnEnd(messages);
+			await settleUntil(() => promptInputs.length >= 2 && runtime.backlog === 0);
+
+			expect(promptInputs).toHaveLength(2);
+			expect(promptText(promptInputs[1])).toContain("except the single plan file named below");
+			expect(promptText(promptInputs[1])).not.toContain("unchanged — still in effect");
+		});
+
 		it("classifies structured overflow metadata before rolling back the failed turn", async () => {
 			const promptInputs: Array<string | AgentMessage[]> = [];
 			const state: { messages: AgentMessage[]; error?: string } = {

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -1957,7 +1957,11 @@ describe("advisor", () => {
 
 			runtime.onTurnEnd();
 			await runtime.waitForCatchup(1000, 1);
-			agent.state.messages.push({ role: "user", content: promptText(promptInputs[0]!), timestamp: 1 } as AgentMessage);
+			agent.state.messages.push({
+				role: "user",
+				content: promptText(promptInputs[0]!),
+				timestamp: 1,
+			} as AgentMessage);
 			expect(firstStoredPrompt()).toContain("TOKABC123_");
 
 			messages.push({ role: "user", content: "later tok_abc123", timestamp: 2 } as AgentMessage);
@@ -2224,6 +2228,49 @@ describe("advisor", () => {
 			expect(promptInputs).toHaveLength(2);
 			expect(promptText(promptInputs[1])).toContain("unchanged — still in effect");
 			expect(promptText(promptInputs[1])).not.toContain("except the single plan file named below");
+		});
+
+		it("re-expands first-time primary context when a failed turn is retried", async () => {
+			// Regression: the failed turn is rolled back, so the advisor history no
+			// longer contains the full plan-mode context; the retry must not collapse
+			// it to "(unchanged — still in effect)" against the pre-failure dedup map.
+			const promptInputs: Array<string | AgentMessage[]> = [];
+			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
+			let promptCalls = 0;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+					promptCalls++;
+					state.error = promptCalls === 1 ? "transient provider 500" : undefined;
+				},
+				abort: () => {},
+				reset: () => {},
+				state,
+			};
+			const rule =
+				"Plan mode is active. You MUST perform READ-ONLY work only:\n- You NEVER create, edit, or delete files — except the single plan file named below.";
+			const messages: AgentMessage[] = [];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			messages.push({ role: "user", content: "start planning", timestamp: 1 } as AgentMessage);
+			messages.push({
+				role: "custom",
+				customType: "plan-mode-context",
+				content: rule,
+				display: false,
+				timestamp: 2,
+			} as AgentMessage);
+			runtime.onTurnEnd();
+			await settleUntil(() => promptInputs.length >= 2 && runtime.backlog === 0);
+
+			expect(promptInputs).toHaveLength(2);
+			expect(promptText(promptInputs[0])).toContain("except the single plan file named below");
+			expect(promptText(promptInputs[1])).toContain("except the single plan file named below");
+			expect(promptText(promptInputs[1])).not.toContain("unchanged — still in effect");
 		});
 
 		it("renders the watched delta with a heading, watched-role labels, and no inner ## headings", async () => {
@@ -3088,7 +3135,11 @@ describe("advisor", () => {
 				) as AgentMessage;
 			};
 
-			const waitForPrompts = async (prompts: Array<string | AgentMessage[]>, count: number, timeoutMs = 10_000): Promise<void> => {
+			const waitForPrompts = async (
+				prompts: Array<string | AgentMessage[]>,
+				count: number,
+				timeoutMs = 10_000,
+			): Promise<void> => {
 				const deadline = Date.now() + timeoutMs;
 				while (prompts.length < count && Date.now() < deadline) await Bun.sleep(5);
 			};
@@ -3222,7 +3273,9 @@ describe("advisor", () => {
 				await waitForPrompts(promptInputs, 1);
 				// The aborted pre-reset render must not have advanced the cursor:
 				// the post-reset replay carries the whole transcript.
-				const replay = promptInputs.find(input => promptText(input).includes("msg-0 ") && promptText(input).includes("msg-399 "));
+				const replay = promptInputs.find(
+					input => promptText(input).includes("msg-0 ") && promptText(input).includes("msg-399 "),
+				);
 				expect(replay).toBeDefined();
 				runtime.dispose();
 			}, 20_000);
@@ -3248,7 +3301,14 @@ describe("advisor", () => {
 				messages.push({ role: "user", content: "late-arrival tail", timestamp: 300 } as AgentMessage);
 				runtime.onTurnEnd(messages);
 				const deadline = Date.now() + 10_000;
-				while (Date.now() < deadline && !promptInputs.map(i => promptText(i)).join("\n").includes("late-arrival tail")) await Bun.sleep(5);
+				while (
+					Date.now() < deadline &&
+					!promptInputs
+						.map(i => promptText(i))
+						.join("\n")
+						.includes("late-arrival tail")
+				)
+					await Bun.sleep(5);
 				const combined = promptInputs.map(i => promptText(i)).join("\n");
 				// Every message exactly once, ordering preserved.
 				expect(combined).toContain("msg-0 ");

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -1438,6 +1438,29 @@ describe("advisor", () => {
 			expect(promptText(promptInputs[0])).not.toContain(secret);
 		});
 
+		it("falls back to one redacted update when a regex secret spans source messages", async () => {
+			const obfuscator = new SecretObfuscator([{ type: "regex", content: "BEGIN[\\s\\S]*END" }]);
+			const promptInputs: Array<string | AgentMessage[]> = [];
+			const agent = makeAgent(promptInputs);
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "BEGIN", timestamp: 1 } as AgentMessage,
+				{ role: "user", content: "sensitive END", timestamp: 2 } as AgentMessage,
+			];
+			const runtime = new AdvisorRuntime(agent, {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				obfuscator,
+			});
+
+			runtime.onTurnEnd(messages);
+			await Promise.resolve();
+
+			expect(promptInputs).toHaveLength(1);
+			expect(typeof promptInputs[0]).toBe("string");
+			expect(promptText(promptInputs[0]!)).not.toContain("BEGIN");
+			expect(promptText(promptInputs[0]!)).not.toContain("sensitive END");
+		});
+
 		it("redacts expanded primary context before XML escaping", async () => {
 			const secret = "ADVISOR&SECRET<TOKEN>123";
 			const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
@@ -2581,6 +2604,78 @@ describe("advisor", () => {
 			expect(resetCount).toBe(1);
 		});
 
+		it("re-renders a queued primary context before its maintenance budget after overflow resets advisor context", async () => {
+			const overflowMessage = "context_length_exceeded: Your input exceeds the context window of this model.";
+			const firstOverflowPromptStarted = Promise.withResolvers<void>();
+			const releaseOverflowPrompt = Promise.withResolvers<void>();
+			const fourthMaintenance = Promise.withResolvers<void>();
+			const maintenanceTokens: number[] = [];
+			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
+			let promptCalls = 0;
+			const agent: AdvisorAgent = {
+				prompt: async () => {
+					promptCalls++;
+					if (promptCalls === 2) {
+						firstOverflowPromptStarted.resolve();
+						await releaseOverflowPrompt.promise;
+						state.error = overflowMessage;
+					} else {
+						state.error = undefined;
+					}
+				},
+				abort: () => {},
+				reset: () => {
+					state.messages.length = 0;
+					state.error = undefined;
+				},
+				state,
+			};
+			const planRule = "keep-expanded ".repeat(300);
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "seed", timestamp: 1 } as AgentMessage,
+				{
+					role: "custom",
+					customType: "plan-mode-context",
+					content: planRule,
+					display: false,
+					timestamp: 2,
+				} as AgentMessage,
+			];
+			const runtime = new AdvisorRuntime(
+				agent,
+				{
+					snapshotMessages: () => messages,
+					enqueueAdvice: () => {},
+					maintainContext: async incomingTokens => {
+						maintenanceTokens.push(incomingTokens);
+						if (maintenanceTokens.length === 4) fourthMaintenance.resolve();
+						return false;
+					},
+				},
+				0,
+			);
+			runtime.onTurnEnd(messages);
+			await settleUntil(() => promptCalls === 1 && runtime.backlog === 0);
+
+			messages.push({ role: "user", content: "overflow", timestamp: 3 } as AgentMessage);
+			runtime.onTurnEnd(messages);
+			await firstOverflowPromptStarted.promise;
+			messages.push({ role: "user", content: "after overflow", timestamp: 4 } as AgentMessage);
+			messages.push({
+				role: "custom",
+				customType: "plan-mode-context",
+				content: planRule,
+				display: false,
+				timestamp: 5,
+			} as AgentMessage);
+			runtime.onTurnEnd(messages);
+			releaseOverflowPrompt.resolve();
+			await fourthMaintenance.promise;
+
+			expect(maintenanceTokens).toHaveLength(4);
+			expect(maintenanceTokens[3]).toBeGreaterThan(500);
+		});
+
 		it("does not double-fold first-time primary context on overflow-recovery retry", async () => {
 			// Regression: the recovery render previews the retry batch; if it advances
 			// #seenContext, the retry's #prepareBatch re-dedup would collapse first-time
@@ -2612,7 +2707,6 @@ describe("advisor", () => {
 			};
 			const runtime = new AdvisorRuntime(agent, host, 0);
 			runtime.seedTo(messages.length);
-
 			const rule =
 				"Plan mode is active. You MUST perform READ-ONLY work only:\n- You NEVER create, edit, or delete files — except the single plan file named below.";
 			messages.push({ role: "user", content: "overflowing-current-update", timestamp: 2 } as AgentMessage);
@@ -4366,6 +4460,53 @@ describe("advisor", () => {
 			await settleUntil(() => runtime.backlog === 0);
 			expect(promptInputs).toHaveLength(2);
 			expect(promptText(promptInputs[1])).toContain("keep me");
+		});
+
+		it("re-expands first-time primary context after a session transition pauses before dispatch", async () => {
+			const promptInputs: Array<string | AgentMessage[]> = [];
+			const planRule = "Plan mode is active. Keep this first delivery expanded.";
+			const maintenancePaused = Promise.withResolvers<void>();
+			const prompted = Promise.withResolvers<void>();
+			let maintenanceCalls = 0;
+			let runtime: AdvisorRuntime;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+					prompted.resolve();
+				},
+				abort: () => {},
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "start planning", timestamp: 1 } as AgentMessage,
+				{
+					role: "custom",
+					customType: "plan-mode-context",
+					content: planRule,
+					display: false,
+					timestamp: 2,
+				} as AgentMessage,
+			];
+			runtime = new AdvisorRuntime(agent, {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				maintainContext: async () => {
+					if (++maintenanceCalls === 1) {
+						void runtime.pauseForSessionTransition();
+						maintenancePaused.resolve();
+					}
+					return false;
+				},
+			});
+
+			runtime.onTurnEnd(messages);
+			await maintenancePaused.promise;
+			runtime.resumeAfterSessionTransition();
+			await prompted.promise;
+
+			expect(promptText(promptInputs[0]!)).toContain(planRule);
+			expect(promptText(promptInputs[0]!)).not.toContain("unchanged — still in effect");
 		});
 
 		it.each(["success", "error"] as const)(

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -43,6 +43,18 @@ async function settleUntil(predicate: () => boolean, timeoutMs = 2_000): Promise
 	while (!predicate() && Date.now() < deadline) await Bun.sleep(2);
 }
 
+function promptText(input: string | AgentMessage[]): string {
+	if (typeof input === "string") return input;
+	return input
+		.map(m => {
+			const c = (m as { content?: unknown }).content;
+			if (typeof c === "string") return c;
+			if (Array.isArray(c)) return c.map((b: unknown) => (b as { text?: string }).text ?? "").join("\n");
+			return String(m);
+		})
+		.join("\n");
+}
+
 describe("advisor", () => {
 	describe("advisor system prompt", () => {
 		it("forbids concrete claims about tool arguments hidden from the advisor transcript", () => {
@@ -863,7 +875,7 @@ describe("advisor", () => {
 	});
 
 	describe("AdvisorRuntime", () => {
-		function makeAgent(promptInputs: string[]): AdvisorAgent {
+		function makeAgent(promptInputs: Array<string | AgentMessage[]>): AdvisorAgent {
 			return {
 				prompt: async input => {
 					promptInputs.push(input);
@@ -875,7 +887,7 @@ describe("advisor", () => {
 		}
 
 		it("coalesces multiple onTurnEnd calls while a prompt is in-flight", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: firstPromptPromise, resolve: finishFirstPrompt } = Promise.withResolvers<void>();
 			const { promise: secondPromptDone, resolve: finishSecondPrompt } = Promise.withResolvers<void>();
 			let promptCalls = 0;
@@ -900,7 +912,7 @@ describe("advisor", () => {
 			runtime.onTurnEnd();
 			await Promise.resolve();
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("first");
+			expect(promptText(promptInputs[0])).toContain("first");
 
 			messages.push({ role: "user", content: "second", timestamp: 2 } as AgentMessage);
 			runtime.onTurnEnd();
@@ -910,7 +922,7 @@ describe("advisor", () => {
 			finishFirstPrompt();
 			await secondPromptDone;
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[1]).toContain("second");
+			expect(promptText(promptInputs[1])).toContain("second");
 		});
 
 		it("waits for an in-flight review within the catch-up deadline", async () => {
@@ -973,7 +985,7 @@ describe("advisor", () => {
 		});
 
 		it("preserves the next user turn when an accepted empty stop is pruned", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{ role: "user", content: "synthetic capture", synthetic: true, timestamp: 1 } as AgentMessage,
@@ -1017,14 +1029,14 @@ describe("advisor", () => {
 			runtime.onTurnEnd(messages);
 			await runtime.waitForCatchup(1000, 1);
 
-			const nextTurn = promptInputs.at(-1);
+			const nextTurn = promptText(promptInputs.at(-1) as string | AgentMessage[]);
 			expect(nextTurn).toContain("real user instruction");
 			expect(nextTurn?.match(/real user instruction/g)).toHaveLength(1);
 			expect(nextTurn?.indexOf("real user instruction")).toBeLessThan(nextTurn?.indexOf("checking files") ?? -1);
 		});
 
 		it("coalesces late-arriving deltas into the batch after context maintenance", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: firstMaintainStarted, resolve: startFirstMaintain } = Promise.withResolvers<void>();
 			const { promise: finishFirstMaintain, resolve: releaseFirstMaintain } = Promise.withResolvers<boolean>();
 			const { promise: promptStarted, resolve: startPrompt } = Promise.withResolvers<void>();
@@ -1065,8 +1077,8 @@ describe("advisor", () => {
 
 			// Both deltas land in a single prompt — late arrival coalesced before agent.prompt().
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("first");
-			expect(promptInputs[0]).toContain("second");
+			expect(promptText(promptInputs[0])).toContain("first");
+			expect(promptText(promptInputs[0])).toContain("second");
 			// The loop re-checked maintenance for the expanded batch.
 			expect(maintainCalls).toBe(2);
 		});
@@ -1075,7 +1087,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+", mode: "replace" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: firstMaintainStarted, resolve: startFirstMaintain } = Promise.withResolvers<void>();
 			const { promise: finishFirstMaintain, resolve: releaseFirstMaintain } = Promise.withResolvers<boolean>();
 			const { promise: promptStarted, resolve: startPrompt } = Promise.withResolvers<void>();
@@ -1117,8 +1129,8 @@ describe("advisor", () => {
 			await promptStarted;
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).not.toContain("TOKABC123_");
-			expect(promptInputs[0]).not.toContain("tok_abc123");
+			expect(promptText(promptInputs[0])).not.toContain("TOKABC123_");
+			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 		});
 
 		it("caps maintainContext calls per drain cycle when arrivals never go stable", async () => {
@@ -1126,7 +1138,7 @@ describe("advisor", () => {
 			// each maintainContext call pushes a new turn (queue never goes stable on its
 			// own). After exactly 3 calls the cap must stop coalescing, dispatch the
 			// budgeted batch, and defer the final-round arrival to the next iteration.
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: promptStarted, resolve: startPrompt } = Promise.withResolvers<void>();
 			let maintainCalls = 0;
 			let runtime!: AdvisorRuntime;
@@ -1173,7 +1185,7 @@ describe("advisor", () => {
 		});
 
 		it("late-arriving delta that triggers reprime: full replay and correct turn accounting", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: firstMaintainStarted, resolve: startFirstMaintain } = Promise.withResolvers<void>();
 			const { promise: finishFirstMaintain, resolve: releaseFirstMaintain } = Promise.withResolvers<boolean>();
 			const { promise: promptStarted, resolve: startPrompt } = Promise.withResolvers<void>();
@@ -1217,8 +1229,8 @@ describe("advisor", () => {
 
 			// Full replay includes both turns.
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("turn1");
-			expect(promptInputs[0]).toContain("turn2");
+			expect(promptText(promptInputs[0])).toContain("turn1");
+			expect(promptText(promptInputs[0])).toContain("turn2");
 			// Reprime resets the advisor agent.
 			expect(resetCount).toBeGreaterThan(0);
 		});
@@ -1289,7 +1301,7 @@ describe("advisor", () => {
 		});
 
 		it("tags in-progress turns with [in progress] heading", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const updateStates: boolean[] = [];
 			const { promise: promptStarted, resolve: startPrompt } = Promise.withResolvers<void>();
 			const agent: AdvisorAgent = {
@@ -1313,12 +1325,12 @@ describe("advisor", () => {
 			await promptStarted;
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("[in progress — more steps follow]");
+			expect(promptText(promptInputs[0])).toContain("[in progress — more steps follow]");
 			expect(updateStates).toEqual([true]);
 		});
 
 		it("uses plain heading when willContinue is false or absent", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const updateStates: boolean[] = [];
 			const { promise: promptStarted, resolve: startPrompt } = Promise.withResolvers<void>();
 			const agent: AdvisorAgent = {
@@ -1342,13 +1354,13 @@ describe("advisor", () => {
 			await promptStarted;
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("### Session update\n");
-			expect(promptInputs[0]).not.toContain("[in progress");
+			expect(promptText(promptInputs[0])).toContain("### Session update\n");
+			expect(promptText(promptInputs[0])).not.toContain("[in progress");
 			expect(updateStates).toEqual([false]);
 		});
 
 		it("sends the batch when context maintenance fails", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: promptStarted, resolve: startPrompt } = Promise.withResolvers<void>();
 			const agent: AdvisorAgent = {
 				prompt: async input => {
@@ -1373,11 +1385,11 @@ describe("advisor", () => {
 			await promptStarted;
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("first");
+			expect(promptText(promptInputs[0])).toContain("first");
 		});
 
 		it("excludes advisor custom messages from the rendered delta", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: promptStarted, resolve: startPrompt } = Promise.withResolvers<void>();
 			const agent: AdvisorAgent = {
 				prompt: async input => {
@@ -1400,15 +1412,15 @@ describe("advisor", () => {
 			runtime.onTurnEnd();
 			await promptStarted;
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("hello");
-			expect(promptInputs[0]).not.toContain("note");
+			expect(promptText(promptInputs[0])).toContain("hello");
+			expect(promptText(promptInputs[0])).not.toContain("note");
 		});
 
 		it("obfuscates session updates before prompting the advisor", async () => {
 			const secret = "ADVISOR_SECRET_TOKEN_123";
 			const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
 			const placeholder = obfuscator.obfuscate(secret);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [{ role: "user", content: `token ${secret}`, timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
@@ -1422,15 +1434,15 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain(placeholder);
-			expect(promptInputs[0]).not.toContain(secret);
+			expect(promptText(promptInputs[0])).toContain(placeholder);
+			expect(promptText(promptInputs[0])).not.toContain(secret);
 		});
 
 		it("redacts expanded primary context before XML escaping", async () => {
 			const secret = "ADVISOR&SECRET<TOKEN>123";
 			const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
 			const placeholder = obfuscator.obfuscate(secret);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{
@@ -1452,16 +1464,16 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain(placeholder);
-			expect(promptInputs[0]).not.toContain(secret);
-			expect(promptInputs[0]).not.toContain("ADVISOR&amp;SECRET&lt;TOKEN&gt;123");
+			expect(promptText(promptInputs[0])).toContain(placeholder);
+			expect(promptText(promptInputs[0])).not.toContain(secret);
+			expect(promptText(promptInputs[0])).not.toContain("ADVISOR&amp;SECRET&lt;TOKEN&gt;123");
 		});
 
 		it("redacts file-mention paths before formatting", async () => {
 			const secret = "MENTION_SECRET_TOKEN_123";
 			const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
 			const placeholder = obfuscator.obfuscate(secret);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{
@@ -1481,15 +1493,15 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain(placeholder);
-			expect(promptInputs[0]).not.toContain(secret);
+			expect(promptText(promptInputs[0])).toContain(placeholder);
+			expect(promptText(promptInputs[0])).not.toContain(secret);
 		});
 
 		it("redacts nested async-result job labels before formatting", async () => {
 			const secret = "JOB_LABEL_SECRET_TOKEN_123";
 			const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
 			const placeholder = obfuscator.obfuscate(secret);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{
@@ -1513,15 +1525,15 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain(placeholder);
-			expect(promptInputs[0]).not.toContain(secret);
+			expect(promptText(promptInputs[0])).toContain(placeholder);
+			expect(promptText(promptInputs[0])).not.toContain(secret);
 		});
 
 		it("surfaces edit diff details but redacts secrets inside the diff", async () => {
 			const secret = "DIFF_SECRET_TOKEN_123";
 			const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
 			const placeholder = obfuscator.obfuscate(secret);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const diff = `--- a/config.ts\n+++ b/config.ts\n@@ -1 +1 @@\n-const token = "old";\n+const token = "${secret}";`;
 			const messages: AgentMessage[] = [
@@ -1551,10 +1563,10 @@ describe("advisor", () => {
 
 			expect(promptInputs).toHaveLength(1);
 			// The diff is surfaced to the advisor (expandEditDiffs) ...
-			expect(promptInputs[0]).toContain("+const token =");
+			expect(promptText(promptInputs[0])).toContain("+const token =");
 			// ... but a secret living inside details.diff is obfuscated (details now walked).
-			expect(promptInputs[0]).toContain(placeholder);
-			expect(promptInputs[0]).not.toContain(secret);
+			expect(promptText(promptInputs[0])).toContain(placeholder);
+			expect(promptText(promptInputs[0])).not.toContain(secret);
 		});
 
 		it("does not scan tool details omitted from advisor history", async () => {
@@ -1562,7 +1574,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{ role: "user", content: "remember OTHERSECRET for later", timestamp: 1 } as AgentMessage,
@@ -1591,15 +1603,15 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("$$TOKABC123_");
-			expect(promptInputs[0]).not.toContain("tok_abc123");
+			expect(promptText(promptInputs[0])).toContain("$$TOKABC123_");
+			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 		});
 		it("does not scan advisor-hidden successful tool-result bodies", async () => {
 			const obfuscator = new SecretObfuscator([
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{ role: "user", content: "remember OTHERSECRET for later", timestamp: 1 } as AgentMessage,
@@ -1623,15 +1635,15 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("$$TOKABC123_");
-			expect(promptInputs[0]).not.toContain("tok_abc123");
+			expect(promptText(promptInputs[0])).toContain("$$TOKABC123_");
+			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 		});
 		it("does not scan tool-call arguments hidden by the primary-argument preview", async () => {
 			const obfuscator = new SecretObfuscator([
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+", mode: "replace" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{ role: "user", content: "remember OTHERSECRET", timestamp: 1 } as AgentMessage,
@@ -1650,8 +1662,8 @@ describe("advisor", () => {
 			});
 			runtime.onTurnEnd();
 			await runtime.waitForCatchup(1000, 1);
-			expect(promptInputs[0]).toContain("$$TOKABC123_");
-			expect(promptInputs[0]).not.toContain("tok_abc123");
+			expect(promptText(promptInputs[0])).toContain("$$TOKABC123_");
+			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 		});
 
 		it("does not scan failed tool-result text beyond its visible preview", async () => {
@@ -1659,7 +1671,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+", mode: "replace" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{ role: "user", content: "remember OTHERSECRET", timestamp: 1 } as AgentMessage,
@@ -1679,8 +1691,8 @@ describe("advisor", () => {
 			});
 			runtime.onTurnEnd();
 			await runtime.waitForCatchup(1000, 1);
-			expect(promptInputs[0]).toContain("$$TOKABC123_");
-			expect(promptInputs[0]).not.toContain("tok_abc123");
+			expect(promptText(promptInputs[0])).toContain("$$TOKABC123_");
+			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 		});
 
 		it("does not scan advisor-hidden execution output", async () => {
@@ -1688,7 +1700,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{ role: "user", content: "remember OTHERSECRET for later", timestamp: 1 } as AgentMessage,
@@ -1718,15 +1730,15 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("$$TOKABC123_");
-			expect(promptInputs[0]).not.toContain("tok_abc123");
+			expect(promptText(promptInputs[0])).toContain("$$TOKABC123_");
+			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 		});
 		it("does not scan execution source after the advisor preview cap", async () => {
 			const obfuscator = new SecretObfuscator([
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const hiddenSuffix = `${"x".repeat(120)} tok_abc123`;
 			const messages: AgentMessage[] = [
@@ -1755,8 +1767,8 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("$$TOKABC123_");
-			expect(promptInputs[0]).not.toContain("tok_abc123");
+			expect(promptText(promptInputs[0])).toContain("$$TOKABC123_");
+			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 		});
 
 		it("does not scan advisor-hidden file mention content", async () => {
@@ -1764,7 +1776,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const obfuscate = vi.spyOn(obfuscator, "obfuscate");
 			const messages: AgentMessage[] = [
@@ -1786,8 +1798,8 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("$$TOKABC123_");
-			expect(promptInputs[0]).not.toContain("tok_abc123");
+			expect(promptText(promptInputs[0])).toContain("$$TOKABC123_");
+			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 			expect(obfuscate).not.toHaveBeenCalledWith("tok_abc123", expect.anything());
 		});
 
@@ -1796,7 +1808,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const obfuscate = vi.spyOn(obfuscator, "obfuscate");
 			const messages: AgentMessage[] = [
@@ -1821,8 +1833,8 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("$$TOKABC123_");
-			expect(promptInputs[0]).not.toContain("tok_abc123");
+			expect(promptText(promptInputs[0])).toContain("$$TOKABC123_");
+			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
 			expect(obfuscate).not.toHaveBeenCalledWith("tok_abc123", expect.anything());
 		});
 
@@ -1843,7 +1855,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const diff = `--- a/config.ts\n+++ b/config.ts\n@@ -1 +1 @@\n-const token = "old";\n+const token = "tok_abc123";`;
 			const messages: AgentMessage[] = [
@@ -1873,7 +1885,7 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			const prompt = promptInputs[0]!;
+			const prompt = promptText(promptInputs[0]!);
 			expect(prompt).not.toContain("OTHERSECRET");
 			expect(prompt).not.toContain("tok_abc123");
 			// The friendly prefix is itself a normalized rendering of the
@@ -1894,7 +1906,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+", mode: "replace" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [{ role: "user", content: "first tok_abc123", timestamp: 1 } as AgentMessage];
 			const host: AdvisorRuntimeHost = {
@@ -1911,9 +1923,9 @@ describe("advisor", () => {
 			await runtime.waitForCatchup(1000, 1);
 
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[0]).not.toContain("tok_abc123");
-			expect(promptInputs[1]).not.toContain("OTHERSECRET");
-			expect(promptInputs[1]).not.toContain("TOKABC123_");
+			expect(promptText(promptInputs[0])).not.toContain("tok_abc123");
+			expect(promptText(promptInputs[1])).not.toContain("OTHERSECRET");
+			expect(promptText(promptInputs[1])).not.toContain("TOKABC123_");
 		});
 
 		it("scrubs prior advisor prompts when a later replace regex collides with their friendly prefix", async () => {
@@ -1921,14 +1933,17 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+", mode: "replace" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const firstStoredPrompt = (): string => {
 				const message = agent.state.messages[0];
-				if (message?.role !== "user" || !("content" in message) || typeof message.content !== "string") {
+				if (message?.role !== "user" || !("content" in message)) {
 					throw new Error("Expected the first advisor history item to be a user prompt");
 				}
-				return message.content;
+				const c = (message as { content?: unknown }).content;
+				if (typeof c === "string") return c;
+				if (Array.isArray(c)) return c.map((b: unknown) => (b as { text?: string }).text ?? "").join("\n");
+				throw new Error("Unexpected content shape");
 			};
 			const messages: AgentMessage[] = [
 				{ role: "user", content: "remember OTHERSECRET", timestamp: 1 } as AgentMessage,
@@ -1942,7 +1957,7 @@ describe("advisor", () => {
 
 			runtime.onTurnEnd();
 			await runtime.waitForCatchup(1000, 1);
-			agent.state.messages.push({ role: "user", content: promptInputs[0]!, timestamp: 1 } as AgentMessage);
+			agent.state.messages.push({ role: "user", content: promptText(promptInputs[0]!), timestamp: 1 } as AgentMessage);
 			expect(firstStoredPrompt()).toContain("TOKABC123_");
 
 			messages.push({ role: "user", content: "later tok_abc123", timestamp: 2 } as AgentMessage);
@@ -1951,7 +1966,7 @@ describe("advisor", () => {
 
 			expect(promptInputs).toHaveLength(2);
 			expect(firstStoredPrompt()).not.toContain("TOKABC123_");
-			expect(promptInputs[1]).not.toContain("TOKABC123_");
+			expect(promptText(promptInputs[1])).not.toContain("TOKABC123_");
 		});
 
 		it("redacts secrets inside assistant thinking blocks, honoring the whole-delta friendly-prefix collision set", async () => {
@@ -1967,7 +1982,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const diff = `--- a/config.ts\n+++ b/config.ts\n@@ -1 +1 @@\n-const token = "old";\n+const token = "tok_abc123";`;
 			const messages: AgentMessage[] = [
@@ -1999,7 +2014,7 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			const prompt = promptInputs[0]!;
+			const prompt = promptText(promptInputs[0]!);
 			expect(prompt).toContain("_thinking:_");
 			expect(prompt).not.toContain("OTHERSECRET");
 			expect(prompt).not.toContain("tok_abc123");
@@ -2016,7 +2031,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const staleThinking = obfuscator.obfuscate("OTHERSECRET");
 			agent.state.messages.push({
@@ -2056,7 +2071,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{ role: "user", content: "remember OTHERSECRET for later", timestamp: 1 } as AgentMessage,
@@ -2077,7 +2092,7 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			const prompt = promptInputs[0]!;
+			const prompt = promptText(promptInputs[0]!);
 			expect(prompt).not.toContain("OTHERSECRET");
 			// Because the image bytes were skipped by the collision pre-scan, the
 			// plain secret's friendly-name placeholder needed no collision avoidance.
@@ -2089,7 +2104,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{
@@ -2110,7 +2125,7 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			const prompt = promptInputs[0]!;
+			const prompt = promptText(promptInputs[0]!);
 			expect(prompt).not.toContain("OTHERSECRET");
 			expect(prompt).not.toContain("tok_abc123");
 			expect(prompt).toContain("TOKABC123_");
@@ -2121,7 +2136,7 @@ describe("advisor", () => {
 				{ type: "plain", content: "OTHERSECRET", friendlyName: "TOKABC123" },
 				{ type: "regex", content: "tok_[a-z0-9]+" },
 			]);
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{ role: "user", content: "remember OTHERSECRET for later", timestamp: 1 } as AgentMessage,
@@ -2144,14 +2159,14 @@ describe("advisor", () => {
 			await Promise.resolve();
 
 			expect(promptInputs).toHaveLength(1);
-			const prompt = promptInputs[0]!;
+			const prompt = promptText(promptInputs[0]!);
 			expect(prompt).not.toContain("OTHERSECRET");
 			expect(prompt).not.toContain("tok_abc123");
 			expect(prompt).toContain("TOKABC123_");
 		});
 
 		it("expands plan-mode context once, then collapses an unchanged re-injection", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: firstPromptDone, resolve: finishFirst } = Promise.withResolvers<void>();
 			const { promise: secondPromptDone, resolve: finishSecond } = Promise.withResolvers<void>();
 			let promptCalls = 0;
@@ -2187,8 +2202,8 @@ describe("advisor", () => {
 			await firstPromptDone;
 
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain('<primary-context kind="plan-mode-context">');
-			expect(promptInputs[0]).toContain("except the single plan file named below");
+			expect(promptText(promptInputs[0])).toContain('<primary-context kind="plan-mode-context">');
+			expect(promptText(promptInputs[0])).toContain("except the single plan file named below");
 
 			// A later turn re-injects the byte-identical rule as a fresh message object.
 			messages.push({
@@ -2207,12 +2222,12 @@ describe("advisor", () => {
 			await secondPromptDone;
 
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[1]).toContain("unchanged — still in effect");
-			expect(promptInputs[1]).not.toContain("except the single plan file named below");
+			expect(promptText(promptInputs[1])).toContain("unchanged — still in effect");
+			expect(promptText(promptInputs[1])).not.toContain("except the single plan file named below");
 		});
 
 		it("renders the watched delta with a heading, watched-role labels, and no inner ## headings", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const messages: AgentMessage[] = [
 				{ role: "user", content: "do the thing", timestamp: 1 } as AgentMessage,
@@ -2251,7 +2266,7 @@ describe("advisor", () => {
 			runtime.onTurnEnd();
 			await Promise.resolve();
 			expect(promptInputs).toHaveLength(1);
-			const prompt = promptInputs[0];
+			const prompt = promptText(promptInputs[0]);
 			expect(prompt).toContain("### Session update");
 			expect(prompt).toContain("**user**:");
 			expect(prompt).toContain("**agent**:");
@@ -2263,7 +2278,7 @@ describe("advisor", () => {
 		});
 
 		it("handles compaction shrink without prompting", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			let messages: AgentMessage[] = [
 				{ role: "user", content: "a", timestamp: 1 } as AgentMessage,
@@ -2284,7 +2299,7 @@ describe("advisor", () => {
 		});
 
 		it("reset re-primes the advisor with the full current transcript", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: secondPromptDone, resolve: finishSecond } = Promise.withResolvers<void>();
 			let promptCalls = 0;
 			const agent: AdvisorAgent = {
@@ -2306,7 +2321,7 @@ describe("advisor", () => {
 			runtime.onTurnEnd();
 			await Promise.resolve();
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("aaa");
+			expect(promptText(promptInputs[0])).toContain("aaa");
 
 			// Simulate a compaction: transcript replaced, then reset.
 			messages.length = 0;
@@ -2317,11 +2332,11 @@ describe("advisor", () => {
 			await secondPromptDone;
 			// The next turn replays the full post-compaction transcript, not just new tail.
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[1]).toContain("summary-bbb");
+			expect(promptText(promptInputs[1])).toContain("summary-bbb");
 		});
 
 		it("clears advisor context without replaying primary history when maintenance requests recovery", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: firstPromptDone, resolve: finishFirst } = Promise.withResolvers<void>();
 			const { promise: secondPromptDone, resolve: finishSecond } = Promise.withResolvers<void>();
 			let promptCalls = 0;
@@ -2354,7 +2369,7 @@ describe("advisor", () => {
 			runtime.onTurnEnd(messages);
 			await firstPromptDone;
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("aaa");
+			expect(promptText(promptInputs[0])).toContain("aaa");
 			expect(resetCount).toBe(0);
 
 			shouldResetContext = true;
@@ -2363,13 +2378,13 @@ describe("advisor", () => {
 			await secondPromptDone;
 
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[1]).toContain("bbb");
-			expect(promptInputs[1]).not.toContain("aaa");
+			expect(promptText(promptInputs[1])).toContain("bbb");
+			expect(promptText(promptInputs[1])).not.toContain("aaa");
 			expect(resetCount).toBe(1);
 		});
 
 		it("preserves updates queued while async maintenance resets the advisor context", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			let resetCount = 0;
 			const agent: AdvisorAgent = {
 				prompt: async input => {
@@ -2405,15 +2420,15 @@ describe("advisor", () => {
 			await runtime.waitForCatchup(1000, 1);
 
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[0]).toContain("bbb");
-			expect(promptInputs[0]).not.toContain("ccc");
-			expect(promptInputs[1]).toContain("ccc");
-			expect(promptInputs[1]).not.toContain("bbb");
+			expect(promptText(promptInputs[0])).toContain("bbb");
+			expect(promptText(promptInputs[0])).not.toContain("ccc");
+			expect(promptText(promptInputs[1])).toContain("ccc");
+			expect(promptText(promptInputs[1])).not.toContain("bbb");
 			expect(resetCount).toBe(1);
 		});
 
 		it("re-expands active primary context when maintenance clears advisor history", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent = makeAgent(promptInputs);
 			const planRule =
 				"Plan mode is active. You MUST remain read-only except for the approved plan file at local://PLAN.md.";
@@ -2437,7 +2452,7 @@ describe("advisor", () => {
 
 			runtime.onTurnEnd(messages);
 			await runtime.waitForCatchup(1000, 1);
-			expect(promptInputs[0]).toContain(planRule);
+			expect(promptText(promptInputs[0])).toContain(planRule);
 
 			shouldResetContext = true;
 			messages.push({ role: "user", content: "bbb", timestamp: 3 } as AgentMessage);
@@ -2452,15 +2467,15 @@ describe("advisor", () => {
 			await runtime.waitForCatchup(1000, 1);
 
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[1]).toContain("bbb");
-			expect(promptInputs[1]).not.toContain("aaa");
-			expect(promptInputs[1]).toContain(planRule);
-			expect(promptInputs[1]).not.toContain("unchanged — still in effect");
+			expect(promptText(promptInputs[1])).toContain("bbb");
+			expect(promptText(promptInputs[1])).not.toContain("aaa");
+			expect(promptText(promptInputs[1])).toContain(planRule);
+			expect(promptText(promptInputs[1])).not.toContain("unchanged — still in effect");
 		});
 
 		it("recovers a provider overflow at the current cursor without replaying primary history", async () => {
 			const overflowMessage = "context_length_exceeded: Your input exceeds the context window of this model.";
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const state: { messages: AgentMessage[]; error?: string } = {
 				messages: [{ role: "user", content: "existing advisor context", timestamp: 1 } as AgentMessage],
 			};
@@ -2501,7 +2516,7 @@ describe("advisor", () => {
 
 			expect(promptInputs).toHaveLength(2);
 			for (const input of promptInputs) {
-				expect(input).toContain("overflowing-current-update");
+				expect(promptText(input)).toContain("overflowing-current-update");
 				expect(input).not.toContain("ancient-primary-one");
 				expect(input).not.toContain("ancient-primary-two");
 			}
@@ -2512,15 +2527,15 @@ describe("advisor", () => {
 			await settleUntil(() => promptInputs.length >= 3 && runtime.backlog === 0);
 
 			expect(promptInputs).toHaveLength(3);
-			expect(promptInputs[2]).toContain("post-recovery-update");
-			expect(promptInputs[2]).not.toContain("overflowing-current-update");
-			expect(promptInputs[2]).not.toContain("ancient-primary-one");
-			expect(promptInputs[2]).not.toContain("ancient-primary-two");
+			expect(promptText(promptInputs[2])).toContain("post-recovery-update");
+			expect(promptText(promptInputs[2])).not.toContain("overflowing-current-update");
+			expect(promptText(promptInputs[2])).not.toContain("ancient-primary-one");
+			expect(promptText(promptInputs[2])).not.toContain("ancient-primary-two");
 			expect(resetCount).toBe(1);
 		});
 
 		it("classifies structured overflow metadata before rolling back the failed turn", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const state: { messages: AgentMessage[]; error?: string } = {
 				messages: [{ role: "user", content: "existing advisor context", timestamp: 1 } as AgentMessage],
 			};
@@ -2584,7 +2599,7 @@ describe("advisor", () => {
 
 			expect(promptInputs).toHaveLength(2);
 			for (const input of promptInputs) {
-				expect(input).toContain("structured-current-update");
+				expect(promptText(input)).toContain("structured-current-update");
 				expect(input).not.toContain("ancient-primary");
 			}
 			expect(resetCount).toBe(1);
@@ -2592,7 +2607,7 @@ describe("advisor", () => {
 
 		it("drops only a double-overflowing batch and continues queued and later updates", async () => {
 			const overflowMessage = "context_length_exceeded: Your input exceeds the context window of this model.";
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const failures: unknown[] = [];
 			const secondAttemptStarted = Promise.withResolvers<void>();
 			const finishSecondAttempt = Promise.withResolvers<void>();
@@ -2603,7 +2618,7 @@ describe("advisor", () => {
 			const agent: AdvisorAgent = {
 				prompt: async input => {
 					promptInputs.push(input);
-					if (!input.includes("first-overflow")) {
+					if (!promptText(input).includes("first-overflow")) {
 						state.error = undefined;
 						return;
 					}
@@ -2642,12 +2657,12 @@ describe("advisor", () => {
 			expect(failingAttempts).toBe(2);
 			expect(promptInputs).toHaveLength(3);
 			for (const input of promptInputs.slice(0, 2)) {
-				expect(input).toContain("first-overflow");
-				expect(input).not.toContain("ancient-history");
+				expect(promptText(input)).toContain("first-overflow");
+				expect(promptText(input)).not.toContain("ancient-history");
 			}
-			expect(promptInputs[2]).toContain("queued-small-update");
-			expect(promptInputs[2]).not.toContain("first-overflow");
-			expect(promptInputs[2]).not.toContain("ancient-history");
+			expect(promptText(promptInputs[2])).toContain("queued-small-update");
+			expect(promptText(promptInputs[2])).not.toContain("first-overflow");
+			expect(promptText(promptInputs[2])).not.toContain("ancient-history");
 			expect(failures).toHaveLength(1);
 			expect(runtime.backlog).toBe(0);
 
@@ -2656,11 +2671,11 @@ describe("advisor", () => {
 			await runtime.waitForCatchup(1000, 1);
 
 			expect(promptInputs).toHaveLength(4);
-			expect(promptInputs[3]).toContain("later-small-update");
-			expect(promptInputs[3]).not.toContain("first-overflow");
+			expect(promptText(promptInputs[3])).toContain("later-small-update");
+			expect(promptText(promptInputs[3])).not.toContain("first-overflow");
 		});
 		it("tracks backlog and blocks until caught up", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: promptStarted, resolve: startPrompt } = Promise.withResolvers<void>();
 			const { promise: promptFinish, resolve: finishPrompt } = Promise.withResolvers<void>();
 			const agent: AdvisorAgent = {
@@ -2755,7 +2770,7 @@ describe("advisor", () => {
 		});
 
 		it("retries failed prompts and only decrements backlog on success", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			let fail = true;
 			const agent: AdvisorAgent = {
 				prompt: async input => {
@@ -2785,7 +2800,7 @@ describe("advisor", () => {
 		});
 
 		it("drops backlog after 3 consecutive failures to prevent permanent stall", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent: AdvisorAgent = {
 				prompt: async input => {
 					promptInputs.push(input);
@@ -2812,7 +2827,7 @@ describe("advisor", () => {
 		});
 
 		it("notifies the host once when consecutive prompt failures make the advisor unavailable", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const failures: unknown[] = [];
 			let shouldFail = true;
 			const agent: AdvisorAgent = {
@@ -2876,7 +2891,7 @@ describe("advisor", () => {
 			// model outright ("not supported ... (code=invalid_request_error)")
 			// failed 351 turns/hour in a shared daemon, rebuilding heavy context
 			// every cycle. One drop cycle must latch the runtime off.
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const failures: unknown[] = [];
 			const agent: AdvisorAgent = {
 				prompt: async input => {
@@ -2923,7 +2938,7 @@ describe("advisor", () => {
 		});
 
 		it("halts after three transient drop cycles without an intervening success, but not across successes", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			let shouldFail = true;
 			const agent: AdvisorAgent = {
 				prompt: async input => {
@@ -3011,7 +3026,7 @@ describe("advisor", () => {
 			// formatter bug) must neither propagate into the primary agent's
 			// turn-end callback nor park it on the catch-up gate — and the
 			// unrendered delta must survive for the next turn.
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent: AdvisorAgent = {
 				prompt: async input => {
 					promptInputs.push(input);
@@ -3053,8 +3068,8 @@ describe("advisor", () => {
 			runtime.onTurnEnd(messages);
 			await settleUntil(() => promptInputs.length >= 2);
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[1]).toContain("bbb-recovered");
-			expect(promptInputs[1]).toContain("ccc");
+			expect(promptText(promptInputs[1])).toContain("bbb-recovered");
+			expect(promptText(promptInputs[1])).toContain("ccc");
 			runtime.dispose();
 		}, 10_000);
 
@@ -3073,13 +3088,13 @@ describe("advisor", () => {
 				) as AgentMessage;
 			};
 
-			const waitForPrompts = async (prompts: string[], count: number, timeoutMs = 10_000): Promise<void> => {
+			const waitForPrompts = async (prompts: Array<string | AgentMessage[]>, count: number, timeoutMs = 10_000): Promise<void> => {
 				const deadline = Date.now() + timeoutMs;
 				while (prompts.length < count && Date.now() < deadline) await Bun.sleep(5);
 			};
 
 			it("delivers a multi-MB transcript replay completely", async () => {
-				const promptInputs: string[] = [];
+				const promptInputs: Array<string | AgentMessage[]> = [];
 				const agent: AdvisorAgent = {
 					prompt: async input => {
 						promptInputs.push(input);
@@ -3099,13 +3114,13 @@ describe("advisor", () => {
 				await waitForPrompts(promptInputs, 1);
 				expect(promptInputs).toHaveLength(1);
 				// Nothing dropped: first and last transcript messages both rendered.
-				expect(promptInputs[0]).toContain("msg-0 ");
-				expect(promptInputs[0]).toContain("msg-1999 ");
+				expect(promptText(promptInputs[0])).toContain("msg-0 ");
+				expect(promptText(promptInputs[0])).toContain("msg-1999 ");
 				runtime.dispose();
 			}, 20_000);
 
 			it("pairs a toolCall with its non-adjacent toolResult inside one update", async () => {
-				const promptInputs: string[] = [];
+				const promptInputs: Array<string | AgentMessage[]> = [];
 				const agent: AdvisorAgent = {
 					prompt: async input => {
 						promptInputs.push(input);
@@ -3143,16 +3158,16 @@ describe("advisor", () => {
 				runtime.onTurnEnd(messages);
 				await waitForPrompts(promptInputs, 1);
 				expect(promptInputs).toHaveLength(1);
-				expect(promptInputs[0]).toContain("read(");
+				expect(promptText(promptInputs[0])).toContain("read(");
 				// The call+result pair rendered as completed, never as a spurious
 				// in-flight call.
-				expect(promptInputs[0]).toContain("⇒ ok");
-				expect(promptInputs[0]).not.toContain("⇒ pending");
+				expect(promptText(promptInputs[0])).toContain("⇒ ok");
+				expect(promptText(promptInputs[0])).not.toContain("⇒ pending");
 				runtime.dispose();
 			}, 20_000);
 
 			it("delivers a single turn carrying a multi-MB payload", async () => {
-				const promptInputs: string[] = [];
+				const promptInputs: Array<string | AgentMessage[]> = [];
 				const agent: AdvisorAgent = {
 					prompt: async input => {
 						promptInputs.push(input);
@@ -3181,12 +3196,12 @@ describe("advisor", () => {
 				runtime.onTurnEnd(messages);
 				await waitForPrompts(promptInputs, 2);
 				expect(promptInputs).toHaveLength(2);
-				expect(promptInputs[1]).toContain("huge ");
+				expect(promptText(promptInputs[1])).toContain("huge ");
 				runtime.dispose();
 			}, 20_000);
 
 			it("replays the full transcript after a reset lands between renders", async () => {
-				const promptInputs: string[] = [];
+				const promptInputs: Array<string | AgentMessage[]> = [];
 				const agent: AdvisorAgent = {
 					prompt: async input => {
 						promptInputs.push(input);
@@ -3207,13 +3222,13 @@ describe("advisor", () => {
 				await waitForPrompts(promptInputs, 1);
 				// The aborted pre-reset render must not have advanced the cursor:
 				// the post-reset replay carries the whole transcript.
-				const replay = promptInputs.find(input => input.includes("msg-0 ") && input.includes("msg-399 "));
+				const replay = promptInputs.find(input => promptText(input).includes("msg-0 ") && promptText(input).includes("msg-399 "));
 				expect(replay).toBeDefined();
 				runtime.dispose();
 			}, 20_000);
 
 			it("delivers interleaved turns in order without loss", async () => {
-				const promptInputs: string[] = [];
+				const promptInputs: Array<string | AgentMessage[]> = [];
 				const agent: AdvisorAgent = {
 					prompt: async input => {
 						promptInputs.push(input);
@@ -3233,8 +3248,8 @@ describe("advisor", () => {
 				messages.push({ role: "user", content: "late-arrival tail", timestamp: 300 } as AgentMessage);
 				runtime.onTurnEnd(messages);
 				const deadline = Date.now() + 10_000;
-				while (Date.now() < deadline && !promptInputs.join("\n").includes("late-arrival tail")) await Bun.sleep(5);
-				const combined = promptInputs.join("\n");
+				while (Date.now() < deadline && !promptInputs.map(i => promptText(i)).join("\n").includes("late-arrival tail")) await Bun.sleep(5);
+				const combined = promptInputs.map(i => promptText(i)).join("\n");
 				// Every message exactly once, ordering preserved.
 				expect(combined).toContain("msg-0 ");
 				expect(combined).toContain("msg-299 ");
@@ -3252,7 +3267,7 @@ describe("advisor", () => {
 			// OpenRouter ZDR `404 No endpoints available` case from #3635). The runtime
 			// must surface that as a failed turn even though the awaited promise did
 			// not reject.
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const failures: unknown[] = [];
 			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
 			let shouldFail = true;
@@ -3497,7 +3512,7 @@ describe("advisor", () => {
 		});
 
 		it("strips echoed thinking after a classifier refusal and succeeds without a notice", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const failures: unknown[] = [];
 			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
 			let promptCalls = 0;
@@ -3557,14 +3572,14 @@ describe("advisor", () => {
 			await settleUntil(() => runtime.backlog === 0);
 
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[0]).toContain("private reasoning");
-			expect(promptInputs[1]).not.toContain("private reasoning");
-			expect(promptInputs[1]).toContain("answer");
+			expect(promptText(promptInputs[0])).toContain("private reasoning");
+			expect(promptText(promptInputs[1])).not.toContain("private reasoning");
+			expect(promptText(promptInputs[1])).toContain("answer");
 			expect(failures).toEqual([]);
 		});
 
 		it("surfaces a persistent classifier refusal after one stripped resend", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const failures: unknown[] = [];
 			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
 			const agent: AdvisorAgent = {
@@ -3612,13 +3627,13 @@ describe("advisor", () => {
 			await settleUntil(() => failures.length === 1 && runtime.backlog === 0);
 
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[0]).toContain("private reasoning");
-			expect(promptInputs[1]).not.toContain("private reasoning");
+			expect(promptText(promptInputs[0])).toContain("private reasoning");
+			expect(promptText(promptInputs[1])).not.toContain("private reasoning");
 			expect(failures).toHaveLength(1);
 		});
 
 		it("degrades on a category-less refusal", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const failures: unknown[] = [];
 			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
 			let promptCalls = 0;
@@ -3678,13 +3693,13 @@ describe("advisor", () => {
 			await settleUntil(() => runtime.backlog === 0);
 
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[0]).toContain("private reasoning");
-			expect(promptInputs[1]).not.toContain("private reasoning");
+			expect(promptText(promptInputs[0])).toContain("private reasoning");
+			expect(promptText(promptInputs[1])).not.toContain("private reasoning");
 			expect(failures).toEqual([]);
 		});
 
 		it("calls onTurnError with state.error before retrying the batch", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const turnErrors: unknown[] = [];
 			const events: string[] = [];
 			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
@@ -3726,7 +3741,7 @@ describe("advisor", () => {
 		});
 
 		it("calls onTurnError for each consecutive failure including the dropped third turn", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const turnErrors: unknown[] = [];
 			const failures: unknown[] = [];
 			const events: string[] = [];
@@ -3786,7 +3801,7 @@ describe("advisor", () => {
 		});
 
 		it("continues retrying when onTurnError rejects", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const turnErrors: unknown[] = [];
 			const events: string[] = [];
 			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
@@ -3830,7 +3845,7 @@ describe("advisor", () => {
 
 		it("drops a terminal non-retriable assistant failure without retrying", async () => {
 			const errorMessage = "Codex error event: Request blocked. (code=invalid_prompt)";
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const rollbackCalls: number[] = [];
 			const turnErrors: unknown[] = [];
 			const failures: unknown[] = [];
@@ -3977,7 +3992,7 @@ describe("advisor", () => {
 
 		it("resets advisor context after quarantining an unavailable tool response", async () => {
 			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const lengthsBeforePrompt: number[] = [];
 			let resetCalls = 0;
 			const agent: AdvisorAgent = {
@@ -4038,11 +4053,11 @@ describe("advisor", () => {
 
 			expect(promptInputs).toHaveLength(2);
 			expect(lengthsBeforePrompt).toEqual([0, 0]);
-			expect(promptInputs[1]).toContain("aaa");
-			expect(promptInputs[1]).toContain("bbb");
+			expect(promptText(promptInputs[1])).toContain("aaa");
+			expect(promptText(promptInputs[1])).toContain("bbb");
 		});
 		it("re-primes queued primary updates after a quarantine reset", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: firstPromptStarted, resolve: startFirstPrompt } = Promise.withResolvers<void>();
 			const { promise: firstPrompt, reject: rejectFirstPrompt } = Promise.withResolvers<void>();
 			let promptCalls = 0;
@@ -4078,8 +4093,8 @@ describe("advisor", () => {
 			await settleUntil(() => promptInputs.length >= 2 && runtime.backlog === 0);
 
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[1]).toContain("aaa");
-			expect(promptInputs[1]).toContain("bbb");
+			expect(promptText(promptInputs[1])).toContain("aaa");
+			expect(promptText(promptInputs[1])).toContain("bbb");
 		});
 
 		it("notifies the host after the advisor persistently quarantines its output (issue #6661)", async () => {
@@ -4153,7 +4168,7 @@ describe("advisor", () => {
 		});
 
 		it("drops the in-flight batch when a reset aborts the advisor prompt", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const { promise: firstPromptStarted, resolve: startFirstPrompt } = Promise.withResolvers<void>();
 			let rejectInFlight: ((err: unknown) => void) | undefined;
 			let promptCalls = 0;
@@ -4185,7 +4200,7 @@ describe("advisor", () => {
 			runtime.onTurnEnd(messages);
 			await firstPromptStarted;
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("old-conversation");
+			expect(promptText(promptInputs[0])).toContain("old-conversation");
 
 			// Conversation boundary (/new): transcript replaced and the runtime reset
 			// while the advisor prompt is still in flight. The abort that rejects the
@@ -4205,12 +4220,12 @@ describe("advisor", () => {
 			runtime.onTurnEnd(messages);
 			await Bun.sleep(0);
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[1]).toContain("new-conversation");
-			expect(promptInputs[1]).not.toContain("old-conversation");
+			expect(promptText(promptInputs[1])).toContain("new-conversation");
+			expect(promptText(promptInputs[1])).not.toContain("old-conversation");
 		});
 
 		it("retries the interrupted batch after a session transition rolls back", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const firstPromptStarted = Promise.withResolvers<void>();
 			let rejectInFlight: ((reason?: unknown) => void) | undefined;
 			const agent: AdvisorAgent = {
@@ -4240,7 +4255,7 @@ describe("advisor", () => {
 			runtime.resumeAfterSessionTransition();
 			await settleUntil(() => runtime.backlog === 0);
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[1]).toContain("keep me");
+			expect(promptText(promptInputs[1])).toContain("keep me");
 		});
 
 		it.each(["success", "error"] as const)(
@@ -4334,7 +4349,7 @@ describe("advisor", () => {
 
 	describe("AdvisorRuntime quota classification", () => {
 		it("pauses on quota/rate-limit errors and notifies the host without retrying", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			let quotaNotified = false;
 			let failureNotified = false;
 			const agent: AdvisorAgent = {
@@ -4377,7 +4392,7 @@ describe("advisor", () => {
 		});
 
 		it("treats 'overloaded' as a transient server error, not quota exhaustion", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const failures: unknown[] = [];
 			const agent: AdvisorAgent = {
 				prompt: async input => {
@@ -4407,7 +4422,7 @@ describe("advisor", () => {
 			expect(failures).toHaveLength(1);
 		});
 		it("retains the failed batch in the pending queue on quota error", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			let shouldFail = true;
 			const agent: AdvisorAgent = {
 				prompt: async input => {
@@ -4434,7 +4449,7 @@ describe("advisor", () => {
 			expect(runtime.quotaExhausted).toBe(true);
 			expect(runtime.backlog).toBeGreaterThan(0);
 			expect(promptInputs).toHaveLength(1);
-			expect(promptInputs[0]).toContain("quota-turn");
+			expect(promptText(promptInputs[0])).toContain("quota-turn");
 
 			await runtime.pauseForSessionTransition();
 			runtime.resumeAfterSessionTransition();
@@ -4448,7 +4463,7 @@ describe("advisor", () => {
 			runtime.onTurnEnd(messages);
 			await Bun.sleep(0);
 			await Bun.sleep(0);
-			expect(promptInputs.at(-1)).toContain("quota-turn");
+			expect(promptText(promptInputs.at(-1) as string | AgentMessage[])).toContain("quota-turn");
 		});
 
 		it("resolves waitForCatchup immediately when quota is exhausted", async () => {
@@ -4481,7 +4496,7 @@ describe("advisor", () => {
 			expect(Date.now() - start).toBeLessThan(1000);
 		});
 		it("retries once when onTurnError signals a switched sibling credential", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			let firstCall = true;
 			const agent: AdvisorAgent = {
 				prompt: async input => {
@@ -4520,7 +4535,7 @@ describe("advisor", () => {
 		});
 
 		it("requeues when a switched retry produces no assistant response", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const state = { messages: [] as AgentMessage[] };
 			let callCount = 0;
 			const agent: AdvisorAgent = {
@@ -4557,7 +4572,7 @@ describe("advisor", () => {
 		});
 
 		it("falls through to quota pause when onTurnError returns false (no sibling)", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent: AdvisorAgent = {
 				prompt: async input => {
 					promptInputs.push(input);
@@ -4589,11 +4604,11 @@ describe("advisor", () => {
 			expect(quotaNotified).toBe(true);
 		});
 		it("drops stale quota handling when reset happens during onTurnError", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent: AdvisorAgent = {
 				prompt: async input => {
 					promptInputs.push(input);
-					if (input.includes("stale-turn")) {
+					if (promptText(input).includes("stale-turn")) {
 						throw new Error("insufficient_quota: you have exceeded your rate limit");
 					}
 				},
@@ -4635,8 +4650,8 @@ describe("advisor", () => {
 
 			expect(hookInvocations).toBe(1);
 			expect(promptInputs).toHaveLength(2);
-			expect(promptInputs[0]).toContain("stale-turn");
-			expect(promptInputs[1]).toContain("fresh-turn");
+			expect(promptText(promptInputs[0])).toContain("stale-turn");
+			expect(promptText(promptInputs[1])).toContain("fresh-turn");
 			expect(maintenanceSignals).toHaveLength(2);
 			expect(maintenanceSignals[0]?.aborted).toBe(true);
 			expect(maintenanceSignals[1]?.aborted).toBe(false);
@@ -4675,7 +4690,7 @@ describe("advisor", () => {
 			expect(recoverySignal.aborted).toBe(true);
 		});
 		it("uses generic failure path when switched retry hits a non-quota error", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			let callCount = 0;
 			const agent: AdvisorAgent = {
 				prompt: async input => {
@@ -4728,7 +4743,7 @@ describe("advisor", () => {
 		});
 
 		it("marks sibling and pauses when switched retry hits a second quota error", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			let firstCall = true;
 			const agent: AdvisorAgent = {
 				prompt: async input => {
@@ -4774,7 +4789,7 @@ describe("advisor", () => {
 		});
 
 		it("keeps rotating while another credential is immediately available", async () => {
-			const promptInputs: string[] = [];
+			const promptInputs: Array<string | AgentMessage[]> = [];
 			const agent: AdvisorAgent = {
 				prompt: async input => {
 					promptInputs.push(input);

--- a/packages/coding-agent/test/advisor/delta-split-obfuscation.test.ts
+++ b/packages/coding-agent/test/advisor/delta-split-obfuscation.test.ts
@@ -55,4 +55,24 @@ describe("renderAdvisorDeltaChunks obfuscation", () => {
 		expect(text).not.toContain("SECRETVALUE123");
 		expect(text).toContain("[REDACTED]");
 	});
+
+	it("falls back when full-delta redaction spans source chunks", () => {
+		const crossChunkObfuscator: AdvisorObfuscator = {
+			obfuscate: text => text.replace(/first[\s\S]*second/g, "[REDACTED]"),
+		};
+		const chunks = renderAdvisorDeltaChunks(
+			[
+				{ role: "user", content: "first", timestamp: 1 } as AgentMessage,
+				{ role: "user", content: "second", timestamp: 2 } as AgentMessage,
+			],
+			{
+				wip: false,
+				includeThinking: true,
+				obfuscator: crossChunkObfuscator,
+				advisorRegexSecretValues: new Set(),
+			},
+		);
+
+		expect(chunks).toBeNull();
+	});
 });

--- a/packages/coding-agent/test/advisor/delta-split-obfuscation.test.ts
+++ b/packages/coding-agent/test/advisor/delta-split-obfuscation.test.ts
@@ -4,18 +4,22 @@
 import { describe, expect, it } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 
-import { renderAdvisorDeltaChunks } from "../../src/advisor/delta-split";
+import {
+	type AdvisorObfuscator,
+	renderAdvisorDeltaChunks,
+} from "../../src/advisor/delta-split";
 
 function chunksToText(chunks: AgentMessage[] | null): string | null {
 	if (!chunks) return null;
 	return chunks.map(c => ((c as { content: unknown }).content as { text: string }[])[0].text).join("\n");
 }
 
-// Fake SecretObfuscator-compatible object for the pure renderer's text pass.
-function makeObfuscator() {
+// Fake obfuscator for the pure renderer's text pass, typed against the narrow
+// AdvisorObfuscator contract so the test exercises redaction without `any`.
+function makeObfuscator(): AdvisorObfuscator {
 	return {
 		obfuscate: (text: string) => text.replace(/SECRETVALUE123/g, "[REDACTED]"),
-	} as any;
+	};
 }
 
 describe("renderAdvisorDeltaChunks obfuscation", () => {
@@ -34,7 +38,6 @@ describe("renderAdvisorDeltaChunks obfuscation", () => {
 			advisorRegexSecretValues: new Set(),
 		});
 		const text = chunksToText(chunks) ?? "";
-		console.log("diff chunk:", JSON.stringify(text));
 		expect(text).not.toContain("SECRETVALUE123");
 		expect(text).toContain("[REDACTED]");
 	});
@@ -52,7 +55,6 @@ describe("renderAdvisorDeltaChunks obfuscation", () => {
 			advisorRegexSecretValues: new Set(),
 		});
 		const text = chunksToText(chunks) ?? "";
-		console.log("user chunk:", JSON.stringify(text));
 		expect(text).not.toContain("SECRETVALUE123");
 		expect(text).toContain("[REDACTED]");
 	});

--- a/packages/coding-agent/test/advisor/delta-split-obfuscation.test.ts
+++ b/packages/coding-agent/test/advisor/delta-split-obfuscation.test.ts
@@ -4,10 +4,7 @@
 import { describe, expect, it } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 
-import {
-	type AdvisorObfuscator,
-	renderAdvisorDeltaChunks,
-} from "../../src/advisor/delta-split";
+import { type AdvisorObfuscator, renderAdvisorDeltaChunks } from "../../src/advisor/delta-split";
 
 function chunksToText(chunks: AgentMessage[] | null): string | null {
 	if (!chunks) return null;

--- a/packages/coding-agent/test/advisor/delta-split-obfuscation.test.ts
+++ b/packages/coding-agent/test/advisor/delta-split-obfuscation.test.ts
@@ -40,7 +40,11 @@ describe("renderAdvisorDeltaChunks obfuscation", () => {
 	});
 
 	it("redacts secrets in user message text", () => {
-		const msg = { role: "user", content: [{ type: "text", text: "prefix SECRETVALUE123 suffix" }], timestamp: 1 } as AgentMessage;
+		const msg = {
+			role: "user",
+			content: [{ type: "text", text: "prefix SECRETVALUE123 suffix" }],
+			timestamp: 1,
+		} as AgentMessage;
 		const chunks = renderAdvisorDeltaChunks([msg], {
 			wip: false,
 			includeThinking: true,

--- a/packages/coding-agent/test/advisor/delta-split-obfuscation.test.ts
+++ b/packages/coding-agent/test/advisor/delta-split-obfuscation.test.ts
@@ -1,0 +1,55 @@
+// Obfuscation contract for multi-message split: renderAdvisorDeltaChunks must redact
+// secrets that ACTUALLY appear in rendered advisor context — toolResult
+// details.diff and custom message content — matching the old single-block path.
+import { describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+
+import { renderAdvisorDeltaChunks } from "../../src/advisor/delta-split";
+
+function chunksToText(chunks: AgentMessage[] | null): string | null {
+	if (!chunks) return null;
+	return chunks.map(c => ((c as { content: unknown }).content as { text: string }[])[0].text).join("\n");
+}
+
+// Fake SecretObfuscator-compatible object for the pure renderer's text pass.
+function makeObfuscator() {
+	return {
+		obfuscate: (text: string) => text.replace(/SECRETVALUE123/g, "[REDACTED]"),
+	} as any;
+}
+
+describe("renderAdvisorDeltaChunks obfuscation", () => {
+	it("redacts secrets in toolResult details.diff", () => {
+		const msg = {
+			role: "toolResult",
+			toolCallId: "c1",
+			content: "ok",
+			details: { diff: "--- a/x\n+++ b/x\n-SECRETVALUE123\n+new" },
+			timestamp: 1,
+		} as unknown as AgentMessage;
+		const chunks = renderAdvisorDeltaChunks([msg], {
+			wip: false,
+			includeThinking: true,
+			obfuscator: makeObfuscator(),
+			advisorRegexSecretValues: new Set(),
+		});
+		const text = chunksToText(chunks) ?? "";
+		console.log("diff chunk:", JSON.stringify(text));
+		expect(text).not.toContain("SECRETVALUE123");
+		expect(text).toContain("[REDACTED]");
+	});
+
+	it("redacts secrets in user message text", () => {
+		const msg = { role: "user", content: [{ type: "text", text: "prefix SECRETVALUE123 suffix" }], timestamp: 1 } as AgentMessage;
+		const chunks = renderAdvisorDeltaChunks([msg], {
+			wip: false,
+			includeThinking: true,
+			obfuscator: makeObfuscator(),
+			advisorRegexSecretValues: new Set(),
+		});
+		const text = chunksToText(chunks) ?? "";
+		console.log("user chunk:", JSON.stringify(text));
+		expect(text).not.toContain("SECRETVALUE123");
+		expect(text).toContain("[REDACTED]");
+	});
+});

--- a/packages/coding-agent/test/advisor/delta-split.test.ts
+++ b/packages/coding-agent/test/advisor/delta-split.test.ts
@@ -1,0 +1,96 @@
+// Direct unit tests for the multi-message-split pure renderer (src/advisor/delta-split.ts).
+// Verifies:
+//  1. Multi-message split is byte-equivalent to the old single-block render
+//     for mixed user/assistant/toolResult history.
+//  2. WIP marker lands on the LAST chunk only.
+//  3. Obfuscation fixture: secrets in tool-call arguments / toolResult
+//     details.diff are obfuscated BEFORE chunk rendering (message-level pass),
+//     matching the old security contract.
+import { describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+
+import { renderAdvisorDeltaChunks } from "../../src/advisor/delta-split";
+import { formatSessionHistoryMarkdown } from "../../src/session/session-history-format";
+
+function user(text: string, ts: number): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp: ts } as AgentMessage;
+}
+function agent(text: string, ts: number): AgentMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		timestamp: ts,
+		usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
+		stopReason: "stop",
+	} as unknown as AgentMessage;
+}
+function toolCall(id: string, ts: number): AgentMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id, name: "read", arguments: { path: "a.ts" } }],
+		timestamp: ts,
+		usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
+		stopReason: "tool_use",
+	} as unknown as AgentMessage;
+}
+function toolResult(id: string, ts: number): AgentMessage {
+	return { role: "toolResult", toolCallId: id, content: "file content", timestamp: ts } as unknown as AgentMessage;
+}
+
+const OPTS = { includeToolIntent: true, watchedRoles: true, expandPrimaryContext: true, expandEditDiffs: true, includeThinking: true } as const;
+
+function chunksToText(chunks: AgentMessage[] | null): string | null {
+	if (!chunks) return null;
+	return chunks.map(c => ((c as { content: unknown }).content as { text: string }[])[0].text).join("\n");
+}
+
+describe("renderAdvisorDeltaChunks (delta-split)", () => {
+	it("alternating user/agent byte-identical to single-block", () => {
+		const msgs = [user("first", 1), agent("a1", 2), user("second", 3), agent("a2", 4)];
+		const old = "### Session update\n\n" + formatSessionHistoryMarkdown(msgs, OPTS);
+		const chunks = renderAdvisorDeltaChunks(msgs, { wip: false, includeThinking: true, advisorRegexSecretValues: new Set() });
+		expect(chunksToText(chunks)).toBe(old);
+	});
+
+	it("consecutive same-role user byte-identical", () => {
+		const msgs = [user("u1", 1), user("u2", 2), agent("a", 3)];
+		const old = "### Session update\n\n" + formatSessionHistoryMarkdown(msgs, OPTS);
+		expect(chunksToText(renderAdvisorDeltaChunks(msgs, { wip: false, includeThinking: true, advisorRegexSecretValues: new Set() }))).toBe(old);
+	});
+
+	it("toolCall + toolResult pairing byte-identical", () => {
+		const msgs = [toolCall("call_1", 1), toolResult("call_1", 2), user("done", 3)];
+		const old = "### Session update\n\n" + formatSessionHistoryMarkdown(msgs, OPTS);
+		const chunks = renderAdvisorDeltaChunks(msgs, { wip: false, includeThinking: true, advisorRegexSecretValues: new Set() });
+		console.log("OLD:", JSON.stringify(old));
+		console.log("NEW:", JSON.stringify(chunksToText(chunks)));
+		expect(chunksToText(chunks)).toBe(old);
+	});
+
+	it("complex mixed history byte-identical", () => {
+		const msgs = [user("question", 1), agent("thinking", 2), toolCall("c2", 3), toolResult("c2", 4), agent("answer", 5), user("follow-up", 6), user("steering", 7), agent("final", 8)];
+		const old = "### Session update\n\n" + formatSessionHistoryMarkdown(msgs, OPTS);
+		const chunks = renderAdvisorDeltaChunks(msgs, { wip: false, includeThinking: true, advisorRegexSecretValues: new Set() });
+		console.log("OLD:", JSON.stringify(old));
+		console.log("NEW:", JSON.stringify(chunksToText(chunks)));
+		expect(chunksToText(chunks)).toBe(old);
+	});
+
+	it("wip marker lands on LAST chunk only", () => {
+		const msgs = [user("u1", 1), agent("a1", 2), user("u2", 3)];
+		const chunks = renderAdvisorDeltaChunks(msgs, { wip: true, includeThinking: true, advisorRegexSecretValues: new Set() });
+		expect(chunks).not.toBeNull();
+		const texts = chunks!.map(c => ((c as { content: unknown }).content as { text: string }[])[0].text);
+		// Marker only in the final chunk; earlier chunks unchanged.
+		for (let i = 0; i < texts.length - 1; i++) {
+			expect(texts[i]).not.toContain("[in progress");
+		}
+		expect(texts[texts.length - 1]).toContain("[in progress — more steps follow]");
+	});
+
+	it("splits into multiple user messages for multi-message history", () => {
+		const msgs = [user("u1", 1), agent("a1", 2), user("u2", 3), agent("a2", 4)];
+		const chunks = renderAdvisorDeltaChunks(msgs, { wip: false, includeThinking: true, advisorRegexSecretValues: new Set() });
+		expect(chunks!.length).toBeGreaterThan(1);
+	});
+});

--- a/packages/coding-agent/test/advisor/delta-split.test.ts
+++ b/packages/coding-agent/test/advisor/delta-split.test.ts
@@ -53,7 +53,7 @@ function chunksToText(chunks: AgentMessage[] | null): string | null {
 describe("renderAdvisorDeltaChunks (delta-split)", () => {
 	it("alternating user/agent byte-identical to single-block", () => {
 		const msgs = [user("first", 1), agent("a1", 2), user("second", 3), agent("a2", 4)];
-		const old = "### Session update\n\n" + formatSessionHistoryMarkdown(msgs, OPTS);
+		const old = `### Session update\n\n${formatSessionHistoryMarkdown(msgs, OPTS)}`;
 		const chunks = renderAdvisorDeltaChunks(msgs, {
 			wip: false,
 			includeThinking: true,
@@ -64,7 +64,7 @@ describe("renderAdvisorDeltaChunks (delta-split)", () => {
 
 	it("consecutive same-role user byte-identical", () => {
 		const msgs = [user("u1", 1), user("u2", 2), agent("a", 3)];
-		const old = "### Session update\n\n" + formatSessionHistoryMarkdown(msgs, OPTS);
+		const old = `### Session update\n\n${formatSessionHistoryMarkdown(msgs, OPTS)}`;
 		expect(
 			chunksToText(
 				renderAdvisorDeltaChunks(msgs, { wip: false, includeThinking: true, advisorRegexSecretValues: new Set() }),
@@ -74,7 +74,7 @@ describe("renderAdvisorDeltaChunks (delta-split)", () => {
 
 	it("toolCall + toolResult pairing byte-identical", () => {
 		const msgs = [toolCall("call_1", 1), toolResult("call_1", 2), user("done", 3)];
-		const old = "### Session update\n\n" + formatSessionHistoryMarkdown(msgs, OPTS);
+		const old = `### Session update\n\n${formatSessionHistoryMarkdown(msgs, OPTS)}`;
 		const chunks = renderAdvisorDeltaChunks(msgs, {
 			wip: false,
 			includeThinking: true,
@@ -94,7 +94,7 @@ describe("renderAdvisorDeltaChunks (delta-split)", () => {
 			user("steering", 7),
 			agent("final", 8),
 		];
-		const old = "### Session update\n\n" + formatSessionHistoryMarkdown(msgs, OPTS);
+		const old = `### Session update\n\n${formatSessionHistoryMarkdown(msgs, OPTS)}`;
 		const chunks = renderAdvisorDeltaChunks(msgs, {
 			wip: false,
 			includeThinking: true,

--- a/packages/coding-agent/test/advisor/delta-split.test.ts
+++ b/packages/coding-agent/test/advisor/delta-split.test.ts
@@ -37,7 +37,13 @@ function toolResult(id: string, ts: number): AgentMessage {
 	return { role: "toolResult", toolCallId: id, content: "file content", timestamp: ts } as unknown as AgentMessage;
 }
 
-const OPTS = { includeToolIntent: true, watchedRoles: true, expandPrimaryContext: true, expandEditDiffs: true, includeThinking: true } as const;
+const OPTS = {
+	includeToolIntent: true,
+	watchedRoles: true,
+	expandPrimaryContext: true,
+	expandEditDiffs: true,
+	includeThinking: true,
+} as const;
 
 function chunksToText(chunks: AgentMessage[] | null): string | null {
 	if (!chunks) return null;
@@ -48,37 +54,62 @@ describe("renderAdvisorDeltaChunks (delta-split)", () => {
 	it("alternating user/agent byte-identical to single-block", () => {
 		const msgs = [user("first", 1), agent("a1", 2), user("second", 3), agent("a2", 4)];
 		const old = "### Session update\n\n" + formatSessionHistoryMarkdown(msgs, OPTS);
-		const chunks = renderAdvisorDeltaChunks(msgs, { wip: false, includeThinking: true, advisorRegexSecretValues: new Set() });
+		const chunks = renderAdvisorDeltaChunks(msgs, {
+			wip: false,
+			includeThinking: true,
+			advisorRegexSecretValues: new Set(),
+		});
 		expect(chunksToText(chunks)).toBe(old);
 	});
 
 	it("consecutive same-role user byte-identical", () => {
 		const msgs = [user("u1", 1), user("u2", 2), agent("a", 3)];
 		const old = "### Session update\n\n" + formatSessionHistoryMarkdown(msgs, OPTS);
-		expect(chunksToText(renderAdvisorDeltaChunks(msgs, { wip: false, includeThinking: true, advisorRegexSecretValues: new Set() }))).toBe(old);
+		expect(
+			chunksToText(
+				renderAdvisorDeltaChunks(msgs, { wip: false, includeThinking: true, advisorRegexSecretValues: new Set() }),
+			),
+		).toBe(old);
 	});
 
 	it("toolCall + toolResult pairing byte-identical", () => {
 		const msgs = [toolCall("call_1", 1), toolResult("call_1", 2), user("done", 3)];
 		const old = "### Session update\n\n" + formatSessionHistoryMarkdown(msgs, OPTS);
-		const chunks = renderAdvisorDeltaChunks(msgs, { wip: false, includeThinking: true, advisorRegexSecretValues: new Set() });
-		console.log("OLD:", JSON.stringify(old));
-		console.log("NEW:", JSON.stringify(chunksToText(chunks)));
+		const chunks = renderAdvisorDeltaChunks(msgs, {
+			wip: false,
+			includeThinking: true,
+			advisorRegexSecretValues: new Set(),
+		});
 		expect(chunksToText(chunks)).toBe(old);
 	});
 
 	it("complex mixed history byte-identical", () => {
-		const msgs = [user("question", 1), agent("thinking", 2), toolCall("c2", 3), toolResult("c2", 4), agent("answer", 5), user("follow-up", 6), user("steering", 7), agent("final", 8)];
+		const msgs = [
+			user("question", 1),
+			agent("thinking", 2),
+			toolCall("c2", 3),
+			toolResult("c2", 4),
+			agent("answer", 5),
+			user("follow-up", 6),
+			user("steering", 7),
+			agent("final", 8),
+		];
 		const old = "### Session update\n\n" + formatSessionHistoryMarkdown(msgs, OPTS);
-		const chunks = renderAdvisorDeltaChunks(msgs, { wip: false, includeThinking: true, advisorRegexSecretValues: new Set() });
-		console.log("OLD:", JSON.stringify(old));
-		console.log("NEW:", JSON.stringify(chunksToText(chunks)));
+		const chunks = renderAdvisorDeltaChunks(msgs, {
+			wip: false,
+			includeThinking: true,
+			advisorRegexSecretValues: new Set(),
+		});
 		expect(chunksToText(chunks)).toBe(old);
 	});
 
 	it("wip marker lands on LAST chunk only", () => {
 		const msgs = [user("u1", 1), agent("a1", 2), user("u2", 3)];
-		const chunks = renderAdvisorDeltaChunks(msgs, { wip: true, includeThinking: true, advisorRegexSecretValues: new Set() });
+		const chunks = renderAdvisorDeltaChunks(msgs, {
+			wip: true,
+			includeThinking: true,
+			advisorRegexSecretValues: new Set(),
+		});
 		expect(chunks).not.toBeNull();
 		const texts = chunks!.map(c => ((c as { content: unknown }).content as { text: string }[])[0].text);
 		// Marker only in the final chunk; earlier chunks unchanged.
@@ -90,7 +121,11 @@ describe("renderAdvisorDeltaChunks (delta-split)", () => {
 
 	it("splits into multiple user messages for multi-message history", () => {
 		const msgs = [user("u1", 1), agent("a1", 2), user("u2", 3), agent("a2", 4)];
-		const chunks = renderAdvisorDeltaChunks(msgs, { wip: false, includeThinking: true, advisorRegexSecretValues: new Set() });
+		const chunks = renderAdvisorDeltaChunks(msgs, {
+			wip: false,
+			includeThinking: true,
+			advisorRegexSecretValues: new Set(),
+		});
 		expect(chunks!.length).toBeGreaterThan(1);
 	});
 });

--- a/packages/coding-agent/test/advisor/delta-split.test.ts
+++ b/packages/coding-agent/test/advisor/delta-split.test.ts
@@ -128,4 +128,20 @@ describe("renderAdvisorDeltaChunks (delta-split)", () => {
 		});
 		expect(chunks!.length).toBeGreaterThan(1);
 	});
+
+	it("puts the heading on the first emitted chunk when earlier messages render empty", () => {
+		const empty = {
+			role: "custom",
+			customType: "advisor",
+			content: "internal advice",
+			display: false,
+			timestamp: 1,
+		} as AgentMessage;
+		const chunks = renderAdvisorDeltaChunks([empty, user("visible", 2)], {
+			wip: false,
+			includeThinking: true,
+			advisorRegexSecretValues: new Set(),
+		});
+		expect(chunksToText(chunks)).toStartWith("### Session update\n\n");
+	});
 });

--- a/packages/coding-agent/test/advisor/fingerprint-multi-message.test.ts
+++ b/packages/coding-agent/test/advisor/fingerprint-multi-message.test.ts
@@ -1,0 +1,156 @@
+// PoC: evaluate which candidate fix prevents advisor full-transcript replays.
+// Scenarios reproduce the production triggers observed in the live session
+// (omp 17.2.2, omp-cop-sticky / gpt-5.6-terra):
+//   A. delivered message replaced by a clone differing only in unrendered
+//      fields (timestamp/usage)  -> full-JSON fingerprint mismatch
+//   B. delivered message content rewritten to a `[shaken ...]` placeholder
+//      (auto-shake mutates in place, then rewriteEntries yields a new object)
+//   C. wip heading flip (## Session update [in progress ...] vs final)
+//   E. rendered field change (custom.display) must replay
+//   F. unrendered field change (usage) must NOT replay under candidate 1
+//
+// formatSessionHistoryMarkdown folds consecutive user messages into one block,
+// so full-vs-incremental is judged by content: `seed-body-001` is never
+// mutated by scenarios A/B/F, so its presence proves the whole history was
+// re-rendered (full replay); absence means only the new tail shipped.
+import { describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+
+import { AdvisorRuntime, type AdvisorAgent, type AdvisorRuntimeHost } from "../../src/advisor/runtime";
+
+function mkMsg(role: AgentMessage["role"], text: string, timestamp: number, extra: Record<string, unknown> = {}): AgentMessage {
+	return { role, content: text, timestamp, ...extra } as AgentMessage;
+}
+
+function history(parts: string[]): AgentMessage[] {
+	return parts.map((text, i) => mkMsg("user", text, i + 1));
+}
+
+async function settle() {
+	for (let i = 0; i < 60; i++) await Promise.resolve();
+}
+
+async function runScenario(
+	seed: AgentMessage[],
+	mutate: (messages: AgentMessage[]) => void,
+	extraTurn: AgentMessage[],
+): Promise<{ prompts: string[] }> {
+	const messages: AgentMessage[] = [...seed];
+	const prompts: string[] = [];
+	const agent: AdvisorAgent = {
+		prompt: async (input: string) => {
+			prompts.push(input);
+		},
+		abort: () => {},
+		reset: () => {},
+		state: { messages: [] },
+	} as unknown as AdvisorAgent;
+	const host: AdvisorRuntimeHost = {
+		snapshotMessages: () => messages,
+		enqueueAdvice: () => {},
+	} as unknown as AdvisorRuntimeHost;
+	const runtime = new AdvisorRuntime(agent, host);
+	runtime.onTurnEnd();
+	await settle();
+	mutate(messages);
+	messages.push(...extraTurn);
+	runtime.onTurnEnd();
+	await settle();
+	return { prompts };
+}
+
+function promptTextOf(input: string | AgentMessage[]): string {
+	if (typeof input === "string") return input;
+	return input
+		.map(m => {
+			const c = (m as { content?: unknown }).content;
+			if (typeof c === "string") return c;
+			if (Array.isArray(c)) return c.map((b: { text?: string }) => b.text ?? "").join("\n");
+			return String(m);
+		})
+		.join("\n");
+}
+
+function describeDelta(prompts: Array<string | AgentMessage[]>): { full: boolean; tailOnly: boolean } {
+	if (prompts.length === 0) return { full: false, tailOnly: false };
+	const last = promptTextOf(prompts[prompts.length - 1]);
+	const full = last.includes("seed-body-001");
+	const tailOnly = !full;
+	return { full, tailOnly };
+}
+
+describe("fingerprint: field-selective fingerprint (applied)", () => {
+	it("scenario A: timestamp-only clone replacement is INCREMENTAL (no full replay)", async () => {
+		const { prompts } = await runScenario(
+			history(["seed-body-000", "seed-body-001"]),
+			messages => {
+				messages[0] = { ...messages[0], timestamp: 999999 } as AgentMessage;
+			},
+			[mkMsg("user", "tail-body-002", 3)],
+		);
+		const d = describeDelta(prompts);
+		expect(d.full).toBe(false);
+		expect(d.tailOnly).toBe(true);
+	});
+
+	it("scenario B: content rewrite to shaken placeholder STILL triggers FULL replay (content is rendered)", async () => {
+		const { prompts } = await runScenario(
+			history(["seed-body-000", "seed-body-001"]),
+			messages => {
+				messages[0] = { ...messages[0], content: "[shaken ~10 tokens — recover: artifact://1 (region 1)]" } as AgentMessage;
+			},
+			[mkMsg("user", "tail-body-002", 3)],
+		);
+		expect(describeDelta(prompts).full).toBe(true);
+	});
+
+	it("scenario E: rendered field change (custom.display flip) triggers FULL replay", async () => {
+		const messages: AgentMessage[] = [
+			{
+				role: "custom",
+				customType: "xdev-mount-notice",
+				content: "seed-body-000",
+				display: true,
+				timestamp: 1,
+			} as unknown as AgentMessage,
+			mkMsg("user", "seed-body-001", 2),
+		];
+		const prompts: string[] = [];
+		const agent: AdvisorAgent = {
+			prompt: async (input: string) => {
+				prompts.push(input);
+			},
+			abort: () => {},
+			reset: () => {},
+			state: { messages: [] },
+		} as unknown as AdvisorAgent;
+		const host: AdvisorRuntimeHost = {
+			snapshotMessages: () => messages,
+			enqueueAdvice: () => {},
+		} as unknown as AdvisorRuntimeHost;
+		const runtime = new AdvisorRuntime(agent, host);
+		runtime.onTurnEnd();
+		await settle();
+		// Replace with a NEW object whose display flipped (rewriteEntries clone).
+		messages[0] = { ...messages[0], display: false } as unknown as AgentMessage;
+		messages.push(mkMsg("user", "tail-body-002", 3));
+		runtime.onTurnEnd();
+		await settle();
+		const last = promptTextOf(prompts[prompts.length - 1]);
+		// display is rendered (folding gate); flipping it must re-render history.
+		expect(last).toContain("seed-body-001");
+	});
+
+	it("scenario F: unrendered field change (usage) does NOT trigger replay", async () => {
+		const { prompts } = await runScenario(
+			history(["seed-body-000", "seed-body-001"]),
+			messages => {
+				messages[0] = { ...messages[0], usage: { input_tokens: 123 } } as unknown as AgentMessage;
+			},
+			[mkMsg("user", "tail-body-002", 3)],
+		);
+		const d = describeDelta(prompts);
+		expect(d.full).toBe(false);
+		expect(d.tailOnly).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/advisor/fingerprint-multi-message.test.ts
+++ b/packages/coding-agent/test/advisor/fingerprint-multi-message.test.ts
@@ -16,9 +16,14 @@
 import { describe, expect, it } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 
-import { AdvisorRuntime, type AdvisorAgent, type AdvisorRuntimeHost } from "../../src/advisor/runtime";
+import { type AdvisorAgent, AdvisorRuntime, type AdvisorRuntimeHost } from "../../src/advisor/runtime";
 
-function mkMsg(role: AgentMessage["role"], text: string, timestamp: number, extra: Record<string, unknown> = {}): AgentMessage {
+function mkMsg(
+	role: AgentMessage["role"],
+	text: string,
+	timestamp: number,
+	extra: Record<string, unknown> = {},
+): AgentMessage {
 	return { role, content: text, timestamp, ...extra } as AgentMessage;
 }
 
@@ -97,7 +102,10 @@ describe("fingerprint: field-selective fingerprint (applied)", () => {
 		const { prompts } = await runScenario(
 			history(["seed-body-000", "seed-body-001"]),
 			messages => {
-				messages[0] = { ...messages[0], content: "[shaken ~10 tokens — recover: artifact://1 (region 1)]" } as AgentMessage;
+				messages[0] = {
+					...messages[0],
+					content: "[shaken ~10 tokens — recover: artifact://1 (region 1)]",
+				} as AgentMessage;
 			},
 			[mkMsg("user", "tail-body-002", 3)],
 		);
@@ -152,5 +160,29 @@ describe("fingerprint: field-selective fingerprint (applied)", () => {
 		const d = describeDelta(prompts);
 		expect(d.full).toBe(false);
 		expect(d.tailOnly).toBe(true);
+	});
+
+	it("scenario G: rendered field change (bashExecution.command) triggers FULL replay", async () => {
+		// command is rendered by formatSessionHistoryMarkdown (executionLine), so
+		// a clone changing only command must not pass the prefix check.
+		const { prompts } = await runScenario(
+			[mkMsg("bashExecution", "", 1, { command: "ls -la" }), mkMsg("user", "seed-body-001", 2)],
+			messages => {
+				messages[0] = { ...messages[0], command: "ls -la /tmp" } as unknown as AgentMessage;
+			},
+			[mkMsg("user", "tail-body-002", 3)],
+		);
+		expect(describeDelta(prompts).full).toBe(true);
+	});
+
+	it("scenario H: rendered field change (compaction summary) triggers FULL replay", async () => {
+		const { prompts } = await runScenario(
+			[mkMsg("compactionSummary", "", 1, { summary: "seed summary" }), mkMsg("user", "seed-body-001", 2)],
+			messages => {
+				messages[0] = { ...messages[0], summary: "rewritten summary" } as unknown as AgentMessage;
+			},
+			[mkMsg("user", "tail-body-002", 3)],
+		);
+		expect(describeDelta(prompts).full).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/advisor/replay-observability.test.ts
+++ b/packages/coding-agent/test/advisor/replay-observability.test.ts
@@ -8,7 +8,12 @@ import { describe, expect, it, vi } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { logger } from "@oh-my-pi/pi-utils";
 
-import { type AdvisorAgent, AdvisorRuntime, type AdvisorRuntimeHost } from "../../src/advisor/runtime";
+import {
+	type AdvisorAgent,
+	AdvisorOutputQuarantinedError,
+	AdvisorRuntime,
+	type AdvisorRuntimeHost,
+} from "../../src/advisor/runtime";
 
 function userMessage(text: string, timestamp: number): AgentMessage {
 	return { role: "user", content: text, timestamp } as AgentMessage;
@@ -16,6 +21,10 @@ function userMessage(text: string, timestamp: number): AgentMessage {
 
 async function settle() {
 	for (let i = 0; i < 50; i++) await Promise.resolve();
+}
+
+function hasResetReason(details: unknown, reason: string): details is { reason: string } {
+	return typeof details === "object" && details !== null && "reason" in details && details.reason === reason;
 }
 
 describe("advisor context reset observability", () => {
@@ -89,6 +98,55 @@ describe("advisor context reset observability", () => {
 					(event.details as { reason: string }).reason === "auto-compaction",
 			);
 			expect(reset).toBeDefined();
+		} finally {
+			debugSpy.mockRestore();
+		}
+	});
+
+	it("logs quarantine reset reasons while preserving the retry limit", async () => {
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		try {
+			const messages: AgentMessage[] = [userMessage("turn body", 1)];
+			let agentResetCalls = 0;
+			const failures: unknown[] = [];
+			const agent: AdvisorAgent = {
+				prompt: async () => {
+					throw new AdvisorOutputQuarantinedError("quarantined");
+				},
+				abort: () => {},
+				reset: () => {
+					agentResetCalls++;
+				},
+				state: { messages: [] },
+			};
+			const runtime = new AdvisorRuntime(agent, {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				notifyFailure: error => failures.push(error),
+			});
+
+			runtime.onTurnEnd();
+			await settle();
+			runtime.onTurnEnd();
+			await settle();
+
+			const events = debugSpy.mock.calls.map(call => ({ message: call[0], details: call[1] }));
+			expect(
+				events.some(
+					event =>
+						event.message === "advisor context reset" && hasResetReason(event.details, "quarantine-recovery"),
+				),
+			).toBe(true);
+			expect(
+				events.some(
+					event =>
+						event.message === "advisor context reset" &&
+						hasResetReason(event.details, "quarantine-retry-exhausted"),
+				),
+			).toBe(true);
+			expect(agentResetCalls).toBe(2);
+			expect(failures).toHaveLength(1);
+			expect(failures[0]).toBeInstanceOf(AdvisorOutputQuarantinedError);
 		} finally {
 			debugSpy.mockRestore();
 		}

--- a/packages/coding-agent/test/advisor/replay-observability.test.ts
+++ b/packages/coding-agent/test/advisor/replay-observability.test.ts
@@ -1,0 +1,67 @@
+// The advisor's full-transcript replays re-send the entire primary history and
+// force the provider to re-prefill from the system prompt. Until now none of
+// the reset paths logged anything, making production replay storms
+// undiagnosable. These tests pin the observability contract: every reset path
+// emits a structured debug event, and the delivered-prefix path reports which
+// message diverged and which fields changed.
+import { describe, expect, it, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { logger } from "@oh-my-pi/pi-utils";
+
+import { AdvisorRuntime, type AdvisorAgent, type AdvisorRuntimeHost } from "../../src/advisor/runtime";
+
+function userMessage(text: string, timestamp: number): AgentMessage {
+	return { role: "user", content: text, timestamp } as AgentMessage;
+}
+
+async function settle() {
+	for (let i = 0; i < 50; i++) await Promise.resolve();
+}
+
+describe("advisor context reset observability", () => {
+	it("logs the diverging message and differing fields when the delivered prefix changes", async () => {
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		try {
+			const messages: AgentMessage[] = [userMessage("turn one body", 1), userMessage("turn two body", 2)];
+			const prompts: string[] = [];
+			const agent: AdvisorAgent = {
+				prompt: async (input: string) => {
+					prompts.push(input);
+				},
+				abort: () => {},
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+			};
+			const runtime = new AdvisorRuntime(agent, host);
+
+			runtime.onTurnEnd();
+			await settle();
+
+			// Replace a delivered message with a changed clone, then grow the tail.
+			messages[0] = userMessage("turn one body EDITED", 1);
+			messages.push(userMessage("turn three body", 3));
+			runtime.onTurnEnd();
+			await settle();
+
+			const events = debugSpy.mock.calls.map(call => ({ message: call[0], details: call[1] }));
+			const divergence = events.find(event => event.message === "advisor delivered prefix changed");
+			expect(divergence).toBeDefined();
+			const divergenceDetails = divergence?.details as { index: number; differingFields: string[] };
+			expect(divergenceDetails.index).toBe(0);
+			expect(divergenceDetails.differingFields).toContain("content");
+
+			const reset = events.find(
+				event =>
+					event.message === "advisor context reset" &&
+					(event.details as { reason: string }).reason === "delivered-prefix-changed",
+			);
+			expect(reset).toBeDefined();
+		} finally {
+			debugSpy.mockRestore();
+		}
+	});
+});

--- a/packages/coding-agent/test/advisor/replay-observability.test.ts
+++ b/packages/coding-agent/test/advisor/replay-observability.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { logger } from "@oh-my-pi/pi-utils";
 
-import { AdvisorRuntime, type AdvisorAgent, type AdvisorRuntimeHost } from "../../src/advisor/runtime";
+import { type AdvisorAgent, AdvisorRuntime, type AdvisorRuntimeHost } from "../../src/advisor/runtime";
 
 function userMessage(text: string, timestamp: number): AgentMessage {
 	return { role: "user", content: text, timestamp } as AgentMessage;
@@ -58,6 +58,35 @@ describe("advisor context reset observability", () => {
 				event =>
 					event.message === "advisor context reset" &&
 					(event.details as { reason: string }).reason === "delivered-prefix-changed",
+			);
+			expect(reset).toBeDefined();
+		} finally {
+			debugSpy.mockRestore();
+		}
+	});
+
+	it("logs the caller-supplied reason on external reset (compaction/shake/prune triggers)", () => {
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		try {
+			const agent: AdvisorAgent = {
+				prompt: async () => {},
+				abort: () => {},
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => [],
+				enqueueAdvice: () => {},
+			};
+			const runtime = new AdvisorRuntime(agent, host);
+
+			runtime.reset("auto-compaction");
+
+			const events = debugSpy.mock.calls.map(call => ({ message: call[0], details: call[1] }));
+			const reset = events.find(
+				event =>
+					event.message === "advisor context reset" &&
+					(event.details as { reason: string }).reason === "auto-compaction",
 			);
 			expect(reset).toBeDefined();
 		} finally {


### PR DESCRIPTION
## Summary

Advisor context can be reset and re-primed when its delivered primary-history prefix changes. Before this PR, the prefix fingerprint hashed the entire message object, so non-rendered metadata such as timestamps or usage could look like a history rewrite. That causes a full advisor replay and an avoidable provider cache rebuild.

This PR keeps advisor history append-only when the rendered primary context is unchanged, while preserving full replays when advisor-visible content actually changes.

### Changes

- **Fingerprint rendered state, not incidental metadata.** `fingerprintMessage` now includes the fields consumed by the advisor history renderer and excludes non-rendered timestamp/usage churn. A real rendered-content change still resets and re-primes the advisor.
- **Split Session updates by source message.** One `Agent.prompt(AgentMessage[])` call now sends one user message per source message. Old source-message items remain stable while newly appended items can extend provider cache reuse. The concatenated rendered text remains byte-equivalent to the prior single-block form.
- **Move WIP state to the tail.** `[in progress — more steps follow]` no longer changes the Session update heading, so a WIP/final transition cannot shift all prior body content behind an early heading difference.
- **Make reset causes observable.** Logs identify delivered-prefix changes and external reset reasons. Quarantined advisor output now logs `quarantine-recovery` or `quarantine-retry-exhausted` before its existing context clear/re-prime path, without resetting the quarantine retry counter.

## Why this is scoped

This does **not** claim that every advisor cache miss disappears. A real compaction, branch/resume, explicit reset, or other semantic history rewrite must still re-prime advisor context and can incur one cache rebuild. The goal is to avoid false full replays caused by non-rendered metadata and preserve cache growth for normal append-only updates.

## Verification

- Changed-file Biome check: passed.
- `git diff --check`: passed.
- Focused advisor tests were attempted but this WSL session has a hard FD limit of 512 and Bun fails before test execution with `EMFILE` while reading `packages/coding-agent` / its `tsconfig.json`.
- `bun run check` reaches and passes Biome, but the local package environment lacks `tsgo`, so `check:types` exits 127 before type checking.

## Follow-up runtime validation

Use a fresh OMP session with the same Terra main-agent / Luna advisor workload. The old false-replay signature is a high Luna cache read followed by roughly `16,280` cached tokens plus a large cache write, then a high read on the next request. The PR should remove that false-replay loop for append-only primary history. If a reset remains, the new structured reason logs identify its path.
