### PR TITLE
feat(ai): add Cursor personal usage reporting

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Cursor personal monthly USD quota and remaining-balance reporting with verified profile email account labels.
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/ai/src/registry/oauth/cursor.ts
+++ b/packages/ai/src/registry/oauth/cursor.ts
@@ -138,18 +138,33 @@ export async function refreshCursorToken(apiKeyOrRefreshToken: string): Promise<
 	};
 }
 
+function decodeCursorAccessTokenPayload(token: string): unknown | undefined {
+	const parts = token.split(".");
+	if (parts.length !== 3) return undefined;
+	const payload = parts[1];
+	if (!payload) return undefined;
+	return JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/")));
+}
+
+export function extractCursorAccessTokenUserId(accessToken: string): string | undefined {
+	try {
+		const payload = decodeCursorAccessTokenPayload(accessToken);
+		if (!payload || typeof payload !== "object" || !("sub" in payload) || typeof payload.sub !== "string") {
+			return undefined;
+		}
+		const { sub } = payload;
+		const parts = sub.split("|");
+		const userId = (parts.length > 1 ? parts[1] : sub).trim();
+		return userId || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 function getTokenExpiry(token: string): number {
 	try {
-		const parts = token.split(".");
-		if (parts.length !== 3) {
-			return Date.now() + 3600 * 1000;
-		}
-		const payload = parts[1];
-		if (!payload) {
-			return Date.now() + 3600 * 1000;
-		}
-		const decoded = JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/")));
-		if (decoded && typeof decoded === "object" && typeof decoded.exp === "number") {
+		const decoded = decodeCursorAccessTokenPayload(token);
+		if (decoded && typeof decoded === "object" && "exp" in decoded && typeof decoded.exp === "number") {
 			return decoded.exp * 1000 - 5 * 60 * 1000;
 		}
 	} catch {
@@ -160,9 +175,10 @@ function getTokenExpiry(token: string): number {
 
 export function isCursorTokenExpiringSoon(token: string, thresholdSeconds = 300): boolean {
 	try {
-		const [, payload] = token.split(".");
-		if (!payload) return true;
-		const decoded = JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/")));
+		const decoded = decodeCursorAccessTokenPayload(token);
+		if (!decoded || typeof decoded !== "object" || !("exp" in decoded) || typeof decoded.exp !== "number") {
+			return true;
+		}
 		const currentTime = Math.floor(Date.now() / 1000);
 		return decoded.exp - currentTime < thresholdSeconds;
 	} catch {

--- a/packages/ai/src/usage/cursor.ts
+++ b/packages/ai/src/usage/cursor.ts
@@ -112,7 +112,7 @@ export function parseCursorIndividualUsage(payload: unknown, fetchedAt = Date.no
 		} else {
 			return null;
 		}
-		const remaining = hasValidRemaining ? reportedRemaining : Math.max(0, limit - used);
+		const remaining = Math.max(0, limit - used);
 		amount = {
 			used: used / 100,
 			limit: limit / 100,

--- a/packages/ai/src/usage/cursor.ts
+++ b/packages/ai/src/usage/cursor.ts
@@ -1,3 +1,4 @@
+import { extractCursorAccessTokenUserId } from "../registry/oauth/cursor";
 import type {
 	UsageAmount,
 	UsageFetchContext,
@@ -27,6 +28,35 @@ function normalizeCursorBaseUrl(baseUrl?: string): string {
 	return baseUrl.replace(/\/+$/, "");
 }
 
+type CursorUsageSource = "auth-usage" | "usage-summary" | "auth-me";
+
+async function fetchCursorJson(
+	ctx: UsageFetchContext,
+	url: string,
+	init: RequestInit,
+	source: CursorUsageSource,
+): Promise<unknown | undefined> {
+	try {
+		const response = await ctx.fetch(url, init);
+		if (!response.ok) {
+			ctx.logger?.warn("Cursor usage request failed", {
+				status: response.status,
+				provider: "cursor",
+				source,
+			});
+			return undefined;
+		}
+		return await response.json();
+	} catch (error) {
+		ctx.logger?.warn("Cursor usage request error", {
+			provider: "cursor",
+			source,
+			error: String(error),
+		});
+		return undefined;
+	}
+}
+
 function deriveResetsAt(payload: Record<string, unknown>): number | undefined {
 	const endKeys = ["billingCycleEnd", "endOfMonth", "resetsAt", "nextReset"];
 	for (const key of endKeys) {
@@ -44,6 +74,78 @@ function deriveResetsAt(payload: Record<string, unknown>): number | undefined {
 		}
 	}
 	return undefined;
+}
+
+function resolveCursorStatus(usedFraction: number | undefined): UsageStatus {
+	if (usedFraction === undefined) return "unknown";
+	if (usedFraction >= 1) return "exhausted";
+	if (usedFraction >= 0.9) return "warning";
+	return "ok";
+}
+
+export function parseCursorIndividualUsage(payload: unknown, fetchedAt = Date.now()): UsageReport | null {
+	if (!isRecord(payload) || !isRecord(payload.individualUsage) || !isRecord(payload.individualUsage.overall)) {
+		return null;
+	}
+	const individual = payload.individualUsage.overall;
+	if (individual.enabled === false) return null;
+
+	const reportedUsed = toNumber(individual.used);
+	const reportedRemaining = toNumber(individual.remaining);
+	const hasValidUsed = reportedUsed !== undefined && reportedUsed >= 0;
+	const hasValidRemaining = reportedRemaining !== undefined && reportedRemaining >= 0;
+	const limit = toNumber(individual.limit);
+
+	let amount: UsageAmount;
+	if (individual.limit === null || individual.limit === undefined) {
+		if (!hasValidUsed) return null;
+		amount = { used: reportedUsed / 100, unit: "usd" };
+	} else {
+		if (limit === undefined || limit <= 0) return null;
+		let used: number;
+		if (reportedUsed !== undefined && reportedUsed > 0) {
+			used = reportedUsed;
+		} else if (hasValidRemaining && reportedRemaining < limit) {
+			used = Math.max(0, limit - reportedRemaining);
+		} else if (hasValidUsed) {
+			used = reportedUsed;
+		} else {
+			return null;
+		}
+		const remaining = hasValidRemaining ? reportedRemaining : Math.max(0, limit - used);
+		amount = {
+			used: used / 100,
+			limit: limit / 100,
+			remaining: remaining / 100,
+			usedFraction: used / limit,
+			remainingFraction: remaining / limit,
+			unit: "usd",
+		};
+	}
+
+	const resetsAt = deriveResetsAt(payload);
+	const window: UsageWindow = {
+		id: "monthly",
+		label: "Monthly",
+		...(resetsAt !== undefined ? { resetsAt } : {}),
+	};
+	const limitEntry: UsageLimit = {
+		id: "cursor:usd:individual-overall",
+		label: "Personal Usage",
+		scope: {
+			provider: "cursor",
+			windowId: window.id,
+		},
+		window,
+		amount,
+		...(amount.usedFraction !== undefined ? { status: resolveCursorStatus(amount.usedFraction) } : {}),
+	};
+	return {
+		provider: "cursor",
+		fetchedAt,
+		limits: [limitEntry],
+		raw: payload,
+	};
 }
 
 export function parseCursorUsage(payload: unknown, fetchedAt = Date.now()): UsageReport | null {
@@ -93,17 +195,7 @@ export function parseCursorUsage(payload: unknown, fetchedAt = Date.now()): Usag
 				unit,
 			};
 
-			const usedFraction = amount.usedFraction;
-			let status: UsageStatus = "unknown";
-			if (usedFraction !== undefined) {
-				if (usedFraction >= 1) {
-					status = "exhausted";
-				} else if (usedFraction >= 0.9) {
-					status = "warning";
-				} else {
-					status = "ok";
-				}
-			}
+			const status = resolveCursorStatus(amount.usedFraction);
 
 			limits.push({
 				id: limitId,
@@ -152,41 +244,90 @@ export const cursorUsageProvider: UsageProvider = {
 
 		const baseUrl = normalizeCursorBaseUrl(params.baseUrl ?? credential.apiEndpoint);
 		const url = `${baseUrl}/auth/usage`;
-
 		const headers: Record<string, string> = {
 			Accept: "application/json",
 			Authorization: `Bearer ${token}`,
 		};
+		const fetchedAt = Date.now();
 
-		try {
-			const response = await ctx.fetch(url, {
+		const legacyReportPromise = fetchCursorJson(
+			ctx,
+			url,
+			{
 				headers,
 				signal: params.signal,
-			});
-			if (!response.ok) {
-				ctx.logger?.warn("Cursor usage request failed", {
-					status: response.status,
-					provider: params.provider,
-				});
-				return null;
-			}
-			const payload = await response.json();
-			const report = parseCursorUsage(payload);
-			if (report) {
-				const metadata = {
-					...(credential.email ? { email: credential.email } : {}),
-					...(credential.accountId ? { accountId: credential.accountId } : {}),
-					...(credential.projectId ? { projectId: credential.projectId } : {}),
+			},
+			"auth-usage",
+		).then(payload => parseCursorUsage(payload, fetchedAt));
+
+		let summaryReportPromise = Promise.resolve<UsageReport | null>(null);
+		let profileEmailPromise = Promise.resolve<string | undefined>(undefined);
+		if (credential.type === "oauth") {
+			const userId = extractCursorAccessTokenUserId(token);
+			if (userId) {
+				const sessionHeaders: Record<string, string> = {
+					Accept: "application/json",
+					Cookie: `WorkosCursorSessionToken=${encodeURIComponent(`${userId}::${token}`)}`,
 				};
-				if (Object.keys(metadata).length > 0) report.metadata = metadata;
+				summaryReportPromise = fetchCursorJson(
+					ctx,
+					"https://cursor.com/api/usage-summary",
+					{
+						headers: sessionHeaders,
+						signal: params.signal,
+					},
+					"usage-summary",
+				).then(payload => parseCursorIndividualUsage(payload, fetchedAt));
+				profileEmailPromise = fetchCursorJson(
+					ctx,
+					"https://cursor.com/api/auth/me",
+					{
+						headers: sessionHeaders,
+						signal: params.signal,
+					},
+					"auth-me",
+				).then(payload => {
+					if (
+						!isRecord(payload) ||
+						payload.sub !== userId ||
+						typeof payload.email !== "string" ||
+						!payload.email.trim()
+					) {
+						return undefined;
+					}
+					return payload.email.trim();
+				});
 			}
-			return report;
-		} catch (error) {
-			ctx.logger?.warn("Cursor usage request error", {
-				provider: params.provider,
-				error: String(error),
-			});
-			return null;
 		}
+
+		const [legacyReport, summaryReport, profileEmail] = await Promise.all([
+			legacyReportPromise,
+			summaryReportPromise,
+			profileEmailPromise,
+		]);
+		let report: UsageReport | null;
+		if (legacyReport && summaryReport) {
+			report = {
+				provider: "cursor",
+				fetchedAt,
+				limits: [...legacyReport.limits, ...summaryReport.limits],
+				raw: {
+					authUsage: legacyReport.raw,
+					usageSummary: summaryReport.raw,
+				},
+			};
+		} else {
+			report = legacyReport ?? summaryReport;
+		}
+		if (!report) return null;
+
+		const email = profileEmail ?? credential.email?.trim();
+		const metadata = {
+			...(email ? { email } : {}),
+			...(credential.accountId ? { accountId: credential.accountId } : {}),
+			...(credential.projectId ? { projectId: credential.projectId } : {}),
+		};
+		if (Object.keys(metadata).length > 0) report.metadata = metadata;
+		return report;
 	},
 };

--- a/packages/ai/test/cursor-usage.test.ts
+++ b/packages/ai/test/cursor-usage.test.ts
@@ -257,6 +257,29 @@ describe("cursor usage provider", () => {
 			});
 			expect(report?.limits[0]?.status).toBe("ok");
 		});
+
+		it("derives remaining from selected used when reported values conflict", () => {
+			const report = parseCursorIndividualUsage({
+				individualUsage: {
+					overall: {
+						used: 100,
+						limit: 1000,
+						remaining: 0,
+					},
+				},
+			});
+			expect(report?.limits[0]).toMatchObject({
+				amount: {
+					used: 1,
+					limit: 10,
+					remaining: 9,
+					usedFraction: 0.1,
+					remainingFraction: 0.9,
+					unit: "usd",
+				},
+				status: "ok",
+			});
+		});
 	});
 
 	describe("default registration", () => {
@@ -480,6 +503,42 @@ describe("cursor usage provider", () => {
 				},
 			});
 			expect(report?.raw).toEqual(usageSummaryPayload);
+		});
+
+		it("ignores a profile email returned for a different subject", async () => {
+			const accessToken = createCursorAccessToken("auth0|user_123");
+			const mockFetch = (async (input: string | URL): Promise<Response> => {
+				const url = typeof input === "string" ? input : input.toString();
+				if (url === "https://api2.cursor.sh/auth/usage") {
+					return Response.json({});
+				}
+				if (url === "https://cursor.com/api/usage-summary") {
+					return Response.json({
+						individualUsage: {
+							overall: {
+								used: 2000,
+								limit: 10000,
+								remaining: 8000,
+							},
+						},
+					});
+				}
+				return Response.json({ email: "other@example.com", sub: "different_user" });
+			}) as unknown as typeof fetch;
+
+			const report = await cursorUsageProvider.fetchUsage(
+				{
+					provider: "cursor",
+					credential: {
+						type: "oauth",
+						accessToken,
+						email: "stored@example.com",
+					},
+				},
+				{ fetch: mockFetch },
+			);
+
+			expect(report?.metadata).toEqual({ email: "stored@example.com" });
 		});
 
 		it("merges legacy request usage before personal usage", async () => {

--- a/packages/ai/test/cursor-usage.test.ts
+++ b/packages/ai/test/cursor-usage.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { type AuthCredentialStore, AuthStorage } from "../src/auth-storage";
 import type { UsageFetchContext, UsageFetchParams } from "../src/usage";
-import { cursorUsageProvider, parseCursorUsage } from "../src/usage/cursor";
+import { cursorUsageProvider, parseCursorIndividualUsage, parseCursorUsage } from "../src/usage/cursor";
+
+function createCursorAccessToken(sub: string): string {
+	const payload = btoa(JSON.stringify({ sub })).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+	return `header.${payload}.signature`;
+}
 
 describe("cursor usage provider", () => {
 	describe("parseCursorUsage", () => {
@@ -134,6 +139,123 @@ describe("cursor usage provider", () => {
 			expect(report).not.toBeNull();
 			const limit = report?.limits[0];
 			expect(limit?.window?.resetsAt).toBe(Date.parse("2026-07-20T00:00:00.000Z"));
+		});
+	});
+
+	describe("parseCursorIndividualUsage", () => {
+		it("parses personal usage cents into a capped monthly dollar limit", () => {
+			const payload = {
+				individualUsage: {
+					overall: {
+						enabled: true,
+						used: "9000",
+						limit: "10000",
+						remaining: "1000",
+					},
+				},
+				teamUsage: {
+					onDemand: {
+						enabled: true,
+						used: 900000,
+						limit: 1000000,
+						remaining: 100000,
+					},
+				},
+				billingCycleEnd: "2026-08-20T00:00:00.000Z",
+			};
+
+			const report = parseCursorIndividualUsage(payload, 123);
+			expect(report).toEqual({
+				provider: "cursor",
+				fetchedAt: 123,
+				limits: [
+					{
+						id: "cursor:usd:individual-overall",
+						label: "Personal Usage",
+						scope: {
+							provider: "cursor",
+							windowId: "monthly",
+						},
+						window: {
+							id: "monthly",
+							label: "Monthly",
+							resetsAt: Date.parse("2026-08-20T00:00:00.000Z"),
+						},
+						amount: {
+							used: 90,
+							limit: 100,
+							remaining: 10,
+							usedFraction: 0.9,
+							remainingFraction: 0.1,
+							unit: "usd",
+						},
+						status: "warning",
+					},
+				],
+				raw: payload,
+			});
+		});
+
+		it("rejects disabled, malformed, and non-positive personal usage buckets", () => {
+			expect(
+				parseCursorIndividualUsage({
+					individualUsage: { overall: { enabled: false, used: 100, limit: 1000, remaining: 900 } },
+				}),
+			).toBeNull();
+			expect(
+				parseCursorIndividualUsage({ individualUsage: { overall: { limit: null, used: "invalid" } } }),
+			).toBeNull();
+			expect(
+				parseCursorIndividualUsage({ individualUsage: { overall: { used: 0, limit: 0, remaining: 0 } } }),
+			).toBeNull();
+			expect(
+				parseCursorIndividualUsage({ individualUsage: { overall: { used: 0, limit: -100, remaining: 0 } } }),
+			).toBeNull();
+		});
+
+		it("emits uncapped used-only dollar usage when the limit is null", () => {
+			const report = parseCursorIndividualUsage({
+				individualUsage: { overall: { enabled: true, used: "2500", limit: null } },
+			});
+			expect(report?.limits).toEqual([
+				{
+					id: "cursor:usd:individual-overall",
+					label: "Personal Usage",
+					scope: {
+						provider: "cursor",
+						windowId: "monthly",
+					},
+					window: {
+						id: "monthly",
+						label: "Monthly",
+					},
+					amount: {
+						used: 25,
+						unit: "usd",
+					},
+				},
+			]);
+		});
+
+		it("infers positive spend from limit and remaining when reported used is zero", () => {
+			const report = parseCursorIndividualUsage({
+				individualUsage: {
+					overall: {
+						used: 0,
+						limit: 5000,
+						remaining: 1500,
+					},
+				},
+			});
+			expect(report?.limits[0]?.amount).toEqual({
+				used: 35,
+				limit: 50,
+				remaining: 15,
+				usedFraction: 0.7,
+				remainingFraction: 0.3,
+				unit: "usd",
+			});
+			expect(report?.limits[0]?.status).toBe("ok");
 		});
 	});
 
@@ -273,6 +395,174 @@ describe("cursor usage provider", () => {
 				email: "user@example.com",
 				accountId: "acc_123",
 			});
+		});
+
+		it("fetches personal usage and profile email with a WorkOS cookie", async () => {
+			const accessToken = createCursorAccessToken("auth0|user_123");
+			const authUsagePayload = {
+				"gpt-4": {
+					numRequests: 0,
+					maxRequestUsage: null,
+				},
+			};
+			const usageSummaryPayload = {
+				individualUsage: {
+					overall: {
+						enabled: true,
+						used: 2000,
+						limit: 10000,
+						remaining: 8000,
+					},
+				},
+				teamUsage: {
+					onDemand: {
+						enabled: true,
+						used: 900000,
+						limit: 1000000,
+						remaining: 100000,
+					},
+				},
+			};
+			const seenUrls: string[] = [];
+			const mockFetch = (async (input: string | URL, init?: RequestInit): Promise<Response> => {
+				const url = typeof input === "string" ? input : input.toString();
+				seenUrls.push(url);
+				const headers = new Headers(init?.headers);
+				if (url === "https://api2.cursor.sh/auth/usage") {
+					expect(headers.get("Accept")).toBe("application/json");
+					expect(headers.get("Authorization")).toBe(`Bearer ${accessToken}`);
+					return Response.json(authUsagePayload);
+				}
+				expect(["https://cursor.com/api/usage-summary", "https://cursor.com/api/auth/me"]).toContain(url);
+				expect(headers.get("Accept")).toBe("application/json");
+				expect(headers.get("Cookie")).toBe(
+					`WorkosCursorSessionToken=${encodeURIComponent(`user_123::${accessToken}`)}`,
+				);
+				expect(headers.has("Authorization")).toBe(false);
+				if (url === "https://cursor.com/api/auth/me") {
+					return Response.json({ email: "person@example.com", sub: "user_123" });
+				}
+				return Response.json(usageSummaryPayload);
+			}) as unknown as typeof fetch;
+
+			const report = await cursorUsageProvider.fetchUsage(
+				{
+					provider: "cursor",
+					credential: {
+						type: "oauth",
+						accessToken,
+						email: "stored@example.com",
+						accountId: "account_123",
+						projectId: "project_123",
+					},
+				},
+				{ fetch: mockFetch },
+			);
+
+			expect(seenUrls).toEqual([
+				"https://api2.cursor.sh/auth/usage",
+				"https://cursor.com/api/usage-summary",
+				"https://cursor.com/api/auth/me",
+			]);
+			expect(report?.metadata).toEqual({
+				email: "person@example.com",
+				accountId: "account_123",
+				projectId: "project_123",
+			});
+			expect(report?.limits).toHaveLength(1);
+			expect(report?.limits[0]).toMatchObject({
+				id: "cursor:usd:individual-overall",
+				amount: {
+					used: 20,
+					limit: 100,
+					remaining: 80,
+					unit: "usd",
+				},
+			});
+			expect(report?.raw).toEqual(usageSummaryPayload);
+		});
+
+		it("merges legacy request usage before personal usage", async () => {
+			const accessToken = createCursorAccessToken("workos|user_456");
+			const authUsagePayload = {
+				"gpt-4": {
+					numRequests: 10,
+					maxRequestUsage: 100,
+				},
+			};
+			const usageSummaryPayload = {
+				individualUsage: {
+					overall: {
+						used: 2000,
+						limit: 10000,
+						remaining: 8000,
+					},
+				},
+			};
+			const mockFetch = (async (input: string | URL): Promise<Response> => {
+				const url = typeof input === "string" ? input : input.toString();
+				return Response.json(url === "https://api2.cursor.sh/auth/usage" ? authUsagePayload : usageSummaryPayload);
+			}) as unknown as typeof fetch;
+
+			const report = await cursorUsageProvider.fetchUsage(
+				{
+					provider: "cursor",
+					credential: {
+						type: "oauth",
+						accessToken,
+					},
+				},
+				{ fetch: mockFetch },
+			);
+
+			expect(report?.limits.map(limit => limit.id)).toEqual([
+				"cursor:requests:gpt-4",
+				"cursor:usd:individual-overall",
+			]);
+			expect(report?.raw).toEqual({
+				authUsage: authUsagePayload,
+				usageSummary: usageSummaryPayload,
+			});
+		});
+
+		it("returns legacy usage when the personal summary request fails", async () => {
+			const accessToken = createCursorAccessToken("auth0|user_789");
+			const authUsagePayload = {
+				"gpt-4": {
+					numRequests: 10,
+					maxRequestUsage: 100,
+				},
+			};
+			const seenUrls: string[] = [];
+			const mockFetch = (async (input: string | URL): Promise<Response> => {
+				const url = typeof input === "string" ? input : input.toString();
+				seenUrls.push(url);
+				if (url === "https://cursor.com/api/usage-summary") {
+					return new Response("Unavailable", { status: 503 });
+				}
+				return Response.json(authUsagePayload);
+			}) as unknown as typeof fetch;
+
+			const report = await cursorUsageProvider.fetchUsage(
+				{
+					provider: "cursor",
+					credential: {
+						type: "oauth",
+						accessToken,
+						email: "fallback@example.com",
+					},
+				},
+				{ fetch: mockFetch },
+			);
+
+			expect(seenUrls).toEqual([
+				"https://api2.cursor.sh/auth/usage",
+				"https://cursor.com/api/usage-summary",
+				"https://cursor.com/api/auth/me",
+			]);
+			expect(report?.limits.map(limit => limit.id)).toEqual(["cursor:requests:gpt-4"]);
+			expect(report?.raw).toEqual(authUsagePayload);
+			expect(report?.metadata).toEqual({ email: "fallback@example.com" });
 		});
 
 		it("returns null on non-2xx response", async () => {


### PR DESCRIPTION
## What

Add Cursor Enterprise personal monthly USD usage reporting while preserving the existing request-count usage.

- Fetch `/auth/usage` and `/api/usage-summary` concurrently with isolated failure handling.
- Parse `individualUsage.overall` cents into one `Personal Usage (Monthly)` USD limit.
- Intentionally ignore `teamUsage`, so team quotas are not presented as personal limits.
- Authenticate Cursor dashboard requests with the JWT-derived WorkOS session cookie.
- Use the subject-verified `/api/auth/me` email as the account label, with credential metadata as fallback.
- Preserve legacy-first limit ordering, raw payloads, reset timestamps, and credential metadata.

## Why

Cursor Enterprise accounts can return `maxRequestUsage: null` from `/auth/usage`, leaving `omp usage` without a usable limit even though Cursor's dashboard exposes the personal monthly allocation through `/api/usage-summary`.

Related prior art:

- [OpenUsage issue #829](https://github.com/robinebers/openusage/issues/829) documents the unusable legacy response and the `/api/usage-summary` fallback.
- [OpenUsage PR #986](https://github.com/robinebers/openusage/pull/986) independently implements and live-validates that endpoint, WorkOS session authentication, and cent-denominated usage meters.

This implementation uses that endpoint narrowly for `individualUsage.overall`; it does not expose Cursor team usage.

## Testing

- `bun test test/cursor-usage.test.ts` from `packages/ai`: 23 passed, 0 failed.
- `bun run check:types` from `packages/ai`: passed.
- Repository-wide `bun run check:ts`: passed.
- Added regression coverage for contradictory `used`/`remaining` values and `/api/auth/me` responses whose subject does not match the authenticated Cursor user.
- Live-tested `omp usage --provider cursor` against an authenticated Cursor account. It rendered the verified email label and one `Personal Usage (Monthly)` limit with USD usage, utilization, and reset countdown; no team quota was displayed.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)