### PR TITLE
fix(ai): preserve Codex websocket chaining after tool calls

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -2279,12 +2279,16 @@ class CodexStreamProcessor {
 				resetCodexWebSocketAppendState(state);
 			} else {
 				state.lastRequest = structuredCloneJSON(runtime.requestBodyForState);
-				if (responseId) {
+				const replayableResponseItems = sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(
+					structuredCloneJSON(runtime.nativeOutputItems),
+				);
+				if (responseId && replayableResponseItems) {
 					state.lastResponseId = responseId;
-					state.lastResponseItems = stripInputItemIds(structuredCloneJSON(runtime.nativeOutputItems));
+					state.lastResponseItems = replayableResponseItems as InputItem[];
 					state.canAppend = rawEvent.type === "response.done" || rawEvent.type === "response.completed";
 				} else {
-					// Without a response id the append baseline cannot be trusted.
+					// Without a response id and replay-equivalent response items,
+					// the append baseline cannot be trusted.
 					state.canAppend = false;
 				}
 			}
@@ -3003,14 +3007,6 @@ export function getOpenAICodexTransportDetails(
 		hasTurnState: state?.turnState !== undefined,
 		lastFallbackAt: state?.lastFallbackAt,
 	};
-}
-
-function stripInputItemIds(items: Array<Record<string, unknown>>): InputItem[] {
-	return items.map(item => {
-		if (item.id == null) return item as InputItem;
-		const { id: _id, ...rest } = item;
-		return rest as InputItem;
-	});
 }
 
 const codexDiagnosticsTextEncoder = new TextEncoder();

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -3375,6 +3375,114 @@ describe("openai-codex streaming", () => {
 		});
 	});
 
+	it("chains websocket tool output after normalizing an oversized call id", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-tool-delta-");
+		setAgentDir(tempDir.path());
+		const token = createCodexTestToken();
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const longCallId = `call_${"x".repeat(80)}`;
+		const fetchMock = vi.fn(async () => {
+			throw new Error("SSE fallback should not be called");
+		});
+
+		class ToolDeltaWebSocket extends MockWebSocket {
+			constructor(url: string, options?: WsOptions) {
+				super(url, options);
+				this.scheduleOpen();
+			}
+
+			send(data: string): void {
+				sentRequests.push(JSON.parse(data) as Record<string, unknown>);
+				if (sentRequests.length === 1) {
+					this.sendJson({ type: "response.created", response: { id: "resp_tool_1" } });
+					this.sendJson({
+						type: "response.output_item.added",
+						item: {
+							type: "function_call",
+							id: "fc_tool_1",
+							call_id: longCallId,
+							name: "read",
+							arguments: "",
+						},
+					});
+					this.sendJson({
+						type: "response.output_item.done",
+						item: {
+							type: "function_call",
+							id: "fc_tool_1",
+							call_id: longCallId,
+							name: "read",
+							arguments: '{"path":"README.md"}',
+						},
+					});
+					this.sendJson({
+						type: "response.completed",
+						response: { id: "resp_tool_1", status: "completed", usage: DEFAULT_USAGE },
+					});
+					return;
+				}
+				this.emitCodexResponse({
+					messageId: "msg_tool_2",
+					responseId: "resp_tool_2",
+					text: "Done",
+					terminalType: "response.completed",
+				});
+			}
+		}
+
+		global.WebSocket = ToolDeltaWebSocket as unknown as typeof WebSocket;
+		const model = createCodexTestModel("https://chatgpt.com/backend-api");
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const firstUser = { role: "user" as const, content: "Read README", timestamp: Date.now() };
+		const baseContext: Context = {
+			systemPrompt: ["You are a helpful assistant."],
+			messages: [firstUser],
+			tools: [
+				{
+					name: "read",
+					description: "Read a file",
+					parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+				},
+			],
+		};
+		const options = {
+			fetch: fetchMock as FetchImpl,
+			apiKey: token,
+			sessionId: "ws-tool-delta-session",
+			providerSessionState,
+		};
+
+		const firstResponse = await streamOpenAICodexResponses(model, baseContext, options).result();
+		const toolCall = firstResponse.content.find(block => block.type === "toolCall");
+		if (toolCall?.type !== "toolCall") throw new Error("expected tool call");
+		await streamOpenAICodexResponses(
+			model,
+			{
+				...baseContext,
+				messages: [
+					firstUser,
+					firstResponse,
+					{
+						role: "toolResult",
+						toolCallId: toolCall.id,
+						toolName: toolCall.name,
+						content: [{ type: "text", text: "file contents" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			},
+			options,
+		).result();
+
+		expect(sentRequests).toHaveLength(2);
+		expect(sentRequests[1]?.previous_response_id).toBe("resp_tool_1");
+		expect(sentRequests[1]?.input).toEqual([
+			expect.objectContaining({ type: "function_call_output", output: "file contents" }),
+		]);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
 	it("drops a stale terminal frame from the prior response leaking onto a reused websocket", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stale-frame-");
 		setAgentDir(tempDir.path());


### PR DESCRIPTION
## Summary

- record Codex WebSocket response baselines with the same replay sanitizer used to rebuild assistant history
- enable append state only when both a response ID and replay-equivalent response items are available
- cover oversized tool-call ID normalization with a focused WebSocket tool-loop regression

Fixes #7279

## Verification

- `bun test packages/ai/test/openai-codex-stream.test.ts -t "chains websocket tool output after normalizing an oversized call id"`
- `bun test packages/ai/test/openai-codex-stream.test.ts` — 75 passed
- `bun --cwd=packages/ai run check:types`
- `bunx biome check packages/ai/src/providers/openai-codex-responses.ts packages/ai/test/openai-codex-stream.test.ts`