### PR TITLE
fix(tui): close open inline styles at wrapped table-cell line ends

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed markdown table borders inheriting an inline code (or bold/italic) color when a cell wraps mid-span; wrapped cell lines now close any open foreground/bold/italic before the border glyph ([#7575](https://github.com/can1357/oh-my-pi/issues/7575)).
+
 ## [17.2.5] - 2026-08-03
 
 ### Fixed

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -324,6 +324,84 @@ function compactSgrCarry(carry: string): string {
 	return cut === -1 ? carry : carry.slice(cut);
 }
 
+// Closers for the inline attributes a wrapped table-cell line can leave open.
+// Background is deliberately preserved (no `49`/`0`) so an outer
+// message-background pass keeps its fill; only foreground color and the
+// bold/dim + italic attributes that would tint or embolden the following border
+// glyph are cleared.
+const CELL_STYLE_FG_RESET = "\x1b[39m";
+const CELL_STYLE_WEIGHT_RESET = "\x1b[22m";
+const CELL_STYLE_ITALIC_RESET = "\x1b[23m";
+
+/**
+ * Terminate a wrapped table-cell line so its trailing border glyph, padding,
+ * and every cell to its right never inherit an inline style left open mid-cell.
+ *
+ * `wrapTextWithAnsi` keeps foreground/bold/italic open across wrapped line ends
+ * by design — paragraph continuation lines re-open the run via
+ * `write_active_codes`, and only underline/strikethrough/OSC 8 are reset per
+ * line. Table cells instead splice each wrapped line directly between unstyled
+ * `│` borders, so an open color (e.g. an inline codespan that wraps) bleeds
+ * into the border. This scans the line's SGR runs and appends only the closers
+ * actually needed (fg → `39`, bold/dim → `22`, italic → `23`), leaving
+ * background and underline/strike (already closed by the wrapper) untouched.
+ */
+function closeOpenCellLineStyle(line: string): string {
+	let fg = false;
+	let weight = false;
+	let italic = false;
+	const reset = () => {
+		fg = false;
+		weight = false;
+		italic = false;
+	};
+	for (const match of line.matchAll(SGR_SEQUENCE_GLOBAL)) {
+		const body = match[0].slice(2, -1);
+		if (body.length === 0) {
+			reset();
+			continue;
+		}
+		const params = body.split(/[;:]/);
+		for (let i = 0; i < params.length; i++) {
+			const code = params[i] === "" ? 0 : Number(params[i]);
+			switch (code) {
+				case 0:
+					reset();
+					break;
+				case 1:
+				case 2:
+					weight = true;
+					break;
+				case 3:
+					italic = true;
+					break;
+				case 22:
+					weight = false;
+					break;
+				case 23:
+					italic = false;
+					break;
+				case 39:
+					fg = false;
+					break;
+				case 38:
+				case 48:
+				case 58:
+					// Consume extended-color arguments so their numeric values are
+					// never misread as attributes (`38;2;r;g;b`, `38;5;n`).
+					if (code === 38) fg = true;
+					i += params[i + 1] === "5" ? 2 : params[i + 1] === "2" ? 4 : 0;
+					break;
+				default:
+					if ((code >= 30 && code <= 37) || (code >= 90 && code <= 97)) fg = true;
+					break;
+			}
+		}
+	}
+	if (!fg && !weight && !italic) return line;
+	return `${line}${weight ? CELL_STYLE_WEIGHT_RESET : ""}${italic ? CELL_STYLE_ITALIC_RESET : ""}${fg ? CELL_STYLE_FG_RESET : ""}`;
+}
+
 interface TreeGuidePrefix {
 	/** Index of the first char past the guide run (start of the node text). */
 	end: number;
@@ -2816,7 +2894,10 @@ export class Markdown implements Component, NativeScrollbackCommittedRows, Nativ
 		while (wrapped.length > 1 && wrapped[wrapped.length - 1] === "") {
 			wrapped.pop();
 		}
-		return wrapped;
+		// Close any fg/bold/italic left open at a wrapped line end so the border
+		// glyph spliced after the cell never inherits an inline codespan/emphasis
+		// color (issue #7575). The wrapper only resets underline/strike/OSC 8.
+		return wrapped.map(closeOpenCellLineStyle);
 	}
 
 	/**

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -466,6 +466,43 @@ describe("Markdown component", () => {
 			}
 		});
 
+		it("does not leak inline-code color into table borders when a cell wraps mid-code-span (#7575)", () => {
+			const markdown = new Markdown(
+				`| Command | Notes |
+| --- | --- |
+| \`config.setupgrading(pendingRequests, emptyFlag)\` | plain |`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const width = 30;
+			const lines = markdown.render(width);
+
+			// The code column must actually wrap: more than one physical row carries
+			// the code color, so at least one wrapped line ends mid-code-span — the
+			// exact condition that used to leak the color into the trailing border.
+			const codeRows = lines.filter(line => line.includes("\x1b[33m"));
+			expect(codeRows.length).toBeGreaterThan(1);
+
+			// Render into the VT engine and assert every table border glyph resolves
+			// to the default foreground — never the codespan color.
+			const terminal = new VirtualTerminal(width, lines.length + 2);
+			terminal.write(lines.join("\r\n"));
+			const vertical = defaultMarkdownTheme.symbols.table.vertical;
+			for (let row = 0; row < lines.length; row++) {
+				const plain = stripVTControlCharacters(lines[row]);
+				if (!plain.includes(vertical)) continue;
+				const colored = new Set(terminal.getViewportRowForegroundColumns(row));
+				for (let col = 0; col < plain.length; col++) {
+					if (plain[col] !== vertical) continue;
+					expect(colored.has(col), `border at row ${row} col ${col} inherited a non-default fg: "${plain}"`).toBe(
+						false,
+					);
+				}
+			}
+		});
+
 		it("should handle extremely narrow width gracefully", () => {
 			const markdown = new Markdown(
 				`| A | B | C |


### PR DESCRIPTION
## Repro
Render a markdown table whose column is narrow enough to wrap an inline code span, e.g. `| Command | Notes |` / `| `+"`config.setupgrading(pendingRequests, emptyFlag)`"+` | plain |`. At width 30 the code column wraps across three physical rows; every wrapped row except the last keeps the codespan foreground (`\x1b[33m` in the default theme) open, so the trailing `|` border and every cell to its right on that row render in the code color. Confirmed at the VT-cell level: with the leak, the border columns resolve to a non-default foreground.

## Cause
`Markdown.#wrapCellText` (`packages/tui/src/components/markdown.ts`) splices each wrapped cell line directly between unstyled `|` border glyphs. `wrapTextWithAnsi` (crates/pi-natives) deliberately leaves foreground/bold/italic open across wrapped line ends — continuation lines re-open the run via `write_active_codes`, and `write_line_end_reset` only closes underline/strikethrough and OSC 8 hyperlinks. That paragraph contract is correct for prose, but for table cells it means the codespan's own `\x1b[39m` close only lands on the cell's final wrapped line; intermediate lines end with the color still open. The same mechanism leaks bold/italic when a line ends inside `**strong**`/`*em*`.

## Fix
- Add `closeOpenCellLineStyle` in `markdown.ts`: scans a line's SGR runs (reusing `SGR_SEQUENCE_GLOBAL`), tracks whether foreground / bold-or-dim / italic remain open at line end, and appends only the closers actually needed (`39` / `22` / `23`). Background is left untouched so the outer message-background pass keeps its fill; underline/strike are already reset by the wrapper. Extended-color args (`38;2;r;g;b`, `38;5;n`) are consumed so their numeric values are never misread as attributes.
- `#wrapCellText` maps every wrapped line through it — single chokepoint for both header and body cells.
- Changelog entry under `packages/tui` `[Unreleased]`.

## Verification
`bun test packages/tui/test/markdown.test.ts` → 143 pass. Added a regression test (`does not leak inline-code color into table borders when a cell wraps mid-code-span (#7575)`) that renders the reproduction into the Ghostty-backed `VirtualTerminal` and asserts every table border glyph resolves to the default foreground; it fails on the pre-fix code (`border at row 4 col 23 inherited a non-default fg`) and passes with the fix. `biome check` clean on the changed files; pre-publish gate (`bun run fix` + `bun check`) passed on push.

Fixes #7575