### PR TITLE
fix(coding-agent): explicit model:default resolves to the agent's own model

### DIFF
--- a/docs/tools/eval.md
+++ b/docs/tools/eval.md
@@ -151,7 +151,7 @@ Runs one subagent through `runStructuredSubagent(...)`:
 
 - JS supports the preferred `await agent(prompt, { agent?, model?, label?, schema?, schemaMode?, isolated?, apply?, merge?, handle? })`; legacy positional slots are still implemented.
 - Python/Ruby/Julia use keyword arguments (`schema_mode` outside JS).
-- `agent` defaults from the current spawn policy. `model` may pin a selector/fallback chain. `schema` overrides agent/session schemas; `schemaMode`/`schema_mode` chooses `permissive` or `strict`.
+- `agent` defaults from the current spawn policy. `model` may pin a selector/fallback chain; `model: "default"` (or `"*"`) means the selected agent's own default model — the same as omitting `model` — never the parent session model. `schema` overrides agent/session schemas; `schemaMode`/`schema_mode` chooses `permissive` or `strict`.
 - `isolated` requests isolation. `apply` controls whether captured changes are integrated; `merge=false` selects patch mode while the normal setting controls branch mode.
 - `handle=true` returns `{ text, output, handle, id, agent }`, optional parsed `data`, and isolation metadata instead of only output/data.
 - Eval subagents are one-shot (`keepAlive=false`), are unregistered/disposed after completion, and **do not share the caller's eval executor** (`shareEvalSession=false`). Their code mutations therefore do not appear in the caller's retained VM/kernel.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an explicit `model: "default"` selector on subagent spawns (eval `agent()`, task internals) silently resolving to the parent session model instead of the selected agent's frontmatter model, which broke project agent routing ([#6438](https://github.com/can1357/oh-my-pi/issues/6438)).
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/coding-agent/src/eval/agent-bridge.ts
+++ b/packages/coding-agent/src/eval/agent-bridge.ts
@@ -2,6 +2,7 @@
  * Host-side handler for the eval `agent()` helper.
  */
 import { type } from "@oh-my-pi/omptype";
+import { DEFAULT_MODEL_ROLE_ALIAS, formatModelRoleAlias, LEGACY_MODEL_ROLE_ALIAS_PREFIX } from "../config/model-roles";
 import {
 	buildStructuredSubagentRecoveryHint,
 	runStructuredSubagent,
@@ -86,6 +87,32 @@ function trimToUndefined(value: string | undefined): string | undefined {
 	return trimmed ? trimmed : undefined;
 }
 
+/**
+ * The `model` override the eval agent() helper forwards to the subagent.
+ * A sole "default" selector ("default", "*", "@default", "pi/default")
+ * means "this agent's default model" — identical to omitting the override
+ * (issue #6438) — so it is dropped here instead of being expanded through
+ * the parent session's default role, which would silently discard the
+ * agent's frontmatter model.
+ */
+function normalizeAgentModel(model: string | string[] | undefined): string | string[] | undefined {
+	const patterns = Array.isArray(model)
+		? model
+		: model
+				?.split(",")
+				.map(pattern => pattern.trim())
+				.filter(Boolean);
+	if (!patterns || patterns.length === 0) return undefined;
+	if (patterns.length !== 1) return patterns;
+	const pattern = patterns[0]!;
+	const isDefaultSelector =
+		pattern === "default" ||
+		pattern === formatModelRoleAlias("default") ||
+		pattern === DEFAULT_MODEL_ROLE_ALIAS ||
+		pattern === `${LEGACY_MODEL_ROLE_ALIAS_PREFIX}default`;
+	return isDefaultSelector ? undefined : pattern;
+}
+
 function emitProgressStatus(emitStatus: ((event: JsStatusEvent) => void) | undefined, progress: AgentProgress): void {
 	if (!emitStatus) return;
 	const preview = (progress.assignment ?? progress.task ?? "").split("\n")[0]?.slice(0, 120);
@@ -148,7 +175,7 @@ export async function runEvalAgent(args: unknown, options: EvalAgentBridgeOption
 					invocationKind: "eval",
 					assignment: parsed.prompt,
 					...(parsed.agent !== undefined ? { agent: parsed.agent } : {}),
-					...(parsed.model !== undefined ? { model: parsed.model } : {}),
+					...(normalizeAgentModel(parsed.model) !== undefined ? { model: normalizeAgentModel(parsed.model) } : {}),
 					...(Object.hasOwn(parsed, "schema") ? { outputSchema: parsed.schema } : {}),
 					...(parsed.schemaMode !== undefined ? { schemaMode: parsed.schemaMode } : {}),
 					...(parsed.label !== undefined ? { identity: { label: parsed.label } } : {}),

--- a/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
+++ b/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
@@ -253,10 +253,61 @@ describe("runEvalAgent", () => {
 		expect(runSpy).toHaveBeenCalledTimes(1);
 	});
 
+	it("resolves an explicit model: default to the agent frontmatter model (issue #6438)", async () => {
+		const frontmatterAgent = {
+			name: "task",
+			description: "Task agent",
+			systemPrompt: "Run the task.",
+			source: "bundled",
+			spawns: "*",
+			model: ["opencode-go/deepseek-v4-flash"],
+		} satisfies AgentDefinition;
+		mockAgents([frontmatterAgent]);
+		const runSpy = vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async options => singleResult(options));
+
+		await runEvalAgent(
+			{ prompt: "work", model: "default" },
+			{
+				session: makeSession({
+					settings: Settings.isolated({
+						"async.enabled": false,
+						"task.isolation.mode": "none",
+						"task.enableLsp": true,
+						modelRoles: { default: "openai-codex/gpt-5.6-terra" },
+					}),
+				}),
+			},
+		);
+
+		const options = runSpy.mock.calls[0]?.[0];
+		expect(options?.modelOverride).toEqual(["opencode-go/deepseek-v4-flash"]);
+	});
+
+	it("keeps a non-default model override on eval agent()", async () => {
+		mockAgents();
+		const runSpy = vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async options => singleResult(options));
+
+		await runEvalAgent(
+			{ prompt: "work", model: "@smol" },
+			{
+				session: makeSession({
+					settings: Settings.isolated({
+						"async.enabled": false,
+						"task.isolation.mode": "none",
+						"task.enableLsp": true,
+						modelRoles: { default: "openai-codex/gpt-5.6-terra", smol: "local/llama" },
+					}),
+				}),
+			},
+		);
+
+		const options = runSpy.mock.calls[0]?.[0];
+		expect(options?.modelOverride).toEqual(["local/llama"]);
+	});
+
 	it("runs plan-mode eval agents with an attenuated policy", async () => {
 		mockAgents([{ ...taskAgent, tools: ["ast_grep", "write"] }]);
 		const runSpy = vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async options => singleResult(options));
-
 		await expect(
 			runEvalAgent({ prompt: "hello" }, { session: makeSession({ planMode: true }) }),
 		).resolves.toMatchObject({


### PR DESCRIPTION
Closes #6438

## Problem

An explicit `model: "default"` selector on the eval `agent()` helper resolved to the **parent session model** instead of the selected agent's frontmatter model. Orchestrators/models that emit `model: "default"` (intending "use the configured default for this agent") silently lost `.omp/agents/*.md` routing, defeating project agent model configuration.

## Change

The eval `agent()` bridge (`src/eval/agent-bridge.ts`) now treats a **sole** `"default"` selector (`"default"`, `"*"`, `"@default"`, `"pi/default"`) as identical to omitting the override: the agent's own frontmatter model wins, with the normal fallback chain (configured `modelRoles.task`, session-inherited patterns, priority defaults) applying exactly as if `model` were absent.

- Scoped to the eval bridge only — shared `resolveAgentModelPatterns` resolution and `task.agentModelOverrides` precedence are untouched (settings overrides keep documented precedence).
- Non-default selectors (`@smol`, a literal `provider/model`, fallback chains, mixed lists) are unchanged.
- The `task` tool's per-call `model` was already removed in `9f8aa87dbf`; this fixes the surviving per-call override surface.

## Verification

- New regression tests in `agent-bridge-policy.test.ts`: `model: "default"` → `modelOverride` = agent frontmatter model; `model: "@smol"` still resolves as an override.
- Full suite: 644 pass / 2 pre-existing skips across eval bridges, model-resolver, bundled-agent-parsing, and all task tests.
- `bun check` (biome + tsgo) clean.
