### PR TITLE
fix(coding-agent): keep an Escape-raced prompt instead of discarding it

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -40,7 +40,8 @@
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
-
+- Fixed Escape immediately after sending a message discarding that message entirely: the pre-flight chain in `AgentSession#promptWithMessage` bails out before `agent.prompt()` ever commits the turn, so the message reached no session entry, was unreachable from `/tree`, and could not be undone. It now commits as a genuine aborted turn (user message plus an `aborted` assistant reply) through the normal event pipeline.
+- Fixed the interactive transcript keeping a phantom user-message row after such an abort, the `Working...` loader staying frozen on screen because the cleanup path never requested a repaint, and Escape appearing to do nothing for several seconds while the auto-thinking classifier ran out its own timeout instead of being cancelled with the turn.
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1568,6 +1568,27 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#optimisticUserMessageComponents = [];
 	}
 
+	/**
+	 * Same bookkeeping reset as `clearOptimisticUserMessage`, but for a
+	 * submission that will never be committed at all -- cancelled before
+	 * dispatch, or bailed out of `AgentSession#promptWithMessage` before
+	 * `agent.prompt()` ever ran (e.g. an Esc-triggered abort racing the
+	 * pre-flight setup) -- so the optimistic row it painted must actually be
+	 * detached from `chatContainer` too. `clearOptimisticUserMessage` is
+	 * reserved for the opposite case, where the real `message_start` event
+	 * for this exact text just arrived (`EventController`'s `wasOptimistic`
+	 * branch): the already-rendered optimistic row IS the correct permanent
+	 * render, so touching `chatContainer` there would remove the user's
+	 * message with nothing to replace it -- every plain submission would
+	 * vanish from the transcript the instant its own turn started streaming.
+	 */
+	detachOptimisticUserMessage(): void {
+		for (const component of this.#optimisticUserMessageComponents) {
+			this.chatContainer.removeChild(component);
+		}
+		this.clearOptimisticUserMessage();
+	}
+
 	replaceOptimisticUserMessage(
 		message: AgentMessage,
 		options?: { imageLinks?: readonly (string | undefined)[] },
@@ -1618,7 +1639,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				);
 			});
 		} else {
-			this.clearOptimisticUserMessage();
+			this.detachOptimisticUserMessage();
 		}
 		this.editor.setText("");
 		this.editor.imageLinks = undefined;
@@ -1635,7 +1656,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		submission.cancelled = true;
 		this.#pendingSubmittedInput = undefined;
-		this.clearOptimisticUserMessage();
+		this.detachOptimisticUserMessage();
 		this.#pendingWorkingMessage = undefined;
 		if (submission.customType === "goal-continuation") {
 			this.#goalContinuationTurnInFlight = false;
@@ -1680,13 +1701,20 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		if (wasPendingSubmission && !this.session.isStreaming && !this.streamingComponent) {
-			this.optimisticUserMessageSignature = undefined;
 			pendingSubmissionDispose?.();
-			this.#optimisticUserMessageComponents = [];
+			this.detachOptimisticUserMessage();
 			this.#pendingWorkingMessage = undefined;
 			if (this.loadingAnimation) {
 				this.#stopLoadingAnimation(true);
 			}
+			// Every sibling mutator that tears down the optimistic row and loader
+			// (`startPendingSubmission`, `cancelPendingSubmission`) ends with this
+			// call; this cleanup branch mutated the same state without ever asking
+			// for a repaint. The next real render (an unrelated log line, a resize,
+			// a keystroke) painted over it, but nothing forced that render, so an
+			// Esc-abort mid pre-flight left the "Working... [esc]" loader frozen on
+			// screen indefinitely even though the state it reflected was gone.
+			this.ui.requestRender();
 		}
 	}
 
@@ -4182,7 +4210,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	showError(message: string): void {
 		this.#pendingSubmittedInput = undefined;
-		this.clearOptimisticUserMessage();
+		this.detachOptimisticUserMessage();
 		this.#pendingWorkingMessage = undefined;
 		if (this.loadingAnimation) {
 			this.#stopLoadingAnimation(true);

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -303,7 +303,16 @@ export interface InteractiveModeContext {
 	 * delivery error should leave the signature set untouched.
 	 */
 	withLocalSubmission<T>(text: string, fn: () => Promise<T>, options?: { imageCount?: number }): Promise<T>;
-	/** Clears bookkeeping for an optimistic local user message once the matching session event arrives. */
+	/**
+	 * Clears bookkeeping for an optimistic local user message once the matching
+	 * session `message_start` event for that exact text arrives. Deliberately
+	 * leaves the already-rendered optimistic row attached to `chatContainer` --
+	 * it already shows the correct final content, so it simply becomes
+	 * permanent history. A submission that will never be committed (cancelled,
+	 * aborted, or replaced by different final text) needs the row actually
+	 * removed instead; see `InteractiveMode#detachOptimisticUserMessage` /
+	 * `replaceOptimisticUserMessage` for that.
+	 */
 	clearOptimisticUserMessage(): void;
 	/** Replaces the raw optimistic user render with the canonical message emitted by the session. */
 	replaceOptimisticUserMessage(

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -570,6 +570,23 @@ export class AgentSession {
 	#planInternalAbortPending = false;
 	#pendingAbortErrorId?: number;
 
+	/**
+	 * The user's own message, captured the instant `#promptWithMessage` is
+	 * entered, cleared the instant it hands off to `agent.prompt()` (from
+	 * there, the normal event pipeline owns persistence). If a bail-out
+	 * fires before that hand-off -- Escape racing the pre-flight chain
+	 * (recovery, bash/eval/irc flush, before_agent_start, auto-thinking
+	 * classification; the classifier's genuine several-hundred-ms local-
+	 * model-load window is the realistic way this actually gets hit) --
+	 * `#commitAbortedPromptIfPending` still commits it as a real aborted
+	 * turn instead of discarding it with no trace: not doing so left the
+	 * message unrecoverable and invisible in `/tree`, the originally
+	 * reported bug. `generation` lets a superseding newer call (which
+	 * captures and stores its own pair here first) suppress this one's
+	 * now-stale commit.
+	 */
+	#pendingUncommittedPrompt?: { message: AgentMessage; generation: number };
+
 	#postPromptTasks = new Set<Promise<unknown>>();
 	#postPromptTasksPromise: Promise<void> | undefined = undefined;
 	#postPromptTasksResolve: (() => void) | undefined = undefined;
@@ -5005,9 +5022,22 @@ export class AgentSession {
 	): Promise<void> {
 		this.#beginInFlight();
 		const generation = this.#promptGeneration;
+		if (message.role === "user") {
+			this.#pendingUncommittedPrompt = { message, generation };
+		}
 		try {
 			await this.#recovery.maybeRestoreRetryFallbackPrimary();
-			if (!(await this.#runUsageAwarePreflight())) return;
+			if (!(await this.#runUsageAwarePreflight())) {
+				// `abort()` cancels every controller in `#usagePreflightAbortControllers`
+				// (this preflight registers its own) *and* bumps `#promptGeneration`, so an
+				// Escape landing inside the preflight surfaces here as a plain `false` and
+				// returns before any generation checkpoint below can observe it. Commit the
+				// pending message for that case only: a `false` from a genuine usage/reserve
+				// decision is a precondition failure, which commits nothing (same as a
+				// pre-flight step throwing).
+				if (this.#promptGeneration !== generation) await this.#commitAbortedPromptIfPending(generation);
+				return;
+			}
 			// Flush any pending bash messages before the new prompt
 			await this.#bash.flushPending();
 			this.#eval.flushPending();
@@ -5075,6 +5105,7 @@ export class AgentSession {
 			// Early bail-out: if a newer abort/prompt cycle started during setup,
 			// return before mutating shared state (nextTurn messages, system prompt).
 			if (this.#promptGeneration !== generation) {
+				await this.#commitAbortedPromptIfPending(generation);
 				return;
 			}
 
@@ -5110,7 +5141,10 @@ export class AgentSession {
 			// resuming would start a turn on a torn-down session.
 			const disposingBeforeTransition = this.#isDisposed;
 			await this.#memory.transition;
-			if ((this.#isDisposed && !disposingBeforeTransition) || this.#promptGeneration !== generation) return;
+			if ((this.#isDisposed && !disposingBeforeTransition) || this.#promptGeneration !== generation) {
+				if (!this.#isDisposed || disposingBeforeTransition) await this.#commitAbortedPromptIfPending(generation);
+				return;
+			}
 			const beforeAgentStartSystemPrompt = await this.#buildSystemPromptForAgentStart(expandedText);
 
 			let baseXdevCatalogDelivered = true;
@@ -5159,6 +5193,7 @@ export class AgentSession {
 
 			// Bail out if a newer abort/prompt cycle has started since we began setup
 			if (this.#promptGeneration !== generation) {
+				await this.#commitAbortedPromptIfPending(generation);
 				return;
 			}
 
@@ -5167,8 +5202,21 @@ export class AgentSession {
 			// custom roles) and non-auto sessions are skipped. Never blocks the turn —
 			// failures fall back to a concrete level inside the helper.
 			if (this.isAutoThinking && message.role === "user") {
-				await this.#models.applyAutoThinkingLevel(expandedText, generation);
+				// Track a dedicated controller in the existing preflight-abort set
+				// (see `#runUsageAwarePreflight`) so an Escape-triggered `abort()`
+				// cancels the in-flight classifier request instead of leaving it to
+				// run out the classifier's own fallback timeout — otherwise the
+				// aborted turn's optimistic user-message row stays visible for that
+				// whole window before `finishPendingSubmission` can clean it up.
+				const autoThinkingAbort = new AbortController();
+				this.#usagePreflightAbortControllers.add(autoThinkingAbort);
+				try {
+					await this.#models.applyAutoThinkingLevel(expandedText, generation, autoThinkingAbort.signal);
+				} finally {
+					this.#usagePreflightAbortControllers.delete(autoThinkingAbort);
+				}
 				if (this.#promptGeneration !== generation) {
+					await this.#commitAbortedPromptIfPending(generation);
 					return;
 				}
 			}
@@ -5181,6 +5229,7 @@ export class AgentSession {
 
 			await this.#maintenance.runPrePromptCompactionIfNeeded(messages);
 			if (this.#promptGeneration !== generation) {
+				await this.#commitAbortedPromptIfPending(generation);
 				return;
 			}
 
@@ -5209,6 +5258,7 @@ export class AgentSession {
 			if (planReferenceMessage) {
 				this.#planReferenceSent = true;
 			}
+			this.#clearPendingUncommittedPrompt(generation);
 			try {
 				await this.#recovery.promptAgentWithIdleRetry(messages, agentPromptOptions);
 			} finally {
@@ -5218,8 +5268,78 @@ export class AgentSession {
 				await this.#waitForPostPromptRecovery(generation);
 			}
 		} finally {
+			this.#clearPendingUncommittedPrompt(generation);
 			this.#endInFlight();
 		}
+	}
+
+	/**
+	 * Drops `#pendingUncommittedPrompt` once it's no longer this call's to
+	 * commit: either it just handed off to `agent.prompt()` (which owns
+	 * persistence from here), or its own call is exiting (success, bail-out
+	 * after already committing, or an uncaught exception) and a newer call
+	 * may have since overwritten the slot with its own pending pair, which
+	 * this generation check leaves untouched.
+	 */
+	#clearPendingUncommittedPrompt(generation: number): void {
+		if (this.#pendingUncommittedPrompt?.generation === generation) {
+			this.#pendingUncommittedPrompt = undefined;
+		}
+	}
+
+	/**
+	 * Commits `message` (plus a synthetic aborted assistant turn) when
+	 * `#promptWithMessage` bails out of its pre-flight chain before ever
+	 * reaching `agent.prompt()` -- the point that normally owns commit.
+	 * Mirrors exactly what a genuine in-flight abort produces (see
+	 * `emitAbortedAssistantMessage` in agent-loop.ts): an empty,
+	 * `stopReason: "aborted"` assistant reply parented off the user's own
+	 * message, fed through the same `#handleAgentEvent` pipeline a real
+	 * agent-emitted event uses -- so persistence, `/tree`, and the live
+	 * chat render exactly as they would for any other aborted turn, with
+	 * no new UI-side logic to get wrong.
+	 *
+	 * No-ops when nothing is pending for `generation`: either this call's
+	 * own turn already handed off to `agent.prompt()` (which cleared the
+	 * slot itself), or a newer `#promptWithMessage` call has since
+	 * overwritten it with its own pending pair -- in which case that
+	 * newer call's own bail-out/hand-off owns the outcome, not this one.
+	 */
+	async #commitAbortedPromptIfPending(generation: number): Promise<void> {
+		const pending = this.#pendingUncommittedPrompt;
+		if (!pending || pending.generation !== generation) return;
+		this.#pendingUncommittedPrompt = undefined;
+		const userMessage = pending.message;
+		this.agent.appendMessage(userMessage);
+		await this.#handleAgentEvent({ type: "message_start", message: userMessage });
+		await this.#handleAgentEvent({ type: "message_end", message: userMessage });
+		// No model resolved (session created but never assigned one): still land
+		// the user's own message -- unresolvable but reachable via `/tree` beats
+		// vanishing outright -- but there's no model identity left to attribute a
+		// synthetic reply to, so skip it rather than fabricate one.
+		const model = this.model;
+		if (!model) return;
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "aborted",
+			errorMessage: this.#pendingAbortErrorId ? USER_INTERRUPT_LABEL : "Request was aborted",
+			timestamp: Date.now(),
+		};
+		this.agent.appendMessage(assistantMessage);
+		await this.#handleAgentEvent({ type: "message_start", message: assistantMessage });
+		await this.#handleAgentEvent({ type: "message_end", message: assistantMessage });
 	}
 
 	/**

--- a/packages/coding-agent/src/session/model-controls.ts
+++ b/packages/coding-agent/src/session/model-controls.ts
@@ -583,9 +583,13 @@ export class ModelControls {
 	 * Classify the current user turn and set the effective thinking level for it.
 	 * Bounded by a timeout + abort; on failure it preserves the last classified
 	 * level, or uses the provisional concrete level before the first resolution.
-	 * Never throws into the turn, and never clears `#autoThinking`.
+	 * `abortSignal` (typically the caller's per-turn preflight-abort controller)
+	 * is combined with the internal timeout via `AbortSignal.any` so an aborted
+	 * turn cancels the in-flight classifier request immediately instead of
+	 * waiting out the timeout. Never throws into the turn, and never clears
+	 * `#autoThinking`.
 	 */
-	async applyAutoThinkingLevel(promptText: string, generation: number): Promise<void> {
+	async applyAutoThinkingLevel(promptText: string, generation: number, abortSignal?: AbortSignal): Promise<void> {
 		const model = this.#model;
 		if (!model?.reasoning) return;
 		// Models with reasoning but no controllable effort surface (devin-agent
@@ -600,15 +604,22 @@ export class ModelControls {
 			// to the highest supported level for this model.
 			resolved = clampAutoThinkingEffort(model, Effort.Max);
 		} else {
-			const controller = new AbortController();
-			const timer = setTimeout(() => controller.abort(), ModelControls.#AUTO_THINKING_TIMEOUT_MS);
+			const timeoutController = new AbortController();
+			const timer = setTimeout(() => timeoutController.abort(), ModelControls.#AUTO_THINKING_TIMEOUT_MS);
+			// An external abort (e.g. Escape racing this classification call) must cancel
+			// the request immediately rather than waiting out the fallback timeout below —
+			// otherwise the aborted turn's optimistic UI lingers for up to
+			// AUTO_THINKING_TIMEOUT_MS after the user already interrupted it.
+			const signal = abortSignal
+				? AbortSignal.any([abortSignal, timeoutController.signal])
+				: timeoutController.signal;
 			try {
 				resolved = await classifyDifficulty(promptText, {
 					settings: this.#host.settings,
 					registry: this.#host.modelRegistry,
 					model,
 					sessionId: this.#host.sessionId(),
-					signal: controller.signal,
+					signal,
 					metadataResolver: provider => this.#host.agent.metadataForProvider(provider),
 				});
 			} catch (error) {

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -17,6 +17,14 @@ import {
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { createAssistantMessage } from "./helpers/agent-session-setup";
 
+async function pollUntil(predicate: () => boolean, timeoutMs: number): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) throw new Error("pollUntil timed out");
+		await Bun.sleep(0);
+	}
+}
+
 describe("AgentSession role model thinking behavior", () => {
 	let tempDir: TempDir;
 	let session: AgentSession;
@@ -626,6 +634,44 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(classifierSpy).not.toHaveBeenCalled();
 		expect(session.thinkingLevel).toBe(Effort.Max);
 		expect(session.autoResolvedThinkingLevel()).toBe(Effort.Max);
+	});
+
+	it("cancels an in-flight classifier request immediately when the turn is aborted", async () => {
+		// Regression test: Escape racing a just-submitted message used to abort
+		// the turn (bumping promptGeneration) without cancelling the auto-thinking
+		// classifier's own network call, which kept running until its internal
+		// AUTO_THINKING_TIMEOUT_MS fallback fired. Any UI relying on the abort
+		// settling promptly (e.g. detaching the optimistic user-message row) sat
+		// stuck for that whole window. `abort()` must now cancel the classifier's
+		// signal directly instead of waiting it out.
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		await createSession({
+			initialModelId: model.id,
+			initialThinkingLevel: Effort.High,
+			modelRoles: { default: `${model.provider}/${model.id}` },
+		});
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		let capturedSignal: AbortSignal | undefined;
+		vi.spyOn(autoThinkingClassifier, "classifyDifficulty").mockImplementation((_text, options) => {
+			const { promise, reject } = Promise.withResolvers<Effort>();
+			capturedSignal = options.signal;
+			options.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+			return promise;
+		});
+
+		session.setThinkingLevel(AUTO_THINKING);
+
+		const promptPromise = session.prompt("Investigate a regression");
+		await pollUntil(() => capturedSignal !== undefined, 2_000);
+
+		await session.abort({ reason: "test interrupt" });
+		await promptPromise;
+
+		// The abort must short-circuit the classifier request itself rather than
+		// leaving it to run out the multi-second internal fallback timeout, which
+		// is what kept post-abort UI cleanup waiting.
+		expect(capturedSignal?.aborted).toBe(true);
 	});
 
 	it("keeps auto effectively off for non-reasoning models", async () => {

--- a/packages/coding-agent/test/issue-esc-abort-tree-persistence-repro.test.ts
+++ b/packages/coding-agent/test/issue-esc-abort-tree-persistence-repro.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { Effort, ModelUsageHealth } from "@oh-my-pi/pi-ai";
+import * as autoThinkingClassifier from "@oh-my-pi/pi-coding-agent/auto-thinking/classifier";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Installs a classifier mock that never resolves on its own -- it only
+ * settles (by rejecting) once its own `AbortSignal` fires. Returns a promise
+ * that resolves with that signal the instant the classifier is actually
+ * invoked, so callers can await the real event instead of polling/sleeping.
+ */
+function mockHangingClassifier(): Promise<AbortSignal | undefined> {
+	const { promise: signalCaptured, resolve: onSignalCaptured } = Promise.withResolvers<AbortSignal | undefined>();
+	vi.spyOn(autoThinkingClassifier, "classifyDifficulty").mockImplementation((_text, options) => {
+		const { promise, reject } = Promise.withResolvers<Effort>();
+		options.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+		onSignalCaptured(options.signal);
+		return promise;
+	});
+	return signalCaptured;
+}
+
+/**
+ * Same shape as {@link mockHangingClassifier}, for the *usage-aware preflight*
+ * window instead: `#runUsageAwarePreflight` runs before every generation
+ * checkpoint in the pre-flight chain and reports an abort as a plain `false`
+ * return rather than letting the next checkpoint observe the bumped
+ * generation, so it needs its own coverage.
+ */
+function mockHangingUsageHealth(storage: AuthStorage): Promise<AbortSignal | undefined> {
+	const { promise: signalCaptured, resolve: onSignalCaptured } = Promise.withResolvers<AbortSignal | undefined>();
+	vi.spyOn(storage, "getModelUsageHealth").mockImplementation((_provider, options) => {
+		const { promise, reject } = Promise.withResolvers<ModelUsageHealth>();
+		options.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+		onSignalCaptured(options.signal);
+		return promise;
+	});
+	return signalCaptured;
+}
+
+/**
+ * Reproduces the original report: pressing Escape immediately after sending a
+ * message races `AgentSession#promptWithMessage`'s pre-flight chain (see
+ * `issue-esc-optimistic-leak-repro.test.ts` for the full chain description).
+ * Patch 0009 fixed the UI-side symptoms (stuck optimistic row, frozen loader),
+ * but the underlying bail-out still just `return`s -- the user's message never
+ * reaches `agent.prompt()`, so it's never persisted via
+ * `sessionManager.appendMessage()`. It has no node in the session tree at all,
+ * so `/tree` can't reach it and there is nothing to undo: exactly the
+ * "doesn't get added to the conversation tree so you can't undo it" bug.
+ *
+ * The auto-thinking classifier call is the realistic way this window gets hit
+ * live (a several-hundred-ms local-model-load/classify round trip), so this
+ * drives the race the same way the classifier-cancellation regression test in
+ * `agent-session-role-thinking.test.ts` does: mock the classifier to hang
+ * until its signal aborts, then call `session.abort()` while the prompt is
+ * still inside that window.
+ */
+describe("Esc-abort before agent.prompt() still lands the message in the tree", () => {
+	let authStorage: AuthStorage;
+	let settings: Settings;
+	let session: AgentSession;
+	let tempDir: TempDir;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-issue-esc-tree-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 test model");
+
+		settings = Settings.isolated();
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings,
+			modelRegistry,
+		});
+		session.setThinkingLevel(AUTO_THINKING);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	it("commits the user message and an aborted assistant turn instead of discarding it", async () => {
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		const signalCaptured = mockHangingClassifier();
+		expect(session.isAutoThinking).toBe(true);
+
+		const promptPromise = session.prompt("Say the word banana.");
+		const signal = await signalCaptured;
+
+		await session.abort({ reason: "test interrupt" });
+		await promptPromise;
+
+		expect(signal?.aborted).toBe(true);
+		// The regression: this used to be `[]` -- the message vanished with no
+		// trace, unreachable from `/tree` and impossible to undo.
+		expect(session.messages).toHaveLength(2);
+		const [userMessage, assistantMessage] = session.messages;
+		if (userMessage?.role !== "user") throw new Error("Expected committed user message");
+		expect(userMessage.content).toEqual([{ type: "text", text: "Say the word banana." }]);
+		if (assistantMessage?.role !== "assistant") throw new Error("Expected committed assistant message");
+		expect(assistantMessage.stopReason).toBe("aborted");
+	});
+	it("commits the message when the abort lands inside the usage-aware preflight", async () => {
+		// `retry.usageAwareFallback` is off by default, which makes the preflight a
+		// pair of setting reads; enabling it is what opens the real window (a
+		// `getModelUsageHealth` round trip per fallback candidate).
+		settings.set("retry.usageAwareFallback", true);
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		const signalCaptured = mockHangingUsageHealth(authStorage);
+
+		const promptPromise = session.prompt("Say the word banana.");
+		const signal = await signalCaptured;
+
+		await session.abort({ reason: "test interrupt" });
+		await promptPromise;
+
+		expect(signal?.aborted).toBe(true);
+		expect(session.messages).toHaveLength(2);
+		const [userMessage, assistantMessage] = session.messages;
+		if (userMessage?.role !== "user") throw new Error("Expected committed user message");
+		expect(userMessage.content).toEqual([{ type: "text", text: "Say the word banana." }]);
+		if (assistantMessage?.role !== "assistant") throw new Error("Expected committed assistant message");
+		expect(assistantMessage.stopReason).toBe("aborted");
+	});
+});

--- a/packages/coding-agent/test/issue-esc-optimistic-leak-repro.test.ts
+++ b/packages/coding-agent/test/issue-esc-optimistic-leak-repro.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, type Mock, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { submitInteractiveInput } from "@oh-my-pi/pi-coding-agent/main";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Reproduces two related bugs in the optimistic-row lifecycle around
+ * `AgentSession#promptWithMessage`'s pre-flight chain (recovery/preflight
+ * checks, bash/eval/irc flush, compaction check, plan/goal/vibe message
+ * building, before_agent_start extension hook, auto-thinking classification)
+ * that runs before `agent.prompt()` ever commits the user's message:
+ *
+ * 1. Escape racing this chain bumps `#promptGeneration` and bails out early
+ *    with a plain `return` (no throw), so `session.prompt()` resolves
+ *    normally with no `message_start`/`message_end` ever emitted and nothing
+ *    persisted to the session/conversation tree — but the optimistic row
+ *    `startPendingSubmission` painted must not be left dangling in
+ *    `chatContainer` (must go through `detachOptimisticUserMessage`).
+ * 2. The opposite case: once the REAL `message_start` for that exact text
+ *    lands, `EventController`'s `wasOptimistic` branch calls
+ *    `clearOptimisticUserMessage` to hand the row off to permanent history.
+ *    That row already shows the correct final content, so this must NOT
+ *    strip it from `chatContainer` too — the fix for (1) briefly collapsed
+ *    both methods into one DOM-removing implementation, which erased every
+ *    plain submission's own message from the transcript the instant its
+ *    turn started streaming.
+ */
+describe("Esc-abort before agent.prompt() commits the message", () => {
+	let authStorage: AuthStorage;
+	let mode: InteractiveMode;
+	let session: AgentSession;
+	let tempDir: TempDir;
+
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	beforeEach(async () => {
+		vi.spyOn(process.stdout, "write").mockReturnValue(true);
+		vi.spyOn(process.stdin, "resume").mockReturnValue(process.stdin);
+		vi.spyOn(process.stdin, "pause").mockReturnValue(process.stdin);
+		vi.spyOn(process.stdin, "setEncoding").mockReturnValue(process.stdin);
+		if (typeof process.stdin.setRawMode === "function") {
+			vi.spyOn(process.stdin, "setRawMode").mockReturnValue(process.stdin);
+		}
+
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-issue-esc-leak-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 test model");
+
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		mode.ui.requestRender = vi.fn();
+	});
+
+	afterEach(async () => {
+		mode?.stop();
+		vi.restoreAllMocks();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	it("removes the optimistic row from chatContainer, not just the bookkeeping array", async () => {
+		// Simulate AgentSession#promptWithMessage's generation-bail-out: it
+		// resolves `true` (as if the prompt were accepted) without ever calling
+		// `agent.prompt()`, so no message_start/message_end fires and nothing is
+		// persisted to the session — exactly what happens when abort() races the
+		// pre-flight setup ahead of the model call.
+		vi.spyOn(session, "prompt").mockResolvedValue(true);
+
+		const input = mode.startPendingSubmission({ text: "hello" });
+		expect(mode.chatContainer.children.length).toBe(1);
+		(mode.ui.requestRender as Mock<() => void>).mockClear();
+
+		await submitInteractiveInput(mode, session, input);
+
+		expect(mode.loadingAnimation).toBeUndefined();
+		expect(mode.chatContainer.children.length).toBe(0);
+		// Regression: this cleanup branch mutated chat/loader state without ever
+		// requesting a repaint, so the "Working... [esc]" loader stayed painted
+		// on screen until some unrelated event happened to trigger a render.
+		expect(mode.ui.requestRender).toHaveBeenCalled();
+	});
+
+	it("keeps the optimistic row on screen once its own message_start commits it", () => {
+		// EventController's wasOptimistic branch calls clearOptimisticUserMessage()
+		// when the real message_start for this exact text arrives. The row it
+		// already painted IS the correct permanent render, so this must be a pure
+		// bookkeeping reset — not a chatContainer mutation.
+		mode.startPendingSubmission({ text: "hello" });
+		expect(mode.chatContainer.children.length).toBe(1);
+
+		mode.clearOptimisticUserMessage();
+
+		expect(mode.chatContainer.children.length).toBe(1);
+		expect(mode.optimisticUserMessageSignature).toBeUndefined();
+	});
+
+	it("removes the optimistic row when showError abandons the submission", () => {
+		// The other half of the same contract, through the second call site that
+		// needs it: showError() fires when the prompt throws before the message
+		// could be committed (e.g. "No API key found"), so no real message_start
+		// will ever arrive to replace the row it painted.
+		mode.startPendingSubmission({ text: "hello" });
+		expect(mode.chatContainer.children.length).toBe(1);
+		const optimisticRow = mode.chatContainer.children[0];
+
+		mode.showError("No API key found");
+
+		// showError renders its own error output into the chat, so assert on the
+		// row's identity rather than a child count: the abandoned optimistic row
+		// specifically must be gone.
+		expect(mode.chatContainer.children).not.toContain(optimisticRow);
+		expect(mode.optimisticUserMessageSignature).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What

Five symptoms of one race. Pressing Escape immediately after Enter aborts `AgentSession#promptWithMessage` while it is still in its async pre-flight chain, before it reaches `agent.prompt()` — the call that would have committed the turn via `sessionManager.appendMessage()`. Its bail-out checkpoints return plainly once `#promptGeneration` no longer matches the generation captured at entry, which is exactly what `abort()` causes.

- **The message was discarded outright** — no node in the session tree, unreachable from `/tree`, nothing to undo. It is now captured in `#pendingUncommittedPrompt` on entry and committed by each bail-out as a genuine aborted turn (the user's message plus an empty `stopReason: "aborted"` assistant reply parented off it), driven through the same `#handleAgentEvent` pipeline a real agent-emitted event uses, so no new rendering path is introduced. With no model resolved there is no identity to attribute a synthetic reply to, so only the user's own message commits. The slot is generation-scoped, and cleared both on hand-off to `agent.prompt()` and in `finally`.
- **`#runUsageAwarePreflight()` returning `false` was the one early return in that window that committed nothing**, and `abort()` reaches it: it aborts every controller in `#usagePreflightAbortControllers` — which that preflight registers its own into — as well as bumping the generation, so an Escape inside the preflight surfaced as a plain `false` and returned before any checkpoint could observe the bump. It now commits too, gated on the generation having actually moved, so the commit stays tied to a real abort rather than to any `false`.
- **The optimistic user-message row was left dangling in `chatContainer`.** Only `replaceOptimisticUserMessage()` or `cancelPendingSubmission()`'s `rebuildChatFromMessages()` ever detached it, and neither runs on this path. A new `detachOptimisticUserMessage()` does the bookkeeping reset *and* removes the row, at the four call sites where no real message will ever replace it; `clearOptimisticUserMessage()` keeps its bookkeeping-only contract for `EventController`'s `wasOptimistic` branch, where the already-rendered row *is* the correct permanent render. One of those four is `showError()`, which is off the Escape path but shares the same dangling-row bug once the clear/detach distinction exists — flagging it explicitly since it is the one hunk not reachable from the reported symptom.
- **A `Working… [esc]` loader could sit frozen on screen**, because `finishPendingSubmission()`'s cleanup branch mutated chat/loader state without requesting a repaint, unlike its sibling mutators.
- **Escape could appear to do nothing for seconds**: the auto-thinking classifier call was bounded only by its own internal timeout, unrelated to the turn's abort, so the bail-out right after it could not run until that elapsed. It now takes the turn's abort signal, combined with its own timeout via `AbortSignal.any`.

Behavior change worth flagging: an Escape-raced pre-flight bail-out now persists two entries where it previously persisted none, in every head that calls `promptWithMessage` (not just the interactive TUI). Anything asserting that an aborted-before-dispatch turn leaves a session empty would need updating.

## Why

I'm used to Claude Code, where pressing `Escape` after submitting a prompt — but before any visible response — acts as if you never sent it and puts the prompt back in the input field. `oh-my-pi` is inconsistent here, and which behavior you get depends on whether the abort lands while the turn is still in pre-flight rather than on how fast you were: that window is normally held open by the auto-thinking classifier's round trip, so a local or slow classifier widens it and a fast one can close it before you ever get the chance. Land inside it and the TUI partially freezes — the loader keeps spinning, the row never repaints — and the message is discarded outright, unreachable from `/tree` and impossible to undo. Land after dispatch and you get the sane outcome instead: an aborted turn that's still there in `/tree`. This PR makes that second outcome happen every time. I went with persisting the aborted turn rather than Claude Code's restore-to-input because it keeps the message recoverable and matches what `oh-my-pi` already does for a mid-stream abort — happy to reshape it if you'd rather the input were restored.

Related in-flight work, no issue filed for this bug: #3864 (`defer auto-thinking classifier`) touches the same `agent-session.ts` pre-flight region and `agent-session-role-thinking.test.ts`, so it will likely conflict textually and would also narrow the window this race normally opens in; #6392 (`usage-aware model fallback`) owns the preflight whose `false` return is fixed in the second bullet above. The CHANGELOG entries deliberately carry no attribution yet, since `AGENTS.md`'s external-contribution format needs this PR's own number — happy to push that as a follow-up commit once it exists.

## Testing

Reproduced against pristine `main` (8baa330), then re-verified with the fix applied. The pre-flight window is normally opened by the auto-thinking classifier's local-model round trip; to make it deterministic the window was widened with a scratch `before_agent_start` extension sleeping 3s, the real TUI launched from source in tmux, a message sent, and Escape pressed 1s later:

| | pristine `main` | this branch |
|---|---|---|
| transcript row after abort | still on screen, phantom | still on screen, now backed by a committed message |
| `Working… [esc]` loader | still spinning 9s after Escape | gone |
| `/tree` | `(0/1)` — no navigable turn | `user: Say the word banana.` + `assistant: (aborted)` |
| persisted session JSONL | **no session file created at all** | both messages, `stopReason: "aborted"` on the assistant entry |

Unit tests in `packages/coding-agent`, each confirmed red before the corresponding hunk and green after:

- `test/issue-esc-abort-tree-persistence-repro.test.ts` — drives the real `AgentSession`, hangs the classifier until its signal aborts, aborts mid-window, and asserts the committed user + aborted-assistant pair (red baseline: `session.messages` was empty). A second case covers the usage-preflight return with `retry.usageAwareFallback` enabled and `getModelUsageHealth` hung on its signal.
- `test/issue-esc-optimistic-leak-repro.test.ts` — pins both halves of the clear-vs-detach contract, asserts the repaint request, and covers the `showError()` call site by row identity (it renders its own error output into the chat, so a child count would not express it).
- `test/agent-session-role-thinking.test.ts` — gains a case asserting the classifier's signal is actually aborted by `session.abort()`.
- 27 pass across those three files. Full `bun test test/agent-session` sweep: **626 pass / 10 fail** here vs **625 pass / 10 fail** on pristine `main` — the same 10 pre-existing failures (bundled test-model catalog lacks `gpt-5.5` / `gpt-5.6-sol`), delta is exactly the one added test.
- `bun run check:types` (tsgo) in `packages/coding-agent`: clean.

Not run: `bun check` in full — biome's bundled `@biomejs/cli-linux-x64` binary is dynamically linked and will not execute on this NixOS host. Added lines were hand-checked against `biome.json`'s 120-column limit at `indentWidth: 3`, but formatting and lint are unverified; happy to fix whatever CI flags.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
