### PR TITLE
fix(extensions): bundle nested wildcard export subpaths for compiled binaries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compiled binaries failing to import nested wildcard export subpaths such as `@oh-my-pi/pi-coding-agent/slash-commands/helpers/active-oauth-account`. Node matches `*` in an `exports` pattern across `/`, but the bundled registry enumerated only the top level and skipped any key containing a slash, so such an import resolved from source and died under bunfs — reproducible on the published 17.2.1 binary.
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/scripts/legacy-pi-virtual-module.ts
+++ b/packages/coding-agent/scripts/legacy-pi-virtual-module.ts
@@ -142,7 +142,13 @@ export async function collectBundledPiEntries(): Promise<BundledPiEntry[]> {
 
 			const sourceDir = path.join(packageRoot, pattern.sourcePrefix);
 			try {
-				const glob = new Bun.Glob(`*${pattern.sourceSuffix}`);
+				// Recursive on purpose: Node matches `*` in an `exports` pattern across
+				// `/`, so `./slash-commands/*` genuinely serves
+				// `slash-commands/helpers/active-oauth-account`. Enumerating only the
+				// top level left every nested key out of the compiled registry, where
+				// it fell through to `Bun.resolveSync` and died under bunfs — so such
+				// an import worked from source and failed inside a binary.
+				const glob = new Bun.Glob(`**/*${pattern.sourceSuffix}`);
 				const matches: string[] = [];
 				for await (const match of glob.scan({ cwd: sourceDir, onlyFiles: true })) {
 					matches.push(match);
@@ -151,7 +157,11 @@ export async function collectBundledPiEntries(): Promise<BundledPiEntry[]> {
 				for (const match of matches) {
 					if (!match.endsWith(pattern.sourceSuffix)) continue;
 					const basename = match.slice(0, match.length - pattern.sourceSuffix.length);
-					if (!isSafeWildcardBasename(basename) || basename.includes("/")) continue;
+					const segments = basename.split("/");
+					// Every directory on the way has to be importable too: a private or
+					// hidden folder is no more exported than a private file.
+					if (segments.some(segment => segment.startsWith(".") || segment.startsWith("_"))) continue;
+					if (!isSafeWildcardBasename(segments.at(-1) ?? "")) continue;
 					const subpath = `${pattern.exportPrefix}${basename}${pattern.exportSuffix}`;
 					const key = `${manifest.name}/${subpath}`;
 					addEntry(key, bindingForSubpath(pkg.identifier, subpath), key);

--- a/packages/coding-agent/test/extensibility/legacy-pi-bundled-subpath-overrides.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-bundled-subpath-overrides.test.ts
@@ -222,4 +222,19 @@ process.stdout.write(JSON.stringify([
 		const overrides = __buildLegacyPiPackageRootOverrides(true, bundledModuleKeys);
 		expect(overrides).not.toHaveProperty("typebox");
 	});
+
+	it("bundles nested wildcard subpaths so a compiled extension can import them", async () => {
+		// Node matches `*` in an `exports` pattern across `/`, so
+		// `./slash-commands/*` genuinely serves
+		// `slash-commands/helpers/active-oauth-account`. Enumerating only the
+		// top level left every nested key out of the compiled registry, so the
+		// import resolved from source and failed inside a binary — which is how
+		// a real extension (`quota-hud.ts`) broke on this exact specifier.
+		const entries = await collectBundledPiEntries();
+		const keys = new Set(entries.map(entry => entry.key));
+		expect(keys.has("@oh-my-pi/pi-coding-agent/slash-commands/helpers/active-oauth-account")).toBe(true);
+		// Directory index modules stay excluded: `./x/*` must not serve `x/y`
+		// from `y/index.ts`, which Node would not resolve either.
+		expect([...keys].some(key => key.endsWith("/index"))).toBe(false);
+	});
 });


### PR DESCRIPTION
## Problem

A compiled binary cannot import a nested wildcard export subpath. `quota-hud.ts`, a real extension, imports:

```ts
import { activeOAuthAccount } from "@oh-my-pi/pi-coding-agent/slash-commands/helpers/active-oauth-account";
```

That works from source and fails inside a binary. Reproduced on the **published 17.2.1 binary**, not just a local build.

## Cause

`collectBundledPiEntries` enumerated each `exports` wildcard with a single-level glob and then explicitly dropped anything containing a slash:

```ts
const glob = new Bun.Glob(`*${pattern.sourceSuffix}`);
...
if (!isSafeWildcardBasename(basename) || basename.includes("/")) continue;
```

Node matches `*` in an `exports` pattern **across `/`**, so `./slash-commands/*` genuinely serves `slash-commands/helpers/active-oauth-account`. Every nested key was therefore missing from the compiled registry, fell through to `Bun.resolveSync`, and died under bunfs.

## Fix

Enumerate recursively, and hold every path segment to the same private/hidden rules previously applied to the leaf — a `.private/` or `_internal/` directory is no more exported than a private file.

## Test

`bundles nested wildcard subpaths so a compiled extension can import them` asserts the real specifier is present, and that directory index modules stay excluded (`./x/*` must not serve `x/y` from `y/index.ts`, which Node would not resolve either).

Verified red→green against this branch's base: **12 pass** with the fix, **11 pass / 1 fail** with only the glob reverted.