### PR TITLE
feat(catalog): add peak pricing support for DeepSeek API

### DIFF
--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -297,6 +297,28 @@ function applyCodexPricingFallback(models: readonly ModelSpec[]): ModelSpec[] {
 }
 
 /**
+ * DeepSeek API 峰谷定价：北京时间 9-12, 14-18 为高峰时段，价格 2 倍。
+ * 转换为 UTC：1-4, 6-10。
+ */
+function applyDeepSeekPeakPricing(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.map(model => {
+		if (model.provider === "deepseek") {
+			return {
+				...model,
+				peakPricing: {
+					windows: [
+						{ startHour: 1, endHour: 4 }, // 北京 9-12
+						{ startHour: 6, endHour: 10 }, // 北京 14-18
+					],
+					multiplier: 2,
+				},
+			};
+		}
+		return model;
+	});
+}
+
+/**
  * Provider discovery sometimes reports context-sized Kimi output ceilings. Keep
  * the bundled catalog at the documented/provider-safe caps so request builders
  * that always send `max_tokens` do not over-allocate.
@@ -660,6 +682,7 @@ async function generateModels() {
 	allModels = applyPremiumMultiplierOverrides(allModels);
 	allModels = applyCodexPricingFallback(allModels);
 	allModels = applyAntigravityPricingFallback(allModels);
+	allModels = applyDeepSeekPeakPricing(allModels);
 	allModels = applyKimiMaxTokensCap(allModels);
 	allModels = applyFireworksDeepSeekReasoningShape(allModels);
 	allModels = dropFireworksWireIds(allModels);

--- a/packages/catalog/src/models.ts
+++ b/packages/catalog/src/models.ts
@@ -44,13 +44,26 @@ export function getBundledModels(provider: GeneratedProvider): Model<Api>[] {
 }
 
 export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
+	const peakMultiplier = getPeakPricingMultiplier(model);
 	const orchestration = usage.orchestration;
-	usage.cost.input = (model.cost.input / 1000000) * (usage.input + (orchestration?.input ?? 0));
-	usage.cost.output = (model.cost.output / 1000000) * (usage.output + (orchestration?.output ?? 0));
-	usage.cost.cacheRead = (model.cost.cacheRead / 1000000) * (usage.cacheRead + (orchestration?.cacheRead ?? 0));
-	usage.cost.cacheWrite = cacheWriteCost(model, usage);
+	usage.cost.input = (model.cost.input / 1000000) * (usage.input + (orchestration?.input ?? 0)) * peakMultiplier;
+	usage.cost.output = (model.cost.output / 1000000) * (usage.output + (orchestration?.output ?? 0)) * peakMultiplier;
+	usage.cost.cacheRead =
+		(model.cost.cacheRead / 1000000) * (usage.cacheRead + (orchestration?.cacheRead ?? 0)) * peakMultiplier;
+	usage.cost.cacheWrite = cacheWriteCost(model, usage) * peakMultiplier;
 	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 	return usage.cost;
+}
+
+function getPeakPricingMultiplier<TApi extends Api>(model: Model<TApi>): number {
+	const peak = model.peakPricing;
+	if (!peak) return 1;
+	const utcHour = new Date().getUTCHours();
+	const isPeak = peak.windows.some(w => {
+		if (w.startHour <= w.endHour) return utcHour >= w.startHour && utcHour < w.endHour;
+		return utcHour >= w.startHour || utcHour < w.endHour; // cross-midnight
+	});
+	return isPeak ? peak.multiplier : 1;
 }
 
 /**

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -857,6 +857,17 @@ export interface Model<TApi extends Api = Api> {
 		cacheRead: number; // $/million tokens
 		cacheWrite: number; // $/million tokens
 	};
+	/**
+	 * Peak/off-peak pricing windows. When the current time falls within a window,
+	 * all costs are multiplied by the multiplier. Hours are in UTC to ensure
+	 * correct behavior regardless of the user's local timezone.
+	 *
+	 * Example: DeepSeek peak hours (Beijing 9-12, 14-18) = UTC 1-4, 6-10
+	 */
+	peakPricing?: {
+		windows: Array<{ startHour: number; endHour: number }>;
+		multiplier: number;
+	};
 	/** Premium Copilot requests charged per user-initiated request (defaults to 1). */
 	premiumMultiplier?: number;
 	contextWindow: number | null;


### PR DESCRIPTION
## Summary

DeepSeek API 采用峰谷定价：北京时间 9-12 和 14-18 为高峰时段，价格 2 倍。

## Changes

- 给 `Model` 接口添加 `peakPricing` 字段（UTC 小时窗口 + 倍率）
- 修改 `calculateCost` 检查当前 UTC 时间，命中窗口就乘倍率
- 在生成器中添加 `applyDeepSeekPeakPricing`，自动给所有 `provider === 'deepseek'` 的模型加配置

## Design

**为什么用 UTC 小时？**
峰谷定价基于北京时间（UTC+8），但用户可能在任何时区。用 UTC 小时配置，确保全球用户都正确。检查用 `new Date().getUTCHours()`，通用。

**为什么在生成器里加？**
DeepSeek 峰谷是 provider 级别的策略，不是单个模型的。生成器自动给所有 DeepSeek 模型加配置，保持一致。

北京时间 9-12, 14-18 = UTC 1-4, 6-10

## Testing

验证了不同 UTC 时间的成本计算：
- UTC 2（北京 10）→ 2x ✓
- UTC 7（北京 15）→ 2x ✓  
- 其他时间 → 1x ✓