### PR TITLE
feat(tui): copy resume command on shutdown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Copied the resume command to the system clipboard when an interactive session closes.
+
 ## [17.2.6] - 2026-08-03
 
 ### Added

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4064,11 +4064,13 @@ export class InteractiveMode implements InteractiveModeContext {
 		popTerminalTitle();
 		this.stop();
 
-		// Print resumption hint if this is a persisted session
+		// Copy and print the resumption command if this is a persisted session.
 		const sessionId = this.sessionManager.getSessionId();
 		const sessionFile = this.sessionManager.getSessionFile();
 		if (sessionId && sessionFile) {
-			process.stderr.write(`\n${chalk.dim(`Resume this session with ${APP_NAME} --resume ${sessionId}`)}\n`);
+			const resumeCommand = `${APP_NAME} --resume ${sessionId}`;
+			await copyToClipboard(resumeCommand);
+			process.stderr.write(`\n${chalk.dim(`Resume this session with ${resumeCommand} (copied to clipboard)`)}\n`);
 		}
 
 		await postmortem.quit(0);

--- a/packages/coding-agent/test/interactive-mode-shutdown-resume.test.ts
+++ b/packages/coding-agent/test/interactive-mode-shutdown-resume.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import * as clipboard from "@oh-my-pi/pi-coding-agent/utils/clipboard";
+import { postmortem, TempDir } from "@oh-my-pi/pi-utils";
+
+describe("InteractiveMode shutdown resume command", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let mode: InteractiveMode;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		mode?.stop();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	it("copies the persisted session resume command before exiting", async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-shutdown-resume-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+
+		const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		await sessionManager.ensureOnDisk();
+		session = new AgentSession({
+			agent: new Agent({ initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] } }),
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		vi.spyOn(mode.ui.terminal, "drainInput").mockResolvedValue(undefined);
+		const copySpy = vi.spyOn(clipboard, "copyToClipboard").mockResolvedValue(undefined);
+		vi.spyOn(postmortem, "quit").mockResolvedValue(undefined);
+		vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+		await mode.shutdown();
+
+		expect(copySpy).toHaveBeenCalledWith(`omp --resume ${sessionManager.getSessionId()}`);
+	});
+});


### PR DESCRIPTION
## What
- copy `omp --resume <session-id>` to the system clipboard when a persisted interactive session closes
- keep the printed resume hint and state that the command was copied
- add regression coverage for the shutdown clipboard contract

## Testing
- `bun test packages/coding-agent/test/interactive-mode-shutdown-resume.test.ts` (1 pass)
- `bun --cwd=packages/coding-agent run check`
- fresh TUI shutdown copied the exact resume command to the macOS clipboard