### PR TITLE
feat(status-line): show compact provider labels

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Added
 
 - Added the `/reset` slash command to reset the conversation context in place: it drops the live messages, queued turns, and pending tool calls (and cancels the turn's async jobs, post-prompt continuations, and checkpoint/plan runtime state) while keeping the session id, title, cwd, model, and on-disk transcript. It records a durable reset boundary so the live transcript stays cleared across rebuilds (theme change, focus attach, `/shake`, resume) instead of resurrecting the pre-reset messages, while the full pre-reset history stays on disk ([#3580](https://github.com/can1357/oh-my-pi/issues/3580)).
+### Changed
+
+- Added compact provider labels before model names in the status line.
 
 ### Fixed
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -93,15 +93,42 @@ const piSegment: StatusLineSegment = {
 	},
 };
 
+const COMPACT_PROVIDER_LABELS: Readonly<Record<string, string>> = {
+	anthropic: "Claude",
+	"openai-codex": "Codex",
+	devin: "Devin",
+	openai: "OpenAI",
+	google: "Gemini",
+	"google-gemini": "Gemini",
+	"google-vertex": "Vertex",
+	"github-copilot": "Copilot",
+	xai: "Grok",
+	openrouter: "OpenRouter",
+	"amazon-bedrock": "Bedrock",
+	"azure-openai": "Azure",
+};
+
+function compactProviderLabel(provider: string | undefined): string {
+	if (!provider) return "";
+	const known = COMPACT_PROVIDER_LABELS[provider.toLowerCase()];
+	if (known) return known;
+	return provider
+		.split(/[-_]/u)
+		.filter(Boolean)
+		.map(part => part[0]!.toUpperCase() + part.slice(1))
+		.join(" ");
+}
+
 const modelSegment: StatusLineSegment = {
 	id: "model",
 	render(ctx) {
 		const state = ctx.session.state;
 		const opts = ctx.options.model ?? {};
 
+		const providerLabel = compactProviderLabel(state.model?.provider);
 		let modelName = state.model?.name || state.model?.id || "no-model";
-		if (modelName.startsWith("Claude ")) {
-			modelName = modelName.slice(7);
+		if (providerLabel && modelName.toLowerCase().startsWith(`${providerLabel.toLowerCase()} `)) {
+			modelName = modelName.slice(providerLabel.length + 1);
 		}
 
 		// Resolve the current thinking-level display ("◉ xhigh", "⟳ auto", …)
@@ -143,7 +170,9 @@ const modelSegment: StatusLineSegment = {
 
 		// `statusLineModel` is aliased to `accent` in many themes, so the badge
 		// uses status colors to stay visibly distinct from the model name color.
-		let content = theme.fg("statusLineModel", withIcon(modelIcon, modelName));
+		let content = theme.fg("statusLineModel", modelIcon ? `${modelIcon} ` : "");
+		if (providerLabel) content += theme.fg("dim", `${providerLabel} `);
+		content += theme.fg("statusLineModel", modelName);
 		// Advisor "++" badge, colored by the worst status in the roster:
 		// success = all running, warning = quota-exhausted, error = failed,
 		// dim = everything paused/no-model. Per-advisor detail lives in

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -56,6 +56,20 @@ function createModelContext(advisorActive: boolean): SegmentContext {
 	};
 }
 
+describe("status line model segment provider label", () => {
+	it.each([
+		["anthropic", "Claude Opus 4.6", "Claude Opus 4.6"],
+		["openai-codex", "GPT-5.6 Sol", "Codex GPT-5.6 Sol"],
+		["devin", "SWE-1.7 Lightning", "Devin SWE-1.7 Lightning"],
+	])("prefixes %s models without duplicating the model family", (provider, name, expected) => {
+		const ctx = createModelContext(false);
+		ctx.session.state.model = { ...ctx.session.state.model!, id: "test-model", name, provider };
+		const modelPrefix = theme.icon.model ? `${theme.icon.model} ` : "";
+
+		expect(Bun.stripANSI(renderSegment("model", ctx).content)).toBe(`${modelPrefix}${expected}`);
+	});
+});
+
 describe("status line model segment advisor badge", () => {
 	it("appends a success-colored ++ badge when all advisors run", () => {
 		const rendered = renderSegment("model", createModelContext(true));


### PR DESCRIPTION
## What
- prefix model names with compact provider labels in the status line
- map common provider IDs to user-facing labels such as Claude, Codex, and Devin
- dim the provider label while preserving the active model color

## Why
Model names alone do not identify the execution provider when several providers expose similarly named models.

## Testing
- `bun test packages/coding-agent/test/status-line-model.test.ts` (8 pass)
- `bun --cwd=packages/coding-agent run check`
- fresh TUI smoke rendered `⬢ Codex GPT-5.6-Sol · ⟳ auto`