### PR TITLE
fix(tui): keep working title across non-terminal agent_end

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the terminal-tab title dropping to idle (`>`) while an unsuppressed async job was still running — a `/vibe` worker turn or a bash `async` job that re-wakes the director after it settles. `EventController.#handleAgentEnd` now skips the idle/loader teardown on a non-terminal `agent_end` (`isTerminal: false`) and only tears down at the true terminal settle ([#7386](https://github.com/can1357/oh-my-pi/issues/7386)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1454,6 +1454,15 @@ export class EventController {
 		}
 	}
 	async #handleAgentEnd(event: Extract<AgentSessionEvent, { type: "agent_end" }>): Promise<void> {
+		// A non-terminal settle (`isTerminal: false`) is a scheduling pause, not the
+		// end of the run: an unsuppressed async job (a `/vibe` worker turn, a bash
+		// `async` job, etc.) will re-wake the loop when its result is delivered.
+		// `AgentSession` tags this on the deferred event (see `#hasPendingAsyncWake`
+		// in agent-session.ts); flipping the title to `idle` and tearing down the
+		// loader here would make the tab read idle while work is still running. The
+		// later terminal `agent_end` performs the normal teardown. Mirrors the same
+		// guard already used by `#appendFinalResponse` and `sendErrorNotification`.
+		if (event.isTerminal === false) return;
 		// A superseded agent_end: the agent is already streaming a fresh turn, so
 		// this event belongs to a turn that has already been replaced. The session
 		// dispatches to listeners fire-and-forget across an async extension-emit hop

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1454,15 +1454,6 @@ export class EventController {
 		}
 	}
 	async #handleAgentEnd(event: Extract<AgentSessionEvent, { type: "agent_end" }>): Promise<void> {
-		// A non-terminal settle (`isTerminal: false`) is a scheduling pause, not the
-		// end of the run: an unsuppressed async job (a `/vibe` worker turn, a bash
-		// `async` job, etc.) will re-wake the loop when its result is delivered.
-		// `AgentSession` tags this on the deferred event (see `#hasPendingAsyncWake`
-		// in agent-session.ts); flipping the title to `idle` and tearing down the
-		// loader here would make the tab read idle while work is still running. The
-		// later terminal `agent_end` performs the normal teardown. Mirrors the same
-		// guard already used by `#appendFinalResponse` and `sendErrorNotification`.
-		if (event.isTerminal === false) return;
 		// A superseded agent_end: the agent is already streaming a fresh turn, so
 		// this event belongs to a turn that has already been replaced. The session
 		// dispatches to listeners fire-and-forget across an async extension-emit hop
@@ -1473,6 +1464,20 @@ export class EventController {
 		// the loader and finalizes it at its own agent_end (isStreaming === false by
 		// then). Mirrors the collab guest's !isStreaming loader reconciler.
 		if (this.ctx.session.isStreaming) return;
+		// A non-terminal settle (`isTerminal: false`) is a scheduling pause, not the
+		// end of the run: an unsuppressed async job (a `/vibe` worker turn, a bash
+		// `async` job, etc.) will re-wake the loop when its result is delivered.
+		// `AgentSession` tags this on the deferred event (see `#hasPendingAsyncWake`
+		// in agent-session.ts). Skip the idle title/loader teardown so the tab keeps
+		// reading "working"; the later terminal `agent_end` performs it. Still flush
+		// a deferred model switch — the plan-mode reconciler queues it to apply once
+		// the current stream ends, and `#finishAgentEnd` is otherwise its only flush
+		// site, so the automatic continuation would otherwise run on the old
+		// model/thinking level until the terminal settle.
+		if (event.isTerminal === false) {
+			await this.ctx.flushPendingModelSwitch();
+			return;
+		}
 		setTerminalTitleState("idle");
 
 		await this.#finishAgentEnd(event);

--- a/packages/coding-agent/test/modes/controllers/event-controller-abort-guard.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-abort-guard.test.ts
@@ -406,10 +406,11 @@ describe("EventController — error toast gated while auto-retry is pending", ()
 });
 
 describe("EventController — terminal title across a non-terminal agent_end", () => {
-	it("keeps the working title and skips loader teardown during a pending async-wake pause (isTerminal:false)", async () => {
+	it("keeps the working title and skips loader teardown but still flushes a deferred model switch during a pending async-wake pause (isTerminal:false)", async () => {
 		const stateSpy = vi.spyOn(titleGenerator, "setTerminalTitleState").mockImplementation(() => {});
 		const ctx = makeTurnEndContext();
 		const markActivityEnd = vi.spyOn(ctx.statusLine, "markActivityEnd");
+		const flushPendingModelSwitch = vi.spyOn(ctx, "flushPendingModelSwitch");
 		const controller = new EventController(ctx);
 		await controller.handleEvent({
 			...makeAgentEndEvent([makeAssistantMessage("stop")]),
@@ -418,6 +419,8 @@ describe("EventController — terminal title across a non-terminal agent_end", (
 		// The async job still runs: never drop to `idle`, never run #finishAgentEnd teardown.
 		expect(stateSpy).not.toHaveBeenCalledWith("idle");
 		expect(markActivityEnd).not.toHaveBeenCalled();
+		// The automatic continuation must still pick up a queued plan-mode model switch.
+		expect(flushPendingModelSwitch).toHaveBeenCalledTimes(1);
 	});
 
 	it("transitions to idle and tears down on the terminal agent_end", async () => {

--- a/packages/coding-agent/test/modes/controllers/event-controller-abort-guard.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-abort-guard.test.ts
@@ -23,6 +23,7 @@ import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/eve
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import * as titleGenerator from "@oh-my-pi/pi-coding-agent/utils/title-generator";
 import { TERMINAL } from "@oh-my-pi/pi-tui";
 
 const originalWarpProtocolVersion = process.env.WARP_CLI_AGENT_PROTOCOL_VERSION;
@@ -401,5 +402,31 @@ describe("EventController — error toast gated while auto-retry is pending", ()
 		await controller.handleEvent(makeAgentEndEvent([makeAssistantMessage("error")]));
 		expect(spy).toHaveBeenCalledTimes(1);
 		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ body: "Stopped with error", type: "error" }));
+	});
+});
+
+describe("EventController — terminal title across a non-terminal agent_end", () => {
+	it("keeps the working title and skips loader teardown during a pending async-wake pause (isTerminal:false)", async () => {
+		const stateSpy = vi.spyOn(titleGenerator, "setTerminalTitleState").mockImplementation(() => {});
+		const ctx = makeTurnEndContext();
+		const markActivityEnd = vi.spyOn(ctx.statusLine, "markActivityEnd");
+		const controller = new EventController(ctx);
+		await controller.handleEvent({
+			...makeAgentEndEvent([makeAssistantMessage("stop")]),
+			isTerminal: false,
+		} as Extract<AgentSessionEvent, { type: "agent_end" }> & { isTerminal: false });
+		// The async job still runs: never drop to `idle`, never run #finishAgentEnd teardown.
+		expect(stateSpy).not.toHaveBeenCalledWith("idle");
+		expect(markActivityEnd).not.toHaveBeenCalled();
+	});
+
+	it("transitions to idle and tears down on the terminal agent_end", async () => {
+		const stateSpy = vi.spyOn(titleGenerator, "setTerminalTitleState").mockImplementation(() => {});
+		const ctx = makeTurnEndContext();
+		const markActivityEnd = vi.spyOn(ctx.statusLine, "markActivityEnd");
+		const controller = new EventController(ctx);
+		await controller.handleEvent(makeAgentEndEvent([makeAssistantMessage("stop")]));
+		expect(stateSpy).toHaveBeenCalledWith("idle");
+		expect(markActivityEnd).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Repro
With `tui.titleState` enabled, run an unsuppressed async job that outlives the director turn — a `/vibe` worker whose turn takes ~30s, or `sleep 30` through the Bash tool with `async: true` — then let the director return without waiting. While the job stays `running` the tab title shows the idle separator `π > <session>` instead of the animated `π <spinner> <session>`. Reproduced in-process by dispatching an `agent_end` with `isTerminal: false` (the shape `AgentSession` emits when `#hasPendingAsyncWake()` is true) through `EventController.handleEvent`: `bun test test/modes/controllers/event-controller-abort-guard.test.ts -t "terminal title across a non-terminal agent_end"` failed with `setTerminalTitleState` called with `"idle"` during the pause.

## Cause
`EventController.#handleAgentEnd` (`packages/coding-agent/src/modes/controllers/event-controller.ts`) guarded only on `session.isStreaming`. At an async-wake scheduling pause `session.isStreaming` is already `false` (the loop is idle, waiting for the job to deliver), so the method fell through to the unconditional `setTerminalTitleState("idle")` and `#finishAgentEnd` loader teardown. `AgentSession` tags that settle `isTerminal: false` (`emitAgentEndNotification({ willContinue: true })` from the `#hasPendingAsyncWake()` branch in `agent-session.ts`), and every other `agent_end` consumer already honors it — `#appendFinalResponse`, `sendErrorNotification`, `rpc-frame`, `warp-events` — but this path was the outlier.

## Fix
- `EventController.#handleAgentEnd`: early-return when `event.isTerminal === false`, before the idle title transition and loader teardown, so the working title/loader survive the scheduling pause; the later terminal `agent_end` performs the normal teardown.
- Added two regression tests in `event-controller-abort-guard.test.ts` driving the real `handleEvent` → `#handleAgentEnd` path: a non-terminal `agent_end` must not set `"idle"` or run `#finishAgentEnd` teardown, and a terminal `agent_end` still does both.

## Verification
`bun test test/modes/controllers/event-controller-abort-guard.test.ts` → 23 pass, 0 fail (the two new tests fail without the fix). `bun test test/terminal-title-state.test.ts test/title-generator.test.ts` → 42 pass, 0 fail (no title-generator regression).

Fixes #7386