### PR TITLE
fix(tui): preserve loop after cancelling iteration

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Esc during a streaming `/loop` iteration pausing the loop instead of only aborting the current turn ([#7329](https://github.com/can1357/oh-my-pi/issues/7329)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -327,10 +327,10 @@ export class InputController {
 			}
 
 			if (this.ctx.loopModeEnabled) {
-				this.ctx.pauseLoop();
 				if (this.ctx.session.isStreaming) {
 					this.#abortStreamingTurn();
 				} else {
+					this.ctx.pauseLoop();
 					this.ctx.cancelPendingSubmission();
 				}
 				return;

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -368,6 +368,37 @@ describe("InputController escape behavior", () => {
 		expect(spies.abort).toHaveBeenCalledWith({ reason: USER_INTERRUPT_LABEL });
 	});
 
+	it("aborts a streaming loop iteration without pausing the loop", () => {
+		const { ctx, editor, spies } = createContext();
+		const pauseLoop = vi.fn();
+		ctx.loopModeEnabled = true;
+		ctx.pauseLoop = pauseLoop;
+		mutableSessionState(ctx).isStreaming = true;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(pauseLoop).not.toHaveBeenCalled();
+		expect(spies.cancelPendingSubmission).not.toHaveBeenCalled();
+		expect(spies.abort).toHaveBeenCalledWith({ reason: USER_INTERRUPT_LABEL });
+	});
+
+	it("pauses an idle loop and cancels its pending submission", () => {
+		const { ctx, editor, spies } = createContext();
+		const pauseLoop = vi.fn();
+		ctx.loopModeEnabled = true;
+		ctx.pauseLoop = pauseLoop;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(pauseLoop).toHaveBeenCalledTimes(1);
+		expect(spies.cancelPendingSubmission).toHaveBeenCalledTimes(1);
+		expect(spies.abort).not.toHaveBeenCalled();
+	});
+
 	it("aborts active handoff generation before default Esc handling", () => {
 		const { ctx, editor, spies } = createContext();
 		(ctx.viewSession as { isGeneratingHandoff: boolean }).isGeneratingHandoff = true;


### PR DESCRIPTION
## Repro
With `/loop` running and the repeated turn streaming, press Esc. The loop pauses because its prompt is cleared before the active turn aborts. The regression is reproduced by `bun test packages/coding-agent/test/input-controller-escape.test.ts`, which failed with 33 passing and 1 failing test because `pauseLoop()` was called during streaming.

## Cause
`InputController.setupKeyHandlers()` in `packages/coding-agent/src/modes/controllers/input-controller.ts` handled `loopModeEnabled` by calling `pauseLoop()` before checking `session.isStreaming`; `InteractiveMode.pauseLoop()` clears `loopPrompt`, so no next iteration remained to schedule after abort.

## Fix
- Abort an active streaming loop iteration without pausing or clearing its prompt.
- Preserve idle Esc behavior by pausing the loop and cancelling its pending submission.
- Cover both streaming and idle branches in `input-controller-escape.test.ts`, and document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/input-controller-escape.test.ts` passes: 34 tests, 0 failures, 107 assertions. `bun run check:types` passes for `packages/coding-agent`. The pre-publish `bun run fix` and `bun check` gate also passed.

Fixes #7329