### PR TITLE
fix(catalog): add reasoning config for deepseek-v4 family in alibaba-token-plan

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `deepseek-v4` family models (e.g. `deepseek-v4-flash-0731`) discovered dynamically by `alibaba-token-plan` missing reasoning configuration and the `max` thinking effort.
+
 ## [17.2.5] - 2026-08-03
 
 ### Fixed

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2878,15 +2878,27 @@ export function alibabaTokenPlanModelManagerOptions(
 					filterModel: (_entry, model) => isAlibabaTokenPlanChatModelId(model.id),
 					mapModel: (_entry, defaults) => {
 						const reference = ALIBABA_TOKEN_PLAN_STATIC_MODELS.find(model => model.id === defaults.id);
-						return reference
-							? {
-									...reference,
-									id: defaults.id,
-									api: defaults.api,
-									provider: defaults.provider,
-									baseUrl: defaults.baseUrl,
-								}
-							: defaults;
+						if (reference) {
+							return {
+								...reference,
+								id: defaults.id,
+								api: defaults.api,
+								provider: defaults.provider,
+								baseUrl: defaults.baseUrl,
+							};
+						}
+						// DeepSeek V4 family models discovered dynamically need reasoning config
+						if (defaults.id.startsWith("deepseek-v4")) {
+							return {
+								...defaults,
+								reasoning: true,
+								thinking: {
+									mode: "effort" as const,
+									efforts: [Effort.High, Effort.Max],
+								},
+							};
+						}
+						return defaults;
 					},
 					fetch: config?.fetch,
 				}),

--- a/packages/catalog/test/alibaba-token-plan.test.ts
+++ b/packages/catalog/test/alibaba-token-plan.test.ts
@@ -63,6 +63,7 @@ describe("QwenCloud Token Plan provider", () => {
 							max_completion_tokens: 16_384,
 						},
 						{ id: "deepseek-v4-flash", owned_by: "qwencloud" },
+						{ id: "deepseek-v4-flash-0731", owned_by: "qwencloud" },
 						{ id: "kimi-k2.7-code", owned_by: "qwencloud" },
 						{ id: "MiniMax-M2.5", owned_by: "qwencloud" },
 						{ id: "fun-asr", owned_by: "qwencloud" },
@@ -84,10 +85,25 @@ describe("QwenCloud Token Plan provider", () => {
 		expect(authorization).toBe("Bearer sk-sp-test");
 		expect(models?.map(model => model.id)).toEqual([
 			"deepseek-v4-flash",
+			"deepseek-v4-flash-0731",
 			"kimi-k2.7-code",
 			"MiniMax-M2.5",
 			"qwen3.7-plus",
 		]);
+		expect(models?.find(model => model.id === "deepseek-v4-flash")).toMatchObject({
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				efforts: ["high", "max"],
+			},
+		});
+		expect(models?.find(model => model.id === "deepseek-v4-flash-0731")).toMatchObject({
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				efforts: ["high", "max"],
+			},
+		});
 		expect(models?.find(model => model.id === "qwen3.7-plus")).toMatchObject({
 			id: "qwen3.7-plus",
 			provider: "alibaba-token-plan",


### PR DESCRIPTION
## Summary

Dynamically discovered `deepseek-v4*` models (e.g. `deepseek-v4-flash-0731`) from the `alibaba-token-plan` provider were missing reasoning configuration, causing the `max` thinking effort to be unavailable.

## Changes

- **Source**: Added `deepseek-v4` prefix matching in the dynamic discovery mapper to supply `reasoning: true` and `[high, max]` thinking efforts
- **Test**: Added `deepseek-v4-flash-0731` to discovery test mock and assertions for both `deepseek-v4-flash` and `deepseek-v4-flash-0731`
- **Changelog**: Added entry under `[Unreleased]` → `### Fixed`