### PR TITLE
fix(memory): clarify /memory stats and /memory diagnose message when memory is off

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/memory stats` and `/memory diagnose` showing "Memory stats is not available for the off backend" when memory is off; the off backend now says memory is off directly instead of naming itself as an unsupported backend ([#7251](https://github.com/can1357/oh-my-pi/pull/7251) by [@KennethHoff](https://github.com/KennethHoff)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `/memory stats` and `/memory diagnose` showing "Memory stats is not available for the off backend" when memory is off; the off backend now says memory is off directly instead of naming itself as an unsupported backend ([#7251](https://github.com/can1357/oh-my-pi/pull/7251) by [@KennethHoff](https://github.com/KennethHoff)).
+- Fixed `/memory stats` and `/memory diagnose` showing "Memory stats is not available for the off backend" when memory is off, in both the TUI and ACP/RPC slash-command handlers; the off backend now says memory is off directly instead of naming itself as an unsupported backend ([#7251](https://github.com/can1357/oh-my-pi/pull/7251) by [@KennethHoff](https://github.com/KennethHoff)).
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/coding-agent/src/memory-backend/index.ts
+++ b/packages/coding-agent/src/memory-backend/index.ts
@@ -12,6 +12,7 @@ export type {
 	MnemopiSessionStateOptions,
 } from "../mnemopi/state";
 export * from "./local-backend";
+export * from "./messages";
 export * from "./off-backend";
 export * from "./resolve";
 export * from "./runtime";

--- a/packages/coding-agent/src/memory-backend/messages.ts
+++ b/packages/coding-agent/src/memory-backend/messages.ts
@@ -1,0 +1,19 @@
+import type { MemoryBackendId } from "./types";
+
+/**
+ * Fallback text for `/memory stats` and `/memory diagnose` when the active
+ * backend's hook is missing or returns nothing.
+ *
+ * The `off` backend isn't a real backend a user picked among several
+ * stats-capable options — it's the no-op state memory falls back to by
+ * default — so it gets its own message instead of the generic
+ * "not available for the X backend" template, which would otherwise read as
+ * the self-contradictory "not available for the off backend".
+ *
+ * Shared by both the TUI (`CommandController.handleMemoryCommand`) and the
+ * ACP/RPC slash-command handler so the two surfaces stay consistent.
+ */
+export function memoryStatsUnavailableMessage(backendId: MemoryBackendId, action: "stats" | "diagnose"): string {
+	if (backendId === "off") return "Memory backend is off — there is nothing to show.";
+	return `Memory ${action} is not available for the ${backendId} backend.`;
+}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -28,7 +28,7 @@ import {
 	seedAlreadyExists,
 	summarizeMentalModel,
 } from "../../hindsight";
-import { resolveMemoryBackend } from "../../memory-backend";
+import { memoryStatsUnavailableMessage, resolveMemoryBackend } from "../../memory-backend";
 import { BashExecutionComponent } from "../../modes/components/bash-execution";
 import { BorderedLoader } from "../../modes/components/bordered-loader";
 import { DynamicBorder } from "../../modes/components/dynamic-border";
@@ -658,11 +658,7 @@ export class CommandController {
 			try {
 				const payload = await hook?.(agentDir, this.ctx.sessionManager.getCwd(), this.ctx.session);
 				if (!payload) {
-					if (backend.id === "off") {
-						this.ctx.showWarning("Memory backend is off — there is nothing to show.");
-					} else {
-						this.ctx.showWarning(`Memory ${action} is not available for the ${backend.id} backend.`);
-					}
+					this.ctx.showWarning(memoryStatsUnavailableMessage(backend.id, action));
 					return;
 				}
 				showMarkdownPanel(this.ctx, `Memory ${action === "stats" ? "Stats" : "Diagnostics"}`, payload);

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -658,7 +658,11 @@ export class CommandController {
 			try {
 				const payload = await hook?.(agentDir, this.ctx.sessionManager.getCwd(), this.ctx.session);
 				if (!payload) {
-					this.ctx.showWarning(`Memory ${action} is not available for the ${backend.id} backend.`);
+					if (backend.id === "off") {
+						this.ctx.showWarning("Memory backend is off — there is nothing to show.");
+					} else {
+						this.ctx.showWarning(`Memory ${action} is not available for the ${backend.id} backend.`);
+					}
 					return;
 				}
 				showMarkdownPanel(this.ctx, `Memory ${action === "stats" ? "Stats" : "Diagnostics"}`, payload);

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -32,7 +32,7 @@ import {
 	MarketplaceManager,
 } from "../extensibility/plugins/marketplace";
 import { readMCPConfigFile } from "../mcp/config-writer";
-import { resolveMemoryBackend } from "../memory-backend";
+import { memoryStatsUnavailableMessage, resolveMemoryBackend } from "../memory-backend";
 import { runPauseScreen } from "../modes/components/pause-screen";
 import { collectMcpServerNames, MCPCommandController } from "../modes/controllers/mcp-command-controller";
 import { describeLoopLimitRuntime } from "../modes/loop-limit";
@@ -1947,7 +1947,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				case "diagnose": {
 					const hook = verb === "stats" ? backend.stats : backend.diagnose;
 					const payload = await hook?.(runtime.settings.getAgentDir(), runtime.cwd, runtime.session);
-					await runtime.output(payload ?? `Memory ${verb} is not available for the ${backend.id} backend.`);
+					await runtime.output(payload ?? memoryStatsUnavailableMessage(backend.id, verb));
 					return commandConsumed();
 				}
 				case "mm":

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -818,6 +818,28 @@ describe("wave 3 commands", () => {
 		expect(output[0]).toContain("Usage: /memory");
 	});
 
+	it("/memory stats: tells the user memory is off instead of naming a nonexistent 'off backend'", async () => {
+		const { output, runtime } = createRuntime();
+		const result = await executeAcpBuiltinSlashCommand("/memory stats", runtime);
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toBe("Memory backend is off — there is nothing to show.");
+	});
+
+	it("/memory diagnose: tells the user memory is off instead of naming a nonexistent 'off backend'", async () => {
+		const { output, runtime } = createRuntime();
+		const result = await executeAcpBuiltinSlashCommand("/memory diagnose", runtime);
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toBe("Memory backend is off — there is nothing to show.");
+	});
+
+	it("/memory stats: still names the backend when a real backend simply has no stats hook", async () => {
+		const { output, runtime } = createRuntime();
+		runtime.settings.set("memory.backend" as never, "local" as never);
+		const result = await executeAcpBuiltinSlashCommand("/memory stats", runtime);
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toBe("Memory stats is not available for the local backend.");
+	});
+
 	// /todo start fuzzy match
 	it("/todo start: finds pending task by substring and starts it", async () => {
 		const { output, session, runtime } = createRuntime();

--- a/packages/coding-agent/test/modes/controllers/memory-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/memory-command.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { CommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+function createMemoryContext(backend: string) {
+	const showWarning = vi.fn();
+	const ctx = {
+		settings: Settings.isolated({ "memory.backend": backend }),
+		sessionManager: { getCwd: () => "/tmp/project" },
+		session: undefined,
+		showWarning,
+	} as unknown as InteractiveModeContext;
+	return { ctx, showWarning };
+}
+
+describe("CommandController /memory stats and /memory diagnose", () => {
+	beforeEach(() => {
+		resetSettingsForTest();
+	});
+
+	afterEach(() => {
+		resetSettingsForTest();
+	});
+
+	it("tells the user memory is off instead of naming a nonexistent 'off backend' for /memory stats", async () => {
+		const { ctx, showWarning } = createMemoryContext("off");
+		const controller = new CommandController(ctx);
+
+		await controller.handleMemoryCommand("/memory stats");
+
+		expect(showWarning).toHaveBeenCalledWith("Memory backend is off — there is nothing to show.");
+	});
+
+	it("tells the user memory is off instead of naming a nonexistent 'off backend' for /memory diagnose", async () => {
+		const { ctx, showWarning } = createMemoryContext("off");
+		const controller = new CommandController(ctx);
+
+		await controller.handleMemoryCommand("/memory diagnose");
+
+		expect(showWarning).toHaveBeenCalledWith("Memory backend is off — there is nothing to show.");
+	});
+
+	it("still names the backend when a real backend simply has no stats hook", async () => {
+		const { ctx, showWarning } = createMemoryContext("local");
+		const controller = new CommandController(ctx);
+
+		await controller.handleMemoryCommand("/memory stats");
+
+		expect(showWarning).toHaveBeenCalledWith("Memory stats is not available for the local backend.");
+	});
+});


### PR DESCRIPTION
I tried checking how much the memory backend had used before being told that it hadn't been activated, and I found the error message quite amusing.

---

`/memory stats` and `/memory diagnose` fall back to a generic message — `` `Memory ${action} is not available for the ${backend.id} backend.` `` — whenever the active backend's `stats`/`diagnose` hook is `undefined` (`command-controller.ts`, `handleMemoryCommand`). For a real backend (`hindsight`, `mnemopi`, `local`) that template reads fine. For the `off` backend it doesn't: `off` isn't a backend a user picked among several stats-capable options, it's the no-op state memory falls back to by default, so the same template renders as:

> Warning: Memory stats is not available for the off backend.

which reads as an odd, near self-contradictory warning ("the off backend").

This special-cases `backend.id === "off"` with a single, action-agnostic message, matching the phrasing `offBackend.status()` already uses elsewhere in the same file ("Memory backend is off."), instead of running the generic backend-is-a-real-thing template against a state that isn't one:

> Warning: Memory backend is off — there is nothing to show.

The generic message is untouched for every real backend that simply lacks a `stats`/`diagnose` hook (covered by a new test case against the `local` backend).

**Verification:** added `packages/coding-agent/test/modes/controllers/memory-command.test.ts`, covering `/memory stats` and `/memory diagnose` against the `off` backend (asserts the new wording) and `/memory stats` against `local` (asserts the generic wording is unchanged). Confirmed red→green: the new assertions fail against the pre-fix code with the old message and pass after the fix. Also ran `bun run check:types` for `packages/coding-agent` (clean) and the existing `test/slash-commands/memory.test.ts` + `test/memory-backend-resolve.test.ts` suites (all passing, no regressions), and booted the actual CLI (`bun src/cli.ts --version`) from this branch to confirm it starts cleanly. Did not run `bun run lint` (biome's Linux binary doesn't run under NixOS without `nix-ld`/patching — an environment limitation, not exercised here) or a full compiled-binary build (native addon requires a Bazel build); reused an already-extracted `pi_natives` addon matching this branch's version to run the JS-level test suite and boot the CLI instead of a full rebuild.
