### PR TITLE
fix(update): detect active Linux libc

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed self-update misclassifying glibc Linux hosts with an installed musl loader as musl hosts, which could download an unusable musl binary instead of the glibc release.
+
 ## [17.2.4] - 2026-08-01
 
 ### Added

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -765,14 +765,33 @@ async function pruneBunCacheAfterGlobalInstall(): Promise<BunInstallCachePruneRe
 /**
  * Detect a musl-libc Linux host (Alpine, Void-musl) so self-update replaces a
  * musl binary with the musl release asset instead of the glibc build, which
- * would fail to start on the next run. Mirrors the detection in
- * scripts/install.sh.
+ * would fail to start on the next run. The loader file alone is not sufficient:
+ * glibc hosts may have musl installed for cross-compilation.
  */
-function isMuslLinux(): boolean {
-	if (process.platform !== "linux") return false;
-	if (fs.existsSync("/etc/alpine-release")) return true;
-	const loaderArch = process.arch === "arm64" ? "aarch64" : "x86_64";
-	return fs.existsSync(`/lib/ld-musl-${loaderArch}.so.1`);
+interface MuslDetectionOptions {
+	platform?: NodeJS.Platform;
+	alpineRelease?: boolean;
+	lddOutput?: string;
+}
+
+function detectLddOutput(): string | undefined {
+	try {
+		const result = Bun.spawnSync(["ldd", "--version"], { stdout: "pipe", stderr: "pipe" });
+		return `${result.stdout.toString("utf-8")}\n${result.stderr.toString("utf-8")}`;
+	} catch {
+		return undefined;
+	}
+}
+
+function isMuslLinux(options: MuslDetectionOptions = {}): boolean {
+	if ((options.platform ?? process.platform) !== "linux") return false;
+	if (options.alpineRelease ?? fs.existsSync("/etc/alpine-release")) return true;
+	return /\bmusl\b/i.test(options.lddOutput ?? detectLddOutput() ?? "");
+}
+
+/** Test seam for libc detection. */
+export function isMuslLinuxForTest(options: Required<MuslDetectionOptions>): boolean {
+	return isMuslLinux(options);
 }
 
 /**

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -13,6 +13,7 @@ import {
 	buildMiseUpgradeArgs,
 	buildNpmInstallArgs,
 	downloadVerifiedBinary,
+	isMuslLinuxForTest,
 	parseUpdateArgs,
 	pruneBunInstallCache,
 	replaceBinaryForUpdate,
@@ -74,6 +75,29 @@ describe("parseUpdateArgs", () => {
 		expect(parseUpdateArgs(["update", "-l"])).toEqual({ force: false, check: false, plugins: true });
 	});
 });
+
+describe("update-cli libc detection", () => {
+	it("does not mistake an installed musl loader for a glibc host", () => {
+		expect(
+			isMuslLinuxForTest({
+				platform: "linux",
+				alpineRelease: false,
+				lddOutput: "ldd (Ubuntu GLIBC 2.39-0ubuntu8.7) 2.39",
+			}),
+		).toBe(false);
+	});
+
+	it("recognizes a musl host from ldd output", () => {
+		expect(
+			isMuslLinuxForTest({
+				platform: "linux",
+				alpineRelease: false,
+				lddOutput: "musl libc (x86_64)",
+			}),
+		).toBe(true);
+	});
+});
+
 describe("update-cli install target detection", () => {
 	it("uses bun update when prioritized omp is inside bun global bin", () => {
 		const method = resolveUpdateMethodForTest("/Users/test/.bun/bin/omp", "/Users/test/.bun/bin");


### PR DESCRIPTION
## What

Fix Linux self-update libc detection. The updater previously treated `/lib/ld-musl-<arch>.so.1` as proof that the host was musl, so a glibc host with musl tooling installed downloaded `omp-linux-musl-x64` and then failed its post-install version check. It now detects musl from Alpine's release marker or `ldd --version`, matching the installer behavior.

## Why

On Pop!_OS with glibc and musl installed side by side, `omp update` downloaded the musl binary and rolled back because it could not load `libstdc++.so.6` and `libgcc_s.so.1`.

I reviewed the full diff; this keeps genuine musl hosts on the musl release while preventing mixed glibc/musl installations from selecting an unusable binary.

## Verification

- `bun test packages/coding-agent/test/update-cli.test.ts` — 40 passed.
- `bun test scripts/musl-release.test.ts` — 2 passed.
- Biome check and `git diff --check` passed.
- Real forced self-update against a temporary target downloaded `omp-linux-x64`, verified its GitHub digest, installed it, and reported `omp/17.2.4`.

Related to #6189.
