### PR TITLE
fix(extensions): resolve compiled dependency graphs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ### Fixed
 
+- Fixed compiled binaries dropping extensions whose CommonJS dependencies require nested ESM packages, converge dual import/require graphs on one source file, or use directory-style package requires such as `require("../")` and `require("punycode/")` ([#7402](https://github.com/can1357/oh-my-pi/issues/7402)).
+
 - Fixed template argument substitution (`substituteArgs`) executing recursive placeholder expansion when positional argument values contain literal `$@` or `$ARGUMENTS` tokens.
 - Fixed focused-agent status bar dimming darkening Powerline end caps.
 - Fixed the browser relay creating duplicate "omp" tab groups: the bridge now keeps at most one group RPC in flight (a queued drain replaces fire-and-forget per-tab requests), so concurrent requests can no longer race the extension's non-atomic query→create→set-title sequence in the same window. Also fixed an extension reconnect (relay daemon restart, service-worker recycle) being misread as the user dragging every tab out of the omp group — grouping state is reset when the extension socket closes, so tabs regroup on the next hello instead of being permanently opted out.

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -1774,6 +1774,7 @@ const extensionGraphCacheBustResolvedImportModules = new Map<string, Set<string>
 const commonJsModuleSources = new Map<string, string>();
 const commonJsFallbackModulePaths = new Map<string, string>();
 const extensionSynchronousSpecifierTargets = new Map<string, Map<string, string>>();
+const synchronousModuleSources = new Map<string, string>();
 const commonJsGraphModulePaths = new Set<string>();
 const COMMONJS_REQUIRE_GLOBAL = "__ompLegacyPiRequireGraphModule";
 const commonJsModuleDefinitions = new Map<string, { source: string; filename: string; dirname: string }>();
@@ -2300,18 +2301,13 @@ async function installExtensionGraphHook(
 	commonJsPaths: Set<string>,
 	synchronousSourcePaths: ReadonlySet<string>,
 	cacheBustResolvedImportModules: ReadonlySet<string>,
-): Promise<{ asyncModules: Map<string, string>; syncSourceModules: Map<string, string> }> {
+): Promise<{ asyncModules: Map<string, string> }> {
 	const asyncModules = new Map<string, string>();
-	const syncSourceModules = new Map<string, string>();
 	for (const [modulePath, source] of modules) {
-		if (commonJsPaths.has(modulePath)) {
+		if (commonJsPaths.has(modulePath) || synchronousSourcePaths.has(modulePath)) {
 			continue;
 		}
-		if (synchronousSourcePaths.has(modulePath)) {
-			syncSourceModules.set(modulePath, source);
-		} else {
-			asyncModules.set(modulePath, source);
-		}
+		asyncModules.set(modulePath, source);
 	}
 
 	if (asyncModules.size > 0) {
@@ -2366,28 +2362,26 @@ async function installExtensionGraphHook(
 		});
 	}
 
-	if (syncSourceModules.size > 0) {
-		const alternation = [...syncSourceModules.keys()].map(escapeRegExp).join("|");
+	if (synchronousSourcePaths.size > 0) {
+		const alternation = [...synchronousSourcePaths].map(escapeRegExp).join("|");
 		const filter = new RegExp(`^(?:${alternation})(?:\\?mtime=\\d+)?$`);
-		const hookId = Bun.hash(`${entryRealPath}\0sync-source\0${[...syncSourceModules.keys()].join("\0")}`).toString(
-			36,
-		);
+		const hookId = Bun.hash(`${entryRealPath}\0sync-source\0${[...synchronousSourcePaths].join("\0")}`).toString(36);
 		Bun.plugin({
 			name: `omp:legacy-pi-ext:${hookId}`,
 			setup(build) {
 				build.onLoad({ filter, namespace: "file" }, args => {
 					const queryIndex = args.path.indexOf("?mtime=");
 					const sourcePath = queryIndex >= 0 ? args.path.slice(0, queryIndex) : args.path;
-					const source = syncSourceModules.get(sourcePath);
+					const source = synchronousModuleSources.get(sourcePath);
 					if (source === undefined) {
-						throw new Error(`Missing pre-rewritten CommonJS extension source: ${sourcePath}`);
+						throw new Error(`Missing pre-rewritten synchronous extension source: ${sourcePath}`);
 					}
 					return { contents: source, loader: getLoader(sourcePath) };
 				});
 			},
 		});
 	}
-	return { asyncModules, syncSourceModules };
+	return { asyncModules };
 }
 
 /**
@@ -2418,6 +2412,9 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 			commonJsModuleSources.set(modulePath, await prepareCommonJsDefaultModule(modulePath, source));
 			commonJsGraphModulePaths.add(modulePath);
 		}
+		if (synchronousSourcePaths.has(modulePath)) {
+			synchronousModuleSources.set(modulePath, source);
+		}
 	}
 	let hookedModules = extensionGraphHookModules.get(entryRealPath);
 	if (!hookedModules) {
@@ -2444,9 +2441,8 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 	}
 
 	let asyncModules = new Map<string, string>();
-	let syncSourceModules = new Map<string, string>();
 	if (pendingModules.size > 0) {
-		({ asyncModules, syncSourceModules } = await installExtensionGraphHook(
+		({ asyncModules } = await installExtensionGraphHook(
 			entryRealPath,
 			pendingModules,
 			pendingCommonJsPaths,
@@ -2460,7 +2456,6 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 	return {
 		clear() {
 			asyncModules.clear();
-			syncSourceModules.clear();
 			for (const modulePath of commonJsPaths) {
 				commonJsModuleSources.delete(modulePath);
 				commonJsModuleDefinitions.delete(modulePath);

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -1970,6 +1970,7 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 				let resolvedEsmBranch = false;
 				let requiresNativeAddonRewrite = false;
 				let requiresSynchronousSourceHook = false;
+				let synchronousSourceUpgraded = false;
 				const isRequired = reference.kind === "require";
 				if (specifier.startsWith(".")) {
 					const candidate = isRequired
@@ -2068,6 +2069,7 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 						requiresSynchronousSourceHook ||
 						(synchronousSourcePaths.has(file) && resolvedModuleKind === "esm"))
 				) {
+					synchronousSourceUpgraded = !synchronousSourcePaths.has(resolved);
 					synchronousSourcePaths.add(resolved);
 				}
 				if (resolved) {
@@ -2088,7 +2090,7 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 					if (mergedEsmBranch) {
 						queuedEsmBranchPaths.add(resolved);
 					}
-					if (modules.has(resolved) && queuedModuleKind !== mergedModuleKind) {
+					if (modules.has(resolved) && (queuedModuleKind !== mergedModuleKind || synchronousSourceUpgraded)) {
 						modules.delete(resolved);
 						commonJsPaths.delete(resolved);
 					}

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -665,7 +665,6 @@ const bareRequireResolutionCache = new Map<string, Promise<string | null>>();
 const realpathCache = new Map<string, Promise<string>>();
 const nativeAddonResolutionCache = new Map<string, Promise<string | null>>();
 const nativeAddonRequireScanCache = new Map<string, Promise<boolean>>();
-const nativeAddonLoaderModulePaths = new Set<string>();
 
 function clearLegacyPiResolutionCaches(): void {
 	resolvedSpecifierFallbacks.clear();
@@ -677,7 +676,6 @@ function clearLegacyPiResolutionCaches(): void {
 	bareRequireResolutionCache.clear();
 	nativeAddonResolutionCache.clear();
 	nativeAddonRequireScanCache.clear();
-	nativeAddonLoaderModulePaths.clear();
 	realpathCache.clear();
 }
 
@@ -1076,6 +1074,23 @@ async function resolveSourceModuleFile(basePath: string): Promise<string | null>
 	return null;
 }
 
+async function resolveRelativeCommonJsRequire(specifier: string, importerPath: string): Promise<string | null> {
+	const candidate = path.resolve(path.dirname(importerPath), specifier);
+	try {
+		const stats = await fs.promises.stat(candidate);
+		if (stats.isDirectory()) {
+			const manifest = await readPackageManifest(candidate);
+			if (typeof manifest?.main === "string") {
+				const main = await resolveSourceModuleFile(path.resolve(candidate, manifest.main));
+				if (main) return main;
+			}
+		}
+	} catch {
+		// Missing candidates fall through to extension and index resolution.
+	}
+	return resolveSourceModuleFile(candidate);
+}
+
 function isPathInsideRoot(rootPath: string, candidatePath: string): boolean {
 	const relative = path.relative(rootPath, candidatePath);
 	return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
@@ -1255,7 +1270,7 @@ function isBareExtensionDependencySpecifier(specifier: string): boolean {
 		return false;
 	}
 	const packageName = specifier.startsWith("@") ? specifier.split("/").slice(0, 2).join("/") : specifier.split("/")[0];
-	return Boolean(packageName && !isBuiltin(packageName));
+	return Boolean(packageName && !isBuiltin(specifier));
 }
 
 interface BarePackageSpecifier {
@@ -1319,7 +1334,6 @@ async function readPackageManifestUncached(packageRoot: string): Promise<Record<
 }
 
 type ExtensionModuleKind = "commonjs" | "esm";
-class ExtensionModuleKindConflictError extends Error {}
 
 async function isCommonJsModulePath(
 	modulePath: string,
@@ -1440,7 +1454,7 @@ async function resolveNodePackageFallback(
 	subpath: string | null,
 	manifest: Record<string, unknown>,
 ): Promise<string | null> {
-	if (subpath !== null) {
+	if (subpath) {
 		return resolvePackageSourceTarget(packageRoot, path.join(packageRoot, subpath));
 	}
 	for (const field of ["module", "main"]) {
@@ -1476,7 +1490,7 @@ async function resolveNodePackageRequire(specifier: string, importerPath: string
 	if (Object.hasOwn(manifest, "exports")) {
 		return resolveNodePackageExport(packageRoot, parsed.subpath, manifest, SUPPORTED_PACKAGE_REQUIRE_CONDITIONS);
 	}
-	if (parsed.subpath !== null) {
+	if (parsed.subpath) {
 		return resolvePackageSourceTarget(packageRoot, path.join(packageRoot, parsed.subpath));
 	}
 	const main = manifest.main;
@@ -1638,6 +1652,9 @@ async function resolveExtensionBareRequire(specifier: string, importerPath: stri
 }
 
 async function resolveExtensionCommonJsRequire(specifier: string, importerPath: string): Promise<string | null> {
+	if (specifier.startsWith(".")) {
+		return resolveRelativeCommonJsRequire(specifier, importerPath);
+	}
 	const remappedSpecifier = remapLegacyPiSpecifier(specifier);
 	if (remappedSpecifier) {
 		try {
@@ -1886,6 +1903,7 @@ interface ExtensionModuleGraph {
 	readonly modules: Map<string, string>;
 	readonly cacheBustResolvedImportModules: Set<string>;
 	readonly commonJsPaths: Set<string>;
+	readonly synchronousSourcePaths: Set<string>;
 }
 
 /**
@@ -1901,6 +1919,7 @@ interface ExtensionModuleGraph {
 async function collectExtensionModules(entryRealPath: string): Promise<ExtensionModuleGraph> {
 	const modules = new Map<string, string>();
 	const commonJsPaths = new Set<string>();
+	const synchronousSourcePaths = new Set<string>();
 	const queuedCacheBustResolvedImports = new Map<string, boolean>([[entryRealPath, true]]);
 	const queuedModuleKinds = new Map<string, ExtensionModuleKind>([[entryRealPath, "esm"]]);
 	const queuedEsmBranchPaths = new Set<string>();
@@ -1949,10 +1968,13 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 				let resolvedModuleKind: ExtensionModuleKind | undefined;
 				let resolvedEsmBranch = false;
 				let requiresNativeAddonRewrite = false;
+				let requiresSynchronousSourceHook = false;
 				const isRequired = reference.kind === "require";
 				if (specifier.startsWith(".")) {
-					const candidate = Bun.resolveSync(specifier, dir);
-					if (hasSourceModuleExtension(candidate)) {
+					const candidate = isRequired
+						? await resolveRelativeCommonJsRequire(specifier, file)
+						: Bun.resolveSync(specifier, dir);
+					if (candidate && hasSourceModuleExtension(candidate)) {
 						const inheritedTargetKind = isRequired
 							? sourceIsCommonJs
 								? "commonjs"
@@ -1966,10 +1988,11 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 						const isCommonJsDescendant = isRequired && sourceIsCommonJs && targetIsCommonJs;
 						requiresNativeAddonRewrite =
 							isRequired && !isCommonJsDescendant && (await moduleRequiresNativeAddon(candidate));
-						if (!isRequired || isCommonJsDescendant || requiresNativeAddonRewrite) {
+						if (!isRequired || isCommonJsDescendant || requiresNativeAddonRewrite || !targetIsCommonJs) {
 							resolved = await realpathOrSelf(candidate);
 							resolvedModuleKind = targetIsCommonJs ? "commonjs" : "esm";
 							resolvedEsmBranch = !targetIsCommonJs && esmBranch;
+							requiresSynchronousSourceHook = isRequired && !targetIsCommonJs;
 						}
 					}
 				} else if (specifier.startsWith("#")) {
@@ -1988,10 +2011,11 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 						const isCommonJsDescendant = isRequired && sourceIsCommonJs && targetIsCommonJs;
 						requiresNativeAddonRewrite =
 							isRequired && !isCommonJsDescendant && (await moduleRequiresNativeAddon(candidate));
-						if (!isRequired || isCommonJsDescendant || requiresNativeAddonRewrite) {
+						if (!isRequired || isCommonJsDescendant || requiresNativeAddonRewrite || !targetIsCommonJs) {
 							resolved = candidate;
 							resolvedModuleKind = targetIsCommonJs ? "commonjs" : "esm";
 							resolvedEsmBranch = !targetIsCommonJs && esmBranch;
+							requiresSynchronousSourceHook = isRequired && !targetIsCommonJs;
 						}
 					}
 				} else if (
@@ -2022,6 +2046,9 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 							: false;
 					if (isHookableEntry && dependencyEntry && (!isRequired || (sourceIsCommonJs && isCommonJsEntry))) {
 						resolved = await realpathOrSelf(dependencyEntry);
+					} else if (isHookableEntry && dependencyEntry && isRequired && !isCommonJsEntry) {
+						resolved = await realpathOrSelf(dependencyEntry);
+						requiresSynchronousSourceHook = true;
 					} else if (isHookableEntry && dependencyEntry && isRequired) {
 						requiresNativeAddonRewrite = await moduleRequiresNativeAddon(dependencyEntry);
 						if (requiresNativeAddonRewrite) {
@@ -2034,25 +2061,35 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 					}
 					nextCacheBustResolvedImports = false;
 				}
-				if (resolved && requiresNativeAddonRewrite) {
-					nativeAddonLoaderModulePaths.add(resolved);
+				if (
+					resolved &&
+					(requiresNativeAddonRewrite ||
+						requiresSynchronousSourceHook ||
+						(synchronousSourcePaths.has(file) && resolvedModuleKind === "esm"))
+				) {
+					synchronousSourcePaths.add(resolved);
 				}
 				if (resolved) {
 					const queuedCacheBust = queuedCacheBustResolvedImports.get(resolved) ?? false;
 					const mergedCacheBust = queuedCacheBust || nextCacheBustResolvedImports;
 					queuedCacheBustResolvedImports.set(resolved, mergedCacheBust);
 					const queuedModuleKind = queuedModuleKinds.get(resolved);
-					if (queuedModuleKind && resolvedModuleKind && queuedModuleKind !== resolvedModuleKind) {
-						throw new ExtensionModuleKindConflictError(
-							`Conflicting extension module kinds for ${resolved}: ${queuedModuleKind} and ${resolvedModuleKind}`,
-						);
-					}
-					const mergedModuleKind = queuedModuleKind ?? resolvedModuleKind;
+					const mergedEsmBranch = queuedEsmBranchPaths.has(resolved) || resolvedEsmBranch;
+					const mergedModuleKind =
+						queuedModuleKind && resolvedModuleKind && queuedModuleKind !== resolvedModuleKind
+							? mergedEsmBranch
+								? "esm"
+								: "commonjs"
+							: (queuedModuleKind ?? resolvedModuleKind);
 					if (mergedModuleKind) {
 						queuedModuleKinds.set(resolved, mergedModuleKind);
 					}
-					if (resolvedEsmBranch) {
+					if (mergedEsmBranch) {
 						queuedEsmBranchPaths.add(resolved);
+					}
+					if (modules.has(resolved) && queuedModuleKind !== mergedModuleKind) {
+						modules.delete(resolved);
+						commonJsPaths.delete(resolved);
 					}
 					if (!modules.has(resolved)) {
 						queue.push({
@@ -2063,28 +2100,37 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 						});
 					}
 				}
-			} catch (error) {
-				if (error instanceof ExtensionModuleKindConflictError) {
-					throw error;
-				}
+			} catch {
 				// Unresolvable import (e.g. a type-only path); skip it.
 			}
 		}
 	}
 	for (const [modulePath, source] of modules) {
-		if (commonJsPaths.has(modulePath) || nativeAddonLoaderModulePaths.has(modulePath)) {
-			modules.set(modulePath, await rewriteExtensionSpecifiers(source, modulePath, commonJsPaths.has(modulePath)));
+		if (commonJsPaths.has(modulePath)) {
+			modules.set(modulePath, await rewriteExtensionSpecifiers(source, modulePath, true));
+		} else if (synchronousSourcePaths.has(modulePath)) {
+			modules.set(modulePath, await rewriteLegacyExtensionSource(source, modulePath));
 		}
 	}
 	return {
 		modules,
 		commonJsPaths,
+		synchronousSourcePaths,
 		cacheBustResolvedImportModules: new Set(
 			[...queuedCacheBustResolvedImports]
 				.filter(([modulePath, enabled]) => enabled && modules.has(modulePath))
 				.map(([modulePath]) => modulePath),
 		),
 	};
+}
+
+/** Test seam for compiled-binary dependency graph discovery and rewriting. */
+export async function __collectLegacyPiExtensionSourcesForTests(
+	entryPath: string,
+): Promise<ReadonlyMap<string, string>> {
+	const entryRealPath = await realpathOrSelf(path.resolve(entryPath));
+	const graph = await collectExtensionModules(entryRealPath);
+	return graph.modules;
 }
 
 /**
@@ -2252,6 +2298,7 @@ async function installExtensionGraphHook(
 	entryRealPath: string,
 	modules: Map<string, string>,
 	commonJsPaths: Set<string>,
+	synchronousSourcePaths: ReadonlySet<string>,
 	cacheBustResolvedImportModules: ReadonlySet<string>,
 ): Promise<{ asyncModules: Map<string, string>; syncSourceModules: Map<string, string> }> {
 	const asyncModules = new Map<string, string>();
@@ -2260,7 +2307,7 @@ async function installExtensionGraphHook(
 		if (commonJsPaths.has(modulePath)) {
 			continue;
 		}
-		if (nativeAddonLoaderModulePaths.has(modulePath)) {
+		if (synchronousSourcePaths.has(modulePath)) {
 			syncSourceModules.set(modulePath, source);
 		} else {
 			asyncModules.set(modulePath, source);
@@ -2356,6 +2403,7 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 		modules: currentModules,
 		commonJsPaths,
 		cacheBustResolvedImportModules: discoveredCacheBustModules,
+		synchronousSourcePaths,
 	} = await collectExtensionModules(entryRealPath);
 	let cacheBustResolvedImportModules = extensionGraphCacheBustResolvedImportModules.get(entryRealPath);
 	if (!cacheBustResolvedImportModules) {
@@ -2379,11 +2427,15 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 
 	const pendingModules = new Map<string, string>();
 	const pendingCommonJsPaths = new Set<string>();
+	const pendingSynchronousSourcePaths = new Set<string>();
 	for (const [modulePath, source] of currentModules) {
 		if (!hookedModules.has(modulePath)) {
 			pendingModules.set(modulePath, source);
 			if (commonJsPaths.has(modulePath)) {
 				pendingCommonJsPaths.add(modulePath);
+			}
+			if (synchronousSourcePaths.has(modulePath)) {
+				pendingSynchronousSourcePaths.add(modulePath);
 			}
 		}
 	}
@@ -2398,6 +2450,7 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 			entryRealPath,
 			pendingModules,
 			pendingCommonJsPaths,
+			pendingSynchronousSourcePaths,
 			cacheBustResolvedImportModules,
 		));
 		for (const modulePath of pendingModules.keys()) {

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -1042,6 +1042,46 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(sources.get(nestedEntry)).toContain(url.pathToFileURL(nestedLeaf).href);
 	});
 
+	it("loads a nested ESM cluster required after the extension import settles", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "lazy-nested-esm-ext", version: "1.0.0", type: "module" }),
+			"node_modules/cjs-parent/package.json": JSON.stringify({
+				name: "cjs-parent",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/cjs-parent/index.js": 'module.exports = { load: () => require("nested-esm").default };',
+			"node_modules/cjs-parent/node_modules/nested-esm/package.json": JSON.stringify({
+				name: "nested-esm",
+				version: "1.0.0",
+				type: "module",
+				main: "index.js",
+			}),
+			"node_modules/cjs-parent/node_modules/nested-esm/index.js":
+				'import { value } from "nested-leaf"; export default value;',
+			"node_modules/cjs-parent/node_modules/nested-leaf/package.json": JSON.stringify({
+				name: "nested-leaf",
+				version: "1.0.0",
+				type: "module",
+				main: "index.js",
+			}),
+			"node_modules/cjs-parent/node_modules/nested-leaf/index.js": 'export const value = "lazy-nested-ok";',
+			"index.js": [
+				'import parent from "cjs-parent";',
+				"export const loadValue = parent.load;",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = await loadLegacyPiModule(path.join(dir, "index.js"));
+		const loadValue = Reflect.get(Object(mod), "loadValue");
+		if (typeof loadValue !== "function") {
+			throw new Error("lazy nested ESM fixture did not export loadValue");
+		}
+
+		expect(loadValue()).toBe("lazy-nested-ok");
+	});
+
 	it("chooses the ESM branch when dual package graphs converge", async () => {
 		const dir = await writePackage({
 			"package.json": JSON.stringify({ name: "dual-convergence-ext", version: "1.0.0", type: "module" }),

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import {
+	__collectLegacyPiExtensionSourcesForTests,
 	__rewriteLegacyExtensionSourceForTests,
 	loadLegacyPiModule,
 } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
@@ -1003,6 +1004,103 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(expectedEsmDepUrls.some(expected => rewritten.includes(expected))).toBe(true);
 		expect(expectedRootDepUrls.some(expected => rewritten.includes(expected))).toBe(true);
 		expect(rewritten).toContain('from "node:path"');
+	});
+
+	it("pre-rewrites a nested ESM cluster required by CommonJS", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "nested-esm-ext", version: "1.0.0", type: "module" }),
+			"node_modules/cjs-parent/package.json": JSON.stringify({
+				name: "cjs-parent",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/cjs-parent/index.js": 'module.exports = require("nested-esm");',
+			"node_modules/cjs-parent/node_modules/nested-esm/package.json": JSON.stringify({
+				name: "nested-esm",
+				version: "1.0.0",
+				type: "module",
+				main: "index.js",
+			}),
+			"node_modules/cjs-parent/node_modules/nested-esm/index.js":
+				'import { value } from "nested-leaf"; export default value;',
+			"node_modules/cjs-parent/node_modules/nested-leaf/package.json": JSON.stringify({
+				name: "nested-leaf",
+				version: "1.0.0",
+				type: "module",
+				main: "index.js",
+			}),
+			"node_modules/cjs-parent/node_modules/nested-leaf/index.js": 'export const value = "nested-ok";',
+			"index.js": 'import value from "cjs-parent"; export { value };',
+		});
+		const entry = path.join(dir, "index.js");
+		const nestedEntry = await fs.realpath(path.join(dir, "node_modules/cjs-parent/node_modules/nested-esm/index.js"));
+		const nestedLeaf = await fs.realpath(path.join(dir, "node_modules/cjs-parent/node_modules/nested-leaf/index.js"));
+
+		const sources = await __collectLegacyPiExtensionSourcesForTests(entry);
+
+		expect(sources.has(nestedEntry)).toBe(true);
+		expect(sources.get(nestedEntry)).toContain(url.pathToFileURL(nestedLeaf).href);
+	});
+
+	it("chooses the ESM branch when dual package graphs converge", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "dual-convergence-ext", version: "1.0.0", type: "module" }),
+			"node_modules/dual/package.json": JSON.stringify({
+				name: "dual",
+				version: "1.0.0",
+				exports: { import: "./esm.js", require: "./cjs.js" },
+			}),
+			"node_modules/dual/esm.js": 'import "./shared.js"; export const mode = "esm";',
+			"node_modules/dual/cjs.js": 'if (false) require("./shared.js"); module.exports = { mode: "cjs" };',
+			"node_modules/dual/shared.js": "globalThis.__ompDualGraphLoaded = true;",
+			"node_modules/dual-consumer/package.json": JSON.stringify({
+				name: "dual-consumer",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/dual-consumer/index.js": 'module.exports = require("dual");',
+			"index.js": 'import "dual"; import "dual-consumer";',
+		});
+		const shared = await fs.realpath(path.join(dir, "node_modules/dual/shared.js"));
+
+		const sources = await __collectLegacyPiExtensionSourcesForTests(path.join(dir, "index.js"));
+
+		expect(sources.has(shared)).toBe(true);
+	});
+
+	it("rewrites directory and builtin-named package requires through package main", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "directory-require-ext", version: "1.0.0" }),
+			"node_modules/directory-package/package.json": JSON.stringify({
+				name: "directory-package",
+				version: "1.0.0",
+				main: "lib/plumbing.js",
+			}),
+			"node_modules/directory-package/lib/plumbing.js": 'module.exports = "directory-ok";',
+			"node_modules/directory-package/configure/request.js": "",
+			"node_modules/punycode/package.json": JSON.stringify({
+				name: "punycode",
+				version: "1.0.0",
+				main: "punycode.js",
+			}),
+			"node_modules/punycode/punycode.js": 'module.exports = "punycode-ok";',
+			"index.js": "",
+		});
+		const importer = path.join(dir, "node_modules/directory-package/configure/request.js");
+		const rewritten = await __rewriteLegacyExtensionSourceForTests(
+			'const directory = require("../"); const punycode = require("punycode/");',
+			importer,
+		);
+		const directoryEntry = (
+			await fs.realpath(path.join(dir, "node_modules/directory-package/lib/plumbing.js"))
+		).replaceAll("\\", "/");
+		const punycodeEntry = (await fs.realpath(path.join(dir, "node_modules/punycode/punycode.js"))).replaceAll(
+			"\\",
+			"/",
+		);
+
+		expect(rewritten).toContain(`require("${directoryEntry}")`);
+		expect(rewritten).toContain(`require("${punycodeEntry}")`);
 	});
 
 	it("honors export pattern specificity and package encapsulation", async () => {

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -1082,6 +1082,47 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(loadValue()).toBe("lazy-nested-ok");
 	});
 
+	it("rewalks an ESM graph when a later require upgrades it to synchronous loading", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "sync-upgrade-ext", version: "1.0.0", type: "module" }),
+			"node_modules/cjs-parent/package.json": JSON.stringify({
+				name: "cjs-parent",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/cjs-parent/index.js": 'module.exports = { load: () => require("shared").default };',
+			"node_modules/shared/package.json": JSON.stringify({
+				name: "shared",
+				version: "1.0.0",
+				type: "module",
+				main: "index.js",
+			}),
+			"node_modules/shared/index.js": 'import { value } from "shared-leaf"; export default value;',
+			"node_modules/shared-leaf/package.json": JSON.stringify({
+				name: "shared-leaf",
+				version: "1.0.0",
+				type: "module",
+				main: "index.js",
+			}),
+			"node_modules/shared-leaf/index.js": 'export const value = "sync-upgrade-ok";',
+			"index.ts": [
+				'import parent from "cjs-parent";',
+				'import type { Marker } from "shared";',
+				"export const loadValue = parent.load;",
+				"export type SharedMarker = Marker;",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = await loadLegacyPiModule(path.join(dir, "index.ts"));
+		const loadValue = Reflect.get(Object(mod), "loadValue");
+		if (typeof loadValue !== "function") {
+			throw new Error("sync-upgrade fixture did not export loadValue");
+		}
+
+		expect(loadValue()).toBe("sync-upgrade-ok");
+	});
+
 	it("chooses the ESM branch when dual package graphs converge", async () => {
 		const dir = await writePackage({
 			"package.json": JSON.stringify({ name: "dual-convergence-ext", version: "1.0.0", type: "module" }),


### PR DESCRIPTION
## Repro
Install `pi-messenger-bridge@0.4.0`, build the current binary with `bun --cwd=packages/coding-agent run build`, then run `PI_DEBUG_STARTUP=1 packages/coding-agent/dist/omp -e /tmp/omp-7402-repro/node_modules/pi-messenger-bridge/dist/index.js -p hi --model openai/gpt-5.2`. Before this change, `loadExtensions` drops the extension with `Cannot find package 'domhandler'` from the nested `sanitize-html/node_modules/htmlparser2` ESM graph; after bypassing that edge, the same graph reaches `require("punycode/")` resolution failures.

## Cause
`collectExtensionModules` in `packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` left ESM packages reached through CommonJS `require()` outside the pre-rewritten synchronous graph, so compiled Bun tried to resolve their nested bare imports itself. The graph also treated conflicting inherited module kinds as fatal, while `resolveExtensionCommonJsRequire` ignored relative directory package mains and `isBareExtensionDependencySpecifier` misclassified `punycode/` as the Node builtin.

## Fix
- Propagate synchronous pre-rewriting through ESM subgraphs reached from CommonJS and deterministically prefer an explicit ESM branch when dual graphs converge.
- Resolve relative directory requires through the target package's `main`, and distinguish builtin subpaths from builtin-named npm package specifiers.
- Add focused graph/rewrite regressions and an `[Unreleased]` changelog entry.

## Verification
`bun test test/extensibility/legacy-pi-inplace-load.test.ts` passes 40 tests; `bun run check` passes in `packages/coding-agent`. A rebuilt compiled binary reaches `loadExtensions:done` with the unmodified 533-package `pi-messenger-bridge@0.4.0` install active and no extension-load diagnostic; the command then exits only for the intentionally unconfigured OpenAI key. Fixes #7402