### PR TITLE
feat(task): persist logical subagent run lifecycle timing

### DIFF
--- a/docs/tools/task.md
+++ b/docs/tools/task.md
@@ -97,12 +97,13 @@ Artifacts and side channels:
 12. `runSubprocess(...)` creates a child agent session with an isolated settings snapshot (parent settings inherited — `async.enabled` and `bash.autoBackground.enabled` are **inherited** from the parent, not force-disabled; `tier.openai`/`tier.anthropic`/`tier.google` are re-resolved through `tier.subagent`; `tools.approvalMode` is forced to `yolo` because headless subagents have no UI to confirm prompts against; `advisor.enabled` is forced off unless the spawn opts in per agent; per-spawn overrides may disable read summarization and clear extra workspace roots for isolated runs), child `agentId` equal to the allocated id, child internal URL router/`AgentOutputManager`, output schema, the shared `context` (batch calls) in the system prompt's `CONTEXT` section, and the IRC peer roster in the system prompt.
 13. Child tool availability: explicit `agent.tools` if provided; auto-add `task` when the agent has `spawns` and depth allows; strip `task` at `task.maxRecursionDepth`; ensure `hub` is present in explicit tool lists; expand `exec` to `eval` + `bash`; strip parent-owned `todo` — unless the spawn is prewalk-armed, whose plan nudge + todo gate need the child to commit its own todo list before the model hand-off.
 14. The child must finish through the hidden `yield` tool; up to 3 reminder prompts, the last forcing `toolChoice = yield` when supported. `finalizeSubprocessOutput(...)` reconciles raw text, `yield` payloads, structured schemas, and abort states.
-15. End-of-run lifecycle (keep-alive, in the run finalizer):
+15. Logical run lifecycle is independent from session retention: `initial`, `follow_up`, and `irc_wake` executions emit versioned start/terminal payloads with a unique `runId`, epoch boundaries, and monotonic `durationMs`. The parent session persists the same payloads as `task_subagent_lifecycle` custom entries, so task completion does not depend on a later idle-TTL park or process disposal.
+16. End-of-run lifecycle (keep-alive, in the run finalizer):
     - caller signal, wall-clock timeout, or internal hard abort → registry status `aborted`, session disposed — terminal;
     - soft-request-budget abort on a non-isolated kept-alive agent → treated as resumable: the agent becomes `idle` and may receive a follow-up/revival;
     - isolated run → status `parked` without a reviver (workspace is merged + cleaned, so the session is not revivable; transcript stays readable via `history://`), then session disposed and detached;
     - everything else (success and failure alike) → status `idle` with the live session attached, and `AgentLifecycleManager.global().adopt(id, { idleTtlMs, revive })` arms the park timer. The reviver reopens the session JSONL.
-16. Lifecycle thereafter: `idle` agents are parked after `task.agentIdleTtlMs` (session disposed; `AgentRef` + session file retained); messaging (`hub`) or the Agent Hub revives them back to `idle`. `"Main"` is never parked.
+17. Lifecycle thereafter: `idle` agents are parked after `task.agentIdleTtlMs` (session disposed; `AgentRef` + session file retained); messaging (`hub`) or the Agent Hub revives them back to `idle`. `"Main"` is never parked.
 
 ## Modes / Variants
 - Execution mode
@@ -131,7 +132,7 @@ Artifacts and side channels:
   - Creates child `AgentSession` instances with isolated settings snapshots; finished sessions stay registered in the process-global `AgentRegistry` as `idle`/`parked` until process teardown or explicit release.
   - With `async.enabled=true`, registers one async job per spawn in `session.asyncJobManager`; completion is injected into the parent as an async-result message.
   - Arms idle-TTL timers in `AgentLifecycleManager` (unref'd; they never hold the process open).
-  - Emits `task:subagent:event`, `task:subagent:progress`, and `task:subagent:lifecycle` on the parent event bus.
+  - Emits `task:subagent:event`, `task:subagent:progress`, and versioned `task:subagent:lifecycle` payloads on the parent event bus; persists the lifecycle payloads as `task_subagent_lifecycle` custom entries.
   - Allocates session-scoped output ids through `AgentOutputManager` so `agent://` stays unique across invocations.
   - Shares the parent `local://` root and `ArtifactManager` with subagents.
 - Background work / cancellation

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added versioned start and terminal lifecycle boundaries for each initial, follow-up, and IRC-wake subagent run, including unique run IDs and monotonic durations, with task runs persisted in the live parent session independently of retained child-session lifetime. ([#7334](https://github.com/can1357/oh-my-pi/pull/7334) by [@usr-bin-roygbiv](https://github.com/usr-bin-roygbiv))
+
 ## [17.3.2] - 2026-08-13
 
 ### Fixed

--- a/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-subagents.ts
@@ -183,12 +183,14 @@ export class RpcSubagentRegistry {
 		const existing = this.#subagents.get(payload.id);
 		if (existing && !hasSameOwner(payload, existing)) return;
 		if (!existing && payload.status !== "started") return;
+		if (existing && payload.status !== "started" && existing.runId !== payload.runId) return;
 		if (payload.status === "started") {
 			this.#staleSubagentIds.delete(payload.id);
 		}
 		const sessionFile = payload.sessionFile ?? existing?.sessionFile;
 		const snapshot: RpcSubagentSnapshot = {
 			id: payload.id,
+			runId: payload.runId,
 			index: payload.index,
 			agent: payload.agent,
 			agentSource: payload.agentSource,
@@ -218,10 +220,12 @@ export class RpcSubagentRegistry {
 		const existing = this.#subagents.get(progress.id);
 		if (!existing) return;
 		if (!hasSameOwner(payload, existing)) return;
+		if (existing.runId !== payload.runId) return;
 		const sessionFile = payload.sessionFile ?? existing?.sessionFile;
 		this.#rememberTranscriptSession(progress.id, sessionFile);
 		this.#subagents.set(progress.id, {
 			id: progress.id,
+			runId: payload.runId,
 			index: payload.index,
 			agent: payload.agent,
 			agentSource: payload.agentSource,

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -166,6 +166,7 @@ export type RpcSubagentSubscriptionLevel = "off" | "progress" | "events";
 
 export interface RpcSubagentSnapshot {
 	id: string;
+	runId: string;
 	index: number;
 	agent: string;
 	agentSource: AgentProgress["agentSource"];

--- a/packages/coding-agent/src/modes/session-observer-registry.ts
+++ b/packages/coding-agent/src/modes/session-observer-registry.ts
@@ -4,6 +4,8 @@ import type { EventBus } from "../utils/event-bus";
 
 export interface ObservableSession {
 	id: string;
+	/** Active logical run id; absent for the main session and progress-only snapshots. */
+	runId?: string;
 	kind: "main" | "subagent";
 	label: string;
 	agent?: string;
@@ -153,10 +155,14 @@ export class SessionObserverRegistry {
 				const status = STATUS_MAP[payload.status];
 				if (!status) return;
 
+				const existing = this.#sessions.get(payload.id);
+				if (existing?.runId !== undefined && payload.status !== "started" && existing.runId !== payload.runId)
+					return;
+
 				const sortOrder = this.#ensureSortOrder(payload.id);
 				this.#ensureParentSortOrder(payload.parentToolCallId, sortOrder);
-				const existing = this.#sessions.get(payload.id);
 				if (existing) {
+					existing.runId = payload.runId;
 					existing.status = status;
 					existing.lastUpdate = Date.now();
 					existing.index = payload.index;
@@ -167,6 +173,7 @@ export class SessionObserverRegistry {
 				} else {
 					this.#sessions.set(payload.id, {
 						id: payload.id,
+						runId: payload.runId,
 						kind: "subagent",
 						label: payload.description ?? `Subagent #${payload.index}`,
 						agent: payload.agent,
@@ -189,10 +196,12 @@ export class SessionObserverRegistry {
 				const progress = payload.progress;
 				const id = progress.id;
 				const existing = this.#sessions.get(id);
+				if (existing?.runId !== undefined && existing.runId !== payload.runId) return;
 
 				const sortOrder = this.#ensureSortOrder(id);
 				this.#ensureParentSortOrder(payload.parentToolCallId, sortOrder);
 				if (existing) {
+					existing.runId = payload.runId;
 					existing.lastUpdate = Date.now();
 					existing.index = payload.index;
 					existing.parentToolCallId = payload.parentToolCallId ?? existing.parentToolCallId;
@@ -203,6 +212,7 @@ export class SessionObserverRegistry {
 				} else {
 					this.#sessions.set(id, {
 						id,
+						runId: payload.runId,
 						kind: "subagent",
 						label: progress.description ?? `Subagent #${payload.index}`,
 						agent: payload.agent,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -62,6 +62,11 @@ import type { WorkspaceTree } from "../workspace-tree";
 import { generateTaskLabel } from "./label";
 import { resolveAgentPrewalkDefault } from "./prewalk";
 import { isReadOnlyAgent } from "./read-only-policy";
+import {
+	createSubagentLifecycleEmitter,
+	createSubagentLifecycleRun,
+	type SubagentLifecycleRun,
+} from "./subagent-lifecycle";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
 import {
 	type AgentDefinition,
@@ -72,6 +77,7 @@ import {
 	type StructuredSubagentOutput,
 	type StructuredSubagentSchemaMode,
 	type StructuredSubagentSchemaSource,
+	type SubagentLifecyclePayload,
 	TASK_SUBAGENT_EVENT_CHANNEL,
 	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
 	TASK_SUBAGENT_PROGRESS_CHANNEL,
@@ -113,6 +119,16 @@ export function resolveSoftRequestBudget(agentName: string, configuredBudget: nu
 	const normalized = Math.max(0, Math.trunc(configuredBudget));
 	if (normalized === 0) return 0;
 	return Math.min(normalized, SOFT_REQUEST_BUDGET[agentName] ?? normalized);
+}
+
+function lifecycleEmitter(
+	eventBus?: EventBus,
+	recordLifecycle?: (payload: SubagentLifecyclePayload) => void,
+): (payload: SubagentLifecyclePayload) => void {
+	return createSubagentLifecycleEmitter({
+		emitEvent: eventBus ? payload => eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, payload) : undefined,
+		appendEntry: recordLifecycle ? (_customType, payload) => recordLifecycle(payload) : undefined,
+	});
 }
 
 /** Extra requests allowed after a budget stop for the forced yield to land before the run is hard-aborted. */
@@ -427,6 +443,8 @@ export interface ExecutorOptions {
 	persistArtifacts?: boolean;
 	artifactsDir?: string;
 	eventBus?: EventBus;
+	/** Persist versioned run boundaries independently from the retained child session lifetime. */
+	recordLifecycle?: (payload: SubagentLifecyclePayload) => void;
 	contextFiles?: ContextFileEntry[];
 	skills?: Skill[];
 	promptTemplates?: PromptTemplate[];
@@ -913,6 +931,8 @@ const MAX_YIELD_TOOL_ERRORS = 6;
 /** Inputs for the run monitor driving one subagent assignment. */
 interface RunMonitorArgs {
 	index: number;
+	/** Logical run id; set after initial session startup creates its lifecycle boundary. */
+	runId?: string;
 	id: string;
 	agent: AgentDefinition;
 	task: string;
@@ -984,6 +1004,8 @@ interface SubagentRunMonitor {
 	resolveSignalAbortReason(): string;
 	resolveAbortReasonText(): string;
 	setActiveSession(session: AgentSession | null): void;
+	/** Bind progress frames to the logical lifecycle run they describe. */
+	setRunId(runId: string): void;
 	/** Return and clear the active session reference. */
 	takeActiveSession(): AgentSession | null;
 	/** Subscribe the monitor to a session's events. Returns the unsubscribe function. */
@@ -1021,6 +1043,7 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		maxRuntimeMs,
 	} = args;
 	const startTime = Date.now();
+	let runId = args.runId;
 
 	const progress: AgentProgress = {
 		index,
@@ -1256,8 +1279,10 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		const activityGist =
 			progress.lastIntent ?? (progress.currentTool ? `running ${progress.currentTool}` : undefined);
 		if (activityGist) AgentRegistry.global().setActivity(id, activityGist);
-		if (args.eventBus) {
+		const activeRunId = runId;
+		if (args.eventBus && activeRunId) {
 			args.eventBus.emit(TASK_SUBAGENT_PROGRESS_CHANNEL, {
+				runId: activeRunId,
 				index,
 				agent: agent.name,
 				agentSource: agent.source,
@@ -1819,6 +1844,9 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		waitForActiveSessionAbort,
 		resolveSignalAbortReason,
 		resolveAbortReasonText,
+		setRunId: value => {
+			runId = value;
+		},
 		setActiveSession: session => {
 			activeSession = session;
 		},
@@ -2123,10 +2151,7 @@ interface FinalizeRunArgs {
 	outputSchemaSource?: StructuredSubagentSchemaSource;
 	signal?: AbortSignal;
 	artifactsDir?: string;
-	eventBus?: EventBus;
-	parentToolCallId?: string;
-	detached?: boolean;
-	sessionFile?: string;
+	lifecycleRun?: SubagentLifecycleRun;
 	startTime: number;
 }
 
@@ -2229,20 +2254,9 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 	progress.status = wasAborted ? "aborted" : exitCode === 0 ? "completed" : "failed";
 	monitor.scheduleProgress(true);
 
-	// Emit lifecycle end event after finalization so yield status is reflected
-	if (args.eventBus) {
-		args.eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
-			id,
-			agent: agent.name,
-			parentToolCallId: args.parentToolCallId,
-			detached: args.detached,
-			agentSource: agent.source,
-			description: progress.description,
-			status: progress.status as "completed" | "failed" | "aborted",
-			sessionFile: args.sessionFile,
-			index,
-		});
-	}
+	const completedAt = Date.now();
+	const lifecycle = args.lifecycleRun?.complete(progress.status as "completed" | "failed" | "aborted", completedAt);
+	const durationMs = lifecycle?.durationMs ?? Math.max(0, completedAt - args.startTime);
 
 	return {
 		index,
@@ -2258,7 +2272,7 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 		stderr,
 		truncated: Boolean(truncated),
 		...(finalized.structuredOutput ? { structuredOutput: finalized.structuredOutput } : {}),
-		durationMs: Date.now() - args.startTime,
+		durationMs,
 		tokens: progress.tokens,
 		requests: progress.requests,
 		contextTokens: progress.contextTokens,
@@ -2289,6 +2303,7 @@ export interface IrcWakeTurnMonitorOptions {
 	/** Explicit pre-expansion model role alias selected for this run. */
 	modelRole?: string;
 	eventBus?: EventBus;
+	recordLifecycle?: (payload: SubagentLifecyclePayload) => void;
 	parentToolCallId?: string;
 	/** Fallback session file when the registry ref carries none. */
 	sessionFile?: string;
@@ -2324,13 +2339,29 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 				.filter(Boolean)
 				.join("\n\n") || "IRC follow-up";
 		const turnStartTime = Date.now();
+		const turnStartedMonotonicAt = performance.now();
 		const sessionFile = AgentRegistry.global().get(id)?.sessionFile ?? options.sessionFile ?? undefined;
+		const lifecycleRun = createSubagentLifecycleRun({
+			id,
+			agent: agent.name,
+			agentSource: agent.source,
+			index,
+			runKind: "irc_wake",
+			description: options.description,
+			sessionFile,
+			parentToolCallId: options.parentToolCallId,
+			detached: true,
+			startedAt: turnStartTime,
+			startedMonotonicAt: turnStartedMonotonicAt,
+			emit: lifecycleEmitter(options.eventBus, options.recordLifecycle),
+		});
 		const turnMonitor = createSubagentRunMonitor({
 			index,
 			id,
 			agent,
 			task: ircTask,
 			description: options.description,
+			runId: lifecycleRun.started.runId,
 			modelOverride: options.modelOverride,
 			modelRole: options.modelRole,
 			eventBus: options.eventBus,
@@ -2341,20 +2372,6 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 			softRequestBudgetNotice: false,
 			maxRuntimeMs,
 		});
-
-		if (options.eventBus) {
-			options.eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
-				id,
-				agent: agent.name,
-				parentToolCallId: options.parentToolCallId,
-				detached: true,
-				agentSource: agent.source,
-				description: options.description,
-				status: "started",
-				sessionFile,
-				index,
-			});
-		}
 
 		turnMonitor.setActiveSession(session);
 		const unsubscribeTurn = turnMonitor.attach(session);
@@ -2395,10 +2412,7 @@ export function attachIrcWakeTurnMonitor(session: AgentSession, options: IrcWake
 					outputSchemaMode: options.outputSchemaMode,
 					outputSchemaSource: options.outputSchemaSource,
 					artifactsDir: options.artifactsDir,
-					eventBus: options.eventBus,
-					parentToolCallId: options.parentToolCallId,
-					detached: true,
-					sessionFile,
+					lifecycleRun,
 					startTime: turnStartTime,
 				});
 			} catch (finalizeError) {
@@ -2544,6 +2558,7 @@ export interface FollowUpTurnOptions {
 	signal?: AbortSignal;
 	onProgress?: (progress: AgentProgress) => void;
 	eventBus?: EventBus;
+	recordLifecycle?: (payload: SubagentLifecyclePayload) => void;
 	parentToolCallId?: string;
 	/** When set, the turn's raw output is (re)written to `<artifactsDir>/<id>.md` so `agent://<id>` tracks the latest turn. */
 	artifactsDir?: string;
@@ -2566,9 +2581,24 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 	const { id, agent, message, signal } = options;
 	const index = options.index ?? 0;
 	const startTime = Date.now();
+	const startedMonotonicAt = performance.now();
 	const session = await AgentLifecycleManager.global().ensureLive(id);
 	const ref = AgentRegistry.global().get(id);
 	const sessionFile = ref?.sessionFile ?? undefined;
+	const lifecycleRun = createSubagentLifecycleRun({
+		id,
+		agent: agent.name,
+		agentSource: agent.source,
+		index,
+		runKind: "follow_up",
+		description: options.description,
+		sessionFile,
+		parentToolCallId: options.parentToolCallId,
+		detached: true,
+		startedAt: startTime,
+		startedMonotonicAt,
+		emit: lifecycleEmitter(options.eventBus, options.recordLifecycle),
+	});
 
 	const monitor = createSubagentRunMonitor({
 		index,
@@ -2576,6 +2606,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		agent,
 		task: message,
 		description: options.description,
+		runId: lifecycleRun.started.runId,
 		modelRole: options.modelRole,
 		signal,
 		onProgress: options.onProgress,
@@ -2587,20 +2618,6 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		softRequestBudgetNotice: false,
 		maxRuntimeMs: options.maxRuntimeMs ?? 0,
 	});
-
-	if (options.eventBus) {
-		options.eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
-			id,
-			agent: agent.name,
-			parentToolCallId: options.parentToolCallId,
-			detached: true,
-			agentSource: agent.source,
-			description: options.description,
-			status: "started",
-			sessionFile,
-			index,
-		});
-	}
 
 	monitor.setActiveSession(session);
 	const unsubscribe = monitor.attach(session);
@@ -2632,10 +2649,7 @@ export async function runSubagentFollowUpTurn(options: FollowUpTurnOptions): Pro
 		outputSchemaSource: options.outputSchemaSource,
 		signal,
 		artifactsDir: options.artifactsDir,
-		eventBus: options.eventBus,
-		parentToolCallId: options.parentToolCallId,
-		detached: true,
-		sessionFile,
+		lifecycleRun,
 		startTime,
 	});
 }
@@ -2662,6 +2676,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	} = options;
 	const cleanupGraceMs = options.cleanupGraceMs ?? TASK_ABORT_CLEANUP_GRACE_MS;
 	const startTime = Date.now();
+	const startedMonotonicAt = performance.now();
 	// Set by the session's onFirstChatDispatch hook the first time the agent
 	// loop dispatches a chat request to the provider — the launch-complete boundary.
 	let firstChatDispatchAt: number | undefined;
@@ -2803,6 +2818,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	const progress = monitor.progress;
 	let unsubscribe: (() => void) | null = null;
 	let reviveSession: AgentReviver | null = null;
+	let lifecycleRun: SubagentLifecycleRun | undefined;
 	// Adopted (kept-alive) subagents flip registry status from session events on
 	// later turns: revive/wake → running, turn drained → idle. The subscription
 	// intentionally survives this run; a disposed session emits nothing, so it
@@ -2825,6 +2841,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			modelOverride,
 			modelRole,
 			eventBus: options.eventBus,
+			recordLifecycle: options.recordLifecycle,
 			parentToolCallId: options.parentToolCallId,
 			sessionFile: subtaskSessionFile,
 			maxRuntimeMs,
@@ -3163,6 +3180,21 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			monitor.setActiveSession(session);
 			installRegistryStatusSync(session);
+			lifecycleRun = createSubagentLifecycleRun({
+				id,
+				agent: agent.name,
+				agentSource: agent.source,
+				index,
+				runKind: "initial",
+				description: options.description,
+				sessionFile: subtaskSessionFile,
+				parentToolCallId: options.parentToolCallId,
+				detached: options.detached,
+				startedAt: startTime,
+				startedMonotonicAt,
+				emit: lifecycleEmitter(options.eventBus, options.recordLifecycle),
+			});
+			monitor.setRunId(lifecycleRun.started.runId);
 			if (sessionFile !== null && worktree === undefined) {
 				// Lifecycle reviver: park closed the JSONL writer, so reopening takes
 				// the single-writer lock cleanly and restores the full message history
@@ -3182,21 +3214,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					installIrcWakeTurnMonitor(revived);
 					return revived;
 				};
-			}
-
-			// Emit lifecycle start event
-			if (options.eventBus) {
-				options.eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
-					id,
-					agent: agent.name,
-					parentToolCallId: options.parentToolCallId,
-					detached: options.detached,
-					agentSource: agent.source,
-					description: options.description,
-					status: "started",
-					sessionFile: subtaskSessionFile,
-					index,
-				});
 			}
 
 			// Todos are parent-owned bookkeeping and stripped from subagents —
@@ -3493,10 +3510,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		outputSchemaSource: options.outputSchemaSource,
 		signal,
 		artifactsDir: options.artifactsDir,
-		eventBus: options.eventBus,
-		parentToolCallId: options.parentToolCallId,
-		detached: options.detached,
-		sessionFile: subtaskSessionFile,
+		lifecycleRun,
 		startTime,
 	});
 	AgentRegistry.global().setHistory(id, { outputPath: result.outputPath });

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -104,6 +104,7 @@ export { discoverCommands, expandCommand, getCommand } from "./commands";
 export { discoverAgents, getAgent } from "./discovery";
 export { AgentOutputManager } from "./output-manager";
 export * from "./read-only-policy";
+export { TASK_SUBAGENT_LIFECYCLE_CUSTOM_TYPE } from "./subagent-lifecycle";
 export type {
 	AgentDefinition,
 	AgentProgress,
@@ -111,6 +112,7 @@ export type {
 	SubagentEventPayload,
 	SubagentLifecyclePayload,
 	SubagentProgressPayload,
+	SubagentRunKind,
 	TaskParams,
 	TaskToolDetails,
 } from "./types";

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -11,6 +11,7 @@ import type { AuthStorage } from "../session/auth-storage";
 import { SessionManager } from "../session/session-manager";
 import type { EventBus } from "../utils/event-bus";
 import { attachIrcWakeTurnMonitor, createMCPProxyTools, createSubagentSettings } from "./executor";
+import { createParentSubagentLifecycleRecorder } from "./subagent-lifecycle";
 import type { AgentDefinition } from "./types";
 
 /**
@@ -173,6 +174,10 @@ export function createPersistedSubagentReviverFactory(
 				id: ref.id,
 				agent: wakeAgent,
 				eventBus: ctx.eventBus,
+				recordLifecycle: createParentSubagentLifecycleRecorder({
+					getSessionManager: () => ctx.session.sessionManager,
+					isDisposed: () => ctx.session.isDisposed,
+				}),
 				sessionFile,
 				outputSchema: init.outputSchema,
 				outputSchemaMode: init.outputSchemaMode,

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -34,6 +34,7 @@ import {
 import { generateTaskName } from "./name-generator";
 import { AgentOutputManager } from "./output-manager";
 import { resolveSpawnPolicy } from "./spawn-policy";
+import { createParentSubagentLifecycleRecorder } from "./subagent-lifecycle";
 import {
 	type AgentDefinition,
 	type AgentProgress,
@@ -424,6 +425,10 @@ function buildExecutorOptions(
 		keepAlive: request.keepAlive,
 		signal: request.signal,
 		eventBus: session.eventBus,
+		recordLifecycle: createParentSubagentLifecycleRecorder({
+			getSessionManager: () => session.sessionManager,
+			isDisposed: () => session.isDisposed?.() ?? false,
+		}),
 		onProgress: request.onProgress,
 		authStorage: session.authStorage,
 		modelRegistry: session.modelRegistry,

--- a/packages/coding-agent/src/task/subagent-lifecycle.ts
+++ b/packages/coding-agent/src/task/subagent-lifecycle.ts
@@ -1,0 +1,106 @@
+import { randomUUID } from "node:crypto";
+import { performance } from "node:perf_hooks";
+import type { AgentSource, SubagentLifecyclePayload, SubagentRunKind } from "./types";
+
+export const TASK_SUBAGENT_LIFECYCLE_CUSTOM_TYPE = "task_subagent_lifecycle";
+
+export interface CreateSubagentLifecycleEmitterOptions {
+	emitEvent?: (payload: SubagentLifecyclePayload) => void;
+	appendEntry?: (customType: string, data: SubagentLifecyclePayload) => void;
+}
+
+/** Fan one versioned payload into the live event channel and durable session JSONL. */
+export function createSubagentLifecycleEmitter(
+	options: CreateSubagentLifecycleEmitterOptions,
+): (payload: SubagentLifecyclePayload) => void {
+	return payload => {
+		options.emitEvent?.(payload);
+		options.appendEntry?.(TASK_SUBAGENT_LIFECYCLE_CUSTOM_TYPE, payload);
+	};
+}
+
+export interface ParentSubagentLifecycleHost {
+	getSessionManager(): { appendCustomEntry(customType: string, data?: unknown): unknown } | undefined;
+	isDisposed?(): boolean;
+}
+
+/**
+ * Persist lifecycle boundaries into the live parent journal only. Resolving the
+ * manager per payload follows parent session switches and avoids retaining a
+ * disposed manager for later IRC wake turns.
+ */
+export function createParentSubagentLifecycleRecorder(
+	host: ParentSubagentLifecycleHost,
+): ((payload: SubagentLifecyclePayload) => void) | undefined {
+	if (!host.getSessionManager()) return undefined;
+	return payload => {
+		if (host.isDisposed?.()) return;
+		host.getSessionManager()?.appendCustomEntry(TASK_SUBAGENT_LIFECYCLE_CUSTOM_TYPE, payload);
+	};
+}
+
+export interface CreateSubagentLifecycleRunOptions {
+	id: string;
+	agent: string;
+	agentSource: AgentSource;
+	index: number;
+	runKind: SubagentRunKind;
+	description?: string;
+	sessionFile?: string;
+	parentToolCallId?: string;
+	detached?: boolean;
+	startedAt?: number;
+	startedMonotonicAt?: number;
+	emit: (payload: SubagentLifecyclePayload) => void;
+}
+
+export interface SubagentLifecycleRun {
+	readonly started: SubagentLifecyclePayload;
+	complete(
+		status: Exclude<SubagentLifecyclePayload["status"], "started">,
+		completedAt?: number,
+		completedMonotonicAt?: number,
+	): SubagentLifecyclePayload;
+}
+
+/**
+ * Emit exactly one start and terminal boundary for a logical subagent run.
+ * Epochs make the boundary reconstructible from JSONL; duration uses a
+ * monotonic clock so wall-clock adjustments cannot create negative work.
+ */
+export function createSubagentLifecycleRun(options: CreateSubagentLifecycleRunOptions): SubagentLifecycleRun {
+	const startedAt = options.startedAt ?? Date.now();
+	const startedMonotonicAt = options.startedMonotonicAt ?? performance.now();
+	const common = {
+		version: 1 as const,
+		runId: randomUUID(),
+		runKind: options.runKind,
+		id: options.id,
+		agent: options.agent,
+		agentSource: options.agentSource,
+		description: options.description,
+		sessionFile: options.sessionFile,
+		parentToolCallId: options.parentToolCallId,
+		index: options.index,
+		detached: options.detached,
+		startedAt,
+	};
+	const started: SubagentLifecyclePayload = { ...common, status: "started" };
+	options.emit(started);
+	let terminal = false;
+	return {
+		started,
+		complete(status, completedAt = Date.now(), completedMonotonicAt = performance.now()) {
+			if (terminal) throw new Error(`Subagent lifecycle run ${common.runId} already completed`);
+			terminal = true;
+			const payload: SubagentLifecyclePayload = {
+				...common,
+				status,
+				completedAt,
+				durationMs: Math.max(0, completedMonotonicAt - startedMonotonicAt),
+			};
+			options.emit(payload);
+			return payload;
+		},
+	};
+}

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -64,8 +64,13 @@ export const TASK_SUBAGENT_PROGRESS_CHANNEL = "task:subagent:progress";
 /** EventBus channel for subagent lifecycle (start/end) */
 export const TASK_SUBAGENT_LIFECYCLE_CHANNEL = "task:subagent:lifecycle";
 
+/** A logical execution within a retained subagent session. */
+export type SubagentRunKind = "initial" | "follow_up" | "irc_wake";
+
 /** Payload emitted on TASK_SUBAGENT_PROGRESS_CHANNEL */
 export interface SubagentProgressPayload {
+	/** Logical run that produced this snapshot. */
+	runId: string;
 	index: number;
 	agent: string;
 	agentSource: AgentSource;
@@ -86,6 +91,18 @@ export interface SubagentEventPayload {
 
 /** Payload emitted on TASK_SUBAGENT_LIFECYCLE_CHANNEL */
 export interface SubagentLifecyclePayload {
+	/** Versioned independently from the EventBus channel and session JSONL envelope. */
+	version: 1;
+	/** Unique execution id; one retained agent can have multiple follow-up/wake runs. */
+	runId: string;
+	/** Distinguishes the delegated task from later turns on the retained session. */
+	runKind: SubagentRunKind;
+	/** Epoch milliseconds at the actual run boundary, not session creation/disposal. */
+	startedAt: number;
+	/** Terminal epoch milliseconds. Present only for completed/failed/aborted payloads. */
+	completedAt?: number;
+	/** Monotonic elapsed milliseconds. Present only for terminal payloads. */
+	durationMs?: number;
 	id: string;
 	agent: string;
 	agentSource: AgentSource;

--- a/packages/coding-agent/test/rpc-subagents.test.ts
+++ b/packages/coding-agent/test/rpc-subagents.test.ts
@@ -57,6 +57,10 @@ function createRegistryWithSnapshot(): RpcSubagentRegistry {
 	const eventBus = new EventBus();
 	const registry = new RpcSubagentRegistry(eventBus, () => {});
 	eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+		version: 1,
+		runId: "run-subagent-a",
+		runKind: "initial",
+		startedAt: 1,
 		id: "SubagentA",
 		index: 0,
 		agent: "task",
@@ -89,6 +93,10 @@ describe("RPC subagent registry", () => {
 		const frames: RpcSubagentFrame[] = [];
 		const registry = new RpcSubagentRegistry(eventBus, frame => frames.push(frame));
 		const lifecycle: SubagentLifecyclePayload = {
+			version: 1,
+			runId: "run-subagent-a",
+			runKind: "initial",
+			startedAt: 1,
 			id: "SubagentA",
 			index: 0,
 			agent: "task",
@@ -99,6 +107,7 @@ describe("RPC subagent registry", () => {
 			parentToolCallId: "toolu_parent",
 		};
 		const progressPayload: SubagentProgressPayload = {
+			runId: lifecycle.runId,
 			index: 0,
 			agent: "task",
 			agentSource: "bundled",
@@ -135,6 +144,10 @@ describe("RPC subagent registry", () => {
 		const registry = new RpcSubagentRegistry(eventBus, frame => frames.push(frame));
 		registry.setSubscriptionLevel("progress");
 		const lifecycle: SubagentLifecyclePayload = {
+			version: 1,
+			runId: "run-subagent-a",
+			runKind: "initial",
+			startedAt: 1,
 			id: "SubagentA",
 			index: 0,
 			agent: "task",
@@ -145,6 +158,7 @@ describe("RPC subagent registry", () => {
 			parentToolCallId: "toolu_parent",
 		};
 		const progressPayload: SubagentProgressPayload = {
+			runId: lifecycle.runId,
 			index: 0,
 			agent: "task",
 			agentSource: "bundled",
@@ -173,10 +187,70 @@ describe("RPC subagent registry", () => {
 		registry.dispose();
 	});
 
+	test("ignores terminal lifecycle and progress frames from an older retained-agent run", () => {
+		const eventBus = new EventBus();
+		const frames: RpcSubagentFrame[] = [];
+		const registry = new RpcSubagentRegistry(eventBus, frame => frames.push(frame));
+		registry.setSubscriptionLevel("progress");
+		const firstRun: SubagentLifecyclePayload = {
+			version: 1,
+			runId: "run-first",
+			runKind: "initial",
+			startedAt: 1,
+			id: "SubagentA",
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			status: "started",
+			sessionFile: "/tmp/subagent.jsonl",
+		};
+		const secondRun: SubagentLifecyclePayload = {
+			...firstRun,
+			runId: "run-second",
+			runKind: "follow_up",
+			startedAt: 2,
+		};
+
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, firstRun);
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, secondRun);
+		eventBus.emit(TASK_SUBAGENT_PROGRESS_CHANNEL, {
+			runId: firstRun.runId,
+			index: 0,
+			agent: "task",
+			agentSource: "bundled",
+			task: "Old work",
+			sessionFile: "/tmp/subagent.jsonl",
+			progress: createProgress({ status: "completed", task: "Old work" }),
+		} satisfies SubagentProgressPayload & { runId: string });
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			...firstRun,
+			status: "completed",
+			completedAt: 3,
+			durationMs: 2,
+		});
+
+		expect(registry.getSubagents()).toMatchObject([{ id: "SubagentA", runId: "run-second", status: "running" }]);
+		expect(frames).toHaveLength(2);
+
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			...secondRun,
+			status: "completed",
+			completedAt: 4,
+			durationMs: 2,
+		});
+		expect(registry.getSubagents()).toEqual([]);
+		expect(frames).toHaveLength(3);
+		registry.dispose();
+	});
+
 	test("clears stale snapshots when the active RPC session changes", () => {
 		const eventBus = new EventBus();
 		const registry = new RpcSubagentRegistry(eventBus, () => {});
 		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			version: 1,
+			runId: "run-subagent-a",
+			runKind: "initial",
+			startedAt: 1,
 			id: "SubagentA",
 			index: 0,
 			agent: "task",
@@ -275,6 +349,10 @@ describe("RPC subagent registry", () => {
 		const registry = new RpcSubagentRegistry(eventBus, () => {});
 		const sessionFile = "/tmp/subagent.jsonl";
 		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			version: 1,
+			runId: "run-subagent-a",
+			runKind: "initial",
+			startedAt: 1,
 			id: "SubagentA",
 			index: 0,
 			agent: "task",
@@ -285,6 +363,12 @@ describe("RPC subagent registry", () => {
 
 		expect(registry.getSubagents()).toHaveLength(1);
 		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			version: 1,
+			runId: "run-subagent-a",
+			runKind: "initial",
+			startedAt: 1,
+			completedAt: 2,
+			durationMs: 1,
 			id: "SubagentA",
 			index: 0,
 			agent: "task",
@@ -404,7 +488,7 @@ function handle(frame) {
 		return;
 	}
 	if (frame.type === "get_subagents") {
-		write({ id: frame.id, type: "response", command: "get_subagents", success: true, data: { subagents: [{ id: "SubagentA", index: 0, agent: "task", agentSource: "bundled", status: "running", lastUpdate: 1 }] } });
+		write({ id: frame.id, type: "response", command: "get_subagents", success: true, data: { subagents: [{ id: "SubagentA", runId: "run-subagent-a", index: 0, agent: "task", agentSource: "bundled", status: "running", lastUpdate: 1 }] } });
 		return;
 	}
 	if (frame.type === "get_subagent_messages") {
@@ -414,8 +498,8 @@ function handle(frame) {
 	if (frame.type === "prompt") {
 		write({ id: frame.id, type: "response", command: "prompt", success: true });
 		write({ type: "notice", level: "info", message: "subagent test" });
-		write({ type: "subagent_lifecycle", payload: { id: "SubagentA", index: 0, agent: "task", agentSource: "bundled", status: "started", sessionFile: "/tmp/subagent.jsonl" } });
-		write({ type: "subagent_progress", payload: { index: 0, agent: "task", agentSource: "bundled", task: "Do work", assignment: "Implement work", sessionFile: "/tmp/subagent.jsonl", progress } });
+		write({ type: "subagent_lifecycle", payload: { version: 1, runId: "run-subagent-a", runKind: "initial", startedAt: 1, id: "SubagentA", index: 0, agent: "task", agentSource: "bundled", status: "started", sessionFile: "/tmp/subagent.jsonl" } });
+		write({ type: "subagent_progress", payload: { runId: "run-subagent-a", index: 0, agent: "task", agentSource: "bundled", task: "Do work", assignment: "Implement work", sessionFile: "/tmp/subagent.jsonl", progress } });
 		write({ type: "subagent_event", payload: { id: "SubagentA", event: { type: "agent_start" } } });
 		write({ type: "agent_end", messages: [] });
 	}

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -60,6 +60,10 @@ function makeProgress(overrides: Partial<AgentProgress> & { id: string }): Agent
 
 function makeLifecycle(id: string, index: number, description: string, detached?: boolean): SubagentLifecyclePayload {
 	return {
+		version: 1,
+		runId: `run-${id}`,
+		runKind: "initial",
+		startedAt: 1,
 		id,
 		index,
 		agent: "task",
@@ -78,6 +82,7 @@ function makeProgressPayload(
 	detached?: boolean,
 ): SubagentProgressPayload {
 	return {
+		runId: `run-${id}`,
 		index,
 		agent: "task",
 		agentSource: "bundled",
@@ -161,6 +166,53 @@ describe("subagent HUD lines", () => {
 		expect(out).toContain("Detached: background work");
 		expect(out).toContain("FromProgress: background work");
 		expect(out).not.toContain("Inline");
+	});
+
+	it("ignores a terminal lifecycle update from an older retained-agent run", () => {
+		const eventBus = new EventBus();
+		const registry = new SessionObserverRegistry();
+		registry.subscribeToEventBus(eventBus);
+		const firstRun = makeLifecycle("Retained", 0, "initial work", true);
+		const secondRun: SubagentLifecyclePayload = {
+			...firstRun,
+			runId: "run-retained-follow-up",
+			runKind: "follow_up",
+			startedAt: 2,
+			description: "follow-up work",
+		};
+
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, firstRun);
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, secondRun);
+		eventBus.emit(TASK_SUBAGENT_PROGRESS_CHANNEL, {
+			...makeProgressPayload("Retained", 0, "stale initial progress", true),
+			runId: firstRun.runId,
+			progress: makeProgress({
+				id: "Retained",
+				status: "completed",
+				description: "stale initial progress",
+			}),
+		});
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			...firstRun,
+			status: "completed",
+			completedAt: 3,
+			durationMs: 2,
+		});
+
+		expect(registry.getSession("Retained")).toMatchObject({
+			runId: "run-retained-follow-up",
+			status: "active",
+			description: "follow-up work",
+		});
+		expect(registry.getSession("Retained")?.progress).toBeUndefined();
+
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			...secondRun,
+			status: "completed",
+			completedAt: 4,
+			durationMs: 2,
+		});
+		expect(registry.getSession("Retained")?.status).toBe("completed");
 	});
 
 	it("renders nested ids as a breadcrumb and truncates long descriptions to the viewport", () => {

--- a/packages/coding-agent/test/task/executor-launch-startup.test.ts
+++ b/packages/coding-agent/test/task/executor-launch-startup.test.ts
@@ -102,5 +102,8 @@ it("overlaps registry refresh with session-file opening and session setup", asyn
 	expect(sessionCreated).toBe(true);
 
 	refreshGate.resolve();
-	expect((await run).exitCode).toBe(0);
+	const result = await run;
+	expect(result.exitCode).toBe(0);
+	expect(result.outputPath).toBe(tempDir.join("task-launch-overlap.md"));
+	expect(await Bun.file(tempDir.join("task-launch-overlap.md")).exists()).toBe(true);
 });

--- a/packages/coding-agent/test/task/executor-soft-budget.test.ts
+++ b/packages/coding-agent/test/task/executor-soft-budget.test.ts
@@ -13,7 +13,11 @@ import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
-import { resolveSoftRequestBudget, runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
+import {
+	resolveSoftRequestBudget,
+	runSubagentFollowUpTurn,
+	runSubprocess,
+} from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -210,6 +214,55 @@ describe("runSubprocess soft request budget", () => {
 		});
 	}
 
+	it("writes the latest output artifact for a monitored follow-up turn", async () => {
+		const id = "FollowUpScout";
+		const handle = createMockSession(({ emit, pushMessage }) => {
+			const yieldMessage = {
+				role: "assistant" as const,
+				content: [
+					{
+						type: "toolCall" as const,
+						id: "follow-up-yield",
+						name: "yield",
+						arguments: { result: { data: { report: "follow-up findings" } } },
+					},
+				],
+				stopReason: "toolUse" as const,
+			};
+			pushMessage(yieldMessage);
+			emit({ type: "message_end", message: yieldMessage } as unknown as AgentSessionEvent);
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "follow-up-yield",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { report: "follow-up findings" } },
+				},
+				isError: false,
+			} as AgentSessionEvent);
+		});
+		AgentRegistry.global().register({
+			id,
+			displayName: id,
+			kind: "sub",
+			session: handle.session,
+			status: "idle",
+		});
+		AgentLifecycleManager.global().adopt(id, { idleTtlMs: 0 });
+
+		const result = await runSubagentFollowUpTurn({
+			id,
+			agent: baseAgent,
+			message: "continue the inventory",
+			artifactsDir: tempDir.path(),
+		});
+
+		const outputPath = tempDir.join(`${id}.md`);
+		expect(result.outputPath).toBe(outputPath);
+		expect(await Bun.file(outputPath).text()).toContain("follow-up findings");
+	});
+
 	it("a budget stop drives one forced final yield and finishes as a normal completion", async () => {
 		const id = "BudgetScout";
 		let abortCallsAtReminder: number | undefined;
@@ -319,27 +372,38 @@ describe("runSubprocess soft request budget", () => {
 				payload: { id, status: "started" },
 			});
 			expect(frames.some(frame => frame.type === "subagent_progress")).toBe(true);
+			const started = frames[0];
+			if (started?.type !== "subagent_lifecycle") throw new Error("expected lifecycle start");
+			const progressRunIds = frames
+				.filter(frame => frame.type === "subagent_progress")
+				.map(frame => frame.payload.runId);
+			expect(progressRunIds).toEqual(progressRunIds.map(() => started.payload.runId));
 			expect(frames.at(-1)).toMatchObject({
 				type: "subagent_lifecycle",
 				payload: { id, status: "completed" },
 			});
 		};
 
+		const outputPath = tempDir.join(`${id}.md`);
+		await Bun.write(outputPath, "stale");
 		frames.length = 0;
 		const idleTerminal = waitForFollowUpTerminal();
 		const idleReceipt = await new IrcBus().send({ from: "Main", to: id, body: "resume your inventory" });
 		expect(idleReceipt.outcome).toBe("woken");
 		await idleTerminal;
 		expectRpcTurn();
+		expect(await Bun.file(outputPath).text()).toContain("resumed findings");
 
 		await AgentLifecycleManager.global().park(id);
 		expect(AgentRegistry.global().get(id)?.status).toBe("parked");
+		await Bun.write(outputPath, "stale");
 		frames.length = 0;
 		const revivedTerminal = waitForFollowUpTerminal();
 		const revivedReceipt = await new IrcBus().send({ from: "Main", to: id, body: "resume after parking" });
 		expect(revivedReceipt.outcome).toBe("revived");
 		await revivedTerminal;
 		expectRpcTurn();
+		expect(await Bun.file(outputPath).text()).toContain("resumed findings");
 		rpcRegistry.dispose();
 	});
 

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -106,6 +106,7 @@ function createFactory(cwd: string, eventBus?: EventBus) {
 		sessionManager: {
 			getCwd: () => cwd,
 			getArtifactManager: () => undefined,
+			appendCustomEntry: vi.fn(),
 		},
 		get sessionFile() {
 			return path.join(cwd, "parent.jsonl");

--- a/packages/coding-agent/test/task/structured-subagent.test.ts
+++ b/packages/coding-agent/test/task/structured-subagent.test.ts
@@ -18,7 +18,7 @@ import {
 	StructuredSubagentError,
 	type StructuredSubagentRequest,
 } from "@oh-my-pi/pi-coding-agent/task/structured-subagent";
-import type { AgentDefinition, SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
+import type { AgentDefinition, SingleResult, SubagentLifecyclePayload } from "@oh-my-pi/pi-coding-agent/task/types";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 
 const AGENT: AgentDefinition = {
@@ -184,6 +184,43 @@ describe("structured subagent primitive", () => {
 		expect(settled.policy.modelRole).toBe("reviewer");
 		expect(dispatched[0]?.modelRole).toBe("reviewer");
 		expect(settled.result.modelRole).toBe("reviewer");
+		await fs.rm(settled.artifactsDir, { recursive: true, force: true });
+	});
+	it("records task lifecycle boundaries only while the parent session is live", async () => {
+		mockDiscovery();
+		const parent = session();
+		const entries: Array<{ customType: string; data: unknown }> = [];
+		let disposed = false;
+		parent.sessionManager = {
+			appendCustomEntry: (customType: string, data?: unknown) => {
+				entries.push({ customType, data });
+				return "entry";
+			},
+		} as ToolSession["sessionManager"];
+		parent.isDisposed = () => disposed;
+		let recordLifecycle: executorModule.ExecutorOptions["recordLifecycle"];
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			recordLifecycle = options.recordLifecycle;
+			return result();
+		});
+
+		const settled = await runStructuredSubagent(request({ session: parent, retainArtifacts: true }));
+		const started: SubagentLifecyclePayload = {
+			version: 1,
+			runId: "run-1",
+			runKind: "initial",
+			id: "Worker",
+			agent: "worker",
+			agentSource: "bundled",
+			index: 0,
+			status: "started",
+			startedAt: 1_000,
+		};
+		recordLifecycle?.(started);
+		disposed = true;
+		recordLifecycle?.({ ...started, status: "completed", completedAt: 1_100, durationMs: 100 });
+
+		expect(entries).toEqual([{ customType: "task_subagent_lifecycle", data: started }]);
 		await fs.rm(settled.artifactsDir, { recursive: true, force: true });
 	});
 	it("derives modelRole from the raw selector source in request, override, definition order", async () => {

--- a/packages/coding-agent/test/task/subagent-lifecycle.test.ts
+++ b/packages/coding-agent/test/task/subagent-lifecycle.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import {
+	createParentSubagentLifecycleRecorder,
+	createSubagentLifecycleEmitter,
+	createSubagentLifecycleRun,
+} from "@oh-my-pi/pi-coding-agent/task/subagent-lifecycle";
+import type { SubagentLifecyclePayload } from "@oh-my-pi/pi-coding-agent/task/types";
+
+describe("subagent run lifecycle timing", () => {
+	it("emits one completion boundary independently from retained session lifetime", () => {
+		const emitted: SubagentLifecyclePayload[] = [];
+		const persisted: Array<{ customType: string; data: SubagentLifecyclePayload }> = [];
+		const emit = createSubagentLifecycleEmitter({
+			emitEvent: payload => emitted.push(payload),
+			appendEntry: (customType, data) => persisted.push({ customType, data }),
+		});
+		const run = createSubagentLifecycleRun({
+			id: "TimingScout",
+			agent: "scout",
+			agentSource: "bundled",
+			index: 0,
+			runKind: "initial",
+			startedMonotonicAt: 500,
+			startedAt: 1_000,
+			emit,
+		});
+		const completed = run.complete("completed", 1_625, 1_125);
+
+		expect(emitted).toHaveLength(2);
+		expect(emitted[0]).toMatchObject({
+			version: 1,
+			runKind: "initial",
+			status: "started",
+			startedAt: 1_000,
+		});
+		expect(completed).toEqual(emitted[1]);
+		expect(completed).toMatchObject({
+			version: 1,
+			runId: emitted[0]!.runId,
+			runKind: "initial",
+			status: "completed",
+			startedAt: 1_000,
+			completedAt: 1_625,
+			durationMs: 625,
+		});
+		expect(persisted).toEqual([
+			{ customType: "task_subagent_lifecycle", data: emitted[0]! },
+			{ customType: "task_subagent_lifecycle", data: emitted[1]! },
+		]);
+	});
+
+	it("stops recording into a parent session once disposal begins", () => {
+		const persisted: Array<{ customType: string; data: SubagentLifecyclePayload }> = [];
+		let disposed = false;
+		const record = createParentSubagentLifecycleRecorder({
+			getSessionManager: () => ({
+				appendCustomEntry: (customType, data) => {
+					persisted.push({ customType, data: data as SubagentLifecyclePayload });
+					return "entry";
+				},
+			}),
+			isDisposed: () => disposed,
+		});
+		const payload: SubagentLifecyclePayload = {
+			version: 1,
+			runId: "run-1",
+			runKind: "irc_wake",
+			id: "Worker",
+			agent: "task",
+			agentSource: "bundled",
+			index: 0,
+			status: "started",
+			startedAt: 1_000,
+		};
+
+		record?.(payload);
+		disposed = true;
+		record?.({ ...payload, status: "completed", completedAt: 1_100, durationMs: 100 });
+
+		expect(persisted).toEqual([{ customType: "task_subagent_lifecycle", data: payload }]);
+	});
+
+	it("rejects duplicate terminal boundaries", () => {
+		const run = createSubagentLifecycleRun({
+			id: "TimingScout",
+			agent: "scout",
+			agentSource: "bundled",
+			index: 0,
+			startedMonotonicAt: 1_000,
+			runKind: "irc_wake",
+			startedAt: 2_000,
+			emit: () => {},
+		});
+		run.complete("failed", 2_100, 1_100);
+		expect(() => run.complete("completed", 2_200, 1_200)).toThrow("already completed");
+	});
+});


### PR DESCRIPTION
## What

> Requester direction: “rebase the omp fork (not the rust one) summarize all of our improvements and open a PR”

- Emit versioned `task:subagent:lifecycle` payloads for every logical subagent run, with a stable `runId`, run kind, epoch boundaries, terminal status, and monotonic `durationMs`.
- Persist task/eval lifecycle payloads as `task_subagent_lifecycle` entries in the live parent session; non-task `runSubprocess` callers retain live events without implicit child-journal writes.
- Cover `initial`, `follow_up`, and `irc_wake` executions, including detached/session metadata and structured-subagent paths.
- Resolve the parent manager at each append and suppress persistence after parent disposal, so retained IRC-wake callbacks do not hold or write through stale managers.
- Carry the active `runId` through lifecycle and progress payloads plus RPC and observer snapshots; ignore delayed terminal lifecycle/progress updates from an older retained-agent run.
- Preserve `<artifactsDir>/<id>.md` output artifacts for initial, follow-up, live IRC-wake, and revived IRC-wake finalization.
- Document the lifecycle contract and add the coding-agent Unreleased changelog entry.

## Why

Retained subagents can execute multiple logical runs while one session remains alive. Explicit run boundaries make execution timing reconstructible without conflating work with session retention, parking, or disposal.

This remains deliberately scoped lifecycle observability. It does not change routing, scheduling, model selection, or idle-TTL behavior.

## Testing

- `bun test packages/coding-agent/test/task/subagent-lifecycle.test.ts packages/coding-agent/test/task/executor-launch-startup.test.ts packages/coding-agent/test/task/structured-subagent.test.ts packages/coding-agent/test/task/executor-soft-budget.test.ts packages/coding-agent/test/task/persisted-revive.test.ts packages/coding-agent/test/rpc-subagents.test.ts packages/coding-agent/test/subagent-hud-render.test.ts --timeout 30000` — 66 passed, 0 failed, 272 assertions.
- `bun check` — passed across TypeScript and Rust workspace checks.
- Regression coverage verifies task-parent persistence, disposal suppression, shared run IDs/monotonic duration, stale lifecycle/progress filtering in both live snapshot consumers, and output artifacts for every finalization path.

---

- [x] `bun check` passes
- [x] Focused lifecycle and executor tests pass
- [x] CHANGELOG updated
- [x] All review feedback addressed