### PR TITLE
fix(coding-agent): keep focused status bar caps bright

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed focused-agent status bar dimming darkening Powerline end caps.
 
 ## [17.2.4] - 2026-08-01
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1785,7 +1785,9 @@ export class StatusLineComponent implements Component {
 						: separatorDef.endCaps.left
 					: "";
 			const capPrefix = separatorDef.endCaps?.useBgAsFg ? bgAnsi.replace("\x1b[48;", "\x1b[38;") : bgAnsi + sepAnsi;
-			const capText = cap ? `${capPrefix}${cap}\x1b[0m` : "";
+			const capText = cap
+				? `${capPrefix}${this.#focusedAgentId ? "\x1b[22m" : ""}${cap}${this.#focusedAgentId ? "\x1b[2m" : ""}\x1b[0m`
+				: "";
 
 			let content = bgAnsi + fgAnsi;
 			content += ` ${parts.join(` ${sepAnsi}${sep}${fgAnsi} `)} `;

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -162,6 +162,28 @@ describe("status line session accent", () => {
 	});
 });
 
+describe("status line focused-agent dimming", () => {
+	it("keeps powerline end caps at full intensity while text stays dimmed", () => {
+		const component = new StatusLineComponent(createStatusLineSession("Focused session"));
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["pi"],
+			rightSegments: ["session_name"],
+			separator: "powerline-thin",
+			sessionAccent: false,
+		});
+		component.setSession(createStatusLineSession("Focused session"), "agent-1");
+
+		const border = component.getTopBorder(80).content;
+
+		expect(border).toStartWith("\x1b[2m");
+		expect(border).toContain(`\x1b[22m${theme.sep.powerlineLeft}\x1b[2m`);
+		expect(border).toContain(`\x1b[22m${theme.sep.powerlineRight}\x1b[2m`);
+		expect(border).toContain("\x1b[0m\x1b[2m");
+		expect(border).toEndWith("\x1b[22m");
+	});
+});
+
 describe("path segment truncation at varying maxLength", () => {
 	let tmpDir: string;
 


### PR DESCRIPTION
## Summary

When the status bar is proxied to a focused subagent, the whole bar is rendered with ANSI faint. Powerline end caps use the status background as their foreground, so they were fainted too and appeared in a different color/intensity from the bar background.

This change temporarily disables faint only around the two Powerline end-cap glyphs, then restores it for the rest of the status bar. It also adds a regression test and changelog entry.

## Verification

- `bun test packages/coding-agent/test/status-line-overflow.test.ts`
- `bun test packages/coding-agent/test/status-line-*.test.ts`
- `bun run check:types` from `packages/coding-agent`
- `bunx biome check packages/coding-agent/src/modes/components/status-line/component.ts packages/coding-agent/test/status-line-overflow.test.ts`