### PR TITLE
fix(catalog): downgrade forced tool choice for deepseek reasoning models

### DIFF
--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -1724,6 +1724,41 @@ describe("kimi model detection via detectCompat", () => {
 		expect(payload.tool_choice).toBe("auto");
 	});
 
+	// #7315: DeepSeek reasoning models via OpenCode Zen/Go 400 with "Thinking
+	// mode does not support this tool_choice" when a specific function is forced.
+	// Dropping reasoning_effort does not turn off the gateway's default thinking
+	// mode, so the compat descriptor itself must mark forced tool choice
+	// unsupported (no per-model override) and buildParams must downgrade the
+	// selector to "auto" while keeping the tool advertised.
+	it("downgrades forced tool_choice to auto for bundled DeepSeek reasoning on OpenCode Zen", async () => {
+		const model = getBundledModel("opencode-zen", "deepseek-v4-flash-free") as Model<"openai-completions">;
+		expect(model.compat.supportsForcedToolChoice).toBe(false);
+		const todoTool: Tool = {
+			name: "todo",
+			description: "Manage the todo list",
+			parameters: { type: "object", properties: {}, required: [] },
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(
+			model,
+			{
+				messages: [{ role: "user", content: "do it", timestamp: Date.now() }],
+				tools: [todoTool],
+			},
+			{
+				apiKey: "test-key",
+				fetch: createMockFetch(["[DONE]"]),
+				reasoning: "high",
+				toolChoice: { type: "tool", name: "todo" },
+				signal: createAbortedSignal(),
+				onPayload: payload => resolve(payload),
+			},
+		);
+		const payload = (await promise) as { tool_choice?: unknown; tools?: Array<{ function?: { name?: string } }> };
+		expect(payload.tool_choice).toBe("auto");
+		expect(payload.tools?.some(t => t.function?.name === "todo")).toBe(true);
+	});
+
 	// #1484 follow-up: DeepSeek V4 on opencode-go exhibits the same gateway
 	// invariant as Kimi (same Zen gateway). DeepSeek emits reasoning under the
 	// `reasoning` signature, so the pre-fix code wrote both `reasoning` and

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -1769,6 +1769,20 @@ describe("kimi model detection via detectCompat", () => {
 				openCodePayload.tools.some(tool => getNestedObject(tool, "function")?.name === "todo"),
 		).toBe(true);
 
+		// A custom provider id pointed at the OpenCode gateway URL is still
+		// classified as OpenCode by baseUrl, so the downgrade must apply there too.
+		const customOpenCode = buildModel({
+			...gpt4oMiniSpec,
+			api: "openai-completions",
+			provider: "my-opencode",
+			baseUrl: "https://opencode.ai/zen/v1",
+			id: "deepseek-v4-flash",
+			reasoning: true,
+		} satisfies ModelSpec<"openai-completions">);
+		expect(customOpenCode.compat.supportsForcedToolChoice).toBe(false);
+		const customPayload = await captureToolChoice(customOpenCode);
+		expect(customPayload.tool_choice).toBe("auto");
+
 		const nvidia = buildModel({
 			...gpt4oMiniSpec,
 			api: "openai-completions",

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -1730,33 +1730,59 @@ describe("kimi model detection via detectCompat", () => {
 	// mode, so the compat descriptor itself must mark forced tool choice
 	// unsupported (no per-model override) and buildParams must downgrade the
 	// selector to "auto" while keeping the tool advertised.
-	it("downgrades forced tool_choice to auto for bundled DeepSeek reasoning on OpenCode Zen", async () => {
-		const model = getBundledModel("opencode-zen", "deepseek-v4-flash-free") as Model<"openai-completions">;
-		expect(model.compat.supportsForcedToolChoice).toBe(false);
+	it("scopes the DeepSeek forced tool_choice downgrade to OpenCode gateways", async () => {
 		const todoTool: Tool = {
 			name: "todo",
 			description: "Manage the todo list",
 			parameters: { type: "object", properties: {}, required: [] },
 		};
-		const { promise, resolve } = Promise.withResolvers<unknown>();
-		streamOpenAICompletions(
-			model,
-			{
-				messages: [{ role: "user", content: "do it", timestamp: Date.now() }],
-				tools: [todoTool],
-			},
-			{
-				apiKey: "test-key",
-				fetch: createMockFetch(["[DONE]"]),
-				reasoning: "high",
-				toolChoice: { type: "tool", name: "todo" },
-				signal: createAbortedSignal(),
-				onPayload: payload => resolve(payload),
-			},
-		);
-		const payload = (await promise) as { tool_choice?: unknown; tools?: Array<{ function?: { name?: string } }> };
-		expect(payload.tool_choice).toBe("auto");
-		expect(payload.tools?.some(t => t.function?.name === "todo")).toBe(true);
+		async function captureToolChoice(model: Model<"openai-completions">): Promise<Record<string, unknown>> {
+			const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
+			streamOpenAICompletions(
+				model,
+				{
+					messages: [{ role: "user", content: "do it", timestamp: Date.now() }],
+					tools: [todoTool],
+				},
+				{
+					apiKey: "test-key",
+					fetch: createMockFetch(["[DONE]"]),
+					reasoning: "high",
+					toolChoice: { type: "tool", name: "todo" },
+					signal: createAbortedSignal(),
+					onPayload: payload => {
+						const object = toObject(payload);
+						if (!object) throw new Error("Expected object payload");
+						resolve(object);
+					},
+				},
+			);
+			return promise;
+		}
+
+		const openCode = getBundledModel<"openai-completions">("opencode-zen", "deepseek-v4-flash-free");
+		expect(openCode.compat.supportsForcedToolChoice).toBe(false);
+		const openCodePayload = await captureToolChoice(openCode);
+		expect(openCodePayload.tool_choice).toBe("auto");
+		expect(
+			Array.isArray(openCodePayload.tools) &&
+				openCodePayload.tools.some(tool => getNestedObject(tool, "function")?.name === "todo"),
+		).toBe(true);
+
+		const nvidia = buildModel({
+			...gpt4oMiniSpec,
+			api: "openai-completions",
+			provider: "nvidia",
+			baseUrl: "https://integrate.api.nvidia.com/v1",
+			id: "deepseek-ai/deepseek-v4-flash",
+			reasoning: true,
+		} satisfies ModelSpec<"openai-completions">);
+		expect(nvidia.compat.supportsForcedToolChoice).toBe(true);
+		const nvidiaPayload = await captureToolChoice(nvidia);
+		expect(nvidiaPayload.tool_choice).toEqual({
+			type: "function",
+			function: { name: "todo" },
+		});
 	});
 
 	// #1484 follow-up: DeepSeek V4 on opencode-go exhibits the same gateway

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `gen:models` Codex discovery to union models across every stored OAuth account and fail closed on partial resolution, matching runtime discovery ([#6265](https://github.com/can1357/oh-my-pi/issues/6265)); restored the bundled `gpt-5.4`, `gpt-5.6-sol`, and `gpt-5.3-codex-spark` entries a single-account regen had dropped.
+- Fixed DeepSeek reasoning models on the OpenCode Zen/Go gateways (e.g. `opencode-zen/deepseek-v4-flash-free`) failing with `400 Thinking mode does not support this tool_choice` when a specific tool was forced. Dropping `reasoning_effort` does not disable the gateway's default thinking mode, so the OpenAI-compat descriptor now marks forced `tool_choice` unsupported for DeepSeek reasoning models, downgrading the selector to `auto` while keeping the tool advertised ([#7315](https://github.com/can1357/oh-my-pi/issues/7315)).
 
 ## [17.2.3] - 2026-08-01
 

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -318,7 +318,8 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		isDeepseekModelIdOrName(spec.name ?? "") ||
 		isOpenCodeDeepseekAlias;
 	const isDirectDeepseekApi = modelMatchesHost(hostModel, "deepseekDirect");
-	const isDirectDeepseekReasoning = isDirectDeepseekApi && isDeepseekFamily && Boolean(spec.reasoning);
+	const isDeepseekReasoning = isDeepseekFamily && Boolean(spec.reasoning);
+	const isDirectDeepseekReasoning = isDirectDeepseekApi && isDeepseekReasoning;
 	const isGrok = modelMatchesHost(hostModel, "xai");
 	const isMistral = modelMatchesHost(hostModel, "mistral");
 	const isOpenCodeHost = modelMatchesHost(hostModel, "opencode");
@@ -490,7 +491,14 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		disableReasoningOnForcedToolChoice: (isKimiModel && !isMoonshotKimiK3) || isAnthropicModel,
 		disableReasoningOnToolChoice: isDeepseekFamily && Boolean(spec.reasoning) && !isOpenRouter,
 		supportsToolChoice: !isDirectDeepseekReasoning,
-		supportsForcedToolChoice: !requiresEnabledThinking,
+		// DeepSeek reasoning models (deepseek-reasoner, DeepSeek V4 thinking) 400
+		// with "Thinking mode does not support this tool_choice" when a specific
+		// function is forced while thinking is active. Direct-API DeepSeek drops
+		// tool_choice entirely (supportsToolChoice above); gateway-hosted DeepSeek
+		// (OpenCode Zen/Go, etc.) keeps tools available but must downgrade a forced
+		// selector to `auto`, since dropping `reasoning_effort` alone does not turn
+		// the gateway's default thinking mode off (#7315).
+		supportsForcedToolChoice: !requiresEnabledThinking && !isDeepseekReasoning,
 		supportsNamedToolChoice: STRING_ONLY_NAMED_TOOL_CHOICE_PROVIDERS[provider] !== true,
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: isMistral,

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -496,7 +496,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		// function is forced while the gateway's default thinking mode is active.
 		// Downgrade only on those gateways: other hosts can turn thinking off via
 		// disableReasoningOnToolChoice and must retain hard tool selection.
-		supportsForcedToolChoice: !requiresEnabledThinking && !(isOpenCodeProvider && isDeepseekReasoning),
+		supportsForcedToolChoice: !requiresEnabledThinking && !(isOpenCodeHost && isDeepseekReasoning),
 		supportsNamedToolChoice: STRING_ONLY_NAMED_TOOL_CHOICE_PROVIDERS[provider] !== true,
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: isMistral,

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -491,14 +491,12 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		disableReasoningOnForcedToolChoice: (isKimiModel && !isMoonshotKimiK3) || isAnthropicModel,
 		disableReasoningOnToolChoice: isDeepseekFamily && Boolean(spec.reasoning) && !isOpenRouter,
 		supportsToolChoice: !isDirectDeepseekReasoning,
-		// DeepSeek reasoning models (deepseek-reasoner, DeepSeek V4 thinking) 400
-		// with "Thinking mode does not support this tool_choice" when a specific
-		// function is forced while thinking is active. Direct-API DeepSeek drops
-		// tool_choice entirely (supportsToolChoice above); gateway-hosted DeepSeek
-		// (OpenCode Zen/Go, etc.) keeps tools available but must downgrade a forced
-		// selector to `auto`, since dropping `reasoning_effort` alone does not turn
-		// the gateway's default thinking mode off (#7315).
-		supportsForcedToolChoice: !requiresEnabledThinking && !isDeepseekReasoning,
+		// DeepSeek reasoning models on OpenCode Zen/Go 400 with
+		// "Thinking mode does not support this tool_choice" when a specific
+		// function is forced while the gateway's default thinking mode is active.
+		// Downgrade only on those gateways: other hosts can turn thinking off via
+		// disableReasoningOnToolChoice and must retain hard tool selection.
+		supportsForcedToolChoice: !requiresEnabledThinking && !(isOpenCodeProvider && isDeepseekReasoning),
 		supportsNamedToolChoice: STRING_ONLY_NAMED_TOOL_CHOICE_PROVIDERS[provider] !== true,
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
 		requiresToolResultName: isMistral,


### PR DESCRIPTION
## Repro
A turn against `opencode-zen/deepseek-v4-flash-free` (a DeepSeek V4 thinking model) dies with `400 Error from provider (DeepSeek): Thinking mode does not support this tool_choice` whenever omp forces a specific tool. Building the bundled model and capturing the chat-completions wire body for a forced-tool turn (`reasoning: high`, `toolChoice: {type:'tool', name:'todo'}`, 12 tools advertised) reproduces the exact request from the reporter's `~/.omp/logs/http-400-requests` capture: `tool_choice: {"type":"function","function":{"name":"todo"}}` with `reasoning_effort` already dropped.

## Cause
`buildOpenAICompat` in `packages/catalog/src/compat/openai.ts` already sets `disableReasoningOnToolChoice` for DeepSeek reasoning models, so `reasoning_effort` is dropped when a tool_choice is present. But the OpenCode Zen/Go gateways keep DeepSeek's thinking mode on by default for a reasoning model regardless of `reasoning_effort` — the `openai` reasoning dialect has no explicit "thinking off" wire field — so the *forced* named `tool_choice` still trips DeepSeek's thinking+tool_choice guard. `supportsForcedToolChoice` was `!requiresEnabledThinking` (true for DeepSeek), so `buildParams` never downgraded the selector.

## Fix
- `packages/catalog/src/compat/openai.ts`: add `isDeepseekReasoning` (`isDeepseekFamily && spec.reasoning`), reuse it for the existing `isDirectDeepseekReasoning`, and set `supportsForcedToolChoice: !requiresEnabledThinking && !isDeepseekReasoning`. `openai-completions.ts` `buildParams` then downgrades a forced selector to `auto` while keeping the tool advertised (mirrors the Anthropic and direct-DeepSeek paths).
- `packages/ai/test/openai-completions-compat.test.ts`: regression test asserting the bundled `opencode-zen/deepseek-v4-flash-free` compat marks forced choice unsupported and the wire body emits `tool_choice: "auto"` with the `todo` tool still advertised.
- `packages/catalog/CHANGELOG.md`: `[Unreleased] > Fixed` entry.

## Verification
`bun test` (packages/catalog: 546 pass; packages/ai targeted suites deepseek-reasoning-content, disable-reasoning, reasoning-disable-dialects, kimi-code-thinking, issue-827/1838/5756, openai-completions-compat: all pass). Full `packages/ai` suite: 3643 pass, 1 fail in `proxy.test.ts` which is a pre-existing full-suite ordering flake (passes in isolation on a clean tree and with this diff; unrelated to a compat boolean). `bun run fix` + `bun check` pass via the pre-publish gate. Fixes #7315