### PR TITLE
fix(read): split semicolon-delimited internal URLs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Restored the legacy project-scoped session directory naming scheme and removed its automatic migration ([#7646](https://github.com/can1357/oh-my-pi/issues/7646)).
 
+### Fixed
+
+- Fixed `read` treating semicolon-delimited internal URLs, such as batched `skill://` resources, as one invalid resource.
+
 ## [17.2.8] - 2026-08-04
 
 ### Changed

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -810,14 +810,17 @@ export async function splitDelimitedPathEntry(
 ): Promise<string[] | null> {
 	const normalizedEntry = normalizePathLikeInput(entry);
 	if (!hasTopLevelPathDelimiter(normalizedEntry)) return null;
-	if (isInternalUrlPath(normalizedEntry)) return null;
+	// Internal URLs may contain whitespace; only the documented semicolon delimiter may fan them out.
+	const splitter = options.splitter ?? parseSearchPath;
+	if (isInternalUrlPath(normalizedEntry)) {
+		return tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none");
+	}
 	// A real POSIX file may contain the delimiter and a selector-shaped tail
 	// (`a;b:1-2`, `a b:1-2`). Preserve the raw entry whenever the full literal
 	// resolves — or is only ambiguous — so downstream literal-preferring
 	// splitters see it before delimiter expansion peels or splits (issue #4618
 	// reviewer feedback: delimited expansion ran before the literal check).
 	if ((await probeLiteralPathExists(normalizedEntry, cwd)) !== "missing") return null;
-	const splitter = options.splitter ?? parseSearchPath;
 	const peeledEntry = splitPathAndSel(normalizedEntry).path;
 	if (!hasGlobPathChars(peeledEntry) && (await delimitedPathPartResolves(normalizedEntry, cwd, splitter))) {
 		return null;

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -806,15 +806,19 @@ async function tryDelimitedPathSplit(
 export async function splitDelimitedPathEntry(
 	entry: string,
 	cwd: string,
-	options: { splitter?: PathEntrySplitter } = {},
+	options: {
+		splitter?: PathEntrySplitter;
+		routedUrlPredicate?: (entry: string) => boolean;
+	} = {},
 ): Promise<string[] | null> {
 	const normalizedEntry = normalizePathLikeInput(entry);
 	if (!hasTopLevelPathDelimiter(normalizedEntry)) return null;
-	// Internal URLs may contain whitespace; only the documented semicolon delimiter may fan them out.
 	const splitter = options.splitter ?? parseSearchPath;
-	if (isInternalUrlPath(normalizedEntry)) {
-		return tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none");
+	if (options.routedUrlPredicate?.(normalizedEntry)) {
+		const parts = await tryDelimitedPathSplit(normalizedEntry, cwd, splitter, "semicolon", "none");
+		return parts?.every(options.routedUrlPredicate) ? parts : null;
 	}
+	if (isInternalUrlPath(normalizedEntry)) return null;
 	// A real POSIX file may contain the delimiter and a selector-shaped tail
 	// (`a;b:1-2`, `a b:1-2`). Preserve the raw entry whenever the full literal
 	// resolves — or is only ambiguous — so downstream literal-preferring

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -101,6 +101,7 @@ import {
 	expandPath,
 	findUniqueWorkspaceSuffix,
 	formatPathRelativeToCwd,
+	isInternalUrlPath,
 	isReadableUrlPath,
 	type LineRange,
 	parseLineRanges,
@@ -2300,6 +2301,11 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			}
 			return executeReadUrl(this.session, { path: parsedUrlTarget.path, raw: urlRaw }, signal);
 		}
+
+		const delimitedInternalResult = isInternalUrlPath(readPath)
+			? await this.#tryReadDelimitedPaths(readPath, signal)
+			: null;
+		if (delimitedInternalResult) return delimitedInternalResult;
 
 		// Handle native OMP URLs and custom-scheme resources advertised by MCP servers.
 		// Use the internal-URL-aware splitter so malformed selectors are peeled

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -101,7 +101,6 @@ import {
 	expandPath,
 	findUniqueWorkspaceSuffix,
 	formatPathRelativeToCwd,
-	isInternalUrlPath,
 	isReadableUrlPath,
 	type LineRange,
 	parseLineRanges,
@@ -961,8 +960,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	async #tryReadDelimitedPaths(
 		readPath: string,
 		signal?: AbortSignal,
+		routedUrlPredicate?: (entry: string) => boolean,
 	): Promise<AgentToolResult<ReadToolDetails> | null> {
-		const parts = await splitDelimitedPathEntry(readPath, this.session.cwd);
+		const parts = await splitDelimitedPathEntry(readPath, this.session.cwd, { routedUrlPredicate });
 		if (!parts) return null;
 
 		const notice = `Note: interpreted as ${parts.length} paths: ${parts.join(", ")}`;
@@ -2302,15 +2302,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			return executeReadUrl(this.session, { path: parsedUrlTarget.path, raw: urlRaw }, signal);
 		}
 
-		const delimitedInternalResult = isInternalUrlPath(readPath)
-			? await this.#tryReadDelimitedPaths(readPath, signal)
+		// Handle native OMP URLs and custom-scheme resources advertised by MCP servers.
+		const internalRouter = InternalUrlRouter.instance();
+		const delimitedInternalResult = internalRouter.canResolve(readPath)
+			? await this.#tryReadDelimitedPaths(readPath, signal, entry => internalRouter.canResolve(entry))
 			: null;
 		if (delimitedInternalResult) return delimitedInternalResult;
 
-		// Handle native OMP URLs and custom-scheme resources advertised by MCP servers.
-		// Use the internal-URL-aware splitter so malformed selectors are peeled
-		// off the URL and surfaced via parseSel rather than confusing handlers.
-		const internalRouter = InternalUrlRouter.instance();
+		// Peel malformed selectors through the internal-URL-aware parser before routing.
 		let promotedSelector: string | undefined;
 		if (internalRouter.canResolve(readPath)) {
 			const internalTarget = splitInternalUrlSel(readPath);

--- a/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/mcp-protocol.test.ts
@@ -106,6 +106,31 @@ describe("McpProtocolHandler", () => {
 		expect(resource.notes).toEqual(["MCP server: my-server"]);
 	});
 
+	it("preserves a literal semicolon in an exact MCP resource URI", async () => {
+		const uri = "catalog://items;active";
+		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
+		resources.set("catalog", {
+			resources: [{ uri, name: "active-items" }],
+			templates: [],
+		});
+		const manager = createMockManager({
+			servers: ["catalog"],
+			resources,
+			readResult: { contents: [{ uri, text: "active items" }] },
+		});
+		MCPManager.setInstance(manager);
+
+		const result = await new ReadTool(createToolSession()).execute("read-semicolon-resource", {
+			path: `mcp://${uri}`,
+		});
+		const output = result.content.find(block => block.type === "text");
+
+		expect(output?.type).toBe("text");
+		if (output?.type !== "text") throw new Error("Expected text output");
+		expect(output.text).toContain("active items");
+		expect(output.text).not.toContain("interpreted as");
+	});
+
 	it("lets read consume a native URI advertised by an MCP server", async () => {
 		const resources = new Map<string, { resources: MCPResource[]; templates: MCPResourceTemplate[] }>();
 		resources.set("ags", {

--- a/packages/coding-agent/test/skill-protocol-customdirs.test.ts
+++ b/packages/coding-agent/test/skill-protocol-customdirs.test.ts
@@ -51,7 +51,7 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 		expect(resource.content).toContain(`from ${tempDir}`);
 	});
 
-	it("reads a semicolon-delimited list of skill URLs", async () => {
+	it("reads semicolon-delimited lists across routed URL schemes", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-delimited-skills-"));
 		tempDirs.push(tempDir);
 		for (const name of ["first-skill", "second-skill"]) {
@@ -80,6 +80,18 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 		expect(text).toContain("Note: interpreted as 2 paths: skill://first-skill:1-3, skill://second-skill:1-3");
 		expect(text).toContain("first-skill skill.");
 		expect(text).toContain("second-skill skill.");
+
+		const historyResult = await new ReadTool(session).execute("read-delimited-history", {
+			path: "history://missing-first:1-3; history://missing-second:1-3",
+		});
+		const historyText = historyResult.content
+			.flatMap(block => (block.type === "text" ? [block.text] : []))
+			.join("\n");
+		expect(historyText).toContain(
+			"Note: interpreted as 2 paths: history://missing-first:1-3, history://missing-second:1-3",
+		);
+		expect(historyText).toContain("Could not read history://missing-first:1-3");
+		expect(historyText).toContain("Could not read history://missing-second:1-3");
 	});
 
 	it("keeps first-wins across multiple custom directories", async () => {

--- a/packages/coding-agent/test/skill-protocol-customdirs.test.ts
+++ b/packages/coding-agent/test/skill-protocol-customdirs.test.ts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { loadSkills, resetActiveSkillsForTests, setActiveSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import { parseInternalUrl } from "@oh-my-pi/pi-coding-agent/internal-urls/parse";
 import { SkillProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/skill-protocol";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 
 function makeSkillMd(name: string, dir: string) {
 	return `---\nname: ${name}\ndescription: ${name} skill.\n---\n\n# ${name} from ${dir}\n`;
@@ -46,6 +49,37 @@ describe("skill:// resolution honors skills.customDirectories (#7190)", () => {
 		const resource = await handler.resolve(parseInternalUrl("skill://my-custom-skill/"));
 		expect(resource.sourcePath).toBe(path.join(skillDir, "SKILL.md"));
 		expect(resource.content).toContain(`from ${tempDir}`);
+	});
+
+	it("reads a semicolon-delimited list of skill URLs", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-delimited-skills-"));
+		tempDirs.push(tempDir);
+		for (const name of ["first-skill", "second-skill"]) {
+			const skillDir = path.join(tempDir, name);
+			await fs.mkdir(skillDir, { recursive: true });
+			await Bun.write(path.join(skillDir, "SKILL.md"), makeSkillMd(name, tempDir));
+		}
+
+		const { skills } = await loadSkills({
+			...ALL_DEFAULT_SOURCES_DISABLED,
+			customDirectories: [tempDir],
+		});
+		setActiveSkills(skills);
+		const session: ToolSession = {
+			cwd: tempDir,
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated(),
+		};
+		const result = await new ReadTool(session).execute("read-delimited-skills", {
+			path: "skill://first-skill:1-3; skill://second-skill:1-3",
+		});
+		const text = result.content.flatMap(block => (block.type === "text" ? [block.text] : [])).join("\n");
+
+		expect(text).toContain("Note: interpreted as 2 paths: skill://first-skill:1-3, skill://second-skill:1-3");
+		expect(text).toContain("first-skill skill.");
+		expect(text).toContain("second-skill skill.");
 	});
 
 	it("keeps first-wins across multiple custom directories", async () => {


### PR DESCRIPTION
## What

Make `read` split semicolon-delimited routed URLs only when every segment is independently resolvable by the internal URL router. Preserve literal semicolons in exact resources such as MCP URIs. Add coverage for `skill://`, `history://`, and opaque MCP resources, and document the fix.

## Why

I reviewed the diff; this fixes batched skill reads by splitting semicolon-delimited internal URLs before protocol resolution.

Previously, the entire input was sent to the first skill resolver, producing an unknown skill such as `semantic-compression:1-3; skill:`. The initial fix was too narrow for registered schemes such as `history://` and could split literal semicolons in exact MCP or SSH resources; router-based validation now handles both cases.

## Testing

- `bun test packages/coding-agent/test/tools/glob-validate-paths.test.ts packages/coding-agent/test/skill-protocol-customdirs.test.ts packages/coding-agent/test/internal-urls/mcp-protocol.test.ts` — 38 passed, 0 failed.
- `bun --cwd=packages/coding-agent run check` — passed; root Biome passed.
- Exercised ranged batched `skill://` and `history://` reads and an exact MCP resource URI containing a literal semicolon.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)