### PR TITLE
fix(browser): honor explicit Chromium executable override

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `PUPPETEER_EXECUTABLE_PATH` being ignored when a system Chrome installation was detected, preventing Windows users from selecting a compatible headless browser for the shared browser daemon ([#7601](https://github.com/can1357/oh-my-pi/issues/7601)).
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -121,9 +121,9 @@ async function loadBrowsers(): Promise<typeof BrowsersNs> {
 }
 
 /**
- * Resolve the Chromium executable puppeteer will launch, lazily downloading it
- * on first use via @puppeteer/browsers. Skipped when a system Chromium (NixOS)
- * or PUPPETEER_EXECUTABLE_PATH is set. The browser is cached under
+ * Resolve the Chromium executable puppeteer will launch, honoring
+ * PUPPETEER_EXECUTABLE_PATH before system browser detection and lazily
+ * downloading Chromium otherwise. The browser is cached under
  * ~/.omp/puppeteer (getPuppeteerDir). Returns undefined when platform
  * detection fails (puppeteer default resolution takes over). Exported so
  * real-browser tests can probe launchability and skip on hosts missing
@@ -131,10 +131,10 @@ async function loadBrowsers(): Promise<typeof BrowsersNs> {
  */
 let chromiumExecutablePromise: Promise<string | undefined> | undefined;
 export async function ensureChromiumExecutable(): Promise<string | undefined> {
-	const sysChrome = resolveSystemChromium();
-	if (sysChrome) return sysChrome;
 	const envPath = process.env.PUPPETEER_EXECUTABLE_PATH;
 	if (envPath) return envPath;
+	const sysChrome = resolveSystemChromium();
+	if (sysChrome) return sysChrome;
 	if (chromiumExecutablePromise) return chromiumExecutablePromise;
 
 	chromiumExecutablePromise = (async () => {

--- a/packages/coding-agent/test/fixtures/browser-executable-probe.ts
+++ b/packages/coding-agent/test/fixtures/browser-executable-probe.ts
@@ -1,0 +1,7 @@
+import { ensureChromiumExecutable } from "@oh-my-pi/pi-coding-agent/tools/browser/launch";
+
+const platform = process.env.OMP_BROWSER_PROBE_PLATFORM;
+if (platform) Object.defineProperty(process, "platform", { value: platform });
+
+const executable = await ensureChromiumExecutable();
+process.stdout.write(executable ?? "");

--- a/packages/coding-agent/test/tools/browser-launch.test.ts
+++ b/packages/coding-agent/test/tools/browser-launch.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
 import { stealthIgnoreDefaultArgsForTest } from "@oh-my-pi/pi-coding-agent/tools/browser/launch";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const EXECUTABLE_PROBE = path.resolve(import.meta.dir, "../fixtures/browser-executable-probe.ts");
 
 const AUTOMATION_FLAG = "--enable-automation";
 
@@ -30,6 +34,37 @@ describe("browser launch stealth defaults", () => {
 			const ignoreDefaultArgs = stealthIgnoreDefaultArgsForTest(executablePath);
 
 			expect(ignoreDefaultArgs).toContain(AUTOMATION_FLAG);
+		}
+	});
+});
+
+describe("browser executable selection", () => {
+	it("honors PUPPETEER_EXECUTABLE_PATH before a detected Windows system Chrome", async () => {
+		const tempDir = TempDir.createSync("@browser-executable-");
+		try {
+			const override = path.join(tempDir.path(), "chrome-headless-shell.exe");
+			const systemChrome = path.join(tempDir.path(), "Google\\Chrome\\Application\\chrome.exe");
+			await Bun.write(override, "override");
+			await Bun.write(systemChrome, "system");
+
+			const result = Bun.spawnSync([process.execPath, EXECUTABLE_PROBE], {
+				env: {
+					...process.env,
+					OMP_BROWSER_PROBE_PLATFORM: "win32",
+					ProgramFiles: tempDir.path(),
+					"ProgramFiles(x86)": path.join(tempDir.path(), "missing-x86"),
+					LOCALAPPDATA: path.join(tempDir.path(), "missing-local"),
+					PUPPETEER_EXECUTABLE_PATH: override,
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const stderr = new TextDecoder().decode(result.stderr);
+
+			expect(result.exitCode, stderr).toBe(0);
+			expect(new TextDecoder().decode(result.stdout)).toBe(override);
+		} finally {
+			await tempDir.remove();
 		}
 	});
 });


### PR DESCRIPTION
## Repro
On Windows 10 with system Chrome installed, set `PUPPETEER_EXECUTABLE_PATH` to `chrome-headless-shell.exe`, start `omp`, and call browser `open` for any URL; 17.2.7 still launches the system `chrome.exe` with `--remote-debugging-port=0`, which exits before CDP becomes ready. The browser failure is also visible directly with `chrome.exe --headless=new --no-sandbox --user-data-dir=X --remote-debugging-port=0 about:blank`.

## Cause
`ensureChromiumExecutable()` in `packages/coding-agent/src/tools/browser/launch.ts` called `resolveSystemChromium()` before reading `PUPPETEER_EXECUTABLE_PATH`, so any detected Windows Chrome installation masked the documented explicit executable override used by `resolveSharedBrowserLaunchSpec()`.

## Fix
- Resolve `PUPPETEER_EXECUTABLE_PATH` before system browser candidates.
- Add an isolated Windows candidate-selection probe proving a configured headless-shell wins even when system Chrome exists.
- Document the fix in the coding-agent changelog.

## Verification
`bun test test/tools/browser-launch.test.ts` passes 3 tests; `bun check` passes all packages; an end-to-end selection probe changed from `overrideHonored: false` (exit 1) to `overrideHonored: true` (exit 0). Fixes #7601