### PR TITLE
test(vibe): fix kill-before-init race with a worker-ready handshake

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the vibe pre-init-kill test racing `registry.kill()` against the worker's job-body dispatch (the mock only registered its AgentRef after the abort signal landed, so a loaded runner could observe no registration); the test now waits for the worker to be mid-initialization before killing.
+
 ## [17.2.4] - 2026-08-01
 
 ### Added

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2074,16 +2074,13 @@ describe("vibe session registry", () => {
 		// failing the registry assertion below. Resolving once the body is inside
 		// the abort-wait keeps the test exercising exactly the late-registration
 		// path it names.
-		let signalWorkerStarted: () => void = () => {};
-		const workerStarted = new Promise<void>(resolve => {
-			signalWorkerStarted = resolve;
-		});
+		const workerStarted = deferred();
 		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
 			const artifactsDir = options.artifactsDir;
 			if (!artifactsDir) throw new Error("Persisted vibe test requires an artifacts directory");
 			const signal = options.signal;
 			if (!signal) throw new Error("Pre-initialization worker requires a cancellation signal");
-			signalWorkerStarted();
+			workerStarted.resolve();
 			await new Promise<void>(resolve => {
 				if (signal.aborted) resolve();
 				else signal.addEventListener("abort", () => resolve(), { once: true });
@@ -2115,7 +2112,7 @@ describe("vibe session registry", () => {
 		await registry.spawn(session, { cli: "fast", name: "pre-init-kill", prompt: "Start later." });
 		// Wait for the worker to be mid-init (inside the abort-wait) before
 		// issuing the kill — see the handshake comment at the top of the test.
-		await workerStarted;
+		await workerStarted.promise;
 
 		expect((await registry.kill(session, "pre-init-kill")).cancelledTurn).toBe(true);
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -2067,11 +2067,23 @@ describe("vibe session registry", () => {
 	});
 
 	it("persists a kill issued before child initialization and terminalizes the worker if it registers late", async () => {
+		// Handshake so kill() lands while the worker is mid-init, not before its
+		// job body has started executing: on a loaded runner the job may not have
+		// dispatched yet when spawn() returns, and kill would then observe no
+		// registration at all (the mock registers only after the abort lands),
+		// failing the registry assertion below. Resolving once the body is inside
+		// the abort-wait keeps the test exercising exactly the late-registration
+		// path it names.
+		let signalWorkerStarted: () => void = () => {};
+		const workerStarted = new Promise<void>(resolve => {
+			signalWorkerStarted = resolve;
+		});
 		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
 			const artifactsDir = options.artifactsDir;
 			if (!artifactsDir) throw new Error("Persisted vibe test requires an artifacts directory");
 			const signal = options.signal;
 			if (!signal) throw new Error("Pre-initialization worker requires a cancellation signal");
+			signalWorkerStarted();
 			await new Promise<void>(resolve => {
 				if (signal.aborted) resolve();
 				else signal.addEventListener("abort", () => resolve(), { once: true });
@@ -2101,6 +2113,9 @@ describe("vibe session registry", () => {
 		const session = createSession({ manager: jobs, sessionManager: parentManager });
 		const registry = VibeSessionRegistry.global();
 		await registry.spawn(session, { cli: "fast", name: "pre-init-kill", prompt: "Start later." });
+		// Wait for the worker to be mid-init (inside the abort-wait) before
+		// issuing the kill — see the handshake comment at the top of the test.
+		await workerStarted;
 
 		expect((await registry.kill(session, "pre-init-kill")).cancelledTurn).toBe(true);
 		expect(AgentRegistry.global().get("pre-init-kill")).toMatchObject({ status: "aborted", session: null });


### PR DESCRIPTION
Split from #6897.

The pre-init-kill test issued `registry.kill()` immediately after `spawn()` returned; the mock worker only registers its AgentRef after the abort signal lands, so on a loaded runner the job body may not have dispatched yet and kill observed no registration at all (`AgentRegistry.get()` undefined), failing the aborted-ref assertion. The mock now signals readiness once it is inside the abort-wait, and the test awaits that before killing — deterministically exercising the late-registration terminalization path the test names.

Flaked once on CI singleton (vibe session registry). Verified: kill-before-init 5/5, full file 32/32, check:types exit 0, biome clean.