### PR TITLE
fix(coding-agent/eval): remove per-call model override from agent()

### DIFF
--- a/docs/python-repl.md
+++ b/docs/python-repl.md
@@ -146,7 +146,7 @@ The backend settings `eval.py` / `eval.js` default to `true`; `eval.rb` / `eval.
 
 The tool's session-scoped schema lists only enabled runtimes. If Python preflight fails while another runtime is enabled, `eval` remains available for that runtime and a `py` call reports a Python-backend availability error with enabled alternatives.
 
-Python prelude helpers include `agent(prompt, *, agent="task", model=None, label=None, schema=None, schema_mode=None, isolated=None, apply=None, merge=None, handle=False)`. It synchronously calls the host bridge and returns final text, or parsed data when `schema` is supplied. `schema_mode` selects permissive or strict structured-output handling; the isolation/apply/merge flags control task worktree behavior. With `handle=True`, it returns a DAG node dict (`{"text", "output", "handle", "id", "agent"}`) whose handle is the recoverable `agent://<id>` URI; parsed output is also stored under `"data"` when available.
+Python prelude helpers include `agent(prompt, *, agent="task", label=None, schema=None, schema_mode=None, isolated=None, apply=None, merge=None, handle=False)`. It synchronously calls the host bridge and returns final text, or parsed data when `schema` is supplied. `schema_mode` selects permissive or strict structured-output handling; the isolation/apply/merge flags control task worktree behavior. With `handle=True`, it returns a DAG node dict (`{"text", "output", "handle", "id", "agent"}`) whose handle is the recoverable `agent://<id>` URI; parsed output is also stored under `"data"` when available.
 
 ## Execution flow and cancellation/timeout
 

--- a/docs/tools/eval.md
+++ b/docs/tools/eval.md
@@ -149,9 +149,9 @@ A stateless, tool-free one-shot model call:
 
 Runs one subagent through `runStructuredSubagent(...)`:
 
-- JS supports the preferred `await agent(prompt, { agent?, model?, label?, schema?, schemaMode?, isolated?, apply?, merge?, handle? })`; legacy positional slots are still implemented.
+- JS supports the preferred `await agent(prompt, { agent?, label?, schema?, schemaMode?, isolated?, apply?, merge?, handle? })`; legacy positional slots are still implemented.
 - Python/Ruby/Julia use keyword arguments (`schema_mode` outside JS).
-- `agent` defaults from the current spawn policy. `model` may pin a selector/fallback chain. `schema` overrides agent/session schemas; `schemaMode`/`schema_mode` chooses `permissive` or `strict`.
+- `agent` defaults from the current spawn policy; the selected agent's frontmatter model and settings always apply (there is no per-call model override — `model` is not accepted). `schema` overrides agent/session schemas; `schemaMode`/`schema_mode` chooses `permissive` or `strict`.
 - `isolated` requests isolation. `apply` controls whether captured changes are integrated; `merge=false` selects patch mode while the normal setting controls branch mode.
 - `handle=true` returns `{ text, output, handle, id, agent }`, optional parsed `data`, and isolation metadata instead of only output/data.
 - Eval subagents are one-shot (`keepAlive=false`), are unregistered/disposed after completion, and **do not share the caller's eval executor** (`shareEvalSession=false`). Their code mutations therefore do not appear in the caller's retained VM/kernel.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Removed the per-call `model` override from the eval `agent()` helper (all runtimes), completing the earlier task-tool removal (`9f8aa87dbf`). Subagents always use their selected agent's frontmatter model and settings; a legacy `model` argument is silently ignored, so an explicit `model: "default"` can no longer route children onto the parent session model ([#6438](https://github.com/can1357/oh-my-pi/issues/6438)).
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/coding-agent/src/eval/agent-bridge.ts
+++ b/packages/coding-agent/src/eval/agent-bridge.ts
@@ -23,7 +23,6 @@ export const EVAL_AGENT_BRIDGE_NAME = "__agent__";
 const agentArgsSchema = type({
 	prompt: "string>0",
 	"agent?": "string>0",
-	"model?": "string>0|string>0[]",
 	"label?": "string",
 	"schema?": "unknown",
 	"schemaMode?": "'permissive' | 'strict'",
@@ -31,12 +30,12 @@ const agentArgsSchema = type({
 	"apply?": "boolean",
 	"merge?": "boolean",
 	"handle?": "boolean",
+	"+": "delete",
 });
 
 interface EvalAgentArgs {
 	prompt: string;
 	agent?: string;
-	model?: string | string[];
 	label?: string;
 	schema?: unknown;
 	schemaMode?: StructuredSubagentSchemaMode;
@@ -148,7 +147,6 @@ export async function runEvalAgent(args: unknown, options: EvalAgentBridgeOption
 					invocationKind: "eval",
 					assignment: parsed.prompt,
 					...(parsed.agent !== undefined ? { agent: parsed.agent } : {}),
-					...(parsed.model !== undefined ? { model: parsed.model } : {}),
 					...(Object.hasOwn(parsed, "schema") ? { outputSchema: parsed.schema } : {}),
 					...(parsed.schemaMode !== undefined ? { schemaMode: parsed.schemaMode } : {}),
 					...(parsed.label !== undefined ? { identity: { label: parsed.label } } : {}),

--- a/packages/coding-agent/src/eval/jl/prelude.jl
+++ b/packages/coding-agent/src/eval/jl/prelude.jl
@@ -519,13 +519,10 @@ function completion(prompt::String; model="default", system=nothing, schema=noth
     return schema === nothing ? text : Main.json_parse(string(text))
 end
 
-function agent(prompt::String; agent="task", model=nothing, label=nothing, schema=nothing, schema_mode=nothing, isolated=nothing, apply=nothing, merge=nothing, handle=false, kwargs...)
+function agent(prompt::String; agent="task", label=nothing, schema=nothing, schema_mode=nothing, isolated=nothing, apply=nothing, merge=nothing, handle=false, kwargs...)
     args_dict = Dict{String, Any}("prompt" => prompt)
     if agent !== nothing
         args_dict["agent"] = agent
-    end
-    if model !== nothing
-        args_dict["model"] = model
     end
     if label !== nothing
         args_dict["label"] = label

--- a/packages/coding-agent/src/eval/jl/prelude.jl
+++ b/packages/coding-agent/src/eval/jl/prelude.jl
@@ -542,6 +542,9 @@ function agent(prompt::String; agent="task", label=nothing, schema=nothing, sche
     if merge !== nothing
         args_dict["merge"] = Bool(merge)
     end
+    if haskey(kwargs, :model)
+        error("agent() no longer accepts a per-call model override; the selected agent's frontmatter model is used")
+    end
     handle_result = handle
     for (k, v) in kwargs
         args_dict[string(k)] = v

--- a/packages/coding-agent/src/eval/js/shared/prelude.txt
+++ b/packages/coding-agent/src/eval/js/shared/prelude.txt
@@ -104,8 +104,8 @@ if (!globalThis.__omp_js_prelude_loaded__) {
 			"agent",
 			opts,
 			rest,
-			["agent", "model", "label", "schema", "isolated", "apply", "merge", "schemaMode"],
-			"{ agent, model, label, schema, isolated, apply, merge, schemaMode, handle }",
+			["agent", "label", "schema", "isolated", "apply", "merge", "schemaMode"],
+			"{ agent, label, schema, isolated, apply, merge, schemaMode, handle }",
 		);
 		const { handle, ...callArgs } = o;
 		const res = await globalThis.__omp_call_tool__("__agent__", { prompt, ...callArgs, handle: Boolean(handle) });

--- a/packages/coding-agent/src/eval/py/prelude.py
+++ b/packages/coding-agent/src/eval/py/prelude.py
@@ -488,7 +488,6 @@ if "__omp_prelude_loaded__" not in globals():
         prompt,
         *,
         agent="task",
-        model=None,
         label=None,
         schema=None,
         schema_mode=None,
@@ -506,8 +505,6 @@ if "__omp_prelude_loaded__" not in globals():
         args = {"prompt": prompt}
         if agent is not None:
             args["agent"] = agent
-        if model is not None:
-            args["model"] = model
         if label is not None:
             args["label"] = label
         if schema is not None:

--- a/packages/coding-agent/src/eval/rb/prelude.rb
+++ b/packages/coding-agent/src/eval/rb/prelude.rb
@@ -392,10 +392,9 @@ unless defined?($__omp_prelude_loaded) && $__omp_prelude_loaded
     schema.nil? ? text : JSON.parse(text)
   end
 
-  def agent(prompt, agent: "task", model: nil, label: nil, schema: nil, schema_mode: nil, isolated: nil, apply: nil, merge: nil, handle: false)
+  def agent(prompt, agent: "task", label: nil, schema: nil, schema_mode: nil, isolated: nil, apply: nil, merge: nil, handle: false)
     args = { "prompt" => prompt }
     args["agent"] = agent unless agent.nil?
-    args["model"] = model unless model.nil?
     args["label"] = label unless label.nil?
     args["schema"] = schema unless schema.nil?
     args["schemaMode"] = schema_mode unless schema_mode.nil?

--- a/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
+++ b/packages/coding-agent/test/eval/agent-bridge-policy.test.ts
@@ -290,10 +290,7 @@ describe("runEvalAgent", () => {
 			}),
 		});
 
-		await runEvalAgent(
-			{ prompt: " hello ", label: "My Agent", model: "p/override", schema },
-			{ session, signal: abortController.signal },
-		);
+		await runEvalAgent({ prompt: " hello ", label: "My Agent", schema }, { session, signal: abortController.signal });
 		await runEvalAgent({ prompt: "plain" }, { session });
 
 		const firstOptions = runSpy.mock.calls[0]?.[0];
@@ -306,9 +303,25 @@ describe("runEvalAgent", () => {
 		expect(firstOptions.outputSchemaOverridesAgent).toBe(true);
 		expect(firstOptions.assignment).toBe("hello");
 		expect(firstOptions.description).toBe("My Agent");
-		expect(firstOptions.modelOverride).toEqual(["p/override"]);
+		// No per-call override: the agent's own frontmatter model applies.
+		expect(firstOptions.modelOverride).toEqual(["p/current"]);
 		expect(secondOptions.outputSchema).toBeUndefined();
 		expect(secondOptions.outputSchemaOverridesAgent).toBeUndefined();
+	});
+
+	it("drops a per-call model argument on agent() (removed, issue #6438)", async () => {
+		mockAgents();
+		const runSpy = vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async options => singleResult(options));
+
+		// The schema strips unknown keys; a legacy `model` argument is silently
+		// discarded so resolution is identical to omitting it — the agent's own
+		// frontmatter model applies (issue #6438).
+		await runEvalAgent({ prompt: "work", model: "default" }, { session: makeSession() });
+		await runEvalAgent({ prompt: "work" }, { session: makeSession() });
+
+		const withModel = runSpy.mock.calls[0]?.[0];
+		const withoutModel = runSpy.mock.calls[1]?.[0];
+		expect(withModel?.modelOverride).toEqual(withoutModel?.modelOverride);
 	});
 	it("returns host-parsed data for caller, agent, and inherited schemas", async () => {
 		const agentSchema = { type: "object" };

--- a/packages/coding-agent/test/eval/prelude-agent.test.ts
+++ b/packages/coding-agent/test/eval/prelude-agent.test.ts
@@ -66,12 +66,11 @@ describe("eval js agent() handle", () => {
 		) => Promise<unknown>;
 		const schema = { type: "object", properties: { ok: { type: "boolean" } } };
 
-		await positionalAgent("scout", "reviewer", "p/model", "Legacy", schema, true, false, true, "strict");
+		await positionalAgent("scout", "reviewer", "Legacy", schema, true, false, true, "strict");
 
 		expect(seenArgs).toEqual({
 			prompt: "scout",
 			agent: "reviewer",
-			model: "p/model",
 			label: "Legacy",
 			schema,
 			isolated: true,


### PR DESCRIPTION
Closes #6438

## Problem

An explicit `model: "default"` selector on the eval `agent()` helper resolved to the **parent session model** instead of the selected agent's frontmatter model — silently defeating `.omp/agents/*.md` routing.

Per [review guidance on #7619](https://github.com/can1357/oh-my-pi/pull/7619#discussion_r3707417387) and the maintainer's own work history, the consistent fix is not to reinterpret `default`, but to **remove the per-call override entirely**.

## Why removal, not reinterpretation

- The maintainer already removed per-call `model` from the `task` tool and the model-facing `agent()` docs/prompt in `9f8aa87dbf` ("removed per-call model override from task tool") — the eval runtime and preludes were simply left behind, and a later docs chore re-advertised `model`.
- Reinterpreting `default` at shared resolution would break deliberate highest-priority overrides like `task.agentModelOverrides.custom: "@default"` (vibe/task routing) — the blocking concern from the first review round.
- Removing the surface eliminates the foot-gun entirely: subagents always use their selected agent's frontmatter model and settings.

## Change

- **`agent-bridge.ts`**: `model?` removed from `agentArgsSchema` and the request forward; `"+": "delete"` added so a legacy `model` argument is silently stripped (same contract as the task wire schemas). `completion()` is untouched — its `model` tier selector stays.
- **JS/Python/Ruby/Julia preludes**: `model` parameter removed from `agent()`; the JS positional slot list shifts accordingly.
- **Docs** (`docs/tools/eval.md`, `docs/python-repl.md`): `model` removed from the `agent()` signatures; note that the agent's frontmatter model always applies.

## Verification

- `agent-bridge-policy.test.ts`: legacy `model: "default"` produces **identical** resolution to omitting `model`; parent-options test asserts the agent's own model applies.
- `prelude-agent.test.ts`: positional slot contract updated to the 7-option shape.
- 643 pass / 2 pre-existing skips across eval, task, model-resolver, bundled-agent-parsing suites; biome + tsgo clean.
