### PR TITLE
fix(stats): wait for contended usage snapshot reads

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed provider usage window stats silently showing no data during SQLite contention by installing a five-second busy timeout on read-only agent database connections ([#7300](https://github.com/can1357/oh-my-pi/issues/7300)).
+
 ## [17.1.2] - 2026-07-24
 
 ### Added

--- a/packages/stats/src/usage-windows.ts
+++ b/packages/stats/src/usage-windows.ts
@@ -59,6 +59,7 @@ export function readUsageSnapshots(sinceMs: number, dbPath = getAgentDbPath()): 
 	let db: Database | null = null;
 	try {
 		db = new Database(dbPath, { readonly: true });
+		db.run("PRAGMA busy_timeout = 5000");
 		const rows = db
 			.prepare(
 				`SELECT recorded_at, provider, account_key, email, account_id, limit_id, label, window_label, used_fraction, status

--- a/packages/stats/test/provider-stats.test.ts
+++ b/packages/stats/test/provider-stats.test.ts
@@ -183,6 +183,35 @@ describe("readUsageSnapshots", () => {
 			usedFraction: 0.3,
 		});
 	});
+
+	it("waits for a contended database instead of returning no snapshots", async () => {
+		createAgentDb([snapshot({ recordedAt: T0, usedFraction: 0.3 })]);
+		const locker = Bun.spawn(
+			[
+				process.execPath,
+				"-e",
+				`import { Database } from "bun:sqlite";
+const db = new Database(process.argv[1]);
+db.run("BEGIN EXCLUSIVE");
+process.stdout.write("locked\\n");
+// This integration probe needs a real SQLite lock lifetime; fake timers cannot advance a separate process.
+await Bun.sleep(100);
+db.run("COMMIT");
+db.close();`,
+				getAgentDbPath(),
+			],
+			{ env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "" }, stdout: "pipe", stderr: "pipe" },
+		);
+		const output = locker.stdout.getReader();
+		const ready = await output.read();
+		output.releaseLock();
+		expect(new TextDecoder().decode(ready.value)).toContain("locked");
+
+		const rows = readUsageSnapshots(0);
+		const [exitCode, stderr] = await Promise.all([locker.exited, new Response(locker.stderr).text()]);
+		expect(exitCode, stderr).toBe(0);
+		expect(rows).toHaveLength(1);
+	});
 });
 
 describe("getProviderDashboardStats", () => {


### PR DESCRIPTION
## Repro
Hold an exclusive lock on a populated agent database with `sqlite3 /tmp/omp-7300-repro.db 'BEGIN EXCLUSIVE;'`, then run `bun -e "import { readUsageSnapshots } from './packages/stats/src/usage-windows.ts'; console.log(readUsageSnapshots(0, '/tmp/omp-7300-repro.db'))"`. Before the fix, the read returned `[]` in 9 ms even though the database contained a usage snapshot.

## Cause
`readUsageSnapshots` in `packages/stats/src/usage-windows.ts` opened its read-only `bun:sqlite` connection without installing a busy handler. The connection therefore inherited SQLite's zero timeout, and the function's expected-missing-database catch path converted lock contention into an empty snapshot list.

## Fix
- Install `PRAGMA busy_timeout = 5000` immediately after opening the read-only usage database.
- Cover real lock contention with a subprocess-backed regression test that verifies the persisted snapshot is returned after the lock clears.
- Record the user-visible fix in `packages/stats/CHANGELOG.md`.

## Verification
`bun test packages/stats/test` passed: 84 tests, 0 failures. The publish gate also passed `bun check`.

Fixes #7300