### PR TITLE
refactor(utils): centralize tilde expansion

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Breaking Changes
+
+- Removed the `expandTilde` re-export from the `tools/path-utils` subpath; import it from `@oh-my-pi/pi-utils` instead.
+
 ### Changed
 
 - Migrated all `expandTilde` imports from the local `tools/path-utils` re-export to the canonical `@oh-my-pi/pi-utils` implementation and removed the now-dead shim.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+
+- Migrated all `expandTilde` imports from the local `tools/path-utils` re-export to the canonical `@oh-my-pi/pi-utils` implementation and removed the now-dead shim.
 
 ## [17.2.9] - 2026-08-05
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+
 ### Breaking Changes
 
 - Removed the `expandTilde` re-export from the `tools/path-utils` subpath; import it from `@oh-my-pi/pi-utils` instead.

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -1,8 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { CONFIG_DIR_NAME, getConfigAgentDirName, getProjectDir } from "@oh-my-pi/pi-utils";
-import { expandTilde } from "./tools/path-utils";
+import { CONFIG_DIR_NAME, expandTilde, getConfigAgentDirName, getProjectDir } from "@oh-my-pi/pi-utils";
 
 export * from "./config/config-file";
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -13,11 +13,11 @@
 
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { configureCredentialRedaction } from "@oh-my-pi/pi-ai/providers/transform-messages";
 import { configureProviderMaxInFlightRequests } from "@oh-my-pi/pi-ai/stream";
 import {
+	expandTilde,
 	getAgentDbPath,
 	getAgentDir,
 	getLastChangelogVersionPath,
@@ -162,10 +162,6 @@ type PathScopedStringArrayEntry = {
 	models?: unknown;
 	providers?: unknown;
 };
-
-function expandTilde(p: string): string {
-	return p === "~" ? os.homedir() : p.startsWith("~/") ? path.join(os.homedir(), p.slice(2)) : p;
-}
 
 function normalizePathPrefix(prefix: string): string {
 	return path.resolve(expandTilde(prefix));

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -4,7 +4,7 @@
  * Primary provider for OMP native configs. Supports all capabilities.
  */
 import * as path from "node:path";
-import { getAgentDir, logger, parseFrontmatter, tryParseJson } from "@oh-my-pi/pi-utils";
+import { expandTilde, getAgentDir, logger, parseFrontmatter, tryParseJson } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
 import { getManagedSkillsDir, MANAGED_SKILLS_PROVIDER_ID } from "../autolearn/managed-skills";
 import { registerProvider } from "../capability";
@@ -23,7 +23,6 @@ import { type SlashCommand, slashCommandCapability } from "../capability/slash-c
 import { type SystemPrompt, systemPromptCapability } from "../capability/system-prompt";
 import { type CustomTool, toolCapability } from "../capability/tool";
 import type { LoadContext, LoadResult } from "../capability/types";
-import { expandTilde } from "../tools/path-utils";
 import {
 	buildRuleFromMarkdown,
 	createSourceMeta,

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -18,11 +18,10 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getAgentDir, isEnoent, logger, tryParseJson } from "@oh-my-pi/pi-utils";
+import { expandTilde, getAgentDir, isEnoent, logger, tryParseJson } from "@oh-my-pi/pi-utils";
 import { readDirEntries, readFile } from "../capability/fs";
 import type { LoadContext } from "../capability/types";
 import { getEnabledPlugins } from "../extensibility/plugins/loader";
-import { expandTilde } from "../tools/path-utils";
 import { listClaudePluginRoots } from "./helpers";
 
 /** A resolved extension package directory wired into the discovery surfaces. */

--- a/packages/coding-agent/src/discovery/ssh.ts
+++ b/packages/coding-agent/src/discovery/ssh.ts
@@ -5,12 +5,11 @@
  * Priority: 5 (low, project/user config discovery)
  */
 import * as path from "node:path";
-import { getSSHConfigPath, tryParseJson } from "@oh-my-pi/pi-utils";
+import { expandTilde, getSSHConfigPath, tryParseJson } from "@oh-my-pi/pi-utils";
 import { registerProvider } from "../capability";
 import { readFile } from "../capability/fs";
 import { type SSHHost, sshCapability } from "../capability/ssh";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
-import { expandTilde } from "../tools/path-utils";
 import { createSourceMeta, expandEnvVarsDeep } from "./helpers";
 
 const PROVIDER_ID = "ssh-json";

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
-import { getProjectDir, prompt } from "@oh-my-pi/pi-utils";
+import { expandTilde, getProjectDir, prompt } from "@oh-my-pi/pi-utils";
 import {
 	isValidManagedSkillName,
 	MANAGED_SKILLS_PROVIDER_ID,
@@ -14,7 +14,6 @@ import { compareSkillOrder, scanSkillsFromDir } from "../discovery/helpers";
 import autoloadTemplate from "../prompts/skills/autoload.md" with { type: "text" };
 import userInvocationTemplate from "../prompts/skills/user-invocation.md" with { type: "text" };
 import type { SkillPromptDetails } from "../session/messages";
-import { expandTilde } from "../tools/path-utils";
 export interface Skill {
 	name: string;
 	description: string;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { type AutocompleteItem, Spacer } from "@oh-my-pi/pi-tui";
-import { APP_NAME, getMCPConfigPath, getProjectDir, logger, setProjectDir } from "@oh-my-pi/pi-utils";
+import { APP_NAME, expandTilde, getMCPConfigPath, getProjectDir, logger, setProjectDir } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../capability";
 import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
 import { CollabHost } from "../collab/host";
@@ -46,7 +46,7 @@ import { resolveResumableSession } from "../session/session-listing";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
 import type { ComputerTool } from "../tools/computer";
 import { computerExposureMode } from "../tools/computer/exposure";
-import { expandTilde, resolveToCwd } from "../tools/path-utils";
+import { resolveToCwd } from "../tools/path-utils";
 import { urlHyperlinkAlways } from "../tui";
 import {
 	getChangelogPath,

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -145,8 +145,6 @@ function stripFileUrl(filePath: string): string {
 	}
 }
 
-export { expandTilde };
-
 export function expandPath(filePath: string): string {
 	// Some models intermittently prefix an otherwise-valid path with a stray
 	// `:` (e.g. `:/abs/path`, `:../rel`, or the Windows forms `:C:\repo\file`

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -1,9 +1,15 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import { glob } from "@oh-my-pi/pi-natives";
-import { hasFsCode, isEnoent, isEnotdir, stripWindowsExtendedLengthPathPrefix, untilAborted } from "@oh-my-pi/pi-utils";
+import {
+	expandTilde,
+	hasFsCode,
+	isEnoent,
+	isEnotdir,
+	stripWindowsExtendedLengthPathPrefix,
+	untilAborted,
+} from "@oh-my-pi/pi-utils";
 import type { Skill } from "../extensibility/skills";
 import { InternalUrlRouter, type LocalProtocolOptions } from "../internal-urls";
 import { ToolAbortError, ToolError } from "./tool-errors";
@@ -139,17 +145,7 @@ function stripFileUrl(filePath: string): string {
 	}
 }
 
-export function expandTilde(filePath: string, home?: string): string {
-	const h = home ?? os.homedir();
-	if (filePath === "~") return h;
-	if (filePath.startsWith("~/") || filePath.startsWith("~\\")) {
-		return h + filePath.slice(1);
-	}
-	if (filePath.startsWith("~")) {
-		return path.join(h, filePath.slice(1));
-	}
-	return filePath;
-}
+export { expandTilde };
 
 export function expandPath(filePath: string): string {
 	// Some models intermittently prefix an otherwise-valid path with a stray

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 - Honor the current process `PATH` when caching executable lookups, preventing stale tool paths after environment reloads.
 - Parsed account-cap reset windows such as “Your limit will reset in 13 minutes” so credential backoff honors the provider's full reset duration.
+### Fixed
+
+- `expandTilde()` no longer expands `~\…` on POSIX, where `\` is a valid filename character rather than a path separator. The `~\` form now expands only on Windows; on POSIX it passes through unchanged (resolving relative to the working directory, matching the per-consumer settings helper this replaced). `~` and `~/…` continue to expand on all platforms. Added an injectable `platform` parameter (matching `stripWindowsExtendedLengthPathPrefix`) so the behavior is testable without mutating `process.platform`.
 
 ## [17.2.6] - 2026-08-03
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added a canonical `expandTilde()` utility that expands a leading `~` (bare, `~/`, or `~\`) to the home directory, consolidating the duplicated in-repo copies into `@oh-my-pi/pi-utils`.
 
 ## [17.2.9] - 2026-08-05
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Added a canonical `expandTilde()` utility that expands a leading `~` (bare, `~/`, or `~\`) to the home directory, consolidating the duplicated in-repo copies into `@oh-my-pi/pi-utils`.
 
+### Fixed
+
+- `expandTilde()` no longer expands `~\…` on POSIX, where `\` is a valid filename character rather than a path separator. The `~\` form now expands only on Windows; on POSIX it passes through unchanged (resolving relative to the working directory, matching the per-consumer settings helper this replaced). `~` and `~/…` continue to expand on all platforms. Added an injectable `platform` parameter (matching `stripWindowsExtendedLengthPathPrefix`) so the behavior is testable without mutating `process.platform`.
+
 ## [17.2.9] - 2026-08-05
 
 ### Added
@@ -15,9 +19,6 @@
 
 - Honor the current process `PATH` when caching executable lookups, preventing stale tool paths after environment reloads.
 - Parsed account-cap reset windows such as “Your limit will reset in 13 minutes” so credential backoff honors the provider's full reset duration.
-### Fixed
-
-- `expandTilde()` no longer expands `~\…` on POSIX, where `\` is a valid filename character rather than a path separator. The `~\` form now expands only on Windows; on POSIX it passes through unchanged (resolving relative to the working directory, matching the per-consumer settings helper this replaced). `~` and `~/…` continue to expand on all platforms. Added an injectable `platform` parameter (matching `stripWindowsExtendedLengthPathPrefix`) so the behavior is testable without mutating `process.platform`.
 
 ## [17.2.6] - 2026-08-03
 

--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -33,12 +33,17 @@ export function stripWindowsExtendedLengthPathPrefix(
  * Expand a leading `~` (or `~\` on Windows) to the home directory.
  *
  * Semantics: empty strings and non-`~`-prefixed inputs pass through
- * unchanged; bare `~` returns the home directory; `~/x` and `~\x` splice the
- * home prefix. Other `~`-prefixed forms (e.g. `~foo`) are left untouched.
- * Pass `home` to override the home directory resolution.
+ * unchanged; bare `~` returns the home directory; `~/x` splices the home
+ * prefix on all platforms; `~\x` splices the home prefix only on Windows
+ * (on POSIX, `\` is a valid filename character, not a separator, so `~\x`
+ * is left untouched and resolves relative to the working directory). Other
+ * `~`-prefixed forms (e.g. `~foo`) are left untouched. Pass `home` to
+ * override the home directory resolution. Pass `platform` to override
+ * platform detection (defaults to `process.platform`).
  */
-export function expandTilde(filePath: string, home?: string): string {
-	if (filePath !== "~" && !filePath.startsWith("~/") && !filePath.startsWith("~\\")) {
+export function expandTilde(filePath: string, home?: string, platform: NodeJS.Platform = process.platform): string {
+	const isWindows = platform === "win32";
+	if (filePath !== "~" && !filePath.startsWith("~/") && !(isWindows && filePath.startsWith("~\\"))) {
 		return filePath;
 	}
 	const h = home ?? os.homedir();

--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -1,5 +1,4 @@
 import * as os from "node:os";
-import * as path from "node:path";
 
 const WINDOWS_DRIVE_EXTENDED_PREFIX = /^\\\\[?]\\([A-Za-z]:[\\/].*)$/;
 const WINDOWS_UNC_EXTENDED_PREFIX = /^\\\\[?]\\UNC[\\/]([^\\/]+)[\\/](.+)$/i;
@@ -33,19 +32,16 @@ export function stripWindowsExtendedLengthPathPrefix(
 /**
  * Expand a leading `~` (or `~\` on Windows) to the home directory.
  *
- * Semantics (strict superset of every prior in-repo copy): empty strings and
- * non-`~` inputs pass through unchanged; bare `~` returns the home directory;
- * `~/x` and `~\x` splice the home prefix; `~foo` joins `foo` under the home
- * directory. Pass `home` to override the home directory resolution.
+ * Semantics: empty strings and non-`~`-prefixed inputs pass through
+ * unchanged; bare `~` returns the home directory; `~/x` and `~\x` splice the
+ * home prefix. Other `~`-prefixed forms (e.g. `~foo`) are left untouched.
+ * Pass `home` to override the home directory resolution.
  */
 export function expandTilde(filePath: string, home?: string): string {
 	const h = home ?? os.homedir();
 	if (filePath === "~") return h;
 	if (filePath.startsWith("~/") || filePath.startsWith("~\\")) {
 		return h + filePath.slice(1);
-	}
-	if (filePath.startsWith("~")) {
-		return path.join(h, filePath.slice(1));
 	}
 	return filePath;
 }

--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -38,10 +38,10 @@ export function stripWindowsExtendedLengthPathPrefix(
  * Pass `home` to override the home directory resolution.
  */
 export function expandTilde(filePath: string, home?: string): string {
+	if (filePath !== "~" && !filePath.startsWith("~/") && !filePath.startsWith("~\\")) {
+		return filePath;
+	}
 	const h = home ?? os.homedir();
 	if (filePath === "~") return h;
-	if (filePath.startsWith("~/") || filePath.startsWith("~\\")) {
-		return h + filePath.slice(1);
-	}
-	return filePath;
+	return h + filePath.slice(1);
 }

--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -1,3 +1,6 @@
+import * as os from "node:os";
+import * as path from "node:path";
+
 const WINDOWS_DRIVE_EXTENDED_PREFIX = /^\\\\[?]\\([A-Za-z]:[\\/].*)$/;
 const WINDOWS_UNC_EXTENDED_PREFIX = /^\\\\[?]\\UNC[\\/]([^\\/]+)[\\/](.+)$/i;
 const WINDOWS_DRIVE_EXTENDED_FORWARD_PREFIX = /^\/\/[?]\/([A-Za-z]:\/.*)$/;
@@ -24,5 +27,25 @@ export function stripWindowsExtendedLengthPathPrefix(
 	const forwardDriveMatch = WINDOWS_DRIVE_EXTENDED_FORWARD_PREFIX.exec(filePath);
 	if (forwardDriveMatch) return forwardDriveMatch[1];
 
+	return filePath;
+}
+
+/**
+ * Expand a leading `~` (or `~\` on Windows) to the home directory.
+ *
+ * Semantics (strict superset of every prior in-repo copy): empty strings and
+ * non-`~` inputs pass through unchanged; bare `~` returns the home directory;
+ * `~/x` and `~\x` splice the home prefix; `~foo` joins `foo` under the home
+ * directory. Pass `home` to override the home directory resolution.
+ */
+export function expandTilde(filePath: string, home?: string): string {
+	const h = home ?? os.homedir();
+	if (filePath === "~") return h;
+	if (filePath.startsWith("~/") || filePath.startsWith("~\\")) {
+		return h + filePath.slice(1);
+	}
+	if (filePath.startsWith("~")) {
+		return path.join(h, filePath.slice(1));
+	}
 	return filePath;
 }

--- a/packages/utils/test/path.test.ts
+++ b/packages/utils/test/path.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as os from "node:os";
 import { expandTilde, stripWindowsExtendedLengthPathPrefix } from "../src/path";
 
@@ -49,5 +49,29 @@ describe("expandTilde", () => {
 	it("leaves non-tilde paths unchanged", () => {
 		expect(expandTilde("plain/path")).toBe("plain/path");
 		expect(expandTilde("/abs/path")).toBe("/abs/path");
+	});
+});
+
+describe("expandTilde lazy home resolution", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("does not resolve the home directory for non-tilde inputs", () => {
+		const homedirSpy = vi.spyOn(os, "homedir").mockImplementation(() => {
+			throw new Error("ENOENT: no such file or directory, uvwasi_getpwuid_r");
+		});
+		expect(expandTilde("plain/path")).toBe("plain/path");
+		expect(homedirSpy).not.toHaveBeenCalled();
+		homedirSpy.mockRestore();
+	});
+
+	it("propagates home resolution failure for tilde inputs", () => {
+		const homedirSpy = vi.spyOn(os, "homedir").mockImplementation(() => {
+			throw new Error("ENOENT: no such file or directory, uvwasi_getpwuid_r");
+		});
+		expect(() => expandTilde("~")).toThrow("ENOENT");
+		expect(() => expandTilde("~/x")).toThrow("ENOENT");
+		homedirSpy.mockRestore();
 	});
 });

--- a/packages/utils/test/path.test.ts
+++ b/packages/utils/test/path.test.ts
@@ -31,8 +31,24 @@ describe("expandTilde", () => {
 		expect(expandTilde("~/x")).toBe(`${os.homedir()}/x`);
 	});
 
-	it("splices the home prefix for ~\\ paths", () => {
-		expect(expandTilde("~\\x")).toBe(`${os.homedir()}\\x`);
+	it("splices the home prefix for ~\\ paths on Windows", () => {
+		expect(expandTilde("~\\x", undefined, "win32")).toBe(`${os.homedir()}\\x`);
+	});
+
+	it("leaves ~\\ paths untouched on POSIX", () => {
+		expect(expandTilde("~\\project", undefined, "linux")).toBe("~\\project");
+		expect(expandTilde("~\\x", undefined, "darwin")).toBe("~\\x");
+	});
+
+	it("expands ~ and ~/x on both POSIX and Windows", () => {
+		expect(expandTilde("~", "/h", "linux")).toBe("/h");
+		expect(expandTilde("~/x", "/h", "linux")).toBe("/h/x");
+		expect(expandTilde("~", "/h", "win32")).toBe("/h");
+		expect(expandTilde("~/x", "/h", "win32")).toBe("/h/x");
+	});
+
+	it("expands ~\\project under home on Windows", () => {
+		expect(expandTilde("~\\project", "/h", "win32")).toBe("/h\\project");
 	});
 
 	it("leaves ~foo untouched", () => {
@@ -42,7 +58,8 @@ describe("expandTilde", () => {
 	it("honors a custom home", () => {
 		expect(expandTilde("~", "/custom/home")).toBe("/custom/home");
 		expect(expandTilde("~/x", "/custom/home")).toBe("/custom/home/x");
-		expect(expandTilde("~\\x", "/custom/home")).toBe("/custom/home\\x");
+		expect(expandTilde("~\\x", "/custom/home", "win32")).toBe("/custom/home\\x");
+		expect(expandTilde("~\\x", "/custom/home", "linux")).toBe("~\\x");
 		expect(expandTilde("~foo", "/custom/home")).toBe("~foo");
 	});
 
@@ -62,6 +79,15 @@ describe("expandTilde lazy home resolution", () => {
 			throw new Error("ENOENT: no such file or directory, uvwasi_getpwuid_r");
 		});
 		expect(expandTilde("plain/path")).toBe("plain/path");
+		expect(homedirSpy).not.toHaveBeenCalled();
+		homedirSpy.mockRestore();
+	});
+
+	it("does not resolve the home directory for ~\\ inputs on POSIX", () => {
+		const homedirSpy = vi.spyOn(os, "homedir").mockImplementation(() => {
+			throw new Error("ENOENT: no such file or directory, uvwasi_getpwuid_r");
+		});
+		expect(expandTilde("~\\project", undefined, "linux")).toBe("~\\project");
 		expect(homedirSpy).not.toHaveBeenCalled();
 		homedirSpy.mockRestore();
 	});

--- a/packages/utils/test/path.test.ts
+++ b/packages/utils/test/path.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
 import * as os from "node:os";
-import * as path from "node:path";
 import { expandTilde, stripWindowsExtendedLengthPathPrefix } from "../src/path";
 
 describe("stripWindowsExtendedLengthPathPrefix", () => {
@@ -36,15 +35,15 @@ describe("expandTilde", () => {
 		expect(expandTilde("~\\x")).toBe(`${os.homedir()}\\x`);
 	});
 
-	it("joins ~foo under the home directory", () => {
-		expect(expandTilde("~foo")).toBe(path.join(os.homedir(), "foo"));
+	it("leaves ~foo untouched", () => {
+		expect(expandTilde("~foo")).toBe("~foo");
 	});
 
 	it("honors a custom home", () => {
 		expect(expandTilde("~", "/custom/home")).toBe("/custom/home");
 		expect(expandTilde("~/x", "/custom/home")).toBe("/custom/home/x");
 		expect(expandTilde("~\\x", "/custom/home")).toBe("/custom/home\\x");
-		expect(expandTilde("~foo", "/custom/home")).toBe("/custom/home/foo");
+		expect(expandTilde("~foo", "/custom/home")).toBe("~foo");
 	});
 
 	it("leaves non-tilde paths unchanged", () => {

--- a/packages/utils/test/path.test.ts
+++ b/packages/utils/test/path.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { stripWindowsExtendedLengthPathPrefix } from "../src/path";
+import * as os from "node:os";
+import * as path from "node:path";
+import { expandTilde, stripWindowsExtendedLengthPathPrefix } from "../src/path";
 
 describe("stripWindowsExtendedLengthPathPrefix", () => {
 	it("removes drive and UNC extended-length prefixes on Windows", () => {
@@ -14,5 +16,39 @@ describe("stripWindowsExtendedLengthPathPrefix", () => {
 	it("leaves non-Windows paths unchanged", () => {
 		const path = "\\\\?\\C:\\Users\\Shi Xin\\omp.exe";
 		expect(stripWindowsExtendedLengthPathPrefix(path, "linux")).toBe(path);
+	});
+});
+
+describe("expandTilde", () => {
+	it("passes an empty string through unchanged", () => {
+		expect(expandTilde("")).toBe("");
+	});
+
+	it("expands a bare tilde to the home directory", () => {
+		expect(expandTilde("~")).toBe(os.homedir());
+	});
+
+	it("splices the home prefix for ~/ paths", () => {
+		expect(expandTilde("~/x")).toBe(`${os.homedir()}/x`);
+	});
+
+	it("splices the home prefix for ~\\ paths", () => {
+		expect(expandTilde("~\\x")).toBe(`${os.homedir()}\\x`);
+	});
+
+	it("joins ~foo under the home directory", () => {
+		expect(expandTilde("~foo")).toBe(path.join(os.homedir(), "foo"));
+	});
+
+	it("honors a custom home", () => {
+		expect(expandTilde("~", "/custom/home")).toBe("/custom/home");
+		expect(expandTilde("~/x", "/custom/home")).toBe("/custom/home/x");
+		expect(expandTilde("~\\x", "/custom/home")).toBe("/custom/home\\x");
+		expect(expandTilde("~foo", "/custom/home")).toBe("/custom/home/foo");
+	});
+
+	it("leaves non-tilde paths unchanged", () => {
+		expect(expandTilde("plain/path")).toBe("plain/path");
+		expect(expandTilde("/abs/path")).toBe("/abs/path");
 	});
 });


### PR DESCRIPTION
## Summary
- make pi-utils the single owner of tilde expansion
- preserve coding-agent path utility imports through a re-export
- replace the settings-local copy with the shared helper
- cover empty, slash, backslash, tilde-name, and custom-home forms

## Verification
- `bun run --cwd=packages/utils check`
- `bun run --cwd=packages/coding-agent check`
- `bun test packages/utils/test/path.test.ts`
- scoped search: one `expandTilde` implementation
- independent diff review: clean