### PR TITLE
fix(session): make project directories safe and unique

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Fixed
 
 - Fixed sessions without a granted `write` tool hiding discoverable and MCP tools behind the unusable `xd://` transport; those sessions now disable device mounting and expose the tools directly without gaining write access.
+- Fixed project-scoped session directories using leading-hyphen names and collapsing distinct paths such as `~/project/hail-mary` and `~/project-hail-mary` into one bucket; directory names now use a portable readable prefix plus the canonical cwd hash, and colliding legacy buckets are split by their recorded session cwd during migration ([#7396](https://github.com/can1357/oh-my-pi/issues/7396)).
 - Fixed collab guest prompts being sent to models as unframed developer context, so guest messages now retain their transcript attribution while reaching the model as prioritized user interjections ([#7288](https://github.com/can1357/oh-my-pi/issues/7288)).
 - Fixed `/memory stats` and `/memory diagnose` showing "Memory stats is not available for the off backend" when memory is off, in both the TUI and ACP/RPC slash-command handlers; the off backend now says memory is off directly instead of naming itself as an unsupported backend ([#7251](https://github.com/can1357/oh-my-pi/pull/7251) by [@KennethHoff](https://github.com/KennethHoff)).
 - Fixed `/reload-plugins` retaining stale context-file contents and activation state in the current system prompt ([#7258](https://github.com/can1357/oh-my-pi/issues/7258)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed project-scoped session directories using leading-hyphen names and collapsing distinct paths such as `~/project/hail-mary` and `~/project-hail-mary` into one bucket; directory names now use a portable readable prefix plus the canonical cwd hash, and colliding legacy buckets are split by their recorded session cwd during migration ([#7396](https://github.com/can1357/oh-my-pi/issues/7396)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Added
@@ -25,7 +29,6 @@
 ### Fixed
 
 - Fixed sessions without a granted `write` tool hiding discoverable and MCP tools behind the unusable `xd://` transport; those sessions now disable device mounting and expose the tools directly without gaining write access.
-- Fixed project-scoped session directories using leading-hyphen names and collapsing distinct paths such as `~/project/hail-mary` and `~/project-hail-mary` into one bucket; directory names now use a portable readable prefix plus the canonical cwd hash, and colliding legacy buckets are split by their recorded session cwd during migration ([#7396](https://github.com/can1357/oh-my-pi/issues/7396)).
 - Fixed collab guest prompts being sent to models as unframed developer context, so guest messages now retain their transcript attribution while reaching the model as prioritized user interjections ([#7288](https://github.com/can1357/oh-my-pi/issues/7288)).
 - Fixed `/memory stats` and `/memory diagnose` showing "Memory stats is not available for the off backend" when memory is off, in both the TUI and ACP/RPC slash-command handlers; the off backend now says memory is off directly instead of naming itself as an unsupported backend ([#7251](https://github.com/can1357/oh-my-pi/pull/7251) by [@KennethHoff](https://github.com/KennethHoff)).
 - Fixed `/reload-plugins` retaining stale context-file contents and activation state in the current system prompt ([#7258](https://github.com/can1357/oh-my-pi/issues/7258)).

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -2,10 +2,17 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getTerminalId } from "@oh-my-pi/pi-tui";
-import { getSessionsDir, getTerminalSessionsDir, isEnoent, logger, resolveEquivalentPath } from "@oh-my-pi/pi-utils";
+import {
+	getSessionsDir,
+	getTerminalSessionsDir,
+	isEnoent,
+	isRecord,
+	logger,
+	resolveEquivalentPath,
+} from "@oh-my-pi/pi-utils";
 import type { SessionStorage } from "./session-storage";
 
-const migratedSessionRoots = new Set<string>();
+const SESSION_HEADER_PREFIX_BYTES = 4096;
 
 /**
  * Merge or rename a legacy session directory into its canonical target.
@@ -35,12 +42,16 @@ function encodeLegacyAbsoluteSessionDirName(cwd: string): string {
 	return `--${resolvedCwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
 }
 
-function encodeRelativeSessionDirName(prefix: string, relative: string): string {
+function encodeLegacyRelativeSessionDirName(prefix: string, relative: string): string {
 	const encoded = relative.replace(/[/\\:]/g, "-");
 	return encoded ? (prefix.endsWith("-") ? `${prefix}${encoded}` : `${prefix}-${encoded}`) : prefix;
 }
 
-function getDefaultSessionDirName(cwd: string): { encodedDirName: string; resolvedCwd: string } {
+function getDefaultSessionDirName(cwd: string): {
+	encodedDirName: string;
+	legacyRelativeDirName: string | undefined;
+	resolvedCwd: string;
+} {
 	const resolvedCwd = path.resolve(cwd);
 	const canonicalCwd = resolveEquivalentPath(resolvedCwd);
 	const home = os.homedir();
@@ -49,72 +60,111 @@ function getDefaultSessionDirName(cwd: string): { encodedDirName: string; resolv
 	const canonicalTempRoot = resolveEquivalentPath(tempRoot);
 	const homeRelative = path.relative(canonicalHome, canonicalCwd);
 	const tempRelative = path.relative(canonicalTempRoot, canonicalCwd);
-	const encodedDirName =
-		homeRelative === "" || (!homeRelative.startsWith("..") && !path.isAbsolute(homeRelative))
-			? encodeRelativeSessionDirName("-", homeRelative)
-			: tempRelative === "" || (!tempRelative.startsWith("..") && !path.isAbsolute(tempRelative))
-				? encodeRelativeSessionDirName("-tmp", tempRelative)
-				: encodeLegacyAbsoluteSessionDirName(canonicalCwd);
-	return { encodedDirName, resolvedCwd };
-}
 
-/**
- * Migrate old `--<home-encoded>-*--` session dirs to the new `-*` format.
- * Runs once per sessions root on first access, best-effort.
- */
-function migrateHomeSessionDirs(sessionsRoot: string): void {
-	if (migratedSessionRoots.has(sessionsRoot)) return;
-	migratedSessionRoots.add(sessionsRoot);
-
-	const home = os.homedir();
-	const homeEncoded = home.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-");
-	const oldPrefix = `--${homeEncoded}-`;
-	const oldExact = `--${homeEncoded}--`;
-
-	let entries: string[];
-	try {
-		entries = fs.readdirSync(sessionsRoot);
-	} catch {
-		return;
+	let scope: "home" | "tmp" | "abs";
+	let legacyRelativeDirName: string | undefined;
+	if (homeRelative === "" || (!homeRelative.startsWith("..") && !path.isAbsolute(homeRelative))) {
+		scope = "home";
+		legacyRelativeDirName = encodeLegacyRelativeSessionDirName("-", homeRelative);
+	} else if (tempRelative === "" || (!tempRelative.startsWith("..") && !path.isAbsolute(tempRelative))) {
+		scope = "tmp";
+		legacyRelativeDirName = encodeLegacyRelativeSessionDirName("-tmp", tempRelative);
+	} else {
+		scope = "abs";
 	}
 
+	const normalized = canonicalCwd.replaceAll("\\", "/");
+	const readable = path
+		.basename(canonicalCwd)
+		.replace(/[^a-zA-Z0-9._-]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(-80);
+	const digest = Bun.SHA256.hash(normalized, "hex");
+	const encodedDirName = `${scope}-${readable || "project"}-${digest}`;
+	return { encodedDirName, legacyRelativeDirName, resolvedCwd };
+}
+
+function readSessionCwd(sessionFile: string, buffer: Buffer): string | undefined {
+	let descriptor: number | undefined;
+	try {
+		descriptor = fs.openSync(sessionFile, "r");
+		const bytesRead = fs.readSync(descriptor, buffer, 0, buffer.length, 0);
+		const prefix = buffer.toString("utf8", 0, bytesRead);
+		for (const line of prefix.split(/\r?\n/, 3)) {
+			try {
+				const record: unknown = JSON.parse(line);
+				if (isRecord(record) && record.type === "session" && typeof record.cwd === "string") {
+					return record.cwd;
+				}
+			} catch {
+				// Ignore title slots or truncated/corrupt headers.
+			}
+		}
+	} catch {
+		// Best-effort migration leaves unreadable sessions in the current bucket.
+	} finally {
+		if (descriptor !== undefined) fs.closeSync(descriptor);
+	}
+	return undefined;
+}
+
+function moveSessionBundle(sourceDir: string, targetDir: string, sessionName: string, entries: string[]): void {
+	fs.mkdirSync(targetDir, { recursive: true });
+	const artifactsName = path.basename(sessionName, ".jsonl");
 	for (const entry of entries) {
-		let remainder: string;
-		if (entry === oldExact) {
-			remainder = "";
-		} else if (entry.startsWith(oldPrefix) && entry.endsWith("--")) {
-			remainder = entry.slice(oldPrefix.length, -2);
+		if (entry !== sessionName && entry !== artifactsName && !entry.startsWith(`${sessionName}.`)) continue;
+		const source = path.join(sourceDir, entry);
+		if (!fs.existsSync(source)) continue;
+		const target = path.join(targetDir, entry);
+		const existing = fs.statSync(target, { throwIfNoEntry: false });
+		if (!existing) {
+			fs.renameSync(source, target);
+		} else if (existing.isDirectory() && fs.statSync(source).isDirectory()) {
+			migrateSessionDirPath(source, target);
 		} else {
+			fs.rmSync(source, { recursive: true, force: true });
+		}
+	}
+}
+
+function rerouteCollidingSessions(
+	cwd: string,
+	legacyDir: string,
+	sessionsRoot: string,
+	kind: "relative" | "absolute",
+): void {
+	const entries = fs.readdirSync(legacyDir);
+	const currentCwd = resolveEquivalentPath(path.resolve(cwd));
+	const buffer = Buffer.allocUnsafe(SESSION_HEADER_PREFIX_BYTES);
+	for (const entry of entries) {
+		if (!entry.endsWith(".jsonl")) continue;
+		const recordedCwd = readSessionCwd(path.join(legacyDir, entry), buffer);
+		if (!recordedCwd) continue;
+		const recordedCanonical = resolveEquivalentPath(path.resolve(recordedCwd));
+		if (
+			recordedCanonical === currentCwd ||
+			!fs.statSync(recordedCanonical, { throwIfNoEntry: false })?.isDirectory()
+		) {
 			continue;
 		}
-
-		const newName = remainder ? `-${remainder}` : "-";
-		const oldPath = path.join(sessionsRoot, entry);
-		const newPath = path.join(sessionsRoot, newName);
-
-		try {
-			migrateSessionDirPath(oldPath, newPath);
-		} catch {
-			// Best effort
-		}
-	}
-}
-
-function migrateLegacyAbsoluteSessionDir(cwd: string, sessionDir: string, sessionsRoot: string): void {
-	const legacyDir = path.join(sessionsRoot, encodeLegacyAbsoluteSessionDirName(cwd));
-	if (legacyDir === sessionDir || !fs.existsSync(legacyDir)) return;
-
-	try {
-		migrateSessionDirPath(legacyDir, sessionDir);
-	} catch {
-		// Best effort
+		const recordedNames = getDefaultSessionDirName(recordedCanonical);
+		const recordedLegacyName =
+			kind === "relative"
+				? recordedNames.legacyRelativeDirName
+				: encodeLegacyAbsoluteSessionDirName(recordedCanonical);
+		if (recordedLegacyName !== path.basename(legacyDir)) continue;
+		moveSessionBundle(legacyDir, path.join(sessionsRoot, recordedNames.encodedDirName), entry, entries);
 	}
 }
 
 export function resolveManagedSessionRoot(sessionDir: string, cwd: string): string | undefined {
 	const currentDirName = path.basename(sessionDir);
-	const { encodedDirName } = getDefaultSessionDirName(cwd);
-	if (currentDirName !== encodedDirName && currentDirName !== encodeLegacyAbsoluteSessionDirName(cwd)) {
+	const { encodedDirName, legacyRelativeDirName } = getDefaultSessionDirName(cwd);
+	if (
+		currentDirName !== encodedDirName &&
+		currentDirName !== legacyRelativeDirName &&
+		currentDirName !== encodeLegacyAbsoluteSessionDirName(cwd)
+	) {
 		return undefined;
 	}
 	return path.dirname(sessionDir);
@@ -130,10 +180,23 @@ export function computeDefaultSessionDir(
 	storage: SessionStorage,
 	sessionsRoot: string = getSessionsDir(),
 ): string {
-	const { encodedDirName, resolvedCwd } = getDefaultSessionDirName(cwd);
-	migrateHomeSessionDirs(sessionsRoot);
+	const { encodedDirName, legacyRelativeDirName, resolvedCwd } = getDefaultSessionDirName(cwd);
 	const sessionDir = path.join(sessionsRoot, encodedDirName);
-	migrateLegacyAbsoluteSessionDir(resolvedCwd, sessionDir, sessionsRoot);
+	const legacyDirs: Array<{ kind: "relative" | "absolute"; name: string | undefined }> = [
+		{ kind: "relative", name: legacyRelativeDirName },
+		{ kind: "absolute", name: encodeLegacyAbsoluteSessionDirName(resolvedCwd) },
+	];
+	for (const legacy of legacyDirs) {
+		if (!legacy.name) continue;
+		const legacyDir = path.join(sessionsRoot, legacy.name);
+		if (legacyDir === sessionDir || !fs.existsSync(legacyDir)) continue;
+		try {
+			rerouteCollidingSessions(resolvedCwd, legacyDir, sessionsRoot, legacy.kind);
+			migrateSessionDirPath(legacyDir, sessionDir);
+		} catch {
+			// Best effort
+		}
+	}
 	storage.ensureDirSync(sessionDir);
 	return sessionDir;
 }

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -163,7 +163,9 @@ describe("SessionManager temp cwd session dirs", () => {
 	const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
 
 	function expectedTempSessionDirName(tempCwd: string): string {
-		return `-tmp-${path.relative(os.tmpdir(), path.resolve(tempCwd)).replace(/[/\\:]/g, "-")}`;
+		const normalized = path.resolve(tempCwd).replaceAll("\\", "/");
+		const digest = Bun.SHA256.hash(normalized, "hex");
+		return `tmp-${path.basename(tempCwd)}-${digest}`;
 	}
 
 	function toLegacyAbsoluteSessionDirName(cwd: string): string {
@@ -188,7 +190,7 @@ describe("SessionManager temp cwd session dirs", () => {
 		removeSyncWithRetries(testAgentDir);
 	});
 
-	it("stores temp-root cwd sessions under -tmp-prefixed directories", () => {
+	it("stores temp-root cwd sessions under safe hashed directories", () => {
 		const tempCwd = path.join(testAgentDir, `temp-cwd-${Snowflake.next()}`);
 		fs.mkdirSync(tempCwd, { recursive: true });
 
@@ -199,7 +201,7 @@ describe("SessionManager temp cwd session dirs", () => {
 		expect(path.dirname(sessionFile)).toBe(path.join(getSessionsDir(), expectedTempSessionDirName(tempCwd)));
 	});
 
-	it("migrates legacy temp-root absolute session dirs to -tmp prefixes", () => {
+	it("migrates legacy temp-root absolute session dirs to safe names", () => {
 		const tempCwd = path.join(testAgentDir, `legacy-cwd-${Snowflake.next()}`);
 		fs.mkdirSync(tempCwd, { recursive: true });
 
@@ -216,6 +218,41 @@ describe("SessionManager temp cwd session dirs", () => {
 		expect(fs.existsSync(legacyDir)).toBe(false);
 		expect(path.dirname(sessionFile)).toBe(expectedDir);
 		expect(fs.existsSync(path.join(expectedDir, "carried.jsonl"))).toBe(true);
+	});
+
+	it("separates colliding legacy cwd buckets into safe directories", () => {
+		const firstCwd = path.join(testAgentDir, "project", "hail-mary");
+		const secondCwd = path.join(testAgentDir, "project-hail-mary");
+		fs.mkdirSync(firstCwd, { recursive: true });
+		fs.mkdirSync(secondCwd, { recursive: true });
+
+		const legacyName = `-tmp-${path.relative(os.tmpdir(), firstCwd).replace(/[/\\:]/g, "-")}`;
+		expect(legacyName).toBe(`-tmp-${path.relative(os.tmpdir(), secondCwd).replace(/[/\\:]/g, "-")}`);
+		const legacyDir = path.join(getSessionsDir(), legacyName);
+		fs.mkdirSync(path.join(legacyDir, "first"), { recursive: true });
+		fs.mkdirSync(path.join(legacyDir, "second"), { recursive: true });
+		fs.writeFileSync(
+			path.join(legacyDir, "first.jsonl"),
+			`${JSON.stringify({ type: "session", id: "first", cwd: firstCwd })}\n`,
+		);
+		fs.writeFileSync(
+			path.join(legacyDir, "second.jsonl"),
+			`${JSON.stringify({ type: "session", id: "second", cwd: secondCwd })}\n`,
+		);
+		fs.writeFileSync(path.join(legacyDir, "first", "artifact.txt"), "first");
+		fs.writeFileSync(path.join(legacyDir, "second", "artifact.txt"), "second");
+
+		const firstDir = path.dirname(SessionManager.create(firstCwd).getSessionFile()!);
+		const secondDir = path.dirname(SessionManager.create(secondCwd).getSessionFile()!);
+
+		expect(firstDir).not.toBe(secondDir);
+		expect(path.basename(firstDir).startsWith("-")).toBe(false);
+		expect(path.basename(secondDir).startsWith("-")).toBe(false);
+		expect(fs.existsSync(path.join(firstDir, "first.jsonl"))).toBe(true);
+		expect(fs.existsSync(path.join(firstDir, "first", "artifact.txt"))).toBe(true);
+		expect(fs.existsSync(path.join(secondDir, "second.jsonl"))).toBe(true);
+		expect(fs.existsSync(path.join(secondDir, "second", "artifact.txt"))).toBe(true);
+		expect(fs.existsSync(legacyDir)).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Repro
On 17.2.4/current `main`, run `cd ~/project/hail-mary && omp`, then `cd ~/project-hail-mary && omp`; both projects use `~/.omp/agent/sessions/-project-hail-mary`. Likewise, `cd ~/rf && omp` creates the option-like directory `~/.omp/agent/sessions/-rf`.

## Cause
`getDefaultSessionDirName` in `packages/coding-agent/src/session/session-paths.ts` replaced path separators and colons with hyphens and prefixed home-relative names with `-`, making the encoding lossy and producing shell-option-shaped basenames; `listSessions` then treated colliding projects as one local bucket.

## Fix
- Derive portable session-directory names from a readable cwd basename plus the full SHA-256 of the canonical cwd, with explicit `home`, `tmp`, or `abs` prefixes.
- Recognize old relative and absolute names as managed directories and migrate them on access.
- Split colliding legacy buckets by the recorded cwd before moving remaining sessions and artifact directories.
- Cover safe naming, uniqueness, and collision-aware migration in the session-manager file-operations suite.

## Verification
`bun test packages/coding-agent/test/session-manager/file-operations.test.ts` passes 16/16 tests; `bun check` passes. The original probe now reports `collision=false` and `optionLike=false`. The broader session-manager/resume test entrypoints currently stop before tests because `packages/coding-agent/src/export/html/tool-views.generated.js` is absent in this checkout.

Fixes #7396