### PR TITLE
fix(cli): restore piped custom session persistence

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed redirected stdin being ignored when Bun reports a pipe with an undefined `isTTY`, so JSON/print sessions now process piped prompts and persist them under `--session-dir` or `PI_CODING_AGENT_SESSION_DIR` as requested ([#7378](https://github.com/can1357/oh-my-pi/issues/7378)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Added

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -1,7 +1,7 @@
 /**
  * CLI argument parsing and help display
  */
-import { APP_NAME, CONFIG_DIR_NAME, logger } from "@oh-my-pi/pi-utils";
+import { $env, APP_NAME, CONFIG_DIR_NAME, logger } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import { CLI_THINKING_LEVELS, type ConfiguredThinkingLevel, parseCliThinkingLevel } from "../thinking";
 import { BUILTIN_TOOL_NAMES, HIDDEN_TOOL_NAMES, normalizeToolNames } from "../tools/builtin-names";
@@ -145,6 +145,7 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 		fileArgs: [],
 		unknownFlags: new Map(),
 		unrecognizedFlags: [],
+		sessionDir: $env.PI_CODING_AGENT_SESSION_DIR || undefined,
 	};
 
 	// `--` ends option parsing (POSIX end-of-options). Everything after it is

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -188,8 +188,9 @@ function applyAcpDefaultSettingOverrides(targetSettings: Settings = settings): v
 	applyDefaultSettingOverrides(HOST_DEFAULTED_SETTING_PATHS, targetSettings);
 }
 
-async function readPipedInput(): Promise<string | undefined> {
-	if (process.stdin.isTTY !== false) return undefined;
+/** Reads a non-TTY stdin stream as prompt text. */
+export async function readPipedInput(): Promise<string | undefined> {
+	if (process.stdin.isTTY === true) return undefined;
 	// stdin is a pipe: a producer that never writes nor closes would block
 	// startup forever with zero output. Say what we're blocked on after 1s.
 	const notice = setTimeout(() => {

--- a/packages/coding-agent/test/flag-tables.test.ts
+++ b/packages/coding-agent/test/flag-tables.test.ts
@@ -56,6 +56,23 @@ describe("OPTIONAL_VALUE_FLAGS table is honored by args.ts parseArgs", () => {
 	}
 });
 
+describe("--session-dir", () => {
+	it("uses PI_CODING_AGENT_SESSION_DIR unless the CLI flag overrides it", () => {
+		const previous = Bun.env.PI_CODING_AGENT_SESSION_DIR;
+		Bun.env.PI_CODING_AGENT_SESSION_DIR = "/env/sessions";
+		try {
+			expect(parseArgs([]).sessionDir).toBe("/env/sessions");
+			expect(parseArgs(["--session-dir", "/cli/sessions"]).sessionDir).toBe("/cli/sessions");
+		} finally {
+			if (previous === undefined) {
+				delete Bun.env.PI_CODING_AGENT_SESSION_DIR;
+			} else {
+				Bun.env.PI_CODING_AGENT_SESSION_DIR = previous;
+			}
+		}
+	});
+});
+
 describe("--tools legacy aliases", () => {
 	it("maps search and find to grep and glob", () => {
 		const result = parseArgs(["--tools", "search,find,grep"]);

--- a/packages/coding-agent/test/main-interactive-input.test.ts
+++ b/packages/coding-agent/test/main-interactive-input.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { applyResolvedSystemPromptInputs, submitInteractiveInput } from "@oh-my-pi/pi-coding-agent/main";
+import {
+	applyResolvedSystemPromptInputs,
+	readPipedInput,
+	submitInteractiveInput,
+} from "@oh-my-pi/pi-coding-agent/main";
 import type { SubmittedUserInput } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { CreateAgentSessionOptions } from "@oh-my-pi/pi-coding-agent/sdk";
 import { discoverTitleSystemPromptFile } from "@oh-my-pi/pi-coding-agent/system-prompt";
@@ -12,6 +16,7 @@ const cleanupDirs: string[] = [];
 
 afterEach(async () => {
 	await Promise.all(cleanupDirs.splice(0).map(dir => removeWithRetries(dir)));
+	vi.restoreAllMocks();
 });
 
 function createInput(overrides: Partial<SubmittedUserInput> = {}): SubmittedUserInput {
@@ -34,6 +39,21 @@ describe("discoverTitleSystemPromptFile", () => {
 		await fs.writeFile(promptPath, "custom title prompt");
 
 		expect(discoverTitleSystemPromptFile(projectDir)).toBe(promptPath);
+	});
+});
+
+describe("readPipedInput", () => {
+	it("reads redirected stdin when Bun reports isTTY as undefined", async () => {
+		const originalIsTTY = process.stdin.isTTY;
+		const readText = vi.spyOn(Bun.stdin, "text").mockResolvedValue("piped prompt\n");
+		Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+
+		try {
+			expect(await readPipedInput()).toBe("piped prompt\n");
+			expect(readText).toHaveBeenCalledTimes(1);
+		} finally {
+			Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, configurable: true });
+		}
 	});
 });
 


### PR DESCRIPTION
## Repro
Pipe a prompt into JSON mode with an explicit session directory: `D=$(mktemp -d); printf 'Reply with exactly: ok\n' | omp --mode json --no-extensions --session-dir="$D"; find "$D" -type f`. Before the fix, OMP exited 0 after emitting only the startup `session` event and `find` returned no files.

## Cause
`readPipedInput` in `packages/coding-agent/src/main.ts` accepted redirected stdin only when `process.stdin.isTTY` was exactly `false`; Bun reports `undefined` for this pipe, so startup discarded the prompt and never appended anything to the custom `SessionManager`. Separately, `parseArgs` never seeded `sessionDir` from `PI_CODING_AGENT_SESSION_DIR`.

## Fix
- Treat every stdin stream not explicitly marked as a TTY as redirected prompt input.
- Seed parsed session storage from `PI_CODING_AGENT_SESSION_DIR`, preserving explicit `--session-dir` precedence.
- Cover Bun's undefined pipe state and environment/CLI precedence; document the fix under `[Unreleased]`.

## Verification
`bun test test/main-interactive-input.test.ts test/flag-tables.test.ts` passes 55 tests. `bun check` passes. Manual JSON-mode smoke runs with both `--session-dir` and `PI_CODING_AGENT_SESSION_DIR` returned `ok` and created the expected `.jsonl` file in each requested directory.

Fixes #7378