### PR TITLE
fix(coding-agent): keep hub-killed subagent from resurrecting as parked

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a subagent killed from the Agent Hub (`x`) reappearing as a `parked` row after closing and reopening the hub in a local session; the kill now leaves the ref registered as terminal `aborted` instead of unregistering it, so the persisted-subagent rescan no longer re-adopts the surviving transcript ([#7250](https://github.com/can1357/oh-my-pi/issues/7250)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -636,7 +636,7 @@ export class AgentHubOverlayComponent extends Container {
 				if (ref.status === "running" && ref.session) {
 					await ref.session.abort({ reason: USER_INTERRUPT_LABEL });
 				}
-				await this.#lifecycle().release(ref.id, ref);
+				await this.#lifecycle().release(ref.id, ref, { tombstone: true });
 			} catch (error) {
 				logger.warn("Agent hub: kill failed", { id: ref.id, error: String(error) });
 				this.#notice = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -378,6 +378,14 @@ export class AgentLifecycleManager {
 			await park.promise;
 		}
 
+		if (options?.tombstone) {
+			// Mark the tombstone terminal BEFORE disposing. A live session's wrapped
+			// dispose (createAgentSession) unregisters any non-terminal ref via
+			// `unregisterUnlessParked`, which would otherwise delete the ref out from
+			// under the detach/status calls below. Setting `aborted` first makes that
+			// guard preserve the ref, so a later persisted-subagent rescan skips it.
+			this.#registry.setStatus(id, "aborted", ref);
+		}
 		if (this.#registry.get(id) === ref && ref.session) {
 			try {
 				await ref.session.dispose();
@@ -387,7 +395,6 @@ export class AgentLifecycleManager {
 		}
 		if (options?.tombstone) {
 			this.#registry.detachSession(id, ref);
-			this.#registry.setStatus(id, "aborted", ref);
 		} else {
 			this.#registry.unregister(id, ref);
 		}

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -345,12 +345,19 @@ export class AgentLifecycleManager {
 	}
 
 	/**
-	 * Hard removal: dispose if live, unregister from registry, drop timers.
-	 * When `expected` is given, only a ref matching it is released; a stale
-	 * release can never take down a newer same-id ref. Returns true when a
-	 * matching ref was released.
+	 * Dispose if live and drop timers. When `expected` is given, only a ref
+	 * matching it is released; a stale release can never take down a newer
+	 * same-id ref. Returns true when a matching ref was released.
+	 *
+	 * By default the ref is unregistered (teardown / one-shot removal). Pass
+	 * `tombstone: true` for an explicit kill: the ref is kept registered as a
+	 * terminal `aborted` row (session detached) instead of being removed, so a
+	 * later persisted-subagent scan (e.g. Agent Hub reopen) skips it via its
+	 * `if (!registry.get(id))` guard rather than re-adopting the surviving
+	 * on-disk transcript as a fresh `parked` row. Mirrors
+	 * `finalizeSubagentLifecycle`'s genuine-kill path.
 	 */
-	async release(id: string, expected?: AgentRefExpectation): Promise<boolean> {
+	async release(id: string, expected?: AgentRefExpectation, options?: { tombstone?: boolean }): Promise<boolean> {
 		const adopted = this.#adopted.get(id);
 		const current = this.#registry.get(id);
 		const currentMatches =
@@ -378,7 +385,12 @@ export class AgentLifecycleManager {
 				logger.warn("AgentLifecycleManager.release: session dispose failed", { id, error: String(error) });
 			}
 		}
-		this.#registry.unregister(id, ref);
+		if (options?.tombstone) {
+			this.#registry.detachSession(id, ref);
+			this.#registry.setStatus(id, "aborted", ref);
+		} else {
+			this.#registry.unregister(id, ref);
+		}
 		return true;
 	}
 

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -415,21 +415,27 @@ export class AgentLifecycleManager {
 	async #revive(id: string, revive: AgentReviver, ref: AgentRef, adopted: AdoptedAgent): Promise<AgentSession> {
 		const session = await revive(ref);
 		let liveRef = this.#registry.get(id);
-		if (liveRef === ref) {
+		if (liveRef === ref && ref.status === "parked" && !ref.session) {
+			// A simple reviver returned a session without claiming the parked ref;
+			// attach it here while the exact ref is still revivable.
 			if (!this.#registry.attachSession(id, session, ref.sessionFile, ref)) {
 				await session.dispose();
 				throw new Error(`Agent "${id}" changed before its persisted session could attach.`);
 			}
 			liveRef = ref;
 		} else if (
-			!liveRef ||
+			liveRef !== ref ||
+			liveRef.status !== "running" ||
 			liveRef.session !== session ||
 			liveRef.kind !== ref.kind ||
 			liveRef.parentId !== ref.parentId ||
 			liveRef.sessionFile !== ref.sessionFile
 		) {
+			// createAgentSession may have already claimed this exact parked ref and
+			// attached the returned session. Any other state — especially an
+			// `aborted` tombstone set while revive() was in flight — is stale.
 			await session.dispose();
-			throw new Error(`Agent "${id}" was replaced while its persisted session was reviving.`);
+			throw new Error(`Agent "${id}" was replaced or became terminal while its persisted session was reviving.`);
 		}
 		adopted.ref = liveRef;
 		// Emits status_changed → "idle", which re-arms the TTL timer below.

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -379,25 +379,25 @@ export class AgentLifecycleManager {
 		}
 
 		if (options?.tombstone) {
-			// Mark the tombstone terminal BEFORE disposing. A live session's wrapped
-			// dispose (createAgentSession) unregisters any non-terminal ref via
-			// `unregisterUnlessParked`, which would otherwise delete the ref out from
-			// under the detach/status calls below. Setting `aborted` first makes that
-			// guard preserve the ref, so a later persisted-subagent rescan skips it.
+			// Explicit kill: mark the ref terminal `aborted` and detach the session
+			// BEFORE disposing. aborted refs must satisfy the AgentRef invariant
+			// (session === null) so ensureLive / hub focus can never route into a
+			// disposed session; setting the terminal status first also makes
+			// createAgentSession's dispose wrapper (unregisterUnlessParked) preserve
+			// the ref instead of removing it, so a later persisted-subagent rescan
+			// skips it. The transcript file is left intact (history://<id>).
 			this.#registry.setStatus(id, "aborted", ref);
 		}
-		if (this.#registry.get(id) === ref && ref.session) {
+		const live = this.#registry.get(id) === ref ? ref.session : null;
+		if (options?.tombstone) this.#registry.detachSession(id, ref);
+		if (live) {
 			try {
-				await ref.session.dispose();
+				await live.dispose();
 			} catch (error) {
 				logger.warn("AgentLifecycleManager.release: session dispose failed", { id, error: String(error) });
 			}
 		}
-		if (options?.tombstone) {
-			this.#registry.detachSession(id, ref);
-		} else {
-			this.#registry.unregister(id, ref);
-		}
+		if (!options?.tombstone) this.#registry.unregister(id, ref);
 		return true;
 	}
 

--- a/packages/coding-agent/src/registry/agent-registry.ts
+++ b/packages/coding-agent/src/registry/agent-registry.ts
@@ -105,19 +105,23 @@ export class AgentRegistry {
 	}
 
 	/**
-	 * Register a new id only when it is absent, or reuse the exact ref a parked
-	 * revival was authorized to revive. A missing expected ref is a failed CAS:
-	 * callers must never claim an id after its prior generation disappeared.
+	 * Register a new id only when it is absent, or reuse the exact detached
+	 * `parked` ref a revival was authorized to revive. A missing, replaced, or
+	 * terminal expected ref is a failed CAS: delayed revivers must never claim an
+	 * id after its prior generation disappeared or was hard-killed.
 	 */
 	registerIfAvailable(input: RegisterInput, expected: AgentRef | null): AgentRef | undefined {
 		const current = this.#refs.get(input.id);
 		if (expected === null) return current ? undefined : this.register(input);
-		return current === expected ? current : undefined;
+		return current === expected && current.status === "parked" && !current.session ? current : undefined;
 	}
 
 	setStatus(id: string, status: AgentStatus, expected?: AgentRefExpectation): boolean {
 		const ref = this.#refs.get(id);
 		if (!ref || !this.#matchesExpected(ref, expected)) return false;
+		// `aborted` is terminal: delayed progress/revival work from the killed
+		// generation must never transition the tombstone back to a live status.
+		if (ref.status === "aborted") return status === "aborted";
 		if (ref.status === status) return true;
 		ref.status = status;
 		// Activity describes current work; it is meaningless once the agent
@@ -159,7 +163,10 @@ export class AgentRegistry {
 		expected?: AgentRefExpectation,
 	): boolean {
 		const ref = this.#refs.get(id);
-		if (!ref || !this.#matchesExpected(ref, expected)) return false;
+		// Never attach a late-created session to a hard-killed tombstone. This
+		// closes the race between a parked reviver claiming the ref and finishing
+		// createAgentSession after an explicit kill.
+		if (!ref || ref.status === "aborted" || !this.#matchesExpected(ref, expected)) return false;
 		ref.session = session;
 		if (sessionFile !== undefined) ref.sessionFile = sessionFile;
 		ref.lastActivity = Date.now();

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1633,15 +1633,19 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const agentKind = (options.taskDepth ?? 0) > 0 || options.parentTaskPrefix ? ("sub" as const) : ("main" as const);
 	let registeredAgentRef: AgentRef | undefined;
 	/**
-	 * Forget the agent ref on teardown — unless the agent is being parked (or is
-	 * already parked/aborted). Parking disposes the session but keeps the ref
-	 * addressable (history://, revive); a hard kill leaves it as a terminal
-	 * `aborted` tombstone. Only process teardown / a plain release unregisters.
+	 * Forget the agent ref on teardown — unless it is a retained terminal ref.
+	 * Parking disposes the session but keeps the ref addressable (history://,
+	 * revive); a hard kill leaves it as a terminal `aborted` tombstone. Both are
+	 * detached (session === null) by the time dispose runs, per the AgentRef
+	 * invariant, so preserving them never keeps a disposed session reachable — an
+	 * aborted ref that still holds a live session is a bug and is unregistered
+	 * rather than handed to ensureLive. Only process teardown / a plain release
+	 * unregisters.
 	 */
 	const unregisterUnlessParked = (): void => {
 		const ref = registeredAgentRef;
 		if (!ref || agentRegistry.get(resolvedAgentId) !== ref) return;
-		if (ref.status === "parked" || ref.status === "aborted") return;
+		if (ref.status === "parked" || (ref.status === "aborted" && !ref.session)) return;
 		if (AgentLifecycleManager.global().isParking(resolvedAgentId, ref)) return;
 		agentRegistry.unregister(resolvedAgentId, ref);
 	};

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1634,13 +1634,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	let registeredAgentRef: AgentRef | undefined;
 	/**
 	 * Forget the agent ref on teardown — unless the agent is being parked (or is
-	 * already parked). Parking disposes the session but keeps the ref addressable
-	 * (history://, revive); only process teardown / explicit kill unregisters.
+	 * already parked/aborted). Parking disposes the session but keeps the ref
+	 * addressable (history://, revive); a hard kill leaves it as a terminal
+	 * `aborted` tombstone. Only process teardown / a plain release unregisters.
 	 */
 	const unregisterUnlessParked = (): void => {
 		const ref = registeredAgentRef;
 		if (!ref || agentRegistry.get(resolvedAgentId) !== ref) return;
-		if (ref.status === "parked") return;
+		if (ref.status === "parked" || ref.status === "aborted") return;
 		if (AgentLifecycleManager.global().isParking(resolvedAgentId, ref)) return;
 		agentRegistry.unregister(resolvedAgentId, ref);
 	};

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2364,7 +2364,14 @@ export async function finalizeSubagentLifecycle(args: {
 	const resumableAbort =
 		args.abortKind === "budget" && args.keepAlive && !args.isolated && args.reviveSession !== null;
 	if (args.aborted && !resumableAbort) {
-		if (ref && ownsRef) registry.setStatus(args.id, "aborted", ref);
+		if (ref && ownsRef) {
+			// Terminal hard kill: mark `aborted` and detach the session before
+			// disposing so the ref satisfies the AgentRef invariant (session null
+			// when aborted) — ensureLive/hub focus must treat it as terminal, never
+			// route into the disposed session.
+			registry.setStatus(args.id, "aborted", ref);
+			registry.detachSession(args.id, ref);
+		}
 		await disposeSession();
 		return;
 	}

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -524,12 +524,25 @@ describe("AgentLifecycleManager", () => {
 		await Bun.write(rootSessionFile, "");
 		await Bun.write(workerSessionFile, "");
 
-		const stub = makeSessionStub();
+		// Mirror the real wrapped session dispose (createAgentSession's
+		// `unregisterUnlessParked`): disposing a live session unregisters the ref
+		// unless it is already terminal (parked/aborted). This is what defeated the
+		// naive fix — the ref must be marked `aborted` *before* dispose runs.
+		let disposeCalls = 0;
+		const session = {
+			dispose: async () => {
+				disposeCalls++;
+				const live = registry.get(workerId);
+				if (live && live.status !== "parked" && live.status !== "aborted") {
+					registry.unregister(workerId, live);
+				}
+			},
+		} as unknown as AgentSession;
 		const ref = registry.register({
 			id: workerId,
 			displayName: "task",
 			kind: "sub",
-			session: stub.session,
+			session,
 			sessionFile: workerSessionFile,
 			status: "running",
 		});
@@ -537,7 +550,7 @@ describe("AgentLifecycleManager", () => {
 		expect(await lifecycle.release(workerId, ref, { tombstone: true })).toBe(true);
 		// The kill disposes the live session but keeps the ref registered as a
 		// terminal, hard-killed row (session detached) instead of removing it.
-		expect(stub.disposeCalls()).toBe(1);
+		expect(disposeCalls).toBe(1);
 		expect(registry.get(workerId)?.status).toBe("aborted");
 		expect(registry.get(workerId)?.session).toBeNull();
 

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { registerPersistedSubagents } from "@oh-my-pi/pi-coding-agent/registry/persisted-agents";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { TempDir } from "@oh-my-pi/pi-utils";
 
 interface SessionStub {
 	session: AgentSession;
@@ -511,5 +514,37 @@ describe("AgentLifecycleManager", () => {
 		expect(ref?.session).toBe(stub.session);
 		expect(stub.disposeCalls()).toBe(0);
 		expect(lifecycle.has("8-Sub")).toBe(true);
+	});
+
+	it("tombstone release keeps a killed ref as terminal `aborted` so a persisted-subagent rescan cannot resurrect it as parked", async () => {
+		using tempDir = TempDir.createSync("@omp-lifecycle-tombstone-");
+		const rootSessionFile = path.join(tempDir.path(), "main.jsonl");
+		const workerId = "Killed-Sub";
+		const workerSessionFile = path.join(tempDir.path(), "main", `${workerId}.jsonl`);
+		await Bun.write(rootSessionFile, "");
+		await Bun.write(workerSessionFile, "");
+
+		const stub = makeSessionStub();
+		const ref = registry.register({
+			id: workerId,
+			displayName: "task",
+			kind: "sub",
+			session: stub.session,
+			sessionFile: workerSessionFile,
+			status: "running",
+		});
+
+		expect(await lifecycle.release(workerId, ref, { tombstone: true })).toBe(true);
+		// The kill disposes the live session but keeps the ref registered as a
+		// terminal, hard-killed row (session detached) instead of removing it.
+		expect(stub.disposeCalls()).toBe(1);
+		expect(registry.get(workerId)?.status).toBe("aborted");
+		expect(registry.get(workerId)?.session).toBeNull();
+
+		// Reopening the Agent Hub rescans on-disk transcripts. The surviving
+		// `.jsonl` must not be re-adopted as a fresh `parked` row, because the
+		// id is still present in the registry.
+		await registerPersistedSubagents(registry, rootSessionFile);
+		expect(registry.get(workerId)?.status).toBe("aborted");
 	});
 });

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -75,6 +75,13 @@ describe("AgentLifecycleManager", () => {
 		expect(registry.registerIfAvailable(next, parked)).toBe(parked);
 		expect(registry.get("generation-Sub")).toBe(parked);
 
+		registry.setStatus("generation-Sub", "aborted", parked);
+		expect(registry.registerIfAvailable(next, parked)).toBeUndefined();
+		const staleSession = makeSessionStub().session;
+		expect(registry.attachSession("generation-Sub", staleSession, undefined, parked)).toBe(false);
+		expect(registry.setStatus("generation-Sub", "idle", parked)).toBe(false);
+		expect(registry.get("generation-Sub")).toMatchObject({ status: "aborted", session: null });
+
 		registry.unregister("generation-Sub", parked);
 		expect(registry.registerIfAvailable(next, parked)).toBeUndefined();
 		expect(registry.get("generation-Sub")).toBeUndefined();
@@ -167,6 +174,39 @@ describe("AgentLifecycleManager", () => {
 		expect(reviverRuns).toBe(1);
 		expect(a).toBe(revived.session);
 		expect(b).toBe(revived.session);
+	});
+
+	it("tombstoning a parked agent during revive prevents the stale session from attaching", async () => {
+		const gate = deferred();
+		const revived = makeSessionStub();
+		const ref = registry.register({
+			id: "Revive-Killed",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: "/tmp/Revive-Killed.jsonl",
+			status: "parked",
+		});
+		lifecycle.adopt(
+			"Revive-Killed",
+			{
+				idleTtlMs: 0,
+				revive: async () => {
+					await gate.promise;
+					return revived.session;
+				},
+			},
+			ref,
+		);
+
+		const revival = lifecycle.ensureLive("Revive-Killed");
+		expect(await lifecycle.release("Revive-Killed", ref, { tombstone: true })).toBe(true);
+		expect(registry.get("Revive-Killed")).toMatchObject({ status: "aborted", session: null });
+
+		gate.resolve();
+		await expect(revival).rejects.toThrow(/became terminal/);
+		expect(revived.disposeCalls()).toBe(1);
+		expect(registry.get("Revive-Killed")).toMatchObject({ status: "aborted", session: null });
 	});
 
 	it("ensureLive on an unknown id throws and points at history://", async () => {

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -553,6 +553,9 @@ describe("AgentLifecycleManager", () => {
 		expect(disposeCalls).toBe(1);
 		expect(registry.get(workerId)?.status).toBe("aborted");
 		expect(registry.get(workerId)?.session).toBeNull();
+		// The tombstone is terminal: ensureLive must not hand back the disposed
+		// session (the ref carries session === null), it treats it as unrevivable.
+		await expect(lifecycle.ensureLive(workerId)).rejects.toThrow(/aborted/);
 
 		// Reopening the Agent Hub rescans on-disk transcripts. The surviving
 		// `.jsonl` must not be re-adopted as a fresh `parked` row, because the


### PR DESCRIPTION
## Repro
Kill a subagent from the Agent Hub (`x`) in a plain local session, close the hub (Esc), then reopen it: the killed agent returns as a `parked` row, every time. Reproduced at the registry level — register a running sub whose `<id>.jsonl` exists on disk, run the pre-fix kill path (`AgentLifecycleManager.release(id, ref)`), then simulate the hub reopen with `registerPersistedSubagents(registry, sessionFile)`. After release the id is gone (`registry.get(id) === undefined`); after the rescan it is back with `status === "parked"`.

## Cause
`AgentHubOverlayComponent.#killSelected` (`packages/coding-agent/src/modes/components/agent-hub.ts`) ends by calling `AgentLifecycleManager.release(id, ref)`, which disposes the session and unconditionally `registry.unregister(id, ref)` (`packages/coding-agent/src/registry/agent-lifecycle.ts:381`) while leaving the on-disk `<id>.jsonl` intact. Because every hub open reconstructs the overlay and (in a non-collab session) calls `registerPersistedSubagents`, the next scan's `if (!registry.get(id))` guard (`packages/coding-agent/src/registry/persisted-agents.ts:85`) cannot tell an explicit kill from a normally parked-for-history agent, so it re-adopts the surviving transcript as a fresh `parked` ref. The executor's own genuine-kill path already avoids this: `finalizeSubagentLifecycle` sets `status: "aborted"` and returns without unregistering, keeping the ref as a terminal row.

## Fix
- Added an optional `{ tombstone?: boolean }` argument to `AgentLifecycleManager.release`. In tombstone mode it performs the same cleanup (clear adopted timer, cancel/await park, dispose session) but detaches the session and sets `status: "aborted"` instead of unregistering, mirroring `finalizeSubagentLifecycle`.
- `#killSelected` now calls `release(ref.id, ref, { tombstone: true })`, so a killed row stays registered as terminal `aborted` and the rescan guard skips it. The `.jsonl` is untouched, so `history://<id>` still resolves (per #5261).
- Added a lifecycle regression test that kills a sub with an on-disk transcript, asserts the ref becomes `aborted` with a detached session, then runs `registerPersistedSubagents` and asserts it is not resurrected as `parked`.

## Verification
`bun test test/registry/agent-lifecycle.test.ts` — 22 pass. `bun test test/agent-hub-activate.test.ts test/agent-hub-ordering.test.ts` — 15 pass. Also confirmed the pre-fix path (plain `release`) reproduces the resurrection in a scratch test. Fixes #7250