### PR TITLE
feat(coding-agent): add OpenAI service tier override

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `--service-tier` to override the OpenAI service tier for a session. The flag takes precedence over the configured `tier.openai` setting and over a resumed session's recorded tier, leaves the Anthropic and Google tiers alone, and persists across resumes; `none` omits `service_tier` from the request.
+
 ## [17.2.5] - 2026-08-03
 
 ### Breaking Changes


### PR DESCRIPTION
Upstream main now contains the service-tier implementation from this branch. Retain the remaining changelog entry so users can discover the session-level service tier override, its precedence over the configured OpenAI tier, and its persistence across resumed sessions.