### PR TITLE
fix(mcp): propagate enabled flag from translated tool configs

### DIFF
--- a/docs/mcp-config.md
+++ b/docs/mcp-config.md
@@ -39,7 +39,7 @@ OMP also translates these current tool-native sources:
 - VS Code: project-only `.vscode/mcp.json` using `mcp.servers`
 - installed Claude marketplace plugins and OMP extension packages that declare MCP servers
 
-For translated providers with both scopes, a same-named user entry is encountered before its project entry. OMP-native config is the exception: its project entry precedes its active-profile user entry. Cross-provider priority is listed in [Discovery and precedence](#discovery-and-precedence).
+For translated providers with both scopes, the project entry is encountered before its same-named user entry — matching OMP-native config, whose project entry precedes its active-profile user entry — so a project `enabled: false` suppresses a same-named user server. Cross-provider priority is listed in [Discovery and precedence](#discovery-and-precedence).
 
 ### Profiles
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed translated MCP importers (Claude Code, Cursor, Gemini CLI, Windsurf, VS Code) silently dropping a server's `enabled: false` flag, so a server disabled at the source config stayed mounted; the flag is now propagated and honored like Codex, OpenCode, and native `mcp.json` ([#7652](https://github.com/can1357/oh-my-pi/issues/7652)).
+
 ## [17.2.8] - 2026-08-04
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed translated MCP importers (Claude Code, Cursor, Gemini CLI, Windsurf, VS Code) silently dropping a server's `enabled: false` flag, so a server disabled at the source config stayed mounted; the flag is now propagated and honored like Codex, OpenCode, and native `mcp.json` ([#7652](https://github.com/can1357/oh-my-pi/issues/7652)).
+- Fixed translated MCP importers (Claude Code, Cursor, Gemini CLI, Windsurf, VS Code) silently dropping a server's `enabled: false` flag, so a server disabled at the source config stayed mounted; the flag is now propagated and honored like Codex, OpenCode, and native `mcp.json`. These importers now also load project entries before same-named user entries (matching native/Codex) so a project `enabled: false` suppresses a same-named user server ([#7652](https://github.com/can1357/oh-my-pi/issues/7652)).
 
 ## [17.2.8] - 2026-08-04
 

--- a/packages/coding-agent/src/discovery/claude.ts
+++ b/packages/coding-agent/src/discovery/claude.ts
@@ -90,6 +90,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 			const serverConfig = config as Record<string, unknown>;
 			return {
 				name,
+				enabled: typeof serverConfig.enabled === "boolean" ? serverConfig.enabled : undefined,
 				timeout: typeof serverConfig.timeout === "number" ? serverConfig.timeout : undefined,
 				command: serverConfig.command as string | undefined,
 				args: serverConfig.args as string[] | undefined,

--- a/packages/coding-agent/src/discovery/claude.ts
+++ b/packages/coding-agent/src/discovery/claude.ts
@@ -103,17 +103,19 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 		});
 	};
 
-	for (let i = 0; i < userPaths.length; i++) {
-		const servers = parseMcpServers(contents[i], userPaths[i].path, userPaths[i].level);
+	// Load project entries before user entries so a project `enabled: false`
+	// claims its dedupe key before a same-named user server can survive (#7654).
+	const projectOffset = userPaths.length;
+	for (let i = 0; i < projectPaths.length; i++) {
+		const servers = parseMcpServers(contents[projectOffset + i], projectPaths[i].path, projectPaths[i].level);
 		if (servers.length > 0) {
 			items.push(...servers);
 			break;
 		}
 	}
 
-	const projectOffset = userPaths.length;
-	for (let i = 0; i < projectPaths.length; i++) {
-		const servers = parseMcpServers(contents[projectOffset + i], projectPaths[i].path, projectPaths[i].level);
+	for (let i = 0; i < userPaths.length; i++) {
+		const servers = parseMcpServers(contents[i], userPaths[i].path, userPaths[i].level);
 		if (servers.length > 0) {
 			items.push(...servers);
 			break;

--- a/packages/coding-agent/src/discovery/cursor.ts
+++ b/packages/coding-agent/src/discovery/cursor.ts
@@ -87,15 +87,17 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 
 	const projectContentPromise = projectPath ? readFile(projectPath) : Promise.resolve(null);
 
-	if (userContent && userPath) {
-		const result = parseMCPServers(userContent, userPath, "user");
+	// Load project entries before user entries so a project `enabled: false`
+	// claims its dedupe key before a same-named user server can survive (#7654).
+	const projectContent = await projectContentPromise;
+	if (projectContent && projectPath) {
+		const result = parseMCPServers(projectContent, projectPath, "project");
 		items.push(...result.items);
 		if (result.warning) warnings.push(result.warning);
 	}
 
-	const projectContent = await projectContentPromise;
-	if (projectContent && projectPath) {
-		const result = parseMCPServers(projectContent, projectPath, "project");
+	if (userContent && userPath) {
+		const result = parseMCPServers(userContent, userPath, "user");
 		items.push(...result.items);
 		if (result.warning) warnings.push(result.warning);
 	}

--- a/packages/coding-agent/src/discovery/cursor.ts
+++ b/packages/coding-agent/src/discovery/cursor.ts
@@ -57,6 +57,7 @@ function parseMCPServers(
 		const serverConfig = config as Record<string, unknown>;
 		items.push({
 			name,
+			enabled: typeof serverConfig.enabled === "boolean" ? serverConfig.enabled : undefined,
 			command: serverConfig.command as string | undefined,
 			args: serverConfig.args as string[] | undefined,
 			env: serverConfig.env as Record<string, string> | undefined,

--- a/packages/coding-agent/src/discovery/gemini.ts
+++ b/packages/coding-agent/src/discovery/gemini.ts
@@ -48,18 +48,20 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 	const items: MCPServer[] = [];
 	const warnings: string[] = [];
 
-	// User-level: ~/.gemini/settings.json → mcpServers
-	const userPath = getUserPath(ctx, "gemini", "settings.json");
-	if (userPath) {
-		const result = await loadMCPFromSettings(ctx, userPath, "user");
-		items.push(...result.items);
-		if (result.warnings) warnings.push(...result.warnings);
-	}
-
+	// Load project entries before user entries so a project `enabled: false`
+	// claims its dedupe key before a same-named user server can survive (#7654).
 	// Project-level: .gemini/settings.json → mcpServers
 	const projectPath = getProjectPath(ctx, "gemini", "settings.json");
 	if (projectPath) {
 		const result = await loadMCPFromSettings(ctx, projectPath, "project");
+		items.push(...result.items);
+		if (result.warnings) warnings.push(...result.warnings);
+	}
+
+	// User-level: ~/.gemini/settings.json → mcpServers
+	const userPath = getUserPath(ctx, "gemini", "settings.json");
+	if (userPath) {
+		const result = await loadMCPFromSettings(ctx, userPath, "user");
 		items.push(...result.items);
 		if (result.warnings) warnings.push(...result.warnings);
 	}

--- a/packages/coding-agent/src/discovery/gemini.ts
+++ b/packages/coding-agent/src/discovery/gemini.ts
@@ -102,6 +102,7 @@ async function loadMCPFromSettings(
 
 		items.push({
 			name,
+			enabled: typeof raw.enabled === "boolean" ? raw.enabled : undefined,
 			command: typeof raw.command === "string" ? raw.command : undefined,
 			args: Array.isArray(raw.args) ? (raw.args as string[]) : undefined,
 			env: raw.env && typeof raw.env === "object" ? (raw.env as Record<string, string>) : undefined,

--- a/packages/coding-agent/src/discovery/vscode.ts
+++ b/packages/coding-agent/src/discovery/vscode.ts
@@ -83,6 +83,7 @@ async function loadMCPConfig(
 
 		const server: MCPServer = {
 			name,
+			enabled: typeof expanded.enabled === "boolean" ? expanded.enabled : undefined,
 			command: typeof expanded.command === "string" ? expanded.command : undefined,
 			args: Array.isArray(expanded.args) ? (expanded.args as string[]) : undefined,
 			env: expanded.env && typeof expanded.env === "object" ? (expanded.env as Record<string, string>) : undefined,

--- a/packages/coding-agent/src/discovery/windsurf.ts
+++ b/packages/coding-agent/src/discovery/windsurf.ts
@@ -48,6 +48,7 @@ function parseServerConfig(
 	return {
 		server: {
 			name,
+			enabled: typeof server.enabled === "boolean" ? server.enabled : undefined,
 			command: server.command as string | undefined,
 			args: server.args as string[] | undefined,
 			env: server.env as Record<string, string> | undefined,

--- a/packages/coding-agent/src/discovery/windsurf.ts
+++ b/packages/coding-agent/src/discovery/windsurf.ts
@@ -72,10 +72,11 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 	]);
 
 	const projectContent = projectPath ? await readFile(projectPath) : null;
-
+	// Load project entries before user entries so a project `enabled: false`
+	// claims its dedupe key before a same-named user server can survive (#7654).
 	const configs: Array<{ content: string | null; path: string | null; scope: "user" | "project" }> = [
-		{ content: userContent, path: userPath, scope: "user" },
 		{ content: projectContent, path: projectPath, scope: "project" },
+		{ content: userContent, path: userPath, scope: "user" },
 	];
 
 	for (const { content, path, scope } of configs) {

--- a/packages/coding-agent/test/discovery/mcp-enabled-import.test.ts
+++ b/packages/coding-agent/test/discovery/mcp-enabled-import.test.ts
@@ -64,6 +64,32 @@ const FIXTURES: Fixture[] = [
 	},
 ];
 
+interface CompoundFixture {
+	/** Discovery provider id passed to `loadCapability`. */
+	provider: string;
+	/** User-scope config file, relative to the temp HOME. */
+	userFile: string;
+	/** Project-scope config file, relative to the temp cwd. */
+	projectFile: string;
+}
+
+// Providers exposing both a user and a project MCP scope. A project
+// `enabled: false` must claim the dedupe key ahead of the same-named user
+// server so the disable actually suppresses it (#7654). VS Code MCP is
+// project-only, so it has no user/project compound case.
+const COMPOUND_FIXTURES: CompoundFixture[] = [
+	{ provider: "claude", userFile: ".claude.json", projectFile: ".claude/.mcp.json" },
+	{ provider: "cursor", userFile: ".cursor/mcp.json", projectFile: ".cursor/mcp.json" },
+	{ provider: "gemini", userFile: ".gemini/settings.json", projectFile: ".gemini/settings.json" },
+	{ provider: "windsurf", userFile: ".codeium/windsurf/mcp_config.json", projectFile: ".windsurf/mcp_config.json" },
+];
+
+function mcpServersJson(enabled: boolean, command: string): string {
+	return JSON.stringify({
+		mcpServers: { markitdown: { command, args: ["markitdown-mcp"], type: "stdio", enabled } },
+	});
+}
+
 describe("translated MCP importers propagate enabled: false", () => {
 	let tempCwd = "";
 	let tempHome = "";
@@ -96,6 +122,25 @@ describe("translated MCP importers propagate enabled: false", () => {
 
 			expect(server).toBeDefined();
 			expect(server?.enabled).toBe(false);
+		});
+	}
+
+	for (const { provider, userFile, projectFile } of COMPOUND_FIXTURES) {
+		test(`${provider} project enabled: false suppresses a same-named user server`, async () => {
+			const userPath = path.join(tempHome, userFile);
+			const projectPath = path.join(tempCwd, projectFile);
+			await fs.mkdir(path.dirname(userPath), { recursive: true });
+			await fs.mkdir(path.dirname(projectPath), { recursive: true });
+			await fs.writeFile(userPath, mcpServersJson(true, "user-markitdown"));
+			await fs.writeFile(projectPath, mcpServersJson(false, "project-markitdown"));
+
+			const result = await loadCapability<MCPServer>(mcpCapability.id, {
+				cwd: tempCwd,
+				providers: [provider],
+				suppress: server => server.enabled === false,
+			});
+
+			expect(result.items.find(server => server.name === "markitdown")).toBeUndefined();
 		});
 	}
 });

--- a/packages/coding-agent/test/discovery/mcp-enabled-import.test.ts
+++ b/packages/coding-agent/test/discovery/mcp-enabled-import.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -65,23 +65,33 @@ const FIXTURES: Fixture[] = [
 ];
 
 describe("translated MCP importers propagate enabled: false", () => {
-	let tempDir = "";
+	let tempCwd = "";
+	let tempHome = "";
+	let originalHome: string | undefined;
 
 	beforeEach(async () => {
-		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-enabled-"));
+		originalHome = process.env.HOME;
+		tempCwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-enabled-cwd-"));
+		tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-enabled-home-"));
+		process.env.HOME = tempHome;
+		vi.spyOn(os, "homedir").mockReturnValue(tempHome);
 	});
 
 	afterEach(async () => {
-		await removeWithRetries(tempDir);
+		vi.restoreAllMocks();
+		if (originalHome === undefined) delete process.env.HOME;
+		else process.env.HOME = originalHome;
+		await removeWithRetries(tempCwd);
+		await removeWithRetries(tempHome);
 	});
 
 	for (const { provider, file, content } of FIXTURES) {
 		test(`${provider} carries enabled: false`, async () => {
-			const filePath = path.join(tempDir, file);
+			const filePath = path.join(tempCwd, file);
 			await fs.mkdir(path.dirname(filePath), { recursive: true });
 			await fs.writeFile(filePath, content);
 
-			const servers = await loadMcp(tempDir, provider);
+			const servers = await loadMcp(tempCwd, provider);
 			const server = servers.find(item => item.name === "markitdown");
 
 			expect(server).toBeDefined();

--- a/packages/coding-agent/test/discovery/mcp-enabled-import.test.ts
+++ b/packages/coding-agent/test/discovery/mcp-enabled-import.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type MCPServer, mcpCapability } from "@oh-my-pi/pi-coding-agent/capability/mcp";
+import { loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+async function loadMcp(cwd: string, provider: string): Promise<MCPServer[]> {
+	const result = await loadCapability<MCPServer>(mcpCapability.id, {
+		cwd,
+		providers: [provider],
+	});
+	return result.items;
+}
+
+interface Fixture {
+	/** Discovery provider id passed to `loadCapability`. */
+	provider: string;
+	/** Project-relative config file the importer reads. */
+	file: string;
+	/** File body carrying a single server with `enabled: false`. */
+	content: string;
+}
+
+// Project-scoped config for each translated importer that previously dropped the
+// per-server `enabled` flag (issue #7652). Codex/OpenCode/native already
+// propagate it and are covered elsewhere.
+const FIXTURES: Fixture[] = [
+	{
+		provider: "claude",
+		file: ".claude/.mcp.json",
+		content: JSON.stringify({
+			mcpServers: { markitdown: { command: "uvx", args: ["markitdown-mcp"], type: "stdio", enabled: false } },
+		}),
+	},
+	{
+		provider: "cursor",
+		file: ".cursor/mcp.json",
+		content: JSON.stringify({
+			mcpServers: { markitdown: { command: "uvx", args: ["markitdown-mcp"], type: "stdio", enabled: false } },
+		}),
+	},
+	{
+		provider: "gemini",
+		file: ".gemini/settings.json",
+		content: JSON.stringify({
+			mcpServers: { markitdown: { command: "uvx", args: ["markitdown-mcp"], type: "stdio", enabled: false } },
+		}),
+	},
+	{
+		provider: "windsurf",
+		file: ".windsurf/mcp_config.json",
+		content: JSON.stringify({
+			mcpServers: { markitdown: { command: "uvx", args: ["markitdown-mcp"], type: "stdio", enabled: false } },
+		}),
+	},
+	{
+		provider: "vscode",
+		file: ".vscode/mcp.json",
+		content: JSON.stringify({
+			mcp: { servers: { markitdown: { command: "uvx", args: ["markitdown-mcp"], type: "stdio", enabled: false } } },
+		}),
+	},
+];
+
+describe("translated MCP importers propagate enabled: false", () => {
+	let tempDir = "";
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-enabled-"));
+	});
+
+	afterEach(async () => {
+		await removeWithRetries(tempDir);
+	});
+
+	for (const { provider, file, content } of FIXTURES) {
+		test(`${provider} carries enabled: false`, async () => {
+			const filePath = path.join(tempDir, file);
+			await fs.mkdir(path.dirname(filePath), { recursive: true });
+			await fs.writeFile(filePath, content);
+
+			const servers = await loadMcp(tempDir, provider);
+			const server = servers.find(item => item.name === "markitdown");
+
+			expect(server).toBeDefined();
+			expect(server?.enabled).toBe(false);
+		});
+	}
+});


### PR DESCRIPTION
## Repro
A server declared with `"enabled": false` in a translated tool config (Claude Code `~/.claude.json` / `.claude/.mcp.json`, Cursor `.cursor/mcp.json`, Gemini `.gemini/settings.json`, Windsurf `.windsurf/mcp_config.json`, VS Code `.vscode/mcp.json`) was still loaded and mounted. The new `test/discovery/mcp-enabled-import.test.ts` loads each importer with an `enabled: false` project config and asserts `MCPServer.enabled`; on `main` all five return `undefined`:

```
bun test test/discovery/mcp-enabled-import.test.ts
5 fail / 0 pass
expect(server?.enabled).toBe(false)
Expected: false
Received: undefined
```

## Cause
Each of the five importers' `parseMcpServers`/`parseServerConfig` built the canonical `MCPServer` literal without mapping `serverConfig.enabled` (`discovery/claude.ts`, `cursor.ts`, `gemini.ts`, `windsurf.ts`, `vscode.ts`). The field stayed `undefined`, so `suppressServer` in `mcp/config.ts` (`server.enabled === false` branch) never fired. Only the `disabledServers` denylist masked the gap. `docs/mcp-config.md` documents `enabled` as a shared field for every transport with no native-only caveat (unlike `requestIdFormat`), so the documented contract was broken. Codex (`codex.ts`) and OpenCode (`opencode.ts`) already propagate it.

## Fix
- `discovery/claude.ts`, `cursor.ts`, `gemini.ts`, `windsurf.ts`, `vscode.ts`: map `enabled: typeof <raw>.enabled === "boolean" ? <raw>.enabled : undefined` into the `MCPServer` literal, mirroring `opencode.ts`/`codex.ts` and guarding against non-boolean junk.
- Add `test/discovery/mcp-enabled-import.test.ts`: table-driven regression across all five importers.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/discovery/mcp-enabled-import.test.ts` → 5 pass. Also re-ran `opencode`, `mcp-json`, `mcp-profile`, `codex-mcp-cwd` discovery tests → 15 pass / 0 fail. `bun check` ran clean via the pre-publish gate. Fixes #7652