### PR TITLE
feat(coding-agent): Tab-accept suggestion API + Windows glob path fix

### DIFF
--- a/packages/coding-agent/scripts/legacy-pi-virtual-module.ts
+++ b/packages/coding-agent/scripts/legacy-pi-virtual-module.ts
@@ -151,7 +151,10 @@ export async function collectBundledPiEntries(): Promise<BundledPiEntry[]> {
 				const glob = new Bun.Glob(`**/*${pattern.sourceSuffix}`);
 				const matches: string[] = [];
 				for await (const match of glob.scan({ cwd: sourceDir, onlyFiles: true })) {
-					matches.push(match);
+					// Bun.Glob.scan() on Windows yields backslash-separated paths; every
+					// downstream consumer here (segment splitting, binding-name generation)
+					// assumes POSIX separators, same as the exports-pattern `*` semantics.
+					matches.push(match.replaceAll("\\", "/"));
 				}
 				matches.sort();
 				for (const match of matches) {

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -319,6 +319,7 @@ const noOpUIContext: ExtensionUIContext = {
 	setEditorText: () => {},
 	pasteToEditor: () => {},
 	getEditorText: () => "",
+	setSuggestion: () => {},
 	editor: async () => undefined,
 	addAutocompleteProvider: () => {},
 	setEditorComponent: () => {},

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -296,6 +296,16 @@ export interface ExtensionUIContext {
 	/** Get the current text from the core input editor. */
 	getEditorText(): string;
 
+	/**
+	 * Register text that Tab will insert when pressed on a genuinely empty
+	 * editor (the same condition under which Tab's file/slash completion
+	 * already has nothing to offer). Unlike `setEditorText`, this never
+	 * touches the buffer directly — nothing to delete if the reader just
+	 * starts typing their own message instead. Cleared automatically after
+	 * one use, or by any other keystroke; pass `undefined` to clear early.
+	 */
+	setSuggestion(text: string | undefined): void;
+
 	/** Show a multi-line editor for text editing. */
 	editor(
 		title: string,

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -216,6 +216,10 @@ export type ExtensionWidgetContent = string[] | ExtensionUiComponentFactory | un
 /** Wrap the current autocomplete provider with additional behavior (pi-compatible). */
 export type AutocompleteProviderFactory = (current: AutocompleteProvider) => AutocompleteProvider;
 
+/** Why a Tab suggestion registered via {@link ExtensionUIContext.setSuggestion} stopped
+ *  being pending. */
+export type SuggestionOutcome = "accepted" | "dismissed";
+
 /**
  * UI context for extensions to request interactive UI.
  * Each mode (interactive, RPC, print) provides its own implementation.
@@ -303,8 +307,13 @@ export interface ExtensionUIContext {
 	 * touches the buffer directly — nothing to delete if the reader just
 	 * starts typing their own message instead. Cleared automatically after
 	 * one use, or by any other keystroke; pass `undefined` to clear early.
+	 *
+	 * `onOutcome`, if given, fires exactly once for a non-`undefined` `text`:
+	 * `"accepted"` when Tab inserts it, `"dismissed"` for any other keystroke,
+	 * an early `undefined` clear, or a later `setSuggestion` call that
+	 * replaces it unresolved.
 	 */
-	setSuggestion(text: string | undefined): void;
+	setSuggestion(text: string | undefined, onOutcome?: (outcome: SuggestionOutcome) => void): void;
 
 	/** Show a multi-line editor for text editing. */
 	editor(

--- a/packages/coding-agent/src/extensibility/hooks/types.ts
+++ b/packages/coding-agent/src/extensibility/hooks/types.ts
@@ -140,6 +140,16 @@ export interface HookUIContext {
 	getEditorText(): string;
 
 	/**
+	 * Register text that Tab will insert when pressed on a genuinely empty
+	 * editor (the same condition under which Tab's file/slash completion
+	 * already has nothing to offer). Unlike `setEditorText`, this never
+	 * touches the buffer directly — nothing to delete if the reader just
+	 * starts typing their own message instead. Cleared automatically after
+	 * one use, or by any other keystroke; pass `undefined` to clear early.
+	 */
+	setSuggestion(text: string | undefined): void;
+
+	/**
 	 * Show a multi-line editor for text editing.
 	 * Supports Ctrl+G to open external editor ($VISUAL or $EDITOR).
 	 * @param title - Title describing what is being edited

--- a/packages/coding-agent/src/extensibility/hooks/types.ts
+++ b/packages/coding-agent/src/extensibility/hooks/types.ts
@@ -48,6 +48,10 @@ import type * as TypeBox from "../typebox";
 // Re-export for backward compatibility
 export type { ExecOptions, ExecResult } from "../../exec/exec";
 
+/** Why a Tab suggestion registered via {@link HookUIContext.setSuggestion} stopped
+ *  being pending. */
+export type SuggestionOutcome = "accepted" | "dismissed";
+
 /**
  * UI context for hooks to request interactive UI from the harness.
  * Each mode (interactive, RPC, print) provides its own implementation.
@@ -146,8 +150,13 @@ export interface HookUIContext {
 	 * touches the buffer directly — nothing to delete if the reader just
 	 * starts typing their own message instead. Cleared automatically after
 	 * one use, or by any other keystroke; pass `undefined` to clear early.
+	 *
+	 * `onOutcome`, if given, fires exactly once for a non-`undefined` `text`:
+	 * `"accepted"` when Tab inserts it, `"dismissed"` for any other keystroke,
+	 * an early `undefined` clear, or a later `setSuggestion` call that
+	 * replaces it unresolved.
 	 */
-	setSuggestion(text: string | undefined): void;
+	setSuggestion(text: string | undefined, onOutcome?: (outcome: SuggestionOutcome) => void): void;
 
 	/**
 	 * Show a multi-line editor for text editing.

--- a/packages/coding-agent/src/extensibility/utils.ts
+++ b/packages/coding-agent/src/extensibility/utils.ts
@@ -36,6 +36,7 @@ export function createNoOpUIContext(): HookUIContext {
 		custom: async () => undefined as never,
 		setEditorText: () => {},
 		getEditorText: () => "",
+		setSuggestion: () => {},
 		editor: async () => undefined,
 		get theme() {
 			return theme;

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -443,6 +443,7 @@ export function createAcpExtensionUiContext(
 		pasteToEditor: () => {},
 		setEditorText: () => {},
 		getEditorText: () => "",
+		setSuggestion: () => {},
 		editor: async (title, prefill, dialogOptions) => {
 			if (!supportsForm) return undefined;
 			const value = await elicitFromAcpClient(

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -11,8 +11,10 @@ import {
 	TUI,
 } from "@oh-my-pi/pi-tui";
 import { BracketedPasteHandler } from "@oh-my-pi/pi-tui/bracketed-paste";
+import { logger } from "@oh-my-pi/pi-utils";
 import type { AppKeybinding } from "../../config/keybindings";
 import { isSettingsInitialized, settings } from "../../config/settings";
+import type { SuggestionOutcome } from "../../extensibility/extensions/types";
 import { imageReferenceHyperlink, PLACEHOLDER_REGEX, renderPlaceholders } from "../image-references";
 import { hasMagicKeyword, highlightMagicKeywords } from "../magic-keywords";
 import { isQueuedMessageList, parseQueueShorthand, QUEUE_LIST_MARKER_RE } from "../queue-input";
@@ -392,6 +394,9 @@ export class CustomEditor extends Editor {
 	/** Text a hook registered via `setSuggestion` for Tab to insert on an empty
 	 *  editor. See the Tab-accept branch in {@link handleInput}. */
 	#tabSuggestion: string | undefined;
+	/** Callback to notify with the outcome ("accepted"/"dismissed") of the
+	 *  pending {@link #tabSuggestion}, set alongside it. */
+	#tabSuggestionOnOutcome: ((outcome: SuggestionOutcome) => void) | undefined;
 
 	/**
 	 * The host {@link TUI}, captured when a plugin constructs this editor through
@@ -432,9 +437,26 @@ export class CustomEditor extends Editor {
 	}
 
 	/** Register (or clear, with `undefined`) the text Tab will insert on an
-	 *  empty editor. See the Tab-accept branch in {@link handleInput}. */
-	setTabSuggestion(text: string | undefined): void {
+	 *  empty editor. See the Tab-accept branch in {@link handleInput}. `onOutcome`
+	 *  fires exactly once, resolving whatever suggestion is currently pending
+	 *  (superseding a prior unresolved one as "dismissed" first). */
+	setTabSuggestion(text: string | undefined, onOutcome?: (outcome: SuggestionOutcome) => void): void {
+		this.#resolveTabSuggestion("dismissed");
 		this.#tabSuggestion = text;
+		this.#tabSuggestionOnOutcome = text !== undefined ? onOutcome : undefined;
+	}
+
+	/** Resolve the pending Tab suggestion (if any) with `outcome`: clears the
+	 *  pending state, records telemetry, and notifies the registering hook's
+	 *  `onOutcome`. No-op when nothing is pending. */
+	#resolveTabSuggestion(outcome: SuggestionOutcome): void {
+		if (this.#tabSuggestion === undefined) return;
+		const length = this.#tabSuggestion.length;
+		const onOutcome = this.#tabSuggestionOnOutcome;
+		this.#tabSuggestion = undefined;
+		this.#tabSuggestionOnOutcome = undefined;
+		logger.debug("tab-suggestion: resolved", { outcome, length });
+		onOutcome?.(outcome);
 	}
 
 	/** Replace the composer draft with a restored historical prompt: sets the text and
@@ -862,11 +884,11 @@ export class CustomEditor extends Editor {
 		if (this.#tabSuggestion !== undefined) {
 			if (canonical === "tab" && !this.isShowingAutocomplete() && this.getText().trim() === "") {
 				const suggestion = this.#tabSuggestion;
-				this.#tabSuggestion = undefined;
+				this.#resolveTabSuggestion("accepted");
 				this.setText(suggestion);
 				return;
 			}
-			this.#tabSuggestion = undefined;
+			this.#resolveTabSuggestion("dismissed");
 		}
 
 		// Space-hold push-to-talk: a sustained space bar starts/stops STT instead of typing spaces.

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -389,6 +389,10 @@ export class CustomEditor extends Editor {
 	 *  `undefined` entries are images without a backing reference yet. */
 	pendingImageLinks: (string | undefined)[] = [];
 
+	/** Text a hook registered via `setSuggestion` for Tab to insert on an empty
+	 *  editor. See the Tab-accept branch in {@link handleInput}. */
+	#tabSuggestion: string | undefined;
+
 	/**
 	 * The host {@link TUI}, captured when a plugin constructs this editor through
 	 * the upstream-pi `(tui, theme, keybindings)` convention. Undefined for omp's
@@ -425,6 +429,12 @@ export class CustomEditor extends Editor {
 		this.imageLinks = undefined;
 		this.pendingImages = [];
 		this.pendingImageLinks = [];
+	}
+
+	/** Register (or clear, with `undefined`) the text Tab will insert on an
+	 *  empty editor. See the Tab-accept branch in {@link handleInput}. */
+	setTabSuggestion(text: string | undefined): void {
+		this.#tabSuggestion = text;
 	}
 
 	/** Replace the composer draft with a restored historical prompt: sets the text and
@@ -839,6 +849,24 @@ export class CustomEditor extends Editor {
 		if (canonical === "left" && this.onLeftAtStart && this.getText().trim() === "") {
 			this.onLeftAtStart();
 			return;
+		}
+
+		// Tab-accept: a hook registered a suggestion (via `ctx.ui.setSuggestion`)
+		// that lives only in the status line, never the buffer — `setEditorText`
+		// writes real, literal text with no way to grey it out or dismiss on the
+		// next keystroke, so this is the alternative accept gesture. Only claims
+		// Tab when the editor is genuinely empty: the same condition under which
+		// Tab's file/slash completion already has nothing to offer, so this never
+		// shadows real completion. Any other keystroke invalidates a stale
+		// suggestion rather than letting it resurface later.
+		if (this.#tabSuggestion !== undefined) {
+			if (canonical === "tab" && !this.isShowingAutocomplete() && this.getText().trim() === "") {
+				const suggestion = this.#tabSuggestion;
+				this.#tabSuggestion = undefined;
+				this.setText(suggestion);
+				return;
+			}
+			this.#tabSuggestion = undefined;
 		}
 
 		// Space-hold push-to-talk: a sustained space bar starts/stops STT instead of typing spaces.

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -105,7 +105,7 @@ export class ExtensionUiController {
 				this.ctx.ui.requestRender();
 			},
 			getEditorText: () => this.ctx.editor.getText(),
-			setSuggestion: text => this.ctx.editor.setTabSuggestion(text),
+			setSuggestion: (text, onOutcome) => this.ctx.editor.setTabSuggestion(text, onOutcome),
 			editor: (title, prefill, dialogOptions, editorOptions) =>
 				this.showCollabAwareEditor(title, prefill, dialogOptions, editorOptions),
 			addAutocompleteProvider: factory => this.ctx.addAutocompleteProvider(factory),

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -105,6 +105,7 @@ export class ExtensionUiController {
 				this.ctx.ui.requestRender();
 			},
 			getEditorText: () => this.ctx.editor.getText(),
+			setSuggestion: text => this.ctx.editor.setTabSuggestion(text),
 			editor: (title, prefill, dialogOptions, editorOptions) =>
 				this.showCollabAwareEditor(title, prefill, dialogOptions, editorOptions),
 			addAutocompleteProvider: factory => this.ctx.addAutocompleteProvider(factory),

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -881,6 +881,10 @@ export async function runRpcMode(
 			return "";
 		}
 
+		setSuggestion(): void {
+			// No local editor/Tab-accept concept in RPC mode.
+		}
+
 		async editor(
 			title: string,
 			prefill?: string,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -360,6 +360,7 @@ const noOpUIContext: ExtensionUIContext = {
 	setEditorText: () => {},
 	pasteToEditor: () => {},
 	getEditorText: () => "",
+	setSuggestion: () => {},
 	editor: async () => undefined,
 	addAutocompleteProvider: () => {},
 	get theme() {

--- a/packages/coding-agent/test/compaction-hooks.test.ts
+++ b/packages/coding-agent/test/compaction-hooks.test.ts
@@ -121,6 +121,7 @@ describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))("Compaction hooks", () => {
 				custom: async () => undefined as never,
 				setEditorText: () => {},
 				getEditorText: () => "",
+				setSuggestion: () => {},
 				editor: async () => undefined,
 				get theme() {
 					return theme;

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -62,6 +62,41 @@ describe("CustomEditor keybindings", () => {
 		expect(onDisplayReset).toHaveBeenCalledTimes(1);
 		expect(onLiveToggle).toHaveBeenCalledTimes(1);
 	});
+
+	it("accepts a Tab suggestion on an empty editor and consumes it once", () => {
+		const editor = new CustomEditor(getEditorTheme());
+
+		editor.setTabSuggestion("git status");
+		editor.handleInput("\t");
+
+		expect(editor.getText()).toBe("git status");
+
+		// Second Tab is plain input now that the suggestion was consumed.
+		editor.setText("");
+		editor.handleInput("\t");
+		expect(editor.getText()).toBe("");
+	});
+
+	it("drops a Tab suggestion on any other keystroke instead of letting it resurface", () => {
+		const editor = new CustomEditor(getEditorTheme());
+
+		editor.setTabSuggestion("git status");
+		editor.handleInput("x");
+		editor.setText("");
+		editor.handleInput("\t");
+
+		expect(editor.getText()).toBe("");
+	});
+
+	it("never claims Tab for a suggestion once the editor has text", () => {
+		const editor = new CustomEditor(getEditorTheme());
+
+		editor.setText("already typing");
+		editor.setTabSuggestion("git status");
+		editor.handleInput("\t");
+
+		expect(editor.getText()).not.toBe("git status");
+	});
 });
 
 describe("shipped dequeue defaults", () => {

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -97,6 +97,66 @@ describe("CustomEditor keybindings", () => {
 
 		expect(editor.getText()).not.toBe("git status");
 	});
+
+	it('notifies onOutcome with "accepted" exactly once when Tab consumes the suggestion', () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onOutcome = vi.fn();
+
+		editor.setTabSuggestion("git status", onOutcome);
+		editor.handleInput("\t");
+
+		expect(onOutcome).toHaveBeenCalledTimes(1);
+		expect(onOutcome).toHaveBeenCalledWith("accepted");
+	});
+
+	it('notifies onOutcome with "dismissed" when another keystroke drops the suggestion', () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onOutcome = vi.fn();
+
+		editor.setTabSuggestion("git status", onOutcome);
+		editor.handleInput("x");
+
+		expect(onOutcome).toHaveBeenCalledTimes(1);
+		expect(onOutcome).toHaveBeenCalledWith("dismissed");
+	});
+
+	it('notifies onOutcome with "dismissed" when a new suggestion supersedes an unresolved one', () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const first = vi.fn();
+		const second = vi.fn();
+
+		editor.setTabSuggestion("git status", first);
+		editor.setTabSuggestion("git log", second);
+
+		expect(first).toHaveBeenCalledTimes(1);
+		expect(first).toHaveBeenCalledWith("dismissed");
+		expect(second).not.toHaveBeenCalled();
+
+		editor.handleInput("\t");
+		expect(editor.getText()).toBe("git log");
+		expect(second).toHaveBeenCalledWith("accepted");
+	});
+
+	it('notifies onOutcome with "dismissed" when the caller clears the suggestion early', () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onOutcome = vi.fn();
+
+		editor.setTabSuggestion("git status", onOutcome);
+		editor.setTabSuggestion(undefined);
+
+		expect(onOutcome).toHaveBeenCalledTimes(1);
+		expect(onOutcome).toHaveBeenCalledWith("dismissed");
+	});
+
+	it("never fires onOutcome when nothing was pending", () => {
+		const editor = new CustomEditor(getEditorTheme());
+		const onOutcome = vi.fn();
+
+		editor.setTabSuggestion(undefined, onOutcome);
+		editor.handleInput("x");
+
+		expect(onOutcome).not.toHaveBeenCalled();
+	});
 });
 
 describe("shipped dequeue defaults", () => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1712,6 +1712,7 @@ describe("ExtensionRunner", () => {
 					pasteToEditor: () => {},
 					setEditorText: () => {},
 					getEditorText: () => "",
+					setSuggestion: () => {},
 					editor: async () => undefined,
 					addAutocompleteProvider: () => {},
 					setEditorComponent: () => {},


### PR DESCRIPTION
## What

- Adds `ExtensionUIContext.setSuggestion` / `HookUIContext.setSuggestion`: hooks can register text that Tab inserts on a genuinely empty editor. Unlike `setEditorText`, it never touches the buffer directly, so there's nothing to delete if the user just starts typing. Cleared after one use or by any other keystroke.
- Wires the accept gesture into `CustomEditor.handleInput`: only claims Tab when the editor is empty and autocomplete isn't showing, so it never shadows file/slash completion.
- Adds noop `setSuggestion` implementations across ACP, RPC, and session UI contexts (and the extension runner/test noop contexts) to keep every `ExtensionUIContext`/`HookUIContext` implementer exhaustive.
- Fixes a Windows-only bug in the legacy-pi virtual module builder: `Bun.Glob.scan()` yields backslash-separated paths on Windows, but downstream segment splitting and binding-name generation assume POSIX separators. Now normalized with `replaceAll("\\", "/")`.

## Why

Gives extensions/hooks a lightweight, non-destructive way to surface a Tab-completable suggestion (e.g. a suggested next command) without risking stale literal text left in the composer. The glob fix was found while working in this area on Windows — the legacy-pi module builder was silently producing broken keys/paths on that platform.

## Testing

- `tsgo -p tsconfig.json --noEmit` — clean.
- `bun test test/extensions-runner.test.ts test/compaction-hooks.test.ts` — 71 pass.
- `bun test test/custom-editor-keybindings.test.ts` — 10 pass, including 3 new tests covering accept-once, drop-on-other-keystroke, and never-claim-when-editor-has-text.
- `bun test test/extensibility/legacy-pi-bundled-subpath-overrides.test.ts` — 12 pass (regression coverage for the Windows glob path fix).

---

- [x] `bun check` passes (types clean; targeted test suites above)
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing) — no CHANGELOG.md in this repo