### PR TITLE
chore(ts): enforce switch non-fallthrough

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,6 +6,7 @@
 		"moduleResolution": "Bundler",
 		"moduleDetection": "force",
 		"strict": true,
+		"noFallthroughCasesInSwitch": true,
 		"skipLibCheck": true,
 		"allowArbitraryExtensions": true,
 		"verbatimModuleSyntax": true,


### PR DESCRIPTION
## Summary
- enable `noFallthroughCasesInSwitch` in the shared TypeScript config
- turn the codebase's existing zero-fallthrough state into a permanent compiler check

## Verification
- `bun check` across all packages
- independent config review: clean

No source file or runtime behavior changed.