### PR TITLE
fix(session): preserve title when branching

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved explicit session titles when branching from an earlier conversation turn.
+
 ## [17.2.5] - 2026-08-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2340,6 +2340,8 @@ export class SessionManager {
 			id: newSessionId,
 			timestamp,
 			cwd: this.#cwd,
+			title: this.#sessionName,
+			titleSource: this.#titleSource,
 			parentSession: this.#persist ? sourceSessionFile : undefined,
 			additionalDirectories: this.#additionalDirectories.length > 0 ? [...this.#additionalDirectories] : undefined,
 		};

--- a/packages/coding-agent/test/session-manager/tree-traversal.test.ts
+++ b/packages/coding-agent/test/session-manager/tree-traversal.test.ts
@@ -453,6 +453,16 @@ describe("createBranchedSession", () => {
 		expect(entries[1].id).toBe(id2);
 	});
 
+	it("preserves the session title when creating a branch", async () => {
+		const session = SessionManager.inMemory();
+		const leafId = session.appendMessage(userMsg("hello"));
+		await session.setSessionName("new-ds", "user");
+
+		session.createBranchedSession(leafId);
+
+		expect(session.getSessionName()).toBe("new-ds");
+	});
+
 	it("extracts correct path from branched tree", () => {
 		const session = SessionManager.inMemory();
 


### PR DESCRIPTION
## What
- copy the active session title and title source into branched session headers
- add regression coverage for explicit titles

## Why
Branching from an earlier turn rebuilt the session header without title metadata, so the branch appeared unnamed and cmux fell back to the project directory.

## Testing
- `bun test packages/coding-agent/test/session-manager/tree-traversal.test.ts` (30 pass)
- `bun --cwd=packages/coding-agent run check`
- persistent branch smoke: title slot and session header both retained `new-ds` with source `user`