### PR TITLE
fix(coding-agent): restore legacy convertToPng export

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy Pi extension validation rejecting plugins such as `remote-pi` that import the package-root `convertToPng` image helper. ([#7610](https://github.com/can1357/oh-my-pi/issues/7610))
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -54,6 +54,7 @@ import { ReadTool } from "../tools/read";
 import { formatBytes } from "../tools/render-utils";
 import { WriteTool } from "../tools/write";
 import { EventBus } from "../utils/event-bus";
+import { convertImageToPng } from "../utils/image-loading";
 import { discoverExtensionPaths, loadExtensionFromFactory, loadExtensions } from "./extensions";
 import { ExtensionRuntime } from "./extensions/loader";
 import type { ExtensionFactory, ToolDefinition } from "./extensions/types";
@@ -381,6 +382,28 @@ async function executeLegacyBashOperations(
 			throw new Error(appendStatus(text, `Command timed out after ${err.message.slice("timeout:".length)} seconds`));
 		}
 		throw err;
+	}
+}
+
+/**
+ * Convert an image attachment to PNG using the legacy package-root contract.
+ *
+ * Invalid or unsupported image data returns `null`, matching Pi's historical
+ * helper instead of surfacing Bun's decoder error to extensions.
+ */
+export async function convertToPng(
+	base64Data: string,
+	mimeType: string,
+): Promise<{ data: string; mimeType: string } | null> {
+	if (mimeType === "image/png") {
+		return { data: base64Data, mimeType };
+	}
+
+	try {
+		const converted = await convertImageToPng({ type: "image", data: base64Data, mimeType });
+		return { data: converted.data, mimeType: converted.mimeType };
+	} catch {
+		return null;
 	}
 }
 

--- a/packages/coding-agent/test/extensibility/legacy-pi-image-convert.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-image-convert.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { convertToPng } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
+
+const RED_1X1_PNG_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+describe("legacy shim image conversion", () => {
+	it("preserves PNG attachments without re-encoding", async () => {
+		await expect(convertToPng(RED_1X1_PNG_BASE64, "image/png")).resolves.toEqual({
+			data: RED_1X1_PNG_BASE64,
+			mimeType: "image/png",
+		});
+	});
+
+	it("converts decodable image attachments to PNG", async () => {
+		const jpeg = await new Bun.Image(Buffer.from(RED_1X1_PNG_BASE64, "base64")).jpeg({ quality: 90 }).toBase64();
+		const converted = await convertToPng(jpeg, "image/jpeg");
+
+		expect(converted?.mimeType).toBe("image/png");
+		expect(Buffer.from(converted?.data ?? "", "base64").subarray(0, PNG_SIGNATURE.byteLength)).toEqual(PNG_SIGNATURE);
+	});
+
+	it("returns null when image decoding fails", async () => {
+		await expect(convertToPng("not-base64-image-data", "image/jpeg")).resolves.toBeNull();
+	});
+});


### PR DESCRIPTION
## Repro

Running `HOME=/tmp/omp-7610-repro bun run dev plugin install npm:remote-pi` on current `main` exits 1 during extension validation with `Export named 'convertToPng' not found` from `remote-pi/dist/index.js`.

## Cause

`packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts` did not expose Pi's historical package-root `convertToPng` helper, so Bun's static named-export validation rejected `remote-pi` before installation even though OMP already has image conversion in `convertImageToPng`.

## Fix

- Add the legacy `convertToPng(base64Data, mimeType)` contract to the compatibility shim, preserving PNG passthrough and `null` on decoder failure while using OMP's central image conversion path.
- Cover PNG passthrough, JPEG-to-PNG conversion, and invalid image input through the public shim specifier.
- Record the compatibility fix in the coding-agent changelog.

## Verification

`bun test packages/coding-agent/test/extensibility/legacy-pi-image-convert.test.ts` passes 3 tests. `HOME=/tmp/omp-7610-repro bun run dev plugin install npm:remote-pi` now reports `Installed remote-pi@0.5.5`. `bun check` passes.

Fixes #7610