### PR TITLE
fix(natives): recover from tokio worker spawn panic

### DIFF
--- a/crates/pi-natives/src/crash_handler.rs
+++ b/crates/pi-natives/src/crash_handler.rs
@@ -57,13 +57,13 @@ static INSTALL: Once = Once::new();
 static ALLOC_HOOK_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 thread_local! {
-	/// Active `task::blocking` panic recovery frames on this thread.
+	/// Active recoverable panic frames on this thread.
 	///
 	/// The panic hook runs before [`std::panic::catch_unwind`] returns. A
 	/// borrow-free `Cell` lets the hook recognize panics that are already inside
 	/// a known recovery boundary without touching potentially borrowed task
 	/// state while the stack is unwinding.
-	static BLOCKING_TASK_PANIC_SCOPE_DEPTH: Cell<usize> = const { Cell::new(0) };
+	static RECOVERABLE_PANIC_SCOPE_DEPTH: Cell<usize> = const { Cell::new(0) };
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -71,9 +71,9 @@ enum PanicDisposition {
 	/// No recovery boundary is active: persist the report, echo it to stderr,
 	/// and chain to the default hook (which ends the process).
 	Fatal,
-	/// The panic will be caught and mapped to a failed command / rejected
-	/// Promise: persist the report to the crash log for diagnosis, but keep
-	/// stderr quiet and do not chain to the default hook.
+	/// The panic will be caught and mapped to a recoverable result or fallback:
+	/// persist the report to the crash log for diagnosis, but keep stderr quiet
+	/// and do not chain to the default hook.
 	LoggedRecoverable,
 }
 
@@ -109,34 +109,33 @@ pub fn install() {
 	});
 }
 
-/// Run `f` inside a `task::blocking` panic recovery boundary.
+/// Run `f` inside a panic recovery boundary.
 ///
-/// The global panic hook checks this thread-local scope before reporting a
-/// panic. When a blocking worker closure panics, [`std::panic::catch_unwind`]
-/// will turn it into a rejected JS Promise, so the hook downgrades the panic
-/// to [`PanicDisposition::LoggedRecoverable`]: the report (location +
-/// backtrace) is still persisted to the crash log, but nothing is echoed to
-/// stderr and the default hook is not chained.
-pub(crate) fn blocking_task_panic_scope<R>(f: impl FnOnce() -> R) -> R {
+/// Callers MUST wrap this scope in [`std::panic::catch_unwind`]. The scope
+/// tells the global panic hook that an unwind will be recovered, downgrading
+/// the report to [`PanicDisposition::LoggedRecoverable`]: the report is still
+/// persisted for diagnosis, but nothing is echoed to stderr and the default
+/// hook is not chained.
+pub(crate) fn recoverable_panic_scope<R>(f: impl FnOnce() -> R) -> R {
 	struct Guard;
 
 	impl Drop for Guard {
 		fn drop(&mut self) {
-			BLOCKING_TASK_PANIC_SCOPE_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+			RECOVERABLE_PANIC_SCOPE_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
 		}
 	}
 
-	BLOCKING_TASK_PANIC_SCOPE_DEPTH.with(|d| d.set(d.get() + 1));
+	RECOVERABLE_PANIC_SCOPE_DEPTH.with(|d| d.set(d.get() + 1));
 	let _guard = Guard;
 	f()
 }
 
-fn blocking_task_panic_scope_active() -> bool {
-	BLOCKING_TASK_PANIC_SCOPE_DEPTH.with(|d| d.get() > 0)
+fn recoverable_panic_scope_active() -> bool {
+	RECOVERABLE_PANIC_SCOPE_DEPTH.with(|d| d.get() > 0)
 }
 
 fn panic_disposition() -> PanicDisposition {
-	if blocking_task_panic_scope_active() || pi_uutils_ctx::is_active() {
+	if recoverable_panic_scope_active() || pi_uutils_ctx::is_active() {
 		PanicDisposition::LoggedRecoverable
 	} else {
 		PanicDisposition::Fatal
@@ -390,20 +389,20 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn blocking_task_panic_scope_downgrades_to_logged_recoverable() {
+	fn recoverable_panic_scope_downgrades_hook() {
 		assert_eq!(panic_disposition(), PanicDisposition::Fatal);
-		blocking_task_panic_scope(|| {
+		recoverable_panic_scope(|| {
 			assert_eq!(panic_disposition(), PanicDisposition::LoggedRecoverable);
 		});
 		assert_eq!(panic_disposition(), PanicDisposition::Fatal);
 	}
 
 	#[test]
-	fn blocking_task_panic_scope_restores_after_unwind() {
+	fn recoverable_panic_scope_restores_after_unwind() {
 		// Silence the process-global hook for the injected panic (and serialize
 		// the swap with every other hook-mutating test — see `crate::testing`).
 		let _silence = crate::testing::SilenceHook::new();
-		let unwound = std::panic::catch_unwind(|| blocking_task_panic_scope(|| panic!("boom")));
+		let unwound = std::panic::catch_unwind(|| recoverable_panic_scope(|| panic!("boom")));
 
 		assert!(unwound.is_err(), "panic propagated to catch_unwind");
 		assert_eq!(panic_disposition(), PanicDisposition::Fatal);

--- a/crates/pi-natives/src/lib.rs
+++ b/crates/pi-natives/src/lib.rs
@@ -62,6 +62,8 @@ pub(crate) mod utils;
 pub mod vectors;
 pub mod workspace;
 
+#[cfg(any(target_os = "windows", test))]
+use std::panic::{AssertUnwindSafe, catch_unwind};
 #[cfg(target_os = "windows")]
 use std::sync::{
 	Arc,
@@ -139,16 +141,16 @@ fn rayon_pool_plan(desired: usize, spawnable: usize) -> RayonPoolPlan {
 /// not even one extra thread is possible).
 ///
 /// `Builder::build()` for a multi-thread runtime spawns every worker eagerly
-/// and **panics** (not `Err`) when Windows refuses one — on a
-/// memory-constrained host (tiny pagefile / commit limit, `os error 1455`) that
-/// aborts the whole process at addon load before any JS error can surface — and
-/// a panic thrown that deep in runtime construction is not something we can
-/// usefully catch and recover from at module-init time. We instead pre-flight
-/// with `std::thread::Builder::spawn`, which returns an
-/// `io::Result`, holding each probe thread alive (so their stacks are committed
-/// concurrently, matching how real workers coexist) until we know the safe
-/// count. Probe threads use the std default stack, exactly like Tokio's workers
-/// (it leaves `thread_stack_size` unset), so the probe is representative.
+/// and **panics** (not `Err`) when Windows refuses one. On a memory-constrained
+/// host (tiny pagefile / commit limit, `os error 1455`), an uncaught panic
+/// aborts startup before any JS error can surface. Pre-flight with
+/// `std::thread::Builder::spawn`, which returns an `io::Result`, holding each
+/// probe thread alive so their stacks are committed concurrently, matching how
+/// real workers coexist. Probe threads use the std default stack, exactly like
+/// Tokio's workers (it leaves `thread_stack_size` unset).
+///
+/// Capacity can disappear after the probes join. The runtime builder therefore
+/// also catches Tokio's spawn panic and falls back to a current-thread runtime.
 ///
 /// Keep this Windows-only. On Linux, spawning probe threads from `module_init`
 /// can deadlock while Bun is loading the `.node`; napi-rs's default runtime
@@ -212,23 +214,21 @@ fn configure_rayon_pool() {
 }
 
 /// Build the custom Tokio runtime napi-rs uses on Windows, sized to what the
-/// host can actually spawn. Never panics: backs off from
-/// [`desired_worker_threads`] to whatever the probe allows, and falls back to a
-/// current-thread runtime (which spawns no workers at build time, so it can't
-/// abort under commit-limit pressure) when not even one worker is available.
-/// Returns `None` only if even that fails, in which case we leave napi-rs to
-/// construct its own default.
-#[cfg(target_os = "windows")]
-fn create_windows_napi_tokio_runtime() -> Option<tokio::runtime::Runtime> {
-	let workers = probe_spawnable_workers(desired_worker_threads());
+/// host can actually spawn. Falls back to a current-thread runtime (which
+/// spawns no workers at build time) when no worker is available, the
+/// multi-thread builder returns an error, or Tokio panics after a stale probe.
+#[cfg(any(target_os = "windows", test))]
+fn build_windows_napi_tokio_runtime(
+	workers: usize,
+	build_multi_thread: impl FnOnce(usize) -> std::io::Result<tokio::runtime::Runtime>,
+) -> Option<tokio::runtime::Runtime> {
 	let multi_thread = (workers > 0)
 		.then(|| {
-			tokio::runtime::Builder::new_multi_thread()
-				.worker_threads(workers)
-				.max_blocking_threads(NAPI_TOKIO_MAX_BLOCKING_THREADS)
-				.enable_all()
-				.build()
-				.ok()
+			catch_unwind(AssertUnwindSafe(|| {
+				crash_handler::recoverable_panic_scope(|| build_multi_thread(workers))
+			}))
+			.ok()
+			.and_then(Result::ok)
 		})
 		.flatten();
 	multi_thread.or_else(|| {
@@ -236,6 +236,18 @@ fn create_windows_napi_tokio_runtime() -> Option<tokio::runtime::Runtime> {
 			.enable_all()
 			.build()
 			.ok()
+	})
+}
+
+/// Probe Windows thread capacity before building the custom napi-rs runtime.
+#[cfg(target_os = "windows")]
+fn create_windows_napi_tokio_runtime() -> Option<tokio::runtime::Runtime> {
+	build_windows_napi_tokio_runtime(probe_spawnable_workers(desired_worker_threads()), |workers| {
+		tokio::runtime::Builder::new_multi_thread()
+			.worker_threads(workers)
+			.max_blocking_threads(NAPI_TOKIO_MAX_BLOCKING_THREADS)
+			.enable_all()
+			.build()
 	})
 }
 
@@ -296,8 +308,9 @@ static TOKIO_RUNTIME_INSTALLED: AtomicBool = AtomicBool::new(false);
 /// Without the Tokio override napi builds its own default (one worker per CPU,
 /// spawned eagerly), which aborts the process (`os error 1455`) on a
 /// memory-constrained Windows host before any JS error can surface;
-/// [`create_windows_napi_tokio_runtime`] pre-flights the spawn instead. Rayon
-/// has the same one-thread-per-core lazy default, so [`configure_rayon_pool`]
+/// [`create_windows_napi_tokio_runtime`] pre-flights the spawn and recovers
+/// from a stale probe by falling back to a current-thread runtime. Rayon has
+/// the same one-thread-per-core lazy default, so [`configure_rayon_pool`]
 /// installs a probed global pool before `count_tokens` or vendored `sort` can
 /// trigger it across a N-API nounwind boundary. If no worker thread is
 /// spawnable, patched Rayon callsites stay sequential rather than registering a
@@ -321,8 +334,10 @@ pub fn omp_install_tokio_runtime() {
 #[cfg(test)]
 mod tests {
 	use super::{
-		RAYON_MAX_THREADS, RayonPoolPlan, clamped_rayon_threads, rayon_pool_plan, rayon_probe_target,
+		RAYON_MAX_THREADS, RayonPoolPlan, build_windows_napi_tokio_runtime, clamped_rayon_threads,
+		rayon_pool_plan, rayon_probe_target,
 	};
+	use crate::testing::SilenceHook;
 
 	#[test]
 	fn rayon_threads_are_capped_for_windows_commit_pressure() {
@@ -359,5 +374,15 @@ mod tests {
 	fn rayon_skips_global_pool_when_only_reserved_capacity_can_spawn() {
 		assert_eq!(rayon_pool_plan(4, 1), RayonPoolPlan::SkipGlobalPool);
 		assert_eq!(rayon_pool_plan(1, 0), RayonPoolPlan::SkipGlobalPool);
+	}
+	#[test]
+	fn tokio_spawn_panic_uses_current_thread_runtime() {
+		let _silence = SilenceHook::new();
+		let runtime = build_windows_napi_tokio_runtime(1, |_| {
+			panic!("OS can't spawn worker thread: simulated commit pressure")
+		})
+		.expect("current-thread fallback");
+
+		assert_eq!(runtime.block_on(async { 42 }), 42);
 	}
 }

--- a/crates/pi-natives/src/task.rs
+++ b/crates/pi-natives/src/task.rs
@@ -186,7 +186,7 @@ where
 		// `GenericFailure`, so it downgrades the report to a disk-only crash
 		// log — no stderr dump, no default-hook chaining.
 		match catch_unwind(AssertUnwindSafe(move || {
-			crate::crash_handler::blocking_task_panic_scope(move || work(cancel_token))
+			crate::crash_handler::recoverable_panic_scope(move || work(cancel_token))
 		})) {
 			Ok(result) => result,
 			Err(payload) => {
@@ -228,7 +228,7 @@ where
 /// and leaks the allocation).
 fn dispose_panic_payload(payload: Box<dyn std::any::Any + Send>) {
 	if let Err(secondary) = catch_unwind(AssertUnwindSafe(|| {
-		crate::crash_handler::blocking_task_panic_scope(|| drop(payload));
+		crate::crash_handler::recoverable_panic_scope(|| drop(payload));
 	})) {
 		std::mem::forget(secondary);
 	}

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows startup aborts when Tokio refused a scheduler worker after the native capacity probe; runtime installation now recovers to a current-thread fallback ([#7653](https://github.com/can1357/oh-my-pi/issues/7653)).
+
 ## [17.2.7] - 2026-08-03
 
 ### Added


### PR DESCRIPTION
## Repro
With a positive Windows worker-capacity probe followed by a simulated Tokio scheduler spawn panic, `RUST_BACKTRACE=1 cargo test -p pi-natives tokio_spawn_panic_uses_current_thread_runtime -- --nocapture` exited 101 before the current-thread fallback ran.

## Cause
`probe_spawnable_workers()` joined every probe thread before `create_windows_napi_tokio_runtime()` called Tokio’s multi-thread builder. Windows commit capacity could disappear in that gap, and Tokio 1.53.1’s `Launch::launch()` panics when the blocking pool cannot create its first scheduler worker, so the existing `.build().ok()` path never reached the fallback.

## Fix
- Generalize the native crash-handler recovery scope so expected caught panics stay off stderr while retaining a disk diagnostic.
- Catch the Tokio multi-thread builder panic inside that recovery scope and build the current-thread runtime instead.
- Add a regression test that forces a successful probe result followed by a spawn panic, plus the native changelog entry.

## Verification
`cargo test -p pi-natives` passes all 196 tests, including the injected stale-probe regression; the branch publish gate also passed `bun run fix` and `bun check`. A direct `cargo check -p pi-natives --target x86_64-pc-windows-msvc` could not complete on this Linux host because C dependencies require the MSVC toolchain (`lib.exe`/Visual Studio); the changed fallback path is compiled and exercised under `cfg(test)`. Fixes #7653