### PR TITLE
refactor(collab-web): collapse duplicate shortenPath

### DIFF
--- a/packages/coding-agent/test/export-html-template.test.ts
+++ b/packages/coding-agent/test/export-html-template.test.ts
@@ -19,9 +19,9 @@ interface TemplateProbeResult {
 }
 
 const expectedTemplate: TemplateProbeResult = {
-	chars: 376_316,
-	bytes: 376_472,
-	sha256: "72721b125d8eaa0e995ef0b77e01cf561c9a76e36e745510b19734def07936e0",
+	chars: 376_855,
+	bytes: 377_015,
+	sha256: "3d6d5fa7430f206a37e2a3ef279d748a26cc87fd79b1155bd1557d118168f365",
 	stableCache: true,
 	assetsRemoved: 0,
 };

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Tool renderers now use the canonical home-relative middle-elided path format (matching `shortenPath` in `lib/format.ts`) for filesystem paths, unifying summary and body display across all tool cards.
+
+### Fixed
+
+- Stopped path-shortening URLs in the `browser` and `inspect_image` tool renderers; URLs are now rendered intact (truncated only) instead of being split on `/` and middle-elided.
+
 ## [17.2.2] - 2026-07-31
 
 ### Fixed

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Stopped path-shortening URLs in the `browser` and `inspect_image` tool renderers; URLs are now rendered intact (truncated only) instead of being split on `/` and middle-elided.
+- Stopped middle-eliding glob search scopes in the `glob` tool summary; pattern-bearing (`*`/`?`/`[`) and scheme-bearing (`memory://…`) scope values are now rendered intact instead of being corrupted by `shortenPath`. Factored the existing scheme guard into a shared `compactPath` helper used by `PathText`, `inspect_image`, and `glob`.
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Stopped path-shortening URLs in the `browser` and `inspect_image` tool renderers; URLs are now rendered intact (truncated only) instead of being split on `/` and middle-elided.
 - Stopped middle-eliding glob search scopes in the `glob` tool summary; pattern-bearing (`*`/`?`/`[`) and scheme-bearing (`memory://…`) scope values are now rendered intact instead of being corrupted by `shortenPath`. Factored the existing scheme guard into a shared `compactPath` helper used by `PathText`, `inspect_image`, and `glob`.
+- Restored unconditional home-directory redaction for glob, URI, and bracketed-literal paths routed through the canonical path formatter; scopes under `/home/<user>` (e.g. `/home/alice/project/src/**/*.ts` or `/home/alice/project/apps/[id]/page.tsx`) now render home-relative (`~/…`) instead of leaking the username. Also preserved the `server/share` root of UNC paths (`//server/share/…`) through middle elision.
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Stopped path-shortening URLs in the `browser` and `inspect_image` tool renderers; URLs are now rendered intact (truncated only) instead of being split on `/` and middle-elided.
 - Stopped middle-eliding glob search scopes in the `glob` tool summary; pattern-bearing (`*`/`?`/`[`) and scheme-bearing (`memory://…`) scope values are now rendered intact instead of being corrupted by `shortenPath`. Factored the existing scheme guard into a shared `compactPath` helper used by `PathText`, `inspect_image`, and `glob`.
 - Restored unconditional home-directory redaction for glob, URI, and bracketed-literal paths routed through the canonical path formatter; scopes under `/home/<user>` (e.g. `/home/alice/project/src/**/*.ts` or `/home/alice/project/apps/[id]/page.tsx`) now render home-relative (`~/…`) instead of leaking the username. Also preserved the `server/share` root of UNC paths (`//server/share/…`) through middle elision.
+- Migrated the `grep` tool's scope and missing-path display and the `glob` tool's result scope badge to `compactPath`, so deep and scheme-bearing (`memory://…`) grep scopes and multi-pattern glob scope badges are no longer middle-elided or corrupted.
+- Extended the `compactPath` glob guard to the canonical metacharacter set (`*`, `?`, `[`, `{`, matching `hasGlobPathChars`), so brace-glob scopes like `src/features/{admin,user}/…` render with their alternatives intact.
+- Extended unconditional home redaction to home paths immediately after a URI scheme prefix (`file:///home/<user>/…` now renders `file://~/…` instead of leaking the username).
 
 ## [17.2.2] - 2026-07-31
 

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed collab-web path formatting for non-file URLs, multi-path scopes, and local file URLs.
 - Stopped path-shortening URLs in the `browser` and `inspect_image` tool renderers; URLs are now rendered intact (truncated only) instead of being split on `/` and middle-elided.
 - Stopped middle-eliding glob search scopes in the `glob` tool summary; pattern-bearing (`*`/`?`/`[`) and scheme-bearing (`memory://…`) scope values are now rendered intact instead of being corrupted by `shortenPath`. Factored the existing scheme guard into a shared `compactPath` helper used by `PathText`, `inspect_image`, and `glob`.
 - Restored unconditional home-directory redaction for glob, URI, and bracketed-literal paths routed through the canonical path formatter; scopes under `/home/<user>` (e.g. `/home/alice/project/src/**/*.ts` or `/home/alice/project/apps/[id]/page.tsx`) now render home-relative (`~/…`) instead of leaking the username. Also preserved the `server/share` root of UNC paths (`//server/share/…`) through middle elision.

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Tool renderers now use the canonical home-relative middle-elided path format (matching `shortenPath` in `lib/format.ts`) for filesystem paths, unifying summary and body display across all tool cards.
+- Tool renderers now use a single `compactPath` path formatter (replacing the duplicate `shortenPath` implementation) for filesystem paths, unifying summary and body display with unconditional home-directory redaction and safe handling of URLs, globs, brace patterns, and multi-pattern scope values.
 
 ### Fixed
 

--- a/packages/collab-web/src/lib/format.ts
+++ b/packages/collab-web/src/lib/format.ts
@@ -50,13 +50,40 @@ export function fmtPercent(p: number | null | undefined): string {
 	return `${Math.round(Math.min(100, Math.max(0, p)))}%`;
 }
 
+/**
+ * Replace a leading `/home/<user>` or `/Users/<user>` with `~`.
+ * Unconditional — applied to every path before any elision decision,
+ * so glob/URI/bracketed scopes under a home directory never leak the
+ * username. No-op for values that do not start with a home prefix.
+ */
+export function redactHome(p: string): string {
+	if (typeof p !== "string" || p.length === 0) return "";
+	return p.replace(/^\/(?:Users|home)\/[^/]+(?=\/|$)/, "~");
+}
+
+/**
+ * Middle-elide a path to at most four segments. A UNC root (`//server/share`
+ * or `\\server\share`) is retained verbatim so paths on different shares stay
+ * distinguishable; only the tail beyond `server/share` is elided. Ordinary
+ * POSIX/relative paths behave exactly as before.
+ */
+export function elideMiddle(p: string): string {
+	if (typeof p !== "string" || p.length === 0) return "";
+	const unc = p.match(/^(?:\/\/|\\\\)([^/\\]+\/[^/]+)/);
+	if (unc) {
+		const root = unc[0];
+		const rest = p.slice(root.length).split("/").filter(Boolean);
+		if (rest.length <= 2) return p;
+		return `${root}/…/${rest.slice(-2).join("/")}`;
+	}
+	const segs = p.split("/");
+	if (segs.length > 4) return `${segs[0]}/…/${segs.slice(-2).join("/")}`;
+	return p;
+}
+
 /** Home-relative, middle-elided path: "~/…/packages/collab-web". */
 export function shortenPath(p: string): string {
-	if (typeof p !== "string" || p.length === 0) return "";
-	let out = p.replace(/^\/(?:Users|home)\/[^/]+(?=\/|$)/, "~");
-	const segs = out.split("/");
-	if (segs.length > 4) out = `${segs[0]}/…/${segs.slice(-2).join("/")}`;
-	return out;
+	return elideMiddle(redactHome(p));
 }
 
 /** Tolerant text extraction from string | content-block array | message-like objects. */

--- a/packages/collab-web/src/lib/format.ts
+++ b/packages/collab-web/src/lib/format.ts
@@ -54,11 +54,14 @@ export function fmtPercent(p: number | null | undefined): string {
  * Replace a leading `/home/<user>` or `/Users/<user>` with `~`.
  * Unconditional — applied to every path before any elision decision,
  * so glob/URI/bracketed scopes under a home directory never leak the
- * username. No-op for values that do not start with a home prefix.
+ * username. A home path immediately after a URI scheme prefix
+ * (`file:///home/<user>/…`, optional authority) is redacted too, with
+ * the prefix kept intact. No-op for values carrying no home prefix;
+ * a `/home/<user>` mid-string in unrelated text is never touched.
  */
 export function redactHome(p: string): string {
 	if (typeof p !== "string" || p.length === 0) return "";
-	return p.replace(/^\/(?:Users|home)\/[^/]+(?=\/|$)/, "~");
+	return p.replace(/^((?:[A-Za-z][A-Za-z0-9+.-]*:\/\/[^/]*)?)\/(?:Users|home)\/[^/]+(?=\/|$)/, "$1~");
 }
 
 /**

--- a/packages/collab-web/src/lib/format.ts
+++ b/packages/collab-web/src/lib/format.ts
@@ -61,7 +61,7 @@ export function fmtPercent(p: number | null | undefined): string {
  */
 export function redactHome(p: string): string {
 	if (typeof p !== "string" || p.length === 0) return "";
-	return p.replace(/^((?:[A-Za-z][A-Za-z0-9+.-]*:\/\/[^/]*)?)\/(?:Users|home)\/[^/]+(?=\/|$)/, "$1~");
+	return p.replace(/^((?:file:\/\/[^/]*)?)\/(?:Users|home)\/[^/]+(?=\/|$)/i, "$1~");
 }
 
 /**

--- a/packages/collab-web/src/tool-render/parts.tsx
+++ b/packages/collab-web/src/tool-render/parts.tsx
@@ -5,7 +5,7 @@
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import type { ToolRenderHost, ToolResultImage, ToolResultLike } from "./types";
-import { getHljs, replaceTabs, resultImagesOf, resultTextOf, shortenPath, stripAnsi } from "./util";
+import { compactPath, getHljs, replaceTabs, resultImagesOf, resultTextOf, stripAnsi } from "./util";
 
 export type Tone = "accent" | "ok" | "err" | "warn";
 
@@ -47,7 +47,7 @@ export function PathText({
 	}
 	return (
 		<span className="tv-path">
-			{path.includes("://") ? path : shortenPath(path)}
+			{compactPath(path)}
 			{range && <span className="tv-lines">{range}</span>}
 			{sel && <span className="tv-lines">:{sel}</span>}
 		</span>

--- a/packages/collab-web/src/tool-render/parts.tsx
+++ b/packages/collab-web/src/tool-render/parts.tsx
@@ -47,7 +47,7 @@ export function PathText({
 	}
 	return (
 		<span className="tv-path">
-			{shortenPath(path)}
+			{path.includes("://") ? path : shortenPath(path)}
 			{range && <span className="tv-lines">{range}</span>}
 			{sel && <span className="tv-lines">:{sel}</span>}
 		</span>

--- a/packages/collab-web/src/tool-render/tools/ast-edit.tsx
+++ b/packages/collab-web/src/tool-render/tools/ast-edit.tsx
@@ -2,7 +2,7 @@
 import type { ReactNode } from "react";
 import { Badge, CodeBlock, DiffBlock, InvalidArg, Note, Output, PathText, ResultText, Row } from "../parts";
 import type { ToolRenderer, ToolRenderProps } from "../types";
-import { detailsRecord, isRecord, languageFromPath, num, shortenPath, str } from "../util";
+import { compactPath, detailsRecord, isRecord, languageFromPath, num, str } from "../util";
 
 interface AstEditOp {
 	pat: string;
@@ -150,7 +150,7 @@ function Body({ args, result }: ToolRenderProps): ReactNode {
 						</Badge>
 					)}
 					{details.filesSearched != null && <Badge>searched {details.filesSearched}</Badge>}
-					{details.scopePath && <Badge>in {shortenPath(details.scopePath)}</Badge>}
+					{details.scopePath && <Badge>in {compactPath(details.scopePath)}</Badge>}
 					{details.limitReached && <Badge tone="warn">limit reached</Badge>}
 				</span>
 			)}

--- a/packages/collab-web/src/tool-render/tools/bash.tsx
+++ b/packages/collab-web/src/tool-render/tools/bash.tsx
@@ -2,7 +2,7 @@
 import type { ReactNode } from "react";
 import { Badge, Badges, InvalidArg, ResultImages, ResultText, Row } from "../parts";
 import type { ToolRenderer, ToolRenderProps } from "../types";
-import { detailsRecord, display, isRecord, normalizeWs, num, resultTextOf, shortenPath, str, truncate } from "../util";
+import { compactPath, detailsRecord, display, isRecord, normalizeWs, num, resultTextOf, str, truncate } from "../util";
 
 /** Values safe to show unquoted in a `NAME=value` shell prefix. */
 const SHELL_SAFE = /^[\w@%+=:,./-]+$/;
@@ -73,7 +73,7 @@ function Body({ args, result }: ToolRenderProps): ReactNode {
 			</div>
 			<Badges
 				items={[
-					cwd && <Badge>cwd={shortenPath(cwd)}</Badge>,
+					cwd && <Badge>cwd={compactPath(cwd)}</Badge>,
 					timeoutSeconds !== null && <Badge>timeout={timeoutSeconds}s</Badge>,
 					args.pty === true && <Badge tone="accent">pty</Badge>,
 					!job && args.async === true && <Badge tone="accent">async</Badge>,

--- a/packages/collab-web/src/tool-render/tools/browser.tsx
+++ b/packages/collab-web/src/tool-render/tools/browser.tsx
@@ -45,6 +45,10 @@ function actionTone(action: string): Tone | undefined {
 	}
 }
 
+function displayUrl(url: string, maxLen: number): string {
+	return /^file:/i.test(url) ? compactPath(url) : truncate(url, maxLen);
+}
+
 /** Mirrors the TUI's `describeBrowser`: explicit app args win over reported mode. */
 function describeBrowser(app: AppArg | null, details: BrowserDetails): string | null {
 	if (app?.cdpUrl) return `connected ${app.cdpUrl}`;
@@ -63,7 +67,7 @@ function Summary({ args, result }: ToolRenderProps): ReactNode {
 			<Badge tone={actionTone(action)}>{action}</Badge>
 			<span>{closeAll ? "all tabs" : tab}</span>
 			{args.kill === true && <Badge tone="err">kill</Badge>}
-			{url && <span className="tv-faint">{truncate(url, 72)}</span>}
+			{url && <span className="tv-faint">{displayUrl(url, 72)}</span>}
 		</>
 	);
 }
@@ -84,7 +88,7 @@ function Body({ args, result }: ToolRenderProps): ReactNode {
 		<>
 			<span className="tv-badges">
 				{tab !== null && <Badge>tab {tab}</Badge>}
-				{url && <Badge tone="accent">{truncate(url, 120)}</Badge>}
+				{url && <Badge tone="accent">{displayUrl(url, 120)}</Badge>}
 				{browserDesc && <Badge>{browserDesc}</Badge>}
 				{app?.target && <Badge>target {app.target}</Badge>}
 				{args.all === true && <Badge tone="warn">all</Badge>}

--- a/packages/collab-web/src/tool-render/tools/browser.tsx
+++ b/packages/collab-web/src/tool-render/tools/browser.tsx
@@ -63,7 +63,7 @@ function Summary({ args, result }: ToolRenderProps): ReactNode {
 			<Badge tone={actionTone(action)}>{action}</Badge>
 			<span>{closeAll ? "all tabs" : tab}</span>
 			{args.kill === true && <Badge tone="err">kill</Badge>}
-			{url && <span className="tv-faint">{truncate(shortenPath(url), 72)}</span>}
+			{url && <span className="tv-faint">{truncate(url, 72)}</span>}
 		</>
 	);
 }
@@ -84,7 +84,7 @@ function Body({ args, result }: ToolRenderProps): ReactNode {
 		<>
 			<span className="tv-badges">
 				{tab !== null && <Badge>tab {tab}</Badge>}
-				{url && <Badge tone="accent">{truncate(shortenPath(url), 120)}</Badge>}
+				{url && <Badge tone="accent">{truncate(url, 120)}</Badge>}
 				{browserDesc && <Badge>{browserDesc}</Badge>}
 				{app?.target && <Badge>target {app.target}</Badge>}
 				{args.all === true && <Badge tone="warn">all</Badge>}

--- a/packages/collab-web/src/tool-render/tools/browser.tsx
+++ b/packages/collab-web/src/tool-render/tools/browser.tsx
@@ -2,7 +2,7 @@
 import type { ReactNode } from "react";
 import { Badge, CodeBlock, ResultImages, ResultText, type Tone } from "../parts";
 import type { ToolRenderer, ToolRenderProps } from "../types";
-import { detailsRecord, isRecord, num, shortenPath, str, truncate } from "../util";
+import { compactPath, detailsRecord, isRecord, num, str, truncate } from "../util";
 
 interface BrowserDetails {
 	action: string | null;
@@ -48,7 +48,7 @@ function actionTone(action: string): Tone | undefined {
 /** Mirrors the TUI's `describeBrowser`: explicit app args win over reported mode. */
 function describeBrowser(app: AppArg | null, details: BrowserDetails): string | null {
 	if (app?.cdpUrl) return `connected ${app.cdpUrl}`;
-	if (app?.path) return `spawned ${shortenPath(app.path)}`;
+	if (app?.path) return `spawned ${compactPath(app.path)}`;
 	return details.browser;
 }
 

--- a/packages/collab-web/src/tool-render/tools/github.tsx
+++ b/packages/collab-web/src/tool-render/tools/github.tsx
@@ -2,7 +2,7 @@
 import type { ReactNode } from "react";
 import { Badge, InvalidArg, Kv, KvGrid, Note, Output, ResultText, Row } from "../parts";
 import type { ToolRenderer, ToolRenderProps } from "../types";
-import { detailsRecord, isRecord, normalizeWs, num, shortenPath, str, truncate } from "../util";
+import { compactPath, detailsRecord, isRecord, normalizeWs, num, str, truncate } from "../util";
 
 const SUCCESS_CONCLUSIONS: Record<string, true> = { success: true, neutral: true, skipped: true };
 const FAILURE_CONCLUSIONS: Record<string, true> = {
@@ -236,7 +236,7 @@ function CheckoutRows({ checkouts }: { checkouts: readonly unknown[] }): ReactNo
 				return (
 					<Row k={prNumber !== null ? `#${prNumber}` : "PR"} key={prNumber ?? index}>
 						<span>{str(entry.branch) ?? ""}</span>
-						{worktree && <span className="tv-muted"> {shortenPath(worktree)}</span>}
+						{worktree && <span className="tv-muted"> {compactPath(worktree)}</span>}
 						{entry.reused === true && <Badge>reused</Badge>}
 					</Row>
 				);
@@ -268,7 +268,7 @@ function DetailsGrid({ details }: { details: Record<string, unknown> }): ReactNo
 				</Kv>,
 			);
 		} else if (typeof value === "string" && value) {
-			const text = key === "worktreePath" ? shortenPath(value) : key === "headSha" ? shortSha(value) : value;
+			const text = key === "worktreePath" ? compactPath(value) : key === "headSha" ? shortSha(value) : value;
 			rows.push(
 				<Kv k={key} key={key}>
 					{text}

--- a/packages/collab-web/src/tool-render/tools/glob.tsx
+++ b/packages/collab-web/src/tool-render/tools/glob.tsx
@@ -2,12 +2,12 @@
 import type { ReactNode } from "react";
 import { Badge, Badges, InvalidArg, Note, ResultText } from "../parts";
 import type { ToolRenderer, ToolRenderProps } from "../types";
-import { detailsRecord, isRecord, num, scopePaths, shortenPath, str, truncate } from "../util";
+import { compactPath, detailsRecord, isRecord, num, scopePaths, shortenPath, str, truncate } from "../util";
 
 function Summary({ args }: ToolRenderProps): ReactNode {
 	const raw = args.path ?? args.paths;
 	if (raw !== undefined && typeof raw !== "string" && !Array.isArray(raw)) return <InvalidArg what="path" />;
-	const globs = scopePaths(args).map(shortenPath).join(", ");
+	const globs = scopePaths(args).map(compactPath).join(", ");
 	return <span className="tv-pattern">{truncate(globs || "*", 120)}</span>;
 }
 
@@ -50,7 +50,7 @@ function Body({ args, result }: ToolRenderProps): ReactNode {
 					),
 				]}
 			/>
-			{missing.length > 0 && <Note tone="warn">skipped missing: {missing.map(shortenPath).join(", ")}</Note>}
+			{missing.length > 0 && <Note tone="warn">skipped missing: {missing.map(compactPath).join(", ")}</Note>}
 			{error !== null && !result?.isError && <Note tone="err">{error}</Note>}
 			<ResultText result={result} maxLines={12} />
 		</>

--- a/packages/collab-web/src/tool-render/tools/glob.tsx
+++ b/packages/collab-web/src/tool-render/tools/glob.tsx
@@ -2,7 +2,7 @@
 import type { ReactNode } from "react";
 import { Badge, Badges, InvalidArg, Note, ResultText } from "../parts";
 import type { ToolRenderer, ToolRenderProps } from "../types";
-import { compactPath, detailsRecord, isRecord, num, scopePaths, shortenPath, str, truncate } from "../util";
+import { compactPath, detailsRecord, isRecord, num, scopePaths, str, truncate } from "../util";
 
 function Summary({ args }: ToolRenderProps): ReactNode {
 	const raw = args.path ?? args.paths;
@@ -44,7 +44,7 @@ function Body({ args, result }: ToolRenderProps): ReactNode {
 							{fileCount} file{fileCount === 1 ? "" : "s"}
 						</Badge>
 					),
-					scopePath !== null && <Badge>in {shortenPath(scopePath)}</Badge>,
+					scopePath !== null && <Badge>in {compactPath(scopePath)}</Badge>,
 					truncated && (
 						<Badge tone="warn">{resultLimit !== null ? `truncated at ${resultLimit}` : "truncated"}</Badge>
 					),

--- a/packages/collab-web/src/tool-render/tools/grep.tsx
+++ b/packages/collab-web/src/tool-render/tools/grep.tsx
@@ -2,11 +2,11 @@
 import type { ReactNode } from "react";
 import { Badge, Badges, InvalidArg, Note, ResultText } from "../parts";
 import type { ToolRenderer, ToolRenderProps } from "../types";
-import { detailsRecord, num, resultTextOf, scopePaths, shortenPath, str } from "../util";
+import { compactPath, detailsRecord, num, resultTextOf, scopePaths, str } from "../util";
 
 /** Grep scope: current `path` (string, delimited, or JSON array) or legacy `paths`; defaults to workspace root. */
 function pathsOf(args: Record<string, unknown>): string[] {
-	const list = scopePaths(args).map(shortenPath);
+	const list = scopePaths(args).map(compactPath);
 	return list.length ? list : ["."];
 }
 
@@ -49,7 +49,7 @@ function Body({ args, result }: ToolRenderProps): ReactNode {
 	const missing: string[] = [];
 	if (details && Array.isArray(details.missingPaths)) {
 		for (const p of details.missingPaths) {
-			if (typeof p === "string") missing.push(shortenPath(p));
+			if (typeof p === "string") missing.push(compactPath(p));
 		}
 	}
 	const badges = argBadges(args);

--- a/packages/collab-web/src/tool-render/tools/inspect-image.tsx
+++ b/packages/collab-web/src/tool-render/tools/inspect-image.tsx
@@ -8,7 +8,7 @@ function Summary({ args, result }: ToolRenderProps): ReactNode {
 	const rec = detailsRecord(result);
 	const target = str(args.path) ?? str(args.url) ?? (rec ? str(rec.imagePath) : null);
 	if (target === null) return <InvalidArg what="image path" />;
-	// URLs and glob patterns must not go through shortenPath — it splits on "/" and middle-elides.
+	// compactPath redacts the home prefix but skips elision for URLs and glob patterns, which splitting on "/" would corrupt.
 	const display = compactPath(target);
 	return <span>{truncate(display)}</span>;
 }

--- a/packages/collab-web/src/tool-render/tools/inspect-image.tsx
+++ b/packages/collab-web/src/tool-render/tools/inspect-image.tsx
@@ -8,7 +8,9 @@ function Summary({ args, result }: ToolRenderProps): ReactNode {
 	const rec = detailsRecord(result);
 	const target = str(args.path) ?? str(args.url) ?? (rec ? str(rec.imagePath) : null);
 	if (target === null) return <InvalidArg what="image path" />;
-	return <span>{truncate(shortenPath(target))}</span>;
+	// URLs (args.url) must not go through shortenPath — it splits on "/" and middle-elides.
+	const display = target.includes("://") ? target : shortenPath(target);
+	return <span>{truncate(display)}</span>;
 }
 
 function Body({ args, result }: ToolRenderProps): ReactNode {

--- a/packages/collab-web/src/tool-render/tools/inspect-image.tsx
+++ b/packages/collab-web/src/tool-render/tools/inspect-image.tsx
@@ -2,14 +2,14 @@
 import type { ReactNode } from "react";
 import { Badge, Badges, InvalidArg, PathText, ResultImages, ResultText, Row } from "../parts";
 import type { ToolRenderer, ToolRenderProps } from "../types";
-import { detailsRecord, normalizeWs, shortenPath, str, truncate } from "../util";
+import { compactPath, detailsRecord, normalizeWs, str, truncate } from "../util";
 
 function Summary({ args, result }: ToolRenderProps): ReactNode {
 	const rec = detailsRecord(result);
 	const target = str(args.path) ?? str(args.url) ?? (rec ? str(rec.imagePath) : null);
 	if (target === null) return <InvalidArg what="image path" />;
-	// URLs (args.url) must not go through shortenPath — it splits on "/" and middle-elides.
-	const display = target.includes("://") ? target : shortenPath(target);
+	// URLs and glob patterns must not go through shortenPath — it splits on "/" and middle-elides.
+	const display = compactPath(target);
 	return <span>{truncate(display)}</span>;
 }
 

--- a/packages/collab-web/src/tool-render/tools/read.tsx
+++ b/packages/collab-web/src/tool-render/tools/read.tsx
@@ -2,7 +2,7 @@
 import type { ReactNode } from "react";
 import { Badge, Badges, Kv, KvGrid, PathText, ResultImages, ResultText } from "../parts";
 import type { ToolRenderer, ToolRenderProps } from "../types";
-import { detailsRecord, isRecord, languageFromPath, num, shortenPath, str } from "../util";
+import { compactPath, detailsRecord, isRecord, languageFromPath, num, str } from "../util";
 
 /** Fields of `ReadToolDetails` the web view surfaces (untrusted wire JSON). */
 interface ReadDetails {
@@ -90,7 +90,7 @@ function Body({ args, result }: ToolRenderProps): ReactNode {
 							<PathText path={resolved} />
 						</Kv>
 					)}
-					{d.suffixFrom !== null && <Kv k="corrected from">{shortenPath(d.suffixFrom)}</Kv>}
+					{d.suffixFrom !== null && <Kv k="corrected from">{compactPath(d.suffixFrom)}</Kv>}
 				</KvGrid>
 			)}
 			<Badges items={[conflictBadge, elidedBadge, truncatedBadge]} />

--- a/packages/collab-web/src/tool-render/util.ts
+++ b/packages/collab-web/src/tool-render/util.ts
@@ -30,16 +30,7 @@ export function display(value: unknown): string {
 }
 
 /** Replace `/Users/<x>` / `/home/<x>` prefix with `~` for display. */
-export function shortenPath(p: string): string {
-	for (const prefix of ["/Users/", "/home/"]) {
-		if (p.startsWith(prefix)) {
-			const rest = p.slice(prefix.length);
-			const slash = rest.indexOf("/");
-			return slash < 0 ? "~" : `~${rest.slice(slash)}`;
-		}
-	}
-	return p;
-}
+export { shortenPath } from "../lib/format";
 
 /**
  * Search scope for display: the current `path` argument (else the legacy

--- a/packages/collab-web/src/tool-render/util.ts
+++ b/packages/collab-web/src/tool-render/util.ts
@@ -29,21 +29,22 @@ export function display(value: unknown): string {
 	}
 }
 
-import { shortenPath } from "../lib/format";
+import { elideMiddle, redactHome, shortenPath } from "../lib/format";
 
 export { shortenPath };
 
 /**
- * Display-safe path compaction: middle-elide long filesystem paths, but
- * return URLs and glob patterns intact. `shortenPath` splits on `/` and
- * middle-elides, which corrupts scheme-bearing values
- * (`memory://root/skills` → `memory:/…/skills`) and hides glob scope
- * (e.g. `src` + `**` + `*.ts` + `; test` + `**` + `*.ts` → `src/…` + `**` + `*.ts`).
- * A value is shown intact when it carries a scheme (`://`) or glob
- * metacharacters (`*`, `?`, `[`).
+ * Display-safe path compaction. Home redaction is UNCONDITIONAL — every
+ * value is normalized to `~` first so a glob/URI/bracketed scope under a
+ * home directory never leaks the username. Middle elision is the only
+ * conditional part: it is skipped for scheme-bearing values (`://`, which
+ * `elideMiddle` would corrupt by splitting on `/`) and glob patterns
+ * (`*`, `?`, `[`, which carry scope meaning that elision would hide).
  */
 export function compactPath(p: string): string {
-	return /:\/\//.test(p) || /[*?[]/.test(p) ? p : shortenPath(p);
+	const redacted = redactHome(p);
+	if (/:\/\//.test(redacted) || /[*?[]/.test(redacted)) return redacted;
+	return elideMiddle(redacted);
 }
 
 /**

--- a/packages/collab-web/src/tool-render/util.ts
+++ b/packages/collab-web/src/tool-render/util.ts
@@ -29,8 +29,22 @@ export function display(value: unknown): string {
 	}
 }
 
-/** Replace `/Users/<x>` / `/home/<x>` prefix with `~` for display. */
-export { shortenPath } from "../lib/format";
+import { shortenPath } from "../lib/format";
+
+export { shortenPath };
+
+/**
+ * Display-safe path compaction: middle-elide long filesystem paths, but
+ * return URLs and glob patterns intact. `shortenPath` splits on `/` and
+ * middle-elides, which corrupts scheme-bearing values
+ * (`memory://root/skills` → `memory:/…/skills`) and hides glob scope
+ * (e.g. `src` + `**` + `*.ts` + `; test` + `**` + `*.ts` → `src/…` + `**` + `*.ts`).
+ * A value is shown intact when it carries a scheme (`://`) or glob
+ * metacharacters (`*`, `?`, `[`).
+ */
+export function compactPath(p: string): string {
+	return /:\/\//.test(p) || /[*?[]/.test(p) ? p : shortenPath(p);
+}
 
 /**
  * Search scope for display: the current `path` argument (else the legacy

--- a/packages/collab-web/src/tool-render/util.ts
+++ b/packages/collab-web/src/tool-render/util.ts
@@ -42,6 +42,12 @@ import { elideMiddle, redactHome } from "../lib/format";
  * meaning that elision would hide.
  */
 export function compactPath(p: string): string {
+	if (/[,;]/.test(p)) {
+		return p
+			.split(/([,;]\s*)/)
+			.map((part, index) => (index % 2 === 0 ? compactPath(part) : part))
+			.join("");
+	}
 	const redacted = redactHome(p);
 	if (/:\/\//.test(redacted) || /[*?[{]/.test(redacted)) return redacted;
 	return elideMiddle(redacted);

--- a/packages/collab-web/src/tool-render/util.ts
+++ b/packages/collab-web/src/tool-render/util.ts
@@ -29,21 +29,21 @@ export function display(value: unknown): string {
 	}
 }
 
-import { elideMiddle, redactHome, shortenPath } from "../lib/format";
-
-export { shortenPath };
+import { elideMiddle, redactHome } from "../lib/format";
 
 /**
  * Display-safe path compaction. Home redaction is UNCONDITIONAL — every
  * value is normalized to `~` first so a glob/URI/bracketed scope under a
  * home directory never leaks the username. Middle elision is the only
  * conditional part: it is skipped for scheme-bearing values (`://`, which
- * `elideMiddle` would corrupt by splitting on `/`) and glob patterns
- * (`*`, `?`, `[`, which carry scope meaning that elision would hide).
+ * `elideMiddle` would corrupt by splitting on `/`) and glob patterns — the
+ * canonical metacharacter set is `*`, `?`, `[`, `{` (matching
+ * `hasGlobPathChars` in coding-agent `path-utils.ts`), which carry scope
+ * meaning that elision would hide.
  */
 export function compactPath(p: string): string {
 	const redacted = redactHome(p);
-	if (/:\/\//.test(redacted) || /[*?[]/.test(redacted)) return redacted;
+	if (/:\/\//.test(redacted) || /[*?[{]/.test(redacted)) return redacted;
 	return elideMiddle(redacted);
 }
 

--- a/packages/collab-web/test/tool-view.test.tsx
+++ b/packages/collab-web/test/tool-view.test.tsx
@@ -201,3 +201,59 @@ describe("ToolView glob scopes", () => {
 		expect(html).not.toContain("…");
 	});
 });
+
+describe("ToolView home redaction", () => {
+	it("renders a glob scope under a home directory home-relative without leaking the username", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="glob"
+				defaultOpen
+				args={{ path: "/home/alice/project/src/**/*.ts" }}
+				result={{ content: [] }}
+			/>,
+		);
+
+		// Home prefix is redacted to ~ even though the value carries glob
+		// metacharacters (the early return used to skip redaction entirely).
+		expect(html).toContain("~/project/src/**/*.ts");
+		expect(html).not.toContain("/home/alice");
+		expect(html).not.toContain("alice/");
+		// The glob pattern itself stays intact.
+		expect(html).toContain("**/*.ts");
+	});
+
+	it("renders a bracketed literal path under a home directory home-relative", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="glob"
+				defaultOpen
+				args={{ path: "/home/alice/project/apps/[id]/page.tsx" }}
+				result={{ content: [] }}
+			/>,
+		);
+
+		// The `[id]` bracket is a glob metacharacter, so elision is skipped —
+		// but home redaction still applies.
+		expect(html).toContain("~/project/apps/[id]/page.tsx");
+		expect(html).not.toContain("/home/alice");
+		expect(html).not.toContain("alice/");
+	});
+});
+
+describe("ToolView UNC paths", () => {
+	it("retains the server/share root of a UNC path through elision", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="inspect_image"
+				defaultOpen
+				args={{ path: "//server/share/file.ts" }}
+				result={{ content: [] }}
+			/>,
+		);
+
+		// The server name must survive — the old elision produced "/…/share/file.ts".
+		expect(html).toContain("server");
+		expect(html).toContain("share");
+		expect(html).toContain("//server/share/file.ts");
+	});
+});

--- a/packages/collab-web/test/tool-view.test.tsx
+++ b/packages/collab-web/test/tool-view.test.tsx
@@ -152,3 +152,20 @@ describe("ToolView xd:// dispatches", () => {
 		expect(html).not.toContain("tv-out-title");
 	});
 });
+
+describe("ToolView browser URLs", () => {
+	it("renders browser tool URLs intact without path-shortening", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="browser"
+				defaultOpen
+				args={{ action: "open", url: "https://example.com/a/b/c" }}
+				result={{ content: [] }}
+			/>,
+		);
+
+		// Scheme + host must survive — shortenPath would have produced "https:/…/b/c".
+		expect(html).toContain("https://example.com");
+		expect(html).not.toContain("…/b/c");
+	});
+});

--- a/packages/collab-web/test/tool-view.test.tsx
+++ b/packages/collab-web/test/tool-view.test.tsx
@@ -200,6 +200,57 @@ describe("ToolView glob scopes", () => {
 		expect(html).toContain("memory://root/skills/**/*.md");
 		expect(html).not.toContain("…");
 	});
+
+	it("renders brace-glob scopes with their alternatives intact", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="glob"
+				defaultOpen
+				args={{ path: "src/features/{admin,user}/pages/index.tsx" }}
+				result={{ content: [] }}
+			/>,
+		);
+
+		// `{` is a glob metacharacter — elision would hide which alternatives
+		// were searched ("src/…/pages/index.tsx").
+		expect(html).toContain("src/features/{admin,user}/pages/index.tsx");
+		expect(html).not.toContain("…");
+	});
+
+	it("renders a multi-pattern glob result scope badge with every pattern intact", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="glob"
+				defaultOpen
+				args={{ path: "src/**/*.ts" }}
+				result={{ content: [], details: { scopePath: "src/**/*.ts, test/**/*.ts" } }}
+			/>,
+		);
+
+		// The comma-joined display has >4 segments — shortenPath would have
+		// produced "src/…/**/*.ts", hiding the second pattern.
+		expect(html).toContain("in src/**/*.ts, test/**/*.ts");
+		expect(html).not.toContain("…");
+	});
+});
+
+describe("ToolView grep scopes", () => {
+	it("renders deep and scheme-bearing grep scopes intact", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="grep"
+				defaultOpen
+				args={{ pattern: "foo", path: ["src/deep/nested/path/**/*.ts", "memory://root/skills/**/*.md"] }}
+				result={{ content: [] }}
+			/>,
+		);
+
+		// Both scopes must survive — shortenPath would have produced
+		// "src/…/**/*.ts" and corrupted the scheme to "memory:/…/**/*.md".
+		expect(html).toContain("src/deep/nested/path/**/*.ts");
+		expect(html).toContain("memory://root/skills/**/*.md");
+		expect(html).not.toContain("…");
+	});
 });
 
 describe("ToolView home redaction", () => {
@@ -235,6 +286,22 @@ describe("ToolView home redaction", () => {
 		// The `[id]` bracket is a glob metacharacter, so elision is skipped —
 		// but home redaction still applies.
 		expect(html).toContain("~/project/apps/[id]/page.tsx");
+		expect(html).not.toContain("/home/alice");
+		expect(html).not.toContain("alice/");
+	});
+
+	it("redacts the username from a scheme-prefixed home path", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="glob"
+				defaultOpen
+				args={{ path: "file:///home/alice/project/**/*.ts" }}
+				result={{ content: [] }}
+			/>,
+		);
+
+		// The `://` early return must not skip home redaction.
+		expect(html).toContain("file://~/project/**/*.ts");
 		expect(html).not.toContain("/home/alice");
 		expect(html).not.toContain("alice/");
 	});

--- a/packages/collab-web/test/tool-view.test.tsx
+++ b/packages/collab-web/test/tool-view.test.tsx
@@ -168,6 +168,20 @@ describe("ToolView browser URLs", () => {
 		expect(html).toContain("https://example.com");
 		expect(html).not.toContain("…/b/c");
 	});
+
+	it("redacts home paths in file URLs while preserving the file scheme", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="browser"
+				defaultOpen
+				args={{ action: "open", url: "file:///home/alice/report.html" }}
+				result={{ content: [] }}
+			/>,
+		);
+
+		expect(html).toContain("file://~/report.html");
+		expect(html).not.toContain("/home/alice");
+	});
 });
 
 describe("ToolView glob scopes", () => {
@@ -231,6 +245,25 @@ describe("ToolView glob scopes", () => {
 		// produced "src/…/**/*.ts", hiding the second pattern.
 		expect(html).toContain("in src/**/*.ts, test/**/*.ts");
 		expect(html).not.toContain("…");
+	});
+
+	it("keeps comma-delimited deep scope paths independently compacted", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="glob"
+				defaultOpen
+				args={{ path: "packages/collab-web/src" }}
+				result={{
+					content: [],
+					details: {
+						scopePath: "packages/collab-web/src, packages/coding-agent/src",
+					},
+				}}
+			/>,
+		);
+
+		expect(html).toContain("in packages/collab-web/src, packages/coding-agent/src");
+		expect(html).not.toContain("packages/�?�/src");
 	});
 });
 

--- a/packages/collab-web/test/tool-view.test.tsx
+++ b/packages/collab-web/test/tool-view.test.tsx
@@ -169,3 +169,35 @@ describe("ToolView browser URLs", () => {
 		expect(html).not.toContain("…/b/c");
 	});
 });
+
+describe("ToolView glob scopes", () => {
+	it("renders semicolon-delimited glob scopes intact without middle-eliding", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="glob"
+				defaultOpen
+				args={{ path: "src/**/*.ts; test/**/*.ts" }}
+				result={{ content: [] }}
+			/>,
+		);
+
+		// Both scopes must survive — shortenPath would have produced "src/…/**/*.ts".
+		expect(html).toContain("src/**/*.ts; test/**/*.ts");
+		expect(html).not.toContain("…");
+	});
+
+	it("renders scheme-bearing glob scopes intact without corrupting the scheme", () => {
+		const html = renderToStaticMarkup(
+			<ToolView
+				name="glob"
+				defaultOpen
+				args={{ path: "memory://root/skills/**/*.md" }}
+				result={{ content: [] }}
+			/>,
+		);
+
+		// Scheme + path must survive — shortenPath would have produced "memory:/…/**/*.md".
+		expect(html).toContain("memory://root/skills/**/*.md");
+		expect(html).not.toContain("…");
+	});
+});


### PR DESCRIPTION
## Summary
- make `tool-render/util.ts` re-export the canonical path formatter
- remove the duplicate implementation while preserving existing imports
- use the tolerant renderer behavior for invalid values

## Verification
- `bun run --cwd packages/collab-web check`
- `bun run --cwd packages/collab-web build`
- scoped search: one `shortenPath` implementation
- independent diff review: clean