### PR TITLE
fix(stats): give the read-only usage reader a busy timeout

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the read-only usage-snapshot reader inheriting `busy_timeout = 0` and throwing `SQLITE_BUSY` immediately on a race with a concurrent WAL checkpoint, which the catch turned into a silently empty usage view; it now installs `PRAGMA busy_timeout = 5000` right after open.
+
 ## [17.1.2] - 2026-07-24
 
 ### Added

--- a/packages/stats/src/usage-windows.ts
+++ b/packages/stats/src/usage-windows.ts
@@ -59,6 +59,11 @@ export function readUsageSnapshots(sinceMs: number, dbPath = getAgentDbPath()): 
 	let db: Database | null = null;
 	try {
 		db = new Database(dbPath, { readonly: true });
+		// Match every other agent.db opener: without this the reader inherits
+		// busy_timeout = 0 and throws SQLITE_BUSY immediately on a race with a
+		// concurrent WAL checkpoint, which the catch below would silently report
+		// as "no usage history".
+		db.run("PRAGMA busy_timeout = 5000");
 		const rows = db
 			.prepare(
 				`SELECT recorded_at, provider, account_key, email, account_id, limit_id, label, window_label, used_fraction, status


### PR DESCRIPTION
## What

`readUsageSnapshots` (packages/stats) now installs `PRAGMA busy_timeout = 5000` immediately after opening `agent.db` read-only.

## Why

The reader previously opened the database with no pragmas, inheriting `busy_timeout = 0`. A WAL reader that collides with a concurrent checkpoint therefore threw `SQLITE_BUSY` immediately, and the existing `catch` turned that into `return []` — the usage view silently rendered as "no data" under contention instead of waiting a few milliseconds. Every other `agent.db` opener in the repo already installs the busy handler (issue-#2421 invariant); this reader was the outlier.

The `catch` behavior and the readonly flag are unchanged.


Closes #7300
