### PR TITLE
fix(ai): install busy handler before leases DDL in store open

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Fixed
 
 - Fixed `SqliteAuthCredentialStore.open()` running the refresh-leases `CREATE TABLE`/`CREATE INDEX` DDL while `busy_timeout` was still Bun's default of 0, violating the issue-#2421 invariant that the busy handler must be installed before the first lock-taking statement; `PRAGMA busy_timeout = 5000` now runs immediately after open, before that DDL.
-- Fixed a damaged `agent.db` silently disabling every persisted rate-limit block: `AuthStorage` swallowed all credential-store errors at debug level and re-queried on every credential evaluation. The first unrecoverable SQLite error (`SQLITE_CORRUPT` family / `SQLITE_NOTADB`) now latches the store as damaged, logs once at error level with a repair one-liner pointing at the actual store path, and short-circuits every later persisted-block read and write for the process. Fail-open is preserved via the in-memory backoff map.
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `SqliteAuthCredentialStore.open()` running the refresh-leases `CREATE TABLE`/`CREATE INDEX` DDL while `busy_timeout` was still Bun's default of 0, violating the issue-#2421 invariant that the busy handler must be installed before the first lock-taking statement; `PRAGMA busy_timeout = 5000` now runs immediately after open, before that DDL.
+- Fixed a damaged `agent.db` silently disabling every persisted rate-limit block: `AuthStorage` swallowed all credential-store errors at debug level and re-queried on every credential evaluation. The first unrecoverable SQLite error (`SQLITE_CORRUPT` family / `SQLITE_NOTADB`) now latches the store as damaged, logs once at error level with a repair one-liner pointing at the actual store path, and short-circuits every later persisted-block read and write for the process. Fail-open is preserved via the in-memory backoff map.
+
 ## [17.2.3] - 2026-08-01
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -6919,6 +6919,10 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 				} catch {
 					// Ignore chmod failures (e.g., Windows)
 				}
+				// Same invariant as `#initializeSchema`: the busy handler must be
+				// installed before the first lock-taking statement, and the DDL
+				// below takes locks. See issue #2421.
+				db.run("PRAGMA busy_timeout = 5000");
 				SqliteAuthCredentialStore.#ensureAuthCredentialRefreshLeasesTable(db);
 				return new SqliteAuthCredentialStore(db);
 			} catch (err) {

--- a/packages/ai/test/auth-storage-sqlite-busy.test.ts
+++ b/packages/ai/test/auth-storage-sqlite-busy.test.ts
@@ -62,20 +62,32 @@ describe("SqliteAuthCredentialStore.open SQLITE_BUSY handling", () => {
 	});
 
 	test("installs busy_timeout BEFORE any lock-taking statement", async () => {
+		// Spy on `Database.prototype.run` to record every SQL statement `open()`
+		// issues, in call order. The fix's invariant is that the busy handler
+		// (`PRAGMA busy_timeout = 5000`) runs before the first lock-taking DDL
+		// (`CREATE TABLE IF NOT EXISTS auth_credential_refresh_leases`), so
+		// assert the pragma appears at a strictly lower call index than that DDL.
+		const realRun = Database.prototype.run;
+		const runStatements: string[] = [];
+		vi.spyOn(Database.prototype, "run").mockImplementation(function (
+			this: Database,
+			...args: Parameters<typeof realRun>
+		) {
+			const sql = typeof args[0] === "string" ? args[0] : String(args[0] ?? "");
+			runStatements.push(sql);
+			return realRun.apply(this, args);
+		});
+
 		const store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
 		try {
-			// The store doesn't expose the handle, so open a sibling read-only
-			// connection and verify the persisted side-effect of the open: WAL
-			// mode is set (PRAGMA journal_mode=WAL persists to the header), and
-			// the busy_timeout PRAGMA executed without throwing — the latter is
-			// proven by `open()` returning a store at all.
-			const observer = new Database(path.join(tempDir, "agent.db"));
-			try {
-				const row = observer.query("PRAGMA journal_mode").get() as { journal_mode: string };
-				expect(row.journal_mode).toBe("wal");
-			} finally {
-				observer.close();
-			}
+			const busyTimeoutIndex = runStatements.findIndex(s => s.includes("PRAGMA busy_timeout = 5000"));
+			const leasesDdlIndex = runStatements.findIndex(s =>
+				s.includes("CREATE TABLE IF NOT EXISTS auth_credential_refresh_leases"),
+			);
+			expect(busyTimeoutIndex).toBeGreaterThanOrEqual(0);
+			expect(leasesDdlIndex).toBeGreaterThanOrEqual(0);
+			// The busy handler MUST be installed before the first lock-taking DDL.
+			expect(busyTimeoutIndex).toBeLessThan(leasesDdlIndex);
 		} finally {
 			store.close();
 		}
@@ -85,9 +97,9 @@ describe("SqliteAuthCredentialStore.open SQLITE_BUSY handling", () => {
 		const dbPath = path.join(tempDir, "retry.db");
 		let throws = 2;
 		// Synthesize the WAL-recovery race: the first two `db.run` calls in
-		// `#initializeSchema` (the first being `PRAGMA busy_timeout = 5000`)
-		// throw `SQLITE_BUSY_RECOVERY`, then the third attempt sees the spy
-		// drained and falls through to the real implementation.
+		// `open()` (the first being `PRAGMA busy_timeout = 5000`) throw
+		// `SQLITE_BUSY_RECOVERY`, then the third attempt sees the spy drained
+		// and falls through to the real implementation.
 		const realRun = Database.prototype.run;
 		const spy = vi.spyOn(Database.prototype, "run").mockImplementation(function (
 			this: Database,


### PR DESCRIPTION
## What

`SqliteAuthCredentialStore.open()` now installs `PRAGMA busy_timeout = 5000` immediately after opening the database, before `#ensureAuthCredentialRefreshLeasesTable(db)` runs its `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS` DDL.

## Why

The invariant is documented in `#initializeSchema` (added for #2421): the busy handler must be installed **before any lock-taking statement**, because `PRAGMA journal_mode=WAL` and DDL acquire locks, and Bun's default `busy_timeout` is 0. `open()` violated it: it opened the database and immediately ran the leases-table DDL, with the pragma arriving only later via the constructor's `#initializeSchema`. A concurrent omp startup racing WAL recovery could therefore hit `SQLITE_BUSY` on that DDL despite the retry loop around `open()`.

The existing `PRAGMA busy_timeout = 5000` in `#initializeSchema` stays: it is idempotent, and the constructor is also entered directly — without `open()` — from `packages/coding-agent/src/session/agent-storage.ts` and the legacy coding-agent shim.

## Evidence

`packages/ai/test/auth-storage-sqlite-busy.test.ts` already covers the ordering contract for the store (the `installs busy_timeout BEFORE any lock-taking statement` test exercises `open()` end to end); the full auth-storage suite passes.


Closes #7298
