### PR TITLE
fix(coding-agent): detect unexpected stops with thinking-only content

### DIFF
--- a/packages/ai/src/providers/mock.ts
+++ b/packages/ai/src/providers/mock.ts
@@ -67,7 +67,7 @@ export type MockApi = typeof MOCK_API;
 export type MockContent =
 	| string
 	| { type: "text"; text: string }
-	| { type: "thinking"; thinking: string }
+	| { type: "thinking"; thinking: string; thinkingSignature?: string }
 	| {
 			type: "toolCall";
 			/** Optional explicit id; auto-generated when omitted. */

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed the unexpected-stop guard (`features.unexpectedStopDetection`) never firing for thinking-only stops: `isUnexpectedStopCandidate` only counted non-whitespace `text` blocks, so a `stopReason: "stop"` turn whose sole content was a signed `thinking` block (a trapped response or a truncated reasoning fragment from reasoning models) bypassed classification and silently ended the turn mid-task. Such stops are now candidates and are classified on their thinking text ([#7499](https://github.com/can1357/oh-my-pi/issues/7499)).
 - Fixed extension slash commands appearing as user prompts after being handled locally.
 - Preserved explicit session titles when branching from an earlier conversation turn.
 - Fixed floating rejections from cmux browser guest JavaScript terminating the main process and every active session; attributable rejections now fail the browser run as tool errors while unrelated process rejections retain the fatal path ([#7365](https://github.com/can1357/oh-my-pi/issues/7365)).

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -14,6 +14,7 @@ import type {
 	Effort,
 	Model,
 	TextContent,
+	ThinkingContent,
 	ToolChoice,
 } from "@oh-my-pi/pi-ai";
 import { calculateRateLimitBackoffMs, parseRateLimitReason } from "@oh-my-pi/pi-ai";
@@ -591,9 +592,16 @@ export class TurnRecovery {
 			return false;
 		}
 
-		const text = assistantMessage.content
-			.filter((content): content is TextContent => content.type === "text")
-			.map(content => content.text)
+		const textBlocks = assistantMessage.content.filter((content): content is TextContent => content.type === "text");
+		// Prefer text for the classifier, but fall back to thinking when the
+		// turn produced no text (thinking-only unexpected stops). The thinking
+		// content is what the model was mid-deliberation about, so the
+		// classifier can still judge whether the stop is terminal.
+		const thinkingBlocks = assistantMessage.content.filter(
+			(content): content is ThinkingContent => content.type === "thinking",
+		);
+		const text = (textBlocks.length > 0 ? textBlocks : thinkingBlocks)
+			.map(content => ("text" in content ? content.text : content.thinking))
 			.join("\n");
 		if (!/\S/.test(text)) {
 			this.#unexpectedStopRetryCount = 0;

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -593,17 +593,20 @@ export class TurnRecovery {
 		}
 
 		const textBlocks = assistantMessage.content.filter((content): content is TextContent => content.type === "text");
-		// Prefer text for the classifier, but fall back to thinking when the
-		// turn produced no text (thinking-only unexpected stops). The thinking
-		// content is what the model was mid-deliberation about, so the
-		// classifier can still judge whether the stop is terminal.
+		// Prefer non-whitespace text for the classifier, but fall back to
+		// thinking when the turn has no usable text (thinking-only unexpected
+		// stops). Keying on non-whitespace content — not block presence — keeps
+		// this consistent with isUnexpectedStopCandidate: a turn with an
+		// empty/whitespace text block plus real thinking passes the gate and
+		// must not bail here.
 		const thinkingBlocks = assistantMessage.content.filter(
 			(content): content is ThinkingContent => content.type === "thinking",
 		);
-		const text = (textBlocks.length > 0 ? textBlocks : thinkingBlocks)
-			.map(content => ("text" in content ? content.text : content.thinking))
-			.join("\n");
-		if (!/\S/.test(text)) {
+		let text = textBlocks.map(content => content.text).join("\n");
+		if (!hasNonWhitespace(text)) {
+			text = thinkingBlocks.map(content => content.thinking).join("\n");
+		}
+		if (!hasNonWhitespace(text)) {
 			this.#unexpectedStopRetryCount = 0;
 			return false;
 		}

--- a/packages/coding-agent/src/session/unexpected-stop-classifier.ts
+++ b/packages/coding-agent/src/session/unexpected-stop-classifier.ts
@@ -34,14 +34,22 @@ export interface ClassifyUnexpectedStopDeps {
 
 export function isUnexpectedStopCandidate(message: AssistantMessage): boolean {
 	if (message.stopReason !== "stop") return false;
-	let hasText = false;
+	let hasActionableContent = false;
 	for (const content of message.content) {
 		if (content.type === "toolCall") return false;
 		if (content.type === "text" && /\S/.test(content.text)) {
-			hasText = true;
+			hasActionableContent = true;
+		}
+		// A stop turn with non-whitespace thinking but no text is a candidate
+		// too: on reasoning models (thinkingFormat openai / reasoning_content)
+		// the intended response is sometimes emitted as a thinking fragment and
+		// the turn ends without any text or tool call. Without this, the guard
+		// is bypassed and the agent silently stops mid-task.
+		if (content.type === "thinking" && /\S/.test(content.thinking)) {
+			hasActionableContent = true;
 		}
 	}
-	return hasText;
+	return hasActionableContent;
 }
 
 export async function classifyUnexpectedStop(

--- a/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import { z } from "@oh-my-pi/pi-ai";
-import { createMockModel, type MockContent, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { type SettingPath, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -57,11 +57,8 @@ function thinkingOnlyStop(thinking: string): MockResponse {
 	// "provider-authenticated content"). The unexpected-stop gate must then
 	// pick it up, or the turn slips past BOTH guards and the agent stops
 	// silently mid-task.
-	const thinkingBlock: Extract<NonNullable<MockResponse["content"]>[number], { type: "thinking" }> & {
-		thinkingSignature: string;
-	} = { type: "thinking", thinking, thinkingSignature: "reasoning_content" };
 	return {
-		content: [thinkingBlock as MockContent],
+		content: [{ type: "thinking", thinking, thinkingSignature: "reasoning_content" }],
 		stopReason: "stop",
 	};
 }
@@ -204,6 +201,9 @@ describe("AgentSession unexpected stop guard", () => {
 		await session.waitForIdle();
 
 		expect(spy).toHaveBeenCalledTimes(2);
+		// The classifier must receive the thinking text (not empty text): this is
+		// what proves the thinking fallback in #handleUnexpectedAssistantStop works.
+		expect(spy.mock.calls[0]?.[0]).toContain("响应");
 		expect(mock.calls).toHaveLength(2);
 		expect(assistantText(session.agent.state.messages)).toContain("finished after thinking-only stop");
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);

--- a/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import { z } from "@oh-my-pi/pi-ai";
-import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { createMockModel, type MockContent, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { type SettingPath, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -46,6 +46,22 @@ function recordCall(value: string, id: string): MockResponse {
 function unexpectedStop(text: string): MockResponse {
 	return {
 		content: [{ type: "text", text }],
+		stopReason: "stop",
+	};
+}
+
+function thinkingOnlyStop(thinking: string): MockResponse {
+	// Mirrors the real wire shape for openai-completions reasoning models:
+	// thinking carries `thinkingSignature: "reasoning_content"`, which makes
+	// `#isEmptyAssistantStop` treat the turn as non-empty (signed thinking is
+	// "provider-authenticated content"). The unexpected-stop gate must then
+	// pick it up, or the turn slips past BOTH guards and the agent stops
+	// silently mid-task.
+	const thinkingBlock: Extract<NonNullable<MockResponse["content"]>[number], { type: "thinking" }> & {
+		thinkingSignature: string;
+	} = { type: "thinking", thinking, thinkingSignature: "reasoning_content" };
+	return {
+		content: [thinkingBlock as MockContent],
 		stopReason: "stop",
 	};
 }
@@ -167,6 +183,29 @@ describe("AgentSession unexpected stop guard", () => {
 		expect(spy).toHaveBeenCalledTimes(2);
 		expect(mock.calls).toHaveLength(2);
 		expect(assistantText(session.agent.state.messages)).toContain("done now");
+		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);
+	});
+
+	it("classifies and continues on a thinking-only stop", async () => {
+		let calls = 0;
+		const spy = vi.spyOn(unexpectedStopClassifier, "classifyUnexpectedStop").mockImplementation(async () => {
+			calls++;
+			return calls === 1;
+		});
+		const { session, mock } = await createHarness(
+			[thinkingOnlyStop(" 响应"), { content: ["finished after thinking-only stop"], stopReason: "stop" }],
+			{
+				"features.unexpectedStopDetection": true,
+				"providers.unexpectedStopModel": "online",
+			},
+		);
+
+		await session.prompt("do the thing");
+		await session.waitForIdle();
+
+		expect(spy).toHaveBeenCalledTimes(2);
+		expect(mock.calls).toHaveLength(2);
+		expect(assistantText(session.agent.state.messages)).toContain("finished after thinking-only stop");
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);
 	});
 

--- a/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-unexpected-stop-guard.test.ts
@@ -63,6 +63,20 @@ function thinkingOnlyStop(thinking: string): MockResponse {
 	};
 }
 
+function whitespaceTextPlusThinkingStop(thinking: string): MockResponse {
+	// A degenerate empty/whitespace text block alongside real thinking: the
+	// gate passes (non-whitespace thinking), so the classifier-input fallback
+	// must ignore the whitespace text and classify on the thinking. Regression
+	// for the mismatch between block presence and non-whitespace content.
+	return {
+		content: [
+			{ type: "text", text: "   \n\t  " },
+			{ type: "thinking", thinking, thinkingSignature: "reasoning_content" },
+		],
+		stopReason: "stop",
+	};
+}
+
 async function createHarness(
 	responses: MockResponse[],
 	settingsOverrides: SettingsOverrides = {},
@@ -206,6 +220,33 @@ describe("AgentSession unexpected stop guard", () => {
 		expect(spy.mock.calls[0]?.[0]).toContain("响应");
 		expect(mock.calls).toHaveLength(2);
 		expect(assistantText(session.agent.state.messages)).toContain("finished after thinking-only stop");
+		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);
+	});
+
+	it("classifies on thinking when a whitespace text block accompanies it", async () => {
+		let calls = 0;
+		const spy = vi.spyOn(unexpectedStopClassifier, "classifyUnexpectedStop").mockImplementation(async () => {
+			calls++;
+			return calls === 1;
+		});
+		const { session, mock } = await createHarness(
+			[
+				whitespaceTextPlusThinkingStop("still working, next step is running the build"),
+				{ content: ["done after whitespace-text thinking stop"], stopReason: "stop" },
+			],
+			{
+				"features.unexpectedStopDetection": true,
+				"providers.unexpectedStopModel": "online",
+			},
+		);
+
+		await session.prompt("do the thing");
+		await session.waitForIdle();
+
+		expect(spy).toHaveBeenCalledTimes(2);
+		expect(spy.mock.calls[0]?.[0]).toContain("still working");
+		expect(mock.calls).toHaveLength(2);
+		expect(assistantText(session.agent.state.messages)).toContain("done after whitespace-text thinking stop");
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);
 	});
 

--- a/packages/coding-agent/test/unexpected-stop-classifier.test.ts
+++ b/packages/coding-agent/test/unexpected-stop-classifier.test.ts
@@ -76,6 +76,46 @@ describe("isUnexpectedStopCandidate", () => {
 		});
 		expect(isUnexpectedStopCandidate(message)).toBe(false);
 	});
+
+	it("returns true for a thinking-only stop with non-whitespace thinking", () => {
+		const message = makeAssistantMessage({
+			stopReason: "stop",
+			content: [{ type: "thinking", thinking: " 响应" }],
+		});
+		expect(isUnexpectedStopCandidate(message)).toBe(true);
+	});
+
+	it("returns true for a thinking-only stop with a full response trapped in thinking", () => {
+		const message = makeAssistantMessage({
+			stopReason: "stop",
+			content: [
+				{
+					type: "thinking",
+					thinking: "responseAll four reviewers complete. Let me now synthesize the findings.",
+				},
+			],
+		});
+		expect(isUnexpectedStopCandidate(message)).toBe(true);
+	});
+
+	it("returns false when thinking is only whitespace", () => {
+		const message = makeAssistantMessage({
+			stopReason: "stop",
+			content: [{ type: "thinking", thinking: "   \n\t  " }],
+		});
+		expect(isUnexpectedStopCandidate(message)).toBe(false);
+	});
+
+	it("returns false when thinking-only stop has a toolCall", () => {
+		const message = makeAssistantMessage({
+			stopReason: "stop",
+			content: [
+				{ type: "thinking", thinking: "I should run the tests." },
+				{ type: "toolCall", id: "call-1", name: "bash", arguments: {} },
+			],
+		});
+		expect(isUnexpectedStopCandidate(message)).toBe(false);
+	});
 });
 
 describe("classifyUnexpectedStop", () => {


### PR DESCRIPTION
## Summary

Fixes #7499 — the unexpected-stop guard (`features.unexpectedStopDetection`) is bypassed for **thinking-only stops**: turns whose content is only a `thinking` block (no text, no tool call) slip past both guards and the agent silently stops mid-task.

This is the mirror image of #6540 (classifier false-positives on clean final answers): here a genuine mid-task stop is never even classified.

## Root cause

Two guards, both bypassed by a thinking-only stop on reasoning models:

1. `isUnexpectedStopCandidate` (unexpected-stop-classifier.ts) only counts non-whitespace **text** blocks → thinking-only stop returns `false`, classifier never runs.
2. `#isEmptyAssistantStop` (turn-recovery.ts) treats thinking with a non-whitespace `thinkingSignature` as *non-empty / terminal* → the empty-stop rescue path doesn't run either (thinking signatures like `"reasoning_content"` are present on every openai-completions reasoning turn, including degenerate 1–2 token fragments).

Net: neither guard fires, no continuation is scheduled, the session ends silently mid-task. The user's only recourse is manually sending "continue".

## Change

- **Gate** (`unexpected-stop-classifier.ts`): `isUnexpectedStopCandidate` now treats non-whitespace `thinking` as actionable content, alongside `text`. Tool-call turns still return `false`.
- **Classifier input** (`turn-recovery.ts`): when a candidate turn has no text blocks, feed the thinking text to the classifier instead of bailing on empty text — so it can judge "mid-deliberation vs terminal" on thinking-only stops.

## Tests

- `unexpected-stop-classifier.test.ts`: thinking-only stop with non-whitespace thinking is a candidate; whitespace-only thinking is not; thinking + toolCall is not; a full response trapped in thinking is a candidate.
- `agent-session-unexpected-stop-guard.test.ts`: a thinking-only stop carrying `thinkingSignature: "reasoning_content"` (the real wire shape) is classified and the session auto-continues.

## Verification

- `bun test` on both changed test files: 20 pass.
- Adjacent regression suites (empty-stop guard, yield suppression, turn-recovery replay, session-stop-will-continue): 35 pass.
- `tsgo -p tsconfig.json --noEmit`: clean.
- `biome check` on changed files: clean.

## Notes

The user-facing behavior when the classifier says "no" (a genuinely terminal thinking-only stop) is unchanged — the classifier verdict still gates the continuation. This only routes thinking-only stops *into* classification, where they previously bypassed it entirely.


---

## Related

- Fixes #7499
- **Related PR: #7501** — the upstream bot (`roboomp`) generated an independent fix for the same issue with the same root cause and approach (gate thinking-only stops into the unexpected-stop classifier, classify on thinking text). This PR is the human-authored version and has been strengthened to match the bot's coverage: `MockContent` now types `thinkingSignature`, the guard test asserts the classifier input contains the thinking text, and the CHANGELOG entry is included. Both PRs touch the same files; if either merges first, the other needs a rebase — the changes are functionally equivalent.
