### PR TITLE
fix(omptype): emit postfix bound for min-only numeric typebox schemas

### DIFF
--- a/packages/omptype/CHANGELOG.md
+++ b/packages/omptype/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the TypeBox adapter emitting an invalid left-bound-only DSL for min-only numeric schemas (e.g. `Type.Integer({ minimum: 1 })`), which threw `left bound requires a corresponding right bound` and broke extension tool loading ([#7648](https://github.com/can1357/oh-my-pi/issues/7648)).
+
 ## [17.2.8] - 2026-08-04
 
 ### Added

--- a/packages/omptype/src/typebox.ts
+++ b/packages/omptype/src/typebox.ts
@@ -267,9 +267,19 @@ function tNumber(opts?: NumberOpts, integer = false): TNumber {
 		upper = { value: opts.exclusiveMaximum, exclusive: true };
 	}
 	const keyword = integer ? "number.integer" : "number";
-	const lowerDsl = lower ? `${lower.value} ${lower.exclusive ? "<" : "<="} ` : "";
-	const upperDsl = upper ? ` ${upper.exclusive ? "<" : "<="} ${upper.value}` : "";
-	let schema = asRuntime<number>(type.raw(`${lowerDsl}${keyword}${upperDsl}`));
+	// The `LO <= TYPE <= HI` range spelling requires both bounds; a min-only
+	// bound must use the postfix `TYPE >= LO` form (see parseBounded in ir.ts).
+	let src: string;
+	if (lower && upper) {
+		src = `${lower.value} ${lower.exclusive ? "<" : "<="} ${keyword} ${upper.exclusive ? "<" : "<="} ${upper.value}`;
+	} else if (lower) {
+		src = `${keyword} ${lower.exclusive ? ">" : ">="} ${lower.value}`;
+	} else if (upper) {
+		src = `${keyword} ${upper.exclusive ? "<" : "<="} ${upper.value}`;
+	} else {
+		src = keyword;
+	}
+	let schema = asRuntime<number>(type.raw(src));
 	if (opts?.multipleOf !== undefined) {
 		const divisor = opts.multipleOf;
 		schema = schema.narrow((value, ctx) => {

--- a/packages/omptype/test/typebox.test.ts
+++ b/packages/omptype/test/typebox.test.ts
@@ -56,6 +56,22 @@ describe("TypeBox adapter", () => {
 		expect(valid(exclusive, 1)).toBe(false);
 		expect(valid(exclusive, 3)).toBe(false);
 		expect(exclusive.toJsonSchema()).toEqual({ type: "number", exclusiveMinimum: 1, exclusiveMaximum: 3 });
+
+		const minOnly = Type.Integer({ minimum: 1 });
+		expect(valid(minOnly, 1)).toBe(true);
+		expect(valid(minOnly, 0)).toBe(false);
+		expect(valid(minOnly, 1.5)).toBe(false);
+		expect(minOnly.toJsonSchema()).toEqual({ type: "integer", minimum: 1 });
+		const exclusiveMinOnly = Type.Number({ exclusiveMinimum: 0 });
+		expect(valid(exclusiveMinOnly, 0)).toBe(false);
+		expect(valid(exclusiveMinOnly, 0.5)).toBe(true);
+		const maxOnly = Type.Number({ maximum: 5 });
+		expect(valid(maxOnly, 5)).toBe(true);
+		expect(valid(maxOnly, 6)).toBe(false);
+		const minWithMultiple = Type.Integer({ minimum: 1, multipleOf: 2 });
+		expect(valid(minWithMultiple, 4)).toBe(true);
+		expect(valid(minWithMultiple, 3)).toBe(false);
+		expect(valid(minWithMultiple, 0)).toBe(false);
 	});
 
 	test("arrays, tuples, objects, records and intersections validate", () => {


### PR DESCRIPTION
## Repro

Constructing a standard min-only TypeBox numeric schema throws at build time:

```ts
Type.Object({ lines: Type.Optional(Type.Integer({ minimum: 1 })) });
// left bound requires a corresponding right bound in "1 <= number.integer"
```

This breaks loading any extension whose tool params use the idiomatic `Type.Integer({ minimum: 1 })` pattern (e.g. `@ogulcancelik/pi-herdr`).

## Cause

`packages/omptype/src/typebox.ts` `tNumber` rendered a lower bound as the range-prefix DSL `1 <= number.integer`. `parseBounded()` in `ir.ts` treats the `LO <= TYPE` spelling as an ArkType-style range and requires a trailing right bound, so a min-only constraint (no `maximum`) produced an unparseable string. The DSL supports min-only bounds only in the postfix spelling `number.integer >= 1`, which the emitter never produced.

## Fix

- `tNumber` now selects the DSL by which bounds are present: `LO <= TYPE <= HI` only when both bounds exist; postfix `TYPE >= LO` / `TYPE > LO` for min-only; `TYPE <= HI` for max-only; bare keyword when unbounded.
- Added a regression test covering min-only, exclusive-min-only, max-only, and min+multipleOf schemas (validation + JSON-schema round-trip).

## Verification

`bun test` in `packages/omptype`: 1145 pass / 0 fail (was failing to even construct min-only schemas before). Manually confirmed `Type.Integer({ minimum: 1 })` builds and validates (accepts 1, rejects 0 and 1.5) and round-trips to `{ type: "integer", minimum: 1 }`.

Fixes #7648