### PR TITLE
feat(coding-agent): compact /usage layout with per-account percentages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -238,6 +238,13 @@
 - Fixed heavily branched conversation trees shifting linear continuations into disconnected columns.
 - Fixed plugin installation validation failures for legacy compatibility shims.
 - Removed hard-coded references to disabled or absent agents in system and tool prompts.
+### Added
+
+- Added `/usage models`, which lists every model backed by a live usage report grouped by provider. The default `/usage` view now shows only a per-provider model count, so the quota bars are no longer buried under a full model roster.
+
+### Changed
+
+- Rewrote the `/usage` TUI layout: each quota window is now one row, the account legend renders once per provider instead of once per window, and every account cell carries its own remaining percentage beside its bar. A window group previously spent three or four lines on a title row, a label row, a bar row and a reset line, and showed a single unlabelled cross-account average where a per-account reader expects the active account's headroom ([#5770](https://github.com/can1357/oh-my-pi/issues/5770)). Bars still fill with used quota and percentages still report free quota, with a one-line legend stating both. Accounts that report no limits no longer occupy an empty bar column, and cells are keyed to the owning report so a provider where one account is missing a window keeps its bars under the right legend entry. Narrow terminals shrink the label column, then drop the reset column, then drop the bar glyphs, so the percentage survives longest.
 
 ## [17.2.4] - 2026-08-01
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -577,7 +577,10 @@ export class CommandController {
 		}
 		const availableWidth = Math.max(40, (this.ctx.ui.terminal.columns ?? 100) - 2);
 		const selectors = this.ctx.session.getUsageReportingModelSelectors(usageReports ?? []);
-		this.ctx.present([new Spacer(1), new Text(renderUsageModelRoster(theme, selectors, availableWidth), 1, 0)]);
+		this.ctx.presentCommandOutput([
+			new Spacer(1),
+			new Text(renderUsageModelRoster(theme, selectors, availableWidth), 1, 0),
+		]);
 	}
 
 	async handleChangelogCommand(showFull = false): Promise<void> {
@@ -1605,7 +1608,10 @@ function formatLegendLabels(reports: UsageReport[]): string[] {
 	const labels = reports.map((report, index) => formatReportLabel(report, index));
 	if (labels.length < 2) return labels;
 	const orgs = new Set(reports.map(report => orgSuffix(report)));
-	const withoutOrg = orgs.size > 1 ? labels : labels.map(label => label.replace(/\s\([^()]*\)$/, ""));
+	const sharedOrg = orgs.size === 1 ? [...orgs][0] : undefined;
+	const withoutOrg = sharedOrg
+		? labels.map(label => (label.endsWith(sharedOrg) ? label.slice(0, -sharedOrg.length) : label))
+		: labels;
 	const domains = new Set(withoutOrg.map(label => label.slice(label.indexOf("@"))));
 	if (domains.size === 1 && withoutOrg.every(label => label.includes("@"))) {
 		return withoutOrg.map(label => label.slice(0, label.indexOf("@")));
@@ -2004,9 +2010,10 @@ export function renderUsageReports(
 			// legend row on a single column. A positional `account 1` placeholder
 			// carries no identity, so only a real label is worth the space.
 			const report = block.accounts[0]!;
-			const named = report.metadata?.email || report.metadata?.accountId || report.metadata?.projectId;
+			const label = labels[0] ?? "";
+			const named = label !== "account 1";
 			const marker = isActive(report) ? `${uiTheme.fg("accent", uiTheme.status.enabled)} ` : "";
-			const detail = [named ? labels[0] : "", modelSuffix.replace(/^ · /, "")].filter(Boolean).join(" · ");
+			const detail = [named ? label : "", modelSuffix.replace(/^ · /, "")].filter(Boolean).join(" · ");
 			lines.push(detail ? `${heading}  ${marker}${uiTheme.fg("dim", detail)}` : heading);
 		} else {
 			const accountText = `${block.accounts.length} accounts`;

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -561,6 +561,25 @@ export class CommandController {
 		this.ctx.presentCommandOutput([new Spacer(1), new Text(output, 1, 0)]);
 	}
 
+	/** `/usage models`: the full model roster the default `/usage` view summarizes. */
+	async handleUsageModelsCommand(): Promise<void> {
+		const provider = this.ctx.session as { fetchUsageReports?: () => Promise<UsageReport[] | null> };
+		if (!provider.fetchUsageReports) {
+			this.ctx.showWarning("Usage reporting is not configured for this session.");
+			return;
+		}
+		let usageReports: UsageReport[] | null = null;
+		try {
+			usageReports = await provider.fetchUsageReports();
+		} catch (error) {
+			this.ctx.showError(`Failed to fetch usage data: ${error instanceof Error ? error.message : String(error)}`);
+			return;
+		}
+		const availableWidth = Math.max(40, (this.ctx.ui.terminal.columns ?? 100) - 2);
+		const selectors = this.ctx.session.getUsageReportingModelSelectors(usageReports ?? []);
+		this.ctx.present([new Spacer(1), new Text(renderUsageModelRoster(theme, selectors, availableWidth), 1, 0)]);
+	}
+
 	async handleChangelogCommand(showFull = false): Promise<void> {
 		const changelogPath = getChangelogPath();
 		const allEntries = await parseChangelog(changelogPath);
@@ -1456,7 +1475,7 @@ export class CommandController {
 }
 
 const BAR_WIDTH_MAX = 24;
-const COLUMN_WIDTH_MIN = 4;
+const BAR_WIDTH_MIN = 6;
 
 function renderJobLine(job: AsyncJobSnapshotItem, now: number): string {
 	const duration = formatDuration(Math.max(0, now - job.startTime));
@@ -1483,13 +1502,6 @@ function truncateJobLabel(label: string, maxWidth: number): string {
 	}
 
 	return `${out}…`;
-}
-
-function formatProviderName(provider: string): string {
-	return provider
-		.split(/[-_]/g)
-		.map(part => (part ? part[0].toUpperCase() + part.slice(1) : ""))
-		.join(" ");
 }
 
 function formatNumber(value: number, maxFractionDigits = 1): string {
@@ -1521,13 +1533,6 @@ export function renderProviderSection(details: ProviderDetails, uiTheme: Pick<ty
 	return `${lines.join("\n")}\n`;
 }
 
-function resolveProviderUsageTotal(reports: UsageReport[]): number {
-	return reports
-		.flatMap(report => report.limits)
-		.map(limit => resolveUsedFraction(limit) ?? 0)
-		.reduce((sum, value) => sum + value, 0);
-}
-
 function formatLimitTitle(limit: UsageLimit): string {
 	const tier = limit.scope.tier;
 	if (tier && !limit.label.toLowerCase().includes(tier.toLowerCase())) {
@@ -1536,12 +1541,13 @@ function formatLimitTitle(limit: UsageLimit): string {
 	return limit.label;
 }
 
-function formatWindowSuffix(label: string, windowLabel: string, uiTheme: typeof theme): string {
+/** Window label to append to a limit title, or "" when it would just repeat it. */
+function formatWindowSuffix(label: string, windowLabel: string): string {
 	const normalizedLabel = label.toLowerCase();
 	const normalizedWindow = windowLabel.toLowerCase();
 	if (normalizedWindow === "quota window") return "";
 	if (normalizedLabel.includes(normalizedWindow)) return "";
-	return uiTheme.fg("dim", `(${windowLabel})`);
+	return windowLabel;
 }
 
 /** ` (org)` suffix when the report is org-attributed — two subscriptions can share one email. */
@@ -1578,55 +1584,33 @@ function formatUnlimitedReportLabel(report: UsageReport, index: number): string 
 	return `account ${index + 1}`;
 }
 
-function formatResetShort(limit: UsageLimit, nowMs: number): string | undefined {
-	const resetsAt = limit.window?.resetsAt;
-	if (resetsAt === undefined) return undefined;
-	// Codex returns the prior window's reset_at until a new request opens a fresh window —
-	// rendering a negative delta is meaningless, so drop the suffix in that case.
-	if (resetsAt <= nowMs) return undefined;
-	return formatDuration(resetsAt - nowMs);
+/**
+ * Account label for a report's legend cell. Reports with limits resolve through
+ * {@link formatAccountLabel} so scoped account/project ids still win over empty
+ * metadata strings; limit-less reports fall back to metadata alone.
+ */
+function formatReportLabel(report: UsageReport, index: number): string {
+	const limit = report.limits[0];
+	return limit ? formatAccountLabel(limit, report, index) : formatUnlimitedReportLabel(report, index);
 }
 
-function formatAccountHeaderRow(
-	limits: UsageLimit[],
-	reports: UsageReport[],
-	nowMs: number,
-	columnWidth: number,
-	uiTheme: typeof theme,
-	activeAccount?: OAuthAccountIdentity,
-): string[] {
-	const parts = limits.map((limit, index) => {
-		const reset = formatResetShort(limit, nowMs);
-		const report = reports[index];
-		const active = report !== undefined && limitMatchesActiveAccount(report, limit, activeAccount);
-		const label = formatAccountLabel(limit, report, index);
-		return {
-			label: active ? `● ${label}` : label,
-			suffix: reset ? `(${reset})` : "",
-			active,
-		};
-	});
-	const maxSuffixWidth = parts.reduce((max, p) => Math.max(max, visibleWidth(p.suffix)), 0);
-	const gap = maxSuffixWidth > 0 ? 1 : 0;
-	const prefixBudget = columnWidth - maxSuffixWidth - gap;
-
-	// If suffix can't share the cell with at least `x…`, fall back to whole-label truncation.
-	if (prefixBudget < 2) {
-		return parts.map(p => {
-			const full = p.suffix ? `${p.label} ${p.suffix}` : p.label;
-			const cell = padColumn(truncateJobLabel(full, columnWidth), columnWidth);
-			return p.active ? uiTheme.fg("accent", cell) : cell;
-		});
+/**
+ * Legend labels for one provider's account columns. With two or more columns,
+ * an organization suffix or an email domain that every account shares costs
+ * width without telling the credentials apart, so it is dropped. A single
+ * column keeps its full label: the org is then the only field distinguishing
+ * two subscriptions on one email ([#5691](https://github.com/can1357/oh-my-pi/issues/5691)).
+ */
+function formatLegendLabels(reports: UsageReport[]): string[] {
+	const labels = reports.map((report, index) => formatReportLabel(report, index));
+	if (labels.length < 2) return labels;
+	const orgs = new Set(reports.map(report => orgSuffix(report)));
+	const withoutOrg = orgs.size > 1 ? labels : labels.map(label => label.replace(/\s\([^()]*\)$/, ""));
+	const domains = new Set(withoutOrg.map(label => label.slice(label.indexOf("@"))));
+	if (domains.size === 1 && withoutOrg.every(label => label.includes("@"))) {
+		return withoutOrg.map(label => label.slice(0, label.indexOf("@")));
 	}
-
-	return parts.map(p => {
-		const prefix = truncateJobLabel(p.label, prefixBudget);
-		const prefixCell = prefix + " ".repeat(prefixBudget - visibleWidth(prefix));
-		const styledPrefix = p.active ? uiTheme.fg("accent", prefixCell) : prefixCell;
-		if (!p.suffix) return styledPrefix + " ".repeat(maxSuffixWidth + gap);
-		const suffixPad = " ".repeat(maxSuffixWidth - visibleWidth(p.suffix));
-		return `${styledPrefix} ${suffixPad}${uiTheme.fg("dim", p.suffix)}`;
-	});
+	return withoutOrg;
 }
 
 function padColumn(text: string, width: number): string {
@@ -1662,38 +1646,6 @@ function resolveAggregateStatus(limits: UsageLimit[]): AggregateDisplayStatus {
 	}
 	if (hasWarning) return "warning";
 	return "exhausted";
-}
-
-function formatAggregateAmount(limits: UsageLimit[]): string {
-	const fractions = limits
-		.map(limit => resolveUsedFraction(limit))
-		.filter((value): value is number => value !== undefined);
-	if (fractions.length === limits.length && fractions.length > 0) {
-		const sum = fractions.reduce((total, value) => total + value, 0);
-		const avgRemaining = Math.max(0, ((limits.length - sum) / limits.length) * 100);
-		return `${formatNumber(avgRemaining)}% free`;
-	}
-
-	const amounts = limits
-		.map(limit => limit.amount)
-		.filter(amount => amount.used !== undefined && amount.limit !== undefined && amount.limit > 0);
-	if (amounts.length === limits.length && amounts.length > 0) {
-		const totalUsed = amounts.reduce((sum, amount) => sum + (amount.used ?? 0), 0);
-		const totalLimit = amounts.reduce((sum, amount) => sum + (amount.limit ?? 0), 0);
-		const remainingPct = totalLimit > 0 ? Math.max(0, 100 - (totalUsed / totalLimit) * 100) : 0;
-		return `${formatNumber(remainingPct)}% free`;
-	}
-
-	if (limits.length > 0 && limits.every(isUsedOnlyAbsoluteAmount)) return "";
-
-	// Count unique accounts from limit scopes — not limits.length.
-	const uniqueAccountIds = new Set(
-		limits.map(limit => limit.scope.accountId).filter((id): id is string => typeof id === "string" && id.length > 0),
-	);
-	if (uniqueAccountIds.size > 0) return `${uniqueAccountIds.size} ${uniqueAccountIds.size === 1 ? "acct" : "accts"}`;
-	// No account IDs available — keep the pre-existing fallback so providers
-	// that don't populate scope.accountId still show a summary.
-	return `${limits.length} accts`;
 }
 
 function resolveResetRange(limits: UsageLimit[], nowMs: number): string | null {
@@ -1783,44 +1735,207 @@ function resolveStatusColor(status: UsageLimit["status"]): "success" | "warning"
 	return "dim";
 }
 
-function renderUsageBar(limit: UsageLimit, uiTheme: typeof theme, barWidth: number): string {
-	const usedAmount = limit.amount.used;
-	if (usedAmount !== undefined && isUsedOnlyAbsoluteAmount(limit)) {
-		const used =
-			limit.amount.unit === "usd"
-				? `$${usedAmount.toFixed(2)}`
-				: `${formatNumber(usedAmount, 2)} ${limit.amount.unit}`;
-		return uiTheme.fg("dim", truncateJobLabel(`${used} used`, barWidth));
+/** Eighth-block ramp so a bar carries sub-cell precision at small widths. */
+const BAR_PARTIALS = ["", "▏", "▎", "▍", "▌", "▋", "▊", "▉"] as const;
+
+/** Filled portion is the USED fraction; the remainder is a dim track. */
+function renderUsageBar(
+	fraction: number,
+	status: UsageLimit["status"],
+	uiTheme: typeof theme,
+	barWidth: number,
+): string {
+	if (barWidth <= 0) return "";
+	const exact = Math.min(Math.max(fraction, 0), 1) * barWidth;
+	let fullCells = Math.floor(exact);
+	let eighths = Math.round((exact - fullCells) * 8);
+	if (eighths === 8) {
+		fullCells += 1;
+		eighths = 0;
 	}
-	const fraction = resolveUsedFraction(limit);
-	if (fraction === undefined) {
-		return uiTheme.fg("dim", "·".repeat(barWidth));
-	}
-	const clamped = Math.min(Math.max(fraction, 0), 1);
-	const exact = clamped * barWidth;
-	const fullCells = Math.floor(exact);
-	const remainder = exact - fullCells;
-	let partial = "";
-	if (remainder >= 2 / 3) partial = "▓";
-	else if (remainder >= 1 / 3) partial = "▒";
+	const partial = fullCells < barWidth ? BAR_PARTIALS[eighths] : "";
 	const leading = "█".repeat(fullCells) + partial;
-	const empty = "░".repeat(Math.max(0, barWidth - fullCells - (partial ? 1 : 0)));
-	const color = resolveStatusColor(limit.status);
-	return `${uiTheme.fg(color, leading)}${uiTheme.fg("dim", empty)}`;
+	const track = "─".repeat(Math.max(0, barWidth - fullCells - (partial ? 1 : 0)));
+	return `${uiTheme.fg(resolveStatusColor(status), leading)}${uiTheme.fg("dim", track)}`;
+}
+
+/** Remaining quota as a short cell string: `100%`, `<1%`, `0%`. */
+function formatFreePercent(fraction: number): string {
+	const free = Math.max(0, 1 - fraction) * 100;
+	if (free === 0) return "0%";
+	if (free >= 99.95) return "100%";
+	if (free < 1) return "<1%";
+	return `${Math.round(free)}%`;
+}
+
+/** Absolute used-only amount (no cap to draw a bar against), e.g. `$12.44 used`. */
+function formatUsedOnlyAmount(limit: UsageLimit): string {
+	const used = limit.amount.used ?? 0;
+	const text = limit.amount.unit === "usd" ? `$${used.toFixed(2)}` : `${formatNumber(used, 2)} ${limit.amount.unit}`;
+	return `${text} used`;
+}
+
+/** One quota window across every account column of a provider. */
+interface UsageRow {
+	title: string;
+	cells: (UsageLimit | undefined)[];
+	reset: string;
+	notes: string[];
+}
+
+/** One provider section: metered accounts as columns, one row per quota window. */
+interface UsageBlock {
+	provider: string;
+	accounts: UsageReport[];
+	rows: UsageRow[];
+	notes: string[];
+	credits: string[];
+	unmetered: string[];
+	status: AggregateDisplayStatus;
+	modelCount: number;
+}
+
+/** Column geometry shared by every provider block so bars stay comparable. */
+interface UsageLayout {
+	labelWidth: number;
+	barWidth: number;
+	resetWidth: number;
+	cellWidth: number;
+}
+
+const LABEL_WIDTH_MAX = 26;
+const LABEL_WIDTH_MIN = 8;
+const PERCENT_WIDTH = 4;
+const USAGE_INDENT = 2;
+
+function buildUsageBlock(
+	provider: string,
+	providerReports: UsageReport[],
+	nowMs: number,
+	modelCount: number,
+): UsageBlock {
+	// An account with no reported limits owns no bar column: a blank column only
+	// shrinks its siblings' bars and shifts the legend away from the data.
+	const metered = providerReports.filter(report => report.limits.length > 0);
+	// Order account columns ONCE per provider (worst-first), then apply that same
+	// order to every window row. Sorting each row by its own used fraction
+	// (issue #6067) desynchronized the columns, so a positional label denoted a
+	// different credential per row.
+	const accounts = metered
+		.map((report, position) => ({
+			report,
+			position,
+			worst: report.limits.reduce((max, limit) => Math.max(max, resolveUsedFraction(limit) ?? -1), -1),
+		}))
+		.sort((a, b) => (b.worst !== a.worst ? b.worst - a.worst : a.position - b.position))
+		.map(entry => entry.report);
+	const columnOf = new Map(accounts.map((report, index) => [report, index]));
+
+	// Cells are keyed by the owning report, not by array position, so a provider
+	// where one account is missing a window still lines its bars up with the legend.
+	const grouped = new Map<string, UsageRow>();
+	for (const report of metered) {
+		for (const limit of report.limits) {
+			const windowId = limit.window?.id ?? limit.scope.windowId ?? "default";
+			const title = formatLimitTitle(limit);
+			const windowLabel = limit.window?.label ?? windowId;
+			const suffix = formatWindowSuffix(title, windowLabel);
+			const row = grouped.get(`${title}|${windowId}`) ?? {
+				title: suffix ? `${title} · ${suffix}` : title,
+				cells: new Array<UsageLimit | undefined>(accounts.length).fill(undefined),
+				reset: "",
+				notes: [],
+			};
+			row.cells[columnOf.get(report) ?? 0] = limit;
+			grouped.set(`${title}|${windowId}`, row);
+		}
+	}
+	const rows = [...grouped.values()];
+	for (const row of rows) {
+		const cells = row.cells.filter((limit): limit is UsageLimit => limit !== undefined);
+		// Accounts on the same window rarely reset at the same instant, and the
+		// old per-account label suffix showed each one. Collapsing to a single
+		// countdown must not drop that: `resolveResetRange` keeps the shared verb
+		// when every account agrees and widens to `earliest–latest` when they do
+		// not, so a mixed-reset row still reports when quota comes back.
+		row.reset = resolveResetRange(cells, nowMs) ?? "";
+		// Accounts sharing a window group usually repeat the same per-limit note
+		// (e.g. "Overage requests: 5"); dedupe so it renders once for the row.
+		row.notes = [...new Set(cells.flatMap(limit => limit.notes ?? []))];
+	}
+
+	const credits: string[] = [];
+	for (const report of providerReports) {
+		const count = report.resetCredits?.availableCount ?? 0;
+		if (count <= 0) continue;
+		const expiries = (report.resetCredits?.credits ?? [])
+			.map(credit => (credit.expiresAt ? Date.parse(credit.expiresAt) : Number.NaN))
+			.filter(expiry => Number.isFinite(expiry));
+		const upcoming = expiries.filter(expiry => expiry > nowMs);
+		const expired = expiries.length - upcoming.length;
+		const detail = [
+			upcoming.length > 0 ? `first expires in ${formatDuration(Math.min(...upcoming) - nowMs)}` : "",
+			expired > 0 ? `${expired} expired` : "",
+		].filter(Boolean);
+		credits.push(
+			`${formatReportLabel(report, 0)}: ${count} saved reset${count === 1 ? "" : "s"}${detail.length > 0 ? ` (${detail.join(", ")})` : ""} — /usage reset`,
+		);
+	}
+
+	return {
+		provider,
+		accounts,
+		rows,
+		notes: [...new Set(providerReports.flatMap(report => report.notes ?? []))],
+		credits,
+		unmetered: providerReports
+			.filter(report => report.limits.length === 0)
+			.map((report, index) => {
+				const tier = report.metadata?.planType;
+				const suffix = typeof tier === "string" && tier ? ` (${tier})` : "";
+				return `${formatReportLabel(report, index)}${suffix} — no limits reported`;
+			}),
+		status: resolveAggregateStatus(providerReports.flatMap(report => report.limits)),
+		modelCount,
+	};
 }
 
 /**
- * Pick a per-account column width so the columns and trailing amount fit in `available`.
- * Falls back to the minimum when the terminal is too narrow rather than wrapping.
+ * Solve one column geometry for the whole report so every bar is the same
+ * length and directly comparable. When the widest provider cannot fit, the
+ * label column gives ground first, then the reset column, then the bar itself.
  */
-function resolveColumnWidth(count: number, available: number, trailing: number): number {
-	if (count <= 0) return BAR_WIDTH_MAX;
-	const indent = 2;
-	const gaps = count - 1;
-	const spaceForBars = available - indent - gaps - (trailing > 0 ? trailing + 1 : 0);
-	const ideal = Math.floor(spaceForBars / count);
-	if (ideal < COLUMN_WIDTH_MIN) return COLUMN_WIDTH_MIN;
-	return ideal;
+function resolveUsageLayout(blocks: UsageBlock[], availableWidth: number): UsageLayout {
+	const columns = blocks.reduce((max, block) => Math.max(max, block.accounts.length), 1);
+	const longestTitle = blocks.reduce(
+		(max, block) => Math.max(max, ...block.rows.map(row => visibleWidth(row.title))),
+		0,
+	);
+	const longestReset = blocks.reduce(
+		(max, block) => Math.max(max, ...block.rows.map(row => visibleWidth(row.reset))),
+		0,
+	);
+	let labelWidth = Math.max(LABEL_WIDTH_MIN, Math.min(LABEL_WIDTH_MAX, longestTitle));
+	let resetWidth = longestReset;
+	let barWidth = 0;
+	for (;;) {
+		const fixed = USAGE_INDENT + labelWidth + 2 + (resetWidth > 0 ? resetWidth + 2 : 0) + (columns - 1) * 2;
+		barWidth = Math.floor((availableWidth - fixed) / columns) - 1 - PERCENT_WIDTH;
+		if (barWidth >= BAR_WIDTH_MIN) break;
+		if (labelWidth > LABEL_WIDTH_MIN) {
+			labelWidth = Math.max(LABEL_WIDTH_MIN, labelWidth - Math.max(1, BAR_WIDTH_MIN - barWidth));
+			continue;
+		}
+		if (resetWidth > 0) {
+			resetWidth = 0;
+			continue;
+		}
+		break;
+	}
+	// A one- or two-cell bar is decoration, not information: below the legible
+	// minimum the cell keeps only the percentage ([#5770](https://github.com/can1357/oh-my-pi/issues/5770)).
+	barWidth = barWidth < BAR_WIDTH_MIN ? 0 : Math.min(BAR_WIDTH_MAX, barWidth);
+	return { labelWidth, barWidth, resetWidth, cellWidth: barWidth + (barWidth > 0 ? 1 : 0) + PERCENT_WIDTH };
 }
 
 export function renderUsageReports(
@@ -1831,200 +1946,188 @@ export function renderUsageReports(
 	resolveActiveAccount?: (provider: string) => OAuthAccountIdentity | undefined,
 	usageModelSelectors: readonly string[] = [],
 ): string {
-	const lines: string[] = [];
-	const latestFetchedAt = Math.max(...reports.map(report => report.fetchedAt ?? 0));
-	const headerSuffix = latestFetchedAt ? ` (${formatDuration(nowMs - latestFetchedAt)} ago)` : "";
-	lines.push(uiTheme.bold(uiTheme.fg("accent", `Usage${headerSuffix}`)));
 	const grouped = new Map<string, UsageReport[]>();
 	for (const report of reports) {
 		const list = grouped.get(report.provider) ?? [];
 		list.push(report);
 		grouped.set(report.provider, list);
 	}
-	const providerEntries = Array.from(grouped.entries())
-		.map(([provider, providerReports]) => ({
-			provider,
-			providerReports,
-			totalUsage: resolveProviderUsageTotal(providerReports),
-		}))
-		.sort((a, b) => {
-			if (a.totalUsage !== b.totalUsage) return a.totalUsage - b.totalUsage;
-			return a.provider.localeCompare(b.provider);
-		});
-
-	for (const { provider, providerReports } of providerEntries) {
-		lines.push("");
-		const providerName = formatProviderName(provider);
-		const activeAccount = resolveActiveAccount?.(provider);
-
-		const limitGroups = new Map<
-			string,
-			{ label: string; windowLabel: string; limits: UsageLimit[]; reports: UsageReport[] }
-		>();
-		for (const report of providerReports) {
-			for (const limit of report.limits) {
-				const windowId = limit.window?.id ?? limit.scope.windowId ?? "default";
-				const key = `${formatLimitTitle(limit)}|${windowId}`;
-				const windowLabel = limit.window?.label ?? windowId;
-				const entry = limitGroups.get(key) ?? {
-					label: formatLimitTitle(limit),
-					windowLabel,
-					limits: [],
-					reports: [],
-				};
-				entry.limits.push(limit);
-				entry.reports.push(report);
-				limitGroups.set(key, entry);
-			}
-		}
-
-		lines.push(uiTheme.bold(uiTheme.fg("accent", providerName)));
-		const activeAccountLabel = formatActiveAccountLabel(activeAccount);
-		if (activeAccountLabel) {
-			lines.push(`  ${uiTheme.fg("accent", "in use by this session:")} ${activeAccountLabel}`);
-		}
-		const reportingModels = usageModelSelectors.filter(selector => selector.startsWith(`${provider}/`));
-		if (reportingModels.length > 0) {
-			lines.push(`  ${uiTheme.fg("accent", "Models with usage data")}`);
-			for (const selector of reportingModels) {
-				lines.push(`    ${replaceTabs(truncateToWidth(sanitizeText(selector), availableWidth - 4))}`);
-			}
-		}
-
-		// Provider-wide disclaimers (e.g. "OMP-observed spend only") render once
-		// above the per-account sections instead of duplicating onto every limit.
-		const providerNotes = [...new Set(providerReports.flatMap(report => report.notes ?? []))];
-		if (providerNotes.length > 0) {
-			lines.push(
-				`  ${uiTheme.fg("dim", replaceTabs(truncateToWidth(sanitizeText(providerNotes.map(n => n.replace(/[\r\n]+/g, " ")).join(" • ")), 110)))}`.trimEnd(),
-			);
-		}
-
-		const resetAccountLines: string[] = [];
-		for (const report of providerReports) {
-			const count = report.resetCredits?.availableCount ?? 0;
-			if (count <= 0) continue;
-			const label =
-				typeof report.metadata?.email === "string" && report.metadata.email
-					? report.metadata.email
-					: typeof report.metadata?.accountId === "string" && report.metadata.accountId
-						? report.metadata.accountId
-						: "account";
-			const isActive =
-				!!activeAccount &&
-				((!!activeAccount.accountId && activeAccount.accountId === report.metadata?.accountId) ||
-					(!!activeAccount.email && activeAccount.email === report.metadata?.email));
-			resetAccountLines.push(
-				`    • ${label}: ${count} saved reset${count === 1 ? "" : "s"}${isActive ? " (active)" : ""}`,
-			);
-			const credits = report.resetCredits?.credits;
-			if (credits) {
-				for (const credit of credits) {
-					if (credit.expiresAt) {
-						const expiryMs = Date.parse(credit.expiresAt);
-						if (!Number.isNaN(expiryMs)) {
-							const remaining = expiryMs - nowMs;
-							const expiryDate = credit.expiresAt.slice(0, 10);
-							if (remaining > 0) {
-								resetAccountLines.push(`        expires in ${formatDuration(remaining)} (${expiryDate})`);
-							} else {
-								resetAccountLines.push(`        expired (${expiryDate})`);
-							}
-						}
-					}
-				}
-			}
-		}
-		if (resetAccountLines.length > 0) {
-			lines.push(
-				`  ${uiTheme.fg("accent", "Saved rate-limit resets")} ${uiTheme.fg("dim", "(/usage reset to spend)")}`,
-			);
-			for (const line of resetAccountLines) lines.push(uiTheme.fg("dim", line));
-		}
-
-		// Order account columns ONCE per provider (worst-first), then apply that
-		// same order to every window group. Sorting each group independently by
-		// its own used fraction (issue #6067) desynchronized the columns: an
-		// account exhausted on its 5h window but light on the weekly window would
-		// land in different column positions on each row, so the positional
-		// `account N` labels denoted different credentials per row and an
-		// exhausted limit appeared under a sibling that still had quota.
-		const accountRank = new Map<UsageReport, number>();
-		providerReports.forEach((report, position) => {
-			const worst = report.limits.reduce((max, limit) => {
-				const fraction = resolveUsedFraction(limit) ?? -1;
-				return fraction > max ? fraction : max;
-			}, -1);
-			// Encode worst-first primary key with the stable position as tiebreak
-			// so accounts tied on pressure keep their discovery order.
-			accountRank.set(report, -worst * 1000 + position);
-		});
-
-		const renderableGroups = Array.from(limitGroups.values()).map(group => {
-			const entries = group.limits.map((limit, index) => ({
-				limit,
-				report: group.reports[index],
-				index,
-			}));
-			entries.sort((a, b) => {
-				const aRank = accountRank.get(a.report) ?? a.index;
-				const bRank = accountRank.get(b.report) ?? b.index;
-				if (aRank !== bRank) return aRank - bRank;
-				return a.index - b.index;
-			});
-			const sortedLimits = entries.map(entry => entry.limit);
-			const sortedReports = entries.map(entry => entry.report);
-			return { group, sortedLimits, sortedReports, amountText: formatAggregateAmount(sortedLimits) };
-		});
-
-		const sectionCount = renderableGroups.reduce((max, g) => Math.max(max, g.sortedLimits.length), 0);
-		const sectionTrailing = renderableGroups.reduce((max, g) => Math.max(max, visibleWidth(g.amountText)), 0);
-		const sectionColumnWidth = resolveColumnWidth(sectionCount, availableWidth, sectionTrailing);
-		const sectionBarWidth = Math.min(sectionColumnWidth, BAR_WIDTH_MAX);
-
-		for (const { group, sortedLimits, sortedReports, amountText } of renderableGroups) {
-			const status = resolveAggregateStatus(sortedLimits);
-			const statusIcon = resolveStatusIcon(status, uiTheme);
-
-			const windowSuffix = formatWindowSuffix(group.label, group.windowLabel, uiTheme);
-			lines.push(`${statusIcon} ${uiTheme.bold(group.label)} ${windowSuffix}`.trim());
-			const accountLabels = formatAccountHeaderRow(
-				sortedLimits,
-				sortedReports,
+	// Most-pressured provider first: the quota about to run out is the one the
+	// user opened `/usage` to find.
+	const blocks = Array.from(grouped.entries())
+		.map(([provider, providerReports]) =>
+			buildUsageBlock(
+				provider,
+				providerReports,
 				nowMs,
-				sectionColumnWidth,
-				uiTheme,
-				activeAccount,
-			);
-			lines.push(`  ${accountLabels.join(" ")}`.trimEnd());
-			const bars = sortedLimits.map(limit =>
-				padColumn(renderUsageBar(limit, uiTheme, sectionBarWidth), sectionColumnWidth),
-			);
-			lines.push(`  ${bars.join(" ")} ${amountText}`.trimEnd());
-			const resetText = sortedLimits.length <= 1 ? resolveResetRange(sortedLimits, nowMs) : null;
-			if (resetText) {
-				lines.push(`  ${uiTheme.fg("dim", resetText)}`.trimEnd());
+				usageModelSelectors.filter(selector => selector.startsWith(`${provider}/`)).length,
+			),
+		)
+		.sort((a, b) => {
+			const pressure = (block: UsageBlock): number =>
+				block.accounts
+					.flatMap(report => report.limits)
+					.reduce((max, limit) => Math.max(max, resolveUsedFraction(limit) ?? -1), -1);
+			const delta = pressure(b) - pressure(a);
+			return delta !== 0 ? delta : a.provider.localeCompare(b.provider);
+		});
+
+	const layout = resolveUsageLayout(blocks, availableWidth);
+	const latestFetchedAt = Math.max(...reports.map(report => report.fetchedAt ?? 0));
+	const accountCount = reports.length;
+	const summary = [
+		`${blocks.length} provider${blocks.length === 1 ? "" : "s"}`,
+		`${accountCount} account${accountCount === 1 ? "" : "s"}`,
+		latestFetchedAt ? `updated ${formatDuration(nowMs - latestFetchedAt)} ago` : "",
+	].filter(Boolean);
+	const lines: string[] = [
+		`${uiTheme.bold(uiTheme.fg("accent", "Usage"))} ${uiTheme.fg("dim", `· ${summary.join(" · ")}`)}`,
+		uiTheme.fg("dim", `${padding(USAGE_INDENT)}bar shows quota used · percentage shows quota free`),
+	];
+
+	for (const block of blocks) {
+		const activeAccount = resolveActiveAccount?.(block.provider);
+		const isActive = (report: UsageReport): boolean =>
+			report.limits.some(limit => limitMatchesActiveAccount(report, limit, activeAccount));
+		const labels = formatLegendLabels(block.accounts);
+		const heading = `${resolveStatusIcon(block.status, uiTheme)} ${uiTheme.bold(uiTheme.fg("accent", block.provider))}`;
+		const modelSuffix =
+			block.modelCount > 0 ? ` · ${block.modelCount} model${block.modelCount === 1 ? "" : "s"}` : "";
+
+		lines.push("");
+		if (block.accounts.length === 0) {
+			// Every account under this provider is limit-less; the rows below are
+			// empty, so the heading carries the provider on its own.
+			lines.push(`${heading}${modelSuffix ? `  ${uiTheme.fg("dim", modelSuffix.replace(/^ · /, ""))}` : ""}`);
+		} else if (block.accounts.length === 1) {
+			// One account: fold its label into the heading instead of spending a
+			// legend row on a single column. A positional `account 1` placeholder
+			// carries no identity, so only a real label is worth the space.
+			const report = block.accounts[0]!;
+			const named = report.metadata?.email || report.metadata?.accountId || report.metadata?.projectId;
+			const marker = isActive(report) ? `${uiTheme.fg("accent", uiTheme.status.enabled)} ` : "";
+			const detail = [named ? labels[0] : "", modelSuffix.replace(/^ · /, "")].filter(Boolean).join(" · ");
+			lines.push(detail ? `${heading}  ${marker}${uiTheme.fg("dim", detail)}` : heading);
+		} else {
+			const accountText = `${block.accounts.length} accounts`;
+			lines.push(`${heading}  ${uiTheme.fg("dim", `${accountText}${modelSuffix}`)}`);
+			// The legend renders once per provider, not once per window row, and
+			// sits on the same column offsets the bars use.
+			const legend = block.accounts.map((report, index) => {
+				const active = isActive(report);
+				const text = `${active ? uiTheme.status.enabled : " "} ${truncateJobLabel(labels[index] ?? "", layout.cellWidth - 2)}`;
+				return (
+					uiTheme.fg(active ? "accent" : "dim", text) + padding(Math.max(0, layout.cellWidth - visibleWidth(text)))
+				);
+			});
+			lines.push(`${padding(USAGE_INDENT + layout.labelWidth + 2)}${legend.join("  ")}`.trimEnd());
+		}
+
+		// The active credential is normally flagged with a marker on its own
+		// column. When the session's identity matches no reported account — an
+		// org-qualified identity against org-less report metadata, for instance —
+		// name it explicitly rather than leaving the session unattributed.
+		if (activeAccount && !block.accounts.some(isActive)) {
+			const sessionLabel = formatActiveAccountLabel(activeAccount);
+			if (sessionLabel) {
+				lines.push(`${padding(USAGE_INDENT)}${uiTheme.fg("dim", `in use by this session: ${sessionLabel}`)}`);
 			}
-			const notes = [...new Set(sortedLimits.flatMap(limit => limit.notes ?? []))];
-			if (notes.length > 0) {
+		}
+
+		for (const row of block.rows) {
+			const cells = row.cells.map(limit => {
+				if (!limit) return padding(layout.cellWidth);
+				if (isUsedOnlyAbsoluteAmount(limit)) {
+					return padColumn(
+						uiTheme.fg("dim", truncateJobLabel(formatUsedOnlyAmount(limit), layout.cellWidth)),
+						layout.cellWidth,
+					);
+				}
+				const fraction = resolveUsedFraction(limit);
+				const bar = renderUsageBar(
+					fraction ?? 0,
+					fraction === undefined ? undefined : limit.status,
+					uiTheme,
+					layout.barWidth,
+				);
+				const percent = fraction === undefined ? "—" : formatFreePercent(fraction);
+				const color = fraction === undefined ? "dim" : resolveStatusColor(limit.status);
+				const value = uiTheme.fg(color === "success" ? "muted" : color, percent);
+				const cell = `${bar}${layout.barWidth > 0 ? " " : ""}${padding(PERCENT_WIDTH - percent.length)}${value}`;
+				return cell;
+			});
+			const label = padColumn(truncateJobLabel(row.title, layout.labelWidth), layout.labelWidth);
+			const reset = row.reset && layout.resetWidth > 0 ? `  ${uiTheme.fg("dim", row.reset)}` : "";
+			lines.push(truncateToWidth(`${padding(USAGE_INDENT)}${label}  ${cells.join("  ")}${reset}`, availableWidth));
+			// Per-window notes (e.g. "Overage requests: 5") hang under their row.
+			if (row.notes.length > 0) {
+				const notes = row.notes.map(note => note.replace(/[\r\n]+/g, " ")).join(" • ");
 				lines.push(
-					`  ${uiTheme.fg("dim", replaceTabs(truncateToWidth(sanitizeText(notes.map(n => n.replace(/[\r\n]+/g, " ")).join(" • ")), 110)))}`.trimEnd(),
+					`${padding(USAGE_INDENT * 2)}${uiTheme.fg("dim", replaceTabs(truncateToWidth(sanitizeText(notes), availableWidth - USAGE_INDENT * 2)))}`.trimEnd(),
 				);
 			}
 		}
 
-		// Render accounts with no rate limits (e.g. business/enterprise plans).
-		const unlimitedReports = providerReports.filter(report => report.limits.length === 0);
-		for (const report of unlimitedReports) {
-			const label = formatUnlimitedReportLabel(report, 0);
-			const tier = report.metadata?.planType;
-			const tierSuffix = typeof tier === "string" && tier ? ` ${uiTheme.fg("dim", `(${tier})`)}` : "";
+		// Provider-wide disclaimers (e.g. "OMP-observed spend only") render once
+		// below the rows instead of duplicating onto every limit.
+		if (block.notes.length > 0) {
+			const notes = block.notes.map(note => note.replace(/[\r\n]+/g, " ")).join(" • ");
 			lines.push(
-				`${uiTheme.fg("success", uiTheme.status.success)} ${label}${tierSuffix} ${uiTheme.fg("dim", "-- no limits")}`,
+				`${padding(USAGE_INDENT)}${uiTheme.fg("dim", replaceTabs(truncateToWidth(sanitizeText(notes), availableWidth - USAGE_INDENT)))}`.trimEnd(),
 			);
 		}
-		// No per-provider footer; global header shows last check.
+		for (const credit of block.credits) {
+			lines.push(
+				`${padding(USAGE_INDENT)}${uiTheme.fg("dim", truncateToWidth(credit, availableWidth - USAGE_INDENT))}`,
+			);
+		}
+		// Accounts with no rate limits (e.g. business/enterprise plans).
+		for (const account of block.unmetered) {
+			lines.push(
+				`${padding(USAGE_INDENT)}${uiTheme.fg("dim", truncateToWidth(account, availableWidth - USAGE_INDENT))}`,
+			);
+		}
 	}
 
+	// Single guard for every line kind — headings, legends, notes and rows all
+	// stay inside the terminal even when the solver has already hit its floors.
+	return lines.map(line => truncateToWidth(line, availableWidth)).join("\n");
+}
+
+/**
+ * `/usage models` body: every model selector whose provider reports live usage,
+ * grouped by provider. The default `/usage` view only carries the per-provider
+ * count so the quota bars are not buried under a model roster.
+ */
+export function renderUsageModelRoster(
+	uiTheme: typeof theme,
+	usageModelSelectors: readonly string[],
+	availableWidth: number,
+): string {
+	if (usageModelSelectors.length === 0) {
+		return uiTheme.fg("dim", "No models are mapped to a live usage report.");
+	}
+	const byProvider = new Map<string, string[]>();
+	for (const selector of usageModelSelectors) {
+		const slash = selector.indexOf("/");
+		const provider = slash > 0 ? selector.slice(0, slash) : selector;
+		const model = slash > 0 ? selector.slice(slash + 1) : selector;
+		const models = byProvider.get(provider) ?? [];
+		models.push(model);
+		byProvider.set(provider, models);
+	}
+	const total = usageModelSelectors.length;
+	const lines = [
+		`${uiTheme.bold(uiTheme.fg("accent", "Models with usage data"))} ${uiTheme.fg("dim", `· ${total} model${total === 1 ? "" : "s"}`)}`,
+	];
+	for (const [provider, models] of [...byProvider.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+		lines.push("");
+		lines.push(`${uiTheme.fg("accent", provider)} ${uiTheme.fg("dim", `(${models.length})`)}`);
+		for (const model of models) {
+			lines.push(
+				`${padding(USAGE_INDENT)}${replaceTabs(truncateToWidth(sanitizeText(model), availableWidth - USAGE_INDENT))}`,
+			);
+		}
+	}
 	return lines.join("\n");
 }

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1744,6 +1744,12 @@ function resolveStatusColor(status: UsageLimit["status"]): "success" | "warning"
 /** Eighth-block ramp so a bar carries sub-cell precision at small widths. */
 const BAR_PARTIALS = ["", "▏", "▎", "▍", "▌", "▋", "▊", "▉"] as const;
 
+/** Provider fractions are untrusted input: reject non-finite values and clamp overage. */
+function normalizeUsageFraction(fraction: number | undefined): number | undefined {
+	if (fraction === undefined || !Number.isFinite(fraction)) return undefined;
+	return Math.min(Math.max(fraction, 0), 1);
+}
+
 /** Filled portion is the USED fraction; the remainder is a dim track. */
 function renderUsageBar(
 	fraction: number,
@@ -1752,7 +1758,7 @@ function renderUsageBar(
 	barWidth: number,
 ): string {
 	if (barWidth <= 0) return "";
-	const exact = Math.min(Math.max(fraction, 0), 1) * barWidth;
+	const exact = (normalizeUsageFraction(fraction) ?? 0) * barWidth;
 	let fullCells = Math.floor(exact);
 	let eighths = Math.round((exact - fullCells) * 8);
 	if (eighths === 8) {
@@ -1767,7 +1773,9 @@ function renderUsageBar(
 
 /** Remaining quota as a short cell string: `100%`, `<1%`, `0%`. */
 function formatFreePercent(fraction: number): string {
-	const free = Math.max(0, 1 - fraction) * 100;
+	const normalized = normalizeUsageFraction(fraction);
+	if (normalized === undefined) return "—";
+	const free = (1 - normalized) * 100;
 	if (free === 0) return "0%";
 	if (free >= 99.95) return "100%";
 	if (free < 1) return "<1%";
@@ -1831,7 +1839,10 @@ function buildUsageBlock(
 		.map((report, position) => ({
 			report,
 			position,
-			worst: report.limits.reduce((max, limit) => Math.max(max, resolveUsedFraction(limit) ?? -1), -1),
+			worst: report.limits.reduce(
+				(max, limit) => Math.max(max, normalizeUsageFraction(resolveUsedFraction(limit)) ?? -1),
+				-1,
+			),
 		}))
 		.sort((a, b) => (b.worst !== a.worst ? b.worst - a.worst : a.position - b.position))
 		.map(entry => entry.report);
@@ -1871,7 +1882,7 @@ function buildUsageBlock(
 	}
 
 	const credits: string[] = [];
-	for (const report of providerReports) {
+	for (const [index, report] of providerReports.entries()) {
 		const count = report.resetCredits?.availableCount ?? 0;
 		if (count <= 0) continue;
 		const expiries = (report.resetCredits?.credits ?? [])
@@ -1884,7 +1895,7 @@ function buildUsageBlock(
 			expired > 0 ? `${expired} expired` : "",
 		].filter(Boolean);
 		credits.push(
-			`${formatReportLabel(report, 0)}: ${count} saved reset${count === 1 ? "" : "s"}${detail.length > 0 ? ` (${detail.join(", ")})` : ""} — /usage reset`,
+			`${formatReportLabel(report, index)}: ${count} saved reset${count === 1 ? "" : "s"}${detail.length > 0 ? ` (${detail.join(", ")})` : ""} — /usage reset`,
 		);
 	}
 
@@ -1973,7 +1984,7 @@ export function renderUsageReports(
 			const pressure = (block: UsageBlock): number =>
 				block.accounts
 					.flatMap(report => report.limits)
-					.reduce((max, limit) => Math.max(max, resolveUsedFraction(limit) ?? -1), -1);
+					.reduce((max, limit) => Math.max(max, normalizeUsageFraction(resolveUsedFraction(limit)) ?? -1), -1);
 			const delta = pressure(b) - pressure(a);
 			return delta !== 0 ? delta : a.provider.localeCompare(b.provider);
 		});
@@ -2050,7 +2061,7 @@ export function renderUsageReports(
 						layout.cellWidth,
 					);
 				}
-				const fraction = resolveUsedFraction(limit);
+				const fraction = normalizeUsageFraction(resolveUsedFraction(limit));
 				const bar = renderUsageBar(
 					fraction ?? 0,
 					fraction === undefined ? undefined : limit.status,
@@ -2085,13 +2096,13 @@ export function renderUsageReports(
 		}
 		for (const credit of block.credits) {
 			lines.push(
-				`${padding(USAGE_INDENT)}${uiTheme.fg("dim", truncateToWidth(credit, availableWidth - USAGE_INDENT))}`,
+				`${padding(USAGE_INDENT)}${uiTheme.fg("dim", truncateToWidth(replaceTabs(sanitizeText(credit)), availableWidth - USAGE_INDENT))}`,
 			);
 		}
 		// Accounts with no rate limits (e.g. business/enterprise plans).
 		for (const account of block.unmetered) {
 			lines.push(
-				`${padding(USAGE_INDENT)}${uiTheme.fg("dim", truncateToWidth(account, availableWidth - USAGE_INDENT))}`,
+				`${padding(USAGE_INDENT)}${uiTheme.fg("dim", truncateToWidth(replaceTabs(sanitizeText(account)), availableWidth - USAGE_INDENT))}`,
 			);
 		}
 	}
@@ -2112,7 +2123,7 @@ export function renderUsageModelRoster(
 	availableWidth: number,
 ): string {
 	if (usageModelSelectors.length === 0) {
-		return uiTheme.fg("dim", "No models are mapped to a live usage report.");
+		return truncateToWidth(uiTheme.fg("dim", "No models are mapped to a live usage report."), availableWidth);
 	}
 	const byProvider = new Map<string, string[]>();
 	for (const selector of usageModelSelectors) {
@@ -2128,13 +2139,14 @@ export function renderUsageModelRoster(
 		`${uiTheme.bold(uiTheme.fg("accent", "Models with usage data"))} ${uiTheme.fg("dim", `· ${total} model${total === 1 ? "" : "s"}`)}`,
 	];
 	for (const [provider, models] of [...byProvider.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+		const safeProvider = replaceTabs(sanitizeText(provider));
 		lines.push("");
-		lines.push(`${uiTheme.fg("accent", provider)} ${uiTheme.fg("dim", `(${models.length})`)}`);
+		lines.push(`${uiTheme.fg("accent", safeProvider)} ${uiTheme.fg("dim", `(${models.length})`)}`);
 		for (const model of models) {
 			lines.push(
-				`${padding(USAGE_INDENT)}${replaceTabs(truncateToWidth(sanitizeText(model), availableWidth - USAGE_INDENT))}`,
+				`${padding(USAGE_INDENT)}${truncateToWidth(replaceTabs(sanitizeText(model)), availableWidth - USAGE_INDENT)}`,
 			);
 		}
 	}
-	return lines.join("\n");
+	return lines.map(line => truncateToWidth(line, availableWidth)).join("\n");
 }

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4484,6 +4484,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleUsageCommand(reports);
 	}
 
+	handleUsageModelsCommand(): Promise<void> {
+		return this.#commandController.handleUsageModelsCommand();
+	}
+
 	async handleChangelogCommand(showFull = false): Promise<void> {
 		await this.#commandController.handleChangelogCommand(showFull);
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -341,6 +341,7 @@ export interface InteractiveModeContext {
 	handleAdvisorStatusCommand(): Promise<void>;
 	handleJobsCommand(): Promise<void>;
 	handleUsageCommand(reports?: UsageReport[] | null): Promise<void>;
+	handleUsageModelsCommand(): Promise<void>;
 	handleChangelogCommand(showFull?: boolean): Promise<void>;
 	handleHotkeysCommand(): void;
 	handleToolsCommand(): void;

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -17,7 +17,7 @@ import { describeRedeemOutcome, type ResetUsageAccount, toResetUsageAccounts } f
 import { matchSessionPinAccounts, toSessionPinAccounts } from "./helpers/session-pin";
 import { launchStatsDashboard, parseStatsDashboardArgs } from "./helpers/stats-dashboard";
 import { handleTodoAcp } from "./helpers/todo";
-import { buildUsageReportText } from "./helpers/usage-report";
+import { buildUsageModelRosterText, buildUsageReportText } from "./helpers/usage-report";
 import type { SlashCommandRuntime, SlashCommandSpec } from "./types";
 
 async function handleUsageResetCommand(
@@ -295,9 +295,10 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		name: "usage",
 		description: "Show provider usage and limits",
 		acpDescription: "Show token usage",
-		acpInputHint: "[show|reset [account|active]]",
+		acpInputHint: "[show|models|reset [account|active]]",
 		subcommands: [
 			{ name: "show", description: "Show provider usage and limits" },
+			{ name: "models", description: "List models backed by a live usage report" },
 			{ name: "reset", description: "Spend a saved Codex rate-limit reset", usage: "[account|active]" },
 		],
 		allowArgs: true,
@@ -307,16 +308,25 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 				await runtime.output(await buildUsageReportText(runtime));
 				return commandConsumed();
 			}
+			if (verb === "models" && !rest) {
+				await runtime.output(await buildUsageModelRosterText(runtime));
+				return commandConsumed();
+			}
 			if (verb === "reset") {
 				await handleUsageResetCommand(rest, runtime.session, runtime.output);
 				return commandConsumed();
 			}
-			return usage("Usage: /usage [show|reset [account|active]]", runtime);
+			return usage("Usage: /usage [show|models|reset [account|active]]", runtime);
 		},
 		handleTui: async (command, runtime) => {
 			const { verb, rest } = parseSubcommand(command.args);
 			if (!verb || (verb === "show" && !rest)) {
 				await runtime.ctx.handleUsageCommand();
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			if (verb === "models" && !rest) {
+				await runtime.ctx.handleUsageModelsCommand();
 				runtime.ctx.editor.setText("");
 				return;
 			}
@@ -329,7 +339,7 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 				runtime.ctx.editor.setText("");
 				return;
 			}
-			runtime.ctx.showStatus("Usage: /usage [show|reset [account|active]]");
+			runtime.ctx.showStatus("Usage: /usage [show|models|reset [account|active]]");
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
@@ -80,8 +80,9 @@ function renderUsageReports(
 		lines.push("", formatProviderName(provider));
 		const reportingModels = usageModelSelectors.filter(selector => selector.startsWith(`${provider}/`));
 		if (reportingModels.length > 0) {
-			lines.push("  Models with usage data");
-			for (const selector of reportingModels) lines.push(`    ${sanitizeText(selector)}`);
+			lines.push(
+				`  ${reportingModels.length} model${reportingModels.length === 1 ? "" : "s"} with usage data (/usage models)`,
+			);
 		}
 		const activeAccount = resolveActiveAccount?.(provider);
 		// Provider-wide disclaimers render once per provider, not per limit.
@@ -195,4 +196,33 @@ export async function buildUsageReportText(runtime: SlashCommandRuntime): Promis
 		`Premium requests: ${stats.premiumRequests}`,
 		`Cost: $${stats.cost.toFixed(6)}`,
 	].join("\n");
+}
+
+/**
+ * Build the `/usage models` ACP-mode text: the full roster of model selectors
+ * backed by a live usage report, grouped by provider. The default `/usage`
+ * view only carries the per-provider count.
+ */
+export async function buildUsageModelRosterText(runtime: SlashCommandRuntime): Promise<string> {
+	const provider = runtime.session as SlashCommandRuntime["session"] & {
+		fetchUsageReports?: () => Promise<UsageReport[] | null>;
+		getUsageReportingModelSelectors?: (reports: readonly UsageReport[]) => string[];
+	};
+	const reports = (await provider.fetchUsageReports?.()) ?? [];
+	const selectors = provider.getUsageReportingModelSelectors?.(reports) ?? [];
+	if (selectors.length === 0) return "No models are mapped to a live usage report.";
+	const byProvider = new Map<string, string[]>();
+	for (const selector of selectors) {
+		const slash = selector.indexOf("/");
+		const providerId = slash > 0 ? selector.slice(0, slash) : selector;
+		const models = byProvider.get(providerId) ?? [];
+		models.push(slash > 0 ? selector.slice(slash + 1) : selector);
+		byProvider.set(providerId, models);
+	}
+	const lines = [`Models with usage data (${selectors.length})`];
+	for (const [providerId, models] of [...byProvider.entries()].sort(([left], [right]) => left.localeCompare(right))) {
+		lines.push("", `${formatProviderName(providerId)} (${models.length})`);
+		for (const model of models) lines.push(`  ${sanitizeText(model)}`);
+	}
+	return ["```", ...lines, "```"].join("\n");
 }

--- a/packages/coding-agent/test/issue-6767-usage-command-streaming.test.ts
+++ b/packages/coding-agent/test/issue-6767-usage-command-streaming.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import type { UsageReport } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -97,7 +98,25 @@ describe("issue #6767 /usage output during streaming", () => {
 
 		// streamedReply + the deferred usage panel (Spacer + Text).
 		expect(mode.chatContainer.children).toHaveLength(3);
+		const transcript = stripVTControlCharacters(mode.chatContainer.render(80).join("\n"));
+		expect(transcript.match(/Usage ·/g)).toHaveLength(1);
+	});
+
+	it("defers the usage model roster until the active turn ends, mounting it once", async () => {
+		vi.spyOn(session, "fetchUsageReports").mockResolvedValue(usageReports);
+		vi.spyOn(session, "getUsageReportingModelSelectors").mockReturnValue(["openai-codex/gpt-5.6"]);
+		const streamedReply = new Text("agent is streaming", 0, 0);
+		mode.chatContainer.addChild(streamedReply);
+
+		await mode.handleUsageModelsCommand();
+
+		expect(mode.chatContainer.children).toEqual([streamedReply]);
+
+		streaming = false;
+		await mode.eventController.handleEvent({ type: "agent_end", messages: [] } as AgentSessionEvent);
+
+		expect(mode.chatContainer.children).toHaveLength(3);
 		const transcript = mode.chatContainer.render(80).join("\n");
-		expect(transcript.match(/Usage \(/g)).toHaveLength(1);
+		expect(transcript.match(/Models with usage data/g)).toHaveLength(1);
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/usage-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/usage-command.test.ts
@@ -31,7 +31,7 @@ describe("CommandController /usage", () => {
 		setThemeInstance(theme);
 	});
 
-	it("renders bars and free percentage for limits that only report remainingFraction", async () => {
+	it("renders a bar and the free percentage for limits that only report remainingFraction", async () => {
 		const present = vi.fn();
 		const ctx = {
 			session: createUsageSessionDouble(),
@@ -66,7 +66,7 @@ describe("CommandController /usage", () => {
 		const firstCall = present.mock.calls[0];
 		expect(firstCall).toBeDefined();
 		const output = renderPresentedBlocks(firstCall?.[0]);
-		expect(output).toContain("25% free");
+		expect(output).toContain("25%");
 		expect(output).toContain("█");
 		expect(output).not.toContain("··········");
 	});
@@ -114,9 +114,9 @@ describe("CommandController /usage", () => {
 		const firstCall = present.mock.calls[0];
 		expect(firstCall).toBeDefined();
 		const output = renderPresentedBlocks(firstCall?.[0]);
-		expect(output).toContain("Cursor");
+		expect(output).toContain("cursor");
 		expect(output).toContain("gpt-4 requests");
-		expect(output).toContain("70% free");
+		expect(output).toContain("70%");
 		expect(output).toContain("resets in 1d");
 	});
 
@@ -154,10 +154,11 @@ describe("CommandController /usage", () => {
 		const firstCall = present.mock.calls[0];
 		expect(firstCall).toBeDefined();
 		const output = renderPresentedBlocks(firstCall?.[0]);
-		expect(output).toContain("Saved rate-limit resets");
+		// A limit-less account owns no bar column, so its banked resets render as
+		// a provider footnote with the soonest expiry and the already-lapsed count.
 		expect(output).toContain("user@example.com: 2 saved resets");
-		expect(output).toContain(`expires in`);
-		expect(output).toContain(`(${futureIso.slice(0, 10)})`);
-		expect(output).toContain(`expired (${expiredIso.slice(0, 10)})`);
+		expect(output).toContain("first expires in");
+		expect(output).toContain("1 expired");
+		expect(output).toContain("/usage reset");
 	});
 });

--- a/packages/coding-agent/test/pr-3318-repro.test.ts
+++ b/packages/coding-agent/test/pr-3318-repro.test.ts
@@ -1,33 +1,47 @@
 import { describe, expect, it } from "bun:test";
 import type { UsageReport } from "@oh-my-pi/pi-ai";
-import { buildUsageReportText } from "@oh-my-pi/pi-coding-agent/slash-commands/helpers/usage-report";
+import {
+	buildUsageModelRosterText,
+	buildUsageReportText,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/helpers/usage-report";
+
+const report: UsageReport = {
+	provider: "test-provider",
+	fetchedAt: Date.now(),
+	limits: [
+		{
+			id: "daily",
+			label: "Daily",
+			scope: { provider: "test-provider", accountId: "scoped-account", projectId: "scoped-project" },
+			amount: { used: 1, usedFraction: 0.1, unit: "requests" },
+		},
+	],
+	metadata: { email: "", accountId: "", projectId: "" },
+};
+
+const runtime = {
+	session: {
+		model: undefined,
+		fetchUsageReports: async () => [report],
+		getUsageReportingModelSelectors: () => ["test-provider/coding-plan-model"],
+	},
+} as never;
 
 describe("PR 3318 repro", () => {
 	it("falls back to scoped account when metadata identities are empty strings", async () => {
-		const report: UsageReport = {
-			provider: "test-provider",
-			fetchedAt: Date.now(),
-			limits: [
-				{
-					id: "daily",
-					label: "Daily",
-					scope: { provider: "test-provider", accountId: "scoped-account", projectId: "scoped-project" },
-					amount: { used: 1, usedFraction: 0.1, unit: "requests" },
-				},
-			],
-			metadata: { email: "", accountId: "", projectId: "" },
-		};
-		const text = await buildUsageReportText({
-			session: {
-				model: undefined,
-				fetchUsageReports: async () => [report],
-				getUsageReportingModelSelectors: () => ["test-provider/coding-plan-model"],
-			},
-		} as never);
+		const text = await buildUsageReportText(runtime);
 
 		expect(text).toContain("scoped-account: 1.00 requests used");
 		expect(text).not.toContain("account 1: 1.00 requests used");
+		// The roster itself moved behind `/usage models`; the report keeps the count.
+		expect(text).toContain("1 model with usage data");
+		expect(text).not.toContain("test-provider/coding-plan-model");
+	});
+
+	it("lists the usage-reporting models under /usage models", async () => {
+		const text = await buildUsageModelRosterText(runtime);
+
 		expect(text).toContain("Models with usage data");
-		expect(text).toContain("test-provider/coding-plan-model");
+		expect(text).toContain("coding-plan-model");
 	});
 });

--- a/packages/coding-agent/test/tools/browser-attach.test.ts
+++ b/packages/coding-agent/test/tools/browser-attach.test.ts
@@ -11,7 +11,9 @@ import {
 } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
 import { acquireTab, releaseTab } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 import type { Browser, Page, Target } from "puppeteer-core";
-import { CHROMIUM_AVAILABLE } from "./chromium-probe";
+import { chromiumAvailable as probeChromiumAvailable } from "./chromium-probe";
+
+const chromiumAvailable = await probeChromiumAvailable();
 
 interface FakePageOptions {
 	url: string;
@@ -108,7 +110,7 @@ describe("pickElectronTarget", () => {
 	});
 
 	// Launches real headless Chromium; skipped where Chrome's system libraries are absent.
-	test.skipIf(!CHROMIUM_AVAILABLE)(
+	test.skipIf(!chromiumAvailable)(
 		"navigates a fresh attached tab to the requested URL",
 		async () => {
 			const launched = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
@@ -141,7 +143,7 @@ describe("pickElectronTarget", () => {
 		30_000,
 	);
 
-	test.skipIf(!CHROMIUM_AVAILABLE)(
+	test.skipIf(!chromiumAvailable)(
 		"does not retry an attached navigation failure as worker startup",
 		async () => {
 			let requestCount = 0;

--- a/packages/coding-agent/test/tools/browser-attach.test.ts
+++ b/packages/coding-agent/test/tools/browser-attach.test.ts
@@ -11,9 +11,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
 import { acquireTab, releaseTab } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 import type { Browser, Page, Target } from "puppeteer-core";
-import { chromiumAvailable } from "./chromium-probe";
-
-const CHROMIUM_AVAILABLE = await chromiumAvailable();
+import { CHROMIUM_AVAILABLE } from "./chromium-probe";
 
 interface FakePageOptions {
 	url: string;

--- a/packages/coding-agent/test/usage-report-column-align.test.ts
+++ b/packages/coding-agent/test/usage-report-column-align.test.ts
@@ -62,52 +62,93 @@ function spendAcct(email: string, used: number, limit?: number): UsageReport {
 }
 
 describe("renderUsageReports multi-account column alignment (#6067)", () => {
-	it("keeps account columns in the same order across every window row", () => {
+	it("keeps every window row on the single account-legend column order", () => {
 		// Account A: weekly exhausted, 5h free. Account B: weekly light, 5h exhausted.
-		// A naive per-window sort by used fraction swaps the columns between rows.
+		// A naive per-window sort by used fraction swaps the columns between rows,
+		// so the exhausted cell lands under the sibling that still has quota.
 		const reports: UsageReport[] = [acct("alice@example.test", 1.0, 0.0), acct("bob@example.test", 0.2, 1.0)];
 		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 160));
 		const lines = text.split("\n");
 
-		const columnOrder = (sectionLabel: string): string[] => {
-			const headerIdx = lines.findIndex(l => l.includes(sectionLabel));
-			expect(headerIdx).toBeGreaterThanOrEqual(0);
-			// The account-label row is the line right after the section header.
-			const labelRow = lines[headerIdx + 1];
-			return ["alice@example.test", "bob@example.test"].sort((a, b) => labelRow.indexOf(a) - labelRow.indexOf(b));
+		const legend = lines.find(line => line.includes("alice") && line.includes("bob"));
+		expect(legend).toBeDefined();
+		expect(legend!.indexOf("alice")).toBeLessThan(legend!.indexOf("bob"));
+
+		const percents = (rowLabel: string): string[] => {
+			const row = lines.find(line => line.includes(rowLabel));
+			expect(row).toBeDefined();
+			return [...row!.matchAll(/(\d+)%/g)].map(match => match[0]);
 		};
 
-		const totalOrder = columnOrder("Total quota");
-		const fiveHOrder = columnOrder("5h limit");
-		expect(fiveHOrder).toEqual(totalOrder);
+		// Column 0 is alice, column 1 is bob, on BOTH rows.
+		expect(percents("Total quota")).toEqual(["0%", "80%"]);
+		expect(percents("5h limit")).toEqual(["100%", "0%"]);
 	});
 
-	it("keeps all-used-only amount cells within four-column narrow widths", () => {
+	it("keeps every line inside the terminal when used-only amounts squeeze the columns", () => {
 		const reports = [spendAcct("first@example.test", 123.45), spendAcct("second@example.test", 67.89)];
-		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 11));
-		const lines = text.split("\n");
-		const headerIdx = lines.findIndex(line => line.includes("Claude Extra Usage"));
-		expect(headerIdx).toBeGreaterThanOrEqual(0);
-		const amountRow = lines[headerIdx + 2]!;
-		const cells = amountRow.trim().split(/\s+/);
-
-		expect(cells).toHaveLength(2);
-		expect(cells.every(cell => Bun.stringWidth(cell) <= 4)).toBe(true);
-		expect(Bun.stringWidth(amountRow)).toBeLessThanOrEqual(11);
+		for (const width of [11, 20, 40, 80]) {
+			const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), width));
+			for (const line of text.split("\n")) {
+				expect(Bun.stringWidth(line)).toBeLessThanOrEqual(width);
+			}
+		}
 	});
 
-	it("keeps mixed capped and used-only amount cells aligned at narrow widths", () => {
+	it("drops the bar before the percentage when a mixed group runs out of width", () => {
 		const reports = [spendAcct("capped@example.test", 50, 100), spendAcct("uncapped@example.test", 123.45)];
-		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 20));
-		const lines = text.split("\n");
-		const headerIdx = lines.findIndex(line => line.includes("Claude Extra Usage"));
-		expect(headerIdx).toBeGreaterThanOrEqual(0);
-		const labelRow = lines[headerIdx + 1]!;
-		const amountRow = lines[headerIdx + 2]!;
-		const summaryStart = amountRow.lastIndexOf(" 2 accts");
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 30));
+		const row = text.split("\n").find(line => line.includes("50%"));
 
-		expect(summaryStart).toBeGreaterThanOrEqual(0);
-		expect(Bun.stringWidth(labelRow)).toBe(11);
-		expect(Bun.stringWidth(amountRow.slice(2, summaryStart))).toBe(9);
+		// Narrow terminals keep the number readers need and give up the bar glyphs
+		// first (issue #5770: percentage outranks decoration).
+		expect(row).toBeDefined();
+		expect(row).not.toContain("█");
+		expect(Bun.stringWidth(row!)).toBeLessThanOrEqual(30);
+	});
+});
+
+describe("renderUsageReports shared reset column", () => {
+	function resetAcct(email: string, resetsInMs: number): UsageReport {
+		const now = Date.now();
+		return {
+			provider: "openai-codex",
+			fetchedAt: now,
+			metadata: { email },
+			limits: [
+				{
+					id: "7d",
+					label: "7 days",
+					scope: { provider: "openai-codex", windowId: "7d" },
+					window: { id: "7d", label: "7 days", durationMs: 7 * 24 * HOUR, resetsAt: now + resetsInMs },
+					amount: { unit: "percent", usedFraction: 0.4 },
+					status: "ok",
+				},
+			],
+		};
+	}
+
+	it("keeps a countdown when accounts on one window reset at different times", () => {
+		// The old layout carried a per-account `(6d)` suffix on every label, so a
+		// single hoisted countdown must not silently blank when they disagree —
+		// independent 7-day windows almost never line up.
+		const reports = [resetAcct("early@example.test", 6 * HOUR), resetAcct("late@example.test", 5 * 24 * HOUR)];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 160));
+		const row = text.split("\n").find(line => line.includes("7 days"));
+
+		expect(row).toBeDefined();
+		expect(row).toContain("resets in");
+		// Both bounds stay visible so neither account's return is hidden.
+		expect(row).toContain("6h");
+		expect(row).toContain("5d");
+	});
+
+	it("collapses to one countdown when every account agrees", () => {
+		const reports = [resetAcct("a@example.test", 3 * HOUR), resetAcct("b@example.test", 3 * HOUR)];
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 160));
+		const row = text.split("\n").find(line => line.includes("7 days"))!;
+
+		expect([...row.matchAll(/resets in/g)]).toHaveLength(1);
+		expect(row).not.toContain("–");
 	});
 });

--- a/packages/coding-agent/test/usage-report-tui-notes.test.ts
+++ b/packages/coding-agent/test/usage-report-tui-notes.test.ts
@@ -134,6 +134,17 @@ describe("renderUsageReports (#3268 TUI aggregate)", () => {
 		expect(text).toContain("rae@example.com (Team Org)");
 	});
 
+	it("shows a scoped account identity for a single report with empty metadata", () => {
+		const baseLimit = limit("Daily", "daily", 24 * HOUR, 0.3);
+		const scopedLimit = { ...baseLimit, scope: { ...baseLimit.scope, accountId: "scoped-account" } };
+		const reports: UsageReport[] = [report("test-provider", "", [scopedLimit])];
+
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
+
+		expect(text).toContain("scoped-account");
+		expect(text).not.toContain("account 1");
+	});
+
 	it("renders used-only absolute amounts with neutral status and no account summary", () => {
 		const reports: UsageReport[] = [
 			report("anthropic", "spend@example.test", [

--- a/packages/coding-agent/test/usage-report-tui-notes.test.ts
+++ b/packages/coding-agent/test/usage-report-tui-notes.test.ts
@@ -16,7 +16,10 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import type { UsageReport } from "@oh-my-pi/pi-ai";
-import { renderUsageReports } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
+import {
+	renderUsageModelRoster,
+	renderUsageReports,
+} from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 const HOUR = 3_600_000;
@@ -69,15 +72,27 @@ describe("renderUsageReports (#3268 TUI aggregate)", () => {
 		expect(occurrences).toBe(1);
 	});
 
-	it("lists every model mapped to the provider's live usage data", () => {
+	it("summarizes the provider's usage-reporting models instead of listing them inline", () => {
 		const reports = [
 			report("github-copilot", "acct@example.test", [limit("Copilot", "monthly", 30 * 24 * HOUR, 0.4)]),
 		];
 		const models = ["github-copilot/gpt-5.6", "github-copilot/claude-sonnet-4.6"];
 		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120, undefined, models));
+		// The roster moved behind `/usage models`; the default view keeps the count
+		// so the quota bars are not buried under it.
+		expect(text).toContain("2 models");
+		expect(text).not.toContain(models[0]);
+		expect(text).not.toContain(models[1]);
+	});
+
+	it("groups the full model roster by provider for /usage models", () => {
+		const models = ["github-copilot/gpt-5.6", "github-copilot/claude-sonnet-4.6", "anthropic/claude-opus-4-6"];
+		const text = stripVTControlCharacters(renderUsageModelRoster(theme, models, 120));
 		expect(text).toContain("Models with usage data");
-		expect(text).toContain(models[0]);
-		expect(text).toContain(models[1]);
+		expect(text).toContain("github-copilot");
+		expect(text).toContain("gpt-5.6");
+		expect(text).toContain("claude-sonnet-4.6");
+		expect(text).toContain("claude-opus-4-6");
 	});
 
 	it("deduplicates identical per-limit notes when accounts share one window group", () => {
@@ -139,7 +154,7 @@ describe("renderUsageReports (#3268 TUI aggregate)", () => {
 		expect(text).not.toContain("1 accts");
 	});
 
-	it("preserves capped aggregate status when a group mixes capped and used-only amounts", () => {
+	it("keeps a per-account cell for every account when a group mixes capped and used-only amounts", () => {
 		const reports: UsageReport[] = [
 			report("anthropic", "capped@example.test", [
 				{
@@ -170,17 +185,23 @@ describe("renderUsageReports (#3268 TUI aggregate)", () => {
 		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 160));
 
 		expect(text).toContain(theme.status.success);
+		// The capped account resolves to a percentage; the used-only sibling keeps
+		// its absolute amount. Both occupy their own column on the same row.
+		expect(text).toContain("50%");
 		expect(text).toContain("$123.45 used");
-		expect(text).toContain("2 accts");
+		const row = text.split("\n").find(line => line.includes("$123.45 used"));
+		expect(row).toContain("50%");
 	});
 });
 
 describe("renderUsageReports session marker (#5691 org-qualified identity)", () => {
-	it("suffixes the active org so same-email multi-org accounts are tellable apart", () => {
+	it("names the org-qualified session identity when no reported account matches it", () => {
 		const email = "dev@example.test";
 		const reports: UsageReport[] = [
 			report("anthropic", email, [limit("Claude 7 Day", "weekly", 7 * 24 * HOUR, 0.4)]),
 		];
+		// The identity carries an org; the report metadata does not, so the org
+		// gate rejects the match and the session must still be attributed.
 		const text = stripVTControlCharacters(
 			renderUsageReports(reports, theme, Date.now(), 120, provider =>
 				provider === "anthropic" ? { email, orgId: "uuid-A", orgName: "Team Org" } : undefined,
@@ -190,7 +211,7 @@ describe("renderUsageReports session marker (#5691 org-qualified identity)", () 
 		expect(marker).toContain(`${email} (Team Org)`);
 	});
 
-	it("falls back to the bare base when the active identity carries no org", () => {
+	it("marks the matching account column instead of repeating the session identity", () => {
 		const email = "solo@example.test";
 		const reports: UsageReport[] = [
 			report("anthropic", email, [limit("Claude 7 Day", "weekly", 7 * 24 * HOUR, 0.4)]),
@@ -200,8 +221,10 @@ describe("renderUsageReports session marker (#5691 org-qualified identity)", () 
 				provider === "anthropic" ? { email } : undefined,
 			),
 		);
-		const marker = text.split("\n").find(line => line.includes("in use by this session"));
-		expect(marker).toContain(email);
-		expect(marker).not.toContain("(");
+		const heading = text.split("\n").find(line => line.includes("anthropic"));
+		expect(heading).toContain(theme.status.enabled);
+		expect(heading).toContain(email);
+		expect(heading).not.toContain("(");
+		expect(text).not.toContain("in use by this session");
 	});
 });

--- a/packages/coding-agent/test/usage-report-tui-notes.test.ts
+++ b/packages/coding-agent/test/usage-report-tui-notes.test.ts
@@ -95,6 +95,19 @@ describe("renderUsageReports (#3268 TUI aggregate)", () => {
 		expect(text).toContain("claude-opus-4-6");
 	});
 
+	it("sanitizes roster identifiers before enforcing the width cap", () => {
+		const width = 24;
+		const models = [
+			"custom-provider-with-a-very-long-name/model\twith-tabs",
+			"custom-provider-with-a-very-long-name/model\x1b]0;hidden\x07-safe",
+		];
+		const text = stripVTControlCharacters(renderUsageModelRoster(theme, models, width));
+
+		expect(text).not.toContain("\t");
+		expect(text).not.toContain("hidden");
+		for (const line of text.split("\n")) expect(Bun.stringWidth(line)).toBeLessThanOrEqual(width);
+	});
+
 	it("deduplicates identical per-limit notes when accounts share one window group", () => {
 		// Both accounts report the SAME label+windowId, so their limits land in
 		// one aggregate group; both carry an identical per-limit note.
@@ -143,6 +156,59 @@ describe("renderUsageReports (#3268 TUI aggregate)", () => {
 
 		expect(text).toContain("scoped-account");
 		expect(text).not.toContain("account 1");
+	});
+
+	it("numbers saved-reset footnotes by their owning report", () => {
+		const resetCredits = { availableCount: 1, credits: [] };
+		const reports: UsageReport[] = [
+			{ provider: "openai-codex", fetchedAt: Date.now(), limits: [], resetCredits },
+			{ provider: "openai-codex", fetchedAt: Date.now(), limits: [], resetCredits },
+		];
+
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
+
+		expect(text).toContain("account 1: 1 saved reset");
+		expect(text).toContain("account 2: 1 saved reset");
+	});
+
+	it("sanitizes provider-supplied reset and unmetered account text", () => {
+		const reports: UsageReport[] = [
+			{
+				provider: "test-provider",
+				fetchedAt: Date.now(),
+				limits: [],
+				metadata: { email: "acct\tname\x1b]0;hidden\x07@example.test", planType: "business\tplan" },
+				resetCredits: { availableCount: 1, credits: [] },
+			},
+		];
+
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
+
+		expect(text).not.toContain("\t");
+		expect(text).not.toContain("hidden");
+		expect(text).toContain("business");
+		expect(text).toContain("plan");
+	});
+
+	it("clamps finite provider fractions and rejects non-finite values", () => {
+		const reports: UsageReport[] = [
+			report("test-provider", "acct@example.test", [
+				limit("Overage", "over", HOUR, 1.25),
+				limit("Negative", "negative", HOUR, -0.25),
+				limit("Not a number", "nan", HOUR, Number.NaN),
+				limit("Infinite", "infinite", HOUR, Number.POSITIVE_INFINITY),
+			]),
+		];
+
+		const text = stripVTControlCharacters(renderUsageReports(reports, theme, Date.now(), 120));
+		const lines = text.split("\n");
+
+		expect(lines.find(line => line.includes("Overage"))).toContain("0%");
+		expect(lines.find(line => line.includes("Negative"))).toContain("100%");
+		expect(lines.find(line => line.includes("Not a number"))).toContain("—");
+		expect(lines.find(line => line.includes("Infinite"))).toContain("—");
+		expect(text).not.toContain("NaN%");
+		expect(text).not.toContain("Infinity%");
 	});
 
 	it("renders used-only absolute amounts with neutral status and no account summary", () => {


### PR DESCRIPTION
## What

I noticed `/usage` had gotten pretty bloated: on my setup it prints well over a full screen of output, most of it model names rather than quota, so I collapsed it down.

Concretely, the TUI block now renders one row per quota window with the account legend hoisted to the provider header, and every account cell carries its own remaining percentage next to its bar:

**Before** (one provider, 19 lines):

```
Google Antigravity
  Models with usage data
    google-antigravity/gemini-2.5-flash
    google-antigravity/gemini-2.5-flash-lite
    google-antigravity/gemini-2.5-pro
    google-antigravity/gemini-3-flash
    google-antigravity/gemini-3-pro
    google-antigravity/gemini-3.1-flash-image
    google-antigravity/gemini-3.1-flash-lite
    google-antigravity/gemini-3.1-pro
    google-antigravity/gpt-oss-120b
✔ Usage (Google) (Daily)
  alex.rivera@example.com       (10m) sam.chen@example.com          (10m) jordan.kim@example.com        (10m)
  █░░░░░░░░░░░░░░░░░░░░░░░            ░░░░░░░░░░░░░░░░░░░░░░░░            ░░░░░░░░░░░░░░░░░░░░░░░░            98.4% free
✔ Usage (OpenAI) (Daily)
  alex.rivera@example.com       (10m) sam.chen@example.com          (10m) jordan.kim@example.com        (10m)
  ░░░░░░░░░░░░░░░░░░░░░░░░            ░░░░░░░░░░░░░░░░░░░░░░░░            ░░░░░░░░░░░░░░░░░░░░░░░░            100% free
✔ Usage (Anthropic) (Daily)
  alex.rivera@example.com       (10m) sam.chen@example.com          (10m) jordan.kim@example.com        (10m)
  ░░░░░░░░░░░░░░░░░░░░░░░░            ░░░░░░░░░░░░░░░░░░░░░░░░            ░░░░░░░░░░░░░░░░░░░░░░░░            100% free
```

**After** (same provider, same data, 5 lines):

```
✔ google-antigravity  3 accounts · 9 models
                                alex.rivera               sam.chen                  jordan.kim
  Usage (Google) · Daily      ▉──────────────────  95%  ─────────────────── 100%  ─────────────────── 100%  resets in 10m
  Usage (OpenAI) · Daily      ─────────────────── 100%  ─────────────────── 100%  ─────────────────── 100%  resets in 10m
  Usage (Anthropic) · Daily   ─────────────────── 100%  ─────────────────── 100%  ─────────────────── 100%  resets in 10m
```

The pieces:

- **One row per quota window.** A window group used to spend a title row, an account-label row, a bar row and a `resets in …` line that repeated the countdown already shown on the label row.
- **Per-account percentages.** Each cell reads `bar  NN%`. The old layout showed one unlabelled `formatAggregateAmount` average at the end of the row, which is what #5770 reports.
- **Legend once per provider.** `formatAccountHeaderRow` re-emitted the same account labels for every window group; the legend now renders once, on the same column offsets the bars use. With two or more columns a shared org suffix or shared email domain is dropped, since neither tells the credentials apart; a single column keeps its full label so #5691 identities stay distinguishable.
- **Cells keyed to the owning report.** Row cells are placed by report identity rather than array position, so a provider where one account is missing a window keeps its remaining bars under the right legend entry.
- **Limit-less accounts get a footnote** instead of an empty bar column that shrinks its siblings' bars.
- **Shared reset column.** The countdown moves from a per-account label suffix to one column per row via the existing `resolveResetRange`, so it keeps the shared verb when every account agrees and widens to `resets in 6h–5d` when independent windows disagree. Collapsing it to a single value would otherwise have dropped the countdown entirely for mixed-reset providers, which is the common case for sibling Codex accounts.
- **Model roster moved to `/usage models`,** grouped by provider; the default view keeps `· N models` in the provider header.

The four points raised on #5770 are settled as follows:

1. **used vs. free** — the bar still fills with used quota and the percentage still reports free quota, matching the previous `% free` text. A one-line legend under the header states both, so the polarity is no longer implicit.
2. **aggregate label** — the cross-account average is dropped rather than relabelled. Once every account shows its own number, the average has no reader.
3. **column width** — the solver shrinks the label column first, then drops the reset column, then drops the bar glyphs, so the percentage is the last thing to go. Every rendered line is truncated to the available width.
4. **absolute `used`/`limit` providers** — `resolveUsedFraction` already normalizes these, so they render as percentages like everything else. Used-only amounts with no cap (e.g. `$12.44 used`) keep their absolute cell.

## Why

Fixes #5770.

On six providers with nine accounts the block was 119 lines at every terminal width, so reading the last provider's quota meant scrolling past everything above it. 41 of those lines were the per-provider model roster, and no individual account's headroom was readable anywhere in the output. The same input now renders in 33 lines with every account's remaining percentage on screen.

## Testing

`bun --cwd=packages/coding-agent run check` — clean (biome + tsgo).

`bun --cwd=packages/coding-agent test test/usage-report-tui-notes.test.ts test/usage-report-column-align.test.ts test/modes/controllers/usage-command.test.ts test/pr-3318-repro.test.ts test/acp-builtins.test.ts test/slash-commands test/active-oauth-account.test.ts` — 223 pass, 0 fail.

Exercised end to end in the TUI (`bun packages/coding-agent/src/cli.ts`, 120 columns, six authenticated providers across nine OAuth accounts):

- `/usage` renders 33 lines. The active-account marker landed on the OpenAI Codex credential the session was actually using, and the model counts matched the roster.
- Re-rendered the same reports with sibling accounts skewed onto different reset instants: mixed rows render `resets in 21h10m–1d` rather than losing the countdown, and rows where every account agrees keep the single value.
- `/usage models` lists the roster grouped by provider and shows up in slash-command completion.
- Re-rendered the same reports at 11, 20, 40, 60, 80, 120 and 160 columns: no line exceeds the available width at any size, and below the legible bar minimum the cells keep the percentage and drop the bar.

Existing regression coverage was updated rather than dropped:

- **#6067** column alignment now asserts the per-row percentages in legend order (`["0%", "80%"]` weekly, `["100%", "0%"]` on 5h), which a naive per-row sort still breaks.
- **#5691** org-qualified identity keeps both branches: an identity matching no reported account is still named on its own line, and a matching account is flagged with the column marker instead.
- **#3318** empty-metadata fallback is unchanged; its model-roster assertion moved to `/usage models`.
- Two narrow-width tests that asserted the old three-row geometry now assert the width invariant and the bar-drop behavior.
- Added coverage for the shared reset column in both directions (mixed accounts keep a range, agreeing accounts collapse to one value).

Not covered: providers I hold no credentials for (Cursor, GitHub Copilot, Devin) are exercised through fixtures only.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
