### PR TITLE
fix(tui): use Kitty flag 1 on Windows to fix Shift+letter input

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Shift+letter and shifted symbol input (capital letters, `?`, `!`, etc.) being silently dropped on Windows and WSL terminals using ConPTY (e.g. WezTerm stable) by avoiding Kitty keyboard protocol flag 4 in that context.
+
 ## [17.2.5] - 2026-08-03
 
 ### Fixed

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -307,32 +307,6 @@ const KITTY_MOD_CTRL = 4;
 const KITTY_MOD_SUPER = 8;
 const KITTY_MOD_NUM_LOCK = 128;
 const KITTY_LOCK_MASK = 64 + KITTY_MOD_NUM_LOCK; // Caps Lock + Num Lock
-const SHIFT_MAP: Record<number, number> = {
-	// US layout: unshifted codepoint → shifted codepoint
-	// digits
-	48: 41, // 0 → )
-	49: 33, // 1 → !
-	50: 64, // 2 → @
-	51: 35, // 3 → #
-	52: 36, // 4 → $
-	53: 37, // 5 → %
-	54: 94, // 6 → ^
-	55: 38, // 7 → &
-	56: 42, // 8 → *
-	57: 40, // 9 → (
-	// symbols
-	45: 95, // - → _
-	61: 43, // = → +
-	91: 123, // [ → {
-	93: 125, // ] → }
-	92: 124, // \ → |
-	59: 58, // ; → :
-	39: 34, // ' → "
-	96: 126, // ` → ~
-	44: 60, // , → <
-	46: 62, // . → >
-	47: 63, // / → ?
-};
 const MODIFY_OTHER_KEYS_PATTERN = /^\x1b\[27;(\d+);(\d+)~$/;
 const KITTY_KEYPAD_OPERATOR_TEXT: Record<number, string> = {
 	57410: "/",
@@ -456,15 +430,8 @@ function decodeKittyPrintable(data: string): string | undefined {
 	}
 
 	let effectiveCodepoint = codepoint;
-	if (effectiveMod & KITTY_MOD_SHIFT) {
-		if (typeof shiftedKey === "number") {
-			effectiveCodepoint = shiftedKey;
-		} else if (codepoint >= 97 && codepoint <= 122) {
-			effectiveCodepoint = codepoint - 32;
-		} else {
-			const shifted = SHIFT_MAP[codepoint];
-			if (shifted !== undefined) effectiveCodepoint = shifted;
-		}
+	if (effectiveMod & KITTY_MOD_SHIFT && typeof shiftedKey === "number") {
+		effectiveCodepoint = shiftedKey;
 	}
 
 	if (effectiveCodepoint >= 0xe000 && effectiveCodepoint <= 0xf8ff) {

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -307,6 +307,32 @@ const KITTY_MOD_CTRL = 4;
 const KITTY_MOD_SUPER = 8;
 const KITTY_MOD_NUM_LOCK = 128;
 const KITTY_LOCK_MASK = 64 + KITTY_MOD_NUM_LOCK; // Caps Lock + Num Lock
+const SHIFT_MAP: Record<number, number> = {
+	// US layout: unshifted codepoint → shifted codepoint
+	// digits
+	48: 41, // 0 → )
+	49: 33, // 1 → !
+	50: 64, // 2 → @
+	51: 35, // 3 → #
+	52: 36, // 4 → $
+	53: 37, // 5 → %
+	54: 94, // 6 → ^
+	55: 38, // 7 → &
+	56: 42, // 8 → *
+	57: 40, // 9 → (
+	// symbols
+	45: 95, // - → _
+	61: 43, // = → +
+	91: 123, // [ → {
+	93: 125, // ] → }
+	92: 124, // \ → |
+	59: 58, // ; → :
+	39: 34, // ' → "
+	96: 126, // ` → ~
+	44: 60, // , → <
+	46: 62, // . → >
+	47: 63, // / → ?
+};
 const MODIFY_OTHER_KEYS_PATTERN = /^\x1b\[27;(\d+);(\d+)~$/;
 const KITTY_KEYPAD_OPERATOR_TEXT: Record<number, string> = {
 	57410: "/",
@@ -430,8 +456,15 @@ function decodeKittyPrintable(data: string): string | undefined {
 	}
 
 	let effectiveCodepoint = codepoint;
-	if (effectiveMod & KITTY_MOD_SHIFT && typeof shiftedKey === "number") {
-		effectiveCodepoint = shiftedKey;
+	if (effectiveMod & KITTY_MOD_SHIFT) {
+		if (typeof shiftedKey === "number") {
+			effectiveCodepoint = shiftedKey;
+		} else if (codepoint >= 97 && codepoint <= 122) {
+			effectiveCodepoint = codepoint - 32;
+		} else {
+			const shifted = SHIFT_MAP[codepoint];
+			if (shifted !== undefined) effectiveCodepoint = shifted;
+		}
 	}
 
 	if (effectiveCodepoint >= 0xe000 && effectiveCodepoint <= 0xf8ff) {

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1100,9 +1100,9 @@ export class ProcessTerminal implements Terminal {
 				const reportedFlags = parseInt(match[1]!, 10);
 				this.#kittyProtocolActive = true;
 				setKittyProtocolActive(true);
-				if (process.platform === "win32") {
-					// WezTerm/ConPTY on Windows drops Shift+letter keypresses entirely
-					// when flag 4 (report alternate keys) is set. Use flag 1
+				if (isConPTYHosted()) {
+					// ConPTY (native Windows and WSL) drops Shift+letter keypresses
+					// entirely when flag 4 (report alternate keys) is set. Use flag 1
 					// (disambiguate only), preserving flag 2 if already active.
 					this.#kittyEnableSeq = (reportedFlags & 2) !== 0 ? "\x1b[>3u" : "\x1b[>1u";
 					this.#safeWrite(this.#kittyEnableSeq);

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1105,6 +1105,12 @@ export class ProcessTerminal implements Terminal {
 					// Push level-2 to keep its shortcuts reporting consistently.
 					this.#kittyEnableSeq = "\x1b[>7u";
 					this.#safeWrite(this.#kittyEnableSeq);
+				} else if (process.platform === "win32") {
+					// WezTerm/ConPTY on Windows drops Shift+letter keypresses entirely
+					// when flag 4 (report alternate keys) is set. Use flag 1
+					// (disambiguate only) to keep shifted printable keys working.
+					this.#kittyEnableSeq = "\x1b[>1u";
+					this.#safeWrite(this.#kittyEnableSeq);
 				} else {
 					// Disambiguate escape codes and report base-layout keys for physical
 					// shortcut matching, without event reporting that caused regression #3259.

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1100,16 +1100,16 @@ export class ProcessTerminal implements Terminal {
 				const reportedFlags = parseInt(match[1]!, 10);
 				this.#kittyProtocolActive = true;
 				setKittyProtocolActive(true);
-				if ((reportedFlags & 2) !== 0) {
+				if (process.platform === "win32") {
+					// WezTerm/ConPTY on Windows drops Shift+letter keypresses entirely
+					// when flag 4 (report alternate keys) is set. Use flag 1
+					// (disambiguate only), preserving flag 2 if already active.
+					this.#kittyEnableSeq = (reportedFlags & 2) !== 0 ? "\x1b[>3u" : "\x1b[>1u";
+					this.#safeWrite(this.#kittyEnableSeq);
+				} else if ((reportedFlags & 2) !== 0) {
 					// Preserve event-type reporting already enabled by a parent app.
 					// Push level-2 to keep its shortcuts reporting consistently.
 					this.#kittyEnableSeq = "\x1b[>7u";
-					this.#safeWrite(this.#kittyEnableSeq);
-				} else if (process.platform === "win32") {
-					// WezTerm/ConPTY on Windows drops Shift+letter keypresses entirely
-					// when flag 4 (report alternate keys) is set. Use flag 1
-					// (disambiguate only) to keep shifted printable keys working.
-					this.#kittyEnableSeq = "\x1b[>1u";
 					this.#safeWrite(this.#kittyEnableSeq);
 				} else {
 					// Disambiguate escape codes and report base-layout keys for physical


### PR DESCRIPTION
## What

Use the `isConPTYHosted()` predicate to select Kitty keyboard protocol flag 1 (disambiguate only) on ConPTY-hosted terminals (Windows and WSL) instead of flag 5 (disambiguate + report alternate keys).

## Why

Commit `422aeeea4` changed the Kitty protocol flags from 1 to 5 to enable base-layout key reporting for physical shortcut matching. On ConPTY-hosted terminals (Windows native and WSL under WezTerm stable), flag 4 (report alternate keys) causes Shift+letter keypresses to be silently dropped -- the keypress never reaches the application's stdin. This makes it impossible to type capital letters, `?`, `!`, or any other Shift+symbol character.

Flag 1 (disambiguate only) works correctly: shifted printable keys are delivered as raw characters (e.g., `A` for Shift+A) rather than being silently eaten.

Note: WezTerm nightly appears to fix this on their side, but the stable release (20240203) is affected. The flag 1 fallback on ConPTY protects users on older WezTerm versions and potentially other ConPTY-based terminals.

## Testing

Tested locally on Windows 11 + WezTerm stable: capital letters, `?`, `!`, and other shifted symbols all work. Ctrl+C and other modifier combos unaffected.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)