### PR TITLE
fix(eval): preserve console for ConPTY Python kernels

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed
 
+- Fixed compiled Windows launches misclassifying ConPTY-backed terminals as console-less when `GetConsoleWindow()` returned no HWND, which spawned Python eval kernels with `CREATE_NO_WINDOW` and could deadlock imports of NumPy-backed packages such as Matplotlib ([#7343](https://github.com/can1357/oh-my-pi/issues/7343)).
 - Fixed sessions without a granted `write` tool hiding discoverable and MCP tools behind the unusable `xd://` transport; those sessions now disable device mounting and expose the tools directly without gaining write access.
 - Fixed collab guest prompts being sent to models as unframed developer context, so guest messages now retain their transcript attribution while reaching the model as prioritized user interjections ([#7288](https://github.com/can1357/oh-my-pi/issues/7288)).
 - Fixed `/memory stats` and `/memory diagnose` showing "Memory stats is not available for the off backend" when memory is off, in both the TUI and ACP/RPC slash-command handlers; the off backend now says memory is off directly instead of naming itself as an unsupported backend ([#7251](https://github.com/can1357/oh-my-pi/pull/7251) by [@KennethHoff](https://github.com/KennethHoff)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compiled Windows launches misclassifying ConPTY-backed terminals as console-less when `GetConsoleWindow()` returned no HWND, which spawned Python eval kernels with `CREATE_NO_WINDOW` and could deadlock imports of NumPy-backed packages such as Matplotlib ([#7343](https://github.com/can1357/oh-my-pi/issues/7343)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Added
@@ -24,7 +28,6 @@
 
 ### Fixed
 
-- Fixed compiled Windows launches misclassifying ConPTY-backed terminals as console-less when `GetConsoleWindow()` returned no HWND, which spawned Python eval kernels with `CREATE_NO_WINDOW` and could deadlock imports of NumPy-backed packages such as Matplotlib ([#7343](https://github.com/can1357/oh-my-pi/issues/7343)).
 - Fixed sessions without a granted `write` tool hiding discoverable and MCP tools behind the unusable `xd://` transport; those sessions now disable device mounting and expose the tools directly without gaining write access.
 - Fixed collab guest prompts being sent to models as unframed developer context, so guest messages now retain their transcript attribution while reaching the model as prioritized user interjections ([#7288](https://github.com/can1357/oh-my-pi/issues/7288)).
 - Fixed `/memory stats` and `/memory diagnose` showing "Memory stats is not available for the off backend" when memory is off, in both the TUI and ACP/RPC slash-command handlers; the off backend now says memory is off directly instead of naming itself as an unsupported backend ([#7251](https://github.com/can1357/oh-my-pi/pull/7251) by [@KennethHoff](https://github.com/KennethHoff)).

--- a/packages/coding-agent/src/eval/py/spawn-options.ts
+++ b/packages/coding-agent/src/eval/py/spawn-options.ts
@@ -1,10 +1,10 @@
 /**
  * Subprocess spawn-option helpers for the Python kernel.
  *
- * Pure helpers (`shouldHideKernelWindow`, `consoleAttachedViaTTY`) live here
- * so they can be unit-tested without dragging in the kernel's runtime
- * dependencies. The effectful `hostHasInheritableConsole` wraps a Win32 FFI
- * probe with a TTY fallback and is the function `kernel.ts` actually calls.
+ * Pure helpers (`shouldHideKernelWindow`, `consoleAttached`) live here so they
+ * can be unit-tested without dragging in the kernel's runtime dependencies.
+ * The effectful `hostHasInheritableConsole` combines a Win32 FFI probe with
+ * TTY evidence and is the function `kernel.ts` actually calls.
  */
 import { dlopen, FFIType } from "bun:ffi";
 
@@ -54,20 +54,21 @@ export function shouldDetachKernel(platform: NodeJS.Platform): boolean {
 }
 
 /**
- * TTY-based fallback used when the Win32 console probe is unavailable.
+ * Combine native Win32 and stdio TTY evidence of an inheritable console.
  *
- * Returns `true` if any of stdin/stdout/stderr is currently a TTY. This
- * correctly detects the common interactive launches and the partial-
- * redirection cases (`omp -p > out.txt`, `< in.txt`, `2> err.log`) where at
- * least one stream stays bound to the terminal. The all-stdio-redirected
- * case (`< in > out 2> err` from a console) is the reason we prefer the
- * Win32 probe over this fallback whenever possible.
+ * `GetConsoleWindow()` detects classic consoles even when every stdio stream
+ * is redirected. TTY detection covers ConPTY-backed terminals, where compiled
+ * hosts can receive a null HWND despite being attached to Windows Terminal.
+ * Either signal must preserve console inheritance: `CREATE_NO_WINDOW` can
+ * deadlock NumPy native-extension loading in the Python child.
  */
-export function consoleAttachedViaTTY(opts: {
+export function consoleAttached(opts: {
+	nativeConsole?: boolean | null;
 	stdinIsTTY: boolean;
 	stdoutIsTTY: boolean;
 	stderrIsTTY: boolean;
 }): boolean {
+	if (opts.nativeConsole === true) return true;
 	return opts.stdinIsTTY || opts.stdoutIsTTY || opts.stderrIsTTY;
 }
 
@@ -75,10 +76,10 @@ export function consoleAttachedViaTTY(opts: {
  * Probe `kernel32.dll!GetConsoleWindow()` to detect whether the current
  * Windows process owns a console window.
  *
- * Returns `true` for a non-NULL HWND, `false` when NULL (no console — true
- * service / `DETACHED_PROCESS` / GUI parent), and `null` when the probe
- * itself fails (off-Windows, FFI disabled, or unexpected kernel32 layout).
- * A `null` return means "don't trust me, use the TTY fallback".
+ * Returns `true` for a non-NULL HWND, `false` when NULL, and `null` when the
+ * probe itself fails (off-Windows, FFI disabled, or unexpected kernel32
+ * layout). A false result is not conclusive for ConPTY-backed terminals, so
+ * callers must also inspect the stdio TTY signals.
  *
  * Cached on first call because in practice the console attachment of a
  * long-lived OMP host never changes for the lifetime of the process, and
@@ -117,21 +118,15 @@ export function __resetWindowsConsoleProbeCache(): void {
 /**
  * Whether the host process owns a console its children can inherit.
  *
- * - On Windows, the authoritative signal is `GetConsoleWindow()`. It returns
- *   a non-NULL HWND whenever the process has a console attached, regardless
- *   of how the standard streams are redirected — so an `omp -p ... < in.txt
- *   > out.txt 2> err.log` launched from a real Windows Terminal session is
- *   correctly classified as console-attached and the kernel keeps its
- *   inheritable console.
- * - On any other platform, or if the FFI probe fails, fall back to the
- *   TTY-OR heuristic. That still catches the common interactive cases.
+ * On Windows, `GetConsoleWindow()` detects classic consoles and all-stdio-
+ * redirected launches while stdio TTYs detect ConPTY-backed terminals. Either
+ * signal is sufficient. Other platforms use the same TTY evidence, although
+ * `windowsHide` is a no-op there.
  */
 export function hostHasInheritableConsole(): boolean {
-	if (process.platform === "win32") {
-		const native = probeWindowsConsoleWindow();
-		if (native !== null) return native;
-	}
-	return consoleAttachedViaTTY({
+	const nativeConsole = process.platform === "win32" ? probeWindowsConsoleWindow() : null;
+	return consoleAttached({
+		nativeConsole,
 		stdinIsTTY: !!process.stdin.isTTY,
 		stdoutIsTTY: !!process.stdout.isTTY,
 		stderrIsTTY: !!process.stderr.isTTY,

--- a/packages/coding-agent/test/eval/kernel-spawn.test.ts
+++ b/packages/coding-agent/test/eval/kernel-spawn.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
 	__resetWindowsConsoleProbeCache,
-	consoleAttachedViaTTY,
+	consoleAttached,
 	hostHasInheritableConsole,
 	shouldDetachKernel,
 	shouldHideKernelWindow,
@@ -24,16 +24,12 @@ describe("shouldDetachKernel", () => {
  * option to `CREATE_NO_WINDOW`, which detaches the child from any inherited
  * console — breaking both (a) `LoadLibraryExW` for NumPy/pandas native
  * extensions and (b) SIGINT delivery via `GenerateConsoleCtrlEvent`. See
- * issue #1960. The tests below pin the three layered concerns the PR review
- * surfaced:
+ * issue #1960. The tests below pin the three layered concerns:
  *
- * 1. `shouldHideKernelWindow` — pure predicate over a single boolean.
- * 2. `consoleAttachedViaTTY` — the TTY-OR fallback used when the Win32 FFI
- *    probe is unavailable; covers the partial-redirection cases.
- * 3. `hostHasInheritableConsole` — the integration boundary. Off-Windows it
- *    short-circuits to the TTY fallback; on Windows it is expected to
- *    consult `kernel32!GetConsoleWindow()` first, which is the authoritative
- *    signal even for the all-stdio-redirected case.
+ * 1. `shouldHideKernelWindow` — pure predicate over the combined detection.
+ * 2. `consoleAttached` — native HWND and stdio TTY evidence; either wins.
+ * 3. `hostHasInheritableConsole` — the integration boundary that collects
+ *    both signals before the kernel spawn.
  */
 describe("shouldHideKernelWindow", () => {
 	it("inherits the host console on Windows when one is attached", () => {
@@ -59,38 +55,50 @@ describe("shouldHideKernelWindow", () => {
 	});
 });
 
-describe("consoleAttachedViaTTY (FFI fallback heuristic)", () => {
-	// The OR of three TTY signals correctly classifies the realistic shell
-	// redirection scenarios that motivated widening the check beyond stdout
-	// in the first review pass (PR #1961). The all-three-redirected case
-	// (false here) is the gap that the Win32 FFI probe in
-	// `hostHasInheritableConsole` is meant to close — this fallback is best-
-	// effort.
+describe("consoleAttached", () => {
+	it("treats a ConPTY TTY as attached when GetConsoleWindow returns null", () => {
+		expect(
+			consoleAttached({
+				nativeConsole: false,
+				stdinIsTTY: true,
+				stdoutIsTTY: true,
+				stderrIsTTY: true,
+			}),
+		).toBe(true);
+	});
 
-	it("treats a fully interactive launch as console-attached", () => {
-		expect(consoleAttachedViaTTY({ stdinIsTTY: true, stdoutIsTTY: true, stderrIsTTY: true })).toBe(true);
+	it("trusts the native console for fully redirected stdio", () => {
+		expect(
+			consoleAttached({
+				nativeConsole: true,
+				stdinIsTTY: false,
+				stdoutIsTTY: false,
+				stderrIsTTY: false,
+			}),
+		).toBe(true);
 	});
 
 	it("treats `omp -p '...' > out.txt` (stdout-only redirect) as console-attached", () => {
-		// The reviewer's first-pass repro: stdout off the terminal, stdin
-		// and stderr still attached. OR keeps the console.
-		expect(consoleAttachedViaTTY({ stdinIsTTY: true, stdoutIsTTY: false, stderrIsTTY: true })).toBe(true);
+		expect(consoleAttached({ stdinIsTTY: true, stdoutIsTTY: false, stderrIsTTY: true })).toBe(true);
 	});
 
 	it("treats stdin-only redirects (`< in.txt`) as console-attached", () => {
-		expect(consoleAttachedViaTTY({ stdinIsTTY: false, stdoutIsTTY: true, stderrIsTTY: true })).toBe(true);
+		expect(consoleAttached({ stdinIsTTY: false, stdoutIsTTY: true, stderrIsTTY: true })).toBe(true);
 	});
 
 	it("treats stderr-only redirects (`2> err.log`) as console-attached", () => {
-		expect(consoleAttachedViaTTY({ stdinIsTTY: true, stdoutIsTTY: true, stderrIsTTY: false })).toBe(true);
+		expect(consoleAttached({ stdinIsTTY: true, stdoutIsTTY: true, stderrIsTTY: false })).toBe(true);
 	});
 
-	it("returns false only when none of stdin/stdout/stderr is a TTY", () => {
-		// This is the gap: a real Windows Terminal session with all three
-		// streams redirected (`omp ... < in > out 2> err`) lands here.
-		// `hostHasInheritableConsole` uses the Win32 FFI probe to recover
-		// the right answer in that scenario; this helper is the fallback.
-		expect(consoleAttachedViaTTY({ stdinIsTTY: false, stdoutIsTTY: false, stderrIsTTY: false })).toBe(false);
+	it("returns false without native-console or TTY evidence", () => {
+		expect(
+			consoleAttached({
+				nativeConsole: false,
+				stdinIsTTY: false,
+				stdoutIsTTY: false,
+				stderrIsTTY: false,
+			}),
+		).toBe(false);
 	});
 });
 
@@ -100,16 +108,14 @@ describe("hostHasInheritableConsole", () => {
 	});
 
 	if (process.platform !== "win32") {
-		it("matches the TTY-OR fallback off-Windows", () => {
-			// Off-Windows, `windowsHide` is a no-op anyway, but we still
-			// expose `hostHasInheritableConsole` symmetrically. Confirm it
-			// degrades to the same OR the call site would compute by hand.
-			const tty = consoleAttachedViaTTY({
+		it("matches the TTY evidence off-Windows", () => {
+			const expected = consoleAttached({
+				nativeConsole: null,
 				stdinIsTTY: !!process.stdin.isTTY,
 				stdoutIsTTY: !!process.stdout.isTTY,
 				stderrIsTTY: !!process.stderr.isTTY,
 			});
-			expect(hostHasInheritableConsole()).toBe(tty);
+			expect(hostHasInheritableConsole()).toBe(expected);
 		});
 	}
 });


### PR DESCRIPTION
## Repro
On native Windows with the compiled 17.2.4 binary launched from Windows Terminal/PowerShell or cmd, an eval cell containing `import matplotlib; print(matplotlib.__version__)` hangs until the Python kernel is killed, while `python -c "import matplotlib; print(matplotlib.__version__)"` prints `3.11.1` immediately in the same terminal. A 10-second `faulthandler` dump from the eval cell shows the executing thread blocked in importlib `create_module` while loading NumPy's native `_multiarray_umath` extension.

## Cause
`hostHasInheritableConsole` in `packages/coding-agent/src/eval/py/spawn-options.ts` treated a false `GetConsoleWindow()` probe as authoritative and skipped positive stdio TTY evidence. Compiled ConPTY-backed launches can have no HWND while still being attached to Windows Terminal, so the Python kernel was spawned with `windowsHide: true` / `CREATE_NO_WINDOW`; NumPy's native extension then deadlocked during module loading.

## Fix
- Combine the Win32 HWND probe and stdio TTY evidence; either signal now preserves console inheritance for the Python kernel.
- Cover the ConPTY/no-HWND case, fully redirected classic consoles, partial redirection, and genuinely console-less launches.
- Document the Windows Matplotlib/NumPy import fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/eval/kernel-spawn.test.ts` — 12 passed, 0 failed.

`bun run check` in `packages/coding-agent` — passed.

Skipped the pre-publish gate: `bun run fix` fails identically on clean `origin/main` because `audiopus_sys` cannot execute the unavailable `cmake` binary; the TypeScript formatter completed without changes before that unrelated Rust build failure.

Fixes #7343