### PR TITLE
feat(gateway): opt-in Vercel AI Gateway Zero Data Retention

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -534,6 +534,7 @@ Gateway routing (only applied when `baseUrl` matches the gateway):
 
 - `openRouterRouting.only` / `openRouterRouting.order` — provider routing on `openrouter.ai` (see <https://openrouter.ai/docs/provider-routing>).
 - `vercelGatewayRouting.only` / `vercelGatewayRouting.order` — provider routing on `ai-gateway.vercel.sh` (see <https://vercel.com/docs/ai-gateway/models-and-providers/provider-options>).
+- `vercelGatewayRouting.zeroDataRetention` — restrict routing to providers with zero data retention agreements (see <https://vercel.com/docs/ai-gateway/security-and-compliance/zdr>).
 
 Provider-level `compat` is the baseline; per-model `compat` is deep-merged on top, with
 `openRouterRouting`, `vercelGatewayRouting`, `extraBody`, and `whenThinking` merged as nested objects.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Added
 
-- Added opt-in Vercel AI Gateway per-request Zero Data Retention (`zeroDataRetention`) across Chat Completions, Responses, and Anthropic Messages transports, emitted under `providerOptions.gateway` alongside existing `only`/`order` routing.
+- Added opt-in Vercel AI Gateway per-request Zero Data Retention (`zeroDataRetention`) across Chat Completions, Responses, and Anthropic Messages transports, emitted under `providerOptions.gateway` alongside existing `only`/`order` routing ([#7446](https://github.com/can1357/oh-my-pi/pull/7446) by [@sjdweb](https://github.com/sjdweb)).
 
 ### Fixed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Replaced `arktype` with `@oh-my-pi/omptype` for schema validation, delivering up to 100x faster schema construction and 60-100x faster validation while maintaining full compatibility with existing `type`/`Type` exports and the `isArkSchema` contract.
 
+### Added
+
+- Added opt-in Vercel AI Gateway per-request Zero Data Retention (`zeroDataRetention`) for Chat Completions and Responses, emitted under `providerOptions.gateway` alongside existing `only`/`order`/`caching` routing.
+
 ### Fixed
 
 - Fixed OpenAI-Codex (ChatGPT OAuth) requests failing with an `Unsupported service_tier: auto` error on default or legacy sessions by omitting the implicit `auto` service tier on the wire.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in Vercel AI Gateway per-request Zero Data Retention (`zeroDataRetention`) across Chat Completions, Responses, and Anthropic Messages transports, emitted under `providerOptions.gateway` alongside existing `only`/`order` routing ([#7446](https://github.com/can1357/oh-my-pi/pull/7446) by [@sjdweb](https://github.com/sjdweb)).
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed
 
 - Replaced `arktype` with `@oh-my-pi/omptype` for schema validation, delivering up to 100x faster schema construction and 60-100x faster validation while maintaining full compatibility with existing `type`/`Type` exports and the `isArkSchema` contract.
-
-### Added
-
-- Added opt-in Vercel AI Gateway per-request Zero Data Retention (`zeroDataRetention`) across Chat Completions, Responses, and Anthropic Messages transports, emitted under `providerOptions.gateway` alongside existing `only`/`order` routing ([#7446](https://github.com/can1357/oh-my-pi/pull/7446) by [@sjdweb](https://github.com/sjdweb)).
 
 ### Fixed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Added
 
-- Added opt-in Vercel AI Gateway per-request Zero Data Retention (`zeroDataRetention`) for Chat Completions and Responses, emitted under `providerOptions.gateway` alongside existing `only`/`order`/`caching` routing.
+- Added opt-in Vercel AI Gateway per-request Zero Data Retention (`zeroDataRetention`) across Chat Completions, Responses, and Anthropic Messages transports, emitted under `providerOptions.gateway` alongside existing `only`/`order` routing.
 
 ### Fixed
 

--- a/packages/ai/src/providers/anthropic-wire.ts
+++ b/packages/ai/src/providers/anthropic-wire.ts
@@ -221,6 +221,20 @@ export type ContextManagement = {
 	edits: Array<{ type: "clear_thinking_20251015"; keep: "all" }>;
 };
 
+/**
+ * Vercel AI Gateway per-request `providerOptions.gateway` wire shape. The
+ * gateway accepts this nested object in the Messages body (docs: per-request
+ * ZDR / provider routing); the Anthropic SDK types don't model it, so it is
+ * declared here alongside every other first-class request field.
+ */
+export interface AnthropicGatewayProviderOptionsWire {
+	gateway?: {
+		only?: string[];
+		order?: string[];
+		zeroDataRetention?: boolean;
+	};
+}
+
 export type MessageCreateParams = {
 	model: string;
 	messages: MessageParam[];
@@ -246,6 +260,11 @@ export type MessageCreateParams = {
 	 * header: `server-side-fallback-2026-06-01`.
 	 */
 	fallbacks?: FallbackParam[];
+	/**
+	 * Vercel AI Gateway provider options carried verbatim in the Messages body
+	 * (see {@link AnthropicGatewayProviderOptionsWire}).
+	 */
+	providerOptions?: AnthropicGatewayProviderOptionsWire;
 };
 
 export type MessageCreateParamsStreaming = MessageCreateParams & { stream: true };

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -45,6 +45,7 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 	Usage,
+	VercelGatewayRouting,
 } from "../types";
 import { isRecord, normalizeSystemPrompts, normalizeToolCallId, resolveCacheRetention } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
@@ -3627,8 +3628,28 @@ function buildParams(
 	applyPromptCaching(params, cacheControl);
 	enforceCacheControlLimit(params, 4);
 	normalizeCacheControlTtlOrdering(params);
+	applyAnthropicGatewayRouting(params, model);
 
 	return params;
+}
+
+/**
+ * Forward Vercel AI Gateway routing preferences on the Anthropic Messages
+ * transport. The gateway accepts `providerOptions.gateway` directly in the
+ * Messages body (its ZDR docs carry the field with @ts-expect-error because
+ * the Anthropic SDK does not type it); `caching` stays on the Chat/Responses
+ * surfaces (#6410), so only routing and `zeroDataRetention` are forwarded here.
+ */
+function applyAnthropicGatewayRouting(params: MessageCreateParamsStreaming, model: Model<"anthropic-messages">): void {
+	const compat = model.compat;
+	if (!compat.isVercelGatewayHost || !compat.vercelGatewayRouting) return;
+	const routing = compat.vercelGatewayRouting;
+	const gateway: Pick<VercelGatewayRouting, "only" | "order" | "zeroDataRetention"> = {};
+	if (routing.only) gateway.only = routing.only;
+	if (routing.order) gateway.order = routing.order;
+	if (routing.zeroDataRetention) gateway.zeroDataRetention = true;
+	if (!gateway.only && !gateway.order && !gateway.zeroDataRetention) return;
+	(params as MessageCreateParamsStreaming & { providerOptions?: unknown }).providerOptions = { gateway };
 }
 
 const EMPTY_ERROR_TOOL_RESULT_TEXT = "Tool failed with no output.";

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3647,9 +3647,11 @@ function applyAnthropicGatewayRouting(params: MessageCreateParamsStreaming, mode
 	const gateway: Pick<VercelGatewayRouting, "only" | "order" | "zeroDataRetention"> = {};
 	if (routing.only) gateway.only = routing.only;
 	if (routing.order) gateway.order = routing.order;
-	if (routing.zeroDataRetention) gateway.zeroDataRetention = true;
+	// The ZDR retention claim additionally requires the actual Vercel hostname:
+	// a models.yml baseUrl override may point the provider id at another proxy.
+	if (compat.isVercelGatewayUrl && routing.zeroDataRetention) gateway.zeroDataRetention = true;
 	if (!gateway.only && !gateway.order && !gateway.zeroDataRetention) return;
-	(params as MessageCreateParamsStreaming & { providerOptions?: unknown }).providerOptions = { gateway };
+	params.providerOptions = { gateway };
 }
 
 const EMPTY_ERROR_TOOL_RESULT_TEXT = "Tool failed with no output.";

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -621,9 +621,13 @@ export function resolveOpenAIOutputTokenParam(
 	return { field: input.field, value };
 }
 
+type VercelGatewayProviderOptions = {
+	gateway?: Pick<VercelGatewayRouting, "only" | "order" | "caching" | "zeroDataRetention">;
+};
+
 export interface OpenAIGatewayRoutingParams {
 	provider?: OpenRouterRouting;
-	providerOptions?: { gateway?: Pick<VercelGatewayRouting, "only" | "order" | "caching" | "zeroDataRetention"> };
+	providerOptions?: VercelGatewayProviderOptions;
 }
 
 export interface OpenAIGatewayRoutingCompat {
@@ -752,14 +756,15 @@ export function applyOpenAIExtraBody<P extends object>(
 	const existingProviderOptions = (params as Record<string, unknown>).providerOptions;
 	const incomingProviderOptions = extraBody.providerOptions;
 	if (isRecord(existingProviderOptions) && isRecord(existingProviderOptions.gateway)) {
+		const existingGateway = existingProviderOptions.gateway;
 		const mergedProviderOptions = { ...existingProviderOptions };
 		if (isRecord(incomingProviderOptions)) {
 			Object.assign(mergedProviderOptions, incomingProviderOptions);
 		}
 		const incomingGateway = isRecord(incomingProviderOptions) ? incomingProviderOptions.gateway : undefined;
-		if (isRecord(incomingGateway)) {
-			mergedProviderOptions.gateway = { ...incomingGateway, ...existingProviderOptions.gateway };
-		}
+		mergedProviderOptions.gateway = isRecord(incomingGateway)
+			? { ...incomingGateway, ...existingGateway }
+			: existingGateway;
 		Object.assign(params, { ...extraBody, providerOptions: mergedProviderOptions });
 	} else {
 		Object.assign(params, extraBody);
@@ -792,7 +797,7 @@ export type OpenAICompletionsParams = Omit<ChatCompletionCreateParamsStreaming, 
 	service_tier?: ServiceTier;
 	tool_stream?: boolean;
 	provider?: OpenAICompat["openRouterRouting"];
-	providerOptions?: { gateway?: { only?: string[]; order?: string[] } };
+	providerOptions?: VercelGatewayProviderOptions;
 };
 
 /** Reasoning-relevant slice of caller options the Chat Completions dialect dispatch reads. */

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -745,21 +745,21 @@ export function applyOpenAIExtraBody<P extends object>(
 	// `params.providerOptions` may already carry the Vercel gateway routing block
 	// emitted by applyOpenAIGatewayRouting / applyVercelResponsesCacheControls. A
 	// wholesale assign would silently drop zeroDataRetention/only/order/caching
-	// when compat.extraBody.providerOptions is also present. Deep-merge the nested
-	// `gateway` object so the typed routing constraint always survives; the typed
-	// value wins on conflicts.
+	// when compat.extraBody.providerOptions is also present. Preserve the typed
+	// gateway block across the merge of any extraBody.providerOptions shape
+	// (including null/primitives), deep-merging the nested `gateway` when the
+	// incoming value is a record; the typed value wins on conflicts.
 	const existingProviderOptions = (params as Record<string, unknown>).providerOptions;
 	const incomingProviderOptions = extraBody.providerOptions;
-	if (
-		isRecord(existingProviderOptions) &&
-		isRecord(incomingProviderOptions) &&
-		(isRecord(existingProviderOptions.gateway) || isRecord(incomingProviderOptions.gateway))
-	) {
-		const mergedProviderOptions = { ...existingProviderOptions, ...incomingProviderOptions };
-		mergedProviderOptions.gateway = {
-			...(isRecord(incomingProviderOptions.gateway) ? incomingProviderOptions.gateway : {}),
-			...(isRecord(existingProviderOptions.gateway) ? existingProviderOptions.gateway : {}),
-		};
+	if (isRecord(existingProviderOptions) && isRecord(existingProviderOptions.gateway)) {
+		const mergedProviderOptions = { ...existingProviderOptions };
+		if (isRecord(incomingProviderOptions)) {
+			Object.assign(mergedProviderOptions, incomingProviderOptions);
+		}
+		const incomingGateway = isRecord(incomingProviderOptions) ? incomingProviderOptions.gateway : undefined;
+		if (isRecord(incomingGateway)) {
+			mergedProviderOptions.gateway = { ...incomingGateway, ...existingProviderOptions.gateway };
+		}
 		Object.assign(params, { ...extraBody, providerOptions: mergedProviderOptions });
 	} else {
 		Object.assign(params, extraBody);

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -63,6 +63,7 @@ export type { OpenAIPromptCacheOptions } from "../types";
 import {
 	getOpenAIResponsesHistoryItems,
 	getOpenAIResponsesHistoryPayload,
+	isRecord,
 	normalizeResponsesToolCallId,
 	normalizeSystemPrompts,
 	resolveCacheRetention,
@@ -629,6 +630,8 @@ export interface OpenAIGatewayRoutingCompat {
 	isOpenRouterHost: boolean;
 	openRouterRouting?: OpenRouterRouting;
 	isVercelGatewayHost?: boolean;
+	/** baseUrl actually matches the Vercel AI Gateway hostname; gates the ZDR retention claim. */
+	isVercelGatewayUrl?: boolean;
 	vercelGatewayRouting?: VercelGatewayRouting;
 }
 
@@ -649,7 +652,12 @@ export function applyOpenAIGatewayRouting(
 	}
 	if (compat.isVercelGatewayHost && compat.vercelGatewayRouting) {
 		const routing = compat.vercelGatewayRouting;
-		if (routing.only || routing.order || routing.zeroDataRetention || (emitCaching && routing.caching)) {
+		if (
+			routing.only ||
+			routing.order ||
+			(compat.isVercelGatewayUrl && routing.zeroDataRetention) ||
+			(emitCaching && routing.caching)
+		) {
 			const gatewayOptions: Pick<VercelGatewayRouting, "only" | "order" | "caching" | "zeroDataRetention"> = {};
 			if (routing.only) gatewayOptions.only = routing.only;
 			if (routing.order) gatewayOptions.order = routing.order;
@@ -657,7 +665,9 @@ export function applyOpenAIGatewayRouting(
 			// ZDR is a routing constraint, not a cache preference: emit it regardless
 			// of cache retention, and only when explicitly requested (docs: "If
 			// zeroDataRetention is false or not set, there is no ZDR enforcement").
-			if (routing.zeroDataRetention) gatewayOptions.zeroDataRetention = true;
+			// The retention claim additionally requires the actual Vercel hostname:
+			// a models.yml baseUrl override may point the provider id elsewhere.
+			if (compat.isVercelGatewayUrl && routing.zeroDataRetention) gatewayOptions.zeroDataRetention = true;
 			params.providerOptions = { gateway: gatewayOptions };
 		}
 	}
@@ -672,6 +682,8 @@ export interface VercelResponsesCacheParams {
 
 export interface VercelResponsesCacheCompat {
 	isVercelGatewayHost: boolean;
+	/** baseUrl actually matches the Vercel AI Gateway hostname; gates the ZDR retention claim. */
+	isVercelGatewayUrl?: boolean;
 	vercelGatewayRouting?: VercelGatewayRouting;
 }
 
@@ -688,14 +700,16 @@ export function applyVercelResponsesCacheControls(
 	const routing = compat.vercelGatewayRouting;
 	if (!compat.isVercelGatewayHost) return;
 
-	if (routing?.only || routing?.order || routing?.zeroDataRetention) {
+	if (routing?.only || routing?.order || (compat.isVercelGatewayUrl && routing?.zeroDataRetention)) {
 		const gateway: Pick<VercelGatewayRouting, "only" | "order" | "zeroDataRetention"> = {};
 		if (routing.only) gateway.only = routing.only;
 		if (routing.order) gateway.order = routing.order;
 		// Request-scoped ZDR is independent of cache retention and caching mode:
 		// the gateway filters to ZDR-compliant providers before any fallback or
-		// cache planning runs. Emit only on the explicit `true` from config.
-		if (routing.zeroDataRetention) gateway.zeroDataRetention = true;
+		// cache planning runs. Emit only on the explicit `true` from config AND
+		// only when the request actually goes to Vercel (baseUrl overrides must
+		// not claim a retention guarantee the endpoint won't enforce).
+		if (compat.isVercelGatewayUrl && routing?.zeroDataRetention) gateway.zeroDataRetention = true;
 		params.providerOptions = { gateway };
 	}
 
@@ -728,7 +742,28 @@ export function applyOpenAIExtraBody<P extends object>(
 	options?: OpenAIExtraBodyOptions,
 ): void {
 	if (!extraBody) return;
-	Object.assign(params, extraBody);
+	// `params.providerOptions` may already carry the Vercel gateway routing block
+	// emitted by applyOpenAIGatewayRouting / applyVercelResponsesCacheControls. A
+	// wholesale assign would silently drop zeroDataRetention/only/order/caching
+	// when compat.extraBody.providerOptions is also present. Deep-merge the nested
+	// `gateway` object so the typed routing constraint always survives; the typed
+	// value wins on conflicts.
+	const existingProviderOptions = (params as Record<string, unknown>).providerOptions;
+	const incomingProviderOptions = extraBody.providerOptions;
+	if (
+		isRecord(existingProviderOptions) &&
+		isRecord(incomingProviderOptions) &&
+		(isRecord(existingProviderOptions.gateway) || isRecord(incomingProviderOptions.gateway))
+	) {
+		const mergedProviderOptions = { ...existingProviderOptions, ...incomingProviderOptions };
+		mergedProviderOptions.gateway = {
+			...(isRecord(incomingProviderOptions.gateway) ? incomingProviderOptions.gateway : {}),
+			...(isRecord(existingProviderOptions.gateway) ? existingProviderOptions.gateway : {}),
+		};
+		Object.assign(params, { ...extraBody, providerOptions: mergedProviderOptions });
+	} else {
+		Object.assign(params, extraBody);
+	}
 	if (options?.dropThinkingWhenReasoningEffort) {
 		const shaped = params as { reasoning_effort?: unknown; thinking?: unknown };
 		if (shaped.reasoning_effort !== undefined) {

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -622,7 +622,7 @@ export function resolveOpenAIOutputTokenParam(
 
 export interface OpenAIGatewayRoutingParams {
 	provider?: OpenRouterRouting;
-	providerOptions?: { gateway?: Pick<VercelGatewayRouting, "only" | "order" | "caching"> };
+	providerOptions?: { gateway?: Pick<VercelGatewayRouting, "only" | "order" | "caching" | "zeroDataRetention"> };
 }
 
 export interface OpenAIGatewayRoutingCompat {
@@ -640,18 +640,24 @@ export interface OpenAIGatewayRoutingCompat {
 export function applyOpenAIGatewayRouting(
 	params: OpenAIGatewayRoutingParams,
 	compat: OpenAIGatewayRoutingCompat,
-	cacheEnabled = true,
+	// Gates only the `caching` option; `only`/`order`/`zeroDataRetention` are
+	// routing constraints emitted regardless of cache retention.
+	emitCaching = true,
 ): void {
 	if (compat.isOpenRouterHost && compat.openRouterRouting) {
 		params.provider = compat.openRouterRouting;
 	}
 	if (compat.isVercelGatewayHost && compat.vercelGatewayRouting) {
 		const routing = compat.vercelGatewayRouting;
-		if (routing.only || routing.order || (cacheEnabled && routing.caching)) {
-			const gatewayOptions: Pick<VercelGatewayRouting, "only" | "order" | "caching"> = {};
+		if (routing.only || routing.order || routing.zeroDataRetention || (emitCaching && routing.caching)) {
+			const gatewayOptions: Pick<VercelGatewayRouting, "only" | "order" | "caching" | "zeroDataRetention"> = {};
 			if (routing.only) gatewayOptions.only = routing.only;
 			if (routing.order) gatewayOptions.order = routing.order;
-			if (cacheEnabled && routing.caching) gatewayOptions.caching = routing.caching;
+			if (emitCaching && routing.caching) gatewayOptions.caching = routing.caching;
+			// ZDR is a routing constraint, not a cache preference: emit it regardless
+			// of cache retention, and only when explicitly requested (docs: "If
+			// zeroDataRetention is false or not set, there is no ZDR enforcement").
+			if (routing.zeroDataRetention) gatewayOptions.zeroDataRetention = true;
 			params.providerOptions = { gateway: gatewayOptions };
 		}
 	}
@@ -661,7 +667,7 @@ export interface VercelResponsesCacheParams {
 	caching?: "auto";
 	cache_anchor_items?: number;
 	cache_ttl?: "5m" | "1h";
-	providerOptions?: { gateway?: Pick<VercelGatewayRouting, "only" | "order"> };
+	providerOptions?: { gateway?: Pick<VercelGatewayRouting, "only" | "order" | "zeroDataRetention"> };
 }
 
 export interface VercelResponsesCacheCompat {
@@ -682,10 +688,14 @@ export function applyVercelResponsesCacheControls(
 	const routing = compat.vercelGatewayRouting;
 	if (!compat.isVercelGatewayHost) return;
 
-	if (routing?.only || routing?.order) {
-		const gateway: Pick<VercelGatewayRouting, "only" | "order"> = {};
+	if (routing?.only || routing?.order || routing?.zeroDataRetention) {
+		const gateway: Pick<VercelGatewayRouting, "only" | "order" | "zeroDataRetention"> = {};
 		if (routing.only) gateway.only = routing.only;
 		if (routing.order) gateway.order = routing.order;
+		// Request-scoped ZDR is independent of cache retention and caching mode:
+		// the gateway filters to ZDR-compliant providers before any fallback or
+		// cache planning runs. Emit only on the explicit `true` from config.
+		if (routing.zeroDataRetention) gateway.zeroDataRetention = true;
 		params.providerOptions = { gateway };
 	}
 

--- a/packages/ai/test/anthropic-vercel-gateway.test.ts
+++ b/packages/ai/test/anthropic-vercel-gateway.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type { Context, Model, ModelSpec, VercelGatewayRouting } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const context: Context = {
+	messages: [{ role: "user", content: "Hello", timestamp: 0 }],
+};
+
+type Payload = Record<string, unknown>;
+
+function abortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function vercelModel(routing?: VercelGatewayRouting): Model<"anthropic-messages"> {
+	return buildModel({
+		id: "anthropic/claude-sonnet-4.6",
+		name: "Claude Sonnet 4.6",
+		api: "anthropic-messages",
+		provider: "vercel-ai-gateway",
+		baseUrl: "https://ai-gateway.vercel.sh",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		...(routing ? { compat: { vercelGatewayRouting: routing } } : {}),
+	} satisfies ModelSpec<"anthropic-messages">);
+}
+
+function customModel(routing?: VercelGatewayRouting): Model<"anthropic-messages"> {
+	return buildModel({
+		id: "anthropic/claude-sonnet-4.6",
+		name: "Claude Sonnet 4.6",
+		api: "anthropic-messages",
+		provider: "custom",
+		baseUrl: "https://api.example.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		...(routing ? { compat: { vercelGatewayRouting: routing } } : {}),
+	} satisfies ModelSpec<"anthropic-messages">);
+}
+
+function capturePayload(model: Model<"anthropic-messages">): Promise<Payload> {
+	const { promise, resolve } = Promise.withResolvers<Payload>();
+	streamAnthropic(model, context, {
+		apiKey: "test-key",
+		signal: abortedSignal(),
+		onPayload: payload => resolve(payload as Payload),
+	});
+	return promise;
+}
+
+describe("Vercel AI Gateway routing on the Anthropic transport", () => {
+	it("forwards routing and zeroDataRetention as providerOptions.gateway", async () => {
+		const payload = await capturePayload(
+			vercelModel({ only: ["bedrock"], order: ["anthropic", "bedrock"], zeroDataRetention: true }),
+		);
+		expect(payload.providerOptions).toEqual({
+			gateway: { only: ["bedrock"], order: ["anthropic", "bedrock"], zeroDataRetention: true },
+		});
+	});
+
+	it("emits zeroDataRetention alone without a routing preference", async () => {
+		const payload = await capturePayload(vercelModel({ zeroDataRetention: true }));
+		expect(payload.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });
+	});
+
+	it("leaves unset, disabled, and non-Vercel requests unchanged", async () => {
+		const [unset, disabled, nonVercel] = await Promise.all([
+			capturePayload(vercelModel()),
+			capturePayload(vercelModel({ zeroDataRetention: false })),
+			capturePayload(customModel({ zeroDataRetention: true })),
+		]);
+		for (const payload of [unset, disabled, nonVercel]) {
+			expect(payload.providerOptions).toBeUndefined();
+		}
+	});
+});

--- a/packages/ai/test/anthropic-vercel-gateway.test.ts
+++ b/packages/ai/test/anthropic-vercel-gateway.test.ts
@@ -72,6 +72,27 @@ describe("Vercel AI Gateway routing on the Anthropic transport", () => {
 		expect(payload.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });
 	});
 
+	it("drops zeroDataRetention when baseUrl is overridden away from Vercel", async () => {
+		const proxy = buildModel({
+			id: "anthropic/claude-sonnet-4.6",
+			name: "Claude Sonnet 4.6",
+			api: "anthropic-messages",
+			provider: "vercel-ai-gateway",
+			baseUrl: "https://corp-proxy.example",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 16_384,
+			compat: { vercelGatewayRouting: { only: ["bedrock"], zeroDataRetention: true } },
+		} satisfies ModelSpec<"anthropic-messages">);
+
+		// The provider id alone is not enough for a retention claim; only routing
+		// survives a baseUrl override away from the Vercel hostname.
+		const payload = await capturePayload(proxy);
+		expect(payload.providerOptions).toEqual({ gateway: { only: ["bedrock"] } });
+	});
+
 	it("leaves unset, disabled, and non-Vercel requests unchanged", async () => {
 		const [unset, disabled, nonVercel] = await Promise.all([
 			capturePayload(vercelModel()),

--- a/packages/ai/test/anthropic-vercel-gateway.test.ts
+++ b/packages/ai/test/anthropic-vercel-gateway.test.ts
@@ -15,13 +15,16 @@ function abortedSignal(): AbortSignal {
 	return controller.signal;
 }
 
-function vercelModel(routing?: VercelGatewayRouting): Model<"anthropic-messages"> {
+function vercelModel(
+	routing?: VercelGatewayRouting,
+	baseUrl = "https://ai-gateway.vercel.sh",
+): Model<"anthropic-messages"> {
 	return buildModel({
 		id: "anthropic/claude-sonnet-4.6",
 		name: "Claude Sonnet 4.6",
 		api: "anthropic-messages",
 		provider: "vercel-ai-gateway",
-		baseUrl: "https://ai-gateway.vercel.sh",
+		baseUrl,
 		reasoning: false,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -73,24 +76,15 @@ describe("Vercel AI Gateway routing on the Anthropic transport", () => {
 	});
 
 	it("drops zeroDataRetention when baseUrl is overridden away from Vercel", async () => {
-		const proxy = buildModel({
-			id: "anthropic/claude-sonnet-4.6",
-			name: "Claude Sonnet 4.6",
-			api: "anthropic-messages",
-			provider: "vercel-ai-gateway",
-			baseUrl: "https://corp-proxy.example",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 200_000,
-			maxTokens: 16_384,
-			compat: { vercelGatewayRouting: { only: ["bedrock"], zeroDataRetention: true } },
-		} satisfies ModelSpec<"anthropic-messages">);
-
 		// The provider id alone is not enough for a retention claim; only routing
 		// survives a baseUrl override away from the Vercel hostname.
-		const payload = await capturePayload(proxy);
-		expect(payload.providerOptions).toEqual({ gateway: { only: ["bedrock"] } });
+		const routing: VercelGatewayRouting = { only: ["bedrock"], zeroDataRetention: true };
+		const [proxyPayload, lookalikePayload] = await Promise.all([
+			capturePayload(vercelModel(routing, "https://corp-proxy.example")),
+			capturePayload(vercelModel(routing, "https://ai-gateway.vercel.sh.proxy.example")),
+		]);
+		expect(proxyPayload.providerOptions).toEqual({ gateway: { only: ["bedrock"] } });
+		expect(lookalikePayload.providerOptions).toEqual({ gateway: { only: ["bedrock"] } });
 	});
 
 	it("leaves unset, disabled, and non-Vercel requests unchanged", async () => {

--- a/packages/ai/test/issue-967-vision-guard.test.ts
+++ b/packages/ai/test/issue-967-vision-guard.test.ts
@@ -31,6 +31,7 @@ const compat: ResolvedOpenAICompat = {
 	alwaysSendMaxTokens: false,
 	isOpenRouterHost: false,
 	isVercelGatewayHost: false,
+	isVercelGatewayUrl: false,
 	reasoningEffortMap: {},
 	supportsUsageInStreaming: true,
 	supportsToolChoice: true,

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -213,6 +213,7 @@ describe("openai-completions compatibility", () => {
 			alwaysSendMaxTokens: false,
 			isOpenRouterHost: false,
 			isVercelGatewayHost: false,
+			isVercelGatewayUrl: false,
 			wireModelIdMode: "raw",
 			stripDeepseekSpecialTokens: false,
 			reasoningDeltasMayBeCumulative: false,

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -54,6 +54,7 @@ const compat: ResolvedOpenAICompat = {
 	alwaysSendMaxTokens: false,
 	isOpenRouterHost: false,
 	isVercelGatewayHost: false,
+	isVercelGatewayUrl: false,
 	wireModelIdMode: "raw",
 	stripDeepseekSpecialTokens: false,
 	reasoningDeltasMayBeCumulative: false,

--- a/packages/ai/test/openai-output-token-policy.test.ts
+++ b/packages/ai/test/openai-output-token-policy.test.ts
@@ -169,6 +169,7 @@ describe("applyOpenAIGatewayRouting", () => {
 		applyOpenAIGatewayRouting(params, {
 			isOpenRouterHost: false,
 			isVercelGatewayHost: true,
+			isVercelGatewayUrl: true,
 			vercelGatewayRouting: { zeroDataRetention: true },
 		});
 		expect(params.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });

--- a/packages/ai/test/openai-output-token-policy.test.ts
+++ b/packages/ai/test/openai-output-token-policy.test.ts
@@ -164,7 +164,29 @@ describe("applyOpenAIGatewayRouting", () => {
 		expect(params.provider).toBeUndefined();
 	});
 
-	it("ignores Vercel gateway routing with neither only nor order", () => {
+	it("maps Vercel zeroDataRetention to providerOptions.gateway", () => {
+		const params = routingParams();
+		applyOpenAIGatewayRouting(params, {
+			isOpenRouterHost: false,
+			isVercelGatewayHost: true,
+			vercelGatewayRouting: { zeroDataRetention: true },
+		});
+		expect(params.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });
+		expect(params.provider).toBeUndefined();
+	});
+
+	it("omits Vercel zeroDataRetention when false or unset", () => {
+		const compat: OpenAIGatewayRoutingCompat = {
+			isOpenRouterHost: false,
+			isVercelGatewayHost: true,
+			vercelGatewayRouting: { zeroDataRetention: false },
+		};
+		const params = routingParams();
+		applyOpenAIGatewayRouting(params, compat);
+		expect(params.providerOptions).toBeUndefined();
+	});
+
+	it("ignores Vercel gateway routing without routing or zero-data-retention preferences", () => {
 		const params = routingParams();
 		applyOpenAIGatewayRouting(params, {
 			isOpenRouterHost: false,

--- a/packages/ai/test/vercel-gateway-cache-controls.test.ts
+++ b/packages/ai/test/vercel-gateway-cache-controls.test.ts
@@ -215,3 +215,99 @@ describe("Vercel AI Gateway automatic cache controls", () => {
 		}
 	});
 });
+
+describe("Vercel AI Gateway zero data retention", () => {
+	it("maps zeroDataRetention to the documented Chat and Responses request shapes", async () => {
+		const routing: VercelGatewayRouting = { zeroDataRetention: true };
+		const [chat, responses] = await Promise.all([
+			captureChatPayload(vercelChatModel(routing)),
+			captureResponsesPayload(responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing)),
+		]);
+
+		expect(chat.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });
+		expect(chat.caching).toBeUndefined();
+
+		expect(responses.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });
+		expect(responses.caching).toBeUndefined();
+	});
+
+	it("keeps zeroDataRetention beside only/order routing on both surfaces", async () => {
+		const routing: VercelGatewayRouting = {
+			only: ["bedrock"],
+			order: ["anthropic", "bedrock"],
+			zeroDataRetention: true,
+		};
+		const [chat, responses] = await Promise.all([
+			captureChatPayload(vercelChatModel(routing)),
+			captureResponsesPayload(responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing)),
+		]);
+
+		expect(chat.providerOptions).toEqual({
+			gateway: { only: ["bedrock"], order: ["anthropic", "bedrock"], zeroDataRetention: true },
+		});
+		expect(responses.providerOptions).toEqual({
+			gateway: { only: ["bedrock"], order: ["anthropic", "bedrock"], zeroDataRetention: true },
+		});
+	});
+
+	it("keeps zeroDataRetention while suppressing caching when cache retention is none", async () => {
+		const routing: VercelGatewayRouting = { caching: "auto", zeroDataRetention: true };
+		const [chat, responses] = await Promise.all([
+			captureChatPayload(vercelChatModel(routing), { cacheRetention: "none" }),
+			captureResponsesPayload(responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing), {
+				cacheRetention: "none",
+			}),
+		]);
+
+		// ZDR is a routing constraint, not a cache preference: `none` retention
+		// suppresses `caching` but must not silently drop zeroDataRetention.
+		expect(chat.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });
+		expect(chat.caching).toBeUndefined();
+
+		expect(responses.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });
+		expect(responses.caching).toBeUndefined();
+	});
+
+	it("keeps zeroDataRetention while suppressing caching when PI_CACHE_RETENTION is none", async () => {
+		const routing: VercelGatewayRouting = { caching: "auto", zeroDataRetention: true };
+		await withEnv({ PI_CACHE_RETENTION: "none" }, async () => {
+			const [chat, responses] = await Promise.all([
+				captureChatPayload(vercelChatModel(routing)),
+				captureResponsesPayload(responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing)),
+			]);
+
+			expect(chat.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });
+			expect(chat.caching).toBeUndefined();
+
+			expect(responses.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });
+			expect(responses.caching).toBeUndefined();
+		});
+	});
+
+	it("emits nothing for unset, disabled, or non-Vercel hosts", async () => {
+		const nonVercelChat = buildModel({
+			id: "anthropic/claude-sonnet-4.6",
+			name: "Claude Sonnet 4.6",
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://api.example.com/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 16_384,
+			compat: { vercelGatewayRouting: { zeroDataRetention: true } },
+		} satisfies ModelSpec<"openai-completions">);
+
+		const [unsetChat, disabledChat, nonVercelChatPayload, nonVercelResponses] = await Promise.all([
+			captureChatPayload(vercelChatModel()),
+			captureChatPayload(vercelChatModel({ zeroDataRetention: false })),
+			captureChatPayload(nonVercelChat),
+			captureResponsesPayload(responsesModel("custom", "https://api.example.com/v1", { zeroDataRetention: true })),
+		]);
+
+		for (const payload of [unsetChat, disabledChat, nonVercelChatPayload, nonVercelResponses]) {
+			expect(payload.providerOptions).toBeUndefined();
+		}
+	});
+});

--- a/packages/ai/test/vercel-gateway-cache-controls.test.ts
+++ b/packages/ai/test/vercel-gateway-cache-controls.test.ts
@@ -3,6 +3,7 @@ import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-comple
 import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import type { Context, Model, ModelSpec, VercelGatewayRouting } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { withEnv } from "./helpers";
 
 const context: Context = {
@@ -19,7 +20,12 @@ function abortedSignal(): AbortSignal {
 
 function vercelChatModel(
 	routing?: VercelGatewayRouting,
-	options: { baseUrl?: string; extraBody?: Record<string, unknown> } = {},
+	options: {
+		baseUrl?: string;
+		extraBody?: Record<string, unknown>;
+		reasoning?: boolean;
+		whenThinkingRouting?: VercelGatewayRouting;
+	} = {},
 ): Model<"openai-completions"> {
 	return buildModel({
 		id: "anthropic/claude-sonnet-4.6",
@@ -27,13 +33,21 @@ function vercelChatModel(
 		api: "openai-completions",
 		provider: "vercel-ai-gateway",
 		baseUrl: options.baseUrl ?? "https://ai-gateway.vercel.sh/v1",
-		reasoning: false,
+		reasoning: options.reasoning ?? false,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 200_000,
 		maxTokens: 16_384,
-		...(routing || options.extraBody
-			? { compat: { vercelGatewayRouting: routing, extraBody: options.extraBody } }
+		...(routing || options.extraBody || options.whenThinkingRouting
+			? {
+					compat: {
+						vercelGatewayRouting: routing,
+						extraBody: options.extraBody,
+						whenThinking: options.whenThinkingRouting
+							? { vercelGatewayRouting: options.whenThinkingRouting }
+							: undefined,
+					},
+				}
 			: {}),
 	} satisfies ModelSpec<"openai-completions">);
 }
@@ -56,7 +70,11 @@ function responsesModel(provider: string, baseUrl: string, routing?: VercelGatew
 
 function captureChatPayload(
 	model: Model<"openai-completions">,
-	options: { cacheRetention?: "long" | "short" | "none"; extraBody?: Record<string, unknown> } = {},
+	options: {
+		cacheRetention?: "long" | "short" | "none";
+		extraBody?: Record<string, unknown>;
+		reasoning?: Effort;
+	} = {},
 ): Promise<Payload> {
 	const { promise, resolve } = Promise.withResolvers<Payload>();
 	streamOpenAICompletions(model, context, {
@@ -222,6 +240,49 @@ describe("Vercel AI Gateway automatic cache controls", () => {
 });
 
 describe("Vercel AI Gateway zero data retention", () => {
+	it("preserves baseline routing when a thinking-specific policy adds an upstream", async () => {
+		const payload = await captureChatPayload(
+			vercelChatModel(
+				{ order: ["anthropic", "bedrock"], caching: "auto", zeroDataRetention: true },
+				{
+					reasoning: true,
+					whenThinkingRouting: { only: ["bedrock"] },
+				},
+			),
+			{ reasoning: Effort.High },
+		);
+
+		expect(payload.providerOptions).toEqual({
+			gateway: {
+				only: ["bedrock"],
+				order: ["anthropic", "bedrock"],
+				caching: "auto",
+				zeroDataRetention: true,
+			},
+		});
+	});
+
+	it("honors an explicit thinking-specific ZDR disable without dropping other baseline routing", async () => {
+		const payload = await captureChatPayload(
+			vercelChatModel(
+				{ order: ["anthropic", "bedrock"], caching: "auto", zeroDataRetention: true },
+				{
+					reasoning: true,
+					whenThinkingRouting: { only: ["bedrock"], zeroDataRetention: false },
+				},
+			),
+			{ reasoning: Effort.High },
+		);
+
+		expect(payload.providerOptions).toEqual({
+			gateway: {
+				only: ["bedrock"],
+				order: ["anthropic", "bedrock"],
+				caching: "auto",
+			},
+		});
+	});
+
 	it("maps zeroDataRetention to the documented Chat and Responses request shapes", async () => {
 		const routing: VercelGatewayRouting = { zeroDataRetention: true };
 		const [chat, responses] = await Promise.all([

--- a/packages/ai/test/vercel-gateway-cache-controls.test.ts
+++ b/packages/ai/test/vercel-gateway-cache-controls.test.ts
@@ -51,7 +51,7 @@ function responsesModel(provider: string, baseUrl: string, routing?: VercelGatew
 
 function captureChatPayload(
 	model: Model<"openai-completions">,
-	options: { cacheRetention?: "long" | "short" | "none" } = {},
+	options: { cacheRetention?: "long" | "short" | "none"; extraBody?: Record<string, unknown> } = {},
 ): Promise<Payload> {
 	const { promise, resolve } = Promise.withResolvers<Payload>();
 	streamOpenAICompletions(model, context, {
@@ -65,7 +65,7 @@ function captureChatPayload(
 
 function captureResponsesPayload(
 	model: Model<"openai-responses">,
-	options: { cacheRetention?: "long" | "short" | "none" } = {},
+	options: { cacheRetention?: "long" | "short" | "none"; extraBody?: Record<string, unknown> } = {},
 ): Promise<Payload> {
 	const { promise, resolve } = Promise.withResolvers<Payload>();
 	streamOpenAIResponses(model, context, {
@@ -282,6 +282,85 @@ describe("Vercel AI Gateway zero data retention", () => {
 			expect(responses.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });
 			expect(responses.caching).toBeUndefined();
 		});
+	});
+
+	it("keeps zeroDataRetention when extraBody supplies providerOptions", async () => {
+		const routing: VercelGatewayRouting = { only: ["anthropic"], zeroDataRetention: true };
+		const extraBody = { gateway: { only: ["openai"] } };
+		const chat = buildModel({
+			id: "anthropic/claude-sonnet-4.6",
+			name: "Claude Sonnet 4.6",
+			api: "openai-completions",
+			provider: "vercel-ai-gateway",
+			baseUrl: "https://ai-gateway.vercel.sh/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 16_384,
+			compat: { vercelGatewayRouting: routing, extraBody: { providerOptions: extraBody } },
+		} satisfies ModelSpec<"openai-completions">);
+		const responses = buildModel({
+			id: "anthropic/claude-sonnet-4.6",
+			name: "Claude Sonnet 4.6",
+			api: "openai-responses",
+			provider: "vercel-ai-gateway",
+			baseUrl: "https://ai-gateway.vercel.sh/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 16_384,
+			compat: { vercelGatewayRouting: routing },
+		} satisfies ModelSpec<"openai-responses">);
+
+		// extraBody.providerOptions (documented escape hatch) must not clobber the
+		// typed gateway routing; the typed value wins on conflicts (bot P1).
+		const [chatPayload, responsesPayload] = await Promise.all([
+			captureChatPayload(chat),
+			captureResponsesPayload(responses, { extraBody: { providerOptions: extraBody } }),
+		]);
+		expect(chatPayload.providerOptions).toEqual({ gateway: { only: ["anthropic"], zeroDataRetention: true } });
+		expect(responsesPayload.providerOptions).toEqual({ gateway: { only: ["anthropic"], zeroDataRetention: true } });
+	});
+
+	it("drops zeroDataRetention but keeps routing when baseUrl is overridden away from Vercel", async () => {
+		const routing: VercelGatewayRouting = { only: ["bedrock"], zeroDataRetention: true };
+		const chat = buildModel({
+			id: "anthropic/claude-sonnet-4.6",
+			name: "Claude Sonnet 4.6",
+			api: "openai-completions",
+			provider: "vercel-ai-gateway",
+			baseUrl: "https://corp-proxy.example/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 16_384,
+			compat: { vercelGatewayRouting: routing },
+		} satisfies ModelSpec<"openai-completions">);
+		const responses = buildModel({
+			id: "anthropic/claude-sonnet-4.6",
+			name: "Claude Sonnet 4.6",
+			api: "openai-responses",
+			provider: "vercel-ai-gateway",
+			baseUrl: "https://corp-proxy.example/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 16_384,
+			compat: { vercelGatewayRouting: routing },
+		} satisfies ModelSpec<"openai-responses">);
+
+		// ZDR is a retention claim: a non-Vercel baseUrl must not carry it even
+		// with the provider id intact; only/order stay on the broader routing class.
+		const [chatPayload, responsesPayload] = await Promise.all([
+			captureChatPayload(chat),
+			captureResponsesPayload(responses),
+		]);
+		expect(chatPayload.providerOptions).toEqual({ gateway: { only: ["bedrock"] } });
+		expect(responsesPayload.providerOptions).toEqual({ gateway: { only: ["bedrock"] } });
 	});
 
 	it("emits nothing for unset, disabled, or non-Vercel hosts", async () => {

--- a/packages/ai/test/vercel-gateway-cache-controls.test.ts
+++ b/packages/ai/test/vercel-gateway-cache-controls.test.ts
@@ -17,19 +17,24 @@ function abortedSignal(): AbortSignal {
 	return controller.signal;
 }
 
-function vercelChatModel(routing?: VercelGatewayRouting): Model<"openai-completions"> {
+function vercelChatModel(
+	routing?: VercelGatewayRouting,
+	options: { baseUrl?: string; extraBody?: Record<string, unknown> } = {},
+): Model<"openai-completions"> {
 	return buildModel({
 		id: "anthropic/claude-sonnet-4.6",
 		name: "Claude Sonnet 4.6",
 		api: "openai-completions",
 		provider: "vercel-ai-gateway",
-		baseUrl: "https://ai-gateway.vercel.sh/v1",
+		baseUrl: options.baseUrl ?? "https://ai-gateway.vercel.sh/v1",
 		reasoning: false,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 200_000,
 		maxTokens: 16_384,
-		...(routing ? { compat: { vercelGatewayRouting: routing } } : {}),
+		...(routing || options.extraBody
+			? { compat: { vercelGatewayRouting: routing, extraBody: options.extraBody } }
+			: {}),
 	} satisfies ModelSpec<"openai-completions">);
 }
 
@@ -287,32 +292,8 @@ describe("Vercel AI Gateway zero data retention", () => {
 	it("keeps zeroDataRetention when extraBody supplies providerOptions", async () => {
 		const routing: VercelGatewayRouting = { only: ["anthropic"], zeroDataRetention: true };
 		const extraBody = { gateway: { only: ["openai"] } };
-		const chat = buildModel({
-			id: "anthropic/claude-sonnet-4.6",
-			name: "Claude Sonnet 4.6",
-			api: "openai-completions",
-			provider: "vercel-ai-gateway",
-			baseUrl: "https://ai-gateway.vercel.sh/v1",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 200_000,
-			maxTokens: 16_384,
-			compat: { vercelGatewayRouting: routing, extraBody: { providerOptions: extraBody } },
-		} satisfies ModelSpec<"openai-completions">);
-		const responses = buildModel({
-			id: "anthropic/claude-sonnet-4.6",
-			name: "Claude Sonnet 4.6",
-			api: "openai-responses",
-			provider: "vercel-ai-gateway",
-			baseUrl: "https://ai-gateway.vercel.sh/v1",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 200_000,
-			maxTokens: 16_384,
-			compat: { vercelGatewayRouting: routing },
-		} satisfies ModelSpec<"openai-responses">);
+		const chat = vercelChatModel(routing, { extraBody: { providerOptions: extraBody } });
+		const responses = responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing);
 
 		// extraBody.providerOptions (documented escape hatch) must not clobber the
 		// typed gateway routing; the typed value wins on conflicts (bot P1).
@@ -325,22 +306,7 @@ describe("Vercel AI Gateway zero data retention", () => {
 	});
 
 	it("keeps zeroDataRetention when extraBody.providerOptions is null", async () => {
-		const chat = buildModel({
-			id: "anthropic/claude-sonnet-4.6",
-			name: "Claude Sonnet 4.6",
-			api: "openai-completions",
-			provider: "vercel-ai-gateway",
-			baseUrl: "https://ai-gateway.vercel.sh/v1",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 200_000,
-			maxTokens: 16_384,
-			compat: {
-				vercelGatewayRouting: { zeroDataRetention: true },
-				extraBody: { providerOptions: null },
-			},
-		} satisfies ModelSpec<"openai-completions">);
+		const chat = vercelChatModel({ zeroDataRetention: true }, { extraBody: { providerOptions: null } });
 
 		// A non-record incoming providerOptions must not replace the typed gateway
 		// block (external review P2).
@@ -348,37 +314,47 @@ describe("Vercel AI Gateway zero data retention", () => {
 		expect(payload.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });
 	});
 
+	it.each([null, "invalid", undefined])(
+		"keeps typed gateway routing when extraBody.providerOptions.gateway is %p",
+		async incomingGateway => {
+			const routing: VercelGatewayRouting = { only: ["anthropic"], zeroDataRetention: true };
+			const extraBody = { providerOptions: { gateway: incomingGateway, trace: "kept" } };
+			const chat = vercelChatModel(routing, { extraBody });
+			const responses = responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", routing);
+
+			const [chatPayload, responsesPayload] = await Promise.all([
+				captureChatPayload(chat),
+				captureResponsesPayload(responses, { extraBody }),
+			]);
+			const expected = {
+				gateway: { only: ["anthropic"], zeroDataRetention: true },
+				trace: "kept",
+			};
+			expect(chatPayload.providerOptions).toEqual(expected);
+			expect(responsesPayload.providerOptions).toEqual(expected);
+		},
+	);
+
 	it("drops zeroDataRetention but keeps routing when baseUrl is overridden away from Vercel", async () => {
 		const routing: VercelGatewayRouting = { only: ["bedrock"], zeroDataRetention: true };
-		const chat = buildModel({
-			id: "anthropic/claude-sonnet-4.6",
-			name: "Claude Sonnet 4.6",
-			api: "openai-completions",
-			provider: "vercel-ai-gateway",
-			baseUrl: "https://corp-proxy.example/v1",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 200_000,
-			maxTokens: 16_384,
-			compat: { vercelGatewayRouting: routing },
-		} satisfies ModelSpec<"openai-completions">);
-		const responses = buildModel({
-			id: "anthropic/claude-sonnet-4.6",
-			name: "Claude Sonnet 4.6",
-			api: "openai-responses",
-			provider: "vercel-ai-gateway",
-			baseUrl: "https://corp-proxy.example/v1",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 200_000,
-			maxTokens: 16_384,
-			compat: { vercelGatewayRouting: routing },
-		} satisfies ModelSpec<"openai-responses">);
+		const chat = vercelChatModel(routing, { baseUrl: "https://corp-proxy.example/v1" });
+		const responses = responsesModel("vercel-ai-gateway", "https://corp-proxy.example/v1", routing);
 
 		// ZDR is a retention claim: a non-Vercel baseUrl must not carry it even
 		// with the provider id intact; only/order stay on the broader routing class.
+		const [chatPayload, responsesPayload] = await Promise.all([
+			captureChatPayload(chat),
+			captureResponsesPayload(responses),
+		]);
+		expect(chatPayload.providerOptions).toEqual({ gateway: { only: ["bedrock"] } });
+		expect(responsesPayload.providerOptions).toEqual({ gateway: { only: ["bedrock"] } });
+	});
+
+	it("drops zeroDataRetention for lookalike Vercel hostnames on both OpenAI transports", async () => {
+		const routing: VercelGatewayRouting = { only: ["bedrock"], zeroDataRetention: true };
+		const chat = vercelChatModel(routing, { baseUrl: "https://ai-gateway.vercel.sh.proxy.example/v1" });
+		const responses = responsesModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh.proxy.example/v1", routing);
+
 		const [chatPayload, responsesPayload] = await Promise.all([
 			captureChatPayload(chat),
 			captureResponsesPayload(responses),

--- a/packages/ai/test/vercel-gateway-cache-controls.test.ts
+++ b/packages/ai/test/vercel-gateway-cache-controls.test.ts
@@ -324,6 +324,30 @@ describe("Vercel AI Gateway zero data retention", () => {
 		expect(responsesPayload.providerOptions).toEqual({ gateway: { only: ["anthropic"], zeroDataRetention: true } });
 	});
 
+	it("keeps zeroDataRetention when extraBody.providerOptions is null", async () => {
+		const chat = buildModel({
+			id: "anthropic/claude-sonnet-4.6",
+			name: "Claude Sonnet 4.6",
+			api: "openai-completions",
+			provider: "vercel-ai-gateway",
+			baseUrl: "https://ai-gateway.vercel.sh/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 16_384,
+			compat: {
+				vercelGatewayRouting: { zeroDataRetention: true },
+				extraBody: { providerOptions: null },
+			},
+		} satisfies ModelSpec<"openai-completions">);
+
+		// A non-record incoming providerOptions must not replace the typed gateway
+		// block (external review P2).
+		const payload = await captureChatPayload(chat);
+		expect(payload.providerOptions).toEqual({ gateway: { zeroDataRetention: true } });
+	});
+
 	it("drops zeroDataRetention but keeps routing when baseUrl is overridden away from Vercel", async () => {
 		const routing: VercelGatewayRouting = { only: ["bedrock"], zeroDataRetention: true };
 		const chat = buildModel({

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added
 
-- Added Vercel AI Gateway `zeroDataRetention` routing preference to `VercelGatewayRouting`, configurable per model via `compat.vercelGatewayRouting`.
+- Added Vercel AI Gateway `zeroDataRetention` routing preference to `VercelGatewayRouting`, configurable per model via `compat.vercelGatewayRouting` ([#7446](https://github.com/can1357/oh-my-pi/pull/7446) by [@sjdweb](https://github.com/sjdweb)).
 
 ### Fixed
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 
-## [17.2.7] - 2026-08-03
-
 ### Added
 
 - Added Vercel AI Gateway `zeroDataRetention` routing preference to `VercelGatewayRouting`, configurable per model via `compat.vercelGatewayRouting` ([#7446](https://github.com/can1357/oh-my-pi/pull/7446) by [@sjdweb](https://github.com/sjdweb)).
+
+## [17.2.7] - 2026-08-03
 
 ### Fixed
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [17.2.7] - 2026-08-03
 
+### Added
+
+- Added Vercel AI Gateway `zeroDataRetention` routing preference to `VercelGatewayRouting`, configurable per model via `compat.vercelGatewayRouting`.
+
 ### Fixed
 
 - Fixed an issue where setting `thinking-level: off` failed to disable reasoning on direct DeepSeek V4 requests.

--- a/packages/catalog/src/compat/anthropic.ts
+++ b/packages/catalog/src/compat/anthropic.ts
@@ -130,6 +130,7 @@ export function buildAnthropicCompat(spec: ModelSpec<"anthropic-messages">): Res
 	// (issue #4192).
 	const isZenmux = modelMatchesHost(spec, "zenmux");
 	const requiresThinkingEnabled = modelMatchesHost(spec, "moonshotNative") && matchesKimiMandatoryThinkingModel(spec);
+	const isVercelGateway = modelMatchesHost(spec, "vercelAIGateway");
 	const isAzure = isAzureAnthropicRoute(baseUrl);
 	const signingEndpoint = official || isCopilot || isZenmux || isAnthropicSigningProxyUrl(baseUrl);
 	const compat: ResolvedAnthropicCompat = {
@@ -173,6 +174,10 @@ export function buildAnthropicCompat(spec: ModelSpec<"anthropic-messages">): Res
 		replayUnsignedThinking: !signingEndpoint && (Boolean(spec.reasoning) || modelMatchesHost(spec, "deepseekFamily")),
 		escapeBuiltinToolNames: modelMatchesHost(spec, "umans"),
 		streamIdleTimeoutMs: spec.compat?.streamIdleTimeoutMs,
+		// Vercel AI Gateway accepts `providerOptions.gateway` in the Messages
+		// body itself; the resolved routing block is filled by applyCompatOverrides.
+		isVercelGatewayHost: isVercelGateway,
+		vercelGatewayRouting: undefined,
 	};
 	applyCompatOverrides(compat, spec.compat);
 	return compat;

--- a/packages/catalog/src/compat/anthropic.ts
+++ b/packages/catalog/src/compat/anthropic.ts
@@ -176,7 +176,10 @@ export function buildAnthropicCompat(spec: ModelSpec<"anthropic-messages">): Res
 		streamIdleTimeoutMs: spec.compat?.streamIdleTimeoutMs,
 		// Vercel AI Gateway accepts `providerOptions.gateway` in the Messages
 		// body itself; the resolved routing block is filled by applyCompatOverrides.
+		// ZDR emission additionally requires the URL gate: the provider id alone
+		// survives baseUrl overrides and must not claim Vercel retention.
 		isVercelGatewayHost: isVercelGateway,
+		isVercelGatewayUrl: hostMatchesUrl(baseUrl, "vercelAIGateway"),
 		vercelGatewayRouting: undefined,
 	};
 	applyCompatOverrides(compat, spec.compat);

--- a/packages/catalog/src/compat/anthropic.ts
+++ b/packages/catalog/src/compat/anthropic.ts
@@ -4,7 +4,7 @@
  * defaults come from provider ids, strict host checks, and model-id
  * classification, with explicit spec overrides assigned on top.
  */
-import { hostMatchesUrl, modelMatchesHost } from "../hosts";
+import { hostMatchesUrl, isVercelAIGatewayUrl, modelMatchesHost } from "../hosts";
 import {
 	hasOpus47ApiRestrictions,
 	isAnthropicFableOrMythosModel,
@@ -179,9 +179,11 @@ export function buildAnthropicCompat(spec: ModelSpec<"anthropic-messages">): Res
 		// ZDR emission additionally requires the URL gate: the provider id alone
 		// survives baseUrl overrides and must not claim Vercel retention.
 		isVercelGatewayHost: isVercelGateway,
-		isVercelGatewayUrl: hostMatchesUrl(baseUrl, "vercelAIGateway"),
+		isVercelGatewayUrl: isVercelAIGatewayUrl(baseUrl),
 		vercelGatewayRouting: undefined,
 	};
 	applyCompatOverrides(compat, spec.compat);
+	// Resolved-only retention gate; never trust a raw compat override here.
+	compat.isVercelGatewayUrl = isVercelAIGatewayUrl(baseUrl);
 	return compat;
 }

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -582,6 +582,11 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		isOpenRouterHost: isOpenRouter,
 		wireModelIdMode,
 		isVercelGatewayHost: isVercelGateway,
+		// ZDR is a retention guarantee: it must only be claimed when the request
+		// actually goes to Vercel. Provider-id matching alone is not enough — a
+		// models.yml baseUrl override can point a `vercel-ai-gateway` provider at
+		// an unrelated proxy.
+		isVercelGatewayUrl: hostMatchesUrl(baseUrl, "vercelAIGateway"),
 		supportsStrictMode: detectStrictModeSupport(provider, baseUrl),
 		extraBody: undefined,
 		toolStrictMode: isCerebras ? "all_strict" : "mixed",
@@ -744,6 +749,9 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 		vercelGatewayRouting: undefined,
 		isOpenRouterHost: isOpenRouter,
 		isVercelGatewayHost: isVercelGateway,
+		// ZDR is a retention guarantee: only claim it when the request actually
+		// goes to Vercel (provider-id matching survives baseUrl overrides).
+		isVercelGatewayUrl: hostMatchesUrl(baseUrl, "vercelAIGateway"),
 		wireModelIdMode: isOpenRouter ? "openrouter" : "raw",
 		// Mirrors buildOpenAICompat: Kimi behind a Responses-capable proxy still
 		// lands on Moonshot's MFJS validator.
@@ -783,6 +791,7 @@ function pickResponsesOnly(compat: ResolvedOpenAIResponsesCompat): ResponsesOnly
 		supportsImageDetailOriginal: compat.supportsImageDetailOriginal,
 		supportsObfuscationOptOut: compat.supportsObfuscationOptOut,
 		isVercelGatewayHost: compat.isVercelGatewayHost,
+		isVercelGatewayUrl: compat.isVercelGatewayUrl,
 	} satisfies ResponsesOnlyCompat;
 }
 

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -646,6 +646,14 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	if (whenThinkingPolicy) {
 		const variant: ResolvedOpenAICompat = { ...compat };
 		applyCompatOverrides(variant, whenThinkingPolicy);
+		if (whenThinkingPolicy.vercelGatewayRouting) {
+			variant.vercelGatewayRouting = {
+				...compat.vercelGatewayRouting,
+				...whenThinkingPolicy.vercelGatewayRouting,
+			};
+		}
+		// The retention gate is resolved from baseUrl, not user-overridable compat.
+		variant.isVercelGatewayUrl = compat.isVercelGatewayUrl;
 		if (whenThinkingPolicy.reasoningDisableMode === undefined) {
 			variant.reasoningDisableMode = resolveReasoningDisableMode(variant.thinkingFormat);
 		}

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -8,7 +8,7 @@
  * never detect, resolve, or allocate.
  */
 import { isFireworksFastModelId } from "../fireworks-model-id";
-import { hostMatchesUrl, modelMatchesHost } from "../hosts";
+import { hostMatchesUrl, isVercelAIGatewayUrl, modelMatchesHost } from "../hosts";
 import { bareModelId, parseOpenAIModel, semverGte } from "../identity/classify";
 import {
 	isAnthropicNamespacedModelId,
@@ -586,7 +586,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		// actually goes to Vercel. Provider-id matching alone is not enough — a
 		// models.yml baseUrl override can point a `vercel-ai-gateway` provider at
 		// an unrelated proxy.
-		isVercelGatewayUrl: hostMatchesUrl(baseUrl, "vercelAIGateway"),
+		isVercelGatewayUrl: isVercelAIGatewayUrl(baseUrl),
 		supportsStrictMode: detectStrictModeSupport(provider, baseUrl),
 		extraBody: undefined,
 		toolStrictMode: isCerebras ? "all_strict" : "mixed",
@@ -609,6 +609,9 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	};
 
 	applyCompatOverrides(compat, spec.compat);
+	// Resolved-only retention gate: loosely typed compat input must not be able
+	// to assert a Vercel guarantee for an unrelated endpoint.
+	compat.isVercelGatewayUrl = isVercelAIGatewayUrl(baseUrl);
 	const deepseekThinking = compat.extraBody?.thinking;
 	if (
 		isDirectDeepseekReasoning &&
@@ -751,7 +754,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 		isVercelGatewayHost: isVercelGateway,
 		// ZDR is a retention guarantee: only claim it when the request actually
 		// goes to Vercel (provider-id matching survives baseUrl overrides).
-		isVercelGatewayUrl: hostMatchesUrl(baseUrl, "vercelAIGateway"),
+		isVercelGatewayUrl: isVercelAIGatewayUrl(baseUrl),
 		wireModelIdMode: isOpenRouter ? "openrouter" : "raw",
 		// Mirrors buildOpenAICompat: Kimi behind a Responses-capable proxy still
 		// lands on Moonshot's MFJS validator.
@@ -773,6 +776,8 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 			: spec.compat?.streamIdleTimeoutMs,
 	};
 	applyCompatOverrides(compat, spec.compat);
+	// Resolved-only retention gate; never trust a raw compat override here.
+	compat.isVercelGatewayUrl = isVercelAIGatewayUrl(baseUrl);
 	if (spec.compat?.reasoningDisableMode === undefined) {
 		compat.reasoningDisableMode = resolveReasoningDisableMode(compat.thinkingFormat);
 	}

--- a/packages/catalog/src/hosts.ts
+++ b/packages/catalog/src/hosts.ts
@@ -7,8 +7,8 @@
  * parsed hostnames: proxies regularly embed the upstream host in a path
  * segment, and the historical call sites all used substring semantics.
  * Callers that need strict hostname matching — where a substring false
- * positive is dangerous, e.g. the Anthropic official-endpoint OAuth gate —
- * parse the URL and compare the hostname themselves.
+ * positive is dangerous, e.g. auth or retention gates — use a dedicated
+ * parsed-URL predicate instead.
  */
 
 interface HostClassSpec {
@@ -18,9 +18,8 @@ interface HostClassSpec {
 	readonly providerPrefixes?: readonly string[];
 	/** Lowercase ASCII substrings matched case-insensitively against the base URL. */
 	readonly urlMarkers: readonly string[];
-	// Strict hostname matching is intentionally not modeled here: the one
-	// auth-sensitive consumer (Anthropic official-endpoint) parses the URL
-	// itself; every other call site is benign and uses substring matching.
+	// Strict hostname matching is intentionally not modeled here. Security-
+	// sensitive consumers use dedicated parsed-URL predicates instead.
 }
 
 export const KNOWN_HOSTS = {
@@ -80,6 +79,17 @@ export function hostMatchesUrl(baseUrl: string | undefined, host: KnownHost): bo
 		if (includesAsciiCaseInsensitive(baseUrl, marker)) return true;
 	}
 	return false;
+}
+
+/** Exact HTTPS endpoint check for retention guarantees enforced by Vercel AI Gateway. */
+export function isVercelAIGatewayUrl(baseUrl: string | undefined): boolean {
+	if (!baseUrl) return false;
+	try {
+		const url = new URL(baseUrl);
+		return url.protocol === "https:" && url.hostname === "ai-gateway.vercel.sh";
+	} catch {
+		return false;
+	}
 }
 
 /** Provider-or-URL host check — the canonical `provider === id || baseUrl.includes(marker)` idiom. */

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -496,6 +496,12 @@ export interface AnthropicCompat {
 	 * {@link ResolvedAnthropicCompat.officialEndpoint}.
 	 */
 	signingEndpoint?: boolean;
+	/**
+	 * Vercel AI Gateway routing preferences. Only used when baseUrl points to
+	 * Vercel AI Gateway; forwarded as `providerOptions.gateway` in the
+	 * Messages body (the gateway's Anthropic transport accepts the field).
+	 */
+	vercelGatewayRouting?: VercelGatewayRouting;
 }
 
 /**
@@ -723,7 +729,9 @@ export interface ResolvedOpenAIResponsesCompat extends ResolvedOpenAISharedCompa
 export type ResolvedOpenRouterCompat = ResolvedOpenAICompat & ResolvedOpenAIResponsesCompat;
 
 /** Fully-resolved anthropic-messages compat view (same contract as `ResolvedOpenAICompat`). */
-export type ResolvedAnthropicCompat = Required<Omit<AnthropicCompat, "streamIdleTimeoutMs">> & {
+export type ResolvedAnthropicCompat = Required<
+	Omit<AnthropicCompat, "streamIdleTimeoutMs" | "vercelGatewayRouting">
+> & {
 	/**
 	 * Stream-watchdog idle-timeout fallback in ms for slow reasoning hosts; 0 disables the idle watchdog.
 	 * Undefined defers to `PI_STREAM_IDLE_TIMEOUT_MS`, then the legacy
@@ -737,6 +745,10 @@ export type ResolvedAnthropicCompat = Required<Omit<AnthropicCompat, "streamIdle
 	 * env headers, and cache-TTL shaping without per-request URL parsing.
 	 */
 	officialEndpoint: boolean;
+	/** The model sits behind Vercel AI Gateway; gateway preferences are forwarded in the Messages body. */
+	isVercelGatewayHost: boolean;
+	/** Vercel AI Gateway routing preferences (only/order/zeroDataRetention). */
+	vercelGatewayRouting?: VercelGatewayRouting;
 };
 
 /**

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -704,6 +704,8 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 		toolStrictMode: ResolvedToolStrictMode;
 		/** The model sits behind Vercel AI Gateway. */
 		isVercelGatewayHost: boolean;
+		/** baseUrl actually matches the Vercel AI Gateway hostname (ai-gateway.vercel.sh). */
+		isVercelGatewayUrl: boolean;
 		dropThinkingWhenReasoningEffort: boolean;
 		/** Complete alternate view for thinking-engaged requests; swap pointers, never spread. */
 		whenThinking?: ResolvedOpenAICompat;
@@ -719,6 +721,8 @@ export interface ResolvedOpenAIResponsesCompat extends ResolvedOpenAISharedCompa
 	vercelGatewayRouting?: OpenAICompat["vercelGatewayRouting"];
 	/** The model sits behind Vercel AI Gateway's Responses endpoint. */
 	isVercelGatewayHost: boolean;
+	/** baseUrl actually matches the Vercel AI Gateway hostname (ai-gateway.vercel.sh). */
+	isVercelGatewayUrl: boolean;
 }
 
 /**
@@ -747,6 +751,8 @@ export type ResolvedAnthropicCompat = Required<
 	officialEndpoint: boolean;
 	/** The model sits behind Vercel AI Gateway; gateway preferences are forwarded in the Messages body. */
 	isVercelGatewayHost: boolean;
+	/** baseUrl actually matches the Vercel AI Gateway hostname (ai-gateway.vercel.sh). */
+	isVercelGatewayUrl: boolean;
 	/** Vercel AI Gateway routing preferences (only/order/zeroDataRetention). */
 	vercelGatewayRouting?: VercelGatewayRouting;
 };

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -556,6 +556,8 @@ export interface VercelGatewayRouting {
 	cacheAnchorItems?: number;
 	/** Requested automatic-cache lifetime for the Responses API. */
 	cacheTtl?: "5m" | "1h";
+	/** Route only through providers with zero data retention agreements with Vercel. */
+	zeroDataRetention?: boolean;
 }
 
 type ResolvedToolStrictMode = NonNullable<OpenAICompat["toolStrictMode"]> | "mixed";

--- a/packages/catalog/test/gateway-reference.test.ts
+++ b/packages/catalog/test/gateway-reference.test.ts
@@ -78,6 +78,7 @@ test("keeps the routing host class but drops the ZDR URL claim for non-Vercel ba
 	const forgedCompat = {
 		vercelGatewayRouting: routing,
 		isVercelGatewayUrl: true,
+		whenThinking: { isVercelGatewayUrl: true },
 	} as unknown as ModelSpec<"openai-completions">["compat"];
 	const forged = buildOverridden("https://corp-proxy.example/v1", forgedCompat);
 
@@ -90,6 +91,7 @@ test("keeps the routing host class but drops the ZDR URL claim for non-Vercel ba
 	expect(lookalike.compat.isVercelGatewayUrl).toBe(false);
 	expect(insecure.compat.isVercelGatewayUrl).toBe(false);
 	expect(forged.compat.isVercelGatewayUrl).toBe(false);
+	expect(forged.compat.whenThinking?.isVercelGatewayUrl).toBe(false);
 });
 
 test("resolves Responses gateway controls only for the Vercel endpoint", () => {

--- a/packages/catalog/test/gateway-reference.test.ts
+++ b/packages/catalog/test/gateway-reference.test.ts
@@ -19,8 +19,8 @@ describe("Portkey gateway model references", () => {
 	});
 });
 
-describe("Vercel AI Gateway cache compat", () => {
-	test("resolves Chat Completions caching controls only for the Vercel endpoint", () => {
+describe("Vercel AI Gateway compat", () => {
+	test("resolves Chat Completions gateway controls only for the Vercel endpoint", () => {
 		const model = buildModel({
 			id: "anthropic/claude-sonnet-4.6",
 			name: "Claude Sonnet 4.6",
@@ -37,6 +37,7 @@ describe("Vercel AI Gateway cache compat", () => {
 					only: ["anthropic"],
 					order: ["anthropic", "bedrock"],
 					caching: "auto",
+					zeroDataRetention: true,
 				},
 			},
 		} satisfies ModelSpec<"openai-completions">);
@@ -46,12 +47,13 @@ describe("Vercel AI Gateway cache compat", () => {
 			only: ["anthropic"],
 			order: ["anthropic", "bedrock"],
 			caching: "auto",
+			zeroDataRetention: true,
 		});
 	});
 });
 
-test("resolves Responses cache controls only for the Vercel endpoint", () => {
-	const routing = { caching: "auto" as const, cacheAnchorItems: 1, cacheTtl: "1h" as const };
+test("resolves Responses gateway controls only for the Vercel endpoint", () => {
+	const routing = { caching: "auto" as const, cacheAnchorItems: 1, cacheTtl: "1h" as const, zeroDataRetention: true };
 	const vercel = buildModel({
 		id: "anthropic/claude-sonnet-4.6",
 		name: "Claude Sonnet 4.6",

--- a/packages/catalog/test/gateway-reference.test.ts
+++ b/packages/catalog/test/gateway-reference.test.ts
@@ -85,3 +85,38 @@ test("resolves Responses gateway controls only for the Vercel endpoint", () => {
 	expect(vercel.compat.vercelGatewayRouting).toEqual(routing);
 	expect(direct.compat.isVercelGatewayHost).toBe(false);
 });
+
+test("resolves gateway routing controls for anthropic-messages Vercel models", () => {
+	const routing = { only: ["bedrock"], zeroDataRetention: true };
+	const vercel = buildModel({
+		id: "anthropic/claude-sonnet-4.6",
+		name: "Claude Sonnet 4.6",
+		api: "anthropic-messages",
+		provider: "vercel-ai-gateway",
+		baseUrl: "https://ai-gateway.vercel.sh",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		compat: { vercelGatewayRouting: routing },
+	} satisfies ModelSpec<"anthropic-messages">);
+	const direct = buildModel({
+		id: "anthropic/claude-sonnet-4.6",
+		name: "Claude Sonnet 4.6",
+		api: "anthropic-messages",
+		provider: "custom",
+		baseUrl: "https://api.example.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		compat: { vercelGatewayRouting: routing },
+	} satisfies ModelSpec<"anthropic-messages">);
+
+	expect(vercel.compat.isVercelGatewayHost).toBe(true);
+	expect(vercel.compat.vercelGatewayRouting).toEqual(routing);
+	expect(direct.compat.isVercelGatewayHost).toBe(false);
+	expect(direct.compat.vercelGatewayRouting).toEqual(routing);
+});

--- a/packages/catalog/test/gateway-reference.test.ts
+++ b/packages/catalog/test/gateway-reference.test.ts
@@ -53,31 +53,51 @@ describe("Vercel AI Gateway compat", () => {
 	});
 });
 
-test("keeps the routing host class but drops the ZDR URL claim for a baseUrl override", () => {
+test("keeps the routing host class but drops the ZDR URL claim for non-Vercel baseUrl overrides", () => {
 	const routing = { only: ["bedrock"], zeroDataRetention: true };
-	const overridden = buildModel({
-		id: "anthropic/claude-sonnet-4.6",
-		name: "Claude Sonnet 4.6",
-		api: "openai-completions",
-		provider: "vercel-ai-gateway",
-		baseUrl: "https://corp-proxy.example/v1",
-		reasoning: false,
-		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 200_000,
-		maxTokens: 16_384,
-		compat: { vercelGatewayRouting: routing },
-	} satisfies ModelSpec<"openai-completions">);
+	const buildOverridden = (
+		baseUrl: string,
+		compat: ModelSpec<"openai-completions">["compat"] = { vercelGatewayRouting: routing },
+	) =>
+		buildModel({
+			id: "anthropic/claude-sonnet-4.6",
+			name: "Claude Sonnet 4.6",
+			api: "openai-completions",
+			provider: "vercel-ai-gateway",
+			baseUrl,
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 16_384,
+			compat,
+		} satisfies ModelSpec<"openai-completions">);
+	const overridden = buildOverridden("https://corp-proxy.example/v1");
+	const lookalike = buildOverridden("https://ai-gateway.vercel.sh.proxy.example/v1");
+	const insecure = buildOverridden("http://ai-gateway.vercel.sh/v1");
+	const forgedCompat = {
+		vercelGatewayRouting: routing,
+		isVercelGatewayUrl: true,
+	} as unknown as ModelSpec<"openai-completions">["compat"];
+	const forged = buildOverridden("https://corp-proxy.example/v1", forgedCompat);
 
 	// Provider id alone keeps the broad routing host class (only/order may still
 	// be emitted), but the ZDR retention claim must not be made for a non-Vercel
 	// endpoint that won't enforce it.
 	expect(overridden.compat.isVercelGatewayHost).toBe(true);
 	expect(overridden.compat.isVercelGatewayUrl).toBe(false);
+	expect(lookalike.compat.isVercelGatewayHost).toBe(true);
+	expect(lookalike.compat.isVercelGatewayUrl).toBe(false);
+	expect(insecure.compat.isVercelGatewayUrl).toBe(false);
+	expect(forged.compat.isVercelGatewayUrl).toBe(false);
 });
 
 test("resolves Responses gateway controls only for the Vercel endpoint", () => {
 	const routing = { caching: "auto" as const, cacheAnchorItems: 1, cacheTtl: "1h" as const, zeroDataRetention: true };
+	const forgedCompat = {
+		vercelGatewayRouting: routing,
+		isVercelGatewayUrl: true,
+	} as unknown as ModelSpec<"openai-responses">["compat"];
 	const vercel = buildModel({
 		id: "anthropic/claude-sonnet-4.6",
 		name: "Claude Sonnet 4.6",
@@ -102,7 +122,7 @@ test("resolves Responses gateway controls only for the Vercel endpoint", () => {
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 200_000,
 		maxTokens: 16_384,
-		compat: { vercelGatewayRouting: routing },
+		compat: forgedCompat,
 	} satisfies ModelSpec<"openai-responses">);
 
 	expect(vercel.compat.isVercelGatewayHost).toBe(true);
@@ -114,6 +134,10 @@ test("resolves Responses gateway controls only for the Vercel endpoint", () => {
 
 test("resolves gateway routing controls for anthropic-messages Vercel models", () => {
 	const routing = { only: ["bedrock"], zeroDataRetention: true };
+	const forgedCompat = {
+		vercelGatewayRouting: routing,
+		isVercelGatewayUrl: true,
+	} as unknown as ModelSpec<"anthropic-messages">["compat"];
 	const vercel = buildModel({
 		id: "anthropic/claude-sonnet-4.6",
 		name: "Claude Sonnet 4.6",
@@ -138,7 +162,7 @@ test("resolves gateway routing controls for anthropic-messages Vercel models", (
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 200_000,
 		maxTokens: 16_384,
-		compat: { vercelGatewayRouting: routing },
+		compat: forgedCompat,
 	} satisfies ModelSpec<"anthropic-messages">);
 
 	expect(vercel.compat.isVercelGatewayHost).toBe(true);

--- a/packages/catalog/test/gateway-reference.test.ts
+++ b/packages/catalog/test/gateway-reference.test.ts
@@ -43,6 +43,7 @@ describe("Vercel AI Gateway compat", () => {
 		} satisfies ModelSpec<"openai-completions">);
 
 		expect(model.compat.isVercelGatewayHost).toBe(true);
+		expect(model.compat.isVercelGatewayUrl).toBe(true);
 		expect(model.compat.vercelGatewayRouting).toEqual({
 			only: ["anthropic"],
 			order: ["anthropic", "bedrock"],
@@ -50,6 +51,29 @@ describe("Vercel AI Gateway compat", () => {
 			zeroDataRetention: true,
 		});
 	});
+});
+
+test("keeps the routing host class but drops the ZDR URL claim for a baseUrl override", () => {
+	const routing = { only: ["bedrock"], zeroDataRetention: true };
+	const overridden = buildModel({
+		id: "anthropic/claude-sonnet-4.6",
+		name: "Claude Sonnet 4.6",
+		api: "openai-completions",
+		provider: "vercel-ai-gateway",
+		baseUrl: "https://corp-proxy.example/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		compat: { vercelGatewayRouting: routing },
+	} satisfies ModelSpec<"openai-completions">);
+
+	// Provider id alone keeps the broad routing host class (only/order may still
+	// be emitted), but the ZDR retention claim must not be made for a non-Vercel
+	// endpoint that won't enforce it.
+	expect(overridden.compat.isVercelGatewayHost).toBe(true);
+	expect(overridden.compat.isVercelGatewayUrl).toBe(false);
 });
 
 test("resolves Responses gateway controls only for the Vercel endpoint", () => {
@@ -82,8 +106,10 @@ test("resolves Responses gateway controls only for the Vercel endpoint", () => {
 	} satisfies ModelSpec<"openai-responses">);
 
 	expect(vercel.compat.isVercelGatewayHost).toBe(true);
+	expect(vercel.compat.isVercelGatewayUrl).toBe(true);
 	expect(vercel.compat.vercelGatewayRouting).toEqual(routing);
 	expect(direct.compat.isVercelGatewayHost).toBe(false);
+	expect(direct.compat.isVercelGatewayUrl).toBe(false);
 });
 
 test("resolves gateway routing controls for anthropic-messages Vercel models", () => {
@@ -116,7 +142,9 @@ test("resolves gateway routing controls for anthropic-messages Vercel models", (
 	} satisfies ModelSpec<"anthropic-messages">);
 
 	expect(vercel.compat.isVercelGatewayHost).toBe(true);
+	expect(vercel.compat.isVercelGatewayUrl).toBe(true);
 	expect(vercel.compat.vercelGatewayRouting).toEqual(routing);
 	expect(direct.compat.isVercelGatewayHost).toBe(false);
+	expect(direct.compat.isVercelGatewayUrl).toBe(false);
 	expect(direct.compat.vercelGatewayRouting).toEqual(routing);
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,22 +2,11 @@
 
 ## [Unreleased]
 
-## [17.2.7] - 2026-08-03
-### Breaking Changes
-
-- Replaced the computer tool's `{ window, actions }` coordinate batches with persistent JavaScript runs using `{ code, read_only?, timeout? }`; removed `computer.backend` and model-specific controller switching.
-
 ### Added
 
 - Added support for `compat.vercelGatewayRouting.zeroDataRetention` in `models.yml` to opt Vercel AI Gateway requests into per-request Zero Data Retention; ZDR is emitted only when the model's `baseUrl` actually points at the gateway ([#7446](https://github.com/can1357/oh-my-pi/pull/7446) by [@sjdweb](https://github.com/sjdweb)).
-- Added optional `timeoutMs` to `discovery` configuration in provider options (`models.yml` / `models.json`) to configure custom HTTP probe timeouts for llama.cpp, Ollama, and OpenAI-compatible discovery endpoints ([#6952](https://github.com/can1357/oh-my-pi/issues/6952)).
-- Added a cross-platform, in-process `ps` shell builtin with BSD/procps selection forms, custom output columns, sorting, process metrics, and header suppression.
-- Added a `relay` browser mode that drives the user's own Chrome tabs through a local CDP relay plus the OMP Browser Relay extension: `omp browser-relay install` writes the bundled extension to disk, and `browser.relay` / `browser.relayUrl` (or per-call `app.relay`) route the browser tool through it. The relay server auto-starts under a profile-independent global daemon broker when the browser tool needs it; every relay consumer holds a broker lease, so the fixed-port singleton stops only after its last consumer across all projects exits. `omp browser-relay` remains available for `--token`/`--no-group`/custom ports, and a relay already serving the port is adopted. It multiplexes the supervisor and per-tab worker puppeteer connections over the single `chrome.debugger` attachment Chrome allows per tab, and gathers only the tabs the agent actively drives into a per-window "omp" tab group (released when the last client lets go of the tab, dissolved on disconnect, never re-grouping tabs the user pulls out).
-- Added a scriptable desktop session with persistent `desktop`/`Win`/`El` handles, window-targeted capture and input, native accessibility trees with `[ref=eN]` actions, clipboard access, streamed screenshots, and enforced read-only runs.
-- Added broker-shared language servers: one LSP server per (server, project) is now spawned by an `omp lsp mux` daemon under the per-project daemon broker (the same broker that owns the shared Chromium and `hub start` processes) and multiplexed to every omp instance in the project over a local socket — instances share the server's index, initialize result, diagnostics, and document state instead of each paying a private cold start. The mux reference-counts `didOpen`/`didClose`, remaps request ids and document versions per client, replays cached diagnostics/registrations/progress to late joiners, routes `workspace/applyEdit` to the most recently active instance, and intercepts per-session `shutdown`/`exit` so one instance leaving never kills the server for the rest; the broker still reaps everything when the last omp process in the project exits. Controlled by the new `lsp.shared` setting (default on); any broker/mux failure falls back to a private server spawn, and an external `lspmux` wrapper keeps precedence when configured.
-- Added `--service-tier` to override the OpenAI service tier for a session. The flag takes precedence over the configured `tier.openai` setting and over a resumed session's recorded tier, leaves the Anthropic and Google tiers alone, and persists across resumes; `none` omits `service_tier` from the request.
-- Added a configurable per-request web search timeout via `providers.webSearchTimeoutSeconds` ([#7197](https://github.com/can1357/oh-my-pi/pull/7197) by [@will-bogusz](https://github.com/will-bogusz)).
-- Added turn-aware `/tree` navigation: Alt+Up/Alt+Down traverses previous/next user or assistant turns while skipping tool and bookkeeping entries, Home/End jumps to the first/last visible item, and PageUp/PageDown moves by a visible page.
+
+## [17.2.7] - 2026-08-03
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,21 @@
 ## [Unreleased]
 
 ## [17.2.7] - 2026-08-03
+### Breaking Changes
+
+- Replaced the computer tool's `{ window, actions }` coordinate batches with persistent JavaScript runs using `{ code, read_only?, timeout? }`; removed `computer.backend` and model-specific controller switching.
+
+### Added
+
+- Added support for `compat.vercelGatewayRouting.zeroDataRetention` in `models.yml` to opt Vercel AI Gateway requests into per-request Zero Data Retention; ZDR is emitted only when the model's `baseUrl` actually points at the gateway ([#7446](https://github.com/can1357/oh-my-pi/pull/7446) by [@sjdweb](https://github.com/sjdweb)).
+- Added optional `timeoutMs` to `discovery` configuration in provider options (`models.yml` / `models.json`) to configure custom HTTP probe timeouts for llama.cpp, Ollama, and OpenAI-compatible discovery endpoints ([#6952](https://github.com/can1357/oh-my-pi/issues/6952)).
+- Added a cross-platform, in-process `ps` shell builtin with BSD/procps selection forms, custom output columns, sorting, process metrics, and header suppression.
+- Added a `relay` browser mode that drives the user's own Chrome tabs through a local CDP relay plus the OMP Browser Relay extension: `omp browser-relay install` writes the bundled extension to disk, and `browser.relay` / `browser.relayUrl` (or per-call `app.relay`) route the browser tool through it. The relay server auto-starts under a profile-independent global daemon broker when the browser tool needs it; every relay consumer holds a broker lease, so the fixed-port singleton stops only after its last consumer across all projects exits. `omp browser-relay` remains available for `--token`/`--no-group`/custom ports, and a relay already serving the port is adopted. It multiplexes the supervisor and per-tab worker puppeteer connections over the single `chrome.debugger` attachment Chrome allows per tab, and gathers only the tabs the agent actively drives into a per-window "omp" tab group (released when the last client lets go of the tab, dissolved on disconnect, never re-grouping tabs the user pulls out).
+- Added a scriptable desktop session with persistent `desktop`/`Win`/`El` handles, window-targeted capture and input, native accessibility trees with `[ref=eN]` actions, clipboard access, streamed screenshots, and enforced read-only runs.
+- Added broker-shared language servers: one LSP server per (server, project) is now spawned by an `omp lsp mux` daemon under the per-project daemon broker (the same broker that owns the shared Chromium and `hub start` processes) and multiplexed to every omp instance in the project over a local socket — instances share the server's index, initialize result, diagnostics, and document state instead of each paying a private cold start. The mux reference-counts `didOpen`/`didClose`, remaps request ids and document versions per client, replays cached diagnostics/registrations/progress to late joiners, routes `workspace/applyEdit` to the most recently active instance, and intercepts per-session `shutdown`/`exit` so one instance leaving never kills the server for the rest; the broker still reaps everything when the last omp process in the project exits. Controlled by the new `lsp.shared` setting (default on); any broker/mux failure falls back to a private server spawn, and an external `lspmux` wrapper keeps precedence when configured.
+- Added `--service-tier` to override the OpenAI service tier for a session. The flag takes precedence over the configured `tier.openai` setting and over a resumed session's recorded tier, leaves the Anthropic and Google tiers alone, and persists across resumes; `none` omits `service_tier` from the request.
+- Added a configurable per-request web search timeout via `providers.webSearchTimeoutSeconds` ([#7197](https://github.com/can1357/oh-my-pi/pull/7197) by [@will-bogusz](https://github.com/will-bogusz)).
+- Added turn-aware `/tree` navigation: Alt+Up/Alt+Down traverses previous/next user or assistant turns while skipping tool and bookkeeping entries, Home/End jumps to the first/last visible item, and PageUp/PageDown moves by a visible page.
 
 ### Changed
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -375,7 +375,13 @@ function applyUpstreamRouting(model: Model<Api>, upstream: string): Model<Api> {
 	return buildModel({
 		...model,
 		compat: modelMatchesHost(model, "vercelAIGateway")
-			? { ...aggregatorModel.compatConfig, vercelGatewayRouting: routing }
+			? {
+					...aggregatorModel.compatConfig,
+					vercelGatewayRouting: {
+						...aggregatorModel.compatConfig?.vercelGatewayRouting,
+						...routing,
+					},
+				}
 			: { ...aggregatorModel.compatConfig, openRouterRouting: routing },
 	} as ModelSpec<Api>);
 }

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -10,6 +10,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 	const VercelGatewayRoutingSchema = type({
 		"only?": "string[]",
 		"order?": "string[]",
+		"zeroDataRetention?": "boolean",
 	});
 
 	const ReasoningEffortMapSchema = type({

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { type Api, Effort, type Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models";
+import type { VercelGatewayRouting } from "@oh-my-pi/pi-catalog/types";
 import {
 	expandRoleAlias,
 	extractExplicitThinkingSelector,
@@ -1757,6 +1758,8 @@ describe("extractExplicitThinkingSelector", () => {
 describe("provider routing selector (@upstream)", () => {
 	const openRouterOnly = (model: Model<Api> | undefined): string[] | undefined =>
 		(model?.compat as { openRouterRouting?: { only?: string[] } } | undefined)?.openRouterRouting?.only;
+	const vercelGatewayRouting = (model: Model<Api> | undefined): VercelGatewayRouting | undefined =>
+		(model?.compat as { vercelGatewayRouting?: VercelGatewayRouting } | undefined)?.vercelGatewayRouting;
 
 	test("pins an OpenRouter model to one upstream via @slug", () => {
 		const result = parseModelPattern("openrouter/z-ai/glm-4.7@cerebras", allModels);
@@ -1799,13 +1802,22 @@ describe("provider routing selector (@upstream)", () => {
 			cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
 			contextWindow: 128000,
 			maxTokens: 8192,
+			compat: {
+				vercelGatewayRouting: {
+					order: ["anthropic", "bedrock"],
+					caching: "auto",
+					zeroDataRetention: true,
+				},
+			},
 		});
 		const result = parseModelPattern("vercel-ai-gateway/zai/glm-4.7@cerebras", [gatewayModel]);
 		expect(result.model?.id).toBe("zai/glm-4.7");
-		expect(
-			(result.model?.compat as { vercelGatewayRouting?: { only?: string[] } } | undefined)?.vercelGatewayRouting
-				?.only,
-		).toEqual(["cerebras"]);
+		expect(vercelGatewayRouting(result.model)).toEqual({
+			only: ["cerebras"],
+			order: ["anthropic", "bedrock"],
+			caching: "auto",
+			zeroDataRetention: true,
+		});
 		expect(openRouterOnly(result.model)).toBeUndefined();
 	});
 


### PR DESCRIPTION
## What

- Adds opt-in per-request [Vercel AI Gateway ZDR](https://vercel.com/docs/ai-gateway/security-and-compliance/zdr#per-request-zero-data-retention). `compat.vercelGatewayRouting.zeroDataRetention: true` emits `providerOptions.gateway.zeroDataRetention: true` on all three transports omp uses against `ai-gateway.vercel.sh`: Chat Completions, Responses, and Anthropic Messages. `only`/`order` routing now forwards on the Anthropic transport as well; `caching` stays on Chat/Responses (the scope #6410 set).
- Emitted only for recognized Vercel endpoints (`isVercelGatewayHost`) and only on explicit `true`; `false`, unset, and non-Vercel hosts are byte-for-byte unchanged.
- ZDR is a routing constraint, not a cache preference: `cacheRetention: "none"` / `PI_CACHE_RETENTION=none` suppress `caching` but intentionally keep `zeroDataRetention`.

## Why

I wanted to use Vercel AI Gateway's per-request ZDR flag, ensuring if the model supports it my requests are only routed to providers that have Zero Data Retention agreements with Vercel (if no compliant provider serves the model, the request fails rather than falling back). I couldn't see a way to do this when checking the code and existing issues/pull requests.

## Testing

- Request-shape fixtures capture the real `streamOpenAICompletions` / `streamOpenAIResponses` / `streamAnthropic` payloads: 38 tests across four files cover Chat + Responses + Anthropic bodies, merge with `only`/`order`, `false`/unset/non-Vercel omission, the retention-`none` interaction, and anthropic compat resolution.
- Full `packages/ai` + `packages/catalog` test sweep: 4230 pass / 0 fail.
- `bun run check:ts` passes.
- Live end-to-end against the real gateway (stored credential, locally-built CLI):
  - `deepseek/deepseek-v4-flash-0731` with `zeroDataRetention: true` configured completed normally via the Anthropic Messages transport — the gateway accepted `providerOptions.gateway` and served the request.
  - `xai/grok-4.5` (no ZDR-attested provider) rejected with the documented `400 no_zdr_providers_available`. The persisted HTTP 400 dump shows the exact request body omp sent: `POST https://ai-gateway.vercel.sh/v1/messages` with `providerOptions: { gateway: { zeroDataRetention: true } }` — the flag reached the wire and was enforced server-side.

---

- [x] `bun run check:ts` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
