### PR TITLE
fix(coding-agent): corrective memory:// error under hindsight backend

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `read memory://<id>` returning a confusing "Unknown memory namespace" error under `memory.backend=hindsight` (Hindsight stores memories server-side and has no `memory://` addressing); the handler now returns a corrective pointer to `recall`/`reflect` so a stray read — steered by the shared `recall` tool description — self-corrects in one turn ([#7587](https://github.com/can1357/oh-my-pi/issues/7587)).
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -291,6 +291,20 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 		if (namespace !== MEMORY_NAMESPACE) {
 			const mnemopiStates = mnemopiSessionStatesFromRegistry();
 			if (mnemopiStates.length === 0) {
+				// Hindsight keeps memories server-side and exposes no
+				// `memory://<id>` addressing, yet the shared `recall` tool
+				// description still steers a follow-up `read memory://<id>`.
+				// Return a corrective pointer so that stray read self-corrects in
+				// one turn instead of derailing on the generic namespace error
+				// (issue #7587).
+				const hindsightActive = AgentRegistry.global()
+					.list()
+					.some(ref => ref.session?.getHindsightSessionState?.());
+				if (hindsightActive) {
+					throw new Error(
+						"Hindsight memories are not addressable via memory://. Recall results are final — use `recall` to search or `reflect` to synthesize. `read memory://<id>` is only available with memory.backend=mnemopi.",
+					);
+				}
 				throw new Error(
 					`Unknown memory namespace: ${namespace}. Supported: ${MEMORY_NAMESPACE} (file-backed memory summary), or a mnemopi memory id when memory.backend=mnemopi is active.`,
 				);

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -524,3 +524,50 @@ describe("MemoryProtocolHandler — mnemopi bridge (issue #4443)", () => {
 		});
 	});
 });
+
+/**
+ * Register a live session simulating memory.backend=hindsight: it exposes a
+ * Hindsight state but no mnemopi state, so the handler must treat memory://<id>
+ * as unaddressable and return a corrective pointer (issue #7587).
+ */
+function withHindsightSession(fn: () => Promise<void>): Promise<void> {
+	const session = {
+		getHindsightSessionState: () => ({ bankId: "test-bank" }),
+	} as unknown as AgentSession;
+	AgentRegistry.global().register({
+		id: "test-hindsight",
+		displayName: "test-hindsight",
+		kind: "main",
+		session,
+		sessionFile: null,
+	});
+	return fn();
+}
+
+describe("MemoryProtocolHandler — hindsight (issue #7587)", () => {
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		InternalUrlRouter.resetForTests();
+	});
+
+	afterEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		InternalUrlRouter.resetForTests();
+	});
+
+	it("returns a corrective error for memory://<id> when hindsight is active", async () => {
+		await withHindsightSession(async () => {
+			const router = InternalUrlRouter.instance();
+			await expect(router.resolve("memory://a1b2c3d4e5f6")).rejects.toThrow(
+				/Hindsight memories are not addressable via memory:\/\/.*use `recall`.*`reflect`/s,
+			);
+		});
+	});
+
+	it("keeps the generic namespace error when no memory backend is active", async () => {
+		const router = InternalUrlRouter.instance();
+		await expect(router.resolve("memory://a1b2c3d4e5f6")).rejects.toThrow(
+			/Unknown memory namespace: a1b2c3d4e5f6\. Supported: root/,
+		);
+	});
+});


### PR DESCRIPTION
## Repro
With `memory.backend=hindsight`, the shared `recall` tool description (`prompts/tools/recall.md:7`) instructs a follow-up `read memory://<id>`, but the `memory://` handler resolves only `root` and mnemopi ids. Registering a live session whose `getHindsightSessionState()` is set and resolving `memory://a1b2c3d4e5f6` via `InternalUrlRouter` fails with the generic:

```
Unknown memory namespace: a1b2c3d4e5f6. Supported: root (file-backed memory summary), or a mnemopi memory id when memory.backend=mnemopi is active.
```

The message never mentions Hindsight, so a model following the tool's own docs hits a dead end and retries/derails.

## Cause
`MemoryProtocolHandler.resolve` in `packages/coding-agent/src/internal-urls/memory-protocol.ts` has only two branches: `memory://root` (file-backed summaries) and `memory://<id>` via `mnemopiSessionStatesFromRegistry()`. There is no Hindsight branch, and Hindsight keeps memories server-side with no `memory://` addressing (`RecallResult.id` is a memory-unit id with no `getMemory` endpoint in `hindsight/client.ts`). So under Hindsight, any `memory://<id>` read falls through to the mnemopi-only "Unknown memory namespace" error.

## Fix
- `memory-protocol.ts`: when a `memory://<id>` (non-`root`) read arrives, no mnemopi state can serve it, and a live session has an active Hindsight backend (`AgentRegistry.global().list().some(ref => ref.session?.getHindsightSessionState?.())`), throw a corrective error pointing at `recall`/`reflect` and noting `memory://<id>` reads require `memory.backend=mnemopi`.
- `test/internal-urls/memory-protocol.test.ts`: regression tests — the corrective error fires when Hindsight is active, and the generic namespace error is preserved when no backend is active.
- `CHANGELOG.md`: `[Unreleased] > Fixed` entry.

Scope note (maintainer-owned, intentionally not touched here): the cleanest cure the reporter proposes is a backend-aware `recall.md` (a prompt file) and emitting ids in `formatMemories` so `read memory://<id>` actually resolves against the Hindsight bank. Making the read *succeed* needs a Hindsight get-memory-by-id endpoint that the client does not expose and I could not verify against a live server, and the prompt/tool-description edits are maintainer territory. This PR turns the guaranteed dead-end into a one-turn self-correction without editing prompts or fabricating API surface.

## Verification
`bun test test/internal-urls/memory-protocol.test.ts` → 23 pass, 0 fail. Manual repro before/after: pre-fix the resolve throws the generic namespace error; post-fix it throws "Hindsight memories are not addressable via memory://. Recall results are final — use `recall` ... `reflect` ...". Pre-publish gate (`bun run fix` + `bun check`) passed on push. Fixes #7587