### PR TITLE
feat(coding-agent): add /side throwaway conversation fork

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -103,6 +103,9 @@
 - Fixed the Python RPC client dropping context, compaction, OAuth URL, and terminal-settlement fields.
 - Fixed the browser tool ignoring the url parameter when opening a new tab on an attached browser.
 - Fixed browser automation disrupting attached browsers by adopting the active foreground tab and avoiding raising new tabs during screenshots.
+### Added
+
+- Added `/side [question]`: open a throwaway side conversation forked from the current session. The fork inherits the transcript as reference-only context behind a boundary marker, runs with full tools (minus `task` and `hub`), and focuses the TUI until Esc. `/side end` discards it: the side session file and its artifacts are deleted and the parent transcript is never written.
 
 ## [17.2.1] - 2026-07-30
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `/side [question]`: open a throwaway side conversation forked from the current session. The fork inherits the transcript as reference-only context behind a boundary marker, runs with full tools (minus `task` and `hub`), and focuses the TUI until Esc. `/side end` discards it: the side session file and its artifacts are deleted, and the side never appends entries to the parent session's transcript.
+
 ## [17.2.4] - 2026-08-01
 
 ### Added
@@ -103,10 +107,6 @@
 - Fixed the Python RPC client dropping context, compaction, OAuth URL, and terminal-settlement fields.
 - Fixed the browser tool ignoring the url parameter when opening a new tab on an attached browser.
 - Fixed browser automation disrupting attached browsers by adopting the active foreground tab and avoiding raising new tabs during screenshots.
-### Added
-
-- Added `/side [question]`: open a throwaway side conversation forked from the current session. The fork inherits the transcript as reference-only context behind a boundary marker, runs with full tools (minus `task` and `hub`), and focuses the TUI until Esc. `/side end` discards it: the side session file and its artifacts are deleted and the parent transcript is never written.
-
 ## [17.2.1] - 2026-07-30
 
 ### Added

--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -126,6 +126,15 @@ export class IrcBus {
 				error: `Agent "${message.to}" is a read-only advisor transcript and cannot be messaged.`,
 			};
 		}
+		// Throwaway sessions (side conversations) are user-only after their
+		// boundary marker — peer IRC must not wake or steer them.
+		if (!ref.messageable) {
+			return {
+				to: message.to,
+				outcome: "failed",
+				error: `Agent "${message.to}" is not messageable.`,
+			};
+		}
 
 		// A `parked` recipient always needs the lifecycle to revive it — this is
 		// read from *this* bus's registry, so it holds for any registry. The

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -22,6 +22,7 @@ import {
 	BACKGROUND_TAN_DISPATCH_MESSAGE_TYPE,
 	type CustomMessage,
 	LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE,
+	SIDE_BOUNDARY_MESSAGE_TYPE,
 	SKILL_PROMPT_MESSAGE_TYPE,
 	type SkillPromptDetails,
 } from "../../session/messages";
@@ -52,6 +53,7 @@ import { CustomMessageComponent } from "./custom-message";
 import { EvalExecutionComponent } from "./eval-execution";
 import { type LateDiagnosticsFile, LateDiagnosticsMessageComponent } from "./late-diagnostics-message";
 import { groupedReadUsageCallIds, ReadToolGroupComponent, readArgsCollapseIntoGroup } from "./read-tool-group";
+import { createSideBoundaryBlock } from "./side-boundary-message";
 import { SkillMessageComponent } from "./skill-message";
 import { ToolExecutionComponent } from "./tool-execution";
 import { TranscriptContainer } from "./transcript-container";
@@ -492,6 +494,10 @@ export class ChatTranscriptBuilder {
 		if (message.customType === "advisor") {
 			const details = (message as CustomMessage<AdvisorMessageDetails>).details;
 			this.container.addChild(createAdvisorMessageCard(details, () => this.#expanded, theme));
+			return;
+		}
+		if (message.customType === SIDE_BOUNDARY_MESSAGE_TYPE) {
+			this.container.addChild(createSideBoundaryBlock());
 			return;
 		}
 		if (message.customType === BACKGROUND_TAN_DISPATCH_MESSAGE_TYPE) {

--- a/packages/coding-agent/src/modes/components/side-boundary-message.ts
+++ b/packages/coding-agent/src/modes/components/side-boundary-message.ts
@@ -1,0 +1,20 @@
+import { Text } from "@oh-my-pi/pi-tui";
+import { theme } from "../theme/theme";
+import { TranscriptBlock } from "./transcript-container";
+
+/**
+ * Single-line transcript rule marking where a `/side` conversation begins.
+ * Carries the same ghost glyph and `warning` token as the focused-session
+ * status badge so the marker and the badge read as one mode. The persisted
+ * `<system-notice>` content is for the model only.
+ */
+export function createSideBoundaryBlock(): TranscriptBlock {
+	const icon = theme.icon.ghost ? `${theme.icon.ghost} ` : "";
+	const line = [
+		theme.fg("warning", `${icon}Side conversation`),
+		theme.fg("dim", `${theme.format.dash} context above is inherited, reference only`),
+	].join(" ");
+	const block = new TranscriptBlock();
+	block.addChild(new Text(line, 1, 0));
+	return block;
+}

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -4,6 +4,7 @@ import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { TERMINAL } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, getProjectDir, pathIsWithin, relativePathWithinRoot } from "@oh-my-pi/pi-utils";
 import { type ThemeColor, theme } from "../../../modes/theme/theme";
+import { AgentRegistry } from "../../../registry/agent-registry";
 import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../../tools/render-utils";
 import { fileHyperlink } from "../../../tui/hyperlink";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
@@ -86,7 +87,11 @@ const piSegment: StatusLineSegment = {
 	render(ctx) {
 		if (ctx.focusedAgentId) {
 			const icon = theme.icon.ghost ? `${theme.icon.ghost} ` : "";
-			return { content: theme.fg("warning", `${icon}${ctx.focusedAgentId} `), visible: true };
+			// Render the focused agent's display name, not its registry id — ids
+			// may be internal (e.g. collision-proof `side.internal`) and are not
+			// user-facing labels.
+			const label = AgentRegistry.global().get(ctx.focusedAgentId)?.displayName ?? ctx.focusedAgentId;
+			return { content: theme.fg("warning", `${icon}${label} `), visible: true };
 		}
 		const content = theme.icon.pi ? `${theme.icon.pi} ` : "";
 		return { content: theme.fg("accent", content), visible: true };

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -90,10 +90,11 @@ const piSegment: StatusLineSegment = {
 			const icon = theme.icon.ghost ? `${theme.icon.ghost} ` : "";
 			// Render the focused agent's display name, not its registry id — ids
 			// may be internal (e.g. collision-proof `side.internal`) and are not
-			// user-facing labels. oneLineLabel flattens control characters and
-			// caps length: agent display names are arbitrary frontmatter strings.
+			// user-facing labels. Strip ANSI first (oneLineLabel alone would leave
+			// the printable `[31m` payload), then flatten and cap: agent display
+			// names are arbitrary frontmatter strings.
 			const displayName = AgentRegistry.global().get(ctx.focusedAgentId)?.displayName ?? ctx.focusedAgentId;
-			const label = oneLineLabel(displayName);
+			const label = oneLineLabel(Bun.stripANSI(displayName));
 			return { content: theme.fg("warning", `${icon}${label} `), visible: true };
 		}
 		const content = theme.icon.pi ? `${theme.icon.pi} ` : "";

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -5,6 +5,7 @@ import { TERMINAL } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, getProjectDir, pathIsWithin, relativePathWithinRoot } from "@oh-my-pi/pi-utils";
 import { type ThemeColor, theme } from "../../../modes/theme/theme";
 import { AgentRegistry } from "../../../registry/agent-registry";
+import { oneLineLabel } from "../../../task/types";
 import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../../tools/render-utils";
 import { fileHyperlink } from "../../../tui/hyperlink";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
@@ -89,8 +90,10 @@ const piSegment: StatusLineSegment = {
 			const icon = theme.icon.ghost ? `${theme.icon.ghost} ` : "";
 			// Render the focused agent's display name, not its registry id — ids
 			// may be internal (e.g. collision-proof `side.internal`) and are not
-			// user-facing labels.
-			const label = AgentRegistry.global().get(ctx.focusedAgentId)?.displayName ?? ctx.focusedAgentId;
+			// user-facing labels. oneLineLabel flattens control characters and
+			// caps length: agent display names are arbitrary frontmatter strings.
+			const displayName = AgentRegistry.global().get(ctx.focusedAgentId)?.displayName ?? ctx.focusedAgentId;
+			const label = oneLineLabel(displayName);
 			return { content: theme.fg("warning", `${icon}${label} `), visible: true };
 		}
 		const content = theme.icon.pi ? `${theme.icon.pi} ` : "";

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1171,6 +1171,9 @@ export class CommandController {
 	}
 
 	async #moveInteractiveCwd(resolvedPath: string): Promise<void> {
+		// Relocation renames the artifact dir out from under a live side —
+		// dispose it before the move (same rule as the explicit /move path).
+		await this.ctx.disposeSideConversation();
 		await this.ctx.sessionManager.moveTo(resolvedPath);
 		await this.ctx.applyCwdChange(resolvedPath);
 		this.ctx.updateEditorBorderColor();

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -931,6 +931,9 @@ export class CommandController {
 			}
 		}
 		if (!(await this.ctx.session.newSession(options))) return;
+		// The switch committed (a session_before_switch cancel returns above) —
+		// now discard the side conversation forked from the old session.
+		await this.ctx.disposeSideConversation();
 		this.ctx.resetObserverRegistry();
 		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -989,6 +989,10 @@ export class CommandController {
 			return;
 		}
 
+		// The fork committed (streaming refusal and session_before_switch cancel
+		// both return above) — now discard the side conversation.
+		await this.ctx.disposeSideConversation();
+
 		this.ctx.statusLine.invalidate();
 		this.ctx.ui.requestRender();
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -11,7 +11,7 @@ import {
 	type UsageReport,
 } from "@oh-my-pi/pi-ai";
 import { Loader, Markdown, padding, Spacer, Text, visibleWidth } from "@oh-my-pi/pi-tui";
-import { formatDuration, Snowflake, sanitizeText } from "@oh-my-pi/pi-utils";
+import { formatDuration, isEnoent, logger, Snowflake, sanitizeText } from "@oh-my-pi/pi-utils";
 import { shouldEnableAppendOnlyContext } from "../../config/append-only-context-mode";
 import { type BashResult, isPersistentShellCdCommand } from "../../exec/bash-executor";
 import { type LoadedCustomShare, loadCustomShare } from "../../export/custom-share";
@@ -44,7 +44,9 @@ import type { AsyncJobSnapshotItem } from "../../session/agent-session";
 import type { AuthStorage, OAuthAccountIdentity } from "../../session/auth-storage";
 import type { CompactMode } from "../../session/compact-modes";
 import type { NewSessionOptions } from "../../session/session-entries";
+import { SessionManager } from "../../session/session-manager";
 import { formatShakeSummary, type ShakeMode, type ShakeResult } from "../../session/shake-types";
+import { SIDE_SESSION_FILE_PREFIX } from "../../session/side-conversation";
 import { formatActiveAccountLabel, limitMatchesActiveAccount } from "../../slash-commands/helpers/active-oauth-account";
 import { outputMeta } from "../../tools/output-meta";
 import { resolveToCwd, stripOuterDoubleQuotes } from "../../tools/path-utils";
@@ -992,6 +994,29 @@ export class CommandController {
 		// The fork committed (streaming refusal and session_before_switch cancel
 		// both return above) — now discard the side conversation.
 		await this.ctx.disposeSideConversation();
+		// fork() copies the parent's whole artifact directory, including any
+		// side.internal-*.jsonl transcripts and their nested artifacts. Delete
+		// the copies from the new session's artifact dir — they are duplicates,
+		// possibly torn, and the persisted scan deliberately skips them.
+		const forkedSessionFile = this.ctx.sessionManager.getSessionFile();
+		if (forkedSessionFile) {
+			const forkedArtifactDir = forkedSessionFile.slice(0, -6);
+			try {
+				const entries = await fs.readdir(forkedArtifactDir);
+				for (const entry of entries) {
+					if (!entry.startsWith(SIDE_SESSION_FILE_PREFIX) || !entry.endsWith(".jsonl")) continue;
+					// Per-entry catch: one stubborn copy must not strand the rest.
+					try {
+						await SessionManager.removeSessionFiles(path.join(forkedArtifactDir, entry));
+					} catch (entryError) {
+						logger.warn("Failed to remove copied side transcript", { file: entry, error: String(entryError) });
+					}
+				}
+			} catch (error) {
+				if (!isEnoent(error))
+					logger.warn("Failed to sweep copied side transcripts after fork", { error: String(error) });
+			}
+		}
 
 		this.ctx.statusLine.invalidate();
 		this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1072,6 +1072,10 @@ export class CommandController {
 			return;
 		}
 
+		// Moving renames the artifact dir out from under a live side — dispose only
+		// after cancellable validation (path overlay, create-dir confirm, invalid target).
+		await this.ctx.disposeSideConversation();
+
 		try {
 			await this.ctx.session.moveSession(resolvedPath);
 		} catch (err) {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1004,12 +1004,21 @@ export class CommandController {
 			try {
 				const entries = await fs.readdir(forkedArtifactDir);
 				for (const entry of entries) {
-					if (!entry.startsWith(SIDE_SESSION_FILE_PREFIX) || !entry.endsWith(".jsonl")) continue;
+					if (!entry.startsWith(SIDE_SESSION_FILE_PREFIX)) continue;
+					const entryPath = path.join(forkedArtifactDir, entry);
 					// Per-entry catch: one stubborn copy must not strand the rest.
 					try {
-						await SessionManager.removeSessionFiles(path.join(forkedArtifactDir, entry));
+						if (entry.endsWith(".jsonl")) {
+							await SessionManager.removeSessionFiles(entryPath);
+						} else {
+							// Directory-only artifact copy: indexed backends store the
+							// transcript in the backend, not on disk, but ArtifactManager
+							// still spills tool output to the physical directory. The
+							// fork copies that directory; sweep it recursively.
+							await fs.rm(entryPath, { recursive: true, force: true });
+						}
 					} catch (entryError) {
-						logger.warn("Failed to remove copied side transcript", { file: entry, error: String(entryError) });
+						logger.warn("Failed to remove copied side artifact", { file: entry, error: String(entryError) });
 					}
 				}
 			} catch (error) {
@@ -1101,6 +1110,14 @@ export class CommandController {
 			await this.ctx.settings.flush();
 		} catch (err) {
 			this.ctx.showError(`Failed to save pending settings: ${err instanceof Error ? err.message : String(err)}`);
+			return;
+		}
+
+		// Detect the no-op BEFORE disposal: moveTo returns immediately when the
+		// resolved cwd equals the current cwd, so disposing the side here would
+		// destroy a live conversation for a move that performs no relocation.
+		if (path.resolve(resolvedPath) === path.resolve(cwd)) {
+			this.ctx.showStatus(`Already in ${resolvedPath}`);
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -18,6 +18,7 @@ import { invokeSkillCommandFromText, isKnownSkillCommand } from "../../modes/ski
 import type { InteractiveModeContext } from "../../modes/types";
 import manualContinuePrompt from "../../prompts/system/manual-continue.md" with { type: "text" };
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
+import { SIDE_AGENT_ID } from "../../session/side-conversation";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
 import { isTinyTitleLocalModelKey } from "../../tiny/models";
 import { tinyTitleClient } from "../../tiny/title-client";
@@ -936,7 +937,7 @@ export class InputController {
 			}
 			return;
 		}
-		if (text.trim() === "/side end") {
+		if (text.trim() === "/side end" && this.ctx.focusedAgentId === SIDE_AGENT_ID) {
 			// The one focus-scoped command: discarding the side is meaningful from
 			// inside it (disposal unfocuses first), so route instead of refusing.
 			this.ctx.editor.clearDraft(text);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -936,6 +936,13 @@ export class InputController {
 			}
 			return;
 		}
+		if (text.trim() === "/side end") {
+			// The one focus-scoped command: discarding the side is meaningful from
+			// inside it (disposal unfocuses first), so route instead of refusing.
+			this.ctx.editor.clearDraft(text);
+			await this.ctx.handleSideCommand("end");
+			return;
+		}
 		if (text && (text.startsWith("/") || text.startsWith("!") || parsePythonCommandInput(text))) {
 			this.ctx.showStatus("Commands run in the main session — press ←← to return first");
 			return; // editor text not cleared: Editor does not auto-clear on submit

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -16,26 +16,40 @@ export const SIDE_AGENT_ID = "side.internal";
 const SIDE_STATUS = "Side conversation — Esc returns to main, /side end discards it";
 const DISPOSE_FAILURE_MESSAGE = "Side conversation ended, but its file could not be deleted";
 
+/** A deferred question submit, run outside the lifecycle queue. */
+type SubmitClosure = () => Promise<void>;
+
+/** Outcome of {@link SideController.#handleExistingRef}: proceed to create, or done (optionally submit). */
+type RefHandling = { outcome: "proceed" } | { outcome: "done"; submit?: SubmitClosure };
+
 export class SideController {
 	constructor(private readonly ctx: InteractiveModeContext) {}
 
-	// Operations are serialized through this queue so start()/dispose() cannot
-	// interleave at await points — a /side end fired during an in-flight create
-	// now waits for the create to finish, then disposes the live session, rather
-	// than early-returning and leaving the side alive. The registry ref
-	// classification below stays as defense-in-depth for refs created outside
-	// the queue (a failed create the SDK did not clean up, platform lifecycle
-	// actions); the queue is the primary mechanism.
+	// Lifecycle operations (dispatch, preconditions, reuse/stale handling,
+	// create, focus, status overwrite) are serialized through this queue so
+	// start()/dispose() cannot interleave at await points — a /side end fired
+	// during an in-flight create waits for the create to finish, then disposes
+	// the live session, rather than early-returning and leaving the side alive.
+	// The question submit runs AFTER the queued op resolves (in start()), so a
+	// /side end, session transition, or shutdown during a long side turn is not
+	// blocked by the in-flight prompt — AgentSession.dispose handles in-flight
+	// turns. The registry ref classification below stays as defense-in-depth for
+	// refs created outside the queue (a failed create the SDK did not clean up,
+	// platform lifecycle actions); the queue is the primary mechanism.
 	#queue: Promise<void> = Promise.resolve();
 
 	/** `/side` (create+focus), `/side <question>` (create+focus+ask), `/side end` (discard). */
 	async start(args: string): Promise<void> {
-		const op = this.#queue.then(() => this.#startImpl(args));
-		this.#queue = op.catch(() => {});
-		return op;
+		const lifecycleOp = this.#queue.then(() => this.#startImpl(args));
+		this.#queue = lifecycleOp.then(
+			() => {},
+			() => {},
+		);
+		const submit = await lifecycleOp;
+		if (submit) await submit();
 	}
 
-	async #startImpl(args: string): Promise<void> {
+	async #startImpl(args: string): Promise<SubmitClosure | undefined> {
 		const trimmed = args.trim();
 		if (trimmed === "end") {
 			const existed = AgentRegistry.global().get(SIDE_AGENT_ID) !== undefined;
@@ -70,7 +84,8 @@ export class SideController {
 		}
 
 		// Reuse, busy, or stale-ref reclaim — shared with the create-race catch.
-		if (await this.#handleExistingRef(question)) return;
+		const handling = await this.#handleExistingRef(question);
+		if (handling.outcome === "done") return handling.submit;
 
 		// --- Create path ---
 		const parentSessionId = session.sessionId;
@@ -173,7 +188,12 @@ export class SideController {
 			await ctx.focusAgentSession(SIDE_AGENT_ID);
 			ctx.showStatus(SIDE_STATUS);
 
-			if (question) await this.#submitQuestion(side, question);
+			// Return a submit closure so the question is asked outside the
+			// lifecycle queue — a /side end or shutdown during the turn is not
+			// blocked by it. The status overwrite above is the last status the
+			// controller emits on this path.
+			const sideSession = side;
+			return question ? () => this.#submitQuestion(sideSession, question) : undefined;
 		} catch (error) {
 			if (side) {
 				// A session was constructed — dispose it fully (disposes the
@@ -181,21 +201,20 @@ export class SideController {
 				await this.#disposeImpl();
 				await ctx.unfocusSession().catch(() => {});
 				ctx.showError(error instanceof Error ? error.message : String(error));
-			} else {
-				// createAgentSession threw before a session existed (the
-				// expectedAgentRef:null race or another failure). Clear the orphan
-				// fork, then route the winning ref through the same handling the
-				// top of start() uses — a mid-init winner (session: null, status:
-				// "running") surfaces the clean "still starting" error instead of
-				// the raw registration exception.
-				await this.#removeSideFile(
-					sideFile,
-					"Side conversation setup failed, and its fork file could not be deleted",
-				);
-				if (await this.#handleExistingRef(question)) return;
-				await ctx.unfocusSession().catch(() => {});
-				ctx.showError(error instanceof Error ? error.message : String(error));
+				return undefined;
 			}
+			// createAgentSession threw before a session existed (the
+			// expectedAgentRef:null race or another failure). Clear the orphan
+			// fork, then route the winning ref through the same handling the
+			// top of start() uses — a mid-init winner (session: null, status:
+			// "running") surfaces the clean "still starting" error instead of
+			// the raw registration exception.
+			await this.#removeSideFile(sideFile, "Side conversation setup failed, and its fork file could not be deleted");
+			const catchHandling = await this.#handleExistingRef(question);
+			if (catchHandling.outcome === "done") return catchHandling.submit;
+			await ctx.unfocusSession().catch(() => {});
+			ctx.showError(error instanceof Error ? error.message : String(error));
+			return undefined;
 		}
 	}
 
@@ -338,17 +357,17 @@ export class SideController {
 
 	/**
 	 * Handle an existing Side registry ref: reuse a live session, report a busy
-	 * initializing one, or reclaim a stale one. Returns true if the caller
-	 * should return (ref was reused, is busy, or a lost-race reuse was taken);
-	 * returns false if the ref was reclaimed or there was no ref, and the
-	 * caller should proceed to create (top of start) or surface its own error
-	 * (create-race catch).
+	 * initializing one, or reclaim a stale one. Returns `{ outcome: "proceed" }`
+	 * when the caller should create (no ref, or a stale ref was reclaimed);
+	 * returns `{ outcome: "done", submit? }` when the ref was reused or is busy
+	 * — the caller returns, optionally running the submit closure outside the
+	 * lifecycle queue.
 	 */
-	async #handleExistingRef(question: string): Promise<boolean> {
+	async #handleExistingRef(question: string): Promise<RefHandling> {
 		const ctx = this.ctx;
 		const registry = AgentRegistry.global();
 		const existing = registry.get(SIDE_AGENT_ID);
-		if (!existing) return false;
+		if (!existing) return { outcome: "proceed" };
 
 		// Reuse path: a live side session already exists — focus it, no new fork.
 		// Registry ids are re-resolved across awaits (SessionFocusController
@@ -365,10 +384,10 @@ export class SideController {
 				const current = registry.get(SIDE_AGENT_ID);
 				if (current?.session !== existing.session) {
 					ctx.showError("Side conversation is still starting — try again in a moment");
-					return true;
+					return { outcome: "done" };
 				}
 				ctx.showError(error instanceof Error ? error.message : String(error));
-				return true;
+				return { outcome: "done" };
 			}
 			// Focus succeeded — re-read the registry and confirm the generation
 			// is still the one we captured. If a concurrent dispose + create
@@ -376,11 +395,15 @@ export class SideController {
 			// stale captured session.
 			if (registry.get(SIDE_AGENT_ID)?.session !== existing.session) {
 				ctx.showError("Side conversation is still starting — try again in a moment");
-				return true;
+				return { outcome: "done" };
 			}
 			ctx.showStatus(SIDE_STATUS);
-			if (question) await this.#submitQuestion(existing.session, question);
-			return true;
+			// Capture the session for the closure; the revalidation above
+			// confirmed the registry still holds it. The closure runs outside
+			// the queue, so a concurrent dispose may still land first —
+			// #submitQuestion's try/catch handles a prompt on a disposed session.
+			const session = existing.session;
+			return { outcome: "done", submit: question ? () => this.#submitQuestion(session, question) : undefined };
 		}
 
 		// Stale-ref path: ref exists but session is null. A genuinely stale ref
@@ -392,7 +415,7 @@ export class SideController {
 		// generation-checked attach fail — losing the user's side conversation.
 		if (existing.status === "running") {
 			ctx.showError("Side conversation is still starting — try again in a moment");
-			return true;
+			return { outcome: "done" };
 		}
 
 		// Stale: parked/aborted. Reclaim the slot before any await — a concurrent
@@ -413,6 +436,6 @@ export class SideController {
 		if (existing.sessionFile) {
 			await this.#removeSideFile(existing.sessionFile, "Failed to delete the previous side conversation file");
 		}
-		return false;
+		return { outcome: "proceed" };
 	}
 }

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -339,8 +339,8 @@ export class SideController {
 			// Storage of the CURRENT parent manager. Documented limitation: a side
 			// inherited from a different-backend session (crashed previous process,
 			// or a backend switch while the side was live) may not be deletable
-			// through this backend and lingers as inert files until the
-			// filesystem-bound persisted-scan cleanup.
+			// through this backend; such files stay inert on disk until the user
+			// removes them (the persisted scan skips side files without deleting).
 			await SessionManager.removeSessionFiles(sessionFile, this.ctx.sessionManager.getStorage());
 			return true;
 		} catch (err) {

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -7,7 +7,7 @@ import type { AgentSession } from "../../session/agent-session";
 import { SIDE_BOUNDARY_MESSAGE_TYPE } from "../../session/messages";
 import { SessionManager } from "../../session/session-manager";
 import { SIDE_AGENT_ID, SIDE_SESSION_FILE_PREFIX } from "../../session/side-conversation";
-import { createMCPProxyTools } from "../../task/executor";
+import { createIsolatedSettingsSnapshot, createMCPProxyTools } from "../../task/executor";
 import { shortenPath } from "../../tools/render-utils";
 import { USER_TODO_EDIT_CUSTOM_TYPE } from "../../tools/todo";
 import type { InteractiveModeContext } from "../types";
@@ -90,7 +90,12 @@ export class SideController {
 		const parentSessionId = session.sessionId;
 		const parentPromptCacheKey = session.agent.promptCacheKey ?? parentSessionId;
 		const thinkingLevel = session.configuredThinkingLevel();
-		const toolNames = session.getActiveToolNames();
+		// getEnabledToolNames includes xd://-mounted names the active list omits.
+		// The SDK keeps explicitly granted names top-level, so mounted tools lose
+		// their xd:// presentation in the side — availability is preserved, the
+		// prompt-size partition is not (acceptable in a throwaway session).
+		const toolNames = session.getEnabledToolNames();
+		const enabledNames = new Set(toolNames);
 		const extensionPaths = session.extensionPaths;
 		const modelRegistry = session.modelRegistry;
 		const ownerId = session.getAgentId() ?? MAIN_AGENT_ID;
@@ -139,10 +144,19 @@ export class SideController {
 				providerPromptCacheKey: parentPromptCacheKey,
 				modelRegistry,
 				authStorage: modelRegistry.authStorage,
-				settings: this.ctx.settings,
+				settings: createIsolatedSettingsSnapshot(this.ctx.settings, {
+					// A handoff would replace the side with a fresh file and strand the
+					// transcript as a revivable session; force normal compaction so the
+					// throwaway contract and the boundary re-injection both hold.
+					"compaction.strategy": "context-full",
+				}),
 				hasUI: true,
 				enableMCP: false,
-				customTools: mcpManager ? createMCPProxyTools(mcpManager) : undefined,
+				customTools: mcpManager
+					? // Only proxy MCP tools the parent actually has enabled — customTools
+						// are always included regardless of the toolNames filter.
+						createMCPProxyTools(mcpManager).filter(tool => enabledNames.has(tool.name))
+					: undefined,
 				enableLsp: this.ctx.settings.get("task.enableLsp") !== false,
 				agentId: SIDE_AGENT_ID,
 				agentDisplayName: "side",

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import { logger, Snowflake } from "@oh-my-pi/pi-utils";
 import sideBoundaryPrompt from "../../prompts/system/side-boundary.md" with { type: "text" };
-import { AgentRegistry, MAIN_AGENT_ID } from "../../registry/agent-registry";
+import { type AgentRef, AgentRegistry, MAIN_AGENT_ID } from "../../registry/agent-registry";
 import * as sdk from "../../sdk";
 import type { AgentSession } from "../../session/agent-session";
 import { SIDE_BOUNDARY_MESSAGE_TYPE } from "../../session/messages";
@@ -111,6 +111,7 @@ export class SideController {
 		await ctx.sessionManager.flush();
 
 		let side: AgentSession | undefined;
+		let capturedRef: AgentRef | undefined;
 		const reinject = () =>
 			side?.agent.appendMessage({
 				role: "developer",
@@ -153,6 +154,7 @@ export class SideController {
 				localProtocolOptions,
 			});
 			side = created.session;
+			capturedRef = AgentRegistry.global().get(SIDE_AGENT_ID);
 			const uiContext = this.ctx.getToolUIContext();
 			if (uiContext) created.setToolUIContext(uiContext, true);
 
@@ -187,6 +189,17 @@ export class SideController {
 			// Focus, then overwrite the status string focusAgent emits (it is
 			// written for viewing a subagent and is wrong for a side conversation).
 			await ctx.focusAgentSession(SIDE_AGENT_ID);
+			// Revalidate: an external generation may have replaced ours during
+			// the focus await (a concurrent dispose + create, or a platform
+			// lifecycle action). If so, do not submit against the stale captured
+			// session — surface the busy error and clean up only the captured
+			// generation, never the replacement.
+			if (AgentRegistry.global().get(SIDE_AGENT_ID)?.session !== side) {
+				ctx.showError("Side conversation is still starting — try again in a moment");
+				await this.#cleanupCapturedGeneration(side, capturedRef, sideFile);
+				await ctx.unfocusSession().catch(() => {});
+				return undefined;
+			}
 			ctx.showStatus(SIDE_STATUS);
 
 			// Return a submit closure so the question is asked outside the
@@ -197,9 +210,12 @@ export class SideController {
 			return question ? () => this.#submitQuestion(sideSession, question) : undefined;
 		} catch (error) {
 			if (side) {
-				// A session was constructed — dispose it fully (disposes the
-				// session, removes files).
-				await this.#disposeImpl();
+				// A session was constructed — clean up the CAPTURED generation
+				// only, not whatever owns the id now. An external replacement
+				// may have won the slot during the failed operation; routing
+				// through #disposeImpl would destroy the replacement while
+				// leaking the captured session and its file.
+				await this.#cleanupCapturedGeneration(side, capturedRef, sideFile);
 				await ctx.unfocusSession().catch(() => {});
 				ctx.showError(error instanceof Error ? error.message : String(error));
 				return undefined;
@@ -348,6 +364,33 @@ export class SideController {
 			this.ctx.showError(`${failureMessage}: ${shortenPath(sessionFile)}`);
 			return false;
 		}
+	}
+
+	/**
+	 * Clean up the CAPTURED side generation only: dispose its session directly,
+	 * generation-checked unregister its ref, and delete its file. Never touches
+	 * a replacement generation that won the id — `unregister` is generation-
+	 * checked (returns false when `capturedRef` is no longer the registered
+	 * ref), and `sideFile` is unique per generation. Used by both the create-
+	 * failure catch and the post-focus revalidation, so neither routes through
+	 * the id-wide `#disposeImpl` loop that could destroy an external
+	 * replacement while leaking the captured session and file.
+	 */
+	async #cleanupCapturedGeneration(
+		side: AgentSession,
+		capturedRef: AgentRef | undefined,
+		sideFile: string,
+	): Promise<void> {
+		try {
+			await side.dispose();
+		} catch (error) {
+			logger.warn("Failed to dispose captured side session", { error: String(error) });
+		}
+		// Generation-checked: a no-op if dispose already unregistered the ref,
+		// or if a replacement won the id. Reclaims a parked ref the SDK wrapper
+		// left behind for revival.
+		if (capturedRef) AgentRegistry.global().unregister(SIDE_AGENT_ID, capturedRef);
+		await this.#removeSideFile(sideFile, "Side conversation setup failed, and its fork file could not be deleted");
 	}
 
 	async #submitQuestion(side: AgentSession, question: string): Promise<void> {

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -76,7 +76,6 @@ export class SideController {
 		const parentSessionId = session.sessionId;
 		const parentPromptCacheKey = session.agent.promptCacheKey ?? parentSessionId;
 		const thinkingLevel = session.configuredThinkingLevel();
-		const systemPrompt = [...session.systemPrompt];
 		const toolNames = session.getActiveToolNames();
 		const extensionPaths = session.extensionPaths;
 		const modelRegistry = session.modelRegistry;
@@ -116,7 +115,6 @@ export class SideController {
 				sessionManager: sideManager,
 				model,
 				thinkingLevel,
-				systemPrompt,
 				toolNames: toolNames.filter(name => name !== "task" && name !== "hub"),
 				spawns: "",
 				providerSessionId: `${parentSessionId}:side:${Snowflake.next()}`,
@@ -159,7 +157,7 @@ export class SideController {
 			// 3. Append session-init so a cold Agent Hub revival describes the side
 			//    correctly, using the post-filter tool list.
 			sideManager.appendSessionInit({
-				systemPrompt: side.systemPrompt ? side.systemPrompt.join("\n\n") : systemPrompt.join("\n\n"),
+				systemPrompt: side.systemPrompt.join("\n\n"),
 				task: question || "side conversation",
 				tools: side.getActiveToolNames(),
 			});

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -97,11 +97,13 @@ export class SideController {
 		const mcpManager = ctx.mcpManager;
 		const cwd = ctx.sessionManager.getCwd();
 		const parentStorage = ctx.sessionManager.getStorage();
-		const parentArtifactsDir = ctx.sessionManager.getArtifactsDir();
-		const parentLocalSessionId = ctx.sessionManager.getSessionId();
 		const localProtocolOptions = {
-			getArtifactsDir: () => parentArtifactsDir,
-			getSessionId: () => parentLocalSessionId,
+			// Live getters, not captured values: the SDK installs these as the
+			// process-global local:// mapping, so they must track the CURRENT
+			// parent. A committed session switch then repoints the mapping without
+			// any restore-on-dispose work.
+			getArtifactsDir: () => ctx.sessionManager.getArtifactsDir(),
+			getSessionId: () => ctx.sessionManager.getSessionId(),
 		};
 
 		const sessionDir = parentFile.slice(0, -6);

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -1,0 +1,429 @@
+import * as path from "node:path";
+import { logger, Snowflake } from "@oh-my-pi/pi-utils";
+import sideBoundaryPrompt from "../../prompts/system/side-boundary.md" with { type: "text" };
+import { AgentRegistry, MAIN_AGENT_ID } from "../../registry/agent-registry";
+import * as sdk from "../../sdk";
+import type { AgentSession } from "../../session/agent-session";
+import { SIDE_BOUNDARY_MESSAGE_TYPE } from "../../session/messages";
+import { SessionManager } from "../../session/session-manager";
+import { createMCPProxyTools } from "../../task/executor";
+import { shortenPath } from "../../tools/render-utils";
+import { USER_TODO_EDIT_CUSTOM_TYPE } from "../../tools/todo";
+import type { InteractiveModeContext } from "../types";
+
+export const SIDE_AGENT_ID = "Side";
+
+const SIDE_STATUS = "Side conversation — Esc returns to main, /side end discards it";
+const DISPOSE_FAILURE_MESSAGE = "Side conversation ended, but its file could not be deleted";
+
+export class SideController {
+	constructor(private readonly ctx: InteractiveModeContext) {}
+
+	#unsubscribeCompaction: (() => void) | undefined;
+
+	// Operations are serialized through this queue so start()/dispose() cannot
+	// interleave at await points — a /side end fired during an in-flight create
+	// now waits for the create to finish, then disposes the live session, rather
+	// than early-returning and leaving the side alive. The registry ref
+	// classification below stays as defense-in-depth for refs created outside
+	// the queue (a failed create the SDK did not clean up, platform lifecycle
+	// actions); the queue is the primary mechanism.
+	#queue: Promise<void> = Promise.resolve();
+
+	/** `/side` (create+focus), `/side <question>` (create+focus+ask), `/side end` (discard). */
+	async start(args: string): Promise<void> {
+		const op = this.#queue.then(() => this.#startImpl(args));
+		this.#queue = op.catch(() => {});
+		return op;
+	}
+
+	async #startImpl(args: string): Promise<void> {
+		const trimmed = args.trim();
+		if (trimmed === "end") {
+			const existed = AgentRegistry.global().get(SIDE_AGENT_ID) !== undefined;
+			const ok = await this.#disposeImpl();
+			if (!existed) this.ctx.showStatus("No side conversation to end");
+			else if (ok) this.ctx.showStatus("Side conversation ended");
+			return;
+		}
+
+		const question = trimmed;
+		const ctx = this.ctx;
+
+		// Preconditions — each matches an exact sibling string in the codebase.
+		if (ctx.collabGuest) {
+			ctx.showError("/side is unavailable in a collab session");
+			return;
+		}
+		if (ctx.focusedAgentId) {
+			ctx.showError("Already viewing an agent — press ←← to return first");
+			return;
+		}
+		const session = ctx.session;
+		const model = session.model;
+		if (!model) {
+			ctx.showError("No active model available for /side.");
+			return;
+		}
+		const parentFile = ctx.sessionManager.getSessionFile();
+		if (!parentFile) {
+			ctx.showError("/side requires a persisted session.");
+			return;
+		}
+
+		// Reuse, busy, or stale-ref reclaim — shared with the create-race catch.
+		if (await this.#handleExistingRef(question)) return;
+
+		// --- Create path ---
+		const parentSessionId = session.sessionId;
+		const parentPromptCacheKey = session.agent.promptCacheKey ?? parentSessionId;
+		const thinkingLevel = session.configuredThinkingLevel();
+		const systemPrompt = [...session.systemPrompt];
+		const toolNames = session.getActiveToolNames();
+		const modelRegistry = session.modelRegistry;
+		const ownerId = session.getAgentId() ?? MAIN_AGENT_ID;
+		const mcpManager = ctx.mcpManager;
+		const cwd = ctx.sessionManager.getCwd();
+		const parentArtifactsDir = ctx.sessionManager.getArtifactsDir();
+		const parentLocalSessionId = ctx.sessionManager.getSessionId();
+		const localProtocolOptions = {
+			getArtifactsDir: () => parentArtifactsDir,
+			getSessionId: () => parentLocalSessionId,
+		};
+
+		const sessionDir = parentFile.slice(0, -6);
+		const sideFile = path.join(sessionDir, `${SIDE_AGENT_ID}-${Snowflake.next()}.jsonl`);
+
+		await ctx.sessionManager.ensureOnDisk();
+		await ctx.sessionManager.flush();
+
+		let side: AgentSession | undefined;
+		const reinject = () =>
+			side?.agent.appendMessage({
+				role: "developer",
+				content: sideBoundaryPrompt,
+				attribution: "agent",
+				timestamp: Date.now(),
+			});
+
+		try {
+			const sideManager = await SessionManager.forkFrom(parentFile, cwd, sessionDir, undefined, {
+				suppressBreadcrumb: true,
+				sessionFile: sideFile,
+			});
+
+			const created = await sdk.createAgentSession({
+				cwd,
+				sessionManager: sideManager,
+				model,
+				thinkingLevel,
+				systemPrompt,
+				toolNames: toolNames.filter(name => name !== "task" && name !== "hub"),
+				spawns: "",
+				providerSessionId: `${parentSessionId}:side:${Snowflake.next()}`,
+				providerPromptCacheKey: parentPromptCacheKey,
+				modelRegistry,
+				authStorage: modelRegistry.authStorage,
+				settings: this.ctx.settings,
+				hasUI: true,
+				enableMCP: false,
+				customTools: mcpManager ? createMCPProxyTools(mcpManager) : undefined,
+				enableLsp: this.ctx.settings.get("task.enableLsp") !== false,
+				agentId: SIDE_AGENT_ID,
+				agentDisplayName: "side",
+				taskDepth: 1,
+				parentAgentId: ownerId,
+				agentRegistry: AgentRegistry.global(),
+				expectedAgentRef: null,
+				disableExtensionDiscovery: true,
+				extensions: [pi => pi.on("session_compact", reinject)],
+				localProtocolOptions,
+			});
+			side = created.session;
+			const uiContext = this.ctx.getToolUIContext();
+			if (uiContext) created.setToolUIContext(uiContext, true);
+
+			// 1. Clear inherited todos so the fork does not drag the parent's task.
+			side.setTodoPhases([]);
+			sideManager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases: [] });
+
+			// 2. Append the boundary as one message that is both model context and
+			//    a visible transcript rule. A freshly created session is idle, so
+			//    triggerTurn:false + deliverAs:"nextTurn" appends without starting
+			//    a turn.
+			await side.sendCustomMessage(
+				{ customType: SIDE_BOUNDARY_MESSAGE_TYPE, content: sideBoundaryPrompt, display: true, attribution: "user" },
+				{ triggerTurn: false, deliverAs: "nextTurn" },
+			);
+
+			// 3. Append session-init so a cold Agent Hub revival describes the side
+			//    correctly, using the post-filter tool list.
+			sideManager.appendSessionInit({
+				systemPrompt: side.systemPrompt ? side.systemPrompt.join("\n\n") : systemPrompt.join("\n\n"),
+				task: question || "side conversation",
+				tools: side.getActiveToolNames(),
+			});
+
+			// 4. Re-inject the boundary after any successful compaction.
+			//    Manual compaction emits "session_compact" through the extension
+			//    runner (handled by the inline extension factory above).
+			//    Automatic compaction emits "auto_compaction_end" through the
+			//    session event stream — subscribe here.
+			this.#unsubscribeCompaction = side.subscribe(event => {
+				if (event.type === "auto_compaction_end" && event.result && !event.aborted) reinject();
+			});
+
+			// Focus, then overwrite the status string focusAgent emits (it is
+			// written for viewing a subagent and is wrong for a side conversation).
+			await ctx.focusAgentSession(SIDE_AGENT_ID);
+			ctx.showStatus(SIDE_STATUS);
+
+			if (question) await this.#submitQuestion(side, question);
+		} catch (error) {
+			if (side) {
+				// A session was constructed — dispose it fully (clears
+				// #unsubscribeCompaction, disposes the session, removes files).
+				await this.#disposeImpl();
+				await ctx.unfocusSession().catch(() => {});
+				ctx.showError(error instanceof Error ? error.message : String(error));
+			} else {
+				// createAgentSession threw before a session existed (the
+				// expectedAgentRef:null race or another failure). Clear the orphan
+				// fork, then route the winning ref through the same handling the
+				// top of start() uses — a mid-init winner (session: null, status:
+				// "running") surfaces the clean "still starting" error instead of
+				// the raw registration exception.
+				await this.#removeSideFile(
+					sideFile,
+					"Side conversation setup failed, and its fork file could not be deleted",
+				);
+				if (await this.#handleExistingRef(question)) return;
+				await ctx.unfocusSession().catch(() => {});
+				ctx.showError(error instanceof Error ? error.message : String(error));
+			}
+		}
+	}
+
+	async dispose(): Promise<void> {
+		const op = this.#queue.then(() => this.#disposeImpl().then(() => {}));
+		this.#queue = op.catch(() => {});
+		await op;
+	}
+
+	/**
+	 * Discard the side conversation. Resolves `true` ⇔ the Side ref is gone
+	 * from the registry AND (its file is gone or never existed). Resolves
+	 * `false` when something remains AND every remnant (a leaked file or a
+	 * surviving generation) is covered by a shown `ctx.showError` explaining
+	 * why — one remnant means one error, two remnants two. Never rejects:
+	 * errors are caught and surfaced via `#removeSideFile`, session-dispose
+	 * errors are only warned. An externally-created in-flight generation
+	 * (null-session `running` ref not from this controller) is never
+	 * unregistered, deleted, or focused — it survives, but the user is told,
+	 * not shown a false success.
+	 */
+	async #disposeImpl(): Promise<boolean> {
+		// A focused side must be unfocused BEFORE disposal unregisters it: the
+		// registry-event auto-unfocus is fire-and-forget, and its in-flight
+		// #attach(main) can race a subsequent focusAgentSession("Side") into a
+		// wrong final focus state.
+		if (this.ctx.focusedAgentId === SIDE_AGENT_ID) {
+			try {
+				await this.ctx.unfocusSession();
+			} catch (error) {
+				logger.warn("Failed to unfocus side session before disposal", { error: String(error) });
+			}
+		}
+		// Compaction subscription is controller-owned, not ref-owned: clear it
+		// once before the loop regardless of which ref is eventually disposed.
+		if (this.#unsubscribeCompaction) {
+			this.#unsubscribeCompaction();
+			this.#unsubscribeCompaction = undefined;
+		}
+		let cleanupFailed = false;
+
+		// Reclassifying loop. Each iteration re-reads the registry, so every
+		// success exit is preceded by a fresh read showing nothing named Side
+		// remains. The body never assumes a ref stays classified the same
+		// across an await: the SDK dispose wrapper unregisters in its `finally`
+		// UNLESS the lifecycle manager is parking the ref (sdk.ts:1632-1640,
+		// 3428-3429), so `await ref.session.dispose()` can leave the SAME ref
+		// registered with status "parked", session null — and a concurrent
+		// start() can replace it entirely. Each `continue` re-reads to
+		// reclassify whatever is actually there now. Each iteration corresponds
+		// to a real concurrent generation change, so the loop is bounded in
+		// practice.
+		//
+		// Invariant: every `return true` is preceded by a registry read
+		// showing nothing named Side; every `return false` is preceded by one
+		// shown error per remnant that remains (a leaked file or a surviving
+		// generation — one remnant means one error, two remnants two); a
+		// captured ref's file is deleted only when its ref is
+		// gone from the registry or its unregister was won; a lost unregister
+		// never deletes anything. Side filenames are unique per generation
+		// (Side-<snowflake>.jsonl), so a captured ref's file is never a
+		// replacement generation's file — deleting it after the ref left the
+		// registry, or after a won unregister, is always safe.
+		for (;;) {
+			const ref = AgentRegistry.global().get(SIDE_AGENT_ID);
+			if (!ref) return !cleanupFailed;
+
+			// In-flight pre-registration: the SDK registers a null-session
+			// "running" ref before attaching the live session (sdk.ts:2950-
+			// 2958). Deleting its file would leave the creator attaching a
+			// live session backed by a deleted JSONL. Never touch it; tell
+			// the user instead of reporting a false success.
+			if (ref.session === null && ref.status === "running") {
+				this.ctx.showError("Side conversation is still starting — try again in a moment");
+				return false;
+			}
+
+			// Stale ref: null session, parked or aborted (a failed prior
+			// dispose, or the SDK wrapper that left it parked for revival).
+			// Reclaim the slot synchronously before any await so a concurrent
+			// start() cannot register a fresh live Side whose file a delayed
+			// delete would orphan.
+			if (ref.session === null) {
+				const won = AgentRegistry.global().unregister(SIDE_AGENT_ID, ref);
+				if (!won) continue; // another generation owns the id; reclassify it
+				if (ref.sessionFile && !(await this.#removeSideFile(ref.sessionFile, DISPOSE_FAILURE_MESSAGE)))
+					cleanupFailed = true;
+				continue; // re-read to confirm the slot is empty
+			}
+
+			// Live ref: dispose the session, then re-read the registry.
+			try {
+				await ref.session.dispose();
+			} catch (error) {
+				logger.warn("Failed to dispose side session", { error: String(error) });
+			}
+
+			// After the await the same ref may still be registered — the
+			// wrapper left it parked for revival (sdk.ts:1632-1640), but the
+			// user asked to end it. Or a concurrent start() may have replaced
+			// it. Re-read and reclassify by identity.
+			if (AgentRegistry.global().get(SIDE_AGENT_ID) === ref) {
+				// Same ref survived as parked. Reclaim it now.
+				const won = AgentRegistry.global().unregister(SIDE_AGENT_ID, ref);
+				if (!won) continue; // replaced between the two reads; reclassify
+				if (ref.sessionFile && !(await this.#removeSideFile(ref.sessionFile, DISPOSE_FAILURE_MESSAGE)))
+					cleanupFailed = true;
+				continue;
+			}
+			// Ref absent or replaced: the captured file is unique per
+			// generation and now unreferenced, so it is safe to delete.
+			if (ref.sessionFile && !(await this.#removeSideFile(ref.sessionFile, DISPOSE_FAILURE_MESSAGE)))
+				cleanupFailed = true;
+		}
+	}
+
+	/**
+	 * Delete a side session file. Resolves `true` when the file is gone (or
+	 * never existed — `removeSessionFiles` swallows ENOENT); `false` when the
+	 * deletion failed, in which case the user has already been shown the error
+	 * (the caller-supplied `failureMessage` prefix plus the shortened path) and
+	 * a warning logged. Never rejects: a leaked `Side-*.jsonl` must not break
+	 * shutdown or session transitions that await disposal.
+	 */
+	async #removeSideFile(sessionFile: string, failureMessage: string): Promise<boolean> {
+		try {
+			await SessionManager.removeSessionFiles(sessionFile);
+			return true;
+		} catch (err) {
+			logger.warn("Failed to remove side session file", { sessionFile, error: String(err) });
+			this.ctx.showError(`${failureMessage}: ${shortenPath(sessionFile)}`);
+			return false;
+		}
+	}
+
+	async #submitQuestion(side: AgentSession, question: string): Promise<void> {
+		const ctx = this.ctx;
+		try {
+			await ctx.withLocalSubmission(question, () => side.prompt(question, { streamingBehavior: "steer" }));
+		} catch (error) {
+			ctx.showError(error instanceof Error ? error.message : String(error));
+		}
+		ctx.updatePendingMessagesDisplay();
+		ctx.ui.requestRender();
+	}
+
+	/**
+	 * Handle an existing Side registry ref: reuse a live session, report a busy
+	 * initializing one, or reclaim a stale one. Returns true if the caller
+	 * should return (ref was reused, is busy, or a lost-race reuse was taken);
+	 * returns false if the ref was reclaimed or there was no ref, and the
+	 * caller should proceed to create (top of start) or surface its own error
+	 * (create-race catch).
+	 */
+	async #handleExistingRef(question: string): Promise<boolean> {
+		const ctx = this.ctx;
+		const registry = AgentRegistry.global();
+		const existing = registry.get(SIDE_AGENT_ID);
+		if (!existing) return false;
+
+		// Reuse path: a live side session already exists — focus it, no new fork.
+		// Registry ids are re-resolved across awaits (SessionFocusController
+		// .focusAgent → AgentLifecycleManager.ensureLive re-reads by id), so a
+		// captured ref must be revalidated before use: a concurrent dispose +
+		// new create can replace `existing` with a fresh null-session running
+		// generation during the focus await, which would either throw the
+		// lifecycle's raw "running agent cannot be revived" error or focus a
+		// different generation than the one we captured.
+		if (existing.session) {
+			try {
+				await ctx.focusAgentSession(SIDE_AGENT_ID);
+			} catch (error) {
+				const current = registry.get(SIDE_AGENT_ID);
+				if (current?.session !== existing.session) {
+					ctx.showError("Side conversation is still starting — try again in a moment");
+					return true;
+				}
+				ctx.showError(error instanceof Error ? error.message : String(error));
+				return true;
+			}
+			// Focus succeeded — re-read the registry and confirm the generation
+			// is still the one we captured. If a concurrent dispose + create
+			// swapped in a new session, do not submit the question against the
+			// stale captured session.
+			if (registry.get(SIDE_AGENT_ID)?.session !== existing.session) {
+				ctx.showError("Side conversation is still starting — try again in a moment");
+				return true;
+			}
+			ctx.showStatus(SIDE_STATUS);
+			if (question) await this.#submitQuestion(existing.session, question);
+			return true;
+		}
+
+		// Stale-ref path: ref exists but session is null. A genuinely stale ref
+		// (parked/aborted after a failed dispose) is reclaimed below; but the SDK
+		// pre-registers with session: null, status: "running" BEFORE attaching the
+		// live session (sdk.ts:2949-2958, attached at 3380-3386), so a running
+		// status means another start() is mid-create. Unregistering that
+		// generation would delete a live initializing session's file and make its
+		// generation-checked attach fail — losing the user's side conversation.
+		if (existing.status === "running") {
+			ctx.showError("Side conversation is still starting — try again in a moment");
+			return true;
+		}
+
+		// Stale: parked/aborted. Reclaim the slot before any await — a concurrent
+		// start() could register a fresh live Side that the resumed call would
+		// otherwise unregister and whose file it would delete.
+		const won = registry.unregister(SIDE_AGENT_ID, existing);
+		if (!won) {
+			// Another generation already won. The replacement ref may be a live
+			// session (reuse), a still-initializing running ref (busy), another
+			// stale ref (reclaim again), or already gone (create). Reclassify it
+			// through the same four-way classifier instead of focusing blindly — a
+			// null-session running ref must surface the busy error, not trigger
+			// revival. Each recursion is a real concurrent generation change, so
+			// depth is bounded in practice. Never delete the original ref's file
+			// here: the replacement generation may own a different file.
+			return this.#handleExistingRef(question);
+		}
+		if (existing.sessionFile) {
+			await this.#removeSideFile(existing.sessionFile, "Failed to delete the previous side conversation file");
+		}
+		return false;
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -167,6 +167,9 @@ export class SideController {
 				enableLsp: this.ctx.settings.get("task.enableLsp") !== false,
 				agentId: SIDE_AGENT_ID,
 				agentDisplayName: "side",
+				// The side is user-only after the boundary marker: peer IRC must
+				// not wake or steer it, and the side must not send content back.
+				messageable: false,
 				taskDepth: 1,
 				parentAgentId: ownerId,
 				agentRegistry: AgentRegistry.global(),
@@ -189,6 +192,12 @@ export class SideController {
 			// 1. Clear inherited todos so the fork does not drag the parent's task.
 			side.setTodoPhases([]);
 			sideManager.appendCustomEntry(USER_TODO_EDIT_CUSTOM_TYPE, { phases: [] });
+
+			// 1b. Clear inherited checkpoint/rewind state. The fork rehydrates the
+			//     parent's active checkpoint from the copied branch entries; without
+			//     this, end-of-turn enforcement forces a rewind that branches back
+			//     to the parent checkpoint, dropping the side boundary and question.
+			side.clearCheckpointRuntimeState();
 
 			// 2. Append the boundary as one message that is both model context and
 			//    a visible transcript rule. A freshly created session is idle, so

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -156,7 +156,11 @@ export class SideController {
 				localProtocolOptions,
 			});
 			side = created.session;
-			capturedRef = AgentRegistry.global().get(SIDE_AGENT_ID);
+			// Capture the ref ONLY if it owns the session we just constructed — an
+			// external replacement between the SDK's attach and this read would
+			// otherwise be unregistered by captured-generation cleanup.
+			const registered = AgentRegistry.global().get(SIDE_AGENT_ID);
+			capturedRef = registered?.session === side ? registered : undefined;
 			const uiContext = this.ctx.getToolUIContext();
 			if (uiContext) created.setToolUIContext(uiContext, true);
 

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -168,6 +168,7 @@ export class SideController {
 				preloadedExtensionPaths: extensionPaths,
 				extensions: [pi => pi.on("session_compact", reinject)],
 				localProtocolOptions,
+				initializeCapabilitySettings: false,
 			});
 			side = created.session;
 			// Capture the ref ONLY if it owns the session we just constructed — an
@@ -472,6 +473,13 @@ export class SideController {
 			} catch (error) {
 				const current = registry.get(SIDE_AGENT_ID);
 				if (current?.session !== existing.session) {
+					// Focus attached a replacement generation — undo it before
+					// reporting, so the UI is not left on a session we rejected.
+					try {
+						await ctx.unfocusSession();
+					} catch (unfocusError) {
+						logger.warn("Failed to unfocus replaced side generation", { error: String(unfocusError) });
+					}
 					ctx.showError("Side conversation is still starting — try again in a moment");
 					return { outcome: "done" };
 				}
@@ -483,6 +491,13 @@ export class SideController {
 			// swapped in a new session, do not submit the question against the
 			// stale captured session.
 			if (registry.get(SIDE_AGENT_ID)?.session !== existing.session) {
+				// Focus attached a replacement generation — undo it before
+				// reporting, so the UI is not left on a session we rejected.
+				try {
+					await ctx.unfocusSession();
+				} catch (unfocusError) {
+					logger.warn("Failed to unfocus replaced side generation", { error: String(unfocusError) });
+				}
 				ctx.showError("Side conversation is still starting — try again in a moment");
 				return { outcome: "done" };
 			}

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -78,6 +78,7 @@ export class SideController {
 		const thinkingLevel = session.configuredThinkingLevel();
 		const systemPrompt = [...session.systemPrompt];
 		const toolNames = session.getActiveToolNames();
+		const extensionPaths = session.extensionPaths;
 		const modelRegistry = session.modelRegistry;
 		const ownerId = session.getAgentId() ?? MAIN_AGENT_ID;
 		const mcpManager = ctx.mcpManager;
@@ -134,6 +135,7 @@ export class SideController {
 				agentRegistry: AgentRegistry.global(),
 				expectedAgentRef: null,
 				disableExtensionDiscovery: true,
+				preloadedExtensionPaths: extensionPaths,
 				extensions: [pi => pi.on("session_compact", reinject)],
 				localProtocolOptions,
 			});

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -336,6 +336,11 @@ export class SideController {
 	 */
 	async #removeSideFile(sessionFile: string, failureMessage: string): Promise<boolean> {
 		try {
+			// Storage of the CURRENT parent manager. Documented limitation: a side
+			// inherited from a different-backend session (crashed previous process,
+			// or a backend switch while the side was live) may not be deletable
+			// through this backend and lingers as inert files until the
+			// filesystem-bound persisted-scan cleanup.
 			await SessionManager.removeSessionFiles(sessionFile, this.ctx.sessionManager.getStorage());
 			return true;
 		} catch (err) {

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -114,8 +114,15 @@ export class SideController {
 		const sessionDir = parentFile.slice(0, -6);
 		const sideFile = path.join(sessionDir, `${SIDE_SESSION_FILE_PREFIX}${Snowflake.next()}.jsonl`);
 
-		await ctx.sessionManager.ensureOnDisk();
-		await ctx.sessionManager.flush();
+		try {
+			await ctx.sessionManager.ensureOnDisk();
+			await ctx.sessionManager.flush();
+		} catch (error) {
+			// The slash handler already cleared the editor — surface the failure
+			// here instead of letting it escape as an unhandled rejection.
+			ctx.showError(error instanceof Error ? error.message : String(error));
+			return;
+		}
 
 		let side: AgentSession | undefined;
 		let capturedRef: AgentRef | undefined;

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -11,7 +11,7 @@ import { shortenPath } from "../../tools/render-utils";
 import { USER_TODO_EDIT_CUSTOM_TYPE } from "../../tools/todo";
 import type { InteractiveModeContext } from "../types";
 
-export const SIDE_AGENT_ID = "Side";
+export const SIDE_AGENT_ID = "side.internal";
 
 const SIDE_STATUS = "Side conversation — Esc returns to main, /side end discards it";
 const DISPOSE_FAILURE_MESSAGE = "Side conversation ended, but its file could not be deleted";
@@ -220,7 +220,7 @@ export class SideController {
 	async #disposeImpl(): Promise<boolean> {
 		// A focused side must be unfocused BEFORE disposal unregisters it: the
 		// registry-event auto-unfocus is fire-and-forget, and its in-flight
-		// #attach(main) can race a subsequent focusAgentSession("Side") into a
+		// #attach(main) can race a subsequent focusAgentSession("side.internal") into a
 		// wrong final focus state.
 		if (this.ctx.focusedAgentId === SIDE_AGENT_ID) {
 			try {
@@ -232,7 +232,7 @@ export class SideController {
 		let cleanupFailed = false;
 
 		// Reclassifying loop. Each iteration re-reads the registry, so every
-		// success exit is preceded by a fresh read showing nothing named Side
+		// success exit is preceded by a fresh read showing nothing named side.internal
 		// remains. The body never assumes a ref stays classified the same
 		// across an await: the SDK dispose wrapper unregisters in its `finally`
 		// UNLESS the lifecycle manager is parking the ref (sdk.ts:1632-1640,
@@ -244,13 +244,13 @@ export class SideController {
 		// practice.
 		//
 		// Invariant: every `return true` is preceded by a registry read
-		// showing nothing named Side; every `return false` is preceded by one
+		// showing nothing named side.internal; every `return false` is preceded by one
 		// shown error per remnant that remains (a leaked file or a surviving
 		// generation — one remnant means one error, two remnants two); a
 		// captured ref's file is deleted only when its ref is
 		// gone from the registry or its unregister was won; a lost unregister
 		// never deletes anything. Side filenames are unique per generation
-		// (Side-<snowflake>.jsonl), so a captured ref's file is never a
+		// (side.internal-<snowflake>.jsonl), so a captured ref's file is never a
 		// replacement generation's file — deleting it after the ref left the
 		// registry, or after a won unregister, is always safe.
 		for (;;) {
@@ -311,7 +311,7 @@ export class SideController {
 	 * never existed — `removeSessionFiles` swallows ENOENT); `false` when the
 	 * deletion failed, in which case the user has already been shown the error
 	 * (the caller-supplied `failureMessage` prefix plus the shortened path) and
-	 * a warning logged. Never rejects: a leaked `Side-*.jsonl` must not break
+	 * a warning logged. Never rejects: a leaked `side.internal-*.jsonl` must not break
 	 * shutdown or session transitions that await disposal.
 	 */
 	async #removeSideFile(sessionFile: string, failureMessage: string): Promise<boolean> {

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -6,12 +6,11 @@ import * as sdk from "../../sdk";
 import type { AgentSession } from "../../session/agent-session";
 import { SIDE_BOUNDARY_MESSAGE_TYPE } from "../../session/messages";
 import { SessionManager } from "../../session/session-manager";
+import { SIDE_AGENT_ID, SIDE_SESSION_FILE_PREFIX } from "../../session/side-conversation";
 import { createMCPProxyTools } from "../../task/executor";
 import { shortenPath } from "../../tools/render-utils";
 import { USER_TODO_EDIT_CUSTOM_TYPE } from "../../tools/todo";
 import type { InteractiveModeContext } from "../types";
-
-export const SIDE_AGENT_ID = "side.internal";
 
 const SIDE_STATUS = "Side conversation — Esc returns to main, /side end discards it";
 const DISPOSE_FAILURE_MESSAGE = "Side conversation ended, but its file could not be deleted";
@@ -105,7 +104,7 @@ export class SideController {
 		};
 
 		const sessionDir = parentFile.slice(0, -6);
-		const sideFile = path.join(sessionDir, `${SIDE_AGENT_ID}-${Snowflake.next()}.jsonl`);
+		const sideFile = path.join(sessionDir, `${SIDE_SESSION_FILE_PREFIX}${Snowflake.next()}.jsonl`);
 
 		await ctx.sessionManager.ensureOnDisk();
 		await ctx.sessionManager.flush();
@@ -169,8 +168,9 @@ export class SideController {
 				{ triggerTurn: false, deliverAs: "nextTurn" },
 			);
 
-			// 3. Append session-init so a cold Agent Hub revival describes the side
-			//    correctly, using the post-filter tool list.
+			// 3. Append session-init so the side transcript describes itself for
+			//    inspection and export (cold revival is excluded from the persisted
+			//    agent scan), using the post-filter tool list.
 			sideManager.appendSessionInit({
 				systemPrompt: side.systemPrompt.join("\n\n"),
 				task: question || "side conversation",

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -19,8 +19,6 @@ const DISPOSE_FAILURE_MESSAGE = "Side conversation ended, but its file could not
 export class SideController {
 	constructor(private readonly ctx: InteractiveModeContext) {}
 
-	#unsubscribeCompaction: (() => void) | undefined;
-
 	// Operations are serialized through this queue so start()/dispose() cannot
 	// interleave at await points — a /side end fired during an in-flight create
 	// now waits for the create to finish, then disposes the live session, rather
@@ -164,14 +162,11 @@ export class SideController {
 				tools: side.getActiveToolNames(),
 			});
 
-			// 4. Re-inject the boundary after any successful compaction.
-			//    Manual compaction emits "session_compact" through the extension
-			//    runner (handled by the inline extension factory above).
-			//    Automatic compaction emits "auto_compaction_end" through the
-			//    session event stream — subscribe here.
-			this.#unsubscribeCompaction = side.subscribe(event => {
-				if (event.type === "auto_compaction_end" && event.result && !event.aborted) reinject();
-			});
+			// 4. Re-inject the boundary after any successful compaction. Both
+			//    manual and automatic compaction emit "session_compact" through
+			//    the extension runner on success (session-maintenance.ts:863 and
+			//    :2747), so the inline extension factory above is the single
+			//    mechanism — no separate event-stream subscription is needed.
 
 			// Focus, then overwrite the status string focusAgent emits (it is
 			// written for viewing a subagent and is wrong for a side conversation).
@@ -181,8 +176,8 @@ export class SideController {
 			if (question) await this.#submitQuestion(side, question);
 		} catch (error) {
 			if (side) {
-				// A session was constructed — dispose it fully (clears
-				// #unsubscribeCompaction, disposes the session, removes files).
+				// A session was constructed — dispose it fully (disposes the
+				// session, removes files).
 				await this.#disposeImpl();
 				await ctx.unfocusSession().catch(() => {});
 				ctx.showError(error instanceof Error ? error.message : String(error));
@@ -233,12 +228,6 @@ export class SideController {
 			} catch (error) {
 				logger.warn("Failed to unfocus side session before disposal", { error: String(error) });
 			}
-		}
-		// Compaction subscription is controller-owned, not ref-owned: clear it
-		// once before the loop regardless of which ref is eventually disposed.
-		if (this.#unsubscribeCompaction) {
-			this.#unsubscribeCompaction();
-			this.#unsubscribeCompaction = undefined;
 		}
 		let cleanupFailed = false;
 

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -96,6 +96,7 @@ export class SideController {
 		const ownerId = session.getAgentId() ?? MAIN_AGENT_ID;
 		const mcpManager = ctx.mcpManager;
 		const cwd = ctx.sessionManager.getCwd();
+		const parentStorage = ctx.sessionManager.getStorage();
 		const parentArtifactsDir = ctx.sessionManager.getArtifactsDir();
 		const parentLocalSessionId = ctx.sessionManager.getSessionId();
 		const localProtocolOptions = {
@@ -119,7 +120,7 @@ export class SideController {
 			});
 
 		try {
-			const sideManager = await SessionManager.forkFrom(parentFile, cwd, sessionDir, undefined, {
+			const sideManager = await SessionManager.forkFrom(parentFile, cwd, sessionDir, parentStorage, {
 				suppressBreadcrumb: true,
 				sessionFile: sideFile,
 			});
@@ -335,7 +336,7 @@ export class SideController {
 	 */
 	async #removeSideFile(sessionFile: string, failureMessage: string): Promise<boolean> {
 		try {
-			await SessionManager.removeSessionFiles(sessionFile);
+			await SessionManager.removeSessionFiles(sessionFile, this.ctx.sessionManager.getStorage());
 			return true;
 		} catch (err) {
 			logger.warn("Failed to remove side session file", { sessionFile, error: String(err) });

--- a/packages/coding-agent/src/modes/controllers/side-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/side-controller.ts
@@ -369,6 +369,26 @@ export class SideController {
 		const existing = registry.get(SIDE_AGENT_ID);
 		if (!existing) return { outcome: "proceed" };
 
+		// Parentage validation: the side file lives at <parentArtifactDir>/<name>.jsonl.
+		// Some parent-session transitions (SelectorController.handleResumeSession from
+		// the blank /resume picker, handoff) do not invoke this controller's dispose,
+		// so after switching from parent A to parent B the registry can still hold A's
+		// Side ref. Reusing it would fork from the wrong context (possibly wrong cwd).
+		// On mismatch, dispose the foreign side (its file is deleted from the OLD
+		// parent's artifact dir — correct) and fall through to create against the
+		// current parent. If disposal cannot complete (a running foreign ref another
+		// process is still creating), surface the busy error and stop — do not fall
+		// through to a create that will fail the registration race.
+		const currentParentFile = ctx.sessionManager.getSessionFile();
+		if (currentParentFile && existing.sessionFile) {
+			const currentArtifactDir = currentParentFile.slice(0, -6) + path.sep;
+			if (!existing.sessionFile.startsWith(currentArtifactDir)) {
+				const disposed = await this.#disposeImpl();
+				if (!disposed) return { outcome: "done" };
+				return { outcome: "proceed" };
+			}
+		}
+
 		// Reuse path: a live side session already exists — focus it, no new fork.
 		// Registry ids are re-resolved across awaits (SessionFocusController
 		// .focusAgent → AgentLifecycleManager.ensureLive re-reads by id), so a

--- a/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/tan-command-controller.ts
@@ -1,7 +1,6 @@
-import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { prompt, Snowflake } from "@oh-my-pi/pi-utils";
+import { logger, prompt, Snowflake } from "@oh-my-pi/pi-utils";
 import backgroundTanDispatchPrompt from "../../prompts/system/background-tan-dispatch.md" with { type: "text" };
 import tanContextSwitchPrompt from "../../prompts/system/tan-context-switch.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "../../registry/agent-registry";
@@ -28,13 +27,6 @@ function extractAssistantText(message: AssistantMessage | undefined): string {
 		.map(content => content.text)
 		.join("")
 		.trim();
-}
-
-async function removeCloneSession(cloneFile: string): Promise<void> {
-	await Promise.allSettled([
-		fs.rm(cloneFile, { force: true }),
-		fs.rm(cloneFile.slice(0, -6), { recursive: true, force: true }),
-	]);
 }
 
 export class TanCommandController {
@@ -216,7 +208,10 @@ export class TanCommandController {
 				{ ownerId, agentId: cloneId },
 			);
 		} catch (error) {
-			if (cloneFile) await removeCloneSession(cloneFile);
+			if (cloneFile)
+				await SessionManager.removeSessionFiles(cloneFile).catch(err =>
+					logger.warn("Failed to remove /tan clone", { cloneFile, error: String(err) }),
+				);
 			this.ctx.showError(error instanceof Error ? error.message : String(error));
 			return;
 		}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -174,6 +174,7 @@ import { MCPCommandController } from "./controllers/mcp-command-controller";
 import { OmfgController } from "./controllers/omfg-controller";
 import { SelectorController } from "./controllers/selector-controller";
 import { SessionFocusController } from "./controllers/session-focus-controller";
+import { SideController } from "./controllers/side-controller";
 import { SSHCommandController } from "./controllers/ssh-command-controller";
 import { TanCommandController } from "./controllers/tan-command-controller";
 import { TodoCommandController } from "./controllers/todo-command-controller";
@@ -592,6 +593,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	readonly #codexResetFireworksController: CodexResetFireworksController;
 	readonly #btwController: BtwController;
 	readonly #tanCommandController: TanCommandController;
+	readonly #sideController: SideController;
 	readonly #omfgController: OmfgController;
 	readonly #commandController: CommandController;
 	readonly #todoCommandController: TodoCommandController;
@@ -804,6 +806,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#uiHelpers = new UiHelpers(this);
 		this.#btwController = new BtwController(this);
 		this.#tanCommandController = new TanCommandController(this);
+		this.#sideController = new SideController(this);
 		this.#omfgController = new OmfgController(this);
 		this.#extensionUiController = new ExtensionUiController(this);
 		this.#eventController = new EventController(this);
@@ -4019,6 +4022,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		await this.#liveCommandController.stop();
 
 		this.#btwController.dispose();
+		await this.#sideController.dispose();
 		this.#omfgController.dispose();
 		this.#focusController.dispose();
 
@@ -4493,8 +4497,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		return true;
 	}
 
-	#prepareSessionSwitch(): void {
+	async #prepareSessionSwitch(): Promise<void> {
 		this.#btwController.dispose();
+		await this.#sideController.dispose();
 		this.#omfgController.dispose();
 		this.#extensionUiController.clearExtensionTerminalInputListeners();
 		this.clearPinnedError();
@@ -4503,7 +4508,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async handleClearCommand(): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
-		this.#prepareSessionSwitch();
+		await this.#prepareSessionSwitch();
 		await this.#commandController.handleClearCommand();
 	}
 
@@ -4513,13 +4518,14 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async handleDropCommand(): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
-		this.#prepareSessionSwitch();
+		await this.#prepareSessionSwitch();
 		await this.#commandController.handleDropCommand();
 	}
 
 	async handleForkCommand(): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
 		this.#btwController.dispose();
+		await this.#sideController.dispose();
 		this.#omfgController.dispose();
 		await this.#commandController.handleForkCommand();
 	}
@@ -4746,6 +4752,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 		this.#btwController.dispose();
+		await this.#sideController.dispose();
 		this.#omfgController.dispose();
 		this.resetObserverRegistry();
 		await this.#selectorController.handleResumeSession(sessionPath, { settingsFlushed: true });
@@ -4830,6 +4837,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#tanCommandController.start(work);
 	}
 
+	handleSideCommand(args: string): Promise<void> {
+		return this.#sideController.start(args);
+	}
+
 	hasActiveBtw(): boolean {
 		return this.#btwController.hasActiveRequest();
 	}
@@ -4862,6 +4873,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				return;
 			}
 			this.#btwController.dispose();
+			await this.#sideController.dispose();
 			this.#omfgController.dispose();
 			this.renderInitialMessages({ clearTerminalHistory: true });
 			this.updateEditorBorderColor();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4532,8 +4532,6 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async handleMoveCommand(targetPath?: string): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
-		// Moving renames the artifact dir out from under a live side.
-		await this.#sideController.dispose();
 		await this.#commandController.handleMoveCommand(targetPath);
 	}
 
@@ -4841,6 +4839,10 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	handleSideCommand(args: string): Promise<void> {
 		return this.#sideController.start(args);
+	}
+
+	disposeSideConversation(): Promise<void> {
+		return this.#sideController.dispose();
 	}
 
 	hasActiveBtw(): boolean {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4499,7 +4499,6 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async #prepareSessionSwitch(): Promise<void> {
 		this.#btwController.dispose();
-		await this.#sideController.dispose();
 		this.#omfgController.dispose();
 		this.#extensionUiController.clearExtensionTerminalInputListeners();
 		this.clearPinnedError();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4524,7 +4524,6 @@ export class InteractiveMode implements InteractiveModeContext {
 	async handleForkCommand(): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
 		this.#btwController.dispose();
-		await this.#sideController.dispose();
 		this.#omfgController.dispose();
 		await this.#commandController.handleForkCommand();
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4532,6 +4532,8 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async handleMoveCommand(targetPath?: string): Promise<void> {
 		if (this.#vibeSessionTransitionBlocked()) return;
+		// Moving renames the artifact dir out from under a live side.
+		await this.#sideController.dispose();
 		await this.#commandController.handleMoveCommand(targetPath);
 	}
 

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -414,6 +414,8 @@ export interface InteractiveModeContext {
 	handleBtwCommand(question: string): Promise<void>;
 	handleTanCommand(work: string): Promise<void>;
 	handleSideCommand(args: string): Promise<void>;
+	/** Tear down a live side conversation (e.g. before relocating the parent session). */
+	disposeSideConversation(): Promise<void>;
 	hasActiveBtw(): boolean;
 	handleBtwEscape(): boolean;
 	handleBtwBranchKey(): Promise<boolean>;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -413,6 +413,7 @@ export interface InteractiveModeContext {
 	handleQueueCommand(message: string): Promise<void>;
 	handleBtwCommand(question: string): Promise<void>;
 	handleTanCommand(work: string): Promise<void>;
+	handleSideCommand(args: string): Promise<void>;
 	hasActiveBtw(): boolean;
 	handleBtwEscape(): boolean;
 	handleBtwBranchKey(): Promise<boolean>;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -30,6 +30,7 @@ import {
 	ReadToolGroupComponent,
 	readArgsCollapseIntoGroup,
 } from "../../modes/components/read-tool-group";
+import { createSideBoundaryBlock } from "../../modes/components/side-boundary-message";
 import { SkillMessageComponent } from "../../modes/components/skill-message";
 import { ToolExecutionComponent } from "../../modes/components/tool-execution";
 import { TranscriptBlock } from "../../modes/components/transcript-container";
@@ -43,6 +44,7 @@ import {
 	BACKGROUND_TAN_DISPATCH_MESSAGE_TYPE,
 	type CustomMessage,
 	LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE,
+	SIDE_BOUNDARY_MESSAGE_TYPE,
 	SKILL_PROMPT_MESSAGE_TYPE,
 	type SkillPromptDetails,
 } from "../../session/messages";
@@ -198,6 +200,10 @@ export class UiHelpers {
 						this.ctx.chatContainer.addChild(
 							createAdvisorMessageCard(details, () => this.ctx.toolOutputExpanded, theme),
 						);
+						break;
+					}
+					if (message.customType === SIDE_BOUNDARY_MESSAGE_TYPE) {
+						this.ctx.chatContainer.addChild(createSideBoundaryBlock());
 						break;
 					}
 					if (message.customType === BACKGROUND_TAN_DISPATCH_MESSAGE_TYPE) {

--- a/packages/coding-agent/src/prompts/system/side-boundary.md
+++ b/packages/coding-agent/src/prompts/system/side-boundary.md
@@ -1,0 +1,18 @@
+<system-notice cause="side-conversation">
+Everything above belongs to the parent session. It is inherited context, for
+reference only. It is NOT your current task.
+
+You are in a side conversation: a throwaway fork. Nothing you say here returns
+to the parent session, and this transcript is deleted when the user closes it.
+
+- Only messages AFTER this notice are live instructions. NEVER continue,
+  execute, or complete any task, plan, todo, tool call, or request that appears
+  only above it.
+- Read, search, and inspect freely. That is what this space is for.
+- NEVER modify files, git state, permissions, or configuration unless the user
+  explicitly asks for that change HERE, after this notice. The parent session is
+  concurrently working in this same directory; its files may look mid-refactor
+  or fail to compile. That is the parent's live work, not yours to fix.
+- If the user does explicitly ask for a change, keep it minimal and local.
+- Answer the question. Then STOP.
+</system-notice>

--- a/packages/coding-agent/src/registry/agent-registry.ts
+++ b/packages/coding-agent/src/registry/agent-registry.ts
@@ -43,6 +43,13 @@ export interface AgentRef {
 	lastActivity: number;
 	/** Short gist of what the agent is currently doing (latest intent or tool), for the work-aware roster. Display-only. */
 	activity?: string;
+	/**
+	 * Whether peer agents can address this ref via IRC (`hub send`). Default
+	 * `true`. Set `false` for throwaway sessions whose isolation boundary must
+	 * not be crossed by inbound peer messages — the side conversation is
+	 * user-only after the boundary marker.
+	 */
+	messageable: boolean;
 }
 
 export type AgentRefExpectation = AgentRef | AgentSession;
@@ -62,6 +69,8 @@ export interface RegisterInput {
 	session: AgentSession | null;
 	sessionFile?: string | null;
 	status?: AgentStatus;
+	/** See {@link AgentRef.messageable}. Default `true`. */
+	messageable?: boolean;
 }
 
 export class AgentRegistry {
@@ -96,6 +105,7 @@ export class AgentRegistry {
 			status: input.status ?? "running",
 			session: input.session,
 			sessionFile: input.sessionFile ?? null,
+			messageable: input.messageable ?? true,
 			createdAt: now,
 			lastActivity: now,
 		};

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -49,6 +49,11 @@ async function registerPersistedSubagentsFromDir(
 	}
 	for (const entry of entries) {
 		if (!entry.isFile() || !entry.name.endsWith(".jsonl") || entry.name.includes(".bak")) continue;
+		// Throwaway side conversations (`side.internal-<snowflake>.jsonl`) must not
+		// cold-revive as generic subagents — after process exit their controller and
+		// compaction hooks are gone, and the reference-only boundary contract would
+		// degrade after the first compaction.
+		if (entry.name.startsWith("side.internal-")) continue;
 		const sessionFile = path.join(dir, entry.name);
 		// The advisor transcript is observability-only: register it as a non-peer
 		// `advisor` kind under its owning session so the Hub can show its read-only

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { logger } from "@oh-my-pi/pi-utils";
 import { ADVISOR_TRANSCRIPT_FILENAME, isAdvisorTranscriptName } from "../advisor/transcript-recorder";
 import { SessionManager } from "../session/session-manager";
 import { SIDE_SESSION_FILE_PREFIX } from "../session/side-conversation";
@@ -53,8 +54,19 @@ async function registerPersistedSubagentsFromDir(
 		// Throwaway side conversations (`side.internal-<snowflake>.jsonl`) must not
 		// cold-revive as generic subagents — after process exit their controller and
 		// compaction hooks are gone, and the reference-only boundary contract would
-		// degrade after the first compaction.
-		if (entry.name.startsWith(SIDE_SESSION_FILE_PREFIX)) continue;
+		// degrade after the first compaction. Delete abandoned side files (and their
+		// artifact dirs) during the scan so crashed transcripts do not linger forever.
+		if (entry.name.startsWith(SIDE_SESSION_FILE_PREFIX)) {
+			try {
+				await SessionManager.removeSessionFiles(path.join(dir, entry.name));
+			} catch (err) {
+				logger.warn("Failed to delete abandoned side transcript", {
+					file: entry.name,
+					error: String(err),
+				});
+			}
+			continue;
+		}
 		const sessionFile = path.join(dir, entry.name);
 		// The advisor transcript is observability-only: register it as a non-peer
 		// `advisor` kind under its owning session so the Hub can show its read-only

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -57,13 +57,27 @@ async function registerPersistedSubagentsFromDir(
 		// degrade after the first compaction. Delete abandoned side files (and their
 		// artifact dirs) during the scan so crashed transcripts do not linger forever.
 		if (entry.name.startsWith(SIDE_SESSION_FILE_PREFIX)) {
-			try {
-				await SessionManager.removeSessionFiles(path.join(dir, entry.name));
-			} catch (err) {
-				logger.warn("Failed to delete abandoned side transcript", {
-					file: entry.name,
-					error: String(err),
-				});
+			const sideFile = path.join(dir, entry.name);
+			// Live if a current registry ref owns the exact path — including a
+			// mid-registration null-session `running` ref, so the Hub opening while
+			// a side is focused (or starting) cannot delete it.
+			const owned = registry.list().some(ref => ref.sessionFile === sideFile);
+			if (!owned) {
+				// Only files proven to predate this process are abandoned:
+				// forkFrom writes the side file before createAgentSession registers
+				// its ref, so a fresh unowned file may be an initializing fork, not
+				// garbage (TOCTOU window the ownership check cannot close).
+				const { mtimeMs } = await fs.promises.stat(sideFile);
+				if (mtimeMs < performance.timeOrigin) {
+					try {
+						await SessionManager.removeSessionFiles(sideFile);
+					} catch (err) {
+						logger.warn("Failed to delete abandoned side transcript", {
+							file: entry.name,
+							error: String(err),
+						});
+					}
+				}
 			}
 			continue;
 		}

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { ADVISOR_TRANSCRIPT_FILENAME, isAdvisorTranscriptName } from "../advisor/transcript-recorder";
 import { SessionManager } from "../session/session-manager";
+import { SIDE_SESSION_FILE_PREFIX } from "../session/side-conversation";
 import { persistedVibeChildIds } from "../vibe/runtime";
 import { type AgentRegistry, MAIN_AGENT_ID } from "./agent-registry";
 
@@ -53,7 +54,7 @@ async function registerPersistedSubagentsFromDir(
 		// cold-revive as generic subagents — after process exit their controller and
 		// compaction hooks are gone, and the reference-only boundary contract would
 		// degrade after the first compaction.
-		if (entry.name.startsWith("side.internal-")) continue;
+		if (entry.name.startsWith(SIDE_SESSION_FILE_PREFIX)) continue;
 		const sessionFile = path.join(dir, entry.name);
 		// The advisor transcript is observability-only: register it as a non-peer
 		// `advisor` kind under its owning session so the Hub can show its read-only

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { logger } from "@oh-my-pi/pi-utils";
 import { ADVISOR_TRANSCRIPT_FILENAME, isAdvisorTranscriptName } from "../advisor/transcript-recorder";
 import { SessionManager } from "../session/session-manager";
 import { SIDE_SESSION_FILE_PREFIX } from "../session/side-conversation";
@@ -54,33 +53,12 @@ async function registerPersistedSubagentsFromDir(
 		// Throwaway side conversations (`side.internal-<snowflake>.jsonl`) must not
 		// cold-revive as generic subagents — after process exit their controller and
 		// compaction hooks are gone, and the reference-only boundary contract would
-		// degrade after the first compaction. Delete abandoned side files (and their
-		// artifact dirs) during the scan so crashed transcripts do not linger forever.
-		if (entry.name.startsWith(SIDE_SESSION_FILE_PREFIX)) {
-			const sideFile = path.join(dir, entry.name);
-			// Live if a current registry ref owns the exact path — including a
-			// mid-registration null-session `running` ref, so the Hub opening while
-			// a side is focused (or starting) cannot delete it.
-			const owned = registry.list().some(ref => ref.sessionFile === sideFile);
-			if (!owned) {
-				// Only files proven to predate this process are abandoned:
-				// forkFrom writes the side file before createAgentSession registers
-				// its ref, so a fresh unowned file may be an initializing fork, not
-				// garbage (TOCTOU window the ownership check cannot close).
-				const { mtimeMs } = await fs.promises.stat(sideFile);
-				if (mtimeMs < performance.timeOrigin) {
-					try {
-						await SessionManager.removeSessionFiles(sideFile);
-					} catch (err) {
-						logger.warn("Failed to delete abandoned side transcript", {
-							file: entry.name,
-							error: String(err),
-						});
-					}
-				}
-			}
-			continue;
-		}
+		// degrade after the first compaction. They are only SKIPPED, never deleted:
+		// a second process opening the Hub would see another process's live side as
+		// unowned and there is no cheap cross-process liveness check, so deleting
+		// here can destroy an active transcript. Abandoned files stay inert on
+		// disk for the user to clean up.
+		if (entry.name.startsWith(SIDE_SESSION_FILE_PREFIX)) continue;
 		const sessionFile = path.join(dir, entry.name);
 		// The advisor transcript is observability-only: register it as a non-peer
 		// `advisor` kind under its owning session so the Hub can show its read-only

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -522,7 +522,12 @@ export interface CreateAgentSessionOptions {
 	agentId?: string;
 	/** Display name for the agent in IRC. Default: "main" or "sub". */
 	agentDisplayName?: string;
-	/** Optional shared agent registry for IRC routing. Default: AgentRegistry.global(). */
+	/**
+	 * Whether peer agents can address this session via IRC (`hub send`).
+	 * Default `true`. Set `false` for throwaway sessions (side conversations)
+	 * whose isolation boundary must not be crossed by inbound peer messages.
+	 */
+	messageable?: boolean;
 	agentRegistry?: AgentRegistry;
 	/**
 	 * Registry generation authorized for this creation. `null` requires the id
@@ -3031,6 +3036,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			session: null,
 			sessionFile: sessionManager.getSessionFile() ?? null,
 			status: "running" as const,
+			messageable: options.messageable ?? true,
 		};
 		registeredAgentRef =
 			options.expectedAgentRef === undefined

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3352,6 +3352,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			promptTemplates,
 			slashCommands,
 			extensionRunner,
+			extensionPaths,
 			customCommands: customCommandsResult.commands,
 			skills,
 			skillWarnings,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -420,6 +420,12 @@ export interface CreateAgentSessionOptions {
 	/** Disable extension discovery (explicit paths still load). */
 	disableExtensionDiscovery?: boolean;
 	/**
+	 * Re-bind the process-global capability settings to this session's settings
+	 * (default true). Child sessions with isolated settings pass false so the
+	 * parent's binding — and provider persistence — stays untouched.
+	 */
+	initializeCapabilitySettings?: boolean;
+	/**
 	 * Pre-loaded extensions (skips file discovery and the per-session factory
 	 * call). Used by the CLI when extensions are loaded early to parse custom
 	 * flags — the same process owns the returned instances, so reusing them is
@@ -1266,7 +1272,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 	const settings = await (options.settings ??
 		options.settingsManager ??
 		logger.time("settings", Settings.init, { cwd, agentDir }));
-	logger.time("initializeWithSettings", initializeWithSettings, settings);
+	if (options.initializeCapabilitySettings !== false) {
+		logger.time("initializeWithSettings", initializeWithSettings, settings);
+	}
 	if (!options.modelRegistry) {
 		modelRegistry.refreshInBackground();
 	}

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -131,6 +131,8 @@ export interface AgentSessionConfig {
 	slashCommands?: FileSlashCommand[];
 	/** Extension runner created with wrapped tools. */
 	extensionRunner?: ExtensionRunner;
+	/** Source paths of loaded extensions, for forwarding to forked sub-sessions. */
+	extensionPaths?: string[];
 	/** Loaded skills already discovered by the SDK. */
 	skills?: Skill[];
 	/** Skill loading warnings already captured by the SDK. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -528,6 +528,8 @@ export class AgentSession {
 	#codexResetCoordinator: CodexAutoRedeemCoordinator;
 	// Extension system
 	#extensionRunner: ExtensionRunner | undefined = undefined;
+	/** Source paths of loaded extensions, forwarded to forked sub-sessions. */
+	#extensionPaths: string[] = [];
 	/**
 	 * Backs `ctx.setInterval`/`setTimeout`/`clearTimer` for the runner-less
 	 * command-context fallback (SDK embeddings with no extension runner). Lazily
@@ -1003,6 +1005,7 @@ export class AgentSession {
 		this.#promptTemplates = config.promptTemplates ?? [];
 		this.#slashCommands = config.slashCommands ?? [];
 		this.#extensionRunner = config.extensionRunner;
+		this.#extensionPaths = config.extensionPaths ?? [];
 		this.#customCommands = config.customCommands ?? [];
 		const recoveryHost: TurnRecoveryHost = {
 			agent: this.agent,
@@ -8819,5 +8822,10 @@ export class AgentSession {
 	 */
 	get extensionRunner(): ExtensionRunner | undefined {
 		return this.#extensionRunner;
+	}
+
+	/** Source paths of loaded extensions, for forwarding to forked sub-sessions. */
+	get extensionPaths(): string[] {
+		return this.#extensionPaths;
 	}
 }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4436,6 +4436,17 @@ export class AgentSession {
 		this.#rewoundToolResultIds.clear();
 	}
 
+	/**
+	 * Clear all checkpoint/rewind runtime state. Throwaway forks (side
+	 * conversations) call this after construction to avoid inheriting the
+	 * parent's active checkpoint, which would force a rewind at the end of
+	 * the first side turn and branch back to the parent's checkpoint —
+	 * dropping the side boundary and the user's question.
+	 */
+	clearCheckpointRuntimeState(): void {
+		this.#clearCheckpointRuntimeState();
+	}
+
 	/** Drop mutable tool decisions and directives owned by the previous logical session. */
 	#clearSessionScopedToolState(): void {
 		this.agent.clearDeferredToolDirectives();

--- a/packages/coding-agent/src/session/indexed-session-storage.ts
+++ b/packages/coding-agent/src/session/indexed-session-storage.ts
@@ -1,3 +1,4 @@
+import * as fsp from "node:fs/promises";
 import { toError } from "@oh-my-pi/pi-utils";
 import type {
 	SessionStorage,
@@ -338,6 +339,18 @@ export class IndexedSessionStorage implements SessionStorage {
 			await this.#enqueuePaths(paths, () => this.#backend.remove(paths), { trackDrain: false });
 		} catch (err) {
 			for (const [path, entry] of previous) this.#index.set(path, entry);
+			throw toError(err);
+		}
+
+		// Also remove the physical artifact directory. ArtifactManager always
+		// spills tool output to the on-disk directory at sessionPath.slice(0, -6),
+		// even when the session transcript itself lives in the indexed backend.
+		// Without this, /side end removes the backend keys but leaves spilled
+		// artifacts on disk. Tolerate missing directories (force: true) so a
+		// session that never spilled artifacts cleans up cleanly.
+		try {
+			await fsp.rm(artifactsDir, { recursive: true, force: true });
+		} catch (err) {
 			throw toError(err);
 		}
 	}

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -42,6 +42,7 @@ import { formatOutputNotice } from "../tools/output-meta";
 export const SKILL_PROMPT_MESSAGE_TYPE = "skill-prompt";
 export const LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE = "lsp-late-diagnostic";
 export const BACKGROUND_TAN_DISPATCH_MESSAGE_TYPE = "background-tan-dispatch";
+export const SIDE_BOUNDARY_MESSAGE_TYPE = "side-boundary";
 
 /**
  * Logs provider-error turns so their actual cause is available outside the

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2392,6 +2392,18 @@ export class SessionManager {
 		return file;
 	}
 
+	/** Delete a session file and its artifact directory by path. ENOENT is success. */
+	static async removeSessionFiles(
+		sessionPath: string,
+		storage: SessionStorage = new FileSessionStorage(),
+	): Promise<void> {
+		try {
+			await storage.deleteSessionWithArtifacts(sessionPath);
+		} catch (err) {
+			if (!isEnoent(err)) throw err;
+		}
+	}
+
 	/**
 	 * Fork a session into the current project directory: copy history from another
 	 * session file while creating a fresh session file in this sessionDir.

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1669,6 +1669,11 @@ export class SessionManager {
 		return this.#cwd;
 	}
 
+	/** The storage backend this manager reads and writes through. */
+	getStorage(): SessionStorage {
+		return this.#storage;
+	}
+
 	/** Additional workspace directories beyond cwd (multi-root), absolute and normalized. */
 	getAdditionalDirectories(): string[] {
 		return [...this.#additionalDirectories];

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -430,8 +430,15 @@ export class FileSessionStorage implements SessionStorage {
 	 * Artifacts are stored in a sibling directory with the same name minus .jsonl extension.
 	 */
 	async deleteSessionWithArtifacts(sessionPath: string): Promise<void> {
-		// Delete the session file itself
-		await this.unlink(sessionPath);
+		// Delete the session file itself. Tolerate ENOENT so a prior partial
+		// delete still gets a chance to remove the artifacts directory.
+		try {
+			await this.unlink(sessionPath);
+		} catch (err) {
+			if (!isEnoent(err)) {
+				throw toError(err);
+			}
+		}
 
 		// Compute artifacts directory: /path/to/session.jsonl -> /path/to/session
 		const artifactsDir = sessionPath.slice(0, -6);

--- a/packages/coding-agent/src/session/side-conversation.ts
+++ b/packages/coding-agent/src/session/side-conversation.ts
@@ -1,0 +1,15 @@
+/**
+ * Identity constants for `/side` conversations, shared by the controller, the
+ * persisted-agent scan, and tests. Kept out of session/messages.ts, which is
+ * message schema; this module is registry/file identity.
+ */
+
+/**
+ * Registry id for the live side conversation. The dot makes it
+ * collision-proof: task-id sanitization strips everything outside
+ * `[A-Za-z0-9_-]` (structured-subagent.ts), so no user task can produce it.
+ */
+export const SIDE_AGENT_ID = "side.internal";
+
+/** Filename prefix for side session files (`side.internal-<snowflake>.jsonl`). */
+export const SIDE_SESSION_FILE_PREFIX = `${SIDE_AGENT_ID}-`;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1852,6 +1852,18 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "side",
+		description: "Open a throwaway side conversation forked from this session",
+		subcommands: [{ name: "end", description: "Discard the side conversation" }],
+		inlineHint: "[question]",
+		allowArgs: true,
+		handleTui: async (command, runtime) => {
+			const args = command.text.slice(`/${command.name}`.length).trim();
+			runtime.ctx.editor.setText("");
+			await runtime.ctx.handleSideCommand(args);
+		},
+	},
+	{
 		name: "tan",
 		description: "Run a full background agent on tangential work",
 		inlineHint: "<work>",

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -819,15 +819,26 @@ export function createMCPProxyTools(mcpManager: MCPManager): CustomTool[] {
 	});
 }
 
-export function createSubagentSettings(
+/**
+ * Snapshot every schema setting from `baseSettings` into an in-memory Settings
+ * with `overrides` applied. No disk writes — the parent's live config is untouched.
+ */
+export function createIsolatedSettingsSnapshot(
 	baseSettings: Settings,
 	overrides?: Partial<Record<SettingPath, unknown>>,
-	inheritedServiceTier?: ServiceTierByFamily | null,
 ): Settings {
 	const snapshot: Partial<Record<SettingPath, unknown>> = {};
 	for (const key of Object.keys(SETTINGS_SCHEMA) as SettingPath[]) {
 		snapshot[key] = baseSettings.get(key);
 	}
+	return Settings.isolated({ ...snapshot, ...overrides });
+}
+
+export function createSubagentSettings(
+	baseSettings: Settings,
+	overrides?: Partial<Record<SettingPath, unknown>>,
+	inheritedServiceTier?: ServiceTierByFamily | null,
+): Settings {
 	// Resolve the subagent's per-family tiers from `tier.subagent` ("inherit" =
 	// match the parent's live tiers when a live session supplied them, else the
 	// subagent's own configured tier.* settings). The result is stamped back onto
@@ -841,11 +852,10 @@ export function createSubagentSettings(
 				)
 			: (inheritedServiceTier ?? {});
 	const subagentTiers = resolveSubagentServiceTier(baseSettings.get("tier.subagent"), inheritedTiers);
-	snapshot["tier.openai"] = subagentTiers.openai ?? "none";
-	snapshot["tier.anthropic"] = subagentTiers.anthropic ?? "none";
-	snapshot["tier.google"] = subagentTiers.google ?? "none";
-	return Settings.isolated({
-		...snapshot,
+	return createIsolatedSettingsSnapshot(baseSettings, {
+		"tier.openai": subagentTiers.openai ?? "none",
+		"tier.anthropic": subagentTiers.anthropic ?? "none",
+		"tier.google": subagentTiers.google ?? "none",
 		// Async jobs and bash auto-backgrounding are inherited from the parent:
 		// background jobs are owner-routed to the subagent's own session, and
 		// the run driver's quiescence barrier + teardown reap guarantee no

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -91,14 +91,16 @@ export async function executeList(
 	senderId: string,
 ): Promise<AgentToolResult<CoordinationDetails>> {
 	let refs = registry.list();
-	if (!refs.some(ref => ref.id !== senderId && ref.status !== "aborted" && ref.kind !== "advisor")) {
+	if (
+		!refs.some(ref => ref.id !== senderId && ref.status !== "aborted" && ref.kind !== "advisor" && ref.messageable)
+	) {
 		await registerPersistedSubagents(registry, registry.get(senderId)?.sessionFile);
 		refs = registry.list();
 	}
 
 	const bus = IrcBus.global();
 	const peers = refs
-		.filter(ref => ref.id !== senderId && ref.status !== "aborted" && ref.kind !== "advisor")
+		.filter(ref => ref.id !== senderId && ref.status !== "aborted" && ref.kind !== "advisor" && ref.messageable)
 		.map(ref => ({
 			id: ref.id,
 			displayName: ref.displayName,

--- a/packages/coding-agent/test/modes/components/status-line/segments.test.ts
+++ b/packages/coding-agent/test/modes/components/status-line/segments.test.ts
@@ -73,4 +73,25 @@ describe("status line pi segment focused badge", () => {
 		const content = Bun.stripANSI(renderSegment("pi", createFocusedContext("side.internal")).content);
 		expect(content).toContain("side.internal");
 	});
+
+	it("flattens control characters and bounds the focused display name", () => {
+		AgentRegistry.global().register({
+			id: "agent-1",
+			displayName: `evil\tname\nwith\x1b[31mansi ${"x".repeat(200)}`,
+			kind: "sub",
+			session: null,
+			sessionFile: null,
+			status: "idle",
+		});
+
+		const raw = renderSegment("pi", createFocusedContext("agent-1")).content;
+		// The injected escape must not survive into the rendered label (before
+		// any stripping — stripping here would make this assertion vacuous).
+		expect(raw).not.toContain("\x1b[31m");
+		const content = Bun.stripANSI(raw);
+		expect(content).not.toContain("[31m");
+		expect(content).not.toContain("\t");
+		expect(content).not.toContain("\n");
+		expect(content.length).toBeLessThan(120);
+	});
 });

--- a/packages/coding-agent/test/modes/components/status-line/segments.test.ts
+++ b/packages/coding-agent/test/modes/components/status-line/segments.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+afterEach(() => {
+	AgentRegistry.resetGlobalForTests();
+});
+
+function createFocusedContext(focusedAgentId: string): SegmentContext {
+	return {
+		session: {
+			state: {},
+		} as unknown as SegmentContext["session"],
+		focusedAgentId,
+		width: 120,
+		compactThinkingLevel: false,
+		options: {},
+		planMode: null,
+		loopMode: null,
+		prewalk: null,
+		goalMode: null,
+		vibeMode: null,
+		collab: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			orchestrationInput: 0,
+			orchestrationOutput: 0,
+			orchestrationCacheRead: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		},
+		contextPercent: 0,
+		contextTokens: 0,
+		contextWindow: 0,
+		autoCompactEnabled: false,
+		subagentCount: 0,
+		activeMs: 0,
+		activeRepo: null,
+		worktree: null,
+		git: { branch: null, status: null, pr: null },
+		usage: null,
+	};
+}
+
+describe("status line pi segment focused badge", () => {
+	it("renders the focused ref displayName instead of the registry id", () => {
+		AgentRegistry.global().register({
+			id: "side.internal",
+			displayName: "side",
+			kind: "sub",
+			session: null,
+			sessionFile: null,
+			status: "idle",
+		});
+
+		const content = Bun.stripANSI(renderSegment("pi", createFocusedContext("side.internal")).content);
+		expect(content).toContain("side");
+		expect(content).not.toContain("side.internal");
+	});
+
+	it("falls back to the focused id when the ref is unregistered", () => {
+		const content = Bun.stripANSI(renderSegment("pi", createFocusedContext("side.internal")).content);
+		expect(content).toContain("side.internal");
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/move-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/move-command.test.ts
@@ -9,6 +9,7 @@ import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/typ
 function createMoveContext(sourceDir: string, settingsFlush?: () => Promise<void>) {
 	const state = { cwd: sourceDir, movedTo: undefined as string | undefined };
 	const present = vi.fn();
+	const disposeSideConversation = vi.fn(async () => {});
 	const applyCwdChange = vi.fn(async (cwd: string) => {
 		expect(state.cwd).toBe(cwd);
 	});
@@ -16,6 +17,7 @@ function createMoveContext(sourceDir: string, settingsFlush?: () => Promise<void
 		state.cwd = cwd;
 		state.movedTo = cwd;
 	});
+
 	const ctx = {
 		session: { isStreaming: false, moveSession },
 		sessionManager: {
@@ -25,6 +27,7 @@ function createMoveContext(sourceDir: string, settingsFlush?: () => Promise<void
 		settings: {
 			flush: vi.fn(settingsFlush ?? (async () => {})),
 		},
+		disposeSideConversation,
 		showHookCustom: vi.fn(),
 		showHookConfirm: vi.fn(),
 		showError: vi.fn(),
@@ -35,7 +38,7 @@ function createMoveContext(sourceDir: string, settingsFlush?: () => Promise<void
 		ui: { requestRender: vi.fn() },
 		present,
 	} as unknown as InteractiveModeContext;
-	return { ctx, state, present };
+	return { ctx, state, present, disposeSideConversation, moveSession };
 }
 
 describe("CommandController /move", () => {
@@ -49,12 +52,16 @@ describe("CommandController /move", () => {
 		const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-move-source-"));
 		const targetDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-move-target-"));
 		try {
-			const { ctx, state, present } = createMoveContext(sourceDir);
+			const { ctx, state, present, disposeSideConversation, moveSession } = createMoveContext(sourceDir);
 			const controller = new CommandController(ctx);
 
 			await controller.handleMoveCommand(targetDir);
 
 			expect(state.movedTo).toBe(targetDir);
+			expect(disposeSideConversation).toHaveBeenCalledTimes(1);
+			expect(disposeSideConversation.mock.invocationCallOrder[0]).toBeLessThan(
+				moveSession.mock.invocationCallOrder[0],
+			);
 			expect(ctx.sessionManager.dropSession).not.toHaveBeenCalled();
 			expect(ctx.applyCwdChange).toHaveBeenCalledWith(targetDir);
 			expect(ctx.updateEditorBorderColor).toHaveBeenCalled();
@@ -72,7 +79,7 @@ describe("CommandController /move", () => {
 		const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-move-source-"));
 		const targetDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-move-target-"));
 		try {
-			const { ctx, state } = createMoveContext(sourceDir, async () => {
+			const { ctx, state, disposeSideConversation, moveSession } = createMoveContext(sourceDir, async () => {
 				throw new Error("disk full");
 			});
 			const controller = new CommandController(ctx);
@@ -80,7 +87,8 @@ describe("CommandController /move", () => {
 			await controller.handleMoveCommand(targetDir);
 
 			expect(ctx.showError).toHaveBeenCalledWith(expect.stringContaining("disk full"));
-			expect(ctx.session.moveSession).not.toHaveBeenCalled();
+			expect(disposeSideConversation).not.toHaveBeenCalled();
+			expect(moveSession).not.toHaveBeenCalled();
 			expect(ctx.applyCwdChange).not.toHaveBeenCalled();
 			expect(state.movedTo).toBeUndefined();
 			expect(state.cwd).toBe(sourceDir);

--- a/packages/coding-agent/test/modes/controllers/move-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/move-command.test.ts
@@ -99,13 +99,18 @@ describe("CommandController /move", () => {
 	});
 });
 
-function createSwitchContext(sourceDir: string, newSession: (options?: unknown) => Promise<boolean>) {
+function createSwitchContext(
+	sourceDir: string,
+	newSession: (options?: unknown) => Promise<boolean>,
+	fork: (() => Promise<boolean>) | undefined = undefined,
+) {
 	const base = createMoveContext(sourceDir);
 	const session = {
 		isStreaming: false,
 		isCompacting: false,
 		moveSession: base.moveSession,
 		newSession,
+		fork: fork ?? vi.fn(async () => true),
 	};
 	const sessionManager = {
 		getCwd: () => sourceDir,
@@ -114,12 +119,14 @@ function createSwitchContext(sourceDir: string, newSession: (options?: unknown) 
 		dropSession: vi.fn(async () => {}),
 	};
 	const statusLine = { invalidate: vi.fn(), resetActiveTime: vi.fn() };
+	const statusContainer = { disposeChildren: vi.fn() };
 	// Object.assign keeps the existing harness context type while overriding the
 	// members the new-session flow touches (no re-cast needed).
 	Object.assign(base.ctx, {
 		session,
 		sessionManager,
 		statusLine,
+		statusContainer,
 		clearTransientSessionUi: vi.fn(),
 		resetObserverRegistry: vi.fn(),
 		resetTranscript: vi.fn(),
@@ -172,6 +179,52 @@ describe("CommandController /clear and /drop side disposal", () => {
 			await drop;
 
 			expect(disposeSideConversation).toHaveBeenCalledTimes(1);
+		} finally {
+			await fs.rm(sourceDir, { recursive: true, force: true });
+		}
+	});
+
+	it("disposes the side only after a fork commits", async () => {
+		const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-switch-source-"));
+		try {
+			const entered = Promise.withResolvers<void>();
+			const gate = Promise.withResolvers<boolean>();
+			const forkStub = vi.fn(() => {
+				entered.resolve();
+				return gate.promise;
+			});
+			const { ctx, disposeSideConversation } = createSwitchContext(
+				sourceDir,
+				vi.fn(async () => true),
+				forkStub,
+			);
+			const controller = new CommandController(ctx);
+
+			const fork = controller.handleForkCommand();
+			await entered.promise;
+			expect(disposeSideConversation).not.toHaveBeenCalled();
+
+			gate.resolve(true);
+			await fork;
+			expect(disposeSideConversation).toHaveBeenCalledTimes(1);
+		} finally {
+			await fs.rm(sourceDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the side when a fork is refused or cancelled", async () => {
+		const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-switch-source-"));
+		try {
+			const { ctx, disposeSideConversation } = createSwitchContext(
+				sourceDir,
+				vi.fn(async () => true),
+				vi.fn(async () => false),
+			);
+			const controller = new CommandController(ctx);
+
+			await controller.handleForkCommand();
+
+			expect(disposeSideConversation).not.toHaveBeenCalled();
 		} finally {
 			await fs.rm(sourceDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/modes/controllers/move-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/move-command.test.ts
@@ -98,3 +98,82 @@ describe("CommandController /move", () => {
 		}
 	});
 });
+
+function createSwitchContext(sourceDir: string, newSession: (options?: unknown) => Promise<boolean>) {
+	const base = createMoveContext(sourceDir);
+	const session = {
+		isStreaming: false,
+		isCompacting: false,
+		moveSession: base.moveSession,
+		newSession,
+	};
+	const sessionManager = {
+		getCwd: () => sourceDir,
+		getSessionName: () => undefined,
+		getSessionFile: () => path.join(sourceDir, "session.jsonl"),
+		dropSession: vi.fn(async () => {}),
+	};
+	const statusLine = { invalidate: vi.fn(), resetActiveTime: vi.fn() };
+	// Object.assign keeps the existing harness context type while overriding the
+	// members the new-session flow touches (no re-cast needed).
+	Object.assign(base.ctx, {
+		session,
+		sessionManager,
+		statusLine,
+		clearTransientSessionUi: vi.fn(),
+		resetObserverRegistry: vi.fn(),
+		resetTranscript: vi.fn(),
+	});
+	return { ...base, newSession };
+}
+
+describe("CommandController /clear and /drop side disposal", () => {
+	beforeAll(async () => {
+		const theme = await getThemeByName("dark");
+		if (!theme) throw new Error("Expected dark theme");
+		setThemeInstance(theme);
+	});
+
+	it("does not dispose the side when the session switch is cancelled", async () => {
+		const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-switch-source-"));
+		try {
+			const newSession = vi.fn(async () => false);
+			const { ctx, disposeSideConversation } = createSwitchContext(sourceDir, newSession);
+			const controller = new CommandController(ctx);
+
+			await controller.handleClearCommand();
+
+			expect(newSession).toHaveBeenCalledTimes(1);
+			expect(disposeSideConversation).not.toHaveBeenCalled();
+		} finally {
+			await fs.rm(sourceDir, { recursive: true, force: true });
+		}
+	});
+
+	it("disposes the side only after a successful session switch", async () => {
+		const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-switch-source-"));
+		try {
+			const entered = Promise.withResolvers<void>();
+			const gate = Promise.withResolvers<boolean>();
+			const newSession = vi.fn(() => {
+				entered.resolve();
+				return gate.promise;
+			});
+			const { ctx, disposeSideConversation } = createSwitchContext(sourceDir, newSession);
+			const controller = new CommandController(ctx);
+
+			const drop = controller.handleDropCommand();
+			await entered.promise;
+			expect(newSession).toHaveBeenCalledTimes(1);
+			// Not disposed while the switch outcome is pending.
+			expect(disposeSideConversation).not.toHaveBeenCalled();
+
+			gate.resolve(true);
+			await drop;
+
+			expect(disposeSideConversation).toHaveBeenCalledTimes(1);
+		} finally {
+			await fs.rm(sourceDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/move-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/move-command.test.ts
@@ -99,6 +99,12 @@ describe("CommandController /move", () => {
 	});
 });
 
+const pathExists = (target: string) =>
+	fs.stat(target).then(
+		() => true,
+		() => false,
+	);
+
 function createSwitchContext(
 	sourceDir: string,
 	newSession: (options?: unknown) => Promise<boolean>,
@@ -115,9 +121,10 @@ function createSwitchContext(
 	const sessionManager = {
 		getCwd: () => sourceDir,
 		getSessionName: () => undefined,
-		getSessionFile: () => path.join(sourceDir, "session.jsonl"),
+		getSessionFile: vi.fn(() => currentFile),
 		dropSession: vi.fn(async () => {}),
 	};
+	let currentFile = path.join(sourceDir, "session.jsonl");
 	const statusLine = { invalidate: vi.fn(), resetActiveTime: vi.fn() };
 	const statusContainer = { disposeChildren: vi.fn() };
 	// Object.assign keeps the existing harness context type while overriding the
@@ -131,7 +138,13 @@ function createSwitchContext(
 		resetObserverRegistry: vi.fn(),
 		resetTranscript: vi.fn(),
 	});
-	return { ...base, newSession };
+	return {
+		...base,
+		newSession,
+		setCurrentFile: (file: string) => {
+			currentFile = file;
+		},
+	};
 }
 
 describe("CommandController /clear and /drop side disposal", () => {
@@ -225,6 +238,44 @@ describe("CommandController /clear and /drop side disposal", () => {
 			await controller.handleForkCommand();
 
 			expect(disposeSideConversation).not.toHaveBeenCalled();
+		} finally {
+			await fs.rm(sourceDir, { recursive: true, force: true });
+		}
+	});
+
+	it("sweeps copied side transcripts after a fork commits, keeping other artifacts", async () => {
+		const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-switch-source-"));
+		try {
+			const { ctx, disposeSideConversation, setCurrentFile } = createSwitchContext(
+				sourceDir,
+				vi.fn(async () => true),
+			);
+			// Pre-populate the FORKED session's artifact dir (the sweep reads the
+			// post-fork sessionFile): one side transcript with its paired artifact
+			// dir, plus ordinary unrelated artifacts that must survive.
+			const artifactDir = path.join(sourceDir, "forked");
+			const sideFile = path.join(artifactDir, "side.internal-0123abcd.jsonl");
+			const sidePairedDir = path.join(artifactDir, "side.internal-0123abcd");
+			await fs.mkdir(sidePairedDir, { recursive: true });
+			await fs.writeFile(sideFile, "{}\n");
+			await fs.writeFile(path.join(sidePairedDir, "blob"), "x");
+			await fs.writeFile(path.join(artifactDir, "RegularAgent.jsonl"), "{}\n");
+			await fs.writeFile(path.join(artifactDir, "keep.txt"), "keep");
+			const controller = new CommandController(ctx);
+			// fork() switches the session — the sweep must read the FORKED file.
+			const forkStub = vi.fn(async () => {
+				setCurrentFile(path.join(sourceDir, "forked.jsonl"));
+				return true;
+			});
+			Object.assign(ctx.session, { fork: forkStub });
+
+			await controller.handleForkCommand();
+
+			expect(disposeSideConversation).toHaveBeenCalledTimes(1);
+			expect(await pathExists(sideFile)).toBe(false);
+			expect(await pathExists(sidePairedDir)).toBe(false);
+			expect(await pathExists(path.join(artifactDir, "RegularAgent.jsonl"))).toBe(true);
+			expect(await pathExists(path.join(artifactDir, "keep.txt"))).toBe(true);
 		} finally {
 			await fs.rm(sourceDir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionAPI, ExtensionUIContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
@@ -96,7 +97,9 @@ function createSideStub(overrides?: {
 }
 
 function createContext(tempDir: TempDir) {
-	const parentManager = SessionManager.create(tempDir.path());
+	// Isolate the parent session inside the TempDir — the default session dir is
+	// the real user store (~/.omp/agent/sessions), which tests would pollute.
+	const parentManager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), "sessions"));
 	const parentFile = parentManager.getSessionFile();
 	if (!parentFile) throw new Error("parent session file was not created");
 

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -495,4 +495,76 @@ describe("SideController", () => {
 		if (!sideFile) throw new Error("side file path was not captured");
 		expect(fs.existsSync(sideFile)).toBe(false);
 	});
+
+	it("disposes a foreign side and recreates when the parent session changes", async () => {
+		tempDir = TempDir.createSync("@omp-side-foreign-");
+		const harness = createContext(tempDir);
+		const { stub } = createSideStub({ activeToolNames: ["read", "bash"] });
+		const setToolUIContext = vi.fn();
+
+		// Mutable side-file tracker — the createAgentSession spy reads through
+		// this closure to create the file on disk.
+		let currentSideFile: string | undefined;
+		const realForkFrom = SessionManager.forkFrom;
+
+		// Stage 1: Create side from parent A.
+		let forkArgsA: Parameters<typeof SessionManager.forkFrom> | undefined;
+		vi.spyOn(SessionManager, "forkFrom").mockImplementation(async (...args) => {
+			forkArgsA = args;
+			currentSideFile = args[4]?.sessionFile;
+			return realForkFrom(...args);
+		});
+		createAgentSessionSpy(stub, setToolUIContext, () => currentSideFile);
+
+		const controller = new SideController(harness.ctx);
+		await controller.start("question");
+
+		// Side exists from parent A.
+		expect(AgentRegistry.global().get(SIDE_AGENT_ID)).toBeDefined();
+		const sideFileA = currentSideFile;
+		if (!sideFileA) throw new Error("side file A was not created");
+		expect(fs.existsSync(sideFileA)).toBe(true);
+		expect(forkArgsA?.[0]).toBe(harness.parentFile);
+
+		// Simulate a parent-session transition that does NOT invoke this
+		// controller's dispose (SelectorController.handleResumeSession from the
+		// blank /resume picker, handoff): create a second parent in a different
+		// session directory and swap it onto the ctx.
+		const parentB = SessionManager.create(tempDir.path(), path.join(tempDir.path(), "sessions-b"));
+		const parentBFile = parentB.getSessionFile();
+		if (!parentBFile) throw new Error("parent B session file was not created");
+		harness.ctx.sessionManager = parentB;
+
+		// Stage 2: /side again — should detect the foreign side (its file is
+		// in parent A's artifact dir, not parent B's), dispose it, and create
+		// fresh from parent B.
+		let forkArgsB: Parameters<typeof SessionManager.forkFrom> | undefined;
+		vi.spyOn(SessionManager, "forkFrom").mockImplementation(async (...args) => {
+			forkArgsB = args;
+			currentSideFile = args[4]?.sessionFile;
+			return realForkFrom(...args);
+		});
+
+		await controller.start("another question");
+
+		// Old side file (from parent A) is deleted.
+		expect(fs.existsSync(sideFileA)).toBe(false);
+		// New side file (from parent B) exists.
+		const sideFileB = currentSideFile;
+		if (!sideFileB) throw new Error("side file B was not created");
+		expect(fs.existsSync(sideFileB)).toBe(true);
+		// forkFrom received parent B's file, not parent A's.
+		expect(forkArgsB?.[0]).toBe(parentBFile);
+		// The new side file is inside parent B's artifact directory.
+		const parentBArtifactDir = parentBFile.slice(0, -6) + path.sep;
+		expect(sideFileB.startsWith(parentBArtifactDir)).toBe(true);
+		// The old side file was NOT inside parent B's artifact directory.
+		expect(sideFileA.startsWith(parentBArtifactDir)).toBe(false);
+		// The registry holds a live ref (the new side, not the old one).
+		expect(AgentRegistry.global().get(SIDE_AGENT_ID)).toBeDefined();
+
+		// Cleanup.
+		await controller.start("end");
+		expect(AgentRegistry.global().get(SIDE_AGENT_ID)).toBeUndefined();
+	});
 });

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -104,7 +104,13 @@ function createSideStub(overrides?: {
 	};
 }
 
-function createContext(tempDir: TempDir) {
+function createContext(
+	tempDir: TempDir,
+	options?: {
+		toolNames?: string[];
+		mcpTools?: ReadonlyArray<{ name: string; mcpServerName?: string; mcpToolName?: string }>;
+	},
+) {
 	// Isolate the parent session inside the TempDir — the default session dir is
 	// the real user store (~/.omp/agent/sessions), which tests would pollute.
 	const parentManager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), "sessions"));
@@ -117,7 +123,7 @@ function createContext(tempDir: TempDir) {
 		agent: { promptCacheKey: undefined },
 		configuredThinkingLevel: vi.fn(() => undefined),
 		systemPrompt: ["system prompt"],
-		getActiveToolNames: vi.fn(() => ["read", "bash", "task", "hub"]),
+		getEnabledToolNames: vi.fn(() => options?.toolNames ?? ["read", "bash", "task", "hub"]),
 		modelRegistry: { authStorage: { marker: "auth" } },
 		getAgentId: vi.fn(() => undefined),
 	} as unknown as InteractiveModeContext["session"];
@@ -128,11 +134,26 @@ function createContext(tempDir: TempDir) {
 	// focusing into the side, since the ctx type marks focusedAgentId readonly.
 	const focusState: { current: string | undefined } = { current: undefined };
 
+	const mcpManager = options?.mcpTools
+		? {
+				getTools: () =>
+					options.mcpTools?.map(tool => ({
+						name: tool.name,
+						label: tool.name,
+						description: "",
+						parameters: {},
+						strict: false,
+						mcpServerName: tool.mcpServerName ?? "s",
+						mcpToolName: tool.mcpToolName ?? tool.name,
+					})) ?? [],
+			}
+		: undefined;
+
 	const ctx = {
 		session,
 		sessionManager: parentManager,
 		settings,
-		mcpManager: undefined,
+		mcpManager,
 		collabGuest: undefined,
 		get focusedAgentId() {
 			return focusState.current;
@@ -276,7 +297,13 @@ describe("SideController", () => {
 		expect(capturedCreateOpts?.spawns).toBe("");
 		expect(capturedCreateOpts?.taskDepth).toBe(1);
 		expect(capturedCreateOpts?.parentTaskPrefix).toBeUndefined();
-		expect(capturedCreateOpts?.settings).toBe(harness.ctx.settings);
+		// Settings must be an isolated snapshot: parent values preserved, only
+		// compaction.strategy forced to context-full (handoff would strand the side).
+		const sideSettings = capturedCreateOpts?.settings;
+		expect(sideSettings).not.toBe(harness.ctx.settings);
+		expect(sideSettings?.get("compaction.strategy")).toBe("context-full");
+		expect(sideSettings?.get("tools.approvalMode")).toBe(harness.ctx.settings.get("tools.approvalMode"));
+		expect(sideSettings?.get("task.enableLsp")).toBe(true);
 		const toolNames = capturedCreateOpts?.toolNames;
 		expect(toolNames).not.toContain("task");
 		expect(toolNames).not.toContain("hub");
@@ -647,5 +674,42 @@ describe("SideController", () => {
 		// Release the prompt gate and await start — it resolves cleanly.
 		promptGate.resolve();
 		await startPromise;
+	});
+
+	it("inherits xd-mounted tool names and filters MCP proxies to enabled tools", async () => {
+		tempDir = TempDir.createSync("@omp-side-tools-");
+		const harness = createContext(tempDir, {
+			toolNames: ["read", "bash", "task", "hub", "xd_mounted_tool", "mcp__s_enabled"],
+			mcpTools: [{ name: "mcp__s_enabled" }, { name: "mcp__s_disabled" }],
+		});
+		const { stub } = createSideStub({ activeToolNames: ["read", "bash"] });
+
+		let sideFile: string | undefined;
+		const realForkFrom = SessionManager.forkFrom;
+		vi.spyOn(SessionManager, "forkFrom").mockImplementation(async (...args) => {
+			sideFile = args[4]?.sessionFile;
+			return realForkFrom(...args);
+		});
+		let capturedCreateOpts: CreateAgentSessionOptions | undefined;
+		const createSpy = createAgentSessionSpy(stub, vi.fn(), () => sideFile);
+		const origImpl = createSpy.getMockImplementation();
+		if (!origImpl) throw new Error("createAgentSession spy has no implementation");
+		createSpy.mockImplementation(async (options?: CreateAgentSessionOptions) => {
+			if (!options) throw new Error("options required");
+			capturedCreateOpts = options;
+			return origImpl(options);
+		});
+
+		const controller = new SideController(harness.ctx);
+		await controller.start("q");
+
+		// getEnabledToolNames (not getActiveToolNames) drives the grant:
+		// xd-mounted names survive, builtin task/hub are filtered out.
+		expect(capturedCreateOpts?.toolNames).toContain("xd_mounted_tool");
+		expect(capturedCreateOpts?.toolNames).not.toContain("task");
+		expect(capturedCreateOpts?.toolNames).not.toContain("hub");
+		// Only the MCP tool the parent has enabled is proxied; customTools are
+		// always included regardless of the toolNames filter.
+		expect(capturedCreateOpts?.customTools?.map(tool => tool.name)).toEqual(["mcp__s_enabled"]);
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -452,7 +452,7 @@ describe("SideController", () => {
 		// Assert: the side file is gone, deletion was called with the side
 		// file path, and the registry is empty.
 		expect(fs.existsSync(sideFile2)).toBe(false);
-		expect(removeSessionFilesSpy).toHaveBeenCalledWith(sideFile2);
+		expect(removeSessionFilesSpy).toHaveBeenCalledWith(sideFile2, harness2.parentManager.getStorage());
 		expect(AgentRegistry.global().get(SIDE_AGENT_ID)).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -35,6 +35,7 @@ interface SideSessionStub {
 	prompt: () => Promise<void>;
 	dispose: () => Promise<void>;
 	getActiveToolNames: () => string[];
+	clearCheckpointRuntimeState: () => void;
 	systemPrompt: string[];
 }
 
@@ -93,6 +94,7 @@ function createSideStub(overrides?: {
 		prompt: vi.fn(overrides?.prompt ?? (async () => {})),
 		dispose: vi.fn(async () => {}),
 		getActiveToolNames: vi.fn(() => overrides?.activeToolNames ?? ["read", "bash"]),
+		clearCheckpointRuntimeState: vi.fn(),
 		systemPrompt: overrides?.systemPrompt ?? ["system prompt"],
 	};
 	return {
@@ -194,6 +196,7 @@ function createAgentSessionSpy(
 				session: null,
 				sessionFile: sideFile ?? null,
 				status: "running",
+				messageable: options.messageable ?? true,
 			},
 			options.expectedAgentRef ?? null,
 		);
@@ -445,6 +448,7 @@ describe("SideController", () => {
 					session: null,
 					sessionFile: sideFile2 ?? null,
 					status: "running",
+					messageable: options.messageable ?? true,
 				},
 				options.expectedAgentRef ?? null,
 			);
@@ -726,5 +730,60 @@ describe("SideController", () => {
 		expect(harness.ctx.showError).toHaveBeenCalledWith("disk full");
 		expect(forkSpy).not.toHaveBeenCalled();
 		expect(AgentRegistry.global().get(SIDE_AGENT_ID)).toBeUndefined();
+	});
+
+	it("registers the side ref as non-messageable for IRC isolation", async () => {
+		tempDir = TempDir.createSync("@omp-side-messageable-");
+		const harness = createContext(tempDir);
+		const { stub } = createSideStub({ activeToolNames: ["read", "bash"] });
+
+		let capturedCreateOpts: CreateAgentSessionOptions | undefined;
+		let sideFile: string | undefined;
+		const realForkFrom = SessionManager.forkFrom;
+		vi.spyOn(SessionManager, "forkFrom").mockImplementation(async (...args) => {
+			sideFile = args[4]?.sessionFile;
+			return realForkFrom(...args);
+		});
+		const createSpy = createAgentSessionSpy(stub, vi.fn(), () => sideFile);
+		const origImpl = createSpy.getMockImplementation();
+		if (!origImpl) throw new Error("createAgentSession spy has no implementation");
+		createSpy.mockImplementation(async (options?: CreateAgentSessionOptions) => {
+			if (!options) throw new Error("options required");
+			capturedCreateOpts = options;
+			return origImpl(options);
+		});
+
+		const controller = new SideController(harness.ctx);
+		await controller.start("q");
+
+		// The side ref must be non-messageable so peer IRC cannot wake or steer it.
+		expect(capturedCreateOpts?.messageable).toBe(false);
+		const ref = AgentRegistry.global().get(SIDE_AGENT_ID);
+		expect(ref?.messageable).toBe(false);
+
+		await controller.start("end");
+	});
+
+	it("clears inherited checkpoint/rewind state so the side does not rewind to the parent checkpoint", async () => {
+		tempDir = TempDir.createSync("@omp-side-checkpoint-");
+		const harness = createContext(tempDir);
+		const { stub } = createSideStub({ activeToolNames: ["read", "bash"] });
+
+		let sideFile: string | undefined;
+		const realForkFrom = SessionManager.forkFrom;
+		vi.spyOn(SessionManager, "forkFrom").mockImplementation(async (...args) => {
+			sideFile = args[4]?.sessionFile;
+			return realForkFrom(...args);
+		});
+		createAgentSessionSpy(stub, vi.fn(), () => sideFile);
+
+		const controller = new SideController(harness.ctx);
+		await controller.start("q");
+
+		// clearCheckpointRuntimeState must be called exactly once after creation
+		// to reset the parent's active checkpoint that the fork rehydrated.
+		expect(stub.clearCheckpointRuntimeState).toHaveBeenCalledTimes(1);
+
+		await controller.start("end");
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -69,12 +69,19 @@ function createSideStub(overrides?: {
 				options?: { triggerTurn?: boolean; deliverAs?: string },
 			) => {
 				// Mirror the real AgentSession idle + nextTurn + triggerTurn:false
-				// path (agent-session.ts:5666-5673): persist a custom_message entry
-				// via the session manager seam. Re-injection does NOT go through
-				// this path — it calls agent.appendMessage directly — so only the
-				// boundary creation persists a side-boundary entry.
-				if (options?.deliverAs === "nextTurn" && !options?.triggerTurn && overrides?.persistCustomMessage) {
-					overrides.persistCustomMessage({
+				// path (agent-session.ts:5666-5673): append to BOTH the agent
+				// message stream (agent.appendMessage) AND the persisted session
+				// entries (appendCustomMessageEntry). Re-injection does NOT go
+				// through this path — it calls agent.appendMessage directly — so
+				// only the boundary creation reaches both seams, and re-injection
+				// appends to the agent list only (no second persisted entry).
+				if (options?.deliverAs === "nextTurn" && !options?.triggerTurn) {
+					appendMessage({
+						role: "user",
+						content: message.content,
+						attribution: message.attribution,
+					});
+					overrides?.persistCustomMessage?.({
 						customType: message.customType,
 						content: message.content,
 						display: message.display,
@@ -290,6 +297,16 @@ describe("SideController", () => {
 		expect(boundaryEntries[0]?.display).toBe(true);
 		expect(harness.ctx.focusAgentSession).toHaveBeenCalledWith(SIDE_AGENT_ID);
 
+		// Fix 4: The boundary reached the agent message stream too. Production's
+		// idle nextTurn sendCustomMessage appends to BOTH agent.state.messages and
+		// the persisted session entries — the stub mirrors that dual seam, so the
+		// initial boundary must appear in both.
+		const agentBoundaryMessages = appendMessage.mock.calls.filter(([msg]) =>
+			(msg as { content?: string } | undefined)?.content?.includes('<system-notice cause="side-conversation">'),
+		);
+		expect(agentBoundaryMessages).toHaveLength(1);
+		expect((agentBoundaryMessages[0]?.[0] as { role?: string } | undefined)?.role).toBe("user");
+
 		// Snapshot parent entry ids AFTER ensureOnDisk/flush (the create path
 		// already ran them). The parent should not be modified by the side.
 		const parentEntryIds = harness.parentManager.getEntries().map(e => e.id);
@@ -341,6 +358,16 @@ describe("SideController", () => {
 		expect(
 			recordedEntries.filter(e => e.type === "custom_message" && e.customType === SIDE_BOUNDARY_MESSAGE_TYPE),
 		).toHaveLength(1);
+
+		// Fix 4: Re-injection appended a non-visible developer message to the
+		// agent message stream only — the agent list now has two boundary messages
+		// (one user from creation, one developer from re-injection), while the
+		// persisted entries still have exactly one side-boundary entry (above).
+		const agentBoundaryMessagesAfterReinject = appendMessage.mock.calls.filter(([msg]) =>
+			(msg as { content?: string } | undefined)?.content?.includes('<system-notice cause="side-conversation">'),
+		);
+		expect(agentBoundaryMessagesAfterReinject).toHaveLength(2);
+		expect((agentBoundaryMessagesAfterReinject[1]?.[0] as { role?: string } | undefined)?.role).toBe("developer");
 
 		// --- Stage 4: start("end") destroys file + ref, parent entries unchanged ---
 		const sideFile = capturedForkArgs?.[4]?.sessionFile;
@@ -566,5 +593,59 @@ describe("SideController", () => {
 		// Cleanup.
 		await controller.start("end");
 		expect(AgentRegistry.global().get(SIDE_AGENT_ID)).toBeUndefined();
+	});
+
+	it("runs the question submit outside the lifecycle queue so dispose is not blocked by an in-flight prompt", async () => {
+		tempDir = TempDir.createSync("@omp-side-submit-queue-");
+		const harness = createContext(tempDir);
+
+		// Gate the prompt: signal when entered, block until released. This
+		// proves the submit closure runs OUTSIDE the lifecycle queue — if it
+		// were inside, dispose() would queue behind the gated prompt and
+		// could not complete until the gate is released.
+		const promptEntered = Promise.withResolvers<void>();
+		const promptGate = Promise.withResolvers<void>();
+		const promptFn = async () => {
+			promptEntered.resolve();
+			await promptGate.promise;
+		};
+
+		const { stub } = createSideStub({
+			activeToolNames: ["read", "bash"],
+			prompt: promptFn,
+		});
+
+		let sideFile: string | undefined;
+		const realForkFrom = SessionManager.forkFrom;
+		vi.spyOn(SessionManager, "forkFrom").mockImplementation(async (...args) => {
+			sideFile = args[4]?.sessionFile;
+			return realForkFrom(...args);
+		});
+		createAgentSessionSpy(stub, vi.fn(), () => sideFile);
+
+		const controller = new SideController(harness.ctx);
+
+		// Fire start without awaiting — it will block inside the gated prompt.
+		const startPromise = controller.start("question");
+		await promptEntered.promise;
+
+		// The side exists and the prompt has been entered (blocked on the gate).
+		expect(AgentRegistry.global().get(SIDE_AGENT_ID)).toBeDefined();
+		if (!sideFile) throw new Error("side file was not created");
+		expect(fs.existsSync(sideFile)).toBe(true);
+
+		// Fire dispose without awaiting — it must NOT block on the prompt gate.
+		const disposePromise = controller.dispose();
+
+		// Disposal completes BEFORE the prompt gate is released: the submit
+		// runs outside the lifecycle queue, so dispose queues behind the
+		// already-resolved #startImpl, not behind the in-flight prompt.
+		await disposePromise;
+		expect(AgentRegistry.global().get(SIDE_AGENT_ID)).toBeUndefined();
+		expect(fs.existsSync(sideFile)).toBe(false);
+
+		// Release the prompt gate and await start — it resolves cleanly.
+		promptGate.resolve();
+		await startPromise;
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -77,7 +77,7 @@ function createSideStub(overrides?: {
 				// appends to the agent list only (no second persisted entry).
 				if (options?.deliverAs === "nextTurn" && !options?.triggerTurn) {
 					appendMessage({
-						role: "user",
+						role: "custom",
 						content: message.content,
 						attribution: message.attribution,
 					});
@@ -305,7 +305,7 @@ describe("SideController", () => {
 			(msg as { content?: string } | undefined)?.content?.includes('<system-notice cause="side-conversation">'),
 		);
 		expect(agentBoundaryMessages).toHaveLength(1);
-		expect((agentBoundaryMessages[0]?.[0] as { role?: string } | undefined)?.role).toBe("user");
+		expect((agentBoundaryMessages[0]?.[0] as { role?: string } | undefined)?.role).toBe("custom");
 
 		// Snapshot parent entry ids AFTER ensureOnDisk/flush (the create path
 		// already ran them). The parent should not be modified by the side.

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -1,0 +1,496 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ExtensionAPI, ExtensionUIContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
+import { SIDE_AGENT_ID, SideController } from "@oh-my-pi/pi-coding-agent/modes/controllers/side-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
+import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { SIDE_BOUNDARY_MESSAGE_TYPE } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const model = { provider: "anthropic", id: "claude-sonnet-4-5" } as Model;
+
+interface SideSessionEvent {
+	type: string;
+	result?: unknown;
+	aborted?: boolean;
+}
+
+/** The surface of the side-session stub that createAgentSessionSpy passes through. */
+interface SideSessionStub {
+	agent: { appendMessage: (message: unknown) => void };
+	setTodoPhases: (phases: never[]) => void;
+	subscribe: (listener: (event: SideSessionEvent) => void) => () => void;
+	sendCustomMessage: (
+		message: { customType?: string; content?: unknown; display?: boolean; attribution?: string },
+		options?: { triggerTurn?: boolean; deliverAs?: string },
+	) => Promise<void>;
+	prompt: () => Promise<void>;
+	dispose: () => Promise<void>;
+	getActiveToolNames: () => string[];
+	systemPrompt: string[];
+}
+
+/** Minimal side session stub covering the surface SideController drives. */
+function createSideStub(overrides?: {
+	prompt?: () => Promise<void>;
+	systemPrompt?: string[];
+	activeToolNames?: string[];
+	/** Called by sendCustomMessage on the idle nextTurn path, mirroring
+	 * AgentSession's sessionManager.appendCustomMessageEntry persistence seam. */
+	persistCustomMessage?: (entry: {
+		customType: string | undefined;
+		content: unknown;
+		display: boolean | undefined;
+		attribution: string | undefined;
+	}) => void;
+}) {
+	const appendMessage = vi.fn();
+	let listener: ((event: SideSessionEvent) => void) | undefined;
+	const stub = {
+		agent: { appendMessage },
+		setTodoPhases: vi.fn(),
+		subscribe: vi.fn((l: (event: SideSessionEvent) => void) => {
+			listener = l;
+			return () => {
+				listener = undefined;
+			};
+		}),
+		sendCustomMessage: vi.fn(
+			async (
+				message: { customType?: string; content?: unknown; display?: boolean; attribution?: string },
+				options?: { triggerTurn?: boolean; deliverAs?: string },
+			) => {
+				// Mirror the real AgentSession idle + nextTurn + triggerTurn:false
+				// path (agent-session.ts:5666-5673): persist a custom_message entry
+				// via the session manager seam. Re-injection does NOT go through
+				// this path — it calls agent.appendMessage directly — so only the
+				// boundary creation persists a side-boundary entry.
+				if (options?.deliverAs === "nextTurn" && !options?.triggerTurn && overrides?.persistCustomMessage) {
+					overrides.persistCustomMessage({
+						customType: message.customType,
+						content: message.content,
+						display: message.display,
+						attribution: message.attribution,
+					});
+				}
+			},
+		),
+		prompt: vi.fn(overrides?.prompt ?? (async () => {})),
+		dispose: vi.fn(async () => {}),
+		getActiveToolNames: vi.fn(() => overrides?.activeToolNames ?? ["read", "bash"]),
+		systemPrompt: overrides?.systemPrompt ?? ["system prompt"],
+	};
+	return {
+		stub,
+		appendMessage,
+		get compactionListener() {
+			return listener;
+		},
+	};
+}
+
+function createContext(tempDir: TempDir) {
+	const parentManager = SessionManager.create(tempDir.path());
+	const parentFile = parentManager.getSessionFile();
+	if (!parentFile) throw new Error("parent session file was not created");
+
+	const session = {
+		model,
+		sessionId: "parent-session",
+		agent: { promptCacheKey: undefined },
+		configuredThinkingLevel: vi.fn(() => undefined),
+		systemPrompt: ["system prompt"],
+		getActiveToolNames: vi.fn(() => ["read", "bash", "task", "hub"]),
+		modelRegistry: { authStorage: { marker: "auth" } },
+		getAgentId: vi.fn(() => undefined),
+	} as unknown as InteractiveModeContext["session"];
+
+	const settings = Settings.isolated({ "task.enableLsp": true });
+	const uiContext = { marker: "ui-context" } as unknown as ExtensionUIContext;
+	// Mutable focus holder: tests flip it after creation to simulate the user
+	// focusing into the side, since the ctx type marks focusedAgentId readonly.
+	const focusState: { current: string | undefined } = { current: undefined };
+
+	const ctx = {
+		session,
+		sessionManager: parentManager,
+		settings,
+		mcpManager: undefined,
+		collabGuest: undefined,
+		get focusedAgentId() {
+			return focusState.current;
+		},
+		showStatus: vi.fn(),
+		showError: vi.fn(),
+		focusAgentSession: vi.fn(async () => {}),
+		unfocusSession: vi.fn(async () => {}),
+		getToolUIContext: vi.fn(() => uiContext),
+		withLocalSubmission: vi.fn(async (_text: string, fn: () => Promise<unknown>) => fn()),
+		updatePendingMessagesDisplay: vi.fn(),
+		ui: { requestRender: vi.fn() },
+	} as unknown as InteractiveModeContext;
+
+	return { tempDir, parentManager, parentFile, ctx, uiContext, focusState };
+}
+
+/**
+ * Build a createAgentSession spy that simulates the SDK registration protocol:
+ * registerIfAvailable with expectedAgentRef:null, create the side file on disk,
+ * attach the session, set status to idle, and return a CreateAgentSessionResult.
+ */
+function createAgentSessionSpy(
+	stub: SideSessionStub,
+	setToolUIContext: (ctx: unknown, focused: boolean) => void,
+	sideFileFromManager: () => string | undefined,
+) {
+	return vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async (options?: CreateAgentSessionOptions) => {
+		if (!options) throw new Error("options required");
+		const registry = AgentRegistry.global();
+		const sideFile = sideFileFromManager();
+		const ref = registry.registerIfAvailable(
+			{
+				id: SIDE_AGENT_ID,
+				displayName: options.agentDisplayName ?? "side",
+				kind: "sub",
+				parentId: options.parentAgentId,
+				session: null,
+				sessionFile: sideFile ?? null,
+				status: "running",
+			},
+			options.expectedAgentRef ?? null,
+		);
+		if (!ref) {
+			throw new Error(`Agent "${SIDE_AGENT_ID}" is already owned by another session generation.`);
+		}
+		// Create the side file on disk so removeSessionFiles can delete it.
+		if (sideFile) {
+			const dir = sideFile.slice(0, -6);
+			fs.mkdirSync(dir, { recursive: true });
+			fs.writeFileSync(
+				sideFile,
+				`${JSON.stringify({ type: "session", id: "side", timestamp: "2025-01-01T00:00:00Z", cwd: "." })}\n`,
+			);
+		}
+		// Attach the live session (simulating sdk.ts:3380-3386).
+		registry.attachSession(SIDE_AGENT_ID, stub as unknown as AgentSession, sideFile ?? null, ref);
+		registry.setStatus(SIDE_AGENT_ID, "idle");
+		return {
+			session: stub,
+			setToolUIContext,
+			extensionsResult: { extensions: [], runtime: {}, errors: [] },
+			eventBus: { emit: vi.fn(), on: vi.fn() },
+		} as unknown as CreateAgentSessionResult;
+	});
+}
+
+describe("SideController", () => {
+	let tempDir: TempDir;
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		AgentRegistry.resetGlobalForTests();
+		if (tempDir) tempDir.removeSync();
+	});
+
+	it("walks the full lifecycle: create, boundary, compaction re-injection, end, queue serialization", async () => {
+		tempDir = TempDir.createSync("@omp-side-controller-");
+		const harness = createContext(tempDir);
+
+		// Recording side manager: models the persistence seam the production code
+		// writes through. sendCustomMessage's idle nextTurn path calls
+		// appendCustomMessageEntry (as AgentSession does at agent-session.ts:5667);
+		// the controller calls appendCustomEntry directly for todo clearing. Both
+		// record here so the test asserts on persisted entries, not mock call counts.
+		const recordedEntries: Array<{ type: "custom_message" | "custom"; customType?: string; display?: boolean }> = [];
+		const appendCustomMessageEntry = vi.fn(
+			(customType?: string, _content?: unknown, display?: boolean, _details?: unknown, _attribution?: string) => {
+				recordedEntries.push({ type: "custom_message", customType, display });
+			},
+		);
+		const appendCustomEntry = vi.fn((customType: string) => {
+			recordedEntries.push({ type: "custom", customType });
+		});
+
+		const sideStub = createSideStub({
+			activeToolNames: ["read", "bash"],
+			persistCustomMessage: ({ customType, content, display, attribution }) =>
+				appendCustomMessageEntry(customType, content, display, undefined, attribution),
+		});
+		const { stub, appendMessage } = sideStub;
+		const setToolUIContext = vi.fn();
+
+		// --- Stage 1: Create path ---
+		let capturedForkArgs: Parameters<typeof SessionManager.forkFrom> | undefined;
+		vi.spyOn(SessionManager, "forkFrom").mockImplementation(async (...args) => {
+			capturedForkArgs = args;
+			const opts = args[4];
+			const sideFile = opts?.sessionFile;
+			return {
+				getSessionFile: () => sideFile,
+				appendCustomEntry,
+				appendCustomMessageEntry,
+				appendSessionInit: vi.fn(),
+			} as unknown as SessionManager;
+		});
+
+		let capturedCreateOpts: CreateAgentSessionOptions | undefined;
+		const createSpy = createAgentSessionSpy(stub, setToolUIContext, () => {
+			const opts = capturedForkArgs?.[4];
+			return opts?.sessionFile;
+		});
+		const origImpl = createSpy.getMockImplementation();
+		if (!origImpl) throw new Error("createAgentSession spy has no implementation");
+		createSpy.mockImplementation(async (options?: CreateAgentSessionOptions) => {
+			if (!options) throw new Error("options required");
+			capturedCreateOpts = options;
+			return origImpl(options);
+		});
+
+		const controller = new SideController(harness.ctx);
+		await controller.start("what changed");
+
+		// Stage 1: forkFrom received the parent file and a Side-*.jsonl.
+		expect(capturedForkArgs?.[0]).toBe(harness.parentFile);
+		expect(capturedForkArgs?.[4]?.sessionFile).toMatch(/Side-[0-9a-f]+\.jsonl$/);
+
+		// Stage 1: createAgentSession received the exact field set.
+		expect(capturedCreateOpts?.expectedAgentRef).toBeNull();
+		expect(capturedCreateOpts?.hasUI).toBe(true);
+		expect(capturedCreateOpts?.spawns).toBe("");
+		expect(capturedCreateOpts?.taskDepth).toBe(1);
+		expect(capturedCreateOpts?.parentTaskPrefix).toBeUndefined();
+		expect(capturedCreateOpts?.settings).toBe(harness.ctx.settings);
+		const toolNames = capturedCreateOpts?.toolNames;
+		expect(toolNames).not.toContain("task");
+		expect(toolNames).not.toContain("hub");
+
+		// Stage 1: setToolUIContext called exactly once with the
+		// ctx.getToolUIContext() result and true — hasUI:true alone would pass
+		// while prompt-gated tools still failed closed.
+		expect(setToolUIContext).toHaveBeenCalledTimes(1);
+		expect(setToolUIContext).toHaveBeenCalledWith(harness.uiContext, true);
+
+		// --- Stage 2: Boundary persisted + focus called ---
+		// Assert on the persisted session entries (the real seam), not on mock
+		// call counts. Exactly one visible side-boundary custom_message entry.
+		const boundaryEntries = recordedEntries.filter(
+			e => e.type === "custom_message" && e.customType === SIDE_BOUNDARY_MESSAGE_TYPE,
+		);
+		expect(boundaryEntries).toHaveLength(1);
+		expect(boundaryEntries[0]?.display).toBe(true);
+		expect(harness.ctx.focusAgentSession).toHaveBeenCalledWith(SIDE_AGENT_ID);
+
+		// Snapshot parent entry ids AFTER ensureOnDisk/flush (the create path
+		// already ran them). The parent should not be modified by the side.
+		const parentEntryIds = harness.parentManager.getEntries().map(e => e.id);
+
+		// --- Stage 3: Both compaction re-injection paths ---
+
+		const appendCountBefore = appendMessage.mock.calls.length;
+		// 3a: auto_compaction_end path — emit through the session subscriber.
+		sideStub.compactionListener?.({ type: "auto_compaction_end", result: {}, aborted: false });
+		expect(appendMessage.mock.calls.length).toBe(appendCountBefore + 1);
+		expect(appendMessage.mock.calls[appendMessage.mock.calls.length - 1]?.[0]).toEqual(
+			expect.objectContaining({
+				role: "developer",
+				content: expect.stringContaining('<system-notice cause="side-conversation">'),
+			}),
+		);
+		// No second persisted side-boundary entry — re-injection appends a
+		// plain developer message to agent state, not a custom_message entry.
+		expect(
+			recordedEntries.filter(e => e.type === "custom_message" && e.customType === SIDE_BOUNDARY_MESSAGE_TYPE),
+		).toHaveLength(1);
+
+		// 3b: session_compact path — invoke the registered extension handler.
+		// The inline extension factory was passed to createAgentSession; since
+		// the spy doesn't load extensions, capture and invoke it manually.
+		const extensionFactories = capturedCreateOpts?.extensions ?? [];
+		expect(extensionFactories.length).toBeGreaterThan(0);
+		const compactHandlers: Array<() => void> = [];
+		const fakeApi = {
+			on: ((event: string, handler: () => void) => {
+				if (event === "session_compact") compactHandlers.push(handler);
+			}) as Partial<ExtensionAPI["on"]> as ExtensionAPI["on"],
+		} as unknown as ExtensionAPI;
+		for (const factory of extensionFactories) {
+			await factory(fakeApi);
+		}
+		expect(compactHandlers).toHaveLength(1);
+
+		const appendCountBeforeManual = appendMessage.mock.calls.length;
+		const compactHandler = compactHandlers[0];
+		if (!compactHandler) throw new Error("session_compact handler was not registered");
+		compactHandler();
+		expect(appendMessage.mock.calls.length).toBe(appendCountBeforeManual + 1);
+		expect(appendMessage.mock.calls[appendMessage.mock.calls.length - 1]?.[0]).toEqual(
+			expect.objectContaining({
+				role: "developer",
+				content: expect.stringContaining('<system-notice cause="side-conversation">'),
+			}),
+		);
+		// Still no second persisted side-boundary entry.
+		expect(
+			recordedEntries.filter(e => e.type === "custom_message" && e.customType === SIDE_BOUNDARY_MESSAGE_TYPE),
+		).toHaveLength(1);
+
+		// --- Stage 4: start("end") destroys file + ref, parent entries unchanged ---
+		const sideFile = capturedForkArgs?.[4]?.sessionFile;
+		if (!sideFile) throw new Error("side file path was not captured");
+		expect(fs.existsSync(sideFile)).toBe(true);
+
+		await controller.start("end");
+
+		expect(fs.existsSync(sideFile)).toBe(false);
+		expect(AgentRegistry.global().get(SIDE_AGENT_ID)).toBeUndefined();
+		// Parent entry ids unchanged — the side conversation never wrote to the parent.
+		expect(harness.parentManager.getEntries().map(e => e.id)).toEqual(parentEntryIds);
+
+		// --- Stage 5: Queue serialization ---
+		// Reset spies for the serialization test.
+		vi.restoreAllMocks();
+		AgentRegistry.resetGlobalForTests();
+
+		const harness2 = createContext(tempDir);
+		const stub2 = createSideStub({ activeToolNames: ["read", "bash"] });
+		const setToolUIContext2 = vi.fn();
+		const gate = Promise.withResolvers<void>();
+		const createStarted = Promise.withResolvers<void>();
+
+		let capturedForkArgs2: Parameters<typeof SessionManager.forkFrom> | undefined;
+		vi.spyOn(SessionManager, "forkFrom").mockImplementation(async (...args) => {
+			capturedForkArgs2 = args;
+			const sideFile2 = args[4]?.sessionFile;
+			return {
+				getSessionFile: () => sideFile2,
+				appendCustomEntry: vi.fn(),
+				appendSessionInit: vi.fn(),
+			} as unknown as SessionManager;
+		});
+
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async (options?: CreateAgentSessionOptions) => {
+			if (!options) throw new Error("options required");
+			createStarted.resolve();
+			const registry = AgentRegistry.global();
+			const sideFile2 = capturedForkArgs2?.[4]?.sessionFile;
+			const ref = registry.registerIfAvailable(
+				{
+					id: SIDE_AGENT_ID,
+					displayName: "side",
+					kind: "sub",
+					parentId: options.parentAgentId,
+					session: null,
+					sessionFile: sideFile2 ?? null,
+					status: "running",
+				},
+				options.expectedAgentRef ?? null,
+			);
+			if (!ref) {
+				throw new Error(`Agent "${SIDE_AGENT_ID}" is already owned by another session generation.`);
+			}
+			if (sideFile2) {
+				const dir = sideFile2.slice(0, -6);
+				fs.mkdirSync(dir, { recursive: true });
+				fs.writeFileSync(
+					sideFile2,
+					`${JSON.stringify({ type: "session", id: "side", timestamp: "2025-01-01T00:00:00Z", cwd: "." })}\n`,
+				);
+			}
+			// Block on the gate — simulate a slow createAgentSession.
+			await gate.promise;
+			registry.attachSession(SIDE_AGENT_ID, stub2.stub as unknown as AgentSession, sideFile2 ?? null, ref);
+			registry.setStatus(SIDE_AGENT_ID, "idle");
+			return {
+				session: stub2.stub,
+				setToolUIContext: setToolUIContext2,
+				extensionsResult: { extensions: [], runtime: {}, errors: [] },
+				eventBus: { emit: vi.fn(), on: vi.fn() },
+			} as unknown as CreateAgentSessionResult;
+		});
+
+		// Spy on the static deletion method — restored in afterEach. Calls
+		// through to the real implementation so the file is actually deleted.
+		const removeSessionFilesSpy = vi.spyOn(SessionManager, "removeSessionFiles");
+
+		const controller2 = new SideController(harness2.ctx);
+
+		// Fire start (do not await) — it will block inside createAgentSession.
+		const startPromise = controller2.start("q");
+		await createStarted.promise;
+
+		// The side file was created by the create spy before blocking on the gate.
+		const sideFile2 = capturedForkArgs2?.[4]?.sessionFile;
+		if (!sideFile2) throw new Error("side file path was not captured (stage 5)");
+		expect(fs.existsSync(sideFile2)).toBe(true);
+
+		// Fire dispose (do not await) — it queues behind start.
+		const disposePromise = controller2.dispose();
+
+		// Assert: dispose has NOT cleaned up while create is blocked.
+		// The file still exists and the registry ref is untouched (running).
+		expect(fs.existsSync(sideFile2)).toBe(true);
+		const refDuringCreate = AgentRegistry.global().get(SIDE_AGENT_ID);
+		expect(refDuringCreate).toBeDefined();
+		expect(refDuringCreate?.status).toBe("running");
+		// Deletion has NOT been attempted — proves dispose() is queued, not
+		// running concurrently and declining to delete.
+		expect(removeSessionFilesSpy).not.toHaveBeenCalled();
+
+		// Resolve the gate — create finishes, then dispose runs.
+		gate.resolve();
+		await startPromise;
+		await disposePromise;
+
+		// Assert: the side file is gone, deletion was called with the side
+		// file path, and the registry is empty.
+		expect(fs.existsSync(sideFile2)).toBe(false);
+		expect(removeSessionFilesSpy).toHaveBeenCalledWith(sideFile2);
+		expect(AgentRegistry.global().get(SIDE_AGENT_ID)).toBeUndefined();
+	});
+
+	it("unfocuses a focused side before disposal unregisters it", async () => {
+		tempDir = TempDir.createSync("@omp-side-focused-");
+		const harness = createContext(tempDir);
+		const { stub } = createSideStub({ activeToolNames: ["read", "bash"] });
+
+		// Wrap the real forkFrom so the side manager (and its file) is real;
+		// only the path is captured for the assertions.
+		let sideFile: string | undefined;
+		const realForkFrom = SessionManager.forkFrom;
+		vi.spyOn(SessionManager, "forkFrom").mockImplementation(async (...args) => {
+			sideFile = args[4]?.sessionFile;
+			return realForkFrom(...args);
+		});
+		createAgentSessionSpy(stub, vi.fn(), () => sideFile);
+
+		// Record the ordering of unfocus vs. file deletion.
+		const order: string[] = [];
+		harness.ctx.unfocusSession = vi.fn(async () => {
+			order.push("unfocus");
+		});
+		const realRemove = SessionManager.removeSessionFiles;
+		vi.spyOn(SessionManager, "removeSessionFiles").mockImplementation(async (sessionPath: string) => {
+			order.push("delete");
+			return realRemove(sessionPath);
+		});
+
+		const controller = new SideController(harness.ctx);
+		await controller.start("question");
+		// Simulate the user focused into the side (the focus stub is inert, so
+		// the ctx still reports unfocused until flipped).
+		harness.focusState.current = SIDE_AGENT_ID;
+		await controller.dispose();
+
+		// Unfocus must precede the file deletion; the ref and file are gone.
+		expect(order).toEqual(["unfocus", "delete"]);
+		expect(AgentRegistry.global().get(SIDE_AGENT_ID)).toBeUndefined();
+		if (!sideFile) throw new Error("side file path was not captured");
+		expect(fs.existsSync(sideFile)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -713,4 +713,18 @@ describe("SideController", () => {
 		// always included regardless of the toolNames filter.
 		expect(capturedCreateOpts?.customTools?.map(tool => tool.name)).toEqual(["mcp__s_enabled"]);
 	});
+
+	it("surfaces parent persistence failures without starting creation", async () => {
+		tempDir = TempDir.createSync("@omp-side-flush-");
+		const harness = createContext(tempDir);
+		const forkSpy = vi.spyOn(SessionManager, "forkFrom");
+		vi.spyOn(harness.parentManager, "ensureOnDisk").mockRejectedValueOnce(new Error("disk full"));
+
+		const controller = new SideController(harness.ctx);
+		await controller.start("what changed");
+
+		expect(harness.ctx.showError).toHaveBeenCalledWith("disk full");
+		expect(forkSpy).not.toHaveBeenCalled();
+		expect(AgentRegistry.global().get(SIDE_AGENT_ID)).toBeUndefined();
+	});
 });

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -258,9 +258,9 @@ describe("SideController", () => {
 		const controller = new SideController(harness.ctx);
 		await controller.start("what changed");
 
-		// Stage 1: forkFrom received the parent file and a Side-*.jsonl.
+		// Stage 1: forkFrom received the parent file and a side.internal-*.jsonl.
 		expect(capturedForkArgs?.[0]).toBe(harness.parentFile);
-		expect(capturedForkArgs?.[4]?.sessionFile).toMatch(/Side-[0-9a-f]+\.jsonl$/);
+		expect(capturedForkArgs?.[4]?.sessionFile).toMatch(/side\.internal-[0-9a-f]+\.jsonl$/);
 
 		// Stage 1: createAgentSession received the exact field set.
 		expect(capturedCreateOpts?.expectedAgentRef).toBeNull();

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -293,20 +293,18 @@ describe("SideController", () => {
 		// already ran them). The parent should not be modified by the side.
 		const parentEntryIds = harness.parentManager.getEntries().map(e => e.id);
 
-		// --- Stage 3: Both compaction re-injection paths ---
+		// --- Stage 3: Boundary re-injection after compaction ---
 
+		// 3a: The controller no longer subscribes to the session event stream —
+		// automatic compaction's "auto_compaction_end" event must NOT re-inject.
+		// The single mechanism is the inline "session_compact" extension handler,
+		// which covers both manual and automatic compaction (both emit
+		// "session_compact" on success). Assert no subscriber was registered,
+		// and that emitting the event (a no-op with no listener) adds no message.
+		expect(sideStub.compactionListener).toBeUndefined();
 		const appendCountBefore = appendMessage.mock.calls.length;
-		// 3a: auto_compaction_end path — emit through the session subscriber.
 		sideStub.compactionListener?.({ type: "auto_compaction_end", result: {}, aborted: false });
-		expect(appendMessage.mock.calls.length).toBe(appendCountBefore + 1);
-		expect(appendMessage.mock.calls[appendMessage.mock.calls.length - 1]?.[0]).toEqual(
-			expect.objectContaining({
-				role: "developer",
-				content: expect.stringContaining('<system-notice cause="side-conversation">'),
-			}),
-		);
-		// No second persisted side-boundary entry — re-injection appends a
-		// plain developer message to agent state, not a custom_message entry.
+		expect(appendMessage.mock.calls.length).toBe(appendCountBefore);
 		expect(
 			recordedEntries.filter(e => e.type === "custom_message" && e.customType === SIDE_BOUNDARY_MESSAGE_TYPE),
 		).toHaveLength(1);

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -297,6 +297,7 @@ describe("SideController", () => {
 		expect(capturedCreateOpts?.spawns).toBe("");
 		expect(capturedCreateOpts?.taskDepth).toBe(1);
 		expect(capturedCreateOpts?.parentTaskPrefix).toBeUndefined();
+		expect(capturedCreateOpts?.initializeCapabilitySettings).toBe(false);
 		// Settings must be an isolated snapshot: parent values preserved, only
 		// compaction.strategy forced to context-full (handoff would strand the side).
 		const sideSettings = capturedCreateOpts?.settings;

--- a/packages/coding-agent/test/modes/controllers/side-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/side-controller.test.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionAPI, ExtensionUIContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
-import { SIDE_AGENT_ID, SideController } from "@oh-my-pi/pi-coding-agent/modes/controllers/side-controller";
+import { SideController } from "@oh-my-pi/pi-coding-agent/modes/controllers/side-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
@@ -12,6 +12,7 @@ import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SIDE_BOUNDARY_MESSAGE_TYPE } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { SIDE_AGENT_ID } from "@oh-my-pi/pi-coding-agent/session/side-conversation";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 const model = { provider: "anthropic", id: "claude-sonnet-4-5" } as Model;

--- a/packages/coding-agent/test/registry/persisted-agents.test.ts
+++ b/packages/coding-agent/test/registry/persisted-agents.test.ts
@@ -46,9 +46,6 @@ describe("registerPersistedSubagents", () => {
 		const sideFile = path.join(artifactDir, `${sideStem}.jsonl`);
 		const sideArtifactDir = path.join(artifactDir, sideStem);
 		writeJsonl(sideFile);
-		// The mtime guard only deletes files proven to predate this process, so
-		// the abandoned fixture must be older than the runner's timeOrigin.
-		fs.utimesSync(sideFile, new Date(0), new Date(0));
 		fs.mkdirSync(sideArtifactDir, { recursive: true });
 		fs.writeFileSync(path.join(sideArtifactDir, "marker.txt"), "abandoned");
 		writeJsonl(path.join(artifactDir, "RegularAgent.jsonl"));
@@ -59,28 +56,23 @@ describe("registerPersistedSubagents", () => {
 		// absence proves the exclusion — not a malformed-fixture artifact.
 		expect(AgentRegistry.global().get(sideStem)).toBeUndefined();
 		expect(AgentRegistry.global().get("RegularAgent")).toBeDefined();
-		// Abandoned side transcripts (and their artifact dirs) are deleted during
-		// the scan so crashed leftovers do not linger on disk forever.
-		expect(fs.existsSync(sideFile)).toBe(false);
-		expect(fs.existsSync(sideArtifactDir)).toBe(false);
+		// Side files are skipped, never deleted: a second process opening the Hub
+		// cannot tell another process's live side from an abandoned one, so the
+		// scan must leave every side file on disk.
+		expect(fs.existsSync(sideFile)).toBe(true);
+		expect(fs.existsSync(sideArtifactDir)).toBe(true);
 	});
 
-	it("keeps fresh unowned and live-owned side files during the scan", async () => {
+	it("does not re-register a live-owned side file", async () => {
 		tempDir = TempDir.createSync("@omp-persisted-scan-live-");
 		parentManager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), "sessions"));
 		const parentFile = parentManager.getSessionFile();
 		if (!parentFile) throw new Error("parent session file was not created");
 
 		const artifactDir = parentFile.slice(0, -6);
-		// Fresh unowned file (mtime now): may be an initializing fork, not garbage.
-		const freshStem = `${SIDE_SESSION_FILE_PREFIX}f1e57unowned`;
-		const freshFile = path.join(artifactDir, `${freshStem}.jsonl`);
-		writeJsonl(freshFile);
-		// Old but owned by a live ref: owned beats the mtime guard.
 		const ownedStem = `${SIDE_SESSION_FILE_PREFIX}0123owned89abcdef`;
 		const ownedFile = path.join(artifactDir, `${ownedStem}.jsonl`);
 		writeJsonl(ownedFile);
-		fs.utimesSync(ownedFile, new Date(0), new Date(0));
 		AgentRegistry.global().register({
 			id: "side.internal",
 			displayName: "side",
@@ -92,9 +84,9 @@ describe("registerPersistedSubagents", () => {
 
 		await registerPersistedSubagents(AgentRegistry.global(), parentFile);
 
-		expect(fs.existsSync(freshFile)).toBe(true);
-		expect(fs.existsSync(ownedFile)).toBe(true);
-		expect(AgentRegistry.global().get(freshStem)).toBeUndefined();
+		// Skipped like any side file: no second ref under the stem, file intact.
 		expect(AgentRegistry.global().get(ownedStem)).toBeUndefined();
+		expect(fs.existsSync(ownedFile)).toBe(true);
+		expect(AgentRegistry.global().get("side.internal")).toBeDefined();
 	});
 });

--- a/packages/coding-agent/test/registry/persisted-agents.test.ts
+++ b/packages/coding-agent/test/registry/persisted-agents.test.ts
@@ -43,7 +43,11 @@ describe("registerPersistedSubagents", () => {
 
 		const artifactDir = parentFile.slice(0, -6);
 		const sideStem = `${SIDE_SESSION_FILE_PREFIX}0123456789abcdef`;
-		writeJsonl(path.join(artifactDir, `${sideStem}.jsonl`));
+		const sideFile = path.join(artifactDir, `${sideStem}.jsonl`);
+		const sideArtifactDir = path.join(artifactDir, sideStem);
+		writeJsonl(sideFile);
+		fs.mkdirSync(sideArtifactDir, { recursive: true });
+		fs.writeFileSync(path.join(sideArtifactDir, "marker.txt"), "abandoned");
 		writeJsonl(path.join(artifactDir, "RegularAgent.jsonl"));
 
 		await registerPersistedSubagents(AgentRegistry.global(), parentFile);
@@ -52,5 +56,9 @@ describe("registerPersistedSubagents", () => {
 		// absence proves the exclusion — not a malformed-fixture artifact.
 		expect(AgentRegistry.global().get(sideStem)).toBeUndefined();
 		expect(AgentRegistry.global().get("RegularAgent")).toBeDefined();
+		// Abandoned side transcripts (and their artifact dirs) are deleted during
+		// the scan so crashed leftovers do not linger on disk forever.
+		expect(fs.existsSync(sideFile)).toBe(false);
+		expect(fs.existsSync(sideArtifactDir)).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/registry/persisted-agents.test.ts
+++ b/packages/coding-agent/test/registry/persisted-agents.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { registerPersistedSubagents } from "@oh-my-pi/pi-coding-agent/registry/persisted-agents";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { SIDE_SESSION_FILE_PREFIX } from "@oh-my-pi/pi-coding-agent/session/side-conversation";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function writeJsonl(file: string): void {
+	const header = JSON.stringify({ type: "session", version: 3, id: "s", timestamp: "t", cwd: "/tmp" });
+	const init = JSON.stringify({
+		type: "session_init",
+		id: "e1",
+		parentId: null,
+		timestamp: "t",
+		systemPrompt: "sys",
+		task: "work",
+		tools: [],
+	});
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, `${header}\n${init}\n`);
+}
+
+describe("registerPersistedSubagents", () => {
+	let tempDir: TempDir | undefined;
+	let parentManager: SessionManager | undefined;
+
+	afterEach(async () => {
+		AgentRegistry.resetGlobalForTests();
+		await parentManager?.close();
+		parentManager = undefined;
+		tempDir?.removeSync();
+		tempDir = undefined;
+	});
+
+	it("skips side conversation files but registers other persisted subagents", async () => {
+		tempDir = TempDir.createSync("@omp-persisted-scan-");
+		// Isolate under the TempDir — the default session dir is the real user store.
+		parentManager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), "sessions"));
+		const parentFile = parentManager.getSessionFile();
+		if (!parentFile) throw new Error("parent session file was not created");
+
+		const artifactDir = parentFile.slice(0, -6);
+		const sideStem = `${SIDE_SESSION_FILE_PREFIX}0123456789abcdef`;
+		writeJsonl(path.join(artifactDir, `${sideStem}.jsonl`));
+		writeJsonl(path.join(artifactDir, "RegularAgent.jsonl"));
+
+		await registerPersistedSubagents(AgentRegistry.global(), parentFile);
+
+		// The side file would be revivable (it carries session_init), so its
+		// absence proves the exclusion — not a malformed-fixture artifact.
+		expect(AgentRegistry.global().get(sideStem)).toBeUndefined();
+		expect(AgentRegistry.global().get("RegularAgent")).toBeDefined();
+	});
+});

--- a/packages/coding-agent/test/registry/persisted-agents.test.ts
+++ b/packages/coding-agent/test/registry/persisted-agents.test.ts
@@ -46,6 +46,9 @@ describe("registerPersistedSubagents", () => {
 		const sideFile = path.join(artifactDir, `${sideStem}.jsonl`);
 		const sideArtifactDir = path.join(artifactDir, sideStem);
 		writeJsonl(sideFile);
+		// The mtime guard only deletes files proven to predate this process, so
+		// the abandoned fixture must be older than the runner's timeOrigin.
+		fs.utimesSync(sideFile, new Date(0), new Date(0));
 		fs.mkdirSync(sideArtifactDir, { recursive: true });
 		fs.writeFileSync(path.join(sideArtifactDir, "marker.txt"), "abandoned");
 		writeJsonl(path.join(artifactDir, "RegularAgent.jsonl"));
@@ -60,5 +63,38 @@ describe("registerPersistedSubagents", () => {
 		// the scan so crashed leftovers do not linger on disk forever.
 		expect(fs.existsSync(sideFile)).toBe(false);
 		expect(fs.existsSync(sideArtifactDir)).toBe(false);
+	});
+
+	it("keeps fresh unowned and live-owned side files during the scan", async () => {
+		tempDir = TempDir.createSync("@omp-persisted-scan-live-");
+		parentManager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), "sessions"));
+		const parentFile = parentManager.getSessionFile();
+		if (!parentFile) throw new Error("parent session file was not created");
+
+		const artifactDir = parentFile.slice(0, -6);
+		// Fresh unowned file (mtime now): may be an initializing fork, not garbage.
+		const freshStem = `${SIDE_SESSION_FILE_PREFIX}f1e57unowned`;
+		const freshFile = path.join(artifactDir, `${freshStem}.jsonl`);
+		writeJsonl(freshFile);
+		// Old but owned by a live ref: owned beats the mtime guard.
+		const ownedStem = `${SIDE_SESSION_FILE_PREFIX}0123owned89abcdef`;
+		const ownedFile = path.join(artifactDir, `${ownedStem}.jsonl`);
+		writeJsonl(ownedFile);
+		fs.utimesSync(ownedFile, new Date(0), new Date(0));
+		AgentRegistry.global().register({
+			id: "side.internal",
+			displayName: "side",
+			kind: "sub",
+			session: null,
+			sessionFile: ownedFile,
+			status: "running",
+		});
+
+		await registerPersistedSubagents(AgentRegistry.global(), parentFile);
+
+		expect(fs.existsSync(freshFile)).toBe(true);
+		expect(fs.existsSync(ownedFile)).toBe(true);
+		expect(AgentRegistry.global().get(freshStem)).toBeUndefined();
+		expect(AgentRegistry.global().get(ownedStem)).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -169,6 +169,20 @@ describe("FileSessionStorage.deleteSessionWithArtifacts", () => {
 		expect(fs.existsSync(artifactsDir)).toBe(false);
 	});
 
+	it("removes artifact directory when the session file is already gone", async () => {
+		const sessionPath = path.join(tempDir, "orphan-artifacts.jsonl");
+		const artifactsDir = sessionPath.slice(0, -6);
+		await fsp.mkdir(artifactsDir, { recursive: true });
+		await Bun.write(path.join(artifactsDir, "artifact.txt"), "artifact payload");
+
+		expect(fs.existsSync(sessionPath)).toBe(false);
+		expect(fs.existsSync(artifactsDir)).toBe(true);
+
+		await expect(storage.deleteSessionWithArtifacts(sessionPath)).resolves.toBeUndefined();
+		expect(fs.existsSync(sessionPath)).toBe(false);
+		expect(fs.existsSync(artifactsDir)).toBe(false);
+	});
+
 	it("throws when artifact cleanup fails after the session file is deleted", async () => {
 		const sessionPath = await createSessionFile("cleanup-failure");
 		const artifactsDir = sessionPath.slice(0, -6);

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -201,6 +201,72 @@ describe("FileSessionStorage.deleteSessionWithArtifacts", () => {
 	});
 });
 
+describe("IndexedSessionStorage.deleteSessionWithArtifacts", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-indexed-delete-"));
+	});
+
+	afterEach(async () => {
+		await fsp.rm(tempDir, { recursive: true, force: true });
+	});
+
+	/** Simple non-blocking in-memory backend for delete tests. */
+	class InMemoryBackend implements SessionStorageBackend {
+		readonly #files = new Map<string, string>();
+		init(): Promise<void> {
+			return Promise.resolve();
+		}
+		loadIndex(): Promise<Iterable<SessionStorageIndexEntry>> {
+			return Promise.resolve([]);
+		}
+		readFull(p: string): Promise<string | null> {
+			return Promise.resolve(this.#files.get(p) ?? null);
+		}
+		readSlices(): Promise<[string, string]> {
+			return Promise.resolve(["", ""]);
+		}
+		async writeFull(p: string, content: string): Promise<void> {
+			this.#files.set(p, content);
+		}
+		async append(p: string, line: string): Promise<void> {
+			this.#files.set(p, (this.#files.get(p) ?? "") + line);
+		}
+		updateSessionTitle(): Promise<void> {
+			return Promise.resolve();
+		}
+		truncate(): Promise<void> {
+			return Promise.resolve();
+		}
+		async remove(paths: string[]): Promise<void> {
+			for (const p of paths) this.#files.delete(p);
+		}
+		move(): Promise<void> {
+			return Promise.resolve();
+		}
+	}
+
+	it("removes the physical artifact directory alongside backend keys", async () => {
+		const sessionPath = path.join(tempDir, "side.jsonl");
+		const artifactsDir = sessionPath.slice(0, -6);
+		const backend = new InMemoryBackend();
+		const storage = new IndexedSessionStorage(backend);
+		await storage.initialize();
+		await storage.writeText(sessionPath, "session body\n");
+		// Simulate ArtifactManager spilling tool output to the physical dir.
+		await fsp.mkdir(artifactsDir, { recursive: true });
+		await Bun.write(path.join(artifactsDir, "artifact.txt"), "spilled output");
+
+		expect(fs.existsSync(artifactsDir)).toBe(true);
+
+		await storage.deleteSessionWithArtifacts(sessionPath);
+
+		expect(storage.existsSync(sessionPath)).toBe(false);
+		expect(fs.existsSync(artifactsDir)).toBe(false);
+	});
+});
+
 describe("FileSessionStorage.writeTextSync", () => {
 	let tempDir: string;
 

--- a/packages/coding-agent/test/slash-commands/side.test.ts
+++ b/packages/coding-agent/test/slash-commands/side.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+
+function createRuntime() {
+	const handleSideCommand = vi.fn(async () => {});
+	const setText = vi.fn();
+	const addToHistory = vi.fn();
+	return {
+		handleSideCommand,
+		setText,
+		runtime: {
+			ctx: {
+				editor: { setText, addToHistory } as Partial<
+					InteractiveModeContext["editor"]
+				> as InteractiveModeContext["editor"],
+				handleSideCommand,
+			} as Partial<InteractiveModeContext> as InteractiveModeContext,
+		},
+	};
+}
+
+describe("/side slash command", () => {
+	it("routes the question through the side handler and clears the editor", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/side which deps are unused", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.setText).toHaveBeenCalledWith("");
+		expect(harness.handleSideCommand).toHaveBeenCalledWith("which deps are unused");
+	});
+
+	it("reaches the create-and-focus path with no question on a blank invocation", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/side   ", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.setText).toHaveBeenCalledWith("");
+		expect(harness.handleSideCommand).toHaveBeenCalledWith("");
+	});
+
+	it("passes the end subcommand through the allowArgs gate as an argument", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/side end", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.setText).toHaveBeenCalledWith("");
+		expect(harness.handleSideCommand).toHaveBeenCalledWith("end");
+	});
+});

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -36,6 +36,7 @@ function createRef(sessionFile: string): AgentRef {
 		sessionFile,
 		createdAt: 0,
 		lastActivity: 0,
+		messageable: true,
 	};
 }
 

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -666,6 +666,42 @@ describe("IRC", () => {
 			expect(peerIds).not.toContain("0-Main/advisor");
 		});
 
+		it("op=list hides non-messageable refs from the peer roster", async () => {
+			const sub = makeFakeSession();
+			registry.register({ id: "0-Worker", displayName: "task", kind: "sub", session: sub.session });
+			registry.register({
+				id: "0-Side",
+				displayName: "side",
+				kind: "sub",
+				session: makeFakeSession().session,
+				messageable: false,
+			});
+
+			const tool = new HubTool(makeToolSession(registry, "0-Main"));
+			const result = await tool.execute("call-1", { op: "list" });
+			const details = result.details as CoordinationDetails | undefined;
+			const peerIds = details?.peers?.map(peer => peer.id) ?? [];
+			expect(peerIds).toContain("0-Worker");
+			expect(peerIds).not.toContain("0-Side");
+		});
+
+		it("op=send to a non-messageable ref fails with 'not messageable'", async () => {
+			registry.register({
+				id: "0-Side",
+				displayName: "side",
+				kind: "sub",
+				session: makeFakeSession().session,
+				messageable: false,
+			});
+
+			const tool = new HubTool(makeToolSession(registry, "0-Main"));
+			const result = await tool.execute("call-1", { op: "send", to: "0-Side", message: "ping" });
+			const details = result.details as CoordinationDetails | undefined;
+			expect(details?.receipts).toEqual([
+				{ to: "0-Side", outcome: "failed", error: 'Agent "0-Side" is not messageable.' },
+			]);
+		});
+
 		it("op=send returns receipts immediately without waiting for a reply", async () => {
 			const sub = makeFakeSession();
 			registry.register({ id: "0-Sub", displayName: "task", kind: "sub", session: sub.session });


### PR DESCRIPTION
## What

`/side [question]` opens a throwaway side conversation forked from the current session: a full multi-turn conversation with tools, focused in the TUI, and destroyed on `/side end`. The side never appends entries to the parent session's transcript.

## Why

There is currently no way to talk to the agent about the live session without writing into it. `/btw` answers a single question with no tools and no follow-up; `/tan` forks the session but runs in the background with no interaction. A side conversation is the missing middle: inherited history as reference-only context (marked by a boundary rule in the transcript), full tools minus `task` and `hub`, and a lifecycle that guarantees cleanup.

Construction composes two existing halves — `/tan`'s fork (`SessionManager.forkFrom` + `createAgentSession`) and the focus controller's attach/teardown — through a new `SideController`. Deliberate decisions a reviewer won't see in the diff:

- **Esc keeps the side alive; only `/side end`, a session transition, or shutdown destroys it.** Codex's `/side` discards on return; a single accidental Esc would otherwise destroy a long exploration. Disposal is deferred until transitions actually commit: `/move`, `/clear`, `/drop`, and `/fork` only discard the side after their cancellable validation and `session_before_switch` hooks pass. `/side end` also works while the side is focused (routed through the focused-input gate).
- **The side keeps the user's own approval mode and settings** (not `/tan`'s subagent-yolo rewrite), gets `hasUI` plus the live tool UI context so approvals prompt exactly as in main, drops `task` and `hub` from the tool list, sets an empty spawn policy (closing `eval`'s `agent()` bridge), omits `parentTaskPrefix` (managed background jobs are refused rather than outliving the side), forwards the parent's extension paths so extension-registered tools rebind, and lets the SDK rebuild the system prompt against the filtered tool set rather than inheriting a prompt rendered with `task`/`hub` instructions. The parent session's storage backend is threaded into the fork and cleanup, so `/side` also works for SQL/Redis-backed sessions.
- **Concurrency model:** the SDK pre-registers agent refs with `session: null` before async init, so a null-session `running` ref is *in progress*, not stale. `start()`/`dispose()` serialize lifecycle operations through a promise queue (question submits run outside it, so disposal can interrupt a live side turn); every registry read classifies refs and validates the fork's parentage (a side left over from a previous parent session is disposed and recreated, never silently reused); disposal is a reclassifying loop over fresh reads with a single deletion path; `dispose()` never rejects (shutdown and transitions await it). The registry id is the collision-proof `side.internal` (task-id sanitization can never produce it); the status badge renders the display name, not the id.
- **The boundary** is one persisted, visible `side-boundary` entry. After any successful compaction it is re-injected once as a plain non-visible developer message via a single inline `session_compact` extension handler, which covers both manual and automatic compaction.
- **Persistence hygiene:** side files (`side.internal-<snowflake>.jsonl`) are excluded from the persisted-subagent scan so a crashed side never cold-revives without its controller — and are never deleted by the scan, because no cheap cross-process liveness check exists (a second process opening the Hub could otherwise destroy the first's live side).
- Accepted trade-offs, documented in code: an externally created in-flight `Side` registration (e.g. agent-hub revival of a parked ref) is never unregistered or deleted by `dispose()`; a side inherited from a different-backend session may not be deletable through the current backend; and the shared local-protocol mapping can go stale after a later session switch — a scoped SDK-layer fix left for a follow-up.

## Testing

- `bun check` passes (biome + tsgo + rust, exit 0).
- New tests: `/side` routing (3 cases), a lifecycle suite (construction options incl. `setToolUIContext`, persisted boundary, compaction re-injection, end disposal, queue serialization, focused-dispose ordering, parent-swap revalidation, create-generation revalidation), transition-ordering tests for move/clear/drop/fork (no disposal on cancelled or refused transitions), and persisted-scan exclusion tests (side files never registered, never deleted). Sibling `tan-command-controller`, `session-storage`, `move-command`, input-controller, and status-line suites pass.
- Headless storage smoke: real 500-entry parent session, real `forkFrom`, real side jsonl, real dispose — the already-flushed smoke parent remained byte-identical across create+end, side file and `Side-<id>/` artifact dir removed, registry empty, exactly one persisted `display: true` boundary entry. `forkFrom` on the 500-entry parent: 12.3 ms.
- Interactive TUI smoke (real session, Opus 5): boundary rule and `side` badge render, tools work in the side (read/bash), multi-turn, focused slash refusal, Esc returns to main, bare `/side` re-enters the same conversation with the boundary re-rendered, `/side end` prints `Side conversation ended` then `No side conversation to end`, `/side end` also works *while focused* (routed, not refused), `/new` teardown is clean, and the parent session file stayed byte-identical with zero side files left behind.
- Not covered: the resume/btw-branch disposal sites still run before their `session_before_switch` hook (interposing requires core session changes; parentage validation covers the aftermath).

**Verification notes**: `bun check` passes (exit 0) and every focused suite covering this change passes (side routing/lifecycle, transition ordering, persisted scan, storage, status line, slash commands, registry). Two test areas fail identically on clean `upstream/main` in this environment, not from this change: `interactive-mode-still-closing.test.ts` (fails on base) and process-spawning suites (`tools/launch.test.ts` daemon tests, `extensions-runner.test.ts`) which cannot start daemons/native addons in this sandbox on either tree.

**Known follow-ups** (acknowledged in review, deliberately not in this PR): side artifact-id resolution vs. the parent's artifact space — side artifacts write to their own generation subdir (no parent overwrite possible), but artifact-id resolution via the shared mapping can return a same-id parent artifact; adopting the parent's allocator would fix resolution but breaks the delete-on-end contract, so this needs a view-aware resolution design; Hindsight/Mnemopi and `preloadedCustomToolPaths` forwarding (siblings of the shipped extension-paths fix); side ref idle/running status sync in Agent Hub (display-only); the stale local-protocol mapping after a switch; extension-runner runtime initialization for inherited extensions (executor.ts:3106 shape); reapplying the inherited enabled tool set via `setActiveToolsByName` (MCP proxies already filtered; extension/custom tools need the same); `MemorySessionStorage.deleteSessionWithArtifacts` is a no-op (memory-backed sessions retain side transcripts); SDK-constructor-provided `systemPrompt` is not carried into the side's rebuilt prompt (settings-based overrides flow through the snapshot); bash advertises async mode in manager-less sessions (the throw is the intended refusal).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

