### PR TITLE
fix(native): expose deterministic shell close

### DIFF
--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -18,6 +18,7 @@ use napi::{
 };
 use napi_derive::napi;
 use parking_lot::Mutex;
+use pi_shell::process::Process as ShellProcess;
 use portable_pty::{Child, CommandBuilder, PtySize, native_pty_system};
 
 use crate::{ps, task};
@@ -251,15 +252,11 @@ impl PtySession {
 
 fn terminate_pty_processes(
 	child: &mut Box<dyn Child + Send + Sync>,
-	child_pid: Option<i32>,
-	process_group_id: Option<i32>,
+	child_process: Option<&ShellProcess>,
 ) {
 	let mut targets = ps::TerminationTargets::new();
-	if let Some(pgid) = process_group_id {
-		targets.add_pgid(pgid);
-	}
-	if let Some(pid) = child_pid {
-		targets.add_pid(pid);
+	if let Some(process) = child_process {
+		targets.add_process(process.clone());
 	}
 
 	targets.signal(ps::TERM_SIGNAL);
@@ -353,6 +350,7 @@ fn run_pty_sync(
 	drop(pair.slave);
 	let child_process_id = child.process_id();
 	let child_pid = child_process_id.and_then(|value| i32::try_from(value).ok());
+	let child_process = child_pid.and_then(ShellProcess::from_pid);
 	if let Some(callback) = on_start.as_ref() {
 		callback.call(Ok(child_process_id.unwrap_or(0)), ThreadsafeFunctionCallMode::NonBlocking);
 	}
@@ -436,10 +434,6 @@ fn run_pty_sync(
 		let _ = reader_tx.send(ReaderEvent::Done);
 	});
 
-	#[cfg(unix)]
-	let process_group_id = master.process_group_leader().filter(|pgid| *pgid > 0);
-	#[cfg(not(unix))]
-	let process_group_id: Option<i32> = None;
 	let mut timed_out = false;
 	let mut cancelled = false;
 	let mut reader_done = false;
@@ -451,7 +445,7 @@ fn run_pty_sync(
 			let message = err.to_string();
 			timed_out = message.contains("Timeout");
 			cancelled = !timed_out;
-			terminate_pty_processes(&mut child, child_pid, process_group_id);
+			terminate_pty_processes(&mut child, child_process.as_ref());
 			terminate_requested = true;
 			reader_drain_deadline = Some(Instant::now() + POST_CANCEL_DRAIN_TIMEOUT);
 		}
@@ -468,7 +462,7 @@ fn run_pty_sync(
 				Ok(ControlMessage::Kill) => {
 					cancelled = true;
 					if !terminate_requested {
-						terminate_pty_processes(&mut child, child_pid, process_group_id);
+						terminate_pty_processes(&mut child, child_process.as_ref());
 						terminate_requested = true;
 						reader_drain_deadline = Some(Instant::now() + POST_CANCEL_DRAIN_TIMEOUT);
 					}

--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -253,16 +253,36 @@ impl PtySession {
 fn terminate_pty_processes(
 	child: &mut Box<dyn Child + Send + Sync>,
 	child_process: Option<&ShellProcess>,
+	process_group: Option<i32>,
+	child_reaped: bool,
 ) {
 	let mut targets = ps::TerminationTargets::new();
 	if let Some(process) = child_process {
 		targets.add_process(process.clone());
 	}
 
-	targets.signal(ps::TERM_SIGNAL);
+	let fallback_pgid = pty_fallback_pgid(child_process.is_some(), process_group, child_reaped);
+	if let Some(pgid) = fallback_pgid {
+		// A raw pgid is safe only for this immediate cancellation wave: retaining
+		// it after reaping could signal an unrelated process group after reuse.
+		let _ = ps::kill_process_group(pgid, ps::TERM_SIGNAL);
+	} else {
+		targets.signal(ps::TERM_SIGNAL);
+	}
 	let _ = child.kill();
-	targets.signal(ps::KILL_SIGNAL);
+	if let Some(pgid) = fallback_pgid {
+		let _ = ps::kill_process_group(pgid, ps::KILL_SIGNAL);
+	} else {
+		targets.signal(ps::KILL_SIGNAL);
+	}
 }
+
+fn pty_fallback_pgid(pinned: bool, process_group: Option<i32>, child_reaped: bool) -> Option<i32> {
+	(!pinned && !child_reaped)
+		.then_some(process_group)
+		.flatten()
+}
+
 fn run_pty_sync(
 	config: PtyRunConfig,
 	on_chunk: Option<ThreadsafeFunction<String>>,
@@ -358,6 +378,10 @@ fn run_pty_sync(
 		.map_err(|err| Error::from_reason(format!("PTY setup cancelled before reader: {err}")))?;
 
 	let master = pair.master;
+	#[cfg(unix)]
+	let process_group = master.process_group_leader().filter(|pid| *pid > 0);
+	#[cfg(not(unix))]
+	let process_group = None;
 	let mut writer = master
 		.take_writer()
 		.map_err(|err| Error::from_reason(format!("Failed to create PTY writer: {err}")))?;
@@ -445,7 +469,12 @@ fn run_pty_sync(
 			let message = err.to_string();
 			timed_out = message.contains("Timeout");
 			cancelled = !timed_out;
-			terminate_pty_processes(&mut child, child_process.as_ref());
+			terminate_pty_processes(
+				&mut child,
+				child_process.as_ref(),
+				process_group,
+				exit_code.is_some(),
+			);
 			terminate_requested = true;
 			reader_drain_deadline = Some(Instant::now() + POST_CANCEL_DRAIN_TIMEOUT);
 		}
@@ -462,7 +491,12 @@ fn run_pty_sync(
 				Ok(ControlMessage::Kill) => {
 					cancelled = true;
 					if !terminate_requested {
-						terminate_pty_processes(&mut child, child_process.as_ref());
+						terminate_pty_processes(
+							&mut child,
+							child_process.as_ref(),
+							process_group,
+							exit_code.is_some(),
+						);
 						terminate_requested = true;
 						reader_drain_deadline = Some(Instant::now() + POST_CANCEL_DRAIN_TIMEOUT);
 					}
@@ -623,5 +657,17 @@ fn run_pty_sync(
 fn emit_chunk(text: &str, callback: Option<&ThreadsafeFunction<String>>) {
 	if let Some(callback) = callback {
 		callback.call(Ok(text.to_string()), ThreadsafeFunctionCallMode::NonBlocking);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::pty_fallback_pgid;
+
+	#[test]
+	fn pty_fallback_pgid_respects_process_lifecycle() {
+		assert_eq!(pty_fallback_pgid(true, Some(41), false), None);
+		assert_eq!(pty_fallback_pgid(false, Some(41), false), Some(41));
+		assert_eq!(pty_fallback_pgid(false, Some(41), true), None);
 	}
 }

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -1,6 +1,9 @@
 //! Brush-based shell execution exported via N-API.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+	collections::{HashMap, HashSet},
+	sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard},
+};
 
 use napi::{
 	Env, Result,
@@ -16,6 +19,75 @@ use pi_shell::{
 };
 
 use crate::task;
+
+#[derive(Default)]
+struct NativeRunStatus {
+	active_runs: HashSet<u64>,
+	next_run_id: u64,
+	closed:      bool,
+}
+
+struct NativeRuns {
+	status:  StdMutex<NativeRunStatus>,
+	changed: tokio::sync::watch::Sender<u64>,
+}
+
+impl Default for NativeRuns {
+	fn default() -> Self {
+		let (changed, _) = tokio::sync::watch::channel(0);
+		Self { status: StdMutex::new(NativeRunStatus::default()), changed }
+	}
+}
+
+struct NativeRunLease {
+	runs:   Arc<NativeRuns>,
+	run_id: u64,
+}
+
+impl Drop for NativeRunLease {
+	fn drop(&mut self) {
+		let removed = self.runs.lock().active_runs.remove(&self.run_id);
+		if removed {
+			self.runs.changed.send_modify(|generation| {
+				*generation = generation.wrapping_add(1);
+			});
+		}
+	}
+}
+
+impl NativeRuns {
+	fn lock(&self) -> StdMutexGuard<'_, NativeRunStatus> {
+		match self.status.lock() {
+			Ok(status) => status,
+			Err(poisoned) => poisoned.into_inner(),
+		}
+	}
+
+	fn register(self: &Arc<Self>) -> Option<NativeRunLease> {
+		let mut status = self.lock();
+		if status.closed {
+			return None;
+		}
+		let run_id = status.next_run_id;
+		status.next_run_id = status.next_run_id.wrapping_add(1);
+		status.active_runs.insert(run_id);
+		Some(NativeRunLease { runs: Arc::clone(self), run_id })
+	}
+
+	fn close(&self) {
+		self.lock().closed = true;
+	}
+
+	async fn wait_until_idle(&self) {
+		let mut changed = self.changed.subscribe();
+		loop {
+			if self.lock().active_runs.is_empty() {
+				return;
+			}
+			let _ = changed.changed().await;
+		}
+	}
+}
 
 /// N-API opt-in handle for the minimizer.
 #[napi(object)]
@@ -191,8 +263,17 @@ impl From<CoreShellRunResult> for ShellRunResult {
 #[napi]
 pub struct Shell {
 	inner: Arc<CoreShell>,
+	runs:  Arc<NativeRuns>,
 }
 
+impl Drop for Shell {
+	fn drop(&mut self) {
+		self.runs.close();
+		self.inner.close_now();
+	}
+}
+
+#[allow(clippy::unused_async, reason = "N-API exposes abort as a Promise-returning method")]
 #[napi]
 impl Shell {
 	/// Create a new shell session from optional configuration.
@@ -200,7 +281,10 @@ impl Shell {
 	/// The options set session-scoped environment variables and a snapshot path.
 	#[napi(constructor)]
 	pub fn new(options: Option<ShellOptions>) -> Self {
-		Self { inner: Arc::new(CoreShell::new(options.map(Into::into))) }
+		Self {
+			inner: Arc::new(CoreShell::new(options.map(Into::into))),
+			runs:  Arc::new(NativeRuns::default()),
+		}
 	}
 
 	/// Run a shell command using the provided options.
@@ -216,6 +300,10 @@ impl Shell {
 		#[napi(ts_arg_type = "((error: Error | null, chunk: string) => void) | undefined | null")]
 		on_chunk: Option<ThreadsafeFunction<String, UnknownReturnValue>>,
 	) -> Result<PromiseRaw<'env, ShellRunResult>> {
+		let run_lease = self
+			.runs
+			.register()
+			.ok_or_else(|| Error::from_reason("Shell session is closed"))?;
 		let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
 		let inner = Arc::clone(&self.inner);
 		let run_options = CoreShellRunOptions {
@@ -225,6 +313,7 @@ impl Shell {
 			timeout_ms: options.timeout_ms,
 		};
 		task::future(env, "shell.run", async move {
+			let _run_lease = run_lease;
 			let (chunk_tx, drain_handle) = bridge_chunks(on_chunk);
 			let result = inner
 				.run(run_options, chunk_tx, cancel_token.into_core())
@@ -243,7 +332,7 @@ impl Shell {
 	/// Returns `Ok(())` even when no commands are running.
 	#[napi]
 	pub async fn abort(&self) -> Result<()> {
-		self.inner.abort().await;
+		self.inner.abort();
 		Ok(())
 	}
 
@@ -252,7 +341,9 @@ impl Shell {
 	/// Closing is terminal and safe to call more than once.
 	#[napi]
 	pub async fn close(&self) -> Result<()> {
+		self.runs.close();
 		self.inner.close().await;
+		self.runs.wait_until_idle().await;
 		Ok(())
 	}
 
@@ -363,7 +454,7 @@ async fn pump_chunks(rx: flume::Receiver<String>, mut forward: impl AsyncFnMut(S
 
 #[cfg(test)]
 mod tests {
-	use std::time::Duration;
+	use std::{sync::Arc, time::Duration};
 
 	use flume;
 	use pi_shell::{
@@ -372,7 +463,69 @@ mod tests {
 	};
 	use tokio::time;
 
-	use super::{BRIDGE_QUEUE_CHUNKS, CoreShell, pump_chunks};
+	use super::{BRIDGE_QUEUE_CHUNKS, CoreShell, NativeRuns, Shell as NativeShell, pump_chunks};
+
+	#[tokio::test]
+	async fn native_close_waits_for_core_run_and_chunk_drain() {
+		let runs = Arc::new(NativeRuns::default());
+		let run_lease = runs.register().expect("open wrapper should register a run");
+		let (core_done_tx, core_done_rx) = tokio::sync::oneshot::channel::<()>();
+		let (drain_done_tx, drain_done_rx) = tokio::sync::oneshot::channel::<()>();
+		let run = tokio::spawn(async move {
+			core_done_rx.await.expect("core completion signal");
+			drain_done_rx.await.expect("chunk drain completion signal");
+			drop(run_lease);
+		});
+
+		runs.close();
+		let waiting_runs = Arc::clone(&runs);
+		let close = tokio::spawn(async move { waiting_runs.wait_until_idle().await });
+		core_done_tx.send(()).expect("signal core completion");
+		time::sleep(Duration::from_millis(20)).await;
+		assert!(!close.is_finished(), "close must wait while chunk callbacks are still draining");
+
+		drain_done_tx
+			.send(())
+			.expect("signal chunk drain completion");
+		time::timeout(Duration::from_secs(1), close)
+			.await
+			.expect("close should settle after the chunk drain")
+			.expect("close wait task should not panic");
+		run.await.expect("run lease task should not panic");
+		assert!(runs.register().is_none(), "closed wrapper must reject later runs");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn dropping_native_shell_synchronously_cancels_active_core_work() {
+		let shell = NativeShell::new(None);
+		let inner = Arc::clone(&shell.inner);
+		let (tx, rx) = flume::unbounded::<String>();
+		let run = tokio::spawn(async move {
+			inner
+				.run(
+					CoreShellRunOptions {
+						command: "/bin/sh -c 'printf \"ready\\n\"; sleep 30'".into(),
+						..Default::default()
+					},
+					Some(tx),
+					CancelToken::default(),
+				)
+				.await
+		});
+		time::timeout(Duration::from_secs(5), rx.recv_async())
+			.await
+			.expect("active command should print readiness")
+			.expect("active command output should remain connected");
+
+		drop(shell);
+		let result = time::timeout(Duration::from_secs(10), run)
+			.await
+			.expect("dropping native wrapper should settle active work")
+			.expect("active run task should not panic")
+			.expect("active run should return cancellation");
+		assert!(result.cancelled);
+	}
 
 	/// Regression for #4078: the reader→JS bridge queue must stay bounded when
 	/// the JS side (here: a deliberately slow `forward`) cannot keep up with a

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -273,7 +273,11 @@ impl Drop for Shell {
 	}
 }
 
-#[allow(clippy::unused_async, reason = "N-API exposes abort as a Promise-returning method")]
+#[allow(
+	clippy::unused_async,
+	clippy::unused_async_trait_impl,
+	reason = "N-API exposes abort as a Promise-returning method"
+)]
 #[napi]
 impl Shell {
 	/// Create a new shell session from optional configuration.
@@ -463,36 +467,31 @@ mod tests {
 	};
 	use tokio::time;
 
-	use super::{BRIDGE_QUEUE_CHUNKS, CoreShell, NativeRuns, Shell as NativeShell, pump_chunks};
+	use super::{BRIDGE_QUEUE_CHUNKS, CoreShell, Shell as NativeShell, pump_chunks};
 
 	#[tokio::test]
 	async fn native_close_waits_for_core_run_and_chunk_drain() {
-		let runs = Arc::new(NativeRuns::default());
-		let run_lease = runs.register().expect("open wrapper should register a run");
-		let (core_done_tx, core_done_rx) = tokio::sync::oneshot::channel::<()>();
-		let (drain_done_tx, drain_done_rx) = tokio::sync::oneshot::channel::<()>();
-		let run = tokio::spawn(async move {
-			core_done_rx.await.expect("core completion signal");
-			drain_done_rx.await.expect("chunk drain completion signal");
-			drop(run_lease);
-		});
+		let shell = NativeShell::new(None);
+		let run_lease = shell
+			.runs
+			.register()
+			.expect("open wrapper should register a run");
+		let close = shell.close();
+		tokio::pin!(close);
 
-		runs.close();
-		let waiting_runs = Arc::clone(&runs);
-		let close = tokio::spawn(async move { waiting_runs.wait_until_idle().await });
-		core_done_tx.send(()).expect("signal core completion");
-		time::sleep(Duration::from_millis(20)).await;
-		assert!(!close.is_finished(), "close must wait while chunk callbacks are still draining");
+		assert!(
+			time::timeout(Duration::from_millis(20), &mut close)
+				.await
+				.is_err(),
+			"exported close must wait while chunk callbacks are still draining"
+		);
 
-		drain_done_tx
-			.send(())
-			.expect("signal chunk drain completion");
-		time::timeout(Duration::from_secs(1), close)
+		drop(run_lease);
+		time::timeout(Duration::from_secs(1), &mut close)
 			.await
-			.expect("close should settle after the chunk drain")
-			.expect("close wait task should not panic");
-		run.await.expect("run lease task should not panic");
-		assert!(runs.register().is_none(), "closed wrapper must reject later runs");
+			.expect("exported close should settle after the chunk drain")
+			.expect("exported close should succeed");
+		assert!(shell.runs.register().is_none(), "exported close must reject later runs");
 	}
 
 	#[cfg(unix)]

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -247,6 +247,15 @@ impl Shell {
 		Ok(())
 	}
 
+	/// Stop active work and release this shell session.
+	///
+	/// Closing is terminal and safe to call more than once.
+	#[napi]
+	pub async fn close(&self) -> Result<()> {
+		self.inner.close().await;
+		Ok(())
+	}
+
 	/// Count live background jobs (`&`/`nohup` children still running) on this
 	/// session. Completed jobs are reaped first. The host uses this to retain a
 	/// per-call shell whose background processes are still running instead of

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -343,6 +343,12 @@ impl Shell {
 	/// Stop active work and release this shell session.
 	///
 	/// Closing is terminal and safe to call more than once.
+	/// It terminates processes whose spawn-time identities this session pinned,
+	/// plus descendants and process groups reachable from them at close time.
+	/// On Unix, a descendant that deliberately detaches and whose recorded
+	/// ancestor exited before close is out of scope because retaining only its
+	/// numeric pid or process-group id could signal an unrelated process after
+	/// reuse.
 	#[napi]
 	pub async fn close(&self) -> Result<()> {
 		self.runs.close();

--- a/crates/pi-shell/src/process.rs
+++ b/crates/pi-shell/src/process.rs
@@ -697,6 +697,7 @@ mod platform {
 		collections::{HashMap, HashSet},
 		ffi::c_void,
 		mem,
+		os::windows::io::{IntoRawHandle, OwnedHandle as StdOwnedHandle},
 		sync::Arc,
 	};
 
@@ -786,6 +787,7 @@ mod platform {
 		fn Process32NextW(hSnapshot: Handle, lppe: *mut PROCESSENTRY32W) -> i32;
 		fn CloseHandle(hObject: Handle) -> i32;
 		fn OpenProcess(dwDesiredAccess: u32, bInheritHandle: i32, dwProcessId: u32) -> Handle;
+		fn GetProcessId(Process: Handle) -> u32;
 		fn TerminateProcess(hProcess: Handle, uExitCode: u32) -> i32;
 		fn QueryFullProcessImageNameW(
 			hProcess: Handle,
@@ -843,6 +845,10 @@ mod platform {
 		const fn as_raw(&self) -> Handle {
 			self.raw as Handle
 		}
+
+		fn from_std(handle: StdOwnedHandle) -> Self {
+			Self { raw: handle.into_raw_handle() as isize }
+		}
 	}
 
 	impl Drop for OwnedHandle {
@@ -871,6 +877,17 @@ mod platform {
 			}
 			let pid_u32 = u32::try_from(pid).ok()?;
 			let handle = open_process(pid_u32, PROCESS_REFERENCE_ACCESS)?;
+			let creation_time = process_creation_time(handle.as_raw())?;
+			Some(Self { pid, handle, creation_time })
+		}
+
+		pub fn from_owned_handle(handle: StdOwnedHandle) -> Option<Self> {
+			let handle = Arc::new(OwnedHandle::from_std(handle));
+			// SAFETY: `handle` is a live process handle duplicated from the spawned
+			// child and remains owned by this process reference.
+			let pid = i32::try_from(unsafe { GetProcessId(handle.as_raw()) })
+				.ok()
+				.filter(|pid| *pid > 0)?;
 			let creation_time = process_creation_time(handle.as_raw())?;
 			Some(Self { pid, handle, creation_time })
 		}
@@ -1283,6 +1300,13 @@ impl Process {
 	/// Open a stable process reference from a PID.
 	pub fn from_pid(pid: i32) -> Option<Self> {
 		platform::Process::from_pid(pid).map(Self::from_inner)
+	}
+
+	/// Build a stable Windows process reference from a spawn-time process
+	/// handle.
+	#[cfg(target_os = "windows")]
+	pub fn from_owned_handle(handle: std::os::windows::io::OwnedHandle) -> Option<Self> {
+		platform::Process::from_owned_handle(handle).map(Self::from_inner)
 	}
 
 	/// Open stable process references whose executable path matches exactly.

--- a/crates/pi-shell/src/process.rs
+++ b/crates/pi-shell/src/process.rs
@@ -1718,7 +1718,9 @@ pub const KILL_SIGNAL: i32 = 9;
 /// Built incrementally from job records or PTY metadata, then signalled
 /// in escalating waves (typically `TERM_SIGNAL` followed by
 /// `KILL_SIGNAL` after a grace period). Process-group calls are no-ops
-/// on platforms that do not expose process groups.
+/// on platforms that do not expose process groups. Process trees are reached
+/// through pinned process identities; detached descendants are not retained
+/// as bare numeric pids or process-group ids because either can be reused.
 #[derive(Default)]
 pub struct TerminationTargets {
 	processes: Vec<Process>,
@@ -1931,7 +1933,9 @@ impl SpawnRegistry {
 	/// without a live pinned member because the id can be reused.
 	///
 	/// Pruning also runs here so a cancellation cycle sees a compact target
-	/// set even when the record-time threshold hasn't fired yet.
+	/// set even when the record-time threshold hasn't fired yet. A descendant
+	/// that detached after its recorded ancestor exited is no longer reachable
+	/// from the pinned identity and is outside this target set.
 	#[must_use]
 	pub fn build_targets(&self) -> TerminationTargets {
 		let mut targets = TerminationTargets::new();

--- a/crates/pi-shell/src/process.rs
+++ b/crates/pi-shell/src/process.rs
@@ -2,6 +2,7 @@
 
 use std::{
 	collections::{HashMap, HashSet},
+	sync::Arc,
 	time::Duration,
 };
 
@@ -697,7 +698,6 @@ mod platform {
 		collections::{HashMap, HashSet},
 		ffi::c_void,
 		mem,
-		os::windows::io::{IntoRawHandle, OwnedHandle as StdOwnedHandle},
 		sync::Arc,
 	};
 
@@ -787,7 +787,6 @@ mod platform {
 		fn Process32NextW(hSnapshot: Handle, lppe: *mut PROCESSENTRY32W) -> i32;
 		fn CloseHandle(hObject: Handle) -> i32;
 		fn OpenProcess(dwDesiredAccess: u32, bInheritHandle: i32, dwProcessId: u32) -> Handle;
-		fn GetProcessId(Process: Handle) -> u32;
 		fn TerminateProcess(hProcess: Handle, uExitCode: u32) -> i32;
 		fn QueryFullProcessImageNameW(
 			hProcess: Handle,
@@ -845,10 +844,6 @@ mod platform {
 		const fn as_raw(&self) -> Handle {
 			self.raw as Handle
 		}
-
-		fn from_std(handle: StdOwnedHandle) -> Self {
-			Self { raw: handle.into_raw_handle() as isize }
-		}
 	}
 
 	impl Drop for OwnedHandle {
@@ -877,17 +872,6 @@ mod platform {
 			}
 			let pid_u32 = u32::try_from(pid).ok()?;
 			let handle = open_process(pid_u32, PROCESS_REFERENCE_ACCESS)?;
-			let creation_time = process_creation_time(handle.as_raw())?;
-			Some(Self { pid, handle, creation_time })
-		}
-
-		pub fn from_owned_handle(handle: StdOwnedHandle) -> Option<Self> {
-			let handle = Arc::new(OwnedHandle::from_std(handle));
-			// SAFETY: `handle` is a live process handle duplicated from the spawned
-			// child and remains owned by this process reference.
-			let pid = i32::try_from(unsafe { GetProcessId(handle.as_raw()) })
-				.ok()
-				.filter(|pid| *pid > 0)?;
 			let creation_time = process_creation_time(handle.as_raw())?;
 			Some(Self { pid, handle, creation_time })
 		}
@@ -1302,13 +1286,6 @@ impl Process {
 		platform::Process::from_pid(pid).map(Self::from_inner)
 	}
 
-	/// Build a stable Windows process reference from a spawn-time process
-	/// handle.
-	#[cfg(target_os = "windows")]
-	pub fn from_owned_handle(handle: std::os::windows::io::OwnedHandle) -> Option<Self> {
-		platform::Process::from_owned_handle(handle).map(Self::from_inner)
-	}
-
 	/// Open stable process references whose executable path matches exactly.
 	pub fn from_path(path: String) -> Vec<Self> {
 		platform::find_by_path(&path)
@@ -1721,6 +1698,21 @@ impl TerminationTargets {
 		}
 	}
 
+	/// Merge another target set while keeping process and group ids unique.
+	pub fn extend(&mut self, other: Self) {
+		for pgid in other.pgids {
+			self.add_pgid(pgid);
+		}
+		for process in other.processes {
+			self.add_process(process);
+		}
+	}
+
+	/// Iterate over the stable process references in this target set.
+	pub fn processes(&self) -> impl Iterator<Item = &Process> {
+		self.processes.iter()
+	}
+
 	/// True when no targets have been recorded.
 	#[must_use]
 	pub const fn is_empty(&self) -> bool {
@@ -1779,9 +1771,15 @@ struct RegistryState {
 	next_sweep_at: usize,
 }
 
-#[derive(Default)]
 pub struct SpawnRegistry {
-	state: Mutex<RegistryState>,
+	state:  Mutex<RegistryState>,
+	mirror: Option<Arc<Self>>,
+}
+
+impl Default for SpawnRegistry {
+	fn default() -> Self {
+		Self { state: Mutex::new(RegistryState::default()), mirror: None }
+	}
 }
 
 impl SpawnRegistry {
@@ -1807,6 +1805,13 @@ impl SpawnRegistry {
 		Self::default()
 	}
 
+	/// Create a per-run registry that also records each spawn in a persistent
+	/// session registry.
+	#[must_use]
+	pub fn with_mirror(mirror: Arc<Self>) -> Self {
+		Self { state: Mutex::new(RegistryState::default()), mirror: Some(mirror) }
+	}
+
 	/// Record a freshly spawned child. Called from the spawn-observer hook.
 	///
 	/// The `Process` handle MUST be opened by the caller *immediately* after
@@ -1820,6 +1825,7 @@ impl SpawnRegistry {
 	/// external commands cannot exhaust the process' FD/handle limit by
 	/// retaining one owned handle per historical spawn.
 	pub fn record(&self, pgid: Option<i32>, process: Option<Process>) {
+		let mirrored_process = process.clone();
 		let mut state = self.state.lock();
 		state.spawned.push(SpawnedProcess { process, pgid });
 		if state.spawned.len() >= state.next_sweep_at.max(Self::PRUNE_THRESHOLD) {
@@ -1831,6 +1837,10 @@ impl SpawnRegistry {
 			// `PRUNE_THRESHOLD` records, so amortized per-record cost is O(1)
 			// even if the live set stays large.
 			state.next_sweep_at = state.spawned.len() + Self::PRUNE_THRESHOLD;
+		}
+		drop(state);
+		if let Some(mirror) = &self.mirror {
+			mirror.record(pgid, mirrored_process);
 		}
 	}
 

--- a/crates/pi-shell/src/process.rs
+++ b/crates/pi-shell/src/process.rs
@@ -698,6 +698,7 @@ mod platform {
 		collections::{HashMap, HashSet},
 		ffi::c_void,
 		mem,
+		os::windows::io::{AsRawHandle, IntoRawHandle, OwnedHandle as StdOwnedHandle},
 		sync::Arc,
 	};
 
@@ -802,6 +803,7 @@ mod platform {
 			lpKernelTime: *mut Filetime,
 			lpUserTime: *mut Filetime,
 		) -> i32;
+		fn GetProcessId(process_handle: Handle) -> u32;
 		fn ReadProcessMemory(
 			hProcess: Handle,
 			lpBaseAddress: *const c_void,
@@ -866,6 +868,20 @@ mod platform {
 	}
 
 	impl Process {
+		pub fn from_owned_handle(handle: StdOwnedHandle) -> Option<Self> {
+			let raw = handle.as_raw_handle().cast::<c_void>();
+			// SAFETY: `raw` comes from a live owned process handle and remains valid
+			// for both queries. Ownership moves into the internal handle only after
+			// every fallible query succeeds.
+			let pid = i32::try_from(unsafe { GetProcessId(raw) })
+				.ok()
+				.filter(|pid| *pid > 0)?;
+			let creation_time = process_creation_time(raw)?;
+			let raw = handle.into_raw_handle().cast::<c_void>();
+			let handle = Arc::new(OwnedHandle::from_raw(raw)?);
+			Some(Self { pid, handle, creation_time })
+		}
+
 		pub fn from_pid(pid: i32) -> Option<Self> {
 			if pid <= 0 {
 				return None;
@@ -1281,6 +1297,12 @@ pub struct Process {
 }
 
 impl Process {
+	/// Take ownership of a process handle duplicated at spawn time.
+	#[cfg(target_os = "windows")]
+	pub fn from_owned_handle(handle: std::os::windows::io::OwnedHandle) -> Option<Self> {
+		platform::Process::from_owned_handle(handle).map(Self::from_inner)
+	}
+
 	/// Open a stable process reference from a PID.
 	pub fn from_pid(pid: i32) -> Option<Self> {
 		platform::Process::from_pid(pid).map(Self::from_inner)
@@ -1722,13 +1744,39 @@ impl TerminationTargets {
 	/// Send `signal` to every recorded target. Failures are swallowed:
 	/// targets routinely exit between collection and signalling, and
 	/// the caller's policy is "best effort".
-	pub fn signal(&self, signal: i32) {
+	pub fn signal(&mut self, signal: i32) {
+		let protected = host_protected_pids();
+		let descendants: Vec<Process> = self
+			.processes
+			.iter()
+			.flat_map(|process| process.signalable_descendants(&protected))
+			.collect();
+		for descendant in descendants {
+			self.add_process(descendant);
+		}
+		let leader_groups: Vec<i32> = self
+			.processes
+			.iter()
+			.filter_map(|process| process.group_id().filter(|group| *group == process.pid()))
+			.collect();
+		for group in leader_groups {
+			self.add_pgid(group);
+		}
 		for &pgid in &self.pgids {
 			let _ = kill_process_group(pgid, signal);
 		}
 		for process in &self.processes {
-			let _ = process.signal_tree(signal);
+			let _ = process.signal_tree_excluding(signal, &protected);
 		}
+	}
+
+	/// Drop exited targets before extending the next termination wave.
+	pub fn retain_live(&mut self) {
+		self
+			.processes
+			.retain(|process| process.status() == ProcessStatus::Running);
+		self.pgids.retain(|pgid| process_group_alive(*pgid));
+		self.seen_pids = self.processes.iter().map(Process::pid).collect();
 	}
 }
 

--- a/crates/pi-shell/src/process.rs
+++ b/crates/pi-shell/src/process.rs
@@ -11,6 +11,13 @@ use parking_lot::Mutex;
 
 use crate::cancel::CancelToken;
 
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct ProcessIdentity {
+	pid:               i32,
+	start_time:        u64,
+	start_time_subsec: u64,
+}
+
 /// Current state of a process reference.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ProcessStatus {
@@ -31,7 +38,7 @@ mod platform {
 		sync::Arc,
 	};
 
-	use super::ProcessStatus;
+	use super::{ProcessIdentity, ProcessStatus};
 
 	/// Stable Linux process reference backed by a pidfd.
 	#[derive(Clone)]
@@ -53,6 +60,14 @@ mod platform {
 
 		pub const fn pid(&self) -> i32 {
 			self.pid
+		}
+
+		pub(super) const fn identity(&self) -> ProcessIdentity {
+			ProcessIdentity {
+				pid:               self.pid,
+				start_time:        self.start_time,
+				start_time_subsec: 0,
+			}
 		}
 
 		pub fn children(&self) -> Vec<Self> {
@@ -332,7 +347,7 @@ mod platform {
 		ptr,
 	};
 
-	use super::ProcessStatus;
+	use super::{ProcessIdentity, ProcessStatus};
 
 	#[link(name = "proc", kind = "dylib")]
 	unsafe extern "C" {
@@ -364,6 +379,14 @@ mod platform {
 
 		pub const fn pid(&self) -> i32 {
 			self.pid
+		}
+
+		pub(super) const fn identity(&self) -> ProcessIdentity {
+			ProcessIdentity {
+				pid:               self.pid,
+				start_time:        self.start_tvsec,
+				start_time_subsec: self.start_tvusec,
+			}
 		}
 
 		pub fn children(&self) -> Vec<Self> {
@@ -704,7 +727,7 @@ mod platform {
 
 	use smallvec::SmallVec;
 
-	use super::ProcessStatus;
+	use super::{ProcessIdentity, ProcessStatus};
 
 	#[repr(C)]
 	#[allow(non_snake_case, reason = "Windows PROCESSENTRY32W field names must match Win32 ABI")]
@@ -894,6 +917,14 @@ mod platform {
 
 		pub const fn pid(&self) -> i32 {
 			self.pid
+		}
+
+		pub(super) const fn identity(&self) -> ProcessIdentity {
+			ProcessIdentity {
+				pid:               self.pid,
+				start_time:        self.creation_time,
+				start_time_subsec: 0,
+			}
 		}
 
 		pub fn parent_pid(&self) -> Option<i32> {
@@ -1416,6 +1447,23 @@ impl Process {
 			.collect()
 	}
 
+	const fn identity(&self) -> ProcessIdentity {
+		self.inner.identity()
+	}
+
+	/// Keep descendants pinned before TERM alongside a fresh walk for the hard
+	/// wave. The group leader may exit during grace, making `group_id()` empty
+	/// and hiding a reparented descendant; deduplicating by pinned identity also
+	/// avoids confusing a recycled PID with the original process.
+	fn merge_descendants(pinned: Vec<Self>, fresh: Vec<Self>) -> Vec<Self> {
+		let mut seen = HashSet::new();
+		pinned
+			.into_iter()
+			.chain(fresh)
+			.filter(|process| seen.insert(process.identity()))
+			.collect()
+	}
+
 	fn signal_tree(&self, signal: i32) -> u32 {
 		self.signal_tree_excluding(signal, &host_protected_pids())
 	}
@@ -1487,10 +1535,10 @@ impl Process {
 		let protected = host_protected_pids();
 
 		// Polite wave: SIGTERM the group, every live descendant, then the root.
+		let mut descendants = self.signalable_descendants(&protected);
 		if group && let Some(pgid) = self.group_id() {
 			let _ = kill_process_group(pgid, TERM_SIGNAL);
 		}
-		let mut descendants = self.signalable_descendants(&protected);
 		for child in &descendants {
 			let _ = child.inner.kill(TERM_SIGNAL);
 		}
@@ -1513,12 +1561,12 @@ impl Process {
 			}
 		}
 
-		// Hard wave. Re-walk the tree so any grandchild spawned during the grace
-		// period — or any process re-parented to the root — is signalled too.
+		// Hard wave. Keep the pre-TERM identities and add a fresh walk so
+		// descendants spawned during grace are signalled too.
 		if group && let Some(pgid) = self.group_id() {
 			let _ = kill_process_group(pgid, KILL_SIGNAL);
 		}
-		descendants = self.signalable_descendants(&protected);
+		descendants = Self::merge_descendants(descendants, self.signalable_descendants(&protected));
 		for child in &descendants {
 			let _ = child.inner.kill(KILL_SIGNAL);
 		}
@@ -2087,6 +2135,100 @@ mod tests {
 			 cancellation cleanup can reach it; this regressed on macOS when the walk relied on the \
 			 broken `proc_listchildpids`",
 		);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn terminate_tree_kills_reparented_term_ignoring_child() {
+		use std::{
+			fs,
+			os::unix::process::CommandExt,
+			process::{Child, Command},
+			thread,
+			time::Duration,
+		};
+
+		struct Cleanup {
+			child:      Option<Child>,
+			descendant: Option<Process>,
+			pgid:       Option<i32>,
+		}
+
+		impl Drop for Cleanup {
+			fn drop(&mut self) {
+				if let Some(descendant) = &self.descendant {
+					let _ = descendant.inner.kill(KILL_SIGNAL);
+				}
+				if let Some(pgid) = self.pgid {
+					let _ = kill_process_group(pgid, KILL_SIGNAL);
+				}
+				if let Some(child) = self.child.as_mut() {
+					let _ = child.kill();
+					let _ = child.wait();
+				}
+			}
+		}
+
+		let pid_file = tempfile::NamedTempFile::new().expect("create child pid file");
+		let pid_file_path = pid_file.path().to_owned();
+		let child = {
+			let mut command = Command::new("sh");
+			command
+				.arg("-c")
+				.arg(
+					r#"(trap "" TERM; echo $$ > "$CHILD_PID_FILE"; while :; do :; done) & trap "exit 0" TERM; while :; do :; done"#,
+				)
+				.env("CHILD_PID_FILE", &pid_file_path);
+			// SAFETY: This runs in the freshly forked child before exec and only
+			// changes its own session and process-group membership.
+			unsafe {
+				command.pre_exec(|| {
+					if libc::setsid() == -1 {
+						return Err(std::io::Error::last_os_error());
+					}
+					Ok(())
+				});
+			}
+			command.spawn().expect("spawn process-group leader")
+		};
+		let root_pid = i32::try_from(child.id()).expect("root pid fits in i32");
+		let mut cleanup =
+			Cleanup { child: Some(child), descendant: None, pgid: Some(root_pid) };
+		let root = Process::from_pid(root_pid).expect("pin process-group leader");
+
+		let child_pid = loop {
+			if let Ok(contents) = fs::read_to_string(&pid_file_path)
+				&& let Ok(pid) = contents.trim().parse::<i32>()
+			{
+				break pid;
+			}
+			assert_eq!(
+				root.status(),
+				ProcessStatus::Running,
+				"leader exited before its child was observable",
+			);
+			thread::sleep(Duration::from_millis(10));
+		};
+		let descendant = Process::from_pid(child_pid).expect("pin TERM-ignoring child");
+		assert_eq!(descendant.status(), ProcessStatus::Running);
+		cleanup.descendant = Some(descendant.clone());
+
+		let result = root
+			.terminate_tree(true, 50, 500, CancelToken::default())
+			.await
+			.expect("terminate tree");
+
+		assert!(result, "termination should finish within the hard-kill timeout");
+		assert_ne!(
+			descendant.status(),
+			ProcessStatus::Running,
+			"terminate_tree must not report success while a reparented child remains alive",
+		);
+
+		cleanup.pgid = None;
+		if let Some(child) = cleanup.child.as_mut() {
+			let _ = child.wait();
+		}
 	}
 
 	/// Regression test for issue #4605: `SpawnRegistry` MUST pin a stable

--- a/crates/pi-shell/src/process.rs
+++ b/crates/pi-shell/src/process.rs
@@ -1484,11 +1484,10 @@ impl Process {
 			return Ok(true);
 		}
 
-		let process_group = if group { self.group_id() } else { None };
 		let protected = host_protected_pids();
 
 		// Polite wave: SIGTERM the group, every live descendant, then the root.
-		if let Some(pgid) = process_group {
+		if group && let Some(pgid) = self.group_id() {
 			let _ = kill_process_group(pgid, TERM_SIGNAL);
 		}
 		let mut descendants = self.signalable_descendants(&protected);
@@ -1516,7 +1515,7 @@ impl Process {
 
 		// Hard wave. Re-walk the tree so any grandchild spawned during the grace
 		// period — or any process re-parented to the root — is signalled too.
-		if let Some(pgid) = process_group {
+		if group && let Some(pgid) = self.group_id() {
 			let _ = kill_process_group(pgid, KILL_SIGNAL);
 		}
 		descendants = self.signalable_descendants(&protected);
@@ -1674,7 +1673,6 @@ pub const KILL_SIGNAL: i32 = 9;
 /// on platforms that do not expose process groups.
 #[derive(Default)]
 pub struct TerminationTargets {
-	pgids:     Vec<i32>,
 	processes: Vec<Process>,
 	seen_pids: HashSet<i32>,
 }
@@ -1684,13 +1682,6 @@ impl TerminationTargets {
 	#[must_use]
 	pub fn new() -> Self {
 		Self::default()
-	}
-
-	/// Record a process group id. Duplicates are ignored.
-	pub fn add_pgid(&mut self, pgid: i32) {
-		if pgid > 0 && !self.pgids.contains(&pgid) {
-			self.pgids.push(pgid);
-		}
 	}
 
 	/// Record a pid. Duplicates are ignored. If the pid is alive, opens
@@ -1720,11 +1711,8 @@ impl TerminationTargets {
 		}
 	}
 
-	/// Merge another target set while keeping process and group ids unique.
+	/// Merge another target set while keeping process ids unique.
 	pub fn extend(&mut self, other: Self) {
-		for pgid in other.pgids {
-			self.add_pgid(pgid);
-		}
 		for process in other.processes {
 			self.add_process(process);
 		}
@@ -1738,7 +1726,7 @@ impl TerminationTargets {
 	/// True when no targets have been recorded.
 	#[must_use]
 	pub const fn is_empty(&self) -> bool {
-		self.pgids.is_empty() && self.processes.is_empty()
+		self.processes.is_empty()
 	}
 
 	/// Send `signal` to every recorded target. Failures are swallowed:
@@ -1754,16 +1742,11 @@ impl TerminationTargets {
 		for descendant in descendants {
 			self.add_process(descendant);
 		}
-		let leader_groups: Vec<i32> = self
-			.processes
-			.iter()
-			.filter_map(|process| process.group_id().filter(|group| *group == process.pid()))
-			.collect();
-		for group in leader_groups {
-			self.add_pgid(group);
-		}
-		for &pgid in &self.pgids {
-			let _ = kill_process_group(pgid, signal);
+		for process in &self.processes {
+			if process.status() == ProcessStatus::Running && process.group_id() == Some(process.pid())
+			{
+				let _ = kill_process_group(process.pid(), signal);
+			}
 		}
 		for process in &self.processes {
 			let _ = process.signal_tree_excluding(signal, &protected);
@@ -1775,7 +1758,6 @@ impl TerminationTargets {
 		self
 			.processes
 			.retain(|process| process.status() == ProcessStatus::Running);
-		self.pgids.retain(|pgid| process_group_alive(*pgid));
 		self.seen_pids = self.processes.iter().map(Process::pid).collect();
 	}
 }
@@ -1793,7 +1775,6 @@ impl TerminationTargets {
 #[derive(Clone)]
 struct SpawnedProcess {
 	process: Option<Process>,
-	pgid:    Option<i32>,
 }
 
 /// Per-run record of the OS processes a single shell command launched,
@@ -1872,10 +1853,10 @@ impl SpawnRegistry {
 	/// crosses the next-sweep watermark, so long-running loops of short
 	/// external commands cannot exhaust the process' FD/handle limit by
 	/// retaining one owned handle per historical spawn.
-	pub fn record(&self, pgid: Option<i32>, process: Option<Process>) {
+	pub fn record(&self, process: Option<Process>) {
 		let mirrored_process = process.clone();
 		let mut state = self.state.lock();
-		state.spawned.push(SpawnedProcess { process, pgid });
+		state.spawned.push(SpawnedProcess { process });
 		if state.spawned.len() >= state.next_sweep_at.max(Self::PRUNE_THRESHOLD) {
 			prune_exited(&mut state.spawned);
 			// Schedule the next sweep `PRUNE_THRESHOLD` further records away.
@@ -1888,7 +1869,7 @@ impl SpawnRegistry {
 		}
 		drop(state);
 		if let Some(mirror) = &self.mirror {
-			mirror.record(pgid, mirrored_process);
+			mirror.record(mirrored_process);
 		}
 	}
 
@@ -1896,9 +1877,10 @@ impl SpawnRegistry {
 	/// signal wave so a child spawned during a grace window — between the
 	/// cancel firing and the next wave — is still reaped.
 	///
-	/// A recorded process contributes only while alive; a recorded pgid
-	/// contributes only while the group still has members, so once the run's
-	/// whole tree exits the targets are empty and the wave loop can stop early.
+	/// A recorded process contributes only while its spawn-time identity remains
+	/// live, so once the run's whole tree exits the targets are empty and the
+	/// wave loop can stop early. Numeric process-group ids are never retained
+	/// without a live pinned member because the id can be reused.
 	///
 	/// Pruning also runs here so a cancellation cycle sees a compact target
 	/// set even when the record-time threshold hasn't fired yet.
@@ -1918,32 +1900,17 @@ impl SpawnRegistry {
 			if let Some(process) = entry.process {
 				targets.add_process(process);
 			}
-			// If the observer failed to pin a handle at spawn time (the child
-			// exited before `Process::from_pid` could open it), the child is
-			// already gone — signalling anything for that pid would either
-			// no-op or, worse, race a recycled pid onto an unrelated process.
-			// Drop the entry entirely rather than reintroduce the pid-reuse
-			// window this whole change exists to close (#4605).
-			if let Some(pgid) = entry.pgid
-				&& pgid > 0
-				&& process_group_alive(pgid)
-			{
-				targets.add_pgid(pgid);
-			}
 		}
 		targets
 	}
 }
 
-/// Drop registry entries whose pinned process, process group, and — on
-/// Windows — descendant tree are all gone. With nothing still-live the entry
+/// Drop registry entries whose pinned process and — on Windows — descendant
+/// tree are both gone. With nothing still-live the entry
 /// contributes nothing to the next termination wave and only pins an owned OS
 /// handle for no reason.
 ///
-/// The platform split matters because Windows has no process groups. On Unix
-/// a child reparented onto init keeps its pgid, so a live pgid still catches
-/// grandchildren whose immediate parent exited. On Windows there is no
-/// reparenting and no pgid, so we probe the descendant tree directly through
+/// On Windows we probe the descendant tree directly through
 /// the still-open pinned handle — dropping that handle would release the pid
 /// slot, letting a recycled pid make future Toolhelp walks unsafe (issue
 /// #4605) and orphaning any leftover child from the next cancellation wave.
@@ -1963,36 +1930,8 @@ fn prune_exited(spawned: &mut Vec<SpawnedProcess>) {
 				return true;
 			}
 		}
-		entry
-			.pgid
-			.is_some_and(|pgid| pgid > 0 && process_group_alive(pgid))
+		false
 	});
-}
-
-/// True when process group `pgid` still has at least one member. `kill(2)`
-/// with signal 0 performs permission/existence checks without delivering a
-/// signal; `EPERM` means the group exists but is not ours to signal, which
-/// still counts as alive.
-#[must_use]
-fn process_group_alive(pgid: i32) -> bool {
-	if pgid <= 0 {
-		return false;
-	}
-	platform_process_group_alive(pgid)
-}
-
-#[cfg(unix)]
-fn platform_process_group_alive(pgid: i32) -> bool {
-	// SAFETY: `kill` takes integer identifiers by value and does not access
-	// caller-owned memory. A negative pid targets the process group; signal 0
-	// only runs the existence/permission checks.
-	let ret = unsafe { libc::kill(-pgid, 0) };
-	ret == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
-}
-
-#[cfg(not(unix))]
-const fn platform_process_group_alive(_pgid: i32) -> bool {
-	false
 }
 
 #[cfg(test)]
@@ -2183,7 +2122,7 @@ mod tests {
 
 		let registry = SpawnRegistry::new();
 		let pinned = Process::from_pid(long_pid).expect("pin child at record time");
-		registry.record(None, Some(pinned));
+		registry.record(Some(pinned));
 
 		let live_targets = registry.build_targets();
 		assert!(
@@ -2280,7 +2219,7 @@ mod tests {
 				}
 				thread::sleep(Duration::from_millis(5));
 			}
-			registry.record(None, pinned);
+			registry.record(pinned);
 		}
 
 		let retained = registry.state.lock().spawned.len();
@@ -2318,7 +2257,7 @@ mod tests {
 		// (pinning ourselves) so the pruner has nothing to remove.
 		let fill = SpawnRegistry::PRUNE_THRESHOLD + 10;
 		for _ in 0..fill {
-			registry.record(None, Process::from_pid(self_pid));
+			registry.record(Process::from_pid(self_pid));
 		}
 		let after_fill = registry.state.lock().spawned.len();
 		assert_eq!(after_fill, fill, "live-only entries must not be pruned during warm-up");
@@ -2331,7 +2270,7 @@ mod tests {
 		// every one of these records.
 		let extra = 20;
 		for _ in 0..extra {
-			registry.record(None, Process::from_pid(self_pid));
+			registry.record(Process::from_pid(self_pid));
 		}
 		let after_extra = registry.state.lock().spawned.len();
 		assert_eq!(

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -307,10 +307,13 @@ impl Shell {
 		self.close_now();
 		self.abort_state.wait_for_runs().await;
 		let mut session = self.session.lock().await;
-		if let Some(core) = session.as_mut() {
-			terminate_background_jobs_and_wait(core).await;
-		}
+		let mut targets = session
+			.as_mut()
+			.map_or_else(|| self.background_registry.build_targets(), background_job_targets);
+		targets.signal(process::TERM_SIGNAL);
 		*session = None;
+		drop(session);
+		finish_background_termination(&mut targets).await;
 	}
 
 	/// Number of live background jobs (running `&`/`nohup` children) tracked by
@@ -467,7 +470,13 @@ async fn run_shell_session(
 		RunOutcome::Completed(res) => res,
 		RunOutcome::Cancelled(reason) => {
 			if let Ok(mut guard) = session.try_lock() {
-				*guard = None;
+				if abort_state.is_closed() {
+					if let Some(core) = guard.as_mut() {
+						terminate_background_jobs(core);
+					}
+				} else {
+					*guard = None;
+				}
 			}
 			let _ = process_cancel_bridge.await;
 			return Ok(ShellRunResult {
@@ -1561,13 +1570,23 @@ async fn read_output_bytes(
 }
 
 impl SpawnObserver for process::SpawnRegistry {
-	fn on_spawn(&self, pid: i32, pgid: Option<i32>) {
+	fn on_spawn(
+		&self,
+		pid: i32,
+		pgid: Option<i32>,
+		#[cfg(windows)] handle: Option<std::os::windows::io::OwnedHandle>,
+	) {
 		// Pin a stable process reference *now*, before the pid can be recycled.
 		// On Windows an open handle keeps the pid slot reserved for the lifetime
 		// of the handle; on Linux the pidfd carries identity; on macOS the
 		// recorded start-time triple detects impersonation. Deferring the open
 		// to `build_targets` (as the old code did) let a recycled pid resolve
 		// to an unrelated process — issue #4605.
+		#[cfg(windows)]
+		let process = handle
+			.and_then(process::Process::from_owned_handle)
+			.or_else(|| process::Process::from_pid(pid));
+		#[cfg(not(windows))]
 		let process = process::Process::from_pid(pid);
 		self.record(pgid, process);
 	}
@@ -1583,8 +1602,10 @@ impl SpawnObserver for process::SpawnRegistry {
 async fn terminate_run(registry: &process::SpawnRegistry) {
 	const WAVES: u32 = 3;
 	let mut saw_targets = false;
+	let mut targets = process::TerminationTargets::new();
 	for wave in 0..WAVES {
-		let targets = registry.build_targets();
+		targets.retain_live();
+		targets.extend(registry.build_targets());
 		if targets.is_empty() {
 			if saw_targets || wave + 1 == WAVES {
 				return;
@@ -1608,9 +1629,7 @@ async fn terminate_run(registry: &process::SpawnRegistry) {
 		}
 	}
 }
-fn background_job_targets(
-	session: &mut ShellSessionCore,
-) -> (process::TerminationTargets, Vec<process::Process>) {
+fn background_job_targets(session: &mut ShellSessionCore) -> process::TerminationTargets {
 	let mut targets = process::TerminationTargets::new();
 	let jobs = session.shell.jobs_mut();
 	let _ = jobs.poll();
@@ -1618,12 +1637,11 @@ fn background_job_targets(
 		job.abort_internal_tasks();
 	}
 	targets.extend(session.background_registry.build_targets());
-	let processes = targets.processes().cloned().collect();
-	(targets, processes)
+	targets
 }
 
 fn terminate_background_jobs(session: &mut ShellSessionCore) {
-	let (targets, _) = background_job_targets(session);
+	let mut targets = background_job_targets(session);
 	if targets.is_empty() {
 		// Shell-internal jobs were aborted above. Pure descendant cleanup is
 		// handled by `process_cancel_bridge` while the cancel was in flight;
@@ -1638,15 +1656,14 @@ fn terminate_background_jobs(session: &mut ShellSessionCore) {
 	});
 }
 
-async fn terminate_background_jobs_and_wait(session: &mut ShellSessionCore) {
-	let (targets, processes) = background_job_targets(session);
+async fn finish_background_termination(targets: &mut process::TerminationTargets) {
 	if targets.is_empty() {
 		return;
 	}
 
-	targets.signal(process::TERM_SIGNAL);
 	time::sleep(Duration::from_millis(150)).await;
 	targets.signal(process::KILL_SIGNAL);
+	let processes: Vec<process::Process> = targets.processes().cloned().collect();
 	for process in processes {
 		let _ = process
 			.wait_for_exit(Some(Duration::from_secs(1)), CancelToken::default())
@@ -6763,9 +6780,9 @@ mod tests {
 			2,
 			"jobspec must retain every external pipeline process",
 		);
-		let (_, captured_processes) = background_job_targets(&mut session);
+		let captured_targets = background_job_targets(&mut session);
 		assert_eq!(
-			captured_processes.len(),
+			captured_targets.processes().count(),
 			2,
 			"background cleanup must capture every external pipeline process",
 		);
@@ -8338,10 +8355,60 @@ replace = [{ pattern = "hello", replacement = "HI" }]
 		let core = session
 			.as_mut()
 			.expect("live background job should retain the session");
-		let (targets, processes) = background_job_targets(core);
+		let targets = background_job_targets(core);
 		assert!(targets.is_empty(), "completed jobs must not become termination targets");
-		assert!(processes.is_empty(), "completed jobs must not reopen process identities");
 		assert!(core.shell.jobs().jobs.is_empty(), "completed job should be reaped before capture");
+	}
+
+	#[cfg(target_os = "linux")]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn close_retains_detached_descendant_through_term_to_kill_grace() {
+		let _guard = shell_test_lock().lock().await;
+		let root = unique_temp_dir("detached-descendant-close");
+		let script_path = root.join("daemon.sh");
+		let pid_path = root.join("daemon.pid");
+		fs::write(
+			&script_path,
+			"#!/bin/sh\ntrap '' TERM\nprintf '%d\\n' \"$$\" > \"$1\"\nwhile :; do /bin/sleep 1; \
+			 done\n",
+		)
+		.expect("write daemon script");
+		let shell = Shell::new(None);
+		let command = format!(
+			"/bin/sh -c 'setsid /bin/sh \"$1\" \"$2\" & wait' sh {} {} &",
+			quote_arg(script_path.to_str().expect("utf8 script path")),
+			quote_arg(pid_path.to_str().expect("utf8 pid path")),
+		);
+		shell
+			.run(ShellRunOptions { command, ..Default::default() }, None, CancelToken::default())
+			.await
+			.expect("start detached descendant");
+		time::timeout(Duration::from_secs(5), async {
+			while !pid_path.exists() {
+				time::sleep(Duration::from_millis(10)).await;
+			}
+		})
+		.await
+		.expect("detached descendant should start");
+		let child_pid = fs::read_to_string(&pid_path)
+			.expect("read detached descendant pid")
+			.trim()
+			.parse::<i32>()
+			.expect("detached descendant pid should be an integer");
+		let child =
+			process::Process::from_pid(child_pid).expect("detached descendant should be live");
+
+		shell.close().await;
+		let child_status = child.status();
+		if child_status != process::ProcessStatus::Exited {
+			let _ = child.kill_tree(Some(process::KILL_SIGNAL));
+		}
+		assert_eq!(
+			child_status,
+			process::ProcessStatus::Exited,
+			"close must retain and kill a detached TERM-ignoring descendant",
+		);
+		let _ = fs::remove_dir_all(root);
 	}
 
 	#[cfg(unix)]
@@ -9314,6 +9381,92 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 			.await
 			.expect_err("closed shell must reject later work");
 		assert_eq!(error.to_string(), "Shell session is closed");
+	}
+
+	#[cfg(target_os = "linux")]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn close_cleans_retained_job_after_cancelling_later_run() {
+		let _guard = shell_test_lock().lock().await;
+		let root = unique_temp_dir("retained-and-active-close");
+		let script_path = root.join("retained.sh");
+		let retained_pid_path = root.join("retained.pid");
+		fs::write(
+			&script_path,
+			"#!/bin/sh\ntrap '' TERM\nprintf '%d\\n' \"$$\" > \"$1\"\nwhile :; do /bin/sleep 1; \
+			 done\n",
+		)
+		.expect("write retained script");
+		let shell = Arc::new(Shell::new(None));
+		let retained_command = format!(
+			"/bin/sh -c 'setsid /bin/sh \"$1\" \"$2\" & wait' sh {} {} &",
+			quote_arg(script_path.to_str().expect("utf8 script path")),
+			quote_arg(retained_pid_path.to_str().expect("utf8 pid path")),
+		);
+		shell
+			.run(
+				ShellRunOptions { command: retained_command, ..Default::default() },
+				None,
+				CancelToken::default(),
+			)
+			.await
+			.expect("start retained job");
+		time::timeout(Duration::from_secs(5), async {
+			while !retained_pid_path.exists() {
+				time::sleep(Duration::from_millis(10)).await;
+			}
+		})
+		.await
+		.expect("retained child should start");
+		let retained_pid = fs::read_to_string(&retained_pid_path)
+			.expect("read retained pid")
+			.trim()
+			.parse::<i32>()
+			.expect("retained pid should be an integer");
+		let retained =
+			process::Process::from_pid(retained_pid).expect("retained child should be live");
+
+		let running_shell = Arc::clone(&shell);
+		let (tx, rx) = flume::unbounded::<String>();
+		let run_handle = tokio::spawn(async move {
+			running_shell
+				.run(
+					ShellRunOptions {
+						command: "/bin/sh -c 'trap \"\" TERM; printf \"%d\\n\" \"$$\"; while :; do \
+						          /bin/sleep 1; done'"
+							.into(),
+						..Default::default()
+					},
+					Some(tx),
+					CancelToken::default(),
+				)
+				.await
+		});
+		let active_pid = time::timeout(Duration::from_secs(5), rx.recv_async())
+			.await
+			.expect("active command should print readiness")
+			.expect("active command output should remain connected")
+			.trim()
+			.parse::<i32>()
+			.expect("active pid should be an integer");
+		let active = process::Process::from_pid(active_pid).expect("active child should be live");
+
+		shell.close().await;
+		let run_result = run_handle
+			.await
+			.expect("active run task should not panic")
+			.expect("active close should report cancellation");
+		let retained_status = retained.status();
+		let active_status = active.status();
+		if retained_status != process::ProcessStatus::Exited {
+			let _ = retained.kill_tree(Some(process::KILL_SIGNAL));
+		}
+		if active_status != process::ProcessStatus::Exited {
+			let _ = active.kill_tree(Some(process::KILL_SIGNAL));
+		}
+		assert!(run_result.cancelled);
+		assert_eq!(retained_status, process::ProcessStatus::Exited);
+		assert_eq!(active_status, process::ProcessStatus::Exited);
+		let _ = fs::remove_dir_all(root);
 	}
 
 	#[cfg(unix)]

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -28,7 +28,10 @@ use flume::Sender;
 use jiff::{Timestamp, fmt::strtime, tz::TimeZone};
 #[cfg(not(unix))]
 use tokio::io::AsyncReadExt as _;
-use tokio::{sync::Mutex as TokioMutex, time};
+use tokio::{
+	sync::{Mutex as TokioMutex, Notify},
+	time,
+};
 use tokio_util::sync::CancellationToken;
 
 #[cfg(windows)]
@@ -39,12 +42,14 @@ use crate::{
 };
 
 struct ShellSessionCore {
-	shell: BrushShell,
+	shell:               BrushShell,
+	background_registry: Arc<process::SpawnRegistry>,
 }
 
 #[derive(Default)]
 struct ShellAbortStatus {
 	active_runs: HashMap<u64, AbortToken>,
+	run_waiters: Vec<Arc<Notify>>,
 	next_run_id: u64,
 	closed:      bool,
 }
@@ -67,7 +72,18 @@ impl Drop for CancelRunOnDrop {
 
 impl Drop for ShellRunLease {
 	fn drop(&mut self) {
-		self.state.lock().active_runs.remove(&self.run_id);
+		let waiters = {
+			let mut status = self.state.lock();
+			status.active_runs.remove(&self.run_id);
+			if status.active_runs.is_empty() {
+				std::mem::take(&mut status.run_waiters)
+			} else {
+				Vec::new()
+			}
+		};
+		for waiter in waiters {
+			waiter.notify_one();
+		}
 	}
 }
 
@@ -116,6 +132,19 @@ impl ShellAbortState {
 
 	fn is_closed(&self) -> bool {
 		self.lock().closed
+	}
+
+	async fn wait_for_runs(&self) {
+		let waiter = {
+			let mut status = self.lock();
+			if status.active_runs.is_empty() {
+				return;
+			}
+			let waiter = Arc::new(Notify::new());
+			status.run_waiters.push(waiter.clone());
+			waiter
+		};
+		waiter.notified().await;
 	}
 }
 
@@ -198,9 +227,10 @@ pub struct ShellExecuteOptions {
 pub type ShellExecuteResult = ShellRunResult;
 
 pub struct Shell {
-	session:     Arc<TokioMutex<Option<ShellSessionCore>>>,
-	abort_state: ShellAbortState,
-	config:      ShellConfig,
+	session:             Arc<TokioMutex<Option<ShellSessionCore>>>,
+	abort_state:         ShellAbortState,
+	background_registry: Arc<process::SpawnRegistry>,
+	config:              ShellConfig,
 }
 
 impl Shell {
@@ -223,6 +253,7 @@ impl Shell {
 		Self {
 			session: Arc::new(TokioMutex::new(None)),
 			abort_state: ShellAbortState::default(),
+			background_registry: Arc::new(process::SpawnRegistry::new()),
 			config,
 		}
 	}
@@ -234,7 +265,7 @@ impl Shell {
 		mut cancel_token: CancelToken,
 	) -> Result<ShellRunResult> {
 		let abort_token = cancel_token.emplace_abort_token();
-		let _run_lease = self
+		let run_lease = self
 			.abort_state
 			.register(abort_token)
 			.ok_or_else(|| Error::msg("Shell session is closed"))?;
@@ -251,6 +282,8 @@ impl Shell {
 			run_config,
 			on_chunk,
 			&cancel_token,
+			self.background_registry.clone(),
+			Some(run_lease),
 		)
 		.await
 	}
@@ -272,9 +305,10 @@ impl Shell {
 	/// Closing is terminal and idempotent. Future calls to [`Self::run`] fail.
 	pub async fn close(&self) {
 		self.close_now();
+		self.abort_state.wait_for_runs().await;
 		let mut session = self.session.lock().await;
 		if let Some(core) = session.as_mut() {
-			terminate_background_jobs_and_wait(&mut core.shell).await;
+			terminate_background_jobs_and_wait(core).await;
 		}
 		*session = None;
 	}
@@ -371,14 +405,17 @@ async fn run_shell_session(
 	run_config: ShellRunConfig,
 	on_chunk: Option<Sender<String>>,
 	ct: &CancelToken,
+	background_registry: Arc<process::SpawnRegistry>,
+	run_lease: Option<ShellRunLease>,
 ) -> Result<ShellRunResult> {
 	let tokio_cancel = CancellationToken::new();
 	let _cancel_on_drop = CancelRunOnDrop(tokio_cancel.clone());
-	let spawn_registry = Arc::new(process::SpawnRegistry::new());
+	let spawn_registry = Arc::new(process::SpawnRegistry::with_mirror(background_registry.clone()));
 	let process_cancel_bridge = tokio::spawn({
 		let tokio_cancel = tokio_cancel.clone();
 		let spawn_registry = spawn_registry.clone();
 		async move {
+			let _run_lease = run_lease;
 			tokio_cancel.cancelled().await;
 			terminate_run(&spawn_registry).await;
 		}
@@ -409,6 +446,7 @@ async fn run_shell_session(
 						&config,
 						Some(spawn_registry.clone()),
 						Some(command_cancel.clone()),
+						Some(background_registry),
 					)
 					.await?,
 				),
@@ -482,6 +520,7 @@ async fn run_shell_oneshot(
 				&config,
 				Some(spawn_registry.clone()),
 				Some(tokio_cancel.clone()),
+				None,
 			)
 			.await?;
 			run_shell_command(&mut session, &run_config, on_chunk, tokio_cancel, spawn_registry).await
@@ -547,6 +586,7 @@ async fn run_shell_oneshot_streams(
 				&config,
 				Some(spawn_registry.clone()),
 				Some(tokio_cancel.clone()),
+				None,
 			)
 			.await?;
 			run_shell_command_streams(&mut session, &run_config, streams, tokio_cancel, spawn_registry)
@@ -667,13 +707,14 @@ fn merge_path_values(_existing: &str, incoming: &str) -> String {
 
 #[cfg(test)]
 async fn create_session(config: &ShellConfig) -> Result<ShellSessionCore> {
-	create_session_for_run(config, None, None).await
+	create_session_for_run(config, None, None, None).await
 }
 
 async fn create_session_for_run(
 	config: &ShellConfig,
 	spawn_registry: Option<Arc<process::SpawnRegistry>>,
 	cancel_token: Option<CancellationToken>,
+	background_registry: Option<Arc<process::SpawnRegistry>>,
 ) -> Result<ShellSessionCore> {
 	let mut shell = BrushShell::builder()
 		.do_not_inherit_env(true)
@@ -853,7 +894,11 @@ async fn create_session_for_run(
 		source_snapshot(&mut shell, snapshot_path, spawn_registry, cancel_token).await?;
 	}
 
-	Ok(ShellSessionCore { shell })
+	Ok(ShellSessionCore {
+		shell,
+		background_registry: background_registry
+			.unwrap_or_else(|| Arc::new(process::SpawnRegistry::new())),
+	})
 }
 
 async fn source_snapshot(
@@ -1265,7 +1310,7 @@ async fn run_shell_command_once(
 		.await;
 
 	if cancel_token.is_cancelled() {
-		terminate_background_jobs(&mut session.shell);
+		terminate_background_jobs(session);
 	}
 
 	drop(params);
@@ -1384,7 +1429,7 @@ async fn run_shell_command_streams(
 		.await;
 
 	if cancel_token.is_cancelled() {
-		terminate_background_jobs(&mut session.shell);
+		terminate_background_jobs(session);
 	}
 
 	if env_scope_pushed {
@@ -1564,43 +1609,25 @@ async fn terminate_run(registry: &process::SpawnRegistry) {
 	}
 }
 fn background_job_targets(
-	shell: &mut BrushShell,
+	session: &mut ShellSessionCore,
 ) -> (process::TerminationTargets, Vec<process::Process>) {
 	let mut targets = process::TerminationTargets::new();
-	let mut processes = Vec::new();
-	let jobs = shell.jobs_mut();
-	if jobs.poll().is_err() {
-		return (targets, processes);
-	}
+	let jobs = session.shell.jobs_mut();
+	let _ = jobs.poll();
 	for job in &mut jobs.jobs {
 		job.abort_internal_tasks();
-		if let Some(pgid) = job.process_group_id() {
-			targets.add_pgid(pgid);
-		}
-		#[cfg(target_os = "windows")]
-		for handle in job.duplicate_kill_handles() {
-			if let Some(process) = process::Process::from_owned_handle(handle) {
-				targets.add_process(process.clone());
-				processes.push(process);
-			}
-		}
-		#[cfg(not(target_os = "windows"))]
-		for pid in job.process_ids() {
-			if let Some(process) = process::Process::from_pid(pid) {
-				targets.add_process(process.clone());
-				processes.push(process);
-			}
-		}
 	}
+	targets.extend(session.background_registry.build_targets());
+	let processes = targets.processes().cloned().collect();
 	(targets, processes)
 }
 
-fn terminate_background_jobs(shell: &mut BrushShell) {
-	let (targets, _) = background_job_targets(shell);
+fn terminate_background_jobs(session: &mut ShellSessionCore) {
+	let (targets, _) = background_job_targets(session);
 	if targets.is_empty() {
 		// Shell-internal jobs were aborted above. Pure descendant cleanup is
 		// handled by `process_cancel_bridge` while the cancel was in flight;
-		// without job-tracked pgids or pids there is nothing else to signal here.
+		// without spawn-time registry targets there is nothing else to signal here.
 		return;
 	}
 
@@ -1611,8 +1638,8 @@ fn terminate_background_jobs(shell: &mut BrushShell) {
 	});
 }
 
-async fn terminate_background_jobs_and_wait(shell: &mut BrushShell) {
-	let (targets, processes) = background_job_targets(shell);
+async fn terminate_background_jobs_and_wait(session: &mut ShellSessionCore) {
+	let (targets, processes) = background_job_targets(session);
 	if targets.is_empty() {
 		return;
 	}
@@ -6705,7 +6732,10 @@ mod tests {
 			quote_arg(second_pidfile.to_str().expect("utf8 second pidfile")),
 			quote_arg(second_ready.to_str().expect("utf8 second ready path")),
 		);
-		let (mut session, params) = kill_test_context().await;
+		let (mut session, mut params) = kill_test_context().await;
+		let spawn_registry =
+			Arc::new(process::SpawnRegistry::with_mirror(session.background_registry.clone()));
+		params.set_spawn_observer(spawn_registry.clone());
 		let source_info = SourceInfo::from("pi-natives:test");
 
 		time::timeout(
@@ -6733,7 +6763,7 @@ mod tests {
 			2,
 			"jobspec must retain every external pipeline process",
 		);
-		let (_, captured_processes) = background_job_targets(&mut session.shell);
+		let (_, captured_processes) = background_job_targets(&mut session);
 		assert_eq!(
 			captured_processes.len(),
 			2,
@@ -8245,6 +8275,52 @@ replace = [{ pattern = "hello", replacement = "HI" }]
 
 	#[cfg(unix)]
 	#[tokio::test(flavor = "multi_thread")]
+	async fn close_terminates_background_process_spawned_after_run_returns() {
+		let _guard = shell_test_lock().lock().await;
+		let root = unique_temp_dir("delayed-background-close");
+		let pid_path = root.join("child.pid");
+		let escaped_pid_path = pid_path.to_string_lossy().replace('\'', "'\\''");
+		let shell = Shell::new(None);
+		shell
+			.run(
+				ShellRunOptions {
+					command: format!(
+						"{{ sleep 0.1; /bin/sh -c 'trap \"\" TERM; printf \"%d\\n\" \"$$\" > \"$1\"; \
+						 while :; do /bin/sleep 1; done' sh '{escaped_pid_path}'; }} &"
+					),
+					..Default::default()
+				},
+				None,
+				CancelToken::default(),
+			)
+			.await
+			.expect("start delayed background task");
+		time::timeout(Duration::from_secs(5), async {
+			while !pid_path.exists() {
+				time::sleep(Duration::from_millis(10)).await;
+			}
+		})
+		.await
+		.expect("delayed background child should start");
+		let child_pid = fs::read_to_string(&pid_path)
+			.expect("read delayed background pid")
+			.trim()
+			.parse::<i32>()
+			.expect("delayed background pid should be an integer");
+		let child =
+			process::Process::from_pid(child_pid).expect("delayed background child should be live");
+
+		shell.close().await;
+		assert_eq!(
+			child.status(),
+			process::ProcessStatus::Exited,
+			"delayed background child must be gone when close resolves"
+		);
+		let _ = fs::remove_dir_all(root);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
 	async fn close_reaps_completed_background_job_before_target_capture() {
 		let _guard = shell_test_lock().lock().await;
 		let shell = Shell::new(None);
@@ -8262,7 +8338,7 @@ replace = [{ pattern = "hello", replacement = "HI" }]
 		let core = session
 			.as_mut()
 			.expect("live background job should retain the session");
-		let (targets, processes) = background_job_targets(&mut core.shell);
+		let (targets, processes) = background_job_targets(core);
 		assert!(targets.is_empty(), "completed jobs must not become termination targets");
 		assert!(processes.is_empty(), "completed jobs must not reopen process identities");
 		assert!(core.shell.jobs().jobs.is_empty(), "completed job should be reaped before capture");
@@ -9162,6 +9238,8 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 			},
 			None,
 			&CancelToken::default(),
+			Arc::new(process::SpawnRegistry::new()),
+			None,
 		)
 		.await
 		.expect_err("closed state must reject creation before cancellation is bridged");
@@ -9197,7 +9275,9 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 			running_shell
 				.run(
 					ShellRunOptions {
-						command: "/bin/sh -c 'printf \"ready\\n\"; sleep 30'".into(),
+						command: "/bin/sh -c 'trap \"\" TERM; printf \"%d\\n\" \"$$\"; while :; do \
+						          /bin/sleep 1; done'"
+							.into(),
 						..Default::default()
 					},
 					Some(tx),
@@ -9205,14 +9285,23 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 				)
 				.await
 		});
-		time::timeout(Duration::from_secs(5), rx.recv_async())
+		let child_pid = time::timeout(Duration::from_secs(5), rx.recv_async())
 			.await
 			.expect("active command should print readiness")
-			.expect("active command output should remain connected");
+			.expect("active command output should remain connected")
+			.trim()
+			.parse::<i32>()
+			.expect("active command pid should be an integer");
+		let child =
+			process::Process::from_pid(child_pid).expect("active command should still be running");
 
-		time::timeout(Duration::from_secs(10), shell.close())
-			.await
-			.expect("close should settle after cancelling active work");
+		time::timeout(Duration::from_secs(10), async {
+			tokio::join!(shell.close(), shell.close());
+		})
+		.await
+		.expect("concurrent close calls should settle after cancelling active work");
+		assert!(run_handle.is_finished(), "active run must be settled when close resolves");
+		assert_eq!(child.status(), process::ProcessStatus::Exited);
 		let result = time::timeout(Duration::from_secs(10), run_handle)
 			.await
 			.expect("active run should settle before close returns")
@@ -9253,14 +9342,20 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 			.trim()
 			.parse::<i32>()
 			.expect("active command pid should be an integer");
+		let child =
+			process::Process::from_pid(child_pid).expect("active command should still be running");
 
 		run.abort();
 		let error = run.await.expect_err("aborted task should drop Shell::run");
 		assert!(error.is_cancelled());
 		time::timeout(Duration::from_secs(10), shell.close())
 			.await
-			.expect("close must not wait on detached command work");
-		wait_for_process_exit(child_pid).await;
+			.expect("close must wait for dropped-run cleanup");
+		assert_eq!(
+			child.status(),
+			process::ProcessStatus::Exited,
+			"dropped run child must be gone when close resolves"
+		);
 
 		let error = shell
 			.run(ShellRunOptions::default(), None, CancelToken::default())

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -57,6 +57,14 @@ struct ShellRunLease {
 	run_id: u64,
 }
 
+struct CancelRunOnDrop(CancellationToken);
+
+impl Drop for CancelRunOnDrop {
+	fn drop(&mut self) {
+		self.0.cancel();
+	}
+}
+
 impl Drop for ShellRunLease {
 	fn drop(&mut self) {
 		self.state.lock().active_runs.remove(&self.run_id);
@@ -365,6 +373,7 @@ async fn run_shell_session(
 	ct: &CancelToken,
 ) -> Result<ShellRunResult> {
 	let tokio_cancel = CancellationToken::new();
+	let _cancel_on_drop = CancelRunOnDrop(tokio_cancel.clone());
 	let spawn_registry = Arc::new(process::SpawnRegistry::new());
 	let process_cancel_bridge = tokio::spawn({
 		let tokio_cancel = tokio_cancel.clone();
@@ -375,15 +384,19 @@ async fn run_shell_session(
 		}
 	});
 
-	let mut run_task = tokio::spawn({
+	enum RunOutcome {
+		Completed(Result<(ExecutionResult, Option<MinimizerResult>, Option<String>)>),
+		Cancelled(AbortReason),
+	}
+	let outcome = {
 		let session = session.clone();
 		let abort_state = abort_state.clone();
-		let tokio_cancel = tokio_cancel.clone();
+		let command_cancel = tokio_cancel.clone();
 		let spawn_registry = spawn_registry.clone();
-		async move {
+		let run = async move {
 			let mut session_guard = tokio::select! {
 				guard = session.lock() => guard,
-				() = tokio_cancel.cancelled() => return Err(Error::msg("Shell run cancelled")),
+				() = command_cancel.cancelled() => return Err(Error::msg("Shell run cancelled")),
 			};
 			if abort_state.is_closed() {
 				return Err(Error::msg("Shell session is closed"));
@@ -395,27 +408,26 @@ async fn run_shell_session(
 					create_session_for_run(
 						&config,
 						Some(spawn_registry.clone()),
-						Some(tokio_cancel.clone()),
+						Some(command_cancel.clone()),
 					)
 					.await?,
 				),
 			};
-			run_shell_command(session, &run_config, on_chunk, tokio_cancel, spawn_registry).await
-		}
-	});
-
-	let res = tokio::select! {
-		res = &mut run_task => res,
-		reason = ct.wait() => {
-			tokio_cancel.cancel();
-			let graceful = time::timeout(Duration::from_secs(2), &mut run_task).await;
-			if graceful.is_err() {
-				run_task.abort();
-				let _ = run_task.await;
+			run_shell_command(session, &run_config, on_chunk, command_cancel, spawn_registry).await
+		};
+		tokio::pin!(run);
+		tokio::select! {
+			res = &mut run => RunOutcome::Completed(res),
+			reason = ct.wait() => {
+				tokio_cancel.cancel();
+				let _ = time::timeout(Duration::from_secs(2), &mut run).await;
+				RunOutcome::Cancelled(reason)
 			}
-			// Use try_lock to avoid deadlocking if another task holds the session.
-			// If we can't acquire the lock, the session will be cleaned up when the
-			// holding task finishes.
+		}
+	};
+	let res = match outcome {
+		RunOutcome::Completed(res) => res,
+		RunOutcome::Cancelled(reason) => {
 			if let Ok(mut guard) = session.try_lock() {
 				*guard = None;
 			}
@@ -427,10 +439,8 @@ async fn run_shell_session(
 				minimized:   None,
 				working_dir: None,
 			});
-		}
+		},
 	};
-	let res =
-		res.unwrap_or_else(|err| Err(Error::msg(format!("Shell execution task failed: {err}"))));
 	process_cancel_bridge.abort();
 	let _ = process_cancel_bridge.await;
 	let keepalive = res.as_ref().is_ok_and(|(exec, ..)| session_keepalive(exec));
@@ -1558,14 +1568,26 @@ fn background_job_targets(
 ) -> (process::TerminationTargets, Vec<process::Process>) {
 	let mut targets = process::TerminationTargets::new();
 	let mut processes = Vec::new();
-	for job in &mut shell.jobs_mut().jobs {
+	let jobs = shell.jobs_mut();
+	if jobs.poll().is_err() {
+		return (targets, processes);
+	}
+	for job in &mut jobs.jobs {
 		job.abort_internal_tasks();
 		if let Some(pgid) = job.process_group_id() {
 			targets.add_pgid(pgid);
 		}
-		if let Some(pid) = job.representative_pid() {
-			targets.add_pid(pid);
+		#[cfg(target_os = "windows")]
+		for handle in job.duplicate_kill_handles() {
+			if let Some(process) = process::Process::from_owned_handle(handle) {
+				targets.add_process(process.clone());
+				processes.push(process);
+			}
+		}
+		#[cfg(not(target_os = "windows"))]
+		for pid in job.process_ids() {
 			if let Some(process) = process::Process::from_pid(pid) {
+				targets.add_process(process.clone());
 				processes.push(process);
 			}
 		}
@@ -6711,6 +6733,12 @@ mod tests {
 			2,
 			"jobspec must retain every external pipeline process",
 		);
+		let (_, captured_processes) = background_job_targets(&mut session.shell);
+		assert_eq!(
+			captured_processes.len(),
+			2,
+			"background cleanup must capture every external pipeline process",
+		);
 		let pids = [&first_pidfile, &second_pidfile].map(|pidfile| {
 			fs::read_to_string(pidfile)
 				.expect("pipeline pidfile")
@@ -8217,6 +8245,31 @@ replace = [{ pattern = "hello", replacement = "HI" }]
 
 	#[cfg(unix)]
 	#[tokio::test(flavor = "multi_thread")]
+	async fn close_reaps_completed_background_job_before_target_capture() {
+		let _guard = shell_test_lock().lock().await;
+		let shell = Shell::new(None);
+		shell
+			.run(
+				ShellRunOptions { command: "/bin/sleep 1 &".into(), ..Default::default() },
+				None,
+				CancelToken::default(),
+			)
+			.await
+			.expect("start short background job");
+		time::sleep(Duration::from_millis(1_100)).await;
+
+		let mut session = shell.session.lock().await;
+		let core = session
+			.as_mut()
+			.expect("live background job should retain the session");
+		let (targets, processes) = background_job_targets(&mut core.shell);
+		assert!(targets.is_empty(), "completed jobs must not become termination targets");
+		assert!(processes.is_empty(), "completed jobs must not reopen process identities");
+		assert!(core.shell.jobs().jobs.is_empty(), "completed job should be reaped before capture");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
 	async fn segmented_false_and_printf_skips_second_and_returns_nonzero() {
 		let root = unique_temp_dir("false-and");
 		let minimizer = printf_minimizer(&root.join("minimizer.toml"), None);
@@ -9166,6 +9219,48 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 			.expect("active run task should not panic")
 			.expect("active close should report cancellation");
 		assert!(result.cancelled);
+
+		let error = shell
+			.run(ShellRunOptions::default(), None, CancelToken::default())
+			.await
+			.expect_err("closed shell must reject later work");
+		assert_eq!(error.to_string(), "Shell session is closed");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn dropping_run_future_releases_session_and_allows_close() {
+		let _guard = shell_test_lock().lock().await;
+		let shell = Arc::new(Shell::new(None));
+		let running_shell = Arc::clone(&shell);
+		let (tx, rx) = flume::unbounded::<String>();
+		let run = tokio::spawn(async move {
+			running_shell
+				.run(
+					ShellRunOptions {
+						command: "/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 30'".into(),
+						..Default::default()
+					},
+					Some(tx),
+					CancelToken::default(),
+				)
+				.await
+		});
+		let child_pid = time::timeout(Duration::from_secs(5), rx.recv_async())
+			.await
+			.expect("active command should print its pid")
+			.expect("active command output should remain connected")
+			.trim()
+			.parse::<i32>()
+			.expect("active command pid should be an integer");
+
+		run.abort();
+		let error = run.await.expect_err("aborted task should drop Shell::run");
+		assert!(error.is_cancelled());
+		time::timeout(Duration::from_secs(10), shell.close())
+			.await
+			.expect("close must not wait on detached command work");
+		wait_for_process_exit(child_pid).await;
 
 		let error = shell
 			.run(ShellRunOptions::default(), None, CancelToken::default())

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -105,6 +105,10 @@ impl ShellAbortState {
 			abort_token.abort(AbortReason::Signal);
 		}
 	}
+
+	fn is_closed(&self) -> bool {
+		self.lock().closed
+	}
 }
 
 fn shell_working_dir_matches(shell: &BrushShell, cwd: &str) -> bool {
@@ -234,6 +238,7 @@ impl Shell {
 		};
 		run_shell_session(
 			self.session.clone(),
+			self.abort_state.clone(),
 			self.config.clone(),
 			run_config,
 			on_chunk,
@@ -261,7 +266,7 @@ impl Shell {
 		self.close_now();
 		let mut session = self.session.lock().await;
 		if let Some(core) = session.as_mut() {
-			terminate_background_jobs(&mut core.shell);
+			terminate_background_jobs_and_wait(&mut core.shell).await;
 		}
 		*session = None;
 	}
@@ -353,6 +358,7 @@ pub async fn execute_shell_streams(
 
 async fn run_shell_session(
 	session: Arc<TokioMutex<Option<ShellSessionCore>>>,
+	abort_state: ShellAbortState,
 	config: ShellConfig,
 	run_config: ShellRunConfig,
 	on_chunk: Option<Sender<String>>,
@@ -371,6 +377,7 @@ async fn run_shell_session(
 
 	let mut run_task = tokio::spawn({
 		let session = session.clone();
+		let abort_state = abort_state.clone();
 		let tokio_cancel = tokio_cancel.clone();
 		let spawn_registry = spawn_registry.clone();
 		async move {
@@ -378,6 +385,9 @@ async fn run_shell_session(
 				guard = session.lock() => guard,
 				() = tokio_cancel.cancelled() => return Err(Error::msg("Shell run cancelled")),
 			};
+			if abort_state.is_closed() {
+				return Err(Error::msg("Shell session is closed"));
+			}
 
 			let session = match &mut *session_guard {
 				Some(session) => session,
@@ -1543,8 +1553,11 @@ async fn terminate_run(registry: &process::SpawnRegistry) {
 		}
 	}
 }
-fn terminate_background_jobs(shell: &mut BrushShell) {
+fn background_job_targets(
+	shell: &mut BrushShell,
+) -> (process::TerminationTargets, Vec<process::Process>) {
 	let mut targets = process::TerminationTargets::new();
+	let mut processes = Vec::new();
 	for job in &mut shell.jobs_mut().jobs {
 		job.abort_internal_tasks();
 		if let Some(pgid) = job.process_group_id() {
@@ -1552,8 +1565,16 @@ fn terminate_background_jobs(shell: &mut BrushShell) {
 		}
 		if let Some(pid) = job.representative_pid() {
 			targets.add_pid(pid);
+			if let Some(process) = process::Process::from_pid(pid) {
+				processes.push(process);
+			}
 		}
 	}
+	(targets, processes)
+}
+
+fn terminate_background_jobs(shell: &mut BrushShell) {
+	let (targets, _) = background_job_targets(shell);
 	if targets.is_empty() {
 		// Shell-internal jobs were aborted above. Pure descendant cleanup is
 		// handled by `process_cancel_bridge` while the cancel was in flight;
@@ -1566,6 +1587,22 @@ fn terminate_background_jobs(shell: &mut BrushShell) {
 		time::sleep(Duration::from_millis(150)).await;
 		targets.signal(process::KILL_SIGNAL);
 	});
+}
+
+async fn terminate_background_jobs_and_wait(shell: &mut BrushShell) {
+	let (targets, processes) = background_job_targets(shell);
+	if targets.is_empty() {
+		return;
+	}
+
+	targets.signal(process::TERM_SIGNAL);
+	time::sleep(Duration::from_millis(150)).await;
+	targets.signal(process::KILL_SIGNAL);
+	for process in processes {
+		let _ = process
+			.wait_for_exit(Some(Duration::from_secs(1)), CancelToken::default())
+			.await;
+	}
 }
 
 /// Apply per-command environment variables onto a freshly pushed
@@ -8148,7 +8185,9 @@ replace = [{ pattern = "hello", replacement = "HI" }]
 		shell
 			.run(
 				ShellRunOptions {
-					command: "/bin/sleep 30 & printf '%d\\n' \"$!\"".into(),
+					command: "/bin/sh -c 'trap \"\" TERM; printf \"%d\\n\" \"$$\"; while :; do \
+					          /bin/sleep 1; done' &"
+						.into(),
 					..Default::default()
 				},
 				Some(tx),
@@ -8163,10 +8202,17 @@ replace = [{ pattern = "hello", replacement = "HI" }]
 			.trim()
 			.parse::<i32>()
 			.expect("background pid should be an integer");
+		let child = process::Process::from_pid(child_pid)
+			.expect("background child should still be running before close");
 		assert_eq!(shell.live_background_job_count().await, 1);
+		assert_eq!(child.status(), process::ProcessStatus::Running);
 
 		shell.close().await;
-		wait_for_process_exit(child_pid).await;
+		assert_eq!(
+			child.status(),
+			process::ProcessStatus::Exited,
+			"TERM-ignoring background child must be gone when close resolves"
+		);
 	}
 
 	#[cfg(unix)]
@@ -9032,6 +9078,45 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 				.is_err(),
 			"completed run should no longer receive shared abort signals"
 		);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn closed_state_blocks_session_creation_before_cancel_bridge_runs() {
+		let root = unique_temp_dir("closed-before-create");
+		let snapshot_path = root.join("snapshot.sh");
+		let marker_path = root.join("created");
+		let escaped_marker_path = marker_path.to_string_lossy().replace('\'', "'\\''");
+		std::fs::write(&snapshot_path, format!("printf created > '{escaped_marker_path}'\n"))
+			.expect("write snapshot");
+
+		let session = Arc::new(TokioMutex::new(None));
+		let abort_state = ShellAbortState::default();
+		abort_state.close();
+		let result = run_shell_session(
+			Arc::clone(&session),
+			abort_state,
+			ShellConfig {
+				session_env:   None,
+				snapshot_path: Some(snapshot_path.to_string_lossy().into_owned()),
+				minimizer:     None,
+			},
+			ShellRunConfig {
+				command:   "true".into(),
+				cwd:       None,
+				env:       None,
+				minimizer: None,
+			},
+			None,
+			&CancelToken::default(),
+		)
+		.await
+		.expect_err("closed state must reject creation before cancellation is bridged");
+
+		assert_eq!(result.to_string(), "Shell session is closed");
+		assert!(!marker_path.exists(), "closed run must not source its snapshot");
+		assert!(session.lock().await.is_none(), "closed run must not insert a session core");
+		let _ = std::fs::remove_dir_all(&root);
 	}
 
 	#[tokio::test]

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -1573,7 +1573,7 @@ impl SpawnObserver for process::SpawnRegistry {
 	fn on_spawn(
 		&self,
 		pid: i32,
-		pgid: Option<i32>,
+		_pgid: Option<i32>,
 		#[cfg(windows)] handle: Option<std::os::windows::io::OwnedHandle>,
 	) {
 		// Pin a stable process reference *now*, before the pid can be recycled.
@@ -1588,15 +1588,14 @@ impl SpawnObserver for process::SpawnRegistry {
 			.or_else(|| process::Process::from_pid(pid));
 		#[cfg(not(windows))]
 		let process = process::Process::from_pid(pid);
-		self.record(pgid, process);
+		self.record(process);
 	}
 }
 
 // Escalating TERM -> KILL waves over the processes this run spawned, scoped via
 // the per-run `SpawnRegistry`. The kill set is rebuilt each wave so a child
-// spawned in a grace window — or a grandchild whose recorded parent already
-// exited but whose process group is still live — is still reaped, and the loop
-// stops as soon as the run's whole tree is gone. Scoping to the registry (vs a
+// spawned in a grace window is still reaped, and the loop stops as soon as the
+// run's whole tree is gone. Scoping to the registry (vs a
 // process-global descendant diff) is what keeps a cancel from reaping a
 // concurrent run's children in a shared host process.
 async fn terminate_run(registry: &process::SpawnRegistry) {

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -42,23 +42,50 @@ struct ShellSessionCore {
 	shell: BrushShell,
 }
 
+#[derive(Default)]
+struct ShellAbortStatus {
+	abort_token: Option<AbortToken>,
+	closed:      bool,
+}
+
 #[derive(Clone, Default)]
-struct ShellAbortState(Arc<TokioMutex<Option<AbortToken>>>);
+struct ShellAbortState(Arc<TokioMutex<ShellAbortStatus>>);
 
 impl ShellAbortState {
-	async fn set(&self, abort_token: AbortToken) {
-		*self.0.lock().await = Some(abort_token);
+	async fn set(&self, abort_token: AbortToken) -> bool {
+		let mut status = self.0.lock().await;
+		if status.closed {
+			abort_token.abort(AbortReason::Signal);
+			return false;
+		}
+		status.abort_token = Some(abort_token);
+		true
 	}
 
 	async fn clear(&self) {
-		*self.0.lock().await = None;
+		self.0.lock().await.abort_token = None;
 	}
 
 	async fn abort(&self) {
-		let abort_token = self.0.lock().await.clone();
+		let abort_token = self.0.lock().await.abort_token.clone();
 		if let Some(abort_token) = abort_token {
 			abort_token.abort(AbortReason::Signal);
 		}
+	}
+
+	async fn close(&self) {
+		let abort_token = {
+			let mut status = self.0.lock().await;
+			status.closed = true;
+			status.abort_token.clone()
+		};
+		if let Some(abort_token) = abort_token {
+			abort_token.abort(AbortReason::Signal);
+		}
+	}
+
+	async fn is_closed(&self) -> bool {
+		self.0.lock().await.closed
 	}
 }
 
@@ -176,6 +203,9 @@ impl Shell {
 		on_chunk: Option<Sender<String>>,
 		mut cancel_token: CancelToken,
 	) -> Result<ShellRunResult> {
+		if self.abort_state.is_closed().await {
+			return Err(Error::msg("Shell session is closed"));
+		}
 		let run_config = ShellRunConfig {
 			command:   options.command,
 			cwd:       options.cwd,
@@ -195,6 +225,15 @@ impl Shell {
 
 	pub async fn abort(&self) {
 		self.abort_state.abort().await;
+	}
+
+	/// Stop active work and release the persistent session.
+	///
+	/// Closing is terminal and idempotent. Future calls to [`Self::run`] fail.
+	pub async fn close(&self) {
+		self.abort_state.close().await;
+		*self.session.lock().await = None;
+		self.abort_state.clear().await;
 	}
 
 	/// Number of live background jobs (running `&`/`nohup` children) tracked by
@@ -321,7 +360,9 @@ async fn run_shell_session(
 					.await?,
 				),
 			};
-			abort_state.set(at).await;
+			if !abort_state.set(at).await {
+				return Err(Error::msg("Shell session is closed"));
+			}
 			run_shell_command(session, &run_config, on_chunk, tokio_cancel, spawn_registry).await
 		}
 	});
@@ -8816,13 +8857,27 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 		let mut cancel_token = CancelToken::default();
 		let abort_token = cancel_token.emplace_abort_token();
 
-		abort_state.set(abort_token).await;
+		assert!(abort_state.set(abort_token).await);
 		abort_state.abort().await;
 
 		let reason = time::timeout(Duration::from_millis(100), cancel_token.wait())
 			.await
 			.expect("cancel token should be signalled");
 		assert!(matches!(reason, AbortReason::Signal));
+	}
+
+	#[tokio::test]
+	async fn close_is_terminal_and_idempotent() {
+		let shell = Shell::new(None);
+
+		shell.close().await;
+		shell.close().await;
+
+		let error = shell
+			.run(ShellRunOptions::default(), None, CancelToken::default())
+			.await
+			.expect_err("closed shell must reject new work");
+		assert_eq!(error.to_string(), "Shell session is closed");
 	}
 
 	#[cfg(unix)]

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -303,6 +303,11 @@ impl Shell {
 	/// Stop active work and release the persistent session.
 	///
 	/// Closing is terminal and idempotent. Future calls to [`Self::run`] fail.
+	/// It terminates processes whose spawn-time identities this session pinned,
+	/// plus descendants and process groups reachable from them at close time.
+	/// On Unix, a descendant that deliberately detaches and whose recorded
+	/// ancestor exited before close is out of scope: retaining only its numeric
+	/// pid or process-group id could signal an unrelated process after reuse.
 	pub async fn close(&self) {
 		self.close_now();
 		self.abort_state.wait_for_runs().await;

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -7,7 +7,7 @@ use std::{
 	io::{self, BufRead, Write},
 	path::{Path, PathBuf},
 	str,
-	sync::Arc,
+	sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard},
 	time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -44,48 +44,66 @@ struct ShellSessionCore {
 
 #[derive(Default)]
 struct ShellAbortStatus {
-	abort_token: Option<AbortToken>,
+	active_runs: HashMap<u64, AbortToken>,
+	next_run_id: u64,
 	closed:      bool,
 }
 
 #[derive(Clone, Default)]
-struct ShellAbortState(Arc<TokioMutex<ShellAbortStatus>>);
+struct ShellAbortState(Arc<StdMutex<ShellAbortStatus>>);
+
+struct ShellRunLease {
+	state:  ShellAbortState,
+	run_id: u64,
+}
+
+impl Drop for ShellRunLease {
+	fn drop(&mut self) {
+		self.state.lock().active_runs.remove(&self.run_id);
+	}
+}
 
 impl ShellAbortState {
-	async fn set(&self, abort_token: AbortToken) -> bool {
-		let mut status = self.0.lock().await;
+	fn lock(&self) -> StdMutexGuard<'_, ShellAbortStatus> {
+		match self.0.lock() {
+			Ok(status) => status,
+			Err(poisoned) => poisoned.into_inner(),
+		}
+	}
+
+	fn register(&self, abort_token: AbortToken) -> Option<ShellRunLease> {
+		let mut status = self.lock();
 		if status.closed {
 			abort_token.abort(AbortReason::Signal);
-			return false;
+			return None;
 		}
-		status.abort_token = Some(abort_token);
-		true
+		let run_id = status.next_run_id;
+		status.next_run_id = status.next_run_id.wrapping_add(1);
+		status.active_runs.insert(run_id, abort_token);
+		Some(ShellRunLease { state: self.clone(), run_id })
 	}
 
-	async fn clear(&self) {
-		self.0.lock().await.abort_token = None;
-	}
-
-	async fn abort(&self) {
-		let abort_token = self.0.lock().await.abort_token.clone();
-		if let Some(abort_token) = abort_token {
+	fn abort(&self) {
+		let abort_tokens = self
+			.lock()
+			.active_runs
+			.values()
+			.cloned()
+			.collect::<Vec<_>>();
+		for abort_token in abort_tokens {
 			abort_token.abort(AbortReason::Signal);
 		}
 	}
 
-	async fn close(&self) {
-		let abort_token = {
-			let mut status = self.0.lock().await;
+	fn close(&self) {
+		let abort_tokens = {
+			let mut status = self.lock();
 			status.closed = true;
-			status.abort_token.clone()
+			status.active_runs.values().cloned().collect::<Vec<_>>()
 		};
-		if let Some(abort_token) = abort_token {
+		for abort_token in abort_tokens {
 			abort_token.abort(AbortReason::Signal);
 		}
-	}
-
-	async fn is_closed(&self) -> bool {
-		self.0.lock().await.closed
 	}
 }
 
@@ -203,9 +221,11 @@ impl Shell {
 		on_chunk: Option<Sender<String>>,
 		mut cancel_token: CancelToken,
 	) -> Result<ShellRunResult> {
-		if self.abort_state.is_closed().await {
-			return Err(Error::msg("Shell session is closed"));
-		}
+		let abort_token = cancel_token.emplace_abort_token();
+		let _run_lease = self
+			.abort_state
+			.register(abort_token)
+			.ok_or_else(|| Error::msg("Shell session is closed"))?;
 		let run_config = ShellRunConfig {
 			command:   options.command,
 			cwd:       options.cwd,
@@ -214,26 +234,36 @@ impl Shell {
 		};
 		run_shell_session(
 			self.session.clone(),
-			self.abort_state.clone(),
 			self.config.clone(),
 			run_config,
 			on_chunk,
-			&mut cancel_token,
+			&cancel_token,
 		)
 		.await
 	}
 
-	pub async fn abort(&self) {
-		self.abort_state.abort().await;
+	pub fn abort(&self) {
+		self.abort_state.abort();
+	}
+
+	/// Mark the shell closed and synchronously signal all registered runs.
+	///
+	/// This is used by host wrappers whose destructor cannot await
+	/// [`Self::close`].
+	pub fn close_now(&self) {
+		self.abort_state.close();
 	}
 
 	/// Stop active work and release the persistent session.
 	///
 	/// Closing is terminal and idempotent. Future calls to [`Self::run`] fail.
 	pub async fn close(&self) {
-		self.abort_state.close().await;
-		*self.session.lock().await = None;
-		self.abort_state.clear().await;
+		self.close_now();
+		let mut session = self.session.lock().await;
+		if let Some(core) = session.as_mut() {
+			terminate_background_jobs(&mut core.shell);
+		}
+		*session = None;
 	}
 
 	/// Number of live background jobs (running `&`/`nohup` children) tracked by
@@ -323,11 +353,10 @@ pub async fn execute_shell_streams(
 
 async fn run_shell_session(
 	session: Arc<TokioMutex<Option<ShellSessionCore>>>,
-	abort_state: ShellAbortState,
 	config: ShellConfig,
 	run_config: ShellRunConfig,
 	on_chunk: Option<Sender<String>>,
-	ct: &mut CancelToken,
+	ct: &CancelToken,
 ) -> Result<ShellRunResult> {
 	let tokio_cancel = CancellationToken::new();
 	let spawn_registry = Arc::new(process::SpawnRegistry::new());
@@ -342,12 +371,13 @@ async fn run_shell_session(
 
 	let mut run_task = tokio::spawn({
 		let session = session.clone();
-		let abort_state = abort_state.clone();
 		let tokio_cancel = tokio_cancel.clone();
-		let at = ct.emplace_abort_token();
 		let spawn_registry = spawn_registry.clone();
 		async move {
-			let mut session_guard = session.lock().await;
+			let mut session_guard = tokio::select! {
+				guard = session.lock() => guard,
+				() = tokio_cancel.cancelled() => return Err(Error::msg("Shell run cancelled")),
+			};
 
 			let session = match &mut *session_guard {
 				Some(session) => session,
@@ -360,9 +390,6 @@ async fn run_shell_session(
 					.await?,
 				),
 			};
-			if !abort_state.set(at).await {
-				return Err(Error::msg("Shell session is closed"));
-			}
 			run_shell_command(session, &run_config, on_chunk, tokio_cancel, spawn_registry).await
 		}
 	});
@@ -376,7 +403,6 @@ async fn run_shell_session(
 				run_task.abort();
 				let _ = run_task.await;
 			}
-			abort_state.clear().await;
 			// Use try_lock to avoid deadlocking if another task holds the session.
 			// If we can't acquire the lock, the session will be cleaned up when the
 			// holding task finishes.
@@ -397,8 +423,6 @@ async fn run_shell_session(
 		res.unwrap_or_else(|err| Err(Error::msg(format!("Shell execution task failed: {err}"))));
 	process_cancel_bridge.abort();
 	let _ = process_cancel_bridge.await;
-	abort_state.clear().await;
-
 	let keepalive = res.as_ref().is_ok_and(|(exec, ..)| session_keepalive(exec));
 	if !keepalive {
 		*session.lock().await = None;
@@ -8015,6 +8039,26 @@ mod tests {
 	}
 
 	#[cfg(unix)]
+	async fn wait_for_process_exit(pid: i32) {
+		time::timeout(Duration::from_secs(5), async {
+			loop {
+				// SAFETY: tests pass a positive PID reported by their own child process.
+				// Signal 0 only checks whether that process still exists.
+				if unsafe { libc::kill(pid, 0) } == -1 {
+					let error = std::io::Error::last_os_error();
+					if error.raw_os_error() == Some(libc::ESRCH) {
+						return;
+					}
+					panic!("kill({pid}, 0) failed while checking child cleanup: {error}");
+				}
+				time::sleep(Duration::from_millis(20)).await;
+			}
+		})
+		.await
+		.expect("timed out waiting for child process to exit");
+	}
+
+	#[cfg(unix)]
 	#[tokio::test(flavor = "multi_thread")]
 	async fn uutils_diff_reads_process_substitution_fds() {
 		let (result, output) = time::timeout(
@@ -8091,7 +8135,38 @@ replace = [{ pattern = "hello", replacement = "HI" }]
 		assert_eq!(shell.live_background_job_count().await, 1);
 
 		// Dropping the shell at scope end reaps the child via kill-on-drop.
-		shell.abort().await;
+		shell.abort();
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn close_terminates_retained_background_jobs() {
+		let _guard = shell_test_lock().lock().await;
+		let shell = Shell::new(None);
+		let (tx, rx) = flume::unbounded::<String>();
+
+		shell
+			.run(
+				ShellRunOptions {
+					command: "/bin/sleep 30 & printf '%d\\n' \"$!\"".into(),
+					..Default::default()
+				},
+				Some(tx),
+				CancelToken::default(),
+			)
+			.await
+			.expect("start retained background job");
+		let child_pid = rx
+			.recv_async()
+			.await
+			.expect("background command should print its pid")
+			.trim()
+			.parse::<i32>()
+			.expect("background pid should be an integer");
+		assert_eq!(shell.live_background_job_count().await, 1);
+
+		shell.close().await;
+		wait_for_process_exit(child_pid).await;
 	}
 
 	#[cfg(unix)]
@@ -8675,6 +8750,70 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 		);
 	}
 
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn close_while_sourcing_snapshot_stops_snapshot_and_rejects_later_runs() {
+		let _guard = shell_test_lock().lock().await;
+		let root = unique_temp_dir("snapshot-close");
+		let snapshot_path = root.join("snapshot.sh");
+		let pid_path = root.join("snapshot-child.pid");
+		let escaped_pid_path = pid_path.to_string_lossy().replace('\'', "'\\''");
+		std::fs::write(
+			&snapshot_path,
+			format!(
+				"/bin/sh -c 'printf \"%d\\n\" \"$$\" > \"$1\"; sleep 30' sh '{escaped_pid_path}'\n"
+			),
+		)
+		.expect("write snapshot file");
+
+		let shell = Arc::new(Shell::new(Some(ShellOptions {
+			snapshot_path: Some(snapshot_path.to_string_lossy().into_owned()),
+			..Default::default()
+		})));
+		let running_shell = Arc::clone(&shell);
+		let run_handle = tokio::spawn(async move {
+			running_shell
+				.run(
+					ShellRunOptions { command: "printf done".into(), ..Default::default() },
+					None,
+					CancelToken::default(),
+				)
+				.await
+		});
+
+		let child_pid = time::timeout(Duration::from_secs(5), async {
+			loop {
+				if let Ok(pid_text) = std::fs::read_to_string(&pid_path)
+					&& let Ok(pid) = pid_text.trim().parse::<i32>()
+					&& pid > 0
+				{
+					return pid;
+				}
+				time::sleep(Duration::from_millis(20)).await;
+			}
+		})
+		.await
+		.expect("timed out waiting for snapshot child pid");
+
+		time::timeout(Duration::from_secs(10), shell.close())
+			.await
+			.expect("close should settle while snapshot setup is blocked");
+		let result = time::timeout(Duration::from_secs(10), run_handle)
+			.await
+			.expect("snapshot run should settle after close")
+			.expect("snapshot run task should not panic")
+			.expect("closing an active run should return cancellation");
+		assert!(result.cancelled);
+		wait_for_process_exit(child_pid).await;
+
+		let error = shell
+			.run(ShellRunOptions::default(), None, CancelToken::default())
+			.await
+			.expect_err("closed shell must reject later work");
+		assert_eq!(error.to_string(), "Shell session is closed");
+		let _ = std::fs::remove_dir_all(&root);
+	}
+
 	/// Regression for the `suspended (tty input)` bug: an **interactive child
 	/// inside a pipeline** (`zsh -i ... | awk`) used to stay in the host
 	/// session, open `/dev/tty`, `tcsetpgrp` itself to the foreground, and
@@ -8857,13 +8996,42 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 		let mut cancel_token = CancelToken::default();
 		let abort_token = cancel_token.emplace_abort_token();
 
-		assert!(abort_state.set(abort_token).await);
-		abort_state.abort().await;
+		let _run_lease = abort_state
+			.register(abort_token)
+			.expect("open state should register a run");
+		abort_state.abort();
 
 		let reason = time::timeout(Duration::from_millis(100), cancel_token.wait())
 			.await
 			.expect("cancel token should be signalled");
 		assert!(matches!(reason, AbortReason::Signal));
+	}
+
+	#[tokio::test]
+	async fn completed_run_cannot_clear_a_newer_run_abort_token() {
+		let abort_state = ShellAbortState::default();
+		let mut first_cancel = CancelToken::default();
+		let mut second_cancel = CancelToken::default();
+		let first = abort_state
+			.register(first_cancel.emplace_abort_token())
+			.expect("first run should register");
+		let _second = abort_state
+			.register(second_cancel.emplace_abort_token())
+			.expect("second run should register");
+
+		drop(first);
+		abort_state.abort();
+
+		let reason = time::timeout(Duration::from_millis(100), second_cancel.wait())
+			.await
+			.expect("newer run should remain registered after the older run finishes");
+		assert!(matches!(reason, AbortReason::Signal));
+		assert!(
+			time::timeout(Duration::from_millis(20), first_cancel.wait())
+				.await
+				.is_err(),
+			"completed run should no longer receive shared abort signals"
+		);
 	}
 
 	#[tokio::test]
@@ -8877,6 +9045,47 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 			.run(ShellRunOptions::default(), None, CancelToken::default())
 			.await
 			.expect_err("closed shell must reject new work");
+		assert_eq!(error.to_string(), "Shell session is closed");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn close_cancels_active_work_before_it_resolves() {
+		let _guard = shell_test_lock().lock().await;
+		let shell = Arc::new(Shell::new(None));
+		let running_shell = Arc::clone(&shell);
+		let (tx, rx) = flume::unbounded::<String>();
+		let run_handle = tokio::spawn(async move {
+			running_shell
+				.run(
+					ShellRunOptions {
+						command: "/bin/sh -c 'printf \"ready\\n\"; sleep 30'".into(),
+						..Default::default()
+					},
+					Some(tx),
+					CancelToken::default(),
+				)
+				.await
+		});
+		time::timeout(Duration::from_secs(5), rx.recv_async())
+			.await
+			.expect("active command should print readiness")
+			.expect("active command output should remain connected");
+
+		time::timeout(Duration::from_secs(10), shell.close())
+			.await
+			.expect("close should settle after cancelling active work");
+		let result = time::timeout(Duration::from_secs(10), run_handle)
+			.await
+			.expect("active run should settle before close returns")
+			.expect("active run task should not panic")
+			.expect("active close should report cancellation");
+		assert!(result.cancelled);
+
+		let error = shell
+			.run(ShellRunOptions::default(), None, CancelToken::default())
+			.await
+			.expect_err("closed shell must reject later work");
 		assert_eq!(error.to_string(), "Shell session is closed");
 	}
 

--- a/crates/vendor/brush-core/src/commands.rs
+++ b/crates/vendor/brush-core/src/commands.rs
@@ -689,6 +689,8 @@ pub(crate) fn execute_external_command(
 				tracing::warn!("could not retrieve pid for child process");
 			}
 
+			let mut child_process = processes::ChildProcess::new(child, pid, actual_pgid);
+
 			// Report the spawned child for scoped teardown. Skipped for reparented
 			// launches (`detach_reparent`, e.g. `nohup cmd &`): those double-fork
 			// out of the descendant tree and must survive the host's cancellation
@@ -697,10 +699,11 @@ pub(crate) fn execute_external_command(
 				&& let Some(observer) = context.params.spawn_observer()
 				&& let Some(pid) = pid
 			{
+				#[cfg(windows)]
+				observer.on_spawn(pid, actual_pgid, child_process.duplicate_kill_handle());
+				#[cfg(not(windows))]
 				observer.on_spawn(pid, actual_pgid);
 			}
-
-			let mut child_process = processes::ChildProcess::new(child, pid, actual_pgid);
 			if let Some((output, markers)) = marker_output.take() {
 				child_process.set_completion_marker(
 					output,

--- a/crates/vendor/brush-core/src/interp.rs
+++ b/crates/vendor/brush-core/src/interp.rs
@@ -10,6 +10,9 @@ use itertools::Itertools;
 
 use tokio_util::sync::CancellationToken;
 
+#[cfg(windows)]
+use std::os::windows::io::OwnedHandle;
+
 use crate::{
 	ShellFd,
 	arithmetic::{self, ExpandAndEvaluate},
@@ -79,7 +82,7 @@ pub trait ExternalCommandOutputMarker: Send + Sync {
 pub trait SpawnObserver: Send + Sync {
 	/// Reports a freshly spawned external child. `pgid` is the child's process
 	/// group id when known (always its own pid under `NewProcessGroup`).
-	fn on_spawn(&self, pid: i32, pgid: Option<i32>);
+	fn on_spawn(&self, pid: i32, pgid: Option<i32>, #[cfg(windows)] handle: Option<OwnedHandle>);
 }
 
 /// Parameters for execution.

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Added deterministic, terminal cleanup for native shell sessions ([#7485](https://github.com/can1357/oh-my-pi/issues/7485)).
+
 ## [17.2.5] - 2026-08-03
 
 ### Breaking Changes

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Added deterministic, terminal cleanup for native shell sessions ([#7485](https://github.com/can1357/oh-my-pi/issues/7485)).
+- Added deterministic cleanup for native shell sessions' pinned processes and reachable descendants ([#7485](https://github.com/can1357/oh-my-pi/issues/7485)).
 
 ## [17.2.5] - 2026-08-03
 

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -210,6 +210,12 @@ export declare class Shell {
    */
   abort(): Promise<void>
   /**
+   * Stop active work and release this shell session.
+   *
+   * Closing is terminal and safe to call more than once.
+   */
+  close(): Promise<void>
+  /**
    * Count live background jobs (`&`/`nohup` children still running) on this
    * session. Completed jobs are reaped first. The host uses this to retain a
    * per-call shell whose background processes are still running instead of

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -213,6 +213,12 @@ export declare class Shell {
    * Stop active work and release this shell session.
    *
    * Closing is terminal and safe to call more than once.
+   * It terminates processes whose spawn-time identities this session pinned,
+   * plus descendants and process groups reachable from them at close time.
+   * On Unix, a descendant that deliberately detaches and whose recorded
+   * ancestor exited before close is out of scope because retaining only its
+   * numeric pid or process-group id could signal an unrelated process after
+   * reuse.
    */
   close(): Promise<void>
   /**


### PR DESCRIPTION
## Summary

- add a terminal, idempotent close operation to the Rust shell session
- export `Shell.close(): Promise<void>` through N-API
- make closed shells reject new work
- use the same shutdown state for explicit close and final drop

## Why this is separate

Pull request CI tests TypeScript against the last released native addon. The coding-agent teardown fix cannot call this method until the native addon lands and ships.

This PR is the native API stage. #7490 is the caller stage and must follow the native release.

## Checks

- `cargo test -p pi-shell close_is_terminal_and_idempotent`
- `cargo test -p pi-shell abort_state_signals_cancel_token`
- `cargo check -p pi-natives --lib`
- `cargo fmt --check`

## CI note

The native build, lint, smoke, integration, runtime, UI, workspace, and singleton groups passed. The native/unit group passed 62 of 63 chunks. Its only failure was the existing daemon restart test in `test/tools/launch.test.ts`, where `readyAt` was briefly missing. This PR does not touch that path.

Part of #7485
Closes #7491
