### PR TITLE
perf(coding-agent): load extensions concurrently

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Loaded independent extensions concurrently while preserving their configured order for command, flag, renderer, and handler precedence.
+
 ## [17.2.5] - 2026-08-03
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Loaded independent extensions concurrently while preserving their configured order for command, flag, renderer, and handler precedence.
+- Loaded independent extension modules concurrently, then initialized their factories in configured path order while preserving command, flag, renderer, handler, and shared-event initialization contracts.
 
 ## [17.2.5] - 2026-08-03
 

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -156,6 +156,8 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 		private readonly runtime: IExtensionRuntime,
 		private readonly cwd: string,
 		public readonly events: EventBus,
+		private readonly providerSink?: Array<{ name: string; config: ProviderConfig; sourceId: string }>,
+		private readonly flagValueSink?: Map<string, boolean | string>,
 	) {}
 
 	on<F extends HandlerFn>(event: string, handler: F): void {
@@ -202,7 +204,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	): void {
 		this.extension.flags.set(name, { name, extensionPath: this.extension.path, ...options });
 		if (options.default !== undefined) {
-			this.runtime.flagValues.set(name, options.default);
+			(this.flagValueSink ?? this.runtime.flagValues).set(name, options.default);
 		}
 	}
 
@@ -216,7 +218,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 
 	getFlag(name: string): boolean | string | undefined {
 		if (!this.extension.flags.has(name)) return undefined;
-		return this.runtime.flagValues.get(name);
+		return (this.flagValueSink ?? this.runtime.flagValues).get(name);
 	}
 
 	sendMessage<T = unknown>(
@@ -289,7 +291,12 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	}
 
 	registerProvider(name: string, config: ProviderConfig): void {
-		this.runtime.pendingProviderRegistrations.push({ name, config, sourceId: this.extension.path });
+		const registration = { name, config, sourceId: this.extension.path };
+		if (this.providerSink) {
+			this.providerSink.push(registration);
+		} else {
+			this.runtime.pendingProviderRegistrations.push(registration);
+		}
 	}
 }
 
@@ -310,13 +317,22 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 	};
 }
 
+type ExtensionLoadResult = {
+	extension: Extension | null;
+	error: string | null;
+	providers: Array<{ name: string; config: ProviderConfig; sourceId: string }>;
+	flagDefaults: Map<string, boolean | string>;
+};
+
 async function loadExtension(
 	extensionPath: string,
 	cwd: string,
 	eventBus: EventBus,
 	runtime: IExtensionRuntime,
-): Promise<{ extension: Extension | null; error: string | null }> {
+): Promise<ExtensionLoadResult> {
 	const resolvedPath = resolvePath(extensionPath, cwd);
+	const providers: Array<{ name: string; config: ProviderConfig; sourceId: string }> = [];
+	const flagDefaults = new Map<string, boolean | string>();
 	try {
 		const module = (await withHostGuard(() => loadLegacyPiModule(resolvedPath))) as LoadedExtensionModule;
 		const factory = getExtensionFactory(module);
@@ -325,19 +341,21 @@ async function loadExtension(
 			return {
 				extension: null,
 				error: `Extension does not export a valid factory function: ${extensionPath}`,
+				providers,
+				flagDefaults,
 			};
 		}
 
 		const extension = createExtension(extensionPath, resolvedPath);
-		const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, eventBus);
+		const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, eventBus, providers, flagDefaults);
 		await withHostGuard(async () => {
 			await factory(api);
 		});
 
-		return { extension, error: null };
+		return { extension, error: null, providers, flagDefaults };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		return { extension: null, error: `Failed to load extension: ${message}` };
+		return { extension: null, error: `Failed to load extension: ${message}`, providers, flagDefaults };
 	}
 }
 
@@ -357,25 +375,38 @@ export async function loadExtensionFromFactory(
 	return extension;
 }
 
+const LOAD_CONCURRENCY = 8;
+
 /**
  * Load extensions from paths.
+ *
+ * Loads up to {@link LOAD_CONCURRENCY} extensions concurrently. Results are
+ * written into a pre-sized array by input index, so `extensions`, `errors`,
+ * and `runtime.pendingProviderRegistrations` preserve the `paths` order
+ * regardless of completion order.
  */
 export async function loadExtensions(paths: string[], cwd: string, eventBus?: EventBus): Promise<LoadExtensionsResult> {
 	const extensions: Extension[] = [];
 	const errors: Array<{ path: string; error: string }> = [];
 	const resolvedEventBus = eventBus ?? new EventBus();
 	const runtime = new ExtensionRuntime();
-
-	for (const extPath of paths) {
-		const { extension, error } = await loadExtension(extPath, cwd, resolvedEventBus, runtime);
-
-		if (error) {
-			errors.push({ path: extPath, error });
-			continue;
+	const settled: ExtensionLoadResult[] = new Array(paths.length);
+	let next = 0;
+	const workers = Array.from({ length: Math.min(LOAD_CONCURRENCY, paths.length) }, async () => {
+		while (true) {
+			const index = next++;
+			if (index >= paths.length) return;
+			settled[index] = await loadExtension(paths[index], cwd, resolvedEventBus, runtime);
 		}
+	});
+	await Promise.all(workers);
 
-		if (extension) {
-			extensions.push(extension);
+	for (const [index, { extension, error, providers, flagDefaults }] of settled.entries()) {
+		if (error) errors.push({ path: paths[index], error });
+		if (extension) extensions.push(extension);
+		runtime.pendingProviderRegistrations.push(...providers);
+		for (const [name, value] of flagDefaults) {
+			runtime.flagValues.set(name, value);
 		}
 	}
 

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -156,8 +156,6 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 		private readonly runtime: IExtensionRuntime,
 		private readonly cwd: string,
 		public readonly events: EventBus,
-		private readonly providerSink?: Array<{ name: string; config: ProviderConfig; sourceId: string }>,
-		private readonly flagValueSink?: Map<string, boolean | string>,
 	) {}
 
 	on<F extends HandlerFn>(event: string, handler: F): void {
@@ -204,7 +202,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	): void {
 		this.extension.flags.set(name, { name, extensionPath: this.extension.path, ...options });
 		if (options.default !== undefined) {
-			(this.flagValueSink ?? this.runtime.flagValues).set(name, options.default);
+			this.runtime.flagValues.set(name, options.default);
 		}
 	}
 
@@ -218,7 +216,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 
 	getFlag(name: string): boolean | string | undefined {
 		if (!this.extension.flags.has(name)) return undefined;
-		return (this.flagValueSink ?? this.runtime.flagValues).get(name);
+		return this.runtime.flagValues.get(name);
 	}
 
 	sendMessage<T = unknown>(
@@ -291,12 +289,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	}
 
 	registerProvider(name: string, config: ProviderConfig): void {
-		const registration = { name, config, sourceId: this.extension.path };
-		if (this.providerSink) {
-			this.providerSink.push(registration);
-		} else {
-			this.runtime.pendingProviderRegistrations.push(registration);
-		}
+		this.runtime.pendingProviderRegistrations.push({ name, config, sourceId: this.extension.path });
 	}
 }
 
@@ -317,45 +310,76 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 	};
 }
 
-type ExtensionLoadResult = {
-	extension: Extension | null;
+type ImportedExtensionModule = {
+	path: string;
+	resolvedPath: string;
+	factory: ExtensionFactory | null;
 	error: string | null;
-	providers: Array<{ name: string; config: ProviderConfig; sourceId: string }>;
-	flagDefaults: Map<string, boolean | string>;
 };
 
-async function loadExtension(
-	extensionPath: string,
-	cwd: string,
-	eventBus: EventBus,
-	runtime: IExtensionRuntime,
-): Promise<ExtensionLoadResult> {
+/**
+ * Import an extension module without running its factory.
+ */
+async function importExtensionModule(extensionPath: string, cwd: string): Promise<ImportedExtensionModule> {
 	const resolvedPath = resolvePath(extensionPath, cwd);
-	const providers: Array<{ name: string; config: ProviderConfig; sourceId: string }> = [];
-	const flagDefaults = new Map<string, boolean | string>();
 	try {
 		const module = (await withHostGuard(() => loadLegacyPiModule(resolvedPath))) as LoadedExtensionModule;
 		const factory = getExtensionFactory(module);
 
 		if (typeof factory !== "function") {
 			return {
-				extension: null,
+				path: extensionPath,
+				resolvedPath,
+				factory: null,
 				error: `Extension does not export a valid factory function: ${extensionPath}`,
-				providers,
-				flagDefaults,
 			};
 		}
 
-		const extension = createExtension(extensionPath, resolvedPath);
-		const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, eventBus, providers, flagDefaults);
-		await withHostGuard(async () => {
-			await factory(api);
-		});
-
-		return { extension, error: null, providers, flagDefaults };
+		return { path: extensionPath, resolvedPath, factory, error: null };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		return { extension: null, error: `Failed to load extension: ${message}`, providers, flagDefaults };
+		return {
+			path: extensionPath,
+			resolvedPath,
+			factory: null,
+			error: `Failed to load extension: ${message}`,
+		};
+	}
+}
+
+/**
+ * Run an already-imported extension factory against the shared runtime.
+ *
+ * Provider and flag registrations write directly to `runtime`. When a factory
+ * throws after partial registration, those writes remain (matching the previous
+ * sequential loader contract).
+ */
+async function initializeImportedExtension(
+	imported: ImportedExtensionModule,
+	cwd: string,
+	eventBus: EventBus,
+	runtime: IExtensionRuntime,
+): Promise<{ extension: Extension | null; error: string | null }> {
+	if (imported.error) {
+		return { extension: null, error: imported.error };
+	}
+	if (!imported.factory) {
+		return {
+			extension: null,
+			error: `Extension does not export a valid factory function: ${imported.path}`,
+		};
+	}
+
+	try {
+		const extension = createExtension(imported.path, imported.resolvedPath);
+		const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, eventBus);
+		await withHostGuard(async () => {
+			await imported.factory!(api);
+		});
+		return { extension, error: null };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { extension: null, error: `Failed to load extension: ${message}` };
 	}
 }
 
@@ -380,34 +404,32 @@ const LOAD_CONCURRENCY = 8;
 /**
  * Load extensions from paths.
  *
- * Loads up to {@link LOAD_CONCURRENCY} extensions concurrently. Results are
- * written into a pre-sized array by input index, so `extensions`, `errors`,
- * and `runtime.pendingProviderRegistrations` preserve the `paths` order
- * regardless of completion order.
+ * Imports up to {@link LOAD_CONCURRENCY} independent modules concurrently, then
+ * runs their factories sequentially in `paths` order so shared `events`,
+ * provider registrations, and flag defaults keep the configured initialization
+ * contract. `pi.getFlag()` always reads `runtime.flagValues`, including CLI
+ * overrides applied after loading.
  */
 export async function loadExtensions(paths: string[], cwd: string, eventBus?: EventBus): Promise<LoadExtensionsResult> {
 	const extensions: Extension[] = [];
 	const errors: Array<{ path: string; error: string }> = [];
 	const resolvedEventBus = eventBus ?? new EventBus();
 	const runtime = new ExtensionRuntime();
-	const settled: ExtensionLoadResult[] = new Array(paths.length);
+	const imported: ImportedExtensionModule[] = new Array(paths.length);
 	let next = 0;
 	const workers = Array.from({ length: Math.min(LOAD_CONCURRENCY, paths.length) }, async () => {
 		while (true) {
 			const index = next++;
 			if (index >= paths.length) return;
-			settled[index] = await loadExtension(paths[index], cwd, resolvedEventBus, runtime);
+			imported[index] = await importExtensionModule(paths[index], cwd);
 		}
 	});
 	await Promise.all(workers);
 
-	for (const [index, { extension, error, providers, flagDefaults }] of settled.entries()) {
-		if (error) errors.push({ path: paths[index], error });
+	for (const module of imported) {
+		const { extension, error } = await initializeImportedExtension(module, cwd, resolvedEventBus, runtime);
+		if (error) errors.push({ path: module.path, error });
 		if (extension) extensions.push(extension);
-		runtime.pendingProviderRegistrations.push(...providers);
-		for (const [name, value] of flagDefaults) {
-			runtime.flagValues.set(name, value);
-		}
 	}
 
 	return {

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -2404,6 +2404,11 @@ async function installExtensionGraphHook(
  *
  * Returns a clearable handle to drop cached sources that weren't consumed
  * during the initial load; `undefined` when no new modules were discovered.
+ *
+ * Callers must not clear the handle while another {@link loadLegacyPiModule}
+ * import may still need the process-global CommonJS source/definition/cache
+ * maps. Concurrent loads retain every handle and flush them together after the
+ * last in-flight load settles, including peers still inside this preparation.
  */
 async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(): void } | undefined> {
 	const {
@@ -2434,6 +2439,11 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 			// stale snapshot from the walk that flagged it.
 			synchronousModuleSources.set(modulePath, await rewriteLegacyExtensionSource(source, modulePath));
 		}
+	}
+	// Test seam: after shared CommonJS sources are written, allow a concurrent
+	// load to finish and attempt cleanup while this preparation is still open.
+	if (graphPreparationPauseForTests) {
+		await graphPreparationPauseForTests();
 	}
 	let hookedModules = extensionGraphHookModules.get(entryRealPath);
 	if (!hookedModules) {
@@ -2484,6 +2494,72 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<{ clear(
 	};
 }
 
+type ExtensionGraphHookCleanup = { clear(): void };
+
+/**
+ * Concurrent {@link loadLegacyPiModule} calls share process-global CommonJS
+ * source/definition/cache maps. Clearing a single entry's handle while another
+ * import is still in flight can delete a shared rewritten dependency out from
+ * under that import. Retain every cleanup handle and flush them only after the
+ * last in-flight load settles — including loads still inside async graph
+ * preparation, before their cleanup handle exists.
+ */
+let inFlightLegacyPiLoads = 0;
+const retainedGraphHookCleanups: ExtensionGraphHookCleanup[] = [];
+
+/** Test seam: pause inside {@link ensureExtensionGraphHook} after CJS sources are written. */
+let graphPreparationPauseForTests: (() => Promise<void>) | undefined;
+
+/** Test seam: observe in-flight legacy load count changes. */
+let inFlightChangedForTests: ((count: number) => void) | undefined;
+
+function notifyInFlightChangedForTests(): void {
+	inFlightChangedForTests?.(inFlightLegacyPiLoads);
+}
+
+function beginLegacyPiLoadLifetime(): void {
+	inFlightLegacyPiLoads++;
+	notifyInFlightChangedForTests();
+}
+
+function retainExtensionGraphHookCleanup(cleanup: ExtensionGraphHookCleanup | undefined): void {
+	if (cleanup) {
+		retainedGraphHookCleanups.push(cleanup);
+	}
+}
+
+function releaseExtensionGraphHookCleanup(): void {
+	inFlightLegacyPiLoads--;
+	notifyInFlightChangedForTests();
+	if (inFlightLegacyPiLoads > 0) {
+		return;
+	}
+	const cleanups = retainedGraphHookCleanups.splice(0);
+	for (const cleanup of cleanups) {
+		cleanup.clear();
+	}
+}
+
+/** Test seam: whether a graph-owned CommonJS source is still retained. */
+export function __hasCommonJsModuleSourceForTests(modulePath: string): boolean {
+	return commonJsModuleSources.has(modulePath);
+}
+
+/** Test seam: in-flight legacy module loads retaining graph-hook cleanups. */
+export function __inFlightLegacyPiLoadsForTests(): number {
+	return inFlightLegacyPiLoads;
+}
+
+/** Test seam: pause graph preparation after rewritten CommonJS sources are stored. */
+export function __setLegacyPiGraphPreparationPauseForTests(pause: (() => Promise<void>) | undefined): void {
+	graphPreparationPauseForTests = pause;
+}
+
+/** Test seam: observe in-flight count changes for deterministic reverse-completion gates. */
+export function __setLegacyPiInFlightChangedForTests(listener: ((count: number) => void) | undefined): void {
+	inFlightChangedForTests = listener;
+}
+
 /**
  * Load a legacy Pi extension module from its real on-disk location.
  *
@@ -2501,8 +2577,13 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 	// actually hands the hook.
 	const entryRealPath = await realpathOrSelf(path.resolve(resolvedPath));
 	await ensureLegacyPiOverridesReady();
-	const pendingSources = await ensureExtensionGraphHook(entryRealPath);
+	// Count this load before graph preparation writes shared maps. Otherwise a
+	// peer that finishes while we are still inside `ensureExtensionGraphHook`
+	// can flush retained cleanups and delete CommonJS sources we just prepared.
+	beginLegacyPiLoadLifetime();
 	try {
+		const pendingSources = await ensureExtensionGraphHook(entryRealPath);
+		retainExtensionGraphHookCleanup(pendingSources);
 		// Dynamic import is required: legacy extension entry paths are user/plugin supplied at runtime.
 		// On POSIX, use the raw filesystem path so Bun keys the `?mtime`
 		// suffix as part of the module identity; Bun ignores query strings on
@@ -2513,10 +2594,10 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 				: entryRealPath;
 		return await import(`${entrySpecifier}?mtime=${nextLegacyPiLoadTag()}`);
 	} finally {
-		// Drop whatever the initial import didn't consume: graph modules only
-		// reached by lazy dynamic imports must be read from disk at their actual
-		// import time, not served from this load-time snapshot.
-		pendingSources?.clear();
+		// Drop load-time snapshots only after every overlapping import settles:
+		// graph modules only reached by lazy dynamic imports must then be read
+		// from disk at their actual import time, not served from this snapshot.
+		releaseExtensionGraphHookCleanup();
 	}
 }
 

--- a/packages/coding-agent/test/cli-extension-providers.test.ts
+++ b/packages/coding-agent/test/cli-extension-providers.test.ts
@@ -14,12 +14,13 @@
  * passed explicitly so the test never touches the developer's real `~/.omp`.
  */
 
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import { AuthStorage } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { getModelMatchPreferences, resolveCliModel } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { loadCliExtensionProviders } from "@oh-my-pi/pi-coding-agent/sdk";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
@@ -86,4 +87,150 @@ test("loadCliExtensionProviders makes extension providers resolvable by selector
 	} finally {
 		authStorage.close();
 	}
+});
+
+type ExtensionLoadGate = {
+	firstStarted: () => void;
+	secondRegistered: () => void;
+	wait: Promise<void>;
+};
+
+describe("loadExtensions registration order", () => {
+	let orderTmp: TempDir;
+
+	beforeEach(async () => {
+		orderTmp = await TempDir.create("@cli-ext-providers-order-");
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		await orderTmp.remove();
+	});
+
+	test("preserves provider order when concurrent factories finish out of order", async () => {
+		const firstPath = orderTmp.join("first-provider.ts");
+		const secondPath = orderTmp.join("second-provider.ts");
+		const firstStarted = Promise.withResolvers<void>();
+		const secondRegistered = Promise.withResolvers<void>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const gateKey = `__ompExtensionLoadGate_${Bun.hash(orderTmp.path()).toString(36)}`;
+		const globals = globalThis as typeof globalThis & Record<string, ExtensionLoadGate | undefined>;
+		globals[gateKey] = {
+			firstStarted: () => firstStarted.resolve(),
+			secondRegistered: () => secondRegistered.resolve(),
+			wait: releaseFirst.promise,
+		};
+
+		try {
+			await fs.writeFile(
+				firstPath,
+				`export default async function (pi) {
+	const gate = globalThis[${JSON.stringify(gateKey)}] as { firstStarted: () => void; wait: Promise<void> };
+	gate.firstStarted();
+	await gate.wait;
+	pi.registerProvider("shared-provider", { baseUrl: "https://first.example.com/v1" });
+}`,
+			);
+			await fs.writeFile(
+				secondPath,
+				`export default function (pi) {
+	pi.registerProvider("shared-provider", { baseUrl: "https://second.example.com/v1" });
+	(globalThis[${JSON.stringify(gateKey)}] as { secondRegistered: () => void }).secondRegistered();
+}`,
+			);
+
+			const resultPromise = loadExtensions([firstPath, secondPath], orderTmp.path());
+			await Promise.all([firstStarted.promise, secondRegistered.promise]);
+			releaseFirst.resolve();
+			const result = await resultPromise;
+
+			expect(result.errors).toEqual([]);
+			expect(result.extensions).toHaveLength(2);
+			expect(result.runtime.pendingProviderRegistrations).toEqual([
+				{
+					name: "shared-provider",
+					config: { baseUrl: "https://first.example.com/v1" },
+					sourceId: firstPath,
+				},
+				{
+					name: "shared-provider",
+					config: { baseUrl: "https://second.example.com/v1" },
+					sourceId: secondPath,
+				},
+			]);
+		} finally {
+			delete globals[gateKey];
+		}
+	});
+
+	test("preserves later flag defaults when factories finish out of order", async () => {
+		const firstPath = orderTmp.join("first-flag.ts");
+		const secondPath = orderTmp.join("second-flag.ts");
+		const firstStarted = Promise.withResolvers<void>();
+		const secondRegistered = Promise.withResolvers<void>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const gateKey = `__ompExtensionLoadGate_${Bun.hash(orderTmp.path()).toString(36)}`;
+		const globals = globalThis as typeof globalThis & Record<string, ExtensionLoadGate | undefined>;
+		globals[gateKey] = {
+			firstStarted: () => firstStarted.resolve(),
+			secondRegistered: () => secondRegistered.resolve(),
+			wait: releaseFirst.promise,
+		};
+
+		try {
+			await fs.writeFile(
+				firstPath,
+				`export default async function (pi) {
+	const gate = globalThis[${JSON.stringify(gateKey)}] as { firstStarted: () => void; wait: Promise<void> };
+	gate.firstStarted();
+	await gate.wait;
+	pi.registerFlag("shared-flag", { type: "string", default: "first" });
+}
+`,
+			);
+			await fs.writeFile(
+				secondPath,
+				`export default function (pi) {
+	pi.registerFlag("shared-flag", { type: "string", default: "second" });
+	(globalThis[${JSON.stringify(gateKey)}] as { secondRegistered: () => void }).secondRegistered();
+}
+`,
+			);
+
+			const resultPromise = loadExtensions([firstPath, secondPath], orderTmp.path());
+			await Promise.all([firstStarted.promise, secondRegistered.promise]);
+			releaseFirst.resolve();
+			const result = await resultPromise;
+
+			expect(result.errors).toEqual([]);
+			expect(result.runtime.flagValues.get("shared-flag")).toBe("second");
+		} finally {
+			delete globals[gateKey];
+		}
+	});
+
+	test("keeps providers registered before a factory fails", async () => {
+		const failingPath = orderTmp.join("failing-provider.ts");
+		await fs.writeFile(
+			failingPath,
+			`export default function (pi) {
+	pi.registerProvider("kept-provider", { baseUrl: "https://kept.example.com/v1" });
+	throw new Error("failure after provider registration");
+}
+`,
+		);
+
+		const result = await loadExtensions([failingPath], orderTmp.path());
+
+		expect(result.extensions).toEqual([]);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]?.path).toBe(failingPath);
+		expect(result.runtime.pendingProviderRegistrations).toEqual([
+			{
+				name: "kept-provider",
+				config: { baseUrl: "https://kept.example.com/v1" },
+				sourceId: failingPath,
+			},
+		]);
+	});
 });

--- a/packages/coding-agent/test/cli-extension-providers.test.ts
+++ b/packages/coding-agent/test/cli-extension-providers.test.ts
@@ -21,6 +21,12 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { getModelMatchPreferences, resolveCliModel } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import {
+	__hasCommonJsModuleSourceForTests,
+	__inFlightLegacyPiLoadsForTests,
+	__setLegacyPiInFlightChangedForTests,
+} from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
 import { loadCliExtensionProviders } from "@oh-my-pi/pi-coding-agent/sdk";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
@@ -89,10 +95,14 @@ test("loadCliExtensionProviders makes extension providers resolvable by selector
 	}
 });
 
-type ExtensionLoadGate = {
-	firstStarted: () => void;
-	secondRegistered: () => void;
+type ExtensionImportGate = {
+	firstImportStarted: () => void;
+	secondImported: () => void;
 	wait: Promise<void>;
+};
+
+type ExtensionFlagProbe = {
+	getFlag: () => boolean | string | undefined;
 };
 
 describe("loadExtensions registration order", () => {
@@ -107,53 +117,59 @@ describe("loadExtensions registration order", () => {
 		await orderTmp.remove();
 	});
 
-	test("preserves provider order when concurrent factories finish out of order", async () => {
-		const firstPath = orderTmp.join("first-provider.ts");
-		const secondPath = orderTmp.join("second-provider.ts");
-		const firstStarted = Promise.withResolvers<void>();
-		const secondRegistered = Promise.withResolvers<void>();
-		const releaseFirst = Promise.withResolvers<void>();
-		const gateKey = `__ompExtensionLoadGate_${Bun.hash(orderTmp.path()).toString(36)}`;
-		const globals = globalThis as typeof globalThis & Record<string, ExtensionLoadGate | undefined>;
+	test("imports independent modules concurrently before sequential factory init", async () => {
+		const firstPath = orderTmp.join("first-import.ts");
+		const secondPath = orderTmp.join("second-import.ts");
+		const firstImportStarted = Promise.withResolvers<void>();
+		const secondImported = Promise.withResolvers<void>();
+		const releaseFirstImport = Promise.withResolvers<void>();
+		const gateKey = `__ompExtensionImportGate_${Bun.hash(orderTmp.path()).toString(36)}`;
+		const globals = globalThis as typeof globalThis & Record<string, ExtensionImportGate | undefined>;
 		globals[gateKey] = {
-			firstStarted: () => firstStarted.resolve(),
-			secondRegistered: () => secondRegistered.resolve(),
-			wait: releaseFirst.promise,
+			firstImportStarted: () => firstImportStarted.resolve(),
+			secondImported: () => secondImported.resolve(),
+			wait: releaseFirstImport.promise,
 		};
 
 		try {
 			await fs.writeFile(
 				firstPath,
-				`export default async function (pi) {
-	const gate = globalThis[${JSON.stringify(gateKey)}] as { firstStarted: () => void; wait: Promise<void> };
-	gate.firstStarted();
-	await gate.wait;
-	pi.registerProvider("shared-provider", { baseUrl: "https://first.example.com/v1" });
-}`,
+				`const gate = globalThis[${JSON.stringify(gateKey)}] as {
+	firstImportStarted: () => void;
+	wait: Promise<void>;
+};
+gate.firstImportStarted();
+await gate.wait;
+export default function (pi) {
+	pi.registerProvider("first-provider", { baseUrl: "https://first.example.com/v1" });
+}
+`,
 			);
 			await fs.writeFile(
 				secondPath,
-				`export default function (pi) {
-	pi.registerProvider("shared-provider", { baseUrl: "https://second.example.com/v1" });
-	(globalThis[${JSON.stringify(gateKey)}] as { secondRegistered: () => void }).secondRegistered();
-}`,
+				`(globalThis[${JSON.stringify(gateKey)}] as { secondImported: () => void }).secondImported();
+export default function (pi) {
+	pi.registerProvider("second-provider", { baseUrl: "https://second.example.com/v1" });
+}
+`,
 			);
 
 			const resultPromise = loadExtensions([firstPath, secondPath], orderTmp.path());
-			await Promise.all([firstStarted.promise, secondRegistered.promise]);
-			releaseFirst.resolve();
+			// Sequential imports would deadlock here: the first module awaits release
+			await Promise.all([firstImportStarted.promise, secondImported.promise]);
+			releaseFirstImport.resolve();
 			const result = await resultPromise;
 
 			expect(result.errors).toEqual([]);
 			expect(result.extensions).toHaveLength(2);
 			expect(result.runtime.pendingProviderRegistrations).toEqual([
 				{
-					name: "shared-provider",
+					name: "first-provider",
 					config: { baseUrl: "https://first.example.com/v1" },
 					sourceId: firstPath,
 				},
 				{
-					name: "shared-provider",
+					name: "second-provider",
 					config: { baseUrl: "https://second.example.com/v1" },
 					sourceId: secondPath,
 				},
@@ -163,49 +179,126 @@ describe("loadExtensions registration order", () => {
 		}
 	});
 
-	test("preserves later flag defaults when factories finish out of order", async () => {
+	test("preserves provider order across sequential factory initialization", async () => {
+		const firstPath = orderTmp.join("first-provider.ts");
+		const secondPath = orderTmp.join("second-provider.ts");
+		await fs.writeFile(
+			firstPath,
+			`export default function (pi) {
+	pi.registerProvider("shared-provider", { baseUrl: "https://first.example.com/v1" });
+}
+`,
+		);
+		await fs.writeFile(
+			secondPath,
+			`export default function (pi) {
+	pi.registerProvider("shared-provider", { baseUrl: "https://second.example.com/v1" });
+}
+`,
+		);
+
+		const result = await loadExtensions([firstPath, secondPath], orderTmp.path());
+
+		expect(result.errors).toEqual([]);
+		expect(result.extensions).toHaveLength(2);
+		expect(result.runtime.pendingProviderRegistrations).toEqual([
+			{
+				name: "shared-provider",
+				config: { baseUrl: "https://first.example.com/v1" },
+				sourceId: firstPath,
+			},
+			{
+				name: "shared-provider",
+				config: { baseUrl: "https://second.example.com/v1" },
+				sourceId: secondPath,
+			},
+		]);
+	});
+
+	test("preserves later flag defaults from configured path order", async () => {
 		const firstPath = orderTmp.join("first-flag.ts");
 		const secondPath = orderTmp.join("second-flag.ts");
-		const firstStarted = Promise.withResolvers<void>();
-		const secondRegistered = Promise.withResolvers<void>();
-		const releaseFirst = Promise.withResolvers<void>();
-		const gateKey = `__ompExtensionLoadGate_${Bun.hash(orderTmp.path()).toString(36)}`;
-		const globals = globalThis as typeof globalThis & Record<string, ExtensionLoadGate | undefined>;
-		globals[gateKey] = {
-			firstStarted: () => firstStarted.resolve(),
-			secondRegistered: () => secondRegistered.resolve(),
-			wait: releaseFirst.promise,
-		};
-
-		try {
-			await fs.writeFile(
-				firstPath,
-				`export default async function (pi) {
-	const gate = globalThis[${JSON.stringify(gateKey)}] as { firstStarted: () => void; wait: Promise<void> };
-	gate.firstStarted();
-	await gate.wait;
+		await fs.writeFile(
+			firstPath,
+			`export default function (pi) {
 	pi.registerFlag("shared-flag", { type: "string", default: "first" });
 }
 `,
+		);
+		await fs.writeFile(
+			secondPath,
+			`export default function (pi) {
+	pi.registerFlag("shared-flag", { type: "string", default: "second" });
+}
+`,
+		);
+
+		const result = await loadExtensions([firstPath, secondPath], orderTmp.path());
+
+		expect(result.errors).toEqual([]);
+		expect(result.runtime.flagValues.get("shared-flag")).toBe("second");
+	});
+
+	test("getFlag reads runtime overrides after loading", async () => {
+		const flagPath = orderTmp.join("flag-override.ts");
+		const probeKey = `__ompExtensionFlagProbe_${Bun.hash(orderTmp.path()).toString(36)}`;
+		const globals = globalThis as typeof globalThis & Record<string, ExtensionFlagProbe | undefined>;
+
+		try {
+			await fs.writeFile(
+				flagPath,
+				`export default function (pi) {
+	pi.registerFlag("demo-flag", { type: "string", default: "from-default" });
+	(globalThis[${JSON.stringify(probeKey)}] as { getFlag: () => boolean | string | undefined }).getFlag = () =>
+		pi.getFlag("demo-flag");
+}
+`,
+			);
+			globals[probeKey] = { getFlag: () => undefined };
+
+			const result = await loadExtensions([flagPath], orderTmp.path());
+
+			expect(result.errors).toEqual([]);
+			expect(globals[probeKey]?.getFlag()).toBe("from-default");
+			result.runtime.flagValues.set("demo-flag", "from-cli");
+			expect(globals[probeKey]?.getFlag()).toBe("from-cli");
+		} finally {
+			delete globals[probeKey];
+		}
+	});
+
+	test("delivers shared startup events from later factories to earlier listeners", async () => {
+		const listenerPath = orderTmp.join("event-listener.ts");
+		const emitterPath = orderTmp.join("event-emitter.ts");
+		const seenKey = `__ompExtensionEventSeen_${Bun.hash(orderTmp.path()).toString(36)}`;
+		const globals = globalThis as typeof globalThis & Record<string, string[] | undefined>;
+		globals[seenKey] = [];
+
+		try {
+			await fs.writeFile(
+				listenerPath,
+				`export default function (pi) {
+	pi.events.on("extension-boot", (payload) => {
+		(globalThis[${JSON.stringify(seenKey)}] as string[]).push(String(payload));
+	});
+}
+`,
 			);
 			await fs.writeFile(
-				secondPath,
+				emitterPath,
 				`export default function (pi) {
-	pi.registerFlag("shared-flag", { type: "string", default: "second" });
-	(globalThis[${JSON.stringify(gateKey)}] as { secondRegistered: () => void }).secondRegistered();
+	pi.events.emit("extension-boot", "hello-from-later");
 }
 `,
 			);
 
-			const resultPromise = loadExtensions([firstPath, secondPath], orderTmp.path());
-			await Promise.all([firstStarted.promise, secondRegistered.promise]);
-			releaseFirst.resolve();
-			const result = await resultPromise;
+			const result = await loadExtensions([listenerPath, emitterPath], orderTmp.path());
 
 			expect(result.errors).toEqual([]);
-			expect(result.runtime.flagValues.get("shared-flag")).toBe("second");
+			expect(result.extensions).toHaveLength(2);
+			expect(globals[seenKey]).toEqual(["hello-from-later"]);
 		} finally {
-			delete globals[gateKey];
+			delete globals[seenKey];
 		}
 	});
 
@@ -232,5 +325,111 @@ describe("loadExtensions registration order", () => {
 				sourceId: failingPath,
 			},
 		]);
+	});
+
+	test("keeps flag defaults registered before a factory fails", async () => {
+		const failingPath = orderTmp.join("failing-flag.ts");
+		await fs.writeFile(
+			failingPath,
+			`export default function (pi) {
+	pi.registerFlag("kept-flag", { type: "string", default: "kept" });
+	throw new Error("failure after flag registration");
+}
+`,
+		);
+
+		const result = await loadExtensions([failingPath], orderTmp.path());
+
+		expect(result.extensions).toEqual([]);
+		expect(result.errors).toHaveLength(1);
+		expect(result.runtime.flagValues.get("kept-flag")).toBe("kept");
+	});
+
+	test("retains shared rewritten CommonJS sources across reverse-completion imports", async () => {
+		const sharedDir = orderTmp.join("node_modules", "direct");
+		await fs.mkdir(sharedDir, { recursive: true });
+		await fs.writeFile(
+			orderTmp.join("node_modules", "direct", "package.json"),
+			JSON.stringify({ name: "direct", version: "1.0.0", main: "index.js" }),
+		);
+		await fs.writeFile(
+			orderTmp.join("node_modules", "direct", "index.js"),
+			'module.exports = require("@mariozechner/pi-ai").Type;\n',
+		);
+
+		const firstPath = orderTmp.join("shared-cjs-first.ts");
+		const secondPath = orderTmp.join("shared-cjs-second.ts");
+		const firstReady = Promise.withResolvers<boolean>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const onlyFirstInFlight = Promise.withResolvers<void>();
+		const gateKey = `__ompSharedCjsExtGate_${Bun.hash(orderTmp.path()).toString(36)}`;
+		const globals = globalThis as typeof globalThis &
+			Record<string, { firstReady: (ok: boolean) => void; wait: Promise<void> } | undefined>;
+		globals[gateKey] = {
+			firstReady: ok => firstReady.resolve(ok),
+			wait: releaseFirst.promise,
+		};
+		let sawOverlappingLoads = false;
+		__setLegacyPiInFlightChangedForTests(count => {
+			if (count >= 2) sawOverlappingLoads = true;
+			if (sawOverlappingLoads && count === 1) onlyFirstInFlight.resolve();
+		});
+		let resultPromise: Promise<LoadExtensionsResult> | undefined;
+
+		try {
+			await fs.writeFile(
+				firstPath,
+				`import { Type } from "@oh-my-pi/pi-ai";
+import requiredType from "direct";
+const gate = globalThis[${JSON.stringify(gateKey)}] as {
+	firstReady: (ok: boolean) => void;
+	wait: Promise<void>;
+};
+gate.firstReady(requiredType === Type);
+await gate.wait;
+export default function (pi) {
+	pi.registerProvider("shared-cjs-first", { baseUrl: "https://first-shared.example.com/v1" });
+}
+`,
+			);
+			await fs.writeFile(
+				secondPath,
+				`import { Type } from "@oh-my-pi/pi-ai";
+import requiredType from "direct";
+if (requiredType !== Type) {
+	throw new Error("shared rewritten CommonJS dependency failed to remap");
+}
+export default function (pi) {
+	pi.registerProvider("shared-cjs-second", { baseUrl: "https://second-shared.example.com/v1" });
+}
+`,
+			);
+
+			const sharedPath = await fs.realpath(orderTmp.join("node_modules", "direct", "index.js"));
+			resultPromise = loadExtensions([firstPath, secondPath], orderTmp.path());
+			expect(await firstReady.promise).toBe(true);
+
+			// Reverse completion: wait until only the gated first import remains
+			// in flight. Eager cleanup would have cleared the shared source here.
+			await onlyFirstInFlight.promise;
+			expect(__inFlightLegacyPiLoadsForTests()).toBe(1);
+			expect(__hasCommonJsModuleSourceForTests(sharedPath)).toBe(true);
+
+			releaseFirst.resolve();
+			const result = await resultPromise;
+			expect(result.errors).toEqual([]);
+			expect(result.extensions).toHaveLength(2);
+			expect(result.runtime.pendingProviderRegistrations.map(entry => entry.name)).toEqual([
+				"shared-cjs-first",
+				"shared-cjs-second",
+			]);
+			expect(__inFlightLegacyPiLoadsForTests()).toBe(0);
+			expect(__hasCommonJsModuleSourceForTests(sharedPath)).toBe(false);
+		} finally {
+			releaseFirst.resolve();
+			await resultPromise?.catch(() => undefined);
+			__setLegacyPiInFlightChangedForTests(undefined);
+			delete globals[gateKey];
+		}
 	});
 });

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -5,7 +5,10 @@ import * as path from "node:path";
 import * as url from "node:url";
 import {
 	__collectLegacyPiExtensionSourcesForTests,
+	__hasCommonJsModuleSourceForTests,
+	__inFlightLegacyPiLoadsForTests,
 	__rewriteLegacyExtensionSourceForTests,
+	__setLegacyPiGraphPreparationPauseForTests,
 	loadLegacyPiModule,
 } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
@@ -1541,5 +1544,158 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		// extension's rewrite hook; its fork-scope import stays unresolved.
 		const siblingUrl = `${url.pathToFileURL(await fs.realpath(path.join(dir, "unrelated.ts"))).href}?nonce=${Date.now()}`;
 		await expect(import(siblingUrl)).rejects.toThrow(/@earendil-works\/pi-ai/);
+	});
+
+	it("keeps shared rewritten CommonJS sources until concurrent loads settle", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "shared-cjs-concurrent-root", version: "1.0.0", type: "module" }),
+			"node_modules/direct/package.json": JSON.stringify({
+				name: "direct",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			// Graph-owned CommonJS with a legacy Pi require that must stay rewritten
+			// in the process-global source map while overlapping imports run.
+			"node_modules/direct/index.js": 'module.exports = require("@mariozechner/pi-ai").Type;\n',
+			"first.ts": [
+				'import { Type } from "@oh-my-pi/pi-ai";',
+				'import requiredType from "direct";',
+				"const gate = globalThis.__ompSharedCjsGate;",
+				"gate.firstReady(requiredType === Type);",
+				"await gate.wait;",
+				"export const sharesHostType = requiredType === Type;",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+			"second.ts": [
+				'import { Type } from "@oh-my-pi/pi-ai";',
+				'import requiredType from "direct";',
+				"export const sharesHostType = requiredType === Type;",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const sharedPath = await fs.realpath(path.join(dir, "node_modules", "direct", "index.js"));
+		const firstReady = Promise.withResolvers<boolean>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const gateKey = "__ompSharedCjsGate";
+		const globals = globalThis as typeof globalThis &
+			Record<string, { firstReady: (ok: boolean) => void; wait: Promise<void> } | undefined>;
+		globals[gateKey] = {
+			firstReady: ok => firstReady.resolve(ok),
+			wait: releaseFirst.promise,
+		};
+		let firstPromise: Promise<unknown> | undefined;
+
+		try {
+			firstPromise = loadLegacyPiModule(path.join(dir, "first.ts"));
+			expect(await firstReady.promise).toBe(true);
+			expect(__hasCommonJsModuleSourceForTests(sharedPath)).toBe(true);
+
+			// Reverse completion: the later-started load finishes while the first
+			// import is still held open. Eager per-load clear would delete the
+			// shared rewritten CommonJS source here.
+			const second = (await loadLegacyPiModule(path.join(dir, "second.ts"))) as {
+				sharesHostType: boolean;
+			};
+			expect(second.sharesHostType).toBe(true);
+			expect(__inFlightLegacyPiLoadsForTests()).toBe(1);
+			expect(__hasCommonJsModuleSourceForTests(sharedPath)).toBe(true);
+
+			releaseFirst.resolve();
+			const first = (await firstPromise) as { sharesHostType: boolean };
+			expect(first.sharesHostType).toBe(true);
+			expect(__inFlightLegacyPiLoadsForTests()).toBe(0);
+			expect(__hasCommonJsModuleSourceForTests(sharedPath)).toBe(false);
+		} finally {
+			releaseFirst.resolve();
+			await firstPromise?.catch(() => undefined);
+			delete globals[gateKey];
+		}
+	});
+
+	it("retains shared CommonJS sources when a peer finishes during graph preparation", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "shared-cjs-prep-race-root", version: "1.0.0", type: "module" }),
+			"node_modules/direct/package.json": JSON.stringify({
+				name: "direct",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+			"node_modules/direct/index.js": 'module.exports = require("@mariozechner/pi-ai").Type;\n',
+			"first.ts": [
+				'import { Type } from "@oh-my-pi/pi-ai";',
+				'import requiredType from "direct";',
+				"const gate = globalThis.__ompSharedCjsPrepGate;",
+				"gate.firstReady(requiredType === Type);",
+				"await gate.wait;",
+				"export const sharesHostType = requiredType === Type;",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+			"second.ts": [
+				'import { Type } from "@oh-my-pi/pi-ai";',
+				'import requiredType from "direct";',
+				"export const sharesHostType = requiredType === Type;",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const sharedPath = await fs.realpath(path.join(dir, "node_modules", "direct", "index.js"));
+		const firstReady = Promise.withResolvers<boolean>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const prepEntered = Promise.withResolvers<void>();
+		const releasePrep = Promise.withResolvers<void>();
+		const gateKey = "__ompSharedCjsPrepGate";
+		const globals = globalThis as typeof globalThis &
+			Record<string, { firstReady: (ok: boolean) => void; wait: Promise<void> } | undefined>;
+		globals[gateKey] = {
+			firstReady: ok => firstReady.resolve(ok),
+			wait: releaseFirst.promise,
+		};
+		let firstPromise: Promise<unknown> | undefined;
+		let secondPromise: Promise<unknown> | undefined;
+
+		__setLegacyPiGraphPreparationPauseForTests(async () => {
+			// Only the overlapping second load should pause inside preparation.
+			if (__inFlightLegacyPiLoadsForTests() < 2) {
+				return;
+			}
+			prepEntered.resolve();
+			await releasePrep.promise;
+		});
+
+		try {
+			firstPromise = loadLegacyPiModule(path.join(dir, "first.ts"));
+			expect(await firstReady.promise).toBe(true);
+			expect(__hasCommonJsModuleSourceForTests(sharedPath)).toBe(true);
+			expect(__inFlightLegacyPiLoadsForTests()).toBe(1);
+
+			// Dangerous interleaving: B is inside async graph preparation (after
+			// writing shared CommonJS sources) when A completes and would otherwise
+			// flush retained cleanups because B was not yet counted as in flight.
+			secondPromise = loadLegacyPiModule(path.join(dir, "second.ts"));
+			await prepEntered.promise;
+			expect(__inFlightLegacyPiLoadsForTests()).toBe(2);
+			expect(__hasCommonJsModuleSourceForTests(sharedPath)).toBe(true);
+
+			releaseFirst.resolve();
+			const first = (await firstPromise) as { sharesHostType: boolean };
+			expect(first.sharesHostType).toBe(true);
+			// A finished while B is still preparing; shared rewritten sources must remain.
+			expect(__inFlightLegacyPiLoadsForTests()).toBe(1);
+			expect(__hasCommonJsModuleSourceForTests(sharedPath)).toBe(true);
+
+			releasePrep.resolve();
+			const second = (await secondPromise) as { sharesHostType: boolean };
+			expect(second.sharesHostType).toBe(true);
+			expect(__inFlightLegacyPiLoadsForTests()).toBe(0);
+			expect(__hasCommonJsModuleSourceForTests(sharedPath)).toBe(false);
+		} finally {
+			releasePrep.resolve();
+			releaseFirst.resolve();
+			await firstPromise?.catch(() => undefined);
+			await secondPromise?.catch(() => undefined);
+			__setLegacyPiGraphPreparationPauseForTests(undefined);
+			delete globals[gateKey];
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Independent extension modules now import concurrently, then their factories initialize in configured order against the shared runtime and event bus. Runtime flag overrides, provider/default precedence, partial registrations on factory failure, and shared startup events keep their prior behavior.

Overlapping legacy module imports retain shared graph-hook state until the final load settles, including overlap during async graph preparation.

## Verification

- [x] `bun check`
- [x] `bun --cwd=packages/coding-agent test test/cli-extension-providers.test.ts test/extensibility/legacy-pi-inplace-load.test.ts` (55 pass)
- [x] Deterministic reverse-completion and graph-preparation interleaving tests
