### PR TITLE
fix(coding-agent/hindsight): route recall through single injection path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Hindsight `autoRecall` intermittently not reaching the model: two recall paths shared the `hasRecalledForFirstTurn` flag, and the `agent_start` event path could consume it first and inject only via an unawaited background prompt rebuild that a fast turn outran. `beforeAgentStartPrompt` (awaited before the turn builds) is now the sole injection path ([#7568](https://github.com/can1357/oh-my-pi/issues/7568)).
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -411,24 +411,6 @@ export class HindsightSessionState {
 		}
 	}
 
-	async maybeRecallOnAgentStart(): Promise<void> {
-		if (!this.config.autoRecall || this.hasRecalledForFirstTurn) return;
-		const messages = extractMessages(this.session.sessionManager);
-		const lastUser = messages.findLast(m => m.role === "user");
-		if (!lastUser) return;
-
-		const query = composeRecallQuery(lastUser.content, messages, this.config.recallContextTurns);
-		const truncated = truncateRecallQuery(query, lastUser.content, this.config.recallMaxQueryChars);
-		const { context, ok } = await this.recallForContext(truncated);
-		if (!ok) return;
-
-		this.hasRecalledForFirstTurn = true;
-		if (!context) return;
-
-		this.lastRecallSnippet = context;
-		await this.#refreshBaseSystemPromptAfter("recall");
-	}
-
 	async beforeAgentStartPrompt(promptText: string): Promise<string | undefined> {
 		if (this.config.mentalModelsEnabled && this.mentalModelsLoadPromise && this.mentalModelsLoadedAt === undefined) {
 			await Promise.race([this.mentalModelsLoadPromise, Bun.sleep(MENTAL_MODEL_FIRST_TURN_DEADLINE_MS)]);
@@ -509,9 +491,7 @@ export class HindsightSessionState {
 	attachSessionListeners(): void {
 		this.unsubscribe?.();
 		this.unsubscribe = this.session.subscribe(event => {
-			if (event.type === "agent_start") {
-				void this.maybeRecallOnAgentStart();
-			} else if (event.type === "agent_end") {
+			if (event.type === "agent_end") {
 				void this.maybeRetainOnAgentEnd();
 				// Drain any queued tool-initiated retain calls now that the turn
 				// is settled. The queue is also debounced/size-bounded, but
@@ -540,7 +520,7 @@ export class HindsightSessionState {
 		this.retainQueue.dispose();
 	}
 
-	async #refreshBaseSystemPromptAfter(reason: "recall" | "MM load" | "MM reload" | "MM TTL reload"): Promise<void> {
+	async #refreshBaseSystemPromptAfter(reason: "MM load" | "MM reload" | "MM TTL reload"): Promise<void> {
 		try {
 			await this.session.refreshBaseSystemPrompt();
 		} catch (err) {

--- a/packages/coding-agent/test/hindsight-backend.test.ts
+++ b/packages/coding-agent/test/hindsight-backend.test.ts
@@ -338,6 +338,42 @@ describe("hindsightBackend first-turn injection", () => {
 		expect(session.getHindsightSessionState()?.lastRecallSnippet).toBe(block);
 	});
 
+	it("does not let agent_start preempt first-turn recall injection", async () => {
+		const settings = Settings.isolated({
+			"memory.backend": "hindsight",
+			"hindsight.apiUrl": "http://localhost:8888",
+		});
+		const session = makeFakeSession({
+			sessionId: "s-race",
+			entries: [{ role: "user", text: "What is the canary phrase?" }],
+		});
+		await hindsightBackend.start({
+			session: session as never,
+			settings,
+			modelRegistry: {} as never,
+			agentDir: "/tmp",
+			taskDepth: 0,
+		});
+
+		vi.spyOn(HindsightApi.prototype, "recall").mockResolvedValue({
+			results: [{ id: "1", text: "The canary phrase is PURPLE-OTTER-9931." }],
+		} as never);
+
+		// The agent loop fires agent_start once the turn begins. This must NOT run
+		// its own recall: doing so consumed the shared first-turn flag and left
+		// injection to a racing background prompt rebuild that a fast turn outran,
+		// dropping recalled memory from the model's prompt (#7568).
+		session.emit({ type: "agent_start" });
+		for (let i = 0; i < 50; i++) await Promise.resolve();
+
+		expect(session.getHindsightSessionState()?.hasRecalledForFirstTurn).toBe(false);
+
+		// beforeAgentStartPrompt is the sole, awaited injection path.
+		const block = await hindsightBackend.beforeAgentStartPrompt?.(session as never, "What is the canary phrase?");
+		expect(block).toContain("PURPLE-OTTER-9931");
+		expect(session.getHindsightSessionState()?.hasRecalledForFirstTurn).toBe(true);
+	});
+
 	it("keeps the <memories> wrapper in buildDeveloperInstructions", async () => {
 		const settings = Settings.isolated({
 			"memory.backend": "hindsight",


### PR DESCRIPTION
## Repro
With `memory.backend: hindsight` and `hindsight.autoRecall: true`, the server completes recall and returns facts, but the model intermittently answers as if it has no memory (e.g. `No canary phrase exists.` for a retained `world` fact). Reproduced in-process: emitting the turn's `agent_start` event before `beforeAgentStartPrompt` runs consumes the shared first-turn recall flag, so the awaited injection path returns nothing.

```
bun test test/hindsight-backend.test.ts -t "does not let agent_start preempt"
# before fix: expected hasRecalledForFirstTurn=false, received true — 0 pass / 1 fail
```

## Cause
`packages/coding-agent/src/hindsight/state.ts` had two recall paths sharing `hasRecalledForFirstTurn`:
- `maybeRecallOnAgentStart()` — subscribed to `agent_start`, invoked fire-and-forget (`void`); sets the flag then triggers an **unawaited** `#refreshBaseSystemPromptAfter("recall")` background rebuild.
- `beforeAgentStartPrompt()` — **awaited** at `agent-session.ts:5275` before the turn builds; returns the context that `buildSystemPromptForAgentStart` bakes into the prompt.

When the event path won and set the flag first, `beforeAgentStartPrompt` returned `undefined`, so the snippet reached the prompt only if the unawaited background rebuild had already finished — on a fast turn it had not, dropping recall (intermittent). The dual path dates to `0e761ef9e`.

## Fix
- Remove `maybeRecallOnAgentStart()` and the `agent_start` recall branch in `attachSessionListeners()`; the subscription keeps its `agent_end` retain/flush work.
- `beforeAgentStartPrompt()` (awaited, synchronous with prompt construction) is now the sole injection path — no shared-flag race, no unawaited background rebuild.
- Narrow `#refreshBaseSystemPromptAfter` reason type to the remaining mental-model callers.
- Add a regression test asserting `agent_start` does not consume the first-turn flag and that `beforeAgentStartPrompt` still injects.

(mnemopi is a separate single-path design and is unaffected.)

## Verification
`bun test test/hindsight-backend.test.ts` — 26 pass. `bun test test/agent-session-message-pipeline.test.ts` — 22 pass. The new regression test fails on the pre-fix code and passes after.

Fixes #7568