### PR TITLE
fix(title): reject overlong auto-generated session titles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/src/tiny/text.ts
+++ b/packages/coding-agent/src/tiny/text.ts
@@ -142,6 +142,17 @@ export function isLowSignalTitleInput(message: string): boolean {
  */
 export const NO_TITLE_SENTINEL = "none";
 
+/**
+ * Upper bounds on an accepted title. Titling is a 3-7 word task, so any output
+ * past these limits is a model that ignored the task and answered the user's
+ * message instead — its whole reply must not become the session title (issue
+ * #7303). Rejecting (return null) lets the caller defer titling to the next
+ * user turn; truncating would keep half an assistant blob, which is still an
+ * assistant blob.
+ */
+const MAX_TITLE_CHARS = 80;
+const MAX_TITLE_WORDS = 12;
+
 export function normalizeGeneratedTitle(value: string | null | undefined, sourceText?: string): string | null {
 	const firstLine = value?.trim().split(/\r?\n/, 1)[0]?.trim();
 	if (!firstLine) return null;
@@ -154,6 +165,7 @@ export function normalizeGeneratedTitle(value: string | null | undefined, source
 		.replace(/[.!?]$/, "")
 		.trim();
 	if (!title || title.toLowerCase() === NO_TITLE_SENTINEL) return null;
+	if (title.length > MAX_TITLE_CHARS || (title.match(TITLE_WORD)?.length ?? 0) > MAX_TITLE_WORDS) return null;
 	return sourceText === undefined ? title : reconcileTitleCasing(title, sourceText);
 }
 

--- a/packages/coding-agent/test/tiny-text.test.ts
+++ b/packages/coding-agent/test/tiny-text.test.ts
@@ -142,6 +142,21 @@ describe("normalizeGeneratedTitle", () => {
 		expect(normalizeGeneratedTitle("   ")).toBeNull();
 		expect(normalizeGeneratedTitle(null)).toBeNull();
 	});
+
+	it("rejects an overlong answer the model produced instead of a title", () => {
+		// Regression (#7303): a model that ignores the titling task and answers the
+		// user's question returns a full sentence; without a length bound the whole
+		// reply became the session title. Reject so the caller defers titling.
+		const answer =
+			"I don't have context on a \"registration system\" — that's not something I recognize from this conversation, and I don't see any prior discussion or code about it here";
+		expect(normalizeGeneratedTitle(answer, "how does the registration system work?")).toBeNull();
+		// Word-count bound: 13 short words stays under the char cap but is not a title.
+		expect(
+			normalizeGeneratedTitle("one two three four five six seven eight nine ten eleven twelve thirteen"),
+		).toBeNull();
+		// A normal 3-7 word title is unaffected.
+		expect(normalizeGeneratedTitle("Investigate the title resolver bug")).toBe("Investigate the title resolver bug");
+	});
 });
 
 describe("normalizeGeneratedTitle source-aware casing", () => {


### PR DESCRIPTION
## Repro
When the tiny title model ignores the titling task and answers the first user message instead, its full reply becomes the session title verbatim. Feeding the observed reply through `normalizeGeneratedTitle` reproduces it:

```
$ cd packages/coding-agent && bun -e 'import { normalizeGeneratedTitle } from "./src/tiny/text.ts"; ...'
"I don't have context on a \"registration system\" — that's not something I recognize from this conversation, and I don't see any prior discussion or code about it here"
len= 165 words= 29
```

## Cause
`normalizeGeneratedTitle` in `packages/coding-agent/src/tiny/text.ts` validated only emptiness and the `none` sentinel and stripped quotes/trailing punctuation — no length or word-count bound — so any single-line prose passed. Both the online path (`utils/title-generator.ts` → `extractGeneratedTitle` → `normalizeGeneratedTitle`) and the local worker path (`tiny/worker.ts`) funnel through this normalizer, so the gap affected both.

## Fix
- Add `MAX_TITLE_CHARS = 80` / `MAX_TITLE_WORDS = 12` bounds to `normalizeGeneratedTitle`; return `null` when the candidate exceeds either, so the caller defers titling to the next user turn instead of accepting an assistant blob.
- Regression tests in `test/tiny-text.test.ts` cover the observed 29-word answer, the 13-word word-count boundary, and a normal 3-7 word title that must still pass.
- Changelog entry under `[Unreleased]`.

## Verification
`cd packages/coding-agent && bun test test/tiny-text.test.ts` → 43 pass / 0 fail. Manual check confirms the observed reply and a 13-word line now return `null` while `Docker client/daemon for TinyVMM` and `Investigate the title resolver bug` are preserved.

Fixes #7303