### PR TITLE
feat(coding-agent): add user-authorized cross-session agent channels

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -133,6 +133,9 @@
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
+### Added
+
+- Added opt-in, user-authorized cross-session agent channels with interactive multi-select membership, multiple concurrent groups, channel-scoped recipient fanout, revocation, and termination notifications.
 
 ## [17.2.3] - 2026-08-01
 
@@ -147,9 +150,6 @@
 - Fixed ephemeral side turns and native compaction bypassing an explicit or fork-inherited prompt cache key ([#7218](https://github.com/can1357/oh-my-pi/issues/7218)).
 - Fixed the live Ask dialog crashing the whole session with a `replaceTabs` TypeError when a question reached `AskDialogComponent` without a string `question` field; questions are now normalized at dialog entry, mirroring the transcript renderer ([#7211](https://github.com/can1357/oh-my-pi/issues/7211)).
 - Fixed Codex web search collapsing backend errors to `Codex error (): Unknown error`; the SSE error parser now preserves the backend code and message from top-level, nested `error`, and `response.error` envelopes ([#7200](https://github.com/can1357/oh-my-pi/issues/7200)).
-### Added
-
-- Added user-authorized cross-session agent channels with bidirectional group messaging, channel-scoped recipient fanout, user and agent revocation, and member termination notifications.
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -147,6 +147,9 @@
 - Fixed ephemeral side turns and native compaction bypassing an explicit or fork-inherited prompt cache key ([#7218](https://github.com/can1357/oh-my-pi/issues/7218)).
 - Fixed the live Ask dialog crashing the whole session with a `replaceTabs` TypeError when a question reached `AskDialogComponent` without a string `question` field; questions are now normalized at dialog entry, mirroring the transcript renderer ([#7211](https://github.com/can1357/oh-my-pi/issues/7211)).
 - Fixed Codex web search collapsing backend errors to `Codex error (): Unknown error`; the SSE error parser now preserves the backend code and message from top-level, nested `error`, and `response.error` envelopes ([#7200](https://github.com/can1357/oh-my-pi/issues/7200)).
+### Added
+
+- Added user-authorized cross-session agent channels with bidirectional group messaging, channel-scoped recipient fanout, user and agent revocation, and member termination notifications.
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -133,6 +133,7 @@ export const TAB_GROUPS: Record<SettingTab, readonly string[]> = {
 		"Notifications",
 		"Speech",
 		"Collab",
+		"Agent Channels",
 		"Magic Keywords",
 		"Startup & Updates",
 		"Power (macOS)",
@@ -1993,6 +1994,18 @@ export const SETTINGS_SCHEMA = {
 				{ value: "300", label: "5 minutes" },
 				{ value: "600", label: "10 minutes" },
 			],
+		},
+	},
+
+	// Cross-session agent channels are opt-in while the feature stabilizes.
+	"channels.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			group: "Agent Channels",
+			label: "Cross-session agent channels",
+			description: "Advertise this session to other local OMP sessions and allow user-authorized agent channels",
 		},
 	},
 

--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -37,6 +37,28 @@ export interface IrcDeliveryReceipt {
 	outcome: "injected" | "woken" | "revived" | "failed";
 	error?: string;
 }
+export interface IrcExternalPeer {
+	id: string;
+	displayName: string;
+	kind: string;
+	status: string;
+	parentId?: string;
+	lastActivity: number;
+	activity?: string;
+	channelId: string;
+}
+
+export interface IrcExternalTransport {
+	handles(address: string): boolean;
+	validateTargets(addresses: readonly string[]): string | undefined;
+	send(
+		message: Omit<IrcMessage, "id" | "ts">,
+		options?: { expectsReply?: boolean; suppressRelay?: boolean },
+	): Promise<IrcDeliveryReceipt>;
+	listPeers(): IrcExternalPeer[];
+	isPeerRunning(address: string): boolean;
+	onPeersChanged(listener: () => void): () => void;
+}
 
 interface IrcWaiter {
 	from?: string;
@@ -66,12 +88,36 @@ export class IrcBus {
 	readonly #lifecycle: () => AgentLifecycleManager;
 	readonly #mailboxes = new Map<string, IrcMessage[]>();
 	readonly #waiters = new Map<string, IrcWaiter[]>();
+	#externalTransport: IrcExternalTransport | undefined;
 
 	constructor(registry: AgentRegistry = AgentRegistry.global(), lifecycle?: AgentLifecycleManager) {
 		this.#registry = registry;
 		// Lazy: the lifecycle global self-constructs against the global registry,
 		// so only touch it when a parked recipient actually needs reviving.
 		this.#lifecycle = () => lifecycle ?? AgentLifecycleManager.global();
+	}
+
+	setExternalTransport(transport: IrcExternalTransport): void {
+		this.#externalTransport = transport;
+	}
+
+	clearExternalTransport(transport: IrcExternalTransport): void {
+		if (this.#externalTransport === transport) this.#externalTransport = undefined;
+	}
+
+	listExternalPeers(): IrcExternalPeer[] {
+		return this.#externalTransport?.listPeers() ?? [];
+	}
+
+	hasRunningExternalPeers(): boolean {
+		return this.listExternalPeers().some(peer => peer.status === "running");
+	}
+
+	validateExternalTargets(addresses: readonly string[]): string | undefined {
+		const transport = this.#externalTransport;
+		return transport
+			? transport.validateTargets(addresses)
+			: "Recipient arrays require an open cross-session channel.";
 	}
 
 	/**
@@ -105,10 +151,12 @@ export class IrcBus {
 		const message: IrcMessage = { ...msg, id: Snowflake.next(), ts: Date.now() };
 		const ref = this.#registry.get(message.to);
 		if (!ref) {
+			const external = this.#externalTransport;
+			if (external?.handles(message.to)) return external.send(msg, opts);
 			return {
 				to: message.to,
 				outcome: "failed",
-				error: `Unknown agent "${message.to}" — check \`irc list\` for live peers.`,
+				error: `Unknown agent "${message.to}" — check \`hub list\` for addressable peers.`,
 			};
 		}
 		if (ref.status === "aborted") {
@@ -221,6 +269,7 @@ export class IrcBus {
 		let timer: NodeJS.Timeout | undefined;
 		let onAbort: (() => void) | undefined;
 		let unsubscribeLiveness: (() => void) | undefined;
+		let unsubscribeExternalLiveness: (() => void) | undefined;
 
 		const liveness = options?.liveness;
 		const livenessReason = filter.from
@@ -245,6 +294,7 @@ export class IrcBus {
 			clearTimeout(timer);
 			if (signal && onAbort) signal.removeEventListener("abort", onAbort);
 			unsubscribeLiveness?.();
+			unsubscribeExternalLiveness?.();
 		};
 
 		const waiter: IrcWaiter = {
@@ -275,17 +325,21 @@ export class IrcBus {
 
 		if (liveness) {
 			const { registry, senderId } = liveness;
-			const hasRunningSender = (from?: string): boolean =>
-				registry.listVisibleTo(senderId).some(ref => ref.status === "running" && (!from || ref.id === from));
+			const hasRunningSender = (from?: string): boolean => {
+				const local = registry
+					.listVisibleTo(senderId)
+					.some(ref => ref.status === "running" && (!from || ref.id === from));
+				if (local) return true;
+				const external = this.#externalTransport;
+				return from ? external?.isPeerRunning(from) === true : this.hasRunningExternalPeers();
+			};
 			const check = filter.from ? () => hasRunningSender(filter.from) : () => hasRunningSender();
-			unsubscribeLiveness = registry.onChange(() => {
-				if (!check()) {
-					settle({ kind: "abort", error: new Error(livenessReason) });
-				}
-			});
-			if (!check()) {
-				settle({ kind: "abort", error: new Error(livenessReason) });
-			}
+			const checkLiveness = (): void => {
+				if (!check()) settle({ kind: "abort", error: new Error(livenessReason) });
+			};
+			unsubscribeLiveness = registry.onChange(checkLiveness);
+			unsubscribeExternalLiveness = this.#externalTransport?.onPeersChanged(checkLiveness);
+			checkLiveness();
 		}
 
 		return promise;

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -6,6 +6,7 @@ import { Process, type PtyRunResult, PtySession } from "@oh-my-pi/pi-natives";
 import { isEexist, isEnoent, logger, postmortem, procmgr, sanitizeText, setProcessName } from "@oh-my-pi/pi-utils";
 import { hostHasInheritableConsole } from "../eval/py/spawn-options";
 import { truncateHead, truncateHeadBytes, truncateTail, truncateTailBytes } from "../session/streaming-output";
+import { SessionChannelBroker } from "../session-channels/broker";
 import { workerEnvFromParent } from "../subprocess/worker-client";
 import { daemonBrokerEndpoint } from "./paths";
 import { hasLiveDaemonProjectPresence } from "./presence";
@@ -361,6 +362,7 @@ class DaemonBroker {
 	 * profile lock) or keeps running untracked.
 	 */
 	readonly #startingNames = new Set<string>();
+	readonly #sessionChannels = new SessionChannelBroker();
 	readonly #clients = new Set<net.Socket>();
 	readonly #ownerSockets = new Map<string, { socket: net.Socket; subscriptionId: string | undefined }>();
 	readonly #completionSubscriptions = new Map<string, string | undefined>();
@@ -407,6 +409,7 @@ class DaemonBroker {
 			await record.persistQueue;
 		}
 		this.#ownerSockets.clear();
+		this.#sessionChannels.shutdown();
 		for (const socket of this.#sockets) socket.destroy();
 		this.#sockets.clear();
 		this.#clients.clear();
@@ -450,6 +453,7 @@ class DaemonBroker {
 		});
 		socket.on("close", () => {
 			this.#sockets.delete(socket);
+			this.#sessionChannels.disconnectSocket(socket);
 			if (!authenticated) return;
 			this.#clients.delete(socket);
 			this.#scheduleIdleShutdown();
@@ -539,7 +543,7 @@ class DaemonBroker {
 					if (registration?.subscriptionId === request.completionSubscriptionId) this.#ownerSockets.delete(owner);
 				}
 			}
-			const result = await this.#dispatch(request.operation);
+			const result = await this.#dispatch(request.operation, socket);
 			socket.write(`${JSON.stringify({ id, ok: true, result })}\n`);
 			if (request.operation.op === "shutdown") setTimeout(() => void this.shutdown(), 10);
 		} catch (error) {
@@ -548,7 +552,7 @@ class DaemonBroker {
 		}
 	}
 
-	async #dispatch(operation: DaemonOperation): Promise<DaemonRpcResult> {
+	async #dispatch(operation: DaemonOperation, socket: net.Socket): Promise<DaemonRpcResult> {
 		switch (operation.op) {
 			case "ping":
 				return { op: "ping", projectDir: this.#projectDir };
@@ -579,6 +583,8 @@ class DaemonBroker {
 				await this.#refreshDetached(record);
 				return { op: "describe", daemon: record.snapshot, spec: record.spec };
 			}
+			case "channel":
+				return { op: "channel", result: await this.#sessionChannels.dispatch(operation.operation, socket) };
 			case "shutdown":
 				return { op: "shutdown" };
 		}

--- a/packages/coding-agent/src/launch/client.ts
+++ b/packages/coding-agent/src/launch/client.ts
@@ -111,6 +111,8 @@ function requestTimeoutMs(operation: DaemonOperation): number {
 		case "logs":
 		case "stop":
 			return operation.timeoutMs + 5_000;
+		case "channel":
+			return operation.operation.op === "wait" ? operation.operation.timeoutMs + 5_000 : 30_000;
 		default:
 			return 30_000;
 	}

--- a/packages/coding-agent/src/launch/protocol.ts
+++ b/packages/coding-agent/src/launch/protocol.ts
@@ -1,3 +1,10 @@
+import {
+	parseSessionChannelOperation,
+	parseSessionChannelResult,
+	type SessionChannelOperation,
+	type SessionChannelResult,
+} from "../session-channels/protocol";
+
 /**
  * Cross-process daemon broker protocol shared by the tool, client, and broker.
  */
@@ -92,6 +99,7 @@ export type DaemonOperation =
 	| { op: "stop"; name: string; timeoutMs: number }
 	| { op: "restart"; name: string }
 	| { op: "describe"; name: string }
+	| { op: "channel"; operation: SessionChannelOperation }
 	| { op: "shutdown" };
 
 /** Typed broker result decoded before it reaches tool code. */
@@ -116,6 +124,7 @@ export type DaemonRpcResult =
 	| { op: "stop"; daemon: DaemonSnapshot }
 	| { op: "restart"; daemon: DaemonSnapshot }
 	| { op: "describe"; daemon: DaemonSnapshot; spec: DaemonSpec }
+	| { op: "channel"; result: SessionChannelResult }
 	| { op: "shutdown" };
 
 /** Authenticated request envelope used by socket clients. */
@@ -389,6 +398,8 @@ function parseDaemonOperation(value: unknown): DaemonOperation {
 		case "restart":
 		case "describe":
 			return { op, name: stringValue(source.name, "operation.name") };
+		case "channel":
+			return { op, operation: parseSessionChannelOperation(source.operation) };
 		default:
 			throw new Error(`Unknown daemon operation: ${op}`);
 	}
@@ -442,6 +453,8 @@ export function parseDaemonRpcResult(operation: DaemonOperation, value: unknown)
 				daemon: parseDaemonSnapshot(source.daemon),
 				spec: parseDaemonSpec(source.spec),
 			};
+		case "channel":
+			return { op: "channel", result: parseSessionChannelResult(operation.operation, source.result) };
 		case "shutdown":
 			return { op: "shutdown" };
 	}

--- a/packages/coding-agent/src/prompts/tools/hub.md
+++ b/packages/coding-agent/src/prompts/tools/hub.md
@@ -1,11 +1,23 @@
-Agent coordination: peer messaging, background-job control, and supervised long-running processes. Main agent is `Main`; subagents inherit task ID.
-Use `op: "list"` to discover peers. Address peers by exact roster ID — NEVER invent names.
+Agent coordination: peer messaging, user-authorized cross-session channels, background jobs, and supervised processes. Main agent is `Main`; subagents inherit task ID.
+Use `op: "list"` to discover exact peer addresses. NEVER invent addresses.
+
+# Cross-Session Channels
+
+Users alone open or add sessions to channels. Agents NEVER authorize communication.
+
+- **`channels`** lists active groups, member agents, and broadcast addresses.
+- **Direct**: send to one exact roster address.
+- **Selected**: `to` MAY be an array of 1+ same-channel addresses.
+- **All**: send to `<channel-id>/all`; plain `all` remains process-local.
+- **`disconnect`** leaves this session's channel by agent initiative.
+- Disconnect is final. Resuming REQUIRES new user authorization.
+- Session/agent termination notices reach every remaining channel agent.
 
 # Messaging & Jobs
 
 Background jobs auto-deliver when they finish. You NEVER need to poll; if `jobs`/`wait` observes a settled job first, that snapshot is the delivery and suppresses duplicate `async-result`.
 
-- **`send`** (with `to`): fire-and-forget, NEVER blocks. Delivery receipts (`delivered`/`failed`) immediate; `failed` → peer gone, don't retry.
+- **`send`** (with `to`): fire-and-forget, NEVER blocks. Receipts (`injected`/`woken`/`revived`/`failed`) are immediate; `failed` → peer unavailable.
   Sending wakes `idle`/`parked` peers. Answering: lead with answer, NEVER quote, set `replyTo`.
 - **Format**: plain prose ONLY. No JSON status objects. Share paths via `local://`/`artifact://` URLs, not pasted blobs.
 - **`wait`**: use ONLY when completely blocked with no other work. Returns on the FIRST of: an incoming message, a watched job finishing, the wait window elapsing, or a steering interrupt — NOT when all jobs finish; re-issue to keep waiting.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3496,7 +3496,11 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			throw new Error(`Agent "${resolvedAgentId}" was replaced during session initialization.`);
 		}
 		hasRegistered = true;
-		if (agentKind === "main" && options.hasUI && !options.parentTaskPrefix) {
+		const sessionChannelsEnabled =
+			settings.get("channels.enabled") ||
+			process.env.OMP_SESSION_CHANNELS === "1" ||
+			process.env.PI_SESSION_CHANNELS === "1";
+		if (agentKind === "main" && options.hasUI && !options.parentTaskPrefix && sessionChannelsEnabled) {
 			try {
 				sessionChannelManager = await SessionChannelManager.start(session, agentRegistry);
 			} catch (error) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -161,6 +161,7 @@ import { collectMountedMCPToolRoutes, projectMountedMCPXdevGuidance } from "./se
 import { createSettingsAwareStreamFn } from "./session/settings-stream-fn";
 import { SnapcompactInlineTransformer } from "./session/snapcompact-inline";
 import { createSnapcompactSavingsRecorder } from "./session/snapcompact-savings-journal";
+import { SessionChannelManager } from "./session-channels/manager";
 import { closeAllConnections } from "./ssh/connection-manager";
 import { unmountAll } from "./ssh/sshfs-mount";
 import {
@@ -1656,6 +1657,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		options.agentDisplayName ?? ((options.taskDepth ?? 0) > 0 || options.parentTaskPrefix ? "sub" : "main");
 	const agentKind = (options.taskDepth ?? 0) > 0 || options.parentTaskPrefix ? ("sub" as const) : ("main" as const);
 	let registeredAgentRef: AgentRef | undefined;
+	let sessionChannelManager: SessionChannelManager | undefined;
 	/**
 	 * Forget the agent ref on teardown — unless it is a retained terminal ref.
 	 * Parking disposes the session but keeps the ref addressable (history://,
@@ -3494,6 +3496,15 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			throw new Error(`Agent "${resolvedAgentId}" was replaced during session initialization.`);
 		}
 		hasRegistered = true;
+		if (agentKind === "main" && options.hasUI && !options.parentTaskPrefix) {
+			try {
+				sessionChannelManager = await SessionChannelManager.start(session, agentRegistry);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				session.configWarnings.push(`Cross-session channels unavailable: ${message}`);
+				logger.warn("Failed to start cross-session channel manager", { error: message });
+			}
+		}
 		// MCP notification bridge cleanup — assigned when the bridge is wired below,
 		// invoked from the dispose wrapper AND registered as a postmortem so both
 		// explicit-dispose (SDK embedders that reuse the process across sessions) and
@@ -3511,6 +3522,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					// begins — the lifecycle await below opens an async gap before
 					// AgentSession.dispose() would otherwise set its guards.
 					session.beginDispose();
+					await sessionChannelManager?.close();
 					if (agentKind === "main") {
 						// Top-level teardown owns the global agent lifecycle: park timers,
 						// adopted subagent sessions, revivers. Tear it down while shared

--- a/packages/coding-agent/src/session-channels/broker.ts
+++ b/packages/coding-agent/src/session-channels/broker.ts
@@ -59,25 +59,11 @@ export class SessionChannelBroker {
 			case "open":
 				this.#assertSocketSession(operation.sessionId, socket);
 				return { op: "open", channel: this.#open(operation.sessionId, operation.memberIds, operation.name) };
-			case "add":
+			case "set-members":
 				this.#assertSocketSession(operation.sessionId, socket);
 				return {
-					op: "add",
-					channel: this.#add(operation.sessionId, operation.channelId, operation.memberIds),
-				};
-			case "remove":
-				this.#assertSocketSession(operation.sessionId, socket);
-				if (operation.memberId === operation.sessionId) {
-					throw new Error("Use leave to remove the initiating session from a channel");
-				}
-				return {
-					op: "remove",
-					channel: this.#removeMember(
-						this.#memberChannel(operation.channelId, operation.sessionId),
-						operation.memberId,
-						"user",
-						operation.sessionId,
-					),
+					op: "set-members",
+					channel: this.#setMembers(operation.sessionId, operation.channelId, operation.memberIds),
 				};
 			case "close":
 				this.#assertSocketSession(operation.sessionId, socket);
@@ -173,12 +159,36 @@ export class SessionChannelBroker {
 		return snapshot;
 	}
 
-	#add(sessionId: string, channelId: string, requestedMemberIds: string[]): SessionChannelSnapshot {
+	#setMembers(sessionId: string, channelId: string, requestedMemberIds: string[]): SessionChannelSnapshot {
 		const channel = this.#memberChannel(channelId, sessionId);
-		for (const memberId of new Set(requestedMemberIds)) {
-			this.#session(memberId);
-			channel.members.add(memberId);
+		const nextMemberIds = [...new Set([sessionId, ...requestedMemberIds])];
+		if (nextMemberIds.length < 2) throw new Error("A channel requires at least one other running session");
+		for (const memberId of nextMemberIds) this.#session(memberId);
+
+		const previousMemberIds = new Set(channel.members);
+		const nextMembers = new Set(nextMemberIds);
+		const removedIds = [...previousMemberIds].filter(memberId => !nextMembers.has(memberId));
+		const retainedIds = nextMemberIds.filter(memberId => previousMemberIds.has(memberId));
+		channel.members = nextMembers;
+		const remainingMembers = nextMemberIds.map(memberId => this.#session(memberId).snapshot);
+
+		for (const removedId of removedIds) {
+			const member = this.#session(removedId).snapshot;
+			this.#purgeMessages(channel.id, removedId);
+			const event: SessionChannelEvent = {
+				type: "member-left",
+				channelId: channel.id,
+				channelName: channel.name,
+				member,
+				reason: "user",
+				actorSessionId: sessionId,
+				remainingMembers,
+				closed: false,
+			};
+			for (const retainedId of retainedIds) this.#enqueue(this.#session(retainedId), event);
+			this.#enqueue(this.#session(removedId), event);
 		}
+
 		const snapshot = this.#snapshot(channel);
 		this.#broadcast(channel, { type: "channel-updated", channel: snapshot });
 		return snapshot;

--- a/packages/coding-agent/src/session-channels/broker.ts
+++ b/packages/coding-agent/src/session-channels/broker.ts
@@ -1,0 +1,361 @@
+import type * as net from "node:net";
+import type {
+	ChannelLeaveReason,
+	ChannelSessionSnapshot,
+	SessionChannelEvent,
+	SessionChannelOperation,
+	SessionChannelResult,
+	SessionChannelSnapshot,
+} from "./protocol";
+
+const EVENT_QUEUE_CAP = 100;
+
+interface PendingEventWait {
+	resolve: (event: SessionChannelEvent | null) => void;
+	timer?: NodeJS.Timeout;
+}
+
+interface RegisteredChannelSession {
+	snapshot: ChannelSessionSnapshot;
+	socket: net.Socket;
+	events: SessionChannelEvent[];
+	waiter?: PendingEventWait;
+}
+
+interface ChannelRecord {
+	id: string;
+	name?: string;
+	createdAt: number;
+	members: Set<string>;
+}
+
+/** User-global channel state hosted inside the authenticated daemon broker. */
+export class SessionChannelBroker {
+	readonly #sessions = new Map<string, RegisteredChannelSession>();
+	readonly #sessionIdsBySocket = new Map<net.Socket, string>();
+	readonly #channels = new Map<string, ChannelRecord>();
+
+	async dispatch(operation: SessionChannelOperation, socket: net.Socket): Promise<SessionChannelResult> {
+		switch (operation.op) {
+			case "register":
+				return this.#register(operation.session, socket);
+			case "unregister":
+				this.#assertSocketSession(operation.sessionId, socket);
+				this.#dropSession(operation.sessionId, "session-ended");
+				return { op: "unregister" };
+			case "list": {
+				this.#assertSocketSession(operation.sessionId, socket);
+				const channels = [...this.#channels.values()]
+					.filter(channel => channel.members.has(operation.sessionId))
+					.map(channel => this.#snapshot(channel));
+				return {
+					op: "list",
+					sessions: [...this.#sessions.values()]
+						.map(record => record.snapshot)
+						.sort((a, b) => a.startedAt - b.startedAt || a.id.localeCompare(b.id)),
+					channels,
+				};
+			}
+			case "open":
+				this.#assertSocketSession(operation.sessionId, socket);
+				return { op: "open", channel: this.#open(operation.sessionId, operation.memberIds, operation.name) };
+			case "add":
+				this.#assertSocketSession(operation.sessionId, socket);
+				return {
+					op: "add",
+					channel: this.#add(operation.sessionId, operation.channelId, operation.memberIds),
+				};
+			case "remove":
+				this.#assertSocketSession(operation.sessionId, socket);
+				if (operation.memberId === operation.sessionId) {
+					throw new Error("Use leave to remove the initiating session from a channel");
+				}
+				return {
+					op: "remove",
+					channel: this.#removeMember(
+						this.#memberChannel(operation.channelId, operation.sessionId),
+						operation.memberId,
+						"user",
+						operation.sessionId,
+					),
+				};
+			case "close":
+				this.#assertSocketSession(operation.sessionId, socket);
+				this.#close(this.#memberChannel(operation.channelId, operation.sessionId), operation.sessionId);
+				return { op: "close" };
+			case "leave":
+				this.#assertSocketSession(operation.sessionId, socket);
+				return {
+					op: "leave",
+					channel: this.#removeMember(
+						this.#memberChannel(operation.channelId, operation.sessionId),
+						operation.sessionId,
+						operation.reason,
+						operation.sessionId,
+					),
+				};
+			case "update":
+				return this.#update(operation.session, socket);
+			case "send":
+				this.#assertSocketSession(operation.sessionId, socket);
+				return { op: "send", targets: this.#send(operation) };
+			case "wait":
+				this.#assertSocketSession(operation.sessionId, socket);
+				return { op: "wait", event: await this.#wait(operation.sessionId, operation.timeoutMs) };
+		}
+	}
+
+	disconnectSocket(socket: net.Socket): void {
+		const sessionId = this.#sessionIdsBySocket.get(socket);
+		if (sessionId) this.#dropSession(sessionId, "session-ended");
+	}
+
+	shutdown(): void {
+		for (const record of this.#sessions.values()) {
+			clearTimeout(record.waiter?.timer);
+			record.waiter?.resolve(null);
+		}
+		this.#sessions.clear();
+		this.#sessionIdsBySocket.clear();
+		this.#channels.clear();
+	}
+
+	#register(snapshot: ChannelSessionSnapshot, socket: net.Socket): SessionChannelResult {
+		const socketSessionId = this.#sessionIdsBySocket.get(socket);
+		if (socketSessionId && socketSessionId !== snapshot.id) {
+			throw new Error(`Broker connection is already registered as session ${socketSessionId}`);
+		}
+		const existing = this.#sessions.get(snapshot.id);
+		if (existing && existing.socket !== socket) throw new Error(`Session ${snapshot.id} is already registered`);
+		if (existing) {
+			existing.snapshot = snapshot;
+		} else {
+			this.#sessions.set(snapshot.id, { snapshot, socket, events: [] });
+			this.#sessionIdsBySocket.set(socket, snapshot.id);
+		}
+		return { op: "register", session: snapshot };
+	}
+
+	#update(snapshot: ChannelSessionSnapshot, socket: net.Socket): SessionChannelResult {
+		this.#assertSocketSession(snapshot.id, socket);
+		const record = this.#session(snapshot.id);
+		const currentAgentIds = new Set(snapshot.agents.map(agent => agent.id));
+		const departedAgents = record.snapshot.agents.filter(agent => !currentAgentIds.has(agent.id));
+		record.snapshot = snapshot;
+		for (const channel of this.#channels.values()) {
+			if (!channel.members.has(snapshot.id)) continue;
+			for (const agent of departedAgents) {
+				this.#broadcast(channel, {
+					type: "agent-left",
+					channelId: channel.id,
+					channelName: channel.name,
+					sessionId: snapshot.id,
+					agent,
+				});
+			}
+			this.#broadcast(channel, { type: "channel-updated", channel: this.#snapshot(channel) });
+		}
+		return { op: "update", session: snapshot };
+	}
+
+	#open(sessionId: string, requestedMemberIds: string[], name?: string): SessionChannelSnapshot {
+		const memberIds = [...new Set([sessionId, ...requestedMemberIds])];
+		if (memberIds.length < 2) throw new Error("Opening a channel requires at least one other running session");
+		for (const memberId of memberIds) this.#session(memberId);
+		let id: string;
+		do {
+			id = crypto.randomUUID().replaceAll("-", "").slice(0, 16);
+		} while (this.#channels.has(id));
+		const channel: ChannelRecord = { id, name, createdAt: Date.now(), members: new Set(memberIds) };
+		this.#channels.set(id, channel);
+		const snapshot = this.#snapshot(channel);
+		this.#broadcast(channel, { type: "channel-updated", channel: snapshot });
+		return snapshot;
+	}
+
+	#add(sessionId: string, channelId: string, requestedMemberIds: string[]): SessionChannelSnapshot {
+		const channel = this.#memberChannel(channelId, sessionId);
+		for (const memberId of new Set(requestedMemberIds)) {
+			this.#session(memberId);
+			channel.members.add(memberId);
+		}
+		const snapshot = this.#snapshot(channel);
+		this.#broadcast(channel, { type: "channel-updated", channel: snapshot });
+		return snapshot;
+	}
+
+	#close(channel: ChannelRecord, actorSessionId: string): void {
+		const snapshot = this.#snapshot(channel);
+		this.#channels.delete(channel.id);
+		this.#broadcast(channel, {
+			type: "channel-closed",
+			channel: snapshot,
+			reason: "user",
+			actorSessionId,
+		});
+	}
+
+	#removeMember(
+		channel: ChannelRecord,
+		memberId: string,
+		reason: ChannelLeaveReason,
+		actorSessionId?: string,
+	): SessionChannelSnapshot | null {
+		if (!channel.members.has(memberId)) throw new Error(`Session ${memberId} is not in channel ${channel.id}`);
+		const member = this.#session(memberId).snapshot;
+		channel.members.delete(memberId);
+		this.#purgeMessages(channel.id, memberId);
+		const remainingMembers = [...channel.members].map(id => this.#session(id).snapshot);
+		const closed = channel.members.size < 2;
+		if (closed) this.#channels.delete(channel.id);
+		const event: SessionChannelEvent = {
+			type: "member-left",
+			channelId: channel.id,
+			channelName: channel.name,
+			member,
+			reason,
+			actorSessionId,
+			remainingMembers,
+			closed,
+		};
+		for (const remainingId of channel.members) this.#enqueue(this.#session(remainingId), event);
+		if (reason === "user" && actorSessionId !== memberId) {
+			this.#enqueue(this.#session(memberId), event);
+		}
+		return closed ? null : this.#snapshot(channel);
+	}
+
+	#dropSession(sessionId: string, reason: "session-ended"): void {
+		const record = this.#sessions.get(sessionId);
+		if (!record) return;
+		for (const channel of [...this.#channels.values()]) {
+			if (channel.members.has(sessionId)) this.#removeMember(channel, sessionId, reason);
+		}
+		clearTimeout(record.waiter?.timer);
+		record.waiter?.resolve(null);
+		this.#sessions.delete(sessionId);
+		this.#sessionIdsBySocket.delete(record.socket);
+	}
+
+	#send(operation: Extract<SessionChannelOperation, { op: "send" }>): number {
+		const channel = this.#memberChannel(operation.channelId, operation.sessionId);
+		const sender = this.#session(operation.sessionId).snapshot;
+		if (!sender.agents.some(agent => agent.id === operation.fromAgentId)) {
+			throw new Error(`Agent ${operation.fromAgentId} is not registered in session ${operation.sessionId}`);
+		}
+
+		const channelWide = operation.targetSessionId === undefined;
+		const targetSessions = operation.targetSessionId ? [operation.targetSessionId] : [...channel.members];
+		let targets = 0;
+		for (const targetSessionId of targetSessions) {
+			if (!channel.members.has(targetSessionId)) {
+				throw new Error(`Session ${targetSessionId} is not in channel ${channel.id}`);
+			}
+			const target = this.#session(targetSessionId);
+			const targetAgentIds =
+				operation.targetAgentId === "all"
+					? target.snapshot.agents.map(agent => agent.id)
+					: [operation.targetAgentId];
+			for (const targetAgentId of targetAgentIds) {
+				if (targetSessionId === operation.sessionId && targetAgentId === operation.fromAgentId) continue;
+				if (!target.snapshot.agents.some(agent => agent.id === targetAgentId)) {
+					throw new Error(`Agent ${targetAgentId} is not registered in session ${targetSessionId}`);
+				}
+				if (!channelWide && targetSessionId === operation.sessionId) {
+					throw new Error("Direct channel targets must belong to another session");
+				}
+				this.#enqueue(target, {
+					type: "message",
+					channelId: channel.id,
+					fromSessionId: operation.sessionId,
+					fromAgentId: operation.fromAgentId,
+					toAgentId: targetAgentId,
+					body: operation.body,
+					replyTo: operation.replyTo,
+				});
+				targets++;
+			}
+		}
+		if (targets === 0) throw new Error("No other agents are available in this channel");
+		return targets;
+	}
+
+	#wait(sessionId: string, timeoutMs: number): Promise<SessionChannelEvent | null> {
+		const record = this.#session(sessionId);
+		const pending = record.events.shift();
+		if (pending) return Promise.resolve(pending);
+		if (record.waiter) throw new Error(`Session ${sessionId} already has a pending channel wait`);
+		const { promise, resolve } = Promise.withResolvers<SessionChannelEvent | null>();
+		const waiter: PendingEventWait = { resolve };
+		if (timeoutMs > 0) {
+			waiter.timer = setTimeout(() => {
+				if (record.waiter !== waiter) return;
+				record.waiter = undefined;
+				resolve(null);
+			}, timeoutMs);
+			waiter.timer.unref?.();
+		}
+		record.waiter = waiter;
+		return promise;
+	}
+
+	#enqueue(record: RegisteredChannelSession, event: SessionChannelEvent): void {
+		const waiter = record.waiter;
+		if (waiter) {
+			record.waiter = undefined;
+			clearTimeout(waiter.timer);
+			waiter.resolve(event);
+			return;
+		}
+		record.events.push(event);
+		if (record.events.length > EVENT_QUEUE_CAP) record.events.shift();
+	}
+
+	#broadcast(channel: ChannelRecord, event: SessionChannelEvent): void {
+		for (const memberId of channel.members) this.#enqueue(this.#session(memberId), event);
+	}
+
+	#purgeMessages(channelId: string, departedSessionId: string): void {
+		for (const record of this.#sessions.values()) {
+			for (let index = record.events.length - 1; index >= 0; index--) {
+				const event = record.events[index];
+				if (
+					event?.type === "message" &&
+					event.channelId === channelId &&
+					event.fromSessionId === departedSessionId
+				) {
+					record.events.splice(index, 1);
+				}
+			}
+		}
+	}
+
+	#snapshot(channel: ChannelRecord): SessionChannelSnapshot {
+		return {
+			id: channel.id,
+			name: channel.name,
+			createdAt: channel.createdAt,
+			members: [...channel.members]
+				.map(id => this.#session(id).snapshot)
+				.sort((a, b) => a.startedAt - b.startedAt || a.id.localeCompare(b.id)),
+		};
+	}
+
+	#session(sessionId: string): RegisteredChannelSession {
+		const session = this.#sessions.get(sessionId);
+		if (!session) throw new Error(`Unknown running session ${sessionId}`);
+		return session;
+	}
+
+	#memberChannel(channelId: string, sessionId: string): ChannelRecord {
+		const channel = this.#channels.get(channelId);
+		if (!channel) throw new Error(`Unknown or closed channel ${channelId}`);
+		if (!channel.members.has(sessionId)) throw new Error(`Session ${sessionId} is not in channel ${channelId}`);
+		return channel;
+	}
+
+	#assertSocketSession(sessionId: string, socket: net.Socket): void {
+		const registeredId = this.#sessionIdsBySocket.get(socket);
+		if (registeredId !== sessionId) throw new Error(`Broker connection is not registered as session ${sessionId}`);
+	}
+}

--- a/packages/coding-agent/src/session-channels/command.ts
+++ b/packages/coding-agent/src/session-channels/command.ts
@@ -1,0 +1,111 @@
+import { commandConsumed } from "../slash-commands/helpers/parse";
+import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime } from "../slash-commands/types";
+import { shortenPath } from "../tools/render-utils";
+import { SessionChannelManager, type SessionChannelState } from "./manager";
+import type { SessionChannelSnapshot } from "./protocol";
+
+function formatChannel(channel: SessionChannelSnapshot, selfId: string): string[] {
+	const name = channel.name ? ` (${channel.name})` : "";
+	const lines = [`- ${channel.id}${name} — ${channel.members.length} sessions — agent broadcast: ${channel.id}/all`];
+	for (const member of channel.members) {
+		const marker = member.id === selfId ? " (this session)" : "";
+		const label = member.title ?? shortenPath(member.cwd);
+		lines.push(`  - ${member.id}${marker} — ${label}`);
+		for (const agent of member.agents) {
+			const address = `${channel.id}/${member.id}/${agent.id}`;
+			lines.push(`    - ${address} [${agent.displayName} · ${agent.status}]`);
+		}
+	}
+	return lines;
+}
+
+function formatState(state: SessionChannelState): string {
+	const lines = [`This running session: ${state.self.id}`];
+	if (state.channels.length === 0) {
+		lines.push("Open channels: none");
+	} else {
+		lines.push("Open channels:");
+		for (const channel of state.channels) lines.push(...formatChannel(channel, state.self.id));
+	}
+	const available = state.sessions.filter(session => session.id !== state.self.id);
+	if (available.length === 0) {
+		lines.push("Other running sessions: none");
+	} else {
+		lines.push("Other running sessions:");
+		for (const session of available) {
+			lines.push(`- ${session.id} — ${session.title ?? shortenPath(session.cwd)} — ${session.agents.length} agents`);
+		}
+	}
+	lines.push("Authorize: /channel open <session-id> [session-id ...]");
+	return lines.join("\n");
+}
+
+/** User-only authorization and revocation surface for cross-session groups. */
+export async function handleSessionChannelCommand(
+	command: ParsedSlashCommand,
+	runtime: SlashCommandRuntime,
+): Promise<SlashCommandResult> {
+	const manager = SessionChannelManager.forSession(runtime.session);
+	if (!manager) {
+		await runtime.output("Cross-session channels are unavailable in this session.");
+		return commandConsumed();
+	}
+	const [verb = "list", ...args] = command.args.trim().split(/\s+/).filter(Boolean);
+	try {
+		switch (verb) {
+			case "list":
+			case "status":
+				await runtime.output(formatState(await manager.state()));
+				break;
+			case "open": {
+				if (args.length === 0) throw new Error("Usage: /channel open <session-id> [session-id ...]");
+				const channel = await manager.open(args);
+				await runtime.output(
+					`Channel ${channel.id} opened with ${channel.members.length} sessions. Every member can send to ${channel.id}/all or select one or more listed agent addresses.`,
+				);
+				break;
+			}
+			case "add": {
+				const [channel, ...sessions] = args;
+				if (!channel || sessions.length === 0) {
+					throw new Error("Usage: /channel add <channel-id> <session-id> [session-id ...]");
+				}
+				const updated = await manager.add(channel, sessions);
+				await runtime.output(`Channel ${updated.id} now has ${updated.members.length} sessions.`);
+				break;
+			}
+			case "remove": {
+				const [channel, session] = args;
+				if (!channel || !session || args.length !== 2) {
+					throw new Error("Usage: /channel remove <channel-id> <session-id>");
+				}
+				const updated = await manager.remove(channel, session);
+				await runtime.output(
+					updated
+						? `Session removed. Channel ${updated.id} remains open with ${updated.members.length} sessions.`
+						: "Session removed. Fewer than two sessions remain, so the channel closed.",
+				);
+				break;
+			}
+			case "leave": {
+				const [channel] = args;
+				if (!channel || args.length !== 1) throw new Error("Usage: /channel leave <channel-id>");
+				await manager.leave(channel, "user");
+				await runtime.output(`Left channel ${channel}. Rejoining requires new user authorization.`);
+				break;
+			}
+			case "close": {
+				const [channel] = args;
+				if (!channel || args.length !== 1) throw new Error("Usage: /channel close <channel-id>");
+				await manager.closeChannel(channel);
+				await runtime.output(`Closed channel ${channel}. Reopening requires new user authorization.`);
+				break;
+			}
+			default:
+				throw new Error(`Unknown /channel action: ${verb}`);
+		}
+	} catch (error) {
+		await runtime.output(error instanceof Error ? error.message : String(error));
+	}
+	return commandConsumed();
+}

--- a/packages/coding-agent/src/session-channels/command.ts
+++ b/packages/coding-agent/src/session-channels/command.ts
@@ -1,8 +1,13 @@
 import { commandConsumed } from "../slash-commands/helpers/parse";
-import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime } from "../slash-commands/types";
+import type {
+	ParsedSlashCommand,
+	SlashCommandResult,
+	SlashCommandRuntime,
+	TuiSlashCommandRuntime,
+} from "../slash-commands/types";
 import { shortenPath } from "../tools/render-utils";
 import { SessionChannelManager, type SessionChannelState } from "./manager";
-import type { SessionChannelSnapshot } from "./protocol";
+import type { ChannelSessionSnapshot, SessionChannelSnapshot } from "./protocol";
 
 function formatChannel(channel: SessionChannelSnapshot, selfId: string): string[] {
 	const name = channel.name ? ` (${channel.name})` : "";
@@ -36,76 +41,185 @@ function formatState(state: SessionChannelState): string {
 			lines.push(`- ${session.id} — ${session.title ?? shortenPath(session.cwd)} — ${session.agents.length} agents`);
 		}
 	}
-	lines.push("Authorize: /channel open <session-id> [session-id ...]");
+	lines.push("Authorize: /channel open (interactive) or /channel open <session-id> [session-id ...]");
 	return lines.join("\n");
 }
 
-/** User-only authorization and revocation surface for cross-session groups. */
+type ChannelOutput = (text: string) => Promise<void> | void;
+
+async function executeChannelAction(
+	manager: SessionChannelManager,
+	verb: string,
+	args: string[],
+	output: ChannelOutput,
+): Promise<void> {
+	switch (verb) {
+		case "list":
+		case "status":
+			await output(formatState(await manager.state()));
+			return;
+		case "open": {
+			if (args.length === 0) throw new Error("Usage: /channel open <session-id> [session-id ...]");
+			const channel = await manager.open(args);
+			await output(
+				`Channel ${channel.id} opened with ${channel.members.length} sessions. Every member can send to ${channel.id}/all or select one or more listed agent addresses.`,
+			);
+			return;
+		}
+		case "toggle": {
+			const [channel, ...sessions] = args;
+			if (!channel || sessions.length === 0) {
+				throw new Error("Usage: /channel toggle <channel-id> <session-id> [session-id ...]");
+			}
+			const updated = await manager.setMembers(channel, sessions);
+			await output(`Channel ${updated.id} now has ${updated.members.length} sessions.`);
+			return;
+		}
+		case "leave": {
+			const [channel] = args;
+			if (!channel || args.length !== 1) throw new Error("Usage: /channel leave <channel-id>");
+			await manager.leave(channel, "user");
+			await output(`Left channel ${channel}. Rejoining requires new user authorization.`);
+			return;
+		}
+		case "close": {
+			const [channel] = args;
+			if (!channel || args.length !== 1) throw new Error("Usage: /channel close <channel-id>");
+			await manager.closeChannel(channel);
+			await output(`Closed channel ${channel}. Reopening requires new user authorization.`);
+			return;
+		}
+		default:
+			throw new Error(`Unknown /channel action: ${verb}`);
+	}
+}
+
+async function selectSessions(
+	runtime: TuiSlashCommandRuntime,
+	title: string,
+	sessions: readonly ChannelSessionSnapshot[],
+	initiallySelected: ReadonlySet<string>,
+): Promise<string[] | undefined> {
+	const selected = new Set(initiallySelected);
+	const rows = sessions.map(session => ({
+		id: session.id,
+		label: `${session.id} — ${session.title ?? shortenPath(session.cwd)} — ${session.agents.length} agents`,
+	}));
+	const idByLabel = new Map(rows.map(row => [row.label, row.id]));
+
+	while (true) {
+		const doneLabel = `Done (${selected.size} selected)`;
+		const choice = await runtime.ctx.showHookSelector(title, [...rows.map(row => row.label), doneLabel], {
+			selectionMarker: "checkbox",
+			checkedIndices: rows.flatMap((row, index) => (selected.has(row.id) ? [index] : [])),
+			markableCount: rows.length,
+			disabledIndices: selected.size === 0 ? [rows.length] : [],
+			helpText: "Enter/click toggles · choose Done to apply · Esc cancels",
+		});
+		if (choice === undefined) return undefined;
+		if (choice === doneLabel) return [...selected];
+		const id = idByLabel.get(choice);
+		if (!id) continue;
+		if (selected.has(id)) selected.delete(id);
+		else selected.add(id);
+	}
+}
+
+function resolveChannel(query: string, channels: readonly SessionChannelSnapshot[]): SessionChannelSnapshot {
+	const matches = channels.filter(
+		channel => channel.id === query || channel.id.startsWith(query) || channel.name === query,
+	);
+	if (matches.length === 1 && matches[0]) return matches[0];
+	if (matches.length === 0) throw new Error(`No open channel matches ${query}`);
+	throw new Error(`Channel selector ${query} is ambiguous`);
+}
+
+/** Headless/ACP authorization surface. Interactive mode overrides open/toggle with selectors. */
 export async function handleSessionChannelCommand(
 	command: ParsedSlashCommand,
 	runtime: SlashCommandRuntime,
 ): Promise<SlashCommandResult> {
 	const manager = SessionChannelManager.forSession(runtime.session);
 	if (!manager) {
-		await runtime.output("Cross-session channels are unavailable in this session.");
+		await runtime.output(
+			"Cross-session channels are disabled. Enable Interaction → Agent Channels in /settings and restart.",
+		);
 		return commandConsumed();
 	}
 	const [verb = "list", ...args] = command.args.trim().split(/\s+/).filter(Boolean);
 	try {
-		switch (verb) {
-			case "list":
-			case "status":
-				await runtime.output(formatState(await manager.state()));
-				break;
-			case "open": {
-				if (args.length === 0) throw new Error("Usage: /channel open <session-id> [session-id ...]");
-				const channel = await manager.open(args);
-				await runtime.output(
-					`Channel ${channel.id} opened with ${channel.members.length} sessions. Every member can send to ${channel.id}/all or select one or more listed agent addresses.`,
-				);
-				break;
-			}
-			case "add": {
-				const [channel, ...sessions] = args;
-				if (!channel || sessions.length === 0) {
-					throw new Error("Usage: /channel add <channel-id> <session-id> [session-id ...]");
-				}
-				const updated = await manager.add(channel, sessions);
-				await runtime.output(`Channel ${updated.id} now has ${updated.members.length} sessions.`);
-				break;
-			}
-			case "remove": {
-				const [channel, session] = args;
-				if (!channel || !session || args.length !== 2) {
-					throw new Error("Usage: /channel remove <channel-id> <session-id>");
-				}
-				const updated = await manager.remove(channel, session);
-				await runtime.output(
-					updated
-						? `Session removed. Channel ${updated.id} remains open with ${updated.members.length} sessions.`
-						: "Session removed. Fewer than two sessions remain, so the channel closed.",
-				);
-				break;
-			}
-			case "leave": {
-				const [channel] = args;
-				if (!channel || args.length !== 1) throw new Error("Usage: /channel leave <channel-id>");
-				await manager.leave(channel, "user");
-				await runtime.output(`Left channel ${channel}. Rejoining requires new user authorization.`);
-				break;
-			}
-			case "close": {
-				const [channel] = args;
-				if (!channel || args.length !== 1) throw new Error("Usage: /channel close <channel-id>");
-				await manager.closeChannel(channel);
-				await runtime.output(`Closed channel ${channel}. Reopening requires new user authorization.`);
-				break;
-			}
-			default:
-				throw new Error(`Unknown /channel action: ${verb}`);
-		}
+		await executeChannelAction(manager, verb, args, runtime.output);
 	} catch (error) {
 		await runtime.output(error instanceof Error ? error.message : String(error));
+	}
+	return commandConsumed();
+}
+
+/** Interactive user authorization with checkbox selectors for opening and membership changes. */
+export async function handleSessionChannelTuiCommand(
+	command: ParsedSlashCommand,
+	runtime: TuiSlashCommandRuntime,
+): Promise<SlashCommandResult> {
+	const ctx = runtime.ctx;
+	ctx.editor.setText("");
+	const manager = SessionChannelManager.forSession(ctx.session);
+	if (!manager) {
+		ctx.showStatus(
+			"Cross-session channels are disabled. Enable Interaction → Agent Channels in /settings and restart.",
+		);
+		return commandConsumed();
+	}
+	const [verb = "list", ...args] = command.args.trim().split(/\s+/).filter(Boolean);
+	try {
+		if (verb === "open" && args.length === 0) {
+			const state = await manager.state();
+			const sessions = state.sessions.filter(session => session.id !== state.self.id);
+			if (sessions.length === 0) throw new Error("No other channel-capable sessions are running.");
+			const selected = await selectSessions(runtime, "Open channel with sessions", sessions, new Set());
+			if (!selected) return commandConsumed();
+			const channel = await manager.open(selected);
+			ctx.showStatus(`Channel ${channel.id} opened with ${channel.members.length} sessions.`);
+			return commandConsumed();
+		}
+
+		if (verb === "toggle" && args.length <= 1) {
+			const state = await manager.state();
+			if (state.channels.length === 0) throw new Error("No cross-session channels are open.");
+			let channel: SessionChannelSnapshot;
+			if (args[0]) {
+				channel = resolveChannel(args[0], state.channels);
+			} else if (state.channels.length === 1 && state.channels[0]) {
+				channel = state.channels[0];
+			} else {
+				const labels = state.channels.map(candidate =>
+					candidate.name ? `${candidate.id} — ${candidate.name}` : candidate.id,
+				);
+				const selectedChannel = await ctx.showHookSelector("Choose channel", labels);
+				if (!selectedChannel) return commandConsumed();
+				const index = labels.indexOf(selectedChannel);
+				const matched = state.channels[index];
+				if (!matched) return commandConsumed();
+				channel = matched;
+			}
+			const sessions = state.sessions.filter(session => session.id !== state.self.id);
+			const currentIds = new Set(
+				channel.members.filter(member => member.id !== state.self.id).map(member => member.id),
+			);
+			const selected = await selectSessions(
+				runtime,
+				`Toggle sessions in ${channel.name ?? channel.id}`,
+				sessions,
+				currentIds,
+			);
+			if (!selected) return commandConsumed();
+			const updated = await manager.setMembers(channel.id, selected);
+			ctx.showStatus(`Channel ${updated.id} now has ${updated.members.length} sessions.`);
+			return commandConsumed();
+		}
+
+		await executeChannelAction(manager, verb, args, text => ctx.showStatus(text));
+	} catch (error) {
+		ctx.showError(error instanceof Error ? error.message : String(error));
 	}
 	return commandConsumed();
 }

--- a/packages/coding-agent/src/session-channels/manager.ts
+++ b/packages/coding-agent/src/session-channels/manager.ts
@@ -33,7 +33,7 @@ function channelAddress(channelId: string, sessionId: string, agentId: string): 
 }
 
 function sessionLabel(session: ChannelSessionSnapshot): string {
-	return session.title ?? path.basename(session.cwd) ?? session.id;
+	return session.title?.trim() || path.basename(session.cwd) || session.id;
 }
 
 interface ParsedChannelAddress {
@@ -114,31 +114,19 @@ export class SessionChannelManager implements IrcExternalTransport {
 		return result.channel;
 	}
 
-	async add(channelQuery: string, memberQueries: readonly string[]): Promise<SessionChannelSnapshot> {
-		if (memberQueries.length === 0) throw new Error("Adding members requires at least one target session");
+	async setMembers(channelQuery: string, memberQueries: readonly string[]): Promise<SessionChannelSnapshot> {
+		if (memberQueries.length === 0) throw new Error("A channel requires at least one other running session");
 		const state = await this.state();
 		const channel = this.#resolveChannel(channelQuery, state.channels);
 		const memberIds = memberQueries.map(query => this.#resolveSession(query, state.sessions).id);
-		const result = await this.#request({ op: "add", sessionId: this.id, channelId: channel.id, memberIds });
-		if (result.op !== "add") throw new Error(`Unexpected channel ${result.op} result`);
-		this.#channels.set(result.channel.id, result.channel);
-		this.#notifyPeerListeners();
-		return result.channel;
-	}
-
-	async remove(channelQuery: string, memberQuery: string): Promise<SessionChannelSnapshot | null> {
-		const state = await this.state();
-		const channel = this.#resolveChannel(channelQuery, state.channels);
-		const member = this.#resolveSession(memberQuery, channel.members);
 		const result = await this.#request({
-			op: "remove",
+			op: "set-members",
 			sessionId: this.id,
 			channelId: channel.id,
-			memberId: member.id,
+			memberIds,
 		});
-		if (result.op !== "remove") throw new Error(`Unexpected channel ${result.op} result`);
-		if (result.channel) this.#channels.set(result.channel.id, result.channel);
-		else this.#channels.delete(channel.id);
+		if (result.op !== "set-members") throw new Error(`Unexpected channel ${result.op} result`);
+		this.#channels.set(result.channel.id, result.channel);
 		this.#notifyPeerListeners();
 		return result.channel;
 	}
@@ -280,8 +268,19 @@ export class SessionChannelManager implements IrcExternalTransport {
 				if (result.event) await this.#handleEvent(result.event);
 			} catch (error) {
 				if (this.#closed) return;
+				const lostChannels = [...this.#channels.values()];
 				this.#channels.clear();
 				this.#notifyPeerListeners();
+				await Promise.all(
+					lostChannels.map(channel =>
+						this.#notifyLocalAgents(
+							channel.id,
+							`Connection to channel ${channel.name ?? channel.id} was lost when the channel broker disconnected. New user authorization is required to reconnect. No response is expected.`,
+						),
+					),
+				).catch(notifyError => {
+					logger.debug("Session channel disconnect notification failed", { error: String(notifyError) });
+				});
 				logger.debug("Session channel event wait failed; reconnecting", { error: String(error) });
 				await Bun.sleep(RECONNECT_DELAY_MS);
 				try {

--- a/packages/coding-agent/src/session-channels/manager.ts
+++ b/packages/coding-agent/src/session-channels/manager.ts
@@ -1,0 +1,441 @@
+import * as path from "node:path";
+import { getConfigRootDir, logger, postmortem } from "@oh-my-pi/pi-utils";
+import { IrcBus, type IrcDeliveryReceipt, type IrcExternalPeer, type IrcExternalTransport } from "../irc/bus";
+import type { DaemonBrokerClient } from "../launch/client";
+import * as launchClient from "../launch/client";
+import type { AgentRef, AgentRegistry } from "../registry/agent-registry";
+import type { AgentSession } from "../session/agent-session";
+import type {
+	ChannelAgentSnapshot,
+	ChannelSessionSnapshot,
+	SessionChannelEvent,
+	SessionChannelOperation,
+	SessionChannelResult,
+	SessionChannelSnapshot,
+} from "./protocol";
+
+const CHANNEL_WAIT_MS = 30_000;
+const RECONNECT_DELAY_MS = 250;
+const UPDATE_DEBOUNCE_MS = 25;
+
+export interface SessionChannelState {
+	self: ChannelSessionSnapshot;
+	sessions: ChannelSessionSnapshot[];
+	channels: SessionChannelSnapshot[];
+}
+
+function channelBrokerScope(): string {
+	return path.join(getConfigRootDir(), "run", "session-channels");
+}
+
+function channelAddress(channelId: string, sessionId: string, agentId: string): string {
+	return `${channelId}/${sessionId}/${agentId}`;
+}
+
+function sessionLabel(session: ChannelSessionSnapshot): string {
+	return session.title ?? path.basename(session.cwd) ?? session.id;
+}
+
+interface ParsedChannelAddress {
+	channelId: string;
+	targetSessionId?: string;
+	targetAgentId: string;
+}
+
+/** Per-running-session bridge between the local IRC bus and user-authorized groups. */
+export class SessionChannelManager implements IrcExternalTransport {
+	static readonly #byRegistry = new WeakMap<AgentRegistry, SessionChannelManager>();
+	static readonly #bySession = new WeakMap<AgentSession, SessionChannelManager>();
+
+	static async start(
+		session: AgentSession,
+		registry: AgentRegistry,
+		bus: IrcBus = IrcBus.global(),
+	): Promise<SessionChannelManager> {
+		const existing = SessionChannelManager.#byRegistry.get(registry);
+		if (existing) return existing;
+		const client = await launchClient.createDaemonBrokerClient(channelBrokerScope());
+		const manager = new SessionChannelManager(session, registry, bus, client);
+		await manager.#register();
+		SessionChannelManager.#byRegistry.set(registry, manager);
+		SessionChannelManager.#bySession.set(session, manager);
+		bus.setExternalTransport(manager);
+		manager.#start();
+		return manager;
+	}
+
+	static forRegistry(registry: AgentRegistry): SessionChannelManager | undefined {
+		return SessionChannelManager.#byRegistry.get(registry);
+	}
+
+	static forSession(session: AgentSession): SessionChannelManager | undefined {
+		return SessionChannelManager.#bySession.get(session);
+	}
+
+	readonly id = crypto.randomUUID().replaceAll("-", "").slice(0, 16);
+	readonly #startedAt = Date.now();
+	readonly #session: AgentSession;
+	readonly #registry: AgentRegistry;
+	readonly #bus: IrcBus;
+	readonly #client: DaemonBrokerClient;
+	readonly #channels = new Map<string, SessionChannelSnapshot>();
+	readonly #peerListeners = new Set<() => void>();
+	#unsubscribeRegistry: (() => void) | undefined;
+	#unsubscribeTitle: (() => void) | undefined;
+	#cancelPostmortem: (() => void) | undefined;
+	#updateTimer: NodeJS.Timeout | undefined;
+	#listenTask: Promise<void> | undefined;
+	#closed = false;
+
+	private constructor(session: AgentSession, registry: AgentRegistry, bus: IrcBus, client: DaemonBrokerClient) {
+		this.#session = session;
+		this.#registry = registry;
+		this.#bus = bus;
+		this.#client = client;
+	}
+
+	async state(): Promise<SessionChannelState> {
+		await this.#updateNow();
+		const result = await this.#request({ op: "list", sessionId: this.id });
+		if (result.op !== "list") throw new Error(`Unexpected channel ${result.op} result`);
+		for (const channel of result.channels) this.#channels.set(channel.id, channel);
+		this.#notifyPeerListeners();
+		return { self: this.#snapshot(), sessions: result.sessions, channels: result.channels };
+	}
+
+	async open(memberQueries: readonly string[], name?: string): Promise<SessionChannelSnapshot> {
+		if (memberQueries.length === 0) throw new Error("Opening a channel requires at least one target session");
+		const state = await this.state();
+		const memberIds = memberQueries.map(query => this.#resolveSession(query, state.sessions).id);
+		const result = await this.#request({ op: "open", sessionId: this.id, memberIds, name });
+		if (result.op !== "open") throw new Error(`Unexpected channel ${result.op} result`);
+		this.#channels.set(result.channel.id, result.channel);
+		this.#notifyPeerListeners();
+		return result.channel;
+	}
+
+	async add(channelQuery: string, memberQueries: readonly string[]): Promise<SessionChannelSnapshot> {
+		if (memberQueries.length === 0) throw new Error("Adding members requires at least one target session");
+		const state = await this.state();
+		const channel = this.#resolveChannel(channelQuery, state.channels);
+		const memberIds = memberQueries.map(query => this.#resolveSession(query, state.sessions).id);
+		const result = await this.#request({ op: "add", sessionId: this.id, channelId: channel.id, memberIds });
+		if (result.op !== "add") throw new Error(`Unexpected channel ${result.op} result`);
+		this.#channels.set(result.channel.id, result.channel);
+		this.#notifyPeerListeners();
+		return result.channel;
+	}
+
+	async remove(channelQuery: string, memberQuery: string): Promise<SessionChannelSnapshot | null> {
+		const state = await this.state();
+		const channel = this.#resolveChannel(channelQuery, state.channels);
+		const member = this.#resolveSession(memberQuery, channel.members);
+		const result = await this.#request({
+			op: "remove",
+			sessionId: this.id,
+			channelId: channel.id,
+			memberId: member.id,
+		});
+		if (result.op !== "remove") throw new Error(`Unexpected channel ${result.op} result`);
+		if (result.channel) this.#channels.set(result.channel.id, result.channel);
+		else this.#channels.delete(channel.id);
+		this.#notifyPeerListeners();
+		return result.channel;
+	}
+
+	async closeChannel(channelQuery: string): Promise<void> {
+		const channel = this.#resolveChannel(channelQuery, [...this.#channels.values()]);
+		const result = await this.#request({ op: "close", sessionId: this.id, channelId: channel.id });
+		if (result.op !== "close") throw new Error(`Unexpected channel ${result.op} result`);
+		this.#channels.delete(channel.id);
+		this.#notifyPeerListeners();
+	}
+
+	async leave(channelQuery: string, reason: "user" | "agent"): Promise<void> {
+		const channel = this.#resolveChannel(channelQuery, [...this.#channels.values()]);
+		const result = await this.#request({ op: "leave", sessionId: this.id, channelId: channel.id, reason });
+		if (result.op !== "leave") throw new Error(`Unexpected channel ${result.op} result`);
+		this.#channels.delete(channel.id);
+		this.#notifyPeerListeners();
+	}
+
+	async close(): Promise<void> {
+		if (this.#closed) return;
+		this.#closed = true;
+		clearTimeout(this.#updateTimer);
+		this.#unsubscribeRegistry?.();
+		this.#unsubscribeTitle?.();
+		this.#cancelPostmortem?.();
+		this.#bus.clearExternalTransport(this);
+		try {
+			await this.#request({ op: "unregister", sessionId: this.id });
+		} catch (error) {
+			logger.debug("Session channel unregister failed during close", { error: String(error) });
+		} finally {
+			this.#client.close();
+			this.#channels.clear();
+			this.#notifyPeerListeners();
+			SessionChannelManager.#byRegistry.delete(this.#registry);
+			SessionChannelManager.#bySession.delete(this.#session);
+		}
+		await this.#listenTask?.catch(() => {});
+	}
+
+	handles(address: string): boolean {
+		return this.#parseAddress(address) !== undefined;
+	}
+
+	validateTargets(addresses: readonly string[]): string | undefined {
+		if (addresses.length === 0) return "At least one recipient is required.";
+		const parsed = addresses.map(address => this.#parseAddress(address));
+		if (parsed.some(target => !target || target.targetSessionId === undefined)) {
+			return "Recipient arrays must contain concrete agent addresses from `hub list`.";
+		}
+		const channelIds = new Set(parsed.map(target => target?.channelId));
+		return channelIds.size === 1 ? undefined : "Every recipient in an array must belong to the same channel.";
+	}
+
+	async send(message: { from: string; to: string; body: string; replyTo?: string }): Promise<IrcDeliveryReceipt> {
+		const target = this.#parseAddress(message.to);
+		if (!target) return { to: message.to, outcome: "failed", error: "Unknown or closed session channel target" };
+		if (target.targetSessionId === this.id) {
+			return this.#bus.send({
+				from: message.from,
+				to: target.targetAgentId,
+				body: message.body,
+				replyTo: message.replyTo,
+			});
+		}
+		try {
+			const result = await this.#request({
+				op: "send",
+				sessionId: this.id,
+				channelId: target.channelId,
+				fromAgentId: message.from,
+				targetSessionId: target.targetSessionId,
+				targetAgentId: target.targetAgentId,
+				body: message.body,
+				replyTo: message.replyTo,
+			});
+			if (result.op !== "send") throw new Error(`Unexpected channel ${result.op} result`);
+			return { to: message.to, outcome: "injected" };
+		} catch (error) {
+			return { to: message.to, outcome: "failed", error: error instanceof Error ? error.message : String(error) };
+		}
+	}
+
+	listPeers(): IrcExternalPeer[] {
+		const peers: IrcExternalPeer[] = [];
+		for (const channel of this.#channels.values()) {
+			for (const member of channel.members) {
+				if (member.id === this.id) continue;
+				for (const agent of member.agents) {
+					peers.push({
+						id: channelAddress(channel.id, member.id, agent.id),
+						displayName: `${agent.displayName}@${sessionLabel(member)}`,
+						kind: `remote-${agent.kind}`,
+						status: agent.status,
+						parentId: agent.parentId ? channelAddress(channel.id, member.id, agent.parentId) : undefined,
+						lastActivity: agent.lastActivity,
+						activity: agent.activity,
+						channelId: channel.id,
+					});
+				}
+			}
+		}
+		return peers;
+	}
+
+	isPeerRunning(address: string): boolean {
+		const target = this.#parseAddress(address);
+		if (!target) return false;
+		if (!target.targetSessionId) {
+			return this.listPeers().some(peer => peer.channelId === target.channelId && peer.status === "running");
+		}
+		return this.listPeers().some(peer => peer.id === address && peer.status === "running");
+	}
+
+	onPeersChanged(listener: () => void): () => void {
+		this.#peerListeners.add(listener);
+		return () => this.#peerListeners.delete(listener);
+	}
+
+	#start(): void {
+		this.#unsubscribeRegistry = this.#registry.onChange(() => this.#scheduleUpdate());
+		this.#unsubscribeTitle = this.#session.sessionManager.onSessionNameChanged(() => this.#scheduleUpdate());
+		this.#cancelPostmortem = postmortem.register(`session-channel:${this.id}`, () => this.close());
+		this.#listenTask = this.#listen();
+	}
+
+	async #register(): Promise<void> {
+		const result = await this.#request({ op: "register", session: this.#snapshot() });
+		if (result.op !== "register") throw new Error(`Unexpected channel ${result.op} result`);
+	}
+
+	async #listen(): Promise<void> {
+		while (!this.#closed) {
+			try {
+				const result = await this.#request({ op: "wait", sessionId: this.id, timeoutMs: CHANNEL_WAIT_MS });
+				if (result.op !== "wait") throw new Error(`Unexpected channel ${result.op} result`);
+				if (result.event) await this.#handleEvent(result.event);
+			} catch (error) {
+				if (this.#closed) return;
+				this.#channels.clear();
+				this.#notifyPeerListeners();
+				logger.debug("Session channel event wait failed; reconnecting", { error: String(error) });
+				await Bun.sleep(RECONNECT_DELAY_MS);
+				try {
+					await this.#register();
+				} catch (registerError) {
+					logger.debug("Session channel reconnect failed", { error: String(registerError) });
+				}
+			}
+		}
+	}
+
+	async #handleEvent(event: SessionChannelEvent): Promise<void> {
+		switch (event.type) {
+			case "channel-updated":
+				this.#channels.set(event.channel.id, event.channel);
+				this.#notifyPeerListeners();
+				return;
+			case "message": {
+				const from = channelAddress(event.channelId, event.fromSessionId, event.fromAgentId);
+				await this.#bus.send({
+					from,
+					to: event.toAgentId,
+					body: event.body,
+					replyTo: event.replyTo,
+				});
+				return;
+			}
+			case "member-left": {
+				const channel = this.#channels.get(event.channelId);
+				const stillMember = event.remainingMembers.some(member => member.id === this.id);
+				if (event.closed || !channel || !stillMember) this.#channels.delete(event.channelId);
+				else this.#channels.set(event.channelId, { ...channel, members: event.remainingMembers });
+				this.#notifyPeerListeners();
+				const action = event.reason === "session-ended" ? "terminated" : `left by ${event.reason}`;
+				const suffix = event.closed
+					? " The channel is now closed; new user authorization is required to reconnect."
+					: ` ${event.remainingMembers.length} sessions remain connected.`;
+				await this.#notifyLocalAgents(
+					event.channelId,
+					`Session ${event.member.id} (${sessionLabel(event.member)}) ${action} in channel ${event.channelName ?? event.channelId}.${suffix} No response is expected.`,
+				);
+				return;
+			}
+			case "agent-left":
+				await this.#notifyLocalAgents(
+					event.channelId,
+					`Agent ${event.agent.id} (${event.agent.displayName}) terminated in session ${event.sessionId} on channel ${event.channelName ?? event.channelId}. No response is expected.`,
+				);
+				return;
+			case "channel-closed":
+				this.#channels.delete(event.channel.id);
+				this.#notifyPeerListeners();
+				await this.#notifyLocalAgents(
+					event.channel.id,
+					`Channel ${event.channel.name ?? event.channel.id} was closed by its user. New user authorization is required to reconnect. No response is expected.`,
+				);
+		}
+	}
+
+	async #notifyLocalAgents(channelId: string, body: string): Promise<void> {
+		const recipients = this.#registry.list().filter(ref => ref.kind !== "advisor" && ref.status !== "aborted");
+		await Promise.all(recipients.map(ref => this.#bus.send({ from: `${channelId}/system`, to: ref.id, body })));
+	}
+
+	#scheduleUpdate(): void {
+		if (this.#closed || this.#updateTimer) return;
+		this.#updateTimer = setTimeout(() => {
+			this.#updateTimer = undefined;
+			void this.#updateNow().catch(error => {
+				logger.debug("Session channel roster update failed", { error: String(error) });
+			});
+		}, UPDATE_DEBOUNCE_MS);
+		this.#updateTimer.unref?.();
+	}
+
+	async #updateNow(): Promise<void> {
+		if (this.#closed) throw new Error("Session channel manager is closed");
+		clearTimeout(this.#updateTimer);
+		this.#updateTimer = undefined;
+		const result = await this.#request({ op: "update", session: this.#snapshot() });
+		if (result.op !== "update") throw new Error(`Unexpected channel ${result.op} result`);
+	}
+
+	#snapshot(): ChannelSessionSnapshot {
+		return {
+			id: this.id,
+			pid: process.pid,
+			sessionId: this.#session.sessionManager.getSessionId(),
+			title: this.#session.sessionManager.getSessionName(),
+			cwd: this.#session.sessionManager.getCwd(),
+			startedAt: this.#startedAt,
+			agents: this.#registry
+				.list()
+				.filter(
+					(ref): ref is AgentRef & { kind: "main" | "sub"; status: "running" | "idle" | "parked" } =>
+						ref.kind !== "advisor" && ref.status !== "aborted",
+				)
+				.map(ref => this.#agentSnapshot(ref)),
+		};
+	}
+
+	#agentSnapshot(
+		ref: AgentRef & { kind: "main" | "sub"; status: "running" | "idle" | "parked" },
+	): ChannelAgentSnapshot {
+		return {
+			id: ref.id,
+			displayName: ref.displayName,
+			kind: ref.kind,
+			status: ref.status,
+			parentId: ref.parentId,
+			lastActivity: ref.lastActivity,
+			activity: ref.activity,
+		};
+	}
+
+	#parseAddress(address: string): ParsedChannelAddress | undefined {
+		const parts = address.split("/");
+		const channel = this.#channels.get(parts[0] ?? "");
+		if (!channel) return undefined;
+		if (parts.length === 2 && parts[1] === "all") {
+			return { channelId: channel.id, targetAgentId: "all" };
+		}
+		if (parts.length !== 3) return undefined;
+		const targetSessionId = parts[1];
+		const targetAgentId = parts[2];
+		if (!targetSessionId || !targetAgentId) return undefined;
+		const member = channel.members.find(candidate => candidate.id === targetSessionId);
+		if (!member?.agents.some(agent => agent.id === targetAgentId)) return undefined;
+		return { channelId: channel.id, targetSessionId, targetAgentId };
+	}
+
+	#resolveSession(query: string, sessions: readonly ChannelSessionSnapshot[]): ChannelSessionSnapshot {
+		const matches = sessions.filter(session => session.id === query || session.id.startsWith(query));
+		if (matches.length === 1 && matches[0]) return matches[0];
+		if (matches.length === 0) throw new Error(`No running session matches ${query}`);
+		throw new Error(`Session prefix ${query} is ambiguous`);
+	}
+
+	#resolveChannel(query: string, channels: readonly SessionChannelSnapshot[]): SessionChannelSnapshot {
+		const matches = channels.filter(
+			channel => channel.id === query || channel.id.startsWith(query) || channel.name === query,
+		);
+		if (matches.length === 1 && matches[0]) return matches[0];
+		if (matches.length === 0) throw new Error(`No open channel matches ${query}`);
+		throw new Error(`Channel selector ${query} is ambiguous`);
+	}
+
+	#notifyPeerListeners(): void {
+		for (const listener of this.#peerListeners) listener();
+	}
+
+	async #request(operation: SessionChannelOperation): Promise<SessionChannelResult> {
+		const result = await this.#client.request({ op: "channel", operation });
+		if (result.op !== "channel") throw new Error(`Unexpected broker ${result.op} result`);
+		return result.result;
+	}
+}

--- a/packages/coding-agent/src/session-channels/protocol.ts
+++ b/packages/coding-agent/src/session-channels/protocol.ts
@@ -72,8 +72,7 @@ export type SessionChannelOperation =
 	| { op: "unregister"; sessionId: string }
 	| { op: "list"; sessionId: string }
 	| { op: "open"; sessionId: string; memberIds: string[]; name?: string }
-	| { op: "add"; sessionId: string; channelId: string; memberIds: string[] }
-	| { op: "remove"; sessionId: string; channelId: string; memberId: string }
+	| { op: "set-members"; sessionId: string; channelId: string; memberIds: string[] }
 	| { op: "close"; sessionId: string; channelId: string }
 	| { op: "leave"; sessionId: string; channelId: string; reason: "user" | "agent" }
 	| { op: "update"; session: ChannelSessionSnapshot }
@@ -94,8 +93,7 @@ export type SessionChannelResult =
 	| { op: "unregister" }
 	| { op: "list"; sessions: ChannelSessionSnapshot[]; channels: SessionChannelSnapshot[] }
 	| { op: "open"; channel: SessionChannelSnapshot }
-	| { op: "add"; channel: SessionChannelSnapshot }
-	| { op: "remove"; channel: SessionChannelSnapshot | null }
+	| { op: "set-members"; channel: SessionChannelSnapshot }
 	| { op: "close" }
 	| { op: "leave"; channel: SessionChannelSnapshot | null }
 	| { op: "update"; session: ChannelSessionSnapshot }
@@ -267,19 +265,12 @@ export function parseSessionChannelOperation(value: unknown): SessionChannelOper
 				memberIds: stringArray(source.memberIds, "operation.memberIds"),
 				name: optionalString(source.name, "operation.name", CHANNEL_NAME_MAX),
 			};
-		case "add":
+		case "set-members":
 			return {
 				op,
 				sessionId: runtimeId(source.sessionId, "operation.sessionId"),
 				channelId: runtimeId(source.channelId, "operation.channelId"),
 				memberIds: stringArray(source.memberIds, "operation.memberIds"),
-			};
-		case "remove":
-			return {
-				op,
-				sessionId: runtimeId(source.sessionId, "operation.sessionId"),
-				channelId: runtimeId(source.channelId, "operation.channelId"),
-				memberId: runtimeId(source.memberId, "operation.memberId"),
 			};
 		case "close":
 			return {
@@ -342,9 +333,8 @@ export function parseSessionChannelResult(operation: SessionChannelOperation, va
 				channels: source.channels.map(parseSessionChannelSnapshot),
 			};
 		case "open":
-		case "add":
+		case "set-members":
 			return { op: operation.op, channel: parseSessionChannelSnapshot(source.channel) };
-		case "remove":
 		case "leave":
 			return {
 				op: operation.op,

--- a/packages/coding-agent/src/session-channels/protocol.ts
+++ b/packages/coding-agent/src/session-channels/protocol.ts
@@ -1,0 +1,358 @@
+export type ChannelAgentStatus = "running" | "idle" | "parked";
+export type ChannelAgentKind = "main" | "sub";
+
+export interface ChannelAgentSnapshot {
+	id: string;
+	displayName: string;
+	kind: ChannelAgentKind;
+	status: ChannelAgentStatus;
+	parentId?: string;
+	lastActivity: number;
+	activity?: string;
+}
+
+/** One running top-level session registered with the user-global broker. */
+export interface ChannelSessionSnapshot {
+	id: string;
+	pid: number;
+	sessionId: string;
+	title?: string;
+	cwd: string;
+	startedAt: number;
+	agents: ChannelAgentSnapshot[];
+}
+
+/** A user-authorized group. Every member may message every other member. */
+export interface SessionChannelSnapshot {
+	id: string;
+	name?: string;
+	createdAt: number;
+	members: ChannelSessionSnapshot[];
+}
+
+export type ChannelLeaveReason = "user" | "agent" | "session-ended";
+
+export type SessionChannelEvent =
+	| { type: "channel-updated"; channel: SessionChannelSnapshot }
+	| {
+			type: "member-left";
+			channelId: string;
+			channelName?: string;
+			member: ChannelSessionSnapshot;
+			reason: ChannelLeaveReason;
+			actorSessionId?: string;
+			remainingMembers: ChannelSessionSnapshot[];
+			closed: boolean;
+	  }
+	| {
+			type: "agent-left";
+			channelId: string;
+			channelName?: string;
+			sessionId: string;
+			agent: ChannelAgentSnapshot;
+	  }
+	| {
+			type: "channel-closed";
+			channel: SessionChannelSnapshot;
+			reason: "user";
+			actorSessionId: string;
+	  }
+	| {
+			type: "message";
+			channelId: string;
+			fromSessionId: string;
+			fromAgentId: string;
+			toAgentId: string;
+			body: string;
+			replyTo?: string;
+	  };
+
+export type SessionChannelOperation =
+	| { op: "register"; session: ChannelSessionSnapshot }
+	| { op: "unregister"; sessionId: string }
+	| { op: "list"; sessionId: string }
+	| { op: "open"; sessionId: string; memberIds: string[]; name?: string }
+	| { op: "add"; sessionId: string; channelId: string; memberIds: string[] }
+	| { op: "remove"; sessionId: string; channelId: string; memberId: string }
+	| { op: "close"; sessionId: string; channelId: string }
+	| { op: "leave"; sessionId: string; channelId: string; reason: "user" | "agent" }
+	| { op: "update"; session: ChannelSessionSnapshot }
+	| {
+			op: "send";
+			sessionId: string;
+			channelId: string;
+			fromAgentId: string;
+			targetSessionId?: string;
+			targetAgentId: string;
+			body: string;
+			replyTo?: string;
+	  }
+	| { op: "wait"; sessionId: string; timeoutMs: number };
+
+export type SessionChannelResult =
+	| { op: "register"; session: ChannelSessionSnapshot }
+	| { op: "unregister" }
+	| { op: "list"; sessions: ChannelSessionSnapshot[]; channels: SessionChannelSnapshot[] }
+	| { op: "open"; channel: SessionChannelSnapshot }
+	| { op: "add"; channel: SessionChannelSnapshot }
+	| { op: "remove"; channel: SessionChannelSnapshot | null }
+	| { op: "close" }
+	| { op: "leave"; channel: SessionChannelSnapshot | null }
+	| { op: "update"; session: ChannelSessionSnapshot }
+	| { op: "send"; targets: number }
+	| { op: "wait"; event: SessionChannelEvent | null };
+
+const RUNTIME_ID_RE = /^[a-f0-9]{16}$/;
+const CHANNEL_NAME_MAX = 80;
+const MESSAGE_MAX = 64 * 1024;
+
+function record(value: unknown, label: string): Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value))
+		throw new Error(`${label} must be an object`);
+	return value as Record<string, unknown>;
+}
+
+function stringValue(value: unknown, label: string, max = 512): string {
+	if (typeof value !== "string" || value.length === 0 || value.length > max) {
+		throw new Error(`${label} must be a non-empty string up to ${max} characters`);
+	}
+	return value;
+}
+
+function optionalString(value: unknown, label: string, max = 512): string | undefined {
+	return value === undefined ? undefined : stringValue(value, label, max);
+}
+
+function numberValue(value: unknown, label: string): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${label} must be a finite number`);
+	return value;
+}
+
+function booleanValue(value: unknown, label: string): boolean {
+	if (typeof value !== "boolean") throw new Error(`${label} must be a boolean`);
+	return value;
+}
+
+function runtimeId(value: unknown, label: string): string {
+	const id = stringValue(value, label, 16);
+	if (!RUNTIME_ID_RE.test(id)) throw new Error(`${label} must be 16 lowercase hexadecimal characters`);
+	return id;
+}
+
+function stringArray(value: unknown, label: string): string[] {
+	if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+	return value.map((entry, index) => runtimeId(entry, `${label}[${index}]`));
+}
+
+function agentStatus(value: unknown): ChannelAgentStatus {
+	if (value === "running" || value === "idle" || value === "parked") return value;
+	throw new Error("agent.status must be running, idle, or parked");
+}
+
+function agentKind(value: unknown): ChannelAgentKind {
+	if (value === "main" || value === "sub") return value;
+	throw new Error("agent.kind must be main or sub");
+}
+
+export function parseChannelAgentSnapshot(value: unknown): ChannelAgentSnapshot {
+	const source = record(value, "channel agent");
+	return {
+		id: stringValue(source.id, "agent.id", 128),
+		displayName: stringValue(source.displayName, "agent.displayName", 256),
+		kind: agentKind(source.kind),
+		status: agentStatus(source.status),
+		parentId: optionalString(source.parentId, "agent.parentId", 128),
+		lastActivity: numberValue(source.lastActivity, "agent.lastActivity"),
+		activity: optionalString(source.activity, "agent.activity", 512),
+	};
+}
+
+export function parseChannelSessionSnapshot(value: unknown): ChannelSessionSnapshot {
+	const source = record(value, "channel session");
+	if (!Array.isArray(source.agents)) throw new Error("session.agents must be an array");
+	return {
+		id: runtimeId(source.id, "session.id"),
+		pid: numberValue(source.pid, "session.pid"),
+		sessionId: stringValue(source.sessionId, "session.sessionId", 128),
+		title: optionalString(source.title, "session.title", 256),
+		cwd: stringValue(source.cwd, "session.cwd", 4096),
+		startedAt: numberValue(source.startedAt, "session.startedAt"),
+		agents: source.agents.map(parseChannelAgentSnapshot),
+	};
+}
+
+export function parseSessionChannelSnapshot(value: unknown): SessionChannelSnapshot {
+	const source = record(value, "session channel");
+	if (!Array.isArray(source.members)) throw new Error("channel.members must be an array");
+	return {
+		id: runtimeId(source.id, "channel.id"),
+		name: optionalString(source.name, "channel.name", CHANNEL_NAME_MAX),
+		createdAt: numberValue(source.createdAt, "channel.createdAt"),
+		members: source.members.map(parseChannelSessionSnapshot),
+	};
+}
+
+function leaveReason(value: unknown): ChannelLeaveReason {
+	if (value === "user" || value === "agent" || value === "session-ended") return value;
+	throw new Error("event.reason must be user, agent, or session-ended");
+}
+
+export function parseSessionChannelEvent(value: unknown): SessionChannelEvent {
+	const source = record(value, "session channel event");
+	const eventType = stringValue(source.type, "event.type");
+	switch (eventType) {
+		case "channel-updated":
+			return { type: eventType, channel: parseSessionChannelSnapshot(source.channel) };
+		case "member-left": {
+			if (!Array.isArray(source.remainingMembers)) throw new Error("event.remainingMembers must be an array");
+			return {
+				type: eventType,
+				channelId: runtimeId(source.channelId, "event.channelId"),
+				channelName: optionalString(source.channelName, "event.channelName", CHANNEL_NAME_MAX),
+				member: parseChannelSessionSnapshot(source.member),
+				reason: leaveReason(source.reason),
+				actorSessionId:
+					source.actorSessionId === undefined
+						? undefined
+						: runtimeId(source.actorSessionId, "event.actorSessionId"),
+				remainingMembers: source.remainingMembers.map(parseChannelSessionSnapshot),
+				closed: booleanValue(source.closed, "event.closed"),
+			};
+		}
+		case "agent-left":
+			return {
+				type: eventType,
+				channelId: runtimeId(source.channelId, "event.channelId"),
+				channelName: optionalString(source.channelName, "event.channelName", CHANNEL_NAME_MAX),
+				sessionId: runtimeId(source.sessionId, "event.sessionId"),
+				agent: parseChannelAgentSnapshot(source.agent),
+			};
+		case "channel-closed":
+			if (source.reason !== "user") throw new Error("channel-closed reason must be user");
+			return {
+				type: eventType,
+				channel: parseSessionChannelSnapshot(source.channel),
+				reason: "user",
+				actorSessionId: runtimeId(source.actorSessionId, "event.actorSessionId"),
+			};
+		case "message":
+			return {
+				type: eventType,
+				channelId: runtimeId(source.channelId, "event.channelId"),
+				fromSessionId: runtimeId(source.fromSessionId, "event.fromSessionId"),
+				fromAgentId: stringValue(source.fromAgentId, "event.fromAgentId", 128),
+				toAgentId: stringValue(source.toAgentId, "event.toAgentId", 128),
+				body: stringValue(source.body, "event.body", MESSAGE_MAX),
+				replyTo: optionalString(source.replyTo, "event.replyTo", 128),
+			};
+		default:
+			throw new Error(`Unknown session channel event: ${eventType}`);
+	}
+}
+
+export function parseSessionChannelOperation(value: unknown): SessionChannelOperation {
+	const source = record(value, "session channel operation");
+	const op = stringValue(source.op, "operation.op");
+	switch (op) {
+		case "register":
+		case "update":
+			return { op, session: parseChannelSessionSnapshot(source.session) };
+		case "unregister":
+		case "list":
+			return { op, sessionId: runtimeId(source.sessionId, "operation.sessionId") };
+		case "open":
+			return {
+				op,
+				sessionId: runtimeId(source.sessionId, "operation.sessionId"),
+				memberIds: stringArray(source.memberIds, "operation.memberIds"),
+				name: optionalString(source.name, "operation.name", CHANNEL_NAME_MAX),
+			};
+		case "add":
+			return {
+				op,
+				sessionId: runtimeId(source.sessionId, "operation.sessionId"),
+				channelId: runtimeId(source.channelId, "operation.channelId"),
+				memberIds: stringArray(source.memberIds, "operation.memberIds"),
+			};
+		case "remove":
+			return {
+				op,
+				sessionId: runtimeId(source.sessionId, "operation.sessionId"),
+				channelId: runtimeId(source.channelId, "operation.channelId"),
+				memberId: runtimeId(source.memberId, "operation.memberId"),
+			};
+		case "close":
+			return {
+				op,
+				sessionId: runtimeId(source.sessionId, "operation.sessionId"),
+				channelId: runtimeId(source.channelId, "operation.channelId"),
+			};
+		case "leave": {
+			const reason = leaveReason(source.reason);
+			if (reason === "session-ended") throw new Error("leave reason must be user or agent");
+			return {
+				op,
+				sessionId: runtimeId(source.sessionId, "operation.sessionId"),
+				channelId: runtimeId(source.channelId, "operation.channelId"),
+				reason,
+			};
+		}
+		case "send":
+			return {
+				op,
+				sessionId: runtimeId(source.sessionId, "operation.sessionId"),
+				channelId: runtimeId(source.channelId, "operation.channelId"),
+				fromAgentId: stringValue(source.fromAgentId, "operation.fromAgentId", 128),
+				targetSessionId:
+					source.targetSessionId === undefined
+						? undefined
+						: runtimeId(source.targetSessionId, "operation.targetSessionId"),
+				targetAgentId: stringValue(source.targetAgentId, "operation.targetAgentId", 128),
+				body: stringValue(source.body, "operation.body", MESSAGE_MAX),
+				replyTo: optionalString(source.replyTo, "operation.replyTo", 128),
+			};
+		case "wait":
+			return {
+				op,
+				sessionId: runtimeId(source.sessionId, "operation.sessionId"),
+				timeoutMs: numberValue(source.timeoutMs, "operation.timeoutMs"),
+			};
+		default:
+			throw new Error(`Unknown session channel operation: ${op}`);
+	}
+}
+
+export function parseSessionChannelResult(operation: SessionChannelOperation, value: unknown): SessionChannelResult {
+	const source = record(value, `${operation.op} result`);
+	const op = stringValue(source.op, "result.op");
+	if (op !== operation.op) throw new Error(`Expected ${operation.op} result, received ${op}`);
+	switch (operation.op) {
+		case "register":
+		case "update":
+			return { op: operation.op, session: parseChannelSessionSnapshot(source.session) };
+		case "unregister":
+		case "close":
+			return { op: operation.op };
+		case "list":
+			if (!Array.isArray(source.sessions)) throw new Error("result.sessions must be an array");
+			if (!Array.isArray(source.channels)) throw new Error("result.channels must be an array");
+			return {
+				op: "list",
+				sessions: source.sessions.map(parseChannelSessionSnapshot),
+				channels: source.channels.map(parseSessionChannelSnapshot),
+			};
+		case "open":
+		case "add":
+			return { op: operation.op, channel: parseSessionChannelSnapshot(source.channel) };
+		case "remove":
+		case "leave":
+			return {
+				op: operation.op,
+				channel: source.channel === null ? null : parseSessionChannelSnapshot(source.channel),
+			};
+		case "send":
+			return { op: "send", targets: numberValue(source.targets, "result.targets") };
+		case "wait":
+			return { op: "wait", event: source.event === null ? null : parseSessionChannelEvent(source.event) };
+	}
+}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -44,6 +44,7 @@ import type { SessionOAuthAccountList } from "../session/agent-session-types";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
 import { resolveResumableSession } from "../session/session-listing";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
+import { handleSessionChannelCommand } from "../session-channels/command";
 import type { ComputerTool } from "../tools/computer";
 import { computerExposureMode } from "../tools/computer/exposure";
 import { expandTilde, resolveToCwd } from "../tools/path-utils";
@@ -964,6 +965,21 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			await runtime.ctx.handleShareCommand();
 			runtime.ctx.editor.setText("");
 		},
+	},
+	{
+		name: "channel",
+		description: "Authorize cross-session agent communication",
+		inlineHint: "[list|open|add|remove|leave|close] ...",
+		subcommands: [
+			{ name: "list", description: "List running sessions and open channels" },
+			{ name: "open", description: "Authorize a channel with one or more sessions", usage: "<session-id>..." },
+			{ name: "add", description: "Authorize more sessions on an open channel", usage: "<channel> <session-id>..." },
+			{ name: "remove", description: "Remove a session from a channel", usage: "<channel> <session-id>" },
+			{ name: "leave", description: "Leave a channel from this session", usage: "<channel>" },
+			{ name: "close", description: "Close a channel for every member", usage: "<channel>" },
+		],
+		allowArgs: true,
+		handle: handleSessionChannelCommand,
 	},
 	{
 		name: "collab",

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -44,7 +44,7 @@ import type { SessionOAuthAccountList } from "../session/agent-session-types";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
 import { resolveResumableSession } from "../session/session-listing";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
-import { handleSessionChannelCommand } from "../session-channels/command";
+import { handleSessionChannelCommand, handleSessionChannelTuiCommand } from "../session-channels/command";
 import type { ComputerTool } from "../tools/computer";
 import { computerExposureMode } from "../tools/computer/exposure";
 import { expandTilde, resolveToCwd } from "../tools/path-utils";
@@ -969,17 +969,17 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "channel",
 		description: "Authorize cross-session agent communication",
-		inlineHint: "[list|open|add|remove|leave|close] ...",
+		inlineHint: "[list|open|toggle|leave|close] ...",
 		subcommands: [
 			{ name: "list", description: "List running sessions and open channels" },
-			{ name: "open", description: "Authorize a channel with one or more sessions", usage: "<session-id>..." },
-			{ name: "add", description: "Authorize more sessions on an open channel", usage: "<channel> <session-id>..." },
-			{ name: "remove", description: "Remove a session from a channel", usage: "<channel> <session-id>" },
+			{ name: "open", description: "Select sessions for a new channel", usage: "[session-id ...]" },
+			{ name: "toggle", description: "Toggle sessions in an open channel", usage: "[channel] [session-id ...]" },
 			{ name: "leave", description: "Leave a channel from this session", usage: "<channel>" },
 			{ name: "close", description: "Close a channel for every member", usage: "<channel>" },
 		],
 		allowArgs: true,
 		handle: handleSessionChannelCommand,
+		handleTui: handleSessionChannelTuiCommand,
 	},
 	{
 		name: "collab",

--- a/packages/coding-agent/src/tools/hub/index.ts
+++ b/packages/coding-agent/src/tools/hub/index.ts
@@ -31,6 +31,7 @@ import { IrcBus } from "../../irc/bus";
 import type { Theme } from "../../modes/theme/theme";
 import hubDescription from "../../prompts/tools/hub.md" with { type: "text" };
 import type { AgentRegistry } from "../../registry/agent-registry";
+import { SessionChannelManager } from "../../session-channels/manager";
 import type { ToolSession } from "..";
 import {
 	buildJobResult,
@@ -72,9 +73,9 @@ export * from "./types";
 
 const hubSchema = type({
 	op: type(
-		"'send' | 'wait' | 'inbox' | 'list' | 'jobs' | 'cancel' | 'start' | 'ps' | 'logs' | 'stop' | 'restart' | 'describe'",
+		"'send' | 'wait' | 'inbox' | 'list' | 'channels' | 'disconnect' | 'jobs' | 'cancel' | 'start' | 'ps' | 'logs' | 'stop' | 'restart' | 'describe'",
 	).describe("hub operation"),
-	"to?": type("string").describe('send: recipient agent id or "all"'),
+	"to?": type("string | string[]").describe('send: recipient agent id, same-channel agent id array, or "all"'),
 	"message?": type("string").describe("send: message body"),
 	"replyTo?": type("string").describe("send: message id being answered"),
 	"await?": type("boolean").describe('send: wait for the recipient\'s reply (invalid with to:"all")'),
@@ -82,6 +83,7 @@ const hubSchema = type({
 	"ids?": type("string[]").describe("wait: job ids to watch (omit = all running jobs); cancel: job ids to kill"),
 	"timeoutMs?": type("number").describe("wait (messages/jobs): timeout in milliseconds (0 waits indefinitely)"),
 	"peek?": type("boolean").describe("inbox: list messages without consuming them"),
+	"channel?": type("string").describe("disconnect: channel id or unique name/prefix"),
 	"name?": type("string <= 48").describe("process ops: stable project-scoped launch name"),
 	"application?": type("string > 0").describe("start: executable or application path"),
 	"args?": type("string[]").describe("start: argv passed directly to the application"),
@@ -134,6 +136,8 @@ function hubApproval(params: unknown): ToolApprovalDecision {
 		case "inbox":
 		case "list":
 		case "jobs":
+		case "channels":
+		case "disconnect":
 		case "cancel":
 		case "ps":
 		case "logs":
@@ -256,8 +260,71 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 				if (!messaging) return hubErrorResult("Peer messaging is unavailable in this session.", { op: "list" });
 				return executeList(messaging.registry, messaging.senderId);
 			}
+			case "channels": {
+				const messaging = this.#messaging();
+				if (!messaging) return hubErrorResult("Peer messaging is unavailable in this session.", { op: "channels" });
+				const manager = SessionChannelManager.forRegistry(messaging.registry);
+				if (!manager) {
+					return hubErrorResult("No cross-session channel manager is active.", {
+						op: "channels",
+						from: messaging.senderId,
+					});
+				}
+				const state = await manager.state();
+				const lines =
+					state.channels.length === 0
+						? ["No cross-session channels are open."]
+						: [
+								`${state.channels.length} open channel(s):`,
+								...state.channels.map(channel => {
+									const remoteAgents = channel.members
+										.filter(member => member.id !== state.self.id)
+										.flatMap(member =>
+											member.agents.map(
+												agent => `${channel.id}/${member.id}/${agent.id} (${agent.displayName})`,
+											),
+										);
+									const name = channel.name ? ` ${channel.name}` : "";
+									return `- ${channel.id}${name}: ${channel.members.length} sessions; all ${channel.id}/all; peers ${remoteAgents.join(", ") || "none"}`;
+								}),
+							];
+				return {
+					content: [{ type: "text", text: lines.join("\n") }],
+					details: { op: "channels", from: messaging.senderId, channels: state.channels },
+				};
+			}
+			case "disconnect": {
+				const messaging = this.#messaging();
+				if (!messaging) {
+					return hubErrorResult("Peer messaging is unavailable in this session.", { op: "disconnect" });
+				}
+				const channel = params.channel?.trim();
+				if (!channel) {
+					return hubErrorResult('`channel` is required for op="disconnect".', {
+						op: "disconnect",
+						from: messaging.senderId,
+					});
+				}
+				const manager = SessionChannelManager.forRegistry(messaging.registry);
+				if (!manager) {
+					return hubErrorResult("No cross-session channel manager is active.", {
+						op: "disconnect",
+						from: messaging.senderId,
+					});
+				}
+				await manager.leave(channel, "agent");
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Left channel ${channel}. Rejoining requires new user authorization.`,
+						},
+					],
+					details: { op: "disconnect", from: messaging.senderId },
+				};
+			}
 			case "send": {
-				const toPeer = params.to?.trim();
+				const toPeer = Array.isArray(params.to) ? params.to.length > 0 : !!params.to?.trim();
 				const toProcess = params.name?.trim();
 				if (toPeer && toProcess) {
 					return hubErrorResult('`to` (peer) and `name` (process) are mutually exclusive for op="send".', {
@@ -375,9 +442,9 @@ export class HubTool implements AgentTool<typeof hubSchema, HubDetails> {
 				// A bare wait can only be satisfied by a running peer eventually
 				// sending something; with none, return the snapshot immediately
 				// instead of blocking a full message-timeout window.
-				const hasRunningPeer = messaging.registry
-					.listVisibleTo(messaging.senderId)
-					.some(ref => ref.status === "running");
+				const hasRunningPeer =
+					messaging.registry.listVisibleTo(messaging.senderId).some(ref => ref.status === "running") ||
+					IrcBus.global().hasRunningExternalPeers();
 				if (!hasRunningPeer) return nothingToWaitForResult(this.session);
 			}
 			return executeMessageWait(messaging, { from, timeoutMs: params.timeoutMs }, signal);

--- a/packages/coding-agent/src/tools/hub/launch.ts
+++ b/packages/coding-agent/src/tools/hub/launch.ts
@@ -296,6 +296,7 @@ function toolContent(result: DaemonRpcResult, params: LaunchParams): string {
 	switch (result.op) {
 		case "ping":
 		case "shutdown":
+		case "channel":
 			throw new ToolError(`Internal daemon result ${result.op} is not tool-visible`);
 		case "start": {
 			const daemon = result.daemon;
@@ -385,6 +386,7 @@ async function toolDetails(result: DaemonRpcResult, params: LaunchParams): Promi
 			return { op: "describe", daemon: result.daemon, spec: result.spec };
 		case "ping":
 		case "shutdown":
+		case "channel":
 			throw new ToolError(`Internal daemon result ${result.op} is not tool-visible`);
 	}
 }

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -170,9 +170,10 @@ export async function executeSend(
 		return hubErrorResult("`await` requires exactly one recipient.", { op: "send", from: senderId, to: toLabel });
 	}
 	const singleRecipient = recipients[0] ?? "";
-	const isBroadcast = !recipientArray && singleRecipient === "all";
-	if (isBroadcast && params.await) {
-		return hubErrorResult('`await` is invalid with to:"all" — broadcasts have no single replier.', {
+	const isLocalBroadcast = !recipientArray && singleRecipient === "all";
+	const isChannelBroadcast = !recipientArray && singleRecipient.endsWith("/all");
+	if ((isLocalBroadcast || isChannelBroadcast) && params.await) {
+		return hubErrorResult("`await` is invalid for broadcasts because replies come from individual agents.", {
 			op: "send",
 			from: senderId,
 			to: toLabel,
@@ -217,8 +218,8 @@ export async function executeSend(
 	try {
 		// `all` retains the process-local broadcast contract. Cross-session
 		// broadcasts use `<channel-id>/all` so one channel cannot leak into another.
-		const targets = isBroadcast ? registry.listVisibleTo(senderId).map(ref => ref.id) : recipients;
-		const suppressRelay = isBroadcast && targets.includes(MAIN_AGENT_ID);
+		const targets = isLocalBroadcast ? registry.listVisibleTo(senderId).map(ref => ref.id) : recipients;
+		const suppressRelay = isLocalBroadcast && targets.includes(MAIN_AGENT_ID);
 		const receipts = await Promise.all(
 			targets.map(target =>
 				bus.send(

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -97,18 +97,21 @@ export async function executeList(
 	}
 
 	const bus = IrcBus.global();
-	const peers = refs
-		.filter(ref => ref.id !== senderId && ref.status !== "aborted" && ref.kind !== "advisor")
-		.map(ref => ({
-			id: ref.id,
-			displayName: ref.displayName,
-			kind: ref.kind,
-			status: ref.status,
-			parentId: ref.parentId,
-			unread: bus.unreadCount(ref.id),
-			lastActivity: ref.lastActivity,
-			activity: ref.activity,
-		}));
+	const peers = [
+		...refs
+			.filter(ref => ref.id !== senderId && ref.status !== "aborted" && ref.kind !== "advisor")
+			.map(ref => ({
+				id: ref.id,
+				displayName: ref.displayName,
+				kind: ref.kind,
+				status: ref.status,
+				parentId: ref.parentId,
+				unread: bus.unreadCount(ref.id),
+				lastActivity: ref.lastActivity,
+				activity: ref.activity,
+			})),
+		...bus.listExternalPeers().map(peer => ({ ...peer, unread: 0 })),
+	];
 	const lines: string[] = [];
 	if (peers.length === 0) {
 		lines.push("No other agents.");
@@ -119,6 +122,7 @@ export async function executeList(
 				peer.activity || undefined,
 				peer.unread > 0 ? `unread ${peer.unread}` : undefined,
 				peer.parentId ? `parent ${peer.parentId}` : undefined,
+				"channelId" in peer ? `channel ${peer.channelId}` : undefined,
 				`active ${formatDuration(Date.now() - peer.lastActivity)} ago`,
 			].filter(Boolean);
 			lines.push(`- ${peer.id} [${peer.displayName} · ${peer.kind} · ${peer.status}] — ${extras.join(", ")}`);
@@ -135,7 +139,7 @@ export async function executeList(
 }
 
 export interface HubSendParams {
-	to?: string;
+	to?: string | string[];
 	message?: string;
 	replyTo?: string;
 	await?: boolean;
@@ -148,27 +152,38 @@ export async function executeSend(
 	signal?: AbortSignal,
 ): Promise<AgentToolResult<CoordinationDetails>> {
 	const { registry, senderId, settings } = deps;
-	const to = params.to?.trim();
+	const recipientArray = Array.isArray(params.to);
+	const rawRecipients: string[] = Array.isArray(params.to) ? params.to : [params.to ?? ""];
+	const recipients = [...new Set(rawRecipients.map(recipient => recipient.trim()).filter(Boolean))];
+	const toLabel = recipients.join(", ");
 	const message = params.message?.trim();
-	if (!to) {
-		return hubErrorResult('`to` is required for op="send".', { op: "send", from: senderId });
+	if (recipients.length === 0) {
+		return hubErrorResult('`to` requires one or more recipients for op="send".', { op: "send", from: senderId });
 	}
 	if (!message) {
-		return hubErrorResult('`message` is required for op="send".', { op: "send", from: senderId });
+		return hubErrorResult('`message` is required for op="send".', { op: "send", from: senderId, to: toLabel });
 	}
-	if (to === senderId) {
-		return hubErrorResult("Cannot send a message to yourself.", { op: "send", from: senderId, to });
+	if (recipients.includes(senderId)) {
+		return hubErrorResult("Cannot send a message to yourself.", { op: "send", from: senderId, to: toLabel });
 	}
-	const isBroadcast = to === "all";
+	if (params.await && recipients.length !== 1) {
+		return hubErrorResult("`await` requires exactly one recipient.", { op: "send", from: senderId, to: toLabel });
+	}
+	const singleRecipient = recipients[0] ?? "";
+	const isBroadcast = !recipientArray && singleRecipient === "all";
 	if (isBroadcast && params.await) {
 		return hubErrorResult('`await` is invalid with to:"all" — broadcasts have no single replier.', {
 			op: "send",
 			from: senderId,
-			to,
+			to: toLabel,
 		});
 	}
 
 	const bus = IrcBus.global();
+	if (recipientArray) {
+		const validationError = bus.validateExternalTargets(recipients);
+		if (validationError) return hubErrorResult(validationError, { op: "send", from: senderId, to: toLabel });
+	}
 	let waited: IrcMessage | null | undefined;
 	const timeoutMs = params.await ? resolveMessageTimeoutMs(settings, params.timeoutMs) : undefined;
 	const awaitAbort = params.await ? new AbortController() : undefined;
@@ -176,7 +191,7 @@ export async function executeSend(
 	let removeAwaitAbortListener: (() => void) | undefined;
 	const waiting = params.await
 		? bus
-				.wait(senderId, { from: to }, timeoutMs ?? DEFAULT_IRC_TIMEOUT_MS, awaitAbort?.signal, {
+				.wait(senderId, { from: singleRecipient }, timeoutMs ?? DEFAULT_IRC_TIMEOUT_MS, awaitAbort?.signal, {
 					drainPending: false,
 				})
 				.then(
@@ -200,21 +215,14 @@ export async function executeSend(
 	}
 
 	try {
-		// Broadcasts fan out to live peers only (running | idle); reviving every
-		// parked agent on a broadcast would be a stampede. Direct sends go
-		// through the bus unfiltered so parked recipients are revived.
-		const targets = isBroadcast ? registry.listVisibleTo(senderId).map(ref => ref.id) : [to];
-		// A broadcast that also reaches the main agent delivers the body to it
-		// directly (its own incoming card); relaying the sibling legs to the
-		// main UI would then show the same body once per other recipient.
+		// `all` retains the process-local broadcast contract. Cross-session
+		// broadcasts use `<channel-id>/all` so one channel cannot leak into another.
+		const targets = isBroadcast ? registry.listVisibleTo(senderId).map(ref => ref.id) : recipients;
 		const suppressRelay = isBroadcast && targets.includes(MAIN_AGENT_ID);
 		const receipts = await Promise.all(
 			targets.map(target =>
 				bus.send(
 					{ from: senderId, to: target, body: message, replyTo: params.replyTo },
-					// Awaited sends mark the sender as blocked on an answer so a
-					// busy recipient that cannot reach a step boundary (async
-					// disabled) auto-replies instead of stranding the sender.
 					{ expectsReply: params.await || undefined, suppressRelay: suppressRelay || undefined },
 				),
 			),
@@ -242,13 +250,9 @@ export async function executeSend(
 			if (delivered.length > 0) {
 				const reply = await waiting;
 				if (reply.error) {
-					// The send already succeeded; if the wait was interrupted by our
-					// caller signal (steering / messaging), preserve the delivery receipt
-					// so the agent loop keeps this tool as "sent" instead of marking it
-					// skipped, which would prompt a duplicate resend on the next turn.
 					if (signal?.aborted) {
 						lines.push(
-							`Send delivered but the reply wait was interrupted before ${to} answered. ` +
+							`Send delivered but the reply wait was interrupted before ${singleRecipient} answered. ` +
 								"Check `inbox` or `wait` again after handling the interrupt.",
 						);
 					} else {
@@ -261,7 +265,7 @@ export async function executeSend(
 						lines.push(waited.body);
 					} else {
 						lines.push(
-							`No reply from ${to} within ${formatDuration(timeoutMs)}. ` +
+							`No reply from ${singleRecipient} within ${formatDuration(timeoutMs)}. ` +
 								"They may answer later — check `inbox` or `wait` again.",
 						);
 					}
@@ -278,7 +282,7 @@ export async function executeSend(
 			details: {
 				op: "send",
 				from: senderId,
-				to,
+				to: toLabel,
 				receipts,
 				...(waited !== undefined ? { waited } : {}),
 			},
@@ -422,11 +426,15 @@ function bodyLines(
 	return lines;
 }
 
+function recipientLabel(to: string | string[] | undefined): string {
+	return Array.isArray(to) ? to.join(", ") : (to?.trim() ?? "");
+}
+
 /** Header title carrying the op direction: `IRC ➤ peer` out, `IRC ⟵ peer` in. */
 function callTitle(args: HubRenderArgs | undefined, theme: Theme): string {
 	switch (args?.op) {
 		case "send":
-			return `IRC ${theme.nav.selected} ${args.to?.trim() || "…"}`;
+			return `IRC ${theme.nav.selected} ${recipientLabel(args.to) || "…"}`;
 		case "wait":
 			return `IRC ${theme.nav.back} ${args.from?.trim() || "anyone"}`;
 		case "inbox":
@@ -515,7 +523,7 @@ function renderSendResult(
 	theme: Theme,
 ): string[] {
 	const receipts = details.receipts ?? [];
-	const to = details.to ?? args?.to?.trim() ?? "?";
+	const to = (details.to ?? recipientLabel(args?.to)) || "?";
 	const title = `IRC ${theme.nav.selected} ${to}`;
 
 	// Pre-delivery failures (validation) and empty broadcasts carry no receipts.

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -6,6 +6,7 @@
 
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { IrcDeliveryReceipt, IrcMessage } from "../../irc/bus";
+import type { SessionChannelSnapshot } from "../../session-channels/protocol";
 import type { LaunchParams, LaunchToolDetails } from "./launch";
 
 /**
@@ -18,6 +19,8 @@ export type HubOp =
 	| "wait"
 	| "inbox"
 	| "list"
+	| "channels"
+	| "disconnect"
 	| "jobs"
 	| "cancel"
 	| "start"
@@ -37,6 +40,7 @@ export interface HubPeerInfo {
 	unread: number;
 	lastActivity: number;
 	activity?: string;
+	channelId?: string;
 }
 
 /** Background-job row surfaced by `wait`/`cancel`/`jobs` results. */
@@ -90,6 +94,8 @@ export interface CoordinationDetails {
 	cancelled?: { id: string; status: CancelStatus }[];
 	/** Running subagents not represented by a job row in this result. */
 	agents?: AgentActivitySnapshot[];
+	/** User-authorized cross-session groups visible to this agent. */
+	channels?: SessionChannelSnapshot[];
 }
 
 /** Hub result details: coordination snapshots or launch (process) state. */
@@ -98,13 +104,14 @@ export type HubDetails = CoordinationDetails | LaunchToolDetails;
 /** Partially-streamed hub call arguments, as seen by the renderers. */
 export type HubRenderArgs = {
 	op?: string;
-	to?: string;
+	to?: string | string[];
 	message?: string;
 	replyTo?: string;
 	await?: boolean;
 	from?: string;
 	timeoutMs?: number;
 	peek?: boolean;
+	channel?: string;
 	ids?: string[];
 } & Partial<Omit<LaunchParams, "op">>;
 

--- a/packages/coding-agent/test/session-channels.test.ts
+++ b/packages/coding-agent/test/session-channels.test.ts
@@ -1,15 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as net from "node:net";
+import {
+	type ExtensionUISelectItem,
+	getExtensionUISelectOptionLabel,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import { IrcBus } from "@oh-my-pi/pi-coding-agent/irc/bus";
 import type { DaemonBrokerClient } from "@oh-my-pi/pi-coding-agent/launch/client";
 import * as launchClient from "@oh-my-pi/pi-coding-agent/launch/client";
 import type { DaemonOperation } from "@oh-my-pi/pi-coding-agent/launch/protocol";
+import type { InteractiveSelectorDialogOptions } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { SessionChannelBroker } from "@oh-my-pi/pi-coding-agent/session-channels/broker";
+import { handleSessionChannelTuiCommand } from "@oh-my-pi/pi-coding-agent/session-channels/command";
 import { SessionChannelManager } from "@oh-my-pi/pi-coding-agent/session-channels/manager";
 import type { ChannelAgentSnapshot, ChannelSessionSnapshot } from "@oh-my-pi/pi-coding-agent/session-channels/protocol";
+import type { TuiSlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
 
 function agent(id: string, kind: "main" | "sub" = "main"): ChannelAgentSnapshot {
 	return { id, displayName: id, kind, status: "running", lastActivity: Date.now() };
@@ -253,7 +260,7 @@ describe("cross-session channels", () => {
 		).rejects.toThrow("Unknown or closed channel");
 	});
 
-	it("supports user removal and full closure while notifying every affected member", async () => {
+	it("keeps multiple channels for one session independent", async () => {
 		const broker = new SessionChannelBroker();
 		const socketA = new net.Socket();
 		const socketB = new net.Socket();
@@ -262,6 +269,50 @@ describe("cross-session channels", () => {
 			[socketA, channelSession("aaaaaaaaaaaaaaaa")],
 			[socketB, channelSession("bbbbbbbbbbbbbbbb")],
 			[socketC, channelSession("cccccccccccccccc")],
+		] as const) {
+			await broker.dispatch({ op: "register", session: snapshot }, socket);
+		}
+
+		const first = await broker.dispatch(
+			{ op: "open", sessionId: "aaaaaaaaaaaaaaaa", memberIds: ["bbbbbbbbbbbbbbbb"] },
+			socketA,
+		);
+		if (first.op !== "open") throw new Error("Expected first open result");
+		await drainChannelUpdate(broker, socketA, "aaaaaaaaaaaaaaaa");
+		await drainChannelUpdate(broker, socketB, "bbbbbbbbbbbbbbbb");
+		const second = await broker.dispatch(
+			{ op: "open", sessionId: "aaaaaaaaaaaaaaaa", memberIds: ["cccccccccccccccc"] },
+			socketA,
+		);
+		if (second.op !== "open") throw new Error("Expected second open result");
+		await drainChannelUpdate(broker, socketA, "aaaaaaaaaaaaaaaa");
+		await drainChannelUpdate(broker, socketC, "cccccccccccccccc");
+
+		const beforeClose = await broker.dispatch({ op: "list", sessionId: "aaaaaaaaaaaaaaaa" }, socketA);
+		if (beforeClose.op !== "list") throw new Error("Expected list result");
+		expect(beforeClose.channels).toHaveLength(2);
+		expect(beforeClose.channels.map(channel => channel.id)).toEqual(
+			expect.arrayContaining([first.channel.id, second.channel.id]),
+		);
+
+		await broker.dispatch({ op: "close", sessionId: "aaaaaaaaaaaaaaaa", channelId: first.channel.id }, socketA);
+		await broker.dispatch({ op: "wait", sessionId: "aaaaaaaaaaaaaaaa", timeoutMs: 1 }, socketA);
+		await broker.dispatch({ op: "wait", sessionId: "bbbbbbbbbbbbbbbb", timeoutMs: 1 }, socketB);
+		const afterClose = await broker.dispatch({ op: "list", sessionId: "aaaaaaaaaaaaaaaa" }, socketA);
+		expect(afterClose.op === "list" && afterClose.channels.map(channel => channel.id)).toEqual([second.channel.id]);
+	});
+
+	it("atomically toggles user-selected members and notifies removed sessions", async () => {
+		const broker = new SessionChannelBroker();
+		const socketA = new net.Socket();
+		const socketB = new net.Socket();
+		const socketC = new net.Socket();
+		const socketD = new net.Socket();
+		for (const [socket, snapshot] of [
+			[socketA, channelSession("aaaaaaaaaaaaaaaa")],
+			[socketB, channelSession("bbbbbbbbbbbbbbbb")],
+			[socketC, channelSession("cccccccccccccccc")],
+			[socketD, channelSession("dddddddddddddddd")],
 		] as const) {
 			await broker.dispatch({ op: "register", session: snapshot }, socket);
 		}
@@ -274,15 +325,20 @@ describe("cross-session channels", () => {
 		await drainChannelUpdate(broker, socketB, "bbbbbbbbbbbbbbbb");
 		await drainChannelUpdate(broker, socketC, "cccccccccccccccc");
 
-		await broker.dispatch(
+		const toggled = await broker.dispatch(
 			{
-				op: "remove",
+				op: "set-members",
 				sessionId: "aaaaaaaaaaaaaaaa",
 				channelId: opened.channel.id,
-				memberId: "cccccccccccccccc",
+				memberIds: ["bbbbbbbbbbbbbbbb", "dddddddddddddddd"],
 			},
 			socketA,
 		);
+		expect(toggled.op === "set-members" && toggled.channel.members.map(member => member.id)).toEqual([
+			"aaaaaaaaaaaaaaaa",
+			"bbbbbbbbbbbbbbbb",
+			"dddddddddddddddd",
+		]);
 		for (const [socket, sessionId] of [
 			[socketA, "aaaaaaaaaaaaaaaa"],
 			[socketB, "bbbbbbbbbbbbbbbb"],
@@ -295,11 +351,15 @@ describe("cross-session channels", () => {
 				closed: false,
 			});
 		}
+		await drainChannelUpdate(broker, socketA, "aaaaaaaaaaaaaaaa");
+		await drainChannelUpdate(broker, socketB, "bbbbbbbbbbbbbbbb");
+		await drainChannelUpdate(broker, socketD, "dddddddddddddddd");
 
 		await broker.dispatch({ op: "close", sessionId: "aaaaaaaaaaaaaaaa", channelId: opened.channel.id }, socketA);
 		for (const [socket, sessionId] of [
 			[socketA, "aaaaaaaaaaaaaaaa"],
 			[socketB, "bbbbbbbbbbbbbbbb"],
+			[socketD, "dddddddddddddddd"],
 		] as const) {
 			const result = await broker.dispatch({ op: "wait", sessionId, timeoutMs: 1 }, socket);
 			expect(result.op === "wait" && result.event).toMatchObject({ type: "channel-closed", reason: "user" });
@@ -318,6 +378,80 @@ describe("cross-session channels", () => {
 				socketB,
 			),
 		).rejects.toThrow("Unknown or closed channel");
+	});
+
+	it("opens and toggles among multiple channels through checkbox selectors", async () => {
+		const broker = new SessionChannelBroker();
+		vi.spyOn(launchClient, "createDaemonBrokerClient").mockImplementation(async () => {
+			const socket = new net.Socket();
+			return {
+				request: async (operation: DaemonOperation) => {
+					if (operation.op !== "channel") throw new Error("Expected channel operation");
+					return { op: "channel", result: await broker.dispatch(operation.operation, socket) };
+				},
+				close: () => broker.disconnectSocket(socket),
+			} as unknown as DaemonBrokerClient;
+		});
+
+		const a = participant("A");
+		const b = participant("B");
+		const c = participant("C");
+		const managerA = await SessionChannelManager.start(a.session, a.registry, a.bus);
+		const managerB = await SessionChannelManager.start(b.session, b.registry, b.bus);
+		const managerC = await SessionChannelManager.start(c.session, c.registry, c.bus);
+		managers.push(managerA, managerB, managerC);
+
+		type SelectorChoice = (labels: string[]) => string | undefined;
+		const choices: SelectorChoice[] = [
+			labels => labels.find(label => label.startsWith(managerB.id)),
+			labels => labels.find(label => label.startsWith(managerC.id)),
+			labels => labels.find(label => label === "Done (2 selected)"),
+		];
+		const selectorStates: Array<{ title: string; checked: readonly number[] | undefined }> = [];
+		const statuses: string[] = [];
+		const errors: string[] = [];
+		const ctx = {
+			session: a.session,
+			editor: { setText: () => {} },
+			showStatus: (message: string) => statuses.push(message),
+			showError: (message: string) => errors.push(message),
+			showHookSelector: async (
+				title: string,
+				options: ExtensionUISelectItem[],
+				dialogOptions?: InteractiveSelectorDialogOptions,
+			) => {
+				const labels = options.map(getExtensionUISelectOptionLabel);
+				selectorStates.push({ title, checked: dialogOptions?.checkedIndices });
+				return choices.shift()?.(labels);
+			},
+		};
+		// InteractiveModeContext is intentionally narrowed to the fields used by the command handler.
+		const runtime = { ctx } as unknown as TuiSlashCommandRuntime;
+
+		await handleSessionChannelTuiCommand({ name: "channel", args: "open", text: "/channel open" }, runtime);
+		const openedState = await managerA.state();
+		expect(openedState.channels).toHaveLength(1);
+		expect(openedState.channels[0]?.members).toHaveLength(3);
+		expect(selectorStates.filter(state => state.title === "Open channel with sessions").at(-1)?.checked).toHaveLength(
+			2,
+		);
+
+		const second = await managerA.open([managerB.id]);
+		choices.push(
+			labels => labels.find(label => label.startsWith(second.id)),
+			labels => labels.find(label => label.startsWith(managerB.id)),
+			labels => labels.find(label => label.startsWith(managerC.id)),
+			labels => labels.find(label => label === "Done (1 selected)"),
+		);
+		await handleSessionChannelTuiCommand({ name: "channel", args: "toggle", text: "/channel toggle" }, runtime);
+
+		const toggledState = await managerA.state();
+		expect(toggledState.channels).toHaveLength(2);
+		const toggled = toggledState.channels.find(channel => channel.id === second.id);
+		expect(toggled?.members).toHaveLength(2);
+		expect(toggled?.members.map(member => member.id)).toEqual(expect.arrayContaining([managerA.id, managerC.id]));
+		expect(statuses.some(message => message.includes("opened with 3 sessions"))).toBe(true);
+		expect(errors).toEqual([]);
 	});
 
 	it("delivers session and subagent termination notices to every local channel agent", async () => {
@@ -375,5 +509,38 @@ describe("cross-session channels", () => {
 		expect(managerA.listPeers().every(peer => peer.channelId === channel.id && !peer.id.includes(managerB.id))).toBe(
 			true,
 		);
+	});
+	it("notifies local agents when the broker connection drops their channels", async () => {
+		const broker = new SessionChannelBroker();
+		const sockets: net.Socket[] = [];
+		vi.spyOn(Bun, "sleep").mockResolvedValue();
+		vi.spyOn(launchClient, "createDaemonBrokerClient").mockImplementation(async () => {
+			const socket = new net.Socket();
+			sockets.push(socket);
+			return {
+				request: async (operation: DaemonOperation) => {
+					if (operation.op !== "channel") throw new Error("Expected channel operation");
+					return { op: "channel", result: await broker.dispatch(operation.operation, socket) };
+				},
+				close: () => broker.disconnectSocket(socket),
+			} as unknown as DaemonBrokerClient;
+		});
+
+		const a = participant("A");
+		const b = participant("B");
+		const managerA = await SessionChannelManager.start(a.session, a.registry, a.bus);
+		const managerB = await SessionChannelManager.start(b.session, b.registry, b.bus);
+		managers.push(managerA, managerB);
+		await managerA.open([managerB.id]);
+		await waitForPeers(managerB, () => managerB.listPeers().length === 1);
+
+		const notice = a.waitForMessage(
+			message => message.body.includes("channel broker disconnected") && message.body.includes("authorization"),
+		);
+		const socketA = sockets[0];
+		if (!socketA) throw new Error("Expected manager A broker socket");
+		broker.disconnectSocket(socketA);
+		await notice;
+		expect(managerA.listPeers()).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/session-channels.test.ts
+++ b/packages/coding-agent/test/session-channels.test.ts
@@ -1,0 +1,379 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as net from "node:net";
+import { IrcBus } from "@oh-my-pi/pi-coding-agent/irc/bus";
+import type { DaemonBrokerClient } from "@oh-my-pi/pi-coding-agent/launch/client";
+import * as launchClient from "@oh-my-pi/pi-coding-agent/launch/client";
+import type { DaemonOperation } from "@oh-my-pi/pi-coding-agent/launch/protocol";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { SessionChannelBroker } from "@oh-my-pi/pi-coding-agent/session-channels/broker";
+import { SessionChannelManager } from "@oh-my-pi/pi-coding-agent/session-channels/manager";
+import type { ChannelAgentSnapshot, ChannelSessionSnapshot } from "@oh-my-pi/pi-coding-agent/session-channels/protocol";
+
+function agent(id: string, kind: "main" | "sub" = "main"): ChannelAgentSnapshot {
+	return { id, displayName: id, kind, status: "running", lastActivity: Date.now() };
+}
+
+function channelSession(id: string, agents: ChannelAgentSnapshot[] = [agent("Main")]): ChannelSessionSnapshot {
+	return {
+		id,
+		pid: process.pid,
+		sessionId: `persisted-${id}`,
+		cwd: `/tmp/${id}`,
+		startedAt: Date.now(),
+		agents,
+	};
+}
+
+async function drainChannelUpdate(broker: SessionChannelBroker, socket: net.Socket, sessionId: string): Promise<void> {
+	const result = await broker.dispatch({ op: "wait", sessionId, timeoutMs: 1 }, socket);
+	expect(result.op).toBe("wait");
+	if (result.op === "wait") expect(result.event?.type).toBe("channel-updated");
+}
+
+type DeliveredMessage = { from: string; to: string; body: string };
+
+function waitForPeers(manager: SessionChannelManager, check: () => boolean): Promise<void> {
+	if (check()) return Promise.resolve();
+	const { promise, resolve } = Promise.withResolvers<void>();
+	const unsubscribe = manager.onPeersChanged(() => {
+		if (!check()) return;
+		unsubscribe();
+		resolve();
+	});
+	return promise;
+}
+
+interface Participant {
+	registry: AgentRegistry;
+	bus: IrcBus;
+	session: AgentSession;
+	delivered: DeliveredMessage[];
+	waitForMessage: (predicate: (message: DeliveredMessage) => boolean) => Promise<DeliveredMessage>;
+}
+
+function participant(name: string): Participant {
+	const registry = new AgentRegistry();
+	const bus = new IrcBus(registry);
+	const delivered: DeliveredMessage[] = [];
+	const waiters = new Set<{
+		predicate: (message: DeliveredMessage) => boolean;
+		resolve: (message: DeliveredMessage) => void;
+	}>();
+	const session = {
+		sessionManager: SessionManager.inMemory(`/tmp/${name}`),
+		deliverIrcMessage: async (message: DeliveredMessage) => {
+			delivered.push(message);
+			for (const waiter of waiters) {
+				if (!waiter.predicate(message)) continue;
+				waiters.delete(waiter);
+				waiter.resolve(message);
+			}
+			return "injected" as const;
+		},
+		emitIrcRelayObservation: () => {},
+	} as unknown as AgentSession;
+	registry.register({ id: "Main", displayName: name, kind: "main", session });
+	return {
+		registry,
+		bus,
+		session,
+		delivered,
+		waitForMessage: predicate => {
+			const existing = delivered.find(predicate);
+			if (existing) return Promise.resolve(existing);
+			const { promise, resolve } = Promise.withResolvers<DeliveredMessage>();
+			waiters.add({ predicate, resolve });
+			return promise;
+		},
+	};
+}
+
+describe("cross-session channels", () => {
+	const managers: SessionChannelManager[] = [];
+
+	afterEach(async () => {
+		await Promise.all(managers.splice(0).map(manager => manager.close()));
+		vi.restoreAllMocks();
+	});
+
+	it("authorizes bidirectional messaging and supports groups larger than two sessions", async () => {
+		const broker = new SessionChannelBroker();
+		const socketA = new net.Socket();
+		const socketB = new net.Socket();
+		const socketC = new net.Socket();
+		await broker.dispatch({ op: "register", session: channelSession("aaaaaaaaaaaaaaaa") }, socketA);
+		await broker.dispatch({ op: "register", session: channelSession("bbbbbbbbbbbbbbbb") }, socketB);
+		await broker.dispatch({ op: "register", session: channelSession("cccccccccccccccc") }, socketC);
+
+		const opened = await broker.dispatch(
+			{
+				op: "open",
+				sessionId: "aaaaaaaaaaaaaaaa",
+				memberIds: ["bbbbbbbbbbbbbbbb", "cccccccccccccccc"],
+			},
+			socketA,
+		);
+		expect(opened.op).toBe("open");
+		if (opened.op !== "open") throw new Error("Expected open result");
+		expect(opened.channel.members).toHaveLength(3);
+		await drainChannelUpdate(broker, socketA, "aaaaaaaaaaaaaaaa");
+		await drainChannelUpdate(broker, socketB, "bbbbbbbbbbbbbbbb");
+		await drainChannelUpdate(broker, socketC, "cccccccccccccccc");
+
+		const aToB = await broker.dispatch(
+			{
+				op: "send",
+				sessionId: "aaaaaaaaaaaaaaaa",
+				channelId: opened.channel.id,
+				fromAgentId: "Main",
+				targetSessionId: "bbbbbbbbbbbbbbbb",
+				targetAgentId: "Main",
+				body: "from A",
+			},
+			socketA,
+		);
+		expect(aToB).toEqual({ op: "send", targets: 1 });
+		const atB = await broker.dispatch({ op: "wait", sessionId: "bbbbbbbbbbbbbbbb", timeoutMs: 1 }, socketB);
+		expect(atB.op === "wait" && atB.event).toMatchObject({
+			type: "message",
+			fromSessionId: "aaaaaaaaaaaaaaaa",
+			body: "from A",
+		});
+
+		await broker.dispatch(
+			{
+				op: "send",
+				sessionId: "bbbbbbbbbbbbbbbb",
+				channelId: opened.channel.id,
+				fromAgentId: "Main",
+				targetSessionId: "aaaaaaaaaaaaaaaa",
+				targetAgentId: "Main",
+				body: "from B",
+			},
+			socketB,
+		);
+		const atA = await broker.dispatch({ op: "wait", sessionId: "aaaaaaaaaaaaaaaa", timeoutMs: 1 }, socketA);
+		expect(atA.op === "wait" && atA.event).toMatchObject({
+			type: "message",
+			fromSessionId: "bbbbbbbbbbbbbbbb",
+			body: "from B",
+		});
+	});
+
+	it("notifies every remaining session and keeps a three-session channel open after termination", async () => {
+		const broker = new SessionChannelBroker();
+		const socketA = new net.Socket();
+		const socketB = new net.Socket();
+		const socketC = new net.Socket();
+		for (const [socket, snapshot] of [
+			[socketA, channelSession("aaaaaaaaaaaaaaaa")],
+			[socketB, channelSession("bbbbbbbbbbbbbbbb")],
+			[socketC, channelSession("cccccccccccccccc")],
+		] as const) {
+			await broker.dispatch({ op: "register", session: snapshot }, socket);
+		}
+		const opened = await broker.dispatch(
+			{ op: "open", sessionId: "aaaaaaaaaaaaaaaa", memberIds: ["bbbbbbbbbbbbbbbb", "cccccccccccccccc"] },
+			socketA,
+		);
+		if (opened.op !== "open") throw new Error("Expected open result");
+		await drainChannelUpdate(broker, socketA, "aaaaaaaaaaaaaaaa");
+		await drainChannelUpdate(broker, socketB, "bbbbbbbbbbbbbbbb");
+		await drainChannelUpdate(broker, socketC, "cccccccccccccccc");
+
+		broker.disconnectSocket(socketB);
+		for (const [socket, sessionId] of [
+			[socketA, "aaaaaaaaaaaaaaaa"],
+			[socketC, "cccccccccccccccc"],
+		] as const) {
+			const result = await broker.dispatch({ op: "wait", sessionId, timeoutMs: 1 }, socket);
+			expect(result.op === "wait" && result.event).toMatchObject({
+				type: "member-left",
+				reason: "session-ended",
+				closed: false,
+			});
+			if (result.op === "wait" && result.event?.type === "member-left") {
+				expect(result.event.remainingMembers).toHaveLength(2);
+			}
+		}
+
+		const sendAfterTermination = await broker.dispatch(
+			{
+				op: "send",
+				sessionId: "cccccccccccccccc",
+				channelId: opened.channel.id,
+				fromAgentId: "Main",
+				targetSessionId: "aaaaaaaaaaaaaaaa",
+				targetAgentId: "Main",
+				body: "still connected",
+			},
+			socketC,
+		);
+		expect(sendAfterTermination).toEqual({ op: "send", targets: 1 });
+	});
+
+	it("closes severed pair channels and requires a new authorization", async () => {
+		const broker = new SessionChannelBroker();
+		const socketA = new net.Socket();
+		const socketB = new net.Socket();
+		await broker.dispatch({ op: "register", session: channelSession("aaaaaaaaaaaaaaaa") }, socketA);
+		await broker.dispatch({ op: "register", session: channelSession("bbbbbbbbbbbbbbbb") }, socketB);
+		const opened = await broker.dispatch(
+			{ op: "open", sessionId: "aaaaaaaaaaaaaaaa", memberIds: ["bbbbbbbbbbbbbbbb"] },
+			socketA,
+		);
+		if (opened.op !== "open") throw new Error("Expected open result");
+		await drainChannelUpdate(broker, socketA, "aaaaaaaaaaaaaaaa");
+		await drainChannelUpdate(broker, socketB, "bbbbbbbbbbbbbbbb");
+		await broker.dispatch(
+			{ op: "leave", sessionId: "bbbbbbbbbbbbbbbb", channelId: opened.channel.id, reason: "agent" },
+			socketB,
+		);
+		const notice = await broker.dispatch({ op: "wait", sessionId: "aaaaaaaaaaaaaaaa", timeoutMs: 1 }, socketA);
+		expect(notice.op === "wait" && notice.event).toMatchObject({
+			type: "member-left",
+			reason: "agent",
+			closed: true,
+		});
+		await expect(
+			broker.dispatch(
+				{
+					op: "send",
+					sessionId: "aaaaaaaaaaaaaaaa",
+					channelId: opened.channel.id,
+					fromAgentId: "Main",
+					targetSessionId: "bbbbbbbbbbbbbbbb",
+					targetAgentId: "Main",
+					body: "must fail",
+				},
+				socketA,
+			),
+		).rejects.toThrow("Unknown or closed channel");
+	});
+
+	it("supports user removal and full closure while notifying every affected member", async () => {
+		const broker = new SessionChannelBroker();
+		const socketA = new net.Socket();
+		const socketB = new net.Socket();
+		const socketC = new net.Socket();
+		for (const [socket, snapshot] of [
+			[socketA, channelSession("aaaaaaaaaaaaaaaa")],
+			[socketB, channelSession("bbbbbbbbbbbbbbbb")],
+			[socketC, channelSession("cccccccccccccccc")],
+		] as const) {
+			await broker.dispatch({ op: "register", session: snapshot }, socket);
+		}
+		const opened = await broker.dispatch(
+			{ op: "open", sessionId: "aaaaaaaaaaaaaaaa", memberIds: ["bbbbbbbbbbbbbbbb", "cccccccccccccccc"] },
+			socketA,
+		);
+		if (opened.op !== "open") throw new Error("Expected open result");
+		await drainChannelUpdate(broker, socketA, "aaaaaaaaaaaaaaaa");
+		await drainChannelUpdate(broker, socketB, "bbbbbbbbbbbbbbbb");
+		await drainChannelUpdate(broker, socketC, "cccccccccccccccc");
+
+		await broker.dispatch(
+			{
+				op: "remove",
+				sessionId: "aaaaaaaaaaaaaaaa",
+				channelId: opened.channel.id,
+				memberId: "cccccccccccccccc",
+			},
+			socketA,
+		);
+		for (const [socket, sessionId] of [
+			[socketA, "aaaaaaaaaaaaaaaa"],
+			[socketB, "bbbbbbbbbbbbbbbb"],
+			[socketC, "cccccccccccccccc"],
+		] as const) {
+			const result = await broker.dispatch({ op: "wait", sessionId, timeoutMs: 1 }, socket);
+			expect(result.op === "wait" && result.event).toMatchObject({
+				type: "member-left",
+				reason: "user",
+				closed: false,
+			});
+		}
+
+		await broker.dispatch({ op: "close", sessionId: "aaaaaaaaaaaaaaaa", channelId: opened.channel.id }, socketA);
+		for (const [socket, sessionId] of [
+			[socketA, "aaaaaaaaaaaaaaaa"],
+			[socketB, "bbbbbbbbbbbbbbbb"],
+		] as const) {
+			const result = await broker.dispatch({ op: "wait", sessionId, timeoutMs: 1 }, socket);
+			expect(result.op === "wait" && result.event).toMatchObject({ type: "channel-closed", reason: "user" });
+		}
+		await expect(
+			broker.dispatch(
+				{
+					op: "send",
+					sessionId: "bbbbbbbbbbbbbbbb",
+					channelId: opened.channel.id,
+					fromAgentId: "Main",
+					targetSessionId: "aaaaaaaaaaaaaaaa",
+					targetAgentId: "Main",
+					body: "closed",
+				},
+				socketB,
+			),
+		).rejects.toThrow("Unknown or closed channel");
+	});
+
+	it("delivers session and subagent termination notices to every local channel agent", async () => {
+		const broker = new SessionChannelBroker();
+		vi.spyOn(launchClient, "createDaemonBrokerClient").mockImplementation(async () => {
+			const socket = new net.Socket();
+			return {
+				request: async (operation: DaemonOperation) => {
+					if (operation.op !== "channel") throw new Error("Expected channel operation");
+					return { op: "channel", result: await broker.dispatch(operation.operation, socket) };
+				},
+				close: () => broker.disconnectSocket(socket),
+			} as unknown as DaemonBrokerClient;
+		});
+
+		const a = participant("A");
+		const b = participant("B");
+		const c = participant("C");
+		const managerA = await SessionChannelManager.start(a.session, a.registry, a.bus);
+		const managerB = await SessionChannelManager.start(b.session, b.registry, b.bus);
+		const managerC = await SessionChannelManager.start(c.session, c.registry, c.bus);
+		managers.push(managerA, managerB, managerC);
+		const channel = await managerA.open([managerB.id, managerC.id]);
+		await Promise.all([
+			waitForPeers(managerB, () => managerB.listPeers().length === 2),
+			waitForPeers(managerC, () => managerC.listPeers().length === 2),
+		]);
+
+		const subSession = {
+			deliverIrcMessage: async () => "injected" as const,
+			emitIrcRelayObservation: () => {},
+		} as unknown as AgentSession;
+		const subAppeared = waitForPeers(managerA, () => managerA.listPeers().some(peer => peer.id.endsWith("/C-Sub")));
+		c.registry.register({ id: "C-Sub", displayName: "C subagent", kind: "sub", session: subSession });
+		await managerC.state();
+		await subAppeared;
+
+		const subNoticeA = a.waitForMessage(
+			message => message.body.includes("C-Sub") && message.body.includes("terminated"),
+		);
+		const subNoticeC = c.waitForMessage(
+			message => message.body.includes("C-Sub") && message.body.includes("terminated"),
+		);
+		c.registry.unregister("C-Sub");
+		await managerC.state();
+		await Promise.all([subNoticeA, subNoticeC]);
+
+		const sessionNoticeA = a.waitForMessage(
+			message => message.body.includes(`Session ${managerB.id}`) && message.body.includes("terminated"),
+		);
+		const sessionNoticeC = c.waitForMessage(message => message.body.includes(`Session ${managerB.id}`));
+		await managerB.close();
+		managers.splice(managers.indexOf(managerB), 1);
+		await Promise.all([sessionNoticeA, sessionNoticeC]);
+		expect(managerA.listPeers().every(peer => peer.channelId === channel.id && !peer.id.includes(managerB.id))).toBe(
+			true,
+		);
+	});
+});

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -713,6 +713,15 @@ describe("IRC", () => {
 			expect(crossChannel.isError).toBe(true);
 			expect(sent).toHaveLength(2);
 
+			const awaitedBroadcast = await tool.execute("call-awaited-all", {
+				op: "send",
+				to: "channel-a/all",
+				message: "who replies?",
+				await: true,
+			});
+			expect(awaitedBroadcast.isError).toBe(true);
+			expect(sent).toHaveLength(2);
+
 			const all = await tool.execute("call-all", {
 				op: "send",
 				to: "channel-a/all",

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { SettingPath } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
-import { IrcBus, type IrcMessage } from "@oh-my-pi/pi-coding-agent/irc/bus";
+import { IrcBus, type IrcExternalTransport, type IrcMessage } from "@oh-my-pi/pi-coding-agent/irc/bus";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -677,6 +677,49 @@ describe("IRC", () => {
 			expect(details?.receipts).toEqual([{ to: "0-Sub", outcome: "injected" }]);
 			expect(details?.waited).toBeUndefined();
 			expect(sub.delivered.map(msg => msg.body)).toEqual(["ping"]);
+		});
+
+		it("op=send targets one or more agents from one channel, or the channel broadcast address", async () => {
+			const sent: string[] = [];
+			const transport: IrcExternalTransport = {
+				handles: address => address.startsWith("channel-a/") || address === "channel-b/session-c/Main",
+				validateTargets: addresses => {
+					const channels = new Set(addresses.map(address => address.split("/")[0]));
+					return channels.size === 1 ? undefined : "Every recipient in an array must belong to the same channel.";
+				},
+				send: async message => {
+					sent.push(message.to);
+					return { to: message.to, outcome: "injected" };
+				},
+				listPeers: () => [],
+				isPeerRunning: () => true,
+				onPeersChanged: () => () => {},
+			};
+			bus.setExternalTransport(transport);
+			const tool = new HubTool(makeToolSession(registry, "0-Main"));
+			const selected = await tool.execute("call-selected", {
+				op: "send",
+				to: ["channel-a/session-b/Main", "channel-a/session-c/Worker"],
+				message: "selected",
+			});
+			expect(selected.isError).toBeFalsy();
+			expect(sent).toEqual(["channel-a/session-b/Main", "channel-a/session-c/Worker"]);
+
+			const crossChannel = await tool.execute("call-cross-channel", {
+				op: "send",
+				to: ["channel-a/session-b/Main", "channel-b/session-c/Main"],
+				message: "must not leak",
+			});
+			expect(crossChannel.isError).toBe(true);
+			expect(sent).toHaveLength(2);
+
+			const all = await tool.execute("call-all", {
+				op: "send",
+				to: "channel-a/all",
+				message: "everyone",
+			});
+			expect(all.isError).toBeFalsy();
+			expect(sent.at(-1)).toBe("channel-a/all");
 		});
 
 		it("op=send to=all fans out to live peers and reports per-recipient receipts", async () => {


### PR DESCRIPTION
## What

Allows agents in separately running OMP sessions to communicate through explicitly user-authorized, bidirectional channels.

The initiating session's user authorizes a channel; invited sessions do not require a second confirmation. Each session can participate in multiple independent channels, and each channel can contain two or more sessions.

Interactive users get checkbox selectors:

- `/channel open` selects one or more running sessions for a new channel;
- `/channel toggle [channel]` preselects current members and atomically applies additions and removals;
- when a session has multiple channels, `/channel toggle` first asks which channel to edit.

Headless/ACP callers can still provide explicit session ids. Agent messaging supports:

- direct messaging to one channel agent;
- selected fanout to an array of one or more agents in the same channel;
- channel-wide fanout through `<channel-id>/all`.

Channels can be severed by user leave or closure; by an agent using `hub disconnect`; or by session termination. Rejoining always requires fresh user authorization. Session, subagent, and broker termination notify every affected remaining agent.

## Motivation: primary autonomous-work pain points

The two primary pain points motivating this contribution are keeping related autonomous work synchronized and coordinating shared system-resource usage.

As the contributor: keeping related work in sync and coordinating system resource usage are my main pain points; there could be others.

### Keep related work synchronized

Independent autonomous sessions cannot currently exchange live coordination state. Parallel work is therefore vulnerable to duplicated effort, stale assumptions, conflicting edits, and missed dependency changes.

Cross-session channels let autonomous agents share discoveries, interface changes, blockers, ownership boundaries, and completion state while their tasks remain independently runnable.

### Coordinate shared system resources

Independent sessions can unknowingly contend for ports, development servers, GPU workers, build jobs, test suites, and other scarce resources. A live channel lets agents communicate ownership, expected duration, and availability before starting conflicting work.

This PR provides the communication substrate; it does not introduce resource locks or an automatic scheduler.

These are the primary motivating pain points, not an exhaustive list of uses. The channel primitive is deliberately general so autonomous agents can coordinate other relevant work, dependencies, state, or shared constraints without requiring a dedicated feature for every coordination pattern.

## Safety and lifecycle

- The subsystem is off by default while it stabilizes. Enable `Interaction → Agent Channels` in `/settings` and restart; `OMP_SESSION_CHANNELS=1` is an explicit environment opt-in.
- Only user slash commands create channels or change membership; no agent-facing operation authorizes communication.
- The initiating user's authorization is sufficient because the sessions run under the same authenticated user-global broker.
- Channel membership is live and non-persistent. Broker or session loss severs affected membership and notifies local agents.
- User and agent disconnects immediately revoke routing; reconnecting requires new user authorization.
- Plain `to: "all"` remains process-local. Cross-session broadcasts require `<channel-id>/all`, preventing accidental fanout across unrelated channels.
- Recipient arrays are rejected unless every address belongs to one channel.
- Awaiting any broadcast is rejected because replies arrive from concrete agent addresses.

## User and agent surfaces

User commands:

- `/channel list`
- `/channel open [session-id ...]`
- `/channel toggle [channel] [session-id ...]`
- `/channel leave <channel>`
- `/channel close <channel>`

Agent operations:

- `hub channels` lists authorized groups and exact peer addresses.
- `hub send` accepts one address, a same-channel address array, or `<channel-id>/all`.
- `hub disconnect` lets an agent leave a channel when it is no longer relevant.

## Implementation

- Extends the authenticated daemon protocol with an opt-in, user-global in-memory channel broker.
- Bridges authorized remote peers into `IrcBus` while preserving local routing and reply behavior.
- Publishes live session and agent rosters and propagates membership, message, termination, and broker-loss events.
- Applies interactive membership changes atomically so a channel never closes between removals and additions.
- Wires graceful disposal and abrupt socket loss into the same observable severance lifecycle.
- Adds checkbox selectors, `/channel` commands, channel-aware `hub` operations, settings, and prompt guidance.

## Verification

- `bun test packages/coding-agent/test/session-channels.test.ts packages/coding-agent/test/tools/irc.test.ts` — 58 passed, 0 failed.
- `bun run check:ts` — root Biome and all TypeScript workspace checks passed.
- `omp-pr7255 --smoke-test` — passed using the compiled side-by-side `omp/17.2.8` opt-in binary.
- Rebased onto the latest `origin/main` before validation.