### PR TITLE
fix(discovery): honor disabled codex mcp servers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex `config.toml` discovery importing MCP servers with `enabled = false` ([#7538](https://github.com/can1357/oh-my-pi/issues/7538)).
+
 ## [17.2.6] - 2026-08-03
 
 ### Added

--- a/packages/coding-agent/src/discovery/codex.ts
+++ b/packages/coding-agent/src/discovery/codex.ts
@@ -87,23 +87,28 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 	]);
 
 	const items: MCPServer[] = [];
-	if (userConfig) {
-		const servers = extractMCPServersFromToml(userConfig, path.dirname(userConfigPath));
-		for (const [name, config] of Object.entries(servers)) {
-			items.push({
-				name,
-				...config,
-				_source: createSourceMeta(PROVIDER_ID, userConfigPath, "user"),
-			});
-		}
-	}
+	// Capability dedupe is first-wins, including suppressed items claiming their
+	// key. Load project entries first so a project `enabled = false` keeps a
+	// same-named user server disabled.
 	if (projectConfig) {
 		const servers = extractMCPServersFromToml(projectConfig, path.dirname(projectConfigPath));
-		for (const [name, config] of Object.entries(servers)) {
+		for (const name in servers) {
+			const config = servers[name];
 			items.push({
 				name,
 				...config,
 				_source: createSourceMeta(PROVIDER_ID, projectConfigPath, "project"),
+			});
+		}
+	}
+	if (userConfig) {
+		const servers = extractMCPServersFromToml(userConfig, path.dirname(userConfigPath));
+		for (const name in servers) {
+			const config = servers[name];
+			items.push({
+				name,
+				...config,
+				_source: createSourceMeta(PROVIDER_ID, userConfigPath, "user"),
 			});
 		}
 	}
@@ -153,7 +158,8 @@ function extractMCPServersFromToml(
 	const codexServers = toml.mcp_servers as Record<string, CodexMCPConfig>;
 	const result: Record<string, Partial<MCPServer>> = {};
 
-	for (const [name, config] of Object.entries(codexServers)) {
+	for (const name in codexServers) {
+		const config = codexServers[name];
 		// Root relative cwd/command against the Codex config directory. Codex
 		// spawns the process with the resolved cwd, so a relative command is
 		// resolved by the OS from there — pass "cwd" so e.g. cwd="server",

--- a/packages/coding-agent/src/discovery/codex.ts
+++ b/packages/coding-agent/src/discovery/codex.ts
@@ -125,6 +125,7 @@ async function loadTomlConfig(_ctx: LoadContext, path: string): Promise<Record<s
 
 /** Codex MCP server config format (from config.toml) */
 interface CodexMCPConfig {
+	enabled?: boolean;
 	command?: string;
 	args?: string[];
 	env?: Record<string, string>;
@@ -153,6 +154,8 @@ function extractMCPServersFromToml(
 	const result: Record<string, Partial<MCPServer>> = {};
 
 	for (const [name, config] of Object.entries(codexServers)) {
+		if (config.enabled === false) continue;
+
 		// Root relative cwd/command against the Codex config directory. Codex
 		// spawns the process with the resolved cwd, so a relative command is
 		// resolved by the OS from there — pass "cwd" so e.g. cwd="server",

--- a/packages/coding-agent/src/discovery/codex.ts
+++ b/packages/coding-agent/src/discovery/codex.ts
@@ -154,14 +154,18 @@ function extractMCPServersFromToml(
 	const result: Record<string, Partial<MCPServer>> = {};
 
 	for (const [name, config] of Object.entries(codexServers)) {
-		if (config.enabled === false) continue;
-
 		// Root relative cwd/command against the Codex config directory. Codex
 		// spawns the process with the resolved cwd, so a relative command is
 		// resolved by the OS from there — pass "cwd" so e.g. cwd="server",
 		// command="./bin/mcp" resolves to <configDir>/server/bin/mcp.
 		const rooted = resolvePluginStdioPaths({ command: config.command, cwd: config.cwd }, configDir, "cwd");
 		const server: Partial<MCPServer> = {
+			// Carry `enabled: false` through rather than dropping the entry: the
+			// central MCP loader (`loadAllMCPConfigs`) suppresses disabled servers
+			// so they still claim their dedupe key (keeping a same-named,
+			// lower-priority source disabled) and remain overridable via the user
+			// force-enable allowlist. Dropping here would defeat both.
+			...(config.enabled === false && { enabled: false }),
 			...(rooted.command !== undefined && { command: rooted.command }),
 			args: config.args,
 			url: config.url,

--- a/packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts
+++ b/packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts
@@ -48,7 +48,7 @@ async function loadCodexServers(): Promise<MCPServer[]> {
 	return result.items;
 }
 
-test("disabled Codex MCP servers are not discovered (#7538)", async () => {
+test("disabled Codex MCP servers survive discovery tagged enabled: false (#7538)", async () => {
 	const codexDir = path.join(tempHome, ".codex");
 	await fs.writeFile(
 		path.join(codexDir, "config.toml"),
@@ -65,8 +65,16 @@ test("disabled Codex MCP servers are not discovered (#7538)", async () => {
 	);
 
 	const servers = await loadCodexServers();
-	expect(servers.find(server => server.name === "computer-use")).toBeUndefined();
-	expect(servers.find(server => server.name === "context7")?.command).toBe("npx");
+	const cu = servers.find(server => server.name === "computer-use");
+	const context7 = servers.find(server => server.name === "context7");
+
+	// The disabled entry is NOT dropped: it stays so loadAllMCPConfigs' suppress
+	// path can claim its dedupe key (keeping a same-named, lower-priority source
+	// disabled) and honor the user force-enable allowlist. `enabled: true` is the
+	// default, so it is not persisted onto the enabled sibling.
+	expect(cu?.enabled).toBe(false);
+	expect(context7?.command).toBe("npx");
+	expect(context7?.enabled).toBeUndefined();
 });
 
 test("relative path-like command and cwd resolve against the Codex config directory (#5561)", async () => {

--- a/packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts
+++ b/packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression tests for #5561.
+ * Regression tests for Codex MCP config discovery (#5561, #7538).
  *
  * The Codex `config.toml` MCP importer in `packages/coding-agent/src/discovery/codex.ts`
  * used to copy only `command`/`args`/`url` into the returned `MCPServer`, dropping
@@ -47,6 +47,27 @@ async function loadCodexServers(): Promise<MCPServer[]> {
 	});
 	return result.items;
 }
+
+test("disabled Codex MCP servers are not discovered (#7538)", async () => {
+	const codexDir = path.join(tempHome, ".codex");
+	await fs.writeFile(
+		path.join(codexDir, "config.toml"),
+		[
+			"[mcp_servers.computer-use]",
+			'command = "./Codex Computer Use.app/Contents/MacOS/SkyComputerUseClient"',
+			"enabled = false",
+			"",
+			"[mcp_servers.context7]",
+			'command = "npx"',
+			"enabled = true",
+			"",
+		].join("\n"),
+	);
+
+	const servers = await loadCodexServers();
+	expect(servers.find(server => server.name === "computer-use")).toBeUndefined();
+	expect(servers.find(server => server.name === "context7")?.command).toBe("npx");
+});
 
 test("relative path-like command and cwd resolve against the Codex config directory (#5561)", async () => {
 	const codexDir = path.join(tempHome, ".codex");

--- a/packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts
+++ b/packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts
@@ -77,6 +77,30 @@ test("disabled Codex MCP servers survive discovery tagged enabled: false (#7538)
 	expect(context7?.enabled).toBeUndefined();
 });
 
+test("project Codex disable suppresses a same-named user server (#7538)", async () => {
+	const userCodexDir = path.join(tempHome, ".codex");
+	const projectCodexDir = path.join(tempCwd, ".codex");
+	await fs.mkdir(projectCodexDir, { recursive: true });
+	await Promise.all([
+		fs.writeFile(
+			path.join(userCodexDir, "config.toml"),
+			["[mcp_servers.shared]", 'command = "user-server"', ""].join("\n"),
+		),
+		fs.writeFile(
+			path.join(projectCodexDir, "config.toml"),
+			["[mcp_servers.shared]", 'command = "project-server"', "enabled = false", ""].join("\n"),
+		),
+	]);
+
+	const result = await loadCapability<MCPServer>(mcpCapability.id, {
+		cwd: tempCwd,
+		providers: ["codex"],
+		suppress: server => server.enabled === false,
+	});
+
+	expect(result.items.find(server => server.name === "shared")).toBeUndefined();
+});
+
 test("relative path-like command and cwd resolve against the Codex config directory (#5561)", async () => {
 	const codexDir = path.join(tempHome, ".codex");
 	await fs.writeFile(


### PR DESCRIPTION
## Repro
A Codex `config.toml` fixture with `[mcp_servers.computer-use]`, a path-like command, and `enabled = false` remained in MCP discovery. `bun test packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts` reproduced it by returning the disabled stdio server and failed with 2 passing / 1 failing.

## Cause
`CodexMCPConfig` in `packages/coding-agent/src/discovery/codex.ts` did not model `enabled`, and `extractMCPServersFromToml` converted every `mcp_servers.*` table unconditionally. The disabled Computer Use entry therefore reached `resolvePluginStdioPaths`, which correctly applied the existing config-directory rooting contract but should never have seen that entry.

## Fix
- Model Codex MCP enable state and skip entries explicitly set to `enabled = false`.
- Cover disabled exclusion while preserving discovery of an explicitly enabled sibling server.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts` passes: 3 tests, 0 failures, 9 assertions. The pre-publish `bun run fix` and `bun check` gate passed while pushing the branch.

Fixes #7538