### PR TITLE
feat(coding-agent): add startup changelog crawl

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an optional `crawl` startup changelog mode that plays complete release notes as a yellow cinematic crawl with twinkling terminal stars in every interactive terminal.
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1841,13 +1841,13 @@ export const SETTINGS_SCHEMA = {
 
 	"startup.changelogMode": {
 		type: "enum",
-		values: ["summary", "expanded", "hidden"] as const,
+		values: ["summary", "expanded", "crawl", "hidden"] as const,
 		default: "summary",
 		ui: {
 			tab: "interaction",
 			group: "Startup & Updates",
 			label: "Startup Changelog",
-			description: "Choose whether update notes start as a summary, full details, or stay hidden",
+			description: "Choose whether update notes start as a summary, full details, a cinematic crawl, or stay hidden",
 			options: [
 				{
 					value: "summary",
@@ -1858,6 +1858,11 @@ export const SETTINGS_SCHEMA = {
 					value: "expanded",
 					label: "Expanded",
 					description: "Show the recent release notes in full",
+				},
+				{
+					value: "crawl",
+					label: "Crawl",
+					description: "Play the full release notes as a yellow cinematic crawl",
 				},
 				{
 					value: "hidden",

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1354,7 +1354,10 @@ export class Settings {
 		const legacyCollapseChangelog = typeof raw.collapseChangelog === "boolean" ? raw.collapseChangelog : undefined;
 		const flatChangelogMode = raw["startup.changelogMode"];
 		const normalizedFlatChangelogMode =
-			flatChangelogMode === "summary" || flatChangelogMode === "expanded" || flatChangelogMode === "hidden"
+			flatChangelogMode === "summary" ||
+			flatChangelogMode === "expanded" ||
+			flatChangelogMode === "crawl" ||
+			flatChangelogMode === "hidden"
 				? flatChangelogMode
 				: undefined;
 		if (legacyCollapseChangelog !== undefined || normalizedFlatChangelogMode !== undefined) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -57,6 +57,7 @@ import type { ExtensionUIContext } from "./extensibility/extensions/types";
 import { scheduleMarketplaceAutoUpdate } from "./extensibility/plugins/marketplace-auto-update";
 import { registerDaemonProjectPresence } from "./launch/presence";
 import type { MCPManager } from "./mcp";
+import { runUpdateCrawl } from "./modes/components/update-crawl";
 import { InteractiveMode } from "./modes/interactive-mode";
 import type { PrintModeOptions } from "./modes/print-mode";
 import { claimRpcInput } from "./modes/rpc/rpc-input";
@@ -425,10 +426,14 @@ async function runInteractiveMode(
 	initialImages?: ImageContent[],
 	joinLink?: string,
 ): Promise<void> {
+	const updateCrawlMarkdown =
+		!settings.get("startup.quiet") && settings.get("startup.changelogMode") === "crawl"
+			? startupChangelog?.markdown
+			: undefined;
 	const mode = new InteractiveMode(
 		session,
 		version,
-		startupChangelog,
+		updateCrawlMarkdown ? undefined : startupChangelog,
 		setExtensionUIContext,
 		lspServers,
 		mcpManager,
@@ -456,7 +461,8 @@ async function runInteractiveMode(
 	const playStartupSplash = showStartupSplash && setupScenes.length === 0;
 
 	await mode.init({
-		suppressWelcomeIntro: resuming || setupScenes.length > 0 || playStartupSplash,
+		suppressWelcomeIntro:
+			resuming || setupScenes.length > 0 || playStartupSplash || updateCrawlMarkdown !== undefined,
 		clearInitialTerminalHistory: true,
 	});
 
@@ -466,6 +472,10 @@ async function runInteractiveMode(
 
 	if (setupWizard && setupScenes.length > 0) {
 		await setupWizard.runSetupWizard(mode, setupScenes);
+	}
+
+	if (updateCrawlMarkdown) {
+		await runUpdateCrawl(mode, updateCrawlMarkdown, version);
 	}
 
 	versionCheckPromise

--- a/packages/coding-agent/src/modes/components/update-crawl.ts
+++ b/packages/coding-agent/src/modes/components/update-crawl.ts
@@ -1,0 +1,338 @@
+import {
+	type Component,
+	matchesKey,
+	type OverlayFocusOwner,
+	type OverlayHandle,
+	type OverlayOptions,
+	replaceTabs,
+	TERMINAL,
+	visibleWidth,
+} from "@oh-my-pi/pi-tui";
+import { theme } from "../theme/theme";
+import { stripInlineMarkdown } from "./plan-toc";
+
+const UPDATE_CRAWL_TICK_MS = 48;
+
+const ROWS_PER_SECOND = 2.5;
+const MAX_CONTENT_WIDTH = 58;
+const CONTENT_WIDTH_RATIO = 0.52;
+const TOP_EDGE_ROW = 1;
+const TOP_FADE_ROWS = 5;
+const NEAR_YELLOW = [255, 216, 64] as const;
+const FAR_AMBER = [132, 78, 12] as const;
+type Rgb = readonly [red: number, green: number, blue: number];
+const STAR_BRIGHT: Rgb = [208, 220, 235];
+const STAR_MEDIUM: Rgb = [132, 148, 168];
+const STAR_DIM: Rgb = [72, 84, 102];
+const HINT_COLOR: Rgb = [104, 108, 116];
+const BLACK_BACKGROUND = "\x1b[40m";
+const DEFAULT_BACKGROUND = "\x1b[49m";
+
+interface CrawlRow {
+	readonly text: string;
+	readonly kind: "title" | "heading" | "body";
+}
+const BLANK_ROW = { text: "", kind: "body" } as const;
+const THREE_BLANK_ROWS = [BLANK_ROW, BLANK_ROW, BLANK_ROW];
+
+const TITLE_ART = [
+	" ###  #   #    #   # #   #    ####  #####",
+	"#   # #   #    ## ##  # #     #   #   #  ",
+	"#   # #####    # # #   #      ####    #  ",
+	"#   # #   #    #   #   #      #       #  ",
+	" ###  #   #    #   #   #      #     #####",
+] as const;
+
+/** Slice of the interactive mode used by the fullscreen update overlay. */
+export interface UpdateCrawlHost {
+	ui: {
+		showOverlay(component: Component, options?: OverlayOptions): OverlayHandle;
+		setFocus(component: Component): void;
+		requestRender(): void;
+		readonly terminal: {
+			readonly rows: number;
+		};
+	};
+}
+
+/** Optional animation clock overrides for deterministic hosts and tests. */
+export interface RunUpdateCrawlOptions {
+	readonly tickMs?: number;
+	readonly now?: () => number;
+}
+
+function clamp01(value: number): number {
+	return Math.max(0, Math.min(1, value));
+}
+
+function smoothstep(edge0: number, edge1: number, value: number): number {
+	const t = clamp01((value - edge0) / Math.max(Number.EPSILON, edge1 - edge0));
+	return t * t * (3 - 2 * t);
+}
+
+function crawlContentWidth(width: number): number {
+	return Math.max(1, Math.min(MAX_CONTENT_WIDTH, Math.floor(Math.max(1, width) * CONTENT_WIDTH_RATIO)));
+}
+
+function cleanTerminalText(value: string): string {
+	return replaceTabs(Bun.stripANSI(value)).replace(/[\u0000-\u0008\u000b-\u001f\u007f]/g, "");
+}
+
+function cleanInlineMarkdown(value: string): string {
+	return stripInlineMarkdown(cleanTerminalText(value)).replace(/\\([\\`*_[\]{}()#+\-.!])/g, "$1");
+}
+
+function wrapRow(text: string, width: number, kind: CrawlRow["kind"], preserveWhitespace = false): CrawlRow[] {
+	if (!text) return [{ text: "", kind }];
+	return Bun.wrapAnsi(text, width, { hard: true, trim: false, wordWrap: true })
+		.split("\n")
+		.map(line => ({ text: preserveWhitespace ? line : line.trim(), kind }));
+}
+
+const ROMAN_PLACES = [
+	["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX"],
+	["", "X", "XX", "XXX", "XL", "L", "LX", "LXX", "LXXX", "XC"],
+	["", "C", "CC", "CCC", "CD", "D", "DC", "DCC", "DCCC", "CM"],
+] as const;
+
+function romanizeInteger(value: number): string {
+	if (!Number.isSafeInteger(value) || value < 0) return String(value);
+	if (value === 0) return "N";
+	return (
+		"M".repeat(Math.floor(value / 1_000)) +
+		ROMAN_PLACES[2][Math.floor(value / 100) % 10] +
+		ROMAN_PLACES[1][Math.floor(value / 10) % 10] +
+		ROMAN_PLACES[0][value % 10]
+	);
+}
+
+/** Format every numeric segment of a version as a Roman numeral. */
+export function formatRomanVersion(version: string): string {
+	return version.replace(/\d+/g, digits => romanizeInteger(Number.parseInt(digits, 10)));
+}
+
+function buildReleaseRows(markdown: string, version: string, contentWidth: number, bullet: string): CrawlRow[] {
+	const rows: CrawlRow[] = [];
+	let activeFence: string | undefined;
+
+	for (const rawLine of markdown.split("\n")) {
+		const trimmed = rawLine.trim();
+		const fence = trimmed.match(/^(`{3,}|~{3,})(.*)$/);
+		if (!activeFence && fence) {
+			activeFence = fence[1];
+			continue;
+		}
+		if (
+			activeFence &&
+			fence &&
+			fence[2] === "" &&
+			fence[1][0] === activeFence[0] &&
+			fence[1].length >= activeFence.length
+		) {
+			activeFence = undefined;
+			continue;
+		}
+
+		if (activeFence) {
+			const text = cleanTerminalText(rawLine);
+			rows.push(...wrapRow(text, contentWidth, "body", true));
+			continue;
+		}
+
+		if (!trimmed) {
+			if (rows.at(-1)?.text) rows.push(BLANK_ROW);
+			continue;
+		}
+
+		const release = trimmed.match(/^##\s+\[?(\d+\.\d+\.\d+)\]?/);
+		if (release) {
+			if (release[1] !== version) {
+				rows.push(...wrapRow(`EPISODE ${formatRomanVersion(release[1])}`, contentWidth, "heading"));
+			}
+			continue;
+		}
+
+		const heading = trimmed.match(/^#{1,6}\s+(.+)$/);
+		if (heading) {
+			rows.push(...wrapRow(cleanInlineMarkdown(heading[1]).toUpperCase(), contentWidth, "heading"));
+			continue;
+		}
+
+		const listItem = trimmed.match(/^[-*+]\s+(.+)$/);
+		if (listItem) {
+			rows.push(...wrapRow(`${bullet} ${cleanInlineMarkdown(listItem[1])}`, contentWidth, "body"), BLANK_ROW);
+			continue;
+		}
+
+		if (/^\d+[.)]\s+/.test(trimmed)) {
+			rows.push(...wrapRow(cleanInlineMarkdown(trimmed), contentWidth, "body"), BLANK_ROW);
+			continue;
+		}
+
+		const text = cleanInlineMarkdown(trimmed);
+		if (text) rows.push(...wrapRow(text, contentWidth, "body"));
+	}
+
+	while (rows.length > 0 && !rows.at(-1)?.text) rows.pop();
+	return rows;
+}
+function buildCrawlRows(markdown: string, version: string, width: number): CrawlRow[] {
+	const contentWidth = crawlContentWidth(width);
+	const titleRows: CrawlRow[] = TITLE_ART.every(line => visibleWidth(line) <= contentWidth)
+		? TITLE_ART.map(text => ({ text, kind: "title" as const }))
+		: wrapRow("O H   M Y   P I", contentWidth, "title");
+	return [
+		...titleRows,
+		BLANK_ROW,
+		...wrapRow(`EPISODE ${formatRomanVersion(version)}`, contentWidth, "heading"),
+		BLANK_ROW,
+		...wrapRow("W H A T ' S   N E W", contentWidth, "title"),
+		BLANK_ROW,
+		...buildReleaseRows(markdown, version, contentWidth, "•"),
+		...THREE_BLANK_ROWS,
+	];
+}
+
+function starGlyph(x: number, y: number, frame: number): string {
+	let hash = Math.imul(x + 1, 73856093) ^ Math.imul(y + 1, 19349663);
+	hash = Math.imul(hash ^ (hash >>> 13), 1274126177) >>> 0;
+	if (hash % 59 > 2) return " ";
+	const phase = (frame + ((hash >>> 8) % 16)) % 16;
+	if (phase === 0) return styleSceneText("✦", STAR_BRIGHT);
+	if (phase <= 2) return styleSceneText("*", STAR_MEDIUM);
+	return styleSceneText("·", STAR_DIM);
+}
+
+function starfieldRow(width: number, y: number, frame: number): string[] {
+	return Array.from({ length: width }, (_, x) => starGlyph(x, y, frame));
+}
+
+function interpolateChannel(far: number, near: number, depth: number): number {
+	return Math.round(far + (near - far) * smoothstep(0, 1, depth));
+}
+function styleSceneText(text: string, [red, green, blue]: Rgb): string {
+	const format = TERMINAL.trueColor ? "ansi-16m" : "ansi-256";
+	const color = Bun.color(`rgb(${red}, ${green}, ${blue})`, format) ?? "";
+	return `${color}${text}\x1b[39m`;
+}
+
+function styleCrawlText(row: CrawlRow, text: string, depth: number, opacity: number): string {
+	const background = 0;
+	const red = interpolateChannel(FAR_AMBER[0], NEAR_YELLOW[0], depth);
+	const green = interpolateChannel(FAR_AMBER[1], NEAR_YELLOW[1], depth);
+	const blue = interpolateChannel(FAR_AMBER[2], NEAR_YELLOW[2], depth);
+	const fadedRed = Math.round(background + (red - background) * opacity);
+	const fadedGreen = Math.round(background + (green - background) * opacity);
+	const fadedBlue = Math.round(background + (blue - background) * opacity);
+	const styled = styleSceneText(text, [fadedRed, fadedGreen, fadedBlue]);
+	return row.kind === "body" || opacity < 0.6 ? styled : theme.bold(styled);
+}
+
+function renderPreparedCrawl(width: number, height: number, elapsedMs: number, rows: readonly CrawlRow[]): string[] {
+	const w = Math.max(1, width);
+	const h = Math.max(1, height);
+	const frame = Math.floor(Math.max(0, elapsedMs) / UPDATE_CRAWL_TICK_MS);
+	const output = Array.from({ length: h }, (_, y) => starfieldRow(w, y, frame));
+	const usableHeight = Math.max(1, h - TOP_EDGE_ROW - 2);
+	const scrollRows = (Math.max(0, elapsedMs) / 1000) * ROWS_PER_SECOND;
+	const firstY = TOP_EDGE_ROW + usableHeight - 1 - scrollRows;
+
+	for (let index = 0; index < rows.length; index++) {
+		const targetY = Math.round(firstY + index);
+		if (targetY <= TOP_EDGE_ROW || targetY >= h - 1) continue;
+		const row = rows[index];
+		if (!row.text || visibleWidth(row.text) > w) continue;
+		const distanceFromTop = targetY - TOP_EDGE_ROW;
+		const opacity = smoothstep(0, TOP_FADE_ROWS, distanceFromTop);
+		const depth = distanceFromTop / usableHeight;
+		const lineWidth = visibleWidth(row.text);
+		const start = Math.max(0, Math.floor((w - lineWidth) / 2));
+		const background = output[targetY];
+		output[targetY] = [
+			...background.slice(0, start),
+			styleCrawlText(row, row.text, depth, opacity),
+			...background.slice(Math.min(w, start + lineWidth)),
+		];
+	}
+
+	const complete = firstY + rows.length <= TOP_EDGE_ROW + 1;
+	const hint = complete ? "enter to continue" : "enter to skip";
+	const hintWidth = visibleWidth(hint);
+	if (hintWidth <= w) {
+		const styledHint = styleSceneText(hint, HINT_COLOR);
+		const hintStart = Math.floor((w - hintWidth) / 2);
+		const bottom = output[h - 1];
+		output[h - 1] = [...bottom.slice(0, hintStart), styledHint, ...bottom.slice(hintStart + hintWidth)];
+	}
+
+	return output.map(line => `${BLACK_BACKGROUND}${line.join("")}${DEFAULT_BACKGROUND}`);
+}
+
+/** Paint one deterministic crawl frame. Exported for rendering tests and gallery use. */
+export function renderUpdateCrawl(
+	width: number,
+	height: number,
+	elapsedMs: number,
+	markdown: string,
+	version: string,
+): string[] {
+	return renderPreparedCrawl(width, height, elapsedMs, buildCrawlRows(markdown, version, width));
+}
+
+/** Hold a fullscreen cinematic changelog until the user continues or skips it with Enter. */
+export async function runUpdateCrawl(
+	host: UpdateCrawlHost,
+	markdown: string,
+	version: string,
+	options: RunUpdateCrawlOptions = {},
+): Promise<void> {
+	const done = Promise.withResolvers<void>();
+	const now = options.now ?? (() => performance.now());
+	let startedAt = 0;
+	let renderWidth = 0;
+	let rows: CrawlRow[] = [];
+
+	const component: Component & OverlayFocusOwner = {
+		ownsOverlayFocusTarget: target => target === component,
+		handleInput(data) {
+			if (
+				matchesKey(data, "enter") ||
+				matchesKey(data, "return") ||
+				matchesKey(data, "escape") ||
+				matchesKey(data, "esc") ||
+				matchesKey(data, "ctrl+c")
+			) {
+				done.resolve();
+			}
+		},
+		render(width) {
+			const safeWidth = Math.max(1, width);
+			const height = Math.max(1, host.ui.terminal.rows);
+			const elapsedMs = Math.max(0, now() - startedAt);
+			if (safeWidth !== renderWidth) {
+				renderWidth = safeWidth;
+				rows = buildCrawlRows(markdown, version, safeWidth);
+			}
+			return renderPreparedCrawl(safeWidth, height, elapsedMs, rows);
+		},
+	};
+	const overlay = host.ui.showOverlay(component, {
+		width: "100%",
+		maxHeight: "100%",
+		anchor: "top-left",
+		margin: 0,
+		fullscreen: true,
+	});
+	let timer: NodeJS.Timeout | undefined;
+	try {
+		host.ui.setFocus(component);
+		startedAt = now();
+		timer = setInterval(() => host.ui.requestRender(), options.tickMs ?? UPDATE_CRAWL_TICK_MS);
+		host.ui.requestRender();
+		await done.promise;
+	} finally {
+		clearInterval(timer);
+		host.ui.setFocus(component);
+		overlay.hide();
+	}
+}

--- a/packages/coding-agent/test/update-crawl.test.ts
+++ b/packages/coding-agent/test/update-crawl.test.ts
@@ -1,0 +1,167 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	formatRomanVersion,
+	renderUpdateCrawl,
+	runUpdateCrawl,
+} from "@oh-my-pi/pi-coding-agent/modes/components/update-crawl";
+import { getCurrentThemeName, initTheme, setTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { type Component, TERMINAL, visibleWidth } from "@oh-my-pi/pi-tui";
+
+const stripAnsi = (text: string): string => Bun.stripANSI(text);
+const normalizeWhitespace = (text: string): string => text.replace(/\s+/g, " ").trim();
+const TITLE_TOP = " ###  #   #    #   # #   #    ####  #####";
+const sceneColor = (rgb: string): string => Bun.color(rgb, TERMINAL.trueColor ? "ansi-16m" : "ansi-256") ?? "";
+const foregroundBefore = (line: string, needle: string): string | undefined => {
+	const prefix = line.slice(0, line.indexOf(needle));
+	return prefix.match(/\x1b\[[0-9;]*m/g)?.at(-1);
+};
+
+beforeAll(async () => {
+	await initTheme(false);
+});
+
+describe("update crawl", () => {
+	it("renders complete release notes beneath an ASCII title over twinkling stars", () => {
+		const markdown = "## [2.4.0]\n\n### Added\n\n- A new feature with **bold** details.";
+		const opening = renderUpdateCrawl(80, 24, 0, markdown, "2.4.0");
+		const introText = renderUpdateCrawl(80, 24, 3_000, markdown, "2.4.0").map(stripAnsi).join("\n");
+		const releaseText = renderUpdateCrawl(80, 24, 6_000, markdown, "2.4.0").map(stripAnsi).join("\n");
+		const openingFrame = opening.join("\n");
+		const openingText = opening.map(stripAnsi).join("\n");
+		const finishedText = renderUpdateCrawl(80, 24, 100_000, markdown, "2.4.0").map(stripAnsi).join("\n");
+
+		expect(opening).toHaveLength(24);
+		expect(opening.map(line => Bun.stringWidth(line))).toEqual(Array(24).fill(80));
+		expect(opening.every(line => line.startsWith("\x1b[40m") && line.endsWith("\x1b[49m"))).toBe(true);
+		expect(openingFrame).toContain(`${sceneColor("rgb(208, 220, 235)")}✦`);
+		expect(openingFrame).toContain(`${sceneColor("rgb(104, 108, 116)")}enter to skip`);
+		expect(introText).toContain(TITLE_TOP);
+		expect(introText).toContain("EPISODE II.IV.N");
+		expect(introText).not.toContain("RELEASE 2.4.0");
+		expect(openingText).toMatch(/[✦*·]/);
+		expect(releaseText).toContain("ADDED");
+		expect(normalizeWhitespace(releaseText)).toContain("• A new feature with bold details.");
+		expect(releaseText).toContain("enter to skip");
+		expect(finishedText).toContain("enter to continue");
+	});
+
+	it("keeps the cinematic palette identical across light and dark themes", async () => {
+		const previousTheme = getCurrentThemeName() ?? "dark";
+		try {
+			await setTheme("light");
+			const lightFrame = renderUpdateCrawl(80, 24, 3_000, "### Added\n\n- Theme proof.", "2.4.0");
+			await setTheme("dark");
+			const darkFrame = renderUpdateCrawl(80, 24, 3_000, "### Added\n\n- Theme proof.", "2.4.0");
+			expect(lightFrame).toEqual(darkFrame);
+		} finally {
+			await setTheme(previousTheme);
+		}
+	});
+
+	it("formats every numeric version component as a Roman numeral", () => {
+		expect(formatRomanVersion("17.0.5")).toBe("XVII.N.V");
+		expect(formatRomanVersion("2026.12.104-beta.3")).toBe("MMXXVI.XII.CIV-beta.III");
+	});
+
+	it("wraps complete lines without ellipses, preserves word spacing, and fades at the horizon", () => {
+		const markdown =
+			"### Added\n\n- BEGINNING a deliberately long release note whose complete wording must remain readable across conservatively wrapped crawl rows without losing its ENDING.";
+		const frames = Array.from({ length: 81 }, (_, index) =>
+			renderUpdateCrawl(80, 24, index * 250, markdown, "2.4.0"),
+		);
+		const allText = frames.flat().map(stripAnsi).join("\n");
+		const readableFrame = renderUpdateCrawl(80, 24, 6_000, "### Added\n\n- A new feature.", "2.4.0");
+		const readableText = readableFrame.map(stripAnsi).join("\n");
+		const fencedText = renderUpdateCrawl(
+			80,
+			24,
+			6_000,
+			"````text\r\n# Before\r\n```\r\n- literal item\r\n````",
+			"2.4.0",
+		)
+			.map(stripAnsi)
+			.join("\n");
+		const nearTitle = renderUpdateCrawl(80, 24, 0, markdown, "2.4.0").find(line =>
+			stripAnsi(line).includes(TITLE_TOP),
+		);
+		const farTitle = renderUpdateCrawl(80, 24, 6_800, markdown, "2.4.0").find(line =>
+			stripAnsi(line).includes(TITLE_TOP),
+		);
+		const fadedFrame = renderUpdateCrawl(80, 24, 8_000, markdown, "2.4.0").map(stripAnsi).join("\n");
+		const headingOnlyFrame = renderUpdateCrawl(80, 24, 0, "## [2.4.0]", "2.4.0");
+		const narrowFrames = [1, 8, 12].map(width => ({
+			width,
+			frame: renderUpdateCrawl(width, 24, 0, markdown, "2.4.0"),
+		}));
+
+		expect(normalizeWhitespace(allText)).toContain("BEGINNING");
+		expect(normalizeWhitespace(allText)).toContain("ENDING");
+		expect(allText).not.toContain("…");
+		expect(allText).not.toContain("...");
+		expect(readableText).toContain("• A new feature.");
+		expect(fencedText).toContain("# Before");
+		expect(fencedText).toContain("- literal item");
+		expect(fencedText).toContain("```");
+		expect(fencedText).not.toContain("\r");
+		expect(nearTitle).toBeDefined();
+		expect(farTitle).toBeDefined();
+		expect(foregroundBefore(nearTitle!, TITLE_TOP)).not.toBe(foregroundBefore(farTitle!, TITLE_TOP));
+		expect(fadedFrame).not.toContain(TITLE_TOP);
+		expect(headingOnlyFrame).toHaveLength(24);
+		for (const { width, frame } of narrowFrames) {
+			expect(Math.max(...frame.map(visibleWidth))).toBeLessThanOrEqual(width);
+		}
+	});
+
+	it("waits after the full crawl and dismisses on Enter, Escape, or Ctrl+C", async () => {
+		const preCrawlFocus: Component = { render: () => [] };
+		let focused: Component | undefined = preCrawlFocus;
+		let overlayComponent: (Component & { handleInput(data: string): void }) | undefined;
+		let hidden = false;
+		const host = {
+			ui: {
+				terminal: { rows: 12, write: () => {} },
+				showOverlay: (component: Component) => {
+					overlayComponent = component as Component & { handleInput(data: string): void };
+					const previousFocus = focused;
+					focused = component;
+					return {
+						hide: () => {
+							hidden = true;
+							if (focused === component) focused = previousFocus;
+						},
+						setHidden: (nextHidden: boolean) => {
+							hidden = nextHidden;
+						},
+						isHidden: () => hidden,
+					};
+				},
+				setFocus: (component: Component) => {
+					focused = component;
+				},
+				requestRender: () => {},
+			},
+		};
+
+		for (const key of ["\r", "\x1b", "\x03"]) {
+			hidden = false;
+			const running = runUpdateCrawl(host, "### Fixed\n\n- A bug.", "2.4.0", {
+				tickMs: 60_000,
+				now: () => 0,
+			});
+			overlayComponent?.handleInput(" ");
+			expect(hidden).toBe(false);
+
+			overlayComponent?.handleInput(key);
+			await running;
+			expect(hidden).toBe(true);
+			expect(focused).toBe(preCrawlFocus);
+		}
+	});
+
+	it("registers crawl as an optional mode without changing the summary default", () => {
+		expect(Settings.isolated().get("startup.changelogMode")).toBe("summary");
+		expect(Settings.isolated({ "startup.changelogMode": "crawl" }).get("startup.changelogMode")).toBe("crawl");
+	});
+});


### PR DESCRIPTION
## What

- Add `crawl` as an optional `startup.changelogMode`.
- Present startup release notes as a fullscreen yellow cinematic crawl over twinkling terminal stars.
- Render an ASCII Oh My Pi title, the current version as a Roman-numeral episode number, and the selected startup changelog without crawl-side truncation.
- Use a single portable TUI renderer with a fixed black background and theme-independent scene colors—no terminal-specific graphics protocol.
- Allow Enter to skip an active crawl or continue after it finishes.
- Keep `summary` as the default startup changelog mode.

## Why

This adds an optional, playful way to review release notes without changing the default startup experience or introducing terminal-specific rendering paths.

It builds on the startup changelog-mode contract introduced by @wolfiesch in #6857.

## Testing

- `bun check`
- `bun test packages/coding-agent/test/update-crawl.test.ts`
  - 6 passed
  - 0 failed
- Launched the source CLI in Ghostty with `startup.changelogMode: crawl` and an older changelog marker.
- Visually verified the fullscreen title, Roman-numeral version, release-note crawl, twinkling starfield, fixed cinematic palette, and Enter-to-skip behavior.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
