### PR TITLE
chore(ts): enforce noImplicitOverride

### DIFF
--- a/packages/agent/src/compaction/errors.ts
+++ b/packages/agent/src/compaction/errors.ts
@@ -11,7 +11,7 @@
  */
 
 export class CompactionCancelledError extends Error {
-	readonly name = "CompactionCancelledError" as const;
+	override readonly name = "CompactionCancelledError" as const;
 
 	constructor(message = "Compaction cancelled") {
 		super(message);
@@ -27,7 +27,7 @@ export class CompactionCancelledError extends Error {
  * ordinary summarization errors and must not fall through to another provider.
  */
 export class NativeCompactionError extends Error {
-	readonly name = "NativeCompactionError" as const;
+	override readonly name = "NativeCompactionError" as const;
 
 	constructor(cause: unknown) {
 		super(cause instanceof Error ? cause.message : String(cause), { cause });

--- a/packages/ai/src/registry/oauth/devin.ts
+++ b/packages/ai/src/registry/oauth/devin.ts
@@ -33,7 +33,7 @@ class DevinOAuthFlow extends OAuthCallbackFlow {
 		});
 	}
 
-	generateState(): string {
+	override generateState(): string {
 		return crypto.randomUUID();
 	}
 

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -409,7 +409,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				this.emitCodexResponse({ messageId: "msg_opaque", responseId: "resp_opaque", text: "pong" });
 			}
 		}
@@ -1316,7 +1316,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				const added = encodeWebSocketMessage({
 					type: "response.output_item.added",
 					item: { type: "message", id: "msg_ws", role: "assistant", status: "in_progress", content: [] },
@@ -1374,7 +1374,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				this.emitCodexResponse({ messageId: "msg_obs", responseId: "resp_obs", text: "Observed" });
 			}
 		}
@@ -1431,7 +1431,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				this.sendJson({
 					type: "response.done",
 					response: {
@@ -1484,7 +1484,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				this.sendJson({
 					type: "response.done",
 					response: {
@@ -1638,7 +1638,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(data: string): void {
+			override send(data: string): void {
 				sentRequests.push(JSON.parse(data) as Record<string, unknown>);
 				this.emitCodexResponse({ messageId: "msg_lite", responseId: "resp_lite", text: "Hi" });
 			}
@@ -2876,7 +2876,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(data: string): void {
+			override send(data: string): void {
 				websocketRequestCount += 1;
 				const body: unknown = JSON.parse(data);
 				if (websocketRequestCount === 1) {
@@ -3064,7 +3064,7 @@ describe("openai-codex streaming", () => {
 				});
 			}
 
-			send(_data: string): void {
+			override send(_data: string): void {
 				websocketRequestCount += 1;
 				this.emitCodexResponse({
 					messageId: `msg_pre_turn_${websocketRequestCount}`,
@@ -3184,7 +3184,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(data: string): void {
+			override send(data: string): void {
 				sentRequests.push(JSON.parse(data) as Record<string, unknown>);
 				this.sendJson({
 					type: "response.output_item.added",
@@ -3269,7 +3269,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(data: string): void {
+			override send(data: string): void {
 				sentRequests.push(JSON.parse(data) as Record<string, unknown>);
 				const responseIndex = sentRequests.length;
 				this.emitCodexResponse({
@@ -3409,7 +3409,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(data: string): void {
+			override send(data: string): void {
 				sentRequests.push(JSON.parse(data) as Record<string, unknown>);
 				if (sentRequests.length === 1) {
 					this.sendJson({
@@ -3508,7 +3508,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				this.sendJson({
 					type: "response.completed",
 					response: {
@@ -3564,7 +3564,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				this.#sendCount += 1;
 				if (this.#sendCount === 1) {
 					this.emitCodexResponse({
@@ -3653,7 +3653,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(data: string): void {
+			override send(data: string): void {
 				sentRequests.push(JSON.parse(data) as Record<string, unknown>);
 				const responseIndex = sentRequests.length;
 				this.emitCodexResponse({
@@ -3770,7 +3770,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(data: string): void {
+			override send(data: string): void {
 				const request = JSON.parse(data) as Record<string, unknown>;
 				sentRequests.push(request);
 				const requestIndex = sentRequests.length;
@@ -3878,7 +3878,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(data: string): void {
+			override send(data: string): void {
 				const request = JSON.parse(data) as Record<string, unknown>;
 				sentRequests.push(request);
 				const requestIndex = sentRequests.length;
@@ -3996,7 +3996,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				this.emitCodexResponse({ messageId: "msg_v2", responseId: "resp_v2", text: "Hello v2" });
 			}
 		}
@@ -4053,7 +4053,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				sendCount += 1;
 			}
 		}
@@ -4113,7 +4113,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				sendCount += 1;
 				this.sendJson({
 					type: "response.output_item.added",
@@ -4143,7 +4143,7 @@ describe("openai-codex streaming", () => {
 				}, 2);
 			}
 
-			close(): void {
+			override close(): void {
 				if (interval) clearInterval(interval);
 				super.close();
 			}
@@ -4190,7 +4190,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				sendCount += 1;
 				this.sendJson({
 					type: "response.output_item.added",
@@ -4213,7 +4213,7 @@ describe("openai-codex streaming", () => {
 				}
 			}
 
-			close(): void {
+			override close(): void {
 				closeCount += 1;
 				super.close();
 			}
@@ -4257,7 +4257,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				if (this.#index === 0) {
 					// First attempt: a function call whose arguments are only whitespace.
 					// A completed reasoning item lands in nativeOutputItems before the
@@ -4313,7 +4313,7 @@ describe("openai-codex streaming", () => {
 				});
 			}
 
-			close(): void {
+			override close(): void {
 				closeCount += 1;
 				super.close();
 			}
@@ -4384,7 +4384,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				sendCount += 1;
 				this.sendJson({
 					type: "response.output_item.added",
@@ -4436,7 +4436,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				// Every frame lands in the connection queue synchronously, before the
 				// consumer microtask drains any of them; the close event used to wipe
 				// the queued terminal event and turn success into a transport error.
@@ -4479,7 +4479,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				this.sendJson({
 					type: "response.output_item.added",
 					item: { type: "function_call", id: "fc_limit", call_id: "call_limit", name: "todo", arguments: "" },
@@ -4534,13 +4534,13 @@ describe("openai-codex streaming", () => {
 				this.emit("open", new Event("open"));
 			}
 
-			close(): void {
+			override close(): void {
 				const wasPending = this.readyState === MockWebSocket.CONNECTING;
 				super.close();
 				if (wasPending) this.emit("close", { code: 1000 } as unknown as Event);
 			}
 
-			send(): void {
+			override send(): void {
 				this.emitCodexResponse({ messageId: "msg_join", responseId: "resp_join", text: "Joined" });
 			}
 		}
@@ -4597,7 +4597,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				sendCount += 1;
 				this.sendJson({
 					type: "response.output_item.added",
@@ -4669,7 +4669,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(data: string): void {
+			override send(data: string): void {
 				const request = JSON.parse(data) as { type?: string };
 				const requestType = typeof request.type === "string" ? request.type : "";
 				sentTypesByConnection[this.#connectionIndex]?.push(requestType);
@@ -4796,7 +4796,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(): void {
+			override send(): void {
 				this.sendJson({
 					type: "response.output_item.added",
 					item: {
@@ -4886,7 +4886,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(data: string): void {
+			override send(data: string): void {
 				this.#sendCount += 1;
 				const request = JSON.parse(data) as { type?: string };
 				requestTypes.push(typeof request.type === "string" ? request.type : "");
@@ -4979,7 +4979,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(data: string): void {
+			override send(data: string): void {
 				sendCount += 1;
 				const request = JSON.parse(data) as Record<string, unknown>;
 				expect(typeof request.type).toBe("string");
@@ -5272,7 +5272,7 @@ describe("openai-codex streaming", () => {
 				this.scheduleOpen();
 			}
 
-			send(_data: string): void {
+			override send(_data: string): void {
 				sendCount += 1;
 				if (sendCount === 1) {
 					this.emitCodexResponse({

--- a/packages/coding-agent/src/config/config-file.ts
+++ b/packages/coding-agent/src/config/config-file.ts
@@ -109,11 +109,11 @@ export class ConfigError extends Error {
 		this.#message = message;
 	}
 
-	get message(): string {
+	override get message(): string {
 		return this.#message;
 	}
 
-	toString(): string {
+	override toString(): string {
 		return this.message;
 	}
 }

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -607,12 +607,12 @@ export class KeybindingsManager extends TuiKeybindingsManager {
 		this.setUserBindings(mergeKeybindingsConfig(inheritedConfig, profileConfig));
 	}
 
-	setUserBindings(userBindings: KeybindingsConfig): void {
+	override setUserBindings(userBindings: KeybindingsConfig): void {
 		this.#userBindings = userBindings;
 		super.setUserBindings(userBindings);
 	}
 
-	getKeys(keybinding: Keybinding): KeyId[] {
+	override getKeys(keybinding: Keybinding): KeyId[] {
 		const keys = super.getKeys(keybinding);
 		const fallbackKey = getFallbackKey(keybinding);
 		if (fallbackKey === undefined || this.#userBindings[keybinding] !== undefined) return keys;
@@ -620,7 +620,7 @@ export class KeybindingsManager extends TuiKeybindingsManager {
 		return removeKey(keys, fallbackKey);
 	}
 
-	getResolvedBindings(): KeybindingsConfig {
+	override getResolvedBindings(): KeybindingsConfig {
 		const resolved = super.getResolvedBindings();
 		resolved[FOLLOW_UP_KEYBINDING] = keyConfigValue(this.getKeys(FOLLOW_UP_KEYBINDING));
 		return resolved;

--- a/packages/coding-agent/src/edit/hashline/filesystem.ts
+++ b/packages/coding-agent/src/edit/hashline/filesystem.ts
@@ -87,11 +87,11 @@ export class HashlineFilesystem extends Filesystem {
 		return resolvePlanPath(this.session, relativePath);
 	}
 
-	canonicalPath(relativePath: string): string {
+	override canonicalPath(relativePath: string): string {
 		return canonicalSnapshotKey(this.resolveAbsolute(relativePath));
 	}
 
-	allowTagPathRecovery(authoredPath: string, resolvedPath: string): boolean {
+	override allowTagPathRecovery(authoredPath: string, resolvedPath: string): boolean {
 		// Internal-URL authored targets (`local://`, `vault://`, …) are approved
 		// at the lower "read" privilege; never let one redirect onto a "write".
 		if (isInternalUrlPath(authoredPath)) return false;
@@ -125,7 +125,7 @@ export class HashlineFilesystem extends Filesystem {
 		return content;
 	}
 
-	async readBinary(relativePath: string): Promise<Uint8Array | undefined> {
+	override async readBinary(relativePath: string): Promise<Uint8Array | undefined> {
 		const absolutePath = this.resolveAbsolute(relativePath);
 		if (isNotebookPath(absolutePath)) return undefined;
 		try {
@@ -136,7 +136,7 @@ export class HashlineFilesystem extends Filesystem {
 		}
 	}
 
-	async preflightWrite(relativePath: string, options?: PreflightWriteOptions): Promise<void> {
+	override async preflightWrite(relativePath: string, options?: PreflightWriteOptions): Promise<void> {
 		const fileOp = options?.fileOp;
 		if (fileOp?.kind === "rem") {
 			enforcePlanModeWrite(this.session, relativePath, { op: "delete" });
@@ -149,7 +149,7 @@ export class HashlineFilesystem extends Filesystem {
 		enforcePlanModeWrite(this.session, relativePath, { op: "update" });
 	}
 
-	async delete(relativePath: string): Promise<void> {
+	override async delete(relativePath: string): Promise<void> {
 		enforcePlanModeWrite(this.session, relativePath, { op: "delete" });
 		const absolutePath = this.resolveAbsolute(relativePath);
 		try {
@@ -168,7 +168,7 @@ export class HashlineFilesystem extends Filesystem {
 		invalidateFsScanAfterWrite(absolutePath);
 	}
 
-	async move(fromRelative: string, toRelative: string, content?: string): Promise<void> {
+	override async move(fromRelative: string, toRelative: string, content?: string): Promise<void> {
 		enforcePlanModeWrite(this.session, fromRelative, { op: "update", move: toRelative });
 		const fromAbsolute = this.resolveAbsolute(fromRelative);
 		const toAbsolute = this.resolveAbsolute(toRelative);
@@ -240,7 +240,7 @@ export class HashlineFilesystem extends Filesystem {
 		return { text: content };
 	}
 
-	async exists(relativePath: string): Promise<boolean> {
+	override async exists(relativePath: string): Promise<boolean> {
 		const absolutePath = this.resolveAbsolute(relativePath);
 		return Bun.file(absolutePath).exists();
 	}

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -258,7 +258,7 @@ export class AgentHubOverlayComponent extends Container {
 	}
 
 	/** Tear down every subscription and timer. Called by the overlay owner on close. */
-	dispose(): void {
+	override dispose(): void {
 		for (const unsubscribe of this.#unsubscribers.splice(0)) unsubscribe();
 		if (this.#ageTimer) {
 			clearInterval(this.#ageTimer);

--- a/packages/coding-agent/src/modes/components/bordered-loader.ts
+++ b/packages/coding-agent/src/modes/components/bordered-loader.ts
@@ -35,7 +35,7 @@ export class BorderedLoader extends Container {
 		this.#loader.handleInput(data);
 	}
 
-	dispose(): void {
+	override dispose(): void {
 		this.#loader.dispose();
 	}
 }

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -466,7 +466,7 @@ export class CustomEditor extends Editor {
 	/** Decorate magic keywords, attachments, and the queue-composer header/list markers.
 	 *  Queue shorthand reserves its first logical line as a dim `Queueing` label; sequential
 	 *  item markers use the accent color so separate follow-ups remain visible while composing. */
-	decorateText = (text: string): string => {
+	override decorateText = (text: string): string => {
 		const editorText = this.getText();
 		const animated = this.focused && this.#shimmerEnabled() && hasMagicKeyword(editorText);
 		const phase = animated ? (Date.now() % CustomEditor.SHIMMER_PERIOD_MS) / CustomEditor.SHIMMER_PERIOD_MS : 0;
@@ -775,7 +775,7 @@ export class CustomEditor extends Editor {
 		void promise.then(this.#onPasteSettled, this.#onPasteSettled);
 	}
 
-	handleInput(data: string): void {
+	override handleInput(data: string): void {
 		// Serialize behind any in-flight async paste so a trailing Enter / follow-up key can't
 		// submit before the clipboard image reaches `pendingImages` (Codex PR #3602 review).
 		if (this.#pasteInFlight > 0) {

--- a/packages/coding-agent/src/modes/components/hook-input.ts
+++ b/packages/coding-agent/src/modes/components/hook-input.ts
@@ -81,7 +81,7 @@ export class HookInputComponent extends Container {
 		this.#input.pasteText(text);
 	}
 
-	dispose(): void {
+	override dispose(): void {
 		this.#countdown?.dispose();
 	}
 }

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -135,7 +135,7 @@ class OutlinedList extends Container {
 		this.invalidate();
 	}
 
-	render(width: number): readonly string[] {
+	override render(width: number): readonly string[] {
 		const borderColor = (text: string) => theme.fg("border", text);
 		const horizontal = borderColor(theme.boxRound.horizontal.repeat(Math.max(1, width)));
 		const innerWidth = Math.max(1, width - 2);
@@ -685,7 +685,7 @@ export class HookSelectorComponent extends Container {
 		return super.render(renderWidth);
 	}
 
-	dispose(): void {
+	override dispose(): void {
 		this.#countdown?.dispose();
 	}
 }

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -905,7 +905,7 @@ export class SessionSelectorComponent extends Container {
 	 * is mounted the list is detached from the child tree, so Container's
 	 * child-walking dispose would miss its pending history-merge timer.
 	 */
-	dispose(): void {
+	override dispose(): void {
 		this.#sessionList.dispose();
 		super.dispose();
 	}
@@ -971,7 +971,7 @@ export class SessionSelectorComponent extends Container {
 	 * footer is always visible and never drifts as the list window resizes. The
 	 * in-editor selector just appends the footer directly.
 	 */
-	render(width: number): readonly string[] {
+	override render(width: number): readonly string[] {
 		const lines: string[] = [];
 		for (const child of this.children) {
 			const childLines = child.render(width);

--- a/packages/coding-agent/src/task/agents.ts
+++ b/packages/coding-agent/src/task/agents.ts
@@ -85,7 +85,7 @@ export class AgentParsingError extends Error {
 		this.name = "AgentParsingError";
 	}
 
-	toString(): string {
+	override toString(): string {
 		const details: string[] = [this.message];
 		if (this.source !== undefined) {
 			details.push(`Source: ${JSON.stringify(this.source)}`);

--- a/packages/coding-agent/src/tiny/worker.ts
+++ b/packages/coding-agent/src/tiny/worker.ts
@@ -94,7 +94,7 @@ function createStopOnTextCriteria(
 			this.#text = text;
 		}
 
-		_call(inputIds: number[][]): boolean[] {
+		override _call(inputIds: number[][]): boolean[] {
 			return inputIds.map(ids => {
 				const tail = ids.slice(-STOP_DECODE_WINDOW_TOKENS);
 				const decoded = this.#tokenizer.decode(tail, {

--- a/packages/coding-agent/src/web/search/providers/duckduckgo.ts
+++ b/packages/coding-agent/src/web/search/providers/duckduckgo.ts
@@ -372,7 +372,7 @@ export class DuckDuckGoProvider extends SearchProvider {
 		return true;
 	}
 
-	isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+	override isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
 		return true;
 	}
 

--- a/packages/coding-agent/src/web/search/providers/ecosia.ts
+++ b/packages/coding-agent/src/web/search/providers/ecosia.ts
@@ -173,7 +173,7 @@ export class EcosiaProvider extends SearchProvider {
 		return true;
 	}
 
-	isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+	override isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
 		return true;
 	}
 

--- a/packages/coding-agent/src/web/search/providers/exa.ts
+++ b/packages/coding-agent/src/web/search/providers/exa.ts
@@ -458,7 +458,7 @@ export class ExaProvider extends SearchProvider {
 	 * still uses {@link isAvailable} so an unrelated configured provider
 	 * keeps priority over the public fallback.
 	 */
-	isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+	override isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
 		return this.#settingsAllowSearch();
 	}
 

--- a/packages/coding-agent/src/web/search/providers/firecrawl.ts
+++ b/packages/coding-agent/src/web/search/providers/firecrawl.ts
@@ -203,7 +203,7 @@ export class FirecrawlProvider extends SearchProvider {
 	 * Firecrawl supports keyless mode, so an explicit user selection
 	 * (`webSearch: firecrawl`) works without any credential configured.
 	 */
-	isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+	override isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
 		return true;
 	}
 

--- a/packages/coding-agent/src/web/search/providers/mojeek.ts
+++ b/packages/coding-agent/src/web/search/providers/mojeek.ts
@@ -210,7 +210,7 @@ export class MojeekProvider extends SearchProvider {
 		return true;
 	}
 
-	isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+	override isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
 		return true;
 	}
 

--- a/packages/coding-agent/src/web/search/providers/perplexity.ts
+++ b/packages/coding-agent/src/web/search/providers/perplexity.ts
@@ -973,7 +973,7 @@ export class PerplexityProvider extends SearchProvider {
 	 * configured provider keeps priority over the anonymous/OpenRouter
 	 * fallbacks.
 	 */
-	isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+	override isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
 		return true;
 	}
 

--- a/packages/coding-agent/src/web/search/providers/public.ts
+++ b/packages/coding-agent/src/web/search/providers/public.ts
@@ -189,7 +189,7 @@ export class PublicWebProvider extends SearchProvider {
 		return false;
 	}
 
-	isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+	override isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
 		return true;
 	}
 

--- a/packages/coding-agent/src/web/search/providers/startpage.ts
+++ b/packages/coding-agent/src/web/search/providers/startpage.ts
@@ -215,7 +215,7 @@ export class StartpageProvider extends SearchProvider {
 		return true;
 	}
 
-	isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
+	override isExplicitlyAvailable(_authStorage: AuthStorage): boolean {
 		return true;
 	}
 

--- a/packages/coding-agent/test/session-manager-atomic-rewrite-race.test.ts
+++ b/packages/coding-agent/test/session-manager-atomic-rewrite-race.test.ts
@@ -27,7 +27,10 @@ class DetachingRewriteStorage extends MemorySessionStorage {
 	guardRejections = 0;
 	readonly #writers = new Set<DetachableWriter>();
 
-	openWriter(path: string, options?: { flags?: "a" | "w"; onError?: (err: Error) => void }): SessionStorageWriter {
+	override openWriter(
+		path: string,
+		options?: { flags?: "a" | "w"; onError?: (err: Error) => void },
+	): SessionStorageWriter {
 		const inner = super.openWriter(path, options);
 		const writers = this.#writers;
 		const detachedLines = this.detachedLines;

--- a/packages/coding-agent/test/session-manager/large-session-memory.test.ts
+++ b/packages/coding-agent/test/session-manager/large-session-memory.test.ts
@@ -12,7 +12,7 @@ import * as snapcompact from "@oh-my-pi/snapcompact";
 class CountingMemorySessionStorage extends MemorySessionStorage {
 	writeTextSyncCalls = 0;
 
-	writeTextSync(filePath: string, content: string): void {
+	override writeTextSync(filePath: string, content: string): void {
 		this.writeTextSyncCalls++;
 		super.writeTextSync(filePath, content);
 	}

--- a/packages/hashline/src/fs.ts
+++ b/packages/hashline/src/fs.ts
@@ -150,11 +150,11 @@ export class InMemoryFilesystem extends Filesystem {
 		return { text: content };
 	}
 
-	async delete(path: string): Promise<void> {
+	override async delete(path: string): Promise<void> {
 		if (!this.#files.delete(path)) throw new NotFoundError(path);
 	}
 
-	async move(from: string, to: string, content?: string): Promise<void> {
+	override async move(from: string, to: string, content?: string): Promise<void> {
 		const existing = this.#files.get(from);
 		if (existing === undefined) throw new NotFoundError(from);
 		const finalContent = content ?? existing;
@@ -162,7 +162,7 @@ export class InMemoryFilesystem extends Filesystem {
 		this.#files.delete(from);
 	}
 
-	async exists(path: string): Promise<boolean> {
+	override async exists(path: string): Promise<boolean> {
 		return this.#files.has(path);
 	}
 
@@ -199,7 +199,7 @@ export class NodeFilesystem extends Filesystem {
 		return file.text();
 	}
 
-	async readBinary(path: string): Promise<Uint8Array> {
+	override async readBinary(path: string): Promise<Uint8Array> {
 		try {
 			return await fs.readFile(path);
 		} catch (error) {
@@ -213,7 +213,7 @@ export class NodeFilesystem extends Filesystem {
 		return { text: content };
 	}
 
-	async delete(path: string): Promise<void> {
+	override async delete(path: string): Promise<void> {
 		try {
 			await fs.rm(path);
 		} catch (error) {
@@ -222,7 +222,7 @@ export class NodeFilesystem extends Filesystem {
 		}
 	}
 
-	async move(from: string, to: string, content?: string): Promise<void> {
+	override async move(from: string, to: string, content?: string): Promise<void> {
 		if (content !== undefined) {
 			await Bun.write(to, content);
 			await this.delete(from);
@@ -236,11 +236,11 @@ export class NodeFilesystem extends Filesystem {
 		}
 	}
 
-	canonicalPath(path: string): string {
+	override canonicalPath(path: string): string {
 		return pathModule.resolve(path);
 	}
 
-	async exists(path: string): Promise<boolean> {
+	override async exists(path: string): Promise<boolean> {
 		return Bun.file(path).exists();
 	}
 }

--- a/packages/hashline/src/snapshots.ts
+++ b/packages/hashline/src/snapshots.ts
@@ -180,7 +180,7 @@ export class InMemorySnapshotStore extends SnapshotStore {
 		return history?.find(version => version.text === fullText) ?? null;
 	}
 
-	findByHash(hash: string): Snapshot[] {
+	override findByHash(hash: string): Snapshot[] {
 		const matches: Snapshot[] = [];
 		for (const history of this.#versions.values()) {
 			for (const version of history) {

--- a/packages/hashline/test/core-contracts.test.ts
+++ b/packages/hashline/test/core-contracts.test.ts
@@ -71,7 +71,7 @@ class BlockingFilesystem extends InMemoryFilesystem {
 		for (const filePath of blocked) this.#blocked.add(filePath);
 	}
 
-	async preflightWrite(filePath: string): Promise<void> {
+	override async preflightWrite(filePath: string): Promise<void> {
 		if (this.#blocked.has(filePath)) throw new Error(`blocked write: ${filePath}`);
 	}
 }

--- a/packages/hashline/test/patcher.test.ts
+++ b/packages/hashline/test/patcher.test.ts
@@ -158,7 +158,7 @@ describe("Patcher snapshot tag integrity", () => {
 // call returned), but `writeText` echoes back a *reformatted* copy — spaces
 // turned into tabs, exactly the corruption reported against the ACP bridge.
 class DriftingFilesystem extends InMemoryFilesystem {
-	async writeText(path: string, content: string): Promise<WriteResult> {
+	override async writeText(path: string, content: string): Promise<WriteResult> {
 		const drifted = content.replace(/^ {4}/gm, "\t");
 		await super.writeText(path, drifted);
 		return { text: drifted };

--- a/packages/mnemopi/test/recovery.test.ts
+++ b/packages/mnemopi/test/recovery.test.ts
@@ -52,7 +52,7 @@ function withFrozenNow<T>(iso: string, fn: () => T): T {
 			else super(value);
 		}
 
-		static now(): number {
+		static override now(): number {
 			return fixedMs;
 		}
 	}

--- a/packages/tui/src/components/cancellable-loader.ts
+++ b/packages/tui/src/components/cancellable-loader.ts
@@ -34,7 +34,7 @@ export class CancellableLoader extends Loader {
 		}
 	}
 
-	dispose(): void {
+	override dispose(): void {
 		this.stop();
 	}
 }

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -55,7 +55,7 @@ export class Loader extends Text {
 		this.start();
 	}
 
-	render(width: number): readonly string[] {
+	override render(width: number): readonly string[] {
 		const source = super.render(width);
 		if (source !== this.#layoutSource) {
 			const paddingX = getPaddingX(1);

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -804,11 +804,11 @@ markdownParser.use({
 // (no `m` flag), and stickiness only removes the futile later attempts. The
 // flags/anchor guard below skips any rule a future marked version changes.
 class AnchoredAtZero extends RegExp {
-	exec(str: string): RegExpExecArray | null {
+	override exec(str: string): RegExpExecArray | null {
 		this.lastIndex = 0; // sticky matches set lastIndex; rules are shared
 		return super.exec(str);
 	}
-	test(str: string): boolean {
+	override test(str: string): boolean {
 		this.lastIndex = 0;
 		return super.test(str);
 	}

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -87,7 +87,7 @@ class WrappingLinesComponent implements Component {
 }
 
 class UnknownViewportTerminal extends VirtualTerminal {
-	isNativeViewportAtBottom(): undefined {
+	override isNativeViewportAtBottom(): undefined {
 		return undefined;
 	}
 }
@@ -96,7 +96,7 @@ class StaleBottomViewportTerminal extends VirtualTerminal {
 	#previous: boolean | undefined;
 	#returnStale = false;
 
-	isNativeViewportAtBottom(): boolean | undefined {
+	override isNativeViewportAtBottom(): boolean | undefined {
 		const current = super.isNativeViewportAtBottom();
 		if (this.#returnStale) {
 			this.#returnStale = false;
@@ -113,18 +113,18 @@ class StaleBottomViewportTerminal extends VirtualTerminal {
 class CountingViewportTerminal extends VirtualTerminal {
 	viewportProbeCount = 0;
 
-	isNativeViewportAtBottom(): boolean | undefined {
+	override isNativeViewportAtBottom(): boolean | undefined {
 		this.viewportProbeCount += 1;
 		return super.isNativeViewportAtBottom();
 	}
 }
 
 class LegacyKeyboardVirtualTerminal extends VirtualTerminal {
-	get keyboardEnhancementEnterSequence(): string | null {
+	override get keyboardEnhancementEnterSequence(): string | null {
 		return undefined as unknown as string | null;
 	}
 
-	get keyboardEnhancementExitSequence(): string | null {
+	override get keyboardEnhancementExitSequence(): string | null {
 		return undefined as unknown as string | null;
 	}
 }

--- a/packages/tui/test/render-stress-harness.ts
+++ b/packages/tui/test/render-stress-harness.ts
@@ -425,7 +425,7 @@ const BURST_STEP_METADATA = {
 } satisfies Record<BurstStepKind, BurstStepMetadata>;
 
 class UnknownViewportTerminal extends VirtualTerminal {
-	isNativeViewportAtBottom(): undefined {
+	override isNativeViewportAtBottom(): undefined {
 		return undefined;
 	}
 }
@@ -433,7 +433,7 @@ class UnknownViewportTerminal extends VirtualTerminal {
 class IntermittentUnknownViewportTerminal extends VirtualTerminal {
 	#probeCount = 0;
 
-	isNativeViewportAtBottom(): boolean | undefined {
+	override isNativeViewportAtBottom(): boolean | undefined {
 		this.#probeCount += 1;
 		return this.#probeCount % 3 === 0 ? undefined : super.isNativeViewportAtBottom();
 	}
@@ -443,7 +443,7 @@ class StaleBottomTerminal extends VirtualTerminal {
 	#previous: boolean | undefined;
 	#returnStale = false;
 
-	isNativeViewportAtBottom(): boolean | undefined {
+	override isNativeViewportAtBottom(): boolean | undefined {
 		const current = super.isNativeViewportAtBottom();
 		if (this.#returnStale) {
 			this.#returnStale = false;

--- a/packages/typescript-edit-benchmark/src/mutations.ts
+++ b/packages/typescript-edit-benchmark/src/mutations.ts
@@ -489,7 +489,7 @@ class CallArgumentSwapMutation extends BaseAstMutation {
 		return out;
 	}
 
-	mutate(content: string, rng: () => number): [string, MutationInfo] {
+	override mutate(content: string, rng: () => number): [string, MutationInfo] {
 		const parsed = parseCode(content);
 		if (!parsed) return [content, noopInfo()];
 		const candidates = this.collectCandidates(parsed);
@@ -722,7 +722,7 @@ class IdentifierMultiEditMutation extends BaseAstMutation {
 		return out;
 	}
 
-	mutate(content: string, rng: () => number): [string, MutationInfo] {
+	override mutate(content: string, rng: () => number): [string, MutationInfo] {
 		const parsed = parseCode(content);
 		if (!parsed) return [content, noopInfo()];
 		const candidates = this.collectCandidates(parsed);
@@ -1036,7 +1036,7 @@ class SwapAdjacentLinesMutation extends BaseAstMutation {
 		return out;
 	}
 
-	mutate(content: string, rng: () => number): [string, MutationInfo] {
+	override mutate(content: string, rng: () => number): [string, MutationInfo] {
 		const parsed = parseCode(content);
 		if (!parsed) return [content, noopInfo()];
 		const candidates = this.collectCandidates(parsed);

--- a/packages/utils/src/frontmatter.ts
+++ b/packages/utils/src/frontmatter.ts
@@ -71,7 +71,7 @@ export class FrontmatterError extends Error {
 		this.name = "FrontmatterError";
 	}
 
-	toString(): string {
+	override toString(): string {
 		// Format the error with stack and detail, including the error message, stack, and source if present
 		const details: string[] = [this.message];
 		if (this.source !== undefined) {

--- a/packages/utils/test/fixtures/logger-fixed-date-preload.ts
+++ b/packages/utils/test/fixtures/logger-fixed-date-preload.ts
@@ -13,7 +13,7 @@ class FixedDate extends NativeDate {
 		super(value === undefined ? fixtureNow() : value);
 	}
 
-	static now(): number {
+	static override now(): number {
 		return fixtureNow();
 	}
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,6 +6,7 @@
 		"moduleResolution": "Bundler",
 		"moduleDetection": "force",
 		"strict": true,
+		"noImplicitOverride": true,
 		"skipLibCheck": true,
 		"allowArbitraryExtensions": true,
 		"verbatimModuleSyntax": true,


### PR DESCRIPTION
## Summary
- add explicit `override` modifiers to every existing class override
- enable `noImplicitOverride` in the shared TypeScript config
- make base-method renames fail instead of silently creating unrelated members

## Verification
- `bun check` across all packages with the flag enabled
- independent full-diff review: clean

This is type-only. TypeScript erases every modifier at runtime.