### PR TITLE
fix(omp): refresh context budget after shake

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -844,6 +844,8 @@ export interface AssistantRetryRecovery {
 export interface ContextSnapshot {
 	promptTokens: number; // authoritative provider prompt/input tokens
 	nonMessageTokens: number; // estimated non-message total at send time
+	/** Estimated prompt tokens removed by local history rewrites after this provider snapshot was recorded. */
+	historyRewriteTokensRemoved?: number;
 	lastMessageTimestamp?: number;
 }
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -42,6 +42,9 @@
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
+### Fixed
+
+- Fixed manual `/shake` leaving the context budget and next pre-turn compaction decision anchored to the stale pre-shake provider token count until another model response arrived.
 
 ## [17.2.3] - 2026-08-01
 
@@ -104,9 +107,6 @@
 - Fixed the browser tool ignoring the url parameter when opening a new tab on an attached browser.
 - Fixed browser automation disrupting attached browsers by adopting the active foreground tab and avoiding raising new tabs during screenshots.
 
-### Fixed
-
-- Fixed manual `/shake` leaving the context budget and next pre-turn compaction decision anchored to the stale pre-shake provider token count until another model response arrived.
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -104,6 +104,10 @@
 - Fixed the browser tool ignoring the url parameter when opening a new tab on an attached browser.
 - Fixed browser automation disrupting attached browsers by adopting the active foreground tab and avoiding raising new tabs during screenshots.
 
+### Fixed
+
+- Fixed manual `/shake` leaving the context budget and next pre-turn compaction decision anchored to the stale pre-shake provider token count until another model response arrived.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed manual `/shake` leaving the context budget and next pre-turn compaction decision anchored to the stale pre-shake provider token count until another model response arrived.
+
 ## [17.2.4] - 2026-08-01
 
 ### Added
@@ -42,9 +46,6 @@
 - Fixed explicit `thinking` metadata in `models.yml` custom definitions and `modelOverrides` being replaced by canonical catalog policy during model rebuilding. ([#7307](https://github.com/can1357/oh-my-pi/issues/7307))
 - Fixed the auto-titler installing a model's whole answer as the session title when the tiny title model ignored the titling task and answered the first user message instead. `normalizeGeneratedTitle` now rejects overlong output (>80 chars or >12 words) so the caller defers titling to the next user turn rather than accepting a full sentence ([#7303](https://github.com/can1357/oh-my-pi/issues/7303)).
 - Fixed the in-process `kill` builtin to validate signals, preserve negative PID operands, signal every process in pipeline jobs, continue after bad targets, and refuse non-probe signals aimed at the host process or process group.
-### Fixed
-
-- Fixed manual `/shake` leaving the context budget and next pre-turn compaction decision anchored to the stale pre-shake provider token count until another model response arrived.
 
 ## [17.2.3] - 2026-08-01
 
@@ -106,7 +107,6 @@
 - Fixed the Python RPC client dropping context, compaction, OAuth URL, and terminal-settlement fields.
 - Fixed the browser tool ignoring the url parameter when opening a new tab on an attached browser.
 - Fixed browser automation disrupting attached browsers by adopting the active foreground tab and avoiding raising new tabs during screenshots.
-
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1418,6 +1418,7 @@ export class AgentSession {
 			syncTodoPhasesFromBranch: () => this.#todo.syncFromBranch(),
 			resetAdvisorRuntimes: () => this.#advisors.resetAllRuntimes(),
 			rebaseAfterCompaction: () => this.#stats.rebaseAfterCompaction(),
+			recordAnchoredHistoryRewrite: tokensRemoved => this.#stats.recordAnchoredHistoryRewrite(tokensRemoved),
 			getContextBreakdown: options => this.getContextBreakdown(options),
 			getContextUsage: options => this.getContextUsage(options),
 			shake: (mode, options) => this.shake(mode, options),

--- a/packages/coding-agent/src/session/session-context.ts
+++ b/packages/coding-agent/src/session/session-context.ts
@@ -154,6 +154,21 @@ function snapcompactHistoryBlocksForContext(
 	return snapcompact.historyBlocks(archive, snapcompactHistoryBlockOptions(archive, options));
 }
 
+export function getOpenAiRemoteCompactionPayload(
+	compaction: CompactionEntry | null | undefined,
+): ProviderPayload | undefined {
+	const candidate = compaction?.preserveData?.openaiRemoteCompaction;
+	if (!candidate || typeof candidate !== "object") return undefined;
+	const remote = candidate as { provider?: unknown; replacementHistory?: unknown };
+	if (typeof remote.provider !== "string" || remote.provider.length === 0) return undefined;
+	if (!Array.isArray(remote.replacementHistory)) return undefined;
+	return {
+		type: "openaiResponsesHistory",
+		provider: remote.provider,
+		items: remote.replacementHistory as Array<Record<string, unknown>>,
+	};
+}
+
 export function buildSessionContext(
 	entries: SessionEntry[],
 	leafId?: string | null,
@@ -365,18 +380,7 @@ export function buildSessionContext(
 			}
 		}
 	} else if (compaction) {
-		const providerPayload: ProviderPayload | undefined = (() => {
-			const candidate = compaction.preserveData?.openaiRemoteCompaction;
-			if (!candidate || typeof candidate !== "object") return undefined;
-			const remote = candidate as { provider?: unknown; replacementHistory?: unknown };
-			if (typeof remote.provider !== "string" || remote.provider.length === 0) return undefined;
-			if (!Array.isArray(remote.replacementHistory)) return undefined;
-			return {
-				type: "openaiResponsesHistory",
-				provider: remote.provider,
-				items: remote.replacementHistory as Array<Record<string, unknown>>,
-			};
-		})();
+		const providerPayload = getOpenAiRemoteCompactionPayload(compaction);
 		const remoteReplacementHistory = providerPayload?.items;
 
 		// Re-attach any archived snapcompact frames so the model can keep

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -26,6 +26,7 @@ import {
 	DEFAULT_SHAKE_CONFIG,
 	effectiveReserveTokens,
 	estimateTokens,
+	hasContextTokenUsage,
 	NativeCompactionError,
 	prepareCompaction,
 	resolveBudgetReserveTokens,
@@ -483,7 +484,12 @@ export class SessionMaintenance {
 			const entry = branchEntries[index];
 			if (entry.type !== "message" || entry.message.role !== "assistant") continue;
 			const assistant = entry.message;
-			if (assistant.stopReason !== "aborted" && assistant.stopReason !== "error" && assistant.usage) {
+			if (
+				assistant.stopReason !== "aborted" &&
+				assistant.stopReason !== "error" &&
+				assistant.usage &&
+				hasContextTokenUsage(assistant.usage)
+			) {
 				anchorIndex = index;
 				break;
 			}

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -75,7 +75,7 @@ import {
 	resolveRoleModelFull,
 } from "./role-models";
 import type { SessionContext } from "./session-context";
-import { getLatestCompactionEntry } from "./session-context";
+import { getLatestCompactionEntry, getOpenAiRemoteCompactionPayload } from "./session-context";
 import type { CompactionEntry, SessionEntry } from "./session-entries";
 import type { SessionManager } from "./session-manager";
 import type { ShakeMode, ShakeResult } from "./shake-types";
@@ -478,6 +478,7 @@ export class SessionMaintenance {
 		const artifactId = await this.#saveShakeArtifact(regions);
 		const replacements = regions.map((region, index) => this.#shakeElidePlaceholder(region, index, artifactId));
 
+		const hasRemoteReplacementHistory = getOpenAiRemoteCompactionPayload(latestCompaction) !== undefined;
 		const compactionIndex = latestCompaction ? branchEntries.lastIndexOf(latestCompaction) : -1;
 		let anchorIndex = -1;
 		for (let index = branchEntries.length - 1; index > compactionIndex; index--) {
@@ -509,7 +510,11 @@ export class SessionMaintenance {
 			const replacementTokenCount = replacement.length > 0 ? countTokens(replacement) : 0;
 			replacementTokens += replacementTokenCount;
 			const entryIndex = entryIndexes.get(region.entry) ?? -1;
-			if (entryIndex >= 0 && entryIndex < anchorIndex) {
+			if (
+				entryIndex >= 0 &&
+				entryIndex < anchorIndex &&
+				(!hasRemoteReplacementHistory || entryIndex > compactionIndex)
+			) {
 				anchoredTokensRemoved += Math.max(0, region.tokens - replacementTokenCount);
 			}
 			return { region, replacement };

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -235,6 +235,7 @@ export interface SessionMaintenanceHost {
 	syncTodoPhasesFromBranch(): void;
 	resetAdvisorRuntimes(): void;
 	rebaseAfterCompaction(): void;
+	recordAnchoredHistoryRewrite(tokensRemoved: number): void;
 	getContextBreakdown(options?: {
 		contextWindow?: number;
 		pendingMessages?: AgentMessage[];
@@ -461,11 +462,12 @@ export class SessionMaintenance {
 		}
 
 		const branchEntries = this.#host.sessionManager.getBranch();
+		const latestCompaction = getLatestCompactionEntry(branchEntries);
 		const config = this.#withPlanProtection({
 			...(opts.config ?? AGGRESSIVE_SHAKE_CONFIG),
 			// Skip entries summarized away by the latest compaction — shaking them
 			// only churns persisted history with no prompt/cache effect.
-			keepBoundaryId: getLatestCompactionEntry(branchEntries)?.firstKeptEntryId,
+			keepBoundaryId: latestCompaction?.firstKeptEntryId,
 		});
 		const regions = collectShakeRegions(branchEntries, config);
 		if (regions.length === 0) {
@@ -475,20 +477,40 @@ export class SessionMaintenance {
 		const artifactId = await this.#saveShakeArtifact(regions);
 		const replacements = regions.map((region, index) => this.#shakeElidePlaceholder(region, index, artifactId));
 
+		const compactionIndex = latestCompaction ? branchEntries.lastIndexOf(latestCompaction) : -1;
+		let anchorIndex = -1;
+		for (let index = branchEntries.length - 1; index > compactionIndex; index--) {
+			const entry = branchEntries[index];
+			if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+			const assistant = entry.message;
+			if (assistant.stopReason !== "aborted" && assistant.stopReason !== "error" && assistant.usage) {
+				anchorIndex = index;
+				break;
+			}
+		}
+		const entryIndexes = new Map(branchEntries.map((entry, index) => [entry, index]));
+
 		let toolResultsDropped = 0;
 		let blocksDropped = 0;
 		let originalTokens = 0;
 		let replacementTokens = 0;
+		let anchoredTokensRemoved = 0;
 		const items = regions.map((region, index) => {
 			if (region.kind === "toolResult") toolResultsDropped++;
 			else blocksDropped++;
 			originalTokens += region.tokens;
 			const replacement = replacements[index];
-			if (replacement.length > 0) replacementTokens += countTokens(replacement);
+			const replacementTokenCount = replacement.length > 0 ? countTokens(replacement) : 0;
+			replacementTokens += replacementTokenCount;
+			const entryIndex = entryIndexes.get(region.entry) ?? -1;
+			if (entryIndex >= 0 && entryIndex < anchorIndex) {
+				anchoredTokensRemoved += Math.max(0, region.tokens - replacementTokenCount);
+			}
 			return { region, replacement };
 		});
 
 		applyShakeRegions(items);
+		this.#host.recordAnchoredHistoryRewrite(anchoredTokensRemoved);
 
 		await this.#host.sessionManager.rewriteEntries();
 		const sessionContext = this.#host.buildDisplaySessionContext();

--- a/packages/coding-agent/src/session/session-stats.ts
+++ b/packages/coding-agent/src/session/session-stats.ts
@@ -34,6 +34,11 @@ export interface SessionStatsTrackerHost {
 	sessionId(): string;
 }
 
+function correctedPromptTokens(assistant: AssistantMessage): number {
+	const providerPromptTokens = assistant.contextSnapshot?.promptTokens ?? calculatePromptTokens(assistant.usage);
+	return Math.max(0, providerPromptTokens - (assistant.contextSnapshot?.historyRewriteTokensRemoved ?? 0));
+}
+
 /** Computes session totals and tracks the in-flight context estimate. */
 export class SessionStatsTracker {
 	readonly #host: SessionStatsTrackerHost;
@@ -160,8 +165,7 @@ export class SessionStatsTracker {
 		const useAnchor =
 			anchorAssistant !== undefined && anchorIndex !== -1 && (!pending || anchorIndex >= pending.cutoffCount);
 		if (useAnchor && anchorAssistant) {
-			const promptTokens =
-				anchorAssistant.contextSnapshot?.promptTokens ?? calculatePromptTokens(anchorAssistant.usage);
+			const promptTokens = correctedPromptTokens(anchorAssistant);
 			const nonMessageTokens =
 				anchorAssistant.contextSnapshot?.nonMessageTokens ?? computeNonMessageTokens(this.#host.session);
 			anchored = true;
@@ -199,7 +203,7 @@ export class SessionStatsTracker {
 				) {
 					continue;
 				}
-				const promptTokens = message.contextSnapshot?.promptTokens ?? calculatePromptTokens(message.usage);
+				const promptTokens = correctedPromptTokens(message);
 				const nonMessageTokens =
 					message.contextSnapshot?.nonMessageTokens ?? computeNonMessageTokens(this.#host.session);
 				let tailTokens = 0;
@@ -254,6 +258,40 @@ export class SessionStatsTracker {
 	/** Non-message token count captured for the active provider request. */
 	get pendingNonMessageTokens(): number | undefined {
 		return this.#pendingContextSnapshot?.nonMessageTokens;
+	}
+
+	/**
+	 * Apply an estimated prompt-prefix reduction to the current provider anchor.
+	 *
+	 * History after the anchor is estimated live by {@link getContextBreakdown};
+	 * callers must pass only savings from entries already included in the
+	 * anchor's provider-reported prompt. Persisting the correction on the
+	 * assistant snapshot keeps reloads accurate, and the next successful
+	 * assistant response naturally replaces it with a fresh provider anchor.
+	 */
+	recordAnchoredHistoryRewrite(tokensRemoved: number): void {
+		if (!Number.isFinite(tokensRemoved) || tokensRemoved <= 0) return;
+
+		const branchEntries = this.#host.sessionManager.getBranch();
+		const latestCompaction = getLatestCompactionEntry(branchEntries);
+		const compactionIndex = latestCompaction ? branchEntries.lastIndexOf(latestCompaction) : -1;
+		for (let index = branchEntries.length - 1; index > compactionIndex; index--) {
+			const entry = branchEntries[index];
+			if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+			const assistant = entry.message;
+			if (assistant.stopReason === "aborted" || assistant.stopReason === "error" || !assistant.usage) continue;
+
+			if (!assistant.contextSnapshot) {
+				assistant.contextSnapshot = {
+					promptTokens: calculatePromptTokens(assistant.usage),
+					nonMessageTokens: computeNonMessageTokens(this.#host.session),
+				};
+			}
+			const snapshot = assistant.contextSnapshot;
+			snapshot.historyRewriteTokensRemoved = (snapshot.historyRewriteTokensRemoved ?? 0) + Math.floor(tokensRemoved);
+			this.#contextUsageRevision++;
+			return;
+		}
 	}
 
 	/** Sets or clears the in-flight context snapshot. */

--- a/packages/coding-agent/src/session/session-stats.ts
+++ b/packages/coding-agent/src/session/session-stats.ts
@@ -279,7 +279,14 @@ export class SessionStatsTracker {
 			const entry = branchEntries[index];
 			if (entry.type !== "message" || entry.message.role !== "assistant") continue;
 			const assistant = entry.message;
-			if (assistant.stopReason === "aborted" || assistant.stopReason === "error" || !assistant.usage) continue;
+			if (
+				assistant.stopReason === "aborted" ||
+				assistant.stopReason === "error" ||
+				!assistant.usage ||
+				!hasContextTokenUsage(assistant.usage)
+			) {
+				continue;
+			}
 
 			if (!assistant.contextSnapshot) {
 				assistant.contextSnapshot = {

--- a/packages/coding-agent/test/shake.test.ts
+++ b/packages/coding-agent/test/shake.test.ts
@@ -117,6 +117,42 @@ describe("AgentSession shake", () => {
 			expect(text).toContain("shaken");
 		});
 
+		it("updates provider-anchored context usage immediately after rewriting prompt history", async () => {
+			seedHeavyToolResult("X".repeat(20_000));
+			sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: "done" }],
+				...apiInfo,
+				stopReason: "stop",
+				usage: { ...usage, input: 20_000, totalTokens: 20_008 },
+				timestamp: Date.now(),
+			});
+			session.agent.replaceMessages(
+				sessionManager
+					.getBranch()
+					.filter(entry => entry.type === "message")
+					.map(entry => entry.message as AgentMessage),
+			);
+			const before = session.getContextUsage()?.tokens;
+			expect(before).toBe(20_000);
+
+			const result = await session.shake("elide");
+
+			expect(result.tokensFreed).toBeGreaterThan(0);
+			expect(session.getContextUsage()?.tokens).toBe(20_000 - result.tokensFreed);
+			const anchor = sessionManager
+				.getBranch()
+				.findLast(
+					entry =>
+						entry.type === "message" && entry.message.role === "assistant" && entry.message.stopReason === "stop",
+				);
+			expect(
+				anchor?.type === "message" && anchor.message.role === "assistant"
+					? anchor.message.contextSnapshot?.historyRewriteTokensRemoved
+					: undefined,
+			).toBe(result.tokensFreed);
+		});
+
 		it("returns zero counts for an empty branch", async () => {
 			const result = await session.shake("elide");
 			expect(result.toolResultsDropped).toBe(0);

--- a/packages/coding-agent/test/shake.test.ts
+++ b/packages/coding-agent/test/shake.test.ts
@@ -153,6 +153,54 @@ describe("AgentSession shake", () => {
 			).toBe(result.tokensFreed);
 		});
 
+		it("skips response-only usage when selecting the correction anchor", async () => {
+			seedHeavyToolResult("X".repeat(20_000));
+			sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: "anchored" }],
+				...apiInfo,
+				stopReason: "stop",
+				usage: { ...usage, input: 20_000, totalTokens: 20_008 },
+				timestamp: Date.now(),
+			});
+			sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: "response-only" }],
+				...apiInfo,
+				stopReason: "stop",
+				usage: { ...usage, input: 0, output: 8, totalTokens: 8 },
+				timestamp: Date.now() + 1,
+			});
+			session.agent.replaceMessages(
+				sessionManager
+					.getBranch()
+					.filter(entry => entry.type === "message")
+					.map(entry => entry.message as AgentMessage),
+			);
+			const before = session.getContextUsage()?.tokens;
+			expect(before).toBeDefined();
+
+			const result = await session.shake("elide");
+
+			expect(result.tokensFreed).toBeGreaterThan(0);
+			expect(session.getContextUsage()?.tokens).toBe(before! - result.tokensFreed);
+			const assistants = sessionManager
+				.getBranch()
+				.filter(entry => entry.type === "message" && entry.message.role === "assistant");
+			const usableAnchor = assistants.at(-2);
+			const responseOnly = assistants.at(-1);
+			expect(
+				usableAnchor?.type === "message" && usableAnchor.message.role === "assistant"
+					? usableAnchor.message.contextSnapshot?.historyRewriteTokensRemoved
+					: undefined,
+			).toBe(result.tokensFreed);
+			expect(
+				responseOnly?.type === "message" && responseOnly.message.role === "assistant"
+					? responseOnly.message.contextSnapshot?.historyRewriteTokensRemoved
+					: undefined,
+			).toBeUndefined();
+		});
+
 		it("returns zero counts for an empty branch", async () => {
 			const result = await session.shake("elide");
 			expect(result.toolResultsDropped).toBe(0);

--- a/packages/coding-agent/test/shake.test.ts
+++ b/packages/coding-agent/test/shake.test.ts
@@ -201,6 +201,41 @@ describe("AgentSession shake", () => {
 			).toBeUndefined();
 		});
 
+		it("does not subtract remote-compacted entries omitted from the provider prompt", async () => {
+			seedHeavyToolResult("X".repeat(20_000));
+			const firstKeptEntryId = sessionManager.getBranch()[0]?.id;
+			if (!firstKeptEntryId) throw new Error("Expected seeded branch");
+			sessionManager.appendCompaction("remote summary", undefined, firstKeptEntryId, 10_000, {}, false, {
+				openaiRemoteCompaction: {
+					provider: "openai",
+					replacementHistory: [],
+				},
+			});
+			sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: "post-compaction" }],
+				...apiInfo,
+				stopReason: "stop",
+				usage: { ...usage, input: 20_000, totalTokens: 20_008 },
+				timestamp: Date.now(),
+			});
+			session.agent.replaceMessages(session.buildDisplaySessionContext().messages);
+			expect(session.getContextUsage()?.tokens).toBe(20_000);
+
+			const result = await session.shake("elide");
+
+			expect(result.tokensFreed).toBeGreaterThan(0);
+			expect(session.getContextUsage()?.tokens).toBe(20_000);
+			const anchor = sessionManager
+				.getBranch()
+				.findLast(entry => entry.type === "message" && entry.message.role === "assistant");
+			expect(
+				anchor?.type === "message" && anchor.message.role === "assistant"
+					? anchor.message.contextSnapshot?.historyRewriteTokensRemoved
+					: undefined,
+			).toBeUndefined();
+		});
+
 		it("returns zero counts for an empty branch", async () => {
 			const result = await session.shake("elide");
 			expect(result.toolResultsDropped).toBe(0);


### PR DESCRIPTION
## What

- Track estimated prompt-prefix savings from local history rewrites on the active provider context snapshot.
- Apply `/shake` savings only for entries actually included in that provider anchor, while leaving post-anchor tail accounting live-estimated.
- Exclude kept pre-compaction entries replaced by OpenAI remote-compaction provider history.
- Refresh context usage immediately and preserve the correction across session reloads until a fresh provider response replaces the anchor.

## Why

Manual `/shake` rewrote and persisted the reduced history, but context usage remained anchored to the previous provider-reported prompt count. The status bar and pre-turn compaction check therefore stayed stale until the next model response supplied a new usage snapshot.

## Testing

- `bun test packages/coding-agent/test/shake.test.ts` — 15 passed
- `bun run --cwd packages/ai check:types`
- `bun run --cwd packages/coding-agent check:types`
- `bunx biome check packages/ai/src/types.ts packages/coding-agent/src/session/agent-session.ts packages/coding-agent/src/session/session-context.ts packages/coding-agent/src/session/session-maintenance.ts packages/coding-agent/src/session/session-stats.ts packages/coding-agent/test/shake.test.ts`
- `bun packages/coding-agent/src/cli.ts --version` — `omp/17.2.1`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

## Risk

- The correction is estimated, like the existing local tail accounting, but remains bounded by the authoritative provider prompt count.
- Corrections are scoped to the current assistant anchor and naturally expire when the next successful response records fresh provider usage.
- Remote replacement detection shares the parser used by `buildSessionContext`, keeping correction eligibility aligned with the actual provider prompt.

## AI Review Report

- Verified prefix and tail accounting are separated so rewritten post-anchor messages are not double-counted.
- Aligned all anchor selection paths on `hasContextTokenUsage`, including response-only usage coverage.
- Excluded pre-compaction entries omitted by OpenAI remote replacement history, with focused regression coverage.
- Moved the changelog entry to `Unreleased` per review.

## Security Audit

- No new external inputs, permissions, network paths, or secret handling.
- Non-finite and non-positive corrections are rejected; corrected prompt usage is clamped at zero.
