### PR TITLE
fix(ai): respect explicit Codex usage allowance

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Codex usage telemetry blocking explicitly allowed ChatGPT Team credentials when a weekly `used_percent` rounded to 100, which could route multi-account sessions to an actually exhausted sibling instead ([#7617](https://github.com/can1357/oh-my-pi/issues/7617)).
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3708,7 +3708,7 @@ export class AuthStorage {
 	}
 
 	#isUsageLimitExhausted(limit: UsageLimit): boolean {
-		if (limit.status === "exhausted") return true;
+		if (limit.status !== undefined && limit.status !== "unknown") return limit.status === "exhausted";
 		const amount = limit.amount;
 		if (amount.usedFraction !== undefined && amount.usedFraction >= 1) return true;
 		if (amount.remainingFraction !== undefined && amount.remainingFraction <= 0) return true;

--- a/packages/ai/src/usage/openai-codex.ts
+++ b/packages/ai/src/usage/openai-codex.ts
@@ -263,11 +263,10 @@ function buildUsageAmount(window: ParsedUsageWindow): UsageAmount {
 	};
 }
 
-function buildUsageStatus(usedFraction?: number, limitReached?: boolean): UsageLimit["status"] {
-	if (limitReached) return "exhausted";
-	if (usedFraction === undefined) return "unknown";
-	if (usedFraction >= 1) return "exhausted";
-	if (usedFraction >= 0.9) return "warning";
+function buildUsageStatus(args: { usedFraction?: number; explicitlyAllowed: boolean }): UsageLimit["status"] {
+	if (args.usedFraction === undefined) return "unknown";
+	if (args.usedFraction >= 1) return args.explicitlyAllowed ? "warning" : "exhausted";
+	if (args.usedFraction >= 0.9) return "warning";
 	return "ok";
 }
 
@@ -276,6 +275,8 @@ function buildUsageLimit(args: {
 	window: ParsedUsageWindow;
 	accountId?: string;
 	planType?: string;
+	allowed?: boolean;
+	limitReached?: boolean;
 	nowMs: number;
 }): UsageLimit {
 	const usageWindow = buildUsageWindow(args.window, args.key, args.nowMs);
@@ -290,16 +291,14 @@ function buildUsageLimit(args: {
 		},
 		window: usageWindow,
 		amount,
-		// Each chat window's status reflects ONLY its own usage. The account-level
-		// `rate_limit.limit_reached` flag is intentionally not applied here: Codex
-		// returns a single shared flag for the whole account, so threading it into
-		// both the primary (5h) and secondary (weekly) windows marked a window with
-		// real headroom `exhausted` purely because a different window (or a separate
-		// metered feature) was at its limit, which over-blocked sibling accounts
-		// during credential selection. `usedFraction >= 1` already marks a window
-		// that is genuinely full; a real enforced limit not reflected in
-		// `used_percent` is caught when the live request returns usage_limit_reached.
-		status: buildUsageStatus(amount.usedFraction),
+		// The shared account-level rejection flag cannot identify which window
+		// is binding, but an explicit positive verdict applies to both windows.
+		// Preserve 100% as a warning when Codex still allows requests; live
+		// usage_limit_reached responses remain authoritative for blocking.
+		status: buildUsageStatus({
+			usedFraction: amount.usedFraction,
+			explicitlyAllowed: args.allowed === true && args.limitReached === false,
+		}),
 	};
 }
 function additionalLimitSlug(args: { limitName?: string; meteredFeature?: string }): string {
@@ -331,6 +330,8 @@ function buildAdditionalUsageLimit(args: {
 	accountId?: string;
 	limitName?: string;
 	meteredFeature?: string;
+	allowed?: boolean;
+	limitReached?: boolean;
 	nowMs: number;
 }): UsageLimit {
 	const usageWindow = buildUsageWindow(args.window, args.key, args.nowMs);
@@ -348,10 +349,12 @@ function buildAdditionalUsageLimit(args: {
 		},
 		window: usageWindow,
 		amount,
-		// The additional meter exposes one account-level flag for both windows.
-		// Status must follow this window's own usage or a full weekly meter marks
-		// the shorter window exhausted and schedules a premature retry.
-		status: buildUsageStatus(amount.usedFraction),
+		// A positive meter verdict is authoritative even when the advisory
+		// percentage rounds to 100; negative shared verdicts remain window-local.
+		status: buildUsageStatus({
+			usedFraction: amount.usedFraction,
+			explicitlyAllowed: args.allowed === true && args.limitReached === false,
+		}),
 	};
 }
 
@@ -449,6 +452,8 @@ export const openaiCodexUsageProvider: UsageProvider = {
 					window: parsed.primary,
 					accountId,
 					planType,
+					allowed: parsed.allowed,
+					limitReached: parsed.limitReached,
 					nowMs,
 				}),
 			);
@@ -460,6 +465,8 @@ export const openaiCodexUsageProvider: UsageProvider = {
 					window: parsed.secondary,
 					accountId,
 					planType,
+					allowed: parsed.allowed,
+					limitReached: parsed.limitReached,
 					nowMs,
 				}),
 			);
@@ -478,6 +485,8 @@ export const openaiCodexUsageProvider: UsageProvider = {
 						accountId,
 						limitName: extra.limitName,
 						meteredFeature: extra.meteredFeature,
+						allowed: extra.allowed,
+						limitReached: extra.limitReached,
 						nowMs,
 					}),
 				);
@@ -492,6 +501,8 @@ export const openaiCodexUsageProvider: UsageProvider = {
 						accountId,
 						limitName: extra.limitName,
 						meteredFeature: extra.meteredFeature,
+						allowed: extra.allowed,
+						limitReached: extra.limitReached,
 						nowMs,
 					}),
 				);

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -418,6 +418,37 @@ describe("AuthStorage codex oauth ranking", () => {
 		expect(apiKey).toBe("api-acct-healthy");
 	});
 
+	test("selects an explicitly allowed 100% Team account over a rejected exhausted sibling", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-exhausted", "exhausted@example.com") },
+			{ type: "oauth", ...createCredential("acct-team", "team@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-exhausted",
+			createCodexUsageReport({
+				accountId: "acct-exhausted",
+				primary: { usedFraction: 1, resetInMs: 3 * 24 * HOUR_MS },
+				secondary: { usedFraction: 1, resetInMs: 3 * 24 * HOUR_MS },
+				metadata: { allowed: false, limitReached: true, planType: "prolite" },
+			}),
+		);
+		const teamReport = createCodexUsageReport({
+			accountId: "acct-team",
+			primary: { usedFraction: 0.2, resetInMs: HOUR_MS },
+			secondary: { usedFraction: 1, resetInMs: 6 * 24 * HOUR_MS },
+			metadata: { allowed: true, limitReached: false, planType: "team" },
+		});
+		const teamSecondary = teamReport.limits.find(limit => limit.id === "openai-codex:secondary");
+		if (!teamSecondary) throw new Error("expected Team weekly usage limit");
+		teamSecondary.status = "warning";
+		usageByAccount.set("acct-team", teamReport);
+
+		expect(await authStorage.getApiKey("openai-codex", "allowed-team-at-100-percent")).toBe("api-acct-team");
+	});
+
 	test("temporarily blocks only the exhausted Codex OAuth credential after a quota 429", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 

--- a/packages/ai/test/openai-codex-usage.test.ts
+++ b/packages/ai/test/openai-codex-usage.test.ts
@@ -67,6 +67,24 @@ describe("openai-codex usage parser", () => {
 		expect(main?.[0].amount.usedFraction).toBeCloseTo(0.04, 5);
 	});
 
+	it("keeps an explicitly allowed Team window usable at 100% reported usage", async () => {
+		const payload = makePayload();
+		payload.plan_type = "team";
+		payload.rate_limit.secondary_window.used_percent = 100;
+		const report = await openaiCodexUsageProvider.fetchUsage(
+			{
+				provider: "openai-codex",
+				credential: { type: "oauth", accessToken: accessTokenFixture, accountId: "acct-1", email: "u@example.com" },
+			},
+			{ fetch: fakeFetch(payload) },
+		);
+
+		const secondary = report?.limits.find(limit => limit.id === "openai-codex:secondary");
+		expect(secondary?.amount.usedFraction).toBe(1);
+		expect(secondary?.status).toBe("warning");
+		expect(report?.metadata).toMatchObject({ planType: "team", allowed: true, limitReached: false });
+	});
+
 	it("surfaces additional_rate_limits as spark UsageLimit entries the widget can detect", async () => {
 		const report = await openaiCodexUsageProvider.fetchUsage(
 			{


### PR DESCRIPTION
## Repro
A ChatGPT Team usage payload with `allowed: true`, `limit_reached: false`, and weekly `used_percent: 100` produced an exhausted normalized limit; when paired with a genuinely exhausted credential resetting sooner, selection chose that rejected sibling. Reproduced with `bun test packages/ai/test/openai-codex-usage.test.ts packages/ai/test/auth-storage-codex-selection.test.ts`, which failed both the parser verdict and end-to-end credential choice before the fix.

## Cause
`buildUsageStatus` in `packages/ai/src/usage/openai-codex.ts` treated every `usedFraction >= 1` as exhausted despite the meter's explicit positive verdict. `AuthStorage.#isUsageLimitExhausted` in `packages/ai/src/auth-storage.ts` then re-derived exhaustion from numeric amounts even when the normalized status said otherwise, persisted the weekly reset as a block, and the all-blocked comparator selected the sibling with the earlier reset.

## Fix
- Preserve the reported 100% amount but normalize it to `warning` when the same Codex meter explicitly reports `allowed: true` and `limit_reached: false`.
- Make explicit normalized `ok`, `warning`, and `exhausted` statuses authoritative in credential blocking, retaining numeric fallback for absent or unknown statuses.
- Cover both raw Team payload parsing and the exhausted-sibling selection regression.
- Document the fix in the AI package changelog.

## Verification
`bun test packages/ai/test/openai-codex-usage.test.ts packages/ai/test/auth-storage-codex-selection.test.ts` — 76 passed, 0 failed. `cd packages/ai && bun run check` — passed. Pre-publish `bun run fix` and `bun check` also passed through the branch gate.

Fixes #7617