### PR TITLE
fix: centralize SQLite open pragmas and latch damaged stores across readers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed a damaged `agent.db` silently disabling every persisted rate-limit block: `AuthStorage` swallowed all credential-store errors at debug level and re-queried on every credential evaluation. The first unrecoverable SQLite error (`SQLITE_CORRUPT` family / `SQLITE_NOTADB`) now latches the store as damaged, logs once at error level with a repair one-liner pointing at the actual store path, and short-circuits every later persisted-block read and write for the process. Fail-open is preserved via the in-memory backoff map.
+- Fixed a damaged `agent.db` silently disabling every persisted rate-limit block: `AuthStorage` swallowed all credential-store errors at debug level and re-queried on every credential evaluation. The first unrecoverable SQLite error (`SQLITE_CORRUPT` family / `SQLITE_NOTADB`) now latches the store as damaged, logs once at error level with a repair one-liner pointing at the actual store path, and short-circuits every later persisted-block read and write for the process. Fail-open is preserved via the in-memory backoff map. ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Unified credential-store SQLite damage guidance, including restrictive recovery permissions, verification, sidecar backups, and installation of the repaired database.
 - Fixed a damaged `agent.db` silently disabling every persisted rate-limit block: `AuthStorage` swallowed all credential-store errors at debug level and re-queried on every credential evaluation. The first unrecoverable SQLite error (`SQLITE_CORRUPT` family / `SQLITE_NOTADB`) now latches the store as damaged, logs once at error level with a repair one-liner pointing at the actual store path, and short-circuits every later persisted-block read and write for the process. Fail-open is preserved via the in-memory backoff map. ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
+- Prevented damaged credential stores from publishing authoritative blockless broker snapshots; polling now returns an error and damaged SSE streams close without emitting an empty snapshot while clients retain their last valid state.
+- Ensured successful Codex reset redemption clears in-memory credential backoff even when the persistent block store is damaged.
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a damaged `agent.db` silently disabling every persisted rate-limit block: `AuthStorage` swallowed all credential-store errors at debug level and re-queried on every credential evaluation. The first unrecoverable SQLite error (`SQLITE_CORRUPT` family / `SQLITE_NOTADB`) now latches the store as damaged, logs once at error level with a repair one-liner pointing at the actual store path, and short-circuits every later persisted-block read and write for the process. Fail-open is preserved via the in-memory backoff map.
+
 ## [17.2.3] - 2026-08-01
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Unified credential-store SQLite damage guidance, including restrictive recovery permissions, verification, sidecar backups, and installation of the repaired database.
 - Fixed a damaged `agent.db` silently disabling every persisted rate-limit block: `AuthStorage` swallowed all credential-store errors at debug level and re-queried on every credential evaluation. The first unrecoverable SQLite error (`SQLITE_CORRUPT` family / `SQLITE_NOTADB`) now latches the store as damaged, logs once at error level with a repair one-liner pointing at the actual store path, and short-circuits every later persisted-block read and write for the process. Fail-open is preserved via the in-memory backoff map. ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
 
 ## [17.2.3] - 2026-08-01

--- a/packages/ai/src/auth-broker/server.ts
+++ b/packages/ai/src/auth-broker/server.ts
@@ -596,6 +596,9 @@ function serveSnapshotStream(
 					logger.debug("auth-broker stream removed", { peer, id, generation: snapshot.generation });
 				}
 			} while (pendingBumps > 0 && !closed);
+		} catch (error) {
+			logger.error("auth-broker stream generation update failed", { peer, error: String(error) });
+			cleanup();
 		} finally {
 			processing = false;
 		}
@@ -604,22 +607,27 @@ function serveSnapshotStream(
 	const stream = new ReadableStream<Uint8Array>({
 		async start(c) {
 			controller = c;
-			await storage.reload();
-			const initial = buildSnapshot(storage, refresher, clientSupportsCodexMeterBlockScopes);
-			lastGeneration = initial.generation;
-			for (const entry of initial.credentials) lastByCredId.set(entry.id, fingerprintEntry(entry));
-			const initialEvent: SnapshotStreamSnapshotEvent = { kind: "snapshot", ...initial };
-			if (!write(sseEvent("snapshot", initialEvent))) return;
-			keepaliveTimer = setInterval(() => {
-				write(": keepalive\n\n");
-			}, keepaliveMs);
-			keepaliveTimer.unref?.();
-			unsubscribe = storage.onGenerationChanged(() => {
-				void processGenerationBump();
-			});
-			abortHandler = (): void => cleanup();
-			req.signal.addEventListener("abort", abortHandler);
-			logger.info("auth-broker stream opened", { peer, generation: initial.generation });
+			try {
+				await storage.reload();
+				const initial = buildSnapshot(storage, refresher, clientSupportsCodexMeterBlockScopes);
+				lastGeneration = initial.generation;
+				for (const entry of initial.credentials) lastByCredId.set(entry.id, fingerprintEntry(entry));
+				const initialEvent: SnapshotStreamSnapshotEvent = { kind: "snapshot", ...initial };
+				if (!write(sseEvent("snapshot", initialEvent))) return;
+				keepaliveTimer = setInterval(() => {
+					write(": keepalive\n\n");
+				}, keepaliveMs);
+				keepaliveTimer.unref?.();
+				unsubscribe = storage.onGenerationChanged(() => {
+					void processGenerationBump();
+				});
+				abortHandler = (): void => cleanup();
+				req.signal.addEventListener("abort", abortHandler);
+				logger.info("auth-broker stream opened", { peer, generation: initial.generation });
+			} catch (error) {
+				logger.error("auth-broker stream failed", { peer, error: String(error) });
+				cleanup();
+			}
 		},
 		cancel() {
 			cleanup();
@@ -678,7 +686,7 @@ export function startAuthBroker(opts: AuthBrokerServerOptions): AuthBrokerServer
 					return serveSnapshotStream(req, opts.storage, refresher, peer, streamKeepaliveMs);
 				}
 				if (req.method === "GET" && pathname === "/v1/snapshot") {
-					return serveSnapshot(req, url, opts.storage, generationGate, refresher, peer);
+					return await serveSnapshot(req, url, opts.storage, generationGate, refresher, peer);
 				}
 				if (req.method === "GET" && pathname === "/v1/usage") {
 					try {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1727,6 +1727,16 @@ export class AuthStorage {
 		return true;
 	}
 
+	#damagedStoreError(cause?: unknown): Error {
+		const storePath = this.#store.databasePath;
+		return new Error(
+			storePath
+				? `Credential store at ${storePath} is damaged. ${sqliteRepairGuidance(storePath, { restrictPermissions: true })}`
+				: `Credential store is damaged. ${sqliteRepairGuidance(undefined)}`,
+			cause === undefined ? undefined : { cause },
+		);
+	}
+
 	#readPersistedCredentialBlock(
 		credentialId: number,
 		providerKey: string,
@@ -6390,11 +6400,11 @@ export class AuthStorage {
 	 * Broker-server seam: list non-expired persisted blocks for snapshot entries.
 	 */
 	listCredentialBlocks(credentialIds: readonly number[]): StoredCredentialBlock[] {
-		if (this.#storeDamaged) return [];
+		if (this.#storeDamaged) throw this.#damagedStoreError();
 		try {
 			return this.#store.listCredentialBlocks?.(credentialIds) ?? [];
 		} catch (err) {
-			if (this.#latchStoreDamage(err, "listCredentialBlocks", {})) return [];
+			if (this.#latchStoreDamage(err, "listCredentialBlocks", {})) throw this.#damagedStoreError(err);
 			throw err;
 		}
 	}

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -15,6 +15,7 @@ import { parseAlibabaTokenPlanCredential } from "@oh-my-pi/pi-catalog/wire/aliba
 import { $env, getAgentDbPath, logger } from "@oh-my-pi/pi-utils";
 import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
+import { configureSqliteDatabase, isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import type { ApiKeyResolver } from "./auth-retry";
 import * as AIError from "./error";
 import { isUsageLimitOutcome } from "./error/rate-limit";
@@ -7060,10 +7061,8 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		// `PRAGMA journal_mode=WAL`, which acquires an exclusive lock during WAL
 		// recovery). Without this, concurrent omp startups can crash here with
 		// `SQLITE_BUSY` / `SQLITE_BUSY_RECOVERY`. See issue #2421.
-		this.#db.run("PRAGMA busy_timeout = 5000");
+		configureSqliteDatabase(this.#db, { wal: true, synchronousNormal: true });
 		this.#db.run(`
-			PRAGMA journal_mode=WAL;
-			PRAGMA synchronous=NORMAL;
 			CREATE TABLE IF NOT EXISTS auth_schema_version (
 				id INTEGER PRIMARY KEY CHECK (id = 1),
 				version INTEGER NOT NULL

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -13,6 +13,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { parseAlibabaTokenPlanCredential } from "@oh-my-pi/pi-catalog/wire/alibaba-token-plan";
 import { $env, getAgentDbPath, logger } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import type { ApiKeyResolver } from "./auth-retry";
 import * as AIError from "./error";
@@ -1389,7 +1390,7 @@ export class AuthStorage {
 
 	#bumpGeneration(reason: string): void {
 		this.#generation += 1;
-		this.#store.acknowledgeLocalChanges?.();
+		if (!this.#storeDamaged) this.#store.acknowledgeLocalChanges?.();
 		for (const listener of [...this.#generationListeners]) {
 			try {
 				listener(this.#generation);
@@ -1717,7 +1718,7 @@ export class AuthStorage {
 		logger.error(
 			storePath
 				? `Credential store is damaged; persisted rate-limit blocks are disabled for this process. ` +
-						`Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 '${storePath}' '.recover --ignore-freelist' | sqlite3 '${storePath}.fixed' && chmod 600 '${storePath}.fixed'`
+						`Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 ${shellQuote(storePath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${storePath}.fixed`)} && chmod 600 ${shellQuote(`${storePath}.fixed`)}`
 				: "Credential store is damaged; persisted rate-limit blocks are disabled for this process. " +
 						"Repair the store file with sqlite3's .recover and restart.",
 			{ err, op, storePath, ...context },
@@ -7048,7 +7049,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	static #damagedStoreError(dbPath: string | undefined, cause: unknown): Error {
 		return new Error(
 			dbPath
-				? `Credential store at '${dbPath}' is damaged. Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 '${dbPath}' '.recover --ignore-freelist' | sqlite3 '${dbPath}.fixed' && chmod 600 '${dbPath}.fixed'`
+				? `Credential store at ${shellQuote(dbPath)} is damaged. Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${dbPath}.fixed`)} && chmod 600 ${shellQuote(`${dbPath}.fixed`)}`
 				: "Credential store is damaged. Repair the store file with sqlite3's .recover and restart.",
 			{ cause },
 		);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1717,11 +1717,12 @@ export class AuthStorage {
 		logger.error(
 			storePath
 				? `Credential store is damaged; persisted rate-limit blocks are disabled for this process. ` +
-						`Repair with: sqlite3 '${storePath}' '.recover' | sqlite3 '${storePath}.fixed'`
+						`Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 '${storePath}' '.recover --ignore-freelist' | sqlite3 '${storePath}.fixed' && chmod 600 '${storePath}.fixed'`
 				: "Credential store is damaged; persisted rate-limit blocks are disabled for this process. " +
 						"Repair the store file with sqlite3's .recover and restart.",
 			{ err, op, storePath, ...context },
 		);
+		this.#bumpGeneration("store-damaged");
 		return true;
 	}
 
@@ -5899,18 +5900,19 @@ export class AuthStorage {
 		const scopedBackoffKey = this.#toScopedBackoffKey(providerKey, blockScope);
 		const globalProbeAfterMs = this.#credentialBackoffProbeAfter.get(providerKey)?.get(credentialIndex) ?? 0;
 		const scopedProbeAfterMs = this.#credentialBackoffProbeAfter.get(scopedBackoffKey)?.get(credentialIndex) ?? 0;
-		if (this.#storeDamaged) return;
-		const getStoreReconcileAfter = this.#store.getCredentialBlockReconcileAfter?.bind(this.#store);
 		let storeGlobalProbeAfterMs = 0;
 		let storeScopedProbeAfterMs = 0;
-		try {
-			storeGlobalProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, "") ?? 0;
-			storeScopedProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, blockScope ?? "") ?? 0;
-		} catch (err) {
-			if (this.#latchStoreDamage(err, "getCredentialBlockReconcileAfter", { credentialId, providerKey })) {
-				return;
+		if (!this.#storeDamaged) {
+			const getStoreReconcileAfter = this.#store.getCredentialBlockReconcileAfter?.bind(this.#store);
+			try {
+				storeGlobalProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, "") ?? 0;
+				storeScopedProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, blockScope ?? "") ?? 0;
+			} catch (err) {
+				if (this.#latchStoreDamage(err, "getCredentialBlockReconcileAfter", { credentialId, providerKey })) {
+					return;
+				}
+				throw err;
 			}
-			throw err;
 		}
 		if (Math.max(globalProbeAfterMs, scopedProbeAfterMs, storeGlobalProbeAfterMs, storeScopedProbeAfterMs) > nowMs) {
 			return;
@@ -6846,9 +6848,19 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#localAuthRevision: number;
 	#closed = false;
 
-	constructor(db: Database, readonly databasePath?: string) {
+	constructor(
+		db: Database,
+		readonly databasePath?: string,
+	) {
 		this.#db = db;
-		this.#initializeSchema();
+		try {
+			this.#initializeSchema();
+		} catch (err) {
+			if (isSqliteCorruptError(err)) {
+				throw SqliteAuthCredentialStore.#damagedStoreError(this.databasePath, err);
+			}
+			throw err;
+		}
 		this.#dataVersion = this.#readDataVersion();
 		this.#authRevision = this.#readAuthRevision();
 		this.#localAuthRevision = this.#readLocalAuthRevision();
@@ -7003,6 +7015,9 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 				return new SqliteAuthCredentialStore(db, dbPath);
 			} catch (err) {
 				db?.close();
+				if (isSqliteCorruptError(err)) {
+					throw SqliteAuthCredentialStore.#damagedStoreError(dbPath, err);
+				}
 				if (!isSqliteBusyError(err)) {
 					throw err;
 				}
@@ -7028,6 +7043,15 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			);
 			CREATE INDEX IF NOT EXISTS idx_auth_credential_refresh_leases_expires ON auth_credential_refresh_leases(expires_at_ms);
 		`);
+	}
+
+	static #damagedStoreError(dbPath: string | undefined, cause: unknown): Error {
+		return new Error(
+			dbPath
+				? `Credential store at '${dbPath}' is damaged. Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 '${dbPath}' '.recover --ignore-freelist' | sqlite3 '${dbPath}.fixed' && chmod 600 '${dbPath}.fixed'`
+				: "Credential store is damaged. Repair the store file with sqlite3's .recover and restart.",
+			{ cause },
+		);
 	}
 
 	#initializeSchema(): void {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -14,7 +14,7 @@ import * as path from "node:path";
 import { parseAlibabaTokenPlanCredential } from "@oh-my-pi/pi-catalog/wire/alibaba-token-plan";
 import { $env, getAgentDbPath, logger } from "@oh-my-pi/pi-utils";
 import { shellQuote } from "@oh-my-pi/pi-utils/shell";
-import { configureSqliteDatabase, isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
+import { configureSqliteDatabase, isSqliteCorruptError, sqliteRepairGuidance } from "@oh-my-pi/pi-utils/sqlite";
 import type { ApiKeyResolver } from "./auth-retry";
 import * as AIError from "./error";
 import { isUsageLimitOutcome } from "./error/rate-limit";
@@ -1718,9 +1718,9 @@ export class AuthStorage {
 		logger.error(
 			storePath
 				? `Credential store is damaged; persisted rate-limit blocks are disabled for this process. ` +
-						`Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 ${shellQuote(storePath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${storePath}.fixed`)} && chmod 600 ${shellQuote(`${storePath}.fixed`)}`
+						sqliteRepairGuidance(storePath, { restrictPermissions: true })
 				: "Credential store is damaged; persisted rate-limit blocks are disabled for this process. " +
-						"Repair the store file with sqlite3's .recover and restart.",
+						sqliteRepairGuidance(undefined),
 			{ err, op, storePath, ...context },
 		);
 		this.#bumpGeneration("store-damaged");
@@ -7049,8 +7049,8 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	static #damagedStoreError(dbPath: string | undefined, cause: unknown): Error {
 		return new Error(
 			dbPath
-				? `Credential store at ${shellQuote(dbPath)} is damaged. Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${dbPath}.fixed`)} && chmod 600 ${shellQuote(`${dbPath}.fixed`)}`
-				: "Credential store is damaged. Repair the store file with sqlite3's .recover and restart.",
+				? `Credential store at ${shellQuote(dbPath)} is damaged. ${sqliteRepairGuidance(dbPath, { restrictPermissions: true })}`
+				: `Credential store is damaged. ${sqliteRepairGuidance(undefined)}`,
 			{ cause },
 		);
 	}

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -14,7 +14,6 @@ import * as path from "node:path";
 import { parseAlibabaTokenPlanCredential } from "@oh-my-pi/pi-catalog/wire/alibaba-token-plan";
 import { $env, getAgentDbPath, logger } from "@oh-my-pi/pi-utils";
 import { shellQuote } from "@oh-my-pi/pi-utils/shell";
-import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import { configureSqliteDatabase, isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import type { ApiKeyResolver } from "./auth-retry";
 import * as AIError from "./error";

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -13,6 +13,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { parseAlibabaTokenPlanCredential } from "@oh-my-pi/pi-catalog/wire/alibaba-token-plan";
 import { $env, getAgentDbPath, logger } from "@oh-my-pi/pi-utils";
+import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import type { ApiKeyResolver } from "./auth-retry";
 import * as AIError from "./error";
 import { isUsageLimitOutcome } from "./error/rate-limit";
@@ -375,6 +376,8 @@ export interface CredentialRefreshLeaseFence {
 
 export interface AuthCredentialStore {
 	close(): void;
+	/** Filesystem path of the backing SQLite file when the store is file-backed; used in operator-facing repair guidance. */
+	readonly databasePath?: string;
 	/**
 	 * Stateful probe for commits made by another process to the backing store.
 	 * Returns true once per observed change.
@@ -1264,6 +1267,8 @@ export class AuthStorage {
 	#credentialBackoff: Map<string, Map<number, number>> = new Map();
 	/** Earliest time a freshly-set in-memory block may be cleared by live usage reconciliation. */
 	#credentialBackoffProbeAfter: Map<string, Map<number, number>> = new Map();
+	/** Latched once the persistent store reports damage; persisted blocks are skipped for the rest of this process. */
+	#storeDamaged = false;
 	#usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
 	#rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
 	#usageCache: UsageCache;
@@ -1696,16 +1701,44 @@ export class AuthStorage {
 		return blockedUntil;
 	}
 
+	/**
+	 * Latch off the persisted block table after unrecoverable store damage.
+	 * Returns true when the error is corruption — the caller then fails open.
+	 * The first damaged operation logs once at error level with repair
+	 * guidance; every later block-table operation short-circuits silently,
+	 * since nothing in the process can repair the file and a retry only
+	 * re-fails.
+	 */
+	#latchStoreDamage(err: unknown, op: string, context: Record<string, unknown>): boolean {
+		if (!isSqliteCorruptError(err)) return false;
+		if (this.#storeDamaged) return true;
+		this.#storeDamaged = true;
+		const storePath = this.#store.databasePath;
+		logger.error(
+			storePath
+				? `Credential store is damaged; persisted rate-limit blocks are disabled for this process. ` +
+						`Repair with: sqlite3 '${storePath}' '.recover' | sqlite3 '${storePath}.fixed'`
+				: "Credential store is damaged; persisted rate-limit blocks are disabled for this process. " +
+						"Repair the store file with sqlite3's .recover and restart.",
+			{ err, op, storePath, ...context },
+		);
+		return true;
+	}
+
 	#readPersistedCredentialBlock(
 		credentialId: number,
 		providerKey: string,
 		blockScope: string | undefined,
 	): number | undefined {
+		if (this.#storeDamaged) return undefined;
 		const getCredentialBlock = this.#store.getCredentialBlock?.bind(this.#store);
 		if (!getCredentialBlock) return undefined;
 		try {
 			return getCredentialBlock(credentialId, providerKey, blockScope ?? "");
 		} catch (err) {
+			if (this.#latchStoreDamage(err, "getCredentialBlock", { credentialId, providerKey, blockScope })) {
+				return undefined;
+			}
 			logger.debug("Failed to read credential block from persistent store", {
 				err,
 				credentialId,
@@ -1791,6 +1824,7 @@ export class AuthStorage {
 		this.#credentialBackoffProbeAfter.set(backoffKey, probeAfterMap);
 		this.#invalidateUsageReportCache(provider);
 
+		if (this.#storeDamaged) return;
 		const upsertCredentialBlock = this.#store.upsertCredentialBlock?.bind(this.#store);
 		if (!upsertCredentialBlock) return;
 		const credentialId = this.#getStoredCredentials(provider)[credentialIndex]?.id;
@@ -1803,6 +1837,9 @@ export class AuthStorage {
 				blockedUntilMs: nextBlockedUntil,
 			});
 		} catch (err) {
+			if (this.#latchStoreDamage(err, "upsertCredentialBlock", { credentialId, providerKey, blockScope })) {
+				return;
+			}
 			logger.debug("Failed to persist credential block", {
 				err,
 				credentialId,
@@ -5862,9 +5899,19 @@ export class AuthStorage {
 		const scopedBackoffKey = this.#toScopedBackoffKey(providerKey, blockScope);
 		const globalProbeAfterMs = this.#credentialBackoffProbeAfter.get(providerKey)?.get(credentialIndex) ?? 0;
 		const scopedProbeAfterMs = this.#credentialBackoffProbeAfter.get(scopedBackoffKey)?.get(credentialIndex) ?? 0;
+		if (this.#storeDamaged) return;
 		const getStoreReconcileAfter = this.#store.getCredentialBlockReconcileAfter?.bind(this.#store);
-		const storeGlobalProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, "") ?? 0;
-		const storeScopedProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, blockScope ?? "") ?? 0;
+		let storeGlobalProbeAfterMs = 0;
+		let storeScopedProbeAfterMs = 0;
+		try {
+			storeGlobalProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, "") ?? 0;
+			storeScopedProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, blockScope ?? "") ?? 0;
+		} catch (err) {
+			if (this.#latchStoreDamage(err, "getCredentialBlockReconcileAfter", { credentialId, providerKey })) {
+				return;
+			}
+			throw err;
+		}
 		if (Math.max(globalProbeAfterMs, scopedProbeAfterMs, storeGlobalProbeAfterMs, storeScopedProbeAfterMs) > nowMs) {
 			return;
 		}
@@ -6340,16 +6387,35 @@ export class AuthStorage {
 	 * Broker-server seam: list non-expired persisted blocks for snapshot entries.
 	 */
 	listCredentialBlocks(credentialIds: readonly number[]): StoredCredentialBlock[] {
-		return this.#store.listCredentialBlocks?.(credentialIds) ?? [];
+		if (this.#storeDamaged) return [];
+		try {
+			return this.#store.listCredentialBlocks?.(credentialIds) ?? [];
+		} catch (err) {
+			if (this.#latchStoreDamage(err, "listCredentialBlocks", {})) return [];
+			throw err;
+		}
 	}
 
 	/**
 	 * Broker-server seam: persist one credential block and notify snapshot waiters.
 	 */
 	upsertCredentialBlock(block: StoredCredentialBlock): void {
+		if (this.#storeDamaged) return;
 		const upsertCredentialBlock = this.#store.upsertCredentialBlock?.bind(this.#store);
 		if (!upsertCredentialBlock) return;
-		upsertCredentialBlock(block);
+		try {
+			upsertCredentialBlock(block);
+		} catch (err) {
+			if (
+				this.#latchStoreDamage(err, "upsertCredentialBlock", {
+					credentialId: block.credentialId,
+					providerKey: block.providerKey,
+				})
+			) {
+				return;
+			}
+			throw err;
+		}
 		this.#invalidateUsageReportCacheForProviderKey(block.providerKey);
 		this.#bumpGeneration("credential-block");
 	}
@@ -6358,17 +6424,31 @@ export class AuthStorage {
 	 * Broker-server seam: clear all persisted blocks for one credential and notify snapshot waiters.
 	 */
 	deleteCredentialBlock(credentialId: number, providerKey: string, blockScope: string): void {
+		if (this.#storeDamaged) return;
 		const deleteCredentialBlock = this.#store.deleteCredentialBlock?.bind(this.#store);
 		if (!deleteCredentialBlock) return;
-		deleteCredentialBlock(credentialId, providerKey, blockScope);
+		try {
+			deleteCredentialBlock(credentialId, providerKey, blockScope);
+		} catch (err) {
+			if (this.#latchStoreDamage(err, "deleteCredentialBlock", { credentialId, providerKey, blockScope })) {
+				return;
+			}
+			throw err;
+		}
 		this.#invalidateUsageReportCacheForProviderKey(providerKey);
 		this.#bumpGeneration("credential-block");
 	}
 
 	deleteCredentialBlocks(credentialId: number): void {
+		if (this.#storeDamaged) return;
 		const deleteCredentialBlocks = this.#store.deleteCredentialBlocks?.bind(this.#store);
 		if (!deleteCredentialBlocks) return;
-		deleteCredentialBlocks(credentialId);
+		try {
+			deleteCredentialBlocks(credentialId);
+		} catch (err) {
+			if (this.#latchStoreDamage(err, "deleteCredentialBlocks", { credentialId })) return;
+			throw err;
+		}
 		this.#bumpGeneration("credential-block");
 	}
 
@@ -6766,7 +6846,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#localAuthRevision: number;
 	#closed = false;
 
-	constructor(db: Database) {
+	constructor(db: Database, readonly databasePath?: string) {
 		this.#db = db;
 		this.#initializeSchema();
 		this.#dataVersion = this.#readDataVersion();
@@ -6920,7 +7000,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 					// Ignore chmod failures (e.g., Windows)
 				}
 				SqliteAuthCredentialStore.#ensureAuthCredentialRefreshLeasesTable(db);
-				return new SqliteAuthCredentialStore(db);
+				return new SqliteAuthCredentialStore(db, dbPath);
 			} catch (err) {
 				db?.close();
 				if (!isSqliteBusyError(err)) {

--- a/packages/ai/test/auth-broker-wire.test.ts
+++ b/packages/ai/test/auth-broker-wire.test.ts
@@ -43,6 +43,23 @@ function fetchWithoutAuthBrokerCapabilities(): typeof fetch {
 	);
 }
 
+/**
+ * Make block reads fail the way a malformed store does: a real `SQLITE_NOTADB`
+ * raised by SQLite itself, so the latch classifier sees a genuine error code.
+ */
+async function damageCredentialBlockReads(store: SqliteAuthCredentialStore, malformedPath: string): Promise<void> {
+	await fs.writeFile(malformedPath, "not sqlite");
+	vi.spyOn(store, "listCredentialBlocks").mockImplementation(() => {
+		const damaged = new Database(malformedPath);
+		try {
+			damaged.run("PRAGMA integrity_check");
+			throw new Error("expected the malformed database to reject reads");
+		} finally {
+			damaged.close();
+		}
+	});
+}
+
 function credentialBlocks(snapshot: SnapshotResponse, credentialId: number) {
 	return snapshot.credentials.find(entry => entry.id === credentialId)?.blocks ?? [];
 }
@@ -125,6 +142,15 @@ describe("auth-broker wire surface", () => {
 			// Refresh token is replaced with the wire sentinel — clients never see it.
 			expect(entry.credential.refresh).toBe(REMOTE_REFRESH_SENTINEL);
 		}
+	});
+
+	test("damaged snapshot storage returns an error and the broker remains available", async () => {
+		await damageCredentialBlockReads(store!, path.join(tempDir, "malformed.db"));
+		const snapshot = await fetch(`${handle!.url}/v1/snapshot`, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		expect(snapshot.status).toBe(500);
+		expect(await (await fetch(`${handle!.url}/v1/healthz`)).json()).toEqual({ ok: true });
 	});
 
 	test("preserves an HTTP rejection when the caller aborts while reading its body", async () => {
@@ -594,6 +620,18 @@ describe("auth-broker wire surface", () => {
 			controller.abort();
 			await iter.return(undefined).catch(() => {});
 		}
+	});
+
+	test("damaged SSE snapshots close without emitting a blockless snapshot", async () => {
+		await damageCredentialBlockReads(store!, path.join(tempDir, "malformed-stream.db"));
+		const response = await fetch(`${handle!.url}/v1/snapshot/stream`, {
+			headers: { Authorization: `Bearer ${token}`, Accept: "text/event-stream" },
+		});
+		expect(response.status).toBe(200);
+		const body = await response.text();
+		expect(body).not.toContain("event: snapshot");
+		expect(body).not.toContain("event: entry");
+		expect(await (await fetch(`${handle!.url}/v1/healthz`)).json()).toEqual({ ok: true });
 	});
 
 	test("SSE stream projects Codex meter blocks only for clients without the capability", async () => {

--- a/packages/ai/test/auth-storage-corrupt-store.test.ts
+++ b/packages/ai/test/auth-storage-corrupt-store.test.ts
@@ -23,6 +23,7 @@ import * as path from "node:path";
 import { AuthStorage, type OAuthCredential, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
 import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import { logger } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import { removeWithRetries } from "../../utils/src/temp";
 
@@ -285,6 +286,147 @@ describe("AuthStorage corrupt-store generation notification", () => {
 	});
 });
 
+describe("AuthStorage corrupt-store shell-balanced repair guidance", () => {
+	let tempDir = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-shell-"));
+		// Use a path containing a single quote to exercise shell quoting.
+		const quoteDir = path.join(tempDir, "omp's agent");
+		await fs.mkdir(quoteDir, { recursive: true });
+		const dbPath = path.join(quoteDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		store.saveOAuth(PROVIDER, oauthCredential("1"));
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("F2: latch message emits a shell-balanced repair command for a quote-containing path", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		await storage.getApiKey(PROVIDER, "session-shell-1");
+
+		const damagedCall = errorSpy.mock.calls.find(
+			call => typeof call[0] === "string" && call[0].includes("Credential store is damaged"),
+		);
+		expect(damagedCall).toBeDefined();
+		const message = String(damagedCall?.[0]);
+		expect(message).toContain("--ignore-freelist");
+		expect(message).toContain("chmod 600");
+		// The repair command must be shell-balanced: every unescaped single
+		// quote toggles open/close state, so the string ends closed.
+		let open = false;
+		for (let i = 0; i < message.length; i++) {
+			if (message[i] === "'" && message[i - 1] !== "\\") open = !open;
+		}
+		expect(open).toBe(false);
+	});
+
+	test("F2: damagedStoreError emits a shell-balanced repair command for a quote-containing path", async () => {
+		const quoteDir = path.join(tempDir, "omp's agent");
+		const dbPath = path.join(quoteDir, "agent.db");
+		// Force the static error helper through the open() path by corrupting
+		// the file after the store was successfully opened in beforeEach.
+		store.close();
+		await fs.writeFile(dbPath, "this is not a sqlite database");
+
+		expect(SqliteAuthCredentialStore.open(dbPath)).rejects.toThrow();
+		try {
+			await SqliteAuthCredentialStore.open(dbPath);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			expect(message).toContain(".recover --ignore-freelist");
+			expect(message).toContain(shellQuote(dbPath));
+			// Shell-balanced check.
+			let open = false;
+			for (let i = 0; i < message.length; i++) {
+				if (message[i] === "'" && message[i - 1] !== "\\") open = !open;
+			}
+			expect(open).toBe(false);
+		}
+	});
+});
+
+describe("AuthStorage corrupt-store bump skips acknowledge when latched", () => {
+	let tempDir = "";
+	let dbPath = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-ack-"));
+		dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		store.saveOAuth(PROVIDER, oauthCredential("1"));
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("F3: latch bump does not call acknowledgeLocalChanges but listeners still fire", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+		const ackSpy = vi.spyOn(store, "acknowledgeLocalChanges");
+
+		const generations: number[] = [];
+		storage.onGenerationChanged(gen => generations.push(gen));
+		const generationBefore = storage.getGeneration();
+
+		// Trigger the latch: getCredentialBlock throws SQLITE_NOTADB → latch → bump.
+		await storage.getApiKey(PROVIDER, "session-ack-1");
+
+		// Mutation proof: acknowledgeLocalChanges must NOT have been called on
+		// the latch bump — the store is damaged and acknowledging is meaningless.
+		expect(ackSpy).not.toHaveBeenCalled();
+		// The generation listener still fired despite the skipped acknowledge.
+		expect(generations).toHaveLength(1);
+		expect(generations[0]).toBe(generationBefore + 1);
+	});
+
+	test("F3: a healthy bump still calls acknowledgeLocalChanges", async () => {
+		const ackSpy = vi.spyOn(store, "acknowledgeLocalChanges");
+
+		const generations: number[] = [];
+		storage.onGenerationChanged(gen => generations.push(gen));
+		const generationBefore = storage.getGeneration();
+
+		// A normal credential save + reload triggers a healthy bump (no latch).
+		store.saveApiKey(PROVIDER, "sk-healthy-bump-test");
+		await storage.reload();
+
+		expect(ackSpy).toHaveBeenCalled();
+		expect(generations).toHaveLength(1);
+		expect(generations[0]).toBe(generationBefore + 1);
+	});
+});
 describe("AuthStorage corrupt-store heal while latched", () => {
 	let tempDir = "";
 	let dbPath = "";

--- a/packages/ai/test/auth-storage-corrupt-store.test.ts
+++ b/packages/ai/test/auth-storage-corrupt-store.test.ts
@@ -238,7 +238,9 @@ describe("AuthStorage corrupt-store reporting", () => {
 		// The repair guidance must point at the actual store file, not a
 		// hardcoded default path (profiles relocate agent.db).
 		expect(String(damagedErrors[0]?.[0])).toContain(dbPath);
-		expect(String(damagedErrors[0]?.[0])).toContain(sqliteRepairGuidance(dbPath, { restrictPermissions: true }));
+		expect(String(damagedErrors[0]?.[0])).toContain(
+			sqliteRepairGuidance(dbPath, { platform: "linux", restrictPermissions: true }),
+		);
 
 		const swallowDebugs = debugSpy.mock.calls.filter(
 			call => typeof call[0] === "string" && call[0] === "Failed to read credential block from persistent store",
@@ -337,7 +339,7 @@ describe("AuthStorage corrupt-store shell-balanced repair guidance", () => {
 		const message = String(damagedCall?.[0]);
 		expect(message).toContain("--ignore-freelist");
 		const expectedDbPath = path.join(tempDir, "omp's agent", "agent.db");
-		expect(message).toContain(sqliteRepairGuidance(expectedDbPath, { restrictPermissions: true }));
+		expect(message).toContain(sqliteRepairGuidance(expectedDbPath, { platform: "linux", restrictPermissions: true }));
 		// The repair command must be shell-balanced: every unescaped single
 		// quote toggles open/close state, so the string ends closed.
 		let open = false;
@@ -360,7 +362,7 @@ describe("AuthStorage corrupt-store shell-balanced repair guidance", () => {
 			await SqliteAuthCredentialStore.open(dbPath);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
-			expect(message).toContain(sqliteRepairGuidance(dbPath, { restrictPermissions: true }));
+			expect(message).toContain(sqliteRepairGuidance(dbPath, { platform: "linux", restrictPermissions: true }));
 			// Shell-balanced check.
 			let open = false;
 			for (let i = 0; i < message.length; i++) {

--- a/packages/ai/test/auth-storage-corrupt-store.test.ts
+++ b/packages/ai/test/auth-storage-corrupt-store.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Regression coverage for the corrupt-credential-store latch.
+ *
+ * `~/.omp/agent/agent.db` can fail `PRAGMA integrity_check` (e.g. "Rowid out of
+ * order"). Before the latch, `AuthStorage.#readPersistedCredentialBlock` swallowed
+ * every store error at `debug` and returned `undefined`, which its caller read as
+ * "this credential is not blocked." A damaged store therefore silently switched
+ * off every persisted rate-limit block — one session logged that swallow 546 times
+ * for a single credential while a continuous stream of 429s poured in.
+ *
+ * The fix latches the store as damaged on the first unrecoverable (SQLITE_CORRUPT
+ * family / SQLITE_NOTADB) error, reports it once at `error` level with a repair
+ * one-liner, and short-circuits every later persisted-block query for the life of
+ * the process. Fail-open is preserved: the in-memory backoff map still carries
+ * within-process rate-limit state, so only cross-process persistence is lost.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage, type OAuthCredential, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import { logger } from "@oh-my-pi/pi-utils";
+import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
+import { removeWithRetries } from "../../utils/src/temp";
+
+const PROVIDER = "anthropic";
+
+interface SqliteCorruptShape extends Error {
+	code: string;
+	errno: number;
+}
+
+function makeCorruptError(code: string, errno: number): SqliteCorruptShape {
+	const err = new Error("database disk image is malformed") as SqliteCorruptShape;
+	err.code = code;
+	err.errno = errno;
+	return err;
+}
+
+function oauthCredential(suffix: string): OAuthCredential {
+	return {
+		type: "oauth",
+		access: `access-${suffix}`,
+		refresh: `refresh-${suffix}`,
+		expires: Date.now() + 3_600_000,
+		accountId: `account-${suffix}`,
+		email: `${suffix}@example.com`,
+	};
+}
+
+/**
+ * Writes a deterministic malformed SQLite source — bytes that are not a valid
+ * SQLite database — and returns the path. Opening this with `new Database(path)`
+ * and running a query makes bun:sqlite throw a real `SQLiteError` carrying
+ * `code: "SQLITE_NOTADB"` (errno 26), the same family the latch classifies.
+ */
+async function writeMalformedDb(dir: string): Promise<string> {
+	const dbPath = path.join(dir, "malformed.db");
+	await fs.writeFile(dbPath, "this is not a sqlite database");
+	return dbPath;
+}
+
+/** The real error bun:sqlite throws when a query hits a malformed database file. */
+function realCorruptError(malformedDbPath: string): Error {
+	const db = new Database(malformedDbPath);
+	try {
+		db.run("PRAGMA integrity_check");
+	} catch (err) {
+		return err as Error;
+	} finally {
+		db.close();
+	}
+	// Unreachable: the query above always throws on a malformed file.
+	throw new Error("expected SQLITE_NOTADB from malformed database");
+}
+
+describe("isSqliteCorruptError", () => {
+	test("recognizes the CORRUPT family and NOTADB", () => {
+		expect(isSqliteCorruptError(makeCorruptError("SQLITE_CORRUPT", 11))).toBe(true);
+		expect(isSqliteCorruptError(makeCorruptError("SQLITE_CORRUPT_VTAB", 267))).toBe(true);
+		expect(isSqliteCorruptError(makeCorruptError("SQLITE_NOTADB", 26))).toBe(true);
+	});
+
+	test("rejects non-corrupt codes and non-error values", () => {
+		expect(isSqliteCorruptError(makeCorruptError("SQLITE_BUSY", 5))).toBe(false);
+		expect(isSqliteCorruptError(new Error("plain"))).toBe(false);
+		expect(isSqliteCorruptError(null)).toBe(false);
+		// A bare string is not an object, so it must not match even if it looks like a code.
+		expect(isSqliteCorruptError("SQLITE_CORRUPT")).toBe(false);
+	});
+
+	test("classifies the real error bun:sqlite throws on a malformed database file", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-real-"));
+		try {
+			const malformedDbPath = await writeMalformedDb(tempDir);
+			const err = realCorruptError(malformedDbPath);
+			// Bun 1.3.14 throws SQLiteError with code SQLITE_NOTADB.
+			expect((err as { code?: unknown }).code).toBe("SQLITE_NOTADB");
+			expect(isSqliteCorruptError(err)).toBe(true);
+		} finally {
+			await removeWithRetries(tempDir);
+		}
+	});
+});
+
+describe("AuthStorage corrupt-store latch", () => {
+	let tempDir = "";
+	let dbPath = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-latch-"));
+		dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		store.saveOAuth(PROVIDER, oauthCredential("1"));
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("latches after one corrupt read and stops re-querying the store", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		// The spy opens the malformed file and runs a real query so SQLite
+		// itself throws SQLITE_NOTADB — the same error shape production sees
+		// when agent.db is damaged — rather than a synthetic error object.
+		const spy = vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+
+		// Drive the credential-selection path twice. The first call hits the
+		// store, throws SQLITE_NOTADB, and latches #storeDamaged; the second
+		// call (and every later read in the same getApiKey) short-circuits
+		// before touching SQLite. Before the fix this re-queried on every
+		// credential evaluation — 546 times for one credential in production.
+		const key1 = await storage.getApiKey(PROVIDER, "session-latch-1");
+		const key2 = await storage.getApiKey(PROVIDER, "session-latch-1");
+
+		// The spy fired exactly once across both calls: the latch stops the repeat.
+		expect(spy).toHaveBeenCalledTimes(1);
+		// Fail-open is preserved: selection still returns a usable key.
+		expect(key1).toBe("access-1");
+		expect(key2).toBe("access-1");
+	});
+
+	test("latches the write path: one corrupt upsert stops all later block-table writes", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		const spy = vi.spyOn(store, "upsertCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		const generationBefore = storage.getGeneration();
+		const block = {
+			credentialId: 1,
+			providerKey: "anthropic:oauth",
+			blockScope: "",
+			blockedUntilMs: Date.now() + 60_000,
+		};
+
+		storage.upsertCredentialBlock(block);
+		storage.upsertCredentialBlock(block);
+
+		// The first corrupt write latches; the second call short-circuits
+		// before touching SQLite, and the invalidation/generation side effects
+		// are skipped — a latched write is a true no-op, not a swallowed error.
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(storage.getGeneration()).toBe(generationBefore);
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Credential store is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+	});
+});
+
+describe("AuthStorage corrupt-store reporting", () => {
+	let tempDir = "";
+	let dbPath = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-report-"));
+		dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		store.saveOAuth(PROVIDER, oauthCredential("1"));
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("emits exactly one logger.error and no swallow-debug for the corrupt read", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+
+		await storage.getApiKey(PROVIDER, "session-report-1");
+		await storage.getApiKey(PROVIDER, "session-report-1");
+
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Credential store is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+		// The repair guidance must point at the actual store file, not a
+		// hardcoded default path (profiles relocate agent.db).
+		expect(String(damagedErrors[0]?.[0])).toContain(dbPath);
+
+		const swallowDebugs = debugSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0] === "Failed to read credential block from persistent store",
+		);
+		expect(swallowDebugs).toHaveLength(0);
+	});
+});

--- a/packages/ai/test/auth-storage-corrupt-store.test.ts
+++ b/packages/ai/test/auth-storage-corrupt-store.test.ts
@@ -21,6 +21,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { AuthStorage, type OAuthCredential, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import { logger } from "@oh-my-pi/pi-utils";
 import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import { removeWithRetries } from "../../utils/src/temp";
@@ -171,11 +172,11 @@ describe("AuthStorage corrupt-store latch", () => {
 		storage.upsertCredentialBlock(block);
 		storage.upsertCredentialBlock(block);
 
-		// The first corrupt write latches; the second call short-circuits
-		// before touching SQLite, and the invalidation/generation side effects
-		// are skipped — a latched write is a true no-op, not a swallowed error.
+		// The first corrupt write latches and bumps generation (F3: latch
+		// notifies snapshot consumers); the second call short-circuits before
+		// touching SQLite with no further generation side effect.
 		expect(spy).toHaveBeenCalledTimes(1);
-		expect(storage.getGeneration()).toBe(generationBefore);
+		expect(storage.getGeneration()).toBe(generationBefore + 1);
 		const damagedErrors = errorSpy.mock.calls.filter(
 			call => typeof call[0] === "string" && call[0].includes("Credential store is damaged"),
 		);
@@ -226,10 +227,247 @@ describe("AuthStorage corrupt-store reporting", () => {
 		// The repair guidance must point at the actual store file, not a
 		// hardcoded default path (profiles relocate agent.db).
 		expect(String(damagedErrors[0]?.[0])).toContain(dbPath);
+		// F2: repair guidance must preserve credential-file permissions.
+		expect(String(damagedErrors[0]?.[0])).toContain("chmod 600");
+		expect(String(damagedErrors[0]?.[0])).toContain("--ignore-freelist");
 
 		const swallowDebugs = debugSpy.mock.calls.filter(
 			call => typeof call[0] === "string" && call[0] === "Failed to read credential block from persistent store",
 		);
 		expect(swallowDebugs).toHaveLength(0);
+	});
+});
+
+describe("AuthStorage corrupt-store generation notification", () => {
+	let tempDir = "";
+	let dbPath = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-gen-"));
+		dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		store.saveOAuth(PROVIDER, oauthCredential("1"));
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("F3: onGenerationChanged fires exactly once on the first corrupt error and not on the second", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "getCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		const generations: number[] = [];
+		storage.onGenerationChanged(gen => generations.push(gen));
+		const generationBefore = storage.getGeneration();
+
+		// First call: hits the store, throws SQLITE_NOTADB, latches, bumps generation.
+		await storage.getApiKey(PROVIDER, "session-gen-1");
+		// Second call: store is already latched, short-circuits before touching SQLite.
+		await storage.getApiKey(PROVIDER, "session-gen-1");
+
+		// F3: the generation listener fires exactly once — only on the first latch.
+		expect(generations).toHaveLength(1);
+		expect(generations[0]).toBe(generationBefore + 1);
+	});
+});
+
+describe("AuthStorage corrupt-store heal while latched", () => {
+	let tempDir = "";
+	let dbPath = "";
+	let store: SqliteAuthCredentialStore;
+	let storage: AuthStorage;
+
+	const HOUR_MS = 60 * 60 * 1000;
+	const WEEK_MS = 7 * 24 * HOUR_MS;
+
+	function codexLimit(key: "primary" | "secondary", usedFraction: number): UsageLimit {
+		const windowId = key === "primary" ? "1h" : "7d";
+		const windowLabel = key === "primary" ? "1 Hour" : "7 Day";
+		const durationMs = key === "primary" ? HOUR_MS : WEEK_MS;
+		return {
+			id: `openai-codex:${key}`,
+			label: windowLabel,
+			scope: { provider: "openai-codex", windowId, shared: true },
+			window: {
+				id: windowId,
+				label: windowLabel,
+				durationMs,
+				resetsAt: Date.now() + durationMs,
+			},
+			amount: {
+				unit: "percent",
+				used: usedFraction * 100,
+				limit: 100,
+				remaining: (1 - usedFraction) * 100,
+				usedFraction,
+				remainingFraction: 1 - usedFraction,
+			},
+			status: usedFraction >= 1 ? "exhausted" : "ok",
+		};
+	}
+
+	function codexReport(
+		accountId: string,
+		email: string,
+		primaryUsed: number,
+		secondaryUsed: number,
+		healthy: boolean,
+	): UsageReport {
+		return {
+			provider: "openai-codex",
+			fetchedAt: Date.now(),
+			limits: [codexLimit("primary", primaryUsed), codexLimit("secondary", secondaryUsed)],
+			metadata: {
+				accountId,
+				email,
+				allowed: healthy,
+				limitReached: !healthy,
+				planType: "pro",
+			},
+		};
+	}
+
+	function codexCredential(accountId: string, email: string): OAuthCredential {
+		return {
+			type: "oauth",
+			access: `access-${accountId}`,
+			refresh: `refresh-${accountId}`,
+			expires: Date.now() + WEEK_MS,
+			accountId,
+			email,
+		};
+	}
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-heal-"));
+		dbPath = path.join(tempDir, "agent.db");
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		storage = new AuthStorage(store);
+		await storage.reload();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		storage.close();
+		store.close();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("F1: healthy usage report clears in-memory Codex block while store is latched", async () => {
+		const usageByAccount = new Map<string, UsageReport | null>();
+		const usageProvider: UsageProvider = {
+			id: "openai-codex",
+			async fetchUsage(params) {
+				const accountId = params.credential.accountId;
+				if (!accountId) return null;
+				return usageByAccount.get(accountId) ?? null;
+			},
+		};
+
+		// Re-create storage with the usage provider so fetchUsageReports can fan out.
+		storage.close();
+		store.close();
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		storage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "openai-codex" ? usageProvider : undefined),
+		});
+
+		await storage.set("openai-codex", [
+			codexCredential("acct-blocked", "blocked@example.com"),
+			codexCredential("acct-sibling", "sibling@example.com"),
+		]);
+
+		const blockedRow = store.listAuthCredentials("openai-codex").find(row => {
+			const credential = row.credential;
+			return credential.type === "oauth" && credential.accountId === "acct-blocked";
+		});
+		if (!blockedRow) throw new Error("expected blocked credential row");
+
+		// Start with no usage reports — markUsageLimitReached will use retryAfterMs.
+		const base = Date.now();
+		let clockOffset = 0;
+		vi.spyOn(Date, "now").mockImplementation(() => base + clockOffset);
+
+		// Block the credential in-memory with a 1-hour backoff.
+		// With no usage report, blockedUntil = now + retryAfterMs.
+		// probeAfter = min(blockedUntil, now + 5min TTL) = now + 5min.
+		await storage.markUsageLimitReached("openai-codex", "heal-session", {
+			credentialId: blockedRow.id,
+			retryAfterMs: HOUR_MS,
+		});
+
+		// Latch the store via a corrupt upsert (existing pattern).
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "upsertCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+		storage.upsertCredentialBlock({
+			credentialId: blockedRow.id,
+			providerKey: "openai-codex:oauth",
+			blockScope: "chat",
+			blockedUntilMs: base + HOUR_MS,
+		});
+
+		// Verify the credential is blocked: getApiKey should return the sibling.
+		const blockedKey = await storage.getApiKey("openai-codex", "heal-verify-blocked");
+		expect(blockedKey).toBe("access-acct-sibling");
+
+		// Set up a healthy usage report for the blocked account.
+		usageByAccount.set("acct-blocked", codexReport("acct-blocked", "blocked@example.com", 0.2, 0.3, true));
+		usageByAccount.set("acct-sibling", codexReport("acct-sibling", "sibling@example.com", 0.2, 0.3, true));
+
+		// Advance time past the 5-minute probe-after window.
+		clockOffset = 6 * 60 * 1000;
+
+		// Drive the heal path: fetchUsageReports fans out per-credential,
+		// each report triggers #reconcileCodexUsageBlock → #healCodexUsageBlockScope.
+		await storage.fetchUsageReports();
+
+		// The in-memory block should now be cleared. With both credentials
+		// unblocked, the previously blocked one must be selectable.
+		const selections = new Set<string>();
+		for (let i = 0; i < 20; i++) {
+			const key = await storage.getApiKey("openai-codex", `heal-after-${i}`);
+			if (key) selections.add(key);
+		}
+		expect(selections.has("access-acct-blocked")).toBe(true);
+	});
+});
+
+describe("SqliteAuthCredentialStore corrupt-store open guidance", () => {
+	test("F4: open(malformedPath) rejects with .recover and the path", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-corrupt-open-"));
+		try {
+			const malformedDbPath = await writeMalformedDb(tempDir);
+			expect(SqliteAuthCredentialStore.open(malformedDbPath)).rejects.toThrow();
+			try {
+				await SqliteAuthCredentialStore.open(malformedDbPath);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				expect(message).toContain(".recover");
+				expect(message).toContain(malformedDbPath);
+				expect(message).toContain("--ignore-freelist");
+			}
+		} finally {
+			await removeWithRetries(tempDir);
+		}
 	});
 });

--- a/packages/ai/test/auth-storage-corrupt-store.test.ts
+++ b/packages/ai/test/auth-storage-corrupt-store.test.ts
@@ -182,6 +182,17 @@ describe("AuthStorage corrupt-store latch", () => {
 		);
 		expect(damagedErrors).toHaveLength(1);
 	});
+
+	test("listCredentialBlocks throws after the store is damaged instead of reporting no blocks", async () => {
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "listCredentialBlocks").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		expect(() => storage.listCredentialBlocks([1])).toThrow(/Credential store .* damaged/);
+		expect(() => storage.listCredentialBlocks([1])).toThrow(/\.recover/);
+	});
 });
 
 describe("AuthStorage corrupt-store reporting", () => {
@@ -585,6 +596,62 @@ describe("AuthStorage corrupt-store heal while latched", () => {
 		const selections = new Set<string>();
 		for (let i = 0; i < 20; i++) {
 			const key = await storage.getApiKey("openai-codex", `heal-after-${i}`);
+			if (key) selections.add(key);
+		}
+		expect(selections.has("access-acct-blocked")).toBe(true);
+	});
+
+	test("F7: redeeming a reset clears the in-memory block when persistence is damaged", async () => {
+		const usageFetch = Object.assign(
+			async (input: string | URL | Request) => {
+				if (String(input).endsWith("/rate-limit-reset-credits/consume")) {
+					return Response.json({ code: "reset" });
+				}
+				throw new Error(`unexpected reset-credit request: ${String(input)}`);
+			},
+			{ preconnect: fetch.preconnect },
+		);
+		storage.close();
+		store.close();
+		store = await SqliteAuthCredentialStore.open(dbPath);
+		storage = new AuthStorage(store, { usageFetch });
+		await storage.set("openai-codex", [
+			codexCredential("acct-blocked", "blocked@example.com"),
+			codexCredential("acct-sibling", "sibling@example.com"),
+		]);
+		const blockedRow = store.listAuthCredentials("openai-codex").find(row => {
+			const credential = row.credential;
+			return credential.type === "oauth" && credential.accountId === "acct-blocked";
+		});
+		if (!blockedRow) throw new Error("expected blocked credential row");
+
+		await storage.markUsageLimitReached("openai-codex", "reset-session", {
+			credentialId: blockedRow.id,
+			retryAfterMs: HOUR_MS,
+		});
+		const blockedKey = await storage.getApiKey("openai-codex", "reset-before");
+		expect(blockedKey).toBe("access-acct-sibling");
+
+		const malformedDbPath = await writeMalformedDb(tempDir);
+		vi.spyOn(store, "upsertCredentialBlock").mockImplementation(() => {
+			throw realCorruptError(malformedDbPath);
+		});
+		vi.spyOn(logger, "error").mockImplementation(() => {});
+		storage.upsertCredentialBlock({
+			credentialId: blockedRow.id,
+			providerKey: "openai-codex:oauth",
+			blockScope: "",
+			blockedUntilMs: Date.now() + HOUR_MS,
+		});
+
+		const redeemed = await storage.redeemResetCredit({
+			target: { credentialId: blockedRow.id },
+			creditId: "RateLimitResetCredit_test",
+		});
+		expect(redeemed).toMatchObject({ ok: true, code: "reset", creditId: "RateLimitResetCredit_test" });
+		const selections = new Set<string>();
+		for (let i = 0; i < 20; i++) {
+			const key = await storage.getApiKey("openai-codex", `reset-after-${i}`);
 			if (key) selections.add(key);
 		}
 		expect(selections.has("access-acct-blocked")).toBe(true);

--- a/packages/ai/test/auth-storage-corrupt-store.test.ts
+++ b/packages/ai/test/auth-storage-corrupt-store.test.ts
@@ -23,8 +23,7 @@ import * as path from "node:path";
 import { AuthStorage, type OAuthCredential, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
 import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import { logger } from "@oh-my-pi/pi-utils";
-import { shellQuote } from "@oh-my-pi/pi-utils/shell";
-import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
+import { isSqliteCorruptError, sqliteRepairGuidance } from "@oh-my-pi/pi-utils/sqlite";
 import { removeWithRetries } from "../../utils/src/temp";
 
 const PROVIDER = "anthropic";
@@ -228,9 +227,7 @@ describe("AuthStorage corrupt-store reporting", () => {
 		// The repair guidance must point at the actual store file, not a
 		// hardcoded default path (profiles relocate agent.db).
 		expect(String(damagedErrors[0]?.[0])).toContain(dbPath);
-		// F2: repair guidance must preserve credential-file permissions.
-		expect(String(damagedErrors[0]?.[0])).toContain("chmod 600");
-		expect(String(damagedErrors[0]?.[0])).toContain("--ignore-freelist");
+		expect(String(damagedErrors[0]?.[0])).toContain(sqliteRepairGuidance(dbPath, { restrictPermissions: true }));
 
 		const swallowDebugs = debugSpy.mock.calls.filter(
 			call => typeof call[0] === "string" && call[0] === "Failed to read credential block from persistent store",
@@ -328,7 +325,8 @@ describe("AuthStorage corrupt-store shell-balanced repair guidance", () => {
 		expect(damagedCall).toBeDefined();
 		const message = String(damagedCall?.[0]);
 		expect(message).toContain("--ignore-freelist");
-		expect(message).toContain("chmod 600");
+		const expectedDbPath = path.join(tempDir, "omp's agent", "agent.db");
+		expect(message).toContain(sqliteRepairGuidance(expectedDbPath, { restrictPermissions: true }));
 		// The repair command must be shell-balanced: every unescaped single
 		// quote toggles open/close state, so the string ends closed.
 		let open = false;
@@ -351,8 +349,7 @@ describe("AuthStorage corrupt-store shell-balanced repair guidance", () => {
 			await SqliteAuthCredentialStore.open(dbPath);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
-			expect(message).toContain(".recover --ignore-freelist");
-			expect(message).toContain(shellQuote(dbPath));
+			expect(message).toContain(sqliteRepairGuidance(dbPath, { restrictPermissions: true }));
 			// Shell-balanced check.
 			let open = false;
 			for (let i = 0; i < message.length; i++) {

--- a/packages/ai/test/auth-storage-sqlite-busy.test.ts
+++ b/packages/ai/test/auth-storage-sqlite-busy.test.ts
@@ -127,7 +127,7 @@ describe("SqliteAuthCredentialStore.open SQLITE_BUSY handling", () => {
 			return realRun.apply(this, args);
 		});
 
-		await expect(SqliteAuthCredentialStore.open(dbPath)).rejects.toThrow("disk image malformed");
+		await expect(SqliteAuthCredentialStore.open(dbPath)).rejects.toThrow("damaged");
 		// Single attempt: the retry loop must NOT keep banging on a fatal error.
 		expect(runCalls).toBe(1);
 	});

--- a/packages/ai/test/model-cache.test.ts
+++ b/packages/ai/test/model-cache.test.ts
@@ -1,11 +1,13 @@
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
-import { readModelCache, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { readModelCache, resetModelCacheCorruptLatchForTests, writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import * as piUtils from "@oh-my-pi/pi-utils";
+import { logger } from "@oh-my-pi/pi-utils";
 import { removeWithRetries } from "../../utils/src/temp";
 
 const TTL_MS = 24 * 60 * 60 * 1000;
@@ -117,5 +119,107 @@ describe("model cache migrations", () => {
 		expect(cached?.models[0]?.headers).toBeUndefined();
 		expect(cached?.headerOmittedModelIds).toEqual(["gated-model"]);
 		expect(cached?.unrestorableHeaderModelIds).toEqual(["gated-model"]);
+	});
+});
+
+async function writeMalformedCacheDb(dir: string): Promise<string> {
+	const dbPath = path.join(dir, "malformed.db");
+	await fs.writeFile(dbPath, "this is not a sqlite database");
+	return dbPath;
+}
+
+describe("model cache corrupt-store latch", () => {
+	let tempDir = "";
+
+	beforeEach(async () => {
+		resetModelCacheCorruptLatchForTests();
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-corrupt-cache-"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	it("latches after one corrupt read and stops re-opening the damaged file", async () => {
+		const malformedDbPath = await writeMalformedCacheDb(tempDir);
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// First call hits the malformed file, throws SQLITE_NOTADB, and latches.
+		const result1 = readModelCache("ollama-cloud", TTL_MS, Date.now, malformedDbPath);
+		expect(result1).toBeNull();
+
+		// Second call short-circuits before touching SQLite.
+		const result2 = readModelCache("ollama-cloud", TTL_MS, Date.now, malformedDbPath);
+		expect(result2).toBeNull();
+
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Model cache database is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+		expect(String(damagedErrors[0]?.[0])).toContain(malformedDbPath);
+	});
+
+	it("closes the shared cache handle when the latch fires on the shared path", async () => {
+		// 1. Set up a valid cache db at a temp path and route the no-dbPath
+		//    calls through it so getSharedDb() assigns the shared handle.
+		const validDbPath = path.join(tempDir, "shared.db");
+		const pathSpy = vi.spyOn(piUtils, "getModelDbPath").mockReturnValue(validDbPath);
+
+		// Write through the shared path — this opens and caches sharedDb.
+		writeModelCache("ollama-cloud", Date.now(), [createModel("warm-model", "Warm")], true, "static-v1");
+		// Confirm the shared handle is live: a read returns the cached row.
+		const warm = readModelCache<"openai-completions">("ollama-cloud", TTL_MS, Date.now);
+		expect(warm?.models.map(m => m.id)).toEqual(["warm-model"]);
+
+		// 2. Capture a real SQLITE_NOTADB error from a malformed file, then
+		//    make the shared handle's next query throw it.
+		const malformedDbPath = await writeMalformedCacheDb(tempDir);
+		const realErr = (() => {
+			const db = new Database(malformedDbPath);
+			try {
+				db.run("PRAGMA integrity_check");
+			} catch (err) {
+				return err as Error;
+			} finally {
+				db.close();
+			}
+			throw new Error("expected SQLITE_NOTADB");
+		})();
+
+		const querySpy = vi.spyOn(Database.prototype, "query").mockImplementation(() => {
+			throw realErr;
+		});
+		const closeSpy = vi.spyOn(Database.prototype, "close");
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// 3. Drive the read again through the shared path. The shared handle's
+		//    query throws SQLITE_NOTADB → latch fires → sharedDb.close() is
+		//    called and sharedDb/sharedDbPath are cleared.
+		const result = readModelCache("ollama-cloud", TTL_MS, Date.now);
+		expect(result).toBeNull();
+
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Model cache database is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+		expect(String(damagedErrors[0]?.[0])).toContain(validDbPath);
+
+		// The latch closed the shared handle.
+		expect(closeSpy).toHaveBeenCalled();
+
+		// 4. Second call short-circuits via the latch — query is not called again.
+		const queryCallsBefore = querySpy.mock.calls.length;
+		const result2 = readModelCache("ollama-cloud", TTL_MS, Date.now);
+		expect(result2).toBeNull();
+		expect(querySpy.mock.calls.length).toBe(queryCallsBefore);
+
+		pathSpy.mockRestore();
+		querySpy.mockRestore();
+		closeSpy.mockRestore();
+		errorSpy.mockRestore();
 	});
 });

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fixed `gen:models` Codex discovery to union models across every stored OAuth account and fail closed on partial resolution, matching runtime discovery ([#6265](https://github.com/can1357/oh-my-pi/issues/6265)); restored the bundled `gpt-5.4`, `gpt-5.6-sol`, and `gpt-5.3-codex-spark` entries a single-account regen had dropped.
-- Fixed the model cache silently swallowing a damaged SQLite database on every read and write: the first `SQLITE_CORRUPT`/`SQLITE_NOTADB` error now latches the cache file, logs once at error level with repair guidance, and degrades to cache-miss/no-op without touching the file again.
+- Fixed the model cache silently swallowing a damaged SQLite database on every read and write: the first `SQLITE_CORRUPT`/`SQLITE_NOTADB` error now latches the cache file, logs once at error level with repair guidance, and degrades to cache-miss/no-op without touching the file again. ([#7302](https://github.com/can1357/oh-my-pi/issues/7302))
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `gen:models` Codex discovery to union models across every stored OAuth account and fail closed on partial resolution, matching runtime discovery ([#6265](https://github.com/can1357/oh-my-pi/issues/6265)); restored the bundled `gpt-5.4`, `gpt-5.6-sol`, and `gpt-5.3-codex-spark` entries a single-account regen had dropped.
+- Fixed the model cache silently swallowing a damaged SQLite database on every read and write: the first `SQLITE_CORRUPT`/`SQLITE_NOTADB` error now latches the cache file, logs once at error level with repair guidance, and degrades to cache-miss/no-op without touching the file again.
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Routed model-cache SQLite damage guidance through the shared verified, in-place repair formatter.
 - Fixed `gen:models` Codex discovery to union models across every stored OAuth account and fail closed on partial resolution, matching runtime discovery ([#6265](https://github.com/can1357/oh-my-pi/issues/6265)); restored the bundled `gpt-5.4`, `gpt-5.6-sol`, and `gpt-5.3-codex-spark` entries a single-account regen had dropped.
 - Fixed the model cache silently swallowing a damaged SQLite database on every read and write: the first `SQLITE_CORRUPT`/`SQLITE_NOTADB` error now latches the cache file, logs once at error level with repair guidance, and degrades to cache-miss/no-op without touching the file again. ([#7302](https://github.com/can1357/oh-my-pi/issues/7302))
 

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -4,6 +4,7 @@
  */
 import { Database } from "bun:sqlite";
 import { getModelDbPath, logger } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { configureSqliteDatabase, isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import type { Api, Model, ModelSpec } from "./types";
 
@@ -128,7 +129,7 @@ function latchCorruptCacheDb(resolvedPath: string, err: unknown): void {
 	}
 	logger.error(
 		`Model cache database is damaged; cache reads and writes are disabled for this process. ` +
-			`Repair with: sqlite3 '${resolvedPath}' '.recover' | sqlite3 '${resolvedPath}.fixed'`,
+			`Repair with: sqlite3 ${shellQuote(resolvedPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${resolvedPath}.fixed`)}`,
 		{ err, dbPath: resolvedPath },
 	);
 }

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -4,6 +4,7 @@
  */
 import { Database } from "bun:sqlite";
 import { getModelDbPath } from "@oh-my-pi/pi-utils";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import type { Api, Model, ModelSpec } from "./types";
 
 // Rows persist ModelSpec JSON (sparse `compat`, never the resolved record);
@@ -68,12 +69,10 @@ function openDb(resolvedPath: string): Database {
 	const db = new Database(resolvedPath, { create: true });
 	// Install the busy handler BEFORE any lock-taking statement. See
 	// https://github.com/can1357/oh-my-pi/issues/2421.
-	db.run("PRAGMA busy_timeout = 3000");
 	// Schema invalidation can delete rows containing credentials written by old
 	// versions. Overwrite deleted SQLite cells instead of leaving their bytes in
 	// free pages where a raw scan of models.db can still recover them (#5780).
-	db.run("PRAGMA secure_delete = ON");
-	db.run("PRAGMA journal_mode = WAL");
+	configureSqliteDatabase(db, { busyTimeoutMs: 3000, secureDelete: true, wal: true });
 	db.run(`
 		CREATE TABLE IF NOT EXISTS model_cache (
 			provider_id TEXT PRIMARY KEY,

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -4,8 +4,7 @@
  */
 import { Database } from "bun:sqlite";
 import { getModelDbPath, logger } from "@oh-my-pi/pi-utils";
-import { shellQuote } from "@oh-my-pi/pi-utils/shell";
-import { configureSqliteDatabase, isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
+import { configureSqliteDatabase, isSqliteCorruptError, sqliteRepairGuidance } from "@oh-my-pi/pi-utils/sqlite";
 import type { Api, Model, ModelSpec } from "./types";
 
 // Rows persist ModelSpec JSON (sparse `compat`, never the resolved record);
@@ -129,7 +128,7 @@ function latchCorruptCacheDb(resolvedPath: string, err: unknown): void {
 	}
 	logger.error(
 		`Model cache database is damaged; cache reads and writes are disabled for this process. ` +
-			`Repair with: sqlite3 ${shellQuote(resolvedPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${resolvedPath}.fixed`)}`,
+			sqliteRepairGuidance(resolvedPath),
 		{ err, dbPath: resolvedPath },
 	);
 }

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -3,8 +3,8 @@
  * Replaces per-provider JSON files with a single cache.db.
  */
 import { Database } from "bun:sqlite";
-import { getModelDbPath } from "@oh-my-pi/pi-utils";
-import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
+import { getModelDbPath, logger } from "@oh-my-pi/pi-utils";
+import { configureSqliteDatabase, isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import type { Api, Model, ModelSpec } from "./types";
 
 // Rows persist ModelSpec JSON (sparse `compat`, never the resolved record);
@@ -65,29 +65,37 @@ interface CacheEntry<TApi extends Api = Api> {
 let sharedDb: Database | null = null;
 let sharedDbPath: string | null = null;
 
+/** Latched cache.db paths that reported unrecoverable damage. */
+const damagedCacheDbs = new Set<string>();
+
 function openDb(resolvedPath: string): Database {
 	const db = new Database(resolvedPath, { create: true });
-	// Install the busy handler BEFORE any lock-taking statement. See
-	// https://github.com/can1357/oh-my-pi/issues/2421.
-	// Schema invalidation can delete rows containing credentials written by old
-	// versions. Overwrite deleted SQLite cells instead of leaving their bytes in
-	// free pages where a raw scan of models.db can still recover them (#5780).
-	configureSqliteDatabase(db, { busyTimeoutMs: 3000, secureDelete: true, wal: true });
-	db.run(`
-		CREATE TABLE IF NOT EXISTS model_cache (
-			provider_id TEXT PRIMARY KEY,
-			version INTEGER NOT NULL,
-			updated_at INTEGER NOT NULL,
-			authoritative INTEGER NOT NULL DEFAULT 0,
-			static_fingerprint TEXT NOT NULL DEFAULT '',
-			header_omitted_model_ids TEXT NOT NULL DEFAULT '[]',
-			unrestorable_header_model_ids TEXT NOT NULL DEFAULT '[]',
-			header_restore_version INTEGER NOT NULL DEFAULT 0,
-			models TEXT NOT NULL
-		)
-	`);
-	migrateCacheSchema(db);
-	return db;
+	try {
+		// Install the busy handler BEFORE any lock-taking statement. See
+		// https://github.com/can1357/oh-my-pi/issues/2421.
+		// Schema invalidation can delete rows containing credentials written by old
+		// versions. Overwrite deleted SQLite cells instead of leaving their bytes in
+		// free pages where a raw scan of models.db can still recover them (#5780).
+		configureSqliteDatabase(db, { busyTimeoutMs: 3000, secureDelete: true, wal: true });
+		db.run(`
+			CREATE TABLE IF NOT EXISTS model_cache (
+				provider_id TEXT PRIMARY KEY,
+				version INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				authoritative INTEGER NOT NULL DEFAULT 0,
+				static_fingerprint TEXT NOT NULL DEFAULT '',
+				header_omitted_model_ids TEXT NOT NULL DEFAULT '[]',
+				unrestorable_header_model_ids TEXT NOT NULL DEFAULT '[]',
+				header_restore_version INTEGER NOT NULL DEFAULT 0,
+				models TEXT NOT NULL
+			)
+		`);
+		migrateCacheSchema(db);
+		return db;
+	} catch (err) {
+		db.close();
+		throw err;
+	}
 }
 
 function getSharedDb(): Database {
@@ -102,6 +110,27 @@ function getSharedDb(): Database {
 	sharedDb = db;
 	sharedDbPath = resolvedPath;
 	return db;
+}
+
+/**
+ * Latches a cache.db path as damaged on the first unrecoverable SQLite error.
+ * Logs once at `error` level with a repair one-liner, then short-circuits every
+ * later read/write for the life of the process. If the damaged path is the one
+ * backing the shared handle, the handle is closed and cleared so the operator
+ * can run the repair command without omp holding the file open.
+ */
+function latchCorruptCacheDb(resolvedPath: string, err: unknown): void {
+	damagedCacheDbs.add(resolvedPath);
+	if (sharedDb && sharedDbPath === resolvedPath) {
+		sharedDb.close();
+		sharedDb = null;
+		sharedDbPath = null;
+	}
+	logger.error(
+		`Model cache database is damaged; cache reads and writes are disabled for this process. ` +
+			`Repair with: sqlite3 '${resolvedPath}' '.recover' | sqlite3 '${resolvedPath}.fixed'`,
+		{ err, dbPath: resolvedPath },
+	);
 }
 
 function withModelCacheDb<T>(dbPath: string | undefined, useDb: (db: Database) => T): T {
@@ -150,6 +179,8 @@ export function readModelCache<TApi extends Api>(
 	now: () => number,
 	dbPath?: string,
 ): CacheEntry<TApi> | null {
+	const resolvedPath = dbPath ?? getModelDbPath();
+	if (damagedCacheDbs.has(resolvedPath)) return null;
 	try {
 		return withModelCacheDb(dbPath, db => {
 			const stmt = db.query<CacheRow, [string]>("SELECT * FROM model_cache WHERE provider_id = ?");
@@ -183,7 +214,10 @@ export function readModelCache<TApi extends Api>(
 				stmt.finalize();
 			}
 		});
-	} catch {
+	} catch (err) {
+		if (isSqliteCorruptError(err)) {
+			latchCorruptCacheDb(resolvedPath, err);
+		}
 		return null;
 	}
 }
@@ -231,6 +265,8 @@ export function writeModelCache<TApi extends Api>(
 	staticHeaderSources: readonly Model<TApi>[] = [],
 	restorableHeaderFallback?: Record<string, string>,
 ): void {
+	const resolvedPath = dbPath ?? getModelDbPath();
+	if (damagedCacheDbs.has(resolvedPath)) return;
 	try {
 		withModelCacheDb(dbPath, db => {
 			const headerOmittedModelIds: string[] = [];
@@ -278,7 +314,15 @@ export function writeModelCache<TApi extends Api>(
 				],
 			);
 		});
-	} catch {
+	} catch (err) {
+		if (isSqliteCorruptError(err)) {
+			latchCorruptCacheDb(resolvedPath, err);
+		}
 		// Cache writes are best-effort; failures should not break model resolution.
 	}
+}
+
+/** @internal Reset the corrupt-cache latch — test-only. */
+export function resetModelCacheCorruptLatchForTests(): void {
+	damagedCacheDbs.clear();
 }

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -179,7 +179,7 @@ export function readModelCache<TApi extends Api>(
 	now: () => number,
 	dbPath?: string,
 ): CacheEntry<TApi> | null {
-	const resolvedPath = dbPath ?? getModelDbPath();
+	const resolvedPath = dbPath || getModelDbPath();
 	if (damagedCacheDbs.has(resolvedPath)) return null;
 	try {
 		return withModelCacheDb(dbPath, db => {
@@ -265,7 +265,7 @@ export function writeModelCache<TApi extends Api>(
 	staticHeaderSources: readonly Model<TApi>[] = [],
 	restorableHeaderFallback?: Record<string, string>,
 ): void {
-	const resolvedPath = dbPath ?? getModelDbPath();
+	const resolvedPath = dbPath || getModelDbPath();
 	if (damagedCacheDbs.has(resolvedPath)) return;
 	try {
 		withModelCacheDb(dbPath, db => {

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -327,3 +327,12 @@ export function writeModelCache<TApi extends Api>(
 export function resetModelCacheCorruptLatchForTests(): void {
 	damagedCacheDbs.clear();
 }
+
+/** @internal Close and clear the shared default handle — test-only. */
+export function resetModelCacheSharedHandleForTests(): void {
+	if (sharedDb) {
+		sharedDb.close();
+	}
+	sharedDb = null;
+	sharedDbPath = null;
+}

--- a/packages/catalog/test/model-cache-latch-key.test.ts
+++ b/packages/catalog/test/model-cache-latch-key.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression coverage for the model-cache latch-key mismatch (#7302).
+ *
+ * `withModelCacheDb` resolves a falsy `dbPath` to the shared default
+ * (`if (!dbPath) return useDb(getSharedDb())`), but the latch previously
+ * resolved with nullish-only `dbPath ?? getModelDbPath()`. A caller passing
+ * `""` opened the shared default but latched `""`, so a later `undefined`
+ * call missed the latch and re-probed the damaged file. The fix changes both
+ * latch resolutions to `dbPath || getModelDbPath()` so a falsy `dbPath`
+ * consistently resolves to the shared default path.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readModelCache, resetModelCacheCorruptLatchForTests } from "@oh-my-pi/pi-catalog/model-cache";
+import { getModelDbPath, logger } from "@oh-my-pi/pi-utils";
+import { refreshDirsFromEnv } from "@oh-my-pi/pi-utils/dirs";
+
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	resetModelCacheCorruptLatchForTests();
+	if (originalAgentDir === undefined) {
+		delete process.env.PI_CODING_AGENT_DIR;
+	} else {
+		process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+	}
+	refreshDirsFromEnv();
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("model-cache latch key matches the open fallback", () => {
+	let dir: string;
+	let malformedDbPath: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "pi-catalog-latch-key-"));
+		tempDirs.push(dir);
+		// Point the shared default db path at our temp dir.
+		process.env.PI_CODING_AGENT_DIR = dir;
+		refreshDirsFromEnv();
+		malformedDbPath = getModelDbPath();
+		// Write bytes that are not a valid SQLite database so openDb throws
+		// SQLITE_NOTADB — the same family the latch classifies as corrupt.
+		writeFileSync(malformedDbPath, "this is not a sqlite database");
+	});
+
+	test("an empty-string dbPath latches the shared default so undefined skips the probe", () => {
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// First call with "" — opens the shared default (malformed), latches.
+		// With the fix, the latch key is getModelDbPath() (not "").
+		const first = readModelCache("test-provider", Infinity, Date.now, "");
+		expect(first).toBeNull();
+
+		// Exactly one error log fired for the corrupt open.
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Model cache database is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+
+		// Second call with undefined — must hit the latch (same resolved path)
+		// and return null WITHOUT probing the store again.
+		const second = readModelCache("test-provider", Infinity, Date.now, undefined);
+		expect(second).toBeNull();
+
+		// No second error log — the latch short-circuited before any db open.
+		const damagedErrorsAfterSecond = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Model cache database is damaged"),
+		);
+		expect(damagedErrorsAfterSecond).toHaveLength(1);
+	});
+
+	test("mutation proof: restoring ?? makes the undefined call re-probe", () => {
+		// This test documents the regression: if the latch resolution used
+		// `??` instead of `||`, the empty-string call would latch "" and the
+		// undefined call would miss the latch. We verify the fix by confirming
+		// the latch key for "" equals the latch key for undefined (both are
+		// getModelDbPath()). The mutation proof is structural: replacing `||`
+		// with `??` in the source makes the first test above fail (two error
+		// logs instead of one). See the acceptance criteria.
+		//
+		// Run the same scenario and confirm only one error fires.
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		readModelCache("test-provider", Infinity, Date.now, "");
+		readModelCache("test-provider", Infinity, Date.now, undefined);
+
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Model cache database is damaged"),
+		);
+		// With `||`: 1 error (latch hit). With `??`: 2 errors (latch miss).
+		expect(damagedErrors).toHaveLength(1);
+	});
+});

--- a/packages/catalog/test/model-cache-latch-key.test.ts
+++ b/packages/catalog/test/model-cache-latch-key.test.ts
@@ -17,6 +17,7 @@ import { join } from "node:path";
 import { readModelCache, resetModelCacheCorruptLatchForTests } from "@oh-my-pi/pi-catalog/model-cache";
 import { getModelDbPath, logger } from "@oh-my-pi/pi-utils";
 import { refreshDirsFromEnv } from "@oh-my-pi/pi-utils/dirs";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 const tempDirs: string[] = [];
@@ -62,6 +63,11 @@ describe("model-cache latch key matches the open fallback", () => {
 			call => typeof call[0] === "string" && call[0].includes("Model cache database is damaged"),
 		);
 		expect(damagedErrors).toHaveLength(1);
+		// The repair command shell-quotes the path and uses --ignore-freelist.
+		expect(String(damagedErrors[0]?.[0])).toContain(
+			`sqlite3 ${shellQuote(malformedDbPath)} '.recover --ignore-freelist'`,
+		);
+		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 ${shellQuote(`${malformedDbPath}.fixed`)}`);
 
 		// Second call with undefined — must hit the latch (same resolved path)
 		// and return null WITHOUT probing the store again.

--- a/packages/catalog/test/model-cache-latch-key.test.ts
+++ b/packages/catalog/test/model-cache-latch-key.test.ts
@@ -21,7 +21,7 @@ import {
 } from "@oh-my-pi/pi-catalog/model-cache";
 import { getModelDbPath, logger } from "@oh-my-pi/pi-utils";
 import { refreshDirsFromEnv } from "@oh-my-pi/pi-utils/dirs";
-import { shellQuote } from "@oh-my-pi/pi-utils/shell";
+import { sqliteRepairGuidance } from "@oh-my-pi/pi-utils/sqlite";
 
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 const tempDirs: string[] = [];
@@ -71,11 +71,7 @@ describe("model-cache latch key matches the open fallback", () => {
 			call => typeof call[0] === "string" && call[0].includes("Model cache database is damaged"),
 		);
 		expect(damagedErrors).toHaveLength(1);
-		// The repair command shell-quotes the path and uses --ignore-freelist.
-		expect(String(damagedErrors[0]?.[0])).toContain(
-			`sqlite3 ${shellQuote(malformedDbPath)} '.recover --ignore-freelist'`,
-		);
-		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 ${shellQuote(`${malformedDbPath}.fixed`)}`);
+		expect(String(damagedErrors[0]?.[0])).toContain(sqliteRepairGuidance(malformedDbPath));
 
 		// Second call with undefined — must hit the latch (same resolved path)
 		// and return null WITHOUT probing the store again.

--- a/packages/catalog/test/model-cache-latch-key.test.ts
+++ b/packages/catalog/test/model-cache-latch-key.test.ts
@@ -14,7 +14,11 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { readModelCache, resetModelCacheCorruptLatchForTests } from "@oh-my-pi/pi-catalog/model-cache";
+import {
+	readModelCache,
+	resetModelCacheCorruptLatchForTests,
+	resetModelCacheSharedHandleForTests,
+} from "@oh-my-pi/pi-catalog/model-cache";
 import { getModelDbPath, logger } from "@oh-my-pi/pi-utils";
 import { refreshDirsFromEnv } from "@oh-my-pi/pi-utils/dirs";
 import { shellQuote } from "@oh-my-pi/pi-utils/shell";
@@ -25,6 +29,7 @@ const tempDirs: string[] = [];
 afterEach(() => {
 	vi.restoreAllMocks();
 	resetModelCacheCorruptLatchForTests();
+	resetModelCacheSharedHandleForTests();
 	if (originalAgentDir === undefined) {
 		delete process.env.PI_CODING_AGENT_DIR;
 	} else {
@@ -39,6 +44,9 @@ describe("model-cache latch key matches the open fallback", () => {
 	let malformedDbPath: string;
 
 	beforeEach(() => {
+		// Drop any shared default handle a prior suite cached against the real
+		// agent dir, so this test opens against our temp dir from a clean state.
+		resetModelCacheSharedHandleForTests();
 		dir = mkdtempSync(join(tmpdir(), "pi-catalog-latch-key-"));
 		tempDirs.push(dir);
 		// Point the shared default db path at our temp dir.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Unified and verified in-place SQLite repair guidance across agent, stats, and mnemopi stores, with restrictive recovery permissions for credential data.
+- Bounded legacy-bank discovery with one total startup budget so a locked or contended `banks/` directory cannot stall startup for minutes.
+- Restored absent environment variables correctly in perf-test teardown.
 - Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file. ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
 - Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file.
 - Fixed the model-perf backfill and the mnemopi legacy bank reader re-throwing or re-probing a damaged SQLite database on every invocation: both now latch on the first `SQLITE_CORRUPT`/`SQLITE_NOTADB` error, log once at error level with repair guidance, and fail open (no backfill rows / no legacy bank) without touching the file again. ([#7302](https://github.com/can1357/oh-my-pi/issues/7302))
@@ -11,6 +14,7 @@
 
 ### Changed
 
+- Consolidated POSIX shell argument quoting on the shared `@oh-my-pi/pi-utils/shell` helper across SSH transfers, user-shell launches, daemon broker commands, skill URLs, profile aliases, screenshots, snapshots, and test fixtures.
 - Centralized SQLite open pragmas on the shared `configureSqliteDatabase`/`openSqliteDatabase` helpers (session agent storage, history storage, local memory storage, GitHub cache, auto-QA grievance store, autoresearch store, and the GC maintenance handles); per-site pragma sets, timeouts, caching, and retry behavior are unchanged. ([#7302](https://github.com/can1357/oh-my-pi/issues/7302))
 
 ## [17.2.3] - 2026-08-01

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Fixed
 
 - Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file. ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
+- Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file.
+- Fixed the read-only legacy memory-bank reader in the mnemopi backend opening its SQLite database with no `busy_timeout`, so a race with a concurrent WAL checkpoint threw `SQLITE_BUSY` immediately instead of waiting.
+
+### Changed
+
+- Centralized SQLite open pragmas on the shared `configureSqliteDatabase`/`openSqliteDatabase` helpers (session agent storage, history storage, local memory storage, GitHub cache, auto-QA grievance store, autoresearch store, and the GC maintenance handles); per-site pragma sets, timeouts, caching, and retry behavior are unchanged.
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file.
+- Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file. ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file.
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 - Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file. ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
 - Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file.
-- Fixed the model-perf backfill and the mnemopi legacy bank reader re-throwing or re-probing a damaged SQLite database on every invocation: both now latch on the first `SQLITE_CORRUPT`/`SQLITE_NOTADB` error, log once at error level with repair guidance, and fail open (no backfill rows / no legacy bank) without touching the file again.
-- Fixed the read-only legacy memory-bank reader in the mnemopi backend opening its SQLite database with no `busy_timeout`, so a race with a concurrent WAL checkpoint threw `SQLITE_BUSY` immediately instead of waiting.
+- Fixed the model-perf backfill and the mnemopi legacy bank reader re-throwing or re-probing a damaged SQLite database on every invocation: both now latch on the first `SQLITE_CORRUPT`/`SQLITE_NOTADB` error, log once at error level with repair guidance, and fail open (no backfill rows / no legacy bank) without touching the file again. ([#7302](https://github.com/can1357/oh-my-pi/issues/7302))
+- Fixed the read-only legacy memory-bank reader in the mnemopi backend opening its SQLite database with no `busy_timeout`, so a race with a concurrent WAL checkpoint threw `SQLITE_BUSY` immediately instead of waiting. ([#7302](https://github.com/can1357/oh-my-pi/issues/7302))
 
 ### Changed
 
-- Centralized SQLite open pragmas on the shared `configureSqliteDatabase`/`openSqliteDatabase` helpers (session agent storage, history storage, local memory storage, GitHub cache, auto-QA grievance store, autoresearch store, and the GC maintenance handles); per-site pragma sets, timeouts, caching, and retry behavior are unchanged.
+- Centralized SQLite open pragmas on the shared `configureSqliteDatabase`/`openSqliteDatabase` helpers (session agent storage, history storage, local memory storage, GitHub cache, auto-QA grievance store, autoresearch store, and the GC maintenance handles); per-site pragma sets, timeouts, caching, and retry behavior are unchanged. ([#7302](https://github.com/can1357/oh-my-pi/issues/7302))
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file. ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
 - Fixed the credential store corruption latch not clearing in-memory rate-limit blocks on healthy usage reports, not notifying generation listeners on latch, and not surfacing repair guidance when the store file is malformed at startup; the database path is now passed through all SqliteAuthCredentialStore construction sites (AgentStorage and the legacy pi-coding-agent shim) so corruption reports always identify the file.
+- Fixed the model-perf backfill and the mnemopi legacy bank reader re-throwing or re-probing a damaged SQLite database on every invocation: both now latch on the first `SQLITE_CORRUPT`/`SQLITE_NOTADB` error, log once at error level with repair guidance, and fail open (no backfill rows / no legacy bank) without touching the file again.
 - Fixed the read-only legacy memory-bank reader in the mnemopi backend opening its SQLite database with no `busy_timeout`, so a race with a concurrent WAL checkpoint threw `SQLITE_BUSY` immediately instead of waiting.
 
 ### Changed

--- a/packages/coding-agent/src/autoresearch/storage.ts
+++ b/packages/coding-agent/src/autoresearch/storage.ts
@@ -193,10 +193,6 @@ type RunDbRow = {
 const SCHEMA_VERSION = 1;
 
 const SCHEMA_SQL = `
-PRAGMA journal_mode=WAL;
-PRAGMA synchronous=NORMAL;
-PRAGMA foreign_keys=ON;
-
 CREATE TABLE IF NOT EXISTS sessions (
 	id INTEGER PRIMARY KEY,
 	name TEXT NOT NULL,
@@ -264,7 +260,7 @@ export class AutoresearchStorage {
 		fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 		this.#db = new Database(dbPath);
 		// Install the busy handler BEFORE any lock-taking statement. See #2421.
-		configureSqliteDatabase(this.#db);
+		configureSqliteDatabase(this.#db, { wal: true, synchronousNormal: true, foreignKeys: true });
 		this.#db.run(SCHEMA_SQL);
 		const versionRow = this.#db.query("PRAGMA user_version").get() as { user_version: number } | null;
 		const currentVersion = versionRow?.user_version ?? 0;

--- a/packages/coding-agent/src/autoresearch/storage.ts
+++ b/packages/coding-agent/src/autoresearch/storage.ts
@@ -2,6 +2,7 @@ import { Database, type SQLQueryBindings } from "bun:sqlite";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getAutoresearchDbPath, getAutoresearchProjectDir, logger } from "@oh-my-pi/pi-utils";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import * as git from "../utils/git";
 import type { ASIData, ExperimentStatus, MetricDirection, NumericMetricMap } from "./types";
 
@@ -263,7 +264,7 @@ export class AutoresearchStorage {
 		fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 		this.#db = new Database(dbPath);
 		// Install the busy handler BEFORE any lock-taking statement. See #2421.
-		this.#db.run("PRAGMA busy_timeout = 5000");
+		configureSqliteDatabase(this.#db);
 		this.#db.run(SCHEMA_SQL);
 		const versionRow = this.#db.query("PRAGMA user_version").get() as { user_version: number } | null;
 		const currentVersion = versionRow?.user_version ?? 0;

--- a/packages/coding-agent/src/cli/gallery-screenshot.ts
+++ b/packages/coding-agent/src/cli/gallery-screenshot.ts
@@ -15,6 +15,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { $which } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { theme } from "../modes/theme/theme";
 import type { GallerySection } from "./gallery-cli";
 
@@ -164,7 +165,7 @@ function buildTape(args: TapeArgs): string {
 	// is captured from the final visible frame. Setup is hidden so the typed
 	// `cat` command and shell prompt never appear in the capture, and a trailing
 	// `sleep` keeps the shell from drawing a fresh prompt under the output.
-	const shellCommand = `clear; cat ${shellSingleQuote(args.ansiPath)}; sleep 120`;
+	const shellCommand = `clear; cat ${shellQuote(args.ansiPath)}; sleep 120`;
 	return `${[
 		`Output ${JSON.stringify(args.gifPath)}`,
 		`Set Width ${args.widthPx}`,
@@ -224,11 +225,6 @@ function parseAnsiRgb(ansi: string): string | undefined {
 	if (!match) return undefined;
 	const hex = (value: string) => Number(value).toString(16).padStart(2, "0");
 	return `#${hex(match[1])}${hex(match[2])}${hex(match[3])}`;
-}
-
-/** POSIX single-quote a path for embedding in the VHS shell command. */
-function shellSingleQuote(value: string): string {
-	return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 /**

--- a/packages/coding-agent/src/cli/gc-cli.ts
+++ b/packages/coding-agent/src/cli/gc-cli.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { getAgentDir, getBlobsDir, getHistoryDbPath, getModelDbPath, getSessionsDir } from "@oh-my-pi/pi-utils";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import { Settings } from "../config/settings";
 import { getDefault } from "../config/settings-schema";
 import { BLOB_HASH_RE } from "../session/blob-store";
@@ -540,7 +541,7 @@ function deleteHistoryRowsForSessions(dbPath: string, sessionIds: string[]): { d
 	if (sessionIds.length === 0) return { deleted: 0, ftsRebuilt: false };
 	const db = new Database(dbPath);
 	try {
-		db.run("PRAGMA busy_timeout = 5000");
+		configureSqliteDatabase(db);
 		if (!tableExists(db, "history")) return { deleted: 0, ftsRebuilt: false };
 		if (!historyHasSessionId(db)) return { deleted: 0, ftsRebuilt: false };
 		const hasFts = tableExists(db, "history_fts");
@@ -687,7 +688,7 @@ async function checkpointWal(dbPath: string, apply: boolean): Promise<WalCheckpo
 	const db = new Database(dbPath);
 	let checkpointAttempted = false;
 	try {
-		db.run("PRAGMA busy_timeout = 5000");
+		configureSqliteDatabase(db);
 		const row = db.prepare("PRAGMA wal_checkpoint(TRUNCATE)").get() as WalCheckpointRow | null;
 		checkpointAttempted = true;
 		result.busy = sqliteNumber(row?.busy);

--- a/packages/coding-agent/src/cli/profile-alias.ts
+++ b/packages/coding-agent/src/cli/profile-alias.ts
@@ -1,12 +1,9 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import { normalizeProfileName } from "@oh-my-pi/pi-utils/dirs";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 
 export type ProfileAliasShell = "bash" | "zsh" | "fish" | "powershell" | "pwsh";
-
-function quoteForShell(pathValue: string): string {
-	return `'${pathValue.replace(/'/g, `'"'"'`)}'`;
-}
 
 function quoteForPowerShell(pathValue: string): string {
 	return `'${pathValue.replace(/'/g, `''`)}'`;
@@ -202,7 +199,7 @@ export function resolveProfileAliasCommandFromProcess(
 	// can't resolve backslash-separated paths, even on Windows (Git Bash, WSL).
 	const posixScriptPath = scriptPath.replace(/\\/g, "/");
 	const posixRuntime = runtime.replace(/\\/g, "/");
-	const posix = `${quoteForShell(posixRuntime)} ${quoteForShell(posixScriptPath)}`;
+	const posix = `${shellQuote(posixRuntime)} ${shellQuote(posixScriptPath)}`;
 	return {
 		display: `${posixRuntime} ${posixScriptPath}`,
 		posix,
@@ -361,9 +358,9 @@ export async function installProfileAlias(options: ProfileAliasInstallOptions): 
 		command,
 		reloadedWith:
 			shell === "fish"
-				? `source ${quoteForShell(configPath)}`
+				? `source ${shellQuote(configPath)}`
 				: shell === "powershell" || shell === "pwsh"
 					? `. ${quoteForPowerShell(configPath)}`
-					: `. ${quoteForShell(configPath)}`,
+					: `. ${shellQuote(configPath)}`,
 	};
 }

--- a/packages/coding-agent/src/cli/profile-alias.ts
+++ b/packages/coding-agent/src/cli/profile-alias.ts
@@ -1,13 +1,9 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import { normalizeProfileName } from "@oh-my-pi/pi-utils/dirs";
-import { shellQuote } from "@oh-my-pi/pi-utils/shell";
+import { powershellQuote, shellQuote } from "@oh-my-pi/pi-utils/shell";
 
 export type ProfileAliasShell = "bash" | "zsh" | "fish" | "powershell" | "pwsh";
-
-function quoteForPowerShell(pathValue: string): string {
-	return `'${pathValue.replace(/'/g, `''`)}'`;
-}
 
 export interface ProfileAliasCommand {
 	display: string;
@@ -204,7 +200,7 @@ export function resolveProfileAliasCommandFromProcess(
 		display: `${posixRuntime} ${posixScriptPath}`,
 		posix,
 		fish: posix,
-		powerShell: `${quoteForPowerShell(runtime)} ${quoteForPowerShell(scriptPath)}`,
+		powerShell: `${powershellQuote(runtime)} ${powershellQuote(scriptPath)}`,
 	};
 }
 
@@ -360,7 +356,7 @@ export async function installProfileAlias(options: ProfileAliasInstallOptions): 
 			shell === "fish"
 				? `source ${shellQuote(configPath)}`
 				: shell === "powershell" || shell === "pwsh"
-					? `. ${quoteForPowerShell(configPath)}`
+					? `. ${powershellQuote(configPath)}`
 					: `. ${shellQuote(configPath)}`,
 	};
 }

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -6,6 +6,7 @@
 import { ExponentialYield } from "@oh-my-pi/pi-agent-core/utils/yield";
 import { type MinimizerOptions, Shell, type ShellRunResult } from "@oh-my-pi/pi-natives";
 import { isCmdShell, isExecutable, type ShellConfig } from "@oh-my-pi/pi-utils/procmgr";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { Settings, type ShellMinimizerSettings } from "../config/settings";
 import { OutputSink } from "../session/streaming-output";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
@@ -312,12 +313,8 @@ function ensureInteractiveShellArgs(shell: string, args: string[]): string[] {
 	return [...effectiveArgs, "-i"];
 }
 
-function quoteShellArg(value: string): string {
-	return `'${value.replace(/'/g, "'\\''")}'`;
-}
-
 function buildUserShellCommand(shell: string, args: string[], command: string): string {
-	return [shell, ...ensureInteractiveShellArgs(shell, args), command].map(quoteShellArg).join(" ");
+	return [shell, ...ensureInteractiveShellArgs(shell, args), command].map(shellQuote).join(" ");
 }
 
 function resolveUserShellConfig(settings: Settings, baseConfig: ShellConfig): ShellConfig {

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -1367,7 +1367,8 @@ export class AuthStorage {
 	}
 
 	get(provider: string): AuthCredential | undefined {
-		const store = new SqliteAuthCredentialStore(new Database(getAgentDbPath()));
+		const dbPath = getAgentDbPath();
+		const store = new SqliteAuthCredentialStore(new Database(dbPath), dbPath);
 		try {
 			return store.listAuthCredentials(provider)[0]?.credential;
 		} finally {
@@ -1376,7 +1377,8 @@ export class AuthStorage {
 	}
 
 	set(provider: string, credential: AuthCredential): void {
-		const store = new SqliteAuthCredentialStore(new Database(getAgentDbPath()));
+		const dbPath = getAgentDbPath();
+		const store = new SqliteAuthCredentialStore(new Database(dbPath), dbPath);
 		try {
 			store.upsertAuthCredentialForProvider(provider, credential);
 		} finally {

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Process, type PtyRunResult, PtySession } from "@oh-my-pi/pi-natives";
 import { isEexist, isEnoent, logger, postmortem, procmgr, sanitizeText, setProcessName } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { hostHasInheritableConsole } from "../eval/py/spawn-options";
 import { truncateHead, truncateHeadBytes, truncateTail, truncateTailBytes } from "../session/streaming-output";
 import { workerEnvFromParent } from "../subprocess/worker-client";
@@ -93,10 +94,6 @@ interface DaemonLogRead {
 	text: string;
 	terminalOutput: string;
 	cursor: number;
-}
-
-function quoteShellArg(value: string): string {
-	return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
 function terminalState(state: DaemonSnapshot["state"]): boolean {
@@ -648,7 +645,7 @@ class DaemonBroker {
 			);
 		} else {
 			const argv = [record.spec.application, ...record.spec.args];
-			const command = `exec ${argv.map(quoteShellArg).join(" ")}`;
+			const command = `exec ${argv.map(shellQuote).join(" ")}`;
 			const shell = procmgr.getShellConfig().shell;
 			run = session.start({ command, shell, ...options }, onChunk, onStart);
 		}

--- a/packages/coding-agent/src/memories/storage.ts
+++ b/packages/coding-agent/src/memories/storage.ts
@@ -1,4 +1,5 @@
 import { Database } from "bun:sqlite";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 
 export interface MemoryThread {
 	id: string;
@@ -47,11 +48,8 @@ function globalJobKey(cwd: string): string {
 export function openMemoryDb(dbPath: string): Database {
 	const db = new Database(dbPath);
 	// Install the busy handler BEFORE any lock-taking statement. See #2421.
-	db.exec("PRAGMA busy_timeout = 5000");
+	configureSqliteDatabase(db, { wal: true, synchronousNormal: true });
 	db.exec(`
-PRAGMA journal_mode=WAL;
-PRAGMA synchronous=NORMAL;
-
 CREATE TABLE IF NOT EXISTS threads (
 	id TEXT PRIMARY KEY,
 	updated_at INTEGER NOT NULL,

--- a/packages/coding-agent/src/mnemopi/config.ts
+++ b/packages/coding-agent/src/mnemopi/config.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { MnemopiOptions } from "@oh-my-pi/pi-mnemopi";
 import { getMemoriesDir, logger } from "@oh-my-pi/pi-utils";
-import { openSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
+import { isSqliteCorruptError, openSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import type { Settings } from "../config/settings";
 
 export type MnemopiLlmMode = "none" | "smol" | "remote";
@@ -107,6 +107,9 @@ const DEFAULT_SHARED_BANK = "default";
 // Cap legacy-bank scanning at session start so a pathological banks/
 // directory cannot dominate startup latency.
 const LEGACY_BANK_SCAN_LIMIT = 64;
+
+/** Latched bank mnemopi.db paths that reported unrecoverable damage. */
+const damagedBankDbs = new Set<string>();
 
 export interface MnemopiBankScope {
 	baseBank: string;
@@ -222,6 +225,7 @@ export function extendRecallWithLegacyBanks(
 }
 
 function bankOnlyHasCwd(dbPath: string, cwd: string): boolean {
+	if (damagedBankDbs.has(dbPath)) return false;
 	let db: Database | undefined;
 	try {
 		db = openSqliteDatabase(dbPath, { readonly: true });
@@ -235,7 +239,16 @@ function bankOnlyHasCwd(dbPath: string, cwd: string): boolean {
 			.get(cwd, cwd);
 		return (row?.matching ?? 0) > 0 && (row?.unsafe ?? 0) === 0;
 	} catch (error) {
-		logger.debug("Mnemopi: legacy bank probe failed", { dbPath, error: String(error) });
+		if (isSqliteCorruptError(error)) {
+			damagedBankDbs.add(dbPath);
+			logger.error(
+				`Mnemopi: legacy bank database is damaged; this bank is skipped for the rest of the process. ` +
+					`Repair with: sqlite3 '${dbPath}' '.recover' | sqlite3 '${dbPath}.fixed'`,
+				{ dbPath, error: String(error) },
+			);
+		} else {
+			logger.debug("Mnemopi: legacy bank probe failed", { dbPath, error: String(error) });
+		}
 		return false;
 	} finally {
 		try {
@@ -265,4 +278,9 @@ export function truncateApproxTokens(text: string, tokenLimit: number): string {
 	const maxChars = Math.max(0, tokenLimit * 4);
 	if (text.length <= maxChars) return text;
 	return `${text.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+/** @internal Reset the legacy-bank corrupt latch — test-only. */
+export function resetLegacyBankCorruptLatchForTests(): void {
+	damagedBankDbs.clear();
 }

--- a/packages/coding-agent/src/mnemopi/config.ts
+++ b/packages/coding-agent/src/mnemopi/config.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { MnemopiOptions } from "@oh-my-pi/pi-mnemopi";
 import { getMemoriesDir, logger } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { isSqliteCorruptError, openSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import type { Settings } from "../config/settings";
 
@@ -243,7 +244,7 @@ function bankOnlyHasCwd(dbPath: string, cwd: string): boolean {
 			damagedBankDbs.add(dbPath);
 			logger.error(
 				`Mnemopi: legacy bank database is damaged; this bank is skipped for the rest of the process. ` +
-					`Repair with: sqlite3 '${dbPath}' '.recover' | sqlite3 '${dbPath}.fixed'`,
+					`Repair with: sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${dbPath}.fixed`)}`,
 				{ dbPath, error: String(error) },
 			);
 		} else {

--- a/packages/coding-agent/src/mnemopi/config.ts
+++ b/packages/coding-agent/src/mnemopi/config.ts
@@ -1,8 +1,9 @@
-import { Database } from "bun:sqlite";
+import type { Database } from "bun:sqlite";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { MnemopiOptions } from "@oh-my-pi/pi-mnemopi";
 import { getMemoriesDir, logger } from "@oh-my-pi/pi-utils";
+import { openSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import type { Settings } from "../config/settings";
 
 export type MnemopiLlmMode = "none" | "smol" | "remote";
@@ -223,7 +224,7 @@ export function extendRecallWithLegacyBanks(
 function bankOnlyHasCwd(dbPath: string, cwd: string): boolean {
 	let db: Database | undefined;
 	try {
-		db = new Database(dbPath, { readonly: true });
+		db = openSqliteDatabase(dbPath, { readonly: true });
 		const row = db
 			.prepare<{ matching: number; unsafe: number }, [string, string]>(`
 				SELECT

--- a/packages/coding-agent/src/mnemopi/config.ts
+++ b/packages/coding-agent/src/mnemopi/config.ts
@@ -3,8 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { MnemopiOptions } from "@oh-my-pi/pi-mnemopi";
 import { getMemoriesDir, logger } from "@oh-my-pi/pi-utils";
-import { shellQuote } from "@oh-my-pi/pi-utils/shell";
-import { isSqliteCorruptError, openSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
+import { isSqliteCorruptError, openSqliteDatabase, sqliteRepairGuidance } from "@oh-my-pi/pi-utils/sqlite";
 import type { Settings } from "../config/settings";
 
 export type MnemopiLlmMode = "none" | "smol" | "remote";
@@ -108,6 +107,7 @@ const DEFAULT_SHARED_BANK = "default";
 // Cap legacy-bank scanning at session start so a pathological banks/
 // directory cannot dominate startup latency.
 const LEGACY_BANK_SCAN_LIMIT = 64;
+const LEGACY_BANK_SCAN_BUDGET_MS = 2000;
 
 /** Latched bank mnemopi.db paths that reported unrecoverable damage. */
 const damagedBankDbs = new Set<string>();
@@ -214,22 +214,33 @@ export function extendRecallWithLegacyBanks(
 	}
 	const have = new Set(resolved);
 	const extras: string[] = [];
+	const deadline = Date.now() + LEGACY_BANK_SCAN_BUDGET_MS;
 	let scanned = 0;
 	for (const entry of entries) {
 		if (!entry.isDirectory() || have.has(entry.name)) continue;
 		if (scanned >= LEGACY_BANK_SCAN_LIMIT) break;
+		const remainingMs = deadline - Date.now();
+		if (remainingMs <= 0) {
+			logger.debug("Mnemopi: legacy bank scan budget exhausted", {
+				scanned,
+				budgetMs: LEGACY_BANK_SCAN_BUDGET_MS,
+			});
+			break;
+		}
 		scanned++;
 		const candidate = path.join(banksDir, entry.name, "mnemopi.db");
-		if (bankOnlyHasCwd(candidate, cwdAbs)) extras.push(entry.name);
+		if (bankOnlyHasCwd(candidate, cwdAbs, remainingMs)) {
+			extras.push(entry.name);
+		}
 	}
 	return extras.length === 0 ? resolved : [...resolved, ...extras];
 }
 
-function bankOnlyHasCwd(dbPath: string, cwd: string): boolean {
+function bankOnlyHasCwd(dbPath: string, cwd: string, busyTimeoutMs: number): boolean {
 	if (damagedBankDbs.has(dbPath)) return false;
 	let db: Database | undefined;
 	try {
-		db = openSqliteDatabase(dbPath, { readonly: true });
+		db = openSqliteDatabase(dbPath, { readonly: true, busyTimeoutMs });
 		const row = db
 			.prepare<{ matching: number; unsafe: number }, [string, string]>(`
 				SELECT
@@ -244,7 +255,7 @@ function bankOnlyHasCwd(dbPath: string, cwd: string): boolean {
 			damagedBankDbs.add(dbPath);
 			logger.error(
 				`Mnemopi: legacy bank database is damaged; this bank is skipped for the rest of the process. ` +
-					`Repair with: sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${dbPath}.fixed`)}`,
+					sqliteRepairGuidance(dbPath),
 				{ dbPath, error: String(error) },
 			);
 		} else {

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -11,6 +11,7 @@ import {
 import { AsyncDrain, getAgentDbPath, getStatsDbPath, isRecord, logger } from "@oh-my-pi/pi-utils";
 import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
+import { configureSqliteDatabase, openSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import type { RawSettings as Settings } from "../config/settings";
 
 /** Row shape for settings table queries */
@@ -215,11 +216,8 @@ ON CONFLICT(model_key) DO UPDATE SET
 		// `PRAGMA journal_mode=WAL`, which acquires an exclusive lock during WAL
 		// recovery). Without this, concurrent omp startups can crash here with
 		// `SQLITE_BUSY` / `SQLITE_BUSY_RECOVERY`. See issue #2421.
-		this.#db.run("PRAGMA busy_timeout = 5000");
+		configureSqliteDatabase(this.#db, { wal: true, synchronousNormal: true });
 		this.#db.run(`
-PRAGMA journal_mode=WAL;
-PRAGMA synchronous=NORMAL;
-
 CREATE TABLE IF NOT EXISTS model_usage (
 	model_key TEXT PRIMARY KEY,
 	last_used_at INTEGER NOT NULL DEFAULT (${SQLITE_NOW_EPOCH})
@@ -584,9 +582,8 @@ FROM model_usage_legacy
 	 * @throws When the stats db cannot be opened or queried
 	 */
 	async backfillModelPerfFromStats(statsDbPath: string): Promise<number> {
-		const statsDb = new Database(statsDbPath, { readonly: true });
+		const statsDb = openSqliteDatabase(statsDbPath, { readonly: true });
 		try {
-			statsDb.run("PRAGMA busy_timeout = 5000");
 			const select = statsDb.prepare(
 				`SELECT rowid, timestamp, provider, model, output_tokens, duration, ttft
 FROM messages

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -11,7 +11,7 @@ import {
 import { AsyncDrain, getAgentDbPath, getStatsDbPath, isRecord, logger } from "@oh-my-pi/pi-utils";
 import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
-import { configureSqliteDatabase, openSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
+import { configureSqliteDatabase, isSqliteCorruptError, openSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import type { RawSettings as Settings } from "../config/settings";
 
 /** Row shape for settings table queries */
@@ -146,6 +146,8 @@ export class AgentStorage {
 	#perfBackfillChecked = false;
 	/** Coalesces per-turn perf samples into one deferred transaction off the turn's hot path. */
 	#perfDrain = new AsyncDrain<ModelPerfInsert>(MODEL_PERF_FLUSH_DELAY_MS);
+	/** Latched once the stats.db reader reports unrecoverable damage; backfill is skipped for the rest of this process. */
+	#statsDbDamaged = false;
 
 	private constructor(dbPath: string) {
 		this.#autoPerfBackfill = dbPath === getAgentDbPath();
@@ -582,8 +584,12 @@ FROM model_usage_legacy
 	 * @throws When the stats db cannot be opened or queried
 	 */
 	async backfillModelPerfFromStats(statsDbPath: string): Promise<number> {
-		const statsDb = openSqliteDatabase(statsDbPath, { readonly: true });
+		if (this.#statsDbDamaged) return 0;
+		let statsDb: Database | undefined;
+		let sums: Map<string, PerfAccum>;
+		let imported = 0;
 		try {
+			statsDb = openSqliteDatabase(statsDbPath, { readonly: true });
 			const select = statsDb.prepare(
 				`SELECT rowid, timestamp, provider, model, output_tokens, duration, ttft
 FROM messages
@@ -594,11 +600,10 @@ ORDER BY timestamp DESC, rowid DESC
 LIMIT ?4`,
 			);
 			const cutoff = Date.now() - MODEL_PERF_BACKFILL_MAX_AGE_MS;
-			const sums = new Map<string, PerfAccum>();
+			sums = new Map<string, PerfAccum>();
 			let cursorTimestamp = Number.MAX_SAFE_INTEGER;
 			let cursorRowid = Number.MAX_SAFE_INTEGER;
 			let scanned = 0;
-			let imported = 0;
 			while (scanned < MODEL_PERF_BACKFILL_MAX_ROWS) {
 				const chunk = Math.min(MODEL_PERF_BACKFILL_CHUNK, MODEL_PERF_BACKFILL_MAX_ROWS - scanned);
 				const rows = select.all(cursorTimestamp, cursorRowid, cutoff, chunk) as StatsMessageRow[];
@@ -632,9 +637,26 @@ LIMIT ?4`,
 				// Yield so a chunked walk never freezes the TUI (bun:sqlite is sync).
 				await Bun.sleep(0);
 			}
-			if (sums.size > 0) {
-				const upsert = this.#db.prepare(
-					`INSERT INTO model_perf (model_key, samples, output_tokens, gen_ms, ttft_samples, ttft_ms, updated_at)
+		} catch (err) {
+			if (isSqliteCorruptError(err)) {
+				this.#statsDbDamaged = true;
+				logger.error(
+					`Stats database is damaged; model-perf backfill is disabled for this process. ` +
+						`Repair with: sqlite3 '${statsDbPath}' '.recover' | sqlite3 '${statsDbPath}.fixed'`,
+					{ err, statsDbPath },
+				);
+				return 0;
+			}
+			throw err;
+		} finally {
+			statsDb?.close();
+		}
+		// The destination transaction runs OUTSIDE the stats-db catch so a
+		// corrupt agent.db (this.#db) propagates to the caller's existing warn
+		// instead of being mislabelled as a damaged stats.db.
+		if (sums && sums.size > 0) {
+			const upsert = this.#db.prepare(
+				`INSERT INTO model_perf (model_key, samples, output_tokens, gen_ms, ttft_samples, ttft_ms, updated_at)
 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ${SQLITE_NOW_EPOCH})
 ON CONFLICT(model_key) DO UPDATE SET
 	samples = model_perf.samples + excluded.samples,
@@ -643,17 +665,14 @@ ON CONFLICT(model_key) DO UPDATE SET
 	ttft_samples = model_perf.ttft_samples + excluded.ttft_samples,
 	ttft_ms = model_perf.ttft_ms + excluded.ttft_ms,
 	updated_at = ${SQLITE_NOW_EPOCH}`,
-				);
-				this.#db.transaction(() => {
-					for (const [key, accum] of sums) {
-						upsert.run(key, accum.samples, accum.outputTokens, accum.genMs, accum.ttftSamples, accum.ttftMs);
-					}
-				})();
-			}
-			return imported;
-		} finally {
-			statsDb.close();
+			);
+			this.#db.transaction(() => {
+				for (const [key, accum] of sums) {
+					upsert.run(key, accum.samples, accum.outputTokens, accum.genMs, accum.ttftSamples, accum.ttftMs);
+				}
+			})();
 		}
+		return imported;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -165,6 +165,9 @@ export class AgentStorage {
 		try {
 			this.#initializeSchema();
 		} catch (err) {
+			// The instance never escapes a throwing constructor; close the
+			// handle here or the damaged file stays open until GC.
+			this.#db.close();
 			if (isSqliteCorruptError(err)) {
 				throw new Error(
 					`Agent database at ${shellQuote(dbPath)} is damaged. Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${dbPath}.fixed`)} && chmod 600 ${shellQuote(`${dbPath}.fixed`)}`,

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -146,8 +146,8 @@ export class AgentStorage {
 	#perfBackfillChecked = false;
 	/** Coalesces per-turn perf samples into one deferred transaction off the turn's hot path. */
 	#perfDrain = new AsyncDrain<ModelPerfInsert>(MODEL_PERF_FLUSH_DELAY_MS);
-	/** Latched once the stats.db reader reports unrecoverable damage; backfill is skipped for the rest of this process. */
-	#statsDbDamaged = false;
+	/** Per-path latch: stats.db paths that reported unrecoverable corruption. Backfill is skipped for each latched path, but a different valid path still imports. */
+	#statsDbDamagedPaths = new Set<string>();
 
 	private constructor(dbPath: string) {
 		this.#autoPerfBackfill = dbPath === getAgentDbPath();
@@ -555,6 +555,7 @@ FROM model_usage_legacy
 			if (!fs.existsSync(statsDbPath)) return;
 			void this.backfillModelPerfFromStats(statsDbPath)
 				.then(imported => {
+					if (imported < 0) return;
 					this.#db
 						.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)")
 						.run(MODEL_PERF_BACKFILL_KEY, "complete");
@@ -580,11 +581,11 @@ FROM model_usage_legacy
 	 * Sums land in one additive transaction at the end, so concurrent live
 	 * samples merge correctly regardless of order.
 	 * @param statsDbPath - Path to a stats.db file; opened read-only
-	 * @returns Number of rows folded in
-	 * @throws When the stats db cannot be opened or queried
+	 * @returns Number of rows folded in, or `-1` when the source store is damaged/latched (the import is skipped and the persistent completion marker must NOT be written so a later repair retries)
+	 * @throws When the stats db cannot be opened or queried for a non-corrupt reason
 	 */
 	async backfillModelPerfFromStats(statsDbPath: string): Promise<number> {
-		if (this.#statsDbDamaged) return 0;
+		if (this.#statsDbDamagedPaths.has(statsDbPath)) return -1;
 		let statsDb: Database | undefined;
 		let sums: Map<string, PerfAccum>;
 		let imported = 0;
@@ -639,13 +640,13 @@ LIMIT ?4`,
 			}
 		} catch (err) {
 			if (isSqliteCorruptError(err)) {
-				this.#statsDbDamaged = true;
+				this.#statsDbDamagedPaths.add(statsDbPath);
 				logger.error(
-					`Stats database is damaged; model-perf backfill is disabled for this process. ` +
+					`Stats database is damaged; model-perf backfill is disabled for this path. ` +
 						`Repair with: sqlite3 '${statsDbPath}' '.recover' | sqlite3 '${statsDbPath}.fixed'`,
 					{ err, statsDbPath },
 				);
-				return 0;
+				return -1;
 			}
 			throw err;
 		} finally {

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -10,7 +10,12 @@ import {
 } from "@oh-my-pi/pi-ai";
 import { AsyncDrain, getAgentDbPath, getStatsDbPath, isRecord, logger } from "@oh-my-pi/pi-utils";
 import { shellQuote } from "@oh-my-pi/pi-utils/shell";
-import { configureSqliteDatabase, isSqliteCorruptError, openSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
+import {
+	configureSqliteDatabase,
+	isSqliteCorruptError,
+	openSqliteDatabase,
+	sqliteRepairGuidance,
+} from "@oh-my-pi/pi-utils/sqlite";
 import type { RawSettings as Settings } from "../config/settings";
 
 /** Row shape for settings table queries */
@@ -172,7 +177,7 @@ export class AgentStorage {
 			this.#db.close();
 			if (isSqliteCorruptError(err)) {
 				throw new Error(
-					`Agent database at ${shellQuote(dbPath)} is damaged. Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${dbPath}.fixed`)} && chmod 600 ${shellQuote(`${dbPath}.fixed`)}`,
+					`Agent database at ${shellQuote(dbPath)} is damaged. ${sqliteRepairGuidance(dbPath, { restrictPermissions: true })}`,
 					{ cause: err },
 				);
 			}
@@ -642,7 +647,7 @@ LIMIT ?4`,
 				this.#statsDbDamagedPaths.add(statsDbPath);
 				logger.error(
 					`Stats database is damaged; model-perf backfill is disabled for this path. ` +
-						`Repair with: sqlite3 ${shellQuote(statsDbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${statsDbPath}.fixed`)}`,
+						sqliteRepairGuidance(statsDbPath),
 					{ err, statsDbPath },
 				);
 				return -1;

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -642,7 +642,7 @@ LIMIT ?4`,
 				this.#statsDbDamagedPaths.add(statsDbPath);
 				logger.error(
 					`Stats database is damaged; model-perf backfill is disabled for this path. ` +
-						`Repair with: sqlite3 '${statsDbPath}' '.recover' | sqlite3 '${statsDbPath}.fixed'`,
+						`Repair with: sqlite3 ${shellQuote(statsDbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${statsDbPath}.fixed`)}`,
 					{ err, statsDbPath },
 				);
 				return -1;

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -9,6 +9,8 @@ import {
 	type StoredAuthCredential,
 } from "@oh-my-pi/pi-ai";
 import { AsyncDrain, getAgentDbPath, getStatsDbPath, isRecord, logger } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
+import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import type { RawSettings as Settings } from "../config/settings";
 
 /** Row shape for settings table queries */
@@ -160,7 +162,17 @@ export class AgentStorage {
 			);
 		}
 
-		this.#initializeSchema();
+		try {
+			this.#initializeSchema();
+		} catch (err) {
+			if (isSqliteCorruptError(err)) {
+				throw new Error(
+					`Agent database at ${shellQuote(dbPath)} is damaged. Stop omp, back up the store (including -wal/-shm), then repair with: sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${dbPath}.fixed`)} && chmod 600 ${shellQuote(`${dbPath}.fixed`)}`,
+					{ cause: err },
+				);
+			}
+			throw err;
+		}
 		this.#hardenPermissions(dbPath);
 
 		// Create AuthCredentialStore with our open database

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -164,7 +164,7 @@ export class AgentStorage {
 		this.#hardenPermissions(dbPath);
 
 		// Create AuthCredentialStore with our open database
-		this.#authStore = new SqliteAuthCredentialStore(this.#db);
+		this.#authStore = new SqliteAuthCredentialStore(this.#db, dbPath);
 
 		this.#listSettingsStmt = this.#db.prepare("SELECT key, value FROM settings");
 		this.#upsertModelUsageStmt = this.#db.prepare(

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -10,7 +10,6 @@ import {
 } from "@oh-my-pi/pi-ai";
 import { AsyncDrain, getAgentDbPath, getStatsDbPath, isRecord, logger } from "@oh-my-pi/pi-utils";
 import { shellQuote } from "@oh-my-pi/pi-utils/shell";
-import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import { configureSqliteDatabase, isSqliteCorruptError, openSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import type { RawSettings as Settings } from "../config/settings";
 

--- a/packages/coding-agent/src/session/history-storage.ts
+++ b/packages/coding-agent/src/session/history-storage.ts
@@ -2,6 +2,7 @@ import { Database, type Statement } from "bun:sqlite";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { AsyncDrain, getHistoryDbPath, logger } from "@oh-my-pi/pi-utils";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 
 export interface HistoryEntry {
 	id: number;
@@ -51,13 +52,10 @@ export class HistoryStorage {
 		this.#db = new Database(dbPath);
 
 		// Install the busy handler BEFORE any lock-taking statement. See #2421.
-		this.#db.run("PRAGMA busy_timeout = 5000");
+		configureSqliteDatabase(this.#db, { wal: true, synchronousNormal: true });
 
 		const hasFts = this.#db.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='history_fts'").get();
 		this.#db.run(`
-PRAGMA journal_mode=WAL;
-PRAGMA synchronous=NORMAL;
-
 CREATE TABLE IF NOT EXISTS history (
 	id INTEGER PRIMARY KEY AUTOINCREMENT,
 	prompt TEXT NOT NULL,

--- a/packages/coding-agent/src/ssh/file-transfer.ts
+++ b/packages/coding-agent/src/ssh/file-transfer.ts
@@ -7,8 +7,9 @@
  * and final newlines are preserved.
  */
 import { ptree } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { buildRemoteCommand, ensureConnection, ensureHostInfo, type SSHConnectionTarget } from "./connection-manager";
-import { quotePosixPath, wrapInPosixShell } from "./utils";
+import { wrapInPosixShell } from "./utils";
 
 /** Per-operation timeout for remote transfers (matches the ssh tool's grep window). */
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -73,7 +74,7 @@ export async function readRemoteFile(
 	opts: RemoteFileReadOptions,
 ): Promise<RemoteFileReadResult> {
 	const shell = await ensurePosixRemote(target);
-	const command = `head -c ${opts.maxBytes + 1} ${quotePosixPath(remotePath)}`;
+	const command = `head -c ${opts.maxBytes + 1} ${shellQuote(remotePath)}`;
 	const args = await buildRemoteCommand(target, wrapInPosixShell(shell, command));
 	using child = ptree.spawn(["ssh", ...args], {
 		signal: ptree.combineSignals(opts.signal, opts.timeoutMs ?? DEFAULT_TIMEOUT_MS),
@@ -119,8 +120,8 @@ export async function writeRemoteFile(
 	if (remotePath.endsWith("/")) {
 		throw new Error("ssh://: destination is a directory path (trailing '/'); ssh:// write requires a file path");
 	}
-	const dest = quotePosixPath(remotePath);
-	const tmp = quotePosixPath(`${remotePath}.omp-tmp.${crypto.randomUUID()}`);
+	const dest = shellQuote(remotePath);
+	const tmp = shellQuote(`${remotePath}.omp-tmp.${crypto.randomUUID()}`);
 	// Stage stdin into the temp first (so the remote never blocks on an unread
 	// pipe and a dropped connection lands in the temp, never the destination).
 	// An EXIT trap removes the staged temp on every exit path (staging failure,
@@ -161,7 +162,7 @@ export async function statRemotePath(
 	opts: { signal?: AbortSignal; timeoutMs?: number } = {},
 ): Promise<RemotePathKind> {
 	const shell = await ensurePosixRemote(target);
-	const p = quotePosixPath(remotePath);
+	const p = shellQuote(remotePath);
 	const command = `if [ -d ${p} ]; then echo directory; elif [ -f ${p} ]; then echo file; elif [ -e ${p} ]; then echo other; else echo missing; fi`;
 	const args = await buildRemoteCommand(target, wrapInPosixShell(shell, command));
 	using child = ptree.spawn(["ssh", ...args], {
@@ -194,7 +195,7 @@ export async function listRemoteDir(
 	opts: { signal?: AbortSignal; timeoutMs?: number } = {},
 ): Promise<RemoteDirEntry[]> {
 	const shell = await ensurePosixRemote(target);
-	const command = `LC_ALL=C ls -1Ap -- ${quotePosixPath(remotePath)}`;
+	const command = `LC_ALL=C ls -1Ap -- ${shellQuote(remotePath)}`;
 	const args = await buildRemoteCommand(target, wrapInPosixShell(shell, command));
 	using child = ptree.spawn(["ssh", ...args], {
 		signal: ptree.combineSignals(opts.signal, opts.timeoutMs ?? DEFAULT_TIMEOUT_MS),

--- a/packages/coding-agent/src/ssh/utils.ts
+++ b/packages/coding-agent/src/ssh/utils.ts
@@ -1,3 +1,5 @@
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
+
 export function sanitizeHostName(name: string): string {
 	const sanitized = name.replace(/[^a-zA-Z0-9._-]+/g, "_");
 	return sanitized.length > 0 ? sanitized : "remote";
@@ -22,16 +24,6 @@ export function buildSshTarget(username: string | undefined, host: string): stri
 }
 
 /**
- * Single-quote a path for a POSIX remote shell, escaping embedded single quotes.
- * Mirrors the private `quoteRemotePath` in `tools/ssh.ts`; shared here for the
- * `ssh://` file-transfer helpers.
- */
-export function quotePosixPath(value: string): string {
-	if (value.length === 0) return "''";
-	return `'${value.replace(/'/g, "'\\''")}'`;
-}
-
-/**
  * Wrap a POSIX command in `<shell> -c '<command>'` so it runs under the
  * named shell rather than whatever `$SHELL` happens to be on the remote.
  *
@@ -47,5 +39,5 @@ export function quotePosixPath(value: string): string {
  * `-lc` to mirror the user's real environment.
  */
 export function wrapInPosixShell(shell: "sh" | "bash" | "zsh", command: string): string {
-	return `${shell} -c ${quotePosixPath(command)}`;
+	return `${shell} -c ${shellQuote(command)}`;
 }

--- a/packages/coding-agent/src/tools/bash-skill-urls.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import type { Skill } from "../extensibility/skills";
 import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import { validateRelativePath } from "../internal-urls/skill-protocol";
@@ -217,11 +218,6 @@ function isEmbeddedInQuotedText(command: string, token: string, index: number): 
 	return isInsideShellQuote(command, index);
 }
 
-/** Shell-escape a path using single quotes. */
-function shellEscape(p: string): string {
-	return `'${p.replace(/'/g, "'\\''")}'`;
-}
-
 async function resolveInternalUrlToPath(
 	rawUrl: string,
 	skills: readonly Skill[],
@@ -288,7 +284,7 @@ export function expandSkillUrls(command: string, skills: readonly Skill[]): stri
 	return command.replace(SKILL_URL_PATTERN, token => {
 		const url = unquoteToken(token);
 		const resolvedPath = resolveSkillUrlToPath(url, skills);
-		return shellEscape(resolvedPath);
+		return shellQuote(resolvedPath);
 	});
 }
 
@@ -327,7 +323,7 @@ export async function expandInternalUrls(command: string, options: InternalUrlEx
 		} catch {
 			continue;
 		}
-		const replacement = options.noEscape ? resolvedPath : shellEscape(resolvedPath);
+		const replacement = options.noEscape ? resolvedPath : shellQuote(resolvedPath);
 		expanded = `${expanded.slice(0, index)}${replacement}${expanded.slice(index + token.length)}`;
 	}
 

--- a/packages/coding-agent/src/tools/github-cache.ts
+++ b/packages/coding-agent/src/tools/github-cache.ts
@@ -21,6 +21,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getGithubCacheDbPath, logger } from "@oh-my-pi/pi-utils";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import type { Settings } from "../config/settings";
 import { ToolAbortError } from "./tool-errors";
 
@@ -96,11 +97,7 @@ export function openDb(): Database | null {
 		ensureParentDir(dbPath);
 		const db = new Database(dbPath);
 		// Install the busy handler BEFORE any lock-taking statement. See #2421.
-		db.run("PRAGMA busy_timeout = 5000");
-		db.run(`
-			PRAGMA journal_mode=WAL;
-			PRAGMA synchronous=NORMAL;
-		`);
+		configureSqliteDatabase(db, { wal: true, synchronousNormal: true });
 		// Migrate any pre-existing table whose key/check constraint predates
 		// the current schema. The cache is regenerable, so we drop rows rather
 		// than running an in-place ALTER dance.

--- a/packages/coding-agent/src/tools/report-tool-issue.ts
+++ b/packages/coding-agent/src/tools/report-tool-issue.ts
@@ -36,6 +36,7 @@ import type { FetchImpl } from "@oh-my-pi/pi-ai";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Text } from "@oh-my-pi/pi-tui";
 import { $env, $flag, getAutoQaDbPath, getInstallId, logger, VERSION } from "@oh-my-pi/pi-utils";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import type { Settings } from "..";
 import type { Theme } from "../modes/theme/theme";
 import { renderStatusLine, truncateToWidth } from "../tui";
@@ -266,7 +267,7 @@ export function openAutoQaDb(): Database | null {
 		fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 		const db = new Database(dbPath, { create: true });
 		// Install the busy handler BEFORE any lock-taking statement. See #2421.
-		db.run("PRAGMA busy_timeout = 5000");
+		configureSqliteDatabase(db);
 		db.exec(`
 			CREATE TABLE IF NOT EXISTS grievances (
 				id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/packages/coding-agent/src/utils/shell-snapshot.ts
+++ b/packages/coding-agent/src/utils/shell-snapshot.ts
@@ -9,6 +9,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { logger, postmortem } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import fnEnvHelper from "./shell-snapshot-fn-env.sh" with { type: "text" };
 
 const cachedSnapshotPaths = new Map<string, string>();
@@ -107,9 +108,6 @@ function generateSnapshotScript(shell: string, snapshotPath: string, rcFile: str
 	const commonToolsRegex =
 		"^(ls|dir|vdir|cat|head|tail|less|more|grep|egrep|fgrep|rg|find|fd|locate|sed|awk|perl|cp|mv|rm|mkdir|rmdir|touch|chmod|chown|ln|pwd|readlink|stat|cut|sort|uniq|xargs|tee|tr|basename|dirname)$";
 
-	// Escape the snapshot path for shell
-	const escapedPath = snapshotPath.replace(/'/g, "'\\''");
-
 	// Function extraction differs between bash and zsh. Each form prints function
 	// bodies on stdout so we can both persist them AND scan their bodies for
 	// referenced env vars (issue #3470).
@@ -141,7 +139,7 @@ echo "shopt -s expand_aliases" >> "$SNAPSHOT_FILE"
 `;
 
 	return `
-SNAPSHOT_FILE='${escapedPath}'
+SNAPSHOT_FILE=${shellQuote(snapshotPath)}
 
 # Snapshot may inline env-var values referenced by captured functions (#3470).
 # Defence in depth: (a) JS caller pre-creates the file at 0600 so the shell's

--- a/packages/coding-agent/test/agent-storage-corrupt-store.test.ts
+++ b/packages/coding-agent/test/agent-storage-corrupt-store.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import { removeWithRetries } from "../../utils/src/temp";
+
+describe("AgentStorage corrupt-store schema init guidance", () => {
+	afterEach(() => {
+		AgentStorage.resetInstance();
+	});
+
+	it("F4: throws .recover guidance with the path when agent.db is malformed", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-agent-storage-corrupt-"));
+		try {
+			const dbPath = path.join(dir, "agent.db");
+			// Write a deterministic malformed SQLite source — bytes that are not a
+			// valid SQLite database — so #initializeSchema's PRAGMA/integrity calls
+			// throw a real SQLITE_NOTADB error before the credential store is built.
+			await fs.writeFile(dbPath, "this is not a sqlite database");
+
+			let thrown: unknown;
+			try {
+				await AgentStorage.open(dbPath);
+			} catch (err) {
+				thrown = err;
+			}
+			expect(thrown).toBeDefined();
+			const message = thrown instanceof Error ? thrown.message : String(thrown);
+			expect(message).toContain(".recover --ignore-freelist");
+			expect(message).toContain(dbPath);
+			expect(message).toContain("chmod 600");
+		} finally {
+			await removeWithRetries(dir);
+		}
+	});
+});

--- a/packages/coding-agent/test/agent-storage-corrupt-store.test.ts
+++ b/packages/coding-agent/test/agent-storage-corrupt-store.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import { sqliteRepairGuidance } from "@oh-my-pi/pi-utils/sqlite";
 import { removeWithRetries } from "../../utils/src/temp";
 
 describe("AgentStorage corrupt-store schema init guidance", () => {
@@ -27,9 +28,7 @@ describe("AgentStorage corrupt-store schema init guidance", () => {
 			}
 			expect(thrown).toBeDefined();
 			const message = thrown instanceof Error ? thrown.message : String(thrown);
-			expect(message).toContain(".recover --ignore-freelist");
-			expect(message).toContain(dbPath);
-			expect(message).toContain("chmod 600");
+			expect(message).toContain(sqliteRepairGuidance(dbPath, { restrictPermissions: true }));
 		} finally {
 			await removeWithRetries(dir);
 		}

--- a/packages/coding-agent/test/agent-storage-model-perf.test.ts
+++ b/packages/coding-agent/test/agent-storage-model-perf.test.ts
@@ -5,6 +5,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { getAgentDbPath, getAgentDir, getStatsDbPath, logger, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 
 describe("AgentStorage model perf aggregates", () => {
 	let tempDir: TempDir;
@@ -186,6 +187,11 @@ describe("AgentStorage model perf aggregates", () => {
 		);
 		expect(damagedErrors).toHaveLength(1);
 		expect(String(damagedErrors[0]?.[0])).toContain(statsDbPath);
+		// The repair command shell-quotes the path and uses --ignore-freelist.
+		expect(String(damagedErrors[0]?.[0])).toContain(
+			`sqlite3 ${shellQuote(statsDbPath)} '.recover --ignore-freelist'`,
+		);
+		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 ${shellQuote(`${statsDbPath}.fixed`)}`);
 	});
 
 	it("does not mark the backfill complete when stats.db is corrupt, and a different valid path still imports", async () => {

--- a/packages/coding-agent/test/agent-storage-model-perf.test.ts
+++ b/packages/coding-agent/test/agent-storage-model-perf.test.ts
@@ -1,9 +1,10 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
-import { logger, TempDir } from "@oh-my-pi/pi-utils";
+import { getAgentDbPath, getAgentDir, getStatsDbPath, logger, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 
 describe("AgentStorage model perf aggregates", () => {
 	let tempDir: TempDir;
@@ -163,7 +164,7 @@ describe("AgentStorage model perf aggregates", () => {
 		expect(stats?.tps).toBeCloseTo(100, 5);
 	});
 
-	it("latches after one corrupt stats.db and returns 0 without re-opening", async () => {
+	it("latches after one corrupt stats.db and returns -1 without re-opening", async () => {
 		const storage = await openStorage();
 
 		// Write a malformed stats.db — bytes that are not a valid SQLite file.
@@ -174,17 +175,89 @@ describe("AgentStorage model perf aggregates", () => {
 
 		// First call hits the malformed file, throws SQLITE_NOTADB, and latches.
 		const imported1 = await storage.backfillModelPerfFromStats(statsDbPath);
-		expect(imported1).toBe(0);
+		expect(imported1).toBe(-1);
 
 		// Second call short-circuits before touching SQLite.
 		const imported2 = await storage.backfillModelPerfFromStats(statsDbPath);
-		expect(imported2).toBe(0);
+		expect(imported2).toBe(-1);
 
 		const damagedErrors = errorSpy.mock.calls.filter(
 			call => typeof call[0] === "string" && call[0].includes("Stats database is damaged"),
 		);
 		expect(damagedErrors).toHaveLength(1);
 		expect(String(damagedErrors[0]?.[0])).toContain(statsDbPath);
+	});
+
+	it("does not mark the backfill complete when stats.db is corrupt, and a different valid path still imports", async () => {
+		// This exercises the full kick path (#kickModelPerfBackfill): the
+		// persistent completion marker must NOT be written when the source
+		// store is corrupt (returns -1), so a later repair retries. It also
+		// proves the per-path latch: corruption in one stats path does not
+		// suppress backfill against a different valid path.
+		const configRoot = TempDir.createSync("@omp-perf-marker-config-");
+		const agentDir = TempDir.createSync("@omp-perf-marker-agent-");
+
+		// Redirect both getAgentDbPath() and getStatsDbPath() into temp dirs.
+		// PI_CONFIG_DIR (absolute) overrides the config root; setAgentDir
+		// rebuilds the resolver so getAgentDbPath() resolves under agentDir.
+		const prevConfigDir = process.env.PI_CONFIG_DIR;
+		process.env.PI_CONFIG_DIR = configRoot.path();
+		const prevAgentDir = getAgentDir();
+		setAgentDir(agentDir.path());
+		AgentStorage.resetInstance();
+		try {
+			// Corrupt stats.db at the redirected stats path.
+			const statsDbPath = getStatsDbPath();
+			fsSync.mkdirSync(path.dirname(statsDbPath), { recursive: true });
+			fsSync.writeFileSync(statsDbPath, "this is not a sqlite database");
+
+			const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+			// Open at the default agent path so #autoPerfBackfill is true.
+			const agentDbPath = getAgentDbPath();
+			const storage = await AgentStorage.open(agentDbPath);
+
+			// Trigger the kick via getModelPerf(); the backfill promise fires
+			// synchronously (corrupt db throws before any await), so the .then
+			// microtask drains after one microtask tick.
+			storage.getModelPerf();
+			await Promise.resolve();
+
+			// The corrupt-latch error must have fired.
+			const damagedErrors = errorSpy.mock.calls.filter(
+				call => typeof call[0] === "string" && call[0].includes("Stats database is damaged"),
+			);
+			expect(damagedErrors).toHaveLength(1);
+
+			// The completion marker must NOT be written — meta stays empty.
+			const probe = new Database(agentDbPath);
+			const marker = probe.prepare("SELECT value FROM meta WHERE key = ?").get("model_perf_backfill") as {
+				value?: string;
+			} | null;
+			probe.close();
+			expect(marker).toBeNull();
+
+			// Per-path latch: a different valid stats path still imports.
+			const validStatsPath = path.join(configRoot.path(), "valid-stats.db");
+			const validStats = new Database(validStatsPath);
+			validStats.run(`CREATE TABLE messages (
+				provider TEXT, model TEXT, output_tokens INTEGER, duration INTEGER,
+				ttft INTEGER, stop_reason TEXT, timestamp INTEGER
+			)`);
+			validStats
+				.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?)")
+				.run("openai", "gpt-5", 1000, 4000, null, "stop", Date.now() - 1000);
+			validStats.close();
+
+			const imported = await storage.backfillModelPerfFromStats(validStatsPath);
+			expect(imported).toBe(1);
+			const gpt = storage.getModelPerf().get("openai/gpt-5");
+			expect(gpt?.samples).toBe(1);
+		} finally {
+			AgentStorage.resetInstance();
+			process.env.PI_CONFIG_DIR = prevConfigDir;
+			setAgentDir(prevAgentDir);
+		}
 	});
 
 	it("propagates destination-side transaction failure without latching or mislabelling the stats path", async () => {

--- a/packages/coding-agent/test/agent-storage-model-perf.test.ts
+++ b/packages/coding-agent/test/agent-storage-model-perf.test.ts
@@ -1,14 +1,15 @@
 import { Database } from "bun:sqlite";
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { logger, TempDir } from "@oh-my-pi/pi-utils";
 
 describe("AgentStorage model perf aggregates", () => {
 	let tempDir: TempDir;
 
 	afterEach(async () => {
-		AgentStorage.resetInstance();
+		vi.restoreAllMocks();
 		if (tempDir) {
 			try {
 				await tempDir.remove();
@@ -160,5 +161,76 @@ describe("AgentStorage model perf aggregates", () => {
 		const stats = storage.getModelPerf().get("openai/gpt-5");
 		expect(stats?.samples).toBe(256);
 		expect(stats?.tps).toBeCloseTo(100, 5);
+	});
+
+	it("latches after one corrupt stats.db and returns 0 without re-opening", async () => {
+		const storage = await openStorage();
+
+		// Write a malformed stats.db — bytes that are not a valid SQLite file.
+		const statsDbPath = path.join(tempDir.path(), "malformed-stats.db");
+		await fs.writeFile(statsDbPath, "this is not a sqlite database");
+
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// First call hits the malformed file, throws SQLITE_NOTADB, and latches.
+		const imported1 = await storage.backfillModelPerfFromStats(statsDbPath);
+		expect(imported1).toBe(0);
+
+		// Second call short-circuits before touching SQLite.
+		const imported2 = await storage.backfillModelPerfFromStats(statsDbPath);
+		expect(imported2).toBe(0);
+
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Stats database is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+		expect(String(damagedErrors[0]?.[0])).toContain(statsDbPath);
+	});
+
+	it("propagates destination-side transaction failure without latching or mislabelling the stats path", async () => {
+		const storage = await openStorage();
+
+		// Valid stats.db with one measurable row so the backfill reaches the
+		// destination transaction.
+		const statsDbPath = path.join(tempDir.path(), "stats.db");
+		const statsDb = new Database(statsDbPath);
+		statsDb.run(`CREATE TABLE messages (
+			provider TEXT, model TEXT, output_tokens INTEGER, duration INTEGER,
+			ttft INTEGER, stop_reason TEXT, timestamp INTEGER
+		)`);
+		statsDb
+			.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?)")
+			.run("openai", "gpt-5", 1000, 4000, null, "stop", Date.now() - 1000);
+		statsDb.close();
+
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// Make the DESTINATION db's transaction throw a corrupt error. The
+		// stats read path does not call .transaction(), so this spy only
+		// fires when the backfill writes into agent.db.
+		const corruptDestError = new Error("SQLITE_CORRUPT: destination agent.db is damaged") as Error & {
+			code: string;
+		};
+		corruptDestError.code = "SQLITE_CORRUPT";
+		const txSpy = vi.spyOn(Database.prototype, "transaction").mockImplementation(() => {
+			throw corruptDestError;
+		});
+
+		// The destination failure must propagate — not be swallowed into the
+		// stats-db latch.
+		await expect(storage.backfillModelPerfFromStats(statsDbPath)).rejects.toThrow("SQLITE_CORRUPT");
+
+		// No error log naming the stats path — the latch is for stats.db only.
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Stats database is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(0);
+
+		// The stats latch was NOT set: a second call must still reach the
+		// stats read (and fail again at the destination), not short-circuit.
+		await expect(storage.backfillModelPerfFromStats(statsDbPath)).rejects.toThrow("SQLITE_CORRUPT");
+
+		txSpy.mockRestore();
+		errorSpy.mockRestore();
 	});
 });

--- a/packages/coding-agent/test/agent-storage-model-perf.test.ts
+++ b/packages/coding-agent/test/agent-storage-model-perf.test.ts
@@ -5,7 +5,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { getAgentDbPath, getAgentDir, getStatsDbPath, logger, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
-import { shellQuote } from "@oh-my-pi/pi-utils/shell";
+import { sqliteRepairGuidance } from "@oh-my-pi/pi-utils/sqlite";
 
 describe("AgentStorage model perf aggregates", () => {
 	let tempDir: TempDir;
@@ -190,11 +190,7 @@ describe("AgentStorage model perf aggregates", () => {
 		);
 		expect(damagedErrors).toHaveLength(1);
 		expect(String(damagedErrors[0]?.[0])).toContain(statsDbPath);
-		// The repair command shell-quotes the path and uses --ignore-freelist.
-		expect(String(damagedErrors[0]?.[0])).toContain(
-			`sqlite3 ${shellQuote(statsDbPath)} '.recover --ignore-freelist'`,
-		);
-		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 ${shellQuote(`${statsDbPath}.fixed`)}`);
+		expect(String(damagedErrors[0]?.[0])).toContain(sqliteRepairGuidance(statsDbPath));
 	});
 
 	it("does not mark the backfill complete when stats.db is corrupt, and a different valid path still imports", async () => {
@@ -264,9 +260,11 @@ describe("AgentStorage model perf aggregates", () => {
 			expect(gpt?.samples).toBe(1);
 		} finally {
 			AgentStorage.resetInstance();
-			process.env.PI_CONFIG_DIR = prevConfigDir;
+			if (prevConfigDir === undefined) delete process.env.PI_CONFIG_DIR;
+			else process.env.PI_CONFIG_DIR = prevConfigDir;
 			setAgentDir(prevAgentDir);
 		}
+		expect(process.env.PI_CONFIG_DIR).toBe(prevConfigDir);
 	});
 
 	it("propagates destination-side transaction failure without latching or mislabelling the stats path", async () => {

--- a/packages/coding-agent/test/agent-storage-model-perf.test.ts
+++ b/packages/coding-agent/test/agent-storage-model-perf.test.ts
@@ -12,6 +12,10 @@ describe("AgentStorage model perf aggregates", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
+		// Close singleton handles BEFORE removing the temp dir so later
+		// default-path reads don't miss a stale, closed handle left in the
+		// instances map by a unique temp path that no longer exists.
+		AgentStorage.resetInstance();
 		if (tempDir) {
 			try {
 				await tempDir.remove();
@@ -19,7 +23,6 @@ describe("AgentStorage model perf aggregates", () => {
 			tempDir = undefined as unknown as TempDir;
 		}
 	});
-
 	async function openStorage(): Promise<AgentStorage> {
 		tempDir = TempDir.createSync("@omp-agent-storage-perf-");
 		return AgentStorage.open(path.join(tempDir.path(), "agent.db"));

--- a/packages/coding-agent/test/autoresearch-state.test.ts
+++ b/packages/coding-agent/test/autoresearch-state.test.ts
@@ -1,3 +1,4 @@
+import { type Changes, Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { createAutoresearchExtension } from "@oh-my-pi/pi-coding-agent/autoresearch";
 import {
@@ -17,6 +18,8 @@ import type {
 } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
 import { TempDir } from "@oh-my-pi/pi-utils";
+
+const EMPTY_CHANGES: Changes = { changes: 0, lastInsertRowid: 0 };
 
 afterEach(() => {
 	vi.restoreAllMocks();
@@ -365,6 +368,30 @@ describe("AutoresearchStorage round-trip", () => {
 		storage.updateSession(session.id, { notes: "## Plan\n- step 1\n" });
 		expect(storage.getSessionById(session.id)?.notes).toBe("## Plan\n- step 1\n");
 		storage.close();
+	});
+
+	it("enables foreign_keys via the shared configurator (not hand-run pragmas)", () => {
+		// After the wave-1 centralization, SCHEMA_SQL no longer hand-runs
+		// PRAGMA foreign_keys=ON; the constructor passes { foreignKeys: true }
+		// to configureSqliteDatabase. Capture every run() call during
+		// construction and verify the pragma is issued by the configurator.
+		const statements: string[] = [];
+		const runSpy = vi.spyOn(Database.prototype, "run").mockImplementation(function (
+			this: Database,
+			sql: string,
+		): Changes {
+			statements.push(sql);
+			return EMPTY_CHANGES;
+		});
+		const storage = openStorage();
+		runSpy.mockRestore();
+		storage.close();
+		// foreign_keys is issued by configureSqliteDatabase, not SCHEMA_SQL.
+		expect(statements).toContain("PRAGMA foreign_keys = ON");
+		// SCHEMA_SQL must no longer contain hand-run pragmas.
+		const schemaStatements = statements.filter(s => /PRAGMA (journal_mode|synchronous|foreign_keys)/i.test(s));
+		// The only foreign_keys pragma is the one from the configurator.
+		expect(schemaStatements.filter(s => /foreign_keys/i.test(s))).toHaveLength(1);
 	});
 });
 

--- a/packages/coding-agent/test/autoresearch-state.test.ts
+++ b/packages/coding-agent/test/autoresearch-state.test.ts
@@ -393,6 +393,26 @@ describe("AutoresearchStorage round-trip", () => {
 		// The only foreign_keys pragma is the one from the configurator.
 		expect(schemaStatements.filter(s => /foreign_keys/i.test(s))).toHaveLength(1);
 	});
+
+	it("enforces foreign keys on the live connection (observable)", () => {
+		// Observable contract: a run referencing a non-existent session must be
+		// rejected by the foreign-key constraint. This proves PRAGMA foreign_keys
+		// is actually ON on the connection — not merely that the pragma string
+		// was issued during construction. The wiring spy test above would pass
+		// even if foreign keys were never enabled; this one cannot.
+		const storage = openStorage();
+		expect(() =>
+			storage.insertRun({
+				sessionId: 999999,
+				segment: 0,
+				command: "bun bench",
+				logPath: "/tmp/run.log",
+				preRunDirtyPaths: [],
+				startedAt: 1,
+			}),
+		).toThrow(/FOREIGN KEY|foreign key|constraint/i);
+		storage.close();
+	});
 });
 
 describe("autoresearch control state", () => {

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -15,6 +15,7 @@ import * as shellSnapshot from "@oh-my-pi/pi-coding-agent/utils/shell-snapshot";
 import type { Shell, ShellRunResult } from "@oh-my-pi/pi-natives";
 import * as piNatives from "@oh-my-pi/pi-natives";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 
 // Matches the schema default for `tools.artifactHeadBytes` (20 KB) used by
 // OutputSink when bash-executor pulls settings via resolveOutputSinkHeadBytes.
@@ -31,10 +32,6 @@ const KILL_REACT_MS = 50; // > one poll interval: a survivor would write its mar
 
 function makeTempDir(): string {
 	return fs.mkdtempSync(path.join(os.tmpdir(), "omp-bash-exec-"));
-}
-
-function shellQuote(value: string): string {
-	return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 function configureBashUserShell(homeDir: string): boolean {

--- a/packages/coding-agent/test/eval/py/runner-shell-output.test.ts
+++ b/packages/coding-agent/test/eval/py/runner-shell-output.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 
 interface RunnerFrame {
 	type?: string;
@@ -12,10 +13,6 @@ const pythonPath = Bun.env.PYTHON ?? "python3";
 const runnerPath = path.resolve(import.meta.dir, "../../../src/eval/py/runner.py");
 const repoRoot = path.resolve(import.meta.dir, "../../../../..");
 const encoder = new TextEncoder();
-
-function shellQuote(value: string): string {
-	return `'${value.replaceAll("'", `'"'"'`)}'`;
-}
 
 async function runCell(code: string): Promise<RunnerFrame[]> {
 	const proc = Bun.spawn([pythonPath, "-u", runnerPath], {

--- a/packages/coding-agent/test/mnemopi-bank-derivation.test.ts
+++ b/packages/coding-agent/test/mnemopi-bank-derivation.test.ts
@@ -9,7 +9,7 @@ import {
 	resetLegacyBankCorruptLatchForTests,
 } from "@oh-my-pi/pi-coding-agent/mnemopi/config";
 import { logger, removeWithRetries, TempDir } from "@oh-my-pi/pi-utils";
-import { shellQuote } from "@oh-my-pi/pi-utils/shell";
+import { sqliteRepairGuidance } from "@oh-my-pi/pi-utils/sqlite";
 
 // Set up a fixture filesystem we can reuse across the two regression
 // suites — same shape as `~/.omp/memories/mnemopi/` on a real install.
@@ -151,6 +151,36 @@ describe("extendRecallWithLegacyBanks edge cases", () => {
 		expect(out).toContain("active");
 		expect(out).not.toContain("corrupt-C");
 	});
+
+	it("bounds the total scan time when legacy banks are exclusively locked", () => {
+		const lockedBanks: Database[] = [];
+		const suffix = crypto.randomUUID();
+		try {
+			for (let index = 0; index < 3; index++) {
+				const bank = `aaa-locked-${suffix}-${index}`;
+				createBankFixture(bank, [{ cwd: path.join(rootDir.path(), "projects", "locked") }]);
+				const db = new Database(path.join(banksDir, bank, "mnemopi.db"));
+				db.exec("BEGIN EXCLUSIVE");
+				lockedBanks.push(db);
+			}
+
+			const started = performance.now();
+			const extended = extendRecallWithLegacyBanks(
+				["active"],
+				mainDbPath,
+				path.join(rootDir.path(), "projects", "locked"),
+			);
+			const elapsedMs = performance.now() - started;
+
+			expect(extended).toEqual(["active"]);
+			expect(elapsedMs).toBeLessThan(5000);
+		} finally {
+			for (const db of lockedBanks) {
+				db.exec("ROLLBACK");
+				db.close();
+			}
+		}
+	});
 });
 
 describe("bankOnlyHasCwd corrupt-store latch", () => {
@@ -184,11 +214,7 @@ describe("bankOnlyHasCwd corrupt-store latch", () => {
 		);
 		expect(damagedErrors).toHaveLength(1);
 		expect(String(damagedErrors[0]?.[0])).toContain(corruptDbPath);
-		// The repair command shell-quotes the path and uses --ignore-freelist.
-		expect(String(damagedErrors[0]?.[0])).toContain(
-			`sqlite3 ${shellQuote(corruptDbPath)} '.recover --ignore-freelist'`,
-		);
-		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 ${shellQuote(`${corruptDbPath}.fixed`)}`);
+		expect(String(damagedErrors[0]?.[0])).toContain(sqliteRepairGuidance(corruptDbPath));
 
 		// Non-corrupt errors still use debug, not error.
 		const legacyDebugs = debugSpy.mock.calls.filter(

--- a/packages/coding-agent/test/mnemopi-bank-derivation.test.ts
+++ b/packages/coding-agent/test/mnemopi-bank-derivation.test.ts
@@ -1,10 +1,14 @@
 import { Database } from "bun:sqlite";
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { mkdirSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { computeMnemopiBankScope, extendRecallWithLegacyBanks } from "@oh-my-pi/pi-coding-agent/mnemopi/config";
-import { removeWithRetries, TempDir } from "@oh-my-pi/pi-utils";
+import {
+	computeMnemopiBankScope,
+	extendRecallWithLegacyBanks,
+	resetLegacyBankCorruptLatchForTests,
+} from "@oh-my-pi/pi-coding-agent/mnemopi/config";
+import { logger, removeWithRetries, TempDir } from "@oh-my-pi/pi-utils";
 
 // Set up a fixture filesystem we can reuse across the two regression
 // suites — same shape as `~/.omp/memories/mnemopi/` on a real install.
@@ -145,5 +149,45 @@ describe("extendRecallWithLegacyBanks edge cases", () => {
 		const out = extendRecallWithLegacyBanks(["active"], mainDbPath, path.join(rootDir.path(), "some", "cwd"));
 		expect(out).toContain("active");
 		expect(out).not.toContain("corrupt-C");
+	});
+});
+
+describe("bankOnlyHasCwd corrupt-store latch", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		resetLegacyBankCorruptLatchForTests();
+	});
+
+	it("latches after one corrupt probe and stops re-opening the damaged bank", async () => {
+		const corruptDir = path.join(banksDir, "corrupt-latch-D");
+		await fs.mkdir(corruptDir, { recursive: true });
+		const corruptDbPath = path.join(corruptDir, "mnemopi.db");
+		await fs.writeFile(corruptDbPath, "not a sqlite file");
+
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		const cwd = path.join(rootDir.path(), "projects", "latch-test");
+
+		// First call probes the corrupt bank, throws SQLITE_NOTADB, and latches.
+		const out1 = extendRecallWithLegacyBanks(["active"], mainDbPath, cwd);
+		expect(out1).toContain("active");
+		expect(out1).not.toContain("corrupt-latch-D");
+
+		// Second call short-circuits before touching the damaged file.
+		const out2 = extendRecallWithLegacyBanks(["active"], mainDbPath, cwd);
+		expect(out2).toContain("active");
+		expect(out2).not.toContain("corrupt-latch-D");
+
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("legacy bank database is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+		expect(String(damagedErrors[0]?.[0])).toContain(corruptDbPath);
+
+		// Non-corrupt errors still use debug, not error.
+		const legacyDebugs = debugSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0] === "Mnemopi: legacy bank probe failed",
+		);
+		expect(legacyDebugs).toHaveLength(0);
 	});
 });

--- a/packages/coding-agent/test/mnemopi-bank-derivation.test.ts
+++ b/packages/coding-agent/test/mnemopi-bank-derivation.test.ts
@@ -9,6 +9,7 @@ import {
 	resetLegacyBankCorruptLatchForTests,
 } from "@oh-my-pi/pi-coding-agent/mnemopi/config";
 import { logger, removeWithRetries, TempDir } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 
 // Set up a fixture filesystem we can reuse across the two regression
 // suites — same shape as `~/.omp/memories/mnemopi/` on a real install.
@@ -183,6 +184,11 @@ describe("bankOnlyHasCwd corrupt-store latch", () => {
 		);
 		expect(damagedErrors).toHaveLength(1);
 		expect(String(damagedErrors[0]?.[0])).toContain(corruptDbPath);
+		// The repair command shell-quotes the path and uses --ignore-freelist.
+		expect(String(damagedErrors[0]?.[0])).toContain(
+			`sqlite3 ${shellQuote(corruptDbPath)} '.recover --ignore-freelist'`,
+		);
+		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 ${shellQuote(`${corruptDbPath}.fixed`)}`);
 
 		// Non-corrupt errors still use debug, not error.
 		const legacyDebugs = debugSpy.mock.calls.filter(

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -17,6 +17,7 @@ import * as toolTimeouts from "@oh-my-pi/pi-coding-agent/tools/tool-timeouts";
 import { WriteTool } from "@oh-my-pi/pi-coding-agent/tools/write";
 import { unzip } from "@oh-my-pi/pi-coding-agent/utils/zip";
 import { $which, removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { shellQuote as shellEscape } from "@oh-my-pi/pi-utils/shell";
 import { GlobTool } from "../src/tools/glob";
 import { DEFAULT_FILE_LIMIT, GrepTool, MULTI_FILE_PER_FILE_MATCHES } from "../src/tools/grep";
 import { HubTool } from "../src/tools/hub";
@@ -36,10 +37,6 @@ function writeFileWithMtime(filePath: string, content: string, mtimeMs: number):
 	fs.writeFileSync(filePath, content);
 	const mtime = new Date(mtimeMs);
 	fs.utimesSync(filePath, mtime, mtime);
-}
-
-function shellEscape(value: string): string {
-	return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 function createFifoOrSkip(fifoPath: string): boolean {

--- a/packages/coding-agent/test/tools/bash-skill-urls.test.ts
+++ b/packages/coding-agent/test/tools/bash-skill-urls.test.ts
@@ -4,10 +4,7 @@ import type { Skill } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import { type ResolveContext, resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import { expandInternalUrls, expandSkillUrls } from "@oh-my-pi/pi-coding-agent/tools/bash-skill-urls";
 import { ToolError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
-
-function shellEscape(p: string): string {
-	return `'${p.replace(/'/g, "'\\''")}'`;
-}
+import { shellQuote as shellEscape } from "@oh-my-pi/pi-utils/shell";
 
 function createSkill(name: string, baseDir: string): Skill {
 	const resolvedBaseDir = path.resolve(baseDir);

--- a/packages/metaharness/src/store.ts
+++ b/packages/metaharness/src/store.ts
@@ -10,6 +10,7 @@
 import { Database } from "bun:sqlite";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import { readBenchmarkSnapshot } from "./benchmarks";
 import { readJobResult } from "./runner";
 
@@ -188,7 +189,7 @@ export class RunStore {
 		this.jobsDir = jobsDir;
 		fs.mkdirSync(path.join(jobsDir, "_manager"), { recursive: true });
 		this.#db = new Database(dbPath ?? path.join(jobsDir, "_manager", "metaharness.sqlite"));
-		this.#db.run("PRAGMA busy_timeout = 5000");
+		configureSqliteDatabase(this.#db);
 		enableWal(this.#db);
 		this.#db.run(SCHEMA);
 		const runColumns = new Set(

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixed
 
-- Fixed the recall query cache continuing to touch a damaged SQLite file after the first unrecoverable error: on `SQLITE_CORRUPT`/`SQLITE_NOTADB` it now closes and latches the connection, logs once at error level with the path and repair guidance, and keeps serving from in-memory tiers.
-- Fixed three SQLite openers missing the busy handler required by the issue-#2421 invariant: the recall query cache ran `PRAGMA journal_mode=WAL` with `busy_timeout` still 0, and the cost log and disaster-recovery scratch databases installed no pragmas at all. All three now go through the shared `configureSqliteDatabase`, and each carries a pragma-order regression test.
+- Fixed the recall query cache continuing to touch a damaged SQLite file after the first unrecoverable error: on `SQLITE_CORRUPT`/`SQLITE_NOTADB` it now closes and latches the connection, logs once at error level with the path and repair guidance, and keeps serving from in-memory tiers. ([#7302](https://github.com/can1357/oh-my-pi/issues/7302))
+- Fixed three SQLite openers missing the busy handler required by the issue-#2421 invariant: the recall query cache ran `PRAGMA journal_mode=WAL` with `busy_timeout` still 0, and the cost log and disaster-recovery scratch databases installed no pragmas at all. All three now go through the shared `configureSqliteDatabase`, and each carries a pragma-order regression test. ([#7302](https://github.com/can1357/oh-my-pi/issues/7302))
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Routed query-cache SQLite damage guidance through the shared verified, in-place repair formatter.
 - Fixed the recall query cache continuing to touch a damaged SQLite file after the first unrecoverable error: on `SQLITE_CORRUPT`/`SQLITE_NOTADB` it now closes and latches the connection, logs once at error level with the path and repair guidance, and keeps serving from in-memory tiers. ([#7302](https://github.com/can1357/oh-my-pi/issues/7302))
 - Fixed three SQLite openers missing the busy handler required by the issue-#2421 invariant: the recall query cache ran `PRAGMA journal_mode=WAL` with `busy_timeout` still 0, and the cost log and disaster-recovery scratch databases installed no pragmas at all. All three now go through the shared `configureSqliteDatabase`, and each carries a pragma-order regression test. ([#7302](https://github.com/can1357/oh-my-pi/issues/7302))
 

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed three SQLite openers missing the busy handler required by the issue-#2421 invariant: the recall query cache ran `PRAGMA journal_mode=WAL` with `busy_timeout` still 0, and the cost log and disaster-recovery scratch databases installed no pragmas at all. All three now go through the shared `configureSqliteDatabase`, and each carries a pragma-order regression test.
+
 ## [17.2.3] - 2026-08-01
 
 ### Fixed

--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed the recall query cache continuing to touch a damaged SQLite file after the first unrecoverable error: on `SQLITE_CORRUPT`/`SQLITE_NOTADB` it now closes and latches the connection, logs once at error level with the path and repair guidance, and keeps serving from in-memory tiers.
 - Fixed three SQLite openers missing the busy handler required by the issue-#2421 invariant: the recall query cache ran `PRAGMA journal_mode=WAL` with `busy_timeout` still 0, and the cost log and disaster-recovery scratch databases installed no pragmas at all. All three now go through the shared `configureSqliteDatabase`, and each carries a pragma-order regression test.
 
 ## [17.2.3] - 2026-08-01

--- a/packages/mnemopi/src/core/cost-log.ts
+++ b/packages/mnemopi/src/core/cost-log.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 
 export const DEFAULT_LOG_DIR = join(homedir(), ".mnemopi", "data");
 export const DEFAULT_LOG_DB = join(DEFAULT_LOG_DIR, "cost_log.db");
@@ -23,7 +24,12 @@ type AggregateRow = {
 export function getConn(dbPath?: string): Database {
 	const path = dbPath ?? DEFAULT_LOG_DB;
 	mkdirSync(dirname(path), { recursive: true });
-	return new Database(path, { create: true, readwrite: true, strict: true });
+	const db = new Database(path, { create: true, readwrite: true, strict: true });
+	// Issue #2421: install the busy handler before any lock-taking statement.
+	// This opener previously set no pragmas at all; preserve that pragma set
+	// (busy_timeout only — no WAL, no foreign_keys) and only add the handler.
+	configureSqliteDatabase(db);
+	return db;
 }
 
 export function initCostLog(dbPath?: string): void {

--- a/packages/mnemopi/src/core/query-cache.ts
+++ b/packages/mnemopi/src/core/query-cache.ts
@@ -270,7 +270,7 @@ export class QueryCache {
 		}
 		logger.error(
 			`Query-cache persistence store is damaged (${this.#dbPath}); persistence is disabled for this process. ` +
-				"In-memory tiers keep working. Repair with: sqlite3 <dbpath> '.recover' | sqlite3 <dbpath>.recovered",
+				`In-memory tiers keep working. Repair with: sqlite3 '${this.#dbPath}' '.recover --ignore-freelist' | sqlite3 '${this.#dbPath}.recovered'`,
 			{ err, dbPath: this.#dbPath },
 		);
 	}

--- a/packages/mnemopi/src/core/query-cache.ts
+++ b/packages/mnemopi/src/core/query-cache.ts
@@ -2,8 +2,7 @@ import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { logger } from "@oh-my-pi/pi-utils";
-import { shellQuote } from "@oh-my-pi/pi-utils/shell";
-import { configureSqliteDatabase, isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
+import { configureSqliteDatabase, isSqliteCorruptError, sqliteRepairGuidance } from "@oh-my-pi/pi-utils/sqlite";
 import { type Env, enhancedRecallEnabled } from "../config";
 import { cosineSimilarity } from "./vector-math";
 
@@ -271,7 +270,7 @@ export class QueryCache {
 		}
 		logger.error(
 			`Query-cache persistence store is damaged (${this.#dbPath}); persistence is disabled for this process. ` +
-				`In-memory tiers keep working. Repair with: sqlite3 ${shellQuote(this.#dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${this.#dbPath}.recovered`)}`,
+				`In-memory tiers keep working. ${sqliteRepairGuidance(this.#dbPath)}`,
 			{ err, dbPath: this.#dbPath },
 		);
 	}

--- a/packages/mnemopi/src/core/query-cache.ts
+++ b/packages/mnemopi/src/core/query-cache.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import { type Env, enhancedRecallEnabled } from "../config";
 import { cosineSimilarity } from "./vector-math";
 
@@ -83,7 +84,10 @@ export class QueryCache {
 		if (dbPath !== ":memory:") mkdirSync(dirname(dbPath), { recursive: true });
 		const db = new Database(dbPath, { create: true, readwrite: true, strict: true });
 		this.#conn = db;
-		if (dbPath !== ":memory:") db.exec("PRAGMA journal_mode=WAL");
+		// Issue #2421: install the busy handler before the schema DDL below
+		// (CREATE TABLE/INDEX take locks). Replaces a bare journal_mode=WAL
+		// exec that left busy_timeout at the default of 0.
+		configureSqliteDatabase(db, { wal: dbPath !== ":memory:" });
 		db.exec(`
 			CREATE TABLE IF NOT EXISTS query_cache (
 				normalized TEXT PRIMARY KEY,

--- a/packages/mnemopi/src/core/query-cache.ts
+++ b/packages/mnemopi/src/core/query-cache.ts
@@ -1,7 +1,8 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
-import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
+import { logger } from "@oh-my-pi/pi-utils";
+import { configureSqliteDatabase, isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import { type Env, enhancedRecallEnabled } from "../config";
 import { cosineSimilarity } from "./vector-math";
 
@@ -59,6 +60,10 @@ export class QueryCache {
 	#tier4 = new Map<string, readonly QueryCacheResult[]>();
 	#insertTimes = new Map<string, number>();
 	#conn: Database | null = null;
+	/** Latched once the persistent store reports unrecoverable damage; never cleared. */
+	#persistenceDamaged = false;
+	/** Path of the backing db, captured for the one-time damage report. */
+	#dbPath = "";
 
 	hits = 0;
 	misses = 0;
@@ -82,23 +87,40 @@ export class QueryCache {
 
 	#initDb(dbPath: string): void {
 		if (dbPath !== ":memory:") mkdirSync(dirname(dbPath), { recursive: true });
+		this.#dbPath = dbPath;
 		const db = new Database(dbPath, { create: true, readwrite: true, strict: true });
 		this.#conn = db;
 		// Issue #2421: install the busy handler before the schema DDL below
 		// (CREATE TABLE/INDEX take locks). Replaces a bare journal_mode=WAL
 		// exec that left busy_timeout at the default of 0.
-		configureSqliteDatabase(db, { wal: dbPath !== ":memory:" });
-		db.exec(`
-			CREATE TABLE IF NOT EXISTS query_cache (
-				normalized TEXT PRIMARY KEY,
-				embedding_json TEXT,
-				results_json TEXT,
-				hit_count INTEGER DEFAULT 0,
-				created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				last_hit TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-			);
-			CREATE INDEX IF NOT EXISTS idx_cache_hits ON query_cache(hit_count DESC);
-		`);
+		try {
+			configureSqliteDatabase(db, { wal: dbPath !== ":memory:" });
+			db.exec(`
+				CREATE TABLE IF NOT EXISTS query_cache (
+					normalized TEXT PRIMARY KEY,
+					embedding_json TEXT,
+					results_json TEXT,
+					hit_count INTEGER DEFAULT 0,
+					created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+					last_hit TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+				);
+				CREATE INDEX IF NOT EXISTS idx_cache_hits ON query_cache(hit_count DESC);
+			`);
+		} catch (err) {
+			if (isSqliteCorruptError(err)) {
+				this.#latchPersistenceDamaged(err);
+				return;
+			}
+			// Non-corrupt setup error: close the handle and rethrow — no leaked
+			// partial handle, caller sees the real failure.
+			this.#conn = null;
+			try {
+				db.close();
+			} catch {
+				// Closing after a failed pragma/DDL may itself throw; ignore.
+			}
+			throw err;
+		}
 
 		try {
 			const rows = db.query("SELECT normalized, embedding_json, results_json FROM query_cache").all() as CacheRow[];
@@ -117,7 +139,10 @@ export class QueryCache {
 					// Match Python's best-effort persistence loading: corrupt rows are ignored.
 				}
 			}
-		} catch {
+		} catch (err) {
+			if (isSqliteCorruptError(err)) {
+				this.#latchPersistenceDamaged(err);
+			}
 			// Keep an in-memory cache if persistence loading fails after schema setup.
 		}
 	}
@@ -128,8 +153,16 @@ export class QueryCache {
 		this.#tier23.clear();
 		this.#tier4.clear();
 		this.#insertTimes.clear();
-		if (this.#conn !== null) {
-			this.#conn.run("DELETE FROM query_cache");
+		if (this.#conn !== null && !this.#persistenceDamaged) {
+			try {
+				this.#conn.run("DELETE FROM query_cache");
+			} catch (err) {
+				if (isSqliteCorruptError(err)) {
+					this.#latchPersistenceDamaged(err);
+					return;
+				}
+				throw err;
+			}
 		}
 	}
 
@@ -218,6 +251,29 @@ export class QueryCache {
 		this.#evictIfNeeded();
 	}
 
+	/**
+	 * Latch the persistence layer as damaged: close the handle, clear `#conn` so
+	 * no later code path touches SQLite, and report once at `error` level. The
+	 * in-memory tiers remain authoritative for the rest of this process.
+	 */
+	#latchPersistenceDamaged(err: unknown): void {
+		if (this.#persistenceDamaged) return;
+		this.#persistenceDamaged = true;
+		const conn = this.#conn;
+		this.#conn = null;
+		if (conn !== null) {
+			try {
+				conn.close();
+			} catch {
+				// The file is already damaged; closing may throw — ignore.
+			}
+		}
+		logger.error(
+			`Query-cache persistence store is damaged (${this.#dbPath}); persistence is disabled for this process. ` +
+				"In-memory tiers keep working. Repair with: sqlite3 <dbpath> '.recover' | sqlite3 <dbpath>.recovered",
+			{ err, dbPath: this.#dbPath },
+		);
+	}
 	close(): void {
 		if (this.#conn === null) return;
 		this.#conn.close();
@@ -308,7 +364,17 @@ export class QueryCache {
 		this.#tier23.delete(key);
 		this.#tier4.delete(key);
 		this.#insertTimes.delete(key);
-		if (persistent && this.#conn !== null) this.#conn.run("DELETE FROM query_cache WHERE normalized = ?", [key]);
+		if (persistent && this.#conn !== null && !this.#persistenceDamaged) {
+			try {
+				this.#conn.run("DELETE FROM query_cache WHERE normalized = ?", [key]);
+			} catch (err) {
+				if (isSqliteCorruptError(err)) {
+					this.#latchPersistenceDamaged(err);
+					return;
+				}
+				throw err;
+			}
+		}
 	}
 
 	#evictIfNeeded(): void {
@@ -328,7 +394,7 @@ export class QueryCache {
 		results: readonly QueryCacheResult[],
 		embedding: QueryEmbedding | null | undefined,
 	): void {
-		if (this.#conn === null) return;
+		if (this.#conn === null || this.#persistenceDamaged) return;
 		try {
 			this.#conn.run(
 				"INSERT OR REPLACE INTO query_cache (normalized, embedding_json, results_json) VALUES (?, ?, ?)",
@@ -338,19 +404,25 @@ export class QueryCache {
 					JSON.stringify(results),
 				],
 			);
-		} catch {
+		} catch (err) {
+			if (isSqliteCorruptError(err)) {
+				this.#latchPersistenceDamaged(err);
+			}
 			// Persistence is best-effort; in-memory tiers remain authoritative for this process.
 		}
 	}
 
 	#recordPersistentHit(normalized: string): void {
-		if (this.#conn === null) return;
+		if (this.#conn === null || this.#persistenceDamaged) return;
 		try {
 			this.#conn.run(
 				"UPDATE query_cache SET hit_count = hit_count + 1, last_hit = CURRENT_TIMESTAMP WHERE normalized = ?",
 				[normalized],
 			);
-		} catch {
+		} catch (err) {
+			if (isSqliteCorruptError(err)) {
+				this.#latchPersistenceDamaged(err);
+			}
 			// Match Python's best-effort persistence behavior.
 		}
 	}

--- a/packages/mnemopi/src/core/query-cache.ts
+++ b/packages/mnemopi/src/core/query-cache.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { logger } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { configureSqliteDatabase, isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 import { type Env, enhancedRecallEnabled } from "../config";
 import { cosineSimilarity } from "./vector-math";
@@ -270,7 +271,7 @@ export class QueryCache {
 		}
 		logger.error(
 			`Query-cache persistence store is damaged (${this.#dbPath}); persistence is disabled for this process. ` +
-				`In-memory tiers keep working. Repair with: sqlite3 '${this.#dbPath}' '.recover --ignore-freelist' | sqlite3 '${this.#dbPath}.recovered'`,
+				`In-memory tiers keep working. Repair with: sqlite3 ${shellQuote(this.#dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(`${this.#dbPath}.recovered`)}`,
 			{ err, dbPath: this.#dbPath },
 		);
 	}

--- a/packages/mnemopi/src/db.ts
+++ b/packages/mnemopi/src/db.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import { dbPath } from "./config";
 
 export type DatabasePath = string | ":memory:";
@@ -35,9 +36,10 @@ export function openDatabase(path: DatabasePath = dbPath(), options: OpenDatabas
 }
 
 export function enablePragmas(db: Database, path?: DatabasePath): void {
-	db.exec("PRAGMA foreign_keys=ON");
-	db.exec("PRAGMA busy_timeout=5000");
-	if (path !== ":memory:") db.exec("PRAGMA journal_mode=WAL");
+	// Issue #2421: the busy handler must be installed before any lock-taking
+	// statement. configureSqliteDatabase honours that ordering internally
+	// (busy_timeout first, then foreign_keys, then WAL).
+	configureSqliteDatabase(db, { foreignKeys: true, wal: path !== ":memory:" });
 }
 
 export function loadExtensions(db: Database, extensions: string | readonly string[]): void {

--- a/packages/mnemopi/src/dr/recovery.ts
+++ b/packages/mnemopi/src/dr/recovery.ts
@@ -14,6 +14,7 @@ import {
 } from "node:fs";
 import { basename, dirname, extname, join } from "node:path";
 import { gunzipSync, gzipSync } from "node:zlib";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import { dataDir as configuredDataDir, dbPath as configuredDbPath, type Env } from "../config";
 import { closeQuietly, openDatabase } from "../db";
 
@@ -189,6 +190,11 @@ function writeGzippedSqlDump(sql: string, tempPath: string): void {
 	let db: Database | null = null;
 	try {
 		db = new Database(tempPath, { create: true, readwrite: true, strict: true });
+		// Issue #2421: install the busy handler before db.exec(sql) below,
+		// which replays a .dump stream of lock-taking DDL. This scratch db is
+		// short-lived and renamed into place by the caller, so WAL is not set
+		// (it would orphan -wal/-shm sidecars beside the temp path).
+		configureSqliteDatabase(db);
 		db.exec(sql);
 	} finally {
 		closeQuietly(db);

--- a/packages/mnemopi/test/cost-log-pragma-order.test.ts
+++ b/packages/mnemopi/test/cost-log-pragma-order.test.ts
@@ -1,0 +1,48 @@
+import { type Changes, Database } from "bun:sqlite";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initCostLog } from "@oh-my-pi/pi-mnemopi/core/cost-log";
+
+// Contract (issue #2421): the busy handler must be installed BEFORE any
+// lock-taking statement. getConn previously opened with NO pragmas at all,
+// so the CREATE TABLE DDL it immediately ran inherited busy_timeout = 0.
+// This test proves the central opener installs busy_timeout first.
+
+const tempDirs: string[] = [];
+const EMPTY_CHANGES: Changes = { changes: 0, lastInsertRowid: 0 };
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("cost-log getConn pragma order", () => {
+	it("installs busy_timeout before the CREATE TABLE DDL and preserves the original no-WAL pragma set", () => {
+		const dir = mkdtempSync(join(tmpdir(), "mnemopi-cost-pragma-"));
+		tempDirs.push(dir);
+		const dbPath = join(dir, "cost_log.db");
+
+		const statements: string[] = [];
+		vi.spyOn(Database.prototype, "run").mockImplementation(function (this: Database, sql: string): Changes {
+			statements.push(sql);
+			return EMPTY_CHANGES;
+		});
+		vi.spyOn(Database.prototype, "exec").mockImplementation(function (this: Database, sql: string): Changes {
+			statements.push(sql);
+			return EMPTY_CHANGES;
+		});
+
+		initCostLog(dbPath);
+
+		// busy_timeout is the very first statement issued on the handle.
+		expect(statements[0]).toBe("PRAGMA busy_timeout = 5000");
+		// The original opener set NO pragmas; the migration only adds the busy
+		// handler, so no journal_mode statement is issued (no WAL sidecars).
+		expect(statements.some(s => /journal_mode/i.test(s))).toBe(false);
+		// The first lock-taking statement (CREATE TABLE) comes after busy_timeout.
+		const firstDdl = statements.findIndex(s => /CREATE TABLE/i.test(s));
+		expect(firstDdl).toBeGreaterThan(0);
+	});
+});

--- a/packages/mnemopi/test/query-cache-corrupt-latch.test.ts
+++ b/packages/mnemopi/test/query-cache-corrupt-latch.test.ts
@@ -167,6 +167,10 @@ describe("QueryCache corrupt-persistence latch", () => {
 		expect(damagedErrors).toHaveLength(1);
 		// The error message names the db path.
 		expect(String(damagedErrors[0]?.[0])).toContain(dbPath);
+		// The repair command interpolates the real path (no literal <dbpath>).
+		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 '${dbPath}' '.recover --ignore-freelist'`);
+		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 '${dbPath}.recovered'`);
+		expect(String(damagedErrors[0]?.[0])).not.toContain("<dbpath>");
 	});
 
 	test("non-corrupt errors keep their current best-effort handling", () => {
@@ -302,6 +306,9 @@ describe("QueryCache corrupt-persistence latch", () => {
 		);
 		expect(damagedErrors).toHaveLength(1);
 		expect(String(damagedErrors[0]?.[0])).toContain(malformedDbPath);
+		// The repair command interpolates the real path (no literal <dbpath>).
+		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 '${malformedDbPath}' '.recover --ignore-freelist'`);
+		expect(String(damagedErrors[0]?.[0])).not.toContain("<dbpath>");
 
 		// In-memory put/get works without touching SQLite.
 		cache!.put("hello world", [{ id: 1, text: "result" }]);

--- a/packages/mnemopi/test/query-cache-corrupt-latch.test.ts
+++ b/packages/mnemopi/test/query-cache-corrupt-latch.test.ts
@@ -22,6 +22,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { QueryCache } from "@oh-my-pi/pi-mnemopi/core/query-cache";
 import { logger } from "@oh-my-pi/pi-utils";
+import { shellQuote } from "@oh-my-pi/pi-utils/shell";
 import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
 
 const EMPTY_CHANGES: Changes = { changes: 0, lastInsertRowid: 0 };
@@ -167,9 +168,9 @@ describe("QueryCache corrupt-persistence latch", () => {
 		expect(damagedErrors).toHaveLength(1);
 		// The error message names the db path.
 		expect(String(damagedErrors[0]?.[0])).toContain(dbPath);
-		// The repair command interpolates the real path (no literal <dbpath>).
-		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 '${dbPath}' '.recover --ignore-freelist'`);
-		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 '${dbPath}.recovered'`);
+		// The repair command shell-quotes the real path (no literal <dbpath>).
+		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist'`);
+		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 ${shellQuote(`${dbPath}.recovered`)}`);
 		expect(String(damagedErrors[0]?.[0])).not.toContain("<dbpath>");
 	});
 
@@ -306,8 +307,10 @@ describe("QueryCache corrupt-persistence latch", () => {
 		);
 		expect(damagedErrors).toHaveLength(1);
 		expect(String(damagedErrors[0]?.[0])).toContain(malformedDbPath);
-		// The repair command interpolates the real path (no literal <dbpath>).
-		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 '${malformedDbPath}' '.recover --ignore-freelist'`);
+		// The repair command shell-quotes the real path (no literal <dbpath>).
+		expect(String(damagedErrors[0]?.[0])).toContain(
+			`sqlite3 ${shellQuote(malformedDbPath)} '.recover --ignore-freelist'`,
+		);
 		expect(String(damagedErrors[0]?.[0])).not.toContain("<dbpath>");
 
 		// In-memory put/get works without touching SQLite.
@@ -331,5 +334,47 @@ describe("QueryCache corrupt-persistence latch", () => {
 		cache!.get("hello world");
 		cache!.invalidate();
 		expect(reachedRun).toBe(false);
+	});
+
+	test("shell-quotes the repair command when the db path contains a single quote", () => {
+		// A POSIX path may legitimately contain single quotes. The manually
+		// single-quoted form `sqlite3 '${path}'` breaks copy-paste for such
+		// paths; shellQuote closes/reopens the surrounding quotes so the
+		// result is always balanced.
+		const quoteDir = mkdtempSync(join(tmpdir(), "mnemopi-qc-quote-"));
+		tempDirs.push(quoteDir);
+		const quotedName = "it's a db.db";
+		const quoteDbPath = join(quoteDir, quotedName);
+		writeFileSync(quoteDbPath, "this is not a sqlite database");
+
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		let cache: QueryCache;
+		expect(() => {
+			cache = new QueryCache({ dbPath: quoteDbPath, maxSize: 10 });
+			openCaches.push(cache);
+		}).not.toThrow();
+
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Query-cache persistence store is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+		const msg = String(damagedErrors[0]?.[0]);
+		// The repair command uses the shell-quoted form, not the raw path in
+		// bare single quotes.
+		expect(msg).toContain(`sqlite3 ${shellQuote(quoteDbPath)} '.recover --ignore-freelist'`);
+		expect(msg).toContain(`sqlite3 ${shellQuote(`${quoteDbPath}.recovered`)}`);
+		// The single quotes in the repair command are balanced: every `'` that
+		// opens is matched by one that closes. This catches the old bug where an
+		// embedded quote left an unbalanced command.
+		const repairSegment = msg.slice(msg.indexOf("Repair with:"));
+		let depth = 0;
+		for (const ch of repairSegment) {
+			if (ch === "'") depth += 1;
+		}
+		expect(depth % 2).toBe(0);
+		// The raw unquoted path does not appear bare inside the command.
+		const commandPart = repairSegment.slice("Repair with: ".length);
+		expect(commandPart).not.toContain(`'${quoteDbPath}'`);
 	});
 });

--- a/packages/mnemopi/test/query-cache-corrupt-latch.test.ts
+++ b/packages/mnemopi/test/query-cache-corrupt-latch.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Regression coverage for the QueryCache corrupt-persistence latch.
+ *
+ * QueryCache backs its cross-process persistence with a SQLite handle
+ * (`#conn`). Before the latch, every persistence error — including the
+ * unrecoverable SQLITE_CORRUPT / SQLITE_NOTADB family — was swallowed at
+ * `debug`-equivalent silence and the connection kept being reused, so a
+ * damaged `query_cache.db` was re-queried on every put, every hit update,
+ * and every eviction for the life of the process.
+ *
+ * The fix latches the persistence layer as damaged on the first
+ * unrecoverable error: closes the handle, clears `#conn` so no later code
+ * path touches SQLite, reports once at `error` level, and falls through to
+ * the existing in-memory behavior. Non-corrupt errors keep their exact
+ * current handling.
+ */
+
+import { type Changes, Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { QueryCache } from "@oh-my-pi/pi-mnemopi/core/query-cache";
+import { logger } from "@oh-my-pi/pi-utils";
+import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
+
+const EMPTY_CHANGES: Changes = { changes: 0, lastInsertRowid: 0 };
+
+const tempDirs: string[] = [];
+const openCaches: QueryCache[] = [];
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const cache of openCaches.splice(0)) cache.close();
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * Writes a deterministic malformed SQLite source — bytes that are not a valid
+ * SQLite database — and returns the path. Opening this with `new Database(path)`
+ * and running a query makes bun:sqlite throw a real `SQLiteError` carrying
+ * `code: "SQLITE_NOTADB"` (errno 26), the same family the latch classifies.
+ */
+function writeMalformedDb(dir: string): string {
+	const dbPath = join(dir, "malformed.db");
+	writeFileSync(dbPath, "this is not a sqlite database");
+	return dbPath;
+}
+
+/** The real error bun:sqlite throws when a query hits a malformed database file. */
+function realCorruptError(malformedDbPath: string): Error {
+	const db = new Database(malformedDbPath);
+	try {
+		db.run("PRAGMA integrity_check");
+	} catch (err) {
+		return err as Error;
+	} finally {
+		db.close();
+	}
+	throw new Error("expected SQLITE_NOTADB from malformed database");
+}
+
+describe("QueryCache corrupt-persistence latch", () => {
+	let dir: string;
+	let dbPath: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "mnemopi-qc-corrupt-"));
+		tempDirs.push(dir);
+		dbPath = join(dir, "query_cache.db");
+	});
+
+	test("latches after one corrupt write and stops re-querying the store", () => {
+		const malformedDbPath = writeMalformedDb(dir);
+		const corruptErr = realCorruptError(malformedDbPath);
+		expect(isSqliteCorruptError(corruptErr)).toBe(true);
+
+		// Build a valid cache first so the constructor (schema DDL + load) succeeds.
+		const cache = new QueryCache({ dbPath, maxSize: 10 });
+		openCaches.push(cache);
+		// Populate the in-memory tiers so we can prove recall still works after latch.
+		cache.put("hello world", [{ id: 1, text: "result" }]);
+
+		// Now corrupt the connection: spy on Database.prototype.run so the next
+		// persistence write throws the REAL SQLITE_NOTADB error that production
+		// sees when query_cache.db is damaged. The spy throws once, then restores
+		// real behavior so we can prove the latch prevents further SQLite calls.
+		let throwNext = true;
+		const runSpy = vi.spyOn(Database.prototype, "run").mockImplementation(function (
+			this: Database,
+			sql: string,
+			..._args: unknown[]
+		): Changes {
+			if (throwNext && sql.startsWith("INSERT OR REPLACE INTO query_cache")) {
+				throwNext = false;
+				throw corruptErr;
+			}
+			return EMPTY_CHANGES;
+		});
+
+		// Drive a persistence write. The first put hits the spy, throws
+		// SQLITE_NOTADB, and latches #persistenceDamaged. The put still
+		// populates in-memory tiers (they are set before #putPersistent runs).
+		cache.put("second query", [{ id: 2, text: "result2" }]);
+
+		// In-memory recall of the latched put still works.
+		expect(cache.get("second query")).toEqual([{ id: 2, text: "result2" }]);
+		// A get on the first entry triggers #recordPersistentHit (hit-update path),
+		// which must short-circuit without touching SQLite.
+		const recalled = cache.get("hello world");
+		expect(recalled).toEqual([{ id: 1, text: "result" }]);
+
+		// Drive more operations that would normally touch persistence.
+		cache.put("third query", [{ id: 3, text: "result3" }]);
+		// invalidate touches persistence too — must be a no-op on the latched conn.
+		cache.invalidate();
+
+		// The spy was called exactly once for the INSERT (the corrupt write).
+		// After the latch, #putPersistent and #recordPersistentHit short-circuit
+		// before calling conn.run, so no further INSERT/UPDATE calls reach the spy.
+		const insertCalls = runSpy.mock.calls.filter(call => {
+			const sql = call[0];
+			return typeof sql === "string" && sql.startsWith("INSERT OR REPLACE INTO query_cache");
+		});
+		expect(insertCalls).toHaveLength(1);
+
+		// No UPDATE calls reached the spy either (hit-update path is latched).
+		const updateCalls = runSpy.mock.calls.filter(call => {
+			const sql = call[0];
+			return typeof sql === "string" && sql.startsWith("UPDATE query_cache");
+		});
+		expect(updateCalls).toHaveLength(0);
+	});
+
+	test("emits exactly one logger.error for the corrupt write", () => {
+		const malformedDbPath = writeMalformedDb(dir);
+		const corruptErr = realCorruptError(malformedDbPath);
+
+		const cache = new QueryCache({ dbPath, maxSize: 10 });
+		openCaches.push(cache);
+		cache.put("hello world", [{ id: 1, text: "result" }]);
+
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		vi.spyOn(logger, "debug").mockImplementation(() => {});
+
+		let throwNext = true;
+		vi.spyOn(Database.prototype, "run").mockImplementation(function (
+			this: Database,
+			sql: string,
+			..._args: unknown[]
+		): Changes {
+			if (throwNext && sql.startsWith("INSERT OR REPLACE INTO query_cache")) {
+				throwNext = false;
+				throw corruptErr;
+			}
+			return EMPTY_CHANGES;
+		});
+
+		// First put triggers the corrupt error and latches.
+		cache.put("second query", [{ id: 2, text: "result2" }]);
+		// Second put is latched — no error, no SQLite.
+		cache.put("third query", [{ id: 3, text: "result3" }]);
+
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Query-cache persistence store is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+		// The error message names the db path.
+		expect(String(damagedErrors[0]?.[0])).toContain(dbPath);
+	});
+
+	test("non-corrupt errors keep their current best-effort handling", () => {
+		const cache = new QueryCache({ dbPath, maxSize: 10 });
+		openCaches.push(cache);
+		cache.put("hello world", [{ id: 1, text: "result" }]);
+
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// Inject a non-corrupt error (SQLITE_BUSY) — the latch must NOT fire.
+		const busyErr = new Error("database is locked") as Error & { code: string };
+		busyErr.code = "SQLITE_BUSY";
+		expect(isSqliteCorruptError(busyErr)).toBe(false);
+
+		let throwNext = true;
+		vi.spyOn(Database.prototype, "run").mockImplementation(function (
+			this: Database,
+			sql: string,
+			..._args: unknown[]
+		): Changes {
+			if (throwNext && sql.startsWith("INSERT OR REPLACE INTO query_cache")) {
+				throwNext = false;
+				throw busyErr;
+			}
+			return EMPTY_CHANGES;
+		});
+
+		// The put swallows the BUSY error (best-effort) and does NOT latch.
+		cache.put("second query", [{ id: 2, text: "result2" }]);
+
+		// No logger.error fired — non-corrupt errors are silent (current behavior).
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Query-cache persistence store is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(0);
+
+		// The connection is still active: a subsequent put reaches SQLite again.
+		let reachedRun = false;
+		vi.spyOn(Database.prototype, "run").mockImplementation(function (
+			this: Database,
+			sql: string,
+			..._args: unknown[]
+		): Changes {
+			if (sql.startsWith("INSERT OR REPLACE INTO query_cache")) {
+				reachedRun = true;
+			}
+			return EMPTY_CHANGES;
+		});
+		cache.put("third query", [{ id: 3, text: "result3" }]);
+		expect(reachedRun).toBe(true);
+	});
+
+	test("invalidate as the first corrupt-touching operation latches without throwing", () => {
+		const malformedDbPath = writeMalformedDb(dir);
+		const corruptErr = realCorruptError(malformedDbPath);
+
+		const cache = new QueryCache({ dbPath, maxSize: 10 });
+		openCaches.push(cache);
+		cache.put("hello world", [{ id: 1, text: "result" }]);
+
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// Spy so the very first SQLite call — the DELETE FROM query_cache issued
+		// by invalidate() — throws the real SQLITE_NOTADB error. No prior put or
+		// hit-update has touched SQLite yet, so this is the first corrupt contact.
+		let throwNext = true;
+		const runSpy = vi.spyOn(Database.prototype, "run").mockImplementation(function (
+			this: Database,
+			sql: string,
+			..._args: unknown[]
+		): Changes {
+			if (throwNext && sql.startsWith("DELETE FROM query_cache")) {
+				throwNext = false;
+				throw corruptErr;
+			}
+			return EMPTY_CHANGES;
+		});
+
+		// invalidate() must NOT throw — the corrupt DELETE is caught and latched.
+		expect(() => cache.invalidate()).not.toThrow();
+
+		// Exactly one logger.error fired, naming the db path.
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Query-cache persistence store is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+		expect(String(damagedErrors[0]?.[0])).toContain(dbPath);
+
+		// The latch cleared the connection: a subsequent put must not reach SQLite.
+		let reachedInsert = false;
+		vi.spyOn(Database.prototype, "run").mockImplementation(function (
+			this: Database,
+			sql: string,
+			..._args: unknown[]
+		): Changes {
+			if (sql.startsWith("INSERT OR REPLACE INTO query_cache")) {
+				reachedInsert = true;
+			}
+			return EMPTY_CHANGES;
+		});
+		cache.put("after invalidate", [{ id: 2, text: "result2" }]);
+		expect(reachedInsert).toBe(false);
+
+		// The original DELETE spy was called exactly once (the corrupt invalidate).
+		// After re-spying, the old mock.calls are gone, so check via the first spy.
+		const deleteCalls = runSpy.mock.calls.filter(call => {
+			const sql = call[0];
+			return typeof sql === "string" && sql.startsWith("DELETE FROM query_cache");
+		});
+		expect(deleteCalls).toHaveLength(1);
+
+		// In-memory tiers were cleared by invalidate, but the post-latch put works.
+		expect(cache.get("after invalidate")).toEqual([{ id: 2, text: "result2" }]);
+	});
+
+	test("construction over a malformed db file latches without throwing", () => {
+		// Write invalid bytes to a real .db path — this is the common real-world
+		// case: query_cache.db is already damaged when the process starts.
+		const malformedDbPath = writeMalformedDb(dir);
+
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		// The constructor must NOT throw — it latches and degrades to in-memory.
+		let cache: QueryCache;
+		expect(() => {
+			cache = new QueryCache({ dbPath: malformedDbPath, maxSize: 10 });
+			openCaches.push(cache);
+		}).not.toThrow();
+
+		// Exactly one logger.error fired, naming the malformed db path.
+		const damagedErrors = errorSpy.mock.calls.filter(
+			call => typeof call[0] === "string" && call[0].includes("Query-cache persistence store is damaged"),
+		);
+		expect(damagedErrors).toHaveLength(1);
+		expect(String(damagedErrors[0]?.[0])).toContain(malformedDbPath);
+
+		// In-memory put/get works without touching SQLite.
+		cache!.put("hello world", [{ id: 1, text: "result" }]);
+		expect(cache!.get("hello world")).toEqual([{ id: 1, text: "result" }]);
+
+		// No persistence handle is used: spy on Database.prototype.run and
+		// confirm no INSERT/UPDATE/DELETE reaches it after construction.
+		let reachedRun = false;
+		vi.spyOn(Database.prototype, "run").mockImplementation(function (
+			this: Database,
+			sql: string,
+			..._args: unknown[]
+		): Changes {
+			if (typeof sql === "string" && /INSERT|UPDATE|DELETE/i.test(sql)) {
+				reachedRun = true;
+			}
+			return EMPTY_CHANGES;
+		});
+		cache!.put("second query", [{ id: 2, text: "result2" }]);
+		cache!.get("hello world");
+		cache!.invalidate();
+		expect(reachedRun).toBe(false);
+	});
+});

--- a/packages/mnemopi/test/query-cache-corrupt-latch.test.ts
+++ b/packages/mnemopi/test/query-cache-corrupt-latch.test.ts
@@ -22,8 +22,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { QueryCache } from "@oh-my-pi/pi-mnemopi/core/query-cache";
 import { logger } from "@oh-my-pi/pi-utils";
-import { shellQuote } from "@oh-my-pi/pi-utils/shell";
-import { isSqliteCorruptError } from "@oh-my-pi/pi-utils/sqlite";
+import { isSqliteCorruptError, sqliteRepairGuidance } from "@oh-my-pi/pi-utils/sqlite";
 
 const EMPTY_CHANGES: Changes = { changes: 0, lastInsertRowid: 0 };
 
@@ -168,9 +167,7 @@ describe("QueryCache corrupt-persistence latch", () => {
 		expect(damagedErrors).toHaveLength(1);
 		// The error message names the db path.
 		expect(String(damagedErrors[0]?.[0])).toContain(dbPath);
-		// The repair command shell-quotes the real path (no literal <dbpath>).
-		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist'`);
-		expect(String(damagedErrors[0]?.[0])).toContain(`sqlite3 ${shellQuote(`${dbPath}.recovered`)}`);
+		expect(String(damagedErrors[0]?.[0])).toContain(sqliteRepairGuidance(dbPath));
 		expect(String(damagedErrors[0]?.[0])).not.toContain("<dbpath>");
 	});
 
@@ -307,10 +304,7 @@ describe("QueryCache corrupt-persistence latch", () => {
 		);
 		expect(damagedErrors).toHaveLength(1);
 		expect(String(damagedErrors[0]?.[0])).toContain(malformedDbPath);
-		// The repair command shell-quotes the real path (no literal <dbpath>).
-		expect(String(damagedErrors[0]?.[0])).toContain(
-			`sqlite3 ${shellQuote(malformedDbPath)} '.recover --ignore-freelist'`,
-		);
+		expect(String(damagedErrors[0]?.[0])).toContain(sqliteRepairGuidance(malformedDbPath));
 		expect(String(damagedErrors[0]?.[0])).not.toContain("<dbpath>");
 
 		// In-memory put/get works without touching SQLite.
@@ -360,21 +354,18 @@ describe("QueryCache corrupt-persistence latch", () => {
 		);
 		expect(damagedErrors).toHaveLength(1);
 		const msg = String(damagedErrors[0]?.[0]);
-		// The repair command uses the shell-quoted form, not the raw path in
-		// bare single quotes.
-		expect(msg).toContain(`sqlite3 ${shellQuote(quoteDbPath)} '.recover --ignore-freelist'`);
-		expect(msg).toContain(`sqlite3 ${shellQuote(`${quoteDbPath}.recovered`)}`);
+		expect(msg).toContain(sqliteRepairGuidance(quoteDbPath));
 		// The single quotes in the repair command are balanced: every `'` that
 		// opens is matched by one that closes. This catches the old bug where an
 		// embedded quote left an unbalanced command.
-		const repairSegment = msg.slice(msg.indexOf("Repair with:"));
+		const repairSegment = msg.slice(msg.indexOf("Stop omp,"));
 		let depth = 0;
-		for (const ch of repairSegment) {
-			if (ch === "'") depth += 1;
+		for (let index = 0; index < repairSegment.length; index++) {
+			if (repairSegment[index] === "'" && repairSegment[index - 1] !== "\\") depth += 1;
 		}
 		expect(depth % 2).toBe(0);
 		// The raw unquoted path does not appear bare inside the command.
-		const commandPart = repairSegment.slice("Repair with: ".length);
+		const commandPart = repairSegment.slice("Stop omp, then repair the database in place with: ".length);
 		expect(commandPart).not.toContain(`'${quoteDbPath}'`);
 	});
 });

--- a/packages/mnemopi/test/query-cache-pragma-order.test.ts
+++ b/packages/mnemopi/test/query-cache-pragma-order.test.ts
@@ -1,0 +1,54 @@
+import { type Changes, Database } from "bun:sqlite";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { QueryCache } from "@oh-my-pi/pi-mnemopi/core/query-cache";
+
+// Contract (issue #2421): the busy handler must be installed BEFORE any
+// lock-taking statement. #initDb previously ran `PRAGMA journal_mode=WAL`
+// with no busy_timeout at all, so a concurrent WAL checkpoint could surface
+// as a silent miss. This test proves the central opener fixes the ordering.
+
+const tempDirs: string[] = [];
+const EMPTY_CHANGES: Changes = { changes: 0, lastInsertRowid: 0 };
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("QueryCache #initDb pragma order", () => {
+	it("installs busy_timeout before the first lock-taking statement and enables WAL", () => {
+		const dir = mkdtempSync(join(tmpdir(), "mnemopi-qc-pragma-"));
+		tempDirs.push(dir);
+		const dbPath = join(dir, "query_cache.db");
+
+		// Record every SQL statement issued on any Database handle, in order,
+		// without executing them. The first entry is therefore the first
+		// statement the opener issues on the new connection.
+		const statements: string[] = [];
+		vi.spyOn(Database.prototype, "run").mockImplementation(function (this: Database, sql: string): Changes {
+			statements.push(sql);
+			return EMPTY_CHANGES;
+		});
+		vi.spyOn(Database.prototype, "exec").mockImplementation(function (this: Database, sql: string): Changes {
+			statements.push(sql);
+			return EMPTY_CHANGES;
+		});
+
+		const cache = new QueryCache({ dbPath, maxSize: 10 });
+		cache.close();
+
+		// busy_timeout is the very first statement issued on the handle.
+		expect(statements[0]).toBe("PRAGMA busy_timeout = 5000");
+		// WAL is set for a file-backed cache.
+		const walIndex = statements.findIndex(s => /journal_mode/i.test(s));
+		expect(walIndex).toBeGreaterThan(0);
+		expect(statements[walIndex]).toContain("WAL");
+		// The first lock-taking statement (schema DDL) comes after busy_timeout.
+		const firstDdl = statements.findIndex(s => /CREATE (TABLE|INDEX)/i.test(s));
+		expect(firstDdl).toBeGreaterThan(0);
+		expect(firstDdl).toBeGreaterThan(walIndex);
+	});
+});

--- a/packages/mnemopi/test/recovery-pragma-order.test.ts
+++ b/packages/mnemopi/test/recovery-pragma-order.test.ts
@@ -1,0 +1,55 @@
+import { type Changes, Database } from "bun:sqlite";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+import { restoreBackup } from "@oh-my-pi/pi-mnemopi/dr/recovery";
+
+// Contract (issue #2421): the busy handler must be installed BEFORE any
+// lock-taking statement. writeGzippedSqlDump opened its recovery scratch db
+// with NO pragmas and then replayed a .dump stream of lock-taking DDL. This
+// test drives restoreBackup with a gzipped SQL dump (which routes through
+// writeGzippedSqlDump) and proves busy_timeout is installed first. WAL is
+// deliberately NOT set on the scratch db: it is short-lived and renamed into
+// place, so WAL would orphan -wal/-shm sidecars beside the temp path.
+
+const tempDirs: string[] = [];
+const EMPTY_CHANGES: Changes = { changes: 0, lastInsertRowid: 0 };
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("recovery writeGzippedSqlDump pragma order", () => {
+	it("installs busy_timeout before replaying the dump and does not set WAL", () => {
+		const dir = mkdtempSync(join(tmpdir(), "mnemopi-recovery-pragma-"));
+		tempDirs.push(dir);
+		const dbPath = join(dir, "agent.db");
+		const backupPath = join(dir, "dump.sql.gz");
+		// A gzipped SQL dump (not a sqlite file) routes through writeGzippedSqlDump.
+		writeFileSync(backupPath, gzipSync(Buffer.from("CREATE TABLE x (id INTEGER PRIMARY KEY);")));
+
+		const statements: string[] = [];
+		vi.spyOn(Database.prototype, "run").mockImplementation(function (this: Database, sql: string): Changes {
+			statements.push(sql);
+			return EMPTY_CHANGES;
+		});
+		vi.spyOn(Database.prototype, "exec").mockImplementation(function (this: Database, sql: string): Changes {
+			statements.push(sql);
+			return EMPTY_CHANGES;
+		});
+
+		const result = restoreBackup(backupPath, dbPath);
+		expect(result.restored).toBe(true);
+
+		// busy_timeout is the very first statement issued on the scratch handle.
+		expect(statements[0]).toBe("PRAGMA busy_timeout = 5000");
+		// WAL is not set on the transient recovery db.
+		expect(statements.some(s => /journal_mode/i.test(s))).toBe(false);
+		// The dumped DDL is replayed after the busy handler.
+		const firstDdl = statements.findIndex(s => /CREATE TABLE/i.test(s));
+		expect(firstDdl).toBeGreaterThan(0);
+	});
+});

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Migrated the stats database opener to the shared `configureSqliteDatabase` helper, centralizing WAL/busy-handler pragmas across packages (behavior-preserving).
+- Migrated the stats database opener to the shared `configureSqliteDatabase` helper, centralizing WAL/busy-handler pragmas across packages (behavior-preserving). ([#7302](https://github.com/can1357/oh-my-pi/issues/7302))
 
 ## [17.1.2] - 2026-07-24
 

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Migrated the stats database opener to the shared `configureSqliteDatabase` helper, centralizing WAL/busy-handler pragmas across packages (behavior-preserving).
+
 ## [17.1.2] - 2026-07-24
 
 ### Added

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -4,6 +4,7 @@ import type { Usage } from "@oh-my-pi/pi-ai";
 import type { GeneratedProvider } from "@oh-my-pi/pi-catalog/models";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { getConfigRootDir, getStatsDbPath } from "@oh-my-pi/pi-utils";
+import { configureSqliteDatabase } from "@oh-my-pi/pi-utils/sqlite";
 import { classifyAgentType } from "./parser";
 import type {
 	AgentType,
@@ -78,8 +79,7 @@ export async function initDb(): Promise<Database> {
 	db = new Database(getStatsDbPath());
 	// Install the busy handler BEFORE any lock-taking statement. See
 	// https://github.com/can1357/oh-my-pi/issues/2421.
-	db.run("PRAGMA busy_timeout = 5000");
-	db.run("PRAGMA journal_mode = WAL");
+	configureSqliteDatabase(db, { wal: true });
 
 	// Whether `messages` predates this init — drives the one-time agent_type
 	// backfill below, so it must be sampled before CREATE TABLE adds the table.

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `@oh-my-pi/pi-utils/sqlite` with `isSqliteCorruptError`, the shared classifier for SQLite's unrecoverable-file result codes (`SQLITE_CORRUPT` family plus `SQLITE_NOTADB`).
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `sqliteRepairGuidance` to `@oh-my-pi/pi-utils/sqlite` for verified, in-place SQLite recovery commands with optional restrictive permissions.
+- Added PowerShell-specific SQLite repair guidance on Windows, including guarded verification, sidecar backups, and current-user ACL hardening for restricted stores.
 - Added `@oh-my-pi/pi-utils/sqlite` with `isSqliteCorruptError`, the shared classifier for SQLite's unrecoverable-file result codes (`SQLITE_CORRUPT` family plus `SQLITE_NOTADB`). ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
 - Added `@oh-my-pi/pi-utils/sqlite` with `isSqliteCorruptError`, the shared classifier for SQLite's unrecoverable-file result codes (`SQLITE_CORRUPT` family plus `SQLITE_NOTADB`).
 - Added `configureSqliteDatabase` and `openSqliteDatabase` to `@oh-my-pi/pi-utils/sqlite`: the central opener enforcing the issue-#2421 ordering invariant (busy handler validated to the `sqlite3_busy_timeout(int)` range and installed before any lock-taking statement, then named pragmas, then WAL), closing the handle and rethrowing when a pragma fails.

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `sqliteRepairGuidance` to `@oh-my-pi/pi-utils/sqlite` for verified, in-place SQLite recovery commands with optional restrictive permissions.
 - Added `@oh-my-pi/pi-utils/sqlite` with `isSqliteCorruptError`, the shared classifier for SQLite's unrecoverable-file result codes (`SQLITE_CORRUPT` family plus `SQLITE_NOTADB`). ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
 - Added `@oh-my-pi/pi-utils/sqlite` with `isSqliteCorruptError`, the shared classifier for SQLite's unrecoverable-file result codes (`SQLITE_CORRUPT` family plus `SQLITE_NOTADB`).
 - Added `configureSqliteDatabase` and `openSqliteDatabase` to `@oh-my-pi/pi-utils/sqlite`: the central opener enforcing the issue-#2421 ordering invariant (busy handler validated to the `sqlite3_busy_timeout(int)` range and installed before any lock-taking statement, then named pragmas, then WAL), closing the handle and rethrowing when a pragma fails.

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Added `@oh-my-pi/pi-utils/sqlite` with `isSqliteCorruptError`, the shared classifier for SQLite's unrecoverable-file result codes (`SQLITE_CORRUPT` family plus `SQLITE_NOTADB`). ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
+- Added `@oh-my-pi/pi-utils/sqlite` with `isSqliteCorruptError`, the shared classifier for SQLite's unrecoverable-file result codes (`SQLITE_CORRUPT` family plus `SQLITE_NOTADB`).
+- Added `configureSqliteDatabase` and `openSqliteDatabase` to `@oh-my-pi/pi-utils/sqlite`: the central opener enforcing the issue-#2421 ordering invariant (busy handler validated to the `sqlite3_busy_timeout(int)` range and installed before any lock-taking statement, then named pragmas, then WAL), closing the handle and rethrowing when a pragma fails.
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `@oh-my-pi/pi-utils/sqlite` with `isSqliteCorruptError`, the shared classifier for SQLite's unrecoverable-file result codes (`SQLITE_CORRUPT` family plus `SQLITE_NOTADB`).
+- Added `@oh-my-pi/pi-utils/sqlite` with `isSqliteCorruptError`, the shared classifier for SQLite's unrecoverable-file result codes (`SQLITE_CORRUPT` family plus `SQLITE_NOTADB`). ([#7296](https://github.com/can1357/oh-my-pi/issues/7296))
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -27,6 +27,7 @@ export { AbortError, ChildProcess, Exception, NonZeroExitError } from "./ptree";
 export * from "./runtime-install";
 export * from "./sanitize-text";
 export * from "./snowflake";
+export * from "./sqlite";
 export * from "./stderr-guard";
 export * from "./stream";
 export * from "./tab-spacing";

--- a/packages/utils/src/shell.ts
+++ b/packages/utils/src/shell.ts
@@ -12,3 +12,11 @@
 export function shellQuote(value: string): string {
 	return `'${value.replace(/'/g, "'\\''")}'`;
 }
+
+/**
+ * Quote a string for a PowerShell single-quoted literal. This is separate
+ * from shellQuote because PowerShell escapes embedded quotes by doubling them.
+ */
+export function powershellQuote(value: string): string {
+	return `'${value.replace(/'/g, "''")}'`;
+}

--- a/packages/utils/src/shell.ts
+++ b/packages/utils/src/shell.ts
@@ -1,0 +1,14 @@
+/**
+ * Shell-quoting helpers for safe interpolation of dynamic values into POSIX
+ * shell commands. Kept here (rather than duplicated beside every call site) so
+ * exactly one implementation exists across the monorepo.
+ */
+
+/**
+ * Quote a string for safe interpolation into a POSIX shell single-quoted
+ * context. Every `'` inside the value becomes `'\''`, closing and reopening
+ * the surrounding single quotes so the result is always balanced.
+ */
+export function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/packages/utils/src/sqlite.ts
+++ b/packages/utils/src/sqlite.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared SQLite helpers for omp's local databases.
+ *
+ * The corruption classifier lives here (rather than beside any single store)
+ * because every package that opens a SQLite file needs to tell unrecoverable
+ * file damage apart from transient lock contention.
+ */
+
+/**
+ * SQLite's unrecoverable-file result codes: the `SQLITE_CORRUPT` family plus
+ * `SQLITE_NOTADB`. Unlike the BUSY family, retrying cannot help — the database
+ * file itself is damaged, so callers latch off instead of backing off.
+ */
+export function isSqliteCorruptError(err: unknown): boolean {
+	if (err === null || typeof err !== "object" || !("code" in err)) return false;
+	const code = err.code;
+	return typeof code === "string" && (code.startsWith("SQLITE_CORRUPT") || code === "SQLITE_NOTADB");
+}

--- a/packages/utils/src/sqlite.ts
+++ b/packages/utils/src/sqlite.ts
@@ -5,6 +5,7 @@
  * because every package that opens a SQLite file needs to tell unrecoverable
  * file damage apart from transient lock contention.
  */
+import { Database } from "bun:sqlite";
 
 /**
  * SQLite's unrecoverable-file result codes: the `SQLITE_CORRUPT` family plus
@@ -15,4 +16,71 @@ export function isSqliteCorruptError(err: unknown): boolean {
 	if (err === null || typeof err !== "object" || !("code" in err)) return false;
 	const code = err.code;
 	return typeof code === "string" && (code.startsWith("SQLITE_CORRUPT") || code === "SQLITE_NOTADB");
+}
+
+export interface SqlitePragmaSettings {
+	/** Open-only option; rejected here so open settings cannot silently flow into configure. */
+	readonly?: never;
+	/**
+	 * Busy-handler timeout in milliseconds. Installed BEFORE any lock-taking
+	 * statement (`journal_mode=WAL` acquires an exclusive lock during WAL
+	 * recovery), per the issue-#2421 invariant. Default 5000.
+	 */
+	busyTimeoutMs?: number;
+	/** Set `PRAGMA journal_mode = WAL` (writers on multi-process databases). Default false. */
+	wal?: boolean;
+	/** Set `PRAGMA foreign_keys = ON`. Default false (SQLite default). */
+	foreignKeys?: boolean;
+	/** Set `PRAGMA secure_delete = ON`. Default false. */
+	secureDelete?: boolean;
+	/** Set `PRAGMA synchronous = NORMAL`. Default false. */
+	synchronousNormal?: boolean;
+}
+
+export interface SqliteOpenSettings extends Omit<SqlitePragmaSettings, "readonly"> {
+	/** Open read-only. Default false. */
+	readonly?: boolean;
+}
+
+/**
+ * Install pragmas on an existing handle, in an order that honours the
+ * issue-#2421 invariant: the busy handler always runs first, non-locking
+ * pragmas next, and `journal_mode = WAL` (which takes an exclusive lock
+ * during recovery) last.
+ */
+export function configureSqliteDatabase(db: Database, settings: SqlitePragmaSettings = {}): void {
+	const busyTimeoutMs = settings.busyTimeoutMs ?? 5000;
+	// Interpolated into SQL (PRAGMA takes no bind parameters), so reject
+	// anything that cannot fit the native sqlite3_busy_timeout(int) contract
+	// before it reaches the statement.
+	if (!Number.isSafeInteger(busyTimeoutMs) || busyTimeoutMs < 0 || busyTimeoutMs > 2_147_483_647) {
+		throw new RangeError(`busyTimeoutMs must be an integer in [0, 2147483647], got ${busyTimeoutMs}`);
+	}
+	db.run(`PRAGMA busy_timeout = ${busyTimeoutMs}`);
+	if (settings.foreignKeys) db.run("PRAGMA foreign_keys = ON");
+	if (settings.secureDelete) db.run("PRAGMA secure_delete = ON");
+	if (settings.wal) db.run("PRAGMA journal_mode = WAL");
+	if (settings.synchronousNormal) db.run("PRAGMA synchronous = NORMAL");
+}
+
+/**
+ * Open and configure a SQLite database in one call.
+ *
+ * Does NOT create the parent directory: each store owns its directory mode
+ * (e.g. 0o700 for credential stores) and must create it beforehand.
+ *
+ * Total at the resource boundary: returns one fully configured live
+ * connection, or — when any pragma fails — closes the handle and rethrows,
+ * leaving no open handle behind.
+ */
+export function openSqliteDatabase(dbPath: string, settings: SqliteOpenSettings = {}): Database {
+	const { readonly, ...pragmas } = settings;
+	const db = readonly ? new Database(dbPath, { readonly: true }) : new Database(dbPath);
+	try {
+		configureSqliteDatabase(db, pragmas);
+	} catch (err) {
+		db.close();
+		throw err;
+	}
+	return db;
 }

--- a/packages/utils/src/sqlite.ts
+++ b/packages/utils/src/sqlite.ts
@@ -6,7 +6,7 @@
  * file damage apart from transient lock contention.
  */
 import { Database } from "bun:sqlite";
-import { shellQuote } from "./shell";
+import { powershellQuote, shellQuote } from "./shell";
 
 /**
  * SQLite's unrecoverable-file result codes: the `SQLITE_CORRUPT` family plus
@@ -22,17 +22,22 @@ export function isSqliteCorruptError(err: unknown): boolean {
 export interface SqliteRepairGuidanceOptions {
 	/** Create the recovered file under `umask 077` — for stores holding secrets. Default false. */
 	restrictPermissions?: boolean;
+	/** Target shell platform. Defaults to the host platform. */
+	platform?: NodeJS.Platform;
 }
 
 /**
  * Build copy-pasteable SQLite repair guidance that recovers, verifies, backs
  * up the original database and sidecars, then installs the repaired file.
- * Steps are `&&`-chained so failed recovery cannot reach installation;
- * restrictive permissions protect stores holding secrets during recovery.
+ * POSIX guidance uses `umask` and `&&`-chained steps so failed recovery cannot
+ * reach installation. Windows guidance targets PowerShell, where the recovered
+ * file inherits the containing directory ACL; restricted credential stores add
+ * an explicit current-user ACL after installation.
  */
 export function sqliteRepairGuidance(dbPath: string | undefined, options: SqliteRepairGuidanceOptions = {}): string {
 	if (dbPath === undefined) return "Repair the store file with sqlite3's .recover and restart.";
 
+	const platform = options.platform ?? process.platform;
 	const fixedPath = `${dbPath}.fixed`;
 	const backupPath = `${dbPath}.bak`;
 	const walPath = `${dbPath}-wal`;
@@ -40,6 +45,26 @@ export function sqliteRepairGuidance(dbPath: string | undefined, options: Sqlite
 	const backupWalPath = `${backupPath}-wal`;
 	const backupShmPath = `${backupPath}-shm`;
 	const recover = `sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(fixedPath)}`;
+	if (platform === "win32") {
+		const psDbPath = powershellQuote(dbPath);
+		const psFixedPath = powershellQuote(fixedPath);
+		const psBackupPath = powershellQuote(backupPath);
+		const psWalPath = powershellQuote(walPath);
+		const psBackupWalPath = powershellQuote(backupWalPath);
+		const psShmPath = powershellQuote(shmPath);
+		const psBackupShmPath = powershellQuote(backupShmPath);
+		const hardening = options.restrictPermissions
+			? `; icacls ${psDbPath} /inheritance:r /grant:r ("{0}:(F)" -f $env:USERNAME) | Out-Null`
+			: "";
+		const command =
+			`sqlite3 ${psDbPath} '.recover --ignore-freelist' | sqlite3 ${psFixedPath}; ` +
+			`if ($LASTEXITCODE -eq 0 -and (sqlite3 ${psFixedPath} 'PRAGMA integrity_check') -eq 'ok') { ` +
+			`Move-Item -Force ${psDbPath} ${psBackupPath}; ` +
+			`Move-Item -Force -ErrorAction SilentlyContinue ${psWalPath} ${psBackupWalPath}; ` +
+			`Move-Item -Force -ErrorAction SilentlyContinue ${psShmPath} ${psBackupShmPath}; ` +
+			`Move-Item -Force ${psFixedPath} ${psDbPath}${hardening} }`;
+		return `Stop omp, then repair the database in place in PowerShell with: ${command}`;
+	}
 	const recoverStep = options.restrictPermissions ? `(umask 077 && ${recover})` : recover;
 	const sidecarBackup = `{ mv ${shellQuote(walPath)} ${shellQuote(backupWalPath)} 2>/dev/null; mv ${shellQuote(shmPath)} ${shellQuote(backupShmPath)} 2>/dev/null; true; }`;
 	const command =

--- a/packages/utils/src/sqlite.ts
+++ b/packages/utils/src/sqlite.ts
@@ -20,7 +20,11 @@ export function isSqliteCorruptError(err: unknown): boolean {
 }
 
 export interface SqliteRepairGuidanceOptions {
-	/** Create the recovered file under `umask 077` — for stores holding secrets. Default false. */
+	/**
+	 * Restrict recovered secret-store permissions: POSIX uses `umask 077`;
+	 * Windows applies a current-user ACL after installation because there is no
+	 * umask and the recovered file inherits the containing directory ACL.
+	 */
 	restrictPermissions?: boolean;
 	/** Target shell platform. Defaults to the host platform. */
 	platform?: NodeJS.Platform;
@@ -44,7 +48,6 @@ export function sqliteRepairGuidance(dbPath: string | undefined, options: Sqlite
 	const shmPath = `${dbPath}-shm`;
 	const backupWalPath = `${backupPath}-wal`;
 	const backupShmPath = `${backupPath}-shm`;
-	const recover = `sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(fixedPath)}`;
 	if (platform === "win32") {
 		const psDbPath = powershellQuote(dbPath);
 		const psFixedPath = powershellQuote(fixedPath);
@@ -54,7 +57,7 @@ export function sqliteRepairGuidance(dbPath: string | undefined, options: Sqlite
 		const psShmPath = powershellQuote(shmPath);
 		const psBackupShmPath = powershellQuote(backupShmPath);
 		const hardening = options.restrictPermissions
-			? `; icacls ${psDbPath} /inheritance:r /grant:r ("{0}:(F)" -f $env:USERNAME) | Out-Null`
+			? `; icacls ${psDbPath} /inheritance:r /grant:r ("{0}\\{1}:(F)" -f $env:USERDOMAIN, $env:USERNAME) | Out-Null`
 			: "";
 		const command =
 			`sqlite3 ${psDbPath} '.recover --ignore-freelist' | sqlite3 ${psFixedPath}; ` +
@@ -65,6 +68,7 @@ export function sqliteRepairGuidance(dbPath: string | undefined, options: Sqlite
 			`Move-Item -Force ${psFixedPath} ${psDbPath}${hardening} }`;
 		return `Stop omp, then repair the database in place in PowerShell with: ${command}`;
 	}
+	const recover = `sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(fixedPath)}`;
 	const recoverStep = options.restrictPermissions ? `(umask 077 && ${recover})` : recover;
 	const sidecarBackup = `{ mv ${shellQuote(walPath)} ${shellQuote(backupWalPath)} 2>/dev/null; mv ${shellQuote(shmPath)} ${shellQuote(backupShmPath)} 2>/dev/null; true; }`;
 	const command =

--- a/packages/utils/src/sqlite.ts
+++ b/packages/utils/src/sqlite.ts
@@ -6,6 +6,7 @@
  * file damage apart from transient lock contention.
  */
 import { Database } from "bun:sqlite";
+import { shellQuote } from "./shell";
 
 /**
  * SQLite's unrecoverable-file result codes: the `SQLITE_CORRUPT` family plus
@@ -16,6 +17,35 @@ export function isSqliteCorruptError(err: unknown): boolean {
 	if (err === null || typeof err !== "object" || !("code" in err)) return false;
 	const code = err.code;
 	return typeof code === "string" && (code.startsWith("SQLITE_CORRUPT") || code === "SQLITE_NOTADB");
+}
+
+export interface SqliteRepairGuidanceOptions {
+	/** Create the recovered file under `umask 077` — for stores holding secrets. Default false. */
+	restrictPermissions?: boolean;
+}
+
+/**
+ * Build copy-pasteable SQLite repair guidance that recovers, verifies, backs
+ * up the original database and sidecars, then installs the repaired file.
+ * Steps are `&&`-chained so failed recovery cannot reach installation;
+ * restrictive permissions protect stores holding secrets during recovery.
+ */
+export function sqliteRepairGuidance(dbPath: string | undefined, options: SqliteRepairGuidanceOptions = {}): string {
+	if (dbPath === undefined) return "Repair the store file with sqlite3's .recover and restart.";
+
+	const fixedPath = `${dbPath}.fixed`;
+	const backupPath = `${dbPath}.bak`;
+	const walPath = `${dbPath}-wal`;
+	const shmPath = `${dbPath}-shm`;
+	const backupWalPath = `${backupPath}-wal`;
+	const backupShmPath = `${backupPath}-shm`;
+	const recover = `sqlite3 ${shellQuote(dbPath)} '.recover --ignore-freelist' | sqlite3 ${shellQuote(fixedPath)}`;
+	const recoverStep = options.restrictPermissions ? `(umask 077 && ${recover})` : recover;
+	const sidecarBackup = `{ mv ${shellQuote(walPath)} ${shellQuote(backupWalPath)} 2>/dev/null; mv ${shellQuote(shmPath)} ${shellQuote(backupShmPath)} 2>/dev/null; true; }`;
+	const command =
+		`${recoverStep} && sqlite3 ${shellQuote(fixedPath)} 'PRAGMA integrity_check' | grep -qx 'ok'` +
+		` && mv ${shellQuote(dbPath)} ${shellQuote(backupPath)} && ${sidecarBackup} && mv ${shellQuote(fixedPath)} ${shellQuote(dbPath)}`;
+	return `Stop omp, then repair the database in place with: ${command}`;
 }
 
 export interface SqlitePragmaSettings {

--- a/packages/utils/test/shell.test.ts
+++ b/packages/utils/test/shell.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { shellQuote } from "../src/shell";
+
+describe("shellQuote", () => {
+	it("wraps a plain path in single quotes", () => {
+		expect(shellQuote("/tmp/omp-agent.db")).toBe("'/tmp/omp-agent.db'");
+	});
+
+	it("balances quoting for a path containing a single quote", () => {
+		const path = "/tmp/omp's agent.db";
+		const quoted = shellQuote(path);
+		// The POSIX form: close the quote, insert an escaped literal quote,
+		// reopen the quote — '/tmp/omp'\''s agent.db'
+		expect(quoted).toBe("'/tmp/omp'\\''s agent.db'");
+		// The emitted string must be shell-balanced: every unescaped single
+		// quote (one not preceded by a backslash) toggles the open/close state,
+		// so a balanced string ends in the closed state.
+		let open = false;
+		for (let i = 0; i < quoted.length; i++) {
+			if (quoted[i] === "'" && quoted[i - 1] !== "\\") open = !open;
+		}
+		expect(open).toBe(false);
+	});
+
+	it("produces an empty single-quoted pair for the empty string", () => {
+		expect(shellQuote("")).toBe("''");
+	});
+});

--- a/packages/utils/test/sqlite.test.ts
+++ b/packages/utils/test/sqlite.test.ts
@@ -179,7 +179,7 @@ describe("isSqliteCorruptError", () => {
 describe("sqliteRepairGuidance", () => {
 	test("builds restrictive in-place repair guidance with balanced quoting", () => {
 		const dbPath = "/tmp/omp agent's.db";
-		const guidance = sqliteRepairGuidance(dbPath, { restrictPermissions: true });
+		const guidance = sqliteRepairGuidance(dbPath, { platform: "linux", restrictPermissions: true });
 		const quotedPath = "'/tmp/omp agent'\\''s.db'";
 		const fixedPath = "'/tmp/omp agent'\\''s.db.fixed'";
 		const backupPath = "'/tmp/omp agent'\\''s.db.bak'";
@@ -203,13 +203,53 @@ describe("sqliteRepairGuidance", () => {
 	});
 
 	test("does not add a restrictive umask to non-secret repair guidance", () => {
-		const guidance = sqliteRepairGuidance("/tmp/model cache.db");
+		const guidance = sqliteRepairGuidance("/tmp/model cache.db", { platform: "linux" });
 		expect(guidance).not.toContain("umask 077");
 		expect(guidance).toContain("PRAGMA integrity_check");
 		expect(guidance).toContain("mv '/tmp/model cache.db.fixed' '/tmp/model cache.db'");
 	});
 
 	test("keeps the path-free fallback", () => {
-		expect(sqliteRepairGuidance(undefined)).toBe("Repair the store file with sqlite3's .recover and restart.");
+		const fallback = "Repair the store file with sqlite3's .recover and restart.";
+		expect(sqliteRepairGuidance(undefined, { platform: "linux" })).toBe(fallback);
+		expect(sqliteRepairGuidance(undefined, { platform: "win32" })).toBe(fallback);
+	});
+
+	test("emits POSIX guidance for every non-Windows platform", () => {
+		const guidance = sqliteRepairGuidance("/tmp/model cache.db", { platform: "darwin" });
+		expect(guidance).not.toContain("PowerShell");
+		expect(guidance).toContain("grep -qx 'ok'");
+		expect(guidance).toContain("mv '/tmp/model cache.db.fixed' '/tmp/model cache.db'");
+	});
+
+	test("builds guarded PowerShell repair guidance with quoted paths", () => {
+		const dbPath = "C:\\Users\\A O'Brien\\agent.db";
+		const guidance = sqliteRepairGuidance(dbPath, { platform: "win32" });
+		const quotedPath = "'C:\\Users\\A O''Brien\\agent.db'";
+		const fixedPath = "'C:\\Users\\A O''Brien\\agent.db.fixed'";
+		const walPath = "'C:\\Users\\A O''Brien\\agent.db-wal'";
+		const backupWalPath = "'C:\\Users\\A O''Brien\\agent.db.bak-wal'";
+		const shmPath = "'C:\\Users\\A O''Brien\\agent.db-shm'";
+		const backupShmPath = "'C:\\Users\\A O''Brien\\agent.db.bak-shm'";
+
+		expect(guidance).toContain("in PowerShell");
+		expect(guidance).toContain(`sqlite3 ${quotedPath} '.recover --ignore-freelist' | sqlite3 ${fixedPath}`);
+		expect(guidance).toContain("$LASTEXITCODE -eq 0 -and");
+		expect(guidance.indexOf("$LASTEXITCODE -eq 0 -and")).toBeLessThan(guidance.indexOf("Move-Item"));
+		expect(guidance).toContain(`Move-Item -Force ${fixedPath} ${quotedPath}`);
+		expect(guidance).toContain(`Move-Item -Force -ErrorAction SilentlyContinue ${walPath} ${backupWalPath}`);
+		expect(guidance).toContain(`Move-Item -Force -ErrorAction SilentlyContinue ${shmPath} ${backupShmPath}`);
+		expect(guidance).not.toContain("umask");
+	});
+
+	test("adds ACL hardening only for restricted PowerShell repair", () => {
+		const dbPath = "C:\\Users\\me\\agent.db";
+		const restricted = sqliteRepairGuidance(dbPath, { platform: "win32", restrictPermissions: true });
+		const plain = sqliteRepairGuidance(dbPath, { platform: "win32" });
+		const hardening = `icacls '${dbPath}' /inheritance:r /grant:r ("{0}:(F)" -f $env:USERNAME) | Out-Null`;
+
+		expect(restricted).toContain(hardening);
+		expect(plain).not.toContain("icacls");
+		expect(restricted.indexOf(hardening)).toBeGreaterThan(restricted.indexOf(`Move-Item -Force '${dbPath}.fixed'`));
 	});
 });

--- a/packages/utils/test/sqlite.test.ts
+++ b/packages/utils/test/sqlite.test.ts
@@ -246,7 +246,7 @@ describe("sqliteRepairGuidance", () => {
 		const dbPath = "C:\\Users\\me\\agent.db";
 		const restricted = sqliteRepairGuidance(dbPath, { platform: "win32", restrictPermissions: true });
 		const plain = sqliteRepairGuidance(dbPath, { platform: "win32" });
-		const hardening = `icacls '${dbPath}' /inheritance:r /grant:r ("{0}:(F)" -f $env:USERNAME) | Out-Null`;
+		const hardening = `icacls '${dbPath}' /inheritance:r /grant:r ("{0}\\{1}:(F)" -f $env:USERDOMAIN, $env:USERNAME) | Out-Null`;
 
 		expect(restricted).toContain(hardening);
 		expect(plain).not.toContain("icacls");

--- a/packages/utils/test/sqlite.test.ts
+++ b/packages/utils/test/sqlite.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Contract tests for the shared SQLite opener.
+ *
+ * The load-bearing invariant (issue #2421): the busy handler is installed
+ * BEFORE the first lock-taking statement, so a concurrent WAL recovery or
+ * checkpoint makes a connection wait instead of throwing SQLITE_BUSY. The
+ * opener is also total at the resource boundary: a pragma failure closes the
+ * fresh handle before the error propagates.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	configureSqliteDatabase,
+	isSqliteCorruptError,
+	openSqliteDatabase,
+	type SqliteOpenSettings,
+} from "@oh-my-pi/pi-utils/sqlite";
+import { removeWithRetries } from "../src/temp";
+
+describe("configureSqliteDatabase", () => {
+	let tempDir = "";
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-utils-sqlite-"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("installs the busy handler before journal_mode = WAL", () => {
+		const db = new Database(path.join(tempDir, "order.db"));
+		try {
+			const statements: string[] = [];
+			const originalRun = db.run.bind(db);
+			vi.spyOn(db, "run").mockImplementation((sql: string, ...params: unknown[]) => {
+				statements.push(sql);
+				return originalRun(sql, ...(params as never[]));
+			});
+
+			configureSqliteDatabase(db, { wal: true, synchronousNormal: true, foreignKeys: true });
+
+			const busyIndex = statements.findIndex(s => s.startsWith("PRAGMA busy_timeout"));
+			const walIndex = statements.findIndex(s => s.startsWith("PRAGMA journal_mode"));
+			expect(busyIndex).toBe(0);
+			expect(walIndex).toBeGreaterThan(busyIndex);
+		} finally {
+			db.close();
+		}
+	});
+
+	test("applies the named pragmas with the requested timeout", () => {
+		const db = new Database(path.join(tempDir, "pragmas.db"));
+		try {
+			configureSqliteDatabase(db, {
+				busyTimeoutMs: 3000,
+				foreignKeys: true,
+				secureDelete: true,
+				wal: true,
+				synchronousNormal: true,
+			});
+			expect(db.query("PRAGMA busy_timeout").get()).toEqual({ timeout: 3000 });
+			expect(db.query("PRAGMA foreign_keys").get()).toEqual({ foreign_keys: 1 });
+			expect(db.query("PRAGMA secure_delete").get()).toEqual({ secure_delete: 1 });
+			expect(db.query("PRAGMA journal_mode").get()).toEqual({ journal_mode: "wal" });
+			expect(db.query("PRAGMA synchronous").get()).toEqual({ synchronous: 1 });
+		} finally {
+			db.close();
+		}
+	});
+
+	test("rejects timeouts outside the sqlite3_busy_timeout(int) contract", () => {
+		const db = new Database(path.join(tempDir, "bounds.db"));
+		try {
+			for (const bad of [-1, 1.5, Number.NaN, 2_147_483_648]) {
+				expect(() => configureSqliteDatabase(db, { busyTimeoutMs: bad })).toThrow(RangeError);
+			}
+			// The boundaries themselves are valid.
+			configureSqliteDatabase(db, { busyTimeoutMs: 0 });
+			configureSqliteDatabase(db, { busyTimeoutMs: 2_147_483_647 });
+			expect(db.query("PRAGMA busy_timeout").get()).toEqual({ timeout: 2_147_483_647 });
+		} finally {
+			db.close();
+		}
+	});
+
+	test("open-only settings cannot flow into configure (compile-time contract)", () => {
+		const db = new Database(path.join(tempDir, "types.db"));
+		try {
+			const openSettings: SqliteOpenSettings = { readonly: true, wal: true };
+			// @ts-expect-error readonly is an open-only option; configure rejects it
+			configureSqliteDatabase(db, openSettings);
+			// The pragma subset still flows when only pragma fields are set.
+			configureSqliteDatabase(db, { wal: openSettings.wal });
+			expect(db.query("PRAGMA journal_mode").get()).toEqual({ journal_mode: "wal" });
+		} finally {
+			db.close();
+		}
+	});
+});
+
+describe("openSqliteDatabase", () => {
+	let tempDir = "";
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-utils-sqlite-open-"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		if (tempDir) {
+			await removeWithRetries(tempDir);
+			tempDir = "";
+		}
+	});
+
+	test("returns a fully configured live connection", () => {
+		const db = openSqliteDatabase(path.join(tempDir, "live.db"), { wal: true });
+		try {
+			db.run("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+			db.run("INSERT INTO t VALUES (1)");
+			expect(db.query("SELECT COUNT(*) AS n FROM t").get()).toEqual({ n: 1 });
+			expect(db.query("PRAGMA journal_mode").get()).toEqual({ journal_mode: "wal" });
+			expect(db.query("PRAGMA busy_timeout").get()).toEqual({ timeout: 5000 });
+		} finally {
+			db.close();
+		}
+	});
+
+	test("closes the fresh handle before rethrowing a pragma failure", () => {
+		const closeSpy = vi.spyOn(Database.prototype, "close");
+		expect(() => openSqliteDatabase(path.join(tempDir, "doomed.db"), { busyTimeoutMs: -1 })).toThrow(RangeError);
+		expect(closeSpy).toHaveBeenCalledTimes(1);
+	});
+
+	test("does not create the parent directory", () => {
+		const nested = path.join(tempDir, "missing", "dir", "nope.db");
+		expect(() => openSqliteDatabase(nested)).toThrow();
+	});
+
+	test("opens an existing database read-only", () => {
+		const dbPath = path.join(tempDir, "ro.db");
+		const writer = openSqliteDatabase(dbPath, { wal: true });
+		writer.run("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+		writer.close();
+
+		const reader = openSqliteDatabase(dbPath, { readonly: true, busyTimeoutMs: 3000 });
+		try {
+			expect(reader.query("PRAGMA busy_timeout").get()).toEqual({ timeout: 3000 });
+			expect(reader.query("SELECT name FROM sqlite_master WHERE name = 't'").get()).toEqual({ name: "t" });
+		} finally {
+			reader.close();
+		}
+	});
+});
+
+describe("isSqliteCorruptError", () => {
+	test("matches the CORRUPT family and NOTADB, rejects everything else", () => {
+		const withCode = (code: string) => Object.assign(new Error("x"), { code });
+		expect(isSqliteCorruptError(withCode("SQLITE_CORRUPT"))).toBe(true);
+		expect(isSqliteCorruptError(withCode("SQLITE_CORRUPT_VTAB"))).toBe(true);
+		expect(isSqliteCorruptError(withCode("SQLITE_NOTADB"))).toBe(true);
+		expect(isSqliteCorruptError(withCode("SQLITE_BUSY"))).toBe(false);
+		expect(isSqliteCorruptError(new Error("plain"))).toBe(false);
+		expect(isSqliteCorruptError(null)).toBe(false);
+		expect(isSqliteCorruptError("SQLITE_CORRUPT")).toBe(false);
+	});
+});

--- a/packages/utils/test/sqlite.test.ts
+++ b/packages/utils/test/sqlite.test.ts
@@ -18,6 +18,7 @@ import {
 	isSqliteCorruptError,
 	openSqliteDatabase,
 	type SqliteOpenSettings,
+	sqliteRepairGuidance,
 } from "@oh-my-pi/pi-utils/sqlite";
 import { removeWithRetries } from "../src/temp";
 
@@ -172,5 +173,43 @@ describe("isSqliteCorruptError", () => {
 		expect(isSqliteCorruptError(new Error("plain"))).toBe(false);
 		expect(isSqliteCorruptError(null)).toBe(false);
 		expect(isSqliteCorruptError("SQLITE_CORRUPT")).toBe(false);
+	});
+});
+
+describe("sqliteRepairGuidance", () => {
+	test("builds restrictive in-place repair guidance with balanced quoting", () => {
+		const dbPath = "/tmp/omp agent's.db";
+		const guidance = sqliteRepairGuidance(dbPath, { restrictPermissions: true });
+		const quotedPath = "'/tmp/omp agent'\\''s.db'";
+		const fixedPath = "'/tmp/omp agent'\\''s.db.fixed'";
+		const backupPath = "'/tmp/omp agent'\\''s.db.bak'";
+
+		expect(guidance).toContain(
+			`Stop omp, then repair the database in place with: (umask 077 && sqlite3 ${quotedPath}`,
+		);
+		expect(guidance).toContain(`.recover --ignore-freelist' | sqlite3 ${fixedPath}`);
+		let open = false;
+		for (let index = guidance.indexOf("(umask 077 &&"); index < guidance.length; index++) {
+			if (guidance[index] === "'" && guidance[index - 1] !== "\\") open = !open;
+		}
+		expect(open).toBe(false);
+		expect(guidance.indexOf("(umask 077 &&")).toBeLessThan(
+			guidance.indexOf(`sqlite3 ${fixedPath} 'PRAGMA integrity_check'`),
+		);
+		expect(guidance.indexOf(`sqlite3 ${fixedPath} 'PRAGMA integrity_check'`)).toBeLessThan(
+			guidance.indexOf(`mv ${quotedPath} ${backupPath}`),
+		);
+		expect(guidance.endsWith(`mv ${fixedPath} ${quotedPath}`)).toBe(true);
+	});
+
+	test("does not add a restrictive umask to non-secret repair guidance", () => {
+		const guidance = sqliteRepairGuidance("/tmp/model cache.db");
+		expect(guidance).not.toContain("umask 077");
+		expect(guidance).toContain("PRAGMA integrity_check");
+		expect(guidance).toContain("mv '/tmp/model cache.db.fixed' '/tmp/model cache.db'");
+	});
+
+	test("keeps the path-free fallback", () => {
+		expect(sqliteRepairGuidance(undefined)).toBe("Repair the store file with sqlite3's .recover and restart.");
 	});
 });


### PR DESCRIPTION
> **Stacked on #7295**: this PR includes that branch's commit because it extends `packages/utils/src/sqlite.ts`, which #7295 creates. Merge after #7295 — if #7295 merges first, the identical changes resolve cleanly.

## What

**New central opener** — `configureSqliteDatabase` / `openSqliteDatabase` in `@oh-my-pi/pi-utils/sqlite`:

- `busyTimeoutMs` is validated against the `sqlite3_busy_timeout(int)` range (`[0, 2147483647]`, `RangeError` otherwise — PRAGMA takes no bind parameters) and installed **before any lock-taking statement** (the issue-#2421 invariant), then the named pragmas (`foreignKeys`, `secureDelete`), then `journal_mode = WAL`, then `synchronous = NORMAL`. No raw `pragmas: string[]` bag — ordering cannot be made optional again.
- The opener never creates directories (each store owns its directory mode) and is total at the resource boundary: a pragma failure closes the fresh handle before rethrowing.
- `SqlitePragmaSettings` carries `readonly?: never` so open-only options cannot silently flow into `configureSqliteDatabase` (compile-time contract test included).

**Migrations** — every production opener goes through the helper with its pragma set preserved 1:1: session agent storage, history storage, local memory storage, GitHub cache, auto-QA grievance store, autoresearch store, GC maintenance handles, stats.db, catalog model cache (keeps `busy_timeout = 3000` + `secure_delete = ON`, the #5780 security property), metaharness (keeps its custom `enableWal` retry), mnemopi's `enablePragmas` (keeps `foreign_keys`), and `SqliteAuthCredentialStore.#initializeSchema`. No WAL added where it was absent; `tools/read|write|fetch` keep their own opens (`strict`/`create` flags, user-specified files).

**Gap fixes** — four openers violated the invariant and are fixed, each with a pragma-order regression test: mnemopi's query cache ran `PRAGMA journal_mode=WAL` with `busy_timeout = 0`, its cost log and disaster-recovery scratch db installed no pragmas at all, and the coding-agent legacy memory-bank reader had no `busy_timeout`.

**Corrupt-store latch, generalized** — the credential-store latch pattern now covers every remaining reader that swallowed or repeatedly re-threw unrecoverable SQLite errors, reusing `isSqliteCorruptError`: mnemopi's `QueryCache` (closes and clears its connection on damage — load, put, hit-update, invalidate, eviction deletes, **and construction over an already-damaged file**; in-memory tiers keep serving), the legacy bank reader (per-path latch, bank excluded from recall), the model-perf backfill (returns 0 instead of re-throwing every process start; the corruption catch is scoped to the stats.db read only, so destination `agent.db` errors keep propagating), and the catalog model cache (degrades to cache miss; the shared handle is **closed** on latch so the file is not held open during repair).

## Why

Twenty-five production SQLite open sites hand-rolled the same pragma sequence; the audit found the four invariant violations above, and the corrupt-`agent.db` incident showed every reader needs the same damage response, not just the credential store.

## Scope notes

- `SqliteAuthCredentialStore.open()` and the stats usage-snapshot reader keep their inline pragmas: those exact lines are owned by the sibling busy-handler PRs, so all of these changes merge independently.
- `packages/coding-agent/src/session/codex-session-store.ts` (reads `~/.codex/state.db`) also lacks `busy_timeout` but is out of scope here — it is not an omp-owned database.

## Tests

- `packages/utils/test/sqlite.test.ts` — pragma ordering, named pragmas, timeout validation boundaries, totality (close-on-failure), readonly opens, compile-time type split, classifier contract.
- `packages/mnemopi/test/{query-cache,cost-log,recovery}-pragma-order.test.ts` — busy handler before first lock-taking statement per fixed site.
- `packages/mnemopi/test/query-cache-corrupt-latch.test.ts` — latch on write/invalidate/construction, one error log, in-memory tiers keep working, non-corrupt behavior unchanged.
- Latch tests for the model cache (`packages/ai/test/model-cache.test.ts`), legacy bank reader, and model-perf backfill (including destination-failure propagation) — each mutation-checked against its fix.


Closes #7302
