### PR TITLE
feat(providers): add Kyma

### DIFF
--- a/packages/ai/src/registry/kyma.ts
+++ b/packages/ai/src/registry/kyma.ts
@@ -1,0 +1,6 @@
+import type { ProviderDefinition } from "./types";
+
+export const kymaProvider = {
+	id: "kyma",
+	name: "Kyma",
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -30,6 +30,7 @@ import { huggingfaceProvider } from "./huggingface";
 import { kagiProvider } from "./kagi";
 import { kiloProvider } from "./kilo";
 import { kimiCodeProvider } from "./kimi-code";
+import { kymaProvider } from "./kyma";
 import { litellmProvider } from "./litellm";
 import { llamaCppProvider } from "./llama-cpp";
 import { lmStudioProvider } from "./lm-studio";
@@ -90,6 +91,7 @@ const ALL = [
 	zaiProvider,
 	zaiCodingPlanProvider,
 	kimiCodeProvider,
+	kymaProvider,
 	openrouterProvider,
 	githubCopilotProvider,
 	cursorProvider,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -39941,6 +39941,1018 @@
 			"supportsComputerUseConfig": false
 		}
 	},
+	"kyma": {
+		"llama-4-maverick": {
+			"id": "llama-4-maverick",
+			"name": "Llama 4 Maverick",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.27,
+				"output": 1.08,
+				"cacheRead": 0.027,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 16384,
+			"supportsComputerUse": false
+		},
+		"muse-spark-1.1": {
+			"id": "muse-spark-1.1",
+			"name": "Muse Spark 1.1",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.688,
+				"output": 5.738,
+				"cacheRead": 0.1688,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"grok-4.20": {
+			"id": "grok-4.20",
+			"name": "Grok 4.20",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.688,
+				"output": 3.375,
+				"cacheRead": 0.1688,
+				"cacheWrite": 0
+			},
+			"contextWindow": 2000000,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.7,
+				"output": 8.1,
+				"cacheRead": 0.27,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-pro": {
+			"id": "gpt-5.6-sol-pro",
+			"name": "GPT-5.6 Sol Pro",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 6.75,
+				"output": 40.5,
+				"cacheRead": 0.675,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol": {
+			"id": "gpt-5.6-sol",
+			"name": "GPT-5.6 Sol",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 6.75,
+				"output": 40.5,
+				"cacheRead": 0.675,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-pro": {
+			"id": "gpt-5.6-terra-pro",
+			"name": "GPT-5.6 Terra Pro",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.35,
+				"output": 8.1,
+				"cacheRead": 0.135,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna-pro": {
+			"id": "gpt-5.6-luna-pro",
+			"name": "GPT-5.6 Luna Pro",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.135,
+				"output": 0.81,
+				"cacheRead": 0.0135,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna": {
+			"id": "gpt-5.6-luna",
+			"name": "GPT-5.6 Luna",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1373,
+				"output": 0.8231,
+				"cacheRead": 0.01373,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"supportsComputerUse": false
+		},
+		"claude-sonnet-5": {
+			"id": "claude-sonnet-5",
+			"name": "Claude Sonnet 5",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.7,
+				"output": 13.5,
+				"cacheRead": 0.27,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"supportsComputerUse": false
+		},
+		"claude-opus-5-fast": {
+			"id": "claude-opus-5-fast",
+			"name": "Claude Opus 5 Fast",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 13.5,
+				"output": 67.5,
+				"cacheRead": 1.35,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"supportsComputerUse": false
+		},
+		"claude-opus-5": {
+			"id": "claude-opus-5",
+			"name": "Claude Opus 5",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 6.75,
+				"output": 33.75,
+				"cacheRead": 0.675,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra": {
+			"id": "gpt-5.6-terra",
+			"name": "GPT-5.6 Terra",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.443,
+				"output": 8.656,
+				"cacheRead": 0.1443,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"qwen3.7-flash": {
+			"id": "qwen3.7-flash",
+			"name": "Qwen 3.7 Flash",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.0458,
+				"output": 0.1987,
+				"cacheRead": 0.00458,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"gemini-3.5-flash-lite": {
+			"id": "gemini-3.5-flash-lite",
+			"name": "Gemini 3.5 Flash Lite",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.405,
+				"output": 3.375,
+				"cacheRead": 0.0405,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"gemini-3.6-flash": {
+			"id": "gemini-3.6-flash",
+			"name": "Gemini 3.6 Flash",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.025,
+				"output": 10.125,
+				"cacheRead": 0.2025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"kimi-k3": {
+			"id": "kimi-k3",
+			"name": "Kimi K3",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 4.05,
+				"output": 20.25,
+				"cacheRead": 0.405,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"qwen-3.7-max": {
+			"id": "qwen-3.7-max",
+			"name": "Qwen 3.7 Max",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 2.56,
+				"output": 7.676,
+				"cacheRead": 0.256,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"qwen-3.6-plus": {
+			"id": "qwen-3.6-plus",
+			"name": "Qwen 3.6 Plus",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.4388,
+				"output": 2.633,
+				"cacheRead": 0.04388,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"qwen-3.7-plus": {
+			"id": "qwen-3.7-plus",
+			"name": "Qwen 3.7 Plus",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4482,
+				"output": 1.793,
+				"cacheRead": 0.04482,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"qwen-3-coder": {
+			"id": "qwen-3-coder",
+			"name": "Qwen 3 Coder",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.297,
+				"output": 1.35,
+				"cacheRead": 0.0297,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"qwen-3-32b": {
+			"id": "qwen-3-32b",
+			"name": "Qwen 3 32B",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.108,
+				"output": 0.378,
+				"cacheRead": 0.0108,
+				"cacheWrite": 0
+			},
+			"contextWindow": 32768,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"gemma-4-31b": {
+			"id": "gemma-4-31b",
+			"name": "Gemma 4 31B",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.0702,
+				"output": 0.2006,
+				"cacheRead": 0.00702,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"minimax-m2.5": {
+			"id": "minimax-m2.5",
+			"name": "MiniMax M2.5",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.3826,
+				"output": 1.346,
+				"cacheRead": 0.03826,
+				"cacheWrite": 0
+			},
+			"contextWindow": 196608,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"minimax-m3": {
+			"id": "minimax-m3",
+			"name": "MiniMax M3",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3852,
+				"output": 1.54,
+				"cacheRead": 0.03852,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"deepseek-v4-pro": {
+			"id": "deepseek-v4-pro",
+			"name": "DeepSeek V4 Pro",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.6901,
+				"output": 1.38,
+				"cacheRead": 0.06901,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"supportsComputerUse": false
+		},
+		"deepseek-v4-flash": {
+			"id": "deepseek-v4-flash",
+			"name": "DeepSeek V4 Flash",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.187,
+				"output": 0.3741,
+				"cacheRead": 0.0187,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"supportsComputerUse": false
+		},
+		"deepseek-v3": {
+			"id": "deepseek-v3",
+			"name": "DeepSeek V3",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.351,
+				"output": 0.513,
+				"cacheRead": 0.0351,
+				"cacheWrite": 0
+			},
+			"contextWindow": 160000,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"deepseek-r1": {
+			"id": "deepseek-r1",
+			"name": "DeepSeek R1",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.7309,
+				"output": 2.957,
+				"cacheRead": 0.07309,
+				"cacheWrite": 0
+			},
+			"contextWindow": 64000,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"gemini-3.5-flash": {
+			"id": "gemini-3.5-flash",
+			"name": "Gemini 3.5 Flash",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.025,
+				"output": 12.15,
+				"cacheRead": 0.2025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"gemini-2.5-flash": {
+			"id": "gemini-2.5-flash",
+			"name": "Gemini 2.5 Flash",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.405,
+				"output": 3.375,
+				"cacheRead": 0.0405,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"gemini-3-flash": {
+			"id": "gemini-3-flash",
+			"name": "Gemini 3 Flash",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.675,
+				"output": 4.05,
+				"cacheRead": 0.0675,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"llama-3.3-70b": {
+			"id": "llama-3.3-70b",
+			"name": "Llama 3.3 70B",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.135,
+				"output": 0.432,
+				"cacheRead": 0.0135,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"gpt-oss-120b": {
+			"id": "gpt-oss-120b",
+			"name": "GPT-OSS 120B",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.0527,
+				"output": 0.2565,
+				"cacheRead": 0.00527,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"nemotron-3-ultra-550b": {
+			"id": "nemotron-3-ultra-550b",
+			"name": "Nemotron 3 Ultra 550B",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.675,
+				"output": 3.375,
+				"cacheRead": 0.0675,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"step-3.7-flash": {
+			"id": "step-3.7-flash",
+			"name": "Step 3.7 Flash",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.27,
+				"output": 1.553,
+				"cacheRead": 0.027,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"kimi-k2.7-code": {
+			"id": "kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.009,
+				"output": 4.774,
+				"cacheRead": 0.1009,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"supportsComputerUse": false
+		},
+		"kimi-k2.6": {
+			"id": "kimi-k2.6",
+			"name": "Kimi K2.6",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.776,
+				"output": 3.622,
+				"cacheRead": 0.0776,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"kimi-k2.5": {
+			"id": "kimi-k2.5",
+			"name": "Kimi K2.5",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6075,
+				"output": 3.038,
+				"cacheRead": 0.06075,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-7": {
+			"id": "claude-opus-4-7",
+			"name": "Claude Opus 4.7",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 6.75,
+				"output": 33.75,
+				"cacheRead": 0.675,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"supportsComputerUse": false
+		},
+		"claude-sonnet-4-6": {
+			"id": "claude-sonnet-4-6",
+			"name": "Claude Sonnet 4.6",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 4.05,
+				"output": 20.25,
+				"cacheRead": 0.405,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"supportsComputerUse": false
+		},
+		"claude-haiku-4-5": {
+			"id": "claude-haiku-4-5",
+			"name": "Claude Haiku 4.5",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.35,
+				"output": 6.75,
+				"cacheRead": 0.135,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"supportsComputerUse": false
+		},
+		"minimax-m2.7": {
+			"id": "minimax-m2.7",
+			"name": "MiniMax M2.7",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.405,
+				"output": 1.62,
+				"cacheRead": 0.0405,
+				"cacheWrite": 0
+			},
+			"contextWindow": 204800,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"glm-5.2": {
+			"id": "glm-5.2",
+			"name": "GLM 5.2",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.459,
+				"output": 4.984,
+				"cacheRead": 0.1459,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"supportsComputerUse": false
+		},
+		"glm-5.1": {
+			"id": "glm-5.1",
+			"name": "GLM 5.1",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.89,
+				"output": 5.94,
+				"cacheRead": 0.189,
+				"cacheWrite": 0
+			},
+			"contextWindow": 203000,
+			"maxTokens": 65536,
+			"supportsComputerUse": false
+		},
+		"glm-4.5-air": {
+			"id": "glm-4.5-air",
+			"name": "GLM 4.5 Air",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.176,
+				"output": 1.148,
+				"cacheRead": 0.0176,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
+		},
+		"glm-4.7-flash": {
+			"id": "glm-4.7-flash",
+			"name": "GLM 4.7 Flash",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.081,
+				"output": 0.54,
+				"cacheRead": 0.0081,
+				"cacheWrite": 0
+			},
+			"contextWindow": 203000,
+			"maxTokens": 65536,
+			"supportsComputerUse": false
+		},
+		"grok-4.3": {
+			"id": "grok-4.3",
+			"name": "Grok 4.3",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.688,
+				"output": 3.375,
+				"cacheRead": 0.1688,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"grok-build": {
+			"id": "grok-build",
+			"name": "Grok Build",
+			"api": "openai-completions",
+			"provider": "kyma",
+			"baseUrl": "https://kymaapi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.389,
+				"output": 2.777,
+				"cacheRead": 0.1389,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		}
+	},
 	"meta": {
 		"muse-spark-1.1": {
 			"id": "muse-spark-1.1",

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -28,6 +28,7 @@ import {
 	huggingfaceModelManagerOptions,
 	kiloModelManagerOptions,
 	kimiCodeModelManagerOptions,
+	kymaModelManagerOptions,
 	litellmModelManagerOptions,
 	lmStudioModelManagerOptions,
 	metaModelManagerOptions,
@@ -302,6 +303,16 @@ export const CATALOG_PROVIDERS = [
 		envVars: ["MOONSHOT_API_KEY", "KIMI_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => moonshotModelManagerOptions(config),
 		catalogDiscovery: { label: "Moonshot" },
+	},
+	{
+		id: "kyma",
+		defaultModel: "claude-sonnet-5",
+		envVars: ["KYMA_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => kymaModelManagerOptions(config),
+		// The gateway's /v1/models is the source of truth for what it serves and
+		// what it charges; a bundled snapshot of it would be wrong within weeks.
+		dynamicModelsAuthoritative: true,
+		catalogDiscovery: { label: "Kyma" },
 	},
 	{
 		id: "nanogpt",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1085,6 +1085,19 @@ export interface NvidiaModelManagerConfig {
 	fetch?: FetchImpl;
 }
 
+// ---------------------------------------------------------------------------
+// Kyma
+
+export interface KymaModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+export function kymaModelManagerOptions(config?: KymaModelManagerConfig): ModelManagerOptions<"openai-completions"> {
+	return createSimpleOpenAICompletionsOptions("kyma", "https://kymaapi.com/v1", config);
+}
+
 export function nvidiaModelManagerOptions(
 	config?: NvidiaModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {


### PR DESCRIPTION
Kyma is an OpenAI-compatible gateway (`https://kymaapi.com/v1`, API-key only, no OAuth). This follows `docs/adding-a-provider.md` for the simple gateway case — one catalog entry, one registry def, one registry line — plus the generated bundle section.

| File | Change |
|---|---|
| `packages/catalog/src/provider-models/openai-compat.ts` | factory via the documented `createSimpleOpenAICompletionsOptions` helper |
| `packages/catalog/src/provider-models/descriptors.ts` | one `CATALOG_PROVIDERS` entry |
| `packages/ai/src/registry/kyma.ts` | env-key-only `ProviderDefinition`, no login flow |
| `packages/ai/src/registry/registry.ts` | one import, one `ALL` entry |
| `packages/catalog/src/models.json` | 49 models |

`dynamicModelsAuthoritative: true` because the gateway's `/v1/models` is the source of truth for what it serves and what it charges — a bundled snapshot alone goes stale within weeks.

## What I exercised

- `bun run check:tools` — clean
- `bun run check:ts` — clean. It was **failing** before the `models.json` section was added, which is the non-obvious part of this change: `GeneratedProvider` is `keyof typeof MODELS`, so `createSimpleOpenAICompletionsOptions` rejects a provider id that exists in `CATALOG_PROVIDERS` but not in the bundle. Worth knowing for anyone following the doc.
- The 49 entries were generated from the live `/v1/models`, not typed by hand. All carry `provider: "kyma"` and `api: "openai-completions"`; none malformed.
- The declared `defaultModel` `claude-sonnet-5` answers a real chat completion (`200`) at the context window and price recorded in the bundle.

## What I could not do, honestly

**I could not run the binary.** `bun run gen:models` and any runtime import of the catalog fail on this machine with `Failed to load pi_natives native addon for darwin-arm64`. So the bundle section was written directly in the documented shape rather than emitted by your generator.

Re-running `gen:models` where the natives are built should be a no-op against this. If it isn't, the generator's output should win over mine — happy to push whatever it produces.

I noted the PR gate is temporarily open; if a vouch is still preferred for this, say so and I'll wait rather than push.