### PR TITLE
feat(config): reload global settings changes

### DIFF
--- a/docs/config-usage.md
+++ b/docs/config-usage.md
@@ -166,6 +166,14 @@ Write behavior:
 - `settings.set(...)` writes to the **global** layer (the global YAML file selected at startup) and queues a background save.
 - Project settings and config overlays are read-only from the settings API.
 
+The global config directory is watched for `config.yml` and `config.yaml`
+changes. Successful external edits replace the global layer in the running
+process, rebuild effective settings, and notify changed setting hooks and model
+role listeners. Atomic replacements and repeated editor events are debounced.
+A malformed or unreadable live edit leaves the last valid settings active and
+is not quarantined; startup validation retains the stricter failure behavior
+below. Project settings and explicit config overlays are not watched.
+
 ### Settings load failures
 
 - Missing global/project YAML is treated as empty configuration.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added live reloads for global `config.yml` and `config.yaml` changes.
+
 ## [17.2.8] - 2026-08-04
 
 ### Changed

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -370,6 +370,10 @@ export class Settings {
 	#savePromise?: Promise<void>;
 	#projectSaveTimer?: NodeJS.Timeout;
 	#projectSavePromise?: Promise<void>;
+	/** Debounced watcher for the active global config.yml/config.yaml. */
+	#configWatcher?: fs.FSWatcher;
+	#configReloadTimer?: NodeJS.Timeout;
+	#configReloadPromise?: Promise<boolean>;
 
 	/** Whether to persist changes */
 	#persist: boolean;
@@ -413,6 +417,7 @@ export class Settings {
 				globalInstance = instance;
 				clearBoundSettingsMethods();
 				globalInstancePromise = Promise.resolve(instance);
+				instance.#startConfigWatcher();
 				return instance;
 			},
 			error => {
@@ -571,6 +576,128 @@ export class Settings {
 		this.#saveTimer = undefined;
 		clearTimeout(this.#projectSaveTimer);
 		this.#projectSaveTimer = undefined;
+		clearTimeout(this.#configReloadTimer);
+		this.#configReloadTimer = undefined;
+		this.#configWatcher?.close();
+		this.#configWatcher = undefined;
+	}
+
+	#startConfigWatcher(): void {
+		if (!this.#persist || this.#savesCancelled || this.#configWatcher) return;
+		try {
+			const watcher = fs.watch(this.#agentDir, { persistent: false }, (_eventType, filename) => {
+				if (filename && !MAIN_CONFIG_FILENAMES.some(name => name === path.basename(filename.toString()))) return;
+				this.#queueConfigReload();
+			});
+			watcher.on("error", error => {
+				if (this.#configWatcher !== watcher) return;
+				logger.warn("Settings: config watcher failed", {
+					path: this.#configPath,
+					error: toError(error).message,
+				});
+				watcher.close();
+				this.#configWatcher = undefined;
+			});
+			this.#configWatcher = watcher;
+		} catch (error) {
+			logger.warn("Settings: could not watch config", {
+				path: this.#configPath,
+				error: toError(error).message,
+			});
+		}
+	}
+
+	#queueConfigReload(): void {
+		if (this.#savesCancelled) return;
+		clearTimeout(this.#configReloadTimer);
+		this.#configReloadTimer = setTimeout(() => {
+			this.#configReloadTimer = undefined;
+			const previousReload = this.#configReloadPromise;
+			const reloadPromise = previousReload
+				? previousReload.then(
+						() => this.reloadFromDisk(),
+						() => this.reloadFromDisk(),
+					)
+				: this.reloadFromDisk();
+			this.#configReloadPromise = reloadPromise;
+			reloadPromise
+				.catch(error => {
+					logger.warn("Settings: config reload failed", {
+						path: this.#configPath,
+						error: toError(error).message,
+					});
+				})
+				.finally(() => {
+					if (this.#configReloadPromise === reloadPromise) {
+						this.#configReloadPromise = undefined;
+					}
+				});
+		}, 150);
+	}
+
+	async #readGlobalConfigForReload(): Promise<{ configPath: string; settings: RawSettings } | null> {
+		for (const filename of MAIN_CONFIG_FILENAMES) {
+			const configPath = path.join(this.#agentDir, filename);
+			const result = await this.#loadYamlIfPresent(configPath);
+			switch (result.kind) {
+				case "missing":
+					continue;
+				case "loaded":
+					return { configPath, settings: result.settings };
+				case "invalid":
+				case "unreadable":
+					logger.warn("Settings: ignored invalid live config update", {
+						path: configPath,
+						error: toError(result.error).message,
+					});
+					return null;
+			}
+		}
+		return {
+			configPath: path.join(this.#agentDir, MAIN_CONFIG_FILENAMES[0]),
+			settings: {},
+		};
+	}
+
+	/**
+	 * Reload the active global config from disk without quarantining malformed
+	 * edits. Returns false and preserves the last valid settings when the file
+	 * cannot be read or parsed.
+	 */
+	async reloadFromDisk(): Promise<boolean> {
+		let loaded = await this.#readGlobalConfigForReload();
+		if (!loaded || this.#savesCancelled) return false;
+
+		if (this.#saveTimer || this.#savePromise || this.#modified.size > 0 || this.#modifiedGlobalModelRoles.size > 0) {
+			await this.flush();
+			loaded = await this.#readGlobalConfigForReload();
+			if (!loaded || this.#savesCancelled) return false;
+		}
+
+		const previousHookValues = new Map<SettingPath, unknown>();
+		for (const key of Object.keys(SETTING_HOOKS) as SettingPath[]) {
+			previousHookValues.set(key, this.get(key));
+		}
+		const previousModelRoles = this.get("modelRoles");
+		const previousSessionAccent = this.get("statusLine.sessionAccent");
+
+		this.#configPath = loaded.configPath;
+		this.#global = loaded.settings;
+		this.#rebuildMerged();
+
+		for (const [key, previous] of previousHookValues) {
+			const next = this.get(key);
+			if (Bun.deepEquals(next, previous)) continue;
+			SETTING_HOOKS[key]?.(next, previous);
+		}
+		if (!Bun.deepEquals(this.get("modelRoles"), previousModelRoles)) {
+			modelRolesSignal.fire();
+		}
+		if (!Bun.deepEquals(this.get("statusLine.sessionAccent"), previousSessionAccent)) {
+			statusLineSessionAccentSignal.fire();
+		}
+		logger.debug("Settings: reloaded config", { path: this.#configPath });
+		return true;
 	}
 
 	/**

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -10,6 +10,7 @@ import {
 	getDefault,
 	getEnumValues,
 	onAppendOnlyModeChanged,
+	onModelRolesChanged,
 	onStatusLineSessionAccentChanged,
 	resetSettingsForTest,
 	type SettingPath,
@@ -125,6 +126,45 @@ describe("Settings", () => {
 			expect(await Bun.file(getConfigPath()).exists()).toBe(true);
 			expect(await Bun.file(yamlConfigPath).exists()).toBe(false);
 			expect((await readSettings()).setupVersion).toBe(1);
+		});
+	});
+
+	describe("live config reload", () => {
+		it("reloads model roles and keeps the last valid settings after a malformed update", async () => {
+			await writeSettings({
+				modelRoles: { luna: "github-copilot/gpt-5.6-luna:high" },
+			});
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const reloaded = Promise.withResolvers<void>();
+			let roleChanges = 0;
+			const unsubscribe = onModelRolesChanged(() => {
+				roleChanges++;
+				reloaded.resolve();
+			});
+
+			try {
+				await writeSettings({
+					modelRoles: {
+						luna: "openai-codex/gpt-5.6-luna:high",
+						kimi: "openrouter/moonshotai/kimi-k3:high",
+					},
+				});
+				await reloaded.promise;
+
+				expect(settings.getModelRole("luna")).toBe("openai-codex/gpt-5.6-luna:high");
+				expect(settings.getModelRole("kimi")).toBe("openrouter/moonshotai/kimi-k3:high");
+				expect(roleChanges).toBe(1);
+
+				await Bun.write(getConfigPath(), "modelRoles:\n  luna: [\n");
+				expect(await settings.reloadFromDisk()).toBe(false);
+
+				expect(settings.getModelRole("luna")).toBe("openai-codex/gpt-5.6-luna:high");
+				expect(settings.getModelRole("kimi")).toBe("openrouter/moonshotai/kimi-k3:high");
+				expect(roleChanges).toBe(1);
+				expect(fs.readdirSync(agentDir).some(name => name.startsWith("config.yml.broken-"))).toBe(false);
+			} finally {
+				unsubscribe();
+			}
 		});
 	});
 


### PR DESCRIPTION
Watch the active global config directory and debounce config.yml and config.yaml events. Apply valid replacements to the live Settings global layer and notify changed hooks and model-role listeners. Retain the last valid state for malformed or unreadable live edits without quarantining the file. Project settings and explicit overlays remain startup-loaded.

Add focused coverage for model-role reload, signal delivery, malformed-update retention, and backup absence. Update the configuration reference and Unreleased changelog.