### PR TITLE
fix(retry): single-flight automatic fallback probes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed parallel subagents sending duplicate probes to the same unknown retry fallback ([#7484](https://github.com/can1357/oh-my-pi/issues/7484)).
+
 ## [17.2.5] - 2026-08-03
 
 ### Breaking Changes

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -72,6 +72,8 @@ export interface AdvisorRuntimeHost {
 	): Promise<boolean | undefined> | boolean | undefined;
 	/** Called after a successful advisor turn so the host can finish fallback lifecycle reporting. */
 	onTurnSuccess?(): Promise<void> | void;
+	/** Called when a failed turn is dropped without entering normal recovery. */
+	onTurnDiscarded?(): Promise<void> | void;
 	/** Surface a non-recovering advisor failure to the host UI without adding model-visible context. */
 	notifyFailure?(error: unknown): void;
 	/** Signal that the advisor paused on a quota/rate-limit after host-level
@@ -996,6 +998,13 @@ export class AdvisorRuntime {
 							}
 						}
 						this.#notifyFailureOnce(err);
+						if (this.host.onTurnDiscarded) {
+							try {
+								await raceWithSignal(Promise.resolve(this.host.onTurnDiscarded()), iterationAbort.signal);
+							} catch (hookErr) {
+								logger.debug("advisor onTurnDiscarded hook failed", { err: String(hookErr) });
+							}
+						}
 						this.#clearSeenContext();
 						this.#backlog = Math.max(0, this.#backlog - finalTurns);
 						this.#notifyWaiters();

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -56,6 +56,8 @@ export interface AdvisorRuntimeHost {
 	 * primary.
 	 */
 	beginAdvisorUpdate?(inProgress: boolean): void;
+	/** Admit the advisor's active automatic fallback immediately before provider dispatch. */
+	beforeAdvisorDispatch?(signal: AbortSignal): Promise<boolean> | boolean;
 	/**
 	 * Called with the error of every failed advisor turn, before the retry sleep
 	 * or the dropped-after-3 path. Lets the host apply credential-level remedies
@@ -854,6 +856,18 @@ export class AdvisorRuntime {
 		}
 	}
 
+	async #waitBeforeRetry(signal: AbortSignal): Promise<void> {
+		if (this.retryDelayMs <= 0) {
+			await Bun.sleep(0);
+			return;
+		}
+		try {
+			await raceWithSignal(Bun.sleep(this.retryDelayMs), signal);
+		} catch (error) {
+			if (!signal.aborted) throw error;
+		}
+	}
+
 	async #drain(): Promise<void> {
 		if (this.#busy || this.#sessionTransitionPaused) return;
 		this.#busy = true;
@@ -899,6 +913,28 @@ export class AdvisorRuntime {
 					this.#backlog = Math.max(0, this.#backlog - finalTurns);
 					this.#notifyWaiters();
 					continue;
+				}
+				if (this.host.beforeAdvisorDispatch) {
+					let admitted = false;
+					try {
+						admitted = await raceWithSignal(
+							Promise.resolve(this.host.beforeAdvisorDispatch(iterationAbort.signal)),
+							iterationAbort.signal,
+						);
+					} catch (error) {
+						if (this.#epoch !== epoch || this.disposed) continue;
+						this.#pending.unshift(...popped);
+						if (!iterationAbort.signal.aborted) {
+							logger.debug("advisor pre-dispatch admission failed", { err: String(error) });
+						}
+						await this.#waitBeforeRetry(iterationAbort.signal);
+						continue;
+					}
+					if (!admitted) {
+						this.#pending.unshift(...popped);
+						await this.#waitBeforeRetry(iterationAbort.signal);
+						continue;
+					}
 				}
 
 				let success = false;

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -742,6 +742,18 @@ function normalizeSuppressedSelector(
 	return `${parsed.provider}/${aliasId ?? parsed.id}`;
 }
 
+/** Ownership token for the first automatic request sent to an untested fallback selector. */
+export interface FallbackProbeLease {
+	readonly selector: string;
+	readonly generation: number;
+}
+
+/** Non-waiting admission result for an automatic fallback selector. */
+export type FallbackProbeAdmission =
+	| { status: "probe"; lease: FallbackProbeLease }
+	| { status: "healthy" }
+	| { status: "busy" };
+
 /**
  * Look up a model's override, falling back to entries keyed by retired
  * effort-tier variant ids (models.yml authored before collapsing). A raw key
@@ -812,6 +824,8 @@ export class ModelRegistry {
 	#providerDiscoveryStates: Map<string, ProviderDiscoveryState> = new Map();
 	#cacheDbPath?: string;
 	#suppressedSelectors: Map<string, number> = new Map();
+	#fallbackProbeStates: Map<string, { state: "probing"; generation: number } | { state: "healthy" }> = new Map();
+	#nextFallbackProbeGeneration = 0;
 	#backgroundRefresh?: Promise<void>;
 	#lastDiscoveryWarnings: Map<string, string> = new Map();
 	// Runtime extension model overlays — persist across refresh() cycles so that
@@ -903,6 +917,7 @@ export class ModelRegistry {
 	async refresh(strategy: ModelRefreshStrategy = "online-if-uncached"): Promise<void> {
 		this.#reloadStaticModels();
 		this.#suppressedSelectors.clear();
+		this.#fallbackProbeStates.clear();
 		await this.#refreshRuntimeDiscoveries(strategy);
 	}
 
@@ -952,6 +967,9 @@ export class ModelRegistry {
 			if (selector.startsWith(`${providerId}/`)) {
 				this.#suppressedSelectors.delete(selector);
 			}
+		}
+		for (const selector of this.#fallbackProbeStates.keys()) {
+			if (selector.startsWith(`${providerId}/`)) this.#fallbackProbeStates.delete(selector);
 		}
 		await this.#refreshRuntimeDiscoveries(strategy, new Set([providerId]));
 		// #reloadStaticModels above may have rebuilt #models from static sources,
@@ -2720,24 +2738,63 @@ export class ModelRegistry {
 		}
 	}
 
+	#normalizeFallbackSelector(selector: string): string {
+		return normalizeSuppressedSelector(selector, (provider, id) => this.find(provider, id) !== undefined);
+	}
+
+	/**
+	 * Admit automatic traffic to a fallback selector without waiting.
+	 *
+	 * The first caller owns a probe. Concurrent callers skip the selector until
+	 * that probe succeeds or is abandoned. Once healthy, normal parallel traffic
+	 * resumes. Primary model traffic never calls this method.
+	 */
+	admitFallbackProbe(selector: string): FallbackProbeAdmission {
+		const normalizedSelector = this.#normalizeFallbackSelector(selector);
+		const state = this.#fallbackProbeStates.get(normalizedSelector);
+		if (state?.state === "healthy") return { status: "healthy" };
+		if (state?.state === "probing") return { status: "busy" };
+
+		const generation = ++this.#nextFallbackProbeGeneration;
+		this.#fallbackProbeStates.set(normalizedSelector, { state: "probing", generation });
+		return { status: "probe", lease: { selector: normalizedSelector, generation } };
+	}
+
+	/** Mark the owned probe healthy. Stale leases cannot change newer state. */
+	markFallbackProbeHealthy(lease: FallbackProbeLease): void {
+		const state = this.#fallbackProbeStates.get(lease.selector);
+		if (state?.state !== "probing" || state.generation !== lease.generation) return;
+		this.#fallbackProbeStates.set(lease.selector, { state: "healthy" });
+	}
+
+	/** Release an unfinished probe. Stale leases cannot release a newer owner. */
+	abandonFallbackProbe(lease: FallbackProbeLease): void {
+		const state = this.#fallbackProbeStates.get(lease.selector);
+		if (state?.state !== "probing" || state.generation !== lease.generation) return;
+		this.#fallbackProbeStates.delete(lease.selector);
+	}
+
+	/** Release a probe only when the failing selector is the selector that lease owns. */
+	abandonFallbackProbeForSelector(lease: FallbackProbeLease, selector: string): boolean {
+		if (lease.selector !== this.#normalizeFallbackSelector(selector)) return false;
+		const state = this.#fallbackProbeStates.get(lease.selector);
+		if (state?.state !== "probing" || state.generation !== lease.generation) return false;
+		this.#fallbackProbeStates.delete(lease.selector);
+		return true;
+	}
+
 	/**
 	 * Suppress a specific model selector (e.g., "provider/id") until a specific timestamp.
 	 */
 	suppressSelector(selector: string, untilMs: number): void {
-		this.#suppressedSelectors.set(
-			normalizeSuppressedSelector(selector, (provider, id) => this.find(provider, id) !== undefined),
-			untilMs,
-		);
+		this.#suppressedSelectors.set(this.#normalizeFallbackSelector(selector), untilMs);
 	}
 
 	/**
 	 * Check if a model selector is currently suppressed due to rate limits.
 	 */
 	isSelectorSuppressed(selector: string): boolean {
-		const normalizedSelector = normalizeSuppressedSelector(
-			selector,
-			(provider, id) => this.find(provider, id) !== undefined,
-		);
+		const normalizedSelector = this.#normalizeFallbackSelector(selector);
 		const suppressedUntil = this.#suppressedSelectors.get(normalizedSelector);
 		if (!suppressedUntil) return false;
 		if (suppressedUntil <= Date.now()) {
@@ -2751,9 +2808,7 @@ export class ModelRegistry {
 	 * Clear the cooldown suppression for one selector after an explicit user selection.
 	 */
 	clearSuppressedSelector(selector: string): void {
-		this.#suppressedSelectors.delete(
-			normalizeSuppressedSelector(selector, (provider, id) => this.find(provider, id) !== undefined),
-		);
+		this.#suppressedSelectors.delete(this.#normalizeFallbackSelector(selector));
 	}
 
 	/**
@@ -2762,6 +2817,11 @@ export class ModelRegistry {
 	 */
 	clearSuppressedSelectors(): void {
 		this.#suppressedSelectors.clear();
+	}
+
+	/** Reset automatic fallback health and probe state without reloading models. */
+	clearFallbackProbeStates(): void {
+		this.#fallbackProbeStates.clear();
 	}
 }
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2743,7 +2743,17 @@ export class ModelRegistry {
 	}
 
 	#normalizeFallbackSelector(selector: string): string {
-		return normalizeSuppressedSelector(selector, (provider, id) => this.find(provider, id) !== undefined);
+		const normalized = normalizeSuppressedSelector(selector, (provider, id) => this.find(provider, id) !== undefined);
+		const parsed = parseModelString(normalized, {
+			allowMaxSuffix: true,
+			allowAutoAlias: true,
+			isLiteralModelId: (provider, id) => this.find(provider, id) !== undefined,
+		});
+		if (!parsed) return normalized;
+		const model = this.find(parsed.provider, parsed.id);
+		if (!model) return normalized;
+		const aliasId = resolveVariantAlias(model.provider, model.id);
+		return `${model.provider}/${aliasId ?? model.id}`;
 	}
 
 	/**
@@ -2798,7 +2808,9 @@ export class ModelRegistry {
 	suppressSelector(selector: string, untilMs: number): void {
 		const normalizedSelector = this.#normalizeFallbackSelector(selector);
 		this.#suppressedSelectors.set(normalizedSelector, untilMs);
-		this.#fallbackProbeStates.delete(normalizedSelector);
+		if (this.#fallbackProbeStates.get(normalizedSelector)?.state === "healthy") {
+			this.#fallbackProbeStates.delete(normalizedSelector);
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -754,6 +754,8 @@ export type FallbackProbeAdmission =
 	| { status: "healthy" }
 	| { status: "busy" };
 
+const FALLBACK_PROBE_TTL_MS = 5 * 60 * 1000;
+
 /**
  * Look up a model's override, falling back to entries keyed by retired
  * effort-tier variant ids (models.yml authored before collapsing). A raw key
@@ -824,7 +826,10 @@ export class ModelRegistry {
 	#providerDiscoveryStates: Map<string, ProviderDiscoveryState> = new Map();
 	#cacheDbPath?: string;
 	#suppressedSelectors: Map<string, number> = new Map();
-	#fallbackProbeStates: Map<string, { state: "probing"; generation: number } | { state: "healthy" }> = new Map();
+	#fallbackProbeStates: Map<
+		string,
+		{ state: "probing"; generation: number; expiresAt: number } | { state: "healthy" }
+	> = new Map();
 	#nextFallbackProbeGeneration = 0;
 	#backgroundRefresh?: Promise<void>;
 	#lastDiscoveryWarnings: Map<string, string> = new Map();
@@ -2752,10 +2757,15 @@ export class ModelRegistry {
 		const normalizedSelector = this.#normalizeFallbackSelector(selector);
 		const state = this.#fallbackProbeStates.get(normalizedSelector);
 		if (state?.state === "healthy") return { status: "healthy" };
-		if (state?.state === "probing") return { status: "busy" };
+		const now = Date.now();
+		if (state?.state === "probing" && state.expiresAt > now) return { status: "busy" };
 
 		const generation = ++this.#nextFallbackProbeGeneration;
-		this.#fallbackProbeStates.set(normalizedSelector, { state: "probing", generation });
+		this.#fallbackProbeStates.set(normalizedSelector, {
+			state: "probing",
+			generation,
+			expiresAt: now + FALLBACK_PROBE_TTL_MS,
+		});
 		return { status: "probe", lease: { selector: normalizedSelector, generation } };
 	}
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2796,7 +2796,9 @@ export class ModelRegistry {
 	 * Suppress a specific model selector (e.g., "provider/id") until a specific timestamp.
 	 */
 	suppressSelector(selector: string, untilMs: number): void {
-		this.#suppressedSelectors.set(this.#normalizeFallbackSelector(selector), untilMs);
+		const normalizedSelector = this.#normalizeFallbackSelector(selector);
+		this.#suppressedSelectors.set(normalizedSelector, untilMs);
+		this.#fallbackProbeStates.delete(normalizedSelector);
 	}
 
 	/**

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -917,7 +917,6 @@ export class ModelRegistry {
 	async refresh(strategy: ModelRefreshStrategy = "online-if-uncached"): Promise<void> {
 		this.#reloadStaticModels();
 		this.#suppressedSelectors.clear();
-		this.#fallbackProbeStates.clear();
 		await this.#refreshRuntimeDiscoveries(strategy);
 	}
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2391,17 +2391,18 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						settings.override("retry.fallbackChains", fallbackChains);
 					}
 				}
+				const selectedRetryFallback = authFallbackUsed ? undefined : retryFallback;
 				let probeLease: FallbackProbeLease | undefined;
-				if (retryFallback) {
+				if (selectedRetryFallback) {
 					const admission = modelRegistry.admitFallbackProbe(pattern);
 					if (admission.status === "busy") continue;
 					probeLease = admission.status === "probe" ? admission.lease : undefined;
 				}
 				model = selectedModel;
-				initialRetryFallback = retryFallback
+				initialRetryFallback = selectedRetryFallback
 					? {
-							...retryFallback,
-							pinned: usageFallbackTriggered || retryFallback.pinned,
+							...selectedRetryFallback,
+							pinned: usageFallbackTriggered || selectedRetryFallback.pinned,
 							probeLease,
 						}
 					: undefined;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -45,7 +45,7 @@ import { type Rule, ruleCapability, setActiveRules } from "./capability/rule";
 import { bucketRules } from "./capability/rule-buckets";
 import { shouldEnableAppendOnlyContext } from "./config/append-only-context-mode";
 import { shouldInlineToolDescriptors } from "./config/inline-tool-descriptors-mode";
-import { isAuthenticated, kNoAuth, ModelRegistry } from "./config/model-registry";
+import { type FallbackProbeLease, isAuthenticated, kNoAuth, ModelRegistry } from "./config/model-registry";
 import {
 	formatModelSelectorValue,
 	formatModelString,
@@ -2391,9 +2391,20 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						settings.override("retry.fallbackChains", fallbackChains);
 					}
 				}
+				let probeLease: FallbackProbeLease | undefined;
+				if (retryFallback) {
+					const admission = modelRegistry.admitFallbackProbe(pattern);
+					if (admission.status === "busy") continue;
+					probeLease = admission.status === "probe" ? admission.lease : undefined;
+				}
 				model = selectedModel;
-				initialRetryFallback =
-					retryFallback && usageFallbackTriggered ? { ...retryFallback, pinned: true } : retryFallback;
+				initialRetryFallback = retryFallback
+					? {
+							...retryFallback,
+							pinned: usageFallbackTriggered || retryFallback.pinned,
+							probeLease,
+						}
+					: undefined;
 				modelFallbackMessage = undefined;
 				if (selectedExplicitThinkingLevel) {
 					restoredSessionThinkingLevel = selectedThinkingLevel;
@@ -3792,6 +3803,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			eventBus,
 		};
 	} catch (error) {
+		if (!hasSession && initialRetryFallback?.probeLease) {
+			modelRegistry.abandonFallbackProbe(initialRetryFallback.probeLease);
+			initialRetryFallback.probeLease = undefined;
+		}
 		// Release the subscription if the throw happened after install but before the
 		// dispose-wrap took ownership. Idempotent with dispose() — Set.delete is a no-op
 		// for already-removed listeners.

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -21,7 +21,7 @@ import type {
 import type { postmortem } from "@oh-my-pi/pi-utils";
 import type { AdvisorConfig } from "../advisor";
 import type { AsyncJob, AsyncJobDeliveryState, AsyncJobManager } from "../async";
-import type { ModelRegistry } from "../config/model-registry";
+import type { FallbackProbeLease, ModelRegistry } from "../config/model-registry";
 import type { PromptTemplate } from "../config/prompt-templates";
 import type { Settings, SkillsSettings } from "../config/settings";
 import type { CursorMcpResourceAdapter } from "../cursor";
@@ -102,6 +102,8 @@ export interface InitialRetryFallbackState {
 	originalThinkingLevel: ConfiguredThinkingLevel | undefined;
 	/** Prevent cooldown restoration when startup selected this fallback from live usage health. */
 	pinned?: boolean;
+	/** Present only when startup owns the selector's first live probe. */
+	probeLease?: FallbackProbeLease;
 }
 
 /** Dependencies and initial state used to construct an AgentSession. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3559,6 +3559,7 @@ export class AgentSession {
 	 */
 	beginDispose(): void {
 		this.#isDisposed = true;
+		this.agent.abort();
 		this.#recovery.abandonActiveRetryFallbackProbe();
 		this.#memory.cancelLocalMemoryStartup();
 		this.#titleGenerationAbortController.abort();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2711,6 +2711,7 @@ export class AgentSession {
 						continuationScheduled: compactionResult.continuationScheduled,
 						automaticContinuationBlocked: compactionResult.automaticContinuationBlocked === true,
 					});
+					await this.#recovery.onErrorSettledWithoutRetry(msg, compactionResult);
 					this.#recovery.resolveRetry();
 					await emitAgentEndNotification(
 						compactionResult.continuationScheduled ? { willContinue: true } : undefined,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -100,7 +100,7 @@ import {
 import { type AdvisorConfig, type AdvisorRuntimeStatus, loadAdvisorTranscriptCosts } from "../advisor";
 import { type AsyncJob, AsyncJobManager } from "../async";
 import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mode";
-import type { ModelRegistry } from "../config/model-registry";
+import type { FallbackProbeLease, ModelRegistry } from "../config/model-registry";
 import { type ResolvedModelRoleValue, resolveModelOverride } from "../config/model-resolver";
 import { expandPromptTemplate, type PromptTemplate } from "../config/prompt-templates";
 import { buildServiceTierByFamily } from "../config/service-tier";
@@ -3555,6 +3555,7 @@ export class AgentSession {
 	 */
 	beginDispose(): void {
 		this.#isDisposed = true;
+		this.#recovery.abandonActiveRetryFallbackProbe();
 		this.#memory.cancelLocalMemoryStartup();
 		this.#titleGenerationAbortController.abort();
 		this.#abortAutolearnCapture();
@@ -3858,7 +3859,7 @@ export class AgentSession {
 
 		const role = this.#recovery.resolveRetryFallbackRole(currentSelector, currentModel);
 		if (!role) return;
-		let fallback: { selector: RetryFallbackSelector; apiKey: string } | undefined;
+		let fallback: { selector: RetryFallbackSelector; apiKey: string; probeLease?: FallbackProbeLease } | undefined;
 		for (const candidate of this.#recovery.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
 			if (this.#recovery.isRetryFallbackSelectorSuppressed(candidate)) continue;
 			const resolved = resolveModelOverride([candidate.raw], this.#modelRegistry, this.settings);
@@ -3902,49 +3903,63 @@ export class AgentSession {
 			}
 			if (signal.aborted) return;
 			if (!apiKey) continue;
-			fallback = { selector: candidate, apiKey };
+			const admission = this.#modelRegistry.admitFallbackProbe(candidate.raw);
+			if (admission.status === "busy") continue;
+			fallback = {
+				selector: candidate,
+				apiKey,
+				probeLease: admission.status === "probe" ? admission.lease : undefined,
+			};
 			break;
 		}
 		if (!fallback) return;
 
-		if (health.state === "reserve") {
-			if (reservePolicy === "confirm" && this.#usageFallbackConfirmer) {
-				if (this.#usageReserveApprovedSelector === currentSelector) return;
-				const selected = health.accounts.find(account => account.selected);
-				const remainingFraction =
-					selected?.remainingFraction ??
-					health.accounts.reduce<number | undefined>(
-						(minimum, account) =>
-							account.remainingFraction === undefined
-								? minimum
-								: minimum === undefined
-									? account.remainingFraction
-									: Math.min(minimum, account.remainingFraction),
-						undefined,
+		let transferred = false;
+		try {
+			if (health.state === "reserve") {
+				if (reservePolicy === "confirm" && this.#usageFallbackConfirmer) {
+					if (this.#usageReserveApprovedSelector === currentSelector) return;
+					const selected = health.accounts.find(account => account.selected);
+					const remainingFraction =
+						selected?.remainingFraction ??
+						health.accounts.reduce<number | undefined>(
+							(minimum, account) =>
+								account.remainingFraction === undefined
+									? minimum
+									: minimum === undefined
+										? account.remainingFraction
+										: Math.min(minimum, account.remainingFraction),
+							undefined,
+						);
+					const shouldFallback = await this.#confirmUsageFallback(
+						{
+							from: currentSelector,
+							to: fallback.selector.raw,
+							remainingPercent:
+								remainingFraction === undefined ? undefined : Math.max(0, remainingFraction * 100),
+						},
+						signal,
 					);
-				const shouldFallback = await this.#confirmUsageFallback(
-					{
-						from: currentSelector,
-						to: fallback.selector.raw,
-						remainingPercent: remainingFraction === undefined ? undefined : Math.max(0, remainingFraction * 100),
-					},
-					signal,
-				);
-				if (signal.aborted) return;
-				if (!shouldFallback) {
-					this.#usageReserveApprovedSelector = currentSelector;
-					return;
+					if (signal.aborted) return;
+					if (!shouldFallback) {
+						this.#usageReserveApprovedSelector = currentSelector;
+						return;
+					}
 				}
 			}
-		}
 
-		if (signal.aborted) return;
-		this.#usageReserveApprovedSelector = undefined;
-		await this.#recovery.applyRetryFallbackCandidate(role, fallback.selector, currentSelector, {
-			pinFallback: true,
-			apiKey: fallback.apiKey,
-			signal,
-		});
+			if (signal.aborted) return;
+			this.#usageReserveApprovedSelector = undefined;
+			await this.#recovery.applyRetryFallbackCandidate(role, fallback.selector, currentSelector, {
+				pinFallback: true,
+				apiKey: fallback.apiKey,
+				signal,
+				probeLease: fallback.probeLease,
+			});
+			transferred = true;
+		} finally {
+			if (fallback.probeLease && !transferred) this.#modelRegistry.abandonFallbackProbe(fallback.probeLease);
+		}
 	}
 
 	/** Effective thinking level applied to the agent (the resolved level when `auto`). */
@@ -6064,6 +6079,7 @@ export class AgentSession {
 		this.#abortInProgress = true;
 		try {
 			this.#abortAutolearnCapture();
+			this.#recovery.abandonActiveRetryFallbackProbe();
 			for (const controller of this.#usagePreflightAbortControllers) controller.abort();
 			this.abortRetry();
 			this.#promptGeneration++;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -775,8 +775,8 @@ export class AgentSession {
 		const generation = this.#promptGeneration;
 		this.#beginInFlight();
 		let turnError: unknown;
-		void this.agent
-			.prompt(records)
+		void this.#recovery
+			.promptAgentWithIdleRetry(records)
 			.catch(error => {
 				turnError = error;
 				logger.warn("IRC wake turn failed", { error: String(error) });
@@ -1122,7 +1122,7 @@ export class AgentSession {
 			injectIdle: async messages => {
 				const first = messages[0];
 				if (!first) return;
-				await this.agent.prompt(messages.length === 1 ? first : messages);
+				await this.#recovery.promptAgentWithIdleRetry(messages.length === 1 ? [first] : messages);
 			},
 			scheduleIdleFlush: run => {
 				this.#schedulePostPromptTask(
@@ -1201,6 +1201,7 @@ export class AgentSession {
 			emitSessionEvent: event => this.#emitSessionEvent(event),
 			schedulePostPromptTask: (task, options) => this.#schedulePostPromptTask(task, options),
 			scheduleAgentContinue: options => this.#scheduleAgentContinue(options),
+			continueAgent: () => this.#recovery.continueAgentWithIdleRetry(),
 			promptGeneration: () => this.#promptGeneration,
 		};
 		this.#ttsr = new TtsrCoordinator(ttsrHost, config.ttsrManager);
@@ -1232,6 +1233,7 @@ export class AgentSession {
 			localProtocolOptions: () => this.#localProtocolOptions(),
 			emitNotice: (level, message, source) => this.emitNotice(level, message, source),
 			schedulePostPromptTask: task => this.#schedulePostPromptTask(task),
+			continueAgent: () => this.#recovery.continueAgentWithIdleRetry(),
 			discardAssistantTurn: message => this.#recovery.discardAssistantTurn(message),
 		};
 		this.#streamingEditGuard = new StreamingEditGuard(streamGuardsHost);
@@ -2954,7 +2956,7 @@ export class AgentSession {
 						this.#skipAgentContinue("post-restore-unavailable", options);
 						return;
 					}
-					await this.agent.continue();
+					await this.#recovery.continueAgentWithIdleRetry();
 				} catch (error) {
 					logger.warn("agent.continue failed after scheduling", {
 						error: error instanceof Error ? error.message : String(error),
@@ -5027,6 +5029,7 @@ export class AgentSession {
 	): Promise<void> {
 		this.#beginInFlight();
 		const generation = this.#promptGeneration;
+		let providerDispatchStarted = false;
 		try {
 			await this.#recovery.maybeRestoreRetryFallbackPrimary();
 			if (!(await this.#runUsageAwarePreflight())) return;
@@ -5232,6 +5235,7 @@ export class AgentSession {
 				this.#planReferenceSent = true;
 			}
 			try {
+				providerDispatchStarted = true;
 				await this.#recovery.promptAgentWithIdleRetry(messages, agentPromptOptions);
 			} finally {
 				this.#stats.setPendingSnapshot(undefined);
@@ -5240,6 +5244,7 @@ export class AgentSession {
 				await this.#waitForPostPromptRecovery(generation);
 			}
 		} finally {
+			if (!providerDispatchStarted) this.#recovery.deferActiveRetryFallbackProbe();
 			this.#endInFlight();
 		}
 	}
@@ -5634,6 +5639,7 @@ export class AgentSession {
 		options?: { acceptTerminalEmptyStop?: boolean },
 	): Promise<void> {
 		this.#beginInFlight();
+		let providerDispatchStarted = false;
 		try {
 			if (!(await this.#runUsageAwarePreflight())) return;
 			const acceptTerminalEmptyStop = options?.acceptTerminalEmptyStop === true;
@@ -5641,9 +5647,11 @@ export class AgentSession {
 				this.#resetPromptMaintenanceState();
 			}
 			this.#recovery.setAcceptTerminalEmptyStop(acceptTerminalEmptyStop);
-			await this.agent.prompt(message);
+			providerDispatchStarted = true;
+			await this.#recovery.promptAgentWithIdleRetry([message]);
 			await this.#waitForPostPromptRecovery();
 		} finally {
+			if (!providerDispatchStarted) this.#recovery.deferActiveRetryFallbackProbe();
 			this.#recovery.setAcceptTerminalEmptyStop(false);
 			this.#endInFlight();
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2743,7 +2743,7 @@ export class AgentSession {
 			// continuations — except TTSR self-repair, which already scheduled a
 			// hidden retry while #ttsrAbortPending is still true.
 			if (msg.stopReason === "aborted") {
-				this.#recovery.onAbortSettledWithoutRetry(msg);
+				if (!ttsrAbortPendingAtAgentEnd) this.#recovery.onAbortSettledWithoutRetry(msg);
 				this.#recovery.resolveRetry();
 				this.#resetSessionStopContinuationState();
 				await emitAgentEndNotification(ttsrAbortPendingAtAgentEnd ? { willContinue: true } : undefined);
@@ -3941,13 +3941,14 @@ export class AgentSession {
 			let transferred = false;
 			try {
 				this.#usageReserveApprovedSelector = undefined;
-				await this.#recovery.applyRetryFallbackCandidate(role, candidate, currentSelector, {
+				const applied = await this.#recovery.applyRetryFallbackCandidate(role, candidate, currentSelector, {
 					pinFallback: true,
 					apiKey,
 					signal,
 					probeLease,
 				});
-				transferred = true;
+				transferred = applied;
+				if (!applied) return;
 				return;
 			} finally {
 				if (probeLease && !transferred) this.#modelRegistry.abandonFallbackProbe(probeLease);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -100,7 +100,7 @@ import {
 import { type AdvisorConfig, type AdvisorRuntimeStatus, loadAdvisorTranscriptCosts } from "../advisor";
 import { type AsyncJob, AsyncJobManager } from "../async";
 import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mode";
-import type { FallbackProbeLease, ModelRegistry } from "../config/model-registry";
+import type { ModelRegistry } from "../config/model-registry";
 import { type ResolvedModelRoleValue, resolveModelOverride } from "../config/model-resolver";
 import { expandPromptTemplate, type PromptTemplate } from "../config/prompt-templates";
 import { buildServiceTierByFamily } from "../config/service-tier";
@@ -304,7 +304,7 @@ import {
 	queueChipText,
 	toRestoredQueuedMessage,
 } from "./queued-messages";
-import { formatRetryFallbackSelector, type RetryFallbackSelector } from "./retry-fallback-chains";
+import { formatRetryFallbackSelector } from "./retry-fallback-chains";
 import { type AdvisorStats, SessionAdvisors, type SessionAdvisorsHost } from "./session-advisors";
 import type { BuildSessionContextOptions, SessionContext } from "./session-context";
 import { getRestorableSessionModels } from "./session-context";
@@ -2743,6 +2743,7 @@ export class AgentSession {
 			// continuations — except TTSR self-repair, which already scheduled a
 			// hidden retry while #ttsrAbortPending is still true.
 			if (msg.stopReason === "aborted") {
+				this.#recovery.onAbortSettledWithoutRetry(msg);
 				this.#recovery.resolveRetry();
 				this.#resetSessionStopContinuationState();
 				await emitAgentEndNotification(ttsrAbortPendingAtAgentEnd ? { willContinue: true } : undefined);
@@ -3859,7 +3860,25 @@ export class AgentSession {
 
 		const role = this.#recovery.resolveRetryFallbackRole(currentSelector, currentModel);
 		if (!role) return;
-		let fallback: { selector: RetryFallbackSelector; apiKey: string; probeLease?: FallbackProbeLease } | undefined;
+		let remainingPercent: number | undefined;
+		const needsConfirmation =
+			health.state === "reserve" && reservePolicy === "confirm" && this.#usageFallbackConfirmer !== undefined;
+		if (needsConfirmation) {
+			if (this.#usageReserveApprovedSelector === currentSelector) return;
+			const selected = health.accounts.find(account => account.selected);
+			const remainingFraction =
+				selected?.remainingFraction ??
+				health.accounts.reduce<number | undefined>(
+					(minimum, account) =>
+						account.remainingFraction === undefined
+							? minimum
+							: minimum === undefined
+								? account.remainingFraction
+								: Math.min(minimum, account.remainingFraction),
+					undefined,
+				);
+			remainingPercent = remainingFraction === undefined ? undefined : Math.max(0, remainingFraction * 100);
+		}
 		for (const candidate of this.#recovery.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
 			if (this.#recovery.isRetryFallbackSelectorSuppressed(candidate)) continue;
 			const resolved = resolveModelOverride([candidate.raw], this.#modelRegistry, this.settings);
@@ -3903,62 +3922,36 @@ export class AgentSession {
 			}
 			if (signal.aborted) return;
 			if (!apiKey) continue;
-			const admission = this.#modelRegistry.admitFallbackProbe(candidate.raw);
-			if (admission.status === "busy") continue;
-			fallback = {
-				selector: candidate,
-				apiKey,
-				probeLease: admission.status === "probe" ? admission.lease : undefined,
-			};
-			break;
-		}
-		if (!fallback) return;
-
-		let transferred = false;
-		try {
-			if (health.state === "reserve") {
-				if (reservePolicy === "confirm" && this.#usageFallbackConfirmer) {
-					if (this.#usageReserveApprovedSelector === currentSelector) return;
-					const selected = health.accounts.find(account => account.selected);
-					const remainingFraction =
-						selected?.remainingFraction ??
-						health.accounts.reduce<number | undefined>(
-							(minimum, account) =>
-								account.remainingFraction === undefined
-									? minimum
-									: minimum === undefined
-										? account.remainingFraction
-										: Math.min(minimum, account.remainingFraction),
-							undefined,
-						);
-					const shouldFallback = await this.#confirmUsageFallback(
-						{
-							from: currentSelector,
-							to: fallback.selector.raw,
-							remainingPercent:
-								remainingFraction === undefined ? undefined : Math.max(0, remainingFraction * 100),
-						},
-						signal,
-					);
-					if (signal.aborted) return;
-					if (!shouldFallback) {
-						this.#usageReserveApprovedSelector = currentSelector;
-						return;
-					}
+			if (needsConfirmation) {
+				const shouldFallback = await this.#confirmUsageFallback(
+					{ from: currentSelector, to: candidate.raw, remainingPercent },
+					signal,
+				);
+				if (signal.aborted) return;
+				if (!shouldFallback) {
+					this.#usageReserveApprovedSelector = currentSelector;
+					return;
 				}
 			}
 
 			if (signal.aborted) return;
-			this.#usageReserveApprovedSelector = undefined;
-			await this.#recovery.applyRetryFallbackCandidate(role, fallback.selector, currentSelector, {
-				pinFallback: true,
-				apiKey: fallback.apiKey,
-				signal,
-				probeLease: fallback.probeLease,
-			});
-			transferred = true;
-		} finally {
-			if (fallback.probeLease && !transferred) this.#modelRegistry.abandonFallbackProbe(fallback.probeLease);
+			const admission = this.#modelRegistry.admitFallbackProbe(candidate.raw);
+			if (admission.status === "busy") continue;
+			const probeLease = admission.status === "probe" ? admission.lease : undefined;
+			let transferred = false;
+			try {
+				this.#usageReserveApprovedSelector = undefined;
+				await this.#recovery.applyRetryFallbackCandidate(role, candidate, currentSelector, {
+					pinFallback: true,
+					apiKey,
+					signal,
+					probeLease,
+				});
+				transferred = true;
+				return;
+			} finally {
+				if (probeLease && !transferred) this.#modelRegistry.abandonFallbackProbe(probeLease);
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -50,6 +50,8 @@ export interface ActiveRetryFallbackState {
 	originalThinkingLevel: ConfiguredThinkingLevel | undefined;
 	lastAppliedFallbackThinkingLevel: ConfiguredThinkingLevel | undefined;
 	pinned: boolean;
+	/** The current fallback model must pass admission before its next prompt. */
+	pendingAdmission?: boolean;
 	/** Present only while this session owns the selector's first live probe. */
 	probeLease?: FallbackProbeLease;
 }

--- a/packages/coding-agent/src/session/retry-fallback-chains.ts
+++ b/packages/coding-agent/src/session/retry-fallback-chains.ts
@@ -1,7 +1,7 @@
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
-import type { ModelRegistry } from "../config/model-registry";
+import type { FallbackProbeLease, ModelRegistry } from "../config/model-registry";
 import {
 	formatModelSelectorValue,
 	formatModelString,
@@ -50,6 +50,8 @@ export interface ActiveRetryFallbackState {
 	originalThinkingLevel: ConfiguredThinkingLevel | undefined;
 	lastAppliedFallbackThinkingLevel: ConfiguredThinkingLevel | undefined;
 	pinned: boolean;
+	/** Present only while this session owns the selector's first live probe. */
+	probeLease?: FallbackProbeLease;
 }
 
 const RETRY_BACKOFF_MAX_DELAY_MS = 8_000;

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1171,6 +1171,10 @@ export class SessionAdvisors {
 		failedMessages: readonly AgentMessage[],
 		signal: AbortSignal,
 	): Promise<boolean> {
+		if (advisor.retryFallback?.probeLease) {
+			this.#host.modelRegistry.abandonFallbackProbe(advisor.retryFallback.probeLease);
+			advisor.retryFallback.probeLease = undefined;
+		}
 		if (error instanceof AdvisorOutputQuarantinedError) return false;
 
 		const failedMessage = failedMessages.findLast(
@@ -1236,10 +1240,6 @@ export class SessionAdvisors {
 		if (!role || this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel).length === 0)
 			return false;
 
-		if (advisor.retryFallback?.probeLease) {
-			this.#host.modelRegistry.abandonFallbackProbe(advisor.retryFallback.probeLease);
-			advisor.retryFallback.probeLease = undefined;
-		}
 		this.#host.noteRetryFallbackCooldown(currentSelector, retryAfterMs, message);
 		for (const selector of this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
 			if (this.#host.isRetryFallbackSelectorSuppressed(selector)) continue;

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -536,7 +536,7 @@ export class SessionAdvisors {
 		for (const a of this.#advisors) {
 			a.agentUnsubscribe?.();
 			a.agentUnsubscribe = undefined;
-			this.#discardAdvisorRetryFallback(a);
+			this.#releaseAdvisorRetryFallbackProbe(a);
 			a.runtime.reset();
 			a.adviseTool.resetDeliveredNotes();
 			a.emissionGuard.reset();
@@ -883,6 +883,7 @@ export class SessionAdvisors {
 					advisorRef.adviseTool.beginUpdate(inProgress);
 					advisorRef.emissionGuard.beginUpdate();
 				},
+				beforeAdvisorDispatch: signal => this.#admitAdvisorRetryFallbackDispatch(advisorRef, signal),
 				onTurnError: (error, failedMessages, signal) =>
 					this.#recoverAdvisorTurn(advisorRef, error, failedMessages, signal),
 				onTurnSuccess: async () => {
@@ -1066,7 +1067,7 @@ export class SessionAdvisors {
 	/** Re-prime every advisor's transcript view after an in-conversation history rewrite. */
 	#resetAllAdvisorRuntimes(): void {
 		for (const a of this.#advisors) {
-			this.#discardAdvisorRetryFallback(a);
+			this.#releaseAdvisorRetryFallbackProbe(a);
 			a.runtime.reset();
 		}
 	}
@@ -1164,6 +1165,95 @@ export class SessionAdvisors {
 		const lease = advisor.retryFallback?.probeLease;
 		if (lease) this.#abandonAdvisorRetryFallbackProbe(advisor, lease);
 		advisor.retryFallbackPendingSuccess = false;
+	}
+
+	async #admitAdvisorRetryFallbackDispatch(advisor: ActiveAdvisor, signal: AbortSignal): Promise<boolean> {
+		const fallback = advisor.retryFallback;
+		if (!fallback) return true;
+		const currentSelector = formatRetryFallbackSelector(advisor.agent.state.model, advisor.thinkingLevel);
+		const parsedSelector = parseRetryFallbackSelector(currentSelector, this.#host.modelRegistry);
+		if (fallback.probeLease) this.#abandonAdvisorRetryFallbackProbe(advisor, fallback.probeLease);
+		if (!parsedSelector) return false;
+		if (this.#host.isRetryFallbackSelectorSuppressed(parsedSelector)) {
+			const switched = await this.#tryAdvisorRetryFallback(
+				advisor,
+				currentSelector,
+				advisor.agent.state.model,
+				fallback.role,
+				signal,
+			);
+			return switched && this.#admitAdvisorRetryFallbackDispatch(advisor, signal);
+		}
+		signal.throwIfAborted();
+		const admission = this.#host.modelRegistry.admitFallbackProbe(currentSelector);
+		if (admission.status === "busy") {
+			const switched = await this.#tryAdvisorRetryFallback(
+				advisor,
+				currentSelector,
+				advisor.agent.state.model,
+				fallback.role,
+				signal,
+			);
+			return switched && this.#admitAdvisorRetryFallbackDispatch(advisor, signal);
+		}
+		if (admission.status === "probe") {
+			fallback.probeLease = admission.lease;
+			advisor.retryFallbackPendingSuccess = true;
+		}
+		return true;
+	}
+
+	async #tryAdvisorRetryFallback(
+		advisor: ActiveAdvisor,
+		currentSelector: string,
+		currentModel: Model,
+		role: string,
+		signal: AbortSignal,
+	): Promise<boolean> {
+		for (const selector of this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
+			if (this.#host.isRetryFallbackSelectorSuppressed(selector)) continue;
+			const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
+			const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
+			if (!candidate || modelsAreEqual(candidate, currentModel)) continue;
+			const admission = this.#host.modelRegistry.admitFallbackProbe(selector.raw);
+			if (admission.status === "busy") continue;
+			const probeLease = admission.status === "probe" ? admission.lease : undefined;
+			let transferred = false;
+			try {
+				const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisor.providerSessionId, { signal });
+				if (!apiKey) continue;
+				signal.throwIfAborted();
+
+				const originalThinkingLevel = advisor.thinkingLevel;
+				const requestedThinkingLevel = selector.thinkingLevel ?? originalThinkingLevel;
+				const nextThinkingLevel = this.#setAdvisorModel(advisor, candidate, requestedThinkingLevel);
+				if (advisor.retryFallback) {
+					advisor.retryFallback.lastAppliedThinkingLevel = nextThinkingLevel;
+					advisor.retryFallback.probeLease = probeLease;
+				} else {
+					advisor.retryFallback = {
+						role,
+						originalSelector: currentSelector,
+						originalThinkingLevel,
+						lastAppliedThinkingLevel: nextThinkingLevel,
+						probeLease,
+					};
+				}
+				advisor.retryFallbackPendingSuccess = true;
+				this.#host.settings.getStorage()?.recordModelUsage(formatModelStringWithRouting(candidate));
+				await this.#host.emitSessionEvent({
+					type: "retry_fallback_applied",
+					from: currentSelector,
+					to: selector.raw,
+					role,
+				});
+				transferred = true;
+				return true;
+			} finally {
+				if (probeLease && !transferred) this.#abandonAdvisorRetryFallbackProbe(advisor, probeLease);
+			}
+		}
+		return false;
 	}
 
 	#discardAdvisorRetryFallback(advisor: ActiveAdvisor): void {
@@ -1270,52 +1360,7 @@ export class SessionAdvisors {
 				return false;
 
 			this.#host.noteRetryFallbackCooldown(currentSelector, retryAfterMs, message);
-			for (const selector of this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
-				if (this.#host.isRetryFallbackSelectorSuppressed(selector)) continue;
-				const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
-				const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
-				if (!candidate || modelsAreEqual(candidate, currentModel)) continue;
-				const admission = this.#host.modelRegistry.admitFallbackProbe(selector.raw);
-				if (admission.status === "busy") continue;
-				const probeLease = admission.status === "probe" ? admission.lease : undefined;
-				let transferred = false;
-				try {
-					const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisor.providerSessionId, {
-						signal,
-					});
-					if (!apiKey) continue;
-					signal.throwIfAborted();
-
-					const originalThinkingLevel = advisor.thinkingLevel;
-					const requestedThinkingLevel = selector.thinkingLevel ?? originalThinkingLevel;
-					const nextThinkingLevel = this.#setAdvisorModel(advisor, candidate, requestedThinkingLevel);
-					if (advisor.retryFallback) {
-						advisor.retryFallback.lastAppliedThinkingLevel = nextThinkingLevel;
-						advisor.retryFallback.probeLease = probeLease;
-					} else {
-						advisor.retryFallback = {
-							role,
-							originalSelector: currentSelector,
-							originalThinkingLevel,
-							lastAppliedThinkingLevel: nextThinkingLevel,
-							probeLease,
-						};
-					}
-					advisor.retryFallbackPendingSuccess = true;
-					this.#host.settings.getStorage()?.recordModelUsage(formatModelStringWithRouting(candidate));
-					await this.#host.emitSessionEvent({
-						type: "retry_fallback_applied",
-						from: currentSelector,
-						to: selector.raw,
-						role,
-					});
-					transferred = true;
-					return true;
-				} finally {
-					if (probeLease && !transferred) this.#abandonAdvisorRetryFallbackProbe(advisor, probeLease);
-				}
-			}
-			return false;
+			return this.#tryAdvisorRetryFallback(advisor, currentSelector, currentModel, role, signal);
 		} finally {
 			if (activeProbeLease && !retainActiveProbeLease) {
 				this.#abandonAdvisorRetryFallbackProbe(advisor, activeProbeLease);

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -536,6 +536,7 @@ export class SessionAdvisors {
 		for (const a of this.#advisors) {
 			a.agentUnsubscribe?.();
 			a.agentUnsubscribe = undefined;
+			this.#discardAdvisorRetryFallback(a);
 			a.runtime.reset();
 			a.adviseTool.resetDeliveredNotes();
 			a.emissionGuard.reset();
@@ -898,6 +899,7 @@ export class SessionAdvisors {
 						role: fallback.role,
 					});
 				},
+				onTurnDiscarded: () => this.#releaseAdvisorRetryFallbackProbe(advisorRef),
 				notifyFailure: error => {
 					this.#advisorStatuses.set(slug, { name: advisorName, status: "error" });
 					const message = error instanceof Error ? error.message : String(error);
@@ -1063,7 +1065,10 @@ export class SessionAdvisors {
 
 	/** Re-prime every advisor's transcript view after an in-conversation history rewrite. */
 	#resetAllAdvisorRuntimes(): void {
-		for (const a of this.#advisors) a.runtime.reset();
+		for (const a of this.#advisors) {
+			this.#discardAdvisorRetryFallback(a);
+			a.runtime.reset();
+		}
 	}
 
 	#stopAdvisorRuntime(): void {
@@ -1072,10 +1077,7 @@ export class SessionAdvisors {
 		// a closing recorder (it would reopen and resurrect an already-released file).
 		const closes: Promise<void>[] = [];
 		for (const a of this.#advisors) {
-			if (a.retryFallback?.probeLease) {
-				this.#host.modelRegistry.abandonFallbackProbe(a.retryFallback.probeLease);
-				a.retryFallback.probeLease = undefined;
-			}
+			this.#discardAdvisorRetryFallback(a);
 			a.agentUnsubscribe?.();
 			a.agentUnsubscribe = undefined;
 			a.runtime.dispose();
@@ -1125,15 +1127,13 @@ export class SessionAdvisors {
 
 		const originalSelector = parseRetryFallbackSelector(fallback.originalSelector, this.#host.modelRegistry);
 		if (!originalSelector) {
-			advisor.retryFallback = undefined;
-			advisor.retryFallbackPendingSuccess = false;
+			this.#discardAdvisorRetryFallback(advisor);
 			return;
 		}
 		const currentSelector = formatRetryFallbackSelector(advisor.agent.state.model, advisor.thinkingLevel);
 		if (currentSelector === originalSelector.raw) {
 			if (!this.#host.isRetryFallbackSelectorSuppressed(originalSelector)) {
-				advisor.retryFallback = undefined;
-				advisor.retryFallbackPendingSuccess = false;
+				this.#discardAdvisorRetryFallback(advisor);
 			}
 			return;
 		}
@@ -1157,8 +1157,25 @@ export class SessionAdvisors {
 				: advisor.thinkingLevel;
 		this.#setAdvisorModel(advisor, primaryModel, thinkingToApply);
 		this.#host.settings.getStorage()?.recordModelUsage(formatModelStringWithRouting(primaryModel));
-		advisor.retryFallback = undefined;
+		this.#discardAdvisorRetryFallback(advisor);
+	}
+
+	#releaseAdvisorRetryFallbackProbe(advisor: ActiveAdvisor): void {
+		const lease = advisor.retryFallback?.probeLease;
+		if (lease) this.#abandonAdvisorRetryFallbackProbe(advisor, lease);
 		advisor.retryFallbackPendingSuccess = false;
+	}
+
+	#discardAdvisorRetryFallback(advisor: ActiveAdvisor): void {
+		const fallback = advisor.retryFallback;
+		if (!fallback) return;
+		this.#releaseAdvisorRetryFallbackProbe(advisor);
+		const original = parseRetryFallbackSelector(fallback.originalSelector, this.#host.modelRegistry);
+		if (original) {
+			const model = this.#host.modelRegistry.find(original.provider, original.id);
+			if (model) this.#setAdvisorModel(advisor, model, fallback.originalThinkingLevel);
+		}
+		advisor.retryFallback = undefined;
 	}
 
 	#abandonAdvisorRetryFallbackProbe(advisor: ActiveAdvisor, lease: FallbackProbeLease): void {

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -60,7 +60,7 @@ import {
 	resolveAdvisorDeliveryChannel,
 	slugifyAdvisorName,
 } from "../advisor";
-import type { ModelRegistry } from "../config/model-registry";
+import type { FallbackProbeLease, ModelRegistry } from "../config/model-registry";
 import {
 	formatModelString,
 	formatModelStringWithRouting,
@@ -143,6 +143,7 @@ interface AdvisorRetryFallbackState {
 	originalSelector: string;
 	originalThinkingLevel: ThinkingLevel;
 	lastAppliedThinkingLevel: ThinkingLevel;
+	probeLease?: FallbackProbeLease;
 }
 
 interface ActiveAdvisor {
@@ -887,6 +888,10 @@ export class SessionAdvisors {
 					const fallback = advisorRef.retryFallback;
 					if (!advisorRef.retryFallbackPendingSuccess || !fallback) return;
 					advisorRef.retryFallbackPendingSuccess = false;
+					if (fallback.probeLease) {
+						this.#host.modelRegistry.markFallbackProbeHealthy(fallback.probeLease);
+						fallback.probeLease = undefined;
+					}
 					await this.#host.emitSessionEvent({
 						type: "retry_fallback_succeeded",
 						model: formatRetryFallbackSelector(advisorRef.agent.state.model, advisorRef.thinkingLevel),
@@ -1067,6 +1072,10 @@ export class SessionAdvisors {
 		// a closing recorder (it would reopen and resurrect an already-released file).
 		const closes: Promise<void>[] = [];
 		for (const a of this.#advisors) {
+			if (a.retryFallback?.probeLease) {
+				this.#host.modelRegistry.abandonFallbackProbe(a.retryFallback.probeLease);
+				a.retryFallback.probeLease = undefined;
+			}
 			a.agentUnsubscribe?.();
 			a.agentUnsubscribe = undefined;
 			a.runtime.dispose();
@@ -1227,38 +1236,53 @@ export class SessionAdvisors {
 		if (!role || this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel).length === 0)
 			return false;
 
+		if (advisor.retryFallback?.probeLease) {
+			this.#host.modelRegistry.abandonFallbackProbe(advisor.retryFallback.probeLease);
+			advisor.retryFallback.probeLease = undefined;
+		}
 		this.#host.noteRetryFallbackCooldown(currentSelector, retryAfterMs, message);
 		for (const selector of this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
 			if (this.#host.isRetryFallbackSelectorSuppressed(selector)) continue;
 			const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
 			const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
 			if (!candidate || modelsAreEqual(candidate, currentModel)) continue;
-			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisor.providerSessionId, { signal });
-			if (!apiKey) continue;
-			signal.throwIfAborted();
+			const admission = this.#host.modelRegistry.admitFallbackProbe(selector.raw);
+			if (admission.status === "busy") continue;
+			const probeLease = admission.status === "probe" ? admission.lease : undefined;
+			let transferred = false;
+			try {
+				const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisor.providerSessionId, { signal });
+				if (!apiKey) continue;
+				signal.throwIfAborted();
 
-			const originalThinkingLevel = advisor.thinkingLevel;
-			const requestedThinkingLevel = selector.thinkingLevel ?? originalThinkingLevel;
-			const nextThinkingLevel = this.#setAdvisorModel(advisor, candidate, requestedThinkingLevel);
-			if (advisor.retryFallback) {
-				advisor.retryFallback.lastAppliedThinkingLevel = nextThinkingLevel;
-			} else {
-				advisor.retryFallback = {
+				const originalThinkingLevel = advisor.thinkingLevel;
+				const requestedThinkingLevel = selector.thinkingLevel ?? originalThinkingLevel;
+				const nextThinkingLevel = this.#setAdvisorModel(advisor, candidate, requestedThinkingLevel);
+				if (advisor.retryFallback) {
+					advisor.retryFallback.lastAppliedThinkingLevel = nextThinkingLevel;
+					advisor.retryFallback.probeLease = probeLease;
+				} else {
+					advisor.retryFallback = {
+						role,
+						originalSelector: currentSelector,
+						originalThinkingLevel,
+						lastAppliedThinkingLevel: nextThinkingLevel,
+						probeLease,
+					};
+				}
+				advisor.retryFallbackPendingSuccess = true;
+				this.#host.settings.getStorage()?.recordModelUsage(formatModelStringWithRouting(candidate));
+				await this.#host.emitSessionEvent({
+					type: "retry_fallback_applied",
+					from: currentSelector,
+					to: selector.raw,
 					role,
-					originalSelector: currentSelector,
-					originalThinkingLevel,
-					lastAppliedThinkingLevel: nextThinkingLevel,
-				};
+				});
+				transferred = true;
+				return true;
+			} finally {
+				if (probeLease && !transferred) this.#host.modelRegistry.abandonFallbackProbe(probeLease);
 			}
-			advisor.retryFallbackPendingSuccess = true;
-			this.#host.settings.getStorage()?.recordModelUsage(formatModelStringWithRouting(candidate));
-			await this.#host.emitSessionEvent({
-				type: "retry_fallback_applied",
-				from: currentSelector,
-				to: selector.raw,
-				role,
-			});
-			return true;
 		}
 		return false;
 	}

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -1161,6 +1161,15 @@ export class SessionAdvisors {
 		advisor.retryFallbackPendingSuccess = false;
 	}
 
+	#abandonAdvisorRetryFallbackProbe(advisor: ActiveAdvisor, lease: FallbackProbeLease): void {
+		this.#host.modelRegistry.abandonFallbackProbe(lease);
+		const fallback = advisor.retryFallback;
+		const activeLease = fallback?.probeLease;
+		if (fallback && activeLease?.selector === lease.selector && activeLease.generation === lease.generation) {
+			fallback.probeLease = undefined;
+		}
+	}
+
 	/**
 	 * Apply the advisor's configured provider-failure fallback chain after
 	 * same-provider credential rotation has no usable sibling.
@@ -1171,120 +1180,130 @@ export class SessionAdvisors {
 		failedMessages: readonly AgentMessage[],
 		signal: AbortSignal,
 	): Promise<boolean> {
-		if (advisor.retryFallback?.probeLease) {
-			this.#host.modelRegistry.abandonFallbackProbe(advisor.retryFallback.probeLease);
-			advisor.retryFallback.probeLease = undefined;
-		}
-		if (error instanceof AdvisorOutputQuarantinedError) return false;
+		const activeProbeLease = advisor.retryFallback?.probeLease;
+		let retainActiveProbeLease = false;
+		try {
+			if (error instanceof AdvisorOutputQuarantinedError) return false;
 
-		const failedMessage = failedMessages.findLast(
-			(message): message is AssistantMessage => message.role === "assistant",
-		);
-		if (failedMessage?.stopReason !== "error") {
-			// Stream setup can reject before any assistant turn is recorded (e.g.
-			// an HTTP 429 thrown from prompt()); classify the raw error so a
-			// structural usage limit still marks the exhausted credential.
-			const message = error instanceof Error ? error.message : String(error);
-			if (!AIError.isUsageLimit(error) && !isUsageLimitOutcome(extractHttpStatusFromError(error), message)) {
-				return false;
-			}
-			const currentModel = advisor.agent.state.model;
-			const outcome = await this.#host.modelRegistry.authStorage.markUsageLimitReached(
-				currentModel.provider,
-				advisor.providerSessionId,
-				{
-					retryAfterMs: extractRetryHint(undefined, message),
-					baseUrl: currentModel.baseUrl,
-					modelId: currentModel.id,
-					signal,
-				},
+			const failedMessage = failedMessages.findLast(
+				(message): message is AssistantMessage => message.role === "assistant",
 			);
-			return outcome.switched;
-		}
-		if (failedMessage.content.some(block => block.type === "toolCall")) return false;
-
-		const currentModel = advisor.agent.state.model;
-		const message = failedMessage.errorMessage ?? (error instanceof Error ? error.message : String(error));
-		const errorId = AIError.classifyMessage({
-			api: currentModel.api,
-			errorId: failedMessage.errorId,
-			errorMessage: message,
-			errorStatus: failedMessage.errorStatus,
-		});
-		if (AIError.is(errorId, AIError.Flag.Abort) || AIError.is(errorId, AIError.Flag.UserInterrupt)) return false;
-		if (AIError.isContextOverflow(failedMessage, currentModel.contextWindow ?? 0)) return false;
-
-		const currentSelector = formatRetryFallbackSelector(currentModel, advisor.thinkingLevel);
-
-		const retryAfterMs = extractRetryHint(undefined, message);
-		if (
-			AIError.is(errorId, AIError.Flag.UsageLimit) ||
-			isUsageLimitOutcome(extractHttpStatusFromError(error), message)
-		) {
-			const outcome = await this.#host.modelRegistry.authStorage.markUsageLimitReached(
-				currentModel.provider,
-				advisor.providerSessionId,
-				{
-					retryAfterMs,
-					baseUrl: currentModel.baseUrl,
-					modelId: currentModel.id,
-					signal,
-				},
-			);
-			if (outcome.switched) return true;
-		}
-
-		const retrySettings = this.#host.settings.getGroup("retry");
-		if (!retrySettings.enabled || !retrySettings.modelFallback) return false;
-		const role = advisor.retryFallback?.role ?? this.#host.resolveRetryFallbackRole(currentSelector, currentModel);
-		if (!role || this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel).length === 0)
-			return false;
-
-		this.#host.noteRetryFallbackCooldown(currentSelector, retryAfterMs, message);
-		for (const selector of this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
-			if (this.#host.isRetryFallbackSelectorSuppressed(selector)) continue;
-			const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
-			const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
-			if (!candidate || modelsAreEqual(candidate, currentModel)) continue;
-			const admission = this.#host.modelRegistry.admitFallbackProbe(selector.raw);
-			if (admission.status === "busy") continue;
-			const probeLease = admission.status === "probe" ? admission.lease : undefined;
-			let transferred = false;
-			try {
-				const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisor.providerSessionId, { signal });
-				if (!apiKey) continue;
-				signal.throwIfAborted();
-
-				const originalThinkingLevel = advisor.thinkingLevel;
-				const requestedThinkingLevel = selector.thinkingLevel ?? originalThinkingLevel;
-				const nextThinkingLevel = this.#setAdvisorModel(advisor, candidate, requestedThinkingLevel);
-				if (advisor.retryFallback) {
-					advisor.retryFallback.lastAppliedThinkingLevel = nextThinkingLevel;
-					advisor.retryFallback.probeLease = probeLease;
-				} else {
-					advisor.retryFallback = {
-						role,
-						originalSelector: currentSelector,
-						originalThinkingLevel,
-						lastAppliedThinkingLevel: nextThinkingLevel,
-						probeLease,
-					};
+			if (failedMessage?.stopReason !== "error") {
+				// Stream setup can reject before any assistant turn is recorded (e.g.
+				// an HTTP 429 thrown from prompt()); classify the raw error so a
+				// structural usage limit still marks the exhausted credential.
+				const message = error instanceof Error ? error.message : String(error);
+				if (!AIError.isUsageLimit(error) && !isUsageLimitOutcome(extractHttpStatusFromError(error), message)) {
+					return false;
 				}
-				advisor.retryFallbackPendingSuccess = true;
-				this.#host.settings.getStorage()?.recordModelUsage(formatModelStringWithRouting(candidate));
-				await this.#host.emitSessionEvent({
-					type: "retry_fallback_applied",
-					from: currentSelector,
-					to: selector.raw,
-					role,
-				});
-				transferred = true;
-				return true;
-			} finally {
-				if (probeLease && !transferred) this.#host.modelRegistry.abandonFallbackProbe(probeLease);
+				const currentModel = advisor.agent.state.model;
+				const outcome = await this.#host.modelRegistry.authStorage.markUsageLimitReached(
+					currentModel.provider,
+					advisor.providerSessionId,
+					{
+						retryAfterMs: extractRetryHint(undefined, message),
+						baseUrl: currentModel.baseUrl,
+						modelId: currentModel.id,
+						signal,
+					},
+				);
+				if (outcome.switched) retainActiveProbeLease = true;
+				return outcome.switched;
+			}
+			if (failedMessage.content.some(block => block.type === "toolCall")) return false;
+
+			const currentModel = advisor.agent.state.model;
+			const message = failedMessage.errorMessage ?? (error instanceof Error ? error.message : String(error));
+			const errorId = AIError.classifyMessage({
+				api: currentModel.api,
+				errorId: failedMessage.errorId,
+				errorMessage: message,
+				errorStatus: failedMessage.errorStatus,
+			});
+			if (AIError.is(errorId, AIError.Flag.Abort) || AIError.is(errorId, AIError.Flag.UserInterrupt)) return false;
+			if (AIError.isContextOverflow(failedMessage, currentModel.contextWindow ?? 0)) return false;
+
+			const currentSelector = formatRetryFallbackSelector(currentModel, advisor.thinkingLevel);
+
+			const retryAfterMs = extractRetryHint(undefined, message);
+			if (
+				AIError.is(errorId, AIError.Flag.UsageLimit) ||
+				isUsageLimitOutcome(extractHttpStatusFromError(error), message)
+			) {
+				const outcome = await this.#host.modelRegistry.authStorage.markUsageLimitReached(
+					currentModel.provider,
+					advisor.providerSessionId,
+					{
+						retryAfterMs,
+						baseUrl: currentModel.baseUrl,
+						modelId: currentModel.id,
+						signal,
+					},
+				);
+				if (outcome.switched) {
+					retainActiveProbeLease = true;
+					return true;
+				}
+			}
+
+			const retrySettings = this.#host.settings.getGroup("retry");
+			if (!retrySettings.enabled || !retrySettings.modelFallback) return false;
+			const role = advisor.retryFallback?.role ?? this.#host.resolveRetryFallbackRole(currentSelector, currentModel);
+			if (!role || this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel).length === 0)
+				return false;
+
+			this.#host.noteRetryFallbackCooldown(currentSelector, retryAfterMs, message);
+			for (const selector of this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel)) {
+				if (this.#host.isRetryFallbackSelectorSuppressed(selector)) continue;
+				const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
+				const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
+				if (!candidate || modelsAreEqual(candidate, currentModel)) continue;
+				const admission = this.#host.modelRegistry.admitFallbackProbe(selector.raw);
+				if (admission.status === "busy") continue;
+				const probeLease = admission.status === "probe" ? admission.lease : undefined;
+				let transferred = false;
+				try {
+					const apiKey = await this.#host.modelRegistry.getApiKey(candidate, advisor.providerSessionId, {
+						signal,
+					});
+					if (!apiKey) continue;
+					signal.throwIfAborted();
+
+					const originalThinkingLevel = advisor.thinkingLevel;
+					const requestedThinkingLevel = selector.thinkingLevel ?? originalThinkingLevel;
+					const nextThinkingLevel = this.#setAdvisorModel(advisor, candidate, requestedThinkingLevel);
+					if (advisor.retryFallback) {
+						advisor.retryFallback.lastAppliedThinkingLevel = nextThinkingLevel;
+						advisor.retryFallback.probeLease = probeLease;
+					} else {
+						advisor.retryFallback = {
+							role,
+							originalSelector: currentSelector,
+							originalThinkingLevel,
+							lastAppliedThinkingLevel: nextThinkingLevel,
+							probeLease,
+						};
+					}
+					advisor.retryFallbackPendingSuccess = true;
+					this.#host.settings.getStorage()?.recordModelUsage(formatModelStringWithRouting(candidate));
+					await this.#host.emitSessionEvent({
+						type: "retry_fallback_applied",
+						from: currentSelector,
+						to: selector.raw,
+						role,
+					});
+					transferred = true;
+					return true;
+				} finally {
+					if (probeLease && !transferred) this.#abandonAdvisorRetryFallbackProbe(advisor, probeLease);
+				}
+			}
+			return false;
+		} finally {
+			if (activeProbeLease && !retainActiveProbeLease) {
+				this.#abandonAdvisorRetryFallbackProbe(advisor, activeProbeLease);
 			}
 		}
-		return false;
 	}
 
 	async #promoteAdvisorContextModel(

--- a/packages/coding-agent/src/session/stream-guards.ts
+++ b/packages/coding-agent/src/session/stream-guards.ts
@@ -32,6 +32,7 @@ export interface StreamGuardsHost {
 	localProtocolOptions(): LocalProtocolOptions;
 	emitNotice(level: "info" | "warning" | "error", message: string, source?: string): void;
 	schedulePostPromptTask(task: (signal: AbortSignal) => Promise<void>): void;
+	continueAgent(): Promise<void>;
 	discardAssistantTurn(message: AssistantMessage): void;
 }
 
@@ -408,7 +409,7 @@ export class LoopGuards {
 				"agent",
 			);
 			try {
-				await this.#host.agent.continue();
+				await this.#host.continueAgent();
 			} catch (error) {
 				logger.warn("gemini tool-call reminder continue failed", { error: String(error) });
 			}

--- a/packages/coding-agent/src/session/ttsr-coordinator.ts
+++ b/packages/coding-agent/src/session/ttsr-coordinator.ts
@@ -34,6 +34,7 @@ export interface TtsrCoordinatorHost {
 	emitSessionEvent(event: AgentSessionEvent): Promise<void>;
 	schedulePostPromptTask(task: (signal: AbortSignal) => Promise<void>, options?: { delayMs?: number }): void;
 	scheduleAgentContinue(options: TtsrContinueOptions): void;
+	continueAgent(): Promise<void>;
 	promptGeneration(): number;
 }
 
@@ -452,7 +453,7 @@ export class TtsrCoordinator {
 					this.#markInjected(details.rules);
 				}
 				try {
-					await this.#host.agent.continue();
+					await this.#host.continueAgent();
 				} catch {
 					this.resolveResume();
 				}

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -540,6 +540,7 @@ export class TurnRecovery {
 			});
 			this.#clearPendingRecoveredRetryErrors();
 			this.#retryAttempt = 0;
+			this.abandonActiveRetryFallbackProbe();
 			this.resolveRetry();
 			// A zero-content turn carries no transcript value, while its provider usage
 			// can anchor the next prompt at the full failed-request size and re-trigger
@@ -1042,8 +1043,17 @@ export class TurnRecovery {
 		const fallback = this.#activeRetryFallback;
 		const lease = fallback?.probeLease;
 		if (!lease) return;
+		this.#abandonRetryFallbackProbe(lease);
+	}
+
+	/** Release one captured lease without clearing a newer fallback owner. */
+	#abandonRetryFallbackProbe(lease: FallbackProbeLease): void {
 		this.#host.modelRegistry.abandonFallbackProbe(lease);
-		fallback.probeLease = undefined;
+		const fallback = this.#activeRetryFallback;
+		const activeLease = fallback?.probeLease;
+		if (fallback && activeLease?.selector === lease.selector && activeLease.generation === lease.generation) {
+			fallback.probeLease = undefined;
+		}
 	}
 
 	/** Checks whether a fallback selector remains in cooldown. */
@@ -1666,10 +1676,11 @@ export class TurnRecovery {
 		// continuation that still fails locally must close the retry saga —
 		// otherwise auto_retry_end never fires, retryPromise stays pending, and
 		// the in-flight prompt() (and the TUI retry indicator) hang forever.
+		const probeLease = this.#activeRetryFallback?.probeLease;
 		this.#host.scheduleAgentContinue({
 			delayMs: 1,
 			generation,
-			onError: error => void this.#failRetryAfterLocalContinueError(message, error),
+			onError: error => void this.#failRetryAfterLocalContinueError(message, error, probeLease),
 		});
 
 		return true;
@@ -1701,7 +1712,12 @@ export class TurnRecovery {
 	 * closing `auto_retry_end` so subscribers stop showing retry progress, and
 	 * resolve the retry promise so the in-flight prompt() unwinds (issue #5382).
 	 */
-	async #failRetryAfterLocalContinueError(message: AssistantMessage, error: unknown): Promise<void> {
+	async #failRetryAfterLocalContinueError(
+		message: AssistantMessage,
+		error: unknown,
+		probeLease: FallbackProbeLease | undefined,
+	): Promise<void> {
+		if (probeLease) this.#abandonRetryFallbackProbe(probeLease);
 		if (this.#retryAttempt === 0) return;
 		const attempt = this.#retryAttempt;
 		this.#retryAttempt = 0;

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1300,19 +1300,34 @@ export class TurnRecovery {
 		if (!model) return false;
 		const baseModel = this.#host.modelRegistry.find("fireworks", toFireworksBaseModelId(model.id));
 		if (!baseModel) return false;
-		const apiKey = await this.#host.modelRegistry.getApiKey(baseModel, this.#host.sessionId());
-		if (!apiKey) return false;
 		const baseSelector = formatModelStringWithRouting(baseModel);
-		await this.#host.setModelWithProviderSessionReset(baseModel);
-		this.#host.sessionManager.appendModelChange(baseSelector, EPHEMERAL_MODEL_CHANGE_ROLE);
-		this.#host.settings.getStorage()?.recordModelUsage(baseSelector);
-		await this.#host.emitSessionEvent({
-			type: "retry_fallback_applied",
-			from: currentSelector,
-			to: baseSelector,
-			role: "fireworks-fast",
-		});
-		return true;
+		const admission = this.#host.modelRegistry.admitFallbackProbe(baseSelector);
+		if (admission.status === "busy") return false;
+		const probeLease = admission.status === "probe" ? admission.lease : undefined;
+		let transferred = false;
+		const generation = this.#host.promptGeneration();
+		try {
+			const apiKey = await this.#host.modelRegistry.getApiKey(baseModel, this.#host.sessionId());
+			if (!apiKey) return false;
+			if (this.#host.isDisposed() || this.#host.abortInProgress() || this.#host.promptGeneration() !== generation) {
+				return false;
+			}
+			const applied = await this.applyRetryFallbackCandidate(
+				"fireworks-fast",
+				{
+					raw: baseSelector,
+					provider: baseModel.provider,
+					id: baseModel.id,
+					thinkingLevel: undefined,
+				},
+				currentSelector,
+				{ pinFallback: true, apiKey, probeLease },
+			);
+			transferred = applied;
+			return applied;
+		} finally {
+			if (probeLease && !transferred) this.#host.modelRegistry.abandonFallbackProbe(probeLease);
+		}
 	}
 
 	async #maybeRestoreRetryFallbackPrimary(): Promise<void> {

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -21,7 +21,7 @@ import * as AIError from "@oh-my-pi/pi-ai/error";
 import { kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { isFireworksFastModelId, toFireworksBaseModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
 import { extractRetryHint, logger, prompt } from "@oh-my-pi/pi-utils";
-import type { ModelRegistry } from "../config/model-registry";
+import type { FallbackProbeLease, ModelRegistry } from "../config/model-registry";
 import { formatModelStringWithRouting, resolveModelOverride } from "../config/model-resolver";
 import type { Settings } from "../config/settings";
 import type { RecoveredRetryError } from "../extensibility/shared-events";
@@ -222,14 +222,14 @@ export class TurnRecovery {
 
 	/** Closes a successful retry saga and annotates recovered persisted errors. */
 	async onAssistantSettledSuccessfully(message: AssistantMessage): Promise<void> {
-		if (
-			message.stopReason === "error" ||
-			message.stopReason === "aborted" ||
-			this.#isEmptyAssistantStop(message) ||
-			this.#retryAttempt === 0
-		) {
+		if (message.stopReason === "error" || message.stopReason === "aborted" || this.#isEmptyAssistantStop(message)) {
 			return;
 		}
+		if (this.#activeRetryFallback?.probeLease) {
+			this.#host.modelRegistry.markFallbackProbeHealthy(this.#activeRetryFallback.probeLease);
+			this.#activeRetryFallback.probeLease = undefined;
+		}
+		if (this.#retryAttempt === 0) return;
 		const model = this.#host.model();
 		if (this.#activeRetryFallback && model) {
 			await this.#host.emitSessionEvent({
@@ -1025,7 +1025,17 @@ export class TurnRecovery {
 
 	/** Clears fallback ownership after an explicit model change. */
 	clearActiveRetryFallback(): void {
+		this.abandonActiveRetryFallbackProbe();
 		this.#activeRetryFallback = undefined;
+	}
+
+	/** Release an unfinished first-probe lease without changing fallback ownership. */
+	abandonActiveRetryFallbackProbe(): void {
+		const fallback = this.#activeRetryFallback;
+		const lease = fallback?.probeLease;
+		if (!lease) return;
+		this.#host.modelRegistry.abandonFallbackProbe(lease);
+		fallback.probeLease = undefined;
 	}
 
 	/** Checks whether a fallback selector remains in cooldown. */
@@ -1035,6 +1045,13 @@ export class TurnRecovery {
 
 	/** Records the cooldown that should suppress a failing selector. */
 	noteRetryFallbackCooldown(currentSelector: string, retryAfterMs: number | undefined, errorMessage: string): void {
+		const fallback = this.#activeRetryFallback;
+		if (
+			fallback?.probeLease &&
+			this.#host.modelRegistry.abandonFallbackProbeForSelector(fallback.probeLease, currentSelector)
+		) {
+			fallback.probeLease = undefined;
+		}
 		let cooldownMs = retryAfterMs;
 		if (!cooldownMs || cooldownMs <= 0) {
 			const reason = parseRateLimitReason(errorMessage);
@@ -1075,7 +1092,7 @@ export class TurnRecovery {
 		role: string,
 		selector: RetryFallbackSelector,
 		currentSelector: string,
-		options?: { pinFallback?: boolean; apiKey?: string; signal?: AbortSignal },
+		options?: { pinFallback?: boolean; apiKey?: string; signal?: AbortSignal; probeLease?: FallbackProbeLease },
 	): Promise<void> {
 		const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
 		const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
@@ -1112,10 +1129,13 @@ export class TurnRecovery {
 				originalThinkingLevel: currentThinkingLevel,
 				lastAppliedFallbackThinkingLevel: nextThinkingLevel,
 				pinned: options?.pinFallback === true,
+				probeLease: options?.probeLease,
 			};
 		} else {
+			this.abandonActiveRetryFallbackProbe();
 			this.#activeRetryFallback.lastAppliedFallbackThinkingLevel = nextThinkingLevel;
 			this.#activeRetryFallback.pinned = this.#activeRetryFallback.pinned || options?.pinFallback === true;
+			this.#activeRetryFallback.probeLease = options?.probeLease;
 		}
 		await this.#host.emitSessionEvent({
 			type: "retry_fallback_applied",
@@ -1138,10 +1158,23 @@ export class TurnRecovery {
 			// A candidate whose effort floor exceeds the per-spawn ceiling would be
 			// clamped UP past the cap by its model floor — skip it entirely.
 			if (ceiling !== undefined && !modelSupportsEffortCeiling(candidate, ceiling)) continue;
-			const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId());
-			if (!apiKey) continue;
-			await this.applyRetryFallbackCandidate(role, selector, currentSelector, options);
-			return true;
+			const admission = this.#host.modelRegistry.admitFallbackProbe(selector.raw);
+			if (admission.status === "busy") continue;
+			const probeLease = admission.status === "probe" ? admission.lease : undefined;
+			let transferred = false;
+			try {
+				const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId());
+				if (!apiKey) continue;
+				await this.applyRetryFallbackCandidate(role, selector, currentSelector, {
+					...options,
+					apiKey,
+					probeLease,
+				});
+				transferred = true;
+				return true;
+			} finally {
+				if (probeLease && !transferred) this.#host.modelRegistry.abandonFallbackProbe(probeLease);
+			}
 		}
 
 		return false;

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1104,7 +1104,9 @@ export class TurnRecovery {
 		selector: RetryFallbackSelector,
 		currentSelector: string,
 		options?: { pinFallback?: boolean; apiKey?: string; signal?: AbortSignal; probeLease?: FallbackProbeLease },
-	): Promise<void> {
+	): Promise<boolean> {
+		const generation = this.#host.promptGeneration();
+		const probeLease = options?.probeLease;
 		const resolved = resolveModelOverride([selector.raw], this.#host.modelRegistry, this.#host.settings);
 		const candidate = resolved.model ?? this.#host.modelRegistry.find(selector.provider, selector.id);
 		if (!candidate) {
@@ -1115,7 +1117,10 @@ export class TurnRecovery {
 		if (!apiKey) {
 			throw new Error(`No API key for retry fallback ${selector.raw}`);
 		}
-		if (options?.signal?.aborted) return;
+		if (this.#retryFallbackApplicationCancelled(options?.signal, generation)) {
+			if (probeLease) this.#host.modelRegistry.abandonFallbackProbe(probeLease);
+			return false;
+		}
 
 		// Capture the configured selector (auto-aware) so a fallback chain preserves
 		// `auto` instead of collapsing it to the level it resolved to this turn.
@@ -1133,6 +1138,8 @@ export class TurnRecovery {
 		this.#host.sessionManager.appendModelChange(candidateSelector, EPHEMERAL_MODEL_CHANGE_ROLE);
 		this.#host.settings.getStorage()?.recordModelUsage(candidateSelector);
 		this.#host.setThinkingLevel(nextThinkingLevel);
+		const cancelledAfterSwitch = this.#retryFallbackApplicationCancelled(options?.signal, generation);
+		if (cancelledAfterSwitch && probeLease) this.#host.modelRegistry.abandonFallbackProbe(probeLease);
 		if (!this.#activeRetryFallback) {
 			this.#activeRetryFallback = {
 				role,
@@ -1140,20 +1147,45 @@ export class TurnRecovery {
 				originalThinkingLevel: currentThinkingLevel,
 				lastAppliedFallbackThinkingLevel: nextThinkingLevel,
 				pinned: options?.pinFallback === true,
-				probeLease: options?.probeLease,
+				pendingAdmission: cancelledAfterSwitch,
+				probeLease: cancelledAfterSwitch ? undefined : probeLease,
 			};
 		} else {
 			this.abandonActiveRetryFallbackProbe();
 			this.#activeRetryFallback.lastAppliedFallbackThinkingLevel = nextThinkingLevel;
 			this.#activeRetryFallback.pinned = this.#activeRetryFallback.pinned || options?.pinFallback === true;
-			this.#activeRetryFallback.probeLease = options?.probeLease;
+			this.#activeRetryFallback.pendingAdmission = cancelledAfterSwitch;
+			this.#activeRetryFallback.probeLease = cancelledAfterSwitch ? undefined : probeLease;
 		}
-		await this.#host.emitSessionEvent({
-			type: "retry_fallback_applied",
-			from: currentSelector,
-			to: selector.raw,
-			role,
-		});
+		if (cancelledAfterSwitch) return false;
+		try {
+			await this.#host.emitSessionEvent({
+				type: "retry_fallback_applied",
+				from: currentSelector,
+				to: selector.raw,
+				role,
+			});
+		} catch (error) {
+			if (probeLease) {
+				const fallback = this.#activeRetryFallback;
+				const activeLease = fallback?.probeLease;
+				const ownsExactLease =
+					activeLease?.selector === probeLease.selector && activeLease.generation === probeLease.generation;
+				this.#abandonRetryFallbackProbe(probeLease);
+				if (fallback && ownsExactLease) fallback.pendingAdmission = true;
+			}
+			throw error;
+		}
+		return true;
+	}
+
+	#retryFallbackApplicationCancelled(signal: AbortSignal | undefined, generation: number): boolean {
+		return (
+			signal?.aborted === true ||
+			this.#host.isDisposed() ||
+			this.#host.abortInProgress() ||
+			this.#host.promptGeneration() !== generation
+		);
 	}
 
 	async #tryRetryModelFallback(currentSelector: string, options?: { pinFallback?: boolean }): Promise<boolean> {
@@ -1184,13 +1216,13 @@ export class TurnRecovery {
 				) {
 					return false;
 				}
-				await this.applyRetryFallbackCandidate(role, selector, currentSelector, {
+				const applied = await this.applyRetryFallbackCandidate(role, selector, currentSelector, {
 					...options,
 					apiKey,
 					probeLease,
 				});
-				transferred = true;
-				return true;
+				transferred = applied;
+				return applied;
 			} finally {
 				if (probeLease && !transferred) this.#host.modelRegistry.abandonFallbackProbe(probeLease);
 			}
@@ -1776,18 +1808,22 @@ export class TurnRecovery {
 		for (;;) {
 			const fallback = this.#activeRetryFallback;
 			const probeLease = fallback?.probeLease;
-			if (fallback && probeLease) {
+			if (fallback && (fallback.pendingAdmission || probeLease)) {
 				const currentModel = this.#host.model();
 				const currentSelector = currentModel
 					? formatRetryFallbackSelector(currentModel, this.#host.thinkingLevel())
-					: probeLease.selector;
-				this.#abandonRetryFallbackProbe(probeLease);
+					: probeLease?.selector;
+				if (!currentSelector) throw new Error("Fallback admission requires an active model");
+				if (probeLease) this.#abandonRetryFallbackProbe(probeLease);
 				const admission = this.#host.modelRegistry.admitFallbackProbe(currentSelector);
 				if (admission.status === "probe") {
 					fallback.probeLease = admission.lease;
+					fallback.pendingAdmission = false;
+				} else if (admission.status === "healthy") {
+					fallback.pendingAdmission = false;
 				} else if (admission.status === "busy") {
 					if (!(await this.#tryRetryModelFallback(currentSelector, { pinFallback: fallback.pinned }))) {
-						throw new Error(`Fallback probe already in progress for ${probeLease.selector}`);
+						throw new Error(`Fallback probe already in progress for ${currentSelector}`);
 					}
 				}
 			}

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1873,12 +1873,20 @@ export class TurnRecovery {
 		for (;;) {
 			const fallback = this.#activeRetryFallback;
 			const probeLease = fallback?.probeLease;
-			if (fallback && (fallback.pendingAdmission || probeLease)) {
+			if (fallback) {
 				const currentModel = this.#host.model();
 				const currentSelector = currentModel
 					? formatRetryFallbackSelector(currentModel, this.#host.thinkingLevel())
 					: probeLease?.selector;
 				if (!currentSelector) throw new Error("Fallback admission requires an active model");
+				const parsedSelector = parseRetryFallbackSelector(currentSelector, this.#host.modelRegistry);
+				if (parsedSelector && this.isRetryFallbackSelectorSuppressed(parsedSelector)) {
+					if (probeLease) this.#abandonRetryFallbackProbe(probeLease);
+					if (!(await this.#tryRetryModelFallback(currentSelector, { pinFallback: fallback.pinned }))) {
+						throw new Error(`No admitted fallback remains after ${currentSelector}`);
+					}
+					continue;
+				}
 				if (probeLease) this.#abandonRetryFallbackProbe(probeLease);
 				const admission = this.#host.modelRegistry.admitFallbackProbe(currentSelector);
 				if (admission.status === "probe") {
@@ -1890,6 +1898,7 @@ export class TurnRecovery {
 					if (!(await this.#tryRetryModelFallback(currentSelector, { pinFallback: fallback.pinned }))) {
 						throw new Error(`Fallback probe already in progress for ${currentSelector}`);
 					}
+					continue;
 				}
 			}
 			try {

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -172,6 +172,7 @@ export class TurnRecovery {
 	#retryPromise: Promise<void> | undefined;
 	#retryResolve: (() => void) | undefined;
 	#activeRetryFallback: ActiveRetryFallbackState | undefined;
+	#dispatchedRetryFallbackProbe: FallbackProbeLease | undefined;
 	#pendingRecoveredRetryErrors: PendingRecoveredRetryError[] = [];
 	#usageLimitOutcomes = new WeakMap<AssistantMessage, Promise<UsageLimitOutcome>>();
 	#emptyStopRetryCount = 0;
@@ -222,13 +223,16 @@ export class TurnRecovery {
 
 	/** Closes a successful retry saga and annotates recovered persisted errors. */
 	async onAssistantSettledSuccessfully(message: AssistantMessage): Promise<void> {
-		if (message.stopReason === "error" || message.stopReason === "aborted" || this.#isEmptyAssistantStop(message)) {
+		if (message.stopReason === "error" || message.stopReason === "aborted") {
 			return;
 		}
-		if (this.#activeRetryFallback?.probeLease) {
-			this.#host.modelRegistry.markFallbackProbeHealthy(this.#activeRetryFallback.probeLease);
-			this.#activeRetryFallback.probeLease = undefined;
+		if (this.#isEmptyAssistantStop(message)) {
+			if (message.stopReason === "stop" && this.#acceptTerminalEmptyStopForPrompt) {
+				this.#markMatchingRetryFallbackProbeHealthy(message);
+			}
+			return;
 		}
+		this.#markMatchingRetryFallbackProbeHealthy(message);
 		if (this.#retryAttempt === 0) return;
 		const model = this.#host.model();
 		if (this.#activeRetryFallback && model) {
@@ -252,7 +256,7 @@ export class TurnRecovery {
 	/** Closes a failed retry saga when no compaction continuation took ownership. */
 	async onErrorSettledWithoutRetry(message: AssistantMessage, compaction: RecoveryCompactionResult): Promise<void> {
 		if (message.stopReason !== "error" || compaction.continuationScheduled) return;
-		this.abandonActiveRetryFallbackProbe();
+		this.#abandonMatchingRetryFallbackProbe(message);
 		if (this.#retryAttempt === 0) return;
 		const attempt = this.#retryAttempt;
 		this.#retryAttempt = 0;
@@ -268,7 +272,7 @@ export class TurnRecovery {
 	/** Releases a failed probe after abort handling declines every continuation. */
 	onAbortSettledWithoutRetry(message: AssistantMessage): void {
 		if (message.stopReason !== "aborted") return;
-		this.abandonActiveRetryFallbackProbe();
+		this.#abandonMatchingRetryFallbackProbe(message);
 	}
 
 	/** Persists an otherwise skipped terminal empty error turn. */
@@ -1046,6 +1050,52 @@ export class TurnRecovery {
 		this.#abandonRetryFallbackProbe(lease);
 	}
 
+	/** Release the current lease and require fresh admission at the next provider dispatch. */
+	deferActiveRetryFallbackProbe(): void {
+		const fallback = this.#activeRetryFallback;
+		const lease = fallback?.probeLease;
+		if (!fallback || !lease) return;
+		this.#abandonRetryFallbackProbe(lease);
+		fallback.pendingAdmission = true;
+	}
+
+	#markMatchingRetryFallbackProbeHealthy(_message: AssistantMessage): void {
+		const fallback = this.#activeRetryFallback;
+		const lease = this.#settledRetryFallbackProbe(_message);
+		const activeLease = fallback?.probeLease;
+		if (
+			!fallback ||
+			!lease ||
+			activeLease?.selector !== lease.selector ||
+			activeLease.generation !== lease.generation
+		)
+			return;
+		this.#host.modelRegistry.markFallbackProbeHealthy(lease);
+		fallback.probeLease = undefined;
+	}
+
+	#abandonMatchingRetryFallbackProbe(_message: AssistantMessage): void {
+		const fallback = this.#activeRetryFallback;
+		const lease = this.#settledRetryFallbackProbe(_message);
+		const activeLease = fallback?.probeLease;
+		if (
+			!fallback ||
+			!lease ||
+			activeLease?.selector !== lease.selector ||
+			activeLease.generation !== lease.generation
+		)
+			return;
+		this.#abandonRetryFallbackProbe(lease);
+	}
+
+	#settledRetryFallbackProbe(message: AssistantMessage): FallbackProbeLease | undefined {
+		if (this.#dispatchedRetryFallbackProbe) return this.#dispatchedRetryFallbackProbe;
+		const lease = this.#activeRetryFallback?.probeLease;
+		if (!lease) return undefined;
+		const selector = parseRetryFallbackSelector(lease.selector, this.#host.modelRegistry);
+		return selector?.provider === message.provider && selector.id === message.model ? lease : undefined;
+	}
+
 	/** Release one captured lease without clearing a newer fallback owner. */
 	#abandonRetryFallbackProbe(lease: FallbackProbeLease): void {
 		this.#host.modelRegistry.abandonFallbackProbe(lease);
@@ -1818,7 +1868,7 @@ export class TurnRecovery {
 		this.resolveRetry();
 	}
 
-	async #promptAgentWithIdleRetry(messages: AgentMessage[], options?: { toolChoice?: ToolChoice }): Promise<void> {
+	async #runAgentWithIdleRetry(dispatch: () => Promise<void>): Promise<void> {
 		const deadline = Date.now() + 30_000;
 		for (;;) {
 			const fallback = this.#activeRetryFallback;
@@ -1843,18 +1893,37 @@ export class TurnRecovery {
 				}
 			}
 			try {
-				await this.#host.agent.prompt(messages, options);
+				const dispatchedLease = this.#activeRetryFallback?.probeLease;
+				this.#dispatchedRetryFallbackProbe = dispatchedLease;
+				try {
+					await dispatch();
+				} finally {
+					if (this.#dispatchedRetryFallbackProbe === dispatchedLease) {
+						this.#dispatchedRetryFallbackProbe = undefined;
+					}
+				}
 				return;
 			} catch (err) {
 				if (!(err instanceof AgentBusyError)) {
+					this.deferActiveRetryFallbackProbe();
 					throw err;
 				}
 				if (Date.now() >= deadline) {
+					this.deferActiveRetryFallbackProbe();
 					throw new Error("Timed out waiting for prior agent run to finish before prompting.");
 				}
 				await this.#host.agent.waitForIdle();
 			}
 		}
+	}
+
+	async #promptAgentWithIdleRetry(messages: AgentMessage[], options?: { toolChoice?: ToolChoice }): Promise<void> {
+		await this.#runAgentWithIdleRetry(() => this.#host.agent.prompt(messages, options));
+	}
+
+	/** Revalidates fallback admission immediately before an agent continuation. */
+	continueAgentWithIdleRetry(): Promise<void> {
+		return this.#runAgentWithIdleRetry(() => this.#host.agent.continue());
 	}
 
 	/** Whether auto-retry is currently in progress */

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -251,7 +251,9 @@ export class TurnRecovery {
 
 	/** Closes a failed retry saga when no compaction continuation took ownership. */
 	async onErrorSettledWithoutRetry(message: AssistantMessage, compaction: RecoveryCompactionResult): Promise<void> {
-		if (message.stopReason !== "error" || this.#retryAttempt === 0 || compaction.continuationScheduled) return;
+		if (message.stopReason !== "error" || compaction.continuationScheduled) return;
+		this.abandonActiveRetryFallbackProbe();
+		if (this.#retryAttempt === 0) return;
 		const attempt = this.#retryAttempt;
 		this.#retryAttempt = 0;
 		await this.#host.emitSessionEvent({
@@ -1045,13 +1047,6 @@ export class TurnRecovery {
 
 	/** Records the cooldown that should suppress a failing selector. */
 	noteRetryFallbackCooldown(currentSelector: string, retryAfterMs: number | undefined, errorMessage: string): void {
-		const fallback = this.#activeRetryFallback;
-		if (
-			fallback?.probeLease &&
-			this.#host.modelRegistry.abandonFallbackProbeForSelector(fallback.probeLease, currentSelector)
-		) {
-			fallback.probeLease = undefined;
-		}
 		let cooldownMs = retryAfterMs;
 		if (!cooldownMs || cooldownMs <= 0) {
 			const reason = parseRateLimitReason(errorMessage);
@@ -1162,9 +1157,17 @@ export class TurnRecovery {
 			if (admission.status === "busy") continue;
 			const probeLease = admission.status === "probe" ? admission.lease : undefined;
 			let transferred = false;
+			const generation = this.#host.promptGeneration();
 			try {
 				const apiKey = await this.#host.modelRegistry.getApiKey(candidate, this.#host.sessionId());
 				if (!apiKey) continue;
+				if (
+					this.#host.isDisposed() ||
+					this.#host.abortInProgress() ||
+					this.#host.promptGeneration() !== generation
+				) {
+					return false;
+				}
 				await this.applyRetryFallbackCandidate(role, selector, currentSelector, {
 					...options,
 					apiKey,
@@ -1472,6 +1475,14 @@ export class TurnRecovery {
 			// last resort is for provider failures, not classifier decisions.
 			if (allowModelFallback && retrySettings.modelFallback && !(retryBudgetExhausted && classifierRefusal)) {
 				if (!classifierRefusal) {
+					const activeFallback = this.#activeRetryFallback;
+					const activeLease = activeFallback?.probeLease;
+					if (
+						activeLease &&
+						this.#host.modelRegistry.abandonFallbackProbeForSelector(activeLease, currentSelector)
+					) {
+						activeFallback.probeLease = undefined;
+					}
 					this.noteRetryFallbackCooldown(currentSelector, parsedRetryAfterMs, errorMessage);
 				}
 				switchedModel = await this.#tryRetryModelFallback(currentSelector, { pinFallback: classifierRefusal });

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -265,6 +265,12 @@ export class TurnRecovery {
 		this.#clearPendingRecoveredRetryErrors();
 	}
 
+	/** Releases a failed probe after abort handling declines every continuation. */
+	onAbortSettledWithoutRetry(message: AssistantMessage): void {
+		if (message.stopReason !== "aborted") return;
+		this.abandonActiveRetryFallbackProbe();
+	}
+
 	/** Persists an otherwise skipped terminal empty error turn. */
 	persistTerminalEmptyErrorTurn(message: AssistantMessage): Promise<void> {
 		return this.#persistTerminalEmptyErrorTurn(message);

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1774,6 +1774,23 @@ export class TurnRecovery {
 	async #promptAgentWithIdleRetry(messages: AgentMessage[], options?: { toolChoice?: ToolChoice }): Promise<void> {
 		const deadline = Date.now() + 30_000;
 		for (;;) {
+			const fallback = this.#activeRetryFallback;
+			const probeLease = fallback?.probeLease;
+			if (fallback && probeLease) {
+				const currentModel = this.#host.model();
+				const currentSelector = currentModel
+					? formatRetryFallbackSelector(currentModel, this.#host.thinkingLevel())
+					: probeLease.selector;
+				this.#abandonRetryFallbackProbe(probeLease);
+				const admission = this.#host.modelRegistry.admitFallbackProbe(currentSelector);
+				if (admission.status === "probe") {
+					fallback.probeLease = admission.lease;
+				} else if (admission.status === "busy") {
+					if (!(await this.#tryRetryModelFallback(currentSelector, { pinFallback: fallback.pinned }))) {
+						throw new Error(`Fallback probe already in progress for ${probeLease.selector}`);
+					}
+				}
+			}
 			try {
 				await this.#host.agent.prompt(messages, options);
 				return;

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -3566,6 +3566,7 @@ describe("advisor", () => {
 		it("surfaces a persistent classifier refusal after one stripped resend", async () => {
 			const promptInputs: string[] = [];
 			const failures: unknown[] = [];
+			let discardedTurns = 0;
 			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
 			const agent: AdvisorAgent = {
 				prompt: async input => {
@@ -3604,6 +3605,9 @@ describe("advisor", () => {
 					snapshotMessages: () => messages,
 					enqueueAdvice: () => {},
 					notifyFailure: error => failures.push(error),
+					onTurnDiscarded: () => {
+						discardedTurns += 1;
+					},
 				},
 				0,
 			);
@@ -3615,6 +3619,7 @@ describe("advisor", () => {
 			expect(promptInputs[0]).toContain("private reasoning");
 			expect(promptInputs[1]).not.toContain("private reasoning");
 			expect(failures).toHaveLength(1);
+			expect(discardedTurns).toBe(1);
 		});
 
 		it("degrades on a category-less refusal", async () => {

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -208,10 +208,8 @@ describe("Agent hub row ordering", () => {
 	it("flags a fallback badge for a live row whose fallback armed no session retry state", () => {
 		geometry = stubStdoutGeometry(120);
 		const agents = new AgentRegistry();
-		// Live session with a resolved model but no `retryFallbackModel` — the
-		// Fireworks Fast → base degrade emits `retry_fallback_applied` without
-		// arming `#activeRetryFallback`, so the badge must fall back to the
-		// executor-reported progress flag.
+		// A live progress update can arrive without a retryFallbackModel snapshot,
+		// so the badge must fall back to the executor-reported progress flag.
 		const session = { model: { id: "kimi-k2" }, retryFallbackModel: undefined } as unknown as AgentSession;
 		agents.register({ id: "FastAgent", displayName: "Fast Agent", kind: "sub", session });
 

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -1275,11 +1275,13 @@ describe("AgentSession TTSR resume gate", () => {
 		});
 	}
 
-	it("prompt() blocks until TTSR interrupt continuation completes", async () => {
+	it("preserves a fallback probe until the TTSR interrupt continuation completes", async () => {
 		collapseSchedulerSettleDelays();
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		let streamCallCount = 0;
 		let continuationCompleted = false;
+		let continuationAdmission: string | undefined;
+		let modelRegistry: ModelRegistry;
 
 		const ttsrManager = new TtsrManager({
 			enabled: true,
@@ -1303,6 +1305,7 @@ describe("AgentSession TTSR resume gate", () => {
 					pushAbortableTtsrStream(stream, signal);
 				} else {
 					// Continuation stream: complete normally after a delay
+					continuationAdmission = modelRegistry.admitFallbackProbe(`${model.provider}/${model.id}`).status;
 					pushContinuationStream(stream, () => {
 						continuationCompleted = true;
 					});
@@ -1316,8 +1319,10 @@ describe("AgentSession TTSR resume gate", () => {
 		const settings = Settings.isolated();
 		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth-int.db"));
 		authStorages.push(authStorage);
-		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const probeAdmission = modelRegistry.admitFallbackProbe(`${model.provider}/${model.id}`);
+		if (probeAdmission.status !== "probe") throw new Error("Expected TTSR session to own the fallback probe");
 
 		session = new AgentSession({
 			agent,
@@ -1325,6 +1330,12 @@ describe("AgentSession TTSR resume gate", () => {
 			settings,
 			modelRegistry,
 			ttsrManager,
+			initialRetryFallback: {
+				role: "ttsr-test",
+				originalSelector: "missing-provider/missing-model",
+				originalThinkingLevel: undefined,
+				probeLease: probeAdmission.lease,
+			},
 		});
 
 		// prompt() must block until the TTSR continuation completes
@@ -1332,6 +1343,8 @@ describe("AgentSession TTSR resume gate", () => {
 
 		// By the time prompt() returns, the continuation must have finished
 		expect(continuationCompleted).toBe(true);
+		expect(continuationAdmission).toBe("busy");
+		expect(modelRegistry.admitFallbackProbe(`${model.provider}/${model.id}`)).toEqual({ status: "healthy" });
 		expect(streamCallCount).toBeGreaterThanOrEqual(2);
 		expect(session.isStreaming).toBe(false);
 	});

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -86,7 +86,7 @@ async function createHarness(
 		provider?: string;
 		id?: string;
 	} = {},
-): Promise<Harness & { mock: MockModel }> {
+): Promise<Harness & { mock: MockModel; modelRegistry: ModelRegistry }> {
 	const tempDir = TempDir.createSync("@pi-empty-stop-guard-");
 	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
 	authStorage.setRuntimeApiKey("mock", "test-key");
@@ -130,7 +130,7 @@ async function createHarness(
 	});
 	const harness = { session, authStorage, tempDir };
 	activeHarnesses.push(harness);
-	return { ...harness, mock };
+	return { ...harness, mock, modelRegistry };
 }
 
 function assistantText(messages: AgentMessage[]): string {
@@ -302,6 +302,25 @@ describe("AgentSession empty stop guard", () => {
 			.filter(entry => entry.type === "message")
 			.map(entry => entry.message as AgentMessage);
 		expect(emptyAssistantStops(activeBranchMessages)).toHaveLength(0);
+	});
+
+	it("releases a fallback probe when empty stop retries hit the cap", async () => {
+		const primarySelector = "openai/gpt-4o-mini";
+		const fallbackSelector = "openai/gpt-4o";
+		const { session, modelRegistry } = await createHarness(
+			[{ throw: "503 service unavailable: overloaded_error" }, emptyStop(), emptyStop(), emptyStop(), emptyStop()],
+			{
+				"retry.enabled": true,
+				"retry.baseDelayMs": 0,
+				"retry.fallbackChains": { [primarySelector]: [fallbackSelector] },
+			},
+			{ provider: "openai", id: "gpt-4o-mini" },
+		);
+
+		await expectPromptCompletes(session.prompt("release capped fallback probe"));
+		await session.waitForIdle();
+
+		expect(modelRegistry.admitFallbackProbe(fallbackSelector).status).toBe("probe");
 	});
 
 	it("waits for capped empty-stop persistence before removing the active branch entry", async () => {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -3427,4 +3427,54 @@ describe("AgentSession retry fallback", () => {
 		expect(session.isRetrying).toBe(false);
 		expect(getLastAssistantMessage(session).stopReason).toBe("stop");
 	});
+
+	it("releases the fallback probe when retry continuation fails before provider dispatch", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) throw new Error("Expected bundled fallback test models");
+		const primarySelector = `${primaryModel.provider}/${primaryModel.id}`;
+		const fallbackSelector = `${fallbackModel.provider}/${fallbackModel.id}`;
+		const mock = createMockModel({
+			responses: [{ throw: "503 service unavailable: overloaded_error" }],
+		});
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: mock.stream,
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 0,
+			"retry.fallbackChains": { [primarySelector]: [fallbackSelector] },
+		});
+		settings.setModelRole("default", primarySelector);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const { retryEndEvents } = trackRetryEvents(session);
+		session.subscribe(event => {
+			if (event.type !== "auto_retry_start") return;
+			vi.spyOn(agent, "continue").mockRejectedValue(new Error("synthetic local continuation failure"));
+		});
+
+		const outcome = await Promise.race([
+			session.prompt("fail the scheduled continuation").then(() => "completed" as const),
+			scheduler.wait(3_000).then(() => "stuck" as const),
+		]);
+
+		expect(outcome).toBe("completed");
+		expect(mock.calls).toHaveLength(1);
+		expect(retryEndEvents).toEqual([
+			expect.objectContaining({ success: false, finalError: expect.stringContaining("failed locally") }),
+		]);
+		expect(modelRegistry.admitFallbackProbe(fallbackSelector).status).toBe("probe");
+	});
 });

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -842,6 +842,72 @@ describe("AgentSession retry fallback", () => {
 		});
 	});
 
+	it("releases an advisor probe when the fallback turn exits with a tool-call error", async () => {
+		const mainModel = getBundledModel("openai", "gpt-4o-mini");
+		const advisorPrimary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const advisorFallback = getBundledModel("openai", "gpt-4o");
+		if (!mainModel || !advisorPrimary || !advisorFallback) {
+			throw new Error("Expected bundled advisor fallback models to exist");
+		}
+
+		const mainMock = createMockModel({ responses: [{ content: ["Primary complete"] }] });
+		const advisorMock = createMockModel();
+		const advisorPrimarySelector = `${advisorPrimary.provider}/${advisorPrimary.id}`;
+		const advisorFallbackSelector = `${advisorFallback.provider}/${advisorFallback.id}`;
+		const fallbackReturned = Promise.withResolvers<void>();
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: mainModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: mainMock.stream,
+		});
+		const settings = Settings.isolated({
+			"advisor.syncBacklog": "1",
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 0,
+			"retry.fallbackChains": { [advisorPrimarySelector]: [advisorFallbackSelector] },
+		});
+		settings.setModelRole("advisor", advisorPrimarySelector);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: (requestedModel, context, options) => {
+				const selector = `${requestedModel.provider}/${requestedModel.id}`;
+				if (selector === advisorPrimarySelector) {
+					advisorMock.push({ throw: "service unavailable: 503 overloaded" });
+				} else if (selector === advisorFallbackSelector) {
+					advisorMock.push({
+						content: [{ type: "toolCall", name: "missing-tool", arguments: {} }],
+						stopReason: "error",
+						errorMessage: "fallback tool-call response failed",
+					});
+					fallbackReturned.resolve();
+				} else {
+					throw new Error(`Unexpected advisor model requested: ${selector}`);
+				}
+				return advisorMock.stream(requestedModel, context, options);
+			},
+		});
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+
+		await session.prompt("Trigger advisor fallback failure");
+		await fallbackReturned.promise;
+		let releasedProbe = false;
+		for (let attempt = 0; attempt < 50; attempt += 1) {
+			const admission = modelRegistry.admitFallbackProbe(advisorFallbackSelector);
+			if (admission.status === "probe") {
+				modelRegistry.abandonFallbackProbe(admission.lease);
+				releasedProbe = true;
+				break;
+			}
+			await Bun.sleep(0);
+		}
+
+		expect(releasedProbe).toBe(true);
+	});
+
 	it("activates a model-keyed fallback chain without any role assignment", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -380,6 +380,55 @@ describe("AgentSession retry fallback", () => {
 		expect(modelRegistry.admitFallbackProbe(`${fallbackModel.provider}/${fallbackModel.id}`).status).toBe("probe");
 	});
 
+	it("aborts an active fallback request before beginDispose releases its probe", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) throw new Error("Expected bundled fallback probe models");
+		const fallbackStarted = Promise.withResolvers<void>();
+		let fallbackSignal: AbortSignal | undefined;
+		const primaryMock = createMockModel({ responses: [{ throw: "service unavailable: 503 overloaded" }] });
+		const fallbackMock = createMockModel({
+			handler: () => {
+				fallbackStarted.resolve();
+				return { content: ["late fallback response"], delayMs: 60_000 };
+			},
+		});
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: primaryModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, context, options) => {
+				if (requestedModel.provider === fallbackModel.provider && requestedModel.id === fallbackModel.id) {
+					fallbackSignal = options?.signal;
+					return fallbackMock.stream(requestedModel, context, options);
+				}
+				return primaryMock.stream(requestedModel, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 0,
+			"retry.maxRetries": 1,
+			"retry.fallbackChains": { default: [`${fallbackModel.provider}/${fallbackModel.id}`] },
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		const prompt = session.prompt("Dispose the fallback probe");
+		await fallbackStarted.promise;
+		session.beginDispose();
+		const siblingAdmission = modelRegistry.admitFallbackProbe(`${fallbackModel.provider}/${fallbackModel.id}`);
+
+		expect(fallbackSignal?.aborted).toBe(true);
+		expect(siblingAdmission.status).toBe("probe");
+		if (siblingAdmission.status === "probe") modelRegistry.abandonFallbackProbe(siblingAdmission.lease);
+		await prompt;
+	});
+
 	it("confirms before crossing models when every pooled account is inside reserve", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
@@ -810,6 +859,122 @@ describe("AgentSession retry fallback", () => {
 		expect(modelRegistry.admitFallbackProbe(firstSelector)).toEqual({ status: "busy" });
 	});
 
+	it("revalidates a healthy active fallback after cooldown before dispatch", async () => {
+		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
+		const secondFallback = getBundledModel("openai", "gpt-4o");
+		if (!firstFallback || !secondFallback) throw new Error("Expected bundled startup fallback models");
+		const firstSelector = `${firstFallback.provider}/${firstFallback.id}`;
+		const secondSelector = `${secondFallback.provider}/${secondFallback.id}`;
+		const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+		const firstAdmission = modelRegistry.admitFallbackProbe(firstSelector);
+		if (firstAdmission.status !== "probe") throw new Error("Expected initial fallback probe");
+		modelRegistry.markFallbackProbeHealthy(firstAdmission.lease);
+		modelRegistry.suppressSelector(firstSelector, 2_000);
+		now.mockReturnValue(3_000);
+		const siblingAdmission = modelRegistry.admitFallbackProbe(firstSelector);
+		if (siblingAdmission.status !== "probe") throw new Error("Expected sibling cooldown probe");
+
+		const requestedModels: string[] = [];
+		const mock = createMockModel({ responses: [{ content: ["Used the uncontended fallback"] }] });
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: firstFallback, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				return mock.stream(model, context, options);
+			},
+		});
+		const primarySelector = "missing-provider/missing-model";
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.fallbackChains": { slow: [firstSelector, secondSelector] },
+		});
+		settings.setModelRole("slow", primarySelector);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			initialRetryFallback: {
+				role: "slow",
+				originalSelector: primarySelector,
+				originalThinkingLevel: undefined,
+			},
+		});
+
+		await session.prompt("Revalidate the active fallback");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([secondSelector]);
+		expect(modelRegistry.admitFallbackProbe(firstSelector)).toEqual({ status: "busy" });
+	});
+
+	it("revalidates a fallback switched after an earlier selector is busy", async () => {
+		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
+		const secondFallback = getBundledModel("openai", "gpt-4o");
+		const thirdFallback = getBundledModel("anthropic", "claude-haiku-4-5");
+		if (!firstFallback || !secondFallback || !thirdFallback) {
+			throw new Error("Expected bundled fallback race models");
+		}
+		const firstSelector = `${firstFallback.provider}/${firstFallback.id}`;
+		const secondSelector = `${secondFallback.provider}/${secondFallback.id}`;
+		const thirdSelector = `${thirdFallback.provider}/${thirdFallback.id}`;
+		const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+		const firstSibling = modelRegistry.admitFallbackProbe(firstSelector);
+		if (firstSibling.status !== "probe") throw new Error("Expected sibling first fallback probe");
+		const credentialStarted = Promise.withResolvers<void>();
+		const releaseCredential = Promise.withResolvers<void>();
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async model => {
+			if (model.provider === secondFallback.provider && model.id === secondFallback.id) {
+				credentialStarted.resolve();
+				await releaseCredential.promise;
+			}
+			return `${model.provider}-test-key`;
+		});
+
+		const requestedModels: string[] = [];
+		const mock = createMockModel({ responses: [{ content: ["Used the final admitted fallback"] }] });
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: firstFallback, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				return mock.stream(model, context, options);
+			},
+		});
+		const primarySelector = "missing-provider/missing-model";
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.fallbackChains": { slow: [firstSelector, secondSelector, thirdSelector] },
+		});
+		settings.setModelRole("slow", primarySelector);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			initialRetryFallback: {
+				role: "slow",
+				originalSelector: primarySelector,
+				originalThinkingLevel: undefined,
+			},
+		});
+
+		const prompt = session.prompt("Revalidate every async fallback switch");
+		await credentialStarted.promise;
+		now.mockReturnValue(1_000 + 10 * 60 * 1_000);
+		const secondSibling = modelRegistry.admitFallbackProbe(secondSelector);
+		if (secondSibling.status !== "probe") throw new Error("Expected sibling second fallback probe");
+		releaseCredential.resolve();
+		await prompt;
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([thirdSelector]);
+		expect(modelRegistry.admitFallbackProbe(secondSelector)).toEqual({ status: "busy" });
+		modelRegistry.abandonFallbackProbe(firstSibling.lease);
+		modelRegistry.abandonFallbackProbe(secondSibling.lease);
+	});
+
 	it("applies a model-keyed fallback chain to advisor quota failures", async () => {
 		const mainModel = getBundledModel("openai", "gpt-4o-mini");
 		const advisorPrimary = getBundledModel("anthropic", "claude-sonnet-4-5");
@@ -819,14 +984,20 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		const mainMock = createMockModel({
-			responses: [{ content: ["Primary complete"] }, { content: ["Primary complete again"] }],
+			responses: [
+				{ content: ["Primary complete"] },
+				{ content: ["Primary complete after reset"] },
+				{ content: ["Primary complete again"] },
+			],
 		});
 		const advisorMock = createMockModel();
 		let advisorPrimaryAttempts = 0;
+		let advisorFallbackAttempts = 0;
 		const requestedAdvisorModels: string[] = [];
 		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
 		const fallbackSucceededEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_succeeded" }>> = [];
 		const fallbackSucceeded = Promise.withResolvers<void>();
+		const fallbackAfterReset = Promise.withResolvers<void>();
 		const advisorFailures: string[] = [];
 		const advisorPrimarySelector = `${advisorPrimary.provider}/${advisorPrimary.id}`;
 		const advisorFallbackSelector = `${advisorFallback.provider}/${advisorFallback.id}`;
@@ -864,11 +1035,12 @@ describe("AgentSession retry fallback", () => {
 				requestedAdvisorModels.push(selector);
 				if (selector === advisorPrimarySelector && advisorPrimaryAttempts++ === 0) {
 					advisorMock.push({
-						throw: "Devin stream error failed_precondition: Your daily usage quota has been exhausted. Your quota will reset after 1s.",
+						throw: "Devin stream error failed_precondition: Your daily usage quota has been exhausted. Your quota will reset after 60s.",
 					});
 				} else if (selector === advisorPrimarySelector) {
 					advisorMock.push({ content: ["Advisor primary restored"] });
 				} else if (selector === advisorFallbackSelector) {
+					if (advisorFallbackAttempts++ > 0) fallbackAfterReset.resolve();
 					advisorMock.push({ content: ["Advisor recovered"] });
 				} else {
 					throw new Error(`Unexpected advisor model requested: ${selector}`);
@@ -918,8 +1090,22 @@ describe("AgentSession retry fallback", () => {
 		expect(advisorFailures).toEqual([]);
 		expect(modelRegistry.admitFallbackProbe(advisorFallbackSelector)).toEqual({ status: "healthy" });
 
+		await session.newSession();
+		await session.prompt("Complete another primary turn before the advisor cooldown expires");
+		await fallbackAfterReset.promise;
+		await session.waitForIdle();
+		expect(requestedAdvisorModels).toEqual([
+			advisorPrimarySelector,
+			advisorFallbackSelector,
+			advisorFallbackSelector,
+		]);
+		expect(session.getAdvisorAgent()?.state.model).toMatchObject({
+			provider: advisorFallback.provider,
+			id: advisorFallback.id,
+		});
+
 		const getApiKey = vi.spyOn(modelRegistry, "getApiKey");
-		const afterCooldown = Date.now() + 2_000;
+		const afterCooldown = Date.now() + 61_000;
 		vi.spyOn(Date, "now").mockReturnValue(afterCooldown);
 		await session.prompt("Complete another primary turn after the advisor cooldown");
 		await session.waitForIdle();
@@ -929,7 +1115,12 @@ describe("AgentSession retry fallback", () => {
 			{ signal: expect.any(AbortSignal) },
 		);
 
-		expect(requestedAdvisorModels).toEqual([advisorPrimarySelector, advisorFallbackSelector, advisorPrimarySelector]);
+		expect(requestedAdvisorModels).toEqual([
+			advisorPrimarySelector,
+			advisorFallbackSelector,
+			advisorFallbackSelector,
+			advisorPrimarySelector,
+		]);
 		expect(session.getAdvisorAgent()?.state.model).toMatchObject({
 			provider: advisorPrimary.provider,
 			id: advisorPrimary.id,
@@ -1005,6 +1196,103 @@ describe("AgentSession retry fallback", () => {
 			provider: advisorPrimary.provider,
 			id: advisorPrimary.id,
 		});
+	});
+
+	it("revalidates an advisor fallback lease immediately before dispatch", async () => {
+		const mainModel = getBundledModel("openai", "gpt-4o-mini");
+		const advisorPrimary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const firstFallback = getBundledModel("openai", "gpt-4o");
+		const secondFallback = getBundledModel("anthropic", "claude-haiku-4-5");
+		const thirdFallback = getBundledModel("google", "gemini-2.5-flash");
+		if (!mainModel || !advisorPrimary || !firstFallback || !secondFallback || !thirdFallback) {
+			throw new Error("Expected bundled advisor lease models");
+		}
+		const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+		const advisorPrimarySelector = `${advisorPrimary.provider}/${advisorPrimary.id}`;
+		const firstFallbackSelector = `${firstFallback.provider}/${firstFallback.id}`;
+		const secondFallbackSelector = `${secondFallback.provider}/${secondFallback.id}`;
+		const thirdFallbackSelector = `${thirdFallback.provider}/${thirdFallback.id}`;
+		const firstCredentialStarted = Promise.withResolvers<void>();
+		const releaseFirstCredential = Promise.withResolvers<void>();
+		const secondCredentialStarted = Promise.withResolvers<void>();
+		const releaseSecondCredential = Promise.withResolvers<void>();
+		const thirdFallbackDispatched = Promise.withResolvers<void>();
+		const requestedAdvisorModels: string[] = [];
+		const mainMock = createMockModel({ responses: [{ content: ["Primary complete"] }] });
+		const advisorMock = createMockModel();
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: mainModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: mainMock.stream,
+		});
+		const settings = Settings.isolated({
+			"advisor.syncBacklog": "1",
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 0,
+			"retry.fallbackChains": {
+				[advisorPrimarySelector]: [firstFallbackSelector, secondFallbackSelector, thirdFallbackSelector],
+			},
+		});
+		settings.setModelRole("advisor", advisorPrimarySelector);
+		vi.spyOn(modelRegistry.authStorage, "markUsageLimitReached").mockResolvedValue({ switched: false });
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async (model, _sessionId, options) => {
+			if (model.provider === firstFallback.provider && model.id === firstFallback.id) {
+				firstCredentialStarted.resolve();
+				await releaseFirstCredential.promise;
+				options?.signal?.throwIfAborted();
+			}
+			if (model.provider === secondFallback.provider && model.id === secondFallback.id) {
+				secondCredentialStarted.resolve();
+				await releaseSecondCredential.promise;
+				options?.signal?.throwIfAborted();
+			}
+			return `${model.provider}-test-key`;
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			advisorTools: [],
+			advisorConfigs: [{ name: "lease-test", model: advisorPrimarySelector }],
+			advisorStreamFn: (model, context, options) => {
+				const selector = `${model.provider}/${model.id}`;
+				requestedAdvisorModels.push(selector);
+				if (selector === advisorPrimarySelector) {
+					advisorMock.push({
+						throw: "Devin stream error failed_precondition: Your daily usage quota has been exhausted. Your quota will reset after 3600s.",
+					});
+				} else if (selector === thirdFallbackSelector) {
+					thirdFallbackDispatched.resolve();
+					advisorMock.push({ content: ["Recovered on the admitted advisor fallback"] });
+				} else {
+					throw new Error(`Unexpected advisor model request: ${selector}`);
+				}
+				return advisorMock.stream(model, context, options);
+			},
+		});
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+
+		await session.prompt("Trigger advisor fallback lease revalidation");
+		await firstCredentialStarted.promise;
+		now.mockReturnValue(1_000 + 10 * 60 * 1_000);
+		const firstSibling = modelRegistry.admitFallbackProbe(firstFallbackSelector);
+		if (firstSibling.status !== "probe") throw new Error("Expected sibling first advisor probe");
+		releaseFirstCredential.resolve();
+		await secondCredentialStarted.promise;
+		now.mockReturnValue(1_000 + 20 * 60 * 1_000);
+		const secondSibling = modelRegistry.admitFallbackProbe(secondFallbackSelector);
+		if (secondSibling.status !== "probe") throw new Error("Expected sibling second advisor probe");
+		releaseSecondCredential.resolve();
+		await thirdFallbackDispatched.promise;
+		await session.waitForIdle();
+
+		expect(requestedAdvisorModels).not.toContain(firstFallbackSelector);
+		expect(requestedAdvisorModels).not.toContain(secondFallbackSelector);
+		expect(requestedAdvisorModels.at(-1)).toBe(thirdFallbackSelector);
+		expect(modelRegistry.admitFallbackProbe(secondFallbackSelector)).toEqual({ status: "busy" });
+		modelRegistry.abandonFallbackProbe(firstSibling.lease);
+		modelRegistry.abandonFallbackProbe(secondSibling.lease);
 	});
 
 	it("releases an advisor probe when the fallback turn exits with a tool-call error", async () => {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -115,6 +115,7 @@ describe("AgentSession retry fallback", () => {
 		// (default 5-minute suppression) so state never leaks between tests.
 		modelRegistry = sharedRegistry;
 		modelRegistry.clearSuppressedSelectors();
+		modelRegistry.clearFallbackProbeStates();
 	});
 
 	afterEach(async () => {
@@ -258,6 +259,85 @@ describe("AgentSession retry fallback", () => {
 		}
 	});
 
+	it("lets one sibling probe an unknown fallback without making the others wait", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) throw new Error("Expected bundled fallback probe models");
+
+		const releasePrimary = Promise.withResolvers<void>();
+		const allPrimaryStarted = Promise.withResolvers<void>();
+		const releaseFallback = Promise.withResolvers<void>();
+		const fallbackStarted = Promise.withResolvers<void>();
+		const fiveCallersFinished = Promise.withResolvers<void>();
+		let primaryAttempts = 0;
+		let fallbackAttempts = 0;
+		let finishedCallers = 0;
+		const primaryMock = createMockModel({
+			handler: async () => {
+				primaryAttempts += 1;
+				if (primaryAttempts === 6) allPrimaryStarted.resolve();
+				await releasePrimary.promise;
+				return { throw: "overloaded_error: provider returned error 503" };
+			},
+		});
+		const fallbackMock = createMockModel({
+			handler: async () => {
+				fallbackAttempts += 1;
+				fallbackStarted.resolve();
+				await releaseFallback.promise;
+				return { content: ["Fallback probe passed"] };
+			},
+		});
+		const sessions = Array.from({ length: 6 }, () => {
+			const agent = new Agent({
+				getApiKey: model => `${model.provider}-test-key`,
+				initialState: { model: primaryModel, systemPrompt: ["Test"], tools: [], messages: [] },
+				streamFn: (model, context, options) =>
+					model.provider === fallbackModel.provider && model.id === fallbackModel.id
+						? fallbackMock.stream(model, context, options)
+						: primaryMock.stream(model, context, options),
+			});
+			const settings = Settings.isolated({
+				"compaction.enabled": false,
+				"retry.baseDelayMs": 0,
+				"retry.maxRetries": 1,
+				"retry.fallbackChains": { default: [`${fallbackModel.provider}/${fallbackModel.id}`] },
+			});
+			settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+			return new AgentSession({
+				agent,
+				sessionManager: SessionManager.inMemory(),
+				settings,
+				modelRegistry,
+			});
+		});
+
+		try {
+			const prompts = sessions.map(candidateSession =>
+				candidateSession.prompt("Recover together").finally(() => {
+					finishedCallers += 1;
+					if (finishedCallers === 5) fiveCallersFinished.resolve();
+				}),
+			);
+			await allPrimaryStarted.promise;
+			releasePrimary.resolve();
+			await fallbackStarted.promise;
+			await fiveCallersFinished.promise;
+
+			expect(fallbackAttempts).toBe(1);
+
+			releaseFallback.resolve();
+			await Promise.all(prompts);
+			expect(modelRegistry.admitFallbackProbe(`${fallbackModel.provider}/${fallbackModel.id}`)).toEqual({
+				status: "healthy",
+			});
+		} finally {
+			releasePrimary.resolve();
+			releaseFallback.resolve();
+			await Promise.all(sessions.map(candidateSession => candidateSession.dispose()));
+		}
+	});
+
 	it("confirms before crossing models when every pooled account is inside reserve", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
@@ -315,6 +395,9 @@ describe("AgentSession retry fallback", () => {
 		});
 		expect(requestedModels).toEqual([`${fallbackModel.provider}/${fallbackModel.id}`]);
 		expect(session.messages.some(message => message.role === "user")).toBe(true);
+		expect(modelRegistry.admitFallbackProbe(`${fallbackModel.provider}/${fallbackModel.id}`)).toEqual({
+			status: "healthy",
+		});
 	});
 
 	it("reselects a healthy same-provider account before considering a model fallback", async () => {
@@ -668,6 +751,7 @@ describe("AgentSession retry fallback", () => {
 			},
 		]);
 		expect(advisorFailures).toEqual([]);
+		expect(modelRegistry.admitFallbackProbe(advisorFallbackSelector)).toEqual({ status: "healthy" });
 
 		const getApiKey = vi.spyOn(modelRegistry, "getApiKey");
 		const afterCooldown = Date.now() + 2_000;

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -760,6 +760,56 @@ describe("AgentSession retry fallback", () => {
 		]);
 	});
 
+	it("does not dispatch an expired startup probe after a sibling takes ownership", async () => {
+		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
+		const secondFallback = getBundledModel("openai", "gpt-4o");
+		if (!firstFallback || !secondFallback) throw new Error("Expected bundled startup fallback models");
+		const firstSelector = `${firstFallback.provider}/${firstFallback.id}`;
+		const secondSelector = `${secondFallback.provider}/${secondFallback.id}`;
+		const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+		const initialAdmission = modelRegistry.admitFallbackProbe(firstSelector);
+		if (initialAdmission.status !== "probe") throw new Error("Expected startup session to own the first probe");
+
+		const requestedModels: string[] = [];
+		const mock = createMockModel({ responses: [{ content: ["Used the uncontended fallback"] }] });
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: firstFallback, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (model, context, options) => {
+				requestedModels.push(`${model.provider}/${model.id}`);
+				return mock.stream(model, context, options);
+			},
+		});
+		const primarySelector = "missing-provider/missing-model";
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.fallbackChains": { slow: [firstSelector, secondSelector] },
+		});
+		settings.setModelRole("slow", primarySelector);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			initialRetryFallback: {
+				role: "slow",
+				originalSelector: primarySelector,
+				originalThinkingLevel: undefined,
+				probeLease: initialAdmission.lease,
+			},
+		});
+
+		now.mockReturnValue(1_000 + 10 * 60 * 1000);
+		const siblingAdmission = modelRegistry.admitFallbackProbe(firstSelector);
+		if (siblingAdmission.status !== "probe") throw new Error("Expected sibling to replace the expired probe");
+
+		await session.prompt("Do not send the stale startup probe");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([secondSelector]);
+		expect(modelRegistry.admitFallbackProbe(firstSelector)).toEqual({ status: "busy" });
+	});
+
 	it("applies a model-keyed fallback chain to advisor quota failures", async () => {
 		const mainModel = getBundledModel("openai", "gpt-4o-mini");
 		const advisorPrimary = getBundledModel("anthropic", "claude-sonnet-4-5");
@@ -1021,6 +1071,69 @@ describe("AgentSession retry fallback", () => {
 		}
 
 		expect(releasedProbe).toBe(true);
+	});
+
+	it("keeps an advisor probe across same-selector credential rotation", async () => {
+		const mainModel = getBundledModel("openai", "gpt-4o-mini");
+		const advisorPrimary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const advisorFallback = getBundledModel("openai", "gpt-4o");
+		if (!mainModel || !advisorPrimary || !advisorFallback) {
+			throw new Error("Expected bundled advisor credential-rotation models");
+		}
+		const mainMock = createMockModel({ responses: [{ content: ["Primary complete"] }] });
+		const advisorMock = createMockModel();
+		const primarySelector = `${advisorPrimary.provider}/${advisorPrimary.id}`;
+		const fallbackSelector = `${advisorFallback.provider}/${advisorFallback.id}`;
+		let fallbackAttempts = 0;
+		let siblingAdmissionStatus: string | undefined;
+		const fallbackRetried = Promise.withResolvers<void>();
+		const fallbackSucceeded = Promise.withResolvers<void>();
+		vi.spyOn(modelRegistry.authStorage, "markUsageLimitReached").mockResolvedValue({ switched: true });
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: mainModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: mainMock.stream,
+		});
+		const settings = Settings.isolated({
+			"advisor.syncBacklog": "1",
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 0,
+			"retry.fallbackChains": { [primarySelector]: [fallbackSelector] },
+		});
+		settings.setModelRole("advisor", primarySelector);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			advisorTools: [],
+			advisorStreamFn: (requestedModel, context, options) => {
+				const selector = `${requestedModel.provider}/${requestedModel.id}`;
+				if (selector === primarySelector) {
+					advisorMock.push({ throw: "service unavailable: 503 overloaded" });
+				} else if (selector === fallbackSelector && fallbackAttempts++ === 0) {
+					advisorMock.push({ throw: "429 usage_limit_reached" });
+				} else if (selector === fallbackSelector) {
+					siblingAdmissionStatus = modelRegistry.admitFallbackProbe(fallbackSelector).status;
+					advisorMock.push({ content: ["Advisor recovered after credential rotation"] });
+					fallbackRetried.resolve();
+				} else {
+					throw new Error(`Unexpected advisor model requested: ${selector}`);
+				}
+				return advisorMock.stream(requestedModel, context, options);
+			},
+		});
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_succeeded") fallbackSucceeded.resolve();
+		});
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+
+		await session.prompt("Trigger advisor credential rotation");
+		await fallbackRetried.promise;
+		await fallbackSucceeded.promise;
+
+		expect(siblingAdmissionStatus).toBe("busy");
+		expect(modelRegistry.admitFallbackProbe(fallbackSelector)).toEqual({ status: "healthy" });
 	});
 
 	it("activates a model-keyed fallback chain without any role assignment", async () => {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -13,7 +13,7 @@ import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { type FallbackProbeLease, ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { parseModelPattern, parseModelString } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
@@ -338,6 +338,48 @@ describe("AgentSession retry fallback", () => {
 		}
 	});
 
+	it("releases a fallback probe when the active turn is aborted", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) throw new Error("Expected bundled fallback probe models");
+		const fallbackStarted = Promise.withResolvers<void>();
+		const primaryMock = createMockModel({ responses: [{ throw: "service unavailable: 503 overloaded" }] });
+		const fallbackMock = createMockModel({
+			handler: () => {
+				fallbackStarted.resolve();
+				return { content: ["late fallback response"], delayMs: 60_000 };
+			},
+		});
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: primaryModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, context, options) =>
+				requestedModel.provider === fallbackModel.provider && requestedModel.id === fallbackModel.id
+					? fallbackMock.stream(requestedModel, context, options)
+					: primaryMock.stream(requestedModel, context, options),
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 0,
+			"retry.maxRetries": 1,
+			"retry.fallbackChains": { default: [`${fallbackModel.provider}/${fallbackModel.id}`] },
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		const prompt = session.prompt("Abort the fallback probe");
+		await fallbackStarted.promise;
+		await session.abort();
+		await prompt;
+
+		expect(modelRegistry.admitFallbackProbe(`${fallbackModel.provider}/${fallbackModel.id}`).status).toBe("probe");
+	});
+
 	it("confirms before crossing models when every pooled account is inside reserve", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
@@ -398,6 +440,79 @@ describe("AgentSession retry fallback", () => {
 		expect(modelRegistry.admitFallbackProbe(`${fallbackModel.provider}/${fallbackModel.id}`)).toEqual({
 			status: "healthy",
 		});
+	});
+
+	it("admits after reserve confirmation and reselects when another caller wins", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const firstFallback = getBundledModel("openai", "gpt-4o-mini");
+		const secondFallback = getBundledModel("openai", "gpt-4o");
+		if (!primaryModel || !firstFallback || !secondFallback) {
+			throw new Error("Expected bundled reserve fallback models");
+		}
+		const firstSelector = `${firstFallback.provider}/${firstFallback.id}`;
+		const secondSelector = `${secondFallback.provider}/${secondFallback.id}`;
+		const requestedModels: string[] = [];
+		const mock = createMockModel({ responses: [{ content: ["continued on the second fallback"] }] });
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: primaryModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.usageAwareFallback": true,
+			"retry.usageReservePct": 10,
+			"retry.usageReservePolicy": "confirm",
+			"retry.fallbackChains": { default: [firstSelector, secondSelector] },
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+		vi.spyOn(modelRegistry.authStorage, "getModelUsageHealth").mockImplementation(async provider =>
+			provider === primaryModel.provider
+				? {
+						state: "reserve",
+						accounts: [
+							{
+								credentialId: 1,
+								credentialType: "oauth",
+								selected: true,
+								state: "reserve",
+								remainingFraction: 0.05,
+							},
+						],
+					}
+				: { state: "healthy", accounts: [] },
+		);
+		let siblingLease: FallbackProbeLease | undefined;
+		const confirmations: string[] = [];
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		session.setUsageFallbackConfirmer(async confirmation => {
+			confirmations.push(confirmation.to);
+			if (confirmation.to === firstSelector) {
+				const admission = modelRegistry.admitFallbackProbe(firstSelector);
+				if (admission.status !== "probe") throw new Error("Expected sibling to win the first probe");
+				siblingLease = admission.lease;
+			}
+			return true;
+		});
+
+		try {
+			await session.prompt("Choose an available reserve fallback");
+			await session.waitForIdle();
+		} finally {
+			if (siblingLease) modelRegistry.abandonFallbackProbe(siblingLease);
+		}
+
+		expect(confirmations).toEqual([firstSelector, secondSelector]);
+		expect(requestedModels).toEqual([secondSelector]);
+		expect(session.model).toMatchObject({ provider: secondFallback.provider, id: secondFallback.id });
 	});
 
 	it("reselects a healthy same-provider account before considering a model fallback", async () => {

--- a/packages/coding-agent/test/config/model-registry.test.ts
+++ b/packages/coding-agent/test/config/model-registry.test.ts
@@ -13,6 +13,7 @@ function createStubAuthStorage(): AuthStorage {
 		clearConfigApiKeys: () => {},
 		hasAuth: () => false,
 		getApiKey: async () => undefined,
+		peekApiKey: () => undefined,
 	};
 	return stub as unknown as AuthStorage;
 }
@@ -178,6 +179,18 @@ describe("ModelRegistry", () => {
 		expect(Array.from({ length: 6 }, () => registry.admitFallbackProbe("test/test-model"))).toEqual(
 			Array.from({ length: 6 }, () => ({ status: "healthy" })),
 		);
+	});
+
+	test("preserves fallback probe state across routine refreshes", async () => {
+		const probe = registry.admitFallbackProbe("test/test-model");
+		if (probe.status !== "probe") throw new Error("Expected first fallback caller to own the probe");
+
+		await registry.refresh("offline");
+		expect(registry.admitFallbackProbe("test/test-model")).toEqual({ status: "busy" });
+
+		registry.markFallbackProbeHealthy(probe.lease);
+		await registry.refresh("offline");
+		expect(registry.admitFallbackProbe("test/test-model")).toEqual({ status: "healthy" });
 	});
 
 	test("ignores a stale probe callback after ownership changes", () => {

--- a/packages/coding-agent/test/config/model-registry.test.ts
+++ b/packages/coding-agent/test/config/model-registry.test.ts
@@ -181,6 +181,24 @@ describe("ModelRegistry", () => {
 		);
 	});
 
+	test("requires a fresh single-owner probe after selector cooldown", () => {
+		const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+		const first = registry.admitFallbackProbe("test/test-model");
+		if (first.status !== "probe") throw new Error("Expected first fallback caller to own the probe");
+		registry.markFallbackProbeHealthy(first.lease);
+
+		registry.suppressSelector("test/test-model:high", 2_000);
+		now.mockReturnValue(2_001);
+		expect(registry.isSelectorSuppressed("test/test-model")).toBe(false);
+
+		const second = registry.admitFallbackProbe("test/test-model");
+		if (second.status !== "probe") throw new Error("Expected cooldown expiry to admit one fresh probe");
+		expect(registry.admitFallbackProbe("test/test-model")).toEqual({ status: "busy" });
+
+		registry.markFallbackProbeHealthy(first.lease);
+		expect(registry.admitFallbackProbe("test/test-model")).toEqual({ status: "busy" });
+	});
+
 	test("preserves fallback probe state across routine refreshes", async () => {
 		const probe = registry.admitFallbackProbe("test/test-model");
 		if (probe.status !== "probe") throw new Error("Expected first fallback caller to own the probe");

--- a/packages/coding-agent/test/config/model-registry.test.ts
+++ b/packages/coding-agent/test/config/model-registry.test.ts
@@ -154,6 +154,48 @@ describe("ModelRegistry", () => {
 		secondResolve();
 		await registry.awaitBackgroundRefresh();
 	});
+
+	test("admits one non-waiting first probe across concurrent fallback callers", async () => {
+		const start = Promise.withResolvers<void>();
+		const callers = Array.from({ length: 6 }, async () => {
+			await start.promise;
+			return registry.admitFallbackProbe("test/test-model:high");
+		});
+
+		start.resolve();
+		const admissions = await Promise.all(callers);
+
+		expect(admissions.filter(admission => admission.status === "probe")).toHaveLength(1);
+		expect(admissions.filter(admission => admission.status === "busy")).toHaveLength(5);
+	});
+
+	test("restores parallel fallback admission after the first probe succeeds", () => {
+		const first = registry.admitFallbackProbe("test/test-model");
+		if (first.status !== "probe") throw new Error("Expected first fallback caller to own the probe");
+
+		registry.markFallbackProbeHealthy(first.lease);
+
+		expect(Array.from({ length: 6 }, () => registry.admitFallbackProbe("test/test-model"))).toEqual(
+			Array.from({ length: 6 }, () => ({ status: "healthy" })),
+		);
+	});
+
+	test("ignores a stale probe callback after ownership changes", () => {
+		const first = registry.admitFallbackProbe("test/test-model");
+		if (first.status !== "probe") throw new Error("Expected first fallback caller to own the probe");
+		expect(registry.abandonFallbackProbeForSelector(first.lease, "other/model")).toBe(false);
+		expect(registry.admitFallbackProbe("test/test-model")).toEqual({ status: "busy" });
+		registry.abandonFallbackProbe(first.lease);
+
+		const second = registry.admitFallbackProbe("test/test-model");
+		if (second.status !== "probe") throw new Error("Expected abandoned probe to admit a new owner");
+		registry.markFallbackProbeHealthy(first.lease);
+
+		expect(registry.admitFallbackProbe("test/test-model")).toEqual({ status: "busy" });
+		registry.abandonFallbackProbe(second.lease);
+		expect(registry.admitFallbackProbe("test/test-model").status).toBe("probe");
+	});
+
 	test("resolves API keys and provider headers for legacy extensions", async () => {
 		const model = testModel;
 		vi.spyOn(registry, "getApiKey").mockResolvedValue("test-key");

--- a/packages/coding-agent/test/config/model-registry.test.ts
+++ b/packages/coding-agent/test/config/model-registry.test.ts
@@ -170,6 +170,15 @@ describe("ModelRegistry", () => {
 		expect(admissions.filter(admission => admission.status === "busy")).toHaveLength(5);
 	});
 
+	test("canonicalizes live fallback selector casing before admission", () => {
+		const first = registry.admitFallbackProbe(" OpenAI/GPT-4O:high ");
+		if (first.status !== "probe") throw new Error("Expected mixed-case selector to own the probe");
+
+		expect(registry.admitFallbackProbe("openai/gpt-4o")).toEqual({ status: "busy" });
+		registry.markFallbackProbeHealthy(first.lease);
+		expect(registry.admitFallbackProbe("OpenAI/Gpt-4O:max")).toEqual({ status: "healthy" });
+	});
+
 	test("restores parallel fallback admission after the first probe succeeds", () => {
 		const first = registry.admitFallbackProbe("test/test-model");
 		if (first.status !== "probe") throw new Error("Expected first fallback caller to own the probe");

--- a/packages/coding-agent/test/config/model-registry.test.ts
+++ b/packages/coding-agent/test/config/model-registry.test.ts
@@ -209,6 +209,24 @@ describe("ModelRegistry", () => {
 		expect(registry.admitFallbackProbe("test/test-model").status).toBe("probe");
 	});
 
+	test("expires a hung probe without letting its late callback change the new owner", () => {
+		const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+		const first = registry.admitFallbackProbe("test/test-model");
+		if (first.status !== "probe") throw new Error("Expected first fallback caller to own the probe");
+
+		now.mockReturnValue(1_000 + 10 * 60 * 1000);
+		const second = registry.admitFallbackProbe("test/test-model");
+		if (second.status !== "probe") throw new Error("Expected the expired probe to admit a new owner");
+
+		registry.markFallbackProbeHealthy(first.lease);
+		expect(registry.admitFallbackProbe("test/test-model")).toEqual({ status: "busy" });
+		registry.abandonFallbackProbe(first.lease);
+		expect(registry.admitFallbackProbe("test/test-model")).toEqual({ status: "busy" });
+
+		registry.markFallbackProbeHealthy(second.lease);
+		expect(registry.admitFallbackProbe("test/test-model")).toEqual({ status: "healthy" });
+	});
+
 	test("resolves API keys and provider headers for legacy extensions", async () => {
 		const model = testModel;
 		vi.spyOn(registry, "getApiKey").mockResolvedValue("test-key");

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -451,6 +451,9 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			try {
 				expect(session.model?.provider).toBe("runtime-provider");
 				expect(session.model?.id).toBe("runtime-reasoning-model");
+				expect(modelRegistry.admitFallbackProbe("runtime-provider/runtime-reasoning-model")).toEqual({
+					status: "busy",
+				});
 				// `low` differs from the fallback model's default (`high`), so this
 				// proves the suffix is inherited rather than the model default applied.
 				expect(session.thinkingLevel).toBe(Effort.Low);
@@ -458,6 +461,9 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			} finally {
 				await session.dispose();
 			}
+			const admission = modelRegistry.admitFallbackProbe("runtime-provider/runtime-reasoning-model");
+			if (admission.status !== "probe") throw new Error("Expected startup probe release on session disposal");
+			modelRegistry.abandonFallbackProbe(admission.lease);
 		} finally {
 			exitSpy.mockRestore();
 		}

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -177,6 +177,10 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		authStoragesToClose.push(authStorage);
 		authStorage.setRuntimeApiKey(parentModel.provider, "test-key");
 		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "fallback-models.yml"));
+		const settings = Settings.isolated({
+			"retry.fallbackChains": { smol: ["runtime-provider/runtime-model"] },
+		});
+		settings.setModelRole("smol", "missing-provider/missing-model");
 		const getApiKeySpy = vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async requested => {
 			if (requested.provider === "runtime-provider") return undefined;
 			if (requested.provider === parentModel.provider) return "test-key";
@@ -187,6 +191,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			agentDir: tempDir,
 			authStorage,
 			modelRegistry,
+			settings,
 			sessionManager: SessionManager.inMemory(),
 			disableExtensionDiscovery: true,
 			extensions: [providerExtension],
@@ -197,7 +202,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			enableMCP: false,
 			enableLsp: false,
 			skipPythonPreflight: true,
-			modelPattern: "runtime-provider/runtime-model",
+			modelPattern: "@smol",
 			modelPatternAuthFallback: `${parentModel.provider}/${parentModel.id}`,
 		});
 
@@ -205,6 +210,11 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			expect(session.model?.provider).toBe(parentModel.provider);
 			expect(session.model?.id).toBe(parentModel.id);
 			expect(modelFallbackMessage).toBeUndefined();
+			const unavailableAdmission = modelRegistry.admitFallbackProbe("runtime-provider/runtime-model");
+			expect(unavailableAdmission.status).toBe("probe");
+			if (unavailableAdmission.status === "probe") {
+				modelRegistry.abandonFallbackProbe(unavailableAdmission.lease);
+			}
 		} finally {
 			await session.dispose();
 			getApiKeySpy.mockRestore();

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -364,6 +364,51 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		expect(modelRegistry.admitFallbackProbe(fallbackSelector)).toEqual({ status: "busy" });
 	});
 
+	it("settles an accepted empty stop from the fallback request", async () => {
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!fallback) throw new Error("Expected bundled fallback model gpt-4o-mini");
+		const currentSelector = `${model.provider}/${model.id}`;
+		const fallbackSelector = `${fallback.provider}/${fallback.id}`;
+		const recovery = new TurnRecovery(createHost(model, modelRegistry, { [currentSelector]: [fallbackSelector] }));
+		const selector = recovery.findRetryFallbackCandidates(currentSelector, currentSelector).at(0);
+		if (!selector) throw new Error("Expected configured fallback candidate");
+		const admission = modelRegistry.admitFallbackProbe(fallbackSelector);
+		if (admission.status !== "probe") throw new Error("Expected recovery to own the fallback probe");
+		await recovery.applyRetryFallbackCandidate(currentSelector, selector, currentSelector, {
+			apiKey: "test-key",
+			probeLease: admission.lease,
+		});
+		const emptyStop = makeMessage([], fallback);
+		emptyStop.stopReason = "stop";
+		recovery.setAcceptTerminalEmptyStop(true);
+
+		await recovery.onAssistantSettledSuccessfully(emptyStop);
+
+		expect(modelRegistry.admitFallbackProbe(fallbackSelector)).toEqual({ status: "healthy" });
+	});
+
+	it("does not settle a fallback lease from an older primary response", async () => {
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!fallback) throw new Error("Expected bundled fallback model gpt-4o-mini");
+		const currentSelector = `${model.provider}/${model.id}`;
+		const fallbackSelector = `${fallback.provider}/${fallback.id}`;
+		const recovery = new TurnRecovery(createHost(model, modelRegistry, { [currentSelector]: [fallbackSelector] }));
+		const selector = recovery.findRetryFallbackCandidates(currentSelector, currentSelector).at(0);
+		if (!selector) throw new Error("Expected configured fallback candidate");
+		const admission = modelRegistry.admitFallbackProbe(fallbackSelector);
+		if (admission.status !== "probe") throw new Error("Expected recovery to own the fallback probe");
+		await recovery.applyRetryFallbackCandidate(currentSelector, selector, currentSelector, {
+			apiKey: "test-key",
+			probeLease: admission.lease,
+		});
+		const oldPrimaryStop = makeMessage([{ type: "text", text: "Old primary turn" }], model);
+		oldPrimaryStop.stopReason = "stop";
+
+		await recovery.onAssistantSettledSuccessfully(oldPrimaryStop);
+
+		expect(modelRegistry.admitFallbackProbe(fallbackSelector)).toEqual({ status: "busy" });
+	});
+
 	it("releases an attempt-zero probe when compaction blocks continuation", async () => {
 		const fallback = getBundledModel("openai", "gpt-4o-mini");
 		if (!fallback) throw new Error("Expected bundled fallback model gpt-4o-mini");

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -6,6 +6,7 @@ import type { Model, Usage } from "@oh-my-pi/pi-catalog/types";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import {
 	type RecoveryCompactionResult,
 	TurnRecovery,
@@ -45,7 +46,7 @@ function createHost(
 	const settings = Settings.isolated(fallbackChains ? { "retry.fallbackChains": fallbackChains } : {});
 	return {
 		agent: undefined as never,
-		sessionManager: undefined as never,
+		sessionManager: SessionManager.inMemory(),
 		persistedAssistantEntryId: () => undefined,
 		settings,
 		modelRegistry,
@@ -93,6 +94,12 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 	afterAll(() => {
 		authStorage.close();
 		tempDir.removeSync();
+	});
+
+	afterEach(() => {
+		modelRegistry.clearSuppressedSelectors();
+		modelRegistry.clearFallbackProbeStates();
+		vi.restoreAllMocks();
 	});
 
 	it("treats a failed turn with partial non-whitespace text as NOT retriable", () => {
@@ -244,5 +251,88 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		const recovery = new TurnRecovery(createHost(model, modelRegistry));
 		const message = createProviderErrorMessage(model, new Error("fetch failed"));
 		expect(recovery.isRetryableError(message)).toBe(true);
+	});
+
+	it("does not release a recovery-owned probe when another caller records cooldown", async () => {
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!fallback) throw new Error("Expected bundled fallback model gpt-4o-mini");
+		const currentSelector = `${model.provider}/${model.id}`;
+		const fallbackSelector = `${fallback.provider}/${fallback.id}`;
+		const recovery = new TurnRecovery(createHost(model, modelRegistry, { [currentSelector]: [fallbackSelector] }));
+		const selector = recovery.findRetryFallbackCandidates(currentSelector, currentSelector).at(0);
+		if (!selector) throw new Error("Expected configured fallback candidate");
+		const admission = modelRegistry.admitFallbackProbe(fallbackSelector);
+		if (admission.status !== "probe") throw new Error("Expected recovery to own the fallback probe");
+
+		await recovery.applyRetryFallbackCandidate(currentSelector, selector, currentSelector, {
+			apiKey: "test-key",
+			probeLease: admission.lease,
+		});
+		recovery.noteRetryFallbackCooldown(fallbackSelector, 1_000, "rate limited");
+
+		expect(modelRegistry.admitFallbackProbe(fallbackSelector)).toEqual({ status: "busy" });
+	});
+
+	it("releases an attempt-zero probe only after terminal compaction handling", async () => {
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!fallback) throw new Error("Expected bundled fallback model gpt-4o-mini");
+		const currentSelector = `${model.provider}/${model.id}`;
+		const fallbackSelector = `${fallback.provider}/${fallback.id}`;
+		const recovery = new TurnRecovery(createHost(model, modelRegistry, { [currentSelector]: [fallbackSelector] }));
+		const selector = recovery.findRetryFallbackCandidates(currentSelector, currentSelector).at(0);
+		if (!selector) throw new Error("Expected configured fallback candidate");
+		const admission = modelRegistry.admitFallbackProbe(fallbackSelector);
+		if (admission.status !== "probe") throw new Error("Expected recovery to own the fallback probe");
+		await recovery.applyRetryFallbackCandidate(currentSelector, selector, currentSelector, {
+			apiKey: "test-key",
+			probeLease: admission.lease,
+		});
+
+		await recovery.onErrorSettledWithoutRetry(makeMessage([], fallback), {
+			deferredHandoff: false,
+			continuationScheduled: true,
+		});
+		expect(modelRegistry.admitFallbackProbe(fallbackSelector)).toEqual({ status: "busy" });
+
+		await recovery.onErrorSettledWithoutRetry(makeMessage([], fallback), {
+			deferredHandoff: false,
+			continuationScheduled: false,
+		});
+		expect(modelRegistry.admitFallbackProbe(fallbackSelector).status).toBe("probe");
+	});
+
+	it("releases a probe when the prompt changes during fallback credential lookup", async () => {
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!fallback) throw new Error("Expected bundled fallback model gpt-4o-mini");
+		const currentSelector = `${model.provider}/${model.id}`;
+		const fallbackSelector = `${fallback.provider}/${fallback.id}`;
+		const host = createHost(model, modelRegistry, { [currentSelector]: [fallbackSelector] });
+		let generation = 0;
+		let modelChanges = 0;
+		host.promptGeneration = () => generation;
+		host.setModelWithProviderSessionReset = async () => {
+			modelChanges += 1;
+		};
+		const credentialStarted = Promise.withResolvers<void>();
+		const credential = Promise.withResolvers<string>();
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async candidate => {
+			if (candidate.provider === fallback.provider && candidate.id === fallback.id) {
+				credentialStarted.resolve();
+				return credential.promise;
+			}
+			return "test-key";
+		});
+		const recovery = new TurnRecovery(host);
+		const message = makeMessage([], model);
+		message.errorMessage = "invalid request";
+
+		const result = recovery.handleRetryableError(message, { hardErrorFallback: true });
+		await credentialStarted.promise;
+		generation += 1;
+		credential.resolve("test-key");
+
+		expect(await result).toBe(false);
+		expect(modelChanges).toBe(0);
+		expect(modelRegistry.admitFallbackProbe(fallbackSelector).status).toBe("probe");
 	});
 });

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -357,4 +357,113 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		expect(modelChanges).toBe(0);
 		expect(modelRegistry.admitFallbackProbe(fallbackSelector).status).toBe("probe");
 	});
+
+	it("releases the probe when disposal finishes during the model switch", async () => {
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!fallback) throw new Error("Expected bundled fallback model gpt-4o-mini");
+		const currentSelector = `${model.provider}/${model.id}`;
+		const fallbackSelector = `${fallback.provider}/${fallback.id}`;
+		const host = createHost(model, modelRegistry, { [currentSelector]: [fallbackSelector] });
+		let disposed = false;
+		host.isDisposed = () => disposed;
+		const switchStarted = Promise.withResolvers<void>();
+		const releaseSwitch = Promise.withResolvers<void>();
+		host.setModelWithProviderSessionReset = async () => {
+			switchStarted.resolve();
+			await releaseSwitch.promise;
+		};
+		const emitSessionEvent = vi.fn(async () => {});
+		host.emitSessionEvent = emitSessionEvent;
+		const recovery = new TurnRecovery(host);
+		const selector = recovery.findRetryFallbackCandidates(currentSelector, currentSelector).at(0);
+		if (!selector) throw new Error("Expected configured fallback candidate");
+		const admission = modelRegistry.admitFallbackProbe(fallbackSelector);
+		if (admission.status !== "probe") throw new Error("Expected recovery to own the fallback probe");
+
+		const applied = recovery.applyRetryFallbackCandidate(currentSelector, selector, currentSelector, {
+			apiKey: "test-key",
+			probeLease: admission.lease,
+		});
+		await switchStarted.promise;
+		disposed = true;
+		releaseSwitch.resolve();
+
+		expect(await applied).toBe(false);
+		expect(emitSessionEvent).not.toHaveBeenCalled();
+		expect(modelRegistry.admitFallbackProbe(fallbackSelector).status).toBe("probe");
+	});
+
+	it("re-admits pending fallback state before a later fresh prompt", async () => {
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!fallback) throw new Error("Expected bundled fallback model gpt-4o-mini");
+		const currentSelector = `${model.provider}/${model.id}`;
+		const fallbackSelector = `${fallback.provider}/${fallback.id}`;
+		const host = createHost(model, modelRegistry, { [currentSelector]: [fallbackSelector] });
+		let generation = 0;
+		let activeModel = model;
+		host.promptGeneration = () => generation;
+		host.model = () => activeModel;
+		const switchStarted = Promise.withResolvers<void>();
+		const releaseSwitch = Promise.withResolvers<void>();
+		host.setModelWithProviderSessionReset = async candidate => {
+			switchStarted.resolve();
+			await releaseSwitch.promise;
+			activeModel = candidate;
+		};
+		host.agent = {
+			prompt: vi.fn(async () => {
+				expect(modelRegistry.admitFallbackProbe(fallbackSelector)).toEqual({ status: "busy" });
+			}),
+		} as never;
+		const recovery = new TurnRecovery(host);
+		const selector = recovery.findRetryFallbackCandidates(currentSelector, currentSelector).at(0);
+		if (!selector) throw new Error("Expected configured fallback candidate");
+		const admission = modelRegistry.admitFallbackProbe(fallbackSelector);
+		if (admission.status !== "probe") throw new Error("Expected recovery to own the fallback probe");
+
+		const applied = recovery.applyRetryFallbackCandidate(currentSelector, selector, currentSelector, {
+			apiKey: "test-key",
+			probeLease: admission.lease,
+		});
+		await switchStarted.promise;
+		generation += 1;
+		releaseSwitch.resolve();
+
+		expect(await applied).toBe(false);
+		await recovery.promptAgentWithIdleRetry([]);
+	});
+
+	it("re-admits the fallback before a later prompt after the applied event fails", async () => {
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!fallback) throw new Error("Expected bundled fallback model gpt-4o-mini");
+		const currentSelector = `${model.provider}/${model.id}`;
+		const fallbackSelector = `${fallback.provider}/${fallback.id}`;
+		const host = createHost(model, modelRegistry, { [currentSelector]: [fallbackSelector] });
+		let activeModel = model;
+		host.model = () => activeModel;
+		host.setModelWithProviderSessionReset = async candidate => {
+			activeModel = candidate;
+		};
+		host.emitSessionEvent = async () => {
+			throw new Error("event delivery failed");
+		};
+		host.agent = {
+			prompt: vi.fn(async () => {
+				expect(modelRegistry.admitFallbackProbe(fallbackSelector)).toEqual({ status: "busy" });
+			}),
+		} as never;
+		const recovery = new TurnRecovery(host);
+		const selector = recovery.findRetryFallbackCandidates(currentSelector, currentSelector).at(0);
+		if (!selector) throw new Error("Expected configured fallback candidate");
+		const admission = modelRegistry.admitFallbackProbe(fallbackSelector);
+		if (admission.status !== "probe") throw new Error("Expected recovery to own the fallback probe");
+
+		expect(
+			recovery.applyRetryFallbackCandidate(currentSelector, selector, currentSelector, {
+				apiKey: "test-key",
+				probeLease: admission.lease,
+			}),
+		).rejects.toThrow("event delivery failed");
+		await recovery.promptAgentWithIdleRetry([]);
+	});
 });

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -139,6 +139,97 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		);
 	});
 
+	it("admits only one concurrent Fireworks Fast fallback probe", async () => {
+		const fastModel = getBundledModel("fireworks", "kimi-k2.6-fast");
+		const baseModel = getBundledModel("fireworks", "kimi-k2.6");
+		if (!fastModel || !baseModel) throw new Error("Expected bundled Fireworks Fast and base models");
+		const baseSelector = `${baseModel.provider}/${baseModel.id}`;
+		vi.spyOn(modelRegistry, "getApiKey").mockResolvedValue("test-key");
+		const switchStarted = Promise.withResolvers<void>();
+		const releaseSwitch = Promise.withResolvers<void>();
+		let firstModel = fastModel;
+		let secondModel = fastModel;
+		let modelChanges = 0;
+		const firstContinue = vi.fn();
+		const secondContinue = vi.fn();
+		const firstHost = createHost(fastModel, modelRegistry);
+		firstHost.model = () => firstModel;
+		firstHost.scheduleAgentContinue = firstContinue;
+		firstHost.setModelWithProviderSessionReset = async candidate => {
+			modelChanges++;
+			switchStarted.resolve();
+			await releaseSwitch.promise;
+			firstModel = candidate;
+		};
+		const secondHost = createHost(fastModel, modelRegistry);
+		secondHost.model = () => secondModel;
+		secondHost.scheduleAgentContinue = secondContinue;
+		secondHost.setModelWithProviderSessionReset = async candidate => {
+			modelChanges++;
+			secondModel = candidate;
+		};
+		const firstRecovery = new TurnRecovery(firstHost);
+		const secondRecovery = new TurnRecovery(secondHost);
+		const firstMessage = makeMessage([], fastModel);
+		const secondMessage = makeMessage([], fastModel);
+		firstMessage.errorMessage = "router unavailable";
+		secondMessage.errorMessage = "router unavailable";
+
+		const first = firstRecovery.handleRetryableError(firstMessage, {
+			fireworksFastFallback: true,
+			preserveFailedTurn: true,
+		});
+		await switchStarted.promise;
+		expect(modelRegistry.admitFallbackProbe(baseSelector)).toEqual({ status: "busy" });
+		expect(
+			await secondRecovery.handleRetryableError(secondMessage, {
+				fireworksFastFallback: true,
+				preserveFailedTurn: true,
+			}),
+		).toBe(false);
+		expect(modelChanges).toBe(1);
+		expect(secondContinue).not.toHaveBeenCalled();
+		releaseSwitch.resolve();
+		expect(await first).toBe(true);
+		expect(firstContinue).toHaveBeenCalledTimes(1);
+	});
+
+	it("releases a Fireworks Fast probe when the prompt changes during key lookup", async () => {
+		const fastModel = getBundledModel("fireworks", "kimi-k2.6-fast");
+		const baseModel = getBundledModel("fireworks", "kimi-k2.6");
+		if (!fastModel || !baseModel) throw new Error("Expected bundled Fireworks Fast and base models");
+		const baseSelector = `${baseModel.provider}/${baseModel.id}`;
+		const credentialStarted = Promise.withResolvers<void>();
+		const credential = Promise.withResolvers<string>();
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async candidate => {
+			if (candidate.provider === baseModel.provider && candidate.id === baseModel.id) {
+				credentialStarted.resolve();
+				return credential.promise;
+			}
+			return "test-key";
+		});
+		let generation = 0;
+		const host = createHost(fastModel, modelRegistry);
+		host.promptGeneration = () => generation;
+		const setModel = vi.fn(async () => {});
+		host.setModelWithProviderSessionReset = setModel;
+		const recovery = new TurnRecovery(host);
+		const message = makeMessage([], fastModel);
+		message.errorMessage = "router unavailable";
+
+		const result = recovery.handleRetryableError(message, {
+			fireworksFastFallback: true,
+			preserveFailedTurn: true,
+		});
+		await credentialStarted.promise;
+		generation++;
+		credential.resolve("test-key");
+
+		expect(await result).toBe(false);
+		expect(setModel).not.toHaveBeenCalled();
+		expect(modelRegistry.admitFallbackProbe(baseSelector).status).toBe("probe");
+	});
+
 	it("treats a thinking-only partial turn as still retriable", () => {
 		const recovery = new TurnRecovery(createHost(model, modelRegistry));
 		const message = makeMessage([{ type: "thinking", thinking: "Let me reason about this step by step." }], model);
@@ -273,7 +364,7 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		expect(modelRegistry.admitFallbackProbe(fallbackSelector)).toEqual({ status: "busy" });
 	});
 
-	it("releases an attempt-zero probe only after terminal compaction handling", async () => {
+	it("releases an attempt-zero probe when compaction blocks continuation", async () => {
 		const fallback = getBundledModel("openai", "gpt-4o-mini");
 		if (!fallback) throw new Error("Expected bundled fallback model gpt-4o-mini");
 		const currentSelector = `${model.provider}/${model.id}`;
@@ -297,6 +388,7 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		await recovery.onErrorSettledWithoutRetry(makeMessage([], fallback), {
 			deferredHandoff: false,
 			continuationScheduled: false,
+			automaticContinuationBlocked: true,
 		});
 		expect(modelRegistry.admitFallbackProbe(fallbackSelector).status).toBe("probe");
 	});

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -301,6 +301,28 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		expect(modelRegistry.admitFallbackProbe(fallbackSelector).status).toBe("probe");
 	});
 
+	it("releases an active probe when an aborted turn has no continuation", async () => {
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!fallback) throw new Error("Expected bundled fallback model gpt-4o-mini");
+		const currentSelector = `${model.provider}/${model.id}`;
+		const fallbackSelector = `${fallback.provider}/${fallback.id}`;
+		const recovery = new TurnRecovery(createHost(model, modelRegistry, { [currentSelector]: [fallbackSelector] }));
+		const selector = recovery.findRetryFallbackCandidates(currentSelector, currentSelector).at(0);
+		if (!selector) throw new Error("Expected configured fallback candidate");
+		const admission = modelRegistry.admitFallbackProbe(fallbackSelector);
+		if (admission.status !== "probe") throw new Error("Expected recovery to own the fallback probe");
+		await recovery.applyRetryFallbackCandidate(currentSelector, selector, currentSelector, {
+			apiKey: "test-key",
+			probeLease: admission.lease,
+		});
+		const aborted = makeMessage([], fallback);
+		aborted.stopReason = "aborted";
+
+		recovery.onAbortSettledWithoutRetry(aborted);
+
+		expect(modelRegistry.admitFallbackProbe(fallbackSelector).status).toBe("probe");
+	});
+
 	it("releases a probe when the prompt changes during fallback credential lookup", async () => {
 		const fallback = getBundledModel("openai", "gpt-4o-mini");
 		if (!fallback) throw new Error("Expected bundled fallback model gpt-4o-mini");


### PR DESCRIPTION
## Summary

- add a shared fallback probe lease to the model registry
- let only one sibling test an unknown automatic fallback selector
- let concurrent siblings skip a selector while its probe is active
- restore parallel use after the probe succeeds
- release probe ownership on failure, abort, session transition, or disposal
- protect newer probe owners from late callbacks with lease generations

Primary model selection does not use this gate.

## Tests

- `bun test --parallel=1 packages/coding-agent/test/config/model-registry.test.ts packages/coding-agent/test/agent-session-retry-fallback.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- scoped Biome checks

## CI note

All checks passed except one native/unit chunk. Its only failure was an existing browser worker startup timeout in `test/tools/browser-attach.test.ts`. This PR does not touch the browser path. GitHub does not allow a fork author to rerun that upstream job.

Fixes #7484
