### PR TITLE
fix(hub): wake owners when supervised processes exit

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -74,12 +74,13 @@ import type {
 	AgentTurnEndContext,
 	AsideMessage,
 	BeforeToolCallResult,
+	CommittableAsideMessage,
 	SoftToolRequirement,
 	SteeringInterruptSource,
 	SteeringQueueState,
 	StreamFn,
 } from "./types";
-import { isSoftToolRequirement } from "./types";
+import { ASIDE_MESSAGE_COMMIT, ASIDE_MESSAGE_DISCARD, isSoftToolRequirement } from "./types";
 import { yieldIfDue } from "./utils/yield";
 
 /** Stop-details marker for a provider error after assistant content/tool args already streamed. */
@@ -527,6 +528,9 @@ export function agentLoop(
 			...context,
 			messages: [...context.messages, ...prompts],
 		};
+		for (const prompt of prompts) {
+			(prompt as CommittableAsideMessage)[ASIDE_MESSAGE_COMMIT]?.();
+		}
 
 		stream.push({ type: "agent_start" });
 
@@ -952,11 +956,22 @@ function emitInputMessages(stream: EventStream<AgentEvent, AgentMessage[]>, mess
 function resolveAsides(entries: AsideMessage[] | undefined): AgentMessage[] {
 	if (!entries || entries.length === 0) return [];
 	const out: AgentMessage[] = [];
-	for (const entry of entries) {
-		const message = typeof entry === "function" ? entry() : entry;
-		if (message) out.push(message);
+	try {
+		for (const entry of entries) {
+			const message = typeof entry === "function" ? entry() : entry;
+			if (message) out.push(message);
+		}
+	} catch (error) {
+		discardAsides(out, error instanceof Error ? error : new Error(String(error)));
+		throw error;
 	}
 	return out;
+}
+
+function discardAsides(messages: readonly AgentMessage[], error: Error): void {
+	for (const message of messages) {
+		(message as CommittableAsideMessage)[ASIDE_MESSAGE_DISCARD]?.(error);
+	}
 }
 
 async function runLoopBody(
@@ -989,6 +1004,7 @@ async function runLoopBody(
 	const softRequirementState = config.softToolRequirementState ?? { escalations: 0 };
 	let preserveSoftRequirementState = false;
 
+	let pendingMessages: AgentMessage[] = [];
 	try {
 		let messagesToEmit = [...initialMessages];
 		if (isDeadlineExceeded(config.deadline)) {
@@ -999,7 +1015,6 @@ async function runLoopBody(
 		// Check for steering messages at start (user may have typed while waiting).
 		// Skip when the run is already externally aborted — dequeuing would strand
 		// the messages in a run that is about to die.
-		let pendingMessages: AgentMessage[];
 		try {
 			pendingMessages = signal?.aborted ? [] : (await config.getSteeringMessages?.()) || [];
 		} catch (error) {
@@ -1051,6 +1066,7 @@ async function runLoopBody(
 						currentContext.messages.push(message);
 						newMessages.push(message);
 						turnMessages.push(message);
+						(message as CommittableAsideMessage)[ASIDE_MESSAGE_COMMIT]?.();
 					}
 					pendingMessages = [];
 				}
@@ -1449,6 +1465,7 @@ async function runLoopBody(
 
 		endAgentStream(stream, newMessages, telemetry, stepCounter.count);
 	} finally {
+		discardAsides(pendingMessages, new Error("Aside message was not committed before the agent loop ended"));
 		if (!preserveSoftRequirementState) {
 			softRequirementState.id = undefined;
 			softRequirementState.forcedToolChoice = undefined;

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -31,13 +31,23 @@ export type StreamFn = (
 	...args: Parameters<typeof streamSimple>
 ) => AssistantMessageEventStream | Promise<AssistantMessageEventStream>;
 
+/** Called once an aside has been inserted into the agent's live context. */
+export const ASIDE_MESSAGE_COMMIT = Symbol("aside-message-commit");
+/** Called when an aside was drained but the agent loop ended before inserting it. */
+export const ASIDE_MESSAGE_DISCARD = Symbol("aside-message-discard");
+
+export type CommittableAsideMessage = AgentMessage & {
+	[ASIDE_MESSAGE_COMMIT]?: () => void;
+	[ASIDE_MESSAGE_DISCARD]?: (error: Error) => void;
+};
+
 /**
  * An aside entry: a ready {@link AgentMessage}, or a sync thunk evaluated at
  * injection time that returns the message to inject or `null` to skip it. Thunks
  * let the producer make the final inject-or-drop decision against current state
  * (e.g. dropping late diagnostics a newer edit superseded).
  */
-export type AsideMessage = AgentMessage | (() => AgentMessage | null);
+export type AsideMessage = CommittableAsideMessage | (() => CommittableAsideMessage | null);
 
 export interface AgentTurnEndContext {
 	/** Assistant/user message that just completed this turn boundary. */

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, vi } from "bun:test";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import {
 	agentLoop,
@@ -15,6 +15,7 @@ import type {
 	AgentToolContext,
 	ToolCallContext,
 } from "@oh-my-pi/pi-agent-core/types";
+import { ASIDE_MESSAGE_COMMIT, ASIDE_MESSAGE_DISCARD } from "@oh-my-pi/pi-agent-core/types";
 import type { AssistantMessage, AssistantMessageEvent, Context, Message, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
@@ -2384,6 +2385,8 @@ describe("agentLoop with AgentMessage", () => {
 		});
 
 		const asideMessage = createUserMessage("bg-job-complete");
+		let asideCommitted = false;
+		Object.defineProperty(asideMessage, ASIDE_MESSAGE_COMMIT, { value: () => (asideCommitted = true) });
 		let asideDelivered = false;
 		const config: AgentLoopConfig = {
 			model: mock.model,
@@ -2424,6 +2427,131 @@ describe("agentLoop with AgentMessage", () => {
 			m => m.role === "user" && typeof m.content === "string" && m.content === "bg-job-complete",
 		);
 		expect(sawAsideInContext).toBe(true);
+		expect(asideCommitted).toBe(true);
+	});
+
+	it("commits initial aside messages when they enter the live context", async () => {
+		const message = createUserMessage("idle completion");
+		let committed = false;
+		Object.defineProperty(message, ASIDE_MESSAGE_COMMIT, { value: () => (committed = true) });
+		const mock = createMockModel({ handler: () => ({ content: ["done"] }) });
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [] };
+
+		const stream = agentLoop(
+			[message],
+			context,
+			{ model: mock.model, convertToLlm: identityConverter },
+			undefined,
+			mock.stream,
+		);
+		expect(committed).toBe(true);
+		for await (const _event of stream) {
+			// Drain the loop.
+		}
+	});
+
+	it("discards a drained aside when the deadline expires before insertion", async () => {
+		let now = 100;
+		const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+		try {
+			const toolSchema = type({ value: "string" });
+			let executed = false;
+			const tool: AgentTool<typeof toolSchema, { value: string }> = {
+				name: "echo",
+				label: "Echo",
+				description: "Echo tool",
+				parameters: toolSchema,
+				async execute(_toolCallId, params) {
+					executed = true;
+					return { content: [{ type: "text", text: "done" }], details: { value: params.value } };
+				},
+			};
+			const aside = createUserMessage("completion");
+			let committed = false;
+			let discarded: Error | undefined;
+			Object.defineProperties(aside, {
+				[ASIDE_MESSAGE_COMMIT]: { value: () => (committed = true) },
+				[ASIDE_MESSAGE_DISCARD]: { value: (error: Error) => (discarded = error) },
+			});
+			let delivered = false;
+			const mock = createMockModel({
+				responses: [
+					{ content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } }] },
+					{ content: ["unused"] },
+				],
+			});
+			const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+			const stream = agentLoop(
+				[createUserMessage("start")],
+				context,
+				{
+					model: mock.model,
+					convertToLlm: identityConverter,
+					deadline: 200,
+					getAsideMessages: async () => {
+						if (!delivered && executed) {
+							delivered = true;
+							now = 200;
+							return [aside];
+						}
+						return [];
+					},
+				},
+				undefined,
+				mock.stream,
+			);
+
+			for await (const _event of stream) {
+				// Drain the loop.
+			}
+
+			expect(committed).toBe(false);
+			expect(discarded?.message).toContain("not committed");
+			expect(context.messages).not.toContain(aside);
+		} finally {
+			nowSpy.mockRestore();
+		}
+	});
+
+	it("discards resolved asides when a later thunk fails", async () => {
+		const aside = createUserMessage("completion");
+		let discarded: Error | undefined;
+		Object.defineProperty(aside, ASIDE_MESSAGE_DISCARD, {
+			value: (error: Error) => {
+				discarded = error;
+			},
+		});
+		let delivered = false;
+		const mock = createMockModel({ responses: [{ content: ["done"] }] });
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [] };
+		const stream = agentLoop(
+			[createUserMessage("hi")],
+			context,
+			{
+				model: mock.model,
+				convertToLlm: identityConverter,
+				getAsideMessages: async () => {
+					if (delivered) return [];
+					delivered = true;
+					return [
+						() => aside,
+						() => {
+							throw new Error("later aside failed");
+						},
+					];
+				},
+			},
+			undefined,
+			mock.stream,
+		);
+
+		const drain = async () => {
+			for await (const _event of stream) {
+				// Drain the loop.
+			}
+		};
+		await expect(drain()).rejects.toThrow("later aside failed");
+		expect(discarded?.message).toBe("later aside failed");
 	});
 
 	it("evaluates aside thunks at injection and skips ones that return null", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a supervised process reaching a terminal state without telling the session that launched it. The broker recorded the final snapshot for `hub ps` to read but emitted no event, so an idle owner only learned that a process had exited by polling. The broker now sends one `daemon-completed` notification per terminal exit to the owner socket recorded at launch, and the session turns it into a model-visible message. Restart transitions stay live, and a stale or disposed session drops the notification without changing explicit `hub wait` or persistence behavior.
+
 ## [17.2.5] - 2026-08-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -15,14 +15,17 @@ import {
 	DAEMON_PTY_COLUMNS,
 	DAEMON_PTY_ROWS,
 	DAEMON_RUNTIME_DIR_ENV,
+	type DaemonCompletionNotification,
 	type DaemonOperation,
 	type DaemonReadySpec,
 	type DaemonRpcResult,
 	type DaemonSignal,
 	type DaemonSnapshot,
 	type DaemonSpec,
+	type DaemonWireRequest,
 	parseDaemonSnapshot,
 	parseDaemonSpec,
+	parseDaemonWireMessage,
 	parseDaemonWireRequest,
 } from "./protocol";
 import { resolveDaemonSpawnOptions } from "./spawn-options";
@@ -81,6 +84,9 @@ interface ManagedDaemon {
 	readyPattern?: RegExp;
 	restartTimer?: NodeJS.Timeout;
 	consecutiveFailures: number;
+	completionCapable: boolean;
+	pendingCompletions: DaemonCompletionNotification[];
+	completionSubscriptionId?: string;
 	persistQueue: Promise<void>;
 }
 
@@ -105,6 +111,10 @@ function terminalState(state: DaemonSnapshot["state"]): boolean {
 
 function settledState(state: DaemonSnapshot["state"]): boolean {
 	return terminalState(state) || state === "restarting";
+}
+
+function publishesCompletionOwners(request: DaemonWireRequest): boolean {
+	return request.completionEvents === true && (request.completionAcks?.length ?? 0) === 0;
 }
 
 /**
@@ -352,6 +362,9 @@ class DaemonBroker {
 	 */
 	readonly #startingNames = new Set<string>();
 	readonly #clients = new Set<net.Socket>();
+	readonly #ownerSockets = new Map<string, { socket: net.Socket; subscriptionId: string | undefined }>();
+	readonly #completionSubscriptions = new Map<string, string | undefined>();
+	readonly #pendingCompletions = new Map<string, Map<string, DaemonCompletionNotification>>();
 	readonly #finished = Promise.withResolvers<void>();
 	readonly #sockets = new Set<net.Socket>();
 	#server: net.Server | undefined;
@@ -393,6 +406,7 @@ class DaemonBroker {
 			await record.log?.close();
 			await record.persistQueue;
 		}
+		this.#ownerSockets.clear();
 		for (const socket of this.#sockets) socket.destroy();
 		this.#sockets.clear();
 		this.#clients.clear();
@@ -439,6 +453,9 @@ class DaemonBroker {
 			if (!authenticated) return;
 			this.#clients.delete(socket);
 			this.#scheduleIdleShutdown();
+			for (const [owner, registration] of this.#ownerSockets) {
+				if (registration.socket === socket) this.#ownerSockets.delete(owner);
+			}
 		});
 	}
 
@@ -450,6 +467,78 @@ class DaemonBroker {
 			id = request.id;
 			if (request.token !== this.#token) throw new Error("Daemon broker authentication failed");
 			onAuthenticated();
+			for (const owner of request.completionUnsubscribes ?? []) {
+				const subscriptionId = this.#completionSubscriptions.get(owner);
+				if (
+					!this.#completionSubscriptions.has(owner) ||
+					(subscriptionId !== undefined && subscriptionId !== request.completionSubscriptionId)
+				) {
+					continue;
+				}
+				this.#ownerSockets.delete(owner);
+				this.#completionSubscriptions.delete(owner);
+				await this.#setRecordCompletionCapability(owner, false);
+				this.#pendingCompletions.delete(owner);
+			}
+			for (const completionId of request.completionAcks ?? []) {
+				for (const [owner, pending] of this.#pendingCompletions) {
+					const registration = this.#ownerSockets.get(owner);
+					if (
+						!registration ||
+						registration.socket !== socket ||
+						registration.subscriptionId !== request.completionSubscriptionId
+					) {
+						continue;
+					}
+					const completion = pending.get(completionId);
+					if (!completion) continue;
+					pending.delete(completionId);
+					if (pending.size === 0) this.#pendingCompletions.delete(owner);
+					const record = this.#records.get(completion.daemon.name);
+					const index = record?.pendingCompletions.findIndex(item => item.completionId === completionId) ?? -1;
+					if (record && index >= 0) {
+						record.pendingCompletions.splice(index, 1);
+						this.#persist(record);
+						await record.persistQueue;
+					}
+				}
+			}
+			if (publishesCompletionOwners(request)) {
+				const replayOwners = new Set(request.completionReplays ?? []);
+				const activeOwners = new Set(request.owners ?? []);
+				const detachedOwners = new Set(request.detachedOwners ?? []);
+				const advertisedOwners = new Set([...activeOwners, ...detachedOwners]);
+				for (const [owner, subscriptionId] of this.#completionSubscriptions) {
+					if (subscriptionId !== request.completionSubscriptionId || advertisedOwners.has(owner)) continue;
+					this.#ownerSockets.delete(owner);
+					this.#completionSubscriptions.delete(owner);
+					await this.#setRecordCompletionCapability(owner, false);
+					this.#pendingCompletions.delete(owner);
+				}
+				for (const owner of activeOwners) {
+					this.#completionSubscriptions.set(owner, request.completionSubscriptionId);
+					await this.#setRecordCompletionCapability(owner, true);
+					const previous = this.#ownerSockets.get(owner);
+					this.#ownerSockets.set(owner, {
+						socket,
+						subscriptionId: request.completionSubscriptionId,
+					});
+					if (previous?.socket === socket && !replayOwners.has(owner)) continue;
+					for (const completion of this.#pendingCompletions.get(owner)?.values() ?? []) {
+						socket.write(`${JSON.stringify(completion)}\n`);
+					}
+				}
+				for (const owner of detachedOwners) {
+					const subscriptionId = this.#completionSubscriptions.get(owner);
+					if (this.#completionSubscriptions.has(owner) && subscriptionId !== request.completionSubscriptionId) {
+						continue;
+					}
+					this.#completionSubscriptions.set(owner, request.completionSubscriptionId);
+					await this.#setRecordCompletionCapability(owner, true);
+					const registration = this.#ownerSockets.get(owner);
+					if (registration?.subscriptionId === request.completionSubscriptionId) this.#ownerSockets.delete(owner);
+				}
+			}
 			const result = await this.#dispatch(request.operation);
 			socket.write(`${JSON.stringify({ id, ok: true, result })}\n`);
 			if (request.operation.op === "shutdown") setTimeout(() => void this.shutdown(), 10);
@@ -520,6 +609,9 @@ class DaemonBroker {
 			if (existing && !terminalState(existing.snapshot.state)) {
 				throw new Error(`Daemon ${spec.name} is already ${existing.snapshot.state}`);
 			}
+			if (existing && existing.pendingCompletions.length > 0) {
+				throw new Error(`Daemon ${spec.name} has unacknowledged completion notifications`);
+			}
 			if (spec.ready?.log) {
 				try {
 					new RegExp(spec.ready.log, "u");
@@ -556,6 +648,9 @@ class DaemonBroker {
 				readyPattern: spec.ready?.log ? new RegExp(spec.ready.log, "u") : undefined,
 				consecutiveFailures: 0,
 				persistQueue: Promise.resolve(),
+				completionCapable: owner !== undefined && this.#completionSubscriptions.has(owner),
+				completionSubscriptionId: owner === undefined ? undefined : this.#completionSubscriptions.get(owner),
+				pendingCompletions: [],
 			};
 			syncReadyPending(record);
 			this.#records.set(spec.name, record);
@@ -785,6 +880,14 @@ class DaemonBroker {
 		await this.#settle(record, generation);
 	}
 
+	async #monitorRecoveredDetached(record: ManagedDaemon, generation: number): Promise<void> {
+		while (!this.#shuttingDown && generation === record.generation && !settledState(record.snapshot.state)) {
+			await Bun.sleep(100);
+			if (this.#shuttingDown || generation !== record.generation) return;
+			await this.#refreshDetached(record);
+		}
+	}
+
 	async #pollPort(record: ManagedDaemon, generation: number, ready: DaemonReadySpec): Promise<void> {
 		const host = ready.host ?? "127.0.0.1";
 		const port = ready.port;
@@ -810,6 +913,15 @@ class DaemonBroker {
 
 	async #onPtyExit(record: ManagedDaemon, generation: number, result: PtyRunResult): Promise<void> {
 		return this.#settle(record, generation, result.exitCode, result.timedOut ? "timed out" : undefined);
+	}
+
+	#notifyCompletion(completion: DaemonCompletionNotification): void {
+		const pending = this.#pendingCompletions.get(completion.owner) ?? new Map<string, DaemonCompletionNotification>();
+		pending.set(completion.completionId, completion);
+		this.#pendingCompletions.set(completion.owner, pending);
+		const registration = this.#ownerSockets.get(completion.owner);
+		if (!registration || registration.socket.destroyed) return;
+		registration.socket.write(`${JSON.stringify(completion)}\n`);
 	}
 
 	async #settle(record: ManagedDaemon, generation: number, exitCode?: number, error?: string): Promise<void> {
@@ -855,9 +967,29 @@ class DaemonBroker {
 			return;
 		}
 		record.snapshot.state = failed && !record.stopRequested ? "failed" : "exited";
+		const completion =
+			record.snapshot.owner !== undefined &&
+			!record.stopRequested &&
+			this.#completionSubscriptions.has(record.snapshot.owner)
+				? ({
+						event: "daemon-completed",
+						completionId: crypto.randomUUID(),
+						owner: record.snapshot.owner,
+						daemon: { ...record.snapshot },
+					} satisfies DaemonCompletionNotification)
+				: undefined;
+		if (completion) record.pendingCompletions.push(completion);
 		this.#persist(record);
 		await record.log?.close();
 		record.log = undefined;
+		await record.persistQueue;
+		if (
+			completion &&
+			this.#completionSubscriptions.has(completion.owner) &&
+			record.pendingCompletions.some(pending => pending.completionId === completion.completionId)
+		) {
+			this.#notifyCompletion(completion);
+		}
 	}
 
 	async #logs(operation: Extract<DaemonOperation, { op: "logs" }>): Promise<DaemonRpcResult> {
@@ -1027,9 +1159,21 @@ class DaemonBroker {
 	#persist(record: ManagedDaemon): void {
 		const metaPath = path.join(record.dir, META_FILE);
 		const tempPath = `${metaPath}.${process.pid}.tmp`;
+		const metadata = {
+			daemon: { ...record.snapshot },
+			spec: record.spec,
+			completionEvents: record.completionCapable,
+			completionSubscriptionId: record.completionSubscriptionId,
+			completionPending: record.pendingCompletions.length > 0,
+			pendingCompletion: record.pendingCompletions.at(-1)?.daemon,
+			pendingCompletions: record.pendingCompletions.map(completion => ({
+				...completion,
+				daemon: { ...completion.daemon },
+			})),
+		};
 		record.persistQueue = record.persistQueue
 			.then(async () => {
-				await Bun.write(tempPath, JSON.stringify({ daemon: record.snapshot, spec: record.spec }));
+				await Bun.write(tempPath, JSON.stringify(metadata));
 				await fs.rename(tempPath, metaPath);
 			})
 			.catch(error => {
@@ -1038,6 +1182,28 @@ class DaemonBroker {
 					error: error instanceof Error ? error.message : String(error),
 				});
 			});
+	}
+
+	async #setRecordCompletionCapability(owner: string, capable: boolean): Promise<void> {
+		const subscriptionId = capable ? this.#completionSubscriptions.get(owner) : undefined;
+		const persistence: Promise<void>[] = [];
+		for (const record of this.#records.values()) {
+			const clearPendingCompletions = !capable && record.pendingCompletions.length > 0;
+			if (
+				record.snapshot.owner !== owner ||
+				(record.completionCapable === capable &&
+					record.completionSubscriptionId === subscriptionId &&
+					!clearPendingCompletions)
+			) {
+				continue;
+			}
+			record.completionCapable = capable;
+			record.completionSubscriptionId = subscriptionId;
+			if (!capable) record.pendingCompletions = [];
+			this.#persist(record);
+			persistence.push(record.persistQueue);
+		}
+		await Promise.all(persistence);
 	}
 
 	async #recoverRecords(): Promise<void> {
@@ -1057,11 +1223,9 @@ class DaemonBroker {
 				const snapshot = parseDaemonSnapshot(decoded.daemon);
 				const spec = parseDaemonSpec(decoded.spec);
 				const processRef = snapshot.pid === undefined ? null : Process.fromPid(snapshot.pid);
-				const detached =
-					spec.detached &&
-					!terminalState(snapshot.state) &&
-					snapshot.state !== "stopping" &&
-					processRef?.status() === "running";
+				const recoverableExit = !terminalState(snapshot.state) && snapshot.state !== "stopping";
+				const detached = spec.detached && recoverableExit && processRef?.status() === "running";
+				const recoveredDead = recoverableExit && !detached;
 				if (!detached) {
 					// Reap only records that were still alive when the previous broker
 					// exited; already-terminal records keep their real exit time so
@@ -1088,11 +1252,63 @@ class DaemonBroker {
 					readyPattern: spec.ready?.log ? new RegExp(spec.ready.log, "u") : undefined,
 					consecutiveFailures: 0,
 					persistQueue: Promise.resolve(),
+					completionCapable: "completionEvents" in decoded && decoded.completionEvents === true,
+					completionSubscriptionId:
+						"completionSubscriptionId" in decoded && typeof decoded.completionSubscriptionId === "string"
+							? decoded.completionSubscriptionId
+							: undefined,
+					pendingCompletions: (() => {
+						if ("pendingCompletions" in decoded && Array.isArray(decoded.pendingCompletions)) {
+							return decoded.pendingCompletions.map(value => {
+								const message = parseDaemonWireMessage(value);
+								if (!("event" in message)) throw new Error("Pending daemon completion is not an event");
+								return message;
+							});
+						}
+						const pendingSnapshot =
+							"pendingCompletion" in decoded
+								? parseDaemonSnapshot(decoded.pendingCompletion)
+								: "completionPending" in decoded && decoded.completionPending === true
+									? { ...snapshot }
+									: undefined;
+						return pendingSnapshot
+							? [
+									{
+										event: "daemon-completed",
+										completionId: crypto.randomUUID(),
+										owner: pendingSnapshot.owner ?? snapshot.owner ?? "",
+										daemon: pendingSnapshot,
+									},
+								]
+							: [];
+					})(),
 				};
+				if (recoveredDead && record.completionCapable && snapshot.owner && record.pendingCompletions.length === 0) {
+					record.pendingCompletions.push({
+						event: "daemon-completed",
+						completionId: crypto.randomUUID(),
+						owner: snapshot.owner,
+						daemon: { ...snapshot },
+					});
+				}
 				syncReadyPending(record);
 				this.#records.set(snapshot.name, record);
+				if (snapshot.owner && record.completionCapable && (detached || record.pendingCompletions.length > 0)) {
+					this.#completionSubscriptions.set(snapshot.owner, record.completionSubscriptionId);
+				}
+				if (record.completionCapable) {
+					for (const completion of record.pendingCompletions) this.#notifyCompletion(completion);
+				}
 				if (detached && spec.ready?.port !== undefined && snapshot.state !== "ready") {
 					void this.#pollPort(record, record.generation, spec.ready);
+				}
+				if (detached) {
+					void this.#monitorRecoveredDetached(record, record.generation).catch(error => {
+						logger.warn("Failed to monitor recovered detached daemon", {
+							name: record.snapshot.name,
+							error: error instanceof Error ? error.message : String(error),
+						});
+					});
 				}
 				this.#persist(record);
 			} catch (error) {

--- a/packages/coding-agent/src/launch/client.ts
+++ b/packages/coding-agent/src/launch/client.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getGlobalDaemonRuntimeDir, isEexist, isEisdir, isEnoent, postmortem } from "@oh-my-pi/pi-utils";
+import { getGlobalDaemonRuntimeDir, isEexist, isEisdir, isEnoent, logger, postmortem } from "@oh-my-pi/pi-utils";
 import { hostHasInheritableConsole } from "../eval/py/spawn-options";
 import { resolveWorkerSpawnCmd, workerEnvFromParent } from "../subprocess/worker-client";
 import { daemonBrokerEndpoint, daemonRuntimeDir } from "./paths";
@@ -11,11 +11,12 @@ import {
 	DAEMON_IDLE_GRACE_ENV,
 	DAEMON_PROJECT_DIR_ENV,
 	DAEMON_RUNTIME_DIR_ENV,
+	type DaemonCompletionNotification,
 	type DaemonOperation,
 	type DaemonRpcResult,
-	type DaemonWireResponse,
+	type DaemonWireMessage,
 	parseDaemonRpcResult,
-	parseDaemonWireResponse,
+	parseDaemonWireMessage,
 } from "./protocol";
 import { resolveDaemonSpawnOptions } from "./spawn-options";
 
@@ -43,13 +44,25 @@ export interface DaemonBrokerClientOptions {
 	idleGraceMs?: number;
 }
 
+export interface DaemonCompletionUnregisterOptions {
+	/** Detach this process without deleting broker-persisted pending notifications. */
+	preservePending?: boolean;
+}
+
 /** Persistent per-process connection to one project or global daemon broker. */
 export interface DaemonBrokerClient {
+	onCompletion(
+		owner: string,
+		sink: (notification: DaemonCompletionNotification) => Promise<void> | void,
+	): (options?: DaemonCompletionUnregisterOptions) => void;
 	/** Canonical project directory or synthetic directory identifying a global scope. */
 	readonly projectDir: string;
 	request(operation: DaemonOperation, signal?: AbortSignal): Promise<DaemonRpcResult>;
 	close(): void;
 }
+
+/** A request reached the broker and the broker rejected the operation. */
+export class DaemonBrokerRejectedError extends Error {}
 
 async function canonicalProjectDir(projectDir: string): Promise<string> {
 	const resolved = path.resolve(projectDir);
@@ -134,12 +147,20 @@ class SocketDaemonClient implements DaemonBrokerClient {
 	readonly #runtimeDir: string;
 	readonly #endpoint: string;
 	readonly #token: string;
+	readonly #seenCompletionIds = new Set<string>();
 	readonly #idleGraceMs: number | undefined;
 	readonly #pending = new Map<string, PendingRequest>();
+	readonly #completionSinks = new Map<string, (notification: DaemonCompletionNotification) => Promise<void> | void>();
+	readonly #completionUnsubscribes = new Set<string>();
+	readonly #preservedCompletionOwners = new Set<string>();
+	readonly #completionReplays = new Set<string>();
+	readonly #inFlightCompletionIds = new Set<string>();
+	readonly #completionSubscriptionId = crypto.randomUUID();
 	#socket: net.Socket | undefined;
 	#connectPromise: Promise<void> | undefined;
 	#buffer = "";
 	#closed = false;
+	#completionReconnectTimer: NodeJS.Timeout | undefined;
 
 	constructor(projectDir: string, runtimeDir: string, token: string, options: DaemonBrokerClientOptions) {
 		this.projectDir = projectDir;
@@ -156,6 +177,8 @@ class SocketDaemonClient implements DaemonBrokerClient {
 		const socket = this.#socket;
 		if (!socket || socket.destroyed) throw new Error("Daemon broker socket is unavailable");
 
+		const completionUnsubscribes = [...this.#completionUnsubscribes];
+		const completionReplays = [...this.#completionReplays];
 		const id = crypto.randomUUID();
 		const { promise, resolve, reject } = Promise.withResolvers<DaemonRpcResult>();
 		const timer = setTimeout(() => {
@@ -176,16 +199,86 @@ class SocketDaemonClient implements DaemonBrokerClient {
 			pending.removeAbort = () => signal.removeEventListener("abort", abort);
 		}
 		this.#pending.set(id, pending);
-		socket.write(`${JSON.stringify({ id, token: this.#token, operation })}\n`);
-		return promise;
+		socket.write(
+			`${JSON.stringify({
+				id,
+				token: this.#token,
+				owners: [...this.#completionSinks.keys()],
+				detachedOwners: [...this.#preservedCompletionOwners],
+				completionEvents: true,
+				completionUnsubscribes,
+				completionReplays,
+				completionSubscriptionId: this.#completionSubscriptionId,
+				operation,
+			})}\n`,
+		);
+		const result = await promise;
+		for (const owner of completionUnsubscribes) {
+			if (!this.#completionSinks.has(owner)) this.#completionUnsubscribes.delete(owner);
+		}
+		for (const owner of completionReplays) {
+			if (this.#completionSinks.has(owner)) this.#completionReplays.delete(owner);
+		}
+		return result;
 	}
 
 	close(): void {
 		if (this.#closed) return;
 		this.#closed = true;
+		clearTimeout(this.#completionReconnectTimer);
+		this.#completionReconnectTimer = undefined;
 		this.#socket?.destroy();
+		this.#completionSinks.clear();
+		this.#preservedCompletionOwners.clear();
+		this.#completionReplays.clear();
 		this.#socket = undefined;
 		this.#rejectPending(new Error("Daemon broker client closed"));
+	}
+
+	onCompletion(
+		owner: string,
+		sink: (notification: DaemonCompletionNotification) => Promise<void> | void,
+	): (options?: DaemonCompletionUnregisterOptions) => void {
+		this.#completionUnsubscribes.delete(owner);
+		if (this.#preservedCompletionOwners.delete(owner)) this.#completionReplays.add(owner);
+		this.#completionSinks.set(owner, sink);
+		this.#publishCompletionOwners();
+		return options => {
+			if (this.#completionSinks.get(owner) !== sink) return;
+			this.#completionSinks.delete(owner);
+			if (options?.preservePending) {
+				this.#preservedCompletionOwners.add(owner);
+			} else {
+				this.#preservedCompletionOwners.delete(owner);
+				this.#completionUnsubscribes.add(owner);
+			}
+			if (this.#completionSinks.size === 0 && this.#completionReconnectTimer) {
+				clearTimeout(this.#completionReconnectTimer);
+				this.#completionReconnectTimer = undefined;
+			}
+			this.#publishCompletionOwners();
+		};
+	}
+
+	#publishCompletionOwners(): void {
+		if (this.#closed) return;
+		void this.request({ op: "ping" }).catch(() => this.#scheduleCompletionReconnect());
+	}
+
+	#scheduleCompletionReconnect(): void {
+		if (
+			this.#closed ||
+			this.#completionSinks.size === 0 ||
+			this.#completionReconnectTimer !== undefined ||
+			(this.#socket !== undefined && !this.#socket.destroyed)
+		) {
+			return;
+		}
+		this.#completionReconnectTimer = setTimeout(() => {
+			this.#completionReconnectTimer = undefined;
+			this.#publishCompletionOwners();
+		}, CONNECT_RETRY_MS);
+		this.#completionReconnectTimer.unref();
 	}
 
 	async #connect(): Promise<void> {
@@ -251,6 +344,7 @@ class SocketDaemonClient implements DaemonBrokerClient {
 		socket.on("close", () => {
 			if (this.#socket === socket) this.#socket = undefined;
 			this.#rejectPending(new Error("Daemon broker connection closed"));
+			this.#scheduleCompletionReconnect();
 		});
 	}
 
@@ -262,21 +356,32 @@ class SocketDaemonClient implements DaemonBrokerClient {
 			const line = this.#buffer.slice(0, newline);
 			this.#buffer = this.#buffer.slice(newline + 1);
 			if (line.length === 0) continue;
-			let response: DaemonWireResponse;
+			let decoded: unknown;
 			try {
-				const decoded: unknown = JSON.parse(line);
-				response = parseDaemonWireResponse(decoded);
+				decoded = JSON.parse(line);
 			} catch (error) {
 				this.#rejectPending(error instanceof Error ? error : new Error(String(error)));
 				continue;
 			}
+			let message: DaemonWireMessage;
+			try {
+				message = parseDaemonWireMessage(decoded);
+			} catch (error) {
+				this.#rejectPending(error instanceof Error ? error : new Error(String(error)));
+				continue;
+			}
+			if ("event" in message) {
+				void this.#deliverCompletion(message);
+				continue;
+			}
+			const response = message;
 			const pending = this.#pending.get(response.id);
 			if (!pending) continue;
 			this.#pending.delete(response.id);
 			clearTimeout(pending.timer);
 			pending.removeAbort?.();
 			if (!response.ok) {
-				pending.reject(new Error(response.error));
+				pending.reject(new DaemonBrokerRejectedError(response.error));
 				continue;
 			}
 			try {
@@ -285,6 +390,53 @@ class SocketDaemonClient implements DaemonBrokerClient {
 				pending.reject(error instanceof Error ? error : new Error(String(error)));
 			}
 		}
+	}
+
+	async #deliverCompletion(message: DaemonCompletionNotification): Promise<void> {
+		if (this.#seenCompletionIds.has(message.completionId)) {
+			this.#ackCompletion(message.completionId);
+			return;
+		}
+		if (this.#inFlightCompletionIds.has(message.completionId)) return;
+		const sink = this.#completionSinks.get(message.owner);
+		if (!sink) return;
+		this.#inFlightCompletionIds.add(message.completionId);
+		try {
+			await sink(message);
+			if (this.#seenCompletionIds.size >= 512) {
+				const oldest = this.#seenCompletionIds.values().next().value;
+				if (oldest !== undefined) this.#seenCompletionIds.delete(oldest);
+			}
+			this.#seenCompletionIds.add(message.completionId);
+			this.#ackCompletion(message.completionId);
+		} catch (error) {
+			logger.warn("Daemon completion sink failed", {
+				owner: message.owner,
+				completionId: message.completionId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			this.#socket?.destroy();
+		} finally {
+			this.#inFlightCompletionIds.delete(message.completionId);
+		}
+	}
+
+	#ackCompletion(completionId: string): void {
+		const socket = this.#socket;
+		if (!socket || socket.destroyed) return;
+		socket.write(
+			`${JSON.stringify({
+				id: crypto.randomUUID(),
+				token: this.#token,
+				owners: [...this.#completionSinks.keys()],
+				detachedOwners: [...this.#preservedCompletionOwners],
+				completionEvents: true,
+				completionAcks: [completionId],
+				completionUnsubscribes: [...this.#completionUnsubscribes],
+				completionSubscriptionId: this.#completionSubscriptionId,
+				operation: { op: "ping" },
+			})}\n`,
+		);
 	}
 
 	#rejectPending(error: Error): void {

--- a/packages/coding-agent/src/launch/protocol.ts
+++ b/packages/coding-agent/src/launch/protocol.ts
@@ -122,11 +122,28 @@ export type DaemonRpcResult =
 export interface DaemonWireRequest {
 	id: string;
 	token: string;
+	owners?: string[];
+	detachedOwners?: string[];
+	completionEvents?: boolean;
+	completionAcks?: string[];
+	completionUnsubscribes?: string[];
+	completionReplays?: string[];
+	completionSubscriptionId?: string;
 	operation: DaemonOperation;
 }
 
 /** Response envelope kept raw until matched with its pending operation. */
 export type DaemonWireResponse = { id: string; ok: true; result: unknown } | { id: string; ok: false; error: string };
+
+/** Unsolicited terminal completion sent to the socket that owns a daemon. */
+export interface DaemonCompletionNotification {
+	event: "daemon-completed";
+	completionId: string;
+	owner: string;
+	daemon: DaemonSnapshot;
+}
+
+export type DaemonWireMessage = DaemonWireResponse | DaemonCompletionNotification;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -268,6 +285,27 @@ export function parseDaemonWireRequest(value: unknown): DaemonWireRequest {
 	return {
 		id: stringValue(source.id, "request.id"),
 		token: stringValue(source.token, "request.token"),
+		owners: source.owners === undefined ? undefined : stringArray(source.owners, "request.owners"),
+		detachedOwners:
+			source.detachedOwners === undefined ? undefined : stringArray(source.detachedOwners, "request.detachedOwners"),
+		completionEvents:
+			source.completionEvents === undefined
+				? undefined
+				: booleanValue(source.completionEvents, "request.completionEvents"),
+		completionAcks:
+			source.completionAcks === undefined ? undefined : stringArray(source.completionAcks, "request.completionAcks"),
+		completionUnsubscribes:
+			source.completionUnsubscribes === undefined
+				? undefined
+				: stringArray(source.completionUnsubscribes, "request.completionUnsubscribes"),
+		completionReplays:
+			source.completionReplays === undefined
+				? undefined
+				: stringArray(source.completionReplays, "request.completionReplays"),
+		completionSubscriptionId:
+			source.completionSubscriptionId === undefined
+				? undefined
+				: stringValue(source.completionSubscriptionId, "request.completionSubscriptionId"),
 		operation: parseDaemonOperation(source.operation),
 	};
 }
@@ -279,6 +317,20 @@ export function parseDaemonWireResponse(value: unknown): DaemonWireResponse {
 	if (source.ok === true) return { id, ok: true, result: source.result };
 	if (source.ok === false) return { id, ok: false, error: stringValue(source.error, "response.error") };
 	throw new Error("response.ok must be a boolean");
+}
+
+/** Decode one broker response or unsolicited completion notification. */
+export function parseDaemonWireMessage(value: unknown): DaemonWireMessage {
+	const source = record(value, "daemon message");
+	if (source.event === "daemon-completed") {
+		return {
+			event: "daemon-completed",
+			completionId: stringValue(source.completionId, "completion.id"),
+			owner: stringValue(source.owner, "completion.owner"),
+			daemon: parseDaemonSnapshot(source.daemon),
+		};
+	}
+	return parseDaemonWireResponse(value);
 }
 
 function parseDaemonOperation(value: unknown): DaemonOperation {

--- a/packages/coding-agent/src/prompts/session/launch-completion.md
+++ b/packages/coding-agent/src/prompts/session/launch-completion.md
@@ -1,0 +1,1 @@
+Supervised process {{name}} {{state}} {{#if hasExitCode}}with exit code {{exitCode}}{{else}}without an exit code{{/if}}.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1686,6 +1686,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// entries capture it at fetch time and are dropped at injection if a newer
 		// mutation (any tool) bumped it in the meantime.
 		const fileMutationVersions = new Map<string, number>();
+		const disposeCallbacks = new Set<() => void>();
 		const activeToolNames = new Set<string>();
 		const toolRegistry = new Map<string, Tool>();
 		const setActiveToolNames = (names: Iterable<string>): void => {
@@ -1739,6 +1740,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			trackEvalExecution: (execution, abortController) =>
 				session ? session.trackEvalExecution(execution, abortController) : execution,
 			getSessionId: () => sessionManager.getSessionId?.() ?? null,
+			isDisposed: () => session?.isDisposed ?? false,
 			getHindsightSessionState: () => session?.getHindsightSessionState(),
 			getMnemopiSessionState: () => session?.getMnemopiSessionState(),
 			getAgentId: () => resolvedAgentId,
@@ -1765,6 +1767,14 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			recordEvalSubagentUsage: output => sessionManager.recordEvalSubagentOutput(output),
 			getClientBridge: () => session?.clientBridge,
 			queueDeferredDiagnostics: entry => session?.yieldQueue.enqueue(LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE, entry),
+			queueLaunchCompletion: notification =>
+				session?.queueLaunchCompletion(notification) ??
+				Promise.reject(new Error("Session unavailable for launch completion delivery")),
+			registerDisposeCallback: callback => {
+				disposeCallbacks.add(callback);
+				return () => disposeCallbacks.delete(callback);
+			},
+			registerSessionChangeCallback: callback => session?.registerSessionChangeCallback(callback),
 			bumpFileMutationVersion: path => {
 				const next = (fileMutationVersions.get(path) ?? 0) + 1;
 				fileMutationVersions.set(path, next);
@@ -3307,6 +3317,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				const id = sessionManager.getSessionId?.();
 				return id ? `${id}-advisor` : null;
 			},
+			queueLaunchCompletion: notification =>
+				session?.queueLaunchCompletion(notification) ??
+				Promise.reject(new Error("Session unavailable for launch completion delivery")),
 			getAgentId: () => "advisor",
 			// The primary's availability signals are wrong for advisors: their tool
 			// slate is filtered separately at runtime (default read/grep/glob, no
@@ -3522,6 +3535,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					unsubscribeCredentialDisabled?.();
 					unsubscribeMcpNotifications?.();
 					unregisterMcpPostmortem?.();
+					for (const callback of disposeCallbacks) callback();
+					disposeCallbacks.clear();
 					// Drop refs so the process-global postmortem list doesn't retain
 					// the bridge closure past explicit dispose.
 					unsubscribeMcpNotifications = undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -144,6 +144,7 @@ import type { GoalModeState } from "../goals/state";
 import type { HindsightSessionState } from "../hindsight/state";
 import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import type { IrcMessage } from "../irc/bus";
+import type { DaemonCompletionNotification } from "../launch/protocol";
 import { shutdownMnemopiEmbedClient } from "../mnemopi/embed-client";
 import { getMnemopiSessionState, type MnemopiSessionState, setMnemopiSessionState } from "../mnemopi/state";
 import { containsOrchestrate, ORCHESTRATE_NOTICE } from "../modes/orchestrate";
@@ -271,6 +272,12 @@ import {
 	type ToolExecutionStartData,
 } from "./exit-diagnostics";
 import { IrcBridge, type IrcBridgeHost } from "./irc-bridge";
+import {
+	buildLaunchCompletionBatchMessage,
+	isLaunchCompletionOwner,
+	LAUNCH_COMPLETION_MESSAGE_TYPE,
+	type LaunchCompletionEntry,
+} from "./launch-completion";
 import {
 	type BashExecutionMessage,
 	buildReplanTitleContext,
@@ -445,6 +452,8 @@ export class AgentSession {
 	#lastAppendOnlyResolution?: { enable: boolean; providerId: string | undefined };
 	#eventListeners: AgentSessionEventListener[] = [];
 	#commandMetadataChangedListeners: CommandMetadataChangedListener[] = [];
+	#sessionChangeCallbacks = new Set<() => void>();
+	#observedSessionId: string | undefined;
 
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	#pendingNextTurnMessages: CustomMessage[] = [];
@@ -658,6 +667,7 @@ export class AgentSession {
 		if (onSettled) this.#inFlightSettledCallbacks.push(onSettled);
 		this.#promptInFlightCount = Math.max(0, this.#promptInFlightCount - 1);
 		if (this.#promptInFlightCount !== 0) return;
+		this.yieldQueue.requestIdleFlush();
 		this.#releasePowerAssertion();
 		this.#flushPendingAgentEnd();
 		if (this.#inFlightSettledCallbacks.length === 0) {
@@ -839,6 +849,7 @@ export class AgentSession {
 
 	#resetInFlight(): void {
 		this.#promptInFlightCount = 0;
+		this.yieldQueue.requestIdleFlush();
 		this.#releasePowerAssertion();
 		this.#flushPendingAgentEnd();
 		if (this.#inFlightSettledCallbacks.length === 0) {
@@ -1122,16 +1133,29 @@ export class AgentSession {
 			injectIdle: async messages => {
 				const first = messages[0];
 				if (!first) return;
-				await this.agent.prompt(messages.length === 1 ? first : messages);
+				this.#beginInFlight();
+				try {
+					await this.agent.prompt(messages.length === 1 ? first : messages);
+				} finally {
+					this.#endInFlight();
+				}
 			},
 			scheduleIdleFlush: run => {
 				this.#schedulePostPromptTask(
 					async () => {
 						await run();
 					},
-					{ delayMs: 1 },
+					{
+						delayMs: 1,
+						onSkip: () => this.yieldQueue.cancelIdleFlushScheduling(),
+					},
 				);
 			},
+		});
+		this.yieldQueue.register<LaunchCompletionEntry>(LAUNCH_COMPLETION_MESSAGE_TYPE, {
+			isStale: entry =>
+				this.#isDisposed || !isLaunchCompletionOwner(entry.owner, this.sessionManager.getSessionId()),
+			build: buildLaunchCompletionBatchMessage,
 		});
 		// Background-job completions / late diagnostics are pulled into the run at
 		// each step boundary as non-interrupting asides. Peer IRCs share the aside
@@ -2900,6 +2924,7 @@ export class AgentSession {
 				try {
 					await scheduler.wait(delayMs, { signal });
 				} catch {
+					if (signal.aborted) options?.onSkip?.("aborted");
 					return;
 				}
 			}
@@ -3400,6 +3425,12 @@ export class AgentSession {
 		};
 	}
 
+	/** Register cleanup that runs when this AgentSession adopts a different session ID. */
+	registerSessionChangeCallback(callback: () => void): () => void {
+		this.#sessionChangeCallbacks.add(callback);
+		return () => this.#sessionChangeCallbacks.delete(callback);
+	}
+
 	subscribeCommandMetadataChanged(listener: CommandMetadataChangedListener): () => void {
 		this.#commandMetadataChangedListeners.push(listener);
 		return () => {
@@ -3474,7 +3505,14 @@ export class AgentSession {
 	 * (login/logout, token refresh that surfaces a new account UUID) without
 	 * needing to re-call `#syncAgentSessionId()` on every such event.
 	 */
-	#syncAgentSessionId(sessionId?: string): void {
+	#syncAgentSessionId(sessionId?: string, notifyChange = true): void {
+		const currentSessionId = this.sessionManager.getSessionId();
+		if (this.#observedSessionId === undefined) {
+			this.#observedSessionId = currentSessionId;
+		} else if (this.#observedSessionId !== currentSessionId) {
+			this.#observedSessionId = currentSessionId;
+			if (notifyChange) this.#notifySessionChangeCallbacks();
+		}
 		const sid = this.#activeProviderSessionId(sessionId);
 		this.agent.sessionId = sid;
 		this.agent.setMetadataResolver((provider: string) =>
@@ -3494,6 +3532,16 @@ export class AgentSession {
 		// conversation's session id/metadata (issue #6625). Guarded because this
 		// runs once during construction before the advisor controller exists.
 		if (this.#advisors) this.#advisors.refreshProviderIdentity();
+	}
+
+	#notifySessionChangeCallbacks(): void {
+		for (const callback of [...this.#sessionChangeCallbacks]) {
+			try {
+				callback();
+			} catch (error) {
+				logger.warn("Session change callback failed", { error: String(error) });
+			}
+		}
 	}
 
 	/** Run one abortable auto-learn capture outside the primary agent loop. */
@@ -3723,6 +3771,7 @@ export class AgentSession {
 			this.#unsubscribeModelRoles = undefined;
 		}
 		this.#eventListeners = [];
+		this.#sessionChangeCallbacks.clear();
 	}
 
 	#closeAllProviderSessions(reason: string): void {
@@ -5534,6 +5583,16 @@ export class AgentSession {
 		this.#queueHiddenNextTurnMessage(message, true);
 	}
 
+	queueLaunchCompletion(notification: DaemonCompletionNotification): Promise<void> {
+		if (this.#isDisposed) return Promise.reject(new Error("Session disposed before launch completion delivery"));
+		const delivered = this.yieldQueue.enqueueWithReceipt<LaunchCompletionEntry>(
+			LAUNCH_COMPLETION_MESSAGE_TYPE,
+			notification,
+		);
+		this.yieldQueue.requestIdleFlush();
+		return delivered;
+	}
+
 	#queueHiddenNextTurnMessage(message: CustomMessage, triggerTurn: boolean): void {
 		this.#pendingNextTurnMessages.push(message);
 		if (!triggerTurn) return;
@@ -7251,7 +7310,7 @@ export class AgentSession {
 				this.#clearInheritedProviderPromptCacheKey();
 				this.#adoptInheritedProviderPromptCacheKey();
 			}
-			this.#syncAgentSessionId();
+			this.#syncAgentSessionId(undefined, false);
 			this.#memory.rekeyForCurrentSessionId();
 
 			let sessionContext = this.buildDisplaySessionContext();
@@ -7388,11 +7447,14 @@ export class AgentSession {
 				this.#advisors.restoreCost(await loadAdvisorTranscriptCosts(this.sessionFile));
 			}
 			this.#bash.finishSessionTransition(bashTransition, true);
+			if (previousSessionState.sessionId !== this.sessionManager.getSessionId()) {
+				this.#notifySessionChangeCallbacks();
+			}
 			return true;
 		} catch (error) {
 			this.sessionManager.restoreState(previousSessionState);
 			this.#freshProviderSessionId = previousFreshProviderSessionId;
-			this.#syncAgentSessionId(previousSessionState.sessionId);
+			this.#syncAgentSessionId(previousSessionState.sessionId, false);
 			this.#memory.rekeyForCurrentSessionId();
 			this.agent.setTools(previousTools);
 			this.#tools.setBaseSystemPrompt(previousBaseSystemPrompt);

--- a/packages/coding-agent/src/session/launch-completion.ts
+++ b/packages/coding-agent/src/session/launch-completion.ts
@@ -1,0 +1,37 @@
+import { prompt } from "@oh-my-pi/pi-utils";
+import type { DaemonCompletionNotification } from "../launch/protocol";
+import launchCompletionTemplate from "../prompts/session/launch-completion.md" with { type: "text" };
+import type { CustomMessage } from "./messages";
+
+/** Yield-queue kind for broker-owned supervised process completions. */
+export const LAUNCH_COMPLETION_MESSAGE_TYPE = "launch-completion";
+
+/** One broker completion awaiting injection into its owning session. */
+export type LaunchCompletionEntry = DaemonCompletionNotification;
+
+/** Whether a broker completion belongs to the primary session or its advisor. */
+export function isLaunchCompletionOwner(owner: string, sessionId: string): boolean {
+	return owner === sessionId || owner === `${sessionId}-advisor`;
+}
+
+/** Build one model-visible notification per terminal supervised process exit. */
+export function buildLaunchCompletionBatchMessage(entries: LaunchCompletionEntry[]): CustomMessage {
+	return {
+		role: "custom",
+		customType: LAUNCH_COMPLETION_MESSAGE_TYPE,
+		content: entries
+			.map(({ daemon }) =>
+				prompt.render(launchCompletionTemplate, {
+					name: daemon.name,
+					state: daemon.state,
+					exitCode: daemon.exitCode,
+					hasExitCode: daemon.exitCode !== undefined,
+				}),
+			)
+			.join("\n"),
+		display: true,
+		attribution: "agent",
+		details: { daemons: entries.map(entry => entry.daemon) },
+		timestamp: Date.now(),
+	};
+}

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { type AgentMessage, ASIDE_MESSAGE_COMMIT, ASIDE_MESSAGE_DISCARD } from "@oh-my-pi/pi-agent-core";
 import { logger } from "@oh-my-pi/pi-utils";
 
 export interface YieldDispatcher<P> {
@@ -25,6 +25,17 @@ interface StoredDispatcher {
 	skipIdleFlush?: boolean;
 }
 
+interface StoredEntry {
+	value: unknown;
+	resolve?: () => void;
+	reject?: (error: Error) => void;
+}
+
+interface BuiltMessage {
+	message: AgentMessage;
+	entries: StoredEntry[];
+}
+
 function formatError(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
@@ -32,7 +43,7 @@ function formatError(error: unknown): string {
 export class YieldQueue {
 	readonly #options: YieldQueueOptions;
 	readonly #dispatchers = new Map<string, StoredDispatcher>();
-	readonly #entries = new Map<string, unknown[]>();
+	readonly #entries = new Map<string, StoredEntry[]>();
 	#idleFlushPending = false;
 
 	constructor(options: YieldQueueOptions) {
@@ -49,14 +60,27 @@ export class YieldQueue {
 		return () => {
 			if (this.#dispatchers.get(kind) !== stored) return;
 			this.#dispatchers.delete(kind);
+			this.#rejectEntries(this.#entries.get(kind) ?? [], new Error(`Yield queue dispatcher removed: ${kind}`));
 			this.#entries.delete(kind);
 		};
 	}
 
 	enqueue<P>(kind: string, entry: P): void {
+		this.#enqueue(kind, { value: entry });
+	}
+
+	enqueueWithReceipt<P>(kind: string, entry: P): Promise<void> {
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+		if (!this.#enqueue(kind, { value: entry, resolve, reject })) {
+			reject(new Error(`Yield queue entry ignored for unregistered kind: ${kind}`));
+		}
+		return promise;
+	}
+
+	#enqueue(kind: string, entry: StoredEntry): boolean {
 		if (!this.#dispatchers.has(kind)) {
 			logger.warn("Yield queue entry ignored for unregistered kind", { kind });
-			return;
+			return false;
 		}
 		let entries = this.#entries.get(kind);
 		if (!entries) {
@@ -67,6 +91,7 @@ export class YieldQueue {
 		if (!this.#options.isStreaming() && !this.#dispatchers.get(kind)!.skipIdleFlush) {
 			this.#scheduleIdleFlush();
 		}
+		return true;
 	}
 
 	has(kind?: string): boolean {
@@ -77,30 +102,55 @@ export class YieldQueue {
 		return false;
 	}
 
+	/** Arrange an idle flush for entries queued near the end of a streaming run. */
+	requestIdleFlush(): void {
+		for (const [kind, dispatcher] of this.#dispatchers) {
+			if (!dispatcher.skipIdleFlush && this.has(kind)) {
+				this.#scheduleIdleFlush();
+				return;
+			}
+		}
+	}
+
 	async flush(mode: YieldFlushMode): Promise<void> {
 		if (mode === "idle") {
 			this.#idleFlushPending = false;
 		}
-		const idleMessages: AgentMessage[] = [];
+		const idleMessages: BuiltMessage[] = [];
 		for (const [kind, dispatcher] of this.#dispatchers) {
+			if (mode === "idle" && dispatcher.skipIdleFlush) continue;
 			const entries = this.#drain(kind);
 			if (entries.length === 0) continue;
-			const message = this.#build(kind, dispatcher, entries);
-			if (!message) continue;
+			const built = this.#build(kind, dispatcher, entries);
+			if (!built) continue;
 			if (mode === "streaming") {
 				try {
-					this.#options.injectStreaming?.(message);
+					if (!this.#options.injectStreaming) throw new Error("Streaming injection is unavailable");
+					this.#options.injectStreaming(built.message);
+					this.#resolveEntries(built.entries);
 				} catch (error) {
+					const dispatchError = error instanceof Error ? error : new Error(String(error));
+					this.#rejectEntries(built.entries, dispatchError);
 					logger.warn("Yield queue streaming dispatch failed", { kind, error: formatError(error) });
 				}
 			} else {
-				idleMessages.push(message);
+				idleMessages.push(built);
 			}
 		}
 		if (mode === "idle" && idleMessages.length > 0) {
+			for (const item of idleMessages) this.#attachEntrySettlement(item);
 			try {
-				await this.#options.injectIdle(idleMessages);
+				await this.#options.injectIdle(idleMessages.map(item => item.message));
+				for (const item of idleMessages) {
+					(item.message as AgentMessage & { [ASIDE_MESSAGE_COMMIT]?: () => void })[ASIDE_MESSAGE_COMMIT]?.();
+				}
 			} catch (error) {
+				const dispatchError = error instanceof Error ? error : new Error(String(error));
+				for (const item of idleMessages) {
+					(item.message as AgentMessage & { [ASIDE_MESSAGE_DISCARD]?: (error: Error) => void })[
+						ASIDE_MESSAGE_DISCARD
+					]?.(dispatchError);
+				}
 				logger.warn("Yield queue idle dispatch failed", { error: formatError(error) });
 			}
 		}
@@ -119,7 +169,12 @@ export class YieldQueue {
 		for (const [kind, dispatcher] of this.#dispatchers) {
 			const entries = this.#drain(kind);
 			if (entries.length === 0) continue;
-			thunks.push(() => this.#build(kind, dispatcher, entries));
+			thunks.push(() => {
+				const built = this.#build(kind, dispatcher, entries);
+				if (!built) return null;
+				this.#attachEntrySettlement(built);
+				return built.message;
+			});
 		}
 		return thunks;
 	}
@@ -127,11 +182,19 @@ export class YieldQueue {
 	/** Drop queued entries. With `kind`, drop only that kind's entries (leaving
 	 *  any pending idle-flush for other kinds intact); otherwise drop everything. */
 	clear(kind?: string): void {
+		const error = new Error("Yield queue entry cleared before dispatch");
 		if (kind !== undefined) {
+			this.#rejectEntries(this.#entries.get(kind) ?? [], error);
 			this.#entries.delete(kind);
 			return;
 		}
+		for (const entries of this.#entries.values()) this.#rejectEntries(entries, error);
 		this.#entries.clear();
+		this.#idleFlushPending = false;
+	}
+
+	/** Clear a scheduled-flush latch when its host task is cancelled before running. */
+	cancelIdleFlushScheduling(): void {
 		this.#idleFlushPending = false;
 	}
 
@@ -150,34 +213,76 @@ export class YieldQueue {
 		}
 	}
 
-	#drain(kind: string): unknown[] {
+	#drain(kind: string): StoredEntry[] {
 		const entries = this.#entries.get(kind);
 		if (!entries || entries.length === 0) return [];
 		this.#entries.delete(kind);
 		return entries;
 	}
 
-	#build(kind: string, dispatcher: StoredDispatcher, entries: unknown[]): AgentMessage | null {
-		const survivors: unknown[] = [];
+	#build(kind: string, dispatcher: StoredDispatcher, entries: StoredEntry[]): BuiltMessage | null {
+		const survivors: StoredEntry[] = [];
 		for (const entry of entries) {
 			if (dispatcher.isStale) {
 				let stale: boolean;
 				try {
-					stale = dispatcher.isStale(entry);
+					stale = dispatcher.isStale(entry.value);
 				} catch (error) {
+					const staleError = error instanceof Error ? error : new Error(String(error));
+					entry.reject?.(staleError);
 					logger.warn("Yield queue stale check failed", { kind, error: formatError(error) });
 					continue;
 				}
-				if (stale) continue;
+				if (stale) {
+					entry.reject?.(new Error(`Yield queue entry became stale: ${kind}`));
+					continue;
+				}
 			}
 			survivors.push(entry);
 		}
 		if (survivors.length === 0) return null;
 		try {
-			return dispatcher.build(survivors);
+			const message = dispatcher.build(survivors.map(entry => entry.value));
+			if (!message) {
+				this.#rejectEntries(survivors, new Error(`Yield queue dispatcher skipped entry: ${kind}`));
+				return null;
+			}
+			return { message, entries: survivors };
 		} catch (error) {
+			const buildError = error instanceof Error ? error : new Error(String(error));
+			this.#rejectEntries(survivors, buildError);
 			logger.warn("Yield queue build failed", { kind, error: formatError(error) });
 			return null;
 		}
+	}
+
+	#attachEntrySettlement(built: BuiltMessage): void {
+		let settled = false;
+		Object.defineProperties(built.message, {
+			[ASIDE_MESSAGE_COMMIT]: {
+				configurable: true,
+				value: () => {
+					if (settled) return;
+					settled = true;
+					this.#resolveEntries(built.entries);
+				},
+			},
+			[ASIDE_MESSAGE_DISCARD]: {
+				configurable: true,
+				value: (error: Error) => {
+					if (settled) return;
+					settled = true;
+					this.#rejectEntries(built.entries, error);
+				},
+			},
+		});
+	}
+
+	#resolveEntries(entries: StoredEntry[]): void {
+		for (const entry of entries) entry.resolve?.();
+	}
+
+	#rejectEntries(entries: StoredEntry[], error: Error): void {
+		for (const entry of entries) entry.reject?.(error);
 	}
 }

--- a/packages/coding-agent/src/tools/hub/launch.ts
+++ b/packages/coding-agent/src/tools/hub/launch.ts
@@ -10,7 +10,7 @@ import type { Component } from "@oh-my-pi/pi-tui";
 import { Text } from "@oh-my-pi/pi-tui";
 import { sanitizeText } from "@oh-my-pi/pi-utils";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
-import { daemonClientForProject } from "../../launch/client";
+import { type DaemonBrokerClient, DaemonBrokerRejectedError, daemonClientForProject } from "../../launch/client";
 import type { DaemonOperation, DaemonRpcResult, DaemonSnapshot, DaemonSpec, DaemonState } from "../../launch/protocol";
 import { renderTerminalOutputIsolated } from "../../launch/terminal-output-worker-client";
 import type { Theme, ThemeColor } from "../../modes/theme/theme";
@@ -34,6 +34,81 @@ import {
 } from "../render-utils";
 import { styleTerminalRow } from "../terminal-output";
 import { ToolError } from "../tool-errors";
+
+interface CompletionRegistration {
+	inFlight: number;
+	retained: boolean;
+	active: boolean;
+	cleanup: (preservePending?: boolean) => void;
+}
+
+interface CompletionLease {
+	retain: () => void;
+	reject: (preservePending?: boolean) => void;
+	hasConcurrentRequest: () => boolean;
+}
+
+const completionRegistrations = new WeakMap<
+	ToolSession,
+	Map<DaemonBrokerClient, Map<string, CompletionRegistration>>
+>();
+
+function registerCompletionSink(
+	session: ToolSession,
+	client: DaemonBrokerClient,
+	owner: string,
+): CompletionLease | undefined {
+	if (!session.queueLaunchCompletion) return undefined;
+	let clients = completionRegistrations.get(session);
+	if (!clients) {
+		clients = new Map();
+		completionRegistrations.set(session, clients);
+	}
+	let owners = clients.get(client);
+	if (!owners) {
+		owners = new Map();
+		clients.set(client, owners);
+	}
+	let registration = owners.get(owner);
+	if (!registration) {
+		const unregister = client.onCompletion(owner, notification => {
+			if (session.isDisposed?.()) throw new Error("Session disposed before launch completion delivery");
+			const delivery = session.queueLaunchCompletion?.(notification);
+			if (!delivery) throw new Error("Session cannot accept launch completion delivery");
+			return delivery;
+		});
+		let unregisterDispose: (() => void) | void;
+		let unregisterSessionChange: (() => void) | void;
+		const cleanup = (preservePending = false): void => {
+			if (!registration?.active) return;
+			registration.active = false;
+			unregister({ preservePending });
+			unregisterDispose?.();
+			unregisterSessionChange?.();
+			owners.delete(owner);
+			if (owners.size === 0) clients.delete(client);
+			if (clients.size === 0) completionRegistrations.delete(session);
+		};
+		registration = { inFlight: 0, retained: false, active: true, cleanup };
+		owners.set(owner, registration);
+		unregisterDispose = session.registerDisposeCallback?.(() => cleanup(true));
+		unregisterSessionChange = session.registerSessionChangeCallback?.(() => cleanup(true));
+	}
+	registration.inFlight++;
+	let settled = false;
+	const settle = (retain: boolean, preservePending = false): void => {
+		if (settled || !registration.active) return;
+		settled = true;
+		registration.inFlight--;
+		if (retain) registration.retained = true;
+		if (!registration.retained && registration.inFlight === 0) registration.cleanup(preservePending);
+	};
+	return {
+		retain: () => settle(true),
+		hasConcurrentRequest: () => registration.active && registration.inFlight > 1,
+		reject: preservePending => settle(false, preservePending),
+	};
+}
 
 /** Broker-facing launch parameters; the hub adapts its `ps` op to `list` before calling in. */
 export interface LaunchParams {
@@ -321,11 +396,52 @@ export async function executeLaunch(
 	signal?: AbortSignal,
 ): Promise<AgentToolResult<LaunchToolDetails>> {
 	const client = await daemonClientForProject(session.cwd);
-	const result = await client.request(operationFor(params, session), signal);
-	return {
-		content: [{ type: "text", text: replaceTabs(toolContent(result, params)) }],
-		details: await toolDetails(result, params),
-	};
+	const operation = operationFor(params, session);
+	const owner = operation.op === "start" ? operation.owner : undefined;
+	const resumedOwner = params.op !== "start" ? (session.getSessionId?.() ?? undefined) : undefined;
+	const completionLease = owner
+		? registerCompletionSink(session, client, owner)
+		: resumedOwner
+			? registerCompletionSink(session, client, resumedOwner)
+			: undefined;
+	try {
+		const result = await client.request(operation, signal);
+		const sessionOwner = session.getSessionId?.();
+		let resumedDaemonFound = false;
+		const daemons =
+			result.op === "list" ? result.daemons : "daemon" in result && result.daemon ? [result.daemon] : [];
+		for (const daemon of daemons) {
+			if (!daemon.owner || daemon.owner !== sessionOwner || TERMINAL_STATES[daemon.state]) continue;
+			resumedDaemonFound = true;
+			if (daemon.owner !== resumedOwner) registerCompletionSink(session, client, daemon.owner)?.retain();
+		}
+		if (params.op === "list" && resumedOwner && !resumedDaemonFound) completionLease?.reject(true);
+		else completionLease?.retain();
+		return {
+			content: [{ type: "text", text: replaceTabs(toolContent(result, params)) }],
+			details: await toolDetails(result, params),
+		};
+	} catch (error) {
+		if (error instanceof DaemonBrokerRejectedError && owner) {
+			if (completionLease?.hasConcurrentRequest()) {
+				completionLease.reject();
+			} else {
+				try {
+					const listed = await client.request({ op: "list" }, signal);
+					const ownerStillRunning =
+						listed.op === "list" &&
+						listed.daemons.some(daemon => daemon.owner === owner && !TERMINAL_STATES[daemon.state]);
+					if (ownerStillRunning) completionLease?.retain();
+					else completionLease?.reject(true);
+				} catch {
+					completionLease?.retain();
+				}
+			}
+		} else {
+			completionLease?.retain();
+		}
+		throw error;
+	}
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -16,6 +16,7 @@ import type { GoalModeState, GoalRuntime } from "../goals";
 import { GoalTool } from "../goals/tools/goal-tool";
 import type { HindsightSessionState } from "../hindsight/state";
 import type { LocalProtocolOptions } from "../internal-urls";
+import type { DaemonCompletionNotification } from "../launch/protocol";
 import { LspTool } from "../lsp";
 import type { MCPManager } from "../mcp";
 import type { MnemopiSessionState } from "../mnemopi/state";
@@ -155,6 +156,8 @@ export interface ToolSession {
 	additionalDirectories?: string[];
 	/** Whether UI is available */
 	hasUI: boolean;
+	/** Whether this session has begun disposal. */
+	isDisposed?: () => boolean;
 	/**
 	 * Suppress the spawn specialization/coordination advisory appended to `task`
 	 * results. Set by internal/programmatic callers (e.g. the commit agent's
@@ -380,6 +383,12 @@ export interface ToolSession {
 
 	/** Queue a hidden message to be injected at the next agent turn. */
 	queueDeferredMessage?(message: CustomMessage): void;
+	/** Queue a broker supervised-process completion for the owning session. */
+	queueLaunchCompletion?(notification: DaemonCompletionNotification): Promise<void>;
+	/** Register cleanup that runs when this session is disposed; returns a handle that removes the cleanup. */
+	registerDisposeCallback?(callback: () => void): (() => void) | void;
+	/** Register cleanup that runs when this ToolSession adopts a different session ID. */
+	registerSessionChangeCallback?(callback: () => void): (() => void) | void;
 	/** Queue late LSP diagnostics (arrived after an edit/write returned) to be shown
 	 *  in the transcript and delivered to the model at the next yield, like background
 	 *  job results. */

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -15,6 +15,7 @@ import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { DaemonCompletionNotification } from "@oh-my-pi/pi-coding-agent/launch/protocol";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AsyncResultEntry } from "@oh-my-pi/pi-coding-agent/session/async-job-delivery";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -93,6 +94,60 @@ describe("AgentSession owner-routed async delivery", () => {
 			}),
 		);
 		expect(sawResult).toBe(true);
+	});
+
+	it("routes an advisor-owned launch completion through the session", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const sessionManager = SessionManager.inMemory();
+		const owner = `${sessionManager.getSessionId()}-advisor`;
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+		const completion = {
+			event: "daemon-completed",
+			completionId: "advisor-completion",
+			owner,
+			daemon: {
+				name: "advisor-worker",
+				id: "daemon-id",
+				state: "exited",
+				createdAt: 1,
+				startedAt: 1,
+				exitedAt: 2,
+				exitCode: 0,
+				restartCount: 0,
+				outputBytes: 0,
+				owner,
+				persist: false,
+				detached: false,
+			},
+		} satisfies DaemonCompletionNotification;
+
+		await session.queueLaunchCompletion(completion);
+		await session.waitForIdle();
+
+		expect(
+			mock.calls.some(call =>
+				call.context.messages.some(message =>
+					typeof message.content === "string"
+						? message.content.includes("advisor-worker")
+						: message.content.some(content => content.type === "text" && content.text.includes("advisor-worker")),
+				),
+			),
+		).toBe(true);
 	});
 
 	it("purges finished owned jobs when starting a new session", async () => {

--- a/packages/coding-agent/test/async-yield-queue.test.ts
+++ b/packages/coding-agent/test/async-yield-queue.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import {
+	type AgentMessage,
+	ASIDE_MESSAGE_COMMIT,
+	ASIDE_MESSAGE_DISCARD,
+	type CommittableAsideMessage,
+} from "@oh-my-pi/pi-agent-core";
 import { type AsyncJob, AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import type { CustomMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { YieldQueue } from "@oh-my-pi/pi-coding-agent/session/yield-queue";
@@ -170,5 +175,59 @@ describe("async result yield queue delivery", () => {
 		expect(harness.prompts).toHaveLength(1);
 		expect(harness.prompts[0]).toHaveLength(1);
 		expect(asyncDetails(harness.prompts[0]![0]!).jobs.map(job => job.jobId)).toEqual([jobId]);
+	});
+
+	test("releases a canceled idle-flush latch for rescheduling", () => {
+		const harness = createHarness(false);
+		harness.queue.enqueue<AsyncEntry>("async-result", {
+			jobId: "idle-retry",
+			result: "retry",
+			job: undefined,
+			durationMs: undefined,
+		});
+		expect(harness.scheduledFlushes).toHaveLength(1);
+
+		harness.queue.cancelIdleFlushScheduling();
+		harness.queue.requestIdleFlush();
+
+		expect(harness.scheduledFlushes).toHaveLength(2);
+	});
+
+	test("holds a streaming receipt until the aside enters live context", async () => {
+		const harness = createHarness(true);
+		const receipt = harness.queue.enqueueWithReceipt<AsyncEntry>("async-result", {
+			jobId: "streaming-receipt",
+			result: "done",
+			job: undefined,
+			durationMs: undefined,
+		});
+		let delivered = false;
+		void receipt.then(() => {
+			delivered = true;
+		});
+		const message = harness.queue.drainLazy()[0]?.();
+		if (!message) throw new Error("Expected a lazy aside");
+
+		await Promise.resolve();
+		expect(delivered).toBe(false);
+		(message as CommittableAsideMessage)[ASIDE_MESSAGE_COMMIT]?.();
+		await receipt;
+		expect(delivered).toBe(true);
+	});
+
+	test("rejects a streaming receipt when the agent discards its aside", async () => {
+		const harness = createHarness(true);
+		const receipt = harness.queue.enqueueWithReceipt<AsyncEntry>("async-result", {
+			jobId: "discarded-receipt",
+			result: "done",
+			job: undefined,
+			durationMs: undefined,
+		});
+		const message = harness.queue.drainLazy()[0]?.();
+		if (!message) throw new Error("Expected a lazy aside");
+
+		(message as CommittableAsideMessage)[ASIDE_MESSAGE_DISCARD]?.(new Error("deadline expired"));
+
+		await expect(receipt).rejects.toThrow("deadline expired");
 	});
 });

--- a/packages/coding-agent/test/launch/protocol.test.ts
+++ b/packages/coding-agent/test/launch/protocol.test.ts
@@ -51,6 +51,23 @@ describe("launch logs compatibility", () => {
 		expect(request.operation).toMatchObject({ ...operation, renderTerminalRows: true });
 	});
 
+	it("preserves completion owner changes on reconnect requests", () => {
+		const request = parseDaemonWireRequest({
+			id: "request-1",
+			token: "token-1",
+			owners: ["session-owner"],
+			detachedOwners: ["parked-owner"],
+			completionUnsubscribes: ["disposed-owner"],
+			completionSubscriptionId: "subscription-1",
+			operation: { op: "list" },
+		});
+
+		expect(request.owners).toEqual(["session-owner"]);
+		expect(request.detachedOwners).toEqual(["parked-owner"]);
+		expect(request.completionUnsubscribes).toEqual(["disposed-owner"]);
+		expect(request.completionSubscriptionId).toBe("subscription-1");
+	});
+
 	it("decodes raw terminal text from an already-running legacy broker", () => {
 		const result = parseDaemonRpcResult(operation, { ...baseResult, terminalText: "progress\rready" });
 		if (result.op !== "logs") throw new Error("unexpected result");

--- a/packages/coding-agent/test/session/yield-queue.test.ts
+++ b/packages/coding-agent/test/session/yield-queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { type AgentMessage, ASIDE_MESSAGE_COMMIT } from "@oh-my-pi/pi-agent-core";
 import { YieldQueue } from "@oh-my-pi/pi-coding-agent/session/yield-queue";
 
 type Entry = {
@@ -68,6 +68,46 @@ describe("YieldQueue", () => {
 		expect(harness.streamingMessages.map(messageText)).toEqual(["a"]);
 	});
 
+	test("requested idle flush waits for an explicit stream-settlement retry", async () => {
+		const harness = createHarness(true);
+		harness.queue.register<Entry>("items", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+		harness.queue.enqueue("items", { id: "late" });
+		harness.queue.requestIdleFlush();
+		expect(harness.scheduledFlushes).toHaveLength(1);
+
+		await harness.scheduledFlushes[0]!();
+		expect(harness.scheduledFlushes).toHaveLength(1);
+		expect(harness.idleBatches).toHaveLength(0);
+
+		harness.setStreaming(false);
+		harness.queue.requestIdleFlush();
+		await harness.scheduledFlushes[1]!();
+
+		expect(harness.idleBatches[0]?.map(messageText)).toEqual(["late"]);
+	});
+	test("requested idle flush preserves skip-only entries", async () => {
+		const harness = createHarness(true);
+		harness.queue.register<Entry>("advisor", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+			skipIdleFlush: true,
+		});
+		harness.queue.register<Entry>("completion", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+		harness.queue.enqueue("advisor", { id: "advice" });
+		harness.queue.requestIdleFlush();
+		expect(harness.scheduledFlushes).toHaveLength(0);
+
+		harness.queue.enqueue("completion", { id: "done" });
+		harness.queue.requestIdleFlush();
+		harness.setStreaming(false);
+		await harness.scheduledFlushes[0]!();
+
+		expect(harness.idleBatches[0]?.map(messageText)).toEqual(["done"]);
+		expect(harness.queue.has("advisor")).toBe(true);
+	});
 	test("enqueue while idle schedules one debounced idle flush", async () => {
 		const harness = createHarness(false);
 		harness.queue.register<Entry>("items", {
@@ -84,6 +124,59 @@ describe("YieldQueue", () => {
 
 		expect(harness.idleBatches).toHaveLength(1);
 		expect(harness.idleBatches[0]?.map(messageText)).toEqual(["a,b"]);
+	});
+
+	test("resolves delivery receipts only after idle injection succeeds", async () => {
+		const injected = Promise.withResolvers<void>();
+		const scheduledFlushes: Array<() => Promise<void>> = [];
+		const queue = new YieldQueue({
+			isStreaming: () => false,
+			injectIdle: async () => injected.promise,
+			scheduleIdleFlush: run => scheduledFlushes.push(run),
+		});
+		queue.register<Entry>("items", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+		let delivered = false;
+		const receipt = queue.enqueueWithReceipt("items", { id: "durable" }).then(() => {
+			delivered = true;
+		});
+
+		const flush = scheduledFlushes[0]!();
+		await Promise.resolve();
+		expect(delivered).toBe(false);
+		injected.resolve();
+		await flush;
+		await receipt;
+		expect(delivered).toBe(true);
+	});
+
+	test("resolves an idle receipt when injection commits before the turn finishes", async () => {
+		const finishTurn = Promise.withResolvers<void>();
+		const scheduledFlushes: Array<() => Promise<void>> = [];
+		const queue = new YieldQueue({
+			isStreaming: () => false,
+			injectIdle: async messages => {
+				(messages[0] as AgentMessage & { [ASIDE_MESSAGE_COMMIT]?: () => void })[ASIDE_MESSAGE_COMMIT]?.();
+				await finishTurn.promise;
+			},
+			scheduleIdleFlush: run => scheduledFlushes.push(run),
+		});
+		queue.register<Entry>("items", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+		const receipt = queue.enqueueWithReceipt("items", { id: "idle-commit" });
+
+		const flush = scheduledFlushes[0]!();
+		await receipt;
+		let flushFinished = false;
+		void flush.then(() => {
+			flushFinished = true;
+		});
+		await Promise.resolve();
+		expect(flushFinished).toBe(false);
+		finishTurn.resolve();
+		await flush;
 	});
 
 	test("isStale drops stale entries and keeps survivors", async () => {

--- a/packages/coding-agent/test/tools/hub/launch-compat.test.ts
+++ b/packages/coding-agent/test/tools/hub/launch-compat.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { DaemonBrokerClient } from "../../../src/launch/client";
 import * as daemonClient from "../../../src/launch/client";
-import type { DaemonRpcResult } from "../../../src/launch/protocol";
+import type { DaemonCompletionNotification, DaemonRpcResult } from "../../../src/launch/protocol";
 import type { ToolSession } from "../../../src/tools";
 import { executeLaunch } from "../../../src/tools/hub/launch";
 
@@ -33,6 +33,7 @@ describe("launch broker protocol compatibility", () => {
 			projectDir,
 			request: async () => legacyResult,
 			close() {},
+			onCompletion: () => () => {},
 		} satisfies DaemonBrokerClient;
 		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
 
@@ -60,6 +61,7 @@ describe("launch broker protocol compatibility", () => {
 		const client = {
 			projectDir,
 			request: async () => legacyResult,
+			onCompletion: () => () => {},
 			close() {},
 		} satisfies DaemonBrokerClient;
 		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
@@ -84,5 +86,458 @@ describe("launch broker protocol compatibility", () => {
 			}
 		}
 		expect(Object.getOwnPropertyDescriptor(globalThis, "Worker")).toEqual(originalWorkerDescriptor);
+	});
+
+	it("restores a completion sink when a resumed session lists its live daemon", async () => {
+		const projectDir = process.cwd();
+		const owner = "owner-session";
+		const registered: string[] = [];
+		const client = {
+			projectDir,
+			onCompletion: (registeredOwner: string) => {
+				registered.push(registeredOwner);
+				return () => {};
+			},
+			request: async () => {
+				expect(registered).toEqual([owner]);
+				return {
+					op: "list",
+					daemons: [
+						{
+							name: "web",
+							id: "daemon-id",
+							state: "running",
+							createdAt: 1,
+							startedAt: 1,
+							restartCount: 0,
+							outputBytes: 0,
+							owner,
+							persist: true,
+							detached: false,
+						},
+					],
+				} as const;
+			},
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+
+		await executeLaunch(
+			{
+				cwd: projectDir,
+				getSessionId: () => owner,
+				isDisposed: () => false,
+				queueLaunchCompletion: () => {},
+				registerDisposeCallback: () => {},
+			} as unknown as ToolSession,
+			{ op: "list" },
+		);
+
+		expect(registered).toEqual([owner]);
+	});
+
+	it("restores a completion sink before a resumed session reads logs", async () => {
+		const projectDir = process.cwd();
+		const owner = "owner-session";
+		const registered: string[] = [];
+		const client = {
+			projectDir,
+			onCompletion: (registeredOwner: string) => {
+				registered.push(registeredOwner);
+				return () => {};
+			},
+			request: async () =>
+				({
+					op: "logs",
+					name: "web",
+					text: "ready",
+					cursor: 5,
+					timedOut: false,
+					state: "running",
+				}) as const,
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+
+		await executeLaunch(
+			{
+				cwd: projectDir,
+				getSessionId: () => owner,
+				isDisposed: () => false,
+				queueLaunchCompletion: () => {},
+				registerDisposeCallback: () => {},
+			} as unknown as ToolSession,
+			{ op: "logs", name: "web", lines: 10, head: false, follow: false },
+		);
+
+		expect(registered).toEqual([owner]);
+	});
+
+	it("restores a completion sink before a resumed session stops one daemon", async () => {
+		const projectDir = process.cwd();
+		const owner = "owner-session";
+		const registered: string[] = [];
+		const client = {
+			projectDir,
+			onCompletion: (registeredOwner: string) => {
+				registered.push(registeredOwner);
+				return () => {};
+			},
+			request: async () => {
+				expect(registered).toEqual([owner]);
+				return {
+					op: "stop",
+					daemon: {
+						name: "web",
+						id: "daemon-id",
+						state: "exited",
+						createdAt: 1,
+						startedAt: 1,
+						exitedAt: 2,
+						exitCode: 0,
+						restartCount: 0,
+						outputBytes: 0,
+						owner,
+						persist: true,
+						detached: false,
+					},
+				} as const;
+			},
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+
+		await executeLaunch(
+			{
+				cwd: projectDir,
+				getSessionId: () => owner,
+				isDisposed: () => false,
+				queueLaunchCompletion: () => {},
+				registerDisposeCallback: () => {},
+			} as unknown as ToolSession,
+			{ op: "stop", name: "web", timeout: 1 },
+		);
+	});
+
+	it("restores a completion sink before a resumed session waits on a daemon", async () => {
+		const projectDir = process.cwd();
+		const owner = "owner-session";
+		const registered: string[] = [];
+		const daemon = {
+			name: "web",
+			id: "daemon-id",
+			state: "running",
+			createdAt: 1,
+			startedAt: 1,
+			restartCount: 0,
+			outputBytes: 0,
+			owner,
+			persist: true,
+			detached: false,
+		} as const;
+		const client = {
+			projectDir,
+			onCompletion: (registeredOwner: string) => {
+				registered.push(registeredOwner);
+				return () => {};
+			},
+			request: async () => {
+				expect(registered).toEqual([owner]);
+				return { op: "wait", daemon, timedOut: false } as const;
+			},
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+
+		await executeLaunch(
+			{
+				cwd: projectDir,
+				getSessionId: () => owner,
+				isDisposed: () => false,
+				queueLaunchCompletion: () => {},
+				registerDisposeCallback: () => {},
+			} as unknown as ToolSession,
+			{ op: "wait", name: "web", for: "exit", timeout: 1 },
+		);
+	});
+
+	it("preserves replayed completions when a resumed owner has no live daemon", async () => {
+		const projectDir = process.cwd();
+		const owner = "owner-session";
+		let preservedPending = false;
+		const client = {
+			projectDir,
+			onCompletion: () => options => {
+				preservedPending = options?.preservePending === true;
+			},
+			request: async () => ({ op: "list", daemons: [] }) as const,
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+
+		await executeLaunch(
+			{
+				cwd: projectDir,
+				getSessionId: () => owner,
+				queueLaunchCompletion: () => {},
+			} as unknown as ToolSession,
+			{ op: "list" },
+		);
+
+		expect(preservedPending).toBe(true);
+	});
+
+	it("routes a broker completion and releases its sink on session change", async () => {
+		const projectDir = process.cwd();
+		const owner = "owner-session";
+		const queued: DaemonCompletionNotification[] = [];
+		let liveOwner = owner;
+		let deliver: ((notification: DaemonCompletionNotification) => void) | undefined;
+		let sessionChange: (() => void) | undefined;
+		let preservedPending = false;
+		const completion = {
+			event: "daemon-completed",
+			completionId: "completion-id",
+			owner,
+			daemon: {
+				name: "web",
+				id: "daemon-id",
+				state: "exited",
+				createdAt: 1,
+				startedAt: 1,
+				exitedAt: 2,
+				exitCode: 0,
+				restartCount: 0,
+				outputBytes: 0,
+				owner,
+				persist: false,
+				detached: false,
+			},
+		} satisfies DaemonCompletionNotification;
+		const client = {
+			projectDir,
+			onCompletion: (_owner: string, sink: (notification: DaemonCompletionNotification) => void) => {
+				deliver = sink;
+				return options => {
+					preservedPending = options?.preservePending === true;
+					deliver = undefined;
+				};
+			},
+			request: async () => ({ op: "start", daemon: completion.daemon, readyTimedOut: false }) as const,
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+
+		await executeLaunch(
+			{
+				cwd: projectDir,
+				getSessionId: () => liveOwner,
+				isDisposed: () => false,
+				queueLaunchCompletion: (notification: DaemonCompletionNotification) => queued.push(notification),
+				registerSessionChangeCallback: (callback: () => void) => {
+					sessionChange = callback;
+				},
+			} as unknown as ToolSession,
+			{ op: "start", name: "web", application: process.execPath, args: [] },
+		);
+
+		liveOwner = "target-session";
+		deliver?.(completion);
+		expect(queued).toEqual([completion]);
+		sessionChange?.();
+		expect(deliver).toBeUndefined();
+		expect(preservedPending).toBe(true);
+	});
+
+	it("keeps the completion sink when start delivery is indeterminate", async () => {
+		const projectDir = process.cwd();
+		let unregisters = 0;
+		const client = {
+			projectDir,
+			onCompletion: () => () => {
+				unregisters++;
+			},
+			request: async () => {
+				throw new Error("Daemon broker request aborted");
+			},
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+
+		const session = {
+			cwd: projectDir,
+			getSessionId: () => "owner-session",
+			isDisposed: () => false,
+			queueLaunchCompletion: () => {},
+			registerDisposeCallback: () => {},
+		} as unknown as ToolSession;
+		await expect(
+			executeLaunch(session, { op: "start", name: "web", application: process.execPath, args: [] }),
+		).rejects.toThrow("aborted");
+		expect(unregisters).toBe(0);
+	});
+
+	it("detaches the completion sink without deleting pending replay when the broker rejects start", async () => {
+		const projectDir = process.cwd();
+		let unregisters = 0;
+		let preservedPending = false;
+		let disposeRemovals = 0;
+		const client = {
+			projectDir,
+			onCompletion: () => options => {
+				unregisters++;
+				preservedPending = options?.preservePending === true;
+			},
+			request: async operation => {
+				if (operation.op === "start") throw new daemonClient.DaemonBrokerRejectedError("name already exists");
+				return { op: "list", daemons: [] };
+			},
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+
+		const session = {
+			cwd: projectDir,
+			getSessionId: () => "owner-session",
+			isDisposed: () => false,
+			queueLaunchCompletion: () => {},
+			registerDisposeCallback: () => () => {
+				disposeRemovals++;
+			},
+		} as unknown as ToolSession;
+		await expect(
+			executeLaunch(session, { op: "start", name: "web", application: process.execPath, args: [] }),
+		).rejects.toThrow("name already exists");
+		expect(unregisters).toBe(1);
+		expect(disposeRemovals).toBe(1);
+		expect(preservedPending).toBe(true);
+	});
+
+	it("keeps a resumed owner's sink when duplicate start finds its live daemon", async () => {
+		const projectDir = process.cwd();
+		const owner = "owner-session";
+		let unregisters = 0;
+		const client = {
+			projectDir,
+			onCompletion: () => () => {
+				unregisters++;
+			},
+			request: async operation => {
+				if (operation.op === "start") throw new daemonClient.DaemonBrokerRejectedError("name already exists");
+				return {
+					op: "list",
+					daemons: [
+						{
+							name: "web",
+							id: "daemon-id",
+							state: "running",
+							createdAt: 1,
+							startedAt: 1,
+							restartCount: 0,
+							outputBytes: 0,
+							owner,
+							persist: false,
+							detached: false,
+						},
+					],
+				};
+			},
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+		const session = {
+			cwd: projectDir,
+			getSessionId: () => owner,
+			isDisposed: () => false,
+			queueLaunchCompletion: async () => {},
+			registerDisposeCallback: () => {},
+		} as unknown as ToolSession;
+
+		await expect(
+			executeLaunch(session, { op: "start", name: "web", application: process.execPath, args: [] }),
+		).rejects.toThrow("name already exists");
+		expect(unregisters).toBe(0);
+	});
+
+	it("keeps a resumed owner's completion sink after a rejected operation", async () => {
+		const projectDir = process.cwd();
+		let unregisters = 0;
+		const client = {
+			projectDir,
+			onCompletion: () => () => {
+				unregisters++;
+			},
+			request: async () => {
+				throw new daemonClient.DaemonBrokerRejectedError("daemon not found");
+			},
+			close() {},
+		} satisfies DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+
+		const session = {
+			cwd: projectDir,
+			getSessionId: () => "owner-session",
+			isDisposed: () => false,
+			queueLaunchCompletion: () => {},
+			registerDisposeCallback: () => {},
+		} as unknown as ToolSession;
+
+		await expect(
+			executeLaunch(session, { op: "logs", name: "misspelled", lines: 10, head: false, follow: false }),
+		).rejects.toThrow("daemon not found");
+		expect(unregisters).toBe(0);
+	});
+	it("keeps a shared completion sink when a sibling start succeeds", async () => {
+		const projectDir = process.cwd();
+		const owner = "owner-session";
+		let unregisters = 0;
+		let dispose: (() => void) | undefined;
+		const rejected = Promise.withResolvers<DaemonRpcResult>();
+		const accepted = Promise.withResolvers<DaemonRpcResult>();
+		let requests = 0;
+		const client = {
+			projectDir,
+			onCompletion: () => () => {
+				unregisters++;
+			},
+			request: () => (++requests === 1 ? rejected.promise : accepted.promise),
+			close() {},
+		} as unknown as DaemonBrokerClient;
+		vi.spyOn(daemonClient, "daemonClientForProject").mockResolvedValue(client);
+		const session = {
+			cwd: projectDir,
+			getSessionId: () => owner,
+			isDisposed: () => false,
+			queueLaunchCompletion: () => {},
+			registerDisposeCallback: (callback: () => void) => {
+				dispose = callback;
+			},
+		} as unknown as ToolSession;
+
+		const first = executeLaunch(session, { op: "start", name: "first", application: process.execPath, args: [] });
+		const second = executeLaunch(session, { op: "start", name: "second", application: process.execPath, args: [] });
+		rejected.reject(new daemonClient.DaemonBrokerRejectedError("name already exists"));
+		await expect(first).rejects.toThrow("name already exists");
+		expect(unregisters).toBe(0);
+		accepted.resolve({
+			op: "start",
+			daemon: {
+				name: "second",
+				id: "daemon-id",
+				state: "running",
+				createdAt: 1,
+				startedAt: 1,
+				restartCount: 0,
+				outputBytes: 0,
+				owner,
+				persist: false,
+				detached: false,
+			},
+			readyTimedOut: false,
+		});
+		await second;
+		expect(unregisters).toBe(0);
+		dispose?.();
+		expect(unregisters).toBe(1);
 	});
 });

--- a/packages/coding-agent/test/tools/launch.test.ts
+++ b/packages/coding-agent/test/tools/launch.test.ts
@@ -1,10 +1,17 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
+import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createDaemonBrokerClient, type DaemonBrokerClient } from "../../src/launch/client";
+import { daemonBrokerEndpoint } from "../../src/launch/paths";
 import { registerDaemonProjectPresence } from "../../src/launch/presence";
-import type { DaemonOperation, DaemonSpec } from "../../src/launch/protocol";
+import type {
+	DaemonCompletionNotification,
+	DaemonOperation,
+	DaemonSnapshot,
+	DaemonSpec,
+} from "../../src/launch/protocol";
 
 const cleanupDirs: string[] = [];
 
@@ -40,6 +47,40 @@ async function shutdown(client: DaemonBrokerClient): Promise<void> {
 		// A last-client shutdown may already have closed the broker.
 	}
 	client.close();
+}
+
+async function publishCompletionOwner(
+	projectDir: string,
+	runtimeDir: string,
+	owner: string,
+	subscriptionId: string,
+	completionAcks: string[] = [],
+): Promise<void> {
+	const socket = net.createConnection(daemonBrokerEndpoint(projectDir, runtimeDir));
+	const connected = Promise.withResolvers<void>();
+	const responded = Promise.withResolvers<void>();
+	let buffer = "";
+	socket.setEncoding("utf8");
+	socket.once("connect", connected.resolve);
+	socket.once("error", responded.reject);
+	socket.on("data", chunk => {
+		buffer += chunk;
+		if (buffer.includes("\n")) responded.resolve();
+	});
+	await connected.promise;
+	socket.write(
+		`${JSON.stringify({
+			id: crypto.randomUUID(),
+			token: (await Bun.file(path.join(runtimeDir, "broker.token")).text()).trim(),
+			owners: [owner],
+			completionEvents: true,
+			completionAcks,
+			completionSubscriptionId: subscriptionId,
+			operation: { op: "ping" },
+		})}\n`,
+	);
+	await responded.promise;
+	socket.destroy();
 }
 
 async function startPtyDaemonWithShell(shell: string, initialMarker: string, expectedMarker: string): Promise<void> {
@@ -506,6 +547,265 @@ esac
 		}
 	}, 20_000);
 
+	it("reports a recovered detached daemon exit without a polling RPC", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-recovered-exit-project-");
+		const runtimeDir = await tempDir("omp-daemon-recovered-exit-runtime-");
+		const owner = "recovered-detached-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		let pid: number | undefined;
+		let completion: DaemonSnapshot | undefined;
+		const unregister = first.onCompletion(owner, notification => {
+			completion = notification.daemon;
+		});
+		try {
+			const started = await first.request({
+				op: "start",
+				spec: {
+					name: "recovered-exit",
+					application: "/bin/sh",
+					args: ["-c", "sleep 1.5; exit 7"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "no",
+					persist: false,
+					detached: true,
+				},
+				owner,
+			});
+			if (started.op !== "start" || started.daemon.pid === undefined)
+				throw new Error("detached daemon did not start");
+			pid = started.daemon.pid;
+			await first.request({ op: "shutdown" });
+			expect(
+				await waitUntil(
+					() =>
+						Bun.file(path.join(runtimeDir, "broker.pid"))
+							.exists()
+							.then(exists => !exists),
+					5_000,
+				),
+			).toBeTrue();
+			const launchedPid = pid;
+			expect(processExists(launchedPid)).toBeTrue();
+
+			expect(await waitUntil(() => completion !== undefined, 5_000)).toBeTrue();
+			expect(completion).toMatchObject({ name: "recovered-exit", state: "exited", exitCode: undefined });
+		} finally {
+			unregister();
+			if (completion !== undefined) await shutdown(first);
+			else first.close();
+			if (pid !== undefined && processExists(pid)) {
+				const rescue = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 1_000 });
+				try {
+					await rescue.request({ op: "stop", name: "recovered-exit", timeoutMs: 2_000 });
+				} finally {
+					await shutdown(rescue);
+				}
+			}
+		}
+	}, 15_000);
+
+	it("replays a detached exit that precedes broker recovery", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-pre-recovery-exit-project-");
+		const runtimeDir = await tempDir("omp-daemon-pre-recovery-exit-runtime-");
+		const owner = "pre-recovery-exit-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		let recovered: DaemonBrokerClient | undefined;
+		let unregister: (() => void) | undefined;
+		let pid: number | undefined;
+		try {
+			first.onCompletion(owner, () => {});
+			const started = await first.request({
+				op: "start",
+				spec: {
+					name: "pre-recovery-exit",
+					application: "/bin/sh",
+					args: ["-c", "sleep 0.2; exit 7"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "no",
+					persist: false,
+					detached: true,
+				},
+				owner,
+			});
+			if (started.op !== "start" || started.daemon.pid === undefined)
+				throw new Error("detached daemon did not start");
+			pid = started.daemon.pid;
+			await first.request({ op: "shutdown" });
+			first.close();
+			expect(await waitUntil(() => !processExists(pid!), 3_000)).toBeTrue();
+
+			recovered = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+			const completions: DaemonSnapshot[] = [];
+			unregister = recovered.onCompletion(owner, notification => {
+				completions.push(notification.daemon);
+			});
+			await recovered.request({ op: "list" });
+			expect(await waitUntil(() => completions.length === 1, 2_000)).toBeTrue();
+			expect(completions[0]).toMatchObject({ name: "pre-recovery-exit", state: "exited" });
+		} finally {
+			unregister?.();
+			first.close();
+			if (recovered) await shutdown(recovered);
+			if (pid !== undefined && processExists(pid)) process.kill(pid, "SIGKILL");
+		}
+	}, 12_000);
+
+	it("replays every pending generation completion after broker recovery", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-pending-recovery-project-");
+		const runtimeDir = await tempDir("omp-daemon-pending-recovery-runtime-");
+		const owner = "pending-recovery-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 500 });
+		let controller: DaemonBrokerClient | undefined;
+		let recovered: DaemonBrokerClient | undefined;
+		let unregister: (() => void) | undefined;
+		const completions: DaemonSnapshot[] = [];
+		try {
+			first.onCompletion(owner, () => {});
+			const started = await first.request({
+				op: "start",
+				spec: {
+					name: "pending-recovery-exit",
+					application: "/bin/sh",
+					args: ["-c", "sleep 0.15; exit 7"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "no",
+					persist: false,
+					detached: true,
+				},
+				owner,
+			});
+			if (started.op !== "start") throw new Error("detached daemon did not start");
+			first.close();
+			const metaPath = path.join(runtimeDir, "daemons", "pending-recovery-exit", "meta.json");
+			expect(
+				await waitUntil(async () => {
+					const meta = (await Bun.file(metaPath).json()) as { pendingCompletions?: unknown[] };
+					return meta.pendingCompletions?.length === 1;
+				}, 3_000),
+			).toBeTrue();
+
+			controller = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+			await controller.request({ op: "restart", name: "pending-recovery-exit" });
+			expect(
+				await waitUntil(async () => {
+					const meta = (await Bun.file(metaPath).json()) as { pendingCompletions?: unknown[] };
+					return meta.pendingCompletions?.length === 2;
+				}, 3_000),
+			).toBeTrue();
+			const persisted = (await Bun.file(metaPath).json()) as {
+				daemon: DaemonSnapshot;
+				pendingCompletions: DaemonCompletionNotification[];
+				[key: string]: unknown;
+			};
+			expect(new Set(persisted.pendingCompletions.map(completion => completion.completionId)).size).toBe(2);
+			await Bun.write(
+				metaPath,
+				JSON.stringify({
+					...persisted,
+					daemon: {
+						...persisted.daemon,
+						state: "running",
+						exitCode: undefined,
+						exitedAt: undefined,
+					},
+				}),
+			);
+			const brokerPidPath = path.join(runtimeDir, "broker.pid");
+			const { pid: brokerPid } = (await Bun.file(brokerPidPath).json()) as { pid: number };
+			process.kill(brokerPid, "SIGKILL");
+			expect(await waitUntil(() => !processExists(brokerPid), 3_000)).toBeTrue();
+
+			recovered = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+			unregister = recovered.onCompletion(owner, notification => {
+				completions.push(notification.daemon);
+			});
+			await recovered.request({ op: "list" });
+
+			expect(await waitUntil(() => completions.length === 2, 2_000)).toBeTrue();
+			expect(completions.map(completion => completion.name)).toEqual([
+				"pending-recovery-exit",
+				"pending-recovery-exit",
+			]);
+			expect(completions).toEqual([
+				expect.objectContaining({ state: "failed", exitCode: 7 }),
+				expect.objectContaining({ state: "failed", exitCode: 7 }),
+			]);
+			expect(
+				await waitUntil(async () => {
+					const metadata = (await Bun.file(metaPath).json()) as {
+						completionPending?: boolean;
+						pendingCompletions?: unknown[];
+					};
+					return metadata.completionPending === false && metadata.pendingCompletions?.length === 0;
+				}, 2_000),
+			).toBeTrue();
+		} finally {
+			unregister?.();
+			first.close();
+			controller?.close();
+			if (recovered) await shutdown(recovered);
+		}
+	}, 12_000);
+
+	it("replays a recovered non-detached daemon exit", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-attached-recovery-project-");
+		const runtimeDir = await tempDir("omp-daemon-attached-recovery-runtime-");
+		const owner = "attached-recovery-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		let recovered: DaemonBrokerClient | undefined;
+		let unregister: (() => void) | undefined;
+		let daemonPid: number | undefined;
+		try {
+			first.onCompletion(owner, () => {});
+			const started = await first.request({
+				op: "start",
+				spec: {
+					name: "attached-recovery-exit",
+					application: "/bin/sh",
+					args: ["-c", "sleep 30"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "no",
+					persist: false,
+					detached: false,
+				},
+				owner,
+			});
+			if (started.op !== "start" || started.daemon.pid === undefined) throw new Error("daemon did not start");
+			daemonPid = started.daemon.pid;
+			const { pid: brokerPid } = (await Bun.file(path.join(runtimeDir, "broker.pid")).json()) as { pid: number };
+			process.kill(brokerPid, "SIGKILL");
+			expect(await waitUntil(() => !processExists(brokerPid), 3_000)).toBeTrue();
+			first.close();
+
+			recovered = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+			const completions: DaemonSnapshot[] = [];
+			unregister = recovered.onCompletion(owner, notification => {
+				completions.push(notification.daemon);
+			});
+			await recovered.request({ op: "list" });
+
+			expect(await waitUntil(() => completions.length === 1, 3_000)).toBeTrue();
+			expect(completions[0]).toMatchObject({ name: "attached-recovery-exit", state: "exited" });
+		} finally {
+			unregister?.();
+			first.close();
+			if (recovered) await shutdown(recovered);
+			if (daemonPid !== undefined && processExists(daemonPid)) process.kill(daemonPid, "SIGKILL");
+		}
+	}, 12_000);
+
 	// Regression: a start whose log pattern matched but whose port never accepted
 	// used to report "Ready: <match>" AND "Readiness timed out" with no hint of
 	// which condition failed. The snapshot now names the unmet condition(s).
@@ -704,4 +1004,688 @@ esac
 			await shutdown(client);
 		}
 	}, 30_000);
+	it("delivers owner completions for spontaneous final exits only", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-completion-project-");
+		const runtimeDir = await tempDir("omp-daemon-completion-runtime-");
+		const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const owner = "completion-owner";
+		const completions: DaemonSnapshot[] = [];
+		let resolveNext: ((daemon: DaemonSnapshot) => void) | undefined;
+		const nextCompletion = (): Promise<DaemonSnapshot> => {
+			const { promise, resolve } = Promise.withResolvers<DaemonSnapshot>();
+			resolveNext = resolve;
+			return promise;
+		};
+		const unregister = client.onCompletion(owner, notification => {
+			completions.push(notification.daemon);
+			resolveNext?.(notification.daemon);
+			resolveNext = undefined;
+		});
+		const startSpec = (name: string, command: string, restart: DaemonSpec["restart"]): DaemonSpec => ({
+			name,
+			application: "/bin/sh",
+			args: ["-c", command],
+			env: {},
+			cwd: projectDir,
+			pty: false,
+			restart,
+			persist: false,
+			detached: false,
+		});
+		try {
+			const successPending = nextCompletion();
+			await client.request({
+				op: "start",
+				spec: startSpec("success", "exit 0", "no"),
+				owner,
+			});
+			const success = await successPending;
+			expect(success.state).toBe("exited");
+			expect(success.exitCode).toBe(0);
+			await client.request({ op: "list" });
+			expect(completions).toHaveLength(1);
+			const failurePending = nextCompletion();
+			await client.request({
+				op: "start",
+				spec: startSpec("failure", "exit 7", "no"),
+				owner,
+			});
+			const failure = await failurePending;
+			expect(failure.state).toBe("failed");
+			expect(failure.exitCode).toBe(7);
+
+			const beforeExplicitRestart = completions.length;
+			await client.request({
+				op: "start",
+				spec: startSpec("explicit-restart", "while true; do sleep 1; done", "no"),
+				owner,
+			});
+			await client.request({ op: "restart", name: "explicit-restart" });
+			expect(completions).toHaveLength(beforeExplicitRestart);
+			await client.request({ op: "stop", name: "explicit-restart", timeoutMs: 2_000 });
+			expect(completions).toHaveLength(beforeExplicitRestart);
+
+			const beforeRestart = completions.length;
+			await client.request({
+				op: "start",
+				spec: startSpec("restart", "exit 0", "always"),
+				owner,
+			});
+			const restarting = await waitUntil(async () => {
+				const listed = await client.request({ op: "list" });
+				if (listed.op !== "list") return false;
+				return listed.daemons.find(daemon => daemon.name === "restart")?.state === "restarting";
+			}, 3_000);
+			expect(restarting).toBeTrue();
+			expect(completions).toHaveLength(beforeRestart);
+			await client.request({ op: "stop", name: "restart", timeoutMs: 2_000 });
+			expect(completions).toHaveLength(beforeRestart);
+		} finally {
+			unregister();
+			await shutdown(client);
+		}
+	}, 9_000);
+
+	it("acknowledges a completion only after its consumer accepts delivery", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-sink-acceptance-project-");
+		const runtimeDir = await tempDir("omp-daemon-sink-acceptance-runtime-");
+		const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const owner = "delayed-owner";
+		const delivered = Promise.withResolvers<void>();
+		const accepted = Promise.withResolvers<void>();
+		const unregister = client.onCompletion(owner, async () => {
+			delivered.resolve();
+			await accepted.promise;
+		});
+		const metaPath = path.join(runtimeDir, "daemons", "delayed-sink", "meta.json");
+		try {
+			await client.request({
+				op: "start",
+				spec: {
+					name: "delayed-sink",
+					application: "/bin/sh",
+					args: ["-c", "exit 0"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "no",
+					persist: false,
+					detached: false,
+				},
+				owner,
+			});
+			await delivered.promise;
+			const pending = (await Bun.file(metaPath).json()) as { pendingCompletions?: unknown[] };
+			expect(pending.pendingCompletions).toHaveLength(1);
+
+			accepted.resolve();
+			expect(
+				await waitUntil(async () => {
+					const metadata = (await Bun.file(metaPath).json()) as { pendingCompletions?: unknown[] };
+					return metadata.pendingCompletions?.length === 0;
+				}, 2_000),
+			).toBeTrue();
+		} finally {
+			unregister();
+			await shutdown(client);
+		}
+	}, 9_000);
+
+	it("replays an unacknowledged completion after the owner reconnects", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-reconnect-project-");
+		const runtimeDir = await tempDir("omp-daemon-reconnect-runtime-");
+		const owner = "reconnect-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		first.onCompletion(owner, () => {});
+		await first.request({
+			op: "start",
+			spec: {
+				name: "gap-exit",
+				application: "/bin/sh",
+				args: ["-c", "sleep 0.2; exit 7"],
+				env: {},
+				cwd: projectDir,
+				pty: false,
+				restart: "no",
+				persist: false,
+				detached: false,
+			},
+			owner,
+		});
+		first.close();
+		await Bun.sleep(400);
+
+		const second = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const completions: DaemonSnapshot[] = [];
+		const received = Promise.withResolvers<void>();
+		const unregister = second.onCompletion(owner, notification => {
+			completions.push(notification.daemon);
+			received.resolve();
+		});
+		try {
+			await second.request({ op: "list" });
+			await received.promise;
+			await second.request({ op: "list" });
+			expect(completions).toHaveLength(1);
+			expect(completions[0]).toMatchObject({ name: "gap-exit", state: "failed", exitCode: 7 });
+		} finally {
+			unregister();
+			await shutdown(second);
+		}
+	}, 9_000);
+	it("prevents daemon name reuse until pending completions are acknowledged", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-pending-name-project-");
+		const runtimeDir = await tempDir("omp-daemon-pending-name-runtime-");
+		const owner = "pending-name-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		first.onCompletion(owner, () => {});
+		const spec = {
+			name: "pending-name",
+			application: "/bin/sh",
+			args: ["-c", "sleep 0.2; exit 0"],
+			env: {},
+			cwd: projectDir,
+			pty: false,
+			restart: "no" as const,
+			persist: false,
+			detached: false,
+		};
+		await first.request({ op: "start", spec, owner });
+		first.close();
+		await Bun.sleep(400);
+
+		const second = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		let unregister: (() => void) | undefined;
+		try {
+			await expect(second.request({ op: "start", spec })).rejects.toThrow(
+				"Daemon pending-name has unacknowledged completion notifications",
+			);
+			const received = Promise.withResolvers<void>();
+			unregister = second.onCompletion(owner, () => received.resolve());
+			await second.request({ op: "list" });
+			await received.promise;
+			await second.request({ op: "list" });
+			const restarted = await second.request({ op: "start", spec });
+			expect(restarted).toMatchObject({ op: "start", daemon: { name: "pending-name" } });
+		} finally {
+			unregister?.();
+			await shutdown(second);
+		}
+	}, 9_000);
+	it("publishes a restored owner subscription without another caller request", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-restored-owner-project-");
+		const runtimeDir = await tempDir("omp-daemon-restored-owner-runtime-");
+		const owner = "restored-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const second = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		let completion: DaemonSnapshot | undefined;
+		let unregister: (() => void) | undefined;
+		try {
+			await first.request({
+				op: "start",
+				spec: {
+					name: "restored-owner-exit",
+					application: "/bin/sh",
+					args: ["-c", "sleep 0.3; exit 0"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "no",
+					persist: false,
+					detached: false,
+				},
+				owner,
+			});
+			await second.request({ op: "ping" });
+			unregister = second.onCompletion(owner, notification => {
+				completion = notification.daemon;
+			});
+
+			expect(await waitUntil(() => completion !== undefined, 3_000)).toBeTrue();
+			expect(completion).toMatchObject({ name: "restored-owner-exit", state: "exited", exitCode: 0 });
+		} finally {
+			unregister?.();
+			first.close();
+			await shutdown(second);
+		}
+	}, 9_000);
+
+	it("ignores an unsubscribe from a superseded owner subscription", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-superseded-owner-project-");
+		const runtimeDir = await tempDir("omp-daemon-superseded-owner-runtime-");
+		const owner = "shared-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const second = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const unregisterFirst = first.onCompletion(owner, () => {});
+		let unregisterSecond: (() => void) | undefined;
+		let completion: DaemonSnapshot | undefined;
+		try {
+			await first.request({
+				op: "start",
+				spec: {
+					name: "superseded-owner-exit",
+					application: "/bin/sh",
+					args: ["-c", "sleep 1; exit 0"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "no",
+					persist: false,
+					detached: false,
+				},
+				owner,
+			});
+			const metaPath = path.join(runtimeDir, "daemons", "superseded-owner-exit", "meta.json");
+			const firstMetadata = (await Bun.file(metaPath).json()) as { completionSubscriptionId?: string };
+			if (!firstMetadata.completionSubscriptionId)
+				throw new Error("first completion subscription was not persisted");
+			unregisterSecond = second.onCompletion(owner, notification => {
+				completion = notification.daemon;
+			});
+			const replacementSubscriptionId = crypto.randomUUID();
+			await publishCompletionOwner(projectDir, runtimeDir, owner, replacementSubscriptionId);
+			const replacementMetadata = (await Bun.file(metaPath).json()) as {
+				completionEvents?: boolean;
+				completionSubscriptionId?: string;
+			};
+			expect(replacementMetadata).toMatchObject({
+				completionEvents: true,
+				completionSubscriptionId: replacementSubscriptionId,
+			});
+			await second.request({ op: "ping" });
+			await publishCompletionOwner(projectDir, runtimeDir, owner, firstMetadata.completionSubscriptionId, [
+				"stale-completion",
+			]);
+			unregisterFirst();
+
+			expect(await waitUntil(() => completion !== undefined, 3_000)).toBeTrue();
+			expect(completion).toMatchObject({ name: "superseded-owner-exit", state: "exited", exitCode: 0 });
+		} finally {
+			unregisterFirst();
+			unregisterSecond?.();
+			first.close();
+			await shutdown(second);
+		}
+	}, 9_000);
+	it("preserves a superseding owner subscription through broker recovery", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-recovered-subscription-project-");
+		const runtimeDir = await tempDir("omp-daemon-recovered-subscription-runtime-");
+		const owner = "recovered-shared-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const second = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const unregisterFirst = first.onCompletion(owner, () => {});
+		let unregisterSecond: (() => void) | undefined;
+		let completion: DaemonSnapshot | undefined;
+		let pid: number | undefined;
+		try {
+			await first.request({ op: "ping" });
+			unregisterSecond = second.onCompletion(owner, notification => {
+				completion = notification.daemon;
+			});
+			const started = await second.request({
+				op: "start",
+				spec: {
+					name: "recovered-superseded-owner-exit",
+					application: "/bin/sh",
+					args: ["-c", "sleep 1.5; exit 0"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "no",
+					persist: false,
+					detached: true,
+				},
+				owner,
+			});
+			if (started.op !== "start" || started.daemon.pid === undefined) {
+				throw new Error("detached daemon did not start");
+			}
+			pid = started.daemon.pid;
+			const metaPath = path.join(runtimeDir, "daemons", "recovered-superseded-owner-exit", "meta.json");
+			const beforeRecovery = (await Bun.file(metaPath).json()) as { completionSubscriptionId?: string };
+			expect(beforeRecovery.completionSubscriptionId).toBeString();
+
+			await second.request({ op: "shutdown" });
+			expect(
+				await waitUntil(
+					() =>
+						Bun.file(path.join(runtimeDir, "broker.pid"))
+							.exists()
+							.then(exists => !exists),
+					5_000,
+				),
+			).toBeTrue();
+
+			unregisterFirst();
+			await first.request({ op: "ping" });
+			const afterStaleUnsubscribe = (await Bun.file(metaPath).json()) as {
+				completionEvents?: boolean;
+				completionSubscriptionId?: string;
+			};
+			expect(afterStaleUnsubscribe).toMatchObject({
+				completionEvents: true,
+				completionSubscriptionId: beforeRecovery.completionSubscriptionId,
+			});
+			first.close();
+
+			expect(await waitUntil(() => pid !== undefined && !processExists(pid), 4_000)).toBeTrue();
+			await second.request({ op: "list" });
+			expect(await waitUntil(() => completion !== undefined, 2_000)).toBeTrue();
+			expect(completion).toMatchObject({
+				name: "recovered-superseded-owner-exit",
+				state: "exited",
+			});
+		} finally {
+			unregisterFirst();
+			unregisterSecond?.();
+			first.close();
+			await shutdown(second);
+			if (pid !== undefined && processExists(pid)) {
+				const rescue = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 1_000 });
+				try {
+					await rescue.request({ op: "stop", name: "recovered-superseded-owner-exit", timeoutMs: 2_000 });
+				} finally {
+					await shutdown(rescue);
+				}
+			}
+		}
+	}, 15_000);
+
+	it("clears an owner unsubscribed after a transport reconnect", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-unsubscribe-project-");
+		const runtimeDir = await tempDir("omp-daemon-unsubscribe-runtime-");
+		const owner = "unsubscribed-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 200 });
+		let second: DaemonBrokerClient | undefined;
+		try {
+			first.onCompletion(owner, () => {});
+			await first.request({
+				op: "start",
+				spec: {
+					name: "unsubscribe-gap",
+					application: "/bin/sh",
+					args: ["-c", "sleep 0.4; exit 0"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "no",
+					persist: false,
+					detached: false,
+				},
+				owner,
+			});
+			first.close();
+
+			second = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 200 });
+			const unregister = second.onCompletion(owner, () => {});
+			unregister();
+			await second.request({ op: "ping" });
+			expect(
+				await waitUntil(async () => {
+					const listed = await second!.request({ op: "list" });
+					return listed.op === "list" && listed.daemons[0]?.state === "exited";
+				}, 3_000),
+			).toBeTrue();
+			second.close();
+
+			expect(
+				await waitUntil(
+					() =>
+						Bun.file(path.join(runtimeDir, "broker.sock"))
+							.exists()
+							.then(exists => !exists),
+					3_000,
+				),
+			).toBeTrue();
+		} finally {
+			first.close();
+			second?.close();
+			if (await Bun.file(path.join(runtimeDir, "broker.sock")).exists()) {
+				const rescue = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 200 });
+				await shutdown(rescue);
+			}
+		}
+	}, 12_000);
+
+	it("preserves an owner's pending completion while its sink is detached", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-preserve-owner-project-");
+		const runtimeDir = await tempDir("omp-daemon-preserve-owner-runtime-");
+		const owner = "preserved-owner";
+		const client = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 200 });
+		const unregister = client.onCompletion(owner, () => {});
+		let recovered: DaemonBrokerClient | undefined;
+		try {
+			await client.request({
+				op: "start",
+				spec: {
+					name: "preserved-owner-exit",
+					application: "/bin/sh",
+					args: ["-c", "sleep 0.2; exit 0"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "no",
+					persist: false,
+					detached: false,
+				},
+				owner,
+			});
+			unregister({ preservePending: true });
+			expect(
+				await waitUntil(async () => {
+					const listed = await client.request({ op: "list" });
+					return listed.op === "list" && listed.daemons[0]?.state === "exited";
+				}, 3_000),
+			).toBeTrue();
+
+			client.close();
+			expect(
+				await waitUntil(
+					() =>
+						Bun.file(path.join(runtimeDir, "broker.sock"))
+							.exists()
+							.then(exists => !exists),
+					3_000,
+				),
+			).toBeTrue();
+
+			recovered = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 200 });
+			const received = Promise.withResolvers<void>();
+			const unregisterRecovered = recovered.onCompletion(owner, () => received.resolve());
+			try {
+				await recovered.request({ op: "list" });
+				await received.promise;
+			} finally {
+				unregisterRecovered();
+			}
+		} finally {
+			client.close();
+			recovered?.close();
+			if (await Bun.file(path.join(runtimeDir, "broker.sock")).exists()) {
+				const rescue = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 200 });
+				await shutdown(rescue);
+			}
+		}
+	}, 12_000);
+
+	it("does not let a detached client reclaim a resumed owner", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-detached-owner-project-");
+		const runtimeDir = await tempDir("omp-daemon-detached-owner-runtime-");
+		const owner = "resumed-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const second = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const unregisterFirst = first.onCompletion(owner, () => {});
+		let unregisterSecond: (() => void) | undefined;
+		let completion: DaemonSnapshot | undefined;
+		try {
+			await first.request({
+				op: "start",
+				spec: {
+					name: "resumed-owner-exit",
+					application: "/bin/sh",
+					args: ["-c", "sleep 0.5; exit 0"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "no",
+					persist: false,
+					detached: false,
+				},
+				owner,
+			});
+			unregisterFirst({ preservePending: true });
+			unregisterSecond = second.onCompletion(owner, notification => {
+				completion = notification.daemon;
+			});
+			await second.request({ op: "ping" });
+			await first.request({ op: "ping" });
+
+			expect(await waitUntil(() => completion !== undefined, 3_000)).toBeTrue();
+			expect(completion).toMatchObject({ name: "resumed-owner-exit", state: "exited", exitCode: 0 });
+		} finally {
+			unregisterFirst();
+			unregisterSecond?.();
+			first.close();
+			await shutdown(second);
+		}
+	}, 9_000);
+	it("drops a completion when its owner unsubscribes during settlement", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-settle-unsubscribe-project-");
+		const runtimeDir = await tempDir("omp-daemon-settle-unsubscribe-runtime-");
+		const owner = "settle-unsubscribe-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 200 });
+		const unregister = first.onCompletion(owner, () => {});
+		try {
+			await first.request({
+				op: "start",
+				spec: {
+					name: "settle-unsubscribe",
+					application: "/bin/sh",
+					args: ["-c", "i=0; while [ $i -lt 20000 ]; do echo x; i=$((i+1)); done"],
+					env: {},
+					cwd: projectDir,
+					pty: false,
+					restart: "no",
+					persist: false,
+					detached: false,
+				},
+				owner,
+			});
+			expect(
+				await waitUntil(async () => {
+					const listed = await first.request({ op: "list" });
+					return listed.op === "list" && listed.daemons[0]?.state === "exited";
+				}, 5_000),
+			).toBeTrue();
+			unregister();
+			await first.request({ op: "ping" });
+			first.close();
+			expect(
+				await waitUntil(
+					() =>
+						Bun.file(path.join(runtimeDir, "broker.sock"))
+							.exists()
+							.then(exists => !exists),
+					3_000,
+				),
+			).toBeTrue();
+		} finally {
+			unregister();
+			first.close();
+			if (await Bun.file(path.join(runtimeDir, "broker.sock")).exists()) {
+				const rescue = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 200 });
+				await shutdown(rescue);
+			}
+		}
+	}, 12_000);
+	it("does not retain completions for owners that did not advertise event support", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-legacy-owner-project-");
+		const runtimeDir = await tempDir("omp-daemon-legacy-owner-runtime-");
+		const owner = "legacy-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		await first.request({
+			op: "start",
+			spec: {
+				name: "legacy-exit",
+				application: "/bin/sh",
+				args: ["-c", "exit 7"],
+				env: {},
+				cwd: projectDir,
+				pty: false,
+				restart: "no",
+				persist: false,
+				detached: false,
+			},
+			owner,
+		});
+		first.close();
+		await Bun.sleep(200);
+
+		const second = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const completions: DaemonSnapshot[] = [];
+		const unregister = second.onCompletion(owner, notification => {
+			completions.push(notification.daemon);
+		});
+		try {
+			await second.request({ op: "list" });
+			await Bun.sleep(100);
+			expect(completions).toEqual([]);
+		} finally {
+			unregister();
+			await shutdown(second);
+		}
+	}, 9_000);
+	it("does not replay a completion after the owner unsubscribes", async () => {
+		if (process.platform === "win32") return;
+		const projectDir = await tempDir("omp-daemon-unsubscribe-project-");
+		const runtimeDir = await tempDir("omp-daemon-unsubscribe-runtime-");
+		const owner = "unsubscribe-owner";
+		const first = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const unregisterFirst = first.onCompletion(owner, () => {});
+		await first.request({
+			op: "start",
+			spec: {
+				name: "unsubscribed-exit",
+				application: "/bin/sh",
+				args: ["-c", "sleep 0.3; exit 7"],
+				env: {},
+				cwd: projectDir,
+				pty: false,
+				restart: "no",
+				persist: false,
+				detached: false,
+			},
+			owner,
+		});
+		unregisterFirst();
+		await Bun.sleep(100);
+		first.close();
+		await Bun.sleep(300);
+
+		const second = await createDaemonBrokerClient(projectDir, { runtimeDir, idleGraceMs: 5_000 });
+		const completions: DaemonSnapshot[] = [];
+		const unregisterSecond = second.onCompletion(owner, notification => {
+			completions.push(notification.daemon);
+		});
+		try {
+			await second.request({ op: "list" });
+			await Bun.sleep(100);
+			expect(completions).toEqual([]);
+		} finally {
+			unregisterSecond();
+			await shutdown(second);
+		}
+	}, 9_000);
 });


### PR DESCRIPTION
A session waiting on supervised work could remain asleep when a daemon exited while the owner was disconnected. Repeated daemon generations could also collapse into one completion before the owner acknowledged them.

Persist an immutable completion snapshot for every unacknowledged daemon generation. Wake the owning session when supervised processes exit, replay all pending completions after broker recovery, and remove only the exact generation the owner acknowledges.