### PR TITLE
fix(coding-agent): preserve explicit extensions in isolation

### DIFF
--- a/docs/extension-loading.md
+++ b/docs/extension-loading.md
@@ -98,8 +98,19 @@ extensions:
 
 Behavior split:
 
-- SDK: when `disableExtensionDiscovery=true`, it still loads `additionalExtensionPaths` via `loadExtensions()`.
-- CLI path building (`main.ts`) currently clears CLI extension paths when `--no-extensions` is set, so explicit `-e/--hook` are not forwarded in that mode.
+- SDK: when `disableExtensionDiscovery=true`, ambient extension factories are
+  excluded, while `additionalExtensionPaths` are still resolved normally
+  (including package directories with `package.json#omp.extensions`).
+- CLI: `--no-extensions` follows the same explicit-only contract. Explicit
+  `-e/--extension` and `--hook` paths still load, and only sibling capability
+  roots from explicitly named extension packages remain eligible. Project/user
+  `extensions:` settings and installed OMP extension packages are excluded from
+  that sibling surface.
+
+This flag governs extension factories and OMP extension-package sibling roots;
+it is not a whole-process capability-isolation switch. Skills, MCP servers,
+tools, prompts, and rules owned by other discovery subsystems retain their own
+enable/disable controls.
 
 ### Disable specific extension modules
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -681,6 +681,11 @@
 - Fixed the Cursor-backed advisor losing entire turns when it selected server-native tools (`bash`, `grep`, etc.) outside its grant: exec-resolved native blocks are already rejected in-band by the advisor-scoped bridge, so they no longer trip the unavailable-tool quarantine and discard the `advise` emitted in the same turn ([#5900](https://github.com/can1357/oh-my-pi/issues/5900)).
 - Fixed custom `anthropic-messages` OAuth providers being unable to opt into configured Claude Code fingerprint header overrides. ([#5888](https://github.com/can1357/oh-my-pi/issues/5888))
 - Fixed authoritative providers (e.g. `openai-codex`) keeping unsupported bundled models selectable when a fresh model cache and an expired OAuth token coincided: built-in discovery now forces the OAuth refresh so the provider's model manager is constructed and prunes stale bundled entries (e.g. `gpt-5.4-nano`) instead of waiting out the cache TTL. ([#5364](https://github.com/can1357/oh-my-pi/issues/5364))
+### Fixed
+
+- Preserved explicit `-e`/`--extension` and `--hook` packages under
+  `--no-extensions` while excluding ambient extension factories and sibling
+  capabilities from settings or installed OMP packages.
 
 ## [17.0.5] - 2026-07-18
 

--- a/packages/coding-agent/src/cli/models-cli.ts
+++ b/packages/coding-agent/src/cli/models-cli.ts
@@ -17,12 +17,7 @@ import { formatNumber, getProjectDir } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import { ModelRegistry } from "../config/model-registry";
 import { Settings } from "../config/settings";
-import {
-	discoverAndLoadExtensions,
-	ExtensionRunner,
-	emitSessionShutdownEvent,
-	loadExtensions,
-} from "../extensibility/extensions";
+import { discoverAndLoadExtensions, ExtensionRunner, emitSessionShutdownEvent } from "../extensibility/extensions";
 import { discoverAuthStorage } from "../sdk";
 import { SessionManager } from "../session/session-manager";
 import { EventBus } from "../utils/event-bus";
@@ -283,7 +278,7 @@ export interface RunModelsListingOptions {
 	settingsExtensions?: string[];
 	/** Disabled extension ids from settings (`disabledExtensions`). */
 	disabledExtensionIds?: string[];
-	/** When true, skip discovery and only load `additionalExtensionPaths`. */
+	/** When true, exclude ambient factories and resolve only `additionalExtensionPaths`. */
 	disableExtensionDiscovery?: boolean;
 }
 
@@ -301,14 +296,16 @@ export async function runModelsListing(options: RunModelsListingOptions): Promis
 	} = options;
 
 	const eventBus = new EventBus();
-	const extensionsResult = disableExtensionDiscovery
-		? await loadExtensions(additionalExtensionPaths, cwd, eventBus)
-		: await discoverAndLoadExtensions(
-				[...additionalExtensionPaths, ...settingsExtensions],
-				cwd,
-				eventBus,
-				disabledExtensionIds,
-			);
+	const configuredPaths = disableExtensionDiscovery
+		? additionalExtensionPaths
+		: [...additionalExtensionPaths, ...settingsExtensions];
+	const extensionsResult = await discoverAndLoadExtensions(
+		configuredPaths,
+		cwd,
+		eventBus,
+		disableExtensionDiscovery ? undefined : disabledExtensionIds,
+		{ ambient: !disableExtensionDiscovery },
+	);
 	const extensionRunner =
 		extensionsResult.extensions.length > 0
 			? new ExtensionRunner(
@@ -370,7 +367,7 @@ export async function runModelsCommand(command: ModelsCommandArgs): Promise<void
 		}
 		await modelRegistry.refresh(action === "refresh" ? "online" : "online-if-uncached");
 
-		const cliExtensionPaths = command.flags.noExtensions ? [] : (command.flags.extensions ?? []);
+		const cliExtensionPaths = command.flags.extensions ?? [];
 		await runModelsListing({
 			modelRegistry,
 			cwd,

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -15,6 +15,7 @@
  * @see ./omp-plugins.ts
  * @see ./builtin.ts `loadExtensionModules`
  */
+import { AsyncLocalStorage } from "node:async_hooks";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir, isEnoent, logger, tryParseJson } from "@oh-my-pi/pi-utils";
@@ -41,8 +42,18 @@ interface InjectedRoot {
 	level: "user" | "project";
 }
 
+export type OmpExtensionRootMode = "merge" | "explicit-only";
+
+interface InvocationRootScope {
+	/** Raw SDK spellings, resolved against the LoadContext that performs discovery. */
+	paths: readonly string[];
+	mode: OmpExtensionRootMode;
+}
+
+const invocationRootScope = new AsyncLocalStorage<InvocationRootScope>();
+
 let injectedCliRoots: InjectedRoot[] = [];
-let injectedCliRootMode: "merge" | "explicit-only" = "merge";
+let injectedCliRootMode: OmpExtensionRootMode = "merge";
 
 export interface InjectOmpExtensionCliRootOptions {
 	/**
@@ -50,9 +61,23 @@ export interface InjectOmpExtensionCliRootOptions {
 	 * with `--no-extensions` so configured and installed packages cannot
 	 * contribute sibling capabilities through the `omp-plugins` provider.
 	 */
-	mode?: "merge" | "explicit-only";
+	mode?: OmpExtensionRootMode;
 	/** Replace roots from an earlier invocation instead of extending them. */
 	replace?: boolean;
+}
+
+/**
+ * Run one SDK invocation with its own extension-package roots. Async resources
+ * started inside `callback` retain this scope, including discovery deliberately
+ * deferred until the end of session startup. Raw relative paths are resolved by
+ * {@link listOmpExtensionRoots} against that invocation's active cwd.
+ */
+export function withOmpExtensionRootScope<T>(
+	paths: readonly string[],
+	mode: OmpExtensionRootMode,
+	callback: () => T,
+): T {
+	return invocationRootScope.run({ paths: [...paths], mode }, callback);
 }
 
 /**
@@ -146,7 +171,8 @@ async function isDirectory(p: string): Promise<boolean> {
  * Sources, in order of precedence (later entries with the same absolute path
  * are dropped):
  *
- * 1. CLI roots injected via {@link injectOmpExtensionCliRoots}
+ * 1. Invocation-scoped SDK roots, when present; otherwise CLI roots injected
+ *    via {@link injectOmpExtensionCliRoots}
  * 2. Project `<cwd>/.omp/settings.json#extensions`
  * 3. User `~/.omp/agent/settings.json#extensions`
  * 4. Enabled npm/link plugins installed under `<plugins>/node_modules/` (for
@@ -159,10 +185,14 @@ async function isDirectory(p: string): Promise<boolean> {
  * other sources still surface.
  */
 export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtensionRoot[]> {
-	let candidates: InjectedRoot[] = injectedCliRoots.map(root =>
-		root.relativePath ? { ...root, path: path.resolve(ctx.cwd, root.relativePath) } : root,
-	);
-	if (injectedCliRootMode === "merge") {
+	const scopedRoots = invocationRootScope.getStore();
+	const rootMode = scopedRoots?.mode ?? injectedCliRootMode;
+	let candidates: InjectedRoot[] = scopedRoots
+		? scopedRoots.paths.map(raw => ({ path: resolveAgainst(raw, ctx), level: "user" }))
+		: injectedCliRoots.map(root =>
+				root.relativePath ? { ...root, path: path.resolve(ctx.cwd, root.relativePath) } : root,
+			);
+	if (rootMode === "merge") {
 		const { project, user } = scopeDirs(ctx);
 		const [projectExtensions, userExtensions, installedPlugins] = await Promise.all([
 			readSettingsExtensions(path.join(project, "settings.json")),
@@ -177,7 +207,7 @@ export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtens
 		];
 	}
 
-	// First-seen-wins dedup preserves CLI > project-settings > user-settings > installed precedence.
+	// First-seen-wins dedup preserves invocation/CLI > project-settings > user-settings > installed precedence.
 	const seen = new Set<string>();
 	const unique: InjectedRoot[] = [];
 	for (const candidate of candidates) {

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -40,6 +40,18 @@ interface InjectedRoot {
 }
 
 let injectedCliRoots: InjectedRoot[] = [];
+let injectedCliRootMode: "merge" | "explicit-only" = "merge";
+
+export interface InjectOmpExtensionCliRootOptions {
+	/**
+	 * `explicit-only` exposes only roots named by this CLI invocation. Use it
+	 * with `--no-extensions` so configured and installed packages cannot
+	 * contribute sibling capabilities through the `omp-plugins` provider.
+	 */
+	mode?: "merge" | "explicit-only";
+	/** Replace roots from an earlier invocation instead of extending them. */
+	replace?: boolean;
+}
 
 /**
  * Register CLI-provided extension package paths (e.g. from `--extension`/`-e`)
@@ -50,7 +62,14 @@ let injectedCliRoots: InjectedRoot[] = [];
  * Call once during startup before any capability load. Repeated calls extend
  * the registered set; {@link clearOmpExtensionCliRoots} resets for tests.
  */
-export function injectOmpExtensionCliRoots(paths: readonly string[], home: string, cwd: string): void {
+export function injectOmpExtensionCliRoots(
+	paths: readonly string[],
+	home: string,
+	cwd: string,
+	options: InjectOmpExtensionCliRootOptions = {},
+): void {
+	if (options.mode) injectedCliRootMode = options.mode;
+	if (options.replace) injectedCliRoots = [];
 	if (paths.length === 0) return;
 	const expanded = paths.map(raw => {
 		const tilde = expandTilde(raw, home);
@@ -68,6 +87,7 @@ export function injectOmpExtensionCliRoots(paths: readonly string[], home: strin
 /** Drop every CLI-injected root. Tests use this between cases. */
 export function clearOmpExtensionCliRoots(): void {
 	injectedCliRoots = [];
+	injectedCliRootMode = "merge";
 }
 
 /** Inspect currently-injected CLI roots (read-only). Exposed for diagnostics + tests. */
@@ -134,19 +154,21 @@ async function isDirectory(p: string): Promise<boolean> {
  * other sources still surface.
  */
 export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtensionRoot[]> {
-	const { project, user } = scopeDirs(ctx);
-	const [projectExtensions, userExtensions, installedPlugins] = await Promise.all([
-		readSettingsExtensions(path.join(project, "settings.json")),
-		readSettingsExtensions(path.join(user, "settings.json")),
-		listInstalledPluginRoots(ctx),
-	]);
-
-	const candidates: InjectedRoot[] = [
-		...injectedCliRoots,
-		...projectExtensions.map((raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: "project" })),
-		...userExtensions.map((raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: "user" })),
-		...installedPlugins,
-	];
+	let candidates: InjectedRoot[] = [...injectedCliRoots];
+	if (injectedCliRootMode === "merge") {
+		const { project, user } = scopeDirs(ctx);
+		const [projectExtensions, userExtensions, installedPlugins] = await Promise.all([
+			readSettingsExtensions(path.join(project, "settings.json")),
+			readSettingsExtensions(path.join(user, "settings.json")),
+			listInstalledPluginRoots(ctx),
+		]);
+		candidates = [
+			...candidates,
+			...projectExtensions.map((raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: "project" })),
+			...userExtensions.map((raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: "user" })),
+			...installedPlugins,
+		];
+	}
 
 	// First-seen-wins dedup preserves CLI > project-settings > user-settings > installed precedence.
 	const seen = new Set<string>();

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -36,6 +36,8 @@ export interface OmpExtensionRoot {
 
 interface InjectedRoot {
 	path: string;
+	/** Relative CLI spelling, rebound against the active project on discovery. */
+	relativePath?: string;
 	level: "user" | "project";
 }
 
@@ -73,13 +75,16 @@ export function injectOmpExtensionCliRoots(
 	if (paths.length === 0) return;
 	const expanded = paths.map(raw => {
 		const tilde = expandTilde(raw, home);
-		return path.isAbsolute(tilde) ? tilde : path.resolve(cwd, tilde);
+		return {
+			path: path.isAbsolute(tilde) ? tilde : path.resolve(cwd, tilde),
+			relativePath: path.isAbsolute(tilde) ? undefined : tilde,
+		};
 	});
 	const merged = new Map<string, InjectedRoot>();
 	for (const root of injectedCliRoots) merged.set(root.path, root);
-	for (const resolved of expanded) {
+	for (const { path: resolved, relativePath } of expanded) {
 		// CLI scope mirrors how `--extension` is treated elsewhere — user-level overrides win.
-		if (!merged.has(resolved)) merged.set(resolved, { path: resolved, level: "user" });
+		if (!merged.has(resolved)) merged.set(resolved, { path: resolved, relativePath, level: "user" });
 	}
 	injectedCliRoots = [...merged.values()];
 }
@@ -154,7 +159,9 @@ async function isDirectory(p: string): Promise<boolean> {
  * other sources still surface.
  */
 export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtensionRoot[]> {
-	let candidates: InjectedRoot[] = [...injectedCliRoots];
+	let candidates: InjectedRoot[] = injectedCliRoots.map(root =>
+		root.relativePath ? { ...root, path: path.resolve(ctx.cwd, root.relativePath) } : root,
+	);
 	if (injectedCliRootMode === "merge") {
 		const { project, user } = scopeDirs(ctx);
 		const [projectExtensions, userExtensions, installedPlugins] = await Promise.all([

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -522,10 +522,16 @@ async function discoverExtensionsInDir(dir: string): Promise<string[]> {
  * `LoadExtensionsResult` directly would reuse handlers/tools/commands that
  * closed over the parent's `cwd` and event bus.
  */
+export interface DiscoverExtensionPathOptions {
+	/** Include ambient native extensions, hooks, and installed plugins. */
+	ambient?: boolean;
+}
+
 export async function discoverExtensionPaths(
 	configuredPaths: string[],
 	cwd: string,
 	disabledExtensionIds?: string[],
+	options: DiscoverExtensionPathOptions = {},
 ): Promise<string[]> {
 	const allPaths: string[] = [];
 	const seen = new Set<string>();
@@ -549,33 +555,41 @@ export async function discoverExtensionPaths(
 		}
 	};
 
-	// 1. Discover extension modules via capability API (native .omp/.pi only).
-	// Scope the load to the native provider — the extension-module capability
-	// also has claude/codex/gemini/opencode providers, and their items were
-	// discarded here anyway (see #4198). The provider filter skips the walk
-	// entirely instead of running four foreign directory scans and dropping
-	// the results.
-	const discovered = await loadCapability<ExtensionModule>(extensionModuleCapability.id, {
-		...loadOptions,
-		providers: ["native"],
-	});
-	for (const ext of discovered.items) {
-		addPath(ext.path);
+	const ambient = options.ambient !== false;
+	if (ambient) {
+		// 1. Discover extension modules via capability API (native .omp/.pi only).
+		// Scope the load to the native provider — the extension-module capability
+		// also has claude/codex/gemini/opencode providers, and their items were
+		// discarded here anyway (see #4198). The provider filter skips the walk
+		// entirely instead of running four foreign directory scans and dropping
+		// the results.
+		const discovered = await loadCapability<ExtensionModule>(extensionModuleCapability.id, {
+			...loadOptions,
+			providers: ["native"],
+		});
+		for (const ext of discovered.items) {
+			addPath(ext.path);
+		}
 	}
 
-	// 2. Discover JS/TS hook factories from hookCapability and bind them through
-	// the extension runner, which owns the current runtime event bus. Hook
-	// capability loading already applies hook-specific disabled ids; do not also
-	// filter them through extension-module names.
-	const hooks = await loadCapability<Hook>(hookCapability.id, loadOptions);
+	// 2. Discover JS/TS hook factories and bind them through the extension
+	// runner, which owns the current runtime event bus. Explicit-only discovery
+	// still loads hooks from explicitly injected OMP package roots, while
+	// excluding every ambient hook provider.
+	const hooks = await loadCapability<Hook>(
+		hookCapability.id,
+		ambient ? loadOptions : { ...loadOptions, providers: ["omp-plugins"] },
+	);
 	for (const hookPath of hooks.items
 		.map(hook => hook.path)
 		.filter(hookPath => isExtensionFile(path.basename(hookPath)))) {
 		addPath(hookPath);
 	}
 
-	// 3. Discover extension entry points from installed plugins
-	addPaths(await getAllPluginExtensionPaths(cwd));
+	// 3. Discover extension entry points from installed plugins.
+	if (ambient) {
+		addPaths(await getAllPluginExtensionPaths(cwd));
+	}
 
 	// 4. Explicitly configured paths
 	for (const configuredPath of configuredPaths) {
@@ -618,7 +632,8 @@ export async function discoverAndLoadExtensions(
 	cwd: string,
 	eventBus?: EventBus,
 	disabledExtensionIds?: string[],
+	options: DiscoverExtensionPathOptions = {},
 ): Promise<LoadExtensionsResult> {
-	const paths = await discoverExtensionPaths(configuredPaths, cwd, disabledExtensionIds);
+	const paths = await discoverExtensionPaths(configuredPaths, cwd, disabledExtensionIds, options);
 	return loadExtensions(paths, cwd, eventBus);
 }

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -517,7 +517,7 @@ async function discoverHooksInPackageRoot(root: string): Promise<string[]> {
 		try {
 			entries = await fs.readdir(hookDir, { withFileTypes: true });
 		} catch (err) {
-			if (isEnoent(err) || hasFsCode(err, "ENOTDIR")) continue;
+			if (isEnoent(err) || isEacces(err) || hasFsCode(err, "ENOTDIR") || hasFsCode(err, "EPERM")) continue;
 			throw err;
 		}
 		for (const entry of entries) {

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -509,6 +509,26 @@ async function discoverExtensionsInDir(dir: string): Promise<string[]> {
 
 	return discovered;
 }
+async function discoverHooksInPackageRoot(root: string): Promise<string[]> {
+	const hooks: string[] = [];
+	for (const hookType of ["pre", "post"]) {
+		const hookDir = path.join(root, "hooks", hookType);
+		let entries: fs1.Dirent[];
+		try {
+			entries = await fs.readdir(hookDir, { withFileTypes: true });
+		} catch (err) {
+			if (isEnoent(err) || hasFsCode(err, "ENOTDIR")) continue;
+			throw err;
+		}
+		for (const entry of entries) {
+			if ((entry.isFile() || entry.isSymbolicLink()) && isExtensionFile(entry.name)) {
+				hooks.push(path.join(hookDir, entry.name));
+			}
+		}
+	}
+	return hooks;
+}
+
 /**
  * Discover absolute paths of extensions to load, without importing or
  * binding factories. Hot path on session startup — the scan walks native
@@ -573,17 +593,20 @@ export async function discoverExtensionPaths(
 	}
 
 	// 2. Discover JS/TS hook factories and bind them through the extension
-	// runner, which owns the current runtime event bus. Explicit-only discovery
-	// still loads hooks from explicitly injected OMP package roots, while
-	// excluding every ambient hook provider.
-	const hooks = await loadCapability<Hook>(
-		hookCapability.id,
-		ambient ? loadOptions : { ...loadOptions, providers: ["omp-plugins"] },
-	);
-	for (const hookPath of hooks.items
-		.map(hook => hook.path)
-		.filter(hookPath => isExtensionFile(path.basename(hookPath)))) {
-		addPath(hookPath);
+	// runner, which owns the current runtime event bus. Non-ambient discovery
+	// scans only this invocation's configured package roots; it must not consult
+	// settings, installed packages, or process-global CLI injection state.
+	if (ambient) {
+		const hooks = await loadCapability<Hook>(hookCapability.id, loadOptions);
+		for (const hookPath of hooks.items
+			.map(hook => hook.path)
+			.filter(hookPath => isExtensionFile(path.basename(hookPath)))) {
+			addPath(hookPath);
+		}
+	} else {
+		for (const configuredPath of configuredPaths) {
+			addPaths(await discoverHooksInPackageRoot(resolvePath(configuredPath, cwd)));
+		}
 	}
 
 	// 3. Discover extension entry points from installed plugins.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1110,14 +1110,13 @@ export async function buildSessionOptions(
 	}
 
 	// Additional extension paths from CLI
-	const cliExtensionPaths = parsed.noExtensions ? [] : [...(parsed.extensions ?? []), ...(parsed.hooks ?? [])];
+	const cliExtensionPaths = [...(parsed.extensions ?? []), ...(parsed.hooks ?? [])];
 	if (cliExtensionPaths.length > 0) {
 		options.additionalExtensionPaths = cliExtensionPaths;
 	}
 
 	if (parsed.noExtensions) {
 		options.disableExtensionDiscovery = true;
-		options.additionalExtensionPaths = [];
 	}
 
 	return options;
@@ -1197,13 +1196,13 @@ export async function runRootCommand(
 	// Register CLI-provided extension package paths (`--extension`, `--hook`) so
 	// the `omp-plugins` discovery provider can surface their `skills/`, `hooks/`,
 	// `tools/`, `commands/`, `rules/`, `prompts/`, and `.mcp.json` sub-trees.
-	// `--no-extensions` short-circuits both the factory load and the sub-discovery.
-	if (!parsedArgs.noExtensions) {
-		const cliExtensions = [...(parsedArgs.extensions ?? []), ...(parsedArgs.hooks ?? [])];
-		if (cliExtensions.length > 0) {
-			injectOmpExtensionCliRoots(cliExtensions, home, getProjectDir());
-		}
-	}
+	// Explicit roots remain authorized under `--no-extensions`; only ambient
+	// extension discovery is disabled.
+	const cliExtensions = [...(parsedArgs.extensions ?? []), ...(parsedArgs.hooks ?? [])];
+	injectOmpExtensionCliRoots(cliExtensions, home, getProjectDir(), {
+		mode: parsedArgs.noExtensions ? "explicit-only" : "merge",
+		replace: true,
+	});
 
 	let cwd = getProjectDir();
 	const settingsInstance =

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -66,6 +66,7 @@ import { CursorExecHandlers, type CursorMcpResourceAdapter } from "./cursor";
 import { createBridgeEditTool, createBridgeGrepFactory } from "./cursor-bridge-tools";
 import "./discovery";
 import { initializeWithSettings } from "./discovery";
+import { withOmpExtensionRootScope } from "./discovery/omp-extension-roots";
 import { disposeAllJuliaKernelSessions, disposeJuliaKernelSessionsByOwner } from "./eval/jl/executor";
 import { disposeVmContextsByOwner } from "./eval/js/context-manager";
 import { disposeAllKernelSessions, disposeKernelSessionsByOwner } from "./eval/py/executor";
@@ -1217,6 +1218,13 @@ export function createAutoLearnCaptureRunner(
  * ```
  */
 export async function createAgentSession(options: CreateAgentSessionOptions = {}): Promise<CreateAgentSessionResult> {
+	const rootMode = options.disableExtensionDiscovery ? "explicit-only" : "merge";
+	return await withOmpExtensionRootScope(options.additionalExtensionPaths ?? [], rootMode, () =>
+		createAgentSessionScoped(options),
+	);
+}
+
+async function createAgentSessionScoped(options: CreateAgentSessionOptions): Promise<CreateAgentSessionResult> {
 	const cwd = options.cwd ?? getProjectDir();
 	const agentDir = options.agentDir ?? getAgentDir();
 	const eventBus = options.eventBus ?? new EventBus();

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -695,12 +695,15 @@ export async function discoverSessionExtensionPaths(
 	cwd: string,
 	settings: Settings,
 ): Promise<string[]> {
-	if (options.disableExtensionDiscovery) {
-		return options.additionalExtensionPaths ?? [];
-	}
-	const configuredPaths = [...(options.additionalExtensionPaths ?? []), ...(settings.get("extensions") ?? [])];
-	const disabledExtensionIds = settings.get("disabledExtensions") ?? [];
-	return discoverExtensionPaths(configuredPaths, cwd, disabledExtensionIds);
+	const configuredPaths = options.disableExtensionDiscovery
+		? (options.additionalExtensionPaths ?? [])
+		: [...(options.additionalExtensionPaths ?? []), ...(settings.get("extensions") ?? [])];
+	const disabledExtensionIds = options.disableExtensionDiscovery
+		? undefined
+		: (settings.get("disabledExtensions") ?? []);
+	return discoverExtensionPaths(configuredPaths, cwd, disabledExtensionIds, {
+		ambient: !options.disableExtensionDiscovery,
+	});
 }
 
 /**

--- a/packages/coding-agent/test/cli-explicit-extension-isolation.test.ts
+++ b/packages/coding-agent/test/cli-explicit-extension-isolation.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { AuthStorage } from "@oh-my-pi/pi-ai";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { buildSessionOptions } from "@oh-my-pi/pi-coding-agent/main";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+let tempDir: TempDir;
+let authStorage: AuthStorage;
+
+beforeEach(async () => {
+	tempDir = await TempDir.create("@cli-explicit-extension-isolation-");
+	authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+});
+
+afterEach(async () => {
+	authStorage.close();
+	await tempDir.remove();
+});
+
+test("buildSessionOptions retains explicit extensions and hooks under --no-extensions", async () => {
+	const extensionPath = tempDir.join("extension-package");
+	const hookPath = tempDir.join("hook.ts");
+	const parsed = parseArgs(["--no-extensions", "--extension", extensionPath, "--hook", hookPath]);
+	const settings = Settings.isolated();
+	const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+
+	const options = await buildSessionOptions(parsed, [], SessionManager.inMemory(), modelRegistry, settings);
+
+	expect(options.disableExtensionDiscovery).toBe(true);
+	expect(options.additionalExtensionPaths).toEqual([extensionPath, hookPath]);
+});

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -31,7 +31,9 @@ import "@oh-my-pi/pi-coding-agent/discovery";
 import {
 	clearOmpExtensionCliRoots,
 	injectOmpExtensionCliRoots,
+	listOmpExtensionRoots,
 } from "@oh-my-pi/pi-coding-agent/discovery/omp-extension-roots";
+import { discoverExtensionPaths } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { getConfigRootDir, removeSyncWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
 const PROVIDER_ID = "omp-plugins";
@@ -62,21 +64,22 @@ async function loadFromPlugin<T>(capabilityId: string, ctx: LoadContext): Promis
 	return result.items as T[];
 }
 
-function buildExtensionPackage(packageDir: string): void {
+function buildExtensionPackage(packageDir: string, skillName = "my-skill"): void {
 	writeFile(
 		path.join(packageDir, "package.json"),
 		JSON.stringify({ name: path.basename(packageDir), omp: { extensions: ["./src/main.ts"] } }),
 	);
 	writeFile(path.join(packageDir, "src", "main.ts"), "export default function (_pi) {}\n");
 	writeFile(
-		path.join(packageDir, "skills", "my-skill", "SKILL.md"),
-		"---\nname: my-skill\ndescription: Hello from extension skill\n---\nbody\n",
+		path.join(packageDir, "skills", skillName, "SKILL.md"),
+		`---\nname: ${skillName}\ndescription: Hello from extension skill\n---\nbody\n`,
 	);
 	writeFile(path.join(packageDir, "commands", "greet.md"), "---\ndescription: greet user\n---\nHello {{name}}\n");
 	writeFile(path.join(packageDir, "rules", "style.md"), "---\ndescription: style rule\n---\nUse tabs.\n");
 	writeFile(path.join(packageDir, "prompts", "review.md"), "Review this code.\n");
 	writeFile(path.join(packageDir, "hooks", "pre", "bash.sh"), "#!/bin/sh\necho pre\n");
 	writeFile(path.join(packageDir, "hooks", "post", "edit.sh"), "#!/bin/sh\necho post\n");
+	writeFile(path.join(packageDir, "hooks", "pre", "extension.ts"), "export default function (_pi) {}\n");
 	writeFile(path.join(packageDir, "tools", "wcount.sh"), "#!/bin/sh\nwc -w\n");
 	writeFile(path.join(packageDir, "tools", "deep-tool", "index.ts"), "export default { name: 'deep-tool' };\n");
 	writeFile(
@@ -153,6 +156,43 @@ test("`--extension` CLI injection is wired through the same provider", async () 
 	const tools = await loadFromPlugin<{ name: string }>(toolCapability.id, ctx());
 	expect(skills.map(s => s.name)).toContain("my-skill");
 	expect(tools.map(t => t.name)).toEqual(expect.arrayContaining(["wcount", "deep-tool"]));
+});
+
+test("explicit-only CLI roots replace stale state and exclude every ambient package source", async () => {
+	const stale = path.join(tempDir, "stale-extension");
+	const projectExt = path.join(tempDir, "project-extension");
+	const userExt = path.join(tempDir, "user-extension");
+	const installed = path.join(home, ".omp", "plugins", "node_modules", "installed-extension");
+	buildExtensionPackage(stale, "stale-skill");
+	buildExtensionPackage(projectExt, "project-skill");
+	buildExtensionPackage(userExt, "user-skill");
+	buildExtensionPackage(installed, "installed-skill");
+	writeFile(path.join(project, ".omp", "settings.json"), JSON.stringify({ extensions: [projectExt] }));
+	writeFile(path.join(home, ".omp", "agent", "settings.json"), JSON.stringify({ extensions: [userExt] }));
+	writeFile(
+		path.join(home, ".omp", "plugins", "package.json"),
+		JSON.stringify({ name: "omp-plugins", dependencies: { "installed-extension": "1.0.0" } }),
+	);
+
+	injectOmpExtensionCliRoots([stale], home, project);
+	injectOmpExtensionCliRoots([ext], home, project, { mode: "explicit-only", replace: true });
+
+	const roots = await listOmpExtensionRoots(ctx());
+	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, ctx());
+	const extensionPaths = await discoverExtensionPaths([ext], project, undefined, { ambient: false });
+
+	expect(roots).toHaveLength(1);
+	expect(path.basename(roots[0].path)).toBe("my-extension");
+	expect(skills.map(skill => skill.name)).toContain("my-skill");
+	expect(skills.map(skill => skill.name)).not.toEqual(
+		expect.arrayContaining(["stale-skill", "project-skill", "user-skill", "installed-skill"]),
+	);
+	expect(extensionPaths).toContain(path.join(ext, "hooks", "pre", "extension.ts"));
+	expect(
+		extensionPaths.some(candidate =>
+			[stale, projectExt, userExt, installed].some(ambientRoot => candidate.startsWith(ambientRoot)),
+		),
+	).toBe(false);
 });
 
 test("file-extension entrypoints contribute zero sub-surface (the file has no siblings to scan)", async () => {

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -158,6 +158,24 @@ test("`--extension` CLI injection is wired through the same provider", async () 
 	expect(tools.map(t => t.name)).toEqual(expect.arrayContaining(["wcount", "deep-tool"]));
 });
 
+test("relative CLI roots rebind when resume switches projects", async () => {
+	const relativeRoot = "relative-extension";
+	const launchRoot = path.join(project, relativeRoot);
+	const destination = path.join(tempDir, "destination");
+	const destinationRoot = path.join(destination, relativeRoot);
+	buildExtensionPackage(launchRoot, "launch-skill");
+	buildExtensionPackage(destinationRoot, "destination-skill");
+
+	injectOmpExtensionCliRoots([`./${relativeRoot}`], home, project);
+
+	const destinationContext = { cwd: destination, home, repoRoot: destination };
+	const roots = await listOmpExtensionRoots(destinationContext);
+	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, destinationContext);
+	expect(roots.map(root => root.path)).toEqual([destinationRoot]);
+	expect(skills.map(skill => skill.name)).toContain("destination-skill");
+	expect(skills.map(skill => skill.name)).not.toContain("launch-skill");
+});
+
 test("explicit-only CLI roots replace stale state and exclude every ambient package source", async () => {
 	const stale = path.join(tempDir, "stale-extension");
 	const projectExt = path.join(tempDir, "project-extension");

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -32,6 +32,7 @@ import {
 	clearOmpExtensionCliRoots,
 	injectOmpExtensionCliRoots,
 	listOmpExtensionRoots,
+	withOmpExtensionRootScope,
 } from "@oh-my-pi/pi-coding-agent/discovery/omp-extension-roots";
 import { discoverExtensionPaths } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { getConfigRootDir, removeSyncWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
@@ -211,6 +212,45 @@ test("explicit-only CLI roots replace stale state and exclude every ambient pack
 			[stale, projectExt, userExt, installed].some(ambientRoot => candidate.startsWith(ambientRoot)),
 		),
 	).toBe(false);
+});
+
+test("invocation scopes isolate concurrent SDK roots and merge ambient roots only when requested", async () => {
+	const otherExplicit = path.join(tempDir, "other-explicit-extension");
+	const projectExt = path.join(tempDir, "project-extension");
+	const installed = path.join(home, ".omp", "plugins", "node_modules", "installed-extension");
+	const staleCli = path.join(tempDir, "stale-cli-extension");
+	buildExtensionPackage(otherExplicit, "other-explicit-skill");
+	buildExtensionPackage(projectExt, "project-skill");
+	buildExtensionPackage(installed, "installed-skill");
+	buildExtensionPackage(staleCli, "stale-cli-skill");
+	writeFile(path.join(project, ".omp", "settings.json"), JSON.stringify({ extensions: [projectExt] }));
+	writeFile(
+		path.join(home, ".omp", "plugins", "package.json"),
+		JSON.stringify({ name: "omp-plugins", dependencies: { "installed-extension": "1.0.0" } }),
+	);
+	injectOmpExtensionCliRoots([staleCli], home, project);
+
+	const firstEntered = Promise.withResolvers<void>();
+	const secondEntered = Promise.withResolvers<void>();
+	const [firstRoots, secondRoots] = await Promise.all([
+		withOmpExtensionRootScope([ext], "explicit-only", async () => {
+			firstEntered.resolve();
+			await secondEntered.promise;
+			return listOmpExtensionRoots(ctx());
+		}),
+		withOmpExtensionRootScope([otherExplicit], "explicit-only", async () => {
+			secondEntered.resolve();
+			await firstEntered.promise;
+			return listOmpExtensionRoots(ctx());
+		}),
+	]);
+
+	expect(firstRoots.map(root => root.path)).toEqual([ext]);
+	expect(secondRoots.map(root => root.path)).toEqual([otherExplicit]);
+
+	const mergedRoots = await withOmpExtensionRootScope([ext], "merge", () => listOmpExtensionRoots(ctx()));
+	expect(mergedRoots.map(root => root.path)).toEqual(expect.arrayContaining([ext, projectExt, installed]));
+	expect(mergedRoots.map(root => root.path)).not.toContain(staleCli);
 });
 
 test("file-extension entrypoints contribute zero sub-surface (the file has no siblings to scan)", async () => {

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -138,6 +138,31 @@ describe("extensions discovery", () => {
 		expect(result.extensions[0].path).toContain("main.ts");
 	});
 
+	it("explicit-only discovery resolves a package manifest and excludes ambient factories", async () => {
+		fs.writeFileSync(path.join(extensionsDir, "ambient.ts"), extensionCodeWithTool("ambient-tool"));
+		const packageDir = path.join(tempDir.path(), "explicit-package");
+		const sourceDir = path.join(packageDir, "src");
+		fs.mkdirSync(sourceDir, { recursive: true });
+		fs.writeFileSync(path.join(sourceDir, "main.ts"), extensionCodeWithTool("explicit-tool"));
+		fs.writeFileSync(
+			path.join(packageDir, "package.json"),
+			JSON.stringify({
+				name: "explicit-package",
+				omp: {
+					extensions: ["./src/main.ts"],
+				},
+			}),
+		);
+
+		const result = await discoverAndLoadExtensions([packageDir], tempDir.path(), undefined, undefined, {
+			ambient: false,
+		});
+
+		expect(result.errors).toHaveLength(0);
+		expect(result.extensions.map(extension => extension.path)).toEqual([path.join(sourceDir, "main.ts")]);
+		expect(result.extensions.flatMap(extension => [...extension.tools.keys()])).toEqual(["explicit-tool"]);
+	});
+
 	it("discovers a symlinked extension package directory", async () => {
 		const packageDir = path.join(tempDir.path(), "linked-package");
 		const sourceDir = path.join(packageDir, "src");

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -9,6 +9,7 @@ import {
 	discoverExtensionPaths,
 	loadExtensions,
 } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { discoverSessionExtensionPaths } from "@oh-my-pi/pi-coding-agent/sdk";
 import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 import { filterUserScoped } from "./utils/filter-user-extensions";
 
@@ -138,12 +139,22 @@ describe("extensions discovery", () => {
 		expect(result.extensions[0].path).toContain("main.ts");
 	});
 
-	it("explicit-only discovery resolves a package manifest and excludes ambient factories", async () => {
-		fs.writeFileSync(path.join(extensionsDir, "ambient.ts"), extensionCodeWithTool("ambient-tool"));
+	it("SDK explicit-only discovery loads package hooks without ambient package hooks", async () => {
+		const ambientPackage = path.join(tempDir.path(), "ambient-package");
+		fs.mkdirSync(path.join(ambientPackage, "hooks", "pre"), { recursive: true });
+		fs.writeFileSync(path.join(ambientPackage, "hooks", "pre", "ambient.ts"), extensionCodeWithTool("ambient-tool"));
+		fs.writeFileSync(
+			path.join(getProjectAgentDir(tempDir.path()), "settings.json"),
+			JSON.stringify({ extensions: [ambientPackage] }),
+		);
+
 		const packageDir = path.join(tempDir.path(), "explicit-package");
 		const sourceDir = path.join(packageDir, "src");
+		const hookDir = path.join(packageDir, "hooks", "pre");
 		fs.mkdirSync(sourceDir, { recursive: true });
+		fs.mkdirSync(hookDir, { recursive: true });
 		fs.writeFileSync(path.join(sourceDir, "main.ts"), extensionCodeWithTool("explicit-tool"));
+		fs.writeFileSync(path.join(hookDir, "read.ts"), extensionCodeWithTool("explicit-hook-tool"));
 		fs.writeFileSync(
 			path.join(packageDir, "package.json"),
 			JSON.stringify({
@@ -154,13 +165,27 @@ describe("extensions discovery", () => {
 			}),
 		);
 
-		const result = await discoverAndLoadExtensions([packageDir], tempDir.path(), undefined, undefined, {
-			ambient: false,
+		const settings = await Settings.init({
+			inMemory: true,
+			cwd: tempDir.path(),
+			overrides: { extensions: [ambientPackage] },
 		});
+		const paths = await discoverSessionExtensionPaths(
+			{ disableExtensionDiscovery: true, additionalExtensionPaths: [packageDir] },
+			tempDir.path(),
+			settings,
+		);
+		const result = await loadExtensions(paths, tempDir.path());
 
 		expect(result.errors).toHaveLength(0);
-		expect(result.extensions.map(extension => extension.path)).toEqual([path.join(sourceDir, "main.ts")]);
-		expect(result.extensions.flatMap(extension => [...extension.tools.keys()])).toEqual(["explicit-tool"]);
+		expect(result.extensions.map(extension => extension.path)).toEqual([
+			path.join(hookDir, "read.ts"),
+			path.join(sourceDir, "main.ts"),
+		]);
+		expect(result.extensions.flatMap(extension => [...extension.tools.keys()])).toEqual([
+			"explicit-hook-tool",
+			"explicit-tool",
+		]);
 	});
 
 	it("discovers a symlinked extension package directory", async () => {

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
+import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
 import { type ExtensionModule, extensionModuleCapability } from "@oh-my-pi/pi-coding-agent/capability/extension-module";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -186,6 +187,32 @@ describe("extensions discovery", () => {
 			"explicit-hook-tool",
 			"explicit-tool",
 		]);
+	});
+
+	it("explicit-only discovery ignores unreadable optional hook directories", async () => {
+		const packageDir = path.join(tempDir.path(), "explicit-package");
+		const sourceDir = path.join(packageDir, "src");
+		fs.mkdirSync(sourceDir, { recursive: true });
+		fs.writeFileSync(path.join(sourceDir, "main.ts"), extensionCode);
+		fs.writeFileSync(
+			path.join(packageDir, "package.json"),
+			JSON.stringify({
+				name: "explicit-package",
+				omp: {
+					extensions: ["./src/main.ts"],
+				},
+			}),
+		);
+
+		const permissionError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+		const readdirSpy = vi.spyOn(fsPromises, "readdir").mockRejectedValueOnce(permissionError);
+		try {
+			await expect(
+				discoverExtensionPaths([packageDir], tempDir.path(), undefined, { ambient: false }),
+			).resolves.toEqual([path.join(sourceDir, "main.ts")]);
+		} finally {
+			readdirSpy.mockRestore();
+		}
 	});
 
 	it("discovers a symlinked extension package directory", async () => {

--- a/packages/coding-agent/test/issue-905-repro.test.ts
+++ b/packages/coding-agent/test/issue-905-repro.test.ts
@@ -21,6 +21,8 @@ import { TempDir } from "@oh-my-pi/pi-utils";
 
 let tmp: TempDir;
 let extPath: string;
+let explicitPackagePath: string;
+let ambientExtPath: string;
 let dbPath: string;
 let shutdownExtPath: string;
 let shutdownPath: string;
@@ -56,6 +58,53 @@ beforeAll(async () => {
 		`export default function (pi) {
 	pi.on("session_shutdown", async () => {
 		await Bun.write(${JSON.stringify(shutdownPath)}, "shutdown");
+	});
+}
+`,
+	);
+	explicitPackagePath = tmp.join("explicit-package");
+	ambientExtPath = tmp.join("ambient.ts");
+	await fs.mkdir(tmp.join("explicit-package", "src"), { recursive: true });
+	await fs.writeFile(
+		tmp.join("explicit-package", "package.json"),
+		JSON.stringify({ name: "explicit-package", omp: { extensions: ["./src/main.ts"] } }),
+	);
+	await fs.writeFile(
+		tmp.join("explicit-package", "src", "main.ts"),
+		`export default function (pi) {
+	pi.registerProvider("explicit-gw", {
+		baseUrl: "https://explicit.example.com/v1",
+		apiKey: "literal-test-key",
+		api: "openai-completions",
+		models: [{
+			id: "explicit-model",
+			name: "Explicit Model",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		}],
+	});
+}
+`,
+	);
+	await fs.writeFile(
+		ambientExtPath,
+		`export default function (pi) {
+	pi.registerProvider("ambient-gw", {
+		baseUrl: "https://ambient.example.com/v1",
+		apiKey: "literal-test-key",
+		api: "openai-completions",
+		models: [{
+			id: "ambient-model",
+			name: "Ambient Model",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		}],
 	});
 }
 `,
@@ -113,6 +162,40 @@ test("omp models emits extension shutdown after listing (issue #6297)", async ()
 		});
 
 		expect(await Bun.file(shutdownPath).text()).toBe("shutdown");
+	} finally {
+		authStorage.close();
+	}
+});
+
+test("omp models explicit-only mode resolves a package and excludes settings providers", async () => {
+	const authStorage = await AuthStorage.create(":memory:");
+	try {
+		const modelRegistry = new ModelRegistry(authStorage);
+		const captured: string[] = [];
+		const originalWrite = process.stdout.write.bind(process.stdout);
+		process.stdout.write = ((chunk: string | Uint8Array) => {
+			captured.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		}) as typeof process.stdout.write;
+
+		try {
+			await runModelsListing({
+				modelRegistry,
+				cwd: tmp.path(),
+				action: "ls",
+				additionalExtensionPaths: [explicitPackagePath],
+				settingsExtensions: [ambientExtPath],
+				disableExtensionDiscovery: true,
+			});
+		} finally {
+			process.stdout.write = originalWrite;
+		}
+
+		const output = captured.join("");
+		expect(output).toContain("explicit-gw");
+		expect(output).toContain("explicit-model");
+		expect(output).not.toContain("ambient-gw");
+		expect(output).not.toContain("ambient-model");
 	} finally {
 		authStorage.close();
 	}

--- a/packages/coding-agent/test/sdk-skills.test.ts
+++ b/packages/coding-agent/test/sdk-skills.test.ts
@@ -7,6 +7,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { getActiveSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/sdk";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
@@ -22,6 +23,19 @@ function createIsolatedSkillsSettings(): Settings {
 		"skills.enablePiUser": false,
 		"skills.enablePiProject": true,
 	});
+}
+
+function createExtensionSkill(packageDir: string, skillName: string): void {
+	fs.mkdirSync(path.join(packageDir, "skills", skillName), { recursive: true });
+	fs.writeFileSync(
+		path.join(packageDir, "package.json"),
+		JSON.stringify({ name: path.basename(packageDir), omp: { extensions: ["./extension.ts"] } }),
+	);
+	fs.writeFileSync(path.join(packageDir, "extension.ts"), "export default function extension() {}\n");
+	fs.writeFileSync(
+		path.join(packageDir, "skills", skillName, "SKILL.md"),
+		`---\nname: ${skillName}\ndescription: SDK extension package skill\n---\nbody\n`,
+	);
 }
 
 describe("createAgentSession skills option", () => {
@@ -105,6 +119,63 @@ Loaded via symbolic link.
 		// Skills should be discovered and exposed on the session
 		expect(session.skills.length).toBeGreaterThan(0);
 		expect(session.skills.some((s: Skill) => s.name === "test-skill")).toBe(true);
+	});
+
+	it("SDK invocation root scope isolates disabled discovery and merges normal discovery", async () => {
+		const explicitPackage = path.join(tempDir, "sdk-explicit-extension");
+		const settingsPackage = path.join(tempDir, "sdk-settings-extension");
+		const installedPackage = path.join(tempHomeDir, ".omp", "plugins", "node_modules", "sdk-installed-extension");
+		createExtensionSkill(explicitPackage, "sdk-explicit-skill");
+		createExtensionSkill(settingsPackage, "sdk-settings-skill");
+		createExtensionSkill(installedPackage, "sdk-installed-skill");
+		fs.writeFileSync(path.join(tempDir, ".omp", "settings.json"), JSON.stringify({ extensions: [settingsPackage] }));
+		fs.mkdirSync(path.join(tempHomeDir, ".omp", "plugins"), { recursive: true });
+		fs.writeFileSync(
+			path.join(tempHomeDir, ".omp", "plugins", "package.json"),
+			JSON.stringify({ name: "omp-plugins", dependencies: { "sdk-installed-extension": "1.0.0" } }),
+		);
+
+		const previousAgentDir = getAgentDir();
+		setAgentDir(path.join(tempHomeDir, ".omp", "agent"));
+		const baseSessionOptions = {
+			cwd: tempDir,
+			agentDir: path.join(tempHomeDir, ".omp", "agent"),
+			modelRegistry: sharedModelRegistry,
+			additionalExtensionPaths: [explicitPackage],
+			enableMCP: false,
+			enableLsp: false,
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			rules: [],
+		};
+		let session: AgentSession | undefined;
+		try {
+			({ session } = await createAgentSession({
+				...baseSessionOptions,
+				sessionManager: SessionManager.inMemory(),
+				settings: createIsolatedSkillsSettings(),
+				disableExtensionDiscovery: true,
+			}));
+
+			const isolatedSkillNames = session.skills.map(skill => skill.name);
+			expect(isolatedSkillNames).toContain("sdk-explicit-skill");
+			expect(isolatedSkillNames).not.toEqual(expect.arrayContaining(["sdk-settings-skill", "sdk-installed-skill"]));
+
+			await session.dispose();
+			session = undefined;
+			({ session } = await createAgentSession({
+				...baseSessionOptions,
+				sessionManager: SessionManager.inMemory(),
+				settings: createIsolatedSkillsSettings(),
+			}));
+
+			const mergedSkillNames = session.skills.map(skill => skill.name);
+			expect(mergedSkillNames).toEqual(expect.arrayContaining(["sdk-explicit-skill", "sdk-settings-skill"]));
+		} finally {
+			await session?.dispose();
+			setAgentDir(previousAgentDir);
+		}
 	});
 
 	it("should discover skills when skill directory is a symlink", async () => {

--- a/packages/coding-agent/test/task/discovery.test.ts
+++ b/packages/coding-agent/test/task/discovery.test.ts
@@ -139,4 +139,36 @@ describe("discoverAgents", () => {
 		expect(collide?.description).toBe("from-cli");
 		expect(collide?.filePath).toBe(path.join(cliExt, "agents", "collide.md"));
 	});
+
+	test("explicit-only CLI roots expose only explicitly named package agents", async () => {
+		const staleExt = path.join(tempHome, "stale-ext");
+		const explicitExt = path.join(tempHome, "explicit-ext");
+		const settingsExt = path.join(tempHome, "settings-ext");
+		for (const [root, name] of [
+			[staleExt, "stale-agent"],
+			[explicitExt, "explicit-agent"],
+			[settingsExt, "settings-agent"],
+		] as const) {
+			await fs.mkdir(path.join(root, "agents"), { recursive: true });
+			await fs.writeFile(
+				path.join(root, "agents", `${name}.md`),
+				["---", `name: ${name}`, `description: ${name}`, "---", `${name} body`].join("\n"),
+			);
+		}
+		await fs.mkdir(path.join(projectDir, ".omp"), { recursive: true });
+		await fs.writeFile(path.join(projectDir, ".omp", "settings.json"), JSON.stringify({ extensions: [settingsExt] }));
+		await writeOmpPluginAgent(tempHome);
+
+		injectOmpExtensionCliRoots([staleExt], tempHome, projectDir);
+		injectOmpExtensionCliRoots([explicitExt], tempHome, projectDir, {
+			mode: "explicit-only",
+			replace: true,
+		});
+
+		const { agents } = await discoverAgents(projectDir, tempHome);
+		const names = agents.map(agent => agent.name);
+
+		expect(names).toContain("explicit-agent");
+		expect(names).not.toEqual(expect.arrayContaining(["stale-agent", "settings-agent", "loom-verify-spec"]));
+	});
 });


### PR DESCRIPTION
## Summary

- preserve explicit `-e`/`--extension` and `--hook` paths when `--no-extensions` disables ambient discovery
- restrict package sibling discovery to roots explicitly named by the current invocation
- resolve explicit package manifests consistently in CLI, SDK, and `omp models`
- retain JS/TS hooks bundled in explicit packages while excluding ambient hook providers

This is based on the approach in #6077 and addresses its automated review finding about package-local hooks.

Fixes #7283.

## Verification

- `bun test packages/coding-agent/test/cli-explicit-extension-isolation.test.ts packages/coding-agent/test/extensions-discovery.test.ts packages/coding-agent/test/discovery/omp-plugins.test.ts packages/coding-agent/test/issue-905-repro.test.ts packages/coding-agent/test/task/discovery.test.ts packages/coding-agent/test/sdk-skills.test.ts` — 74 passed, 0 failed
- `bun run check` in `packages/coding-agent` — passed
- source CLI smoke: `omp models --no-extensions --extension <package> --json` reported the explicit provider and excluded a discoverable ambient provider

- [x] CHANGELOG updated
- [x] Documentation updated