### PR TITLE
fix(install): ensure musl runtime deps before reporting success

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The most capable agent surface that ships. Continuously tuned by real-world use 
 curl -fsSL https://omp.sh/install | sh
 ```
 
+On Alpine and other musl systems the binary needs `libstdc++` and `libgcc`; the installer adds them via `apk` automatically (or run `apk add libstdc++ libgcc` yourself).
+
 **Homebrew**
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The most capable agent surface that ships. Continuously tuned by real-world use 
 curl -fsSL https://omp.sh/install | sh
 ```
 
-On Alpine and other musl systems the binary needs `libstdc++` and `libgcc`; the installer adds them via `apk` automatically (or run `apk add libstdc++ libgcc` yourself).
+On Alpine and other musl systems the binary needs `libstdc++` and `libgcc`; the installer adds them automatically on apk-based systems (Alpine), otherwise install them with your package manager (e.g. `xbps-install libstdc++ libgcc` on Void).
 
 **Homebrew**
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the binary installer reporting success on musl Linux (Alpine, Void) when the downloaded binary cannot start because `libstdc++`/`libgcc` are missing; it now smoke-runs the binary, installs the runtime libraries via `apk` when possible, and otherwise fails with the exact manual command instead of leaving a broken install ([#7545](https://github.com/can1357/oh-my-pi/issues/7545)).
+
 ## [17.2.6] - 2026-08-03
 
 ### Added

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -243,7 +243,9 @@ ensure_musl_runtime() {
         echo "omp still fails to start after installing libstdc++ and libgcc."
         exit 1
     fi
-    echo "Install libstdc++ and libgcc with your package manager (e.g. 'apk add libstdc++ libgcc'), then run 'omp' again."
+    echo "Install libstdc++ and libgcc with your package manager, then run 'omp' again:"
+    echo "  Alpine: apk add libstdc++ libgcc"
+    echo "  Void:   xbps-install libstdc++ libgcc"
     exit 1
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -215,6 +215,38 @@ install_via_bun() {
     echo "Run 'omp' to get started!"
 }
 
+# Bun's musl binaries link libstdc++/libgcc dynamically, and stock musl
+# systems (Alpine, Void) don't ship them — the binary exits 127 with
+# relocation errors. Smoke the installed binary and install the runtime
+# libraries when missing; never report success for a binary that can't start.
+ensure_musl_runtime() {
+    if [ "$PLATFORM" != "linux-musl" ]; then
+        return 0
+    fi
+    if "${INSTALL_DIR}/omp" --version >/dev/null 2>&1; then
+        return 0
+    fi
+    echo "omp requires libstdc++ and libgcc on musl systems."
+    if command -v apk >/dev/null 2>&1; then
+        echo "Installing libstdc++ and libgcc via apk..."
+        if [ "$(id -u)" = "0" ]; then
+            apk add --no-cache libstdc++ libgcc
+        elif command -v sudo >/dev/null 2>&1; then
+            sudo apk add --no-cache libstdc++ libgcc
+        else
+            echo "Could not install automatically: rerun as root or run 'apk add libstdc++ libgcc'."
+            exit 1
+        fi
+        if "${INSTALL_DIR}/omp" --version >/dev/null 2>&1; then
+            return 0
+        fi
+        echo "omp still fails to start after installing libstdc++ and libgcc."
+        exit 1
+    fi
+    echo "Install libstdc++ and libgcc with your package manager (e.g. 'apk add libstdc++ libgcc'), then run 'omp' again."
+    exit 1
+}
+
 # Install binary from GitHub releases
 install_binary() {
     # Detect platform
@@ -267,6 +299,7 @@ install_binary() {
     echo "Downloading ${BINARY}..."
     curl -fsSL --connect-timeout 10 --speed-limit 1024 --speed-time 30 "$BINARY_URL" -o "${INSTALL_DIR}/omp"
     chmod +x "${INSTALL_DIR}/omp"
+    ensure_musl_runtime
     echo ""
     echo "✓ Installed omp to ${INSTALL_DIR}/omp"
 

--- a/scripts/musl-release.test.ts
+++ b/scripts/musl-release.test.ts
@@ -68,7 +68,7 @@ describe("musl release artifacts", () => {
 case "$*" in
   *api.github.com*) echo '{"tag_name":"v1.0.0"}' ;;
   *) while [ "$#" -gt 0 ]; do
-       [ "$1" = "-o" ] && { printf binary > "$2"; exit 0; }
+       [ "$1" = "-o" ] && { printf '#!/bin/sh\necho omp/1.0.0\n' > "$2"; exit 0; }
        shift
      done ;;
 esac
@@ -84,6 +84,82 @@ esac
 
 		expect(result.exitCode, result.stderr).toBe(0);
 		expect(result.stdout).toContain("Downloading omp-linux-musl-x64...");
-		expect(await Bun.file(path.join(installDir, "omp")).text()).toBe("binary");
+		expect(await Bun.file(path.join(installDir, "omp")).text()).toContain("echo omp/1.0.0");
+	});
+
+	test("installs libstdc++ and libgcc via apk when the musl binary fails to start", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-musl-install-"));
+		tempDirs.push(dir);
+		const binDir = path.join(dir, "bin");
+		const installDir = path.join(dir, "install");
+		await fs.mkdir(binDir);
+		await writeExecutable(binDir, "uname", '#!/bin/sh\n[ "$1" = "-s" ] && echo Linux || echo x86_64\n');
+		await writeExecutable(binDir, "ldd", "#!/bin/sh\necho 'musl libc (x86_64)'\n");
+		await writeExecutable(
+			binDir,
+			"curl",
+			`#!/bin/sh
+case "$*" in
+  *api.github.com*) echo '{"tag_name":"v1.0.0"}' ;;
+  *) while [ "$#" -gt 0 ]; do
+       [ "$1" = "-o" ] && { printf '#!/bin/sh\\nexit 127\\n' > "$2"; exit 0; }
+       shift
+     done ;;
+esac
+`,
+		);
+		// Non-root install shells out through sudo; exec the args directly.
+		await writeExecutable(binDir, "sudo", '#!/bin/sh\nexec "$@"\n');
+		// apk "installs the runtime libs" by swapping in a runnable binary.
+		await writeExecutable(
+			binDir,
+			"apk",
+			'#!/bin/sh\necho "$@" >> "$PI_INSTALL_DIR/apk.log"\nprintf \'#!/bin/sh\\necho omp/1.0.0\\n\' > "$PI_INSTALL_DIR/omp"\n',
+		);
+
+		const result = await run(["sh", "scripts/install.sh", "--binary"], {
+			...process.env,
+			PATH: `${binDir}:${process.env.PATH ?? ""}`,
+			HOME: dir,
+			PI_INSTALL_DIR: installDir,
+		});
+
+		expect(result.exitCode, result.stderr).toBe(0);
+		expect(result.stdout).toContain("Installing libstdc++ and libgcc via apk...");
+		expect(await Bun.file(path.join(installDir, "apk.log")).text()).toContain("add --no-cache libstdc++ libgcc");
+		expect(await Bun.file(path.join(installDir, "omp")).text()).toContain("echo omp/1.0.0");
+	});
+
+	test("fails with guidance when the musl binary cannot start and apk is unavailable", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-musl-install-"));
+		tempDirs.push(dir);
+		const binDir = path.join(dir, "bin");
+		const installDir = path.join(dir, "install");
+		await fs.mkdir(binDir);
+		await writeExecutable(binDir, "uname", '#!/bin/sh\n[ "$1" = "-s" ] && echo Linux || echo x86_64\n');
+		await writeExecutable(binDir, "ldd", "#!/bin/sh\necho 'musl libc (x86_64)'\n");
+		await writeExecutable(
+			binDir,
+			"curl",
+			`#!/bin/sh
+case "$*" in
+  *api.github.com*) echo '{"tag_name":"v1.0.0"}' ;;
+  *) while [ "$#" -gt 0 ]; do
+       [ "$1" = "-o" ] && { printf '#!/bin/sh\\nexit 127\\n' > "$2"; exit 0; }
+       shift
+     done ;;
+esac
+`,
+		);
+
+		const result = await run(["sh", "scripts/install.sh", "--binary"], {
+			...process.env,
+			PATH: `${binDir}:${process.env.PATH ?? ""}`,
+			HOME: dir,
+			PI_INSTALL_DIR: installDir,
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stdout).toContain("apk add libstdc++ libgcc");
 	});
 });

--- a/scripts/musl-release.test.ts
+++ b/scripts/musl-release.test.ts
@@ -34,6 +34,18 @@ async function writeExecutable(directory: string, name: string, content: string)
 	await fs.chmod(file, 0o755);
 }
 
+// install.sh invokes a handful of real coreutils alongside the stubbed
+// commands; symlink them into binDir so tests can run with an isolated PATH
+// that contains exactly the stubs + the tools the script needs — never the
+// host's apk/sudo, which would make the branch under test host-dependent.
+async function linkHostTools(binDir: string, names: string[]): Promise<void> {
+	for (const name of names) {
+		const real = Bun.which(name);
+		if (!real) throw new Error(`host tool required by install.sh not found on PATH: ${name}`);
+		await fs.symlink(real, path.join(binDir, name));
+	}
+}
+
 describe("musl release artifacts", () => {
 	test("builds the requested x64 and arm64 musl asset names with Bun's musl targets", async () => {
 		const result = await run([
@@ -59,6 +71,7 @@ describe("musl release artifacts", () => {
 		const binDir = path.join(dir, "bin");
 		const installDir = path.join(dir, "install");
 		await fs.mkdir(binDir);
+		await linkHostTools(binDir, ["sh", "mkdir", "chmod", "grep", "sed"]);
 		await writeExecutable(binDir, "uname", '#!/bin/sh\n[ "$1" = "-s" ] && echo Linux || echo x86_64\n');
 		await writeExecutable(binDir, "ldd", "#!/bin/sh\necho 'musl libc (x86_64)'\n");
 		await writeExecutable(
@@ -77,7 +90,7 @@ esac
 
 		const result = await run(["sh", "scripts/install.sh", "--binary"], {
 			...process.env,
-			PATH: `${binDir}:${process.env.PATH ?? ""}`,
+			PATH: binDir,
 			HOME: dir,
 			PI_INSTALL_DIR: installDir,
 		});
@@ -93,6 +106,7 @@ esac
 		const binDir = path.join(dir, "bin");
 		const installDir = path.join(dir, "install");
 		await fs.mkdir(binDir);
+		await linkHostTools(binDir, ["sh", "mkdir", "chmod", "grep", "sed", "id"]);
 		await writeExecutable(binDir, "uname", '#!/bin/sh\n[ "$1" = "-s" ] && echo Linux || echo x86_64\n');
 		await writeExecutable(binDir, "ldd", "#!/bin/sh\necho 'musl libc (x86_64)'\n");
 		await writeExecutable(
@@ -119,7 +133,7 @@ esac
 
 		const result = await run(["sh", "scripts/install.sh", "--binary"], {
 			...process.env,
-			PATH: `${binDir}:${process.env.PATH ?? ""}`,
+			PATH: binDir,
 			HOME: dir,
 			PI_INSTALL_DIR: installDir,
 		});
@@ -136,6 +150,7 @@ esac
 		const binDir = path.join(dir, "bin");
 		const installDir = path.join(dir, "install");
 		await fs.mkdir(binDir);
+		await linkHostTools(binDir, ["sh", "mkdir", "chmod", "grep", "sed"]);
 		await writeExecutable(binDir, "uname", '#!/bin/sh\n[ "$1" = "-s" ] && echo Linux || echo x86_64\n');
 		await writeExecutable(binDir, "ldd", "#!/bin/sh\necho 'musl libc (x86_64)'\n");
 		await writeExecutable(
@@ -154,7 +169,7 @@ esac
 
 		const result = await run(["sh", "scripts/install.sh", "--binary"], {
 			...process.env,
-			PATH: `${binDir}:${process.env.PATH ?? ""}`,
+			PATH: binDir,
 			HOME: dir,
 			PI_INSTALL_DIR: installDir,
 		});


### PR DESCRIPTION
## What

After installing a `linux-musl` binary, `install.sh` now smoke-runs it. If it fails to start (missing `libstdc++`/`libgcc` — Bun's musl targets link both dynamically, and stock musl systems don't ship them), the installer installs the runtime libraries via `apk` (direct as root, via `sudo` otherwise) and re-smokes. If auto-install is impossible or the binary still fails, it exits non-zero with the exact manual command instead of printing `✓ Installed omp` over a binary that exits 127.

Also adds the Alpine/musl note to the README install section.

## Why

Closes #7545. The release CI already knows about the dynamic-link requirement (the musl smoke step does `apk add --no-cache libstdc++ libgcc` first), but nothing reached end users: on stock Alpine, `curl … install.sh | sh` succeeded and left a binary that fails with pages of relocation errors.

## Testing

- `bun test scripts/musl-release.test.ts` — 4/4 pass: existing musl-selection test (stub binary now runnable, since the installer smoke-runs it), new apk-remediation test (asserts `apk add --no-cache libstdc++ libgcc` and a working final binary), new no-apk test (asserts exit 1 with the manual command).
- End-to-end in `alpine:3.22` containers against the real v17.2.6 release:
  - as root: installer auto-installed `libstdc++`/`libgcc` via apk, `omp --version` → `omp/17.2.6`
  - as a non-root sudoer: same result through the `sudo apk add` branch
- Before the fix, the same container repro exits 127 with relocation errors (see issue).

---

- [x] `bun check` passes (`check:ts`; `check:rs` not run — no Rust changes)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)