### PR TITLE
fix(coding-agent): allow quoted metacharacters in bash patterns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed bug where `agent()` calls in eval cells ignored turn cancellation and continued running indefinitely
 - Fixed the built-in `tail` printing `tail: Broken pipe` and failing when a downstream pipeline reader exited early (e.g. `tail -c N file.jsonl | jq …` with jq aborting on a parse error); it now exits silently with 141 (128+SIGPIPE) like a real tail, in every output path including `--follow`.
 - Fixed the in-process ps shell builtin rejecting common procps/BSD format specifiers (`ps -o tpgid,...` failed with `unknown output format specifier`); added `tpgid`, `pri`, `flags`, real/effective user and group columns, `wchan`, fault counters, `sz`, and the STAT `+` foreground flag.
+- Fixed `bash.patterns` allow rules rejecting simple commands when quoted arguments contained shell metacharacters such as Cargo benchmark regex filters ([#7552](https://github.com/can1357/oh-my-pi/issues/7552)).
 
 ## [17.2.6] - 2026-08-03
 

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -58,7 +58,51 @@ export const BASH_DEFAULT_PREVIEW_LINES = DEFAULT_TERMINAL_PREVIEW_LINES;
 
 const BASH_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const DEFAULT_AUTO_BACKGROUND_THRESHOLD_MS = 60_000;
-const BASH_APPROVAL_SHELL_CONTROL_RE = /[\n\r;&|<>`$()]/u;
+const BASH_APPROVAL_SHELL_CONTROL_CHARS: Record<string, true> = {
+	"\n": true,
+	"\r": true,
+	";": true,
+	"&": true,
+	"|": true,
+	"<": true,
+	">": true,
+	"`": true,
+	$: true,
+	"(": true,
+	")": true,
+};
+
+function hasBashApprovalShellControl(command: string): boolean {
+	let quote: "'" | '"' | undefined;
+	for (let i = 0; i < command.length; i++) {
+		const ch = command[i];
+		if (quote === "'") {
+			if (ch === "'") quote = undefined;
+			continue;
+		}
+		if (ch === "\\") {
+			i++;
+			continue;
+		}
+		if (quote === '"') {
+			if (ch === '"') {
+				quote = undefined;
+				continue;
+			}
+			// Expansion remains active inside double quotes; other control-looking
+			// characters are literal argument text.
+			if (ch === "`" || ch === "$") return true;
+			continue;
+		}
+		if (ch === "'" || ch === '"') {
+			quote = ch;
+			continue;
+		}
+		if (Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, ch)) return true;
+	}
+	return false;
+}
+
 const BASH_PATTERN_APPROVAL_VALUES = new Set(["allow", "deny", "prompt"]);
 
 /**
@@ -218,7 +262,7 @@ function commandSegmentMatchesBashApprovalPattern(command: string, pattern: stri
 // `prompt` fire on any matching segment so they mean what they appear to.
 function bashApprovalRuleMatches(command: string, rule: BashApprovalPatternRule): boolean {
 	if (rule.approval === "allow") {
-		if (BASH_APPROVAL_SHELL_CONTROL_RE.test(command)) return false;
+		if (hasBashApprovalShellControl(command)) return false;
 		return commandMatchesBashApprovalPattern(command, rule.match);
 	}
 	return commandSegmentMatchesBashApprovalPattern(command, rule.match);

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -75,18 +75,22 @@ const BASH_APPROVAL_REINTERPRETED_ARGUMENT_RE = /(?:^|[ \t])(?:-[^-]*[ce]|--(?:c
 
 function hasBashApprovalShellControl(command: string): boolean {
 	let quote: "'" | '"' | undefined;
-	let hasQuotedShellControl = false;
+	let hasReinterpretableShellControl = false;
 	for (let i = 0; i < command.length; i++) {
 		const ch = command[i];
 		if (quote === "'") {
 			if (ch === "'") {
 				quote = undefined;
 			} else if (Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, ch)) {
-				hasQuotedShellControl = true;
+				hasReinterpretableShellControl = true;
 			}
 			continue;
 		}
 		if (ch === "\\") {
+			const escaped = command[i + 1];
+			if (escaped && Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, escaped)) {
+				hasReinterpretableShellControl = true;
+			}
 			i++;
 			continue;
 		}
@@ -99,7 +103,7 @@ function hasBashApprovalShellControl(command: string): boolean {
 			if (ch === "`" || ch === "$") return true;
 			// Other control characters are literal here but become executable if a
 			// `-c`/`-e` option reinterprets the argument through another shell.
-			if (Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, ch)) hasQuotedShellControl = true;
+			if (Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, ch)) hasReinterpretableShellControl = true;
 			continue;
 		}
 		if (ch === "'" || ch === '"') {
@@ -109,8 +113,8 @@ function hasBashApprovalShellControl(command: string): boolean {
 		if (Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, ch)) return true;
 	}
 	// Options such as `git -c alias.x='!...'` and `sh -c "..."` reinterpret
-	// otherwise literal quoted arguments as executable code.
-	return hasQuotedShellControl && BASH_APPROVAL_REINTERPRETED_ARGUMENT_RE.test(command);
+	// otherwise literal quoted or escaped arguments as executable code.
+	return hasReinterpretableShellControl && BASH_APPROVAL_REINTERPRETED_ARGUMENT_RE.test(command);
 }
 
 const BASH_PATTERN_APPROVAL_VALUES = new Set(["allow", "deny", "prompt"]);

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -95,9 +95,11 @@ function hasBashApprovalShellControl(command: string): boolean {
 				quote = undefined;
 				continue;
 			}
-			// Expansion remains active inside double quotes; other control-looking
-			// characters are literal argument text.
+			// Expansion is active inside double quotes even in the original line.
 			if (ch === "`" || ch === "$") return true;
+			// Other control characters are literal here but become executable if a
+			// `-c`/`-e` option reinterprets the argument through another shell.
+			if (Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, ch)) hasQuotedShellControl = true;
 			continue;
 		}
 		if (ch === "'" || ch === '"') {
@@ -106,8 +108,8 @@ function hasBashApprovalShellControl(command: string): boolean {
 		}
 		if (Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, ch)) return true;
 	}
-	// Options such as `git -c alias.x='!...'` and `sh -c '...'` reinterpret
-	// otherwise literal single-quoted arguments as executable code.
+	// Options such as `git -c alias.x='!...'` and `sh -c "..."` reinterpret
+	// otherwise literal quoted arguments as executable code.
 	return hasQuotedShellControl && BASH_APPROVAL_REINTERPRETED_ARGUMENT_RE.test(command);
 }
 

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -71,13 +71,19 @@ const BASH_APPROVAL_SHELL_CONTROL_CHARS: Record<string, true> = {
 	"(": true,
 	")": true,
 };
+const BASH_APPROVAL_REINTERPRETED_ARGUMENT_RE = /(?:^|[ \t])(?:-[^-]*[ce]|--(?:command|eval))(?:[= \t]|$)/u;
 
 function hasBashApprovalShellControl(command: string): boolean {
 	let quote: "'" | '"' | undefined;
+	let hasQuotedShellControl = false;
 	for (let i = 0; i < command.length; i++) {
 		const ch = command[i];
 		if (quote === "'") {
-			if (ch === "'") quote = undefined;
+			if (ch === "'") {
+				quote = undefined;
+			} else if (Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, ch)) {
+				hasQuotedShellControl = true;
+			}
 			continue;
 		}
 		if (ch === "\\") {
@@ -100,7 +106,9 @@ function hasBashApprovalShellControl(command: string): boolean {
 		}
 		if (Object.hasOwn(BASH_APPROVAL_SHELL_CONTROL_CHARS, ch)) return true;
 	}
-	return false;
+	// Options such as `git -c alias.x='!...'` and `sh -c '...'` reinterpret
+	// otherwise literal single-quoted arguments as executable code.
+	return hasQuotedShellControl && BASH_APPROVAL_REINTERPRETED_ARGUMENT_RE.test(command);
 }
 
 const BASH_PATTERN_APPROVAL_VALUES = new Set(["allow", "deny", "prompt"]);

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -331,6 +331,7 @@ describe("tool-owned dynamic approval declarations", () => {
 			"git status > /etc/passwd",
 			"git -c alias.x='!touch /tmp/pwn; printf ok' x",
 			'git -c alias.x="!touch /tmp/pwn; printf ok" x',
+			"git -c alias.x=!touch\\ /tmp/pwn\\;\\ printf\\ ok x",
 			"git status < seed",
 			// Different binary resolution than the pattern names.
 			"FOO=1 git status",

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -347,6 +347,16 @@ describe("tool-owned dynamic approval declarations", () => {
 		}
 	});
 
+	it("allows literal shell metacharacters in quoted arguments", () => {
+		const settingsOverrides = {
+			"bash.patterns": [{ match: "cargo *", approval: "allow" }],
+		};
+		const command =
+			"cargo bench --manifest-path layers/layer3/Cargo.toml --bench standardized_criterion -- --full '^layer3/write/file-wal/batch-(10|1000|10000)$'";
+
+		expect(bashApproval(command, settingsOverrides)).toEqual({ tier: "write", policy: "allow" });
+	});
+
 	it("honors bash pattern rules in yolo mode", () => {
 		const tool = createBashTool({
 			"bash.patterns": [

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -329,6 +329,7 @@ describe("tool-owned dynamic approval declarations", () => {
 			"git $(rm file.txt)",
 			"git `rm file.txt` status",
 			"git status > /etc/passwd",
+			"git -c alias.x='!touch /tmp/pwn; printf ok' x",
 			"git status < seed",
 			// Different binary resolution than the pattern names.
 			"FOO=1 git status",

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -330,6 +330,7 @@ describe("tool-owned dynamic approval declarations", () => {
 			"git `rm file.txt` status",
 			"git status > /etc/passwd",
 			"git -c alias.x='!touch /tmp/pwn; printf ok' x",
+			'git -c alias.x="!touch /tmp/pwn; printf ok" x',
 			"git status < seed",
 			// Different binary resolution than the pattern names.
 			"FOO=1 git status",


### PR DESCRIPTION
## Repro
With `bash.patterns: [{ match: "cargo *", approval: "allow" }]`, evaluate `cargo bench --manifest-path layers/layer3/Cargo.toml --bench standardized_criterion -- --full '^layer3/write/file-wal/batch-(10|1000|10000)$'`; current `main` returns the Bash approval decision `"exec"` instead of `{ tier: "write", policy: "allow" }`.

## Cause
`BashTool.approval()` in `packages/coding-agent/src/tools/bash.ts` called `BASH_APPROVAL_SHELL_CONTROL_RE` against the raw command, so shell metacharacters inside single-quoted literal arguments were indistinguishable from executable compound-command syntax.

## Fix
- Replace the raw regex guard with quote-aware shell-control scanning while preserving unquoted controls, double-quoted expansion, command substitution, redirection, and compound-command protections.
- Cover the reported Cargo benchmark regex filter through the observable `BashTool.approval()` decision.
- Record the fix under the coding-agent Unreleased changelog.

## Verification
`bun test packages/coding-agent/test/tools/approval.test.ts` passes 33 tests; the exact reported command now returns `{"tier":"write","policy":"allow"}`. Skipped the pre-publish gate after verifying on a clean `origin/main` checkout that `bun run fix` rewrites unrelated `crates/pi-shell/src/shell.rs` and `bun check` fails identically in unrelated omptype migration paths (`openai-responses-server-schema.ts` and `task/types.ts`). Fixes #7552