### PR TITLE
perf(coding-agent): skip hook-free extension dependency graphs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Exposed the script-driven `computer` schema to every model, including models with provider-native Computer Use support, because native action declarations cannot express persistent desktop sessions or accessibility handles.
 - Reduced `omp --help` cold-start latency and memory use by rendering lightweight command metadata without loading every runtime command and provider graph.
+- Avoided crawling pure-ESM third-party extension dependency graphs that cannot need compatibility rewrites, while retaining the full graph path for CommonJS, native-addon, and host-package dependencies.
 
 ### Fixed
 

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -666,6 +666,8 @@ const realpathCache = new Map<string, Promise<string>>();
 const nativeAddonResolutionCache = new Map<string, Promise<string | null>>();
 const nativeAddonRequireScanCache = new Map<string, Promise<boolean>>();
 const nativeAddonLoaderModulePaths = new Set<string>();
+const packageGraphHookNeedCache = new Map<string, Promise<boolean>>();
+const FORCE_FULL_EXTENSION_CRAWL = process.env.OMP_LEGACY_EXT_FULL_CRAWL === "1";
 
 function clearLegacyPiResolutionCaches(): void {
 	resolvedSpecifierFallbacks.clear();
@@ -679,6 +681,7 @@ function clearLegacyPiResolutionCaches(): void {
 	nativeAddonRequireScanCache.clear();
 	nativeAddonLoaderModulePaths.clear();
 	realpathCache.clear();
+	packageGraphHookNeedCache.clear();
 }
 
 registerPluginCacheInvalidator(clearLegacyPiResolutionCaches);
@@ -1318,6 +1321,85 @@ async function readPackageManifestUncached(packageRoot: string): Promise<Record<
 	}
 }
 
+/**
+ * A third-party package needs graph hooks only when a rewrite could change one
+ * of its files. Pure-ESM packages that declare no host `pi-*` / typebox
+ * dependency and ship no native addon resolve natively from their own
+ * `node_modules` location, so crawling them parses megabytes to produce
+ * byte-identical output.
+ */
+async function packageNeedsGraphHooks(packageRoot: string): Promise<boolean> {
+	if (FORCE_FULL_EXTENSION_CRAWL) {
+		return true;
+	}
+	const cached = packageGraphHookNeedCache.get(packageRoot);
+	if (cached) return cached;
+
+	const promise = packageNeedsGraphHooksUncached(packageRoot);
+	packageGraphHookNeedCache.set(packageRoot, promise);
+	return promise;
+}
+
+async function packageNeedsGraphHooksUncached(packageRoot: string): Promise<boolean> {
+	const manifest = await readPackageManifest(packageRoot);
+	if (!manifest) {
+		return true;
+	}
+	if (manifest.type !== "module") {
+		return true;
+	}
+	if (exportsContainRequireCondition(manifest.exports)) {
+		return true;
+	}
+	for (const field of ["dependencies", "peerDependencies", "optionalDependencies"]) {
+		const deps = manifest[field];
+		if (!isRecord(deps)) continue;
+		for (const name of Object.keys(deps)) {
+			if (
+				LEGACY_PI_SPECIFIER_FILTER.test(name) ||
+				name === "typebox" ||
+				name === "@sinclair/typebox" ||
+				name === "node-gyp-build" ||
+				name === "bindings" ||
+				name.endsWith("-napi")
+			) {
+				return true;
+			}
+		}
+	}
+	if (manifest.gypfile || manifest.binary !== undefined) {
+		return true;
+	}
+	return false;
+}
+
+/** A string leaf is a target, not a condition; only object keys are conditions. */
+function exportsContainRequireCondition(exports: unknown): boolean {
+	if (typeof exports === "string") {
+		return false;
+	}
+	if (Array.isArray(exports)) {
+		for (const item of exports) {
+			if (exportsContainRequireCondition(item)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	if (!isRecord(exports)) {
+		return false;
+	}
+	for (const [key, value] of Object.entries(exports)) {
+		if (key === "require") {
+			return true;
+		}
+		if (exportsContainRequireCondition(value)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 type ExtensionModuleKind = "commonjs" | "esm";
 class ExtensionModuleKindConflictError extends Error {}
 
@@ -1949,6 +2031,7 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 				let resolvedModuleKind: ExtensionModuleKind | undefined;
 				let resolvedEsmBranch = false;
 				let requiresNativeAddonRewrite = false;
+				let crawlResolved = true;
 				const isRequired = reference.kind === "require";
 				if (specifier.startsWith(".")) {
 					const candidate = Bun.resolveSync(specifier, dir);
@@ -2031,6 +2114,21 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 					if (resolved) {
 						resolvedModuleKind = isCommonJsEntry ? "commonjs" : "esm";
 						resolvedEsmBranch = selectedEsmBranch && !isCommonJsEntry;
+						if (resolvedModuleKind === "esm" && !requiresNativeAddonRewrite) {
+							const packageName = splitBarePackageSpecifier(specifier)?.name;
+							const packageRoot = packageName ? await findNodePackageRoot(packageName, file) : null;
+							const realPackageRoot = packageRoot ? await realpathOrSelf(packageRoot) : null;
+							if (
+								packageRoot &&
+								realPackageRoot &&
+								isPathInsideRoot(realPackageRoot, resolved) &&
+								isPathInsideRoot(path.resolve(packageRoot), resolved) &&
+								!isPathInsideRoot(realPackageRoot, entryRealPath) &&
+								!(await packageNeedsGraphHooks(packageRoot))
+							) {
+								crawlResolved = false;
+							}
+						}
 					}
 					nextCacheBustResolvedImports = false;
 				}
@@ -2055,12 +2153,30 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 						queuedEsmBranchPaths.add(resolved);
 					}
 					if (!modules.has(resolved)) {
-						queue.push({
-							file: resolved,
-							cacheBustResolvedImports: mergedCacheBust,
-							moduleKind: mergedModuleKind,
-							esmBranch: resolvedEsmBranch,
-						});
+						if (crawlResolved) {
+							queue.push({
+								file: resolved,
+								cacheBustResolvedImports: mergedCacheBust,
+								moduleKind: mergedModuleKind,
+								esmBranch: resolvedEsmBranch,
+							});
+						} else {
+							// Pure-ESM third-party entry: record it in `modules` so the
+							// importer's rewritten absolute specifier still loads through
+							// the graph hook, but never descend into the package's graph.
+							try {
+								modules.set(resolved, await Bun.file(resolved).text());
+							} catch {
+								// Unreadable entry — fail open to the crawl so native
+								// resolution still surfaces the error after a full walk.
+								queue.push({
+									file: resolved,
+									cacheBustResolvedImports: mergedCacheBust,
+									moduleKind: mergedModuleKind,
+									esmBranch: resolvedEsmBranch,
+								});
+							}
+						}
 					}
 				}
 			} catch (error) {
@@ -2529,4 +2645,9 @@ export function installLegacyPiSpecifierShim(): void {
 /** Test seam: clears the memoized canonical specifier resolutions. */
 export function __resetLegacyPiResolutionCache(): void {
 	clearLegacyPiResolutionCaches();
+}
+
+/** Test seam for the third-party graph-crawl gate. */
+export async function __packageNeedsGraphHooksForTests(packageRoot: string): Promise<boolean> {
+	return packageNeedsGraphHooks(packageRoot);
 }

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -4,10 +4,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import {
+	__packageNeedsGraphHooksForTests,
 	__rewriteLegacyExtensionSourceForTests,
 	loadLegacyPiModule,
 } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
-import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { removeWithRetries, TempDir } from "@oh-my-pi/pi-utils";
 
 // Issue #1674: legacy Pi extensions load browser-UI assets (HTML/CSS) at module
 // init via `readFileSync(join(__dirname, "ui.html"))`. The compat layer must run
@@ -17,10 +18,14 @@ import { removeWithRetries } from "@oh-my-pi/pi-utils";
 // public `loadLegacyPiModule` entry point.
 
 const tempRoots: string[] = [];
+const gateTempDirs: TempDir[] = [];
 
 afterAll(async () => {
 	for (const dir of tempRoots) {
 		await removeWithRetries(dir);
+	}
+	for (const dir of gateTempDirs) {
+		await dir.remove();
 	}
 });
 
@@ -33,6 +38,18 @@ async function writePackage(files: Record<string, string>): Promise<string> {
 		await fs.writeFile(abs, files[rel], "utf8");
 	}
 	return dir;
+}
+
+/** Gate fixtures use the central TempDir helper so cleanup stays full-suite safe. */
+async function writeGatePackage(files: Record<string, string>): Promise<string> {
+	const tempDir = await TempDir.create("@omp-legacy-graph-gate-");
+	gateTempDirs.push(tempDir);
+	for (const rel in files) {
+		const abs = tempDir.join(rel);
+		await fs.mkdir(path.dirname(abs), { recursive: true });
+		await fs.writeFile(abs, files[rel], "utf8");
+	}
+	return tempDir.path();
 }
 
 describe("legacy-pi in-place module loading (issue #1674)", () => {
@@ -1252,5 +1269,79 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		// extension's rewrite hook; its fork-scope import stays unresolved.
 		const siblingUrl = `${url.pathToFileURL(await fs.realpath(path.join(dir, "unrelated.ts"))).href}?nonce=${Date.now()}`;
 		await expect(import(siblingUrl)).rejects.toThrow(/@earendil-works\/pi-ai/);
+	});
+});
+
+describe("third-party graph-crawl gate", () => {
+	it("skips a pure-ESM package with plain dependencies and no exports map", async () => {
+		const dir = await writeGatePackage({
+			"package.json": JSON.stringify({
+				name: "pure-esm",
+				version: "1.0.0",
+				type: "module",
+				dependencies: { "lru-cache": "^11" },
+			}),
+		});
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(false);
+	});
+
+	it("skips an ESM package whose exports map has only import/default conditions", async () => {
+		const dir = await writeGatePackage({
+			"package.json": JSON.stringify({
+				name: "esm-exports",
+				version: "1.0.0",
+				type: "module",
+				exports: { ".": { import: "./index.js", default: "./index.js" } },
+			}),
+		});
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(false);
+	});
+
+	it("crawls a package whose exports map nests a require condition", async () => {
+		const dir = await writeGatePackage({
+			"package.json": JSON.stringify({
+				name: "dual-format",
+				version: "1.0.0",
+				type: "module",
+				exports: { ".": { node: { require: "./index.cjs", import: "./index.js" } } },
+			}),
+		});
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
+	});
+
+	it("crawls an implicit-CommonJS package (no type field)", async () => {
+		const dir = await writeGatePackage({
+			"package.json": JSON.stringify({ name: "implicit-cjs", version: "1.0.0" }),
+		});
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
+	});
+
+	it("crawls an ESM package that depends on a host pi package", async () => {
+		const dir = await writeGatePackage({
+			"package.json": JSON.stringify({
+				name: "pi-dependent",
+				version: "1.0.0",
+				type: "module",
+				dependencies: { "@oh-my-pi/pi-ai": "*" },
+			}),
+		});
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
+	});
+
+	it("crawls an ESM package that ships a native addon build", async () => {
+		const dir = await writeGatePackage({
+			"package.json": JSON.stringify({
+				name: "native-esm",
+				version: "1.0.0",
+				type: "module",
+				gypfile: true,
+			}),
+		});
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
+	});
+
+	it("fails open when the package manifest is unreadable", async () => {
+		const dir = await writeGatePackage({ "readme.md": "no manifest here" });
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

- Avoid the legacy graph crawl for pure-ESM third-party extension dependencies that cannot need compatibility rewrites.
- Keep the full crawl for unknown manifests, CommonJS, `exports.require`, native addons, host-package dependencies, and linked workspaces.
- Add `OMP_LEGACY_EXT_FULL_CRAWL=1` as a diagnostic escape hatch.

## Verification

- [x] `bun check`
- [x] `bun --cwd=packages/coding-agent test test/extensibility/legacy-pi-inplace-load.test.ts` (44 pass)

## Changelog

- [x] Added a coding-agent `[Unreleased]` performance entry.