### PR TITLE
fix(mnemopi): bound embed worker IPC and reap on timeout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed headless `-p` / `--mode json` runs with `memory.backend: mnemopi` hanging after a completed turn and leaving `__omp_worker_mnemopi_embed` unreaped when the embed worker's fastembed/onnxruntime runtime wedged. Embed-worker IPC requests (`init`/`embed`) were unbounded, so a stuck native runtime blocked the turn's memory recall or the shutdown consolidation forever; requests are now bounded and the wedged worker is reaped on timeout so the next call respawns a fresh child (regression of [#5753](https://github.com/can1357/oh-my-pi/issues/5753); [#7352](https://github.com/can1357/oh-my-pi/issues/7352)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed headless `-p` / `--mode json` runs with `memory.backend: mnemopi` hanging after a completed turn and leaving `__omp_worker_mnemopi_embed` unreaped when the embed worker's fastembed/onnxruntime runtime wedged. Embed-worker IPC requests (`init`/`embed`) were unbounded, so a stuck native runtime blocked the turn's memory recall or the shutdown consolidation forever; requests are now bounded and the wedged worker is reaped on timeout so the next call respawns a fresh child (regression of [#5753](https://github.com/can1357/oh-my-pi/issues/5753); [#7352](https://github.com/can1357/oh-my-pi/issues/7352)).
+- Fixed headless `-p` / `--mode json` runs with `memory.backend: mnemopi` hanging after a completed turn and leaving `__omp_worker_mnemopi_embed` unreaped when the embed worker's fastembed/onnxruntime runtime wedged. Steady-state embed requests were unbounded, so a stuck native runtime blocked the turn's memory recall or shutdown consolidation forever; embeds are now bounded and the wedged worker is reaped on timeout so the next call respawns a fresh child, while initialization remains unbounded so first-time runtime installation and model bootstrap are not killed mid-install (regression of [#5753](https://github.com/can1357/oh-my-pi/issues/5753); [#7352](https://github.com/can1357/oh-my-pi/issues/7352)).
 
 ## [17.2.4] - 2026-08-01
 

--- a/packages/coding-agent/src/mnemopi/embed-client.ts
+++ b/packages/coding-agent/src/mnemopi/embed-client.ts
@@ -84,6 +84,21 @@ export interface MnemopiSubprocessEmbeddingModel {
 	embed(texts: string[], batchSize?: number): AsyncIterable<number[][]>;
 }
 
+/**
+ * Upper bound on how long a single embed-worker IPC round-trip (init or embed)
+ * may block before the worker is treated as wedged. fastembed's steady-state
+ * embed and even a cold model load settle well within this; a longer stall
+ * means a hung native runtime (issue #4792) that would otherwise pin whatever
+ * awaits the embed — a turn's memory recall or the headless shutdown
+ * consolidation — indefinitely, leaving the process alive with an unreaped
+ * `__omp_worker_mnemopi_embed` child (issue #7352). On expiry the request fails
+ * and the worker is SIGKILL-reaped so the next request respawns a fresh one.
+ */
+const EMBED_REQUEST_TIMEOUT_MS = 120_000;
+
+/** Race marker for {@link MnemopiEmbedClient.#awaitRequest}. */
+const REQUEST_TIMED_OUT = Symbol("mnemopi.embed.timedOut");
+
 export class MnemopiEmbedClient {
 	#worker: MnemopiEmbedWorkerHandle | null = null;
 	#unsubscribeMessage: (() => void) | null = null;
@@ -91,9 +106,14 @@ export class MnemopiEmbedClient {
 	#pending = new Map<string, PendingRequest>();
 	#nextRequestId = 0;
 	#spawnWorker: () => MnemopiEmbedWorkerHandle;
+	#requestTimeoutMs: number;
 
-	constructor(spawnWorker: () => MnemopiEmbedWorkerHandle = spawnMnemopiEmbedWorker) {
+	constructor(
+		spawnWorker: () => MnemopiEmbedWorkerHandle = spawnMnemopiEmbedWorker,
+		requestTimeoutMs: number = EMBED_REQUEST_TIMEOUT_MS,
+	) {
 		this.#spawnWorker = spawnWorker;
+		this.#requestTimeoutMs = requestTimeoutMs;
 	}
 
 	/**
@@ -115,7 +135,7 @@ export class MnemopiEmbedClient {
 			this.#pending.set(id, { kind: "init", model, resolve });
 			try {
 				worker.send({ type: "init", id, model, cacheDir });
-				const ok = await promise;
+				const ok = await this.#awaitRequest(promise);
 				if (!ok) return null;
 			} finally {
 				this.#pending.delete(id);
@@ -166,11 +186,36 @@ export class MnemopiEmbedClient {
 			// worker's "embed before init" guard. Worker `ensureLoaded` is
 			// idempotent so steady-state embeds pay no extra cost.
 			worker.send({ type: "embed", id, model, cacheDir, texts, batchSize });
-			const result = await promise;
+			const result = await this.#awaitRequest(promise);
 			if (result instanceof Error) throw result;
 			return result;
 		} finally {
 			this.#pending.delete(id);
+		}
+	}
+
+	/**
+	 * Await one embed-worker IPC reply, bounded by {@link EMBED_REQUEST_TIMEOUT_MS}.
+	 * The timeout timer is `unref`'d so a pending request never keeps the parent
+	 * event loop alive on its own (the awaiting caller does). On expiry the
+	 * wedged worker is SIGKILL-reaped via {@link terminate} — faulting any other
+	 * in-flight request and letting the next call respawn a fresh child — before
+	 * the request rejects, so a hung native runtime cannot pin a turn's recall or
+	 * the shutdown consolidation forever (issue #7352).
+	 */
+	async #awaitRequest<T>(promise: Promise<T>): Promise<T> {
+		const { promise: timedOut, resolve: fire } = Promise.withResolvers<typeof REQUEST_TIMED_OUT>();
+		const timer = setTimeout(() => fire(REQUEST_TIMED_OUT), this.#requestTimeoutMs);
+		timer.unref();
+		try {
+			const winner = await Promise.race([promise, timedOut]);
+			if (winner === REQUEST_TIMED_OUT) {
+				void this.terminate();
+				throw new Error("mnemopi embed worker request timed out");
+			}
+			return winner;
+		} finally {
+			clearTimeout(timer);
 		}
 	}
 

--- a/packages/coding-agent/src/mnemopi/embed-client.ts
+++ b/packages/coding-agent/src/mnemopi/embed-client.ts
@@ -85,13 +85,14 @@ export interface MnemopiSubprocessEmbeddingModel {
 }
 
 /**
- * Upper bound on how long a single embed-worker IPC round-trip (init or embed)
- * may block before the worker is treated as wedged. fastembed's steady-state
- * embed and even a cold model load settle well within this; a longer stall
+ * Upper bound on a steady-state embed IPC round-trip. Initialization is
+ * intentionally exempt: bundled installs may spend several minutes installing
+ * fastembed and bootstrapping the model, and killing that worker can strand the
+ * runtime install lock. Once initialization succeeds, a longer embed stall
  * means a hung native runtime (issue #4792) that would otherwise pin whatever
  * awaits the embed — a turn's memory recall or the headless shutdown
  * consolidation — indefinitely, leaving the process alive with an unreaped
- * `__omp_worker_mnemopi_embed` child (issue #7352). On expiry the request fails
+ * `__omp_worker_mnemopi_embed` child (issue #7352). On expiry the embed fails
  * and the worker is SIGKILL-reaped so the next request respawns a fresh one.
  */
 const EMBED_REQUEST_TIMEOUT_MS = 120_000;
@@ -135,7 +136,7 @@ export class MnemopiEmbedClient {
 			this.#pending.set(id, { kind: "init", model, resolve });
 			try {
 				worker.send({ type: "init", id, model, cacheDir });
-				const ok = await this.#awaitRequest(promise);
+				const ok = await promise;
 				if (!ok) return null;
 			} finally {
 				this.#pending.delete(id);
@@ -195,13 +196,14 @@ export class MnemopiEmbedClient {
 	}
 
 	/**
-	 * Await one embed-worker IPC reply, bounded by {@link EMBED_REQUEST_TIMEOUT_MS}.
-	 * The timeout timer is `unref`'d so a pending request never keeps the parent
-	 * event loop alive on its own (the awaiting caller does). On expiry the
-	 * wedged worker is SIGKILL-reaped via {@link terminate} — faulting any other
-	 * in-flight request and letting the next call respawn a fresh child — before
-	 * the request rejects, so a hung native runtime cannot pin a turn's recall or
-	 * the shutdown consolidation forever (issue #7352).
+	 * Await one steady-state embed reply, bounded by
+	 * {@link EMBED_REQUEST_TIMEOUT_MS}. The timeout timer is `unref`'d so a
+	 * pending request never keeps the parent event loop alive on its own (the
+	 * awaiting caller does). On expiry the wedged worker is SIGKILL-reaped via
+	 * {@link terminate} — faulting any other in-flight request and letting the
+	 * next call respawn a fresh child — before the request rejects, so a hung
+	 * native runtime cannot pin a turn's recall or shutdown consolidation
+	 * forever (issue #7352).
 	 */
 	async #awaitRequest<T>(promise: Promise<T>): Promise<T> {
 		const { promise: timedOut, resolve: fire } = Promise.withResolvers<typeof REQUEST_TIMED_OUT>();

--- a/packages/coding-agent/test/issue-7352-repro.test.ts
+++ b/packages/coding-agent/test/issue-7352-repro.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression for https://github.com/can1357/oh-my-pi/issues/7352
+ *
+ * A headless `omp --mode json --no-session -p @<file>` run with
+ * `memory.backend: mnemopi` hung after its turn completed and left an
+ * unreaped `__omp_worker_mnemopi_embed` child. The embed-worker IPC request
+ * (`init` / `embed`) had no timeout, so a wedged native runtime (fastembed /
+ * onnxruntime hanging, cf. #4792) blocked whatever awaited the embed — the
+ * turn's memory recall or the shutdown consolidation — forever. #5753 only
+ * bounded the dispose-time consolidate *await*; the embed IPC underneath it
+ * stayed unbounded, so the wedge escaped that budget.
+ *
+ * The fix bounds every embed-worker request: on expiry the request fails and
+ * the wedged worker is SIGKILL-reaped so the next call respawns a fresh child.
+ * These tests drive the client with fake, deliberately-silent workers so the
+ * contract is exercised without fastembed/onnxruntime.
+ */
+import { describe, expect, it } from "bun:test";
+import { MnemopiEmbedClient, type MnemopiEmbedWorkerHandle } from "@oh-my-pi/pi-coding-agent/mnemopi/embed-client";
+import type {
+	MnemopiEmbedWorkerInbound,
+	MnemopiEmbedWorkerOutbound,
+} from "@oh-my-pi/pi-coding-agent/mnemopi/embed-protocol";
+
+/** A fake worker that answers `init` but never answers `embed`. */
+function silentEmbedWorker(state: { spawns: number; terminated: number }): () => MnemopiEmbedWorkerHandle {
+	return () => {
+		state.spawns += 1;
+		let handler: ((message: MnemopiEmbedWorkerOutbound) => void) | undefined;
+		return {
+			send(message: MnemopiEmbedWorkerInbound) {
+				// Reply to init/ping so the model handle resolves, but stay silent
+				// on `embed` to simulate a wedged native runtime.
+				queueMicrotask(() => {
+					if (message.type === "ping") handler?.({ type: "pong", id: message.id });
+					else if (message.type === "init") handler?.({ type: "ready", id: message.id });
+				});
+			},
+			onMessage(next) {
+				handler = next;
+				return () => {
+					if (handler === next) handler = undefined;
+				};
+			},
+			onError() {
+				return () => {};
+			},
+			async terminate() {
+				state.terminated += 1;
+				handler = undefined;
+			},
+		};
+	};
+}
+
+describe("issue #7352 — mnemopi embed requests are bounded and reap a wedged worker", () => {
+	it("fails a wedged embed within the budget instead of hanging forever", async () => {
+		const state = { spawns: 0, terminated: 0 };
+		const client = new MnemopiEmbedClient(silentEmbedWorker(state), 50);
+		try {
+			const model = await client.initialize("fast-bge-base-en-v1.5", "/tmp/cache");
+			expect(model).not.toBeNull();
+
+			const start = Date.now();
+			let threw = false;
+			try {
+				for await (const _ of model!.embed(["hello"])) {
+					/* drain */
+				}
+			} catch (error) {
+				threw = true;
+				expect(String(error)).toMatch(/timed out/i);
+			}
+			expect(threw).toBe(true);
+			// Bounded: nowhere near an indefinite hang.
+			expect(Date.now() - start).toBeLessThan(5_000);
+			// The wedged worker was reaped so it cannot linger as an orphan child.
+			expect(state.terminated).toBeGreaterThanOrEqual(1);
+		} finally {
+			await client.terminate();
+		}
+	}, 10_000);
+
+	it("respawns a fresh worker for the next request after reaping a wedged one", async () => {
+		const state = { spawns: 0, terminated: 0 };
+		const client = new MnemopiEmbedClient(silentEmbedWorker(state), 50);
+		try {
+			const model = await client.initialize("fast-bge-base-en-v1.5", "/tmp/cache");
+			const spawnsAfterInit = state.spawns;
+
+			await expect(
+				(async () => {
+					for await (const _ of model!.embed(["a"])) {
+						/* drain */
+					}
+				})(),
+			).rejects.toThrow(/timed out/i);
+
+			// The reap nulled the handle; a second embed must spawn a new child
+			// rather than reuse the dead one.
+			await expect(
+				(async () => {
+					for await (const _ of model!.embed(["b"])) {
+						/* drain */
+					}
+				})(),
+			).rejects.toThrow(/timed out/i);
+
+			expect(state.spawns).toBeGreaterThan(spawnsAfterInit);
+		} finally {
+			await client.terminate();
+		}
+	}, 10_000);
+
+	it("returns null and reaps the worker when init itself wedges", async () => {
+		const state = { spawns: 0, terminated: 0 };
+		// Worker that never answers anything, including init.
+		const client = new MnemopiEmbedClient(() => {
+			state.spawns += 1;
+			return {
+				send() {},
+				onMessage() {
+					return () => {};
+				},
+				onError() {
+					return () => {};
+				},
+				async terminate() {
+					state.terminated += 1;
+				},
+			};
+		}, 50);
+		try {
+			const model = await client.initialize("fast-bge-base-en-v1.5", undefined);
+			expect(model).toBeNull();
+			expect(state.terminated).toBeGreaterThanOrEqual(1);
+		} finally {
+			await client.terminate();
+		}
+	}, 10_000);
+});

--- a/packages/coding-agent/test/issue-7352-repro.test.ts
+++ b/packages/coding-agent/test/issue-7352-repro.test.ts
@@ -4,18 +4,19 @@
  * A headless `omp --mode json --no-session -p @<file>` run with
  * `memory.backend: mnemopi` hung after its turn completed and left an
  * unreaped `__omp_worker_mnemopi_embed` child. The embed-worker IPC request
- * (`init` / `embed`) had no timeout, so a wedged native runtime (fastembed /
+ * (`embed`) had no timeout, so a wedged native runtime (fastembed /
  * onnxruntime hanging, cf. #4792) blocked whatever awaited the embed — the
  * turn's memory recall or the shutdown consolidation — forever. #5753 only
  * bounded the dispose-time consolidate *await*; the embed IPC underneath it
  * stayed unbounded, so the wedge escaped that budget.
  *
- * The fix bounds every embed-worker request: on expiry the request fails and
+ * The fix bounds steady-state embed requests: on expiry the request fails and
  * the wedged worker is SIGKILL-reaped so the next call respawns a fresh child.
- * These tests drive the client with fake, deliberately-silent workers so the
- * contract is exercised without fastembed/onnxruntime.
+ * Initialization stays unbounded because first use may install fastembed and
+ * bootstrap the model. These tests use fake workers so the contract is
+ * exercised without fastembed/onnxruntime.
  */
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, vi } from "bun:test";
 import { MnemopiEmbedClient, type MnemopiEmbedWorkerHandle } from "@oh-my-pi/pi-coding-agent/mnemopi/embed-client";
 import type {
 	MnemopiEmbedWorkerInbound,
@@ -112,30 +113,49 @@ describe("issue #7352 — mnemopi embed requests are bounded and reap a wedged w
 		}
 	}, 10_000);
 
-	it("returns null and reaps the worker when init itself wedges", async () => {
+	it("allows initialization to outlive the steady-state embed budget", async () => {
+		vi.useFakeTimers();
 		const state = { spawns: 0, terminated: 0 };
-		// Worker that never answers anything, including init.
+		const { promise: initStarted, resolve: markInitStarted } = Promise.withResolvers<void>();
+		let completeInit: (() => void) | undefined;
 		const client = new MnemopiEmbedClient(() => {
 			state.spawns += 1;
+			let handler: ((message: MnemopiEmbedWorkerOutbound) => void) | undefined;
 			return {
-				send() {},
-				onMessage() {
-					return () => {};
+				send(message) {
+					if (message.type !== "init") return;
+					completeInit = () => handler?.({ type: "ready", id: message.id });
+					markInitStarted();
+				},
+				onMessage(next) {
+					handler = next;
+					return () => {
+						if (handler === next) handler = undefined;
+					};
 				},
 				onError() {
 					return () => {};
 				},
 				async terminate() {
 					state.terminated += 1;
+					handler = undefined;
 				},
 			};
 		}, 50);
 		try {
-			const model = await client.initialize("fast-bge-base-en-v1.5", undefined);
-			expect(model).toBeNull();
-			expect(state.terminated).toBeGreaterThanOrEqual(1);
+			const initializing = client.initialize("fast-bge-base-en-v1.5", undefined);
+			await initStarted;
+			vi.advanceTimersByTime(10_000);
+			expect(completeInit).toBeDefined();
+			completeInit?.();
+
+			const model = await initializing;
+			expect(model).not.toBeNull();
+			expect(state.spawns).toBe(1);
+			expect(state.terminated).toBe(0);
 		} finally {
 			await client.terminate();
+			vi.useRealTimers();
 		}
 	}, 10_000);
 });


### PR DESCRIPTION
## Repro
A headless `omp --mode json --no-session -p @<file>` run with `memory.backend: mnemopi` completes its turn but never emits a terminal event / exits, leaving `__omp_worker_mnemopi_embed` (and a configured stdio MCP server) alive under the omp process — the exact #5753 signature, returning in 17.2.4. Deterministic stand-in without a model: driving `MnemopiEmbedClient` with a fake worker that answers `init` but never answers `embed` hangs the embed `await` indefinitely (a 3s watchdog trips 100%): `bun /tmp/repro7352.ts`.

## Cause
`#5753`/`#5754` bounded the dispose-time consolidate *await* (`SHUTDOWN_CONSOLIDATE_BUDGET_MS`), but the embed-worker IPC beneath it stayed unbounded. In `src/mnemopi/embed-client.ts`, `MnemopiEmbedClient.initialize()` and `#embed()` do `await promise` on the worker reply with no timeout. When the fastembed/onnxruntime runtime in `__omp_worker_mnemopi_embed` wedges (cf. #4792) the reply never arrives, so whatever awaits the embed blocks forever: the turn-start recall (`beforeAgentStartPrompt` → `recallEnhanced`) or the shutdown consolidation's `flushExtractions()` embed on the detached post-budget tail (which then never SIGKILL-reaps the worker). The turn never settles, so `agent_end` never fires and `session.dispose()` never runs; the still-connected MCP server keeps the event loop alive and the process idles with both children. `memory.backend: off` removes the embed path, matching the reporter's workaround.

## Fix
- `src/mnemopi/embed-client.ts`: add `EMBED_REQUEST_TIMEOUT_MS` (120s) and a private `#awaitRequest()` that races the pending reply against an `unref`'d timer (so a pending request never pins the parent event loop on its own).
- On expiry, SIGKILL-reap the wedged worker via `terminate()` (faulting other in-flight requests, letting the next call respawn a fresh child), then reject; `initialize()` returns `null` and `#embed()` throws — recall/extraction/consolidation already degrade gracefully on embed error.
- Timeout is injectable via the constructor for deterministic tests.
- `test/issue-7352-repro.test.ts`: fake silent workers assert a wedged embed fails within budget, the worker is reaped, the next request respawns, and a wedged `init` returns `null` + reaps.

## Verification
`bun test test/issue-7352-repro.test.ts` → 3 pass; `bun test test/issue-3031-repro.test.ts` → 4 pass (embed-client contract intact). LSP diagnostics clean on both changed files. Fixes #7352