### PR TITLE
fix(coding-agent): restore legacy compaction exports

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Reduced `omp --help` cold-start latency and memory use by rendering lightweight command metadata without loading every runtime command and provider graph.
 
 ### Fixed
+- Fixed `omp plugin install git:github.com/algal/pi-openai-server-compaction` failing extension validation because the legacy Pi compatibility shims omitted `serializeConversation` and the `/compat` alias `streamSimpleOpenAIResponses` ([#7403](https://github.com/can1357/oh-my-pi/issues/7403)).
 
 - Fixed template argument substitution (`substituteArgs`) executing recursive placeholder expansion when positional argument values contain literal `$@` or `$ARGUMENTS` tokens.
 - Fixed focused-agent status bar dimming darkening Powerline end caps.

--- a/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
@@ -19,7 +19,15 @@
  * `types.ts` via the `export *` below — pi-ai still exports both as types,
  * only the runtime `Type` builder and `StringEnum()` helper were removed.
  */
-import type { Api, AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+import {
+	type Api,
+	type AssistantMessage,
+	type AssistantMessageEventStream,
+	type Context,
+	type Model,
+	type SimpleStreamOptions,
+	streamSimple,
+} from "@oh-my-pi/pi-ai";
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { clampThinkingLevelForModel } from "@oh-my-pi/pi-catalog/model-thinking";
 import {
@@ -121,11 +129,19 @@ export { calculateCost, getBundledModel, getBundledModels, getBundledProviders, 
 export const getModel = getBundledModel;
 export const getModels = getBundledModels;
 
-// Upstream's `/compat` entrypoint exposes this legacy name for the simple
-// OpenAI Responses stream. OMP's provider uses the same simple-options
-// contract under `streamOpenAIResponses`; alias it for rewritten compat
-// imports from extensions such as pi-openai-server-compaction.
-export { streamOpenAIResponses as streamSimpleOpenAIResponses } from "@oh-my-pi/pi-ai";
+/**
+ * Stream OpenAI Responses through the historical simple-options contract.
+ *
+ * Legacy `/compat` callers pass {@link SimpleStreamOptions}; routing through
+ * `streamSimple` preserves option normalization before provider dispatch.
+ */
+export function streamSimpleOpenAIResponses(
+	model: Model<"openai-responses">,
+	context: Context,
+	options?: SimpleStreamOptions,
+): AssistantMessageEventStream {
+	return streamSimple(model, context, options);
+}
 /**
  * Compatibility re-exports for runtime helpers that upstream
  * `@earendil-works/pi-ai` exposed from its package root but omp's

--- a/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
@@ -121,6 +121,11 @@ export { calculateCost, getBundledModel, getBundledModels, getBundledProviders, 
 export const getModel = getBundledModel;
 export const getModels = getBundledModels;
 
+// Upstream's `/compat` entrypoint exposes this legacy name for the simple
+// OpenAI Responses stream. OMP's provider uses the same simple-options
+// contract under `streamOpenAIResponses`; alias it for rewritten compat
+// imports from extensions such as pi-openai-server-compaction.
+export { streamOpenAIResponses as streamSimpleOpenAIResponses } from "@oh-my-pi/pi-ai";
 /**
  * Compatibility re-exports for runtime helpers that upstream
  * `@earendil-works/pi-ai` exposed from its package root but omp's

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -1415,12 +1415,13 @@ export function getPackageDir(): string {
 	return getOmpPackageDir() ?? (isCompiledBinary() ? path.dirname(process.execPath) : process.cwd());
 }
 
-// Legacy pi's `@earendil-works/pi-coding-agent` re-exported `estimateTokens`
-// and `compact` from its package root (via `./core/compaction/index.ts`). In
-// omp both live in `@oh-my-pi/pi-agent-core/compaction`, and the coding-agent
-// barrel below does not forward them, so legacy extensions importing either
-// fail Bun's static export check during validation (issues #6583, #7174).
-export { compact, estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";
+// Legacy pi's `@earendil-works/pi-coding-agent` re-exported `estimateTokens`,
+// `compact`, and `serializeConversation` from its package root (via
+// `./core/compaction/index.ts`). In omp they live in
+// `@oh-my-pi/pi-agent-core/compaction`, and the coding-agent barrel below does
+// not forward them, so legacy extensions importing them fail Bun's static
+// export check during validation (issues #6583, #7174, #7403).
+export { compact, estimateTokens, serializeConversation } from "@oh-my-pi/pi-agent-core/compaction";
 
 // Same barrel gap for two more legacy package-root exports: pi re-exported the
 // `CONFIG_DIR_NAME` constant and the CLI parser `parseArgs`. In omp

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-root-exports.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-root-exports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { streamOpenAIResponses } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, FetchImpl } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import {
 	isContextOverflow,
 	parseJsonWithRepair,
@@ -55,7 +56,56 @@ describe("legacy pi-ai shim root exports", () => {
 		// parseStreamingJson completes a truncated object at the streaming edge.
 		expect(parseStreamingJson<{ a: number }>('{"a": 1')).toEqual({ a: 1 });
 	});
-	it("aliases the legacy simple OpenAI Responses stream", () => {
-		expect(streamSimpleOpenAIResponses).toBe(streamOpenAIResponses);
+	it("maps legacy simple options before streaming OpenAI Responses", async () => {
+		const requests: unknown[] = [];
+		const fetchMock: FetchImpl = Object.assign(
+			async () =>
+				new Response(
+					JSON.stringify({
+						error: { message: "intentional test response", type: "invalid_request_error" },
+					}),
+					{ status: 400, headers: { "content-type": "application/json" } },
+				),
+			{ preconnect: fetch.preconnect },
+		);
+		const model = buildModel({
+			id: "legacy-simple-options",
+			name: "Legacy Simple Options",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://responses.example.test/v1",
+			reasoning: true,
+			compat: {
+				supportsReasoningParams: true,
+				supportsReasoningEffort: true,
+			},
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.High],
+			},
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+		});
+
+		const result = await streamSimpleOpenAIResponses(
+			model,
+			{ messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+			{
+				apiKey: "test-key",
+				reasoning: Effort.High,
+				hideThinkingSummary: true,
+				fetch: fetchMock,
+				onPayload: request => {
+					requests.push(request);
+				},
+			},
+		).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(requests).toHaveLength(1);
+		expect(requests[0]).toMatchObject({ reasoning: { effort: "high" } });
+		expect(JSON.stringify(requests[0])).not.toContain('"summary"');
 	});
 });

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-root-exports.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-root-exports.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { streamOpenAIResponses } from "@oh-my-pi/pi-ai";
 import {
 	isContextOverflow,
 	parseJsonWithRepair,
 	parseStreamingJson,
 	repairJson,
+	streamSimpleOpenAIResponses,
 } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-ai-shim";
 
 // Issue #6859: pi extensions import runtime helpers from the `@earendil-works/pi-ai`
@@ -52,5 +54,8 @@ describe("legacy pi-ai shim root exports", () => {
 		expect(parseJsonWithRepair<{ a: number }>("{a: 1,}")).toEqual({ a: 1 });
 		// parseStreamingJson completes a truncated object at the streaming edge.
 		expect(parseStreamingJson<{ a: number }>('{"a": 1')).toEqual({ a: 1 });
+	});
+	it("aliases the legacy simple OpenAI Responses stream", () => {
+		expect(streamSimpleOpenAIResponses).toBe(streamOpenAIResponses);
 	});
 });

--- a/packages/coding-agent/test/extensibility/legacy-pi-compaction-helpers.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-compaction-helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { compact, estimateTokens } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
+import {
+	compact,
+	estimateTokens,
+	serializeConversation,
+} from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
 
 // Issue #6583: pi extensions import `estimateTokens` from
 // `@earendil-works/pi-coding-agent`, which aliases to this shim. Legacy pi
@@ -23,5 +27,12 @@ describe("legacy shim compaction helpers", () => {
 	// 'compact' not found". Pin the callable re-export.
 	it("re-exports compact as a callable function", () => {
 		expect(typeof compact).toBe("function");
+	});
+	// Issue #7403: `serializeConversation` is another package-root compaction
+	// helper used by pi-openai-server-compaction. Its absence prevented the
+	// extension from passing static validation.
+	it("re-exports serializeConversation with legacy transcript formatting", () => {
+		const serialized = serializeConversation([{ role: "user", content: "summarize this", timestamp: 0 }]);
+		expect(serialized).toBe("[User]: summarize this");
 	});
 });


### PR DESCRIPTION
## Repro
With a writable isolated profile, `HOME=/tmp/omp-7403-home bun packages/coding-agent/src/cli.ts --profile compaction-check-7403 plugin install git:github.com/algal/pi-openai-server-compaction` exited 1 during static extension validation: first `serializeConversation` was absent from the legacy coding-agent shim, then validation exposed the upstream `/compat` name `streamSimpleOpenAIResponses` as absent from the legacy pi-ai shim.

## Cause
`packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts` re-exported `compact` and `estimateTokens` from `@oh-my-pi/pi-agent-core/compaction` but omitted the serializer from the same historical package-root surface. `packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts` likewise exposed OMP’s equivalent `streamOpenAIResponses` implementation without the legacy `/compat` alias consumed by the plugin.

## Fix
- Re-export `serializeConversation` from the legacy coding-agent package root.
- Alias `streamSimpleOpenAIResponses` to OMP’s compatible `streamOpenAIResponses` implementation.
- Cover both named compatibility exports and record the fix in the coding-agent changelog.

## Verification
`bun test test/extensibility/legacy-pi-compaction-helpers.test.ts test/extensibility/legacy-pi-ai-root-exports.test.ts` passes 6 tests with 0 failures. A fresh isolated-profile install of `git:github.com/algal/pi-openai-server-compaction` now reports `Installed pi-openai-server-compaction@0.1.0`. The pre-publish `bun check` gate passed.

Fixes #7403