### PR TITLE
fix(cursor): degrade K3 same-model history missing thinking

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Cursor `kimi-k3` sessions bricking permanently when a same-model assistant turn was persisted without thinking blocks (a turn whose stream carried no `thinkingDelta` events). `assertCursorKimiK3HistoryReplayable` now only hard-errors on genuinely foreign history; same-model turns missing thinking degrade to a one-time warning and replay without the reasoning part ([#7516](https://github.com/can1357/oh-my-pi/issues/7516)).
+- Fixed Cursor `kimi-k3` sessions bricking permanently when a same-model assistant turn was persisted without thinking blocks (a turn whose stream carried no `thinkingDelta` events). `assertCursorKimiK3HistoryReplayable` now only hard-errors on genuinely foreign history; same-model turns missing thinking replay without the reasoning part, with warnings at turn completion and first degraded replay that identify the affected assistant-turn positions ([#7516](https://github.com/can1357/oh-my-pi/issues/7516)).
 
 ## [17.2.6] - 2026-08-03
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor `kimi-k3` sessions bricking permanently when a same-model assistant turn was persisted without thinking blocks (a turn whose stream carried no `thinkingDelta` events). `assertCursorKimiK3HistoryReplayable` now only hard-errors on genuinely foreign history; same-model turns missing thinking degrade to a one-time warning and replay without the reasoning part ([#7516](https://github.com/can1357/oh-my-pi/issues/7516)).
+
 ## [17.2.6] - 2026-08-03
 
 ### Added

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -144,6 +144,7 @@ import { isKimiK3ModelId } from "@oh-my-pi/pi-catalog/identity";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import {
 	$env,
+	logger,
 	parseJsonWithRepair,
 	parseStreamingJson,
 	parseStreamingJsonThrottled,
@@ -4113,16 +4114,34 @@ function assertCursorKimiK3HistoryReplayable(
 ): void {
 	if (!targetModelId || !isKimiK3ModelId(targetModelId)) return;
 	const historyEnd = activeUserMessageIndex >= 0 ? activeUserMessageIndex : messages.length;
+	let sawSameModelMissingThinking = false;
 	for (let i = 0; i < historyEnd; i++) {
 		const msg = messages[i];
 		if (msg.role !== "assistant") continue;
 		const isSameCursorModel = msg.api === "cursor-agent" && msg.provider === "cursor" && msg.model === targetModelId;
-		const hasThinking = msg.content.some(item => item.type === "thinking" && item.thinking.length > 0);
-		if (!isSameCursorModel || !hasThinking) {
+		if (!isSameCursorModel) {
+			// Foreign history genuinely cannot replay K3 thinking: another model's
+			// turns carry no K3-signed reasoning to reconstruct, so continuation
+			// is unsafe and must fail hard.
 			throw new AIError.ValidationError(
-				`Cursor ${targetModelId} requires complete same-model thinking history; start a new session instead of continuing history from ${msg.provider}/${msg.model}.`,
+				`Cursor ${targetModelId} cannot continue history from a different model (${msg.provider}/${msg.model}); start a new session.`,
 			);
 		}
+		const hasThinking = msg.content.some(item => item.type === "thinking" && item.thinking.length > 0);
+		if (!hasThinking) sawSameModelMissingThinking = true;
+	}
+	if (sawSameModelMissingThinking) {
+		// A same-model turn whose stream carried no `thinkingDelta` events is
+		// persisted without thinking blocks. `buildCursorAssistantContent` still
+		// replays its text/tool-call structure and simply omits the reasoning
+		// part, so the history remains usable — degrade with a one-time warning
+		// rather than permanently bricking the session. Per Kimi's
+		// preserved-thinking caveat, K3 generation may be less stable across the
+		// affected span.
+		logger.warn(
+			"Cursor kimi-k3 history contains a same-model assistant turn without thinking blocks; replaying without reasoning for that span (generation may be less stable)",
+			{ model: targetModelId },
+		);
 	}
 }
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -234,6 +234,7 @@ const NOT_IMPLEMENTED = `Not implemented by this client`;
 
 const conversationStateCache = new Map<string, ConversationStateStructure>();
 const conversationBlobStores = new Map<string, Map<string, Uint8Array>>();
+const warnedCursorKimiK3ReplayMessages = new Set<string>();
 
 export interface CursorOptions extends StreamOptions {
 	customSystemPrompt?: string;
@@ -3903,6 +3904,15 @@ export function processInteractionUpdate(
 		}
 	} else if (updateCase === "turnEnded") {
 		output.stopReason = "stop";
+		if (
+			isKimiK3ModelId(output.model) &&
+			!output.content.some(item => item.type === "thinking" && item.thinking.length > 0)
+		) {
+			logger.warn(
+				"Cursor kimi-k3 turn completed without thinking blocks; persisted history will replay this turn without reasoning",
+				{ model: output.model, messageTimestamp: output.timestamp },
+			);
+		}
 	} else if (updateCase === "tokenDelta") {
 		const tokenDelta = update.message.value;
 		usageState.sawTokenDelta = true;
@@ -4114,35 +4124,34 @@ function assertCursorKimiK3HistoryReplayable(
 ): void {
 	if (!targetModelId || !isKimiK3ModelId(targetModelId)) return;
 	const historyEnd = activeUserMessageIndex >= 0 ? activeUserMessageIndex : messages.length;
-	let sawSameModelMissingThinking = false;
+	const missingThinkingTurns: number[] = [];
+	const newlyWarnedKeys: string[] = [];
+	let assistantTurn = 0;
 	for (let i = 0; i < historyEnd; i++) {
 		const msg = messages[i];
 		if (msg.role !== "assistant") continue;
+		assistantTurn++;
 		const isSameCursorModel = msg.api === "cursor-agent" && msg.provider === "cursor" && msg.model === targetModelId;
 		if (!isSameCursorModel) {
 			// Foreign history genuinely cannot replay K3 thinking: another model's
-			// turns carry no K3-signed reasoning to reconstruct, so continuation
-			// is unsafe and must fail hard.
+			// turns carry no K3-signed reasoning to reconstruct.
 			throw new AIError.ValidationError(
 				`Cursor ${targetModelId} cannot continue history from a different model (${msg.provider}/${msg.model}); start a new session.`,
 			);
 		}
 		const hasThinking = msg.content.some(item => item.type === "thinking" && item.thinking.length > 0);
-		if (!hasThinking) sawSameModelMissingThinking = true;
+		if (hasThinking) continue;
+		const warningKey = `${msg.api}\0${msg.provider}\0${msg.model}\0${msg.timestamp}`;
+		if (warnedCursorKimiK3ReplayMessages.has(warningKey)) continue;
+		missingThinkingTurns.push(assistantTurn);
+		newlyWarnedKeys.push(warningKey);
 	}
-	if (sawSameModelMissingThinking) {
-		// A same-model turn whose stream carried no `thinkingDelta` events is
-		// persisted without thinking blocks. `buildCursorAssistantContent` still
-		// replays its text/tool-call structure and simply omits the reasoning
-		// part, so the history remains usable — degrade with a one-time warning
-		// rather than permanently bricking the session. Per Kimi's
-		// preserved-thinking caveat, K3 generation may be less stable across the
-		// affected span.
-		logger.warn(
-			"Cursor kimi-k3 history contains a same-model assistant turn without thinking blocks; replaying without reasoning for that span (generation may be less stable)",
-			{ model: targetModelId },
-		);
-	}
+	if (missingThinkingTurns.length === 0) return;
+	for (const key of newlyWarnedKeys) warnedCursorKimiK3ReplayMessages.add(key);
+	logger.warn(
+		`Cursor kimi-k3 history contains same-model assistant turn(s) ${missingThinkingTurns.join(", ")} without thinking blocks; replaying those spans without reasoning may make generation less stable`,
+		{ model: targetModelId, assistantTurns: missingThinkingTurns },
+	);
 }
 
 /**

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -757,8 +757,46 @@ describe("Cursor history encoding", () => {
 		];
 
 		expect(() => buildCursorHistoryForTest(messages, undefined, "kimi-k3-high")).toThrow(
-			"start a new session instead of continuing history from anthropic/claude-4.6-opus-high",
+			"cannot continue history from a different model (anthropic/claude-4.6-opus-high)",
 		);
+	});
+
+	it("replays a same-model K3 turn missing thinking instead of bricking the session", () => {
+		const messages: Context["messages"] = [
+			{ role: "user", content: "Do a big multi-tool task", timestamp: 1 },
+			cursorAssistant(
+				"kimi-k3-high",
+				[{ type: "toolCall", id: "call-read", name: "read", arguments: { path: "package.json" } }],
+				2,
+				"toolUse",
+			),
+			{
+				role: "toolResult",
+				toolCallId: "call-read",
+				toolName: "read",
+				content: [{ type: "text", text: "package contents" }],
+				isError: false,
+				timestamp: 3,
+			},
+			cursorAssistant("kimi-k3-high", [{ type: "text", text: "Done." }], 4),
+			{ role: "user", content: "Continue the same session", timestamp: 5 },
+		];
+
+		const history = buildCursorHistoryForTest(messages, undefined, "kimi-k3-high");
+
+		expect(history.rootPromptMessagesJson).toEqual([
+			{ role: "user", content: [{ type: "text", text: "Do a big multi-tool task" }] },
+			{
+				role: "assistant",
+				content: [{ type: "tool-call", toolCallId: "call-read", toolName: "read", args: { path: "package.json" } }],
+			},
+			{
+				role: "tool",
+				id: "call-read",
+				content: [{ type: "tool-result", toolName: "read", toolCallId: "call-read", result: "package contents" }],
+			},
+			{ role: "assistant", content: [{ type: "text", text: "Done." }] },
+		]);
 	});
 
 	it("keeps non-K3 Cursor thinking out of model-facing history", () => {

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { create } from "@bufbuild/protobuf";
 import {
 	type BlockState,
@@ -32,6 +32,11 @@ import {
 	ReadResultSchema,
 	ReadSuccessSchema,
 } from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
+import { logger } from "@oh-my-pi/pi-utils";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 const cursorModel: Model<"cursor-agent"> = buildModel({
 	id: "cursor-composer-2.5",
@@ -782,7 +787,14 @@ describe("Cursor history encoding", () => {
 			{ role: "user", content: "Continue the same session", timestamp: 5 },
 		];
 
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		const history = buildCursorHistoryForTest(messages, undefined, "kimi-k3-high");
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("assistant turn(s) 1, 2"), {
+			model: "kimi-k3-high",
+			assistantTurns: [1, 2],
+		});
+		buildCursorHistoryForTest(messages, undefined, "kimi-k3-high");
+		expect(warnSpy).toHaveBeenCalledTimes(1);
 
 		expect(history.rootPromptMessagesJson).toEqual([
 			{ role: "user", content: [{ type: "text", text: "Do a big multi-tool task" }] },
@@ -1125,6 +1137,28 @@ function newBlockState(): BlockState {
 		setFirstTokenTime: () => {},
 	};
 }
+
+describe("Cursor K3 completion warnings", () => {
+	it("warns when a K3 turn ends without thinking blocks", () => {
+		const output = cursorAssistantMessage();
+		output.model = "kimi-k3-high";
+		output.timestamp = 7516;
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		processInteractionUpdate(
+			{ message: { case: "turnEnded", value: {} } },
+			output,
+			new AssistantMessageEventStream(),
+			newBlockState(),
+			{ sawTokenDelta: false },
+		);
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			"Cursor kimi-k3 turn completed without thinking blocks; persisted history will replay this turn without reasoning",
+			{ model: "kimi-k3-high", messageTimestamp: 7516 },
+		);
+	});
+});
 
 describe("Cursor exec local-work tracking (issue #4593)", () => {
 	it("marks the stream busy for the duration of a local exec handler", async () => {


### PR DESCRIPTION
## Repro
Continuing a `cursor/kimi-k3` session brick permanently once any same-model assistant turn is persisted without thinking blocks — which happens when that turn's stream carried no `thinkingDelta` events (observed on long multi-tool-call turns finishing with stop reason `stop`). Building a K3 history where a `kimi-k3-high` assistant turn has only `text`/`toolCall` blocks and running the history builder throws before any request:

```
RESULT: THREW -> ValidationError -> Cursor kimi-k3-high requires complete same-model thinking history; start a new session instead of continuing history from cursor/kimi-k3-high.
```

Every subsequent turn re-hits the same persisted message; recovery requires switching models or starting a new session.

## Cause
`assertCursorKimiK3HistoryReplayable()` (`packages/ai/src/providers/cursor.ts`) rejected an assistant turn when it failed *either* same-model origin *or* the presence of a non-empty thinking block (`!isSameCursorModel || !hasThinking`). The write path (`processInteractionUpdate`) only creates `thinking` blocks from `thinkingDelta` updates, so a same-model K3 turn with no thinking deltas is persisted with zero thinking blocks — a state the guard then treats as fatal. The error text also interpolated `msg.provider/msg.model`, which for a same-model turn is the *current* model, making it read like a cross-model mismatch.

## Fix
- Split the guard's two failure modes: `!isSameCursorModel` still throws (foreign history genuinely cannot replay K3-signed reasoning), with a clearer message naming the cross-model cause.
- A same-model turn missing thinking no longer throws — it degrades to a one-time `logger.warn` and replays via `buildCursorAssistantContent`, which already omits the reasoning part when no thinking exists (text/tool-call structure is preserved).
- Added `logger` to the existing `@oh-my-pi/pi-utils` import.
- Updated the foreign-history test for the new message and added a regression test asserting a same-model K3 turn without thinking replays its text/tool-call history instead of throwing.
- Changelog entry under `packages/ai` `[Unreleased]`.

## Verification
`bun test test/cursor-exec-handlers.test.ts` in `packages/ai` — 40 pass, 0 fail. The standalone repro now prints `RESULT: no throw (history built)` where it previously threw. Fixes #7516