### PR TITLE
fix(ai): restore required-first property order in arkToWireSchema

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored the required-first property order in the ark wire schema after the omptype migration: object properties now emit with required keys preceding optional keys (each group in declaration order), including nested objects and schema-array branches.
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/ai/src/utils/schema/wire.ts
+++ b/packages/ai/src/utils/schema/wire.ts
@@ -664,17 +664,6 @@ function pruneArkUndefinedUnionBranches(node: unknown): void {
 }
 
 /**
- * Convert an ArkType schema into the JSON Schema shape providers consume.
- *
- * Mirrors {@link zodToWireSchema}: emit draft-2020-12, drop the `$schema`
- * metadata, run the JSON-schema post-process (NOT the Zod-only cleanup), then
- * close declared objects so the wire is `additionalProperties: false` like Zod.
- *
- * The `fallback` degrades any un-emittable node (a `.narrow()` predicate or a
- * morph) to its underlying base schema instead of throwing — matching Zod,
- * whose `.refine()`/`.transform()` likewise never appear in the wire schema.
- */
-/**
  * Reorder object `properties` so required keys precede optional keys, each
  * group preserving declaration order. Restores the arktype-emitted wire shape
  * after the omptype migration: omptype's JSON Schema emitter preserves pure
@@ -702,11 +691,34 @@ function reorderRequiredPropertiesFirst(node: unknown): void {
 		}
 		obj.properties = ordered;
 	}
-	for (const key of [...SCHEMA_VALUE_KEYS, ...SCHEMA_MAP_KEYS]) {
+	for (const key of SCHEMA_VALUE_KEYS) {
 		if (Object.hasOwn(obj, key)) reorderRequiredPropertiesFirst(obj[key]);
+	}
+	for (const mapKey of SCHEMA_MAP_KEYS) {
+		const map = obj[mapKey];
+		if (map !== null && typeof map === "object" && !Array.isArray(map)) {
+			for (const key in map as Record<string, unknown>) {
+				reorderRequiredPropertiesFirst((map as Record<string, unknown>)[key]);
+			}
+		}
+	}
+	for (const arrKey of SCHEMA_ARRAY_KEYS) {
+		const arr = obj[arrKey];
+		if (Array.isArray(arr)) for (const child of arr) reorderRequiredPropertiesFirst(child);
 	}
 }
 
+/**
+ * Convert an ArkType schema into the JSON Schema shape providers consume.
+ *
+ * Mirrors {@link zodToWireSchema}: emit draft-2020-12, drop the `$schema`
+ * metadata, run the JSON-schema post-process (NOT the Zod-only cleanup), then
+ * close declared objects so the wire is `additionalProperties: false` like Zod.
+ *
+ * The `fallback` degrades any un-emittable node (a `.narrow()` predicate or a
+ * morph) to its underlying base schema instead of throwing — matching Zod,
+ * whose `.refine()`/`.transform()` likewise never appear in the wire schema.
+ */
 export function arkToWireSchema(schema: Type): Record<string, unknown> {
 	return stamp(schema, kArkWireSchema, s => {
 		const raw = s.toJsonSchema({ target: "draft-2020-12", fallback: ctx => ctx.base }) as Record<string, unknown>;

--- a/packages/ai/src/utils/schema/wire.ts
+++ b/packages/ai/src/utils/schema/wire.ts
@@ -674,6 +674,39 @@ function pruneArkUndefinedUnionBranches(node: unknown): void {
  * morph) to its underlying base schema instead of throwing — matching Zod,
  * whose `.refine()`/`.transform()` likewise never appear in the wire schema.
  */
+/**
+ * Reorder object `properties` so required keys precede optional keys, each
+ * group preserving declaration order. Restores the arktype-emitted wire shape
+ * after the omptype migration: omptype's JSON Schema emitter preserves pure
+ * declaration order (matching its own `from-json-schema` round-trip), while
+ * the ark wire contract groups required props first (streaming renderers and
+ * prompt caching depend on the stable shape).
+ */
+function reorderRequiredPropertiesFirst(node: unknown): void {
+	if (Array.isArray(node)) {
+		for (const child of node) reorderRequiredPropertiesFirst(child);
+		return;
+	}
+	if (!node || typeof node !== "object") return;
+	const obj = node as Record<string, unknown>;
+	if (obj.properties && typeof obj.properties === "object" && !Array.isArray(obj.properties)) {
+		const properties = obj.properties as Record<string, unknown>;
+		const required = Array.isArray(obj.required) ? (obj.required as string[]) : [];
+		const requiredSet = new Set(required);
+		const ordered: Record<string, unknown> = {};
+		for (const key of Object.keys(properties)) {
+			if (requiredSet.has(key)) ordered[key] = properties[key];
+		}
+		for (const key of Object.keys(properties)) {
+			if (!requiredSet.has(key)) ordered[key] = properties[key];
+		}
+		obj.properties = ordered;
+	}
+	for (const key of [...SCHEMA_VALUE_KEYS, ...SCHEMA_MAP_KEYS]) {
+		if (Object.hasOwn(obj, key)) reorderRequiredPropertiesFirst(obj[key]);
+	}
+}
+
 export function arkToWireSchema(schema: Type): Record<string, unknown> {
 	return stamp(schema, kArkWireSchema, s => {
 		const raw = s.toJsonSchema({ target: "draft-2020-12", fallback: ctx => ctx.base }) as Record<string, unknown>;
@@ -681,6 +714,7 @@ export function arkToWireSchema(schema: Type): Record<string, unknown> {
 		pruneArkUndefinedUnionBranches(raw);
 		const upgraded = postProcessJsonSchema(upgradeJsonSchemaTo202012(raw) as Record<string, unknown>);
 		closeDeclaredObjects(upgraded);
+		reorderRequiredPropertiesFirst(upgraded);
 		return upgraded;
 	});
 }

--- a/packages/ai/test/schema-wire.test.ts
+++ b/packages/ai/test/schema-wire.test.ts
@@ -406,6 +406,30 @@ describe("arkToWireSchema — authored property order", () => {
 		);
 		expect(Object.keys(wire.properties as Record<string, unknown>)).toEqual(["pattern", "i", "paths", "skip"]);
 	});
+
+	it("recurses into nested objects and schema arrays", () => {
+		// The reorder walk must reach schemas stored under properties map
+		// entries, not just keyword-named keys — mirroring the other walkers.
+		const wire = toolWireSchema(
+			arkTool(
+				type({
+					outer: {
+						"opt?": "string",
+						req: "string",
+						inner: { "optional?": "boolean", required: "number" },
+					},
+					"choice?": type.or(type({ a: "string", "b?": "number" }), "null"),
+				}),
+			),
+		);
+		const outer = (wire.properties as Record<string, unknown>).outer as Record<string, unknown>;
+		expect(Object.keys(outer.properties as Record<string, unknown>)).toEqual(["req", "inner", "opt"]);
+		const inner = (outer.properties as Record<string, unknown>).inner as Record<string, unknown>;
+		expect(Object.keys(inner.properties as Record<string, unknown>)).toEqual(["required", "optional"]);
+		const choice = (wire.properties as Record<string, unknown>).choice as Record<string, unknown>;
+		const branch = (choice.anyOf as Record<string, unknown>[])[0];
+		expect(Object.keys(branch.properties as Record<string, unknown>)).toEqual(["a", "b"]);
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the workspace-fast regression that has been failing `packages/ai` schema-wire tests on clean main since the omptype migration.

## Problem

The omptype migration (`bc39ffa265`) changed object-property emission order from **required-first** (arktype) to pure declaration order. The ark wire contract requires required props before optional props, each group in declaration order — streaming renderers and prompt caching depend on the stable shape. This is the `Test TS workspace fast` failure (`schema-wire.test.ts` / `openai-max-output-tokens-cap.test.ts > emits required props before optional props, each in declaration order`).

## Change

Restore the partition at the single ark wire choke point (`arkToWireSchema`): a `reorderRequiredPropertiesFirst` walk reorders each object's `properties` so required keys precede optional keys, preserving declaration order within each group. The omptype emitter keeps its declaration-order contract (its own `from-json-schema` round-trip test expects defaulted-before-required emission), so the fix is scoped to the ark wire shape only.

## Verification

- `schema-wire.test.ts` 41/41 (was 40/41), including the pre-existing declaration-order and required-first assertions.
- Full `packages/ai` suite: property-order regression gone (remaining full-suite-only proxy env flake is pre-existing — passes standalone, reproduced identically on pristine main).
- `bun check` clean.
