### PR TITLE
fix(coding-agent): honor vision role thinking effort in inspect_image

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed
 
+- Fixed `inspect_image` ignoring the thinking effort configured on `modelRoles.vision` (e.g. `<model>:high`): the oneshot resolved the model but dropped the `:high` selector and passed no `reasoning`, so the request went out with a suppressed/zero thinking budget and thinking-only Gemini models rejected it with HTTP 400 (`Budget 0 is invalid. This model only works in thinking mode.`). The tool now resolves the role's explicit thinking selector, clamps it to the model's supported efforts, and forwards it as the oneshot `reasoning` ([#7448](https://github.com/can1357/oh-my-pi/issues/7448)).
 - Fixed template argument substitution (`substituteArgs`) executing recursive placeholder expansion when positional argument values contain literal `$@` or `$ARGUMENTS` tokens.
 - Fixed focused-agent status bar dimming darkening Powerline end caps.
 - Fixed the browser relay creating duplicate "omp" tab groups: the bridge now keeps at most one group RPC in flight (a queued drain replaces fire-and-forget per-tab requests), so concurrent requests can no longer race the extension's non-atomic query→create→set-title sequence in the same window. Also fixed an extension reconnect (relay daemon restart, service-worker recycle) being misread as the user dragging every tab out of the omp group — grouping state is reset when the extension socket closes, so tabs regroup on the next hello instead of being permanently opted out.

--- a/packages/coding-agent/src/tools/inspect-image.ts
+++ b/packages/coding-agent/src/tools/inspect-image.ts
@@ -12,9 +12,15 @@ import { prompt } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import { extractTextContent } from "../commit/utils";
 
-import { expandRoleAlias, getModelMatchPreferences, resolveModelFromString } from "../config/model-resolver";
+import {
+	expandRoleAlias,
+	extractExplicitThinkingSelector,
+	getModelMatchPreferences,
+	resolveModelFromString,
+} from "../config/model-resolver";
 import inspectImageDescription from "../prompts/tools/inspect-image.md" with { type: "text" };
 import inspectImageSystemPromptTemplate from "../prompts/tools/inspect-image-system.md" with { type: "text" };
+import { concreteThinkingLevel, resolveThinkingLevelForModel, toReasoningEffort } from "../thinking";
 import {
 	ImageInputTooLargeError,
 	type LoadedImageInput,
@@ -163,11 +169,17 @@ export class InspectImageTool implements AgentTool<typeof inspectImageSchema, In
 		};
 
 		const activeModelPattern = this.session.getActiveModelString?.() ?? this.session.getModelString?.();
-		const model =
-			resolvePattern("@vision") ??
-			resolvePattern("@default") ??
-			resolvePattern(activeModelPattern) ??
-			availableModels[0];
+		let model: Model<Api> | undefined;
+		let selectedPattern: string | undefined;
+		for (const pattern of ["@vision", "@default", activeModelPattern]) {
+			const resolved = resolvePattern(pattern);
+			if (resolved) {
+				model = resolved;
+				selectedPattern = pattern;
+				break;
+			}
+		}
+		model ??= availableModels[0];
 		if (!model) {
 			throw new ToolError("Unable to resolve a model for inspect_image.");
 		}
@@ -233,6 +245,19 @@ export class InspectImageTool implements AgentTool<typeof inspectImageSchema, In
 			return `inspect_image request timed out after ${seconds}s. Increase inspect_image.timeoutMs (currently ${timeoutMs}ms; 0 disables) or check the vision model provider.`;
 		};
 
+		// Honor the thinking effort configured on the resolved model role
+		// (e.g. `modelRoles.vision: <model>:high`). Without it the oneshot sent a
+		// suppressed/zero thinking budget, which thinking-only models (Gemini 3.x)
+		// reject with HTTP 400 ("Budget 0 is invalid. This model only works in
+		// thinking mode.").
+		const configuredThinking = concreteThinkingLevel(
+			extractExplicitThinkingSelector(selectedPattern, this.session.settings, {
+				isLiteralModelId: (provider, id) =>
+					availableModels.some(candidate => candidate.provider === provider && candidate.id === id),
+			}),
+		);
+		const reasoning = toReasoningEffort(resolveThinkingLevelForModel(model, configuredThinking));
+
 		let response: AssistantMessage;
 		try {
 			response = await instrumentedCompleteSimple(
@@ -253,6 +278,7 @@ export class InspectImageTool implements AgentTool<typeof inspectImageSchema, In
 				{
 					apiKey: modelRegistry.resolver(model, this.session.getSessionId?.() ?? undefined),
 					signal: effectiveSignal,
+					reasoning,
 				},
 				{ telemetry, oneshotKind: "inspect_image", completeImpl: this.completeImageRequest },
 			);

--- a/packages/coding-agent/test/tools/inspect-image.test.ts
+++ b/packages/coding-agent/test/tools/inspect-image.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { AuthStorage, type completeSimple, type ImageContent, type Model } from "@oh-my-pi/pi-ai";
+import { AuthStorage, type completeSimple, Effort, type ImageContent, type Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -36,6 +36,13 @@ const textOnlyModel: Model<"openai-responses"> = {
 	...visionModel,
 	id: "gpt-4.1",
 	input: ["text"],
+};
+
+const reasoningVisionModel: Model<"openai-responses"> = {
+	...visionModel,
+	id: "gpt-5-vision",
+	reasoning: true,
+	thinking: { mode: "effort", efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High] },
 };
 
 interface CreateSessionOptions {
@@ -187,6 +194,32 @@ describe("InspectImageTool", () => {
 		const contentParts = (Array.isArray(content) ? content : []) as Array<{ type: string; text?: string }>;
 		expect(contentParts[0]?.type).toBe("image");
 		expect(contentParts[1]).toEqual({ type: "text", text: "Extract visible UI labels." });
+	});
+
+	it("passes the vision role's configured thinking effort into the oneshot", async () => {
+		const imagePath = path.join(testDir, "screen.png");
+		fs.writeFileSync(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+		const settings = Settings.isolated();
+		settings.setModelRole("vision", `${reasoningVisionModel.provider}/${reasoningVisionModel.id}:high`);
+
+		const stub = createCompleteSimpleSuccessStub("Red");
+		const tool = new InspectImageTool(
+			createSession(testDir, reasoningVisionModel, "test-key", settings, {
+				configureVisionRole: false,
+				availableModels: [reasoningVisionModel],
+			}),
+			stub.fn,
+		);
+
+		await tool.execute("call-effort", {
+			path: imagePath,
+			question: "What dominant color is this image? One word only.",
+		});
+
+		expect(stub.calls).toHaveLength(1);
+		const options = stub.calls[0]?.[2] as { reasoning?: string } | undefined;
+		expect(options?.reasoning).toBe("high");
 	});
 
 	it("resolves pasted image labels from current attachments without using cwd", async () => {


### PR DESCRIPTION
## Repro
With `modelRoles.vision: <model>:high` on a thinking-only Gemini model (e.g. `google-antigravity/gemini-3.1-pro`), calling `inspect_image` on any image failed with HTTP 400 (`Budget 0 is invalid. This model only works in thinking mode.`). A unit repro configures the vision role with a `:high` selector on a reasoning-capable model and asserts the oneshot receives that effort:

```
bun test packages/coding-agent/test/tools/inspect-image.test.ts -t "configured thinking effort"
```

Before the fix the oneshot was invoked with `reasoning: undefined` (Expected `"high"`, Received `undefined`).

## Cause
`InspectImageTool.execute` (`packages/coding-agent/src/tools/inspect-image.ts`) resolved `@vision` via `resolveModelFromString`, which returns the bare `Model` and discards the `:high` thinking level parsed from the pattern. It then called `instrumentedCompleteSimple` with no `reasoning` option. With no reasoning, the `google-gemini-cli` request mapper (`packages/ai/src/stream.ts`) takes the thinking-off path and, for `suppressWhenOff` models, emits `thinking.suppress = { budget: 0 }` → wire `thinkingBudget: 0`, which thinking-only models reject. Every other oneshot (handoff, compaction, `eval` `completion`) forwards `reasoning`; `inspect_image` was the outlier.

## Fix
- Track which pattern (`@vision` / `@default` / active) resolved the model instead of discarding it.
- Resolve that pattern's explicit thinking selector with `extractExplicitThinkingSelector`, clamp it to the model's supported efforts via `resolveThinkingLevelForModel`, and convert with `toReasoningEffort`.
- Pass the resulting effort as the oneshot `reasoning`. When no effort is configured the behavior is unchanged (no `reasoning`).
- Added a regression test asserting the configured `:high` effort reaches the oneshot options.

## Verification
`bun test packages/coding-agent/test/tools/inspect-image.test.ts` → 16 pass / 0 fail. The `retry.fallbackChains.vision` traversal (issue's expected-fix #2) is intentionally out of scope: that setting governs main-session failover, and extending it to tool oneshots is a separate enhancement. Fixes #7448