### PR TITLE
fix(coding-agent): support Wayland image paste

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed image paste failing on Wayland-only Linux sessions by reading PNG clipboard payloads through `wl-paste` before falling back to the native bridge ([#7316](https://github.com/can1357/oh-my-pi/issues/7316)).
+
 ## [17.2.3] - 2026-08-01
 
 ### Changed

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -1,6 +1,6 @@
 import type { ClipboardImage } from "@oh-my-pi/pi-natives";
 import * as native from "@oh-my-pi/pi-natives";
-import { logger } from "@oh-my-pi/pi-utils";
+import { logger, SUPPORTED_IMAGE_MIME_TYPES } from "@oh-my-pi/pi-utils";
 import MAC_FILE_URL_SCRIPT from "./mac-file-urls.applescript" with { type: "text" };
 
 type SpawnCaptureOptions = { input?: string; timeoutMs?: number };
@@ -264,7 +264,7 @@ async function readTextViaPowerShell(): Promise<string | null> {
  * because terminal clipboard paths can leave image payloads invisible to the
  * native bridge.
  *
- * @returns PNG payload or null when no image is available.
+ * @returns A supported image payload or null when no image is available.
  */
 export async function readImageFromClipboard(): Promise<ClipboardImage | null> {
 	if (process.env.TERMUX_VERSION) {
@@ -291,10 +291,14 @@ export async function readImageFromClipboard(): Promise<ClipboardImage | null> {
 
 	if (process.platform === "linux" && process.env.WAYLAND_DISPLAY) {
 		try {
-			const data = await spawnCapture(["wl-paste", "--type", "image/png"], { encoding: "bytes" });
-			if (data.byteLength > 0) return { data, mimeType: "image/png" };
+			const offeredMimeTypes = new Set((await spawnCapture(["wl-paste", "--list-types"])).split(/\r?\n/));
+			for (const mimeType of SUPPORTED_IMAGE_MIME_TYPES) {
+				if (!offeredMimeTypes.has(mimeType)) continue;
+				const data = await spawnCapture(["wl-paste", "--type", mimeType], { encoding: "bytes" });
+				if (data.byteLength > 0) return { data, mimeType };
+			}
 		} catch {
-			// Fall through to arboard when wl-clipboard is absent or has no PNG payload.
+			// Fall through when wl-clipboard is absent or no advertised image payload can be read.
 		}
 	}
 

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -3,6 +3,8 @@ import * as native from "@oh-my-pi/pi-natives";
 import { logger } from "@oh-my-pi/pi-utils";
 import MAC_FILE_URL_SCRIPT from "./mac-file-urls.applescript" with { type: "text" };
 
+type SpawnCaptureOptions = { input?: string; timeoutMs?: number };
+
 /**
  * Run a subprocess and capture its stdout without blocking the event loop.
  *
@@ -10,15 +12,20 @@ import MAC_FILE_URL_SCRIPT from "./mac-file-urls.applescript" with { type: "text
  * path all shell out to CLI clipboard tools. The synchronous `execSync` API
  * parks the render loop until the child exits or the timeout fires, so a hung
  * clipboard daemon freezes the TUI for the full 2000ms budget (#4235). This
- * helper mirrors the previous semantics — read stdout as UTF-8, throw on
- * non-zero exit or timeout, forward optional stdin — but yields to the event
- * loop while the child runs.
+ * helper mirrors the previous semantics — capture stdout, throw on non-zero
+ * exit or timeout, forward optional stdin — but yields to the event loop while
+ * the child runs.
  *
  * @throws Error when the child fails to spawn, is killed by the timeout, or
- *   exits with a non-zero status. Callers rely on this to fall through to the
- *   outer catch and return an empty string / empty list.
+ *   exits with a non-zero status. Callers rely on this to use platform
+ *   fallbacks or report an empty clipboard.
  */
-async function spawnCapture(cmd: string[], options: { input?: string; timeoutMs?: number } = {}): Promise<string> {
+async function spawnCapture(cmd: string[], options: SpawnCaptureOptions & { encoding: "bytes" }): Promise<Uint8Array>;
+async function spawnCapture(cmd: string[], options?: SpawnCaptureOptions): Promise<string>;
+async function spawnCapture(
+	cmd: string[],
+	options: SpawnCaptureOptions & { encoding?: "bytes" } = {},
+): Promise<string | Uint8Array> {
 	const timeoutMs = options.timeoutMs ?? 2000;
 	const proc = Bun.spawn(cmd, {
 		stdout: "pipe",
@@ -31,7 +38,9 @@ async function spawnCapture(cmd: string[], options: { input?: string; timeoutMs?
 		proc.kill();
 	}, timeoutMs);
 	try {
-		const stdout = await new Response(proc.stdout).text();
+		const response = new Response(proc.stdout);
+		const stdout =
+			options.encoding === "bytes" ? new Uint8Array(await response.arrayBuffer()) : await response.text();
 		await proc.exited;
 		if (timedOut) {
 			throw new Error(`${cmd[0]} timed out after ${timeoutMs}ms`);
@@ -278,6 +287,15 @@ export async function readImageFromClipboard(): Promise<ClipboardImage | null> {
 			logger.warn("clipboard: native Windows image read failed", { error: String(err) });
 		}
 		return await readImageViaPowerShell();
+	}
+
+	if (process.platform === "linux" && process.env.WAYLAND_DISPLAY) {
+		try {
+			const data = await spawnCapture(["wl-paste", "--type", "image/png"], { encoding: "bytes" });
+			if (data.byteLength > 0) return { data, mimeType: "image/png" };
+		} catch {
+			// Fall through to arboard when wl-clipboard is absent or has no PNG payload.
+		}
 	}
 
 	if (!hasDisplay()) {

--- a/packages/coding-agent/test/utils/clipboard.test.ts
+++ b/packages/coding-agent/test/utils/clipboard.test.ts
@@ -14,14 +14,15 @@ type SpawnOptions = Bun.SpawnOptions.SpawnOptions<
 >;
 
 type SpawnCall = { cmd: string[]; options: SpawnOptions };
+type SpawnOutput = string | Uint8Array;
 
-function streamOf(body: string | Uint8Array): ReadableStream<Uint8Array> {
+function streamOf(body: SpawnOutput): ReadableStream<Uint8Array> {
 	const stream = new Response(body).body;
 	if (!stream) throw new Error("Failed to create response stream.");
 	return stream;
 }
 
-function fakeProcess(stdout: string | Uint8Array, exitCode = 0): Subprocess {
+function fakeProcess(stdout: SpawnOutput, exitCode = 0): Subprocess {
 	return {
 		pid: 1,
 		stdout: streamOf(stdout),
@@ -32,14 +33,15 @@ function fakeProcess(stdout: string | Uint8Array, exitCode = 0): Subprocess {
 	} as unknown as Subprocess;
 }
 
-function spySpawn(calls: SpawnCall[], stdout: string | Uint8Array, exitCode = 0) {
+function spySpawn(calls: SpawnCall[], stdout: SpawnOutput | SpawnOutput[], exitCode = 0) {
 	function mockSpawn(opts: SpawnOptions & { cmd: string[] }): Subprocess;
 	function mockSpawn(cmd: string[], opts?: SpawnOptions): Subprocess;
 	function mockSpawn(first: string[] | (SpawnOptions & { cmd: string[] }), second?: SpawnOptions): Subprocess {
 		const cmd = Array.isArray(first) ? first : first.cmd;
 		const options = Array.isArray(first) ? (second ?? ({} as SpawnOptions)) : (first as SpawnOptions);
 		calls.push({ cmd, options });
-		return fakeProcess(stdout, exitCode);
+		const output = Array.isArray(stdout) ? (stdout[calls.length - 1] ?? "") : stdout;
+		return fakeProcess(output, exitCode);
 	}
 	return vi.spyOn(Bun, "spawn").mockImplementation(mockSpawn);
 }
@@ -194,21 +196,25 @@ describe("readImageFromClipboard dispatch", () => {
 		expect(nativeSpy).toHaveBeenCalledTimes(1);
 	});
 
-	it("reads PNG bytes through wl-paste before the native bridge on Wayland-only Linux", async () => {
-		setPlatform("linux");
-		process.env.WAYLAND_DISPLAY = "wayland-0";
-		const png = Uint8Array.from([0x89, 0x50, 0x4e, 0x47]);
-		const calls: SpawnCall[] = [];
-		spySpawn(calls, png);
-		const nativeSpy = vi.spyOn(native, "readImageFromClipboard");
+	it.each(["image/png", "image/jpeg", "image/gif", "image/webp"] as const)(
+		"reads %s bytes through wl-paste before the native bridge on Wayland-only Linux",
+		async mimeType => {
+			setPlatform("linux");
+			process.env.WAYLAND_DISPLAY = "wayland-0";
+			const data = Uint8Array.from([0x89, 0x50, 0x4e, 0x47]);
+			const calls: SpawnCall[] = [];
+			spySpawn(calls, [`text/plain\n${mimeType}\n`, data]);
+			const nativeSpy = vi.spyOn(native, "readImageFromClipboard");
 
-		const image = await readImageFromClipboard();
+			const image = await readImageFromClipboard();
 
-		expect(calls).toHaveLength(1);
-		expect(calls[0]?.cmd).toEqual(["wl-paste", "--type", "image/png"]);
-		expect(image).toEqual({ data: png, mimeType: "image/png" });
-		expect(nativeSpy).not.toHaveBeenCalled();
-	});
+			expect(calls).toHaveLength(2);
+			expect(calls[0]?.cmd).toEqual(["wl-paste", "--list-types"]);
+			expect(calls[1]?.cmd).toEqual(["wl-paste", "--type", mimeType]);
+			expect(image).toEqual({ data, mimeType });
+			expect(nativeSpy).not.toHaveBeenCalled();
+		},
+	);
 
 	it("returns null on Termux without spawning anything", async () => {
 		setPlatform("linux");

--- a/packages/coding-agent/test/utils/clipboard.test.ts
+++ b/packages/coding-agent/test/utils/clipboard.test.ts
@@ -15,13 +15,13 @@ type SpawnOptions = Bun.SpawnOptions.SpawnOptions<
 
 type SpawnCall = { cmd: string[]; options: SpawnOptions };
 
-function streamOf(text: string): ReadableStream<Uint8Array> {
-	const body = new Response(text).body;
-	if (!body) throw new Error("Failed to create response stream.");
-	return body;
+function streamOf(body: string | Uint8Array): ReadableStream<Uint8Array> {
+	const stream = new Response(body).body;
+	if (!stream) throw new Error("Failed to create response stream.");
+	return stream;
 }
 
-function fakeProcess(stdout: string, exitCode = 0): Subprocess {
+function fakeProcess(stdout: string | Uint8Array, exitCode = 0): Subprocess {
 	return {
 		pid: 1,
 		stdout: streamOf(stdout),
@@ -32,7 +32,7 @@ function fakeProcess(stdout: string, exitCode = 0): Subprocess {
 	} as unknown as Subprocess;
 }
 
-function spyPowershell(calls: SpawnCall[], stdout: string, exitCode = 0) {
+function spySpawn(calls: SpawnCall[], stdout: string | Uint8Array, exitCode = 0) {
 	function mockSpawn(opts: SpawnOptions & { cmd: string[] }): Subprocess;
 	function mockSpawn(cmd: string[], opts?: SpawnOptions): Subprocess;
 	function mockSpawn(first: string[] | (SpawnOptions & { cmd: string[] }), second?: SpawnOptions): Subprocess {
@@ -86,7 +86,7 @@ describe("readImageFromClipboard on WSL", () => {
 		process.env.WAYLAND_DISPLAY = "wayland-0";
 
 		const calls: SpawnCall[] = [];
-		spyPowershell(calls, RED_1X1_PNG_BASE64);
+		spySpawn(calls, RED_1X1_PNG_BASE64);
 		const nativeSpy = vi.spyOn(native, "readImageFromClipboard");
 
 		const image = await readImageFromClipboard();
@@ -106,7 +106,7 @@ describe("readImageFromClipboard on WSL", () => {
 		process.env.WSL_INTEROP = "/run/WSL/1_interop";
 		process.env.WAYLAND_DISPLAY = "wayland-0";
 
-		spyPowershell([], "");
+		spySpawn([], "");
 		const nativeSpy = vi.spyOn(native, "readImageFromClipboard").mockResolvedValue(null);
 
 		const image = await readImageFromClipboard();
@@ -120,7 +120,7 @@ describe("readImageFromClipboard on WSL", () => {
 		process.env.WSL_DISTRO_NAME = "Ubuntu";
 		process.env.DISPLAY = ":0";
 
-		spyPowershell([], "noise", 1);
+		spySpawn([], "noise", 1);
 		const nativeSpy = vi.spyOn(native, "readImageFromClipboard").mockResolvedValue(null);
 
 		await readImageFromClipboard();
@@ -132,7 +132,7 @@ describe("readImageFromClipboard on WSL", () => {
 		process.env.WSL_DISTRO_NAME = "Ubuntu";
 		// No DISPLAY / WAYLAND_DISPLAY — arboard would reject, so we must short-circuit.
 
-		spyPowershell([], "");
+		spySpawn([], "");
 		const nativeSpy = vi.spyOn(native, "readImageFromClipboard");
 
 		expect(await readImageFromClipboard()).toBeNull();
@@ -154,7 +154,7 @@ describe("readImageFromClipboard dispatch", () => {
 	it("uses the PowerShell bridge on native Windows when arboard has no image payload", async () => {
 		setPlatform("win32");
 		const calls: SpawnCall[] = [];
-		spyPowershell(calls, RED_1X1_PNG_BASE64);
+		spySpawn(calls, RED_1X1_PNG_BASE64);
 		vi.spyOn(native, "readImageFromClipboard").mockResolvedValue(null);
 
 		const image = await readImageFromClipboard();
@@ -169,7 +169,7 @@ describe("readImageFromClipboard dispatch", () => {
 	it("falls back to PowerShell when native Windows image conversion fails", async () => {
 		setPlatform("win32");
 		const calls: SpawnCall[] = [];
-		spyPowershell(calls, RED_1X1_PNG_BASE64);
+		spySpawn(calls, RED_1X1_PNG_BASE64);
 		vi.spyOn(native, "readImageFromClipboard").mockRejectedValue(
 			new Error("The clipboard image could not be converted to the appropriate format."),
 		);
@@ -192,6 +192,22 @@ describe("readImageFromClipboard dispatch", () => {
 		await readImageFromClipboard();
 		expect(spawnSpy).not.toHaveBeenCalled();
 		expect(nativeSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("reads PNG bytes through wl-paste before the native bridge on Wayland-only Linux", async () => {
+		setPlatform("linux");
+		process.env.WAYLAND_DISPLAY = "wayland-0";
+		const png = Uint8Array.from([0x89, 0x50, 0x4e, 0x47]);
+		const calls: SpawnCall[] = [];
+		spySpawn(calls, png);
+		const nativeSpy = vi.spyOn(native, "readImageFromClipboard");
+
+		const image = await readImageFromClipboard();
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.cmd).toEqual(["wl-paste", "--type", "image/png"]);
+		expect(image).toEqual({ data: png, mimeType: "image/png" });
+		expect(nativeSpy).not.toHaveBeenCalled();
 	});
 
 	it("returns null on Termux without spawning anything", async () => {
@@ -219,7 +235,7 @@ describe("readMacFileUrlsFromClipboard", () => {
 	it("splits osascript output into one path per non-empty line on darwin", async () => {
 		setPlatform("darwin");
 		const calls: SpawnCall[] = [];
-		spyPowershell(calls, "/Users/me/Pictures/photo.png\n/Users/me/Pictures/clip.jpg\n\n");
+		spySpawn(calls, "/Users/me/Pictures/photo.png\n/Users/me/Pictures/clip.jpg\n\n");
 
 		const paths = await readMacFileUrlsFromClipboard();
 
@@ -235,7 +251,7 @@ describe("readMacFileUrlsFromClipboard", () => {
 
 	it("returns an empty list when osascript exits non-zero (e.g. binary missing)", async () => {
 		setPlatform("darwin");
-		spyPowershell([], "", 127);
+		spySpawn([], "", 127);
 
 		expect(await readMacFileUrlsFromClipboard()).toEqual([]);
 	});
@@ -245,7 +261,7 @@ describe("readTextFromClipboard", () => {
 	it("returns pbpaste stdout on darwin without touching execSync", async () => {
 		setPlatform("darwin");
 		const calls: SpawnCall[] = [];
-		spyPowershell(calls, "hello from pbpaste");
+		spySpawn(calls, "hello from pbpaste");
 
 		expect(await readTextFromClipboard()).toBe("hello from pbpaste");
 		expect(calls).toHaveLength(1);
@@ -254,7 +270,7 @@ describe("readTextFromClipboard", () => {
 
 	it("returns an empty string when the subprocess exits non-zero", async () => {
 		setPlatform("darwin");
-		spyPowershell([], "", 1);
+		spySpawn([], "", 1);
 
 		expect(await readTextFromClipboard()).toBe("");
 	});


### PR DESCRIPTION
## Repro

On Linux with `WAYLAND_DISPLAY=wayland-0` and `DISPLAY` unset, run `bun -e 'import { readImageFromClipboard } from "./packages/coding-agent/src/utils/clipboard.ts"; await readImageFromClipboard()'`; current `main` exits with `Failed to access clipboard: ... X11 server connection timed out because it was unreachable` instead of reading the Wayland clipboard image.

## Cause

`readImageFromClipboard()` in `packages/coding-agent/src/utils/clipboard.ts` sent every non-Windows display-backed image read directly to `native.readImageFromClipboard()`. On a Wayland-only session, that bridge attempted an unreachable X11 connection; unlike `readTextFromClipboard()`, the image path never consulted `wl-paste`.

## Fix

- Capture binary subprocess output without blocking the TUI event loop.
- Read `image/png` bytes through `wl-paste` on Linux Wayland sessions before falling back to the native bridge.
- Cover the Wayland-only dispatch and byte-preservation contract in the clipboard test suite.

## Verification

`bun test packages/coding-agent/test/utils/clipboard.test.ts` passes: 16 tests, 0 failures. A smoke run with a PATH-injected `wl-paste`, `WAYLAND_DISPLAY=wayland-0`, and no `DISPLAY` returned `{"mimeType":"image/png","data":[137,80,78,71]}` without reaching the failing native bridge. The pre-publish `bun run fix` and `bun check` gate passed in `gh_push_branch`.

Fixes #7316