### PR TITLE
feat(coding-agent): add showProvider option to status line model segment

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+### Added
 
 ## [17.2.7] - 2026-08-03
 
@@ -24,6 +25,7 @@
 
 - Added the `/reset` slash command to reset the conversation context in place: it drops the live messages, queued turns, and pending tool calls (and cancels the turn's async jobs, post-prompt continuations, and checkpoint/plan runtime state) while keeping the session id, title, cwd, model, and on-disk transcript. It records a durable reset boundary so the live transcript stays cleared across rebuilds (theme change, focus attach, `/shake`, resume) instead of resurrecting the pre-reset messages, while the full pre-reset history stays on disk ([#3580](https://github.com/can1357/oh-my-pi/issues/3580)).
 
+- Added `showProvider` option to the status line model segment (`statusLine.segmentOptions.model.showProvider`) to display the provider prefix (e.g. "Anthropic/opus-4.5") for disambiguation in multi-provider sessions.
 ### Fixed
 
 - Fixed extension slash commands appearing as user prompts after being handled locally.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Added
 
+- Added `showProvider` option to the status line model segment (`statusLine.segmentOptions.model.showProvider`) to display the provider prefix (e.g. "Anthropic/opus-4.5") for disambiguation in multi-provider sessions.
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed
@@ -24,8 +26,6 @@
 ### Added
 
 - Added the `/reset` slash command to reset the conversation context in place: it drops the live messages, queued turns, and pending tool calls (and cancels the turn's async jobs, post-prompt continuations, and checkpoint/plan runtime state) while keeping the session id, title, cwd, model, and on-disk transcript. It records a durable reset boundary so the live transcript stays cleared across rebuilds (theme change, focus attach, `/shake`, resume) instead of resurrecting the pre-reset messages, while the full pre-reset history stays on disk ([#3580](https://github.com/can1357/oh-my-pi/issues/3580)).
-
-- Added `showProvider` option to the status line model segment (`statusLine.segmentOptions.model.showProvider`) to display the provider prefix (e.g. "Anthropic/opus-4.5") for disambiguation in multi-provider sessions.
 ### Fixed
 
 - Fixed extension slash commands appearing as user prompts after being handled locally.

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -143,15 +143,19 @@ const modelSegment: StatusLineSegment = {
 
 		// `statusLineModel` is aliased to `accent` in many themes, so the badge
 		// uses status colors to stay visibly distinct from the model name color.
-		let content = theme.fg("statusLineModel", withIcon(modelIcon, modelName));
-
-		// Prepend a dimmed provider prefix when opted in. Concatenated (not
-		// nested) so the inner `\\x1b[39m` from theme.fg("dim", …) does not
-		// reset the outer statusLineModel color on the model name.
+		let content: string;
 		if (opts.showProvider && state.model?.provider) {
 			const provider = sanitizeStatusText(state.model.provider);
 			const label = provider[0].toUpperCase() + provider.slice(1);
-			content = theme.fg("dim", `${label}/`) + content;
+			// Icon (statusLineModel), dimmed provider, then model — three sibling
+			// spans, so the provider's dim reset cannot touch the model color and
+			// the slash separates provider from model, not from the icon.
+			content =
+				theme.fg("statusLineModel", modelIcon ? `${modelIcon} ` : "") +
+				theme.fg("dim", `${label}/`) +
+				theme.fg("statusLineModel", modelName);
+		} else {
+			content = theme.fg("statusLineModel", withIcon(modelIcon, modelName));
 		}
 
 		// Advisor "++" badge, colored by the worst status in the roster:

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -104,6 +104,14 @@ const modelSegment: StatusLineSegment = {
 			modelName = modelName.slice(7);
 		}
 
+		// Prepend provider/id prefix when opted in and the provider is known
+		// (e.g. "anthropic/opus-4.5"). Capitalize the provider for readability
+		// and dim it so the model id remains visually dominant.
+		if (opts.showProvider && state.model?.provider) {
+			const provider = state.model.provider[0].toUpperCase() + state.model.provider.slice(1);
+			modelName = theme.fg("dim", `${provider}/`) + modelName;
+		}
+
 		// Resolve the current thinking-level display ("◉ xhigh", "⟳ auto", …)
 		// when the model supports thinking and the segment isn't hiding it.
 		let thinkingDisplay = "";

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -104,14 +104,6 @@ const modelSegment: StatusLineSegment = {
 			modelName = modelName.slice(7);
 		}
 
-		// Prepend provider/id prefix when opted in and the provider is known
-		// (e.g. "anthropic/opus-4.5"). Capitalize the provider for readability
-		// and dim it so the model id remains visually dominant.
-		if (opts.showProvider && state.model?.provider) {
-			const provider = state.model.provider[0].toUpperCase() + state.model.provider.slice(1);
-			modelName = theme.fg("dim", `${provider}/`) + modelName;
-		}
-
 		// Resolve the current thinking-level display ("◉ xhigh", "⟳ auto", …)
 		// when the model supports thinking and the segment isn't hiding it.
 		let thinkingDisplay = "";
@@ -152,6 +144,16 @@ const modelSegment: StatusLineSegment = {
 		// `statusLineModel` is aliased to `accent` in many themes, so the badge
 		// uses status colors to stay visibly distinct from the model name color.
 		let content = theme.fg("statusLineModel", withIcon(modelIcon, modelName));
+
+		// Prepend a dimmed provider prefix when opted in. Concatenated (not
+		// nested) so the inner `\\x1b[39m` from theme.fg("dim", …) does not
+		// reset the outer statusLineModel color on the model name.
+		if (opts.showProvider && state.model?.provider) {
+			const provider = sanitizeStatusText(state.model.provider);
+			const label = provider[0].toUpperCase() + provider.slice(1);
+			content = theme.fg("dim", `${label}/`) + content;
+		}
+
 		// Advisor "++" badge, colored by the worst status in the roster:
 		// success = all running, warning = quota-exhausted, error = failed,
 		// dim = everything paused/no-model. Per-advisor detail lives in

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -15,7 +15,7 @@ export interface CollabStatus {
 }
 
 export interface StatusLineSegmentOptions {
-	model?: { showThinkingLevel?: boolean };
+	model?: { showThinkingLevel?: boolean; showProvider?: boolean };
 	path?: { abbreviate?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
 	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
 	time?: { format?: "12h" | "24h"; showSeconds?: boolean };

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -157,7 +157,7 @@ describe("status line model segment showProvider", () => {
 
 	it("omits provider prefix when showProvider is true but model has no provider", () => {
 		const ctx = createProviderContext(true, "anthropic");
-		ctx.session.state.model = { id: "test-model", name: "Test Model" };
+		ctx.session.state.model = { id: "test-model", name: "Test Model" } as SegmentContext["session"]["state"]["model"];
 		const rendered = renderSegment("model", ctx);
 		expect(Bun.stripANSI(rendered.content)).not.toContain("Anthropic");
 	});

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -124,3 +124,53 @@ describe("status line model segment compact thinking level", () => {
 		expect(Bun.stripANSI(rendered.content)).not.toContain(theme.sep.dot);
 	});
 });
+
+describe("status line model segment showProvider", () => {
+	function createProviderContext(showProvider: boolean, provider: string): SegmentContext {
+		return {
+			...createModelContext(false),
+			options: { model: { showProvider } },
+			session: {
+				state: {
+					model: { id: "test-model", name: "Test Model", provider },
+				},
+				isFastModeActive: () => false,
+				isAutoThinking: false,
+				autoResolvedThinkingLevel: () => undefined,
+				isAdvisorActive: () => false,
+				getAdvisorStatusOverview: () => ({ configured: false, advisors: [] }),
+			} as unknown as SegmentContext["session"],
+		};
+	}
+
+	it("prepends capitalized provider prefix when showProvider is true", () => {
+		const rendered = renderSegment("model", createProviderContext(true, "anthropic"));
+		expect(Bun.stripANSI(rendered.content)).toContain("Anthropic/");
+		expect(Bun.stripANSI(rendered.content)).toContain("Test Model");
+	});
+
+	it("omits provider prefix when showProvider is false", () => {
+		const rendered = renderSegment("model", createProviderContext(false, "anthropic"));
+		expect(Bun.stripANSI(rendered.content)).not.toContain("Anthropic");
+		expect(Bun.stripANSI(rendered.content)).toContain("Test Model");
+	});
+
+	it("omits provider prefix when showProvider is true but model has no provider", () => {
+		const ctx = createProviderContext(true, "anthropic");
+		ctx.session.state.model = { id: "test-model", name: "Test Model" };
+		const rendered = renderSegment("model", ctx);
+		expect(Bun.stripANSI(rendered.content)).not.toContain("Anthropic");
+	});
+
+	it("omits provider prefix when options.model is absent", () => {
+		const ctx = createModelContext(false);
+		ctx.options = {};
+		ctx.session.state.model = {
+			id: "test-model",
+			name: "Test Model",
+			provider: "anthropic",
+		} as SegmentContext["session"]["state"]["model"];
+		const rendered = renderSegment("model", ctx);
+		expect(Bun.stripANSI(rendered.content)).not.toContain("Anthropic");
+	});
+});

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -145,8 +145,20 @@ describe("status line model segment showProvider", () => {
 
 	it("prepends capitalized provider prefix when showProvider is true", () => {
 		const rendered = renderSegment("model", createProviderContext(true, "anthropic"));
-		expect(Bun.stripANSI(rendered.content)).toContain("Anthropic/");
-		expect(Bun.stripANSI(rendered.content)).toContain("Test Model");
+		const stripped = Bun.stripANSI(rendered.content);
+		expect(stripped).toContain("Anthropic/Test Model");
+		// Slash separates provider from the model name, not from the icon.
+		const icon = theme.icon.model ? `${theme.icon.model} ` : "";
+		expect(stripped).toBe(`${icon}Anthropic/Test Model`);
+		// Provider span is dim and does not wrap (nest inside) the model span:
+		// icon and model keep their own statusLineModel spans, provider its own dim.
+		const dimAnsi = theme.getFgAnsi("dim");
+		const modelAnsi = theme.getFgAnsi("statusLineModel");
+		const reset = "\x1b[39m";
+		expect(rendered.content).toContain(
+			`${modelAnsi}${icon}${reset}${dimAnsi}Anthropic/${reset}${modelAnsi}Test Model`,
+		);
+		expect(rendered.content).not.toContain(`${dimAnsi}Anthropic/${reset}${modelAnsi}${icon}`);
 	});
 
 	it("omits provider prefix when showProvider is false", () => {


### PR DESCRIPTION
## What

Adds `showProvider` option to the status line model segment (`statusLine.segmentOptions.model.showProvider`), default off. When enabled, the model name is prefixed with a dimmed capitalized provider (e.g. "Anthropic/opus-4.5").

## Why

Users with multiple providers configured (e.g. Anthropic + Google + OpenRouter) cannot see which provider is active without opening `/switch` or running `omp models`. This is especially confusing after model fallback or when different roles use different providers.

## Testing

- All 5 existing `test/status-line-model.test.ts` tests pass
- Added 4 new tests for: showProvider=true with provider, showProvider=false, missing provider field, missing options.model
- `bun check` passes (2500 files, 0 fixes)
- Built `dist/omp` and verified `omp config set statusLine.segmentOptions '{"model":{"showProvider":true}}'` succeeds and reads back correctly

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)