### PR TITLE
ci: protect released changelog history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,13 @@ jobs:
       steps:
          - uses: actions/checkout@v4
          - uses: ./.github/actions/bun-install
+         - name: Check immutable changelog history
+           if: github.event_name == 'pull_request'
+           env:
+              CHANGELOG_BASE_REF: ${{ github.event.pull_request.base.sha }}
+           run: |
+              git fetch --no-tags --depth=1 origin "$CHANGELOG_BASE_REF"
+              bun scripts/check-changelog-history.ts --base "$CHANGELOG_BASE_REF"
          - name: Type check workspace
            run: bun run ci:check:full
          - name: Build collab web

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,7 @@ Location: `packages/*/CHANGELOG.md` (per package).
 
 - New entries always go under `## [Unreleased]`.
 - Never modify already-released sections (e.g., `## [0.12.2]`) — they are immutable.
+- After editing a changelog, inspect its diff; any changed line below the first released `## [...]` heading is a defect.
 - Don't flag changelog section order or formatting in reviews or PRs — `bun run release` runs `fix-changelogs` which normalizes everything automatically.
 
 **Attribution:**

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "build:native": "bun --cwd=packages/natives run build",
     "test": "bun scripts/ci-test-ts.ts local",
     "test:ts": "bun scripts/ci-test-ts.ts local-ts",
-    "test:scripts": "bun test scripts/ci-release-build-binaries.test.ts scripts/musl-release.test.ts scripts/ci-release-publish.test.ts scripts/release.test.ts",
+    "test:scripts": "bun test scripts/check-changelog-history.test.ts scripts/ci-release-build-binaries.test.ts scripts/musl-release.test.ts scripts/ci-release-publish.test.ts scripts/release.test.ts",
     "test:rs": "bun scripts/run-rs-task.ts test:rs",
     "check": "bun run --parallel check:ts check:rs",
     "check:ts": "bun run check:tools && bun run --workspaces --if-present check",

--- a/packages/coding-agent/test/interactive-mode-title-prewarm.test.ts
+++ b/packages/coding-agent/test/interactive-mode-title-prewarm.test.ts
@@ -87,6 +87,7 @@ describe("InteractiveMode tiny-title prewarm", () => {
 		const prewarm = vi.spyOn(tinyTitleClient, "prewarm").mockImplementation(() => {});
 
 		await mode.init();
+		await new Promise<void>(resolve => setImmediate(resolve));
 
 		expect(prewarm).toHaveBeenCalledWith("lfm2-350m");
 	});
@@ -97,6 +98,7 @@ describe("InteractiveMode tiny-title prewarm", () => {
 		const prewarm = vi.spyOn(tinyTitleClient, "prewarm").mockImplementation(() => {});
 
 		await mode.init();
+		await new Promise<void>(resolve => setImmediate(resolve));
 
 		expect(prewarm).not.toHaveBeenCalled();
 	});

--- a/packages/coding-agent/test/tools/browser-attach.test.ts
+++ b/packages/coding-agent/test/tools/browser-attach.test.ts
@@ -11,11 +11,9 @@ import {
 } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
 import { acquireTab, releaseTab } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 import type { Browser, Page, Target } from "puppeteer-core";
-import { chromiumAvailable } from "./chromium-probe";
+import { chromiumAvailable as probeChromiumAvailable } from "./chromium-probe";
 
-const CHROMIUM_AVAILABLE = await chromiumAvailable();
-
-const chromiumAvailable = await CHROMIUM_AVAILABLE;
+const chromiumAvailable = await probeChromiumAvailable();
 
 interface FakePageOptions {
 	url: string;

--- a/packages/coding-agent/test/tools/browser-attach.test.ts
+++ b/packages/coding-agent/test/tools/browser-attach.test.ts
@@ -15,6 +15,8 @@ import { chromiumAvailable } from "./chromium-probe";
 
 const CHROMIUM_AVAILABLE = await chromiumAvailable();
 
+const chromiumAvailable = await CHROMIUM_AVAILABLE;
+
 interface FakePageOptions {
 	url: string;
 	title: string;
@@ -110,7 +112,7 @@ describe("pickElectronTarget", () => {
 	});
 
 	// Launches real headless Chromium; skipped where Chrome's system libraries are absent.
-	test.skipIf(!CHROMIUM_AVAILABLE)(
+	test.skipIf(!chromiumAvailable)(
 		"navigates a fresh attached tab to the requested URL",
 		async () => {
 			const launched = await acquireBrowser({ kind: "headless", headless: true }, { cwd: process.cwd() });
@@ -143,7 +145,7 @@ describe("pickElectronTarget", () => {
 		30_000,
 	);
 
-	test.skipIf(!CHROMIUM_AVAILABLE)(
+	test.skipIf(!chromiumAvailable)(
 		"does not retry an attached navigation failure as worker startup",
 		async () => {
 			let requestCount = 0;

--- a/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
@@ -8,8 +8,6 @@ import { chromiumAvailable } from "./chromium-probe";
 
 const CHROMIUM_AVAILABLE = await chromiumAvailable();
 
-const chromiumAvailable = await CHROMIUM_AVAILABLE;
-
 function makeSession(): ToolSession {
 	return {
 		cwd: "/tmp/test",
@@ -20,7 +18,7 @@ function makeSession(): ToolSession {
 	};
 }
 
-describe.skipIf(!chromiumAvailable)("browser tab evaluation", () => {
+describe.skipIf(!CHROMIUM_AVAILABLE)("browser tab evaluation", () => {
 	// Launches real headless Chromium; CI cold start easily exceeds bun's 5s default.
 	it("runs tab.evaluate in the page's main JavaScript world", async () => {
 		const tool = new BrowserTool(makeSession());

--- a/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
@@ -8,6 +8,8 @@ import { chromiumAvailable } from "./chromium-probe";
 
 const CHROMIUM_AVAILABLE = await chromiumAvailable();
 
+const chromiumAvailable = await CHROMIUM_AVAILABLE;
+
 function makeSession(): ToolSession {
 	return {
 		cwd: "/tmp/test",
@@ -18,7 +20,7 @@ function makeSession(): ToolSession {
 	};
 }
 
-describe.skipIf(!CHROMIUM_AVAILABLE)("browser tab evaluation", () => {
+describe.skipIf(!chromiumAvailable)("browser tab evaluation", () => {
 	// Launches real headless Chromium; CI cold start easily exceeds bun's 5s default.
 	it("runs tab.evaluate in the page's main JavaScript world", async () => {
 		const tool = new BrowserTool(makeSession());

--- a/scripts/check-changelog-history.test.ts
+++ b/scripts/check-changelog-history.test.ts
@@ -27,7 +27,7 @@ describe("releasedHistoryViolation", () => {
 	});
 
 	it("rejects repeated insertions into released sections", () => {
-		const head = BASE_CHANGELOG.replaceAll("### Added", "### Added\n\\n- Repeated mechanical insertion.");
+		const head = BASE_CHANGELOG.replaceAll("### Added", "### Added\n\n- Repeated mechanical insertion.");
 		expect(releasedHistoryViolation(BASE_CHANGELOG, head)).toContain("changed immutable history");
 	});
 
@@ -44,7 +44,7 @@ describe("decodeChangelog", () => {
 });
 
 describe("checkChangelogHistories", () => {
-	it("checks the working changelog against a git base", async () => {
+	it("checks changed changelogs against a git base", async () => {
 		const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "changelog-history-"));
 		const git = (...args: string[]) =>
 			$`git ${args}`
@@ -80,6 +80,16 @@ describe("checkChangelogHistories", () => {
 				{
 					path: "packages/example/CHANGELOG.md",
 					message: 'changed immutable history beginning at "## [1.0.0] - 2026-01-01"',
+				},
+			]);
+
+			await fs.rm(changelogPath);
+			const deleted = await checkChangelogHistories(repoRoot, "HEAD");
+			expect(deleted.checkedPaths).toEqual(["packages/example/CHANGELOG.md"]);
+			expect(deleted.violations).toEqual([
+				{
+					path: "packages/example/CHANGELOG.md",
+					message: "removed every released section",
 				},
 			]);
 		} finally {

--- a/scripts/check-changelog-history.test.ts
+++ b/scripts/check-changelog-history.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { $ } from "bun";
+import { checkChangelogHistories, decodeChangelog, releasedHistoryViolation } from "./check-changelog-history";
+
+const BASE_CHANGELOG = `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Pending feature.
+
+## [1.0.0] - 2026-01-01
+
+### Added
+
+- Released feature.
+`;
+
+describe("releasedHistoryViolation", () => {
+	it("allows targeted additions under Unreleased", () => {
+		const head = BASE_CHANGELOG.replace("- Pending feature.", "- Pending feature.\n- Another pending feature.");
+		expect(releasedHistoryViolation(BASE_CHANGELOG, head)).toBeUndefined();
+	});
+
+	it("rejects repeated insertions into released sections", () => {
+		const head = BASE_CHANGELOG.replaceAll("### Added", "### Added\n\\n- Repeated mechanical insertion.");
+		expect(releasedHistoryViolation(BASE_CHANGELOG, head)).toContain("changed immutable history");
+	});
+
+	it("rejects truncated released history", () => {
+		const head = BASE_CHANGELOG.slice(0, BASE_CHANGELOG.indexOf("## [1.0.0]"));
+		expect(releasedHistoryViolation(BASE_CHANGELOG, head)).toBe("removed every released section");
+	});
+});
+
+describe("decodeChangelog", () => {
+	it("rejects invalid UTF-8", () => {
+		expect(() => decodeChangelog(Uint8Array.from([0xc3, 0x28]), "fixture")).toThrow("fixture is not valid UTF-8");
+	});
+});
+
+describe("checkChangelogHistories", () => {
+	it("checks the working changelog against a git base", async () => {
+		const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "changelog-history-"));
+		const git = (...args: string[]) =>
+			$`git ${args}`
+				.cwd(repoRoot)
+				.quiet()
+				.env({
+					...process.env,
+					GIT_CONFIG_GLOBAL: "/dev/null",
+					GIT_CONFIG_SYSTEM: "/dev/null",
+					GIT_AUTHOR_NAME: "t",
+					GIT_AUTHOR_EMAIL: "t@t",
+					GIT_COMMITTER_NAME: "t",
+					GIT_COMMITTER_EMAIL: "t@t",
+				});
+		try {
+			const changelogPath = path.join(repoRoot, "packages/example/CHANGELOG.md");
+			await git("init", "-b", "main");
+			await Bun.write(changelogPath, BASE_CHANGELOG);
+			await git("add", "-A");
+			await git("commit", "-m", "base");
+
+			await Bun.write(
+				changelogPath,
+				BASE_CHANGELOG.replace("- Pending feature.", "- Pending feature.\n- Valid addition."),
+			);
+			const valid = await checkChangelogHistories(repoRoot, "HEAD");
+			expect(valid.checkedPaths).toEqual(["packages/example/CHANGELOG.md"]);
+			expect(valid.violations).toEqual([]);
+
+			await Bun.write(changelogPath, BASE_CHANGELOG.replace("- Released feature.", "- Rewritten history."));
+			const invalid = await checkChangelogHistories(repoRoot, "HEAD");
+			expect(invalid.violations).toEqual([
+				{
+					path: "packages/example/CHANGELOG.md",
+					message: 'changed immutable history beginning at "## [1.0.0] - 2026-01-01"',
+				},
+			]);
+		} finally {
+			await fs.rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/scripts/check-changelog-history.ts
+++ b/scripts/check-changelog-history.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env bun
+
+import * as path from "node:path";
+import { $ } from "bun";
+
+const CHANGELOG_PATHSPEC = "packages/*/CHANGELOG.md";
+const FIRST_RELEASE_HEADING = /^## \[(?!Unreleased\])[^\]\r\n]+\][^\r\n]*$/m;
+
+export interface ChangelogHistoryViolation {
+	path: string;
+	message: string;
+}
+
+export interface ChangelogHistoryCheckResult {
+	checkedPaths: string[];
+	violations: ChangelogHistoryViolation[];
+}
+
+export function decodeChangelog(bytes: Uint8Array, label: string): string {
+	try {
+		return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+	} catch {
+		throw new Error(`${label} is not valid UTF-8`);
+	}
+}
+
+export function releasedHistory(content: string): string | undefined {
+	const match = FIRST_RELEASE_HEADING.exec(content);
+	return match?.index === undefined ? undefined : content.slice(match.index);
+}
+
+export function releasedHistoryViolation(baseContent: string, headContent: string): string | undefined {
+	const baseHistory = releasedHistory(baseContent);
+	if (baseHistory === undefined) return undefined;
+
+	const headHistory = releasedHistory(headContent);
+	if (headHistory === undefined) {
+		return "removed every released section";
+	}
+	if (headHistory === baseHistory) return undefined;
+
+	const firstHeading = baseHistory.split(/\r?\n/, 1)[0] ?? "the first released section";
+	return `changed immutable history beginning at ${JSON.stringify(firstHeading)}`;
+}
+
+async function git(args: readonly string[], cwd: string): Promise<Uint8Array> {
+	const result = await $`git -c core.fsmonitor=false -c core.untrackedCache=false ${args}`.cwd(cwd).quiet().nothrow();
+	if (result.exitCode !== 0) {
+		const stderr = result.stderr.toString().trim();
+		throw new Error(`git ${args.join(" ")} failed${stderr ? `: ${stderr}` : ""}`);
+	}
+	return result.bytes();
+}
+
+async function modifiedChangelogPaths(repoRoot: string, baseRef: string): Promise<string[]> {
+	const output = decodeChangelog(
+		await git(["diff", "--name-only", "--diff-filter=M", baseRef, "--", CHANGELOG_PATHSPEC], repoRoot),
+		"git changelog path output",
+	);
+	return output
+		.split("\n")
+		.map(line => line.trim())
+		.filter(line => line.length > 0);
+}
+
+export async function checkChangelogHistories(repoRoot: string, baseRef: string): Promise<ChangelogHistoryCheckResult> {
+	const checkedPaths = await modifiedChangelogPaths(repoRoot, baseRef);
+	const violations: ChangelogHistoryViolation[] = [];
+
+	for (const changelogPath of checkedPaths) {
+		try {
+			const baseContent = decodeChangelog(
+				await git(["show", `${baseRef}:${changelogPath}`], repoRoot),
+				`${changelogPath} at ${baseRef}`,
+			);
+			const headContent = decodeChangelog(
+				new Uint8Array(await Bun.file(path.join(repoRoot, changelogPath)).arrayBuffer()),
+				changelogPath,
+			);
+			const message = releasedHistoryViolation(baseContent, headContent);
+			if (message) violations.push({ path: changelogPath, message });
+		} catch (error) {
+			violations.push({
+				path: changelogPath,
+				message: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	return { checkedPaths, violations };
+}
+
+function parseBaseRef(args: readonly string[]): string {
+	const baseIndex = args.indexOf("--base");
+	const baseRef = baseIndex === -1 ? process.env.CHANGELOG_BASE_REF : args[baseIndex + 1];
+	if (!baseRef) {
+		throw new Error("Usage: bun scripts/check-changelog-history.ts --base <git-ref>");
+	}
+	return baseRef;
+}
+
+async function main(): Promise<void> {
+	try {
+		const repoRoot = path.join(import.meta.dir, "..");
+		const baseRef = parseBaseRef(process.argv.slice(2));
+		const result = await checkChangelogHistories(repoRoot, baseRef);
+		if (result.violations.length > 0) {
+			console.error("Released changelog history is immutable; only [Unreleased] may change:");
+			for (const violation of result.violations) {
+				console.error(`  ${violation.path}: ${violation.message}`);
+			}
+			process.exit(1);
+		}
+		console.log(`Checked ${result.checkedPaths.length} modified changelog(s); released history is unchanged.`);
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	}
+}
+
+if (import.meta.main) {
+	await main();
+}

--- a/scripts/check-changelog-history.ts
+++ b/scripts/check-changelog-history.ts
@@ -52,9 +52,9 @@ async function git(args: readonly string[], cwd: string): Promise<Uint8Array> {
 	return result.bytes();
 }
 
-async function modifiedChangelogPaths(repoRoot: string, baseRef: string): Promise<string[]> {
+async function changedChangelogPaths(repoRoot: string, baseRef: string): Promise<string[]> {
 	const output = decodeChangelog(
-		await git(["diff", "--name-only", "--diff-filter=M", baseRef, "--", CHANGELOG_PATHSPEC], repoRoot),
+		await git(["diff", "--name-only", "--diff-filter=MD", baseRef, "--", CHANGELOG_PATHSPEC], repoRoot),
 		"git changelog path output",
 	);
 	return output
@@ -64,7 +64,7 @@ async function modifiedChangelogPaths(repoRoot: string, baseRef: string): Promis
 }
 
 export async function checkChangelogHistories(repoRoot: string, baseRef: string): Promise<ChangelogHistoryCheckResult> {
-	const checkedPaths = await modifiedChangelogPaths(repoRoot, baseRef);
+	const checkedPaths = await changedChangelogPaths(repoRoot, baseRef);
 	const violations: ChangelogHistoryViolation[] = [];
 
 	for (const changelogPath of checkedPaths) {
@@ -73,10 +73,10 @@ export async function checkChangelogHistories(repoRoot: string, baseRef: string)
 				await git(["show", `${baseRef}:${changelogPath}`], repoRoot),
 				`${changelogPath} at ${baseRef}`,
 			);
-			const headContent = decodeChangelog(
-				new Uint8Array(await Bun.file(path.join(repoRoot, changelogPath)).arrayBuffer()),
-				changelogPath,
-			);
+			const headFile = Bun.file(path.join(repoRoot, changelogPath));
+			const headContent = (await headFile.exists())
+				? decodeChangelog(new Uint8Array(await headFile.arrayBuffer()), changelogPath)
+				: "";
 			const message = releasedHistoryViolation(baseContent, headContent);
 			if (message) violations.push({ path: changelogPath, message });
 		} catch (error) {
@@ -111,7 +111,7 @@ async function main(): Promise<void> {
 			}
 			process.exit(1);
 		}
-		console.log(`Checked ${result.checkedPaths.length} modified changelog(s); released history is unchanged.`);
+		console.log(`Checked ${result.checkedPaths.length} changed changelog(s); released history is unchanged.`);
 	} catch (error) {
 		console.error(error instanceof Error ? error.message : String(error));
 		process.exit(1);

--- a/scripts/ci-test-ts.ts
+++ b/scripts/ci-test-ts.ts
@@ -327,7 +327,14 @@ async function codingAgentTestCommands(bucket: CodingAgentBucket): Promise<TestC
 async function commandsForMode(mode: Mode): Promise<TestCommand[]> {
 	switch (mode) {
 		case "workspace":
-			return fastWorkspacePackages.map(pkg => workspaceTestCommand(pkg, 8));
+			return [
+				...fastWorkspacePackages.map(pkg => workspaceTestCommand(pkg, 8)),
+				{
+					label: "scripts",
+					cwd: ".",
+					command: ["bun", "test", ...onlyFailuresArgs, "scripts/check-changelog-history.test.ts"],
+				},
+			];
 		case "native":
 			return nativeAndIntegrationPackages.map(pkg => workspaceTestCommand(pkg, 4));
 		case "coding-agent-singleton":


### PR DESCRIPTION
## Summary

- add a strict UTF-8 changelog history check that permits changes under `[Unreleased]` while requiring every released section to remain byte-for-byte unchanged
- reject both modifications and whole-file deletion of changelogs containing released history
- run the check against the pull request base SHA in the fast CI check job
- cover targeted additions, repeated mechanical insertions, truncation, deletion, invalid UTF-8, and git-base integration
- make the existing changelog rule operational by requiring authors to inspect the changelog-only diff
- stabilize the shared Chromium availability probe so Bun's grouped test loading does not observe a top-level-await binding before initialization

## Why

The existing changelog fixer normalizes section layout during releases, but it does not prevent a broad mechanical edit from rewriting, truncating, deleting, or corrupting already-released history. Comparing the pull request merge result with its exact base SHA enforces the durable boundary without imposing an arbitrary line-count cap on legitimate `[Unreleased]` notes.

The Chromium probe adjustment is test-only and fixes a pre-existing CI failure exposed on this base: the two affected browser chunks now await the shared probe promise before registering tests.

## Validation

- `bun test scripts/check-changelog-history.test.ts` (5 passed, 9 assertions)
- `bun run ci:check:full`
- `bun run collab:web:build`
- `bun scripts/ci-test-ts.ts workspace --only-failures` (8 chunks passed)
- live probe against PR #6689 correctly rejected its first changed released section (`17.1.3`)
- exact-head GitHub Actions CI run [#14775](https://github.com/can1357/oh-my-pi/actions/runs/30747832722): all substantive jobs passed
