### PR TITLE
feat(coding-agent): let task agents inherit parent context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added task context sources (`fresh` and `fork`), including forks from a completed parent conversation.
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -53,8 +53,12 @@ Agents marked BLOCKING run inline — results return in this call; non-blocking 
 {{/if}}
 {{/if}}
 
+- `source`: Task context source: `fresh` or `fork`. `fresh` starts with normal blank child history. `fork` clones the scheduling-time completed-parent branch or errors clearly when no completed parent boundary exists; it preserves provider cache lineage while using the selected child agent's normal model, prompt, tools, permissions, schema, and isolation. Agent type and context source are independent choices. In batch calls, a top-level `source` is inherited by items unless an item specifies its own source.
+- Prefer `fork` for work that benefits from the current conversation. Use `fresh` when independence or a clean perspective is specifically valuable.
+- Fork preserves provider cache lineage and MAY improve cache reuse only when the provider-visible request prefix is compatible; cache hits and savings are not guaranteed.
+
 # Communication
-Subagents start blank — no conversation history.{{#if ircEnabled}} Parent-to-subagent IRC delivered immediately as steering.{{/if}}
+Subagents start blank — no conversation history, except forked tasks, which carry the completed parent conversation boundary.{{#if ircEnabled}} Parent-to-subagent IRC delivered immediately as steering.{{/if}}
 Pass large payloads via `local://<path>` URIs, NEVER inline text.
 
 # Format Contracts

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2354,7 +2354,11 @@ export class SessionManager {
 		cwd: string,
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
-		options?: { suppressBreadcrumb?: boolean; sessionFile?: string },
+		options?: {
+			suppressBreadcrumb?: boolean;
+			sessionFile?: string;
+			sourceLeafId?: string | null;
+		},
 	): Promise<SessionManager> {
 		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
 		const manager = new SessionManager(cwd, dir, true, storage);
@@ -2365,7 +2369,29 @@ export class SessionManager {
 		await resolveBlobRefsInEntries(sourceEntries, manager.#blobs);
 
 		const sourceHeader = sourceEntries.find(entry => entry.type === "session") as SessionHeader | undefined;
-		const history = sourceEntries.filter(entry => entry.type !== "session") as SessionEntry[];
+		let history = sourceEntries.filter(entry => entry.type !== "session") as SessionEntry[];
+		if (options && "sourceLeafId" in options) {
+			if (options.sourceLeafId === undefined) {
+				throw new Error("Fork source leaf is unavailable");
+			}
+
+			const entriesById = new Map(history.map(entry => [entry.id, entry]));
+			const branch: SessionEntry[] = [];
+			const seen = new Set<string>();
+			let cursor: string | null = options.sourceLeafId;
+			while (cursor !== null) {
+				if (seen.has(cursor)) throw new Error(`Fork source contains a parent cycle at entry ${cursor}`);
+				seen.add(cursor);
+				const entry = entriesById.get(cursor);
+				if (!entry) throw new Error(`Fork source entry ${cursor} not found`);
+				branch.push(entry);
+				if (entry.parentId !== null && typeof entry.parentId !== "string") {
+					throw new Error(`Fork source entry ${entry.id} has an unavailable parent boundary`);
+				}
+				cursor = entry.parentId;
+			}
+			history = branch.reverse();
+		}
 		manager.#resetToNewSession(
 			{
 				parentSession: sourceHeader?.id,
@@ -2388,6 +2414,26 @@ export class SessionManager {
 		manager.#forceFileCreation = true;
 		await manager.#rewriteAtomically();
 		return manager;
+	}
+
+	/** Clone a completed branch through this manager's configured storage backend. */
+	async forkBranch(options: {
+		cwd: string;
+		sessionDir?: string;
+		sessionFile?: string;
+		sourceFile?: string;
+		sourceLeafId?: string | null;
+		suppressBreadcrumb?: boolean;
+	}): Promise<SessionManager> {
+		const sourceFile = options.sourceFile ?? this.#sessionFile;
+		if (!sourceFile) throw new Error("Cannot fork a session without a persisted transcript");
+		if (sourceFile === this.#sessionFile) {
+			await this.ensureOnDisk();
+			await this.flush();
+		} else {
+			await this.#storage.drain();
+		}
+		return SessionManager.forkFrom(sourceFile, options.cwd, options.sessionDir, this.#storage, options);
 	}
 
 	/**

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -71,6 +71,7 @@ import {
 	TASK_SUBAGENT_EVENT_CHANNEL,
 	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
 	TASK_SUBAGENT_PROGRESS_CHANNEL,
+	type TaskContextSource,
 	type TaskToolDetails,
 	type YieldItem,
 } from "./types";
@@ -314,6 +315,10 @@ export interface ExecutorOptions {
 	assignment?: string;
 	/** Shared background from the task call (`task.batch`), rendered into the subagent's system prompt. */
 	context?: string;
+	/** Requested task context source. */
+	contextSource?: TaskContextSource;
+	/** Parent transcript snapshot captured before task scheduling. */
+	forkContext?: ForkContextSnapshot;
 	/**
 	 * The session's active overall plan, handed off so subagents spawned during
 	 * plan execution share the same plan context as the main agent. Omitted when
@@ -455,6 +460,12 @@ export interface ExecutorOptions {
 	 * set this false so disposal unregisters them instead of leaving idle peers.
 	 */
 	keepAlive?: boolean;
+}
+
+export interface ForkContextSnapshot {
+	sourceFile: string | null;
+	sourceLeafId: string | null;
+	sessionManager: Pick<SessionManager, "forkBranch">;
 }
 
 function parseStringifiedJson(value: unknown): unknown {
@@ -2535,6 +2546,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		onProgress,
 	} = options;
 	const startTime = Date.now();
+	const requestedContextSource = options.contextSource ?? "fresh";
+	let usedContextSource: "fresh" | "fork" = "fresh";
 	// Set by the session's onFirstChatDispatch hook the first time the agent
 	// loop dispatches a chat request to the provider — the launch-complete boundary.
 	let firstChatDispatchAt: number | undefined;
@@ -2832,12 +2845,47 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				effortLevel ?? (explicitThinkingLevel ? resolvedThinkingLevel : (thinkingLevel ?? resolvedThinkingLevel));
 			resolvedAt = performance.now();
 			const effectiveCwd = worktree ?? cwd;
-			const sessionManagerPromise = sessionFile
-				? SessionManager.open(sessionFile, undefined, undefined, {
-						initialCwd: effectiveCwd,
-						suppressBreadcrumb: true,
-					})
-				: Promise.resolve(SessionManager.inMemory(effectiveCwd));
+			const forkContext = options.forkContext;
+			const childTranscriptUnavailable = sessionFile === null;
+			const forkSnapshotUnavailable =
+				forkContext === undefined ||
+				forkContext.sessionManager === undefined ||
+				forkContext.sourceFile === null ||
+				forkContext.sourceFile === undefined;
+			const sessionManagerPromise =
+				requestedContextSource === "fork" &&
+				forkContext !== undefined &&
+				forkContext.sessionManager !== undefined &&
+				forkContext.sourceFile !== null &&
+				forkContext.sourceFile !== undefined &&
+				sessionFile !== null
+					? forkContext.sessionManager
+							.forkBranch({
+								sourceFile: forkContext.sourceFile,
+								sourceLeafId: forkContext.sourceLeafId,
+								cwd: effectiveCwd,
+								sessionDir: path.dirname(sessionFile),
+								sessionFile,
+								suppressBreadcrumb: true,
+							})
+							.then(manager => {
+								usedContextSource = "fork";
+								return manager;
+							})
+					: requestedContextSource === "fork" && (forkSnapshotUnavailable || childTranscriptUnavailable)
+						? Promise.reject(
+								new Error(
+									forkSnapshotUnavailable
+										? "Cannot fork task context: parent session snapshot or transcript is unavailable"
+										: "Cannot fork task context: child transcript path is unavailable",
+								),
+							)
+						: sessionFile
+							? SessionManager.open(sessionFile, undefined, undefined, {
+									initialCwd: effectiveCwd,
+									suppressBreadcrumb: true,
+								})
+							: Promise.resolve(SessionManager.inMemory(effectiveCwd));
 			// Setup below can fail before this promise's consumption boundary.
 			// Observe rejection immediately while preserving it for the later await.
 			sessionManagerPromise.catch(() => {});
@@ -2931,6 +2979,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				getApiKey: options.getApiKey,
 				settings: subagentSettings,
 				model,
+				...(usedContextSource === "fork"
+					? {
+							providerPromptCacheKey: sessionManagerForRun.getHeader()?.providerPromptCacheKey,
+							providerPromptCacheKeySource: "fork" as const,
+						}
+					: {}),
 				modelPattern: model || modelOverride === undefined ? undefined : modelPatterns,
 				modelPatternAuthFallback:
 					model || modelOverride === undefined ? undefined : options.parentActiveModelPattern,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -27,6 +27,7 @@ import { TASK_EFFORTS, type TaskEffort } from "../thinking";
 import { truncateForPrompt } from "../tools/approval";
 import { isIrcEnabled } from "../tools/hub";
 import { formatBytes, formatDuration } from "../tools/render-utils";
+import type { ForkContextSnapshot } from "./executor";
 import { resolveSpawnPolicy } from "./spawn-policy";
 import {
 	type AgentDefinition,
@@ -109,6 +110,7 @@ export type {
 	SubagentEventPayload,
 	SubagentLifecyclePayload,
 	SubagentProgressPayload,
+	TaskContextSource,
 	TaskParams,
 	TaskToolDetails,
 } from "./types";
@@ -244,6 +246,27 @@ function validateEffort(effort: TaskEffort | undefined, label: string): string |
 	return `${label} has an invalid \`effort\` value ${JSON.stringify(effort)}. Use "lo", "med", or "hi".`;
 }
 
+function validateContextSource(source: unknown, label: string): string | undefined {
+	if (source === undefined || source === "fresh" || source === "fork") return undefined;
+	return `${label} has an invalid \`source\` value ${JSON.stringify(source)}. Use "fresh" or "fork".`;
+}
+
+function validateContextSources(params: TaskParams): string | undefined {
+	const topLevelError = validateContextSource(params.source, "The call");
+	if (topLevelError) return topLevelError;
+	if (Array.isArray(params.tasks)) {
+		for (let i = 0; i < params.tasks.length; i++) {
+			const item = params.tasks[i];
+			const itemError = validateContextSource(
+				item?.source,
+				`Task ${i + 1}${item?.name ? ` (\`${item.name}\`)` : ""}`,
+			);
+			if (itemError) return itemError;
+		}
+	}
+	return undefined;
+}
+
 function validateSpawnParams(params: TaskParams, batchEnabled: boolean): string | undefined {
 	const hasTask = typeof params.task === "string" && params.task.trim() !== "";
 	const tasks = params.tasks;
@@ -297,6 +320,7 @@ function resolveSpawnItems(params: TaskParams): TaskItem[] {
 		return params.tasks;
 	}
 	const item: TaskItem = { name: params.name, agent: params.agent, task: params.task };
+	if ("source" in params) item.source = params.source;
 	if ("outputSchema" in params) item.outputSchema = params.outputSchema;
 	if ("schemaMode" in params) item.schemaMode = params.schemaMode;
 	if ("effort" in params) item.effort = params.effort;
@@ -318,6 +342,8 @@ function spawnParamsFor(params: TaskParams, item: TaskItem, defaultAgent: string
 	if (item.name !== undefined) spawn.name = item.name;
 	if (item.task !== undefined) spawn.task = item.task;
 	if (params.context !== undefined) spawn.context = params.context;
+	if ("source" in item) spawn.source = item.source;
+	else if ("source" in params) spawn.source = params.source;
 	if ("outputSchema" in item) spawn.outputSchema = item.outputSchema;
 	if ("schemaMode" in item) spawn.schemaMode = item.schemaMode;
 	if ("effort" in item) spawn.effort = item.effort;
@@ -334,6 +360,28 @@ interface SyncSpawnRef {
 	item: TaskItem;
 	index: number;
 	preAllocatedId?: string;
+}
+
+function captureForkContext(session: ToolSession): ForkContextSnapshot | undefined {
+	const manager = session.sessionManager;
+	if (!manager || typeof manager.forkBranch !== "function") return undefined;
+	const branch = manager.getBranch();
+	let sourceLeafId: string | null = null;
+	let foundAssistant = false;
+	for (let index = branch.length - 1; index >= 0; index--) {
+		const entry = branch[index];
+		if (entry?.type === "message" && entry.message.role === "assistant") {
+			foundAssistant = true;
+			sourceLeafId = entry.id;
+			break;
+		}
+	}
+	if (!foundAssistant && branch.length > 0) sourceLeafId = branch[branch.length - 1]!.id;
+	return {
+		sourceFile: session.getSessionFile(),
+		sourceLeafId,
+		sessionManager: manager,
+	};
 }
 
 /** Merged view of a sync spawn set's payloads: joined text plus flattened results/usage/paths. */
@@ -654,6 +702,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			assignment: (params.task ?? "").trim(),
 			context: this.#isBatchEnabled() ? params.context?.trim() || undefined : undefined,
 			agent: params.agent,
+			contextSource: params.source,
 			...(Object.hasOwn(params, "outputSchema") ? { outputSchema: params.outputSchema } : {}),
 			...(Object.hasOwn(params, "schemaMode") ? { schemaMode: params.schemaMode } : {}),
 			...(params.effort !== undefined ? { effort: params.effort } : {}),
@@ -680,12 +729,16 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		onUpdate?: AgentToolUpdateCallback<TaskToolDetails>,
 	): Promise<AgentToolResult<TaskToolDetails>> {
 		const params = repairTaskParams(rawParams as TaskParams);
+		const forkContext = captureForkContext(this.session);
 		// Schema defaults fill `agent` for model calls, but internal callers
 		// and stale transcripts can bypass arktype. `spawnParamsFor` resolves each
 		// item's agent type against the session's actual default agent.
 		const defaultAgent = resolveSpawnPolicy(this.session.getSessionSpawns()).defaultAgent;
 		const batchEnabled = this.#isBatchEnabled();
-		const validationError = validateShapeParams(batchEnabled, params) ?? validateSpawnParams(params, batchEnabled);
+		const validationError =
+			validateContextSources(params) ??
+			validateShapeParams(batchEnabled, params) ??
+			validateSpawnParams(params, batchEnabled);
 		if (validationError) {
 			return createTaskModeError(validationError);
 		}
@@ -755,6 +808,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			const result = await this.#executeSyncFanout(
 				toolCallId,
 				params,
+				forkContext,
 				spawnItems.map((item, index) => ({ item, index })),
 				defaultAgent,
 				signal,
@@ -806,6 +860,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				await this.#executeSyncFanout(
 					toolCallId,
 					params,
+					forkContext,
 					spawnItems.map((item, index) => ({ item, index })),
 					defaultAgent,
 					signal,
@@ -871,22 +926,37 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		let failedCount = 0;
 		let primaryJobId = asyncSpawns[0].agentId;
 		const syncResults: SingleResult[] = [];
+		const asyncResults: SingleResult[] = [];
 		let syncUsage: Usage | undefined;
-		let syncOutputPaths: string[] | undefined;
+		let asyncUsage: Usage | undefined;
 		let syncProjectAgentsDir: string | null = null;
-		const buildAsyncDetails = (): TaskToolDetails => ({
-			projectAgentsDir: syncProjectAgentsDir,
-			results: [...syncResults],
-			totalDurationMs: Date.now() - callStartedAt,
-			usage: syncUsage,
-			outputPaths: syncOutputPaths,
-			progress: spawns.map(spawn => ({ ...spawn.progress })),
-			async: {
-				state: settledCount < asyncSpawns.length ? "running" : failedCount > 0 ? "failed" : "completed",
-				jobId: primaryJobId,
-				type: "task",
-			},
-		});
+		const buildAsyncDetails = (): TaskToolDetails => {
+			const results = [...syncResults, ...asyncResults].sort((a, b) => a.index - b.index);
+			const outputPaths = results.flatMap(result => (result.outputPath ? [result.outputPath] : []));
+			const usageTotals = createUsageTotals();
+			let hasUsage = false;
+			if (syncUsage) {
+				addUsageTotals(usageTotals, syncUsage);
+				hasUsage = true;
+			}
+			if (asyncUsage) {
+				addUsageTotals(usageTotals, asyncUsage);
+				hasUsage = true;
+			}
+			return {
+				projectAgentsDir: syncProjectAgentsDir,
+				results,
+				totalDurationMs: Date.now() - callStartedAt,
+				usage: hasUsage ? usageTotals : undefined,
+				outputPaths: outputPaths.length > 0 ? outputPaths : undefined,
+				progress: spawns.map(spawn => ({ ...spawn.progress })),
+				async: {
+					state: settledCount < asyncSpawns.length ? "running" : failedCount > 0 ? "failed" : "completed",
+					jobId: primaryJobId,
+					type: "task",
+				},
+			};
+		};
 
 		const started: Array<{ agentId: string; jobId: string }> = [];
 		const failedSchedules: string[] = [];
@@ -896,11 +966,20 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					manager,
 					toolCallId,
 					spawnParams: spawnParamsFor(params, spawn.item, defaultAgent),
+					forkContext,
 					agentId: spawn.agentId,
 					progress: spawn.progress,
 					ircEnabled,
 					buildDetails: buildAsyncDetails,
 					onUpdate,
+					onResult: result => {
+						const orderedResult = { ...result, index: spawn.index };
+						asyncResults.push(orderedResult);
+						if (orderedResult.usage) {
+							asyncUsage ??= createUsageTotals();
+							addUsageTotals(asyncUsage, orderedResult.usage);
+						}
+					},
 					onSettled: failed => {
 						settledCount += 1;
 						if (failed) failedCount += 1;
@@ -993,6 +1072,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const payloads = await this.#runSyncSpawns({
 			toolCallId,
 			params,
+			forkContext,
 			defaultAgent,
 			signal,
 			spawns: syncSpawns.map(spawn => ({ item: spawn.item, index: spawn.index, preAllocatedId: spawn.agentId })),
@@ -1013,7 +1093,6 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		);
 		syncResults.push(...merged.results);
 		syncUsage = merged.usage;
-		syncOutputPaths = merged.outputPaths;
 		syncProjectAgentsDir = merged.projectAgentsDir;
 		// Settle the inline spawns' progress rows from their merged results so
 		// post-return job updates carry final statuses, not the last snapshot.
@@ -1055,15 +1134,28 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		manager: AsyncJobManager;
 		toolCallId: string;
 		spawnParams: TaskParams;
+		forkContext?: ForkContextSnapshot;
 		agentId: string;
 		progress: AgentProgress;
 		ircEnabled: boolean;
 		buildDetails: () => TaskToolDetails;
 		onUpdate?: AgentToolUpdateCallback<TaskToolDetails>;
+		onResult?: (result: SingleResult) => void;
 		onSettled?: (failed: boolean) => void;
 	}): string {
-		const { manager, toolCallId, spawnParams, agentId, progress, ircEnabled, buildDetails, onUpdate, onSettled } =
-			options;
+		const {
+			manager,
+			toolCallId,
+			spawnParams,
+			forkContext,
+			agentId,
+			progress,
+			ircEnabled,
+			buildDetails,
+			onUpdate,
+			onResult,
+			onSettled,
+		} = options;
 		const buildFollowUpHint = async (aborted: boolean): Promise<string> => {
 			if (aborted) {
 				const ref = AgentRegistry.global().get(agentId);
@@ -1150,6 +1242,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					const result = await this.#executeSync(
 						toolCallId,
 						spawnParams,
+						forkContext,
 						runSignal,
 						forwardSyncProgress,
 						agentId,
@@ -1179,6 +1272,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						delete progress.resolvedModel;
 						delete progress.resolvedModelIsFallback;
 					}
+					if (singleResult) onResult?.(singleResult);
 					onSettled?.(resultFailed);
 					const statusText = resultFailed
 						? `Background task ${agentId} failed.`
@@ -1227,6 +1321,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	async #executeSyncFanout(
 		toolCallId: string,
 		params: TaskParams,
+		forkContext: ForkContextSnapshot | undefined,
 		spawns: SyncSpawnRef[],
 		defaultAgent: string,
 		signal?: AbortSignal,
@@ -1242,6 +1337,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				return await this.#executeSync(
 					toolCallId,
 					spawnParamsFor(params, spawn.item, defaultAgent),
+					forkContext,
 					signal,
 					onUpdate,
 					spawn.preAllocatedId,
@@ -1273,6 +1369,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const payloads = await this.#runSyncSpawns({
 			toolCallId,
 			params,
+			forkContext,
 			defaultAgent,
 			signal,
 			spawns,
@@ -1308,12 +1405,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	async #runSyncSpawns(args: {
 		toolCallId: string;
 		params: TaskParams;
+		forkContext: ForkContextSnapshot | undefined;
 		defaultAgent: string;
 		spawns: SyncSpawnRef[];
 		signal?: AbortSignal;
 		onItemProgress?: (index: number, progress: AgentProgress) => void;
 	}): Promise<(AgentToolResult<TaskToolDetails> | undefined)[]> {
-		const { toolCallId, params, defaultAgent, spawns, signal, onItemProgress } = args;
+		const { toolCallId, params, forkContext, defaultAgent, spawns, signal, onItemProgress } = args;
 		const semaphore = this.#getSpawnSemaphore();
 		const { results } = await mapWithConcurrencyLimitAllSettled(
 			spawns,
@@ -1339,6 +1437,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					return await this.#executeSync(
 						toolCallId,
 						spawnParamsFor(params, spawn.item, defaultAgent),
+						forkContext,
 						workerSignal,
 						itemOnUpdate,
 						spawn.preAllocatedId,
@@ -1378,6 +1477,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	async #executeSync(
 		toolCallId: string,
 		params: TaskParams,
+		forkContext: ForkContextSnapshot | undefined,
 		signal?: AbortSignal,
 		onUpdate?: AgentToolUpdateCallback<TaskToolDetails>,
 		preAllocatedId?: string,
@@ -1385,13 +1485,24 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		detached = false,
 		launchTiming?: { invokedAt: number; acquiredAt: number },
 	): Promise<AgentToolResult<TaskToolDetails>> {
-		return this.#runSpawn(toolCallId, params, signal, onUpdate, preAllocatedId, spawnIndex, detached, launchTiming);
+		return this.#runSpawn(
+			toolCallId,
+			params,
+			forkContext,
+			signal,
+			onUpdate,
+			preAllocatedId,
+			spawnIndex,
+			detached,
+			launchTiming,
+		);
 	}
 
 	/** Spawn a fresh subagent and run it to completion. */
 	async #runSpawn(
 		toolCallId: string,
 		params: TaskParams,
+		forkContext: ForkContextSnapshot | undefined,
 		signal?: AbortSignal,
 		onUpdate?: AgentToolUpdateCallback<TaskToolDetails>,
 		preAllocatedId?: string,
@@ -1410,6 +1521,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				assignment,
 				context,
 				agent: params.agent,
+				contextSource: params.source,
+				forkContext,
 				...(Object.hasOwn(params, "outputSchema") ? { outputSchema: params.outputSchema } : {}),
 				...(Object.hasOwn(params, "schemaMode") ? { schemaMode: params.schemaMode } : {}),
 				...(params.effort !== undefined ? { effort: params.effort } : {}),

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -85,6 +85,7 @@ export function createPersistedSubagentReviverFactory(
 			const reopened = await SessionManager.open(sessionFile, undefined, undefined, {
 				suppressBreadcrumb: true,
 			});
+			const providerPromptCacheKey = reopened.getHeader()?.providerPromptCacheKey;
 			const artifactManager = ctx.session.sessionManager.getArtifactManager();
 			if (artifactManager) reopened.adoptArtifactManager(artifactManager);
 			// A restricted persisted contract must not consult process-global MCP
@@ -113,6 +114,9 @@ export function createPersistedSubagentReviverFactory(
 				restrictToolNames: restrictToolNames || undefined,
 				requireYieldTool: true,
 				systemPrompt: () => [init.systemPrompt],
+				...(providerPromptCacheKey !== undefined
+					? { providerPromptCacheKey, providerPromptCacheKeySource: "fork" as const }
+					: {}),
 				// Old files predate persisted spawns: deny re-spawning rather than let
 				// createAgentSession default to wildcard ("*").
 				spawns: init.spawns ?? "",

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -21,7 +21,7 @@ import type { ToolSession } from "../tools";
 import { isIrcEnabled } from "../tools/hub";
 import { buildOutputValidator } from "../tools/output-schema-validator";
 import { type DiscoveryResult, discoverAgents, getAgent } from "./discovery";
-import { type ExecutorOptions, runSubprocess } from "./executor";
+import { type ExecutorOptions, type ForkContextSnapshot, runSubprocess } from "./executor";
 import {
 	applyEligibleNestedPatches,
 	type IsolationContext,
@@ -39,6 +39,7 @@ import {
 	canSpawnAtDepth,
 	type SingleResult,
 	type StructuredSubagentOutput,
+	type TaskContextSource,
 } from "./types";
 import { type NestedRepoPatch, parseIsolationMode } from "./worktree";
 
@@ -83,6 +84,9 @@ export interface StructuredSubagentRequest {
 	invocationKind: "task" | "eval";
 	assignment: string;
 	context?: string;
+	/** Requested task context source and its scheduling-time parent snapshot. */
+	contextSource?: TaskContextSource;
+	forkContext?: ForkContextSnapshot;
 	agent?: string;
 	model?: string | string[];
 	/** Presence, rather than truthiness, makes this the highest-priority schema. */
@@ -383,6 +387,8 @@ function buildExecutorOptions(
 		task: renderSubagentPrompt(request.assignment),
 		assignment: request.assignment.trim(),
 		context: request.context?.trim() || undefined,
+		contextSource: request.contextSource,
+		forkContext: request.forkContext,
 		planReference: undefined,
 		description: trimToUndefined(request.identity?.label),
 		index: request.index ?? 0,

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -7,6 +7,9 @@ import type { NestedRepoPatch } from "./worktree";
 
 /** Source of an agent definition */
 export type AgentSource = "bundled" | "user" | "project";
+
+/** Requested context source for a task invocation. */
+export type TaskContextSource = "fresh" | "fork";
 /**
  * Enforcement policy for a structured subagent output schema.
  *
@@ -115,6 +118,7 @@ export const taskItemSchema = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
+	"source?": '"fresh" | "fork"',
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"+": "delete",
@@ -123,6 +127,7 @@ const taskItemSchemaIsolated = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
+	"source?": '"fresh" | "fork"',
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"isolated?": "boolean",
@@ -137,6 +142,8 @@ export interface TaskItem {
 	agent?: string;
 	/** The work; required by the schema. */
 	task?: string;
+	/** Requested context source for this spawn. */
+	source?: TaskContextSource;
 	/** Per-spawn thinking effort: lowest/middle/highest level the resolved model supports. Overrides the agent's default selector (e.g. `auto`). */
 	effort?: TaskEffort;
 	/** Caller-provided output schema; its presence overrides the selected agent's schema. */
@@ -151,6 +158,7 @@ export const taskSchema = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
+	"source?": '"fresh" | "fork"',
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"isolated?": "boolean",
@@ -160,17 +168,20 @@ const taskSchemaNoIsolation = type({
 	"name?": "string",
 	agent: "string = 'task'",
 	task: "string",
+	"source?": '"fresh" | "fork"',
 	"outputSchema?": outputSchemaInputSchema,
 	"schemaMode?": '"permissive" | "strict"',
 	"+": "delete",
 });
 const taskSchemaBatch = type({
 	context: "string",
+	"source?": '"fresh" | "fork"',
 	tasks: taskItemSchemaIsolated.array(),
 	"+": "delete",
 });
 const taskSchemaBatchNoIsolation = type({
 	context: "string",
+	"source?": '"fresh" | "fork"',
 	tasks: taskItemSchema.array(),
 	"+": "delete",
 });
@@ -206,6 +217,7 @@ function createTaskSchema(options: {
 				"name?": "string",
 				agent,
 				task: "string",
+				"source?": '"fresh" | "fork"',
 				...effortField,
 				"outputSchema?": outputSchemaInputSchema,
 				"schemaMode?": '"permissive" | "strict"',
@@ -214,6 +226,7 @@ function createTaskSchema(options: {
 			});
 			return type.raw({
 				context: "string",
+				"source?": '"fresh" | "fork"',
 				tasks: item.array(),
 				"+": "delete",
 			});
@@ -222,6 +235,7 @@ function createTaskSchema(options: {
 			"name?": "string",
 			agent,
 			task: "string",
+			"source?": '"fresh" | "fork"',
 			...effortField,
 			"outputSchema?": outputSchemaInputSchema,
 			"schemaMode?": '"permissive" | "strict"',
@@ -229,6 +243,7 @@ function createTaskSchema(options: {
 		});
 		return type.raw({
 			context: "string",
+			"source?": '"fresh" | "fork"',
 			tasks: item.array(),
 			"+": "delete",
 		});
@@ -238,6 +253,7 @@ function createTaskSchema(options: {
 			"name?": "string",
 			agent,
 			task: "string",
+			"source?": '"fresh" | "fork"',
 			...effortField,
 			"outputSchema?": outputSchemaInputSchema,
 			"schemaMode?": '"permissive" | "strict"',
@@ -249,6 +265,7 @@ function createTaskSchema(options: {
 		"name?": "string",
 		agent,
 		task: "string",
+		"source?": '"fresh" | "fork"',
 		...effortField,
 		"outputSchema?": outputSchemaInputSchema,
 		"schemaMode?": '"permissive" | "strict"',
@@ -290,6 +307,8 @@ export interface TaskParams {
 	agent?: string;
 	/** The work (flat form). */
 	task?: string;
+	/** Requested context source for this spawn. */
+	source?: TaskContextSource;
 	/** Per-spawn thinking effort (flat form): lowest/middle/highest level the resolved model supports. */
 	effort?: TaskEffort;
 	/** Caller-provided output schema; its presence overrides the selected agent's schema. */
@@ -497,7 +516,7 @@ export interface SingleResult {
 	modelOverride?: string | string[];
 	/** Resolved model display string in the form `<provider>/<id>`, optionally suffixed with `:<thinkingLevel>` when the level was set explicitly. Omitted from tool-result JSON when undefined to keep wire payloads small. */
 	resolvedModel?: string;
-	/** True when {@link resolvedModel} is the target of an active retry fallback. Mirrors {@link AgentProgress.resolvedModelIsFallback} onto the settled result. */
+	/** True when {@link resolvedModel} is the target of an active retry fallback (not the originally configured model). Mirrors {@link AgentProgress.resolvedModelIsFallback} onto the settled result. */
 	resolvedModelIsFallback?: boolean;
 	error?: string;
 	aborted?: boolean;

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -229,7 +229,10 @@ export interface ToolSession {
 	/** Get session file */
 	getSessionFile: () => string | null;
 	/** Parent session journal used by tools that persist runtime lifecycle state. */
-	sessionManager?: Pick<SessionManager, "appendCustomEntry" | "ensureOnDisk" | "flush" | "getBranch" | "getEntries">;
+	sessionManager?: Pick<
+		SessionManager,
+		"appendCustomEntry" | "ensureOnDisk" | "flush" | "getBranch" | "getEntries" | "forkBranch"
+	>;
 	/** Get eval kernel owner ID for session-scoped retained-kernel cleanup. */
 	getEvalKernelOwnerId?: () => string | null;
 	/** Reject new eval work once session disposal has started. */

--- a/packages/coding-agent/test/session/session-manager-fork.test.ts
+++ b/packages/coding-agent/test/session/session-manager-fork.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { loadEntriesFromFile } from "@oh-my-pi/pi-coding-agent/session/session-loader";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { MemorySessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
 import { getTerminalId } from "@oh-my-pi/pi-tui";
 import { getAgentDir, getTerminalSessionsDir, removeWithRetries, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 
@@ -86,5 +87,70 @@ describe("SessionManager.forkFrom", () => {
 			}
 			setAgentDir(previousAgentDir);
 		}
+	});
+
+	it("clones the selected leaf branch and preserves the provider prompt cache key", async () => {
+		using tempDir = TempDir.createSync("@omp-session-bounded-fork-");
+		const storage = new MemorySessionStorage();
+		const cwd = path.join(tempDir.path(), "project");
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		const source = SessionManager.create(cwd, sessionDir, storage);
+		const providerPromptCacheKey = "bounded-fork-cache-key";
+		await source.newSession({ providerPromptCacheKey });
+		const rootId = source.appendMessage({ role: "user", content: "root", timestamp: Date.now() });
+		const selectedId = source.appendMessage({ role: "user", content: "selected", timestamp: Date.now() });
+		source.appendMessage({ role: "user", content: "selected descendant", timestamp: Date.now() });
+		source.branch(rootId);
+		source.appendMessage({ role: "user", content: "later sibling", timestamp: Date.now() });
+		await source.ensureOnDisk();
+		await source.flush();
+
+		const sourceFile = source.getSessionFile();
+		if (!sourceFile) throw new Error("expected source session file");
+		const cloneFile = path.join(sessionDir, "bounded.jsonl");
+		const forked = await SessionManager.forkFrom(sourceFile, cwd, sessionDir, storage, {
+			sourceLeafId: selectedId,
+			sessionFile: cloneFile,
+			suppressBreadcrumb: true,
+		});
+
+		const cloneEntries = await loadEntriesFromFile(cloneFile, storage);
+		const cloneMessages = cloneEntries.filter((entry): entry is SessionMessageEntry => entry.type === "message");
+		expect(cloneMessages.map(entry => entry.id)).toEqual([rootId, selectedId]);
+		expect(
+			cloneMessages.map(entry =>
+				entry.message.role === "user" && typeof entry.message.content === "string"
+					? entry.message.content
+					: undefined,
+			),
+		).toEqual(["root", "selected"]);
+		expect(forked.getHeader()?.providerPromptCacheKey).toBe(providerPromptCacheKey);
+	});
+
+	it("creates a header-only child when the selected source leaf is null", async () => {
+		using tempDir = TempDir.createSync("@omp-session-root-fork-");
+		const storage = new MemorySessionStorage();
+		const cwd = path.join(tempDir.path(), "project");
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		const source = SessionManager.create(cwd, sessionDir, storage);
+		source.appendMessage({ role: "user", content: "not copied", timestamp: Date.now() });
+		await source.ensureOnDisk();
+		await source.flush();
+		const sourceFile = source.getSessionFile();
+		if (!sourceFile) throw new Error("expected source session file");
+		const cloneFile = path.join(sessionDir, "root.jsonl");
+
+		await SessionManager.forkFrom(sourceFile, cwd, sessionDir, storage, {
+			sourceLeafId: null,
+			sessionFile: cloneFile,
+			suppressBreadcrumb: true,
+		});
+
+		const cloneEntries = await loadEntriesFromFile(cloneFile, storage);
+		expect(cloneEntries).toHaveLength(1);
+		expect(cloneEntries[0]?.type).toBe("session");
+		const reopened = await SessionManager.open(cloneFile, sessionDir, storage, { suppressBreadcrumb: true });
+		expect(reopened.getHeader()?.type).toBe("session");
+		expect(reopened.getEntries()).toHaveLength(0);
 	});
 });

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -17,7 +17,8 @@ import type { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
-import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { type ForkContextSnapshot, runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 
@@ -364,5 +365,80 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		expect(result.exitCode).toBe(0);
 		const forwarded = spy.mock.calls[0]?.[0];
 		expect(forwarded?.thinkingLevel).toBe(ThinkingLevel.Low);
+	});
+
+	it("selects and wires the captured fork source", async () => {
+		const sourceFile = "/tmp/source.jsonl";
+		const sourceLeafId: string | null = "selected-leaf";
+		const effectiveCwd = "/tmp/worktree";
+		const childDir = "/tmp/child-artifacts";
+		const childFile = `${childDir}/${baseOptions.id}.jsonl`;
+		const providerPromptCacheKey = "live-fork-cache-key";
+		type ForkBranch = SessionManager["forkBranch"];
+		const childManager = {
+			getHeader: () => ({ providerPromptCacheKey }),
+		} as unknown as SessionManager;
+		const forkBranch = vi.fn<ForkBranch>(async () => childManager);
+		const forkContext = {
+			sourceFile,
+			sourceLeafId,
+			sessionManager: { forkBranch },
+		} as ForkContextSnapshot;
+		const session = yieldEmittingSession();
+		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		const result = await runSubprocess({
+			...baseOptions,
+			cwd: "/tmp/project",
+			worktree: effectiveCwd,
+			artifactsDir: childDir,
+			contextSource: "fork",
+			forkContext,
+		});
+
+		expect(result.exitCode, `${result.error ?? ""} ${result.stderr}`).toBe(0);
+		expect(forkBranch).toHaveBeenCalledTimes(1);
+		expect(forkBranch).toHaveBeenCalledWith({
+			sourceFile,
+			sourceLeafId,
+			cwd: effectiveCwd,
+			sessionDir: childDir,
+			sessionFile: childFile,
+			suppressBreadcrumb: true,
+		});
+		expect(spy).toHaveBeenCalledTimes(1);
+		const forwarded = spy.mock.calls[0]?.[0];
+		expect(forwarded?.sessionManager).toBe(childManager);
+		expect(forwarded?.providerPromptCacheKey).toBe(providerPromptCacheKey);
+		expect(forwarded?.providerPromptCacheKeySource).toBe("fork");
+	});
+
+	it("keeps fresh execution on the existing child path", async () => {
+		const session = yieldEmittingSession();
+		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		const forkBranch = vi.fn(() => {
+			throw new Error("fresh path called forkBranch");
+		});
+
+		const result = await runSubprocess({
+			...baseOptions,
+			contextSource: "fresh",
+			forkContext: {
+				sourceFile: "/tmp/source.jsonl",
+				sourceLeafId: null,
+				sessionManager: { forkBranch },
+			},
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(forkBranch).not.toHaveBeenCalled();
+		expect(spy.mock.calls[0]?.[0]?.sessionManager).toBeDefined();
+	});
+
+	it("fails explicit fork when the scheduling snapshot is unavailable", async () => {
+		const result = await runSubprocess({ ...baseOptions, contextSource: "fork" });
+
+		expect(result.exitCode).toBe(1);
+		expect(result.error).toContain("Cannot fork task context");
 	});
 });

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -62,8 +62,15 @@ function createRevivedSession(activeToolNames: string[][]): RevivedSessionHandle
 	return { session, observer: () => observer };
 }
 
-async function createPersistedSession(cwd: string, restrictToolNames?: boolean): Promise<string> {
+async function createPersistedSession(
+	cwd: string,
+	restrictToolNames?: boolean,
+	providerPromptCacheKey?: string,
+): Promise<string> {
 	const manager = SessionManager.create(cwd, path.join(cwd, "sessions"));
+	if (providerPromptCacheKey !== undefined) {
+		await manager.newSession({ providerPromptCacheKey });
+	}
 	const sessionFile = manager.getSessionFile();
 	if (!sessionFile) throw new Error("Expected a persisted session file");
 	manager.appendSessionInit({
@@ -238,5 +245,35 @@ describe("persisted subagent revival", () => {
 		rpcRegistry.dispose();
 		AgentLifecycleManager.resetGlobalForTests();
 		AgentRegistry.resetGlobalForTests();
+	});
+
+	it("cold-revives persisted child history with its provider cache lineage", async () => {
+		const cwd = makeTempDir("@pi-cache-revive-");
+		const providerPromptCacheKey = "persisted-child-cache-key";
+		const sessionFile = await createPersistedSession(cwd, false, providerPromptCacheKey);
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd)(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		const sessionManager = capturedOptions?.sessionManager;
+		if (!sessionManager) throw new Error("Expected the reopened session manager");
+		const options = capturedOptions;
+		if (!options) throw new Error("Expected createAgentSession options");
+		expect(
+			sessionManager
+				.getEntries()
+				.filter(entry => entry.type === "message")
+				.map(entry => (entry.type === "message" ? entry.message : undefined)),
+		).toEqual([expect.objectContaining({ role: "assistant", content: [{ type: "text", text: "persisted" }] })]);
+		expect(sessionManager.getHeader()?.providerPromptCacheKey).toBe(providerPromptCacheKey);
+		expect(options.providerPromptCacheKey).toBe(providerPromptCacheKey);
+		expect(options.providerPromptCacheKeySource).toBe("fork");
 	});
 });

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -19,10 +19,12 @@ import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { MemorySessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
 import { TaskTool } from "@oh-my-pi/pi-coding-agent/task";
 import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
 import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
-import type { AgentDefinition, SingleResult, TaskParams } from "@oh-my-pi/pi-coding-agent/task/types";
+import type { AgentDefinition, SingleResult, TaskParams, TaskToolDetails } from "@oh-my-pi/pi-coding-agent/task/types";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { isRecord } from "@oh-my-pi/pi-utils";
 
@@ -39,13 +41,16 @@ function createSession(
 		settings?: Record<string, unknown>;
 		agentId?: string;
 		planMode?: boolean;
+		sessionManager?: ToolSession["sessionManager"];
+		sessionFile?: string | null;
 	} = {},
 ): ToolSession {
 	return {
 		cwd: "/tmp",
 		hasUI: false,
 		settings: Settings.isolated(options.settings ?? {}),
-		getSessionFile: () => null,
+		getSessionFile: () => options.sessionFile ?? null,
+		sessionManager: options.sessionManager,
 		getSessionSpawns: () => "*",
 		getAgentId: () => options.agentId ?? null,
 		getPlanModeState: options.planMode ? () => ({ enabled: true }) : undefined,
@@ -584,6 +589,57 @@ describe("task.batch spawning", () => {
 		]);
 	});
 
+	it("keeps completed async results in input order in the aggregate details", async () => {
+		mockDiscovery();
+		const gates = new Map<string, PromiseWithResolvers<void>>();
+		const started = Promise.withResolvers<void>();
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			const id = options.id ?? "?";
+			const gate = Promise.withResolvers<void>();
+			gates.set(id, gate);
+			if (gates.size === 2) started.resolve();
+			await gate.promise;
+			return makeResult(id, {
+				index: id === "First" ? 0 : 1,
+				outputPath: `/tmp/${id}.md`,
+			});
+		});
+
+		const manager = createManager();
+		const tool = await TaskTool.create(
+			createSession({
+				manager,
+				settings: { "async.enabled": true, "task.batch": true, "task.maxConcurrency": 2 },
+			}),
+		);
+		const result = await tool.execute("tc-async-details", {
+			context: "Shared context.",
+			tasks: [
+				{ name: "First", task: "Do first." },
+				{ name: "Second", task: "Do second." },
+			],
+		} as TaskParams);
+
+		const firstJob = manager.getJob("First");
+		const secondJob = manager.getJob("Second");
+		expect(firstJob).toBeDefined();
+		expect(secondJob).toBeDefined();
+		await started.promise;
+
+		gates.get("Second")!.resolve();
+		await secondJob!.promise;
+		gates.get("First")!.resolve();
+		await firstJob!.promise;
+
+		const latestDetails = firstJob!.latestDetails as unknown as TaskToolDetails;
+		expect(result.details?.async?.state).toBe("running");
+		expect(latestDetails.results.map(item => ({ index: item.index, id: item.id }))).toEqual([
+			{ index: 0, id: "First" },
+			{ index: 1, id: "Second" },
+		]);
+		expect(latestDetails.outputPaths).toEqual(["/tmp/First.md", "/tmp/Second.md"]);
+	});
+
 	it("settles the batch async aggregate when a queued spawn is cancelled mid-flight", async () => {
 		mockDiscovery();
 		const started: string[] = [];
@@ -652,5 +708,69 @@ describe("task.batch spawning", () => {
 		expect(last?.async?.state).toBe("failed");
 		expect(last?.progress?.find(p => p.id === "Second")?.status).toBe("aborted");
 		expect(last?.progress?.find(p => p.id === "First")?.status).toBe("completed");
+	});
+
+	it("captures the fork leaf before a delayed background spawn runs", async () => {
+		mockDiscovery();
+		const storage = new MemorySessionStorage();
+		const manager = SessionManager.create("/tmp", "/tmp/sessions", storage);
+		const capturedParent = manager.appendMessage({ role: "user", content: "parent", timestamp: Date.now() });
+		const capturedAssistant = manager.appendMessage({
+			role: "assistant",
+			provider: "anthropic",
+			model: "test",
+			api: "anthropic-messages",
+			content: [{ type: "text", text: "captured" }],
+			stopReason: "stop",
+			timestamp: Date.now(),
+		} as never);
+		const inFlightTaskCall = manager.appendCustomEntry("tool_execution_start", {
+			toolCallId: "task-call",
+			toolName: "task",
+		});
+		const sourceFile = manager.getSessionFile();
+		if (!sourceFile) throw new Error("expected session file");
+		const seen: Array<{ sourceFile: string | null; sourceLeafId: string | null }> = [];
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			seen.push({
+				sourceFile: options.forkContext?.sourceFile ?? null,
+				sourceLeafId: options.forkContext?.sourceLeafId ?? null,
+			});
+			return makeResult(options.id ?? "?");
+		});
+		const jobs = createManager();
+		const tool = await TaskTool.create(
+			createSession({
+				manager: jobs,
+				sessionManager: manager,
+				sessionFile: sourceFile,
+				settings: { "async.enabled": true, "task.batch": false },
+			}),
+		);
+		const result = await tool.execute("tc-captured", { agent: "task", task: "Do it.", source: "fork" } as TaskParams);
+		manager.appendMessage({
+			role: "assistant",
+			provider: "anthropic",
+			model: "test",
+			api: "anthropic-messages",
+			content: [{ type: "text", text: "later" }],
+			stopReason: "stop",
+			timestamp: Date.now(),
+		} as never);
+		await jobs.getJob(result.details?.async?.jobId ?? "")?.promise;
+		expect(seen).toEqual([{ sourceFile, sourceLeafId: capturedAssistant }]);
+		expect(capturedAssistant).not.toBe(capturedParent);
+		const capturedBranch = manager.getBranch(capturedAssistant);
+		expect(capturedBranch).toContainEqual(
+			expect.objectContaining({
+				id: capturedAssistant,
+				type: "message",
+				message: expect.objectContaining({
+					role: "assistant",
+					content: [{ type: "text", text: "captured" }],
+				}),
+			}),
+		);
+		expect(capturedBranch.some(entry => entry.id === inFlightTaskCall)).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

Allow task agents to inherit the parent conversation when their work benefits from its existing context.

The `task` tool now accepts a `source`:

- `fresh` starts the child without parent conversation history and remains the default.
- `fork` clones the persisted parent conversation through the boundary captured when the task is scheduled. It fails clearly when that context is unavailable.

This brings model-controlled conversation forks into the normal task-agent lifecycle instead of requiring a separate one-shot workflow.

Closes #6193.

## Why

Implementation and debugging tasks often depend on requirements, decisions, and investigation already present in the parent conversation. Repeating that context in every handoff is wasteful and easy to get wrong.

Some tasks still benefit from independence, particularly clean-room reviews and second opinions. The parent can now choose between continuity and a fresh perspective for each task.

## Behavior

- Existing task calls remain `fresh` by default.
- Flat and batch task calls accept `source: "fresh" | "fork"`.
- A batch-level source applies to each item unless the item overrides it.
- The parent snapshot is captured when the task is scheduled, so queued background work does not read later conversation state.
- `fork` is strict: it does not silently run without the requested parent context.
- Forking changes the child’s initial conversation only. The selected child agent still controls its model, prompt, tools, permissions, schema, isolation, and lifecycle.
- Provider prompt-cache lineage is preserved across live forks and persisted child revival. Actual cache reuse depends on provider and request compatibility.
- Completed background results retain their input ordering, artifact paths, and usage when jobs finish out of order.

The tool guidance recommends `fork` for work that benefits from the current conversation and `fresh` when independence or a clean perspective is specifically valuable.

## Scope

This PR implements the current completed-parent conversation as the fork source. It does not add arbitrary checkpoint selection, automatic source selection, or cache-hit prediction.
