### PR TITLE
fix(tui): run sixel probe under WSL + Windows Terminal

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed inline images not rendering under WSL + Windows Terminal: the SIXEL capability probe gated on `process.platform === "win32"`, but WSL reports `linux`, so the probe never ran and images fell back to the text placeholder even on Sixel-capable Windows Terminal. The probe now runs on any ConPTY host (native win32 or WSL) ([#6009](https://github.com/can1357/oh-my-pi/issues/6009)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1608,7 +1608,10 @@ export class TUI extends Container {
 
 	#querySixelSupport(): void {
 		if (TERMINAL.imageProtocol) return;
-		if (process.platform !== "win32") return;
+		// win32 native or WSL under Windows Terminal — both are ConPTY-hosted and
+		// reach the same WT graphics negotiation. WSL reports process.platform
+		// "linux", so a bare win32 check silently skips the probe there (#6009).
+		if (!isConPTYHosted()) return;
 		if (!Bun.env.WT_SESSION) return;
 		if (!process.stdin.isTTY || !process.stdout.isTTY) return;
 

--- a/packages/tui/test/sixel-probe.test.ts
+++ b/packages/tui/test/sixel-probe.test.ts
@@ -9,6 +9,8 @@ type MutableTerminalInfo = {
 const terminalInfo = TERMINAL as unknown as MutableTerminalInfo;
 const originalProtocol = TERMINAL.imageProtocol;
 const originalWtSession = Bun.env.WT_SESSION;
+const originalWslDistro = Bun.env.WSL_DISTRO_NAME;
+const originalWslInterop = Bun.env.WSL_INTEROP;
 const stdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
 const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 
@@ -29,6 +31,10 @@ describe("TUI SIXEL capability probe", () => {
 		terminalInfo.imageProtocol = originalProtocol;
 		if (originalWtSession === undefined) delete Bun.env.WT_SESSION;
 		else Bun.env.WT_SESSION = originalWtSession;
+		if (originalWslDistro === undefined) delete Bun.env.WSL_DISTRO_NAME;
+		else Bun.env.WSL_DISTRO_NAME = originalWslDistro;
+		if (originalWslInterop === undefined) delete Bun.env.WSL_INTEROP;
+		else Bun.env.WSL_INTEROP = originalWslInterop;
 		restoreIsTty(process.stdin, stdinIsTtyDescriptor);
 		restoreIsTty(process.stdout, stdoutIsTtyDescriptor);
 	});
@@ -100,6 +106,29 @@ describe("TUI SIXEL capability probe", () => {
 		terminal.sendInput("\x1b[?2;0;0S");
 
 		expect(TERMINAL.imageProtocol).toBeNull();
+		tui.stop();
+	});
+
+	it("enables SIXEL under WSL + Windows Terminal (process.platform is linux)", () => {
+		// Regression for #6009: inside WSL, process.platform reports "linux" even
+		// though the host is Windows Terminal. The probe used to gate on
+		// process.platform === "win32", so WSL sessions never negotiated SIXEL and
+		// fell back to the text image card. It now gates on isConPTYHosted(), which
+		// treats WSL (WSL_DISTRO_NAME/WSL_INTEROP) as a Windows host.
+		if (process.platform !== "linux") return;
+		setTerminalImageProtocol(null);
+		terminalInfo.imageProtocol = null;
+		Bun.env.WT_SESSION = "test-wt-session";
+		Bun.env.WSL_DISTRO_NAME = "Ubuntu";
+		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+
+		const terminal = new VirtualTerminal(80, 24);
+		const tui = new TUI(terminal);
+		tui.start();
+		terminal.sendInput("\x1b[?1;2;4c");
+
+		expect(TERMINAL.imageProtocol).toBe(ImageProtocol.Sixel);
 		tui.stop();
 	});
 });


### PR DESCRIPTION
## Repro
Running omp inside WSL under Windows Terminal (Sixel-capable, WT >= 1.22), `read photo.png` shows only the `[Image: …]` text card instead of the image. Confirmed in #6009: adding `PI_FORCE_IMAGE_PROTOCOL=sixel` makes images render, proving the terminal is Sixel-capable and only automatic protocol negotiation was failing.

## Cause
`TUI.#querySixelSupport` (`packages/tui/src/tui.ts`) gated the SIXEL capability probe on `process.platform !== "win32"`. Inside WSL, `process.platform` is `"linux"`, so the probe returned early and never sent the DA1 / XTSMGRAPHICS queries — `TERMINAL.imageProtocol` stayed `null` and every image fell back to text. WSL under Windows Terminal is treated as a Windows host everywhere else in the codebase (`resolveWarpImageProtocol`, `isConPTYHosted`, clipboard, `open`), so the win32-only gate was an oversight.

## Fix
- `packages/tui/src/tui.ts`: replace the win32-only gate in `#querySixelSupport` with `if (!isConPTYHosted()) return;` (already imported from `./terminal`; true for native win32 **or** linux+WSL). The existing `WT_SESSION` and stdin/stdout TTY requirements still scope the probe to Windows Terminal.
- `packages/tui/test/sixel-probe.test.ts`: add a Linux-runnable regression test that simulates WSL (`WSL_DISTRO_NAME` + `WT_SESSION` + TTY), feeds a positive DA1 reply, and asserts SIXEL is negotiated; capture/restore `WSL_DISTRO_NAME`/`WSL_INTEROP` in `afterEach`.
- `packages/tui/CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

## Verification
`bun test packages/tui/test/sixel-probe.test.ts` → 5 pass. The new test `enables SIXEL under WSL + Windows Terminal (process.platform is linux)` runs on the Linux CI (the four pre-existing tests are win32-guarded and skip). Revert check: restoring the old `process.platform !== "win32"` gate makes the new test fail (`imageProtocol` null), confirming it defends the fix. Pre-publish gate (`bun run fix` + `bun check`) passed on push.

Fixes #6009