### PR TITLE
fix(mcp): surface request timeout when the abort lands mid-JSON-body read

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP Streamable HTTP transport requests aborting mid-JSON-body-read surfacing `Unexpected end of JSON input` instead of the configured request timeout; the abort now latches the timeout contract.
+
 ## [17.2.4] - 2026-08-01
 
 ### Added

--- a/packages/coding-agent/src/mcp/timeout.ts
+++ b/packages/coding-agent/src/mcp/timeout.ts
@@ -37,12 +37,15 @@ export function createMCPTimeout(
 	signal?: AbortSignal;
 	clear: () => void;
 	isTimeoutAbort: (error: unknown) => boolean;
+	/** True when this operation's own timer fired (regardless of what error a consumer saw). */
+	timedOut: () => boolean;
 } {
 	if (!isMCPTimeoutEnabled(timeoutMs)) {
 		return {
 			signal,
 			clear: () => {},
 			isTimeoutAbort: () => false,
+			timedOut: () => false,
 		};
 	}
 
@@ -55,5 +58,6 @@ export function createMCPTimeout(
 		clear: () => clearTimeout(timeoutId),
 		isTimeoutAbort: error =>
 			error instanceof Error && error.name === "AbortError" && abortController.signal.aborted && !signal?.aborted,
+		timedOut: () => abortController.signal.aborted && !signal?.aborted,
 	};
 }

--- a/packages/coding-agent/src/mcp/timeout.ts
+++ b/packages/coding-agent/src/mcp/timeout.ts
@@ -50,7 +50,11 @@ export function createMCPTimeout(
 	}
 
 	const abortController = new AbortController();
-	const timeoutId = setTimeout(() => abortController.abort(), timeoutMs);
+	let didTimeout = false;
+	const timeoutId = setTimeout(() => {
+		didTimeout = true;
+		abortController.abort();
+	}, timeoutMs);
 	const operationSignal = signal ? AbortSignal.any([signal, abortController.signal]) : abortController.signal;
 
 	return {
@@ -58,6 +62,6 @@ export function createMCPTimeout(
 		clear: () => clearTimeout(timeoutId),
 		isTimeoutAbort: error =>
 			error instanceof Error && error.name === "AbortError" && abortController.signal.aborted && !signal?.aborted,
-		timedOut: () => abortController.signal.aborted && !signal?.aborted,
+		timedOut: () => didTimeout,
 	};
 }

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -276,7 +276,7 @@ export class HttpTransport implements MCPTransport {
 
 			return result.result as T;
 		} catch (error) {
-			if (operation.isTimeoutAbort(error)) {
+			if (operation.isTimeoutAbort(error) || operation.timedOut()) {
 				throw new Error(`Request timeout after ${timeout}ms`);
 			}
 			throw error;

--- a/packages/coding-agent/test/mcp-timeout.test.ts
+++ b/packages/coding-agent/test/mcp-timeout.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "@oh-my-pi/pi-coding-agent/mcp/timeout";
+import { afterEach, describe, expect, spyOn, test, vi } from "bun:test";
+import { createMCPTimeout, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "@oh-my-pi/pi-coding-agent/mcp/timeout";
 import { logger } from "@oh-my-pi/pi-utils";
 
 const ORIGINAL_TIMEOUT = process.env.OMP_MCP_TIMEOUT_MS;
@@ -62,5 +62,73 @@ describe("MCP timeout configuration", () => {
 		} finally {
 			warn.mockRestore();
 		}
+	});
+});
+
+describe("MCP timeout ordering", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	function abortError(): Error {
+		return new DOMException("aborted", "AbortError");
+	}
+
+	test("timeout-first: timedOut stays latched when the external signal aborts afterwards", () => {
+		vi.useFakeTimers();
+		const external = new AbortController();
+		const operation = createMCPTimeout(100, external.signal);
+
+		expect(operation.timedOut()).toBe(false);
+		vi.advanceTimersByTime(100);
+
+		// The timer fired first: the timeout contract must latch even though the
+		// underlying abort controller is what the consumer's fetch saw.
+		expect(operation.timedOut()).toBe(true);
+		expect(operation.isTimeoutAbort(abortError())).toBe(true);
+
+		// A later external abort must not rewrite the outcome: the error is still
+		// reported as the timeout, not as an external cancellation. isTimeoutAbort
+		// itself flips false (the external signal did abort), which is why the
+		// transport consults timedOut() as the latched truth.
+		external.abort();
+		expect(operation.timedOut()).toBe(true);
+		expect(operation.isTimeoutAbort(abortError())).toBe(false);
+
+		operation.clear();
+	});
+
+	test("external-first: timedOut stays false until the timer fires; isTimeoutAbort stays false", () => {
+		vi.useFakeTimers();
+		const external = new AbortController();
+		const operation = createMCPTimeout(100, external.signal);
+
+		external.abort();
+		expect(operation.timedOut()).toBe(false);
+		expect(operation.isTimeoutAbort(abortError())).toBe(false);
+
+		// Advancing past the deadline fires the timer: the timeout latch engages,
+		// but isTimeoutAbort still refuses because the external signal aborted
+		// first — the error surfaced to the consumer is an external cancellation,
+		// not the timeout contract.
+		vi.advanceTimersByTime(100);
+		expect(operation.timedOut()).toBe(true);
+		expect(operation.isTimeoutAbort(abortError())).toBe(false);
+
+		operation.clear();
+	});
+
+	test("isTimeoutAbort only treats AbortErrors from the timer as timeouts", () => {
+		vi.useFakeTimers();
+		const external = new AbortController();
+		const operation = createMCPTimeout(100, external.signal);
+
+		// Non-AbortError failures are never the timeout contract, even after the
+		// timer fired.
+		expect(operation.isTimeoutAbort(new Error("Unexpected end of JSON input"))).toBe(false);
+		vi.advanceTimersByTime(100);
+		expect(operation.isTimeoutAbort(new Error("Unexpected end of JSON input"))).toBe(false);
+
+		operation.clear();
 	});
 });


### PR DESCRIPTION
Split from #6897.

When the MCP request timeout fires while `response.json()` is still draining a stalled body, the stream abort surfaced as `Unexpected end of JSON input` instead of the documented `Request timeout after Nms` — the transport's `isTimeoutAbort` check only matched the raw AbortError, not the parse error the abort produces. `createMCPTimeout` now exposes `timedOut()`, and the JSON-response catch path maps it onto the timeout contract.

The stalled-body timeout test (upstream 5d2f9ae5a) flaked on CI with exactly this error. Verified: stalled-body timeout surfaces the contract 5/5 (zero masking), adjacent MCP suites 16/16, biome clean.