### PR TITLE
fix(swarm): propagate dependency failures and exit cleanly

### DIFF
--- a/packages/swarm-extension/CHANGELOG.md
+++ b/packages/swarm-extension/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Block dependent agents when an upstream dependency fails while allowing independent branches to continue.
+- Close standalone runner resources and exit with a status code that reflects the pipeline result.
+
 ## [16.3.7] - 2026-07-05
 
 ### Fixed

--- a/packages/swarm-extension/README.md
+++ b/packages/swarm-extension/README.md
@@ -129,7 +129,7 @@ swarm:
 
 The orchestrator builds a DAG from `waits_for` and `reports_to`, then groups agents into **waves** using topological sort. Agents in the same wave run in parallel; waves execute in sequence.
 
-- `waits_for: [a, b]` — this agent won't start until both `a` and `b` finish
+- `waits_for: [a, b]` — this agent starts only when both `a` and `b` finish successfully; a failed or blocked dependency marks it blocked without running it
 - `reports_to: [x]` — equivalent to `x` having `waits_for: [this_agent]`
 - No explicit deps + `pipeline`/`sequential` mode — agents chain by YAML declaration order
 - No explicit deps + `parallel` mode — all agents run in one wave

--- a/packages/swarm-extension/src/cli.ts
+++ b/packages/swarm-extension/src/cli.ts
@@ -11,7 +11,7 @@ import { discoverAuthStorage } from "@oh-my-pi/pi-coding-agent";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { buildDependencyGraph, buildExecutionWaves, detectCycles } from "./swarm/dag";
-import { PipelineController } from "./swarm/pipeline";
+import { PipelineController, type PipelineResult } from "./swarm/pipeline";
 import { renderSwarmProgress } from "./swarm/render";
 import { parseSwarmYaml, validateSwarmDefinition } from "./swarm/schema";
 import { StateTracker } from "./swarm/state";
@@ -64,31 +64,36 @@ await stateTracker.init([...def.agents.keys()], def.targetCount, def.mode);
 
 // Auth + settings
 const authStorage = await discoverAuthStorage();
-const modelRegistry = new ModelRegistry(authStorage);
-const settings = Settings.isolated();
+let result: PipelineResult;
+try {
+	const modelRegistry = new ModelRegistry(authStorage);
+	const settings = Settings.isolated();
 
-// Progress display
-let lastProgressDump = 0;
-const PROGRESS_INTERVAL_MS = 5000;
+	// Progress display
+	let lastProgressDump = 0;
+	const PROGRESS_INTERVAL_MS = 5000;
 
-// Run
-console.log("\n--- Pipeline starting ---\n");
+	// Run
+	console.log("\n--- Pipeline starting ---\n");
 
-const controller = new PipelineController(def, waves, stateTracker);
-const result = await controller.run({
-	workspace,
-	onProgress: () => {
-		const now = Date.now();
-		if (now - lastProgressDump > PROGRESS_INTERVAL_MS) {
-			lastProgressDump = now;
-			const lines = renderSwarmProgress(stateTracker.state);
-			console.log(lines.join("\n"));
-			console.log();
-		}
-	},
-	modelRegistry,
-	settings,
-});
+	const controller = new PipelineController(def, waves, stateTracker);
+	result = await controller.run({
+		workspace,
+		onProgress: () => {
+			const now = Date.now();
+			if (now - lastProgressDump > PROGRESS_INTERVAL_MS) {
+				lastProgressDump = now;
+				const lines = renderSwarmProgress(stateTracker.state);
+				console.log(lines.join("\n"));
+				console.log();
+			}
+		},
+		modelRegistry,
+		settings,
+	});
+} finally {
+	authStorage.close();
+}
 
 console.log("\n--- Pipeline finished ---\n");
 console.log(`Status: ${result.status}`);
@@ -104,3 +109,13 @@ console.log(`\nState saved to: ${stateTracker.swarmDir}`);
 // Final state dump
 const lines = renderSwarmProgress(stateTracker.state);
 console.log(lines.join("\n"));
+
+const exitCode = result.status === "completed" ? 0 : 1;
+await Promise.all([flushWritable(process.stdout), flushWritable(process.stderr)]);
+process.exit(exitCode);
+
+function flushWritable(stream: NodeJS.WriteStream): Promise<void> {
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	stream.write("", error => (error ? reject(error) : resolve()));
+	return promise;
+}

--- a/packages/swarm-extension/src/swarm/pipeline.ts
+++ b/packages/swarm-extension/src/swarm/pipeline.ts
@@ -101,10 +101,12 @@ export class PipelineController {
 
 				for (const [agentName, result] of iterationResults) {
 					allResults.get(agentName)!.push(result);
-					if (result.exitCode !== 0) {
-						errors.push(
-							`${agentName} (iteration ${iteration + 1}): ${result.error || `exit code ${result.exitCode}`}`,
-						);
+					if (result.exitCode !== 0 || result.error !== undefined || result.aborted === true) {
+						const reason =
+							result.error ??
+							result.abortReason ??
+							(result.aborted ? "aborted" : `exit code ${result.exitCode}`);
+						errors.push(`${agentName} (iteration ${iteration + 1}): ${reason}`);
 					}
 				}
 			}
@@ -161,9 +163,17 @@ export class PipelineController {
 			const waveResults = await Promise.all(
 				wave.map(async agentName => {
 					const currentIndex = agentIndex++;
-					const failedDependencies = [...(this.#dependencies.get(agentName) ?? [])].filter(
-						dependency => results.get(dependency)?.exitCode !== 0,
-					);
+					const failedDependencies = [...(this.#dependencies.get(agentName) ?? [])].filter(dependency => {
+						const dependencyResult = results.get(dependency);
+						if (!dependencyResult) {
+							throw new Error(`Dependency '${dependency}' of '${agentName}' has no result`);
+						}
+						return (
+							dependencyResult.exitCode !== 0 ||
+							dependencyResult.error !== undefined ||
+							dependencyResult.aborted === true
+						);
+					});
 					if (failedDependencies.length > 0) {
 						const result = this.#buildBlockedResult(agentName, currentIndex, iteration, failedDependencies);
 						await this.#stateTracker.updateAgent(agentName, {

--- a/packages/swarm-extension/src/swarm/pipeline.ts
+++ b/packages/swarm-extension/src/swarm/pipeline.ts
@@ -7,6 +7,7 @@
  * - For pipeline mode, iterations repeat the full DAG execution
  */
 import type { AgentSource, ModelRegistry, Settings, SingleResult } from "@oh-my-pi/pi-coding-agent";
+import { buildDependencyGraph } from "./dag";
 import { executeSwarmAgent } from "./executor";
 import type { SwarmDefinition } from "./schema";
 import type { StateTracker } from "./state";
@@ -45,10 +46,12 @@ export interface PipelineResult {
 export class PipelineController {
 	#def: SwarmDefinition;
 	#waves: string[][];
+	#dependencies: Map<string, Set<string>>;
 	#stateTracker: StateTracker;
 
 	constructor(def: SwarmDefinition, waves: string[][], stateTracker: StateTracker) {
 		this.#def = def;
+		this.#dependencies = buildDependencyGraph(def);
 		this.#waves = waves;
 		this.#stateTracker = stateTracker;
 	}
@@ -147,6 +150,9 @@ export class PipelineController {
 					status: "waiting",
 					iteration,
 					wave: waveIdx,
+					startedAt: undefined,
+					completedAt: undefined,
+					error: undefined,
 				});
 			}
 			options.emitProgress(waveIdx);
@@ -154,8 +160,22 @@ export class PipelineController {
 			// Execute all agents in wave in parallel, catching per-agent errors
 			const waveResults = await Promise.all(
 				wave.map(async agentName => {
-					const agent = this.#def.agents.get(agentName)!;
 					const currentIndex = agentIndex++;
+					const failedDependencies = [...(this.#dependencies.get(agentName) ?? [])].filter(
+						dependency => results.get(dependency)?.exitCode !== 0,
+					);
+					if (failedDependencies.length > 0) {
+						const result = this.#buildBlockedResult(agentName, currentIndex, iteration, failedDependencies);
+						await this.#stateTracker.updateAgent(agentName, {
+							status: "blocked",
+							completedAt: Date.now(),
+							error: result.error,
+						});
+						await this.#stateTracker.appendLog(agentName, result.stderr);
+						return { agentName, result };
+					}
+
+					const agent = this.#def.agents.get(agentName)!;
 					try {
 						const result = await executeSwarmAgent(agent, currentIndex, {
 							workspace: options.workspace,
@@ -201,6 +221,31 @@ export class PipelineController {
 		}
 
 		return results;
+	}
+
+	#buildBlockedResult(
+		agentName: string,
+		index: number,
+		iteration: number,
+		failedDependencies: string[],
+	): SingleResult {
+		const agent = this.#def.agents.get(agentName)!;
+		const error = `${agentName} blocked because dependencies did not complete successfully: ${failedDependencies.join(", ")}`;
+		return {
+			index,
+			id: `swarm-${this.#def.name}-${agentName}-${iteration}`,
+			agent: agentName,
+			agentSource: "project" as AgentSource,
+			task: agent.task,
+			exitCode: 1,
+			output: "",
+			stderr: error,
+			truncated: false,
+			durationMs: 0,
+			tokens: 0,
+			requests: 0,
+			error,
+		};
 	}
 
 	#buildProgressSnapshot(): Record<string, { status: string; iteration: number }> {

--- a/packages/swarm-extension/src/swarm/render.ts
+++ b/packages/swarm-extension/src/swarm/render.ts
@@ -12,6 +12,7 @@ const STATUS_LABELS: Record<string, string> = {
 	waiting: "[wait]",
 	idle: "[idle]",
 	aborted: "[stop]",
+	blocked: "[skip]",
 };
 
 export function renderSwarmProgress(state: SwarmState): string[] {
@@ -38,12 +39,14 @@ export function renderSwarmProgress(state: SwarmState): string[] {
 	// Summary line
 	const completed = agents.filter(a => a.status === "completed").length;
 	const failed = agents.filter(a => a.status === "failed").length;
+	const blocked = agents.filter(a => a.status === "blocked").length;
 	const running = agents.filter(a => a.status === "running").length;
 
 	lines.push("");
 	const parts = [`${completed}/${agents.length} done`];
 	if (running > 0) parts.push(`${running} running`);
 	if (failed > 0) parts.push(`${failed} failed`);
+	if (blocked > 0) parts.push(`${blocked} blocked`);
 	if (state.startedAt) {
 		parts.push(`elapsed: ${formatDuration(Date.now() - state.startedAt)}`);
 	}

--- a/packages/swarm-extension/src/swarm/state.ts
+++ b/packages/swarm-extension/src/swarm/state.ts
@@ -12,7 +12,7 @@ import * as path from "node:path";
 // ============================================================================
 
 export type PipelineStatus = "idle" | "running" | "completed" | "failed" | "aborted";
-export type AgentStatus = "pending" | "waiting" | "running" | "completed" | "failed";
+export type AgentStatus = "pending" | "waiting" | "running" | "completed" | "failed" | "blocked";
 
 export interface AgentState {
 	name: string;

--- a/packages/swarm-extension/test/cli.test.ts
+++ b/packages/swarm-extension/test/cli.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+let root: string;
+
+beforeEach(async () => {
+	root = await fs.mkdtemp(path.join(os.tmpdir(), "swarm-cli-test-"));
+});
+
+afterEach(async () => {
+	await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("omp-swarm CLI", () => {
+	it("exits with code 1 after a failed pipeline", async () => {
+		const workspace = path.join(root, "workspace");
+		const yamlPath = path.join(root, "swarm.yaml");
+		await Bun.write(
+			yamlPath,
+			`swarm:
+  name: cli-failure-test
+  workspace: ${workspace}
+  mode: pipeline
+  agents:
+    failing:
+      role: deterministic failure probe
+      model: invalid-provider/definitely-missing-model
+      task: fail before execution
+`,
+		);
+
+		const cliPath = path.resolve(import.meta.dir, "../src/cli.ts");
+		const subprocess = Bun.spawn([process.execPath, cliPath, yamlPath], {
+			cwd: path.resolve(import.meta.dir, ".."),
+			env: {
+				...process.env,
+				PI_CODING_AGENT_DIR: path.join(root, "agent"),
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const stdout = new Response(subprocess.stdout).text();
+		const stderr = new Response(subprocess.stderr).text();
+		// A real deadline is required here: fake timers cannot detect a child process that keeps Bun's event loop alive.
+		const exitCode = await Promise.race([subprocess.exited, Bun.sleep(30_000).then(() => null)]);
+
+		if (exitCode === null) {
+			subprocess.kill();
+			await subprocess.exited;
+		}
+		const output = `${await stdout}${await stderr}`;
+
+		expect(exitCode).not.toBeNull();
+		expect(exitCode).toBe(1);
+		expect(output).toContain("Status: failed");
+	}, 40_000);
+});

--- a/packages/swarm-extension/test/swarm/pipeline.test.ts
+++ b/packages/swarm-extension/test/swarm/pipeline.test.ts
@@ -21,6 +21,7 @@ beforeEach(async () => {
 		async (agent, index, options): Promise<SingleResult> => {
 			executed.push(agent.name);
 			const failed = agent.name === "failing";
+			const aborted = agent.name === "aborted";
 			await options.stateTracker.updateAgent(agent.name, {
 				status: failed ? "failed" : "completed",
 				iteration: options.iteration,
@@ -34,13 +35,14 @@ beforeEach(async () => {
 				agentSource: "project" as AgentSource,
 				task: agent.task,
 				exitCode: failed ? 1 : 0,
-				output: failed ? "" : `${agent.name} completed`,
+				output: failed || aborted ? "" : `${agent.name} completed`,
 				stderr: failed ? "expected failure" : "",
 				truncated: false,
 				durationMs: 1,
 				tokens: 0,
 				requests: 0,
 				error: failed ? "expected failure" : undefined,
+				aborted,
 			};
 		},
 	);
@@ -100,5 +102,34 @@ swarm:
 		expect(progress).toContain("[skip] dependent: blocked");
 		expect(progress).toContain("2 blocked");
 		expect(stateTracker.state.agents.independent_child.status).toBe("completed");
+	});
+
+	it("blocks dependents when an upstream agent is aborted with exit code 0", async () => {
+		const definition = parseSwarmYaml(`
+swarm:
+  name: aborted-gate-test
+  workspace: ./workspace
+  mode: pipeline
+  agents:
+    aborted:
+      role: aborted probe
+      task: abort
+      reports_to: [dependent]
+    dependent:
+      role: blocked child
+      task: must not execute
+      waits_for: [aborted]
+`);
+		const dependencies = buildDependencyGraph(definition);
+		const waves = buildExecutionWaves(dependencies);
+		const stateTracker = new SwarmStateTracker(workspace, definition.name);
+		await stateTracker.init([...definition.agents.keys()], definition.targetCount, definition.mode);
+		const controller = new PipelineController(definition, waves, stateTracker);
+
+		const result = await controller.run({ workspace });
+
+		expect(result.status).toBe("failed");
+		expect(executed).toEqual(["aborted"]);
+		expect(stateTracker.state.agents.dependent.status).toBe("blocked");
 	});
 });

--- a/packages/swarm-extension/test/swarm/pipeline.test.ts
+++ b/packages/swarm-extension/test/swarm/pipeline.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentSource, SingleResult } from "@oh-my-pi/pi-coding-agent";
+import { buildDependencyGraph, buildExecutionWaves } from "../../src/swarm/dag";
+import * as swarmExecutor from "../../src/swarm/executor";
+import { PipelineController } from "../../src/swarm/pipeline";
+import { renderSwarmProgress } from "../../src/swarm/render";
+import { parseSwarmYaml } from "../../src/swarm/schema";
+import { StateTracker as SwarmStateTracker } from "../../src/swarm/state";
+
+const executed: string[] = [];
+
+let workspace: string;
+
+beforeEach(async () => {
+	executed.length = 0;
+	workspace = await fs.mkdtemp(path.join(os.tmpdir(), "swarm-pipeline-test-"));
+	vi.spyOn(swarmExecutor, "executeSwarmAgent").mockImplementation(
+		async (agent, index, options): Promise<SingleResult> => {
+			executed.push(agent.name);
+			const failed = agent.name === "failing";
+			await options.stateTracker.updateAgent(agent.name, {
+				status: failed ? "failed" : "completed",
+				iteration: options.iteration,
+				completedAt: Date.now(),
+				error: failed ? "expected failure" : undefined,
+			});
+			return {
+				index,
+				id: `test-${agent.name}`,
+				agent: agent.name,
+				agentSource: "project" as AgentSource,
+				task: agent.task,
+				exitCode: failed ? 1 : 0,
+				output: failed ? "" : `${agent.name} completed`,
+				stderr: failed ? "expected failure" : "",
+				truncated: false,
+				durationMs: 1,
+				tokens: 0,
+				requests: 0,
+				error: failed ? "expected failure" : undefined,
+			};
+		},
+	);
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await fs.rm(workspace, { recursive: true, force: true });
+});
+
+describe("PipelineController", () => {
+	it("blocks only direct and transitive dependents of a failed agent", async () => {
+		const definition = parseSwarmYaml(`
+swarm:
+  name: failure-gate-test
+  workspace: ./workspace
+  mode: pipeline
+  agents:
+    failing:
+      role: failing probe
+      task: fail
+      reports_to: [dependent]
+    independent:
+      role: independent branch
+      task: succeed independently
+      reports_to: [independent_child]
+    dependent:
+      role: blocked child
+      task: must not execute
+      waits_for: [failing]
+      reports_to: [blocked_grandchild]
+    independent_child:
+      role: successful child
+      task: execute after independent succeeds
+      waits_for: [independent]
+    blocked_grandchild:
+      role: transitively blocked child
+      task: must not execute
+      waits_for: [dependent]
+`);
+		const dependencies = buildDependencyGraph(definition);
+		const waves = buildExecutionWaves(dependencies);
+		const stateTracker = new SwarmStateTracker(workspace, definition.name);
+		await stateTracker.init([...definition.agents.keys()], definition.targetCount, definition.mode);
+		const controller = new PipelineController(definition, waves, stateTracker);
+
+		const result = await controller.run({ workspace });
+
+		expect(result.status).toBe("failed");
+		expect(executed).toEqual(["failing", "independent", "independent_child"]);
+		expect(result.agentResults.get("dependent")).toHaveLength(1);
+		expect(result.agentResults.get("dependent")?.[0]?.exitCode).toBe(1);
+		expect(stateTracker.state.agents.dependent.status).toBe("blocked");
+		expect(result.agentResults.get("blocked_grandchild")?.[0]?.exitCode).toBe(1);
+		expect(stateTracker.state.agents.blocked_grandchild.status).toBe("blocked");
+		const progress = renderSwarmProgress(stateTracker.state).join("\n");
+		expect(progress).toContain("[skip] dependent: blocked");
+		expect(progress).toContain("2 blocked");
+		expect(stateTracker.state.agents.independent_child.status).toBe("completed");
+	});
+});


### PR DESCRIPTION
## Summary

- Treat dependency completion as a success gate: direct and transitive dependents become `blocked`, while unrelated branches continue.
- Count a dependency as successful only when it exits 0 without an error or abort; missing earlier-wave results surface as invariant failures.
- Persist and render the new `blocked` agent state, including synthetic failure results for pipeline accounting.
- Close standalone auth storage, flush stdout/stderr, and exit with code 0 for completed pipelines or 1 otherwise.
- Add unit and subprocess regression coverage, plus README and changelog updates.

## Contributor note

> Swarm의 dependency를 단순 실행 순서가 아니라 성공 조건으로 만들고, standalone runner가 pipeline 결과에 맞는 상태 코드로 확실히 종료되도록 수정하는 것.

Translation: Make Swarm dependencies success conditions rather than mere execution ordering, and ensure the standalone runner exits reliably with a status code that matches the pipeline result.

## Reproduction and result

Before this change, an invalid-model predecessor failed but its dependent still launched, and `omp-swarm` remained alive after printing terminal failure until it was terminated externally. An aborted predecessor could also carry `exitCode: 0`, causing dependents and pipeline accounting to treat it as successful.

After this change, the same source-level probe reports:

- pipeline: `failed`
- predecessor: `failed`
- dependent: `blocked` and never launched
- standalone process: exits naturally with code `1`

The unit regression also confirms an aborted, exit-code-0 predecessor fails pipeline accounting and blocks its dependent.

## Verification

- `bun test packages/swarm-extension` — 4 passed, 0 failed, 19 assertions
- `bun run check` in `packages/swarm-extension` — passed (Biome and type check)
- Cold-transpiler-cache package test — 4 passed, 0 failed
- Disposable source-level CLI probe — dependent blocked, no downstream execution, natural exit code 1