### PR TITLE
fix(cli): flush final json record before print-mode exit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `--mode json` (and text) print mode truncating a large final record (e.g. a multi-MB `agent_end`) when the process exited before stdout drained, while still exiting 0. Per-event writes are now serialized on their own completion callbacks and shutdown blocks on the last one, so the terminal record is delivered in full ([#7635](https://github.com/can1357/oh-my-pi/issues/7635)).
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -91,11 +91,30 @@ export function printableEvent(event: AgentSessionEvent): unknown {
 export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<void> {
 	const { mode, messages = [], initialMessage, initialImages, printThoughts } = options;
 
+	// process.stdout.write is fire-and-forget: a large final record (e.g. a
+	// multi-MB agent_end) can be dropped when the process exits before the pipe
+	// drains, truncating the record mid-line while the process still exits 0.
+	// Serialize every stdout write on the previous write's completion callback so
+	// records stay ordered and honor backpressure, then block shutdown on the
+	// tail before dispose/exit. Same truncation class as issue #5309 (issue #7635).
+	let stdoutTail: Promise<void> = Promise.resolve();
+	const writeStdoutLine = (text: string): void => {
+		stdoutTail = stdoutTail.then(
+			() =>
+				new Promise<void>(resolve => {
+					process.stdout.write(text, err => {
+						if (err) logger.warn("print-mode stdout write failed", { error: err.message });
+						resolve();
+					});
+				}),
+		);
+	};
+
 	// Emit session header for JSON mode
 	if (mode === "json") {
 		const header = session.sessionManager.getHeader();
 		if (header) {
-			process.stdout.write(`${JSON.stringify(header)}\n`);
+			writeStdoutLine(`${JSON.stringify(header)}\n`);
 		}
 	}
 	// Set up extensions for print mode (no UI, no command context)
@@ -172,7 +191,7 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 		}
 		// In JSON mode, output all events
 		if (mode === "json") {
-			process.stdout.write(`${JSON.stringify(printableEvent(event))}\n`);
+			writeStdoutLine(`${JSON.stringify(printableEvent(event))}\n`);
 		}
 	});
 
@@ -243,9 +262,9 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 			// Output text content
 			for (const content of assistantMsg.content) {
 				if (content.type === "text") {
-					process.stdout.write(`${sanitizeText(content.text)}\n`);
+					writeStdoutLine(`${sanitizeText(content.text)}\n`);
 				} else if (printThoughts && content.type === "thinking" && content.thinking.trim().length > 0) {
-					process.stdout.write(`${sanitizeText(content.thinking)}\n`);
+					writeStdoutLine(`${sanitizeText(content.thinking)}\n`);
 				}
 			}
 		}
@@ -253,13 +272,9 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 
 	await session.waitForAdvisorCatchup(PRINT_MODE_ADVISOR_DRAIN_TIMEOUT_MS);
 
-	// Ensure stdout, including late JSON advisor events, is fully flushed before returning.
-	// This prevents race conditions where the process exits before all output is written.
-	await new Promise<void>((resolve, reject) => {
-		process.stdout.write("", err => {
-			if (err) reject(err);
-			else resolve();
-		});
-	});
+	// Block shutdown until every serialized stdout write (including the final
+	// agent_end and late JSON advisor events) has drained; process.exit would
+	// otherwise discard the buffered tail and truncate the last record.
+	await stdoutTail;
 	await session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
 }

--- a/packages/coding-agent/test/print-mode-json-flush.test.ts
+++ b/packages/coding-agent/test/print-mode-json-flush.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression (#7635): `--mode json` must not exit until the final record's
+ * stdout write has fully drained.
+ *
+ * The JSON path emitted each event with a fire-and-forget `process.stdout.write`
+ * and relied on an empty-write "flush barrier" before dispose/exit. The barrier
+ * awaited its own callback, not the preceding large write, so a big final
+ * `agent_end` (multi-MB) could be truncated when the process exited before the
+ * pipe drained — while still exiting 0. The fix serializes every print-mode
+ * stdout write on its own completion callback and blocks shutdown on the tail.
+ *
+ * Contract: `runPrintMode` stays pending until the final record's write callback
+ * fires (so `process.exit` can't discard it), and the full record is delivered.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { runPrintMode } from "@oh-my-pi/pi-coding-agent/modes/print-mode";
+import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+interface FlushHarness {
+	session: AgentSession;
+	promptStarted: Promise<void>;
+	resolvePrompt: () => void;
+	emit: (event: AgentSessionEvent) => void;
+	disposed: () => boolean;
+}
+
+function createFlushHarness(): FlushHarness {
+	const { promise: promptStarted, resolve: markPromptStarted } = Promise.withResolvers<void>();
+	const { promise: promptReleased, resolve: resolvePrompt } = Promise.withResolvers<void>();
+	let subscriber: ((event: AgentSessionEvent) => void) | undefined;
+	let disposed = false;
+	let advisorDrainPrepared = false;
+
+	const session = {
+		sessionManager: {
+			getHeader: () => undefined,
+			buildSessionContext: () => ({ messages: [] }),
+			getEntries: () => [],
+		},
+		settings: { get: () => false },
+		extensionRunner: undefined,
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			subscriber = listener;
+			return () => {};
+		},
+		prompt: async () => {
+			markPromptStarted();
+			await promptReleased;
+			return true;
+		},
+		prepareForHeadlessAdvisorDrain: () => {
+			advisorDrainPrepared = true;
+		},
+		waitForAdvisorCatchup: async () => {
+			if (!advisorDrainPrepared) throw new Error("advisor catch-up started before headless delivery was armed");
+		},
+		dispose: async () => {
+			disposed = true;
+		},
+	} as unknown as AgentSession;
+
+	return {
+		session,
+		promptStarted,
+		resolvePrompt,
+		emit: event => subscriber?.(event),
+		disposed: () => disposed,
+	};
+}
+
+function makeLargeAgentEnd(payload: string): AgentSessionEvent {
+	return {
+		type: "agent_end",
+		messages: [
+			{
+				role: "assistant",
+				content: [{ type: "text", text: payload }],
+				stopReason: "aborted",
+				errorMessage: "Deadline exceeded",
+				timestamp: Date.now(),
+			},
+		],
+	} as unknown as AgentSessionEvent;
+}
+
+describe("print-mode JSON flush (#7635)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("blocks exit until the final agent_end write drains, then delivers it in full", async () => {
+		const writes: string[] = [];
+		let releaseAgentEnd: (() => void) | undefined;
+		const { promise: agentEndWriteIssued, resolve: markAgentEndWriteIssued } = Promise.withResolvers<void>();
+		vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
+			const chunk = args[0];
+			const text = typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString();
+			writes.push(text);
+			const cb = args[args.length - 1];
+			const invoke = typeof cb === "function" ? (cb as (err?: Error | null) => void) : undefined;
+			// Defer the large agent_end record's completion callback to emulate a
+			// backpressured pipe; every other write completes synchronously.
+			if (text.includes('"type":"agent_end"')) {
+				releaseAgentEnd = () => invoke?.(null);
+				markAgentEndWriteIssued();
+			} else {
+				invoke?.(null);
+			}
+			return true;
+		});
+
+		const payload = "x".repeat(1_500_000);
+		const harness = createFlushHarness();
+
+		const run = runPrintMode(harness.session, { mode: "json", initialMessage: "hello" });
+		let settled = false;
+		void run.then(() => {
+			settled = true;
+		});
+
+		await harness.promptStarted;
+		harness.emit(makeLargeAgentEnd(payload));
+		harness.resolvePrompt();
+
+		// Drain to quiescence: every step runPrintMode can complete without the
+		// deferred write is microtask-driven, so one macrotask boundary flushes
+		// them all. The pre-fix fire-and-forget path settles and disposes here;
+		// the fix must still be blocked on the undrained agent_end write.
+		await agentEndWriteIssued;
+		await new Promise<void>(resolve => setImmediate(resolve));
+		expect(releaseAgentEnd).toBeDefined();
+		expect(settled).toBe(false);
+		expect(harness.disposed()).toBe(false);
+
+		releaseAgentEnd?.();
+		await run;
+
+		expect(settled).toBe(true);
+		expect(harness.disposed()).toBe(true);
+
+		const agentEndLine = writes.find(line => line.includes('"type":"agent_end"'));
+		expect(agentEndLine).toBeDefined();
+		expect(agentEndLine?.endsWith("\n")).toBe(true);
+		// The complete payload survives — not a pipe-buffer-sized prefix.
+		expect(agentEndLine).toContain(payload);
+		expect(JSON.parse(agentEndLine as string)).toMatchObject({ type: "agent_end" });
+	});
+});


### PR DESCRIPTION
## Repro
Under `-p --no-session --mode json`, a deadline-aborted turn whose final `agent_end` is large (reporter: 1.5 MB) exits with status 0 after stdout ends partway through that record; the preceding `message_end`/`turn_end` are complete. Reproduced locally on bun 1.3.14 with a harness mirroring the JSON path (fire-and-forget `process.stdout.write` + the empty-write flush barrier + the `quit()` drain guard), a 1.5 MB record, piped to a slow reader that keeps the pipe near-full:

```
bun emit.ts | bun slowread.ts
=== current behavior (fire-and-forget + empty-write barrier + drain guard) ===
received=65536 expected=1500034 complete=false
=== candidate fix (await write completion callback) ===
received=1500034 expected=1500034 complete=true
```

The output truncates at the pipe buffer (64 KiB here; the reporter's 240 KiB is just a larger buffer) while the process still exits 0.

## Cause
`runPrintMode` (`packages/coding-agent/src/modes/print-mode.ts`) emitted each JSON event with a fire-and-forget `process.stdout.write` from the synchronous `subscribe` listener, then relied on an empty-write "flush barrier" (`process.stdout.write("", cb)`) before `session.dispose()` and the `quit(0)` drain guard (`postmortem.ts:368`). The barrier awaits its own callback, not the preceding large write; under Bun that callback can fire before the big record drains, so `process.exit` discards the buffered tail. Same class as #5309 (`config list --json` 64 KiB truncation), fixed there by awaiting the write callback (`config-cli.ts:268`).

## Fix
- Serialize every print-mode stdout write (header, JSON events, and text-mode final content) through a promise chain, each link resolving on the write's own completion callback so writes stay ordered and honor backpressure.
- Replace the ineffective empty-write flush barrier with an `await` on the chain tail before `session.dispose()`, so shutdown blocks until the final record (e.g. `agent_end`) is fully drained.
- Add `test/print-mode-json-flush.test.ts`: emits a 1.5 MB `agent_end` in JSON mode with a deferred write callback and asserts `runPrintMode` stays blocked (not disposed) until the callback fires, then delivers the complete record.

Exit-0-on-abort in JSON mode is left unchanged (by design: the stream carries `stopReason`, which consumers inspect rather than the exit code); this PR scopes to the truncation only.

## Verification
`bun test test/print-mode-json-flush.test.ts test/print-mode-working-indicator.test.ts test/silent-abort-print-mode.test.ts test/modes/noninteractive-dispose.test.ts test/modes/print-mode.test.ts` -> 18 pass. Confirmed the new test fails against the pre-fix fire-and-forget behavior (settled/disposed before the final write drained) and passes with the fix. Manual repro above shows the full 1,500,034-byte record delivered after the change. Fixes #7635