### PR TITLE
test(browser): stop gating chromium tests on a top-level-await export

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Chromium-backed tests failing during suite registration when the shared availability probe was still initializing ([#7384](https://github.com/can1357/oh-my-pi/pull/7384) by [@paralin](https://github.com/paralin)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Added

--- a/packages/coding-agent/test/tools/browser-attach.test.ts
+++ b/packages/coding-agent/test/tools/browser-attach.test.ts
@@ -11,7 +11,9 @@ import {
 } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
 import { acquireTab, releaseTab } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 import type { Browser, Page, Target } from "puppeteer-core";
-import { CHROMIUM_AVAILABLE } from "./chromium-probe";
+import { chromiumAvailable } from "./chromium-probe";
+
+const CHROMIUM_AVAILABLE = await chromiumAvailable();
 
 interface FakePageOptions {
 	url: string;

--- a/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
@@ -3,7 +3,9 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { BrowserTool } from "@oh-my-pi/pi-coding-agent/tools/browser";
 import { getTabsMapForTest } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
-import { CHROMIUM_AVAILABLE } from "./chromium-probe";
+import { chromiumAvailable } from "./chromium-probe";
+
+const CHROMIUM_AVAILABLE = await chromiumAvailable();
 
 function makeSession(): ToolSession {
 	return {

--- a/packages/coding-agent/test/tools/chromium-probe.ts
+++ b/packages/coding-agent/test/tools/chromium-probe.ts
@@ -17,5 +17,23 @@ async function chromiumCanLaunch(): Promise<boolean> {
 	}
 }
 
-/** Gate for tests that launch a real Chromium: `describe.skipIf(!CHROMIUM_AVAILABLE)`. */
-export const CHROMIUM_AVAILABLE = await chromiumCanLaunch();
+let probe: Promise<boolean> | undefined;
+
+/**
+ * Gate for tests that launch a real Chromium:
+ *
+ *     const CHROMIUM_AVAILABLE = await chromiumAvailable();
+ *     describe.skipIf(!CHROMIUM_AVAILABLE)(…);
+ *
+ * The result is a promise rather than an awaited `export const`. A module whose
+ * exports are initialized by top-level await hands the test runner a binding
+ * that is still in its temporal dead zone when a second test file in the same
+ * process imports it, and that file dies during registration with "Cannot
+ * access 'CHROMIUM_AVAILABLE' before initialization". Awaiting in the importer
+ * makes the wait part of that file's own evaluation, which the runner does
+ * sequence. The probe runs once per process.
+ */
+export function chromiumAvailable(): Promise<boolean> {
+	probe ??= chromiumCanLaunch();
+	return probe;
+}


### PR DESCRIPTION
The "Test coding-agent native/unit (TS)" job is red on every open pull request, including #7382, with `ReferenceError: Cannot access 'CHROMIUM_AVAILABLE' before initialization` from test/tools/browser-attach.test.ts and test/tools/browser-tab-evaluate.test.ts.

chromium-probe.ts initializes its only export with top-level await. When a test file importing it happens to be the first file the runner loads, the await settles before that file evaluates and the binding reads fine. When any other test file was loaded into the process first, the importing file's body runs while the binding is still in its temporal dead zone, and registration throws at the skipIf call. That is why the job fails but nobody sees it locally: `bun test test/tools/browser-attach.test.ts` passes, and `bun test --parallel=1 test/tools/ast-edit.test.ts test/tools/browser-attach.test.ts` fails. CI batches ten files per invocation, so the browser files are never first.

This exports the memoized probe as a function and has each test file await it during its own evaluation, which the runner does sequence. The probe still runs once per process and resolves the executable exactly as before.

I reproduced it on a clean checkout of main at 06343fef4 before changing anything: the ten-file batch from the CI log reports "1 error" with that ReferenceError, and the single-file run passes. After the change both failing CI batches pass locally, 130 pass / 0 fail and 133 pass / 0 fail. The gate itself still resolves true on this machine, so the Chromium-launching tests are running rather than silently skipping.