### PR TITLE
fix(catalog): admit discovered Token Plan chat models

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `alibaba-token-plan` dynamic discovery dropping newly advertised chat models by replacing the stale static allowlist with dedicated non-chat media-model filters ([#7391](https://github.com/can1357/oh-my-pi/issues/7391)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Added

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2833,6 +2833,15 @@ export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-comple
 	},
 ];
 
+const ALIBABA_TOKEN_PLAN_NON_CHAT_MODEL_PREFIXES = ["happyhorse-", "qwen-audio-", "qwen-image-", "wan2.7-"] as const;
+
+function isAlibabaTokenPlanChatModelId(id: string): boolean {
+	const normalized = id.trim().toLowerCase();
+	return (
+		normalized.length > 0 && !ALIBABA_TOKEN_PLAN_NON_CHAT_MODEL_PREFIXES.some(prefix => normalized.startsWith(prefix))
+	);
+}
+
 export interface AlibabaTokenPlanModelManagerConfig {
 	apiKey?: string;
 	baseUrl?: string;
@@ -2859,8 +2868,7 @@ export function alibabaTokenPlanModelManagerOptions(
 					provider: "alibaba-token-plan",
 					baseUrl,
 					apiKey,
-					filterModel: (_entry, model) =>
-						ALIBABA_TOKEN_PLAN_STATIC_MODELS.some(reference => reference.id === model.id),
+					filterModel: (_entry, model) => isAlibabaTokenPlanChatModelId(model.id),
 					mapModel: (_entry, defaults) => {
 						const reference = ALIBABA_TOKEN_PLAN_STATIC_MODELS.find(model => model.id === defaults.id);
 						return reference

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2833,7 +2833,13 @@ export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-comple
 	},
 ];
 
-const ALIBABA_TOKEN_PLAN_NON_CHAT_MODEL_PREFIXES = ["happyhorse-", "qwen-audio-", "qwen-image-", "wan2.7-"] as const;
+const ALIBABA_TOKEN_PLAN_NON_CHAT_MODEL_PREFIXES = [
+	"happyhorse-",
+	"qwen-audio-",
+	"qwen-image-",
+	"text-embedding-",
+	"wan2.7-",
+] as const;
 
 function isAlibabaTokenPlanChatModelId(id: string): boolean {
 	const normalized = id.trim().toLowerCase();

--- a/packages/catalog/test/alibaba-token-plan.test.ts
+++ b/packages/catalog/test/alibaba-token-plan.test.ts
@@ -46,7 +46,7 @@ describe("QwenCloud Token Plan provider", () => {
 		]);
 	});
 
-	test("discovers the subscribed allowlist from the native models endpoint", async () => {
+	test("discovers subscribed chat models from the native models endpoint", async () => {
 		let requestedUrl = "";
 		let authorization = "";
 		const fetchMock: FetchImpl = (input, init) => {
@@ -62,6 +62,12 @@ describe("QwenCloud Token Plan provider", () => {
 							context_length: 262_144,
 							max_completion_tokens: 16_384,
 						},
+						{ id: "deepseek-v4-flash", owned_by: "qwencloud" },
+						{ id: "kimi-k2.7-code", owned_by: "qwencloud" },
+						{ id: "MiniMax-M2.5", owned_by: "qwencloud" },
+						{ id: "qwen-image-2.0-pro", owned_by: "qwencloud" },
+						{ id: "qwen-audio-3.0-tts-plus", owned_by: "qwencloud" },
+						{ id: "happyhorse-1.1-t2v", owned_by: "qwencloud" },
 						{ id: "wan2.7-image", owned_by: "qwencloud" },
 					],
 				}),
@@ -74,8 +80,13 @@ describe("QwenCloud Token Plan provider", () => {
 
 		expect(requestedUrl).toBe(`${ALIBABA_TOKEN_PLAN_BASE_URL}/models`);
 		expect(authorization).toBe("Bearer sk-sp-test");
-		expect(models).toHaveLength(1);
-		expect(models?.[0]).toMatchObject({
+		expect(models?.map(model => model.id)).toEqual([
+			"deepseek-v4-flash",
+			"kimi-k2.7-code",
+			"MiniMax-M2.5",
+			"qwen3.7-plus",
+		]);
+		expect(models?.find(model => model.id === "qwen3.7-plus")).toMatchObject({
 			id: "qwen3.7-plus",
 			provider: "alibaba-token-plan",
 			name: "Qwen3.7 Plus",

--- a/packages/catalog/test/alibaba-token-plan.test.ts
+++ b/packages/catalog/test/alibaba-token-plan.test.ts
@@ -68,6 +68,7 @@ describe("QwenCloud Token Plan provider", () => {
 						{ id: "qwen-image-2.0-pro", owned_by: "qwencloud" },
 						{ id: "qwen-audio-3.0-tts-plus", owned_by: "qwencloud" },
 						{ id: "happyhorse-1.1-t2v", owned_by: "qwencloud" },
+						{ id: "text-embedding-v4", owned_by: "qwencloud" },
 						{ id: "wan2.7-image", owned_by: "qwencloud" },
 					],
 				}),


### PR DESCRIPTION
## Repro
A mocked Alibaba Token Plan `/models` response containing both the curated `qwen3.7-plus` and newly advertised `deepseek-v4-flash` reproduced the omission with `bun test packages/catalog/test/alibaba-token-plan.test.ts`: discovery returned only `qwen3.7-plus` and failed the two-model assertion.

## Cause
`alibabaTokenPlanModelManagerOptions` in `packages/catalog/src/provider-models/openai-compat.ts` filtered every dynamic result against `ALIBABA_TOKEN_PLAN_STATIC_MODELS`, turning the six-model offline fallback catalog into a stale runtime allowlist.

## Fix
- Replace the static allowlist gate with explicit Alibaba media-model prefix exclusions for HappyHorse video, Qwen audio/image, and Wan 2.7 generation models.
- Cover newly advertised DeepSeek, Kimi, and MiniMax chat IDs while preserving curated metadata for static matches and excluding non-chat fixtures.
- Record the catalog fix under `[Unreleased]`.

## Verification
`bun test packages/catalog/test/alibaba-token-plan.test.ts` passed 5 tests with 13 assertions; `bun test packages/catalog/test` passed 555 tests across 76 files with 2,566 assertions. The pre-publish `bun run fix` and `bun check` gate also passed.

Fixes #7391