### PR TITLE
fix(ai): latch and surface a damaged credential store

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed a damaged `agent.db` silently disabling every persisted rate-limit block: `AuthStorage` swallowed all credential-store errors at debug level and re-queried on every credential evaluation. The first unrecoverable SQLite error (`SQLITE_CORRUPT` family / `SQLITE_NOTADB`) now latches the store as damaged, logs once at error level with a repair one-liner pointing at the actual store path, and short-circuits every later persisted-block read and write for the process. Fail-open is preserved via the in-memory backoff map.
+- Fixed a damaged `agent.db` silently disabling every persisted rate-limit block: `AuthStorage` swallowed all credential-store errors at debug level and re-queried on every credential evaluation. The first unrecoverable SQLite error (`SQLITE_CORRUPT` family / `SQLITE_NOTADB`) now latches the store as damaged, logs once at error level with a repair one-liner pointing at the actual store path, and short-circuits every later persisted-block read and write for the process. Fail-open is preserved via the in-memory backoff map. ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a damaged `agent.db` silently disabling every persisted rate-limit block: `AuthStorage` swallowed all credential-store errors at debug level and re-queried on every credential evaluation. The first unrecoverable SQLite error (`SQLITE_CORRUPT` family / `SQLITE_NOTADB`) now latches the store as damaged, logs once at error level with a repair one-liner pointing at the actual store path, and short-circuits every later persisted-block read and write for the process. Fail-open is preserved via the in-memory backoff map.
+
 ## [17.2.3] - 2026-08-01
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -6403,7 +6403,9 @@ export class AuthStorage {
 	 * Broker-server seam: persist one credential block and notify snapshot waiters.
 	 */
 	upsertCredentialBlock(block: StoredCredentialBlock): void {
-		if (this.#storeDamaged) return;
+		if (this.#storeDamaged) {
+			throw new Error("Credential store is damaged; block writes are unavailable");
+		}
 		const upsertCredentialBlock = this.#store.upsertCredentialBlock?.bind(this.#store);
 		if (!upsertCredentialBlock) return;
 		try {
@@ -6415,7 +6417,7 @@ export class AuthStorage {
 					providerKey: block.providerKey,
 				})
 			) {
-				return;
+				throw new Error("Credential store is damaged; block writes are unavailable", { cause: err });
 			}
 			throw err;
 		}
@@ -6427,14 +6429,16 @@ export class AuthStorage {
 	 * Broker-server seam: clear all persisted blocks for one credential and notify snapshot waiters.
 	 */
 	deleteCredentialBlock(credentialId: number, providerKey: string, blockScope: string): void {
-		if (this.#storeDamaged) return;
+		if (this.#storeDamaged) {
+			throw new Error("Credential store is damaged; block writes are unavailable");
+		}
 		const deleteCredentialBlock = this.#store.deleteCredentialBlock?.bind(this.#store);
 		if (!deleteCredentialBlock) return;
 		try {
 			deleteCredentialBlock(credentialId, providerKey, blockScope);
 		} catch (err) {
 			if (this.#latchStoreDamage(err, "deleteCredentialBlock", { credentialId, providerKey, blockScope })) {
-				return;
+				throw new Error("Credential store is damaged; block writes are unavailable", { cause: err });
 			}
 			throw err;
 		}
@@ -6443,13 +6447,17 @@ export class AuthStorage {
 	}
 
 	deleteCredentialBlocks(credentialId: number): void {
-		if (this.#storeDamaged) return;
+		if (this.#storeDamaged) {
+			throw new Error("Credential store is damaged; block writes are unavailable");
+		}
 		const deleteCredentialBlocks = this.#store.deleteCredentialBlocks?.bind(this.#store);
 		if (!deleteCredentialBlocks) return;
 		try {
 			deleteCredentialBlocks(credentialId);
 		} catch (err) {
-			if (this.#latchStoreDamage(err, "deleteCredentialBlocks", { credentialId })) return;
+			if (this.#latchStoreDamage(err, "deleteCredentialBlocks", { credentialId })) {
+				throw new Error("Credential store is damaged; block writes are unavailable", { cause: err });
+			}
 			throw err;
 		}
 		this.#bumpGeneration("credential-block");

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -13,6 +13,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { parseAlibabaTokenPlanCredential } from "@oh-my-pi/pi-catalog/wire/alibaba-token-plan";
 import { $env, getAgentDbPath, logger } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import type { ApiKeyResolver } from "./auth-retry";
 import * as AIError from "./error";
@@ -1389,7 +1390,7 @@ export class AuthStorage {
 
 	#bumpGeneration(reason: string): void {
 		this.#generation += 1;
-		this.#store.acknowledgeLocalChanges?.();
+		if (!this.#storeDamaged) this.#store.acknowledgeLocalChanges?.();
 		for (const listener of [...this.#generationListeners]) {
 			try {
 				listener(this.#generation);
@@ -1717,7 +1718,7 @@ export class AuthStorage {
 		logger.error(
 			storePath
 				? `Credential store is damaged; persisted rate-limit blocks are disabled for this process. ` +
-						`Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 '${storePath}' '.recover --ignore-freelist' | sqlite3 '${storePath}.fixed' && chmod 600 '${storePath}.fixed'`
+						`Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 ${shellQuote(storePath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${storePath}.fixed`)} && chmod 600 ${shellQuote(`${storePath}.fixed`)}`
 				: "Credential store is damaged; persisted rate-limit blocks are disabled for this process. " +
 						"Repair the store file with sqlite3's .recover and restart.",
 			{ err, op, storePath, ...context },
@@ -7048,7 +7049,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	static #damagedStoreError(dbPath: string | undefined, cause: unknown): Error {
 		return new Error(
 			dbPath
-				? `Credential store at '${dbPath}' is damaged. Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 '${dbPath}' '.recover --ignore-freelist' | sqlite3 '${dbPath}.fixed' && chmod 600 '${dbPath}.fixed'`
+				? `Credential store at ${shellQuote(dbPath)} is damaged. Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${dbPath}.fixed`)} && chmod 600 ${shellQuote(`${dbPath}.fixed`)}`
 				: "Credential store is damaged. Repair the store file with sqlite3's .recover and restart.",
 			{ cause },
 		);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1717,11 +1717,12 @@ export class AuthStorage {
 		logger.error(
 			storePath
 				? `Credential store is damaged; persisted rate-limit blocks are disabled for this process. ` +
-						`Repair with: sqlite3 '${storePath}' '.recover' | sqlite3 '${storePath}.fixed'`
+						`Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 '${storePath}' '.recover --ignore-freelist' | sqlite3 '${storePath}.fixed' && chmod 600 '${storePath}.fixed'`
 				: "Credential store is damaged; persisted rate-limit blocks are disabled for this process. " +
 						"Repair the store file with sqlite3's .recover and restart.",
 			{ err, op, storePath, ...context },
 		);
+		this.#bumpGeneration("store-damaged");
 		return true;
 	}
 
@@ -5899,18 +5900,19 @@ export class AuthStorage {
 		const scopedBackoffKey = this.#toScopedBackoffKey(providerKey, blockScope);
 		const globalProbeAfterMs = this.#credentialBackoffProbeAfter.get(providerKey)?.get(credentialIndex) ?? 0;
 		const scopedProbeAfterMs = this.#credentialBackoffProbeAfter.get(scopedBackoffKey)?.get(credentialIndex) ?? 0;
-		if (this.#storeDamaged) return;
-		const getStoreReconcileAfter = this.#store.getCredentialBlockReconcileAfter?.bind(this.#store);
 		let storeGlobalProbeAfterMs = 0;
 		let storeScopedProbeAfterMs = 0;
-		try {
-			storeGlobalProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, "") ?? 0;
-			storeScopedProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, blockScope ?? "") ?? 0;
-		} catch (err) {
-			if (this.#latchStoreDamage(err, "getCredentialBlockReconcileAfter", { credentialId, providerKey })) {
-				return;
+		if (!this.#storeDamaged) {
+			const getStoreReconcileAfter = this.#store.getCredentialBlockReconcileAfter?.bind(this.#store);
+			try {
+				storeGlobalProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, "") ?? 0;
+				storeScopedProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, blockScope ?? "") ?? 0;
+			} catch (err) {
+				if (this.#latchStoreDamage(err, "getCredentialBlockReconcileAfter", { credentialId, providerKey })) {
+					return;
+				}
+				throw err;
 			}
-			throw err;
 		}
 		if (Math.max(globalProbeAfterMs, scopedProbeAfterMs, storeGlobalProbeAfterMs, storeScopedProbeAfterMs) > nowMs) {
 			return;
@@ -6846,9 +6848,19 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#localAuthRevision: number;
 	#closed = false;
 
-	constructor(db: Database, readonly databasePath?: string) {
+	constructor(
+		db: Database,
+		readonly databasePath?: string,
+	) {
 		this.#db = db;
-		this.#initializeSchema();
+		try {
+			this.#initializeSchema();
+		} catch (err) {
+			if (isSqliteCorruptError(err)) {
+				throw SqliteAuthCredentialStore.#damagedStoreError(this.databasePath, err);
+			}
+			throw err;
+		}
 		this.#dataVersion = this.#readDataVersion();
 		this.#authRevision = this.#readAuthRevision();
 		this.#localAuthRevision = this.#readLocalAuthRevision();
@@ -7003,6 +7015,9 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 				return new SqliteAuthCredentialStore(db, dbPath);
 			} catch (err) {
 				db?.close();
+				if (isSqliteCorruptError(err)) {
+					throw SqliteAuthCredentialStore.#damagedStoreError(dbPath, err);
+				}
 				if (!isSqliteBusyError(err)) {
 					throw err;
 				}
@@ -7028,6 +7043,15 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			);
 			CREATE INDEX IF NOT EXISTS idx_auth_credential_refresh_leases_expires ON auth_credential_refresh_leases(expires_at_ms);
 		`);
+	}
+
+	static #damagedStoreError(dbPath: string | undefined, cause: unknown): Error {
+		return new Error(
+			dbPath
+				? `Credential store at '${dbPath}' is damaged. Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 '${dbPath}' '.recover --ignore-freelist' | sqlite3 '${dbPath}.fixed' && chmod 600 '${dbPath}.fixed'`
+				: "Credential store is damaged. Repair the store file with sqlite3's .recover and restart.",
+			{ cause },
+		);
 	}
 
 	#initializeSchema(): void {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -13,6 +13,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { parseAlibabaTokenPlanCredential } from "@oh-my-pi/pi-catalog/wire/alibaba-token-plan";
 import { $env, getAgentDbPath, logger } from "@oh-my-pi/pi-utils";
+import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import type { ApiKeyResolver } from "./auth-retry";
 import * as AIError from "./error";
 import { isUsageLimitOutcome } from "./error/rate-limit";
@@ -375,6 +376,8 @@ export interface CredentialRefreshLeaseFence {
 
 export interface AuthCredentialStore {
 	close(): void;
+	/** Filesystem path of the backing SQLite file when the store is file-backed; used in operator-facing repair guidance. */
+	readonly databasePath?: string;
 	/**
 	 * Stateful probe for commits made by another process to the backing store.
 	 * Returns true once per observed change.
@@ -1264,6 +1267,8 @@ export class AuthStorage {
 	#credentialBackoff: Map<string, Map<number, number>> = new Map();
 	/** Earliest time a freshly-set in-memory block may be cleared by live usage reconciliation. */
 	#credentialBackoffProbeAfter: Map<string, Map<number, number>> = new Map();
+	/** Latched once the persistent store reports damage; persisted blocks are skipped for the rest of this process. */
+	#storeDamaged = false;
 	#usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
 	#rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
 	#usageCache: UsageCache;
@@ -1696,16 +1701,44 @@ export class AuthStorage {
 		return blockedUntil;
 	}
 
+	/**
+	 * Latch off the persisted block table after unrecoverable store damage.
+	 * Returns true when the error is corruption — the caller then fails open.
+	 * The first damaged operation logs once at error level with repair
+	 * guidance; every later block-table operation short-circuits silently,
+	 * since nothing in the process can repair the file and a retry only
+	 * re-fails.
+	 */
+	#latchStoreDamage(err: unknown, op: string, context: Record<string, unknown>): boolean {
+		if (!isSqliteCorruptError(err)) return false;
+		if (this.#storeDamaged) return true;
+		this.#storeDamaged = true;
+		const storePath = this.#store.databasePath;
+		logger.error(
+			storePath
+				? `Credential store is damaged; persisted rate-limit blocks are disabled for this process. ` +
+						`Repair with: sqlite3 '${storePath}' '.recover' | sqlite3 '${storePath}.fixed'`
+				: "Credential store is damaged; persisted rate-limit blocks are disabled for this process. " +
+						"Repair the store file with sqlite3's .recover and restart.",
+			{ err, op, storePath, ...context },
+		);
+		return true;
+	}
+
 	#readPersistedCredentialBlock(
 		credentialId: number,
 		providerKey: string,
 		blockScope: string | undefined,
 	): number | undefined {
+		if (this.#storeDamaged) return undefined;
 		const getCredentialBlock = this.#store.getCredentialBlock?.bind(this.#store);
 		if (!getCredentialBlock) return undefined;
 		try {
 			return getCredentialBlock(credentialId, providerKey, blockScope ?? "");
 		} catch (err) {
+			if (this.#latchStoreDamage(err, "getCredentialBlock", { credentialId, providerKey, blockScope })) {
+				return undefined;
+			}
 			logger.debug("Failed to read credential block from persistent store", {
 				err,
 				credentialId,
@@ -1791,6 +1824,7 @@ export class AuthStorage {
 		this.#credentialBackoffProbeAfter.set(backoffKey, probeAfterMap);
 		this.#invalidateUsageReportCache(provider);
 
+		if (this.#storeDamaged) return;
 		const upsertCredentialBlock = this.#store.upsertCredentialBlock?.bind(this.#store);
 		if (!upsertCredentialBlock) return;
 		const credentialId = this.#getStoredCredentials(provider)[credentialIndex]?.id;
@@ -1803,6 +1837,9 @@ export class AuthStorage {
 				blockedUntilMs: nextBlockedUntil,
 			});
 		} catch (err) {
+			if (this.#latchStoreDamage(err, "upsertCredentialBlock", { credentialId, providerKey, blockScope })) {
+				return;
+			}
 			logger.debug("Failed to persist credential block", {
 				err,
 				credentialId,
@@ -5862,9 +5899,19 @@ export class AuthStorage {
 		const scopedBackoffKey = this.#toScopedBackoffKey(providerKey, blockScope);
 		const globalProbeAfterMs = this.#credentialBackoffProbeAfter.get(providerKey)?.get(credentialIndex) ?? 0;
 		const scopedProbeAfterMs = this.#credentialBackoffProbeAfter.get(scopedBackoffKey)?.get(credentialIndex) ?? 0;
+		if (this.#storeDamaged) return;
 		const getStoreReconcileAfter = this.#store.getCredentialBlockReconcileAfter?.bind(this.#store);
-		const storeGlobalProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, "") ?? 0;
-		const storeScopedProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, blockScope ?? "") ?? 0;
+		let storeGlobalProbeAfterMs = 0;
+		let storeScopedProbeAfterMs = 0;
+		try {
+			storeGlobalProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, "") ?? 0;
+			storeScopedProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, blockScope ?? "") ?? 0;
+		} catch (err) {
+			if (this.#latchStoreDamage(err, "getCredentialBlockReconcileAfter", { credentialId, providerKey })) {
+				return;
+			}
+			throw err;
+		}
 		if (Math.max(globalProbeAfterMs, scopedProbeAfterMs, storeGlobalProbeAfterMs, storeScopedProbeAfterMs) > nowMs) {
 			return;
 		}
@@ -6340,16 +6387,35 @@ export class AuthStorage {
 	 * Broker-server seam: list non-expired persisted blocks for snapshot entries.
 	 */
 	listCredentialBlocks(credentialIds: readonly number[]): StoredCredentialBlock[] {
-		return this.#store.listCredentialBlocks?.(credentialIds) ?? [];
+		if (this.#storeDamaged) return [];
+		try {
+			return this.#store.listCredentialBlocks?.(credentialIds) ?? [];
+		} catch (err) {
+			if (this.#latchStoreDamage(err, "listCredentialBlocks", {})) return [];
+			throw err;
+		}
 	}
 
 	/**
 	 * Broker-server seam: persist one credential block and notify snapshot waiters.
 	 */
 	upsertCredentialBlock(block: StoredCredentialBlock): void {
+		if (this.#storeDamaged) return;
 		const upsertCredentialBlock = this.#store.upsertCredentialBlock?.bind(this.#store);
 		if (!upsertCredentialBlock) return;
-		upsertCredentialBlock(block);
+		try {
+			upsertCredentialBlock(block);
+		} catch (err) {
+			if (
+				this.#latchStoreDamage(err, "upsertCredentialBlock", {
+					credentialId: block.credentialId,
+					providerKey: block.providerKey,
+				})
+			) {
+				return;
+			}
+			throw err;
+		}
 		this.#invalidateUsageReportCacheForProviderKey(block.providerKey);
 		this.#bumpGeneration("credential-block");
 	}
@@ -6358,17 +6424,31 @@ export class AuthStorage {
 	 * Broker-server seam: clear all persisted blocks for one credential and notify snapshot waiters.
 	 */
 	deleteCredentialBlock(credentialId: number, providerKey: string, blockScope: string): void {
+		if (this.#storeDamaged) return;
 		const deleteCredentialBlock = this.#store.deleteCredentialBlock?.bind(this.#store);
 		if (!deleteCredentialBlock) return;
-		deleteCredentialBlock(credentialId, providerKey, blockScope);
+		try {
+			deleteCredentialBlock(credentialId, providerKey, blockScope);
+		} catch (err) {
+			if (this.#latchStoreDamage(err, "deleteCredentialBlock", { credentialId, providerKey, blockScope })) {
+				return;
+			}
+			throw err;
+		}
 		this.#invalidateUsageReportCacheForProviderKey(providerKey);
 		this.#bumpGeneration("credential-block");
 	}
 
 	deleteCredentialBlocks(credentialId: number): void {
+		if (this.#storeDamaged) return;
 		const deleteCredentialBlocks = this.#store.deleteCredentialBlocks?.bind(this.#store);
 		if (!deleteCredentialBlocks) return;
-		deleteCredentialBlocks(credentialId);
+		try {
+			deleteCredentialBlocks(credentialId);
+		} catch (err) {
+			if (this.#latchStoreDamage(err, "deleteCredentialBlocks", { credentialId })) return;
+			throw err;
+		}
 		this.#bumpGeneration("credential-block");
 	}
 
@@ -6766,7 +6846,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#localAuthRevision: number;
 	#closed = false;
 
-	constructor(db: Database) {
+	constructor(db: Database, readonly databasePath?: string) {
 		this.#db = db;
 		this.#initializeSchema();
 		this.#dataVersion = this.#readDataVersion();
@@ -6920,7 +7000,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 					// Ignore chmod failures (e.g., Windows)
 				}
 				SqliteAuthCredentialStore.#ensureAuthCredentialRefreshLeasesTable(db);
-				return new SqliteAuthCredentialStore(db);
+				return new SqliteAuthCredentialStore(db, dbPath);
 			} catch (err) {
 				db?.close();
 				if (!isSqliteBusyError(err)) {

--- a/packages/ai/test/auth-storage-corrupt-store.test.ts
+++ b/packages/ai/test/auth-storage-corrupt-store.test.ts
@@ -23,6 +23,7 @@ import * as path from "node:path";
 import { AuthStorage, type OAuthCredential, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
 import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import { logger } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import { removeWithRetries } from "../../utils/src/temp";
 
@@ -285,6 +286,147 @@ describe("AuthStorage corrupt-store generation notification", () => {
 	});
 });
 
+describe("AuthStorage corrupt-store shell-balanced repair guidance", () => {
+	let tempDir = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-shell-"));
+		// Use a path containing a single quote to exercise shell quoting.
+		const quoteDir = path.join(tempDir, "omp's agent");
+		await fs.mkdir(quoteDir, { recursive: true });
+		const dbPath = path.join(quoteDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		store.saveOAuth(PROVIDER, oauthCredential("1"));
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("F2: latch message emits a shell-balanced repair command for a quote-containing path", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		await storage.getApiKey(PROVIDER, "session-shell-1");
+
+		const damagedCall = errorSpy.mock.calls.find(
+			call => typeof call[0] === "string" && call[0].includes("Credential store is damaged"),
+		);
+		expect(damagedCall).toBeDefined();
+		const message = String(damagedCall?.[0]);
+		expect(message).toContain("--ignore-freelist");
+		expect(message).toContain("chmod 600");
+		// The repair command must be shell-balanced: every unescaped single
+		// quote toggles open/close state, so the string ends closed.
+		let open = false;
+		for (let i = 0; i < message.length; i++) {
+			if (message[i] === "'" && message[i - 1] !== "\\") open = !open;
+		}
+		expect(open).toBe(false);
+	});
+
+	test("F2: damagedStoreError emits a shell-balanced repair command for a quote-containing path", async () => {
+		const quoteDir = path.join(tempDir, "omp's agent");
+		const dbPath = path.join(quoteDir, "agent.db");
+		// Force the static error helper through the open() path by corrupting
+		// the file after the store was successfully opened in beforeEach.
+		store.close();
+		await fs.writeFile(dbPath, "this is not a sqlite database");
+
+		expect(SqliteAuthCredentialStore.open(dbPath)).rejects.toThrow();
+		try {
+			await SqliteAuthCredentialStore.open(dbPath);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			expect(message).toContain(".recover --ignore-freelist");
+			expect(message).toContain(shellQuote(dbPath));
+			// Shell-balanced check.
+			let open = false;
+			for (let i = 0; i < message.length; i++) {
+				if (message[i] === "'" && message[i - 1] !== "\\") open = !open;
+			}
+			expect(open).toBe(false);
+		}
+	});
+});
+
+describe("AuthStorage corrupt-store bump skips acknowledge when latched", () => {
+	let tempDir = "";
+	let dbPath = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-ack-"));
+		dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		store.saveOAuth(PROVIDER, oauthCredential("1"));
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("F3: latch bump does not call acknowledgeLocalChanges but listeners still fire", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+		const ackSpy = vi.spyOn(store, "acknowledgeLocalChanges");
+
+		const generations: number[] = [];
+		storage.onGenerationChanged(gen => generations.push(gen));
+		const generationBefore = storage.getGeneration();
+
+		// Trigger the latch: getCredentialBlock throws SQLITE_NOTADB → latch → bump.
+		await storage.getApiKey(PROVIDER, "session-ack-1");
+
+		// Mutation proof: acknowledgeLocalChanges must NOT have been called on
+		// the latch bump — the store is damaged and acknowledging is meaningless.
+		expect(ackSpy).not.toHaveBeenCalled();
+		// The generation listener still fired despite the skipped acknowledge.
+		expect(generations).toHaveLength(1);
+		expect(generations[0]).toBe(generationBefore + 1);
+	});
+
+	test("F3: a healthy bump still calls acknowledgeLocalChanges", async () => {
+		const ackSpy = vi.spyOn(store, "acknowledgeLocalChanges");
+
+		const generations: number[] = [];
+		storage.onGenerationChanged(gen => generations.push(gen));
+		const generationBefore = storage.getGeneration();
+
+		// A normal credential save + reload triggers a healthy bump (no latch).
+		store.saveApiKey(PROVIDER, "sk-healthy-bump-test");
+		await storage.reload();
+
+		expect(ackSpy).toHaveBeenCalled();
+		expect(generations).toHaveLength(1);
+		expect(generations[0]).toBe(generationBefore + 1);
+	});
+});
 describe("AuthStorage corrupt-store heal while latched", () => {
 	let tempDir = "";
 	let dbPath = "";

--- a/packages/ai/test/auth-storage-corrupt-store.test.ts
+++ b/packages/ai/test/auth-storage-corrupt-store.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Regression coverage for the corrupt-credential-store latch.
+ *
+ * `~/.omp/agent/agent.db` can fail `PRAGMA integrity_check` (e.g. "Rowid out of
+ * order"). Before the latch, `AuthStorage.#readPersistedCredentialBlock` swallowed
+ * every store error at `debug` and returned `undefined`, which its caller read as
+ * "this credential is not blocked." A damaged store therefore silently switched
+ * off every persisted rate-limit block — one session logged that swallow 546 times
+ * for a single credential while a continuous stream of 429s poured in.
+ *
+ * The fix latches the store as damaged on the first unrecoverable (SQLITE_CORRUPT
+ * family / SQLITE_NOTADB) error, reports it once at `error` level with a repair
+ * one-liner, and short-circuits every later persisted-block query for the life of
+ * the process. Fail-open is preserved: the in-memory backoff map still carries
+ * within-process rate-limit state, so only cross-process persistence is lost.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage, type OAuthCredential, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import { logger } from "@oh-my-pi/pi-utils";
+import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
+import { removeWithRetries } from "../../utils/src/temp";
+
+const PROVIDER = "anthropic";
+
+interface SqliteCorruptShape extends Error {
+	code: string;
+	errno: number;
+}
+
+function makeCorruptError(code: string, errno: number): SqliteCorruptShape {
+	const err = new Error("database disk image is malformed") as SqliteCorruptShape;
+	err.code = code;
+	err.errno = errno;
+	return err;
+}
+
+function oauthCredential(suffix: string): OAuthCredential {
+	return {
+		type: "oauth",
+		access: `access-${suffix}`,
+		refresh: `refresh-${suffix}`,
+		expires: Date.now() + 3_600_000,
+		accountId: `account-${suffix}`,
+		email: `${suffix}@example.com`,
+	};
+}
+
+/**
+ * Writes a deterministic malformed SQLite source — bytes that are not a valid
+ * SQLite database — and returns the path. Opening this with `new Database(path)`
+ * and running a query makes bun:sqlite throw a real `SQLiteError` carrying
+ * `code: "SQLITE_NOTADB"` (errno 26), the same family the latch classifies.
+ */
+async function writeMalformedDb(dir: string): Promise<string> {
+	const dbPath = path.join(dir, "malformed.db");
+	await fs.writeFile(dbPath, "this is not a sqlite database");
+	return dbPath;
+}
+
+/** The real error bun:sqlite throws when a query hits a malformed database file. */
+function realCorruptError(malformedDbPath: string): Error {
+	const db = new Database(malformedDbPath);
+	try {
+		db.run("PRAGMA integrity_check");
+	} catch (err) {
+		return err as Error;
+	} finally {
+		db.close();
+	}
+	// Unreachable: the query above always throws on a malformed file.
+	throw new Error("expected SQLITE_NOTADB from malformed database");
+}
+
+describe("isSqliteCorruptError", () => {
+	test("recognizes the CORRUPT family and NOTADB", () => {
+		expect(isSqliteCorruptError(makeCorruptError("SQLITE_CORRUPT", 11))).toBe(true);
+		expect(isSqliteCorruptError(makeCorruptError("SQLITE_CORRUPT_VTAB", 267))).toBe(true);
+		expect(isSqliteCorruptError(makeCorruptError("SQLITE_NOTADB", 26))).toBe(true);
+	});
+
+	test("rejects non-corrupt codes and non-error values", () => {
+		expect(isSqliteCorruptError(makeCorruptError("SQLITE_BUSY", 5))).toBe(false);
+		expect(isSqliteCorruptError(new Error("plain"))).toBe(false);
+		expect(isSqliteCorruptError(null)).toBe(false);
+		// A bare string is not an object, so it must not match even if it looks like a code.
+		expect(isSqliteCorruptError("SQLITE_CORRUPT")).toBe(false);
+	});
+
+	test("classifies the real error bun:sqlite throws on a malformed database file", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-real-"));
+		try {
+			const malformedDbPath = await writeMalformedDb(tempDir);
+			const err = realCorruptError(malformedDbPath);
+			// Bun 1.3.14 throws SQLiteError with code SQLITE_NOTADB.
+			expect((err as { code?: unknown }).code).toBe("SQLITE_NOTADB");
+			expect(isSqliteCorruptError(err)).toBe(true);
+		} finally {
+			await removeWithRetries(tempDir);
+		}
+	});
+});
+
+describe("AuthStorage corrupt-store latch", () => {
+	let tempDir = "";
+	let dbPath = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-latch-"));
+		dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		store.saveOAuth(PROVIDER, oauthCredential("1"));
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("latches after one corrupt read and stops re-querying the store", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		// The spy opens the malformed file and runs a real query so SQLite
+		// itself throws SQLITE_NOTADB — the same error shape production sees
+		// when agent.db is damaged — rather than a synthetic error object.
+		const spy = vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+
+		// Drive the credential-selection path twice. The first call hits the
+		// store, throws SQLITE_NOTADB, and latches #storeDamaged; the second
+		// call (and every later read in the same getApiKey) short-circuits
+		// before touching SQLite. Before the fix this re-queried on every
+		// credential evaluation — 546 times for one credential in production.
+		const key1 = await storage.getApiKey(PROVIDER, "session-latch-1");
+		const key2 = await storage.getApiKey(PROVIDER, "session-latch-1");
+
+		// The spy fired exactly once across both calls: the latch stops the repeat.
+		expect(spy).toHaveBeenCalledTimes(1);
+		// Fail-open is preserved: selection still returns a usable key.
+		expect(key1).toBe("access-1");
+		expect(key2).toBe("access-1");
+	});
+
+	test("latches the write path: one corrupt upsert stops all later block-table writes", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		const spy = vi.spyOn(store, "upsertCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		const generationBefore = storage.getGeneration();
+		const block = {
+			credentialId: 1,
+			providerKey: "anthropic:oauth",
+			blockScope: "",
+			blockedUntilMs: Date.now() + 60_000,
+		};
+
+		storage.upsertCredentialBlock(block);
+		storage.upsertCredentialBlock(block);
+
+		// The first corrupt write latches; the second call short-circuits
+		// before touching SQLite, and the invalidation/generation side effects
+		// are skipped — a latched write is a true no-op, not a swallowed error.
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(storage.getGeneration()).toBe(generationBefore);
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Credential store is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+	});
+});
+
+describe("AuthStorage corrupt-store reporting", () => {
+	let tempDir = "";
+	let dbPath = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-report-"));
+		dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		store.saveOAuth(PROVIDER, oauthCredential("1"));
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("emits exactly one logger.error and no swallow-debug for the corrupt read", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+
+		await storage.getApiKey(PROVIDER, "session-report-1");
+		await storage.getApiKey(PROVIDER, "session-report-1");
+
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Credential store is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+		// The repair guidance must point at the actual store file, not a
+		// hardcoded default path (profiles relocate agent.db).
+		expect(String(damagedErrors[0]?.[0])).toContain(dbPath);
+
+		const swallowDebugs = debugSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0] === "Failed to read credential block from persistent store",
+		);
+		expect(swallowDebugs).toHaveLength(0);
+	});
+});

--- a/packages/ai/test/auth-storage-corrupt-store.test.ts
+++ b/packages/ai/test/auth-storage-corrupt-store.test.ts
@@ -21,6 +21,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { AuthStorage, type OAuthCredential, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import { logger } from "@oh-my-pi/pi-utils";
 import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import { removeWithRetries } from "../../utils/src/temp";
@@ -171,11 +172,11 @@ describe("AuthStorage corrupt-store latch", () => {
 		storage.upsertCredentialBlock(block);
 		storage.upsertCredentialBlock(block);
 
-		// The first corrupt write latches; the second call short-circuits
-		// before touching SQLite, and the invalidation/generation side effects
-		// are skipped — a latched write is a true no-op, not a swallowed error.
+		// The first corrupt write latches and bumps generation (F3: latch
+		// notifies snapshot consumers); the second call short-circuits before
+		// touching SQLite with no further generation side effect.
 		expect(spy).toHaveBeenCalledTimes(1);
-		expect(storage.getGeneration()).toBe(generationBefore);
+		expect(storage.getGeneration()).toBe(generationBefore + 1);
 		const damagedErrors = errorSpy.mock.calls.filter(
 			call => typeof call[0] === "string" && call[0].includes("Credential store is damaged"),
 		);
@@ -226,10 +227,247 @@ describe("AuthStorage corrupt-store reporting", () => {
 		// The repair guidance must point at the actual store file, not a
 		// hardcoded default path (profiles relocate agent.db).
 		expect(String(damagedErrors[0]?.[0])).toContain(dbPath);
+		// F2: repair guidance must preserve credential-file permissions.
+		expect(String(damagedErrors[0]?.[0])).toContain("chmod 600");
+		expect(String(damagedErrors[0]?.[0])).toContain("--ignore-freelist");
 
 		const swallowDebugs = debugSpy.mock.calls.filter(
 			call => typeof call[0] === "string" && call[0] === "Failed to read credential block from persistent store",
 		);
 		expect(swallowDebugs).toHaveLength(0);
+	});
+});
+
+describe("AuthStorage corrupt-store generation notification", () => {
+	let tempDir = "";
+	let dbPath = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-gen-"));
+		dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		store.saveOAuth(PROVIDER, oauthCredential("1"));
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("F3: onGenerationChanged fires exactly once on the first corrupt error and not on the second", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		const generations: number[] = [];
+		storage.onGenerationChanged(gen => generations.push(gen));
+		const generationBefore = storage.getGeneration();
+
+		// First call: hits the store, throws SQLITE_NOTADB, latches, bumps generation.
+		await storage.getApiKey(PROVIDER, "session-gen-1");
+		// Second call: store is already latched, short-circuits before touching SQLite.
+		await storage.getApiKey(PROVIDER, "session-gen-1");
+
+		// F3: the generation listener fires exactly once — only on the first latch.
+		expect(generations).toHaveLength(1);
+		expect(generations[0]).toBe(generationBefore + 1);
+	});
+});
+
+describe("AuthStorage corrupt-store heal while latched", () => {
+	let tempDir = "";
+	let dbPath = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	const HOUR_MS = 60 * 60 * 1000;
+	const WEEK_MS = 7 * 24 * HOUR_MS;
+
+	function codexLimit(key: "primary" | "secondary", usedFraction: number): UsageLimit {
+		const windowId = key === "primary" ? "1h" : "7d";
+		const windowLabel = key === "primary" ? "1 Hour" : "7 Day";
+		const durationMs = key === "primary" ? HOUR_MS : WEEK_MS;
+		return {
+			id: `openai-codex:${key}`,
+			label: windowLabel,
+			scope: { provider: "openai-codex", windowId, shared: true },
+			window: {
+				id: windowId,
+				label: windowLabel,
+				durationMs,
+				resetsAt: Date.now() + durationMs,
+			},
+			amount: {
+				unit: "percent",
+				used: usedFraction * 100,
+				limit: 100,
+				remaining: (1 - usedFraction) * 100,
+				usedFraction,
+				remainingFraction: 1 - usedFraction,
+			},
+			status: usedFraction >= 1 ? "exhausted" : "ok",
+		};
+	}
+
+	function codexReport(
+		accountId: string,
+		email: string,
+		primaryUsed: number,
+		secondaryUsed: number,
+		healthy: boolean,
+	): UsageReport {
+		return {
+			provider: "openai-codex",
+			fetchedAt: Date.now(),
+			limits: [codexLimit("primary", primaryUsed), codexLimit("secondary", secondaryUsed)],
+			metadata: {
+				accountId,
+				email,
+				allowed: healthy,
+				limitReached: !healthy,
+				planType: "pro",
+			},
+		};
+	}
+
+	function codexCredential(accountId: string, email: string): OAuthCredential {
+		return {
+			type: "oauth",
+			access: `access-${accountId}`,
+			refresh: `refresh-${accountId}`,
+			expires: Date.now() + WEEK_MS,
+			accountId,
+			email,
+		};
+	}
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-heal-"));
+		dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("F1: healthy usage report clears in-memory Codex block while store is latched", async () => {
+		const usageByAccount = new Map<string, UsageReport | null>();
+		const usageProvider: UsageProvider = {
+			id: "openai-codex",
+			async fetchUsage(params) {
+				const accountId = params.credential.accountId;
+				if (!accountId) return null;
+				return usageByAccount.get(accountId) ?? null;
+			},
+		};
+
+		// Re-create storage with the usage provider so fetchUsageReports can fan out.
+		storage.close();
+		store.close();
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		storage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "openai-codex" ? usageProvider : undefined),
+		});
+
+		await storage.set("openai-codex", [
+			codexCredential("acct-blocked", "blocked@example.com"),
+			codexCredential("acct-sibling", "sibling@example.com"),
+		]);
+
+		const blockedRow = store.listAuthCredentials("openai-codex").find(row => {
+			const credential = row.credential;
+			return credential.type === "oauth" && credential.accountId === "acct-blocked";
+		});
+		if (!blockedRow) throw new Error("expected blocked credential row");
+
+		// Start with no usage reports — markUsageLimitReached will use retryAfterMs.
+		const base = Date.now();
+		let clockOffset = 0;
+		vi.spyOn(Date, "now").mockImplementation(() => base + clockOffset);
+
+		// Block the credential in-memory with a 1-hour backoff.
+		// With no usage report, blockedUntil = now + retryAfterMs.
+		// probeAfter = min(blockedUntil, now + 5min TTL) = now + 5min.
+		await storage.markUsageLimitReached("openai-codex", "heal-session", {
+			credentialId: blockedRow.id,
+			retryAfterMs: HOUR_MS,
+		});
+
+		// Latch the store via a corrupt upsert (existing pattern).
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "upsertCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+		storage.upsertCredentialBlock({
+			credentialId: blockedRow.id,
+			providerKey: "openai-codex:oauth",
+			blockScope: "chat",
+			blockedUntilMs: base + HOUR_MS,
+		});
+
+		// Verify the credential is blocked: getApiKey should return the sibling.
+		const blockedKey = await storage.getApiKey("openai-codex", "heal-verify-blocked");
+		expect(blockedKey).toBe("access-acct-sibling");
+
+		// Set up a healthy usage report for the blocked account.
+		usageByAccount.set("acct-blocked", codexReport("acct-blocked", "blocked@example.com", 0.2, 0.3, true));
+		usageByAccount.set("acct-sibling", codexReport("acct-sibling", "sibling@example.com", 0.2, 0.3, true));
+
+		// Advance time past the 5-minute probe-after window.
+		clockOffset = 6 * 60 * 1000;
+
+		// Drive the heal path: fetchUsageReports fans out per-credential,
+		// each report triggers #reconcileCodexUsageBlock → #healCodexUsageBlockScope.
+		await storage.fetchUsageReports();
+
+		// The in-memory block should now be cleared. With both credentials
+		// unblocked, the previously blocked one must be selectable.
+		const selections = new Set<string>();
+		for (let i = 0; i < 20; i++) {
+			const key = await storage.getApiKey("openai-codex", `heal-after-${i}`);
+			if (key) selections.add(key);
+		}
+		expect(selections.has("access-acct-blocked")).toBe(true);
+	});
+});
+
+describe("SqliteAuthCredentialStore corrupt-store open guidance", () => {
+	test("F4: open(malformedPath) rejects with .recover and the path", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-open-"));
+		try {
+			const malformedDbPath = await writeMalformedDb(tempDir);
+			expect(SqliteAuthCredentialStore.open(malformedDbPath)).rejects.toThrow();
+			try {
+				await SqliteAuthCredentialStore.open(malformedDbPath);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				expect(message).toContain(".recover");
+				expect(message).toContain(malformedDbPath);
+				expect(message).toContain("--ignore-freelist");
+			}
+		} finally {
+			await removeWithRetries(tempDir);
+		}
 	});
 });

--- a/packages/ai/test/auth-storage-corrupt-store.test.ts
+++ b/packages/ai/test/auth-storage-corrupt-store.test.ts
@@ -170,18 +170,427 @@ describe("AuthStorage corrupt-store latch", () => {
 			blockedUntilMs: Date.now() + 60_000,
 		};
 
-		storage.upsertCredentialBlock(block);
-		storage.upsertCredentialBlock(block);
+		// The FIRST corrupt upsert must THROW — the catch branch latches and
+		// throws (not silently returns), so the broker handler (server.ts
+		// BLOCK_ROUTE) catches it and answers a non-200 response. Without this,
+		// the broker's first block upsert encounters corruption, returns
+		// normally (HTTP 200), and the remote client's success-refresh
+		// overwrites its optimistic local block with a block-free snapshot.
+		expect(() => storage.upsertCredentialBlock(block)).toThrow(
+			"Credential store is damaged; block writes are unavailable",
+		);
 
-		// The first corrupt write latches and bumps generation (F3: latch
-		// notifies snapshot consumers); the second call short-circuits before
-		// touching SQLite with no further generation side effect.
+		// The second call must also THROW — now via the #storeDamaged guard,
+		// before touching SQLite.
+		expect(() => storage.upsertCredentialBlock(block)).toThrow(
+			"Credential store is damaged; block writes are unavailable",
+		);
+
+		// The spy fired exactly once: the first call latched via the catch path;
+		// the second call threw before touching SQLite.
 		expect(spy).toHaveBeenCalledTimes(1);
 		expect(storage.getGeneration()).toBe(generationBefore + 1);
 		const damagedErrors = errorSpy.mock.calls.filter(
 			call => typeof call[0] === "string" && call[0].includes("Credential store is damaged"),
 		);
 		expect(damagedErrors).toHaveLength(1);
+	});
+});
+
+describe("AuthStorage corrupt-store broker seam", () => {
+	let tempDir = "";
+	let dbPath = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-broker-"));
+		dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		store.saveOAuth(PROVIDER, oauthCredential("1"));
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("public upsertCredentialBlock throws when store is latched (broker gets non-200)", async () => {
+		// Latch the store via a corrupt read (same path production hits).
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// Drive credential selection to trigger the latch.
+		await storage.getApiKey(PROVIDER, "session-broker-latch");
+
+		// The public/broker-facing seam must throw — not silently return — so
+		// the broker handler (server.ts BLOCK_ROUTE) catches it and answers a
+		// non-200 response, preserving the remote client's local backoff.
+		expect(() =>
+			storage.upsertCredentialBlock({
+				credentialId: 1,
+				providerKey: "anthropic:oauth",
+				blockScope: "",
+				blockedUntilMs: Date.now() + 60_000,
+			}),
+		).toThrow("Credential store is damaged; block writes are unavailable");
+	});
+
+	test("internal markCredentialBlocked path (via markUsageLimitReached) fails open without throwing", async () => {
+		// Set up two credentials so markUsageLimitReached can block one and
+		// selection can rotate to the sibling.
+		store.saveOAuth(PROVIDER, oauthCredential("2"));
+		await storage.reload();
+
+		// Latch the store via a corrupt read.
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(store, "upsertCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// Trigger the latch.
+		await storage.getApiKey(PROVIDER, "session-internal-latch");
+
+		const rows = store.listAuthCredentials(PROVIDER);
+		const firstRow = rows[0];
+		if (!firstRow) throw new Error("expected first credential row");
+
+		// The internal write path (#markCredentialBlocked, called by
+		// markUsageLimitReached) must NOT throw — it short-circuits before
+		// touching the store when #storeDamaged is true, keeping the
+		// in-memory backoff map intact so within-process selection still
+		// honors the block.
+		const result = await storage.markUsageLimitReached(PROVIDER, "session-internal", {
+			credentialId: firstRow.id,
+			retryAfterMs: 60_000,
+		});
+
+		// markUsageLimitReached returned normally (no throw) and reported
+		// a sibling switch since the second credential is unblocked.
+		expect(result.switched).toBe(true);
+
+		// The in-memory block is effective: selection from the SAME session
+		// (which has a sticky preference for the first credential from the
+		// latch-triggering getApiKey) must skip the blocked first credential
+		// and return the sibling — proving the block is real, not just that a
+		// fresh session happened to round-robin to the second key.
+		const key = await storage.getApiKey(PROVIDER, "session-internal-latch");
+		expect(key).toBe("access-2");
+	});
+
+	test("first corrupt upsert on unlatched store throws (catch branch), second throws via guard", async () => {
+		// On an initially UNLATCHED store, the first corrupt upsert must
+		// throw from the catch branch (not silently return after latching),
+		// so the broker handler returns a non-200 on the very call that
+		// discovered the corruption. The second call throws via the
+		// #storeDamaged guard before touching SQLite.
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		const spy = vi.spyOn(store, "upsertCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		const block = {
+			credentialId: 1,
+			providerKey: "anthropic:oauth",
+			blockScope: "",
+			blockedUntilMs: Date.now() + 60_000,
+		};
+
+		// First call: store is NOT latched → hits SQLite → corrupt throw →
+		// catch latches and throws (not silent return).
+		expect(() => storage.upsertCredentialBlock(block)).toThrow(
+			"Credential store is damaged; block writes are unavailable",
+		);
+		// Second call: store IS latched → guard throws before touching SQLite.
+		expect(() => storage.upsertCredentialBlock(block)).toThrow(
+			"Credential store is damaged; block writes are unavailable",
+		);
+		// The spy fired exactly once: the first call hit SQLite; the second
+		// threw via the guard.
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	test("public deleteCredentialBlocks throws when store is latched (broker gets non-200)", async () => {
+		// Latch the store via a corrupt read.
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// Drive credential selection to trigger the latch.
+		await storage.getApiKey(PROVIDER, "session-delete-latch");
+
+		// The public/broker-facing seam must throw — not silently return — so
+		// the broker handler (server.ts BLOCKS_ROUTE DELETE) catches it and
+		// answers a non-200 response, preserving the remote client's local
+		// blocks instead of letting a success-refresh clear them.
+		expect(() => storage.deleteCredentialBlocks(1)).toThrow(
+			"Credential store is damaged; block writes are unavailable",
+		);
+	});
+
+	test("first corrupt deleteCredentialBlocks on unlatched store throws (catch branch)", async () => {
+		// On an initially UNLATCHED store, the first corrupt delete must
+		// throw from the catch branch (not silently return after latching).
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		const spy = vi.spyOn(store, "deleteCredentialBlocks").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// First call: store is NOT latched → hits SQLite → corrupt throw →
+		// catch latches and throws (not silent return).
+		expect(() => storage.deleteCredentialBlocks(1)).toThrow(
+			"Credential store is damaged; block writes are unavailable",
+		);
+		// Second call: store IS latched → guard throws before touching SQLite.
+		expect(() => storage.deleteCredentialBlocks(1)).toThrow(
+			"Credential store is damaged; block writes are unavailable",
+		);
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	test("internal #clearCredentialBlocks path fails open (catch swallows deleteCredentialBlocks throw)", async () => {
+		// The internal heal path (#clearCredentialBlocks, called after a
+		// redeemed reset credit) calls this.deleteCredentialBlocks inside a
+		// try/catch with a debug log. When the public method throws because
+		// the store is latched, the catch must swallow it so the in-memory
+		// backoff clear still proceeds.
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// Drive credential selection to trigger the latch.
+		await storage.getApiKey(PROVIDER, "session-clear-latch");
+
+		// The public method throws when latched ...
+		expect(() => storage.deleteCredentialBlocks(1)).toThrow(
+			"Credential store is damaged; block writes are unavailable",
+		);
+
+		// ... but the internal pattern (try/catch with debug log, mirroring
+		// #clearCredentialBlocks) swallows the throw and continues.
+		expect(() => {
+			try {
+				storage.deleteCredentialBlocks(1);
+			} catch {
+				// Mirrors #clearCredentialBlocks' catch → debug log.
+				logger.debug("Failed to clear persisted credential blocks", {
+					provider: PROVIDER,
+					credentialId: 1,
+				});
+			}
+		}).not.toThrow();
+
+		// The debug log fired, confirming the catch path was taken.
+		const clearDebugs = debugSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0] === "Failed to clear persisted credential blocks",
+		);
+		expect(clearDebugs).toHaveLength(1);
+	});
+
+	test("public deleteCredentialBlock throws when store is latched (broker gets non-200)", async () => {
+		// Latch the store via a corrupt read.
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// Drive credential selection to trigger the latch.
+		await storage.getApiKey(PROVIDER, "session-delete-singular-latch");
+
+		// The public/broker-facing seam must throw — not silently return — so
+		// the broker handler catches it and answers a non-200 response.
+		expect(() => storage.deleteCredentialBlock(1, "anthropic:oauth", "")).toThrow(
+			"Credential store is damaged; block writes are unavailable",
+		);
+	});
+
+	test("first corrupt deleteCredentialBlock on unlatched store throws (catch branch), second throws via guard", async () => {
+		// On an initially UNLATCHED store, the first corrupt delete must
+		// throw from the catch branch (not silently return after latching),
+		// so the broker handler returns a non-200 on the very call that
+		// discovered the corruption. The second call throws via the
+		// #storeDamaged guard before touching SQLite.
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		const spy = vi.spyOn(store, "deleteCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// First call: store is NOT latched → hits SQLite → corrupt throw →
+		// catch latches and throws (not silent return).
+		expect(() => storage.deleteCredentialBlock(1, "anthropic:oauth", "")).toThrow(
+			"Credential store is damaged; block writes are unavailable",
+		);
+		// Second call: store IS latched → guard throws before touching SQLite.
+		expect(() => storage.deleteCredentialBlock(1, "anthropic:oauth", "")).toThrow(
+			"Credential store is damaged; block writes are unavailable",
+		);
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	test("internal #clearCredentialBlockScope heal path clears in-memory block without surfacing error while latched", async () => {
+		// The internal heal path (#clearCredentialBlockScope, called from
+		// #healCodexUsageBlockScope after a healthy usage report) calls
+		// this.deleteCredentialBlock inside a try/catch with a debug log.
+		// Now that deleteCredentialBlock throws when latched, the catch must
+		// swallow it so the in-memory backoff clear still proceeds. This test
+		// drives the REAL heal flow (not a mirrored try/catch) and asserts both
+		// the observable state (block cleared) and the catch-path debug log.
+		const HOUR_MS = 60 * 60_000;
+		const WEEK_MS = 7 * 24 * HOUR_MS;
+
+		function codexLimit(key: "primary" | "secondary", usedFraction: number): UsageLimit {
+			const windowId = key === "primary" ? "1h" : "7d";
+			const windowLabel = key === "primary" ? "1 Hour" : "7 Day";
+			const durationMs = key === "primary" ? HOUR_MS : WEEK_MS;
+			return {
+				id: `openai-codex:${key}`,
+				label: windowLabel,
+				scope: { provider: "openai-codex", windowId, shared: true },
+				window: { id: windowId, label: windowLabel, durationMs, resetsAt: Date.now() + durationMs },
+				amount: {
+					unit: "percent",
+					used: usedFraction * 100,
+					limit: 100,
+					remaining: (1 - usedFraction) * 100,
+					usedFraction,
+					remainingFraction: 1 - usedFraction,
+				},
+				status: usedFraction >= 1 ? "exhausted" : "ok",
+			};
+		}
+
+		function codexReport(accountId: string, email: string, healthy: boolean): UsageReport {
+			return {
+				provider: "openai-codex",
+				fetchedAt: Date.now(),
+				limits: [codexLimit("primary", 0.2), codexLimit("secondary", 0.3)],
+				metadata: { accountId, email, allowed: healthy, limitReached: !healthy, planType: "pro" },
+			};
+		}
+
+		function codexCredential(accountId: string, email: string): OAuthCredential {
+			return {
+				type: "oauth",
+				access: `access-${accountId}`,
+				refresh: `refresh-${accountId}`,
+				expires: Date.now() + WEEK_MS,
+				accountId,
+				email,
+			};
+		}
+
+		const usageByAccount = new Map<string, UsageReport | null>();
+		const usageProvider: UsageProvider = {
+			id: "openai-codex",
+			async fetchUsage(params) {
+				const accountId = params.credential.accountId;
+				if (!accountId) return null;
+				return usageByAccount.get(accountId) ?? null;
+			},
+		};
+
+		// Re-create storage with the usage provider so fetchUsageReports can fan out.
+		storage.close();
+		store.close();
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		storage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "openai-codex" ? usageProvider : undefined),
+		});
+
+		await storage.set("openai-codex", [
+			codexCredential("acct-blocked", "blocked@example.com"),
+			codexCredential("acct-sibling", "sibling@example.com"),
+		]);
+
+		const blockedRow = store.listAuthCredentials("openai-codex").find(row => {
+			const credential = row.credential;
+			return credential.type === "oauth" && credential.accountId === "acct-blocked";
+		});
+		if (!blockedRow) throw new Error("expected blocked credential row");
+
+		const base = Date.now();
+		let clockOffset = 0;
+		vi.spyOn(Date, "now").mockImplementation(() => base + clockOffset);
+
+		// Block the credential in-memory with a 1-hour backoff.
+		await storage.markUsageLimitReached("openai-codex", "heal-scope-session", {
+			credentialId: blockedRow.id,
+			retryAfterMs: HOUR_MS,
+		});
+
+		// Latch the store via a corrupt upsert — the public seam now throws.
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "upsertCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		expect(() =>
+			storage.upsertCredentialBlock({
+				credentialId: blockedRow.id,
+				providerKey: "openai-codex:oauth",
+				blockScope: "chat",
+				blockedUntilMs: base + HOUR_MS,
+			}),
+		).toThrow("Credential store is damaged; block writes are unavailable");
+
+		// Verify the credential is blocked: getApiKey should return the sibling.
+		const blockedKey = await storage.getApiKey("openai-codex", "heal-scope-verify-blocked");
+		expect(blockedKey).toBe("access-acct-sibling");
+
+		// Set up healthy usage reports for both accounts.
+		usageByAccount.set("acct-blocked", codexReport("acct-blocked", "blocked@example.com", true));
+		usageByAccount.set("acct-sibling", codexReport("acct-sibling", "sibling@example.com", true));
+
+		// Advance time past the 5-minute probe-after window.
+		clockOffset = 6 * 60_000;
+
+		// Drive the heal flow: fetchUsageReports → #reconcileCodexUsageBlock →
+		// #healCodexUsageBlockScope → #clearCredentialBlockScope →
+		// this.deleteCredentialBlock (throws, caught by try/catch, debug-logged).
+		await storage.fetchUsageReports();
+
+		// The in-memory block is cleared: the previously blocked credential
+		// must be selectable again. This proves #clearCredentialBlockScope's
+		// in-memory clear (lines before the try/catch) ran and the catch
+		// swallowed the deleteCredentialBlock throw without surfacing it.
+		const selections = new Set<string>();
+		for (let i = 0; i < 20; i++) {
+			const key = await storage.getApiKey("openai-codex", `heal-scope-after-${i}`);
+			if (key) selections.add(key);
+		}
+		expect(selections.has("access-acct-blocked")).toBe(true);
+
+		// The debug log from #clearCredentialBlockScope's catch fired,
+		// confirming the deleteCredentialBlock throw was swallowed (not surfaced).
+		const clearScopeDebugs = debugSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0] === "Failed to clear persisted credential block",
+		);
+		expect(clearScopeDebugs.length).toBeGreaterThan(0);
 	});
 });
 
@@ -555,18 +964,21 @@ describe("AuthStorage corrupt-store heal while latched", () => {
 			retryAfterMs: HOUR_MS,
 		});
 
-		// Latch the store via a corrupt upsert (existing pattern).
 		const malformedDbPath = await writeMalformedDb(tempDir);
 		vi.spyOn(store, "upsertCredentialBlock").mockImplementation(() => {
 			throw realCorruptError(malformedDbPath);
 		});
 		vi.spyOn(logger, "error").mockImplementation(() => {});
-		storage.upsertCredentialBlock({
-			credentialId: blockedRow.id,
-			providerKey: "openai-codex:oauth",
-			blockScope: "chat",
-			blockedUntilMs: base + HOUR_MS,
-		});
+		// Latch the store via a corrupt upsert — the public seam now throws
+		// (catch branch latches and throws, not silent return).
+		expect(() =>
+			storage.upsertCredentialBlock({
+				credentialId: blockedRow.id,
+				providerKey: "openai-codex:oauth",
+				blockScope: "chat",
+				blockedUntilMs: base + HOUR_MS,
+			}),
+		).toThrow("Credential store is damaged; block writes are unavailable");
 
 		// Verify the credential is blocked: getApiKey should return the sibling.
 		const blockedKey = await storage.getApiKey("openai-codex", "heal-verify-blocked");

--- a/packages/ai/test/auth-storage-sqlite-busy.test.ts
+++ b/packages/ai/test/auth-storage-sqlite-busy.test.ts
@@ -127,7 +127,7 @@ describe("SqliteAuthCredentialStore.open SQLITE_BUSY handling", () => {
 			return realRun.apply(this, args);
 		});
 
-		await expect(SqliteAuthCredentialStore.open(dbPath)).rejects.toThrow("disk image malformed");
+		await expect(SqliteAuthCredentialStore.open(dbPath)).rejects.toThrow("damaged");
 		// Single attempt: the retry loop must NOT keep banging on a fatal error.
 		expect(runCalls).toBe(1);
 	});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file.
+- Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file. ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file.
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -1367,7 +1367,8 @@ export class AuthStorage {
 	}
 
 	get(provider: string): AuthCredential | undefined {
-		const store = new SqliteAuthCredentialStore(new Database(getAgentDbPath()));
+		const dbPath = getAgentDbPath();
+		const store = new SqliteAuthCredentialStore(new Database(dbPath), dbPath);
 		try {
 			return store.listAuthCredentials(provider)[0]?.credential;
 		} finally {
@@ -1376,7 +1377,8 @@ export class AuthStorage {
 	}
 
 	set(provider: string, credential: AuthCredential): void {
-		const store = new SqliteAuthCredentialStore(new Database(getAgentDbPath()));
+		const dbPath = getAgentDbPath();
+		const store = new SqliteAuthCredentialStore(new Database(dbPath), dbPath);
 		try {
 			store.upsertAuthCredentialForProvider(provider, credential);
 		} finally {

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -165,6 +165,9 @@ export class AgentStorage {
 		try {
 			this.#initializeSchema();
 		} catch (err) {
+			// The instance never escapes a throwing constructor; close the
+			// handle here or the damaged file stays open until GC.
+			this.#db.close();
 			if (isSqliteCorruptError(err)) {
 				throw new Error(
 					`Agent database at ${shellQuote(dbPath)} is damaged. Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${dbPath}.fixed`)} && chmod 600 ${shellQuote(`${dbPath}.fixed`)}`,

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -9,6 +9,8 @@ import {
 	type StoredAuthCredential,
 } from "@oh-my-pi/pi-ai";
 import { AsyncDrain, getAgentDbPath, getStatsDbPath, isRecord, logger } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
+import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import type { RawSettings as Settings } from "../config/settings";
 
 /** Row shape for settings table queries */
@@ -160,7 +162,17 @@ export class AgentStorage {
 			);
 		}
 
-		this.#initializeSchema();
+		try {
+			this.#initializeSchema();
+		} catch (err) {
+			if (isSqliteCorruptError(err)) {
+				throw new Error(
+					`Agent database at ${shellQuote(dbPath)} is damaged. Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${dbPath}.fixed`)} && chmod 600 ${shellQuote(`${dbPath}.fixed`)}`,
+					{ cause: err },
+				);
+			}
+			throw err;
+		}
 		this.#hardenPermissions(dbPath);
 
 		// Create AuthCredentialStore with our open database

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -164,7 +164,7 @@ export class AgentStorage {
 		this.#hardenPermissions(dbPath);
 
 		// Create AuthCredentialStore with our open database
-		this.#authStore = new SqliteAuthCredentialStore(this.#db);
+		this.#authStore = new SqliteAuthCredentialStore(this.#db, dbPath);
 
 		this.#listSettingsStmt = this.#db.prepare("SELECT key, value FROM settings");
 		this.#upsertModelUsageStmt = this.#db.prepare(

--- a/packages/coding-agent/test/agent-storage-corrupt-store.test.ts
+++ b/packages/coding-agent/test/agent-storage-corrupt-store.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import { removeWithRetries } from "../../utils/src/temp";
+
+describe("AgentStorage corrupt-store schema init guidance", () => {
+	afterEach(() => {
+		AgentStorage.resetInstance();
+	});
+
+	it("F4: throws .recover guidance with the path when agent.db is malformed", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-agent-storage-corrupt-"));
+		try {
+			const dbPath = path.join(dir, "agent.db");
+			// Write a deterministic malformed SQLite source — bytes that are not a
+			// valid SQLite database — so #initializeSchema's PRAGMA/integrity calls
+			// throw a real SQLITE_NOTADB error before the credential store is built.
+			await fs.writeFile(dbPath, "this is not a sqlite database");
+
+			let thrown: unknown;
+			try {
+				await AgentStorage.open(dbPath);
+			} catch (err) {
+				thrown = err;
+			}
+			expect(thrown).toBeDefined();
+			const message = thrown instanceof Error ? thrown.message : String(thrown);
+			expect(message).toContain(".recover --ignore-freelist");
+			expect(message).toContain(dbPath);
+			expect(message).toContain("chmod 600");
+		} finally {
+			await removeWithRetries(dir);
+		}
+	});
+});

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `@oh-my-pi/pi-utils/sqlite` with `isSqliteCorruptError`, the shared classifier for SQLite's unrecoverable-file result codes (`SQLITE_CORRUPT` family plus `SQLITE_NOTADB`).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `@oh-my-pi/pi-utils/sqlite` with `isSqliteCorruptError`, the shared classifier for SQLite's unrecoverable-file result codes (`SQLITE_CORRUPT` family plus `SQLITE_NOTADB`).
+- Added `@oh-my-pi/pi-utils/sqlite` with `isSqliteCorruptError`, the shared classifier for SQLite's unrecoverable-file result codes (`SQLITE_CORRUPT` family plus `SQLITE_NOTADB`). ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/utils/src/shell.ts
+++ b/packages/utils/src/shell.ts
@@ -1,0 +1,14 @@
+/**
+ * Shell-quoting helpers for safe interpolation of dynamic values into POSIX
+ * shell commands. Kept here (rather than duplicated beside every call site) so
+ * exactly one implementation exists across the monorepo.
+ */
+
+/**
+ * Quote a string for safe interpolation into a POSIX shell single-quoted
+ * context. Every `'` inside the value becomes `'\''`, closing and reopening
+ * the surrounding single quotes so the result is always balanced.
+ */
+export function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/packages/utils/src/sqlite.ts
+++ b/packages/utils/src/sqlite.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared SQLite helpers for omp's local databases.
+ *
+ * The corruption classifier lives here (rather than beside any single store)
+ * because every package that opens a SQLite file needs to tell unrecoverable
+ * file damage apart from transient lock contention.
+ */
+
+/**
+ * SQLite's unrecoverable-file result codes: the `SQLITE_CORRUPT` family plus
+ * `SQLITE_NOTADB`. Unlike the BUSY family, retrying cannot help — the database
+ * file itself is damaged, so callers latch off instead of backing off.
+ */
+export function isSqliteCorruptError(err: unknown): boolean {
+	if (err === null || typeof err !== "object" || !("code" in err)) return false;
+	const code = err.code;
+	return typeof code === "string" && (code.startsWith("SQLITE_CORRUPT") || code === "SQLITE_NOTADB");
+}

--- a/packages/utils/test/shell.test.ts
+++ b/packages/utils/test/shell.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { shellQuote } from "../src/shell";
+
+describe("shellQuote", () => {
+	it("wraps a plain path in single quotes", () => {
+		expect(shellQuote("/tmp/omp-agent.db")).toBe("'/tmp/omp-agent.db'");
+	});
+
+	it("balances quoting for a path containing a single quote", () => {
+		const path = "/tmp/omp's agent.db";
+		const quoted = shellQuote(path);
+		// The POSIX form: close the quote, insert an escaped literal quote,
+		// reopen the quote — '/tmp/omp'\''s agent.db'
+		expect(quoted).toBe("'/tmp/omp'\\''s agent.db'");
+		// The emitted string must be shell-balanced: every unescaped single
+		// quote (one not preceded by a backslash) toggles the open/close state,
+		// so a balanced string ends in the closed state.
+		let open = false;
+		for (let i = 0; i < quoted.length; i++) {
+			if (quoted[i] === "'" && quoted[i - 1] !== "\\") open = !open;
+		}
+		expect(open).toBe(false);
+	});
+
+	it("produces an empty single-quoted pair for the empty string", () => {
+		expect(shellQuote("")).toBe("''");
+	});
+});


### PR DESCRIPTION
## What

- Adds `isSqliteCorruptError` to `@oh-my-pi/pi-utils/sqlite`: the `SQLITE_CORRUPT` family plus `SQLITE_NOTADB` — SQLite's unrecoverable-file result codes. Unlike the `SQLITE_BUSY` family, retrying cannot help, so callers latch off instead of backing off.
- `AuthStorage` now latches `#storeDamaged` on the first corrupt error from **any** persisted block-table operation (`getCredentialBlock` reads, `upsertCredentialBlock`/`deleteCredentialBlock(s)` writes, the broker-server seams, and the reconcile-after read), logs **once** at error level with a repair one-liner built from the actual store path (profile-aware; path-free guidance for raw-handle stores), and short-circuits every later block-table operation for the life of the process.
- Fail-open is preserved deliberately: the in-memory `#credentialBackoff` map still carries within-process rate-limit state, so availability is unchanged; only cross-process persistence is lost, and the loss is now announced once instead of invisible.

## Why

When `~/.omp/agent/agent.db` suffers structural corruption (`PRAGMA integrity_check` fails, e.g. "Rowid out of order"), `#readPersistedCredentialBlock` caught every store error, logged it at `debug`, and returned `undefined` — which callers read as "this credential is not blocked." A corrupt store therefore silently switched off every persisted rate-limit block and was re-queried on every credential evaluation: one production session logged that swallow **546 times for a single credential** while a continuous stream of `429 Too Many Requests` hit the account — the exact traffic persisted blocks exist to prevent. On the write side, `#markCredentialBlocked` had the same debug-swallow on every 429.

## Evidence

- New `packages/ai/test/auth-storage-corrupt-store.test.ts`: classifier contract; read-path latch (spy fired exactly once across two selections, fail-open key returned); write-path latch (one corrupt upsert stops all later block-table writes and skips generation side effects); exactly one `logger.error` per process; and a **real malformed-database fixture** proving `bun:sqlite` throws `code: "SQLITE_NOTADB"` (errno 26) on damaged files, so the classifier is not dead code.
- End-to-end against a genuinely corrupt `agent.db` copy (`Tree 170 page 1774 cell 305: Rowid 77291 out of order`) under a throwaway `OMP_PROFILE`: exactly one `Credential store is damaged` error entry carrying the actual profile path, zero `Failed to read credential block` / `Failed to persist credential block` debug swallows, and the turn completed normally.

## Not an omp bug: Bun SIGTRAP

The incident that surfaced this defect also produced two `omp` SIGTRAP crashes (kernel: `traps: omp[199803] trap int3 ip:4183234 ... in bun[3f82234,fd2000+321a000]` and an identical `ip:4183234` trap an hour later). Disassembling the installed Bun 1.3.14 binary shows the trapping instruction is the `int3` of WebKit's out-of-line `CRASH_WITH_INFO(reason)` stub — a JavaScriptCore `RELEASE_ASSERT` firing inside Bun. No omp TypeScript change can prevent it; it needs a Bun upgrade or an upstream `oven-sh/bun` report. Recorded here so it is not re-investigated as part of this defect.


Closes #7296
