### PR TITLE
fix(tui): backpressure slow loader paints

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed animated Loader paints saturating a CPU core on slow WSL/ConPTY terminals by applying cost-aware cadence backpressure while preserving 30fps on cheap frames ([#7290](https://github.com/can1357/oh-my-pi/issues/7290)).
+
 ## [17.2.2] - 2026-07-31
 
 ### Added

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -4,6 +4,8 @@ import { Text } from "./text";
 
 const RENDER_INTERVAL_MS = 1000 / 30;
 const SPINNER_ADVANCE_MS = 80;
+const MAX_RENDER_BACKPRESSURE_MS = 200;
+const RENDER_BACKPRESSURE_MULTIPLIER = 9;
 
 type ColorFn = (str: string) => string;
 
@@ -98,25 +100,12 @@ export class Loader extends Text {
 		this.#syncText();
 		this.#requestPaint();
 		const intervalMs = this.messageColorFn.animated === true ? RENDER_INTERVAL_MS : SPINNER_ADVANCE_MS;
-		this.#intervalId = setInterval(() => {
-			const now = performance.now();
-			const elapsed = now - this.#lastSpinnerTick;
-			const shouldAdvanceSpinner = elapsed >= SPINNER_ADVANCE_MS;
-			if (shouldAdvanceSpinner) {
-				const steps = Math.floor(elapsed / SPINNER_ADVANCE_MS);
-				this.#currentFrame = (this.#currentFrame + steps) % this.#frames.length;
-				this.#lastSpinnerTick += steps * SPINNER_ADVANCE_MS;
-				this.#syncText();
-			}
-			if (shouldAdvanceSpinner || this.#ui?.synchronizedOutput === true) {
-				this.#requestPaint();
-			}
-		}, intervalMs);
+		this.#scheduleTick(intervalMs, intervalMs);
 	}
 
 	stop() {
 		if (this.#intervalId) {
-			clearInterval(this.#intervalId);
+			clearTimeout(this.#intervalId);
 			this.#intervalId = undefined;
 		}
 	}
@@ -135,6 +124,32 @@ export class Loader extends Text {
 		this.#requestPaint();
 	}
 
+	#scheduleTick(intervalMs: number, delayMs: number): void {
+		const timer = setTimeout(() => {
+			if (this.#intervalId !== timer) return;
+			const startedAt = performance.now();
+			const elapsed = startedAt - this.#lastSpinnerTick;
+			const shouldAdvanceSpinner = elapsed >= SPINNER_ADVANCE_MS;
+			if (shouldAdvanceSpinner) {
+				const steps = Math.floor(elapsed / SPINNER_ADVANCE_MS);
+				this.#currentFrame = (this.#currentFrame + steps) % this.#frames.length;
+				this.#lastSpinnerTick += steps * SPINNER_ADVANCE_MS;
+				this.#syncText();
+			}
+			if (shouldAdvanceSpinner || this.#ui?.synchronizedOutput === true) {
+				this.#requestPaint();
+			}
+
+			const frameCostMs = performance.now() - startedAt;
+			if (this.#intervalId !== timer) return;
+			const cadenceDelayMs = Math.max(0, intervalMs - frameCostMs);
+			// Idle for nine times the paint cost to keep animation at or below
+			// 10% CPU, while cheap frames retain their original cadence.
+			const backpressureDelayMs = Math.min(MAX_RENDER_BACKPRESSURE_MS, frameCostMs * RENDER_BACKPRESSURE_MULTIPLIER);
+			this.#scheduleTick(intervalMs, Math.max(cadenceDelayMs, backpressureDelayMs));
+		}, delayMs);
+		this.#intervalId = timer;
+	}
 	/** Re-wrap the underlying Text only when its message or frame width changes. */
 	#syncText(): boolean {
 		const layoutFrame = this.#layoutFrames[this.#currentFrame];

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -134,6 +134,33 @@ describe("Loader component", () => {
 		loader.stop();
 	});
 
+	it("backs off animated paints when direct writes consume the frame budget", () => {
+		vi.useFakeTimers();
+		let now = 0;
+		const ui = {
+			synchronizedOutput: true,
+			requestDirectWrite: vi.fn(() => {
+				now += 20;
+			}),
+			requestComponentRender: vi.fn(),
+		};
+		const colorMessage = ((text: string) => text) as LoaderMessageColorFn & { animated: true };
+		colorMessage.animated = true;
+		spyOn(performance, "now").mockImplementation(() => now);
+		const loader = new Loader(ui as unknown as TUI, text => text, colorMessage, "Checking", ["0"]);
+
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(34);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(2);
+
+		vi.advanceTimersByTime(170);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(2);
+		vi.advanceTimersByTime(10);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(3);
+
+		loader.stop();
+	});
+
 	it("reuses text layout when only animated ANSI styling changes", () => {
 		vi.useFakeTimers();
 		let colorFrame = 0;


### PR DESCRIPTION
## Repro
On WSL/Windows Terminal, an animated Loader repaint can cost about 20ms; the fixed 30fps loop therefore consumes roughly 60% of one core during ordinary model waits. The issue archive records 677.6s on-CPU over 677.6s wall with no subagents and 65.4% of wall below `requestDirectWrite`. A focused reproduction is `bun -e 'import { Loader } from "./packages/tui/src/components/loader.ts"; const ui={synchronizedOutput:true,calls:0,requestDirectWrite(){const end=performance.now()+20;while(performance.now()<end){};this.calls++},requestComponentRender(){}}; const color=s=>s;color.animated=true;const cpu=process.cpuUsage(),start=performance.now(),loader=new Loader(ui,s=>s,color,"Working");await Bun.sleep(1000);loader.stop();const used=process.cpuUsage(cpu);console.log(ui.calls,Math.round((used.user+used.system)/1000/(performance.now()-start)*100))'`; before the fix it prints approximately `31 61`.

## Cause
`Loader.start()` in `packages/tui/src/components/loader.ts` used a fixed 30fps `setInterval` for animated synchronized-output paints. `requestDirectWrite()` is synchronous and bypasses the ordinary TUI render scheduler's adaptive frame-cost backpressure, so a slow WSL/ConPTY paint occupied about 20ms of every 33ms interval indefinitely.

## Fix
- Replace the fixed interval with a self-scheduling Loader timer that measures each paint.
- Preserve the original 30fps/12.5fps cadence for cheap frames, but idle for nine times an expensive paint's cost (10% duty-cycle target), capped at 200ms for responsiveness.
- Add a synchronized-output regression that models a 20ms direct paint and verifies the next frame is deferred.
- Document the fix in the TUI changelog.

## Verification
`bun test packages/tui` — 1416 pass, 3 skip, 0 fail. `bun run check` in `packages/tui` — passed. The focused reproduction changed from `31` paints / `61%` CPU to `6` paints / `13%` CPU over one second. Skipped pre-publish gate: `bun run fix` fails identically on clean `main` because this environment lacks `cmake` while `audiopus_sys` builds vendored Opus; the TypeScript formatter completed and the changed package check passed.

Fixes #7290