### PR TITLE
fix(coding-agent): retry buffered print streams

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed text print mode treating buffered partial responses as replay-unsafe, allowing transient mid-stream connection failures to retry without exposing duplicated output ([#7625](https://github.com/can1357/oh-my-pi/issues/7625)).
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -186,12 +186,14 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 	// Send initial message with attachments
 	if (initialMessage !== undefined) {
 		writeTextWorkingIndicator();
+		if (mode === "text") session.setTextOutputCommitted(false);
 		await logger.time("print:prompt:initial", () => session.prompt(initialMessage, { images: initialImages }));
 	}
 
 	// Send remaining messages
 	for (const message of messages) {
 		writeTextWorkingIndicator();
+		if (mode === "text") session.setTextOutputCommitted(false);
 		await logger.time("print:prompt:next", () => session.prompt(message));
 	}
 
@@ -249,6 +251,7 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 				}
 			}
 		}
+		session.setTextOutputCommitted(true);
 	}
 
 	await session.waitForAdvisorCatchup(PRINT_MODE_ADVISOR_DRAIN_TIMEOUT_MS);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -485,6 +485,7 @@ export class AgentSession {
 
 	// Retry state
 	readonly #recovery: TurnRecovery;
+	#textOutputCommitted = true;
 	#planModeReminderCount = 0;
 	#planModeReminderAwaitingProgress = false;
 	readonly #todo: TodoTracker;
@@ -1025,6 +1026,7 @@ export class AgentSession {
 			modelRegistry: this.#modelRegistry,
 			configWarnings: this.configWarnings,
 			model: () => this.model,
+			textOutputCommitted: () => this.#textOutputCommitted,
 			thinkingLevel: () => this.thinkingLevel,
 			configuredThinkingLevel: () => this.configuredThinkingLevel(),
 			setThinkingLevel: level => this.setThinkingLevel(level),
@@ -4182,6 +4184,11 @@ export class AgentSession {
 	/** Current effective system prompt blocks (includes any per-turn extension modifications) */
 	get systemPrompt(): string[] {
 		return this.agent.state.systemPrompt;
+	}
+
+	/** Marks streamed text as committed or buffered for turn-recovery replay decisions. */
+	setTextOutputCommitted(committed: boolean): void {
+		this.#textOutputCommitted = committed;
 	}
 
 	/** Current retry attempt (0 if not retrying) */

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -101,6 +101,8 @@ export interface TurnRecoveryHost {
 	modelRegistry: ModelRegistry;
 	configWarnings: string[];
 	model(): Model | undefined;
+	/** Whether streamed text has already been committed to the active output sink. */
+	textOutputCommitted(): boolean;
 	thinkingLevel(): ThinkingLevel | undefined;
 	configuredThinkingLevel(): ConfiguredThinkingLevel | undefined;
 	setThinkingLevel(level: ConfiguredThinkingLevel | undefined): void;
@@ -890,8 +892,8 @@ export class TurnRecovery {
 		if (AIError.isContextOverflow(message, contextWindow)) return false;
 
 		// A classifier refusal/sensitivity stop is the model's decision, not a route
-		// failure, but only after we confirm no user-visible output has already been
-		// streamed. Visible text, images, tool calls, or server tools must not be
+		// failure, but only after we confirm no replay-unsafe output has already
+		// streamed. Committed text, images, tool calls, or server tools must not be
 		// discarded and replayed.
 		if (this.#hasReplayUnsafeOutput(message)) return false;
 		if (this.isClassifierRefusal(message)) return true;
@@ -966,10 +968,10 @@ export class TurnRecovery {
 	 * Thinking-only partials are safe to discard and replay: reasoning models
 	 * routinely stall after long thinking with no visible output, and duplicated
 	 * thinking display is materially lower harm than duplicated final text.
-	 * Whitespace-only text is likewise safe since nothing meaningful reached the
-	 * user. Visible text, generated images, server tools, and retained tool calls
-	 * are NOT safe: each has already rendered or may have side effects, so replaying
-	 * the turn can duplicate user-visible output or work.
+	 * Whitespace-only and buffered text are likewise safe since nothing meaningful
+	 * reached the user. Committed text, generated images, server tools, and retained
+	 * tool calls are NOT safe: each has already rendered or may have side effects,
+	 * so replaying the turn can duplicate user-visible output or work.
 	 */
 	#hasReplayUnsafeOutput(message: AssistantMessage): boolean {
 		return message.content.some(
@@ -977,7 +979,7 @@ export class TurnRecovery {
 				block.type === "toolCall" ||
 				block.type === "image" ||
 				block.type === "anthropicServerTool" ||
-				(block.type === "text" && block.text.trim().length > 0),
+				(block.type === "text" && this.#host.textOutputCommitted() && block.text.trim().length > 0),
 		);
 	}
 

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -1164,29 +1164,14 @@ describe("AgentSession retry delay cap", () => {
 
 					if (streamCalls === 1) {
 						const thinking = { type: "thinking" as const, thinking: "partial thought" };
-						// No visible text: a committed text block makes the failed turn
-						// replay-unsafe (turn-recovery #hasReplayUnsafeOutput), which would
-						// correctly suppress this retry. The delay-cap contract under test
-						// needs a replay-safe partial turn, so only thinking plus an
-						// incomplete (never toolcall_end'd) tool call is emitted.
-						const toolCall: ToolCall = {
-							type: "toolCall",
-							id: "tc-incomplete",
-							name: "bash",
-							arguments: { command: "bun probe-archive3.ts" },
-						};
-						partial.content.push(thinking, toolCall);
+						const text = { type: "text" as const, text: "partial buffered answer" };
+						partial.content.push(thinking, text);
 						stream.push({ type: "start", partial });
 						stream.push({ type: "thinking_start", contentIndex: 0, partial });
 						stream.push({ type: "thinking_delta", contentIndex: 0, delta: thinking.thinking, partial });
 						stream.push({ type: "thinking_end", contentIndex: 0, content: thinking.thinking, partial });
-						stream.push({ type: "toolcall_start", contentIndex: 1, partial });
-						stream.push({
-							type: "toolcall_delta",
-							contentIndex: 1,
-							delta: JSON.stringify(toolCall.arguments),
-							partial,
-						});
+						stream.push({ type: "text_start", contentIndex: 1, partial });
+						stream.push({ type: "text_delta", contentIndex: 1, delta: text.text, partial });
 						stream.push({
 							type: "error",
 							reason: "error",
@@ -1243,6 +1228,7 @@ describe("AgentSession retry delay cap", () => {
 			if (event.type === "auto_retry_end") retryEndEvents.push(event);
 		});
 
+		session.setTextOutputCommitted(false);
 		await session.prompt("Trigger partial socket close");
 		await session.waitForIdle();
 

--- a/packages/coding-agent/test/modes/noninteractive-dispose.test.ts
+++ b/packages/coding-agent/test/modes/noninteractive-dispose.test.ts
@@ -40,6 +40,7 @@ describe("print-mode error exit disposes the session before exit", () => {
 			state: { messages: [errorMsg] },
 			getLastAssistantMessage: () => errorMsg,
 			prepareForHeadlessAdvisorDrain: () => {},
+			setTextOutputCommitted: () => {},
 			waitForAdvisorCatchup: async () => {
 				order.push("catchup");
 				return true;

--- a/packages/coding-agent/test/print-mode-working-indicator.test.ts
+++ b/packages/coding-agent/test/print-mode-working-indicator.test.ts
@@ -36,6 +36,7 @@ interface DelayedSession {
 	promptStarted: Promise<void>;
 	resolvePrompt: () => void;
 	getPlanModeAtPrompt: () => PlanModeState | undefined;
+	getTextOutputCommitted: () => boolean;
 	getModeChanges: () => Array<{ mode: string; data?: Record<string, unknown> }>;
 	getPlanProposalHandler: () => PlanProposalHandler | undefined;
 	getCurrentPlanMode: () => PlanModeState | undefined;
@@ -57,6 +58,7 @@ function createDelayedSession(
 	const modeChanges: Array<{ mode: string; data?: Record<string, unknown> }> = [];
 	let planProposalHandler: PlanProposalHandler | undefined;
 	let subscriber: ((event: AgentSessionEvent) => void) | undefined;
+	let textOutputCommitted = true;
 	let abortCalls = 0;
 
 	const session = {
@@ -105,6 +107,9 @@ function createDelayedSession(
 		abort: async () => {
 			abortCalls++;
 		},
+		setTextOutputCommitted: (committed: boolean) => {
+			textOutputCommitted = committed;
+		},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			subscriber = listener;
 			return () => {};
@@ -133,6 +138,7 @@ function createDelayedSession(
 		getPlanModeAtPrompt: () => planModeAtPrompt,
 		getModeChanges: () => modeChanges,
 		getPlanProposalHandler: () => planProposalHandler,
+		getTextOutputCommitted: () => textOutputCommitted,
 		getCurrentPlanMode: () => planModeState,
 		emit: event => subscriber?.(event),
 		getAbortCalls: () => abortCalls,
@@ -226,12 +232,14 @@ describe("print mode working indicator", () => {
 		try {
 			expect(stderrOutput.join("")).toContain("Working");
 			expect(stdoutOutput.join("")).toBe("");
+			expect(delayed.getTextOutputCommitted()).toBe(false);
 		} finally {
 			delayed.resolvePrompt();
 			await run;
 		}
 
 		expect(stdoutOutput.join("")).toBe("final answer\n");
+		expect(delayed.getTextOutputCommitted()).toBe(true);
 	});
 
 	it("does not write the text-mode working indicator in JSON mode while the prompt is pending", async () => {
@@ -241,6 +249,7 @@ describe("print mode working indicator", () => {
 		await delayed.promptStarted;
 		try {
 			expect(stderrOutput.join("")).toBe("");
+			expect(delayed.getTextOutputCommitted()).toBe(true);
 		} finally {
 			delayed.resolvePrompt();
 			await run;
@@ -351,6 +360,7 @@ describe("print mode working indicator", () => {
 				messages.push(message);
 				return true;
 			},
+			setTextOutputCommitted: () => {},
 			prepareForHeadlessAdvisorDrain: () => {},
 			waitForAdvisorCatchup: async (timeoutMs: number) => {
 				catchupTimeoutMs = timeoutMs;

--- a/packages/coding-agent/test/silent-abort-print-mode.test.ts
+++ b/packages/coding-agent/test/silent-abort-print-mode.test.ts
@@ -55,6 +55,7 @@ function createMockSession(
 		subscribe: () => () => {},
 		prompt: async () => {},
 		prepareForHeadlessAdvisorDrain: () => {},
+		setTextOutputCommitted: () => {},
 		waitForAdvisorCatchup: async () => true,
 		dispose,
 	} as unknown as AgentSession;

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -40,9 +40,12 @@ function makeMessage(content: AssistantMessage["content"], model: Model): Assist
 function createHost(
 	model: Model,
 	modelRegistry: ModelRegistry,
-	fallbackChains?: Record<string, string[]>,
+	options: {
+		fallbackChains?: Record<string, string[]>;
+		textOutputCommitted?: boolean;
+	} = {},
 ): TurnRecoveryHost {
-	const settings = Settings.isolated(fallbackChains ? { "retry.fallbackChains": fallbackChains } : {});
+	const settings = Settings.isolated(options.fallbackChains ? { "retry.fallbackChains": options.fallbackChains } : {});
 	return {
 		agent: undefined as never,
 		sessionManager: undefined as never,
@@ -51,6 +54,7 @@ function createHost(
 		modelRegistry,
 		configWarnings: [],
 		model: () => model,
+		textOutputCommitted: () => options.textOutputCommitted !== false,
 		thinkingLevel: () => undefined,
 		configuredThinkingLevel: () => undefined,
 		setThinkingLevel: () => {},
@@ -101,16 +105,27 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		expect(recovery.isRetryableError(message)).toBe(false);
 	});
 
-	it("allows replay-safe hard fallback and excludes visible text with a configured chain", () => {
-		const recovery = new TurnRecovery(
-			createHost(model, modelRegistry, {
-				[`${model.provider}/${model.id}`]: ["openai/gpt-4o-mini"],
-			}),
-		);
+	it("allows replay-safe hard fallback and excludes committed text with a configured chain", () => {
+		const fallbackChains = {
+			[`${model.provider}/${model.id}`]: ["openai/gpt-4o-mini"],
+		};
+		const recovery = new TurnRecovery(createHost(model, modelRegistry, { fallbackChains }));
 		// Thinking-only output is replay-safe: nothing visible reached the user.
 		const message = makeMessage([{ type: "thinking", thinking: "safe reasoning before failing" }], model);
 		const visible = makeMessage([{ type: "text", text: "Already shown" }], model);
 		expect(recovery.isHardErrorFallbackEligible(visible)).toBe(false);
+		expect(recovery.isHardErrorFallbackEligible(message)).toBe(true);
+	});
+
+	it("retries partial text while its buffered output remains uncommitted", () => {
+		const fallbackChains = {
+			[`${model.provider}/${model.id}`]: ["openai/gpt-4o-mini"],
+		};
+		const recovery = new TurnRecovery(
+			createHost(model, modelRegistry, { fallbackChains, textOutputCommitted: false }),
+		);
+		const message = makeMessage([{ type: "text", text: "Buffered partial answer" }], model);
+		expect(recovery.isRetryableError(message)).toBe(true);
 		expect(recovery.isHardErrorFallbackEligible(message)).toBe(true);
 	});
 
@@ -148,6 +163,19 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		const recovery = new TurnRecovery(createHost(model, modelRegistry));
 		const message = makeMessage(
 			[{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: "ls" } }],
+			model,
+		);
+		expect(recovery.isRetryableError(message)).toBe(false);
+		expect(recovery.isHardErrorFallbackEligible(message)).toBe(false);
+	});
+
+	it("keeps side-effecting output replay-unsafe while text is uncommitted", () => {
+		const recovery = new TurnRecovery(createHost(model, modelRegistry, { textOutputCommitted: false }));
+		const message = makeMessage(
+			[
+				{ type: "text", text: "Buffered partial answer" },
+				{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: "ls" } },
+			],
 			model,
 		);
 		expect(recovery.isRetryableError(message)).toBe(false);


### PR DESCRIPTION
## Repro

In text print mode, `runPrintMode` leaves stdout empty until `session.prompt()` settles, but a provider turn containing partial non-whitespace text is rejected by recovery as replay-unsafe. Reproduced with `bun test packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts packages/coding-agent/test/print-mode-working-indicator.test.ts --test-name-pattern 'partial non-whitespace text as NOT retriable|prints the final answer afterward'`.

## Cause

`TurnRecovery.#hasReplayUnsafeOutput` in `packages/coding-agent/src/session/turn-recovery.ts` treated every non-whitespace text block as already visible, while `runPrintMode` in `packages/coding-agent/src/modes/print-mode.ts` buffers text and writes only the settled assistant message. The gate therefore suppressed session retry and fallback after an undisplayed partial response.

## Fix

- Added an `AgentSession` text-commit state exposed to `TurnRecovery`, defaulting to committed for streaming consumers.
- Marked text output uncommitted around text-mode prompts and committed it only after the final response is written; JSON mode retains the existing streaming policy.
- Covered committed and buffered text, unchanged side-effect barriers, print-mode policy, and a real session retry after partial text plus a transient socket close.
- Added the coding-agent changelog entry.

## Verification

`bun test packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts packages/coding-agent/test/print-mode-working-indicator.test.ts packages/coding-agent/test/agent-session-retry-cap.test.ts` passed: 47 tests, 0 failures. `bun check` passed for all packages. An in-process `runPrintMode` smoke using a mock provider emitted partial text plus a socket-close error on the first stream and a successful second stream; it exited 0 with stdout exactly `recovered final answer\n` and no partial output.

Fixes #7625