### PR TITLE
fix(coding-agent): refresh context files on plugin reload

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/reload-plugins` retaining stale context-file contents and activation state in the current system prompt ([#7258](https://github.com/can1357/oh-my-pi/issues/7258)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1591,7 +1591,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}
 		return result;
 	};
-	const [contextFiles, resolvedWorkspaceTree, watchdogFiles, activeRepoContext, discoveredAdvisors] =
+	const [initialContextFiles, resolvedWorkspaceTree, watchdogFiles, activeRepoContext, discoveredAdvisors] =
 		await Promise.all([
 			contextFilesPromise,
 			raceWithDeadline("buildWorkspaceTree", workspaceTreePromise),
@@ -1599,6 +1599,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			activeRepoContextPromise,
 			advisorConfigsPromise,
 		]);
+	let contextFiles = initialContextFiles;
 
 	let agent: Agent;
 	let session!: AgentSession;
@@ -2783,6 +2784,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			tools: Map<string, AgentTool>,
 		): Promise<BuildSystemPromptResult> => {
 			toolContextStore.setToolNames(toolNames);
+			const promptCwd = sessionManager.getCwd();
+			if (hasSession && options.contextFiles === undefined) {
+				contextFiles = await logger.time("discoverContextFiles", discoverContextFiles, promptCwd, agentDir);
+				toolSession.contextFiles = contextFiles;
+			}
 			const memoryBackend = restrictToolNames ? undefined : await resolveMemoryBackend(settings);
 			const memoryInstructions = memoryBackend
 				? await memoryBackend.buildDeveloperInstructions(agentDir, settings, session)
@@ -2852,7 +2858,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					: options.appendSystemPrompt;
 			}
 			const defaultPrompt = await buildSystemPromptInternal({
-				cwd,
+				cwd: promptCwd,
 				additionalWorkspaceRoots: sessionManager.getAdditionalDirectories(),
 				xdevTools: toolSession.xdev ? xdevEntries(toolSession.xdev) : [],
 				xdevDocs: toolSession.xdev

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2792,6 +2792,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					...(settings.get("disabledExtensions") ?? []),
 				]);
 				toolSession.contextFiles = contextFiles;
+				session.setAdvisorContextPrompt(formatAdvisorContextPrompt(contextFiles));
 			}
 			const memoryBackend = restrictToolNames ? undefined : await resolveMemoryBackend(settings);
 			const memoryInstructions = memoryBackend

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -778,9 +778,11 @@ export async function discoverSkills(
 export async function discoverContextFiles(
 	cwd?: string,
 	_agentDir?: string,
+	disabledExtensions?: string[],
 ): Promise<Array<{ path: string; content: string; depth?: number }>> {
 	return await loadContextFilesInternal({
 		cwd: cwd ?? getProjectDir(),
+		disabledExtensions,
 	});
 }
 
@@ -2786,7 +2788,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			toolContextStore.setToolNames(toolNames);
 			const promptCwd = sessionManager.getCwd();
 			if (hasSession && options.contextFiles === undefined) {
-				contextFiles = await logger.time("discoverContextFiles", discoverContextFiles, promptCwd, agentDir);
+				contextFiles = await logger.time("discoverContextFiles", discoverContextFiles, promptCwd, agentDir, [
+					...(settings.get("disabledExtensions") ?? []),
+				]);
 				toolSession.contextFiles = contextFiles;
 			}
 			const memoryBackend = restrictToolNames ? undefined : await resolveMemoryBackend(settings);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8720,6 +8720,15 @@ export class AgentSession {
 	}
 
 	/**
+	 * Refresh the project context prompt advisor sessions run against after
+	 * context files change on `/reload-plugins`. Rebuilds live advisor runtimes so
+	 * they stop evaluating turns against stale `AGENTS.md` instructions.
+	 */
+	setAdvisorContextPrompt(contextPrompt: string | undefined): void {
+		this.#advisors.setContextPrompt(contextPrompt);
+	}
+
+	/**
 	 * Whether the advisor setting is enabled for this session.
 	 */
 	isAdvisorEnabled(): boolean {

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1580,6 +1580,20 @@ export class SessionAdvisors {
 	}
 
 	/**
+	 * Swap the project context prompt handed to advisor sessions after context
+	 * files change (`/reload-plugins` edit/disable). Rebuilds live runtimes in
+	 * place so the next advisor turn evaluates against the current instructions;
+	 * a no-op when the rendered prompt is unchanged.
+	 */
+	setContextPrompt(contextPrompt: string | undefined): void {
+		if (contextPrompt === this.#advisorContextPrompt) return;
+		this.#advisorContextPrompt = contextPrompt;
+		if (!this.#advisorEnabled || this.#advisors.length === 0) return;
+		this.#stopAdvisorRuntime();
+		this.#buildAdvisorRuntime(true);
+	}
+
+	/**
 	 * Whether the advisor setting is enabled for this session.
 	 */
 	isAdvisorEnabled(): boolean {

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -831,23 +831,21 @@ export class SessionTools {
 
 	/** Rediscovers reloadable skills and refreshes prompt metadata. */
 	async refreshSkills(): Promise<void> {
-		if (!this.#skillsReloadable) {
-			return;
-		}
-
 		resetCapabilities();
-		const skillsSettings = this.#host.settings.getGroup("skills");
-		const discovered = await loadSkills({
-			...skillsSettings,
-			cwd: this.#host.sessionManager.getCwd(),
-			disabledExtensions: this.#host.settings.get("disabledExtensions") ?? [],
-		});
-		this.#skills = discovered.skills;
-		this.#skillWarnings = discovered.warnings;
-		this.#skillsSettings = skillsSettings;
+		if (this.#skillsReloadable) {
+			const skillsSettings = this.#host.settings.getGroup("skills");
+			const discovered = await loadSkills({
+				...skillsSettings,
+				cwd: this.#host.sessionManager.getCwd(),
+				disabledExtensions: this.#host.settings.get("disabledExtensions") ?? [],
+			});
+			this.#skills = discovered.skills;
+			this.#skillWarnings = discovered.warnings;
+			this.#skillsSettings = skillsSettings;
 
-		if (this.#host.agentKind() === "main") {
-			setActiveSkills(this.#skills);
+			if (this.#host.agentKind() === "main") {
+				setActiveSkills(this.#skills);
+			}
 		}
 		await this.refreshBaseSystemPrompt();
 		this.#host.notifyCommandMetadataChanged();

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -332,6 +332,8 @@ export async function resolvePromptInput(input: string | undefined, description:
 export interface LoadContextFilesOptions {
 	/** Working directory to start walking up from. Default: getProjectDir() */
 	cwd?: string;
+	/** Disabled extension IDs to honor instead of the process-global settings. */
+	disabledExtensions?: string[];
 }
 
 function dedupeExactContextFiles(
@@ -356,7 +358,10 @@ export async function loadProjectContextFiles(
 ): Promise<Array<{ path: string; content: string; depth?: number }>> {
 	const resolvedCwd = options.cwd ?? getProjectDir();
 
-	const result = await loadCapability(contextFileCapability.id, { cwd: resolvedCwd });
+	const result = await loadCapability(contextFileCapability.id, {
+		cwd: resolvedCwd,
+		disabledExtensions: options.disabledExtensions,
+	});
 
 	// Materialize ContextFile items, expanding any `@path/to/file` includes
 	// in their content. The expansion uses the file's own directory as the

--- a/packages/coding-agent/test/sdk-context-file-refresh.test.ts
+++ b/packages/coding-agent/test/sdk-context-file-refresh.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { AuthStorage } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const INITIAL_CONTEXT = "reload-context-initial-marker";
+const UPDATED_CONTEXT = "reload-context-updated-marker";
+const PROJECT_CONTEXT_EXTENSION_ID = "context-file:project:AGENTS.md";
+
+async function createContextSession(
+	cwd: string,
+	settings: Settings,
+): Promise<{ session: AgentSession; authStorage: AuthStorage }> {
+	const authStorage = await AuthStorage.create(`${cwd}/auth.db`);
+	const modelRegistry = new ModelRegistry(authStorage);
+	const { session } = await createAgentSession({
+		cwd,
+		agentDir: cwd,
+		modelRegistry,
+		sessionManager: SessionManager.inMemory(cwd),
+		settings,
+		model: getBundledModel("openai", "gpt-4o-mini"),
+		disableExtensionDiscovery: true,
+		promptTemplates: [],
+		slashCommands: [],
+		enableMCP: false,
+		enableLsp: false,
+		skipPythonPreflight: true,
+	});
+	return { session, authStorage };
+}
+
+describe("context-file prompt refresh", () => {
+	it("replaces edited context-file content in the current system prompt", async () => {
+		using tempDir = TempDir.createSync("@omp-context-refresh-edit-");
+		const contextPath = tempDir.join("AGENTS.md");
+		await Bun.write(contextPath, INITIAL_CONTEXT);
+		const { session, authStorage } = await createContextSession(tempDir.path(), Settings.isolated({}));
+
+		try {
+			expect(session.systemPrompt.join("\n")).toContain(INITIAL_CONTEXT);
+
+			await Bun.write(contextPath, UPDATED_CONTEXT);
+			await session.refreshSkills();
+
+			const refreshedPrompt = session.systemPrompt.join("\n");
+			expect(refreshedPrompt).toContain(UPDATED_CONTEXT);
+			expect(refreshedPrompt).not.toContain(INITIAL_CONTEXT);
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+
+	it("removes a disabled context file from the current system prompt", async () => {
+		using tempDir = TempDir.createSync("@omp-context-refresh-disable-");
+		await Bun.write(tempDir.join("AGENTS.md"), INITIAL_CONTEXT);
+		const settings = Settings.isolated({});
+		const { session, authStorage } = await createContextSession(tempDir.path(), settings);
+
+		try {
+			expect(session.systemPrompt.join("\n")).toContain(INITIAL_CONTEXT);
+
+			settings.set("disabledExtensions", [PROJECT_CONTEXT_EXTENSION_ID]);
+			await session.refreshSkills();
+
+			expect(session.systemPrompt.join("\n")).not.toContain(INITIAL_CONTEXT);
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+});

--- a/packages/coding-agent/test/sdk-context-file-refresh.test.ts
+++ b/packages/coding-agent/test/sdk-context-file-refresh.test.ts
@@ -3,6 +3,7 @@ import { AuthStorage } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initializeWithSettings } from "@oh-my-pi/pi-coding-agent/discovery";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -70,6 +71,29 @@ describe("context-file prompt refresh", () => {
 			await session.refreshSkills();
 
 			expect(session.systemPrompt.join("\n")).not.toContain(INITIAL_CONTEXT);
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+
+	it("honors the session's own disabledExtensions, not the process-global settings", async () => {
+		using tempDir = TempDir.createSync("@omp-context-refresh-isolation-");
+		await Bun.write(tempDir.join("AGENTS.md"), INITIAL_CONTEXT);
+		const settings = Settings.isolated({});
+		const { session, authStorage } = await createContextSession(tempDir.path(), settings);
+
+		try {
+			expect(session.systemPrompt.join("\n")).toContain(INITIAL_CONTEXT);
+
+			// A concurrently-created session installs different global settings that
+			// disable this session's context file. The refresh must consult this
+			// session's own settings, so the entry survives.
+			const competingSettings = Settings.isolated({ disabledExtensions: [PROJECT_CONTEXT_EXTENSION_ID] });
+			initializeWithSettings(competingSettings);
+			await session.refreshSkills();
+
+			expect(session.systemPrompt.join("\n")).toContain(INITIAL_CONTEXT);
 		} finally {
 			await session.dispose();
 			authStorage.close();

--- a/packages/coding-agent/test/sdk-context-file-refresh.test.ts
+++ b/packages/coding-agent/test/sdk-context-file-refresh.test.ts
@@ -102,6 +102,7 @@ describe("context-file prompt refresh", () => {
 
 			expect(session.systemPrompt.join("\n")).toContain(INITIAL_CONTEXT);
 		} finally {
+			initializeWithSettings(settings);
 			await session.dispose();
 			authStorage.close();
 		}

--- a/packages/coding-agent/test/sdk-context-file-refresh.test.ts
+++ b/packages/coding-agent/test/sdk-context-file-refresh.test.ts
@@ -16,8 +16,15 @@ const PROJECT_CONTEXT_EXTENSION_ID = "context-file:project:AGENTS.md";
 async function createContextSession(
 	cwd: string,
 	settings: Settings,
+	options: { advisor?: boolean } = {},
 ): Promise<{ session: AgentSession; authStorage: AuthStorage }> {
 	const authStorage = await AuthStorage.create(`${cwd}/auth.db`);
+	const model = getBundledModel("openai", "gpt-4o-mini");
+	if (options.advisor) {
+		authStorage.setRuntimeApiKey("openai", "test-key");
+		settings.set("advisor.enabled", true);
+		settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+	}
 	const modelRegistry = new ModelRegistry(authStorage);
 	const { session } = await createAgentSession({
 		cwd,
@@ -25,7 +32,7 @@ async function createContextSession(
 		modelRegistry,
 		sessionManager: SessionManager.inMemory(cwd),
 		settings,
-		model: getBundledModel("openai", "gpt-4o-mini"),
+		model,
 		disableExtensionDiscovery: true,
 		promptTemplates: [],
 		slashCommands: [],
@@ -94,6 +101,31 @@ describe("context-file prompt refresh", () => {
 			await session.refreshSkills();
 
 			expect(session.systemPrompt.join("\n")).toContain(INITIAL_CONTEXT);
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+
+	it("refreshes the advisor context prompt when context files change", async () => {
+		using tempDir = TempDir.createSync("@omp-context-refresh-advisor-");
+		const contextPath = tempDir.join("AGENTS.md");
+		await Bun.write(contextPath, INITIAL_CONTEXT);
+		const { session, authStorage } = await createContextSession(tempDir.path(), Settings.isolated({}), {
+			advisor: true,
+		});
+
+		try {
+			const advisorPrompt = () => session.getAdvisorAgent()?.state.systemPrompt.join("\n") ?? "";
+			expect(session.isAdvisorActive()).toBe(true);
+			expect(advisorPrompt()).toContain(INITIAL_CONTEXT);
+
+			await Bun.write(contextPath, UPDATED_CONTEXT);
+			await session.refreshSkills();
+
+			const refreshed = advisorPrompt();
+			expect(refreshed).toContain(UPDATED_CONTEXT);
+			expect(refreshed).not.toContain(INITIAL_CONTEXT);
 		} finally {
 			await session.dispose();
 			authStorage.close();


### PR DESCRIPTION
## Repro
Create a session with an active `AGENTS.md`, then edit its contents or add `context-file:project:AGENTS.md` to `disabledExtensions` and run the plugin prompt refresh path. `bun test packages/coding-agent/test/sdk-context-file-refresh.test.ts` reproduced both stale-prompt cases before the fix (0 passed, 2 failed).

## Cause
`createAgentSession` in `packages/coding-agent/src/sdk.ts` captured the initially discovered `contextFiles` array and `rebuildSystemPrompt` reused it for every later `SessionTools.refreshBaseSystemPrompt()` call. `SessionTools.refreshSkills()` also returned before rebuilding when skills were preloaded, coupling all prompt-source refreshes to skill reloadability.

## Fix
- Rediscover effective context files from the active session cwd before post-start system-prompt rebuilds, preserving explicitly supplied SDK context files.
- Keep `ToolSession.contextFiles` synchronized with the refreshed discovery result.
- Rebuild prompt metadata on plugin refresh even when skills themselves are not reloadable.
- Cover edited content and disabled context-file activation in the current system prompt, and document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/sdk-context-file-refresh.test.ts packages/coding-agent/test/reload-plugins-mcp.test.ts` passed: 4 tests, 0 failures. `bun run check` in `packages/coding-agent` passed. Fixes #7258