### PR TITLE
fix(session): case-fold windows session bucket key by drive-letter casing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows session workspaces splitting by drive-letter/path casing: the session bucket key is now case-folded on win32 so the same directory opened as `d:\code\zig` or `D:\code\zig` resolves to one workspace for `/resume`, `--continue`, and auto-resume. Existing case-variant buckets migrate into the folded bucket on first use ([#7642](https://github.com/can1357/oh-my-pi/issues/7642)).
+
 ## [17.2.8] - 2026-08-04
 
 ### Changed

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -50,6 +50,7 @@ function encodeLegacyRelativeSessionDirName(prefix: string, relative: string): s
 function getDefaultSessionDirName(cwd: string): {
 	encodedDirName: string;
 	legacyRelativeDirName: string | undefined;
+	legacyDigestDirName: string | undefined;
 	resolvedCwd: string;
 } {
 	const resolvedCwd = path.resolve(cwd);
@@ -73,15 +74,27 @@ function getDefaultSessionDirName(cwd: string): {
 		scope = "abs";
 	}
 
-	const normalized = canonicalCwd.replaceAll("\\", "/");
+	const slashed = canonicalCwd.replaceAll("\\", "/");
+	// Windows filesystems are case-insensitive, so the same directory can surface
+	// with different drive-letter or path casing depending on the shell that
+	// launched omp (e.g. `d:\code\zig` vs `D:\code\zig`). Fold the bucket key to
+	// lowercase on win32 so those variants map to one session workspace. No-op on
+	// macOS/Linux, keeping their case-sensitive keys unchanged.
+	const normalized = process.platform === "win32" ? slashed.toLowerCase() : slashed;
 	const readable = path
 		.basename(canonicalCwd)
 		.replace(/[^a-zA-Z0-9._-]+/g, "-")
 		.replace(/^-+|-+$/g, "")
 		.slice(-80);
+	const label = readable || "project";
 	const digest = Bun.SHA256.hash(normalized, "hex");
-	const encodedDirName = `${scope}-${readable || "project"}-${digest}`;
-	return { encodedDirName, legacyRelativeDirName, resolvedCwd };
+	const encodedDirName = `${scope}-${label}-${digest}`;
+	// Pre-fold bucket for the same cwd, kept only where folding actually changes
+	// the key (win32 paths containing uppercase). Lets existing sessions migrate
+	// into the folded bucket exactly once.
+	const legacyDigestDirName =
+		normalized === slashed ? undefined : `${scope}-${label}-${Bun.SHA256.hash(slashed, "hex")}`;
+	return { encodedDirName, legacyRelativeDirName, legacyDigestDirName, resolvedCwd };
 }
 
 function readSessionCwd(sessionFile: string, buffer: Buffer): string | undefined {
@@ -159,10 +172,11 @@ function rerouteCollidingSessions(
 
 export function resolveManagedSessionRoot(sessionDir: string, cwd: string): string | undefined {
 	const currentDirName = path.basename(sessionDir);
-	const { encodedDirName, legacyRelativeDirName } = getDefaultSessionDirName(cwd);
+	const { encodedDirName, legacyRelativeDirName, legacyDigestDirName } = getDefaultSessionDirName(cwd);
 	if (
 		currentDirName !== encodedDirName &&
 		currentDirName !== legacyRelativeDirName &&
+		currentDirName !== legacyDigestDirName &&
 		currentDirName !== encodeLegacyAbsoluteSessionDirName(cwd)
 	) {
 		return undefined;
@@ -180,7 +194,7 @@ export function computeDefaultSessionDir(
 	storage: SessionStorage,
 	sessionsRoot: string = getSessionsDir(),
 ): string {
-	const { encodedDirName, legacyRelativeDirName, resolvedCwd } = getDefaultSessionDirName(cwd);
+	const { encodedDirName, legacyRelativeDirName, legacyDigestDirName, resolvedCwd } = getDefaultSessionDirName(cwd);
 	const sessionDir = path.join(sessionsRoot, encodedDirName);
 	const legacyDirs: Array<{ kind: "relative" | "absolute"; name: string | undefined }> = [
 		{ kind: "relative", name: legacyRelativeDirName },
@@ -195,6 +209,19 @@ export function computeDefaultSessionDir(
 			migrateSessionDirPath(legacyDir, sessionDir);
 		} catch {
 			// Best effort
+		}
+	}
+	// Consolidate a pre-fold win32 bucket (case-preserving digest) into the folded
+	// one. Distinct casings hash to distinct buckets, so a direct move suffices —
+	// no cross-cwd reroute like the legacy relative/absolute schemes need.
+	if (legacyDigestDirName) {
+		const legacyDir = path.join(sessionsRoot, legacyDigestDirName);
+		if (legacyDir !== sessionDir && fs.existsSync(legacyDir)) {
+			try {
+				migrateSessionDirPath(legacyDir, sessionDir);
+			} catch {
+				// Best effort
+			}
 		}
 	}
 	storage.ensureDirSync(sessionDir);

--- a/packages/coding-agent/test/session/session-paths-casing.test.ts
+++ b/packages/coding-agent/test/session/session-paths-casing.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { computeDefaultSessionDir } from "@oh-my-pi/pi-coding-agent/session/session-paths";
+import { FileSessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const originalPlatform = process.platform;
+const storage = new FileSessionStorage();
+
+function setPlatform(value: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", { value, configurable: true, writable: true });
+}
+
+afterEach(() => {
+	Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true, writable: true });
+});
+
+describe("computeDefaultSessionDir Windows drive-letter/path casing", () => {
+	it("maps case-variant paths of one directory to a single win32 session bucket", () => {
+		using tmp = TempDir.createSync("omp-session-casing-");
+		const sessionsRoot = path.join(tmp.path(), "sessions");
+		// cwd outside home/tmp so both variants classify as "abs" like a real drive path.
+		const upper = path.join(path.sep, "omp-casing", "Code", "zig");
+		const lower = path.join(path.sep, "omp-casing", "code", "zig");
+
+		setPlatform("win32");
+		const bucketUpper = computeDefaultSessionDir(upper, storage, sessionsRoot);
+		const bucketLower = computeDefaultSessionDir(lower, storage, sessionsRoot);
+
+		expect(bucketUpper).toBe(bucketLower);
+	});
+
+	it("keeps macOS/Linux buckets case-sensitive", () => {
+		using tmp = TempDir.createSync("omp-session-casing-");
+		const sessionsRoot = path.join(tmp.path(), "sessions");
+		const upper = path.join(path.sep, "omp-casing", "Code", "zig");
+		const lower = path.join(path.sep, "omp-casing", "code", "zig");
+
+		setPlatform("linux");
+		const bucketUpper = computeDefaultSessionDir(upper, storage, sessionsRoot);
+		const bucketLower = computeDefaultSessionDir(lower, storage, sessionsRoot);
+
+		expect(bucketUpper).not.toBe(bucketLower);
+	});
+
+	it("migrates a pre-fix case-preserving bucket into the folded win32 bucket", () => {
+		using tmp = TempDir.createSync("omp-session-casing-");
+		const sessionsRoot = path.join(tmp.path(), "sessions");
+		const cwd = path.join(path.sep, "omp-casing", "Embedded");
+
+		// A bucket written before the fold matches the (unchanged) non-win32 key.
+		setPlatform("linux");
+		const legacyDir = computeDefaultSessionDir(cwd, storage, sessionsRoot);
+		const sessionName = "2026-01-01T00-00-00-000Z_sess.jsonl";
+		fs.writeFileSync(path.join(legacyDir, sessionName), `${JSON.stringify({ type: "session", id: "sess", cwd })}\n`);
+
+		setPlatform("win32");
+		const foldedDir = computeDefaultSessionDir(cwd, storage, sessionsRoot);
+
+		expect(foldedDir).not.toBe(legacyDir);
+		expect(fs.existsSync(path.join(foldedDir, sessionName))).toBe(true);
+		expect(fs.existsSync(legacyDir)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Repro
On Windows the same directory opened from shells that report different drive-letter/path casing (e.g. VS Code's `D:\code\zig` vs git-bash's `d:\code\zig`) splits into separate session workspaces: `/resume`'s current-folder list, `--continue`, and auto-resume only surface the bucket matching the terminal's exact casing, hiding sessions created under the other casing until Tab switches to all-workspaces scope. Reproduced with `bun test test/session/session-paths-casing.test.ts` (cwd `packages/coding-agent`): with `process.platform` forced to `win32`, `computeDefaultSessionDir()` for two casings of one directory returns two distinct `abs-zig-*` buckets (`abs-zig-1940f138…` vs `abs-zig-6991ef33…`), matching the reporter's on-disk `abs-zig-466ccc5e` / `abs-zig-bbef39ff` pair.

## Cause
`getDefaultSessionDirName()` in `packages/coding-agent/src/session/session-paths.ts` computes the bucket digest from `canonicalCwd.replaceAll("\\","/")` with no case normalization (`resolveEquivalentPath` in `packages/utils/src/dirs.ts` is case-preserving). On Windows's case-insensitive filesystem, differing drive-letter/path case therefore yields different SHA256 buckets, even though the codebase already exposes `normalizePathForComparison()` (case-folding on win32) for path comparison elsewhere.

## Fix
- In `getDefaultSessionDirName()`, lowercase the digest input on win32 only (no-op on macOS/Linux), so case-variant paths of one directory map to a single bucket.
- Emit a `legacyDigestDirName` (the pre-fold, case-preserving bucket name) whenever folding changes the key, and migrate that bucket into the folded one in `computeDefaultSessionDir()` via `migrateSessionDirPath` — a direct move, since distinct casings hash to distinct buckets with no cross-cwd collisions.
- Recognize `legacyDigestDirName` in `resolveManagedSessionRoot()` so a not-yet-migrated bucket still counts as managed.
- Regression test `test/session/session-paths-casing.test.ts` covering win32 folding, macOS/Linux case-sensitivity, and pre-fold bucket migration.

## Verification
`bun test test/slash-commands/resume.test.ts test/session-manager/ test/session/session-paths-casing.test.ts` → 201 pass, 0 fail (after generating the unrelated `tool-views.generated.js` build artifact, which is absent in fresh worktrees and made SessionManager-importing files fail at module load regardless of this change). Pre-publish gate (`bun run fix` + `bun check`) passed on push. Fixes #7642