### PR TITLE
feat(catalog): add peak pricing support for DeepSeek API

### DIFF
--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -297,6 +297,28 @@ function applyCodexPricingFallback(models: readonly ModelSpec[]): ModelSpec[] {
 }
 
 /**
+ * DeepSeek API 峰谷定价：北京时间 9-12, 14-18 为高峰时段，价格 2 倍。
+ * 转换为 UTC：1-4, 6-10。
+ */
+function applyDeepSeekPeakPricing(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.map(model => {
+		if (model.provider === "deepseek") {
+			return {
+				...model,
+				peakPricing: {
+					windows: [
+						{ startHour: 1, endHour: 4 }, // 北京 9-12
+						{ startHour: 6, endHour: 10 }, // 北京 14-18
+					],
+					multiplier: 2,
+				},
+			};
+		}
+		return model;
+	});
+}
+
+/**
  * Provider discovery sometimes reports context-sized Kimi output ceilings. Keep
  * the bundled catalog at the documented/provider-safe caps so request builders
  * that always send `max_tokens` do not over-allocate.
@@ -660,6 +682,7 @@ async function generateModels() {
 	allModels = applyPremiumMultiplierOverrides(allModels);
 	allModels = applyCodexPricingFallback(allModels);
 	allModels = applyAntigravityPricingFallback(allModels);
+	allModels = applyDeepSeekPeakPricing(allModels);
 	allModels = applyKimiMaxTokensCap(allModels);
 	allModels = applyFireworksDeepSeekReasoningShape(allModels);
 	allModels = dropFireworksWireIds(allModels);

--- a/packages/catalog/src/models.ts
+++ b/packages/catalog/src/models.ts
@@ -44,13 +44,26 @@ export function getBundledModels(provider: GeneratedProvider): Model<Api>[] {
 }
 
 export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
+	const peakMultiplier = getPeakPricingMultiplier(model);
 	const orchestration = usage.orchestration;
-	usage.cost.input = (model.cost.input / 1000000) * (usage.input + (orchestration?.input ?? 0));
-	usage.cost.output = (model.cost.output / 1000000) * (usage.output + (orchestration?.output ?? 0));
-	usage.cost.cacheRead = (model.cost.cacheRead / 1000000) * (usage.cacheRead + (orchestration?.cacheRead ?? 0));
-	usage.cost.cacheWrite = cacheWriteCost(model, usage);
+	usage.cost.input = (model.cost.input / 1000000) * (usage.input + (orchestration?.input ?? 0)) * peakMultiplier;
+	usage.cost.output = (model.cost.output / 1000000) * (usage.output + (orchestration?.output ?? 0)) * peakMultiplier;
+	usage.cost.cacheRead =
+		(model.cost.cacheRead / 1000000) * (usage.cacheRead + (orchestration?.cacheRead ?? 0)) * peakMultiplier;
+	usage.cost.cacheWrite = cacheWriteCost(model, usage) * peakMultiplier;
 	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 	return usage.cost;
+}
+
+function getPeakPricingMultiplier<TApi extends Api>(model: Model<TApi>): number {
+	const peak = model.peakPricing;
+	if (!peak) return 1;
+	const utcHour = new Date().getUTCHours();
+	const isPeak = peak.windows.some(w => {
+		if (w.startHour <= w.endHour) return utcHour >= w.startHour && utcHour < w.endHour;
+		return utcHour >= w.startHour || utcHour < w.endHour; // cross-midnight
+	});
+	return isPeak ? peak.multiplier : 1;
 }
 
 /**

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -857,6 +857,17 @@ export interface Model<TApi extends Api = Api> {
 		cacheRead: number; // $/million tokens
 		cacheWrite: number; // $/million tokens
 	};
+	/**
+	 * Peak/off-peak pricing windows. When the current time falls within a window,
+	 * all costs are multiplied by the multiplier. Hours are in UTC to ensure
+	 * correct behavior regardless of the user's local timezone.
+	 *
+	 * Example: DeepSeek peak hours (Beijing 9-12, 14-18) = UTC 1-4, 6-10
+	 */
+	peakPricing?: {
+		windows: Array<{ startHour: number; endHour: number }>;
+		multiplier: number;
+	};
 	/** Premium Copilot requests charged per user-initiated request (defaults to 1). */
 	premiumMultiplier?: number;
 	contextWindow: number | null;


### PR DESCRIPTION
## Summary

Add support for DeepSeek API peak/off-peak pricing. DeepSeek charges 2x during Beijing time peak hours (9-12 and 14-18), which translates to UTC hours 1-4 and 6-10.

## Changes

### Core Implementation
- **Model Interface**: Added `peakPricing` field with UTC hour windows and multiplier
- **Cost Calculation**: Modified `calculateCost` to check current UTC time and apply peak multiplier when in a peak window
- **Generator**: Added `applyDeepSeekPeakPricing` to automatically configure peak pricing for all DeepSeek provider models

### Key Design Decisions

**Why UTC hours?**
Peak pricing is based on Beijing time (UTC+8), but users can be anywhere in the world. By converting to UTC hours in the configuration, we ensure correct behavior regardless of the user's timezone. The check uses `new Date().getUTCHours()` which is universal.

**Why provider-level in generator?**
DeepSeek's peak pricing is a provider-wide policy, not per-model. The generator automatically adds the config to all models with `provider === "deepseek"`, ensuring consistency.

### Generated Models
The `models.json` is auto-generated, so peak pricing is applied via the generator rather than manual edits. Both `deepseek-v4-flash` and `deepseek-v4-pro` now include the peak pricing configuration.

## Testing

Verified cost calculation at different UTC hours:
- UTC 2 (Beijing 10) → 2x ✓
- UTC 7 (Beijing 15) → 2x ✓  
- Other hours → 1x ✓

Current time (UTC 13, Beijing 21) correctly shows 1x pricing.