### PR TITLE
fix(omptype): allow optional object keys to carry a default

### DIFF
--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -1428,7 +1428,6 @@ function parseObjectDefinition(def: Record<PropertyKey, unknown>, resolve?: Alia
 		} else if (!spreadKeys?.has(key) && (key === normalizedKey || normalizedKeys?.includes(key))) {
 			throw new OmpTypeError(`duplicate object key ${String(key)}`);
 		}
-		if (opt && prop.hasDefault) throw new OmpTypeError(`optional key ${String(key)} cannot specify a default`);
 		if (simple && (prop.hasDefault || !isSimpleIR(prop.val))) simple = false;
 		addObjectProp(props, spreadKeys, prop);
 	}

--- a/packages/omptype/src/ir.ts
+++ b/packages/omptype/src/ir.ts
@@ -1428,6 +1428,8 @@ function parseObjectDefinition(def: Record<PropertyKey, unknown>, resolve?: Alia
 		} else if (!spreadKeys?.has(key) && (key === normalizedKey || normalizedKeys?.includes(key))) {
 			throw new OmpTypeError(`duplicate object key ${String(key)}`);
 		}
+		if (opt && prop.hasDefault && !isEmbedded(val))
+			throw new OmpTypeError(`optional key ${String(key)} cannot specify a default`);
 		if (simple && (prop.hasDefault || !isSimpleIR(prop.val))) simple = false;
 		addObjectProp(props, spreadKeys, prop);
 	}

--- a/packages/omptype/test/typebox.test.ts
+++ b/packages/omptype/test/typebox.test.ts
@@ -128,6 +128,23 @@ describe("TypeBox adapter", () => {
 		});
 	});
 
+	test("optional keys with embedded defaults validate, default, and emit clean JSON Schema", () => {
+		const schema = Type.Object({
+			name: Type.String(),
+			depth: Type.Optional(Type.Integer({ minimum: 1, maximum: 10, default: 3 })),
+		});
+
+		expect(valid(schema, { name: "Ada" })).toBe(true);
+		expect(valid(schema, { name: "Ada", depth: 5 })).toBe(true);
+		expect(valid(schema, { name: "Ada", depth: 0 })).toBe(false);
+		expect(schema({ name: "Ada" })).toEqual({ name: "Ada", depth: 3 });
+		expect(schema.toJsonSchema()).toMatchObject({
+			type: "object",
+			properties: { name: { type: "string" }, depth: { type: "integer", minimum: 1, maximum: 10, default: 3 } },
+			required: ["name"],
+		});
+	});
+
 	test("legacy validation helpers are non-enumerable and return compatibility results", () => {
 		const schema = Type.Object({ name: Type.String(), score: Type.Number({ default: 1 }) });
 		expect(schema.safeParse({ name: "Ada" })).toEqual({


### PR DESCRIPTION
Fixes the omptype regression that has been failing `Test coding-agent runtime/session` (typebox-shim) on clean main since the omptype refactor.

## Problem

`parseObjectDefinition` in `ir.ts` (added in `90b5d8e707`) rejects optional object keys that carry a default:

```
OmpTypeError: optional key depth cannot specify a default
```

The combination is legitimate and used throughout the library:
- tuple defaults imply optional (`opt: parsed.optional || parsed.hasDefault`, ir.ts:996)
- `from-json-schema.ts` sets `opt = true` on defaulted properties
- compile/interp/json-schema all handle `opt || hasDefault` (`filled()` at json-schema.ts:275 is explicitly `!prop.opt && (... || !prop.hasDefault)`)

It broke `Type.Optional(Type.Integer({ default }))` and JSON-Schema round-trips through the TypeBox shim — the failing `typebox-shim.test.ts > emits clean JSON Schema for a complex object` on main.

## Change

Scope the throw to **authored** optional keys instead of removing it: the guard stays for `"bar?": "number = 5"` and the `["number", "=", 5]` tuple form (arktype parity, asserted by `test/ark/objects/defaults.test.ts` / `test/type.test.ts`), and is skipped when the value is an embedded schema whose default lives on the inner schema — that's the TypeBox-shim case where `tObject` synthesizes the `?` from the `Optional` wrapper (`type.raw(def)` sees `"depth?"` + the inner defaulted schema).

## Verification

- New regression test in `packages/omptype/test/typebox.test.ts`: `Type.Object({ name, depth: Type.Optional(Type.Integer({ minimum, maximum, default })) })` validates with/without the key, materializes the default, rejects out-of-range, and emits clean JSON Schema.
- omptype suite 1146/0 pass; ark `defaults.test.ts` + `type.test.ts` (authored-`?`-with-default throw) 101/0 pass.
- `typebox-shim.test.ts` 12/12 (was 11/12).
- `bun check` clean.

Note: the initial commit removed the guard outright; CI caught `test/ark/objects/defaults.test.ts > string parsing > optional with default` — authored optional keys must still throw. The follow-up scopes the guard as above.
