### PR TITLE
fix(coding-agent): prune archived session stats

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed archived main and nested session rows from `stats.db` during applied archive GC, including retry cleanup for sessions archived by an earlier run ([#7286](https://github.com/can1357/oh-my-pi/issues/7286)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { gunzipSync, gzipSync } from "node:zlib";
+import { withStatsSyncLock } from "@oh-my-pi/omp-stats/aggregator";
 import {
 	getAgentDir,
 	getBlobsDir,
@@ -429,18 +430,6 @@ function sessionArtifactsPath(sessionPath: string): string {
 	return sessionPath.slice(0, -SESSION_SUFFIX.length);
 }
 
-function sessionIdFromSessionPath(sessionPath: string): string | undefined {
-	const basename = path.basename(sessionPath);
-	if (basename.endsWith(COMPRESSED_SESSION_SUFFIX)) {
-		const id = basename.slice(0, -COMPRESSED_SESSION_SUFFIX.length);
-		return id || undefined;
-	}
-	if (basename.endsWith(SESSION_SUFFIX)) {
-		const id = basename.slice(0, -SESSION_SUFFIX.length);
-		return id || undefined;
-	}
-	return undefined;
-}
 interface SessionLineageHeader {
 	id: string;
 	parentSession?: string;
@@ -467,10 +456,6 @@ function sessionLineageHeaderFromText(text: string): SessionLineageHeader | unde
 		}
 	}
 	return undefined;
-}
-
-async function archivedSessionIdFromFile(file: string): Promise<string | undefined> {
-	return sessionLineageHeaderFromText(await readTextIfPresent(file))?.id ?? sessionIdFromSessionPath(file);
 }
 
 async function gzipSessionFile(source: string, destination: string): Promise<void> {
@@ -578,7 +563,7 @@ function deleteHistoryRowsForSessions(dbPath: string, sessionIds: string[]): { d
 async function collectArchivedSessionIds(archiveRoot: string): Promise<string[]> {
 	const ids = new Set<string>();
 	for (const file of await collectCompressedJsonlFiles(archiveRoot)) {
-		const id = await archivedSessionIdFromFile(file);
+		const id = sessionLineageHeaderFromText(await readTextIfPresent(file))?.id;
 		if (id) ids.add(id);
 	}
 	return [...ids].sort();
@@ -611,6 +596,13 @@ async function cleanupHistoryRowsForArchivedSessions(
 
 const STATS_SESSION_TABLES = ["messages", "user_messages", "tool_calls", "file_offsets"] as const;
 const STATS_ENTRY_TABLES = ["messages", "user_messages", "tool_calls"] as const;
+type StatsEntryTable = (typeof STATS_ENTRY_TABLES)[number];
+
+const STATS_IDENTITY_COLUMNS: Record<StatsEntryTable, readonly string[]> = {
+	messages: ["entry_id", "timestamp"],
+	user_messages: ["entry_id", "timestamp"],
+	tool_calls: ["entry_id", "timestamp", "tool_call_id"],
+};
 
 interface ArchivedStatsSession {
 	path: string;
@@ -622,9 +614,15 @@ interface StatsLineageNode extends ArchivedStatsSession {
 	statsPaths: Set<string>;
 }
 
+interface StatsEntryIdentity {
+	entryId: string;
+	timestamp: number;
+	toolCallId: string;
+}
+
 interface StatsTransferTarget {
 	path: string;
-	entryIds: string[];
+	identities: Record<StatsEntryTable, StatsEntryIdentity[]>;
 }
 
 interface StatsCleanupPlan {
@@ -692,7 +690,7 @@ function resolveLogicalSessionMatch(
 	const stem = matches[0] ? path.basename(matches[0].logicalRoot, SESSION_SUFFIX) : "";
 	const idMatches = matches.filter(match => stem === match.node.id || stem.endsWith(`_${match.node.id}`));
 	if (idMatches.length === 1) return idMatches[0];
-	return matches.length === 1 ? matches[0] : undefined;
+	return undefined;
 }
 
 /**
@@ -787,31 +785,84 @@ function buildStatsCleanupPlans(
 	});
 }
 
-async function collectSessionMessageEntryIds(sessionPath: string): Promise<string[]> {
+async function collectSessionStatsIdentities(
+	sessionPath: string,
+): Promise<Record<StatsEntryTable, StatsEntryIdentity[]>> {
+	const identities: Record<StatsEntryTable, StatsEntryIdentity[]> = {
+		messages: [],
+		user_messages: [],
+		tool_calls: [],
+	};
 	const decoder = new TextDecoder();
-	const entryIds: string[] = [];
 	for await (const line of readLines(Bun.file(sessionPath).stream())) {
 		if (line.length === 0) continue;
 		try {
-			const entry = JSON.parse(decoder.decode(line)) as { type?: unknown; id?: unknown };
-			if (entry.type === "message" && typeof entry.id === "string" && entry.id.length > 0) entryIds.push(entry.id);
+			const record: unknown = JSON.parse(decoder.decode(line));
+			if (
+				!record ||
+				typeof record !== "object" ||
+				!("type" in record) ||
+				record.type !== "message" ||
+				!("id" in record) ||
+				typeof record.id !== "string" ||
+				record.id.length === 0 ||
+				!("message" in record) ||
+				!record.message ||
+				typeof record.message !== "object"
+			) {
+				continue;
+			}
+			const message = record.message;
+			if (!("role" in message)) continue;
+			const parsedEntryTimestamp =
+				"timestamp" in record && typeof record.timestamp === "string" ? Date.parse(record.timestamp) : Number.NaN;
+			if (message.role === "user") {
+				identities.user_messages.push({
+					entryId: record.id,
+					timestamp: Number.isFinite(parsedEntryTimestamp) ? parsedEntryTimestamp : 0,
+					toolCallId: "",
+				});
+				continue;
+			}
+			if (message.role !== "assistant") continue;
+			const timestamp =
+				"timestamp" in message && typeof message.timestamp === "number" && Number.isFinite(message.timestamp)
+					? message.timestamp
+					: Number.isFinite(parsedEntryTimestamp)
+						? parsedEntryTimestamp
+						: 0;
+			identities.messages.push({ entryId: record.id, timestamp, toolCallId: "" });
+			if (!("content" in message) || !Array.isArray(message.content)) continue;
+			for (const block of message.content) {
+				if (
+					block &&
+					typeof block === "object" &&
+					"type" in block &&
+					block.type === "toolCall" &&
+					"id" in block &&
+					typeof block.id === "string" &&
+					block.id.length > 0
+				) {
+					identities.tool_calls.push({ entryId: record.id, timestamp, toolCallId: block.id });
+				}
+			}
 		} catch {
 			// Stats parsing is also lenient: a malformed line cannot own a retained row.
 		}
 	}
-	return entryIds;
+	return identities;
 }
 
 async function populateStatsTransferTargets(plans: StatsCleanupPlan[]): Promise<void> {
-	const entryIdsBySession = new Map<string, Promise<string[]>>();
+	const identitiesBySession = new Map<string, Promise<Record<StatsEntryTable, StatsEntryIdentity[]>>>();
 	for (const plan of plans) {
 		for (const retained of plan.retainedSessions) {
-			let entryIds = entryIdsBySession.get(retained.path);
-			if (!entryIds) {
-				entryIds = collectSessionMessageEntryIds(retained.path);
-				entryIdsBySession.set(retained.path, entryIds);
+			let identities = identitiesBySession.get(retained.path);
+			if (!identities) {
+				identities = collectSessionStatsIdentities(retained.path);
+				identitiesBySession.set(retained.path, identities);
 			}
-			plan.transfers.push({ path: retained.path, entryIds: await entryIds });
+			plan.transfers.push({ path: retained.path, identities: await identities });
 		}
 	}
 }
@@ -830,50 +881,83 @@ function reconcileStatsRowsForSessions(dbPath: string, plans: StatsCleanupPlan[]
 			table => tableExists(db, table) && tableHasColumn(db, table, "session_file"),
 		);
 		const entryTables = STATS_ENTRY_TABLES.filter(
-			table => sessionTables.includes(table) && tableHasColumn(db, table, "entry_id"),
+			table =>
+				sessionTables.includes(table) &&
+				STATS_IDENTITY_COLUMNS[table].every(column => tableHasColumn(db, table, column)),
 		);
-		const missingEntryIdentity = STATS_ENTRY_TABLES.filter(
-			table => sessionTables.includes(table) && !tableHasColumn(db, table, "entry_id"),
-		);
-		if (
-			missingEntryIdentity.length > 0 &&
-			plans.some(plan => plan.transfers.some(target => target.entryIds.length > 0))
-		) {
-			throw new Error(`stats tables missing entry_id: ${missingEntryIdentity.join(", ")}`);
-		}
-		db.run("CREATE TEMP TABLE gc_retained_entries (entry_id TEXT PRIMARY KEY, target_session_file TEXT NOT NULL)");
+
+		db.run(`
+			CREATE TEMP TABLE gc_retained_entries (
+				table_name TEXT NOT NULL,
+				entry_id TEXT NOT NULL,
+				timestamp INTEGER NOT NULL,
+				tool_call_id TEXT NOT NULL,
+				target_session_file TEXT NOT NULL,
+				PRIMARY KEY (table_name, entry_id, timestamp, tool_call_id)
+			)
+		`);
 		const clearRetainedEntries = db.prepare("DELETE FROM gc_retained_entries");
-		const insertRetainedEntry = db.prepare(
-			"INSERT OR IGNORE INTO gc_retained_entries (entry_id, target_session_file) VALUES (?, ?)",
-		);
-		const transferStatements = entryTables.map(table =>
-			db.prepare(`
+		const insertRetainedEntry = db.prepare(`
+			INSERT OR IGNORE INTO gc_retained_entries (
+				table_name, entry_id, timestamp, tool_call_id, target_session_file
+			) VALUES (?, ?, ?, ?, ?)
+		`);
+		const transferStatements = entryTables.map(table => {
+			const toolCallMatch =
+				table === "tool_calls" ? `retained.tool_call_id = ${table}.tool_call_id` : "retained.tool_call_id = ''";
+			const identityMatch = `
+				retained.table_name = '${table}'
+				AND retained.entry_id = ${table}.entry_id
+				AND retained.timestamp = ${table}.timestamp
+				AND ${toolCallMatch}
+			`;
+			return db.prepare(`
 				UPDATE OR IGNORE ${table}
 				SET session_file = (
-					SELECT target_session_file
-					FROM gc_retained_entries
-					WHERE gc_retained_entries.entry_id = ${table}.entry_id
+					SELECT retained.target_session_file
+					FROM gc_retained_entries AS retained
+					WHERE ${identityMatch}
 				)
 				WHERE session_file = ?
-					AND entry_id IN (SELECT entry_id FROM gc_retained_entries)
-			`),
-		);
-		const deleteStatements = sessionTables.map(table =>
-			db.prepare(`DELETE FROM ${table} WHERE session_file = ? OR instr(session_file, ?) = 1`),
-		);
+					AND EXISTS (
+						SELECT 1
+						FROM gc_retained_entries AS retained
+						WHERE ${identityMatch}
+					)
+			`);
+		});
+		const deletionStatements = sessionTables.map(table => ({
+			table,
+			statement: db.prepare(`DELETE FROM ${table} WHERE session_file = ? OR instr(session_file, ?) = 1`),
+		}));
 		let deleted = 0;
 		const tx = db.transaction((cleanupPlans: StatsCleanupPlan[]) => {
 			for (const plan of cleanupPlans) {
 				clearRetainedEntries.run();
 				for (const target of plan.transfers) {
-					for (const entryId of target.entryIds) insertRetainedEntry.run(entryId, target.path);
+					for (const table of entryTables) {
+						for (const identity of target.identities[table]) {
+							insertRetainedEntry.run(
+								table,
+								identity.entryId,
+								identity.timestamp,
+								identity.toolCallId,
+								target.path,
+							);
+						}
+					}
 				}
 				for (const sessionPath of new Set(plan.sessionPaths)) {
 					for (const statement of transferStatements) statement.run(sessionPath);
 				}
 				for (const sessionPath of new Set(plan.sessionPaths)) {
 					const nestedPrefix = `${sessionArtifactsPath(sessionPath)}${path.sep}`;
-					for (const statement of deleteStatements) {
+					for (const { table, statement } of deletionStatements) {
+						const requiresTransfer =
+							plan.retainedSessions.length > 0 &&
+							table !== "file_offsets" &&
+							!entryTables.some(entryTable => entryTable === table);
+						if (requiresTransfer) continue;
 						const result = statement.run(sessionPath, nestedPrefix) as SqliteRunResult;
 						deleted += sqliteNumber(result.changes);
 					}
@@ -890,18 +974,24 @@ function reconcileStatsRowsForSessions(dbPath: string, plans: StatsCleanupPlan[]
 async function collectArchivedStatsSessions(
 	archiveRoot: string,
 	sessionsRoot: string,
+	onError: (file: string, error: unknown) => void,
 ): Promise<ArchivedStatsSession[]> {
 	const sessions: ArchivedStatsSession[] = [];
 	for (const file of await collectCompressedJsonlFiles(archiveRoot)) {
 		const relative = path.relative(archiveRoot, file);
 		if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) continue;
 		const sourcePath = path.join(sessionsRoot, relative.slice(0, -".gz".length));
-		const header = sessionLineageHeaderFromText(await readTextIfPresent(file));
-		sessions.push({
-			path: sourcePath,
-			id: header?.id ?? sessionIdFromSessionPath(sourcePath) ?? sourcePath,
-			parentSession: header?.parentSession,
-		});
+		try {
+			const header = sessionLineageHeaderFromText(await readTextIfPresent(file));
+			if (!header) throw new Error("archive is missing a valid session header");
+			sessions.push({
+				path: sourcePath,
+				id: header.id,
+				parentSession: header.parentSession,
+			});
+		} catch (error) {
+			onError(file, error);
+		}
 	}
 	return sessions;
 }
@@ -929,9 +1019,19 @@ async function cleanupStatsRowsForArchivedSessions(
 
 	let retainedSessions: SessionInfo[];
 	try {
-		for (const session of await collectArchivedStatsSessions(archiveRoot, getSessionsDir(options.agentDir))) {
+		for (const session of await collectArchivedStatsSessions(
+			archiveRoot,
+			getSessionsDir(options.agentDir),
+			(file, error) => {
+				result.errors.push(`stats cleanup scan ${file}: ${errorMessage(error)}`);
+			},
+		)) {
 			archivedByPath.set(path.resolve(session.path), session);
 		}
+	} catch (error) {
+		result.errors.push(`stats cleanup scan: ${errorMessage(error)}`);
+	}
+	try {
 		retainedSessions = await listActiveSessions(getSessionsDir(options.agentDir));
 	} catch (error) {
 		result.errors.push(`stats cleanup scan: ${errorMessage(error)}`);
@@ -939,10 +1039,12 @@ async function cleanupStatsRowsForArchivedSessions(
 	}
 
 	try {
-		const storedSessionPaths = collectStoredStatsSessionPaths(dbPath);
-		const plans = buildStatsCleanupPlans([...archivedByPath.values()], retainedSessions, storedSessionPaths);
-		await populateStatsTransferTargets(plans);
-		result.statsRowsDeleted = reconcileStatsRowsForSessions(dbPath, plans);
+		await withStatsSyncLock(dbPath, async () => {
+			const storedSessionPaths = collectStoredStatsSessionPaths(dbPath);
+			const plans = buildStatsCleanupPlans([...archivedByPath.values()], retainedSessions, storedSessionPaths);
+			await populateStatsTransferTargets(plans);
+			result.statsRowsDeleted = reconcileStatsRowsForSessions(dbPath, plans);
+		});
 	} catch (error) {
 		result.errors.push(`stats cleanup: ${errorMessage(error)}`);
 	}

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -9,6 +9,7 @@ import {
 	getModelDbPath,
 	getSessionsDir,
 	getStatsDbPath,
+	readLines,
 } from "@oh-my-pi/pi-utils";
 import { Settings } from "../config/settings";
 import { getDefault } from "../config/settings-schema";
@@ -440,21 +441,27 @@ function sessionIdFromSessionPath(sessionPath: string): string | undefined {
 	}
 	return undefined;
 }
+interface SessionLineageHeader {
+	id: string;
+	parentSession?: string;
+}
 
-function sessionIdFromSessionText(text: string): string | undefined {
+function sessionLineageHeaderFromText(text: string): SessionLineageHeader | undefined {
 	let sawTitleSlot = false;
 	for (const rawLine of text.split(/\r?\n/)) {
 		const line = rawLine.trim();
 		if (!line) continue;
 		try {
-			const record = JSON.parse(line) as { type?: unknown; id?: unknown };
+			const record = JSON.parse(line) as { type?: unknown; id?: unknown; parentSession?: unknown };
 			if (!sawTitleSlot && record.type === "title") {
 				sawTitleSlot = true;
 				continue;
 			}
-			return record.type === "session" && typeof record.id === "string" && record.id.length > 0
-				? record.id
-				: undefined;
+			if (record.type !== "session" || typeof record.id !== "string" || record.id.length === 0) return undefined;
+			return {
+				id: record.id,
+				parentSession: typeof record.parentSession === "string" ? record.parentSession : undefined,
+			};
 		} catch {
 			return undefined;
 		}
@@ -463,7 +470,7 @@ function sessionIdFromSessionText(text: string): string | undefined {
 }
 
 async function archivedSessionIdFromFile(file: string): Promise<string | undefined> {
-	return sessionIdFromSessionText(await readTextIfPresent(file)) ?? sessionIdFromSessionPath(file);
+	return sessionLineageHeaderFromText(await readTextIfPresent(file))?.id ?? sessionIdFromSessionPath(file);
 }
 
 async function gzipSessionFile(source: string, destination: string): Promise<void> {
@@ -603,46 +610,306 @@ async function cleanupHistoryRowsForArchivedSessions(
 }
 
 const STATS_SESSION_TABLES = ["messages", "user_messages", "tool_calls", "file_offsets"] as const;
+const STATS_ENTRY_TABLES = ["messages", "user_messages", "tool_calls"] as const;
 
-function deleteStatsRowsForSessions(dbPath: string, sessionPaths: string[]): number {
-	if (sessionPaths.length === 0) return 0;
+interface ArchivedStatsSession {
+	path: string;
+	id: string;
+	parentSession?: string;
+}
+
+interface StatsLineageNode extends ArchivedStatsSession {
+	statsPaths: Set<string>;
+}
+
+interface StatsTransferTarget {
+	path: string;
+	entryIds: string[];
+}
+
+interface StatsCleanupPlan {
+	sessionPaths: string[];
+	retainedSessions: StatsLineageNode[];
+	transfers: StatsTransferTarget[];
+}
+
+function tableHasColumn(db: Database, table: string, column: string): boolean {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: string | null }>;
+	return rows.some(row => row.name === column);
+}
+
+function collectStoredStatsSessionPaths(dbPath: string): string[] {
 	const db = new Database(dbPath);
 	try {
 		db.run("PRAGMA busy_timeout = 5000");
-		const statements = STATS_SESSION_TABLES.filter(table => tableExists(db, table)).map(table =>
+		const sessionPaths = new Set<string>();
+		for (const table of STATS_SESSION_TABLES) {
+			if (!tableExists(db, table) || !tableHasColumn(db, table, "session_file")) continue;
+			const rows = db.prepare(`SELECT DISTINCT session_file FROM ${table}`).all() as Array<{
+				session_file?: string | null;
+			}>;
+			for (const row of rows) {
+				if (typeof row.session_file === "string") sessionPaths.add(row.session_file);
+			}
+		}
+		return [...sessionPaths];
+	} finally {
+		db.close();
+	}
+}
+/**
+ * `/move` preserves the session filename and artifacts-directory basename.
+ * Recover the top-level path represented by any main or nested stats row so
+ * one archived logical session can reconcile every historical location.
+ */
+function logicalSessionRootForStatsPath(statsPath: string, sessionPath: string): string | undefined {
+	const sessionFilename = path.basename(sessionPath);
+	if (path.basename(statsPath) === sessionFilename) return statsPath;
+
+	const artifactsDirname = sessionFilename.slice(0, -SESSION_SUFFIX.length);
+	let directory = path.dirname(path.resolve(statsPath));
+	while (true) {
+		if (path.basename(directory) === artifactsDirname) return `${directory}${SESSION_SUFFIX}`;
+		const parent = path.dirname(directory);
+		if (parent === directory) return undefined;
+		directory = parent;
+	}
+}
+
+function resolveLogicalSessionMatch(
+	statsPath: string,
+	nodes: StatsLineageNode[],
+): { node: StatsLineageNode; logicalRoot: string } | undefined {
+	const matches: Array<{ node: StatsLineageNode; logicalRoot: string }> = [];
+	for (const node of nodes) {
+		const logicalRoot = logicalSessionRootForStatsPath(statsPath, node.path);
+		if (logicalRoot) matches.push({ node, logicalRoot });
+	}
+	const exact = matches.filter(match => path.resolve(match.logicalRoot) === path.resolve(match.node.path));
+	if (exact.length === 1) return exact[0];
+	if (exact.length > 1) return undefined;
+
+	const stem = matches[0] ? path.basename(matches[0].logicalRoot, SESSION_SUFFIX) : "";
+	const idMatches = matches.filter(match => stem === match.node.id || stem.endsWith(`_${match.node.id}`));
+	if (idMatches.length === 1) return idMatches[0];
+	return matches.length === 1 ? matches[0] : undefined;
+}
+
+/**
+ * Resolve retained peers through `parentSession`, which is historically either
+ * a session id or an absolute path. Ambiguous aliases are deliberately left
+ * unresolved so cleanup fails safe instead of transferring across sessions.
+ */
+function buildStatsCleanupPlans(
+	archivedSessions: ArchivedStatsSession[],
+	retainedSessions: SessionInfo[],
+	storedSessionPaths: string[],
+): StatsCleanupPlan[] {
+	const archivedNodes: StatsLineageNode[] = archivedSessions.map(session => ({
+		...session,
+		statsPaths: new Set([session.path]),
+	}));
+	const retainedNodes: StatsLineageNode[] = retainedSessions.map(session => ({
+		path: session.path,
+		id: session.id,
+		parentSession: session.parentSessionPath,
+		statsPaths: new Set([session.path]),
+	}));
+	const nodes = [...archivedNodes, ...retainedNodes];
+
+	for (const storedPath of storedSessionPaths) {
+		const match = resolveLogicalSessionMatch(storedPath, nodes);
+		if (match) match.node.statsPaths.add(match.logicalRoot);
+	}
+
+	for (const child of nodes) {
+		if (
+			!child.parentSession ||
+			(!path.isAbsolute(child.parentSession) && !child.parentSession.endsWith(SESSION_SUFFIX))
+		) {
+			continue;
+		}
+		const match = resolveLogicalSessionMatch(child.parentSession, nodes);
+		if (match) match.node.statsPaths.add(match.logicalRoot);
+	}
+
+	const aliases = new Map<string, StatsLineageNode | null>();
+	const identityKeysByNode = new Map<StatsLineageNode, Set<string>>();
+	for (const node of nodes) {
+		const keys = new Set([
+			`id:${node.id}`,
+			...[...node.statsPaths].map(statsPath => `path:${path.resolve(statsPath)}`),
+		]);
+		identityKeysByNode.set(node, keys);
+		for (const key of keys) {
+			if (!aliases.has(key)) {
+				aliases.set(key, node);
+			} else if (aliases.get(key) !== node) {
+				aliases.set(key, null);
+			}
+		}
+	}
+
+	const lineageKeysByNode = new Map<StatsLineageNode, Set<string>>();
+	for (const node of nodes) {
+		const lineageKeys = new Set(identityKeysByNode.get(node));
+		let current: StatsLineageNode | null = node;
+		const seen = new Set<StatsLineageNode>();
+		while (current?.parentSession && !seen.has(current)) {
+			seen.add(current);
+			const parentReference = current.parentSession;
+			const parentKey =
+				path.isAbsolute(parentReference) || parentReference.endsWith(SESSION_SUFFIX)
+					? `path:${path.resolve(parentReference)}`
+					: `id:${parentReference}`;
+			lineageKeys.add(parentKey);
+			const parent = aliases.get(parentKey);
+			if (!parent) break;
+			for (const key of identityKeysByNode.get(parent) ?? []) lineageKeys.add(key);
+			current = parent;
+		}
+		lineageKeysByNode.set(node, lineageKeys);
+	}
+
+	const retainedPathKeys = new Set(
+		retainedNodes.flatMap(retained => [...retained.statsPaths].map(statsPath => path.resolve(statsPath))),
+	);
+	return archivedNodes.map(archived => {
+		const archivedLineage = lineageKeysByNode.get(archived) ?? new Set<string>();
+		return {
+			sessionPaths: [...archived.statsPaths].filter(statsPath => !retainedPathKeys.has(path.resolve(statsPath))),
+			retainedSessions: retainedNodes.filter(retained => {
+				const retainedLineage = lineageKeysByNode.get(retained);
+				return retainedLineage ? [...retainedLineage].some(key => archivedLineage.has(key)) : false;
+			}),
+			transfers: [],
+		};
+	});
+}
+
+async function collectSessionMessageEntryIds(sessionPath: string): Promise<string[]> {
+	const decoder = new TextDecoder();
+	const entryIds: string[] = [];
+	for await (const line of readLines(Bun.file(sessionPath).stream())) {
+		if (line.length === 0) continue;
+		try {
+			const entry = JSON.parse(decoder.decode(line)) as { type?: unknown; id?: unknown };
+			if (entry.type === "message" && typeof entry.id === "string" && entry.id.length > 0) entryIds.push(entry.id);
+		} catch {
+			// Stats parsing is also lenient: a malformed line cannot own a retained row.
+		}
+	}
+	return entryIds;
+}
+
+async function populateStatsTransferTargets(plans: StatsCleanupPlan[]): Promise<void> {
+	const entryIdsBySession = new Map<string, Promise<string[]>>();
+	for (const plan of plans) {
+		for (const retained of plan.retainedSessions) {
+			let entryIds = entryIdsBySession.get(retained.path);
+			if (!entryIds) {
+				entryIds = collectSessionMessageEntryIds(retained.path);
+				entryIdsBySession.set(retained.path, entryIds);
+			}
+			plan.transfers.push({ path: retained.path, entryIds: await entryIds });
+		}
+	}
+}
+
+/**
+ * Rekey copied entry rows to the newest retained lineage peer before pruning.
+ * The retained file's own offset is never rewritten: it already describes that
+ * file's byte position, while every archived historical offset is deleted.
+ */
+function reconcileStatsRowsForSessions(dbPath: string, plans: StatsCleanupPlan[]): number {
+	if (plans.length === 0) return 0;
+	const db = new Database(dbPath);
+	try {
+		db.run("PRAGMA busy_timeout = 5000");
+		const sessionTables = STATS_SESSION_TABLES.filter(
+			table => tableExists(db, table) && tableHasColumn(db, table, "session_file"),
+		);
+		const entryTables = STATS_ENTRY_TABLES.filter(
+			table => sessionTables.includes(table) && tableHasColumn(db, table, "entry_id"),
+		);
+		const missingEntryIdentity = STATS_ENTRY_TABLES.filter(
+			table => sessionTables.includes(table) && !tableHasColumn(db, table, "entry_id"),
+		);
+		if (
+			missingEntryIdentity.length > 0 &&
+			plans.some(plan => plan.transfers.some(target => target.entryIds.length > 0))
+		) {
+			throw new Error(`stats tables missing entry_id: ${missingEntryIdentity.join(", ")}`);
+		}
+		db.run("CREATE TEMP TABLE gc_retained_entries (entry_id TEXT PRIMARY KEY, target_session_file TEXT NOT NULL)");
+		const clearRetainedEntries = db.prepare("DELETE FROM gc_retained_entries");
+		const insertRetainedEntry = db.prepare(
+			"INSERT OR IGNORE INTO gc_retained_entries (entry_id, target_session_file) VALUES (?, ?)",
+		);
+		const transferStatements = entryTables.map(table =>
+			db.prepare(`
+				UPDATE OR IGNORE ${table}
+				SET session_file = (
+					SELECT target_session_file
+					FROM gc_retained_entries
+					WHERE gc_retained_entries.entry_id = ${table}.entry_id
+				)
+				WHERE session_file = ?
+					AND entry_id IN (SELECT entry_id FROM gc_retained_entries)
+			`),
+		);
+		const deleteStatements = sessionTables.map(table =>
 			db.prepare(`DELETE FROM ${table} WHERE session_file = ? OR instr(session_file, ?) = 1`),
 		);
 		let deleted = 0;
-		const tx = db.transaction((paths: string[]) => {
-			for (const sessionPath of paths) {
-				const nestedPrefix = `${sessionArtifactsPath(sessionPath)}${path.sep}`;
-				for (const statement of statements) {
-					const result = statement.run(sessionPath, nestedPrefix) as SqliteRunResult;
-					deleted += sqliteNumber(result.changes);
+		const tx = db.transaction((cleanupPlans: StatsCleanupPlan[]) => {
+			for (const plan of cleanupPlans) {
+				clearRetainedEntries.run();
+				for (const target of plan.transfers) {
+					for (const entryId of target.entryIds) insertRetainedEntry.run(entryId, target.path);
+				}
+				for (const sessionPath of new Set(plan.sessionPaths)) {
+					for (const statement of transferStatements) statement.run(sessionPath);
+				}
+				for (const sessionPath of new Set(plan.sessionPaths)) {
+					const nestedPrefix = `${sessionArtifactsPath(sessionPath)}${path.sep}`;
+					for (const statement of deleteStatements) {
+						const result = statement.run(sessionPath, nestedPrefix) as SqliteRunResult;
+						deleted += sqliteNumber(result.changes);
+					}
 				}
 			}
 		});
-		tx([...new Set(sessionPaths)]);
+		tx(plans);
 		return deleted;
 	} finally {
 		db.close();
 	}
 }
 
-async function collectArchivedSessionSourcePaths(archiveRoot: string, sessionsRoot: string): Promise<string[]> {
-	const sessionPaths = new Set<string>();
+async function collectArchivedStatsSessions(
+	archiveRoot: string,
+	sessionsRoot: string,
+): Promise<ArchivedStatsSession[]> {
+	const sessions: ArchivedStatsSession[] = [];
 	for (const file of await collectCompressedJsonlFiles(archiveRoot)) {
 		const relative = path.relative(archiveRoot, file);
 		if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) continue;
-		sessionPaths.add(path.join(sessionsRoot, relative.slice(0, -".gz".length)));
+		const sourcePath = path.join(sessionsRoot, relative.slice(0, -".gz".length));
+		const header = sessionLineageHeaderFromText(await readTextIfPresent(file));
+		sessions.push({
+			path: sourcePath,
+			id: header?.id ?? sessionIdFromSessionPath(sourcePath) ?? sourcePath,
+			parentSession: header?.parentSession,
+		});
 	}
-	return [...sessionPaths].sort();
+	return sessions;
 }
 
 async function cleanupStatsRowsForArchivedSessions(
 	options: ResolvedGcOptions,
 	archiveRoot: string,
-	archivedSessionPaths: string[],
+	newlyArchivedSessions: SessionInfo[],
 	result: ArchiveGcResult,
 ): Promise<void> {
 	const dbPath =
@@ -651,20 +918,31 @@ async function cleanupStatsRowsForArchivedSessions(
 			: path.join(options.agentDir, "stats.db");
 	if (!(await pathExists(dbPath))) return;
 
-	const cleanupPaths = new Set(archivedSessionPaths);
+	const archivedByPath = new Map<string, ArchivedStatsSession>();
+	for (const session of newlyArchivedSessions) {
+		archivedByPath.set(path.resolve(session.path), {
+			path: session.path,
+			id: session.id,
+			parentSession: session.parentSessionPath,
+		});
+	}
+
+	let retainedSessions: SessionInfo[];
 	try {
-		for (const sessionPath of await collectArchivedSessionSourcePaths(
-			archiveRoot,
-			getSessionsDir(options.agentDir),
-		)) {
-			cleanupPaths.add(sessionPath);
+		for (const session of await collectArchivedStatsSessions(archiveRoot, getSessionsDir(options.agentDir))) {
+			archivedByPath.set(path.resolve(session.path), session);
 		}
+		retainedSessions = await listActiveSessions(getSessionsDir(options.agentDir));
 	} catch (error) {
 		result.errors.push(`stats cleanup scan: ${errorMessage(error)}`);
+		return;
 	}
 
 	try {
-		result.statsRowsDeleted = deleteStatsRowsForSessions(dbPath, [...cleanupPaths]);
+		const storedSessionPaths = collectStoredStatsSessionPaths(dbPath);
+		const plans = buildStatsCleanupPlans([...archivedByPath.values()], retainedSessions, storedSessionPaths);
+		await populateStatsTransferTargets(plans);
+		result.statsRowsDeleted = reconcileStatsRowsForSessions(dbPath, plans);
 	} catch (error) {
 		result.errors.push(`stats cleanup: ${errorMessage(error)}`);
 	}
@@ -728,20 +1006,20 @@ async function runArchiveGc(options: ResolvedGcOptions, archiveRoot: string): Pr
 	if (!options.apply) return result;
 
 	const archivedSessionIds: string[] = [];
-	const archivedSessionPaths: string[] = [];
+	const archivedSessions: SessionInfo[] = [];
 	for (const candidate of candidates) {
 		try {
 			await moveSessionWithArtifacts(candidate);
 			result.archived += 1;
 			archivedSessionIds.push(candidate.session.id);
-			archivedSessionPaths.push(candidate.session.path);
+			archivedSessions.push(candidate.session);
 		} catch (error) {
 			result.errors.push(`${candidate.session.path}: ${errorMessage(error)}`);
 		}
 	}
 
 	await cleanupHistoryRowsForArchivedSessions(options, archiveRoot, archivedSessionIds, result);
-	await cleanupStatsRowsForArchivedSessions(options, archiveRoot, archivedSessionPaths, result);
+	await cleanupStatsRowsForArchivedSessions(options, archiveRoot, archivedSessions, result);
 	return result;
 }
 

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -2,7 +2,14 @@ import { Database } from "bun:sqlite";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { gunzipSync, gzipSync } from "node:zlib";
-import { getAgentDir, getBlobsDir, getHistoryDbPath, getModelDbPath, getSessionsDir } from "@oh-my-pi/pi-utils";
+import {
+	getAgentDir,
+	getBlobsDir,
+	getHistoryDbPath,
+	getModelDbPath,
+	getSessionsDir,
+	getStatsDbPath,
+} from "@oh-my-pi/pi-utils";
 import { Settings } from "../config/settings";
 import { getDefault } from "../config/settings-schema";
 import { BLOB_HASH_RE } from "../session/blob-store";
@@ -54,6 +61,7 @@ export interface ArchiveGcResult {
 	wouldArchive: number;
 	archived: number;
 	historyRowsDeleted: number;
+	statsRowsDeleted: number;
 	ftsRebuilt: boolean;
 	errors: string[];
 }
@@ -594,6 +602,74 @@ async function cleanupHistoryRowsForArchivedSessions(
 	}
 }
 
+const STATS_SESSION_TABLES = ["messages", "user_messages", "tool_calls", "file_offsets"] as const;
+
+function deleteStatsRowsForSessions(dbPath: string, sessionPaths: string[]): number {
+	if (sessionPaths.length === 0) return 0;
+	const db = new Database(dbPath);
+	try {
+		db.run("PRAGMA busy_timeout = 5000");
+		const statements = STATS_SESSION_TABLES.filter(table => tableExists(db, table)).map(table =>
+			db.prepare(`DELETE FROM ${table} WHERE session_file = ? OR instr(session_file, ?) = 1`),
+		);
+		let deleted = 0;
+		const tx = db.transaction((paths: string[]) => {
+			for (const sessionPath of paths) {
+				const nestedPrefix = `${sessionArtifactsPath(sessionPath)}${path.sep}`;
+				for (const statement of statements) {
+					const result = statement.run(sessionPath, nestedPrefix) as SqliteRunResult;
+					deleted += sqliteNumber(result.changes);
+				}
+			}
+		});
+		tx([...new Set(sessionPaths)]);
+		return deleted;
+	} finally {
+		db.close();
+	}
+}
+
+async function collectArchivedSessionSourcePaths(archiveRoot: string, sessionsRoot: string): Promise<string[]> {
+	const sessionPaths = new Set<string>();
+	for (const file of await collectCompressedJsonlFiles(archiveRoot)) {
+		const relative = path.relative(archiveRoot, file);
+		if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) continue;
+		sessionPaths.add(path.join(sessionsRoot, relative.slice(0, -".gz".length)));
+	}
+	return [...sessionPaths].sort();
+}
+
+async function cleanupStatsRowsForArchivedSessions(
+	options: ResolvedGcOptions,
+	archiveRoot: string,
+	archivedSessionPaths: string[],
+	result: ArchiveGcResult,
+): Promise<void> {
+	const dbPath =
+		path.resolve(options.agentDir) === path.resolve(getAgentDir())
+			? getStatsDbPath()
+			: path.join(options.agentDir, "stats.db");
+	if (!(await pathExists(dbPath))) return;
+
+	const cleanupPaths = new Set(archivedSessionPaths);
+	try {
+		for (const sessionPath of await collectArchivedSessionSourcePaths(
+			archiveRoot,
+			getSessionsDir(options.agentDir),
+		)) {
+			cleanupPaths.add(sessionPath);
+		}
+	} catch (error) {
+		result.errors.push(`stats cleanup scan: ${errorMessage(error)}`);
+	}
+
+	try {
+		result.statsRowsDeleted = deleteStatsRowsForSessions(dbPath, [...cleanupPaths]);
+	} catch (error) {
+		result.errors.push(`stats cleanup: ${errorMessage(error)}`);
+	}
+}
+
 async function runArchiveGc(options: ResolvedGcOptions, archiveRoot: string): Promise<ArchiveGcResult> {
 	const sessionsRoot = getSessionsDir(options.agentDir);
 	const sessions = await listActiveSessions(sessionsRoot);
@@ -606,6 +682,7 @@ async function runArchiveGc(options: ResolvedGcOptions, archiveRoot: string): Pr
 		wouldArchive: 0,
 		archived: 0,
 		historyRowsDeleted: 0,
+		statsRowsDeleted: 0,
 		ftsRebuilt: false,
 		errors: [],
 	};
@@ -651,17 +728,20 @@ async function runArchiveGc(options: ResolvedGcOptions, archiveRoot: string): Pr
 	if (!options.apply) return result;
 
 	const archivedSessionIds: string[] = [];
+	const archivedSessionPaths: string[] = [];
 	for (const candidate of candidates) {
 		try {
 			await moveSessionWithArtifacts(candidate);
 			result.archived += 1;
 			archivedSessionIds.push(candidate.session.id);
+			archivedSessionPaths.push(candidate.session.path);
 		} catch (error) {
 			result.errors.push(`${candidate.session.path}: ${errorMessage(error)}`);
 		}
 	}
 
 	await cleanupHistoryRowsForArchivedSessions(options, archiveRoot, archivedSessionIds, result);
+	await cleanupStatsRowsForArchivedSessions(options, archiveRoot, archivedSessionPaths, result);
 	return result;
 }
 
@@ -917,7 +997,7 @@ function renderText(result: GcResult): string {
 	}
 	if (result.archive) {
 		lines.push(
-			`sessions: ${result.archive.archived}/${result.archive.wouldArchive} archived, ${result.archive.historyRowsDeleted} history rows removed`,
+			`sessions: ${result.archive.archived}/${result.archive.wouldArchive} archived, ${result.archive.historyRowsDeleted} history rows and ${result.archive.statsRowsDeleted} stats rows removed`,
 		);
 		if (result.archive.skippedActive > 0) lines.push(`sessions skipped active: ${result.archive.skippedActive}`);
 		if (result.archive.errors.length > 0) lines.push(`session errors: ${result.archive.errors.length}`);

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -433,6 +433,7 @@ function sessionArtifactsPath(sessionPath: string): string {
 interface SessionLineageHeader {
 	id: string;
 	parentSession?: string;
+	previousSessionFiles: string[];
 }
 
 function sessionLineageHeaderFromText(text: string): SessionLineageHeader | undefined {
@@ -441,7 +442,12 @@ function sessionLineageHeaderFromText(text: string): SessionLineageHeader | unde
 		const line = rawLine.trim();
 		if (!line) continue;
 		try {
-			const record = JSON.parse(line) as { type?: unknown; id?: unknown; parentSession?: unknown };
+			const record = JSON.parse(line) as {
+				type?: unknown;
+				id?: unknown;
+				parentSession?: unknown;
+				previousSessionFiles?: unknown;
+			};
 			if (!sawTitleSlot && record.type === "title") {
 				sawTitleSlot = true;
 				continue;
@@ -450,10 +456,29 @@ function sessionLineageHeaderFromText(text: string): SessionLineageHeader | unde
 			return {
 				id: record.id,
 				parentSession: typeof record.parentSession === "string" ? record.parentSession : undefined,
+				previousSessionFiles: Array.isArray(record.previousSessionFiles)
+					? record.previousSessionFiles.filter(
+							(previousSessionFile): previousSessionFile is string =>
+								typeof previousSessionFile === "string" && previousSessionFile.length > 0,
+						)
+					: [],
 			};
 		} catch {
 			return undefined;
 		}
+	}
+	return undefined;
+}
+
+async function readSessionLineageHeader(file: string): Promise<SessionLineageHeader | undefined> {
+	const decoder = new TextDecoder();
+	const lines: string[] = [];
+	for await (const line of readLines(Bun.file(file).stream())) {
+		const decoded = decoder.decode(line).trim();
+		if (!decoded) continue;
+		lines.push(decoded);
+		const header = sessionLineageHeaderFromText(lines.join("\n"));
+		if (header || lines.length >= 2) return header;
 	}
 	return undefined;
 }
@@ -604,14 +629,17 @@ const STATS_IDENTITY_COLUMNS: Record<StatsEntryTable, readonly string[]> = {
 	tool_calls: ["entry_id", "timestamp", "tool_call_id"],
 };
 
-interface ArchivedStatsSession {
+interface StatsSession {
 	path: string;
 	id: string;
 	parentSession?: string;
+	historicalPaths: string[];
+	identities: Record<StatsEntryTable, StatsEntryIdentity[]>;
 }
 
-interface StatsLineageNode extends ArchivedStatsSession {
+interface StatsLineageNode extends StatsSession {
 	statsPaths: Set<string>;
+	identityKeys: Set<string>;
 }
 
 interface StatsEntryIdentity {
@@ -629,6 +657,33 @@ interface StatsCleanupPlan {
 	sessionPaths: string[];
 	retainedSessions: StatsLineageNode[];
 	transfers: StatsTransferTarget[];
+	archivedIdentityKeys: Set<string>;
+	preserveAll: boolean;
+}
+
+interface StatsCleanupContext {
+	plans: StatsCleanupPlan[];
+	incompleteRetainedSessions: StatsLineageNode[];
+}
+
+function createStatsIdentities(): Record<StatsEntryTable, StatsEntryIdentity[]> {
+	return {
+		messages: [],
+		user_messages: [],
+		tool_calls: [],
+	};
+}
+
+function statsIdentityKey(table: StatsEntryTable, identity: StatsEntryIdentity): string {
+	return `${table}\0${identity.entryId}\0${identity.timestamp}\0${identity.toolCallId}`;
+}
+
+function statsIdentityKeys(identities: Record<StatsEntryTable, StatsEntryIdentity[]>): Set<string> {
+	const keys = new Set<string>();
+	for (const table of STATS_ENTRY_TABLES) {
+		for (const identity of identities[table]) keys.add(statsIdentityKey(table, identity));
+	}
+	return keys;
 }
 
 function tableHasColumn(db: Database, table: string, column: string): boolean {
@@ -636,25 +691,20 @@ function tableHasColumn(db: Database, table: string, column: string): boolean {
 	return rows.some(row => row.name === column);
 }
 
-function collectStoredStatsSessionPaths(dbPath: string): string[] {
-	const db = new Database(dbPath);
-	try {
-		db.run("PRAGMA busy_timeout = 5000");
-		const sessionPaths = new Set<string>();
-		for (const table of STATS_SESSION_TABLES) {
-			if (!tableExists(db, table) || !tableHasColumn(db, table, "session_file")) continue;
-			const rows = db.prepare(`SELECT DISTINCT session_file FROM ${table}`).all() as Array<{
-				session_file?: string | null;
-			}>;
-			for (const row of rows) {
-				if (typeof row.session_file === "string") sessionPaths.add(row.session_file);
-			}
+function collectStoredStatsSessionPaths(db: Database): string[] {
+	const sessionPaths = new Set<string>();
+	for (const table of STATS_SESSION_TABLES) {
+		if (!tableExists(db, table) || !tableHasColumn(db, table, "session_file")) continue;
+		const rows = db.prepare(`SELECT DISTINCT session_file FROM ${table}`).all() as Array<{
+			session_file?: string | null;
+		}>;
+		for (const row of rows) {
+			if (typeof row.session_file === "string") sessionPaths.add(row.session_file);
 		}
-		return [...sessionPaths];
-	} finally {
-		db.close();
 	}
+	return [...sessionPaths];
 }
+
 /**
  * `/move` preserves the session filename and artifacts-directory basename.
  * Recover the top-level path represented by any main or nested stats row so
@@ -674,6 +724,37 @@ function logicalSessionRootForStatsPath(statsPath: string, sessionPath: string):
 	}
 }
 
+function sessionPathEncodesId(sessionPath: string, sessionId: string): boolean {
+	const stem = path.basename(sessionPath, SESSION_SUFFIX);
+	return stem === sessionId || stem.endsWith(`_${sessionId}`);
+}
+
+function managedHistoricalSessionPaths(
+	header: SessionLineageHeader,
+	currentSessionPath: string,
+	sessionsRoot: string,
+): string[] {
+	const root = path.resolve(sessionsRoot);
+	const filename = path.basename(currentSessionPath);
+	const paths = new Set<string>();
+	for (const previousSessionFile of header.previousSessionFiles) {
+		if (!path.isAbsolute(previousSessionFile) || path.basename(previousSessionFile) !== filename) continue;
+		const resolved = path.resolve(previousSessionFile);
+		const relative = path.relative(root, resolved);
+		if (
+			!relative ||
+			relative === ".." ||
+			relative.startsWith(`..${path.sep}`) ||
+			path.isAbsolute(relative) ||
+			!resolved.endsWith(SESSION_SUFFIX)
+		) {
+			continue;
+		}
+		paths.add(resolved);
+	}
+	return [...paths];
+}
+
 function resolveLogicalSessionMatch(
 	statsPath: string,
 	nodes: StatsLineageNode[],
@@ -687,10 +768,14 @@ function resolveLogicalSessionMatch(
 	if (exact.length === 1) return exact[0];
 	if (exact.length > 1) return undefined;
 
-	const stem = matches[0] ? path.basename(matches[0].logicalRoot, SESSION_SUFFIX) : "";
-	const idMatches = matches.filter(match => stem === match.node.id || stem.endsWith(`_${match.node.id}`));
-	if (idMatches.length === 1) return idMatches[0];
-	return undefined;
+	const known = matches.filter(match =>
+		[...match.node.statsPaths].some(statsPath => path.resolve(statsPath) === path.resolve(match.logicalRoot)),
+	);
+	if (known.length === 1) return known[0];
+	if (known.length > 1) return undefined;
+
+	const idMatches = matches.filter(match => sessionPathEncodesId(match.logicalRoot, match.node.id));
+	return idMatches.length === 1 ? idMatches[0] : undefined;
 }
 
 /**
@@ -699,25 +784,31 @@ function resolveLogicalSessionMatch(
  * unresolved so cleanup fails safe instead of transferring across sessions.
  */
 function buildStatsCleanupPlans(
-	archivedSessions: ArchivedStatsSession[],
-	retainedSessions: SessionInfo[],
-	storedSessionPaths: string[],
-): StatsCleanupPlan[] {
+	archivedSessions: StatsSession[],
+	retainedSessions: StatsSession[],
+	dbPath: string,
+): StatsCleanupContext {
 	const archivedNodes: StatsLineageNode[] = archivedSessions.map(session => ({
 		...session,
-		statsPaths: new Set([session.path]),
+		statsPaths: new Set([session.path, ...session.historicalPaths]),
+		identityKeys: statsIdentityKeys(session.identities),
 	}));
 	const retainedNodes: StatsLineageNode[] = retainedSessions.map(session => ({
-		path: session.path,
-		id: session.id,
-		parentSession: session.parentSessionPath,
-		statsPaths: new Set([session.path]),
+		...session,
+		statsPaths: new Set([session.path, ...session.historicalPaths]),
+		identityKeys: statsIdentityKeys(session.identities),
 	}));
 	const nodes = [...archivedNodes, ...retainedNodes];
 
-	for (const storedPath of storedSessionPaths) {
-		const match = resolveLogicalSessionMatch(storedPath, nodes);
-		if (match) match.node.statsPaths.add(match.logicalRoot);
+	const db = new Database(dbPath);
+	try {
+		db.run("PRAGMA busy_timeout = 5000");
+		for (const storedPath of collectStoredStatsSessionPaths(db)) {
+			const match = resolveLogicalSessionMatch(storedPath, nodes);
+			if (match) match.node.statsPaths.add(match.logicalRoot);
+		}
+	} finally {
+		db.close();
 	}
 
 	for (const child of nodes) {
@@ -730,6 +821,17 @@ function buildStatsCleanupPlans(
 		const match = resolveLogicalSessionMatch(child.parentSession, nodes);
 		if (match) match.node.statsPaths.add(match.logicalRoot);
 	}
+
+	const archivedPathClaimCounts = new Map<string, number>();
+	for (const archived of archivedNodes) {
+		for (const statsPath of archived.statsPaths) {
+			const key = path.resolve(statsPath);
+			archivedPathClaimCounts.set(key, (archivedPathClaimCounts.get(key) ?? 0) + 1);
+		}
+	}
+	const ambiguousArchivedPathKeys = new Set(
+		[...archivedPathClaimCounts].filter(([, count]) => count > 1).map(([key]) => key),
+	);
 
 	const aliases = new Map<string, StatsLineageNode | null>();
 	const identityKeysByNode = new Map<StatsLineageNode, Set<string>>();
@@ -748,12 +850,17 @@ function buildStatsCleanupPlans(
 		}
 	}
 
+	const incompleteLineage = new Set<StatsLineageNode>();
 	const lineageKeysByNode = new Map<StatsLineageNode, Set<string>>();
 	for (const node of nodes) {
 		const lineageKeys = new Set(identityKeysByNode.get(node));
 		let current: StatsLineageNode | null = node;
 		const seen = new Set<StatsLineageNode>();
-		while (current?.parentSession && !seen.has(current)) {
+		while (current?.parentSession) {
+			if (seen.has(current)) {
+				incompleteLineage.add(node);
+				break;
+			}
 			seen.add(current);
 			const parentReference = current.parentSession;
 			const parentKey =
@@ -762,7 +869,10 @@ function buildStatsCleanupPlans(
 					: `id:${parentReference}`;
 			lineageKeys.add(parentKey);
 			const parent = aliases.get(parentKey);
-			if (!parent) break;
+			if (!parent) {
+				incompleteLineage.add(node);
+				break;
+			}
 			for (const key of identityKeysByNode.get(parent) ?? []) lineageKeys.add(key);
 			current = parent;
 		}
@@ -772,97 +882,130 @@ function buildStatsCleanupPlans(
 	const retainedPathKeys = new Set(
 		retainedNodes.flatMap(retained => [...retained.statsPaths].map(statsPath => path.resolve(statsPath))),
 	);
-	return archivedNodes.map(archived => {
+	const plans = archivedNodes.map(archived => {
 		const archivedLineage = lineageKeysByNode.get(archived) ?? new Set<string>();
 		return {
-			sessionPaths: [...archived.statsPaths].filter(statsPath => !retainedPathKeys.has(path.resolve(statsPath))),
+			sessionPaths: [...archived.statsPaths].filter(statsPath => {
+				const key = path.resolve(statsPath);
+				return !retainedPathKeys.has(key) && !ambiguousArchivedPathKeys.has(key);
+			}),
 			retainedSessions: retainedNodes.filter(retained => {
+				if (incompleteLineage.has(retained)) return false;
 				const retainedLineage = lineageKeysByNode.get(retained);
 				return retainedLineage ? [...retainedLineage].some(key => archivedLineage.has(key)) : false;
 			}),
 			transfers: [],
+			archivedIdentityKeys: archived.identityKeys,
+			preserveAll: false,
 		};
 	});
+	return {
+		plans,
+		incompleteRetainedSessions: retainedNodes.filter(retained => incompleteLineage.has(retained)),
+	};
+}
+
+function addSessionStatsIdentity(line: string, identities: Record<StatsEntryTable, StatsEntryIdentity[]>): void {
+	if (line.length === 0) return;
+	try {
+		const record: unknown = JSON.parse(line);
+		if (
+			!record ||
+			typeof record !== "object" ||
+			!("type" in record) ||
+			record.type !== "message" ||
+			!("id" in record) ||
+			typeof record.id !== "string" ||
+			record.id.length === 0 ||
+			!("message" in record) ||
+			!record.message ||
+			typeof record.message !== "object"
+		) {
+			return;
+		}
+		const message = record.message;
+		if (!("role" in message)) return;
+		const parsedEntryTimestamp =
+			"timestamp" in record && typeof record.timestamp === "string" ? Date.parse(record.timestamp) : Number.NaN;
+		if (message.role === "user") {
+			identities.user_messages.push({
+				entryId: record.id,
+				timestamp: Number.isFinite(parsedEntryTimestamp) ? parsedEntryTimestamp : 0,
+				toolCallId: "",
+			});
+			return;
+		}
+		if (message.role !== "assistant") return;
+		const timestamp =
+			"timestamp" in message && typeof message.timestamp === "number" && Number.isFinite(message.timestamp)
+				? message.timestamp
+				: Number.isFinite(parsedEntryTimestamp)
+					? parsedEntryTimestamp
+					: 0;
+		identities.messages.push({ entryId: record.id, timestamp, toolCallId: "" });
+		if (!("content" in message) || !Array.isArray(message.content)) return;
+		for (const block of message.content) {
+			if (
+				block &&
+				typeof block === "object" &&
+				"type" in block &&
+				block.type === "toolCall" &&
+				"id" in block &&
+				typeof block.id === "string"
+			) {
+				identities.tool_calls.push({ entryId: record.id, timestamp, toolCallId: block.id });
+			}
+		}
+	} catch {
+		// Stats parsing is also lenient: a malformed line cannot own a retained row.
+	}
+}
+
+function collectSessionStatsIdentitiesFromText(text: string): Record<StatsEntryTable, StatsEntryIdentity[]> {
+	const identities = createStatsIdentities();
+	for (const line of text.split(/\r?\n/)) addSessionStatsIdentity(line, identities);
+	return identities;
 }
 
 async function collectSessionStatsIdentities(
 	sessionPath: string,
 ): Promise<Record<StatsEntryTable, StatsEntryIdentity[]>> {
-	const identities: Record<StatsEntryTable, StatsEntryIdentity[]> = {
-		messages: [],
-		user_messages: [],
-		tool_calls: [],
-	};
+	const identities = createStatsIdentities();
 	const decoder = new TextDecoder();
 	for await (const line of readLines(Bun.file(sessionPath).stream())) {
-		if (line.length === 0) continue;
-		try {
-			const record: unknown = JSON.parse(decoder.decode(line));
-			if (
-				!record ||
-				typeof record !== "object" ||
-				!("type" in record) ||
-				record.type !== "message" ||
-				!("id" in record) ||
-				typeof record.id !== "string" ||
-				record.id.length === 0 ||
-				!("message" in record) ||
-				!record.message ||
-				typeof record.message !== "object"
-			) {
-				continue;
-			}
-			const message = record.message;
-			if (!("role" in message)) continue;
-			const parsedEntryTimestamp =
-				"timestamp" in record && typeof record.timestamp === "string" ? Date.parse(record.timestamp) : Number.NaN;
-			if (message.role === "user") {
-				identities.user_messages.push({
-					entryId: record.id,
-					timestamp: Number.isFinite(parsedEntryTimestamp) ? parsedEntryTimestamp : 0,
-					toolCallId: "",
-				});
-				continue;
-			}
-			if (message.role !== "assistant") continue;
-			const timestamp =
-				"timestamp" in message && typeof message.timestamp === "number" && Number.isFinite(message.timestamp)
-					? message.timestamp
-					: Number.isFinite(parsedEntryTimestamp)
-						? parsedEntryTimestamp
-						: 0;
-			identities.messages.push({ entryId: record.id, timestamp, toolCallId: "" });
-			if (!("content" in message) || !Array.isArray(message.content)) continue;
-			for (const block of message.content) {
-				if (
-					block &&
-					typeof block === "object" &&
-					"type" in block &&
-					block.type === "toolCall" &&
-					"id" in block &&
-					typeof block.id === "string" &&
-					block.id.length > 0
-				) {
-					identities.tool_calls.push({ entryId: record.id, timestamp, toolCallId: block.id });
-				}
-			}
-		} catch {
-			// Stats parsing is also lenient: a malformed line cannot own a retained row.
-		}
+		addSessionStatsIdentity(decoder.decode(line), identities);
 	}
 	return identities;
 }
 
-async function populateStatsTransferTargets(plans: StatsCleanupPlan[]): Promise<void> {
+async function populateStatsTransferTargets(context: StatsCleanupContext): Promise<void> {
 	const identitiesBySession = new Map<string, Promise<Record<StatsEntryTable, StatsEntryIdentity[]>>>();
-	for (const plan of plans) {
+	const identitiesFor = (session: StatsLineageNode): Promise<Record<StatsEntryTable, StatsEntryIdentity[]>> => {
+		let identities = identitiesBySession.get(session.path);
+		if (!identities) {
+			identities = collectSessionStatsIdentities(session.path);
+			identitiesBySession.set(session.path, identities);
+		}
+		return identities;
+	};
+
+	const incompleteIdentityKeys = new Set<string>();
+	let hasUnidentifiableIncompleteSession = false;
+	for (const retained of context.incompleteRetainedSessions) {
+		const keys = statsIdentityKeys(await identitiesFor(retained));
+		if (keys.size === 0) hasUnidentifiableIncompleteSession = true;
+		for (const key of keys) incompleteIdentityKeys.add(key);
+	}
+
+	for (const plan of context.plans) {
+		if (context.incompleteRetainedSessions.length > 0) {
+			plan.preserveAll =
+				hasUnidentifiableIncompleteSession ||
+				plan.archivedIdentityKeys.size === 0 ||
+				[...plan.archivedIdentityKeys].some(key => incompleteIdentityKeys.has(key));
+		}
 		for (const retained of plan.retainedSessions) {
-			let identities = identitiesBySession.get(retained.path);
-			if (!identities) {
-				identities = collectSessionStatsIdentities(retained.path);
-				identitiesBySession.set(retained.path, identities);
-			}
-			plan.transfers.push({ path: retained.path, identities: await identities });
+			plan.transfers.push({ path: retained.path, identities: await identitiesFor(retained) });
 		}
 	}
 }
@@ -933,6 +1076,7 @@ function reconcileStatsRowsForSessions(dbPath: string, plans: StatsCleanupPlan[]
 		let deleted = 0;
 		const tx = db.transaction((cleanupPlans: StatsCleanupPlan[]) => {
 			for (const plan of cleanupPlans) {
+				if (plan.preserveAll) continue;
 				clearRetainedEntries.run();
 				for (const target of plan.transfers) {
 					for (const table of entryTables) {
@@ -975,19 +1119,22 @@ async function collectArchivedStatsSessions(
 	archiveRoot: string,
 	sessionsRoot: string,
 	onError: (file: string, error: unknown) => void,
-): Promise<ArchivedStatsSession[]> {
-	const sessions: ArchivedStatsSession[] = [];
+): Promise<StatsSession[]> {
+	const sessions: StatsSession[] = [];
 	for (const file of await collectCompressedJsonlFiles(archiveRoot)) {
 		const relative = path.relative(archiveRoot, file);
 		if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) continue;
 		const sourcePath = path.join(sessionsRoot, relative.slice(0, -".gz".length));
 		try {
-			const header = sessionLineageHeaderFromText(await readTextIfPresent(file));
+			const text = await readTextIfPresent(file);
+			const header = sessionLineageHeaderFromText(text);
 			if (!header) throw new Error("archive is missing a valid session header");
 			sessions.push({
 				path: sourcePath,
 				id: header.id,
 				parentSession: header.parentSession,
+				historicalPaths: managedHistoricalSessionPaths(header, sourcePath, sessionsRoot),
+				identities: collectSessionStatsIdentitiesFromText(text),
 			});
 		} catch (error) {
 			onError(file, error);
@@ -1007,32 +1154,31 @@ async function cleanupStatsRowsForArchivedSessions(
 			? getStatsDbPath()
 			: path.join(options.agentDir, "stats.db");
 	if (!(await pathExists(dbPath))) return;
+	const sessionsRoot = getSessionsDir(options.agentDir);
 
-	const archivedByPath = new Map<string, ArchivedStatsSession>();
+	const archivedByPath = new Map<string, StatsSession>();
 	for (const session of newlyArchivedSessions) {
 		archivedByPath.set(path.resolve(session.path), {
 			path: session.path,
 			id: session.id,
 			parentSession: session.parentSessionPath,
+			historicalPaths: [],
+			identities: createStatsIdentities(),
 		});
 	}
 
 	let retainedSessions: SessionInfo[];
 	try {
-		for (const session of await collectArchivedStatsSessions(
-			archiveRoot,
-			getSessionsDir(options.agentDir),
-			(file, error) => {
-				result.errors.push(`stats cleanup scan ${file}: ${errorMessage(error)}`);
-			},
-		)) {
+		for (const session of await collectArchivedStatsSessions(archiveRoot, sessionsRoot, (file, error) => {
+			result.errors.push(`stats cleanup scan ${file}: ${errorMessage(error)}`);
+		})) {
 			archivedByPath.set(path.resolve(session.path), session);
 		}
 	} catch (error) {
 		result.errors.push(`stats cleanup scan: ${errorMessage(error)}`);
 	}
 	try {
-		retainedSessions = await listActiveSessions(getSessionsDir(options.agentDir));
+		retainedSessions = await listActiveSessions(sessionsRoot);
 	} catch (error) {
 		result.errors.push(`stats cleanup scan: ${errorMessage(error)}`);
 		return;
@@ -1040,10 +1186,24 @@ async function cleanupStatsRowsForArchivedSessions(
 
 	try {
 		await withStatsSyncLock(dbPath, async () => {
-			const storedSessionPaths = collectStoredStatsSessionPaths(dbPath);
-			const plans = buildStatsCleanupPlans([...archivedByPath.values()], retainedSessions, storedSessionPaths);
-			await populateStatsTransferTargets(plans);
-			result.statsRowsDeleted = reconcileStatsRowsForSessions(dbPath, plans);
+			const retainedStatsSessions = await Promise.all(
+				retainedSessions.map(async session => {
+					const header = await readSessionLineageHeader(session.path);
+					if (!header || header.id !== session.id) {
+						throw new Error(`session header changed during stats cleanup: ${session.path}`);
+					}
+					return {
+						path: session.path,
+						id: session.id,
+						parentSession: header.parentSession,
+						historicalPaths: managedHistoricalSessionPaths(header, session.path, sessionsRoot),
+						identities: createStatsIdentities(),
+					};
+				}),
+			);
+			const context = buildStatsCleanupPlans([...archivedByPath.values()], retainedStatsSessions, dbPath);
+			await populateStatsTransferTargets(context);
+			result.statsRowsDeleted = reconcileStatsRowsForSessions(dbPath, context.plans);
 		});
 	} catch (error) {
 		result.errors.push(`stats cleanup: ${errorMessage(error)}`);

--- a/packages/coding-agent/src/export/html/index.ts
+++ b/packages/coding-agent/src/export/html/index.ts
@@ -181,10 +181,17 @@ export interface SessionData {
 	subSessions?: Record<string, SubSession>;
 }
 
+function sessionHeaderForExport(header: SessionHeader | null): SessionHeader | null {
+	if (!header) return null;
+	const exported = { ...header };
+	delete exported.previousSessionFiles;
+	return exported;
+}
+
 /** Snapshot the session (plus optional agent state) into the JSON shape the viewer renders. */
 export function buildSessionData(sm: SessionManager, state?: AgentState): SessionData {
 	return {
-		header: sm.getHeader(),
+		header: sessionHeaderForExport(sm.getHeader()),
 		entries: sm.getEntries(),
 		leafId: sm.getLeafId(),
 		systemPrompt: state?.systemPrompt.join("\n\n"),
@@ -231,7 +238,7 @@ async function collectSubSessionsFromDir(
 			out[key] = {
 				agentId,
 				parent: parentKey,
-				header,
+				header: sessionHeaderForExport(header),
 				entries,
 				leafId: entries.length > 0 ? entries[entries.length - 1].id : null,
 			};
@@ -295,7 +302,7 @@ export async function exportFromFile(inputPath: string, options?: ExportOptions 
 	}
 
 	const sessionData: SessionData = {
-		header: sm.getHeader(),
+		header: sessionHeaderForExport(sm.getHeader()),
 		entries: sm.getEntries(),
 		leafId: sm.getLeafId(),
 	};

--- a/packages/coding-agent/src/export/share.ts
+++ b/packages/coding-agent/src/export/share.ts
@@ -223,6 +223,7 @@ function collectShareRegexSecretValues(o: SecretObfuscator, data: SessionData): 
 		if (!header) return;
 		add(header.title);
 		add(header.cwd);
+		for (const previousSessionFile of header.previousSessionFiles ?? []) add(previousSessionFile);
 	};
 
 	addHeader(data.header);
@@ -246,6 +247,9 @@ function redactShareHeader(
 		...header,
 		title: header.title === undefined ? undefined : o.obfuscate(header.title, sharedRegexSecretValues),
 		cwd: o.obfuscate(header.cwd, sharedRegexSecretValues),
+		previousSessionFiles: header.previousSessionFiles?.map(previousSessionFile =>
+			o.obfuscate(previousSessionFile, sharedRegexSecretValues),
+		),
 	};
 }
 

--- a/packages/coding-agent/src/session/session-entries.ts
+++ b/packages/coding-agent/src/session/session-entries.ts
@@ -39,6 +39,8 @@ export interface SessionHeader {
 	 */
 	additionalDirectories?: string[];
 	parentSession?: string;
+	/** Prior absolute JSONL locations recorded by successful session moves. */
+	previousSessionFiles?: string[];
 	/** Provider prompt-cache identity inherited by exact-route full forks. */
 	providerPromptCacheKey?: string;
 }

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1383,6 +1383,12 @@ export class SessionManager {
 				throw err;
 			}
 
+			if (sessionFileExisted && sessionPathChanged) {
+				this.#header.previousSessionFiles = [
+					...new Set([...(this.#header.previousSessionFiles ?? []), path.resolve(oldSessionFile)]),
+				];
+			}
+
 			this.#sessionFile = newSessionFile;
 			this.#artifactManager = null;
 			this.#artifactManagerSessionFile = null;

--- a/packages/coding-agent/test/export-subsessions.test.ts
+++ b/packages/coding-agent/test/export-subsessions.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
-import { collectSubSessions } from "../src/export/html";
+import { collectSubSessions, exportFromFile } from "../src/export/html";
 
 /**
  * Contract: a session at `<dir>/<name>.jsonl` embeds subagent transcripts from
@@ -11,9 +11,16 @@ import { collectSubSessions } from "../src/export/html";
  * parent links and last-entry leaf ids. Corrupt/empty/backup files are skipped.
  */
 
-function sessionJsonl(id: string, entryIds: string[]): string {
+function sessionJsonl(id: string, entryIds: string[], previousSessionFiles?: string[]): string {
 	const lines = [
-		JSON.stringify({ type: "session", version: 3, id, timestamp: "2026-06-12T00:00:00.000Z", cwd: "/tmp" }),
+		JSON.stringify({
+			type: "session",
+			version: 3,
+			id,
+			timestamp: "2026-06-12T00:00:00.000Z",
+			cwd: "/tmp",
+			previousSessionFiles,
+		}),
 	];
 	let parent: string | null = null;
 	for (const entryId of entryIds) {
@@ -58,6 +65,28 @@ describe("collectSubSessions", () => {
 		expect(subs.Alpha.header?.id).toBe("alpha");
 		expect(subs["Alpha/Child"]).toMatchObject({ agentId: "Child", parent: "Alpha", leafId: "c1" });
 		expect(subs.Beta).toMatchObject({ agentId: "Beta", parent: null, leafId: "b1" });
+	});
+
+	test("omits internal move history from standalone HTML", async () => {
+		const mainPreviousPath = "/Users/private/main.jsonl";
+		const subPreviousPath = "/Users/private/Alpha.jsonl";
+		await Bun.write(mainFile, sessionJsonl("main", ["m1"], [mainPreviousPath]));
+		await Bun.write(path.join(root, "main/Alpha.jsonl"), sessionJsonl("alpha", ["a1"], [subPreviousPath]));
+		const outputPath = path.join(root, "export.html");
+
+		await exportFromFile(mainFile, { outputPath });
+
+		const html = await Bun.file(outputPath).text();
+		const encoded = html.match(/<script id="session-data" type="application\/json">([^<]+)<\/script>/)?.[1];
+		expect(encoded).toBeDefined();
+		const data = JSON.parse(Buffer.from(encoded!, "base64").toString("utf8")) as {
+			header: { previousSessionFiles?: string[] };
+			subSessions: Record<string, { header: { previousSessionFiles?: string[] } }>;
+		};
+		expect(data.header.previousSessionFiles).toBeUndefined();
+		expect(data.subSessions.Alpha.header.previousSessionFiles).toBeUndefined();
+		expect(html).not.toContain(mainPreviousPath);
+		expect(html).not.toContain(subPreviousPath);
 	});
 
 	test("skips corrupt, empty, backup, and non-jsonl files", async () => {

--- a/packages/coding-agent/test/gc-cli.test.ts
+++ b/packages/coding-agent/test/gc-cli.test.ts
@@ -625,6 +625,244 @@ describe("runGcCommand cold-session archive", () => {
 		expect(remaining).toEqual(Object.fromEntries(tables.map(table => [table, [keepSession]])));
 	});
 
+	test("transfers shared stats among retained branches while pruning archived lineage members", async () => {
+		const sessionsDir = path.join(getSessionsDir(root), "project");
+		await fs.mkdir(sessionsDir, { recursive: true });
+		const parent = path.join(sessionsDir, "20260626_parent-session.jsonl");
+		const child = path.join(sessionsDir, "20260726_child-session.jsonl");
+		const sibling = path.join(sessionsDir, "20260725_sibling-session.jsonl");
+		const timestamp = "2026-06-26T12:00:00.000Z";
+		const sharedUser = {
+			type: "message",
+			id: "shared-user",
+			parentId: null,
+			timestamp,
+			message: { role: "user", content: "shared" },
+		};
+		const sharedAssistant = {
+			type: "message",
+			id: "shared-assistant",
+			parentId: "shared-user",
+			timestamp,
+			message: { role: "assistant", content: [] },
+		};
+		const parentOnlyUser = {
+			type: "message",
+			id: "parent-only-user",
+			parentId: "shared-assistant",
+			timestamp,
+			message: { role: "user", content: "abandoned branch" },
+		};
+		const parentOnlyAssistant = {
+			type: "message",
+			id: "parent-only-assistant",
+			parentId: "parent-only-user",
+			timestamp,
+			message: { role: "assistant", content: [] },
+		};
+		await Bun.write(
+			parent,
+			[
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "parent-session",
+					timestamp,
+					cwd: "/tmp",
+				}),
+				sharedUser,
+				sharedAssistant,
+				parentOnlyUser,
+				parentOnlyAssistant,
+				"",
+			]
+				.map(entry => (typeof entry === "string" ? entry : JSON.stringify(entry)))
+				.join("\n"),
+		);
+		await agePath(parent, 90);
+		await Bun.write(
+			child,
+			[
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "child-session",
+					timestamp,
+					cwd: "/tmp",
+					parentSession: parent,
+				}),
+				JSON.stringify(sharedUser),
+				JSON.stringify(sharedAssistant),
+				"",
+			].join("\n"),
+		);
+		await Bun.write(
+			sibling,
+			[
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "sibling-session",
+					timestamp,
+					cwd: "/tmp",
+					parentSession: parent,
+				}),
+				JSON.stringify(sharedUser),
+				JSON.stringify(sharedAssistant),
+				"",
+			].join("\n"),
+		);
+		await agePath(sibling, 1);
+		const siblingStat = await fs.stat(sibling);
+		const childStat = await fs.stat(child);
+
+		const statsDbPath = path.join(root, "stats.db");
+		const db = new Database(statsDbPath);
+		db.run(
+			"CREATE TABLE messages (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, UNIQUE(session_file, entry_id))",
+		);
+		db.run(
+			"CREATE TABLE user_messages (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, UNIQUE(session_file, entry_id))",
+		);
+		db.run(
+			"CREATE TABLE tool_calls (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, tool_call_id TEXT NOT NULL, UNIQUE(session_file, tool_call_id))",
+		);
+		db.run(
+			"CREATE TABLE file_offsets (session_file TEXT PRIMARY KEY, offset INTEGER NOT NULL, last_modified INTEGER NOT NULL)",
+		);
+		for (const [table, sharedId, parentOnlyId] of [
+			["messages", "shared-assistant", "parent-only-assistant"],
+			["user_messages", "shared-user", "parent-only-user"],
+		] as const) {
+			const insert = db.prepare(`INSERT INTO ${table} (session_file, entry_id) VALUES (?, ?)`);
+			insert.run(parent, sharedId);
+			insert.run(parent, parentOnlyId);
+		}
+		const insertToolCall = db.prepare(
+			"INSERT INTO tool_calls (session_file, entry_id, tool_call_id) VALUES (?, ?, ?)",
+		);
+		insertToolCall.run(parent, "shared-assistant", "shared-tool");
+		insertToolCall.run(parent, "parent-only-assistant", "parent-only-tool");
+		db.prepare("INSERT INTO file_offsets (session_file, offset, last_modified) VALUES (?, ?, ?)").run(parent, 444, 1);
+		const insertOffset = db.prepare(
+			"INSERT INTO file_offsets (session_file, offset, last_modified) VALUES (?, ?, ?)",
+		);
+		insertOffset.run(child, childStat.size, childStat.mtimeMs);
+		insertOffset.run(sibling, siblingStat.size, siblingStat.mtimeMs);
+		db.close();
+
+		const result = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+
+		const check = new Database(statsDbPath);
+		const messages = check.prepare("SELECT session_file, entry_id FROM messages").all();
+		const userMessages = check.prepare("SELECT session_file, entry_id FROM user_messages").all();
+		const toolCalls = check.prepare("SELECT session_file, entry_id, tool_call_id FROM tool_calls").all();
+		const offsets = check
+			.prepare("SELECT session_file, offset, last_modified FROM file_offsets ORDER BY session_file")
+			.all();
+		check.close();
+
+		expect(result.archive?.archived).toBe(1);
+		expect(result.archive?.statsRowsDeleted).toBe(4);
+		expect(result.archive?.errors).toEqual([]);
+		expect(messages).toEqual([{ session_file: child, entry_id: "shared-assistant" }]);
+		expect(userMessages).toEqual([{ session_file: child, entry_id: "shared-user" }]);
+		expect(toolCalls).toEqual([{ session_file: child, entry_id: "shared-assistant", tool_call_id: "shared-tool" }]);
+		expect(offsets).toEqual([
+			{ session_file: sibling, offset: siblingStat.size, last_modified: siblingStat.mtimeMs },
+			{ session_file: child, offset: childStat.size, last_modified: childStat.mtimeMs },
+		]);
+
+		await agePath(child, 90);
+		const second = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+		const secondCheck = new Database(statsDbPath);
+		const secondMessages = secondCheck.prepare("SELECT session_file, entry_id FROM messages").all();
+		const secondUserMessages = secondCheck.prepare("SELECT session_file, entry_id FROM user_messages").all();
+		const secondToolCalls = secondCheck.prepare("SELECT session_file, entry_id, tool_call_id FROM tool_calls").all();
+		const secondOffsets = secondCheck.prepare("SELECT session_file, offset, last_modified FROM file_offsets").all();
+		secondCheck.close();
+
+		expect(second.archive?.archived).toBe(1);
+		expect(second.archive?.statsRowsDeleted).toBe(1);
+		expect(second.archive?.errors).toEqual([]);
+		expect(secondMessages).toEqual([{ session_file: sibling, entry_id: "shared-assistant" }]);
+		expect(secondUserMessages).toEqual([{ session_file: sibling, entry_id: "shared-user" }]);
+		expect(secondToolCalls).toEqual([
+			{ session_file: sibling, entry_id: "shared-assistant", tool_call_id: "shared-tool" },
+		]);
+		expect(secondOffsets).toEqual([
+			{ session_file: sibling, offset: siblingStat.size, last_modified: siblingStat.mtimeMs },
+		]);
+	});
+
+	test("prunes stats still owned by a session's paths from before it moved", async () => {
+		const original = await writeSession(root, "before-move", "moved-session", "complete", {
+			filename: "20260626_moved-session",
+		});
+		const moved = path.join(getSessionsDir(root), "after-move", path.basename(original));
+		await fs.mkdir(path.dirname(moved), { recursive: true });
+		await fs.rename(original, moved);
+		await agePath(moved, 90);
+		const historicalNested = path.join(original.slice(0, -".jsonl".length), "nested.jsonl");
+
+		const statsDbPath = path.join(root, "stats.db");
+		const tables = ["messages", "user_messages", "tool_calls", "file_offsets"] as const;
+		const db = new Database(statsDbPath);
+		for (const table of tables) {
+			db.run(`CREATE TABLE ${table} (session_file TEXT NOT NULL)`);
+			const insert = db.prepare(`INSERT INTO ${table} (session_file) VALUES (?)`);
+			insert.run(original);
+			insert.run(historicalNested);
+		}
+		db.prepare("INSERT INTO file_offsets (session_file) VALUES (?)").run(moved);
+		db.close();
+
+		const result = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+
+		const check = new Database(statsDbPath);
+		const remaining = Object.fromEntries(
+			tables.map(table => [
+				table,
+				(check.prepare(`SELECT session_file FROM ${table}`).all() as Array<{ session_file: string }>).map(
+					row => row.session_file,
+				),
+			]),
+		);
+		check.close();
+
+		expect(result.archive?.archived).toBe(1);
+		expect(result.archive?.statsRowsDeleted).toBe(9);
+		expect(result.archive?.errors).toEqual([]);
+		expect(remaining).toEqual(Object.fromEntries(tables.map(table => [table, []])));
+	});
+
 	test("reports stats cleanup failures and retries rows for already archived sessions", async () => {
 		const session = await writeSession(root, "project", "archive-me", "complete", {
 			ageDays: 90,

--- a/packages/coding-agent/test/gc-cli.test.ts
+++ b/packages/coding-agent/test/gc-cli.test.ts
@@ -1000,6 +1000,135 @@ describe("runGcCommand cold-session archive", () => {
 		expect(remaining).toEqual(Object.fromEntries(tables.map(table => [table, []])));
 	});
 
+	test("uses persisted move history to prune custom names without claiming identity collisions", async () => {
+		const timestamp = "2026-06-26T12:00:00.000Z";
+		const timestampMs = Date.parse(timestamp);
+		const original = await writeSession(root, "before-move", "custom-session-id", "complete", {
+			filename: "custom-name",
+		});
+		const sharedAssistant = {
+			type: "message",
+			id: "custom-entry",
+			parentId: null,
+			timestamp,
+			message: { role: "assistant", content: [] },
+		};
+		await Bun.write(
+			original,
+			[
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "custom-session-id",
+					timestamp,
+					cwd: "/tmp",
+					previousSessionFiles: [original],
+				}),
+				JSON.stringify(sharedAssistant),
+				"",
+			].join("\n"),
+		);
+		const moved = path.join(getSessionsDir(root), "after-move", path.basename(original));
+		await fs.mkdir(path.dirname(moved), { recursive: true });
+		await fs.rename(original, moved);
+		await agePath(moved, 90);
+		const historicalNested = path.join(original.slice(0, -".jsonl".length), "nested.jsonl");
+		const unrelated = path.join(getSessionsDir(root), "unrelated", path.basename(original));
+
+		const statsDbPath = path.join(root, "stats.db");
+		const db = new Database(statsDbPath);
+		db.run(
+			"CREATE TABLE messages (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, timestamp INTEGER NOT NULL, UNIQUE(session_file, entry_id))",
+		);
+		db.run(
+			"CREATE TABLE file_offsets (session_file TEXT PRIMARY KEY, offset INTEGER NOT NULL, last_modified INTEGER NOT NULL)",
+		);
+		const insertMessage = db.prepare("INSERT INTO messages (session_file, entry_id, timestamp) VALUES (?, ?, ?)");
+		insertMessage.run(original, sharedAssistant.id, timestampMs);
+		insertMessage.run(historicalNested, "nested-entry", timestampMs);
+		insertMessage.run(unrelated, sharedAssistant.id, timestampMs);
+		const insertOffset = db.prepare(
+			"INSERT INTO file_offsets (session_file, offset, last_modified) VALUES (?, ?, ?)",
+		);
+		insertOffset.run(original, 1, 1);
+		insertOffset.run(moved, 2, 2);
+		db.close();
+
+		const result = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+		const check = new Database(statsDbPath);
+		const messages = check.prepare("SELECT session_file, entry_id FROM messages").all();
+		const offsets = check.prepare("SELECT session_file FROM file_offsets").all();
+		check.close();
+
+		expect(result.archive?.archived).toBe(1);
+		expect(result.archive?.statsRowsDeleted).toBe(4);
+		expect(result.archive?.errors).toEqual([]);
+		expect(messages).toEqual([{ session_file: unrelated, entry_id: sharedAssistant.id }]);
+		expect(offsets).toEqual([]);
+	});
+
+	test("preserves a historical path claimed by multiple archived sessions", async () => {
+		const timestamp = "2026-06-26T12:00:00.000Z";
+		const previousSessionFile = path.join(getSessionsDir(root), "before-move", "custom-name.jsonl");
+		for (const [project, id] of [
+			["archive-one", "session-one"],
+			["archive-two", "session-two"],
+		] as const) {
+			const current = path.join(getSessionsDir(root), project, "custom-name.jsonl");
+			await fs.mkdir(path.dirname(current), { recursive: true });
+			await Bun.write(
+				current,
+				[
+					JSON.stringify({
+						type: "session",
+						version: 3,
+						id,
+						timestamp,
+						cwd: "/tmp",
+						previousSessionFiles: [previousSessionFile],
+					}),
+					JSON.stringify({ type: "message", message: { role: "assistant", content: [] } }),
+					"",
+				].join("\n"),
+			);
+			await agePath(current, 90);
+		}
+
+		const statsDbPath = path.join(root, "stats.db");
+		const db = new Database(statsDbPath);
+		db.run("CREATE TABLE messages (session_file TEXT NOT NULL)");
+		db.prepare("INSERT INTO messages (session_file) VALUES (?)").run(previousSessionFile);
+		db.close();
+
+		const result = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+		const check = new Database(statsDbPath);
+		const rows = check.prepare("SELECT session_file FROM messages").all();
+		check.close();
+
+		expect(result.archive?.archived).toBe(2);
+		expect(result.archive?.statsRowsDeleted).toBe(0);
+		expect(result.archive?.errors).toEqual([]);
+		expect(rows).toEqual([{ session_file: previousSessionFile }]);
+	});
+
 	test("does not claim an unrelated historical path by basename alone", async () => {
 		const session = await writeSession(root, "project", "actual-session-id", "complete", {
 			ageDays: 90,
@@ -1065,6 +1194,232 @@ describe("runGcCommand cold-session archive", () => {
 			true,
 		);
 		expect(rows).toEqual([]);
+	});
+
+	test("preserves shared stats through an unreadable intermediate archive", async () => {
+		const sessionsDir = path.join(getSessionsDir(root), "project");
+		const archiveDir = path.join(root, "archive", "sessions", "project");
+		await fs.mkdir(sessionsDir, { recursive: true });
+		await fs.mkdir(archiveDir, { recursive: true });
+		const ancestorPath = path.join(sessionsDir, "20260625_ancestor.jsonl");
+		const intermediatePath = path.join(sessionsDir, "20260626_intermediate.jsonl");
+		const retainedPath = path.join(sessionsDir, "20260726_retained.jsonl");
+		const ancestorArchive = path.join(archiveDir, `${path.basename(ancestorPath)}.gz`);
+		const corruptArchive = path.join(archiveDir, `${path.basename(intermediatePath)}.gz`);
+		const timestamp = "2026-06-25T12:00:00.000Z";
+		const timestampMs = Date.parse(timestamp);
+		const sharedAssistant = {
+			type: "message",
+			id: "shared-assistant",
+			parentId: null,
+			timestamp,
+			message: { role: "assistant", content: [] },
+		};
+		await Bun.write(
+			ancestorArchive,
+			gzipSync(
+				[
+					JSON.stringify({ type: "session", version: 3, id: "ancestor", timestamp, cwd: "/tmp" }),
+					JSON.stringify(sharedAssistant),
+					"",
+				].join("\n"),
+			),
+		);
+		await Bun.write(corruptArchive, "not gzip");
+		await Bun.write(
+			retainedPath,
+			[
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "retained",
+					timestamp,
+					cwd: "/tmp",
+					parentSession: intermediatePath,
+				}),
+				JSON.stringify(sharedAssistant),
+				"",
+			].join("\n"),
+		);
+		const retainedStat = await fs.stat(retainedPath);
+
+		const statsDbPath = path.join(root, "stats.db");
+		const db = new Database(statsDbPath);
+		db.run(
+			"CREATE TABLE messages (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, timestamp INTEGER NOT NULL, UNIQUE(session_file, entry_id))",
+		);
+		db.run(
+			"CREATE TABLE file_offsets (session_file TEXT PRIMARY KEY, offset INTEGER NOT NULL, last_modified INTEGER NOT NULL)",
+		);
+		db.prepare("INSERT INTO messages (session_file, entry_id, timestamp) VALUES (?, ?, ?)").run(
+			ancestorPath,
+			sharedAssistant.id,
+			timestampMs,
+		);
+		const insertOffset = db.prepare(
+			"INSERT INTO file_offsets (session_file, offset, last_modified) VALUES (?, ?, ?)",
+		);
+		insertOffset.run(ancestorPath, 1, 1);
+		insertOffset.run(retainedPath, retainedStat.size, retainedStat.mtimeMs);
+		db.close();
+
+		const first = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+		const firstCheck = new Database(statsDbPath);
+		const firstMessages = firstCheck.prepare("SELECT session_file, entry_id FROM messages").all();
+		const firstOffsets = firstCheck
+			.prepare("SELECT session_file, offset, last_modified FROM file_offsets ORDER BY session_file")
+			.all();
+		firstCheck.close();
+
+		expect(first.archive?.archived).toBe(0);
+		expect(first.archive?.statsRowsDeleted).toBe(0);
+		expect(first.archive?.errors.some(error => error.startsWith(`stats cleanup scan ${corruptArchive}: `))).toBe(
+			true,
+		);
+		expect(firstMessages).toEqual([{ session_file: ancestorPath, entry_id: sharedAssistant.id }]);
+		expect(firstOffsets).toEqual([
+			{ session_file: ancestorPath, offset: 1, last_modified: 1 },
+			{ session_file: retainedPath, offset: retainedStat.size, last_modified: retainedStat.mtimeMs },
+		]);
+
+		await Bun.write(
+			corruptArchive,
+			gzipSync(
+				[
+					JSON.stringify({
+						type: "session",
+						version: 3,
+						id: "intermediate",
+						timestamp,
+						cwd: "/tmp",
+						parentSession: ancestorPath,
+					}),
+					JSON.stringify(sharedAssistant),
+					"",
+				].join("\n"),
+			),
+		);
+		const second = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+		const secondCheck = new Database(statsDbPath);
+		const secondMessages = secondCheck.prepare("SELECT session_file, entry_id FROM messages").all();
+		const secondOffsets = secondCheck.prepare("SELECT session_file, offset, last_modified FROM file_offsets").all();
+		secondCheck.close();
+
+		expect(second.archive?.archived).toBe(0);
+		expect(second.archive?.statsRowsDeleted).toBe(1);
+		expect(second.archive?.errors).toEqual([]);
+		expect(secondMessages).toEqual([{ session_file: retainedPath, entry_id: sharedAssistant.id }]);
+		expect(secondOffsets).toEqual([
+			{ session_file: retainedPath, offset: retainedStat.size, last_modified: retainedStat.mtimeMs },
+		]);
+	});
+
+	test("transfers shared tool calls with empty ids before pruning archived ownership", async () => {
+		const sessionsDir = path.join(getSessionsDir(root), "project");
+		const archiveDir = path.join(root, "archive", "sessions", "project");
+		await fs.mkdir(sessionsDir, { recursive: true });
+		await fs.mkdir(archiveDir, { recursive: true });
+		const parentPath = path.join(sessionsDir, "20260625_parent.jsonl");
+		const childPath = path.join(sessionsDir, "20260726_child.jsonl");
+		const parentArchive = path.join(archiveDir, `${path.basename(parentPath)}.gz`);
+		const timestamp = "2026-06-25T12:00:00.000Z";
+		const timestampMs = Date.parse(timestamp);
+		const assistant = {
+			type: "message",
+			id: "assistant",
+			parentId: null,
+			timestamp,
+			message: {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "", name: "read" }],
+			},
+		};
+		await Bun.write(
+			parentArchive,
+			gzipSync(
+				[
+					JSON.stringify({ type: "session", version: 3, id: "parent", timestamp, cwd: "/tmp" }),
+					JSON.stringify(assistant),
+					"",
+				].join("\n"),
+			),
+		);
+		await Bun.write(
+			childPath,
+			[
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "child",
+					timestamp,
+					cwd: "/tmp",
+					parentSession: parentPath,
+				}),
+				JSON.stringify(assistant),
+				"",
+			].join("\n"),
+		);
+		const childStat = await fs.stat(childPath);
+
+		const statsDbPath = path.join(root, "stats.db");
+		const db = new Database(statsDbPath);
+		db.run(
+			"CREATE TABLE tool_calls (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, timestamp INTEGER NOT NULL, tool_call_id TEXT NOT NULL, UNIQUE(session_file, tool_call_id))",
+		);
+		db.run(
+			"CREATE TABLE file_offsets (session_file TEXT PRIMARY KEY, offset INTEGER NOT NULL, last_modified INTEGER NOT NULL)",
+		);
+		db.prepare("INSERT INTO tool_calls (session_file, entry_id, timestamp, tool_call_id) VALUES (?, ?, ?, ?)").run(
+			parentPath,
+			assistant.id,
+			timestampMs,
+			"",
+		);
+		const insertOffset = db.prepare(
+			"INSERT INTO file_offsets (session_file, offset, last_modified) VALUES (?, ?, ?)",
+		);
+		insertOffset.run(parentPath, 1, 1);
+		insertOffset.run(childPath, childStat.size, childStat.mtimeMs);
+		db.close();
+
+		const result = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+		const check = new Database(statsDbPath);
+		const toolCalls = check.prepare("SELECT session_file, entry_id, tool_call_id FROM tool_calls").all();
+		const offsets = check.prepare("SELECT session_file, offset, last_modified FROM file_offsets").all();
+		check.close();
+
+		expect(result.archive?.archived).toBe(0);
+		expect(result.archive?.statsRowsDeleted).toBe(1);
+		expect(result.archive?.errors).toEqual([]);
+		expect(toolCalls).toEqual([{ session_file: childPath, entry_id: assistant.id, tool_call_id: "" }]);
+		expect(offsets).toEqual([{ session_file: childPath, offset: childStat.size, last_modified: childStat.mtimeMs }]);
 	});
 
 	test("skips decompressible historical archives without a valid session header", async () => {

--- a/packages/coding-agent/test/gc-cli.test.ts
+++ b/packages/coding-agent/test/gc-cli.test.ts
@@ -3,8 +3,9 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { gunzipSync } from "node:zlib";
-import { runGcCommand } from "@oh-my-pi/pi-coding-agent/cli/gc-cli";
+import { gunzipSync, gzipSync } from "node:zlib";
+import { withStatsSyncLock } from "@oh-my-pi/omp-stats/aggregator";
+import { type GcResult, runGcCommand } from "@oh-my-pi/pi-coding-agent/cli/gc-cli";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	getAgentDir,
@@ -632,6 +633,8 @@ describe("runGcCommand cold-session archive", () => {
 		const child = path.join(sessionsDir, "20260726_child-session.jsonl");
 		const sibling = path.join(sessionsDir, "20260725_sibling-session.jsonl");
 		const timestamp = "2026-06-26T12:00:00.000Z";
+		const timestampMs = Date.parse(timestamp);
+		const collisionTimestamp = "2026-06-27T12:00:00.000Z";
 		const sharedUser = {
 			type: "message",
 			id: "shared-user",
@@ -644,7 +647,12 @@ describe("runGcCommand cold-session archive", () => {
 			id: "shared-assistant",
 			parentId: "shared-user",
 			timestamp,
-			message: { role: "assistant", content: [] },
+			message: {
+				role: "assistant",
+				model: "test-model",
+				provider: "test-provider",
+				content: [{ type: "toolCall", id: "shared-tool", name: "read" }],
+			},
 		};
 		const parentOnlyUser = {
 			type: "message",
@@ -657,6 +665,41 @@ describe("runGcCommand cold-session archive", () => {
 			type: "message",
 			id: "parent-only-assistant",
 			parentId: "parent-only-user",
+			timestamp,
+			message: { role: "assistant", content: [] },
+		};
+		const archivedCollisionUser = {
+			type: "message",
+			id: "collision-user",
+			parentId: "parent-only-assistant",
+			timestamp,
+			message: { role: "user", content: "archived collision" },
+		};
+		const archivedCollisionAssistant = {
+			type: "message",
+			id: "collision-assistant",
+			parentId: "collision-user",
+			timestamp,
+			message: {
+				role: "assistant",
+				model: "test-model",
+				provider: "test-provider",
+				content: [{ type: "toolCall", id: "collision-tool", name: "read" }],
+			},
+		};
+		const retainedCollisionUser = {
+			...archivedCollisionUser,
+			timestamp: collisionTimestamp,
+			message: { role: "user", content: "different retained entry" },
+		};
+		const retainedCollisionAssistant = {
+			...archivedCollisionAssistant,
+			timestamp: collisionTimestamp,
+		};
+		const terminalAssistant = {
+			type: "message",
+			id: "terminal-assistant",
+			parentId: null,
 			timestamp,
 			message: { role: "assistant", content: [] },
 		};
@@ -674,6 +717,9 @@ describe("runGcCommand cold-session archive", () => {
 				sharedAssistant,
 				parentOnlyUser,
 				parentOnlyAssistant,
+				archivedCollisionUser,
+				archivedCollisionAssistant,
+				terminalAssistant,
 				"",
 			]
 				.map(entry => (typeof entry === "string" ? entry : JSON.stringify(entry)))
@@ -693,6 +739,9 @@ describe("runGcCommand cold-session archive", () => {
 				}),
 				JSON.stringify(sharedUser),
 				JSON.stringify(sharedAssistant),
+				JSON.stringify(retainedCollisionUser),
+				JSON.stringify(retainedCollisionAssistant),
+				JSON.stringify(terminalAssistant),
 				"",
 			].join("\n"),
 		);
@@ -709,6 +758,7 @@ describe("runGcCommand cold-session archive", () => {
 				}),
 				JSON.stringify(sharedUser),
 				JSON.stringify(sharedAssistant),
+				JSON.stringify(terminalAssistant),
 				"",
 			].join("\n"),
 		);
@@ -719,13 +769,13 @@ describe("runGcCommand cold-session archive", () => {
 		const statsDbPath = path.join(root, "stats.db");
 		const db = new Database(statsDbPath);
 		db.run(
-			"CREATE TABLE messages (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, UNIQUE(session_file, entry_id))",
+			"CREATE TABLE messages (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, timestamp INTEGER NOT NULL, UNIQUE(session_file, entry_id))",
 		);
 		db.run(
-			"CREATE TABLE user_messages (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, UNIQUE(session_file, entry_id))",
+			"CREATE TABLE user_messages (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, timestamp INTEGER NOT NULL, UNIQUE(session_file, entry_id))",
 		);
 		db.run(
-			"CREATE TABLE tool_calls (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, tool_call_id TEXT NOT NULL, UNIQUE(session_file, tool_call_id))",
+			"CREATE TABLE tool_calls (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, timestamp INTEGER NOT NULL, tool_call_id TEXT NOT NULL, UNIQUE(session_file, tool_call_id))",
 		);
 		db.run(
 			"CREATE TABLE file_offsets (session_file TEXT PRIMARY KEY, offset INTEGER NOT NULL, last_modified INTEGER NOT NULL)",
@@ -734,15 +784,17 @@ describe("runGcCommand cold-session archive", () => {
 			["messages", "shared-assistant", "parent-only-assistant"],
 			["user_messages", "shared-user", "parent-only-user"],
 		] as const) {
-			const insert = db.prepare(`INSERT INTO ${table} (session_file, entry_id) VALUES (?, ?)`);
-			insert.run(parent, sharedId);
-			insert.run(parent, parentOnlyId);
+			const insert = db.prepare(`INSERT INTO ${table} (session_file, entry_id, timestamp) VALUES (?, ?, ?)`);
+			insert.run(parent, sharedId, timestampMs);
+			insert.run(parent, parentOnlyId, timestampMs);
+			insert.run(parent, table === "messages" ? "collision-assistant" : "collision-user", timestampMs);
 		}
 		const insertToolCall = db.prepare(
-			"INSERT INTO tool_calls (session_file, entry_id, tool_call_id) VALUES (?, ?, ?)",
+			"INSERT INTO tool_calls (session_file, entry_id, timestamp, tool_call_id) VALUES (?, ?, ?, ?)",
 		);
-		insertToolCall.run(parent, "shared-assistant", "shared-tool");
-		insertToolCall.run(parent, "parent-only-assistant", "parent-only-tool");
+		insertToolCall.run(parent, "shared-assistant", timestampMs, "shared-tool");
+		insertToolCall.run(parent, "parent-only-assistant", timestampMs, "parent-only-tool");
+		insertToolCall.run(parent, "collision-assistant", timestampMs, "collision-tool");
 		db.prepare("INSERT INTO file_offsets (session_file, offset, last_modified) VALUES (?, ?, ?)").run(parent, 444, 1);
 		const insertOffset = db.prepare(
 			"INSERT INTO file_offsets (session_file, offset, last_modified) VALUES (?, ?, ?)",
@@ -772,7 +824,7 @@ describe("runGcCommand cold-session archive", () => {
 		check.close();
 
 		expect(result.archive?.archived).toBe(1);
-		expect(result.archive?.statsRowsDeleted).toBe(4);
+		expect(result.archive?.statsRowsDeleted).toBe(7);
 		expect(result.archive?.errors).toEqual([]);
 		expect(messages).toEqual([{ session_file: child, entry_id: "shared-assistant" }]);
 		expect(userMessages).toEqual([{ session_file: child, entry_id: "shared-user" }]);
@@ -811,6 +863,91 @@ describe("runGcCommand cold-session archive", () => {
 		expect(secondOffsets).toEqual([
 			{ session_file: sibling, offset: siblingStat.size, last_modified: siblingStat.mtimeMs },
 		]);
+	});
+
+	test("scopes incompatible retained-entry deletion decisions to each cleanup plan", async () => {
+		const sessionsDir = path.join(getSessionsDir(root), "project");
+		await fs.mkdir(sessionsDir, { recursive: true });
+		const parent = path.join(sessionsDir, "20260626_partial-parent.jsonl");
+		const child = path.join(sessionsDir, "20260726_partial-child.jsonl");
+		const timestamp = "2026-06-26T12:00:00.000Z";
+		const sharedAssistant = {
+			type: "message",
+			id: "shared-assistant",
+			parentId: null,
+			timestamp,
+			message: { role: "assistant", content: [] },
+		};
+		await Bun.write(
+			parent,
+			[
+				JSON.stringify({ type: "session", version: 3, id: "partial-parent", timestamp, cwd: "/tmp" }),
+				JSON.stringify(sharedAssistant),
+				"",
+			].join("\n"),
+		);
+		await agePath(parent, 90);
+		await Bun.write(
+			child,
+			[
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "partial-child",
+					timestamp,
+					cwd: "/tmp",
+					parentSession: parent,
+				}),
+				JSON.stringify(sharedAssistant),
+				"",
+			].join("\n"),
+		);
+		const unrelated = await writeSession(root, "project", "partial-unrelated", "complete", {
+			ageDays: 90,
+			filename: "20260625_partial-unrelated",
+		});
+
+		const statsDbPath = path.join(root, "stats.db");
+		const db = new Database(statsDbPath);
+		db.run(
+			"CREATE TABLE messages (session_file TEXT NOT NULL, entry_id TEXT NOT NULL, timestamp INTEGER NOT NULL, UNIQUE(session_file, entry_id))",
+		);
+		db.run("CREATE TABLE user_messages (session_file TEXT NOT NULL)");
+		db.run(
+			"CREATE TABLE file_offsets (session_file TEXT PRIMARY KEY, offset INTEGER NOT NULL, last_modified INTEGER NOT NULL)",
+		);
+		db.prepare("INSERT INTO messages (session_file, entry_id, timestamp) VALUES (?, ?, ?)").run(
+			parent,
+			"shared-assistant",
+			Date.parse(timestamp),
+		);
+		db.prepare("INSERT INTO user_messages (session_file) VALUES (?)").run(parent);
+		db.prepare("INSERT INTO user_messages (session_file) VALUES (?)").run(unrelated);
+		db.prepare("INSERT INTO file_offsets (session_file, offset, last_modified) VALUES (?, ?, ?)").run(parent, 10, 1);
+		db.close();
+
+		const result = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+		const check = new Database(statsDbPath);
+		const messages = check.prepare("SELECT session_file, entry_id FROM messages").all();
+		const legacyRows = check.prepare("SELECT session_file FROM user_messages").all();
+		const offsets = check.prepare("SELECT session_file FROM file_offsets").all();
+		check.close();
+
+		expect(result.archive?.archived).toBe(2);
+		expect(result.archive?.statsRowsDeleted).toBe(2);
+		expect(result.archive?.errors).toEqual([]);
+		expect(messages).toEqual([{ session_file: child, entry_id: "shared-assistant" }]);
+		expect(legacyRows).toEqual([{ session_file: parent }]);
+		expect(offsets).toEqual([]);
 	});
 
 	test("prunes stats still owned by a session's paths from before it moved", async () => {
@@ -861,6 +998,163 @@ describe("runGcCommand cold-session archive", () => {
 		expect(result.archive?.statsRowsDeleted).toBe(9);
 		expect(result.archive?.errors).toEqual([]);
 		expect(remaining).toEqual(Object.fromEntries(tables.map(table => [table, []])));
+	});
+
+	test("does not claim an unrelated historical path by basename alone", async () => {
+		const session = await writeSession(root, "project", "actual-session-id", "complete", {
+			ageDays: 90,
+			filename: "custom-name",
+		});
+		const unrelated = path.join(root, "unrelated", path.basename(session));
+		const statsDbPath = path.join(root, "stats.db");
+		const db = new Database(statsDbPath);
+		db.run("CREATE TABLE messages (session_file TEXT NOT NULL)");
+		const insert = db.prepare("INSERT INTO messages (session_file) VALUES (?)");
+		insert.run(session);
+		insert.run(unrelated);
+		db.close();
+
+		const result = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+		const check = new Database(statsDbPath);
+		const rows = check.prepare("SELECT session_file FROM messages").all();
+		check.close();
+
+		expect(result.archive?.archived).toBe(1);
+		expect(result.archive?.statsRowsDeleted).toBe(1);
+		expect(result.archive?.errors).toEqual([]);
+		expect(rows).toEqual([{ session_file: unrelated }]);
+	});
+
+	test("continues stats cleanup past a corrupt historical archive", async () => {
+		const session = await writeSession(root, "project", "archive-me", "complete", { ageDays: 90 });
+		const corruptArchive = path.join(root, "archive", "sessions", "older", "corrupt.jsonl.gz");
+		await fs.mkdir(path.dirname(corruptArchive), { recursive: true });
+		await Bun.write(corruptArchive, "not gzip");
+		const statsDbPath = path.join(root, "stats.db");
+		const db = new Database(statsDbPath);
+		db.run("CREATE TABLE messages (session_file TEXT NOT NULL)");
+		db.prepare("INSERT INTO messages (session_file) VALUES (?)").run(session);
+		db.close();
+
+		const result = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+		const check = new Database(statsDbPath);
+		const rows = check.prepare("SELECT session_file FROM messages").all();
+		check.close();
+
+		expect(result.archive?.archived).toBe(1);
+		expect(result.archive?.statsRowsDeleted).toBe(1);
+		expect(result.archive?.errors.some(error => error.startsWith(`stats cleanup scan ${corruptArchive}: `))).toBe(
+			true,
+		);
+		expect(rows).toEqual([]);
+	});
+
+	test("skips decompressible historical archives without a valid session header", async () => {
+		const archive = path.join(root, "archive", "sessions", "older", "headerless-session.jsonl.gz");
+		await fs.mkdir(path.dirname(archive), { recursive: true });
+		await Bun.write(
+			archive,
+			gzipSync(`${JSON.stringify({ type: "message", message: { role: "assistant", content: [] } })}\n`),
+		);
+		const historicalStatsPath = path.join(root, "unrelated", "headerless-session.jsonl");
+		const statsDbPath = path.join(root, "stats.db");
+		const stats = new Database(statsDbPath);
+		stats.run("CREATE TABLE messages (session_file TEXT NOT NULL)");
+		stats.prepare("INSERT INTO messages (session_file) VALUES (?)").run(historicalStatsPath);
+		stats.close();
+		const historyDbPath = getHistoryDbPath(root);
+		const history = new Database(historyDbPath);
+		history.run("CREATE TABLE history (id INTEGER PRIMARY KEY, prompt TEXT NOT NULL, session_id TEXT)");
+		history.run("INSERT INTO history (prompt, session_id) VALUES ('keep me', 'headerless-session')");
+		history.close();
+
+		const result = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+		const statsCheck = new Database(statsDbPath);
+		const statsRows = statsCheck.prepare("SELECT session_file FROM messages").all();
+		statsCheck.close();
+		const historyCheck = new Database(historyDbPath);
+		const historyRows = historyCheck.prepare("SELECT session_id FROM history").all();
+		historyCheck.close();
+
+		expect(result.archive?.statsRowsDeleted).toBe(0);
+		expect(result.archive?.historyRowsDeleted).toBe(0);
+		expect(result.archive?.errors).toContain(
+			`stats cleanup scan ${archive}: archive is missing a valid session header`,
+		);
+		expect(statsRows).toEqual([{ session_file: historicalStatsPath }]);
+		expect(historyRows).toEqual([{ session_id: "headerless-session" }]);
+	});
+
+	test("waits for the shared stats lock before archive reconciliation", async () => {
+		const session = await writeSession(root, "project", "archive-me", "complete", { ageDays: 90 });
+		const statsDbPath = path.join(root, "stats.db");
+		const db = new Database(statsDbPath);
+		db.run("CREATE TABLE messages (session_file TEXT NOT NULL)");
+		db.prepare("INSERT INTO messages (session_file) VALUES (?)").run(session);
+		db.close();
+		const sessionMoved = (async () => {
+			for await (const event of fs.watch(path.dirname(session))) {
+				if (event.filename === path.basename(session)) return true;
+			}
+			return false;
+		})();
+
+		let gcPromise: Promise<GcResult> | undefined;
+		let archivedWhileLocked = false;
+		let rowsWhileLocked: unknown[] = [];
+		await withStatsSyncLock(statsDbPath, async () => {
+			gcPromise = runGcCommand({
+				flags: {
+					agentDir: root,
+					archive: true,
+					coldArchiveAfterDays: 30,
+					retainNewestGlobal: 0,
+					retainNewestPerCwd: 0,
+					apply: true,
+				},
+			});
+			archivedWhileLocked = await sessionMoved;
+			const lockedCheck = new Database(statsDbPath);
+			rowsWhileLocked = lockedCheck.prepare("SELECT session_file FROM messages").all();
+			lockedCheck.close();
+		});
+		if (!gcPromise) throw new Error("GC did not start");
+		const result = await gcPromise;
+		const check = new Database(statsDbPath);
+		const rows = check.prepare("SELECT session_file FROM messages").all();
+		check.close();
+
+		expect(archivedWhileLocked).toBe(true);
+		expect(rowsWhileLocked).toEqual([{ session_file: session }]);
+		expect(result.archive?.statsRowsDeleted).toBe(1);
+		expect(rows).toEqual([]);
 	});
 
 	test("reports stats cleanup failures and retries rows for already archived sessions", async () => {

--- a/packages/coding-agent/test/gc-cli.test.ts
+++ b/packages/coding-agent/test/gc-cli.test.ts
@@ -566,6 +566,113 @@ describe("runGcCommand cold-session archive", () => {
 		expect(ftsRows.map(row => row.session_id)).toEqual(["keep-me"]);
 	});
 
+	test("removes archived main and nested session rows from stats", async () => {
+		const session = await writeSession(root, "project", "archive-me", "complete", { ageDays: 90 });
+		const nestedSession = path.join(session.slice(0, -".jsonl".length), "nested.jsonl");
+		const keepSession = path.join(getSessionsDir(root), "project", "keep.jsonl");
+		const statsDbPath = path.join(root, "stats.db");
+		const tables = ["messages", "user_messages", "tool_calls", "file_offsets"] as const;
+		const db = new Database(statsDbPath);
+		for (const table of tables) {
+			db.run(`CREATE TABLE ${table} (session_file TEXT NOT NULL)`);
+			const insert = db.prepare(`INSERT INTO ${table} (session_file) VALUES (?)`);
+			insert.run(session);
+			insert.run(nestedSession);
+			insert.run(keepSession);
+		}
+		db.close();
+
+		const dryRun = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+			},
+		});
+		const dryCheck = new Database(statsDbPath);
+		for (const table of tables) {
+			const row = dryCheck.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as { count: number };
+			expect(row.count).toBe(3);
+		}
+		dryCheck.close();
+		expect(dryRun.archive?.statsRowsDeleted).toBe(0);
+
+		const result = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+
+		const check = new Database(statsDbPath);
+		const remaining = Object.fromEntries(
+			tables.map(table => [
+				table,
+				(check.prepare(`SELECT session_file FROM ${table}`).all() as Array<{ session_file: string }>).map(
+					row => row.session_file,
+				),
+			]),
+		);
+		check.close();
+
+		expect(result.archive?.statsRowsDeleted).toBe(8);
+		expect(remaining).toEqual(Object.fromEntries(tables.map(table => [table, [keepSession]])));
+	});
+
+	test("reports stats cleanup failures and retries rows for already archived sessions", async () => {
+		const session = await writeSession(root, "project", "archive-me", "complete", {
+			ageDays: 90,
+			filename: "20260626_archive-me",
+		});
+		const statsDbPath = path.join(root, "stats.db");
+		await Bun.write(statsDbPath, "not sqlite");
+
+		const first = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+
+		expect(first.archive?.archived).toBe(1);
+		expect(first.archive?.errors.some(error => error.startsWith("stats cleanup: "))).toBe(true);
+
+		await fs.rm(statsDbPath, { force: true });
+		const db = new Database(statsDbPath);
+		db.run("CREATE TABLE messages (session_file TEXT NOT NULL)");
+		db.prepare("INSERT INTO messages (session_file) VALUES (?)").run(session);
+		db.close();
+
+		const second = await runGcCommand({
+			flags: {
+				agentDir: root,
+				archive: true,
+				coldArchiveAfterDays: 30,
+				retainNewestGlobal: 0,
+				retainNewestPerCwd: 0,
+				apply: true,
+			},
+		});
+		const check = new Database(statsDbPath);
+		const rows = check.prepare("SELECT session_file FROM messages").all();
+		check.close();
+
+		expect(second.archive?.archived).toBe(0);
+		expect(second.archive?.statsRowsDeleted).toBe(1);
+		expect(second.archive?.errors).toEqual([]);
+		expect(rows).toEqual([]);
+	});
+
 	test("reports history cleanup failures and retries rows for already archived sessions", async () => {
 		await writeSession(root, "project", "archive-me", "complete", {
 			ageDays: 90,

--- a/packages/coding-agent/test/session-manager/move-to.test.ts
+++ b/packages/coding-agent/test/session-manager/move-to.test.ts
@@ -106,6 +106,7 @@ describe("SessionManager.moveTo", () => {
 		const entries = await loadEntriesFromFile(newFile);
 		const header = getHeader(entries);
 		expect(header?.cwd).toBe(path.resolve(cwdB));
+		expect(header?.previousSessionFiles).toEqual([path.resolve(oldFile)]);
 		expect(hasAssistantEntry(entries)).toBe(true);
 	});
 
@@ -148,6 +149,7 @@ describe("SessionManager.moveTo", () => {
 		const entries = await loadEntriesFromFile(newFile);
 		const header = getHeader(entries);
 		expect(header?.cwd).toBe(path.resolve(cwdB));
+		expect(header?.previousSessionFiles).toBeUndefined();
 	});
 
 	it("recreates file from memory when old file is deleted (assistant exists)", async () => {

--- a/packages/coding-agent/test/share.test.ts
+++ b/packages/coding-agent/test/share.test.ts
@@ -152,7 +152,14 @@ describe("buildShareSnapshot", () => {
 				},
 			} as unknown as SessionEntry,
 		];
-		const header = { type: "session", version: 3, id: "t", timestamp: ts, cwd: `/home/${secret}/proj` };
+		const header = {
+			type: "session",
+			version: 3,
+			id: "t",
+			timestamp: ts,
+			cwd: `/home/${secret}/proj`,
+			previousSessionFiles: [`/home/${secret}/old/session.jsonl`],
+		};
 		const sm = {
 			getHeader: () => header,
 			getEntries: () => entries,
@@ -169,6 +176,7 @@ describe("buildShareSnapshot", () => {
 		expect(flat).toContain("/.env");
 		// Source entries keep the real values; redaction is share-only.
 		expect(JSON.stringify(entries)).toContain(secret);
+		expect(JSON.stringify(header)).toContain(secret);
 	});
 
 	test("redacts assistant tool calls / error messages and bash meta, and drops provider replay payloads", () => {

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
-import { workerHostEntry } from "@oh-my-pi/pi-utils";
+import * as path from "node:path";
+import { getStatsDbPath, workerHostEntry } from "@oh-my-pi/pi-utils";
 import {
 	getRecentErrors as dbGetRecentErrors,
 	getRecentRequests as dbGetRecentRequests,
@@ -47,6 +48,209 @@ import type {
 	ToolDashboardStats,
 } from "./types";
 import { computeUsageWindowStats, fetchUsageSnapshots } from "./usage-windows";
+
+const STATS_SYNC_LOCK_RETRY_MS = 25;
+const STATS_SYNC_LOCK_STALE_MS = 60 * 60 * 1000;
+
+interface StatsLockSnapshot {
+	dev: number;
+	ino: number;
+	size: number;
+	mtimeMs: number;
+	text: string;
+}
+
+function errorCode(error: unknown): string | undefined {
+	if (!error || typeof error !== "object" || !("code" in error)) return undefined;
+	return typeof error.code === "string" ? error.code : undefined;
+}
+
+function sameStatsLock(left: StatsLockSnapshot, right: StatsLockSnapshot): boolean {
+	return (
+		left.dev === right.dev &&
+		left.ino === right.ino &&
+		left.size === right.size &&
+		left.mtimeMs === right.mtimeMs &&
+		left.text === right.text
+	);
+}
+
+async function readStatsLockSnapshot(lockPath: string): Promise<StatsLockSnapshot | null> {
+	try {
+		const before = await fs.promises.stat(lockPath);
+		const text = await fs.promises.readFile(lockPath, "utf8");
+		const after = await fs.promises.stat(lockPath);
+		const first = {
+			dev: before.dev,
+			ino: before.ino,
+			size: before.size,
+			mtimeMs: before.mtimeMs,
+			text,
+		};
+		const second = {
+			dev: after.dev,
+			ino: after.ino,
+			size: after.size,
+			mtimeMs: after.mtimeMs,
+			text,
+		};
+		return sameStatsLock(first, second) ? second : null;
+	} catch (error) {
+		if (errorCode(error) === "ENOENT") return null;
+		throw error;
+	}
+}
+
+function statsLockOwnerIsRunning(snapshot: StatsLockSnapshot): boolean {
+	const pid = Number.parseInt(snapshot.text.split(/\r?\n/, 1)[0] ?? "", 10);
+	if (!Number.isSafeInteger(pid) || pid <= 0) return Date.now() - snapshot.mtimeMs < STATS_SYNC_LOCK_STALE_MS;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return errorCode(error) !== "ESRCH";
+	}
+}
+
+function createStatsLockToken(): string {
+	return `${process.pid}\n${Date.now()}\n${Math.random()}\n`;
+}
+
+async function removeAbandonedStatsLockFile(lockPath: string): Promise<boolean> {
+	const snapshot = await readStatsLockSnapshot(lockPath);
+	if (!snapshot || statsLockOwnerIsRunning(snapshot)) return false;
+
+	const current = await readStatsLockSnapshot(lockPath);
+	if (!current || !sameStatsLock(snapshot, current) || statsLockOwnerIsRunning(current)) return false;
+	try {
+		await fs.promises.unlink(lockPath);
+		return true;
+	} catch (error) {
+		if (errorCode(error) === "ENOENT") return false;
+		throw error;
+	}
+}
+
+async function removeOwnedStatsLockFile(lockPath: string, owned: StatsLockSnapshot): Promise<void> {
+	const current = await readStatsLockSnapshot(lockPath);
+	if (!current || !sameStatsLock(owned, current)) return;
+	try {
+		await fs.promises.unlink(lockPath);
+	} catch (error) {
+		if (errorCode(error) !== "ENOENT") throw error;
+	}
+}
+
+async function removeAbandonedStatsLock(lockPath: string): Promise<boolean> {
+	const snapshot = await readStatsLockSnapshot(lockPath);
+	if (!snapshot || statsLockOwnerIsRunning(snapshot)) return false;
+
+	const breakerPath = `${lockPath}.break`;
+	let breaker: fs.promises.FileHandle;
+	try {
+		breaker = await fs.promises.open(breakerPath, "wx");
+	} catch (error) {
+		if (errorCode(error) === "EEXIST") {
+			await removeAbandonedStatsLockFile(breakerPath);
+			return false;
+		}
+		throw error;
+	}
+
+	const breakerToken = createStatsLockToken();
+	let breakerSnapshot: StatsLockSnapshot | null = null;
+	let breakerTokenWritten = false;
+	let removed = false;
+	let cleanupError: unknown;
+	try {
+		await breaker.writeFile(breakerToken);
+		breakerTokenWritten = true;
+		breakerSnapshot = await readStatsLockSnapshot(breakerPath);
+		if (!breakerSnapshot || breakerSnapshot.text !== breakerToken) {
+			throw new Error(`Stats lock breaker changed while acquiring ${breakerPath}`);
+		}
+
+		const current = await readStatsLockSnapshot(lockPath);
+		if (current && sameStatsLock(snapshot, current) && !statsLockOwnerIsRunning(current)) {
+			try {
+				await fs.promises.unlink(lockPath);
+				removed = true;
+			} catch (error) {
+				if (errorCode(error) !== "ENOENT") throw error;
+			}
+		}
+	} finally {
+		try {
+			await breaker.close();
+		} catch (error) {
+			cleanupError = error;
+		}
+		try {
+			if (!breakerSnapshot && breakerTokenWritten) {
+				const current = await readStatsLockSnapshot(breakerPath);
+				if (current?.text === breakerToken) breakerSnapshot = current;
+			}
+			if (breakerSnapshot) await removeOwnedStatsLockFile(breakerPath, breakerSnapshot);
+		} catch (error) {
+			cleanupError ??= error;
+		}
+	}
+	if (cleanupError) throw cleanupError;
+	return removed;
+}
+
+/**
+ * Serialize stats ingestion and archive reconciliation across processes.
+ * The lock covers file discovery, parsing, and the final SQLite write so a
+ * parse result for a session moved by GC can never commit after cleanup.
+ */
+export async function withStatsSyncLock<T>(dbPath: string, fn: () => Promise<T>): Promise<T> {
+	const lockPath = `${dbPath}.sync.lock`;
+	await fs.promises.mkdir(path.dirname(dbPath), { recursive: true });
+	let handle: fs.promises.FileHandle | undefined;
+	while (!handle) {
+		try {
+			handle = await fs.promises.open(lockPath, "wx");
+		} catch (error) {
+			if (errorCode(error) !== "EEXIST") throw error;
+			await removeAbandonedStatsLock(lockPath);
+			const { promise, resolve } = Promise.withResolvers<void>();
+			setTimeout(resolve, STATS_SYNC_LOCK_RETRY_MS);
+			await promise;
+		}
+	}
+
+	const token = createStatsLockToken();
+	let result: T | undefined;
+	let operationError: unknown;
+	let operationFailed = false;
+	let tokenWritten = false;
+	try {
+		await handle.writeFile(token);
+		tokenWritten = true;
+		result = await fn();
+	} catch (error) {
+		operationFailed = true;
+		operationError = error;
+	}
+
+	let cleanupError: unknown;
+	try {
+		await handle.close();
+	} catch (error) {
+		cleanupError = error;
+	}
+	try {
+		const current = await fs.promises.readFile(lockPath, "utf8");
+		if (!tokenWritten || current === token) await fs.promises.unlink(lockPath);
+	} catch (error) {
+		if (errorCode(error) !== "ENOENT") cleanupError ??= error;
+	}
+
+	if (operationFailed) throw operationError;
+	if (cleanupError) throw cleanupError;
+	return result as T;
+}
 
 /**
  * Apply a freshly parsed result to the database. Runs entirely on the
@@ -218,6 +422,10 @@ export async function smokeTestSyncWorker({ timeoutMs = 5_000 }: { timeoutMs?: n
  * bar walks at a steady rate).
  */
 export async function syncAllSessions(opts?: SyncOptions): Promise<{ processed: number; files: number }> {
+	return withStatsSyncLock(getStatsDbPath(), () => syncAllSessionsLocked(opts));
+}
+
+async function syncAllSessionsLocked(opts?: SyncOptions): Promise<{ processed: number; files: number }> {
 	await initDb();
 
 	const files = await listAllSessionFiles();

--- a/packages/stats/test/sync-serial.test.ts
+++ b/packages/stats/test/sync-serial.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { syncAllSessions } from "@oh-my-pi/omp-stats/aggregator";
+import { syncAllSessions, withStatsSyncLock } from "@oh-my-pi/omp-stats/aggregator";
 import { getOverallStats } from "@oh-my-pi/omp-stats/db";
 import { getSessionsDir } from "@oh-my-pi/pi-utils";
 import { installStatsTestIsolation } from "./helpers/temp-agent";
@@ -92,5 +92,79 @@ describe("stats sync serial mode", () => {
 
 		await expect(syncAllSessions({ workers: 2 })).rejects.toBe(workerProbe);
 		expect(workerSpy).toHaveBeenCalled();
+	});
+
+	it("reclaims a dead owner's abandoned stale breaker", async () => {
+		const dbPath = path.join(getSessionsDir(), "stats-lock.db");
+		const lockPath = `${dbPath}.sync.lock`;
+		const breakerPath = `${lockPath}.break`;
+		const deadPid = 424_242;
+		await fs.mkdir(path.dirname(dbPath), { recursive: true });
+		await Bun.write(lockPath, `${deadPid}\n1\nprimary\n`);
+		await Bun.write(breakerPath, `${deadPid}\n1\nbreaker\n`);
+		const staleTime = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		await fs.utimes(lockPath, staleTime, staleTime);
+		await fs.utimes(breakerPath, staleTime, staleTime);
+		vi.spyOn(process, "kill").mockImplementation(pid => {
+			if (pid === deadPid) throw Object.assign(new Error("dead owner"), { code: "ESRCH" });
+			return true;
+		});
+
+		vi.spyOn(globalThis, "setTimeout").mockImplementation(callback => {
+			queueMicrotask(callback as () => void);
+			return 0;
+		});
+		const result = await withStatsSyncLock(dbPath, async () => "acquired");
+
+		expect(result).toBe("acquired");
+		expect(await Bun.file(lockPath).exists()).toBe(false);
+		expect(await Bun.file(breakerPath).exists()).toBe(false);
+	});
+
+	it("never reclaims a live owner-stamped breaker even when its mtime is stale", async () => {
+		const dbPath = path.join(getSessionsDir(), "stats-live-breaker.db");
+		const lockPath = `${dbPath}.sync.lock`;
+		const breakerPath = `${lockPath}.break`;
+		const deadPid = 424_243;
+		const liveBreakerToken = `${process.pid}\n1\nlive-breaker\n`;
+		await fs.mkdir(path.dirname(dbPath), { recursive: true });
+		await Bun.write(lockPath, `${deadPid}\n1\nprimary\n`);
+		await Bun.write(breakerPath, liveBreakerToken);
+		const staleTime = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		await fs.utimes(lockPath, staleTime, staleTime);
+		await fs.utimes(breakerPath, staleTime, staleTime);
+		vi.spyOn(process, "kill").mockImplementation(pid => {
+			if (pid === deadPid) throw Object.assign(new Error("dead owner"), { code: "ESRCH" });
+			return true;
+		});
+		const retryScheduled = Promise.withResolvers<void>();
+		let resumeRetry: (() => void) | undefined;
+		let breakerReleased = false;
+		vi.spyOn(globalThis, "setTimeout").mockImplementation(callback => {
+			const run = callback as () => void;
+			if (breakerReleased) {
+				queueMicrotask(run);
+			} else {
+				resumeRetry = run;
+				retryScheduled.resolve();
+			}
+			return 0;
+		});
+
+		let acquired = false;
+		const pending = withStatsSyncLock(dbPath, async () => {
+			acquired = true;
+		});
+		try {
+			await retryScheduled.promise;
+			expect(acquired).toBe(false);
+			expect(await Bun.file(breakerPath).text()).toBe(liveBreakerToken);
+		} finally {
+			breakerReleased = true;
+			await fs.rm(breakerPath, { force: true });
+			resumeRetry?.();
+			await pending;
+		}
+		expect(acquired).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

- remove archived main-session rows from `messages`, `user_messages`, `tool_calls`, and `file_offsets`
- remove nested-session rows under the archived parent's artifact directory
- preserve shared stats for retained forks and follow proven historical paths after session moves
- serialize stats sync with archive reconciliation and tolerate corrupt archives or partial schemas
- rescan the archive so later GC runs retry stats cleanup after transient failures
- report deleted-row counts through text and JSON results

Fixes #7286.

## Verification

- `bun test packages/coding-agent/test/gc-cli.test.ts` — 37 passed, 0 failed
- `bun test packages/stats/test/sync-serial.test.ts packages/stats/test/fork-dedup.test.ts` — 10 passed, 0 failed
- `bun run check` in `packages/coding-agent` and `packages/stats` — passed
- source CLI smoke archived one cold session, reported `statsRowsDeleted: 4`, removed all four fixture-table rows, created the `.jsonl.gz` archive, and removed the active source file

- [x] CHANGELOG updated