### PR TITLE
feat(rpc): give RPC mode a durable per-session ledger

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -816,6 +816,8 @@ export interface UserMessage {
 	steering?: boolean;
 	/** Who initiated this message for billing/attribution semantics. */
 	attribution?: MessageAttribution;
+	/** Stable key used to suppress duplicate delivery at a durable injection boundary. */
+	idempotencyKey?: string;
 	/** Provider-specific opaque payload used to reconstruct transport-native history. */
 	providerPayload?: ProviderPayload;
 	timestamp: number; // Unix timestamp in milliseconds

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,9 @@
 - Fixed issues with `/btw` branch promotion where branches could park behind active turns, cut from outdated session leaves, or leave rejected branch keys indistinguishable from composer input.
 - Fixed database bloat by ensuring archived main and nested session rows are properly cleaned up from `stats.db` during garbage collection.
 - Fixed startup hanging during local model discovery when a timed-out transport left its request pending, which blocked the CLI before OAuth login could finish ([#7482](https://github.com/can1357/oh-my-pi/issues/7482)).
+### Added
+
+- Added `session.start`, `session.resume`, `session.replay`, `session.result`, `session.steer`, and `session.watch` to RPC mode, giving an external supervisor a durable append-only record of a session beside its transcript. A run claims an identity so a retried dispatch resolves against the existing episode instead of launching a second one, events carry a sequence a reconnecting supervisor can replay from, steering is acknowledged and redelivered when it was accepted but never injected, and the terminal result is sealed once and returned identically to every later reader. Clients that do not send `session.start` or `session.resume` are unaffected: nothing is recorded and events stream as before.
 
 ## [17.2.5] - 2026-08-03
 

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -78,6 +78,8 @@ export interface AdvisorRuntimeHost {
 	 *  recovery (credential switch, fallback chain) declined. Cleared only by
 	 *  an explicit reset (`/new`, config rebuild, session restart). */
 	notifyQuotaExhausted?(): void;
+	/** Notify the host after backlog custody can have changed. */
+	onBacklogChange?(): void;
 	/** Stable identity for the live advisor model. Used to restore full transcript rendering after a model switch. */
 	getModelIdentity?(): string;
 }
@@ -689,12 +691,14 @@ export class AdvisorRuntime {
 				w.finish(true);
 			}
 		}
+		this.host.onBacklogChange?.();
 	}
 
 	#wakeAllWaiters(): void {
 		for (const w of [...this.#waiters]) {
 			w.finish(false);
 		}
+		this.host.onBacklogChange?.();
 	}
 
 	/**

--- a/packages/coding-agent/src/mcp/tool-cache.ts
+++ b/packages/coding-agent/src/mcp/tool-cache.ts
@@ -3,7 +3,7 @@
  *
  * Stores tool definitions per server in agent.db for fast startup.
  */
-import { isRecord, logger } from "@oh-my-pi/pi-utils";
+import { canonicalJsonStringify, isRecord, logger } from "@oh-my-pi/pi-utils";
 import type { AgentStorage } from "../session/agent-storage";
 import type { MCPServerConfig, MCPToolDefinition } from "./types";
 
@@ -17,24 +17,6 @@ type MCPToolCachePayload = {
 	tools: MCPToolDefinition[];
 };
 
-function stableClone(value: unknown): unknown {
-	if (Array.isArray(value)) {
-		return value.map(item => stableClone(item));
-	}
-	if (isRecord(value)) {
-		const sorted: Record<string, unknown> = {};
-		for (const key of Object.keys(value).sort()) {
-			sorted[key] = stableClone(value[key]);
-		}
-		return sorted;
-	}
-	return value;
-}
-
-function stableStringify(value: unknown): string {
-	return JSON.stringify(stableClone(value));
-}
-
 function toHex(buffer: ArrayBuffer): string {
 	const bytes = new Uint8Array(buffer);
 	let output = "";
@@ -45,7 +27,7 @@ function toHex(buffer: ArrayBuffer): string {
 }
 
 async function hashConfig(config: MCPServerConfig): Promise<string> {
-	const stable = stableStringify(config);
+	const stable = canonicalJsonStringify(config);
 	const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(stable));
 	return toHex(digest);
 }

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -11,7 +11,7 @@ import type { ImageContent, Model } from "@oh-my-pi/pi-ai";
 import { isRecord, ptree, readJsonl } from "@oh-my-pi/pi-utils";
 import type { FileSink } from "bun";
 import type { BashResult } from "../../exec/bash-executor";
-import type { AgentSessionEvent, SessionStats } from "../../session/agent-session";
+import type { SessionStats } from "../../session/agent-session";
 import { MAX_RPC_FRAME_BYTES, MAX_RPC_REASSEMBLED_BYTES, RpcFrameDecoder, type RpcProtocolVersion } from "./rpc-frame";
 import {
 	RPC_MESSAGES_PAGE_BUSY_ERROR,
@@ -20,6 +20,7 @@ import {
 	type RpcMessagesPageOptions,
 } from "./rpc-messages";
 import type {
+	RpcAgentEventPayload,
 	RpcAvailableCommandsUpdateFrame,
 	RpcAvailableSlashCommand,
 	RpcCommand,
@@ -32,7 +33,11 @@ import type {
 	RpcHostToolResult,
 	RpcHostToolUpdate,
 	RpcResponse,
+	RpcSessionEventFrame,
+	RpcSessionResult,
+	RpcSessionStartData,
 	RpcSessionState,
+	RpcSessionSteerAck,
 	RpcSubagentEventFrame,
 	RpcSubagentLifecycleFrame,
 	RpcSubagentMessagesResult,
@@ -69,7 +74,7 @@ export interface RpcClientOptions {
 export type ModelInfo = Pick<Model, "provider" | "id" | "contextWindow" | "reasoning" | "thinking">;
 
 export type RpcEventListener = (event: AgentEvent) => void;
-export type RpcSessionEventListener = (event: AgentSessionEvent) => void;
+export type RpcSessionEventListener = (event: RpcAgentEventPayload) => void;
 export type RpcSubagentLifecycleListener = (payload: RpcSubagentLifecycleFrame["payload"]) => void;
 export type RpcSubagentProgressListener = (payload: RpcSubagentProgressFrame["payload"]) => void;
 export type RpcSubagentEventListener = (payload: RpcSubagentEventFrame["payload"]) => void;
@@ -114,7 +119,7 @@ const agentEventTypes = new Set<AgentEvent["type"]>([
 	"tool_execution_end",
 ]);
 
-const sessionEventTypes = new Set<AgentSessionEvent["type"]>([
+const sessionEventTypes = new Set<RpcAgentEventPayload["type"]>([
 	...agentEventTypes,
 	"auto_compaction_start",
 	"auto_compaction_end",
@@ -130,6 +135,10 @@ const sessionEventTypes = new Set<AgentSessionEvent["type"]>([
 	"thinking_level_changed",
 	"model_changed",
 	"goal_updated",
+	"steering_queued",
+	"steering_injected",
+	"steering_rejected",
+	"session_terminal",
 ]);
 
 function isRpcResponse(value: unknown): value is RpcResponse {
@@ -161,11 +170,11 @@ function isAgentEvent(value: unknown): value is AgentEvent {
 	return agentEventTypes.has(type as AgentEvent["type"]);
 }
 
-function isAgentSessionEvent(value: unknown): value is AgentSessionEvent {
+function isAgentSessionEvent(value: unknown): value is RpcAgentEventPayload {
 	if (!isRecord(value)) return false;
 	const type = value.type;
 	if (typeof type !== "string") return false;
-	return sessionEventTypes.has(type as AgentSessionEvent["type"]);
+	return sessionEventTypes.has(type as RpcAgentEventPayload["type"]);
 }
 
 function isRpcSubagentLifecycleFrame(value: unknown): value is RpcSubagentLifecycleFrame {
@@ -590,6 +599,60 @@ export class RpcClient {
 	 */
 	async newSession(parentSession?: string): Promise<{ cancelled: boolean }> {
 		const response = await this.#send({ type: "new_session", parentSession });
+		return this.#getData(response);
+	}
+	async startSession(runId: string): Promise<RpcSessionStartData> {
+		const response = await this.#send({ type: "session.start", run_id: runId });
+		return this.#getData(response);
+	}
+
+	async resumeSession(
+		runId: string,
+		options: { sessionId?: string; afterSequence?: number } = {},
+	): Promise<RpcSessionStartData> {
+		const response = await this.#send({
+			type: "session.resume",
+			run_id: runId,
+			session_id: options.sessionId,
+			after_sequence: options.afterSequence,
+		});
+		return this.#getData(response);
+	}
+
+	async replaySession(
+		options: { afterSequence?: number; limit?: number } = {},
+	): Promise<{ events: RpcSessionEventFrame[]; next_sequence: number; has_more: boolean }> {
+		const response = await this.#send({
+			type: "session.replay",
+			after_sequence: options.afterSequence,
+			limit: options.limit,
+		});
+		return this.#getData(response);
+	}
+
+	async watchSession(
+		options: { afterSequence?: number; limit?: number } = {},
+	): Promise<{ events: RpcSessionEventFrame[]; next_sequence: number; has_more: boolean }> {
+		const response = await this.#send({
+			type: "session.watch",
+			after_sequence: options.afterSequence,
+			limit: options.limit,
+		});
+		return this.#getData(response);
+	}
+
+	async getSessionResult(timeoutMs = 0): Promise<RpcSessionResult> {
+		const response = await this.#send({ type: "session.result" }, timeoutMs);
+		return this.#getData(response);
+	}
+
+	async steerSession(steeringId: string, message: string, images?: ImageContent[]): Promise<RpcSessionSteerAck> {
+		const response = await this.#send({
+			type: "session.steer",
+			steering_id: steeringId,
+			message,
+			images,
+		});
 		return this.#getData(response);
 	}
 
@@ -1094,14 +1157,19 @@ export class RpcClient {
 		const fullCommand = { ...command, id } as RpcCommand;
 		const { promise, resolve, reject } = Promise.withResolvers<RpcResponse>();
 		let settled = false;
-		const timeoutId = this.#startTimeout(timeoutMs, () => {
-			if (settled) return;
-			this.#pendingRequests.delete(id);
-			settled = true;
-			reject(
-				new Error(`Timeout waiting for response to ${command.type}. Stderr: ${this.#process?.peekStderr() ?? ""}`),
-			);
-		});
+		const timeoutId =
+			timeoutMs > 0
+				? this.#startTimeout(timeoutMs, () => {
+						if (settled) return;
+						this.#pendingRequests.delete(id);
+						settled = true;
+						reject(
+							new Error(
+								`Timeout waiting for response to ${command.type}. Stderr: ${this.#process?.peekStderr() ?? ""}`,
+							),
+						);
+					})
+				: undefined;
 
 		this.#pendingRequests.set(id, {
 			resolve: response => {

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -32,6 +32,7 @@ import type {
 	RpcHostToolDefinition,
 	RpcHostToolResult,
 	RpcHostToolUpdate,
+	RpcPublishedAgentEvent,
 	RpcResponse,
 	RpcSessionEventFrame,
 	RpcSessionResult,
@@ -74,7 +75,7 @@ export interface RpcClientOptions {
 export type ModelInfo = Pick<Model, "provider" | "id" | "contextWindow" | "reasoning" | "thinking">;
 
 export type RpcEventListener = (event: AgentEvent) => void;
-export type RpcSessionEventListener = (event: RpcAgentEventPayload) => void;
+export type RpcSessionEventListener = (event: RpcPublishedAgentEvent) => void;
 export type RpcSubagentLifecycleListener = (payload: RpcSubagentLifecycleFrame["payload"]) => void;
 export type RpcSubagentProgressListener = (payload: RpcSubagentProgressFrame["payload"]) => void;
 export type RpcSubagentEventListener = (payload: RpcSubagentEventFrame["payload"]) => void;

--- a/packages/coding-agent/src/modes/rpc/rpc-harness-claim-child.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-harness-claim-child.ts
@@ -1,0 +1,16 @@
+import { RpcHarnessSessionOwner } from "./rpc-harness";
+
+try {
+	const owner = await RpcHarnessSessionOwner.open(
+		process.env.RPC_SESSION_ID ?? "",
+		process.env.RPC_RECORD_FILE ?? "",
+		undefined,
+		process.env.RPC_RUN_INDEX_FILE ?? "",
+	);
+	const result = await owner.bindRun(process.env.RPC_RUN_ID ?? "run-1");
+	console.log(JSON.stringify({ ok: true, existing: result.existing, sessionId: result.sessionId }));
+	await Bun.sleep(200);
+	await owner.dispose();
+} catch (error) {
+	console.log(JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) }));
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-harness.test.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-harness.test.ts
@@ -1,0 +1,683 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ImageContent } from "@oh-my-pi/pi-ai";
+import {
+	type RpcHarnessPublishedEvent,
+	type RpcHarnessResult,
+	RpcHarnessSessionOwner,
+	rpcHarnessRecordFileForSessionFile,
+	rpcSteeringPayloadIdentity,
+} from "./rpc-harness";
+
+let tmp = "";
+
+beforeEach(async () => {
+	tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-harness-"));
+});
+
+afterEach(async () => {
+	await fs.rm(tmp, { recursive: true, force: true });
+});
+
+function recordFile(sessionId = "session"): string {
+	return path.join(tmp, sessionId, "rpc-ledger", "events.jsonl");
+}
+
+function runIndexFile(): string {
+	return path.join(tmp, "rpc-runs.jsonl");
+}
+
+function usage() {
+	return { input: 10, output: 4, reasoning: 1, cacheRead: 2, cacheWrite: 3, total: 14 };
+}
+
+async function claimRunInChild(
+	sessionId: string,
+	recordFilePath: string,
+	runIndexPath: string,
+	runId = "run-1",
+): Promise<{
+	ok: boolean;
+	existing?: boolean;
+	sessionId?: string;
+	error?: string;
+}> {
+	const child = Bun.spawn(["bun", path.join(import.meta.dir, "rpc-harness-claim-child.ts")], {
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+		env: {
+			...process.env,
+			RPC_SESSION_ID: sessionId,
+			RPC_RECORD_FILE: recordFilePath,
+			RPC_RUN_INDEX_FILE: runIndexPath,
+			RPC_RUN_ID: runId,
+		},
+	});
+	const [output, exitCode] = await Promise.all([new Response(child.stdout).text(), child.exited]);
+	if (exitCode !== 0) throw new Error(`run claim child exited with ${exitCode}`);
+	return JSON.parse(output.trim()) as {
+		ok: boolean;
+		existing?: boolean;
+		sessionId?: string;
+		error?: string;
+	};
+}
+
+describe("RPC harness session owner", () => {
+	it("derives the record path from the transcript path", () => {
+		expect(rpcHarnessRecordFileForSessionFile(path.join(tmp, "20260101-120000_abc.jsonl"))).toBe(
+			path.join(tmp, "20260101-120000_abc", "rpc-ledger", "events.jsonl"),
+		);
+		expect(rpcHarnessRecordFileForSessionFile(path.join(tmp, "transcript"))).toBe(
+			path.join(tmp, "transcript.d", "rpc-ledger", "events.jsonl"),
+		);
+	});
+
+	it("assigns monotonic event sequences and replays durable events", async () => {
+		const file = recordFile();
+		const owner = await RpcHarnessSessionOwner.open("session-1", file);
+		const first = await owner.appendEvent({ type: "notice", level: "info", message: "first" });
+		const second = await owner.appendEvent({ type: "notice", level: "info", message: "second" });
+		expect([first.sequence, second.sequence]).toEqual([1, 2]);
+
+		const reopened = await RpcHarnessSessionOwner.open("session-1", file);
+		const replay = await reopened.replay(first.sequence);
+		expect(replay.map(event => [event.sequence, "message" in event ? event.message : ""])).toEqual([[2, "second"]]);
+	});
+
+	it("persists a safe event while publishing its display form", async () => {
+		const published: object[] = [];
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile(), event => published.push(event));
+		await owner.appendEvent(
+			{ type: "notice", level: "info", message: "$$HASH$$" },
+			{ type: "notice", level: "info", message: "display secret" },
+		);
+
+		expect(await owner.replay()).toMatchObject([{ sequence: 1, message: "$$HASH$$" }]);
+		expect(published).toMatchObject([{ sequence: 1, message: "display secret" }]);
+	});
+
+	it("restores display values when reopening durable events", async () => {
+		const file = recordFile();
+		const owner = await RpcHarnessSessionOwner.open("session-1", file);
+		await owner.appendEvent({ type: "notice", level: "info", message: "$$HASH$$" });
+		await owner.dispose();
+
+		const reopened = await RpcHarnessSessionOwner.open("session-1", file, undefined, undefined, {
+			displayEvent: event =>
+				event.type === "notice"
+					? { ...event, message: event.message.replace("$$HASH$$", "display secret") }
+					: event,
+		});
+		expect(await reopened.replay()).toMatchObject([{ sequence: 1, message: "display secret" }]);
+		expect(await reopened.replayPersisted()).toMatchObject([{ sequence: 1, message: "$$HASH$$" }]);
+		expect(await Bun.file(file).text()).toContain("$$HASH$$");
+	});
+
+	it("returns the same immutable terminal result on every call", async () => {
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile());
+		const result = await owner.completeResult({
+			outcome: "completed",
+			stopReason: "finished",
+			finalMessage: "done",
+			usage: usage(),
+		});
+		const repeated = await owner.waitResult();
+		expect(repeated).toBe(result);
+		expect(repeated.resultId).toBe("session-1:result");
+		expect(repeated.terminalSequence).toBe(1);
+		expect(Object.isFrozen(repeated)).toBe(true);
+		const reopened = await RpcHarnessSessionOwner.open("session-1", recordFile());
+		expect(await reopened.waitResult()).toEqual(result);
+		expect(await reopened.replay()).toMatchObject([
+			{ type: "session_terminal", terminalSequence: 1, resultId: "session-1:result" },
+		]);
+	});
+
+	it("keeps terminal secrets obfuscated on disk while returning display text", async () => {
+		const file = recordFile();
+		const displayResult = (result: RpcHarnessResult) => ({
+			...result,
+			finalMessage: result.finalMessage.replace("$$HASH$$", "display secret"),
+		});
+		const owner = await RpcHarnessSessionOwner.open("session-1", file, undefined, undefined, { displayResult });
+		await owner.completeResult({
+			outcome: "completed",
+			stopReason: "finished",
+			finalMessage: "$$HASH$$",
+			usage: usage(),
+		});
+		expect((await owner.waitResult()).finalMessage).toBe("display secret");
+		expect(await fs.readFile(file, "utf8")).not.toContain("display secret");
+
+		const reopened = await RpcHarnessSessionOwner.open("session-1", file, undefined, undefined, { displayResult });
+		expect((await reopened.waitResult()).finalMessage).toBe("display secret");
+		const replayedTerminal = (await reopened.replay()).find(event => event.type === "session_terminal");
+		expect(replayedTerminal?.finalMessage).toBe("display secret");
+	});
+
+	it("rejects result waiters when ledger persistence fails", async () => {
+		const file = recordFile();
+		const owner = await RpcHarnessSessionOwner.open("session-1", file);
+		const result = owner.waitResult();
+		const observedResult = result.then(
+			() => undefined,
+			error => error,
+		);
+		await fs.mkdir(path.dirname(file), { recursive: true });
+		await fs.rm(path.dirname(file), { recursive: true });
+		await fs.writeFile(path.dirname(file), "blocks directory creation");
+
+		await expect(owner.appendEvent({ type: "notice", level: "info", message: "fail" })).rejects.toThrow();
+		expect(await observedResult).toBeInstanceOf(Error);
+		await expect(owner.waitResult()).rejects.toThrow();
+	});
+
+	it("stores terminal state in one recoverable record", async () => {
+		const file = recordFile();
+		const owner = await RpcHarnessSessionOwner.open("session-1", file);
+		await owner.completeResult({
+			outcome: "completed",
+			stopReason: "finished",
+			finalMessage: "done",
+			usage: usage(),
+		});
+		const records: unknown[] = (await fs.readFile(file, "utf8"))
+			.trim()
+			.split("\n")
+			.map(line => JSON.parse(line));
+		expect(records).toHaveLength(1);
+		expect(records[0]).toMatchObject({ kind: "terminal" });
+		const reopened = await RpcHarnessSessionOwner.open("session-1", file);
+		expect(reopened.hasResult).toBe(true);
+		expect(await reopened.replay()).toHaveLength(1);
+	});
+
+	it("recovers preceding records when the final record is torn", async () => {
+		const file = recordFile();
+		const owner = await RpcHarnessSessionOwner.open("session-1", file);
+		await owner.appendEvent({ type: "notice", level: "info", message: "kept" });
+		await fs.appendFile(file, '{"kind":"event"');
+
+		const reopened = await RpcHarnessSessionOwner.open("session-1", file);
+		expect(await reopened.replay()).toMatchObject([{ type: "notice", message: "kept" }]);
+		await reopened.appendEvent({ type: "notice", level: "info", message: "after repair" });
+
+		const repaired = await RpcHarnessSessionOwner.open("session-1", file);
+		expect((await repaired.replay()).map(event => event.type)).toEqual(["notice", "notice"]);
+	});
+
+	it("normalizes a valid unterminated record before appending", async () => {
+		const file = recordFile();
+		await fs.mkdir(path.dirname(file), { recursive: true });
+		await fs.writeFile(
+			file,
+			JSON.stringify({
+				kind: "event",
+				event: { type: "notice", level: "info", message: "kept", sequence: 1 },
+			}),
+		);
+
+		const reopened = await RpcHarnessSessionOwner.open("session-1", file);
+		await reopened.appendEvent({ type: "notice", level: "info", message: "after repair" });
+
+		const repaired = await RpcHarnessSessionOwner.open("session-1", file);
+		expect((await repaired.replay()).map(event => ("message" in event ? event.message : ""))).toEqual([
+			"kept",
+			"after repair",
+		]);
+	});
+
+	it("bounds replay pages and exposes the latest sequence", async () => {
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile());
+		await owner.appendEvent({ type: "notice", level: "info", message: "first" });
+		await owner.appendEvent({ type: "notice", level: "info", message: "second" });
+		expect(await owner.replay(0, 1)).toHaveLength(1);
+		expect(owner.latestSequence).toBe(2);
+		await expect(owner.replay(0, 1_001)).rejects.toThrow("limit must be an integer from 1 to 1000");
+	});
+
+	it("rejects conflicting run IDs and repeats the same binding idempotently", async () => {
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile("session-1"), undefined, runIndexFile());
+		expect(await owner.bindRun("run-1")).toEqual({ runId: "run-1", sessionId: "session-1", existing: false });
+		expect(await owner.bindRun("run-1")).toEqual({ runId: "run-1", sessionId: "session-1", existing: true });
+		await expect(owner.bindRun("run-2")).rejects.toThrow("already bound to run_id run-1");
+
+		const otherSession = await RpcHarnessSessionOwner.open(
+			"session-2",
+			recordFile("session-2"),
+			undefined,
+			runIndexFile(),
+		);
+		await expect(otherSession.bindRun("run-1")).rejects.toThrow("bound to session session-1");
+		const reopened = await RpcHarnessSessionOwner.open(
+			"session-1",
+			recordFile("session-1"),
+			undefined,
+			runIndexFile(),
+		);
+		await expect(reopened.bindRun("run-2")).rejects.toThrow("already bound to run_id run-1");
+		await Promise.all([owner.dispose(), otherSession.dispose(), reopened.dispose()]);
+	});
+
+	it("repairs a local run record after only the durable claim was published", async () => {
+		const file = recordFile("session-1");
+		const index = runIndexFile();
+		const claimFile = path.join(`${index}.locks`, Bun.SHA256.hash("run-1", "hex"));
+		await fs.mkdir(path.dirname(claimFile), { recursive: true });
+		await fs.writeFile(claimFile, "session-1");
+		const owner = await RpcHarnessSessionOwner.open("session-1", file, undefined, index);
+		await owner.bindRun("run-1");
+		await owner.dispose();
+
+		expect(await Bun.file(file).text()).toContain('"runId":"run-1"');
+		const reopened = await RpcHarnessSessionOwner.open("session-1", file, undefined, index);
+		await expect(reopened.bindRun("run-2")).rejects.toThrow("already bound to run_id run-1");
+		await reopened.dispose();
+	});
+
+	it("rejects a second live owner and allows takeover after release", async () => {
+		const file = recordFile("session-1");
+		const index = runIndexFile();
+		const first = await RpcHarnessSessionOwner.open("session-1", file, undefined, index);
+		const second = await RpcHarnessSessionOwner.open("session-1", file, undefined, index);
+		await first.bindRun("run-1");
+
+		await expect(second.bindRun("run-1")).rejects.toThrow("already has a live owner");
+		await first.dispose();
+		await expect(second.bindRun("run-1")).resolves.toEqual({
+			runId: "run-1",
+			sessionId: "session-1",
+			existing: true,
+		});
+		await second.dispose();
+	});
+
+	it("rejects live custody before repairing a torn ledger tail", async () => {
+		const file = recordFile("session-1");
+		const index = runIndexFile();
+		const first = await RpcHarnessSessionOwner.open("session-1", file, undefined, index, {
+			acquireSessionLease: true,
+		});
+		await first.bindRun("run-1");
+		await fs.appendFile(file, '{"kind":"event"');
+
+		await expect(
+			RpcHarnessSessionOwner.open("session-1", file, undefined, index, { acquireSessionLease: true }),
+		).rejects.toThrow("live owner");
+		expect(await fs.readFile(file, "utf8")).toEndWith('{"kind":"event"');
+		await first.dispose();
+	});
+
+	it("redelivers accepted steering that was not injected before reopen", async () => {
+		const file = recordFile();
+		await fs.mkdir(path.dirname(file), { recursive: true });
+		await fs.writeFile(
+			file,
+			`${[
+				JSON.stringify({ kind: "steering", steeringId: "steer-1", steeringSequence: 1, status: "ACCEPTED" }),
+				JSON.stringify({
+					kind: "event",
+					event: {
+						type: "steering_queued",
+						steeringId: "steer-1",
+						steeringSequence: 1,
+						message: "hello",
+						sequence: 1,
+					},
+				}),
+			].join("\n")}\n`,
+		);
+		const reopened = await RpcHarnessSessionOwner.open("session-1", file);
+		let deliveries = 0;
+		await expect(
+			reopened.steer("steer-1", "hello", async () => {
+				deliveries++;
+			}),
+		).resolves.toEqual({ status: "ACCEPTED", steeringSequence: 1 });
+		expect(deliveries).toBe(1);
+	});
+
+	it("repairs an accepted steering record missing its queued event", async () => {
+		const file = recordFile();
+		await fs.mkdir(path.dirname(file), { recursive: true });
+		await fs.writeFile(
+			file,
+			`${JSON.stringify({
+				kind: "steering",
+				steeringId: "steer-1",
+				steeringSequence: 1,
+				status: "ACCEPTED",
+				message: "hello",
+			})}\n`,
+		);
+
+		const reopened = await RpcHarnessSessionOwner.open("session-1", file);
+		expect((await reopened.replay()).map(event => event.type)).toEqual(["steering_queued"]);
+	});
+
+	it("retries rejected steering after reopening and redelivers it", async () => {
+		const file = recordFile();
+		const owner = await RpcHarnessSessionOwner.open("session-1", file);
+		let deliveries = 0;
+		await expect(
+			owner.steer("steer-1", "hello", async () => {
+				deliveries++;
+				throw new Error("unsafe boundary");
+			}),
+		).resolves.toEqual({ status: "REJECTED", steeringSequence: 1 });
+		const reopened = await RpcHarnessSessionOwner.open("session-1", file);
+		await expect(
+			reopened.steer("steer-1", "hello", async () => {
+				deliveries++;
+			}),
+		).resolves.toEqual({ status: "ACCEPTED", steeringSequence: 1 });
+		expect(deliveries).toBe(2);
+	});
+
+	it("latches a failed rejected-steering append", async () => {
+		const file = recordFile();
+		const owner = await RpcHarnessSessionOwner.open("session-1", file);
+		const result = owner.waitResult().then(
+			() => undefined,
+			error => error,
+		);
+		await owner.appendEvent({ type: "notice", level: "info", message: "initialize" });
+		await fs.chmod(file, 0o400);
+
+		await expect(
+			owner.steer("steer-1", "hello", async () => {
+				throw new Error("delivery failed");
+			}),
+		).rejects.toThrow();
+		expect(await result).toBeInstanceOf(Error);
+		await expect(owner.appendEvent({ type: "notice", level: "info", message: "late" })).rejects.toThrow();
+	});
+
+	it("reopens the terminal boundary when accepted work starts a continuation", async () => {
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile());
+		owner.beginResultSeal();
+		expect(() => owner.assertAcceptingWork()).toThrow("run result is already sealed");
+
+		owner.cancelResultSeal();
+
+		expect(() => owner.assertAcceptingWork()).not.toThrow();
+	});
+
+	it("seals the event sequence after the terminal result", async () => {
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile());
+		const sealing = owner.completeResult({
+			outcome: "completed",
+			stopReason: "stop",
+			finalMessage: "done",
+			usage: usage(),
+		});
+		expect(() => owner.assertAcceptingWork()).toThrow("run result is already sealed");
+		await sealing;
+		await expect(owner.appendEvent({ type: "notice", level: "info", message: "late" })).rejects.toThrow(
+			"after the terminal result",
+		);
+	});
+
+	it("claims a run ID across independently opened owners", async () => {
+		const first = await RpcHarnessSessionOwner.open("session-1", recordFile("session-1"), undefined, runIndexFile());
+		const second = await RpcHarnessSessionOwner.open("session-2", recordFile("session-2"), undefined, runIndexFile());
+		const results = await Promise.allSettled([first.bindRun("run-1"), second.bindRun("run-1")]);
+		expect(results.filter(result => result.status === "fulfilled")).toHaveLength(1);
+		expect(results.filter(result => result.status === "rejected")).toHaveLength(1);
+	});
+
+	it("claims a run ID atomically across separate processes", async () => {
+		const file = recordFile("session-1");
+		const index = runIndexFile();
+		const results = await Promise.all([
+			claimRunInChild("session-1", file, index),
+			claimRunInChild("session-2", recordFile("session-2"), index),
+		]);
+		expect(results.filter(result => result.ok)).toHaveLength(1);
+		expect(results.filter(result => !result.ok && result.error?.includes("bound to session"))).toHaveLength(1);
+	});
+
+	it("binds a long opaque run ID through fixed-length claim paths", async () => {
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile("session-1"), undefined, runIndexFile());
+		const runId = "opaque-".repeat(1_000);
+		await expect(owner.bindRun(runId)).resolves.toMatchObject({ runId });
+		await owner.dispose();
+	});
+
+	it("leases one session ledger across different run IDs", async () => {
+		const file = recordFile("session-1");
+		const index = runIndexFile();
+		const results = await Promise.all([
+			claimRunInChild("session-1", file, index, "run-1"),
+			claimRunInChild("session-1", file, index, "run-2"),
+		]);
+		expect(results.filter(result => result.ok)).toHaveLength(1);
+		expect(results.filter(result => !result.ok && result.error?.includes("session ledger"))).toHaveLength(1);
+	});
+
+	it("recovers an abandoned lease-reclaim directory", async () => {
+		const file = recordFile("session-1");
+		const leaseFile = `${file}.owner`;
+		const reclaimLock = `${leaseFile}.reclaim`;
+		await fs.mkdir(path.dirname(file), { recursive: true });
+		await fs.writeFile(leaseFile, JSON.stringify({ pid: 2_147_483_647, token: "stale" }));
+		await fs.mkdir(reclaimLock);
+		const staleTime = new Date(Date.now() - 10_000);
+		await fs.utimes(reclaimLock, staleTime, staleTime);
+
+		const owner = await RpcHarnessSessionOwner.open("session-1", file, undefined, runIndexFile());
+		await expect(owner.bindRun("run-1")).resolves.toMatchObject({ sessionId: "session-1" });
+		await owner.dispose();
+	});
+
+	it("reclaims a malformed lease left by an interrupted legacy write", async () => {
+		const file = recordFile("session-1");
+		await fs.mkdir(path.dirname(file), { recursive: true });
+		await fs.writeFile(`${file}.owner`, '{"pid":');
+
+		const owner = await RpcHarnessSessionOwner.open("session-1", file, undefined, runIndexFile());
+		await expect(owner.bindRun("run-1")).resolves.toMatchObject({ sessionId: "session-1" });
+		await owner.dispose();
+	});
+
+	it("reclaims a lease whose PID belongs to a different process birth", async () => {
+		const file = recordFile("session-1");
+		await fs.mkdir(path.dirname(file), { recursive: true });
+		await fs.writeFile(
+			`${file}.owner`,
+			JSON.stringify({ pid: process.pid, startToken: "different", token: "stale" }),
+		);
+
+		const owner = await RpcHarnessSessionOwner.open("session-1", file, undefined, runIndexFile());
+		await expect(owner.bindRun("run-1")).resolves.toMatchObject({ sessionId: "session-1" });
+		await owner.dispose();
+	});
+
+	it("keeps a live PID-only lease when start tokens are unavailable", async () => {
+		const file = recordFile("session-1");
+		await fs.mkdir(path.dirname(file), { recursive: true });
+		await fs.writeFile(`${file}.owner`, JSON.stringify({ pid: process.pid, token: "live" }));
+
+		const owner = await RpcHarnessSessionOwner.open("session-1", file, undefined, runIndexFile());
+		await expect(owner.bindRun("run-1")).rejects.toThrow("session ledger already has a live owner");
+		await owner.dispose();
+	});
+
+	it("serializes concurrent reclamation of a stale owner lease", async () => {
+		const file = recordFile("session-1");
+		const index = runIndexFile();
+		const digest = Bun.SHA256.hash("run-1", "hex");
+		const claimFile = path.join(`${index}.locks`, digest);
+		await fs.mkdir(path.dirname(claimFile), { recursive: true });
+		await fs.writeFile(claimFile, "session-1");
+		await fs.writeFile(`${claimFile}.owner`, JSON.stringify({ pid: 2_147_483_647, token: "stale" }));
+
+		const results = await Promise.all([
+			claimRunInChild("session-1", file, index),
+			claimRunInChild("session-1", file, index),
+		]);
+		expect(results.filter(result => result.ok)).toHaveLength(1);
+		expect(results.filter(result => !result.ok && result.error?.includes("live owner"))).toHaveLength(1);
+	});
+
+	it("coalesces cumulative message snapshots while publishing every live delta", async () => {
+		const published: RpcHarnessPublishedEvent[] = [];
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile(), event => published.push(event));
+		const updates = ["one", " two", " three"].map((delta, index) => ({
+			type: "message_update" as const,
+			message: { role: "assistant", content: [{ type: "text", text: ["one", "one two", "one two three"][index] }] },
+			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta },
+		}));
+		const tasks = updates.map(async update => {
+			const task = owner.appendEvent(update as never);
+			await Promise.resolve();
+			return task;
+		});
+
+		const replay = await owner.replay();
+		await Promise.all(tasks);
+		expect(replay).toHaveLength(1);
+		expect(JSON.stringify(replay[0])).toContain("one two three");
+		expect(
+			published.map(event =>
+				event.type === "message_update" && event.assistantMessageEvent.type === "text_delta"
+					? event.assistantMessageEvent.delta
+					: undefined,
+			),
+		).toEqual(["one", " two", " three"]);
+		expect(published.map(event => event.sequence)).toEqual([undefined, undefined, 1]);
+	});
+
+	it("publishes coalesced live deltas after preceding queued events", async () => {
+		const published: RpcHarnessPublishedEvent[] = [];
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile(), event => published.push(event));
+		const start = owner.appendEvent({ type: "notice", level: "info", message: "start" });
+		const first = owner.appendEvent({
+			type: "message_update",
+			message: { role: "assistant", content: [{ type: "text", text: "one" }] },
+			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "one" },
+		} as never);
+		const second = owner.appendEvent({
+			type: "message_update",
+			message: { role: "assistant", content: [{ type: "text", text: "one two" }] },
+			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: " two" },
+		} as never);
+
+		expect(published).toEqual([]);
+		const replay = await owner.replay();
+		await Promise.all([start, first, second]);
+		expect(published.map(event => event.type)).toEqual(["notice", "message_update", "message_update"]);
+		expect(published.map(event => event.sequence)).toEqual([1, undefined, 2]);
+		expect(replay.map(event => event.type)).toEqual(["notice", "message_update"]);
+	});
+
+	it("ends update coalescing at an intervening event", async () => {
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile());
+		const first = owner.appendEvent({
+			type: "message_update",
+			message: { role: "assistant", content: [{ type: "text", text: "first" }] },
+			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "first" },
+		} as never);
+		const boundary = owner.appendEvent({ type: "notice", level: "info", message: "boundary" });
+		const second = owner.appendEvent({
+			type: "message_update",
+			message: { role: "assistant", content: [{ type: "text", text: "second" }] },
+			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "second" },
+		} as never);
+		const replay = await owner.replay();
+		await Promise.all([first, boundary, second]);
+		expect(replay.map(event => event.type)).toEqual(["message_update", "notice", "message_update"]);
+		expect(JSON.stringify(replay[0])).toContain("first");
+		expect(JSON.stringify(replay[2])).toContain("second");
+	});
+
+	it("marks steering duplicate only after durable injection", async () => {
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile());
+		let deliveries = 0;
+		const deliver = async () => {
+			deliveries++;
+		};
+		await expect(owner.steer("steer-1", "hello", deliver)).resolves.toEqual({
+			status: "ACCEPTED",
+			steeringSequence: 1,
+		});
+		await expect(owner.steer("steer-1", "changed", deliver)).rejects.toThrow(
+			"payload does not match the original request",
+		);
+		await expect(owner.steer("steer-1", "hello", deliver, "different images")).rejects.toThrow(
+			"payload does not match the original request",
+		);
+		expect(deliveries).toBe(1);
+		await expect(owner.steer("steer-1", "hello", deliver)).resolves.toEqual({
+			status: "ACCEPTED",
+			steeringSequence: 1,
+		});
+		await owner.markSteeringInjected("steer-1");
+		await expect(owner.steer("steer-1", "hello", deliver)).resolves.toEqual({
+			status: "DUPLICATE",
+			steeringSequence: 1,
+		});
+		expect(deliveries).toBe(2);
+		expect((await owner.replay()).map(event => String(event.type))).toEqual(["steering_queued", "steering_injected"]);
+	});
+
+	it("redelivers accepted steering whose retry reorders payload members", async () => {
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile());
+		let deliveries = 0;
+		const deliver = async () => {
+			deliveries++;
+		};
+		// A supervisor replaying accepted work rebuilds the request from its own
+		// records, so nested members can come back in another order.
+		const accepted = rpcSteeringPayloadIdentity("look", [
+			{ type: "image", data: "AAAA", mimeType: "image/png", detail: "high" },
+		]);
+		const reordered = rpcSteeringPayloadIdentity("look", [
+			{ detail: "high", mimeType: "image/png", data: "AAAA", type: "image" },
+		]);
+		expect(reordered).toBe(accepted);
+
+		await expect(owner.steer("steer-1", "look", deliver, accepted)).resolves.toEqual({
+			status: "ACCEPTED",
+			steeringSequence: 1,
+		});
+		await expect(owner.steer("steer-1", "look", deliver, reordered)).resolves.toEqual({
+			status: "ACCEPTED",
+			steeringSequence: 1,
+		});
+		expect(deliveries).toBe(2);
+	});
+
+	it("still rejects steering retries whose payload genuinely differs", async () => {
+		const owner = await RpcHarnessSessionOwner.open("session-1", recordFile());
+		let deliveries = 0;
+		const deliver = async () => {
+			deliveries++;
+		};
+		const image = (data: string): ImageContent => ({ type: "image", data, mimeType: "image/png" });
+		const accepted = rpcSteeringPayloadIdentity("look", [image("AAAA")]);
+		// Array order, image bytes, and scalar identity all stay meaningful.
+		expect(rpcSteeringPayloadIdentity("look", [image("BBBB")])).not.toBe(accepted);
+		expect(rpcSteeringPayloadIdentity("look", [image("AAAA"), image("BBBB")])).not.toBe(
+			rpcSteeringPayloadIdentity("look", [image("BBBB"), image("AAAA")]),
+		);
+		// An absent image list and an empty one are the same request, though.
+		expect(rpcSteeringPayloadIdentity("look", [])).toBe(rpcSteeringPayloadIdentity("look", undefined));
+
+		await expect(owner.steer("steer-1", "look", deliver, accepted)).resolves.toEqual({
+			status: "ACCEPTED",
+			steeringSequence: 1,
+		});
+		await expect(
+			owner.steer("steer-1", "look", deliver, rpcSteeringPayloadIdentity("look", [image("BBBB")])),
+		).rejects.toThrow("payload does not match the original request");
+		await expect(
+			owner.steer("steer-1", "look", deliver, rpcSteeringPayloadIdentity("looks", [image("AAAA")])),
+		).rejects.toThrow("payload does not match the original request");
+		expect(deliveries).toBe(1);
+	});
+});

--- a/packages/coding-agent/src/modes/rpc/rpc-harness.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-harness.ts
@@ -1,0 +1,800 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { canonicalJsonStringify, isRecord } from "@oh-my-pi/pi-utils";
+import { sessionSidecarDir } from "../../session/session-paths";
+import { isProcessIdentityLive, processStartToken } from "../../task/isolation-ownership";
+import type { RpcAgentEventPayload, RpcSessionResult, RpcSessionSteerAck, RpcSessionUsage } from "./rpc-types";
+
+const RECLAIM_LOCK_STALE_MS = 5_000;
+
+export type RpcHarnessEvent = RpcAgentEventPayload & { sequence: number };
+export type RpcHarnessPublishedEvent = RpcAgentEventPayload & { sequence?: number };
+type RpcHarnessTerminalEvent = Extract<RpcHarnessEvent, { type: "session_terminal" }>;
+export type RpcHarnessResult = RpcSessionResult;
+export type RpcSteeringAck = RpcSessionSteerAck;
+
+interface EventRecord {
+	kind: "event";
+	event: RpcHarnessEvent;
+}
+
+interface RunRecord {
+	kind: "run";
+	runId: string;
+	sessionId: string;
+}
+
+interface SteeringRecord {
+	kind: "steering";
+	steeringId: string;
+	steeringSequence: number;
+	message: string;
+	payloadIdentity?: string;
+	status: "ACCEPTED" | "REJECTED";
+	queuedEvent?: RpcHarnessEvent;
+}
+
+interface TerminalRecord {
+	kind: "terminal";
+	event: RpcHarnessTerminalEvent;
+	result: RpcHarnessResult;
+}
+
+type RpcHarnessRecord = EventRecord | RunRecord | SteeringRecord | TerminalRecord;
+
+interface PendingStreamUpdate {
+	event: RpcAgentEventPayload;
+	publishedEvent: RpcAgentEventPayload;
+	result: PromiseWithResolvers<RpcHarnessEvent>;
+}
+
+function runClaimFile(runIndexFile: string, runId: string): string {
+	const digest = Bun.SHA256.hash(runId, "hex");
+	return path.join(`${runIndexFile}.locks`, digest);
+}
+
+/**
+ * Derives the payload identity a `session.steer` retry has to reproduce.
+ *
+ * A supervisor that replays accepted steering after a restart rebuilds the
+ * request from its own records, so semantically identical members can arrive in
+ * another order. Hashing the canonicalized payload keeps that retry idempotent
+ * and lets accepted-but-not-injected work still be redelivered, while a changed
+ * message or image set moves the digest and stays rejected as a mismatch.
+ */
+export function rpcSteeringPayloadIdentity(message: string, images: ImageContent[] | undefined): string {
+	return Bun.SHA256.hash(canonicalJsonStringify([message, images ?? []]), "hex");
+}
+
+/** Returns the durable RPC record path beside an OMP session transcript. */
+export function rpcHarnessRecordFileForSessionFile(sessionFile: string): string {
+	return path.join(sessionSidecarDir(sessionFile), "rpc-ledger", "events.jsonl");
+}
+
+/**
+ * Sequences RPC events, records them to an append-only JSONL file, and answers
+ * replay, run-binding, steering acknowledgement, and terminal-result reads for
+ * one session.
+ */
+export class RpcHarnessSessionOwner {
+	static #runLocks = new Map<string, Promise<void>>();
+
+	readonly sessionId: string;
+	readonly #recordFile: string;
+	readonly #runIndexFile: string;
+	readonly #publish: ((event: RpcHarnessPublishedEvent) => void) | undefined;
+	readonly #displayEvent: ((event: RpcHarnessEvent) => RpcHarnessEvent) | undefined;
+	readonly #displayResult: ((result: RpcHarnessResult) => RpcHarnessResult) | undefined;
+	#nextEventSequence = 1;
+	#nextSteeringSequence = 1;
+	#events: RpcHarnessEvent[] = [];
+	#persistedEvents: RpcHarnessEvent[] = [];
+	#steering = new Map<string, RpcSteeringAck>();
+	#steeringMessages = new Map<string, string>();
+	#steeringPayloads = new Map<string, string>();
+	#steeringQueued = new Set<string>();
+	#steeringInjected = new Set<string>();
+	#result: RpcHarnessResult | undefined;
+	#sealing = false;
+	#terminalTask: Promise<RpcHarnessResult> | undefined;
+	#resultWaiters: Array<{
+		resolve: (result: RpcHarnessResult) => void;
+		reject: (error: Error) => void;
+	}> = [];
+	#eventTail: Promise<void> = Promise.resolve();
+	#steeringTail: Promise<void> = Promise.resolve();
+	#pendingStreamUpdate: PendingStreamUpdate | undefined;
+	#failure: Error | undefined;
+	#ownedRunLeases = new Map<string, string>();
+	#boundRunId: string | undefined;
+	#sessionLeaseToken: string | undefined;
+
+	constructor(
+		sessionId: string,
+		recordFile: string,
+		runIndexFile: string,
+		publish: ((event: RpcHarnessPublishedEvent) => void) | undefined,
+		displayEvent: ((event: RpcHarnessEvent) => RpcHarnessEvent) | undefined,
+		displayResult: ((result: RpcHarnessResult) => RpcHarnessResult) | undefined,
+	) {
+		this.sessionId = sessionId;
+		this.#recordFile = recordFile;
+		this.#runIndexFile = runIndexFile;
+		this.#publish = publish;
+		this.#displayEvent = displayEvent;
+		this.#displayResult = displayResult;
+	}
+
+	/** Opens a session owner and reloads its durable RPC record. */
+	static async open(
+		sessionId: string,
+		recordFile: string,
+		publish?: (event: RpcHarnessPublishedEvent) => void,
+		runIndexFile = path.join(path.dirname(recordFile), "rpc-runs.jsonl"),
+		options: {
+			acquireSessionLease?: boolean;
+			displayEvent?: (event: RpcHarnessEvent) => RpcHarnessEvent;
+			displayResult?: (result: RpcHarnessResult) => RpcHarnessResult;
+		} = {},
+	): Promise<RpcHarnessSessionOwner> {
+		const owner = new RpcHarnessSessionOwner(
+			sessionId,
+			recordFile,
+			runIndexFile,
+			publish,
+			options.displayEvent,
+			options.displayResult,
+		);
+		let acquired = false;
+		try {
+			if (options.acquireSessionLease) acquired = await owner.#acquireSessionLease();
+			await owner.#load();
+			return owner;
+		} catch (error) {
+			if (acquired) await owner.#releaseSessionLease();
+			throw error;
+		}
+	}
+
+	/** Persists the caller's run binding before start is acknowledged. */
+	async bindRun(runId: string): Promise<{ runId: string; sessionId: string; existing: boolean }> {
+		if (!runId.trim()) throw new Error("run_id must not be empty");
+		return this.#withRunLock(async () => {
+			if (this.#boundRunId !== undefined && this.#boundRunId !== runId) {
+				throw new Error(`RPC owner is already bound to run_id ${this.#boundRunId}`);
+			}
+			if (this.#ownedRunLeases.has(runId)) {
+				return { runId, sessionId: this.sessionId, existing: true };
+			}
+
+			const acquiredSessionLease = await this.#acquireSessionLease();
+			try {
+				const claim = await this.#claimRun(runId);
+				if (!claim.claimed && claim.sessionId !== this.sessionId) {
+					throw new Error(`run_id is bound to session ${claim.sessionId}`);
+				}
+				await this.#acquireRunLease(runId);
+				if (this.#boundRunId === undefined) {
+					const record: RunRecord = { kind: "run", runId, sessionId: this.sessionId };
+					await this.#appendTo(this.#recordFile, record);
+				}
+				this.#boundRunId = runId;
+				return { runId, sessionId: this.sessionId, existing: !claim.claimed };
+			} catch (error) {
+				await this.#releaseRunLease(runId);
+				if (acquiredSessionLease || this.#ownedRunLeases.size === 0) await this.#releaseSessionLease();
+				throw error;
+			}
+		});
+	}
+
+	/** Releases this process's live run leases while preserving durable bindings. */
+	async dispose(): Promise<void> {
+		this.#flushPendingStreamUpdate();
+		try {
+			await this.#eventTail;
+		} finally {
+			await Promise.all([...this.#ownedRunLeases.keys()].map(runId => this.#releaseRunLease(runId)));
+			await this.#releaseSessionLease();
+		}
+	}
+
+	/** Persists one event in owner order, then publishes its display form with the same sequence. */
+	appendEvent(event: RpcAgentEventPayload, publishedEvent: RpcAgentEventPayload = event): Promise<RpcHarnessEvent> {
+		if (event.type !== "message_update") {
+			this.#flushPendingStreamUpdate();
+			return this.#queueEvent(() => this.#persistEvent(event, [publishedEvent]));
+		}
+		const pending = this.#pendingStreamUpdate;
+		if (pending) {
+			this.#queuePublication(pending.publishedEvent);
+			pending.event = event;
+			pending.publishedEvent = publishedEvent;
+			return pending.result.promise;
+		}
+		const update: PendingStreamUpdate = {
+			event,
+			publishedEvent,
+			result: Promise.withResolvers<RpcHarnessEvent>(),
+		};
+		this.#pendingStreamUpdate = update;
+		return update.result.promise;
+	}
+
+	#flushPendingStreamUpdate(): void {
+		const pending = this.#pendingStreamUpdate;
+		if (!pending) return;
+		this.#pendingStreamUpdate = undefined;
+		this.#queueEvent(() => this.#persistEvent(pending.event, [pending.publishedEvent])).then(
+			pending.result.resolve,
+			pending.result.reject,
+		);
+	}
+
+	#queueEvent(task: () => Promise<RpcHarnessEvent>): Promise<RpcHarnessEvent> {
+		return this.#trackEventTask(this.#eventTail.then(task));
+	}
+
+	#queuePublication(event: RpcAgentEventPayload): void {
+		const task = this.#eventTail.then(() => {
+			if (this.#failure) throw this.#failure;
+			this.#publish?.({ ...event });
+		});
+		this.#trackEventTask(task).catch(() => {});
+	}
+
+	async #persistEvent(event: RpcAgentEventPayload, publishedEvents: RpcAgentEventPayload[]): Promise<RpcHarnessEvent> {
+		if (this.#failure) throw this.#failure;
+		if (this.#result) throw new Error("cannot append an event after the terminal result");
+		const sequence = this.#nextEventSequence++;
+		const sequenced: RpcHarnessEvent = { ...event, sequence };
+		await this.#append({ kind: "event", event: sequenced });
+		this.#persistedEvents.push(sequenced);
+		this.#events.push(this.#displayEvent?.(sequenced) ?? sequenced);
+		for (const [index, publishedEvent] of publishedEvents.entries()) {
+			this.#publish?.(
+				index === publishedEvents.length - 1 ? { ...publishedEvent, sequence } : { ...publishedEvent },
+			);
+		}
+		return sequenced;
+	}
+
+	/** Replays durable events strictly after the requested sequence. */
+	async replay(afterSequence = 0, limit?: number): Promise<RpcHarnessEvent[]> {
+		if (!Number.isSafeInteger(afterSequence) || afterSequence < 0)
+			throw new Error("after_sequence must be a non-negative integer");
+		if (limit !== undefined && (!Number.isSafeInteger(limit) || limit < 1 || limit > 1_000))
+			throw new Error("limit must be an integer from 1 to 1000");
+		this.#flushPendingStreamUpdate();
+		await this.#eventTail;
+		const events = this.#events.filter(event => event.sequence > afterSequence);
+		return limit === undefined ? events : events.slice(0, limit);
+	}
+
+	/** Returns provider-safe event values for internal result aggregation. */
+	async replayPersisted(): Promise<RpcHarnessEvent[]> {
+		this.#flushPendingStreamUpdate();
+		await this.#eventTail;
+		return [...this.#persistedEvents];
+	}
+
+	get latestSequence(): number {
+		return this.#nextEventSequence - 1;
+	}
+
+	/** Records queued and injected steering while making retries idempotent. */
+	steer(
+		steeringId: string,
+		message: string,
+		deliver: () => Promise<void>,
+		payloadIdentity = message,
+	): Promise<RpcSteeringAck> {
+		if (!steeringId.trim()) throw new Error("steering_id must not be empty");
+		const task = this.#steeringTail.then(() => this.#steer(steeringId, message, payloadIdentity, deliver));
+		this.#steeringTail = task.then(
+			() => undefined,
+			() => undefined,
+		);
+		return task;
+	}
+
+	/** Records steering injection after its user message reaches durable session history. */
+	markSteeringInjected(steeringId: string): Promise<void> {
+		const task = this.#steeringTail.then(async () => {
+			const prior = this.#steering.get(steeringId);
+			if (prior?.status !== "ACCEPTED" || this.#steeringInjected.has(steeringId)) return;
+			await this.appendEvent({
+				type: "steering_injected",
+				steeringId,
+				steeringSequence: prior.steeringSequence,
+			});
+			this.#steeringInjected.add(steeringId);
+		});
+		this.#steeringTail = task.then(
+			() => undefined,
+			() => undefined,
+		);
+		return task;
+	}
+
+	/** Prevents new episode work while earlier durable boundaries finish. */
+	beginResultSeal(): void {
+		if (!this.#result) this.#sealing = true;
+	}
+	/** Reopens episode work when draining accepted delivery started a continuation. */
+	cancelResultSeal(): void {
+		if (!this.#result && !this.#terminalTask) this.#sealing = false;
+	}
+
+	/** Persists the terminal event and immutable result before publishing terminal state. */
+	completeResult(input: Omit<RpcHarnessResult, "resultId" | "terminalSequence">): Promise<RpcHarnessResult> {
+		if (this.#result) return Promise.resolve(this.#result);
+		if (this.#terminalTask) return this.#terminalTask;
+		this.beginResultSeal();
+		this.#flushPendingStreamUpdate();
+		const task = this.#eventTail.then(async () => {
+			if (this.#result) return this.#result;
+			if (this.#failure) throw this.#failure;
+			const terminalSequence = this.#nextEventSequence++;
+			const resultId = `${this.sessionId}:result`;
+			const usage: RpcSessionUsage = { ...input.usage };
+			const terminalEvent: RpcHarnessTerminalEvent = {
+				type: "session_terminal",
+				sessionId: this.sessionId,
+				outcome: input.outcome,
+				stopReason: input.stopReason,
+				finalMessage: input.finalMessage,
+				usage,
+				resultId,
+				terminalSequence,
+				sequence: terminalSequence,
+			};
+			const persistedResult: RpcHarnessResult = Object.freeze({
+				...input,
+				usage: Object.freeze(usage),
+				resultId,
+				terminalSequence,
+			});
+			await this.#append({ kind: "terminal", event: terminalEvent, result: persistedResult });
+			const result = Object.freeze(this.#displayResult?.(persistedResult) ?? persistedResult);
+			const displayEvent: RpcHarnessEvent = { ...terminalEvent, finalMessage: result.finalMessage };
+			this.#persistedEvents.push(terminalEvent);
+			this.#events.push(displayEvent);
+			this.#result = result;
+			for (const waiter of this.#resultWaiters) waiter.resolve(result);
+			this.#resultWaiters = [];
+			this.#publish?.(displayEvent);
+			return result;
+		});
+		this.#terminalTask = this.#trackEventTask(task);
+		return this.#terminalTask;
+	}
+
+	/** Blocks until terminal and returns the same immutable record on every call. */
+	waitResult(): Promise<RpcHarnessResult> {
+		if (this.#result) return Promise.resolve(this.#result);
+		if (this.#failure) return Promise.reject(this.#failure);
+		const { promise, resolve, reject } = Promise.withResolvers<RpcHarnessResult>();
+		this.#resultWaiters.push({ resolve, reject });
+		return promise;
+	}
+
+	get hasResult(): boolean {
+		return this.#result !== undefined;
+	}
+
+	/**
+	 * Whether a terminal result can still be recorded. Only a latched append
+	 * failure takes sealing away; a failure on a path that never reached the
+	 * ledger — a session transcript flush, for one — leaves the run sealable.
+	 */
+	get canSealResult(): boolean {
+		return this.#failure === undefined;
+	}
+
+	isBoundToRun(runId: string): boolean {
+		return this.#boundRunId === runId;
+	}
+
+	assertAcceptingWork(): void {
+		if (this.#result || this.#sealing) throw new Error("run result is already sealed");
+	}
+
+	async #load(): Promise<void> {
+		await this.#loadFile(this.#recordFile);
+		await this.#repairSteeringQueuedEvents();
+	}
+
+	async #loadFile(file: string): Promise<void> {
+		const text = await fs.readFile(file, "utf8").catch(error => {
+			if (isRecord(error) && error.code === "ENOENT") return undefined;
+			throw error;
+		});
+		if (text === undefined) return;
+		const lines = text.split("\n");
+		for (const [index, line] of lines.entries()) {
+			if (!line.trim()) continue;
+			let record: RpcHarnessRecord;
+			try {
+				record = JSON.parse(line);
+			} catch (error) {
+				if (index === lines.length - 1 && !text.endsWith("\n")) {
+					const validPrefix = text.slice(0, text.lastIndexOf("\n") + 1);
+					await fs.truncate(file, Buffer.byteLength(validPrefix, "utf8"));
+					return;
+				}
+				throw error;
+			}
+			if (record.kind === "run") {
+				if (record.sessionId !== this.sessionId) {
+					throw new Error(`session ledger run is bound to session ${record.sessionId}`);
+				}
+				if (this.#boundRunId !== undefined && this.#boundRunId !== record.runId) {
+					throw new Error(`session ledger contains multiple run IDs: ${this.#boundRunId}, ${record.runId}`);
+				}
+				this.#boundRunId = record.runId;
+				continue;
+			}
+			if (record.kind === "event") {
+				this.#persistedEvents.push(record.event);
+				this.#events.push(this.#displayEvent?.(record.event) ?? record.event);
+				this.#nextEventSequence = Math.max(this.#nextEventSequence, record.event.sequence + 1);
+				if (record.event.type === "steering_injected") this.#steeringInjected.add(record.event.steeringId);
+				if (record.event.type === "steering_queued") {
+					this.#steeringMessages.set(record.event.steeringId, record.event.message);
+					this.#steeringQueued.add(record.event.steeringId);
+				}
+			} else if (record.kind === "steering") {
+				this.#nextSteeringSequence = Math.max(this.#nextSteeringSequence, record.steeringSequence + 1);
+				this.#steering.set(record.steeringId, {
+					status: record.status,
+					steeringSequence: record.steeringSequence,
+				});
+				this.#steeringMessages.set(record.steeringId, record.message);
+				if (record.payloadIdentity !== undefined) {
+					this.#steeringPayloads.set(record.steeringId, record.payloadIdentity);
+				}
+				if (record.queuedEvent) {
+					this.#persistedEvents.push(record.queuedEvent);
+					this.#events.push(this.#displayEvent?.(record.queuedEvent) ?? record.queuedEvent);
+					this.#nextEventSequence = Math.max(this.#nextEventSequence, record.queuedEvent.sequence + 1);
+					this.#steeringQueued.add(record.steeringId);
+				}
+			} else if (record.kind === "terminal") {
+				const persistedResult = Object.freeze({
+					...record.result,
+					usage: Object.freeze({ ...record.result.usage }),
+				});
+				const result = Object.freeze(this.#displayResult?.(persistedResult) ?? persistedResult);
+				this.#persistedEvents.push(record.event);
+				this.#events.push(
+					this.#displayEvent?.({ ...record.event, finalMessage: result.finalMessage }) ?? {
+						...record.event,
+						finalMessage: result.finalMessage,
+					},
+				);
+				this.#nextEventSequence = Math.max(this.#nextEventSequence, record.event.sequence + 1);
+				this.#result = result;
+			}
+		}
+		if (!text.endsWith("\n") && text.trim()) await fs.appendFile(file, "\n");
+	}
+
+	async #repairSteeringQueuedEvents(): Promise<void> {
+		for (const [steeringId, ack] of this.#steering) {
+			if (ack.status !== "ACCEPTED" || this.#steeringQueued.has(steeringId)) continue;
+			const message = this.#steeringMessages.get(steeringId);
+			if (message === undefined) continue;
+			const event: RpcHarnessEvent = {
+				type: "steering_queued",
+				steeringId,
+				steeringSequence: ack.steeringSequence,
+				message,
+				sequence: this.#nextEventSequence++,
+			};
+			await this.#append({ kind: "event", event });
+			this.#persistedEvents.push(event);
+			this.#events.push(this.#displayEvent?.(event) ?? event);
+			this.#steeringQueued.add(steeringId);
+		}
+	}
+
+	async #steer(
+		steeringId: string,
+		message: string,
+		payloadIdentity: string,
+		deliver: () => Promise<void>,
+	): Promise<RpcSteeringAck> {
+		const prior = this.#steering.get(steeringId);
+		const priorPayload = this.#steeringPayloads.get(steeringId);
+		const priorMessage = this.#steeringMessages.get(steeringId);
+		if (
+			(priorPayload !== undefined && priorPayload !== payloadIdentity) ||
+			(priorPayload === undefined && priorMessage !== undefined && priorMessage !== message)
+		) {
+			throw new Error(`steering_id payload does not match the original request: ${steeringId}`);
+		}
+		if (prior && prior.status === "ACCEPTED" && this.#steeringInjected.has(steeringId))
+			return { ...prior, status: "DUPLICATE" };
+		const steeringSequence = prior?.steeringSequence ?? this.#nextSteeringSequence++;
+		const accepted: RpcSteeringAck = { status: "ACCEPTED", steeringSequence };
+		if (prior?.status !== "ACCEPTED") {
+			await this.#queueEvent(async () => {
+				if (this.#failure) throw this.#failure;
+				if (this.#result) throw new Error("cannot append steering after the terminal result");
+				const event: RpcHarnessEvent = {
+					type: "steering_queued",
+					steeringId,
+					steeringSequence,
+					message,
+					sequence: this.#nextEventSequence++,
+				};
+				await this.#append({
+					kind: "steering",
+					steeringId,
+					steeringSequence,
+					status: "ACCEPTED",
+					message,
+					payloadIdentity,
+					queuedEvent: event,
+				});
+				this.#persistedEvents.push(event);
+				this.#events.push(this.#displayEvent?.(event) ?? event);
+				this.#publish?.(event);
+				return event;
+			});
+			this.#steering.set(steeringId, accepted);
+			this.#steeringMessages.set(steeringId, message);
+			this.#steeringPayloads.set(steeringId, payloadIdentity);
+			this.#steeringQueued.add(steeringId);
+		}
+		try {
+			await deliver();
+			return accepted;
+		} catch {
+			const rejected: RpcSteeringAck = { status: "REJECTED", steeringSequence };
+			await this.#trackEventTask(
+				this.#eventTail.then(() =>
+					this.#append({
+						kind: "steering",
+						steeringId,
+						steeringSequence,
+						status: "REJECTED",
+						message,
+						payloadIdentity,
+					}),
+				),
+			);
+			this.#steering.set(steeringId, rejected);
+			await this.appendEvent({ type: "steering_rejected", steeringId, steeringSequence });
+			return rejected;
+		}
+	}
+
+	async #withRunLock<T>(callback: () => Promise<T>): Promise<T> {
+		const prior = RpcHarnessSessionOwner.#runLocks.get(this.#runIndexFile) ?? Promise.resolve();
+		const { promise: current, resolve: release } = Promise.withResolvers<void>();
+		const chain = prior.then(() => current);
+		RpcHarnessSessionOwner.#runLocks.set(this.#runIndexFile, chain);
+		await prior;
+		try {
+			return await callback();
+		} finally {
+			release();
+			if (RpcHarnessSessionOwner.#runLocks.get(this.#runIndexFile) === chain)
+				RpcHarnessSessionOwner.#runLocks.delete(this.#runIndexFile);
+		}
+	}
+
+	async #claimRun(runId: string): Promise<{ claimed: boolean; sessionId: string }> {
+		const claimFile = runClaimFile(this.#runIndexFile, runId);
+		const claimDir = path.dirname(claimFile);
+		await fs.mkdir(claimDir, { recursive: true, mode: 0o700 });
+		const stagedClaim = path.join(claimDir, `.${path.basename(claimFile)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+		await fs.writeFile(stagedClaim, this.sessionId, { encoding: "utf8", flag: "wx", mode: 0o600 });
+		try {
+			try {
+				await fs.link(stagedClaim, claimFile);
+				return { claimed: true, sessionId: this.sessionId };
+			} catch (error) {
+				if (!isRecord(error) || error.code !== "EEXIST") throw error;
+				const sessionId = (await fs.readFile(claimFile, "utf8")).trim();
+				if (!sessionId) throw new Error(`run_id claim is incomplete: ${runId}`);
+				return { claimed: false, sessionId };
+			}
+		} finally {
+			await fs.rm(stagedClaim, { force: true });
+		}
+	}
+
+	async #acquireSessionLease(): Promise<boolean> {
+		if (this.#sessionLeaseToken) return false;
+		this.#sessionLeaseToken = await this.#acquireLease(
+			`${this.#recordFile}.owner`,
+			`session ledger already has a live owner: ${this.sessionId}`,
+		);
+		return true;
+	}
+
+	async #acquireRunLease(runId: string): Promise<void> {
+		const leaseFile = `${runClaimFile(this.#runIndexFile, runId)}.owner`;
+		const token = await this.#acquireLease(leaseFile, `run_id already has a live owner: ${runId}`);
+		this.#ownedRunLeases.set(runId, token);
+	}
+
+	async #acquireLease(leaseFile: string, busyMessage: string): Promise<string> {
+		await fs.mkdir(path.dirname(leaseFile), { recursive: true, mode: 0o700 });
+		const reclaimLock = `${leaseFile}.reclaim`;
+		const token = crypto.randomUUID();
+		const startToken = await processStartToken(process.pid);
+		const content = JSON.stringify({ pid: process.pid, ...(startToken ? { startToken } : {}), token });
+		for (;;) {
+			if (await this.#publishExclusiveFile(leaseFile, content)) return token;
+			let leaseText: string;
+			try {
+				leaseText = await fs.readFile(leaseFile, "utf8");
+			} catch (readError) {
+				if (isRecord(readError) && readError.code === "ENOENT") continue;
+				throw readError;
+			}
+			let lease: unknown;
+			try {
+				lease = JSON.parse(leaseText);
+			} catch {
+				lease = undefined;
+			}
+			if (
+				isRecord(lease) &&
+				typeof lease.pid === "number" &&
+				Number.isSafeInteger(lease.pid) &&
+				lease.pid > 0 &&
+				(await isProcessIdentityLive(
+					lease.pid,
+					typeof lease.startToken === "string" ? lease.startToken : undefined,
+				))
+			) {
+				throw new Error(busyMessage);
+			}
+			if (!(await this.#acquireReclaimLock(reclaimLock, content))) {
+				const retry = Promise.withResolvers<void>();
+				setImmediate(retry.resolve);
+				await retry.promise;
+				continue;
+			}
+			try {
+				const current = await fs.readFile(leaseFile, "utf8").catch(readError => {
+					if (isRecord(readError) && readError.code === "ENOENT") return undefined;
+					throw readError;
+				});
+				if (current !== leaseText) continue;
+				await fs.rm(leaseFile);
+				if (await this.#publishExclusiveFile(leaseFile, content)) return token;
+			} finally {
+				await fs.rm(reclaimLock, { recursive: true, force: true });
+			}
+		}
+	}
+
+	async #publishExclusiveFile(file: string, content: string): Promise<boolean> {
+		const staging = path.join(
+			path.dirname(file),
+			`.${path.basename(file)}.${process.pid}.${crypto.randomUUID()}.tmp`,
+		);
+		await fs.writeFile(staging, content, { encoding: "utf8", flag: "wx", mode: 0o600 });
+		try {
+			try {
+				await fs.link(staging, file);
+				return true;
+			} catch (error) {
+				if (!isRecord(error) || error.code !== "EEXIST") throw error;
+				return false;
+			}
+		} finally {
+			await fs.rm(staging, { force: true });
+		}
+	}
+
+	async #acquireReclaimLock(reclaimLock: string, content: string): Promise<boolean> {
+		const ownerFile = path.join(reclaimLock, "owner.json");
+		try {
+			await fs.mkdir(reclaimLock, { mode: 0o700 });
+			try {
+				await fs.writeFile(ownerFile, content, { encoding: "utf8", flag: "wx", mode: 0o600 });
+			} catch (error) {
+				await fs.rm(reclaimLock, { recursive: true, force: true });
+				throw error;
+			}
+			return true;
+		} catch (error) {
+			if (!isRecord(error) || error.code !== "EEXIST") throw error;
+		}
+		const stat = await fs.stat(reclaimLock).catch(error => {
+			if (isRecord(error) && error.code === "ENOENT") return undefined;
+			throw error;
+		});
+		if (!stat) return false;
+		const existing = await fs.readFile(stat.isDirectory() ? ownerFile : reclaimLock, "utf8").catch(error => {
+			if (isRecord(error) && error.code === "ENOENT") return undefined;
+			throw error;
+		});
+		let owner: unknown;
+		try {
+			owner = existing === undefined ? undefined : JSON.parse(existing);
+		} catch {
+			owner = undefined;
+		}
+		if (
+			isRecord(owner) &&
+			typeof owner.pid === "number" &&
+			Number.isSafeInteger(owner.pid) &&
+			owner.pid > 0 &&
+			(await isProcessIdentityLive(owner.pid, typeof owner.startToken === "string" ? owner.startToken : undefined))
+		) {
+			return false;
+		}
+		if (existing === undefined && Date.now() - stat.mtimeMs < RECLAIM_LOCK_STALE_MS) return false;
+		const abandoned = `${reclaimLock}.${crypto.randomUUID()}.stale`;
+		try {
+			await fs.rename(reclaimLock, abandoned);
+		} catch (error) {
+			if (!isRecord(error) || error.code !== "ENOENT") throw error;
+			return false;
+		}
+		await fs.rm(abandoned, { recursive: true, force: true });
+		return false;
+	}
+
+	async #releaseRunLease(runId: string): Promise<void> {
+		const token = this.#ownedRunLeases.get(runId);
+		if (!token) return;
+		try {
+			await this.#releaseLease(`${runClaimFile(this.#runIndexFile, runId)}.owner`, token);
+		} finally {
+			this.#ownedRunLeases.delete(runId);
+		}
+	}
+
+	async #releaseSessionLease(): Promise<void> {
+		const token = this.#sessionLeaseToken;
+		if (!token) return;
+		try {
+			await this.#releaseLease(`${this.#recordFile}.owner`, token);
+		} finally {
+			this.#sessionLeaseToken = undefined;
+		}
+	}
+
+	async #releaseLease(leaseFile: string, token: string): Promise<void> {
+		try {
+			const lease: unknown = JSON.parse(await fs.readFile(leaseFile, "utf8"));
+			if (isRecord(lease) && lease.token === token) await fs.rm(leaseFile, { force: true });
+		} catch (error) {
+			if (!isRecord(error) || error.code !== "ENOENT") throw error;
+		}
+	}
+
+	#trackEventTask<T>(task: Promise<T>): Promise<T> {
+		const tracked = task.catch(error => {
+			this.#failure ??= error instanceof Error ? error : new Error(String(error));
+			for (const waiter of this.#resultWaiters) waiter.reject(this.#failure);
+			this.#resultWaiters = [];
+			throw error;
+		});
+		this.#eventTail = tracked.then(
+			() => undefined,
+			() => undefined,
+		);
+		return tracked;
+	}
+
+	async #append(record: RpcHarnessRecord): Promise<void> {
+		await this.#appendTo(this.#recordFile, record);
+	}
+
+	async #appendTo(file: string, record: RpcHarnessRecord): Promise<void> {
+		await fs.mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+		await fs.appendFile(file, `${JSON.stringify(record)}\n`, { encoding: "utf8", mode: 0o600 });
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -244,6 +244,17 @@ export async function waitForRpcMessageDurability(
 	await session.sessionManager.flush();
 }
 
+/** Seals a durable result only after every accepted transcript append is visible. */
+export async function completeRpcResultAfterTranscriptFlush(
+	sessionManager: Pick<AgentSession["sessionManager"], "flush">,
+	owner: Pick<RpcHarnessSessionOwner, "beginResultSeal" | "completeResult">,
+	result: Parameters<RpcHarnessSessionOwner["completeResult"]>[0],
+): Promise<void> {
+	owner.beginResultSeal();
+	await sessionManager.flush();
+	await owner.completeResult(result);
+}
+
 export function reuseRpcHarnessBinding(
 	owner: Pick<RpcHarnessSessionOwner, "isBoundToRun" | "sessionId"> | undefined,
 	runId: string,
@@ -564,10 +575,12 @@ export class RpcTerminalTaskTracker {
 	}
 }
 export function rpcForcedExitOutcome(
-	session: Parameters<typeof hasPendingRpcContinuation>[0],
+	session: Parameters<typeof hasPendingRpcContinuation>[0] & Pick<AgentSession, "hasPendingExtensionEvents">,
 	terminalTasks: Pick<RpcTerminalTaskTracker, "hasPendingTasks">,
 ): "aborted" | "completed" {
-	return rpcExitOutcome(hasPendingRpcContinuation(session) || terminalTasks.hasPendingTasks);
+	return rpcExitOutcome(
+		hasPendingRpcContinuation(session) || session.hasPendingExtensionEvents || terminalTasks.hasPendingTasks,
+	);
 }
 
 export async function drainRpcTerminalBoundary(
@@ -1415,8 +1428,7 @@ export async function runRpcMode(
 		}
 		pendingAdvisorSealRetryUnsubscribe?.();
 		pendingAdvisorSealRetryUnsubscribe = undefined;
-		owner.beginResultSeal();
-		await owner.completeResult({
+		await completeRpcResultAfterTranscriptFlush(session.sessionManager, owner, {
 			outcome,
 			stopReason,
 			finalMessage: episodeFinalMessage,

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -92,10 +92,9 @@ export function startRpcResidualPrompt<T>(
  * Whether the episode still owes work that must land before a terminal result.
  *
  * Advisor reviews count even though every primary-facing signal here can read
- * idle while one is running: advisors review out of band, and a review that
- * lands late persists a card into the transcript or resumes the primary through
- * a trigger-turn blocker. Sealing on the primary signals alone writes the
- * terminal result over work that then appears after it.
+ * idle while one is running. Queued yield entries also count when their
+ * dispatchers can start an idle follow-up turn. Sealing on the primary signals
+ * alone writes the terminal result over work that then appears after it.
  */
 export function hasPendingRpcContinuation(
 	session: Pick<
@@ -106,12 +105,14 @@ export function hasPendingRpcContinuation(
 		| "hasQueuedAgentMessages"
 		| "isCompacting"
 		| "isStreaming"
+		| "hasPendingYieldWake"
 	>,
 ): boolean {
 	return (
 		session.isStreaming ||
 		session.isCompacting ||
 		session.hasPendingAsyncWork() ||
+		session.hasPendingYieldWake() ||
 		session.hasPendingBashMessages ||
 		session.hasQueuedAgentMessages ||
 		session.hasPendingAdvisorReviews
@@ -158,7 +159,9 @@ export function rpcResultSealAcceptance(
 export function retryRpcResultSealAfterAdvisorSettlement(
 	session: Pick<AgentSession, "onAdvisorReviewsSettled">,
 	retry: () => void,
+	cancelPending?: () => void,
 ): () => void {
+	cancelPending?.();
 	let active = true;
 	let unsubscribe = () => {};
 	const settled = () => {
@@ -277,6 +280,7 @@ export function hasActiveRpcSessionWork(
 		| "hasQueuedAgentMessages"
 		| "isCompacting"
 		| "isStreaming"
+		| "hasPendingYieldWake"
 	>,
 	hasTrackedTasks: boolean,
 	hasActivePrompts: boolean,
@@ -1410,19 +1414,23 @@ export async function runRpcMode(
 				rpcResultSealAcceptance(owner, () => session.yieldQueue.requestIdleFlush()),
 			))
 		) {
-			if (session.hasPendingAdvisorReviews && !pendingAdvisorSealRetryUnsubscribe) {
-				pendingAdvisorSealRetryUnsubscribe = retryRpcResultSealAfterAdvisorSettlement(session, () => {
-					pendingAdvisorSealRetryUnsubscribe = undefined;
-					void completeRpcResult(stopReason, outcome).catch(errorValue => {
-						output(
-							error(
-								undefined,
-								"session.result",
-								errorValue instanceof Error ? errorValue.message : String(errorValue),
-							),
-						);
-					});
-				});
+			if (session.hasPendingAdvisorReviews) {
+				pendingAdvisorSealRetryUnsubscribe = retryRpcResultSealAfterAdvisorSettlement(
+					session,
+					() => {
+						pendingAdvisorSealRetryUnsubscribe = undefined;
+						void completeRpcResult(stopReason, outcome).catch(errorValue => {
+							output(
+								error(
+									undefined,
+									"session.result",
+									errorValue instanceof Error ? errorValue.message : String(errorValue),
+								),
+							);
+						});
+					},
+					pendingAdvisorSealRetryUnsubscribe,
+				);
 			}
 			return;
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -10,7 +10,11 @@
  * - Events: AgentSessionEvent objects streamed as they occur
  * - Extension UI: Extension UI requests are emitted, client responds with extension_ui_response
  */
+
 import { once } from "node:events";
+import * as path from "node:path";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { Usage } from "@oh-my-pi/pi-ai";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { isZodSchema, zodToWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { $env, isRecord, readLines, Snowflake } from "@oh-my-pi/pi-utils";
@@ -23,13 +27,17 @@ import {
 	type ExtensionWidgetOptions,
 	getExtensionUISelectOptionLabel,
 } from "../../extensibility/extensions";
+import { runExtensionCompact } from "../../extensibility/extensions/compact-handler";
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { type Theme, theme } from "../../modes/theme/theme";
-import type { AgentSession } from "../../session/agent-session";
+import { type AgentSession, persistenceSafeAgentSessionEvent } from "../../session/agent-session";
+import type { AgentSessionEvent } from "../../session/agent-session-events";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../../session/messages";
+import { sessionMessageUsage } from "../../session/session-stats";
 import { executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
 import { buildAvailableSlashCommands } from "../../slash-commands/available-commands";
+import { parseSlashCommand } from "../../slash-commands/helpers/parse";
 import { defaultLoadModeForToolName } from "../../tools/essential-tools";
 import type { EventBus } from "../../utils/event-bus";
 import { calculateTokensPerSecond } from "../../utils/token-rate";
@@ -37,6 +45,12 @@ import { initializeExtensions } from "../runtime-init";
 import { isRpcHostToolResult, isRpcHostToolUpdate, RpcHostToolBridge } from "./host-tools";
 import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
 import { MAX_RPC_FRAME_BYTES, MAX_RPC_REASSEMBLED_BYTES, RpcFrameEncoder } from "./rpc-frame";
+import {
+	type RpcHarnessEvent,
+	RpcHarnessSessionOwner,
+	rpcHarnessRecordFileForSessionFile,
+	rpcSteeringPayloadIdentity,
+} from "./rpc-harness";
 import { claimRpcInput } from "./rpc-input";
 import { pageRpcMessages, RPC_MESSAGES_PAGE_BUSY_ERROR, RpcMessagesPageError } from "./rpc-messages";
 import { RpcSubagentRegistry, readRpcSubagentTranscript } from "./rpc-subagents";
@@ -54,11 +68,269 @@ import type {
 	RpcHostUriResult,
 	RpcResponse,
 	RpcSessionState,
+	RpcSessionUsage,
 	RpcSubagentSubscriptionLevel,
 } from "./rpc-types";
 
 // Re-export types for consumers
 export type * from "./rpc-types";
+
+export function isRpcCustodyRestrictedPrompt(message: string): boolean {
+	const name = parseSlashCommand(message)?.name;
+	return name === "move" || name === "compact";
+}
+
+export function startRpcResidualPrompt<T>(
+	owner: Pick<RpcHarnessSessionOwner, "assertAcceptingWork"> | undefined,
+	start: () => T,
+): T {
+	owner?.assertAcceptingWork();
+	return start();
+}
+
+/**
+ * Whether the episode still owes work that must land before a terminal result.
+ *
+ * Advisor reviews count even though every primary-facing signal here can read
+ * idle while one is running: advisors review out of band, and a review that
+ * lands late persists a card into the transcript or resumes the primary through
+ * a trigger-turn blocker. Sealing on the primary signals alone writes the
+ * terminal result over work that then appears after it.
+ */
+export function hasPendingRpcContinuation(
+	session: Pick<
+		AgentSession,
+		| "hasPendingAdvisorReviews"
+		| "hasPendingAsyncWork"
+		| "hasPendingBashMessages"
+		| "hasQueuedAgentMessages"
+		| "isCompacting"
+		| "isStreaming"
+	>,
+): boolean {
+	return (
+		session.isStreaming ||
+		session.isCompacting ||
+		session.hasPendingAsyncWork() ||
+		session.hasPendingBashMessages ||
+		session.hasQueuedAgentMessages ||
+		session.hasPendingAdvisorReviews
+	);
+}
+
+export function rpcExitOutcome(hasIncompleteWork: boolean): "aborted" | "completed" {
+	return hasIncompleteWork ? "aborted" : "completed";
+}
+/**
+ * Acceptance control for one terminal seal attempt.
+ *
+ * Every source of episode work — extension handlers, stranded IRC asides, and
+ * the yield queue's idle flush — asks the custody gate before starting, so
+ * closing that gate is what makes a continuation check final. `reopen()`
+ * abandons the attempt: it must also re-arm whatever the closed gate parked,
+ * because a refused wake leaves its entries queued with no self-rearming timer.
+ */
+export interface RpcResultSealAcceptance {
+	/** Stop admitting episode work, so a continuation check cannot go stale. */
+	close(): void;
+	/** Abandon the attempt: readmit work and re-arm the wakes the gate parked. */
+	reopen(): void;
+}
+
+/** Closes custody for a seal attempt and re-arms parked idle flushes when it is abandoned. */
+export function rpcResultSealAcceptance(
+	owner: Pick<RpcHarnessSessionOwner, "beginResultSeal" | "cancelResultSeal">,
+	requestIdleFlush: () => void,
+): RpcResultSealAcceptance {
+	return {
+		close: () => owner.beginResultSeal(),
+		reopen: () => {
+			owner.cancelResultSeal();
+			// Reopening only stops the gate refusing; nothing re-evaluates the wakes
+			// it already parked, and neither `#endInFlight` nor `#resetInFlight`
+			// does more than re-ask the same gate. Re-arm once here — the same
+			// re-arm `bindHarness` performs once custody settles — or entries parked
+			// by this abandoned attempt wait for disposal.
+			requestIdleFlush();
+		},
+	};
+}
+export function retryRpcResultSealAfterAdvisorSettlement(
+	session: Pick<AgentSession, "onAdvisorReviewsSettled">,
+	retry: () => void,
+): () => void {
+	let active = true;
+	let unsubscribe = () => {};
+	const settled = () => {
+		if (!active) return;
+		active = false;
+		unsubscribe();
+		retry();
+	};
+	unsubscribe = session.onAdvisorReviewsSettled(settled);
+	return () => {
+		if (!active) return;
+		active = false;
+		unsubscribe();
+	};
+}
+
+/**
+ * Decide whether the terminal result may be sealed now.
+ *
+ * A forced exit path seals unconditionally. Otherwise the terminal boundary is
+ * drained and the episode checked for a continuation — but the check on its own
+ * settles nothing, because work enters through a custody gate that stays open
+ * across every `await` here. A check that yields before sealing can have its
+ * answer invalidated by extension, IRC, or yield-queue work admitted in the gap,
+ * and the terminal result would then be written over work that is still running.
+ *
+ * So acceptance closes in the same synchronous step the first drain resolves in,
+ * and the boundary is drained a second time with the gate shut — nothing new can
+ * enter now, and work admitted *during* the first drain reaches a boundary and
+ * becomes visible. Only then does the continuation check decide. Finding a
+ * continuation abandons the attempt and reopens acceptance.
+ */
+export async function prepareRpcResultSeal(
+	force: boolean,
+	drain: () => Promise<void>,
+	hasPendingContinuation: () => boolean,
+	acceptance?: RpcResultSealAcceptance,
+): Promise<boolean> {
+	if (force) return true;
+	await drain();
+	acceptance?.close();
+	try {
+		await drain();
+		if (!hasPendingContinuation()) return true;
+	} catch (errorValue) {
+		acceptance?.reopen();
+		throw errorValue;
+	}
+	acceptance?.reopen();
+	return false;
+}
+export async function compactRpcSession<T>(
+	isStreaming: boolean,
+	compact: () => Promise<T>,
+	sealResult?: (stopReason: string, outcome: "aborted") => Promise<void>,
+): Promise<T> {
+	try {
+		return await compact();
+	} finally {
+		if (isStreaming) await sealResult?.("aborted", "aborted");
+	}
+}
+
+export async function materializeRpcCustodyTranscript(session: {
+	readonly sessionFile: string | undefined;
+	sessionManager: { ensureOnDisk(): Promise<void> };
+}): Promise<string> {
+	if (!session.sessionFile) throw new Error("Durable RPC custody requires a persisted session");
+	await session.sessionManager.ensureOnDisk();
+	const sessionFile = session.sessionFile;
+	if (!sessionFile) throw new Error("Durable RPC custody requires a persisted session");
+	return sessionFile;
+}
+
+export async function waitForRpcMessageDurability(
+	session: {
+		waitForMessagePersistence(message: AgentMessage): Promise<void>;
+		sessionManager: { flush(): Promise<void> };
+	},
+	message: AgentMessage,
+): Promise<void> {
+	await session.waitForMessagePersistence(message);
+	await session.sessionManager.flush();
+}
+
+export function reuseRpcHarnessBinding(
+	owner: Pick<RpcHarnessSessionOwner, "isBoundToRun" | "sessionId"> | undefined,
+	runId: string,
+):
+	| {
+			owner: Pick<RpcHarnessSessionOwner, "isBoundToRun" | "sessionId">;
+			binding: { runId: string; sessionId: string; existing: true };
+	  }
+	| undefined {
+	if (!owner?.isBoundToRun(runId)) return undefined;
+	return { owner, binding: { runId, sessionId: owner.sessionId, existing: true } };
+}
+export function hasActiveRpcSessionWork(
+	session: Pick<
+		AgentSession,
+		| "hasPendingAdvisorReviews"
+		| "hasPendingAsyncWork"
+		| "hasPendingBashMessages"
+		| "hasPendingExtensionEvents"
+		| "hasQueuedAgentMessages"
+		| "isCompacting"
+		| "isStreaming"
+	>,
+	hasTrackedTasks: boolean,
+	hasActivePrompts: boolean,
+	hasPendingAgentMessageTasks: boolean,
+): boolean {
+	return (
+		hasPendingRpcContinuation(session) ||
+		session.hasPendingExtensionEvents ||
+		hasTrackedTasks ||
+		hasActivePrompts ||
+		hasPendingAgentMessageTasks
+	);
+}
+
+export async function disposeRpcSessionWithCustody(
+	session: { dispose(): Promise<void> },
+	owner?: { dispose(): Promise<void> },
+): Promise<void> {
+	await session.dispose();
+	await owner?.dispose();
+}
+
+export async function deliverRpcSteeringIfNeeded(
+	alreadyPersisted: boolean,
+	deliver: () => Promise<boolean | void>,
+): Promise<void> {
+	if (alreadyPersisted) return;
+	if ((await deliver()) === false) throw new Error("Steering delivery was cancelled before the message was queued");
+}
+
+function providerSafeAssistantText(event: AgentSessionEvent): string | undefined {
+	if (event.type !== "message_end" || event.message.role !== "assistant") return undefined;
+	const safeEvent = persistenceSafeAgentSessionEvent(event);
+	if (safeEvent.type !== "message_end" || safeEvent.message.role !== "assistant") return undefined;
+	const text = safeEvent.message.content
+		.filter(block => block.type === "text")
+		.map(block => block.text)
+		.join("")
+		.trim();
+	return text || undefined;
+}
+
+function addRpcUsage(target: RpcSessionUsage, usage: Usage): void {
+	target.input += usage.input;
+	target.output += usage.output;
+	target.reasoning += usage.reasoningTokens ?? 0;
+	target.cacheRead += usage.cacheRead;
+	target.cacheWrite += usage.cacheWrite;
+	target.total += usage.totalTokens;
+}
+
+export function summarizeRpcEpisode(events: readonly RpcHarnessEvent[]): {
+	finalMessage: string;
+	usage: RpcSessionUsage;
+} {
+	let finalMessage = "";
+	const usage: RpcSessionUsage = { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+	for (const event of events) {
+		if (event.type !== "message_end") continue;
+		finalMessage = providerSafeAssistantText(event as AgentSessionEvent) ?? finalMessage;
+		const messageUsage = sessionMessageUsage(event.message);
+		if (messageUsage) addRpcUsage(usage, messageUsage);
+	}
+	return { finalMessage, usage };
+}
 
 export type PendingExtensionRequest = {
 	resolve: (response: RpcExtensionUIResponse) => void;
@@ -172,6 +444,14 @@ type RpcExtensionUserMessageScope = {
  */
 export class RpcExtensionUserMessageTracker {
 	#activePromptScopes = new Set<RpcExtensionUserMessageScope>();
+	#pendingAgentMessageTasks = new Set<Promise<void>>();
+	get hasActivePrompts(): boolean {
+		return this.#activePromptScopes.size > 0;
+	}
+
+	get hasPendingAgentMessageTasks(): boolean {
+		return this.#pendingAgentMessageTasks.size > 0;
+	}
 
 	markAgentMessageTask(): void {
 		for (const scope of this.#activePromptScopes) {
@@ -180,6 +460,14 @@ export class RpcExtensionUserMessageTracker {
 	}
 
 	trackAgentMessageTask(task: Promise<unknown>): void {
+		const pendingTask = task.then(
+			() => {},
+			() => {},
+		);
+		this.#pendingAgentMessageTasks.add(pendingTask);
+		void pendingTask.then(() => {
+			this.#pendingAgentMessageTasks.delete(pendingTask);
+		});
 		for (const scope of this.#activePromptScopes) {
 			this.#trackAgentMessageTaskForScope(scope, task);
 		}
@@ -201,6 +489,12 @@ export class RpcExtensionUserMessageTracker {
 	async #waitForAgentMessageTasks(scope: RpcExtensionUserMessageScope): Promise<void> {
 		while (scope.pendingAgentMessageTasks.size > 0) {
 			await Promise.allSettled(Array.from(scope.pendingAgentMessageTasks));
+		}
+	}
+
+	async waitForPendingAgentMessageTasks(): Promise<void> {
+		while (this.#pendingAgentMessageTasks.size > 0) {
+			await Promise.allSettled([...this.#pendingAgentMessageTasks]);
 		}
 	}
 
@@ -237,16 +531,159 @@ export function watchAndReportLocalOnlyPromptResult(input: {
 	output: (obj: object) => void;
 	onError: (error: Error) => void;
 	extensionUserMessageTracker: RpcExtensionUserMessageTracker;
+	trackPrompt?: (task: Promise<boolean>) => Promise<boolean>;
 }): void {
 	const trackedPrompt = input.extensionUserMessageTracker.watchPrompt(input.startPrompt);
 	reportLocalOnlyPromptResult({
 		id: input.id,
-		prompt: trackedPrompt.prompt,
+		prompt: input.trackPrompt?.(trackedPrompt.prompt) ?? trackedPrompt.prompt,
 		output: input.output,
 		onError: input.onError,
 		hasExtensionAgentMessageTask: trackedPrompt.hasAgentMessageTask,
 		waitForExtensionAgentMessageTasks: trackedPrompt.waitForAgentMessageTasks,
 	});
+}
+
+export class RpcTerminalTaskTracker {
+	#tasks = new Set<Promise<unknown>>();
+
+	track<T>(task: Promise<T>): Promise<T> {
+		this.#tasks.add(task);
+		void task.finally(() => this.#tasks.delete(task)).catch(() => {});
+		return task;
+	}
+
+	get hasPendingTasks(): boolean {
+		return this.#tasks.size > 0;
+	}
+
+	async wait(): Promise<void> {
+		while (this.#tasks.size > 0) {
+			await Promise.allSettled([...this.#tasks]);
+		}
+	}
+}
+export function rpcForcedExitOutcome(
+	session: Parameters<typeof hasPendingRpcContinuation>[0],
+	terminalTasks: Pick<RpcTerminalTaskTracker, "hasPendingTasks">,
+): "aborted" | "completed" {
+	return rpcExitOutcome(hasPendingRpcContinuation(session) || terminalTasks.hasPendingTasks);
+}
+
+export async function drainRpcTerminalBoundary(
+	session: Pick<
+		AgentSession,
+		| "flushPendingBashMessages"
+		| "hasPendingAdvisorReviews"
+		| "hasPendingBashMessages"
+		| "hasPendingExtensionEvents"
+		| "waitForPendingAdvisorReviews"
+		| "waitForPendingExtensionEvents"
+	>,
+	terminalTasks: RpcTerminalTaskTracker,
+	extensionTasks: RpcExtensionUserMessageTracker,
+): Promise<void> {
+	do {
+		await session.waitForPendingExtensionEvents();
+		await Promise.all([terminalTasks.wait(), extensionTasks.waitForPendingAgentMessageTasks()]);
+		if (session.hasPendingBashMessages) await session.flushPendingBashMessages();
+		// Give an in-flight advisor review its chance to land inside the boundary
+		// rather than after the terminal result. The wait is bounded, so it is
+		// deliberately absent from the loop condition below: an advisor that never
+		// catches up would otherwise spin here. What it leaves behind stays visible
+		// to `hasPendingRpcContinuation`, which then refuses the seal outright.
+		if (session.hasPendingAdvisorReviews) await session.waitForPendingAdvisorReviews();
+	} while (
+		session.hasPendingExtensionEvents ||
+		terminalTasks.hasPendingTasks ||
+		extensionTasks.hasPendingAgentMessageTasks ||
+		session.hasPendingBashMessages
+	);
+}
+
+export class RpcCustodyBindingGuard {
+	#binding = false;
+
+	async run<T>(bind: () => Promise<T>): Promise<T> {
+		if (this.#binding) throw new Error("Durable RPC custody binding is already in progress");
+		this.#binding = true;
+		try {
+			return await bind();
+		} finally {
+			this.#binding = false;
+		}
+	}
+
+	assertWorkAllowed(): void {
+		if (this.#binding) throw new Error("Agent work is unavailable while durable RPC custody is binding");
+	}
+
+	assertSessionChangeAllowed(): void {
+		if (this.#binding) throw new Error("Session changes are unavailable while durable RPC custody is binding");
+	}
+}
+
+/**
+ * Dependencies for {@link streamRpcSessionEvent}. Provided by the RPC mode
+ * entrypoint; broken out so tests can drive the event path with stubs.
+ */
+export interface RpcSessionEventStreamDeps {
+	/** The ledger for the currently bound run, or undefined while none is bound. */
+	ledger: () => RpcHarnessSessionOwner | undefined;
+	output: (frame: object) => void;
+	sealResult: (stopReason: string, outcome: "completed" | "failed" | "aborted") => Promise<void>;
+	waitForMessagePersistence: (message: AgentMessage) => Promise<void>;
+	trackSteeringPersistence: (task: Promise<void>) => void;
+	onLedgerFailure: (command: string, error: unknown) => void;
+}
+
+/**
+ * Write one agent event to stdout.
+ *
+ * A bound run records and sequences the event before it is published, and a
+ * failed append reports `session.watch` and stops the run: emitting an event the
+ * client can never replay would break the replay cursor it depends on. An
+ * `agent_end` under a bound run also seals the terminal result. With no bound
+ * run the event is written straight through, unsequenced and unrecorded, which
+ * is the stream every client saw before the ledger existed.
+ */
+export function streamRpcSessionEvent(
+	event: AgentSessionEvent,
+	deps: RpcSessionEventStreamDeps,
+): Promise<void> | undefined {
+	const ledger = deps.ledger();
+	if (!ledger) {
+		deps.output(event);
+		return undefined;
+	}
+	if (ledger.hasResult) return undefined;
+	const eventPersistence = ledger.appendEvent(persistenceSafeAgentSessionEvent(event), event).then(() => undefined);
+	void eventPersistence.catch(errorValue => {
+		if (ledger.hasResult) return;
+		deps.onLedgerFailure("session.watch", errorValue);
+	});
+	if (event.type === "message_end" && event.message.role === "user" && event.message.idempotencyKey) {
+		const prefix = `rpc:${ledger.sessionId}:`;
+		if (event.message.idempotencyKey.startsWith(prefix)) {
+			const steeringId = event.message.idempotencyKey.slice(prefix.length);
+			const persistence = deps
+				.waitForMessagePersistence(event.message)
+				.then(() => ledger.markSteeringInjected(steeringId));
+			deps.trackSteeringPersistence(persistence);
+			void persistence.catch(errorValue => deps.onLedgerFailure("session.steer", errorValue));
+		}
+	}
+	if (event.type === "agent_end" && event.isTerminal === true) {
+		const assistantMessage = [...event.messages].reverse().find(message => message.role === "assistant") as
+			| { stopReason?: string }
+			| undefined;
+		const stopReason = assistantMessage?.stopReason ?? "completed";
+		const outcome = stopReason === "aborted" ? "aborted" : stopReason === "error" ? "failed" : "completed";
+		void deps.sealResult(stopReason, outcome).catch(errorValue => {
+			deps.onLedgerFailure("session.result", errorValue);
+		});
+	}
+	return eventPersistence;
 }
 
 /**
@@ -316,6 +753,10 @@ export function dispatchRpcControlFrame(parsed: unknown, deps: RpcInputFrameDeps
  *   for the command has been emitted via `output`. Errors from `handleCommand`
  *   on non-`bash` commands propagate; the caller is expected to wrap them.
  */
+function isBackgroundRpcCommand(command: RpcCommand): boolean {
+	return command.type === "bash" || command.type === "session.result";
+}
+
 export function dispatchRpcInputFrame(parsed: unknown, deps: RpcInputFrameDeps): Promise<void> | undefined {
 	if (dispatchRpcControlFrame(parsed, deps)) return undefined;
 	// Regular RPC command. The transport contract states each remaining frame
@@ -324,17 +765,16 @@ export function dispatchRpcInputFrame(parsed: unknown, deps: RpcInputFrameDeps):
 	// the union here.
 	const command = parsed as RpcCommand;
 
-	// `bash` can run for a long time. Dispatch it in the background so a
-	// subsequent `abort_bash` frame can be read and handled without waiting
-	// for the shell command to finish on its own. The response is emitted
-	// when `handleCommand` resolves; clients correlate via `command.id`.
-	if (command.type === "bash") {
+	// Long-running commands dispatch in the background so later control and
+	// steering commands can overtake them. The response is emitted when the
+	// command resolves; clients correlate it through `command.id`.
+	if (isBackgroundRpcCommand(command)) {
 		const task = (async () => {
 			try {
 				deps.output(await deps.handleCommand(command));
 			} catch (err: unknown) {
 				const message = err instanceof Error ? err.message : String(err);
-				deps.output(deps.errorResponse(command.id, "bash", message));
+				deps.output(deps.errorResponse(command.id, command.type, message));
 			}
 		})();
 		deps.trackBackgroundTask?.(task);
@@ -350,12 +790,26 @@ export function dispatchRpcInputFrame(parsed: unknown, deps: RpcInputFrameDeps):
 export class RpcInputDispatcher {
 	#tail: Promise<void> = Promise.resolve();
 	#tasks = new Set<Promise<void>>();
+	#resultWaits = new Set<Promise<void>>();
+	#running = new Set<RpcCommand>();
+	#closing = false;
 	readonly #deps: RpcInputFrameDeps;
 	readonly #afterSerialCommand: (() => Promise<void>) | undefined;
+	readonly #isLongRunningSerialCommand: ((command: RpcCommand) => boolean) | undefined;
+	readonly #abortSerialCommand: ((command: RpcCommand) => void) | undefined;
 
-	constructor(options: { deps: RpcInputFrameDeps; afterSerialCommand?: () => Promise<void> }) {
+	constructor(options: {
+		deps: RpcInputFrameDeps;
+		afterSerialCommand?: () => Promise<void>;
+		/** Whether a serial command starts work that only an abort can settle. */
+		isLongRunningSerialCommand?: (command: RpcCommand) => boolean;
+		/** Aborts the started work of a long-running serial command. */
+		abortSerialCommand?: (command: RpcCommand) => void;
+	}) {
 		this.#deps = options.deps;
 		this.#afterSerialCommand = options.afterSerialCommand;
+		this.#isLongRunningSerialCommand = options.isLongRunningSerialCommand;
+		this.#abortSerialCommand = options.abortSerialCommand;
 	}
 
 	/** Accept a parsed input frame without blocking the stdin reader. */
@@ -364,7 +818,24 @@ export class RpcInputDispatcher {
 			if (dispatchRpcControlFrame(parsed, this.#deps)) return;
 
 			const command = parsed as RpcCommand;
-			if (command.type === "bash") {
+			if (command.type === "session.result") {
+				// A result wait can only settle once terminal state exists, and on
+				// the EOF path that state is created by `sealLedgerOnExit()` which
+				// runs *after* `drain()`. Result waits therefore get their own
+				// custody set instead of `#tasks`: the pre-seal drain covers the
+				// serial tail only, and `drainResultWaits()` (post-seal) plus
+				// `trackBackgroundTask` keep shutdown and disposal waiting for the
+				// response frame this command still owes the client.
+				const wait = this.#tail.then(
+					() => this.#dispatchResultWait(command),
+					() => this.#dispatchResultWait(command),
+				);
+				this.#resultWaits.add(wait);
+				void wait.finally(() => this.#resultWaits.delete(wait)).catch(() => {});
+				return;
+			}
+
+			if (isBackgroundRpcCommand(command)) {
 				dispatchRpcInputFrame(command, this.#deps);
 				return;
 			}
@@ -384,24 +855,130 @@ export class RpcInputDispatcher {
 		}
 	}
 
-	/** Await every accepted serial command, including commands queued before EOF. */
+	/**
+	 * Close the accepted serial tail for an exit path.
+	 *
+	 * A serial command that only an abort can settle — `compact` parked on a
+	 * provider summary is the case that wedges the process — is aborted here if
+	 * it has already started, so {@link drain} can finish. The abort has to
+	 * happen before that drain rather than during teardown: the exit path seals
+	 * the ledger after the drain, and `session.dispose()`, which owns this abort
+	 * today, runs only after the seal. Waiting first costs the whole exit and
+	 * buys nothing, because disposal aborts the same work moments later anyway.
+	 *
+	 * A command of that kind still queued has not started, so there is nothing to
+	 * abort; it is refused when its turn comes instead, since starting fresh
+	 * long-running work after the client is gone would re-stall the drain this
+	 * abort just unblocked. Ordinary queued commands are untouched and still run.
+	 * Both refused and aborted commands settle through
+	 * {@link RpcInputDispatcher.dispatch}'s serial path, so each still emits the
+	 * response or error frame it owes the client.
+	 */
+	closeForExit(): void {
+		this.#closing = true;
+		for (const command of this.#running) {
+			if (this.#isLongRunningSerialCommand?.(command)) this.#abortSerialCommand?.(command);
+		}
+	}
+
+	/**
+	 * Await every accepted serial command, including commands queued before EOF.
+	 *
+	 * Deferred `session.result` waits are deliberately excluded — see
+	 * {@link drainResultWaits} — so an exit path can finish this drain and seal
+	 * the terminal result the waiters are blocked on.
+	 */
 	async drain(): Promise<void> {
 		while (this.#tasks.size > 0) {
 			await Promise.allSettled(Array.from(this.#tasks));
 		}
 	}
 
+	/** Whether a `session.result` command still owes the client a response frame. */
+	get hasPendingResultWaits(): boolean {
+		return this.#resultWaits.size > 0;
+	}
+
+	/**
+	 * Await every accepted `session.result` command, including one still queued
+	 * behind the serial tail. Only safe once the terminal result has been sealed.
+	 */
+	async drainResultWaits(): Promise<void> {
+		while (this.#resultWaits.size > 0) {
+			await Promise.allSettled(Array.from(this.#resultWaits));
+		}
+	}
+
+	/**
+	 * Run a deferred `session.result` once the serial tail settles.
+	 *
+	 * {@link dispatchRpcInputFrame} dispatches it in the background and hands the
+	 * wait to `trackBackgroundTask`; that task is intercepted here (and still
+	 * forwarded) so this promise covers the whole command — queue wait, dispatch,
+	 * and the wait for terminal state — and dispatch failures still reach the
+	 * client as a response frame instead of an unhandled rejection.
+	 */
+	async #dispatchResultWait(command: RpcCommand): Promise<void> {
+		let resultWait: Promise<void> | undefined;
+		try {
+			const awaited = dispatchRpcInputFrame(command, {
+				...this.#deps,
+				trackBackgroundTask: task => {
+					resultWait = task;
+					this.#deps.trackBackgroundTask?.(task);
+				},
+			});
+			if (awaited) await awaited;
+			if (resultWait) await resultWait;
+		} catch (err: unknown) {
+			const message = err instanceof Error ? err.message : String(err);
+			this.#deps.output(this.#deps.errorResponse(command.id, command.type, message));
+		}
+	}
+
 	async #dispatchSerialCommand(command: RpcCommand): Promise<void> {
 		try {
+			// Reached its turn only after the exit path closed the tail: starting
+			// long-running work now would re-stall the drain that close unblocked.
+			// Refusing is still custody — the error frame below is the response this
+			// command owes — whereas starting it would strand the exit again.
+			if (this.#closing && this.#isLongRunningSerialCommand?.(command)) {
+				throw new Error("RPC client disconnected before the command started");
+			}
+			this.#running.add(command);
 			const awaited = dispatchRpcInputFrame(command, this.#deps);
 			if (awaited) await awaited;
 		} catch (err: unknown) {
 			const message = err instanceof Error ? err.message : String(err);
 			this.#deps.output(this.#deps.errorResponse(command.id, command.type, message));
 		} finally {
+			this.#running.delete(command);
 			await this.#afterSerialCommand?.();
 		}
 	}
+}
+
+export async function finalizeRpcInputAfterEof(
+	drainInput: () => Promise<void>,
+	sealLedger: () => Promise<void>,
+	drainBackground: () => Promise<void>,
+): Promise<void> {
+	await drainInput();
+	await sealLedger();
+	await drainBackground();
+}
+
+/**
+ * Whether an exit path must still force the terminal seal.
+ *
+ * Failure reporting latches on the first durable failure from any path,
+ * including a session transcript flush that never reached the ledger. Only a
+ * latched ledger append failure takes sealing away, so every other failure
+ * still has to seal: an unsealed ledger leaves `session.result` waiters blocked
+ * in the shutdown drain and the episode without terminal state.
+ */
+export function shouldForceLedgerSeal(ledger: RpcHarnessSessionOwner | undefined): boolean {
+	return ledger?.canSealResult === true;
 }
 
 /**
@@ -421,10 +998,20 @@ export class RpcShutdownCoordinator {
 	#shutdown: Promise<void> | undefined;
 	readonly #isShutdownRequested: () => boolean;
 	readonly #performShutdown: () => Promise<void>;
+	readonly #prepareShutdown: (() => Promise<void>) | undefined;
 
-	constructor(options: { isShutdownRequested: () => boolean; performShutdown: () => Promise<void> }) {
+	constructor(options: {
+		isShutdownRequested: () => boolean;
+		prepareShutdown?: () => Promise<void>;
+		performShutdown: () => Promise<void>;
+	}) {
 		this.#isShutdownRequested = options.isShutdownRequested;
+		this.#prepareShutdown = options.prepareShutdown;
 		this.#performShutdown = options.performShutdown;
+	}
+
+	get hasTrackedTasks(): boolean {
+		return this.#tasks.size > 0;
 	}
 
 	/**
@@ -457,7 +1044,8 @@ export class RpcShutdownCoordinator {
 	checkShutdownRequested(): Promise<void> {
 		if (!this.#shutdown) {
 			if (!this.#isShutdownRequested()) return Promise.resolve();
-			this.#shutdown = this.drain().then(() => this.#performShutdown());
+			this.#shutdown = this.#prepareShutdown?.().then(() => this.drain()) ?? this.drain();
+			this.#shutdown = this.#shutdown.then(() => this.#performShutdown());
 		}
 		return this.#shutdown;
 	}
@@ -724,7 +1312,132 @@ export async function runRpcMode(
 	const hostToolBridge = new RpcHostToolBridge(output);
 	const hostUriBridge = new RpcHostUriBridge(output);
 	const subagentRegistry = eventBus ? new RpcSubagentRegistry(eventBus, output) : undefined;
+	// The durable ledger stays dormant until a supervisor claims a run through
+	// `session.start` or `session.resume`. A client that never sends those keeps
+	// the original stream: events reach stdout directly, carry no sequence, and
+	// nothing is written to disk.
+	let harnessOwner: RpcHarnessSessionOwner | undefined;
+	let episodeFinalMessage = "";
+	let episodeUsage: RpcSessionUsage = { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+	const terminalTasks = new RpcTerminalTaskTracker();
+	const bindingGuard = new RpcCustodyBindingGuard();
+	session.setBackgroundAgentWorkGuard(() => {
+		bindingGuard.assertWorkAllowed();
+		harnessOwner?.assertAcceptingWork();
+	});
+	const UNBOUND_RUN_ERROR = "No run is bound: send session.start or session.resume first";
+	const bindHarness = (runId: string) => {
+		const reused = reuseRpcHarnessBinding(harnessOwner, runId);
+		if (reused) {
+			return Promise.resolve({
+				owner: reused.owner as RpcHarnessSessionOwner,
+				binding: reused.binding,
+			});
+		}
+		const existingOwner = harnessOwner;
+		return bindingGuard
+			.run(async () => {
+				const sessionFile = await materializeRpcCustodyTranscript(session);
+				const owner =
+					existingOwner ??
+					(await RpcHarnessSessionOwner.open(
+						session.sessionId,
+						rpcHarnessRecordFileForSessionFile(sessionFile),
+						event => output(event),
+						path.join(path.dirname(sessionFile), "rpc-runs.jsonl"),
+						{
+							acquireSessionLease: true,
+							displayEvent: event => session.restoreProviderValueForDisplay(event),
+							displayResult: result => ({
+								...result,
+								finalMessage: session.restoreProviderTextForDisplay(result.finalMessage),
+							}),
+						},
+					));
+				try {
+					const binding = await owner.bindRun(runId);
+					if (!harnessOwner) {
+						harnessOwner = owner;
+						const summary = summarizeRpcEpisode(await owner.replayPersisted());
+						episodeFinalMessage = summary.finalMessage;
+						episodeUsage = summary.usage;
+					}
+					return { owner, binding };
+				} catch (error) {
+					if (!existingOwner) await owner.dispose();
+					throw error;
+				}
+			})
+			.finally(() => {
+				// Binding parks yield-queue idle wakes instead of dropping them, and a parked
+				// flush has no self-rearming timer. Custody has settled by the time this runs,
+				// so re-arm once: entries still blocked by a sealed episode simply park again
+				// at the next wake check.
+				session.yieldQueue.requestIdleFlush();
+			});
+	};
+	let pendingAdvisorSealRetryUnsubscribe: (() => void) | undefined;
 
+	const completeRpcResult = async (
+		stopReason: string,
+		outcome: "completed" | "failed" | "aborted" = "completed",
+		force = false,
+	) => {
+		const owner = harnessOwner;
+		if (!owner || owner.hasResult) {
+			pendingAdvisorSealRetryUnsubscribe?.();
+			pendingAdvisorSealRetryUnsubscribe = undefined;
+			return;
+		}
+		if (
+			!(await prepareRpcResultSeal(
+				force,
+				() => drainRpcTerminalBoundary(session, terminalTasks, extensionUserMessageTracker),
+				() => hasPendingRpcContinuation(session),
+				rpcResultSealAcceptance(owner, () => session.yieldQueue.requestIdleFlush()),
+			))
+		) {
+			if (session.hasPendingAdvisorReviews && !pendingAdvisorSealRetryUnsubscribe) {
+				pendingAdvisorSealRetryUnsubscribe = retryRpcResultSealAfterAdvisorSettlement(session, () => {
+					pendingAdvisorSealRetryUnsubscribe = undefined;
+					void completeRpcResult(stopReason, outcome).catch(errorValue => {
+						output(
+							error(
+								undefined,
+								"session.result",
+								errorValue instanceof Error ? errorValue.message : String(errorValue),
+							),
+						);
+					});
+				});
+			}
+			return;
+		}
+		pendingAdvisorSealRetryUnsubscribe?.();
+		pendingAdvisorSealRetryUnsubscribe = undefined;
+		owner.beginResultSeal();
+		await owner.completeResult({
+			outcome,
+			stopReason,
+			finalMessage: episodeFinalMessage,
+			usage: episodeUsage,
+		});
+	};
+
+	/**
+	 * Seals the ledger on an exit path. The teardown that follows must run even
+	 * when the terminal result cannot be recorded, so the failure is emitted as a
+	 * response frame and the exit continues.
+	 */
+	const sealLedgerOnExit = async (stopReason: string, outcome: "completed" | "failed" | "aborted" = "completed") => {
+		try {
+			await completeRpcResult(stopReason, outcome, true);
+		} catch (errorValue) {
+			output(
+				error(undefined, "session.result", errorValue instanceof Error ? errorValue.message : String(errorValue)),
+			);
+		}
+	};
 	// Shutdown request flag (wrapped in object to allow mutation with const)
 	const shutdownState = { requested: false };
 
@@ -945,12 +1658,56 @@ export async function runRpcMode(
 		trackAgentInvokingMessage: task => {
 			extensionUserMessageTracker.trackAgentMessageTask(task);
 		},
+		assertAgentWorkAllowed: () => {
+			bindingGuard.assertWorkAllowed();
+			harnessOwner?.assertAcceptingWork();
+		},
+		assertSessionChangeAllowed: () => {
+			bindingGuard.assertSessionChangeAllowed();
+			if (harnessOwner) throw new Error("Session changes are unavailable after durable RPC custody is bound");
+		},
+		runCompact: instructionsOrOptions =>
+			compactRpcSession(
+				session.isStreaming,
+				() => runExtensionCompact(session, instructionsOrOptions),
+				harnessOwner ? completeRpcResult : undefined,
+			),
 		uiContext: rpcUiContext,
 	});
 
-	// Output all agent events as JSON
+	let requestFatalWatchShutdown: (() => Promise<void>) | undefined;
+	let watchFailureReported = false;
+	/**
+	 * Reports the first durable failure once and requests shutdown. The latch is
+	 * reporting only — whether the ledger can still record terminal state is
+	 * answered by the ledger itself, through {@link shouldForceLedgerSeal}.
+	 */
+	const reportLedgerFailure = (command: string, errorValue: unknown) => {
+		if (watchFailureReported) return;
+		watchFailureReported = true;
+		shutdownState.requested = true;
+		output(error(undefined, command, errorValue instanceof Error ? errorValue.message : String(errorValue)));
+		void requestFatalWatchShutdown?.();
+	};
+	const eventPersistence = new WeakMap<AgentSessionEvent, Promise<void>>();
+	session.registerMessagePersistenceBarrier(event => eventPersistence.get(event) ?? Promise.resolve());
 	session.subscribe(event => {
-		output(event);
+		if (harnessOwner && event.type === "message_end") {
+			episodeFinalMessage = providerSafeAssistantText(event) ?? episodeFinalMessage;
+			const usage = sessionMessageUsage(event.message);
+			if (usage) addRpcUsage(episodeUsage, usage);
+		}
+		const persistence = streamRpcSessionEvent(event, {
+			ledger: () => harnessOwner,
+			output,
+			sealResult: completeRpcResult,
+			waitForMessagePersistence: message => waitForRpcMessageDurability(session, message),
+			trackSteeringPersistence: task => {
+				terminalTasks.track(task);
+			},
+			onLedgerFailure: reportLedgerFailure,
+		});
+		if (persistence) eventPersistence.set(event, persistence);
 	});
 
 	const getAvailableCommands = async () => buildAvailableSlashCommands(session);
@@ -974,6 +1731,8 @@ export async function runRpcMode(
 	// Handle a single command
 	const handleCommand = async (command: RpcCommand): Promise<RpcResponse> => {
 		const id = command.id;
+		const handoffCompaction = (): boolean =>
+			session.settings.get("compaction.strategy") === "handoff" && session.autoCompactionEnabled;
 
 		switch (command.type) {
 			case "negotiate_protocol": {
@@ -987,11 +1746,20 @@ export async function runRpcMode(
 			// =================================================================
 
 			case "prompt": {
-				const skillResult = await tryRunRpcSkillCommand(session, command.message, command.streamingBehavior);
+				harnessOwner?.assertAcceptingWork();
+				if (harnessOwner && isRpcCustodyRestrictedPrompt(command.message)) {
+					const name = parseSlashCommand(command.message)?.name;
+					return name === "compact"
+						? error(id, "prompt", "Use the compact RPC command after durable RPC custody is bound")
+						: error(id, "prompt", "Session changes are unavailable after durable RPC custody is bound");
+				}
+				const skillTask = tryRunRpcSkillCommand(session, command.message, command.streamingBehavior);
+				if (harnessOwner) terminalTasks.track(skillTask);
+				const skillResult = await skillTask;
 				if (skillResult) {
 					return success(id, "prompt", skillResult);
 				}
-				const builtinResult = await executeAcpBuiltinSlashCommand(command.message, {
+				const builtinTask = executeAcpBuiltinSlashCommand(command.message, {
 					session,
 					sessionManager: session.sessionManager,
 					settings: session.settings,
@@ -1006,14 +1774,19 @@ export async function runRpcMode(
 						output({ type: "config_update", model: session.model, thinkingLevel: session.thinkingLevel });
 					},
 				});
+				const builtinResult = await (harnessOwner ? terminalTasks.track(builtinTask) : builtinTask);
 				if (builtinResult !== false) {
 					if ("prompt" in builtinResult) {
 						watchAndReportLocalOnlyPromptResult({
 							id,
-							startPrompt: () => session.prompt(builtinResult.prompt, { images: command.images }),
+							startPrompt: () =>
+								startRpcResidualPrompt(harnessOwner, () =>
+									session.prompt(builtinResult.prompt, { images: command.images }),
+								),
 							output,
 							onError: promptError => output(error(id, "prompt", promptError.message)),
 							extensionUserMessageTracker,
+							trackPrompt: task => terminalTasks.track(task),
 						});
 						return success(id, "prompt");
 					}
@@ -1033,17 +1806,122 @@ export async function runRpcMode(
 					output,
 					onError: promptError => output(error(id, "prompt", promptError.message)),
 					extensionUserMessageTracker,
+					trackPrompt: task => terminalTasks.track(task),
 				});
 				return success(id, "prompt");
 			}
+			case "session.start": {
+				if (
+					hasActiveRpcSessionWork(
+						session,
+						shutdownCoordinator.hasTrackedTasks,
+						extensionUserMessageTracker.hasActivePrompts,
+						extensionUserMessageTracker.hasPendingAgentMessageTasks,
+					) &&
+					!harnessOwner?.isBoundToRun(command.run_id)
+				) {
+					return error(id, "session.start", "Durable RPC custody must be bound before active session work");
+				}
+				if (handoffCompaction()) {
+					return error(
+						id,
+						"session.start",
+						"Disable automatic handoff compaction before binding durable RPC custody",
+					);
+				}
+				const { binding } = await bindHarness(command.run_id);
+				return success(id, "session.start", {
+					run_id: binding.runId,
+					session_id: binding.sessionId,
+					existing: binding.existing,
+				});
+			}
+
+			case "session.resume": {
+				if (
+					hasActiveRpcSessionWork(
+						session,
+						shutdownCoordinator.hasTrackedTasks,
+						extensionUserMessageTracker.hasActivePrompts,
+						extensionUserMessageTracker.hasPendingAgentMessageTasks,
+					) &&
+					!harnessOwner?.isBoundToRun(command.run_id)
+				) {
+					return error(id, "session.resume", "Durable RPC custody must be bound before active session work");
+				}
+				if (handoffCompaction()) {
+					return error(
+						id,
+						"session.resume",
+						"Disable automatic handoff compaction before binding durable RPC custody",
+					);
+				}
+				if (command.session_id !== undefined && command.session_id !== session.sessionId) {
+					return error(id, "session.resume", `Unknown session_id: ${command.session_id}`);
+				}
+				const { owner, binding } = await bindHarness(command.run_id);
+				const events = await owner.replay(command.after_sequence);
+				for (const event of events) output(event);
+				return success(id, "session.resume", {
+					run_id: binding.runId,
+					session_id: binding.sessionId,
+					existing: binding.existing,
+				});
+			}
+
+			case "session.replay":
+			case "session.watch": {
+				if (!harnessOwner) return error(id, command.type, UNBOUND_RUN_ERROR);
+				const limit = command.limit ?? 1_000;
+				const events = await harnessOwner.replay(command.after_sequence, limit);
+				const nextSequence = events.at(-1)?.sequence ?? command.after_sequence ?? 0;
+				return success(id, command.type, {
+					events,
+					next_sequence: nextSequence,
+					has_more: harnessOwner.latestSequence > nextSequence,
+				});
+			}
+
+			case "session.result": {
+				if (!harnessOwner) return error(id, "session.result", UNBOUND_RUN_ERROR);
+				const result = await harnessOwner.waitResult();
+				return success(id, "session.result", result);
+			}
+
+			case "session.steer": {
+				if (!harnessOwner) return error(id, "session.steer", UNBOUND_RUN_ERROR);
+				harnessOwner.assertAcceptingWork();
+				const idempotencyKey = `rpc:${session.sessionId}:${command.steering_id}`;
+				const persistedMessage = session.findPersistedUserMessageByIdempotencyKey(idempotencyKey);
+				const ack = await terminalTasks.track(
+					harnessOwner.steer(
+						command.steering_id,
+						command.message,
+						() =>
+							deliverRpcSteeringIfNeeded(persistedMessage !== undefined, () =>
+								session.steerWithResult(command.message, command.images, {
+									idempotencyKey,
+								}),
+							),
+						rpcSteeringPayloadIdentity(command.message, command.images),
+					),
+				);
+				if (persistedMessage) {
+					await waitForRpcMessageDurability(session, persistedMessage);
+					await harnessOwner.markSteeringInjected(command.steering_id);
+				}
+				return success(id, "session.steer", ack);
+			}
 
 			case "steer": {
-				await session.steer(command.message, command.images);
+				harnessOwner?.assertAcceptingWork();
+				await terminalTasks.track(session.steer(command.message, command.images));
 				return success(id, "steer");
 			}
 
 			case "follow_up": {
-				await session.followUp(command.message, command.images);
+				harnessOwner?.assertAcceptingWork();
+				await terminalTasks.track(session.followUp(command.message, command.images));
 				return success(id, "follow_up");
 			}
 
@@ -1053,6 +1931,13 @@ export async function runRpcMode(
 			}
 
 			case "abort_and_prompt": {
+				if (harnessOwner) {
+					return error(
+						id,
+						"abort_and_prompt",
+						"abort_and_prompt is unavailable after durable RPC custody is bound",
+					);
+				}
 				await session.abort({ reason: USER_INTERRUPT_LABEL });
 				session
 					.prompt(command.message, { images: command.images })
@@ -1063,6 +1948,8 @@ export async function runRpcMode(
 			case "new_session":
 			case "switch_session":
 			case "branch": {
+				if (harnessOwner)
+					return error(id, command.type, "Session changes are unavailable after durable RPC custody is bound");
 				const result = await handleRpcSessionChange(session, command, subagentRegistry);
 				if (!result.data.cancelled) await emitAvailableCommandsUpdate();
 				return success(id, result.type, result.data);
@@ -1257,11 +2144,26 @@ export async function runRpcMode(
 			// =================================================================
 
 			case "compact": {
-				const result = await session.compact(command.customInstructions);
+				harnessOwner?.assertAcceptingWork();
+				if (harnessOwner && session.settings.get("compaction.strategy") === "handoff") {
+					return error(id, "compact", "Handoff compaction is unavailable after durable RPC custody is bound");
+				}
+				const result = await compactRpcSession(
+					session.isStreaming,
+					() => session.compact(command.customInstructions),
+					harnessOwner ? completeRpcResult : undefined,
+				);
 				return success(id, "compact", result);
 			}
 
 			case "set_auto_compaction": {
+				if (harnessOwner && command.enabled && session.settings.get("compaction.strategy") === "handoff") {
+					return error(
+						id,
+						"set_auto_compaction",
+						"Automatic handoff compaction is unavailable after durable RPC custody is bound",
+					);
+				}
 				session.setAutoCompactionEnabled(command.enabled);
 				return success(id, "set_auto_compaction");
 			}
@@ -1285,7 +2187,11 @@ export async function runRpcMode(
 			// =================================================================
 
 			case "bash": {
-				const result = await session.executeBash(command.command);
+				bindingGuard.assertWorkAllowed();
+				harnessOwner?.assertAcceptingWork();
+				const bashTask = session.executeBash(command.command);
+				if (harnessOwner) terminalTasks.track(bashTask);
+				const result = await bashTask;
 				return success(id, "bash", result);
 			}
 
@@ -1331,6 +2237,9 @@ export async function runRpcMode(
 			}
 
 			case "handoff": {
+				if (harnessOwner) {
+					return error(id, "handoff", "Handoff is unavailable after durable RPC custody is bound");
+				}
 				// Resetting the agent mid-stream lets the live turn keep emitting into a
 				// session that handoff has already torn down. Refuse while a prompt is in
 				// flight (mirrors the TUI /handoff guard).
@@ -1454,16 +2363,26 @@ export async function runRpcMode(
 	// re-checks the request as each task settles.
 	const shutdownCoordinator = new RpcShutdownCoordinator({
 		isShutdownRequested: () => shutdownState.requested,
+		prepareShutdown: async () => {
+			if (shouldForceLedgerSeal(harnessOwner)) {
+				await sealLedgerOnExit("shutdown_requested", rpcForcedExitOutcome(session, terminalTasks));
+			}
+		},
 		performShutdown: async () => {
 			// Route through the idempotent session.dispose() so the browser
 			// reaper (releaseTabsForOwner) and other bounded teardown run before
 			// the process exits. dispose() also emits `session_shutdown`, so we
 			// must NOT emit it separately here or the event fires twice. Skipping
 			// dispose left OMP-owned Chromium alive after RPC shutdown (#5643).
-			await session.dispose();
+			// Ledger sealing runs before the task drain so session.result waiters
+			// resolve before shutdown waits for their response frames.
+			await disposeRpcSessionWithCustody(session, harnessOwner);
+			await stdoutQueue;
 			process.exit(0);
 		},
 	});
+	requestFatalWatchShutdown = () => shutdownCoordinator.checkShutdownRequested();
+	if (shutdownState.requested) void requestFatalWatchShutdown();
 
 	const dispatchFrameDeps: RpcInputFrameDeps = {
 		handleCommand,
@@ -1479,6 +2398,12 @@ export async function runRpcMode(
 	const inputDispatcher = new RpcInputDispatcher({
 		deps: dispatchFrameDeps,
 		afterSerialCommand: () => shutdownCoordinator.checkShutdownRequested(),
+		// `compact` waits on a provider summary that can stall without limit, and
+		// it runs in the serial tail rather than in the background, so nothing but
+		// an abort settles it. Everything else here either answers as soon as its
+		// turn starts or is background-dispatched.
+		isLongRunningSerialCommand: command => command.type === "compact",
+		abortSerialCommand: () => session.abortCompaction(),
 	});
 
 	// Keep the stdin reader moving: side-channel frames dispatch immediately,
@@ -1504,16 +2429,31 @@ export async function runRpcMode(
 
 	// stdin closed — RPC client is gone. Fail pending side-channel requests
 	// first so active/queued commands can settle, then drain accepted work.
+	// Only the serial tail is drained before sealing: a `session.result`
+	// requested before terminal state waits on the seal this path still owes it,
+	// so those waits are drained afterwards together with background tasks.
 	pendingExtensionRequests.rejectAll("RPC client disconnected before extension UI response completed");
 	hostToolBridge.close("RPC client disconnected before host tool execution completed");
 	hostUriBridge.clear("RPC client disconnected before host URI request completed");
-	await inputDispatcher.drain();
-	await shutdownCoordinator.drain();
+	// Abort started serial work that only an abort can settle, before the drain
+	// below waits on it. `session.dispose()` aborts the same work, but it runs
+	// after this drain and the seal, so leaving it to disposal means a stalled
+	// `compact` holds the drain open forever and the ledger never seals.
+	inputDispatcher.closeForExit();
+	await finalizeRpcInputAfterEof(
+		() => inputDispatcher.drain(),
+		() => sealLedgerOnExit("stdin_closed", rpcForcedExitOutcome(session, terminalTasks)),
+		async () => {
+			await inputDispatcher.drainResultWaits();
+			await shutdownCoordinator.drain();
+		},
+	);
 	subagentRegistry?.dispose();
 	// Dispose the main session before exiting so the browser reaper and other
 	// bounded teardown run on the stdin-EOF path too (#5643). Idempotent: a
 	// prior pi.shutdown() through the coordinator makes this await settle
-	// immediately.
-	await session.dispose();
+	// immediately. Durable custody remains held through the complete teardown.
+	await disposeRpcSessionWithCustody(session, harnessOwner);
+	await stdoutQueue;
 	process.exit(0);
 }

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -452,11 +452,13 @@ export type RpcAgentEventPayload =
 export type RpcSequencedAgentEvent = RpcAgentEventPayload & { sequence: number };
 
 /**
- * An event frame on stdout. `sequence` is present only while a durable run is
- * bound through `session.start` or `session.resume`; without one the stream is
- * unsequenced and nothing is recorded.
+ * An agent event published on stdout. `sequence` is present only while a
+ * durable run is bound through `session.start` or `session.resume`.
  */
-export type RpcSessionEventFrame = (RpcAgentEventPayload & { sequence?: number }) | RpcSubagentFrame;
+export type RpcPublishedAgentEvent = RpcAgentEventPayload & { sequence?: number };
+
+/** An event frame published on stdout. */
+export type RpcSessionEventFrame = RpcPublishedAgentEvent | RpcSubagentFrame;
 
 // ============================================================================
 // Extension UI Events (stdout)

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -37,6 +37,14 @@ export type RpcCommand =
 	| { id?: string; type: "abort_and_prompt"; message: string; images?: ImageContent[] }
 	| { id?: string; type: "new_session"; parentSession?: string }
 
+	// Durable session custody
+	| { id?: string; type: "session.start"; run_id: string }
+	| { id?: string; type: "session.resume"; run_id: string; session_id?: string; after_sequence?: number }
+	| { id?: string; type: "session.replay"; after_sequence?: number; limit?: number }
+	| { id?: string; type: "session.result" }
+	| { id?: string; type: "session.steer"; steering_id: string; message: string; images?: ImageContent[] }
+	| { id?: string; type: "session.watch"; after_sequence?: number; limit?: number }
+
 	// State
 	| { id?: string; type: "get_state" }
 	| { id?: string; type: "set_fast_mode"; enabled: boolean }
@@ -188,6 +196,31 @@ export interface RpcSubagentMessagesResult {
 	messages: AgentMessage[];
 }
 
+export interface RpcSessionUsage {
+	input: number;
+	output: number;
+	reasoning: number;
+	cacheRead: number;
+	cacheWrite: number;
+	total: number;
+}
+
+export interface RpcSessionResult {
+	outcome: "completed" | "failed" | "aborted";
+	stopReason: string;
+	finalMessage: string;
+	usage: RpcSessionUsage;
+	resultId: string;
+	terminalSequence: number;
+}
+
+export interface RpcSessionSteerAck {
+	status: "ACCEPTED" | "DUPLICATE" | "REJECTED";
+	steeringSequence: number;
+}
+
+export type RpcSessionStartData = { run_id: string; session_id: string; existing: boolean };
+
 // ============================================================================
 // RPC Responses (stdout)
 // ============================================================================
@@ -210,6 +243,22 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "abort"; success: true }
 	| { id?: string; type: "response"; command: "abort_and_prompt"; success: true }
 	| { id?: string; type: "response"; command: "new_session"; success: true; data: { cancelled: boolean } }
+	| {
+			id?: string;
+			type: "response";
+			command: "session.start" | "session.resume";
+			success: true;
+			data: RpcSessionStartData;
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "session.replay" | "session.watch";
+			success: true;
+			data: { events: RpcSessionEventFrame[]; next_sequence: number; has_more: boolean };
+	  }
+	| { id?: string; type: "response"; command: "session.result"; success: true; data: RpcSessionResult }
+	| { id?: string; type: "response"; command: "session.steer"; success: true; data: RpcSessionSteerAck }
 
 	// State
 	| { id?: string; type: "response"; command: "get_state"; success: true; data: RpcSessionState }
@@ -362,7 +411,52 @@ export interface RpcSubagentEventFrame {
 
 export type RpcSubagentFrame = RpcSubagentLifecycleFrame | RpcSubagentProgressFrame | RpcSubagentEventFrame;
 
-export type RpcSessionEventFrame = AgentSessionEvent | RpcSubagentFrame;
+export interface RpcSteeringQueuedEvent {
+	type: "steering_queued";
+	steeringId: string;
+	steeringSequence: number;
+	message: string;
+}
+
+export interface RpcSteeringInjectedEvent {
+	type: "steering_injected";
+	steeringId: string;
+	steeringSequence: number;
+}
+
+export interface RpcSteeringRejectedEvent {
+	type: "steering_rejected";
+	steeringId: string;
+	steeringSequence: number;
+}
+
+export interface RpcSessionTerminalEvent {
+	type: "session_terminal";
+	sessionId: string;
+	outcome: "completed" | "failed" | "aborted";
+	stopReason: string;
+	finalMessage: string;
+	usage: RpcSessionUsage;
+	resultId: string;
+	terminalSequence: number;
+}
+
+export type RpcAgentEventPayload =
+	| AgentSessionEvent
+	| RpcSteeringQueuedEvent
+	| RpcSteeringInjectedEvent
+	| RpcSteeringRejectedEvent
+	| RpcSessionTerminalEvent;
+
+/** An agent event carrying the durable ledger position it was recorded at. */
+export type RpcSequencedAgentEvent = RpcAgentEventPayload & { sequence: number };
+
+/**
+ * An event frame on stdout. `sequence` is present only while a durable run is
+ * bound through `session.start` or `session.resume`; without one the stream is
+ * unsequenced and nothing is recorded.
+ */
+export type RpcSessionEventFrame = (RpcAgentEventPayload & { sequence?: number }) | RpcSubagentFrame;
 
 // ============================================================================
 // Extension UI Events (stdout)

--- a/packages/coding-agent/src/modes/runtime-init.ts
+++ b/packages/coding-agent/src/modes/runtime-init.ts
@@ -8,7 +8,7 @@
  */
 import { runExtensionCompact, runExtensionSetModel } from "../extensibility/extensions/compact-handler";
 import { getSessionSlashCommands } from "../extensibility/extensions/get-commands-handler";
-import type { ExtensionError, ExtensionUIContext } from "../extensibility/extensions/types";
+import type { CompactOptions, ExtensionError, ExtensionUIContext } from "../extensibility/extensions/types";
 import type { AgentSession } from "../session/agent-session";
 import { USER_INTERRUPT_LABEL } from "../session/messages";
 
@@ -28,6 +28,12 @@ export interface InitializeExtensionsOptions {
 	markAgentInvokingMessage?: () => void;
 	/** Optional lifecycle hook for extension-originated sends whose success/failure determines turn ownership. */
 	trackAgentInvokingMessage?: (task: Promise<unknown>) => void;
+	/** Rejects extension-originated messages that could start an agent turn. */
+	assertAgentWorkAllowed?: () => void;
+	/** Rejects extension command context operations that would change the active session. */
+	assertSessionChangeAllowed?: () => void;
+	/** Overrides extension-initiated compaction for modes with a custom terminal boundary. */
+	runCompact?: (instructionsOrOptions?: string | CompactOptions) => Promise<void>;
 }
 
 /**
@@ -45,8 +51,11 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 		reportRuntimeError,
 		onShutdown,
 		uiContext,
+		assertAgentWorkAllowed,
 		markAgentInvokingMessage,
+		assertSessionChangeAllowed,
 		trackAgentInvokingMessage,
+		runCompact = instructionsOrOptions => runExtensionCompact(session, instructionsOrOptions),
 	} = options;
 	const shutdown = onShutdown ?? (() => {});
 
@@ -54,6 +63,7 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 		// ExtensionActions
 		{
 			sendMessage: (message, sendOptions) => {
+				if (sendOptions?.triggerTurn) assertAgentWorkAllowed?.();
 				const sendTask = session.sendCustomMessage(message, sendOptions);
 				if (sendOptions?.triggerTurn) {
 					if (trackAgentInvokingMessage) {
@@ -67,6 +77,7 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 				});
 			},
 			sendUserMessage: (content, sendOptions) => {
+				assertAgentWorkAllowed?.();
 				const sendTask = session.sendUserMessage(content, sendOptions);
 				if (trackAgentInvokingMessage) {
 					trackAgentInvokingMessage(sendTask);
@@ -106,13 +117,17 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 			shutdown,
 			getContextUsage: () => session.getContextUsage(),
 			getSystemPrompt: () => session.systemPrompt,
-			compact: instructionsOrOptions => runExtensionCompact(session, instructionsOrOptions),
+			compact: instructionsOrOptions => {
+				assertAgentWorkAllowed?.();
+				return runCompact(instructionsOrOptions);
+			},
 		},
 		// ExtensionCommandContextActions — commands invokable via prompt("/command")
 		{
 			getContextUsage: () => session.getContextUsage(),
 			waitForIdle: () => session.agent.waitForIdle(),
 			newSession: async newOptions => {
+				assertSessionChangeAllowed?.();
 				const success = await session.newSession({ parentSession: newOptions?.parentSession });
 				if (success && newOptions?.setup) {
 					await newOptions.setup(session.sessionManager);
@@ -120,21 +135,28 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 				return { cancelled: !success };
 			},
 			branch: async entryId => {
+				assertSessionChangeAllowed?.();
 				const result = await session.branch(entryId);
 				return { cancelled: result.cancelled };
 			},
 			navigateTree: async (targetId, navOptions) => {
+				assertSessionChangeAllowed?.();
 				const result = await session.navigateTree(targetId, { summarize: navOptions?.summarize });
 				return { cancelled: result.cancelled };
 			},
 			switchSession: async sessionPath => {
+				assertSessionChangeAllowed?.();
 				const success = await session.switchSession(sessionPath);
 				return { cancelled: !success };
 			},
 			reload: async () => {
+				assertSessionChangeAllowed?.();
 				await session.reload();
 			},
-			compact: instructionsOrOptions => runExtensionCompact(session, instructionsOrOptions),
+			compact: instructionsOrOptions => {
+				assertAgentWorkAllowed?.();
+				return runCompact(instructionsOrOptions);
+			},
 		},
 		uiContext,
 	);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1827,6 +1827,11 @@ export class AgentSession {
 		return this.#hasPendingAsyncWake();
 	}
 
+	/** Whether a queued notification can start an idle follow-up turn. */
+	hasPendingYieldWake(): boolean {
+		return this.yieldQueue.hasPendingIdleWake();
+	}
+
 	/**
 	 * Settle one generation of owner-scoped async work: wait for running owner
 	 * jobs to finish, deliver their queued results (which enqueue async-result

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -341,6 +341,13 @@ export * from "./agent-session-events";
 export * from "./agent-session-types";
 export type { AdvisorStats, PerAdvisorStat } from "./session-advisors";
 
+const persistenceSafeAgentEvents = new WeakMap<object, AgentSessionEvent>();
+
+/** Returns the provider-safe source event behind a deobfuscated display event. */
+export function persistenceSafeAgentSessionEvent(event: AgentSessionEvent): AgentSessionEvent {
+	return (persistenceSafeAgentEvents.get(event) ?? event) as AgentSessionEvent;
+}
+
 const SESSION_STOP_CONTINUATION_CAP = 8;
 
 import { LoopGuards, type StreamGuardsHost, StreamingEditGuard } from "./stream-guards";
@@ -349,6 +356,13 @@ import { TtsrCoordinator, type TtsrCoordinatorHost } from "./ttsr-coordinator";
 
 const PLAN_MODE_REMINDER_MAX = 3;
 const POST_PROMPT_DRAIN_TIMEOUT_MS = 5_000;
+/**
+ * How long a custody boundary waits on outstanding advisor reviews. Far shorter
+ * than the headless print-mode drain: this runs on a terminal boundary that may
+ * be an exit path, so an advisor stalled on its own provider has to stop gating
+ * progress well before it stops the process from finishing.
+ */
+const ADVISOR_CUSTODY_DRAIN_TIMEOUT_MS = 5_000;
 
 /** Internal marker for hook messages queued through the agent loop */
 // ============================================================================
@@ -431,6 +445,7 @@ export class AgentSession {
 	fileSnapshotStore?: InMemorySnapshotStore;
 	/** Per-session `CUT`/`PASTE` clipboard register shared across edit calls. */
 	editClipboard?: Clipboard;
+	#assertBackgroundAgentWorkAllowed: (() => void) | undefined;
 
 	#powerAssertion: MacOSPowerAssertion | undefined;
 
@@ -453,6 +468,7 @@ export class AgentSession {
 	/** Last (enable, providerId) tuple resolved by `#syncAppendOnlyContext` — used to skip no-op invalidations. */
 	#lastAppendOnlyResolution?: { enable: boolean; providerId: string | undefined };
 	#eventListeners: AgentSessionEventListener[] = [];
+	#messagePersistenceBarriers = new Set<(event: AgentSessionEvent) => Promise<void>>();
 	#commandMetadataChangedListeners: CommandMetadataChangedListener[] = [];
 	#sessionChangeCallbacks = new Set<() => void>();
 	#observedSessionId: string | undefined;
@@ -461,6 +477,9 @@ export class AgentSession {
 	#pendingNextTurnMessages: CustomMessage[] = [];
 	#scheduledHiddenNextTurnGeneration: number | undefined = undefined;
 	#queuedMessageDrainScheduled = false;
+	#pendingExtensionEventCount = 0;
+	#pendingExtensionEventsIdle: Promise<void> = Promise.resolve();
+	#resolvePendingExtensionEvents: (() => void) | undefined;
 	#planModeState: PlanModeState | undefined;
 	/** Session-scoped `/vision` override; undefined = follow persisted `inspect_image.mode`. */
 	#inspectImageModeOverride: InspectImageMode | undefined;
@@ -725,12 +744,26 @@ export class AgentSession {
 		this.#resumeStrandedIrcAsides();
 	}
 
+	/** Whether a mode-installed custody guard currently permits background work to start an
+	 *  autonomous turn. Every wake path — stranded peer IRC asides and the yield queue's idle
+	 *  flush alike — asks here before waking, and a refusal only skips the wake: the pending
+	 *  records stay queued so the owed delivery survives for the next allowed boundary. */
+	#backgroundAgentWorkAllowed(): boolean {
+		try {
+			this.#assertBackgroundAgentWorkAllowed?.();
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
 	/** IRC records that arrive after the loop's final aside poll — or while an abort skipped that
 	 *  poll — land in pending IRC queues with no loop left to drain them; the queued-message drain's
 	 *  gate (agent.hasQueuedMessages()) does not count peer IRC interrupts. Once idle, wake a turn so
 	 *  the agent responds to the peer. Skip only when a queued steer/follow-up will itself drive a
 	 *  resume turn whose aside poll already consumes these (no double-wake). */
 	#resumeStrandedIrcAsides(): void {
+		if (!this.#backgroundAgentWorkAllowed()) return;
 		if (this.#isDisposed || this.isStreaming || !this.#irc.hasPending()) return;
 		if (this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages()) return;
 		const records = this.#irc.drainPending();
@@ -1132,6 +1165,11 @@ export class AgentSession {
 		});
 		this.yieldQueue = new YieldQueue({
 			isStreaming: () => this.isStreaming,
+			// The idle flush prompts the agent, so it is background work in exactly the
+			// sense the custody guard governs: a delayed launch completion, late LSP
+			// diagnostic, or MCP notification must not open a turn while an RPC run is
+			// binding or after its episode is sealed.
+			canWakeIdle: () => this.#backgroundAgentWorkAllowed(),
 			injectIdle: async messages => {
 				const first = messages[0];
 				if (!first) return;
@@ -1972,7 +2010,7 @@ export class AgentSession {
 	async #emitSessionEvent(event: AgentSessionEvent): Promise<void> {
 		if (event.type === "message_update") {
 			this.#emit(event);
-			void this.#queueExtensionEvent(event);
+			await this.#queueExtensionEvent(event);
 			return;
 		}
 		// Take a FIFO ticket before the extension emit: extension deliveries for
@@ -2035,11 +2073,13 @@ export class AgentSession {
 			}
 		}
 		if (event.type !== "agent_end") {
+			const tracksExtensionEvent = this.#extensionRunner?.hasHandlers(event.type) === true;
+			if (tracksExtensionEvent) this.#beginPendingExtensionEvent();
 			const processing = this.#processAgentEvent(event);
 			if ((event.type === "message_start" || event.type === "message_end") && isAdvisorCard(event.message)) {
 				this.#advisors.trackCardEvent(processing);
 			}
-			return processing;
+			return tracksExtensionEvent ? processing.finally(() => this.#endPendingExtensionEvent()) : processing;
 		}
 		const { promise, resolve } = Promise.withResolvers<void>();
 		this.#trackPostPromptTask(promise);
@@ -2054,7 +2094,7 @@ export class AgentSession {
 		const key = sessionMessagePersistenceKey(message);
 		if (!key) return undefined;
 		const previous = this.#messageEndPersistenceTail;
-		const { promise, resolve } = Promise.withResolvers<void>();
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
 		const clear = () => {
 			if (this.#pendingMessageEndPersistence.get(key) === promise) {
 				this.#pendingMessageEndPersistence.delete(key);
@@ -2068,8 +2108,11 @@ export class AgentSession {
 				await previous;
 				try {
 					persistMessage();
-				} finally {
 					resolve();
+				} catch (error) {
+					reject(error);
+					throw error;
+				} finally {
 					clear();
 				}
 			},
@@ -2084,6 +2127,11 @@ export class AgentSession {
 		const key = sessionMessagePersistenceKey(message);
 		if (!key) return;
 		await this.#pendingMessageEndPersistence.get(key);
+	}
+
+	/** Resolves after a completed message has been appended to the session transcript. */
+	waitForMessagePersistence(message: AgentMessage): Promise<void> {
+		return this.#waitForSessionMessagePersistence(message);
 	}
 
 	/**
@@ -2363,6 +2411,7 @@ export class AgentSession {
 			const deobfuscatedContent = deobfuscateAssistantContent(obfuscator, message.content);
 			if (deobfuscatedContent !== message.content) {
 				displayEvent = { ...event, message: { ...message, content: deobfuscatedContent } };
+				persistenceSafeAgentEvents.set(displayEvent, event);
 			}
 		}
 
@@ -2383,6 +2432,9 @@ export class AgentSession {
 		if (event.type !== "agent_end") {
 			try {
 				await this.#emitSessionEvent(displayEvent);
+				if (displayEvent.type === "message_end") {
+					for (const barrier of [...this.#messagePersistenceBarriers]) await barrier(displayEvent);
+				}
 			} catch (error) {
 				messageEndPersistence?.release();
 				throw error;
@@ -2597,13 +2649,21 @@ export class AgentSession {
 			// maintenance can emit agent_end, so preserve the state at settle entry.
 			const ttsrAbortPendingAtAgentEnd = this.#ttsr.abortPending;
 			const emitAgentEndNotification = async (options?: { willContinue?: boolean }) => {
-				// Public agent_end is held out of the eager display pass and emitted
-				// here after maintenance routing, tagged isTerminal so subscribers can
-				// tell final settles from scheduled continuations.
-				await this.#emitSessionEvent({ ...event, isTerminal: !options?.willContinue });
-				void this.#emitAgentEndNotification(activeMessages, options).catch(err => {
-					logger.error("Agent end extension notification failed", { err });
-				});
+				this.#beginPendingExtensionEvent();
+				try {
+					// Public agent_end is held out of the eager display pass and emitted
+					// here after maintenance routing, tagged isTerminal so subscribers can
+					// tell final settles from scheduled continuations.
+					await this.#emitSessionEvent({ ...event, isTerminal: !options?.willContinue });
+				} catch (error) {
+					this.#endPendingExtensionEvent();
+					throw error;
+				}
+				void this.#emitAgentEndNotification(activeMessages, options)
+					.catch(err => {
+						logger.error("Agent end extension notification failed", { err });
+					})
+					.finally(() => this.#endPendingExtensionEvent());
 			};
 			const usage = this.getSessionStats().tokens;
 			await this.#goalRuntime.onAgentEnd({
@@ -3433,6 +3493,15 @@ export class AgentSession {
 		return () => this.#sessionChangeCallbacks.delete(callback);
 	}
 
+	/**
+	 * Register work that must finish after message_end publication and before
+	 * the matching transcript entry is appended.
+	 */
+	registerMessagePersistenceBarrier(barrier: (event: AgentSessionEvent) => Promise<void>): () => void {
+		this.#messagePersistenceBarriers.add(barrier);
+		return () => this.#messagePersistenceBarriers.delete(barrier);
+	}
+
 	subscribeCommandMetadataChanged(listener: CommandMetadataChangedListener): () => void {
 		this.#commandMetadataChangedListeners.push(listener);
 		return () => {
@@ -3778,6 +3847,7 @@ export class AgentSession {
 		}
 		this.#eventListeners = [];
 		this.#sessionChangeCallbacks.clear();
+		this.#messagePersistenceBarriers.clear();
 	}
 
 	#closeAllProviderSessions(reason: string): void {
@@ -4151,6 +4221,34 @@ export class AgentSession {
 	 */
 	waitForAdvisorCatchup(timeoutMs: number): Promise<boolean> {
 		return this.#advisors.waitForAdvisorCatchup(timeoutMs);
+	}
+
+	/**
+	 * Whether an advisor review or an emitted advisor card is still outstanding.
+	 *
+	 * Advisor work runs beside the primary rather than inside it, so this is true
+	 * at moments when every primary-facing signal reads idle. A custody boundary
+	 * that seals on those signals alone would seal over a review that can still
+	 * persist a card or resume the primary.
+	 */
+	get hasPendingAdvisorReviews(): boolean {
+		return this.#advisors.hasPendingReviews;
+	}
+	onAdvisorReviewsSettled(listener: () => void): () => void {
+		return this.#advisors.onReviewsSettled(listener);
+	}
+
+	/**
+	 * Drain outstanding advisor reviews and their card persistence at a custody
+	 * boundary.
+	 *
+	 * Bounded on purpose: an advisor stalled on its own provider must not hold the
+	 * boundary open, so this gives up at the deadline and leaves the remainder
+	 * visible through {@link hasPendingAdvisorReviews} — the caller then declines
+	 * to seal rather than waiting without limit.
+	 */
+	async waitForPendingAdvisorReviews(timeoutMs = ADVISOR_CUSTODY_DRAIN_TIMEOUT_MS): Promise<void> {
+		await this.#advisors.waitForAdvisorCatchup(timeoutMs);
 	}
 
 	async drainAsyncJobDeliveriesForAcp(options?: { timeoutMs?: number }): Promise<boolean> {
@@ -5535,17 +5633,54 @@ export class AgentSession {
 		}
 	}
 
+	findUserMessageByIdempotencyKey(idempotencyKey: string): AgentMessage | undefined {
+		return this.agent.state.messages.find(
+			message => message.role === "user" && message.idempotencyKey === idempotencyKey,
+		);
+	}
+
+	findPersistedUserMessageByIdempotencyKey(idempotencyKey: string): AgentMessage | undefined {
+		const branch = this.sessionManager.getBranch();
+		for (let index = branch.length - 1; index >= 0; index--) {
+			const entry = branch[index];
+			if (entry.type !== "message") continue;
+			const message = entry.message;
+			if (message.role === "user" && message.idempotencyKey === idempotencyKey) return message;
+		}
+		return undefined;
+	}
+
 	/**
 	 * Queue a steering message to interrupt the agent mid-run.
 	 */
-	async steer(text: string, images?: ImageContent[]): Promise<void> {
+	async steer(text: string, images?: ImageContent[], options?: { idempotencyKey?: string }): Promise<void> {
+		await this.steerWithResult(text, images, options);
+	}
+
+	/** Queue steering and report whether usage preflight accepted it. */
+	async steerWithResult(
+		text: string,
+		images?: ImageContent[],
+		options?: { idempotencyKey?: string },
+	): Promise<boolean> {
 		if (text.startsWith("/")) {
 			this.#throwIfExtensionCommand(text);
 		}
+		const idempotencyKey = options?.idempotencyKey;
+		if (
+			idempotencyKey &&
+			(this.findUserMessageByIdempotencyKey(idempotencyKey) ||
+				this.agent
+					.peekSteeringQueue()
+					.some(message => message.role === "user" && message.idempotencyKey === idempotencyKey))
+		) {
+			return true;
+		}
 
 		const expandedText = expandPromptTemplate(text, [...this.#promptTemplates]);
-		if (!(await this.#runUsageAwarePreflight())) return;
-		await this.#queueUserMessage(expandedText, images, "steer");
+		if (!(await this.#runUsageAwarePreflight())) return false;
+		await this.#queueUserMessage(expandedText, images, "steer", options?.idempotencyKey);
+		return true;
 	}
 
 	/**
@@ -5593,6 +5728,7 @@ export class AgentSession {
 		text: string,
 		images: ImageContent[] | undefined,
 		mode: "steer" | "followUp",
+		idempotencyKey?: string,
 	): Promise<void> {
 		// A queued user message (RPC/SDK/collab steer or follow-up, or a typed message
 		// while streaming) is a deliberate resume; re-enable advisor auto-resume that
@@ -5615,6 +5751,7 @@ export class AgentSession {
 				content,
 				attribution: "user",
 				timestamp: Date.now(),
+				...(idempotencyKey ? { idempotencyKey } : {}),
 			});
 		} else {
 			if (imageDescriptionNotice) this.agent.steer(imageDescriptionNotice);
@@ -5624,6 +5761,7 @@ export class AgentSession {
 				steering: true,
 				attribution: "user",
 				timestamp: Date.now(),
+				...(idempotencyKey ? { idempotencyKey } : {}),
 			});
 		}
 		this.#scheduleIdleQueueDrain();
@@ -6016,6 +6154,36 @@ export class AgentSession {
 			this.agent.peekFollowUpQueue().filter(isDisplayableQueuedMessage).length +
 			this.#pendingNextTurnMessages.length
 		);
+	}
+
+	/** Whether any agent or next-turn message remains queued, including hidden extension messages. */
+	get hasQueuedAgentMessages(): boolean {
+		return this.agent.hasQueuedMessages() || this.#pendingNextTurnMessages.length > 0;
+	}
+
+	/** Whether an extension lifecycle handler can still enqueue work from the current custody boundary. */
+	get hasPendingExtensionEvents(): boolean {
+		return this.#pendingExtensionEventCount > 0;
+	}
+
+	/** Wait until extension lifecycle handlers from the current boundary have settled. */
+	waitForPendingExtensionEvents(): Promise<void> {
+		return this.#pendingExtensionEventsIdle;
+	}
+
+	#beginPendingExtensionEvent(): void {
+		if (this.#pendingExtensionEventCount++ > 0) return;
+		const deferred = Promise.withResolvers<void>();
+		this.#pendingExtensionEventsIdle = deferred.promise;
+		this.#resolvePendingExtensionEvents = deferred.resolve;
+	}
+
+	#endPendingExtensionEvent(): void {
+		this.#pendingExtensionEventCount--;
+		if (this.#pendingExtensionEventCount > 0) return;
+		this.#pendingExtensionEventCount = 0;
+		this.#resolvePendingExtensionEvents?.();
+		this.#resolvePendingExtensionEvents = undefined;
 	}
 
 	getQueuedMessages(): { steering: readonly string[]; followUp: readonly string[] } {
@@ -6443,7 +6611,13 @@ export class AgentSession {
 			try {
 				const oldDirStat = await fs.promises.stat(oldArtifactDir);
 				if (oldDirStat.isDirectory()) {
-					await fs.promises.cp(oldArtifactDir, newArtifactDir, { recursive: true });
+					await fs.promises.cp(oldArtifactDir, newArtifactDir, {
+						recursive: true,
+						filter: source => {
+							const relative = path.relative(oldArtifactDir, source);
+							return relative !== "rpc-ledger" && !relative.startsWith(`rpc-ledger${path.sep}`);
+						},
+					});
 				}
 			} catch (err) {
 				if (!isEnoent(err)) {
@@ -7068,6 +7242,11 @@ export class AgentSession {
 		return this.#bash.hasPendingMessages;
 	}
 
+	/** Persist pending bash result messages before a terminal or session boundary. */
+	flushPendingBashMessages(): Promise<void> {
+		return this.#bash.flushPending();
+	}
+
 	// =========================================================================
 	// User-Initiated Python Execution
 	// =========================================================================
@@ -7137,6 +7316,7 @@ export class AgentSession {
 
 	/** Delivers an IRC message into this recipient session. */
 	deliverIrcMessage(msg: IrcMessage, opts?: { expectsReply?: boolean }): Promise<"injected" | "woken"> {
+		this.#assertBackgroundAgentWorkAllowed?.();
 		return this.#irc.deliver(msg, opts);
 	}
 
@@ -7145,6 +7325,11 @@ export class AgentSession {
 		observer: ((records: CustomMessage[]) => ((error?: unknown) => void | Promise<void>) | undefined) | undefined,
 	): void {
 		this.#ircWakeTurnObserver = observer;
+	}
+
+	/** Installs a mode-specific guard for peer messages that can start agent work. */
+	setBackgroundAgentWorkGuard(guard: (() => void) | undefined): void {
+		this.#assertBackgroundAgentWorkAllowed = guard;
 	}
 
 	/** Emits an IRC relay observation for UI rendering without persisting it. */
@@ -8762,18 +8947,30 @@ export class AgentSession {
 	 * Useful for /copy command.
 	 * @returns Text content, or undefined if no assistant message exists
 	 */
-	getLastAssistantText(): string | undefined {
+	getLastAssistantText(options: { providerSafe?: boolean } = {}): string | undefined {
 		const lastAssistant = this.#getLastCopyCandidateAssistantMessage();
 		if (!lastAssistant) return undefined;
 
+		const content =
+			!options.providerSafe && this.#obfuscator?.hasSecrets()
+				? deobfuscateAssistantContent(this.#obfuscator, lastAssistant.content)
+				: lastAssistant.content;
 		let text = "";
-		for (const content of lastAssistant.content) {
-			if (content.type === "text") {
-				text += content.text;
+		for (const block of content) {
+			if (block.type === "text") {
+				text += block.text;
 			}
 		}
 
 		return text.trim() || undefined;
+	}
+
+	restoreProviderTextForDisplay(text: string): string {
+		return this.#deobfuscateFromProvider(text);
+	}
+
+	restoreProviderValueForDisplay<T>(value: T): T {
+		return this.#obfuscator?.deobfuscateObject(value) ?? value;
 	}
 
 	hasCopyCandidateAssistantMessage(): boolean {

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -305,6 +305,7 @@ export class SessionAdvisors {
 	#advisorInterruptImmuneTurnStart: number | undefined;
 	#pendingAdvisorCardEvents = new Set<Promise<void>>();
 	#advisorYieldQueueUnsubscribe: (() => void) | undefined;
+	#reviewSettlementListeners = new Set<() => void>();
 
 	constructor(host: SessionAdvisorsHost, options: SessionAdvisorsOptions) {
 		this.#host = host;
@@ -449,12 +450,50 @@ export class SessionAdvisors {
 	/** Tracks persistence of a visible advisor card emitted outside the primary loop. */
 	trackCardEvent(processing: Promise<void>): void {
 		this.#pendingAdvisorCardEvents.add(processing);
-		void processing.finally(() => this.#pendingAdvisorCardEvents.delete(processing)).catch(() => {});
+		void processing
+			.finally(() => {
+				this.#pendingAdvisorCardEvents.delete(processing);
+				this.#notifyReviewSettlement();
+			})
+			.catch(() => {});
 	}
 
 	/** Waits for all advisor-card persistence handlers currently in flight. */
 	async waitForPendingCardEvents(): Promise<void> {
 		await Promise.allSettled([...this.#pendingAdvisorCardEvents]);
+	}
+
+	/**
+	 * Whether an advisor review or an emitted advisor card is still outstanding.
+	 *
+	 * Advisors review the primary's turn out of band, so the primary can be fully
+	 * idle while a review is still running. A review that lands late emits a card
+	 * that persists into the transcript, and a blocker resumes the primary through
+	 * `sendCustomMessage({ triggerTurn: true })` — both are episode work, so a
+	 * custody boundary that ignores this reports idle while work is still owed.
+	 *
+	 * A halted, quota-exhausted or disposed runtime is excluded: its backlog can
+	 * no longer drain, so counting it would hold a boundary open forever.
+	 */
+	get hasPendingReviews(): boolean {
+		if (this.#pendingAdvisorCardEvents.size > 0) return true;
+		return this.#advisors.some(
+			advisor =>
+				!advisor.runtime.disposed &&
+				!advisor.runtime.halted &&
+				!advisor.runtime.quotaExhausted &&
+				advisor.runtime.backlog > 0,
+		);
+	}
+	onReviewsSettled(listener: () => void): () => void {
+		this.#reviewSettlementListeners.add(listener);
+		if (!this.hasPendingReviews) queueMicrotask(listener);
+		return () => this.#reviewSettlementListeners.delete(listener);
+	}
+
+	#notifyReviewSettlement(): void {
+		if (this.hasPendingReviews) return;
+		for (const listener of [...this.#reviewSettlementListeners]) listener();
 	}
 
 	// Advisor runtime lifecycle
@@ -881,6 +920,7 @@ export class SessionAdvisors {
 					advisorRef.adviseTool.beginUpdate(inProgress);
 					advisorRef.emissionGuard.beginUpdate();
 				},
+				onBacklogChange: () => this.#notifyReviewSettlement(),
 				onTurnError: (error, failedMessages, signal) =>
 					this.#recoverAdvisorTurn(advisorRef, error, failedMessages, signal),
 				onTurnSuccess: async () => {

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -201,6 +201,17 @@ export function computeDefaultSessionDir(
 	return sessionDir;
 }
 
+/**
+ * Derive the directory that holds per-session sidecar files written beside a
+ * transcript. A `<name>.jsonl` transcript yields `<name>/`; any other path
+ * yields `<path>.d/`. The name is a pure function of the transcript path, so a
+ * process holding only the session file can address the sidecars without a
+ * registry lookup, and two sessions in one directory stay separate.
+ */
+export function sessionSidecarDir(sessionFile: string): string {
+	return sessionFile.endsWith(".jsonl") ? sessionFile.slice(0, -".jsonl".length) : `${sessionFile}.d`;
+}
+
 // =============================================================================
 // Terminal breadcrumbs: maps terminal (TTY) -> last session file for --continue
 // =============================================================================

--- a/packages/coding-agent/src/session/session-stats.ts
+++ b/packages/coding-agent/src/session/session-stats.ts
@@ -66,29 +66,18 @@ export class SessionStatsTracker {
 		let totalPremiumRequests = 0;
 		for (const message of state.messages) {
 			if (message.role === "assistant") {
-				const assistant = message;
-				toolCalls += assistant.content.filter(content => content.type === "toolCall").length;
-				totalInput += assistant.usage.input;
-				totalOutput += assistant.usage.output;
-				totalReasoning += assistant.usage.reasoningTokens ?? 0;
-				totalCacheRead += assistant.usage.cacheRead;
-				totalCacheWrite += assistant.usage.cacheWrite;
-				totalTokens += assistant.usage.totalTokens;
-				totalPremiumRequests += assistant.usage.premiumRequests ?? 0;
-				totalCost += assistant.usage.cost.total;
+				toolCalls += message.content.filter(content => content.type === "toolCall").length;
 			}
-			if (message.role === "toolResult" && message.toolName === "task") {
-				const usage = taskToolUsage(message.details);
-				if (!usage) continue;
-				totalInput += usage.input;
-				totalOutput += usage.output;
-				totalReasoning += usage.reasoningTokens ?? 0;
-				totalCacheRead += usage.cacheRead;
-				totalCacheWrite += usage.cacheWrite;
-				totalTokens += usage.totalTokens;
-				totalPremiumRequests += usage.premiumRequests ?? 0;
-				totalCost += usage.cost.total;
-			}
+			const usage = sessionMessageUsage(message);
+			if (!usage) continue;
+			totalInput += usage.input;
+			totalOutput += usage.output;
+			totalReasoning += usage.reasoningTokens ?? 0;
+			totalCacheRead += usage.cacheRead;
+			totalCacheWrite += usage.cacheWrite;
+			totalTokens += usage.totalTokens;
+			totalPremiumRequests += usage.premiumRequests ?? 0;
+			totalCost += usage.cost.total;
 		}
 		return {
 			sessionFile: this.#host.sessionManager.getSessionFile(),
@@ -328,6 +317,13 @@ export class SessionStatsTracker {
 			baseUrl: this.#host.modelRegistry.getProviderBaseUrl?.(provider),
 		});
 	}
+}
+
+/** Returns provider usage carried by one completed session message. */
+export function sessionMessageUsage(message: AgentMessage): Usage | undefined {
+	if (message.role === "assistant") return message.usage;
+	if (message.role === "toolResult" && message.toolName === "task") return taskToolUsage(message.details);
+	return undefined;
 }
 
 function taskToolUsage(details: unknown): Usage | undefined {

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -110,6 +110,14 @@ export class YieldQueue {
 		return false;
 	}
 
+	/** Whether any queued entry can start an idle follow-up turn. */
+	hasPendingIdleWake(): boolean {
+		for (const [kind, dispatcher] of this.#dispatchers) {
+			if (!dispatcher.skipIdleFlush && this.has(kind)) return true;
+		}
+		return false;
+	}
+
 	/** Arrange an idle flush for entries queued near the end of a streaming run. */
 	requestIdleFlush(): void {
 		for (const [kind, dispatcher] of this.#dispatchers) {

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -12,6 +12,14 @@ export interface YieldDispatcher<P> {
 
 export interface YieldQueueOptions {
 	isStreaming: () => boolean;
+	/**
+	 * Gate for idle wake turns. The idle flush is the only path that starts a
+	 * provider turn on its own, so a mode holding durable custody of the session
+	 * can refuse the wake the same way it refuses a peer IRC wake. Refusing
+	 * retains every queued entry untouched: the owed notifications still reach
+	 * the model through a later flush or the next run's lazy aside drain.
+	 */
+	canWakeIdle?: () => boolean;
 	injectStreaming?(msg: AgentMessage): void;
 	injectIdle(messages: AgentMessage[]): Promise<void>;
 	scheduleIdleFlush(run: () => Promise<void>): void;
@@ -115,6 +123,9 @@ export class YieldQueue {
 	async flush(mode: YieldFlushMode): Promise<void> {
 		if (mode === "idle") {
 			this.#idleFlushPending = false;
+			// Wake boundary. Checked before the first #drain so a refusal leaves the
+			// entries queued rather than settling receipts for work that never ran.
+			if (this.#options.canWakeIdle?.() === false) return;
 		}
 		const idleMessages: BuiltMessage[] = [];
 		for (const [kind, dispatcher] of this.#dispatchers) {

--- a/packages/coding-agent/src/task/isolation-ownership.ts
+++ b/packages/coding-agent/src/task/isolation-ownership.ts
@@ -35,7 +35,7 @@ export interface IsolationOwner {
  * boot); other Unixes shell out to `ps -o lstart`. Platforms that report
  * neither (e.g. Windows) yield `null`, degrading to a pid-only liveness check.
  */
-async function processStartToken(pid: number): Promise<string | null> {
+export async function processStartToken(pid: number): Promise<string | null> {
 	if (process.platform === "linux") {
 		let stat: string;
 		try {
@@ -55,6 +55,18 @@ async function processStartToken(pid: number): Promise<string | null> {
 	if (res.exitCode !== 0) return null;
 	const started = res.text().trim();
 	return started.length > 0 ? started : null;
+}
+
+/** Whether `pid` still names the recorded process instance. */
+export async function isProcessIdentityLive(pid: number, startToken?: string): Promise<boolean> {
+	try {
+		process.kill(pid, 0);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ESRCH") return false;
+	}
+	if (!startToken) return true;
+	const current = await processStartToken(pid);
+	return current === null || current === startToken;
 }
 
 /**
@@ -90,17 +102,9 @@ export async function hasLiveIsolationOwner(baseDir: string): Promise<boolean> {
 	if (typeof decoded !== "object" || decoded === null || !("pid" in decoded)) return false;
 	const pid = decoded.pid;
 	if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
-	try {
-		process.kill(pid, 0);
-	} catch (err) {
-		if ((err as NodeJS.ErrnoException).code === "ESRCH") return false;
-	}
-	// The pid is live (or unknowable via EPERM). Reject a recycled pid: if the
-	// marker pinned the owner's start-time token, the process wearing that pid
-	// now must still present the same token.
-	if ("startToken" in decoded && typeof decoded.startToken === "string" && decoded.startToken.length > 0) {
-		const current = await processStartToken(pid);
-		if (current !== null && current !== decoded.startToken) return false;
-	}
-	return true;
+	const startToken =
+		"startToken" in decoded && typeof decoded.startToken === "string" && decoded.startToken.length > 0
+			? decoded.startToken
+			: undefined;
+	return isProcessIdentityLive(pid, startToken);
 }

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -590,6 +590,10 @@ describe("AgentSession advisor toggle", () => {
 		sessionManager.appendMessage({ role: "user", content: "keep me", timestamp: 1 });
 		appendAdvisorCost(advisor, 0.5, 1);
 		const previousSessionFile = sessionManager.getSessionFile();
+		if (!previousSessionFile) throw new Error("Expected the previous session to be persisted");
+		const previousRpcLedgerDir = path.join(previousSessionFile.slice(0, -6), "rpc-ledger");
+		await fs.mkdir(previousRpcLedgerDir, { recursive: true });
+		await fs.writeFile(path.join(previousRpcLedgerDir, "events.jsonl"), "parent custody");
 		const fork = sessionManager.fork.bind(sessionManager);
 		vi.spyOn(sessionManager, "fork").mockImplementation(async () => {
 			const result = await fork();
@@ -607,6 +611,9 @@ describe("AgentSession advisor toggle", () => {
 		expect(advisor.state.messages).toContainEqual(advisorMessage(0.5, 1));
 		const forkedSessionFile = sessionManager.getSessionFile();
 		if (!forkedSessionFile) throw new Error("Expected the forked session to be persisted");
+		expect(await Bun.file(path.join(forkedSessionFile.slice(0, -6), "rpc-ledger", "events.jsonl")).exists()).toBe(
+			false,
+		);
 		await session.dispose();
 		expect((await loadAdvisorTranscriptCosts(forkedSessionFile)).get("")).toBeCloseTo(0.5, 8);
 	});

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -10,18 +10,52 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
-import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { createMockModel, type MockCall } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { DaemonCompletionNotification } from "@oh-my-pi/pi-coding-agent/launch/protocol";
+import { RpcCustodyBindingGuard } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { AsyncResultEntry } from "@oh-my-pi/pi-coding-agent/session/async-job-delivery";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { LAUNCH_COMPLETION_MESSAGE_TYPE } from "@oh-my-pi/pi-coding-agent/session/launch-completion";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+function launchCompletion(owner: string): DaemonCompletionNotification {
+	return {
+		event: "daemon-completed",
+		completionId: "advisor-completion",
+		owner,
+		daemon: {
+			name: "advisor-worker",
+			id: "daemon-id",
+			state: "exited",
+			createdAt: 1,
+			startedAt: 1,
+			exitedAt: 2,
+			exitCode: 0,
+			restartCount: 0,
+			outputBytes: 0,
+			owner,
+			persist: false,
+			detached: false,
+		},
+	};
+}
+
+function sawLaunchCompletion(calls: readonly MockCall[]): boolean {
+	return calls.some(call =>
+		call.context.messages.some(message =>
+			typeof message.content === "string"
+				? message.content.includes("advisor-worker")
+				: message.content.some(content => content.type === "text" && content.text.includes("advisor-worker")),
+		),
+	);
+}
 
 describe("AgentSession owner-routed async delivery", () => {
 	let session: AgentSession;
@@ -116,38 +150,110 @@ describe("AgentSession owner-routed async delivery", () => {
 			settings: Settings.isolated(),
 			modelRegistry: new ModelRegistry(authStorage),
 		});
-		const completion = {
-			event: "daemon-completed",
-			completionId: "advisor-completion",
-			owner,
-			daemon: {
-				name: "advisor-worker",
-				id: "daemon-id",
-				state: "exited",
-				createdAt: 1,
-				startedAt: 1,
-				exitedAt: 2,
-				exitCode: 0,
-				restartCount: 0,
-				outputBytes: 0,
-				owner,
-				persist: false,
-				detached: false,
-			},
-		} satisfies DaemonCompletionNotification;
 
-		await session.queueLaunchCompletion(completion);
+		await session.queueLaunchCompletion(launchCompletion(owner));
 		await session.waitForIdle();
 
-		expect(
-			mock.calls.some(call =>
-				call.context.messages.some(message =>
-					typeof message.content === "string"
-						? message.content.includes("advisor-worker")
-						: message.content.some(content => content.type === "text" && content.text.includes("advisor-worker")),
-				),
-			),
-		).toBe(true);
+		expect(sawLaunchCompletion(mock.calls)).toBe(true);
+	});
+
+	it("defers a launch-completion wake turn while durable RPC custody is binding", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const sessionManager = SessionManager.inMemory();
+		const owner = `${sessionManager.getSessionId()}-advisor`;
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+
+		const bindingGuard = new RpcCustodyBindingGuard();
+		session.setBackgroundAgentWorkGuard(() => bindingGuard.assertWorkAllowed());
+		const bindStep = Promise.withResolvers<void>();
+		const bound = bindingGuard.run(() => bindStep.promise);
+		await Promise.resolve();
+
+		const callsBefore = mock.calls.length;
+		const delivered = session.queueLaunchCompletion(launchCompletion(owner));
+		await session.waitForIdle();
+
+		// The yield queue's idle flush prompts the agent, so waking here would run a
+		// provider turn in the middle of the custody transition.
+		expect(mock.calls).toHaveLength(callsBefore);
+		// Deferred, not dropped: the completion is still owed.
+		expect(session.yieldQueue.has(LAUNCH_COMPLETION_MESSAGE_TYPE)).toBe(true);
+
+		bindStep.resolve();
+		await bound;
+		// What rpc-mode's bindHarness does once the transition settles.
+		session.yieldQueue.requestIdleFlush();
+		await delivered;
+		await session.waitForIdle();
+
+		expect(sawLaunchCompletion(mock.calls)).toBe(true);
+		expect(session.yieldQueue.has(LAUNCH_COMPLETION_MESSAGE_TYPE)).toBe(false);
+	});
+
+	it("refuses a launch-completion wake turn after the RPC episode is sealed", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			convertToLlm,
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const sessionManager = SessionManager.inMemory();
+		const owner = `${sessionManager.getSessionId()}-advisor`;
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+
+		// The composition rpc-mode installs: binding transition, then episode seal.
+		const bindingGuard = new RpcCustodyBindingGuard();
+		session.setBackgroundAgentWorkGuard(() => {
+			bindingGuard.assertWorkAllowed();
+			// Stands in for a sealed RpcHarnessSessionOwner.assertAcceptingWork().
+			throw new Error("run result is already sealed");
+		});
+
+		const callsBefore = mock.calls.length;
+		let settled = false;
+		const delivered = session.queueLaunchCompletion(launchCompletion(owner));
+		void delivered.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+		await session.waitForIdle();
+
+		// A turn started here would emit unsequenced, unpersisted events outside the
+		// immutable episode.
+		expect(mock.calls).toHaveLength(callsBefore);
+		// Sealing is terminal, so the entry is retained rather than delivered: the
+		// receipt stays open until disposal clears the queue and rejects it.
+		expect(session.yieldQueue.has(LAUNCH_COMPLETION_MESSAGE_TYPE)).toBe(true);
+		expect(settled).toBe(false);
 	});
 
 	it("purges finished owned jobs when starting a new session", async () => {

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -181,6 +181,47 @@ describe("AgentSession message pipeline", () => {
 		expect(session.getImageAttachments()).toEqual([{ label: "Image #1", uri: "attachment://1", image: userImage }]);
 	});
 
+	it("deobfuscates the last assistant text returned to clients", () => {
+		const secret = "TERMINAL_SECRET_TOKEN_12345";
+		const obfuscator = new SecretObfuscator([{ type: "plain", content: secret }]);
+		const session = new AgentSession({
+			agent: createAgent(),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: {} as never,
+			obfuscator,
+		});
+		sessions.push(session);
+		session.agent.appendMessage(createAssistantMessage(obfuscator.obfuscate(`terminal ${secret}`)));
+
+		expect(session.getLastAssistantText()).toBe(`terminal ${secret}`);
+		const providerSafe = session.getLastAssistantText({ providerSafe: true });
+		expect(providerSafe).not.toContain(secret);
+		expect(session.restoreProviderTextForDisplay(providerSafe!)).toBe(`terminal ${secret}`);
+	});
+
+	it("distinguishes transient steering state from durable session history", () => {
+		const sessionManager = SessionManager.inMemory();
+		const session = new AgentSession({
+			agent: createAgent(),
+			sessionManager,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: {} as never,
+		});
+		sessions.push(session);
+		const message: AgentMessage = {
+			role: "user",
+			content: "persist me",
+			idempotencyKey: "rpc:session:steer-1",
+			timestamp: Date.now(),
+		};
+		session.agent.appendMessage(message);
+		expect(session.findPersistedUserMessageByIdempotencyKey(message.idempotencyKey!)).toBeUndefined();
+
+		sessionManager.appendMessage(message);
+		expect(session.findPersistedUserMessageByIdempotencyKey(message.idempotencyKey!)).toBe(message);
+	});
+
 	it("keeps stored steering text raw while pre-LLM conversion wraps it", async () => {
 		const session = new AgentSession({
 			agent: createAgent(),

--- a/packages/coding-agent/test/agent-session-silent-abort.test.ts
+++ b/packages/coding-agent/test/agent-session-silent-abort.test.ts
@@ -21,7 +21,11 @@ import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { SecretObfuscator } from "@oh-my-pi/pi-coding-agent/secrets/obfuscator";
-import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import {
+	AgentSession,
+	type AgentSessionEvent,
+	persistenceSafeAgentSessionEvent,
+} from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SILENT_ABORT_MARKER } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -225,6 +229,12 @@ describe("AgentSession silent-abort marker stamping", () => {
 		expect(emittedMessage).not.toBe(message);
 		const emittedText = (emittedMessage.content[0] as TextContent).text;
 		expect(emittedText).toBe("hello SECRET_VALUE world");
+		const persistenceEvent = persistenceSafeAgentSessionEvent(emitted);
+		if (persistenceEvent.type !== "message_end" || persistenceEvent.message.role !== "assistant") {
+			throw new Error("expected a persistence-safe assistant message_end event");
+		}
+		expect((persistenceEvent.message.content[0] as TextContent).text).toBe(obfuscatedText);
+		expect(persistenceEvent.message).toBe(message);
 
 		// Flag is consumed.
 		expect(session.isPlanInternalAbortPending).toBe(false);

--- a/packages/coding-agent/test/agent-session-steer-idle-drain.test.ts
+++ b/packages/coding-agent/test/agent-session-steer-idle-drain.test.ts
@@ -105,6 +105,23 @@ describe("AgentSession steer idle drain", () => {
 		await session.waitForIdle();
 		expect(continueSpy).toHaveBeenCalledTimes(1);
 	});
+	it("does not requeue a durable steering key already in the transcript", async () => {
+		await createSession([
+			{
+				role: "user",
+				content: "already delivered",
+				idempotencyKey: "rpc:session:old",
+				timestamp: Date.now(),
+			},
+			createAssistantMessage(),
+		]);
+		expect(session.findUserMessageByIdempotencyKey("rpc:session:old")).toMatchObject({
+			content: "already delivered",
+		});
+
+		await session.steer("already delivered", undefined, { idempotencyKey: "rpc:session:old" });
+		expect(session.queuedMessageCount).toBe(0);
+	});
 
 	it("delivers a steer queued after an interrupted tool result", async () => {
 		await createSession([

--- a/packages/coding-agent/test/fixtures/mock-rpc-agent.ts
+++ b/packages/coding-agent/test/fixtures/mock-rpc-agent.ts
@@ -43,6 +43,25 @@ process.stdout.write(
 			: { type: "ready" },
 	)}\n`,
 );
+if (Bun.env.MOCK_RPC_DURABLE_EVENTS === "1") {
+	for (const event of [
+		{ type: "steering_queued", steeringId: "steer-1", steeringSequence: 1, message: "queued" },
+		{ type: "steering_injected", steeringId: "steer-1", steeringSequence: 1 },
+		{ type: "steering_rejected", steeringId: "steer-2", steeringSequence: 2 },
+		{
+			type: "session_terminal",
+			sessionId: "mock-session",
+			outcome: "completed",
+			stopReason: "mock",
+			finalMessage: "done",
+			usage: { input: 1, output: 2, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 3 },
+			resultId: "result-1",
+			terminalSequence: 3,
+		},
+	]) {
+		process.stdout.write(`${JSON.stringify(event)}\n`);
+	}
+}
 
 function writeFrame(frame: Record<string, unknown>): void {
 	const logical = Buffer.from(JSON.stringify(frame), "utf8");
@@ -93,6 +112,63 @@ for await (const raw of console) {
 				protocolV2Enabled = true;
 				continue;
 			}
+			if (frame.type === "session.start" || frame.type === "session.resume") {
+				writeFrame({
+					id,
+					type: "response",
+					command: frame.type,
+					success: true,
+					data: {
+						run_id: frame.run_id,
+						session_id:
+							frame.type === "session.start"
+								? `start:${String(frame.run_id)}`
+								: `resume:${String(frame.run_id)}:${String(frame.session_id)}:${String(frame.after_sequence)}`,
+						existing: false,
+					},
+				});
+				continue;
+			}
+			if (frame.type === "session.replay" || frame.type === "session.watch") {
+				writeFrame({
+					id,
+					type: "response",
+					command: frame.type,
+					success: true,
+					data: { events: [], next_sequence: frame.after_sequence ?? 0, has_more: frame.limit === 1 },
+				});
+				continue;
+			}
+			if (frame.type === "session.result") {
+				if (Bun.env.MOCK_RPC_RESULT_DELAY_MS) await Bun.sleep(Number(Bun.env.MOCK_RPC_RESULT_DELAY_MS));
+				writeFrame({
+					id,
+					type: "response",
+					command: frame.type,
+					success: true,
+					data: {
+						outcome: "completed",
+						stopReason: "mock",
+						finalMessage: "mock result",
+						usage: { input: 1, output: 2, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 3 },
+					},
+				});
+				continue;
+			}
+			if (frame.type === "session.steer") {
+				writeFrame({
+					id,
+					type: "response",
+					command: frame.type,
+					success: true,
+					data: {
+						status: frame.message === "durable message" && Array.isArray(frame.images) ? "ACCEPTED" : "REJECTED",
+						steeringSequence: String(frame.steering_id).length,
+					},
+				});
+				continue;
+			}
+
 			if (frame.type === "get_messages_page") {
 				if (Bun.env.MOCK_RPC_PAGE_BUSY === "1") {
 					writeFrame({

--- a/packages/coding-agent/test/rpc-client.restart.test.ts
+++ b/packages/coding-agent/test/rpc-client.restart.test.ts
@@ -30,6 +30,49 @@ describe("RpcClient lifecycle (issue #4079 B)", () => {
 		]);
 	}, 20_000);
 
+	test("exposes durable session custody commands", async () => {
+		using client = new RpcClient({
+			cliPath: MOCK_AGENT,
+			env: { MOCK_RPC_DURABLE_EVENTS: "1", MOCK_RPC_RESULT_DELAY_MS: "20" },
+		});
+		const eventTypes: string[] = [];
+		client.onSessionEvent(event => eventTypes.push(event.type));
+		await client.start();
+
+		expect(await client.startSession("run-1")).toEqual({
+			run_id: "run-1",
+			session_id: "start:run-1",
+			existing: false,
+		});
+		expect(await client.resumeSession("run-2", { sessionId: "session-1", afterSequence: 7 })).toEqual({
+			run_id: "run-2",
+			session_id: "resume:run-2:session-1:7",
+			existing: false,
+		});
+		expect(await client.replaySession({ afterSequence: 4, limit: 1 })).toEqual({
+			events: [],
+			next_sequence: 4,
+			has_more: true,
+		});
+		expect(await client.watchSession({ afterSequence: 5, limit: 2 })).toEqual({
+			events: [],
+			next_sequence: 5,
+			has_more: false,
+		});
+		await expect(client.getSessionResult(1)).rejects.toThrow("Timeout waiting for response to session.result");
+		expect(await client.getSessionResult()).toMatchObject({
+			outcome: "completed",
+			stopReason: "mock",
+			finalMessage: "mock result",
+		});
+		expect(await client.steerSession("steer-1", "durable message", [])).toEqual({
+			status: "ACCEPTED",
+			steeringSequence: 7,
+		});
+		await Bun.sleep(0);
+		expect(eventTypes).toEqual(["steering_queued", "steering_injected", "steering_rejected", "session_terminal"]);
+	}, 20_000);
+
 	test("normalizes state fields omitted by a legacy RPC server", async () => {
 		using client = new RpcClient({
 			cliPath: MOCK_AGENT,

--- a/packages/coding-agent/test/rpc-input-frame.test.ts
+++ b/packages/coding-agent/test/rpc-input-frame.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { RpcHostToolBridge } from "@oh-my-pi/pi-coding-agent/modes/rpc/host-tools";
 import {
 	dispatchRpcInputFrame,
+	finalizeRpcInputAfterEof,
 	type PendingExtensionRequest,
 	RpcInputDispatcher,
 	type RpcInputFrameDeps,
@@ -59,6 +60,21 @@ const requestExtensionInput = (deps: RpcInputFrameDeps, id: string, message: str
 	});
 	return response.promise;
 };
+
+const sessionResultResponse = (id: string | undefined): RpcResponse => ({
+	id,
+	type: "response",
+	command: "session.result",
+	success: true,
+	data: {
+		resultId: "result-1",
+		outcome: "completed",
+		stopReason: "done",
+		finalMessage: "done",
+		usage: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		terminalSequence: 1,
+	},
+});
 
 const cancelledBashResponse = (id: string): RpcResponse => ({
 	id,
@@ -229,6 +245,29 @@ describe("dispatchRpcInputFrame", () => {
 	});
 });
 
+test("drains queued serial input before sealing EOF and releasing result waiters", async () => {
+	const order: string[] = [];
+	let inputDrained = false;
+	let sealed = false;
+
+	await finalizeRpcInputAfterEof(
+		async () => {
+			inputDrained = true;
+			order.push("input");
+		},
+		async () => {
+			expect(inputDrained).toBe(true);
+			sealed = true;
+			order.push("seal");
+		},
+		async () => {
+			expect(sealed).toBe(true);
+			order.push("background");
+		},
+	);
+
+	expect(order).toEqual(["input", "seal", "background"]);
+});
 describe("RpcInputDispatcher", () => {
 	test("control frames resolve extension UI requests while an ordinary command is active", async () => {
 		let depsRef: RpcInputFrameDeps;
@@ -351,6 +390,308 @@ describe("RpcInputDispatcher", () => {
 		expect((outputs[0] as RpcResponse).id).toBe("first");
 		expect((outputs[1] as RpcResponse).id).toBe("second");
 		expect((outputs[1] as RpcResponse).command).toBe("get_state");
+	});
+
+	test("session.result waits in the background while later steering dispatches", async () => {
+		const result = Promise.withResolvers<RpcResponse>();
+		const started: string[] = [];
+		const backgroundTasks: Promise<void>[] = [];
+		const { deps, outputs } = makeDeps(async command => {
+			started.push(command.type);
+			if (command.type === "session.result") return result.promise;
+			if (command.type === "session.steer") {
+				return {
+					id: command.id,
+					type: "response",
+					command: "session.steer",
+					success: true,
+					data: { status: "ACCEPTED", steeringSequence: 1 },
+				};
+			}
+			throw new Error(`unexpected command type: ${command.type}`);
+		});
+		deps.trackBackgroundTask = task => backgroundTasks.push(task);
+		const dispatcher = new RpcInputDispatcher({ deps });
+
+		dispatcher.dispatch({ id: "result", type: "session.result" });
+		dispatcher.dispatch({ id: "steer", type: "session.steer", steering_id: "s-1", message: "continue" });
+		await dispatcher.drain();
+		expect(started).toEqual(["session.result", "session.steer"]);
+		expect((outputs[0] as RpcResponse).id).toBe("steer");
+
+		result.resolve({
+			id: "result",
+			type: "response",
+			command: "session.result",
+			success: true,
+			data: {
+				resultId: "result-1",
+				outcome: "completed",
+				stopReason: "done",
+				finalMessage: "done",
+				usage: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				terminalSequence: 1,
+			},
+		});
+		await Promise.all(backgroundTasks);
+		expect((outputs[1] as RpcResponse).id).toBe("result");
+	});
+
+	test("session.result starts after an earlier custody bind without blocking later steering", async () => {
+		const bind = Promise.withResolvers<void>();
+		const result = Promise.withResolvers<RpcResponse>();
+		const started: string[] = [];
+		const backgroundTasks: Promise<void>[] = [];
+		const { deps, outputs } = makeDeps(async command => {
+			started.push(command.type);
+			if (command.type === "session.start") {
+				await bind.promise;
+				return {
+					id: command.id,
+					type: "response",
+					command: "session.start",
+					success: true,
+					data: { run_id: command.run_id, session_id: "session-1", existing: false },
+				};
+			}
+			if (command.type === "session.result") return result.promise;
+			if (command.type === "session.steer") {
+				return {
+					id: command.id,
+					type: "response",
+					command: "session.steer",
+					success: true,
+					data: { status: "ACCEPTED", steeringSequence: 1 },
+				};
+			}
+			throw new Error(`unexpected command type: ${command.type}`);
+		});
+		deps.trackBackgroundTask = task => backgroundTasks.push(task);
+		const dispatcher = new RpcInputDispatcher({ deps });
+
+		dispatcher.dispatch({ id: "start", type: "session.start", run_id: "run-1" });
+		dispatcher.dispatch({ id: "result", type: "session.result" });
+		dispatcher.dispatch({ id: "steer", type: "session.steer", steering_id: "s-1", message: "continue" });
+		await flushMicrotasks();
+		expect(started).toEqual(["session.start"]);
+		expect(backgroundTasks).toHaveLength(0);
+
+		bind.resolve();
+		await dispatcher.drain();
+		expect(started).toEqual(["session.start", "session.result", "session.steer"]);
+		expect(outputs.map(output => (output as RpcResponse).id)).toEqual(["start", "steer"]);
+
+		result.resolve({
+			id: "result",
+			type: "response",
+			command: "session.result",
+			success: true,
+			data: {
+				resultId: "result-1",
+				outcome: "completed",
+				stopReason: "done",
+				finalMessage: "done",
+				usage: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				terminalSequence: 1,
+			},
+		});
+		await Promise.all(backgroundTasks);
+		expect((outputs[2] as RpcResponse).id).toBe("result");
+	});
+
+	/**
+	 * A bound client can ask for the terminal result before one exists. That wait
+	 * is released by the EOF seal, so it must not join the drain that runs
+	 * *before* sealing — otherwise stdin close never reaches `sealLedgerOnExit()`
+	 * and the run neither seals nor disposes.
+	 */
+	const makeResultWaitHarness = () => {
+		const terminal = Promise.withResolvers<void>();
+		const started: string[] = [];
+		const { deps, outputs } = makeDeps(async command => {
+			started.push(command.type);
+			if (command.type === "prompt") {
+				// Matches production: `prompt` answers as soon as the turn starts,
+				// the turn itself keeps running.
+				return { id: command.id, type: "response", command: "prompt", success: true };
+			}
+			if (command.type === "session.result") {
+				// waitResult() settles only once the ledger holds terminal state.
+				await terminal.promise;
+				return sessionResultResponse(command.id);
+			}
+			throw new Error(`unexpected command type: ${command.type}`);
+		});
+		const coordinator = new RpcShutdownCoordinator({
+			isShutdownRequested: () => false,
+			performShutdown: async () => {},
+		});
+		deps.trackBackgroundTask = task => coordinator.track(task);
+		const dispatcher = new RpcInputDispatcher({ deps });
+		// The pre-seal drain must resolve within the microtask cascade. Racing it
+		// against a flushed sentinel fails fast (instead of hanging the suite) if
+		// the result wait is ever put back into the serial task set.
+		const drainInput = async () => {
+			const drained = dispatcher.drain().then(() => "drained");
+			const winner = await Promise.race([drained, flushMicrotasks().then(() => "blocked")]);
+			expect(winner).toBe("drained");
+		};
+		return { terminal, started, outputs, coordinator, dispatcher, drainInput };
+	};
+
+	test("a result requested before terminal state is released by the EOF seal, not the pre-seal drain", async () => {
+		const { terminal, started, outputs, coordinator, dispatcher, drainInput } = makeResultWaitHarness();
+		const order: string[] = [];
+
+		// Bound client asks for the result, then closes stdin without prompting.
+		dispatcher.dispatch({ id: "result", type: "session.result" });
+
+		await finalizeRpcInputAfterEof(
+			async () => {
+				await drainInput();
+				order.push("input");
+			},
+			async () => {
+				expect(outputs).toHaveLength(0);
+				order.push("seal");
+				terminal.resolve();
+			},
+			async () => {
+				await dispatcher.drainResultWaits();
+				await coordinator.drain();
+				order.push("background");
+			},
+		);
+
+		expect(order).toEqual(["input", "seal", "background"]);
+		expect(started).toEqual(["session.result"]);
+		expect(outputs).toEqual([sessionResultResponse("result")]);
+		expect(dispatcher.hasPendingResultWaits).toBe(false);
+		expect(coordinator.hasTrackedTasks).toBe(false);
+	});
+
+	test("a result queued behind a hung provider turn still seals and answers at EOF", async () => {
+		const { terminal, started, outputs, coordinator, dispatcher, drainInput } = makeResultWaitHarness();
+		let sealed = false;
+
+		dispatcher.dispatch({ id: "p1", type: "prompt", message: "go" });
+		dispatcher.dispatch({ id: "result", type: "session.result" });
+
+		await finalizeRpcInputAfterEof(
+			drainInput,
+			async () => {
+				// Forced sealing runs even though the turn never reached a terminal
+				// event on its own.
+				sealed = true;
+				terminal.resolve();
+			},
+			async () => {
+				await dispatcher.drainResultWaits();
+				await coordinator.drain();
+			},
+		);
+
+		expect(sealed).toBe(true);
+		expect(started).toEqual(["prompt", "session.result"]);
+		expect(outputs.map(frame => (frame as RpcResponse).id)).toEqual(["p1", "result"]);
+		expect(dispatcher.hasPendingResultWaits).toBe(false);
+	});
+
+	test("aborts started long-running serial work so the EOF drain reaches the seal", async () => {
+		// `compact` runs in the serial tail and waits on a provider summary that can
+		// stall without limit. The pre-seal drain awaits that tail, and the abort
+		// that would settle it lives in `session.dispose()` — which only runs after
+		// the seal. Left alone the process wedges: no seal, no dispose, no exit.
+		const compaction = Promise.withResolvers<RpcResponse>();
+		const started: string[] = [];
+		const aborted: string[] = [];
+		const { deps, outputs } = makeDeps(async command => {
+			started.push(command.type);
+			if (command.type === "compact") return compaction.promise;
+			throw new Error(`unexpected command type: ${command.type}`);
+		});
+		const dispatcher = new RpcInputDispatcher({
+			deps,
+			isLongRunningSerialCommand: command => command.type === "compact",
+			abortSerialCommand: command => {
+				aborted.push(command.type);
+				// Production: session.abortCompaction() aborts the controller the
+				// stalled summary is waiting on, so session.compact() rejects.
+				compaction.reject(new Error("Compaction aborted"));
+			},
+		});
+
+		dispatcher.dispatch({ id: "c1", type: "compact" });
+		await flushMicrotasks();
+		expect(started).toEqual(["compact"]);
+
+		// stdin closes. Without the abort this drain never resolves.
+		dispatcher.closeForExit();
+		const order: string[] = [];
+		await finalizeRpcInputAfterEof(
+			async () => {
+				const drained = dispatcher.drain().then(() => "drained");
+				expect(await Promise.race([drained, flushMicrotasks().then(() => "blocked")])).toBe("drained");
+				order.push("input");
+			},
+			async () => {
+				order.push("seal");
+			},
+			async () => {
+				order.push("background");
+			},
+		);
+
+		expect(aborted).toEqual(["compact"]);
+		expect(order).toEqual(["input", "seal", "background"]);
+		// Aborting is not dropping: the command still answers the client.
+		expect(outputs).toEqual([
+			{ id: "c1", type: "response", command: "compact", success: false, error: "Compaction aborted" },
+		]);
+	});
+
+	test("refuses long-running serial work still queued at EOF and runs the ordinary tail", async () => {
+		// The queued/started distinction: a second `compact` has not started, so
+		// there is nothing to abort. Starting it once the tail unblocks would
+		// re-stall the drain the abort just freed, so it is refused instead — but
+		// refused with the frame it owes, and ordinary queued commands still run.
+		const compaction = Promise.withResolvers<RpcResponse>();
+		const started: string[] = [];
+		const { deps, outputs } = makeDeps(async command => {
+			started.push(command.type);
+			if (command.type === "compact") return compaction.promise;
+			if (command.type === "set_auto_retry") {
+				return { id: command.id, type: "response", command: "set_auto_retry", success: true };
+			}
+			throw new Error(`unexpected command type: ${command.type}`);
+		});
+		const dispatcher = new RpcInputDispatcher({
+			deps,
+			isLongRunningSerialCommand: command => command.type === "compact",
+			abortSerialCommand: () => compaction.reject(new Error("Compaction aborted")),
+		});
+
+		dispatcher.dispatch({ id: "c1", type: "compact" });
+		dispatcher.dispatch({ id: "c2", type: "compact" });
+		dispatcher.dispatch({ id: "s1", type: "set_auto_retry", enabled: true });
+		await flushMicrotasks();
+		expect(started).toEqual(["compact"]);
+
+		dispatcher.closeForExit();
+		await dispatcher.drain();
+
+		expect(started).toEqual(["compact", "set_auto_retry"]);
+		expect(outputs).toEqual([
+			{ id: "c1", type: "response", command: "compact", success: false, error: "Compaction aborted" },
+			{
+				id: "c2",
+				type: "response",
+				command: "compact",
+				success: false,
+				error: "RPC client disconnected before the command started",
+			},
+			{ id: "s1", type: "response", command: "set_auto_retry", success: true },
+		]);
 	});
 
 	test("serial command rejection emits an error response and does not poison the queue", async () => {
@@ -563,6 +904,7 @@ describe("RpcShutdownCoordinator", () => {
 		const { gate, deps, outputs, shutdown, recorder, coordinator } = makeBashHarness();
 
 		const awaited = dispatchRpcInputFrame({ id: "s1", type: "bash", command: "sleep 9999" }, deps);
+		expect(coordinator.hasTrackedTasks).toBe(true);
 		expect(awaited).toBeUndefined();
 
 		// Extension calls pi.shutdown() while bash is in flight; the input loop
@@ -580,11 +922,36 @@ describe("RpcShutdownCoordinator", () => {
 
 		gate.resolve(cancelledBashResponse("s1"));
 		await check;
+		expect(coordinator.hasTrackedTasks).toBe(false);
 
 		expect(outputs).toEqual([cancelledBashResponse("s1")]);
 		expect(recorder.state.calls).toBe(1);
 		// The bash response frame was already written when performShutdown ran.
 		expect(recorder.state.outputsAtShutdown).toBe(1);
+	});
+
+	test("prepares shutdown before draining result waiters", async () => {
+		const order: string[] = [];
+		const result = Promise.withResolvers<void>();
+		const coordinator = new RpcShutdownCoordinator({
+			isShutdownRequested: () => true,
+			prepareShutdown: async () => {
+				order.push("sealed");
+				result.resolve();
+			},
+			performShutdown: async () => {
+				order.push("shutdown");
+			},
+		});
+		coordinator.track(
+			result.promise.then(() => {
+				order.push("result");
+			}),
+		);
+
+		await coordinator.checkShutdownRequested();
+
+		expect(order).toEqual(["sealed", "result", "shutdown"]);
 	});
 
 	test("settle hook fires the deferred shutdown when no further client frames arrive", async () => {

--- a/packages/coding-agent/test/rpc-prompt-result.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-result.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, expectTypeOf, test } from "bun:test";
 import {
 	compactRpcSession,
+	completeRpcResultAfterTranscriptFlush,
 	deliverRpcSteeringIfNeeded,
 	drainRpcTerminalBoundary,
 	hasActiveRpcSessionWork,
@@ -26,6 +27,7 @@ import type {
 	ExtensionCommandContextActions,
 	ExtensionContextActions,
 } from "../src/extensibility/extensions/types";
+import type { RpcSessionEventListener } from "../src/modes/rpc/rpc-client";
 import { initializeExtensions } from "../src/modes/runtime-init";
 import type { AgentSession } from "../src/session/agent-session";
 
@@ -125,6 +127,42 @@ describe("RPC durable custody prompts", () => {
 
 		await expect(waitForRpcMessageDurability(session, {} as never)).rejects.toBe(failure);
 		expect(order).toEqual(["message", "flush"]);
+	});
+
+	test("flushes the transcript before completing the durable result", async () => {
+		const order: string[] = [];
+		const failure = new Error("transcript append failed");
+		const owner = {
+			beginResultSeal: () => order.push("seal"),
+			completeResult: async () => {
+				order.push("complete");
+				return {} as never;
+			},
+		};
+		const result = {
+			outcome: "completed" as const,
+			stopReason: "stop",
+			finalMessage: "done",
+			usage: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		await expect(
+			completeRpcResultAfterTranscriptFlush(
+				{
+					flush: async () => {
+						order.push("flush");
+						throw failure;
+					},
+				},
+				owner,
+				result,
+			),
+		).rejects.toBe(failure);
+		expect(order).toEqual(["seal", "flush"]);
+	});
+
+	test("exposes the optional durable sequence to session event listeners", () => {
+		expectTypeOf<Parameters<RpcSessionEventListener>[0]["sequence"]>().toEqualTypeOf<number | undefined>();
 	});
 
 	test("reuses an idempotent run binding without entering a custody transition", () => {
@@ -232,10 +270,25 @@ describe("RPC durable custody prompts", () => {
 			hasPendingAsyncWork: () => false,
 			hasPendingBashMessages: false,
 			hasQueuedAgentMessages: false,
+			hasPendingExtensionEvents: false,
 		};
 
 		expect(rpcForcedExitOutcome(session, terminalTasks)).toBe("aborted");
 		pending.resolve();
+	});
+
+	test("marks a forced exit aborted while an extension handler is running", () => {
+		const session = {
+			isStreaming: false,
+			isCompacting: false,
+			hasPendingAdvisorReviews: false,
+			hasPendingAsyncWork: () => false,
+			hasPendingBashMessages: false,
+			hasQueuedAgentMessages: false,
+			hasPendingExtensionEvents: true,
+		};
+
+		expect(rpcForcedExitOutcome(session, { hasPendingTasks: false })).toBe("aborted");
 	});
 
 	test("treats an outstanding advisor review as active pre-custody work", () => {

--- a/packages/coding-agent/test/rpc-prompt-result.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-result.test.ts
@@ -1,10 +1,31 @@
 import { describe, expect, test } from "bun:test";
 import {
+	compactRpcSession,
+	deliverRpcSteeringIfNeeded,
+	drainRpcTerminalBoundary,
+	hasActiveRpcSessionWork,
+	hasPendingRpcContinuation,
+	isRpcCustodyRestrictedPrompt,
+	materializeRpcCustodyTranscript,
+	prepareRpcResultSeal,
+	RpcCustodyBindingGuard,
 	RpcExtensionUserMessageTracker,
+	RpcTerminalTaskTracker,
 	reportLocalOnlyPromptResult,
+	retryRpcResultSealAfterAdvisorSettlement,
+	reuseRpcHarnessBinding,
+	rpcExitOutcome,
+	rpcForcedExitOutcome,
+	rpcResultSealAcceptance,
+	startRpcResidualPrompt,
+	waitForRpcMessageDurability,
 	watchAndReportLocalOnlyPromptResult,
 } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
-import type { ExtensionActions } from "../src/extensibility/extensions/types";
+import type {
+	ExtensionActions,
+	ExtensionCommandContextActions,
+	ExtensionContextActions,
+} from "../src/extensibility/extensions/types";
 import { initializeExtensions } from "../src/modes/runtime-init";
 import type { AgentSession } from "../src/session/agent-session";
 
@@ -22,6 +43,505 @@ async function waitForTrackedPromptHandlers(trackedPrompt: {
 	await Promise.resolve();
 	await Promise.resolve();
 }
+
+describe("RPC durable custody prompts", () => {
+	test("treats pending asynchronous delivery as active pre-custody work", () => {
+		const session = {
+			isStreaming: false,
+			isCompacting: false,
+			hasPendingAdvisorReviews: false,
+			hasPendingAsyncWork: () => true,
+			hasPendingBashMessages: false,
+			hasQueuedAgentMessages: false,
+			hasPendingExtensionEvents: false,
+		};
+
+		expect(hasActiveRpcSessionWork(session, false, false, false)).toBe(true);
+	});
+
+	test("treats hidden queued messages as active pre-custody work", () => {
+		const session = {
+			isStreaming: false,
+			isCompacting: false,
+			hasPendingAdvisorReviews: false,
+			hasPendingAsyncWork: () => false,
+			hasPendingBashMessages: false,
+			hasQueuedAgentMessages: true,
+			hasPendingExtensionEvents: false,
+		};
+
+		expect(hasActiveRpcSessionWork(session, false, false, false)).toBe(true);
+	});
+
+	test("treats an unfinished extension lifecycle handler as active pre-custody work", () => {
+		const session = {
+			isStreaming: false,
+			isCompacting: false,
+			hasPendingAdvisorReviews: false,
+			hasPendingAsyncWork: () => false,
+			hasPendingBashMessages: false,
+			hasQueuedAgentMessages: false,
+			hasPendingExtensionEvents: true,
+		};
+
+		expect(hasActiveRpcSessionWork(session, false, false, false)).toBe(true);
+	});
+
+	test("rejects custody steering when delivery is cancelled before queueing", async () => {
+		await expect(deliverRpcSteeringIfNeeded(false, async () => false)).rejects.toThrow(
+			"cancelled before the message was queued",
+		);
+	});
+
+	test("materializes the transcript before durable custody opens its sidecar", async () => {
+		let materialized = false;
+		const session = {
+			sessionFile: "/tmp/session.jsonl",
+			sessionManager: {
+				async ensureOnDisk() {
+					materialized = true;
+				},
+			},
+		};
+
+		await expect(materializeRpcCustodyTranscript(session)).resolves.toBe("/tmp/session.jsonl");
+		expect(materialized).toBe(true);
+	});
+
+	test("surfaces a latched transcript failure before steering is marked durable", async () => {
+		const order: string[] = [];
+		const failure = new Error("disk full");
+		const session = {
+			waitForMessagePersistence: async () => {
+				order.push("message");
+			},
+			sessionManager: {
+				flush: async () => {
+					order.push("flush");
+					throw failure;
+				},
+			},
+		};
+
+		await expect(waitForRpcMessageDurability(session, {} as never)).rejects.toBe(failure);
+		expect(order).toEqual(["message", "flush"]);
+	});
+
+	test("reuses an idempotent run binding without entering a custody transition", () => {
+		const owner = { sessionId: "session-1", isBoundToRun: (runId: string) => runId === "run-1" };
+
+		expect(reuseRpcHarnessBinding(owner as never, "run-1")).toEqual({
+			owner,
+			binding: { runId: "run-1", sessionId: "session-1", existing: true },
+		});
+		expect(reuseRpcHarnessBinding(owner as never, "run-2")).toBeUndefined();
+	});
+
+	test("recognizes every parsed move command spelling", () => {
+		expect(isRpcCustodyRestrictedPrompt("/move /existing/dir")).toBe(true);
+		expect(isRpcCustodyRestrictedPrompt("/compact focus on APIs")).toBe(true);
+		expect(isRpcCustodyRestrictedPrompt("/move:/existing/dir")).toBe(true);
+		expect(isRpcCustodyRestrictedPrompt("/model move")).toBe(false);
+	});
+
+	test("blocks session changes throughout durable custody binding", async () => {
+		const guard = new RpcCustodyBindingGuard();
+		const pending = Promise.withResolvers<void>();
+		const binding = guard.run(() => pending.promise);
+		await Promise.resolve();
+
+		expect(() => guard.assertSessionChangeAllowed()).toThrow(
+			"Session changes are unavailable while durable RPC custody is binding",
+		);
+		pending.resolve();
+		await binding;
+		expect(() => guard.assertSessionChangeAllowed()).not.toThrow();
+	});
+
+	test("blocks extension command session changes while custody is bound", async () => {
+		let commandActions: ExtensionCommandContextActions | undefined;
+		let sessionChanges = 0;
+		const session = {
+			extensionRunner: {
+				initialize: (_actions: ExtensionActions, _context: unknown, actions: ExtensionCommandContextActions) => {
+					commandActions = actions;
+				},
+				onError: () => {},
+				emit: async () => {},
+			},
+			agent: { waitForIdle: async () => {} },
+			newSession: async () => {
+				sessionChanges++;
+				return true;
+			},
+			branch: async () => {
+				sessionChanges++;
+				return { cancelled: false };
+			},
+			switchSession: async () => {
+				sessionChanges++;
+				return true;
+			},
+		} as unknown as AgentSession;
+
+		await initializeExtensions(session, {
+			reportSendError: (_action, error) => {
+				throw error;
+			},
+			reportRuntimeError: error => {
+				throw error.error;
+			},
+			assertSessionChangeAllowed: () => {
+				throw new Error("custody bound");
+			},
+		});
+
+		await expect(commandActions!.newSession()).rejects.toThrow("custody bound");
+		await expect(commandActions!.branch("entry-id")).rejects.toThrow("custody bound");
+		await expect(commandActions!.switchSession("other.jsonl")).rejects.toThrow("custody bound");
+		expect(sessionChanges).toBe(0);
+	});
+
+	test("marks exits with unfinished RPC work aborted", () => {
+		const session = {
+			isStreaming: false,
+			isCompacting: false,
+			hasPendingAdvisorReviews: false,
+			hasPendingAsyncWork: () => true,
+			hasPendingBashMessages: false,
+			hasQueuedAgentMessages: false,
+		};
+		expect(rpcExitOutcome(hasPendingRpcContinuation(session))).toBe("aborted");
+		session.hasPendingAsyncWork = () => false;
+		session.hasPendingBashMessages = true;
+		expect(rpcExitOutcome(hasPendingRpcContinuation(session))).toBe("aborted");
+		session.hasPendingBashMessages = false;
+		session.hasQueuedAgentMessages = true;
+		expect(rpcExitOutcome(hasPendingRpcContinuation(session))).toBe("aborted");
+		session.hasQueuedAgentMessages = false;
+		expect(rpcExitOutcome(hasPendingRpcContinuation(session))).toBe("completed");
+	});
+	test("marks a forced exit aborted while an accepted terminal task is running", () => {
+		const pending = Promise.withResolvers<void>();
+		const terminalTasks = new RpcTerminalTaskTracker();
+		terminalTasks.track(pending.promise);
+		const session = {
+			isStreaming: false,
+			isCompacting: false,
+			hasPendingAdvisorReviews: false,
+			hasPendingAsyncWork: () => false,
+			hasPendingBashMessages: false,
+			hasQueuedAgentMessages: false,
+		};
+
+		expect(rpcForcedExitOutcome(session, terminalTasks)).toBe("aborted");
+		pending.resolve();
+	});
+
+	test("treats an outstanding advisor review as active pre-custody work", () => {
+		// `session.start` binds through this predicate. An advisor still reviewing
+		// the pre-custody turn would otherwise have its output bound into the new
+		// run as if the run had produced it.
+		const session = {
+			isStreaming: false,
+			isCompacting: false,
+			hasPendingAdvisorReviews: true,
+			hasPendingAsyncWork: () => false,
+			hasPendingBashMessages: false,
+			hasQueuedAgentMessages: false,
+			hasPendingExtensionEvents: false,
+		};
+
+		expect(hasActiveRpcSessionWork(session, false, false, false)).toBe(true);
+	});
+
+	test("refuses to seal while an advisor review is still outstanding", () => {
+		// Every primary-facing signal reads idle here: advisors review out of band.
+		// A late concern persists a card after the terminal result, and a late
+		// blocker resumes the primary through a trigger turn outside the ledger.
+		const session = {
+			isStreaming: false,
+			isCompacting: false,
+			hasPendingAdvisorReviews: true,
+			hasPendingAsyncWork: () => false,
+			hasPendingBashMessages: false,
+			hasQueuedAgentMessages: false,
+		};
+
+		expect(hasPendingRpcContinuation(session)).toBe(true);
+		expect(rpcExitOutcome(hasPendingRpcContinuation(session))).toBe("aborted");
+		session.hasPendingAdvisorReviews = false;
+		expect(hasPendingRpcContinuation(session)).toBe(false);
+	});
+
+	test("drains an advisor review inside the terminal boundary", async () => {
+		let pendingAdvisor = true;
+		let cardPersisted = false;
+		let drains = 0;
+
+		await drainRpcTerminalBoundary(
+			{
+				hasPendingBashMessages: false,
+				flushPendingBashMessages: async () => {},
+				hasPendingExtensionEvents: false,
+				waitForPendingExtensionEvents: async () => {},
+				get hasPendingAdvisorReviews() {
+					return pendingAdvisor;
+				},
+				waitForPendingAdvisorReviews: async () => {
+					drains++;
+					// The review lands and its card persists — inside the boundary,
+					// which is the whole point of draining here rather than after.
+					cardPersisted = true;
+					pendingAdvisor = false;
+				},
+			},
+			new RpcTerminalTaskTracker(),
+			new RpcExtensionUserMessageTracker(),
+		);
+
+		expect(drains).toBe(1);
+		expect(cardPersisted).toBe(true);
+		expect(pendingAdvisor).toBe(false);
+	});
+
+	test("gives up on a stalled advisor instead of spinning the terminal boundary", async () => {
+		// The advisor drain is bounded, so an advisor that never catches up leaves
+		// the flag set. The boundary must exit anyway — the leftover is reported by
+		// the continuation predicate, which refuses the seal.
+		let drains = 0;
+
+		await drainRpcTerminalBoundary(
+			{
+				hasPendingBashMessages: false,
+				flushPendingBashMessages: async () => {},
+				hasPendingExtensionEvents: false,
+				waitForPendingExtensionEvents: async () => {},
+				hasPendingAdvisorReviews: true,
+				waitForPendingAdvisorReviews: async () => {
+					drains++;
+				},
+			},
+			new RpcTerminalTaskTracker(),
+			new RpcExtensionUserMessageTracker(),
+		);
+
+		expect(drains).toBe(1);
+	});
+	test("retries a refused seal when a silent advisor review settles", () => {
+		let settlementListener: (() => void) | undefined;
+		let unsubscribeCalls = 0;
+		let retryCalls = 0;
+		const cancel = retryRpcResultSealAfterAdvisorSettlement(
+			{
+				onAdvisorReviewsSettled(listener) {
+					settlementListener = listener;
+					return () => {
+						unsubscribeCalls++;
+					};
+				},
+			},
+			() => {
+				retryCalls++;
+			},
+		);
+
+		settlementListener?.();
+		settlementListener?.();
+		cancel();
+
+		expect(retryCalls).toBe(1);
+		expect(unsubscribeCalls).toBe(1);
+	});
+
+	test("flushes deferred bash results before opening the terminal boundary", async () => {
+		let pendingBash = true;
+		let flushes = 0;
+		await drainRpcTerminalBoundary(
+			{
+				get hasPendingBashMessages() {
+					return pendingBash;
+				},
+				hasPendingExtensionEvents: false,
+				async waitForPendingExtensionEvents() {},
+				async flushPendingBashMessages() {
+					flushes++;
+					pendingBash = false;
+				},
+				hasPendingAdvisorReviews: false,
+				waitForPendingAdvisorReviews: async () => {},
+			},
+			new RpcTerminalTaskTracker(),
+			new RpcExtensionUserMessageTracker(),
+		);
+
+		expect(flushes).toBe(1);
+		expect(pendingBash).toBe(false);
+	});
+
+	test("waits for agent-end extension handlers before draining their continuation", async () => {
+		let pendingExtension = true;
+		let continuationFinished = false;
+		const extensionGate = Promise.withResolvers<void>();
+		const terminalTasks = new RpcTerminalTaskTracker();
+		const extensionTasks = new RpcExtensionUserMessageTracker();
+		const extensionEvent = extensionGate.promise.then(async () => {
+			pendingExtension = false;
+			await extensionTasks.trackAgentMessageTask(Promise.resolve().then(() => (continuationFinished = true)));
+		});
+
+		await Promise.all([
+			drainRpcTerminalBoundary(
+				{
+					hasPendingBashMessages: false,
+					flushPendingBashMessages: async () => {},
+					get hasPendingExtensionEvents() {
+						return pendingExtension;
+					},
+					waitForPendingExtensionEvents: async () => extensionEvent,
+					hasPendingAdvisorReviews: false,
+					waitForPendingAdvisorReviews: async () => {},
+				},
+				terminalTasks,
+				extensionTasks,
+			),
+			Promise.resolve().then(() => extensionGate.resolve()),
+		]);
+
+		expect(continuationFinished).toBe(true);
+	});
+
+	test("skips terminal-task draining while forcing an aborted exit result", async () => {
+		let drainCalls = 0;
+		expect(
+			await prepareRpcResultSeal(
+				true,
+				async () => {
+					drainCalls++;
+				},
+				() => true,
+			),
+		).toBe(true);
+		expect(drainCalls).toBe(0);
+	});
+
+	test("takes the terminal decision with acceptance already closed", async () => {
+		// The window this closes: the old order checked for a continuation, then
+		// yielded, then sealed. Anything the custody gate admitted in that gap ran
+		// on under a terminal result. The check must never be consulted while the
+		// gate is still open, and the gate must stay closed through the seal.
+		const openAtCheck: boolean[] = [];
+		let accepting = true;
+
+		const sealed = await prepareRpcResultSeal(
+			false,
+			async () => {},
+			() => {
+				openAtCheck.push(accepting);
+				return false;
+			},
+			{
+				close: () => {
+					accepting = false;
+				},
+				reopen: () => {
+					accepting = true;
+				},
+			},
+		);
+
+		expect(sealed).toBe(true);
+		expect(openAtCheck).toEqual([false]);
+		expect(accepting).toBe(false);
+	});
+
+	test("cancels the seal and re-arms parked wakes when work is admitted during the boundary drain", async () => {
+		// A yield-queue idle flush wakes while the boundary is still draining.
+		// Acceptance is legitimately open there, so the work is admitted — and the
+		// attempt must then abandon rather than seal over it.
+		const events: string[] = [];
+		let accepting = true;
+		let pendingContinuation = false;
+		let drains = 0;
+
+		const sealed = await prepareRpcResultSeal(
+			false,
+			async () => {
+				drains++;
+				if (drains === 1 && accepting) {
+					pendingContinuation = true;
+					events.push("admitted");
+				}
+			},
+			() => pendingContinuation,
+			{
+				close: () => {
+					accepting = false;
+					events.push("closed");
+				},
+				reopen: () => {
+					accepting = true;
+					events.push("reopened");
+				},
+			},
+		);
+
+		expect(sealed).toBe(false);
+		// The second drain is what gives work admitted during the first one a
+		// boundary to reach before the check decides.
+		expect(drains).toBe(2);
+		expect(events).toEqual(["admitted", "closed", "reopened"]);
+		expect(accepting).toBe(true);
+	});
+
+	test("abandoning a seal reopens custody and re-arms the idle flush it parked", () => {
+		// Reopening alone is silent: the gate stops refusing, but nothing
+		// re-evaluates the wakes it already parked, so a missing re-arm strands
+		// them until disposal with no error and no log. Assert the pairing.
+		const calls: string[] = [];
+		const acceptance = rpcResultSealAcceptance(
+			{
+				beginResultSeal: () => calls.push("beginResultSeal"),
+				cancelResultSeal: () => calls.push("cancelResultSeal"),
+			},
+			() => calls.push("requestIdleFlush"),
+		);
+
+		acceptance.close();
+		acceptance.reopen();
+
+		expect(calls).toEqual(["beginResultSeal", "cancelResultSeal", "requestIdleFlush"]);
+	});
+
+	test("rechecks custody before starting an ACP residual prompt", () => {
+		let started = false;
+		expect(() =>
+			startRpcResidualPrompt(
+				{
+					assertAcceptingWork() {
+						throw new Error("run already sealed");
+					},
+				},
+				() => {
+					started = true;
+				},
+			),
+		).toThrow("run already sealed");
+		expect(started).toBe(false);
+	});
+
+	test("seals a streaming episode after manual compaction aborts it", async () => {
+		const seals: Array<[string, string]> = [];
+		const compact = async () => ({ summary: "compacted" });
+
+		const result = await compactRpcSession(true, compact, async (stopReason, outcome) => {
+			seals.push([stopReason, outcome]);
+		});
+
+		expect(result).toEqual({ summary: "compacted" });
+		expect(seals).toEqual([["aborted", "aborted"]]);
+	});
+});
 
 describe("reportLocalOnlyPromptResult", () => {
 	test("emits prompt_result when prompt resolves without invoking the agent or extension user message", async () => {
@@ -41,6 +561,51 @@ describe("reportLocalOnlyPromptResult", () => {
 		await waitForPromptHandlers(trackedPrompt.prompt);
 
 		expect(output).toEqual([{ type: "prompt_result", id: "req_1", agentInvoked: false }]);
+	});
+
+	test("keeps prompt preflight active until the prompt promise settles", async () => {
+		const extensionUserMessages = new RpcExtensionUserMessageTracker();
+		const preflight = Promise.withResolvers<boolean>();
+		const trackedPrompt = extensionUserMessages.watchPrompt(() => preflight.promise);
+
+		expect(extensionUserMessages.hasActivePrompts).toBe(true);
+
+		preflight.resolve(false);
+		await trackedPrompt.prompt;
+		expect(extensionUserMessages.hasActivePrompts).toBe(false);
+	});
+
+	test("keeps extension message preparation pending after the outer prompt resolves", async () => {
+		const extensionUserMessages = new RpcExtensionUserMessageTracker();
+		const messagePreparation = Promise.withResolvers<void>();
+		const trackedPrompt = extensionUserMessages.watchPrompt(() => {
+			extensionUserMessages.trackAgentMessageTask(messagePreparation.promise);
+			return Promise.resolve(false);
+		});
+
+		await trackedPrompt.prompt;
+		expect(extensionUserMessages.hasPendingAgentMessageTasks).toBe(true);
+
+		messagePreparation.resolve();
+		await messagePreparation.promise;
+		await Promise.resolve();
+		expect(extensionUserMessages.hasPendingAgentMessageTasks).toBe(false);
+	});
+
+	test("waits for all extension message preparation to settle", async () => {
+		const extensionUserMessages = new RpcExtensionUserMessageTracker();
+		const messagePreparation = Promise.withResolvers<void>();
+		extensionUserMessages.trackAgentMessageTask(messagePreparation.promise);
+		let settled = false;
+		const terminal = extensionUserMessages.waitForPendingAgentMessageTasks().then(() => {
+			settled = true;
+		});
+
+		await Promise.resolve();
+		expect(settled).toBe(false);
+		messagePreparation.resolve();
+		await terminal;
+		expect(settled).toBe(true);
 	});
 
 	test("does not emit false prompt_result when an extension command schedules a user message", async () => {
@@ -148,6 +713,100 @@ describe("reportLocalOnlyPromptResult", () => {
 
 		expect(markCount).toBe(1);
 		expect(sentOptions).toEqual({ triggerTurn: true });
+	});
+
+	test("rejects extension-triggered work after durable custody seals", async () => {
+		let extensionActions: ExtensionActions | undefined;
+		let contextActions: ExtensionContextActions | undefined;
+		let commandActions: ExtensionCommandContextActions | undefined;
+		let sends = 0;
+		const session = {
+			extensionRunner: {
+				initialize: (
+					actions: ExtensionActions,
+					context: ExtensionContextActions,
+					commands: ExtensionCommandContextActions,
+				) => {
+					extensionActions = actions;
+					contextActions = context;
+					commandActions = commands;
+				},
+				onError: () => {},
+				emit: async () => {},
+			},
+			sendCustomMessage: async () => {
+				sends++;
+			},
+			sendUserMessage: async () => {
+				sends++;
+			},
+		} as unknown as AgentSession;
+
+		await initializeExtensions(session, {
+			reportSendError: (_action, error) => {
+				throw error;
+			},
+			reportRuntimeError: error => {
+				throw error.error;
+			},
+			assertAgentWorkAllowed: () => {
+				throw new Error("run already sealed");
+			},
+		});
+		const actions = extensionActions;
+		if (!actions) throw new Error("extensions not initialized");
+		const context = contextActions;
+		const commands = commandActions;
+		if (!context || !commands) throw new Error("extension contexts not initialized");
+		const message = {
+			customType: "test",
+			content: "context",
+			display: true,
+			details: "context",
+			attribution: "user" as const,
+		};
+
+		expect(() => actions.sendUserMessage("late work")).toThrow("run already sealed");
+		expect(() => actions.sendMessage(message, { triggerTurn: true })).toThrow("run already sealed");
+		expect(() => context.compact()).toThrow("run already sealed");
+		expect(() => commands.compact()).toThrow("run already sealed");
+		expect(sends).toBe(0);
+	});
+
+	test("routes both extension compaction contexts through the mode boundary", async () => {
+		let contextActions: ExtensionContextActions | undefined;
+		let commandActions: ExtensionCommandContextActions | undefined;
+		const calls: unknown[] = [];
+		const session = {
+			extensionRunner: {
+				initialize: (
+					_actions: ExtensionActions,
+					context: ExtensionContextActions,
+					commands: ExtensionCommandContextActions,
+				) => {
+					contextActions = context;
+					commandActions = commands;
+				},
+				onError: () => {},
+				emit: async () => {},
+			},
+		} as unknown as AgentSession;
+
+		await initializeExtensions(session, {
+			reportSendError: (_action, error) => {
+				throw error;
+			},
+			reportRuntimeError: error => {
+				throw error.error;
+			},
+			runCompact: async options => {
+				calls.push(options);
+			},
+		});
+
+		await contextActions!.compact("context");
+		await commandActions!.compact({ mode: "soft" });
+		expect(calls).toEqual(["context", { mode: "soft" }]);
 	});
 
 	test("suppresses prompt_result when extension sendUserMessage succeeds", async () => {
@@ -309,6 +968,30 @@ describe("watchAndReportLocalOnlyPromptResult", () => {
 		await waitForPromptHandlers(prompt);
 
 		expect(output).toEqual([{ type: "prompt_result", id: "req_1", agentInvoked: false }]);
+	});
+
+	test("registers prompt preflight with the terminal task boundary", async () => {
+		const extensionUserMessages = new RpcExtensionUserMessageTracker();
+		const prompt = Promise.withResolvers<boolean>();
+		let tracked: Promise<boolean> | undefined;
+
+		watchAndReportLocalOnlyPromptResult({
+			id: "req_1",
+			startPrompt: () => prompt.promise,
+			output: () => {},
+			onError: error => {
+				throw error;
+			},
+			extensionUserMessageTracker: extensionUserMessages,
+			trackPrompt: task => {
+				tracked = task;
+				return task;
+			},
+		});
+
+		expect(tracked).toBeDefined();
+		prompt.resolve(true);
+		await tracked;
 	});
 
 	test("does not report builtin residual prompts that invoke the agent", async () => {

--- a/packages/coding-agent/test/rpc-prompt-result.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-result.test.ts
@@ -56,6 +56,7 @@ describe("RPC durable custody prompts", () => {
 			hasPendingBashMessages: false,
 			hasQueuedAgentMessages: false,
 			hasPendingExtensionEvents: false,
+			hasPendingYieldWake: () => false,
 		};
 
 		expect(hasActiveRpcSessionWork(session, false, false, false)).toBe(true);
@@ -70,6 +71,7 @@ describe("RPC durable custody prompts", () => {
 			hasPendingBashMessages: false,
 			hasQueuedAgentMessages: true,
 			hasPendingExtensionEvents: false,
+			hasPendingYieldWake: () => false,
 		};
 
 		expect(hasActiveRpcSessionWork(session, false, false, false)).toBe(true);
@@ -84,6 +86,7 @@ describe("RPC durable custody prompts", () => {
 			hasPendingBashMessages: false,
 			hasQueuedAgentMessages: false,
 			hasPendingExtensionEvents: true,
+			hasPendingYieldWake: () => false,
 		};
 
 		expect(hasActiveRpcSessionWork(session, false, false, false)).toBe(true);
@@ -248,6 +251,7 @@ describe("RPC durable custody prompts", () => {
 			hasPendingAsyncWork: () => true,
 			hasPendingBashMessages: false,
 			hasQueuedAgentMessages: false,
+			hasPendingYieldWake: () => false,
 		};
 		expect(rpcExitOutcome(hasPendingRpcContinuation(session))).toBe("aborted");
 		session.hasPendingAsyncWork = () => false;
@@ -271,6 +275,7 @@ describe("RPC durable custody prompts", () => {
 			hasPendingBashMessages: false,
 			hasQueuedAgentMessages: false,
 			hasPendingExtensionEvents: false,
+			hasPendingYieldWake: () => false,
 		};
 
 		expect(rpcForcedExitOutcome(session, terminalTasks)).toBe("aborted");
@@ -286,6 +291,7 @@ describe("RPC durable custody prompts", () => {
 			hasPendingBashMessages: false,
 			hasQueuedAgentMessages: false,
 			hasPendingExtensionEvents: true,
+			hasPendingYieldWake: () => false,
 		};
 
 		expect(rpcForcedExitOutcome(session, { hasPendingTasks: false })).toBe("aborted");
@@ -303,6 +309,7 @@ describe("RPC durable custody prompts", () => {
 			hasPendingBashMessages: false,
 			hasQueuedAgentMessages: false,
 			hasPendingExtensionEvents: false,
+			hasPendingYieldWake: () => false,
 		};
 
 		expect(hasActiveRpcSessionWork(session, false, false, false)).toBe(true);
@@ -319,12 +326,27 @@ describe("RPC durable custody prompts", () => {
 			hasPendingAsyncWork: () => false,
 			hasPendingBashMessages: false,
 			hasQueuedAgentMessages: false,
+			hasPendingYieldWake: () => false,
 		};
 
 		expect(hasPendingRpcContinuation(session)).toBe(true);
 		expect(rpcExitOutcome(hasPendingRpcContinuation(session))).toBe("aborted");
 		session.hasPendingAdvisorReviews = false;
 		expect(hasPendingRpcContinuation(session)).toBe(false);
+	});
+
+	test("refuses to seal while an idle yield wake is queued", () => {
+		const session = {
+			isStreaming: false,
+			isCompacting: false,
+			hasPendingAdvisorReviews: false,
+			hasPendingAsyncWork: () => false,
+			hasPendingBashMessages: false,
+			hasQueuedAgentMessages: false,
+			hasPendingYieldWake: () => true,
+		};
+
+		expect(hasPendingRpcContinuation(session)).toBe(true);
 	});
 
 	test("drains an advisor review inside the terminal boundary", async () => {
@@ -405,6 +427,32 @@ describe("RPC durable custody prompts", () => {
 
 		expect(retryCalls).toBe(1);
 		expect(unsubscribeCalls).toBe(1);
+	});
+	test("replaces a pending advisor retry with the latest terminal boundary", () => {
+		const listeners: Array<() => void> = [];
+		let terminalOutcome = "";
+		const session = {
+			onAdvisorReviewsSettled(listener: () => void) {
+				listeners.push(listener);
+				return () => undefined;
+			},
+		};
+
+		let cancel = retryRpcResultSealAfterAdvisorSettlement(session, () => {
+			terminalOutcome = "completed";
+		});
+		cancel = retryRpcResultSealAfterAdvisorSettlement(
+			session,
+			() => {
+				terminalOutcome = "failed";
+			},
+			cancel,
+		);
+		listeners[0]?.();
+		listeners[1]?.();
+		cancel();
+
+		expect(terminalOutcome).toBe("failed");
 	});
 
 	test("flushes deferred bash results before opening the terminal boundary", async () => {

--- a/packages/coding-agent/test/rpc-session-event-stream.test.ts
+++ b/packages/coding-agent/test/rpc-session-event-stream.test.ts
@@ -1,0 +1,468 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { RpcHarnessSessionOwner } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-harness";
+import {
+	deliverRpcSteeringIfNeeded,
+	disposeRpcSessionWithCustody,
+	RpcCustodyBindingGuard,
+	type RpcSessionEventStreamDeps,
+	RpcShutdownCoordinator,
+	RpcTerminalTaskTracker,
+	shouldForceLedgerSeal,
+	streamRpcSessionEvent,
+	summarizeRpcEpisode,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import type { AgentSessionEvent } from "../src/session/agent-session-events";
+
+function notice(message: string): AgentSessionEvent {
+	return { type: "notice", level: "info", message };
+}
+
+function agentEnd(stopReason: string, isTerminal = true): AgentSessionEvent {
+	return {
+		type: "agent_end",
+		messages: [{ role: "assistant", content: [], stopReason }],
+		isTerminal,
+	} as unknown as AgentSessionEvent;
+}
+
+function collect(overrides: Partial<RpcSessionEventStreamDeps> = {}) {
+	const frames: object[] = [];
+	const seals: Array<[string, string]> = [];
+	const failures: Array<[string, unknown]> = [];
+	const deps: RpcSessionEventStreamDeps = {
+		ledger: () => undefined,
+		output: frame => frames.push(frame),
+		sealResult: async (stopReason, outcome) => {
+			seals.push([stopReason, outcome]);
+		},
+		waitForMessagePersistence: async () => {},
+		trackSteeringPersistence: () => {},
+		onLedgerFailure: (command, error) => failures.push([command, error]),
+		...overrides,
+	};
+	return { deps, frames, seals, failures };
+}
+
+describe("deliverRpcSteeringIfNeeded", () => {
+	test("skips a steering delivery already present in the transcript", async () => {
+		let deliveries = 0;
+
+		await deliverRpcSteeringIfNeeded(true, async () => {
+			deliveries++;
+		});
+
+		expect(deliveries).toBe(0);
+	});
+
+	test("delivers steering absent from the transcript", async () => {
+		let deliveries = 0;
+
+		await deliverRpcSteeringIfNeeded(false, async () => {
+			deliveries++;
+		});
+
+		expect(deliveries).toBe(1);
+	});
+});
+
+describe("RpcCustodyBindingGuard", () => {
+	test("rejects extension work throughout asynchronous custody binding", async () => {
+		const guard = new RpcCustodyBindingGuard();
+		const release = Promise.withResolvers<void>();
+		const binding = guard.run(() => release.promise);
+
+		expect(() => guard.assertWorkAllowed()).toThrow("custody is binding");
+		release.resolve();
+		await binding;
+		expect(() => guard.assertWorkAllowed()).not.toThrow();
+	});
+});
+
+describe("RpcTerminalTaskTracker", () => {
+	test("holds the terminal boundary until accepted steering delivery settles", async () => {
+		const tracker = new RpcTerminalTaskTracker();
+		const delivery = Promise.withResolvers<void>();
+		tracker.track(delivery.promise);
+		let sealed = false;
+		const terminal = tracker.wait().then(() => {
+			sealed = true;
+		});
+
+		await Promise.resolve();
+		expect(sealed).toBe(false);
+
+		delivery.resolve();
+		await terminal;
+		expect(sealed).toBe(true);
+	});
+
+	test("settles rejected application tasks before opening the terminal boundary", async () => {
+		const tracker = new RpcTerminalTaskTracker();
+		tracker.track(Promise.reject(new Error("reported command failure"))).catch(() => {});
+
+		await expect(tracker.wait()).resolves.toBeUndefined();
+		expect(tracker.hasPendingTasks).toBe(false);
+	});
+});
+
+describe("streamRpcSessionEvent", () => {
+	test("writes events straight through and seals nothing while no run is bound", async () => {
+		const { deps, frames, seals } = collect();
+
+		streamRpcSessionEvent(notice("first"), deps);
+		streamRpcSessionEvent(agentEnd("end_turn"), deps);
+		streamRpcSessionEvent(notice("second"), deps);
+		await Promise.resolve();
+
+		expect(frames.map(frame => (frame as { type: string }).type)).toEqual(["notice", "agent_end", "notice"]);
+		expect(frames.every(frame => !("sequence" in frame))).toBe(true);
+		expect(seals).toEqual([]);
+	});
+
+	test("records and sequences events once a run is bound", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-stream-"));
+		try {
+			const recordFile = path.join(tmp, "session", "rpc.jsonl");
+			const frames: object[] = [];
+			const ledger = await RpcHarnessSessionOwner.open("session-1", recordFile, event => frames.push(event));
+			const { deps, seals } = collect({ ledger: () => ledger, output: frame => frames.push(frame) });
+
+			const firstPersistence = streamRpcSessionEvent(notice("first"), deps);
+			const terminalPersistence = streamRpcSessionEvent(agentEnd("error"), deps);
+			expect(firstPersistence).toBeDefined();
+			expect(terminalPersistence).toBeDefined();
+			await Promise.all([firstPersistence, terminalPersistence]);
+
+			expect(frames.map(frame => (frame as { sequence?: number }).sequence)).toEqual([1, 2]);
+			expect(seals).toEqual([["error", "failed"]]);
+			expect(await Bun.file(recordFile).text()).toContain('"sequence":1');
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true });
+		}
+	});
+
+	test("records nonterminal agent_end without sealing the result", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-stream-"));
+		try {
+			const ledger = await RpcHarnessSessionOwner.open("session-1", path.join(tmp, "session", "rpc.jsonl"));
+			const { deps, seals } = collect({ ledger: () => ledger });
+
+			streamRpcSessionEvent(agentEnd("end_turn", false), deps);
+			await ledger.replay();
+
+			expect(seals).toEqual([]);
+			expect(ledger.hasResult).toBe(false);
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true });
+		}
+	});
+
+	test("records steering injection only after message persistence", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-stream-"));
+		try {
+			const ledger = await RpcHarnessSessionOwner.open("session-1", path.join(tmp, "session", "rpc.jsonl"));
+			await ledger.steer("steer-1", "hello", async () => {});
+			const persisted = Promise.withResolvers<void>();
+			const { deps } = collect({
+				ledger: () => ledger,
+				waitForMessagePersistence: () => persisted.promise,
+			});
+			const event = {
+				type: "message_end",
+				message: { role: "user", content: "hello", timestamp: 0, idempotencyKey: "rpc:session-1:steer-1" },
+			} as unknown as AgentSessionEvent;
+
+			streamRpcSessionEvent(event, deps);
+			await ledger.replay();
+			expect((await ledger.replay()).map(item => item.type)).not.toContain("steering_injected");
+			persisted.resolve();
+			await Promise.resolve();
+			await ledger.replay();
+			expect((await ledger.replay()).map(item => item.type)).toContain("steering_injected");
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true });
+		}
+	});
+
+	test("waits for delayed steering persistence before sealing", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-stream-"));
+		try {
+			const ledger = await RpcHarnessSessionOwner.open("session-1", path.join(tmp, "session", "rpc.jsonl"));
+			await ledger.steer("steer-1", "hello", async () => {});
+			const persisted = Promise.withResolvers<void>();
+			const pending = new Set<Promise<void>>();
+			const { deps } = collect({
+				ledger: () => ledger,
+				waitForMessagePersistence: () => persisted.promise,
+				trackSteeringPersistence: task => pending.add(task),
+				sealResult: async (stopReason, outcome) => {
+					ledger.beginResultSeal();
+					await Promise.all(pending);
+					await ledger.completeResult({
+						outcome,
+						stopReason,
+						finalMessage: "",
+						usage: { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					});
+				},
+			});
+			const event = {
+				type: "message_end",
+				message: { role: "user", content: "hello", timestamp: 0, idempotencyKey: "rpc:session-1:steer-1" },
+			} as unknown as AgentSessionEvent;
+
+			streamRpcSessionEvent(event, deps);
+			streamRpcSessionEvent(agentEnd("end_turn"), deps);
+			await ledger.replay();
+			expect(ledger.hasResult).toBe(false);
+			expect(() => ledger.assertAcceptingWork()).toThrow("already sealed");
+
+			persisted.resolve();
+			await ledger.waitResult();
+			expect((await ledger.replay()).map(item => item.type)).toEqual([
+				"steering_queued",
+				"message_end",
+				"agent_end",
+				"steering_injected",
+				"session_terminal",
+			]);
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true });
+		}
+	});
+
+	test("does not mark steering injected when transcript persistence fails", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-stream-"));
+		try {
+			const ledger = await RpcHarnessSessionOwner.open("session-1", path.join(tmp, "session", "rpc.jsonl"));
+			await ledger.steer("steer-1", "hello", async () => {});
+			const { deps, failures } = collect({
+				ledger: () => ledger,
+				waitForMessagePersistence: async () => {
+					throw new Error("transcript write failed");
+				},
+			});
+			const event = {
+				type: "message_end",
+				message: { role: "user", content: "hello", timestamp: 0, idempotencyKey: "rpc:session-1:steer-1" },
+			} as unknown as AgentSessionEvent;
+
+			streamRpcSessionEvent(event, deps);
+			await Promise.resolve();
+			await ledger.replay();
+
+			expect((await ledger.replay()).map(item => item.type)).not.toContain("steering_injected");
+			expect(failures).toEqual([["session.steer", expect.any(Error)]]);
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true });
+		}
+	});
+	test("drops events emitted after the terminal result is sealed", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-stream-"));
+		try {
+			const ledger = await RpcHarnessSessionOwner.open("session-1", path.join(tmp, "session", "rpc.jsonl"));
+			await ledger.completeResult({
+				outcome: "completed",
+				stopReason: "end_turn",
+				finalMessage: "done",
+				usage: { input: 1, output: 1, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 2 },
+			});
+			const { deps, frames, failures } = collect({ ledger: () => ledger });
+
+			streamRpcSessionEvent(notice("after"), deps);
+			await Promise.resolve();
+
+			expect(frames).toEqual([]);
+			expect(failures).toEqual([]);
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true });
+		}
+	});
+
+	test("reports a failed append as session.watch", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-stream-"));
+		try {
+			const sidecar = path.join(tmp, "session");
+			const ledger = await RpcHarnessSessionOwner.open("session-1", path.join(sidecar, "rpc.jsonl"));
+			// Occupying the sidecar directory name with a regular file makes the
+			// append fail the way a full or read-only disk would.
+			await fs.writeFile(sidecar, "");
+			const { deps, failures } = collect({ ledger: () => ledger });
+
+			streamRpcSessionEvent(notice("first"), deps);
+			await ledger.replay().catch(() => undefined);
+			await Promise.resolve();
+
+			expect(failures.map(([command]) => command)).toEqual(["session.watch"]);
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("shouldForceLedgerSeal", () => {
+	const zeroUsage = () => ({ input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 0 });
+
+	/**
+	 * Wires a coordinator the way `runRpcMode` does: the forced seal is gated on
+	 * ledger seal availability, a background `session.result` read is tracked so
+	 * the drain waits on it, and the first reported failure requests shutdown.
+	 */
+	function wireShutdown(ledger: RpcHarnessSessionOwner) {
+		const reported = Promise.withResolvers<void>();
+		const failures: string[] = [];
+		const performed: string[] = [];
+		const sealed: string[] = [];
+		const shutdownState = { requested: false };
+		const coordinator = new RpcShutdownCoordinator({
+			isShutdownRequested: () => shutdownState.requested,
+			prepareShutdown: async () => {
+				if (!shouldForceLedgerSeal(ledger)) return;
+				sealed.push("shutdown_requested");
+				await ledger.completeResult({
+					outcome: "completed",
+					stopReason: "shutdown_requested",
+					finalMessage: "",
+					usage: zeroUsage(),
+				});
+			},
+			performShutdown: async () => {
+				performed.push("shutdown");
+			},
+		});
+		const waiter = ledger.waitResult().then(
+			() => "resolved",
+			() => "rejected",
+		);
+		coordinator.track(waiter.then(() => undefined));
+		const onLedgerFailure = (command: string) => {
+			failures.push(command);
+			shutdownState.requested = true;
+			reported.resolve();
+			void coordinator.checkShutdownRequested();
+		};
+		return { coordinator, failures, onLedgerFailure, performed, reported, sealed, waiter };
+	}
+
+	const steeringDelivery = () =>
+		({
+			type: "message_end",
+			message: { role: "user", content: "hello", timestamp: 0, idempotencyKey: "rpc:session-1:steer-1" },
+		}) as unknown as AgentSessionEvent;
+
+	test("forces a usable ledger to terminal state after a transcript persistence failure", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-stream-"));
+		try {
+			const ledger = await RpcHarnessSessionOwner.open("session-1", path.join(tmp, "session", "rpc.jsonl"));
+			await ledger.steer("steer-1", "hello", async () => {});
+			const wiring = wireShutdown(ledger);
+			const { deps } = collect({
+				ledger: () => ledger,
+				// A full disk fails the transcript flush; the ledger is untouched.
+				waitForMessagePersistence: async () => {
+					throw new Error("transcript write failed");
+				},
+				onLedgerFailure: wiring.onLedgerFailure,
+			});
+
+			streamRpcSessionEvent(steeringDelivery(), deps);
+			await wiring.reported.promise;
+			await wiring.coordinator.checkShutdownRequested();
+
+			expect(wiring.failures).toEqual(["session.steer"]);
+			// The reported failure never reached the ledger, so shutdown still seals.
+			expect(shouldForceLedgerSeal(ledger)).toBe(true);
+			expect(wiring.sealed).toEqual(["shutdown_requested"]);
+			expect(ledger.hasResult).toBe(true);
+			expect((await ledger.waitResult()).stopReason).toBe("shutdown_requested");
+			// The tracked session.result waiter resolved, so the drain reached disposal.
+			expect(await wiring.waiter).toBe("resolved");
+			expect(wiring.coordinator.hasTrackedTasks).toBe(false);
+			expect(wiring.performed).toEqual(["shutdown"]);
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true });
+		}
+	});
+
+	test("skips the forced seal when a latched ledger failure took sealing away", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-stream-"));
+		try {
+			const sidecar = path.join(tmp, "session");
+			const ledger = await RpcHarnessSessionOwner.open("session-1", path.join(sidecar, "rpc.jsonl"));
+			// Occupying the sidecar directory name with a regular file makes the
+			// append fail the way a full or read-only disk would.
+			await fs.writeFile(sidecar, "");
+			const wiring = wireShutdown(ledger);
+			const { deps } = collect({ ledger: () => ledger, onLedgerFailure: wiring.onLedgerFailure });
+
+			streamRpcSessionEvent(notice("first"), deps);
+			await wiring.reported.promise;
+			await wiring.coordinator.checkShutdownRequested();
+
+			expect(wiring.failures).toEqual(["session.watch"]);
+			expect(shouldForceLedgerSeal(ledger)).toBe(false);
+			expect(wiring.sealed).toEqual([]);
+			expect(ledger.hasResult).toBe(false);
+			// The latch already rejected the waiter, so the drain still completes.
+			expect(await wiring.waiter).toBe("rejected");
+			expect(wiring.performed).toEqual(["shutdown"]);
+		} finally {
+			await fs.rm(tmp, { recursive: true, force: true });
+		}
+	});
+});
+
+test("holds durable custody until session disposal finishes", async () => {
+	const sessionDisposed = Promise.withResolvers<void>();
+	const calls: string[] = [];
+	const disposal = disposeRpcSessionWithCustody(
+		{
+			dispose: async () => {
+				calls.push("session-start");
+				await sessionDisposed.promise;
+				calls.push("session-end");
+			},
+		},
+		{
+			dispose: async () => {
+				calls.push("custody");
+			},
+		},
+	);
+
+	await Promise.resolve();
+	expect(calls).toEqual(["session-start"]);
+	sessionDisposed.resolve();
+	await disposal;
+	expect(calls).toEqual(["session-start", "session-end", "custody"]);
+});
+
+test("rebuilds result aggregates from durable message events", () => {
+	const summary = summarizeRpcEpisode([
+		{
+			type: "message_end",
+			sequence: 1,
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "before crash" }],
+				stopReason: "stop",
+				usage: {
+					input: 4,
+					output: 3,
+					cacheRead: 1,
+					cacheWrite: 2,
+					totalTokens: 10,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+			},
+		} as never,
+	]);
+
+	expect(summary).toEqual({
+		finalMessage: "before crash",
+		usage: { input: 4, output: 3, reasoning: 0, cacheRead: 1, cacheWrite: 2, total: 10 },
+	});
+});

--- a/packages/coding-agent/test/session/yield-queue.test.ts
+++ b/packages/coding-agent/test/session/yield-queue.test.ts
@@ -23,11 +23,13 @@ function messageText(message: AgentMessage): string {
 
 function createHarness(initialStreaming: boolean) {
 	let streaming = initialStreaming;
+	let wakeAllowed = true;
 	const streamingMessages: AgentMessage[] = [];
 	const idleBatches: AgentMessage[][] = [];
 	const scheduledFlushes: Array<() => Promise<void>> = [];
 	const queue = new YieldQueue({
 		isStreaming: () => streaming,
+		canWakeIdle: () => wakeAllowed,
 		injectStreaming: message => {
 			streamingMessages.push(message);
 		},
@@ -45,6 +47,9 @@ function createHarness(initialStreaming: boolean) {
 		scheduledFlushes,
 		setStreaming: (value: boolean) => {
 			streaming = value;
+		},
+		setWakeAllowed: (value: boolean) => {
+			wakeAllowed = value;
 		},
 	};
 }
@@ -124,6 +129,55 @@ describe("YieldQueue", () => {
 
 		expect(harness.idleBatches).toHaveLength(1);
 		expect(harness.idleBatches[0]?.map(messageText)).toEqual(["a,b"]);
+	});
+
+	test("refused wake retains entries and delivers them on the next allowed flush", async () => {
+		const harness = createHarness(false);
+		harness.queue.register<Entry>("items", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+		harness.setWakeAllowed(false);
+
+		let delivered = false;
+		const receipt = harness.queue.enqueueWithReceipt("items", { id: "owed" }).then(() => {
+			delivered = true;
+		});
+		await harness.scheduledFlushes[0]!();
+
+		// The wake was refused, so no turn started — and the entry was neither
+		// dropped nor settled, because it is still owed.
+		expect(harness.idleBatches).toHaveLength(0);
+		expect(harness.queue.has("items")).toBe(true);
+		expect(delivered).toBe(false);
+
+		// The refusal cleared the pending latch, so a later request re-arms the flush.
+		harness.setWakeAllowed(true);
+		harness.queue.requestIdleFlush();
+		await harness.scheduledFlushes[1]!();
+		await receipt;
+
+		expect(harness.idleBatches.map(batch => batch.map(messageText))).toEqual([["owed"]]);
+		expect(delivered).toBe(true);
+		expect(harness.queue.has("items")).toBe(false);
+	});
+
+	test("refused wake leaves entries for the lazy aside drain", async () => {
+		const harness = createHarness(false);
+		harness.queue.register<Entry>("items", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+		harness.setWakeAllowed(false);
+
+		harness.queue.enqueue("items", { id: "owed" });
+		await harness.scheduledFlushes[0]!();
+		expect(harness.idleBatches).toHaveLength(0);
+
+		// A run started through some other path still collects the retained entry
+		// at its aside boundary; the gate only suppresses autonomous wakes.
+		const thunks = harness.queue.drainLazy();
+		expect(thunks).toHaveLength(1);
+		const message = thunks[0]!();
+		expect(message && messageText(message)).toBe("owed");
 	});
 
 	test("resolves delivery receipts only after idle injection succeeds", async () => {

--- a/packages/coding-agent/test/session/yield-queue.test.ts
+++ b/packages/coding-agent/test/session/yield-queue.test.ts
@@ -113,6 +113,22 @@ describe("YieldQueue", () => {
 		expect(harness.idleBatches[0]?.map(messageText)).toEqual(["done"]);
 		expect(harness.queue.has("advisor")).toBe(true);
 	});
+	test("distinguishes idle wake entries from lazy-only entries", () => {
+		const harness = createHarness(true);
+		harness.queue.register<Entry>("advisor", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+			skipIdleFlush: true,
+		});
+		harness.queue.register<Entry>("completion", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+
+		harness.queue.enqueue("advisor", { id: "advice" });
+		expect(harness.queue.hasPendingIdleWake()).toBe(false);
+
+		harness.queue.enqueue("completion", { id: "done" });
+		expect(harness.queue.hasPendingIdleWake()).toBe(true);
+	});
 	test("enqueue while idle schedules one debounced idle flush", async () => {
 		const harness = createHarness(false);
 		harness.queue.register<Entry>("items", {

--- a/packages/omptype/src/typebox.ts
+++ b/packages/omptype/src/typebox.ts
@@ -149,7 +149,7 @@ function applyMeta<T>(schema: RuntimeType<T>, opts?: Meta): CompatRuntime<T> {
 }
 
 function withJsonSchemaKeywords<T>(schema: CompatRuntime<T>, keywords: Record<string, unknown>): CompatRuntime<T> {
-	const emitBase = schema.toJsonSchema;
+	const emitBase = schema.toJsonSchema.bind(schema);
 	schema.toJsonSchema = options => ({ ...emitBase(options), ...keywords });
 	return schema;
 }

--- a/packages/utils/src/json.ts
+++ b/packages/utils/src/json.ts
@@ -21,3 +21,41 @@ export function tryParseJson<T = unknown>(content: string): T | null {
 export function stringifyJson(value: unknown, space?: string | number): string | undefined {
 	return JSON.stringify(value, (_key, item) => (typeof item === "bigint" ? item.toString() : item), space);
 }
+
+/**
+ * Only plain objects carry unordered members, so only they may be reordered.
+ *
+ * Arrays, typed arrays, and other exotic objects encode position in their keys:
+ * sorting `Uint8Array` indices lexicographically would reorder the bytes.
+ */
+function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Serialize JSON so that values equal under JSON semantics produce equal text.
+ *
+ * JSON gives object member order no meaning, so a peer that reconstructs a
+ * semantically identical payload may emit its members in another order. Hashing
+ * raw `JSON.stringify` output turns that into a spurious digest mismatch. This
+ * sorts plain-object keys at every depth while preserving array order, scalar
+ * types, and the byte order of binary views, so only a genuine value change
+ * moves the digest.
+ *
+ * `toJSON` hooks still run first, bigints follow {@link stringifyJson}, and a
+ * top-level `undefined` canonicalizes to `null` to keep the result total for
+ * callers that feed it straight into a hash.
+ */
+export function canonicalJsonStringify(value: unknown): string {
+	return (
+		JSON.stringify(value, (_key, item) => {
+			if (typeof item === "bigint") return item.toString();
+			if (!isPlainJsonObject(item)) return item;
+			const canonical: Record<string, unknown> = {};
+			for (const key of Object.keys(item).sort()) canonical[key] = item[key];
+			return canonical;
+		}) ?? "null"
+	);
+}

--- a/packages/utils/test/json.test.ts
+++ b/packages/utils/test/json.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { canonicalJsonStringify } from "@oh-my-pi/pi-utils/json";
+
+describe("canonicalJsonStringify", () => {
+	it("orders object members at every depth", () => {
+		const payload = { b: 1, a: { d: [{ z: 1, y: 2 }], c: 3 } };
+		const reordered = { a: { c: 3, d: [{ y: 2, z: 1 }] }, b: 1 };
+
+		expect(canonicalJsonStringify(payload)).toBe(canonicalJsonStringify(reordered));
+		expect(canonicalJsonStringify(payload)).toBe('{"a":{"c":3,"d":[{"y":2,"z":1}]},"b":1}');
+	});
+
+	it("keeps array order, scalar types, and binary bytes meaningful", () => {
+		expect(canonicalJsonStringify([1, 2])).not.toBe(canonicalJsonStringify([2, 1]));
+		expect(canonicalJsonStringify({ a: 1 })).not.toBe(canonicalJsonStringify({ a: "1" }));
+		expect(canonicalJsonStringify({ a: null })).not.toBe(canonicalJsonStringify({}));
+		// Index keys encode position, so sorting them lexicographically would
+		// reorder the bytes: 10 must stay after 2, not before it.
+		expect(canonicalJsonStringify(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))).toBe(
+			JSON.stringify(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])),
+		);
+	});
+
+	it("keeps toJSON hooks, bigints, and a bare undefined serializable", () => {
+		expect(canonicalJsonStringify({ at: new Date(0) })).toBe('{"at":"1970-01-01T00:00:00.000Z"}');
+		expect(canonicalJsonStringify({ b: 9007199254740993n })).toBe('{"b":"9007199254740993"}');
+		expect(canonicalJsonStringify(undefined)).toBe("null");
+	});
+});


### PR DESCRIPTION
RPC runs lacked durable per-session custody across disconnects, terminal transitions, and process shutdown. Background commands could outlive an incomplete binding, while queued asynchronous outcomes were omitted from the final session result.

Add a durable session ledger for active RPC runs and seal terminal state only after rechecking session continuation. Cancel and reopen sealing when work resumes, reject background bash work without a durable binding, and include queued asynchronous and compaction outcomes in shutdown results.