### PR TITLE
fix(stats): restrict dashboard to loopback

### DIFF
--- a/packages/coding-agent/src/cli/stats-cli.ts
+++ b/packages/coding-agent/src/cli/stats-cli.ts
@@ -136,11 +136,11 @@ export async function runStatsCommand(cmd: StatsCommandArgs): Promise<void> {
 	}
 
 	// Start the dashboard server
-	const { port } = await startServer(cmd.port);
-	console.log(chalk.green(`Dashboard available at: http://localhost:${port}`));
+	const { hostname, port } = await startServer(cmd.port);
+	const url = `http://${hostname}:${port}`;
+	console.log(chalk.green(`Dashboard available at: ${url}`));
 
 	// Open browser
-	const url = `http://localhost:${port}`;
 	openPath(url);
 
 	console.log("Press Ctrl+C to stop\n");

--- a/packages/coding-agent/src/slash-commands/helpers/stats-dashboard.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/stats-dashboard.ts
@@ -4,6 +4,7 @@ import * as openUtils from "../../utils/open";
 export const DEFAULT_STATS_DASHBOARD_PORT = 3847;
 
 interface StatsDashboardServer {
+	hostname: string;
 	port: number;
 	stop: () => void;
 }
@@ -64,7 +65,7 @@ export async function launchStatsDashboard(args: StatsDashboardArgs): Promise<St
 		requestedPortIgnored = true;
 	}
 
-	const url = `http://localhost:${activeStatsServer.port}`;
+	const url = `http://${activeStatsServer.hostname}:${activeStatsServer.port}`;
 	openUtils.openPath(url);
 
 	const serverLine = requestedPortIgnored

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restricted the stats dashboard to IPv4 loopback and removed wildcard CORS access to its API ([#7633](https://github.com/can1357/oh-my-pi/issues/7633)).
+
 ## [17.2.4] - 2026-08-01
 
 ### Fixed

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -171,8 +171,8 @@ Examples:
 
 		// Start server
 		const port = parseInt(values.port || "3847", 10);
-		const { port: actualPort } = await startServer(port);
-		console.log(`Dashboard available at: http://localhost:${actualPort}`);
+		const { hostname, port: actualPort } = await startServer(port);
+		console.log(`Dashboard available at: http://${hostname}:${actualPort}`);
 		console.log("Press Ctrl+C to stop\n");
 
 		// Keep process running

--- a/packages/stats/src/port-conflict.ts
+++ b/packages/stats/src/port-conflict.ts
@@ -18,9 +18,12 @@ interface PortHolder {
 /** Header stamped on every dashboard response so reuse probes can identify us. */
 export const STATS_DASHBOARD_HEADER = "x-omp-stats-dashboard";
 
+/** IPv4 loopback address shared by the dashboard server and reuse probe. */
+export const STATS_DASHBOARD_HOSTNAME = "127.0.0.1";
+
 async function probeStatsDashboard(port: number): Promise<boolean> {
 	try {
-		const response = await fetch(`http://localhost:${port}/api/stats/models`, {
+		const response = await fetch(`http://${STATS_DASHBOARD_HOSTNAME}:${port}/api/stats/models`, {
 			signal: AbortSignal.timeout(STATS_PROBE_TIMEOUT_MS),
 		});
 		if (response.status !== 200) {

--- a/packages/stats/src/port-conflict.ts
+++ b/packages/stats/src/port-conflict.ts
@@ -18,31 +18,23 @@ interface PortHolder {
 /** Header stamped on every dashboard response so reuse probes can identify us. */
 export const STATS_DASHBOARD_HEADER = "x-omp-stats-dashboard";
 
+/** Identity-header value for dashboards enforcing loopback-only, same-origin access. */
+export const STATS_DASHBOARD_SECURITY_VERSION = "2";
+
 /** IPv4 loopback address shared by the dashboard server and reuse probe. */
 export const STATS_DASHBOARD_HOSTNAME = "127.0.0.1";
 
-async function probeStatsDashboard(port: number): Promise<boolean> {
+async function probeReusableStatsDashboard(port: number): Promise<boolean> {
 	try {
 		const response = await fetch(`http://${STATS_DASHBOARD_HOSTNAME}:${port}/api/stats/models`, {
 			signal: AbortSignal.timeout(STATS_PROBE_TIMEOUT_MS),
 		});
-		if (response.status !== 200) {
-			await response.body?.cancel();
-			return false;
-		}
-		// A live omp-stats dashboard stamps this header on every response.
-		if (response.headers.get(STATS_DASHBOARD_HEADER)) {
-			await response.body?.cancel();
-			return true;
-		}
-		// Older dashboards predate the header; fall back to the response shape
-		// (`/api/stats/models` returns a JSON array) so we never reuse — or later
-		// kill — a foreign 200 responder such as an SPA dev server catch-all.
-		if (!(response.headers.get("content-type") ?? "").includes("application/json")) {
-			await response.body?.cancel();
-			return false;
-		}
-		return Array.isArray(await response.json());
+		const reusable =
+			response.status === 200 &&
+			response.headers.get(STATS_DASHBOARD_HEADER) === STATS_DASHBOARD_SECURITY_VERSION &&
+			!response.headers.has("Access-Control-Allow-Origin");
+		await response.body?.cancel();
+		return reusable;
 	} catch {
 		return false;
 	}
@@ -219,9 +211,9 @@ async function terminatePortHolder(holder: PortHolder): Promise<void> {
 	await Bun.sleep(PROCESS_EXIT_POLL_MS);
 }
 
-/** Reuse a live stats dashboard or reclaim the port from a stale omp runtime. */
+/** Reuse a securely configured dashboard or reclaim the port from an older omp runtime. */
 export async function recoverStatsPort(port: number): Promise<"retry" | "reuse"> {
-	if (await probeStatsDashboard(port)) return "reuse";
+	if (await probeReusableStatsDashboard(port)) return "reuse";
 
 	const holder = await findPortHolder(port);
 	if (!holder) {

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -21,7 +21,7 @@ import {
 import { decodeEmbeddedClientArchive } from "./embedded-client";
 import embeddedClientArchiveTxt from "./embedded-client.generated.txt";
 import { getGainDashboardStats } from "./gain-aggregator";
-import { recoverStatsPort, STATS_DASHBOARD_HEADER } from "./port-conflict";
+import { recoverStatsPort, STATS_DASHBOARD_HEADER, STATS_DASHBOARD_HOSTNAME } from "./port-conflict";
 
 const EMBEDDED_CLIENT_ARCHIVE = decodeEmbeddedClientArchive(embeddedClientArchiveTxt);
 
@@ -303,21 +303,19 @@ async function handleStatic(requestPath: string): Promise<Response> {
 function createDashboardServer(port: number) {
 	const server = Bun.serve({
 		port,
+		hostname: STATS_DASHBOARD_HOSTNAME,
 		async fetch(req) {
 			const url = new URL(req.url);
 			const path = url.pathname;
 
-			// CORS headers for local development; the identity header lets another
-			// omp session's reuse probe positively recognize this dashboard.
-			const corsHeaders: Record<string, string> = {
-				"Access-Control-Allow-Origin": "*",
-				"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-				"Access-Control-Allow-Headers": "Content-Type",
+			// The identity header lets another omp session's reuse probe positively
+			// recognize this dashboard without allowing cross-origin API reads.
+			const dashboardHeaders: Record<string, string> = {
 				[STATS_DASHBOARD_HEADER]: "1",
 			};
 
 			if (req.method === "OPTIONS") {
-				return new Response(null, { headers: corsHeaders });
+				return new Response(null, { headers: dashboardHeaders });
 			}
 
 			try {
@@ -329,10 +327,10 @@ function createDashboardServer(port: number) {
 					response = await handleStatic(path);
 				}
 
-				// Add CORS headers to all responses
+				// Add the dashboard identity header to all responses.
 				const headers = new Headers(response.headers);
-				for (const key in corsHeaders) {
-					headers.set(key, corsHeaders[key]);
+				for (const key in dashboardHeaders) {
+					headers.set(key, dashboardHeaders[key]);
 				}
 
 				return new Response(response.body, {
@@ -343,7 +341,7 @@ function createDashboardServer(port: number) {
 				console.error("Server error:", error);
 				return Response.json(
 					{ error: error instanceof Error ? error.message : "Unknown error" },
-					{ status: 500, headers: corsHeaders },
+					{ status: 500, headers: dashboardHeaders },
 				);
 			}
 		},
@@ -354,12 +352,13 @@ function createDashboardServer(port: number) {
 /**
  * Start the HTTP server, reusing a live dashboard or reclaiming a stale omp listener.
  */
-export async function startServer(port = 3847): Promise<{ port: number; stop: () => void }> {
+export async function startServer(port = 3847): Promise<{ hostname: string; port: number; stop: () => void }> {
 	await ensureClientBuild();
 
 	try {
 		const server = createDashboardServer(port);
 		return {
+			hostname: STATS_DASHBOARD_HOSTNAME,
 			port: server.port ?? port,
 			stop: () => server.stop(),
 		};
@@ -368,12 +367,13 @@ export async function startServer(port = 3847): Promise<{ port: number; stop: ()
 
 		const recovery = await recoverStatsPort(port);
 		if (recovery === "reuse") {
-			return { port, stop: () => {} };
+			return { hostname: STATS_DASHBOARD_HOSTNAME, port, stop: () => {} };
 		}
 
 		try {
 			const server = createDashboardServer(port);
 			return {
+				hostname: STATS_DASHBOARD_HOSTNAME,
 				port: server.port ?? port,
 				stop: () => server.stop(),
 			};

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -21,7 +21,12 @@ import {
 import { decodeEmbeddedClientArchive } from "./embedded-client";
 import embeddedClientArchiveTxt from "./embedded-client.generated.txt";
 import { getGainDashboardStats } from "./gain-aggregator";
-import { recoverStatsPort, STATS_DASHBOARD_HEADER, STATS_DASHBOARD_HOSTNAME } from "./port-conflict";
+import {
+	recoverStatsPort,
+	STATS_DASHBOARD_HEADER,
+	STATS_DASHBOARD_HOSTNAME,
+	STATS_DASHBOARD_SECURITY_VERSION,
+} from "./port-conflict";
 
 const EMBEDDED_CLIENT_ARCHIVE = decodeEmbeddedClientArchive(embeddedClientArchiveTxt);
 
@@ -311,7 +316,7 @@ function createDashboardServer(port: number) {
 			// The identity header lets another omp session's reuse probe positively
 			// recognize this dashboard without allowing cross-origin API reads.
 			const dashboardHeaders: Record<string, string> = {
-				[STATS_DASHBOARD_HEADER]: "1",
+				[STATS_DASHBOARD_HEADER]: STATS_DASHBOARD_SECURITY_VERSION,
 			};
 
 			if (req.method === "OPTIONS") {

--- a/packages/stats/test/server-port-conflict.test.ts
+++ b/packages/stats/test/server-port-conflict.test.ts
@@ -1,22 +1,22 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import type { Subprocess } from "bun";
-import { STATS_DASHBOARD_HEADER } from "../src/port-conflict";
+import { STATS_DASHBOARD_HEADER, STATS_DASHBOARD_HOSTNAME } from "../src/port-conflict";
 import { startServer } from "../src/server";
 
 const holderProcesses: Array<Subprocess<"ignore", "pipe", "pipe">> = [];
 
 async function startBunHolder(responseExpr: string, options?: { statsOwned?: boolean }) {
-	// Bind the wildcard address: `startServer` binds the wildcard too, and on
-	// macOS SO_REUSEADDR lets a wildcard bind coexist with a 127.0.0.1-only
-	// listener, which would bypass the EADDRINUSE path this suite exercises.
+	// Bind the same loopback address as `startServer` so macOS cannot let a
+	// wildcard and address-specific listener coexist on the reserved port.
 	const reservation = Bun.serve({
 		port: 0,
+		hostname: STATS_DASHBOARD_HOSTNAME,
 		fetch: () => new Response("reserved"),
 	});
 	const port = reservation.port;
 	reservation.stop(true);
 
-	const source = `Bun.serve({ port: ${port}, fetch: () => ${responseExpr} }); process.stdout.write("ready"); await Promise.withResolvers().promise;`;
+	const source = `Bun.serve({ port: ${port}, hostname: "${STATS_DASHBOARD_HOSTNAME}", fetch: () => ${responseExpr} }); process.stdout.write("ready"); await Promise.withResolvers().promise;`;
 	const args = [process.execPath, "-e", source];
 	if (options?.statsOwned) args.push("omp-stats");
 	const child = Bun.spawn(args, {
@@ -46,10 +46,34 @@ afterEach(async () => {
 	holderProcesses.length = 0;
 });
 
+describe("startServer access", () => {
+	it("only serves loopback requests without cross-origin access", async () => {
+		const server = await startServer(0);
+
+		try {
+			expect(server.hostname).toBe(STATS_DASHBOARD_HOSTNAME);
+			const response = await fetch(`http://${server.hostname}:${server.port}/api/stats/models`);
+			expect(response.status).toBe(200);
+			expect(response.headers.get(STATS_DASHBOARD_HEADER)).toBe("1");
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+			await response.body?.cancel();
+
+			await expect(
+				fetch(`http://127.0.0.2:${server.port}/api/stats/models`, {
+					signal: AbortSignal.timeout(1_000),
+				}),
+			).rejects.toThrow();
+		} finally {
+			server.stop();
+		}
+	});
+});
+
 describe("startServer port conflicts", () => {
 	it("reuses a live stats dashboard identified by its header", async () => {
 		const existing = Bun.serve({
 			port: 0,
+			hostname: STATS_DASHBOARD_HOSTNAME,
 			fetch: request =>
 				new URL(request.url).pathname === "/api/stats/models"
 					? Response.json([], { headers: { [STATS_DASHBOARD_HEADER]: "1" } })
@@ -62,7 +86,7 @@ describe("startServer port conflicts", () => {
 			server.stop();
 
 			// The existing dashboard is untouched: it still answers on the port.
-			const response = await fetch(`http://127.0.0.1:${existing.port}/api/stats/models`);
+			const response = await fetch(`http://${STATS_DASHBOARD_HOSTNAME}:${existing.port}/api/stats/models`);
 			expect(response.status).toBe(200);
 			expect(response.headers.get(STATS_DASHBOARD_HEADER)).toBe("1");
 			await response.body?.cancel();
@@ -76,7 +100,7 @@ describe("startServer port conflicts", () => {
 
 		await expect(startServer(holder.port)).rejects.toThrow("not identifiable as an omp stats dashboard");
 		expect(holder.child.exitCode).toBeNull();
-		const response = await fetch(`http://127.0.0.1:${holder.port}/api/stats/models`);
+		const response = await fetch(`http://${STATS_DASHBOARD_HOSTNAME}:${holder.port}/api/stats/models`);
 		expect(await response.json()).toEqual({ app: "spa" });
 	});
 

--- a/packages/stats/test/server-port-conflict.test.ts
+++ b/packages/stats/test/server-port-conflict.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { connect, type Subprocess } from "bun";
-import { STATS_DASHBOARD_HEADER, STATS_DASHBOARD_HOSTNAME } from "../src/port-conflict";
+import {
+	STATS_DASHBOARD_HEADER,
+	STATS_DASHBOARD_HOSTNAME,
+	STATS_DASHBOARD_SECURITY_VERSION,
+} from "../src/port-conflict";
 import { startServer } from "../src/server";
 
 /**
@@ -69,7 +73,7 @@ describe("startServer access", () => {
 			expect(server.hostname).toBe(STATS_DASHBOARD_HOSTNAME);
 			const response = await fetch(`http://${server.hostname}:${server.port}/api/stats/models`);
 			expect(response.status).toBe(200);
-			expect(response.headers.get(STATS_DASHBOARD_HEADER)).toBe("1");
+			expect(response.headers.get(STATS_DASHBOARD_HEADER)).toBe(STATS_DASHBOARD_SECURITY_VERSION);
 			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
 			await response.body?.cancel();
 
@@ -90,7 +94,7 @@ describe("startServer port conflicts", () => {
 			hostname: STATS_DASHBOARD_HOSTNAME,
 			fetch: request =>
 				new URL(request.url).pathname === "/api/stats/models"
-					? Response.json([], { headers: { [STATS_DASHBOARD_HEADER]: "1" } })
+					? Response.json([], { headers: { [STATS_DASHBOARD_HEADER]: STATS_DASHBOARD_SECURITY_VERSION } })
 					: new Response("dashboard"),
 		});
 
@@ -102,12 +106,38 @@ describe("startServer port conflicts", () => {
 			// The existing dashboard is untouched: it still answers on the port.
 			const response = await fetch(`http://${STATS_DASHBOARD_HOSTNAME}:${existing.port}/api/stats/models`);
 			expect(response.status).toBe(200);
-			expect(response.headers.get(STATS_DASHBOARD_HEADER)).toBe("1");
+			expect(response.headers.get(STATS_DASHBOARD_HEADER)).toBe(STATS_DASHBOARD_SECURITY_VERSION);
 			await response.body?.cancel();
 		} finally {
 			existing.stop(true);
 		}
 	});
+
+	for (const fixture of [
+		{
+			name: "reclaims a version 1 dashboard with wildcard CORS",
+			response: `Response.json([], { headers: { "${STATS_DASHBOARD_HEADER}": "1", "Access-Control-Allow-Origin": "*" } })`,
+		},
+		{
+			name: "reclaims a headerless legacy dashboard",
+			response: "Response.json([])",
+		},
+	]) {
+		it(fixture.name, async () => {
+			const holder = await startBunHolder(fixture.response, { statsOwned: true });
+			const server = await startServer(holder.port);
+
+			try {
+				expect(await holder.child.exited).not.toBe(0);
+				const response = await fetch(`http://${STATS_DASHBOARD_HOSTNAME}:${server.port}/api/stats/models`);
+				expect(response.headers.get(STATS_DASHBOARD_HEADER)).toBe(STATS_DASHBOARD_SECURITY_VERSION);
+				expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+				await response.body?.cancel();
+			} finally {
+				server.stop();
+			}
+		});
+	}
 
 	it("refuses to stop a foreign 200 responder", async () => {
 		const holder = await startBunHolder('Response.json({ app: "spa" })');

--- a/packages/stats/test/server-port-conflict.test.ts
+++ b/packages/stats/test/server-port-conflict.test.ts
@@ -1,7 +1,22 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import type { Subprocess } from "bun";
+import { connect, type Subprocess } from "bun";
 import { STATS_DASHBOARD_HEADER, STATS_DASHBOARD_HOSTNAME } from "../src/port-conflict";
 import { startServer } from "../src/server";
+
+/**
+ * Directly probe a TCP endpoint, bypassing any configured HTTP proxy so the
+ * loopback-only bind is asserted against the real listener rather than a proxy
+ * response. Resolves true when the connection is accepted, false when refused.
+ */
+async function tcpConnects(hostname: string, port: number): Promise<boolean> {
+	try {
+		const socket = await connect({ hostname, port, socket: { data() {}, open() {}, close() {}, error() {} } });
+		socket.end();
+		return true;
+	} catch {
+		return false;
+	}
+}
 
 const holderProcesses: Array<Subprocess<"ignore", "pipe", "pipe">> = [];
 
@@ -58,11 +73,10 @@ describe("startServer access", () => {
 			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
 			await response.body?.cancel();
 
-			await expect(
-				fetch(`http://127.0.0.2:${server.port}/api/stats/models`, {
-					signal: AbortSignal.timeout(1_000),
-				}),
-			).rejects.toThrow();
+			// 127.0.0.2 also routes to the loopback interface, but the server bound
+			// only 127.0.0.1, so a direct connection there must be refused.
+			expect(await tcpConnects(server.hostname, server.port)).toBe(true);
+			expect(await tcpConnects("127.0.0.2", server.port)).toBe(false);
 		} finally {
 			server.stop();
 		}


### PR DESCRIPTION
## Repro

Running `bun /tmp/omp-7633-repro.ts` against `startServer(0)` fetched `/api/stats` through both `127.0.0.1` and the host non-loopback address `172.18.0.3`; both returned HTTP 200, and the non-loopback response carried `Access-Control-Allow-Origin: *`.

## Cause

`createDashboardServer` in `packages/stats/src/server.ts` omitted `Bun.serve`'s `hostname`, so Bun listened on every interface, while its response wrapper attached wildcard CORS headers to every static and API response. `packages/stats/src/index.ts` nevertheless displayed a `localhost` URL.

## Fix

- Define one IPv4 loopback hostname for the dashboard server and the occupied-port reuse probe.
- Remove CORS permission headers while retaining the private dashboard identity header.
- Return and display the configured hostname, and make port-conflict fixtures reserve that same interface.
- Cover loopback success, non-loopback refusal, absent ACAO, and existing port recovery behavior.

## Verification

`bun test packages/stats/test/server-port-conflict.test.ts` passed 5 tests with 0 failures. `bun run check` in `packages/stats` passed. A post-fix `bun /tmp/omp-7633-repro.ts` probe reported `reported-hostname=127.0.0.1`, `loopback-status=200`, `loopback-acao=null`, and `non-loopback-status=refused`.

Fixes #7633