### PR TITLE
feat(coding-agent): add GitHub Projects (V2) board management

### DIFF
--- a/docs/tools/github.md
+++ b/docs/tools/github.md
@@ -17,7 +17,7 @@
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `op` | `"repo_view" \| "pr_create" \| "pr_checkout" \| "pr_push" \| "search_issues" \| "search_prs" \| "search_code" \| "search_commits" \| "search_repos" \| "run_watch"` | Yes | Dispatch selector. `GithubTool.execute()` switches only on this field. |
+| `op` | `"repo_view" \| "pr_create" \| "pr_checkout" \| "pr_push" \| "search_issues" \| "search_prs" \| "search_code" \| "search_commits" \| "search_repos" \| "run_watch" \| "project_view" \| "project_item_add" \| "project_item_create" \| "project_item_edit" \| "project_item_delete" \| "project_create"` | Yes | Dispatch selector. `GithubTool.execute()` switches only on this field. |
 | `repo` | `string` | No | `owner/repo` override. Ignored when the identifier argument is already a full GitHub URL. For `search_issues`/`search_prs`/`search_code`/`search_commits`, defaults to the current checkout's `owner/repo` when omitted (skipped when the query already contains a `repo:`/`org:`/`user:`/`owner:` qualifier or when current-repo resolution fails). Required in practice when `gh` cannot infer repo context from the current checkout. |
 | `branch` | `string` | No | Used by `repo_view`, `pr_push`, and `run_watch`. `run_watch` falls back to current git branch when `run` is omitted; `pr_push` falls back to current branch. |
 | `pr` | `string \| string[]` | No | Used by `pr_checkout`. Each item may be a PR number, branch name, or GitHub PR URL. Array form enables batching. Omitted means current branch PR. |
@@ -36,9 +36,19 @@
 | `since` | `string` | No | Lower date bound for `search_issues`, `search_prs`, `search_commits`, and `search_repos`. Accepts relative durations (`3d`, `12h`, `2w`, `2mo`, `1y`), `YYYY-MM-DD`, or an ISO datetime. Rejected for `search_code`. |
 | `until` | `string` | No | Upper date bound for `search_issues`, `search_prs`, `search_commits`, and `search_repos`. Same formats as `since`. Rejected for `search_code`. |
 | `dateField` | `"created" \| "updated"` | No | Date qualifier field for issue/PR/repo search. Defaults to `created`; repo search maps `updated` to GitHub's `pushed:` qualifier. Ignored for commit search, which always uses `committer-date:`. |
-| `limit` | `number` | No | Used by all `search_*` ops. Defaults to `10`, floored, clamped to `50`, and must be `> 0`. |
+| `limit` | `number` | No | Used by all `search_*` ops (default `10`, max `50`) and `project_view` (default `30`, max `100`). Floored, clamped, and must be `> 0`. |
 | `run` | `string` | No | Used only by `run_watch`. Must be a numeric run ID or full GitHub Actions run URL. |
 | `tail` | `number` | No | Used only by `run_watch`. Defaults to `15`, floored, clamped to `200`, and must be `> 0`. |
+| `project` | `string` | No | Used by all `project_*` ops except `project_create`. A bare project number (then `owner` is required) or a full project URL (`https://github.com/orgs\|users/<login>/projects/<n>`); a URL's owner wins over an explicit `owner`. |
+| `owner` | `string` | No | Org/user login owning the project. Required when `project` is a bare number. |
+| `itemId` | `string` | No | Project item node id (`PVTI_…`) for `project_item_edit`/`project_item_delete`. Mutually exclusive with `contentUrl`. |
+| `contentUrl` | `string` | No | Issue/PR URL. For `project_item_add` it is the content to add; for `project_item_edit`/`project_item_delete` it identifies the project item backed by that issue/PR (resolved via one `item-list` lookup). Mutually exclusive with `itemId` in edit/delete. |
+| `itemStatus` | `string` | No | Target column name for `project_item_edit`; resolved to an option id within the board `field` (case-insensitive). |
+| `field` | `string` | No | Single-select field used as the board column by `project_view` and resolved by `project_item_edit`'s `itemStatus`. Defaults to `"Status"`; must name an existing single-select field. |
+| `archive` | `boolean` | No | Used only by `project_item_delete`. Defaults to `false` (delete); `true` archives instead. |
+| `template` | `string` | No | Used only by `project_create`. One of `kanban`, `team_planning`, `feature_release`, `bug_tracker`, `iterative_development`, `product_launch`, `roadmap`, `team_retrospective`; omit (or `blank`) for a bare project with the default Status field. |
+| `copyFrom` | `string` | No | Used only by `project_create`. Source project number or full URL to clone via `gh project copy` (exact fidelity — fields + views). Mutually exclusive with `template`. |
+| `sourceOwner` | `string` | No | Owner of the `copyFrom` source project (required when `copyFrom` is a bare number; parsed from the URL otherwise). |
 
 ## Outputs
 The tool returns a single text result built by `buildTextResult()` in `packages/coding-agent/src/tools/gh.ts`.
@@ -219,6 +229,89 @@ Watch flow:
 - Inline result includes only the last `tail` lines per failed job. The saved artifact contains full logs (`mode: "full"`).
 - In commit mode, success is intentionally double-checked: once all known runs are successful, the tool waits one more poll interval and succeeds only if the set of run IDs is unchanged. This avoids returning before late workflow runs appear for the same commit.
 - `details.watch` drives a specialized renderer in `packages/coding-agent/src/tools/gh-renderer.ts`; non-watch results fall back to generic text rendering.
+
+### `project_view`
+
+| Aspect | Value |
+| --- | --- |
+| Required fields | `op`, `project` |
+| Optional fields | `owner`, `field`, `limit` |
+| `gh` command | `gh project field-list <num> --owner <owner> --format json` (column field/options), `gh project item-list <num> --owner <owner> --format json --limit <limit>` (items), `gh project view <num> --owner <owner> --format json` (title/url). The three run in parallel. |
+| Batching | None |
+| Output | `# <title> #<num>` header with project URL, `Column field: <field>`, `Items: <n>` (or `Items: <shown> of <totalCount>` on large boards), then one `## <column> (<count>)` section per option of the board field (empty columns shown) plus a trailing `## No status` group. Each item line is `- [PVTI_…] ISSUE\|PR\|DRAFT <title> (#<num> <repo>)`. `sourceUrl` is the project web URL. |
+
+The board column is the single-select field named by `field` (default `"Status"`), resolved case-insensitively from `field-list`; if it is missing or not a single-select, the error lists the available single-select field names. `limit` defaults to `30` and caps at `100`, but caps only the inline item fetch. The spill decision is driven by the board's real `totalCount` (`gh project view`), NOT the page size: when `totalCount` exceeds 30, the full board (all items, no per-column cap) is spilled to a session artifact (`details.artifactId`) and the inline view renders a truncated preview (8 items per column) with a `Full board: artifact://<id>` trailer and an `Items: <shown> of <totalCount>` header. All titles are tab-sanitized and width-truncated; item ids are never truncated.
+
+### `project_item_add`
+
+| Aspect | Value |
+| --- | --- |
+| Required fields | `op`, `project`, `contentUrl` |
+| Optional fields | `owner` |
+| `gh` command | `gh project item-add <num> --owner <owner> --url <contentUrl> --format json` |
+| Batching | None |
+| Output | Confirmation with the added item title, node id, content URL (for issue/PR items), and project URL. `sourceUrl` is the project URL. |
+
+### `project_item_create`
+
+| Aspect | Value |
+| --- | --- |
+| Required fields | `op`, `project`, `title` |
+| Optional fields | `owner`, `body` |
+| `gh` command | `gh project item-create <num> --owner <owner> --title <title> [--body <body>] --format json` |
+| Batching | None |
+| Output | Confirmation with the new draft item title, node id, and project URL. |
+
+### `project_item_edit`
+
+| Aspect | Value |
+| --- | --- |
+| Required fields | `op`, `project`, and exactly one of `itemId` or `contentUrl` |
+| Optional fields | `owner`, `field`, and at least one of `itemStatus` / `title` / `body` |
+| `gh` command | Status move: `gh project item-edit --id <PVTI> --project-id <PVT> --field-id <PVTSSF> --single-select-option-id <opt> --format json` (project/field/option ids resolved from `gh project view`/`field-list`). Draft title/body: `gh project item-edit --id <DI_> --title\|--body … --format json`. |
+| Batching | None |
+| Output | Summary of what changed (e.g. `status → In progress; title updated`), the item id, and the project URL. |
+
+`itemStatus` resolves the option whose name matches case-insensitively within the board `field` (default `"Status"`); an unknown name throws listing the valid options. The project node id comes from `gh project view`. Title/body edits target the draft **content** id (`DI_…`, fetched from `item-list`) and are rejected for issue/PR-backed items — edit those with `gh issue edit`/`gh pr edit`. `contentUrl` is resolved to the backing item via one `item-list` lookup matching `content.url` (trailing slash, query, and fragment stripped on both sides); no match throws `no project item found for <url>`.
+
+### `project_item_delete`
+
+| Aspect | Value |
+| --- | --- |
+| Required fields | `op`, `project`, and exactly one of `itemId` or `contentUrl` |
+| Optional fields | `owner`, `archive` |
+| `gh` command | `gh project item-delete <num> --owner <owner> --id <PVTI> --format json`, or `gh project item-archive …` when `archive` is `true`. |
+| Batching | None |
+| Output | `Deleted`/`Archived project item <id>.` plus the project URL. |
+
+`contentUrl` resolves to the item id via one `item-list` lookup (same matching as `project_item_edit`).
+
+### `project_create`
+
+| Aspect | Value |
+| --- | --- |
+| Required fields | `op`, `owner`, `title` |
+| Optional fields | `template`, `copyFrom`, `sourceOwner` (at most one of `template`/`copyFrom`) |
+| `gh` command | `copyFrom`: `gh project copy <srcNumber> --source-owner <srcOwner> --target-owner <owner> --title <title> --format json`. `template`: `gh project create --owner <owner> --title <title> --format json`, then `gh project field-list <num> --owner <owner> --format json` (find the default Status field id), `gh api graphql --input <body>` (`updateProjectV2Field` to rewrite the Status options), then `gh project field-create <num> --owner <owner> --name <field> --data-type SINGLE_SELECT --single-select-options <csv>` per extra field. `blank`: `gh project create` only. |
+| Batching | None |
+| Output | `Created project <title> #<num>.` with URL and, for a template, the applied Status options + extra fields. `sourceUrl` is the new project URL. |
+
+GitHub has NO API to clone a project template (that is a github.com web-UI feature). Templates are therefore EMULATED: a blank project already ships a default Status field (Todo / In Progress / Done), so a template REWRITES that field's options to the preset's set via the `updateProjectV2Field` GraphQL mutation (gh has no field-option-edit CLI), then adds signature fields. This replicates the template's FIELD SCHEMA — not its built-in views, insights, or automations. `field-create` supports TEXT/SINGLE_SELECT/DATE/NUMBER (NOT ITERATION), so iteration-style templates substitute a NUMBER field and date-style templates carry a real DATE field. Presets:
+- `team_planning` — Status: No status, Backlog, Ready, In progress, In review, Done.
+- `kanban` — Status: Todo, In progress, Done (classic 3-state board).
+- `feature_release` — Status: No status, Backlog, In progress, In review, Done; + DATE "Target date".
+- `iterative_development` — Status: No status, Backlog, In progress, In review, Done; + NUMBER "Story points".
+- `bug_tracker` — Status: No status, Needs triage, In progress, Done; + Priority (P0–P3); + Severity (Low, Medium, High, Critical).
+- `product_launch` — Status: No status, Planning, In progress, In review, Done; + DATE "Launch date".
+- `roadmap` — Status: No status, Planning, In progress, Ready, Done; + DATE "Target date".
+- `team_retrospective` — Status: No status, Went well, Didn't go well, Action items.
+- Omit `template` (or `blank`) — bare project, default Status field left untouched.
+
+If template application fails partway (e.g. after the Status rewrite but before an extra field), the project still exists; the error names the project URL so it can be fixed or deleted manually.
+
+For EXACT fidelity, pass `copyFrom` (source project number/URL + `sourceOwner`) instead of `template`: `gh project copy` (`copyProjectV2`) faithfully clones the source's fields and views, and no preset is applied afterward. `copyFrom` and `template` are mutually exclusive. To prepare a reusable source, build a project once from a gallery template in the GitHub UI, then `gh project mark-template <num> --owner <owner>` it; clone it thereafter via `copyFrom`.
+
+All `project_*` ops go through `git.github.json` and reuse the centralized scope gate: a missing `project` OAuth scope is detected case-insensitively from either gh's pre-flight message (`...missing required scopes ['project']`) or the GraphQL API error (`...granted the required scopes ... ['read:project']`) — both contain "required scopes" and "project" — and surfaced as `GitHub Projects requires the 'project' OAuth scope. Run \`gh auth refresh -s project\` and retry.`
 
 ## Side Effects
 - Filesystem

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- GitHub Projects (V2) board management in the `github` tool: `project_view`, `project_item_add`, `project_item_create`, `project_item_edit`, `project_item_delete`, and `project_create` (with emulated built-in template presets — Status options rewritten + signature single-select fields, not a full template clone — plus a `copyFrom` mode that clones an existing project via `gh project copy` for exact fidelity).
+
 ## [17.2.4] - 2026-08-01
 
 ### Added

--- a/packages/coding-agent/src/prompts/tools/github.md
+++ b/packages/coding-agent/src/prompts/tools/github.md
@@ -11,7 +11,15 @@ Pick op via `op`. Beyond the field descriptions, per op:
 - `search_*` default `repo` to the current checkout's `owner/repo`; pass a `repo:`/`org:`/`user:` qualifier in `query` to search elsewhere. `search_repos` is the exception — it ignores `repo`; scope it with `org:`/`language:` qualifiers in `query`.
 - `since`/`until` — relative duration (`<n>` + `m`/`h`/`d`/`w`/`mo`/`y`, e.g. `3d`, `2w`), ISO date (`YYYY-MM-DD`), or ISO datetime. `dateField: "updated"` filters on update time (issues/PRs) or push time (repos), not creation.
 - `run_watch` — omit `run` to watch every run for the current HEAD (`branch` falls back to current). Fast-fails on the first job failure.
+- `project_view` (read) — show the kanban board. `project` is a bare number (needs `owner`) or a full project URL; `field` selects the single-select column field (defaults to `Status`); `limit` caps items (default 30, max 100). Every item line carries its node id `[PVTI_…]` for use in edits.
+- `project_item_add` — add an existing issue/PR (`contentUrl`) to the project.
+- `project_item_create` — create a draft item (`title`, optional `body`).
+- `project_item_edit` — pass `itemId` OR `contentUrl` (resolved to the backing item), then at least one of `itemStatus` (column name within `field`, default `Status`), `title`, `body`. Title/body only work on draft items; issue/PR-backed items reject them (edit those via `gh issue edit`/`gh pr edit`).
+- `project_item_delete` — pass `itemId` OR `contentUrl`; `archive: true` archives instead of deleting.
+- `project_create` — create a project (`owner` + `title` required). `template` applies one of: `kanban`, `team_planning`, `feature_release`, `bug_tracker`, `iterative_development`, `product_launch`, `roadmap`, `team_retrospective`; omit/`blank` for a bare project. Templates are EMULATED, not cloned: the default Status field's options are rewritten and the template's signature fields are created (e.g. bug_tracker → Priority + Severity single-selects; feature_release/roadmap → a DATE field; iterative_development → a NUMBER field). Only ITERATION fields aren't supported (iterative templates substitute a NUMBER field). GitHub's built-in views/automations/insights are NOT replicated. For EXACT fidelity pass `copyFrom` (source project number/URL + `sourceOwner`) to clone via `gh project copy` — at most one of `template`/`copyFrom`; prepare a reusable source with `gh project mark-template`.
 </instruction>
+
+GitHub Projects V2 needs the `project` OAuth scope. If a project op fails with a missing-scope error, tell the user to run `gh auth refresh -s project`.
 
 <output>
 Concise summary per op. `run_watch` failures save full logs to a session artifact.

--- a/packages/coding-agent/src/tools/gh-renderer.ts
+++ b/packages/coding-agent/src/tools/gh-renderer.ts
@@ -29,6 +29,7 @@ type GithubToolRenderArgs = {
 	repo?: string;
 	pr?: string | string[];
 	query?: string;
+	project?: string;
 };
 
 const SUCCESS_CONCLUSIONS = new Set(["success", "neutral", "skipped"]);
@@ -47,6 +48,12 @@ const OP_TITLES: Record<string, string> = {
 	search_commits: "GitHub Search Commits",
 	search_repos: "GitHub Search Repos",
 	run_watch: "GitHub Run Watch",
+	project_view: "GitHub Project",
+	project_item_add: "GitHub Project Item Add",
+	project_item_create: "GitHub Project Item Create",
+	project_item_edit: "GitHub Project Item Edit",
+	project_item_delete: "GitHub Project Item Delete",
+	project_create: "GitHub Project Create",
 };
 
 function formatOpTitle(op: string | undefined): string {
@@ -104,6 +111,15 @@ function buildOpMeta(args: GithubToolRenderArgs): string[] {
 		case "repo_view": {
 			if (args.repo) meta.push(args.repo);
 			if (args.branch) meta.push(args.branch);
+			break;
+		}
+		case "project_view":
+		case "project_item_add":
+		case "project_item_create":
+		case "project_item_edit":
+		case "project_item_delete":
+		case "project_create": {
+			if (args.project) meta.push(truncateVisualWidth(args.project, TRUNCATE_LENGTHS.SHORT));
 			break;
 		}
 		case "run_watch":

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -19,6 +19,7 @@ import type { ToolSession } from ".";
 import { formatShortSha } from "./gh-format";
 import { type CacheStatus, getOrFetchView, invalidateAllForNumber, resolveGithubCacheAuthKey } from "./github-cache";
 import type { OutputMeta } from "./output-meta";
+import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth as truncateVisualWidth } from "./render-utils";
 import { ToolError, throwIfAborted } from "./tool-errors";
 import { toolResult } from "./tool-result";
 
@@ -247,6 +248,20 @@ const RUN_URL_PATTERN = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/actions\/runs\/
 const RUN_SUCCESS_CONCLUSIONS = new Set(["success", "neutral", "skipped"]);
 const RUN_FAILURE_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required", "startup_failure"]);
 const JOB_FAILURE_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required"]);
+const PROJECT_ITEM_LIMIT_DEFAULT = 30;
+const PROJECT_ITEM_LIMIT_MAX = 100;
+const PROJECT_BOARD_FIELD_DEFAULT = "Status";
+const PROJECT_NO_STATUS_GROUP = "No status";
+const PROJECT_INLINE_ITEMS_PER_COLUMN = 8;
+const PROJECT_SPILL_THRESHOLD = 30;
+// Cap for the project_view RENDER path only. Resolution lookups
+// (contentUrl -> item, itemId find) use PROJECT_ITEM_LOOKUP_LIMIT instead so
+// they are not capped at 100 on large boards.
+const PROJECT_ITEM_LOOKUP_LIMIT = 1000;
+// `gh project field-list` defaults to 30; boards with >30 fields would drop the
+// Status field off the page. Field counts are tiny, so over-fetch at 100.
+const PROJECT_FIELD_LOOKUP_LIMIT = 100;
+const PROJECT_URL_PATTERN = /^https:\/\/github\.com\/(?:orgs|users)\/([^/]+)\/projects\/(\d+)(?:\/.*)?$/;
 const GITHUB_READONLY_OPS: ReadonlySet<string> = new Set([
 	"repo_view",
 	"file_read",
@@ -256,11 +271,12 @@ const GITHUB_READONLY_OPS: ReadonlySet<string> = new Set([
 	"search_commits",
 	"search_repos",
 	"run_watch",
+	"project_view",
 ]);
 
 const githubSchema = type({
 	op: type(
-		"'repo_view' | 'file_read' | 'pr_create' | 'pr_checkout' | 'pr_push' | 'search_issues' | 'search_prs' | 'search_code' | 'search_commits' | 'search_repos' | 'run_watch'",
+		"'repo_view' | 'file_read' | 'pr_create' | 'pr_checkout' | 'pr_push' | 'search_issues' | 'search_prs' | 'search_code' | 'search_commits' | 'search_repos' | 'run_watch' | 'project_view' | 'project_item_add' | 'project_item_create' | 'project_item_edit' | 'project_item_delete' | 'project_create'",
 	).describe("github operation"),
 	"repo?": type("string").describe("owner/repo"),
 	"branch?": type("string").describe("branch"),
@@ -284,6 +300,20 @@ const githubSchema = type({
 	"limit?": type("number").describe("max results"),
 	"run?": type("string").describe("actions run id or url"),
 	"tail?": type("number").describe("log lines per failed job"),
+	"project?": type("string").describe("project number or full github project url"),
+	"owner?": type("string").describe("org or user login owning the project"),
+	"itemId?": type("string").describe("project item node id (edit/delete)"),
+	"contentUrl?": type("string").describe("issue or pr url to add, or item backed by it (edit/delete)"),
+	"itemStatus?": type("string").describe("target status column name (project_item_edit)"),
+	"field?": type("string").describe("single-select field used as board column (defaults to Status)"),
+	"archive?": type("boolean").describe("archive instead of delete (project_item_delete)"),
+	"template?": type("string").describe(
+		"project template id for project_create (kanban, team_planning, feature_release, bug_tracker, iterative_development, product_launch, roadmap, team_retrospective)",
+	),
+	"copyFrom?": type("string").describe("source project number or url to clone via gh project copy (project_create)"),
+	"sourceOwner?": type("string").describe(
+		"owner of the copyFrom source project (required when copyFrom is a bare number)",
+	),
 });
 
 type GithubInput = typeof githubSchema.infer;
@@ -624,6 +654,74 @@ interface GhFailedJobLog {
 	full?: string;
 	tail?: string;
 	available: boolean;
+}
+// ────────────────────────────────────────────────────────────────────────────
+// GitHub Projects (V2) — response shapes observed from `gh project ... --format json`.
+// Projects V2 is GraphQL-only; the `gh` CLI wraps it. Single-select field values
+// are flattened onto each item keyed by field name (e.g. item.status for "Status").
+// ────────────────────────────────────────────────────────────────────────────
+
+interface GhProjectOwner {
+	login?: string;
+	type?: string;
+}
+
+interface GhProjectView {
+	closed?: boolean;
+	id?: string;
+	number?: number;
+	title?: string;
+	url?: string;
+	shortDescription?: string | null;
+	public?: boolean;
+	readme?: string;
+	owner?: GhProjectOwner | null;
+	fields?: { totalCount?: number };
+	items?: { totalCount?: number };
+}
+
+interface GhProjectFieldOption {
+	id?: string;
+	name?: string;
+}
+
+interface GhProjectField {
+	id?: string;
+	name?: string;
+	type?: string;
+	options?: GhProjectFieldOption[];
+}
+
+interface GhProjectFieldList {
+	fields?: GhProjectField[];
+}
+
+interface GhProjectItemContent {
+	id?: string;
+	title?: string;
+	body?: string | null;
+	type?: string;
+	url?: string;
+	number?: number;
+	repository?: string;
+}
+
+type GhProjectItem = {
+	id?: string;
+	title?: string;
+	content?: GhProjectItemContent | null;
+} & Record<string, unknown>;
+
+interface GhProjectItemList {
+	items?: GhProjectItem[];
+}
+
+interface GhProjectItemMutation {
+	id?: string;
+	title?: string;
+	body?: string | null;
+	type?: string;
+	url?: string;
 }
 
 function normalizeText(value: string | null | undefined): string {
@@ -1150,6 +1248,40 @@ function parseRunReference(value: string | undefined): GhRunReference {
 		repo: match[1],
 		runId: Number(match[2]),
 	};
+}
+
+/**
+ * Resolve a GitHub Projects V2 reference into its owner login + project number.
+ * Accepts a bare number (requires `owner`) or a full project URL
+ * (`https://github.com/orgs|users/<login>/projects/<n>`). For URLs the owner is
+ * taken from the URL; an explicit `owner` argument is ignored in that case.
+ */
+export function parseProjectReference(
+	value: string | undefined,
+	owner: string | undefined,
+): { owner: string; number: number } {
+	const normalized = normalizeOptionalString(value);
+	if (!normalized) {
+		throw new ToolError("project must be a project number or a full GitHub project URL");
+	}
+
+	if (/^\d+$/.test(normalized)) {
+		const resolvedOwner = normalizeOptionalString(owner);
+		if (!resolvedOwner) {
+			throw new ToolError("owner is required when project is a bare number");
+		}
+		return { owner: resolvedOwner, number: Number(normalized) };
+	}
+
+	const match = normalized.match(PROJECT_URL_PATTERN);
+	if (!match) {
+		throw new ToolError(
+			"project must be a bare number (with owner) or a full GitHub project URL " +
+				"(https://github.com/orgs/<login>/projects/<n> or https://github.com/users/<login>/projects/<n>)",
+		);
+	}
+
+	return { owner: match[1], number: Number(match[2]) };
 }
 
 function parsePullRequestUrl(value: string | undefined): { repo?: string; prNumber?: number } {
@@ -2502,6 +2634,18 @@ export class GithubTool implements AgentTool<typeof githubSchema, GhToolDetails>
 					return executeSearchRepos(this.session, params, signal);
 				case "run_watch":
 					return executeRunWatch(this.session, this.name, params, signal, onUpdate);
+				case "project_view":
+					return executeProjectView(this.session, params, signal);
+				case "project_item_add":
+					return executeProjectItemAdd(this.session, params, signal);
+				case "project_item_create":
+					return executeProjectItemCreate(this.session, params, signal);
+				case "project_item_edit":
+					return executeProjectItemEdit(this.session, params, signal);
+				case "project_item_delete":
+					return executeProjectItemDelete(this.session, params, signal);
+				case "project_create":
+					return executeProjectCreate(this.session, params, signal);
 			}
 		});
 	}
@@ -3956,4 +4100,781 @@ async function executeRunWatch(
 		}
 		await scheduler.wait(currentIntervalSeconds() * 1000, { signal });
 	}
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// GitHub Projects (V2)
+//
+// Projects V2 is GraphQL-only; `gh project ... --format json` wraps it. The `gh`
+// CLI does not request the `project` OAuth scope by default, so every project
+// call 403s until the user runs `gh auth refresh -s project`. `runProjectJson`
+// centralizes that detection so all project ops surface the remediation.
+// ────────────────────────────────────────────────────────────────────────────
+
+function resolveProjectItemLimit(value: number | undefined): number {
+	if (value === undefined) {
+		return PROJECT_ITEM_LIMIT_DEFAULT;
+	}
+	if (!Number.isFinite(value) || value <= 0) {
+		throw new ToolError("limit must be a positive number");
+	}
+	return Math.min(Math.floor(value), PROJECT_ITEM_LIMIT_MAX);
+}
+
+function isProjectScopeError(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+	const message = err.message.toLowerCase();
+	// Matches both gh's own pre-flight message ("...missing required scopes ['project']")
+	// and the GraphQL API error ("Your token has not been granted the required scopes
+	// ... ['read:project']"). Both contain "required scopes" and "project".
+	return message.includes("required scopes") && message.includes("project");
+}
+
+async function runProjectJson<T>(cwd: string, args: string[], signal: AbortSignal | undefined): Promise<T> {
+	try {
+		return await git.github.json<T>(cwd, args, signal);
+	} catch (err) {
+		if (isProjectScopeError(err)) {
+			throw new ToolError(
+				"GitHub Projects requires the 'project' OAuth scope. Run `gh auth refresh -s project` and retry.",
+			);
+		}
+		throw err;
+	}
+}
+
+async function fetchProjectFields(
+	session: ToolSession,
+	owner: string,
+	number: number,
+	signal: AbortSignal | undefined,
+): Promise<GhProjectField[]> {
+	const data = await runProjectJson<GhProjectFieldList>(
+		session.cwd,
+		[
+			"project",
+			"field-list",
+			String(number),
+			"--owner",
+			owner,
+			"--format",
+			"json",
+			"--limit",
+			String(PROJECT_FIELD_LOOKUP_LIMIT),
+		],
+		signal,
+	);
+	return data.fields ?? [];
+}
+
+async function fetchProjectItems(
+	session: ToolSession,
+	owner: string,
+	number: number,
+	limit: number,
+	signal: AbortSignal | undefined,
+): Promise<GhProjectItem[]> {
+	const data = await runProjectJson<GhProjectItemList>(
+		session.cwd,
+		["project", "item-list", String(number), "--owner", owner, "--format", "json", "--limit", String(limit)],
+		signal,
+	);
+	return data.items ?? [];
+}
+
+async function fetchProjectView(
+	session: ToolSession,
+	owner: string,
+	number: number,
+	signal: AbortSignal | undefined,
+): Promise<GhProjectView> {
+	return runProjectJson<GhProjectView>(
+		session.cwd,
+		["project", "view", String(number), "--owner", owner, "--format", "json"],
+		signal,
+	);
+}
+
+/**
+ * Resolve the single-select field used as the board column. Field name match is
+ * case-insensitive; throws when the field is absent or not a single-select,
+ * listing the available single-select field names.
+ */
+export function resolveProjectBoardField(
+	fields: GhProjectField[],
+	fieldName: string,
+): { field: GhProjectField; options: GhProjectFieldOption[] } {
+	const target = fieldName.trim().toLowerCase();
+	const singleSelectNames = fields
+		.filter(f => f.type === "ProjectV2SingleSelectField")
+		.map(f => f.name ?? "")
+		.filter(name => name.length > 0);
+	const match = fields.find(f => (f.name ?? "").trim().toLowerCase() === target);
+	const list = singleSelectNames.map(name => `"${name}"`).join(", ");
+	const missingMessage = `project has no single-select field named "${fieldName}".${list ? ` Available single-select fields: ${list}.` : ""}`;
+	if (!match) {
+		throw new ToolError(missingMessage);
+	}
+	if (match.type !== "ProjectV2SingleSelectField") {
+		throw new ToolError(missingMessage);
+	}
+	const options = match.options ?? [];
+	if (options.length === 0) {
+		throw new ToolError(`project field "${fieldName}" has no options configured.`);
+	}
+	return { field: match, options };
+}
+
+function findProjectFieldOption(options: GhProjectFieldOption[], value: string): GhProjectFieldOption | undefined {
+	const target = value.trim().toLowerCase();
+	return options.find(option => (option.name ?? "").trim().toLowerCase() === target);
+}
+
+/**
+ * Read an item's value for a flattened single-select field. `gh project
+ * item-list` flattens each single-select field value onto the item keyed by the
+ * field name (e.g. "Status" → `status`); matching is case- and whitespace-insensitive.
+ */
+export function getProjectItemFieldValue(item: GhProjectItem, fieldName: string): string | undefined {
+	const target = fieldName.trim().toLowerCase().replace(/\s+/g, "");
+	for (const [key, value] of Object.entries(item)) {
+		if (key === "id" || key === "title" || key === "content") continue;
+		if (key.toLowerCase().replace(/\s+/g, "") === target && typeof value === "string") {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+export function normalizeGithubContentUrl(url: string): string {
+	let normalized = url.trim().split("#")[0]?.split("?")[0];
+	if (normalized === undefined) return "";
+	while (normalized.endsWith("/")) normalized = normalized.slice(0, -1);
+	// Canonicalize issue/PR subpage URLs down to /issues/<n> or /pull/<n> (e.g.
+	// /pull/7/files -> /pull/7) so a contentUrl with a subpage path matches the
+	// item's canonical content.url. Non-issue/PR URLs are left unchanged.
+	const subpage = normalized.match(/^(https:\/\/github\.com\/[^/]+\/[^/]+\/(?:issues|pull)\/\d+)/);
+	if (subpage) normalized = subpage[1];
+	return normalized;
+}
+
+export function findProjectItemByContentUrl(items: GhProjectItem[], contentUrl: string): GhProjectItem | undefined {
+	const target = normalizeGithubContentUrl(contentUrl);
+	if (!target) return undefined;
+	return items.find(item => {
+		const url = item.content?.url;
+		return url !== undefined && normalizeGithubContentUrl(url) === target;
+	});
+}
+
+function formatProjectItemLine(item: GhProjectItem): string {
+	const id = replaceTabs(item.id ?? "?");
+	const content = item.content;
+	const type = content?.type;
+	let marker: string;
+	if (type === "Issue") {
+		marker = "ISSUE";
+	} else if (type === "PullRequest") {
+		marker = "PR";
+	} else {
+		marker = "DRAFT";
+	}
+	let suffix = "";
+	if ((type === "Issue" || type === "PullRequest") && content?.number !== undefined) {
+		const repo = content.repository ? ` ${replaceTabs(content.repository)}` : "";
+		suffix = ` (#${content.number}${repo})`;
+	}
+	const rawTitle = content?.title ?? item.title ?? "(untitled)";
+	const title = truncateVisualWidth(replaceTabs(rawTitle), TRUNCATE_LENGTHS.TITLE);
+	return `- [${id}] ${marker} ${title}${suffix}`;
+}
+
+function formatProjectColumn(lines: string[], name: string, colItems: GhProjectItem[], itemsPerColumn: number): void {
+	lines.push(`## ${replaceTabs(name)} (${colItems.length})`);
+	if (colItems.length === 0) {
+		lines.push("");
+		return;
+	}
+	const shown = colItems.slice(0, itemsPerColumn);
+	for (const item of shown) lines.push(formatProjectItemLine(item));
+	if (colItems.length > itemsPerColumn) {
+		lines.push(`... and ${colItems.length - itemsPerColumn} more`);
+	}
+	lines.push("");
+}
+
+export function formatProjectBoard(
+	project: GhProjectView,
+	fieldName: string,
+	options: GhProjectFieldOption[],
+	items: GhProjectItem[],
+	itemsPerColumn: number,
+	totalCount?: number,
+): string {
+	const lines: string[] = [];
+	const title = replaceTabs(project.title ?? "GitHub Project");
+	const numberSuffix = project.number !== undefined ? ` #${project.number}` : "";
+	lines.push(`# ${title}${numberSuffix}`);
+	if (project.url) lines.push(replaceTabs(project.url));
+	lines.push("");
+	lines.push(`Column field: ${replaceTabs(fieldName)}`);
+	const countLine =
+		totalCount !== undefined && totalCount > items.length
+			? `Items: ${items.length} of ${totalCount}`
+			: `Items: ${items.length}`;
+	lines.push(countLine);
+	lines.push("");
+
+	// A real option literally named "No status" is the home for empty-value items;
+	// only render the synthetic bucket when no such option exists (otherwise an
+	// external board like kourierai #2 would render two "No status" headers).
+	const orderedNames = options.map(option => option.name ?? "").filter(name => name.length > 0);
+	const realNoStatusName = orderedNames.find(
+		name => name.trim().toLowerCase() === PROJECT_NO_STATUS_GROUP.toLowerCase(),
+	);
+	const bucketMap = new Map<string, GhProjectItem[]>();
+	const noStatus: GhProjectItem[] = [];
+	for (const item of items) {
+		const status = getProjectItemFieldValue(item, fieldName);
+		if (!status) {
+			// An item with no Status is visually equivalent to "No status": fold it into
+			// the real option when one exists, else defer to the synthetic bucket below.
+			if (realNoStatusName) {
+				const existing = bucketMap.get(realNoStatusName);
+				if (existing) existing.push(item);
+				else bucketMap.set(realNoStatusName, [item]);
+			} else {
+				noStatus.push(item);
+			}
+			continue;
+		}
+		const existing = bucketMap.get(status);
+		if (existing) existing.push(item);
+		else bucketMap.set(status, [item]);
+	}
+	const extraNames = [...bucketMap.keys()].filter(
+		name => !orderedNames.some(ordered => ordered.toLowerCase() === name.toLowerCase()),
+	);
+	const columnNames = [...orderedNames, ...extraNames];
+	for (const name of columnNames) {
+		formatProjectColumn(lines, name, bucketMap.get(name) ?? [], itemsPerColumn);
+	}
+	if (!realNoStatusName && noStatus.length > 0) {
+		formatProjectColumn(lines, PROJECT_NO_STATUS_GROUP, noStatus, itemsPerColumn);
+	}
+	return lines.join("\n").trim();
+}
+
+function formatProjectItemMutationResult(verb: string, item: GhProjectItemMutation, projectUrl?: string): string {
+	const lines: string[] = [`${verb} project item.`];
+	const title = truncateVisualWidth(replaceTabs(item.title ?? "(untitled)"), TRUNCATE_LENGTHS.TITLE);
+	const id = item.id ? ` [${replaceTabs(item.id)}]` : "";
+	lines.push(`Item: ${title}${id}`);
+	if (item.type && item.type !== "DraftIssue" && item.url) {
+		lines.push(`URL: ${replaceTabs(item.url)}`);
+	}
+	if (projectUrl) lines.push(`Project: ${replaceTabs(projectUrl)}`);
+	return lines.join("\n");
+}
+
+async function executeProjectView(
+	session: ToolSession,
+	params: GithubInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GhToolDetails>> {
+	const { owner, number } = parseProjectReference(params.project, params.owner);
+	const inlineLimit = resolveProjectItemLimit(params.limit);
+	const fieldName = normalizeOptionalString(params.field) ?? PROJECT_BOARD_FIELD_DEFAULT;
+	const [fields, inlineItems, project] = await Promise.all([
+		fetchProjectFields(session, owner, number, signal),
+		fetchProjectItems(session, owner, number, inlineLimit, signal),
+		fetchProjectView(session, owner, number, signal),
+	]);
+	const { options } = resolveProjectBoardField(fields, fieldName);
+	const sourceUrl = project.url;
+	// `inlineItems` is capped at `inlineLimit` (≤30), so the spill decision is driven
+	// by the board's real `totalCount` (not items.length, which is just the page size).
+	const totalCount = project.items?.totalCount;
+	const large = totalCount !== undefined && totalCount > PROJECT_SPILL_THRESHOLD;
+	const details: GhToolDetails = {};
+	let text: string;
+	if (large) {
+		// Spill the full board (all items, no per-column cap) to a session artifact and
+		// render a truncated inline preview (capped fetch, 8 items per column).
+		const allItems = await fetchProjectItems(session, owner, number, PROJECT_ITEM_LOOKUP_LIMIT, signal);
+		const fullBoard = formatProjectBoard(project, fieldName, options, allItems, Number.POSITIVE_INFINITY, totalCount);
+		const artifactId = await saveArtifactText(session, "github", fullBoard);
+		if (artifactId) details.artifactId = artifactId;
+		const inline = formatProjectBoard(
+			project,
+			fieldName,
+			options,
+			inlineItems,
+			PROJECT_INLINE_ITEMS_PER_COLUMN,
+			totalCount,
+		);
+		const boardLabel =
+			totalCount !== undefined && totalCount > allItems.length
+				? `Full board (first ${allItems.length})`
+				: "Full board";
+		text = appendArtifactReference(inline, artifactId, boardLabel);
+	} else {
+		text = formatProjectBoard(project, fieldName, options, inlineItems, Number.POSITIVE_INFINITY, totalCount);
+	}
+	return buildTextResult(text, sourceUrl, Object.keys(details).length > 0 ? details : undefined);
+}
+
+async function executeProjectItemAdd(
+	session: ToolSession,
+	params: GithubInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GhToolDetails>> {
+	const { owner, number } = parseProjectReference(params.project, params.owner);
+	const contentUrl = requireNonEmpty(normalizeOptionalString(params.contentUrl), "contentUrl");
+	// Fetch the project view BEFORE the mutation so a transient read failure cannot
+	// orphan a successful write (or duplicate it on retry).
+	const project = await fetchProjectView(session, owner, number, signal);
+	const item = await runProjectJson<GhProjectItemMutation>(
+		session.cwd,
+		["project", "item-add", String(number), "--owner", owner, "--url", contentUrl, "--format", "json"],
+		signal,
+	);
+	return buildTextResult(formatProjectItemMutationResult("Added", item, project.url), project.url);
+}
+
+async function executeProjectItemCreate(
+	session: ToolSession,
+	params: GithubInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GhToolDetails>> {
+	const { owner, number } = parseProjectReference(params.project, params.owner);
+	const title = requireNonEmpty(normalizeOptionalString(params.title), "title");
+	const project = await fetchProjectView(session, owner, number, signal);
+	const args = ["project", "item-create", String(number), "--owner", owner, "--title", title];
+	if (params.body !== undefined) args.push("--body", params.body);
+	args.push("--format", "json");
+	const item = await runProjectJson<GhProjectItemMutation>(session.cwd, args, signal);
+	return buildTextResult(formatProjectItemMutationResult("Created draft", item, project.url), project.url);
+}
+
+async function executeProjectItemEdit(
+	session: ToolSession,
+	params: GithubInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GhToolDetails>> {
+	const { owner, number } = parseProjectReference(params.project, params.owner);
+	const itemId = normalizeOptionalString(params.itemId);
+	const contentUrl = normalizeOptionalString(params.contentUrl);
+	if ((itemId !== undefined) === (contentUrl !== undefined)) {
+		throw new ToolError("provide exactly one of itemId or contentUrl");
+	}
+	const itemStatus = normalizeOptionalString(params.itemStatus);
+	const title = normalizeOptionalString(params.title);
+	const bodyProvided = params.body !== undefined;
+	if (!itemStatus && !title && !bodyProvided) {
+		throw new ToolError("provide at least one of itemStatus, title, or body");
+	}
+	const fieldName = normalizeOptionalString(params.field) ?? PROJECT_BOARD_FIELD_DEFAULT;
+
+	// ── resolve the target item node id (PVTI) ───────────────────────────────
+	let resolvedItemId = itemId;
+	let itemRecord: GhProjectItem | undefined;
+	if (contentUrl) {
+		const items = await fetchProjectItems(session, owner, number, PROJECT_ITEM_LOOKUP_LIMIT, signal);
+		itemRecord = findProjectItemByContentUrl(items, contentUrl);
+		if (!itemRecord?.id) {
+			throw new ToolError(`no project item found for ${contentUrl}`);
+		}
+		resolvedItemId = itemRecord.id;
+	}
+
+	// ── VALIDATION PHASE — every check completes before the first mutation ──
+	const project = await fetchProjectView(session, owner, number, signal);
+	let statusTarget:
+		| { clear: true; fieldId: string; projectId: string }
+		| { clear: false; fieldId: string; optionId: string; optionName: string; projectId: string }
+		| undefined;
+	if (itemStatus) {
+		const fields = await fetchProjectFields(session, owner, number, signal);
+		const { field, options } = resolveProjectBoardField(fields, fieldName);
+		if (!field.id) throw new ToolError("could not resolve project field id");
+		if (!project.id) throw new ToolError("could not resolve project node id");
+		if (itemStatus.toLowerCase() === PROJECT_NO_STATUS_GROUP.toLowerCase()) {
+			// "No status" universally means "remove the Status value": always --clear the
+			// board field, never set a real option, so the same input round-trips identically
+			// on bare and templated boards (no behavior split on whether a real "No status"
+			// option exists). The renderer merges cleared items into the "No status" group.
+			statusTarget = { clear: true, fieldId: field.id, projectId: project.id };
+		} else {
+			const option = findProjectFieldOption(options, itemStatus);
+			if (!option?.id || !option.name) {
+				const valid = options
+					.map(o => o.name ?? "")
+					.filter(name => name.length > 0)
+					.join(", ");
+				throw new ToolError(
+					`"${itemStatus}" is not a valid option for field "${fieldName}". Valid options: ${valid}`,
+				);
+			}
+			statusTarget = {
+				clear: false,
+				fieldId: field.id,
+				optionId: option.id,
+				optionName: option.name,
+				projectId: project.id,
+			};
+		}
+	}
+	let draftContentId: string | undefined;
+	if (title || bodyProvided) {
+		if (!itemRecord) {
+			const items = await fetchProjectItems(session, owner, number, PROJECT_ITEM_LOOKUP_LIMIT, signal);
+			itemRecord = items.find(item => item.id === resolvedItemId);
+		}
+		if (!itemRecord) {
+			throw new ToolError(
+				`could not locate item ${resolvedItemId ?? "?"} in the project (it may be beyond the first ${PROJECT_ITEM_LOOKUP_LIMIT} items).`,
+			);
+		}
+		if (itemRecord.content?.type !== "DraftIssue") {
+			throw new ToolError(
+				`title/body can only be edited for draft items; this item is ${itemRecord.content?.type ?? "not a draft"}. ` +
+					"Edit issue/PR content with `gh issue edit` or `gh pr edit`.",
+			);
+		}
+		draftContentId = itemRecord.content?.id;
+		if (!draftContentId) throw new ToolError("could not resolve draft content id for title/body edit");
+	}
+
+	// ── MUTATION PHASE — all validation has passed ──────────────────────────
+	const changes: string[] = [];
+	if (statusTarget) {
+		const editArgs = [
+			"project",
+			"item-edit",
+			"--id",
+			resolvedItemId ?? "",
+			"--project-id",
+			statusTarget.projectId,
+			"--field-id",
+			statusTarget.fieldId,
+		];
+		if (statusTarget.clear) {
+			editArgs.push("--clear");
+			changes.push(`status → ${PROJECT_NO_STATUS_GROUP} (cleared)`);
+		} else {
+			editArgs.push("--single-select-option-id", statusTarget.optionId);
+			changes.push(`status → ${statusTarget.optionName}`);
+		}
+		editArgs.push("--format", "json");
+		await runProjectJson<GhProjectItemMutation>(session.cwd, editArgs, signal);
+	}
+	if (title) {
+		await runProjectJson<GhProjectItemMutation>(
+			session.cwd,
+			["project", "item-edit", "--id", draftContentId ?? "", "--title", title, "--format", "json"],
+			signal,
+		);
+		changes.push("title updated");
+	}
+	if (bodyProvided) {
+		await runProjectJson<GhProjectItemMutation>(
+			session.cwd,
+			["project", "item-edit", "--id", draftContentId ?? "", "--body", params.body ?? "", "--format", "json"],
+			signal,
+		);
+		changes.push("body updated");
+	}
+
+	const summary = changes.length > 0 ? changes.join("; ") : "no changes";
+	const text = `Updated project item ${replaceTabs(resolvedItemId ?? "?")} (${replaceTabs(summary)}).\nProject: ${replaceTabs(project.url ?? "")}`;
+	return buildTextResult(text, project.url);
+}
+
+async function executeProjectItemDelete(
+	session: ToolSession,
+	params: GithubInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GhToolDetails>> {
+	const { owner, number } = parseProjectReference(params.project, params.owner);
+	const itemId = normalizeOptionalString(params.itemId);
+	const contentUrl = normalizeOptionalString(params.contentUrl);
+	if ((itemId !== undefined) === (contentUrl !== undefined)) {
+		throw new ToolError("provide exactly one of itemId or contentUrl");
+	}
+	const archive = params.archive === true;
+	let resolvedItemId = itemId;
+	if (contentUrl) {
+		const items = await fetchProjectItems(session, owner, number, PROJECT_ITEM_LOOKUP_LIMIT, signal);
+		const item = findProjectItemByContentUrl(items, contentUrl);
+		if (!item?.id) {
+			throw new ToolError(`no project item found for ${contentUrl}`);
+		}
+		resolvedItemId = item.id;
+	}
+	const project = await fetchProjectView(session, owner, number, signal);
+	const subcommand = archive ? "item-archive" : "item-delete";
+	await runProjectJson<{ id?: string }>(
+		session.cwd,
+		["project", subcommand, String(number), "--owner", owner, "--id", resolvedItemId ?? "", "--format", "json"],
+		signal,
+	);
+	const verb = archive ? "Archived" : "Deleted";
+	const itemIdSafe = replaceTabs(resolvedItemId ?? "?");
+	const urlSafe = replaceTabs(project.url ?? "");
+	return buildTextResult(`${verb} project item ${itemIdSafe}.\nProject: ${urlSafe}`, project.url);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// GitHub Projects (V2) — project creation + template emulation
+//
+// GitHub exposes NO API to clone a project template (that is a github.com
+// web-UI feature with server-side logic). A blank `gh project create` already
+// ships a default Status field (Todo / In Progress / Done), so applying a
+// template REWRITES that field's options via the `updateProjectV2Field` GraphQL
+// mutation (no CLI field-edit exists) and adds any extra single-select fields
+// via `gh project field-create`. This replicates the template's FIELD SCHEMA —
+// not its built-in views, insights, or automations.
+// ────────────────────────────────────────────────────────────────────────────
+
+const PROJECT_OPTION_COLORS = ["GRAY", "BLUE", "GREEN", "YELLOW", "ORANGE", "RED", "PINK", "PURPLE"] as const;
+const PROJECT_FIELD_REWRITE_MUTATION =
+	"mutation($input: UpdateProjectV2FieldInput!) { updateProjectV2Field(input: $input) { projectV2Field { ... on ProjectV2SingleSelectField { name } } } }";
+
+type ProjectTemplateField =
+	| { name: string; dataType: "SINGLE_SELECT"; options: string[] }
+	| { name: string; dataType: "DATE" }
+	| { name: string; dataType: "NUMBER" };
+
+interface ProjectTemplate {
+	label: string;
+	statusOptions: string[];
+	fields?: ProjectTemplateField[];
+}
+
+/**
+ * Built-in GitHub project templates, emulated by their Status options + signature
+ * fields. `gh project field-create` supports TEXT/SINGLE_SELECT/DATE/NUMBER (NOT
+ * ITERATION), so iteration-style templates substitute a NUMBER field and date-style
+ * templates carry a real DATE field. Presets approximate GitHub's gallery templates
+ * — they replicate the field SCHEMA (Status board + signature fields), not the
+ * built-in views, insights, or automations.
+ */
+const PROJECT_TEMPLATES: Record<string, ProjectTemplate> = {
+	bug_tracker: {
+		label: "Bug tracker",
+		statusOptions: ["No status", "Needs triage", "In progress", "Done"],
+		fields: [
+			{ name: "Priority", dataType: "SINGLE_SELECT", options: ["P0", "P1", "P2", "P3"] },
+			{ name: "Severity", dataType: "SINGLE_SELECT", options: ["Low", "Medium", "High", "Critical"] },
+		],
+	},
+	feature_release: {
+		label: "Feature release",
+		statusOptions: ["No status", "Backlog", "In progress", "In review", "Done"],
+		fields: [{ name: "Target date", dataType: "DATE" }],
+	},
+	iterative_development: {
+		label: "Iterative development",
+		statusOptions: ["No status", "Backlog", "In progress", "In review", "Done"],
+		fields: [{ name: "Story points", dataType: "NUMBER" }],
+	},
+	kanban: { label: "Kanban", statusOptions: ["Todo", "In progress", "Done"] },
+	product_launch: {
+		label: "Product launch",
+		statusOptions: ["No status", "Planning", "In progress", "In review", "Done"],
+		fields: [{ name: "Launch date", dataType: "DATE" }],
+	},
+	roadmap: {
+		label: "Roadmap",
+		statusOptions: ["No status", "Planning", "In progress", "Ready", "Done"],
+		fields: [{ name: "Target date", dataType: "DATE" }],
+	},
+	team_planning: {
+		label: "Team planning",
+		statusOptions: ["No status", "Backlog", "Ready", "In progress", "In review", "Done"],
+	},
+	team_retrospective: {
+		label: "Team retrospective",
+		statusOptions: ["No status", "Went well", "Didn't go well", "Action items"],
+	},
+};
+const PROJECT_TEMPLATE_IDS = Object.keys(PROJECT_TEMPLATES);
+
+/**
+ * Resolve a `template` param to its preset. Returns `undefined` for a blank
+ * project (omitted, empty, or the sentinel "blank"); throws listing the valid
+ * template ids for anything else.
+ */
+export function resolveProjectTemplate(value: string | undefined): ProjectTemplate | undefined {
+	const normalized = value?.trim().toLowerCase();
+	if (!normalized || normalized === "blank") return undefined;
+	const template = PROJECT_TEMPLATES[normalized];
+	if (!template) {
+		throw new ToolError(`unknown project template "${value}". Valid templates: ${PROJECT_TEMPLATE_IDS.join(", ")}.`);
+	}
+	return template;
+}
+
+/**
+ * Rewrite an existing single-select field's options via `updateProjectV2Field`.
+ * `singleSelectOptions` REPLACES the whole option set — omitted options are
+ * DELETED, which breaks items referencing them on a populated board. This is
+ * therefore only safe on a fresh project with no items; it is never reused
+ * against an existing board or exposed as a public op. `gh` has no
+ * field-option-edit CLI, so this posts the GraphQL mutation through
+ * `gh api graphql --input <body>`, routed via `runProjectJson` for scope gating.
+ */
+async function rewriteProjectFieldOptions(
+	session: ToolSession,
+	fieldId: string,
+	options: string[],
+	signal: AbortSignal | undefined,
+): Promise<void> {
+	const singleSelectOptions = options.map((name, index) => ({
+		name,
+		color: PROJECT_OPTION_COLORS[index % PROJECT_OPTION_COLORS.length],
+		description: "",
+	}));
+	const body = JSON.stringify({
+		query: PROJECT_FIELD_REWRITE_MUTATION,
+		variables: { input: { fieldId, singleSelectOptions } },
+	});
+	const bodyPath = path.join(os.tmpdir(), `gh-project-field-${hashPath(fieldId)}.json`);
+	await Bun.write(bodyPath, body);
+	try {
+		const result = await runProjectJson<{
+			data?: { updateProjectV2Field?: { projectV2Field?: { name?: string } } };
+			errors?: unknown;
+		}>(session.cwd, ["api", "graphql", "--input", bodyPath], signal);
+		if (result.errors) {
+			throw new ToolError(`GraphQL rejected field option update: ${JSON.stringify(result.errors)}`);
+		}
+	} finally {
+		await fs.rm(bodyPath, { force: true });
+	}
+}
+
+/**
+ * Apply a template preset to a freshly-created (blank) project: rewrite the
+ * default Status field's options, then create any extra single-select fields.
+ * Throws on the first failure, leaving the project partially configured; the
+ * caller includes the project URL in the surfaced error.
+ */
+async function applyProjectTemplate(
+	session: ToolSession,
+	owner: string,
+	number: number,
+	template: ProjectTemplate,
+	signal: AbortSignal | undefined,
+): Promise<string[]> {
+	const applied: string[] = [];
+	const fields = await fetchProjectFields(session, owner, number, signal);
+	const statusField = fields.find(field => (field.name ?? "").toLowerCase() === "status");
+	if (!statusField?.id) {
+		throw new ToolError("could not find the default Status field to rewrite");
+	}
+	await rewriteProjectFieldOptions(session, statusField.id, template.statusOptions, signal);
+	applied.push(`status options → ${template.statusOptions.join(", ")}`);
+	for (const field of template.fields ?? []) {
+		const fieldArgs = [
+			"project",
+			"field-create",
+			String(number),
+			"--owner",
+			owner,
+			"--name",
+			field.name,
+			"--data-type",
+			field.dataType,
+		];
+		let detail: string;
+		if (field.dataType === "SINGLE_SELECT") {
+			fieldArgs.push("--single-select-options", field.options.join(","));
+			detail = field.options.join(", ");
+		} else {
+			detail = field.dataType.toLowerCase();
+		}
+		fieldArgs.push("--format", "json");
+		await runProjectJson<GhProjectField>(session.cwd, fieldArgs, signal);
+		applied.push(`field "${field.name}" (${detail})`);
+	}
+	return applied;
+}
+
+async function executeProjectCreate(
+	session: ToolSession,
+	params: GithubInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GhToolDetails>> {
+	const owner = requireNonEmpty(normalizeOptionalString(params.owner), "owner");
+	const title = requireNonEmpty(normalizeOptionalString(params.title), "title");
+	const titleSafe = truncateVisualWidth(replaceTabs(title), TRUNCATE_LENGTHS.TITLE);
+	const copyFrom = normalizeOptionalString(params.copyFrom);
+	const template = resolveProjectTemplate(params.template);
+	if (copyFrom && template) {
+		throw new ToolError("provide at most one of template or copyFrom, not both");
+	}
+
+	const lines: string[] = [];
+	let projectUrl: string | undefined;
+
+	if (copyFrom) {
+		// Exact-fidelity clone via `gh project copy` (copyProjectV2): brings the
+		// source's fields + views, so no preset is applied afterward.
+		const source = parseProjectReference(copyFrom, params.sourceOwner);
+		const cloned = await runProjectJson<{ number?: number; url?: string; title?: string }>(
+			session.cwd,
+			[
+				"project",
+				"copy",
+				String(source.number),
+				"--source-owner",
+				source.owner,
+				"--target-owner",
+				owner,
+				"--title",
+				title,
+				"--drafts",
+				"--format",
+				"json",
+			],
+			signal,
+		);
+		const projectNumber = cloned.number;
+		projectUrl = cloned.url;
+		if (projectNumber === undefined) {
+			throw new ToolError("GitHub did not return a project number for the copied project.");
+		}
+		lines.push(`Copied project ${titleSafe} #${projectNumber} from ${replaceTabs(source.owner)}/${source.number}.`);
+	} else {
+		const created = await runProjectJson<{ number?: number; url?: string; title?: string }>(
+			session.cwd,
+			["project", "create", "--owner", owner, "--title", title, "--format", "json"],
+			signal,
+		);
+		const projectNumber = created.number;
+		projectUrl = created.url;
+		if (projectNumber === undefined) {
+			throw new ToolError("GitHub did not return a project number for the created project.");
+		}
+		lines.push(`Created project ${titleSafe} #${projectNumber}.`);
+		if (template) {
+			try {
+				const applied = await applyProjectTemplate(session, owner, projectNumber, template, signal);
+				lines.push(
+					`Template: ${replaceTabs(template.label)} (applied ${applied.length} change(s): ${replaceTabs(applied.join("; "))})`,
+				);
+			} catch (err) {
+				throw new ToolError(
+					`Project ${titleSafe} was created at ${replaceTabs(projectUrl ?? "?")} but template "${replaceTabs(template.label)}" could not be fully applied: ${(err as Error).message}`,
+				);
+			}
+		} else {
+			lines.push("Template: blank (default Status field left untouched)");
+		}
+	}
+
+	if (projectUrl) lines.push(`URL: ${replaceTabs(projectUrl)}`);
+	return buildTextResult(lines.join("\n"), projectUrl);
 }

--- a/packages/coding-agent/test/tools/gh-projects.test.ts
+++ b/packages/coding-agent/test/tools/gh-projects.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "bun:test";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import {
+	findProjectItemByContentUrl,
+	formatProjectBoard,
+	GithubTool,
+	getProjectItemFieldValue,
+	normalizeGithubContentUrl,
+	parseProjectReference,
+	resolveProjectBoardField,
+	resolveProjectTemplate,
+} from "@oh-my-pi/pi-coding-agent/tools/gh";
+
+describe("parseProjectReference", () => {
+	it("accepts a bare number when owner is supplied", () => {
+		expect(parseProjectReference("2", "kourierai")).toEqual({ owner: "kourierai", number: 2 });
+	});
+
+	it("accepts a full orgs project URL and derives the owner from it", () => {
+		expect(parseProjectReference("https://github.com/orgs/kourierai/projects/2", undefined)).toEqual({
+			owner: "kourierai",
+			number: 2,
+		});
+	});
+
+	it("accepts a full users project URL", () => {
+		expect(parseProjectReference("https://github.com/users/monalisa/projects/7", undefined)).toEqual({
+			owner: "monalisa",
+			number: 7,
+		});
+	});
+
+	it("keeps trailing path segments out of the parsed number", () => {
+		expect(parseProjectReference("https://github.com/orgs/kourierai/projects/2/views/1", undefined)).toEqual({
+			owner: "kourierai",
+			number: 2,
+		});
+	});
+
+	it("prefers the owner embedded in a URL over an explicit owner argument", () => {
+		// A URL is self-describing; an explicit owner is ignored so the two
+		// cannot silently disagree.
+		expect(parseProjectReference("https://github.com/orgs/kourierai/projects/2", "someone-else")).toEqual({
+			owner: "kourierai",
+			number: 2,
+		});
+	});
+
+	it("rejects a bare number without an owner", () => {
+		expect(() => parseProjectReference("2", undefined)).toThrow(/owner is required/);
+	});
+
+	it("rejects a malformed URL", () => {
+		expect(() => parseProjectReference("https://github.com/kourierai/whatever", undefined)).toThrow();
+		expect(() => parseProjectReference("not a project ref", undefined)).toThrow();
+	});
+
+	it("rejects an empty value", () => {
+		expect(() => parseProjectReference(undefined, "kourierai")).toThrow(/project must be/);
+	});
+});
+
+describe("resolveProjectTemplate", () => {
+	it("distinguishes kanban (3-state) from team_planning (6-state)", () => {
+		expect(resolveProjectTemplate("kanban")?.statusOptions).toEqual(["Todo", "In progress", "Done"]);
+		expect(resolveProjectTemplate("kanban")?.fields).toBeUndefined();
+		expect(resolveProjectTemplate("team_planning")?.statusOptions).toEqual([
+			"No status",
+			"Backlog",
+			"Ready",
+			"In progress",
+			"In review",
+			"Done",
+		]);
+		// "No status" is a real preset option (real boards carry it); the renderer
+		// de-duplicates it against the synthetic bucket (see formatProjectBoard tests).
+		expect(resolveProjectTemplate("team_planning")?.statusOptions).toContain("No status");
+	});
+
+	it("resolves the bug_tracker preset with single_select Priority + Severity", () => {
+		const bug = resolveProjectTemplate("bug_tracker");
+		expect(bug?.statusOptions).toEqual(["No status", "Needs triage", "In progress", "Done"]);
+		expect(bug?.fields?.map(f => ({ name: f.name, dataType: f.dataType }))).toEqual([
+			{ name: "Priority", dataType: "SINGLE_SELECT" },
+			{ name: "Severity", dataType: "SINGLE_SELECT" },
+		]);
+	});
+
+	it("resolves roadmap to a DATE Target date field with no single_selects", () => {
+		const roadmap = resolveProjectTemplate("roadmap");
+		expect(roadmap?.fields).toEqual([{ name: "Target date", dataType: "DATE" }]);
+		expect(roadmap?.fields?.some(f => f.dataType === "SINGLE_SELECT")).toBe(false);
+	});
+
+	it("resolves iterative_development to a NUMBER Story points field", () => {
+		expect(resolveProjectTemplate("iterative_development")?.fields).toEqual([
+			{ name: "Story points", dataType: "NUMBER" },
+		]);
+	});
+
+	it("keeps product_launch and roadmap distinct (different date field names + status sets)", () => {
+		const launch = resolveProjectTemplate("product_launch");
+		const roadmap = resolveProjectTemplate("roadmap");
+		expect(launch?.fields?.[0]?.name).toBe("Launch date");
+		expect(roadmap?.fields?.[0]?.name).toBe("Target date");
+		expect(launch?.statusOptions).not.toEqual(roadmap?.statusOptions);
+	});
+
+	it("treats omitted, empty, and 'blank' as a blank project", () => {
+		expect(resolveProjectTemplate(undefined)).toBeUndefined();
+		expect(resolveProjectTemplate("blank")).toBeUndefined();
+		expect(resolveProjectTemplate("  ")).toBeUndefined();
+	});
+
+	it("matches template ids case-insensitively", () => {
+		expect(resolveProjectTemplate("ROADMAP")?.label).toBe("Roadmap");
+		expect(resolveProjectTemplate("Bug_Tracker")?.label).toBe("Bug tracker");
+	});
+
+	it("rejects an unknown template name, listing the valid ids", () => {
+		expect(() => resolveProjectTemplate("scrum")).toThrow(/unknown project template/);
+		for (const id of ["kanban", "team_planning", "bug_tracker", "roadmap"]) {
+			expect(() => resolveProjectTemplate("scrum")).toThrow(new RegExp(id));
+		}
+	});
+});
+
+describe("GithubTool approval gating", () => {
+	// `approval` is a read-only field that never inspects the session, so a stub suffices.
+	// Pins the read-vs-exec contract per op (guards the run_watch regression).
+	const tool = new GithubTool({} as unknown as ToolSession);
+
+	it("approves read-only ops as read", () => {
+		expect(tool.approval({ op: "run_watch" })).toBe("read");
+		expect(tool.approval({ op: "project_view" })).toBe("read");
+	});
+
+	it("approves mutating ops as exec", () => {
+		expect(tool.approval({ op: "project_item_edit" })).toBe("exec");
+		expect(tool.approval({ op: "pr_create" })).toBe("exec");
+	});
+});
+
+describe("normalizeGithubContentUrl", () => {
+	it("strips trailing slash, query, and fragment", () => {
+		expect(normalizeGithubContentUrl("https://x/y/z")).toBe("https://x/y/z");
+		expect(normalizeGithubContentUrl("https://x/y/z/")).toBe("https://x/y/z");
+		expect(normalizeGithubContentUrl("https://x/y/z?q=1")).toBe("https://x/y/z");
+		expect(normalizeGithubContentUrl("https://x/y/z#frag")).toBe("https://x/y/z");
+		expect(normalizeGithubContentUrl("https://x/y/z/?q=1#frag")).toBe("https://x/y/z");
+	});
+
+	it("canonicalizes issue/PR subpage URLs down to /issues/<n> or /pull/<n>", () => {
+		expect(normalizeGithubContentUrl("https://github.com/o/r/pull/7/files")).toBe("https://github.com/o/r/pull/7");
+		expect(normalizeGithubContentUrl("https://github.com/o/r/pull/7/commits")).toBe("https://github.com/o/r/pull/7");
+		expect(normalizeGithubContentUrl("https://github.com/o/r/issues/42")).toBe("https://github.com/o/r/issues/42");
+		expect(normalizeGithubContentUrl("https://github.com/o/r/issues/42/#comment")).toBe(
+			"https://github.com/o/r/issues/42",
+		);
+		expect(normalizeGithubContentUrl("https://github.com/o/r/pull/7/files?q=1#diff")).toBe(
+			"https://github.com/o/r/pull/7",
+		);
+	});
+
+	it("leaves non-issue/PR URLs unchanged (still strips slash/query/fragment)", () => {
+		expect(normalizeGithubContentUrl("https://example.com/a/b/c")).toBe("https://example.com/a/b/c");
+	});
+});
+
+describe("findProjectItemByContentUrl", () => {
+	const items = [
+		{ id: "PVTI_1", content: { type: "Issue", url: "https://github.com/o/r/issues/42", number: 42 } },
+		{ id: "PVTI_2", content: { type: "PullRequest", url: "https://github.com/o/r/pull/7" } },
+	];
+	it("matches ignoring trailing slash, query, and fragment", () => {
+		expect(findProjectItemByContentUrl(items, "https://github.com/o/r/issues/42")?.id).toBe("PVTI_1");
+		expect(findProjectItemByContentUrl(items, "https://github.com/o/r/issues/42/")?.id).toBe("PVTI_1");
+		expect(findProjectItemByContentUrl(items, "https://github.com/o/r/issues/42?foo=bar")?.id).toBe("PVTI_1");
+		expect(findProjectItemByContentUrl(items, "https://github.com/o/r/issues/42#frag")?.id).toBe("PVTI_1");
+	});
+	it("returns undefined for no match", () => {
+		expect(findProjectItemByContentUrl(items, "https://github.com/o/r/issues/999")).toBeUndefined();
+	});
+});
+
+describe("getProjectItemFieldValue", () => {
+	it("matches the board field name case- and whitespace-insensitively", () => {
+		const item = { id: "PVTI_1", status: "Done", Priority: "P0" };
+		expect(getProjectItemFieldValue(item, "Status")).toBe("Done");
+		expect(getProjectItemFieldValue(item, "status")).toBe("Done");
+		expect(getProjectItemFieldValue(item, "Priority")).toBe("P0");
+		expect(getProjectItemFieldValue(item, "priority")).toBe("P0");
+		expect(getProjectItemFieldValue(item, "Missing")).toBeUndefined();
+	});
+});
+
+describe("resolveProjectBoardField", () => {
+	it("resolves a single-select field case-insensitively and returns its options", () => {
+		const fields = [
+			{ id: "F1", name: "Status", type: "ProjectV2Field" },
+			{ id: "F2", name: "Priority", type: "ProjectV2SingleSelectField", options: [{ id: "o1", name: "P0" }] },
+		];
+		const { field, options } = resolveProjectBoardField(fields, "priority");
+		expect(field.id).toBe("F2");
+		expect(options.map(o => o.name)).toEqual(["P0"]);
+	});
+	it("throws listing single-select names when the field is missing or not single-select", () => {
+		const fields = [
+			{ id: "F1", name: "Status", type: "ProjectV2Field" },
+			{ id: "F2", name: "Priority", type: "ProjectV2SingleSelectField", options: [{ id: "o1", name: "P0" }] },
+		];
+		// Status exists but is not a single-select -> lists the available single-selects.
+		expect(() => resolveProjectBoardField(fields, "Status")).toThrow(/Priority/);
+		// No field with that name -> lists the available single-selects.
+		expect(() => resolveProjectBoardField(fields, "Nonexistent")).toThrow(/Priority/);
+	});
+});
+
+describe("formatProjectBoard", () => {
+	const project = { title: "Demo", number: 4, url: "https://github.com/orgs/o/projects/4" };
+	const options = [{ name: "Todo" }, { name: "Done" }];
+
+	it("renders a synthetic No status bucket for empty-value items when no real option matches", () => {
+		const items = [
+			{ id: "PVTI_a", title: "first", status: "Done" },
+			{ id: "PVTI_b", title: "second" },
+			{ id: "PVTI_c", title: "third", status: "Todo" },
+		];
+		const out = formatProjectBoard(project, "Status", options, items, Number.POSITIVE_INFINITY);
+		expect(out.split("\n").filter(line => line.startsWith("## "))).toEqual([
+			"## Todo (1)",
+			"## Done (1)",
+			"## No status (1)",
+		]);
+		expect(out.match(/## No status/g)).toHaveLength(1);
+	});
+
+	it("merges empty-value items into a real 'No status' option — exactly one group, no duplicate header", () => {
+		// Defends the render-path fix: a board whose Status field has a real "No status"
+		// option (e.g. kourierai #2) must render ONE "No status" column holding both the
+		// explicitly-"No status" items and the empty-value items — never two headers.
+		const withRealNoStatus = [{ name: "Todo" }, { name: "No status" }, { name: "Done" }];
+		const items = [
+			{ id: "PVTI_a", title: "explicit-ns", status: "No status" },
+			{ id: "PVTI_b", title: "empty-value" },
+			{ id: "PVTI_c", title: "done", status: "Done" },
+		];
+		const out = formatProjectBoard(project, "Status", withRealNoStatus, items, Number.POSITIVE_INFINITY);
+		expect(out.match(/## No status/g)).toHaveLength(1);
+		expect(out.split("\n").filter(line => line.startsWith("## "))).toEqual([
+			"## Todo (0)",
+			"## No status (2)",
+			"## Done (1)",
+		]);
+	});
+
+	it("caps each column to itemsPerColumn and reports X of Y when totalCount exceeds shown", () => {
+		const items = Array.from({ length: 12 }, (_, index) => ({
+			id: `PVTI_${index}`,
+			title: `t${index}`,
+			status: "Todo",
+		}));
+		const out = formatProjectBoard(project, "Status", options, items, 8, 50);
+		expect(out).toContain("Items: 12 of 50");
+		expect(out).toContain("... and 4 more");
+	});
+});
+
+describe("GithubTool project op approval matrix", () => {
+	const tool = new GithubTool({} as unknown as ToolSession);
+	const mutatingProjectOps = [
+		"project_item_add",
+		"project_item_create",
+		"project_item_edit",
+		"project_item_delete",
+		"project_create",
+	];
+
+	it("approves project_view as read", () => {
+		expect(tool.approval({ op: "project_view" })).toBe("read");
+	});
+
+	it("approves every mutating project op as exec", () => {
+		for (const op of mutatingProjectOps) {
+			expect(tool.approval({ op })).toBe("exec");
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds GitHub Projects (V2) management to the `github` tool as six new ops — `project_view` (read-only) and `project_item_add`, `project_item_create`, `project_item_edit`, `project_item_delete`, and `project_create` (all mutating, exec-gated). All calls route through the existing `git.github.*` wrappers; there is no hand-rolled fetch/GITHUB_TOKEN.

Projects V2 is GraphQL-only and the `project` OAuth scope is not requested by `gh` by default, so a centralized scope gate detects the missing-scope error (both gh's pre-flight message and the GraphQL API variant) and surfaces the exact remediation: `gh auth refresh -s project`.

`project_view` renders a kanban board grouped by a configurable single-select column field (`field`, default `Status`), showing every item's node id (`[PVTI_…]`) so edits/deletes can target it. The item ops accept either that `itemId` or a `contentUrl` (issue/PR URL resolved to the backing item). Status moves resolve the project/field/option node ids via `field-list` + `view`; draft title/body edits target the draft content id and are rejected for issue/PR-backed items. The spill-to-artifact decision is driven by the board's real `totalCount` (not the page size): boards with more than 30 items spill the full board to a session artifact (`details.artifactId`) with a truncated 8-per-column inline preview and an `Items: <shown> of <totalCount>` header. A real "No status" option de-duplicates against the synthetic bucket (empty-value items merge into it), so external boards never render two "No status" columns.

`project_create` supports eight built-in template presets (`kanban`, `team_planning`, `feature_release`, `bug_tracker`, `iterative_development`, `product_launch`, `roadmap`, `team_retrospective`). Since GitHub exposes no API to clone a template, templates are EMULATED at the field-schema level: the blank project's default Status field options are rewritten (via `updateProjectV2Field`, scoped to fresh projects only) and signature fields are added (`bug_tracker` → Priority + Severity single-selects; date/roadmap templates → a real DATE field; ITERATION is unsupported so the iterative template substitutes a NUMBER "Story points" field). This replicates the field schema, not built-in views/insights/automations. For exact fidelity, `copyFrom` (source number/URL + `sourceOwner`, `--drafts` included) clones an existing project via `gh project copy`; `copyFrom` and `template` are mutually exclusive, and `gh project mark-template` is the recommended way to prepare a reusable source.

## Verification

- `bun biome check .` clean (exit 0); `bun run check:types` clean for all changed files; `bun test test/tools/gh-projects.test.ts` — 29 pass (parseProjectReference, resolveProjectTemplate, the exported helpers normalizeGithubContentUrl/findProjectItemByContentUrl/getProjectItemFieldValue/resolveProjectBoardField/formatProjectBoard, and the GithubTool approval matrix pinning read/exec per op).
- Live-smoked against real boards (all test projects created under the contributor's own account and deleted): `project_view` rendering; the create→edit-status→edit-title→delete item round-trip; item-add/delete by `contentUrl`; a full `bug_tracker` template apply (Status rewrite + Priority + Severity); a `roadmap` apply (Status rewrite + DATE field); a `copyFrom` clone verifying the source's fields/views carried over; and the >30-item spill path exercised through the real `executeProjectView` (artifactId set, `Items: X of Y`, `Full board: artifact://…` trailer, 8-per-column cap all confirmed).
