### PR TITLE
fix(tui): preserve shortcuts on non-Latin keyboard layouts

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed animated Loader paints saturating a CPU core on slow WSL/ConPTY terminals by applying cost-aware cadence backpressure while preserving 30fps on cheap frames ([#7290](https://github.com/can1357/oh-my-pi/issues/7290)).
 - Fixed interactive terminals suppressing all output and input when the host project sets `NODE_ENV=test` or `BUN_ENV=test` ([#7261](https://github.com/can1357/oh-my-pi/issues/7261)).
+- Fixed Kitty/Ghostty shortcuts bound to ASCII keys failing when a non-Latin keyboard layout is active by requesting alternate-key reporting ([#7320](https://github.com/can1357/oh-my-pi/issues/7320)).
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1106,9 +1106,9 @@ export class ProcessTerminal implements Terminal {
 					this.#kittyEnableSeq = "\x1b[>7u";
 					this.#safeWrite(this.#kittyEnableSeq);
 				} else {
-					// Level 1 (disambiguate escape codes) — enough for Shift+Enter
-					// without the modifyOtherKeys fallback that caused regression #3259.
-					this.#kittyEnableSeq = "\x1b[>1u";
+					// Request disambiguated escape codes plus alternate-key reporting so shortcut
+					// matching is layout-independent without event-type reporting (see #3259).
+					this.#kittyEnableSeq = "\x1b[>5u";
 					this.#safeWrite(this.#kittyEnableSeq);
 				}
 				return;

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -404,7 +404,7 @@ export interface Terminal {
 	// Whether Kitty keyboard protocol is active
 	get kittyProtocolActive(): boolean;
 
-	// The exact kitty keyboard push sequence in effect ("\x1b[>1u" or "\x1b[>7u"),
+	// The exact kitty keyboard push sequence in effect ("\x1b[>1u", "\x1b[>5u", or "\x1b[>7u"),
 	// or null when the protocol is not active. Kitty keyboard flags are per-screen,
 	// so the TUI re-pushes this after entering the alternate screen.
 	get kittyEnableSequence(): string | null;
@@ -1100,9 +1100,9 @@ export class ProcessTerminal implements Terminal {
 				const reportedFlags = parseInt(match[1]!, 10);
 				this.#kittyProtocolActive = true;
 				setKittyProtocolActive(true);
-				if (reportedFlags >= 3) {
-					// Already enriched (Ghostty/foot may keep flags from a parent app).
-					// Push level-2 to lock in event reporting.
+				if ((reportedFlags & 2) !== 0) {
+					// Preserve event-type reporting already enabled by a parent app.
+					// Push level-2 to keep its shortcuts reporting consistently.
 					this.#kittyEnableSeq = "\x1b[>7u";
 					this.#safeWrite(this.#kittyEnableSeq);
 				} else {

--- a/packages/tui/test/emergency-restore-altscreen.test.ts
+++ b/packages/tui/test/emergency-restore-altscreen.test.ts
@@ -127,7 +127,7 @@ describe("emergencyTerminalRestore alt-screen gating", () => {
 	it("pops keyboard enhancement frames on both screens when crashing from a fullscreen overlay", () => {
 		const { terminal, writes } = startCapturedTerminal();
 		process.stdin.emit("data", "\x1b[?0u");
-		expect(terminal.kittyEnableSequence).toBe("\x1b[>1u");
+		expect(terminal.kittyEnableSequence).toBe("\x1b[>5u");
 
 		terminal.write(`\x1b[?1049h${terminal.kittyEnableSequence}`);
 		setAltScreenActive(true);

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -48,6 +48,15 @@ describe("matchesKey", () => {
 		setKittyProtocolActive(false);
 	});
 
+	it("matches Cyrillic Kitty events through base-layout shortcut keys", () => {
+		setKittyProtocolActive(true);
+		const russianCtrlC = "\x1b[1089::99;5u";
+		const russianCtrlP = "\x1b[1087::112;5u";
+		expect(matchesKey(russianCtrlC, "ctrl+c")).toBe(true);
+		expect(matchesKey(russianCtrlP, "ctrl+p")).toBe(true);
+		setKittyProtocolActive(false);
+	});
+
 	it("should prefer codepoint for symbol keys even when base layout differs", () => {
 		setKittyProtocolActive(true);
 		// Dvorak Ctrl+/ reports codepoint '/' (47) and base layout '[' (91)

--- a/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
+++ b/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
@@ -56,7 +56,7 @@ describe("ProcessTerminal kitty keyboard progressive-enhancement ordering", () =
 
 		const out = harness.writes.join("");
 		expect(harness.terminal.kittyProtocolActive).toBe(true);
-		expect(out).toContain("\x1b[>1u");
+		expect(out).toContain("\x1b[>5u");
 		expect(out).not.toContain("\x1b[>4;2m");
 	});
 
@@ -71,10 +71,10 @@ describe("ProcessTerminal kitty keyboard progressive-enhancement ordering", () =
 
 		const out = harness.writes.join("");
 		expect(harness.terminal.kittyProtocolActive).toBe(true);
-		expect(out).toContain("\x1b[>1u");
+		expect(out).toContain("\x1b[>5u");
 		const enableIdx = out.indexOf("\x1b[>4;2m");
 		const disableIdx = out.indexOf("\x1b[>4;0m");
-		const kittyIdx = out.indexOf("\x1b[>1u");
+		const kittyIdx = out.indexOf("\x1b[>5u");
 		expect(enableIdx).toBeGreaterThanOrEqual(0);
 		expect(disableIdx).toBeGreaterThan(enableIdx);
 		expect(kittyIdx).toBeGreaterThan(enableIdx);
@@ -182,7 +182,7 @@ describe("ProcessTerminal kitty keyboard progressive-enhancement ordering", () =
 			margin: 0,
 		});
 		await harness.settle();
-		expect(harness.writes.join("")).toContain("\x1b[?1049h\x1b[>1u");
+		expect(harness.writes.join("")).toContain("\x1b[?1049h\x1b[>5u");
 		harness.writes.length = 0;
 
 		overlay.hide();

--- a/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
+++ b/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
@@ -60,6 +60,28 @@ describe("ProcessTerminal kitty keyboard progressive-enhancement ordering", () =
 		expect(out).not.toContain("\x1b[>4;2m");
 	});
 
+	it("keeps alternate-key reporting without event types after a previous fresh session", async () => {
+		harness = createProcessTerminalRenderHarness(100, 30);
+		await harness.settle();
+		harness.writes.length = 0;
+
+		await harness.feed("\x1b[?5u");
+
+		const out = harness.writes.join("");
+		expect(out).toContain("\x1b[>5u");
+		expect(out).not.toContain("\x1b[>7u");
+	});
+
+	it("preserves parent event-type reporting", async () => {
+		harness = createProcessTerminalRenderHarness(100, 30);
+		await harness.settle();
+		harness.writes.length = 0;
+
+		await harness.feed("\x1b[?3u");
+
+		expect(harness.writes.join("")).toContain("\x1b[>7u");
+	});
+
 	it("enables kitty when the DA1 sentinel arrives before the kitty reply (#2042)", async () => {
 		harness = createProcessTerminalRenderHarness(100, 30);
 		await harness.settle();

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -601,7 +601,9 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		// Simulate kitty-capable terminal reply (level >=1).
 		process.stdin.emit("data", "\x1b[?1u");
 
-		const pushes = writes.filter(w => w === "\x1b[>1u" || w === "\x1b[>7u" || w === "\x1b[>31u").length;
+		const pushes = writes.filter(
+			w => w === "\x1b[>1u" || w === "\x1b[>5u" || w === "\x1b[>7u" || w === "\x1b[>31u",
+		).length;
 		expect(pushes).toBe(1);
 
 		terminal.stop();


### PR DESCRIPTION
## Summary

Fresh Kitty/Ghostty sessions now request alternate-key reporting together with escape-code disambiguation. This supplies the base-layout key for non-Latin layouts, so OMP can resolve physical `Ctrl+C`, `Ctrl+P`, and similar ASCII shortcuts through its existing matcher.

The negotiation now preserves a parent terminal's event-type reporting only when that mode is already active. A previously fresh OMP session reporting flags `5` continues with `CSI > 5 u` rather than escalating to event press/repeat/release reporting.

## Changes

- **Kitty keyboard negotiation:** request `CSI > 5 u` for a fresh protocol reply; retain `CSI > 7 u` only when the reported flags already include event-type reporting.
- **Regression coverage:** verify fresh and retained Kitty flag modes, DA1-first recovery, alternate-screen reassertion, shutdown push/pop balance, and Russian CSI-u events for `ctrl+c` and `ctrl+p`.
- **API documentation and release notes:** document `CSI > 5 u` in `kittyEnableSequence` and add the TUI changelog entry for #7320.

## QA & Evidence

- **What was tested:** `bun test packages/tui/test/terminal-appearance.test.ts packages/tui/test/kitty-keyboard-da1-ordering.test.ts packages/tui/test/keys.test.ts packages/tui/test/emergency-restore-altscreen.test.ts`
  - **Observed result:** 89 pass, 0 fail, 299 assertions.
  - **Why sufficient:** drives fresh, previously fresh (`CSI ? 5 u`), and parent event-reporting (`CSI ? 3 u`) negotiation paths, including shutdown frame balancing.
- **What was tested:** `bun --cwd=packages/tui run test` and `bun --cwd=packages/tui run check`.
  - **Observed result:** 1,419 pass, 3 skip, 0 fail; check passed.
  - **Why sufficient:** validates the full affected package, including formatting and type checking.
- **What was tested:** runtime native matcher smoke for Russian `CSI-u` input `\x1b[1089::99;5u`.
  - **Observed result:** `parseKittySequence` returned `baseLayoutKey: 99`; `matchesKey(..., "ctrl+c", true)` returned `true`.
  - **Why sufficient:** proves the emitted alternate-key data is consumed as the expected physical ASCII shortcut.
- **What was tested:** `bun run ci:check:full`, `bun run ci:test:ts:workspace`, and `bun run collab:web:build`.
  - **Observed result:** all passed before the review fixes; the full TUI package checks above were rerun after them.
  - **Why sufficient:** covers the PR CI typecheck, workspace-test, and web-build paths.

## Risks & Residuals

- `bun run build` could not complete locally because this workstation has neither `bazelisk` nor `bazel`; it fails before building the native addon. The PR CI native-addon job fetches release addons for pull requests, and no native code changes here. The affected TUI tests pass with the version-matched release addon.
- `CSI > 5 u` deliberately omits event-type reporting; `CSI > 7 u` remains limited to terminal sessions that already reported that mode.

## Related Issues

Fixes #7320
