### PR TITLE
fix(collab): treat guest prompts as user interjections

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed collab guest prompts being sent to models as unframed developer context, so guest messages now retain their transcript attribution while reaching the model as prioritized user interjections ([#7288](https://github.com/can1357/oh-my-pi/issues/7288)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -24,6 +24,7 @@ import type {
 } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { isRecord, logger, prompt } from "@oh-my-pi/pi-utils";
+import { COLLAB_PROMPT_MESSAGE_TYPE } from "@oh-my-pi/pi-wire";
 import userInterjectionTemplate from "../prompts/steering/user-interjection.md" with { type: "text" };
 import { formatTitleConversationContext, type TitleConversationTurn } from "../tiny/message-preproc";
 
@@ -614,8 +615,18 @@ export function normalizeCustomMessagePayload<T = unknown>(
 	};
 }
 
-function isSteeringUserMessage(message: AgentMessage | undefined): message is UserMessage & { steering: true } {
-	return message?.role === "user" && message.steering === true;
+type SteeringUserMessage =
+	| (UserMessage & { steering: true })
+	| (CustomMessage & {
+			customType: typeof COLLAB_PROMPT_MESSAGE_TYPE;
+			attribution: "user";
+	  });
+
+function isSteeringUserMessage(message: AgentMessage | undefined): message is SteeringUserMessage {
+	if (message?.role === "user") return message.steering === true;
+	return (
+		message?.role === "custom" && message.customType === COLLAB_PROMPT_MESSAGE_TYPE && message.attribution === "user"
+	);
 }
 
 function userMessageWithoutSteering(message: UserMessage): UserMessage {
@@ -655,17 +666,26 @@ function getArrayContentImages(content: (TextContent | ImageContent)[]): ImageCo
 	return images ?? [];
 }
 
-function wrapSteeringUserMessage(message: UserMessage): UserMessage {
+function wrapSteeringUserMessage(message: SteeringUserMessage): UserMessage {
+	const userMessage: UserMessage =
+		message.role === "user"
+			? userMessageWithoutSteering(message)
+			: {
+					role: "user",
+					content: message.content,
+					attribution: "user",
+					timestamp: message.timestamp,
+				};
 	if (typeof message.content === "string") {
-		if (message.content.length === 0) return message;
-		return { ...userMessageWithoutSteering(message), content: renderSteeringEnvelope(message.content) };
+		if (message.content.length === 0) return message.role === "user" ? message : userMessage;
+		return { ...userMessage, content: renderSteeringEnvelope(message.content) };
 	}
 
 	const text = getArrayContentText(message.content);
-	if (text.length === 0) return message;
+	if (text.length === 0) return message.role === "user" ? message : userMessage;
 	const content: (TextContent | ImageContent)[] = [{ type: "text", text: renderSteeringEnvelope(text) }];
 	content.push(...getArrayContentImages(message.content));
-	return { ...userMessageWithoutSteering(message), content };
+	return { ...userMessage, content };
 }
 
 export function wrapSteeringForModel(messages: AgentMessage[]): AgentMessage[] {

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -1166,6 +1166,10 @@ function convertOne(m: AgentMessage, interruptedNext: boolean): Message[] {
 		}
 		case "custom": {
 			if (!isCustomMessageContent(m.content)) return [];
+			if (isSteeringUserMessage(m)) {
+				const converted = convertMessageToLlm(wrapSteeringUserMessage(m));
+				return converted ? [converted] : [];
+			}
 			if (isUserInvokedSkillPrompt(m)) {
 				return [
 					{

--- a/packages/coding-agent/test/session-messages.test.ts
+++ b/packages/coding-agent/test/session-messages.test.ts
@@ -383,7 +383,7 @@ describe("wrapSteeringForModel", () => {
 		expect(wrappedText).not.toContain("&amp;");
 	});
 
-	it("presents user-attributed collab prompts as wrapped user turns", () => {
+	it("presents user-attributed collab prompts as wrapped user turns on every conversion path", () => {
 		const message: AgentMessage = {
 			role: "custom",
 			customType: COLLAB_PROMPT_MESSAGE_TYPE,
@@ -394,14 +394,19 @@ describe("wrapSteeringForModel", () => {
 			timestamp: 1,
 		};
 
+		const directlyConverted = convertToLlm([message]);
 		const wrapped = wrapSteeringForModel([message]);
-		const providerMessages = convertToLlm(wrapped);
+		const primaryProviderMessages = convertToLlm(wrapped);
 
+		expect(directlyConverted).toHaveLength(1);
+		expect(directlyConverted[0]?.role).toBe("user");
+		expect(getUserText(directlyConverted[0])).toContain("<system-notice>");
+		expect(getUserText(directlyConverted[0])).toContain("Reply with exactly PONG");
 		expect(wrapped[0]?.role).toBe("user");
 		expect(getUserText(wrapped[0])).toContain("<system-notice>");
 		expect(getUserText(wrapped[0])).toContain("Reply with exactly PONG");
-		expect(providerMessages).toHaveLength(1);
-		expect(providerMessages[0]?.role).toBe("user");
+		expect(primaryProviderMessages).toHaveLength(1);
+		expect(primaryProviderMessages[0]?.role).toBe("user");
 		expect(message).toMatchObject({
 			role: "custom",
 			details: { from: "guest" },

--- a/packages/coding-agent/test/session-messages.test.ts
+++ b/packages/coding-agent/test/session-messages.test.ts
@@ -7,6 +7,7 @@ import {
 	SKILL_PROMPT_MESSAGE_TYPE,
 	wrapSteeringForModel,
 } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { COLLAB_PROMPT_MESSAGE_TYPE } from "@oh-my-pi/pi-wire";
 
 function expectAttribution(message: Message | undefined, expected: "user" | "agent" | undefined): void {
 	expect(message).toBeDefined();
@@ -380,6 +381,31 @@ describe("wrapSteeringForModel", () => {
 		expect(wrappedText).toContain("Use <tag> & keep it literal");
 		expect(wrappedText).not.toContain("&lt;tag&gt;");
 		expect(wrappedText).not.toContain("&amp;");
+	});
+
+	it("presents user-attributed collab prompts as wrapped user turns", () => {
+		const message: AgentMessage = {
+			role: "custom",
+			customType: COLLAB_PROMPT_MESSAGE_TYPE,
+			content: "Reply with exactly PONG",
+			display: true,
+			details: { from: "guest" },
+			attribution: "user",
+			timestamp: 1,
+		};
+
+		const wrapped = wrapSteeringForModel([message]);
+		const providerMessages = convertToLlm(wrapped);
+
+		expect(wrapped[0]?.role).toBe("user");
+		expect(getUserText(wrapped[0])).toContain("<system-notice>");
+		expect(getUserText(wrapped[0])).toContain("Reply with exactly PONG");
+		expect(providerMessages).toHaveLength(1);
+		expect(providerMessages[0]?.role).toBe("user");
+		expect(message).toMatchObject({
+			role: "custom",
+			details: { from: "guest" },
+		});
 	});
 
 	it("wraps buried steering messages too so wire bytes stay stable across turns", () => {


### PR DESCRIPTION
## Repro
A user-attributed collab prompt frame survives `wrapSteeringForModel` unchanged and `convertToLlm` emits it as developer context. Reproduced with `bun -e "import { convertToLlm, wrapSteeringForModel } from './packages/coding-agent/src/session/messages.ts'; const guest = { role: 'custom', customType: 'collab-prompt', content: 'Reply PONG', display: true, details: { from: 'guest' }, attribution: 'user', timestamp: 1 }; console.log(JSON.stringify(convertToLlm(wrapSteeringForModel([guest]))[0]));"`; before the fix the output role was `developer` and the content was raw.

## Cause
`CollabHost.#handlePrompt` in `packages/coding-agent/src/collab/host.ts` deliberately persists guest input as a `collab-prompt` custom frame for guest attribution, but `isSteeringUserMessage` in `packages/coding-agent/src/session/messages.ts` recognized only `role: "user"` steers. The custom frame therefore skipped the interjection envelope and fell through the generic custom-message conversion to `role: "developer"`.

## Fix
- Recognize user-attributed `collab-prompt` frames as steering user messages on the model-facing transform path.
- Convert the transformed frame to a wrapped user turn while leaving the persisted custom frame and `details.from` unchanged for transcript badges.
- Add regression coverage for the provider role, interjection envelope, and retained guest attribution; document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/session-messages.test.ts` passed 19 tests with 110 assertions. `bun run check:types` passed for `packages/coding-agent`. The provider-boundary smoke probe now reports `persisted.role=custom`, `transformedRole=user`, `providerRole=user`, and `enveloped=true`; the pre-publish `bun run fix` and `bun check` gate also passed. An additional queued-delivery test could not load because this worktree lacks generated `packages/coding-agent/src/export/html/tool-views.generated.js`; it did not reach the changed path. Fixes #7288