### PR TITLE
chore: drop dead dependency and exports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -276,7 +276,6 @@
         "@types/react": "catalog:",
         "@types/react-dom": "catalog:",
         "linkedom": "catalog:",
-        "postcss": "catalog:",
       },
     },
     "packages/swarm-extension": {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -1,5 +1,3 @@
-import { HookEditorComponent, HookInputComponent, HookSelectorComponent } from "./modes/components";
-
 // Core session management
 
 // Re-export TUI components for custom tool rendering
@@ -58,9 +56,3 @@ export type * from "./task/types";
 // Tools (detail types and utilities)
 export * from "./tools";
 export * from "./utils/git";
-// UI components for extensions
-export {
-	HookEditorComponent as ExtensionEditorComponent,
-	HookInputComponent as ExtensionInputComponent,
-	HookSelectorComponent as ExtensionSelectorComponent,
-};

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -55,8 +55,7 @@
     "@types/bun": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "linkedom": "catalog:",
-    "postcss": "catalog:"
+    "linkedom": "catalog:"
   },
   "engines": {
     "bun": ">=1.3.14"

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -24,7 +24,7 @@ export * from "./process-name";
 export * as procmgr from "./procmgr";
 export * as prompt from "./prompt";
 export * as ptree from "./ptree";
-export { AbortError, ChildProcess, Exception, NonZeroExitError } from "./ptree";
+export { AbortError, NonZeroExitError } from "./ptree";
 export * from "./runtime-install";
 export * from "./sanitize-text";
 export * from "./snowflake";


### PR DESCRIPTION
## Summary
- remove the unused `postcss` dependency from `omp-stats`
- remove three unused coding-agent component aliases
- remove two unused pi-utils ptree re-exports

## Verification
- `bun install`
- `bun run --cwd packages/stats build`
- `bun run --cwd packages/utils check`
- `bun run --cwd packages/coding-agent check`
- independent diff review: clean