### PR TITLE
perf(coding-agent): skip hook-free extension dependency graphs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Skipped legacy extension dependency graph traversal for packages proved not to need compatibility hooks, while retaining fail-open checks for CommonJS, native, and legacy-Pi cases.
+
 ## [17.2.5] - 2026-08-03
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Skipped legacy extension dependency graph traversal for packages proved not to need compatibility hooks, while retaining fail-open checks for CommonJS, native, and legacy-Pi cases.
+- Skipped legacy extension dependency graph traversal for packages proved not to need compatibility hooks, while retaining fail-open checks for CommonJS, native, and legacy-Pi cases. ([#7461](https://github.com/can1357/oh-my-pi/pull/7461) by [@metaphorics](https://github.com/metaphorics))
 
 ## [17.2.5] - 2026-08-03
 

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -665,6 +665,8 @@ const bareRequireResolutionCache = new Map<string, Promise<string | null>>();
 const realpathCache = new Map<string, Promise<string>>();
 const nativeAddonResolutionCache = new Map<string, Promise<string | null>>();
 const nativeAddonRequireScanCache = new Map<string, Promise<boolean>>();
+const packageGraphHookNeedCache = new Map<string, Promise<boolean>>();
+const FORCE_FULL_EXTENSION_CRAWL = process.env.OMP_LEGACY_EXT_FULL_CRAWL === "1";
 
 function clearLegacyPiResolutionCaches(): void {
 	resolvedSpecifierFallbacks.clear();
@@ -677,6 +679,7 @@ function clearLegacyPiResolutionCaches(): void {
 	nativeAddonResolutionCache.clear();
 	nativeAddonRequireScanCache.clear();
 	realpathCache.clear();
+	packageGraphHookNeedCache.clear();
 }
 
 registerPluginCacheInvalidator(clearLegacyPiResolutionCaches);
@@ -1333,6 +1336,85 @@ async function readPackageManifestUncached(packageRoot: string): Promise<Record<
 	}
 }
 
+/**
+ * A third-party package needs graph hooks only when a rewrite could change one
+ * of its files. Pure-ESM packages that declare no host `pi-*` / typebox
+ * dependency and ship no native addon resolve natively from their own
+ * `node_modules` location, so crawling them parses megabytes to produce
+ * byte-identical output.
+ */
+async function packageNeedsGraphHooks(packageRoot: string): Promise<boolean> {
+	if (FORCE_FULL_EXTENSION_CRAWL) {
+		return true;
+	}
+	const cached = packageGraphHookNeedCache.get(packageRoot);
+	if (cached) return cached;
+
+	const promise = packageNeedsGraphHooksUncached(packageRoot);
+	packageGraphHookNeedCache.set(packageRoot, promise);
+	return promise;
+}
+
+async function packageNeedsGraphHooksUncached(packageRoot: string): Promise<boolean> {
+	const manifest = await readPackageManifest(packageRoot);
+	if (!manifest) {
+		return true;
+	}
+	if (manifest.type !== "module") {
+		return true;
+	}
+	if (exportsContainRequireCondition(manifest.exports)) {
+		return true;
+	}
+	for (const field of ["dependencies", "peerDependencies", "optionalDependencies"]) {
+		const deps = manifest[field];
+		if (!isRecord(deps)) continue;
+		for (const name of Object.keys(deps)) {
+			if (
+				LEGACY_PI_SPECIFIER_FILTER.test(name) ||
+				name === "typebox" ||
+				name === "@sinclair/typebox" ||
+				name === "node-gyp-build" ||
+				name === "bindings" ||
+				name.endsWith("-napi")
+			) {
+				return true;
+			}
+		}
+	}
+	if (manifest.gypfile || manifest.binary !== undefined) {
+		return true;
+	}
+	return false;
+}
+
+/** A string leaf is a target, not a condition; only object keys are conditions. */
+function exportsContainRequireCondition(exports: unknown): boolean {
+	if (typeof exports === "string") {
+		return false;
+	}
+	if (Array.isArray(exports)) {
+		for (const item of exports) {
+			if (exportsContainRequireCondition(item)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	if (!isRecord(exports)) {
+		return false;
+	}
+	for (const [key, value] of Object.entries(exports)) {
+		if (key === "require") {
+			return true;
+		}
+		if (exportsContainRequireCondition(value)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 type ExtensionModuleKind = "commonjs" | "esm";
 
 async function isCommonJsModulePath(
@@ -1971,6 +2053,7 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 				let requiresNativeAddonRewrite = false;
 				let requiresSynchronousSourceHook = false;
 				let synchronousSourceUpgraded = false;
+				let crawlResolved = true;
 				const isRequired = reference.kind === "require";
 				if (specifier.startsWith(".")) {
 					const candidate = isRequired
@@ -2060,6 +2143,21 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 					if (resolved) {
 						resolvedModuleKind = isCommonJsEntry ? "commonjs" : "esm";
 						resolvedEsmBranch = selectedEsmBranch && !isCommonJsEntry;
+						if (resolvedModuleKind === "esm" && !requiresNativeAddonRewrite) {
+							const packageName = splitBarePackageSpecifier(specifier)?.name;
+							const packageRoot = packageName ? await findNodePackageRoot(packageName, file) : null;
+							const realPackageRoot = packageRoot ? await realpathOrSelf(packageRoot) : null;
+							if (
+								packageRoot &&
+								realPackageRoot &&
+								isPathInsideRoot(realPackageRoot, resolved) &&
+								isPathInsideRoot(path.resolve(packageRoot), resolved) &&
+								!isPathInsideRoot(realPackageRoot, entryRealPath) &&
+								!(await packageNeedsGraphHooks(packageRoot))
+							) {
+								crawlResolved = false;
+							}
+						}
 					}
 					nextCacheBustResolvedImports = false;
 				}
@@ -2095,12 +2193,30 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 						commonJsPaths.delete(resolved);
 					}
 					if (!modules.has(resolved)) {
-						queue.push({
-							file: resolved,
-							cacheBustResolvedImports: mergedCacheBust,
-							moduleKind: mergedModuleKind,
-							esmBranch: resolvedEsmBranch,
-						});
+						if (crawlResolved) {
+							queue.push({
+								file: resolved,
+								cacheBustResolvedImports: mergedCacheBust,
+								moduleKind: mergedModuleKind,
+								esmBranch: resolvedEsmBranch,
+							});
+						} else {
+							// Pure-ESM third-party entry: record it in `modules` so the
+							// importer's rewritten absolute specifier still loads through
+							// the graph hook, but never descend into the package's graph.
+							try {
+								modules.set(resolved, await Bun.file(resolved).text());
+							} catch {
+								// Unreadable entry — fail open to the crawl so native
+								// resolution still surfaces the error after a full walk.
+								queue.push({
+									file: resolved,
+									cacheBustResolvedImports: mergedCacheBust,
+									moduleKind: mergedModuleKind,
+									esmBranch: resolvedEsmBranch,
+								});
+							}
+						}
 					}
 				}
 			} catch {
@@ -2596,4 +2712,9 @@ export function installLegacyPiSpecifierShim(): void {
 /** Test seam: clears the memoized canonical specifier resolutions. */
 export function __resetLegacyPiResolutionCache(): void {
 	clearLegacyPiResolutionCaches();
+}
+
+/** Test seam for the third-party graph-crawl gate. */
+export async function __packageNeedsGraphHooksForTests(packageRoot: string): Promise<boolean> {
+	return packageNeedsGraphHooks(packageRoot);
 }

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -1336,37 +1336,47 @@ async function readPackageManifestUncached(packageRoot: string): Promise<Record<
 	}
 }
 
+type ExtensionModuleKind = "commonjs" | "esm";
+
 /**
- * A third-party package needs graph hooks only when a rewrite could change one
- * of its files. Pure-ESM packages that declare no host `pi-*` / typebox
- * dependency and ship no native addon resolve natively from their own
- * `node_modules` location, so crawling them parses megabytes to produce
- * byte-identical output.
+ * A resolved third-party file needs graph hooks when its selected module kind
+ * or package metadata could require compatibility rewriting. Classification is
+ * deliberately file-specific: an ESM `.js` import target remains safe to prune
+ * when the same package exposes a sibling `.cjs` require target.
  */
-async function packageNeedsGraphHooks(packageRoot: string): Promise<boolean> {
+async function resolvedModuleNeedsGraphHooks(
+	packageRoot: string,
+	modulePath: string,
+	moduleKind: ExtensionModuleKind | undefined,
+): Promise<boolean> {
 	if (FORCE_FULL_EXTENSION_CRAWL) {
 		return true;
 	}
+	if (moduleKind !== "esm" || !hasSourceModuleExtension(modulePath)) {
+		return true;
+	}
+
 	const cached = packageGraphHookNeedCache.get(packageRoot);
 	if (cached) return cached;
 
-	const promise = packageNeedsGraphHooksUncached(packageRoot);
+	const promise = packageHasGraphRewriteRisk(packageRoot);
 	packageGraphHookNeedCache.set(packageRoot, promise);
 	return promise;
 }
 
-async function packageNeedsGraphHooksUncached(packageRoot: string): Promise<boolean> {
+async function packageHasGraphRewriteRisk(packageRoot: string): Promise<boolean> {
 	const manifest = await readPackageManifest(packageRoot);
 	if (!manifest) {
 		return true;
 	}
-	if (manifest.type !== "module") {
+	// Optional dependencies often name arbitrary prebuilt platform packages
+	// (for example `@scope/pkg-darwin-arm64`) whose `.node` mains need absolute
+	// path rewriting. Package-name heuristics are not a safe allowlist here.
+	const optionalDeps = manifest.optionalDependencies;
+	if (isRecord(optionalDeps) && Object.keys(optionalDeps).length > 0) {
 		return true;
 	}
-	if (exportsContainRequireCondition(manifest.exports)) {
-		return true;
-	}
-	for (const field of ["dependencies", "peerDependencies", "optionalDependencies"]) {
+	for (const field of ["dependencies", "peerDependencies"]) {
 		const deps = manifest[field];
 		if (!isRecord(deps)) continue;
 		for (const name of Object.keys(deps)) {
@@ -1387,35 +1397,6 @@ async function packageNeedsGraphHooksUncached(packageRoot: string): Promise<bool
 	}
 	return false;
 }
-
-/** A string leaf is a target, not a condition; only object keys are conditions. */
-function exportsContainRequireCondition(exports: unknown): boolean {
-	if (typeof exports === "string") {
-		return false;
-	}
-	if (Array.isArray(exports)) {
-		for (const item of exports) {
-			if (exportsContainRequireCondition(item)) {
-				return true;
-			}
-		}
-		return false;
-	}
-	if (!isRecord(exports)) {
-		return false;
-	}
-	for (const [key, value] of Object.entries(exports)) {
-		if (key === "require") {
-			return true;
-		}
-		if (exportsContainRequireCondition(value)) {
-			return true;
-		}
-	}
-	return false;
-}
-
-type ExtensionModuleKind = "commonjs" | "esm";
 
 async function isCommonJsModulePath(
 	modulePath: string,
@@ -2143,7 +2124,7 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 					if (resolved) {
 						resolvedModuleKind = isCommonJsEntry ? "commonjs" : "esm";
 						resolvedEsmBranch = selectedEsmBranch && !isCommonJsEntry;
-						if (resolvedModuleKind === "esm" && !requiresNativeAddonRewrite) {
+						if (!requiresNativeAddonRewrite) {
 							const packageName = splitBarePackageSpecifier(specifier)?.name;
 							const packageRoot = packageName ? await findNodePackageRoot(packageName, file) : null;
 							const realPackageRoot = packageRoot ? await realpathOrSelf(packageRoot) : null;
@@ -2151,9 +2132,8 @@ async function collectExtensionModules(entryRealPath: string): Promise<Extension
 								packageRoot &&
 								realPackageRoot &&
 								isPathInsideRoot(realPackageRoot, resolved) &&
-								isPathInsideRoot(path.resolve(packageRoot), resolved) &&
 								!isPathInsideRoot(realPackageRoot, entryRealPath) &&
-								!(await packageNeedsGraphHooks(packageRoot))
+								!(await resolvedModuleNeedsGraphHooks(packageRoot, resolved, resolvedModuleKind))
 							) {
 								crawlResolved = false;
 							}
@@ -2712,9 +2692,4 @@ export function installLegacyPiSpecifierShim(): void {
 /** Test seam: clears the memoized canonical specifier resolutions. */
 export function __resetLegacyPiResolutionCache(): void {
 	clearLegacyPiResolutionCaches();
-}
-
-/** Test seam for the third-party graph-crawl gate. */
-export async function __packageNeedsGraphHooksForTests(packageRoot: string): Promise<boolean> {
-	return packageNeedsGraphHooks(packageRoot);
 }

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -5,11 +5,10 @@ import * as path from "node:path";
 import * as url from "node:url";
 import {
 	__collectLegacyPiExtensionSourcesForTests,
-	__packageNeedsGraphHooksForTests,
 	__rewriteLegacyExtensionSourceForTests,
 	loadLegacyPiModule,
 } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
-import { removeWithRetries, TempDir } from "@oh-my-pi/pi-utils";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 // Issue #1674: legacy Pi extensions load browser-UI assets (HTML/CSS) at module
 // init via `readFileSync(join(__dirname, "ui.html"))`. The compat layer must run
@@ -19,14 +18,10 @@ import { removeWithRetries, TempDir } from "@oh-my-pi/pi-utils";
 // public `loadLegacyPiModule` entry point.
 
 const tempRoots: string[] = [];
-const gateTempDirs: TempDir[] = [];
 
 afterAll(async () => {
 	for (const dir of tempRoots) {
 		await removeWithRetries(dir);
-	}
-	for (const dir of gateTempDirs) {
-		await dir.remove();
 	}
 });
 
@@ -39,18 +34,6 @@ async function writePackage(files: Record<string, string>): Promise<string> {
 		await fs.writeFile(abs, files[rel], "utf8");
 	}
 	return dir;
-}
-
-/** Gate fixtures use the central TempDir helper so cleanup stays full-suite safe. */
-async function writeGatePackage(files: Record<string, string>): Promise<string> {
-	const tempDir = await TempDir.create("@omp-legacy-graph-gate-");
-	gateTempDirs.push(tempDir);
-	for (const rel in files) {
-		const abs = tempDir.join(rel);
-		await fs.mkdir(path.dirname(abs), { recursive: true });
-		await fs.writeFile(abs, files[rel], "utf8");
-	}
-	return tempDir.path();
 }
 
 describe("legacy-pi in-place module loading (issue #1674)", () => {
@@ -1562,75 +1545,266 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 });
 
 describe("third-party graph-crawl gate", () => {
-	it("skips a pure-ESM package with plain dependencies and no exports map", async () => {
-		const dir = await writeGatePackage({
-			"package.json": JSON.stringify({
-				name: "pure-esm",
-				version: "1.0.0",
-				type: "module",
-				dependencies: { "lru-cache": "^11" },
-			}),
-		});
-		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(false);
-	});
-
-	it("skips an ESM package whose exports map has only import/default conditions", async () => {
-		const dir = await writeGatePackage({
-			"package.json": JSON.stringify({
-				name: "esm-exports",
-				version: "1.0.0",
-				type: "module",
-				exports: { ".": { import: "./index.js", default: "./index.js" } },
-			}),
-		});
-		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(false);
-	});
-
-	it("crawls a package whose exports map nests a require condition", async () => {
-		const dir = await writeGatePackage({
-			"package.json": JSON.stringify({
+	it("loads a selected dual-format ESM entry while omitting its safe descendants", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "graph-gate-ext", version: "1.0.0", type: "module" }),
+			"index.js": [
+				'import { selected } from "dual-format";',
+				"export { selected };",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+			"node_modules/dual-format/package.json": JSON.stringify({
 				name: "dual-format",
 				version: "1.0.0",
 				type: "module",
-				exports: { ".": { node: { require: "./index.cjs", import: "./index.js" } } },
+				exports: { ".": { import: "./index.js", require: "./index.cjs" } },
+				dependencies: { "transitive-esm": "1.0.0" },
 			}),
-		});
-		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
-	});
-
-	it("crawls an implicit-CommonJS package (no type field)", async () => {
-		const dir = await writeGatePackage({
-			"package.json": JSON.stringify({ name: "implicit-cjs", version: "1.0.0" }),
-		});
-		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
-	});
-
-	it("crawls an ESM package that depends on a host pi package", async () => {
-		const dir = await writeGatePackage({
-			"package.json": JSON.stringify({
-				name: "pi-dependent",
+			"node_modules/dual-format/index.js": [
+				'import { transitive } from "transitive-esm";',
+				'import { leaf } from "./leaf.js";',
+				`export const selected = \`esm:\${transitive}:\${leaf}\`;`,
+			].join("\n"),
+			"node_modules/dual-format/index.cjs": 'module.exports = { selected: "cjs" };',
+			"node_modules/dual-format/leaf.js": 'export const leaf = "relative";',
+			"node_modules/dual-format/node_modules/transitive-esm/package.json": JSON.stringify({
+				name: "transitive-esm",
 				version: "1.0.0",
 				type: "module",
-				dependencies: { "@oh-my-pi/pi-ai": "*" },
+				exports: "./index.js",
 			}),
+			"node_modules/dual-format/node_modules/transitive-esm/index.js": 'export const transitive = "transitive";',
 		});
-		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
+		const entry = await fs.realpath(path.join(dir, "index.js"));
+		const selectedEntry = await fs.realpath(path.join(dir, "node_modules/dual-format/index.js"));
+		const safeLeaf = await fs.realpath(path.join(dir, "node_modules/dual-format/leaf.js"));
+		const transitiveEntry = await fs.realpath(
+			path.join(dir, "node_modules/dual-format/node_modules/transitive-esm/index.js"),
+		);
+
+		const sources = await __collectLegacyPiExtensionSourcesForTests(entry);
+		expect(sources.has(entry)).toBe(true);
+		expect(sources.has(selectedEntry)).toBe(true);
+		expect(sources.has(safeLeaf)).toBe(false);
+		expect(sources.has(transitiveEntry)).toBe(false);
+
+		const mod = (await loadLegacyPiModule(entry)) as { selected: string };
+		expect(mod.selected).toBe("esm:transitive:relative");
 	});
 
-	it("crawls an ESM package that ships a native addon build", async () => {
-		const dir = await writeGatePackage({
-			"package.json": JSON.stringify({
-				name: "native-esm",
+	it("crawls resolved CommonJS, native-risk, and legacy-risk package paths", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "fail-open-ext", version: "1.0.0", type: "module" }),
+			"index.js": [
+				'import cjsValue from "commonjs-dep";',
+				'import { nativeValue } from "native-risk";',
+				'import { legacyValue } from "legacy-risk";',
+				"export const values = [cjsValue, nativeValue, legacyValue];",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+			"node_modules/commonjs-dep/package.json": JSON.stringify({
+				name: "commonjs-dep",
+				version: "1.0.0",
+				main: "index.cjs",
+			}),
+			"node_modules/commonjs-dep/index.cjs": 'module.exports = require("./leaf.cjs");',
+			"node_modules/commonjs-dep/leaf.cjs": 'module.exports = "commonjs";',
+			"node_modules/native-risk/package.json": JSON.stringify({
+				name: "native-risk",
 				version: "1.0.0",
 				type: "module",
+				exports: "./index.js",
 				gypfile: true,
 			}),
+			"node_modules/native-risk/index.js": 'export { nativeValue } from "./leaf.js";',
+			"node_modules/native-risk/leaf.js": 'export const nativeValue = "native";',
+			"node_modules/legacy-risk/package.json": JSON.stringify({
+				name: "legacy-risk",
+				version: "1.0.0",
+				type: "module",
+				exports: "./index.js",
+				dependencies: { "@oh-my-pi/pi-ai": "*" },
+			}),
+			"node_modules/legacy-risk/index.js": 'export { legacyValue } from "./leaf.js";',
+			"node_modules/legacy-risk/leaf.js": 'export const legacyValue = "legacy";',
 		});
-		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
+		const entry = await fs.realpath(path.join(dir, "index.js"));
+		const crawledPaths = await Promise.all(
+			[
+				"node_modules/commonjs-dep/index.cjs",
+				"node_modules/commonjs-dep/leaf.cjs",
+				"node_modules/native-risk/index.js",
+				"node_modules/native-risk/leaf.js",
+				"node_modules/legacy-risk/index.js",
+				"node_modules/legacy-risk/leaf.js",
+			].map(relativePath => fs.realpath(path.join(dir, relativePath))),
+		);
+
+		const sources = await __collectLegacyPiExtensionSourcesForTests(entry);
+		for (const crawledPath of crawledPaths) {
+			expect(sources.has(crawledPath)).toBe(true);
+		}
+
+		const mod = (await loadLegacyPiModule(entry)) as { values: string[] };
+		expect(mod.values).toEqual(["commonjs", "native", "legacy"]);
 	});
 
-	it("fails open when the package manifest is unreadable", async () => {
-		const dir = await writeGatePackage({ "readme.md": "no manifest here" });
-		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
+	it("reloads pruned ESM package entries and their relative leaves", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "reload-gate-ext", version: "1.0.0", type: "module" }),
+			"index.js": [
+				'import { dependencyVersion, leafVersion } from "reloadable-esm";',
+				'export const extensionVersion = "one";',
+				"export { dependencyVersion, leafVersion };",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+			"node_modules/reloadable-esm/package.json": JSON.stringify({
+				name: "reloadable-esm",
+				version: "1.0.0",
+				type: "module",
+				exports: "./index.js",
+			}),
+			"node_modules/reloadable-esm/index.js": [
+				'import { leafVersion } from "./leaf.js";',
+				'export const dependencyVersion = "one";',
+				"export { leafVersion };",
+			].join("\n"),
+			"node_modules/reloadable-esm/leaf.js": 'export const leafVersion = "one";',
+		});
+		const entry = path.join(dir, "index.js");
+		const dependencyEntry = path.join(dir, "node_modules/reloadable-esm/index.js");
+		const dependencyLeaf = path.join(dir, "node_modules/reloadable-esm/leaf.js");
+
+		const first = (await loadLegacyPiModule(entry)) as {
+			dependencyVersion: string;
+			extensionVersion: string;
+			leafVersion: string;
+		};
+		expect(first).toMatchObject({
+			dependencyVersion: "one",
+			extensionVersion: "one",
+			leafVersion: "one",
+		});
+
+		await fs.writeFile(
+			entry,
+			[
+				'import { dependencyVersion, leafVersion } from "reloadable-esm";',
+				'export const extensionVersion = "two";',
+				"export { dependencyVersion, leafVersion };",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+			"utf8",
+		);
+		await fs.writeFile(
+			dependencyEntry,
+			[
+				'import { leafVersion } from "./leaf.js";',
+				'export const dependencyVersion = "two";',
+				"export { leafVersion };",
+			].join("\n"),
+			"utf8",
+		);
+		await fs.writeFile(dependencyLeaf, 'export const leafVersion = "two";', "utf8");
+
+		const second = (await loadLegacyPiModule(entry)) as typeof first;
+		expect(second).toMatchObject({
+			dependencyVersion: "two",
+			extensionVersion: "two",
+			leafVersion: "two",
+		});
+	});
+
+	it("keeps arbitrary optional-native CommonJS children in the graph and pins their .node requires", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "arbitrary-native-ext", version: "1.0.0", type: "module" }),
+			"index.js": [
+				'import { loadSource } from "arbitrary-native-wrapper";',
+				"export { loadSource };",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+			"node_modules/arbitrary-native-wrapper/package.json": JSON.stringify({
+				name: "arbitrary-native-wrapper",
+				version: "1.0.0",
+				type: "module",
+				exports: "./index.js",
+				optionalDependencies: {
+					"@fixture/arbitrary-platform-linux-x64": "1.0.0",
+				},
+			}),
+			"node_modules/arbitrary-native-wrapper/index.js": [
+				'import loader from "./native.cjs";',
+				"export const loadSource = loader.load.toString();",
+			].join("\n"),
+			"node_modules/arbitrary-native-wrapper/native.cjs":
+				'module.exports = { load: () => require("@fixture/arbitrary-platform-linux-x64") };\n',
+			"node_modules/arbitrary-native-wrapper/node_modules/@fixture/arbitrary-platform-linux-x64/package.json":
+				JSON.stringify({
+					name: "@fixture/arbitrary-platform-linux-x64",
+					version: "1.0.0",
+					main: "binding.node",
+				}),
+			"node_modules/arbitrary-native-wrapper/node_modules/@fixture/arbitrary-platform-linux-x64/binding.node":
+				"native fixture",
+		});
+		const entry = await fs.realpath(path.join(dir, "index.js"));
+		const wrapperEntry = await fs.realpath(path.join(dir, "node_modules/arbitrary-native-wrapper/index.js"));
+		const nativeChild = await fs.realpath(path.join(dir, "node_modules/arbitrary-native-wrapper/native.cjs"));
+		const addon = await fs.realpath(
+			path.join(
+				dir,
+				"node_modules/arbitrary-native-wrapper/node_modules/@fixture/arbitrary-platform-linux-x64/binding.node",
+			),
+		);
+
+		const sources = await __collectLegacyPiExtensionSourcesForTests(entry);
+		expect(sources.has(wrapperEntry)).toBe(true);
+		expect(sources.has(nativeChild)).toBe(true);
+
+		const mod = (await loadLegacyPiModule(entry)) as { loadSource: string };
+		expect(mod.loadSource).toContain(addon.replaceAll("\\", "/"));
+	});
+
+	it("prunes safe ESM descendants through a symlinked package root", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "symlink-gate-ext", version: "1.0.0", type: "module" }),
+			"index.js": [
+				'import { selected } from "safe-linked";',
+				"export { selected };",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+		const store = path.join(dir, ".store", "safe-linked");
+		await fs.mkdir(store, { recursive: true });
+		await fs.writeFile(
+			path.join(store, "package.json"),
+			JSON.stringify({
+				name: "safe-linked",
+				version: "1.0.0",
+				type: "module",
+				exports: "./index.js",
+			}),
+			"utf8",
+		);
+		await fs.writeFile(
+			path.join(store, "index.js"),
+			['import { leaf } from "./leaf.js";', `export const selected = \`linked:\${leaf}\`;`].join("\n"),
+			"utf8",
+		);
+		await fs.writeFile(path.join(store, "leaf.js"), 'export const leaf = "safe";', "utf8");
+		await fs.mkdir(path.join(dir, "node_modules"), { recursive: true });
+		await fs.symlink(store, path.join(dir, "node_modules", "safe-linked"));
+
+		const entry = await fs.realpath(path.join(dir, "index.js"));
+		const selectedEntry = await fs.realpath(path.join(dir, "node_modules/safe-linked/index.js"));
+		const safeLeaf = await fs.realpath(path.join(dir, "node_modules/safe-linked/leaf.js"));
+
+		const sources = await __collectLegacyPiExtensionSourcesForTests(entry);
+		expect(sources.has(entry)).toBe(true);
+		expect(sources.has(selectedEntry)).toBe(true);
+		expect(sources.has(safeLeaf)).toBe(false);
+
+		const mod = (await loadLegacyPiModule(entry)) as { selected: string };
+		expect(mod.selected).toBe("linked:safe");
 	});
 });

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -5,10 +5,11 @@ import * as path from "node:path";
 import * as url from "node:url";
 import {
 	__collectLegacyPiExtensionSourcesForTests,
+	__packageNeedsGraphHooksForTests,
 	__rewriteLegacyExtensionSourceForTests,
 	loadLegacyPiModule,
 } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
-import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { removeWithRetries, TempDir } from "@oh-my-pi/pi-utils";
 
 // Issue #1674: legacy Pi extensions load browser-UI assets (HTML/CSS) at module
 // init via `readFileSync(join(__dirname, "ui.html"))`. The compat layer must run
@@ -18,10 +19,14 @@ import { removeWithRetries } from "@oh-my-pi/pi-utils";
 // public `loadLegacyPiModule` entry point.
 
 const tempRoots: string[] = [];
+const gateTempDirs: TempDir[] = [];
 
 afterAll(async () => {
 	for (const dir of tempRoots) {
 		await removeWithRetries(dir);
+	}
+	for (const dir of gateTempDirs) {
+		await dir.remove();
 	}
 });
 
@@ -34,6 +39,18 @@ async function writePackage(files: Record<string, string>): Promise<string> {
 		await fs.writeFile(abs, files[rel], "utf8");
 	}
 	return dir;
+}
+
+/** Gate fixtures use the central TempDir helper so cleanup stays full-suite safe. */
+async function writeGatePackage(files: Record<string, string>): Promise<string> {
+	const tempDir = await TempDir.create("@omp-legacy-graph-gate-");
+	gateTempDirs.push(tempDir);
+	for (const rel in files) {
+		const abs = tempDir.join(rel);
+		await fs.mkdir(path.dirname(abs), { recursive: true });
+		await fs.writeFile(abs, files[rel], "utf8");
+	}
+	return tempDir.path();
 }
 
 describe("legacy-pi in-place module loading (issue #1674)", () => {
@@ -1541,5 +1558,79 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		// extension's rewrite hook; its fork-scope import stays unresolved.
 		const siblingUrl = `${url.pathToFileURL(await fs.realpath(path.join(dir, "unrelated.ts"))).href}?nonce=${Date.now()}`;
 		await expect(import(siblingUrl)).rejects.toThrow(/@earendil-works\/pi-ai/);
+	});
+});
+
+describe("third-party graph-crawl gate", () => {
+	it("skips a pure-ESM package with plain dependencies and no exports map", async () => {
+		const dir = await writeGatePackage({
+			"package.json": JSON.stringify({
+				name: "pure-esm",
+				version: "1.0.0",
+				type: "module",
+				dependencies: { "lru-cache": "^11" },
+			}),
+		});
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(false);
+	});
+
+	it("skips an ESM package whose exports map has only import/default conditions", async () => {
+		const dir = await writeGatePackage({
+			"package.json": JSON.stringify({
+				name: "esm-exports",
+				version: "1.0.0",
+				type: "module",
+				exports: { ".": { import: "./index.js", default: "./index.js" } },
+			}),
+		});
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(false);
+	});
+
+	it("crawls a package whose exports map nests a require condition", async () => {
+		const dir = await writeGatePackage({
+			"package.json": JSON.stringify({
+				name: "dual-format",
+				version: "1.0.0",
+				type: "module",
+				exports: { ".": { node: { require: "./index.cjs", import: "./index.js" } } },
+			}),
+		});
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
+	});
+
+	it("crawls an implicit-CommonJS package (no type field)", async () => {
+		const dir = await writeGatePackage({
+			"package.json": JSON.stringify({ name: "implicit-cjs", version: "1.0.0" }),
+		});
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
+	});
+
+	it("crawls an ESM package that depends on a host pi package", async () => {
+		const dir = await writeGatePackage({
+			"package.json": JSON.stringify({
+				name: "pi-dependent",
+				version: "1.0.0",
+				type: "module",
+				dependencies: { "@oh-my-pi/pi-ai": "*" },
+			}),
+		});
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
+	});
+
+	it("crawls an ESM package that ships a native addon build", async () => {
+		const dir = await writeGatePackage({
+			"package.json": JSON.stringify({
+				name: "native-esm",
+				version: "1.0.0",
+				type: "module",
+				gypfile: true,
+			}),
+		});
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
+	});
+
+	it("fails open when the package manifest is unreadable", async () => {
+		const dir = await writeGatePackage({ "readme.md": "no manifest here" });
+		expect(await __packageNeedsGraphHooksForTests(dir)).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

Extension startup now prunes a resolved ESM package graph only when the selected file and package metadata prove compatibility hooks cannot apply. CommonJS, native-addon, optional-dependency, legacy-Pi, linked-root, and ambiguous cases retain the fail-open crawl.

## Performance

| Local Morph source-extension load | Mean |
| --- | ---: |
| Resolved ESM graph pruning | 3.953 s |
| Forced full crawl (`OMP_LEGACY_EXT_FULL_CRAWL=1`) | 7.446 s |

The resolved-file gate ran 1.88 ± 0.16× faster across 10 runs on this host.

## Verification

- [x] `bun check`
- [x] `bun --cwd=packages/coding-agent test test/extensibility/legacy-pi-inplace-load.test.ts` (49 pass)
- [x] Mutation probes for the dual-format, arbitrary-native, and symlinked-package regressions
- [x] 10-run `hyperfine` comparison with and without `OMP_LEGACY_EXT_FULL_CRAWL=1`
