### PR TITLE
fix(coding-agent): split semicolon path lists that trip ENAMETOOLONG

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `grep`/`glob` silently collapsing a semicolon-delimited `path` list to one literal path when the joined string was too long for the OS to name (`ENAMETOOLONG`) — a list of bare filenames past `NAME_MAX` or absolute paths past `PATH_MAX` failed with `Path not found: <whole list>` even though every entry existed. The multipath probe now treats `ENAMETOOLONG` as a definitively non-existent single path so the split proceeds, and `glob` surfaces a clean `Path not found` instead of leaking the raw errno ([#7597](https://github.com/can1357/oh-my-pi/issues/7597)).
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/coding-agent/src/tools/glob.ts
+++ b/packages/coding-agent/src/tools/glob.ts
@@ -6,7 +6,7 @@ import type { ToolExample } from "@oh-my-pi/pi-ai";
 import * as natives from "@oh-my-pi/pi-natives";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Text } from "@oh-my-pi/pi-tui";
-import { formatGroupedPaths, isEnoent, prompt, untilAborted } from "@oh-my-pi/pi-utils";
+import { formatGroupedPaths, hasFsCode, isEnoent, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { InternalUrlRouter } from "../internal-urls";
 import { splitMemoryGlobPattern } from "../internal-urls/memory-protocol";
@@ -415,7 +415,9 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 				try {
 					stat = await fs.promises.stat(target.searchPath);
 				} catch (err) {
-					if (isEnoent(err)) {
+					// ENAMETOOLONG can never name a real target; surface a clean
+					// "Path not found" instead of leaking the raw errno (issue #7597).
+					if (isEnoent(err) || hasFsCode(err, "ENAMETOOLONG")) {
 						if (isSingle) throw new ToolError(`Path not found: ${scopePath}`);
 						return [];
 					}

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import { glob } from "@oh-my-pi/pi-natives";
-import { isEnoent, isEnotdir, stripWindowsExtendedLengthPathPrefix, untilAborted } from "@oh-my-pi/pi-utils";
+import { hasFsCode, isEnoent, isEnotdir, stripWindowsExtendedLengthPathPrefix, untilAborted } from "@oh-my-pi/pi-utils";
 import type { Skill } from "../extensibility/skills";
 import { InternalUrlRouter, type LocalProtocolOptions } from "../internal-urls";
 import { ToolAbortError, ToolError } from "./tool-errors";
@@ -337,6 +337,13 @@ export function splitPathAndSel(rawPath: string): { path: string; sel?: string }
  * plus selector `1-2` (issue #4618). `lstat` inspects the entry itself, so a
  * dangling symlink is still detected as present; ambiguous errors resolve to
  * `"unknown"` so callers keep the raw path instead of guessing.
+ *
+ * `ENAMETOOLONG` resolves to `"missing"` rather than `"unknown"`: a path whose
+ * component or whole length exceeds the OS limit can never name a real single
+ * entry, so it is strictly stronger evidence of non-existence than `ENOENT`.
+ * Without this, a semicolon-joined `path` list long enough to trip the limit
+ * (bare filenames past `NAME_MAX`, or a total past `PATH_MAX`) was read as one
+ * literal path and the delimited split was suppressed (issue #7597).
  */
 export async function probeLiteralPathExists(filePath: string, cwd: string): Promise<"exists" | "missing" | "unknown"> {
 	const resolved = resolveReadPath(filePath, cwd);
@@ -344,7 +351,7 @@ export async function probeLiteralPathExists(filePath: string, cwd: string): Pro
 		await fs.promises.lstat(resolved);
 		return "exists";
 	} catch (err) {
-		if (isEnoent(err) || isEnotdir(err)) return "missing";
+		if (isEnoent(err) || isEnotdir(err) || hasFsCode(err, "ENAMETOOLONG")) return "missing";
 		return "unknown";
 	}
 }
@@ -762,7 +769,10 @@ async function delimitedPathPartResolves(entry: string, cwd: string, splitter: P
 		await fs.promises.stat(absoluteBasePath);
 		return true;
 	} catch (err) {
-		if (isEnoent(err)) return false;
+		// ENOENT and ENAMETOOLONG both mean this string cannot name an existing
+		// path, so the whole entry does not resolve and the delimited split may
+		// proceed (issue #7597). Other errors (EACCES, transient I/O) stay fatal.
+		if (isEnoent(err) || hasFsCode(err, "ENAMETOOLONG")) return false;
 		throw err;
 	}
 }

--- a/packages/coding-agent/test/tools/glob-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/glob-validate-paths.test.ts
@@ -106,6 +106,24 @@ describe("delimited path expansion", () => {
 		).toEqual(["apps/**/*.txt", "packages/**/*.txt"]);
 	});
 
+	it("splits a semicolon list whose joined string exceeds NAME_MAX (issue #7597)", async () => {
+		// Bare filenames in one directory form a single slash-free run once joined,
+		// so ~12 short entries already push the run past NAME_MAX (255). lstat on
+		// the joined string then throws ENAMETOOLONG, which used to be read as an
+		// inconclusive probe and suppress the split, collapsing the whole list to
+		// one non-existent literal path.
+		const names: string[] = [];
+		for (let i = 0; i < 20; i++) {
+			const name = `enametoolong-probe-${String(i).padStart(2, "0")}.txt`;
+			await Bun.write(path.join(tempDir, name), "needle\n");
+			names.push(name);
+		}
+		const joined = names.join("; ");
+		expect(joined.length).toBeGreaterThan(255);
+		expect(await splitDelimitedPathEntry(joined, tempDir)).toEqual(names);
+		expect(await expandDelimitedPathEntries([joined], tempDir)).toEqual(names);
+	});
+
 	it("normalizes Windows path separators before parsing find globs", async () => {
 		expect(parseFindPattern("apps\\**\\*.txt")).toEqual({
 			basePath: "apps",

--- a/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
+++ b/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
@@ -121,6 +121,13 @@ describe("literal colon filename resolution (issue #4618)", () => {
 			await fs.symlink(path.join(tmpDir, "nowhere"), literal);
 			expect(await probeLiteralPathExists(literal, tmpDir)).toBe("exists");
 		});
+
+		it('returns "missing" for an ENAMETOOLONG path (issue #7597)', async () => {
+			// A single component past NAME_MAX can never name a real entry, so the
+			// probe must report "missing" (not "unknown") to let delimited splits run.
+			const overlong = path.join(tmpDir, "x".repeat(300));
+			expect(await probeLiteralPathExists(overlong, tmpDir)).toBe("missing");
+		});
 	});
 
 	describe("read tool", () => {


### PR DESCRIPTION
## Repro
A semicolon-delimited `path` list passed to `grep`/`glob` fails with `Path not found: <whole joined string>` whenever the joined string is a path the OS refuses to name (`ENAMETOOLONG`) — bare filenames whose slash-free joined run exceeds `NAME_MAX` (255), or absolute paths whose total exceeds `PATH_MAX`. Every listed file exists. Verified by driving `expandDelimitedPathEntries([joined], cwd)` against 50 real files: a 250-byte joined run (28 entries) split into all 28, but a 259-byte run (29 entries) collapsed to a single literal path (`splitInto: 1`), and `lstat` on the joined string threw `ENAMETOOLONG`. Boundary sits exactly at `NAME_MAX`.

## Cause
The multipath detector `splitDelimitedPathEntry` (`packages/coding-agent/src/tools/path-utils.ts`) probes the raw joined string with `probeLiteralPathExists` and only splits when the probe reports `"missing"`. `probeLiteralPathExists` mapped only `ENOENT`/`ENOTDIR` to `"missing"`; `ENAMETOOLONG` fell through to `"unknown"`, so the split was suppressed and the whole list flowed downstream as one literal path. The same `ENOENT`-only classification in `delimitedPathPartResolves` re-threw the raw `ENAMETOOLONG` once the probe fix let the split proceed, and `glob`'s `stat` catch leaked the raw errno for a genuinely too-long single path.

## Fix
- `probeLiteralPathExists`: classify `ENAMETOOLONG` as `"missing"` (a path past the OS length limit can never name a real single entry — strictly stronger evidence of non-existence than `ENOENT`). `EACCES`/transient-IO still resolve to `"unknown"`.
- `delimitedPathPartResolves`: treat `ENAMETOOLONG` as unresolved (return `false`) so the whole-entry resolve guard no longer throws.
- `glob` `runTarget`: catch `ENAMETOOLONG` alongside `ENOENT` and surface a clean `Path not found` instead of leaking the raw errno.
- Reused the existing `hasFsCode` helper inline rather than adding a new predicate.

## Verification
`bun test packages/coding-agent/test/tools/glob-validate-paths.test.ts packages/coding-agent/test/tools/path-literal-colon-selector.test.ts` → 41 pass, 0 fail. Added two regression tests: a semicolon list whose joined string exceeds `NAME_MAX` now splits into all entries, and `probeLiteralPathExists` returns `"missing"` for an overlong path. Manually re-ran the repro post-fix: 29- and 50-entry lists now split correctly (`splitInto: 29`, `splitInto: 50`).

Fixes #7597