### PR TITLE
fix(utils): honor current PATH in cached lookups

### DIFF
--- a/packages/utils/src/which.ts
+++ b/packages/utils/src/which.ts
@@ -215,9 +215,7 @@ function cacheKey(command: string, options?: Bun.WhichOptions): CacheKey {
 export function $which(command: string, options?: WhichOptions): string | null {
 	const cachePolicy = options?.cache ?? WhichCachePolicy.Cached;
 	const lookupOptions =
-		options?.PATH !== undefined || process.env.PATH === undefined
-			? options
-			: { ...options, PATH: process.env.PATH };
+		options?.PATH !== undefined || process.env.PATH === undefined ? options : { ...options, PATH: process.env.PATH };
 	let key: CacheKey | undefined;
 
 	if (cachePolicy !== WhichCachePolicy.Bypass) {

--- a/packages/utils/src/which.ts
+++ b/packages/utils/src/which.ts
@@ -183,8 +183,8 @@ export interface WhichOptions extends Bun.WhichOptions {
 
 // Darwin-specific "which" shim: consult Xcode/CLT toolchain directories after $PATH.
 // Uses cached directory listings instead of per-command existsSync or xcrun subprocesses.
-function darwinWhich(command: string, options?: Bun.WhichOptions): string | null {
-	const regular = Bun.which(command, options);
+function darwinWhich(command: string, _options?: Bun.WhichOptions): string | null {
+	const regular = Bun.which(command);
 	if (regular) return regular;
 	if (isXcodeBin(command)) {
 		return getMacosToolPaths().get(command) ?? null;
@@ -214,21 +214,17 @@ function cacheKey(command: string, options?: Bun.WhichOptions): CacheKey {
  */
 export function $which(command: string, options?: WhichOptions): string | null {
 	const cachePolicy = options?.cache ?? WhichCachePolicy.Cached;
-	const lookupOptions =
-		options?.PATH !== undefined || process.env.PATH === undefined
-			? options
-			: { ...options, PATH: process.env.PATH };
 	let key: CacheKey | undefined;
 
 	if (cachePolicy !== WhichCachePolicy.Bypass) {
-		key = cacheKey(command, lookupOptions);
+		key = cacheKey(command, options);
 		if (cachePolicy !== WhichCachePolicy.Fresh) {
 			const cached = toolCache.get(key);
 			if (cached !== undefined) return cached;
 		}
 	}
 
-	const result = whichFresh(command, lookupOptions);
+	const result = whichFresh(command, options);
 	if (key != null && cachePolicy !== WhichCachePolicy.ReadOnly) {
 		toolCache.set(key, result);
 	}

--- a/packages/utils/src/which.ts
+++ b/packages/utils/src/which.ts
@@ -183,8 +183,8 @@ export interface WhichOptions extends Bun.WhichOptions {
 
 // Darwin-specific "which" shim: consult Xcode/CLT toolchain directories after $PATH.
 // Uses cached directory listings instead of per-command existsSync or xcrun subprocesses.
-function darwinWhich(command: string, _options?: Bun.WhichOptions): string | null {
-	const regular = Bun.which(command);
+function darwinWhich(command: string, options?: Bun.WhichOptions): string | null {
+	const regular = Bun.which(command, options);
 	if (regular) return regular;
 	if (isXcodeBin(command)) {
 		return getMacosToolPaths().get(command) ?? null;
@@ -214,17 +214,21 @@ function cacheKey(command: string, options?: Bun.WhichOptions): CacheKey {
  */
 export function $which(command: string, options?: WhichOptions): string | null {
 	const cachePolicy = options?.cache ?? WhichCachePolicy.Cached;
+	const lookupOptions =
+		options?.PATH !== undefined || process.env.PATH === undefined
+			? options
+			: { ...options, PATH: process.env.PATH };
 	let key: CacheKey | undefined;
 
 	if (cachePolicy !== WhichCachePolicy.Bypass) {
-		key = cacheKey(command, options);
+		key = cacheKey(command, lookupOptions);
 		if (cachePolicy !== WhichCachePolicy.Fresh) {
 			const cached = toolCache.get(key);
 			if (cached !== undefined) return cached;
 		}
 	}
 
-	const result = whichFresh(command, options);
+	const result = whichFresh(command, lookupOptions);
 	if (key != null && cachePolicy !== WhichCachePolicy.ReadOnly) {
 		toolCache.set(key, result);
 	}

--- a/packages/utils/test/which.test.ts
+++ b/packages/utils/test/which.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { $which } from "../src/which";
+
+describe("$which", () => {
+	const originalPath = process.env.PATH;
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		process.env.PATH = originalPath;
+		for (const dir of tempDirs.splice(0)) {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it.skipIf(process.platform === "win32")("uses the current process PATH for each cached lookup", () => {
+		const firstDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-which-first-"));
+		const secondDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-which-second-"));
+		tempDirs.push(firstDir, secondDir);
+
+		const command = `omp-which-${process.pid}`;
+		const firstExecutable = path.join(firstDir, command);
+		const secondExecutable = path.join(secondDir, command);
+		fs.writeFileSync(firstExecutable, "#!/bin/sh\n");
+		fs.writeFileSync(secondExecutable, "#!/bin/sh\n");
+		fs.chmodSync(firstExecutable, 0o755);
+		fs.chmodSync(secondExecutable, 0o755);
+
+		process.env.PATH = firstDir;
+		expect($which(command)).toBe(firstExecutable);
+
+		process.env.PATH = secondDir;
+		expect($which(command)).toBe(secondExecutable);
+	});
+});


### PR DESCRIPTION
## Repro

`$which()` cached by command when callers omitted `options.PATH`. If `process.env.PATH` changed during a long-running OMP process, the second lookup reused the first result instead of resolving against the new PATH.

The regression creates two executable files with the same name in separate temporary directories, switches `process.env.PATH` between them, and requires each lookup to resolve the active directory.

## Why this matters

OMP is long-lived and reloads environment state without restarting. A stale executable path can invoke the wrong toolchain or preserve a command that is no longer available. Cache identity must include the effective current PATH.

## Fix

- Use `process.env.PATH` as the effective lookup PATH when callers do not pass one.
- Include that effective PATH in the cache key.
- Pass identical lookup options through `Bun.which` and the Darwin fallback.

## Test-first proof

- RED SHA `71a4c69369`: the new PATH-switch regression failed in `Test TS workspace fast`; install smoke also failed through the same stale lookup behavior.
- GREEN SHA `1bb5b445fe`: `Test TS workspace fast`, install smoke, CLI smoke, native/integration, runtime/session, singleton/global-state, typecheck, and build gates passed.
- The remaining UI/TUI bucket failure is unrelated: `input-controller-orphan-submit.test.ts` calls an existing mock without `editor.clearDraft`; this PR changes only `packages/utils/src/which.ts` and `packages/utils/test/which.test.ts`.

## Scope

Two files: one regression test and the effective-PATH cache fix.