### PR TITLE
fix(browser): guard cmux guest rejections

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed floating rejections from cmux browser guest JavaScript terminating the main process and every active session; attributable rejections now fail the browser run as tool errors while unrelated process rejections retain the fatal path ([#7365](https://github.com/can1357/oh-my-pi/issues/7365)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Added

--- a/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
+++ b/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
@@ -270,36 +270,45 @@ const recentCmuxRunFiles = new Set<string>();
 
 function consumeCmuxRunRejection(reason: unknown): boolean {
 	const stack = reason instanceof Error && typeof reason.stack === "string" ? reason.stack : undefined;
-	if (!stack) return false;
+	if (stack) {
+		let owner: ActiveCmuxRun | undefined;
+		let ownerIndex = -1;
+		for (const run of activeCmuxRuns.values()) {
+			const index = stack.lastIndexOf(run.filename);
+			if (index > ownerIndex) {
+				ownerIndex = index;
+				owner = run;
+			}
+		}
+		if (owner) {
+			owner.floatingRejections.push(reason);
+			return true;
+		}
 
-	let owner: ActiveCmuxRun | undefined;
-	let ownerIndex = -1;
-	for (const run of activeCmuxRuns.values()) {
-		const index = stack.lastIndexOf(run.filename);
-		if (index > ownerIndex) {
-			ownerIndex = index;
-			owner = run;
+		let recent: string | undefined;
+		let recentIndex = -1;
+		for (const filename of recentCmuxRunFiles) {
+			const index = stack.lastIndexOf(filename);
+			if (index > recentIndex) {
+				recentIndex = index;
+				recent = filename;
+			}
+		}
+		if (recent) {
+			logger.warn("Unhandled rejection from a finished cmux browser run (missing await?)", {
+				filename: recent,
+				error: reason,
+			});
+			return true;
 		}
 	}
-	if (owner) {
-		owner.floatingRejections.push(reason);
-		return true;
-	}
 
-	let recent: string | undefined;
-	let recentIndex = -1;
-	for (const filename of recentCmuxRunFiles) {
-		const index = stack.lastIndexOf(filename);
-		if (index > recentIndex) {
-			recentIndex = index;
-			recent = filename;
-		}
-	}
-	if (!recent) return false;
-	logger.warn("Unhandled rejection from a finished cmux browser run (missing await?)", {
-		filename: recent,
-		error: reason,
-	});
+	// Rejection interceptors receive no promise identity. With one live cmux run,
+	// it is the only guest owner available for stackless or library-created reasons.
+	if (activeCmuxRuns.size !== 1) return false;
+	const only = activeCmuxRuns.values().next().value;
+	if (!only) return false;
+	only.floatingRejections.push(reason);
 	return true;
 }
 

--- a/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
+++ b/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
@@ -269,46 +269,42 @@ const activeCmuxRuns = new Map<string, ActiveCmuxRun>();
 const recentCmuxRunFiles = new Set<string>();
 
 function consumeCmuxRunRejection(reason: unknown): boolean {
+	// cmux runs guest JS in the shared main-process realm (TTS/STT/MCP and other
+	// subsystems live here too), so — like the eval inline fallback — only a
+	// guest-file stack frame can safely attribute a rejection. A stackless or
+	// non-run-stack reason is indistinguishable from a subsystem failure and
+	// keeps the default fatal path; worker isolation is the long-term fix.
 	const stack = reason instanceof Error && typeof reason.stack === "string" ? reason.stack : undefined;
-	if (stack) {
-		let owner: ActiveCmuxRun | undefined;
-		let ownerIndex = -1;
-		for (const run of activeCmuxRuns.values()) {
-			const index = stack.lastIndexOf(run.filename);
-			if (index > ownerIndex) {
-				ownerIndex = index;
-				owner = run;
-			}
-		}
-		if (owner) {
-			owner.floatingRejections.push(reason);
-			return true;
-		}
+	if (!stack) return false;
 
-		let recent: string | undefined;
-		let recentIndex = -1;
-		for (const filename of recentCmuxRunFiles) {
-			const index = stack.lastIndexOf(filename);
-			if (index > recentIndex) {
-				recentIndex = index;
-				recent = filename;
-			}
-		}
-		if (recent) {
-			logger.warn("Unhandled rejection from a finished cmux browser run (missing await?)", {
-				filename: recent,
-				error: reason,
-			});
-			return true;
+	let owner: ActiveCmuxRun | undefined;
+	let ownerIndex = -1;
+	for (const run of activeCmuxRuns.values()) {
+		const index = stack.lastIndexOf(run.filename);
+		if (index > ownerIndex) {
+			ownerIndex = index;
+			owner = run;
 		}
 	}
+	if (owner) {
+		owner.floatingRejections.push(reason);
+		return true;
+	}
 
-	// Rejection interceptors receive no promise identity. With one live cmux run,
-	// it is the only guest owner available for stackless or library-created reasons.
-	if (activeCmuxRuns.size !== 1) return false;
-	const only = activeCmuxRuns.values().next().value;
-	if (!only) return false;
-	only.floatingRejections.push(reason);
+	let recent: string | undefined;
+	let recentIndex = -1;
+	for (const filename of recentCmuxRunFiles) {
+		const index = stack.lastIndexOf(filename);
+		if (index > recentIndex) {
+			recentIndex = index;
+			recent = filename;
+		}
+	}
+	if (!recent) return false;
+	logger.warn("Unhandled rejection from a finished cmux browser run (missing await?)", {
+		filename: recent,
+		error: reason,
+	});
 	return true;
 }
 

--- a/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
+++ b/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
@@ -259,6 +259,60 @@ export interface RunCmuxCodeOptions {
 	snapshot: SessionSnapshot;
 }
 
+interface ActiveCmuxRun {
+	filename: string;
+	floatingRejections: unknown[];
+}
+
+const RECENT_CMUX_RUN_FILES_MAX = 256;
+const activeCmuxRuns = new Map<string, ActiveCmuxRun>();
+const recentCmuxRunFiles = new Set<string>();
+
+function consumeCmuxRunRejection(reason: unknown): boolean {
+	const stack = reason instanceof Error && typeof reason.stack === "string" ? reason.stack : undefined;
+	if (!stack) return false;
+
+	let owner: ActiveCmuxRun | undefined;
+	let ownerIndex = -1;
+	for (const run of activeCmuxRuns.values()) {
+		const index = stack.lastIndexOf(run.filename);
+		if (index > ownerIndex) {
+			ownerIndex = index;
+			owner = run;
+		}
+	}
+	if (owner) {
+		owner.floatingRejections.push(reason);
+		return true;
+	}
+
+	let recent: string | undefined;
+	let recentIndex = -1;
+	for (const filename of recentCmuxRunFiles) {
+		const index = stack.lastIndexOf(filename);
+		if (index > recentIndex) {
+			recentIndex = index;
+			recent = filename;
+		}
+	}
+	if (!recent) return false;
+	logger.warn("Unhandled rejection from a finished cmux browser run (missing await?)", {
+		filename: recent,
+		error: reason,
+	});
+	return true;
+}
+
+function rememberCmuxRunFile(filename: string): void {
+	recentCmuxRunFiles.delete(filename);
+	recentCmuxRunFiles.add(filename);
+	if (recentCmuxRunFiles.size <= RECENT_CMUX_RUN_FILES_MAX) return;
+	const oldest = recentCmuxRunFiles.values().next().value;
+	if (oldest !== undefined) recentCmuxRunFiles.delete(oldest);
+}
+
+postmortem.interceptUnhandledRejections(consumeCmuxRunRejection);
+
 export class CmuxTab {
 	readonly #client: CmuxSocketClient;
 	readonly #surfaceId: string;
@@ -1317,6 +1371,9 @@ export async function runCmuxCode(tab: CmuxTab, opts: RunCmuxCodeOptions): Promi
 	const output = new RunOutput();
 	const screenshots: ScreenshotResult[] = [];
 	const runId = crypto.randomUUID();
+	const filename = `cmux-run-${runId}.js`;
+	const activeRun: ActiveCmuxRun = { filename, floatingRejections: [] };
+	activeCmuxRuns.set(filename, activeRun);
 	tab.setRunContext({ session: opts.snapshot, output, screenshots, signal, timeoutMs: opts.timeoutMs });
 
 	const { promise: cancelRejection, reject } = Promise.withResolvers<never>();
@@ -1383,14 +1440,40 @@ export async function runCmuxCode(tab: CmuxTab, opts: RunCmuxCodeOptions): Promi
 		};
 		// Like the inline worker fallback, cmux runs user JS in-process: awaited cmux/tool calls
 		// observe this abort signal, but a synchronous infinite loop cannot be interrupted here.
-		const returnValue = await Promise.race([
-			runtime.run(opts.code, `cmux-run-${runId}.js`, hooks, { runId, cwd: opts.snapshot.cwd }),
-			cancelRejection,
-		]);
+		let returnValue: unknown;
+		let runError: unknown;
+		let runFailed = false;
+		try {
+			returnValue = await Promise.race([
+				runtime.run(opts.code, filename, hooks, { runId, cwd: opts.snapshot.cwd }),
+				cancelRejection,
+			]);
+		} catch (error) {
+			runFailed = true;
+			runError = error;
+		}
+		// Let rejection callbacks run while this run can still own guest-created promises.
+		await Bun.sleep(0);
+		if (runFailed) {
+			for (const reason of activeRun.floatingRejections) {
+				logger.warn("Unhandled rejection accompanied a failed cmux browser run", { filename, error: reason });
+			}
+			throw runError;
+		}
+		if (activeRun.floatingRejections.length > 0) {
+			const messages = activeRun.floatingRejections.map(reason =>
+				reason instanceof Error ? reason.message : String(reason),
+			);
+			throw new ToolError(`Unhandled rejection (missing await?): ${messages.join("\n[unhandled rejection] ")}`, {
+				rejections: activeRun.floatingRejections,
+			});
+		}
 		return { displays: output.finish(), returnValue: cloneSafe(returnValue), screenshots };
 	} finally {
 		signal.removeEventListener("abort", onAbort);
 		runAc.abort(postmortem.markExpectedCleanupError(new ToolAbortError("Browser run ended")));
+		activeCmuxRuns.delete(filename);
+		rememberCmuxRunFile(filename);
 		tab.clearRunContext();
 	}
 }

--- a/packages/coding-agent/test/tools/browser-cmux-guest-rejection.test.ts
+++ b/packages/coding-agent/test/tools/browser-cmux-guest-rejection.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import * as path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "../../../..");
+
+const probe = `
+import { CmuxTab, runCmuxCode } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/cmux-tab";
+import { CmuxSocketClient } from "@oh-my-pi/pi-coding-agent/tools/browser/cmux/socket-client";
+
+const cwd = process.cwd();
+const tab = new CmuxTab({
+	client: new CmuxSocketClient({ socketPath: "/tmp/unused-cmux-rejection-probe.sock" }),
+	surfaceId: "rejection-probe",
+});
+const session = { cwd, hasUI: false, getSessionFile: () => null };
+
+try {
+	await runCmuxCode(tab, {
+		code: \`
+			const { promise, reject } = Promise.withResolvers();
+			reject(new Error("boom"));
+			await Bun.file("package.json").text();
+			await promise.catch(() => undefined);
+		\`,
+		timeoutMs: 10_000,
+		session,
+		snapshot: { cwd },
+	});
+	process.stdout.write("unexpected success\\n");
+	process.exitCode = 2;
+} catch (error) {
+	process.stdout.write(\`caught:\${error instanceof Error ? error.message : String(error)}\\n\`);
+}
+`;
+
+test("cmux guest floating rejection fails the browser run without exiting the host", async () => {
+	const proc = Bun.spawn([process.execPath, "--eval", probe], {
+		cwd: repoRoot,
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [exitCode, stdout, stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+
+	expect(exitCode, stderr).toBe(0);
+	expect(stdout).toBe("caught:Unhandled rejection (missing await?): boom\n");
+	expect(stderr).not.toContain("[Unhandled Rejection]");
+});

--- a/packages/coding-agent/test/tools/browser-cmux-guest-rejection.test.ts
+++ b/packages/coding-agent/test/tools/browser-cmux-guest-rejection.test.ts
@@ -18,7 +18,7 @@ try {
 	await runCmuxCode(tab, {
 		code: \`
 			const { promise, reject } = Promise.withResolvers();
-			reject("boom");
+			reject(new Error("boom"));
 			await Bun.file("package.json").text();
 			await promise.catch(() => undefined);
 		\`,

--- a/packages/coding-agent/test/tools/browser-cmux-guest-rejection.test.ts
+++ b/packages/coding-agent/test/tools/browser-cmux-guest-rejection.test.ts
@@ -18,7 +18,7 @@ try {
 	await runCmuxCode(tab, {
 		code: \`
 			const { promise, reject } = Promise.withResolvers();
-			reject(new Error("boom"));
+			reject("boom");
 			await Bun.file("package.json").text();
 			await promise.catch(() => undefined);
 		\`,


### PR DESCRIPTION
## Repro
A subprocess probe calls `runCmuxCode` with guest JavaScript that rejects a promise, yields across asynchronous file I/O, and attaches its handler afterward. On `main`, `bun test packages/coding-agent/test/tools/browser-cmux-guest-rejection.test.ts` observes `[Unhandled Rejection] Error: boom` from `cmux-run-<uuid>.js` and the child exits 1.

## Cause
`runCmuxCode` in `packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts` executes guest JavaScript through an in-process `JsRuntime` without registering a `postmortem.interceptUnhandledRejections` consumer. Guest-created floating rejections therefore reached the process-global fatal handler instead of the browser run that created them.

## Fix
- Track active cmux run filenames and capture only rejections whose stacks identify those guest files.
- Drain rejection callbacks before completing a run, surfacing captured failures as `ToolError` while leaving unrelated rejections on the fatal path.
- Retain a bounded set of finished run filenames so late guest rejections are logged and isolated.
- Add a subprocess regression proving the host survives and the run reports `boom`; document the fix under `[Unreleased]`.

## Verification
`bun test packages/coding-agent/test/tools/browser-cmux-guest-rejection.test.ts packages/coding-agent/test/tools/browser-cmux-release-mid-run.test.ts packages/coding-agent/test/tools/browser-run-cancellation.test.ts` — 16 passed, 0 failed. `bun check` passed for every package.

Fixes #7365