### PR TITLE
feat(coding-agent): add --session-profile for cross-profile resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `--session-profile <name>` to resolve the `--resume`/`--fork` target from another profile's session store while the process keeps running the active profile's config, so a session created under one `--profile` can be resumed under another (e.g. `omp --profile work --resume <id> --session-profile personal`). Lookup is redirected to that profile's sessions tree; the session opens in place and default resolution is unchanged when the flag is omitted.
+- Added `--session-profile <name>` to resolve the `--resume`/`--fork` target from another profile's session store while the process keeps running the active profile's config, so a session created under one `--profile` can be resumed under another (e.g. `omp --profile work --resume <id> --session-profile personal`). Lookup is redirected to that profile's sessions tree; the session opens in place and default resolution is unchanged when the flag is omitted ([#7565](https://github.com/can1357/oh-my-pi/pull/7565) by [@thekidnamedkd](https://github.com/thekidnamedkd)).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `--session-profile <name>` to resolve the `--resume`/`--fork` target from another profile's session store while the process keeps running the active profile's config, so a session created under one `--profile` can be resumed under another (e.g. `omp --profile work --resume <id> --session-profile personal`). Lookup is redirected to that profile's sessions tree; the session opens in place and default resolution is unchanged when the flag is omitted.
+
 ### Changed
 
 - Replaced arktype with `@oh-my-pi/omptype` across all tool parameter and config schemas: ~100x faster schema construction removes the arktype startup tax (the `scope({}, { jitless: true })` workarounds are gone). Config schema errors now report via `OmpErrors` entries with the same `path`/`problem` shape.

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -56,6 +56,12 @@ export interface Args {
 	mode?: Mode;
 	noSession?: boolean;
 	sessionDir?: string;
+	/**
+	 * Profile whose session store the `--resume`/`--fork` target is resolved
+	 * from, independent of the active `--profile`. Lets a session created under
+	 * one profile be resumed while running another profile's config.
+	 */
+	sessionProfile?: string;
 	providerSessionId?: string;
 	providerPromptCacheKey?: string;
 	fork?: string;

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -179,6 +179,9 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 	"--session-dir": (result, value) => {
 		result.sessionDir = value;
 	},
+	"--session-profile": (result, value) => {
+		result.sessionProfile = value;
+	},
 	"--models": (result, value) => {
 		result.models = value.split(",").map(s => s.trim());
 	},

--- a/packages/coding-agent/src/commands/launch-help.ts
+++ b/packages/coding-agent/src/commands/launch-help.ts
@@ -57,6 +57,10 @@ export const launchHelp = {
 		"from-claude": Flags.boolean({ description: "Import a Claude Code session into OMP" }),
 		"from-codex": Flags.boolean({ description: "Import a Codex session into OMP" }),
 		"session-dir": Flags.string({ description: "Directory for session storage and lookup" }),
+		"session-profile": Flags.string({
+			description:
+				"Resolve the --resume/--fork target from another profile's session store (runs under the active profile)",
+		}),
 		"no-session": Flags.boolean({ description: "Don't save session (ephemeral)" }),
 		models: Flags.string({ description: "Comma-separated model patterns for Ctrl+P cycling" }),
 		"no-tools": Flags.boolean({ description: "Disable all built-in tools" }),

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -13,6 +13,7 @@ import {
 	$env,
 	directoryExists,
 	getLogPath,
+	getProfileSessionsDir,
 	getProjectDir,
 	logger,
 	normalizePathForComparison,
@@ -719,6 +720,17 @@ export async function createSessionManager(
 	activeSettings: Settings = settings,
 	askToMoveSession: SessionPrompt = promptMoveSession,
 ): Promise<SessionManager | undefined> {
+	// `--session-profile` resolves the resume/fork target from another profile's
+	// session store while this process keeps running the active profile's config.
+	// The session opens in place (its own profile's tree); only lookup is
+	// redirected. Empty when unset, so resolution falls back to the active profile.
+	const sessionProfileRoot = parsed.sessionProfile ? getProfileSessionsDir(parsed.sessionProfile) : undefined;
+	if (parsed.sessionProfile && typeof parsed.resume !== "string" && typeof parsed.fork !== "string") {
+		throw new SessionResolutionError(
+			"--session-profile needs a target session; pass --resume <id> or --fork <id> to resolve from that profile.",
+		);
+	}
+	const resumeOptions = { sessionsRoot: sessionProfileRoot };
 	if (parsed.fork) {
 		if (parsed.noSession) {
 			throw new SessionResolutionError("--fork requires session persistence");
@@ -727,7 +739,7 @@ export async function createSessionManager(
 		if (forkSource.includes("/") || forkSource.includes("\\") || forkSource.endsWith(".jsonl")) {
 			return await SessionManager.forkFrom(forkSource, cwd, parsed.sessionDir);
 		}
-		const match = await resolveResumableSession(forkSource, cwd, parsed.sessionDir);
+		const match = await resolveResumableSession(forkSource, cwd, parsed.sessionDir, resumeOptions);
 		if (!match) {
 			throw new SessionResolutionError(
 				`Session "${forkSource}" not found.`,
@@ -747,7 +759,7 @@ export async function createSessionManager(
 		if (sessionArg.includes("/") || sessionArg.includes("\\") || sessionArg.endsWith(".jsonl")) {
 			return await SessionManager.open(sessionArg, parsed.sessionDir);
 		}
-		const match = await resolveResumableSession(sessionArg, cwd, parsed.sessionDir);
+		const match = await resolveResumableSession(sessionArg, cwd, parsed.sessionDir, resumeOptions);
 		if (!match) {
 			throw new SessionResolutionError(
 				`Session "${sessionArg}" not found.`,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -725,10 +725,19 @@ export async function createSessionManager(
 	// The session opens in place (its own profile's tree); only lookup is
 	// redirected. Empty when unset, so resolution falls back to the active profile.
 	const sessionProfileRoot = parsed.sessionProfile ? getProfileSessionsDir(parsed.sessionProfile) : undefined;
-	if (parsed.sessionProfile && typeof parsed.resume !== "string" && typeof parsed.fork !== "string") {
-		throw new SessionResolutionError(
-			"--session-profile needs a target session; pass --resume <id> or --fork <id> to resolve from that profile.",
-		);
+	if (parsed.sessionProfile) {
+		const target =
+			typeof parsed.resume === "string" ? parsed.resume : typeof parsed.fork === "string" ? parsed.fork : undefined;
+		if (target === undefined) {
+			throw new SessionResolutionError(
+				"--session-profile needs a target session; pass --resume <id> or --fork <id> to resolve from that profile.",
+			);
+		}
+		if (target.includes("/") || target.includes("\\") || target.endsWith(".jsonl")) {
+			throw new SessionResolutionError(
+				"--session-profile expects a session id, not a path; a path already names a specific file. Drop --session-profile to resume a path directly.",
+			);
+		}
 	}
 	const resumeOptions = { sessionsRoot: sessionProfileRoot };
 	if (parsed.fork) {

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -709,7 +709,17 @@ export async function resolveResumableSession(
 ): Promise<ResolvedSessionMatch | undefined> {
 	const storage = isSessionStorage(storageOrOptions) ? storageOrOptions : new FileSessionStorage();
 	const resolvedOptions = isSessionStorage(storageOrOptions) ? options : storageOrOptions;
-	const localSessionDir = sessionDir ?? computeDefaultSessionDir(cwd, storage, resolvedOptions.sessionsRoot);
+	// A foreign profile's store is resolved read-only: the all-projects glob finds
+	// the session by id/prefix without the cwd-scoped local pass, which would
+	// ensureDir/migrate and recover backups inside that profile's tree. Lookup
+	// only — the other profile's directories are never created or mutated.
+	if (resolvedOptions.sessionsRoot !== undefined) {
+		const foreignSessions = await listAllSessions(storage, resolvedOptions.sessionsRoot);
+		const foreignMatch = foreignSessions.find(session => sessionMatchesResumeArg(session, sessionArg));
+		return foreignMatch ? { session: foreignMatch, scope: "global" } : undefined;
+	}
+
+	const localSessionDir = sessionDir ?? computeDefaultSessionDir(cwd, storage);
 	const localSessions = await listSessions(localSessionDir, storage);
 	const localMatch = localSessions.find(session => sessionMatchesResumeArg(session, sessionArg));
 	if (localMatch) {
@@ -720,7 +730,7 @@ export async function resolveResumableSession(
 		return undefined;
 	}
 
-	const globalSessions = await listAllSessions(storage, resolvedOptions.sessionsRoot);
+	const globalSessions = await listAllSessions(storage);
 	const globalMatch = globalSessions.find(session => sessionMatchesResumeArg(session, sessionArg));
 	if (!globalMatch) {
 		return undefined;

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -617,9 +617,17 @@ export function listSessionsReadOnly(sessionDir: string, storage: SessionStorage
 	return scanSessionDirReadOnly(sessionDir, storage, true);
 }
 
-/** List all sessions across all project directories (newest first). */
-export async function listAllSessions(storage: SessionStorage = new FileSessionStorage()): Promise<SessionInfo[]> {
-	const sessionsRoot = path.join(getDefaultAgentDir(), "sessions");
+/**
+ * List all sessions across all project directories (newest first).
+ *
+ * @param sessionsRoot Root of the sessions tree to scan. Defaults to the active
+ *   profile's `~/.omp/agent/sessions`; pass another profile's sessions root to
+ *   discover sessions stored under a different `--profile`.
+ */
+export async function listAllSessions(
+	storage: SessionStorage = new FileSessionStorage(),
+	sessionsRoot: string = path.join(getDefaultAgentDir(), "sessions"),
+): Promise<SessionInfo[]> {
 	try {
 		const files = await Array.fromAsync(new Bun.Glob("*/*.jsonl").scan(sessionsRoot), name =>
 			path.join(sessionsRoot, name),
@@ -679,6 +687,13 @@ function sessionMatchesResumeArg(session: SessionInfo, sessionArg: string): bool
 export interface ResolveResumableSessionOptions {
 	/** Search default global session buckets after the active/custom session directory misses. */
 	allowGlobalFallback?: boolean;
+	/**
+	 * Sessions tree to resolve against instead of the active profile's. Redirects
+	 * both the cwd-scoped and all-projects scans to this root so a `--resume`
+	 * target stored under another `--profile` can be found. Defaults to the active
+	 * profile's sessions root.
+	 */
+	sessionsRoot?: string;
 }
 
 function isSessionStorage(value: SessionStorage | ResolveResumableSessionOptions): value is SessionStorage {
@@ -694,7 +709,7 @@ export async function resolveResumableSession(
 ): Promise<ResolvedSessionMatch | undefined> {
 	const storage = isSessionStorage(storageOrOptions) ? storageOrOptions : new FileSessionStorage();
 	const resolvedOptions = isSessionStorage(storageOrOptions) ? options : storageOrOptions;
-	const localSessionDir = sessionDir ?? computeDefaultSessionDir(cwd, storage);
+	const localSessionDir = sessionDir ?? computeDefaultSessionDir(cwd, storage, resolvedOptions.sessionsRoot);
 	const localSessions = await listSessions(localSessionDir, storage);
 	const localMatch = localSessions.find(session => sessionMatchesResumeArg(session, sessionArg));
 	if (localMatch) {
@@ -705,7 +720,7 @@ export async function resolveResumableSession(
 		return undefined;
 	}
 
-	const globalSessions = await listAllSessions(storage);
+	const globalSessions = await listAllSessions(storage, resolvedOptions.sessionsRoot);
 	const globalMatch = globalSessions.find(session => sessionMatchesResumeArg(session, sessionArg));
 	if (!globalMatch) {
 		return undefined;

--- a/packages/coding-agent/test/main-cross-profile-resume.test.ts
+++ b/packages/coding-agent/test/main-cross-profile-resume.test.ts
@@ -1,0 +1,101 @@
+/**
+ * `--session-profile <name>` resolves the `--resume`/`--fork` target from
+ * another profile's session store while the process keeps running the active
+ * profile. Covers the happy path (found in the named profile and opened in
+ * place), the isolation guarantee (not found without the flag), and the
+ * validation that the flag needs a resume/fork target.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Args } from "@oh-my-pi/pi-coding-agent/cli/args";
+import type { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createSessionManager } from "@oh-my-pi/pi-coding-agent/main";
+import { getProfileSessionsDir } from "@oh-my-pi/pi-utils";
+
+const stubSettings = { get: () => undefined } as unknown as Settings;
+
+function buildArgs(overrides: Partial<Args>): Args {
+	return {
+		messages: [],
+		fileArgs: [],
+		unknownFlags: new Map(),
+		unrecognizedFlags: [],
+		...overrides,
+	};
+}
+
+function writeSession(dir: string, id: string, headerCwd: string): string {
+	fs.mkdirSync(dir, { recursive: true });
+	const filePath = path.join(dir, `2025-01-01T00-00-00-000Z_${id}.jsonl`);
+	fs.writeFileSync(
+		filePath,
+		`${[
+			JSON.stringify({ type: "session", id, timestamp: "2025-01-01T00:00:00Z", cwd: headerCwd }),
+			JSON.stringify({
+				type: "message",
+				id: "msg-1",
+				parentId: null,
+				timestamp: "2025-01-01T00:00:01Z",
+				message: { role: "user", content: "hello", timestamp: 1 },
+			}),
+		].join("\n")}\n`,
+	);
+	return filePath;
+}
+
+describe("createSessionManager — --session-profile", () => {
+	const originalHome = process.env.HOME;
+	const id = "019e84ed-b4cc-7000-9c87-5afe6df992c1";
+	let home: string;
+	let projectCwd: string;
+	let foreignFile: string;
+
+	beforeEach(async () => {
+		home = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-home-"));
+		process.env.HOME = home;
+		projectCwd = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-proj-"));
+		// A session that exists only in the "work" profile's session store.
+		foreignFile = writeSession(path.join(getProfileSessionsDir("work"), "-project"), id, projectCwd);
+	});
+
+	afterEach(async () => {
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		await fsp.rm(home, { recursive: true, force: true });
+		await fsp.rm(projectCwd, { recursive: true, force: true });
+	});
+
+	it("resolves and opens a session from the named profile's store", async () => {
+		const result = await createSessionManager(
+			buildArgs({ resume: id.slice(0, 8), sessionProfile: "work" }),
+			projectCwd,
+			stubSettings,
+		);
+
+		if (!result) throw new Error("Expected resumed session manager");
+		try {
+			expect(result.getSessionFile()).toBe(foreignFile);
+			expect(result.getEntries().length).toBeGreaterThan(0);
+		} finally {
+			await result.close();
+		}
+	});
+
+	it("does not find the foreign-profile session without --session-profile", async () => {
+		await expect(
+			createSessionManager(buildArgs({ resume: id.slice(0, 8) }), projectCwd, stubSettings),
+		).rejects.toThrow(/not found/);
+	});
+
+	it("rejects --session-profile without a resume/fork target", async () => {
+		await expect(
+			createSessionManager(buildArgs({ sessionProfile: "work" }), projectCwd, stubSettings),
+		).rejects.toThrow(/session-profile/);
+	});
+});

--- a/packages/coding-agent/test/main-cross-profile-resume.test.ts
+++ b/packages/coding-agent/test/main-cross-profile-resume.test.ts
@@ -98,4 +98,10 @@ describe("createSessionManager — --session-profile", () => {
 			createSessionManager(buildArgs({ sessionProfile: "work" }), projectCwd, stubSettings),
 		).rejects.toThrow(/session-profile/);
 	});
+
+	it("rejects --session-profile with a path-based target", async () => {
+		await expect(
+			createSessionManager(buildArgs({ resume: foreignFile, sessionProfile: "work" }), projectCwd, stubSettings),
+		).rejects.toThrow(/not a path/);
+	});
 });

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -164,6 +164,72 @@ describe("resolveResumableSession", () => {
 	});
 });
 
+describe("resolveResumableSession across profiles", () => {
+	let testAgentDir: string;
+	let foreignRoot: string;
+	let foreignProjectDir: string;
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+	beforeEach(() => {
+		// Point the active profile at an empty store so the default scan misses.
+		testAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-active-profile-"));
+		setAgentDir(testAgentDir);
+		// A separate tree standing in for another profile's sessions root.
+		foreignRoot = fs.mkdtempSync(path.join(os.tmpdir(), "omp-foreign-profile-"));
+		foreignProjectDir = path.join(foreignRoot, "-tmp-project");
+		fs.mkdirSync(foreignProjectDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (originalAgentDir) {
+			setAgentDir(originalAgentDir);
+		} else {
+			setAgentDir(fallbackAgentDir);
+			delete process.env.PI_CODING_AGENT_DIR;
+		}
+		removeSyncWithRetries(testAgentDir);
+		removeSyncWithRetries(foreignRoot);
+	});
+
+	function writeForeignSession(fileName: string, headerCwd: string, id: string): string {
+		const filePath = path.join(foreignProjectDir, fileName);
+		fs.writeFileSync(
+			filePath,
+			`${[
+				JSON.stringify({ type: "session", id, timestamp: "2025-01-01T00:00:00Z", cwd: headerCwd }),
+				JSON.stringify({
+					type: "message",
+					id: "msg-1",
+					parentId: null,
+					timestamp: "2025-01-01T00:00:01Z",
+					message: { role: "user", content: "hello", timestamp: 1 },
+				}),
+			].join("\n")}\n`,
+		);
+		return filePath;
+	}
+
+	it("does not resolve a foreign-profile session without sessionsRoot", async () => {
+		writeForeignSession("2025-01-01_cross.jsonl", "/tmp/project", "crossabcd");
+
+		const match = await resolveResumableSession("crossabcd", "/tmp/project");
+
+		expect(match).toBeUndefined();
+	});
+
+	it("resolves a foreign-profile session when sessionsRoot targets that profile", async () => {
+		const filePath = writeForeignSession("2025-01-01_cross.jsonl", "/tmp/project", "crossabcd");
+
+		const match = await resolveResumableSession("crossabcd", "/tmp/project", undefined, {
+			sessionsRoot: foreignRoot,
+		});
+
+		expect(match?.session.id).toBe("crossabcd");
+		expect(match?.session.path).toBe(filePath);
+	});
+});
+
 describe("SessionManager temp cwd session dirs", () => {
 	let testAgentDir: string;
 	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -228,6 +228,19 @@ describe("resolveResumableSession across profiles", () => {
 		expect(match?.session.id).toBe("crossabcd");
 		expect(match?.session.path).toBe(filePath);
 	});
+
+	it("does not create or mutate the foreign profile's tree on lookup", async () => {
+		writeForeignSession("2025-01-01_cross.jsonl", "/tmp/project", "crossabcd");
+		const before = fs.readdirSync(foreignRoot).sort();
+
+		// A miss must not ensureDir/migrate a cwd-scoped directory in the foreign tree.
+		const miss = await resolveResumableSession("nomatch", "/tmp/some-other-cwd", undefined, {
+			sessionsRoot: foreignRoot,
+		});
+
+		expect(miss).toBeUndefined();
+		expect(fs.readdirSync(foreignRoot).sort()).toEqual(before);
+	});
 });
 
 describe("SessionManager temp cwd session dirs", () => {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `getProfileSessionsDir(profile)` to resolve a named profile's sessions directory without activating it (XDG-aware, mirrors `getSessionsDir` for the active profile), supporting cross-profile session lookups ([#7565](https://github.com/can1357/oh-my-pi/pull/7565) by [@thekidnamedkd](https://github.com/thekidnamedkd)).
+
 ## [17.2.6] - 2026-08-03
 
 ### Added

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -489,6 +489,15 @@ export function getActiveProfile(): string | undefined {
 export function getProfileRootDir(profile: string | undefined): string {
 	return getProfileConfigRoot(normalizeProfileName(profile));
 }
+/**
+ * Resolve a profile's sessions directory without activating it. Mirrors
+ * {@link getSessionsDir} for the active profile, including the XDG data-category
+ * routing a named profile would use if it were the active one, so cross-profile
+ * session lookups target the same tree that profile writes to.
+ */
+export function getProfileSessionsDir(profile: string | undefined): string {
+	return new DirResolver({ profile: normalizeProfileName(profile) }).agentSubdir(undefined, "sessions", "data");
+}
 /** Get the agent config directory (~/.omp/agent). */
 export function getAgentDir(): string {
 	return dirs.agentDir;


### PR DESCRIPTION
--session-profile resumes a session under a different profile than the one it started in: same conversation, the new profile's providers, routing, and roles. OMP already wires routing and roles per profile, so a few profiles work as daily drivers, say open weights on BYOK and frontier-model subs. Moving a live session between them takes one flag instead of a config rebuild, so you can swap providers or roles mid-session, or move onto fresh keys when a quota runs out. Default resume is unchanged unless you pass the flag.

## What

Adds `--session-profile <name>`: resolve the `--resume`/`--fork` target from another profile's session store while the process keeps running the active profile's config. Opt-in; default resolution is unchanged when the flag is omitted.

```
omp --profile work --resume <id-from-personal> --session-profile personal
```

## Why

Sessions are profile-scoped (`~/.omp/profiles/<name>/agent/sessions`), and `--profile` is applied at bootstrap before resume resolution, so `omp --profile B --resume <id-from-A>` can't find A's session; the two flags don't compose today. This makes the combination first-class without weakening isolation: the lookup is read-only, so the other profile's tree is never created or mutated, and the resumed session still runs under the active profile.

Context: profiles are a `DirResolver` base with no registry (#5949). Related asks: #5379 (foreign-CLI session import), #6458 (reload config across sessions).

## How

- `getProfileSessionsDir(profile)` in `packages/utils/src/dirs.ts` resolves a profile's sessions tree without activating it (XDG-aware, mirrors `getSessionsDir` for the active profile).
- `resolveResumableSession` takes an optional `sessionsRoot`. For a foreign profile it resolves read-only through the all-projects glob, skipping the cwd-scoped pass that would `ensureDir`/migrate inside the other profile's tree.
- `--session-profile` is wired through `args.ts`, `flag-tables.ts` (the shared table the profile bootstrap reads, so it never mis-consumes an adjacent `--profile`), and `launch-help.ts`. It errors when set without a `--resume`/`--fork` target, or with a path target since a path already names a file.
- The resumed session opens in place, in its own profile's tree.

Scope is intentionally narrow and opt-in: value-based `--resume <ref>` / `--fork <ref>` only. The valueless `--resume` picker and in-session `/resume` are unchanged, as a natural follow-up. Happy to move this to a Discord discussion first if you'd rather treat it as a larger change.

## Testing

- `bun run check` passes (biome + tsgo) for `packages/coding-agent` and `packages/utils`.
- `bun test`:
  - `test/session-manager/file-operations.test.ts`: cross-profile cases covering a foreign session invisible without `sessionsRoot`, resolvable with it, and a miss leaving the foreign tree untouched (19 pass).
  - `test/main-cross-profile-resume.test.ts`: `createSessionManager` opens the named profile's session end to end, isolation holds without the flag, and the flag errors on a missing or path-based target (4 pass).
  - Adjacent regressions green: `main-cross-project-resume`, `slash-commands/resume`, `main-session-resolution-error` (20 pass).
- Manual, exact combination end to end:
  - `extractProfileFlags(["--profile","B","--session-profile","work","--resume","<id>"])` gives profile `B`, and the residual parses to `sessionProfile:"work"` + `resume:"<id>"`.
  - `--session-profile` shows up in `omp launch --help`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
