### PR TITLE
fix(mnemopi): bound locked retention during teardown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed headless print-mode teardown exceeding its Mnemopi consolidation budget when final retention blocks on a locked SQLite writer, leaving the parent process, embed worker, and MCP children alive after the turn completed ([#7351](https://github.com/can1357/oh-my-pi/issues/7351)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Added

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -650,10 +650,13 @@ export class MnemopiSessionState {
 	 * episodic promotion / embedding for the LAST few turns is skipped,
 	 * and `maybeRetainOnAgentEnd` has already retained earlier turns).
 	 */
-	#boundRetainBusyTimeout(timeoutMs: number): void {
-		// SQLite lock waits block the JS thread, so a Promise race cannot interrupt them.
+	#boundOwnedBusyTimeout(timeoutMs: number): void {
+		// SQLite lock waits block the JS thread, so a Promise race cannot interrupt
+		// them. consolidate() flushes every owned bank, so bound each one — not just
+		// the retain bank — or a locked shared bank (per-project-tagged) still stalls
+		// teardown for Mnemopi's default 5s busy timeout (#7351 review).
 		const busyTimeoutMs = Math.max(1, Math.floor(timeoutMs));
-		this.memory.beam.db.exec(`PRAGMA busy_timeout=${busyTimeoutMs}`);
+		for (const memory of this.scoped.owned) memory.beam.db.exec(`PRAGMA busy_timeout=${busyTimeoutMs}`);
 	}
 
 	async dispose(options: { consolidate?: boolean; timeoutMs?: number } = {}): Promise<void> {
@@ -670,7 +673,7 @@ export class MnemopiSessionState {
 		const { timeoutMs } = options;
 		const boundedTimeoutMs = timeoutMs !== undefined && timeoutMs > 0 ? timeoutMs : undefined;
 		const deadline = boundedTimeoutMs !== undefined ? performance.now() + boundedTimeoutMs : undefined;
-		if (boundedTimeoutMs !== undefined) this.#boundRetainBusyTimeout(boundedTimeoutMs);
+		if (boundedTimeoutMs !== undefined) this.#boundOwnedBusyTimeout(boundedTimeoutMs);
 		const consolidatePromise = this.consolidate({ full: false, extract: false, sleep: false }).catch(
 			(error: unknown) => {
 				logger.warn("Mnemopi: consolidation on dispose failed.", { error: String(error) });

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -639,17 +639,23 @@ export class MnemopiSessionState {
 	 * tokens on memories that will be wiped on the next line is wasted work
 	 * (PR #2327 review).
 	 *
-	 * `timeoutMs` caps how long the consolidate await blocks the caller
-	 * (the user-visible `/quit` / `/exit` shutdown path passes this so
-	 * dispose returns within a UX budget — issue #3641). When the cap is
-	 * hit, dispose returns immediately and detaches the still-in-flight
-	 * consolidate; the SQLite handles are closed in the background once
-	 * the consolidate settles so writes never race a closed handle, and
-	 * any pending embeddings are SIGKILL'd along with the embed worker
+	 * `timeoutMs` caps both synchronous SQLite lock waits during final retention
+	 * and the asynchronous consolidation drain (the user-visible `/quit`,
+	 * `/exit`, and print paths pass this so disposal stays within their shutdown
+	 * budget). When the cap is hit, dispose returns immediately and detaches the
+	 * still-in-flight consolidate; the SQLite handles are closed in the
+	 * background once the consolidate settles so writes never race a closed handle,
+	 * and any pending embeddings are SIGKILL'd along with the embed worker
 	 * (a tolerable loss — working memory rows are durable; only the
 	 * episodic promotion / embedding for the LAST few turns is skipped,
 	 * and `maybeRetainOnAgentEnd` has already retained earlier turns).
 	 */
+	#boundRetainBusyTimeout(timeoutMs: number): void {
+		// SQLite lock waits block the JS thread, so a Promise race cannot interrupt them.
+		const busyTimeoutMs = Math.max(1, Math.floor(timeoutMs));
+		this.memory.beam.db.exec(`PRAGMA busy_timeout=${busyTimeoutMs}`);
+	}
+
 	async dispose(options: { consolidate?: boolean; timeoutMs?: number } = {}): Promise<void> {
 		this.unsubscribe?.();
 		this.unsubscribe = undefined;
@@ -661,19 +667,22 @@ export class MnemopiSessionState {
 			closeOwned();
 			return;
 		}
+		const { timeoutMs } = options;
+		const boundedTimeoutMs = timeoutMs !== undefined && timeoutMs > 0 ? timeoutMs : undefined;
+		const deadline = boundedTimeoutMs !== undefined ? performance.now() + boundedTimeoutMs : undefined;
+		if (boundedTimeoutMs !== undefined) this.#boundRetainBusyTimeout(boundedTimeoutMs);
 		const consolidatePromise = this.consolidate({ full: false, extract: false, sleep: false }).catch(
 			(error: unknown) => {
 				logger.warn("Mnemopi: consolidation on dispose failed.", { error: String(error) });
 			},
 		);
-		const { timeoutMs } = options;
-		if (timeoutMs !== undefined && timeoutMs > 0) {
-			const TIMED_OUT = Symbol("mnemopi.dispose.timedOut");
-			const winner = await Promise.race([
-				consolidatePromise.then(() => undefined as unknown),
-				Bun.sleep(timeoutMs).then(() => TIMED_OUT as unknown),
-			]);
-			if (winner === TIMED_OUT) {
+		if (deadline !== undefined) {
+			const remainingMs = deadline - performance.now();
+			const completed =
+				remainingMs > 0
+					? await Promise.race([consolidatePromise.then(() => true), Bun.sleep(remainingMs).then(() => false)])
+					: false;
+			if (!completed) {
 				logger.warn("Mnemopi: consolidate-on-dispose exceeded shutdown budget; detaching to background.", {
 					timeoutMs,
 				});

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -7,6 +7,7 @@
  * session — these tools only need a populated state accessor and Settings.
  */
 
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
@@ -707,6 +708,28 @@ describe("Mnemopi backend lifecycle", () => {
 		expect(closeSpy).toHaveBeenCalledTimes(1);
 
 		registeredMnemopiState = undefined;
+	});
+
+	it("bounds synchronous SQLite lock waits during final retention (#7351)", async () => {
+		const config = makeMnemopiConfig({ baseBank: "test-bank" });
+		const entries = [
+			{ type: "message", message: { role: "user", content: "hello" } },
+			{ type: "message", message: { role: "assistant", content: [{ type: "text", text: "done" }] } },
+		];
+		const state = registerMnemopiState(config, { entries: () => entries });
+		const lock = new Database(config.dbPath);
+		lock.exec("BEGIN IMMEDIATE");
+
+		const started = performance.now();
+		try {
+			await state.dispose({ timeoutMs: 50 });
+		} finally {
+			lock.exec("ROLLBACK");
+			lock.close();
+			registeredMnemopiState = undefined;
+		}
+
+		expect(performance.now() - started).toBeLessThan(500);
 	});
 
 	it("dispose with no timeoutMs retains, flushes, and closes without sleeping (#3641)", async () => {

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -18,6 +18,7 @@ import { HindsightSessionState } from "@oh-my-pi/pi-coding-agent/hindsight/state
 import { mnemopiBackend } from "@oh-my-pi/pi-coding-agent/mnemopi/backend";
 import { loadMnemopiConfig, type MnemopiBackendConfig } from "@oh-my-pi/pi-coding-agent/mnemopi/config";
 import {
+	getMnemopiScopedDbPaths,
 	getMnemopiSessionState,
 	loadMnemopi,
 	loadMnemopiCore,
@@ -710,14 +711,23 @@ describe("Mnemopi backend lifecycle", () => {
 		registeredMnemopiState = undefined;
 	});
 
-	it("bounds synchronous SQLite lock waits during final retention (#7351)", async () => {
-		const config = makeMnemopiConfig({ baseBank: "test-bank" });
+	it("bounds synchronous SQLite lock waits on every owned bank during final retention (#7351)", async () => {
+		// per-project-tagged owns a project retain bank AND the shared bank; lock the
+		// shared bank so a retain-only busy-timeout fix would still stall teardown.
+		const config = makeMnemopiConfig({
+			scoping: "per-project-tagged",
+			bank: "project-alpha",
+			globalBank: "default",
+		});
 		const entries = [
 			{ type: "message", message: { role: "user", content: "hello" } },
 			{ type: "message", message: { role: "assistant", content: [{ type: "text", text: "done" }] } },
 		];
-		const state = registerMnemopiState(config, { entries: () => entries });
-		const lock = new Database(config.dbPath);
+		const state = registerMnemopiState(config, { cwd: "/work/project-alpha", entries: () => entries });
+		const ownedDbPaths = getMnemopiScopedDbPaths(config);
+		const sharedDbPath = ownedDbPaths.find(dbPath => dbPath === config.dbPath);
+		expect(sharedDbPath).toBeDefined();
+		const lock = new Database(sharedDbPath!);
 		lock.exec("BEGIN IMMEDIATE");
 
 		const started = performance.now();


### PR DESCRIPTION
## Repro

A Mnemopi session with a second SQLite connection holding `BEGIN IMMEDIATE` takes about 5.02 s to complete `dispose({ timeoutMs: 50 })`, because the synchronous final-retention write consumes Mnemopi’s 5 s SQLite busy timeout before the asynchronous deadline race begins. The original reproduction was `bun test packages/coding-agent/test/issue-7351-repro.test.ts`; the permanent equivalent is now in `packages/coding-agent/test/memory-tools.test.ts` and runs with `bun test packages/coding-agent/test/memory-tools.test.ts`.

## Cause

`MnemopiSessionState.dispose()` in `packages/coding-agent/src/mnemopi/state.ts` invoked `consolidate()` before measuring/racing the shutdown deadline. `forceRetainCurrentSession()` performs synchronous SQLite writes, so a locked writer blocked Bun’s JS thread and prevented the `Promise.race` timer from enforcing `SHUTDOWN_CONSOLIDATE_BUDGET_MS`; session teardown therefore could not reach embed-worker and MCP cleanup.

## Fix

- Clamp the retain database’s SQLite `busy_timeout` to the requested disposal budget before final consolidation starts.
- Measure synchronous retention against the same deadline and give asynchronous extraction/embedding drains only the remaining time.
- Add a locked-writer regression proving bounded disposal, plus the coding-agent changelog entry.

## Verification

`bun test packages/coding-agent/test/memory-tools.test.ts packages/coding-agent/test/silent-abort-print-mode.test.ts` passed: 59 tests, 190 assertions. `bun run check:types` passed in `packages/coding-agent`; the push pre-publish gate also completed `bun check`.

Fixes #7351