### PR TITLE
fix(ai): retry opaque OpenRouter strict-tool errors

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenRouter DeepSeek models failing structured subagents when the upstream returns an opaque HTTP 400 for a strict yield schema, retrying once without strict tools and remembering the fallback for the provider session ([#7264](https://github.com/can1357/oh-my-pi/issues/7264)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Added

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -757,7 +757,13 @@ const streamOpenAICompletionsOnce = (
 					disableStrictTools = true;
 					openaiStream = await createCompletionsStream("none");
 				} else {
-					if (!shouldRetryWithoutStrictTools(error, capturedErrorResponse, appliedStrictTools, context.tools)) {
+					if (
+						!shouldRetryWithoutStrictTools(error, capturedErrorResponse, {
+							model,
+							strictToolsApplied: appliedStrictTools,
+							tools: context.tools,
+						})
+					) {
 						throw error;
 					}
 					// Remember the rejection for the rest of the session so every

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -610,12 +610,11 @@ const streamOpenAIResponsesOnce = (
 							strictRetryAvailable &&
 							!requestSignal.aborted &&
 							(compiledGrammarTooLarge ||
-								shouldRetryWithoutStrictTools(
-									error,
-									capturedErrorResponse,
-									activeStrictToolsApplied,
-									context.tools,
-								));
+								shouldRetryWithoutStrictTools(error, capturedErrorResponse, {
+									model,
+									strictToolsApplied: activeStrictToolsApplied,
+									tools: context.tools,
+								}));
 						if (canRetryWithoutStrictTools) {
 							strictRetryAvailable = false;
 							forceDisableStrictTools = true;

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1181,15 +1181,24 @@ export function isCompiledGrammarTooLargeStrictError(
 	);
 }
 
+interface StrictToolsRetryContext {
+	model: OpenAIModelIdentity;
+	strictToolsApplied: boolean;
+	tools: Tool[] | undefined;
+}
+
+/** Decide whether an OpenAI-family request should retry once with non-strict tools. */
 export function shouldRetryWithoutStrictTools(
 	error: unknown,
 	capturedErrorResponse: CapturedHttpErrorResponse | undefined,
-	strictToolsApplied: boolean,
-	tools: Tool[] | undefined,
+	context: StrictToolsRetryContext,
 ): boolean {
+	const { model, strictToolsApplied, tools } = context;
 	if (!tools || tools.length === 0 || !strictToolsApplied) return false;
 	const status = extractHttpStatusFromError(error) ?? capturedErrorResponse?.status;
 	if (status !== 400 && status !== 422) return false;
+	const errorMessage = error instanceof Error ? error.message.trim() : "";
+	if (model.provider === "openrouter" && /^(?:400\s+)?Provider returned error$/i.test(errorMessage)) return true;
 	const messageParts = [error instanceof Error ? error.message : undefined, capturedErrorResponse?.bodyText]
 		.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
 		.join("\n");

--- a/packages/ai/test/openai-tool-strict-mode.test.ts
+++ b/packages/ai/test/openai-tool-strict-mode.test.ts
@@ -90,6 +90,60 @@ function createSseResponse(events: unknown[]): Response {
 	});
 }
 
+function createResponsesTextSseResponse(text: string): Response {
+	return createSseResponse([
+		{
+			type: "response.output_item.added",
+			output_index: 0,
+			item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+		},
+		{
+			type: "response.content_part.added",
+			item_id: "msg_1",
+			output_index: 0,
+			content_index: 0,
+			part: { type: "output_text", text: "" },
+		},
+		{
+			type: "response.output_text.delta",
+			item_id: "msg_1",
+			output_index: 0,
+			content_index: 0,
+			delta: text,
+		},
+		{
+			type: "response.output_text.done",
+			item_id: "msg_1",
+			output_index: 0,
+			content_index: 0,
+			text,
+		},
+		{
+			type: "response.output_item.done",
+			output_index: 0,
+			item: {
+				type: "message",
+				id: "msg_1",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text }],
+			},
+		},
+		{
+			type: "response.completed",
+			response: {
+				status: "completed",
+				usage: {
+					input_tokens: 1,
+					output_tokens: 1,
+					total_tokens: 2,
+					input_tokens_details: { cached_tokens: 0 },
+				},
+			},
+		},
+	]);
+}
+
 function captureCompletionsPayload(
 	model: Model<"openai-completions">,
 	context: Context = testContext,
@@ -504,57 +558,7 @@ describe("OpenAI tool strict mode", () => {
 						{ status: 400, headers: { "content-type": "application/json" } },
 					);
 				}
-				return createSseResponse([
-					{
-						type: "response.output_item.added",
-						output_index: 0,
-						item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
-					},
-					{
-						type: "response.content_part.added",
-						item_id: "msg_1",
-						output_index: 0,
-						content_index: 0,
-						part: { type: "output_text", text: "" },
-					},
-					{
-						type: "response.output_text.delta",
-						item_id: "msg_1",
-						output_index: 0,
-						content_index: 0,
-						delta: "Recovered",
-					},
-					{
-						type: "response.output_text.done",
-						item_id: "msg_1",
-						output_index: 0,
-						content_index: 0,
-						text: "Recovered",
-					},
-					{
-						type: "response.output_item.done",
-						output_index: 0,
-						item: {
-							type: "message",
-							id: "msg_1",
-							role: "assistant",
-							status: "completed",
-							content: [{ type: "output_text", text: "Recovered" }],
-						},
-					},
-					{
-						type: "response.completed",
-						response: {
-							status: "completed",
-							usage: {
-								input_tokens: 1,
-								output_tokens: 1,
-								total_tokens: 2,
-								input_tokens_details: { cached_tokens: 0 },
-							},
-						},
-					},
-				]);
+				return createResponsesTextSseResponse("Recovered");
 			},
 			{ preconnect: fetch.preconnect },
 		);
@@ -624,8 +628,11 @@ describe("OpenAI tool strict mode", () => {
 		expect(strictFlags).toEqual([[true]]);
 	});
 
-	it("falls back to non-strict tools when an upstream validator rejects strict schemas, and remembers it", async () => {
-		const model = getBundledModel("openrouter", "deepseek/deepseek-v4-flash") as Model<"openai-completions">;
+	it.each([
+		["a descriptive schema error", "Invalid tool parameters schema : field `anyOf`: missing field `type`"],
+		["an opaque provider error", "Provider returned error"],
+	])("falls back to non-strict tools after %s, and remembers it", async (_case, rejectionMessage) => {
+		const model = getBundledModel("openrouter", "deepseek/deepseek-v4-flash-0731") as Model<"openai-completions">;
 		const providerSessionState = new Map<string, ProviderSessionState>();
 		const strictFlags: boolean[][] = [];
 		let attempt = 0;
@@ -641,7 +648,7 @@ describe("OpenAI tool strict mode", () => {
 					return new Response(
 						JSON.stringify({
 							error: {
-								message: "Invalid tool parameters schema : field `anyOf`: missing field `type`",
+								message: rejectionMessage,
 								type: "invalid_request_error",
 							},
 						}),
@@ -692,6 +699,57 @@ describe("OpenAI tool strict mode", () => {
 		expect(nextResult.stopReason).toBe("stop");
 		expect(nextResult.content).toContainEqual({ type: "text", text: "Later" });
 		expect(strictFlags).toEqual([[true], [false], [false]]);
+	});
+
+	it("retries opaque OpenRouter provider errors without strict Responses tools and remembers it", async () => {
+		const model = buildModel({
+			id: "deepseek/deepseek-v4-flash-0731",
+			name: "DeepSeek V4 Flash 0731 via OpenRouter Responses",
+			api: "openai-responses",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1_048_576,
+			maxTokens: 384_000,
+		} satisfies ModelSpec<"openai-responses">);
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const strictFlags: unknown[][] = [];
+		let attempt = 0;
+		const fetchMock: FetchImpl = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+				attempt += 1;
+				const bodyText = typeof init?.body === "string" ? init.body : "";
+				const tools = toRecord(JSON.parse(bodyText)).tools;
+				strictFlags.push(Array.isArray(tools) ? tools.map(tool => toRecord(tool).strict) : []);
+				if (attempt === 1) {
+					return new Response(JSON.stringify({ error: { message: "Provider returned error", code: 400 } }), {
+						status: 400,
+						headers: { "content-type": "application/json" },
+					});
+				}
+				return createResponsesTextSseResponse(attempt === 2 ? "Recovered" : "Later");
+			},
+			{ preconnect: fetch.preconnect },
+		);
+		const context: Context = { ...testContext, tools: [testTool] };
+
+		const result = await streamOpenAIResponses(model, context, {
+			apiKey: "test-key",
+			providerSessionState,
+			fetch: fetchMock,
+		}).result();
+		expect(result.stopReason).toBe("stop");
+		expect(result.errorMessage).toBeUndefined();
+
+		const nextResult = await streamOpenAIResponses(model, context, {
+			apiKey: "test-key",
+			providerSessionState,
+			fetch: fetchMock,
+		}).result();
+		expect(nextResult.stopReason).toBe("stop");
+		expect(strictFlags).toEqual([[true], [undefined], [undefined]]);
 	});
 
 	it("sends strict=true for openai-responses tool schemas on OpenAI", async () => {


### PR DESCRIPTION
## Repro

A status-400 OpenRouter error whose message is only `Provider returned error` bypassed the existing strict-tool fallback even when a strict `yield` tool was applied. Running `bun -e 'import { shouldRetryWithoutStrictTools } from "./packages/ai/src/providers/openai-shared.ts"; const error = Object.assign(new Error("400 Provider returned error"), { status: 400 }); console.log(shouldRetryWithoutStrictTools(error, undefined, true, [{ name: "yield", description: "Submit result", strict: true, parameters: { type: "object" } }]));'` on the previous code printed `false`.

## Cause

`packages/coding-agent/src/tools/yield.ts` marks representable structured yield schemas strict, but `shouldRetryWithoutStrictTools` in `packages/ai/src/providers/openai-shared.ts` recognized only descriptive schema-rejection messages. OpenRouter masks the DeepSeek upstream rejection as the opaque `400 Provider returned error`, so both `streamOpenAICompletions` and `streamOpenAIResponses` rethrew before their bounded non-strict fallback could run.

## Fix

- Scope opaque `Provider returned error` recognition to OpenRouter requests that actually carried strict tools.
- Pass model context into the shared retry predicate from completions and Responses, preserving the existing one-retry and provider-session sticky fallback.
- Cover descriptive and opaque completion failures plus opaque Responses failures, including later requests that skip the rejected strict schema.
- Record the fix in the AI changelog.

## Verification

`bun test packages/ai/test/openai-tool-strict-mode.test.ts` passed 24 tests; `bun run --filter @oh-my-pi/pi-ai check` passed; the focused predicate smoke command prints `true` after the fix. `bun check` fails identically on this branch and a detached clean `origin/main` worktree because `cmake` is unavailable while building `audiopus_sys`; the pre-publish gate was skipped for that unrelated environment failure.

Fixes #7264