### PR TITLE
feat(catalog): add peak pricing support for DeepSeek API

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Proxied model responses now pin cost calculation to the request start timestamp.
+
 ## [17.2.6] - 2026-08-03
 
 ### Fixed

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -375,7 +375,7 @@ function processProxyEvent(
 			partial.stopReason = proxyEvent.reason;
 			partial.usage = proxyEvent.usage;
 			if (proxyEvent.content !== undefined) partial.content = proxyEvent.content;
-			calculateCost(model, partial.usage);
+			calculateCost(model, partial.usage, partial.timestamp);
 			scrubPartialJson(partial);
 			return { type: "done", reason: proxyEvent.reason, message: partial };
 
@@ -384,7 +384,7 @@ function processProxyEvent(
 			partial.errorMessage = proxyEvent.errorMessage;
 			partial.usage = proxyEvent.usage;
 			if (proxyEvent.content !== undefined) partial.content = proxyEvent.content;
-			calculateCost(model, partial.usage);
+			calculateCost(model, partial.usage, partial.timestamp);
 			scrubPartialJson(partial);
 			return { type: "error", reason: proxyEvent.reason, error: partial };
 	}

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 - Fixed OpenAI-Codex (ChatGPT OAuth) requests failing with an `Unsupported service_tier: auto` error on default or legacy sessions by omitting the implicit `auto` service tier on the wire.
 - Fixed an issue where Cursor `kimi-k3` sessions would break permanently when a same-model assistant turn was persisted without thinking blocks, replacing hard errors with graceful warnings.
+### Changed
+
+- All providers now pass the request start timestamp into `calculateCost`, keeping cost calculation deterministic regardless of when usage is (re)computed.
 
 ## [17.2.6] - 2026-08-03
 

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -669,7 +669,7 @@ function handleMetadata(event: MetadataEvent, model: Model<"bedrock-converse-str
 		output.usage.cacheRead = event.usage.cacheReadInputTokens || 0;
 		output.usage.cacheWrite = event.usage.cacheWriteInputTokens || 0;
 		output.usage.totalTokens = event.usage.totalTokens || output.usage.input + output.usage.output;
-		calculateCost(model, output.usage);
+		calculateCost(model, output.usage, output.timestamp);
 	}
 }
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1700,6 +1700,7 @@ function calculateFallbackTurnCost(
 	requestModel: Model<"anthropic-messages">,
 	usage: Usage,
 	source: AnthropicWireUsage,
+	requestTimestamp: number,
 ): boolean {
 	const iterations = source.iterations ?? [];
 	if (iterations.length === 0) return false;
@@ -1725,7 +1726,7 @@ function calculateFallbackTurnCost(
 		iterationUsage.cacheWrite = cacheWriteTokens;
 		iterationUsage.totalTokens =
 			iterationUsage.input + iterationUsage.output + iterationUsage.cacheRead + iterationUsage.cacheWrite;
-		calculateCost(resolveIterationModel(requestModel, iteration.model), iterationUsage);
+		calculateCost(resolveIterationModel(requestModel, iteration.model), iterationUsage, requestTimestamp);
 		cost.input += iterationUsage.cost.input;
 		cost.output += iterationUsage.cost.output;
 		cost.cacheRead += iterationUsage.cost.cacheRead;
@@ -2227,11 +2228,11 @@ const streamAnthropicOnce = (
 								if (serverSideFallback) {
 									const served = fallbackServedModelFromUsage(startUsage);
 									if (served) output.model = served;
-									if (!calculateFallbackTurnCost(model, output.usage, startUsage)) {
-										calculateCost(model, output.usage);
+									if (!calculateFallbackTurnCost(model, output.usage, startUsage, output.timestamp)) {
+										calculateCost(model, output.usage, output.timestamp);
 									}
 								} else {
-									calculateCost(model, output.usage);
+									calculateCost(model, output.usage, output.timestamp);
 								}
 							} else {
 								reportAnthropicEnvelopeAnomaly("message_start missing usage");
@@ -2540,11 +2541,11 @@ const streamAnthropicOnce = (
 								if (serverSideFallback) {
 									const served = fallbackServedModelFromUsage(deltaUsage);
 									if (served) output.model = served;
-									if (!calculateFallbackTurnCost(model, output.usage, deltaUsage)) {
-										calculateCost(model, output.usage);
+									if (!calculateFallbackTurnCost(model, output.usage, deltaUsage, output.timestamp)) {
+										calculateCost(model, output.usage, output.timestamp);
 									}
 								} else {
-									calculateCost(model, output.usage);
+									calculateCost(model, output.usage, output.timestamp);
 								}
 							}
 						} else if (event.type === "message_stop") {

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -762,7 +762,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			endCurrentThinkingBlock(output, stream, state);
 			flushOpenToolCalls(output, stream, state);
 
-			calculateCost(model, output.usage);
+			calculateCost(model, output.usage, output.timestamp);
 
 			output.duration = performance.now() - startTime;
 			if (firstTokenTime) output.ttft = firstTokenTime - startTime;

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -411,7 +411,7 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 				toolBlocks.size > 0 ? "toolUse" : latestStopReason === StopReason.MAX_TOKENS ? "length" : "stop";
 			output.stopReason = doneReason;
 
-			calculateCost(model, output.usage);
+			calculateCost(model, output.usage, output.timestamp);
 			output.duration = performance.now() - startTime;
 			if (firstTokenTime) output.ttft = firstTokenTime - startTime;
 

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -887,7 +887,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 								total: 0,
 							},
 						};
-						calculateCost(model, output.usage);
+						calculateCost(model, output.usage, output.timestamp);
 					}
 				}
 

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -758,7 +758,7 @@ export async function consumeGoogleStream<T extends GoogleApiType>(args: {
 					total: 0,
 				},
 			};
-			calculateCost(model, output.usage);
+			calculateCost(model, output.usage, output.timestamp);
 		}
 	}
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -2464,7 +2464,7 @@ class CodexStreamProcessor {
 			hasExecutableIncompleteResponsesToolCalls(output);
 		finalizePendingResponsesToolCalls(output);
 
-		calculateCost(model, output.usage);
+		calculateCost(model, output.usage, output.timestamp);
 		applyCodexServiceTierPricing(model, output.usage, serviceTier, runtime.requestBodyForState.service_tier);
 		output.stopReason = mapOpenAIResponsesStopReason(status);
 		promoteResponsesToolUseStopReason(

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1027,7 +1027,7 @@ const streamOpenAICompletionsOnce = (
 			let sawUsagePayload = false;
 			let awaitTrailingUsageDetails = false;
 			const applyUsagePayload = (rawUsage: object): void => {
-				output.usage = parseChunkUsage(rawUsage, model, premiumRequestsTotal);
+				output.usage = parseChunkUsage(rawUsage, model, premiumRequestsTotal, output.timestamp);
 				sawUsagePayload = true;
 				awaitTrailingUsageDetails = !hasPositiveCacheReadTokenField(rawUsage);
 			};
@@ -1723,6 +1723,7 @@ export function parseChunkUsage(
 	rawUsage: object,
 	model: Model<"openai-completions">,
 	premiumRequests: number | undefined,
+	requestTimestamp?: number,
 ): AssistantMessage["usage"] {
 	const usageLike = rawUsage as OpenAICompletionsUsageLike;
 	const rawPromptTokenDetails = usageLike.prompt_tokens_details;
@@ -1758,7 +1759,7 @@ export function parseChunkUsage(
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		...(premiumRequests !== undefined ? { premiumRequests } : {}),
 	};
-	calculateCost(model, usage);
+	calculateCost(model, usage, requestTimestamp ?? Date.now());
 	applyOpenRouterReportedCost(model, usage, rawUsage);
 	return usage;
 }

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -3005,7 +3005,7 @@ export async function processResponsesStream<TApi extends Api>(
 				output.responseId = response.id;
 			}
 			populateResponsesUsageFromResponse(output, response?.usage);
-			calculateCost(model, output.usage);
+			calculateCost(model, output.usage, output.timestamp);
 			applyOpenRouterReportedCost(model, output.usage, response?.usage);
 			applyOpenAIResponsesServiceTierCost(
 				model,

--- a/packages/ai/test/models-cost.test.ts
+++ b/packages/ai/test/models-cost.test.ts
@@ -28,7 +28,7 @@ describe("calculateCost", () => {
 			},
 		};
 
-		calculateCost(model, usage, Date.now());
+		calculateCost(model, usage);
 
 		expect(usage.cost.input).toBeCloseTo(1, 8);
 		expect(usage.cost.output).toBeCloseTo(1, 8);
@@ -62,7 +62,7 @@ describe("calculateCost", () => {
 			},
 		};
 
-		calculateCost(model, usage, Date.now());
+		calculateCost(model, usage);
 
 		expect(usage.cost.input).toBeCloseTo(1, 8);
 		expect(usage.cost.output).toBeCloseTo(1, 8);
@@ -91,7 +91,7 @@ describe("calculateCost", () => {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 
-		calculateCost(model, usage, Date.now());
+		calculateCost(model, usage);
 
 		expect(usage.input).toBe(100);
 		expect(usage.output).toBe(20);
@@ -115,7 +115,7 @@ describe("calculateCost", () => {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 
-		calculateCost(model, usage, Date.now());
+		calculateCost(model, usage);
 
 		// 1h write bills at 2x base input ($5/MTok -> $10/MTok), not the 5m
 		// scalar cost.cacheWrite ($6.25/MTok) which would give $2.15086875.
@@ -135,7 +135,7 @@ describe("calculateCost", () => {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 
-		calculateCost(model, usage, Date.now());
+		calculateCost(model, usage);
 
 		// 100 * $6.25/MTok (5m) + 200 * $10/MTok (1h).
 		expect(usage.cost.cacheWrite).toBeCloseTo((6.25 * 100 + 10 * 200) / 1e6, 12);
@@ -156,7 +156,7 @@ describe("calculateCost", () => {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 
-		calculateCost(model, usage, Date.now());
+		calculateCost(model, usage);
 
 		// 400 * $10/MTok (1h) + 600 unattributed * $6.25/MTok (flat 5m rate).
 		expect(usage.cost.cacheWrite).toBeCloseTo((10 * 400 + 6.25 * 600) / 1e6, 12);
@@ -173,7 +173,7 @@ describe("calculateCost", () => {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 
-		calculateCost(model, usage, Date.now());
+		calculateCost(model, usage);
 
 		expect(usage.cost.cacheWrite).toBeCloseTo((6.25 * 1000) / 1e6, 12);
 	});
@@ -192,7 +192,7 @@ describe("calculateCost", () => {
 
 		expect(codexModel.cost).toEqual(openAIModel.cost);
 
-		calculateCost(codexModel, usage, Date.now());
+		calculateCost(codexModel, usage);
 
 		expect(usage.cost.total).toBeCloseTo(0.01005, 8);
 	});

--- a/packages/ai/test/models-cost.test.ts
+++ b/packages/ai/test/models-cost.test.ts
@@ -28,7 +28,7 @@ describe("calculateCost", () => {
 			},
 		};
 
-		calculateCost(model, usage);
+		calculateCost(model, usage, Date.now());
 
 		expect(usage.cost.input).toBeCloseTo(1, 8);
 		expect(usage.cost.output).toBeCloseTo(1, 8);
@@ -62,7 +62,7 @@ describe("calculateCost", () => {
 			},
 		};
 
-		calculateCost(model, usage);
+		calculateCost(model, usage, Date.now());
 
 		expect(usage.cost.input).toBeCloseTo(1, 8);
 		expect(usage.cost.output).toBeCloseTo(1, 8);
@@ -91,7 +91,7 @@ describe("calculateCost", () => {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 
-		calculateCost(model, usage);
+		calculateCost(model, usage, Date.now());
 
 		expect(usage.input).toBe(100);
 		expect(usage.output).toBe(20);
@@ -115,7 +115,7 @@ describe("calculateCost", () => {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 
-		calculateCost(model, usage);
+		calculateCost(model, usage, Date.now());
 
 		// 1h write bills at 2x base input ($5/MTok -> $10/MTok), not the 5m
 		// scalar cost.cacheWrite ($6.25/MTok) which would give $2.15086875.
@@ -135,7 +135,7 @@ describe("calculateCost", () => {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 
-		calculateCost(model, usage);
+		calculateCost(model, usage, Date.now());
 
 		// 100 * $6.25/MTok (5m) + 200 * $10/MTok (1h).
 		expect(usage.cost.cacheWrite).toBeCloseTo((6.25 * 100 + 10 * 200) / 1e6, 12);
@@ -156,7 +156,7 @@ describe("calculateCost", () => {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 
-		calculateCost(model, usage);
+		calculateCost(model, usage, Date.now());
 
 		// 400 * $10/MTok (1h) + 600 unattributed * $6.25/MTok (flat 5m rate).
 		expect(usage.cost.cacheWrite).toBeCloseTo((10 * 400 + 6.25 * 600) / 1e6, 12);
@@ -173,7 +173,7 @@ describe("calculateCost", () => {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		};
 
-		calculateCost(model, usage);
+		calculateCost(model, usage, Date.now());
 
 		expect(usage.cost.cacheWrite).toBeCloseTo((6.25 * 1000) / 1e6, 12);
 	});
@@ -192,8 +192,95 @@ describe("calculateCost", () => {
 
 		expect(codexModel.cost).toEqual(openAIModel.cost);
 
-		calculateCost(codexModel, usage);
+		calculateCost(codexModel, usage, Date.now());
 
 		expect(usage.cost.total).toBeCloseTo(0.01005, 8);
+	});
+});
+
+describe("calculateCost peak pricing", () => {
+	const peakModel = {
+		...getBundledModel("github-copilot", "gpt-4o"),
+		cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 1.25 },
+		peakPricing: {
+			windows: [
+				{ startHour: 1, endHour: 4 },
+				{ startHour: 6, endHour: 10 },
+			],
+			multiplier: 2,
+		},
+	};
+
+	function inputCost(timestamp: number): number {
+		const usage: Usage = {
+			input: 1_000_000,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 1_000_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+		calculateCost(peakModel, usage, timestamp);
+		return usage.cost.input;
+	}
+
+	it("applies the multiplier inside a window and keeps 1x outside", () => {
+		// 2026-08-03: UTC 2 and 7 are in-window, 0, 4, 5, 10 are out.
+		expect(inputCost(Date.UTC(2026, 7, 3, 2))).toBeCloseTo(2, 12);
+		expect(inputCost(Date.UTC(2026, 7, 3, 7))).toBeCloseTo(2, 12);
+		expect(inputCost(Date.UTC(2026, 7, 3, 0))).toBeCloseTo(1, 12);
+		expect(inputCost(Date.UTC(2026, 7, 3, 5))).toBeCloseTo(1, 12);
+		expect(inputCost(Date.UTC(2026, 7, 3, 23))).toBeCloseTo(1, 12);
+	});
+
+	it("treats windows as half-open [startHour, endHour)", () => {
+		expect(inputCost(Date.UTC(2026, 7, 3, 1))).toBeCloseTo(2, 12); // start inclusive
+		expect(inputCost(Date.UTC(2026, 7, 3, 4))).toBeCloseTo(1, 12); // end exclusive
+		expect(inputCost(Date.UTC(2026, 7, 3, 10))).toBeCloseTo(1, 12);
+	});
+
+	it("wraps windows that cross midnight", () => {
+		const wrapping = { ...peakModel, peakPricing: { windows: [{ startHour: 22, endHour: 2 }], multiplier: 2 } };
+		const cost = (timestamp: number): number => {
+			const usage: Usage = {
+				input: 1_000_000,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1_000_000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			};
+			calculateCost(wrapping, usage, timestamp);
+			return usage.cost.input;
+		};
+		expect(cost(Date.UTC(2026, 7, 3, 22))).toBeCloseTo(2, 12);
+		expect(cost(Date.UTC(2026, 7, 3, 23))).toBeCloseTo(2, 12);
+		expect(cost(Date.UTC(2026, 7, 3, 1))).toBeCloseTo(2, 12);
+		expect(cost(Date.UTC(2026, 7, 3, 2))).toBeCloseTo(1, 12);
+		expect(cost(Date.UTC(2026, 7, 3, 12))).toBeCloseTo(1, 12);
+	});
+
+	it("stays at 1x before the effective date even inside a window", () => {
+		const dormant = {
+			...peakModel,
+			peakPricing: { ...peakModel.peakPricing, effectiveFrom: Date.UTC(2026, 9, 1) },
+		};
+		const usage: Usage = {
+			input: 1_000_000,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 1_000_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+		calculateCost(dormant, usage, Date.UTC(2026, 7, 3, 2));
+		expect(usage.cost.input).toBeCloseTo(1, 12);
+	});
+
+	it("pins the multiplier to the request timestamp, not the calculation time", () => {
+		// Off-peak request timestamp must stay 1x no matter when cost is recomputed.
+		const offPeak = Date.UTC(2026, 7, 3, 12);
+		expect(inputCost(offPeak)).toBeCloseTo(1, 12);
+		expect(inputCost(offPeak)).toBeCloseTo(1, 12);
 	});
 });

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Changed
 
-- `calculateCost` now requires a request timestamp so peak pricing multipliers pin to when the request started instead of when cost is computed.
+- `calculateCost` accepts a request start timestamp (defaulting to the current time) so peak pricing multipliers pin to when the request started instead of when cost is computed.
 
 ## [17.2.6] - 2026-08-03
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -7,6 +7,13 @@
 ### Fixed
 
 - Fixed an issue where setting `thinking-level: off` failed to disable reasoning on direct DeepSeek V4 requests.
+### Added
+
+- Added peak/off-peak pricing support: models can declare `peakPricing` UTC hour windows with a cost multiplier, evaluated against the request start timestamp. DeepSeek's announced 2x peak-hours policy is wired up in the generator but stays dormant until DeepSeek publishes the effective date, so displayed costs match what is actually billed today.
+
+### Changed
+
+- `calculateCost` now requires a request timestamp so peak pricing multipliers pin to when the request started instead of when cost is computed.
 
 ## [17.2.6] - 2026-08-03
 

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -56,6 +56,7 @@ import { collapseEffortVariantsAcrossProviders } from "../src/variant-collapse";
 import {
 	applyAntigravityPricingFallback,
 	applyCanonicalLimitFallback,
+	applyDeepSeekPeakPricing,
 	applyGeneratedModelPolicies,
 	applyOllamaCloudOutputCap,
 	CLOUDFLARE_FALLBACK_MODEL,
@@ -293,28 +294,6 @@ function applyCodexPricingFallback(models: readonly ModelSpec[]): ModelSpec[] {
 			...model,
 			cost: { ...openAICost },
 		};
-	});
-}
-
-/**
- * DeepSeek API 峰谷定价：北京时间 9-12, 14-18 为高峰时段，价格 2 倍。
- * 转换为 UTC：1-4, 6-10。
- */
-function applyDeepSeekPeakPricing(models: readonly ModelSpec[]): ModelSpec[] {
-	return models.map(model => {
-		if (model.provider === "deepseek") {
-			return {
-				...model,
-				peakPricing: {
-					windows: [
-						{ startHour: 1, endHour: 4 }, // 北京 9-12
-						{ startHour: 6, endHour: 10 }, // 北京 14-18
-					],
-					multiplier: 2,
-				},
-			};
-		}
-		return model;
 	});
 }
 
@@ -782,5 +761,8 @@ function canonicalizeModelCompat(model: ModelSpec<Api>): void {
 	}
 }
 
-// Run the generator
-generateModels().catch(console.error);
+// Run the generator when executed directly (`bun run gen:models`), not when
+// imported by tests.
+if (import.meta.main) {
+	generateModels().catch(console.error);
+}

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -297,6 +297,28 @@ function applyCodexPricingFallback(models: readonly ModelSpec[]): ModelSpec[] {
 }
 
 /**
+ * DeepSeek API 峰谷定价：北京时间 9-12, 14-18 为高峰时段，价格 2 倍。
+ * 转换为 UTC：1-4, 6-10。
+ */
+function applyDeepSeekPeakPricing(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.map(model => {
+		if (model.provider === "deepseek") {
+			return {
+				...model,
+				peakPricing: {
+					windows: [
+						{ startHour: 1, endHour: 4 }, // 北京 9-12
+						{ startHour: 6, endHour: 10 }, // 北京 14-18
+					],
+					multiplier: 2,
+				},
+			};
+		}
+		return model;
+	});
+}
+
+/**
  * Provider discovery sometimes reports context-sized Kimi output ceilings. Keep
  * the bundled catalog at the documented/provider-safe caps so request builders
  * that always send `max_tokens` do not over-allocate.
@@ -660,6 +682,7 @@ async function generateModels() {
 	allModels = applyPremiumMultiplierOverrides(allModels);
 	allModels = applyCodexPricingFallback(allModels);
 	allModels = applyAntigravityPricingFallback(allModels);
+	allModels = applyDeepSeekPeakPricing(allModels);
 	allModels = applyKimiMaxTokensCap(allModels);
 	allModels = applyFireworksDeepSeekReasoningShape(allModels);
 	allModels = dropFireworksWireIds(allModels);

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -152,6 +152,45 @@ const COPILOT_GENERATED_LIMITS: Record<string, { contextWindow: number; maxToken
 };
 
 /**
+ * UTC timestamp at which DeepSeek's peak/off-peak pricing becomes effective.
+ * DeepSeek announced 2x pricing during peak hours (Beijing 9:00-12:00 and
+ * 14:00-18:00 daily) but has not set an activation date
+ * (https://api-docs.deepseek.com/quick_start/pricing — "the effective date
+ * will be subject to the official announcement"). Until that date is
+ * announced, `Number.POSITIVE_INFINITY` keeps the config dormant so reported
+ * costs stay accurate; set it to `Date.UTC(...)` once the policy is live.
+ */
+const DEEPSEEK_PEAK_PRICING_EFFECTIVE_FROM_MS = Number.POSITIVE_INFINITY;
+
+/**
+ * DeepSeek API peak/off-peak pricing: 2x during Beijing time 9-12 and 14-18,
+ * which is UTC hours 1-4 and 6-10. Applied provider-wide because the policy
+ * covers every DeepSeek billing item.
+ */
+export function applyDeepSeekPeakPricing(
+	models: readonly ModelSpec[],
+	effectiveFromMs: number = DEEPSEEK_PEAK_PRICING_EFFECTIVE_FROM_MS,
+): ModelSpec[] {
+	// Dormant until DeepSeek announces the effective date; emitting nothing
+	// keeps the bundled catalog at the actual billed rates.
+	if (!Number.isFinite(effectiveFromMs)) return [...models];
+	return models.map(model => {
+		if (model.provider !== "deepseek") return model;
+		return {
+			...model,
+			peakPricing: {
+				effectiveFrom: effectiveFromMs,
+				windows: [
+					{ startHour: 1, endHour: 4 }, // Beijing 9-12
+					{ startHour: 6, endHour: 10 }, // Beijing 14-18
+				],
+				multiplier: 2,
+			},
+		};
+	});
+}
+
+/**
  * Apply upstream metadata corrections to a mutable array of models, then
  * re-bake canonical thinking metadata so generated catalogs always carry the
  * deriver's output for the post-policy spec.

--- a/packages/catalog/src/models.ts
+++ b/packages/catalog/src/models.ts
@@ -44,13 +44,26 @@ export function getBundledModels(provider: GeneratedProvider): Model<Api>[] {
 }
 
 export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
+	const peakMultiplier = getPeakPricingMultiplier(model);
 	const orchestration = usage.orchestration;
-	usage.cost.input = (model.cost.input / 1000000) * (usage.input + (orchestration?.input ?? 0));
-	usage.cost.output = (model.cost.output / 1000000) * (usage.output + (orchestration?.output ?? 0));
-	usage.cost.cacheRead = (model.cost.cacheRead / 1000000) * (usage.cacheRead + (orchestration?.cacheRead ?? 0));
-	usage.cost.cacheWrite = cacheWriteCost(model, usage);
+	usage.cost.input = (model.cost.input / 1000000) * (usage.input + (orchestration?.input ?? 0)) * peakMultiplier;
+	usage.cost.output = (model.cost.output / 1000000) * (usage.output + (orchestration?.output ?? 0)) * peakMultiplier;
+	usage.cost.cacheRead =
+		(model.cost.cacheRead / 1000000) * (usage.cacheRead + (orchestration?.cacheRead ?? 0)) * peakMultiplier;
+	usage.cost.cacheWrite = cacheWriteCost(model, usage) * peakMultiplier;
 	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 	return usage.cost;
+}
+
+function getPeakPricingMultiplier<TApi extends Api>(model: Model<TApi>): number {
+	const peak = model.peakPricing;
+	if (!peak) return 1;
+	const utcHour = new Date().getUTCHours();
+	const isPeak = peak.windows.some(w => {
+		if (w.startHour <= w.endHour) return utcHour >= w.startHour && utcHour < w.endHour;
+		return utcHour >= w.startHour || utcHour < w.endHour; // cross-midnight
+	});
+	return isPeak ? peak.multiplier : 1;
 }
 
 /**

--- a/packages/catalog/src/models.ts
+++ b/packages/catalog/src/models.ts
@@ -43,10 +43,15 @@ export function getBundledModels(provider: GeneratedProvider): Model<Api>[] {
 	return models ? (Array.from(models.values()) as Model<Api>[]) : [];
 }
 
+/**
+ * `requestTimestamp` pins peak/off-peak pricing to when the request started.
+ * It defaults to the calculation time so untyped callers keep the legacy
+ * two-argument shape; typed provider sites always pass the real request start.
+ */
 export function calculateCost<TApi extends Api>(
 	model: Model<TApi>,
 	usage: Usage,
-	requestTimestamp: number,
+	requestTimestamp: number = Date.now(),
 ): Usage["cost"] {
 	const peakMultiplier = getPeakPricingMultiplier(model, requestTimestamp);
 	const orchestration = usage.orchestration;
@@ -62,8 +67,8 @@ export function calculateCost<TApi extends Api>(
 /**
  * Multiplier for peak/off-peak pricing windows, evaluated at the request start
  * timestamp's UTC hour. Windows are half-open `[startHour, endHour)`; a window
- * whose start exceeds its end wraps midnight. Models without `peakPricing`
- * always pay 1x.
+ * whose start exceeds its end wraps midnight. Models without `peakPricing`,
+ * or with an `effectiveFrom` date in the future, always pay 1x.
  */
 function getPeakPricingMultiplier<TApi extends Api>(model: Model<TApi>, requestTimestamp: number): number {
 	const peak = model.peakPricing;

--- a/packages/catalog/src/models.ts
+++ b/packages/catalog/src/models.ts
@@ -43,8 +43,12 @@ export function getBundledModels(provider: GeneratedProvider): Model<Api>[] {
 	return models ? (Array.from(models.values()) as Model<Api>[]) : [];
 }
 
-export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
-	const peakMultiplier = getPeakPricingMultiplier(model);
+export function calculateCost<TApi extends Api>(
+	model: Model<TApi>,
+	usage: Usage,
+	requestTimestamp: number,
+): Usage["cost"] {
+	const peakMultiplier = getPeakPricingMultiplier(model, requestTimestamp);
 	const orchestration = usage.orchestration;
 	usage.cost.input = (model.cost.input / 1000000) * (usage.input + (orchestration?.input ?? 0)) * peakMultiplier;
 	usage.cost.output = (model.cost.output / 1000000) * (usage.output + (orchestration?.output ?? 0)) * peakMultiplier;
@@ -55,13 +59,20 @@ export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage
 	return usage.cost;
 }
 
-function getPeakPricingMultiplier<TApi extends Api>(model: Model<TApi>): number {
+/**
+ * Multiplier for peak/off-peak pricing windows, evaluated at the request start
+ * timestamp's UTC hour. Windows are half-open `[startHour, endHour)`; a window
+ * whose start exceeds its end wraps midnight. Models without `peakPricing`
+ * always pay 1x.
+ */
+function getPeakPricingMultiplier<TApi extends Api>(model: Model<TApi>, requestTimestamp: number): number {
 	const peak = model.peakPricing;
 	if (!peak) return 1;
-	const utcHour = new Date().getUTCHours();
+	if (peak.effectiveFrom !== undefined && requestTimestamp < peak.effectiveFrom) return 1;
+	const utcHour = new Date(requestTimestamp).getUTCHours();
 	const isPeak = peak.windows.some(w => {
 		if (w.startHour <= w.endHour) return utcHour >= w.startHour && utcHour < w.endHour;
-		return utcHour >= w.startHour || utcHour < w.endHour; // cross-midnight
+		return utcHour >= w.startHour || utcHour < w.endHour;
 	});
 	return isPeak ? peak.multiplier : 1;
 }

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -857,6 +857,17 @@ export interface Model<TApi extends Api = Api> {
 		cacheRead: number; // $/million tokens
 		cacheWrite: number; // $/million tokens
 	};
+	/**
+	 * Peak/off-peak pricing windows. When the current time falls within a window,
+	 * all costs are multiplied by the multiplier. Hours are in UTC to ensure
+	 * correct behavior regardless of the user's local timezone.
+	 *
+	 * Example: DeepSeek peak hours (Beijing 9-12, 14-18) = UTC 1-4, 6-10
+	 */
+	peakPricing?: {
+		windows: Array<{ startHour: number; endHour: number }>;
+		multiplier: number;
+	};
 	/** Premium Copilot requests charged per user-initiated request (defaults to 1). */
 	premiumMultiplier?: number;
 	contextWindow: number | null;

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -858,17 +858,20 @@ export interface Model<TApi extends Api = Api> {
 		cacheWrite: number; // $/million tokens
 	};
 	/**
-	 * Peak/off-peak pricing windows. When the current time falls within a window,
-	 * all costs are multiplied by the multiplier. Hours are in UTC to ensure
-	 * correct behavior regardless of the user's local timezone.
+	 * Peak/off-peak pricing windows. When the request start timestamp falls
+	 * within a window, all costs are multiplied by the multiplier. Windows are
+	 * evaluated at the UTC hour of the request, not at cost-calculation time, so
+	 * recomputing cost for partial/final usage never changes the multiplier.
+	 * Hours are in UTC to keep behavior timezone-independent.
 	 *
 	 * Example: DeepSeek peak hours (Beijing 9-12, 14-18) = UTC 1-4, 6-10
 	 */
 	peakPricing?: {
+		/** UTC timestamp before which the policy is dormant (multiplier stays 1). */
+		effectiveFrom?: number;
 		windows: Array<{ startHour: number; endHour: number }>;
 		multiplier: number;
 	};
-	/** Premium Copilot requests charged per user-initiated request (defaults to 1). */
 	premiumMultiplier?: number;
 	contextWindow: number | null;
 	maxTokens: number | null;

--- a/packages/catalog/test/deepseek-peak-pricing.test.ts
+++ b/packages/catalog/test/deepseek-peak-pricing.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import { applyDeepSeekPeakPricing } from "../scripts/generated-policies";
+
+function spec(overrides: Partial<ModelSpec> & Pick<ModelSpec, "id" | "provider">): ModelSpec {
+	return {
+		...overrides,
+		name: overrides.id,
+		api: "openai-completions",
+		baseUrl: "https://example.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0.1, output: 0.2, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	};
+}
+
+describe("applyDeepSeekPeakPricing", () => {
+	const deepseekModel = spec({ id: "deepseek-v4-flash", provider: "deepseek" });
+	const otherModel = spec({ id: "deepseek-v4-flash", provider: "fireworks" });
+	const effectiveFrom = Date.UTC(2026, 9, 1);
+
+	it("stays dormant while the effective date is unannounced", () => {
+		const [model] = applyDeepSeekPeakPricing([deepseekModel]);
+		expect(model.peakPricing).toBeUndefined();
+		expect(model).toBe(deepseekModel);
+	});
+
+	it("stamps every DeepSeek model with Beijing peak windows once a date is set", () => {
+		const [deepseek, other] = applyDeepSeekPeakPricing([deepseekModel, otherModel], effectiveFrom);
+		expect(deepseek.peakPricing).toEqual({
+			effectiveFrom,
+			windows: [
+				{ startHour: 1, endHour: 4 }, // Beijing 9-12
+				{ startHour: 6, endHour: 10 }, // Beijing 14-18
+			],
+			multiplier: 2,
+		});
+		expect(other.peakPricing).toBeUndefined();
+		expect(other).toBe(otherModel);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `peakPricing` to models.yml custom model definitions, `modelOverrides`, and extension provider registrations, so configured and overridden models can declare peak/off-peak UTC pricing windows that flow into displayed cost calculation.
+
 ## [17.2.8] - 2026-08-04
 
 ### Changed

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -530,6 +530,7 @@ interface ModelPatch {
 	compactionModel?: string;
 	remoteCompaction?: RemoteCompactionConfig<Api>;
 	premiumMultiplier?: number;
+	peakPricing?: ModelSpec<Api>["peakPricing"];
 }
 
 /**
@@ -563,6 +564,7 @@ function applyModelPatch(base: Model<Api>, patch: ModelPatch, transport: ModelTr
 		result.remoteCompaction = mergeRemoteCompactionConfig(base.remoteCompaction, patch.remoteCompaction);
 	}
 	if (patch.premiumMultiplier !== undefined) result.premiumMultiplier = patch.premiumMultiplier;
+	if (patch.peakPricing !== undefined) result.peakPricing = patch.peakPricing;
 	if (patch.cost) {
 		result.cost = {
 			input: patch.cost.input ?? base.cost.input,
@@ -679,6 +681,7 @@ function buildCustomModelOverlay(
 		compactionModel: modelDef.compactionModel,
 		remoteCompaction: mergeRemoteCompactionConfig(providerRemoteCompaction, modelDef.remoteCompaction),
 		premiumMultiplier: modelDef.premiumMultiplier,
+		peakPricing: modelDef.peakPricing,
 		isOAuth: resolveCustomModelIsOAuth(api, providerAuth),
 	};
 }
@@ -721,6 +724,7 @@ function finalizeCustomModel(model: CustomModelOverlay, options: CustomModelBuil
 		compactionModel: resolvedModel.compactionModel,
 		remoteCompaction: resolvedModel.remoteCompaction,
 		premiumMultiplier: resolvedModel.premiumMultiplier,
+		peakPricing: resolvedModel.peakPricing ?? reference?.peakPricing,
 		isOAuth: resolvedModel.isOAuth,
 	} as ModelSpec<Api>);
 }
@@ -2815,5 +2819,6 @@ export interface ProviderConfigInput {
 		compactionModel?: string;
 		remoteCompaction?: RemoteCompactionConfig<Api>;
 		premiumMultiplier?: number;
+		peakPricing?: ModelSpec<Api>["peakPricing"];
 	}>;
 }

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -159,6 +159,22 @@ export const getModelsConfigSchemaBundle = once(() => {
 		return true;
 	});
 
+	const PeakPricingWindowSchema = type({
+		startHour: "0 <= number.integer <= 23",
+		endHour: "0 <= number.integer <= 23",
+	});
+
+	const PeakPricingSchema = type({
+		"effectiveFrom?": "number",
+		windows: [PeakPricingWindowSchema, "[]"],
+		multiplier: "number",
+	}).narrow((value, ctx) => {
+		if (value.windows.length === 0) {
+			return ctx.mustBe("peakPricing.windows a non-empty array");
+		}
+		return true;
+	});
+
 	const ModelDefinitionSchema = type({
 		id: "string",
 		"name?": "string",
@@ -175,6 +191,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 			cacheWrite: "number",
 		},
 		"premiumMultiplier?": "number",
+		"peakPricing?": PeakPricingSchema,
 		"contextWindow?": "number",
 		"maxTokens?": "number",
 		"omitMaxOutputTokens?": "boolean",
@@ -224,6 +241,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 			"cacheWrite?": "number",
 		},
 		"premiumMultiplier?": "number",
+		"peakPricing?": PeakPricingSchema,
 		"contextWindow?": "number",
 		"maxTokens?": "number",
 		"omitMaxOutputTokens?": "boolean",

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -7,6 +7,7 @@ import { Effort, type FetchImpl, type Model, type OpenAICompat, type ThinkingCon
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { getModelsConfigSchema } from "@oh-my-pi/pi-coding-agent/config/models-config-schema-bundle";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
@@ -1522,6 +1523,65 @@ describe("ModelRegistry", () => {
 			const model = omitOnCustom.find("ollama", "glm-5.1:cloud");
 			expect(model?.omitMaxOutputTokens).toBe(true);
 			expect(model?.maxTokens).toBe(202752);
+		});
+	});
+
+	describe("peakPricing config wiring", () => {
+		// Custom definitions and overrides must carry `peakPricing` all the way
+		// into the built catalog so `calculateCost` sees it for configured models.
+		const peakPolicy = {
+			windows: [
+				{ startHour: 1, endHour: 4 },
+				{ startHour: 6, endHour: 10 },
+			],
+			multiplier: 2,
+		};
+		let registry: ModelRegistry;
+		beforeAll(() => {
+			registry = readonlyRegistry({
+				providers: {
+					openrouter: {
+						baseUrl: "https://peak.example.com/v1",
+						apiKey: "TEST_KEY",
+						api: "openai-completions",
+						models: [
+							{
+								id: "peak-custom",
+								api: "openai-completions",
+								reasoning: false,
+								input: ["text"],
+								cost: { input: 1, output: 3, cacheRead: 0.2, cacheWrite: 0 },
+								contextWindow: 128000,
+								maxTokens: 16384,
+								peakPricing: peakPolicy,
+							},
+						],
+						modelOverrides: {
+							"anthropic/claude-sonnet-4": { peakPricing: peakPolicy },
+						},
+					},
+				},
+			});
+		});
+
+		test("custom model definitions carry peakPricing into the built catalog", () => {
+			expect(registry.find("openrouter", "peak-custom")?.peakPricing).toEqual(peakPolicy);
+		});
+
+		test("modelOverrides apply peakPricing to bundled models", () => {
+			const model = getModelsForProvider(registry, "openrouter").find(m => m.id === "anthropic/claude-sonnet-4");
+			expect(model?.peakPricing).toEqual(peakPolicy);
+		});
+
+		test("models.yml schema accepts peakPricing and rejects malformed shapes", () => {
+			const schema = getModelsConfigSchema();
+			const configWith = (peakPricing: unknown) => ({
+				providers: { openrouter: { models: [{ id: "peak-model", peakPricing }] } },
+			});
+			expect(schema.allows(configWith(peakPolicy))).toBe(true);
+			expect(schema.allows(configWith({ windows: [], multiplier: 2 }))).toBe(false);
+			expect(schema.allows(configWith({ windows: [{ startHour: 25, endHour: 2 }], multiplier: 2 }))).toBe(false);
+			expect(schema.allows(configWith({ windows: [{ startHour: 1, endHour: 4 }] }))).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Add support for DeepSeek API peak/off-peak pricing. DeepSeek charges 2x during Beijing time peak hours (9-12 and 14-18), which translates to UTC hours 1-4 and 6-10.

## Changes

### Core Implementation
- **Model Interface**: Added `peakPricing` field with UTC hour windows and multiplier
- **Cost Calculation**: Modified `calculateCost` to check current UTC time and apply peak multiplier when in a peak window
- **Generator**: Added `applyDeepSeekPeakPricing` to automatically configure peak pricing for all DeepSeek provider models

### Key Design Decisions

**Why UTC hours?**
Peak pricing is based on Beijing time (UTC+8), but users can be anywhere in the world. By converting to UTC hours in the configuration, we ensure correct behavior regardless of the user's timezone. The check uses `new Date().getUTCHours()` which is universal.

**Why provider-level in generator?**
DeepSeek's peak pricing is a provider-wide policy, not per-model. The generator automatically adds the config to all models with `provider === "deepseek"`, ensuring consistency.

### Generated Models
The `models.json` is auto-generated, so peak pricing is applied via the generator rather than manual edits. Both `deepseek-v4-flash` and `deepseek-v4-pro` now include the peak pricing configuration.

## Testing

Verified cost calculation at different UTC hours:
- UTC 2 (Beijing 10) → 2x ✓
- UTC 7 (Beijing 15) → 2x ✓  
- Other hours → 1x ✓

Current time (UTC 13, Beijing 21) correctly shows 1x pricing.