### PR TITLE
fix(cli): preserve OMP identity inside Herdr

### DIFF
--- a/packages/coding-agent/scripts/omp
+++ b/packages/coding-agent/scripts/omp
@@ -36,7 +36,16 @@ mkdir -p "$launch_dir"
 OMP_LAUNCH_CWD=$PWD
 export OMP_LAUNCH_CWD
 cd "$launch_dir"
+# Herdr 0.7.5 validates the foreground process name. The macOS shell can
+# preserve OMP's identity while still running the development CLI through Bun.
+run_bun() {
+	if [ "${HERDR_ENV:-}" = 1 ] && [ "$(uname -s)" = Darwin ]; then
+		exec -a omp bun "$@"
+	fi
+	exec bun "$@"
+}
+
 if [ -n "${PI_TIMING:-}" ]; then
-	exec bun --preload "$preload" --preload "$timing_preload" "$cli" "$@"
+	run_bun --preload "$preload" --preload "$timing_preload" "$cli" "$@"
 fi
-exec bun --preload "$preload" "$cli" "$@"
+run_bun --preload "$preload" "$cli" "$@"


### PR DESCRIPTION
## What

I reviewed this change and confirmed that it lets Herdr recognize OMP correctly on macOS while leaving normal OMP launches unchanged.

## Why

Herdr 0.7.5 validates the foreground process name for managed agents. The macOS development launcher executes the CLI through Bun, so the pane appeared as `bun` rather than `omp` and Herdr rejected an otherwise healthy OMP process. The alias is limited to `HERDR_ENV=1` on Darwin; normal launches and other platforms retain the existing Bun execution path.

## Testing

- `sh -n packages/coding-agent/scripts/omp`
- `HERDR_ENV=1 ~/.bun/bin/omp --version` returned `omp/17.2.6`
- `~/.bun/bin/omp --version` returned `omp/17.2.6`
- Started OMP in Herdr-managed macOS panes and confirmed the named agents registered and settled successfully
- `bun check` was attempted after `bun install --frozen-lockfile`; it currently fails in unchanged TypeScript and Rust checks, including `TS2589` in `packages/ai/src/providers/openai-responses-server-schema.ts` and `BaseType.array` errors in `packages/coding-agent/src/task/types.ts`

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (single-platform launcher compatibility fix)
