### PR TITLE
feat(task): scope service tiers per agent

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -238,6 +238,9 @@
 - Fixed heavily branched conversation trees shifting linear continuations into disconnected columns.
 - Fixed plugin installation validation failures for legacy compatibility shims.
 - Removed hard-coded references to disabled or absent agents in system and tool prompts.
+### Added
+
+- Added sparse `task.agentServiceTierOverrides` settings so selected task/eval agents can opt into `priority` fast mode while unlisted agents retain the existing `tier.subagent` fallback; explicit `inherit` overrides preserve the immediate parent's tiers across cold revival ([#7106](https://github.com/can1357/oh-my-pi/issues/7106)).
 
 ## [17.2.4] - 2026-08-01
 

--- a/packages/coding-agent/src/config/service-tier.ts
+++ b/packages/coding-agent/src/config/service-tier.ts
@@ -64,6 +64,21 @@ export const SERVICE_TIER_INHERIT_SETTING_VALUES = [
 
 export type ServiceTierInheritSettingValue = (typeof SERVICE_TIER_INHERIT_SETTING_VALUES)[number];
 
+/** Whether a runtime value is an inherit-capable subagent service-tier setting. */
+export function isServiceTierInheritSettingValue(value: unknown): value is ServiceTierInheritSettingValue {
+	return typeof value === "string" && (SERVICE_TIER_INHERIT_SETTING_VALUES as readonly string[]).includes(value);
+}
+
+/** Resolve a sparse per-agent override, falling back for missing or invalid entries. */
+export function resolveAgentServiceTierSetting(
+	agentName: string,
+	overrides: Readonly<Record<string, string>>,
+	fallback: ServiceTierInheritSettingValue,
+): ServiceTierInheritSettingValue {
+	const override = overrides[agentName];
+	return isServiceTierInheritSettingValue(override) ? override : fallback;
+}
+
 export const SERVICE_TIER_OPENAI_OPTIONS: ReadonlyArray<SubmenuOption<ServiceTierOpenAISettingValue>> = [
 	{ value: "none", label: "None", description: "Omit service_tier (standard processing)" },
 	{ value: "auto", label: "Auto", description: "Provider default tier selection" },

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4726,6 +4726,10 @@ export const SETTINGS_SCHEMA = {
 		type: "record",
 		default: {} as Record<string, string>,
 	},
+	"task.agentServiceTierOverrides": {
+		type: "record",
+		default: {} as Record<string, string>,
+	},
 	"task.agentPrewalk": {
 		type: "record",
 		default: {} as Record<string, string>,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -145,6 +145,7 @@ const HOST_DEFAULTED_SETTING_PATHS: SettingPath[] = [
 	"task.maxRecursionDepth",
 	"task.disabledAgents",
 	"task.agentModelOverrides",
+	"task.agentServiceTierOverrides",
 	"task.agentPrewalk",
 	// Memory subsystems are off-by-default for RPC/ACP hosts; embedders that want
 	// memory should opt in explicitly through their own settings layer.

--- a/packages/coding-agent/src/session/session-entries.ts
+++ b/packages/coding-agent/src/session/session-entries.ts
@@ -227,6 +227,10 @@ export interface SessionInitEntry extends SessionEntryBase {
 	spawns?: string;
 	/** The agent's `readSummarize` setting (`false` = read summarization disabled); absent uses the session default. */
 	readSummarize?: boolean;
+	/** Explicit per-agent service-tier override; absent means use the subagent fallback on revival. */
+	serviceTierOverride?: string;
+	/** Immediate parent's effective tiers recorded for faithful `inherit` revival. */
+	parentServiceTier?: ServiceTierByFamily;
 }
 
 /** Mode change entry - tracks agent mode transitions (e.g. plan mode). */

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2138,6 +2138,8 @@ export class SessionManager {
 		restrictToolNames?: boolean;
 		spawns?: string;
 		readSummarize?: boolean;
+		serviceTierOverride?: string;
+		parentServiceTier?: ServiceTierByFamily;
 	}): string {
 		const entry: SessionInitEntry = { type: "session_init", ...this.#freshEntryFields(), ...init };
 		this.#recordEntry(entry);
@@ -2630,6 +2632,8 @@ export class SessionManager {
 			restrictToolNames?: boolean;
 			spawns?: string;
 			readSummarize?: boolean;
+			serviceTierOverride?: string;
+			parentServiceTier?: ServiceTierByFamily;
 		} | null;
 	} | null> {
 		let loaded: FileEntry[];
@@ -2653,6 +2657,8 @@ export class SessionManager {
 			restrictToolNames?: boolean;
 			spawns?: string;
 			readSummarize?: boolean;
+			serviceTierOverride?: string;
+			parentServiceTier?: ServiceTierByFamily;
 		} | null = null;
 		for (let index = loaded.length - 1; index >= 0; index--) {
 			const entry = loaded[index];
@@ -2668,6 +2674,8 @@ export class SessionManager {
 					outputSchemaMode: entry.outputSchemaMode,
 					restrictToolNames: entry.restrictToolNames,
 					readSummarize: entry.readSummarize,
+					serviceTierOverride: entry.serviceTierOverride,
+					parentServiceTier: entry.parentServiceTier,
 					spawns: entry.spawns,
 				};
 				break;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -22,7 +22,13 @@ import {
 	resolveModelOverrideWithAuthFallback,
 } from "../config/model-resolver";
 import type { PromptTemplate } from "../config/prompt-templates";
-import { buildServiceTierByFamily, resolveSubagentServiceTier } from "../config/service-tier";
+import {
+	buildServiceTierByFamily,
+	isServiceTierInheritSettingValue,
+	resolveAgentServiceTierSetting,
+	resolveSubagentServiceTier,
+	type ServiceTierInheritSettingValue,
+} from "../config/service-tier";
 import { Settings } from "../config/settings";
 import { SETTINGS_SCHEMA, type SettingPath } from "../config/settings-schema";
 import type { ToolPathWithSource } from "../extensibility/custom-tools";
@@ -855,15 +861,15 @@ export function createSubagentSettings(
 	baseSettings: Settings,
 	overrides?: Partial<Record<SettingPath, unknown>>,
 	inheritedServiceTier?: ServiceTierByFamily | null,
+	serviceTierSetting: ServiceTierInheritSettingValue = baseSettings.get("tier.subagent"),
 ): Settings {
 	const snapshot: Partial<Record<SettingPath, unknown>> = {};
 	for (const key of Object.keys(SETTINGS_SCHEMA) as SettingPath[]) {
 		snapshot[key] = baseSettings.get(key);
 	}
-	// Resolve the subagent's per-family tiers from `tier.subagent` ("inherit" =
-	// match the parent's live tiers when a live session supplied them, else the
-	// subagent's own configured tier.* settings). The result is stamped back onto
-	// the snapshot so createAgentSession's tier.* reads pick it up.
+	// Resolve the selected subagent tier. It normally comes from
+	// `tier.subagent`, while a per-agent setting can be supplied by the task
+	// executor. `"inherit"` matches the parent's live tiers when available.
 	const inheritedTiers =
 		inheritedServiceTier === undefined
 			? buildServiceTierByFamily(
@@ -872,7 +878,7 @@ export function createSubagentSettings(
 					baseSettings.get("tier.google"),
 				)
 			: (inheritedServiceTier ?? {});
-	const subagentTiers = resolveSubagentServiceTier(baseSettings.get("tier.subagent"), inheritedTiers);
+	const subagentTiers = resolveSubagentServiceTier(serviceTierSetting, inheritedTiers);
 	snapshot["tier.openai"] = subagentTiers.openai ?? "none";
 	snapshot["tier.anthropic"] = subagentTiers.anthropic ?? "none";
 	snapshot["tier.google"] = subagentTiers.google ?? "none";
@@ -2647,6 +2653,24 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	}
 
 	const settings = options.settings ?? Settings.isolated();
+	const serviceTierOverrides = settings.get("task.agentServiceTierOverrides");
+	const configuredServiceTierOverride = serviceTierOverrides[agent.name];
+	const serviceTierOverride = isServiceTierInheritSettingValue(configuredServiceTierOverride)
+		? configuredServiceTierOverride
+		: undefined;
+	const serviceTierSetting = resolveAgentServiceTierSetting(
+		agent.name,
+		serviceTierOverrides,
+		settings.get("tier.subagent"),
+	);
+	const parentServiceTier =
+		options.parentServiceTier === undefined
+			? buildServiceTierByFamily(
+					settings.get("tier.openai"),
+					settings.get("tier.anthropic"),
+					settings.get("tier.google"),
+				)
+			: { ...(options.parentServiceTier ?? {}) };
 	const subagentSettings = createSubagentSettings(
 		settings,
 		{
@@ -2654,7 +2678,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			// Isolated runs must not expose roots outside the worktree.
 			...(worktree !== undefined ? { "workspace.additionalDirectories": [] } : undefined),
 		},
-		options.parentServiceTier,
+		parentServiceTier,
+		serviceTierSetting,
 	);
 	const maxRecursionDepth = settings.get("task.maxRecursionDepth") ?? 2;
 	const maxRuntimeMs = Math.max(
@@ -3150,6 +3175,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				readOnly: isReadOnlyAgent(agent),
 				spawns: spawnsEnv,
 				readSummarize: agent.readSummarize,
+				serviceTierOverride,
+				parentServiceTier: serviceTierOverride === "inherit" ? parentServiceTier : undefined,
 				outputSchema,
 				outputSchemaMode: options.outputSchemaMode,
 				restrictToolNames: restrictToolNames || undefined,

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import type { ModelRegistry } from "../config/model-registry";
 import { formatModelRoleAlias } from "../config/model-roles";
+import { isServiceTierInheritSettingValue } from "../config/service-tier";
 import type { Settings } from "../config/settings";
 import { MCPManager } from "../mcp/manager";
 import type { PersistedSubagentReviverFactory } from "../registry/agent-lifecycle";
@@ -79,10 +80,6 @@ export function createPersistedSubagentReviverFactory(
 			taskDepth++;
 			parentId = registry.get(parentId)?.parentId;
 		}
-		const subagentSettings = createSubagentSettings(
-			ctx.settings,
-			init.readSummarize === false ? { "read.summarize.enabled": false } : undefined,
-		);
 		const persistedModelPattern =
 			init.modelRole && init.modelRole !== "default"
 				? [formatModelRoleAlias(init.modelRole), ...(init.resolvedModel ? [init.resolvedModel] : [])]
@@ -100,13 +97,23 @@ export function createPersistedSubagentReviverFactory(
 			const restrictToolNames = init.restrictToolNames === true;
 			const mcpManager = restrictToolNames ? undefined : MCPManager.instance();
 			const mcpProxyTools = mcpManager ? createMCPProxyTools(mcpManager) : [];
+			const serviceTierOverride = isServiceTierInheritSettingValue(init.serviceTierOverride)
+				? init.serviceTierOverride
+				: undefined;
 			const { session } = await createAgentSession({
 				cwd: ctx.session.sessionManager.getCwd(),
 				authStorage: ctx.authStorage,
 				modelRegistry: ctx.modelRegistry,
 				...(persistedModelPattern ? { modelPattern: persistedModelPattern } : {}),
 				modelPatternAuthFallback: init.resolvedModel,
-				settings: subagentSettings,
+				settings: createSubagentSettings(
+					ctx.settings,
+					init.readSummarize === false ? { "read.summarize.enabled": false } : undefined,
+					serviceTierOverride === "inherit"
+						? (init.parentServiceTier ?? ctx.session.serviceTierByFamily)
+						: undefined,
+					serviceTierOverride ?? ctx.settings.get("tier.subagent"),
+				),
 				sessionManager: reopened,
 				agentId: ref.id,
 				agentDisplayName: ref.displayName,

--- a/packages/coding-agent/test/task/executor-pass-through.test.ts
+++ b/packages/coding-agent/test/task/executor-pass-through.test.ts
@@ -5,7 +5,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import type { Model } from "@oh-my-pi/pi-ai";
+import type { Model, ServiceTierByFamily } from "@oh-my-pi/pi-ai";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import type { Rule } from "@oh-my-pi/pi-coding-agent/capability/rule";
@@ -21,7 +21,10 @@ import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 
-function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent) => void }) => void): AgentSession {
+function createMockSession(
+	onPrompt: (params: { emit: (event: AgentSessionEvent) => void }) => void,
+	onSessionInit?: (init: { serviceTierOverride?: string; parentServiceTier?: ServiceTierByFamily }) => void,
+): AgentSession {
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
 	const emit = (event: AgentSessionEvent) => {
 		for (const listener of listeners) listener(event);
@@ -31,7 +34,7 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 		agent: { state: { systemPrompt: ["test"] } },
 		model: undefined,
 		extensionRunner: undefined,
-		sessionManager: { appendSessionInit: () => {} },
+		sessionManager: { appendSessionInit: onSessionInit ?? (() => {}) },
 		getActiveToolNames: () => ["read", "yield"],
 		getEnabledToolNames: () => ["read", "yield"],
 		setActiveToolsByName: async (_toolNames: string[]) => {},
@@ -54,7 +57,9 @@ function createMockSession(onPrompt: (params: { emit: (event: AgentSessionEvent)
 	return session as unknown as AgentSession;
 }
 
-function yieldEmittingSession(): AgentSession {
+function yieldEmittingSession(
+	onSessionInit?: (init: { serviceTierOverride?: string; parentServiceTier?: ServiceTierByFamily }) => void,
+): AgentSession {
 	return createMockSession(({ emit }) => {
 		emit({
 			type: "tool_execution_end",
@@ -66,7 +71,7 @@ function yieldEmittingSession(): AgentSession {
 			},
 			isError: false,
 		});
-	});
+	}, onSessionInit);
 }
 
 function createSessionResult(session: AgentSession): CreateAgentSessionResult {
@@ -134,6 +139,89 @@ describe("runSubprocess parent-discovery pass-through (issue #2190)", () => {
 		expect(forwarded?.rules).toBe(rules);
 		expect(forwarded?.preloadedExtensionPaths).toBe(preloadedExtensionPaths);
 		expect(forwarded?.preloadedCustomToolPaths).toBe(preloadedCustomToolPaths);
+	});
+
+	it("applies a selected agent tier override without changing unlisted agents", async () => {
+		const session = yieldEmittingSession();
+		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		const settings = Settings.isolated({
+			"tier.subagent": "none",
+			"task.agentServiceTierOverrides": { selected: "priority" },
+		});
+
+		const selected = await runSubprocess({
+			...baseOptions,
+			agent: { ...baseAgent, name: "selected" },
+			settings,
+		});
+		const unlisted = await runSubprocess({
+			...baseOptions,
+			id: "unlisted-tier-child",
+			agent: { ...baseAgent, name: "unlisted" },
+			settings,
+		});
+
+		expect(selected.exitCode).toBe(0);
+		expect(unlisted.exitCode).toBe(0);
+		const selectedSettings = spy.mock.calls[0]?.[0]?.settings;
+		expect(selectedSettings?.get("tier.openai")).toBe("priority");
+		expect(selectedSettings?.get("tier.anthropic")).toBe("priority");
+		expect(selectedSettings?.get("tier.google")).toBe("priority");
+		const unlistedSettings = spy.mock.calls[1]?.[0]?.settings;
+		expect(unlistedSettings?.get("tier.openai")).toBe("none");
+		expect(unlistedSettings?.get("tier.anthropic")).toBe("none");
+		expect(unlistedSettings?.get("tier.google")).toBe("none");
+	});
+
+	it("lets an explicit none override disable a priority subagent fallback", async () => {
+		const session = yieldEmittingSession();
+		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		const settings = Settings.isolated({
+			"tier.subagent": "priority",
+			"task.agentServiceTierOverrides": { standard: "none" },
+		});
+
+		const result = await runSubprocess({
+			...baseOptions,
+			agent: { ...baseAgent, name: "standard" },
+			settings,
+		});
+
+		expect(result.exitCode).toBe(0);
+		const childSettings = spy.mock.calls[0]?.[0]?.settings;
+		expect(childSettings?.get("tier.openai")).toBe("none");
+		expect(childSettings?.get("tier.anthropic")).toBe("none");
+		expect(childSettings?.get("tier.google")).toBe("none");
+	});
+
+	it("records immediate parent tiers for an agent explicitly configured to inherit", async () => {
+		let persistedInit: { serviceTierOverride?: string; parentServiceTier?: ServiceTierByFamily } | undefined;
+		const session = yieldEmittingSession(init => {
+			persistedInit = init;
+		});
+		const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+		const settings = Settings.isolated({
+			"tier.subagent": "none",
+			"task.agentServiceTierOverrides": { inheriting: "inherit" },
+		});
+		const parentServiceTier = { openai: "flex" as const, anthropic: "priority" as const };
+
+		const result = await runSubprocess({
+			...baseOptions,
+			agent: { ...baseAgent, name: "inheriting" },
+			settings,
+			parentServiceTier,
+		});
+
+		expect(result.exitCode).toBe(0);
+		const childSettings = spy.mock.calls[0]?.[0]?.settings;
+		expect(childSettings?.get("tier.openai")).toBe("flex");
+		expect(childSettings?.get("tier.anthropic")).toBe("priority");
+		expect(childSettings?.get("tier.google")).toBe("none");
+		expect(persistedInit).toMatchObject({
+			serviceTierOverride: "inherit",
+			parentServiceTier,
+		});
 	});
 
 	it("forwards an exact credential resolver without replacing it", async () => {

--- a/packages/coding-agent/test/task/persisted-revive.test.ts
+++ b/packages/coding-agent/test/task/persisted-revive.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
+import type { ServiceTierByFamily } from "@oh-my-pi/pi-ai";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
@@ -62,7 +63,13 @@ function createRevivedSession(activeToolNames: string[][]): RevivedSessionHandle
 	return { session, observer: () => observer };
 }
 
-async function createPersistedSession(cwd: string, restrictToolNames?: boolean, modelRole?: string): Promise<string> {
+async function createPersistedSession(
+	cwd: string,
+	restrictToolNames?: boolean,
+	modelRole?: string,
+	serviceTierOverride?: string,
+	parentServiceTier?: ServiceTierByFamily,
+): Promise<string> {
 	const manager = SessionManager.create(cwd, path.join(cwd, "sessions"));
 	const sessionFile = manager.getSessionFile();
 	if (!sessionFile) throw new Error("Expected a persisted session file");
@@ -73,6 +80,8 @@ async function createPersistedSession(cwd: string, restrictToolNames?: boolean, 
 		restrictToolNames,
 		modelRole,
 		resolvedModel: modelRole ? "anthropic/claude-sonnet-4-5" : undefined,
+		serviceTierOverride,
+		parentServiceTier,
 	});
 	manager.appendMessage({
 		role: "assistant",
@@ -95,7 +104,11 @@ async function createPersistedSession(cwd: string, restrictToolNames?: boolean, 
 	return sessionFile;
 }
 
-function createFactory(cwd: string, eventBus?: EventBus) {
+function createFactory(
+	cwd: string,
+	options: { settings?: Settings; parentServiceTier?: ServiceTierByFamily } = {},
+	eventBus?: EventBus,
+) {
 	const parentSession = {
 		sessionManager: {
 			getCwd: () => cwd,
@@ -104,12 +117,13 @@ function createFactory(cwd: string, eventBus?: EventBus) {
 		get sessionFile() {
 			return path.join(cwd, "parent.jsonl");
 		},
+		serviceTierByFamily: options.parentServiceTier ?? {},
 	} as unknown as AgentSession;
 	return createPersistedSubagentReviverFactory({
 		session: parentSession,
 		authStorage: {} as never,
 		modelRegistry: { authStorage: {} } as ModelRegistry,
-		settings: Settings.isolated(),
+		settings: options.settings ?? Settings.isolated(),
 		enableLsp: true,
 		eventBus,
 	});
@@ -245,7 +259,7 @@ describe("persisted subagent revival", () => {
 			sessionFile,
 			status: "parked",
 		});
-		const reviver = await createFactory(cwd, eventBus)(ref);
+		const reviver = await createFactory(cwd, {}, eventBus)(ref);
 		if (!reviver) throw new Error("Expected a persisted reviver");
 		await reviver(ref);
 
@@ -276,5 +290,53 @@ describe("persisted subagent revival", () => {
 		rpcRegistry.dispose();
 		AgentLifecycleManager.resetGlobalForTests();
 		AgentRegistry.resetGlobalForTests();
+	});
+
+	it("restores a persisted per-agent priority override instead of the global fallback", async () => {
+		const cwd = makeTempDir("@pi-tier-revive-");
+		const sessionFile = await createPersistedSession(cwd, undefined, undefined, "priority");
+		const settings = Settings.isolated({ "tier.subagent": "none" });
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd, { settings })(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.settings?.get("tier.openai")).toBe("priority");
+		expect(capturedOptions?.settings?.get("tier.anthropic")).toBe("priority");
+		expect(capturedOptions?.settings?.get("tier.google")).toBe("priority");
+	});
+
+	it("restores explicit inherit from the recorded immediate parent tiers", async () => {
+		const cwd = makeTempDir("@pi-tier-inherit-revive-");
+		const immediateParentServiceTier = { openai: "priority" as const, google: "flex" as const };
+		const sessionFile = await createPersistedSession(
+			cwd,
+			undefined,
+			undefined,
+			"inherit",
+			immediateParentServiceTier,
+		);
+		const settings = Settings.isolated({ "tier.subagent": "none" });
+		const topLevelServiceTier = { openai: "flex" as const };
+		let capturedOptions: CreateAgentSessionOptions | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			capturedOptions = options;
+			return { session: createRevivedSession([]).session } as CreateAgentSessionResult;
+		});
+
+		const ref = createRef(sessionFile);
+		const reviver = await createFactory(cwd, { settings, parentServiceTier: topLevelServiceTier })(ref);
+		if (!reviver) throw new Error("Expected a persisted reviver");
+		await reviver(ref);
+
+		expect(capturedOptions?.settings?.get("tier.openai")).toBe("priority");
+		expect(capturedOptions?.settings?.get("tier.anthropic")).toBe("none");
+		expect(capturedOptions?.settings?.get("tier.google")).toBe("flex");
 	});
 });


### PR DESCRIPTION
## What

- Add sparse `task.agentServiceTierOverrides` configuration keyed by agent name.
- Resolve an explicit per-agent tier before `tier.subagent`, while leaving unlisted agents unchanged.
- Preserve explicit overrides across cold revival, including the immediate parent tiers required by `inherit`.
- Keep `/agents` editing and settings persistence out of scope.

This is the configuration and runtime slice proposed in #7185 by @TechDufus, split so the dashboard surface can be considered separately.

## Why

I want to toggle fast mode for specific subagents without enabling it for the entire provider family.

A selected agent can use `priority` while the main session and unlisted sibling agents remain on standard processing.

Related to #7106.

## Testing

- `bun test test/task/executor-pass-through.test.ts test/task/persisted-revive.test.ts` from `packages/coding-agent`
- `bun run check` from `packages/coding-agent`
- Manually exercised `tier.subagent: none` with `task.agentServiceTierOverrides.task: priority`; observed `{"main":"none","task":"priority","scout":"none"}`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)