### PR TITLE
fix(catalog): use live Copilot default-tier prices

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GitHub Copilot dynamic discovery retaining stale bundled prices for default-context models instead of using the provider's reported default-tier prices ([#7471](https://github.com/can1357/oh-my-pi/issues/7471)).
+
 ## [17.2.5] - 2026-08-03
 
 ### Fixed

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -5050,6 +5050,11 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 											}
 										: {}),
 								};
+						const defaultCost = copilotTierCost(tokenPrices.defaultTier);
+						if (defaultCost) {
+							// Cache writes are not reported per tier; retain the bundled provider rate.
+							base.cost = { ...defaultCost, cacheWrite: base.cost.cacheWrite };
+						}
 						const variant = createCopilotLongContextVariant(
 							base,
 							contextWindow,

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -545,6 +545,28 @@ describe("github copilot tiered context windows", () => {
 		expect(variant?.cost).toEqual({ input: 4, output: 18, cacheRead: 0.4, cacheWrite: 0 });
 	});
 
+	it("prices the base model from its default tier", async () => {
+		const { models } = await discoverCopilotModels({
+			data: [
+				tieredCopilotEntry({
+					id: "gpt-5.6-luna",
+					name: "GPT-5.6 Luna",
+					window: 1_050_000,
+					maxOutput: 50_000,
+					defaultContextMax: 200_000,
+					longContextMax: 1_000_000,
+					defaultPrices: { input: 20, output: 120, cache: 2 },
+					longPrices: { input: 40, output: 180, cache: 4 },
+				}),
+			],
+		});
+
+		const base = models.find(candidate => candidate.id === "gpt-5.6-luna");
+		expect(base?.cost).toMatchObject({ input: 0.2, output: 1.2, cacheRead: 0.02 });
+		const variant = models.find(candidate => candidate.id === "gpt-5.6-luna-1m");
+		expect(variant?.cost).toMatchObject({ input: 0.4, output: 1.8, cacheRead: 0.04 });
+	});
+
 	it("keeps legacy tier-capped responses unchanged and synthesizes no variant", async () => {
 		const { models } = await discoverCopilotModels({
 			data: [


### PR DESCRIPTION
## Repro

A mocked GitHub Copilot `/models` response for GPT-5.6 Luna reports default-tier rates of $0.20 input, $1.20 output, and $0.02 cached input, but `cd packages/catalog && bun test test/github-copilot-model-limits.test.ts` previously resolved the base model to stale bundled rates of $1, $6, and $0.10 while its synthesized `-1m` sibling used the live long-context rates.

## Cause

`githubCopilotModelManagerOptions` in `packages/catalog/src/provider-models/openai-compat.ts` parsed `billing.token_prices.default` only for its context boundary; `createCopilotLongContextVariant` applied the long-context tier prices, but no corresponding code applied the default tier to the base model.

## Fix

- Apply discovered default-tier input, output, and cached-input rates to the base Copilot model.
- Preserve the bundled cache-write fallback because Copilot does not report cache-write prices per tier.
- Cover GPT-5.6 Luna base and synthesized long-context pricing with a regression test and document the correction.

## Verification

`cd packages/catalog && bun test test/github-copilot-model-limits.test.ts` passes with 31 tests and 0 failures; the pre-publish `bun check` gate also passed. Fixes #7471