### PR TITLE
feat(coding-agent): add interactive code review annotations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -59,7 +59,7 @@
 - Upgraded the bundled omptype schema engine: intersection and pipe operators, bigint and RegExp literals in the string DSL, Standard Schema V1 interop, JSON Schema import via fromJsonSchema(), and richer union/collection error reporting.
 ### Added
 
-- Added `/code-review`, a fullscreen diff annotation flow that reuses `/review` targets and can either pass line-level comments into AI review or insert them into the current prompt.
+- Added `/code-review`, a fullscreen diff annotation flow that reuses `/review` targets and can either pass multiline, line-anchored comments into AI review or insert them into the current prompt.
 
 ## [17.2.7] - 2026-08-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `/code-review`, a fullscreen diff annotation flow that reuses `/review` targets and can either pass multiline, line-anchored comments into AI review or insert them into the current prompt.
+
+### Changed
+
+- Extended bundled custom-command UI contexts with editor insertion and configurable fullscreen/mouse-tracking overlay options.
+
+### Fixed
+
+- Kept diff rendering usable when a source checkout loads a stale native binding without `diffWords`; only intra-line emphasis is omitted until the bindings are rebuilt.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes
@@ -57,9 +69,6 @@
 ### Changed
 
 - Upgraded the bundled omptype schema engine: intersection and pipe operators, bigint and RegExp literals in the string DSL, Standard Schema V1 interop, JSON Schema import via fromJsonSchema(), and richer union/collection error reporting.
-### Added
-
-- Added `/code-review`, a fullscreen diff annotation flow that reuses `/review` targets and can either pass multiline, line-anchored comments into AI review or insert them into the current prompt.
 
 ## [17.2.7] - 2026-08-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -57,6 +57,9 @@
 ### Changed
 
 - Upgraded the bundled omptype schema engine: intersection and pipe operators, bigint and RegExp literals in the string DSL, Standard Schema V1 interop, JSON Schema import via fromJsonSchema(), and richer union/collection error reporting.
+### Added
+
+- Added `/code-review`, a fullscreen diff annotation flow that reuses `/review` targets and can either pass line-level comments into AI review or insert them into the current prompt.
 
 ## [17.2.7] - 2026-08-03
 

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/ci-green/index.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/ci-green/index.ts
@@ -1,6 +1,9 @@
 import { prompt } from "@oh-my-pi/pi-utils";
-import type { CustomCommand, CustomCommandAPI } from "../../../../extensibility/custom-commands/types";
-import type { HookCommandContext } from "../../../../extensibility/hooks/types";
+import type {
+	CustomCommand,
+	CustomCommandAPI,
+	CustomCommandContext,
+} from "../../../../extensibility/custom-commands/types";
 import ciGreenRequestTemplate from "../../../../prompts/ci-green-request.md" with { type: "text" };
 import * as git from "../../../../utils/git";
 
@@ -47,7 +50,7 @@ export class GreenCommand implements CustomCommand {
 
 	constructor(private api: CustomCommandAPI) {}
 
-	async execute(_args: string[], _ctx: HookCommandContext): Promise<string> {
+	async execute(_args: string[], _ctx: CustomCommandContext): Promise<string> {
 		const { headTag, branch, remote } = await getHeadTagContext(this.api);
 		return prompt.render(ciGreenRequestTemplate, { headTag, branch, remote });
 	}

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/review/code-review.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/review/code-review.ts
@@ -1,0 +1,103 @@
+import { prompt } from "@oh-my-pi/pi-utils";
+import type {
+	CustomCommand,
+	CustomCommandAPI,
+	CustomCommandContext,
+} from "../../../../extensibility/custom-commands/types";
+import {
+	type CodeReviewAnnotation,
+	CodeReviewOverlay,
+	type CodeReviewOverlayResult,
+} from "../../../../modes/components/code-review-overlay";
+import codeReviewAnnotationsTemplate from "../../../../prompts/code-review-annotations.md" with { type: "text" };
+import { buildHeadlessReviewPrompt } from ".";
+import { buildReviewPromptForTarget, resolveLocalReviewTarget, selectLocalReviewKind } from "./shared";
+
+interface AnnotationTemplateEntry extends CodeReviewAnnotation {
+	pathLabel: string;
+	lineLabel: string;
+}
+
+function annotationPathLabel(annotation: CodeReviewAnnotation): string {
+	const renamed = annotation.oldPath && annotation.newPath && annotation.oldPath !== annotation.newPath;
+	const path = renamed ? `${annotation.oldPath} → ${annotation.newPath}` : annotation.path;
+	return annotation.occurrence > 1 ? `${path} (${annotation.occurrence})` : path;
+}
+
+function annotationLineLabel(annotation: CodeReviewAnnotation): string {
+	if (annotation.oldLine !== undefined && annotation.newLine !== undefined) {
+		return `old line ${annotation.oldLine}, new line ${annotation.newLine}`;
+	}
+	if (annotation.oldLine !== undefined) return `old line ${annotation.oldLine}`;
+	if (annotation.newLine !== undefined) return `new line ${annotation.newLine}`;
+	return "diff metadata";
+}
+
+function annotationTemplateEntries(annotations: readonly CodeReviewAnnotation[]): AnnotationTemplateEntry[] {
+	return annotations.map(annotation => ({
+		...annotation,
+		pathLabel: annotationPathLabel(annotation),
+		lineLabel: annotationLineLabel(annotation),
+	}));
+}
+
+export function formatCodeReviewAnnotations(
+	annotations: readonly CodeReviewAnnotation[],
+	options: { forReviewer: boolean; supplementalInstructions?: string },
+): string | undefined {
+	if (annotations.length === 0 && !options.supplementalInstructions?.trim()) return undefined;
+	return prompt.render(codeReviewAnnotationsTemplate, {
+		forReviewer: options.forReviewer,
+		annotations: annotationTemplateEntries(annotations),
+		supplementalInstructions: options.supplementalInstructions?.trim(),
+	});
+}
+
+export class CodeReviewCommand implements CustomCommand {
+	name = "code-review";
+	description = "Annotate a diff before review";
+
+	constructor(private api: CustomCommandAPI) {}
+
+	async execute(args: string[], ctx: CustomCommandContext): Promise<string | undefined> {
+		const supplementalInstructions = args.join(" ").trim() || undefined;
+		if (!ctx.hasUI) return buildHeadlessReviewPrompt(supplementalInstructions);
+
+		const kind = await selectLocalReviewKind(ctx.ui);
+		if (!kind) return undefined;
+		const target = await resolveLocalReviewTarget(kind, this.api.cwd, ctx.ui);
+		if (!target) return undefined;
+		if (!target.rawDiff.trim()) {
+			ctx.ui.notify(target.emptyMessage, "warning");
+			return undefined;
+		}
+		if (target.snapshot.files.length === 0) {
+			ctx.ui.notify(target.filteredMessage ?? "No reviewable files (all changes filtered out)", "warning");
+			return undefined;
+		}
+
+		const result = await ctx.ui.custom<CodeReviewOverlayResult | undefined>(
+			(tui, _theme, done) =>
+				new CodeReviewOverlay(tui, target.snapshot.files, target.mode, {
+					onComplete: done,
+					onWarning: message => ctx.ui.notify(message, "warning"),
+				}),
+			{ overlay: true, fullscreen: true, mouseTracking: false },
+		);
+		if (!result) return undefined;
+
+		if (result.action === "paste") {
+			const formatted = formatCodeReviewAnnotations(result.annotations, { forReviewer: false });
+			if (formatted) ctx.ui.pasteToEditor(formatted);
+			return undefined;
+		}
+
+		const additionalInstructions = formatCodeReviewAnnotations(result.annotations, {
+			forReviewer: true,
+			supplementalInstructions,
+		});
+		return buildReviewPromptForTarget(target, ctx.ui, additionalInstructions);
+	}
+}
+
+export default CodeReviewCommand;

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
@@ -1,50 +1,23 @@
-/**
- * /review command - Interactive code review launcher
- *
- * Provides a menu to select review mode:
- * 1. Review against a base branch (PR style)
- * 2. Review uncommitted changes
- * 3. Review a specific commit
- * 4. Custom review instructions
- *
- * Runs VCS diffs upfront, parses results, filters noise, and provides
- * rich context for the orchestrating agent to distribute work across
- * multiple reviewer agents based on diff weight and locality.
- */
 import { prompt } from "@oh-my-pi/pi-utils";
-import type { CustomCommand, CustomCommandAPI } from "../../../../extensibility/custom-commands/types";
-import type { HookCommandContext } from "../../../../extensibility/hooks/types";
+import type {
+	CustomCommand,
+	CustomCommandAPI,
+	CustomCommandContext,
+} from "../../../../extensibility/custom-commands/types";
 import reviewCustomRequestTemplate from "../../../../prompts/review-custom-request.md" with { type: "text" };
 import reviewHeadlessRequestTemplate from "../../../../prompts/review-headless-request.md" with { type: "text" };
-import reviewRequestTemplate from "../../../../prompts/review-request.md" with { type: "text" };
 import * as gh from "../../../../tools/gh";
-import * as git from "../../../../utils/git";
-import * as jj from "../../../../utils/jj";
+import {
+	buildReviewPrompt,
+	buildReviewPromptForTarget,
+	createPrReviewTarget,
+	LOCAL_REVIEW_CHOICES,
+	type LocalReviewKind,
+	resolveLocalReviewTarget,
+	resolveUncommittedReviewTarget,
+} from "./shared";
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Types
-// ─────────────────────────────────────────────────────────────────────────────
-
-interface FileDiff {
-	path: string;
-	linesAdded: number;
-	linesRemoved: number;
-	hunks: string;
-}
-
-interface DiffStats {
-	files: FileDiff[];
-	totalAdded: number;
-	totalRemoved: number;
-	excluded: { path: string; reason: string; linesAdded: number; linesRemoved: number }[];
-}
-
-interface CurrentReviewDiff {
-	diffInstruction: string;
-	diffText: string;
-	emptyMessage?: string;
-	mode: string;
-}
+export * from "./shared";
 
 interface ReviewPrRef {
 	repo: string;
@@ -58,221 +31,14 @@ interface ParsedReviewArgs {
 	extraInstructions: string;
 }
 
-type ReviewMenuChoice =
-	| { kind: "detected-pr"; ref: ReviewPrRef }
-	| { kind: "base-branch" }
-	| { kind: "uncommitted" }
-	| { kind: "commit" }
-	| { kind: "custom" };
+type ReviewMenuChoice = { kind: "detected-pr"; ref: ReviewPrRef } | { kind: LocalReviewKind } | { kind: "custom" };
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Exclusion patterns for noise files
-// ─────────────────────────────────────────────────────────────────────────────
-
-const EXCLUDED_PATTERNS: { pattern: RegExp; reason: string }[] = [
-	// Lock files
-	{ pattern: /\.lock$/, reason: "lock file" },
-	{ pattern: /-lock\.(json|yaml|yml)$/, reason: "lock file" },
-	{ pattern: /package-lock\.json$/, reason: "lock file" },
-	{ pattern: /yarn\.lock$/, reason: "lock file" },
-	{ pattern: /pnpm-lock\.yaml$/, reason: "lock file" },
-	{ pattern: /Cargo\.lock$/, reason: "lock file" },
-	{ pattern: /Gemfile\.lock$/, reason: "lock file" },
-	{ pattern: /poetry\.lock$/, reason: "lock file" },
-	{ pattern: /composer\.lock$/, reason: "lock file" },
-	{ pattern: /flake\.lock$/, reason: "lock file" },
-
-	// Generated/build artifacts
-	{ pattern: /\.min\.(js|css)$/, reason: "minified" },
-	{ pattern: /\.generated\./, reason: "generated" },
-	{ pattern: /\.snap$/, reason: "snapshot" },
-	{ pattern: /\.map$/, reason: "source map" },
-	{ pattern: /^dist\//, reason: "build output" },
-	{ pattern: /^build\//, reason: "build output" },
-	{ pattern: /^out\//, reason: "build output" },
-	{ pattern: /node_modules\//, reason: "vendor" },
-	{ pattern: /vendor\//, reason: "vendor" },
-
-	// Binary/assets (usually shown as binary in diff anyway)
-	{ pattern: /\.(png|jpg|jpeg|gif|ico|webp|avif)$/i, reason: "image" },
-	{ pattern: /\.(woff|woff2|ttf|eot|otf)$/i, reason: "font" },
-	{ pattern: /\.(pdf|zip|tar|gz|rar|7z)$/i, reason: "binary" },
-];
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Diff parsing
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Check if a file path should be excluded from review.
- * Returns the exclusion reason if excluded, undefined otherwise.
- */
-function getExclusionReason(path: string): string | undefined {
-	for (const { pattern, reason } of EXCLUDED_PATTERNS) {
-		if (pattern.test(path)) return reason;
-	}
-	return undefined;
-}
-
-/**
- * Parse unified diff output into per-file stats.
- * Splits on file boundaries, counts +/- lines, and filters excluded files.
- */
-function parseDiff(diffOutput: string): DiffStats {
-	const files: FileDiff[] = [];
-	const excluded: DiffStats["excluded"] = [];
-	let totalAdded = 0;
-	let totalRemoved = 0;
-
-	// Split by file boundary: "diff --git a/... b/..."
-	const fileChunks = diffOutput.split(/^diff --git /m).filter(Boolean);
-
-	for (const chunk of fileChunks) {
-		// Extract file path from "a/path b/path" line
-		const headerMatch = chunk.match(/^a\/(.+?) b\/(.+)/);
-		if (!headerMatch) continue;
-
-		const path = headerMatch[2];
-
-		// Count added/removed lines (lines starting with + or - but not ++ or --)
-		let linesAdded = 0;
-		let linesRemoved = 0;
-
-		const lines = chunk.split("\n");
-		for (const line of lines) {
-			if (line.startsWith("+") && !line.startsWith("+++")) {
-				linesAdded++;
-			} else if (line.startsWith("-") && !line.startsWith("---")) {
-				linesRemoved++;
-			}
-		}
-
-		const exclusionReason = getExclusionReason(path);
-		if (exclusionReason) {
-			excluded.push({ path, reason: exclusionReason, linesAdded, linesRemoved });
-		} else {
-			files.push({
-				path,
-				linesAdded,
-				linesRemoved,
-				hunks: `diff --git ${chunk}`,
-			});
-			totalAdded += linesAdded;
-			totalRemoved += linesRemoved;
-		}
-	}
-
-	return { files, totalAdded, totalRemoved, excluded };
-}
-
-/**
- * Get file extension for display purposes.
- */
-function getFileExt(path: string): string {
-	const match = path.match(/\.([^.]+)$/);
-	return match ? match[1] : "";
-}
-
-/**
- * Determine recommended number of reviewer agents based on diff weight.
- * Uses total lines changed as the primary metric.
- */
-function getRecommendedAgentCount(stats: DiffStats): number {
-	const totalLines = stats.totalAdded + stats.totalRemoved;
-	const fileCount = stats.files.length;
-
-	// Heuristics:
-	// - Tiny (<100 lines or 1-2 files): 1 agent
-	// - Small (<500 lines): 1-2 agents
-	// - Medium (<2000 lines): 2-4 agents
-	// - Large (<5000 lines): 4-8 agents
-	// - Huge (>5000 lines): 8-16 agents
-
-	if (totalLines < 100 || fileCount <= 2) return 1;
-	if (totalLines < 500) return Math.min(2, fileCount);
-	if (totalLines < 2000) return Math.min(4, Math.ceil(fileCount / 3));
-	if (totalLines < 5000) return Math.min(8, Math.ceil(fileCount / 2));
-	return Math.min(16, fileCount);
-}
-
-/**
- * Extract first N lines of actual diff content (excluding headers) for preview.
- */
-function getDiffPreview(hunks: string, maxLines: number): string {
-	const lines = hunks.split("\n");
-	const contentLines: string[] = [];
-
-	for (const line of lines) {
-		// Skip diff headers, keep actual content
-		if (
-			line.startsWith("diff --git") ||
-			line.startsWith("index ") ||
-			line.startsWith("---") ||
-			line.startsWith("+++") ||
-			line.startsWith("@@")
-		) {
-			continue;
-		}
-		contentLines.push(line);
-		if (contentLines.length >= maxLines) break;
-	}
-
-	return contentLines.join("\n");
-}
-
-// Thresholds for diff inclusion
-const MAX_DIFF_CHARS = 50_000; // Don't include diff above this
-const MAX_FILES_FOR_INLINE_DIFF = 20; // Don't include diff if more files than this
-const DEFAULT_LARGE_DIFF_INSTRUCTION = "MUST run `git diff`/`git show` for assigned files";
-const DEFAULT_CONTEXT_INSTRUCTION = "MAY read full file context as needed via `read`";
-const GIT_UNCOMMITTED_DIFF_INSTRUCTION =
-	"MUST run both `git diff -- <path>` and `git diff --cached -- <path>` for assigned files";
-const JJ_UNCOMMITTED_DIFF_INSTRUCTION = "MUST run `jj --ignore-working-copy diff --git -- <path>` for assigned files";
-
-/**
- * Build the full review prompt with diff stats and distribution guidance.
- */
-function buildReviewPrompt(
-	mode: string,
-	stats: DiffStats,
-	rawDiff: string,
-	options: { additionalInstructions?: string; diffInstruction?: string; contextInstruction?: string } = {},
-): string {
-	const agentCount = getRecommendedAgentCount(stats);
-	const skipDiff = rawDiff.length > MAX_DIFF_CHARS || stats.files.length > MAX_FILES_FOR_INLINE_DIFF;
-	const totalLines = stats.totalAdded + stats.totalRemoved;
-	const linesPerFile = skipDiff ? Math.max(5, Math.floor(100 / stats.files.length)) : 0;
-
-	const filesWithExt = stats.files.map(f => ({
-		...f,
-		ext: getFileExt(f.path),
-		hunksPreview: skipDiff ? getDiffPreview(f.hunks, linesPerFile) : "",
-	}));
-
-	return prompt.render(reviewRequestTemplate, {
-		mode,
-		files: filesWithExt,
-		excluded: stats.excluded,
-		totalAdded: stats.totalAdded,
-		totalRemoved: stats.totalRemoved,
-		totalLines,
-		agentCount,
-		multiAgent: agentCount > 1,
-		skipDiff,
-		rawDiff: rawDiff.trim(),
-		linesPerFile,
-		additionalInstructions: options.additionalInstructions,
-		diffInstruction: options.diffInstruction ?? DEFAULT_LARGE_DIFF_INSTRUCTION,
-		contextInstruction: options.contextInstruction ?? DEFAULT_CONTEXT_INSTRUCTION,
-	});
+export function buildHeadlessReviewPrompt(focus?: string): string {
+	return prompt.render(reviewHeadlessRequestTemplate, { focus });
 }
 
 function buildCustomReviewPrompt(instructions: string): string {
 	return prompt.render(reviewCustomRequestTemplate, { instructions });
-}
-
-function buildHeadlessReviewPrompt(focus?: string): string {
-	return prompt.render(reviewHeadlessRequestTemplate, { focus });
 }
 
 const REVIEW_CONTEXT_PR_LIMIT = 3;
@@ -301,29 +67,22 @@ function parseGithubPrUrl(text: string): ReviewPrRef | undefined {
 	} catch {
 		return undefined;
 	}
-
 	if (url.protocol !== "https:" || url.hostname !== "github.com") return undefined;
-
 	const parts = url.pathname.split("/").filter(Boolean);
 	if (parts.length < 4 || parts[2] !== "pull") return undefined;
-
 	const [owner, repo, , numberPart] = parts;
 	if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) return undefined;
-
 	const number = parsePositivePrNumber(numberPart);
 	if (number === undefined) return undefined;
-
 	return { repo: `${owner}/${repo}`, number, raw: text, kind: "github-url" };
 }
 
 function parsePrSchemeRef(text: string): ReviewPrRef | undefined {
 	const match = PR_SCHEME_PATTERN.exec(text);
 	if (!match) return undefined;
-
 	const [, owner, repo, numberPart] = match;
 	const number = parsePositivePrNumber(numberPart);
 	if (number === undefined) return undefined;
-
 	return { repo: `${owner}/${repo}`, number, raw: text, kind: "pr-url" };
 }
 
@@ -345,18 +104,17 @@ function buildPrContextInstruction(ref: ReviewPrRef): string {
 function extractReviewPrRefFromArgs(args: string[]): ParsedReviewArgs {
 	let prRef: ReviewPrRef | undefined;
 	let prRefIndex = -1;
-	for (const [idx, arg] of args.entries()) {
+	for (const [index, arg] of args.entries()) {
 		const parsed = parseReviewPrRef(arg);
 		if (parsed) {
 			prRef = parsed;
-			prRefIndex = idx;
+			prRefIndex = index;
 			break;
 		}
 	}
-
 	return {
 		prRef,
-		extraInstructions: args.filter((_, idx) => idx !== prRefIndex).join(" "),
+		extraInstructions: args.filter((_, index) => index !== prRefIndex).join(" "),
 	};
 }
 
@@ -366,36 +124,9 @@ function extractReviewPrRefsFromText(text: string): ReviewPrRef[] {
 	);
 }
 
-function buildReviewPromptFromDiff(
-	ctx: HookCommandContext,
-	mode: string,
-	diffText: string,
-	extraInstructions: string | undefined,
-	emptyMessage: string,
-	options: { diffInstruction?: string; filteredMessage?: string; contextInstruction?: string } = {},
-): string | undefined {
-	if (!diffText.trim()) {
-		if (ctx.hasUI) ctx.ui.notify(emptyMessage, "warning");
-		return undefined;
-	}
-
-	const stats = parseDiff(diffText);
-	if (stats.files.length === 0) {
-		if (ctx.hasUI)
-			ctx.ui.notify(options.filteredMessage ?? "No reviewable files (all changes filtered out)", "warning");
-		return undefined;
-	}
-
-	return buildReviewPrompt(mode, stats, diffText, {
-		additionalInstructions: extraInstructions,
-		diffInstruction: options.diffInstruction,
-		contextInstruction: options.contextInstruction,
-	});
-}
-
 async function buildPrReviewPrompt(
 	api: CustomCommandAPI,
-	ctx: HookCommandContext,
+	ctx: CustomCommandContext,
 	ref: ReviewPrRef,
 	extraInstructions: string,
 ): Promise<string | undefined> {
@@ -403,8 +134,8 @@ async function buildPrReviewPrompt(
 	try {
 		const lookup = await gh.getOrFetchPrDiff({ cwd: api.cwd, repo: ref.repo, number: ref.number });
 		diffText = lookup.payload.unified;
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
 		const failure = `Failed to fetch PR diff for ${ref.repo}#${ref.number}: ${message}`;
 		if (ctx.hasUI) {
 			ctx.ui.notify(failure, "error");
@@ -412,14 +143,16 @@ async function buildPrReviewPrompt(
 		}
 		return failure;
 	}
-
-	const promptText = buildReviewPromptFromDiff(
-		ctx,
+	const target = createPrReviewTarget(
 		`PR ${ref.repo}#${ref.number}`,
 		diffText,
-		extraInstructions || undefined,
 		`PR ${ref.repo}#${ref.number} has no diff content available`,
 		{ diffInstruction: buildPrLargeDiffInstruction(ref), contextInstruction: buildPrContextInstruction(ref) },
+	);
+	const promptText = buildReviewPromptForTarget(
+		target,
+		ctx.hasUI ? ctx.ui : undefined,
+		extraInstructions || undefined,
 	);
 	if (promptText !== undefined || ctx.hasUI) return promptText;
 	return `Unable to review PR ${ref.repo}#${ref.number}: no diff content available.`;
@@ -432,33 +165,27 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function getTextContentParts(content: unknown): string[] {
 	if (typeof content === "string") return [content];
 	if (!Array.isArray(content)) return [];
-
 	const parts: string[] = [];
 	for (const item of content) {
-		if (isRecord(item) && item.type === "text" && typeof item.text === "string") {
-			parts.push(item.text);
-		}
+		if (isRecord(item) && item.type === "text" && typeof item.text === "string") parts.push(item.text);
 	}
 	return parts;
 }
 
-function findRecentPrRefs(ctx: HookCommandContext, limit: number): ReviewPrRef[] {
+function findRecentPrRefs(ctx: CustomCommandContext, limit: number): ReviewPrRef[] {
 	const refs: ReviewPrRef[] = [];
 	const seen = new Set<string>();
 	const entries = ctx.sessionManager.getBranch();
-
-	for (let idx = entries.length - 1; idx >= 0 && refs.length < limit; idx--) {
-		const entry = entries[idx];
+	for (let entryIndex = entries.length - 1; entryIndex >= 0 && refs.length < limit; entryIndex--) {
+		const entry = entries[entryIndex];
 		if (entry?.type !== "message") continue;
 		const message = entry.message;
 		if (message.role !== "user" && message.role !== "assistant") continue;
-
 		const parts = getTextContentParts(message.content);
-		for (let partIdx = parts.length - 1; partIdx >= 0; partIdx--) {
-			const part = parts[partIdx];
-			const partRefs = extractReviewPrRefsFromText(part);
-			for (let refIdx = partRefs.length - 1; refIdx >= 0; refIdx--) {
-				const ref = partRefs[refIdx];
+		for (let partIndex = parts.length - 1; partIndex >= 0; partIndex--) {
+			const partRefs = extractReviewPrRefsFromText(parts[partIndex]!);
+			for (let refIndex = partRefs.length - 1; refIndex >= 0; refIndex--) {
+				const ref = partRefs[refIndex]!;
 				const key = `${ref.repo.toLowerCase()}#${ref.number}`;
 				if (seen.has(key)) continue;
 				seen.add(key);
@@ -468,7 +195,6 @@ function findRecentPrRefs(ctx: HookCommandContext, limit: number): ReviewPrRef[]
 			if (refs.length >= limit) break;
 		}
 	}
-
 	return refs;
 }
 
@@ -478,131 +204,38 @@ export class ReviewCommand implements CustomCommand {
 
 	constructor(private api: CustomCommandAPI) {}
 
-	async execute(args: string[], ctx: HookCommandContext): Promise<string | undefined> {
+	async execute(args: string[], ctx: CustomCommandContext): Promise<string | undefined> {
 		const parsedArgs = extractReviewPrRefFromArgs(args);
-		if (parsedArgs.prRef) {
-			return buildPrReviewPrompt(this.api, ctx, parsedArgs.prRef, parsedArgs.extraInstructions);
-		}
-
+		if (parsedArgs.prRef) return buildPrReviewPrompt(this.api, ctx, parsedArgs.prRef, parsedArgs.extraInstructions);
 		const extraInstructions = parsedArgs.extraInstructions || undefined;
-		if (!ctx.hasUI) {
-			return buildHeadlessReviewPrompt(extraInstructions);
-		}
+		if (!ctx.hasUI) return buildHeadlessReviewPrompt(extraInstructions);
 
 		const choices: Array<{ label: string; value: ReviewMenuChoice }> = [
 			...findRecentPrRefs(ctx, REVIEW_CONTEXT_PR_LIMIT).map(ref => ({
 				label: `Review PR ${ref.repo}#${ref.number} from conversation`,
 				value: { kind: "detected-pr" as const, ref },
 			})),
-			{
-				label: "1. Review against a base branch (PR Style)",
-				value: { kind: "base-branch" },
-			},
-			{
-				label: "2. Review uncommitted changes",
-				value: { kind: "uncommitted" },
-			},
-			{
-				label: "3. Review a specific commit",
-				value: { kind: "commit" },
-			},
+			...LOCAL_REVIEW_CHOICES.map(choice => ({ label: choice.label, value: { kind: choice.kind } })),
 		];
-
 		if (!extraInstructions) {
-			choices.push({
-				label: "4. Custom review instructions",
-				value: { kind: "custom" },
-			});
+			choices.push({ label: "4. Custom review instructions", value: { kind: "custom" } });
 		}
-
 		const selected = await ctx.ui.select(
 			"Review Mode",
 			choices.map(choice => choice.label),
 		);
-		if (!selected) return undefined;
-
 		const selectedChoice = choices.find(choice => choice.label === selected)?.value;
 		if (!selectedChoice) return undefined;
 
 		switch (selectedChoice.kind) {
 			case "detected-pr":
 				return buildPrReviewPrompt(this.api, ctx, selectedChoice.ref, extraInstructions ?? "");
-
-			case "base-branch": {
-				const branches = await getGitBranches(this.api);
-				if (branches.length === 0) {
-					ctx.ui.notify("No git branches found", "error");
-					return undefined;
-				}
-
-				const baseBranch = await ctx.ui.select("Select base branch to compare against", branches);
-				if (!baseBranch) return undefined;
-
-				const currentBranch = await getCurrentBranch(this.api);
-				let diffText: string;
-				try {
-					diffText = await git.diff(this.api.cwd, { base: `${baseBranch}...${currentBranch}` });
-				} catch (err) {
-					ctx.ui.notify(`Failed to get diff: ${err instanceof Error ? err.message : String(err)}`, "error");
-					return undefined;
-				}
-
-				return buildReviewPromptFromDiff(
-					ctx,
-					`Reviewing changes between \`${baseBranch}\` and \`${currentBranch}\` (PR-style)`,
-					diffText,
-					extraInstructions,
-					`No changes between ${baseBranch} and ${currentBranch}`,
-				);
-			}
-
-			case "uncommitted": {
-				const reviewDiff = await getUncommittedReviewDiff(this.api).catch(err => {
-					ctx.ui.notify(`Failed to get diff: ${err instanceof Error ? err.message : String(err)}`, "error");
-					return undefined;
-				});
-				if (!reviewDiff) return undefined;
-
-				return buildReviewPromptFromDiff(
-					ctx,
-					reviewDiff.mode,
-					reviewDiff.diffText,
-					extraInstructions,
-					reviewDiff.emptyMessage ?? "No diff content found",
-					{ diffInstruction: reviewDiff.diffInstruction },
-				);
-			}
-
+			case "base-branch":
+			case "uncommitted":
 			case "commit": {
-				const commits = await getRecentCommits(this.api, 20);
-				if (commits.length === 0) {
-					ctx.ui.notify("No commits found", "error");
-					return undefined;
-				}
-
-				const selectedCommit = await ctx.ui.select("Select commit to review", commits);
-				if (!selectedCommit) return undefined;
-
-				const hash = selectedCommit.split(" ")[0];
-
-				let diffText: string;
-				try {
-					diffText = await git.show(this.api.cwd, hash, { format: "" });
-				} catch (err) {
-					ctx.ui.notify(`Failed to get commit: ${err instanceof Error ? err.message : String(err)}`, "error");
-					return undefined;
-				}
-
-				return buildReviewPromptFromDiff(
-					ctx,
-					`Reviewing commit \`${hash}\``,
-					diffText,
-					extraInstructions,
-					"Commit has no diff content",
-					{ filteredMessage: "No reviewable files in commit (all changes filtered out)" },
-				);
+				const target = await resolveLocalReviewTarget(selectedChoice.kind, this.api.cwd, ctx.ui);
+				return target ? buildReviewPromptForTarget(target, ctx.ui, extraInstructions) : undefined;
 			}
-
 			case "custom": {
 				const instructions = await ctx.ui.editor(
 					"Enter custom review instructions",
@@ -611,87 +244,18 @@ export class ReviewCommand implements CustomCommand {
 					{ promptStyle: true },
 				);
 				if (!instructions?.trim()) return undefined;
-
-				const reviewDiff = await getUncommittedReviewDiff(this.api).catch(() => undefined);
-
-				if (reviewDiff?.diffText.trim()) {
-					const stats = parseDiff(reviewDiff.diffText);
+				const target = await resolveUncommittedReviewTarget(this.api.cwd).catch(() => undefined);
+				if (target?.rawDiff.trim()) {
 					return buildReviewPrompt(
-						`Custom review: ${instructions.split("\n")[0].slice(0, 60)}…`,
-						stats,
-						reviewDiff.diffText,
-						{
-							additionalInstructions: instructions,
-							diffInstruction: reviewDiff.diffInstruction,
-						},
+						`Custom review: ${instructions.split("\n")[0]!.slice(0, 60)}…`,
+						target.snapshot,
+						target.rawDiff,
+						{ additionalInstructions: instructions, diffInstruction: target.diffInstruction },
 					);
 				}
-
 				return buildCustomReviewPrompt(instructions);
 			}
 		}
-	}
-}
-
-async function getGitBranches(api: CustomCommandAPI): Promise<string[]> {
-	try {
-		return await git.branch.list(api.cwd, { all: true });
-	} catch {
-		return [];
-	}
-}
-
-async function getCurrentBranch(api: CustomCommandAPI): Promise<string> {
-	try {
-		return (await git.branch.current(api.cwd)) ?? "HEAD";
-	} catch {
-		return "HEAD";
-	}
-}
-
-async function getGitStatus(api: CustomCommandAPI): Promise<string> {
-	try {
-		return await git.status(api.cwd);
-	} catch {
-		return "";
-	}
-}
-
-async function getUncommittedReviewDiff(api: CustomCommandAPI): Promise<CurrentReviewDiff> {
-	if (await jj.repo.is(api.cwd)) {
-		return {
-			diffText: await jj.diff(api.cwd),
-			diffInstruction: JJ_UNCOMMITTED_DIFF_INSTRUCTION,
-			emptyMessage: "No uncommitted changes found",
-			mode: "Reviewing JJ working-copy changes",
-		};
-	}
-
-	const status = await getGitStatus(api);
-	if (!status.trim()) {
-		return {
-			diffText: "",
-			diffInstruction: GIT_UNCOMMITTED_DIFF_INSTRUCTION,
-			emptyMessage: "No uncommitted changes found",
-			mode: "Reviewing uncommitted changes (staged + unstaged)",
-		};
-	}
-
-	const [unstagedDiff, stagedDiff] = await Promise.all([git.diff(api.cwd), git.diff(api.cwd, { cached: true })]);
-	const combinedDiff = [unstagedDiff, stagedDiff].filter(Boolean).join("\n");
-	return {
-		diffText: combinedDiff,
-		diffInstruction: GIT_UNCOMMITTED_DIFF_INSTRUCTION,
-		emptyMessage: "No diff content found",
-		mode: "Reviewing uncommitted changes (staged + unstaged)",
-	};
-}
-
-async function getRecentCommits(api: CustomCommandAPI, count: number): Promise<string[]> {
-	try {
-		return await git.log.onelines(api.cwd, count);
-	} catch {
-		return [];
 	}
 }
 

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/review/shared.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/review/shared.ts
@@ -178,7 +178,12 @@ function parseHeaderPaths(header: string): { oldPath?: string; newPath?: string 
 
 function parseMarkerPath(line: string): string | undefined {
 	const payload = line.slice(4);
-	const token = readGitToken(payload, 0)?.token ?? payload.split("\t", 1)[0] ?? "";
+	const separator = payload.indexOf("\t");
+	const token = payload.startsWith('"')
+		? (readGitToken(payload, 0)?.token ?? "")
+		: separator < 0
+			? payload
+			: payload.slice(0, separator);
 	const decoded = decodeGitPath(token);
 	return decoded === "/dev/null" ? undefined : stripDiffPrefix(decoded);
 }

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/review/shared.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/review/shared.ts
@@ -1,0 +1,534 @@
+import { prompt } from "@oh-my-pi/pi-utils";
+import reviewRequestTemplate from "../../../../prompts/review-request.md" with { type: "text" };
+import * as git from "../../../../utils/git";
+import * as jj from "../../../../utils/jj";
+
+export type LocalReviewKind = "base-branch" | "uncommitted" | "commit";
+export type ReviewSourceRowKind = "context" | "added" | "removed";
+
+export interface ReviewSourceRow {
+	kind: ReviewSourceRowKind;
+	raw: string;
+	content: string;
+	oldLine?: number;
+	newLine?: number;
+	hunkHeader: string;
+}
+
+export type ReviewDiffRow =
+	| ReviewSourceRow
+	| { kind: "hunk"; raw: string; hunkHeader: string }
+	| { kind: "no-newline"; raw: string; hunkHeader: string };
+
+export interface ReviewDiffFile {
+	path: string;
+	oldPath?: string;
+	newPath?: string;
+	occurrence: number;
+	linesAdded: number;
+	linesRemoved: number;
+	rawDiff: string;
+	rows: ReviewDiffRow[];
+	isBinary: boolean;
+}
+
+export interface ExcludedReviewFile {
+	path: string;
+	reason: string;
+	linesAdded: number;
+	linesRemoved: number;
+}
+
+export interface ReviewDiffSnapshot {
+	files: ReviewDiffFile[];
+	excluded: ExcludedReviewFile[];
+	totalAdded: number;
+	totalRemoved: number;
+}
+
+export interface ResolvedReviewTarget {
+	kind: LocalReviewKind | "pr";
+	mode: string;
+	rawDiff: string;
+	snapshot: ReviewDiffSnapshot;
+	emptyMessage: string;
+	filteredMessage?: string;
+	diffInstruction?: string;
+	contextInstruction?: string;
+}
+
+export interface LocalReviewUI {
+	select(title: string, options: string[]): Promise<string | undefined>;
+	notify(message: string, type?: "info" | "warning" | "error"): void;
+}
+
+export const LOCAL_REVIEW_CHOICES: ReadonlyArray<{ label: string; kind: LocalReviewKind }> = [
+	{ label: "1. Review against a base branch (PR Style)", kind: "base-branch" },
+	{ label: "2. Review uncommitted changes", kind: "uncommitted" },
+	{ label: "3. Review a specific commit", kind: "commit" },
+];
+
+const EXCLUDED_PATTERNS: ReadonlyArray<{ pattern: RegExp; reason: string }> = [
+	{ pattern: /\.lock$/, reason: "lock file" },
+	{ pattern: /-lock\.(json|yaml|yml)$/, reason: "lock file" },
+	{ pattern: /package-lock\.json$/, reason: "lock file" },
+	{ pattern: /yarn\.lock$/, reason: "lock file" },
+	{ pattern: /pnpm-lock\.yaml$/, reason: "lock file" },
+	{ pattern: /Cargo\.lock$/, reason: "lock file" },
+	{ pattern: /Gemfile\.lock$/, reason: "lock file" },
+	{ pattern: /poetry\.lock$/, reason: "lock file" },
+	{ pattern: /composer\.lock$/, reason: "lock file" },
+	{ pattern: /flake\.lock$/, reason: "lock file" },
+	{ pattern: /\.min\.(js|css)$/, reason: "minified" },
+	{ pattern: /\.generated\./, reason: "generated" },
+	{ pattern: /\.snap$/, reason: "snapshot" },
+	{ pattern: /\.map$/, reason: "source map" },
+	{ pattern: /^dist\//, reason: "build output" },
+	{ pattern: /^build\//, reason: "build output" },
+	{ pattern: /^out\//, reason: "build output" },
+	{ pattern: /node_modules\//, reason: "vendor" },
+	{ pattern: /vendor\//, reason: "vendor" },
+	{ pattern: /\.(png|jpg|jpeg|gif|ico|webp|avif)$/i, reason: "image" },
+	{ pattern: /\.(woff|woff2|ttf|eot|otf)$/i, reason: "font" },
+	{ pattern: /\.(pdf|zip|tar|gz|rar|7z)$/i, reason: "binary" },
+];
+
+const MAX_DIFF_CHARS = 50_000;
+const MAX_FILES_FOR_INLINE_DIFF = 20;
+const DEFAULT_LARGE_DIFF_INSTRUCTION = "MUST run `git diff`/`git show` for assigned files";
+const DEFAULT_CONTEXT_INSTRUCTION = "MAY read full file context as needed via `read`";
+const GIT_UNCOMMITTED_DIFF_INSTRUCTION =
+	"MUST run both `git diff -- <path>` and `git diff --cached -- <path>` for assigned files";
+const JJ_UNCOMMITTED_DIFF_INSTRUCTION = "MUST run `jj --ignore-working-copy diff --git -- <path>` for assigned files";
+const HUNK_HEADER_PATTERN = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?:.*)$/;
+
+function decodeGitPath(token: string): string {
+	if (!(token.startsWith('"') && token.endsWith('"'))) return token;
+	const bytes: number[] = [];
+	const encoder = new TextEncoder();
+	for (let index = 1; index < token.length - 1; index++) {
+		const char = token[index]!;
+		if (char !== "\\") {
+			bytes.push(...encoder.encode(char));
+			continue;
+		}
+		const escaped = token[++index];
+		if (escaped === undefined) break;
+		const escapes: Record<string, string> = {
+			'"': '"',
+			"\\": "\\",
+			a: "\x07",
+			b: "\b",
+			f: "\f",
+			n: "\n",
+			r: "\r",
+			t: "\t",
+			v: "\x0b",
+		};
+		const decoded = escapes[escaped];
+		if (decoded !== undefined) {
+			bytes.push(...encoder.encode(decoded));
+			continue;
+		}
+		if (/[0-7]/.test(escaped)) {
+			let octal = escaped;
+			while (octal.length < 3 && /[0-7]/.test(token[index + 1] ?? "")) octal += token[++index];
+			bytes.push(Number.parseInt(octal, 8));
+			continue;
+		}
+		bytes.push(...encoder.encode(escaped));
+	}
+	return new TextDecoder().decode(Uint8Array.from(bytes));
+}
+
+function readGitToken(input: string, offset: number): { token: string; next: number } | undefined {
+	let index = offset;
+	while (input[index] === " ") index++;
+	if (index >= input.length) return undefined;
+	if (input[index] !== '"') {
+		const end = input.indexOf(" ", index);
+		return end < 0
+			? { token: input.slice(index), next: input.length }
+			: { token: input.slice(index, end), next: end };
+	}
+	const start = index++;
+	let escaped = false;
+	while (index < input.length) {
+		const char = input[index++];
+		if (char === '"' && !escaped) break;
+		if (char === "\\" && !escaped) escaped = true;
+		else escaped = false;
+	}
+	return { token: input.slice(start, index), next: index };
+}
+
+function stripDiffPrefix(path: string): string {
+	return /^[^/]+\//.test(path) ? path.slice(path.indexOf("/") + 1) : path;
+}
+
+function parseHeaderPaths(header: string): { oldPath?: string; newPath?: string } {
+	const payload = header.slice("diff --git ".length);
+	const oldToken = readGitToken(payload, 0);
+	const newToken = oldToken ? readGitToken(payload, oldToken.next) : undefined;
+	return {
+		oldPath: oldToken ? stripDiffPrefix(decodeGitPath(oldToken.token)) : undefined,
+		newPath: newToken ? stripDiffPrefix(decodeGitPath(newToken.token)) : undefined,
+	};
+}
+
+function parseMarkerPath(line: string): string | undefined {
+	const payload = line.slice(4);
+	const token = readGitToken(payload, 0)?.token ?? payload.split("\t", 1)[0] ?? "";
+	const decoded = decodeGitPath(token);
+	return decoded === "/dev/null" ? undefined : stripDiffPrefix(decoded);
+}
+
+function parseRenamePath(line: string, prefix: string): string {
+	return decodeGitPath(line.slice(prefix.length));
+}
+
+function splitFileDiffs(rawDiff: string): string[] {
+	const starts: number[] = [];
+	const pattern = /^diff --git /gm;
+	for (const match of rawDiff.matchAll(pattern)) starts.push(match.index);
+	return starts.map((start, index) => rawDiff.slice(start, starts[index + 1] ?? rawDiff.length).trimEnd());
+}
+
+function parseRows(lines: readonly string[]): { rows: ReviewDiffRow[]; linesAdded: number; linesRemoved: number } {
+	const rows: ReviewDiffRow[] = [];
+	let linesAdded = 0;
+	let linesRemoved = 0;
+	let oldLine = 0;
+	let newLine = 0;
+	let hunkHeader: string | undefined;
+	for (const raw of lines) {
+		const hunk = HUNK_HEADER_PATTERN.exec(raw);
+		if (hunk) {
+			oldLine = Number.parseInt(hunk[1]!, 10);
+			newLine = Number.parseInt(hunk[3]!, 10);
+			hunkHeader = raw;
+			rows.push({ kind: "hunk", raw, hunkHeader: raw });
+			continue;
+		}
+		if (!hunkHeader) continue;
+		if (raw === "\\ No newline at end of file") {
+			rows.push({ kind: "no-newline", raw, hunkHeader });
+			continue;
+		}
+		if (raw.startsWith("+")) {
+			rows.push({ kind: "added", raw, content: raw.slice(1), newLine, hunkHeader });
+			newLine++;
+			linesAdded++;
+			continue;
+		}
+		if (raw.startsWith("-")) {
+			rows.push({ kind: "removed", raw, content: raw.slice(1), oldLine, hunkHeader });
+			oldLine++;
+			linesRemoved++;
+			continue;
+		}
+		if (raw.startsWith(" ")) {
+			rows.push({ kind: "context", raw, content: raw.slice(1), oldLine, newLine, hunkHeader });
+			oldLine++;
+			newLine++;
+		}
+	}
+	return { rows, linesAdded, linesRemoved };
+}
+
+function getExclusionReason(path: string): string | undefined {
+	return EXCLUDED_PATTERNS.find(entry => entry.pattern.test(path))?.reason;
+}
+
+export function parseReviewDiffSnapshot(rawDiff: string): ReviewDiffSnapshot {
+	const files: ReviewDiffFile[] = [];
+	const excluded: ExcludedReviewFile[] = [];
+	const occurrences = new Map<string, number>();
+	let totalAdded = 0;
+	let totalRemoved = 0;
+
+	for (const rawFileDiff of splitFileDiffs(rawDiff)) {
+		const lines = rawFileDiff.split("\n");
+		let { oldPath, newPath } = parseHeaderPaths(lines[0] ?? "");
+		for (const line of lines) {
+			if (line.startsWith("--- ")) oldPath = parseMarkerPath(line);
+			else if (line.startsWith("+++ ")) newPath = parseMarkerPath(line);
+			else if (line.startsWith("rename from ")) oldPath = parseRenamePath(line, "rename from ");
+			else if (line.startsWith("rename to ")) newPath = parseRenamePath(line, "rename to ");
+		}
+		const path = newPath ?? oldPath;
+		if (!path) continue;
+		const parsed = parseRows(lines);
+		const exclusionReason = getExclusionReason(path);
+		if (exclusionReason) {
+			excluded.push({
+				path,
+				reason: exclusionReason,
+				linesAdded: parsed.linesAdded,
+				linesRemoved: parsed.linesRemoved,
+			});
+			continue;
+		}
+		const occurrence = (occurrences.get(path) ?? 0) + 1;
+		occurrences.set(path, occurrence);
+		files.push({
+			path,
+			oldPath,
+			newPath,
+			occurrence,
+			linesAdded: parsed.linesAdded,
+			linesRemoved: parsed.linesRemoved,
+			rawDiff: rawFileDiff,
+			rows: parsed.rows,
+			isBinary: lines.some(line => line.startsWith("Binary files ") || line === "GIT binary patch"),
+		});
+		totalAdded += parsed.linesAdded;
+		totalRemoved += parsed.linesRemoved;
+	}
+	return { files, excluded, totalAdded, totalRemoved };
+}
+
+function getFileExt(path: string): string {
+	return path.match(/\.([^.]+)$/)?.[1] ?? "";
+}
+
+function getRecommendedAgentCount(snapshot: ReviewDiffSnapshot): number {
+	const totalLines = snapshot.totalAdded + snapshot.totalRemoved;
+	const fileCount = snapshot.files.length;
+	if (totalLines < 100 || fileCount <= 2) return 1;
+	if (totalLines < 500) return Math.min(2, fileCount);
+	if (totalLines < 2000) return Math.min(4, Math.ceil(fileCount / 3));
+	if (totalLines < 5000) return Math.min(8, Math.ceil(fileCount / 2));
+	return Math.min(16, fileCount);
+}
+
+function getDiffPreview(rawDiff: string, maxLines: number): string {
+	const contentLines: string[] = [];
+	for (const line of rawDiff.split("\n")) {
+		if (
+			line.startsWith("diff --git") ||
+			line.startsWith("index ") ||
+			line.startsWith("---") ||
+			line.startsWith("+++") ||
+			line.startsWith("@@")
+		) {
+			continue;
+		}
+		contentLines.push(line);
+		if (contentLines.length >= maxLines) break;
+	}
+	return contentLines.join("\n");
+}
+
+export function buildReviewPrompt(
+	mode: string,
+	snapshot: ReviewDiffSnapshot,
+	rawDiff: string,
+	options: { additionalInstructions?: string; diffInstruction?: string; contextInstruction?: string } = {},
+): string {
+	const agentCount = getRecommendedAgentCount(snapshot);
+	const skipDiff = rawDiff.length > MAX_DIFF_CHARS || snapshot.files.length > MAX_FILES_FOR_INLINE_DIFF;
+	const totalLines = snapshot.totalAdded + snapshot.totalRemoved;
+	const linesPerFile = skipDiff ? Math.max(5, Math.floor(100 / snapshot.files.length)) : 0;
+	const files = snapshot.files.map(file => ({
+		path: file.path,
+		linesAdded: file.linesAdded,
+		linesRemoved: file.linesRemoved,
+		ext: getFileExt(file.path),
+		hunksPreview: skipDiff ? getDiffPreview(file.rawDiff, linesPerFile) : "",
+	}));
+	return prompt.render(reviewRequestTemplate, {
+		mode,
+		files,
+		excluded: snapshot.excluded,
+		totalAdded: snapshot.totalAdded,
+		totalRemoved: snapshot.totalRemoved,
+		totalLines,
+		agentCount,
+		multiAgent: agentCount > 1,
+		skipDiff,
+		rawDiff: rawDiff.trim(),
+		linesPerFile,
+		additionalInstructions: options.additionalInstructions,
+		diffInstruction: options.diffInstruction ?? DEFAULT_LARGE_DIFF_INSTRUCTION,
+		contextInstruction: options.contextInstruction ?? DEFAULT_CONTEXT_INSTRUCTION,
+	});
+}
+
+export function buildReviewPromptForTarget(
+	target: ResolvedReviewTarget,
+	ui: Pick<LocalReviewUI, "notify"> | undefined,
+	additionalInstructions?: string,
+): string | undefined {
+	if (!target.rawDiff.trim()) {
+		ui?.notify(target.emptyMessage, "warning");
+		return undefined;
+	}
+	if (target.snapshot.files.length === 0) {
+		ui?.notify(target.filteredMessage ?? "No reviewable files (all changes filtered out)", "warning");
+		return undefined;
+	}
+	return buildReviewPrompt(target.mode, target.snapshot, target.rawDiff, {
+		additionalInstructions,
+		diffInstruction: target.diffInstruction,
+		contextInstruction: target.contextInstruction,
+	});
+}
+
+function resolvedTarget(
+	kind: ResolvedReviewTarget["kind"],
+	mode: string,
+	rawDiff: string,
+	emptyMessage: string,
+	options: Pick<ResolvedReviewTarget, "filteredMessage" | "diffInstruction" | "contextInstruction"> = {},
+): ResolvedReviewTarget {
+	return {
+		kind,
+		mode,
+		rawDiff,
+		snapshot: parseReviewDiffSnapshot(rawDiff),
+		emptyMessage,
+		...options,
+	};
+}
+
+async function getGitBranches(cwd: string): Promise<string[]> {
+	try {
+		return await git.branch.list(cwd, { all: true });
+	} catch {
+		return [];
+	}
+}
+
+async function getCurrentBranch(cwd: string): Promise<string> {
+	try {
+		return (await git.branch.current(cwd)) ?? "HEAD";
+	} catch {
+		return "HEAD";
+	}
+}
+
+async function getGitStatus(cwd: string): Promise<string> {
+	try {
+		return await git.status(cwd);
+	} catch {
+		return "";
+	}
+}
+
+export async function resolveUncommittedReviewTarget(cwd: string): Promise<ResolvedReviewTarget> {
+	if (await jj.repo.is(cwd)) {
+		return resolvedTarget(
+			"uncommitted",
+			"Reviewing JJ working-copy changes",
+			await jj.diff(cwd),
+			"No uncommitted changes found",
+			{
+				diffInstruction: JJ_UNCOMMITTED_DIFF_INSTRUCTION,
+			},
+		);
+	}
+	const status = await getGitStatus(cwd);
+	if (!status.trim()) {
+		return resolvedTarget(
+			"uncommitted",
+			"Reviewing uncommitted changes (staged + unstaged)",
+			"",
+			"No uncommitted changes found",
+			{
+				diffInstruction: GIT_UNCOMMITTED_DIFF_INSTRUCTION,
+			},
+		);
+	}
+	const [unstagedDiff, stagedDiff] = await Promise.all([git.diff(cwd), git.diff(cwd, { cached: true })]);
+	return resolvedTarget(
+		"uncommitted",
+		"Reviewing uncommitted changes (staged + unstaged)",
+		[unstagedDiff, stagedDiff].filter(Boolean).join("\n"),
+		"No diff content found",
+		{ diffInstruction: GIT_UNCOMMITTED_DIFF_INSTRUCTION },
+	);
+}
+
+export async function resolveLocalReviewTarget(
+	kind: LocalReviewKind,
+	cwd: string,
+	ui: LocalReviewUI,
+): Promise<ResolvedReviewTarget | undefined> {
+	switch (kind) {
+		case "base-branch": {
+			const branches = await getGitBranches(cwd);
+			if (branches.length === 0) {
+				ui.notify("No git branches found", "error");
+				return undefined;
+			}
+			const baseBranch = await ui.select("Select base branch to compare against", branches);
+			if (!baseBranch) return undefined;
+			const currentBranch = await getCurrentBranch(cwd);
+			try {
+				return resolvedTarget(
+					kind,
+					`Reviewing changes between \`${baseBranch}\` and \`${currentBranch}\` (PR-style)`,
+					await git.diff(cwd, { base: `${baseBranch}...${currentBranch}` }),
+					`No changes between ${baseBranch} and ${currentBranch}`,
+				);
+			} catch (error) {
+				ui.notify(`Failed to get diff: ${error instanceof Error ? error.message : String(error)}`, "error");
+				return undefined;
+			}
+		}
+		case "uncommitted":
+			try {
+				return await resolveUncommittedReviewTarget(cwd);
+			} catch (error) {
+				ui.notify(`Failed to get diff: ${error instanceof Error ? error.message : String(error)}`, "error");
+				return undefined;
+			}
+		case "commit": {
+			let commits: string[];
+			try {
+				commits = await git.log.onelines(cwd, 20);
+			} catch {
+				commits = [];
+			}
+			if (commits.length === 0) {
+				ui.notify("No commits found", "error");
+				return undefined;
+			}
+			const selectedCommit = await ui.select("Select commit to review", commits);
+			if (!selectedCommit) return undefined;
+			const hash = selectedCommit.split(" ")[0]!;
+			try {
+				return resolvedTarget(
+					kind,
+					`Reviewing commit \`${hash}\``,
+					await git.show(cwd, hash, { format: "" }),
+					"Commit has no diff content",
+					{
+						filteredMessage: "No reviewable files in commit (all changes filtered out)",
+					},
+				);
+			} catch (error) {
+				ui.notify(`Failed to get commit: ${error instanceof Error ? error.message : String(error)}`, "error");
+				return undefined;
+			}
+		}
+	}
+}
+
+export async function selectLocalReviewKind(ui: Pick<LocalReviewUI, "select">): Promise<LocalReviewKind | undefined> {
+	const selected = await ui.select(
+		"Review Mode",
+		LOCAL_REVIEW_CHOICES.map(choice => choice.label),
+	);
+	return LOCAL_REVIEW_CHOICES.find(choice => choice.label === selected)?.kind;
+}
+
+export function createPrReviewTarget(
+	mode: string,
+	rawDiff: string,
+	emptyMessage: string,
+	options: Pick<ResolvedReviewTarget, "diffInstruction" | "contextInstruction"> = {},
+): ResolvedReviewTarget {
+	return resolvedTarget("pr", mode, rawDiff, emptyMessage, options);
+}

--- a/packages/coding-agent/src/extensibility/custom-commands/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/loader.ts
@@ -16,6 +16,7 @@ import * as PiCodingAgent from "../../index";
 import * as typebox from "../legacy-typebox";
 import { GreenCommand } from "./bundled/ci-green";
 import { ReviewCommand } from "./bundled/review";
+import { CodeReviewCommand } from "./bundled/review/code-review";
 import type {
 	CustomCommand,
 	CustomCommandAPI,
@@ -156,6 +157,12 @@ function loadBundledCommands(sharedApi: CustomCommandAPI): LoadedCustomCommand[]
 		path: "bundled:green",
 		resolvedPath: "bundled:green",
 		command: new GreenCommand(sharedApi),
+		source: "bundled",
+	});
+	bundled.push({
+		path: "bundled:code-review",
+		resolvedPath: "bundled:code-review",
+		command: new CodeReviewCommand(sharedApi),
 		source: "bundled",
 	});
 	bundled.push({

--- a/packages/coding-agent/src/extensibility/custom-commands/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/types.ts
@@ -8,11 +8,35 @@
 import type * as arktype from "@oh-my-pi/omptype";
 import type * as TypeBox from "@oh-my-pi/omptype/typebox";
 import type * as zod from "@oh-my-pi/omptype/zod";
-import type { ExecOptions, ExecResult, HookCommandContext } from "../../extensibility/hooks/types";
+import type { Component, TUI } from "@oh-my-pi/pi-tui";
+import type { ExtensionUICustomOptions } from "../../extensibility/extensions/types";
+import type { ExecOptions, ExecResult, HookCommandContext, HookUIContext } from "../../extensibility/hooks/types";
 import type * as PiCodingAgent from "../../index";
+import type { Theme } from "../../modes/theme/theme";
 
 // Re-export for custom commands to use
 export type { ExecOptions, ExecResult, HookCommandContext };
+
+export interface CustomCommandUIContext extends Omit<HookUIContext, "custom"> {
+	/**
+	 * Show a custom component using the documented custom-command callback shape.
+	 * The command runtime adapts the extension UI's keybindings-aware factory.
+	 */
+	custom<T>(
+		factory: (
+			tui: TUI,
+			theme: Theme,
+			done: (result: T) => void,
+		) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>,
+		options?: ExtensionUICustomOptions,
+	): Promise<T>;
+	/** Insert text through the core editor's paste handling. */
+	pasteToEditor(text: string): void;
+}
+
+export type CustomCommandContext = Omit<HookCommandContext, "ui"> & {
+	ui: CustomCommandUIContext;
+};
 
 /**
  * API passed to custom command factory.
@@ -86,7 +110,7 @@ export interface CustomCommand {
 	 * @param ctx - Command context with UI and session control
 	 * @returns String to send as prompt, or void for fire-and-forget
 	 */
-	execute(args: string[], ctx: HookCommandContext): Promise<string | undefined> | string | undefined;
+	execute(args: string[], ctx: CustomCommandContext): Promise<string | undefined> | string | undefined;
 }
 
 /**

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -216,6 +216,14 @@ export type ExtensionWidgetContent = string[] | ExtensionUiComponentFactory | un
 
 /** Wrap the current autocomplete provider with additional behavior (pi-compatible). */
 export type AutocompleteProviderFactory = (current: AutocompleteProvider) => AutocompleteProvider;
+export interface ExtensionUICustomOptions {
+	/** Mount the component through the TUI overlay host instead of the editor slot. */
+	overlay?: boolean;
+	/** Let the overlay occupy the full terminal viewport. */
+	fullscreen?: boolean;
+	/** Override terminal mouse tracking while the overlay is mounted. */
+	mouseTracking?: boolean;
+}
 
 /**
  * UI context for extensions to request interactive UI.
@@ -280,7 +288,7 @@ export interface ExtensionUIContext {
 			keybindings: KeybindingsManager,
 			done: (result: T) => void,
 		) => ExtensionUiComponent | Promise<ExtensionUiComponent>,
-		options?: { overlay?: boolean },
+		options?: ExtensionUICustomOptions,
 	): Promise<T>;
 
 	/** Set the text in the core input editor. */

--- a/packages/coding-agent/src/modes/components/code-review-overlay.ts
+++ b/packages/coding-agent/src/modes/components/code-review-overlay.ts
@@ -1,7 +1,7 @@
 import {
 	type Component,
+	Editor,
 	Ellipsis,
-	Input,
 	matchesKey,
 	replaceTabs,
 	ScrollView,
@@ -17,7 +17,7 @@ import type {
 } from "../../extensibility/custom-commands/bundled/review/shared";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
 import { sanitizeStatusText } from "../shared";
-import { theme } from "../theme/theme";
+import { getEditorTheme, theme } from "../theme/theme";
 import {
 	matchesAppExternalEditor,
 	matchesSelectCancel,
@@ -82,6 +82,7 @@ const MIN_BODY_ROWS = 3;
 const SIDEBAR_MIN_TOTAL_WIDTH = 64;
 const SIDEBAR_MIN_BODY_WIDTH = 40;
 const ACTIONS = [CONTINUE_CODE_REVIEW_ACTION, PASTE_CODE_REVIEW_ACTION] as const;
+const MAX_ANNOTATION_EDITOR_ROWS = 6;
 
 function isSourceRow(row: ReviewDiffRow): row is ReviewSourceRow {
 	return row.kind === "context" || row.kind === "added" || row.kind === "removed";
@@ -108,7 +109,7 @@ export class CodeReviewOverlay implements Component {
 		ellipsis: Ellipsis.Omit,
 		theme: { track: text => theme.fg("dim", text), thumb: text => theme.fg("accent", text) },
 	});
-	#input = new Input();
+	#editor = new Editor(getEditorTheme());
 	#focus: FocusRegion = "files";
 	#fileIndex = 0;
 	#sourceIndex = 0;
@@ -126,9 +127,11 @@ export class CodeReviewOverlay implements Component {
 		private readonly callbacks: CodeReviewOverlayCallbacks,
 		private readonly externalEditorLabel?: string,
 	) {
-		this.#input.setUseTerminalCursor(false);
-		this.#input.onSubmit = value => this.#commitAnnotation(value);
-		this.#input.onEscape = () => this.#cancelAnnotation();
+		this.#editor.setBorderVisible(false);
+		this.#editor.setPromptGutter("> ");
+		this.#editor.setUseTerminalCursor(false);
+		this.#editor.setScrollbarVisible(true);
+		this.#editor.onSubmit = value => this.#commitAnnotation(value);
 		this.#resetSourceCursor();
 	}
 
@@ -149,7 +152,11 @@ export class CodeReviewOverlay implements Component {
 				void this.#openAnnotationEditor();
 				return;
 			}
-			this.#input.handleInput(data);
+			if (matchesSelectCancel(data)) {
+				this.#cancelAnnotation();
+				return;
+			}
+			this.#editor.handleInput(data);
 			return;
 		}
 		if (matchesSelectCancel(data)) {
@@ -329,12 +336,12 @@ export class CodeReviewOverlay implements Component {
 			return;
 		}
 		this.#annotating = true;
-		this.#input.setValue("");
+		this.#editor.setText("");
 	}
 
 	#cancelAnnotation(): void {
 		this.#annotating = false;
-		this.#input.setValue("");
+		this.#editor.setText("");
 	}
 
 	#commitAnnotation(value: string): void {
@@ -342,7 +349,7 @@ export class CodeReviewOverlay implements Component {
 		const file = this.#currentFile();
 		const source = this.#currentSourceRows()[this.#sourceIndex];
 		this.#annotating = false;
-		this.#input.setValue("");
+		this.#editor.setText("");
 		if (!note || !file || !source) return;
 		this.#annotations.push({
 			fileIndex: this.#fileIndex,
@@ -372,7 +379,7 @@ export class CodeReviewOverlay implements Component {
 			this.callbacks.onWarning?.("No editor configured. Set $VISUAL or $EDITOR environment variable.");
 			return;
 		}
-		const draft = this.#input.getValue();
+		const draft = this.#editor.getExpandedText();
 		try {
 			this.tui.stop();
 			const result = await openInEditor(editorCommand, draft, { extension: ".md" });
@@ -525,9 +532,10 @@ export class CodeReviewOverlay implements Component {
 				width,
 				Ellipsis.Unicode,
 			);
-			const hints = ["enter save", "esc cancel"];
+			const hints = ["enter save", "shift+enter newline", "esc cancel"];
 			if (this.externalEditorLabel) hints.push(`${this.externalEditorLabel} editor`);
-			return [caption, this.#input.render(width)[0] ?? "", theme.fg("dim", hints.join(" · "))];
+			this.#editor.focused = true;
+			return [caption, ...this.#editor.render(width), theme.fg("dim", hints.join(" · "))];
 		}
 		const focusHelp =
 			this.#focus === "files"
@@ -545,9 +553,10 @@ export class CodeReviewOverlay implements Component {
 		const sidebarWidth = this.#sidebarShown ? this.#sidebarWidth(width) : 0;
 		const innerWidth = Math.max(1, width - 4);
 		const bodyWidth = this.#sidebarShown ? splitBodyWidth(width, sidebarWidth) : innerWidth;
+		this.#editor.setMaxHeight(Math.max(1, Math.min(MAX_ANNOTATION_EDITOR_ROWS, termHeight - 12)));
+		this.#editor.focused = this.#annotating;
 		const footer = this.#renderFooter(innerWidth);
-		const narrowHeaderRows = this.#sidebarShown ? 0 : 1;
-		const chromeRows = 4 + 1 + ACTIONS.length + footer.length + narrowHeaderRows;
+		const chromeRows = 4 + 1 + ACTIONS.length + footer.length + 1;
 		this.#bodyHeight = Math.max(MIN_BODY_ROWS, termHeight - chromeRows);
 		const renderedBody = this.#renderBody(bodyWidth);
 		this.#scrollView.setLines(renderedBody.lines);
@@ -556,10 +565,11 @@ export class CodeReviewOverlay implements Component {
 		const body = this.#scrollView.render(bodyWidth);
 		const out: string[] = [];
 		if (this.#sidebarShown) {
-			const sidebar = this.#renderSidebar(this.#bodyHeight, sidebarWidth);
+			const sidebar = this.#renderSidebar(this.#bodyHeight + 1, sidebarWidth);
 			out.push(topBorderSplit(width, OVERLAY_TITLE, sidebarWidth));
+			out.push(splitRow(sidebar[0] ?? "", this.#renderCurrentFileHeader(bodyWidth), width, sidebarWidth));
 			for (let index = 0; index < this.#bodyHeight; index++) {
-				out.push(splitRow(sidebar[index] ?? "", body[index] ?? "", width, sidebarWidth));
+				out.push(splitRow(sidebar[index + 1] ?? "", body[index] ?? "", width, sidebarWidth));
 			}
 			out.push(dividerSplit(width, sidebarWidth));
 		} else {

--- a/packages/coding-agent/src/modes/components/code-review-overlay.ts
+++ b/packages/coding-agent/src/modes/components/code-review-overlay.ts
@@ -26,7 +26,7 @@ import {
 	matchesSelectPageUp,
 	matchesSelectUp,
 } from "../utils/keybinding-matchers";
-import { renderDiff } from "./diff";
+import * as diffRenderer from "./diff";
 import {
 	bottomBorder,
 	divider,
@@ -119,6 +119,7 @@ export class CodeReviewOverlay implements Component {
 	#annotating = false;
 	#finished = false;
 	#annotations: CommittedAnnotation[] = [];
+	#staticRenderedDiffBodies = new WeakMap<ReviewDiffFile, RenderedDiffBody>();
 
 	constructor(
 		private readonly tui: TUI,
@@ -135,7 +136,9 @@ export class CodeReviewOverlay implements Component {
 		this.#resetSourceCursor();
 	}
 
-	invalidate(): void {}
+	invalidate(): void {
+		this.#staticRenderedDiffBodies = new WeakMap();
+	}
 
 	dispose(): void {
 		this.#finished = true;
@@ -399,49 +402,68 @@ export class CodeReviewOverlay implements Component {
 	#renderBody(contentWidth: number): RenderedDiffBody {
 		const file = this.#currentFile();
 		if (!file) return { lines: [theme.fg("dim", "No reviewable files")], renderedRowBySource: [] };
-		if (file.isBinary) {
-			return { lines: [theme.fg("dim", "Binary diff; no annotatable source rows")], renderedRowBySource: [] };
-		}
-		if (file.rows.length === 0) {
-			return {
-				lines: [theme.fg("dim", "No diff hunks; this may be a rename-only change")],
-				renderedRowBySource: [],
-			};
-		}
 
+		const staticBody = this.#getStaticRenderedBody(file);
 		const lines: string[] = [];
 		const renderedRowBySource: number[] = [];
 		let sourceIndex = 0;
-		let run: ReviewSourceRow[] = [];
-		const flushRun = (): void => {
-			if (run.length === 0) return;
-			const rendered = renderDiff(run.map(canonicalDiffRow).join("\n"), { filePath: file.path }).split("\n");
-			for (let index = 0; index < run.length; index++) {
-				const currentSourceIndex = sourceIndex++;
-				renderedRowBySource[currentSourceIndex] = lines.length;
-				let renderedLine = rendered[index] ?? "";
-				if (this.#focus === "diff" && currentSourceIndex === this.#sourceIndex) {
-					renderedLine = theme.bg("selectedBg", fit(`${theme.nav.cursor} ${renderedLine}`, contentWidth));
-				}
-				lines.push(truncateToWidth(renderedLine, contentWidth));
-				for (const entry of this.#annotations) {
-					if (entry.fileIndex === this.#fileIndex && entry.sourceIndex === currentSourceIndex) {
-						this.#appendAnnotationCallout(lines, entry.annotation.note, contentWidth);
-					}
+		for (let staticRow = 0; staticRow < staticBody.lines.length; staticRow++) {
+			const currentSourceIndex =
+				staticBody.renderedRowBySource[sourceIndex] === staticRow ? sourceIndex++ : undefined;
+			let renderedLine = staticBody.lines[staticRow] ?? "";
+			if (currentSourceIndex !== undefined) renderedRowBySource[currentSourceIndex] = lines.length;
+			if (currentSourceIndex !== undefined && this.#focus === "diff" && currentSourceIndex === this.#sourceIndex) {
+				renderedLine = theme.bg("selectedBg", fit(`${theme.nav.cursor} ${renderedLine}`, contentWidth));
+			}
+			lines.push(truncateToWidth(renderedLine, contentWidth));
+			if (currentSourceIndex === undefined) continue;
+			for (const entry of this.#annotations) {
+				if (entry.fileIndex === this.#fileIndex && entry.sourceIndex === currentSourceIndex) {
+					this.#appendAnnotationCallout(lines, entry.annotation.note, contentWidth);
 				}
 			}
-			run = [];
-		};
-		for (const diffRow of file.rows) {
-			if (isSourceRow(diffRow)) {
-				run.push(diffRow);
-				continue;
+		}
+		return { lines, renderedRowBySource };
+	}
+
+	#getStaticRenderedBody(file: ReviewDiffFile): RenderedDiffBody {
+		const cached = this.#staticRenderedDiffBodies.get(file);
+		if (cached) return cached;
+
+		const lines: string[] = [];
+		const renderedRowBySource: number[] = [];
+		if (file.isBinary) {
+			lines.push(theme.fg("dim", "Binary diff; no annotatable source rows"));
+		} else if (file.rows.length === 0) {
+			lines.push(theme.fg("dim", "No diff hunks; this may be a rename-only change"));
+		} else {
+			let sourceIndex = 0;
+			let run: ReviewSourceRow[] = [];
+			const flushRun = (): void => {
+				if (run.length === 0) return;
+				const rendered = diffRenderer
+					.renderDiff(run.map(canonicalDiffRow).join("\n"), { filePath: file.path })
+					.split("\n");
+				for (let index = 0; index < run.length; index++) {
+					renderedRowBySource[sourceIndex++] = lines.length;
+					lines.push(rendered[index] ?? "");
+				}
+				run = [];
+			};
+			for (const diffRow of file.rows) {
+				if (isSourceRow(diffRow)) {
+					run.push(diffRow);
+					continue;
+				}
+				flushRun();
+				lines.push(theme.fg(diffRow.kind === "hunk" ? "accent" : "dim", replaceTabs(sanitizeText(diffRow.raw))));
 			}
 			flushRun();
-			lines.push(theme.fg(diffRow.kind === "hunk" ? "accent" : "dim", replaceTabs(sanitizeText(diffRow.raw))));
 		}
-		flushRun();
-		return { lines, renderedRowBySource };
+
+		const body = { lines, renderedRowBySource };
+		this.#staticRenderedDiffBodies.set(file, body);
+		return body;
 	}
 
 	#appendAnnotationCallout(lines: string[], note: string, width: number): void {

--- a/packages/coding-agent/src/modes/components/code-review-overlay.ts
+++ b/packages/coding-agent/src/modes/components/code-review-overlay.ts
@@ -1,0 +1,578 @@
+import {
+	type Component,
+	Ellipsis,
+	Input,
+	matchesKey,
+	replaceTabs,
+	ScrollView,
+	type TUI,
+	truncateToWidth,
+	visibleWidth,
+} from "@oh-my-pi/pi-tui";
+import { sanitizeText } from "@oh-my-pi/pi-utils";
+import type {
+	ReviewDiffFile,
+	ReviewDiffRow,
+	ReviewSourceRow,
+} from "../../extensibility/custom-commands/bundled/review/shared";
+import { getEditorCommand, openInEditor } from "../../utils/external-editor";
+import { sanitizeStatusText } from "../shared";
+import { theme } from "../theme/theme";
+import {
+	matchesAppExternalEditor,
+	matchesSelectCancel,
+	matchesSelectDown,
+	matchesSelectPageDown,
+	matchesSelectPageUp,
+	matchesSelectUp,
+} from "../utils/keybinding-matchers";
+import { renderDiff } from "./diff";
+import {
+	bottomBorder,
+	divider,
+	dividerSplit,
+	fit,
+	row,
+	splitBodyWidth,
+	splitRow,
+	topBorder,
+	topBorderSplit,
+} from "./overlay-box";
+
+export const CONTINUE_CODE_REVIEW_ACTION = "Continue with LLM review";
+export const PASTE_CODE_REVIEW_ACTION = "Paste annotations into prompt";
+
+export interface CodeReviewAnnotation {
+	path: string;
+	oldPath?: string;
+	newPath?: string;
+	occurrence: number;
+	hunkHeader: string;
+	oldLine?: number;
+	newLine?: number;
+	rawLine: string;
+	note: string;
+}
+
+export interface CodeReviewOverlayResult {
+	action: "review" | "paste";
+	annotations: CodeReviewAnnotation[];
+}
+
+export interface CodeReviewOverlayCallbacks {
+	onComplete(result: CodeReviewOverlayResult | undefined): void;
+	onWarning?(message: string): void;
+}
+
+interface CommittedAnnotation {
+	fileIndex: number;
+	sourceIndex: number;
+	annotation: CodeReviewAnnotation;
+}
+
+interface RenderedDiffBody {
+	lines: string[];
+	renderedRowBySource: number[];
+}
+
+type FocusRegion = "files" | "diff" | "actions";
+
+const OVERLAY_TITLE = "Code Review";
+const MIN_BODY_ROWS = 3;
+const SIDEBAR_MIN_TOTAL_WIDTH = 64;
+const SIDEBAR_MIN_BODY_WIDTH = 40;
+const ACTIONS = [CONTINUE_CODE_REVIEW_ACTION, PASTE_CODE_REVIEW_ACTION] as const;
+
+function isSourceRow(row: ReviewDiffRow): row is ReviewSourceRow {
+	return row.kind === "context" || row.kind === "added" || row.kind === "removed";
+}
+
+function sourceRows(file: ReviewDiffFile): ReviewSourceRow[] {
+	return file.rows.filter(isSourceRow);
+}
+
+function canonicalDiffRow(row: ReviewSourceRow): string {
+	const marker = row.kind === "added" ? "+" : row.kind === "removed" ? "-" : " ";
+	const line = row.kind === "removed" ? row.oldLine : (row.newLine ?? row.oldLine);
+	return `${marker}${line ?? ""}|${row.content}`;
+}
+
+function displayFileLabel(file: ReviewDiffFile): string {
+	return file.occurrence > 1 ? `${file.path} (${file.occurrence})` : file.path;
+}
+
+export class CodeReviewOverlay implements Component {
+	#scrollView = new ScrollView([], {
+		height: MIN_BODY_ROWS,
+		scrollbar: "auto",
+		ellipsis: Ellipsis.Omit,
+		theme: { track: text => theme.fg("dim", text), thumb: text => theme.fg("accent", text) },
+	});
+	#input = new Input();
+	#focus: FocusRegion = "actions";
+	#fileIndex = 0;
+	#sourceIndex = 0;
+	#actionIndex = 0;
+	#bodyHeight = MIN_BODY_ROWS;
+	#sidebarShown = false;
+	#annotating = false;
+	#finished = false;
+	#annotations: CommittedAnnotation[] = [];
+
+	constructor(
+		private readonly tui: TUI,
+		private readonly files: readonly ReviewDiffFile[],
+		private readonly mode: string,
+		private readonly callbacks: CodeReviewOverlayCallbacks,
+		private readonly externalEditorLabel?: string,
+	) {
+		this.#input.setUseTerminalCursor(false);
+		this.#input.onSubmit = value => this.#commitAnnotation(value);
+		this.#input.onEscape = () => this.#cancelAnnotation();
+		this.#resetSourceCursor();
+	}
+
+	invalidate(): void {}
+
+	dispose(): void {
+		this.#finished = true;
+	}
+
+	getAnnotations(): CodeReviewAnnotation[] {
+		return this.#annotations.map(entry => ({ ...entry.annotation }));
+	}
+
+	handleInput(data: string): void {
+		if (this.#finished) return;
+		if (this.#annotating) {
+			if (matchesAppExternalEditor(data)) {
+				void this.#openAnnotationEditor();
+				return;
+			}
+			this.#input.handleInput(data);
+			return;
+		}
+		if (matchesSelectCancel(data)) {
+			this.#finish(undefined);
+			return;
+		}
+		if (data === "[") {
+			this.#selectRelativeFile(-1);
+			return;
+		}
+		if (data === "]") {
+			this.#selectRelativeFile(1);
+			return;
+		}
+		if (data === "u") {
+			this.#undoAnnotation();
+			return;
+		}
+		if (matchesKey(data, "tab") || data === "\t") {
+			this.#cycleFocus(1);
+			return;
+		}
+		if (matchesKey(data, "shift+tab") || data === "\x1b[Z") {
+			this.#cycleFocus(-1);
+			return;
+		}
+		switch (this.#focus) {
+			case "files":
+				this.#handleFiles(data);
+				break;
+			case "diff":
+				this.#handleDiff(data);
+				break;
+			case "actions":
+				this.#handleActions(data);
+				break;
+		}
+	}
+
+	#finish(result: CodeReviewOverlayResult | undefined): void {
+		if (this.#finished) return;
+		this.#finished = true;
+		this.callbacks.onComplete(result);
+	}
+
+	#cycleFocus(direction: number): void {
+		const regions: FocusRegion[] = this.#sidebarShown ? ["files", "diff", "actions"] : ["diff", "actions"];
+		const current = regions.indexOf(this.#focus);
+		const base = current < 0 ? regions.length - 1 : current;
+		this.#focus = regions[(base + direction + regions.length) % regions.length]!;
+	}
+
+	#handleFiles(data: string): void {
+		if (matchesSelectUp(data) || matchesKey(data, "k")) {
+			this.#selectFile(Math.max(0, this.#fileIndex - 1));
+			return;
+		}
+		if (matchesSelectDown(data) || matchesKey(data, "j")) {
+			this.#selectFile(Math.min(this.files.length - 1, this.#fileIndex + 1));
+			return;
+		}
+		if (
+			matchesKey(data, "right") ||
+			matchesKey(data, "l") ||
+			matchesKey(data, "enter") ||
+			matchesKey(data, "return") ||
+			data === "\n"
+		) {
+			this.#focus = "diff";
+		}
+	}
+
+	#handleDiff(data: string): void {
+		if (data === "a") {
+			this.#startAnnotation();
+			return;
+		}
+		if (matchesKey(data, "left") || matchesKey(data, "h")) {
+			if (this.#sidebarShown) this.#focus = "files";
+			return;
+		}
+		if (
+			matchesKey(data, "right") ||
+			matchesKey(data, "l") ||
+			matchesKey(data, "enter") ||
+			matchesKey(data, "return") ||
+			data === "\n"
+		) {
+			this.#focus = "actions";
+			return;
+		}
+		if (matchesKey(data, "shift+up")) {
+			this.#moveSourceCursor(-5);
+			return;
+		}
+		if (matchesKey(data, "shift+down")) {
+			this.#moveSourceCursor(5);
+			return;
+		}
+		if (matchesSelectUp(data) || matchesKey(data, "k")) {
+			this.#moveSourceCursor(-1);
+			return;
+		}
+		if (matchesSelectDown(data) || matchesKey(data, "j")) {
+			this.#moveSourceCursor(1);
+			return;
+		}
+		if (matchesSelectPageUp(data)) {
+			this.#moveSourceCursor(-Math.max(1, this.#bodyHeight - 1));
+			return;
+		}
+		if (matchesSelectPageDown(data)) {
+			this.#moveSourceCursor(Math.max(1, this.#bodyHeight - 1));
+			return;
+		}
+		if (data === "g" || matchesKey(data, "home")) {
+			this.#sourceIndex = 0;
+			return;
+		}
+		if (data === "G" || matchesKey(data, "end")) {
+			this.#sourceIndex = Math.max(0, this.#currentSourceRows().length - 1);
+		}
+	}
+
+	#handleActions(data: string): void {
+		if (matchesSelectUp(data) || matchesKey(data, "k")) {
+			this.#actionIndex = 0;
+			return;
+		}
+		if (matchesSelectDown(data) || matchesKey(data, "j")) {
+			if (this.#annotations.length > 0) this.#actionIndex = 1;
+			return;
+		}
+		if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
+			if (this.#actionIndex === 1 && this.#annotations.length === 0) return;
+			this.#finish({
+				action: this.#actionIndex === 0 ? "review" : "paste",
+				annotations: this.getAnnotations(),
+			});
+		}
+	}
+
+	#selectFile(index: number): void {
+		if (this.files.length === 0) return;
+		this.#fileIndex = Math.max(0, Math.min(this.files.length - 1, index));
+		this.#resetSourceCursor();
+		this.#scrollView.scrollToTop();
+	}
+
+	#selectRelativeFile(delta: number): void {
+		if (this.files.length === 0) return;
+		this.#selectFile((this.#fileIndex + delta + this.files.length) % this.files.length);
+	}
+
+	#resetSourceCursor(): void {
+		this.#sourceIndex = 0;
+	}
+
+	#currentFile(): ReviewDiffFile | undefined {
+		return this.files[this.#fileIndex];
+	}
+
+	#currentSourceRows(): ReviewSourceRow[] {
+		const file = this.#currentFile();
+		return file ? sourceRows(file) : [];
+	}
+
+	#moveSourceCursor(delta: number): void {
+		const rows = this.#currentSourceRows();
+		if (rows.length === 0) return;
+		this.#sourceIndex = Math.max(0, Math.min(rows.length - 1, this.#sourceIndex + delta));
+	}
+
+	#startAnnotation(): void {
+		if (this.#currentSourceRows()[this.#sourceIndex] === undefined) {
+			this.callbacks.onWarning?.("This file has no annotatable diff rows");
+			return;
+		}
+		this.#annotating = true;
+		this.#input.setValue("");
+	}
+
+	#cancelAnnotation(): void {
+		this.#annotating = false;
+		this.#input.setValue("");
+	}
+
+	#commitAnnotation(value: string): void {
+		const note = value.trim();
+		const file = this.#currentFile();
+		const source = this.#currentSourceRows()[this.#sourceIndex];
+		this.#annotating = false;
+		this.#input.setValue("");
+		if (!note || !file || !source) return;
+		this.#annotations.push({
+			fileIndex: this.#fileIndex,
+			sourceIndex: this.#sourceIndex,
+			annotation: {
+				path: file.path,
+				oldPath: file.oldPath,
+				newPath: file.newPath,
+				occurrence: file.occurrence,
+				hunkHeader: source.hunkHeader,
+				oldLine: source.oldLine,
+				newLine: source.newLine,
+				rawLine: source.raw,
+				note,
+			},
+		});
+	}
+
+	#undoAnnotation(): void {
+		this.#annotations.pop();
+		if (this.#annotations.length === 0 && this.#actionIndex === 1) this.#actionIndex = 0;
+	}
+
+	async #openAnnotationEditor(): Promise<void> {
+		const editorCommand = getEditorCommand();
+		if (!editorCommand) {
+			this.callbacks.onWarning?.("No editor configured. Set $VISUAL or $EDITOR environment variable.");
+			return;
+		}
+		const draft = this.#input.getValue();
+		try {
+			this.tui.stop();
+			const result = await openInEditor(editorCommand, draft, { extension: ".md" });
+			if (result !== null) this.#commitAnnotation(result);
+		} finally {
+			this.tui.start();
+			this.tui.requestRender(true);
+		}
+	}
+
+	#annotationCount(fileIndex: number): number {
+		let count = 0;
+		for (const entry of this.#annotations) if (entry.fileIndex === fileIndex) count++;
+		return count;
+	}
+
+	#renderBody(contentWidth: number): RenderedDiffBody {
+		const file = this.#currentFile();
+		if (!file) return { lines: [theme.fg("dim", "No reviewable files")], renderedRowBySource: [] };
+		if (file.isBinary) {
+			return { lines: [theme.fg("dim", "Binary diff; no annotatable source rows")], renderedRowBySource: [] };
+		}
+		if (file.rows.length === 0) {
+			return {
+				lines: [theme.fg("dim", "No diff hunks; this may be a rename-only change")],
+				renderedRowBySource: [],
+			};
+		}
+
+		const lines: string[] = [];
+		const renderedRowBySource: number[] = [];
+		let sourceIndex = 0;
+		let run: ReviewSourceRow[] = [];
+		const flushRun = (): void => {
+			if (run.length === 0) return;
+			const rendered = renderDiff(run.map(canonicalDiffRow).join("\n"), { filePath: file.path }).split("\n");
+			for (let index = 0; index < run.length; index++) {
+				const currentSourceIndex = sourceIndex++;
+				renderedRowBySource[currentSourceIndex] = lines.length;
+				let renderedLine = rendered[index] ?? "";
+				if (this.#focus === "diff" && currentSourceIndex === this.#sourceIndex) {
+					renderedLine = theme.bg("selectedBg", fit(`${theme.nav.cursor} ${renderedLine}`, contentWidth));
+				}
+				lines.push(truncateToWidth(renderedLine, contentWidth));
+				for (const entry of this.#annotations) {
+					if (entry.fileIndex === this.#fileIndex && entry.sourceIndex === currentSourceIndex) {
+						this.#appendAnnotationCallout(lines, entry.annotation.note, contentWidth);
+					}
+				}
+			}
+			run = [];
+		};
+		for (const diffRow of file.rows) {
+			if (isSourceRow(diffRow)) {
+				run.push(diffRow);
+				continue;
+			}
+			flushRun();
+			lines.push(theme.fg(diffRow.kind === "hunk" ? "accent" : "dim", replaceTabs(sanitizeText(diffRow.raw))));
+		}
+		flushRun();
+		return { lines, renderedRowBySource };
+	}
+
+	#appendAnnotationCallout(lines: string[], note: string, width: number): void {
+		for (const [index, noteLine] of note.split(/\r?\n/).entries()) {
+			const prefix =
+				index === 0
+					? `${theme.fg("warning", "▎ ")}${theme.fg("dim", "note: ")}`
+					: `${theme.fg("warning", "▎ ")}      `;
+			const available = Math.max(0, width - visibleWidth(prefix));
+			const content = truncateToWidth(replaceTabs(sanitizeText(noteLine)), available, Ellipsis.Unicode);
+			lines.push(truncateToWidth(`${prefix}${theme.fg("accent", content)}`, width));
+		}
+	}
+
+	#ensureCursorVisible(renderedRowBySource: readonly number[]): void {
+		const row = renderedRowBySource[this.#sourceIndex];
+		if (row === undefined) return;
+		const offset = this.#scrollView.getScrollOffset();
+		if (row < offset) this.#scrollView.setScrollOffset(row);
+		else if (row >= offset + this.#bodyHeight) this.#scrollView.setScrollOffset(row - this.#bodyHeight + 1);
+	}
+
+	#sidebarWidth(width: number): number {
+		return Math.max(18, Math.min(32, Math.round(width * 0.28)));
+	}
+
+	#canShowSidebar(width: number): boolean {
+		const sidebarWidth = this.#sidebarWidth(width);
+		return width >= SIDEBAR_MIN_TOTAL_WIDTH && splitBodyWidth(width, sidebarWidth) >= SIDEBAR_MIN_BODY_WIDTH;
+	}
+
+	#renderSidebar(rows: number, width: number): string[] {
+		const start = Math.max(
+			0,
+			Math.min(this.#fileIndex - Math.floor(rows / 2), Math.max(0, this.files.length - rows)),
+		);
+		return Array.from({ length: rows }, (_, rowIndex) => {
+			const index = start + rowIndex;
+			const file = this.files[index];
+			if (!file) return "";
+			const selected = index === this.#fileIndex;
+			const count = this.#annotationCount(index);
+			const badge = `${theme.fg("dim", ` +${file.linesAdded}/-${file.linesRemoved}`)}${count ? theme.fg("warning", ` ✎${count}`) : ""}`;
+			const available = Math.max(0, width - visibleWidth(badge) - 2);
+			const label = truncateToWidth(sanitizeStatusText(displayFileLabel(file)), available, Ellipsis.Unicode);
+			const cursor = selected ? (this.#focus === "files" ? "› " : "▎ ") : "  ";
+			const line = fit(`${cursor}${label}${badge}`, width);
+			return selected && this.#focus === "files"
+				? theme.bg("selectedBg", theme.bold(line))
+				: theme.fg(selected ? "accent" : "muted", line);
+		});
+	}
+
+	#renderCurrentFileHeader(width: number): string {
+		const file = this.#currentFile();
+		if (!file) return theme.fg("dim", "No reviewable files");
+		const count = this.#annotationCount(this.#fileIndex);
+		const suffix = `  +${file.linesAdded}/-${file.linesRemoved}${count ? `  ✎${count}` : ""}`;
+		return truncateToWidth(
+			`${theme.bold(sanitizeStatusText(displayFileLabel(file)))}${theme.fg("dim", suffix)}`,
+			width,
+			Ellipsis.Unicode,
+		);
+	}
+
+	#renderActions(): string[] {
+		return ACTIONS.map((label, index) => {
+			const disabled = index === 1 && this.#annotations.length === 0;
+			const selected = index === this.#actionIndex;
+			const cursor = selected ? `${theme.nav.cursor} ` : "  ";
+			const text = disabled
+				? theme.fg("dim", label)
+				: selected && this.#focus === "actions"
+					? theme.bold(theme.fg("accent", label))
+					: theme.fg("text", label);
+			return cursor + text;
+		});
+	}
+
+	#renderFooter(width: number): string[] {
+		if (this.#annotating) {
+			const source = this.#currentSourceRows()[this.#sourceIndex];
+			const location = source
+				? `${displayFileLabel(this.#currentFile()!)} · ${source.oldLine ?? "-"}/${source.newLine ?? "-"}`
+				: "diff row";
+			const caption = truncateToWidth(
+				`${theme.fg("dim", "Annotate")} ${theme.fg("accent", sanitizeStatusText(location))}`,
+				width,
+				Ellipsis.Unicode,
+			);
+			const hints = ["enter save", "esc cancel"];
+			if (this.externalEditorLabel) hints.push(`${this.externalEditorLabel} editor`);
+			return [caption, this.#input.render(width)[0] ?? "", theme.fg("dim", hints.join(" · "))];
+		}
+		const focusHelp =
+			this.#focus === "files"
+				? "↑↓ file · ⏎ diff"
+				: this.#focus === "diff"
+					? "↑↓ line · ⇧ faster · pgup/pgdn · g/G ends · a annotate"
+					: "↑↓ select · ⏎ confirm";
+		return [theme.fg("dim", `${focusHelp} · [/] file · u undo · tab regions · esc cancel`)];
+	}
+
+	render(width: number): readonly string[] {
+		const termHeight = process.stdout.rows || 40;
+		this.#sidebarShown = this.#canShowSidebar(width);
+		if (!this.#sidebarShown && this.#focus === "files") this.#focus = "diff";
+		const sidebarWidth = this.#sidebarShown ? this.#sidebarWidth(width) : 0;
+		const innerWidth = Math.max(1, width - 4);
+		const bodyWidth = this.#sidebarShown ? splitBodyWidth(width, sidebarWidth) : innerWidth;
+		const footer = this.#renderFooter(innerWidth);
+		const narrowHeaderRows = this.#sidebarShown ? 0 : 1;
+		const chromeRows = 4 + 1 + ACTIONS.length + footer.length + narrowHeaderRows;
+		this.#bodyHeight = Math.max(MIN_BODY_ROWS, termHeight - chromeRows);
+		const renderedBody = this.#renderBody(bodyWidth);
+		this.#scrollView.setLines(renderedBody.lines);
+		this.#scrollView.setHeight(this.#bodyHeight);
+		this.#ensureCursorVisible(renderedBody.renderedRowBySource);
+		const body = this.#scrollView.render(bodyWidth);
+		const out: string[] = [];
+		if (this.#sidebarShown) {
+			const sidebar = this.#renderSidebar(this.#bodyHeight, sidebarWidth);
+			out.push(topBorderSplit(width, OVERLAY_TITLE, sidebarWidth));
+			for (let index = 0; index < this.#bodyHeight; index++) {
+				out.push(splitRow(sidebar[index] ?? "", body[index] ?? "", width, sidebarWidth));
+			}
+			out.push(dividerSplit(width, sidebarWidth));
+		} else {
+			out.push(topBorder(width, OVERLAY_TITLE));
+			out.push(row(this.#renderCurrentFileHeader(innerWidth), width));
+			for (const bodyLine of body) out.push(row(bodyLine, width));
+			out.push(divider(width));
+		}
+		out.push(row(theme.bold(theme.fg("accent", sanitizeStatusText(this.mode))), width));
+		for (const action of this.#renderActions()) out.push(row(action, width));
+		out.push(divider(width));
+		for (const footerLine of footer) out.push(row(footerLine, width));
+		out.push(bottomBorder(width));
+		return out;
+	}
+}

--- a/packages/coding-agent/src/modes/components/code-review-overlay.ts
+++ b/packages/coding-agent/src/modes/components/code-review-overlay.ts
@@ -109,7 +109,7 @@ export class CodeReviewOverlay implements Component {
 		theme: { track: text => theme.fg("dim", text), thumb: text => theme.fg("accent", text) },
 	});
 	#input = new Input();
-	#focus: FocusRegion = "actions";
+	#focus: FocusRegion = "files";
 	#fileIndex = 0;
 	#sourceIndex = 0;
 	#actionIndex = 0;

--- a/packages/coding-agent/src/modes/components/diff.ts
+++ b/packages/coding-agent/src/modes/components/diff.ts
@@ -53,6 +53,11 @@ function parseDiffLine(line: string): { prefix: CodeFrameMarker; lineNum: string
  * Strips leading whitespace from inverse to avoid highlighting indentation.
  */
 function renderIntraLineDiff(oldContent: string, newContent: string): { removedLine: string; addedLine: string } {
+	if (typeof diffWords !== "function") {
+		// Source checkouts can load an older native binary before bindings are
+		// rebuilt. Keep diff rendering usable; only intra-line emphasis degrades.
+		return { removedLine: oldContent, addedLine: newContent };
+	}
 	const wordDiff = diffWords(oldContent, newContent);
 
 	let removedLine = "";

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -12,6 +12,7 @@ import type {
 	ExtensionContextActions,
 	ExtensionError,
 	ExtensionUIContext,
+	ExtensionUICustomOptions,
 	ExtensionUIDialogOptions,
 	ExtensionUISelectItem,
 	ExtensionUiComponent,
@@ -1047,7 +1048,7 @@ export class ExtensionUiController {
 			keybindings: KeybindingsManager,
 			done: (result: T) => void,
 		) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>,
-		options?: { overlay?: boolean },
+		options?: ExtensionUICustomOptions,
 	): Promise<T> {
 		const savedText = this.ctx.editor.getText();
 		const keybindings = KeybindingsManager.inMemory();
@@ -1085,7 +1086,10 @@ export class ExtensionUiController {
 					width: "100%",
 					maxHeight: "100%",
 					margin: 0,
+					fullscreen: options.fullscreen,
+					mouseTracking: options.mouseTracking,
 				});
+				this.ctx.ui.setFocus(component);
 				return;
 			}
 			this.ctx.editorContainer.clear();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -71,6 +71,7 @@ import type {
 	AutocompleteProviderFactory,
 	ContextUsage,
 	ExtensionUIContext,
+	ExtensionUICustomOptions,
 	ExtensionUIDialogOptions,
 	ExtensionUISelectItem,
 	ExtensionWidgetContent,
@@ -5025,7 +5026,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			keybindings: KeybindingsManager,
 			done: (result: T) => void,
 		) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>,
-		options?: { overlay?: boolean },
+		options?: ExtensionUICustomOptions,
 	): Promise<T> {
 		return this.#extensionUiController.showHookCustom(factory, options);
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -9,6 +9,7 @@ import type { Settings } from "../config/settings";
 import type {
 	AutocompleteProviderFactory,
 	ExtensionUIContext,
+	ExtensionUICustomOptions,
 	ExtensionUIDialogOptions,
 	ExtensionUISelectItem,
 	ExtensionWidgetContent,
@@ -487,7 +488,7 @@ export interface InteractiveModeContext {
 			keybindings: KeybindingsManager,
 			done: (result: T) => void,
 		) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>,
-		options?: { overlay?: boolean },
+		options?: ExtensionUICustomOptions,
 	): Promise<T>;
 	showExtensionError(extensionPath: string, error: string): void;
 	showToolError(toolName: string, error: string): void;

--- a/packages/coding-agent/src/prompts/code-review-annotations.md
+++ b/packages/coding-agent/src/prompts/code-review-annotations.md
@@ -1,0 +1,25 @@
+{{#if forReviewer}}
+## Operator-Supplied Review Focus
+
+You MUST verify every annotation against the diff and surrounding code. NEVER repeat an operator note without independently validating it.
+{{else}}
+## Code Review Annotations
+{{/if}}
+
+{{#list annotations join="\n\n"}}
+### {{pathLabel}} — {{lineLabel}}
+
+Hunk: `{{hunkHeader}}`
+
+{{#codeblock lang="diff"}}
+{{rawLine}}
+{{/codeblock}}
+
+{{note}}
+{{/list}}
+{{#if supplementalInstructions}}
+
+## Supplemental Review Instructions
+
+{{supplementalInstructions}}
+{{/if}}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -110,7 +110,7 @@ import { getFileSnapshotStore } from "../edit/file-snapshot-store";
 import type { PythonResult } from "../eval/py/executor";
 import type { BashResult } from "../exec/bash-executor";
 import type { TtsrManager } from "../export/ttsr";
-import type { LoadedCustomCommand } from "../extensibility/custom-commands";
+import type { CustomCommandContext, LoadedCustomCommand } from "../extensibility/custom-commands";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import type {
 	ExtensionCommandContext,
@@ -134,7 +134,6 @@ import { emitSessionShutdownEvent } from "../extensibility/extensions";
 import { ManagedTimers } from "../extensibility/extensions/managed-timers";
 import { createExtensionModelQuery } from "../extensibility/extensions/model-api";
 import type { CompactOptions, ContextUsage } from "../extensibility/extensions/types";
-import type { HookCommandContext } from "../extensibility/hooks/types";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import { expandSlashCommand, type FileSlashCommand } from "../extensibility/slash-commands";
 import { normalizeToolEventInput, resolveToolEventInput } from "../extensibility/tool-event-input";
@@ -5454,10 +5453,15 @@ export class AgentSession {
 
 		// Get command context from extension runner (includes session control methods)
 		const baseCtx = this.#createCommandContext();
-		const ctx = {
+		const ctx: CustomCommandContext = {
 			...baseCtx,
+			ui: {
+				...baseCtx.ui,
+				custom: (factory, options) =>
+					baseCtx.ui.custom((tui, uiTheme, _keybindings, done) => factory(tui, uiTheme, done), options),
+			},
 			hasQueuedMessages: baseCtx.hasPendingMessages,
-		} as unknown as HookCommandContext;
+		};
 
 		try {
 			const args = parseCommandArgs(argsString);

--- a/packages/coding-agent/test/extensibility/custom-commands/ci-green.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/ci-green.test.ts
@@ -4,8 +4,10 @@ import type * as TypeBox from "@oh-my-pi/omptype/typebox";
 import * as zod from "@oh-my-pi/omptype/zod";
 import * as piCodingAgent from "@oh-my-pi/pi-coding-agent";
 import { GreenCommand } from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/bundled/ci-green";
-import type { CustomCommandAPI } from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/types";
-import type { HookCommandContext } from "@oh-my-pi/pi-coding-agent/extensibility/hooks/types";
+import type {
+	CustomCommandAPI,
+	CustomCommandContext,
+} from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/types";
 import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
 
 afterEach(() => {
@@ -33,7 +35,7 @@ describe("GreenCommand", () => {
 		vi.spyOn(git.ref, "tags").mockResolvedValue(["v0.1.0-alpha2"]);
 		const command = new GreenCommand(createApi());
 
-		const result = await command.execute([], {} as HookCommandContext);
+		const result = await command.execute([], {} as CustomCommandContext);
 
 		expect(result).toContain("v0.1.0-alpha2");
 		expect(result).not.toContain("timeouts due to the harnesses");
@@ -43,7 +45,7 @@ describe("GreenCommand", () => {
 		vi.spyOn(git.ref, "tags").mockResolvedValue([]);
 		const command = new GreenCommand(createApi());
 
-		const result = await command.execute([], {} as HookCommandContext);
+		const result = await command.execute([], {} as CustomCommandContext);
 
 		expect(result).not.toContain("v0.1.0-alpha2");
 	});

--- a/packages/coding-agent/test/extensibility/custom-commands/code-review.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/code-review.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, spyOn, vi } from "bun:test";
+import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import { CodeReviewCommand } from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/bundled/review/code-review";
+import { loadCustomCommands } from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/loader";
+import type {
+	CustomCommandAPI,
+	CustomCommandContext,
+	CustomCommandUIContext,
+} from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/types";
+import type { ExtensionUICustomOptions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import type { CodeReviewOverlay } from "@oh-my-pi/pi-coding-agent/modes/components/code-review-overlay";
+import { getThemeByName, setThemeInstance, type Theme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
+import * as jj from "@oh-my-pi/pi-coding-agent/utils/jj";
+import { type Component, setKeybindings, type TUI } from "@oh-my-pi/pi-tui";
+
+const DOWN = "\x1b[B";
+const ENTER = "\r";
+const TAB = "\t";
+
+const SAMPLE_DIFF = `diff --git i/src/workspace.ts w/src/workspace.ts
+--- i/src/workspace.ts
++++ w/src/workspace.ts
+@@ -0,0 +1 @@
++export const value = 2;
+`;
+
+let darkTheme = await getThemeByName("dark");
+
+describe("CodeReviewCommand", () => {
+	beforeAll(async () => {
+		darkTheme = await getThemeByName("dark");
+		if (!darkTheme) throw new Error("Failed to load dark theme");
+	});
+
+	beforeEach(() => {
+		setThemeInstance(darkTheme!);
+		setKeybindings(KeybindingsManager.inMemory());
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function createContext(
+		actionIndex: number,
+		pasted: string[],
+		customOptions: unknown[],
+		selectResults = ["2. Review uncommitted changes"],
+	): CustomCommandContext {
+		const selections = [...selectResults];
+		const pasteToEditor: CustomCommandUIContext["pasteToEditor"] = text => pasted.push(text);
+		const custom: CustomCommandUIContext["custom"] = async <T>(
+			factory: (
+				tui: TUI,
+				uiTheme: Theme,
+				done: (result: T) => void,
+			) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>,
+			options?: ExtensionUICustomOptions,
+		): Promise<T> => {
+			customOptions.push(options);
+			const settled = Promise.withResolvers<T>();
+			const component = (await factory({} as TUI, theme, settled.resolve)) as Component;
+			const overlay = component as CodeReviewOverlay;
+			overlay.render(90);
+			overlay.handleInput(TAB);
+			overlay.handleInput(TAB);
+			overlay.handleInput("a");
+			for (const char of "check the workspace transition") overlay.handleInput(char);
+			overlay.handleInput(ENTER);
+			overlay.handleInput(TAB);
+			for (let index = 0; index < actionIndex; index++) overlay.handleInput(DOWN);
+			overlay.handleInput(ENTER);
+			return settled.promise;
+		};
+		return {
+			hasUI: true,
+			ui: {
+				select: async () => selections.shift(),
+				notify: vi.fn(),
+				pasteToEditor,
+				custom,
+			},
+		} as unknown as CustomCommandContext;
+	}
+
+	it("continues the regular review flow with annotations as additional instructions", async () => {
+		spyOn(jj.repo, "is").mockResolvedValue(true);
+		spyOn(jj, "diff").mockResolvedValue(SAMPLE_DIFF);
+		const pasted: string[] = [];
+		const customOptions: unknown[] = [];
+		const command = new CodeReviewCommand({ cwd: "/tmp/review" } as CustomCommandAPI);
+
+		const result = await command.execute(["focus", "authentication"], createContext(0, pasted, customOptions));
+
+		expect(result).toContain("## Code Review Request");
+		expect(result).toContain("You MUST verify every annotation against the diff and surrounding code");
+		expect(result).toContain("src/workspace.ts");
+		expect(result).toContain("## Supplemental Review Instructions");
+		expect(result).toContain("focus authentication");
+		expect(pasted).toEqual([]);
+		expect(customOptions).toEqual([{ overlay: true, fullscreen: true, mouseTracking: false }]);
+	});
+
+	it("inserts annotations into the current prompt instead of starting AI review", async () => {
+		spyOn(jj.repo, "is").mockResolvedValue(true);
+		spyOn(jj, "diff").mockResolvedValue(SAMPLE_DIFF);
+		const pasted: string[] = [];
+		const command = new CodeReviewCommand({ cwd: "/tmp/review" } as CustomCommandAPI);
+
+		const result = await command.execute([], createContext(1, pasted, []));
+
+		expect(result).toBeUndefined();
+		expect(pasted).toHaveLength(1);
+		expect(pasted[0]).toContain("check the workspace transition");
+		expect(pasted[0]).toContain("### src/workspace.ts — new line 1");
+	});
+
+	it("reuses the base-branch review target", async () => {
+		spyOn(git.branch, "list").mockResolvedValue(["main"]);
+		spyOn(git.branch, "current").mockResolvedValue("feature");
+		const diffSpy = spyOn(git, "diff").mockResolvedValue(SAMPLE_DIFF);
+		const command = new CodeReviewCommand({ cwd: "/tmp/review" } as CustomCommandAPI);
+
+		const result = await command.execute(
+			[],
+			createContext(0, [], [], ["1. Review against a base branch (PR Style)", "main"]),
+		);
+
+		expect(result).toContain("Reviewing changes between `main` and `feature`");
+		expect(diffSpy).toHaveBeenCalledWith("/tmp/review", { base: "main...feature" });
+	});
+
+	it("reuses the specific-commit review target", async () => {
+		spyOn(git.log, "onelines").mockResolvedValue(["abc1234 Add workspace transition"]);
+		const showSpy = spyOn(git, "show").mockResolvedValue(SAMPLE_DIFF);
+		const command = new CodeReviewCommand({ cwd: "/tmp/review" } as CustomCommandAPI);
+
+		const result = await command.execute(
+			[],
+			createContext(0, [], [], ["3. Review a specific commit", "abc1234 Add workspace transition"]),
+		);
+
+		expect(result).toContain("Reviewing commit `abc1234`");
+		expect(showSpy).toHaveBeenCalledWith("/tmp/review", "abc1234", { format: "" });
+	});
+
+	it("registers the bundled slash command", async () => {
+		const result = await loadCustomCommands({
+			cwd: "/tmp/omp-code-review-command-test",
+			agentDir: "/tmp/omp-code-review-command-test-agent",
+		});
+
+		expect(result.errors).toEqual([]);
+		expect(result.commands.map(command => command.command.name)).toContain("code-review");
+	});
+});

--- a/packages/coding-agent/test/extensibility/custom-commands/code-review.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/code-review.test.ts
@@ -64,7 +64,6 @@ describe("CodeReviewCommand", () => {
 			const overlay = component as CodeReviewOverlay;
 			overlay.render(90);
 			overlay.handleInput(TAB);
-			overlay.handleInput(TAB);
 			overlay.handleInput("a");
 			for (const char of "check the workspace transition") overlay.handleInput(char);
 			overlay.handleInput(ENTER);

--- a/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
@@ -2,9 +2,14 @@ import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { ReviewCommand } from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/bundled/review";
-import type { CustomCommandAPI } from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/types";
-import type { HookCommandContext } from "@oh-my-pi/pi-coding-agent/extensibility/hooks/types";
+import {
+	parseReviewDiffSnapshot,
+	ReviewCommand,
+} from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/bundled/review";
+import type {
+	CustomCommandAPI,
+	CustomCommandContext,
+} from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/types";
 import type { SessionEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import type { PrDiffPayload, ViewLookupResult } from "@oh-my-pi/pi-coding-agent/tools/gh";
 import * as gh from "@oh-my-pi/pi-coding-agent/tools/gh";
@@ -106,7 +111,7 @@ describe("ReviewCommand", () => {
 		onEditorCall?: (call: EditorCall) => void;
 		onSelectCall?: (call: SelectCall) => void;
 		onNotify?: (call: NotifyCall) => void;
-	}): HookCommandContext {
+	}): CustomCommandContext {
 		const selectResults = [...(options?.selectResults ?? [])];
 		return {
 			hasUI: true,
@@ -134,7 +139,7 @@ describe("ReviewCommand", () => {
 					options?.onNotify?.({ message, type });
 				},
 			},
-		} as unknown as HookCommandContext;
+		} as unknown as CustomCommandContext;
 	}
 
 	it("uses prompt-style input for custom review instructions", async () => {
@@ -251,7 +256,7 @@ describe("ReviewCommand", () => {
 		const dir = await createTempDir();
 		const diffSpy = spyOn(gh, "getOrFetchPrDiff").mockResolvedValue(makePrDiffLookup(SAMPLE_PR_DIFF));
 		const command = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
-		const ctx = { hasUI: false } as unknown as HookCommandContext;
+		const ctx = { hasUI: false } as unknown as CustomCommandContext;
 
 		const cases = [
 			"https://github.com/owner/repo/pull/123",
@@ -277,7 +282,7 @@ describe("ReviewCommand", () => {
 		const dir = await createTempDir();
 		spyOn(gh, "getOrFetchPrDiff").mockResolvedValue(makePrDiffLookup(SAMPLE_PR_DIFF));
 		const command = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
-		const ctx = { hasUI: false } as unknown as HookCommandContext;
+		const ctx = { hasUI: false } as unknown as CustomCommandContext;
 
 		const result = await command.execute(["https://github.com/owner/repo/pull/123"], ctx);
 
@@ -292,7 +297,7 @@ describe("ReviewCommand", () => {
 		const dir = await createTempDir();
 		spyOn(gh, "getOrFetchPrDiff").mockResolvedValue(makePrDiffLookup(makeManyFileDiff(21)));
 		const command = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
-		const ctx = { hasUI: false } as unknown as HookCommandContext;
+		const ctx = { hasUI: false } as unknown as CustomCommandContext;
 
 		const result = await command.execute(["https://github.com/owner/repo/pull/123"], ctx);
 
@@ -306,7 +311,7 @@ describe("ReviewCommand", () => {
 	it("rejects unsupported PR-like URL formats as normal instructions", async () => {
 		const diffSpy = spyOn(gh, "getOrFetchPrDiff").mockResolvedValue(makePrDiffLookup(SAMPLE_PR_DIFF));
 		const command = new ReviewCommand({ cwd: "/tmp" } as unknown as CustomCommandAPI);
-		const ctx = { hasUI: false } as unknown as HookCommandContext;
+		const ctx = { hasUI: false } as unknown as CustomCommandContext;
 
 		const cases = [
 			"https://github.com/owner/repo/issues/123",
@@ -331,7 +336,7 @@ describe("ReviewCommand", () => {
 		const dir = await createTempDir();
 		const diffSpy = spyOn(gh, "getOrFetchPrDiff").mockResolvedValue(makePrDiffLookup(SAMPLE_PR_DIFF));
 		const command = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
-		const ctx = { hasUI: false } as unknown as HookCommandContext;
+		const ctx = { hasUI: false } as unknown as CustomCommandContext;
 		const secondUrl = "https://github.com/owner/repo/pull/456";
 
 		const result = await command.execute(["focus", "https://github.com/owner/repo/pull/123", "on", secondUrl], ctx);
@@ -591,9 +596,58 @@ describe("ReviewCommand", () => {
 		expect(result!).toContain("src/pr.ts");
 		expect(showSpy).toHaveBeenCalledWith(dir, "abc1234", { format: "" });
 	});
+	it("parses quoted rename paths and exact old/new line anchors", () => {
+		const snapshot = parseReviewDiffSnapshot(`diff --git "a/src/old name.ts" "b/src/new name.ts"
+similarity index 80%
+rename from "src/old name.ts"
+rename to "src/new name.ts"
+--- "a/src/old name.ts"
++++ "b/src/new name.ts"
+@@ -10,2 +10,3 @@ export function value()
+ context
+-removed
++added
++second
+\\ No newline at end of file`);
+
+		expect(snapshot.files).toHaveLength(1);
+		expect(snapshot.files[0]).toEqual(
+			expect.objectContaining({
+				path: "src/new name.ts",
+				oldPath: "src/old name.ts",
+				newPath: "src/new name.ts",
+				linesAdded: 2,
+				linesRemoved: 1,
+			}),
+		);
+		expect(snapshot.files[0]!.rows).toMatchObject([
+			{ kind: "hunk", hunkHeader: "@@ -10,2 +10,3 @@ export function value()" },
+			{ kind: "context", oldLine: 10, newLine: 10, raw: " context" },
+			{ kind: "removed", oldLine: 11, raw: "-removed" },
+			{ kind: "added", newLine: 11, raw: "+added" },
+			{ kind: "added", newLine: 12, raw: "+second" },
+			{ kind: "no-newline", raw: "\\ No newline at end of file" },
+		]);
+	});
+
+	it("keeps duplicate staged and unstaged file diffs independently addressable", () => {
+		const fileDiff = `diff --git a/src/value.ts b/src/value.ts
+--- a/src/value.ts
++++ b/src/value.ts
+@@ -0,0 +1 @@
++value`;
+		const snapshot = parseReviewDiffSnapshot(`${fileDiff}\n${fileDiff}`);
+
+		expect(snapshot.files.map(file => ({ path: file.path, occurrence: file.occurrence }))).toEqual([
+			{ path: "src/value.ts", occurrence: 1 },
+			{ path: "src/value.ts", occurrence: 2 },
+		]);
+		expect(snapshot.totalAdded).toBe(2);
+	});
+
 	it("renders headless review requests through the reviewer task prompt", async () => {
 		const command = new ReviewCommand({ cwd: "/tmp" } as unknown as CustomCommandAPI);
-		const ctx = { hasUI: false } as unknown as HookCommandContext;
+		const ctx = { hasUI: false } as unknown as CustomCommandContext;
 
 		const result = await command.execute(["focus", "auth"], ctx);
 

--- a/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
@@ -630,6 +630,53 @@ rename to "src/new name.ts"
 		]);
 	});
 
+	it("parses unquoted marker paths with spaces through a tab suffix or end of line", () => {
+		const snapshot = parseReviewDiffSnapshot(`diff --git a/src/old-name.ts b/src/new-name.ts
+--- a/src/old name.ts	2026-08-05 12:00:00
++++ b/src/new name.ts
+@@ -1 +1 @@
+-old
++new
+diff --git a/src/created-name.ts b/src/created-name.ts
+new file mode 100644
+--- /dev/null
++++ b/src/created name.ts
+@@ -0,0 +1 @@
++created`);
+
+		expect(snapshot.files.map(file => ({ path: file.path, oldPath: file.oldPath, newPath: file.newPath }))).toEqual([
+			{
+				path: "src/new name.ts",
+				oldPath: "src/old name.ts",
+				newPath: "src/new name.ts",
+			},
+			{
+				path: "src/created name.ts",
+				oldPath: undefined,
+				newPath: "src/created name.ts",
+			},
+		]);
+	});
+
+	it("applies review exclusions to complete unquoted spaced marker paths", () => {
+		const snapshot = parseReviewDiffSnapshot(`diff --git a/config/workspace-lock.json b/config/workspace-lock.json
+--- a/config/workspace lockfile.lock
++++ b/config/workspace lockfile.lock	2026-08-05 12:00:00
+@@ -1 +1 @@
+-old
++new`);
+
+		expect(snapshot.files).toHaveLength(0);
+		expect(snapshot.excluded).toEqual([
+			{
+				path: "config/workspace lockfile.lock",
+				reason: "lock file",
+				linesAdded: 1,
+				linesRemoved: 1,
+			},
+		]);
+	});
+
 	it("keeps duplicate staged and unstaged file diffs independently addressable", () => {
 		const fileDiff = `diff --git a/src/value.ts b/src/value.ts
 --- a/src/value.ts

--- a/packages/coding-agent/test/modes/components/code-review-overlay.test.ts
+++ b/packages/coding-agent/test/modes/components/code-review-overlay.test.ts
@@ -17,6 +17,7 @@ import { setKeybindings, type TUI } from "@oh-my-pi/pi-tui";
 const DOWN = "\x1b[B";
 const ENTER = "\r";
 const TAB = "\t";
+const SHIFT_ENTER = "\x1b[13;2~";
 
 let darkTheme = await getThemeByName("dark");
 
@@ -75,6 +76,17 @@ diff --git a/src/beta.ts b/src/beta.ts
 		expect(render(overlay)).toContain("↑↓ line");
 	});
 
+	it("shows the full current nested path above the wide diff pane", () => {
+		const nestedPath = "packages/coding-agent/src/modes/components/deep/code-review-pane.ts";
+		const { overlay } = makeOverlay(`diff --git a/${nestedPath} b/${nestedPath}
+--- a/${nestedPath}
++++ b/${nestedPath}
+@@ -0,0 +1 @@
++new`);
+
+		expect(render(overlay, 120)).toContain(nestedPath);
+	});
+
 	it("anchors an annotation to the selected diff line", () => {
 		const rows = Array.from({ length: 80 }, (_, index) => ` context-row-${String(index).padStart(3, "0")}`);
 		const { overlay, onComplete } = makeOverlay(
@@ -104,6 +116,28 @@ diff --git a/src/beta.ts b/src/beta.ts
 		expect(onComplete).toHaveBeenCalledWith(
 			expect.objectContaining({ action: "review", annotations: overlay.getAnnotations() }),
 		);
+	});
+
+	it("commits a multiline annotation entered with shift+enter", () => {
+		const { overlay } = makeOverlay(
+			"diff --git a/src/value.ts b/src/value.ts\n--- a/src/value.ts\n+++ b/src/value.ts\n@@ -0,0 +1 @@\n+new",
+		);
+
+		render(overlay);
+		overlay.handleInput(TAB);
+		overlay.handleInput("a");
+		overlay.handleInput("first line");
+		overlay.handleInput(SHIFT_ENTER);
+		overlay.handleInput("second line");
+		expect(render(overlay)).toContain("shift+enter newline");
+		overlay.handleInput(ENTER);
+
+		expect(overlay.getAnnotations()).toEqual([
+			expect.objectContaining({ newLine: 1, note: "first line\nsecond line" }),
+		]);
+		const out = render(overlay);
+		expect(out).toContain("first line");
+		expect(out).toContain("second line");
 	});
 
 	it("gates paste until annotations exist and supports undo", () => {

--- a/packages/coding-agent/test/modes/components/code-review-overlay.test.ts
+++ b/packages/coding-agent/test/modes/components/code-review-overlay.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -11,6 +11,7 @@ import {
 	type CodeReviewOverlayResult,
 	PASTE_CODE_REVIEW_ACTION,
 } from "@oh-my-pi/pi-coding-agent/modes/components/code-review-overlay";
+import * as diffRenderer from "@oh-my-pi/pi-coding-agent/modes/components/diff";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { setKeybindings, type TUI } from "@oh-my-pi/pi-tui";
 
@@ -20,9 +21,10 @@ const TAB = "\t";
 const SHIFT_ENTER = "\x1b[13;2~";
 
 let darkTheme = await getThemeByName("dark");
+let lightTheme = await getThemeByName("light");
 
 function render(component: CodeReviewOverlay, width = 90): string {
-	return stripVTControlCharacters(component.render(width).join("\n"));
+	return component.render(width).map(stripVTControlCharacters).join("\n");
 }
 
 function makeOverlay(
@@ -41,12 +43,18 @@ function makeOverlay(
 describe("CodeReviewOverlay", () => {
 	beforeAll(async () => {
 		darkTheme = await getThemeByName("dark");
+		lightTheme = await getThemeByName("light");
 		if (!darkTheme) throw new Error("Failed to load dark theme");
+		if (!lightTheme) throw new Error("Failed to load light theme");
 	});
 
 	beforeEach(() => {
 		setThemeInstance(darkTheme!);
 		setKeybindings(KeybindingsManager.inMemory());
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
 	});
 
 	it("renders changed files, diff contents, and review actions", () => {
@@ -138,6 +146,73 @@ diff --git a/src/beta.ts b/src/beta.ts
 		const out = render(overlay);
 		expect(out).toContain("first line");
 		expect(out).toContain("second line");
+	});
+
+	it("keeps static diff rows cached while dynamic interactions update", () => {
+		const trailingRows = Array.from(
+			{ length: 40 },
+			(_, index) => ` context-tail-${String(index).padStart(3, "0")}`,
+		).join("\n");
+		const longContent = `long-${"x".repeat(56)}`;
+		const { overlay } = makeOverlay(`diff --git a/src/alpha.ts b/src/alpha.ts
+--- a/src/alpha.ts
++++ b/src/alpha.ts
+@@ -1,41 +1,42 @@
+ context-first
++${longContent}
+${trailingRows}
+diff --git a/src/beta.ts b/src/beta.ts
+--- a/src/beta.ts
++++ b/src/beta.ts
+@@ -0,0 +1 @@
++beta`);
+		const renderDiffSpy = vi.spyOn(diffRenderer, "renderDiff");
+
+		expect(render(overlay, 120)).toContain(longContent);
+		expect(renderDiffSpy).toHaveBeenCalledTimes(1);
+
+		overlay.handleInput(TAB);
+		overlay.handleInput(DOWN);
+		expect(render(overlay, 120)).toContain(longContent);
+		expect(renderDiffSpy).toHaveBeenCalledTimes(1);
+
+		overlay.handleInput("a");
+		for (const char of "cached annotation") overlay.handleInput(char);
+		overlay.handleInput(ENTER);
+		expect(render(overlay, 120)).toContain("cached annotation");
+		expect(overlay.getAnnotations()).toEqual([expect.objectContaining({ newLine: 2, note: "cached annotation" })]);
+		expect(renderDiffSpy).toHaveBeenCalledTimes(1);
+
+		const narrow = render(overlay, 45);
+		expect(narrow).not.toContain(longContent);
+		expect(narrow).toContain("long-");
+		expect(narrow.split("\n").every(line => Bun.stringWidth(line) <= 45)).toBe(true);
+		expect(renderDiffSpy).toHaveBeenCalledTimes(1);
+
+		for (let index = 0; index < 40; index++) overlay.handleInput(DOWN);
+		expect(render(overlay, 120)).toContain("context-tail-039");
+		expect(renderDiffSpy).toHaveBeenCalledTimes(1);
+
+		overlay.handleInput("]");
+		expect(render(overlay, 120)).toContain("beta");
+		expect(renderDiffSpy).toHaveBeenCalledTimes(2);
+
+		overlay.handleInput("[");
+		expect(render(overlay, 120)).toContain("cached annotation");
+		expect(renderDiffSpy).toHaveBeenCalledTimes(2);
+
+		const darkLine = overlay.render(120).find(line => stripVTControlCharacters(line).includes("context-first"));
+		try {
+			setThemeInstance(lightTheme!);
+			overlay.invalidate();
+			const lightLine = overlay.render(120).find(line => stripVTControlCharacters(line).includes("context-first"));
+			expect(stripVTControlCharacters(lightLine ?? "")).toContain("context-first");
+			expect(lightLine).not.toBe(darkLine);
+			expect(renderDiffSpy).toHaveBeenCalledTimes(3);
+		} finally {
+			setThemeInstance(darkTheme!);
+			overlay.invalidate();
+		}
 	});
 
 	it("gates paste until annotations exist and supports undo", () => {

--- a/packages/coding-agent/test/modes/components/code-review-overlay.test.ts
+++ b/packages/coding-agent/test/modes/components/code-review-overlay.test.ts
@@ -52,7 +52,8 @@ describe("CodeReviewOverlay", () => {
 		const { overlay } = makeOverlay(`diff --git a/src/alpha.ts b/src/alpha.ts
 --- a/src/alpha.ts
 +++ b/src/alpha.ts
-@@ -0,0 +1 @@
+@@ -1 +1 @@
+-old
 +new
 diff --git a/src/beta.ts b/src/beta.ts
 --- a/src/beta.ts
@@ -68,8 +69,10 @@ diff --git a/src/beta.ts b/src/beta.ts
 		expect(out).toContain(CONTINUE_CODE_REVIEW_ACTION);
 		expect(out).toContain(PASTE_CODE_REVIEW_ACTION);
 
-		overlay.handleInput("]");
+		overlay.handleInput(DOWN);
 		expect(render(overlay)).toContain("beta");
+		overlay.handleInput(TAB);
+		expect(render(overlay)).toContain("↑↓ line");
 	});
 
 	it("anchors an annotation to the selected diff line", () => {
@@ -79,7 +82,6 @@ diff --git a/src/beta.ts b/src/beta.ts
 		);
 
 		render(overlay);
-		overlay.handleInput(TAB);
 		overlay.handleInput(TAB);
 		for (let index = 0; index < 12; index++) overlay.handleInput(DOWN);
 		overlay.handleInput("a");
@@ -108,6 +110,9 @@ diff --git a/src/beta.ts b/src/beta.ts
 		const diff =
 			"diff --git a/src/value.ts b/src/value.ts\n--- a/src/value.ts\n+++ b/src/value.ts\n@@ -0,0 +1 @@\n+new";
 		const first = makeOverlay(diff);
+		render(first.overlay);
+		first.overlay.handleInput(TAB);
+		first.overlay.handleInput(TAB);
 
 		first.overlay.handleInput(DOWN);
 		first.overlay.handleInput(ENTER);
@@ -115,7 +120,6 @@ diff --git a/src/beta.ts b/src/beta.ts
 
 		const { overlay } = makeOverlay(diff);
 		render(overlay);
-		overlay.handleInput(TAB);
 		overlay.handleInput(TAB);
 		overlay.handleInput("a");
 		overlay.handleInput("n");
@@ -152,7 +156,6 @@ diff --git a/src/beta.ts b/src/beta.ts
 			);
 
 			render(overlay);
-			overlay.handleInput(TAB);
 			overlay.handleInput(TAB);
 			overlay.handleInput("a");
 			overlay.handleInput("draft");

--- a/packages/coding-agent/test/modes/components/code-review-overlay.test.ts
+++ b/packages/coding-agent/test/modes/components/code-review-overlay.test.ts
@@ -1,0 +1,202 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { stripVTControlCharacters } from "node:util";
+import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import { parseReviewDiffSnapshot } from "@oh-my-pi/pi-coding-agent/extensibility/custom-commands/bundled/review";
+import {
+	CONTINUE_CODE_REVIEW_ACTION,
+	CodeReviewOverlay,
+	type CodeReviewOverlayResult,
+	PASTE_CODE_REVIEW_ACTION,
+} from "@oh-my-pi/pi-coding-agent/modes/components/code-review-overlay";
+import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { setKeybindings, type TUI } from "@oh-my-pi/pi-tui";
+
+const DOWN = "\x1b[B";
+const ENTER = "\r";
+const TAB = "\t";
+
+let darkTheme = await getThemeByName("dark");
+
+function render(component: CodeReviewOverlay, width = 90): string {
+	return stripVTControlCharacters(component.render(width).join("\n"));
+}
+
+function makeOverlay(
+	diff: string,
+	onComplete = vi.fn<(result: CodeReviewOverlayResult | undefined) => void>(),
+	tui = {} as TUI,
+) {
+	return {
+		onComplete,
+		overlay: new CodeReviewOverlay(tui, parseReviewDiffSnapshot(diff).files, "Reviewing changes", {
+			onComplete,
+		}),
+	};
+}
+
+describe("CodeReviewOverlay", () => {
+	beforeAll(async () => {
+		darkTheme = await getThemeByName("dark");
+		if (!darkTheme) throw new Error("Failed to load dark theme");
+	});
+
+	beforeEach(() => {
+		setThemeInstance(darkTheme!);
+		setKeybindings(KeybindingsManager.inMemory());
+	});
+
+	it("renders changed files, diff contents, and review actions", () => {
+		const { overlay } = makeOverlay(`diff --git a/src/alpha.ts b/src/alpha.ts
+--- a/src/alpha.ts
++++ b/src/alpha.ts
+@@ -0,0 +1 @@
++new
+diff --git a/src/beta.ts b/src/beta.ts
+--- a/src/beta.ts
++++ b/src/beta.ts
+@@ -0,0 +1 @@
++beta`);
+
+		const out = render(overlay);
+		expect(out).toContain("Code Review");
+		expect(out).toContain("src/alpha.ts");
+		expect(out).toContain("src/beta.ts");
+		expect(out).toContain("new");
+		expect(out).toContain(CONTINUE_CODE_REVIEW_ACTION);
+		expect(out).toContain(PASTE_CODE_REVIEW_ACTION);
+
+		overlay.handleInput("]");
+		expect(render(overlay)).toContain("beta");
+	});
+
+	it("anchors an annotation to the selected diff line", () => {
+		const rows = Array.from({ length: 80 }, (_, index) => ` context-row-${String(index).padStart(3, "0")}`);
+		const { overlay, onComplete } = makeOverlay(
+			`diff --git a/src/long.ts b/src/long.ts\n--- a/src/long.ts\n+++ b/src/long.ts\n@@ -1,80 +1,80 @@\n${rows.join("\n")}`,
+		);
+
+		render(overlay);
+		overlay.handleInput(TAB);
+		overlay.handleInput(TAB);
+		for (let index = 0; index < 12; index++) overlay.handleInput(DOWN);
+		overlay.handleInput("a");
+		for (const char of "check this guard") overlay.handleInput(char);
+		overlay.handleInput(ENTER);
+
+		expect(overlay.getAnnotations()).toEqual([
+			expect.objectContaining({
+				path: "src/long.ts",
+				oldLine: 13,
+				newLine: 13,
+				rawLine: " context-row-012",
+				note: "check this guard",
+			}),
+		]);
+		expect(render(overlay)).toContain("check this guard");
+
+		overlay.handleInput(TAB);
+		overlay.handleInput(ENTER);
+		expect(onComplete).toHaveBeenCalledWith(
+			expect.objectContaining({ action: "review", annotations: overlay.getAnnotations() }),
+		);
+	});
+
+	it("gates paste until annotations exist and supports undo", () => {
+		const diff =
+			"diff --git a/src/value.ts b/src/value.ts\n--- a/src/value.ts\n+++ b/src/value.ts\n@@ -0,0 +1 @@\n+new";
+		const first = makeOverlay(diff);
+
+		first.overlay.handleInput(DOWN);
+		first.overlay.handleInput(ENTER);
+		expect(first.onComplete).toHaveBeenCalledWith({ action: "review", annotations: [] });
+
+		const { overlay } = makeOverlay(diff);
+		render(overlay);
+		overlay.handleInput(TAB);
+		overlay.handleInput(TAB);
+		overlay.handleInput("a");
+		overlay.handleInput("n");
+		overlay.handleInput(ENTER);
+		expect(overlay.getAnnotations()).toHaveLength(1);
+
+		overlay.handleInput("u");
+		expect(overlay.getAnnotations()).toEqual([]);
+	});
+	it("edits an annotation draft in the configured external editor", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-code-review-editor-"));
+		const editorPath = path.join(tempDir, "editor.sh");
+		const previousEditor = Bun.env.EDITOR;
+		const previousVisual = Bun.env.VISUAL;
+		const editorApplied = Promise.withResolvers<void>();
+		const stop = vi.fn();
+		const start = vi.fn();
+		const tui = {
+			stop,
+			start,
+			requestRender: () => editorApplied.resolve(),
+		} as unknown as TUI;
+
+		try {
+			await Bun.write(editorPath, '#!/bin/sh\nprintf "%s" "edited annotation" > "$1"\n');
+			await fs.chmod(editorPath, 0o755);
+			Bun.env.EDITOR = editorPath;
+			delete Bun.env.VISUAL;
+			setKeybindings(KeybindingsManager.inMemory({ "app.editor.external": "ctrl+e" }));
+			const { overlay } = makeOverlay(
+				"diff --git a/src/value.ts b/src/value.ts\n--- a/src/value.ts\n+++ b/src/value.ts\n@@ -0,0 +1 @@\n+new",
+				undefined,
+				tui,
+			);
+
+			render(overlay);
+			overlay.handleInput(TAB);
+			overlay.handleInput(TAB);
+			overlay.handleInput("a");
+			overlay.handleInput("draft");
+			overlay.handleInput("\x05");
+			await editorApplied.promise;
+
+			expect(overlay.getAnnotations()).toEqual([expect.objectContaining({ newLine: 1, note: "edited annotation" })]);
+			expect(stop).toHaveBeenCalledTimes(1);
+			expect(start).toHaveBeenCalledTimes(1);
+		} finally {
+			if (previousEditor === undefined) delete Bun.env.EDITOR;
+			else Bun.env.EDITOR = previousEditor;
+			if (previousVisual === undefined) delete Bun.env.VISUAL;
+			else Bun.env.VISUAL = previousVisual;
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("uses the compact file header when the terminal is narrow", () => {
+		const { overlay } = makeOverlay(`diff --git a/src/alpha.ts b/src/alpha.ts
+--- a/src/alpha.ts
++++ b/src/alpha.ts
+@@ -0,0 +1 @@
++new
+diff --git a/src/beta.ts b/src/beta.ts
+--- a/src/beta.ts
++++ b/src/beta.ts
+@@ -0,0 +1 @@
++after
+`);
+
+		expect(render(overlay, 55)).toContain("src/alpha.ts");
+		overlay.handleInput("]");
+		const out = render(overlay, 55);
+		expect(out).toContain("src/beta.ts");
+		expect(out).toContain("after");
+	});
+	it("cancels without producing a review result", () => {
+		const { overlay, onComplete } = makeOverlay(
+			"diff --git a/src/value.ts b/src/value.ts\n--- a/src/value.ts\n+++ b/src/value.ts\n@@ -0,0 +1 @@\n+new",
+		);
+
+		overlay.handleInput("\x1b");
+
+		expect(onComplete).toHaveBeenCalledWith(undefined);
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts
@@ -24,6 +24,8 @@ function makeHarness() {
 	editorContainer.addChild(editor);
 	const requestRender = vi.fn();
 	const setFocus = vi.fn();
+	const hideOverlay = vi.fn();
+	const showOverlay = vi.fn(() => ({ hide: hideOverlay }) as never);
 	const addAutocompleteProvider = vi.fn();
 	let uiContext: ExtensionUIContext | undefined;
 	const ctx = {
@@ -32,6 +34,7 @@ function makeHarness() {
 			requestRender,
 			setFocus,
 			terminal: { rows: 40 },
+			showOverlay,
 		},
 		editorContainer,
 		session: {
@@ -52,6 +55,8 @@ function makeHarness() {
 		requestRender,
 		addAutocompleteProvider,
 		editorContainer,
+		hideOverlay,
+		showOverlay,
 		setFocus,
 		controller,
 		async init(): Promise<ExtensionUIContext> {
@@ -82,6 +87,36 @@ describe("ExtensionUiController editor UI", () => {
 
 		expect(harness.editor.getText()).toBe("hello");
 		expect(harness.requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("forwards fullscreen custom overlay options and restores editor focus", async () => {
+		const harness = makeHarness();
+		const ui = await harness.init();
+		harness.editor.setText("existing draft");
+		const mounted = Promise.withResolvers<void>();
+		let close: ((result: string) => void) | undefined;
+
+		const pending = ui.custom<string>(
+			(_tui, _theme, _keybindings, done) => {
+				close = done;
+				mounted.resolve();
+				return new Container();
+			},
+			{ overlay: true, fullscreen: true, mouseTracking: false },
+		);
+		await mounted.promise;
+
+		expect(harness.showOverlay).toHaveBeenCalledWith(
+			expect.any(Container),
+			expect.objectContaining({ fullscreen: true, mouseTracking: false }),
+		);
+		expect(harness.setFocus).toHaveBeenLastCalledWith(expect.any(Container));
+		close?.("complete");
+
+		await expect(pending).resolves.toBe("complete");
+		expect(harness.hideOverlay).toHaveBeenCalledTimes(1);
+		expect(harness.setFocus).toHaveBeenLastCalledWith(harness.editor);
+		expect(harness.editor.getText()).toBe("existing draft");
 	});
 
 	it("keeps a populated prompt visible and routes input to it until the draft is cleared", async () => {


### PR DESCRIPTION
Closes #7622

## Summary

- add a bundled `/code-review` command for the three local `/review` targets: base branch, uncommitted changes, and a specific commit
- add a fullscreen diff browser with keyboard file/source-row navigation, exact line anchors, inline callouts, global undo, and external-editor support
- support multiline annotations directly in the overlay (`Enter` saves; `Shift+Enter` inserts a newline)
- show the selected file's full nested path above the diff pane instead of relying on the truncated sidebar label
- let operators either continue through the ordinary LLM review path with annotations as additional instructions or paste formatted annotations into the current editor draft

## Architecture

This intentionally piggybacks on `/review` rather than creating a parallel review implementation.

- Extracts local review target resolution, diff parsing/filtering, statistics, and prompt construction into the shared review module.
- Resolves and parses the diff once, producing an immutable structured snapshot consumed by both the annotation overlay and the eventual review prompt.
- Preserves existing `/review` PR detection, explicit PR mode, custom instructions, and headless behavior.
- Extends custom-command UI plumbing only with the narrow capabilities required here: fullscreen overlay options and `pasteToEditor()`.
- Keeps all model-facing annotation prose in the static Handlebars prompt template.

Each annotation retains the normalized/display path, old/new paths, repeated-path occurrence, hunk header, old/new line numbers, exact raw diff row, and multiline note. Metadata and binary/rename-only rows remain visible but cannot be annotated.

## Interaction

- `Tab` / `Shift+Tab`: cycle file list, diff, and actions
- arrows or `j` / `k`: navigate files and diff source rows
- `[` / `]`: previous or next file
- `a`: annotate the selected source row
- `Enter`: save the annotation
- `Shift+Enter`: insert an annotation newline
- configured external-editor shortcut: edit the active draft externally
- `u`: undo the latest annotation globally
- `Esc`: cancel the draft or overlay

Completion offers:

1. **Continue with LLM review** — renders the manual notes as operator-supplied review focus and submits through the normal review prompt path using the same frozen diff.
2. **Paste annotations into prompt** — inserts a presentation-only rendering at the current editor cursor and reuses the existing large-paste/artifact selection flow.

## Verification

- `bun test packages/coding-agent/test/extensibility/custom-commands/review.test.ts packages/coding-agent/test/extensibility/custom-commands/code-review.test.ts packages/coding-agent/test/extensibility/custom-commands/ci-green.test.ts packages/coding-agent/test/modes/components/code-review-overlay.test.ts packages/coding-agent/test/modes/controllers/extension-ui-controller.test.ts` — 52 passed
- `bun run check` in `packages/coding-agent` — passed
- source-CLI PTY smoke in a temporary Git repository confirmed target selection, full nested-path rendering, diff navigation, and a saved two-line annotation callout

The repository-wide `bun check` completed its TypeScript phase, but the independent Rust phase currently reports widespread rustfmt diffs outside the files changed here.

## Scope

This does not add PR annotation mode, mouse interaction, annotation persistence, GitHub review publishing, or code mutation.