### PR TITLE
fix(tui): prevent test env from suppressing interactive launch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed interactive launches hanging silently when a host project or its `.env` sets `NODE_ENV=test` or `BUN_ENV=test` ([#7261](https://github.com/can1357/oh-my-pi/issues/7261)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed interactive terminals suppressing all output and input when the host project sets `NODE_ENV=test` or `BUN_ENV=test` ([#7261](https://github.com/can1357/oh-my-pi/issues/7261)).
+
 ## [17.2.2] - 2026-07-31
 
 ### Added

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Bun test-runtime detection treating application-owned `NODE_ENV=test` and `BUN_ENV=test` values as test-runner signals ([#7261](https://github.com/can1357/oh-my-pi/issues/7261)).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -258,9 +258,13 @@ export function $envpos(name: string, defaultValue: number): number {
 	return parsed;
 }
 
-/** True when `BUN_ENV` or `NODE_ENV` is the string `test`. */
+const BUN_TEST_ENTRY_PATTERN = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
+
+/** True when the process is an explicitly marked test child or Bun is running a test entrypoint. */
 export function isBunTestRuntime(): boolean {
-	return Bun.env.BUN_ENV === "test" || Bun.env.NODE_ENV === "test";
+	if (Bun.env.PI_TEST_RUNTIME === "1") return true;
+	const hasTestEnvironment = Bun.env.BUN_ENV === "test" || Bun.env.NODE_ENV === "test";
+	return hasTestEnvironment && BUN_TEST_ENTRY_PATTERN.test(Bun.main);
 }
 
 let terminalHeadless = isBunTestRuntime();

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { filterProcessEnv, parseEnvFile } from "@oh-my-pi/pi-utils/env";
 
 const tempDirs: string[] = [];
+const runtimeProbePath = path.join(import.meta.dir, "fixtures", "test-runtime-probe.ts");
 
 afterEach(() => {
 	for (const dir of tempDirs.splice(0)) {
@@ -18,6 +19,23 @@ function writeTempEnv(content: string): string {
 	const filePath = path.join(dir, ".env");
 	fs.writeFileSync(filePath, content);
 	return filePath;
+}
+
+async function runRuntimeProbe(env: Record<string, string | undefined>): Promise<boolean> {
+	const cwd = path.dirname(writeTempEnv(""));
+	const proc = Bun.spawn([process.execPath, runtimeProbePath], {
+		cwd,
+		env: { ...process.env, ...env },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	expect(exitCode, stderr).toBe(0);
+	return JSON.parse(stdout) as boolean;
 }
 
 describe("parseEnvFile", () => {
@@ -119,5 +137,16 @@ describe("filterProcessEnv", () => {
 			"ProgramFiles(x86)": "C:\\Program Files (x86)",
 			"CommonProgramFiles(x86)": "C:\\Program Files (x86)\\Common Files",
 		});
+	});
+});
+
+describe("isBunTestRuntime", () => {
+	it("does not treat shared application env names as a test runner signal", async () => {
+		expect(await runRuntimeProbe({ NODE_ENV: "test", BUN_ENV: undefined, PI_TEST_RUNTIME: undefined })).toBe(false);
+		expect(await runRuntimeProbe({ NODE_ENV: undefined, BUN_ENV: "test", PI_TEST_RUNTIME: undefined })).toBe(false);
+	});
+
+	it("honors the private test runner signal", async () => {
+		expect(await runRuntimeProbe({ NODE_ENV: undefined, BUN_ENV: undefined, PI_TEST_RUNTIME: "1" })).toBe(true);
 	});
 });

--- a/packages/utils/test/fixtures/test-runtime-probe.ts
+++ b/packages/utils/test/fixtures/test-runtime-probe.ts
@@ -1,0 +1,3 @@
+import { isBunTestRuntime } from "@oh-my-pi/pi-utils/env";
+
+process.stdout.write(JSON.stringify(isBunTestRuntime()));

--- a/scripts/ci-test-ts.ts
+++ b/scripts/ci-test-ts.ts
@@ -467,9 +467,9 @@ async function runTestCommand(testCommand: TestCommand): Promise<void> {
 	}
 }
 
-// Child env shared by every spawned test process: the parent env with all CI
-// credential / cloud-config variables scrubbed (see SCRUBBED_ENV_* above) and
-// GITHUB_ACTIONS cleared so suites resolve only against their own fixtures.
+// Child env shared by every spawned test process: the parent env with the
+// private test-runtime marker set, all CI credential / cloud-config variables
+// scrubbed (see SCRUBBED_ENV_* above), and GITHUB_ACTIONS cleared.
 //
 // GC knobs (both needed — they gate different JSC mechanisms):
 // - `BUN_JSC_useConcurrentGC=0` stops the collector from marking concurrently
@@ -493,6 +493,7 @@ function buildChildEnv(): Record<string, string | undefined> {
 	const env: Record<string, string | undefined> = {
 		...Bun.env,
 		GITHUB_ACTIONS: "",
+		PI_TEST_RUNTIME: "1",
 		BUN_JSC_useConcurrentGC: "0",
 		BUN_JSC_numberOfGCMarkers: "1",
 	};


### PR DESCRIPTION
## Repro

In a PTY, `NODE_ENV=test bun packages/coding-agent/src/cli.ts --no-tools --no-skills --no-extensions --no-lsp --no-session --no-title` stayed alive with zero output after 9 seconds, while the `NODE_ENV=development` control emitted the TUI within 6.7 seconds. A project `.env` containing `NODE_ENV=test` reached the same headless path.

## Cause

`isBunTestRuntime()` in `packages/utils/src/env.ts` treated bare application-owned `NODE_ENV=test` and `BUN_ENV=test` values as proof of a Bun test process. The module latched that result into `terminalHeadless`, so `ProcessTerminal.start()` in `packages/tui/src/terminal.ts` returned before installing terminal I/O and all frame writes were suppressed.

## Fix

- Require either the private `PI_TEST_RUNTIME=1` marker or a Bun test/spec entrypoint plus Bun's test environment before identifying a test runtime.
- Inject `PI_TEST_RUNTIME=1` into every child launched by `scripts/ci-test-ts.ts`, preserving test-only behavior in subprocesses.
- Add subprocess regression coverage for shared env values and the private marker, plus affected package changelog entries.

## Verification

`bun test packages/utils/test/env.test.ts packages/tui/test/process-terminal-headless.test.ts` passed: 12 tests, 0 failures. `bun run check:ts` passed across all TypeScript workspaces. PTY smoke tests on the fixed worktree rendered the TUI within 4.4 seconds with inherited `NODE_ENV=test` and within 3.9 seconds from a project `.env` containing `NODE_ENV=test`. `bun check` fails on `main` for the unrelated missing `cmake` executable required by `audiopus_sys`; skipped the pre-publish gate.

Fixes #7261