### PR TITLE
fix(task): bound abort cleanup and quarantine late jobs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Task cancellation hanging forever when a child ignored abort or stalled during cleanup ([#7483](https://github.com/can1357/oh-my-pi/issues/7483)).
+
 ## [17.2.5] - 2026-08-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -94,6 +94,12 @@ export interface AsyncJobDeliveryState {
 	pendingJobIds: string[];
 }
 
+export interface AsyncJobReapResult {
+	settled: boolean;
+	pendingJobIds: string[];
+	completion: Promise<void>;
+}
+
 export interface AsyncJobRegisterOptions {
 	id?: string;
 	/** Registry id of the agent that owns this job; used to scope cancelAll. */
@@ -488,6 +494,26 @@ export class AsyncJobManager {
 			);
 			if (!settled) return false;
 		}
+	}
+
+	/**
+	 * Cancel every job owned by `ownerId`, then wait only until `deadlineAt`.
+	 * The returned completion keeps waiting for actual process settlement when
+	 * the deadline expires, so callers can move that cleanup out of the
+	 * user-visible Task wait without losing ownership of the live work.
+	 */
+	async cancelAndReapOwnerJobs(ownerId: string, deadlineAt: number): Promise<AsyncJobReapResult> {
+		this.cancelAll({ ownerId });
+		const timeoutMs = Math.max(0, deadlineAt - Date.now());
+		const settled = await this.waitForOwnerJobs(ownerId, { timeoutMs });
+		if (settled) {
+			return { settled: true, pendingJobIds: [], completion: Promise.resolve() };
+		}
+		const pendingJobIds = this.getAllJobs({ ownerId })
+			.filter(job => job.status === "running" || job.status === "cancelled")
+			.map(job => job.id);
+		const completion = this.waitForOwnerJobs(ownerId).then(() => {});
+		return { settled: false, pendingJobIds, completion };
 	}
 
 	async #waitForAllUntil(deadline: number): Promise<boolean> {

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -20,8 +20,9 @@
  * a superseded revive) can never clobber a newer same-id ref.
  */
 
-import { logger } from "@oh-my-pi/pi-utils";
+import { logger, untilAborted } from "@oh-my-pi/pi-utils";
 import type { AgentSession } from "../session/agent-session";
+import { trackLateCleanup } from "../utils/late-cleanup";
 import {
 	type AgentRef,
 	type AgentRefExpectation,
@@ -31,6 +32,8 @@ import {
 } from "./agent-registry";
 
 export type AgentReviver = (expected: AgentRef) => Promise<AgentSession>;
+
+const AGENT_RELEASE_GRACE_MS = 5000;
 
 /**
  * Builds a reviver for a `parked` ref restored from disk (Agent Hub scan,
@@ -402,11 +405,26 @@ export class AgentLifecycleManager {
 	}
 
 	/** Teardown everything (process exit / main session dispose). */
-	async dispose(): Promise<void> {
+	async dispose(deadlineAt: number = Date.now() + AGENT_RELEASE_GRACE_MS): Promise<void> {
 		this.#unsubscribe?.();
 		this.#unsubscribe = undefined;
 		const ids = [...new Set([...this.#adopted.keys(), ...this.#parks.keys()])];
-		await Promise.all(ids.map(id => this.release(id)));
+		await Promise.all(
+			ids.map(async id => {
+				const release = this.release(id).then(() => {});
+				try {
+					await untilAborted(AbortSignal.timeout(Math.max(0, deadlineAt - Date.now())), () => release);
+				} catch (error) {
+					if (Date.now() >= deadlineAt) {
+						trackLateCleanup(release, { id, resource: "adopted-agent" });
+					}
+					logger.warn("Agent cleanup exceeded its deadline", {
+						id,
+						error: error instanceof Error ? error.message : String(error),
+					});
+				}
+			}),
+		);
 		this.#revivals.clear();
 		this.#parks.clear();
 		this.#persistedReviverFactory = undefined;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -54,6 +54,7 @@ import { normalizeSchema } from "../tools/jtd-to-json-schema";
 import { buildOutputValidator, summarizeValidationFailure } from "../tools/output-schema-validator";
 import { ToolAbortError } from "../tools/tool-errors";
 import type { EventBus } from "../utils/event-bus";
+import { trackLateCleanup } from "../utils/late-cleanup";
 import { buildNamedToolChoice } from "../utils/tool-choice";
 import type { WorkspaceTree } from "../workspace-tree";
 import { generateTaskLabel } from "./label";
@@ -79,6 +80,7 @@ import { arrayValuedLabels, assembleYieldResult } from "./yield-assembly";
 export type { YieldItem } from "./types";
 
 const MCP_CALL_TIMEOUT_MS = 60_000;
+const TASK_ABORT_CLEANUP_GRACE_MS = 10_000;
 
 /**
  * Soft per-agent request budgets (assistant requests per run). Crossing the
@@ -455,6 +457,8 @@ export interface ExecutorOptions {
 	 * set this false so disposal unregisters them instead of leaving idle peers.
 	 */
 	keepAlive?: boolean;
+	/** Internal ownership handoff for cleanup that outlives the visible Task result. */
+	onCleanupDeferred?: (completion: Promise<void>) => void;
 }
 
 function parseStringifiedJson(value: unknown): unknown {
@@ -1964,9 +1968,7 @@ async function driveSessionToYield(
 			// yield: the next iteration's ladder demands a fresh one.
 		}
 
-		if (monitor.yieldCalled()) {
-			await session.waitForIdle();
-		} else {
+		if (!monitor.yieldCalled()) {
 			await awaitAbortable(session.waitForIdle());
 		}
 
@@ -2346,15 +2348,27 @@ export async function finalizeSubagentLifecycle(args: {
 	isolated: boolean;
 	agentIdleTtlMs: number;
 	reviveSession: AgentReviver | null;
+	cleanupDeadlineAt?: number;
+	onCleanupDeferred?: (completion: Promise<void>) => void;
 }): Promise<void> {
 	const registry = AgentRegistry.global();
 	const ref = registry.get(args.id);
 	const ownsRef = Boolean(ref && ref.session === args.session);
+	const cleanupDeadlineAt = args.cleanupDeadlineAt ?? Date.now() + 5000;
 	const disposeSession = async (): Promise<void> => {
+		const disposal = args.session.dispose();
+		const remainingMs = Math.max(0, cleanupDeadlineAt - Date.now());
 		try {
-			await untilAborted(AbortSignal.timeout(5000), () => args.session.dispose());
-		} catch {
-			// Ignore cleanup errors
+			await untilAborted(AbortSignal.timeout(remainingMs), () => disposal);
+		} catch (error) {
+			if (Date.now() >= cleanupDeadlineAt) {
+				args.onCleanupDeferred?.(disposal);
+				return;
+			}
+			logger.warn("Subagent session cleanup failed", {
+				id: args.id,
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	};
 
@@ -3186,6 +3200,15 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				error = err instanceof Error ? err.stack || err.message : String(err);
 			}
 		} finally {
+			const cleanupDeadlineAt = Date.now() + TASK_ABORT_CLEANUP_GRACE_MS;
+			const lateCleanups: Promise<void>[] = [];
+			const deferCleanup = (completion: Promise<void>): void => {
+				lateCleanups.push(completion);
+				exitCode = 1;
+				aborted = true;
+				abortReasonText = `cleanup exceeded ${TASK_ABORT_CLEANUP_GRACE_MS} ms`;
+				error ??= `Task aborted. Cleanup did not finish within ${TASK_ABORT_CLEANUP_GRACE_MS} ms. No isolated changes were applied.`;
+			};
 			if (abortSignal.aborted) {
 				aborted = monitor.isAbortedRun();
 				if (aborted) {
@@ -3194,10 +3217,21 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				if (exitCode === 0) exitCode = 1;
 			}
 			sessionAbortController.abort();
+			const activeSessionAbort = monitor.waitForActiveSessionAbort();
 			try {
-				await untilAborted(AbortSignal.timeout(5000), () => monitor.waitForActiveSessionAbort());
-			} catch {
-				// Ignore abort cleanup timeouts/errors; terminal disposal below is still best-effort.
+				await untilAborted(
+					AbortSignal.timeout(Math.max(0, cleanupDeadlineAt - Date.now())),
+					() => activeSessionAbort,
+				);
+			} catch (cleanupError) {
+				if (Date.now() >= cleanupDeadlineAt) {
+					deferCleanup(activeSessionAbort);
+				} else {
+					logger.warn("Subagent abort cleanup failed", {
+						id,
+						error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+					});
+				}
 			}
 			if (unsubscribe) {
 				try {
@@ -3206,6 +3240,17 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					// Ignore unsubscribe errors
 				}
 				unsubscribe = null;
+			}
+			const jobManager = AsyncJobManager.instance();
+			if (jobManager) {
+				const reap = await jobManager.cancelAndReapOwnerJobs(id, cleanupDeadlineAt);
+				if (!reap.settled) {
+					deferCleanup(reap.completion);
+					logger.warn("Subagent async job cleanup exceeded its deadline", {
+						id,
+						pendingJobIds: reap.pendingJobIds,
+					});
+				}
 			}
 			const session = monitor.takeActiveSession();
 			if (session) {
@@ -3222,21 +3267,14 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					isolated: worktree !== undefined,
 					agentIdleTtlMs,
 					reviveSession,
+					cleanupDeadlineAt,
+					onCleanupDeferred: deferCleanup,
 				});
 			}
-			// Structured-concurrency reap: cancel and await ALL surviving owner
-			// jobs (abort paths; suppressed/watched jobs the model left behind)
-			// so isolation capture/cleanup never races a live process writing
-			// into the worktree. This never proceeds while an owner process is
-			// live: cancellation SIGKILL-escalates, so settlement is expected
-			// within one interval — an unkillable process blocks here visibly
-			// (with periodic warnings) instead of silently racing teardown.
-			const jobManager = AsyncJobManager.instance();
-			if (jobManager) {
-				jobManager.cancelAll({ ownerId: id });
-				while (!(await jobManager.waitForOwnerJobs(id, { timeoutMs: 10_000 }))) {
-					logger.warn("Subagent async jobs still settling; delaying teardown until process exit", { id });
-				}
+			if (lateCleanups.length > 0) {
+				const completion = Promise.all(lateCleanups).then(() => {});
+				trackLateCleanup(completion, { id, resource: "subagent" });
+				options.onCleanupDeferred?.(completion);
 			}
 		}
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2142,14 +2142,17 @@ async function finalizeRunResult(args: FinalizeRunArgs): Promise<SingleResult> {
 		exitCode = 1;
 	}
 	const wasAborted =
-		runtimeLimitExceeded || abortedViaYield || (!hasYield && (done.aborted || signal?.aborted || false));
+		runtimeLimitExceeded || Boolean(done.aborted) || abortedViaYield || (!hasYield && Boolean(signal?.aborted));
 	const finalAbortReason = wasAborted
 		? runtimeLimitExceeded
 			? monitor.resolveAbortReasonText()
-			: abortedViaYield
-				? yieldAbortReason
-				: (done.abortReason ??
-					(signal?.aborted ? monitor.resolveSignalAbortReason() : monitor.resolveAbortReasonText()))
+			: done.aborted
+				? (done.abortReason ?? monitor.resolveAbortReasonText())
+				: abortedViaYield
+					? yieldAbortReason
+					: signal?.aborted
+						? monitor.resolveSignalAbortReason()
+						: monitor.resolveAbortReasonText()
 		: undefined;
 	progress.status = wasAborted ? "aborted" : exitCode === 0 ? "completed" : "failed";
 	monitor.scheduleProgress(true);
@@ -3202,6 +3205,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		} finally {
 			const cleanupDeadlineAt = Date.now() + TASK_ABORT_CLEANUP_GRACE_MS;
 			const lateCleanups: Promise<void>[] = [];
+			let deferredSessionShutdown: Promise<void> | undefined;
 			const deferCleanup = (completion: Promise<void>): void => {
 				lateCleanups.push(completion);
 				exitCode = 1;
@@ -3268,11 +3272,32 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					agentIdleTtlMs,
 					reviveSession,
 					cleanupDeadlineAt,
-					onCleanupDeferred: deferCleanup,
+					onCleanupDeferred: completion => {
+						deferredSessionShutdown = completion;
+						deferCleanup(completion);
+					},
 				});
 			}
+			if (jobManager) {
+				if (deferredSessionShutdown) {
+					const finalReap = Promise.allSettled([deferredSessionShutdown]).then(async () => {
+						const reap = await jobManager.cancelAndReapOwnerJobs(id, Date.now());
+						await reap.completion;
+					});
+					lateCleanups.push(finalReap);
+				} else {
+					const reap = await jobManager.cancelAndReapOwnerJobs(id, cleanupDeadlineAt);
+					if (!reap.settled) {
+						deferCleanup(reap.completion);
+						logger.warn("Subagent async job cleanup exceeded its deadline after session shutdown", {
+							id,
+							pendingJobIds: reap.pendingJobIds,
+						});
+					}
+				}
+			}
 			if (lateCleanups.length > 0) {
-				const completion = Promise.all(lateCleanups).then(() => {});
+				const completion = Promise.allSettled(lateCleanups).then(() => {});
 				trackLateCleanup(completion, { id, resource: "subagent" });
 				options.onCleanupDeferred?.(completion);
 			}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -3204,6 +3204,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 		} finally {
 			const cleanupDeadlineAt = Date.now() + TASK_ABORT_CLEANUP_GRACE_MS;
+			const cleanupChangeStatus =
+				worktree === undefined
+					? "This task was not isolated, so its changes may remain in the working directory."
+					: "No isolated changes were applied.";
 			const lateCleanups: Promise<void>[] = [];
 			let deferredSessionShutdown: Promise<void> | undefined;
 			const deferCleanup = (completion: Promise<void>): void => {
@@ -3211,7 +3215,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				exitCode = 1;
 				aborted = true;
 				abortReasonText = `cleanup exceeded ${TASK_ABORT_CLEANUP_GRACE_MS} ms`;
-				error ??= `Task aborted. Cleanup did not finish within ${TASK_ABORT_CLEANUP_GRACE_MS} ms. No isolated changes were applied.`;
+				error ??= `Task aborted. Cleanup did not finish within ${TASK_ABORT_CLEANUP_GRACE_MS} ms. ${cleanupChangeStatus}`;
 			};
 			if (abortSignal.aborted) {
 				aborted = monitor.isAbortedRun();

--- a/packages/coding-agent/src/task/isolation-runner.ts
+++ b/packages/coding-agent/src/task/isolation-runner.ts
@@ -23,6 +23,7 @@ import type * as natives from "@oh-my-pi/pi-natives";
 import type { ToolSession } from "../tools";
 import { generateCommitMessage } from "../utils/commit-message-generator";
 import * as git from "../utils/git";
+import { trackLateCleanup } from "../utils/late-cleanup";
 import type { ExecutorOptions } from "./executor";
 import { runSubprocess } from "./executor";
 import type { SingleResult } from "./types";
@@ -146,6 +147,7 @@ async function writeIsolationPatch(
  */
 export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<SingleResult> {
 	let handle: IsolationHandle | undefined;
+	let deferredCleanup: Promise<void> | undefined;
 	try {
 		const taskBaseline = structuredClone(opts.context.baseline);
 		handle = await ensureIsolation(opts.context.repoRoot, opts.agentId, opts.preferredBackend);
@@ -155,7 +157,12 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 			worktree: isolationDir,
 			preloadedExtensionPaths: undefined,
 			preloadedCustomToolPaths: undefined,
+			onCleanupDeferred: completion => {
+				deferredCleanup = completion;
+				opts.baseOptions.onCleanupDeferred?.(completion);
+			},
 		});
+		if (deferredCleanup) return result;
 		if (opts.mergeMode === "branch" && result.exitCode === 0) {
 			try {
 				const commitResult = await commitToBranch(
@@ -213,7 +220,18 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 		return opts.buildFailureResult(err);
 	} finally {
 		if (handle) {
-			await cleanupIsolation(handle);
+			const isolationHandle = handle;
+			if (deferredCleanup) {
+				trackLateCleanup(
+					deferredCleanup.then(() => cleanupIsolation(isolationHandle)),
+					{
+						agentId: opts.agentId,
+						resource: "isolation",
+					},
+				);
+			} else {
+				await cleanupIsolation(isolationHandle);
+			}
 		}
 	}
 }

--- a/packages/coding-agent/src/task/structured-subagent.ts
+++ b/packages/coding-agent/src/task/structured-subagent.ts
@@ -20,6 +20,7 @@ import type { TaskEffort } from "../thinking";
 import type { ToolSession } from "../tools";
 import { isIrcEnabled } from "../tools/hub";
 import { buildOutputValidator } from "../tools/output-schema-validator";
+import { trackLateCleanup } from "../utils/late-cleanup";
 import { type DiscoveryResult, discoverAgents, getAgent } from "./discovery";
 import { type ExecutorOptions, runSubprocess } from "./executor";
 import {
@@ -540,12 +541,16 @@ export async function runStructuredSubagent(request: StructuredSubagentRequest):
 	let mergeSummary = "";
 	let requiresRecoveryArtifacts = false;
 	let completedSuccessfully = false;
+	let deferredCleanup: Promise<void> | undefined;
 	try {
 		const id = await reserveStructuredSubagentId(request.session, {
 			...request.identity,
 			label: request.identity?.label ?? (request.invocationKind === "eval" ? "EvalAgent" : undefined),
 		});
 		const baseOptions = buildExecutorOptions(request, policy, lease, id);
+		baseOptions.onCleanupDeferred = completion => {
+			deferredCleanup = completion;
+		};
 		baseOptions.planReference = await loadPlanReference(request, policy);
 		let isolationContext: IsolationContext | null = null;
 		if (policy.isIsolated) {
@@ -639,8 +644,18 @@ export async function runStructuredSubagent(request: StructuredSubagentRequest):
 			(policy.isIsolated && (!policy.applyChanges || changesApplied === false || requiresRecoveryArtifacts));
 		const shouldCleanup = lease.temporary && !shouldRetainArtifacts;
 		if (shouldCleanup) {
-			await fs.rm(lease.artifactsDir, { recursive: true, force: true });
-			lease.unregister?.();
+			const cleanupArtifacts = async (): Promise<void> => {
+				await fs.rm(lease.artifactsDir, { recursive: true, force: true });
+				lease.unregister?.();
+			};
+			if (deferredCleanup) {
+				trackLateCleanup(deferredCleanup.then(cleanupArtifacts), {
+					resource: "artifacts",
+					artifactsDir: lease.artifactsDir,
+				});
+			} else {
+				await cleanupArtifacts();
+			}
 		}
 	}
 }

--- a/packages/coding-agent/src/utils/late-cleanup.ts
+++ b/packages/coding-agent/src/utils/late-cleanup.ts
@@ -1,0 +1,17 @@
+import { logger } from "@oh-my-pi/pi-utils";
+
+const pendingCleanups = new Set<Promise<void>>();
+
+/** Keep timed-out cleanup reachable until its resources really settle. */
+export function trackLateCleanup(work: Promise<void>, context: Record<string, unknown>): void {
+	let tracked: Promise<void>;
+	tracked = work
+		.catch(error => {
+			logger.warn("Deferred cleanup failed", {
+				...context,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		})
+		.finally(() => pendingCleanups.delete(tracked));
+	pendingCleanups.add(tracked);
+}

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -113,6 +113,30 @@ describe("AsyncJobManager", () => {
 		expect(completions).toHaveLength(0);
 	});
 
+	test("bounds owner-job reap while preserving late settlement", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		const release = Promise.withResolvers<void>();
+		const jobId = manager.register(
+			"task",
+			"ignores abort",
+			async () => {
+				await release.promise;
+				return "late result";
+			},
+			{ ownerId: "owner" },
+		);
+
+		const reap = await manager.cancelAndReapOwnerJobs("owner", Date.now());
+
+		expect(reap.settled).toBe(false);
+		expect(reap.pendingJobIds).toEqual([jobId]);
+		expect(manager.getJob(jobId)?.status).toBe("cancelled");
+
+		release.resolve();
+		await reap.completion;
+		expect(manager.getJob(jobId)?.resultText).toBe("late result");
+	});
+
 	test("enforces maxRunningJobs cap", () => {
 		const manager = new AsyncJobManager({
 			maxRunningJobs: 1,

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -314,6 +314,23 @@ describe("AgentLifecycleManager", () => {
 		expect(registry.get("6-Sub")).toBeUndefined();
 	});
 
+	it("does not let one stuck adopted agent block sibling disposal", async () => {
+		const gate = deferred();
+		const stuck = makeSessionStub(() => gate.promise);
+		const sibling = makeSessionStub();
+		registerIdleSub("stuck-Sub", stuck.session);
+		registerIdleSub("sibling-Sub", sibling.session);
+		lifecycle.adopt("stuck-Sub", { idleTtlMs: TTL });
+		lifecycle.adopt("sibling-Sub", { idleTtlMs: TTL });
+
+		await lifecycle.dispose(Date.now());
+
+		expect(stuck.disposeCalls()).toBe(1);
+		expect(sibling.disposeCalls()).toBe(1);
+		gate.resolve();
+		await flushAsync();
+	});
+
 	it("a delayed release cannot remove or mutate a replacement ref with the same id", async () => {
 		const gate = deferred();
 		const oldSession = makeSessionStub(() => gate.promise);

--- a/packages/coding-agent/test/task/executor-async-quiescence.test.ts
+++ b/packages/coding-agent/test/task/executor-async-quiescence.test.ts
@@ -358,7 +358,9 @@ describe("runSubprocess async quiescence fresh-yield contract", () => {
 		expect(result.exitCode).toBe(1);
 		expect(result.aborted).toBe(true);
 		expect(result.abortReason).toBe("cleanup exceeded 10000 ms");
-		expect(result.error).toContain("Cleanup did not finish within 10000 ms");
+		expect(result.error).toBe(
+			"Task aborted. Cleanup did not finish within 10000 ms. This task was not isolated, so its changes may remain in the working directory.",
+		);
 		expect(result.output).toContain("yielded output");
 		expect(result.usage?.totalTokens).toBe(7);
 		expect(lateJobId).toBeDefined();

--- a/packages/coding-agent/test/task/executor-async-quiescence.test.ts
+++ b/packages/coding-agent/test/task/executor-async-quiescence.test.ts
@@ -250,4 +250,41 @@ describe("runSubprocess async quiescence fresh-yield contract", () => {
 		expect(result.exitCode).toBe(0);
 		expect(result.output).toContain("done");
 	});
+
+	it("does not wait on a second idle barrier after a terminal yield", async () => {
+		const harness = createAsyncSession(({ promptIndex, harness: h }) => {
+			if (promptIndex === 1) {
+				h.finishJob();
+				h.emitTerminalYield({ report: "done" });
+			}
+		});
+		const idleStarted = Promise.withResolvers<void>();
+		const releaseIdle = Promise.withResolvers<void>();
+		let idleCalls = 0;
+		harness.session.waitForIdle = async () => {
+			idleCalls += 1;
+			idleStarted.resolve();
+			await releaseIdle.promise;
+		};
+		mockCreateAgentSession(harness.session);
+
+		const run = runSubprocess({
+			cwd: "/tmp",
+			agent: baseAgent,
+			task: "do the work",
+			index: 0,
+			id: "quiescence-no-second-idle",
+		});
+		const outcome = await Promise.race([
+			run.then(() => "completed" as const),
+			idleStarted.promise.then(() => "blocked" as const),
+		]);
+		releaseIdle.resolve();
+		const result = await run;
+
+		expect(outcome).toBe("completed");
+		expect(idleCalls).toBe(0);
+		expect(result.exitCode).toBe(0);
+		expect(result.output).toContain("done");
+	});
 });

--- a/packages/coding-agent/test/task/executor-async-quiescence.test.ts
+++ b/packages/coding-agent/test/task/executor-async-quiescence.test.ts
@@ -8,6 +8,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 import type { LoadExtensionsResult } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import type { CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
@@ -18,7 +19,7 @@ import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 
 const baseAgent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
 
-function assistantStopMessage(text: string): AssistantMessage {
+function assistantStopMessage(text: string, totalTokens = 0): AssistantMessage {
 	return {
 		role: "assistant",
 		content: [{ type: "text", text }],
@@ -27,10 +28,10 @@ function assistantStopMessage(text: string): AssistantMessage {
 		model: "mock",
 		usage: {
 			input: 0,
-			output: 0,
+			output: totalTokens,
 			cacheRead: 0,
 			cacheWrite: 0,
-			totalTokens: 0,
+			totalTokens,
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		},
 		stopReason: "stop",
@@ -44,7 +45,13 @@ interface AsyncQuiescenceHarness {
 	abortCalls: () => number;
 	settleCalls: () => number;
 	emitTerminalYield: (data: unknown) => void;
+	emitAssistant: (text: string, totalTokens?: number) => void;
 	finishJob: () => void;
+}
+
+interface AsyncSessionOptions {
+	abort?: () => Promise<void>;
+	dispose?: () => Promise<void>;
 }
 
 /**
@@ -56,6 +63,7 @@ interface AsyncQuiescenceHarness {
  */
 function createAsyncSession(
 	onPrompt: (params: { text: string; promptIndex: number; harness: AsyncQuiescenceHarness }) => void,
+	options: AsyncSessionOptions = {},
 ): AsyncQuiescenceHarness {
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
 	const state = { messages: [] as AssistantMessage[] };
@@ -103,6 +111,11 @@ function createAsyncSession(
 		state.messages.push(reaction);
 		emit({ type: "message_end", message: reaction } as AgentSessionEvent);
 	};
+	const emitAssistant = (text: string, totalTokens = 0) => {
+		const message = assistantStopMessage(text, totalTokens);
+		state.messages.push(message);
+		emit({ type: "message_end", message } as AgentSessionEvent);
+	};
 
 	const harness: AsyncQuiescenceHarness = {
 		session: undefined as unknown as AgentSession,
@@ -110,6 +123,7 @@ function createAsyncSession(
 		abortCalls: () => abortCount,
 		settleCalls: () => settleCount,
 		emitTerminalYield,
+		emitAssistant,
 		finishJob,
 	};
 
@@ -143,8 +157,9 @@ function createAsyncSession(
 		},
 		abort: async () => {
 			abortCount += 1;
+			await options.abort?.();
 		},
-		dispose: async () => {},
+		dispose: options.dispose ?? (async () => {}),
 		setIrcWakeTurnObserver: () => {},
 	};
 	harness.session = session as unknown as AgentSession;
@@ -163,6 +178,7 @@ function mockCreateAgentSession(session: AgentSession) {
 describe("runSubprocess async quiescence fresh-yield contract", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
+		AsyncJobManager.resetForTests();
 	});
 
 	it("parks a pending yield, injects the result, and completes on the fresh yield", async () => {
@@ -287,4 +303,86 @@ describe("runSubprocess async quiescence fresh-yield contract", () => {
 		expect(result.exitCode).toBe(0);
 		expect(result.output).toContain("done");
 	});
+
+	it("returns an aborted result after cleanup grace and waits for every late resource", async () => {
+		const abortStarted = Promise.withResolvers<void>();
+		const abortGate = Promise.withResolvers<void>();
+		const disposeGate = Promise.withResolvers<void>();
+		const lateJobGate = Promise.withResolvers<void>();
+		const manager = new AsyncJobManager({});
+		AsyncJobManager.setInstance(manager);
+		let lateJobId: string | undefined;
+		let deferredCleanup: Promise<void> | undefined;
+		const harness = createAsyncSession(
+			({ promptIndex, harness: h }) => {
+				if (promptIndex !== 1) return;
+				h.finishJob();
+				h.emitAssistant("captured before cleanup", 7);
+				h.emitTerminalYield({ report: "yielded output" });
+			},
+			{
+				abort: async () => {
+					abortStarted.resolve();
+					await abortGate.promise;
+				},
+				dispose: async () => {
+					lateJobId = manager.register(
+						"task",
+						"shutdown-time job",
+						async () => {
+							await lateJobGate.promise;
+							return "late result";
+						},
+						{ ownerId: "cleanup-timeout" },
+					);
+					await disposeGate.promise;
+				},
+			},
+		);
+		mockCreateAgentSession(harness.session);
+
+		const run = runSubprocess({
+			cwd: "/tmp",
+			agent: baseAgent,
+			task: "do the work",
+			index: 0,
+			id: "cleanup-timeout",
+			keepAlive: false,
+			onCleanupDeferred: completion => {
+				deferredCleanup = completion;
+			},
+		});
+		await abortStarted.promise;
+
+		const result = await run;
+		expect(result.exitCode).toBe(1);
+		expect(result.aborted).toBe(true);
+		expect(result.abortReason).toBe("cleanup exceeded 10000 ms");
+		expect(result.error).toContain("Cleanup did not finish within 10000 ms");
+		expect(result.output).toContain("yielded output");
+		expect(result.usage?.totalTokens).toBe(7);
+		expect(lateJobId).toBeDefined();
+		expect(deferredCleanup).toBeDefined();
+
+		let cleanupSettled = false;
+		const cleanupOutcome = deferredCleanup?.then(
+			() => {
+				cleanupSettled = true;
+			},
+			() => {
+				cleanupSettled = true;
+			},
+		);
+		abortGate.resolve();
+		disposeGate.reject(new Error("dispose failed"));
+		for (let attempt = 0; attempt < 10 && manager.getJob(lateJobId ?? "")?.status === "running"; attempt += 1) {
+			await Promise.resolve();
+		}
+		expect(cleanupSettled).toBe(false);
+		expect(manager.getJob(lateJobId ?? "")?.status).toBe("cancelled");
+
+		lateJobGate.resolve();
+		await cleanupOutcome;
+		expect(cleanupSettled).toBe(true);
+	}, 15_000);
 });

--- a/packages/coding-agent/test/task/isolation-runner.test.ts
+++ b/packages/coding-agent/test/task/isolation-runner.test.ts
@@ -139,6 +139,63 @@ describe("runIsolatedSubprocess", () => {
 		expect(deleteSpy).toHaveBeenCalledWith(repoRoot, "omp/task/PreserveBranchFailure");
 		expect(cleanupSpy).toHaveBeenCalledTimes(1);
 	});
+
+	it("keeps an isolated worktree until deferred child cleanup settles", async () => {
+		const cleanupGate = Promise.withResolvers<void>();
+		vi.spyOn(worktreeModule, "ensureIsolation").mockResolvedValue({
+			mergedDir: "/repo/isolated",
+			backend: natives.IsoBackendKind.Rcopy,
+			fellBack: false,
+			fallbackReason: null,
+		});
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			options.onCleanupDeferred?.(cleanupGate.promise);
+			return result({ exitCode: 1, aborted: true, error: "cleanup exceeded its deadline" });
+		});
+		const cleanupSpy = vi.spyOn(worktreeModule, "cleanupIsolation").mockResolvedValue();
+
+		const outcome = await runIsolatedSubprocess({
+			baseOptions: {
+				cwd: "/repo",
+				agent: {
+					name: "task",
+					description: "Task agent",
+					systemPrompt: "test",
+					source: "bundled",
+				},
+				task: "Do work",
+				index: 0,
+				id: "DeferredCleanup",
+			},
+			context: {
+				repoRoot: "/repo",
+				baseline: {
+					root: {
+						repoRoot: "/repo",
+						headCommit: "base",
+						staged: "",
+						unstaged: "",
+						untracked: [],
+						untrackedPatch: "",
+					},
+					nested: [],
+				},
+			},
+			preferredBackend: undefined,
+			agentId: "DeferredCleanup",
+			mergeMode: "patch",
+			artifactsDir: "/artifacts",
+			buildFailureResult: error => result({ exitCode: 1, error: String(error) }),
+		});
+
+		expect(outcome.exitCode).toBe(1);
+		expect(cleanupSpy).not.toHaveBeenCalled();
+		cleanupGate.resolve();
+		await cleanupGate.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(cleanupSpy).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe("mergeIsolatedChanges", () => {


### PR DESCRIPTION
## Summary

- stop waiting on a second full idle barrier after a terminal Task yield
- replace the repeated owner-job reap loop with one absolute 10 second cleanup deadline
- return one terminal aborted result when cleanup exceeds that deadline
- keep late cleanup owned in the background
- defer isolated worktree and artifact removal until late work has really stopped
- bound adopted child disposal so one stuck child cannot block its siblings

## Tests

- `bun test --parallel=1 packages/coding-agent/test/async-job-manager.test.ts packages/coding-agent/test/task/executor-async-quiescence.test.ts`
- `bun test --parallel=1 packages/coding-agent/test/registry/agent-lifecycle.test.ts`
- `bun test --parallel=1 packages/coding-agent/test/task/isolation-runner.test.ts`

Fixes #7483
