### PR TITLE
fix(setup): verify musl binary starts before reporting install success

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The most capable agent surface that ships. Continuously tuned by real-world use 
 curl -fsSL https://omp.sh/install | sh
 ```
 
+> **Alpine / musl:** the prebuilt musl binary links `libstdc++`/`libgcc` dynamically, which stock Alpine does not ship. Install them first: `apk add libstdc++ libgcc`.
+
 **Homebrew**
 
 ```sh

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `install.sh` reporting success (exit 0) for a musl binary that cannot start: the installer now smoke-runs the downloaded binary and, on failure, prints the captured error plus the `apk add libstdc++ libgcc` remediation for musl targets and exits non-zero. Documented the Alpine/musl runtime requirement in the README ([#7545](https://github.com/can1357/oh-my-pi/issues/7545)).
+
 ## [17.2.6] - 2026-08-03
 
 ### Added

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -267,6 +267,28 @@ install_binary() {
     echo "Downloading ${BINARY}..."
     curl -fsSL --connect-timeout 10 --speed-limit 1024 --speed-time 30 "$BINARY_URL" -o "${INSTALL_DIR}/omp"
     chmod +x "${INSTALL_DIR}/omp"
+
+    # Verify the freshly installed binary can actually start before reporting
+    # success. Bun's musl-target binaries link libstdc++/libgcc dynamically,
+    # which stock Alpine/musl systems do not ship, so the download succeeds while
+    # the binary exits 127 with relocation errors. Never claim success for a
+    # binary that cannot run.
+    if ! SMOKE_OUTPUT="$("${INSTALL_DIR}/omp" --version 2>&1)"; then
+        echo ""
+        echo "✗ omp was downloaded to ${INSTALL_DIR}/omp but cannot start:"
+        echo "$SMOKE_OUTPUT" | sed 's/^/    /'
+        if [ "$PLATFORM" = "linux-musl" ]; then
+            echo ""
+            echo "The musl build links libstdc++/libgcc dynamically. Install them, then re-run 'omp':"
+            if command -v apk >/dev/null 2>&1; then
+                echo "    apk add libstdc++ libgcc"
+            else
+                echo "    (install the libstdc++ and libgcc runtime packages for your distro)"
+            fi
+        fi
+        exit 1
+    fi
+
     echo ""
     echo "✓ Installed omp to ${INSTALL_DIR}/omp"
 


### PR DESCRIPTION
## Repro
On stock Alpine/musl systems the prebuilt `omp-linux-musl-*` binary cannot start because Bun's musl-target binaries link `libstdc++.so.6`/`libgcc_s.so.1` dynamically and Alpine does not ship them. `scripts/install.sh` downloads the asset, `chmod`s it, prints `✓ Installed omp`, and exits 0 anyway — the user gets a success message and a binary that exits 127. Docker/Alpine wasn't available in the sandbox, so I modeled `install_binary`'s post-download tail against a binary that fails to start the same way:

```
✓ Installed omp to .../omp
installer_exit=0
--- but the binary itself: ---
Error loading shared library libstdc++.so.6: No such file or directory (needed by .../omp)
Error relocating .../omp: __cxa_guard_acquire: symbol not found
binary_exit=127
```

## Cause
`install_binary` (`scripts/install.sh:264-278`) had no post-install verification on any platform: after `curl` + `chmod` it unconditionally printed the success banner and returned 0. The musl runtime requirement (`apk add libstdc++ libgcc`) is already enforced in CI (`.github/workflows/ci.yml:553-563`) but never reached end users via the installer or docs.

## Fix
- `scripts/install.sh`: after `chmod`, smoke-run `omp --version`; capture combined output. On failure, print the captured error, and for `linux-musl` targets append the `apk add libstdc++ libgcc` remediation (with a distro-agnostic fallback when `apk` is absent), then `exit 1` — success is never printed for a binary that cannot start. The binary is left in place so musl users only need `apk add …` and re-run.
- `README.md`: added an Alpine/musl note in the install section documenting the `libstdc++`/`libgcc` requirement.
- `packages/coding-agent/CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

## Verification
`sh -n scripts/install.sh` passes. Exercised both paths locally: a stub binary that exits 127 triggers the failure branch (prints the error + musl remediation, would exit 1, no success banner), and a working stub takes the success path (prints `✓ Installed omp`, exit 0). Fixes #7545