### PR TITLE
fix(mcp): expand env vars in reauth OAuth credentials and reject empty tokens

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed
 
+- Fixed `/mcp reauth` sending literal `${VAR}` placeholders instead of env-expanded OAuth client credentials during the token exchange, and `MCPOAuthFlow.exchangeToken()` accepting an HTTP-200 token response with no `access_token` (e.g. a Slack `{ ok: false, error }` body), which stored an empty access token and only surfaced `invalid_token` on a later MCP request ([#7440](https://github.com/can1357/oh-my-pi/issues/7440)).
 - Fixed template argument substitution (`substituteArgs`) executing recursive placeholder expansion when positional argument values contain literal `$@` or `$ARGUMENTS` tokens.
 - Fixed focused-agent status bar dimming darkening Powerline end caps.
 - Fixed the browser relay creating duplicate "omp" tab groups: the bridge now keeps at most one group RPC in flight (a queued drain replaces fire-and-forget per-tab requests), so concurrent requests can no longer race the extension's non-atomic query→create→set-title sequence in the same window. Also fixed an extension reconnect (relay daemon restart, service-worker recycle) being misread as the user dragging every tab out of the omp group — grouping state is reset when the extension socket closes, so tabs regroup on the next hello instead of being permanently opted out.

--- a/packages/coding-agent/src/mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/mcp/oauth-flow.ts
@@ -489,11 +489,21 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 		}
 
 		const data = (await response.json()) as {
-			access_token: string;
+			access_token?: string;
 			refresh_token?: string;
 			expires_in?: number;
 			token_type?: string;
+			error?: string;
+			error_description?: string;
 		};
+
+		// Some providers (e.g. the Slack Web API) signal failure with HTTP 200 and
+		// an `{ ok: false, error }` body. Accepting such a response would store an
+		// empty access token and only surface `invalid_token` on a later request.
+		if (typeof data.access_token !== "string" || data.access_token.length === 0) {
+			const providerError = data.error_description ?? data.error;
+			throw new Error(`Token exchange returned no access token${providerError ? `: ${providerError}` : ""}`);
+		}
 
 		// Calculate expiry timestamp
 		const expiresIn = data.expires_in ?? 3600; // Default to 1 hour

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1793,16 +1793,22 @@ export class MCPCommandController {
 			const oauth = await this.#resolveOAuthEndpointsFromServer(runtimeBaseConfig, options.authChallenge);
 			const serverUrl =
 				runtimeBaseConfig.type === "http" || runtimeBaseConfig.type === "sse" ? runtimeBaseConfig.url : undefined;
-			// A user-supplied client secret may live in either block (the wizard
-			// writes it to auth.clientSecret); DCR secrets are embedded in the
-			// stored credential and never echoed back into config files.
-			const configuredClientId = found.config.oauth?.clientId ?? currentAuth?.clientId;
+			// Client credentials drive the token exchange, so they must come from the
+			// env-expanded runtime config; `found.config`/`currentAuth` may still hold
+			// `${...}` placeholders (the wizard writes the secret to auth.clientSecret).
+			// DCR secrets are embedded in the stored credential and never echoed back
+			// into config files.
+			const runtimeAuth = currentAuth ? expandEnvVarsDeep(currentAuth) : undefined;
+			const configuredClientId = runtimeBaseConfig.oauth?.clientId ?? runtimeAuth?.clientId;
 			const existingCredential = lookupMcpOAuthCredentialForServer(authStorage, currentAuth, serverUrl)?.credential;
 			const flowClientId = oauth.clientId ?? configuredClientId ?? existingCredential?.clientId ?? "";
 			const storedClientSecret =
 				existingCredential?.clientId === flowClientId ? existingCredential.clientSecret : undefined;
+			const flowClientSecret =
+				runtimeBaseConfig.oauth?.clientSecret ?? runtimeAuth?.clientSecret ?? storedClientSecret ?? "";
+			// Persisted separately below: keep the raw `${...}` placeholder in the file
+			// rather than writing the resolved secret back to (possibly shared) config.
 			const userClientSecret = found.config.oauth?.clientSecret ?? currentAuth?.clientSecret;
-			const flowClientSecret = userClientSecret ?? storedClientSecret ?? "";
 
 			if (!options.silent) {
 				this.#showMessage(["", theme.fg("muted", `Reauthorizing "${name}"...`), ""].join("\n"));

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -557,4 +557,68 @@ describe("/mcp auth commands", () => {
 		) as TestConfigFile;
 		expect(userConfig.mcpServers?.discovered).toBeUndefined();
 	});
+
+	test("passes env-expanded OAuth client credentials to the reauth flow", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		Bun.env.MCP_OAUTH_CLIENT_ID = "expanded-client-id";
+		Bun.env.MCP_OAUTH_CLIENT_SECRET = "expanded-client-secret";
+		await Bun.write(
+			configPath,
+			`${JSON.stringify(
+				{
+					mcpServers: {
+						envserver: {
+							type: "http",
+							url: RAW_SERVER_URL,
+							oauth: {
+								clientId: "${MCP_OAUTH_CLIENT_ID}",
+								clientSecret: "${MCP_OAUTH_CLIENT_SECRET}",
+							},
+						},
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		try {
+			vi.spyOn(mcpClient, "connectToServer").mockRejectedValue(AUTH_ERROR);
+			let flowClientId: string | undefined;
+			let flowClientSecret: string | undefined;
+			vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockImplementation(async function (
+				this: oauthFlow.MCPOAuthFlow,
+			) {
+				// MCPOAuthFlow keeps its config private; read it back to assert the
+				// resolved credentials the flow will use. Structurally known shape,
+				// no runtime validation is meaningful here.
+				const flow = this as unknown as { config: { clientId?: string; clientSecret?: string } };
+				flowClientId = flow.config.clientId;
+				flowClientSecret = flow.config.clientSecret;
+				return {
+					access: "fresh-access",
+					refresh: "fresh-refresh",
+					expires: Date.now() + 3_600_000,
+				};
+			});
+			const { controller, showError } = createController(authStorage);
+
+			await controller.handle("/mcp reauth envserver");
+
+			expect(showError).not.toHaveBeenCalled();
+			// The token exchange must receive the resolved secret, not the literal
+			// `${...}` placeholder.
+			expect(flowClientId).toBe("expanded-client-id");
+			expect(flowClientSecret).toBe("expanded-client-secret");
+
+			// The config file keeps the placeholder; only the flow sees the value.
+			const saved = JSON.parse(await Bun.file(configPath).text()) as TestConfigFile;
+			const savedServer = saved.mcpServers?.envserver;
+			expect(savedServer?.oauth?.clientSecret).toBe("${MCP_OAUTH_CLIENT_SECRET}");
+			expect(savedServer?.oauth?.clientId).toBe("${MCP_OAUTH_CLIENT_ID}");
+		} finally {
+			delete Bun.env.MCP_OAUTH_CLIENT_ID;
+			delete Bun.env.MCP_OAUTH_CLIENT_SECRET;
+		}
+	});
 });

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -561,6 +561,8 @@ describe("/mcp auth commands", () => {
 	test("passes env-expanded OAuth client credentials to the reauth flow", async () => {
 		const authStorage = freshAuthStorage();
 		await authStorage.reload();
+		const originalClientId = Bun.env.MCP_OAUTH_CLIENT_ID;
+		const originalClientSecret = Bun.env.MCP_OAUTH_CLIENT_SECRET;
 		Bun.env.MCP_OAUTH_CLIENT_ID = "expanded-client-id";
 		Bun.env.MCP_OAUTH_CLIENT_SECRET = "expanded-client-secret";
 		await Bun.write(
@@ -617,8 +619,8 @@ describe("/mcp auth commands", () => {
 			expect(savedServer?.oauth?.clientSecret).toBe("${MCP_OAUTH_CLIENT_SECRET}");
 			expect(savedServer?.oauth?.clientId).toBe("${MCP_OAUTH_CLIENT_ID}");
 		} finally {
-			delete Bun.env.MCP_OAUTH_CLIENT_ID;
-			delete Bun.env.MCP_OAUTH_CLIENT_SECRET;
+			restoreEnvValue("MCP_OAUTH_CLIENT_ID", originalClientId);
+			restoreEnvValue("MCP_OAUTH_CLIENT_SECRET", originalClientSecret);
 		}
 	});
 });

--- a/packages/coding-agent/test/oauth-flow.test.ts
+++ b/packages/coding-agent/test/oauth-flow.test.ts
@@ -344,6 +344,44 @@ describe("mcp oauth flow", () => {
 		});
 	});
 
+	it("rejects an HTTP-200 token response that carries no access token", async () => {
+		let observedRedirectUri = "";
+		const flow = new MCPOAuthFlow(
+			{
+				authorizationUrl: "https://provider.example/authorize",
+				tokenUrl: "https://provider.example/token",
+				clientId: "client-id",
+				clientSecret: "client-secret",
+				callbackPort: 14569,
+				fetch: async input => {
+					const url = String(input);
+					if (url === "https://provider.example/token") {
+						// Slack Web API error shape: HTTP 200 with `ok:false` and no
+						// `access_token`. Accepting it would store an empty credential.
+						return new Response(JSON.stringify({ ok: false, error: "bad_client_secret" }), {
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						});
+					}
+					throw new Error(`Unexpected fetch: ${url}`);
+				},
+			},
+			{
+				onAuth: info => {
+					const authUrl = new URL(info.url);
+					observedRedirectUri = authUrl.searchParams.get("redirect_uri") ?? "";
+					const state = authUrl.searchParams.get("state") ?? "";
+					queueMicrotask(() => {
+						void completeLocalOAuthCallback(`${observedRedirectUri}?code=test-code&state=${state}`);
+					});
+				},
+				signal: AbortSignal.timeout(1_000),
+			},
+		);
+
+		await expect(flow.login()).rejects.toThrow(/bad_client_secret/);
+	});
+
 	it("preserves root redirectUri values without adding a trailing slash", async () => {
 		let observedRedirectUri = "";
 		let tokenRequestBody = "";


### PR DESCRIPTION
## Repro
With an OMP-native `mcp.json` whose OAuth block uses `${VAR}` placeholders (e.g. Slack's `"clientSecret": "${SLACK_CLIENT_SECRET}"`), `/mcp reauth slack` completes the browser flow but stores no access token; the connection then fails with `HTTP 401 ... invalid_token`. Replacing the placeholder with the literal secret makes reauth succeed. Reproduced with `bun test test/mcp-command-reauth.test.ts test/oauth-flow.test.ts`: a reauth run with `${...}` credentials passed the literal placeholder to the flow, and a token exchange returning HTTP 200 with `{ ok: false, error }` resolved instead of rejecting.

## Cause
In `MCPCommandController.#handleReauth` (`packages/coding-agent/src/modes/controllers/mcp-command-controller.ts`), `runtimeBaseConfig = expandEnvVarsDeep(baseConfig)` was used for URL/resource, but the OAuth client credentials were selected from the raw, unexpanded config (`found.config.oauth?.clientId` / `currentAuth?.clientId` and the matching `clientSecret`), so `${VAR}` placeholders were sent literally into `MCPOAuthFlow`. A secondary defect masked the failure: `MCPOAuthFlow.exchangeToken()` (`packages/coding-agent/src/mcp/oauth-flow.ts`) accepted any `response.ok` body and returned `data.access_token` without checking it is a non-empty string, so a Slack-style HTTP-200 error body yielded an empty access token that only surfaced as `invalid_token` on a later request.

## Fix
- Select `flowClientId` / `flowClientSecret` from `runtimeBaseConfig.oauth` and the env-expanded `auth` block; keep the raw `${...}` placeholder for the persisted config file so shared/committed configs never gain a resolved secret.
- `exchangeToken()` now rejects a token response lacking a non-empty `access_token`, including the sanitized provider `error_description`/`error` when present.
- Added regression tests: env-expanded credentials reach the reauth flow while the file keeps the placeholder, and an HTTP-200 token error body rejects.

## Verification
`bun test test/mcp-command-reauth.test.ts test/oauth-flow.test.ts` -> 59 pass, 0 fail (both new tests fail before the fix, pass after). Fixes #7440