### PR TITLE
fix(coding-agent): scope session-dir migration to the current cwd

### DIFF
--- a/docs/session.md
+++ b/docs/session.md
@@ -44,7 +44,7 @@ Default session file location:
 - inside the OS temp root: `-tmp-<relative-path>` with the same replacement
 - anywhere else: legacy absolute form `--<cwd-without-leading-slash-with-same-replacement>--`
 
-Old `--<home-encoded>-*--` directories are migrated to the new home-relative names once per sessions root on first access (best-effort).
+Old `--<home-encoded>-*--` directories are migrated to the new home-relative names once per sessions root on first access (best-effort). Migration is scoped to the current cwd's directory only — a global sweep would rename dirs a concurrently running process (e.g. pi, or another omp instance sharing the sessions root) is actively appending to, silently breaking its writes with ENOENT. A stale dir for another cwd stays untouched until a session opens that cwd again.
 
 Blob store location:
 

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -59,12 +59,22 @@ function getDefaultSessionDirName(cwd: string): { encodedDirName: string; resolv
 }
 
 /**
- * Migrate old `--<home-encoded>-*--` session dirs to the new `-*` format.
- * Runs once per sessions root on first access, best-effort.
+ * Migrate the old `--<home-encoded>-*--` session dir for the CURRENT cwd to
+ * the new `-*` format. Runs once per sessions root on first access,
+ * best-effort.
+ *
+ * Deliberately scoped to the current cwd instead of sweeping every matching
+ * directory in the root: omp and pi (or two omp instances) often share one
+ * sessions root, and a global rename would move directories a concurrently
+ * running process is actively appending to, silently breaking its writes with
+ * ENOENT (issue #7183). A stale dir for another cwd stays untouched until a
+ * session opens that cwd again.
  */
-function migrateHomeSessionDirs(sessionsRoot: string): void {
+function migrateHomeSessionDirs(sessionsRoot: string, cwd: string): void {
 	if (migratedSessionRoots.has(sessionsRoot)) return;
 	migratedSessionRoots.add(sessionsRoot);
+
+	const { encodedDirName } = getDefaultSessionDirName(cwd);
 
 	const home = os.homedir();
 	const homeEncoded = home.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-");
@@ -89,6 +99,10 @@ function migrateHomeSessionDirs(sessionsRoot: string): void {
 		}
 
 		const newName = remainder ? `-${remainder}` : "-";
+		// Only migrate the directory this cwd maps to. A global sweep would
+		// rename dirs another process is writing (see above).
+		if (newName !== encodedDirName) continue;
+
 		const oldPath = path.join(sessionsRoot, entry);
 		const newPath = path.join(sessionsRoot, newName);
 
@@ -131,7 +145,7 @@ export function computeDefaultSessionDir(
 	sessionsRoot: string = getSessionsDir(),
 ): string {
 	const { encodedDirName, resolvedCwd } = getDefaultSessionDirName(cwd);
-	migrateHomeSessionDirs(sessionsRoot);
+	migrateHomeSessionDirs(sessionsRoot, cwd);
 	const sessionDir = path.join(sessionsRoot, encodedDirName);
 	migrateLegacyAbsoluteSessionDir(resolvedCwd, sessionDir, sessionsRoot);
 	storage.ensureDirSync(sessionDir);

--- a/packages/coding-agent/test/session-paths-migration.test.ts
+++ b/packages/coding-agent/test/session-paths-migration.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { computeDefaultSessionDir } from "@oh-my-pi/pi-coding-agent/session/session-paths";
+import type { SessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
+
+function makeStorage(): SessionStorage {
+	return {
+		ensureDirSync(dir: string): void {
+			fs.mkdirSync(dir, { recursive: true });
+		},
+	} as SessionStorage;
+}
+
+function encodeLegacyName(dir: string): string {
+	return `--${dir.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
+}
+
+describe("session dir migration scopes to the current cwd (#7183)", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+		tempDirs.length = 0;
+	});
+
+	it("migrates only the old dir for the current cwd and leaves other cwds' dirs alone", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-sess-migrate-"));
+		tempDirs.push(root);
+
+		const home = os.homedir();
+		const homeEncoded = home.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-");
+		const cwdA = path.join(home, "pi-migrate-a");
+
+		// Old-format dirs: `--<homeEncoded>-<rel>--`. Both dirs exist, and the
+		// one for cwdA carries a session file (simulating a legacy session).
+		const oldA = path.join(root, `--${homeEncoded}-pi-migrate-a--`);
+		const oldB = path.join(root, `--${homeEncoded}-pi-migrate-b--`);
+		fs.mkdirSync(oldA, { recursive: true });
+		fs.mkdirSync(oldB, { recursive: true });
+		fs.writeFileSync(path.join(oldA, "1699999999000_sess1.jsonl"), "{}");
+
+		// Opening a session for cwdA must migrate ONLY oldA -> -pi-migrate-a.
+		const sessionDir = computeDefaultSessionDir(cwdA, makeStorage(), root);
+		expect(sessionDir).toBe(path.join(root, "-pi-migrate-a"));
+		expect(fs.existsSync(path.join(root, "-pi-migrate-a", "1699999999000_sess1.jsonl"))).toBe(true);
+		expect(fs.existsSync(oldA)).toBe(false);
+
+		// The other cwd's old dir is untouched: another process (pi, or a
+		// concurrent omp) may still be writing it.
+		expect(fs.existsSync(oldB)).toBe(true);
+		expect(fs.existsSync(path.join(root, "-pi-migrate-b"))).toBe(false);
+	});
+
+	it("later migrates a second cwd's old dir when that cwd is opened", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-sess-migrate-"));
+		tempDirs.push(root);
+
+		const home = os.homedir();
+		const homeEncoded = home.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-");
+		const cwdB = path.join(home, "pi-migrate-b2");
+		const oldB = path.join(root, `--${homeEncoded}-pi-migrate-b2--`);
+		fs.mkdirSync(oldB, { recursive: true });
+		fs.writeFileSync(path.join(oldB, "1700000000000_sess2.jsonl"), "{}");
+
+		// First access for cwdB migrates it.
+		const sessionDir = computeDefaultSessionDir(cwdB, makeStorage(), root);
+		expect(sessionDir).toBe(path.join(root, "-pi-migrate-b2"));
+		expect(fs.existsSync(path.join(root, "-pi-migrate-b2", "1700000000000_sess2.jsonl"))).toBe(true);
+		expect(fs.existsSync(oldB)).toBe(false);
+	});
+
+	it("keeps the legacy absolute-form migration for non-home cwds", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-sess-migrate-"));
+		tempDirs.push(root);
+
+		const outsideHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-outside-home-"));
+		tempDirs.push(outsideHome);
+		const cwd = path.join(outsideHome, "proj");
+		fs.mkdirSync(cwd, { recursive: true });
+
+		// Non-home cwd: legacy absolute form `--<abs>--`.
+		const legacyDir = path.join(root, encodeLegacyName(cwd));
+		fs.mkdirSync(legacyDir, { recursive: true });
+		fs.writeFileSync(path.join(legacyDir, "1700000000000_sess3.jsonl"), "{}");
+
+		const sessionDir = computeDefaultSessionDir(cwd, makeStorage(), root);
+		expect(fs.existsSync(path.join(sessionDir, "1700000000000_sess3.jsonl"))).toBe(true);
+		expect(fs.existsSync(legacyDir)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

omp and pi are often run side by side and can end up sharing one sessions root (e.g. ~/.config/pi/agent/sessions and ~/.local/share/omp/sessions symlinked to the same directory). The old --<home-encoded>-*-- session dir migration swept every matching directory in the sessions root on first access — a global rename that moved directories a concurrently running process was actively appending to, so its subsequent writes failed with ENOENT (issue #7183).

## Changes

- packages/coding-agent/src/session/session-paths.ts: migration now renames only the directory the current cwd maps to. A stale dir for another cwd stays untouched until a session opens that cwd again, so a concurrent omp/pi process is never disrupted.
- packages/coding-agent/test/session-paths-migration.test.ts: new tests — migration leaves other cwds' old dirs alone, migrates a second cwd's dir when that cwd is opened later, and keeps the legacy absolute-form migration for non-home cwds.
- docs/session.md: document the cwd-scoped migration behavior.

## Test plan

- [x] bun test test/session-paths-migration.test.ts — 3 pass
- [x] bun test test/session-manager/ — 187 pass total
- [x] bun run check:types in packages/coding-agent — pass
- [x] biome check — clean

## Human note

I am a 19-year-old independent full-stack developer. I reviewed the full diff and confirmed the change: session-dir migration is now scoped to the current cwd, so it no longer renames directories a concurrent process is actively writing.

Fixes #7183