### PR TITLE
fix(session): fence appends during session moves

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed concurrent session appends during `/move` recreating an orphaned `.jsonl` fragment in the old session directory ([#7270](https://github.com/can1357/oh-my-pi/issues/7270)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -479,10 +479,12 @@ export class SessionManager {
 	#atomicRewriteDirty = false;
 	/**
 	 * True while {@link moveTo} is renaming the session file but has not yet
-	 * repointed `#sessionFile`. A synchronous rewrite (`flushSync` on Ctrl+C)
-	 * during this window would `writeTextSync` the full body to the pre-rename
-	 * path, recreating the very orphan the move fence prevents. Sync rewrites
-	 * defer while this is set; the move's trailing atomic rewrite persists them.
+	 * repointed `#sessionFile`. Both the synchronous append hot path
+	 * ({@link #appendToSessionFile}) and synchronous rewrites
+	 * ({@link #rewriteSynchronously}, reached via `flushSync` on Ctrl+C) would
+	 * otherwise touch the pre-rename path — opening a fresh writer or writing the
+	 * full body — recreating the very orphan the move eliminates. Both defer
+	 * while this is set; the move's trailing atomic rewrite persists them.
 	 */
 	#sessionFileRelocating = false;
 	/** Atomic entry batch currently staged for a full-file commit. */
@@ -863,13 +865,18 @@ export class SessionManager {
 		}
 
 		// Atomic replacement window: the old path may be moved aside underneath
-		// any newly-opened append handle (Windows EPERM fallback). Do not open a
-		// writer here; the active rewrite loops and serializes a fresh full body.
+		// any newly-opened append handle (Windows EPERM fallback), or a `moveTo`
+		// may be renaming the session file to a new directory. Do not open a
+		// writer here; the active rewrite loops and serializes a fresh full body,
+		// and the move's trailing atomic rewrite folds in these deferred entries.
 		// A superseding synchronous rewrite bumps `#diskEpoch`, at which point
 		// the pending atomic publish is guaranteed to abandon via its
 		// `commitGuard`, so appends can (and must) take the hot path so they
 		// don't strand in memory while `close()` returns without a rewrite.
-		if (this.#atomicRewriteFenceEpoch !== null && this.#atomicRewriteFenceEpoch === this.#diskEpoch) {
+		if (
+			this.#sessionFileRelocating ||
+			(this.#atomicRewriteFenceEpoch !== null && this.#atomicRewriteFenceEpoch === this.#diskEpoch)
+		) {
 			this.#fileIsCurrent = false;
 			this.#rewriteRequired = true;
 			this.#atomicRewriteDirty = true;
@@ -1337,12 +1344,13 @@ export class SessionManager {
 				: computeDefaultSessionDir(resolvedCwd, this.#storage));
 
 		let sessionFileExisted = false;
-		let moveFenceEpoch: number | undefined;
-		// Prevent synchronous appends and rewrites from touching the old path while
-		// the rename is in flight (see `#sessionFileRelocating`).
+		// Fence synchronous appends and rewrites away from the session file for the
+		// duration of the relocation (see `#sessionFileRelocating`). This flag —
+		// not a `#diskEpoch` bump — is used deliberately: bumping the epoch here
+		// would cancel any disk task already queued at the current epoch (e.g. a
+		// header-only `ensureOnDisk()` materializing rewrite) before the drain
+		// below runs it, silently dropping an explicitly materialized session.
 		if (this.#persist && this.#sessionFile) {
-			moveFenceEpoch = ++this.#diskEpoch;
-			this.#atomicRewriteFenceEpoch = moveFenceEpoch;
 			this.#sessionFileRelocating = true;
 		}
 
@@ -1434,10 +1442,6 @@ export class SessionManager {
 			if (this.#sessionFile) this.#rememberBreadcrumb(resolvedCwd, this.#sessionFile);
 		} finally {
 			this.#sessionFileRelocating = false;
-			// Rewrites release this fence themselves; lazy and failed moves release it here.
-			if (moveFenceEpoch !== undefined && this.#atomicRewriteFenceEpoch === moveFenceEpoch) {
-				this.#atomicRewriteFenceEpoch = null;
-			}
 		}
 	}
 

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -405,11 +405,11 @@ export class SessionPersistenceIndeterminateError extends AggregateError {
  * tree by `(id, parentId)`, and the mutable leaf pointer selects which path is
  * active for future appends and for LLM context construction.
  *
- * Durability is software-crash safe but not power-loss safe: appends are handed
- * to the OS synchronously in-body (so an entry survives an OOM/SIGKILL the
- * instant `appendMessage` returns) but never `fsync`'d. Full-file rewrites go
- * through the storage layer's atomic temp-write+rename so a crash mid-rewrite
- * cannot truncate the prior good file.
+ * Durability is software-crash safe but not power-loss safe: appends are normally
+ * handed to the OS synchronously in-body but never `fsync`'d. During an atomic
+ * move or rewrite, synchronous appends are fenced in memory and folded into the
+ * full-file rewrite before the operation resolves, so the replaced file cannot
+ * detach their writer.
  */
 export class SessionManager {
 	#cwd: string;
@@ -1325,90 +1325,103 @@ export class SessionManager {
 				: computeDefaultSessionDir(resolvedCwd, this.#storage));
 
 		let sessionFileExisted = false;
-
+		let moveFenceEpoch: number | undefined;
+		// Prevent synchronous appends from reopening the old path while the rename is in flight.
 		if (this.#persist && this.#sessionFile) {
-			this.#storage.ensureDirSync(nextSessionDir);
-			await this.#drainAndCloseWriter();
-			this.#clearDiskError();
+			moveFenceEpoch = ++this.#diskEpoch;
+			this.#atomicRewriteFenceEpoch = moveFenceEpoch;
+		}
 
-			const oldSessionFile = this.#sessionFile;
-			const newSessionFile = path.join(nextSessionDir, path.basename(oldSessionFile));
-			const oldArtifactsDir = artifactsDirectoryFor(oldSessionFile)!;
-			const newArtifactsDir = artifactsDirectoryFor(newSessionFile)!;
-			const sessionPathChanged = path.resolve(oldSessionFile) !== path.resolve(newSessionFile);
-			const artifactPathChanged = path.resolve(oldArtifactsDir) !== path.resolve(newArtifactsDir);
-			sessionFileExisted = this.#storage.existsSync(oldSessionFile);
+		try {
+			if (this.#persist && this.#sessionFile) {
+				this.#storage.ensureDirSync(nextSessionDir);
+				await this.#drainAndCloseWriter();
+				this.#clearDiskError();
 
-			let sessionMoved = false;
-			let artifactsMoved = false;
+				const oldSessionFile = this.#sessionFile;
+				const newSessionFile = path.join(nextSessionDir, path.basename(oldSessionFile));
+				const oldArtifactsDir = artifactsDirectoryFor(oldSessionFile)!;
+				const newArtifactsDir = artifactsDirectoryFor(newSessionFile)!;
+				const sessionPathChanged = path.resolve(oldSessionFile) !== path.resolve(newSessionFile);
+				const artifactPathChanged = path.resolve(oldArtifactsDir) !== path.resolve(newArtifactsDir);
+				sessionFileExisted = this.#storage.existsSync(oldSessionFile);
 
-			try {
-				if (sessionFileExisted && sessionPathChanged) {
-					await fs.promises.rename(oldSessionFile, newSessionFile);
-					sessionMoved = true;
-				}
+				let sessionMoved = false;
+				let artifactsMoved = false;
 
-				if (artifactPathChanged) {
-					try {
-						const artifactStat = await fs.promises.stat(oldArtifactsDir);
-						if (artifactStat.isDirectory()) {
-							await fs.promises.rename(oldArtifactsDir, newArtifactsDir);
-							artifactsMoved = true;
+				try {
+					if (sessionFileExisted && sessionPathChanged) {
+						await fs.promises.rename(oldSessionFile, newSessionFile);
+						sessionMoved = true;
+					}
+
+					if (artifactPathChanged) {
+						try {
+							const artifactStat = await fs.promises.stat(oldArtifactsDir);
+							if (artifactStat.isDirectory()) {
+								await fs.promises.rename(oldArtifactsDir, newArtifactsDir);
+								artifactsMoved = true;
+							}
+						} catch (err) {
+							if (!isEnoent(err)) throw err;
 						}
-					} catch (err) {
-						if (!isEnoent(err)) throw err;
 					}
-				}
-			} catch (err) {
-				if (artifactsMoved) {
-					try {
-						await fs.promises.rename(newArtifactsDir, oldArtifactsDir);
-					} catch (rollbackErr) {
-						throw new Error(
-							`Failed to move artifacts and rollback: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
-						);
+				} catch (err) {
+					if (artifactsMoved) {
+						try {
+							await fs.promises.rename(newArtifactsDir, oldArtifactsDir);
+						} catch (rollbackErr) {
+							throw new Error(
+								`Failed to move artifacts and rollback: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
+							);
+						}
 					}
+
+					if (sessionMoved) {
+						try {
+							await fs.promises.rename(newSessionFile, oldSessionFile);
+						} catch (rollbackErr) {
+							throw new Error(
+								`Failed to move session file and rollback: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
+							);
+						}
+					}
+
+					throw err;
 				}
 
-				if (sessionMoved) {
-					try {
-						await fs.promises.rename(newSessionFile, oldSessionFile);
-					} catch (rollbackErr) {
-						throw new Error(
-							`Failed to move session file and rollback: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
-						);
-					}
-				}
-
-				throw err;
+				this.#sessionFile = newSessionFile;
+				this.#artifactManager = null;
+				this.#artifactManagerSessionFile = null;
 			}
 
-			this.#sessionFile = newSessionFile;
-			this.#artifactManager = null;
-			this.#artifactManagerSessionFile = null;
-		}
+			this.#cwd = resolvedCwd;
+			this.#sessionDir = nextSessionDir;
+			this.#header.cwd = resolvedCwd;
+			// Re-filter additional roots: the new cwd may have been an additional root,
+			// or it may now contain/subsume one. Re-normalize to keep the invariant
+			// that cwd is never also listed as an additional directory.
+			if (this.#additionalDirectories.length > 0) {
+				this.#additionalDirectories = this.#additionalDirectories.filter(d => d !== resolvedCwd);
+				this.#header.additionalDirectories =
+					this.#additionalDirectories.length > 0 ? this.#additionalDirectories : undefined;
+			}
 
-		this.#cwd = resolvedCwd;
-		this.#sessionDir = nextSessionDir;
-		this.#header.cwd = resolvedCwd;
-		// Re-filter additional roots: the new cwd may have been an additional root,
-		// or it may now contain/subsume one. Re-normalize to keep the invariant
-		// that cwd is never also listed as an additional directory.
-		if (this.#additionalDirectories.length > 0) {
-			this.#additionalDirectories = this.#additionalDirectories.filter(d => d !== resolvedCwd);
-			this.#header.additionalDirectories =
-				this.#additionalDirectories.length > 0 ? this.#additionalDirectories : undefined;
-		}
+			// Rewrite at the new location when the file already existed (update cwd) or
+			// there is in-memory output worth materializing; otherwise stay lazy.
+			const hasAssistant = this.#historyContainsAssistantMessage();
+			if (this.#persist && this.#sessionFile && (sessionFileExisted || hasAssistant)) {
+				this.#forceFileCreation = true;
+				await this.#rewriteAtomically();
+			}
 
-		// Rewrite at the new location when the file already existed (update cwd) or
-		// there is in-memory output worth materializing; otherwise stay lazy.
-		const hasAssistant = this.#historyContainsAssistantMessage();
-		if (this.#persist && this.#sessionFile && (sessionFileExisted || hasAssistant)) {
-			this.#forceFileCreation = true;
-			await this.#rewriteAtomically();
+			if (this.#sessionFile) this.#rememberBreadcrumb(resolvedCwd, this.#sessionFile);
+		} finally {
+			// Rewrites release this fence themselves; lazy and failed moves release it here.
+			if (moveFenceEpoch !== undefined && this.#atomicRewriteFenceEpoch === moveFenceEpoch) {
+				this.#atomicRewriteFenceEpoch = null;
+			}
 		}
-
-		if (this.#sessionFile) this.#rememberBreadcrumb(resolvedCwd, this.#sessionFile);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -477,6 +477,14 @@ export class SessionManager {
 	#atomicRewriteFenceEpoch: number | null = null;
 	/** Set by synchronous appends that land while an atomic replacement is active. */
 	#atomicRewriteDirty = false;
+	/**
+	 * True while {@link moveTo} is renaming the session file but has not yet
+	 * repointed `#sessionFile`. A synchronous rewrite (`flushSync` on Ctrl+C)
+	 * during this window would `writeTextSync` the full body to the pre-rename
+	 * path, recreating the very orphan the move fence prevents. Sync rewrites
+	 * defer while this is set; the move's trailing atomic rewrite persists them.
+	 */
+	#sessionFileRelocating = false;
 	/** Atomic entry batch currently staged for a full-file commit. */
 	#atomicEntryBatch: AtomicEntryBatch | undefined;
 
@@ -754,6 +762,10 @@ export class SessionManager {
 	 */
 	#rewriteSynchronously(): void {
 		if (!this.#persist || !this.#sessionFile || !this.#shouldHaveSessionFile()) return;
+		// A move is renaming the file out from under `#sessionFile`; writing the
+		// full body now would recreate an orphan at the pre-rename path. Defer to
+		// moveTo's trailing atomic rewrite, which folds in the fenced appends.
+		if (this.#sessionFileRelocating) return;
 
 		try {
 			const body = this.#fileBody();
@@ -1326,10 +1338,12 @@ export class SessionManager {
 
 		let sessionFileExisted = false;
 		let moveFenceEpoch: number | undefined;
-		// Prevent synchronous appends from reopening the old path while the rename is in flight.
+		// Prevent synchronous appends and rewrites from touching the old path while
+		// the rename is in flight (see `#sessionFileRelocating`).
 		if (this.#persist && this.#sessionFile) {
 			moveFenceEpoch = ++this.#diskEpoch;
 			this.#atomicRewriteFenceEpoch = moveFenceEpoch;
+			this.#sessionFileRelocating = true;
 		}
 
 		try {
@@ -1393,6 +1407,8 @@ export class SessionManager {
 				this.#sessionFile = newSessionFile;
 				this.#artifactManager = null;
 				this.#artifactManagerSessionFile = null;
+				// Path is repointed; a sync rewrite may now safely target the new file.
+				this.#sessionFileRelocating = false;
 			}
 
 			this.#cwd = resolvedCwd;
@@ -1417,6 +1433,7 @@ export class SessionManager {
 
 			if (this.#sessionFile) this.#rememberBreadcrumb(resolvedCwd, this.#sessionFile);
 		} finally {
+			this.#sessionFileRelocating = false;
 			// Rewrites release this fence themselves; lazy and failed moves release it here.
 			if (moveFenceEpoch !== undefined && this.#atomicRewriteFenceEpoch === moveFenceEpoch) {
 				this.#atomicRewriteFenceEpoch = null;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -406,10 +406,16 @@ export class SessionPersistenceIndeterminateError extends AggregateError {
  * active for future appends and for LLM context construction.
  *
  * Durability is software-crash safe but not power-loss safe: appends are normally
- * handed to the OS synchronously in-body but never `fsync`'d. During an atomic
- * move or rewrite, synchronous appends are fenced in memory and folded into the
- * full-file rewrite before the operation resolves, so the replaced file cannot
- * detach their writer.
+ * handed to the OS synchronously in-body but never `fsync`'d. While an in-place
+ * atomic rewrite publishes, a synchronous `flushSync` still persists fenced
+ * appends by superseding the pending publish against the same (stable) path.
+ * A {@link moveTo} relocation is the one exception: the session file is being
+ * renamed to a new path, so appends landing in the rename window are held in
+ * memory and persisted only by the move's trailing rewrite. A `flushSync` in
+ * that narrow window cannot durably place them — writing the vacated source
+ * would recreate the orphan the move eliminates, and a queued backend publish
+ * (fire-and-forget on `IndexedSessionStorage`) could land after the rename all
+ * the same. This gap is inherent to closing the writer for a Windows-safe rename.
  */
 export class SessionManager {
 	#cwd: string;
@@ -764,9 +770,11 @@ export class SessionManager {
 	 */
 	#rewriteSynchronously(): void {
 		if (!this.#persist || !this.#sessionFile || !this.#shouldHaveSessionFile()) return;
-		// A move is renaming the file out from under `#sessionFile`; writing the
-		// full body now would recreate an orphan at the pre-rename path. Defer to
-		// moveTo's trailing atomic rewrite, which folds in the fenced appends.
+		// A move is renaming the file out from under `#sessionFile`. Writing the
+		// full body now would target either the vacated source (recreating the
+		// orphan the move eliminates) or a path a queued backend publish may clobber
+		// post-rename, so defer to moveTo's trailing atomic rewrite. This narrows
+		// flushSync durability for entries in the rename window (see class doc).
 		if (this.#sessionFileRelocating) return;
 
 		try {

--- a/packages/coding-agent/test/session-manager/move-to.test.ts
+++ b/packages/coding-agent/test/session-manager/move-to.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
@@ -241,5 +241,47 @@ describe("SessionManager.moveTo", () => {
 		const newFile = session.getSessionFile()!;
 		const newArtifactDir = newFile.slice(0, -6); // strip .jsonl
 		expect(fs.existsSync(newArtifactDir)).toBe(true);
+	});
+	it("does not orphan appends that race the session file rename", async () => {
+		const session = SessionManager.create(cwdA);
+		session.appendMessage({ role: "user", content: "before move", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage());
+		await session.flush();
+
+		const oldFile = session.getSessionFile();
+		if (!oldFile) throw new Error("Expected session file");
+
+		const renameFinished = Promise.withResolvers<void>();
+		const allowMoveToResume = Promise.withResolvers<void>();
+		const rename = fs.promises.rename.bind(fs.promises);
+		const renameSpy = spyOn(fs.promises, "rename").mockImplementation(async (source, target) => {
+			await rename(source, target);
+			if (path.resolve(source.toString()) !== path.resolve(oldFile)) return;
+			renameFinished.resolve();
+			await allowMoveToResume.promise;
+		});
+
+		try {
+			const move = session.moveTo(cwdB);
+			await renameFinished.promise;
+			session.appendMessage({ role: "user", content: "during move", timestamp: 2 });
+			allowMoveToResume.resolve();
+			await move;
+			await session.flush();
+		} finally {
+			allowMoveToResume.resolve();
+			renameSpy.mockRestore();
+		}
+
+		expect(fs.existsSync(oldFile)).toBe(false);
+		const movedFile = session.getSessionFile();
+		if (!movedFile) throw new Error("Expected moved session file");
+		const entries = await loadEntriesFromFile(movedFile);
+		expect(
+			entries.some(
+				entry =>
+					entry.type === "message" && entry.message.role === "user" && entry.message.content === "during move",
+			),
+		).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/session-manager/move-to.test.ts
+++ b/packages/coding-agent/test/session-manager/move-to.test.ts
@@ -284,4 +284,50 @@ describe("SessionManager.moveTo", () => {
 			),
 		).toBe(true);
 	});
+
+	it("does not orphan a flushSync that races the session file rename", async () => {
+		const session = SessionManager.create(cwdA);
+		session.appendMessage({ role: "user", content: "before move", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage());
+		await session.flush();
+
+		const oldFile = session.getSessionFile();
+		if (!oldFile) throw new Error("Expected session file");
+
+		const renameFinished = Promise.withResolvers<void>();
+		const allowMoveToResume = Promise.withResolvers<void>();
+		const rename = fs.promises.rename.bind(fs.promises);
+		const renameSpy = spyOn(fs.promises, "rename").mockImplementation(async (source, target) => {
+			await rename(source, target);
+			if (path.resolve(source.toString()) !== path.resolve(oldFile)) return;
+			renameFinished.resolve();
+			await allowMoveToResume.promise;
+		});
+
+		try {
+			const move = session.moveTo(cwdB);
+			await renameFinished.promise;
+			// A fenced append followed by a Ctrl+C flushSync in the post-rename,
+			// pre-repoint window must not recreate the old JSONL path.
+			session.appendMessage({ role: "user", content: "during move", timestamp: 2 });
+			session.flushSync();
+			allowMoveToResume.resolve();
+			await move;
+			await session.flush();
+		} finally {
+			allowMoveToResume.resolve();
+			renameSpy.mockRestore();
+		}
+
+		expect(fs.existsSync(oldFile)).toBe(false);
+		const movedFile = session.getSessionFile();
+		if (!movedFile) throw new Error("Expected moved session file");
+		const entries = await loadEntriesFromFile(movedFile);
+		expect(
+			entries.some(
+				entry =>
+					entry.type === "message" && entry.message.role === "user" && entry.message.content === "during move",
+			),
+		).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/session-manager/move-to.test.ts
+++ b/packages/coding-agent/test/session-manager/move-to.test.ts
@@ -330,4 +330,23 @@ describe("SessionManager.moveTo", () => {
 			),
 		).toBe(true);
 	});
+
+	it("materializes an ensureOnDisk session when moveTo races the queued rewrite", async () => {
+		// A header-only session (ACP session/new, drafts) forces creation via
+		// ensureOnDisk(), which schedules its materializing rewrite on the disk
+		// chain. Starting moveTo() before that task runs must not cancel it, or
+		// the explicitly materialized session is lost and never discoverable.
+		const session = SessionManager.create(cwdA);
+		const ensure = session.ensureOnDisk();
+		await session.moveTo(cwdB);
+		await ensure;
+		await session.flush();
+
+		const movedFile = session.getSessionFile();
+		if (!movedFile) throw new Error("Expected moved session file");
+		expect(fs.existsSync(movedFile)).toBe(true);
+
+		const targetSessions = await SessionManager.list(cwdB);
+		expect(targetSessions.some(item => item.path === movedFile)).toBe(true);
+	});
 });


### PR DESCRIPTION
## Repro
A deterministic `fs.promises.rename` gate lets the real source-to-target rename finish, appends a sibling user message before `SessionManager.moveTo()` resumes, then checks the vacated path. On unpatched `main`, `bun test packages/coding-agent/test/session-manager/move-to.test.ts` failed with 14 pass / 1 fail because the old `.jsonl` path existed again.

## Cause
`packages/coding-agent/src/session/session-manager.ts` closed and renamed the journal before updating `#sessionFile`; synchronous `#appendToSessionFile()` calls in that interval reopened the old path with append/create flags. The trailing atomic rewrite preserved in-memory history at the destination but did not remove the orphan fragment.

## Fix
- Claim the existing disk-epoch append fence before `moveTo()` begins asynchronous relocation and retain ownership through repointing and the trailing rewrite.
- Release the fence on lazy, failed, or superseded moves without clearing a newer fence owner.
- Add a real-filesystem race regression covering both absence of the old fragment and persistence of the concurrent message.
- Document fenced-append durability and record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/session-manager/move-to.test.ts packages/coding-agent/test/session-manager-atomic-rewrite-race.test.ts` passes: 27 tests, 0 failures. `bun run check:ts` passes across the workspace. Full `bun check` cannot complete because `audiopus_sys` requires an unavailable `cmake` executable; `bun run check:rs` fails identically on a clean `origin/main` checkout, so the pre-publish gate was skipped.

Fixes #7270