### PR TITLE
feat(coding-agent): add session tree branch map

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Fixed Branch Map rendering for deep or large session trees and terminals with limited height. Maps now avoid recursive traversal and full-size canvas allocation, fall back to the list when more than 5,000 visible entries remain, and compact the selector chrome to preserve the active content.
+- Fixed Branch Map scroll indicators obscuring selected nodes on short terminals, and made narrow terminals cycle only through their visible list and map views.
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a top-down Branch Map to `/tree` and `/branch` navigation. Wide terminals show compact numbered role labels beside the session entry list, while the standalone map shows message summaries; both views share one filter projection, the active filter is highlighted with an explanation, `Ctrl+G` cycles between list, map, and split views, and `Shift+Left`/`Shift+Right` cycle sibling branches before Enter confirms navigation.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Kept active `/tree` search queries visible in the standalone Branch Map view.
 - Fixed Branch Map rendering for deep or large session trees and terminals with limited height. Maps now avoid recursive traversal and full-size canvas allocation, fall back to the list when more than 5,000 visible entries remain, and compact the selector chrome to preserve the active content.
 - Fixed Branch Map scroll indicators obscuring selected nodes on short terminals, and made narrow terminals cycle only through their visible list and map views.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added a top-down Branch Map to `/tree` and `/branch` navigation. Wide terminals show compact numbered role labels beside the session entry list, while the standalone map shows message summaries; both views share one filter projection, the active filter is highlighted with an explanation, `Ctrl+G` cycles between list, map, and split views, and `Shift+Left`/`Shift+Right` cycle sibling branches before Enter confirms navigation.
 
+### Fixed
+
+- Fixed Branch Map rendering for deep or large session trees and terminals with limited height. Maps now avoid recursive traversal and full-size canvas allocation, fall back to the list when more than 5,000 visible entries remain, and compact the selector chrome to preserve the active content.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added a top-down Branch Map to `/tree` and `/branch` navigation. Wide terminals show compact numbered role labels beside the session entry list, while the standalone map shows message summaries; both views share one filter projection, the active filter is highlighted with an explanation, `Ctrl+G` cycles between list, map, and split views, and `Shift+Left`/`Shift+Right` cycle sibling branches before Enter confirms navigation.
 
+### Changed
+
+- Highlighted `/tree` shortcut keys separately from their descriptions to make navigation hints easier to scan.
+
 ### Fixed
 
 - Fixed Branch Map rendering for deep or large session trees and terminals with limited height. Maps now avoid recursive traversal and full-size canvas allocation, fall back to the list when more than 5,000 visible entries remain, and compact the selector chrome to preserve the active content.

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -21,6 +21,7 @@ import { DynamicBorder } from "./dynamic-border";
 import { centeredWindow, contentRowWidth, renderScrollableList } from "./selector-helpers";
 
 const MIN_SPLIT_WIDTH = 100;
+const MAX_BRANCH_MAP_NODES = 5_000;
 
 type TreeViewMode = "list" | "map" | "split";
 
@@ -68,6 +69,7 @@ class TreeList implements Component {
 	#multipleRoots = false;
 	#activePathIds: Set<string> = new Set();
 	#lastSelectedId: string | null = null;
+	#visibleTree: SessionTreeNode[] | undefined;
 
 	onSelect?: (entryId: string, options: { summarize: boolean }) => void;
 	onCancel?: () => void;
@@ -76,7 +78,7 @@ class TreeList implements Component {
 	constructor(
 		tree: SessionTreeNode[],
 		private readonly currentLeafId: string | null,
-		private readonly maxVisibleLines: number,
+		private maxVisibleLines: number,
 		initialFilterMode: FilterMode = "default",
 		initialSelectedId?: string,
 	) {
@@ -280,6 +282,7 @@ class TreeList implements Component {
 		if (this.#filteredNodes.length > 0) {
 			this.#lastSelectedId = this.#filteredNodes[this.#selectedIndex]?.node.entry.id ?? this.#lastSelectedId;
 		}
+		this.#visibleTree = undefined;
 
 		const searchTokens = this.#searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
 
@@ -424,19 +427,42 @@ class TreeList implements Component {
 		return this.#filterMode;
 	}
 
+	getVisibleNodeCount(): number {
+		return this.#filteredNodes.length;
+	}
+
+	setMaxVisibleLines(maxVisibleLines: number): void {
+		this.maxVisibleLines = Math.max(1, maxVisibleLines);
+	}
+
 	getVisibleCurrentLeafId(): string | null {
 		if (this.#filteredNodes.length === 0) return null;
 		return this.#filteredNodes[this.#findNearestVisibleIndex(this.currentLeafId)]?.node.entry.id ?? null;
 	}
 
 	getVisibleTree(): SessionTreeNode[] {
+		if (this.#visibleTree) return this.#visibleTree;
+
 		const visibleIds = new Set(this.#filteredNodes.map(node => node.node.entry.id));
-		const project = (node: SessionTreeNode): SessionTreeNode[] => {
-			const children = node.children.flatMap(project);
-			if (!visibleIds.has(node.entry.id)) return children;
-			return [{ ...node, children }];
-		};
-		return this.#roots.flatMap(project);
+		const roots: SessionTreeNode[] = [];
+		type ProjectionItem = { node: SessionTreeNode; destination: SessionTreeNode[] };
+		const stack: ProjectionItem[] = [];
+		for (let index = this.#roots.length - 1; index >= 0; index--) {
+			stack.push({ node: this.#roots[index]!, destination: roots });
+		}
+		while (stack.length > 0) {
+			const { node, destination } = stack.pop()!;
+			const children: SessionTreeNode[] = [];
+			const visible = visibleIds.has(node.entry.id);
+			if (visible) destination.push({ ...node, children });
+			const childDestination = visible ? children : destination;
+			for (let index = node.children.length - 1; index >= 0; index--) {
+				stack.push({ node: node.children[index]!, destination: childDestination });
+			}
+		}
+
+		this.#visibleTree = roots;
+		return roots;
 	}
 
 	updateNodeLabel(entryId: string, label: string | undefined): void {
@@ -446,6 +472,7 @@ class TreeList implements Component {
 				break;
 			}
 		}
+		this.#visibleTree = undefined;
 	}
 
 	#selectFirstVisibleInSubtree(root: SessionTreeNode): boolean {
@@ -1007,105 +1034,179 @@ interface BranchMapNode {
 	width: number;
 }
 
+interface BranchMapLayout {
+	tree: SessionTreeNode[];
+	nodeWidth: number;
+	roots: BranchMapNode[];
+	nodes: BranchMapNode[];
+	nodesById: Map<string, BranchMapNode>;
+	nodesByY: Map<number, BranchMapNode[]>;
+	width: number;
+	height: number;
+}
+
 /**
  * A top-down tree view. Nodes remain visible instead of collapsing linear
  * runs, so the drawing retains the familiar trunk-and-branches shape.
  */
 class BranchMap implements Component {
+	#layoutCache: BranchMapLayout | undefined;
+	#maxVisibleLines: number;
+
 	constructor(
 		private readonly getVisibleTree: () => SessionTreeNode[],
 		private readonly getVisibleCurrentLeafId: () => string | null,
 		private readonly getSelectedId: () => string | null,
-		private readonly maxVisibleLines: number,
-	) {}
-
-	invalidate(): void {}
-
-	#toMapNodes(): BranchMapNode[] {
-		let number = 1;
-		const create = (node: SessionTreeNode): BranchMapNode => ({
-			node,
-			number: number++,
-			children: node.children.map(create),
-			x: 0,
-			y: 0,
-			width: 0,
-		});
-		return this.getVisibleTree().map(create);
+		maxVisibleLines: number,
+	) {
+		this.#maxVisibleLines = maxVisibleLines;
 	}
 
-	#layout(nodes: BranchMapNode[], nodeWidth: number): { width: number; height: number } {
+	invalidate(): void {
+		this.#layoutCache = undefined;
+	}
+
+	setMaxVisibleLines(maxVisibleLines: number): void {
+		this.#maxVisibleLines = Math.max(1, maxVisibleLines);
+	}
+
+	#getLayout(nodeWidth: number): BranchMapLayout {
+		const tree = this.getVisibleTree();
+		if (this.#layoutCache?.tree === tree && this.#layoutCache.nodeWidth === nodeWidth) return this.#layoutCache;
+
+		let number = 1;
+		const roots: BranchMapNode[] = [];
+		const nodes: BranchMapNode[] = [];
+		const nodesById = new Map<string, BranchMapNode>();
+		type BuildItem = { node: SessionTreeNode; destination: BranchMapNode[] };
+		const buildStack: BuildItem[] = [];
+		for (let index = tree.length - 1; index >= 0; index--) {
+			buildStack.push({ node: tree[index]!, destination: roots });
+		}
+		while (buildStack.length > 0) {
+			const { node, destination } = buildStack.pop()!;
+			const mapNode: BranchMapNode = { node, number: number++, children: [], x: 0, y: 0, width: 0 };
+			destination.push(mapNode);
+			nodes.push(mapNode);
+			nodesById.set(node.entry.id, mapNode);
+			for (let index = node.children.length - 1; index >= 0; index--) {
+				buildStack.push({ node: node.children[index]!, destination: mapNode.children });
+			}
+		}
+
 		const siblingGap = 4;
+		type MeasureItem = { node: BranchMapNode; measured: boolean };
+		const measureStack: MeasureItem[] = roots.map(node => ({ node, measured: false }));
+		while (measureStack.length > 0) {
+			const item = measureStack.pop()!;
+			if (item.measured) {
+				const childrenWidth = item.node.children.reduce(
+					(total, child, index) => total + child.width + (index > 0 ? siblingGap : 0),
+					0,
+				);
+				item.node.width = Math.max(nodeWidth, childrenWidth);
+				continue;
+			}
+			measureStack.push({ node: item.node, measured: true });
+			for (const child of item.node.children) measureStack.push({ node: child, measured: false });
+		}
+
+		const width = roots.reduce((total, node, index) => total + node.width + (index > 0 ? siblingGap : 0), 0);
+		let left = 0;
 		let maxY = 0;
-		const measure = (node: BranchMapNode): number => {
-			const childrenWidth = node.children.reduce((total, child, index) => {
-				return total + measure(child) + (index > 0 ? siblingGap : 0);
-			}, 0);
-			node.width = Math.max(nodeWidth, childrenWidth);
-			return node.width;
-		};
-		const position = (node: BranchMapNode, left: number, depth: number): void => {
-			node.x = left + Math.floor(node.width / 2);
-			node.y = depth * 4;
+		type PositionItem = { node: BranchMapNode; left: number; depth: number };
+		const positionStack: PositionItem[] = [];
+		const rootPositions: PositionItem[] = [];
+		for (const node of roots) {
+			rootPositions.push({ node, left, depth: 0 });
+			left += node.width + siblingGap;
+		}
+		for (let index = rootPositions.length - 1; index >= 0; index--) positionStack.push(rootPositions[index]!);
+		while (positionStack.length > 0) {
+			const item = positionStack.pop()!;
+			const { node } = item;
+			node.x = item.left + Math.floor(node.width / 2);
+			node.y = item.depth * 4;
 			maxY = Math.max(maxY, node.y);
 			const childrenWidth = node.children.reduce(
 				(total, child, index) => total + child.width + (index > 0 ? siblingGap : 0),
 				0,
 			);
-			let childLeft = left + Math.floor((node.width - childrenWidth) / 2);
+			let childLeft = item.left + Math.floor((node.width - childrenWidth) / 2);
+			const childPositions: PositionItem[] = [];
 			for (const child of node.children) {
-				position(child, childLeft, depth + 1);
+				childPositions.push({ node: child, left: childLeft, depth: item.depth + 1 });
 				childLeft += child.width + siblingGap;
 			}
-		};
-
-		const width = nodes.reduce((total, node, index) => total + measure(node) + (index > 0 ? siblingGap : 0), 0);
-		let left = 0;
-		for (const node of nodes) {
-			position(node, left, 0);
-			left += node.width + siblingGap;
+			for (let index = childPositions.length - 1; index >= 0; index--) positionStack.push(childPositions[index]!);
 		}
-		return { width, height: maxY + 1 };
+
+		const nodesByY = new Map<number, BranchMapNode[]>();
+		for (const node of nodes) {
+			const row = nodesByY.get(node.y);
+			if (row) row.push(node);
+			else nodesByY.set(node.y, [node]);
+		}
+		for (const row of nodesByY.values()) row.sort((a, b) => a.x - b.x);
+
+		const layout = { tree, nodeWidth, roots, nodes, nodesById, nodesByY, width, height: maxY + 1 };
+		this.#layoutCache = layout;
+		return layout;
 	}
 
 	render(width: number, showSummaries = true): readonly string[] {
 		const nodeWidth = showSummaries ? Math.max(18, Math.min(30, width - 4)) : Math.max(11, Math.min(14, width - 4));
-		const mapRoots = this.#toMapNodes();
-		const { width: mapWidth, height } = this.#layout(mapRoots, nodeWidth);
+		const layout = this.#getLayout(nodeWidth);
+		const { width: mapWidth, height } = layout;
+		const selectedId = this.getSelectedId();
+		const selected = selectedId ? layout.nodesById.get(selectedId) : undefined;
+		const graphWidth = Math.max(1, width - 2);
+		const selectedLeft = selected ? selected.x - Math.floor(nodeWidth / 2) : 0;
+		const startX = Math.max(0, Math.min(selectedLeft - 2, mapWidth - graphWidth));
+		const endX = Math.min(mapWidth, startX + graphWidth);
+		const visibleRows = Math.max(1, this.#maxVisibleLines - 1);
+		const startY = Math.max(0, Math.min((selected?.y ?? 0) - Math.floor(visibleRows / 2), height - visibleRows));
+		const endY = Math.min(height, startY + visibleRows);
 		const north = 1;
 		const east = 2;
 		const south = 4;
 		const west = 8;
-		const canvas = Array.from({ length: height }, () => Array.from({ length: mapWidth }, () => 0));
+		const canvas = Array.from({ length: Math.max(0, endY - startY) }, () =>
+			Array.from({ length: graphWidth }, () => 0),
+		);
 		const connect = (x: number, y: number, dx: number, dy: number): void => {
 			const nextX = x + dx;
 			const nextY = y + dy;
 			if (
-				x < 0 ||
-				x >= mapWidth ||
-				y < 0 ||
-				y >= height ||
-				nextX < 0 ||
-				nextX >= mapWidth ||
-				nextY < 0 ||
-				nextY >= height
+				x < startX ||
+				x >= endX ||
+				y < startY ||
+				y >= endY ||
+				nextX < startX ||
+				nextX >= endX ||
+				nextY < startY ||
+				nextY >= endY
 			)
 				return;
 			if (dx === 0 && dy === 1) {
-				canvas[y]![x]! |= south;
-				canvas[nextY]![nextX]! |= north;
+				canvas[y - startY]![x - startX]! |= south;
+				canvas[nextY - startY]![nextX - startX]! |= north;
 			} else if (dx === 1 && dy === 0) {
-				canvas[y]![x]! |= east;
-				canvas[nextY]![nextX]! |= west;
+				canvas[y - startY]![x - startX]! |= east;
+				canvas[nextY - startY]![nextX - startX]! |= west;
 			}
 		};
 		const vertical = (x: number, from: number, to: number): void => {
-			for (let y = from; y < to; y++) connect(x, y, 0, 1);
+			if (x < startX || x >= endX) return;
+			for (let y = Math.max(from, startY); y < Math.min(to, endY); y++) connect(x, y, 0, 1);
 		};
 		const horizontal = (from: number, to: number, y: number): void => {
-			for (let x = from; x < to; x++) connect(x, y, 1, 0);
+			if (y < startY || y >= endY) return;
+			for (let x = Math.max(from, startX); x < Math.min(to, endX); x++) connect(x, y, 1, 0);
 		};
-		const drawBranches = (node: BranchMapNode): void => {
+		const drawStack = [...layout.roots];
+		while (drawStack.length > 0) {
+			const node = drawStack.pop()!;
 			if (node.children.length === 1) {
 				vertical(node.x, node.y + 1, node.children[0]!.y);
 			} else if (node.children.length > 1) {
@@ -1114,26 +1215,13 @@ class BranchMap implements Component {
 				horizontal(node.children[0]!.x, node.children[node.children.length - 1]!.x, branchY);
 				for (const child of node.children) vertical(child.x, branchY, child.y);
 			}
-			for (const child of node.children) drawBranches(child);
-		};
-		for (const root of mapRoots) drawBranches(root);
+			for (let index = node.children.length - 1; index >= 0; index--) drawStack.push(node.children[index]!);
+		}
 
-		const selectedId = this.getSelectedId();
-		const allNodes = mapRoots.flatMap(root => this.#flatten(root));
-		const selected = allNodes.find(node => node.node.entry.id === selectedId);
-		const graphWidth = Math.max(1, width - 2);
-		const selectedLeft = selected ? selected.x - Math.floor(nodeWidth / 2) : 0;
-		const startX = Math.max(0, Math.min(selectedLeft - 2, mapWidth - graphWidth));
-		const endX = Math.min(mapWidth, startX + graphWidth);
-		const visibleRows = Math.max(1, this.maxVisibleLines - 2);
-		const startY = Math.max(0, Math.min((selected?.y ?? 0) - Math.floor(visibleRows / 2), height - visibleRows));
-		const endY = Math.min(height, startY + visibleRows);
 		const lines: string[] = [];
 		for (let y = startY; y < endY; y++) {
-			const row = canvas[y]!.slice(startX, endX)
-				.map(cell => this.#connector(cell))
-				.join("");
-			const rowNodes = allNodes
+			const row = canvas[y - startY]!.map(cell => this.#connector(cell)).join("");
+			const rowNodes = (layout.nodesByY.get(y) ?? [])
 				.filter(
 					node =>
 						node.y === y &&
@@ -1159,10 +1247,6 @@ class BranchMap implements Component {
 		if (endY < height && lines.length > 0) lines[lines.length - 1] = theme.fg("muted", "  … ↓");
 		lines.push(truncateToWidth(theme.fg("muted", "  › selected  • current session"), width));
 		return lines;
-	}
-
-	#flatten(node: BranchMapNode): BranchMapNode[] {
-		return [node, ...node.children.flatMap(child => this.#flatten(child))];
 	}
 
 	#connector(cell: number): string {
@@ -1267,8 +1351,9 @@ export class TreeSelectorComponent implements Component {
 		onCancel: () => void,
 		private readonly onLabelChangeCallback?: (entryId: string, label: string | undefined) => void,
 		initialFilterMode: FilterMode = "default",
+		private readonly getTerminalRows: () => number = () => terminalHeight,
 	) {
-		const maxVisibleLines = Math.max(5, Math.floor(terminalHeight / 2));
+		const maxVisibleLines = Math.max(1, terminalHeight);
 
 		this.#treeList = new TreeList(tree, currentLeafId, maxVisibleLines, initialFilterMode);
 		this.#treeList.onSelect = onSelect;
@@ -1308,6 +1393,7 @@ export class TreeSelectorComponent implements Component {
 	}
 
 	render(width: number): readonly string[] {
+		const terminalRows = Math.max(1, this.getTerminalRows());
 		const lines: string[] = [""];
 		const border = this.#border.render(width)[0]!;
 		lines.push(border);
@@ -1315,9 +1401,15 @@ export class TreeSelectorComponent implements Component {
 			lines.push(truncateToWidth(theme.bold("  Session Tree"), width));
 			lines.push(border);
 			lines.push("");
-			lines.push(...this.#labelInput.render(width));
+			const bodyRows = Math.max(1, terminalRows - 7);
+			lines.push(...this.#labelInput.render(width).slice(0, bodyRows));
 		} else {
-			const effectiveMode = this.#viewMode === "split" && width < MIN_SPLIT_WIDTH ? "list" : this.#viewMode;
+			const requestedMode = this.#viewMode === "split" && width < MIN_SPLIT_WIDTH ? "list" : this.#viewMode;
+			const visibleNodeCount = this.#treeList.getVisibleNodeCount();
+			const mapUnavailable = requestedMode !== "list" && visibleNodeCount > MAX_BRANCH_MAP_NODES;
+			const effectiveMode = mapUnavailable ? "list" : requestedMode;
+			const compactChrome = terminalRows < 24;
+			const minimalChrome = terminalRows < 16;
 			const title =
 				effectiveMode === "map"
 					? "  Branch Map"
@@ -1327,22 +1419,32 @@ export class TreeSelectorComponent implements Component {
 							)}Branch Map`
 						: "  Session Tree";
 			lines.push(truncateToWidth(theme.bold(title), width));
-			lines.push(...this.#renderFilterStatus(width));
-			lines.push(...this.#renderShortcutHelp(width));
-			if (effectiveMode !== "map") lines.push(new SearchLine(this.#treeList).render(width)[0]!);
+			const filterLines = this.#renderFilterStatus(width, compactChrome);
+			const shortcutLines = this.#renderShortcutHelp(width, compactChrome, minimalChrome);
+			const searchLines = effectiveMode !== "map" ? [new SearchLine(this.#treeList).render(width)[0]!] : [];
+			const mapLimitLines = mapUnavailable ? [this.#renderMapLimitStatus(width, visibleNodeCount)] : [];
+			const bodyRows = Math.max(
+				1,
+				terminalRows - 7 - filterLines.length - shortcutLines.length - searchLines.length - mapLimitLines.length,
+			);
+			this.#treeList.setMaxVisibleLines(bodyRows);
+			this.#branchMap.setMaxVisibleLines(bodyRows);
+			lines.push(...filterLines, ...mapLimitLines, ...shortcutLines, ...searchLines);
 			lines.push(border);
 			lines.push("");
+			let bodyLines: readonly string[];
 			if (effectiveMode === "split") {
-				lines.push(...this.#renderSplitView(width));
+				bodyLines = this.#renderSplitView(width);
 			} else if (effectiveMode === "map") {
-				lines.push(...this.#branchMap.render(width, true));
+				bodyLines = this.#branchMap.render(width, true);
 			} else {
-				lines.push(...this.#treeList.render(width));
+				bodyLines = this.#treeList.render(width);
 			}
+			lines.push(...bodyLines.slice(0, bodyRows));
 		}
 		lines.push("");
 		lines.push(border);
-		return lines;
+		return lines.slice(0, terminalRows);
 	}
 
 	#renderSplitView(width: number): readonly string[] {
@@ -1362,7 +1464,16 @@ export class TreeSelectorComponent implements Component {
 		return lines;
 	}
 
-	#renderShortcutHelp(width: number): readonly string[] {
+	#renderShortcutHelp(width: number, compact: boolean, minimal: boolean): readonly string[] {
+		if (minimal) return [];
+		if (compact) {
+			return [
+				truncateToWidth(
+					`  ${theme.fg("muted", "↑/↓ select   Enter confirm   Ctrl+G view   Ctrl+O filter")}`,
+					width,
+				),
+			];
+		}
 		const line = (section: string, text: string): string =>
 			truncateToWidth(`  ${theme.fg("accent", section.padEnd(11))}${theme.fg("muted", text)}`, width);
 		return [
@@ -1372,7 +1483,7 @@ export class TreeSelectorComponent implements Component {
 		];
 	}
 
-	#renderFilterStatus(width: number): readonly string[] {
+	#renderFilterStatus(width: number, compact: boolean): readonly string[] {
 		const mode = this.#treeList.getFilterMode();
 		const filters: Array<{ mode: FilterMode; label: string }> = [
 			{ mode: "default", label: "Default" },
@@ -1402,10 +1513,29 @@ export class TreeSelectorComponent implements Component {
 					return "content entries; labels and internal events hidden";
 			}
 		})();
+		if (compact) {
+			const active = filters.find(filter => filter.mode === mode)!;
+			return [
+				truncateToWidth(
+					`  ${theme.fg("muted", "Filter:")} ${theme.bold(theme.fg("accent", active.label))} ${theme.fg("dim", `— ${description}`)}`,
+					width,
+				),
+			];
+		}
 		return [
 			truncateToWidth(`  ${theme.fg("muted", "Filter")}  ${chips}`, width),
 			truncateToWidth(`  ${theme.fg("muted", "Showing:")} ${theme.fg("dim", description)}`, width),
 		];
+	}
+
+	#renderMapLimitStatus(width: number, visibleNodeCount: number): string {
+		return truncateToWidth(
+			theme.fg(
+				"warning",
+				`  Branch Map unavailable for ${visibleNodeCount.toLocaleString()} visible entries (limit ${MAX_BRANCH_MAP_NODES.toLocaleString()}). Search or filter to narrow the tree.`,
+			),
+			width,
+		);
 	}
 
 	#splitListWidth(width: number): number {

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -479,10 +479,10 @@ class TreeList implements Component {
 		this.#visibleTree = undefined;
 	}
 
-	#selectFirstVisibleInSubtree(root: SessionTreeNode): boolean {
-		const visibleIndices = new Map<string, number>(
-			this.#filteredNodes.map((node, index) => [node.node.entry.id, index]),
-		);
+	#selectFirstVisibleInSubtree(
+		root: SessionTreeNode,
+		visibleIndices = new Map<string, number>(this.#filteredNodes.map((node, index) => [node.node.entry.id, index])),
+	): boolean {
 		const stack = [root];
 		while (stack.length > 0) {
 			const node = stack.pop()!;
@@ -499,14 +499,25 @@ class TreeList implements Component {
 		return false;
 	}
 
+	#selectVisibleBranch(branches: SessionTreeNode[], startIndex: number, direction: -1 | 1): boolean {
+		const visibleIndices = new Map<string, number>(
+			this.#filteredNodes.map((node, index) => [node.node.entry.id, index]),
+		);
+		for (let offset = 0; offset < branches.length; offset++) {
+			const targetIndex = (startIndex + direction * offset + branches.length) % branches.length;
+			if (this.#selectFirstVisibleInSubtree(branches[targetIndex]!, visibleIndices)) return true;
+		}
+		return false;
+	}
+
 	#moveToSiblingBranch(direction: -1 | 1): void {
 		const selected = this.getSelectedNode();
 		if (!selected) return;
 
 		const nodeById = new Map<string, SessionTreeNode>(this.#flatNodes.map(node => [node.node.entry.id, node.node]));
 		if (selected.children.length > 1) {
-			const target = selected.children[direction === 1 ? 0 : selected.children.length - 1]!;
-			this.#selectFirstVisibleInSubtree(target);
+			const targetIndex = direction === 1 ? 0 : selected.children.length - 1;
+			this.#selectVisibleBranch(selected.children, targetIndex, direction);
 			return;
 		}
 
@@ -519,7 +530,7 @@ class TreeList implements Component {
 				const currentIndex = parent.children.findIndex(child => child.entry.id === branchChild.entry.id);
 				if (currentIndex === -1) return;
 				const targetIndex = (currentIndex + direction + parent.children.length) % parent.children.length;
-				this.#selectFirstVisibleInSubtree(parent.children[targetIndex]!);
+				this.#selectVisibleBranch(parent.children, targetIndex, direction);
 				return;
 			}
 			branchChild = parent;
@@ -530,7 +541,7 @@ class TreeList implements Component {
 			const currentIndex = this.#roots.findIndex(root => root.entry.id === branchChild.entry.id);
 			if (currentIndex === -1) return;
 			const targetIndex = (currentIndex + direction + this.#roots.length) % this.#roots.length;
-			this.#selectFirstVisibleInSubtree(this.#roots[targetIndex]!);
+			this.#selectVisibleBranch(this.#roots, targetIndex, direction);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -118,11 +118,10 @@ class TreeList implements Component {
 	}
 
 	/**
-	 * Find the index of the nearest visible entry, walking up the parent chain if needed.
-	 * Returns the index in filteredNodes, or the last index as fallback.
+	 * Find the index of a visible entry or ancestor, without selecting an unrelated fallback.
 	 */
-	#findNearestVisibleIndex(entryId: string | null): number {
-		if (this.#filteredNodes.length === 0) return 0;
+	#findVisibleAncestorIndex(entryId: string | null): number | null {
+		if (this.#filteredNodes.length === 0) return null;
 
 		// Build a map for parent lookup
 		const entryMap = new Map<string, FlatNode>();
@@ -143,8 +142,12 @@ class TreeList implements Component {
 			currentId = node.node.entry.parentId ?? null;
 		}
 
-		// Fallback: last visible entry
-		return this.#filteredNodes.length - 1;
+		return null;
+	}
+
+	/** Find the nearest visible entry, falling back to the last row for cursor selection. */
+	#findNearestVisibleIndex(entryId: string | null): number {
+		return this.#findVisibleAncestorIndex(entryId) ?? Math.max(0, this.#filteredNodes.length - 1);
 	}
 
 	#flattenTree(roots: SessionTreeNode[]): FlatNode[] {
@@ -437,8 +440,8 @@ class TreeList implements Component {
 	}
 
 	getVisibleCurrentLeafId(): string | null {
-		if (this.#filteredNodes.length === 0) return null;
-		return this.#filteredNodes[this.#findNearestVisibleIndex(this.currentLeafId)]?.node.entry.id ?? null;
+		const index = this.#findVisibleAncestorIndex(this.currentLeafId);
+		return index === null ? null : (this.#filteredNodes[index]?.node.entry.id ?? null);
 	}
 
 	getVisibleTree(): SessionTreeNode[] {

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -1,15 +1,13 @@
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import {
 	type Component,
-	Container,
 	extractPrintableText,
 	fuzzyMatch,
 	Input,
 	matchesKey,
-	Spacer,
-	Text,
-	TruncatedText,
+	replaceTabs,
 	truncateToWidth,
+	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import type { TreeFilterMode } from "../../config/settings-schema";
 import { theme } from "../../modes/theme/theme";
@@ -21,6 +19,10 @@ import { canonicalizeMessage } from "../../utils/thinking-display";
 import { resolveAssistantErrorPresentation } from "../utils/transcript-render-helpers";
 import { DynamicBorder } from "./dynamic-border";
 import { centeredWindow, contentRowWidth, renderScrollableList } from "./selector-helpers";
+
+const MIN_SPLIT_WIDTH = 100;
+
+type TreeViewMode = "list" | "map" | "split";
 
 /** Gutter info: position (displayIndent where connector was) and whether to show │ */
 interface GutterInfo {
@@ -56,6 +58,7 @@ interface ToolCallInfo {
 }
 
 class TreeList implements Component {
+	#roots: SessionTreeNode[];
 	#flatNodes: FlatNode[] = [];
 	#filteredNodes: FlatNode[] = [];
 	#selectedIndex = 0;
@@ -77,6 +80,7 @@ class TreeList implements Component {
 		initialFilterMode: FilterMode = "default",
 		initialSelectedId?: string,
 	) {
+		this.#roots = tree;
 		this.#filterMode = initialFilterMode;
 		this.#multipleRoots = tree.length > 1;
 		this.#flatNodes = this.#flattenTree(tree);
@@ -416,12 +420,86 @@ class TreeList implements Component {
 		return this.#filteredNodes[this.#selectedIndex]?.node;
 	}
 
+	getFilterMode(): FilterMode {
+		return this.#filterMode;
+	}
+
+	getVisibleCurrentLeafId(): string | null {
+		if (this.#filteredNodes.length === 0) return null;
+		return this.#filteredNodes[this.#findNearestVisibleIndex(this.currentLeafId)]?.node.entry.id ?? null;
+	}
+
+	getVisibleTree(): SessionTreeNode[] {
+		const visibleIds = new Set(this.#filteredNodes.map(node => node.node.entry.id));
+		const project = (node: SessionTreeNode): SessionTreeNode[] => {
+			const children = node.children.flatMap(project);
+			if (!visibleIds.has(node.entry.id)) return children;
+			return [{ ...node, children }];
+		};
+		return this.#roots.flatMap(project);
+	}
+
 	updateNodeLabel(entryId: string, label: string | undefined): void {
 		for (const flatNode of this.#flatNodes) {
 			if (flatNode.node.entry.id === entryId) {
 				flatNode.node.label = label;
 				break;
 			}
+		}
+	}
+
+	#selectFirstVisibleInSubtree(root: SessionTreeNode): boolean {
+		const visibleIndices = new Map<string, number>(
+			this.#filteredNodes.map((node, index) => [node.node.entry.id, index]),
+		);
+		const stack = [root];
+		while (stack.length > 0) {
+			const node = stack.pop()!;
+			const index = visibleIndices.get(node.entry.id);
+			if (index !== undefined) {
+				this.#selectedIndex = index;
+				this.#lastSelectedId = node.entry.id;
+				return true;
+			}
+			for (let childIndex = node.children.length - 1; childIndex >= 0; childIndex--) {
+				stack.push(node.children[childIndex]!);
+			}
+		}
+		return false;
+	}
+
+	#moveToSiblingBranch(direction: -1 | 1): void {
+		const selected = this.getSelectedNode();
+		if (!selected) return;
+
+		const nodeById = new Map<string, SessionTreeNode>(this.#flatNodes.map(node => [node.node.entry.id, node.node]));
+		if (selected.children.length > 1) {
+			const target = selected.children[direction === 1 ? 0 : selected.children.length - 1]!;
+			this.#selectFirstVisibleInSubtree(target);
+			return;
+		}
+
+		let branchChild = selected;
+		let parentId = selected.entry.parentId;
+		while (parentId) {
+			const parent = nodeById.get(parentId);
+			if (!parent) return;
+			if (parent.children.length > 1) {
+				const currentIndex = parent.children.findIndex(child => child.entry.id === branchChild.entry.id);
+				if (currentIndex === -1) return;
+				const targetIndex = (currentIndex + direction + parent.children.length) % parent.children.length;
+				this.#selectFirstVisibleInSubtree(parent.children[targetIndex]!);
+				return;
+			}
+			branchChild = parent;
+			parentId = parent.entry.parentId;
+		}
+
+		if (this.#roots.length > 1) {
+			const currentIndex = this.#roots.findIndex(root => root.entry.id === branchChild.entry.id);
+			if (currentIndex === -1) return;
+			const targetIndex = (currentIndex + direction + this.#roots.length) % this.#roots.length;
+			this.#selectFirstVisibleInSubtree(this.#roots[targetIndex]!);
 		}
 	}
 
@@ -786,6 +864,10 @@ class TreeList implements Component {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.#filteredNodes.length - 1 : this.#selectedIndex - 1;
 		} else if (matchesSelectDown(keyData)) {
 			this.#selectedIndex = this.#selectedIndex === this.#filteredNodes.length - 1 ? 0 : this.#selectedIndex + 1;
+		} else if (matchesKey(keyData, "shift+left")) {
+			this.#moveToSiblingBranch(-1);
+		} else if (matchesKey(keyData, "shift+right")) {
+			this.#moveToSiblingBranch(1);
 		} else if (matchesKey(keyData, "left")) {
 			// Page up
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - this.maxVisibleLines);
@@ -916,14 +998,266 @@ class LabelInput implements Component {
 	}
 }
 
+interface BranchMapNode {
+	node: SessionTreeNode;
+	number: number;
+	children: BranchMapNode[];
+	x: number;
+	y: number;
+	width: number;
+}
+
 /**
- * Component that renders a session tree selector for navigation
+ * A top-down tree view. Nodes remain visible instead of collapsing linear
+ * runs, so the drawing retains the familiar trunk-and-branches shape.
  */
-export class TreeSelectorComponent extends Container {
+class BranchMap implements Component {
+	constructor(
+		private readonly getVisibleTree: () => SessionTreeNode[],
+		private readonly getVisibleCurrentLeafId: () => string | null,
+		private readonly getSelectedId: () => string | null,
+		private readonly maxVisibleLines: number,
+	) {}
+
+	invalidate(): void {}
+
+	#toMapNodes(): BranchMapNode[] {
+		let number = 1;
+		const create = (node: SessionTreeNode): BranchMapNode => ({
+			node,
+			number: number++,
+			children: node.children.map(create),
+			x: 0,
+			y: 0,
+			width: 0,
+		});
+		return this.getVisibleTree().map(create);
+	}
+
+	#layout(nodes: BranchMapNode[], nodeWidth: number): { width: number; height: number } {
+		const siblingGap = 4;
+		let maxY = 0;
+		const measure = (node: BranchMapNode): number => {
+			const childrenWidth = node.children.reduce((total, child, index) => {
+				return total + measure(child) + (index > 0 ? siblingGap : 0);
+			}, 0);
+			node.width = Math.max(nodeWidth, childrenWidth);
+			return node.width;
+		};
+		const position = (node: BranchMapNode, left: number, depth: number): void => {
+			node.x = left + Math.floor(node.width / 2);
+			node.y = depth * 4;
+			maxY = Math.max(maxY, node.y);
+			const childrenWidth = node.children.reduce(
+				(total, child, index) => total + child.width + (index > 0 ? siblingGap : 0),
+				0,
+			);
+			let childLeft = left + Math.floor((node.width - childrenWidth) / 2);
+			for (const child of node.children) {
+				position(child, childLeft, depth + 1);
+				childLeft += child.width + siblingGap;
+			}
+		};
+
+		const width = nodes.reduce((total, node, index) => total + measure(node) + (index > 0 ? siblingGap : 0), 0);
+		let left = 0;
+		for (const node of nodes) {
+			position(node, left, 0);
+			left += node.width + siblingGap;
+		}
+		return { width, height: maxY + 1 };
+	}
+
+	render(width: number, showSummaries = true): readonly string[] {
+		const nodeWidth = showSummaries ? Math.max(18, Math.min(30, width - 4)) : Math.max(11, Math.min(14, width - 4));
+		const mapRoots = this.#toMapNodes();
+		const { width: mapWidth, height } = this.#layout(mapRoots, nodeWidth);
+		const north = 1;
+		const east = 2;
+		const south = 4;
+		const west = 8;
+		const canvas = Array.from({ length: height }, () => Array.from({ length: mapWidth }, () => 0));
+		const connect = (x: number, y: number, dx: number, dy: number): void => {
+			const nextX = x + dx;
+			const nextY = y + dy;
+			if (
+				x < 0 ||
+				x >= mapWidth ||
+				y < 0 ||
+				y >= height ||
+				nextX < 0 ||
+				nextX >= mapWidth ||
+				nextY < 0 ||
+				nextY >= height
+			)
+				return;
+			if (dx === 0 && dy === 1) {
+				canvas[y]![x]! |= south;
+				canvas[nextY]![nextX]! |= north;
+			} else if (dx === 1 && dy === 0) {
+				canvas[y]![x]! |= east;
+				canvas[nextY]![nextX]! |= west;
+			}
+		};
+		const vertical = (x: number, from: number, to: number): void => {
+			for (let y = from; y < to; y++) connect(x, y, 0, 1);
+		};
+		const horizontal = (from: number, to: number, y: number): void => {
+			for (let x = from; x < to; x++) connect(x, y, 1, 0);
+		};
+		const drawBranches = (node: BranchMapNode): void => {
+			if (node.children.length === 1) {
+				vertical(node.x, node.y + 1, node.children[0]!.y);
+			} else if (node.children.length > 1) {
+				const branchY = node.children[0]!.y - 2;
+				vertical(node.x, node.y + 1, branchY + 1);
+				horizontal(node.children[0]!.x, node.children[node.children.length - 1]!.x, branchY);
+				for (const child of node.children) vertical(child.x, branchY, child.y);
+			}
+			for (const child of node.children) drawBranches(child);
+		};
+		for (const root of mapRoots) drawBranches(root);
+
+		const selectedId = this.getSelectedId();
+		const allNodes = mapRoots.flatMap(root => this.#flatten(root));
+		const selected = allNodes.find(node => node.node.entry.id === selectedId);
+		const graphWidth = Math.max(1, width - 2);
+		const selectedLeft = selected ? selected.x - Math.floor(nodeWidth / 2) : 0;
+		const startX = Math.max(0, Math.min(selectedLeft - 2, mapWidth - graphWidth));
+		const endX = Math.min(mapWidth, startX + graphWidth);
+		const visibleRows = Math.max(1, this.maxVisibleLines - 2);
+		const startY = Math.max(0, Math.min((selected?.y ?? 0) - Math.floor(visibleRows / 2), height - visibleRows));
+		const endY = Math.min(height, startY + visibleRows);
+		const lines: string[] = [];
+		for (let y = startY; y < endY; y++) {
+			const row = canvas[y]!.slice(startX, endX)
+				.map(cell => this.#connector(cell))
+				.join("");
+			const rowNodes = allNodes
+				.filter(
+					node =>
+						node.y === y &&
+						node.x - Math.floor(nodeWidth / 2) >= startX &&
+						node.x + Math.ceil(nodeWidth / 2) <= endX,
+				)
+				.toSorted((a, b) => a.x - b.x);
+			const parts: string[] = [];
+			let cursor = 0;
+			for (const node of rowNodes) {
+				const left = node.x - Math.floor(nodeWidth / 2) - startX;
+				const label = this.#nodeLabel(node, nodeWidth, showSummaries, selectedId);
+				parts.push(row.slice(cursor, left), label);
+				cursor = left + nodeWidth;
+			}
+			parts.push(row.slice(cursor));
+			let rendered = parts.join("");
+			if (startX > 0) rendered = `…${rendered.slice(1)}`;
+			if (endX < mapWidth) rendered = `${rendered.slice(0, -1)}…`;
+			lines.push(truncateToWidth(`  ${rendered.trimEnd()}`, width));
+		}
+		if (startY > 0 && lines.length > 0) lines[0] = theme.fg("muted", "  … ↑");
+		if (endY < height && lines.length > 0) lines[lines.length - 1] = theme.fg("muted", "  … ↓");
+		lines.push(truncateToWidth(theme.fg("muted", "  › selected  • current session"), width));
+		return lines;
+	}
+
+	#flatten(node: BranchMapNode): BranchMapNode[] {
+		return [node, ...node.children.flatMap(child => this.#flatten(child))];
+	}
+
+	#connector(cell: number): string {
+		if (theme.tree.horizontal === "-") {
+			return cell === 0 ? " " : cell === 1 || cell === 4 || cell === 5 ? "|" : cell === 10 ? "-" : "+";
+		}
+		switch (cell) {
+			case 0:
+				return " ";
+			case 1:
+			case 4:
+			case 5:
+				return "│";
+			case 2:
+			case 8:
+			case 10:
+				return "─";
+			case 3:
+				return "└";
+			case 6:
+				return "┌";
+			case 9:
+				return "┘";
+			case 12:
+				return "┐";
+			case 7:
+				return "├";
+			case 13:
+				return "┤";
+			case 11:
+				return "┴";
+			case 14:
+				return "┬";
+			default:
+				return "┼";
+		}
+	}
+
+	#nodeLabel(node: BranchMapNode, nodeWidth: number, showSummary: boolean, selectedId: string | null): string {
+		const entry = node.node.entry;
+		const selected = entry.id === selectedId;
+		const current = entry.id === this.getVisibleCurrentLeafId();
+		const role = entry.type === "message" ? entry.message.role : entry.type.replaceAll("_", " ");
+		const summary = showSummary ? this.#summary(entry) : "";
+		const prefix = selected ? "›" : current ? "•" : " ";
+		const content = `${prefix}#${node.number} ${role}${summary ? `: ${summary}` : ""}`;
+		const truncated = truncateToWidth(content, nodeWidth - 2, "");
+		const label = `[${truncated}${" ".repeat(Math.max(0, nodeWidth - 2 - visibleWidth(truncated)))}]`;
+		if (selected) return theme.bg("selectedBg", theme.bold(theme.fg("accent", label)));
+		return current ? theme.fg("success", label) : theme.fg("dim", label);
+	}
+
+	#summary(entry: SessionTreeNode["entry"]): string {
+		if (entry.type === "message") {
+			const message = entry.message as { content?: unknown; command?: string };
+			if (typeof message.content === "string") return this.#normalizeSummary(message.content);
+			if (Array.isArray(message.content)) {
+				const text = message.content
+					.filter(
+						(block): block is { type: "text"; text: string } =>
+							typeof block === "object" &&
+							block !== null &&
+							"type" in block &&
+							block.type === "text" &&
+							"text" in block &&
+							typeof block.text === "string",
+					)
+					.map(block => block.text)
+					.join(" ");
+				if (text) return this.#normalizeSummary(text);
+			}
+			return message.command ? this.#normalizeSummary(message.command) : "";
+		}
+		if (entry.type === "branch_summary") return this.#normalizeSummary(entry.summary);
+		if (entry.type === "label") return this.#normalizeSummary(entry.label ?? "");
+		return "";
+	}
+
+	#normalizeSummary(text: string): string {
+		return replaceTabs(text).replace(/\s+/g, " ").trim();
+	}
+}
+
+/**
+ * Component that renders a session tree selector for navigation.
+ *
+ * The entry list stays the interaction surface. The adjacent branch map is a
+ * read-only topology overview that can be hidden or expanded with Ctrl+G.
+ */
+export class TreeSelectorComponent implements Component {
 	#treeList: TreeList;
+	#branchMap: BranchMap;
 	#labelInput: LabelInput | null = null;
-	#labelInputContainer: Container;
-	#treeContainer: Container;
+	#viewMode: TreeViewMode = "split";
+	#border = new DynamicBorder();
 
 	constructor(
 		tree: SessionTreeNode[],
@@ -934,39 +1268,18 @@ export class TreeSelectorComponent extends Container {
 		private readonly onLabelChangeCallback?: (entryId: string, label: string | undefined) => void,
 		initialFilterMode: FilterMode = "default",
 	) {
-		super();
 		const maxVisibleLines = Math.max(5, Math.floor(terminalHeight / 2));
 
 		this.#treeList = new TreeList(tree, currentLeafId, maxVisibleLines, initialFilterMode);
 		this.#treeList.onSelect = onSelect;
 		this.#treeList.onCancel = onCancel;
 		this.#treeList.onLabelEdit = (entryId, currentLabel) => this.#showLabelInput(entryId, currentLabel);
-
-		this.#treeContainer = new Container();
-		this.#treeContainer.addChild(this.#treeList);
-
-		this.#labelInputContainer = new Container();
-
-		this.addChild(new Spacer(1));
-		this.addChild(new DynamicBorder());
-		this.addChild(new Text(theme.bold("  Session Tree"), 1, 0));
-		this.addChild(
-			new TruncatedText(
-				theme.fg(
-					"muted",
-					"Enter: switch. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
-				),
-				0,
-				0,
-			),
+		this.#branchMap = new BranchMap(
+			() => this.#treeList.getVisibleTree(),
+			() => this.#treeList.getVisibleCurrentLeafId(),
+			() => this.#treeList.getSelectedNode()?.entry.id ?? null,
+			maxVisibleLines,
 		);
-		this.addChild(new SearchLine(this.#treeList));
-		this.addChild(new DynamicBorder());
-		this.addChild(new Spacer(1));
-		this.addChild(this.#treeContainer);
-		this.addChild(this.#labelInputContainer);
-		this.addChild(new Spacer(1));
-		this.addChild(new DynamicBorder());
 
 		if (tree.length === 0) {
 			setTimeout(() => onCancel(), 100);
@@ -981,22 +1294,130 @@ export class TreeSelectorComponent extends Container {
 			this.#hideLabelInput();
 		};
 		this.#labelInput.onCancel = () => this.#hideLabelInput();
-
-		this.#treeContainer.clear();
-		this.#labelInputContainer.clear();
-		this.#labelInputContainer.addChild(this.#labelInput);
 	}
 
 	#hideLabelInput(): void {
 		this.#labelInput = null;
-		this.#labelInputContainer.clear();
-		this.#treeContainer.clear();
-		this.#treeContainer.addChild(this.#treeList);
+	}
+
+	invalidate(): void {
+		this.#treeList.invalidate();
+		this.#branchMap.invalidate();
+		this.#labelInput?.invalidate();
+		this.#border.invalidate();
+	}
+
+	render(width: number): readonly string[] {
+		const lines: string[] = [""];
+		const border = this.#border.render(width)[0]!;
+		lines.push(border);
+		if (this.#labelInput) {
+			lines.push(truncateToWidth(theme.bold("  Session Tree"), width));
+			lines.push(border);
+			lines.push("");
+			lines.push(...this.#labelInput.render(width));
+		} else {
+			const effectiveMode = this.#viewMode === "split" && width < MIN_SPLIT_WIDTH ? "list" : this.#viewMode;
+			const title =
+				effectiveMode === "map"
+					? "  Branch Map"
+					: effectiveMode === "split"
+						? `  Session Tree${" ".repeat(
+								Math.max(2, this.#splitListWidth(width) + 3 - visibleWidth("  Session Tree")),
+							)}Branch Map`
+						: "  Session Tree";
+			lines.push(truncateToWidth(theme.bold(title), width));
+			lines.push(...this.#renderFilterStatus(width));
+			lines.push(...this.#renderShortcutHelp(width));
+			if (effectiveMode !== "map") lines.push(new SearchLine(this.#treeList).render(width)[0]!);
+			lines.push(border);
+			lines.push("");
+			if (effectiveMode === "split") {
+				lines.push(...this.#renderSplitView(width));
+			} else if (effectiveMode === "map") {
+				lines.push(...this.#branchMap.render(width, true));
+			} else {
+				lines.push(...this.#treeList.render(width));
+			}
+		}
+		lines.push("");
+		lines.push(border);
+		return lines;
+	}
+
+	#renderSplitView(width: number): readonly string[] {
+		const separator = " │ ";
+		const listWidth = this.#splitListWidth(width);
+		const mapWidth = Math.max(1, width - separator.length - listWidth);
+		const listLines = this.#treeList.render(listWidth);
+		const mapLines = this.#branchMap.render(mapWidth, false);
+		const rowCount = Math.max(listLines.length, mapLines.length);
+		const lines: string[] = [];
+		for (let index = 0; index < rowCount; index++) {
+			const left = truncateToWidth(listLines[index] ?? "", listWidth);
+			const paddedLeft = left + " ".repeat(Math.max(0, listWidth - visibleWidth(left)));
+			const right = truncateToWidth(mapLines[index] ?? "", mapWidth);
+			lines.push(truncateToWidth(`${paddedLeft}${theme.fg("border", separator)}${right}`, width));
+		}
+		return lines;
+	}
+
+	#renderShortcutHelp(width: number): readonly string[] {
+		const line = (section: string, text: string): string =>
+			truncateToWidth(`  ${theme.fg("accent", section.padEnd(11))}${theme.fg("muted", text)}`, width);
+		return [
+			line("Navigate", "↑/↓ select   Shift+←/→ sibling branch (wraps)   Enter confirm"),
+			line("Actions", "Shift+Enter summarize + switch   Shift+L label   Ctrl+O filter"),
+			line("View", "Ctrl+G list / tree / split   Type to search"),
+		];
+	}
+
+	#renderFilterStatus(width: number): readonly string[] {
+		const mode = this.#treeList.getFilterMode();
+		const filters: Array<{ mode: FilterMode; label: string }> = [
+			{ mode: "default", label: "Default" },
+			{ mode: "no-tools", label: "No tools" },
+			{ mode: "user-only", label: "User only" },
+			{ mode: "labeled-only", label: "Labeled" },
+			{ mode: "all", label: "All" },
+		];
+		const chips = filters
+			.map(filter =>
+				filter.mode === mode
+					? theme.bg("selectedBg", theme.bold(theme.fg("accent", `[${filter.label}]`)))
+					: theme.fg("muted", filter.label),
+			)
+			.join("  ");
+		const description = (() => {
+			switch (mode) {
+				case "no-tools":
+					return "content entries; tool results hidden";
+				case "user-only":
+					return "user messages only";
+				case "labeled-only":
+					return "labeled entries only";
+				case "all":
+					return "all persisted entries";
+				default:
+					return "content entries; labels and internal events hidden";
+			}
+		})();
+		return [
+			truncateToWidth(`  ${theme.fg("muted", "Filter")}  ${chips}`, width),
+			truncateToWidth(`  ${theme.fg("muted", "Showing:")} ${theme.fg("dim", description)}`, width),
+		];
+	}
+
+	#splitListWidth(width: number): number {
+		return Math.max(40, Math.floor((width - 3) * 0.62));
 	}
 
 	handleInput(keyData: string): void {
 		if (this.#labelInput) {
 			this.#labelInput.handleInput(keyData);
+		} else if (matchesKey(keyData, "ctrl+g")) {
+			const modes: TreeViewMode[] = ["split", "map", "list"];
+			this.#viewMode = modes[(modes.indexOf(this.#viewMode) + 1) % modes.length]!;
 		} else {
 			this.#treeList.handleInput(keyData);
 		}

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -1435,7 +1435,7 @@ export class TreeSelectorComponent implements Component {
 			let bodyLines: readonly string[];
 			if (effectiveMode === "split") {
 				bodyLines = this.#renderSplitView(width);
-			} else if (effectiveMode === "map") {
+			} else if (effectiveMode === "map" && visibleNodeCount > 0) {
 				bodyLines = this.#branchMap.render(width, true);
 			} else {
 				bodyLines = this.#treeList.render(width);

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -1479,7 +1479,9 @@ export class TreeSelectorComponent extends Container {
 			lines.push(truncateToWidth(theme.bold(title), width));
 			const filterLines = this.#renderFilterStatus(width, compactChrome);
 			const shortcutLines = this.#renderShortcutHelp(width, compactChrome, minimalChrome);
-			const searchLines = effectiveMode !== "map" ? [new SearchLine(this.#treeList).render(width)[0]!] : [];
+			const hasSearchQuery = this.#treeList.getSearchQuery().length > 0;
+			const searchLines =
+				effectiveMode !== "map" || hasSearchQuery ? [new SearchLine(this.#treeList).render(width)[0]!] : [];
 			const mapLimitLines = mapUnavailable ? [this.#renderMapLimitStatus(width, visibleNodeCount)] : [];
 			const bodyRows = Math.max(
 				1,

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -1185,14 +1185,21 @@ class BranchMap implements Component {
 	}
 
 	render(width: number, showSummaries = true): readonly string[] {
-		const nodeWidth = showSummaries ? Math.max(18, Math.min(30, width - 4)) : Math.max(11, Math.min(14, width - 4));
+		const graphWidth = Math.max(1, width - 2);
+		const preferredNodeWidth = showSummaries
+			? Math.max(18, Math.min(30, width - 4))
+			: Math.max(11, Math.min(14, width - 4));
+		// Reserve one cell for each horizontal ellipsis so a fully rendered node
+		// remains visible even when the viewport crops both sides of the graph.
+		const maxNodeWidth = Math.max(2, graphWidth - 2);
+		const nodeWidth = Math.min(preferredNodeWidth, maxNodeWidth);
 		const layout = this.#getLayout(nodeWidth);
 		const { width: mapWidth, height } = layout;
 		const selectedId = this.getSelectedId();
 		const selected = selectedId ? layout.nodesById.get(selectedId) : undefined;
-		const graphWidth = Math.max(1, width - 2);
 		const selectedLeft = selected ? selected.x - Math.floor(nodeWidth / 2) : 0;
-		const startX = Math.max(0, Math.min(selectedLeft - 2, mapWidth - graphWidth));
+		const selectedMargin = nodeWidth === maxNodeWidth ? 1 : 2;
+		const startX = Math.max(0, Math.min(selectedLeft - selectedMargin, mapWidth - graphWidth));
 		const endX = Math.min(mapWidth, startX + graphWidth);
 		const maxGraphRows = Math.max(1, this.#maxVisibleLines - 1);
 		const viewport = (graphRows: number): { startY: number; endY: number } => {

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -1466,20 +1466,36 @@ export class TreeSelectorComponent implements Component {
 
 	#renderShortcutHelp(width: number, compact: boolean, minimal: boolean): readonly string[] {
 		if (minimal) return [];
+		const key = (text: string): string => theme.fg("accent", text);
+		const description = (text: string): string => theme.fg("muted", text);
 		if (compact) {
 			return [
 				truncateToWidth(
-					`  ${theme.fg("muted", "↑/↓ select   Enter confirm   Ctrl+G view   Ctrl+O filter")}`,
+					`  ${key("↑/↓")}${description(" select   ")}${key("Enter")}${description(" confirm   ")}${key("Ctrl+G")}${description(" view   ")}${key("Ctrl+O")}${description(" filter")}`,
 					width,
 				),
 			];
 		}
-		const line = (section: string, text: string): string =>
-			truncateToWidth(`  ${theme.fg("accent", section.padEnd(11))}${theme.fg("muted", text)}`, width);
+		const line = (section: string, parts: readonly string[]): string =>
+			truncateToWidth(`  ${theme.fg("accent", section.padEnd(11))}${parts.join("")}`, width);
 		return [
-			line("Navigate", "↑/↓ select   Shift+←/→ sibling branch (wraps)   Enter confirm"),
-			line("Actions", "Shift+Enter summarize + switch   Shift+L label   Ctrl+O filter"),
-			line("View", "Ctrl+G list / tree / split   Type to search"),
+			line("Navigate", [
+				key("↑/↓"),
+				description(" select   "),
+				key("Shift+←/→"),
+				description(" sibling branch (wraps)   "),
+				key("Enter"),
+				description(" confirm"),
+			]),
+			line("Actions", [
+				key("Shift+Enter"),
+				description(" summarize + switch   "),
+				key("Shift+L"),
+				description(" label   "),
+				key("Ctrl+O"),
+				description(" filter"),
+			]),
+			line("View", [key("Ctrl+G"), description(" list / tree / split   "), key("Type"), description(" to search")]),
 		];
 	}
 

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -1179,9 +1179,17 @@ class BranchMap implements Component {
 		const selectedLeft = selected ? selected.x - Math.floor(nodeWidth / 2) : 0;
 		const startX = Math.max(0, Math.min(selectedLeft - 2, mapWidth - graphWidth));
 		const endX = Math.min(mapWidth, startX + graphWidth);
-		const visibleRows = Math.max(1, this.#maxVisibleLines - 1);
-		const startY = Math.max(0, Math.min((selected?.y ?? 0) - Math.floor(visibleRows / 2), height - visibleRows));
-		const endY = Math.min(height, startY + visibleRows);
+		const maxGraphRows = Math.max(1, this.#maxVisibleLines - 1);
+		const viewport = (graphRows: number): { startY: number; endY: number } => {
+			const startY = Math.max(0, Math.min((selected?.y ?? 0) - Math.floor(graphRows / 2), height - graphRows));
+			return { startY, endY: Math.min(height, startY + graphRows) };
+		};
+		let { startY, endY } = viewport(maxGraphRows);
+		// Preserve a graph row for the selected node instead of overwriting it with
+		// a scroll indicator. When possible, reserve one separate row for it.
+		if ((startY > 0 || endY < height) && maxGraphRows > 1) {
+			({ startY, endY } = viewport(maxGraphRows - 1));
+		}
 		const north = 1;
 		const east = 2;
 		const south = 4;
@@ -1262,8 +1270,21 @@ class BranchMap implements Component {
 			const rendered = `${showLeftEllipsis ? "…" : ""}${parts.join("")}${showRightEllipsis ? "…" : ""}`;
 			lines.push(truncateToWidth(`  ${rendered.trimEnd()}`, width));
 		}
-		if (startY > 0 && lines.length > 0) lines[0] = theme.fg("muted", "  … ↑");
-		if (endY < height && lines.length > 0) lines[lines.length - 1] = theme.fg("muted", "  … ↓");
+		const scrollIndicator =
+			maxGraphRows > 1
+				? startY > 0 && endY < height
+					? "  … ↑↓"
+					: startY > 0
+						? "  … ↑"
+						: endY < height
+							? "  … ↓"
+							: undefined
+				: undefined;
+		if (scrollIndicator) {
+			const indicatorLine = truncateToWidth(theme.fg("muted", scrollIndicator), width);
+			if (startY > 0) lines.unshift(indicatorLine);
+			else lines.push(indicatorLine);
+		}
 		lines.push(truncateToWidth(theme.fg("muted", "  › selected  • current session"), width));
 		return lines;
 	}
@@ -1373,6 +1394,7 @@ export class TreeSelectorComponent extends Container {
 	#labelInput: LabelInput | null = null;
 	#viewMode: TreeViewMode = "split";
 	#border = new DynamicBorder();
+	#lastRenderWidth = MIN_SPLIT_WIDTH;
 
 	constructor(
 		tree: SessionTreeNode[],
@@ -1383,6 +1405,7 @@ export class TreeSelectorComponent extends Container {
 		private readonly onLabelChangeCallback?: (entryId: string, label: string | undefined) => void,
 		initialFilterMode: FilterMode = "default",
 		private readonly getTerminalRows: () => number = () => terminalHeight,
+		private readonly getTerminalColumns?: () => number,
 	) {
 		super();
 		const maxVisibleLines = Math.max(1, terminalHeight);
@@ -1427,6 +1450,7 @@ export class TreeSelectorComponent extends Container {
 	}
 
 	#renderTree(width: number): readonly string[] {
+		this.#lastRenderWidth = width;
 		const terminalRows = Math.max(1, this.getTerminalRows());
 		const lines: string[] = [""];
 		const border = this.#border.render(width)[0]!;
@@ -1438,7 +1462,7 @@ export class TreeSelectorComponent extends Container {
 			const bodyRows = Math.max(1, terminalRows - 7);
 			lines.push(...this.#labelInput.render(width).slice(0, bodyRows));
 		} else {
-			const requestedMode = this.#viewMode === "split" && width < MIN_SPLIT_WIDTH ? "list" : this.#viewMode;
+			const requestedMode = this.#getVisibleViewMode(width);
 			const visibleNodeCount = this.#treeList.getVisibleNodeCount();
 			const mapUnavailable = requestedMode !== "list" && visibleNodeCount > MAX_BRANCH_MAP_NODES;
 			const effectiveMode = mapUnavailable ? "list" : requestedMode;
@@ -1592,12 +1616,18 @@ export class TreeSelectorComponent extends Container {
 		return Math.max(40, Math.floor((width - 3) * 0.62));
 	}
 
+	#getVisibleViewMode(width: number): TreeViewMode {
+		return this.#viewMode === "split" && width < MIN_SPLIT_WIDTH ? "list" : this.#viewMode;
+	}
+
 	handleInput(keyData: string): void {
 		if (this.#labelInput) {
 			this.#labelInput.handleInput(keyData);
 		} else if (matchesKey(keyData, "ctrl+g")) {
-			const modes: TreeViewMode[] = ["split", "map", "list"];
-			this.#viewMode = modes[(modes.indexOf(this.#viewMode) + 1) % modes.length]!;
+			const width = Math.max(1, this.getTerminalColumns?.() ?? this.#lastRenderWidth);
+			const modes: readonly TreeViewMode[] = width < MIN_SPLIT_WIDTH ? ["list", "map"] : ["split", "map", "list"];
+			const visibleMode = this.#getVisibleViewMode(width);
+			this.#viewMode = modes[(modes.indexOf(visibleMode) + 1) % modes.length]!;
 		} else {
 			this.#treeList.handleInput(keyData);
 		}

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -511,10 +511,27 @@ class TreeList implements Component {
 	}
 
 	#moveToSiblingBranch(direction: -1 | 1): void {
-		const selected = this.getSelectedNode();
-		if (!selected) return;
+		const visibleTree = this.getVisibleTree();
+		const nodeById = new Map<string, SessionTreeNode>();
+		const parentById = new Map<string, SessionTreeNode | null>();
+		type VisibleTreeItem = { node: SessionTreeNode; parent: SessionTreeNode | null };
+		const stack: VisibleTreeItem[] = [];
+		for (let index = visibleTree.length - 1; index >= 0; index--) {
+			stack.push({ node: visibleTree[index]!, parent: null });
+		}
+		while (stack.length > 0) {
+			const { node, parent } = stack.pop()!;
+			nodeById.set(node.entry.id, node);
+			parentById.set(node.entry.id, parent);
+			for (let index = node.children.length - 1; index >= 0; index--) {
+				stack.push({ node: node.children[index]!, parent: node });
+			}
+		}
 
-		const nodeById = new Map<string, SessionTreeNode>(this.#flatNodes.map(node => [node.node.entry.id, node.node]));
+		const selectedId = this.getSelectedNode()?.entry.id;
+		if (!selectedId) return;
+		const selected = nodeById.get(selectedId);
+		if (!selected) return;
 		if (selected.children.length > 1) {
 			const targetIndex = direction === 1 ? 0 : selected.children.length - 1;
 			this.#selectVisibleBranch(selected.children, targetIndex, direction);
@@ -522,10 +539,8 @@ class TreeList implements Component {
 		}
 
 		let branchChild = selected;
-		let parentId = selected.entry.parentId;
-		while (parentId) {
-			const parent = nodeById.get(parentId);
-			if (!parent) return;
+		let parent = parentById.get(selected.entry.id) ?? null;
+		while (parent) {
 			if (parent.children.length > 1) {
 				const currentIndex = parent.children.findIndex(child => child.entry.id === branchChild.entry.id);
 				if (currentIndex === -1) return;
@@ -534,14 +549,14 @@ class TreeList implements Component {
 				return;
 			}
 			branchChild = parent;
-			parentId = parent.entry.parentId;
+			parent = parentById.get(parent.entry.id) ?? null;
 		}
 
-		if (this.#roots.length > 1) {
-			const currentIndex = this.#roots.findIndex(root => root.entry.id === branchChild.entry.id);
+		if (visibleTree.length > 1) {
+			const currentIndex = visibleTree.findIndex(root => root.entry.id === branchChild.entry.id);
 			if (currentIndex === -1) return;
-			const targetIndex = (currentIndex + direction + this.#roots.length) % this.#roots.length;
-			this.#selectVisibleBranch(this.#roots, targetIndex, direction);
+			const targetIndex = (currentIndex + direction + visibleTree.length) % visibleTree.length;
+			this.#selectVisibleBranch(visibleTree, targetIndex, direction);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -1,6 +1,7 @@
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import {
 	type Component,
+	Container,
 	extractPrintableText,
 	fuzzyMatch,
 	Input,
@@ -1334,13 +1335,25 @@ class BranchMap implements Component {
 	}
 }
 
+class TreeSelectorRenderer implements Component {
+	#renderTree: (width: number) => readonly string[];
+
+	constructor(renderTree: (width: number) => readonly string[]) {
+		this.#renderTree = renderTree;
+	}
+
+	render(width: number): readonly string[] {
+		return this.#renderTree(width);
+	}
+}
+
 /**
  * Component that renders a session tree selector for navigation.
  *
  * The entry list stays the interaction surface. The adjacent branch map is a
  * read-only topology overview that can be hidden or expanded with Ctrl+G.
  */
-export class TreeSelectorComponent implements Component {
+export class TreeSelectorComponent extends Container {
 	#treeList: TreeList;
 	#branchMap: BranchMap;
 	#labelInput: LabelInput | null = null;
@@ -1357,6 +1370,7 @@ export class TreeSelectorComponent implements Component {
 		initialFilterMode: FilterMode = "default",
 		private readonly getTerminalRows: () => number = () => terminalHeight,
 	) {
+		super();
 		const maxVisibleLines = Math.max(1, terminalHeight);
 
 		this.#treeList = new TreeList(tree, currentLeafId, maxVisibleLines, initialFilterMode);
@@ -1369,6 +1383,7 @@ export class TreeSelectorComponent implements Component {
 			() => this.#treeList.getSelectedNode()?.entry.id ?? null,
 			maxVisibleLines,
 		);
+		this.addChild(new TreeSelectorRenderer(width => this.#renderTree(width)));
 
 		if (tree.length === 0) {
 			setTimeout(() => onCancel(), 100);
@@ -1394,9 +1409,10 @@ export class TreeSelectorComponent implements Component {
 		this.#branchMap.invalidate();
 		this.#labelInput?.invalidate();
 		this.#border.invalidate();
+		super.invalidate();
 	}
 
-	render(width: number): readonly string[] {
+	#renderTree(width: number): readonly string[] {
 		const terminalRows = Math.max(1, this.getTerminalRows());
 		const lines: string[] = [""];
 		const border = this.#border.render(width)[0]!;

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -1220,27 +1220,31 @@ class BranchMap implements Component {
 
 		const lines: string[] = [];
 		for (let y = startY; y < endY; y++) {
-			const row = canvas[y - startY]!.map(cell => this.#connector(cell)).join("");
+			const showLeftEllipsis = startX > 0;
+			const showRightEllipsis = endX < mapWidth && (!showLeftEllipsis || graphWidth > 1);
+			const contentStartX = startX + (showLeftEllipsis ? 1 : 0);
+			const contentEndX = endX - (showRightEllipsis ? 1 : 0);
+			const row = canvas[y - startY]!.slice(contentStartX - startX, contentEndX - startX)
+				.map(cell => this.#connector(cell))
+				.join("");
 			const rowNodes = (layout.nodesByY.get(y) ?? [])
 				.filter(
 					node =>
 						node.y === y &&
-						node.x - Math.floor(nodeWidth / 2) >= startX &&
-						node.x + Math.ceil(nodeWidth / 2) <= endX,
+						node.x - Math.floor(nodeWidth / 2) >= contentStartX &&
+						node.x + Math.ceil(nodeWidth / 2) <= contentEndX,
 				)
 				.toSorted((a, b) => a.x - b.x);
 			const parts: string[] = [];
 			let cursor = 0;
 			for (const node of rowNodes) {
-				const left = node.x - Math.floor(nodeWidth / 2) - startX;
+				const left = node.x - Math.floor(nodeWidth / 2) - contentStartX;
 				const label = this.#nodeLabel(node, nodeWidth, showSummaries, selectedId);
 				parts.push(row.slice(cursor, left), label);
 				cursor = left + nodeWidth;
 			}
 			parts.push(row.slice(cursor));
-			let rendered = parts.join("");
-			if (startX > 0) rendered = `…${rendered.slice(1)}`;
-			if (endX < mapWidth) rendered = `${rendered.slice(0, -1)}…`;
+			const rendered = `${showLeftEllipsis ? "…" : ""}${parts.join("")}${showRightEllipsis ? "…" : ""}`;
 			lines.push(truncateToWidth(`  ${rendered.trimEnd()}`, width));
 		}
 		if (startY > 0 && lines.length > 0) lines[0] = theme.fg("muted", "  … ↑");

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1315,6 +1315,7 @@ export class SelectorController {
 					this.ctx.ui.requestRender();
 				},
 				settings.get("treeFilterMode"),
+				() => this.ctx.ui.terminal.rows,
 			);
 			return { component: selector, focus: selector };
 		});

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1316,6 +1316,7 @@ export class SelectorController {
 				},
 				settings.get("treeFilterMode"),
 				() => this.ctx.ui.terminal.rows,
+				() => this.ctx.ui.terminal.columns,
 			);
 			return { component: selector, focus: selector };
 		});

--- a/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
@@ -346,6 +346,24 @@ describe("TreeSelectorComponent branch map", () => {
 		expect(moved).not.toContain("•#");
 	});
 
+	it("keeps an active search query visible and editable in the standalone map", () => {
+		const { tree, currentLeafId } = treeWithOffBranchSearchMatches();
+		const selector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			60,
+			() => {},
+			() => {},
+		);
+
+		selector.handleInput("\x07"); // ctrl+g: split -> map
+		for (const character of "needle") selector.handleInput(character);
+		expect(render(selector, 80)).toContain("Search: needle");
+
+		selector.handleInput("\x7f"); // backspace
+		expect(render(selector, 80)).toContain("Search: needl");
+	});
+
 	it("moves the tree highlight with the list selection", () => {
 		const { tree, currentLeafId } = branchyTree();
 		const selector = new TreeSelectorComponent(

--- a/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
@@ -3,6 +3,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
 import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { SessionEntry, SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import type { Component } from "@oh-my-pi/pi-tui";
 
 let nextId = 0;
 
@@ -153,6 +154,43 @@ describe("TreeSelectorComponent branch map", () => {
 		expect(forkRow).toBeGreaterThan(rootRow);
 		expect(selectedRow).toBeGreaterThan(forkRow);
 		expect(graphRows.join("\n")).not.toContain("left branch");
+	});
+
+	it("preserves Container extension child rendering and lifecycle propagation", () => {
+		const { tree, currentLeafId } = branchyTree();
+		const selector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			60,
+			() => {},
+			() => {},
+		);
+		let invalidated = false;
+		let disposed = false;
+		let ignoresTight = false;
+		const extension: Component = {
+			render: () => ["extension child"],
+			invalidate: () => {
+				invalidated = true;
+			},
+			setIgnoreTight: ignore => {
+				ignoresTight = ignore;
+			},
+			dispose: () => {
+				disposed = true;
+			},
+		};
+
+		selector.addChild(extension);
+		expect(selector.children).toContain(extension);
+		expect(render(selector, 120)).toContain("extension child");
+		selector.setIgnoreTight(true);
+		selector.invalidate();
+		expect(ignoresTight).toBe(true);
+		expect(invalidated).toBe(true);
+		selector.disposeChildren();
+		expect(disposed).toBe(true);
+		expect(selector.children).toEqual([]);
 	});
 
 	it("uses the accent color for shortcut keys and muted text for their descriptions", () => {

--- a/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
@@ -254,12 +254,17 @@ describe("TreeSelectorComponent branch map", () => {
 
 	it("falls back to the list on narrow terminals but shows message summaries in the standalone tree", () => {
 		const { tree, currentLeafId } = branchyTree();
+		const terminalColumns = 80;
 		const selector = new TreeSelectorComponent(
 			tree,
 			currentLeafId,
 			60,
 			() => {},
 			() => {},
+			undefined,
+			"default",
+			() => 60,
+			() => terminalColumns,
 		);
 
 		expect(render(selector, 80)).toContain("Session Tree");
@@ -271,6 +276,39 @@ describe("TreeSelectorComponent branch map", () => {
 		expect(mapOnly).not.toContain("Session Tree");
 		expect(mapOnly).toContain("left branch");
 		expect(mapOnly).toContain("›#3 user");
+
+		selector.handleInput("\x07"); // ctrl+g: map -> list
+		expect(render(selector, terminalColumns)).toContain("Session Tree");
+		expect(render(selector, terminalColumns)).not.toContain("Branch Map");
+
+		selector.handleInput("\x07"); // ctrl+g: list -> map
+		expect(render(selector, terminalColumns)).toContain("Branch Map");
+	});
+
+	it("keeps selected map nodes visible when a short viewport needs scroll indicators", () => {
+		const { tree, currentLeafId } = linearUserTree(3);
+		const leafSelector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			10,
+			() => {},
+			() => {},
+		);
+		leafSelector.handleInput("\x07"); // ctrl+g: split -> map
+		expect(render(leafSelector, 120)).toContain("›#3 user");
+
+		const middleSelector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			11,
+			() => {},
+			() => {},
+		);
+		middleSelector.handleInput("\x1b[A"); // up: leaf -> middle node
+		middleSelector.handleInput("\x07"); // ctrl+g: split -> map
+		const output = render(middleSelector, 120);
+		expect(output).toContain("›#2 user");
+		expect(output).toContain("↑↓");
 	});
 
 	it("crops a styled label at the horizontal map edge without emitting an incomplete ANSI sequence", () => {

--- a/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
@@ -80,6 +80,45 @@ function treeWithHiddenMiddleSibling(): { tree: SessionTreeNode[]; currentLeafId
 	return { tree: [root], currentLeafId: firstChild.entry.id, thirdChildId: thirdChild.entry.id };
 }
 
+function treeWithPromotedHiddenBranches(hiddenType: "custom" | "label"): {
+	tree: SessionTreeNode[];
+	currentLeafId: string;
+	rootId: string;
+	firstChildId: string;
+	secondChildId: string;
+} {
+	const root = userNode("root");
+	const hiddenEntry: SessionEntry =
+		hiddenType === "custom"
+			? {
+					type: "custom",
+					id: `entry-${nextId++}`,
+					parentId: root.entry.id,
+					timestamp: new Date().toISOString(),
+					customType: "internal-marker",
+				}
+			: {
+					type: "label",
+					id: `entry-${nextId++}`,
+					parentId: root.entry.id,
+					timestamp: new Date().toISOString(),
+					targetId: root.entry.id,
+					label: "bookmark",
+				};
+	const hiddenNode: SessionTreeNode = { entry: hiddenEntry, children: [] };
+	const firstChild = userNode("first visible branch", hiddenNode.entry.id);
+	const secondChild = userNode("second visible branch", hiddenNode.entry.id);
+	root.children.push(hiddenNode);
+	hiddenNode.children.push(firstChild, secondChild);
+	return {
+		tree: [root],
+		currentLeafId: firstChild.entry.id,
+		rootId: root.entry.id,
+		firstChildId: firstChild.entry.id,
+		secondChildId: secondChild.entry.id,
+	};
+}
+
 function linearUserTree(
 	count: number,
 	textAt: (index: number) => string = index => `node ${index}`,
@@ -422,6 +461,30 @@ describe("TreeSelectorComponent branch map", () => {
 
 		expect(selector.getTreeList().getSelectedNode()?.entry.id).toBe(thirdChildId);
 	});
+
+	for (const hiddenType of ["custom", "label"] as const) {
+		it(`follows branches promoted through a hidden ${hiddenType} node`, () => {
+			const { tree, currentLeafId, rootId, firstChildId, secondChildId } =
+				treeWithPromotedHiddenBranches(hiddenType);
+			const selector = new TreeSelectorComponent(
+				tree,
+				currentLeafId,
+				60,
+				() => {},
+				() => {},
+			);
+			selector.handleInput("\x07"); // ctrl+g: split -> map
+			selector.handleInput("\x1b[A"); // up: first visible branch -> root
+			expect(selector.getTreeList().getSelectedNode()?.entry.id).toBe(rootId);
+
+			selector.handleInput("\x1b[1;2C"); // shift+right: root -> first promoted branch
+			expect(selector.getTreeList().getSelectedNode()?.entry.id).toBe(firstChildId);
+
+			selector.handleInput("\x1b[A"); // up: first visible branch -> root
+			selector.handleInput("\x1b[1;2D"); // shift+left: root -> last promoted branch
+			expect(selector.getTreeList().getSelectedNode()?.entry.id).toBe(secondChildId);
+		});
+	}
 
 	it("projects the same filtered nodes into the branch map and updates the filter status", () => {
 		const { tree, currentLeafId } = treeWithHiddenInternalNode();

--- a/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
@@ -64,6 +64,22 @@ function treeWithHiddenInternalNode(): { tree: SessionTreeNode[]; currentLeafId:
 	return { tree: [root], currentLeafId: child.entry.id };
 }
 
+function treeWithHiddenMiddleSibling(): { tree: SessionTreeNode[]; currentLeafId: string; thirdChildId: string } {
+	const root = userNode("root");
+	const firstChild = userNode("first visible branch", root.entry.id);
+	const hiddenEntry: SessionEntry = {
+		type: "custom",
+		id: `entry-${nextId++}`,
+		parentId: root.entry.id,
+		timestamp: new Date().toISOString(),
+		customType: "internal-marker",
+	};
+	const hiddenChild: SessionTreeNode = { entry: hiddenEntry, children: [] };
+	const thirdChild = userNode("third visible branch", root.entry.id);
+	root.children.push(firstChild, hiddenChild, thirdChild);
+	return { tree: [root], currentLeafId: firstChild.entry.id, thirdChildId: thirdChild.entry.id };
+}
+
 function linearUserTree(
 	count: number,
 	textAt: (index: number) => string = index => `node ${index}`,
@@ -334,6 +350,21 @@ describe("TreeSelectorComponent branch map", () => {
 
 		selector.handleInput("\n");
 		expect(selectedEntries).toEqual([currentLeafId]);
+	});
+
+	it("skips a fully hidden sibling branch with Shift+Right in the default filter", () => {
+		const { tree, currentLeafId, thirdChildId } = treeWithHiddenMiddleSibling();
+		const selector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			60,
+			() => {},
+			() => {},
+		);
+
+		selector.handleInput("\x1b[1;2C"); // shift+right: first visible branch -> third visible branch
+
+		expect(selector.getTreeList().getSelectedNode()?.entry.id).toBe(thirdChildId);
 	});
 
 	it("projects the same filtered nodes into the branch map and updates the filter status", () => {

--- a/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
@@ -27,6 +27,13 @@ function branchyTree(): { tree: SessionTreeNode[]; currentLeafId: string } {
 	return { tree: [root], currentLeafId: right.entry.id };
 }
 
+function wideRootTree(): { tree: SessionTreeNode[]; currentLeafId: string } {
+	const first = userNode("first root");
+	const second = userNode("second root");
+	const third = userNode("third root");
+	return { tree: [first, second, third], currentLeafId: first.entry.id };
+}
+
 function treeWithHiddenInternalNode(): { tree: SessionTreeNode[]; currentLeafId: string } {
 	const root = userNode("before internal event");
 	const internalEntry: SessionEntry = {
@@ -89,6 +96,24 @@ function render(selector: TreeSelectorComponent, width: number): string {
 
 function renderStyled(selector: TreeSelectorComponent, width: number): string {
 	return selector.render(width).join("\n");
+}
+
+function hasOnlyCompleteCsiSequences(text: string): boolean {
+	for (let index = 0; index < text.length; index++) {
+		if (text[index] !== "\x1b" || text[index + 1] !== "[") continue;
+		index += 2;
+		while (index < text.length) {
+			const code = text.charCodeAt(index);
+			if ((code >= 0x30 && code <= 0x3f) || (code >= 0x20 && code <= 0x2f)) {
+				index++;
+				continue;
+			}
+			if (code < 0x40 || code > 0x7e) return false;
+			break;
+		}
+		if (index === text.length) return false;
+	}
+	return true;
 }
 
 describe("TreeSelectorComponent branch map", () => {
@@ -179,6 +204,22 @@ describe("TreeSelectorComponent branch map", () => {
 		expect(mapOnly).not.toContain("Session Tree");
 		expect(mapOnly).toContain("left branch");
 		expect(mapOnly).toContain("›#3 user");
+	});
+
+	it("crops a styled label at the horizontal map edge without emitting an incomplete ANSI sequence", () => {
+		const { tree, currentLeafId } = wideRootTree();
+		const selector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			60,
+			() => {},
+			() => {},
+		);
+		selector.handleInput("\x07"); // ctrl+g: split -> map
+
+		const output = renderStyled(selector, 66);
+		expect(Bun.stripANSI(output)).toContain("…");
+		expect(hasOnlyCompleteCsiSequences(output)).toBe(true);
 	});
 
 	it("moves the tree highlight with the list selection", () => {

--- a/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
@@ -43,6 +43,46 @@ function treeWithHiddenInternalNode(): { tree: SessionTreeNode[]; currentLeafId:
 	return { tree: [root], currentLeafId: child.entry.id };
 }
 
+function linearUserTree(
+	count: number,
+	textAt: (index: number) => string = index => `node ${index}`,
+): {
+	tree: SessionTreeNode[];
+	currentLeafId: string;
+} {
+	const root = userNode(textAt(0));
+	let current = root;
+	for (let index = 1; index < count; index++) {
+		const child = userNode(textAt(index), current.entry.id);
+		current.children.push(child);
+		current = child;
+	}
+	return { tree: [root], currentLeafId: current.entry.id };
+}
+
+function deepProjectedTree(): { tree: SessionTreeNode[]; currentLeafId: string } {
+	const root = userNode("visible root");
+	let current = root;
+	for (let index = 1; index <= 20_000; index++) {
+		let child: SessionTreeNode;
+		if (index % 5 === 0) {
+			child = userNode(`visible ${index}`, current.entry.id);
+		} else {
+			const entry: SessionEntry = {
+				type: "custom",
+				id: `entry-${nextId++}`,
+				parentId: current.entry.id,
+				timestamp: new Date().toISOString(),
+				customType: "hidden-marker",
+			};
+			child = { entry, children: [] };
+		}
+		current.children.push(child);
+		current = child;
+	}
+	return { tree: [root], currentLeafId: current.entry.id };
+}
+
 function render(selector: TreeSelectorComponent, width: number): string {
 	return Bun.stripANSI(selector.render(width).join("\n"));
 }
@@ -172,5 +212,72 @@ describe("TreeSelectorComponent branch map", () => {
 		expect(allMap).toContain("[All]");
 		expect(allMap).toContain("all persisted entries");
 		expect(allMap).toContain("#2 custom");
+	});
+
+	it("renders a 20,001-entry chain iteratively when filtering leaves a map-sized projection", () => {
+		const { tree, currentLeafId } = deepProjectedTree();
+		const selector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			60,
+			() => {},
+			() => {},
+		);
+
+		const splitView = render(selector, 120);
+		expect(splitView).toContain("Branch Map");
+		expect(splitView).toContain("›#4001 user");
+
+		selector.handleInput("\x07"); // ctrl+g: split -> map
+		const mapOnly = render(selector, 80);
+		expect(mapOnly).toContain("›#4001 user");
+	});
+
+	it("falls back to the full-width list above the map node limit and restores the map after search", () => {
+		const { tree, currentLeafId } = linearUserTree(5_001, index => (index === 0 ? "needle" : `node ${index}`));
+		const selector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			60,
+			() => {},
+			() => {},
+		);
+
+		const limited = render(selector, 120);
+		expect(limited).toContain("Branch Map unavailable for 5,001 visible entries");
+		expect(limited).not.toContain("#1 user");
+		selector.handleInput("\x07"); // ctrl+g: split -> map
+		expect(render(selector, 120)).toContain("Branch Map unavailable for 5,001 visible entries");
+
+		for (const key of "needle") selector.handleInput(key);
+		const restored = render(selector, 120);
+		expect(restored).not.toContain("Branch Map unavailable");
+		expect(restored).toContain("Branch Map");
+		expect(restored).toContain("#1 user");
+	});
+
+	it("keeps every view within the live terminal height while it shrinks", () => {
+		const { tree, currentLeafId } = linearUserTree(10);
+		let terminalRows = 30;
+		const selector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			terminalRows,
+			() => {},
+			() => {},
+			undefined,
+			"default",
+			() => terminalRows,
+		);
+
+		expect(selector.render(120)).toHaveLength(30);
+		terminalRows = 20;
+		for (let index = 0; index < 3; index++) {
+			const output = render(selector, 120);
+			expect(selector.render(120).length).toBeLessThanOrEqual(20);
+			expect(output).toContain(index === 1 ? "Branch Map" : "Session Tree");
+			expect(output).toContain("Filter:");
+			selector.handleInput("\x07"); // ctrl+g: split -> map -> list -> split
+		}
 	});
 });

--- a/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
@@ -1,0 +1,176 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
+import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SessionEntry, SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+
+let nextId = 0;
+
+function userNode(text: string, parentId: string | null = null): SessionTreeNode {
+	const id = `entry-${nextId++}`;
+	const message: AgentMessage = { role: "user", content: text, timestamp: nextId };
+	const entry: SessionEntry = {
+		type: "message",
+		id,
+		parentId,
+		timestamp: new Date().toISOString(),
+		message,
+	};
+	return { entry, children: [] };
+}
+
+function branchyTree(): { tree: SessionTreeNode[]; currentLeafId: string } {
+	const root = userNode("start");
+	const left = userNode("left branch", root.entry.id);
+	const right = userNode("right branch", root.entry.id);
+	root.children.push(left, right);
+	return { tree: [root], currentLeafId: right.entry.id };
+}
+
+function treeWithHiddenInternalNode(): { tree: SessionTreeNode[]; currentLeafId: string } {
+	const root = userNode("before internal event");
+	const internalEntry: SessionEntry = {
+		type: "custom",
+		id: `entry-${nextId++}`,
+		parentId: root.entry.id,
+		timestamp: new Date().toISOString(),
+		customType: "internal-marker",
+	};
+	const internal: SessionTreeNode = { entry: internalEntry, children: [] };
+	const child = userNode("after internal event", internal.entry.id);
+	root.children.push(internal);
+	internal.children.push(child);
+	return { tree: [root], currentLeafId: child.entry.id };
+}
+
+function render(selector: TreeSelectorComponent, width: number): string {
+	return Bun.stripANSI(selector.render(width).join("\n"));
+}
+
+describe("TreeSelectorComponent branch map", () => {
+	beforeAll(async () => {
+		await themeModule.initTheme(false, undefined, undefined, "dark", "light");
+	});
+
+	it("draws a top-down tree beside the list with compact numbered role labels", () => {
+		const { tree, currentLeafId } = branchyTree();
+		const output = render(
+			new TreeSelectorComponent(
+				tree,
+				currentLeafId,
+				60,
+				() => {},
+				() => {},
+			),
+			120,
+		);
+
+		expect(output).toContain("Session Tree");
+		expect(output).toContain("Branch Map");
+		expect(output).toContain("Filter");
+		expect(output).toContain("[Default]");
+		expect(output).toContain("labels and internal events hidden");
+		expect(output).toContain("Navigate");
+		expect(output).toContain("Shift+←/→ sibling branch (wraps)");
+		expect(output).toContain("Enter confirm");
+		const graphRows = output
+			.split("\n")
+			.map(line => line.split(" │ ")[1])
+			.filter((line): line is string => line !== undefined);
+		const rootRow = graphRows.findIndex(line => line.includes("#1 user"));
+		const forkRow = graphRows.findIndex(line => line.includes("┌"));
+		const selectedRow = graphRows.findIndex(line => line.includes("›#3 user"));
+		expect(rootRow).toBeGreaterThanOrEqual(0);
+		expect(forkRow).toBeGreaterThan(rootRow);
+		expect(selectedRow).toBeGreaterThan(forkRow);
+		expect(graphRows.join("\n")).not.toContain("left branch");
+	});
+
+	it("falls back to the list on narrow terminals but shows message summaries in the standalone tree", () => {
+		const { tree, currentLeafId } = branchyTree();
+		const selector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			60,
+			() => {},
+			() => {},
+		);
+
+		expect(render(selector, 80)).toContain("Session Tree");
+		expect(render(selector, 80)).not.toContain("Branch Map");
+
+		selector.handleInput("\x07"); // ctrl+g: split -> map
+		const mapOnly = render(selector, 80);
+		expect(mapOnly).toContain("Branch Map");
+		expect(mapOnly).not.toContain("Session Tree");
+		expect(mapOnly).toContain("left branch");
+		expect(mapOnly).toContain("›#3 user");
+	});
+
+	it("moves the tree highlight with the list selection", () => {
+		const { tree, currentLeafId } = branchyTree();
+		const selector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			60,
+			() => {},
+			() => {},
+		);
+		selector.handleInput("\x07"); // ctrl+g: split -> map
+		expect(render(selector, 80)).toContain("›#3 user");
+
+		selector.handleInput("\x1b[A"); // up: current leaf -> root
+		const moved = render(selector, 80);
+		expect(moved).toContain("›#1 user");
+		expect(moved).not.toContain("›#3 user");
+	});
+
+	it("cycles sibling branches with Shift+Left before confirming with Enter", () => {
+		const { tree, currentLeafId } = branchyTree();
+		const selectedEntries: string[] = [];
+		const selector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			60,
+			entryId => selectedEntries.push(entryId),
+			() => {},
+		);
+		selector.handleInput("\x07"); // ctrl+g: split -> map
+
+		selector.handleInput("\x1b[1;2D"); // shift+left: right branch -> left branch
+		const leftSelected = render(selector, 80);
+		expect(leftSelected).toContain("›#2 user");
+		expect(leftSelected).not.toContain("›#3 user");
+		expect(selectedEntries).toEqual([]);
+
+		selector.handleInput("\x1b[1;2D"); // shift+left wraps left branch -> right branch
+		expect(render(selector, 80)).toContain("›#3 user");
+		expect(selectedEntries).toEqual([]);
+
+		selector.handleInput("\n");
+		expect(selectedEntries).toEqual([currentLeafId]);
+	});
+
+	it("projects the same filtered nodes into the branch map and updates the filter status", () => {
+		const { tree, currentLeafId } = treeWithHiddenInternalNode();
+		const selector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			60,
+			() => {},
+			() => {},
+		);
+		selector.handleInput("\x07"); // ctrl+g: split -> map
+
+		const defaultMap = render(selector, 80);
+		expect(defaultMap).toContain("#1 user: before internal");
+		expect(defaultMap).toContain("#2 user: after internal");
+		expect(defaultMap).not.toContain("custom");
+
+		for (let index = 0; index < 4; index++) selector.handleInput("\x0f"); // ctrl+o: default -> all
+		const allMap = render(selector, 80);
+		expect(allMap).toContain("[All]");
+		expect(allMap).toContain("all persisted entries");
+		expect(allMap).toContain("#2 custom");
+	});
+});

--- a/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
@@ -87,6 +87,10 @@ function render(selector: TreeSelectorComponent, width: number): string {
 	return Bun.stripANSI(selector.render(width).join("\n"));
 }
 
+function renderStyled(selector: TreeSelectorComponent, width: number): string {
+	return selector.render(width).join("\n");
+}
+
 describe("TreeSelectorComponent branch map", () => {
 	beforeAll(async () => {
 		await themeModule.initTheme(false, undefined, undefined, "dark", "light");
@@ -124,6 +128,36 @@ describe("TreeSelectorComponent branch map", () => {
 		expect(forkRow).toBeGreaterThan(rootRow);
 		expect(selectedRow).toBeGreaterThan(forkRow);
 		expect(graphRows.join("\n")).not.toContain("left branch");
+	});
+
+	it("uses the accent color for shortcut keys and muted text for their descriptions", () => {
+		const { tree, currentLeafId } = branchyTree();
+		const output = renderStyled(
+			new TreeSelectorComponent(
+				tree,
+				currentLeafId,
+				60,
+				() => {},
+				() => {},
+			),
+			120,
+		);
+
+		expect(output).toContain(themeModule.theme.fg("accent", "Shift+←/→"));
+		expect(output).toContain(themeModule.theme.fg("muted", " sibling branch (wraps)   "));
+
+		const compactOutput = renderStyled(
+			new TreeSelectorComponent(
+				tree,
+				currentLeafId,
+				20,
+				() => {},
+				() => {},
+			),
+			120,
+		);
+		expect(compactOutput).toContain(themeModule.theme.fg("accent", "Ctrl+G"));
+		expect(compactOutput).toContain(themeModule.theme.fg("muted", " view   "));
 	});
 
 	it("falls back to the list on narrow terminals but shows message summaries in the standalone tree", () => {

--- a/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
@@ -35,6 +35,19 @@ function wideRootTree(): { tree: SessionTreeNode[]; currentLeafId: string } {
 	return { tree: [first, second, third], currentLeafId: first.entry.id };
 }
 
+function treeWithOffBranchSearchMatches(): { tree: SessionTreeNode[]; currentLeafId: string } {
+	const root = userNode("root");
+	const activeParent = userNode("active parent", root.entry.id);
+	const activeLeaf = userNode("active leaf", activeParent.entry.id);
+	const otherParent = userNode("other parent", root.entry.id);
+	const firstMatch = userNode("needle first", otherParent.entry.id);
+	const secondMatch = userNode("needle second", otherParent.entry.id);
+	root.children.push(activeParent, otherParent);
+	activeParent.children.push(activeLeaf);
+	otherParent.children.push(firstMatch, secondMatch);
+	return { tree: [root], currentLeafId: activeLeaf.entry.id };
+}
+
 function treeWithHiddenInternalNode(): { tree: SessionTreeNode[]; currentLeafId: string } {
 	const root = userNode("before internal event");
 	const internalEntry: SessionEntry = {
@@ -258,6 +271,25 @@ describe("TreeSelectorComponent branch map", () => {
 		const output = renderStyled(selector, 66);
 		expect(Bun.stripANSI(output)).toContain("…");
 		expect(hasOnlyCompleteCsiSequences(output)).toBe(true);
+	});
+
+	it("does not mark an off-branch search result as the current session", () => {
+		const { tree, currentLeafId } = treeWithOffBranchSearchMatches();
+		const selector = new TreeSelectorComponent(
+			tree,
+			currentLeafId,
+			60,
+			() => {},
+			() => {},
+		);
+		for (const character of "needle") selector.handleInput(character);
+		selector.handleInput("\x07"); // ctrl+g: split -> map
+		expect(render(selector, 80)).toContain("›#2 user: needle second");
+
+		selector.handleInput("\x1b[A");
+		const moved = render(selector, 80);
+		expect(moved).toContain("›#1 user: needle first");
+		expect(moved).not.toContain("•#");
 	});
 
 	it("moves the tree highlight with the list selection", () => {

--- a/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-branch-map.test.ts
@@ -324,6 +324,25 @@ describe("TreeSelectorComponent branch map", () => {
 		expect(render(selector, terminalColumns)).toContain("Branch Map");
 	});
 
+	it("keeps a selected branch root visible in narrow standalone maps", () => {
+		const { tree, currentLeafId } = branchyTree();
+		for (const width of [21, 34]) {
+			const selector = new TreeSelectorComponent(
+				tree,
+				currentLeafId,
+				60,
+				() => {},
+				() => {},
+			);
+			selector.handleInput("\x1b[A"); // leaf -> branch root
+			selector.handleInput("\x07"); // ctrl+g: split -> map
+
+			const output = render(selector, width);
+			expect(output).toContain("›#1 user");
+			for (const line of output.split("\n")) expect(Bun.stringWidth(line)).toBeLessThanOrEqual(width);
+		}
+	});
+
 	it("keeps selected map nodes visible when a short viewport needs scroll indicators", () => {
 		const { tree, currentLeafId } = linearUserTree(3);
 		const leafSelector = new TreeSelectorComponent(

--- a/packages/coding-agent/test/modes/components/tree-selector-empty-state-1909.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-empty-state-1909.test.ts
@@ -89,6 +89,37 @@ describe("issue #1909: tree-selector empty-state messaging", () => {
 		expect(text).not.toContain("hidden by the current filter");
 	});
 
+	it("preserves the zero-result search explanation in standalone map mode", () => {
+		const selector = new TreeSelectorComponent(
+			userMessageTree(),
+			"e1",
+			60,
+			() => {},
+			() => {},
+		);
+		selector.handleInput("\x07"); // ctrl+g: split -> map
+		selector.handleInput("z");
+		const text = renderSelector(selector);
+
+		expect(text).toContain('No entries match search "z"');
+		expect(text.toLowerCase()).toContain("backspace");
+	});
+
+	it("preserves the filter explanation in standalone map mode", () => {
+		const selector = new TreeSelectorComponent(
+			freshSessionTree(),
+			"e2",
+			60,
+			() => {},
+			() => {},
+		);
+		selector.handleInput("\x07"); // ctrl+g: split -> map
+		const text = renderSelector(selector);
+
+		expect(text).toContain("hidden by the current filter");
+		expect(text.toLowerCase()).toContain("alt+a");
+	});
+
 	it("falls back to the bare 'No entries found' line when the tree is genuinely empty", () => {
 		const selector = new TreeSelectorComponent(
 			[],


### PR DESCRIPTION
## What changed

- Added a top-down Branch Map to `/tree` and `/branch` navigation.
- Added list, map, and split views, with `Ctrl+G` to cycle views and `Shift+Left` / `Shift+Right` to move between sibling branches.
- Kept the map and session list on the same filtering and search projection; the active filter and its effect are shown in the selector.
- Added responsive map labels: split view uses compact numbered roles, while map-only view includes message summaries.
- Hardened map rendering for deep, wide, and height-constrained sessions.
- Highlighted `/tree` shortcut keys separately from their descriptions in both full and compact help layouts.

<img width="1734" height="927" alt="omp" src="https://github.com/user-attachments/assets/8a8e2549-5da1-4361-9d36-5855deedb488" />


## Why this PR

Session history can contain many forked branches that are difficult to understand from a linear list alone. The Branch Map makes the branch topology visible while preserving the existing list as the navigation surface.

The initial map implementation also needed safeguards for realistic long-running sessions: recursive traversal could overflow the stack, a full logical canvas could be unnecessarily large, and the expanded selector chrome could be clipped in short terminals.

The selector help also used one muted color for both shortcut keys and their descriptions, making the available controls harder to scan.

## Approach

- Build the visible map from the same filtered session nodes used by the list.
- Use iterative projection, map construction, layout, and connector traversal so deep histories do not depend on call-stack depth.
- Cache the projected tree and map layout; selection changes only move the rendered viewport.
- Allocate a canvas only for the visible terminal region rather than the full logical map.
- Fall back to a full-width list when more than 5,000 visible nodes remain, with guidance to narrow the result through search or filtering.
- Derive selector content rows from the live terminal height and compact filter/help chrome on smaller terminals.
- Render shortcut keys with the theme accent color while retaining muted explanatory text, without changing shortcut behavior.

## Impact

- No configuration, persisted session format, or public API changes.
- Existing list navigation, search, filters, labels, and branch confirmation behavior are preserved.
- Large session trees remain navigable through the list instead of risking a slow or failed map render.
- Keyboard hints are easier to distinguish at a glance in normal and compact terminal layouts.

## Testing

- `bun run check` in `packages/coding-agent`
- Tree selector and keyboard navigation regression suite: 24 passing tests, 303 assertions.
- Added coverage for a 20,001-entry deep chain, the 5,000-node map limit and recovery after search, and live terminal-height changes across list, map, and split views.
- Added ANSI rendering coverage to verify shortcut keys use the accent color and descriptions stay muted in both full and compact help layouts.

## Included commits

- feat(coding-agent): add filtered session branch map
- fix(coding-agent): bound branch map rendering
- fix(coding-agent): distinguish tree shortcut hints

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
