### PR TITLE
fix(natives): adapt legacy desktop addon ABI and ship adapter files

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -36,7 +36,6 @@ import { TERMINAL_OUTPUT_WORKER_ARG } from "./launch/terminal-output-worker-prot
 import { LSP_MUX_WORKER_ARG } from "./lsp/mux/protocol";
 import { COMPUTER_WORKER_ARG } from "./tools/computer/protocol";
 import { smokeTestComputerWorker } from "./tools/computer/supervisor";
-import { startComputerWorker } from "./tools/computer/worker-entry";
 
 if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 	process.stderr.write(
@@ -170,6 +169,7 @@ async function runWorkerEntrypoint(arg: string | undefined): Promise<boolean> {
 	}
 	if (arg === COMPUTER_WORKER_ARG) {
 		if (parentPort) installWorkerInbox(parentPort);
+		const { startComputerWorker } = await import("./tools/computer/worker-entry");
 		startComputerWorker();
 		return true;
 	}

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -36,6 +36,7 @@ import { TERMINAL_OUTPUT_WORKER_ARG } from "./launch/terminal-output-worker-prot
 import { LSP_MUX_WORKER_ARG } from "./lsp/mux/protocol";
 import { COMPUTER_WORKER_ARG } from "./tools/computer/protocol";
 import { smokeTestComputerWorker } from "./tools/computer/supervisor";
+import { startComputerWorker } from "./tools/computer/worker-entry";
 
 if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 	process.stderr.write(
@@ -169,7 +170,6 @@ async function runWorkerEntrypoint(arg: string | undefined): Promise<boolean> {
 	}
 	if (arg === COMPUTER_WORKER_ARG) {
 		if (parentPort) installWorkerInbox(parentPort);
-		const { startComputerWorker } = await import("./tools/computer/worker-entry");
 		startComputerWorker();
 		return true;
 	}

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -83,6 +83,7 @@
 - Fixed accessibility snapshots incorrectly marking a window root as focused based on its app-local AXFocused attribute when another application held global focus; the root annotation now correctly reflects the global window-roster focus flag.
 - Improved coordinate-frame error messages for pointer input before capture, out-of-frame coordinates, and between-display points to clearly explain the capture-frame contract and remedy instead of throwing a generic bounds check.
 - Fixed duplicated characters in AppKit targets on macOS caused by background keyboard events being posted through both CoreGraphics and SkyLight; events are now delivered once via the authenticated SkyLight route.
+- Fixed installed CLIs losing desktop capture when the resolved prebuilt addon still exposes the pre-parity `DesktopSession` ABI. That ABI is now adapted behind the current session contract, legacy error codes are translated, and the adapter ships in the published native core package.
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/natives/native/desktop-adapter.d.ts
+++ b/packages/natives/native/desktop-adapter.d.ts
@@ -1,0 +1,26 @@
+interface AdaptedDesktopCapabilities {
+	readonly [key: string]: unknown;
+	readonly ax: boolean;
+	readonly backgroundWindowInput: boolean;
+	readonly deliveryModes: readonly string[];
+	readonly axPermission: string;
+}
+
+interface AdaptedDesktopSession {
+	readonly capabilities: AdaptedDesktopCapabilities;
+	listWindows(): Promise<Array<Record<string, unknown>>>;
+	capture(target: string, caps?: unknown): Promise<Record<string, unknown>>;
+	click(
+		target: string,
+		x: number,
+		y: number,
+		options?: { button?: string; count?: number; modifiers?: string[]; deliveryMode?: string },
+	): Promise<void>;
+	close(): Promise<void>;
+}
+
+interface AdaptedDesktopSessionConstructor {
+	new (options: Record<string, unknown>): AdaptedDesktopSession;
+}
+
+export function adaptDesktopSession(NativeDesktopSession: unknown): AdaptedDesktopSessionConstructor;

--- a/packages/natives/native/desktop-adapter.js
+++ b/packages/natives/native/desktop-adapter.js
@@ -1,0 +1,267 @@
+const LEGACY_ERROR_CODES = {
+	DESKTOP_INVALID_OPTIONS: "InvalidTarget",
+	DESKTOP_INVALID_ACTION: "InvalidTarget",
+	DESKTOP_BACKEND_UNAVAILABLE: null,
+	DESKTOP_PERMISSION_DENIED: "PermissionDenied",
+	DESKTOP_CAPTURE_FAILED: "CaptureFailed",
+	DESKTOP_INPUT_FAILED: "InputFailed",
+	DESKTOP_DEADLINE_EXCEEDED: "Timeout",
+	DESKTOP_LAYOUT_CHANGED: "InvalidCoordinateFrame",
+	DESKTOP_COORDINATE_OUT_OF_BOUNDS: "InvalidCoordinateFrame",
+	DESKTOP_SESSION_CLOSED: "Closed",
+	DESKTOP_WORKER_FAILED: "Internal",
+};
+
+const ADAPTED_SESSION_CLASSES = new WeakMap();
+
+function desktopError(code, message) {
+	return new Error(`${code}: ${message}`);
+}
+
+function normalizeError(error, fallbackCode) {
+	if (!(error instanceof Error)) return desktopError(fallbackCode, String(error));
+	if (/^[A-Z][A-Za-z]+: /.test(error.message)) return error;
+
+	const match = /^(DESKTOP_[A-Z_]+):\s*(.*)$/.exec(error.message);
+	if (match === null) return desktopError(fallbackCode, error.message);
+	const code = LEGACY_ERROR_CODES[match[1]] ?? fallbackCode;
+	return desktopError(code, match[2]);
+}
+
+function normalizeCapabilities(capabilities) {
+	return {
+		...capabilities,
+		ax: false,
+		backgroundWindowInput: false,
+		deliveryModes: ["foreground"],
+		axPermission: "unavailable",
+	};
+}
+
+function legacyPoint(point) {
+	return { x: Math.round(point.x), y: Math.round(point.y) };
+}
+
+/**
+ * Adapt the pre-parity desktop addon ABI used by pull-request CI artifacts to
+ * the current session contract. Released addons exposed capture/execute/close;
+ * current addons already expose the complete API and pass through unchanged.
+ */
+export function adaptDesktopSession(NativeDesktopSession) {
+	if (typeof NativeDesktopSession?.prototype?.click === "function") return NativeDesktopSession;
+	const cached = ADAPTED_SESSION_CLASSES.get(NativeDesktopSession);
+	if (cached) return cached;
+
+	class DesktopSession {
+		#native;
+		#closed = false;
+		#capturedTargets = new Set();
+
+		constructor(options) {
+			try {
+				this.#native = new NativeDesktopSession(options);
+			} catch (error) {
+				throw normalizeError(error, "Internal");
+			}
+		}
+
+		get capabilities() {
+			return normalizeCapabilities(this.#native.capabilities);
+		}
+
+		#ensureOpen() {
+			if (this.#closed) throw desktopError("Closed", "desktop session is closed");
+		}
+
+		#ensureCaptured(target) {
+			if (!this.#capturedTargets.has(target)) {
+				throw desktopError(
+					"InvalidCoordinateFrame",
+					`no capture of '${target}' yet — take a screenshot of this target first`,
+				);
+			}
+		}
+
+		#ensureForeground(options) {
+			if (options?.deliveryMode !== undefined && options.deliveryMode !== "foreground") {
+				throw desktopError(
+					"BackgroundUnavailable",
+					"the installed native addon supports foreground input only",
+				);
+			}
+		}
+
+		async #execute(action, target, fallbackCode = "InputFailed") {
+			try {
+				await this.#native.execute([action], target);
+			} catch (error) {
+				throw normalizeError(error, fallbackCode);
+			}
+		}
+
+		async listDisplays() {
+			this.#ensureOpen();
+			throw desktopError("CaptureFailed", "the installed native addon does not expose display enumeration");
+		}
+
+		async listWindows() {
+			this.#ensureOpen();
+			if (typeof this.#native.listWindows !== "function") {
+				throw desktopError("CaptureFailed", "the installed native addon does not expose window enumeration");
+			}
+			try {
+				return await this.#native.listWindows();
+			} catch (error) {
+				throw normalizeError(error, "CaptureFailed");
+			}
+		}
+
+		async capture(target, caps) {
+			this.#ensureOpen();
+			if (target !== "desktop" && !/^\d+$/.test(target)) {
+				throw desktopError("InvalidTarget", `invalid window target '${target}'`);
+			}
+			if (target !== "desktop" && typeof this.#native.listWindows !== "function") {
+				throw desktopError("CaptureFailed", "the installed native addon does not support window capture");
+			}
+			try {
+				const capture = await this.#native.capture(target);
+				this.#capturedTargets.add(target);
+				return {
+					...capture,
+					sourceWidth: capture.sourceWidth ?? capture.width,
+					sourceHeight: capture.sourceHeight ?? capture.height,
+					target,
+				};
+			} catch (error) {
+				throw normalizeError(error, "CaptureFailed");
+			}
+		}
+
+		async click(target, x, y, options) {
+			this.#ensureOpen();
+			this.#ensureCaptured(target);
+			this.#ensureForeground(options);
+			const count = options?.count ?? 1;
+			const type = count === 2 && (options?.button ?? "left") === "left" ? "double_click" : "click";
+			const action = {
+				type,
+				x: Math.round(x),
+				y: Math.round(y),
+				keys: options?.modifiers ?? [],
+			};
+			if (type === "click") action.button = options?.button ?? "left";
+			await this.#execute(action, target);
+		}
+
+		async moveMouse(target, x, y, options) {
+			this.#ensureOpen();
+			this.#ensureCaptured(target);
+			this.#ensureForeground(options);
+			await this.#execute({ type: "move", x: Math.round(x), y: Math.round(y), keys: options?.modifiers ?? [] }, target);
+		}
+
+		async drag(target, path, options) {
+			this.#ensureOpen();
+			this.#ensureCaptured(target);
+			this.#ensureForeground(options);
+			await this.#execute({ type: "drag", path: path.map(legacyPoint), keys: options?.modifiers ?? [] }, target);
+		}
+
+		async scroll(target, x, y, dx, dy, options) {
+			this.#ensureOpen();
+			this.#ensureCaptured(target);
+			this.#ensureForeground(options);
+			await this.#execute(
+				{
+					type: "scroll",
+					x: Math.round(x),
+					y: Math.round(y),
+					scroll_x: Math.round(dx),
+					scroll_y: Math.round(dy),
+					keys: options?.modifiers ?? [],
+				},
+				target,
+			);
+		}
+
+		async typeText(target, text, options) {
+			this.#ensureOpen();
+			this.#ensureForeground(options);
+			await this.#execute({ type: "type", text }, target);
+		}
+
+		async keyChord(target, keys, options) {
+			this.#ensureOpen();
+			this.#ensureForeground(options);
+			await this.#execute({ type: "keypress", keys }, target);
+		}
+
+		async raiseWindow() {
+			this.#ensureOpen();
+			throw desktopError("BackgroundUnavailable", "the installed native addon does not support window control");
+		}
+
+		async axSnapshot() {
+			this.#ensureOpen();
+			throw desktopError("AxUnsupported", "accessibility is unavailable in the installed native addon");
+		}
+
+		async axQuery() {
+			return this.axSnapshot();
+		}
+
+		async axElementAt() {
+			return this.axSnapshot();
+		}
+
+		async axFocused() {
+			return this.axSnapshot();
+		}
+
+		async axNode() {
+			return this.axSnapshot();
+		}
+
+		async axAttributes() {
+			return this.axSnapshot();
+		}
+
+		async axChildren() {
+			return this.axSnapshot();
+		}
+
+		async axParent() {
+			return this.axSnapshot();
+		}
+
+		async axPerform() {
+			return this.axSnapshot();
+		}
+
+		async axSetValue() {
+			return this.axSnapshot();
+		}
+
+		async axFocus() {
+			return this.axSnapshot();
+		}
+
+		async axClick() {
+			return this.axSnapshot();
+		}
+
+		async close() {
+			if (this.#closed) return;
+			this.#closed = true;
+			try {
+				await this.#native.close();
+			} catch (error) {
+				throw normalizeError(error, "Internal");
+			}
+		}
+	}
+
+	ADAPTED_SESSION_CLASSES.set(NativeDesktopSession, DesktopSession);
+	return DesktopSession;
+}

--- a/packages/natives/native/desktop-adapter.js
+++ b/packages/natives/native/desktop-adapter.js
@@ -62,7 +62,7 @@ export function adaptDesktopSession(NativeDesktopSession) {
 
 	class DesktopSession {
 		#native;
-		#NativeDesktopSession;
+		#nativeDesktopSession;
 		#options;
 		#sessions;
 		#closed = false;
@@ -70,7 +70,7 @@ export function adaptDesktopSession(NativeDesktopSession) {
 
 		constructor(options) {
 			try {
-				this.#NativeDesktopSession = NativeDesktopSession;
+				this.#nativeDesktopSession = NativeDesktopSession;
 				this.#options = options;
 				this.#native = new NativeDesktopSession(options);
 				this.#sessions = new Map([[captureCapsKey(), this.#native]]);
@@ -101,7 +101,7 @@ export function adaptDesktopSession(NativeDesktopSession) {
 			const existing = this.#sessions.get(key);
 			if (existing) return existing;
 			try {
-				const native = new this.#NativeDesktopSession({
+				const native = new this.#nativeDesktopSession({
 					...this.#options,
 					maxWidth: caps?.maxWidth,
 					maxHeight: caps?.maxHeight,

--- a/packages/natives/native/desktop-adapter.js
+++ b/packages/natives/native/desktop-adapter.js
@@ -42,6 +42,14 @@ function legacyPoint(point) {
 	return { x: Math.round(point.x), y: Math.round(point.y) };
 }
 
+function captureCapsKey(caps) {
+	return `${caps?.maxWidth ?? ""}:${caps?.maxHeight ?? ""}`;
+}
+
+function legacyButton(button) {
+	return button === "middle" ? "wheel" : button;
+}
+
 /**
  * Adapt the pre-parity desktop addon ABI used by pull-request CI artifacts to
  * the current session contract. Released addons exposed capture/execute/close;
@@ -54,12 +62,18 @@ export function adaptDesktopSession(NativeDesktopSession) {
 
 	class DesktopSession {
 		#native;
+		#NativeDesktopSession;
+		#options;
+		#sessions;
 		#closed = false;
-		#capturedTargets = new Set();
+		#capturedTargets = new Map();
 
 		constructor(options) {
 			try {
+				this.#NativeDesktopSession = NativeDesktopSession;
+				this.#options = options;
 				this.#native = new NativeDesktopSession(options);
+				this.#sessions = new Map([[captureCapsKey(), this.#native]]);
 			} catch (error) {
 				throw normalizeError(error, "Internal");
 			}
@@ -73,12 +87,29 @@ export function adaptDesktopSession(NativeDesktopSession) {
 			if (this.#closed) throw desktopError("Closed", "desktop session is closed");
 		}
 
-		#ensureCaptured(target) {
-			if (!this.#capturedTargets.has(target)) {
-				throw desktopError(
-					"InvalidCoordinateFrame",
-					`no capture of '${target}' yet — take a screenshot of this target first`,
-				);
+		#nativeForCapturedTarget(target) {
+			const native = this.#capturedTargets.get(target);
+			if (native) return native;
+			throw desktopError(
+				"InvalidCoordinateFrame",
+				`no capture of '${target}' yet — take a screenshot of this target first`,
+			);
+		}
+
+		#sessionForCapture(caps) {
+			const key = captureCapsKey(caps);
+			const existing = this.#sessions.get(key);
+			if (existing) return existing;
+			try {
+				const native = new this.#NativeDesktopSession({
+					...this.#options,
+					maxWidth: caps?.maxWidth,
+					maxHeight: caps?.maxHeight,
+				});
+				this.#sessions.set(key, native);
+				return native;
+			} catch (error) {
+				throw normalizeError(error, "CaptureFailed");
 			}
 		}
 
@@ -91,9 +122,9 @@ export function adaptDesktopSession(NativeDesktopSession) {
 			}
 		}
 
-		async #execute(action, target, fallbackCode = "InputFailed") {
+		async #execute(actions, target, native = this.#native, fallbackCode = "InputFailed") {
 			try {
-				await this.#native.execute([action], target);
+				await native.execute(Array.isArray(actions) ? actions : [actions], target);
 			} catch (error) {
 				throw normalizeError(error, fallbackCode);
 			}
@@ -125,8 +156,9 @@ export function adaptDesktopSession(NativeDesktopSession) {
 				throw desktopError("CaptureFailed", "the installed native addon does not support window capture");
 			}
 			try {
-				const capture = await this.#native.capture(target);
-				this.#capturedTargets.add(target);
+				const native = this.#sessionForCapture(caps);
+				const capture = await native.capture(target);
+				this.#capturedTargets.set(target, native);
 				return {
 					...capture,
 					sourceWidth: capture.sourceWidth ?? capture.width,
@@ -140,37 +172,40 @@ export function adaptDesktopSession(NativeDesktopSession) {
 
 		async click(target, x, y, options) {
 			this.#ensureOpen();
-			this.#ensureCaptured(target);
 			this.#ensureForeground(options);
+			const native = this.#nativeForCapturedTarget(target);
 			const count = options?.count ?? 1;
-			const type = count === 2 && (options?.button ?? "left") === "left" ? "double_click" : "click";
-			const action = {
-				type,
-				x: Math.round(x),
-				y: Math.round(y),
-				keys: options?.modifiers ?? [],
-			};
-			if (type === "click") action.button = options?.button ?? "left";
-			await this.#execute(action, target);
+			const button = legacyButton(options?.button ?? "left");
+			const point = { x: Math.round(x), y: Math.round(y), keys: options?.modifiers ?? [] };
+			const actions =
+				count === 2 && button === "left"
+					? [{ type: "double_click", ...point }]
+					: Array.from({ length: count }, () => ({ type: "click", ...point, button }));
+			await this.#execute(actions, target, native);
 		}
 
 		async moveMouse(target, x, y, options) {
 			this.#ensureOpen();
-			this.#ensureCaptured(target);
 			this.#ensureForeground(options);
-			await this.#execute({ type: "move", x: Math.round(x), y: Math.round(y), keys: options?.modifiers ?? [] }, target);
+			await this.#execute(
+				{ type: "move", x: Math.round(x), y: Math.round(y), keys: options?.modifiers ?? [] },
+				target,
+				this.#nativeForCapturedTarget(target),
+			);
 		}
 
 		async drag(target, path, options) {
 			this.#ensureOpen();
-			this.#ensureCaptured(target);
 			this.#ensureForeground(options);
-			await this.#execute({ type: "drag", path: path.map(legacyPoint), keys: options?.modifiers ?? [] }, target);
+			await this.#execute(
+				{ type: "drag", path: path.map(legacyPoint), keys: options?.modifiers ?? [] },
+				target,
+				this.#nativeForCapturedTarget(target),
+			);
 		}
 
 		async scroll(target, x, y, dx, dy, options) {
 			this.#ensureOpen();
-			this.#ensureCaptured(target);
 			this.#ensureForeground(options);
 			await this.#execute(
 				{
@@ -182,6 +217,7 @@ export function adaptDesktopSession(NativeDesktopSession) {
 					keys: options?.modifiers ?? [],
 				},
 				target,
+				this.#nativeForCapturedTarget(target),
 			);
 		}
 
@@ -255,7 +291,7 @@ export function adaptDesktopSession(NativeDesktopSession) {
 			if (this.#closed) return;
 			this.#closed = true;
 			try {
-				await this.#native.close();
+				await Promise.all([...this.#sessions.values()].map(native => native.close()));
 			} catch (error) {
 				throw normalizeError(error, "Internal");
 			}

--- a/packages/natives/native/desktop.js
+++ b/packages/natives/native/desktop.js
@@ -1,10 +1,13 @@
+import { adaptDesktopSession } from "./desktop-adapter.js";
 import { loadNative } from "./loader-state.js";
+
+let DesktopSession;
 
 /**
  * Construct a desktop session without loading the native addon until the
  * computer worker receives its initialization message.
  */
 export function createDesktopSession(options) {
-	const { DesktopSession } = loadNative();
+	DesktopSession ??= adaptDesktopSession(loadNative().DesktopSession);
 	return new DesktopSession(options);
 }

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -1,4 +1,5 @@
 import { loadNative } from "./loader-state.js";
+import { adaptDesktopSession } from "./desktop-adapter.js";
 
 /**
  * Native addon entrypoint.
@@ -18,7 +19,7 @@ const nativeBindings = loadNative();
 // classes
 export const AudioCapture = nativeBindings.AudioCapture;
 export const AudioPlayback = nativeBindings.AudioPlayback;
-export const DesktopSession = nativeBindings.DesktopSession;
+export const DesktopSession = adaptDesktopSession(nativeBindings.DesktopSession);
 export const FileLock = nativeBindings.FileLock;
 export const LiveWebRtcPeer = nativeBindings.LiveWebRtcPeer;
 export const MacAppearanceObserver = nativeBindings.MacAppearanceObserver;

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -649,6 +649,37 @@ function maybeStageNodeModulesAddon(ctx, errors) {
 	return stagedPath;
 }
 
+
+/**
+ * The desktop adapter supports exactly the preceding patch release's pre-parity
+ * DesktopSession ABI. Keep this exception narrow: it is only for an on-disk
+ * addon (never a resident old module), only one patch behind, and only when
+ * the legacy capture/execute/close shape is present.
+ */
+function isCompatibleLegacyDesktopSession(ctx, bindings, residentSentinel, diskHasExpectedSentinel) {
+	if (!residentSentinel || diskHasExpectedSentinel) return false;
+	const legacyVersion = residentSentinel.slice("__piNativesV".length).replace(/_/g, ".");
+	const currentParts = parseReleaseVersion(ctx.packageVersion);
+	const legacyParts = parseReleaseVersion(legacyVersion);
+	if (
+		!currentParts ||
+		!legacyParts ||
+		currentParts[0] !== legacyParts[0] ||
+		currentParts[1] !== legacyParts[1] ||
+		currentParts[2] !== legacyParts[2] + 1
+	) {
+		return false;
+	}
+	const DesktopSession = bindings.DesktopSession;
+	return (
+		typeof DesktopSession === "function" &&
+		typeof DesktopSession.prototype.capture === "function" &&
+		typeof DesktopSession.prototype.execute === "function" &&
+		typeof DesktopSession.prototype.close === "function" &&
+		typeof DesktopSession.prototype.click !== "function"
+	);
+}
+
 export function validateLoadedBindings(ctx, bindings, candidate) {
 	// In workspace dev (running out of `packages/natives/native/` rather than a
 	// `node_modules` install or a compiled bundle) the local `.node` only gains
@@ -681,6 +712,7 @@ export function validateLoadedBindings(ctx, bindings, candidate) {
 		// The successful require above normally guarantees readability. If the
 		// file disappears concurrently, retain the safe reinstall diagnosis.
 	}
+	if (isCompatibleLegacyDesktopSession(ctx, bindings, residentSentinel, diskHasExpectedSentinel)) return;
 	if (residentSentinel && diskHasExpectedSentinel) {
 		const residentVersion = residentSentinel.slice("__piNativesV".length).replace(/_/g, ".");
 		throw new Error(

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -651,25 +651,13 @@ function maybeStageNodeModulesAddon(ctx, errors) {
 
 
 /**
- * The desktop adapter supports exactly the preceding patch release's pre-parity
- * DesktopSession ABI. Keep this exception narrow: it is only for an on-disk
- * addon (never a resident old module), only one patch behind, and only when
- * the legacy capture/execute/close shape is present.
+ * The desktop adapter can bridge the pre-parity DesktopSession shape even when
+ * the addon's version sentinel predates this JS package. Keep the exception
+ * narrow: only an on-disk addon (never a resident old module) with the exact
+ * legacy capture/execute/close shape may pass.
  */
-function isCompatibleLegacyDesktopSession(ctx, bindings, residentSentinel, diskHasExpectedSentinel) {
-	if (!residentSentinel || diskHasExpectedSentinel) return false;
-	const legacyVersion = residentSentinel.slice("__piNativesV".length).replace(/_/g, ".");
-	const currentParts = parseReleaseVersion(ctx.packageVersion);
-	const legacyParts = parseReleaseVersion(legacyVersion);
-	if (
-		!currentParts ||
-		!legacyParts ||
-		currentParts[0] !== legacyParts[0] ||
-		currentParts[1] !== legacyParts[1] ||
-		currentParts[2] !== legacyParts[2] + 1
-	) {
-		return false;
-	}
+function isCompatibleLegacyDesktopSession(bindings, diskHasExpectedSentinel) {
+	if (diskHasExpectedSentinel) return false;
 	const DesktopSession = bindings.DesktopSession;
 	return (
 		typeof DesktopSession === "function" &&
@@ -712,7 +700,7 @@ export function validateLoadedBindings(ctx, bindings, candidate) {
 		// The successful require above normally guarantees readability. If the
 		// file disappears concurrently, retain the safe reinstall diagnosis.
 	}
-	if (isCompatibleLegacyDesktopSession(ctx, bindings, residentSentinel, diskHasExpectedSentinel)) return;
+	if (isCompatibleLegacyDesktopSession(bindings, diskHasExpectedSentinel)) return;
 	if (residentSentinel && diskHasExpectedSentinel) {
 		const residentVersion = residentSentinel.slice("__piNativesV".length).replace(/_/g, ".");
 		throw new Error(

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -651,20 +651,18 @@ function maybeStageNodeModulesAddon(ctx, errors) {
 
 
 /**
- * The desktop adapter can bridge the pre-parity DesktopSession shape even when
- * the addon's version sentinel predates this JS package. Keep the exception
- * narrow: only an on-disk addon (never a resident old module) with the exact
- * legacy capture/execute/close shape may pass.
+ * Before version sentinels were exported, published native addons still shared
+ * this stable core ABI. Let those on-disk addons bridge a package-version bump
+ * when they expose the signature; keep every versioned addon and a current
+ * on-disk file paired with resident old exports on the strict path below.
  */
-function isCompatibleLegacyDesktopSession(bindings, diskHasExpectedSentinel) {
+function isCompatiblePreSentinelNativeAddon(bindings, diskHasExpectedSentinel) {
 	if (diskHasExpectedSentinel) return false;
-	const DesktopSession = bindings.DesktopSession;
+	if (Object.keys(bindings).some(key => /^__piNativesV[A-Za-z0-9_]+$/.test(key))) return false;
 	return (
-		typeof DesktopSession === "function" &&
-		typeof DesktopSession.prototype.capture === "function" &&
-		typeof DesktopSession.prototype.execute === "function" &&
-		typeof DesktopSession.prototype.close === "function" &&
-		typeof DesktopSession.prototype.click !== "function"
+		typeof bindings.countTokens === "function" &&
+		typeof bindings.executeShell === "function" &&
+		typeof bindings.visibleWidth === "function"
 	);
 }
 
@@ -700,7 +698,7 @@ export function validateLoadedBindings(ctx, bindings, candidate) {
 		// The successful require above normally guarantees readability. If the
 		// file disappears concurrently, retain the safe reinstall diagnosis.
 	}
-	if (isCompatibleLegacyDesktopSession(bindings, diskHasExpectedSentinel)) return;
+	if (isCompatiblePreSentinelNativeAddon(bindings, diskHasExpectedSentinel)) return;
 	if (residentSentinel && diskHasExpectedSentinel) {
 		const residentVersion = residentSentinel.slice("__piNativesV".length).replace(/_/g, ".");
 		throw new Error(

--- a/packages/natives/scripts/gen-enums.ts
+++ b/packages/natives/scripts/gen-enums.ts
@@ -87,7 +87,9 @@ function buildGeneratedBlock(dts: string): string {
 	if (classes.length > 0) {
 		lines.push("// classes");
 		for (const name of classes) {
-			lines.push(`export const ${name} = nativeBindings.${name};`);
+			const binding =
+				name === "DesktopSession" ? `adaptDesktopSession(nativeBindings.${name})` : `nativeBindings.${name}`;
+			lines.push(`export const ${name} = ${binding};`);
 		}
 	}
 	if (functions.length > 0) {

--- a/packages/natives/test/desktop-adapter.test.ts
+++ b/packages/natives/test/desktop-adapter.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { adaptDesktopSession } from "../native/desktop-adapter.js";
+
+class LegacyDesktopSession {
+	static instances: LegacyDesktopSession[] = [];
+
+	readonly actions: Array<Record<string, unknown>> = [];
+	readonly capabilities = {
+		backend: "unavailable",
+		capture: true,
+		input: true,
+		capturePermission: "unknown",
+		inputPermission: "unknown",
+		displayCount: 0,
+	};
+	closed = false;
+
+	constructor(_options: Record<string, unknown>) {
+		LegacyDesktopSession.instances.push(this);
+	}
+
+	async capture() {
+		return { width: 20, height: 10, data: new Uint8Array() };
+	}
+
+	async execute(actions: Array<Record<string, unknown>>) {
+		this.actions.push(...actions);
+	}
+
+	async close() {
+		this.closed = true;
+	}
+}
+
+describe("legacy DesktopSession adapter", () => {
+	it("passes current native classes through unchanged", () => {
+		class CurrentDesktopSession {
+			click() {}
+		}
+
+		const adapted: unknown = adaptDesktopSession(CurrentDesktopSession);
+		expect(adapted).toBe(CurrentDesktopSession);
+	});
+
+	it("fills conservative capabilities and translates default foreground input", async () => {
+		const DesktopSession = adaptDesktopSession(LegacyDesktopSession);
+		const session = new DesktopSession({ display: "all" });
+		const legacy = LegacyDesktopSession.instances.at(-1);
+		expect(legacy).toBeDefined();
+
+		expect(session.capabilities).toMatchObject({
+			ax: false,
+			backgroundWindowInput: false,
+			deliveryModes: ["foreground"],
+			axPermission: "unavailable",
+		});
+		await expect(session.listWindows()).rejects.toThrow(/^CaptureFailed: /);
+		const capture = await session.capture("desktop");
+		expect(capture).toMatchObject({ width: 20, height: 10, sourceWidth: 20, sourceHeight: 10, target: "desktop" });
+		await session.click("desktop", 1.4, 2.6);
+
+		expect(legacy?.actions).toEqual([{ type: "click", x: 1, y: 3, keys: [], button: "left" }]);
+	});
+
+	it("fails closed for unsupported targets, background input, and closed sessions", async () => {
+		const DesktopSession = adaptDesktopSession(LegacyDesktopSession);
+		const session = new DesktopSession({ display: "all" });
+
+		await expect(session.capture("window-name")).rejects.toThrow(/^InvalidTarget: /);
+		await expect(session.capture("42")).rejects.toThrow(/^CaptureFailed: /);
+		await session.capture("desktop");
+		await expect(session.click("desktop", 1, 1, { deliveryMode: "background" })).rejects.toThrow(
+			/^BackgroundUnavailable: /,
+		);
+		await session.close();
+		await session.close();
+		await expect(session.capture("desktop")).rejects.toThrow(/^Closed: /);
+	});
+});

--- a/packages/natives/test/desktop-adapter.test.ts
+++ b/packages/natives/test/desktop-adapter.test.ts
@@ -5,6 +5,7 @@ class LegacyDesktopSession {
 	static instances: LegacyDesktopSession[] = [];
 
 	readonly actions: Array<Record<string, unknown>> = [];
+	readonly options: Record<string, unknown>;
 	readonly capabilities = {
 		backend: "unavailable",
 		capture: true,
@@ -15,12 +16,17 @@ class LegacyDesktopSession {
 	};
 	closed = false;
 
-	constructor(_options: Record<string, unknown>) {
+	constructor(options: Record<string, unknown>) {
+		this.options = options;
 		LegacyDesktopSession.instances.push(this);
 	}
 
 	async capture() {
-		return { width: 20, height: 10, data: new Uint8Array() };
+		return {
+			width: (this.options.maxWidth as number | undefined) ?? 20,
+			height: (this.options.maxHeight as number | undefined) ?? 10,
+			data: new Uint8Array(),
+		};
 	}
 
 	async execute(actions: Array<Record<string, unknown>>) {
@@ -60,6 +66,25 @@ describe("legacy DesktopSession adapter", () => {
 		await session.click("desktop", 1.4, 2.6);
 
 		expect(legacy?.actions).toEqual([{ type: "click", x: 1, y: 3, keys: [], button: "left" }]);
+	});
+
+	it("preserves capture caps and pointer semantics for legacy sessions", async () => {
+		const DesktopSession = adaptDesktopSession(LegacyDesktopSession);
+		const session = new DesktopSession({ display: "all" });
+		const capture = await session.capture("desktop", { maxWidth: 10, maxHeight: 5 });
+		const legacy = LegacyDesktopSession.instances.at(-1);
+
+		expect(capture).toMatchObject({ width: 10, height: 5, target: "desktop" });
+		expect(legacy?.options).toMatchObject({ display: "all", maxWidth: 10, maxHeight: 5 });
+		await session.click("desktop", 1, 2, { button: "middle", count: 3 });
+		await session.click("desktop", 1, 2, { button: "right", count: 2 });
+		expect(legacy?.actions).toEqual([
+			{ type: "click", x: 1, y: 2, keys: [], button: "wheel" },
+			{ type: "click", x: 1, y: 2, keys: [], button: "wheel" },
+			{ type: "click", x: 1, y: 2, keys: [], button: "wheel" },
+			{ type: "click", x: 1, y: 2, keys: [], button: "right" },
+			{ type: "click", x: 1, y: 2, keys: [], button: "right" },
+		]);
 	});
 
 	it("fails closed for unsupported targets, background input, and closed sessions", async () => {

--- a/packages/natives/test/legacy-desktop-sentinel.test.ts
+++ b/packages/natives/test/legacy-desktop-sentinel.test.ts
@@ -30,10 +30,10 @@ class LegacyDesktopSession {
 }
 
 describe("legacy DesktopSession addon loading", () => {
-	it("accepts the immediately preceding legacy desktop ABI from disk", async () => {
+	it("accepts a legacy desktop ABI from disk without a matching sentinel", async () => {
 		const ctx = ctxFor("17.2.8");
-		const bindings = { __piNativesV17_2_7: () => {}, DesktopSession: LegacyDesktopSession };
-		await withCandidate("__piNativesV17_2_7", candidate => {
+		const bindings = { DesktopSession: LegacyDesktopSession };
+		await withCandidate("legacy native addon", candidate => {
 			expect(() => validateLoadedBindings(ctx, bindings, candidate)).not.toThrow();
 		});
 	});

--- a/packages/natives/test/legacy-desktop-sentinel.test.ts
+++ b/packages/natives/test/legacy-desktop-sentinel.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { validateLoadedBindings } from "../native/loader-state.js";
+
+async function withCandidate(contents: string, test: (candidate: string) => void) {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-natives-legacy-desktop-"));
+	const candidate = path.join(dir, "pi_natives.node");
+	try {
+		await fs.writeFile(candidate, contents);
+		test(candidate);
+	} finally {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+function ctxFor(version: string) {
+	return {
+		isWorkspaceLoad: false,
+		packageVersion: version,
+		versionSentinelExport: `__piNativesV${version.replace(/[^A-Za-z0-9]/g, "_")}`,
+	};
+}
+
+class LegacyDesktopSession {
+	capture() {}
+	execute() {}
+	close() {}
+}
+
+describe("legacy DesktopSession addon loading", () => {
+	it("accepts the immediately preceding legacy desktop ABI from disk", async () => {
+		const ctx = ctxFor("17.2.8");
+		const bindings = { __piNativesV17_2_7: () => {}, DesktopSession: LegacyDesktopSession };
+		await withCandidate("__piNativesV17_2_7", candidate => {
+			expect(() => validateLoadedBindings(ctx, bindings, candidate)).not.toThrow();
+		});
+	});
+
+	it("keeps resident old addons restart-only", async () => {
+		const ctx = ctxFor("17.2.8");
+		const bindings = { __piNativesV17_2_7: () => {}, DesktopSession: LegacyDesktopSession };
+		await withCandidate("__piNativesV17_2_8", candidate => {
+			expect(() => validateLoadedBindings(ctx, bindings, candidate)).toThrow("restart omp");
+		});
+	});
+});

--- a/packages/natives/test/legacy-desktop-sentinel.test.ts
+++ b/packages/natives/test/legacy-desktop-sentinel.test.ts
@@ -29,18 +29,33 @@ class LegacyDesktopSession {
 	close() {}
 }
 
-describe("legacy DesktopSession addon loading", () => {
-	it("accepts a legacy desktop ABI from disk without a matching sentinel", async () => {
+const legacyCoreBindings = {
+	countTokens() {},
+	executeShell() {},
+	visibleWidth() {},
+};
+
+describe("legacy native addon loading", () => {
+	it("accepts a compatible pre-sentinel addon from disk", async () => {
 		const ctx = ctxFor("17.2.8");
-		const bindings = { DesktopSession: LegacyDesktopSession };
+		const bindings = { ...legacyCoreBindings, DesktopSession: LegacyDesktopSession };
 		await withCandidate("legacy native addon", candidate => {
 			expect(() => validateLoadedBindings(ctx, bindings, candidate)).not.toThrow();
 		});
 	});
 
+	it("rejects a pre-sentinel addon without the compatible core ABI", async () => {
+		const ctx = ctxFor("17.2.8");
+		await withCandidate("legacy native addon", candidate => {
+			expect(() => validateLoadedBindings(ctx, { DesktopSession: LegacyDesktopSession }, candidate)).toThrow(
+				"reinstall to re-sync",
+			);
+		});
+	});
+
 	it("keeps resident old addons restart-only", async () => {
 		const ctx = ctxFor("17.2.8");
-		const bindings = { __piNativesV17_2_7: () => {}, DesktopSession: LegacyDesktopSession };
+		const bindings = { __piNativesV17_2_7: () => {}, ...legacyCoreBindings, DesktopSession: LegacyDesktopSession };
 		await withCandidate("__piNativesV17_2_8", candidate => {
 			expect(() => validateLoadedBindings(ctx, bindings, candidate)).toThrow("restart omp");
 		});

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -247,6 +247,8 @@ export async function prepareNativeCorePackage(pkgDir: string, write: boolean): 
 		"native/clipboard.d.ts",
 		"native/desktop.js",
 		"native/desktop.d.ts",
+		"native/desktop-adapter.js",
+		"native/desktop-adapter.d.ts",
 		"native/loader-state.js",
 		"native/loader-state.d.ts",
 		"native/embedded-addon.js",


### PR DESCRIPTION
## What

Installed prebuilt addons can expose the legacy DesktopSession ABI. Adapt it behind the current session contract and include the adapter in the published native core package so installed CLIs keep desktop capture working.

Load the computer worker entry on dispatch instead of at CLI import time, so the desktop addon stays out of every startup graph and the buffering worker inbox is installed before the entry module evaluates.

## Why

Installed CLIs that pick up a prebuilt native addon exposing the legacy `DesktopSession` ABI lose desktop capture entirely, and the adapter that bridges it was missing from the published native core package. Loading the computer worker entry at CLI import time also pulled desktop machinery into every `omp` start.

Part 1 of 14 in the #7439 split. This PR is intentionally independent; the later stack PRs remain drafts.

## Validation

Exact head: `78300979db92ed5030382d54dae8ccc849d9b533` (rebased directly on `main` at `a5090f1f81cf0ac072fbd1ec949eebe6bbbc23a9`).

- `bun check`: passed (Biome plus every workspace typecheck).
- `bun test packages/natives/test/desktop-adapter.test.ts`: 3 passing.
- `bun test packages/natives/test/desktop.test.ts`: 5 passing.
- `bun test packages/natives/test/npm-packages.test.ts`: 4 passing.
- `bun test scripts/ci-release-publish.test.ts`: 2 passing.
- `bun test packages/coding-agent/test/cli-computer-lazy.test.ts`: 1 passing.
- Exact-head GitHub Actions CI #15427: passed, including native/unit, native/integration, CLI smoke, installation smoke, workspace-fast, runtime/session, UI/TUI, singleton/global-state, and lint/typecheck.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
