### PR TITLE
chore(ts): enforce noExplicitAny

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,7 @@
 				"useNodejsImportProtocol": "off"
 			},
 			"suspicious": {
-				"noExplicitAny": "off",
+				"noExplicitAny": "error",
 				"noControlCharactersInRegex": "off",
 				"noEmptyInterface": "off",
 				"noConstEnum": "off",

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added optional `errorMessage` field to `AgentToolResult` to carry a legacy/replay failure reason consumed by ACP text extraction.
+
 ## [17.2.6] - 2026-08-03
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2086,7 +2086,7 @@ function emitAbortedAssistantMessage(
 
 /** Per-call outcome of the pre-dispatch prepare phase (validation + `beforeToolCall`). */
 interface PreparedToolCall {
-	tool: AgentTool<any> | undefined;
+	tool: AgentTool | undefined;
 	/** Validated (possibly hook-revised) execution args; raw args when validation failed. */
 	args: Record<string, unknown>;
 	validationErrorMessage?: string;
@@ -2105,10 +2105,10 @@ interface PreparedToolCall {
 const preparedDispatchByMessage = new WeakMap<AssistantMessage, Map<string, PreparedToolCall>>();
 
 function resolveToolForCall(
-	tools: AgentTool<any>[] | undefined,
+	tools: AgentTool[] | undefined,
 	toolCall: AgentToolCall,
 	resolveFallbackTool: AgentLoopConfig["resolveFallbackTool"],
-): AgentTool<any> | undefined {
+): AgentTool | undefined {
 	// Tools emitted via OpenAI's custom-tool path (e.g. `apply_patch` on GPT-5)
 	// come back under their wire-level name, which may differ from the
 	// harness-internal `name`. Match on either, preferring `name` for
@@ -2301,7 +2301,7 @@ async function executeToolCalls(
 			interruptible,
 			signal: interruptible ? interruptibleSignal : nonInterruptibleSignal,
 			started: false,
-			result: undefined as AgentToolResult<any> | undefined,
+			result: undefined as AgentToolResult | undefined,
 			isError: false,
 			skipped: false,
 			toolResultMessage: undefined as ToolResultMessage | undefined,
@@ -2368,7 +2368,7 @@ async function executeToolCalls(
 		await checkIrcInterrupts();
 	};
 
-	const emitToolResult = (record: (typeof records)[number], result: AgentToolResult<any>, isError: boolean): void => {
+	const emitToolResult = (record: (typeof records)[number], result: AgentToolResult, isError: boolean): void => {
 		if (record.resultEmitted) return;
 		const { toolCall } = record;
 		if (!record.started) {
@@ -2479,7 +2479,7 @@ async function executeToolCalls(
 			toolSpan.setAttribute(PiGenAIAttr.ToolCallIntent, toolCall.intent);
 		}
 
-		let result: AgentToolResult<any> = { content: [], details: {} };
+		let result: AgentToolResult = { content: [], details: {} };
 		let isError = false;
 		let caughtError: unknown;
 		let completedToolExecution = false;

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -246,7 +246,7 @@ export interface AgentOptions {
 	 * route calls to tools exposed through side transports (e.g. `xd://`
 	 * device mounts) instead of failing with "Tool not found".
 	 */
-	resolveFallbackTool?: (name: string) => AgentTool<any> | undefined;
+	resolveFallbackTool?: (name: string) => AgentTool | undefined;
 
 	/** Enable intent tracing schema injection/stripping in the harness. */
 	intentTracing?: boolean;
@@ -405,7 +405,7 @@ export class Agent {
 	#kimiApiFormat?: "openai" | "anthropic";
 	#preferWebsockets?: boolean;
 	#transformToolCallArguments?: (args: Record<string, unknown>, toolName: string) => Record<string, unknown>;
-	#resolveFallbackTool?: (name: string) => AgentTool<any> | undefined;
+	#resolveFallbackTool?: (name: string) => AgentTool | undefined;
 	#intentTracing: boolean;
 	#pruneToolDescriptions: boolean;
 	#dialect?: Dialect;
@@ -902,7 +902,7 @@ export class Agent {
 		return this.#interruptMode;
 	}
 
-	setTools(t: AgentTool<any>[]) {
+	setTools(t: AgentTool[]) {
 		this.#state.tools = t;
 	}
 
@@ -1446,8 +1446,8 @@ export class Agent {
 						break;
 
 					case "turn_end":
-						if (event.message.role === "assistant" && (event.message as any).errorMessage) {
-							this.#state.error = (event.message as any).errorMessage;
+						if (event.message.role === "assistant" && event.message.errorMessage) {
+							this.#state.error = event.message.errorMessage;
 						}
 						break;
 

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -106,16 +106,16 @@ export class AppendOnlyLog {
 		return this.#entries.length;
 	}
 
-	append(message: any): void {
+	append(message: Message): void {
 		this.#entries.push(message);
 	}
 
-	extend(messages: any[]): void {
+	extend(messages: Message[]): void {
 		for (const m of messages) this.#entries.push(m);
 	}
 
 	/** Replace the last entry — only legal for compaction. */
-	replaceTail(replacement: any): void {
+	replaceTail(replacement: Message): void {
 		const idx = this.#entries.length - 1;
 		if (idx >= 0) this.#entries[idx] = replacement;
 	}
@@ -202,7 +202,7 @@ export class AppendOnlyContextManager {
 	 *    lets the provider's KV cache stay warm up to the divergence
 	 *    point — the model only re-prefills from the changed message on.
 	 */
-	syncMessages(normalizedMessages: any[]): void {
+	syncMessages(normalizedMessages: Message[]): void {
 		// Compaction (array shrunk) — every previously-synced message is gone,
 		// so the log can't carry any byte-stable bytes forward.
 		if (normalizedMessages.length < this.#lastSyncCount) {
@@ -249,11 +249,11 @@ export class AppendOnlyContextManager {
 		this.#messageDigests = [];
 	}
 
-	appendMessage(message: any): void {
+	appendMessage(message: Message): void {
 		this.log.append(message);
 	}
 
-	replaceTailMessage(message: any): void {
+	replaceTailMessage(message: Message): void {
 		this.log.replaceTail(message);
 	}
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -687,6 +687,8 @@ export interface AgentToolResult<T = unknown, _TInput = unknown> {
 	providerMetadata?: ToolResultProviderMetadata;
 	/** Marks the result as contextually useless: safe for compaction to elide once consumed (e.g. zero matches, wait timeout). Ignored when isError is set. */
 	useless?: boolean;
+	/** Carries a legacy/replay failure reason for tool results whose readable text lives only in `errorMessage` (imported/older sessions). Consumed by ACP text extraction as fallback content. */
+	readonly errorMessage?: string;
 }
 
 // Callback for streaming tool execution updates

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -342,7 +342,7 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * through side transports (e.g. `xd://` device mounts) instead of failing
 	 * with "Tool not found". Returning `undefined` keeps the failure.
 	 */
-	resolveFallbackTool?: (name: string) => AgentTool<any> | undefined;
+	resolveFallbackTool?: (name: string) => AgentTool | undefined;
 
 	/**
 	 * Enable intent tracing for tool calls.
@@ -607,7 +607,7 @@ export interface BeforeToolCallContext {
 	/** The raw tool call block from `assistantMessage.content`. */
 	toolCall: AgentToolCall;
 	/** The resolved tool the call dispatches to. */
-	tool: AgentTool<any>;
+	tool: AgentTool;
 	/**
 	 * Validated tool arguments. The same reference is forwarded to `tool.execute`
 	 * (after any `transformToolCallArguments` pass), so in-place mutations stick;
@@ -627,7 +627,7 @@ export interface AfterToolCallContext {
 	/** Validated tool arguments used for execution (post `beforeToolCall` mutations). */
 	args: Record<string, unknown>;
 	/** The executed tool result before any `afterToolCall` overrides are applied. */
-	result: AgentToolResult<any>;
+	result: AgentToolResult;
 	/** Whether the executed tool result is currently treated as an error. */
 	isError: boolean;
 	/** Current agent context at the time the tool call is finalized. */
@@ -667,7 +667,7 @@ export interface AgentState {
 	model: Model;
 	thinkingLevel?: Effort;
 	disableReasoning?: boolean;
-	tools: AgentTool<any>[];
+	tools: AgentTool[];
 	messages: AgentMessage[]; // Can include attachments + custom message types
 	isStreaming: boolean;
 	streamMessage: AgentMessage | null;
@@ -675,7 +675,7 @@ export interface AgentState {
 	error?: string;
 }
 
-export interface AgentToolResult<T = any, _TInput = unknown> {
+export interface AgentToolResult<T = unknown, _TInput = unknown> {
 	// Content blocks supporting text and images
 	content: (TextContent | ImageContent)[];
 	// Details to be displayed in a UI or logged
@@ -690,7 +690,9 @@ export interface AgentToolResult<T = any, _TInput = unknown> {
 }
 
 // Callback for streaming tool execution updates
-export type AgentToolUpdateCallback<T = any, TInput = unknown> = (partialResult: AgentToolResult<T, TInput>) => void;
+export type AgentToolUpdateCallback<T = unknown, TInput = unknown> = (
+	partialResult: AgentToolResult<T, TInput>,
+) => void;
 
 /** Options passed to renderResult */
 export interface RenderResultOptions {
@@ -739,7 +741,7 @@ export interface AgentToolContext {
 	// Empty by default - apps extend via declaration merging
 }
 
-export type AgentToolExecFn<TParameters extends TSchema = TSchema, TDetails = any, TTheme = unknown> = (
+export type AgentToolExecFn<TParameters extends TSchema = TSchema, TDetails = unknown, TTheme = unknown> = (
 	this: AgentTool<TParameters, TDetails, TTheme>,
 	toolCallId: string,
 	params: Static<TParameters>,
@@ -749,7 +751,7 @@ export type AgentToolExecFn<TParameters extends TSchema = TSchema, TDetails = an
 ) => Promise<AgentToolResult<TDetails, TParameters>>;
 
 // AgentTool extends Tool but adds the execute function
-export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any, TTheme = unknown>
+export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = unknown, TTheme = unknown>
 	extends Tool<TParameters> {
 	// A human-readable label for the tool to be displayed in UI
 	label: string;
@@ -826,25 +828,44 @@ export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any
 	/** Lines appended after the standard approval prompt header. */
 	formatApprovalDetails?: (args: unknown) => string | string[] | undefined;
 
-	/** The main execution callback for this tool. */
-	execute: AgentToolExecFn<TParameters, TDetails, TTheme>;
+	/**
+	 * The main execution callback for this tool.
+	 *
+	 * Declared with method syntax (not an `AgentToolExecFn` property) so its
+	 * parameters are bivariant: a concrete `AgentTool<Schema, Details>` stays
+	 * assignable to the erased {@link AnyAgentTool} that heterogeneous tool
+	 * collections and adapters hold. Runtime shape is unchanged.
+	 */
+	execute(
+		this: AgentTool<TParameters, TDetails, TTheme>,
+		toolCallId: string,
+		params: Static<TParameters>,
+		signal?: AbortSignal,
+		onUpdate?: AgentToolUpdateCallback<TDetails, TParameters>,
+		context?: AgentToolContext,
+	): Promise<AgentToolResult<TDetails, TParameters>>;
 
 	/** Optional custom rendering for tool call display (returns UI component) */
-	renderCall?: (args: Static<TParameters>, options: RenderResultOptions, theme: TTheme) => unknown;
+	renderCall?(args: Static<TParameters>, options: RenderResultOptions, theme: TTheme): unknown;
 
 	/** Optional custom rendering for tool result display (returns UI component) */
-	renderResult?: (
-		result: AgentToolResult<TDetails, TParameters>,
-		options: RenderResultOptions,
-		theme: TTheme,
-	) => unknown;
+	renderResult?(result: AgentToolResult<TDetails, TParameters>, options: RenderResultOptions, theme: TTheme): unknown;
 }
+
+/**
+ * A tool with erased schema/details/theme type parameters — the canonical
+ * element type for heterogeneous tool collections and adapters that must hold
+ * tools of differing parameter schemas. Concrete `AgentTool<Schema, Details>`
+ * values are assignable here because the interface's callbacks use method
+ * syntax (bivariant parameters).
+ */
+export type AnyAgentTool = AgentTool<TSchema, unknown, unknown>;
 
 // AgentContext is like Context but uses AgentTool
 export interface AgentContext {
 	systemPrompt: string[];
 	messages: AgentMessage[];
-	tools?: AgentTool<any>[];
+	tools?: AgentTool[];
 }
 
 /**
@@ -870,6 +891,18 @@ export type AgentEvent =
 	| { type: "message_update"; message: AgentMessage; assistantMessageEvent: AssistantMessageEvent }
 	| { type: "message_end"; message: AgentMessage }
 	// Tool execution lifecycle
-	| { type: "tool_execution_start"; toolCallId: string; toolName: string; args: any; intent?: string }
-	| { type: "tool_execution_update"; toolCallId: string; toolName: string; args: any; partialResult: any }
-	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError?: boolean };
+	| {
+			type: "tool_execution_start";
+			toolCallId: string;
+			toolName: string;
+			args: unknown;
+			intent?: string;
+	  }
+	| {
+			type: "tool_execution_update";
+			toolCallId: string;
+			toolName: string;
+			args: unknown;
+			partialResult: AgentToolResult;
+	  }
+	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: AgentToolResult; isError?: boolean };

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -14,6 +14,7 @@ import type {
 	AgentMessage,
 	AgentTool,
 	AgentToolContext,
+	StreamFn,
 	ToolCallContext,
 } from "@oh-my-pi/pi-agent-core/types";
 import { ASIDE_MESSAGE_COMMIT, ASIDE_MESSAGE_DISCARD } from "@oh-my-pi/pi-agent-core/types";
@@ -566,23 +567,34 @@ describe("agentLoop with AgentMessage", () => {
 		}
 
 		// Validation should have failed and reported the parse error & truncated JSON
-		const toolResultMsg = events.find(e => e.type === "message_start" && e.message.role === "toolResult") as any;
+		const toolResultMsg = events.find(
+			(e): e is Extract<AgentEvent, { type: "message_start" }> =>
+				e.type === "message_start" && e.message.role === "toolResult",
+		);
 		expect(toolResultMsg).toBeDefined();
-		const resultText = toolResultMsg.message.content[0].text;
+		const toolResultMessage = toolResultMsg!.message;
+		if (toolResultMessage.role !== "toolResult") throw new Error("expected a toolResult message");
+		const firstContent = toolResultMessage.content[0];
+		const resultText = firstContent?.type === "text" ? firstContent.text : "";
 		expect(resultText).toContain("Tool call arguments are not valid JSON.");
 		expect(resultText).toContain("Unexpected token F");
 		expect(resultText).toContain("[truncated");
 
 		// Should have paired start and end events
-		const toolStart = events.find(e => e.type === "tool_execution_start") as any;
-		const toolEnd = events.find(e => e.type === "tool_execution_end") as any;
+		const toolStart = events.find(
+			(e): e is Extract<AgentEvent, { type: "tool_execution_start" }> => e.type === "tool_execution_start",
+		);
+		const toolEnd = events.find(
+			(e): e is Extract<AgentEvent, { type: "tool_execution_end" }> => e.type === "tool_execution_end",
+		);
 		expect(toolStart).toBeDefined();
 		expect(toolEnd).toBeDefined();
 
 		// Start args must not include __rawJson
-		expect(toolStart.args).toBeDefined();
-		expect(toolStart.args.__rawJson).toBeUndefined();
-		expect(toolStart.args.__parseError).toBeDefined(); // keeps __parseError for visibility of parse failure
+		expect(toolStart!.args).toBeDefined();
+		const startArgs = toolStart!.args as { __rawJson?: unknown; __parseError?: unknown };
+		expect(startArgs.__rawJson).toBeUndefined();
+		expect(startArgs.__parseError).toBeDefined(); // keeps __parseError for visibility of parse failure
 	});
 
 	it("runs completed tool calls after a transient stream_read_error", async () => {
@@ -1058,9 +1070,12 @@ describe("agentLoop with AgentMessage", () => {
 		// The event's result carries the same discriminator so the UI can
 		// render "provider transport failed, tool not executed" instead of a
 		// generic "Edit tool failed" panel.
-		expect(endEvent?.result?.details?.__synthetic).toBe(true);
-		expect(endEvent?.result?.details?.source).toBe("assistant_stop_error");
-		expect(endEvent?.result?.details?.executed).toBe(false);
+		const endDetails = endEvent?.result.details as
+			| { __synthetic?: boolean; source?: string; executed?: boolean }
+			| undefined;
+		expect(endDetails?.__synthetic).toBe(true);
+		expect(endDetails?.source).toBe("assistant_stop_error");
+		expect(endDetails?.executed).toBe(false);
 	});
 
 	it("recovers completed custom-wire tool calls after stream_read_error", async () => {
@@ -2743,7 +2758,7 @@ it("recovers from provider whitespace loop recovery without duplicating assistan
 		tools: [],
 	};
 
-	const customStreamFn = (model: any, _context: any, _options: any) => {
+	const customStreamFn: StreamFn = (model, _context, _options) => {
 		const stream = new AssistantMessageEventStream();
 		const run = async () => {
 			try {
@@ -2806,7 +2821,7 @@ it("recovers from provider whitespace loop recovery without duplicating assistan
 	const mock = createMockModel();
 	const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 	const events: AgentEvent[] = [];
-	const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, customStreamFn as any);
+	const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, customStreamFn);
 
 	for await (const event of stream) {
 		events.push(event);

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1278,7 +1278,12 @@ describe("Agent — F3 in-place state mutation", () => {
 		const agent = new Agent({ initialState: { messages, pendingToolCalls } });
 
 		agent.appendMessage({ role: "user", content: "y", timestamp: 2 });
-		agent.emitExternalEvent({ type: "tool_execution_end", toolCallId: "call-1", toolName: "tool", result: {} });
+		agent.emitExternalEvent({
+			type: "tool_execution_end",
+			toolCallId: "call-1",
+			toolName: "tool",
+			result: { content: [] },
+		});
 
 		expect(messages.length).toBe(1);
 		expect(pendingToolCalls.has("call-1")).toBe(true);

--- a/packages/agent/test/append-only-context.test.ts
+++ b/packages/agent/test/append-only-context.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "bun:test";
 import { type } from "@oh-my-pi/omptype";
 import { AppendOnlyContextManager, AppendOnlyLog, StablePrefix } from "@oh-my-pi/pi-agent-core/append-only-context";
 import type { AgentContext, AgentTool } from "@oh-my-pi/pi-agent-core/types";
-import type { Message, Tool, ToolExample } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, Message, Tool, ToolExample, ToolResultMessage, UserMessage } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 
 // ---------------------------------------------------------------------------
@@ -32,6 +33,39 @@ function makeTool(
 		examples,
 		execute: async () => ({ content: [{ type: "text", text: "done" }] }),
 	} as AgentTool;
+}
+
+// Valid provider-level message fixtures. The append-only log inspects entries
+// structurally (via a field digest), so these carry only the fields the tests
+// exercise plus whatever the Message contract requires — no `any`.
+const MOCK_MODEL = createMockModel().model;
+function userMsg(content: string, extra: Partial<UserMessage> = {}): UserMessage {
+	return { role: "user", content, timestamp: 0, ...extra };
+}
+function asstMsg(text: string, extra: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: MOCK_MODEL.api,
+		provider: MOCK_MODEL.provider,
+		model: MOCK_MODEL.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+		...extra,
+	};
+}
+function toolResultMsg(
+	fields: Pick<ToolResultMessage, "content" | "toolCallId" | "toolName" | "isError"> & Partial<ToolResultMessage>,
+): ToolResultMessage {
+	return { role: "toolResult", timestamp: 0, ...fields };
 }
 
 const BUILD_OPTS = { intentTracing: false } as const;
@@ -161,15 +195,15 @@ describe("AppendOnlyLog", () => {
 
 	it("appends messages", () => {
 		const log = new AppendOnlyLog();
-		log.append({ role: "user", content: "hello" } as any);
-		log.append({ role: "assistant", content: "world" } as any);
+		log.append(userMsg("hello"));
+		log.append(asstMsg("world"));
 		expect(log.length).toBe(2);
 		expect(log.toMessages()).toHaveLength(2);
 	});
 
 	it("toMessages returns a copy of the array", () => {
 		const log = new AppendOnlyLog();
-		const msg = { role: "user", content: "test" };
+		const msg = userMsg("test");
 		log.append(msg);
 		const msgs = log.toMessages();
 		// Array is a copy — mutating it doesn't affect the log
@@ -179,37 +213,34 @@ describe("AppendOnlyLog", () => {
 
 	it("replaceTail replaces last entry", () => {
 		const log = new AppendOnlyLog();
-		log.append({ role: "user", content: "old" });
-		log.replaceTail({ role: "user", content: "new" });
+		log.append(userMsg("old"));
+		log.replaceTail(userMsg("new"));
 		expect(log.toMessages()).toHaveLength(1);
 		expect(log.toMessages()[0]!.content).toBe("new");
 	});
 
 	it("replaceTail is no-op on empty log", () => {
 		const log = new AppendOnlyLog();
-		log.replaceTail({ role: "user", content: "nope" });
+		log.replaceTail(userMsg("nope"));
 		expect(log.length).toBe(0);
 	});
 
 	it("extend appends multiple messages", () => {
 		const log = new AppendOnlyLog();
-		log.extend([
-			{ role: "user", content: "a" },
-			{ role: "assistant", content: "b" },
-		]);
+		log.extend([userMsg("a"), asstMsg("b")]);
 		expect(log.length).toBe(2);
 	});
 
 	it("clear resets the log", () => {
 		const log = new AppendOnlyLog();
-		log.append({ role: "user", content: "x" });
+		log.append(userMsg("x"));
 		log.clear();
 		expect(log.length).toBe(0);
 	});
 
 	it("entries readonly access returns internal array", () => {
 		const log = new AppendOnlyLog();
-		log.append({ role: "user", content: "test" });
+		log.append(userMsg("test"));
 		expect(log.entries()).toHaveLength(1);
 	});
 });
@@ -272,8 +303,8 @@ describe("AppendOnlyContextManager", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		mgr.appendMessage({ role: "user", content: "hello" } as any);
-		mgr.appendMessage({ role: "assistant", content: "world" } as any);
+		mgr.appendMessage(userMsg("hello"));
+		mgr.appendMessage(asstMsg("world"));
 
 		const result = mgr.build(makeContext(), BUILD_OPTS);
 		expect(result.messages).toHaveLength(2);
@@ -285,14 +316,14 @@ describe("AppendOnlyContextManager", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		mgr.appendMessage({ role: "user", content: "q1" });
+		mgr.appendMessage(userMsg("q1"));
 		const r1 = mgr.build(makeContext(), BUILD_OPTS);
 		expect(r1.messages).toHaveLength(1);
 
-		mgr.appendMessage({ role: "assistant", content: "a1" });
+		mgr.appendMessage(asstMsg("a1"));
 		const r2 = mgr.build(makeContext(), BUILD_OPTS);
 		expect(r2.messages).toHaveLength(2);
-		expect(r2.messages[1]!.content).toBe("a1");
+		expect(r2.messages[1]!.content).toEqual([{ type: "text", text: "a1" }]);
 	});
 
 	it("invalidate forces prefix rebuild", () => {
@@ -307,7 +338,7 @@ describe("AppendOnlyContextManager", () => {
 	it("reset clears log and prefix", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext({ systemPrompt: ["Original"] }), BUILD_OPTS);
-		mgr.appendMessage({ role: "user", content: "hello" });
+		mgr.appendMessage(userMsg("hello"));
 
 		const freshCtx = makeContext({ systemPrompt: ["Fresh start"] });
 		mgr.reset(freshCtx, BUILD_OPTS);
@@ -320,8 +351,8 @@ describe("AppendOnlyContextManager", () => {
 	it("replaceTailMessage updates last log entry", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
-		mgr.appendMessage({ role: "user", content: "old" });
-		mgr.replaceTailMessage({ role: "user", content: "new" });
+		mgr.appendMessage(userMsg("old"));
+		mgr.replaceTailMessage(userMsg("new"));
 
 		const result = mgr.build(makeContext(), BUILD_OPTS);
 		expect(result.messages).toHaveLength(1);
@@ -331,7 +362,7 @@ describe("AppendOnlyContextManager", () => {
 	it("build propagates tool spec description default", () => {
 		const mgr = new AppendOnlyContextManager();
 		const toolWithNoDesc = makeTool("bare");
-		delete (toolWithNoDesc as any).description;
+		delete (toolWithNoDesc as Partial<Tool>).description;
 
 		const ctx = makeContext({ tools: [toolWithNoDesc] });
 		const result = mgr.build(ctx, BUILD_OPTS);
@@ -356,7 +387,7 @@ describe("AppendOnlyContextManager", () => {
 
 	it("tolerates context with no tools", () => {
 		const mgr = new AppendOnlyContextManager();
-		const ctx = makeContext({ tools: undefined as any });
+		const ctx = makeContext({ tools: undefined });
 
 		const result = mgr.build(ctx, BUILD_OPTS);
 		expect(result.tools).toEqual([]);
@@ -420,44 +451,38 @@ describe("message sync", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		const msgs: Message[] = [
-			{ role: "user", content: "Hello" },
-			{ role: "assistant", content: "Hi" },
-		] as any;
+		const msgs: Message[] = [userMsg("Hello"), asstMsg("Hi")];
 		mgr.syncMessages(msgs);
 
 		const result = mgr.build(makeContext(), BUILD_OPTS);
 		expect(result.messages).toHaveLength(2);
 		expect(result.messages[0]!.content).toBe("Hello");
-		expect(result.messages[1]!.content).toBe("Hi");
+		expect(result.messages[1]!.content).toEqual([{ type: "text", text: "Hi" }]);
 	});
 
 	it("syncMessages on subsequent calls only appends delta", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		mgr.syncMessages([{ role: "user", content: "q1" }]);
+		mgr.syncMessages([userMsg("q1")]);
 		const r1 = mgr.build(makeContext(), BUILD_OPTS);
 		expect(r1.messages).toHaveLength(1);
 
-		mgr.syncMessages([
-			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "a1" },
-		]);
+		mgr.syncMessages([userMsg("q1"), asstMsg("a1")]);
 		const r2 = mgr.build(makeContext(), BUILD_OPTS);
 		expect(r2.messages).toHaveLength(2);
-		expect(r2.messages[1]!.content).toBe("a1");
+		expect(r2.messages[1]!.content).toEqual([{ type: "text", text: "a1" }]);
 	});
 
 	it("syncMessages with unchanged messages is a no-op (same length, no new entries)", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
-		mgr.syncMessages([{ role: "user", content: "q1" }]);
+		mgr.syncMessages([userMsg("q1")]);
 
 		const before = mgr.log.length;
 
 		// Same array length → nothing new to append
-		mgr.syncMessages([{ role: "user", content: "q1" }]);
+		mgr.syncMessages([userMsg("q1")]);
 		expect(mgr.log.length).toBe(before);
 	});
 
@@ -465,15 +490,11 @@ describe("message sync", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		mgr.syncMessages([
-			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "a1" },
-			{ role: "user", content: "q2" },
-		]);
+		mgr.syncMessages([userMsg("q1"), asstMsg("a1"), userMsg("q2")]);
 		expect(mgr.log.length).toBe(3);
 
 		// Simulate compaction — array shrinks
-		mgr.syncMessages([{ role: "user", content: "q2" }]);
+		mgr.syncMessages([userMsg("q2")]);
 		expect(mgr.log.length).toBe(1);
 		expect(mgr.log.toMessages()[0]!.content).toBe("q2");
 	});
@@ -483,28 +504,25 @@ describe("message sync", () => {
 
 		// First turn: build with empty context, sync first message
 		mgr.build(makeContext(), BUILD_OPTS);
-		mgr.syncMessages([{ role: "user", content: "turn1" }]);
+		mgr.syncMessages([userMsg("turn1")]);
 		const r1 = mgr.build(makeContext(), BUILD_OPTS);
 		expect(r1.messages).toHaveLength(1);
 		expect(r1.messages[0]!.content).toBe("turn1");
 
 		// Second turn: sync second message
-		mgr.syncMessages([
-			{ role: "user", content: "turn1" },
-			{ role: "assistant", content: "resp1" },
-		]);
+		mgr.syncMessages([userMsg("turn1"), asstMsg("resp1")]);
 		const r2 = mgr.build(makeContext(), BUILD_OPTS);
 		expect(r2.messages).toHaveLength(2);
-		expect(r2.messages[1]!.content).toBe("resp1");
+		expect(r2.messages[1]!.content).toEqual([{ type: "text", text: "resp1" }]);
 	});
 
 	it("resetSyncCursor forces full re-sync on next call", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
-		mgr.syncMessages([{ role: "user", content: "old" }]);
+		mgr.syncMessages([userMsg("old")]);
 
 		mgr.resetSyncCursor();
-		mgr.syncMessages([{ role: "user", content: "fresh" }]);
+		mgr.syncMessages([userMsg("fresh")]);
 
 		const result = mgr.build(makeContext(), BUILD_OPTS);
 		expect(result.messages).toHaveLength(1);
@@ -515,17 +533,14 @@ describe("message sync", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		const original0 = { role: "user", content: "q1" } as any;
-		const original1 = { role: "assistant", content: "original long result" } as any;
+		const original0 = userMsg("q1");
+		const original1 = asstMsg("original long result");
 		mgr.syncMessages([original0, original1]);
 		expect(mgr.log.length).toBe(2);
 
 		// Same length, but the second message's content changed (simulates per-turn
 		// tool-output pruning / transformContext re-render).
-		mgr.syncMessages([
-			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "[pruned]" },
-		] as any);
+		mgr.syncMessages([userMsg("q1"), asstMsg("[pruned]")]);
 		expect(mgr.log.length).toBe(2);
 
 		const entries = mgr.log.entries();
@@ -533,35 +548,33 @@ describe("message sync", () => {
 		// stops llama.cpp from re-prefilling the entire prior context.
 		expect(entries[0]).toBe(original0);
 		// The diverged tail is re-synced with the new bytes.
-		expect((entries[1] as { content: unknown }).content).toBe("[pruned]");
+		expect((entries[1] as { content: unknown }).content).toEqual([{ type: "text", text: "[pruned]" }]);
 	});
 
 	it("detects tool-result metadata-only rewrites before preserving a later prefix (#3406)", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		const original0 = { role: "user", content: "q1" } as any;
-		const original1 = {
-			role: "toolResult",
+		const original0 = userMsg("q1");
+		const original1 = toolResultMsg({
 			content: [{ type: "text", text: "same output" }],
 			toolCallId: "old-call",
 			toolName: "read",
 			isError: false,
-		} as any;
-		const original2 = { role: "assistant", content: "a1" } as any;
+		});
+		const original2 = asstMsg("a1");
 		mgr.syncMessages([original0, original1, original2]);
 
 		mgr.syncMessages([
-			{ role: "user", content: "q1" },
-			{
-				role: "toolResult",
+			userMsg("q1"),
+			toolResultMsg({
 				content: [{ type: "text", text: "same output" }],
 				toolCallId: "new-call",
 				toolName: "write",
 				isError: true,
-			},
-			{ role: "assistant", content: "a1-pruned" },
-		] as any);
+			}),
+			asstMsg("a1-pruned"),
+		]);
 
 		const entries = mgr.log.entries();
 		expect(entries).toHaveLength(3);
@@ -569,41 +582,35 @@ describe("message sync", () => {
 		expect((entries[1] as { toolCallId: unknown }).toolCallId).toBe("new-call");
 		expect((entries[1] as { toolName: unknown }).toolName).toBe("write");
 		expect((entries[1] as { isError: unknown }).isError).toBe(true);
-		expect((entries[2] as { content: unknown }).content).toBe("a1-pruned");
+		expect((entries[2] as { content: unknown }).content).toEqual([{ type: "text", text: "a1-pruned" }]);
 	});
 
 	it("detects providerPayload-only rewrites before preserving a later prefix (#3406)", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		const original0 = { role: "user", content: "q1" } as any;
-		const original1 = {
-			role: "assistant",
-			content: [{ type: "text", text: "same visible output" }],
-			id: "assistant-1",
+		const original0 = userMsg("q1");
+		const original1 = asstMsg("same visible output", {
 			providerPayload: {
 				type: "openaiResponsesHistory",
 				provider: "openai",
 				items: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "old native" }] }],
 			},
-		} as any;
-		const original2 = { role: "user", content: "q2" } as any;
+		});
+		const original2 = userMsg("q2");
 		mgr.syncMessages([original0, original1, original2]);
 
 		mgr.syncMessages([
-			{ role: "user", content: "q1" },
-			{
-				role: "assistant",
-				content: [{ type: "text", text: "same visible output" }],
-				id: "assistant-1",
+			userMsg("q1"),
+			asstMsg("same visible output", {
 				providerPayload: {
 					type: "openaiResponsesHistory",
 					provider: "openai",
 					items: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "new native" }] }],
 				},
-			},
-			{ role: "user", content: "q2-rewritten" },
-		] as any);
+			}),
+			userMsg("q2-rewritten"),
+		]);
 
 		const entries = mgr.log.entries();
 		expect(entries).toHaveLength(3);
@@ -619,10 +626,7 @@ describe("message sync", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		mgr.syncMessages([
-			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "a1" },
-		] as any);
+		mgr.syncMessages([userMsg("q1"), asstMsg("a1")]);
 		expect(mgr.log.length).toBe(2);
 
 		// Public log clear used by advisor reset: it intentionally empties the
@@ -630,33 +634,26 @@ describe("message sync", () => {
 		mgr.log.clear();
 		expect(mgr.log.length).toBe(0);
 
-		mgr.syncMessages([
-			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "a1-rewritten" },
-		] as any);
+		mgr.syncMessages([userMsg("q1"), asstMsg("a1-rewritten")]);
 
 		const entries = mgr.log.entries();
 		expect(entries).toHaveLength(2);
 		expect((entries[0] as { content: unknown }).content).toBe("q1");
-		expect((entries[1] as { content: unknown }).content).toBe("a1-rewritten");
+		expect((entries[1] as { content: unknown }).content).toEqual([{ type: "text", text: "a1-rewritten" }]);
 	});
 
 	it("preserves the prefix when the tail is rewritten (#3406)", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		const original0 = { role: "user", content: "q1" } as any;
-		const original1 = { role: "assistant", content: "a1" } as any;
-		const original2 = { role: "user", content: "q2" } as any;
+		const original0 = userMsg("q1");
+		const original1 = asstMsg("a1");
+		const original2 = userMsg("q2");
 		mgr.syncMessages([original0, original1, original2]);
 
 		// Tail-only rewrite (e.g. per-turn pruning of the most recent tool result):
 		// the first two messages MUST stay byte-stable; only the tail re-syncs.
-		mgr.syncMessages([
-			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "a1" },
-			{ role: "user", content: "q2-rewritten" },
-		] as any);
+		mgr.syncMessages([userMsg("q1"), asstMsg("a1"), userMsg("q2-rewritten")]);
 
 		const entries = mgr.log.entries();
 		expect(entries).toHaveLength(3);
@@ -669,22 +666,18 @@ describe("message sync", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		const original0 = { role: "user", content: "q1" } as any;
-		const original1 = { role: "assistant", content: "a1" } as any;
+		const original0 = userMsg("q1");
+		const original1 = asstMsg("a1");
 		mgr.syncMessages([original0, original1]);
 
 		// Re-sync with: (a) message #1 rewritten in place; (b) a brand-new tail
 		// appended. The prefix [original0] MUST stay byte-stable.
-		mgr.syncMessages([
-			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "a1-pruned" },
-			{ role: "user", content: "q2" },
-		] as any);
+		mgr.syncMessages([userMsg("q1"), asstMsg("a1-pruned"), userMsg("q2")]);
 
 		const entries = mgr.log.entries();
 		expect(entries).toHaveLength(3);
 		expect(entries[0]).toBe(original0);
-		expect((entries[1] as { content: unknown }).content).toBe("a1-pruned");
+		expect((entries[1] as { content: unknown }).content).toEqual([{ type: "text", text: "a1-pruned" }]);
 		expect((entries[2] as { content: unknown }).content).toBe("q2");
 	});
 
@@ -692,11 +685,11 @@ describe("message sync", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		mgr.syncMessages([{ role: "user", content: "hello" }]);
+		mgr.syncMessages([userMsg("hello")]);
 		expect(mgr.log.length).toBe(1);
 
 		// No byte-stable prefix — the only message diverged.
-		mgr.syncMessages([{ role: "user", content: "world" }]);
+		mgr.syncMessages([userMsg("world")]);
 
 		const msgs = mgr.build(makeContext(), BUILD_OPTS).messages;
 		expect(msgs).toHaveLength(1);
@@ -707,16 +700,10 @@ describe("message sync", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext(), BUILD_OPTS);
 
-		mgr.syncMessages([
-			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "a1" },
-		]);
+		mgr.syncMessages([userMsg("q1"), asstMsg("a1")]);
 
 		const before = mgr.log.length;
-		mgr.syncMessages([
-			{ role: "user", content: "q1" },
-			{ role: "assistant", content: "a1" },
-		]);
+		mgr.syncMessages([userMsg("q1"), asstMsg("a1")]);
 		// Length unchanged — no new messages appended, no clear
 		expect(mgr.log.length).toBe(before);
 	});
@@ -724,7 +711,7 @@ describe("message sync", () => {
 	it("invalidateForModelChange resets prefix and log", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext({ systemPrompt: ["Before"] }), BUILD_OPTS);
-		mgr.syncMessages([{ role: "user", content: "hello" }]);
+		mgr.syncMessages([userMsg("hello")]);
 
 		mgr.invalidateForModelChange();
 
@@ -735,7 +722,7 @@ describe("message sync", () => {
 		expect(result.messages).toHaveLength(0);
 
 		// Re-sync should work cleanly
-		mgr.syncMessages([{ role: "user", content: "new turn" }]);
+		mgr.syncMessages([userMsg("new turn")]);
 		const r2 = mgr.build(ctx, BUILD_OPTS);
 		expect(r2.messages).toHaveLength(1);
 		expect(r2.messages[0]!.content).toBe("new turn");
@@ -864,7 +851,7 @@ describe("syncMessages detects tool_calls mutation", () => {
 			content: null,
 			tool_calls: [{ id: "c1", type: "function", function: { name: "read", arguments: '{"path":"/a"}' } }],
 		};
-		const msgs = [{ role: "user", content: "q" }, assistant] as unknown as Message[];
+		const msgs = [userMsg("q"), assistant] as unknown as Message[];
 		mgr.syncMessages(msgs);
 		expect(mgr.log.length).toBe(2);
 

--- a/packages/agent/test/utils/calculate.ts
+++ b/packages/agent/test/utils/calculate.ts
@@ -10,8 +10,8 @@ export function calculate(expression: string): CalculateResult {
 	try {
 		const result = new Function(`return ${expression}`)();
 		return { content: [{ type: "text", text: `${expression} = ${result}` }], details: undefined };
-	} catch (e: any) {
-		throw new Error(e.message || String(e));
+	} catch (e) {
+		throw new Error(e instanceof Error ? e.message : String(e));
 	}
 }
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -59,6 +59,7 @@ import {
 	GrepSuccessSchema,
 	type GrepUnionResult,
 	GrepUnionResultSchema,
+	type InteractionUpdate,
 	KvClientMessageSchema,
 	type KvServerMessage,
 	ListMcpResourcesErrorSchema,
@@ -339,7 +340,10 @@ function debugReplacer(key: string, value: unknown): unknown {
 		value instanceof Uint8Array ||
 		(value && typeof value === "object" && "type" in value && value.type === "Buffer")
 	) {
-		const bytes = value instanceof Uint8Array ? value : new Uint8Array((value as any).data);
+		const bytes =
+			value instanceof Uint8Array
+				? value
+				: new Uint8Array((value as Record<"type", unknown> & { data: number[] }).data);
 		const asHex = key === "blobId" || key === "blob_id" || key.endsWith("Id") || key.endsWith("_id");
 		return debugBytes(bytes, asHex);
 	}
@@ -1008,7 +1012,7 @@ async function handleShellStreamArgs(
 	const normalizedArgs: ShellArgs = { ...args, workingDirectory: normalizedWorkingDirectory };
 	const startTs = performance.now();
 	log("shellStream", "start", {
-		command: (args as any).command,
+		command: args.command,
 		workingDirectory: normalizedWorkingDirectory,
 		execId: execMsg.execId,
 		hasExecHandlers: !!execHandlers,
@@ -1117,14 +1121,12 @@ async function handleShellStreamArgs(
 	const handler = streamHandler ? (shellArgs: ShellArgs) => streamHandler(shellArgs, streamCallbacks) : batchHandler;
 
 	const { execResult } = await resolveExecHandler(
-		args as any,
+		args,
 		handler as typeof batchHandler,
 		onToolResult,
-		toolResult => buildShellResultFromToolResult(normalizedArgs as any, toolResult),
-		reason =>
-			buildShellRejectedResult((normalizedArgs as any).command, (normalizedArgs as any).workingDirectory, reason),
-		error =>
-			buildShellFailureResult((normalizedArgs as any).command, (normalizedArgs as any).workingDirectory, error),
+		toolResult => buildShellResultFromToolResult(normalizedArgs, toolResult),
+		reason => buildShellRejectedResult(normalizedArgs.command, normalizedArgs.workingDirectory, reason),
+		error => buildShellFailureResult(normalizedArgs.command, normalizedArgs.workingDirectory, error),
 		{ toolCallId: args.toolCallId, toolName: "bash" },
 	);
 
@@ -3638,7 +3640,7 @@ async function pairSynthesizedExecResult(
 
 /** Exported for tests: drives one Cursor interaction update through the streaming state machine. */
 export function processInteractionUpdate(
-	update: any,
+	update: InteractionUpdate,
 	output: AssistantMessage,
 	stream: AssistantMessageEventStream,
 	state: BlockState,
@@ -3790,7 +3792,8 @@ export function processInteractionUpdate(
 			// delta is a cumulative snapshot of the JSON-text args. Strip the prefix we already
 			// have to recover the new suffix; fall back to treating the value as an incremental
 			// fragment when it doesn't extend the buffer.
-			const snapshot: string = update.message.value.argsTextDelta || "";
+			const deltaUpdate = update.message.value;
+			const snapshot: string = ("argsTextDelta" in deltaUpdate ? deltaUpdate.argsTextDelta : "") || "";
 			const current = target[kStreamingPartialJson] ?? "";
 			const chunk = snapshot.startsWith(current) ? snapshot.slice(current.length) : snapshot;
 			if (chunk.length === 0) {

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -36,7 +36,7 @@ import { armPreResponseTimeout, getStreamFirstEventTimeoutMs } from "../utils/id
 // the stream provider trusts the access token threaded through `options.apiKey`.
 import { normalizeSchemaForCCA } from "../utils/schema";
 import { StreamMarkupHealing, type StreamMarkupHealingEvent } from "../utils/stream-markup-healing";
-import type { Content, FunctionCallingConfigMode, ThinkingConfig } from "./google-shared";
+import type { Content, FunctionCallingConfigMode, ThinkingConfig, ThinkingLevel } from "./google-shared";
 import {
 	convertMessages,
 	convertTools,
@@ -1254,8 +1254,8 @@ export function buildRequest(
 		};
 		// Gemini 3 models use thinkingLevel, older models use thinkingBudget
 		if (options.thinking.level !== undefined) {
-			// Cast to any since our GoogleThinkingLevel mirrors Google's ThinkingLevel enum values
-			generationConfig.thinkingConfig.thinkingLevel = options.thinking.level as any;
+			// GoogleThinkingLevel mirrors the SDK's ThinkingLevel string enum values 1:1.
+			generationConfig.thinkingConfig.thinkingLevel = options.thinking.level as ThinkingLevel;
 		} else if (options.thinking.budgetTokens !== undefined) {
 			generationConfig.thinkingConfig.thinkingBudget = options.thinking.budgetTokens;
 		}
@@ -1265,8 +1265,8 @@ export function buildRequest(
 		const suppress = options.thinking.suppress;
 		generationConfig.thinkingConfig = { includeThoughts: false };
 		if ("level" in suppress) {
-			// Cast to any since our GoogleThinkingLevel mirrors Google's ThinkingLevel enum values
-			generationConfig.thinkingConfig.thinkingLevel = suppress.level as any;
+			// GoogleThinkingLevel mirrors the SDK's ThinkingLevel string enum values 1:1.
+			generationConfig.thinkingConfig.thinkingLevel = suppress.level as ThinkingLevel;
 		} else {
 			generationConfig.thinkingConfig.thinkingBudget = suppress.budget;
 		}

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -47,6 +47,7 @@ export type {
 	GenerateContentParameters,
 	GenerateContentResponse,
 	ThinkingConfig,
+	ThinkingLevel,
 } from "./google-types";
 export { normalizeSchemaForGoogle };
 
@@ -710,7 +711,7 @@ export async function consumeGoogleStream<T extends GoogleApiType>(args: {
 						type: "toolCall",
 						id: toolCallId,
 						name: part.functionCall.name || "",
-						arguments: (part.functionCall.args ?? {}) as Record<string, any>,
+						arguments: (part.functionCall.args ?? {}) as Record<string, unknown>,
 						...(part.thoughtSignature && { thoughtSignature: part.thoughtSignature }),
 					};
 

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -3015,9 +3015,12 @@ export async function processResponsesStream<TApi extends Api>(
 			);
 			output.stopReason = mapOpenAIResponsesStopReason(response?.status);
 			if (response?.status === "failed" || response?.status === "cancelled") {
-				const error = response?.error ?? (response as any)?.status_details?.error;
+				const responseWithDetails = response as
+					| { status_details?: { error?: { code?: string; message?: string }; reason?: unknown } }
+					| undefined;
+				const error = response?.error ?? responseWithDetails?.status_details?.error;
 				const details = response?.incomplete_details;
-				const statusDetailsReason = (response as any)?.status_details?.reason;
+				const statusDetailsReason = responseWithDetails?.status_details?.reason;
 				const message = error
 					? `${error.code || "unknown"}: ${error.message || "no message"}`
 					: details?.reason
@@ -3051,7 +3054,12 @@ export async function processResponsesStream<TApi extends Api>(
 			// reaches the SDK stream), actively releasing the connection.
 			break;
 		} else if (event.type === "error") {
-			const err = (event as any).error ?? event;
+			const errEvent = event as {
+				error?: { code?: string; message?: string };
+				code?: string;
+				message?: string;
+			};
+			const err = errEvent.error ?? errEvent;
 			const code = err.code ?? "unknown";
 			const message = err.message ?? "no message";
 			throw new AIError.ProviderResponseError(`Error Code ${code}: ${message}`, {
@@ -3060,7 +3068,10 @@ export async function processResponsesStream<TApi extends Api>(
 			});
 		} else if (event.type === "response.failed") {
 			populateResponsesUsageFromResponse(output, event.response?.usage);
-			const error = event.response?.error ?? (event.response as any)?.status_details?.error;
+			const responseWithDetails = event.response as
+				| { status_details?: { error?: { code?: string; message?: string } } }
+				| undefined;
+			const error = event.response?.error ?? responseWithDetails?.status_details?.error;
 			const details = event.response?.incomplete_details;
 			const message = error
 				? `${error.code || "unknown"}: ${error.message || "no message"}`

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -79,14 +79,14 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		// Notify all waiting consumers that we're done
 		while (this.waiting.length > 0) {
 			const waiter = this.waiting.shift()!;
-			waiter.resolve({ value: undefined as any, done: true });
+			waiter.resolve({ value: undefined, done: true });
 		}
 	}
 
 	endWaiting(): void {
 		while (this.waiting.length > 0) {
 			const waiter = this.waiting.shift()!;
-			waiter.resolve({ value: undefined as any, done: true });
+			waiter.resolve({ value: undefined, done: true });
 		}
 	}
 

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -21,6 +21,7 @@ import {
 	type AgentRunRequest,
 	AgentServerMessageSchema,
 	ExecServerMessageSchema,
+	InteractionUpdateSchema,
 	McpArgsSchema,
 	McpResultSchema,
 	McpSuccessSchema,
@@ -1146,7 +1147,7 @@ describe("Cursor K3 completion warnings", () => {
 		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
 		processInteractionUpdate(
-			{ message: { case: "turnEnded", value: {} } },
+			create(InteractionUpdateSchema, { message: { case: "turnEnded", value: {} } }),
 			output,
 			new AssistantMessageEventStream(),
 			newBlockState(),
@@ -1279,7 +1280,9 @@ describe("Cursor exec local-work tracking (issue #4593)", () => {
 		);
 
 		processInteractionUpdate(
-			{ message: { case: "textDelta", value: { text: "Final synthesized answer" } } },
+			create(InteractionUpdateSchema, {
+				message: { case: "textDelta", value: { text: "Final synthesized answer" } },
+			}),
 			output,
 			stream,
 			state,
@@ -1349,23 +1352,26 @@ describe("Cursor exec local-work tracking (issue #4593)", () => {
 		// The block itself only exists once the streamed call arrives. It must
 		// come out unresolved, so `agent-loop.ts` executes it and pairs a result.
 		processInteractionUpdate(
-			{
+			create(InteractionUpdateSchema, {
 				message: {
 					case: "toolCallStarted",
 					value: {
 						callId: "call-mcp-unhandled",
 						toolCall: {
-							mcpToolCall: {
-								args: {
-									name: "mcp__fixture_report",
-									toolName: "mcp__fixture_report",
-									toolCallId: "call-mcp-unhandled",
+							tool: {
+								case: "mcpToolCall",
+								value: {
+									args: {
+										name: "mcp__fixture_report",
+										toolName: "mcp__fixture_report",
+										toolCallId: "call-mcp-unhandled",
+									},
 								},
 							},
 						},
 					},
 				},
-			},
+			}),
 			output,
 			stream,
 			state,

--- a/packages/ai/test/cursor-exec-modern.test.ts
+++ b/packages/ai/test/cursor-exec-modern.test.ts
@@ -39,6 +39,7 @@ import {
 	ForceBackgroundSubagentStatus,
 	GetDiffRequestSchema,
 	GrepArgsSchema,
+	InteractionUpdateSchema,
 	ListMcpResourcesExecArgsSchema,
 	McpAllowlistPrecheckArgsSchema,
 	McpArgsSchema,
@@ -62,6 +63,7 @@ import {
 	SmartModeClassifierArgsSchema,
 	SubagentArgsSchema,
 	SubagentAwaitArgsSchema,
+	type ToolCall,
 	ToolCallSchema,
 	WebFetchAllowlistPrecheckArgsSchema,
 } from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
@@ -264,7 +266,9 @@ describe("Cursor stream teardown", () => {
 
 		// Start the call and leave it open: the transport dies before completion.
 		processInteractionUpdate(
-			{ message: { case: "toolCallStarted", value: { callId: "envelope-a", toolCall } } },
+			create(InteractionUpdateSchema, {
+				message: { case: "toolCallStarted", value: { callId: "envelope-a", toolCall } },
+			}),
 			output,
 			stream,
 			state,
@@ -293,7 +297,7 @@ describe("Cursor stream teardown", () => {
 		const state = newBlockState();
 
 		processInteractionUpdate(
-			{
+			create(InteractionUpdateSchema, {
 				message: {
 					case: "toolCallStarted",
 					value: {
@@ -301,7 +305,7 @@ describe("Cursor stream teardown", () => {
 						toolCall: { tool: { case: "mcpToolCall", value: { args: { toolCallId: "mcp-1" } } } },
 					},
 				},
-			},
+			}),
 			output,
 			stream,
 			state,
@@ -329,7 +333,7 @@ describe("Cursor stream teardown", () => {
 		const state = newBlockState({ onToolResult: result => void paired.push(result) });
 
 		processInteractionUpdate(
-			{
+			create(InteractionUpdateSchema, {
 				message: {
 					case: "toolCallStarted",
 					value: {
@@ -337,7 +341,7 @@ describe("Cursor stream teardown", () => {
 						toolCall: { tool: { case: "updateTodosToolCall", value: { args: { todos: [] } } } },
 					},
 				},
-			},
+			}),
 			output,
 			stream,
 			state,
@@ -366,7 +370,7 @@ describe("Cursor stream teardown", () => {
 		state.resolvedMcpToolCallIds.add("mcp-1");
 
 		processInteractionUpdate(
-			{
+			create(InteractionUpdateSchema, {
 				message: {
 					case: "toolCallStarted",
 					value: {
@@ -374,7 +378,7 @@ describe("Cursor stream teardown", () => {
 						toolCall: { tool: { case: "mcpToolCall", value: { args: { toolCallId: "mcp-1" } } } },
 					},
 				},
-			},
+			}),
 			output,
 			stream,
 			state,
@@ -909,23 +913,24 @@ describe("Cursor modern exec frames: hooks", () => {
 		// mis-wired branch answers a different hook than the one asked, which the
 		// server reads as a stalled or misrouted hook — invisible unless every
 		// variant is exercised.
-		const requestCases = [
-			"preCompact",
-			"subagentStart",
-			"subagentStop",
-			"preToolUse",
-			"postToolUse",
-			"postToolUseFailure",
-			"beforeSubmitPrompt",
-			"afterAgentResponse",
-			"afterAgentThought",
-			"stop",
-		] as const;
+		// One request per modelled case: an explicit oneof `case` at each `create`
+		// keeps the payload typed, where a variable case would not correlate with
+		// its value. Every payload is optional, so an empty value stands in.
+		const requests = [
+			create(ExecuteHookRequestSchema, { request: { case: "preCompact", value: {} } }),
+			create(ExecuteHookRequestSchema, { request: { case: "subagentStart", value: {} } }),
+			create(ExecuteHookRequestSchema, { request: { case: "subagentStop", value: {} } }),
+			create(ExecuteHookRequestSchema, { request: { case: "preToolUse", value: {} } }),
+			create(ExecuteHookRequestSchema, { request: { case: "postToolUse", value: {} } }),
+			create(ExecuteHookRequestSchema, { request: { case: "postToolUseFailure", value: {} } }),
+			create(ExecuteHookRequestSchema, { request: { case: "beforeSubmitPrompt", value: {} } }),
+			create(ExecuteHookRequestSchema, { request: { case: "afterAgentResponse", value: {} } }),
+			create(ExecuteHookRequestSchema, { request: { case: "afterAgentThought", value: {} } }),
+			create(ExecuteHookRequestSchema, { request: { case: "stop", value: {} } }),
+		];
 
-		for (const requestCase of requestCases) {
-			const request = create(ExecuteHookRequestSchema, {
-				request: { case: requestCase, value: {} },
-			} as never);
+		for (const request of requests) {
+			const requestCase = request.request.case;
 			const { frames } = await dispatchExec(
 				buildExecMessage({ case: "executeHookArgs", value: create(ExecuteHookArgsSchema, { request }) }),
 			);
@@ -1413,7 +1418,9 @@ describe("Cursor modern exec frames: server-resolved tool calls leave a paired b
 
 		const usage = { sawTokenDelta: false };
 		processInteractionUpdate(
-			{ message: { case: "toolCallStarted", value: { callId: options.envelopeId ?? "", toolCall } } },
+			create(InteractionUpdateSchema, {
+				message: { case: "toolCallStarted", value: { callId: options.envelopeId ?? "", toolCall } },
+			}),
 			output,
 			stream,
 			state,
@@ -1421,12 +1428,12 @@ describe("Cursor modern exec frames: server-resolved tool calls leave a paired b
 		);
 		const resultsAfterStart = results.length;
 		processInteractionUpdate(
-			{
+			create(InteractionUpdateSchema, {
 				message: {
 					case: "toolCallCompleted",
 					value: options.completionCarriesCall === false ? {} : { toolCall },
 				},
-			},
+			}),
 			output,
 			stream,
 			state,
@@ -1532,14 +1539,18 @@ describe("Cursor modern exec frames: server-resolved tool calls leave a paired b
 		const usage = { sawTokenDelta: false };
 
 		processInteractionUpdate(
-			{ message: { case: "toolCallStarted", value: { callId: "envelope-a", toolCall } } },
+			create(InteractionUpdateSchema, {
+				message: { case: "toolCallStarted", value: { callId: "envelope-a", toolCall } },
+			}),
 			output,
 			stream,
 			state,
 			usage,
 		);
 		processInteractionUpdate(
-			{ message: { case: "toolCallCompleted", value: { callId: "envelope-b", toolCall } } },
+			create(InteractionUpdateSchema, {
+				message: { case: "toolCallCompleted", value: { callId: "envelope-b", toolCall } },
+			}),
 			output,
 			stream,
 			state,
@@ -1550,7 +1561,9 @@ describe("Cursor modern exec frames: server-resolved tool calls leave a paired b
 		expect(results).toEqual([]);
 
 		processInteractionUpdate(
-			{ message: { case: "toolCallCompleted", value: { callId: "envelope-a", toolCall } } },
+			create(InteractionUpdateSchema, {
+				message: { case: "toolCallCompleted", value: { callId: "envelope-a", toolCall } },
+			}),
 			output,
 			stream,
 			state,
@@ -1593,9 +1606,14 @@ describe("Cursor modern exec frames: server-resolved tool calls leave a paired b
 			return result;
 		};
 		const usage = { sawTokenDelta: false };
-		const send = (updateCase: string, callId: string, toolCall: unknown) =>
+		const send = (updateCase: "toolCallStarted" | "toolCallCompleted", callId: string, toolCall: ToolCall) =>
 			processInteractionUpdate(
-				{ message: { case: updateCase, value: { callId, toolCall } } },
+				create(
+					InteractionUpdateSchema,
+					updateCase === "toolCallStarted"
+						? { message: { case: "toolCallStarted", value: { callId, toolCall } } }
+						: { message: { case: "toolCallCompleted", value: { callId, toolCall } } },
+				),
 				output,
 				stream,
 				state,
@@ -1626,7 +1644,7 @@ describe("Cursor modern exec frames: server-resolved tool calls leave a paired b
 		const state = newBlockState();
 
 		processInteractionUpdate(
-			{
+			create(InteractionUpdateSchema, {
 				message: {
 					case: "toolCallStarted",
 					value: {
@@ -1634,7 +1652,7 @@ describe("Cursor modern exec frames: server-resolved tool calls leave a paired b
 						toolCall: { tool: { case: "piReadToolCall", value: { args: { path: "/a.ts" } } } },
 					},
 				},
-			},
+			}),
 			output,
 			stream,
 			state,

--- a/packages/ai/test/cursor-streaming-args.test.ts
+++ b/packages/ai/test/cursor-streaming-args.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { create } from "@bufbuild/protobuf";
 import {
 	type BlockState,
 	mergeCursorMcpToolCallArgs,
@@ -10,6 +11,7 @@ import {
 import type { AssistantMessage, AssistantMessageEvent } from "@oh-my-pi/pi-ai/types";
 import { getStreamingPartialJson, kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { InteractionUpdateSchema } from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
 
 interface Harness {
 	output: AssistantMessage;
@@ -77,17 +79,17 @@ function newHarness(): Harness {
 
 function startMcpToolCall(h: Harness, name: string, id = "call-1"): void {
 	processInteractionUpdate(
-		{
+		create(InteractionUpdateSchema, {
 			message: {
 				case: "toolCallStarted",
 				value: {
 					callId: id,
 					toolCall: {
-						mcpToolCall: { args: { name, toolName: name, toolCallId: id } },
+						tool: { case: "mcpToolCall", value: { args: { name, toolName: name, toolCallId: id } } },
 					},
 				},
 			},
-		},
+		}),
 		h.output,
 		h.stream,
 		h.state,
@@ -97,7 +99,7 @@ function startMcpToolCall(h: Harness, name: string, id = "call-1"): void {
 
 function pushArgsTextDelta(h: Harness, argsTextDelta: string): void {
 	processInteractionUpdate(
-		{ message: { case: "partialToolCall", value: { argsTextDelta } } },
+		create(InteractionUpdateSchema, { message: { case: "partialToolCall", value: { argsTextDelta } } }),
 		h.output,
 		h.stream,
 		h.state,
@@ -107,12 +109,12 @@ function pushArgsTextDelta(h: Harness, argsTextDelta: string): void {
 
 function completeMcpToolCall(h: Harness, args: Record<string, Uint8Array> | undefined): void {
 	processInteractionUpdate(
-		{
+		create(InteractionUpdateSchema, {
 			message: {
 				case: "toolCallCompleted",
-				value: { toolCall: { mcpToolCall: { args: { args } } } },
+				value: { toolCall: { tool: { case: "mcpToolCall", value: { args: { args } } } } },
 			},
-		},
+		}),
 		h.output,
 		h.stream,
 		h.state,
@@ -122,7 +124,7 @@ function completeMcpToolCall(h: Harness, args: Record<string, Uint8Array> | unde
 
 function pushTextDelta(h: Harness, text: string): void {
 	processInteractionUpdate(
-		{ message: { case: "textDelta", value: { text } } },
+		create(InteractionUpdateSchema, { message: { case: "textDelta", value: { text } } }),
 		h.output,
 		h.stream,
 		h.state,

--- a/packages/ai/test/cursor-todo-bridge.test.ts
+++ b/packages/ai/test/cursor-todo-bridge.test.ts
@@ -11,6 +11,7 @@ import { kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import {
 	AgentServerMessageSchema,
+	type InteractionUpdate,
 	InteractionUpdateSchema,
 	McpArgsSchema,
 	McpToolCallSchema,
@@ -134,9 +135,116 @@ function newHarness(): Harness {
 	};
 }
 
-function start(h: Harness, toolCall: unknown, callId = "call-1"): void {
+type TodoRowLit = { content: string; status: number };
+
+interface UpdateTodoFixture {
+	updateTodosToolCall: {
+		args?: { merge?: boolean; todos?: TodoRowLit[] };
+		result?: {
+			result:
+				| { case: "success"; value: { wasMerge?: boolean; totalCount?: number; todos: TodoRowLit[] } }
+				| { case: "error"; value: { error: string } };
+		};
+	};
+}
+
+interface ReadTodoFixture {
+	readTodosToolCall: {
+		args?: { statusFilter?: number[]; idFilter?: string[] };
+		result?: { result: { case: "success"; value: { totalCount?: number; todos: TodoRowLit[] } } };
+	};
+}
+
+type TodoFixture = UpdateTodoFixture | ReadTodoFixture;
+
+function todoItems(rows: TodoRowLit[]): TodoItem[] {
+	return rows.map(row => create(TodoItemSchema, { content: row.content, status: row.status }));
+}
+
+/**
+ * Builds the real `agent.v1.ToolCall` oneof a decoded interaction stream
+ * carries. A fixture names the variant with the convenience
+ * `updateTodosToolCall` / `readTodosToolCall` key; a wire message only ever
+ * exposes it as the `tool: { case, value }` oneof, so the convenience shape is
+ * mapped onto it here. `total_count` is a proto3 scalar a real server always
+ * sends, so an omitted count becomes the honest row count rather than the
+ * default `0` — which the acceptance guard would misread as a truncated
+ * response.
+ */
+function buildTodoToolCall(fixture: TodoFixture): ToolCall {
+	if ("updateTodosToolCall" in fixture) {
+		const call = fixture.updateTodosToolCall;
+		return create(ToolCallSchema, {
+			tool: {
+				case: "updateTodosToolCall",
+				value: create(UpdateTodosToolCallSchema, {
+					args: create(UpdateTodosArgsSchema, {
+						merge: call.args?.merge ?? false,
+						todos: todoItems(call.args?.todos ?? []),
+					}),
+					result:
+						call.result === undefined
+							? undefined
+							: create(
+									UpdateTodosResultSchema,
+									call.result.result.case === "success"
+										? {
+												result: {
+													case: "success",
+													value: create(UpdateTodosSuccessSchema, {
+														wasMerge: call.result.result.value.wasMerge ?? false,
+														totalCount:
+															call.result.result.value.totalCount ??
+															call.result.result.value.todos.length,
+														todos: todoItems(call.result.result.value.todos),
+													}),
+												},
+											}
+										: {
+												result: {
+													case: "error",
+													value: create(UpdateTodosErrorSchema, { error: call.result.result.value.error }),
+												},
+											},
+								),
+				}),
+			},
+		});
+	}
+	const call = fixture.readTodosToolCall;
+	return create(ToolCallSchema, {
+		tool: {
+			case: "readTodosToolCall",
+			value: create(ReadTodosToolCallSchema, {
+				args: create(ReadTodosArgsSchema, {
+					statusFilter: call.args?.statusFilter ?? [],
+					idFilter: call.args?.idFilter ?? [],
+				}),
+				result:
+					call.result === undefined
+						? undefined
+						: create(ReadTodosResultSchema, {
+								result: {
+									case: "success",
+									value: create(ReadTodosSuccessSchema, {
+										totalCount: call.result.result.value.totalCount ?? call.result.result.value.todos.length,
+										todos: todoItems(call.result.result.value.todos),
+									}),
+								},
+							}),
+			}),
+		},
+	});
+}
+
+function start(h: Harness, fixture: TodoFixture, callId = "call-1"): void {
 	processInteractionUpdate(
-		{ message: { case: "toolCallStarted", value: { callId, toolCall } } },
+		create(InteractionUpdateSchema, {
+			message: {
+				case: "toolCallStarted",
+				value: create(ToolCallStartedUpdateSchema, { callId, toolCall: buildTodoToolCall(fixture) }),
+			},
+		}),
 		h.output,
 		h.stream,
 		h.state,
@@ -144,9 +252,14 @@ function start(h: Harness, toolCall: unknown, callId = "call-1"): void {
 	);
 }
 
-function complete(h: Harness, toolCall: unknown): void {
+function complete(h: Harness, fixture: TodoFixture): void {
 	processInteractionUpdate(
-		{ message: { case: "toolCallCompleted", value: { toolCall } } },
+		create(InteractionUpdateSchema, {
+			message: {
+				case: "toolCallCompleted",
+				value: create(ToolCallCompletedUpdateSchema, { toolCall: buildTodoToolCall(fixture) }),
+			},
+		}),
 		h.output,
 		h.stream,
 		h.state,
@@ -386,21 +499,32 @@ describe("cursor native todo bridge", () => {
  * production ever sees.
  */
 describe("cursor native todo bridge (wire-encoded protobuf)", () => {
-	function wireUpdate(kind: "toolCallStarted" | "toolCallCompleted", toolCall?: ToolCall): unknown {
+	function wireUpdate(kind: "toolCallStarted" | "toolCallCompleted", toolCall?: ToolCall): InteractionUpdate {
 		// `toolCall` is optional on the wire: omitting it exercises a completion
 		// frame that carries no result at all.
-		const value =
+		const update =
 			kind === "toolCallStarted"
-				? create(ToolCallStartedUpdateSchema, { callId: "call-1", toolCall })
-				: create(ToolCallCompletedUpdateSchema, { callId: "call-1", toolCall });
+				? create(InteractionUpdateSchema, {
+						message: {
+							case: "toolCallStarted",
+							value: create(ToolCallStartedUpdateSchema, { callId: "call-1", toolCall }),
+						},
+					})
+				: create(InteractionUpdateSchema, {
+						message: {
+							case: "toolCallCompleted",
+							value: create(ToolCallCompletedUpdateSchema, { callId: "call-1", toolCall }),
+						},
+					});
 		const server = create(AgentServerMessageSchema, {
-			message: {
-				case: "interactionUpdate",
-				value: create(InteractionUpdateSchema, { message: { case: kind, value } } as never),
-			},
+			message: { case: "interactionUpdate", value: update },
 		});
 		// handleServerMessage forwards `message.value` to processInteractionUpdate.
-		return fromBinary(AgentServerMessageSchema, toBinary(AgentServerMessageSchema, server)).message.value;
+		const decoded = fromBinary(AgentServerMessageSchema, toBinary(AgentServerMessageSchema, server));
+		if (decoded.message.case !== "interactionUpdate") {
+			throw new Error(`expected interactionUpdate, got ${decoded.message.case}`);
+		}
+		return decoded.message.value;
 	}
 
 	function items(rows: [string, string, number][]) {
@@ -476,20 +600,8 @@ describe("cursor native todo bridge (wire-encoded protobuf)", () => {
 
 	function drive(toolCall: ToolCall): Harness {
 		const h = newHarness();
-		processInteractionUpdate(
-			wireUpdate("toolCallStarted", toolCall) as never,
-			h.output,
-			h.stream,
-			h.state,
-			h.usageState,
-		);
-		processInteractionUpdate(
-			wireUpdate("toolCallCompleted", toolCall) as never,
-			h.output,
-			h.stream,
-			h.state,
-			h.usageState,
-		);
+		processInteractionUpdate(wireUpdate("toolCallStarted", toolCall), h.output, h.stream, h.state, h.usageState);
+		processInteractionUpdate(wireUpdate("toolCallCompleted", toolCall), h.output, h.stream, h.state, h.usageState);
 		return h;
 	}
 
@@ -578,14 +690,8 @@ describe("cursor native todo bridge (wire-encoded protobuf)", () => {
 		// from every rebuilt transcript.
 		const h = newHarness();
 		const toolCall = updateCall(items([["1", "step one", 2]]), 1);
-		processInteractionUpdate(
-			wireUpdate("toolCallStarted", toolCall) as never,
-			h.output,
-			h.stream,
-			h.state,
-			h.usageState,
-		);
-		processInteractionUpdate(wireUpdate("toolCallCompleted") as never, h.output, h.stream, h.state, h.usageState);
+		processInteractionUpdate(wireUpdate("toolCallStarted", toolCall), h.output, h.stream, h.state, h.usageState);
+		processInteractionUpdate(wireUpdate("toolCallCompleted"), h.output, h.stream, h.state, h.usageState);
 
 		const callId = todoBlocks(h)[0].id;
 		expect(todoBlocks(h)).toHaveLength(1);
@@ -698,7 +804,7 @@ describe("cursor native todo bridge (wire-encoded protobuf)", () => {
 			2,
 		);
 		for (const kind of ["toolCallStarted", "toolCallCompleted"] as const) {
-			processInteractionUpdate(wireUpdate(kind, toolCall) as never, h.output, h.stream, h.state, h.usageState);
+			processInteractionUpdate(wireUpdate(kind, toolCall), h.output, h.stream, h.state, h.usageState);
 		}
 
 		expect(h.toolResults[0]).toMatchObject({
@@ -852,7 +958,7 @@ describe("cursor native todo bridge (wire-encoded protobuf)", () => {
 		h.state.onTodoSnapshot = undefined;
 		const toolCall = updateCall(items([["1", "task", 3]]), 1);
 		for (const kind of ["toolCallStarted", "toolCallCompleted"] as const) {
-			processInteractionUpdate(wireUpdate(kind, toolCall) as never, h.output, h.stream, h.state, h.usageState);
+			processInteractionUpdate(wireUpdate(kind, toolCall), h.output, h.stream, h.state, h.usageState);
 		}
 
 		expect(h.syncCalls).toEqual([]);
@@ -868,7 +974,7 @@ describe("cursor native todo bridge (wire-encoded protobuf)", () => {
 		h.state.onTodoSnapshot = undefined;
 		const toolCall = errorCall("boom");
 		for (const kind of ["toolCallStarted", "toolCallCompleted"] as const) {
-			processInteractionUpdate(wireUpdate(kind, toolCall) as never, h.output, h.stream, h.state, h.usageState);
+			processInteractionUpdate(wireUpdate(kind, toolCall), h.output, h.stream, h.state, h.usageState);
 		}
 
 		expect(h.toolResults[0]).toMatchObject({
@@ -889,7 +995,7 @@ describe("cursor native todo bridge (wire-encoded protobuf)", () => {
 		};
 		const toolCall = updateCall(items([["1", "task", 3]]), 1);
 		for (const kind of ["toolCallStarted", "toolCallCompleted"] as const) {
-			processInteractionUpdate(wireUpdate(kind, toolCall) as never, h.output, h.stream, h.state, h.usageState);
+			processInteractionUpdate(wireUpdate(kind, toolCall), h.output, h.stream, h.state, h.usageState);
 		}
 
 		expect(h.state.currentToolCall).toBeNull();
@@ -928,15 +1034,9 @@ describe("cursor native todo bridge (wire-encoded protobuf)", () => {
 					}),
 				},
 			});
+		processInteractionUpdate(wireUpdate("toolCallStarted", mcpCall({})), h.output, h.stream, h.state, h.usageState);
 		processInteractionUpdate(
-			wireUpdate("toolCallStarted", mcpCall({})) as never,
-			h.output,
-			h.stream,
-			h.state,
-			h.usageState,
-		);
-		processInteractionUpdate(
-			wireUpdate("toolCallCompleted", mcpCall({ query: new TextEncoder().encode('"weather"') })) as never,
+			wireUpdate("toolCallCompleted", mcpCall({ query: new TextEncoder().encode('"weather"') })),
 			h.output,
 			h.stream,
 			h.state,

--- a/packages/ai/test/github-copilot-error.test.ts
+++ b/packages/ai/test/github-copilot-error.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "bun:test";
 import { rewriteCopilotError } from "@oh-my-pi/pi-ai/utils/http-inspector";
 
 function errorWithStatus(status: number): Error {
-	const err = new Error(`${status} Unauthorized`);
-	(err as any).status = status;
+	const err: Error & { status?: number } = new Error(`${status} Unauthorized`);
+	err.status = status;
 	return err;
 }
 

--- a/packages/ai/test/gitlab-duo-workflow-provider.test.ts
+++ b/packages/ai/test/gitlab-duo-workflow-provider.test.ts
@@ -1369,9 +1369,8 @@ describe("GitLab Duo Workflow WebSocket state machine", () => {
 		const result = await stream.result();
 
 		expect(result.stopReason).toBe("error");
-		expect(isContextOverflow({ stopReason: "error", errorMessage: result.errorMessage, content: [] } as any)).toBe(
-			true,
-		);
+		const overflowInput: unknown = { stopReason: "error", errorMessage: result.errorMessage, content: [] };
+		expect(isContextOverflow(overflowInput as AssistantMessage)).toBe(true);
 		expect(result.errorMessage).toContain("prompt is too long");
 		// The request was never spent and the created workflow was stopped.
 		expect(socketOpened).toBe(false);
@@ -1446,9 +1445,8 @@ describe("GitLab Duo Workflow WebSocket state machine", () => {
 		expect(result.stopReason).toBe("error");
 		// The request WAS attempted (jitter zone can succeed), then relabeled on failure.
 		expect(socketOpened).toBe(true);
-		expect(isContextOverflow({ stopReason: "error", errorMessage: result.errorMessage, content: [] } as any)).toBe(
-			true,
-		);
+		const overflowInput: unknown = { stopReason: "error", errorMessage: result.errorMessage, content: [] };
+		expect(isContextOverflow(overflowInput as AssistantMessage)).toBe(true);
 		expect(result.errorMessage).toContain("prompt is too long");
 		expect(result.errorMessage).not.toContain("Internal server error");
 	});

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -277,6 +277,9 @@ describe("openai-completions convertMessages", () => {
 		};
 
 		const now = Date.now();
+		// A stringified-JSON arguments value is what some providers emit on the wire;
+		// erase its static type to unknown so the field assertion is a single cast.
+		const stringToolArgs: unknown = '{"path":"README.md"}';
 		const assistantMessage: AssistantMessage = {
 			role: "assistant",
 			content: [
@@ -284,7 +287,7 @@ describe("openai-completions convertMessages", () => {
 					type: "toolCall",
 					id: "tool-1",
 					name: "read",
-					arguments: '{"path":"README.md"}' as unknown as Record<string, any>,
+					arguments: stringToolArgs as Record<string, unknown>,
 				},
 			],
 			api: model.api,

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -852,10 +852,10 @@ describe("OpenAI-family first-event timeouts", () => {
 			compat: { streamIdleTimeoutMs: 20 },
 		});
 
-		const fetchMock = () => Promise.resolve(createNoProgressOpenAIResponsesStream(undefined));
+		const fetchMock: FetchImpl = () => Promise.resolve(createNoProgressOpenAIResponsesStream(undefined));
 		const result = await streamOpenAIResponses(customResponsesModel, baseContext(), {
 			apiKey: "test-key",
-			fetch: fetchMock as any,
+			fetch: fetchMock,
 		}).result();
 
 		expect(result.stopReason).toBe("error");

--- a/packages/ai/test/schema-dereference.test.ts
+++ b/packages/ai/test/schema-dereference.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { dereferenceJsonSchema } from "@oh-my-pi/pi-ai/utils/schema";
 
+// Dereferenced schemas are plain JSON trees; every node is again a record, so
+// this recursive shape lets the assertions walk arbitrary nested keys.
+interface SchemaNode {
+	[key: string]: SchemaNode;
+}
+
 describe("dereferenceJsonSchema", () => {
 	it("returns non-object input unchanged", () => {
 		expect(dereferenceJsonSchema(null)).toBe(null);
@@ -33,9 +39,9 @@ describe("dereferenceJsonSchema", () => {
 				},
 			},
 		};
-		const result = dereferenceJsonSchema(schema) as any;
+		const result = dereferenceJsonSchema(schema) as SchemaNode;
 		expect(result.$defs).toBeUndefined();
-		expect(result.properties.anchor).toEqual({
+		expect(result.properties.anchor as unknown).toEqual({
 			type: "object",
 			properties: {
 				path: { type: "string" },
@@ -54,9 +60,9 @@ describe("dereferenceJsonSchema", () => {
 				Item: { type: "string", enum: ["a", "b"] },
 			},
 		};
-		const result = dereferenceJsonSchema(schema) as any;
+		const result = dereferenceJsonSchema(schema) as SchemaNode;
 		expect(result.definitions).toBeUndefined();
-		expect(result.properties.item).toEqual({ type: "string", enum: ["a", "b"] });
+		expect(result.properties.item as unknown).toEqual({ type: "string", enum: ["a", "b"] });
 	});
 
 	it("inlines nested $ref inside arrays (items, anyOf, oneOf)", () => {
@@ -83,9 +89,9 @@ describe("dereferenceJsonSchema", () => {
 				Str: { type: "string" },
 			},
 		};
-		const result = dereferenceJsonSchema(schema) as any;
+		const result = dereferenceJsonSchema(schema) as SchemaNode;
 		expect(result.$defs).toBeUndefined();
-		expect(result.properties.anchors.items).toEqual({
+		expect(result.properties.anchors.items as unknown).toEqual({
 			type: "object",
 			properties: {
 				anchor_type: { type: "string", enum: ["file", "symbol", "pattern"] },
@@ -93,8 +99,8 @@ describe("dereferenceJsonSchema", () => {
 			},
 			required: ["anchor_type", "path"],
 		});
-		expect(result.properties.value.anyOf[0]).toEqual({ type: "string" });
-		expect(result.properties.value.anyOf[1]).toEqual({ type: "null" });
+		expect(result.properties.value.anyOf[0] as unknown).toEqual({ type: "string" });
+		expect(result.properties.value.anyOf[1] as unknown).toEqual({ type: "null" });
 	});
 
 	it("handles $ref inside a definition pointing to another definition", () => {
@@ -113,9 +119,9 @@ describe("dereferenceJsonSchema", () => {
 				},
 			},
 		};
-		const result = dereferenceJsonSchema(schema) as any;
+		const result = dereferenceJsonSchema(schema) as SchemaNode;
 		expect(result.$defs).toBeUndefined();
-		expect(result.properties.wrapper).toEqual({
+		expect(result.properties.wrapper as unknown).toEqual({
 			type: "object",
 			properties: {
 				value: { type: "integer", minimum: 0 },
@@ -142,12 +148,12 @@ describe("dereferenceJsonSchema", () => {
 				},
 			},
 		};
-		const result = dereferenceJsonSchema(schema) as any;
+		const result = dereferenceJsonSchema(schema) as SchemaNode;
 		expect(result.$defs).toBeUndefined();
 		const node = result.properties.node;
-		expect(node.properties.name).toEqual({ type: "string" });
+		expect(node.properties.name as unknown).toEqual({ type: "string" });
 		// Circular ref breaks to {}
-		expect(node.properties.children.items).toEqual({});
+		expect(node.properties.children.items as unknown).toEqual({});
 	});
 
 	it("leaves external $ref untouched", () => {
@@ -158,8 +164,8 @@ describe("dereferenceJsonSchema", () => {
 			},
 			$defs: {},
 		};
-		const result = dereferenceJsonSchema(schema) as any;
-		expect(result.properties.ext).toEqual({ $ref: "https://example.com/schema.json#/Foo" });
+		const result = dereferenceJsonSchema(schema) as SchemaNode;
+		expect(result.properties.ext as unknown).toEqual({ $ref: "https://example.com/schema.json#/Foo" });
 	});
 
 	it("preserves sibling keywords alongside $ref", () => {
@@ -180,10 +186,10 @@ describe("dereferenceJsonSchema", () => {
 				},
 			},
 		};
-		const result = dereferenceJsonSchema(schema) as any;
+		const result = dereferenceJsonSchema(schema) as SchemaNode;
 		expect(result.$defs).toBeUndefined();
 		// Sibling description overrides the definition's description
-		expect(result.properties.anchor_type).toEqual({
+		expect(result.properties.anchor_type as unknown).toEqual({
 			type: "string",
 			enum: ["file", "symbol", "pattern"],
 			description: "Field-level description",
@@ -202,10 +208,10 @@ describe("dereferenceJsonSchema", () => {
 				Shared: { type: "string", maxLength: 100 },
 			},
 		};
-		const result = dereferenceJsonSchema(schema) as any;
+		const result = dereferenceJsonSchema(schema) as SchemaNode;
 		expect(result.$defs).toBeUndefined();
-		expect(result.properties.a).toEqual({ type: "string", maxLength: 100 });
-		expect(result.properties.b).toEqual({ type: "string", maxLength: 100 });
+		expect(result.properties.a as unknown).toEqual({ type: "string", maxLength: 100 });
+		expect(result.properties.b as unknown).toEqual({ type: "string", maxLength: 100 });
 	});
 
 	it("reproduces the nucleus write_memory schema pattern", () => {
@@ -239,17 +245,21 @@ describe("dereferenceJsonSchema", () => {
 				},
 			},
 		};
-		const result = dereferenceJsonSchema(schema) as any;
+		const result = dereferenceJsonSchema(schema) as SchemaNode;
 
 		// $defs stripped
 		expect(result.$defs).toBeUndefined();
 
 		// anchors items fully inlined
-		expect(result.properties.anchors.items.properties.anchor_type.enum).toEqual(["file", "symbol", "pattern"]);
-		expect(result.properties.anchors.items.required).toEqual(["anchor_type", "path"]);
+		expect(result.properties.anchors.items.properties.anchor_type.enum as unknown).toEqual([
+			"file",
+			"symbol",
+			"pattern",
+		]);
+		expect(result.properties.anchors.items.required as unknown).toEqual(["anchor_type", "path"]);
 
 		// Other properties preserved
-		expect(result.properties.kind).toEqual({ type: "string", description: "Memory kind" });
-		expect(result.required).toEqual(["kind", "content", "anchors"]);
+		expect(result.properties.kind as unknown).toEqual({ type: "string", description: "Memory kind" });
+		expect(result.required as unknown).toEqual(["kind", "content", "anchors"]);
 	});
 });

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -133,9 +133,9 @@ async function handleToolCall<TApi extends Api>(model: Model<TApi>, options?: Op
 				expect(toolCall.name).toBe("math_operation");
 				JSON.parse(accumulatedToolArgs);
 				expect(toolCall.arguments).not.toBeUndefined();
-				expect((toolCall.arguments as any).a).toBe(15);
-				expect((toolCall.arguments as any).b).toBe(27);
-				expect(["add", "subtract", "multiply", "divide"]).toContain((toolCall.arguments as any).operation);
+				expect(toolCall.arguments.a).toBe(15);
+				expect(toolCall.arguments.b).toBe(27);
+				expect(["add", "subtract", "multiply", "divide"]).toContain(toolCall.arguments.operation as string);
 			}
 		}
 	}

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3208,7 +3208,9 @@ export function lmStudioModelManagerOptions(
 ): ModelManagerOptions<"openai-completions"> {
 	const apiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? Bun.env.LM_STUDIO_BASE_URL ?? "http://127.0.0.1:1234/v1";
-	const references = createBundledReferenceMap<"openai-completions">("lm-studio" as any);
+	// LM Studio serves only locally-discovered models, which have no bundled
+	// catalog entries to project — so there are no references to resolve against.
+	const references = new Map<string, ModelSpec<"openai-completions">>();
 	return {
 		providerId: "lm-studio",
 		fetchDynamicModels: async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fixed ACP session replay dropping `errorMessage` from legacy/imported failed tool-result messages, so the readable failure reason now appears in the replayed tool_call_update content.
 - Replaced banned `Parameters<>`/`ReturnType<>` type queries in `TaskTool.renderResult` with concrete named types.
+- Fixed ACP session replay dropping a stored `toolResult` whose `content` is a plain string (legacy/imported sessions): the replay path now normalizes the string into a text content block instead of emitting an empty result, preserving the tool's only result description.
+- Widened the legacy `pi-ai` shim's `StringEnumOptions` to `T extends string | number` and threaded the `StringEnum` value type through it, so numeric legacy enums like `StringEnum([1, 2], { default: 1, examples: [2] })` compile again instead of being rejected by the `StringEnumOptions<string>` annotation introduced with the `any` removal.
 
 ## [17.2.8] - 2026-08-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ACP session replay dropping `errorMessage` from legacy/imported failed tool-result messages, so the readable failure reason now appears in the replayed tool_call_update content.
+- Replaced banned `Parameters<>`/`ReturnType<>` type queries in `TaskTool.renderResult` with concrete named types.
+
 ## [17.2.8] - 2026-08-04
 
 ### Changed

--- a/packages/coding-agent/src/commit/agentic/agent.ts
+++ b/packages/coding-agent/src/commit/agentic/agent.ts
@@ -1,7 +1,7 @@
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Api, Model } from "@oh-my-pi/pi-ai";
 import { Markdown } from "@oh-my-pi/pi-tui";
-import { prompt } from "@oh-my-pi/pi-utils";
+import { isRecord, prompt } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import chalk from "chalk";
 import typesDescriptionPrompt from "../../commit/prompts/types-description.md" with { type: "text" };
@@ -109,7 +109,10 @@ export async function runCommitAgentSession(input: CommitAgentInput): Promise<Co
 			}
 			case "tool_execution_start":
 				toolCalls += 1;
-				toolArgsById.set(event.toolCallId, { name: event.toolName, args: event.args });
+				toolArgsById.set(event.toolCallId, {
+					name: event.toolName,
+					args: isRecord(event.args) ? event.args : undefined,
+				});
 				break;
 			case "message_end": {
 				const role = event.message?.role;

--- a/packages/coding-agent/src/commit/agentic/tools/index.ts
+++ b/packages/coding-agent/src/commit/agentic/tools/index.ts
@@ -23,8 +23,8 @@ export interface CommitToolOptions {
 	enableAnalyzeFiles?: boolean;
 }
 
-export function createCommitTools(options: CommitToolOptions): Array<CustomTool<any, any>> {
-	const tools: Array<CustomTool<any, any>> = [
+export function createCommitTools(options: CommitToolOptions): Array<CustomTool> {
+	const tools: Array<CustomTool> = [
 		createGitOverviewTool(options.cwd, options.state),
 		createGitFileDiffTool(options.cwd, options.state),
 		createGitHunkTool(options.cwd),

--- a/packages/coding-agent/src/commit/shared-llm.ts
+++ b/packages/coding-agent/src/commit/shared-llm.ts
@@ -61,8 +61,8 @@ export function parseConventionalAnalysisResponse(
 ): ConventionalAnalysis {
 	const toolCall = extractToolCall(message, tool.name);
 	if (toolCall) {
-		const parsed = validateToolCall([tool], toolCall) as any;
-		return normalizeAnalysis(parsed);
+		const validated: unknown = validateToolCall([tool], toolCall);
+		return normalizeAnalysis(validated as ParsedConventionalAnalysis);
 	}
 	const text = extractTextContent(message);
 	const parsed = parseJsonPayload(text) as ParsedConventionalAnalysis;

--- a/packages/coding-agent/src/config/models-config-schema-bundle.ts
+++ b/packages/coding-agent/src/config/models-config-schema-bundle.ts
@@ -115,7 +115,7 @@ export const getModelsConfigSchemaBundle = once(() => {
 				(value.minLevel !== undefined && value.maxLevel !== undefined) ||
 				ctx.mustBe("thinking with `efforts` (or legacy `levels`/`minLevel`+`maxLevel`)"),
 		)
-		.pipe((value: any) => {
+		.pipe(value => {
 			let resolved = value.efforts ?? value.levels;
 			if (!resolved) {
 				const minIndex = EFFORT_ORDER.indexOf(value.minLevel!);

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -2187,8 +2187,6 @@ export class Settings {
 // Setting Hooks
 // ═══════════════════════════════════════════════════════════════════════════
 
-type SettingHook<P extends SettingPath> = (value: SettingValue<P>, prev: SettingValue<P>) => void;
-
 /**
  * Minimal change-notification primitive backing the exported `on*Changed`
  * subscriptions. Holds a listener set, hands out unsubscribe closures, and
@@ -2228,7 +2226,7 @@ class SettingSignal<A extends unknown[] = []> {
 	}
 }
 
-const SETTING_HOOKS: Partial<Record<SettingPath, SettingHook<any>>> = {
+const SETTING_HOOKS: Partial<Record<SettingPath, (value: unknown, prev: unknown) => void>> = {
 	"theme.dark": value => {
 		if (typeof value === "string") {
 			setAutoThemeMapping("dark", value);

--- a/packages/coding-agent/src/cursor.ts
+++ b/packages/coding-agent/src/cursor.ts
@@ -7,6 +7,7 @@ import type {
 	AgentToolContext,
 	AgentToolResult,
 	AgentToolUpdateCallback,
+	AnyAgentTool,
 } from "@oh-my-pi/pi-agent-core";
 import type {
 	CursorMcpCall,
@@ -41,7 +42,7 @@ const CURSOR_TODO_PHASE = "Tasks";
  * tool registry stores. The concrete tools have narrower `execute` parameter
  * types than the default `AgentTool`, which only unify through this alias.
  */
-type CursorBridgeTool = AgentTool<any, any, any>;
+type CursorBridgeTool = AnyAgentTool;
 
 /**
  * The live MCP connections Cursor's resource frames are answered from.

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -162,7 +162,7 @@ export interface RenderResultOptions {
 	spinnerFrame?: number;
 }
 
-export type CustomToolResult<TDetails = any> = AgentToolResult<TDetails>;
+export type CustomToolResult<TDetails = unknown> = AgentToolResult<TDetails>;
 
 /**
  * Custom tool definition.
@@ -197,7 +197,7 @@ export type CustomToolResult<TDetails = any> = AgentToolResult<TDetails>;
  * });
  * ```
  */
-export interface CustomTool<TParams extends TSchema = TSchema, TDetails = any> {
+export interface CustomTool<TParams extends TSchema = TSchema, TDetails = unknown> {
 	/** Tool name (used in LLM tool calls) */
 	name: string;
 	/** Human-readable label for UI */
@@ -243,24 +243,22 @@ export interface CustomTool<TParams extends TSchema = TSchema, TDetails = any> {
 	/** Called on session lifecycle events - use to reconstruct state or cleanup resources */
 	onSession?: (event: CustomToolSessionEvent, ctx: CustomToolContext) => void | Promise<void>;
 	/** Custom rendering for tool call display - return a Component */
-	renderCall?: (args: Static<TParams>, options: RenderResultOptions, theme: Theme) => Component;
+	renderCall?(args: Static<TParams>, options: RenderResultOptions, theme: Theme): Component;
 
 	/** Custom rendering for tool result display - return a Component */
-	renderResult?: (
+	renderResult?(
 		result: CustomToolResult<TDetails>,
 		options: RenderResultOptions,
 		theme: Theme,
 		args?: Static<TParams>,
-	) => Component;
+	): Component;
 }
 
 /** Factory function that creates a custom tool or array of tools */
-export type CustomToolFactory = (
-	pi: CustomToolAPI,
-) => CustomTool<any, any> | CustomTool<any, any>[] | Promise<CustomTool<any, any> | CustomTool<any, any>[]>;
+export type CustomToolFactory = (pi: CustomToolAPI) => CustomTool | CustomTool[] | Promise<CustomTool | CustomTool[]>;
 
 /** Loaded custom tool with metadata and wrapped AgentTool */
-export interface LoadedCustomTool<TParams extends TSchema = TSchema, TDetails = any> {
+export interface LoadedCustomTool<TParams extends TSchema = TSchema, TDetails = unknown> {
 	/** Original path (as specified) */
 	path: string;
 	/** Resolved absolute path */

--- a/packages/coding-agent/src/extensibility/custom-tools/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/wrapper.ts
@@ -8,7 +8,7 @@ import { defaultLoadModeForToolName } from "../../tools/essential-tools";
 import { applyToolProxy } from "../tool-proxy";
 import type { CustomTool, CustomToolContext } from "./types";
 
-export class CustomToolAdapter<TParams extends TSchema = TSchema, TDetails = any, TTheme extends Theme = Theme>
+export class CustomToolAdapter<TParams extends TSchema = TSchema, TDetails = unknown, TTheme extends Theme = Theme>
 	implements AgentTool<TParams, TDetails, TTheme>
 {
 	declare name: string;
@@ -41,7 +41,7 @@ export class CustomToolAdapter<TParams extends TSchema = TSchema, TDetails = any
 	 * Backward-compatible export of factory function for existing callers.
 	 * Prefer CustomToolAdapter constructor directly.
 	 */
-	static wrap<TParams extends TSchema = TSchema, TDetails = any, TTheme extends Theme = Theme>(
+	static wrap<TParams extends TSchema = TSchema, TDetails = unknown, TTheme extends Theme = Theme>(
 		tool: CustomTool<TParams, TDetails>,
 		getContext: () => CustomToolContext,
 	): AgentTool<TParams, TDetails, TTheme> {

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -585,15 +585,15 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	onSession?: (event: ToolSessionEvent, ctx: ExtensionContext) => void | Promise<void>;
 
 	/** Custom rendering for tool call display */
-	renderCall?: (args: Static<TParams>, options: ToolRenderResultOptions, theme: Theme) => Component;
+	renderCall?(args: Static<TParams>, options: ToolRenderResultOptions, theme: Theme): Component;
 
 	/** Custom rendering for tool result display */
-	renderResult?: (
+	renderResult?(
 		result: AgentToolResult<TDetails>,
 		options: ToolRenderResultOptions,
 		theme: Theme,
 		args?: Static<TParams>,
-	) => Component;
+	): Component;
 }
 
 // ============================================================================
@@ -1545,7 +1545,7 @@ export interface Extension {
 	resolvedPath: string;
 	label?: string;
 	handlers: Map<string, HandlerFn[]>;
-	tools: Map<string, RegisteredTool<any, any>>;
+	tools: Map<string, RegisteredTool>;
 	assistantThinkingRenderers: AssistantThinkingRenderer[];
 	messageRenderers: Map<string, MessageRenderer>;
 	commands: Map<string, RegisteredCommand>;

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -6,6 +6,8 @@ import type {
 	AgentToolContext,
 	AgentToolResult,
 	AgentToolUpdateCallback,
+	AnyAgentTool,
+	RenderResultOptions,
 	ToolLoadMode,
 } from "@oh-my-pi/pi-agent-core";
 import type { ComputerSafetyCheck, ImageContent, Static, TextContent, TSchema } from "@oh-my-pi/pi-ai";
@@ -22,15 +24,15 @@ import type { RegisteredTool, ToolCallEventResult } from "./types";
 /**
  * Adapts a RegisteredTool into an AgentTool.
  */
-export class RegisteredToolAdapter implements AgentTool<any, any, any> {
+export class RegisteredToolAdapter implements AnyAgentTool {
 	declare name: string;
 	declare description: string;
-	declare parameters: any;
+	declare parameters: TSchema;
 	declare label: string;
 	declare strict: boolean;
 
-	renderCall?: (args: any, options: any, theme: any) => any;
-	renderResult?: (result: any, options: any, theme: any, args?: any) => any;
+	renderCall?: (args: unknown, options: RenderResultOptions, theme: unknown) => unknown;
+	renderResult?: (result: AgentToolResult, options: RenderResultOptions, theme: unknown, args?: unknown) => unknown;
 	readonly loadMode: ToolLoadMode;
 
 	constructor(
@@ -45,11 +47,11 @@ export class RegisteredToolAdapter implements AgentTool<any, any, any> {
 		// enters the custom-renderer path, gets undefined back, and silently
 		// discards tool result text (extensions without renderers show blank).
 		if (registeredTool.definition.renderCall) {
-			this.renderCall = (args: any, options: any, theme: any) =>
+			this.renderCall = (args, options, theme) =>
 				registeredTool.definition.renderCall!(args, options, theme as Theme);
 		}
 		if (registeredTool.definition.renderResult) {
-			this.renderResult = (result: any, options: any, theme: any, args?: any) =>
+			this.renderResult = (result, options, theme, args) =>
 				registeredTool.definition.renderResult!(
 					result,
 					{ expanded: options.expanded, isPartial: options.isPartial, spinnerFrame: options.spinnerFrame },
@@ -61,9 +63,9 @@ export class RegisteredToolAdapter implements AgentTool<any, any, any> {
 
 	async execute(
 		toolCallId: string,
-		params: any,
+		params: unknown,
 		signal?: AbortSignal,
-		onUpdate?: AgentToolUpdateCallback<any>,
+		onUpdate?: AgentToolUpdateCallback,
 		context?: AgentToolContext,
 	) {
 		// Bind the extension context to this tool's own name so `ctx.invokeTool` delegates to the

--- a/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
@@ -48,7 +48,7 @@ export interface StringEnumOptions<T extends string> {
 
 function stringEnumWireSchema<T extends string | number>(
 	values: readonly T[] | Record<string, T>,
-	options: StringEnumOptions<any> | undefined,
+	options: StringEnumOptions<string> | undefined,
 ) {
 	const enumValues = Array.isArray(values) ? [...values] : Object.values(values);
 	const schema: Record<string, unknown> = {
@@ -66,7 +66,7 @@ function stringEnumWireSchema<T extends string | number>(
 
 export function StringEnum<T extends string | number>(
 	values: readonly T[] | Record<string, T>,
-	options?: StringEnumOptions<any>,
+	options?: StringEnumOptions<string>,
 ): TSchema {
 	const opts = {
 		description: options?.description ?? "Legacy string enum compatibility schema",

--- a/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
@@ -39,7 +39,7 @@ import {
 } from "@oh-my-pi/pi-catalog/models";
 import { type TSchema, Type } from "./legacy-typebox";
 
-export interface StringEnumOptions<T extends string> {
+export interface StringEnumOptions<T extends string | number> {
 	description?: string;
 	default?: T;
 	examples?: T[];
@@ -48,7 +48,7 @@ export interface StringEnumOptions<T extends string> {
 
 function stringEnumWireSchema<T extends string | number>(
 	values: readonly T[] | Record<string, T>,
-	options: StringEnumOptions<string> | undefined,
+	options: StringEnumOptions<T> | undefined,
 ) {
 	const enumValues = Array.isArray(values) ? [...values] : Object.values(values);
 	const schema: Record<string, unknown> = {
@@ -66,7 +66,7 @@ function stringEnumWireSchema<T extends string | number>(
 
 export function StringEnum<T extends string | number>(
 	values: readonly T[] | Record<string, T>,
-	options?: StringEnumOptions<string>,
+	options?: StringEnumOptions<T>,
 ): TSchema {
 	const opts = {
 		description: options?.description ?? "Legacy string enum compatibility schema",

--- a/packages/coding-agent/src/mcp/loader.ts
+++ b/packages/coding-agent/src/mcp/loader.ts
@@ -105,7 +105,7 @@ export async function discoverAndLoadMCPTools(cwd: string, options?: MCPToolsLoa
 		return {
 			path,
 			resolvedPath: `mcp:${tool.name}`,
-			tool: tool as any, // MCPToolDetails is compatible with CustomTool<TSchema, any>
+			tool,
 		};
 	});
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2233,7 +2233,11 @@ export class AcpAgent implements Agent {
 			toolName: message.toolName,
 			isError: message.isError === true,
 			result: {
-				content: Array.isArray(message.content) ? (message.content as AgentToolResult["content"]) : [],
+				content: Array.isArray(message.content)
+					? (message.content as AgentToolResult["content"])
+					: typeof message.content === "string" && message.content.length > 0
+						? [{ type: "text", text: message.content }]
+						: [],
 				details: message.details,
 				...(typeof message.errorMessage === "string" && { errorMessage: message.errorMessage }),
 			},

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2235,6 +2235,7 @@ export class AcpAgent implements Agent {
 			result: {
 				content: Array.isArray(message.content) ? (message.content as AgentToolResult["content"]) : [],
 				details: message.details,
+				...(typeof message.errorMessage === "string" && { errorMessage: message.errorMessage }),
 			},
 		};
 		const notifications = mapAgentSessionEventToAcpSessionUpdates(endEvent, sessionId, {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2233,9 +2233,8 @@ export class AcpAgent implements Agent {
 			toolName: message.toolName,
 			isError: message.isError === true,
 			result: {
-				content: message.content,
+				content: Array.isArray(message.content) ? (message.content as AgentToolResult["content"]) : [],
 				details: message.details,
-				errorMessage: message.errorMessage,
 			},
 		};
 		const notifications = mapAgentSessionEventToAcpSessionUpdates(endEvent, sessionId, {

--- a/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
+++ b/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
@@ -6,7 +6,8 @@
 import * as os from "node:os";
 import { isZodSchema, zodToWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { type Component, truncateToWidth, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
-import { theme } from "../../../modes/theme/theme";
+import { isRecord } from "@oh-my-pi/pi-utils";
+import { type ThemeColor, theme } from "../../../modes/theme/theme";
 import { shortenPath } from "../../../tools/render-utils";
 import type { Extension, ExtensionState } from "./types";
 
@@ -168,22 +169,30 @@ export class InspectorPanel implements Component {
 		lines.push(theme.fg("dim", theme.boxRound.horizontal.repeat(Math.min(width - 2, 40))));
 
 		try {
-			const tool = raw as any;
-			const wire = (s: unknown): any => (isZodSchema(s) ? zodToWireSchema(s) : s);
-			const paramSchema = wire(tool?.parameters);
-			const inputSchema = wire(tool?.inputSchema);
+			const tool = isRecord(raw) ? raw : {};
+			const wire = (s: unknown): { properties?: Record<string, unknown>; required?: unknown } | undefined => {
+				const resolved = isZodSchema(s) ? zodToWireSchema(s) : s;
+				return isRecord(resolved)
+					? (resolved as { properties?: Record<string, unknown>; required?: unknown })
+					: undefined;
+			};
+			const paramSchema = wire(tool.parameters);
+			const inputSchema = wire(tool.inputSchema);
 			const params = paramSchema?.properties || inputSchema?.properties || {};
 
 			if (Object.keys(params).length === 0) {
 				lines.push(theme.fg("dim", "  (no arguments)"));
 			} else {
-				const required = new Set(paramSchema?.required || inputSchema?.required || []);
+				const requiredList = paramSchema?.required ?? inputSchema?.required;
+				const required = new Set<string>(
+					Array.isArray(requiredList) ? requiredList.filter((r): r is string => typeof r === "string") : [],
+				);
 
 				for (const [name, spec] of Object.entries(params)) {
-					const param = spec as any;
-					const type = param.type || "any";
+					const param = isRecord(spec) ? spec : {};
+					const type = typeof param.type === "string" ? param.type : "any";
 					const isRequired = required.has(name);
-					const defaultVal = param.default !== undefined ? `Default: ${param.default}` : null;
+					const defaultVal = param.default !== undefined ? `Default: ${String(param.default)}` : null;
 
 					const nameCol = theme.fg("accent", name.padEnd(12));
 					const typeCol = theme.fg("muted", type.padEnd(10));
@@ -210,8 +219,9 @@ export class InspectorPanel implements Component {
 		lines.push(theme.fg("dim", theme.boxRound.horizontal.repeat(Math.min(width - 2, 40))));
 
 		try {
-			const skill = raw as any;
-			const instruction = skill?.prompt || skill?.instruction || skill?.content || "";
+			const skill = isRecord(raw) ? raw : {};
+			const pickText = (v: unknown): string | undefined => (typeof v === "string" && v.length > 0 ? v : undefined);
+			const instruction = pickText(skill.prompt) ?? pickText(skill.instruction) ?? pickText(skill.content) ?? "";
 
 			if (!instruction) {
 				lines.push(theme.fg("dim", "  (no instruction text)"));
@@ -239,10 +249,11 @@ export class InspectorPanel implements Component {
 		lines.push(theme.fg("dim", theme.boxRound.horizontal.repeat(Math.min(width - 2, 40))));
 
 		try {
-			const mcp = raw as any;
-			const transport = mcp?.transport || mcp?.type || "unknown";
-			const command = mcp?.command || mcp?.cmd || "";
-			const args = mcp?.args || mcp?.arguments || [];
+			const mcp = isRecord(raw) ? raw : {};
+			const asStr = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+			const transport = asStr(mcp.transport) || asStr(mcp.type) || "unknown";
+			const command = asStr(mcp.command) || asStr(mcp.cmd) || "";
+			const args = Array.isArray(mcp.args) ? mcp.args : Array.isArray(mcp.arguments) ? mcp.arguments : [];
 
 			lines.push(`  ${theme.fg("muted", "Transport:")}  ${theme.fg("accent", transport)}`);
 
@@ -255,7 +266,7 @@ export class InspectorPanel implements Component {
 			}
 
 			// Environment variables if present
-			if (mcp?.env && typeof mcp.env === "object") {
+			if (isRecord(mcp.env)) {
 				const envCount = Object.keys(mcp.env).length;
 				if (envCount > 0) {
 					lines.push(`  ${theme.fg("muted", "Env vars:")}   ${theme.fg("dim", `${envCount} defined`)}`);
@@ -284,7 +295,7 @@ export class InspectorPanel implements Component {
 	}
 
 	#getKindBadge(kind: string): string {
-		const kindColors: Record<string, string> = {
+		const kindColors: Record<string, ThemeColor> = {
 			"extension-module": "accent",
 			skill: "accent",
 			rule: "success",
@@ -298,7 +309,7 @@ export class InspectorPanel implements Component {
 		};
 
 		const color = kindColors[kind] || "muted";
-		return theme.fg(color as any, kind);
+		return theme.fg(color, kind);
 	}
 
 	#getStatusBadge(state: ExtensionState, reason?: string, shadowedBy?: string): string {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -198,8 +198,8 @@ interface ContextUsageMemo {
 	usedTokens: number;
 	contextWindow: number;
 	systemPromptRef: readonly string[] | undefined;
-	toolsRef: readonly any[] | undefined;
-	skillsRef: readonly any[] | undefined;
+	toolsRef: readonly unknown[] | undefined;
+	skillsRef: readonly unknown[] | undefined;
 }
 
 interface ActiveRepoCache {

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -185,10 +185,12 @@ class SafeToolRendererComponent implements Component {
 		invalidate.call(this.#component);
 	}
 
-	setIgnoreTight(ignore: boolean): void {
+	setIgnoreTight(ignore: boolean): this {
 		const setIgnoreTight = this.#component.setIgnoreTight;
-		if (setIgnoreTight === undefined) return;
-		setIgnoreTight.call(this.#component, ignore);
+		if (setIgnoreTight !== undefined) {
+			setIgnoreTight.call(this.#component, ignore);
+		}
+		return this;
 	}
 
 	dispose(): void {

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -14,7 +14,7 @@ import {
 	Text,
 	type TUI,
 } from "@oh-my-pi/pi-tui";
-import { getProjectDir, logger, sanitizeText } from "@oh-my-pi/pi-utils";
+import { getProjectDir, isRecord, logger, sanitizeText } from "@oh-my-pi/pi-utils";
 import { EDIT_MODE_STRATEGIES, type EditMode, type PerFileDiffPreview } from "../../edit";
 import type { Theme } from "../../modes/theme/theme";
 import { getThemeEpoch, theme } from "../../modes/theme/theme";
@@ -234,11 +234,11 @@ export interface ToolExecutionOptions {
 }
 
 export interface ToolExecutionHandle extends Component {
-	updateArgs(args: any, toolCallId?: string): void;
+	updateArgs(args: unknown, toolCallId?: string): void;
 	updateResult(
 		result: {
 			content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
-			details?: any;
+			details?: unknown;
 			isError?: boolean;
 		},
 		isPartial?: boolean,
@@ -286,7 +286,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	readonly #instanceId = ++toolExecutionInstanceSeq;
 	#toolName: string;
 	#toolLabel: string;
-	#args: any;
+	#args: unknown;
 	#expanded = false;
 	#toolActivityVisible = true;
 	#showImages: boolean;
@@ -317,7 +317,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	#result?: {
 		content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
 		isError?: boolean;
-		details?: any;
+		details?: unknown;
 	};
 	// Edit preview state
 	#editMode?: EditMode;
@@ -388,7 +388,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 
 	constructor(
 		toolName: string,
-		args: any,
+		args: unknown,
 		options: ToolExecutionOptions = {},
 		tool: AgentTool | undefined,
 		ui: ToolExecutionUi,
@@ -436,7 +436,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#schedulePreviewDiff();
 	}
 
-	updateArgs(args: any, _toolCallId?: string): void {
+	updateArgs(args: unknown, _toolCallId?: string): void {
 		// Reference-equality short-circuit before any further work. Callers
 		// always allocate a new arg object on each streamed delta (see
 		// event-controller.ts and ui-helpers.ts), so a same-reference assignment
@@ -568,7 +568,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	updateResult(
 		result: {
 			content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
-			details?: any;
+			details?: unknown;
 			isError?: boolean;
 		},
 		isPartial = false,
@@ -619,8 +619,11 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	 */
 	#getAllImageBlocks(): Array<{ data?: string; mimeType?: string }> {
 		if (!this.#result) return [];
-		const contentImages = this.#result.content?.filter((c: any) => c.type === "image") || [];
-		const detailImages = this.#result.details?.images || [];
+		const contentImages = this.#result.content?.filter(c => c.type === "image") || [];
+		const detailImages =
+			isRecord(this.#result.details) && Array.isArray(this.#result.details.images)
+				? (this.#result.details.images as Array<{ data?: string; mimeType?: string }>)
+				: [];
 		return [...contentImages, ...detailImages];
 	}
 
@@ -1064,7 +1067,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 					) => Component;
 					const resultComponent = renderResult(
 						{
-							content: this.#result.content as any,
+							content: this.#result.content,
 							details: this.#result.details,
 							isError: this.#result.isError,
 						},
@@ -1112,7 +1115,8 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 			this.#multiFileBoxes = [];
 
 			// Check for multi-file edit results
-			const perFileResults = this.#result?.details?.perFileResults as
+			const resultDetails = this.#result?.details;
+			const perFileResults = (isRecord(resultDetails) ? resultDetails.perFileResults : undefined) as
 				| Array<{ path: string; isError?: boolean }>
 				| undefined;
 			if (perFileResults && perFileResults.length > 1) {
@@ -1150,8 +1154,13 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 				}
 
 				// Show pending indicator for remaining files
-				const totalFiles = this.#args?.edits
-					? new Set((this.#args.edits as any[]).map((e: any) => e?.path).filter(Boolean)).size
+				const editsList = isRecord(this.#args) && Array.isArray(this.#args.edits) ? this.#args.edits : undefined;
+				const totalFiles = editsList
+					? new Set(
+							editsList
+								.map(e => (isRecord(e) && typeof e.path === "string" ? e.path : undefined))
+								.filter((p): p is string => Boolean(p)),
+						).size
 					: 0;
 				const remaining = Math.max(0, totalFiles - perFileResults.length);
 				if (remaining > 0 && this.#isPartial) {
@@ -1210,7 +1219,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 					try {
 						const resultComponent = renderer.renderResult(
 							{
-								content: this.#result.content as any,
+								content: this.#result.content,
 								details: this.#result.details,
 								isError: this.#result.isError,
 							},
@@ -1288,7 +1297,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#renderedImageCount = this.#imageComponents.length;
 	}
 
-	#getCallArgsForRender(): any {
+	#getCallArgsForRender(): unknown {
 		const renderArgs = getArgsWithStreamedTextInput(this.#args);
 		if (!isEditLikeToolName(this.#toolName)) {
 			return renderArgs;
@@ -1326,7 +1335,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 			}
 			context.expanded = this.#expanded;
 			context.previewLines = BASH_DEFAULT_PREVIEW_LINES;
-			context.timeout = normalizeTimeoutSeconds(this.#args?.timeout, 3600);
+			context.timeout = normalizeTimeoutSeconds(isRecord(this.#args) ? this.#args.timeout : undefined, 3600);
 		} else if (this.#toolName === "eval" && this.#result) {
 			const output = this.#getTextOutput().trimEnd();
 			context.output = output;
@@ -1385,20 +1394,21 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	#getTextOutput(): string {
 		if (!this.#result) return "";
 
-		const textBlocks = this.#result.content?.filter((c: any) => c.type === "text") || [];
+		const textBlocks = this.#result.content?.filter(c => c.type === "text") || [];
 		const imageBlocks = this.#getAllImageBlocks();
 
 		let output = textBlocks
-			.map((c: any) => {
+			.map(c => {
 				return sanitizeWithOptionalSixelPassthrough(c.text || "", sanitizeText);
 			})
 			.join("\n");
 
 		if (imageBlocks.length > 0 && (!TERMINAL.imageProtocol || !this.#showImages)) {
 			const imageIndicators = imageBlocks
-				.map((img: any) => {
-					const dims = img.data ? (getImageDimensions(img.data, img.mimeType) ?? undefined) : undefined;
-					return imageFallback(img.mimeType, dims);
+				.map(img => {
+					const dims =
+						img.data && img.mimeType ? (getImageDimensions(img.data, img.mimeType) ?? undefined) : undefined;
+					return imageFallback(img.mimeType ?? "", dims);
 				})
 				.join("\n");
 			output = output ? `${output}\n${imageIndicators}` : imageIndicators;

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -2,7 +2,7 @@ import type { AssistantMessage, ImageContent } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { getStreamingPartialJson } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { type Component, Loader, TERMINAL } from "@oh-my-pi/pi-tui";
-import { logger, prompt, sanitizeText } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, prompt, sanitizeText } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import { extractTextContent } from "../../commit/utils";
 import { settings } from "../../config/settings";
@@ -1151,7 +1151,7 @@ export class EventController {
 					component.updateArgs(event.args, event.toolCallId);
 				} else {
 					const group = this.#getReadGroup();
-					group.updateArgs(event.args, event.toolCallId);
+					group.updateArgs(isRecord(event.args) ? event.args : {}, event.toolCallId);
 					this.ctx.pendingTools.set(event.toolCallId, group);
 					this.#toolTimelineComponents.set(event.toolCallId, group);
 				}
@@ -1411,9 +1411,8 @@ export class EventController {
 				this.ctx.setTodos(details.phases);
 			}
 		} else if (event.toolName === "todo" && event.isError) {
-			const textContent = event.result.content.find(
-				(content: { type: string; text?: string }) => content.type === "text",
-			)?.text;
+			const textBlock = event.result.content.find(content => content.type === "text");
+			const textContent = textBlock && "text" in textBlock ? textBlock.text : undefined;
 			// This text can be a provider error copied verbatim off the wire (the
 			// Cursor todo bridge forwards the server's string), so it may carry
 			// ANSI escapes, other C0/C1 controls, tabs, newlines, or a line far

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -897,7 +897,7 @@ function createCustomToolContext(ctx: ExtensionContext): CustomToolContext {
 function isCustomTool(tool: CustomTool | ToolDefinition): tool is CustomTool {
 	// To distinguish, we mark converted tools with a hidden symbol property.
 	// If the tool doesn't have this marker, it's a CustomTool that needs conversion.
-	return !(tool as any).__isToolDefinition;
+	return !(tool as { __isToolDefinition?: unknown }).__isToolDefinition;
 }
 
 function isLegacyBuiltinToolDefinition(tool: CustomTool | ToolDefinition): boolean {

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -3,6 +3,7 @@ import {
 	type AgentMessage,
 	type AgentTool,
 	type AgentToolContext,
+	type AnyAgentTool,
 	AppendOnlyContextManager,
 	type CompactionSummaryMessage,
 	countTokens,
@@ -700,8 +701,8 @@ export class SessionAdvisors {
 
 			const names = config.tools === undefined ? ADVISOR_DEFAULT_TOOL_NAMES : new Set(config.tools);
 			const tools = (this.#advisorTools ?? []).filter(t => names.has(t.name));
-			const advisorLoopTools: AgentTool<any>[] = [adviseTool, ...tools];
-			const advisorToolMap = new Map<string, AgentTool<any>>();
+			const advisorLoopTools: AnyAgentTool[] = [adviseTool, ...tools];
+			const advisorToolMap = new Map<string, AnyAgentTool>();
 			const availableAdvisorToolNames = new Set<string>();
 			for (const tool of advisorLoopTools) {
 				availableAdvisorToolNames.add(tool.name);

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -16,6 +16,7 @@
 import path from "node:path";
 import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { Usage } from "@oh-my-pi/pi-ai";
+import type { Component } from "@oh-my-pi/pi-tui";
 import { $env, logger, prompt } from "@oh-my-pi/pi-utils";
 import type { ToolSession } from "..";
 import type { Theme } from "../modes/theme/theme";
@@ -48,7 +49,7 @@ import { type DiscoveryResult, discoverAgents } from "./discovery";
 import { generateTaskName } from "./name-generator";
 import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimitAllSettled, Semaphore } from "./parallel";
-import { renderCall as renderTaskCall, renderResult as renderTaskResult } from "./render";
+import { renderCall as renderTaskCall, renderResult as renderTaskResult, type TaskRenderOptions } from "./render";
 import { repairTaskParams } from "./repair-args";
 import { resolveEffectiveSubagentPolicy, runStructuredSubagent, StructuredSubagentError } from "./structured-subagent";
 
@@ -575,10 +576,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	readonly lenientArgValidation = true;
 	renderResult(
 		result: AgentToolResult<TaskToolDetails>,
-		options: Parameters<typeof renderTaskResult>[1],
-		theme: Parameters<typeof renderTaskResult>[2],
-		args?: Parameters<typeof renderTaskResult>[3],
-	): ReturnType<typeof renderTaskResult> {
+		options: TaskRenderOptions,
+		theme: Theme,
+		args?: TaskParams,
+	): Component {
 		return renderTaskResult(result, options, theme, args);
 	}
 	// Suppress the streaming call preview once a (partial or final) result exists

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -48,7 +48,7 @@ import { type DiscoveryResult, discoverAgents } from "./discovery";
 import { generateTaskName } from "./name-generator";
 import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimitAllSettled, Semaphore } from "./parallel";
-import { renderResult, renderCall as renderTaskCall } from "./render";
+import { renderCall as renderTaskCall, renderResult as renderTaskResult } from "./render";
 import { repairTaskParams } from "./repair-args";
 import { resolveEffectiveSubagentPolicy, runStructuredSubagent, StructuredSubagentError } from "./structured-subagent";
 
@@ -573,7 +573,14 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	// calls still normalize through arktype; `execute()` resolves `agent`
 	// defaults independently, so the success path is unchanged.
 	readonly lenientArgValidation = true;
-	readonly renderResult = renderResult;
+	renderResult(
+		result: AgentToolResult<TaskToolDetails>,
+		options: Parameters<typeof renderTaskResult>[1],
+		theme: Parameters<typeof renderTaskResult>[2],
+		args?: Parameters<typeof renderTaskResult>[3],
+	): ReturnType<typeof renderTaskResult> {
+		return renderTaskResult(result, options, theme, args);
+	}
 	// Suppress the streaming call preview once a (partial or final) result exists
 	// so the task renders as ONE block that transitions in place — not a pending
 	// call frame stacked above the result frame. Mirrors `taskToolRenderer`.

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -57,7 +57,7 @@ interface TaskRenderContext {
 	 */
 	nowMs?: number;
 }
-type TaskRenderOptions = RenderResultOptions & { renderContext?: TaskRenderContext };
+export type TaskRenderOptions = RenderResultOptions & { renderContext?: TaskRenderContext };
 
 const MAX_NESTED_TASK_RENDER_DEPTH = 8;
 

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -1,5 +1,5 @@
 import type { Clipboard, InMemorySnapshotStore } from "@oh-my-pi/hashline";
-import type { AgentOptions, AgentTelemetryConfig, AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { AgentOptions, AgentTelemetryConfig, AgentTool, AnyAgentTool } from "@oh-my-pi/pi-agent-core";
 import type { FetchImpl, ImageContent, Model, ServiceTierByFamily, ToolChoice } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { AsyncJobManager } from "../async/job-manager";
@@ -110,7 +110,7 @@ export * from "./xdev";
 export * from "./yield";
 
 /** Tool type (AgentTool from pi-ai) */
-export type Tool = AgentTool<any, any, any>;
+export type Tool = AnyAgentTool;
 
 export type ContextFileEntry = {
 	path: string;

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -10,9 +10,10 @@ import type {
 	AgentToolExecFn,
 	AgentToolResult,
 	AgentToolUpdateCallback,
+	AnyAgentTool,
 } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
-import { logger } from "@oh-my-pi/pi-utils";
+import { isRecord, logger } from "@oh-my-pi/pi-utils";
 import { getDefault, type Settings } from "../config/settings";
 import { formatGroupedDiagnosticMessages } from "../lsp/utils";
 import type { Theme } from "../modes/theme/theme";
@@ -680,7 +681,7 @@ async function spillLargeResultToArtifact(
 	const { threshold, tailBytes, tailLines, headBytes } = getSpillConfig(context?.settings);
 
 	// Skip if tool already saved an artifact
-	const existingMeta: OutputMeta | undefined = result.details?.meta;
+	const existingMeta = (isRecord(result.details) ? result.details.meta : undefined) as OutputMeta | undefined;
 	if (existingMeta?.truncation?.artifactId) return result;
 
 	// Reading an artifact already addresses recoverable full output. Spilling that
@@ -804,7 +805,7 @@ async function spillLargeResultToArtifact(
 async function wrappedExecute(
 	this: AgentTool & { [kUnwrappedExecute]: AgentToolExecFn },
 	toolCallId: string,
-	params: any,
+	params: unknown,
 	signal?: AbortSignal,
 	onUpdate?: AgentToolUpdateCallback,
 	context?: AgentToolContext,
@@ -818,7 +819,7 @@ async function wrappedExecute(
 		result = await spillLargeResultToArtifact(result, this.name, context);
 
 		// Append notices from meta
-		const meta: OutputMeta | undefined = result.details?.meta;
+		const meta = (isRecord(result.details) ? result.details.meta : undefined) as OutputMeta | undefined;
 		if (meta) {
 			return {
 				...result,
@@ -837,7 +838,7 @@ async function wrappedExecute(
  * 1. Automatically append output notices based on details.meta
  * 2. Handle ToolError rendering
  */
-export function wrapToolWithMetaNotice<T extends AgentTool<any, any, any>>(tool: T): T {
+export function wrapToolWithMetaNotice<T extends AnyAgentTool>(tool: T): T {
 	if (kUnwrappedExecute in tool) {
 		return tool;
 	}

--- a/packages/coding-agent/src/web/scrapers/reddit.ts
+++ b/packages/coding-agent/src/web/scrapers/reddit.ts
@@ -21,6 +21,17 @@ interface RedditComment {
 	replies?: { data: { children: Array<{ data: RedditComment }> } };
 }
 
+/** Loosely-typed shape of the Reddit JSON API: a listing (subreddit page) or an
+ *  array of listings (post page: `[post, comments]`). Leaf `data` payloads are
+ *  narrowed to {@link RedditPost}/{@link RedditComment} at each use site. */
+interface RedditChild {
+	kind?: string;
+	data?: unknown;
+}
+interface RedditListing {
+	data?: { children?: RedditChild[] };
+}
+
 /**
  * Handle Reddit URLs via JSON API
  */
@@ -44,7 +55,7 @@ export const handleReddit: SpecialHandler = async (
 		const result = await loadPage(jsonUrl, { timeout, signal });
 		if (!result.ok) return null;
 
-		const data = tryParseJson<any>(result.content);
+		const data = tryParseJson<RedditListing | RedditListing[]>(result.content);
 		if (!data) return null;
 		let md = "";
 
@@ -64,9 +75,10 @@ export const handleReddit: SpecialHandler = async (
 				}
 
 				// Add comments if available
-				if (data.length >= 2 && data[1]?.data?.children) {
+				const commentChildren = data.length >= 2 ? data[1]?.data?.children : undefined;
+				if (commentChildren) {
 					md += `---\n\n## Top Comments\n\n`;
-					const comments = data[1].data.children.filter((c: { kind: string }) => c.kind === "t1").slice(0, 10);
+					const comments = commentChildren.filter(c => c.kind === "t1").slice(0, 10);
 
 					for (const { data: comment } of comments as Array<{ data: RedditComment }>) {
 						md += `### u/${comment.author} · ${comment.score} points\n\n`;
@@ -74,7 +86,7 @@ export const handleReddit: SpecialHandler = async (
 					}
 				}
 			}
-		} else if (data?.data?.children) {
+		} else if (!Array.isArray(data) && data.data?.children) {
 			// Subreddit or listing page
 			const posts = data.data.children.slice(0, 20) as Array<{ data: RedditPost }>;
 			const subreddit = posts[0]?.data?.subreddit;

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -384,7 +384,7 @@ export const webSearchCustomTool: CustomTool<typeof webSearchSchema, SearchRende
 	},
 };
 
-export function getSearchTools(): CustomTool<any, any>[] {
+export function getSearchTools(): CustomTool[] {
 	return [webSearchCustomTool];
 }
 

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -18,7 +18,7 @@ import {
 	zPromptResponse,
 	zSessionNotification,
 } from "@agentclientprotocol/sdk/dist/schema/zod.gen.js";
-import type { Model } from "@oh-my-pi/pi-ai";
+import type { Model, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
@@ -1484,6 +1484,78 @@ describe("ACP agent", () => {
 			}),
 		);
 
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("replays failed tool-result errorMessage as ACP tool_call_update content", async () => {
+		const harness = await createHarness();
+		const stored = new FakeAgentSession(harness.cwdA);
+		harness.sessions.push(stored);
+		stored.sessionManager.appendMessage({ role: "user", content: "run failing tool", timestamp: Date.now() });
+		stored.sessionManager.appendMessage({
+			role: "assistant",
+			content: [
+				{
+					type: "toolCall",
+					id: "toolu_err_replay",
+					name: "bash",
+					arguments: { command: "exit 1" },
+				},
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: TEST_MODELS[0].id,
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		});
+		const failedResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "toolu_err_replay",
+			toolName: "bash",
+			content: [],
+			isError: true,
+			timestamp: Date.now(),
+		};
+		stored.sessionManager.appendMessage(
+			Object.assign(failedResult, { errorMessage: "Command failed with exit code 1" }),
+		);
+		await stored.sessionManager.ensureOnDisk();
+		await stored.sessionManager.flush();
+
+		await harness.agent.loadSession({
+			sessionId: stored.sessionId,
+			cwd: harness.cwdA,
+			mcpServers: [],
+		});
+
+		const completions = harness.updates
+			.filter(update => update.sessionId === stored.sessionId)
+			.map(notification => notification.update)
+			.filter(
+				update =>
+					"toolCallId" in update &&
+					update.toolCallId === "toolu_err_replay" &&
+					update.sessionUpdate === "tool_call_update" &&
+					update.status === "failed",
+			);
+
+		expect(completions).toHaveLength(1);
+		expect(completions[0]).toEqual(
+			expect.objectContaining({
+				content: expect.arrayContaining([
+					{ type: "content", content: { type: "text", text: "Command failed with exit code 1" } },
+				]),
+			}),
+		);
 		harness.abortController.abort();
 		await Bun.sleep(0);
 	});

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -8,6 +8,7 @@ import type {
 	CreateElicitationRequest,
 	CreateElicitationResponse,
 	PromptRequest,
+	SessionConfigSelectOption,
 	SessionNotification,
 } from "@agentclientprotocol/sdk";
 import {
@@ -535,9 +536,9 @@ describe("ACP agent", () => {
 
 		const modelOption = first.configOptions?.find(opt => opt.id === "model");
 		expect(modelOption?.type).toBe("select");
-		expect((modelOption as any).options?.map((opt: any) => opt.value)).toEqual(
-			TEST_MODELS.map(model => `${model.provider}/${model.id}`),
-		);
+		if (modelOption?.type !== "select") throw new Error("expected a select model config option");
+		const modelOptionValues = (modelOption.options as SessionConfigSelectOption[]).map(opt => opt.value);
+		expect(modelOptionValues).toEqual(TEST_MODELS.map(model => `${model.provider}/${model.id}`));
 
 		await harness.agent.setSessionConfigOption({
 			sessionId: first.sessionId,

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1560,6 +1560,84 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("replays stored tool-result string content as ACP tool_call_update text", async () => {
+		const harness = await createHarness();
+		const stored = new FakeAgentSession(harness.cwdA);
+		harness.sessions.push(stored);
+		stored.sessionManager.appendMessage({ role: "user", content: "probe legacy result", timestamp: Date.now() });
+		stored.sessionManager.appendMessage({
+			role: "assistant",
+			content: [
+				{
+					type: "toolCall",
+					id: "toolu_string_content_replay",
+					name: "custom_probe",
+					arguments: { target: "legacy" },
+				},
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: TEST_MODELS[0].id,
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		});
+		// Legacy/imported producers may store a tool result's readable output as
+		// a plain string instead of a content-block array. The JSONL loader
+		// rehydrates entries verbatim (`ReplayableMessage.content` is `unknown`),
+		// so rehydrate the fixture through JSON exactly as the loader does; the
+		// replay path must normalize the string instead of dropping the only
+		// result description.
+		const legacyStringResult = JSON.parse(
+			JSON.stringify({
+				role: "toolResult",
+				toolCallId: "toolu_string_content_replay",
+				toolName: "custom_probe",
+				content: "all probes passed",
+				isError: false,
+				timestamp: Date.now(),
+			}),
+		);
+		stored.sessionManager.appendMessage(legacyStringResult);
+		await stored.sessionManager.ensureOnDisk();
+		await stored.sessionManager.flush();
+
+		await harness.agent.loadSession({
+			sessionId: stored.sessionId,
+			cwd: harness.cwdA,
+			mcpServers: [],
+		});
+
+		const completions = harness.updates
+			.filter(update => update.sessionId === stored.sessionId)
+			.map(notification => notification.update)
+			.filter(
+				update =>
+					"toolCallId" in update &&
+					update.toolCallId === "toolu_string_content_replay" &&
+					update.sessionUpdate === "tool_call_update" &&
+					update.status === "completed",
+			);
+
+		expect(completions).toHaveLength(1);
+		expect(completions[0]).toEqual(
+			expect.objectContaining({
+				content: expect.arrayContaining([
+					{ type: "content", content: { type: "text", text: "all probes passed" } },
+				]),
+			}),
+		);
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("does not replay silent-abort marker as agent_message_chunk to ACP clients", async () => {
 		const harness = await createHarness();
 		const stored = new FakeAgentSession(harness.cwdA);

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -13,6 +13,7 @@ const arkSessionNotification = type({
 	},
 });
 
+import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { AcpAgent } from "@oh-my-pi/pi-coding-agent/modes/acp/acp-agent";
@@ -603,7 +604,7 @@ describe("ACP event mapper", () => {
 				toolCallId: "tc-3",
 				toolName: "bash",
 				args: { command: "npm run check" },
-				partialResult: { details: { terminalId: "term-1" } },
+				partialResult: { content: [], details: { terminalId: "term-1" } },
 			} as AgentSessionEvent,
 			"session-1",
 		);
@@ -740,7 +741,11 @@ describe("ACP event mapper", () => {
 				toolCallId: "tc-terminal-error",
 				toolName: "bash",
 				isError: true,
-				result: { errorMessage: "command failed", details: { terminalId: "term-1" } },
+				result: {
+					content: [],
+					errorMessage: "command failed",
+					details: { terminalId: "term-1" },
+				} as AgentToolResult,
 			} as AgentSessionEvent,
 			"session-1",
 		);
@@ -750,7 +755,11 @@ describe("ACP event mapper", () => {
 				toolCallId: "tc-terminal-message",
 				toolName: "bash",
 				isError: false,
-				result: { message: "command completed", details: { terminalId: "term-1" } },
+				result: {
+					content: [],
+					message: "command completed",
+					details: { terminalId: "term-1" },
+				} as AgentToolResult,
 			} as AgentSessionEvent,
 			"session-1",
 		);
@@ -784,7 +793,7 @@ describe("ACP event mapper", () => {
 				toolCallId: "tc-plain-output",
 				toolName: "bash",
 				isError: false,
-				result: "hello from stdout",
+				result: { content: [{ type: "text", text: "hello from stdout" }] },
 			} as AgentSessionEvent,
 			"session-1",
 		);
@@ -805,7 +814,7 @@ describe("ACP event mapper", () => {
 				toolCallId: "tc-direct-terminal",
 				toolName: "bash",
 				isError: false,
-				result: { terminalId: "term-1" },
+				result: { content: [], terminalId: "term-1" } as AgentToolResult,
 			} as AgentSessionEvent,
 			"session-1",
 		);
@@ -826,9 +835,10 @@ describe("ACP event mapper", () => {
 				toolName: "bash",
 				isError: false,
 				result: {
-					content: [{ type: "terminal", terminalId: "term-1" }],
+					content: [],
+					terminalId: "term-1",
 					details: { terminalId: "term-1" },
-				},
+				} as AgentToolResult,
 			} as AgentSessionEvent,
 			"session-1",
 		);

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -453,7 +453,7 @@ describe("advisor", () => {
 			const valid = tool.parameters({ note: "x", severity: "concern" });
 			expect(valid instanceof type.errors).toBe(false);
 
-			const invalid = tool.parameters({ note: 123, severity: "invalid" as any });
+			const invalid = tool.parameters({ note: 123, severity: "invalid" });
 			expect(invalid instanceof type.errors).toBe(true);
 		});
 	});

--- a/packages/coding-agent/test/agent-session-fresh.test.ts
+++ b/packages/coding-agent/test/agent-session-fresh.test.ts
@@ -66,7 +66,7 @@ describe("AgentSession fresh provider state", () => {
 
 		const appendOnlyContext = new AppendOnlyContextManager();
 		agent.setAppendOnlyContext(appendOnlyContext);
-		appendOnlyContext.syncMessages([{ role: "user", content: "cached context" }]);
+		appendOnlyContext.syncMessages([{ role: "user", content: "cached context", timestamp: Date.now() }]);
 		appendOnlyContext.build({ systemPrompt: ["Test"], messages: [], tools: [] }, { intentTracing: false });
 
 		const result = session.freshSession();

--- a/packages/coding-agent/test/agent-session-python-cleanup.test.ts
+++ b/packages/coding-agent/test/agent-session-python-cleanup.test.ts
@@ -150,6 +150,10 @@ const createMockKernel = () => {
 	};
 };
 
+function toolResultDetailsIsError(details: unknown): boolean {
+	return typeof details === "object" && details !== null && "isError" in details && details.isError === true;
+}
+
 describe("AgentSession python cleanup", () => {
 	const tempDirs: TempDir[] = [];
 	let originalNullPrompt: string | undefined;
@@ -445,7 +449,7 @@ describe("AgentSession python cleanup", () => {
 		expect(disposed).toBe(true);
 		expect(toolExecutionSettled).toBe(true);
 		expect(executeSpy).toHaveBeenCalledTimes(1);
-		expect(toolResult.details?.isError).toBe(true);
+		expect(toolResultDetailsIsError(toolResult.details)).toBe(true);
 		expect(toolResult.content).toContainEqual(
 			expect.objectContaining({ type: "text", text: expect.stringContaining("Command aborted") }),
 		);

--- a/packages/coding-agent/test/autolearn-controller.test.ts
+++ b/packages/coding-agent/test/autolearn-controller.test.ts
@@ -46,7 +46,7 @@ class FakeSession {
 
 	toolCalls(n: number): void {
 		for (let i = 0; i < n; i++) {
-			this.emit({ type: "tool_execution_end", toolCallId: `t${i}`, toolName: "read", result: null });
+			this.emit({ type: "tool_execution_end", toolCallId: `t${i}`, toolName: "read", result: { content: [] } });
 		}
 	}
 

--- a/packages/coding-agent/test/commit-split-hunk-validation.test.ts
+++ b/packages/coding-agent/test/commit-split-hunk-validation.test.ts
@@ -23,6 +23,13 @@ index 3333333..4444444 100644
  }
 `;
 
+function splitCommitDetails(details: unknown): { valid: unknown; errors: unknown } {
+	if (typeof details !== "object" || details === null || !("valid" in details) || !("errors" in details)) {
+		throw new Error("split_commit result details missing valid/errors");
+	}
+	return { valid: details.valid, errors: details.errors };
+}
+
 describe("split_commit hunk selector validation", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
@@ -57,8 +64,8 @@ describe("split_commit hunk selector validation", () => {
 			{} as never,
 		);
 
-		expect(result.details.valid).toBe(false);
-		expect(result.details.errors).toContain("Commit 1: No hunks selected for src/a.ts");
+		expect(splitCommitDetails(result.details).valid).toBe(false);
+		expect(splitCommitDetails(result.details).errors).toContain("Commit 1: No hunks selected for src/a.ts");
 		expect(state.splitProposal).toBeUndefined();
 	});
 
@@ -91,8 +98,8 @@ describe("split_commit hunk selector validation", () => {
 			{} as never,
 		);
 
-		expect(result.details.valid).toBe(false);
-		expect(result.details.errors).toContain("Commit 1: No hunks selected for src/a.ts");
+		expect(splitCommitDetails(result.details).valid).toBe(false);
+		expect(splitCommitDetails(result.details).errors).toContain("Commit 1: No hunks selected for src/a.ts");
 		expect(state.splitProposal).toBeUndefined();
 	});
 
@@ -123,8 +130,10 @@ describe("split_commit hunk selector validation", () => {
 			{} as never,
 		);
 
-		expect(result.details.valid).toBe(true);
-		expect(result.details.errors).not.toContain("Commit 1: No diff found for packages/coding-agent/CHANGELOG.md");
+		expect(splitCommitDetails(result.details).valid).toBe(true);
+		expect(splitCommitDetails(result.details).errors).not.toContain(
+			"Commit 1: No diff found for packages/coding-agent/CHANGELOG.md",
+		);
 		expect(state.splitProposal?.commits[0]?.changes.map(change => change.path)).toContain(
 			"packages/coding-agent/CHANGELOG.md",
 		);

--- a/packages/coding-agent/test/compaction-hooks.test.ts
+++ b/packages/coding-agent/test/compaction-hooks.test.ts
@@ -10,25 +10,26 @@ import { Agent } from "@oh-my-pi/pi-agent-core";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import {
-	HookRunner,
-	type LoadedHook,
-	type SessionBeforeCompactEvent,
-	type SessionCompactEvent,
-	type SessionEvent,
+import type { ExtensionFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
+import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import type {
+	SessionBeforeCompactEvent,
+	SessionBeforeCompactResult,
+	SessionCompactEvent,
+	SessionEvent,
 } from "@oh-my-pi/pi-coding-agent/extensibility/hooks";
-import { theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { createTools, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 import { e2eApiKey } from "./utilities";
 
 describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))("Compaction hooks", () => {
 	let session: AgentSession;
 	let tempDir: string;
-	let hookRunner: HookRunner;
 	let capturedEvents: SessionEvent[];
 
 	beforeEach(() => {
@@ -47,43 +48,22 @@ describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))("Compaction hooks", () => {
 	});
 
 	function createHook(
-		onBeforeCompact?: (event: SessionBeforeCompactEvent) => { cancel?: boolean; compaction?: any } | undefined,
+		onBeforeCompact?: (event: SessionBeforeCompactEvent) => SessionBeforeCompactResult | undefined,
 		onCompact?: (event: SessionCompactEvent) => void,
-	): LoadedHook {
-		const handlers = new Map<string, ((event: any, ctx: any) => Promise<any>)[]>();
-
-		handlers.set("session_before_compact", [
-			async (event: SessionBeforeCompactEvent) => {
+	): ExtensionFactory {
+		return pi => {
+			pi.on("session_before_compact", event => {
 				capturedEvents.push(event);
-				if (onBeforeCompact) {
-					return onBeforeCompact(event);
-				}
-				return undefined;
-			},
-		]);
-
-		handlers.set("session_compact", [
-			async (event: SessionCompactEvent) => {
+				return onBeforeCompact?.(event);
+			});
+			pi.on("session_compact", event => {
 				capturedEvents.push(event);
-				if (onCompact) {
-					onCompact(event);
-				}
-				return undefined;
-			},
-		]);
-
-		return {
-			path: "test-hook",
-			resolvedPath: "/test/test-hook.ts",
-			handlers,
-			messageRenderers: new Map(),
-			commands: new Map(),
-			setSendMessageHandler: () => {},
-			setAppendEntryHandler: () => {},
+				onCompact?.(event);
+			});
 		};
 	}
 
-	async function createSession(hooks: LoadedHook[]) {
+	async function createSession(extensionFactories: ExtensionFactory[]) {
 		const toolSession: ToolSession = {
 			cwd: tempDir,
 			hasUI: false,
@@ -107,33 +87,20 @@ describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))("Compaction hooks", () => {
 		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
 		const modelRegistry = new ModelRegistry(authStorage);
 
-		hookRunner = new HookRunner(hooks, tempDir, sessionManager, modelRegistry);
-		hookRunner.initialize({
-			getModel: () => session.model,
-			sendMessageHandler: async () => {},
-			appendEntryHandler: async () => {},
-			uiContext: {
-				select: async () => undefined,
-				confirm: async () => false,
-				input: async () => undefined,
-				notify: () => {},
-				setStatus: () => {},
-				custom: async () => undefined as never,
-				setEditorText: () => {},
-				getEditorText: () => "",
-				editor: async () => undefined,
-				get theme() {
-					return theme;
-				},
-			},
-			hasUI: false,
-		});
+		const extensionRuntime = new ExtensionRuntime();
+		const eventBus = new EventBus();
+		const extensions = await Promise.all(
+			extensionFactories.map((factory, index) =>
+				loadExtensionFromFactory(factory, tempDir, eventBus, extensionRuntime, `test-hook-${index}`),
+			),
+		);
+		const extensionRunner = new ExtensionRunner(extensions, extensionRuntime, tempDir, sessionManager, modelRegistry);
 
 		session = new AgentSession({
 			agent,
 			sessionManager,
 			settings,
-			extensionRunner: hookRunner as any,
+			extensionRunner,
 			modelRegistry,
 		});
 
@@ -245,33 +212,14 @@ describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))("Compaction hooks", () => {
 	}, 120000);
 
 	it("should continue with default compaction if hook throws error", async () => {
-		const throwingHook: LoadedHook = {
-			path: "throwing-hook",
-			resolvedPath: "/test/throwing-hook.ts",
-			handlers: new Map<string, ((event: any, ctx: any) => Promise<any>)[]>([
-				[
-					"session_before_compact",
-					[
-						async (event: SessionBeforeCompactEvent) => {
-							capturedEvents.push(event);
-							throw new Error("Hook intentionally throws");
-						},
-					],
-				],
-				[
-					"session_compact",
-					[
-						async (event: SessionCompactEvent) => {
-							capturedEvents.push(event);
-							return undefined;
-						},
-					],
-				],
-			]),
-			messageRenderers: new Map(),
-			commands: new Map(),
-			setSendMessageHandler: () => {},
-			setAppendEntryHandler: () => {},
+		const throwingHook: ExtensionFactory = pi => {
+			pi.on("session_before_compact", event => {
+				capturedEvents.push(event);
+				throw new Error("Hook intentionally throws");
+			});
+			pi.on("session_compact", event => {
+				capturedEvents.push(event);
+			});
 		};
 
 		await createSession([throwingHook]);
@@ -291,62 +239,22 @@ describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))("Compaction hooks", () => {
 	it("should call multiple hooks in order", async () => {
 		const callOrder: string[] = [];
 
-		const hook1: LoadedHook = {
-			path: "hook1",
-			resolvedPath: "/test/hook1.ts",
-			handlers: new Map<string, ((event: any, ctx: any) => Promise<any>)[]>([
-				[
-					"session_before_compact",
-					[
-						async () => {
-							callOrder.push("hook1-before");
-							return undefined;
-						},
-					],
-				],
-				[
-					"session_compact",
-					[
-						async () => {
-							callOrder.push("hook1-after");
-							return undefined;
-						},
-					],
-				],
-			]),
-			messageRenderers: new Map(),
-			commands: new Map(),
-			setSendMessageHandler: () => {},
-			setAppendEntryHandler: () => {},
+		const hook1: ExtensionFactory = pi => {
+			pi.on("session_before_compact", () => {
+				callOrder.push("hook1-before");
+			});
+			pi.on("session_compact", () => {
+				callOrder.push("hook1-after");
+			});
 		};
 
-		const hook2: LoadedHook = {
-			path: "hook2",
-			resolvedPath: "/test/hook2.ts",
-			handlers: new Map<string, ((event: any, ctx: any) => Promise<any>)[]>([
-				[
-					"session_before_compact",
-					[
-						async () => {
-							callOrder.push("hook2-before");
-							return undefined;
-						},
-					],
-				],
-				[
-					"session_compact",
-					[
-						async () => {
-							callOrder.push("hook2-after");
-							return undefined;
-						},
-					],
-				],
-			]),
-			messageRenderers: new Map(),
-			commands: new Map(),
-			setSendMessageHandler: () => {},
-			setAppendEntryHandler: () => {},
+		const hook2: ExtensionFactory = pi => {
+			pi.on("session_before_compact", () => {
+				callOrder.push("hook2-before");
+			});
+			pi.on("session_compact", () => {
+				callOrder.push("hook2-after");
+			});
 		};
 
 		await createSession([hook1, hook2]);

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -29,6 +29,7 @@ import type {
 } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { parseSessionEntries } from "@oh-my-pi/pi-coding-agent/session/session-loader";
 import { migrateSessionEntries } from "@oh-my-pi/pi-coding-agent/session/session-migrations";
+import { compactionSummaryText } from "./context-message-assertions";
 import { mockFetch } from "./helpers/fetch-mock";
 import { e2eApiKey } from "./utilities";
 
@@ -1218,7 +1219,7 @@ describe("buildSessionContext", () => {
 		// summary + kept (u2, a2) + after (u3, a3) = 5
 		expect(loaded.messages.length).toBe(5);
 		expect(loaded.messages[0].role).toBe("compactionSummary");
-		expect((loaded.messages[0] as any).summary).toContain("Summary of 1,a,2,b");
+		expect(compactionSummaryText(loaded.messages[0])).toContain("Summary of 1,a,2,b");
 	});
 
 	it("re-attaches snapcompact frames from preserveData as compaction summary images", () => {
@@ -1350,7 +1351,7 @@ describe("buildSessionContext", () => {
 		const loaded = buildSessionContext(entries);
 		// summary + kept from u3 (u3, c) + after (u4, d) = 5
 		expect(loaded.messages.length).toBe(5);
-		expect((loaded.messages[0] as any).summary).toContain("Second summary");
+		expect(compactionSummaryText(loaded.messages[0])).toContain("Second summary");
 	});
 
 	it("should keep all messages when firstKeptEntryId is first entry", () => {
@@ -1429,7 +1430,7 @@ describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))("LLM summarization", () => {
 		// Should have summary + kept messages
 		expect(reloaded.messages.length).toBeLessThan(loaded.messages.length);
 		expect(reloaded.messages[0].role).toBe("compactionSummary");
-		expect((reloaded.messages[0] as any).summary).toContain(compactionResult.summary);
+		expect(compactionSummaryText(reloaded.messages[0])).toContain(compactionResult.summary);
 
 		console.log("Original messages:", loaded.messages.length);
 		console.log("After compaction:", reloaded.messages.length);

--- a/packages/coding-agent/test/context-message-assertions.ts
+++ b/packages/coding-agent/test/context-message-assertions.ts
@@ -1,0 +1,43 @@
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+
+/**
+ * Test helpers that narrow an `AgentMessage` to the shape a specific assertion
+ * needs, replacing `(message as any).<field>` accesses with a checked narrow.
+ * A mismatch throws with the actual role so a broken build-context result fails
+ * loudly instead of reading `undefined`.
+ */
+
+/** Narrow to the compaction-summary variant and return its `summary` text. */
+export function compactionSummaryText(message: AgentMessage | undefined): string {
+	if (message?.role !== "compactionSummary") {
+		throw new Error(`expected a compactionSummary message, got ${message?.role ?? "undefined"}`);
+	}
+	return message.summary;
+}
+
+/** Narrow to the branch-summary variant and return its `summary` text. */
+export function branchSummaryText(message: AgentMessage | undefined): string {
+	if (message?.role !== "branchSummary") {
+		throw new Error(`expected a branchSummary message, got ${message?.role ?? "undefined"}`);
+	}
+	return message.summary;
+}
+
+/**
+ * Return a message's textual content: its string `content`, or the text of its
+ * first content block. Throws when the message carries no text content.
+ */
+export function firstContentText(message: AgentMessage | undefined): string {
+	if (!message || !("content" in message)) {
+		throw new Error(`expected a message with content, got ${message?.role ?? "undefined"}`);
+	}
+	const { content } = message;
+	if (typeof content === "string") {
+		return content;
+	}
+	const first = content[0];
+	if (first && "text" in first && typeof first.text === "string") {
+		return first.text;
+	}
+	throw new Error("expected a text content block");
+}

--- a/packages/coding-agent/test/cursor-exec.test.ts
+++ b/packages/coding-agent/test/cursor-exec.test.ts
@@ -75,7 +75,7 @@ describe("CursorExecHandlers.grep bridge", () => {
 		searchTool = new GrepTool(createTestSession(cwd));
 		handlers = new CursorExecHandlers({
 			cwd,
-			tools: new Map([["grep", searchTool as any]]),
+			tools: new Map<string, AgentTool>([["grep", searchTool]]),
 		});
 	});
 
@@ -89,7 +89,7 @@ describe("CursorExecHandlers.grep bridge", () => {
 			toolCallId: "call-1",
 			path: cwd,
 			pattern: "hello",
-		} as any);
+		} as Parameters<typeof handlers.grep>[0]);
 		expect((defaultResult.details as { matchCount?: number } | undefined)?.matchCount).toBe(1);
 
 		// 2. If caseInsensitive: true, should be case-insensitive (match count 2 for "hello")
@@ -98,7 +98,7 @@ describe("CursorExecHandlers.grep bridge", () => {
 			path: cwd,
 			pattern: "hello",
 			caseInsensitive: true,
-		} as any);
+		} as Parameters<typeof handlers.grep>[0]);
 		expect((insensitiveResult.details as { matchCount?: number } | undefined)?.matchCount).toBe(2);
 
 		// 3. If caseInsensitive: false, should be case-sensitive (match count 1 for "hello")
@@ -107,7 +107,7 @@ describe("CursorExecHandlers.grep bridge", () => {
 			path: cwd,
 			pattern: "hello",
 			caseInsensitive: false,
-		} as any);
+		} as Parameters<typeof handlers.grep>[0]);
 		expect((sensitiveResult.details as { matchCount?: number } | undefined)?.matchCount).toBe(1);
 	});
 

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-root-exports.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-root-exports.test.ts
@@ -7,6 +7,7 @@ import {
 	parseJsonWithRepair,
 	parseStreamingJson,
 	repairJson,
+	StringEnum,
 	streamSimpleOpenAIResponses,
 } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-ai-shim";
 
@@ -55,6 +56,19 @@ describe("legacy pi-ai shim root exports", () => {
 		expect(parseJsonWithRepair<{ a: number }>("{a: 1,}")).toEqual({ a: 1 });
 		// parseStreamingJson completes a truncated object at the streaming edge.
 		expect(parseStreamingJson<{ a: number }>('{"a": 1')).toEqual({ a: 1 });
+	});
+	it("accepts numeric enums through StringEnumOptions without narrowing the shim surface", () => {
+		// Type-level contract: legacy extensions may declare numeric enums, so
+		// StringEnumOptions must carry the function's `T extends string | number`
+		// instead of hardcoding `string`. `default`/`examples` are typed against
+		// the inferred value type, and the call must compile as written.
+		const schema = StringEnum([1, 2] as const, { default: 1, examples: [2], description: "numeric" });
+		expect(schema).toBeDefined();
+		const parsed = JSON.parse(JSON.stringify(schema));
+		expect(parsed.enum).toEqual([1, 2]);
+		expect(parsed.default).toBe(1);
+		expect(parsed.examples).toEqual([2]);
+		expect(parsed.description).toBe("numeric");
 	});
 	it("maps legacy simple options before streaming OpenAI Responses", async () => {
 		const requests: unknown[] = [];

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
@@ -214,7 +214,9 @@ describe("legacy-pi @(scope)/pi-ai root `Type` remap (issue #1437)", () => {
 					'export const schema = StringEnum(["red", "green"] as const, { description: "primary colors" });',
 				].join("\n"),
 			),
-		)) as { schema: { safeParse: (input: unknown) => { success: boolean }; toJSON?: () => any } };
+		)) as {
+			schema: { safeParse: (input: unknown) => { success: boolean }; toJSON?: () => { description?: unknown } };
+		};
 
 		expect(loaded.schema.safeParse("red").success).toBe(true);
 		expect(loaded.schema.safeParse("blue").success).toBe(false);

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1731,7 +1731,7 @@ describe("ExtensionRunner", () => {
 			name: "dangerous_tool",
 			label: "Dangerous Tool",
 			description: "Test tool",
-			parameters: {} as never,
+			parameters: Type.Object({}),
 			approval: "exec" as const,
 			execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
 		};
@@ -1767,7 +1767,7 @@ describe("ExtensionRunner", () => {
 			initializeRunner(runner, select);
 
 			const wrapper = new ExtensionToolWrapper(approvalTool, runner);
-			await (wrapper as ExtensionToolWrapper<any>).execute("call-approval", {}, undefined, undefined, {
+			await wrapper.execute("call-approval", {}, undefined, undefined, {
 				sessionManager,
 				modelRegistry,
 				model: undefined,
@@ -1821,7 +1821,7 @@ describe("ExtensionRunner", () => {
 
 			const wrapper = new ExtensionToolWrapper(approvalTool, runner);
 			await expect(
-				(wrapper as ExtensionToolWrapper<any>).execute("call-denied", {}, undefined, undefined, {
+				wrapper.execute("call-denied", {}, undefined, undefined, {
 					sessionManager,
 					modelRegistry,
 					model: undefined,
@@ -1872,7 +1872,7 @@ describe("ExtensionRunner", () => {
 
 			const wrapper = new ExtensionToolWrapper(approvalTool, runner);
 			await expect(
-				(wrapper as ExtensionToolWrapper<any>).execute("call-thrown", {}, undefined, undefined, {
+				wrapper.execute("call-thrown", {}, undefined, undefined, {
 					sessionManager,
 					modelRegistry,
 					model: undefined,
@@ -1925,7 +1925,7 @@ describe("ExtensionRunner", () => {
 
 			const wrapper = new ExtensionToolWrapper(approvalTool, runner);
 			await expect(
-				(wrapper as ExtensionToolWrapper<any>).execute("call-partial-context", {}, undefined, undefined, {
+				wrapper.execute("call-partial-context", {}, undefined, undefined, {
 					settings: { get: (key: string) => (key === "tools.approvalMode" ? "always-ask" : {}) },
 				} as never),
 			).rejects.toThrow('Tool "dangerous_tool" requires approval but no interactive UI available.');
@@ -2453,13 +2453,7 @@ describe("ExtensionRunner", () => {
 			} as AgentTool;
 			const wrapped = new ExtensionToolWrapper(promptTool, runner);
 
-			await (wrapped as ExtensionToolWrapper<any>).execute(
-				"call-p2p",
-				{ command: "original-command" },
-				undefined,
-				undefined,
-				alwaysAskContext,
-			);
+			await wrapped.execute("call-p2p", { command: "original-command" }, undefined, undefined, alwaysAskContext);
 
 			// The user was prompted for the revised command, and that is what executed.
 			expect(promptedWith).toContain("revised-command");
@@ -2629,13 +2623,7 @@ describe("ExtensionRunner", () => {
 			} as AgentTool;
 			const wrapped = new ExtensionToolWrapper(promptTool, runner);
 
-			await (wrapped as ExtensionToolWrapper<any>).execute(
-				"call-order",
-				{ command: "original" },
-				undefined,
-				undefined,
-				alwaysAskContext,
-			);
+			await wrapped.execute("call-order", { command: "original" }, undefined, undefined, alwaysAskContext);
 
 			expect(order).toEqual(["tool_call", "tool_approval_requested", "ui_select"]);
 			delete globalState.__orderEvents;

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -146,6 +146,13 @@ async function armInputWaiter(mode: InteractiveMode): Promise<{
 	};
 }
 
+function goalCompletionReport(details: unknown): unknown {
+	if (typeof details === "object" && details !== null && "completionBudgetReport" in details) {
+		return details.completionBudgetReport;
+	}
+	return undefined;
+}
+
 describe("InteractiveMode goal mode integration", () => {
 	let harness: GoalHarness;
 	let shared: SharedFixture;
@@ -455,7 +462,7 @@ describe("InteractiveMode goal mode integration", () => {
 		const result = await goalTool.execute("call-1", { op: "complete" });
 		const completionText = JSON.stringify(result.content);
 
-		expect(result.details?.completionBudgetReport).toBe(
+		expect(goalCompletionReport(result.details)).toBe(
 			"Goal achieved. Report final budget usage to the user: tokens used: 0 of 50.",
 		);
 		expect(completionText).toContain("Goal achieved. Report final budget usage to the user: tokens used: 0 of 50.");

--- a/packages/coding-agent/test/hook-editor.test.ts
+++ b/packages/coding-agent/test/hook-editor.test.ts
@@ -67,8 +67,8 @@ function createControllerContext() {
 		stop: vi.fn(),
 		terminal: { columns: 120 },
 	} as unknown as TestContext["ui"] & {
-		setFocus: Mock<any>;
-		requestRender: Mock<any>;
+		setFocus: Mock<TUI["setFocus"]>;
+		requestRender: Mock<TUI["requestRender"]>;
 	};
 	const ctx = {
 		editor,

--- a/packages/coding-agent/test/memories-runtime.test.ts
+++ b/packages/coding-agent/test/memories-runtime.test.ts
@@ -3,7 +3,8 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as ai from "@oh-my-pi/pi-ai";
-import { Effort, type Model } from "@oh-my-pi/pi-ai";
+import { type AssistantMessage, Effort, type Model } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	buildMemoryToolDeveloperInstructions,
@@ -11,6 +12,7 @@ import {
 	startMemoryStartupTask,
 } from "@oh-my-pi/pi-coding-agent/memories";
 import * as memoryStorage from "@oh-my-pi/pi-coding-agent/memories/storage";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { getAgentDbPath, Snowflake, TempDir } from "@oh-my-pi/pi-utils";
 
 interface SessionFixture {
@@ -18,8 +20,8 @@ interface SessionFixture {
 	sessionDir: string;
 	sessionFile: string;
 	settings: Settings;
-	session: any;
-	modelRegistry: any;
+	session: AgentSession;
+	modelRegistry: ModelRegistry;
 	model: Model;
 	whenSettled: Promise<void>;
 }
@@ -49,12 +51,36 @@ function createModel(id = "test-model"): Model {
 	} as Model;
 }
 
-function createModelRegistry(model: Model): any {
-	return {
+function createModelRegistry(model: Model): ModelRegistry {
+	return Object.assign(Object.create(ModelRegistry.prototype), {
 		find: vi.fn(() => model),
 		getAll: vi.fn(() => [model]),
 		getApiKey: vi.fn(async () => "test-api-key"),
 		resolver: vi.fn(() => async () => "test-api-key"),
+	}) as ModelRegistry;
+}
+
+function createAssistantMessage(
+	content: AssistantMessage["content"],
+	usage?: AssistantMessage["usage"],
+	stopReason: string = "end_turn",
+): AssistantMessage {
+	return {
+		role: "assistant",
+		api: "openai-completions",
+		provider: "openai",
+		model: "test-model",
+		stopReason: stopReason as AssistantMessage["stopReason"],
+		content,
+		usage: usage ?? {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: 0,
 	};
 }
 
@@ -79,18 +105,31 @@ async function createFixture(overrides?: Partial<Record<string, unknown>>): Prom
 	const refreshBaseSystemPrompt = vi.fn(async () => {
 		settled.resolve();
 	});
-	const session = {
-		sessionManager: {
-			getSessionFile: () => sessionFile,
-			getSessionDir: () => sessionDir,
-			getSessionId: () => "current-thread",
-			getCwd: () => agentDir,
+	const session = Object.assign(
+		Object.create(AgentSession.prototype, {
+			isDisposed: { value: false, writable: true, configurable: true, enumerable: true },
+			sessionId: { value: "current-thread", writable: true, configurable: true, enumerable: true },
+			beginLocalMemoryStartup: {
+				value: () => new AbortController().signal,
+				writable: true,
+				configurable: true,
+				enumerable: true,
+			},
+			endLocalMemoryStartup: { value: () => {}, writable: true, configurable: true, enumerable: true },
+			model: { value: model, writable: true, configurable: true, enumerable: true },
+			modelRegistry: { value: modelRegistry, writable: true, configurable: true, enumerable: true },
+		}),
+		{
+			sessionManager: {
+				getSessionFile: () => sessionFile,
+				getSessionDir: () => sessionDir,
+				getSessionId: () => "current-thread",
+				getCwd: () => agentDir,
+			},
+			settings,
+			refreshBaseSystemPrompt,
 		},
-		settings,
-		model,
-		modelRegistry,
-		refreshBaseSystemPrompt,
-	};
+	) as AgentSession;
 
 	return { agentDir, sessionDir, sessionFile, settings, session, modelRegistry, model, whenSettled: settled.promise };
 }
@@ -207,23 +246,30 @@ describe("memories runtime", () => {
 
 		const completeSpy = vi
 			.spyOn(ai, "completeSimple")
-			.mockResolvedValueOnce({
-				stopReason: "end_turn",
-				content: [
+			.mockResolvedValueOnce(
+				createAssistantMessage(
+					[
+						{
+							type: "text",
+							text: JSON.stringify({
+								rollout_summary: "Rollout summary A",
+								rollout_slug: "thread-a-rollout",
+								raw_memory: "Raw memory A",
+							}),
+						},
+					],
 					{
-						type: "text",
-						text: JSON.stringify({
-							rollout_summary: "Rollout summary A",
-							rollout_slug: "thread-a-rollout",
-							raw_memory: "Raw memory A",
-						}),
+						input: 10,
+						output: 5,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 15,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 					},
-				],
-				usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15 },
-			} as any)
-			.mockResolvedValueOnce({
-				stopReason: "end_turn",
-				content: [
+				),
+			)
+			.mockResolvedValueOnce(
+				createAssistantMessage([
 					{
 						type: "text",
 						text: JSON.stringify({
@@ -232,8 +278,8 @@ describe("memories runtime", () => {
 							skills: [{ name: "deploy-playbook", content: "# Deploy\nUse blue/green." }],
 						}),
 					},
-				],
-			} as any);
+				]),
+			);
 
 		startMemoryStartupTask({
 			session: fx.session,
@@ -273,7 +319,7 @@ describe("memories runtime", () => {
 			reasoning: true,
 			thinking: { mode: "effort", efforts: [Effort.High, Effort.XHigh] },
 		};
-		fx.session.model = constrainedModel;
+		(fx.session as { model: Model }).model = constrainedModel;
 		fx.modelRegistry.find = vi.fn(() => constrainedModel);
 		fx.modelRegistry.getAll = vi.fn(() => [constrainedModel]);
 
@@ -286,23 +332,30 @@ describe("memories runtime", () => {
 
 		const spy = vi
 			.spyOn(ai, "completeSimple")
-			.mockResolvedValueOnce({
-				stopReason: "end_turn",
-				content: [
+			.mockResolvedValueOnce(
+				createAssistantMessage(
+					[
+						{
+							type: "text",
+							text: JSON.stringify({
+								rollout_summary: "Rollout summary",
+								rollout_slug: "thread-constrained",
+								raw_memory: "Raw memory",
+							}),
+						},
+					],
 					{
-						type: "text",
-						text: JSON.stringify({
-							rollout_summary: "Rollout summary",
-							rollout_slug: "thread-constrained",
-							raw_memory: "Raw memory",
-						}),
+						input: 1,
+						output: 1,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 2,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 					},
-				],
-				usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
-			} as any)
-			.mockResolvedValueOnce({
-				stopReason: "end_turn",
-				content: [
+				),
+			)
+			.mockResolvedValueOnce(
+				createAssistantMessage([
 					{
 						type: "text",
 						text: JSON.stringify({
@@ -311,8 +364,8 @@ describe("memories runtime", () => {
 							skills: [],
 						}),
 					},
-				],
-			} as any);
+				]),
+			);
 
 		startMemoryStartupTask({
 			session: fx.session,
@@ -335,9 +388,8 @@ describe("memories runtime", () => {
 
 	test("phase2 sync prunes stale summaries and preserves raw memory ordering", async () => {
 		const fx = await createFixture();
-		vi.spyOn(ai, "completeSimple").mockResolvedValue({
-			stopReason: "end_turn",
-			content: [
+		vi.spyOn(ai, "completeSimple").mockResolvedValue(
+			createAssistantMessage([
 				{
 					type: "text",
 					text: JSON.stringify({
@@ -346,8 +398,8 @@ describe("memories runtime", () => {
 						skills: [{ name: "ops", content: "# Ops\nRunbook" }],
 					}),
 				},
-			],
-		} as any);
+			]),
+		);
 
 		const db = memoryStorage.openMemoryDb(getAgentDbPath(fx.agentDir));
 		memoryStorage.upsertThreads(db, [

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -1365,7 +1365,7 @@ providers:
 		expect(ProviderDiscoverySchema.allows({ type: "llama.cpp", timeoutMs: -500 })).toBe(false);
 		expect(ProviderDiscoverySchema.allows({ type: "llama.cpp", timeoutMs: 0 })).toBe(false);
 		expect(ProviderDiscoverySchema.allows({ type: "llama.cpp", timeoutMs: Number.NaN })).toBe(false);
-		expect(ProviderDiscoverySchema.allows({ type: "llama.cpp", timeoutMs: "30000" as any })).toBe(false);
+		expect(ProviderDiscoverySchema.allows({ type: "llama.cpp", timeoutMs: "30000" })).toBe(false);
 	});
 	test("llama.cpp discovery marks per-model architecture image modalities as vision-capable", async () => {
 		const fetchMock: FetchImpl = async input => {

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -10,6 +10,7 @@ import type {
 	ThinkingLevelChangeEntry,
 } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import * as snapcompact from "@oh-my-pi/snapcompact";
+import { branchSummaryText, compactionSummaryText, firstContentText } from "../context-message-assertions";
 
 function msg(id: string, parentId: string | null, role: "user" | "assistant", text: string): SessionMessageEntry {
 	const base = { type: "message" as const, id, parentId, timestamp: "2025-01-01T00:00:00Z" };
@@ -199,11 +200,11 @@ describe("buildSessionContext", () => {
 
 			// Should have: summary + kept (3,4) + after (6,7) = 5 messages
 			expect(ctx.messages).toHaveLength(5);
-			expect((ctx.messages[0] as any).summary).toContain("Summary of first two turns");
-			expect((ctx.messages[1] as any).content).toBe("second");
-			expect((ctx.messages[2] as any).content[0].text).toBe("response2");
-			expect((ctx.messages[3] as any).content).toBe("third");
-			expect((ctx.messages[4] as any).content[0].text).toBe("response3");
+			expect(compactionSummaryText(ctx.messages[0])).toContain("Summary of first two turns");
+			expect(firstContentText(ctx.messages[1])).toBe("second");
+			expect(firstContentText(ctx.messages[2])).toBe("response2");
+			expect(firstContentText(ctx.messages[3])).toBe("third");
+			expect(firstContentText(ctx.messages[4])).toBe("response3");
 		});
 
 		it("keeps Anthropic native web-search bytes when compaction retains the assistant turn", () => {
@@ -273,7 +274,7 @@ describe("buildSessionContext", () => {
 
 			// Summary + all messages (1,2,4)
 			expect(ctx.messages).toHaveLength(4);
-			expect((ctx.messages[0] as any).summary).toContain("Empty summary");
+			expect(compactionSummaryText(ctx.messages[0])).toContain("Empty summary");
 		});
 
 		it("uses preserved OpenAI replacement history instead of kept raw messages", () => {
@@ -497,7 +498,7 @@ describe("buildSessionContext", () => {
 
 			// Should use second summary, keep from 4
 			expect(ctx.messages).toHaveLength(4);
-			expect((ctx.messages[0] as any).summary).toContain("Second summary");
+			expect(compactionSummaryText(ctx.messages[0])).toContain("Second summary");
 		});
 	});
 
@@ -614,11 +615,11 @@ describe("buildSessionContext", () => {
 
 			const ctxA = buildSessionContext(entries, "3");
 			expect(ctxA.messages).toHaveLength(3);
-			expect((ctxA.messages[2] as any).content).toBe("branch A");
+			expect(firstContentText(ctxA.messages[2])).toBe("branch A");
 
 			const ctxB = buildSessionContext(entries, "4");
 			expect(ctxB.messages).toHaveLength(3);
-			expect((ctxB.messages[2] as any).content).toBe("branch B");
+			expect(firstContentText(ctxB.messages[2])).toBe("branch B");
 		});
 
 		it("includes branch summary in path", () => {
@@ -632,8 +633,8 @@ describe("buildSessionContext", () => {
 			const ctx = buildSessionContext(entries, "5");
 
 			expect(ctx.messages).toHaveLength(4);
-			expect((ctx.messages[2] as any).summary).toContain("Summary of abandoned work");
-			expect((ctx.messages[3] as any).content).toBe("new direction");
+			expect(branchSummaryText(ctx.messages[2])).toContain("Summary of abandoned work");
+			expect(firstContentText(ctx.messages[3])).toBe("new direction");
 		});
 
 		it("complex tree with multiple branches and compaction", () => {
@@ -660,20 +661,20 @@ describe("buildSessionContext", () => {
 			// Main path to 7: summary + kept(3,4) + after(6,7)
 			const ctxMain = buildSessionContext(entries, "7");
 			expect(ctxMain.messages).toHaveLength(5);
-			expect((ctxMain.messages[0] as any).summary).toContain("Compacted history");
-			expect((ctxMain.messages[1] as any).content).toBe("q2");
-			expect((ctxMain.messages[2] as any).content[0].text).toBe("r2");
-			expect((ctxMain.messages[3] as any).content).toBe("q3");
-			expect((ctxMain.messages[4] as any).content[0].text).toBe("r3");
+			expect(compactionSummaryText(ctxMain.messages[0])).toContain("Compacted history");
+			expect(firstContentText(ctxMain.messages[1])).toBe("q2");
+			expect(firstContentText(ctxMain.messages[2])).toBe("r2");
+			expect(firstContentText(ctxMain.messages[3])).toBe("q3");
+			expect(firstContentText(ctxMain.messages[4])).toBe("r3");
 
 			// Branch path to 11: 1,2,3 + branch_summary + 11
 			const ctxBranch = buildSessionContext(entries, "11");
 			expect(ctxBranch.messages).toHaveLength(5);
-			expect((ctxBranch.messages[0] as any).content).toBe("start");
-			expect((ctxBranch.messages[1] as any).content[0].text).toBe("r1");
-			expect((ctxBranch.messages[2] as any).content).toBe("q2");
-			expect((ctxBranch.messages[3] as any).summary).toContain("Tried wrong approach");
-			expect((ctxBranch.messages[4] as any).content).toBe("better approach");
+			expect(firstContentText(ctxBranch.messages[0])).toBe("start");
+			expect(firstContentText(ctxBranch.messages[1])).toBe("r1");
+			expect(firstContentText(ctxBranch.messages[2])).toBe("q2");
+			expect(branchSummaryText(ctxBranch.messages[3])).toContain("Tried wrong approach");
+			expect(firstContentText(ctxBranch.messages[4])).toBe("better approach");
 		});
 	});
 

--- a/packages/coding-agent/test/session-manager/migration.test.ts
+++ b/packages/coding-agent/test/session-manager/migration.test.ts
@@ -25,12 +25,13 @@ describe("migrateSessionEntries", () => {
 
 		migrateSessionEntries(entries);
 
-		// Header should have version set to current
-		expect((entries[0] as any).version).toBe(3);
+		const header = entries[0];
+		if (header?.type !== "session") throw new Error("expected session header");
+		expect(header.version).toBe(3);
 
-		// Entries should have id/parentId
-		const msg1 = entries[1] as any;
-		const msg2 = entries[2] as any;
+		const msg1 = entries[1];
+		const msg2 = entries[2];
+		if (msg1?.type !== "message" || msg2?.type !== "message") throw new Error("expected message entries");
 
 		expect(msg1.id).toBeDefined();
 		expect(msg1.id.length).toBe(8);
@@ -71,9 +72,11 @@ describe("migrateSessionEntries", () => {
 
 		migrateSessionEntries(entries);
 
-		// IDs should be unchanged
-		expect((entries[1] as any).id).toBe("abc12345");
-		expect((entries[2] as any).id).toBe("def67890");
-		expect((entries[2] as any).parentId).toBe("abc12345");
+		const msg1 = entries[1];
+		const msg2 = entries[2];
+		if (msg1?.type !== "message" || msg2?.type !== "message") throw new Error("expected message entries");
+		expect(msg1.id).toBe("abc12345");
+		expect(msg2.id).toBe("def67890");
+		expect(msg2.parentId).toBe("abc12345");
 	});
 });

--- a/packages/coding-agent/test/session-manager/move-to.test.ts
+++ b/packages/coding-agent/test/session-manager/move-to.test.ts
@@ -15,20 +15,18 @@ import { makeAssistantMessage } from "./helpers";
 
 function getHeader(entries: unknown[]): SessionHeader | undefined {
 	return entries.find(
-		(e): e is SessionHeader => typeof e === "object" && e !== null && "type" in e && (e as any).type === "session",
-	) as SessionHeader | undefined;
+		(e): e is SessionHeader => typeof e === "object" && e !== null && "type" in e && e.type === "session",
+	);
 }
 
 function hasAssistantEntry(entries: unknown[]): boolean {
-	return entries.some(
-		e =>
-			typeof e === "object" &&
-			e !== null &&
-			"type" in e &&
-			(e as any).type === "message" &&
-			"message" in e &&
-			(e as any).message?.role === "assistant",
-	);
+	return entries.some(e => {
+		if (typeof e !== "object" || e === null || !("type" in e) || e.type !== "message" || !("message" in e)) {
+			return false;
+		}
+		const { message } = e;
+		return typeof message === "object" && message !== null && "role" in message && message.role === "assistant";
+	});
 }
 
 // -- stripOuterDoubleQuotes tests -------------------------------------------

--- a/packages/coding-agent/test/session-manager/tree-traversal.test.ts
+++ b/packages/coding-agent/test/session-manager/tree-traversal.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, spyOn } from "bun:test";
 import type { CustomEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { firstContentText } from "../context-message-assertions";
 import { assistantMsg, userMsg } from "../utilities";
 
 describe("SessionManager append and tree traversal", () => {
@@ -393,7 +394,7 @@ describe("SessionManager append and tree traversal", () => {
 			const entry2 = session.getEntry(id2);
 			expect(entry2).toBeDefined();
 			if (entry2?.type === "message" && entry2.message.role === "assistant") {
-				expect((entry2.message.content as any)[0].text).toBe("second");
+				expect(firstContentText(entry2.message)).toBe("second");
 			}
 		});
 	});
@@ -414,9 +415,9 @@ describe("SessionManager append and tree traversal", () => {
 			const ctx = session.buildSessionContext();
 			expect(ctx.messages).toHaveLength(3); // msg1, msg2, msg4-branch (not msg3)
 
-			expect((ctx.messages[0] as any).content).toBe("msg1");
-			expect((ctx.messages[1] as any).content[0].text).toBe("msg2");
-			expect((ctx.messages[2] as any).content[0].text).toBe("msg4-branch");
+			expect(firstContentText(ctx.messages[0])).toBe("msg1");
+			expect(firstContentText(ctx.messages[1])).toBe("msg2");
+			expect(firstContentText(ctx.messages[2])).toBe("msg4-branch");
 		});
 	});
 });

--- a/packages/coding-agent/test/task/autoload-skills.test.ts
+++ b/packages/coding-agent/test/task/autoload-skills.test.ts
@@ -145,7 +145,7 @@ describe("autoloadSkills in executor", () => {
 			autoloadSkills: mockSkills,
 		});
 
-		const sendCustomMessage = session.sendCustomMessage as Mock<any>;
+		const sendCustomMessage = session.sendCustomMessage as Mock<(...args: never[]) => Promise<unknown>>;
 		expect(sendCustomMessage).toHaveBeenCalledTimes(2);
 
 		// Verify first skill
@@ -191,7 +191,7 @@ describe("autoloadSkills in executor", () => {
 
 		await runSubprocess(baseOptions);
 
-		const sendCustomMessage = session.sendCustomMessage as Mock<any>;
+		const sendCustomMessage = session.sendCustomMessage as Mock<(...args: never[]) => Promise<unknown>>;
 		expect(sendCustomMessage).not.toHaveBeenCalled();
 	});
 
@@ -213,7 +213,7 @@ describe("autoloadSkills in executor", () => {
 
 		await runSubprocess({ ...baseOptions, autoloadSkills: undefined });
 
-		const sendCustomMessage = session.sendCustomMessage as Mock<any>;
+		const sendCustomMessage = session.sendCustomMessage as Mock<(...args: never[]) => Promise<unknown>>;
 		expect(sendCustomMessage).not.toHaveBeenCalled();
 	});
 
@@ -233,7 +233,7 @@ describe("autoloadSkills in executor", () => {
 		});
 
 		// Track sendCustomMessage call order
-		(session.sendCustomMessage as Mock<any>).mockImplementation(async () => {
+		(session.sendCustomMessage as Mock<(...args: never[]) => Promise<unknown>>).mockImplementation(async () => {
 			callOrder.push("sendCustomMessage");
 		});
 

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -4,7 +4,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import * as zlib from "node:zlib";
-import type { AgentToolContext } from "@oh-my-pi/pi-agent-core";
+import type { AgentToolContext, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import type { TextContent } from "@oh-my-pi/pi-ai";
 import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
 import { DEFAULT_BASH_INTERCEPTOR_RULES, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { EditTool } from "@oh-my-pi/pi-coding-agent/edit";
@@ -22,11 +23,11 @@ import { DEFAULT_FILE_LIMIT, GrepTool, MULTI_FILE_PER_FILE_MATCHES } from "../sr
 import { HubTool } from "../src/tools/hub";
 
 // Helper to extract text from content blocks
-function getTextOutput(result: any): string {
+function getTextOutput(result: AgentToolResult): string {
 	return (
 		result.content
-			?.filter((c: any) => c.type === "text")
-			.map((c: any) => c.text)
+			.filter((c): c is TextContent => c.type === "text")
+			.map(c => c.text)
 			.join("\n") || ""
 	);
 }
@@ -970,7 +971,7 @@ describe("Coding Agent Tools", () => {
 			const output = getTextOutput(result);
 
 			expect(output).toContain("definitely not a png");
-			expect(result.content.some((c: any) => c.type === "image")).toBe(false);
+			expect(result.content.some(c => c.type === "image")).toBe(false);
 		});
 	});
 

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -49,7 +49,7 @@ function createContext(args: {
 	) => Promise<string | undefined>;
 	askDialog?: (
 		questions: ExtensionAskDialogQuestion[],
-		dialogOptions?: any,
+		dialogOptions?: unknown,
 	) => Promise<ExtensionAskDialogResult | undefined>;
 	abort?: () => void;
 }): AgentToolContext {

--- a/packages/coding-agent/test/write-xdev-dispatch.test.ts
+++ b/packages/coding-agent/test/write-xdev-dispatch.test.ts
@@ -8,6 +8,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { ToolChoiceQueue } from "@oh-my-pi/pi-coding-agent/session/tool-choice-queue";
 import { createTools, type Tool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import type { GhToolDetails } from "@oh-my-pi/pi-coding-agent/tools/gh";
 import { githubToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/gh-renderer";
 import { ToolError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
 import { WriteTool, writeToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/write";
@@ -48,6 +49,20 @@ function createTestXdevState(tools: Tool[], builtInNames: Iterable<string> = too
 		builtInNames: new Set(builtInNames),
 		isActive: () => false,
 	};
+}
+
+function xdevDispatchDetails(details: unknown): { tool?: unknown; mode?: unknown; tier?: unknown } {
+	if (typeof details === "object" && details !== null && "xdev" in details) {
+		const xdev = details.xdev;
+		if (typeof xdev === "object" && xdev !== null) {
+			return {
+				tool: "tool" in xdev ? xdev.tool : undefined,
+				mode: "mode" in xdev ? xdev.mode : undefined,
+				tier: "tier" in xdev ? xdev.tier : undefined,
+			};
+		}
+	}
+	return {};
 }
 
 describe("read and write route xd:// device URLs", () => {
@@ -94,11 +109,11 @@ describe("read and write route xd:// device URLs", () => {
 			// staging a preview (not a direct apply).
 			const previewResult = await write!.execute("write-xdev-preview", { path: "xd://ast_edit", content });
 			expect(previewResult.isError).toBeUndefined();
-			expect(previewResult.details?.xdev?.tool).toBe("ast_edit");
-			expect(previewResult.details?.xdev?.mode).toBe("execute");
+			expect(xdevDispatchDetails(previewResult.details).tool).toBe("ast_edit");
+			expect(xdevDispatchDetails(previewResult.details).mode).toBe("execute");
 			// The dispatch records the wrapped tool's approval tier so prewalk can
 			// tell a mutation from a read-only device call (issue #7312).
-			expect(previewResult.details?.xdev?.tier).toBe("write");
+			expect(xdevDispatchDetails(previewResult.details).tier).toBe("write");
 			const previewText = previewResult.content.find(entry => entry.type === "text")?.text ?? "";
 			expect(previewText).toContain("modernWrap");
 
@@ -270,11 +285,12 @@ describe("read and write route xd:// device URLs", () => {
 		const uiTheme = (await themeModule.getThemeByName("dark")) ?? (await themeModule.getThemeByName("light"));
 		if (!uiTheme) throw new Error("expected an initialized theme");
 
-		const githubDevice = {
+		const githubSchema = type({ op: "string" });
+		const githubDevice: AgentTool<typeof githubSchema, GhToolDetails, themeModule.Theme> = {
 			name: "github",
 			label: "GitHub",
 			description: "fixture",
-			parameters: type({ op: "string" }),
+			parameters: githubSchema,
 			...githubToolRenderer,
 			async execute() {
 				throw new ToolError("gh: Not Found (HTTP 404)");
@@ -537,7 +553,7 @@ describe("web_search stays top-level under xdev", () => {
 				content: "{}",
 			});
 			expect(dispatched.isError).toBe(true);
-			expect(dispatched.details?.xdev?.tool).toBe("web_search");
+			expect(xdevDispatchDetails(dispatched.details).tool).toBe("web_search");
 			expect(dispatched.content.find(entry => entry.type === "text")?.text).not.toContain("No such tool");
 		} finally {
 			await removeWithRetries(tempDir);
@@ -567,7 +583,7 @@ describe("xd:// and top-level calls share the canonical tool map", () => {
 				content: JSON.stringify({ pattern: "fallback-needle", path: tempDir }),
 			});
 			expect(dispatched.isError).toBeUndefined();
-			expect(dispatched.details?.xdev?.tool).toBe("grep");
+			expect(xdevDispatchDetails(dispatched.details).tool).toBe("grep");
 			expect(dispatched.content.find(entry => entry.type === "text")?.text).toContain("fallback-needle");
 
 			// Docs resolve through the same fallback.

--- a/packages/omptype/test/ark/cast.test.ts
+++ b/packages/omptype/test/ark/cast.test.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: tests the schema's any type contract
 import { describe, expect, it } from "bun:test";
 import { type Type, type } from "@oh-my-pi/omptype/ark";
 import type { Eq } from "./type-assert";

--- a/packages/omptype/test/ark/keywords/tsPrimitives.test.ts
+++ b/packages/omptype/test/ark/keywords/tsPrimitives.test.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: tests the schema's any type contract
 import { expect, it } from "bun:test";
 import { type } from "@oh-my-pi/omptype/ark";
 import type { Eq } from "../type-assert";

--- a/packages/omptype/test/ark/pipe.test.ts
+++ b/packages/omptype/test/ark/pipe.test.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: tests the schema's any type contract
 import { describe, expect, it } from "bun:test";
 import { type ArkErrors, scope, type Type, type } from "@oh-my-pi/omptype/ark";
 import type { Eq } from "./type-assert";

--- a/packages/omptype/test/ark/realWorld.test.ts
+++ b/packages/omptype/test/ark/realWorld.test.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: tests the schema's any type contract
 import { expect, it } from "bun:test";
 import { AssertionError } from "node:assert";
 import { type ArkErrors, type Module, type StandardSchemaV1, scope, type Type, type } from "@oh-my-pi/omptype/ark";

--- a/packages/omptype/test/ark/scope.test.ts
+++ b/packages/omptype/test/ark/scope.test.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: tests the schema's any type contract
 import { describe, expect, it } from "bun:test";
 import { type ArkErrors, type Module, type Scope, scope, type } from "@oh-my-pi/omptype/ark";
 import type { Eq } from "./type-assert";

--- a/packages/omptype/test/ark/this.test.ts
+++ b/packages/omptype/test/ark/this.test.ts
@@ -37,7 +37,7 @@ it("at nested path", () => {
 
 	expect(T(validData)).toEqual(validData);
 
-	const invalidData = { foo: { bar: {} as any } };
+	const invalidData = { foo: { bar: {} } };
 	invalidData.foo.bar = invalidData.foo;
 	expect(T(invalidData).toString()).toBe("foo.bar.foo must be an object (was missing)");
 });

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Removed the `export` keyword from the internal `UNKNOWN_MODEL` constant (only consumed in-file).
+
 ## [17.2.4] - 2026-08-01
 
 ### Fixed

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -495,7 +495,7 @@ export async function getRequestDetails(id: number): Promise<RequestDetails | nu
 	if (!msg) return null;
 
 	const entry = await getSessionEntry(msg.sessionFile, msg.entryId);
-	if (entry?.type !== "message") return null;
+	if (entry?.type !== "message" || !("message" in entry)) return null;
 
 	// TODO: Get parent/context messages?
 	// For now we return the single entry which contains the assistant response.
@@ -504,7 +504,7 @@ export async function getRequestDetails(id: number): Promise<RequestDetails | nu
 	return {
 		...msg,
 		messages: [entry],
-		output: (entry as any).message,
+		output: entry.message,
 	};
 }
 

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import * as fs from "node:fs/promises";
-import type { Usage } from "@oh-my-pi/pi-ai";
+import type { StopReason, Usage } from "@oh-my-pi/pi-ai";
 import type { GeneratedProvider } from "@oh-my-pi/pi-catalog/models";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { getConfigRootDir, getStatsDbPath } from "@oh-my-pi/pi-utils";
@@ -463,7 +463,32 @@ export function insertMessageStats(stats: MessageStats[]): number {
 /**
  * Build aggregated stats from query results.
  */
-function buildAggregatedStats(rows: any[]): AggregatedStats {
+interface AggregateRow {
+	total_requests: number | null;
+	failed_requests: number | null;
+	total_input_tokens: number | null;
+	total_output_tokens: number | null;
+	total_cache_read_tokens: number | null;
+	total_cache_write_tokens: number | null;
+	total_premium_requests: number | null;
+	total_cost: number | null;
+	avg_duration: number | null;
+	avg_ttft: number | null;
+	avg_tokens_per_second: number | null;
+	first_timestamp: number | null;
+	last_timestamp: number | null;
+}
+
+interface ModelAggregateRow extends AggregateRow {
+	model: string;
+	provider: string;
+}
+
+interface FolderAggregateRow extends AggregateRow {
+	folder: string;
+}
+
+function buildAggregatedStats(rows: AggregateRow[]): AggregatedStats {
 	if (rows.length === 0) {
 		return {
 			totalRequests: 0,
@@ -543,7 +568,7 @@ export function getOverallStats(cutoff?: number): AggregatedStats {
 	`);
 
 	const rows = hasCutoff ? stmt.all(cutoff) : stmt.all();
-	return buildAggregatedStats(rows as any[]);
+	return buildAggregatedStats(rows as AggregateRow[]);
 }
 /**
  * Get stats grouped by model.
@@ -575,7 +600,7 @@ export function getStatsByModel(cutoff?: number): ModelStats[] {
 		ORDER BY total_requests DESC
 	`);
 
-	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as any[];
+	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as ModelAggregateRow[];
 	return rows.map(row => ({
 		model: row.model,
 		provider: row.provider,
@@ -612,7 +637,7 @@ export function getStatsByFolder(cutoff?: number): FolderStats[] {
 		ORDER BY total_requests DESC
 	`);
 
-	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as any[];
+	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as FolderAggregateRow[];
 	return rows.map(row => ({
 		folder: row.folder,
 		...buildAggregatedStats([row]),
@@ -624,6 +649,16 @@ export function getStatsByFolder(cutoff?: number): FolderStats[] {
  * Token columns are explicit so the dashboard's share denominator matches the
  * counts it renders. Rows missing `agent_type` (defensive) fall back to "main".
  */
+interface AgentTypeAggregateRow {
+	agent_type: AgentType | null;
+	total_requests: number | null;
+	total_input_tokens: number | null;
+	total_output_tokens: number | null;
+	total_cache_read_tokens: number | null;
+	total_cache_write_tokens: number | null;
+	total_cost: number | null;
+}
+
 export function getStatsByAgentType(cutoff?: number): AgentTypeStats[] {
 	if (!db) return [];
 
@@ -642,9 +677,9 @@ export function getStatsByAgentType(cutoff?: number): AgentTypeStats[] {
 		GROUP BY agent_type
 	`);
 
-	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as any[];
+	const rows = (hasCutoff ? stmt.all(cutoff) : stmt.all()) as AgentTypeAggregateRow[];
 	return rows.map(row => ({
-		agentType: (row.agent_type as AgentType) ?? "main",
+		agentType: row.agent_type ?? "main",
 		totalRequests: row.total_requests || 0,
 		totalInputTokens: row.total_input_tokens || 0,
 		totalOutputTokens: row.total_output_tokens || 0,
@@ -657,6 +692,14 @@ export function getStatsByAgentType(cutoff?: number): AgentTypeStats[] {
 /**
  * Get time series data.
  */
+interface TimeSeriesRow {
+	bucket: number;
+	requests: number;
+	errors: number;
+	tokens: number;
+	cost: number;
+}
+
 export function getTimeSeries(hours = 24, cutoff?: number | null, bucketMs = 60 * 60 * 1000): TimeSeriesPoint[] {
 	if (!db) return [];
 
@@ -677,8 +720,8 @@ export function getTimeSeries(hours = 24, cutoff?: number | null, bucketMs = 60 
 	`);
 
 	const rows = hasCutoff
-		? (stmt.all(bucketMs, bucketMs, seriesCutoff) as any[])
-		: (stmt.all(bucketMs, bucketMs) as any[]);
+		? (stmt.all(bucketMs, bucketMs, seriesCutoff) as TimeSeriesRow[])
+		: (stmt.all(bucketMs, bucketMs) as TimeSeriesRow[]);
 	return rows.map(row => ({
 		timestamp: row.bucket,
 		requests: row.requests,
@@ -930,7 +973,34 @@ export function closeDb(): void {
 	}
 }
 
-function rowToMessageStats(row: any): MessageStats {
+interface MessageRow {
+	id: number;
+	session_file: string;
+	entry_id: string;
+	folder: string;
+	model: string;
+	provider: string;
+	api: string;
+	timestamp: number;
+	duration: number | null;
+	ttft: number | null;
+	stop_reason: StopReason;
+	error_message: string | null;
+	input_tokens: number;
+	output_tokens: number;
+	cache_read_tokens: number;
+	cache_write_tokens: number;
+	total_tokens: number;
+	premium_requests: number;
+	cost_input: number;
+	cost_output: number;
+	cost_cache_read: number;
+	cost_cache_write: number;
+	cost_total: number;
+	agent_type: AgentType | null;
+}
+
+function rowToMessageStats(row: MessageRow): MessageStats {
 	return {
 		id: row.id,
 		sessionFile: row.session_file,
@@ -942,7 +1012,7 @@ function rowToMessageStats(row: any): MessageStats {
 		timestamp: row.timestamp,
 		duration: row.duration,
 		ttft: row.ttft,
-		stopReason: row.stop_reason as any,
+		stopReason: row.stop_reason,
 		errorMessage: row.error_message,
 		usage: {
 			input: row.input_tokens,
@@ -959,7 +1029,7 @@ function rowToMessageStats(row: any): MessageStats {
 				total: row.cost_total,
 			},
 		},
-		agentType: (row.agent_type as AgentType) ?? "main",
+		agentType: row.agent_type ?? "main",
 	};
 }
 
@@ -970,7 +1040,7 @@ export function getRecentRequests(limit = 100): MessageStats[] {
 		ORDER BY timestamp DESC 
 		LIMIT ?
 	`);
-	return (stmt.all(limit) as any[]).map(rowToMessageStats);
+	return (stmt.all(limit) as MessageRow[]).map(rowToMessageStats);
 }
 
 export function getRecentErrors(limit = 100, cutoff?: number | null): MessageStats[] {
@@ -983,20 +1053,32 @@ export function getRecentErrors(limit = 100, cutoff?: number | null): MessageSta
 		ORDER BY timestamp DESC
 		LIMIT ?
 	`);
-	const rows = hasCutoff ? stmt.all(cutoff, limit) : stmt.all(limit);
+	const rows = (hasCutoff ? stmt.all(cutoff, limit) : stmt.all(limit)) as MessageRow[];
 	return rows.map(rowToMessageStats);
 }
 
 export function getMessageById(id: number): MessageStats | null {
 	if (!db) return null;
 	const stmt = db.prepare("SELECT * FROM messages WHERE id = ?");
-	const row = stmt.get(id);
+	const row = stmt.get(id) as MessageRow | undefined;
 	return row ? rowToMessageStats(row) : null;
 }
 
 /**
  * Get daily cost time series data for the last N days, broken down by model.
  */
+interface CostSeriesRow {
+	bucket: number;
+	model: string;
+	provider: string;
+	cost: number;
+	cost_input: number;
+	cost_output: number;
+	cost_cache_read: number;
+	cost_cache_write: number;
+	requests: number;
+}
+
 export function getCostTimeSeries(days = 90, cutoff?: number | null): CostTimeSeriesPoint[] {
 	if (!db) return [];
 
@@ -1020,7 +1102,7 @@ export function getCostTimeSeries(days = 90, cutoff?: number | null): CostTimeSe
 		ORDER BY bucket ASC
 	`);
 
-	const rows = hasCutoff ? (stmt.all(seriesCutoff) as any[]) : (stmt.all() as any[]);
+	const rows = hasCutoff ? (stmt.all(seriesCutoff) as CostSeriesRow[]) : (stmt.all() as CostSeriesRow[]);
 	return rows.map(row => ({
 		timestamp: row.bucket,
 		model: row.model,
@@ -1321,7 +1403,7 @@ export function updateUserMessageLinks(links: UserMessageLink[]): number {
 	return updated;
 }
 
-const UNKNOWN_MODEL = "unknown";
+export const UNKNOWN_MODEL = "unknown";
 
 interface BehaviorSeriesRow {
 	bucket: number;

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -1403,7 +1403,7 @@ export function updateUserMessageLinks(links: UserMessageLink[]): number {
 	return updated;
 }
 
-export const UNKNOWN_MODEL = "unknown";
+const UNKNOWN_MODEL = "unknown";
 
 interface BehaviorSeriesRow {
 	bucket: number;

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored the fluent `this` return of `Component.setIgnoreTight` (declared as polymorphic `this` on the interface) that was lost when its `any` return type was removed, so consumers chaining or retaining the call keep typechecking.
+
 ## [17.2.5] - 2026-08-03
 
 ### Fixed

--- a/packages/tui/bench/parse-key.ts
+++ b/packages/tui/bench/parse-key.ts
@@ -97,12 +97,12 @@ console.log(`\nSpeedup: ${(jsTime / nativeTime).toFixed(2)}x`);
 
 bench("js/parse+match", () => {
 	for (const sample of samples) {
-		js.matchesKey(sample.data, sample.expected as any);
+		js.matchesKey(sample.data, sample.expected as js.KeyId);
 	}
 });
 
 bench("native/match", () => {
 	for (const sample of samples) {
-		native.matchesKey(sample.data, sample.expected as any);
+		native.matchesKey(sample.data, sample.expected as native.KeyId);
 	}
 });

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -169,8 +169,9 @@ export interface Component {
 	invalidate?(): void;
 	/**
 	 * Optional hook to set whether this component ignores tight layout mode.
+	 * Returns `this` so implementations keep their fluent chaining surface.
 	 */
-	setIgnoreTight?(ignore: boolean): void;
+	setIgnoreTight?(ignore: boolean): this;
 
 	/**
 	 * Optional teardown. Called when the component is permanently removed from

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -170,7 +170,7 @@ export interface Component {
 	/**
 	 * Optional hook to set whether this component ignores tight layout mode.
 	 */
-	setIgnoreTight?(ignore: boolean): any;
+	setIgnoreTight?(ignore: boolean): void;
 
 	/**
 	 * Optional teardown. Called when the component is permanently removed from

--- a/packages/tui/test/image-test.ts
+++ b/packages/tui/test/image-test.ts
@@ -3,7 +3,7 @@ import { Image } from "@oh-my-pi/pi-tui/components/image";
 import { Spacer } from "@oh-my-pi/pi-tui/components/spacer";
 import { Text } from "@oh-my-pi/pi-tui/components/text";
 import { ProcessTerminal } from "@oh-my-pi/pi-tui/terminal";
-import { TUI } from "@oh-my-pi/pi-tui/tui";
+import { type Component, TUI } from "@oh-my-pi/pi-tui/tui";
 
 const testImagePath = Bun.argv[2] || "/tmp/test-image.png";
 
@@ -43,7 +43,8 @@ if (dims) {
 tui.addChild(new Spacer(1));
 tui.addChild(new Text("Press Ctrl+C to exit", 1, 0));
 
-const editor = {
+const editor: Component = {
+	render: () => [],
 	handleInput(data: string) {
 		if (data.charCodeAt(0) === 3) {
 			tui.stop();
@@ -52,5 +53,5 @@ const editor = {
 	},
 };
 
-tui.setFocus(editor as any);
+tui.setFocus(editor);
 tui.start();

--- a/packages/tui/test/tight-layout.test.ts
+++ b/packages/tui/test/tight-layout.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, expectTypeOf, it } from "bun:test";
 import { Box } from "../src/components/box";
 import { Editor } from "../src/components/editor";
 import { Markdown } from "../src/components/markdown";
 import { Text } from "../src/components/text";
+import { type Component, Container } from "../src/tui";
 import { setTuiTight } from "../src/utils";
 import { defaultEditorTheme, defaultMarkdownTheme } from "./test-themes";
 
@@ -87,5 +88,30 @@ describe("TUI Tight Layout option", () => {
 		const linesTight = mdComponent.render(15);
 		// It should still have 1 char padding (space before Hello)
 		expect(linesTight[0]!.startsWith(" Hello")).toBe(true);
+	});
+
+	it("keeps setIgnoreTight's fluent `this` return on the Component contract", () => {
+		// Type-level contract: the interface returns polymorphic `this`, so
+		// consumers that chain or retain the result keep typechecking, and each
+		// shipped implementation hands back its own instance.
+		function retained<C extends Component>(component: C): C {
+			return component.setIgnoreTight?.(true) ?? component;
+		}
+
+		const textComponent = new Text("Hello", 1, 0);
+		expectTypeOf(textComponent.setIgnoreTight(true)).toEqualTypeOf<Text>();
+		expect(textComponent.setIgnoreTight(true)).toBe(textComponent);
+
+		const boxComponent = new Box(1, 0);
+		expectTypeOf(boxComponent.setIgnoreTight(true)).toEqualTypeOf<Box>();
+		expect(boxComponent.setIgnoreTight(true)).toBe(boxComponent);
+
+		const mdComponent = new Markdown("Hello", 1, 0, defaultMarkdownTheme);
+		expectTypeOf(mdComponent.setIgnoreTight(true)).toEqualTypeOf<Markdown>();
+		expect(mdComponent.setIgnoreTight(true)).toBe(mdComponent);
+
+		const container = new Container();
+		expectTypeOf(container.setIgnoreTight(true)).toEqualTypeOf<Container>();
+		expect(retained(container)).toBe(container);
 	});
 });

--- a/packages/typescript-edit-benchmark/src/mutations.ts
+++ b/packages/typescript-edit-benchmark/src/mutations.ts
@@ -127,7 +127,7 @@ function parseCode(code: string): Parsed | null {
 t.VISITOR_KEYS.TSTypeCastExpression = ["expression", "typeAnnotation"];
 {
 	const { generatorInfosMap } = require("@babel/generator/lib/nodes") as {
-		generatorInfosMap: Map<string, [any, number, unknown]>;
+		generatorInfosMap: Map<string, [unknown, number, unknown]>;
 	};
 	if (!generatorInfosMap.has("TSTypeCastExpression")) {
 		const tsAs = generatorInfosMap.get("TSAsExpression");


### PR DESCRIPTION
## Summary
- enable Biome's `suspicious/noExplicitAny` rule as an error
- replace explicit `any` across source and tests with concrete types or checked `unknown` boundaries
- preserve heterogeneous tool composition with method bivariance and an erased `AnyAgentTool` alias
- keep raw scalar tool arguments intact across ACP session replay
- retain narrow ignores only where omptype tests assert the schema's actual `any` contract

## Verification
- `CI=false bun check`
- `bun x biome lint --only=suspicious/noExplicitAny --max-diagnostics=1000 packages scripts`
- `bun packages/coding-agent/src/cli.ts --smoke-test`
- changed agent suites: 194 pass
- changed AI suites: 306 pass, 118 skip
- changed omptype suites: 182 pass, 2 todo
- ACP agent suite: 59 pass
- agent-loop suite: 100 pass
- build-context suite: 30 pass
- focused stats fork-dedup rerun: 4 pass
- independent review: clean

The repo-wide `bun test` was also attempted. It completed with 20,585 passes and 120 failures dominated by existing 5-second timeout/global-isolation failures; the changed contracts above were rerun in focused suites.

No dependency or runtime configuration change.