### PR TITLE
fix(ai): stop forwarding auto service tier to codex

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-Codex (ChatGPT OAuth) requests failing with `Unsupported service_tier: auto` on default/legacy sessions. `shouldSendServiceTier` no longer forwards `auto` on the wire — it is OpenAI's implicit default, so omitting `service_tier` is equivalent, and the Codex endpoint rejects an explicit `auto`. Explicit `default`/`flex`/`scale`/`priority` are unaffected ([#7517](https://github.com/can1357/oh-my-pi/issues/7517)).
+
 ## [17.2.6] - 2026-08-03
 
 ### Added

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -214,16 +214,19 @@ export function resolveModelServiceTier(
 
 /**
  * True when the tier should be sent on the wire as the provider's service-tier
- * request field. OpenAI / OpenAI-Codex accept every {@link ServiceTier};
- * Google (Gemini API + Vertex) and OpenRouter accept `flex`/`priority`;
- * Fireworks Serverless realizes only its Priority serving path. Anthropic is
- * absent because it realizes `priority` via `speed: "fast"`.
+ * request field. `auto` is never forwarded — it is OpenAI's implicit default, so
+ * omitting `service_tier` is identical to requesting `auto`, and the Codex
+ * (ChatGPT OAuth) endpoint rejects an explicit `auto` outright. OpenAI /
+ * OpenAI-Codex accept every other {@link ServiceTier}; Google (Gemini API +
+ * Vertex) and OpenRouter accept `flex`/`priority`; Fireworks Serverless
+ * realizes only its Priority serving path. Anthropic is absent because it
+ * realizes `priority` via `speed: "fast"`.
  */
 export function shouldSendServiceTier(
 	serviceTier: ServiceTier | null | undefined,
 	target: Provider | ServiceTierModel | undefined,
 ): boolean {
-	if (!serviceTier) return false;
+	if (!serviceTier || serviceTier === "auto") return false;
 	const provider = typeof target === "string" ? target : target?.provider;
 	if (provider === "openai" || provider === "openai-codex") return true;
 	if (provider === "openrouter") {

--- a/packages/ai/test/service-tier-premium-requests.test.ts
+++ b/packages/ai/test/service-tier-premium-requests.test.ts
@@ -78,14 +78,17 @@ describe("resolveModelServiceTier", () => {
 });
 
 describe("shouldSendServiceTier", () => {
-	it("sends every tier on the OpenAI family and supported tiers elsewhere", () => {
+	it("sends every explicit tier on the OpenAI family, omits auto, supported tiers elsewhere", () => {
 		for (const p of ["openai", "openai-codex"] as const) {
 			expect(shouldSendServiceTier("flex", p)).toBe(true);
 			expect(shouldSendServiceTier("scale", p)).toBe(true);
 			expect(shouldSendServiceTier("priority", p)).toBe(true);
 			expect(shouldSendServiceTier("default", p)).toBe(true);
-			expect(shouldSendServiceTier("auto", p)).toBe(true);
+			// `auto` is OpenAI's implicit default and the Codex endpoint rejects it — never sent.
+			expect(shouldSendServiceTier("auto", p)).toBe(false);
 		}
+		expect(shouldSendServiceTier("auto", codex)).toBe(false);
+		expect(shouldSendServiceTier("auto", customOpenAI)).toBe(false);
 		expect(shouldSendServiceTier("flex", "openrouter")).toBe(true);
 		expect(shouldSendServiceTier("default", "openrouter")).toBe(false);
 		expect(shouldSendServiceTier("priority", customCodex)).toBe(true);


### PR DESCRIPTION
## Repro
Since 17.2.5, every `openai-codex` (ChatGPT Plus/Pro OAuth) request fails immediately with `Codex error event: Unsupported service_tier: auto (code=invalid_request_error)` at default settings (0 tokens per turn). Driving the real code path for an `openai-codex` model confirms it: `coerceServiceTierByFamily("auto")` → `{openai:"auto"}` (legacy sessions persisted the bare `auto` scalar), `resolveModelServiceTier` → `auto`, `applyOpenAIServiceTier` → `{"service_tier":"auto"}` on the Codex request, which that endpoint rejects.

## Cause
PR #7376 (`9d69db481`) changed `shouldSendServiceTier` (`packages/ai/src/types.ts`) to `return true` for `provider === "openai" || provider === "openai-codex"` and dropped the `flex`/`scale`/`priority` guard in `applyOpenAIServiceTier` (`packages/ai/src/providers/openai-shared.ts`), so *every* tier — including `auto` and `default` — is now emitted. Pre-17.2.5 only `flex`/`scale`/`priority` reached the wire, so `auto` was never sent. The OpenAI platform API tolerates `auto`; the Codex (ChatGPT OAuth) endpoint rejects it.

## Fix
- `shouldSendServiceTier` now returns `false` for `auto` up front (alongside the unset-tier guard). `auto` is OpenAI's implicit default, so omitting `service_tier` is semantically identical where accepted and required where the endpoint rejects an explicit `auto`. This covers every dispatch path (`applyOpenAIServiceTier` is gated by it), including Codex Responses.
- Explicit `default`/`flex`/`scale`/`priority` remain forwarded unchanged (the PR's intended platform-API override).
- Updated `shouldSendServiceTier` doc comment and `packages/ai/test/service-tier-premium-requests.test.ts` to assert `auto` is omitted for `openai`/`openai-codex` and OpenAI-family model targets.
- Changelog entry under `packages/ai` `[Unreleased]`.

## Verification
`bun test ./test/service-tier-premium-requests.test.ts ./test/anthropic-fast-mode.test.ts ./test/github-copilot-openai-base-url.test.ts ./test/openai-codex-responses-lite.test.ts` (packages/ai) → all pass (74 tests). Repro harness that previously produced `{"service_tier":"auto"}` now yields `{}` for the Codex model. Fixes #7517