### PR TITLE
fix(catalog): add Token Plan discovery metadata

### DIFF
--- a/packages/ai/test/openai-compat-policy.test.ts
+++ b/packages/ai/test/openai-compat-policy.test.ts
@@ -9,6 +9,7 @@ import {
 import type { Model, ModelSpec, OpenAICompat } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 function chatModel(compat: OpenAICompat): Model<"openai-completions"> {
 	return buildModel({
@@ -159,5 +160,37 @@ describe("OpenAI compat policy", () => {
 		expect(responsesPolicy.tools.toolCallIdKind).toBe("mistral-9-alnum");
 		expect(chatPolicy.stream.reasoningDeltasMayBeCumulative).toBe(true);
 		expect(responsesPolicy.stream.reasoningDeltasMayBeCumulative).toBe(true);
+	});
+
+	it("routes the reasoning_effort ladder for the bundled Token Plan qwen3.8-max", () => {
+		// qwen3.8-max drives reasoning through the OpenAI-standard
+		// `reasoning_effort` control, not the legacy `enable_thinking` toggle the
+		// older Qwen3.x Token Plan builds ride. Build from the real bundled entry
+		// so the dialect classification — not a hardcoded override — is exercised.
+		const model = getBundledModel<"openai-completions">("alibaba-token-plan", "qwen3.8-max");
+		for (const [effort, wire] of [
+			[Effort.Low, "low"],
+			[Effort.Medium, "medium"],
+			[Effort.XHigh, "xhigh"],
+		] as const) {
+			const params = chatParams();
+			applyChatCompletionsCompatPolicy(
+				params,
+				resolveOpenAICompatPolicy(model, { endpoint: "chat-completions", reasoning: effort }),
+			);
+			expect(params.reasoning_effort).toBe(wire);
+			expect(params.enable_thinking).toBeUndefined();
+			expect(params.chat_template_kwargs).toBeUndefined();
+		}
+
+		// Disabling reasoning clamps to the lowest supported effort rather than
+		// emitting the legacy binary toggle.
+		const disabled = chatParams();
+		applyChatCompletionsCompatPolicy(
+			disabled,
+			resolveOpenAICompatPolicy(model, { endpoint: "chat-completions", disableReasoning: true }),
+		);
+		expect(disabled.reasoning_effort).toBe("low");
+		expect(disabled.enable_thinking).toBeUndefined();
 	});
 });

--- a/packages/ai/test/openai-completions-disable-reasoning.test.ts
+++ b/packages/ai/test/openai-completions-disable-reasoning.test.ts
@@ -224,7 +224,6 @@ describe("OpenAI completions disableReasoning and thinking dialects", () => {
 		expect(payload.enable_thinking).toBeUndefined();
 		expect(payload.chat_template_kwargs).toBeUndefined();
 	});
-
 	it("sets Z.AI thinking format and toggles type logically based on forced tool choice", async () => {
 		const model = buildModel({
 			id: "zai-reasoner",

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed dynamically discovered `alibaba-token-plan` chat models showing unknown context and output limits by curating metadata for every advertised model ID ([#7486](https://github.com/can1357/oh-my-pi/issues/7486)).
+
 ## [17.2.5] - 2026-08-03
 
 ### Fixed

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -156,7 +156,13 @@ export function applyGeneratedModelPolicies(models: ModelSpec<Api>[]): void {
  */
 export function rebakeModelThinking(model: ModelSpec<Api>): void {
 	if (isVariantCollapsedSpec(model)) return;
-	if (model.provider === "alibaba-token-plan" && model.id === "qwen3.8-max-preview" && model.thinking) return;
+	if (
+		model.provider === "alibaba-token-plan" &&
+		(model.id === "qwen3.8-max-preview" || model.id === "qwen3.8-max") &&
+		model.thinking
+	) {
+		return;
+	}
 	const requiresProviderAuthoredEffort =
 		model.provider === "umans" && (model.thinking?.requiresEffort === true || model.id === "umans-kimi-k2.7");
 	const thinking = resolveModelThinking({ ...model, thinking: undefined }, buildCompat(model));

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -8352,7 +8352,8 @@
 			},
 			"compat": {
 				"supportsDeveloperRole": false,
-				"supportsReasoningEffort": true
+				"supportsReasoningEffort": true,
+				"thinkingFormat": "openai"
 			}
 		},
 		"qwen3.8-max-preview": {
@@ -8385,7 +8386,8 @@
 			},
 			"compat": {
 				"supportsDeveloperRole": false,
-				"supportsReasoningEffort": true
+				"supportsReasoningEffort": true,
+				"thinkingFormat": "openai"
 			}
 		}
 	},
@@ -86483,9 +86485,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.7153999999999999,
-				"output": 2.2483999999999997,
-				"cacheRead": 0.13286,
+				"input": 0.7126,
+				"output": 2.2396000000000003,
+				"cacheRead": 0.13234,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -16,7 +16,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
@@ -24,8 +24,7 @@
 					"high",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"deepseek-ai/deepseek-v4-pro": {
 			"id": "deepseek-ai/deepseek-v4-pro",
@@ -43,7 +42,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
@@ -51,12 +50,11 @@
 					"high",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "openai-completions",
 			"provider": "aiand",
 			"baseUrl": "https://api.aiand.com/v1",
@@ -72,7 +70,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 131072,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -82,8 +80,37 @@
 					"high",
 					"xhigh"
 				]
+			}
+		},
+		"moonshotai/kimi-k2.6": {
+			"id": "moonshotai/kimi-k2.6",
+			"name": "Kimi K2.6",
+			"api": "openai-completions",
+			"provider": "aiand",
+			"baseUrl": "https://api.aiand.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.85,
+				"output": 3.5,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"moonshotai/kimi-k2.7-code": {
 			"id": "moonshotai/kimi-k2.7-code",
@@ -113,8 +140,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -175,8 +201,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"qwen/qwen3.6-27b": {
 			"id": "qwen/qwen3.6-27b",
@@ -190,8 +215,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.32,
-				"output": 3.2,
+				"input": 0,
+				"output": 0,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -205,8 +230,36 @@
 					"medium",
 					"high"
 				]
+			}
+		},
+		"zai-org/glm-5.1": {
+			"id": "zai-org/glm-5.1",
+			"name": "GLM 5.1",
+			"api": "openai-completions",
+			"provider": "aiand",
+			"baseUrl": "https://api.aiand.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 202752,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"zai-org/glm-5.2": {
 			"id": "zai-org/glm-5.2",
@@ -224,7 +277,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -235,8 +288,7 @@
 					"high",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		}
 	},
 	"aimlapi": {
@@ -2727,7 +2779,7 @@
 		},
 		"deepseek/deepseek-r1": {
 			"id": "deepseek/deepseek-r1",
-			"name": "R1",
+			"name": "DeepSeek-R1",
 			"api": "openai-completions",
 			"provider": "aimlapi",
 			"baseUrl": "https://api.aimlapi.com/v1",
@@ -5182,7 +5234,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "aimlapi",
 			"baseUrl": "https://api.aimlapi.com/v1",
@@ -7427,7 +7479,7 @@
 		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
-			"name": "MiMo V2.5 Pro",
+			"name": "MiMo-V2.5-Pro",
 			"api": "openai-completions",
 			"provider": "aimlapi",
 			"baseUrl": "https://api.aimlapi.com/v1",
@@ -7806,6 +7858,93 @@
 		}
 	},
 	"alibaba-token-plan": {
+		"deepseek-v3.2": {
+			"id": "deepseek-v3.2",
+			"name": "DeepSeek V3.2",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				]
+			},
+			"compat": {
+				"supportsDeveloperRole": false
+			}
+		},
+		"deepseek-v4-flash": {
+			"id": "deepseek-v4-flash",
+			"name": "DeepSeek V4 Flash",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				]
+			},
+			"compat": {
+				"supportsDeveloperRole": false
+			}
+		},
+		"deepseek-v4-flash-0731": {
+			"id": "deepseek-v4-flash-0731",
+			"name": "DeepSeek V4 Flash 0731",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				]
+			},
+			"compat": {
+				"supportsDeveloperRole": false
+			}
+		},
 		"deepseek-v4-pro": {
 			"id": "deepseek-v4-pro",
 			"name": "DeepSeek V4 Pro",
@@ -7829,6 +7968,68 @@
 				"efforts": [
 					"high",
 					"max"
+				]
+			},
+			"compat": {
+				"supportsDeveloperRole": false
+			}
+		},
+		"glm-5": {
+			"id": "glm-5",
+			"name": "GLM-5",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 202752,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"compat": {
+				"supportsDeveloperRole": false
+			}
+		},
+		"glm-5.1": {
+			"id": "glm-5.1",
+			"name": "GLM-5.1",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 202752,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
 				]
 			},
 			"compat": {
@@ -7867,9 +8068,168 @@
 				"supportsDeveloperRole": false
 			}
 		},
+		"kimi-k2.5": {
+			"id": "kimi-k2.5",
+			"name": "Kimi K2.5",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 98304,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"compat": {
+				"supportsDeveloperRole": false
+			}
+		},
+		"kimi-k2.6": {
+			"id": "kimi-k2.6",
+			"name": "Kimi K2.6",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"compat": {
+				"supportsDeveloperRole": false
+			}
+		},
+		"kimi-k2.7-code": {
+			"id": "kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"compat": {
+				"supportsDeveloperRole": false
+			}
+		},
+		"MiniMax-M2.5": {
+			"id": "MiniMax-M2.5",
+			"name": "MiniMax-M2.5",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 196608,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"compat": {
+				"supportsDeveloperRole": false
+			}
+		},
 		"qwen3.6-flash": {
 			"id": "qwen3.6-flash",
 			"name": "Qwen3.6 Flash",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"compat": {
+				"supportsDeveloperRole": false
+			}
+		},
+		"qwen3.6-plus": {
+			"id": "qwen3.6-plus",
+			"name": "Qwen3.6 Plus",
 			"api": "openai-completions",
 			"provider": "alibaba-token-plan",
 			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
@@ -7916,7 +8276,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 65536,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -7948,7 +8308,39 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 64000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"compat": {
+				"supportsDeveloperRole": false
+			}
+		},
+		"qwen3.8-max": {
+			"id": "qwen3.8-max",
+			"name": "Qwen3.8 Max",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -7979,7 +8371,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 983616,
+			"contextWindow": 1000000,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -11767,8 +12159,7 @@
 					"max"
 				],
 				"supportsDisplay": true
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"claude-opus-4-0": {
 			"id": "claude-opus-4-0",
@@ -13039,10 +13430,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.2,
-				"output": 1.2,
-				"cacheRead": 0.02,
-				"cacheWrite": 0
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -13099,10 +13490,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 12,
-				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -27515,6 +27906,36 @@
 				]
 			}
 		},
+		"thinkingmachines/Inkling-Small": {
+			"id": "thinkingmachines/Inkling-Small",
+			"name": "Inkling Small",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.5,
+				"output": 1.2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 1048576,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"XiaomiMiMo/MiMo-V2-Flash": {
 			"id": "XiaomiMiMo/MiMo-V2-Flash",
 			"name": "MiMo-V2-Flash",
@@ -27866,23 +28287,33 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"~anthropic/claude-haiku-latest": {
 			"id": "~anthropic/claude-haiku-latest",
-			"name": "Claude Haiku Latest",
+			"name": "Anthropic Claude Haiku Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -27942,7 +28373,7 @@
 		},
 		"~anthropic/claude-sonnet-latest": {
 			"id": "~anthropic/claude-sonnet-latest",
-			"name": "Claude Sonnet Latest",
+			"name": "Anthropic Claude Sonnet Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -27952,10 +28383,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 3,
-				"output": 15,
-				"cacheRead": 0.3,
-				"cacheWrite": 3.75
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -27976,23 +28407,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.09,
+				"output": 0.18,
+				"cacheRead": 0.018,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
-			"supportsComputerUse": false
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				]
+			}
 		},
 		"~google/gemini-flash-latest": {
 			"id": "~google/gemini-flash-latest",
-			"name": "Gemini Flash Latest",
+			"name": "Google Gemini Flash Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28003,9 +28440,9 @@
 			],
 			"cost": {
 				"input": 1.5,
-				"output": 9,
+				"output": 7.5,
 				"cacheRead": 0.15,
-				"cacheWrite": 0.08333333333333334
+				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -28022,7 +28459,7 @@
 		},
 		"~google/gemini-pro-latest": {
 			"id": "~google/gemini-pro-latest",
-			"name": "Gemini Pro Latest",
+			"name": "Google Gemini Pro Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28052,7 +28489,7 @@
 		},
 		"~moonshotai/kimi-latest": {
 			"id": "~moonshotai/kimi-latest",
-			"name": "Kimi Latest",
+			"name": "MoonshotAI Kimi Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28062,13 +28499,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.74,
-				"output": 3.49,
-				"cacheRead": 0.14,
+				"input": 2.9,
+				"output": 14,
+				"cacheRead": 0.29,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262142,
-			"maxTokens": 262142,
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -28082,7 +28519,7 @@
 		},
 		"~openai/gpt-latest": {
 			"id": "~openai/gpt-latest",
-			"name": "GPT Latest",
+			"name": "OpenAI GPT Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28095,7 +28532,7 @@
 				"input": 5,
 				"output": 30,
 				"cacheRead": 0.5,
-				"cacheWrite": 0
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -28112,7 +28549,7 @@
 		},
 		"~openai/gpt-mini-latest": {
 			"id": "~openai/gpt-mini-latest",
-			"name": "GPT Mini Latest",
+			"name": "OpenAI GPT Mini Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28146,19 +28583,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"ai21/jamba-large-1.7": {
 			"id": "ai21/jamba-large-1.7",
@@ -28227,19 +28674,28 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.8,
+				"output": 1.6,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"aion-labs/aion-3.0": {
 			"id": "aion-labs/aion-3.0",
@@ -28247,19 +28703,28 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 6,
+				"cacheRead": 0.75,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"aion-labs/aion-3.0-mini": {
 			"id": "aion-labs/aion-3.0-mini",
@@ -28267,19 +28732,28 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.7,
+				"output": 1.4,
+				"cacheRead": 0.18,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"aion-labs/aion-rp-llama-3.1-8b": {
 			"id": "aion-labs/aion-rp-llama-3.1-8b",
@@ -28593,7 +29067,7 @@
 			"cost": {
 				"input": 2.5,
 				"output": 12.5,
-				"cacheRead": 0,
+				"cacheRead": 0.625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -28677,7 +29151,8 @@
 				"cacheWrite": 1
 			},
 			"contextWindow": 200000,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-3.5-sonnet": {
 			"id": "anthropic/claude-3.5-sonnet",
@@ -28766,10 +29241,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -28782,8 +29257,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
@@ -28963,7 +29437,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.7": {
 			"id": "anthropic/claude-opus-4.7",
@@ -28997,7 +29472,7 @@
 		},
 		"anthropic/claude-opus-4.7-fast": {
 			"id": "anthropic/claude-opus-4.7-fast",
-			"name": "Claude Opus 4.7 (Fast)",
+			"name": "Claude Opus 4.7",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -29037,10 +29512,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -29053,28 +29528,37 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"anthropic/claude-opus-4.8-fast": {
 			"id": "anthropic/claude-opus-4.8-fast",
-			"name": "Claude Opus 4.8 (Fast)",
+			"name": "Claude Opus 4.8",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"anthropic/claude-opus-5": {
 			"id": "anthropic/claude-opus-5",
@@ -29088,14 +29572,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -29109,23 +29592,33 @@
 		},
 		"anthropic/claude-opus-5-fast": {
 			"id": "anthropic/claude-opus-5-fast",
-			"name": "Claude Opus 5 (Fast)",
+			"name": "Claude Opus 5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
@@ -29201,8 +29694,8 @@
 			"cost": {
 				"input": 3,
 				"output": 15,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -29229,10 +29722,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -29245,8 +29738,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"arcee-ai/coder-large": {
 			"id": "arcee-ai/coder-large",
@@ -29366,7 +29858,7 @@
 			"cost": {
 				"input": 0.22,
 				"output": 0.85,
-				"cacheRead": 0,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -29431,7 +29923,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"arcee-ai/virtuoso-large": {
 			"id": "arcee-ai/virtuoso-large",
@@ -29479,7 +29972,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"baidu/ernie-4.5-21b-a3b": {
 			"id": "baidu/ernie-4.5-21b-a3b",
@@ -29498,7 +29992,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 120000,
-			"maxTokens": 8000
+			"maxTokens": 8000,
+			"supportsComputerUse": false
 		},
 		"baidu/ernie-4.5-300b-a47b": {
 			"id": "baidu/ernie-4.5-300b-a47b",
@@ -29549,7 +30044,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"baidu/ernie-4.5-vl-424b-a47b": {
 			"id": "baidu/ernie-4.5-vl-424b-a47b",
@@ -29816,7 +30312,7 @@
 		},
 		"cohere/command-r-08-2024": {
 			"id": "cohere/command-r-08-2024",
-			"name": "Command R (08-2024)",
+			"name": "Command R",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -29835,7 +30331,7 @@
 		},
 		"cohere/command-r-plus-08-2024": {
 			"id": "cohere/command-r-plus-08-2024",
-			"name": "Command R+ (08-2024)",
+			"name": "Command R+",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -29869,7 +30365,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4000
+			"maxTokens": 4000,
+			"supportsComputerUse": false
 		},
 		"cohere/north-mini-code:free": {
 			"id": "cohere/north-mini-code:free",
@@ -29877,7 +30374,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -29889,7 +30386,16 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 64000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"corethink:free": {
 			"id": "corethink:free",
@@ -29934,7 +30440,7 @@
 		},
 		"deepseek/deepseek-chat": {
 			"id": "deepseek/deepseek-chat",
-			"name": "DeepSeek V3",
+			"name": "DeepSeek Chat",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -29943,13 +30449,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.32,
-				"output": 0.89,
-				"cacheRead": 0.15,
+				"input": 0.4,
+				"output": 1.3,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
-			"maxTokens": 163840
+			"contextWindow": 128000,
+			"maxTokens": 16000
 		},
 		"deepseek/deepseek-chat-v3-0324": {
 			"id": "deepseek/deepseek-chat-v3-0324",
@@ -29962,9 +30468,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.2,
-				"output": 0.77,
-				"cacheRead": 0.095,
+				"input": 0.27,
+				"output": 1.12,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
@@ -29981,13 +30487,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.75,
-				"cacheRead": 0,
+				"input": 0.27,
+				"output": 1,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
-			"maxTokens": 7168,
+			"contextWindow": 163840,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -29998,7 +30504,7 @@
 		},
 		"deepseek/deepseek-r1": {
 			"id": "deepseek/deepseek-r1",
-			"name": "R1",
+			"name": "DeepSeek-R1",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -30033,13 +30539,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.45,
-				"output": 2.15,
-				"cacheRead": 0.2,
+				"input": 0.7,
+				"output": 2.5,
+				"cacheRead": 0.35,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 65536,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -30100,12 +30606,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.21,
-				"output": 0.79,
-				"cacheRead": 0.13,
+				"input": 0.27,
+				"output": 1,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
+			"contextWindow": 131072,
 			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
@@ -30147,9 +30653,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 0.38,
-				"cacheRead": 0.125,
+				"input": 0.269,
+				"output": 0.4,
+				"cacheRead": 0.1345,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
@@ -30222,11 +30728,11 @@
 			"cost": {
 				"input": 0.14,
 				"output": 0.28,
-				"cacheRead": 0.0028,
+				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -30241,19 +30747,25 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
-			"supportsComputerUse": false
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				]
+			}
 		},
 		"deepseek/deepseek-v4-flash:discounted": {
 			"id": "deepseek/deepseek-v4-flash:discounted",
@@ -30261,19 +30773,25 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.0028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				]
+			}
 		},
 		"deepseek/deepseek-v4-flash:free": {
 			"id": "deepseek/deepseek-v4-flash:free",
@@ -30307,9 +30825,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.435,
-				"output": 0.87,
-				"cacheRead": 0.003625,
+				"input": 1.6,
+				"output": 3.2,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -30328,19 +30846,25 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.435,
+				"output": 0.87,
+				"cacheRead": 0.003625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				]
+			}
 		},
 		"eleutherai/llemma_7b": {
 			"id": "eleutherai/llemma_7b",
@@ -30380,7 +30904,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
-			"maxTokens": 6554
+			"maxTokens": 6554,
+			"supportsComputerUse": false
 		},
 		"giga-potato": {
 			"id": "giga-potato",
@@ -30439,7 +30964,8 @@
 				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.0-flash-lite-001": {
 			"id": "google/gemini-2.0-flash-lite-001",
@@ -30459,7 +30985,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.5-flash": {
 			"id": "google/gemini-2.5-flash",
@@ -30512,7 +31039,7 @@
 		},
 		"google/gemini-2.5-flash-lite": {
 			"id": "google/gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -30566,7 +31093,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.5-pro": {
 			"id": "google/gemini-2.5-pro",
@@ -30676,7 +31204,7 @@
 				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 65536,
+			"maxTokens": 65535,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -30690,23 +31218,31 @@
 		},
 		"google/gemini-3-pro-image": {
 			"id": "google/gemini-3-pro-image",
-			"name": "Nano Banana Pro (Gemini 3 Pro Image)",
+			"name": "Nano Banana Pro",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 65536,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high"
+				],
+				"requiresEffort": true
+			}
 		},
 		"google/gemini-3-pro-image-preview": {
 			"id": "google/gemini-3-pro-image-preview",
@@ -30822,7 +31358,7 @@
 				"input": 0.25,
 				"output": 1.5,
 				"cacheRead": 0.025,
-				"cacheWrite": 0.08333
+				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -30871,8 +31407,8 @@
 			"cost": {
 				"input": 0.25,
 				"output": 1.5,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheRead": 0.025,
+				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -30901,8 +31437,8 @@
 			"cost": {
 				"input": 2,
 				"output": 12,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheRead": 0.2,
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -30929,8 +31465,8 @@
 			"cost": {
 				"input": 2,
 				"output": 12,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheRead": 0.2,
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -30958,7 +31494,7 @@
 				"input": 1.5,
 				"output": 9,
 				"cacheRead": 0.15,
-				"cacheWrite": 0.08333
+				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -30979,19 +31515,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.3,
+				"output": 2.5,
+				"cacheRead": 0.03,
+				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
 		},
 		"google/gemini-3.6-flash": {
 			"id": "google/gemini-3.6-flash",
@@ -30999,19 +31545,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 1.5,
+				"output": 7.5,
+				"cacheRead": 0.15,
+				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
 		},
 		"google/gemma-2-27b-it": {
 			"id": "google/gemma-2-27b-it",
@@ -31056,7 +31612,7 @@
 		},
 		"google/gemma-3-12b-it": {
 			"id": "google/gemma-3-12b-it",
-			"name": "Gemma 3 12B IT",
+			"name": "Gemma 3 12B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31066,14 +31622,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
+				"input": 0.05,
+				"output": 0.15,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 16384,
-			"supportsComputerUse": false
+			"maxTokens": 16384
 		},
 		"google/gemma-3-27b-it": {
 			"id": "google/gemma-3-27b-it",
@@ -31087,13 +31642,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.03,
-				"output": 0.11,
-				"cacheRead": 0.02,
+				"input": 0.08,
+				"output": 0.16,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 65536
+			"contextWindow": 131072,
+			"maxTokens": 131072
 		},
 		"google/gemma-3-4b-it": {
 			"id": "google/gemma-3-4b-it",
@@ -31139,7 +31694,7 @@
 		},
 		"google/gemma-4-26b-a4b-it": {
 			"id": "google/gemma-4-26b-a4b-it",
-			"name": "Gemma 4 26B A4B",
+			"name": "Gemma 4 26B A4B IT",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31149,13 +31704,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.12,
-				"output": 0.4,
+				"input": 0.07,
+				"output": 0.34,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -31169,7 +31724,7 @@
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31179,13 +31734,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.4,
-				"cacheRead": 0,
+				"input": 0.09,
+				"output": 0.34,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 131072,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -31409,7 +31964,7 @@
 		},
 		"inclusionai/ling-2.6-flash": {
 			"id": "inclusionai/ling-2.6-flash",
-			"name": "Ling-2.6 Flash",
+			"name": "Ling-2.6-flash",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31418,9 +31973,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.24,
-				"cacheRead": 0.016,
+				"input": 0.1,
+				"output": 0.3,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -31453,7 +32008,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -31465,7 +32020,16 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"inclusionai/ring-2.6-1t": {
 			"id": "inclusionai/ring-2.6-1t",
@@ -31478,9 +32042,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.075,
-				"output": 0.625,
-				"cacheRead": 0.015,
+				"input": 0.3,
+				"output": 2.5,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -31561,22 +32125,23 @@
 		},
 		"kilo-auto/balanced": {
 			"id": "kilo-auto/balanced",
-			"name": "Kilo Auto Balanced",
+			"name": "Auto Balanced",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 3,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.325,
+				"output": 1.95,
+				"cacheRead": 0.0325,
+				"cacheWrite": 0.40625
 			},
-			"contextWindow": 204800,
-			"maxTokens": 131072,
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -31594,23 +32159,33 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.325,
+				"output": 1.95,
+				"cacheRead": 0.0325,
+				"cacheWrite": 0.40625
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"kilo-auto/free": {
 			"id": "kilo-auto/free",
-			"name": "Kilo Auto Free",
+			"name": "Auto Free",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31624,8 +32199,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
-			"maxTokens": 131072,
+			"contextWindow": 256000,
+			"maxTokens": 10000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -31639,7 +32214,7 @@
 		},
 		"kilo-auto/frontier": {
 			"id": "kilo-auto/frontier",
-			"name": "Kilo Auto Frontier",
+			"name": "Auto Frontier",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31651,8 +32226,8 @@
 			"cost": {
 				"input": 5,
 				"output": 25,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -31669,7 +32244,7 @@
 		},
 		"kilo-auto/small": {
 			"id": "kilo-auto/small",
-			"name": "Kilo Auto Small",
+			"name": "Auto Small",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31681,11 +32256,11 @@
 			"cost": {
 				"input": 0.05,
 				"output": 0.4,
-				"cacheRead": 0,
+				"cacheRead": 0.005,
 				"cacheWrite": 0
 			},
-			"contextWindow": 400000,
-			"maxTokens": 128000,
+			"contextWindow": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -31771,14 +32346,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 256000,
+			"maxTokens": 80000
 		},
 		"kwaipilot/kat-coder-pro": {
 			"id": "kwaipilot/kat-coder-pro",
@@ -31831,14 +32405,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.74,
+				"output": 2.96,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 256000,
+			"maxTokens": 80000
 		},
 		"kwaipilot/kat-coder-pro-v2.5:free": {
 			"id": "kwaipilot/kat-coder-pro-v2.5:free",
@@ -31950,19 +32523,28 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.75,
+				"output": 3,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 1048756,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"meituan/longcat-flash-chat": {
 			"id": "meituan/longcat-flash-chat",
@@ -32023,7 +32605,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 8192,
-			"maxTokens": 16384
+			"maxTokens": 16384,
+			"supportsComputerUse": false
 		},
 		"meta-llama/llama-3.1-405b": {
 			"id": "meta-llama/llama-3.1-405b",
@@ -32084,7 +32667,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 26215
+			"maxTokens": 16384
 		},
 		"meta-llama/llama-3.1-8b-instruct": {
 			"id": "meta-llama/llama-3.1-8b-instruct",
@@ -32098,12 +32681,12 @@
 			],
 			"cost": {
 				"input": 0.02,
-				"output": 0.05,
+				"output": 0.04,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 16384,
-			"maxTokens": 16384
+			"contextWindow": 131072,
+			"maxTokens": 131072
 		},
 		"meta-llama/llama-3.2-11b-vision-instruct": {
 			"id": "meta-llama/llama-3.2-11b-vision-instruct",
@@ -32168,7 +32751,7 @@
 		},
 		"meta-llama/llama-3.3-70b-instruct": {
 			"id": "meta-llama/llama-3.3-70b-instruct",
-			"name": "Llama 3.3 70B Instruct",
+			"name": "Llama-3.3-70B-Instruct",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32183,7 +32766,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 16384
+			"maxTokens": 128000
 		},
 		"meta-llama/llama-4-maverick": {
 			"id": "meta-llama/llama-4-maverick",
@@ -32197,8 +32780,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.6,
+				"input": 0.2,
+				"output": 0.8,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -32217,7 +32800,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.08,
+				"input": 0.1,
 				"output": 0.3,
 				"cacheRead": 0,
 				"cacheWrite": 0
@@ -32314,19 +32897,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.25,
+				"output": 4.25,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 1048576,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"microsoft/phi-4": {
 			"id": "microsoft/phi-4",
@@ -32440,7 +33033,7 @@
 		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
-			"name": "MiniMax M2",
+			"name": "MiniMax-M2",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32449,13 +33042,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.255,
-				"output": 1,
-				"cacheRead": 0.03,
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
-			"maxTokens": 196608,
+			"contextWindow": 204800,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -32488,7 +33081,7 @@
 		},
 		"minimax/minimax-m2.1": {
 			"id": "minimax/minimax-m2.1",
-			"name": "MiniMax M2.1",
+			"name": "MiniMax-M2.1",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32497,13 +33090,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.27,
-				"output": 0.95,
+				"input": 0.3,
+				"output": 1.2,
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
-			"maxTokens": 39322,
+			"contextWindow": 204800,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -32516,7 +33109,7 @@
 		},
 		"minimax/minimax-m2.5": {
 			"id": "minimax/minimax-m2.5",
-			"name": "MiniMax M2.5",
+			"name": "MiniMax-M2.5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32525,9 +33118,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
+				"input": 0.3,
 				"output": 1.2,
-				"cacheRead": 0.029,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
@@ -32565,7 +33158,7 @@
 		},
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
-			"name": "MiniMax M2.7",
+			"name": "MiniMax-M2.7",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32579,7 +33172,7 @@
 				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
+			"contextWindow": 196608,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -32593,7 +33186,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32608,7 +33201,7 @@
 				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 524288,
 			"maxTokens": 512000,
 			"thinking": {
 				"mode": "effort",
@@ -32655,7 +33248,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 0.9,
-				"cacheRead": 0,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -32678,7 +33271,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536
+			"maxTokens": 65536,
+			"supportsComputerUse": false
 		},
 		"mistralai/devstral-medium": {
 			"id": "mistralai/devstral-medium",
@@ -32697,7 +33291,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 26215
+			"maxTokens": 26215,
+			"supportsComputerUse": false
 		},
 		"mistralai/devstral-small": {
 			"id": "mistralai/devstral-small",
@@ -32716,7 +33311,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 26215
+			"maxTokens": 26215,
+			"supportsComputerUse": false
 		},
 		"mistralai/ministral-14b-2512": {
 			"id": "mistralai/ministral-14b-2512",
@@ -32732,7 +33328,7 @@
 			"cost": {
 				"input": 0.2,
 				"output": 0.2,
-				"cacheRead": 0,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -32752,7 +33348,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -32772,7 +33368,7 @@
 			"cost": {
 				"input": 0.15,
 				"output": 0.15,
-				"cacheRead": 0,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -32854,7 +33450,7 @@
 			"cost": {
 				"input": 2,
 				"output": 6,
-				"cacheRead": 0,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -32873,7 +33469,7 @@
 			"cost": {
 				"input": 2,
 				"output": 6,
-				"cacheRead": 0,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -32896,11 +33492,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 26215
+			"maxTokens": 26215,
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-large-2512": {
 			"id": "mistralai/mistral-large-2512",
-			"name": "Mistral Large 3 2512",
+			"name": "Mistral Large 3",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32912,7 +33509,7 @@
 			"cost": {
 				"input": 0.5,
 				"output": 1.5,
-				"cacheRead": 0,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -32932,7 +33529,7 @@
 			"cost": {
 				"input": 0.4,
 				"output": 2,
-				"cacheRead": 0,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -32982,7 +33579,7 @@
 			"cost": {
 				"input": 0.4,
 				"output": 2,
-				"cacheRead": 0,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -32999,8 +33596,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.02,
-				"output": 0.04,
+				"input": 0.019,
+				"output": 0.03,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -33020,7 +33617,7 @@
 			"cost": {
 				"input": 0.2,
 				"output": 0.6,
-				"cacheRead": 0,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
@@ -33043,7 +33640,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
-			"maxTokens": 16384
+			"maxTokens": 16384,
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-small-2603": {
 			"id": "mistralai/mistral-small-2603",
@@ -33107,13 +33705,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.06,
-				"output": 0.18,
-				"cacheRead": 0.03,
+				"input": 0.075,
+				"output": 0.2,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 131072
+			"contextWindow": 128000,
+			"maxTokens": 16384
 		},
 		"mistralai/mistral-small-creative": {
 			"id": "mistralai/mistral-small-creative",
@@ -33149,7 +33747,7 @@
 			"cost": {
 				"input": 2,
 				"output": 6,
-				"cacheRead": 0,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 65536,
@@ -33194,7 +33792,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 32768
+			"maxTokens": 32768,
+			"supportsComputerUse": false
 		},
 		"mistralai/voxtral-small-24b-2507": {
 			"id": "mistralai/voxtral-small-24b-2507",
@@ -33209,7 +33808,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.3,
-				"cacheRead": 0,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 32000,
@@ -33226,13 +33825,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.55,
-				"output": 2.2,
+				"input": 0.57,
+				"output": 2.3,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131000,
-			"maxTokens": 26215
+			"contextWindow": 131072,
+			"maxTokens": 100352
 		},
 		"moonshotai/kimi-k2-0905": {
 			"id": "moonshotai/kimi-k2-0905",
@@ -33245,13 +33844,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.4,
-				"output": 2,
-				"cacheRead": 0.15,
+				"input": 0.6,
+				"output": 2.5,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 26215
+			"contextWindow": 262144,
+			"maxTokens": 100352
 		},
 		"moonshotai/kimi-k2-0905:exacto": {
 			"id": "moonshotai/kimi-k2-0905:exacto",
@@ -33285,13 +33884,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.47,
-				"output": 2,
-				"cacheRead": 0.2,
+				"input": 0.6,
+				"output": 2.5,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 65535,
+			"contextWindow": 262144,
+			"maxTokens": 100352,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -33316,13 +33915,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.45,
-				"output": 2.2,
-				"cacheRead": 0,
+				"input": 0.6,
+				"output": 3,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65535,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -33367,13 +33966,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
-				"output": 3.5,
-				"cacheRead": 0.375,
+				"input": 0.8,
+				"output": 3.4,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65535,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -33418,9 +34017,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.19,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -33434,8 +34033,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -33449,13 +34047,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -33468,8 +34066,7 @@
 					"max": "max"
 				},
 				"requiresEffort": true
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"morph-warp-grep-v2": {
 			"id": "morph-warp-grep-v2",
@@ -33591,7 +34188,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 163840
+			"maxTokens": 163840,
+			"supportsComputerUse": false
 		},
 		"nex-agi/nex-n2-mini": {
 			"id": "nex-agi/nex-n2-mini",
@@ -33599,19 +34197,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.025,
+				"output": 0.1,
+				"cacheRead": 0.0025,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
@@ -33619,19 +34227,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.25,
+				"output": 1,
+				"cacheRead": 0.025,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nex-agi/nex-n2-pro:free": {
 			"id": "nex-agi/nex-n2-pro:free",
@@ -33809,7 +34427,7 @@
 		},
 		"nvidia/llama-3.3-nemotron-super-49b-v1.5": {
 			"id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
-			"name": "Llama 3.3 Nemotron Super 49B V1.5",
+			"name": "Llama 3.3 Nemotron Super 49B v1.5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -33834,7 +34452,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-nano-30b-a3b": {
 			"id": "nvidia/nemotron-3-nano-30b-a3b",
@@ -33849,11 +34468,11 @@
 			"cost": {
 				"input": 0.05,
 				"output": 0.2,
-				"cacheRead": 0,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 52429,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -33898,7 +34517,7 @@
 		},
 		"nvidia/nemotron-3-super-120b-a12b": {
 			"id": "nvidia/nemotron-3-super-120b-a12b",
-			"name": "Nemotron 3 Super",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -33907,13 +34526,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.1,
-				"output": 0.5,
-				"cacheRead": 0.1,
+				"input": 0.085,
+				"output": 0.4,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -33965,6 +34584,35 @@
 				"text"
 			],
 			"cost": {
+				"input": 0.5,
+				"output": 2.2,
+				"cacheRead": 0.1,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512288,
+			"maxTokens": 512288,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"nvidia/nemotron-3-ultra-550b-a55b:free": {
+			"id": "nvidia/nemotron-3-ultra-550b-a55b:free",
+			"name": "Nemotron 3 Ultra (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
 				"input": 0,
 				"output": 0,
 				"cacheRead": 0,
@@ -33981,28 +34629,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
-		},
-		"nvidia/nemotron-3-ultra-550b-a55b:free": {
-			"id": "nvidia/nemotron-3-ultra-550b-a55b:free",
-			"name": "Nemotron 3 Ultra (free)",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			}
 		},
 		"nvidia/nemotron-3.5-content-safety:free": {
 			"id": "nvidia/nemotron-3.5-content-safety:free",
@@ -34083,11 +34710,12 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-3.5-turbo": {
 			"id": "openai/gpt-3.5-turbo",
-			"name": "GPT-3.5 Turbo",
+			"name": "GPT-3.5-turbo",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34198,7 +34826,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 8191,
-			"maxTokens": 4096
+			"maxTokens": 4096,
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4-1106-preview": {
 			"id": "openai/gpt-4-1106-preview",
@@ -34217,7 +34846,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4096
+			"maxTokens": 4096,
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4-turbo": {
 			"id": "openai/gpt-4-turbo",
@@ -34280,7 +34910,7 @@
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
-			"name": "GPT-4.1 Mini",
+			"name": "GPT-4.1 mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34300,7 +34930,7 @@
 		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
-			"name": "GPT-4.1 Nano",
+			"name": "GPT-4.1 nano",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34415,11 +35045,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 16384
+			"maxTokens": 16384,
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o-mini": {
 			"id": "openai/gpt-4o-mini",
-			"name": "GPT-4o-mini",
+			"name": "GPT-4o mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34451,7 +35082,7 @@
 			"cost": {
 				"input": 0.15,
 				"output": 0.6,
-				"cacheRead": 0,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -34597,7 +35228,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-image": {
 			"id": "openai/gpt-5-image",
@@ -34626,7 +35258,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-image-mini": {
 			"id": "openai/gpt-5-image-mini",
@@ -34655,7 +35288,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-mini": {
 			"id": "openai/gpt-5-mini",
@@ -34791,11 +35425,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 16384
+			"maxTokens": 16384,
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-codex": {
 			"id": "openai/gpt-5.1-codex",
-			"name": "GPT-5.1-Codex",
+			"name": "GPT-5.1 Codex",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34807,7 +35442,7 @@
 			"cost": {
 				"input": 1.25,
 				"output": 10,
-				"cacheRead": 0.125,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -34824,7 +35459,7 @@
 		},
 		"openai/gpt-5.1-codex-max": {
 			"id": "openai/gpt-5.1-codex-max",
-			"name": "GPT-5.1-Codex-Max",
+			"name": "GPT-5.1 Codex Max",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34853,7 +35488,7 @@
 		},
 		"openai/gpt-5.1-codex-mini": {
 			"id": "openai/gpt-5.1-codex-mini",
-			"name": "GPT-5.1-Codex-Mini",
+			"name": "GPT-5.1 Codex mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34865,11 +35500,11 @@
 			"cost": {
 				"input": 0.25,
 				"output": 2,
-				"cacheRead": 0.025,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 100000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -34929,7 +35564,7 @@
 		},
 		"openai/gpt-5.2-codex": {
 			"id": "openai/gpt-5.2-codex",
-			"name": "GPT-5.2-Codex",
+			"name": "GPT-5.2 Codex",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34999,7 +35634,7 @@
 			"cost": {
 				"input": 1.75,
 				"output": 14,
-				"cacheRead": 0,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -35007,7 +35642,7 @@
 		},
 		"openai/gpt-5.3-codex": {
 			"id": "openai/gpt-5.3-codex",
-			"name": "GPT-5.3-Codex",
+			"name": "GPT-5.3 Codex",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35019,7 +35654,7 @@
 			"cost": {
 				"input": 1.75,
 				"output": 14,
-				"cacheRead": 0,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -35048,7 +35683,7 @@
 			"cost": {
 				"input": 2.5,
 				"output": 15,
-				"cacheRead": 0,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1050000,
@@ -35085,7 +35720,7 @@
 		},
 		"openai/gpt-5.4-mini": {
 			"id": "openai/gpt-5.4-mini",
-			"name": "GPT-5.4 Mini",
+			"name": "GPT-5.4 mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35114,7 +35749,7 @@
 		},
 		"openai/gpt-5.4-nano": {
 			"id": "openai/gpt-5.4-nano",
-			"name": "GPT-5.4 Nano",
+			"name": "GPT-5.4 nano",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35242,12 +35877,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
-			"contextWindow": 372000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -35258,28 +35893,37 @@
 					"xhigh",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"openai/gpt-5.6-luna-pro": {
 			"id": "openai/gpt-5.6-luna-pro",
-			"name": "GPT-5.6 Luna Pro",
+			"name": "GPT-5.6 Luna",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		},
 		"openai/gpt-5.6-sol": {
 			"id": "openai/gpt-5.6-sol",
@@ -35293,12 +35937,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
-			"contextWindow": 372000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -35309,28 +35953,37 @@
 					"xhigh",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"openai/gpt-5.6-sol-pro": {
 			"id": "openai/gpt-5.6-sol-pro",
-			"name": "GPT-5.6 Sol Pro",
+			"name": "GPT-5.6 Sol",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		},
 		"openai/gpt-5.6-terra": {
 			"id": "openai/gpt-5.6-terra",
@@ -35344,12 +35997,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
-			"contextWindow": 372000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -35360,28 +36013,37 @@
 					"xhigh",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"openai/gpt-5.6-terra-pro": {
 			"id": "openai/gpt-5.6-terra-pro",
-			"name": "GPT-5.6 Terra Pro",
+			"name": "GPT-5.6 Terra",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		},
 		"openai/gpt-audio": {
 			"id": "openai/gpt-audio",
@@ -35394,14 +36056,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
+				"input": 2.5,
+				"output": 10,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 128000,
+			"maxTokens": 16384
 		},
 		"openai/gpt-audio-mini": {
 			"id": "openai/gpt-audio-mini",
@@ -35414,14 +36075,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
+				"input": 0.6,
+				"output": 2.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 128000,
+			"maxTokens": 16384
 		},
 		"openai/gpt-chat-latest": {
 			"id": "openai/gpt-chat-latest",
@@ -35429,7 +36089,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text",
 				"image"
@@ -35441,21 +36101,11 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 400000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
+			"maxTokens": 128000
 		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
-			"name": "gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35464,13 +36114,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.039,
-				"output": 0.19,
-				"cacheRead": 0,
+				"input": 0.03,
+				"output": 0.17,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 26215,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -35503,7 +36153,7 @@
 		},
 		"openai/gpt-oss-20b": {
 			"id": "openai/gpt-oss-20b",
-			"name": "gpt-oss-20b",
+			"name": "GPT OSS 20B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35513,12 +36163,12 @@
 			],
 			"cost": {
 				"input": 0.03,
-				"output": 0.14,
-				"cacheRead": 0,
+				"output": 0.13,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 26215,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -35541,7 +36191,7 @@
 			"cost": {
 				"input": 0.075,
 				"output": 0.3,
-				"cacheRead": 0.037,
+				"cacheRead": 0.0375,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -35561,7 +36211,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -35573,7 +36223,18 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 100000
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"requiresEffort": true
+			}
 		},
 		"openai/o1-pro": {
 			"id": "openai/o1-pro",
@@ -35655,15 +36316,16 @@
 					"xhigh"
 				],
 				"requiresEffort": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o3-mini": {
 			"id": "openai/o3-mini",
-			"name": "o3 Mini",
+			"name": "o3-mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -35674,7 +36336,18 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 100000
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"requiresEffort": true
+			}
 		},
 		"openai/o3-mini-high": {
 			"id": "openai/o3-mini-high",
@@ -35682,7 +36355,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -35693,11 +36366,22 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 100000
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"requiresEffort": true
+			}
 		},
 		"openai/o3-pro": {
 			"id": "openai/o3-pro",
-			"name": "o3 Pro",
+			"name": "o3-pro",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35728,7 +36412,7 @@
 		},
 		"openai/o4-mini": {
 			"id": "openai/o4-mini",
-			"name": "o4 Mini",
+			"name": "o4-mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35786,7 +36470,8 @@
 					"xhigh"
 				],
 				"requiresEffort": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o4-mini-high": {
 			"id": "openai/o4-mini-high",
@@ -35802,7 +36487,7 @@
 			"cost": {
 				"input": 1.1,
 				"output": 4.4,
-				"cacheRead": 0,
+				"cacheRead": 0.275,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -35933,7 +36618,7 @@
 		},
 		"openrouter/free": {
 			"id": "openrouter/free",
-			"name": "Free Models Router",
+			"name": "OpenRouter Free Models Router",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -36050,7 +36735,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openrouter/pareto-code": {
 			"id": "openrouter/pareto-code",
@@ -36248,7 +36934,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"poolside/laguna-s-2.1": {
 			"id": "poolside/laguna-s-2.1",
@@ -36256,43 +36943,32 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.1,
+				"output": 0.2,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"poolside/laguna-s-2.1:free": {
 			"id": "poolside/laguna-s-2.1:free",
 			"name": "Laguna S 2.1 (free)",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
-			"supportsComputerUse": false
-		},
-		"poolside/laguna-xs-2.1": {
-			"id": "poolside/laguna-xs-2.1",
-			"name": "Laguna XS 2.1",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -36308,7 +36984,35 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"supportsComputerUse": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"poolside/laguna-xs-2.1": {
+			"id": "poolside/laguna-xs-2.1",
+			"name": "Laguna XS 2.1",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.2,
+				"cacheRead": 0.05,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -36326,7 +37030,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -36338,7 +37042,16 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"poolside/laguna-xs.2": {
 			"id": "poolside/laguna-xs.2",
@@ -36398,7 +37111,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"prime-intellect/intellect-3": {
 			"id": "prime-intellect/intellect-3",
@@ -36427,7 +37141,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen-2.5-72b-instruct": {
 			"id": "qwen/qwen-2.5-72b-instruct",
@@ -36440,8 +37155,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.12,
-				"output": 0.39,
+				"input": 0.36,
+				"output": 0.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -36459,13 +37174,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.04,
-				"output": 0.1,
+				"input": 0.1,
+				"output": 0.2,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
-			"maxTokens": 6554
+			"maxTokens": 32768
 		},
 		"qwen/qwen-2.5-coder-32b-instruct": {
 			"id": "qwen/qwen-2.5-coder-32b-instruct",
@@ -36531,7 +37246,7 @@
 		},
 		"qwen/qwen-plus": {
 			"id": "qwen/qwen-plus",
-			"name": "Qwen-Plus",
+			"name": "Qwen Plus",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -36540,10 +37255,10 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.4,
-				"output": 1.2,
-				"cacheRead": 0.08,
-				"cacheWrite": 0
+				"input": 0.26,
+				"output": 0.78,
+				"cacheRead": 0.052,
+				"cacheWrite": 0.325
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768
@@ -36578,10 +37293,10 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 0.78,
+				"input": 0.4,
+				"output": 1.2,
 				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheWrite": 0.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768,
@@ -36731,13 +37446,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06,
-				"output": 0.24,
-				"cacheRead": 0.025,
+				"input": 0.2275,
+				"output": 0.91,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
-			"maxTokens": 40960,
+			"contextWindow": 131072,
+			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -36750,7 +37465,7 @@
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3 235B A22B",
+			"name": "Qwen3 235B-A22B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -36761,7 +37476,7 @@
 			"cost": {
 				"input": 0.455,
 				"output": 1.82,
-				"cacheRead": 0.15,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -36787,13 +37502,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.071,
-				"output": 0.1,
+				"input": 0.1495,
+				"output": 0.598,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 52429
+			"contextWindow": 131072,
+			"maxTokens": 32768
 		},
 		"qwen/qwen3-235b-a22b-thinking-2507": {
 			"id": "qwen/qwen3-235b-a22b-thinking-2507",
@@ -36806,12 +37521,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.11,
-				"output": 0.6,
+				"input": 0.23,
+				"output": 2.3,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 131072,
 			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
@@ -36835,13 +37550,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.28,
-				"cacheRead": 0.03,
+				"input": 0.13,
+				"output": 0.52,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 40960,
-			"maxTokens": 40960,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -36863,13 +37578,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 0.3,
-				"cacheRead": 0.04,
+				"input": 0.13,
+				"output": 0.52,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144
+			"contextWindow": 128000,
+			"maxTokens": 32000
 		},
 		"qwen/qwen3-30b-a3b-thinking-2507": {
 			"id": "qwen/qwen3-30b-a3b-thinking-2507",
@@ -36882,13 +37597,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.051,
-				"output": 0.34,
+				"input": 0.2,
+				"output": 2.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
-			"maxTokens": 6554,
+			"contextWindow": 81920,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -36911,13 +37626,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.24,
-				"cacheRead": 0.04,
+				"input": 0.104,
+				"output": 0.416,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 40960,
-			"maxTokens": 40960,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -36939,12 +37654,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.05,
-				"output": 0.4,
-				"cacheRead": 0.05,
+				"input": 0.117,
+				"output": 0.455,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
+			"contextWindow": 131072,
 			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
@@ -36967,17 +37682,17 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.22,
-				"output": 1,
-				"cacheRead": 0.022,
+				"input": 0.975,
+				"output": 4.875,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 52429
+			"maxTokens": 65536
 		},
 		"qwen/qwen3-coder-30b-a3b-instruct": {
 			"id": "qwen/qwen3-coder-30b-a3b-instruct",
-			"name": "Qwen3 Coder 30B A3B Instruct",
+			"name": "Qwen3-Coder 30B-A3B Instruct",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -36986,13 +37701,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.07,
-				"output": 0.27,
+				"input": 0.2925,
+				"output": 1.4625,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 160000,
-			"maxTokens": 32768
+			"contextWindow": 262144,
+			"maxTokens": 262144
 		},
 		"qwen/qwen3-coder-flash": {
 			"id": "qwen/qwen3-coder-flash",
@@ -37007,8 +37722,8 @@
 			"cost": {
 				"input": 0.195,
 				"output": 0.975,
-				"cacheRead": 0.06,
-				"cacheWrite": 0
+				"cacheRead": 0.039,
+				"cacheWrite": 0.24375
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536
@@ -37024,13 +37739,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.12,
-				"output": 0.75,
-				"cacheRead": 0.035,
+				"input": 0.3,
+				"output": 1.5,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536
+			"maxTokens": 262144
 		},
 		"qwen/qwen3-coder-plus": {
 			"id": "qwen/qwen3-coder-plus",
@@ -37045,8 +37760,8 @@
 			"cost": {
 				"input": 0.65,
 				"output": 3.25,
-				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheRead": 0.13,
+				"cacheWrite": 0.8125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536
@@ -37083,13 +37798,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.2,
-				"output": 6,
-				"cacheRead": 0.24,
-				"cacheWrite": 0
+				"input": 0.78,
+				"output": 3.9,
+				"cacheRead": 0.156,
+				"cacheWrite": 0.975
 			},
 			"contextWindow": 262144,
-			"maxTokens": 32768
+			"maxTokens": 65536
 		},
 		"qwen/qwen3-max-thinking": {
 			"id": "qwen/qwen3-max-thinking",
@@ -37108,7 +37823,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 32768,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37122,7 +37837,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-instruct": {
 			"id": "qwen/qwen3-next-80b-a3b-instruct",
-			"name": "Qwen3 Next 80B A3B Instruct",
+			"name": "Qwen3-Next 80B-A3B Instruct",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37131,17 +37846,17 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 1.1,
+				"input": 0.0975,
+				"output": 0.78,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 52429
+			"contextWindow": 262144,
+			"maxTokens": 262144
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
-			"name": "Qwen3 Next 80B A3B Thinking",
+			"name": "Qwen3-Next 80B-A3B (Thinking)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37150,8 +37865,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.0975,
-				"output": 0.78,
+				"input": 0.15,
+				"output": 1.2,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -37180,13 +37895,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.2,
-				"output": 0.88,
-				"cacheRead": 0.11,
+				"input": 0.26,
+				"output": 1.04,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 52429
+			"contextWindow": 131072,
+			"maxTokens": 32768
 		},
 		"qwen/qwen3-vl-235b-a22b-thinking": {
 			"id": "qwen/qwen3-vl-235b-a22b-thinking",
@@ -37200,8 +37915,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 2.6,
+				"input": 0.4,
+				"output": 4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -37250,8 +37965,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 1.56,
+				"input": 0.2,
+				"output": 2.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -37300,8 +38015,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.5,
+				"input": 0.117,
+				"output": 0.455,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -37320,8 +38035,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.117,
-				"output": 1.365,
+				"input": 0.18,
+				"output": 2.1,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -37340,7 +38055,7 @@
 		},
 		"qwen/qwen3.5-122b-a10b": {
 			"id": "qwen/qwen3.5-122b-a10b",
-			"name": "Qwen3.5-122B-A10B",
+			"name": "Qwen3.5 122B-A10B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37369,7 +38084,7 @@
 		},
 		"qwen/qwen3.5-27b": {
 			"id": "qwen/qwen3.5-27b",
-			"name": "Qwen3.5-27B",
+			"name": "Qwen3.5 27B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37398,7 +38113,7 @@
 		},
 		"qwen/qwen3.5-35b-a3b": {
 			"id": "qwen/qwen3.5-35b-a3b",
-			"name": "Qwen3.5-35B-A3B",
+			"name": "Qwen3.5 35B-A3B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37414,7 +38129,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37427,7 +38142,7 @@
 		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
-			"name": "Qwen3.5 397B A17B",
+			"name": "Qwen3.5 397B-A17B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37456,7 +38171,7 @@
 		},
 		"qwen/qwen3.5-9b": {
 			"id": "qwen/qwen3.5-9b",
-			"name": "Qwen3.5-9B",
+			"name": "Qwen3.5 9B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37466,13 +38181,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.05,
+				"input": 0.1,
 				"output": 0.15,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 32768,
+			"contextWindow": 262144,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37495,8 +38210,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.1,
-				"output": 0.4,
+				"input": 0.065,
+				"output": 0.26,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -37553,10 +38268,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.4,
-				"output": 2.4,
+				"input": 0.3,
+				"output": 1.8,
 				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
@@ -37582,12 +38297,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.325,
-				"output": 3.25,
+				"input": 0.45,
+				"output": 2.7,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 262144,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -37601,23 +38316,32 @@
 		},
 		"qwen/qwen3.6-35b-a3b": {
 			"id": "qwen/qwen3.6-35b-a3b",
-			"name": "Qwen3.6 35B A3B",
+			"name": "Qwen3.6 35B-A3B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
+				"input": 0.14,
+				"output": 1,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 65536,
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"qwen/qwen3.6-flash": {
 			"id": "qwen/qwen3.6-flash",
@@ -37631,10 +38355,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1.5,
+				"input": 0.1875,
+				"output": 1.125,
 				"cacheRead": 0,
-				"cacheWrite": 0.3125
+				"cacheWrite": 0.234375
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
@@ -37659,10 +38383,10 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.04,
-				"output": 6.24,
+				"input": 1.027,
+				"output": 6.162,
 				"cacheRead": 0,
-				"cacheWrite": 1.3
+				"cacheWrite": 1.28375
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
@@ -37690,7 +38414,7 @@
 			"cost": {
 				"input": 0.325,
 				"output": 1.95,
-				"cacheRead": 0.0325,
+				"cacheRead": 0,
 				"cacheWrite": 0.40625
 			},
 			"contextWindow": 1000000,
@@ -37753,19 +38477,28 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.03,
+				"output": 0.13,
+				"cacheRead": 0.006,
+				"cacheWrite": 0.038
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"qwen/qwen3.7-max": {
 			"id": "qwen/qwen3.7-max",
@@ -37778,13 +38511,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.625,
-				"output": 4.875,
-				"cacheRead": 0.1625,
-				"cacheWrite": 2.03125
+				"input": 1.25,
+				"output": 3.75,
+				"cacheRead": 0.125,
+				"cacheWrite": 1.5625
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 65536,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37807,13 +38540,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.32,
+				"output": 1.28,
+				"cacheRead": 0.032,
+				"cacheWrite": 0.4
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 64000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37822,8 +38555,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"qwen/qwen3.7-plus:free": {
 			"id": "qwen/qwen3.7-plus:free",
@@ -38026,7 +38758,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 8192,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"supportsComputerUse": false
 		},
 		"sao10k/l3-lunaris-8b": {
 			"id": "sao10k/l3-lunaris-8b",
@@ -38174,19 +38907,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 4,
+				"output": 20,
+				"cacheRead": 0.4,
+				"cacheWrite": 5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"stealth/claude-sonnet-4.6": {
 			"id": "stealth/claude-sonnet-4.6",
@@ -38224,19 +38967,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 4,
+				"output": 24,
+				"cacheRead": 0.4,
+				"cacheWrite": 5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		},
 		"stealth/qwen3.6-plus": {
 			"id": "stealth/qwen3.6-plus",
@@ -38244,19 +38997,28 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0.025,
+				"cacheWrite": 0.3125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"stepfun/step-3.5-flash": {
 			"id": "stepfun/step-3.5-flash",
@@ -38271,11 +39033,11 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.3,
-				"cacheRead": 0.02,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 256000,
+			"contextWindow": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -38320,9 +39082,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.2,
+				"output": 1.15,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -38336,8 +39098,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"stepfun/step-3.7-flash:free": {
 			"id": "stepfun/step-3.7-flash:free",
@@ -38345,9 +39106,10 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -38355,9 +39117,18 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 256000,
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"switchpoint/router": {
 			"id": "switchpoint/router",
@@ -38406,23 +39177,32 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.14,
+				"output": 0.58,
+				"cacheRead": 0.035,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"supportsComputerUse": false
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
-			"name": "Hy3 Preview",
+			"name": "Hy3 preview",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -38431,9 +39211,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.066,
-				"output": 0.26,
-				"cacheRead": 0.029,
+				"input": 0.18,
+				"output": 0.6,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -38488,8 +39268,7 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUse": false
 		},
 		"thedrummer/cydonia-24b-v4.1": {
 			"id": "thedrummer/cydonia-24b-v4.1",
@@ -38528,7 +39307,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
-			"maxTokens": 32768
+			"maxTokens": 32768,
+			"supportsComputerUse": false
 		},
 		"thedrummer/skyfall-36b-v2": {
 			"id": "thedrummer/skyfall-36b-v2",
@@ -38566,8 +39346,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
-			"maxTokens": 32768
+			"contextWindow": 1024000,
+			"maxTokens": 1024000
 		},
 		"thinkingmachines/inkling": {
 			"id": "thinkingmachines/inkling",
@@ -38581,14 +39361,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.95,
+				"output": 4.05,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 65536,
-			"supportsComputerUse": false,
+			"contextWindow": 524288,
+			"maxTokens": 524288,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -38606,19 +39385,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.45,
+				"output": 1.2,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"contextWindow": 524288,
+			"maxTokens": 524288,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"tngtech/deepseek-r1t2-chimera": {
 			"id": "tngtech/deepseek-r1t2-chimera",
@@ -38674,7 +39463,7 @@
 			"cost": {
 				"input": 0.15,
 				"output": 0.6,
-				"cacheRead": 0,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -38902,8 +39691,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 6,
+				"input": 1.25,
+				"output": 2.5,
 				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
@@ -39035,9 +39824,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 500000,
@@ -39051,8 +39840,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"x-ai/grok-build-0.1": {
 			"id": "x-ai/grok-build-0.1",
@@ -39161,11 +39949,12 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2-omni": {
 			"id": "xiaomi/mimo-v2-omni",
-			"name": "MiMo-V2-Omni",
+			"name": "MiMo V2 Omni",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39189,7 +39978,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2-omni:free": {
 			"id": "xiaomi/mimo-v2-omni:free",
@@ -39214,7 +40004,7 @@
 		},
 		"xiaomi/mimo-v2-pro": {
 			"id": "xiaomi/mimo-v2-pro",
-			"name": "MiMo-V2-Pro",
+			"name": "MiMo V2 Pro",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39237,7 +40027,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2-pro:free": {
 			"id": "xiaomi/mimo-v2-pro:free",
@@ -39272,9 +40063,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.4,
-				"output": 2,
-				"cacheRead": 0.08,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.003,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -39290,7 +40081,7 @@
 		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
-			"name": "MiMo V2.5 Pro",
+			"name": "MiMo-V2.5-Pro",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39299,9 +40090,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 3,
-				"cacheRead": 0.2,
+				"input": 0.435,
+				"output": 0.87,
+				"cacheRead": 0.004,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -39332,11 +40123,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 32768
+			"maxTokens": 32768,
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.5": {
 			"id": "z-ai/glm-4.5",
-			"name": "GLM 4.5",
+			"name": "GLM-4.5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39347,7 +40139,7 @@
 			"cost": {
 				"input": 0.6,
 				"output": 2.2,
-				"cacheRead": 0.175,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -39365,7 +40157,7 @@
 		},
 		"z-ai/glm-4.5-air": {
 			"id": "z-ai/glm-4.5-air",
-			"name": "GLM 4.5 Air",
+			"name": "GLM-4.5-Air",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39394,7 +40186,7 @@
 		},
 		"z-ai/glm-4.5v": {
 			"id": "z-ai/glm-4.5v",
-			"name": "GLM 4.5V",
+			"name": "GLM-4.5V",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39424,7 +40216,7 @@
 		},
 		"z-ai/glm-4.6": {
 			"id": "z-ai/glm-4.6",
-			"name": "GLM 4.6",
+			"name": "GLM-4.6",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39433,13 +40225,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.39,
-				"output": 1.9,
-				"cacheRead": 0.175,
+				"input": 0.55,
+				"output": 2.2,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
-			"maxTokens": 204800,
+			"contextWindow": 202752,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39474,7 +40266,7 @@
 		},
 		"z-ai/glm-4.6v": {
 			"id": "z-ai/glm-4.6v",
-			"name": "GLM 4.6V",
+			"name": "GLM-4.6V",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39486,11 +40278,11 @@
 			"cost": {
 				"input": 0.3,
 				"output": 0.9,
-				"cacheRead": 0,
+				"cacheRead": 0.055,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131072,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39504,7 +40296,7 @@
 		},
 		"z-ai/glm-4.7": {
 			"id": "z-ai/glm-4.7",
-			"name": "GLM 4.7",
+			"name": "GLM-4.7",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39513,13 +40305,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.38,
-				"output": 1.98,
-				"cacheRead": 0.2,
+				"input": 0.6,
+				"output": 2.2,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
-			"maxTokens": 65535,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39533,7 +40325,7 @@
 		},
 		"z-ai/glm-4.7-flash": {
 			"id": "z-ai/glm-4.7-flash",
-			"name": "GLM 4.7 Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39542,13 +40334,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06,
+				"input": 0.07,
 				"output": 0.4,
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
-			"maxTokens": 40551,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39562,7 +40354,7 @@
 		},
 		"z-ai/glm-5": {
 			"id": "z-ai/glm-5",
-			"name": "GLM 5",
+			"name": "GLM-5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39571,12 +40363,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.72,
-				"output": 2.3,
-				"cacheRead": 0,
+				"input": 1,
+				"output": 3.2,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202752,
+			"contextWindow": 204800,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -39591,7 +40383,7 @@
 		},
 		"z-ai/glm-5-turbo": {
 			"id": "z-ai/glm-5-turbo",
-			"name": "GLM 5 Turbo",
+			"name": "GLM-5-Turbo",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39620,7 +40412,7 @@
 		},
 		"z-ai/glm-5.1": {
 			"id": "z-ai/glm-5.1",
-			"name": "GLM 5.1",
+			"name": "GLM-5.1",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39629,13 +40421,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.26,
-				"output": 3.96,
-				"cacheRead": 0,
+				"input": 1.38,
+				"output": 4.4,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202752,
-			"maxTokens": 131072,
+			"contextWindow": 200000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39658,13 +40450,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39674,12 +40466,11 @@
 					"high",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"z-ai/glm-5v-turbo": {
 			"id": "z-ai/glm-5v-turbo",
-			"name": "GLM 5V Turbo",
+			"name": "GLM-5V-Turbo",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -41748,6 +42539,25 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000
+		},
+		"voxtral-small-latest": {
+			"id": "voxtral-small-latest",
+			"name": "Voxtral Small",
+			"api": "openai-completions",
+			"provider": "mistral",
+			"baseUrl": "https://api.mistral.ai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.3,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 32000,
+			"maxTokens": 32000
 		}
 	},
 	"moonshot": {
@@ -42218,11 +43028,11 @@
 		},
 		"aion-labs/aion-2.0": {
 			"id": "aion-labs/aion-2.0",
-			"name": "aion-labs/aion-2.0",
+			"name": "Aion-2.0",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -42232,10 +43042,20 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"aion-labs/aion-2.5": {
 			"id": "aion-labs/aion-2.5",
@@ -42260,11 +43080,11 @@
 		},
 		"aion-labs/aion-3.0": {
 			"id": "aion-labs/aion-3.0",
-			"name": "aion-labs/aion-3.0",
+			"name": "Aion-3.0",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -42274,18 +43094,28 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"aion-labs/aion-3.0-mini": {
 			"id": "aion-labs/aion-3.0-mini",
-			"name": "aion-labs/aion-3.0-mini",
+			"name": "Aion-3.0-Mini",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -42295,10 +43125,20 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"aion-labs/aion-rp-llama-3.1-8b": {
 			"id": "aion-labs/aion-rp-llama-3.1-8b",
@@ -45454,7 +46294,7 @@
 		},
 		"deepseek/deepseek-v4-flash-0731": {
 			"id": "deepseek/deepseek-v4-flash-0731",
-			"name": "deepseek/deepseek-v4-flash-0731",
+			"name": "DeepSeek V4 Flash 0731",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -48622,13 +49462,14 @@
 		},
 		"google/gemini-3.5-flash-lite": {
 			"id": "google/gemini-3.5-flash-lite",
-			"name": "google/gemini-3.5-flash-lite",
+			"name": "Gemini 3.5 Flash Lite",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -48639,17 +49480,28 @@
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
 		},
 		"google/gemini-3.6-flash": {
 			"id": "google/gemini-3.6-flash",
-			"name": "google/gemini-3.6-flash",
+			"name": "Gemini 3.6 Flash",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -48660,7 +49512,17 @@
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
 		},
 		"google/gemini-flash-1.5": {
 			"id": "google/gemini-flash-1.5",
@@ -48775,7 +49637,7 @@
 		},
 		"google/gemma-4-26b-a4b-it": {
 			"id": "google/gemma-4-26b-a4b-it",
-			"name": "Gemma 4 26B A4B",
+			"name": "Gemma 4 26B A4B IT",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -48807,7 +49669,7 @@
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -49672,7 +50534,7 @@
 		},
 		"kwaipilot/kat-coder-air-v2.5": {
 			"id": "kwaipilot/kat-coder-air-v2.5",
-			"name": "kwaipilot/kat-coder-air-v2.5",
+			"name": "KAT-Coder-Air V2.5",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -49686,8 +50548,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 256000,
+			"maxTokens": 80000,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -49714,7 +50576,7 @@
 		},
 		"kwaipilot/kat-coder-pro-v2.5": {
 			"id": "kwaipilot/kat-coder-pro-v2.5",
-			"name": "kwaipilot/kat-coder-pro-v2.5",
+			"name": "KAT-Coder-Pro V2.5",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -49728,8 +50590,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 256000,
+			"maxTokens": 80000,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -51156,13 +52018,14 @@
 		},
 		"meta/muse-spark-1.1": {
 			"id": "meta/muse-spark-1.1",
-			"name": "meta/muse-spark-1.1",
+			"name": "Muse Spark 1.1",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -51173,7 +52036,17 @@
 			"contextWindow": 1048576,
 			"maxTokens": 1048576,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"microsoft/MAI-DS-R1-FP8": {
 			"id": "microsoft/MAI-DS-R1-FP8",
@@ -52814,13 +53687,14 @@
 		},
 		"nex-agi/nex-n2-mini": {
 			"id": "nex-agi/nex-n2-mini",
-			"name": "nex-agi/nex-n2-mini",
+			"name": "Nex-N2-Mini",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -52831,17 +53705,28 @@
 			"contextWindow": 262144,
 			"maxTokens": 262144,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
-			"name": "nex-agi/nex-n2-pro",
+			"name": "Nex-N2-Pro",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -52852,7 +53737,17 @@
 			"contextWindow": 262144,
 			"maxTokens": 262144,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nothingiisreal/L3.1-70B-Celeste-V0.1-BF16": {
 			"id": "nothingiisreal/L3.1-70B-Celeste-V0.1-BF16",
@@ -53289,7 +54184,7 @@
 		},
 		"openai/gpt-3.5-turbo": {
 			"id": "openai/gpt-3.5-turbo",
-			"name": "GPT-3.5 Turbo",
+			"name": "GPT-3.5-turbo",
 			"api": "openai-completions",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
@@ -53373,7 +54268,7 @@
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
-			"name": "GPT-4.1 Mini",
+			"name": "GPT-4.1 mini",
 			"api": "openai-completions",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
@@ -53395,7 +54290,7 @@
 		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
-			"name": "GPT-4.1 Nano",
+			"name": "GPT-4.1 nano",
 			"api": "openai-completions",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
@@ -53874,7 +54769,7 @@
 		},
 		"openai/gpt-5.1-codex-mini": {
 			"id": "openai/gpt-5.1-codex-mini",
-			"name": "GPT-5.1-Codex-Mini",
+			"name": "GPT-5.1 Codex mini",
 			"api": "openai-completions",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
@@ -54241,13 +55136,14 @@
 		},
 		"openai/gpt-5.6-luna-pro": {
 			"id": "openai/gpt-5.6-luna-pro",
-			"name": "GPT-5.6 Luna Pro",
+			"name": "GPT-5.6 Luna",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -54258,7 +55154,17 @@
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		},
 		"openai/gpt-5.6-sol": {
 			"id": "openai/gpt-5.6-sol",
@@ -54294,13 +55200,14 @@
 		},
 		"openai/gpt-5.6-sol-pro": {
 			"id": "openai/gpt-5.6-sol-pro",
-			"name": "GPT-5.6 Sol Pro",
+			"name": "GPT-5.6 Sol",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -54311,7 +55218,17 @@
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		},
 		"openai/gpt-5.6-terra": {
 			"id": "openai/gpt-5.6-terra",
@@ -54347,13 +55264,14 @@
 		},
 		"openai/gpt-5.6-terra-pro": {
 			"id": "openai/gpt-5.6-terra-pro",
-			"name": "GPT-5.6 Terra Pro",
+			"name": "GPT-5.6 Terra",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -54364,7 +55282,17 @@
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		},
 		"openai/gpt-chat-latest": {
 			"id": "openai/gpt-chat-latest",
@@ -55052,7 +55980,7 @@
 		},
 		"poolside/laguna-s-2.1": {
 			"id": "poolside/laguna-s-2.1",
-			"name": "poolside/laguna-s-2.1",
+			"name": "Laguna S 2.1",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -55692,7 +56620,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
-			"name": "Qwen3 Next 80B A3B Thinking",
+			"name": "Qwen3-Next 80B-A3B (Thinking)",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -55744,7 +56672,7 @@
 		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
-			"name": "Qwen3.5 397B A17B",
+			"name": "Qwen3.5 397B-A17B",
 			"api": "openai-completions",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
@@ -55782,7 +56710,7 @@
 		},
 		"qwen/qwen3.5-9b": {
 			"id": "qwen/qwen3.5-9b",
-			"name": "Qwen3.5-9B",
+			"name": "Qwen3.5 9B",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -59070,11 +59998,11 @@
 		},
 		"tencent/hy3": {
 			"id": "tencent/hy3",
-			"name": "tencent/hy3",
+			"name": "Hy3",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -59087,11 +60015,21 @@
 			"contextWindow": 262144,
 			"maxTokens": 262144,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
-			"name": "Hy3 Preview",
+			"name": "Hy3 preview",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -59385,13 +60323,14 @@
 		},
 		"thinkingmachines/Inkling-Small": {
 			"id": "thinkingmachines/Inkling-Small",
-			"name": "thinkingmachines/Inkling-Small",
+			"name": "Inkling Small",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -60573,7 +61512,7 @@
 		},
 		"z-ai/glm-4.5v": {
 			"id": "z-ai/glm-4.5v",
-			"name": "GLM 4.5V",
+			"name": "GLM-4.5V",
 			"api": "openai-completions",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
@@ -61546,7 +62485,7 @@
 		},
 		"deepseek/deepseek-r1": {
 			"id": "deepseek/deepseek-r1",
-			"name": "R1",
+			"name": "DeepSeek-R1",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -61924,7 +62863,7 @@
 		},
 		"deepseek/deepseek-v4-flash-0731": {
 			"id": "deepseek/deepseek-v4-flash-0731",
-			"name": "Deepseek V4 Flash 0731",
+			"name": "DeepSeek V4 Flash 0731",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62050,7 +62989,7 @@
 		},
 		"google/gemma-4-26b-a4b-it": {
 			"id": "google/gemma-4-26b-a4b-it",
-			"name": "Gemma 4 26B A4B",
+			"name": "Gemma 4 26B A4B IT",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62083,7 +63022,7 @@
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62183,7 +63122,7 @@
 		},
 		"inclusionai/ling-2.6-flash": {
 			"id": "inclusionai/ling-2.6-flash",
-			"name": "Ling-2.6 Flash",
+			"name": "Ling-2.6-flash",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62357,7 +63296,7 @@
 		},
 		"meta-llama/llama-3.3-70b-instruct": {
 			"id": "meta-llama/llama-3.3-70b-instruct",
-			"name": "Llama 3.3 70B Instruct",
+			"name": "Llama-3.3-70B-Instruct",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62511,7 +63450,7 @@
 		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
-			"name": "MiniMax M2",
+			"name": "MiniMax-M2",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62542,7 +63481,7 @@
 		},
 		"minimax/minimax-m2.1": {
 			"id": "minimax/minimax-m2.1",
-			"name": "MiniMax M2.1",
+			"name": "MiniMax-M2.1",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62697,7 +63636,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -63262,7 +64201,7 @@
 		},
 		"qwen/qwen3-coder-30b-a3b-instruct": {
 			"id": "qwen/qwen3-coder-30b-a3b-instruct",
-			"name": "Qwen3 Coder 30B A3B Instruct",
+			"name": "Qwen3-Coder 30B-A3B Instruct",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -63350,7 +64289,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-instruct": {
 			"id": "qwen/qwen3-next-80b-a3b-instruct",
-			"name": "Qwen3-Next-80B-A3B-Instruct",
+			"name": "Qwen3-Next 80B-A3B Instruct",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -63539,7 +64478,7 @@
 		},
 		"qwen/qwen3.5-27b": {
 			"id": "qwen/qwen3.5-27b",
-			"name": "Qwen3.5-27B",
+			"name": "Qwen3.5 27B",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -63571,7 +64510,7 @@
 		},
 		"qwen/qwen3.5-35b-a3b": {
 			"id": "qwen/qwen3.5-35b-a3b",
-			"name": "Qwen3.5-35B-A3B",
+			"name": "Qwen3.5 35B-A3B",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -63603,7 +64542,7 @@
 		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
-			"name": "Qwen3.5 397B A17B",
+			"name": "Qwen3.5 397B-A17B",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -63699,7 +64638,7 @@
 		},
 		"qwen/qwen3.6-35b-a3b": {
 			"id": "qwen/qwen3.6-35b-a3b",
-			"name": "Qwen3.6-35B-A3B",
+			"name": "Qwen3.6 35B-A3B",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -63791,6 +64730,37 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"qwen/qwen3.8-max": {
+			"id": "qwen/qwen3.8-max",
+			"name": "Qwen3.8 Max",
+			"api": "openai-completions",
+			"provider": "novita",
+			"baseUrl": "https://api.novita.ai/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"sao10k/l3-70b-euryale-v2.1": {
 			"id": "sao10k/l3-70b-euryale-v2.1",
@@ -67466,7 +68436,7 @@
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3 235B A22B",
+			"name": "Qwen3 235B-A22B",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -67532,7 +68502,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
-			"name": "Qwen3 Next 80B A3B Thinking",
+			"name": "Qwen3-Next 80B-A3B (Thinking)",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -67879,7 +68849,7 @@
 		},
 		"z-ai/glm-5.1": {
 			"id": "z-ai/glm-5.1",
-			"name": "GLM 5.1",
+			"name": "GLM-5.1",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -71815,6 +72785,36 @@
 					"xhigh"
 				]
 			}
+		},
+		"qwen3.8-max": {
+			"id": "qwen3.8-max",
+			"name": "Qwen3.8 Max",
+			"api": "anthropic-messages",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		}
 	},
 	"opencode-zen": {
@@ -72228,7 +73228,7 @@
 		},
 		"deepseek-v4-flash": {
 			"id": "deepseek-v4-flash",
-			"name": "DeepSeek V4 Flash",
+			"name": "DeepSeek V4 Flash 0731",
 			"api": "openai-completions",
 			"provider": "opencode-zen",
 			"baseUrl": "https://opencode.ai/zen/v1",
@@ -74108,7 +75108,7 @@
 		},
 		"~anthropic/claude-haiku-latest": {
 			"id": "~anthropic/claude-haiku-latest",
-			"name": "Claude Haiku Latest",
+			"name": "Anthropic Claude Haiku Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74170,7 +75170,7 @@
 		},
 		"~anthropic/claude-sonnet-latest": {
 			"id": "~anthropic/claude-sonnet-latest",
-			"name": "Claude Sonnet Latest",
+			"name": "Anthropic Claude Sonnet Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74228,7 +75228,7 @@
 		},
 		"~google/gemini-flash-latest": {
 			"id": "~google/gemini-flash-latest",
-			"name": "Gemini Flash Latest",
+			"name": "Google Gemini Flash Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74259,7 +75259,7 @@
 		},
 		"~google/gemini-pro-latest": {
 			"id": "~google/gemini-pro-latest",
-			"name": "Gemini Pro Latest",
+			"name": "Google Gemini Pro Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74290,7 +75290,7 @@
 		},
 		"~moonshotai/kimi-latest": {
 			"id": "~moonshotai/kimi-latest",
-			"name": "Kimi Latest",
+			"name": "MoonshotAI Kimi Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74321,7 +75321,7 @@
 		},
 		"~openai/gpt-latest": {
 			"id": "~openai/gpt-latest",
-			"name": "GPT Latest",
+			"name": "OpenAI GPT Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74352,7 +75352,7 @@
 		},
 		"~openai/gpt-mini-latest": {
 			"id": "~openai/gpt-mini-latest",
-			"name": "GPT Mini Latest",
+			"name": "OpenAI GPT Mini Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74399,7 +75399,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 500000,
-			"maxTokens": null,
+			"maxTokens": 500000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -75240,7 +76240,7 @@
 		},
 		"anthropic/claude-opus-4.7-fast": {
 			"id": "anthropic/claude-opus-4.7-fast",
-			"name": "Claude Opus 4.7 (Fast)",
+			"name": "Claude Opus 4.7",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -75336,7 +76336,7 @@
 		},
 		"anthropic/claude-opus-4.8-fast": {
 			"id": "anthropic/claude-opus-4.8-fast",
-			"name": "Claude Opus 4.8 (Fast)",
+			"name": "Claude Opus 4.8",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -75432,7 +76432,7 @@
 		},
 		"anthropic/claude-opus-5-fast": {
 			"id": "anthropic/claude-opus-5-fast",
-			"name": "Claude Opus 5 (Fast)",
+			"name": "Claude Opus 5",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -76083,7 +77083,7 @@
 		},
 		"cohere/command-r-08-2024": {
 			"id": "cohere/command-r-08-2024",
-			"name": "Command R (08-2024)",
+			"name": "Command R",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -76155,7 +77155,7 @@
 		},
 		"deepseek/deepseek-chat": {
 			"id": "deepseek/deepseek-chat",
-			"name": "DeepSeek V3",
+			"name": "DeepSeek-V3.2 (Non-thinking Mode)",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -76224,7 +77224,7 @@
 		},
 		"deepseek/deepseek-r1": {
 			"id": "deepseek/deepseek-r1",
-			"name": "R1",
+			"name": "DeepSeek-R1",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -76592,7 +77592,7 @@
 		},
 		"google/gemini-2.5-flash-lite": {
 			"id": "google/gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -76939,7 +77939,7 @@
 		},
 		"google/gemini-3-pro-image": {
 			"id": "google/gemini-3-pro-image",
-			"name": "Nano Banana Pro (Gemini 3 Pro Image)",
+			"name": "Nano Banana Pro",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -77433,7 +78433,7 @@
 		},
 		"google/gemma-4-26b-a4b-it": {
 			"id": "google/gemma-4-26b-a4b-it",
-			"name": "Gemma 4 26B A4B",
+			"name": "Gemma 4 26B A4B IT",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -77495,7 +78495,7 @@
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -77692,7 +78692,7 @@
 		},
 		"inclusionai/ling-2.6-flash": {
 			"id": "inclusionai/ling-2.6-flash",
-			"name": "Ling-2.6 Flash",
+			"name": "Ling-2.6-flash",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -78074,7 +79074,7 @@
 		},
 		"meta-llama/llama-3.3-70b-instruct": {
 			"id": "meta-llama/llama-3.3-70b-instruct",
-			"name": "Llama 3.3 70B Instruct",
+			"name": "Llama-3.3-70B-Instruct",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -78221,7 +79221,7 @@
 		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
-			"name": "MiniMax M2",
+			"name": "MiniMax-M2",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -78251,7 +79251,7 @@
 		},
 		"minimax/minimax-m2.1": {
 			"id": "minimax/minimax-m2.1",
-			"name": "MiniMax M2.1",
+			"name": "MiniMax-M2.1",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -78374,7 +79374,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -78649,7 +79649,7 @@
 		},
 		"mistralai/mistral-large-2512": {
 			"id": "mistralai/mistral-large-2512",
-			"name": "Mistral Large 3 2512",
+			"name": "Mistral Large 3",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -79793,7 +80793,7 @@
 		},
 		"openai/gpt-3.5-turbo": {
 			"id": "openai/gpt-3.5-turbo",
-			"name": "GPT-3.5 Turbo",
+			"name": "GPT-3.5-turbo",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -79984,7 +80984,7 @@
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
-			"name": "GPT-4.1 Mini",
+			"name": "GPT-4.1 mini",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -80006,7 +81006,7 @@
 		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
-			"name": "GPT-4.1 Nano",
+			"name": "GPT-4.1 nano",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -80597,7 +81597,7 @@
 		},
 		"openai/gpt-5.1-codex-max": {
 			"id": "openai/gpt-5.1-codex-max",
-			"name": "GPT-5.1-Codex-Max",
+			"name": "GPT-5.1 Codex Max",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -80628,7 +81628,7 @@
 		},
 		"openai/gpt-5.1-codex-mini": {
 			"id": "openai/gpt-5.1-codex-mini",
-			"name": "GPT-5.1-Codex-Mini",
+			"name": "GPT-5.1 Codex mini",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -80918,7 +81918,7 @@
 		},
 		"openai/gpt-5.4-mini": {
 			"id": "openai/gpt-5.4-mini",
-			"name": "GPT-5.4 Mini",
+			"name": "GPT-5.4 mini",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -80980,7 +81980,7 @@
 		},
 		"openai/gpt-5.4-nano": {
 			"id": "openai/gpt-5.4-nano",
-			"name": "GPT-5.4 Nano",
+			"name": "GPT-5.4 nano",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -81211,9 +82211,9 @@
 			],
 			"cost": {
 				"input": 0.09999999999999999,
-				"output": 0.6000000000000001,
+				"output": 0.6,
 				"cacheRead": 0.01,
-				"cacheWrite": 0.12500000000000003
+				"cacheWrite": 0.125
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -81232,7 +82232,7 @@
 		},
 		"openai/gpt-5.6-luna-pro": {
 			"id": "openai/gpt-5.6-luna-pro",
-			"name": "GPT-5.6 Luna Pro",
+			"name": "GPT-5.6 Luna",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -81243,9 +82243,9 @@
 			],
 			"cost": {
 				"input": 0.09999999999999999,
-				"output": 0.6000000000000001,
+				"output": 0.6,
 				"cacheRead": 0.01,
-				"cacheWrite": 0.12500000000000003
+				"cacheWrite": 0.125
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -81296,7 +82296,7 @@
 		},
 		"openai/gpt-5.6-sol-pro": {
 			"id": "openai/gpt-5.6-sol-pro",
-			"name": "GPT-5.6 Sol Pro",
+			"name": "GPT-5.6 Sol",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -81338,7 +82338,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.0000000000000002,
+				"input": 1,
 				"output": 6,
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 1.25
@@ -81360,7 +82360,7 @@
 		},
 		"openai/gpt-5.6-terra-pro": {
 			"id": "openai/gpt-5.6-terra-pro",
-			"name": "GPT-5.6 Terra Pro",
+			"name": "GPT-5.6 Terra",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -81370,7 +82370,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.0000000000000002,
+				"input": 1,
 				"output": 6,
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 1.25
@@ -81438,7 +82438,7 @@
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text",
 				"image"
@@ -81451,15 +82451,6 @@
 			},
 			"contextWindow": 400000,
 			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -81770,7 +82761,7 @@
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -81783,7 +82774,17 @@
 			"contextWindow": 200000,
 			"maxTokens": 100000,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
 		},
 		"openai/o3-pro": {
 			"id": "openai/o3-pro",
@@ -82028,7 +83029,7 @@
 		},
 		"openrouter/free": {
 			"id": "openrouter/free",
-			"name": "Free Models Router",
+			"name": "OpenRouter Free Models Router",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -82486,7 +83487,7 @@
 		},
 		"qwen/qwen-plus": {
 			"id": "qwen/qwen-plus",
-			"name": "Qwen-Plus",
+			"name": "Qwen Plus",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -82631,7 +83632,7 @@
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3 235B A22B",
+			"name": "Qwen3 235B-A22B",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -82670,13 +83671,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 0.55,
+				"input": 0.14950000000000002,
+				"output": 0.5980000000000001,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"maxTokens": 32768,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -82936,7 +83937,7 @@
 		},
 		"qwen/qwen3-coder-30b-a3b-instruct": {
 			"id": "qwen/qwen3-coder-30b-a3b-instruct",
-			"name": "Qwen3 Coder 30B A3B Instruct",
+			"name": "Qwen3-Coder 30B-A3B Instruct",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -83114,7 +84115,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-instruct": {
 			"id": "qwen/qwen3-next-80b-a3b-instruct",
-			"name": "Qwen3-Next-80B-A3B-Instruct",
+			"name": "Qwen3-Next 80B-A3B Instruct",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -83156,7 +84157,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
-			"name": "Qwen3 Next 80B A3B Thinking",
+			"name": "Qwen3-Next 80B-A3B (Thinking)",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -83219,8 +84220,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.39999999999999997,
-				"output": 4,
+				"input": 0.98,
+				"output": 3.95,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -83381,8 +84382,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 2.08,
+				"input": 0.39999999999999997,
+				"output": 3.1999999999999997,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -83402,7 +84403,7 @@
 		},
 		"qwen/qwen3.5-27b": {
 			"id": "qwen/qwen3.5-27b",
-			"name": "Qwen3.5-27B",
+			"name": "Qwen3.5 27B",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -83433,7 +84434,7 @@
 		},
 		"qwen/qwen3.5-35b-a3b": {
 			"id": "qwen/qwen3.5-35b-a3b",
-			"name": "Qwen3.5-35B-A3B",
+			"name": "Qwen3.5 35B-A3B",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -83464,7 +84465,7 @@
 		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
-			"name": "Qwen3.5 397B A17B",
+			"name": "Qwen3.5 397B-A17B",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -83495,7 +84496,7 @@
 		},
 		"qwen/qwen3.5-9b": {
 			"id": "qwen/qwen3.5-9b",
-			"name": "Qwen3.5-9B",
+			"name": "Qwen3.5 9B",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -83650,7 +84651,7 @@
 		},
 		"qwen/qwen3.6-35b-a3b": {
 			"id": "qwen/qwen3.6-35b-a3b",
-			"name": "Qwen3.6 35B A3B",
+			"name": "Qwen3.6 35B-A3B",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -84224,7 +85225,7 @@
 		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
-			"name": "Hy3 Preview",
+			"name": "Hy3 preview",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -84350,7 +85351,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1024000,
-			"maxTokens": 32768,
+			"maxTokens": 1024000,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -84974,7 +85975,7 @@
 		},
 		"xiaomi/mimo-v2-pro": {
 			"id": "xiaomi/mimo-v2-pro",
-			"name": "MiMo-V2-Pro",
+			"name": "MiMo V2 Pro",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -85033,7 +86034,7 @@
 		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
-			"name": "MiMo V2.5 Pro",
+			"name": "MiMo-V2.5-Pro",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -85083,7 +86084,7 @@
 		},
 		"z-ai/glm-4.5": {
 			"id": "z-ai/glm-4.5",
-			"name": "GLM 4.5",
+			"name": "GLM-4.5",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85113,7 +86114,7 @@
 		},
 		"z-ai/glm-4.5-air": {
 			"id": "z-ai/glm-4.5-air",
-			"name": "GLM 4.5 Air",
+			"name": "GLM-4.5-Air",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85173,7 +86174,7 @@
 		},
 		"z-ai/glm-4.5v": {
 			"id": "z-ai/glm-4.5v",
-			"name": "GLM 4.5V",
+			"name": "GLM-4.5V",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85204,7 +86205,7 @@
 		},
 		"z-ai/glm-4.6": {
 			"id": "z-ai/glm-4.6",
-			"name": "GLM 4.6",
+			"name": "GLM-4.6",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85295,7 +86296,7 @@
 		},
 		"z-ai/glm-4.7": {
 			"id": "z-ai/glm-4.7",
-			"name": "GLM 4.7",
+			"name": "GLM-4.7",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85325,7 +86326,7 @@
 		},
 		"z-ai/glm-4.7-flash": {
 			"id": "z-ai/glm-4.7-flash",
-			"name": "GLM 4.7 Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85355,7 +86356,7 @@
 		},
 		"z-ai/glm-5": {
 			"id": "z-ai/glm-5",
-			"name": "GLM 5",
+			"name": "GLM-5",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85406,7 +86407,7 @@
 		},
 		"z-ai/glm-5.1": {
 			"id": "z-ai/glm-5.1",
-			"name": "GLM 5.1",
+			"name": "GLM-5.1",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -85445,13 +86446,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.42,
-				"output": 1.32,
-				"cacheRead": 0.078,
+				"input": 1.19,
+				"output": 3.74,
+				"cacheRead": 0.221,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 128000,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -85650,9 +86651,69 @@
 		}
 	},
 	"synthetic": {
+		"hf:MiniMaxAI/MiniMax-M3": {
+			"id": "hf:MiniMaxAI/MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 1.2,
+				"cacheRead": 0.6,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"hf:moonshotai/Kimi-K2.7-Code": {
+			"id": "hf:moonshotai/Kimi-K2.7-Code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.95,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"hf:moonshotai/Kimi-K3": {
 			"id": "hf:moonshotai/Kimi-K3",
-			"name": "moonshotai/Kimi-K3",
+			"name": "Kimi K3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -85681,12 +86742,11 @@
 					"max": "max"
 				},
 				"requiresEffort": true
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-			"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -85697,7 +86757,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 1,
-				"cacheRead": 0.06,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -85711,12 +86771,11 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:openai/gpt-oss-120b": {
 			"id": "hf:openai/gpt-oss-120b",
-			"name": "openai/gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -85727,11 +86786,11 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0.02,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -85739,12 +86798,11 @@
 					"medium",
 					"high"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:Qwen/Qwen3.6-27B": {
 			"id": "hf:Qwen/Qwen3.6-27B",
-			"name": "Qwen/Qwen3.6-27B",
+			"name": "Qwen3.6 27B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -85755,8 +86813,8 @@
 			],
 			"cost": {
 				"input": 0.45,
-				"output": 2.2,
-				"cacheRead": 0.09,
+				"output": 3.6,
+				"cacheRead": 0.45,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -85769,12 +86827,11 @@
 					"medium",
 					"high"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:zai-org/GLM-4.7-Flash": {
 			"id": "hf:zai-org/GLM-4.7-Flash",
-			"name": "zai-org/GLM-4.7-Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -85785,7 +86842,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.5,
-				"cacheRead": 0.02,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
@@ -85799,12 +86856,11 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:zai-org/GLM-5.2": {
 			"id": "hf:zai-org/GLM-5.2",
-			"name": "zai-org/GLM-5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -85813,9 +86869,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 3,
-				"cacheRead": 0.16,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 1.4,
 				"cacheWrite": 0
 			},
 			"contextWindow": 524288,
@@ -85829,8 +86885,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"syn:large:text": {
 			"id": "syn:large:text",
@@ -90008,6 +91063,29 @@
 				]
 			}
 		},
+		"qwen-3-8-max": {
+			"id": "qwen-3-8-max",
+			"name": "qwen-3-8-max",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null,
+			"supportsComputerUse": false,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"qwen3-235b-a22b-instruct-2507": {
 			"id": "qwen3-235b-a22b-instruct-2507",
 			"name": "Qwen 3 235B A22B Instruct 2507",
@@ -91400,6 +92478,37 @@
 			},
 			"supportsComputerUse": false
 		},
+		"alibaba/qwen3.8-max": {
+			"id": "alibaba/qwen3.8-max",
+			"name": "Qwen 3.8 Max",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"amazon/nova-2-lite": {
 			"id": "amazon/nova-2-lite",
 			"name": "Nova 2 Lite",
@@ -91832,7 +92941,7 @@
 		},
 		"anthropic/claude-opus-4.7-fast": {
 			"id": "anthropic/claude-opus-4.7-fast",
-			"name": "Claude Opus 4.7 (Fast)",
+			"name": "Claude Opus 4.7",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -91897,7 +93006,7 @@
 		},
 		"anthropic/claude-opus-4.8-fast": {
 			"id": "anthropic/claude-opus-4.8-fast",
-			"name": "Claude Opus 4.8 (Fast)",
+			"name": "Claude Opus 4.8",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -91961,7 +93070,7 @@
 		},
 		"anthropic/claude-opus-5-fast": {
 			"id": "anthropic/claude-opus-5-fast",
-			"name": "Claude Opus 5 (Fast)",
+			"name": "Claude Opus 5",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -92280,7 +93389,7 @@
 		},
 		"deepseek/deepseek-r1": {
 			"id": "deepseek/deepseek-r1",
-			"name": "R1",
+			"name": "DeepSeek-R1",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -92461,9 +93570,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.0028,
+				"input": 0.19999999999999998,
+				"output": 0.39999999999999997,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -92616,7 +93725,7 @@
 		},
 		"google/gemini-2.5-flash-lite": {
 			"id": "google/gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -92975,7 +94084,7 @@
 		},
 		"google/gemma-4-26b-a4b-it": {
 			"id": "google/gemma-4-26b-a4b-it",
-			"name": "Gemma 4 26B A4B",
+			"name": "Gemma 4 26B A4B IT",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -93006,7 +94115,7 @@
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -93148,14 +94257,13 @@
 		},
 		"kwaipilot/kat-coder-air-v2.5": {
 			"id": "kwaipilot/kat-coder-air-v2.5",
-			"name": "Kat Coder Air V2.5",
+			"name": "KAT-Coder-Air V2.5",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0.15,
@@ -93165,16 +94273,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 80000,
-			"thinking": {
-				"mode": "budget",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
 			"supportsComputerUse": false
 		},
 		"kwaipilot/kat-coder-pro-v1": {
@@ -93219,14 +94317,13 @@
 		},
 		"kwaipilot/kat-coder-pro-v2.5": {
 			"id": "kwaipilot/kat-coder-pro-v2.5",
-			"name": "Kat Coder Pro V2.5",
+			"name": "KAT-Coder-Pro V2.5",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0.74,
@@ -93236,16 +94333,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 80000,
-			"thinking": {
-				"mode": "budget",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
 			"supportsComputerUse": false
 		},
 		"meituan/longcat-flash-chat": {
@@ -93512,7 +94599,7 @@
 		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
-			"name": "MiniMax M2",
+			"name": "MiniMax-M2",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -93546,7 +94633,7 @@
 		},
 		"minimax/minimax-m2.1": {
 			"id": "minimax/minimax-m2.1",
-			"name": "MiniMax M2.1",
+			"name": "MiniMax-M2.1",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -93751,7 +94838,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -94571,7 +95658,7 @@
 		},
 		"nvidia/nemotron-nano-9b-v2": {
 			"id": "nvidia/nemotron-nano-9b-v2",
-			"name": "Nemotron Nano 9B V2",
+			"name": "Nvidia Nemotron Nano 9B V2",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -94633,7 +95720,7 @@
 		},
 		"openai/gpt-3.5-turbo": {
 			"id": "openai/gpt-3.5-turbo",
-			"name": "GPT-3.5 Turbo",
+			"name": "GPT-3.5-turbo",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -94695,7 +95782,7 @@
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
-			"name": "GPT-4.1 Mini",
+			"name": "GPT-4.1 mini",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -94716,7 +95803,7 @@
 		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
-			"name": "GPT-4.1 Nano",
+			"name": "GPT-4.1 nano",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -94990,7 +96077,7 @@
 		},
 		"openai/gpt-5.1-codex-max": {
 			"id": "openai/gpt-5.1-codex-max",
-			"name": "GPT-5.1-Codex-Max",
+			"name": "GPT-5.1 Codex Max",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -95020,7 +96107,7 @@
 		},
 		"openai/gpt-5.1-codex-mini": {
 			"id": "openai/gpt-5.1-codex-mini",
-			"name": "GPT-5.1-Codex-Mini",
+			"name": "GPT-5.1 Codex mini",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -95302,7 +96389,7 @@
 		},
 		"openai/gpt-5.4-mini": {
 			"id": "openai/gpt-5.4-mini",
-			"name": "GPT-5.4 Mini",
+			"name": "GPT-5.4 mini",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -95332,7 +96419,7 @@
 		},
 		"openai/gpt-5.4-nano": {
 			"id": "openai/gpt-5.4-nano",
-			"name": "GPT-5.4 Nano",
+			"name": "GPT-5.4 nano",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -95701,7 +96788,7 @@
 		},
 		"openai/o3-deep-research": {
 			"id": "openai/o3-deep-research",
-			"name": "o3 Deep Research",
+			"name": "o3-deep-research",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -96760,7 +97847,7 @@
 		},
 		"xiaomi/mimo-v2-pro": {
 			"id": "xiaomi/mimo-v2-pro",
-			"name": "MiMo-V2-Pro",
+			"name": "MiMo V2 Pro",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -96822,7 +97909,7 @@
 		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
-			"name": "MiMo V2.5 Pro",
+			"name": "MiMo-V2.5-Pro",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -98546,7 +99633,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"supportsComputerUse": false,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -98577,7 +99663,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"supportsComputerUse": false,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -98607,6 +99692,16 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98619,17 +99714,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"supportsComputerUse": false,
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
 			}
 		},
 		"grok-4.3": {
@@ -98651,6 +99735,16 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98663,17 +99757,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"supportsComputerUse": false,
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
 			}
 		},
 		"grok-4.5": {
@@ -98695,6 +99778,16 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98707,17 +99800,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"supportsComputerUse": false,
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
 			}
 		},
 		"grok-build": {
@@ -98739,7 +99821,6 @@
 			},
 			"contextWindow": 512000,
 			"maxTokens": 512000,
-			"supportsComputerUse": false,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -98770,7 +99851,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
-			"supportsComputerUse": false,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -98800,7 +99880,6 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 200000,
-			"supportsComputerUse": false,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -101463,7 +102542,7 @@
 		},
 		"inclusionai/ling-2.6-flash": {
 			"id": "inclusionai/ling-2.6-flash",
-			"name": "Ling-2.6 Flash",
+			"name": "Ling-2.6-flash",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -101829,7 +102908,7 @@
 		},
 		"meituan/longcat-2.0": {
 			"id": "meituan/longcat-2.0",
-			"name": "LongCat-2.0",
+			"name": "LongCat 2.0",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -101844,7 +102923,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": null,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -102149,7 +103228,7 @@
 		},
 		"mistralai/mistral-large-2512": {
 			"id": "mistralai/mistral-large-2512",
-			"name": "Mistral Large 3 2512",
+			"name": "Mistral Large 3",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -102529,7 +103608,7 @@
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
-			"name": "GPT-4.1 Mini",
+			"name": "GPT-4.1 mini",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -102550,7 +103629,7 @@
 		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
-			"name": "GPT-4.1 Nano",
+			"name": "GPT-4.1 nano",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -103823,7 +104902,7 @@
 		},
 		"qwen/qwen3.7-flash": {
 			"id": "qwen/qwen3.7-flash",
-			"name": "Qwen3.7-Flash",
+			"name": "Qwen3.7 Flash",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -103907,6 +104986,35 @@
 					"high"
 				]
 			}
+		},
+		"qwen/qwen3.8-max": {
+			"id": "qwen/qwen3.8-max",
+			"name": "Qwen3.8-Max",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.17,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"sapiens-ai/agnes-1.5-flash": {
 			"id": "sapiens-ai/agnes-1.5-flash",

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -8344,14 +8344,15 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high"
-				]
+					"xhigh"
+				],
+				"defaultLevel": "xhigh"
 			},
 			"compat": {
-				"supportsDeveloperRole": false
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": true
 			}
 		},
 		"qwen3.8-max-preview": {
@@ -29152,7 +29153,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 8192,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-3.5-sonnet": {
 			"id": "anthropic/claude-3.5-sonnet",
@@ -29438,7 +29440,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-opus-4.7": {
 			"id": "anthropic/claude-opus-4.7",
@@ -29924,7 +29927,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"arcee-ai/virtuoso-large": {
 			"id": "arcee-ai/virtuoso-large",
@@ -29973,7 +29977,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"baidu/ernie-4.5-21b-a3b": {
 			"id": "baidu/ernie-4.5-21b-a3b",
@@ -29993,7 +29998,8 @@
 			},
 			"contextWindow": 120000,
 			"maxTokens": 8000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"baidu/ernie-4.5-300b-a47b": {
 			"id": "baidu/ernie-4.5-300b-a47b",
@@ -30045,7 +30051,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"baidu/ernie-4.5-vl-424b-a47b": {
 			"id": "baidu/ernie-4.5-vl-424b-a47b",
@@ -30905,7 +30912,8 @@
 			},
 			"contextWindow": 32768,
 			"maxTokens": 6554,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"giga-potato": {
 			"id": "giga-potato",
@@ -30965,7 +30973,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 8192,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-2.0-flash-lite-001": {
 			"id": "google/gemini-2.0-flash-lite-001",
@@ -30986,7 +30995,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 8192,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-2.5-flash": {
 			"id": "google/gemini-2.5-flash",
@@ -31094,7 +31104,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-2.5-pro": {
 			"id": "google/gemini-2.5-pro",
@@ -32606,7 +32617,8 @@
 			},
 			"contextWindow": 8192,
 			"maxTokens": 16384,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"meta-llama/llama-3.1-405b": {
 			"id": "meta-llama/llama-3.1-405b",
@@ -33272,7 +33284,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"mistralai/devstral-medium": {
 			"id": "mistralai/devstral-medium",
@@ -33292,7 +33305,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 26215,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"mistralai/devstral-small": {
 			"id": "mistralai/devstral-small",
@@ -33312,7 +33326,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 26215,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"mistralai/ministral-14b-2512": {
 			"id": "mistralai/ministral-14b-2512",
@@ -33493,7 +33508,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 26215,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"mistralai/mistral-large-2512": {
 			"id": "mistralai/mistral-large-2512",
@@ -33793,7 +33809,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"mistralai/voxtral-small-24b-2507": {
 			"id": "mistralai/voxtral-small-24b-2507",
@@ -34189,7 +34206,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 163840,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"nex-agi/nex-n2-mini": {
 			"id": "nex-agi/nex-n2-mini",
@@ -34453,7 +34471,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"nvidia/nemotron-3-nano-30b-a3b": {
 			"id": "nvidia/nemotron-3-nano-30b-a3b",
@@ -34711,7 +34730,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-3.5-turbo": {
 			"id": "openai/gpt-3.5-turbo",
@@ -34827,7 +34847,8 @@
 			},
 			"contextWindow": 8191,
 			"maxTokens": 4096,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4-1106-preview": {
 			"id": "openai/gpt-4-1106-preview",
@@ -34847,7 +34868,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4-turbo": {
 			"id": "openai/gpt-4-turbo",
@@ -35046,7 +35068,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4o-mini": {
 			"id": "openai/gpt-4o-mini",
@@ -35229,7 +35252,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5-image": {
 			"id": "openai/gpt-5-image",
@@ -35426,7 +35450,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.1-codex": {
 			"id": "openai/gpt-5.1-codex",
@@ -36317,7 +36342,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/o3-mini": {
 			"id": "openai/o3-mini",
@@ -36471,7 +36497,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/o4-mini-high": {
 			"id": "openai/o4-mini-high",
@@ -36736,7 +36763,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openrouter/pareto-code": {
 			"id": "openrouter/pareto-code",
@@ -36935,7 +36963,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"poolside/laguna-s-2.1": {
 			"id": "poolside/laguna-s-2.1",
@@ -37112,7 +37141,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"prime-intellect/intellect-3": {
 			"id": "prime-intellect/intellect-3",
@@ -37142,7 +37172,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"qwen/qwen-2.5-72b-instruct": {
 			"id": "qwen/qwen-2.5-72b-instruct",
@@ -38759,7 +38790,8 @@
 			},
 			"contextWindow": 8192,
 			"maxTokens": 8192,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"sao10k/l3-lunaris-8b": {
 			"id": "sao10k/l3-lunaris-8b",
@@ -39950,7 +39982,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"xiaomi/mimo-v2-omni": {
 			"id": "xiaomi/mimo-v2-omni",
@@ -39979,7 +40012,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"xiaomi/mimo-v2-omni:free": {
 			"id": "xiaomi/mimo-v2-omni:free",
@@ -40028,7 +40062,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"xiaomi/mimo-v2-pro:free": {
 			"id": "xiaomi/mimo-v2-pro:free",
@@ -40124,7 +40159,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"z-ai/glm-4.5": {
 			"id": "z-ai/glm-4.5",
@@ -64760,7 +64796,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"sao10k/l3-70b-euryale-v2.1": {
 			"id": "sao10k/l3-70b-euryale-v2.1",
@@ -86446,13 +86483,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.19,
-				"output": 3.74,
-				"cacheRead": 0.221,
+				"input": 0.7153999999999999,
+				"output": 2.2483999999999997,
+				"cacheRead": 0.13286,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 262144,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91079,9 +91116,10 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
+			"contextWindow": 1000000,
 			"maxTokens": null,
 			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
 			"compat": {
 				"supportsUsageInStreaming": false
 			}

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2815,6 +2815,15 @@ export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-comple
 		contextWindow: 1_000_000,
 		maxTokens: 131_072,
 		input: ["text", "image"],
+		thinking: {
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.XHigh],
+			defaultLevel: Effort.XHigh,
+		},
+		compat: {
+			...ALIBABA_TOKEN_PLAN_COMPAT,
+			supportsReasoningEffort: true,
+		},
 	}),
 	createAlibabaTokenPlanModel({
 		id: "deepseek-v4-pro",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2733,18 +2733,72 @@ const ALIBABA_TOKEN_PLAN_REASONING: ThinkingConfig = {
 	efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
 };
 
-export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
-	{
-		id: "qwen3.8-max-preview",
-		name: "Qwen3.8 Max Preview",
+interface AlibabaTokenPlanModelSpec {
+	id: string;
+	name: string;
+	contextWindow: number;
+	maxTokens: number;
+	input?: ("text" | "image")[];
+	thinking?: ThinkingConfig;
+	compat?: OpenAICompat;
+}
+
+function createAlibabaTokenPlanModel(spec: AlibabaTokenPlanModelSpec): ModelSpec<"openai-completions"> {
+	return {
+		id: spec.id,
+		name: spec.name,
 		api: "openai-completions",
 		provider: "alibaba-token-plan",
 		baseUrl: ALIBABA_TOKEN_PLAN_BASE_URL,
 		reasoning: true,
-		input: ["text", "image"],
+		input: spec.input ?? ["text"],
 		cost: ALIBABA_TOKEN_PLAN_COST,
-		contextWindow: 983_616,
+		contextWindow: spec.contextWindow,
+		maxTokens: spec.maxTokens,
+		thinking: spec.thinking ?? ALIBABA_TOKEN_PLAN_REASONING,
+		compat: spec.compat ?? ALIBABA_TOKEN_PLAN_COMPAT,
+	};
+}
+
+const ALIBABA_TOKEN_PLAN_DEEPSEEK_REASONING: ThinkingConfig = {
+	mode: "effort",
+	efforts: [Effort.High, Effort.Max],
+};
+
+export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
+	createAlibabaTokenPlanModel({
+		id: "qwen3.6-plus",
+		name: "Qwen3.6 Plus",
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+		input: ["text", "image"],
+	}),
+	createAlibabaTokenPlanModel({
+		id: "qwen3.6-flash",
+		name: "Qwen3.6 Flash",
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+		input: ["text", "image"],
+	}),
+	createAlibabaTokenPlanModel({
+		id: "qwen3.7-max",
+		name: "Qwen3.7 Max",
+		contextWindow: 1_000_000,
 		maxTokens: 131_072,
+	}),
+	createAlibabaTokenPlanModel({
+		id: "qwen3.7-plus",
+		name: "Qwen3.7 Plus",
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+		input: ["text", "image"],
+	}),
+	createAlibabaTokenPlanModel({
+		id: "qwen3.8-max-preview",
+		name: "Qwen3.8 Max Preview",
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+		input: ["text", "image"],
 		thinking: {
 			mode: "effort",
 			efforts: [Effort.Low, Effort.High, Effort.XHigh],
@@ -2754,83 +2808,90 @@ export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-comple
 			...ALIBABA_TOKEN_PLAN_COMPAT,
 			supportsReasoningEffort: true,
 		},
-	},
-	{
-		id: "qwen3.7-max",
-		name: "Qwen3.7 Max",
-		api: "openai-completions",
-		provider: "alibaba-token-plan",
-		baseUrl: ALIBABA_TOKEN_PLAN_BASE_URL,
-		reasoning: true,
-		input: ["text"],
-		cost: ALIBABA_TOKEN_PLAN_COST,
+	}),
+	createAlibabaTokenPlanModel({
+		id: "qwen3.8-max",
+		name: "Qwen3.8 Max",
 		contextWindow: 1_000_000,
-		maxTokens: 65_536,
-		thinking: ALIBABA_TOKEN_PLAN_REASONING,
-		compat: ALIBABA_TOKEN_PLAN_COMPAT,
-	},
-	{
-		id: "qwen3.7-plus",
-		name: "Qwen3.7 Plus",
-		api: "openai-completions",
-		provider: "alibaba-token-plan",
-		baseUrl: ALIBABA_TOKEN_PLAN_BASE_URL,
-		reasoning: true,
+		maxTokens: 131_072,
 		input: ["text", "image"],
-		cost: ALIBABA_TOKEN_PLAN_COST,
+	}),
+	createAlibabaTokenPlanModel({
+		id: "deepseek-v4-pro",
+		name: "DeepSeek V4 Pro",
 		contextWindow: 1_000_000,
-		maxTokens: 64_000,
-		thinking: ALIBABA_TOKEN_PLAN_REASONING,
-		compat: ALIBABA_TOKEN_PLAN_COMPAT,
-	},
-	{
-		id: "qwen3.6-flash",
-		name: "Qwen3.6 Flash",
-		api: "openai-completions",
-		provider: "alibaba-token-plan",
-		baseUrl: ALIBABA_TOKEN_PLAN_BASE_URL,
-		reasoning: true,
-		input: ["text", "image"],
-		cost: ALIBABA_TOKEN_PLAN_COST,
+		maxTokens: 384_000,
+		thinking: ALIBABA_TOKEN_PLAN_DEEPSEEK_REASONING,
+	}),
+	createAlibabaTokenPlanModel({
+		id: "deepseek-v4-flash",
+		name: "DeepSeek V4 Flash",
 		contextWindow: 1_000_000,
+		maxTokens: 384_000,
+		thinking: ALIBABA_TOKEN_PLAN_DEEPSEEK_REASONING,
+	}),
+	createAlibabaTokenPlanModel({
+		id: "deepseek-v4-flash-0731",
+		name: "DeepSeek V4 Flash 0731",
+		contextWindow: 1_000_000,
+		maxTokens: 384_000,
+		thinking: ALIBABA_TOKEN_PLAN_DEEPSEEK_REASONING,
+	}),
+	createAlibabaTokenPlanModel({
+		id: "deepseek-v3.2",
+		name: "DeepSeek V3.2",
+		contextWindow: 131_072,
 		maxTokens: 65_536,
-		thinking: ALIBABA_TOKEN_PLAN_REASONING,
-		compat: ALIBABA_TOKEN_PLAN_COMPAT,
-	},
-	{
+	}),
+	createAlibabaTokenPlanModel({
 		id: "glm-5.2",
 		name: "GLM-5.2",
-		api: "openai-completions",
-		provider: "alibaba-token-plan",
-		baseUrl: ALIBABA_TOKEN_PLAN_BASE_URL,
-		reasoning: true,
-		input: ["text"],
-		cost: ALIBABA_TOKEN_PLAN_COST,
 		contextWindow: 1_000_000,
 		maxTokens: 131_072,
 		thinking: {
 			mode: "effort",
 			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.Max],
 		},
-		compat: ALIBABA_TOKEN_PLAN_COMPAT,
-	},
-	{
-		id: "deepseek-v4-pro",
-		name: "DeepSeek V4 Pro",
-		api: "openai-completions",
-		provider: "alibaba-token-plan",
-		baseUrl: ALIBABA_TOKEN_PLAN_BASE_URL,
-		reasoning: true,
-		input: ["text"],
-		cost: ALIBABA_TOKEN_PLAN_COST,
-		contextWindow: 1_000_000,
-		maxTokens: 384_000,
-		thinking: {
-			mode: "effort",
-			efforts: [Effort.High, Effort.Max],
-		},
-		compat: ALIBABA_TOKEN_PLAN_COMPAT,
-	},
+	}),
+	createAlibabaTokenPlanModel({
+		id: "glm-5.1",
+		name: "GLM-5.1",
+		contextWindow: 202_752,
+		maxTokens: 128_000,
+	}),
+	createAlibabaTokenPlanModel({
+		id: "glm-5",
+		name: "GLM-5",
+		contextWindow: 202_752,
+		maxTokens: 16_384,
+	}),
+	createAlibabaTokenPlanModel({
+		id: "kimi-k2.7-code",
+		name: "Kimi K2.7 Code",
+		contextWindow: 262_144,
+		maxTokens: 262_144,
+		input: ["text", "image"],
+	}),
+	createAlibabaTokenPlanModel({
+		id: "kimi-k2.6",
+		name: "Kimi K2.6",
+		contextWindow: 262_144,
+		maxTokens: 262_144,
+		input: ["text", "image"],
+	}),
+	createAlibabaTokenPlanModel({
+		id: "kimi-k2.5",
+		name: "Kimi K2.5",
+		contextWindow: 262_144,
+		maxTokens: 98_304,
+		input: ["text", "image"],
+	}),
+	createAlibabaTokenPlanModel({
+		id: "MiniMax-M2.5",
+		name: "MiniMax-M2.5",
+		contextWindow: 196_608,
+		maxTokens: 32_768,
+	}),
 ];
 
 const ALIBABA_TOKEN_PLAN_NON_CHAT_MODEL_PREFIXES = [

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2765,6 +2765,18 @@ const ALIBABA_TOKEN_PLAN_DEEPSEEK_REASONING: ThinkingConfig = {
 	efforts: [Effort.High, Effort.Max],
 };
 
+// Qwen3.8-Max drives reasoning through the OpenAI-standard `reasoning_effort`
+// control on Model Studio compatible-mode (`xhigh` default / `medium` / `low`),
+// not the legacy binary `enable_thinking` toggle the older Qwen3.x builds use
+// (https://qwen.ai/blog?id=qwen3.8). The default `qwen` thinkingFormat maps to
+// the `qwen-enable-thinking-false` disable mode, which drops the selected effort
+// from the wire, so pin the OpenAI dialect to route the advertised ladder.
+const ALIBABA_TOKEN_PLAN_QWEN_EFFORT_COMPAT: OpenAICompat = {
+	...ALIBABA_TOKEN_PLAN_COMPAT,
+	supportsReasoningEffort: true,
+	thinkingFormat: "openai",
+};
+
 export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
 	createAlibabaTokenPlanModel({
 		id: "qwen3.6-plus",
@@ -2804,10 +2816,7 @@ export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-comple
 			efforts: [Effort.Low, Effort.High, Effort.XHigh],
 			requiresEffort: true,
 		},
-		compat: {
-			...ALIBABA_TOKEN_PLAN_COMPAT,
-			supportsReasoningEffort: true,
-		},
+		compat: ALIBABA_TOKEN_PLAN_QWEN_EFFORT_COMPAT,
 	}),
 	createAlibabaTokenPlanModel({
 		id: "qwen3.8-max",
@@ -2820,10 +2829,7 @@ export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-comple
 			efforts: [Effort.Low, Effort.Medium, Effort.XHigh],
 			defaultLevel: Effort.XHigh,
 		},
-		compat: {
-			...ALIBABA_TOKEN_PLAN_COMPAT,
-			supportsReasoningEffort: true,
-		},
+		compat: ALIBABA_TOKEN_PLAN_QWEN_EFFORT_COMPAT,
 	}),
 	createAlibabaTokenPlanModel({
 		id: "deepseek-v4-pro",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2894,6 +2894,8 @@ export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-comple
 	}),
 ];
 
+const ALIBABA_TOKEN_PLAN_STATIC_MODEL_IDS = ALIBABA_TOKEN_PLAN_STATIC_MODELS.map(model => model.id);
+
 const ALIBABA_TOKEN_PLAN_NON_CHAT_MODEL_PREFIXES = [
 	"fun-asr",
 	"happyhorse-",
@@ -2925,10 +2927,15 @@ export function alibabaTokenPlanModelManagerOptions(
 	// its key only authenticates against its own region, so fetching /models from
 	// any other base URL would 401 (#6682).
 	const baseUrl = credential?.baseUrl ?? config?.baseUrl ?? ALIBABA_TOKEN_PLAN_BASE_URL;
+	const staticModels =
+		baseUrl === ALIBABA_TOKEN_PLAN_BASE_URL
+			? ALIBABA_TOKEN_PLAN_STATIC_MODELS
+			: ALIBABA_TOKEN_PLAN_STATIC_MODELS.map(model => ({ ...model, baseUrl }));
 	return {
 		providerId: "alibaba-token-plan",
 		dynamicModelsAuthoritative: true,
-		staticModels: ALIBABA_TOKEN_PLAN_STATIC_MODELS,
+		staticModels,
+		dropCachedModelIdsOnStaticMismatch: ALIBABA_TOKEN_PLAN_STATIC_MODEL_IDS,
 		...(apiKey && {
 			fetchDynamicModels: () =>
 				fetchOpenAICompatibleModels({
@@ -2938,7 +2945,7 @@ export function alibabaTokenPlanModelManagerOptions(
 					apiKey,
 					filterModel: (_entry, model) => isAlibabaTokenPlanChatModelId(model.id),
 					mapModel: (_entry, defaults) => {
-						const reference = ALIBABA_TOKEN_PLAN_STATIC_MODELS.find(model => model.id === defaults.id);
+						const reference = staticModels.find(model => model.id === defaults.id);
 						return reference
 							? {
 									...reference,

--- a/packages/catalog/test/alibaba-token-plan.test.ts
+++ b/packages/catalog/test/alibaba-token-plan.test.ts
@@ -10,22 +10,37 @@ import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
 import { serializeAlibabaTokenPlanCredential } from "@oh-my-pi/pi-catalog/wire/alibaba-token-plan";
 
 describe("QwenCloud Token Plan provider", () => {
-	test("ships the documented Individual text-model allowlist", () => {
-		expect(ALIBABA_TOKEN_PLAN_STATIC_MODELS.map(model => model.id)).toEqual([
-			"qwen3.8-max-preview",
-			"qwen3.7-max",
-			"qwen3.7-plus",
-			"qwen3.6-flash",
-			"glm-5.2",
-			"deepseek-v4-pro",
+	test("ships curated metadata for every advertised chat model", () => {
+		expect(
+			ALIBABA_TOKEN_PLAN_STATIC_MODELS.map(({ id, contextWindow, maxTokens }) => ({
+				id,
+				contextWindow,
+				maxTokens,
+			})),
+		).toEqual([
+			{ id: "qwen3.6-plus", contextWindow: 1_000_000, maxTokens: 65_536 },
+			{ id: "qwen3.6-flash", contextWindow: 1_000_000, maxTokens: 65_536 },
+			{ id: "qwen3.7-max", contextWindow: 1_000_000, maxTokens: 131_072 },
+			{ id: "qwen3.7-plus", contextWindow: 1_000_000, maxTokens: 65_536 },
+			{ id: "qwen3.8-max-preview", contextWindow: 1_000_000, maxTokens: 131_072 },
+			{ id: "qwen3.8-max", contextWindow: 1_000_000, maxTokens: 131_072 },
+			{ id: "deepseek-v4-pro", contextWindow: 1_000_000, maxTokens: 384_000 },
+			{ id: "deepseek-v4-flash", contextWindow: 1_000_000, maxTokens: 384_000 },
+			{ id: "deepseek-v4-flash-0731", contextWindow: 1_000_000, maxTokens: 384_000 },
+			{ id: "deepseek-v3.2", contextWindow: 131_072, maxTokens: 65_536 },
+			{ id: "glm-5.2", contextWindow: 1_000_000, maxTokens: 131_072 },
+			{ id: "glm-5.1", contextWindow: 202_752, maxTokens: 128_000 },
+			{ id: "glm-5", contextWindow: 202_752, maxTokens: 16_384 },
+			{ id: "kimi-k2.7-code", contextWindow: 262_144, maxTokens: 262_144 },
+			{ id: "kimi-k2.6", contextWindow: 262_144, maxTokens: 262_144 },
+			{ id: "kimi-k2.5", contextWindow: 262_144, maxTokens: 98_304 },
+			{ id: "MiniMax-M2.5", contextWindow: 196_608, maxTokens: 32_768 },
 		]);
 
-		const preview = ALIBABA_TOKEN_PLAN_STATIC_MODELS[0];
+		const preview = ALIBABA_TOKEN_PLAN_STATIC_MODELS.find(model => model.id === "qwen3.8-max-preview");
 		expect(preview).toMatchObject({
 			provider: "alibaba-token-plan",
 			baseUrl: ALIBABA_TOKEN_PLAN_BASE_URL,
-			contextWindow: 983_616,
-			maxTokens: 131_072,
 			input: ["text", "image"],
 			thinking: {
 				efforts: [Effort.Low, Effort.High, Effort.XHigh],
@@ -63,6 +78,7 @@ describe("QwenCloud Token Plan provider", () => {
 							max_completion_tokens: 16_384,
 						},
 						{ id: "deepseek-v4-flash", owned_by: "qwencloud" },
+						{ id: "deepseek-v4-flash-0731", owned_by: "qwencloud" },
 						{ id: "kimi-k2.7-code", owned_by: "qwencloud" },
 						{ id: "MiniMax-M2.5", owned_by: "qwencloud" },
 						{ id: "fun-asr", owned_by: "qwencloud" },
@@ -84,16 +100,21 @@ describe("QwenCloud Token Plan provider", () => {
 		expect(authorization).toBe("Bearer sk-sp-test");
 		expect(models?.map(model => model.id)).toEqual([
 			"deepseek-v4-flash",
+			"deepseek-v4-flash-0731",
 			"kimi-k2.7-code",
 			"MiniMax-M2.5",
 			"qwen3.7-plus",
 		]);
-		expect(models?.find(model => model.id === "qwen3.7-plus")).toMatchObject({
-			id: "qwen3.7-plus",
-			provider: "alibaba-token-plan",
-			name: "Qwen3.7 Plus",
-			contextWindow: 1_000_000,
-			maxTokens: 64_000,
+		expect(
+			Object.fromEntries(
+				models?.map(model => [model.id, { contextWindow: model.contextWindow, maxTokens: model.maxTokens }]) ?? [],
+			),
+		).toEqual({
+			"deepseek-v4-flash": { contextWindow: 1_000_000, maxTokens: 384_000 },
+			"deepseek-v4-flash-0731": { contextWindow: 1_000_000, maxTokens: 384_000 },
+			"kimi-k2.7-code": { contextWindow: 262_144, maxTokens: 262_144 },
+			"MiniMax-M2.5": { contextWindow: 196_608, maxTokens: 32_768 },
+			"qwen3.7-plus": { contextWindow: 1_000_000, maxTokens: 65_536 },
 		});
 		expect(options.dynamicModelsAuthoritative).toBe(true);
 	});

--- a/packages/catalog/test/alibaba-token-plan.test.ts
+++ b/packages/catalog/test/alibaba-token-plan.test.ts
@@ -56,6 +56,16 @@ describe("QwenCloud Token Plan provider", () => {
 			},
 		});
 
+		expect(ALIBABA_TOKEN_PLAN_STATIC_MODELS.find(model => model.id === "qwen3.8-max")).toMatchObject({
+			thinking: {
+				efforts: [Effort.Low, Effort.Medium, Effort.XHigh],
+				defaultLevel: Effort.XHigh,
+			},
+			compat: {
+				supportsReasoningEffort: true,
+			},
+		});
+
 		expect(ALIBABA_TOKEN_PLAN_STATIC_MODELS.find(model => model.id === "glm-5.2")?.thinking?.efforts).toEqual([
 			Effort.Minimal,
 			Effort.Low,

--- a/packages/catalog/test/alibaba-token-plan.test.ts
+++ b/packages/catalog/test/alibaba-token-plan.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { CATALOG_PROVIDERS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
 import {
 	ALIBABA_TOKEN_PLAN_BASE_URL,
 	ALIBABA_TOKEN_PLAN_STATIC_MODELS,
 	alibabaTokenPlanModelManagerOptions,
 } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
-import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
+import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import { serializeAlibabaTokenPlanCredential } from "@oh-my-pi/pi-catalog/wire/alibaba-token-plan";
 
 describe("QwenCloud Token Plan provider", () => {
@@ -139,6 +143,66 @@ describe("QwenCloud Token Plan provider", () => {
 			id: "qwen3.7-plus",
 			baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
 		});
+	});
+
+	test("drops pre-metadata cache rows while preserving the credential region offline", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-alibaba-token-plan-cache-"));
+		const cacheDbPath = path.join(tempDir, "models.db");
+		const cacheProviderId = "alibaba-token-plan-metadata-migration-test";
+		const beijingBaseUrl = "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1";
+		const staleKimi: ModelSpec<"openai-completions"> = {
+			id: "kimi-k2.7-code",
+			name: "kimi-k2.7-code",
+			api: "openai-completions",
+			provider: "alibaba-token-plan",
+			baseUrl: beijingBaseUrl,
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: null,
+			maxTokens: null,
+		};
+		const oldStaticModelIds: Record<string, true> = {
+			"qwen3.8-max-preview": true,
+			"qwen3.7-max": true,
+			"qwen3.7-plus": true,
+			"qwen3.6-flash": true,
+			"glm-5.2": true,
+			"deepseek-v4-pro": true,
+		};
+
+		try {
+			await resolveProviderModels(
+				{
+					providerId: "alibaba-token-plan",
+					cacheProviderId,
+					cacheDbPath,
+					staticModels: ALIBABA_TOKEN_PLAN_STATIC_MODELS.filter(model => oldStaticModelIds[model.id]),
+					dynamicModelsAuthoritative: true,
+					fetchDynamicModels: async () => [staleKimi],
+				},
+				"online",
+			);
+
+			const apiKey = serializeAlibabaTokenPlanCredential("sk-sp-beijing", "", beijingBaseUrl);
+			const offline = await resolveProviderModels(
+				{
+					...alibabaTokenPlanModelManagerOptions({ apiKey }),
+					cacheProviderId,
+					cacheDbPath,
+				},
+				"offline",
+			);
+
+			expect(offline.models.find(model => model.id === staleKimi.id)).toMatchObject({
+				baseUrl: beijingBaseUrl,
+				input: ["text", "image"],
+				contextWindow: 262_144,
+				maxTokens: 262_144,
+			});
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	test("rejects malformed compound credentials before model discovery", () => {

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -145,7 +145,7 @@ describe("generated model policies", () => {
 		});
 	});
 
-	it("preserves QwenCloud's mandatory qwen3.8 effort ladder", () => {
+	it("preserves QwenCloud's provider-authored qwen3.8 effort ladders", () => {
 		const models: ModelSpec<Api>[] = [
 			createSpec({
 				id: "qwen3.8-max-preview",
@@ -157,15 +157,32 @@ describe("generated model policies", () => {
 					requiresEffort: true,
 				},
 			}),
+			createSpec({
+				id: "qwen3.8-max",
+				api: "openai-completions",
+				provider: "alibaba-token-plan",
+				thinking: {
+					mode: "effort",
+					efforts: [Effort.Low, Effort.Medium, Effort.XHigh],
+					defaultLevel: Effort.XHigh,
+				},
+			}),
 		];
 
 		applyGeneratedModelPolicies(models);
 
-		expect(models[0]?.thinking).toEqual({
-			mode: "effort",
-			efforts: [Effort.Low, Effort.High, Effort.XHigh],
-			requiresEffort: true,
-		});
+		expect(models.map(model => model.thinking)).toEqual([
+			{
+				mode: "effort",
+				efforts: [Effort.Low, Effort.High, Effort.XHigh],
+				requiresEffort: true,
+			},
+			{
+				mode: "effort",
+				efforts: [Effort.Low, Effort.Medium, Effort.XHigh],
+				defaultLevel: Effort.XHigh,
+			},
+		]);
 	});
 
 	it("pins zai glm-5.2 base id to 1M context", () => {


### PR DESCRIPTION
## Repro
A Token Plan `/models` response containing only `{ id: "glm-5.1" }` reproduced the picker metadata gap with `bun -e 'import { alibabaTokenPlanModelManagerOptions as options } from "./packages/catalog/src/provider-models/openai-compat.ts"; const models = await options({ apiKey: "sk-test", fetch: () => Promise.resolve(Response.json({ data: [{ id: "glm-5.1" }] })) }).fetchDynamicModels?.(); console.log(models?.[0]?.id, models?.[0]?.contextWindow, models?.[0]?.maxTokens);'`, which printed `glm-5.1 null null` before the fix.

## Cause
`alibabaTokenPlanModelManagerOptions` in `packages/catalog/src/provider-models/openai-compat.ts` only replaces discovery defaults from `ALIBABA_TOKEN_PLAN_STATIC_MODELS`; the static catalog contained six IDs, so newly admitted chat IDs without limits in Alibaba's response retained `contextWindow: null` and `maxTokens: null`.

## Fix
- Curate context windows and output limits for all 17 advertised Token Plan chat model IDs, preserving provider-specific capability overrides.
- Cover the complete metadata table and discovery enrichment for previously unknown IDs in `packages/catalog/test/alibaba-token-plan.test.ts`.
- Regenerate the bundled catalog and document the fix under `[Unreleased]`.

## Verification
`bun test packages/catalog/test/alibaba-token-plan.test.ts` passed 5 tests with 0 failures; the manual reproduction now prints `glm-5.1 202752 128000`; `bun check` passed across the repository.

Fixes #7486