### PR TITLE
fix(ai): install auth-db busy handler before open()-path leases DDL

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `SqliteAuthCredentialStore.open()` running the `auth_credential_refresh_leases` DDL (`CREATE TABLE`/`CREATE INDEX`) with Bun's default `busy_timeout=0`, before the constructor's `#initializeSchema()` installed the busy handler. Under a concurrent write lock (e.g. WAL recovery on parallel omp startups) the lock-taking DDL failed immediately and, since the error wasn't BUSY-classified, bypassed `open()`'s bounded retry loop. The busy handler is now installed on the connection immediately after it opens, before any lock-taking statement, honoring the issue-#2421 invariant on every entry path. ([#7298](https://github.com/can1357/oh-my-pi/issues/7298))
+
 ## [17.2.3] - 2026-08-01
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -6482,6 +6482,14 @@ export function isSqliteBusyError(err: unknown): boolean {
 	return typeof code === "string" && code.startsWith("SQLITE_BUSY");
 }
 
+/**
+ * Busy handler window (ms) installed on every auth-DB connection before any
+ * lock-taking statement. Concurrent omp startups race WAL recovery; without a
+ * non-zero `busy_timeout` (Bun defaults to 0) the first lock-taking statement
+ * fails immediately with `SQLITE_BUSY`. See issue #2421.
+ */
+const AUTH_DB_BUSY_TIMEOUT_MS = 5000;
+
 function normalizeStoredAccountId(accountId: string | null | undefined): string | null {
 	const normalized = accountId?.trim();
 	return normalized && normalized.length > 0 ? normalized : null;
@@ -6914,6 +6922,12 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			let db: Database | undefined;
 			try {
 				db = new Database(dbPath);
+				// Install the busy handler BEFORE the first lock-taking statement
+				// on this connection. The leases DDL below and the constructor's
+				// schema init both acquire locks during WAL recovery; without a
+				// non-zero `busy_timeout` they fail immediately with SQLITE_BUSY.
+				// See issue #2421.
+				SqliteAuthCredentialStore.#installBusyTimeout(db);
 				try {
 					await fs.chmod(dbPath, 0o600);
 				} catch {
@@ -6950,12 +6964,22 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		`);
 	}
 
+	/**
+	 * Install the per-connection busy handler so lock-taking statements wait for
+	 * a contended writer instead of failing immediately. MUST run before the
+	 * first lock-taking statement on the connection. See issue #2421.
+	 */
+	static #installBusyTimeout(db: Database): void {
+		db.run(`PRAGMA busy_timeout = ${AUTH_DB_BUSY_TIMEOUT_MS}`);
+	}
+
 	#initializeSchema(): void {
 		// Install the busy handler BEFORE any lock-taking statement (incl.
 		// `PRAGMA journal_mode=WAL`, which acquires an exclusive lock during WAL
 		// recovery). Without this, concurrent omp startups can crash here with
-		// `SQLITE_BUSY` / `SQLITE_BUSY_RECOVERY`. See issue #2421.
-		this.#db.run("PRAGMA busy_timeout = 5000");
+		// `SQLITE_BUSY` / `SQLITE_BUSY_RECOVERY`. Re-setting when opened via
+		// `open()` (which already installed it) is idempotent. See issue #2421.
+		SqliteAuthCredentialStore.#installBusyTimeout(this.#db);
 		this.#db.run(`
 			PRAGMA journal_mode=WAL;
 			PRAGMA synchronous=NORMAL;

--- a/packages/ai/test/auth-storage-sqlite-busy.test.ts
+++ b/packages/ai/test/auth-storage-sqlite-busy.test.ts
@@ -81,6 +81,33 @@ describe("SqliteAuthCredentialStore.open SQLITE_BUSY handling", () => {
 		}
 	});
 
+	test("installs the busy handler before the open()-path leases DDL (#7298)", async () => {
+		const dbPath = path.join(tempDir, "ordering.db");
+		const realRun = Database.prototype.run;
+		const executed: string[] = [];
+		vi.spyOn(Database.prototype, "run").mockImplementation(function (
+			this: Database,
+			...args: Parameters<typeof realRun>
+		) {
+			executed.push(typeof args[0] === "string" ? args[0] : "");
+			return realRun.apply(this, args);
+		});
+
+		const store = await SqliteAuthCredentialStore.open(dbPath);
+		try {
+			const busyIdx = executed.findIndex(sql => /busy_timeout/i.test(sql));
+			const leasesIdx = executed.findIndex(sql => /auth_credential_refresh_leases/i.test(sql));
+			expect(busyIdx).toBeGreaterThanOrEqual(0);
+			expect(leasesIdx).toBeGreaterThanOrEqual(0);
+			// `open()` runs the leases DDL before constructing the store. The busy
+			// handler MUST be installed first, or that lock-taking DDL races WAL
+			// recovery with busy_timeout=0 and fails immediately.
+			expect(busyIdx).toBeLessThan(leasesIdx);
+		} finally {
+			store.close();
+		}
+	});
+
 	test("retries through a transient SQLITE_BUSY_RECOVERY and eventually succeeds", async () => {
 		const dbPath = path.join(tempDir, "retry.db");
 		let throws = 2;


### PR DESCRIPTION
## Repro
A separate process holds the auth-DB write lock (`BEGIN IMMEDIATE`) for 1.5s while `SqliteAuthCredentialStore.open()` races it. Before the fix, `open()` fails after ~2ms: the leases DDL runs with `busy_timeout=0`, fails on the contended write, and — because the error is not BUSY-classified — bypasses the bounded retry loop entirely. A fresh Bun `Database` connection reports `PRAGMA busy_timeout` = `0`, confirming no handler was installed before that DDL.

## Cause
`SqliteAuthCredentialStore.open()` (`packages/ai/src/auth-storage.ts`) called `#ensureAuthCredentialRefreshLeasesTable(db)` — `CREATE TABLE`/`CREATE INDEX` for `auth_credential_refresh_leases`, lock-taking DDL — immediately after `new Database(dbPath)`. `PRAGMA busy_timeout = 5000` was only issued later, inside the constructor's `#initializeSchema()`, which the constructor reaches after the leases DDL has already run. This violates the issue-#2421 invariant: install the busy handler before any lock-taking statement.

## Fix
- Added a shared `static #installBusyTimeout(db)` helper and an `AUTH_DB_BUSY_TIMEOUT_MS` constant (was a hardcoded `5000`).
- `open()` now calls `#installBusyTimeout(db)` immediately after `new Database(dbPath)`, before the leases DDL.
- `#initializeSchema()` reuses the same helper (idempotent when `open()` already installed it), so the direct-construction path (`new SqliteAuthCredentialStore(db)`) is unchanged.
- Added a regression test in `auth-storage-sqlite-busy.test.ts` recording `Database.prototype.run` call order and asserting the busy PRAGMA precedes the `auth_credential_refresh_leases` DDL. The existing WAL-mode test passed even with the bug; the new test fails on pre-fix code.

## Verification
`bun test test/auth-storage-sqlite-busy.test.ts test/auth-storage-close-releases-handles.test.ts test/auth-storage-block-persistence.test.ts` → 22 pass, 0 fail. Confirmed the new ordering test fails on the pre-fix code (leases DDL at run index 0, busy PRAGMA at index 1) and passes after the fix; the subprocess repro flips from `FAILED after ~2ms` to `SUCCEEDED after ~1548ms`. Fixes #7298