### PR TITLE
feat(auth): copy OAuth URL during account login

### DIFF
--- a/packages/coding-agent/src/modes/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/components/login-dialog.ts
@@ -2,6 +2,7 @@ import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { Container, getKeybindings, Input, Spacer, Text, type TUI, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
 import { theme } from "../../modes/theme/theme";
 import { urlHyperlinkAlways, WidthAwareText } from "../../tui";
+import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
 import { DynamicBorder } from "./dynamic-border";
 
@@ -110,7 +111,7 @@ export class LoginDialogComponent extends Container {
 
 		// Open browser (best-effort)
 		openPath(url);
-
+		void copyToClipboard(url).catch(() => {});
 		this.#tui.requestRender();
 	}
 

--- a/packages/coding-agent/test/modes/components/login-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/login-dialog.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from "bun
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { LoginDialogComponent } from "@oh-my-pi/pi-coding-agent/modes/components/login-dialog";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import * as clipboardModule from "@oh-my-pi/pi-coding-agent/utils/clipboard";
 import * as openModule from "@oh-my-pi/pi-coding-agent/utils/open";
 import type { TUI } from "@oh-my-pi/pi-tui";
 
@@ -23,13 +24,15 @@ describe("LoginDialogComponent", () => {
 	it("links every wrapped authorization URL row to the complete URL", () => {
 		settings.override("tui.hyperlinks", "always");
 		const openSpy = spyOn(openModule, "openPath").mockImplementation(() => {});
+		const copySpy = spyOn(clipboardModule, "copyToClipboard").mockResolvedValue(undefined);
 		try {
 			const tui = { requestRender() {} } as unknown as TUI;
 			const dialog = new LoginDialogComponent(tui, "google-antigravity", () => {});
 			const authorizationUrl =
 				"https://accounts.google.com/o/oauth2/v2/auth?client_id=x&response_type=code&redirect_uri=http%3A%2F%2F127.0.0.1%3A51121%2Foauth-callback&scope=cloud-platform&state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+			const launchUrl = "https://omp.local/oauth-launch";
 
-			dialog.showAuth(authorizationUrl);
+			dialog.showAuth(authorizationUrl, undefined, launchUrl);
 			const linkTarget = `${authorizationUrl}\x07`;
 			const urlRows = dialog
 				.render(40)
@@ -39,7 +42,9 @@ describe("LoginDialogComponent", () => {
 			expect(urlRows.map(line => Bun.stripANSI(line).trim()).join("")).toBe(authorizationUrl);
 			expect(urlRows.every(line => line.includes(linkTarget))).toBe(true);
 			expect(openSpy).toHaveBeenCalledWith(authorizationUrl);
+			expect(copySpy).toHaveBeenCalledWith(authorizationUrl);
 		} finally {
+			copySpy.mockRestore();
 			openSpy.mockRestore();
 		}
 	});


### PR DESCRIPTION
## Summary

- Copy the complete OAuth authorization URL after opening the browser during interactive account login.
- Keep the optional local launch shortcut display-only.
- Cover full-URL precedence with focused dialog test coverage.

## Verification

- `node_modules/.bin/tsgo.exe -p packages/coding-agent/tsconfig.json --noEmit`
- `npx --yes bun test packages/coding-agent/test/modes/components/login-dialog.test.ts` (1 pass, 5 expectations)

The focused test used the published Windows native addon staged locally for verification; generated native/build artifacts were removed afterward.