### PR TITLE
test(browser): fix CHROMIUM_AVAILABLE TDZ in real-Chromium test gating

### DIFF
--- a/packages/coding-agent/test/tools/browser-attach.test.ts
+++ b/packages/coding-agent/test/tools/browser-attach.test.ts
@@ -11,7 +11,12 @@ import {
 } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
 import { acquireTab, releaseTab } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 import type { Browser, Page, Target } from "puppeteer-core";
-import { CHROMIUM_AVAILABLE } from "./chromium-probe";
+import { isChromiumAvailable } from "./chromium-probe";
+
+// Same-module top-level await: guaranteed to resolve before the skipIf
+// registrations below run (a cross-module awaited export would be read from
+// its TDZ here and crash bun).
+const CHROMIUM_AVAILABLE = await isChromiumAvailable();
 
 interface FakePageOptions {
 	url: string;

--- a/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
@@ -3,7 +3,12 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { BrowserTool } from "@oh-my-pi/pi-coding-agent/tools/browser";
 import { getTabsMapForTest } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
-import { CHROMIUM_AVAILABLE } from "./chromium-probe";
+import { isChromiumAvailable } from "./chromium-probe";
+
+// Same-module top-level await: guaranteed to resolve before the skipIf
+// registrations below run (a cross-module awaited export would be read from
+// its TDZ here and crash bun).
+const CHROMIUM_AVAILABLE = await isChromiumAvailable();
 
 function makeSession(): ToolSession {
 	return {

--- a/packages/coding-agent/test/tools/chromium-probe.ts
+++ b/packages/coding-agent/test/tools/chromium-probe.ts
@@ -17,5 +17,15 @@ async function chromiumCanLaunch(): Promise<boolean> {
 	}
 }
 
-/** Gate for tests that launch a real Chromium: `describe.skipIf(!CHROMIUM_AVAILABLE)`. */
-export const CHROMIUM_AVAILABLE = await chromiumCanLaunch();
+/**
+ * Gate for tests that launch a real Chromium. Exported as a function, NOT an
+ * awaited value binding: a cross-module top-level-await export is read from
+ * its temporal dead zone by importers that consume it synchronously at module
+ * scope (test.skipIf/describe.skipIf), crashing bun with "Cannot access before
+ * initialization" regardless of how fast the probe resolves. Consumers do
+ * `const CHROMIUM_AVAILABLE = await isChromiumAvailable()` in their own module
+ * body, where same-module top-level await is guaranteed to complete first.
+ */
+export async function isChromiumAvailable(): Promise<boolean> {
+	return chromiumCanLaunch();
+}


### PR DESCRIPTION
Split from #6897.

Fixes a hard ESM cross-module top-level-await TDZ: `chromium-probe.ts` exported an awaited value binding (`CHROMIUM_AVAILABLE`) that importers read synchronously in `test.skipIf`/`describe.skipIf` at module scope, crashing bun with `ReferenceError: Cannot access 'CHROMIUM_AVAILABLE' before initialization` — failed native/unit chunks 44/46 on every PR CI run (including unrelated PR #7325), independent of probe speed.

The probe now exports `isChromiumAvailable()` and each importer does a same-module `const CHROMIUM_AVAILABLE = await isChromiumAvailable()`, where top-level await is guaranteed to complete before the skipIf registrations run. Skip behavior unchanged (verified: fake-PATH chromium → 7 pass/6 skip).

Verified: 3x 13/13 browser tests, check:types exit 0, biome clean, skip path confirmed.