### PR TITLE
fix(ai): latch and surface a corrupt credential-block store

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a corrupt credential store (`agent.db`) silently disabling every persisted rate-limit block. `AuthStorage` caught unrecoverable SQLite errors (`SQLITE_CORRUPT` family / `SQLITE_NOTADB`) from the persisted block read/write paths at `debug` level with no latch, so the broken store was re-queried on every credential evaluation while blocks quietly stopped applying. The first unrecoverable error is now reported once at `error` level with the store location and repair guidance, and every later persisted-block read/write short-circuits for the process lifetime; in-memory backoff still preserves availability ([#7296](https://github.com/can1357/oh-my-pi/issues/7296)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1264,6 +1264,15 @@ export class AuthStorage {
 	#credentialBackoff: Map<string, Map<number, number>> = new Map();
 	/** Earliest time a freshly-set in-memory block may be cleared by live usage reconciliation. */
 	#credentialBackoffProbeAfter: Map<string, Map<number, number>> = new Map();
+	/**
+	 * Latched true once the persistent credential-block store reports an
+	 * unrecoverable error (SQLite corruption / not-a-database). While set, every
+	 * persisted-block read and write short-circuits for the life of the process:
+	 * availability is preserved through {@link AuthStorage.#credentialBackoff}, but
+	 * cross-process persistence is abandoned rather than re-querying a broken store
+	 * on every credential evaluation.
+	 */
+	#persistedBlockStoreDamaged = false;
 	#usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
 	#rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
 	#usageCache: UsageCache;
@@ -1701,11 +1710,16 @@ export class AuthStorage {
 		providerKey: string,
 		blockScope: string | undefined,
 	): number | undefined {
+		if (this.#persistedBlockStoreDamaged) return undefined;
 		const getCredentialBlock = this.#store.getCredentialBlock?.bind(this.#store);
 		if (!getCredentialBlock) return undefined;
 		try {
 			return getCredentialBlock(credentialId, providerKey, blockScope ?? "");
 		} catch (err) {
+			if (isSqliteCorruptionError(err)) {
+				this.#reportDamagedBlockStore(err);
+				return undefined;
+			}
 			logger.debug("Failed to read credential block from persistent store", {
 				err,
 				credentialId,
@@ -1792,7 +1806,7 @@ export class AuthStorage {
 		this.#invalidateUsageReportCache(provider);
 
 		const upsertCredentialBlock = this.#store.upsertCredentialBlock?.bind(this.#store);
-		if (!upsertCredentialBlock) return;
+		if (!upsertCredentialBlock || this.#persistedBlockStoreDamaged) return;
 		const credentialId = this.#getStoredCredentials(provider)[credentialIndex]?.id;
 		if (credentialId === undefined) return;
 		try {
@@ -1803,6 +1817,10 @@ export class AuthStorage {
 				blockedUntilMs: nextBlockedUntil,
 			});
 		} catch (err) {
+			if (isSqliteCorruptionError(err)) {
+				this.#reportDamagedBlockStore(err);
+				return;
+			}
 			logger.debug("Failed to persist credential block", {
 				err,
 				credentialId,
@@ -1812,6 +1830,24 @@ export class AuthStorage {
 				blockedUntilMs: nextBlockedUntil,
 			});
 		}
+	}
+
+	/**
+	 * Latches {@link AuthStorage.#persistedBlockStoreDamaged} on the first
+	 * unrecoverable persisted-block store error and surfaces it once at `error`
+	 * level with the store location, so an operator can repair or replace it.
+	 * Later reads/writes short-circuit silently — the in-memory backoff map keeps
+	 * rate-limit blocks applying for the life of the process; only cross-process
+	 * persistence is lost.
+	 */
+	#reportDamagedBlockStore(err: unknown): void {
+		if (this.#persistedBlockStoreDamaged) return;
+		this.#persistedBlockStoreDamaged = true;
+		const store = this.#sourceLabel ?? `local ${getAgentDbPath()}`;
+		logger.error(
+			"Persistent credential store is corrupt; cross-process rate-limit persistence is disabled for this process. In-memory backoff still applies. Repair the store with `sqlite3 <path> '.recover'` or delete it to recreate on next login.",
+			{ err, store },
+		);
 	}
 
 	/**
@@ -6480,6 +6516,19 @@ export function isSqliteBusyError(err: unknown): boolean {
 	if (err === null || typeof err !== "object") return false;
 	const code = (err as { code?: unknown }).code;
 	return typeof code === "string" && code.startsWith("SQLITE_BUSY");
+}
+
+/**
+ * SQLite's unrecoverable-corruption result codes — the `SQLITE_CORRUPT` family
+ * (base plus extended variants like `SQLITE_CORRUPT_VTAB` / `SQLITE_CORRUPT_INDEX`)
+ * and `SQLITE_NOTADB` (the file header is not a database). Unlike
+ * {@link isSqliteBusyError}, these never clear by retrying: the store must be
+ * repaired or replaced, so callers latch and stop touching it.
+ */
+export function isSqliteCorruptionError(err: unknown): boolean {
+	if (err === null || typeof err !== "object" || !("code" in err)) return false;
+	const code = err.code;
+	return typeof code === "string" && (code.startsWith("SQLITE_CORRUPT") || code === "SQLITE_NOTADB");
 }
 
 function normalizeStoredAccountId(accountId: string | null | undefined): string | null {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1716,10 +1716,7 @@ export class AuthStorage {
 		try {
 			return getCredentialBlock(credentialId, providerKey, blockScope ?? "");
 		} catch (err) {
-			if (isSqliteCorruptionError(err)) {
-				this.#reportDamagedBlockStore(err);
-				return undefined;
-			}
+			if (this.#handlePersistedBlockStoreError(err)) return undefined;
 			logger.debug("Failed to read credential block from persistent store", {
 				err,
 				credentialId,
@@ -1817,10 +1814,7 @@ export class AuthStorage {
 				blockedUntilMs: nextBlockedUntil,
 			});
 		} catch (err) {
-			if (isSqliteCorruptionError(err)) {
-				this.#reportDamagedBlockStore(err);
-				return;
-			}
+			if (this.#handlePersistedBlockStoreError(err)) return;
 			logger.debug("Failed to persist credential block", {
 				err,
 				credentialId,
@@ -1830,6 +1824,12 @@ export class AuthStorage {
 				blockedUntilMs: nextBlockedUntil,
 			});
 		}
+	}
+
+	#handlePersistedBlockStoreError(err: unknown): boolean {
+		if (!isSqliteCorruptionError(err)) return false;
+		this.#reportDamagedBlockStore(err);
+		return true;
 	}
 
 	/**
@@ -6376,16 +6376,30 @@ export class AuthStorage {
 	 * Broker-server seam: list non-expired persisted blocks for snapshot entries.
 	 */
 	listCredentialBlocks(credentialIds: readonly number[]): StoredCredentialBlock[] {
-		return this.#store.listCredentialBlocks?.(credentialIds) ?? [];
+		if (this.#persistedBlockStoreDamaged) return [];
+		const listCredentialBlocks = this.#store.listCredentialBlocks?.bind(this.#store);
+		if (!listCredentialBlocks) return [];
+		try {
+			return listCredentialBlocks(credentialIds);
+		} catch (err) {
+			if (this.#handlePersistedBlockStoreError(err)) return [];
+			throw err;
+		}
 	}
 
 	/**
 	 * Broker-server seam: persist one credential block and notify snapshot waiters.
 	 */
 	upsertCredentialBlock(block: StoredCredentialBlock): void {
+		if (this.#persistedBlockStoreDamaged) return;
 		const upsertCredentialBlock = this.#store.upsertCredentialBlock?.bind(this.#store);
 		if (!upsertCredentialBlock) return;
-		upsertCredentialBlock(block);
+		try {
+			upsertCredentialBlock(block);
+		} catch (err) {
+			if (this.#handlePersistedBlockStoreError(err)) return;
+			throw err;
+		}
 		this.#invalidateUsageReportCacheForProviderKey(block.providerKey);
 		this.#bumpGeneration("credential-block");
 	}
@@ -6394,17 +6408,29 @@ export class AuthStorage {
 	 * Broker-server seam: clear all persisted blocks for one credential and notify snapshot waiters.
 	 */
 	deleteCredentialBlock(credentialId: number, providerKey: string, blockScope: string): void {
+		if (this.#persistedBlockStoreDamaged) return;
 		const deleteCredentialBlock = this.#store.deleteCredentialBlock?.bind(this.#store);
 		if (!deleteCredentialBlock) return;
-		deleteCredentialBlock(credentialId, providerKey, blockScope);
+		try {
+			deleteCredentialBlock(credentialId, providerKey, blockScope);
+		} catch (err) {
+			if (this.#handlePersistedBlockStoreError(err)) return;
+			throw err;
+		}
 		this.#invalidateUsageReportCacheForProviderKey(providerKey);
 		this.#bumpGeneration("credential-block");
 	}
 
 	deleteCredentialBlocks(credentialId: number): void {
+		if (this.#persistedBlockStoreDamaged) return;
 		const deleteCredentialBlocks = this.#store.deleteCredentialBlocks?.bind(this.#store);
 		if (!deleteCredentialBlocks) return;
-		deleteCredentialBlocks(credentialId);
+		try {
+			deleteCredentialBlocks(credentialId);
+		} catch (err) {
+			if (this.#handlePersistedBlockStoreError(err)) return;
+			throw err;
+		}
 		this.#bumpGeneration("credential-block");
 	}
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1727,6 +1727,18 @@ export class AuthStorage {
 		}
 	}
 
+	#readPersistedCredentialBlockReconcileAfter(credentialId: number, providerKey: string, blockScope: string): number {
+		if (this.#persistedBlockStoreDamaged) return 0;
+		const getCredentialBlockReconcileAfter = this.#store.getCredentialBlockReconcileAfter?.bind(this.#store);
+		if (!getCredentialBlockReconcileAfter) return 0;
+		try {
+			return getCredentialBlockReconcileAfter(credentialId, providerKey, blockScope) ?? 0;
+		} catch (err) {
+			if (this.#handlePersistedBlockStoreError(err)) return 0;
+			throw err;
+		}
+	}
+
 	/** Returns block expiry timestamp for a credential, checking unscoped and scoped blocks. */
 	#getCredentialBlockedUntil(
 		provider: string,
@@ -5898,9 +5910,12 @@ export class AuthStorage {
 		const scopedBackoffKey = this.#toScopedBackoffKey(providerKey, blockScope);
 		const globalProbeAfterMs = this.#credentialBackoffProbeAfter.get(providerKey)?.get(credentialIndex) ?? 0;
 		const scopedProbeAfterMs = this.#credentialBackoffProbeAfter.get(scopedBackoffKey)?.get(credentialIndex) ?? 0;
-		const getStoreReconcileAfter = this.#store.getCredentialBlockReconcileAfter?.bind(this.#store);
-		const storeGlobalProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, "") ?? 0;
-		const storeScopedProbeAfterMs = getStoreReconcileAfter?.(credentialId, providerKey, blockScope ?? "") ?? 0;
+		const storeGlobalProbeAfterMs = this.#readPersistedCredentialBlockReconcileAfter(credentialId, providerKey, "");
+		const storeScopedProbeAfterMs = this.#readPersistedCredentialBlockReconcileAfter(
+			credentialId,
+			providerKey,
+			blockScope ?? "",
+		);
 		if (Math.max(globalProbeAfterMs, scopedProbeAfterMs, storeGlobalProbeAfterMs, storeScopedProbeAfterMs) > nowMs) {
 			return;
 		}

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1844,6 +1844,12 @@ export class AuthStorage {
 		return true;
 	}
 
+	#assertPersistedBlockStoreWritable(): void {
+		if (!this.#persistedBlockStoreDamaged) return;
+		const store = this.#sourceLabel ?? `local ${getAgentDbPath()}`;
+		throw new Error(`Persistent credential block store ${store} is unavailable after SQLite corruption`);
+	}
+
 	/**
 	 * Latches {@link AuthStorage.#persistedBlockStoreDamaged} on the first
 	 * unrecoverable persisted-block store error and surfaces it once at `error`
@@ -6406,13 +6412,13 @@ export class AuthStorage {
 	 * Broker-server seam: persist one credential block and notify snapshot waiters.
 	 */
 	upsertCredentialBlock(block: StoredCredentialBlock): void {
-		if (this.#persistedBlockStoreDamaged) return;
+		this.#assertPersistedBlockStoreWritable();
 		const upsertCredentialBlock = this.#store.upsertCredentialBlock?.bind(this.#store);
 		if (!upsertCredentialBlock) return;
 		try {
 			upsertCredentialBlock(block);
 		} catch (err) {
-			if (this.#handlePersistedBlockStoreError(err)) return;
+			if (this.#handlePersistedBlockStoreError(err)) this.#assertPersistedBlockStoreWritable();
 			throw err;
 		}
 		this.#invalidateUsageReportCacheForProviderKey(block.providerKey);
@@ -6423,13 +6429,13 @@ export class AuthStorage {
 	 * Broker-server seam: clear all persisted blocks for one credential and notify snapshot waiters.
 	 */
 	deleteCredentialBlock(credentialId: number, providerKey: string, blockScope: string): void {
-		if (this.#persistedBlockStoreDamaged) return;
+		this.#assertPersistedBlockStoreWritable();
 		const deleteCredentialBlock = this.#store.deleteCredentialBlock?.bind(this.#store);
 		if (!deleteCredentialBlock) return;
 		try {
 			deleteCredentialBlock(credentialId, providerKey, blockScope);
 		} catch (err) {
-			if (this.#handlePersistedBlockStoreError(err)) return;
+			if (this.#handlePersistedBlockStoreError(err)) this.#assertPersistedBlockStoreWritable();
 			throw err;
 		}
 		this.#invalidateUsageReportCacheForProviderKey(providerKey);
@@ -6437,13 +6443,13 @@ export class AuthStorage {
 	}
 
 	deleteCredentialBlocks(credentialId: number): void {
-		if (this.#persistedBlockStoreDamaged) return;
+		this.#assertPersistedBlockStoreWritable();
 		const deleteCredentialBlocks = this.#store.deleteCredentialBlocks?.bind(this.#store);
 		if (!deleteCredentialBlocks) return;
 		try {
 			deleteCredentialBlocks(credentialId);
 		} catch (err) {
-			if (this.#handlePersistedBlockStoreError(err)) return;
+			if (this.#handlePersistedBlockStoreError(err)) this.#assertPersistedBlockStoreWritable();
 			throw err;
 		}
 		this.#bumpGeneration("credential-block");

--- a/packages/ai/test/auth-storage-model-usage-health.test.ts
+++ b/packages/ai/test/auth-storage-model-usage-health.test.ts
@@ -468,4 +468,81 @@ describe("AuthStorage corrupt persisted block store", () => {
 		expect(upsertCalls).toBe(1);
 		expect(errorSpy).toHaveBeenCalledTimes(1);
 	});
+
+	it("latches every broker-facing block operation independently", async () => {
+		const block = {
+			credentialId: 1,
+			providerKey: "anthropic:api_key",
+			blockScope: "",
+			blockedUntilMs: Date.now() + 60_000,
+		};
+		const scenarios: Array<{
+			name: string;
+			install: (store: AuthCredentialStore, recordCall: () => void) => void;
+			invoke: (storage: AuthStorage) => unknown;
+			fallback: unknown;
+		}> = [
+			{
+				name: "listCredentialBlocks",
+				install: (store, recordCall) => {
+					store.listCredentialBlocks = () => {
+						recordCall();
+						throw sqliteCorruptError();
+					};
+				},
+				invoke: storage => storage.listCredentialBlocks([1]),
+				fallback: [],
+			},
+			{
+				name: "upsertCredentialBlock",
+				install: (store, recordCall) => {
+					store.upsertCredentialBlock = () => {
+						recordCall();
+						throw sqliteCorruptError();
+					};
+				},
+				invoke: storage => storage.upsertCredentialBlock(block),
+				fallback: undefined,
+			},
+			{
+				name: "deleteCredentialBlock",
+				install: (store, recordCall) => {
+					store.deleteCredentialBlock = () => {
+						recordCall();
+						throw sqliteCorruptError();
+					};
+				},
+				invoke: storage => storage.deleteCredentialBlock(1, block.providerKey, block.blockScope),
+				fallback: undefined,
+			},
+			{
+				name: "deleteCredentialBlocks",
+				install: (store, recordCall) => {
+					store.deleteCredentialBlocks = () => {
+						recordCall();
+						throw sqliteCorruptError();
+					};
+				},
+				invoke: storage => storage.deleteCredentialBlocks(1),
+				fallback: undefined,
+			},
+		];
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		for (const scenario of scenarios) {
+			const store = makeStore([]);
+			let calls = 0;
+			scenario.install(store, () => {
+				calls += 1;
+			});
+			const storage = new AuthStorage(store);
+			await storage.reload();
+			storages.push(storage);
+
+			expect(scenario.invoke(storage), scenario.name).toEqual(scenario.fallback);
+			expect(scenario.invoke(storage), scenario.name).toEqual(scenario.fallback);
+			expect(calls, scenario.name).toBe(1);
+		}
+		expect(errorSpy).toHaveBeenCalledTimes(scenarios.length);
+	});
 });

--- a/packages/ai/test/auth-storage-model-usage-health.test.ts
+++ b/packages/ai/test/auth-storage-model-usage-health.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import {
 	type ApiKeyCredential,
 	type AuthCredential,
@@ -7,6 +7,7 @@ import {
 	type StoredAuthCredential,
 } from "@oh-my-pi/pi-ai/auth-storage";
 import type { CredentialRankingStrategy, UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import { logger } from "@oh-my-pi/pi-utils";
 
 interface CacheEntry {
 	value: string;
@@ -394,5 +395,77 @@ describe("AuthStorage model usage health", () => {
 		controller.abort();
 		await expect(health).rejects.toThrow("usage fetch aborted");
 		pending.resolve(report("key-1", [limit("short", 0.2)]));
+	});
+});
+
+function sqliteCorruptError(): Error & { code: string } {
+	const err = new Error("database disk image is malformed (11) (Rowid 77291 out of order)") as Error & {
+		code: string;
+	};
+	err.code = "SQLITE_CORRUPT";
+	return err;
+}
+
+describe("AuthStorage corrupt persisted block store", () => {
+	const storages: AuthStorage[] = [];
+	afterEach(() => {
+		for (const storage of storages) storage.close();
+		storages.length = 0;
+		vi.restoreAllMocks();
+	});
+
+	it("latches a corrupt block read, reports once, and stops re-querying the store", async () => {
+		const rows = [oauthRow(1)];
+		const store = makeStore(rows);
+		let getBlockCalls = 0;
+		store.getCredentialBlock = () => {
+			getBlockCalls += 1;
+			throw sqliteCorruptError();
+		};
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		const storage = new AuthStorage(store, {
+			usageProviderResolver: provider =>
+				provider === "anthropic"
+					? makeUsageProvider({ "account-1": report("account-1", [limit("short", 0.2)]) })
+					: undefined,
+			rankingStrategyResolver: provider => (provider === "anthropic" ? strategy : undefined),
+			configValueResolver: async value => value,
+		});
+		await storage.reload();
+		storages.push(storage);
+
+		const first = await storage.getModelUsageHealth("anthropic", { modelId: "claude", reserveFraction: 0.1 });
+		const second = await storage.getModelUsageHealth("anthropic", { modelId: "claude", reserveFraction: 0.1 });
+
+		// Availability is preserved: a corrupt persisted read fails open to the
+		// in-memory backoff (no block) instead of spuriously forcing depletion.
+		expect(first.state).toBe("healthy");
+		expect(second.state).toBe("healthy");
+		// Latched on the first unrecoverable error: the broken store is queried
+		// exactly once despite three block-scope reads per health check across two calls.
+		expect(getBlockCalls).toBe(1);
+		expect(errorSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("latches a corrupt block write and stops attempting persistence", async () => {
+		const rows = [apiKeyRow(1)];
+		const store = makeStore(rows);
+		let upsertCalls = 0;
+		store.upsertCredentialBlock = () => {
+			upsertCalls += 1;
+			throw sqliteCorruptError();
+		};
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		const storage = new AuthStorage(store);
+		await storage.reload();
+		storages.push(storage);
+
+		await storage.markUsageLimitReached("anthropic", undefined, { apiKey: "key-1" });
+		await storage.markUsageLimitReached("anthropic", undefined, { apiKey: "key-1" });
+
+		// First upsert throws SQLITE_CORRUPT and latches; the second mark skips
+		// the store entirely rather than retrying a broken write on every 429.
+		expect(upsertCalls).toBe(1);
+		expect(errorSpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/ai/test/auth-storage-model-usage-health.test.ts
+++ b/packages/ai/test/auth-storage-model-usage-health.test.ts
@@ -469,6 +469,59 @@ describe("AuthStorage corrupt persisted block store", () => {
 		expect(errorSpy).toHaveBeenCalledTimes(1);
 	});
 
+	it("skips reconcile-after reads after a corrupt Codex block write latches the store", async () => {
+		const credential: AuthCredential = {
+			type: "oauth",
+			access: "access-1",
+			refresh: "refresh-1",
+			expires: Date.now() + 60 * 60_000,
+			accountId: "account-1",
+		};
+		const rows: StoredAuthCredential[] = [{ id: 1, provider: "openai-codex", credential, disabledCause: null }];
+		const healthyReport: UsageReport = {
+			provider: "openai-codex",
+			fetchedAt: Date.now(),
+			limits: [limit("short", 0.2)],
+			metadata: { accountId: "account-1", allowed: true, limitReached: false },
+		};
+		const usageProvider: UsageProvider = {
+			id: "openai-codex",
+			fetchUsage: async () => healthyReport,
+		};
+		const store = makeStore(rows);
+		let upsertCalls = 0;
+		let reconcileAfterCalls = 0;
+		store.upsertCredentialBlock = () => {
+			upsertCalls += 1;
+			throw sqliteCorruptError();
+		};
+		store.getCredentialBlockReconcileAfter = () => {
+			reconcileAfterCalls += 1;
+			throw sqliteCorruptError();
+		};
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		const storage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "openai-codex" ? usageProvider : undefined),
+			rankingStrategyResolver: provider => (provider === "openai-codex" ? strategy : undefined),
+			configValueResolver: async value => value,
+		});
+		await storage.reload();
+		storages.push(storage);
+
+		await storage.markUsageLimitReached("openai-codex", undefined, {
+			credentialId: 1,
+			modelId: "claude",
+		});
+		const health = await storage.getModelUsageHealth("openai-codex", {
+			modelId: "claude",
+			reserveFraction: 0.1,
+		});
+
+		expect(upsertCalls).toBe(1);
+		expect(reconcileAfterCalls).toBe(0);
+		expect(errorSpy).toHaveBeenCalledTimes(1);
+		expect(health.state).toBe("depleted");
+	});
 	it("latches every broker-facing block operation independently", async () => {
 		const block = {
 			credentialId: 1,

--- a/packages/ai/test/auth-storage-model-usage-health.test.ts
+++ b/packages/ai/test/auth-storage-model-usage-health.test.ts
@@ -534,6 +534,7 @@ describe("AuthStorage corrupt persisted block store", () => {
 			install: (store: AuthCredentialStore, recordCall: () => void) => void;
 			invoke: (storage: AuthStorage) => unknown;
 			fallback: unknown;
+			failsWhenLatched: boolean;
 		}> = [
 			{
 				name: "listCredentialBlocks",
@@ -545,6 +546,7 @@ describe("AuthStorage corrupt persisted block store", () => {
 				},
 				invoke: storage => storage.listCredentialBlocks([1]),
 				fallback: [],
+				failsWhenLatched: false,
 			},
 			{
 				name: "upsertCredentialBlock",
@@ -556,6 +558,7 @@ describe("AuthStorage corrupt persisted block store", () => {
 				},
 				invoke: storage => storage.upsertCredentialBlock(block),
 				fallback: undefined,
+				failsWhenLatched: true,
 			},
 			{
 				name: "deleteCredentialBlock",
@@ -567,6 +570,7 @@ describe("AuthStorage corrupt persisted block store", () => {
 				},
 				invoke: storage => storage.deleteCredentialBlock(1, block.providerKey, block.blockScope),
 				fallback: undefined,
+				failsWhenLatched: true,
 			},
 			{
 				name: "deleteCredentialBlocks",
@@ -578,6 +582,7 @@ describe("AuthStorage corrupt persisted block store", () => {
 				},
 				invoke: storage => storage.deleteCredentialBlocks(1),
 				fallback: undefined,
+				failsWhenLatched: true,
 			},
 		];
 		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
@@ -592,8 +597,13 @@ describe("AuthStorage corrupt persisted block store", () => {
 			await storage.reload();
 			storages.push(storage);
 
-			expect(scenario.invoke(storage), scenario.name).toEqual(scenario.fallback);
-			expect(scenario.invoke(storage), scenario.name).toEqual(scenario.fallback);
+			if (scenario.failsWhenLatched) {
+				expect(() => scenario.invoke(storage), scenario.name).toThrow("unavailable after SQLite corruption");
+				expect(() => scenario.invoke(storage), scenario.name).toThrow("unavailable after SQLite corruption");
+			} else {
+				expect(scenario.invoke(storage), scenario.name).toEqual(scenario.fallback);
+				expect(scenario.invoke(storage), scenario.name).toEqual(scenario.fallback);
+			}
 			expect(calls, scenario.name).toBe(1);
 		}
 		expect(errorSpy).toHaveBeenCalledTimes(scenarios.length);

--- a/packages/ai/test/remote-auth-store.test.ts
+++ b/packages/ai/test/remote-auth-store.test.ts
@@ -756,12 +756,12 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 		}
 	});
 
-	test("RemoteAuthCredentialStore reads snapshot blocks and applies upserts before broker acknowledgement", () => {
+	test("applies block upserts before broker acknowledgement and retains them when persistence is rejected", async () => {
 		const futureBlock = Date.now() + 60_000;
 		const laterBlock = futureBlock + 60_000;
 		const brokerClient = new AuthBrokerClient({ url: "http://127.0.0.1:9", token: "unused" });
 		const fetchSnapshotPending = Promise.withResolvers<FetchSnapshotResult>();
-		vi.spyOn(brokerClient, "fetchSnapshot").mockReturnValue(fetchSnapshotPending.promise);
+		const fetchSnapshotSpy = vi.spyOn(brokerClient, "fetchSnapshot").mockReturnValue(fetchSnapshotPending.promise);
 		const upsertPending = Promise.withResolvers<CredentialBlockResponse>();
 		const upsertSpy = vi.spyOn(brokerClient, "upsertCredentialBlock").mockReturnValue(upsertPending.promise);
 		const remoteStore = new RemoteAuthCredentialStore({
@@ -797,6 +797,7 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 		try {
 			expect(remoteStore.getCredentialBlock(7, "anthropic:oauth", "tier:fable")).toBe(futureBlock);
 
+			fetchSnapshotSpy.mockClear();
 			remoteStore.upsertCredentialBlock({
 				credentialId: 7,
 				providerKey: "anthropic:oauth",
@@ -813,6 +814,11 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 			remoteStore.deleteCredentialBlock(7, "anthropic:oauth", "tier:fable");
 			expect(remoteStore.getCredentialBlock(7, "anthropic:oauth", "tier:fable")).toBe(laterBlock);
 			expect(remoteStore.getCredentialBlock(7, "anthropic:oauth", "shared")).toBe(futureBlock);
+			upsertPending.reject(new Error("500 persistent credential block store unavailable"));
+			await upsertPending.promise.catch(() => {});
+			await Promise.resolve();
+			expect(fetchSnapshotSpy).not.toHaveBeenCalled();
+			expect(remoteStore.getCredentialBlock(7, "anthropic:oauth", "tier:fable")).toBe(laterBlock);
 		} finally {
 			remoteStore.close();
 		}


### PR DESCRIPTION
## Repro
Backing `AuthStorage` with a credential store whose `getCredentialBlock`/`upsertCredentialBlock` throw a `SQLITE_CORRUPT`-coded error (`database disk image is malformed ... Rowid ... out of order`, exactly what `bun:sqlite` raises on a corrupt `agent.db`), then issuing 5 `getModelUsageHealth()` calls and 2 `markUsageLimitReached()` calls, showed the broken store being re-queried on every credential evaluation:

```
{"getBlockCalls":15,"upsertCalls":2}
```

Three block-scope reads per health check × 5 = 15 queries, plus a failed persist per 429 mark — all swallowed at `debug`, so persisted rate-limit blocks silently stopped applying while the corrupt store was hammered.

## Cause
`AuthStorage.#readPersistedCredentialBlock` and `#markCredentialBlocked` (`packages/ai/src/auth-storage.ts`) wrapped the store call in a `try/catch` that logged every error at `debug` and returned, with no latch. Unrecoverable SQLite corruption (`SQLITE_CORRUPT` family / `SQLITE_NOTADB`) is therefore indistinguishable from a transient miss: callers read the `undefined` return as "not blocked" (fail-open toward the rate-limited account), the store is re-queried unboundedly, and nothing surfaces above `debug` because the in-memory backoff map keeps availability intact.

## Fix
- Add exported `isSqliteCorruptionError` next to the existing `isSqliteBusyError`, matching the `SQLITE_CORRUPT*` family and `SQLITE_NOTADB`.
- Add a per-`AuthStorage` `#persistedBlockStoreDamaged` latch and `#reportDamagedBlockStore(err)`, which logs once at `error` level with the store location (`sourceLabel` or `getAgentDbPath()`) and repair guidance.
- `#readPersistedCredentialBlock` and `#markCredentialBlocked` now short-circuit while latched, and trip the latch on the first corruption-family error instead of logging at `debug`. Other (transient) errors keep the previous `debug` behavior.

## Verification
`bun test test/auth-storage-model-usage-health.test.ts` (19 pass, incl. 2 new regression tests: corrupt read latches/reports-once/stops re-querying with availability preserved; corrupt write latches and stops persisting). `bun test test/auth-storage-block-persistence.test.ts test/auth-storage-codex-selection.test.ts` (72 pass, no regressions). `bun check` clean (biome + tsgo). The repro above now reports `{"getBlockCalls":1,"upsertCalls":0}` — one query, latched, corruption surfaced once at `error`. Fixes #7296