### PR TITLE
feat(tui): optional Vim-style editing mode for the prompt

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -86,8 +86,22 @@ The prompt then starts in Insert mode and behaves exactly as it always has. `Esc
 | `x` `D` `C`                   | Delete character, delete to line end, change to line end       |
 | `d` `y` `c` + motion          | Operate over a motion, e.g. `dw`, `d$`, `yb`, `cw`             |
 | `dd` `yy` `cc`                | Linewise delete / yank / change                                |
+| `d` `y` `c` + text object     | Operate over a text object, e.g. `diw`, `ca(`, `ci"`, `dap`    |
 | `p` `P`                       | Put the last yank or delete after / before the cursor          |
 | `u`                           | Undo                                                            |
+
+### Text objects
+
+A text object follows an operator (`diw`) or extends a Visual selection (`viw`). `i` takes the inside, `a` takes the surroundings; counts apply, e.g. `d2aw`.
+
+| Object            | Covers                                                                     |
+| ----------------- | -------------------------------------------------------------------------- |
+| `iw` `aw`         | Word; `aw` also takes the adjoining whitespace                             |
+| `iW` `aW`         | Whitespace-delimited WORD                                                  |
+| `i"` `i'` `` i` `` | Inside the quotes on the current line (`a"` takes the quotes too)          |
+| `i(` `i[` `i{` `i<` | Inside the innermost matching pair, nesting-aware and across lines         |
+| `a(` `a[` `a{` `a<` | The same pair including its delimiters (`b` and `B` alias `(` and `{`)     |
+| `ip` `ap`         | Paragraph — the run of non-blank (or blank) lines, linewise                |
 
 ### Visual mode
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -54,3 +54,53 @@ On Windows Terminal, `Ctrl+V` may be handled by the terminal paste command befor
 Terminals that implement OSC 5522 enhanced paste can send clipboard MIME data directly to `omp`; image pastes are attached as `[Image #N]`, while text/plain paste events keep normal paste behavior. When OSC 5522 is unavailable, bracketed paste still handles text, and a pasted single image-file path is loaded as an image when the file is readable from the `omp` host.
 
 Older unqualified action names are migrated when `keybindings.yml` is loaded, but new docs and new configs should use the namespaced action IDs above. Existing `keybindings.json` files are still accepted and migrated to `keybindings.yml`; `keybindings.yaml` is also accepted.
+
+## Vim editing mode
+
+Off by default. Turn it on with **Vim Editing Mode** in `/settings` (Interaction → Input), or set it directly:
+
+```yaml
+tui.vimMode: true
+```
+
+The prompt then starts in Insert mode and behaves exactly as it always has. `Escape` switches to Normal mode; the prompt border changes color so the current mode is visible at a glance. This is a useful subset of Vim, not a full implementation — enough for keyboard-only navigation and selection without adding more `Ctrl` chords that terminals, shells, and tmux already claim.
+
+| Mode        | Enter with              | Leave with                                              |
+| ----------- | ----------------------- | ------------------------------------------------------- |
+| Insert      | `i` `a` `I` `A` `o` `O` | `Escape`                                                |
+| Normal      | `Escape` from Insert    | any Insert-mode key                                     |
+| Visual      | `v`                     | `Escape`, or an operator (`y` `d` `c`)                  |
+| Visual line | `V`                     | `Escape`, or an operator (`y` `d` `c`)                  |
+
+### Normal mode
+
+| Keys                          | Meaning                                                        |
+| ----------------------------- | -------------------------------------------------------------- |
+| `h` `j` `k` `l`               | Move by character and line (arrow keys work too)               |
+| `0` `^` `$`                   | Line start / first non-blank / line end                        |
+| `w` `b` `e`                   | Next word, previous word, end of word                          |
+| `gg` `G`                      | First line, last line (`5gg` and `5G` jump to line 5)          |
+| `1`–`9` prefix                | Repeat a motion or operator, e.g. `3w`, `5j`, `2dd`            |
+| `i` `a` `I` `A`               | Insert before / after cursor, at line start / line end         |
+| `o` `O`                       | Open a line below / above and insert                           |
+| `x` `D` `C`                   | Delete character, delete to line end, change to line end       |
+| `d` `y` `c` + motion          | Operate over a motion, e.g. `dw`, `d$`, `yb`, `cw`             |
+| `dd` `yy` `cc`                | Linewise delete / yank / change                                |
+| `p` `P`                       | Put the last yank or delete after / before the cursor          |
+| `u`                           | Undo                                                            |
+
+### Visual mode
+
+`v` starts a character-wise selection and `V` a line-wise one; motions move the free end. `y` copies the selection to the system clipboard (and to the internal register, so `p` puts it back), `d` deletes it, and `c` deletes it and drops into Insert mode. `o` jumps to the other end of the selection. `Escape` cancels.
+
+A selection that would cut through an attachment placeholder such as `[Image #1, 800x600]` or `[Paste #2, +30 lines]` takes the whole placeholder with it, so a delete can never leave a corrupt fragment behind.
+
+### Escape
+
+`Escape` is shared with the app-level interrupt, so Vim mode takes it only when it has something to do:
+
+- **Insert mode** → switch to Normal mode.
+- **Visual mode**, or a half-typed count or operator → cancel back to a quiet Normal mode.
+- **Normal mode with nothing pending** → falls through to its usual meaning (dismiss autocomplete, abort the running turn, clear the draft).
+
+Vim keys never shadow app chords: `Ctrl`-combinations, `Enter`, and `Tab` keep their normal behavior in every mode, so `Enter` still submits from Normal mode. Prompt history stays on `Up`/`Down` in Insert mode only — in Normal mode those keys are `k` and `j`, so navigating a multi-line draft never loads a previous prompt.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -63,7 +63,7 @@ Off by default. Turn it on with **Vim Editing Mode** in `/settings` (Interaction
 tui.vimMode: true
 ```
 
-The prompt then starts in Insert mode and behaves exactly as it always has. `Escape` switches to Normal mode; the prompt border changes color so the current mode is visible at a glance. This is a useful subset of Vim, not a full implementation — enough for keyboard-only navigation and selection without adding more `Ctrl` chords that terminals, shells, and tmux already claim.
+The prompt then starts in Insert mode and behaves exactly as it always has. `Escape` switches to Normal mode; the prompt border changes color so the current mode is visible at a glance. While Vim mode is on, Insert draws a bar cursor and Normal/Visual a block — the software cursor always, the real terminal cursor via DECSCUSR under `PI_HARDWARE_CURSOR` — overriding the terminal's configured shape until the session restores it on exit. This is a useful subset of Vim, not a full implementation — enough for keyboard-only navigation and selection without adding more `Ctrl` chords that terminals, shells, and tmux already claim.
 
 | Mode        | Enter with              | Leave with                                              |
 | ----------- | ----------------------- | ------------------------------------------------------- |
@@ -83,7 +83,7 @@ The prompt then starts in Insert mode and behaves exactly as it always has. `Esc
 | `1`–`9` prefix                | Repeat a motion or operator, e.g. `3w`, `5j`, `2dd`            |
 | `i` `a` `I` `A`               | Insert before / after cursor, at line start / line end         |
 | `o` `O`                       | Open a line below / above and insert                           |
-| `x` `D` `C`                   | Delete character, delete to line end, change to line end       |
+| `x` `D` `C`                   | Delete character, delete to line end (`2D` takes `count` lines), change to line end (`2C` likewise) |
 | `d` `y` `c` + motion          | Operate over a motion, e.g. `dw`, `d$`, `yb`, `cw`             |
 | `dd` `yy` `cc`                | Linewise delete / yank / change                                |
 | `d` `y` `c` + text object     | Operate over a text object, e.g. `diw`, `ca(`, `ci"`, `dap`    |
@@ -105,7 +105,7 @@ A text object follows an operator (`diw`) or extends a Visual selection (`viw`).
 
 ### Visual mode
 
-`v` starts a character-wise selection and `V` a line-wise one; motions move the free end. `y` copies the selection to the system clipboard (and to the internal register, so `p` puts it back), `d` deletes it, and `c` deletes it and drops into Insert mode. `o` jumps to the other end of the selection. `Escape` cancels.
+`v` starts a character-wise selection and `V` a line-wise one; motions move the free end. `y` copies the selection to the system clipboard (and to the internal register, so `p` puts it back), `d` deletes it, and `c` deletes it and drops into Insert mode. `x` deletes like `d`, and `s` changes like `c`. `o` jumps to the other end of the selection. `Escape` cancels.
 
 A selection that would cut through an attachment placeholder such as `[Image #1, 800x600]` or `[Paste #2, +30 lines]` takes the whole placeholder with it, so a delete can never leave a corrupt fragment behind.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `tui.vimMode`, an opt-in modal editing layer for the prompt, off by default ([#3299](https://github.com/can1357/oh-my-pi/issues/3299)). Escape leaves Insert; Normal mode has `hjkl`, `0`, `^`, `$`, `w`, `b`, `e`, `gg`, `G`, count prefixes, `x`/`D`/`C`, `dd`/`yy`, `p`/`P` and `u`; `v`/`V` start a Visual selection that `y` copies and `d` deletes.
+- Added a `vim` status-line segment showing the current Vim mode (`NORMAL`/`INSERT`/`VISUAL`/`V-LINE`), the half-typed command beside it (Vim's `showcmd`, e.g. `2d`), and the Visual selection height (`V-LINE 4L`). Included in every built-in preset and hidden entirely unless `tui.vimMode` is on; `custom` preset users can add `"vim"` to `statusLine.leftSegments`.
+- The cursor now changes shape with the Vim mode: block in Normal/Visual, thin/underline in Insert. Applies to the software cursor, and to the real terminal cursor (DECSCUSR) when `PI_HARDWARE_CURSOR` is set.
+- Added the `tui.vimModeDisplay` setting (`text` / `icon` / `none`) controlling how the Vim mode appears in the status line: the full mode name, a single glyph per mode, or nothing. Shown in `/settings` only while Vim mode is on.
+- Added `icon.vimNormal`, `icon.vimInsert`, `icon.vimVisual`, and `icon.vimVisualLine` symbols, so the Vim mode icons follow the active symbol preset like every other status-line icon — Nerd Font (fa-square / fa-pencil / fa-eye / fa-bars), Unicode (`■` `▎` `◉` `≡`), or ascii (`N`/`I`/`V`/`L`) — and can be overridden per theme via the `symbols` map.
+
+### Changed
+
+- Toggling `tui.vimMode` or `tui.vimModeDisplay` in `/settings` now takes effect immediately instead of requiring a restart; the editor, prompt border, status-line segment, and cursor shape all switch in place.
+- The prompt border now colors Insert mode too (green), instead of falling through to the session accent. Normal and Visual were already colored, so Insert was the one mode the border could not distinguish — on themes whose accent matches the session accent it was indistinguishable from Normal. Borders outside Vim mode are unchanged.
+
 ## [18.0.5] - 2026-08-25
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `tui.vimMode`, an opt-in modal editing layer for the prompt, off by default ([#3299](https://github.com/can1357/oh-my-pi/issues/3299)). Escape leaves Insert; Normal mode has `hjkl`, `0`, `^`, `$`, `w`, `b`, `e`, `gg`, `G`, count prefixes, `x`/`D`/`C`, `dd`/`yy`, `p`/`P` and `u`; `v`/`V` start a Visual selection that `y` copies and `d` deletes.
+- Added a `vim` status-line segment showing the current Vim mode (`NORMAL`/`INSERT`/`VISUAL`/`V-LINE`), the half-typed command beside it (Vim's `showcmd`, e.g. `2d`), and the Visual selection height (`V-LINE 4L`). Included in every built-in preset and hidden entirely unless `tui.vimMode` is on; `custom` preset users can add `"vim"` to `statusLine.leftSegments`.
+- The cursor now changes shape with the Vim mode: block in Normal/Visual, thin/underline in Insert. Applies to the software cursor, and to the real terminal cursor (DECSCUSR) when `PI_HARDWARE_CURSOR` is set.
+- Added the `tui.vimModeDisplay` setting (`text` / `icon` / `none`) controlling how the Vim mode appears in the status line: the full mode name, a single glyph per mode, or nothing. Shown in `/settings` only while Vim mode is on.
+- Added `icon.vimNormal`, `icon.vimInsert`, `icon.vimVisual`, and `icon.vimVisualLine` symbols, so the Vim mode icons follow the active symbol preset like every other status-line icon — Nerd Font (fa-square / fa-pencil / fa-eye / fa-bars), Unicode (`■` `▎` `◉` `≡`), or ascii (`N`/`I`/`V`/`L`) — and can be overridden per theme via the `symbols` map.
+
+### Changed
+
+- Toggling `tui.vimMode` or `tui.vimModeDisplay` in `/settings` now takes effect immediately instead of requiring a restart; the editor, prompt border, status-line segment, and cursor shape all switch in place.
+- The prompt border now colors Insert mode too (green), instead of falling through to the session accent. Normal and Visual were already colored, so Insert was the one mode the border could not distinguish — on themes whose accent matches the session accent it was indistinguishable from Normal. Borders outside Vim mode are unchanged.
+
 ## [18.1.16] - 2026-09-09
 
 ### Added

--- a/packages/coding-agent/src/cli/gallery-fixtures/segments.ts
+++ b/packages/coding-agent/src/cli/gallery-fixtures/segments.ts
@@ -46,6 +46,7 @@ export function createGallerySegmentContext(sessionOptions?: GallerySessionOptio
 		loopMode: null,
 		goalMode: null,
 		vibeMode: null,
+		vim: null,
 		collab: { role: "host", participantCount: 3 },
 		usageStats: {
 			input: 12_400,
@@ -237,6 +238,25 @@ function variantsFor(id: StatusLineSegmentId): readonly SegmentVariantSpec[] {
 			return [
 				{ label: "host active", context: { collab: { role: "host", participantCount: 3 } } },
 				{ label: "guest active", context: { collab: { role: "guest", participantCount: 3 } } },
+			];
+		case "vim":
+			return [
+				{
+					label: "normal",
+					context: { vim: { mode: "normal", pending: "", selectedLines: 0, display: "text" } },
+				},
+				{
+					label: "insert",
+					context: { vim: { mode: "insert", pending: "", selectedLines: 0, display: "text" } },
+				},
+				{
+					label: "visual with count",
+					context: { vim: { mode: "visual-line", pending: "2d", selectedLines: 4, display: "text" } },
+				},
+				{
+					label: "icon mode",
+					context: { vim: { mode: "normal", pending: "", selectedLines: 0, display: "icon" } },
+				},
 			];
 		default:
 			return [{ label: "canonical" }];

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -255,7 +255,8 @@ export type StatusLineSegmentId =
 	| "cache_hit"
 	| "session_name"
 	| "usage"
-	| "collab";
+	| "collab"
+	| "vim";
 
 /** Submenu choice metadata. */
 export type SubmenuOption<V extends string = string> = {
@@ -1957,6 +1958,24 @@ export const SETTINGS_SCHEMA = {
 			label: "Vim Editing Mode",
 			description:
 				"Modal prompt editing. Escape leaves Insert mode; Normal mode has hjkl, 0, $, ^, w, b, e, gg, G, counts, x/D/C, dd/yy, p and u; v/V start a Visual selection that y copies and d deletes",
+		},
+	},
+
+	"tui.vimModeDisplay": {
+		type: "enum",
+		values: ["text", "icon", "none"] as const,
+		default: "text",
+		ui: {
+			tab: "interaction",
+			group: "Input",
+			label: "Vim Mode Indicator",
+			description: "How the current Vim mode appears in the status line",
+			condition: "vimModeEnabled",
+			options: [
+				{ value: "text", label: "Text", description: "Full mode name — NORMAL, INSERT, VISUAL, V-LINE" },
+				{ value: "icon", label: "Icon", description: "Single compact glyph per mode" },
+				{ value: "none", label: "Hidden", description: "Do not show the mode in the status line" },
+			],
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1948,6 +1948,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"tui.vimMode": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			group: "Input",
+			label: "Vim Editing Mode",
+			description:
+				"Modal prompt editing. Escape leaves Insert mode; Normal mode has hjkl, 0, $, ^, w, b, e, gg, G, counts, x/D/C, dd/yy, p and u; v/V start a Visual selection that y copies and d deletes",
+		},
+	},
+
 	"loop.mode": {
 		type: "enum",
 		values: ["prompt", "compact", "reset"] as const,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1957,7 +1957,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Input",
 			label: "Vim Editing Mode",
 			description:
-				"Modal prompt editing. Escape leaves Insert mode; Normal mode has hjkl, 0, $, ^, w, b, e, gg, G, counts, x/D/C, dd/yy, p and u; v/V start a Visual selection that y copies and d deletes",
+				"Modal prompt editing. Escape leaves Insert mode; Normal mode has hjkl, 0, $, ^, w, b, e, gg, G, counts, x/D/C, dd/yy, p and u; operators take motions or text objects (diw, ca(, dap); v/V start a Visual selection that y copies and d deletes",
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2030,7 +2030,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Input",
 			label: "Vim Editing Mode",
 			description:
-				"Modal prompt editing. Escape leaves Insert mode; Normal mode has hjkl, 0, $, ^, w, b, e, gg, G, counts, x/D/C, dd/yy, p and u; v/V start a Visual selection that y copies and d deletes",
+				"Modal prompt editing. Escape leaves Insert mode; Normal mode has hjkl, 0, $, ^, w, b, e, gg, G, counts, x/D/C, dd/yy, p and u; operators take motions or text objects (diw, ca(, dap); v/V start a Visual selection that y copies and d deletes",
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2021,6 +2021,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"tui.vimMode": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			group: "Input",
+			label: "Vim Editing Mode",
+			description:
+				"Modal prompt editing. Escape leaves Insert mode; Normal mode has hjkl, 0, $, ^, w, b, e, gg, G, counts, x/D/C, dd/yy, p and u; v/V start a Visual selection that y copies and d deletes",
+		},
+	},
+
 	"loop.mode": {
 		type: "enum",
 		values: ["prompt", "compact", "reset"] as const,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -262,7 +262,8 @@ export type StatusLineSegmentId =
 	| "cache_hit"
 	| "session_name"
 	| "usage"
-	| "collab";
+	| "collab"
+	| "vim";
 
 /** Submenu choice metadata. */
 export type SubmenuOption<V extends string = string> = {
@@ -2030,6 +2031,24 @@ export const SETTINGS_SCHEMA = {
 			label: "Vim Editing Mode",
 			description:
 				"Modal prompt editing. Escape leaves Insert mode; Normal mode has hjkl, 0, $, ^, w, b, e, gg, G, counts, x/D/C, dd/yy, p and u; v/V start a Visual selection that y copies and d deletes",
+		},
+	},
+
+	"tui.vimModeDisplay": {
+		type: "enum",
+		values: ["text", "icon", "none"] as const,
+		default: "text",
+		ui: {
+			tab: "interaction",
+			group: "Input",
+			label: "Vim Mode Indicator",
+			description: "How the current Vim mode appears in the status line",
+			condition: "vimModeEnabled",
+			options: [
+				{ value: "text", label: "Text", description: "Full mode name — NORMAL, INSERT, VISUAL, V-LINE" },
+				{ value: "icon", label: "Icon", description: "Single compact glyph per mode" },
+				{ value: "none", label: "Hidden", description: "Do not show the mode in the status line" },
+			],
 		},
 	},
 

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -812,6 +812,9 @@ export class CustomEditor extends Editor {
 	}
 
 	#spaceHoldGestureEnabled(): boolean {
+		// Push-to-talk is a text-composition gesture, so it stays out of Vim's Normal/Visual modes
+		// where the space bar is the `l` motion.
+		if (this.vimMode !== "insert") return false;
 		return this.onSpaceHoldStart !== undefined && (this.sttHoldEnabled?.() ?? false) && !this.isShowingAutocomplete();
 	}
 
@@ -1079,7 +1082,15 @@ export class CustomEditor extends Editor {
 			// handler. This matches the standard TUI/IDE pattern and prevents a
 			// single ESC from both closing an @ completion and aborting an active
 			// agent run (#1655).
-			if (this.#matchesAction(canonical, "app.interrupt") && this.onEscape && !this.isShowingAutocomplete()) {
+			// Vim mode claims Escape ahead of the interrupt: it has to mean "leave Insert mode" and
+			// "cancel a half-typed operator" first. Only a quiet Normal mode gives it back here, so
+			// the familiar single-ESC-to-abort still works once the user is out of Insert mode.
+			if (
+				this.#matchesAction(canonical, "app.interrupt") &&
+				this.onEscape &&
+				!this.isShowingAutocomplete() &&
+				!this.vimConsumesEscape()
+			) {
 				this.onEscape();
 				return;
 			}

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -830,6 +830,9 @@ export class CustomEditor extends Editor {
 	}
 
 	#spaceHoldGestureEnabled(): boolean {
+		// Push-to-talk is a text-composition gesture, so it stays out of Vim's Normal/Visual modes
+		// where the space bar is the `l` motion.
+		if (this.vimMode !== "insert") return false;
 		return this.onSpaceHoldStart !== undefined && (this.sttHoldEnabled?.() ?? false) && !this.isShowingAutocomplete();
 	}
 
@@ -1101,7 +1104,15 @@ export class CustomEditor extends Editor {
 			// handler. This matches the standard TUI/IDE pattern and prevents a
 			// single ESC from both closing an @ completion and aborting an active
 			// agent run (#1655).
-			if (this.#matchesAction(canonical, "app.interrupt") && this.onEscape && !this.isShowingAutocomplete()) {
+			// Vim mode claims Escape ahead of the interrupt: it has to mean "leave Insert mode" and
+			// "cancel a half-typed operator" first. Only a quiet Normal mode gives it back here, so
+			// the familiar single-ESC-to-abort still works once the user is out of Insert mode.
+			if (
+				this.#matchesAction(canonical, "app.interrupt") &&
+				this.onEscape &&
+				!this.isShowingAutocomplete() &&
+				!this.vimConsumesEscape()
+			) {
 				this.onEscape();
 				return;
 			}

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -105,6 +105,13 @@ const CONDITIONS: Record<string, () => boolean> = {
 			return false;
 		}
 	},
+	vimModeEnabled: () => {
+		try {
+			return Settings.instance.get("tui.vimMode") === true;
+		} catch {
+			return false;
+		}
+	},
 	hindsightActive: () => {
 		try {
 			return Settings.instance.get("memory.backend") === "hindsight";

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -406,6 +406,7 @@ export class StatusLineComponent implements Component {
 	#loopModeStatus: SegmentContext["loopMode"] = null;
 	#goalModeStatus: { enabled: boolean; paused: boolean } | null = null;
 	#vibeModeStatus: { enabled: boolean } | null = null;
+	#vimStatus: SegmentContext["vim"] = null;
 	/**
 	 * Injected aggregator that returns the aggregate tok/s of this session's
 	 * live vibe worker sessions, or null when no workers are streaming. Kept as
@@ -668,6 +669,11 @@ export class StatusLineComponent implements Component {
 
 	setVibeModeStatus(status: { enabled: boolean } | undefined): void {
 		this.#vibeModeStatus = status ?? null;
+	}
+
+	/** Mirror of the editor's modal state; `undefined` clears it (Vim mode off). */
+	setVimStatus(status: NonNullable<SegmentContext["vim"]> | undefined): void {
+		this.#vimStatus = status ?? null;
 	}
 
 	/**
@@ -1739,6 +1745,7 @@ export class StatusLineComponent implements Component {
 					: null,
 			goalMode: this.#goalModeStatus,
 			vibeMode: this.#vibeModeStatus,
+			vim: this.#vimStatus,
 			collab: this.#collabStatus,
 			usageStats,
 			contextPercent,

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -434,6 +434,7 @@ export class StatusLineComponent implements Component {
 	#loopModeStatus: SegmentContext["loopMode"] = null;
 	#goalModeStatus: { enabled: boolean; paused: boolean } | null = null;
 	#vibeModeStatus: { enabled: boolean } | null = null;
+	#vimStatus: SegmentContext["vim"] = null;
 	/**
 	 * Injected aggregator that returns the aggregate tok/s of this session's
 	 * live vibe worker sessions, or null when no workers are streaming. Kept as
@@ -722,6 +723,11 @@ export class StatusLineComponent implements Component {
 
 	setVibeModeStatus(status: { enabled: boolean } | undefined): void {
 		this.#vibeModeStatus = status ?? null;
+	}
+
+	/** Mirror of the editor's modal state; `undefined` clears it (Vim mode off). */
+	setVimStatus(status: NonNullable<SegmentContext["vim"]> | undefined): void {
+		this.#vimStatus = status ?? null;
 	}
 
 	/**
@@ -1865,6 +1871,7 @@ export class StatusLineComponent implements Component {
 					: null,
 			goalMode: this.#goalModeStatus,
 			vibeMode: this.#vibeModeStatus,
+			vim: this.#vimStatus,
 			collab: this.#collabStatus,
 			usageStats,
 			contextPercent,

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -2,7 +2,7 @@ import type { PresetDef, StatusLinePreset } from "./types";
 
 export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	default: {
-		leftSegments: ["pi", "model", "mode", "collab", "path", "git", "pr", "context_pct", "cost"],
+		leftSegments: ["pi", "vim", "model", "mode", "collab", "path", "git", "pr", "context_pct", "cost"],
 		rightSegments: ["session_name"],
 		separator: "powerline-thin",
 		segmentOptions: {
@@ -13,7 +13,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	},
 
 	minimal: {
-		leftSegments: ["path", "git"],
+		leftSegments: ["vim", "path", "git"],
 		rightSegments: ["session_name", "mode", "context_pct"],
 		separator: "slash",
 		segmentOptions: {
@@ -23,7 +23,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	},
 
 	compact: {
-		leftSegments: ["model", "mode", "git", "pr"],
+		leftSegments: ["vim", "model", "mode", "git", "pr"],
 		rightSegments: ["session_name", "cost", "context_pct"],
 		separator: "powerline-thin",
 		segmentOptions: {
@@ -33,7 +33,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	},
 
 	full: {
-		leftSegments: ["pi", "hostname", "model", "mode", "path", "git", "pr", "subagents"],
+		leftSegments: ["pi", "vim", "hostname", "model", "mode", "path", "git", "pr", "subagents"],
 		rightSegments: [
 			"session_name",
 			"cache_hit",
@@ -57,7 +57,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	nerd: {
 		// Full preset with all Nerd Font icons
-		leftSegments: ["pi", "hostname", "model", "mode", "path", "git", "pr", "session", "subagents"],
+		leftSegments: ["pi", "vim", "hostname", "model", "mode", "path", "git", "pr", "session", "subagents"],
 		rightSegments: [
 			"session_name",
 			"token_in",
@@ -82,7 +82,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	ascii: {
 		// No Nerd Font dependencies
-		leftSegments: ["model", "mode", "path", "git", "pr"],
+		leftSegments: ["vim", "model", "mode", "path", "git", "pr"],
 		rightSegments: ["session_name", "token_total", "cost", "context_pct"],
 		separator: "ascii",
 		segmentOptions: {
@@ -94,7 +94,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	custom: {
 		// User-defined - these are just defaults that get overridden
-		leftSegments: ["model", "mode", "path", "git", "pr"],
+		leftSegments: ["vim", "model", "mode", "path", "git", "pr"],
 		rightSegments: ["session_name", "token_total", "cost", "context_pct"],
 		separator: "powerline-thin",
 		segmentOptions: {},

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { TERMINAL } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, getProjectDir, pathIsWithin, relativePathWithinRoot } from "@oh-my-pi/pi-utils";
-import { type Theme, type ThemeColor, theme } from "../../../modes/theme/theme";
+import { type SymbolKey, type Theme, type ThemeColor, theme } from "../../../modes/theme/theme";
 import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../../tools/render-utils";
 import { fileHyperlink } from "../../../tui/hyperlink";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
@@ -656,6 +656,53 @@ const collabSegment: StatusLineSegment = {
 	},
 };
 
+/**
+ * Vim modal state, in the shape Vim itself uses: the mode, the half-typed command echoed beside it
+ * (`showcmd`), and the Visual selection size. Hidden entirely when `tui.vimMode` is off, so it
+ * costs nothing for everyone else. `tui.vimModeDisplay` picks the mode's presentation.
+ */
+const VIM_MODE_LABELS: Record<NonNullable<SegmentContext["vim"]>["mode"], string> = {
+	insert: "INSERT",
+	normal: "NORMAL",
+	visual: "VISUAL",
+	"visual-line": "V-LINE",
+};
+
+/**
+ * The `icon` display resolves through the theme's symbol map, so each mode picks up the active
+ * symbol preset (nerd / unicode / ascii) and honours per-theme `symbols` overrides — same mechanism
+ * as every other status-line icon. Glyph choices live in `SYMBOL_PRESETS`.
+ */
+const VIM_MODE_ICON_KEYS: Record<NonNullable<SegmentContext["vim"]>["mode"], SymbolKey> = {
+	insert: "icon.vimInsert",
+	normal: "icon.vimNormal",
+	visual: "icon.vimVisual",
+	"visual-line": "icon.vimVisualLine",
+};
+
+const VIM_MODE_COLORS: Record<NonNullable<SegmentContext["vim"]>["mode"], ThemeColor> = {
+	insert: "success",
+	normal: "accent",
+	visual: "warning",
+	"visual-line": "warning",
+};
+
+const vimSegment: StatusLineSegment = {
+	id: "vim",
+	render(ctx) {
+		const vim = ctx.vim;
+		if (!vim || vim.display === "none") return { content: "", visible: false };
+		let label = vim.display === "icon" ? theme.symbol(VIM_MODE_ICON_KEYS[vim.mode]) : VIM_MODE_LABELS[vim.mode];
+		// The selection height rides along in both presentations — it is the one part of the
+		// indicator with no other on-screen source.
+		if (vim.selectedLines > 1) label += ` ${vim.selectedLines}L`;
+		const content = theme.fg(VIM_MODE_COLORS[vim.mode], label);
+		// Pending echoes to the right of the mode, dimmed, exactly like Vim's showcmd.
+		const pending = vim.pending ? theme.fg("muted", ` ${vim.pending}`) : "";
+		return { content: `${content}${pending}`, visible: true };
+	},
+};
+
 function pickUsageColor(percent: number): "muted" | "warning" | "error" {
 	if (percent >= 80) return "error";
 	if (percent >= 50) return "warning";
@@ -753,6 +800,7 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	session_name: sessionNameSegment,
 	usage: usageSegment,
 	collab: collabSegment,
+	vim: vimSegment,
 };
 
 export function renderSegment(id: StatusLineSegmentId, ctx: SegmentContext): RenderedSegment {

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { SPINNER_ADVANCE_MS, TERMINAL } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, getProjectDir, pathIsWithin, relativePathWithinRoot } from "@oh-my-pi/pi-utils";
-import { type Theme, type ThemeColor, theme } from "../../../modes/theme/theme";
+import { type SymbolKey, type Theme, type ThemeColor, theme } from "../../../modes/theme/theme";
 import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../../tools/render-utils";
 import { fileHyperlink } from "../../../tui/hyperlink";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/session-color";
@@ -777,6 +777,53 @@ const collabSegment: StatusLineSegment = {
 	},
 };
 
+/**
+ * Vim modal state, in the shape Vim itself uses: the mode, the half-typed command echoed beside it
+ * (`showcmd`), and the Visual selection size. Hidden entirely when `tui.vimMode` is off, so it
+ * costs nothing for everyone else. `tui.vimModeDisplay` picks the mode's presentation.
+ */
+const VIM_MODE_LABELS: Record<NonNullable<SegmentContext["vim"]>["mode"], string> = {
+	insert: "INSERT",
+	normal: "NORMAL",
+	visual: "VISUAL",
+	"visual-line": "V-LINE",
+};
+
+/**
+ * The `icon` display resolves through the theme's symbol map, so each mode picks up the active
+ * symbol preset (nerd / unicode / ascii) and honours per-theme `symbols` overrides — same mechanism
+ * as every other status-line icon. Glyph choices live in `SYMBOL_PRESETS`.
+ */
+const VIM_MODE_ICON_KEYS: Record<NonNullable<SegmentContext["vim"]>["mode"], SymbolKey> = {
+	insert: "icon.vimInsert",
+	normal: "icon.vimNormal",
+	visual: "icon.vimVisual",
+	"visual-line": "icon.vimVisualLine",
+};
+
+const VIM_MODE_COLORS: Record<NonNullable<SegmentContext["vim"]>["mode"], ThemeColor> = {
+	insert: "success",
+	normal: "accent",
+	visual: "warning",
+	"visual-line": "warning",
+};
+
+const vimSegment: StatusLineSegment = {
+	id: "vim",
+	render(ctx) {
+		const vim = ctx.vim;
+		if (!vim || vim.display === "none") return { content: "", visible: false };
+		let label = vim.display === "icon" ? theme.symbol(VIM_MODE_ICON_KEYS[vim.mode]) : VIM_MODE_LABELS[vim.mode];
+		// The selection height rides along in both presentations — it is the one part of the
+		// indicator with no other on-screen source.
+		if (vim.selectedLines > 1) label += ` ${vim.selectedLines}L`;
+		const content = theme.fg(VIM_MODE_COLORS[vim.mode], label);
+		// Pending echoes to the right of the mode, dimmed, exactly like Vim's showcmd.
+		const pending = vim.pending ? theme.fg("muted", ` ${vim.pending}`) : "";
+		return { content: `${content}${pending}`, visible: true };
+	},
+};
+
 function pickUsageColor(percent: number): "muted" | "warning" | "error" {
 	if (percent >= 80) return "error";
 	if (percent >= 50) return "warning";
@@ -898,6 +945,7 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	session_name: sessionNameSegment,
 	usage: usageSegment,
 	collab: collabSegment,
+	vim: vimSegment,
 };
 
 export function renderSegment(id: StatusLineSegmentId, ctx: SegmentContext): RenderedSegment {

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -88,6 +88,16 @@ export interface SegmentContext {
 	vibeMode: {
 		enabled: boolean;
 	} | null;
+	/** Modal editing state, or null when `tui.vimMode` is off. */
+	vim: {
+		mode: "insert" | "normal" | "visual" | "visual-line";
+		/** Half-typed operator/count (`"2d"`), empty when nothing is pending. */
+		pending: string;
+		/** Lines spanned by the active Visual selection; 0 outside Visual modes. */
+		selectedLines: number;
+		/** `tui.vimModeDisplay`: how the mode renders in the status line. */
+		display: "text" | "icon" | "none";
+	} | null;
 	collab: CollabStatus | null;
 	// Cached values for performance (computed once per render)
 	usageStats: {

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -98,6 +98,16 @@ export interface SegmentContext {
 	vibeMode: {
 		enabled: boolean;
 	} | null;
+	/** Modal editing state, or null when `tui.vimMode` is off. */
+	vim: {
+		mode: "insert" | "normal" | "visual" | "visual-line";
+		/** Half-typed operator/count (`"2d"`), empty when nothing is pending. */
+		pending: string;
+		/** Lines spanned by the active Visual selection; 0 outside Visual modes. */
+		selectedLines: number;
+		/** `tui.vimModeDisplay`: how the mode renders in the status line. */
+		display: "text" | "icon" | "none";
+	} | null;
 	collab: CollabStatus | null;
 	// Cached values for performance (computed once per render)
 	usageStats: {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -537,6 +537,11 @@ export class SelectorController {
 				this.ctx.ui.requestRender();
 				break;
 
+			case "tui.vimMode":
+			case "tui.vimModeDisplay":
+				this.ctx.applyVimModeSetting();
+				break;
+
 			// Settings with UI side effects
 			case "display.hideToolActivity": {
 				const hidden = value as boolean;

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -588,6 +588,11 @@ export class SelectorController {
 				this.ctx.ui.requestRender();
 				break;
 
+			case "tui.vimMode":
+			case "tui.vimModeDisplay":
+				this.ctx.applyVimModeSetting();
+				break;
+
 			// Settings with UI side effects
 			case "display.hideToolActivity": {
 				const hidden = value as boolean;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1244,7 +1244,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		pushTerminalTitle();
 		setTerminalTitleStateEnabled(this.settings.get("tui.titleState"));
 		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
-		this.updateEditorBorderColor();
+		// Seeds the border, the status-line `vim` segment, and the cursor shape in one call.
+		// Deliberately here rather than beside #applyVimMode in the constructor: that runs before
+		// #focusController exists, which updateEditorBorderColor dereferences.
+		this.#syncVimStatus(this.editor);
 		// Single side-effect point for title changes: every setSessionName caller
 		// (first-input titling, /rename, extension renames, plan seeding, replan
 		// refresh) gets the terminal title + accent updates from here. Registered
@@ -2069,7 +2072,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	updateEditorBorderColor(): void {
-		const vimMode = this.editor.vimMode;
+		// `vimMode` reads "insert" when modal editing is off, so every Vim branch below must gate on
+		// `vimEnabled` — otherwise non-Vim users would lose the session-accent/thinking border.
+		const vimMode = this.editor.vimEnabled ? this.editor.vimMode : undefined;
 		if (this.isBashMode) {
 			this.editor.borderColor = theme.getBashModeBorderColor();
 		} else if (this.isPythonMode) {
@@ -2078,6 +2083,11 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.editor.borderColor = (str: string) => theme.fg("warning", str);
 		} else if (vimMode === "normal") {
 			this.editor.borderColor = (str: string) => theme.fg("accent", str);
+		} else if (vimMode === "insert") {
+			// Insert gets its own colour rather than falling through to the session accent: with Normal
+			// and Visual both coloured, an uncoloured Insert made the border unreadable as a mode.
+			// Matches the `vim` status-line segment, which uses the same three colours.
+			this.editor.borderColor = (str: string) => theme.fg("success", str);
 		} else {
 			const accentEnabled = !isSettingsInitialized() || settings.get("statusLine.sessionAccent") !== false;
 			const sessionName = accentEnabled ? this.sessionManager.getSessionName() : undefined;
@@ -3474,7 +3484,44 @@ export class InteractiveMode implements InteractiveModeContext {
 		};
 		// Recolor the prompt border on every mode switch: in a modal editor the mode has to be
 		// visible at a glance, and the border is where bash/python mode already signal themselves.
-		editor.onVimModeChange = () => this.updateEditorBorderColor();
+		editor.onVimModeChange = () => this.#syncVimStatus(editor);
+	}
+
+	/**
+	 * Re-apply `tui.vimMode` to the live editor. `setVimMode` is idempotent and always lands in
+	 * Insert, so toggling the setting mid-session can never strand the editor in a mode where
+	 * ordinary typing does nothing.
+	 */
+	applyVimModeSetting(): void {
+		this.#applyVimMode(this.editor);
+		this.#syncVimStatus(this.editor);
+		this.ui.requestRender();
+	}
+
+	/**
+	 * Push an editor's modal state into the three places that surface it: the prompt border, the
+	 * status-line `vim` segment, and the hardware cursor shape. Called on every mode/pending change,
+	 * so it stays cheap — the terminal dedupes an unchanged DECSCUSR shape. Takes the editor rather
+	 * than reading `this.editor`: `setEditorComponent` configures its replacement before swapping it in.
+	 */
+	#syncVimStatus(editor: CustomEditor): void {
+		this.statusLine.setVimStatus(
+			editor.vimEnabled
+				? {
+						mode: editor.vimMode,
+						pending: editor.vimPending,
+						selectedLines: editor.vimSelectedLines,
+						display: settings.get("tui.vimModeDisplay"),
+					}
+				: undefined,
+		);
+		// Insert gets the bar every non-modal editor uses; Normal/Visual rest *on* a grapheme, which
+		// is a block. Only reaches the terminal when the hardware cursor is actually on — the
+		// software cursor carries the same distinction itself (Editor#cursorCell).
+		this.ui.terminal.setCursorShape?.(
+			editor.vimEnabled && editor.vimMode !== "insert" ? "block" : editor.vimEnabled ? "bar" : "default",
+		);
+		this.updateEditorBorderColor();
 	}
 
 	async #copyYankToClipboard(content: string): Promise<void> {
@@ -4793,7 +4840,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			logger.warn("Failed to refresh slash command state for custom editor", { error: String(error) });
 		});
 
-		this.updateEditorBorderColor();
+		this.#syncVimStatus(nextEditor);
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3516,8 +3516,9 @@ export class InteractiveMode implements InteractiveModeContext {
 				: undefined,
 		);
 		// Insert gets the bar every non-modal editor uses; Normal/Visual rest *on* a grapheme, which
-		// is a block. Only reaches the terminal when the hardware cursor is actually on — the
-		// software cursor carries the same distinction itself (Editor#cursorCell).
+		// is a block. Sent unconditionally: the software cursor carries the same distinction itself
+		// (Editor#cursorCell), and when the hardware cursor is hidden this only reshapes something
+		// invisible. ProcessTerminal dedupes, so an unchanged shape costs nothing per frame.
 		this.ui.terminal.setCursorShape?.(
 			editor.vimEnabled && editor.vimMode !== "insert" ? "block" : editor.vimEnabled ? "bar" : "default",
 		);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -935,6 +935,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.deferredCommandContainer = new AnchoredLiveContainer();
 		this.editor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		this.editor.setImeSafeCursorLayout(settings.get("tui.imeSafeCursor"));
+		this.#applyVimMode(this.editor);
 		this.editor.setAutocompleteMaxVisible(settings.get("autocompleteMaxVisible"));
 		this.syncEditorSpelling();
 		this.editor.viewportRowsProvider = () => this.ui.terminal.rows;
@@ -2068,10 +2069,15 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	updateEditorBorderColor(): void {
+		const vimMode = this.editor.vimMode;
 		if (this.isBashMode) {
 			this.editor.borderColor = theme.getBashModeBorderColor();
 		} else if (this.isPythonMode) {
 			this.editor.borderColor = theme.getPythonModeBorderColor();
+		} else if (vimMode === "visual" || vimMode === "visual-line") {
+			this.editor.borderColor = (str: string) => theme.fg("warning", str);
+		} else if (vimMode === "normal") {
+			this.editor.borderColor = (str: string) => theme.fg("accent", str);
 		} else {
 			const accentEnabled = !isSettingsInitialized() || settings.get("statusLine.sessionAccent") !== false;
 			const sessionName = accentEnabled ? this.sessionManager.getSessionName() : undefined;
@@ -3460,6 +3466,25 @@ export class InteractiveMode implements InteractiveModeContext {
 		return contextUsage !== undefined && contextUsage.percent > PLAN_KEEP_CONTEXT_DISABLE_THRESHOLD_PERCENT;
 	}
 
+	/** Apply the `tui.vimMode` setting to an editor and route Visual-mode yanks to the clipboard. */
+	#applyVimMode(editor: CustomEditor): void {
+		editor.setVimMode(settings.get("tui.vimMode"));
+		editor.onYank = text => {
+			void this.#copyYankToClipboard(text);
+		};
+		// Recolor the prompt border on every mode switch: in a modal editor the mode has to be
+		// visible at a glance, and the border is where bash/python mode already signal themselves.
+		editor.onVimModeChange = () => this.updateEditorBorderColor();
+	}
+
+	async #copyYankToClipboard(content: string): Promise<void> {
+		try {
+			await copyToClipboard(content);
+		} catch (error) {
+			this.showWarning(`Failed to copy selection: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
 	async #copyPlanToClipboard(content: string): Promise<void> {
 		try {
 			await copyToClipboard(content);
@@ -4731,6 +4756,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			: new CustomEditor(getEditorTheme());
 		nextEditor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		nextEditor.setImeSafeCursorLayout(this.settings.get("tui.imeSafeCursor"));
+		this.#applyVimMode(nextEditor);
 		nextEditor.setAutocompleteMaxVisible(this.settings.get("autocompleteMaxVisible"));
 		nextEditor.setSpellingFeatures({
 			typoDetection: this.settings.get("spelling.typoDetection"),

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3826,8 +3826,9 @@ export class InteractiveMode implements InteractiveModeContext {
 				: undefined,
 		);
 		// Insert gets the bar every non-modal editor uses; Normal/Visual rest *on* a grapheme, which
-		// is a block. Only reaches the terminal when the hardware cursor is actually on — the
-		// software cursor carries the same distinction itself (Editor#cursorCell).
+		// is a block. Sent unconditionally: the software cursor carries the same distinction itself
+		// (Editor#cursorCell), and when the hardware cursor is hidden this only reshapes something
+		// invisible. ProcessTerminal dedupes, so an unchanged shape costs nothing per frame.
 		this.ui.terminal.setCursorShape?.(
 			editor.vimEnabled && editor.vimMode !== "insert" ? "block" : editor.vimEnabled ? "bar" : "default",
 		);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3839,7 +3839,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		try {
 			await copyToClipboard(content);
 		} catch (error) {
-			this.showWarning(`Failed to copy selection: ${error instanceof Error ? error.message : String(error)}`);
+			// Best-effort: the yank already landed in the internal register, so `p` still puts it
+			// back. A per-yank warning would spam headless/SSH sessions on every `yy`.
+			logger.debug("Vim yank clipboard copy failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1321,7 +1321,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		pushTerminalTitle();
 		setTerminalTitleStateEnabled(this.settings.get("tui.titleState"));
 		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());
-		this.updateEditorBorderColor();
+		// Seeds the border, the status-line `vim` segment, and the cursor shape in one call.
+		// Deliberately here rather than beside #applyVimMode in the constructor: that runs before
+		// #focusController exists, which updateEditorBorderColor dereferences.
+		this.#syncVimStatus(this.editor);
 		// Single side-effect point for title changes: every setSessionName caller
 		// (first-input titling, /rename, extension renames, plan seeding, replan
 		// refresh) gets the terminal title + accent updates from here. Registered
@@ -2374,7 +2377,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	updateEditorBorderColor(): void {
-		const vimMode = this.editor.vimMode;
+		// `vimMode` reads "insert" when modal editing is off, so every Vim branch below must gate on
+		// `vimEnabled` — otherwise non-Vim users would lose the session-accent/thinking border.
+		const vimMode = this.editor.vimEnabled ? this.editor.vimMode : undefined;
 		if (this.isBashMode) {
 			this.editor.borderColor = theme.getBashModeBorderColor();
 		} else if (this.isPythonMode) {
@@ -2383,6 +2388,11 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.editor.borderColor = (str: string) => theme.fg("warning", str);
 		} else if (vimMode === "normal") {
 			this.editor.borderColor = (str: string) => theme.fg("accent", str);
+		} else if (vimMode === "insert") {
+			// Insert gets its own colour rather than falling through to the session accent: with Normal
+			// and Visual both coloured, an uncoloured Insert made the border unreadable as a mode.
+			// Matches the `vim` status-line segment, which uses the same three colours.
+			this.editor.borderColor = (str: string) => theme.fg("success", str);
 		} else {
 			const accentEnabled = !isSettingsInitialized() || settings.get("statusLine.sessionAccent") !== false;
 			const sessionName = accentEnabled ? this.sessionManager.getSessionName() : undefined;
@@ -3784,7 +3794,44 @@ export class InteractiveMode implements InteractiveModeContext {
 		};
 		// Recolor the prompt border on every mode switch: in a modal editor the mode has to be
 		// visible at a glance, and the border is where bash/python mode already signal themselves.
-		editor.onVimModeChange = () => this.updateEditorBorderColor();
+		editor.onVimModeChange = () => this.#syncVimStatus(editor);
+	}
+
+	/**
+	 * Re-apply `tui.vimMode` to the live editor. `setVimMode` is idempotent and always lands in
+	 * Insert, so toggling the setting mid-session can never strand the editor in a mode where
+	 * ordinary typing does nothing.
+	 */
+	applyVimModeSetting(): void {
+		this.#applyVimMode(this.editor);
+		this.#syncVimStatus(this.editor);
+		this.ui.requestRender();
+	}
+
+	/**
+	 * Push an editor's modal state into the three places that surface it: the prompt border, the
+	 * status-line `vim` segment, and the hardware cursor shape. Called on every mode/pending change,
+	 * so it stays cheap — the terminal dedupes an unchanged DECSCUSR shape. Takes the editor rather
+	 * than reading `this.editor`: `setEditorComponent` configures its replacement before swapping it in.
+	 */
+	#syncVimStatus(editor: CustomEditor): void {
+		this.statusLine.setVimStatus(
+			editor.vimEnabled
+				? {
+						mode: editor.vimMode,
+						pending: editor.vimPending,
+						selectedLines: editor.vimSelectedLines,
+						display: settings.get("tui.vimModeDisplay"),
+					}
+				: undefined,
+		);
+		// Insert gets the bar every non-modal editor uses; Normal/Visual rest *on* a grapheme, which
+		// is a block. Only reaches the terminal when the hardware cursor is actually on — the
+		// software cursor carries the same distinction itself (Editor#cursorCell).
+		this.ui.terminal.setCursorShape?.(
+			editor.vimEnabled && editor.vimMode !== "insert" ? "block" : editor.vimEnabled ? "bar" : "default",
+		);
+		this.updateEditorBorderColor();
 	}
 
 	async #copyYankToClipboard(content: string): Promise<void> {
@@ -5251,7 +5298,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			logger.warn("Failed to refresh slash command state for custom editor", { error: String(error) });
 		});
 
-		this.updateEditorBorderColor();
+		this.#syncVimStatus(nextEditor);
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1009,6 +1009,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.deferredCommandContainer = new AnchoredLiveContainer();
 		this.editor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		this.editor.setImeSafeCursorLayout(settings.get("tui.imeSafeCursor"));
+		this.#applyVimMode(this.editor);
 		this.editor.setAutocompleteMaxVisible(settings.get("autocompleteMaxVisible"));
 		this.syncEditorSpelling();
 		this.editor.viewportRowsProvider = () => this.ui.terminal.rows;
@@ -2373,10 +2374,15 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	updateEditorBorderColor(): void {
+		const vimMode = this.editor.vimMode;
 		if (this.isBashMode) {
 			this.editor.borderColor = theme.getBashModeBorderColor();
 		} else if (this.isPythonMode) {
 			this.editor.borderColor = theme.getPythonModeBorderColor();
+		} else if (vimMode === "visual" || vimMode === "visual-line") {
+			this.editor.borderColor = (str: string) => theme.fg("warning", str);
+		} else if (vimMode === "normal") {
+			this.editor.borderColor = (str: string) => theme.fg("accent", str);
 		} else {
 			const accentEnabled = !isSettingsInitialized() || settings.get("statusLine.sessionAccent") !== false;
 			const sessionName = accentEnabled ? this.sessionManager.getSessionName() : undefined;
@@ -3768,6 +3774,25 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	#isKeepContextDisabled(contextUsage: ContextUsage | undefined): boolean {
 		return contextUsage !== undefined && contextUsage.percent > PLAN_KEEP_CONTEXT_DISABLE_THRESHOLD_PERCENT;
+	}
+
+	/** Apply the `tui.vimMode` setting to an editor and route Visual-mode yanks to the clipboard. */
+	#applyVimMode(editor: CustomEditor): void {
+		editor.setVimMode(settings.get("tui.vimMode"));
+		editor.onYank = text => {
+			void this.#copyYankToClipboard(text);
+		};
+		// Recolor the prompt border on every mode switch: in a modal editor the mode has to be
+		// visible at a glance, and the border is where bash/python mode already signal themselves.
+		editor.onVimModeChange = () => this.updateEditorBorderColor();
+	}
+
+	async #copyYankToClipboard(content: string): Promise<void> {
+		try {
+			await copyToClipboard(content);
+		} catch (error) {
+			this.showWarning(`Failed to copy selection: ${error instanceof Error ? error.message : String(error)}`);
+		}
 	}
 
 	async #copyPlanToClipboard(content: string): Promise<void> {
@@ -5189,6 +5214,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			: new CustomEditor(getEditorTheme());
 		nextEditor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
 		nextEditor.setImeSafeCursorLayout(this.settings.get("tui.imeSafeCursor"));
+		this.#applyVimMode(nextEditor);
 		nextEditor.setAutocompleteMaxVisible(this.settings.get("autocompleteMaxVisible"));
 		nextEditor.setSpellingFeatures({
 			typoDetection: this.settings.get("spelling.typoDetection"),

--- a/packages/coding-agent/src/modes/theme/symbols.ts
+++ b/packages/coding-agent/src/modes/theme/symbols.ts
@@ -118,6 +118,11 @@ export type SymbolKey =
 	| "icon.extensionPrompt"
 	| "icon.extensionContextFile"
 	| "icon.extensionInstruction"
+	// Vim modes
+	| "icon.vimNormal"
+	| "icon.vimInsert"
+	| "icon.vimVisual"
+	| "icon.vimVisualLine"
 	// Slash-command type indicators (autocomplete); names without an existing
 	// icon.* equivalent — see SlashCommandIconName for the full vocabulary.
 	| "cmd.action"
@@ -463,6 +468,13 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"icon.extensionPrompt": "✎",
 	"icon.extensionContextFile": "📎",
 	"icon.extensionInstruction": "📘",
+	// Vim modes — shape-distinct so Normal and Visual stay legible even when the
+	// theme's accent and warning colours sit in the same hue family. Insert and
+	// Normal echo the cursor each mode draws (a bar and a block).
+	"icon.vimNormal": "■",
+	"icon.vimInsert": "▎",
+	"icon.vimVisual": "◉",
+	"icon.vimVisualLine": "≡",
 	// Slash-command type indicators
 	"cmd.action": "❯",
 	"cmd.prompt": "✎",
@@ -824,6 +836,19 @@ const NERD_SYMBOLS: SymbolMap = {
 	"icon.extensionContextFile": "\uf0f6",
 	// pick:  | alt:  
 	"icon.extensionInstruction": "\uf02d",
+	// Vim modes — fa-square / fa-pencil / fa-eye / fa-bars. Normal takes the filled
+	// block its cursor draws; Insert the pencil, Visual the eye, V-Line the stacked rules.
+	// Nerd Fonts scale the tall-and-narrow FA glyphs (fa-i-cursor, fa-caret-*) to the full
+	// ascender-to-descender box, so terminals with a tighter row shave their serifs (#3299);
+	// every glyph here stays inside the same normalised box the other icons use.
+	// pick:  (nf-fa-square) | alt:  (nf-fa-square_o)
+	"icon.vimNormal": "\uf0c8",
+	// pick:  (nf-fa-pencil) | alt:  (nf-fa-i_cursor, clipped by short rows)
+	"icon.vimInsert": "\uf040",
+	// pick:  (nf-fa-eye) | alt:  (nf-fa-dot_circle)
+	"icon.vimVisual": "\uf06e",
+	// pick:  (nf-fa-bars) | alt:  (nf-fa-align_left)
+	"icon.vimVisualLine": "\uf0c9",
 	// Slash-command type indicators
 	// pick:  (nf-cod-terminal) | alt:  (nf-fa-terminal)
 	"cmd.action": "\uea85",
@@ -1148,6 +1173,11 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"icon.extensionPrompt": "PR",
 	"icon.extensionContextFile": "CF",
 	"icon.extensionInstruction": "IN",
+	// Vim modes
+	"icon.vimNormal": "N",
+	"icon.vimInsert": "I",
+	"icon.vimVisual": "V",
+	"icon.vimVisualLine": "L",
 	// Slash-command type indicators — unused; the icon column is disabled in ASCII mode
 	"cmd.action": "",
 	"cmd.prompt": "",

--- a/packages/coding-agent/src/modes/theme/symbols.ts
+++ b/packages/coding-agent/src/modes/theme/symbols.ts
@@ -125,6 +125,11 @@ export type SymbolKey =
 	| "icon.extensionPrompt"
 	| "icon.extensionContextFile"
 	| "icon.extensionInstruction"
+	// Vim modes
+	| "icon.vimNormal"
+	| "icon.vimInsert"
+	| "icon.vimVisual"
+	| "icon.vimVisualLine"
 	// Slash-command type indicators (autocomplete); names without an existing
 	// icon.* equivalent — see SlashCommandIconName for the full vocabulary.
 	| "cmd.action"
@@ -478,6 +483,13 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"icon.extensionPrompt": "✎",
 	"icon.extensionContextFile": "📎",
 	"icon.extensionInstruction": "📘",
+	// Vim modes — shape-distinct so Normal and Visual stay legible even when the
+	// theme's accent and warning colours sit in the same hue family. Insert and
+	// Normal echo the cursor each mode draws (a bar and a block).
+	"icon.vimNormal": "■",
+	"icon.vimInsert": "▎",
+	"icon.vimVisual": "◉",
+	"icon.vimVisualLine": "≡",
 	// Slash-command type indicators
 	"cmd.action": "❯",
 	"cmd.prompt": "✎",
@@ -854,6 +866,19 @@ const NERD_SYMBOLS: SymbolMap = {
 	"icon.extensionContextFile": "\uf0f6",
 	// pick:  | alt:  
 	"icon.extensionInstruction": "\uf02d",
+	// Vim modes — fa-square / fa-pencil / fa-eye / fa-bars. Normal takes the filled
+	// block its cursor draws; Insert the pencil, Visual the eye, V-Line the stacked rules.
+	// Nerd Fonts scale the tall-and-narrow FA glyphs (fa-i-cursor, fa-caret-*) to the full
+	// ascender-to-descender box, so terminals with a tighter row shave their serifs (#3299);
+	// every glyph here stays inside the same normalised box the other icons use.
+	// pick:  (nf-fa-square) | alt:  (nf-fa-square_o)
+	"icon.vimNormal": "\uf0c8",
+	// pick:  (nf-fa-pencil) | alt:  (nf-fa-i_cursor, clipped by short rows)
+	"icon.vimInsert": "\uf040",
+	// pick:  (nf-fa-eye) | alt:  (nf-fa-dot_circle)
+	"icon.vimVisual": "\uf06e",
+	// pick:  (nf-fa-bars) | alt:  (nf-fa-align_left)
+	"icon.vimVisualLine": "\uf0c9",
 	// Slash-command type indicators
 	// pick:  (nf-cod-terminal) | alt:  (nf-fa-terminal)
 	"cmd.action": "\uea85",
@@ -1186,6 +1211,11 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"icon.extensionPrompt": "PR",
 	"icon.extensionContextFile": "CF",
 	"icon.extensionInstruction": "IN",
+	// Vim modes
+	"icon.vimNormal": "N",
+	"icon.vimInsert": "I",
+	"icon.vimVisual": "V",
+	"icon.vimVisualLine": "L",
 	// Slash-command type indicators — unused; the icon column is disabled in ASCII mode
 	"cmd.action": "",
 	"cmd.prompt": "",

--- a/packages/coding-agent/src/modes/theme/theme-class.ts
+++ b/packages/coding-agent/src/modes/theme/theme-class.ts
@@ -553,6 +553,10 @@ export class Theme {
 			extensionPrompt: this.#symbols["icon.extensionPrompt"],
 			extensionContextFile: this.#symbols["icon.extensionContextFile"],
 			extensionInstruction: this.#symbols["icon.extensionInstruction"],
+			vimNormal: this.#symbols["icon.vimNormal"],
+			vimInsert: this.#symbols["icon.vimInsert"],
+			vimVisual: this.#symbols["icon.vimVisual"],
+			vimVisualLine: this.#symbols["icon.vimVisualLine"],
 			mic: this.#symbols["icon.mic"],
 			camera: this.#symbols["icon.camera"],
 		};

--- a/packages/coding-agent/src/modes/theme/theme-class.ts
+++ b/packages/coding-agent/src/modes/theme/theme-class.ts
@@ -618,6 +618,10 @@ export class Theme {
 			extensionPrompt: this.#symbols["icon.extensionPrompt"],
 			extensionContextFile: this.#symbols["icon.extensionContextFile"],
 			extensionInstruction: this.#symbols["icon.extensionInstruction"],
+			vimNormal: this.#symbols["icon.vimNormal"],
+			vimInsert: this.#symbols["icon.vimInsert"],
+			vimVisual: this.#symbols["icon.vimVisual"],
+			vimVisualLine: this.#symbols["icon.vimVisualLine"],
 			mic: this.#symbols["icon.mic"],
 			camera: this.#symbols["icon.camera"],
 		};

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -360,6 +360,11 @@ export interface InteractiveModeContext {
 	/** Refresh the running-subagents status badge from the active local or collab registry. */
 	syncRunningSubagentBadge(): void;
 	updateEditorBorderColor(): void;
+	/**
+	 * Re-apply `tui.vimMode` to the live editor and refresh the mode chrome (border, status-line
+	 * segment, cursor shape). Lets the setting take effect without restarting the session.
+	 */
+	applyVimModeSetting(): void;
 	rebuildChatFromMessages(options?: { reuseSettledComponents?: boolean }): void;
 	setTodos(todos: TodoItem[] | TodoPhase[]): void;
 	reloadTodos(source?: AgentSession): Promise<void>;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -379,6 +379,11 @@ export interface InteractiveModeContext {
 	/** Refresh the running-subagents status badge from the active local or collab registry. */
 	syncRunningSubagentBadge(): void;
 	updateEditorBorderColor(): void;
+	/**
+	 * Re-apply `tui.vimMode` to the live editor and refresh the mode chrome (border, status-line
+	 * segment, cursor shape). Lets the setting take effect without restarting the session.
+	 */
+	applyVimModeSetting(): void;
 	rebuildChatFromMessages(options?: { reuseSettledComponents?: boolean }): void;
 	setTodos(todos: TodoItem[] | TodoPhase[]): void;
 	reloadTodos(source?: AgentSession): Promise<void>;

--- a/packages/coding-agent/test/modes/components/custom-editor-vim.test.ts
+++ b/packages/coding-agent/test/modes/components/custom-editor-vim.test.ts
@@ -1,0 +1,78 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { CustomEditor } from "../../../src/modes/components/custom-editor";
+import { getEditorTheme, initTheme } from "../../../src/modes/theme/theme";
+
+const ESC = "\x1b";
+
+function makeEditor(vim: boolean): { editor: CustomEditor; state: { escapes: number } } {
+	const editor = new CustomEditor(getEditorTheme());
+	const state = { escapes: 0 };
+	editor.onEscape = () => {
+		state.escapes++;
+	};
+	editor.setVimMode(vim);
+	return { editor, state };
+}
+
+describe("CustomEditor vim mode", () => {
+	beforeAll(() => {
+		initTheme();
+	});
+
+	it("leaves Escape to the app interrupt when vim mode is off", () => {
+		const { editor, state } = makeEditor(false);
+		editor.setText("draft");
+		editor.handleInput(ESC);
+		expect(state.escapes).toBe(1);
+	});
+
+	it("spends the first Escape leaving insert mode instead of interrupting", () => {
+		const { editor, state } = makeEditor(true);
+		editor.setText("draft");
+		editor.handleInput(ESC);
+		expect(state.escapes).toBe(0);
+		expect(editor.vimMode).toBe("normal");
+	});
+
+	it("gives Escape back to the app once normal mode is quiet", () => {
+		const { editor, state } = makeEditor(true);
+		editor.setText("draft");
+		editor.handleInput(ESC);
+		editor.handleInput(ESC);
+		expect(state.escapes).toBe(1);
+		expect(editor.getText()).toBe("draft");
+	});
+
+	it("spends Escape cancelling a visual selection before interrupting", () => {
+		const { editor, state } = makeEditor(true);
+		editor.setText("alfa beta");
+		editor.handleInput(ESC);
+		editor.handleInput("v");
+		editor.handleInput("h");
+		editor.handleInput(ESC);
+		expect(state.escapes).toBe(0);
+		expect(editor.vimMode).toBe("normal");
+		expect(editor.getText()).toBe("alfa beta");
+	});
+
+	it("keeps the space bar as a motion in normal mode instead of push-to-talk", () => {
+		const { editor } = makeEditor(true);
+		const gestures: string[] = [];
+		editor.sttHoldEnabled = () => true;
+		editor.onSpaceHoldStart = () => gestures.push("start");
+		editor.setText("alfa");
+		editor.handleInput(ESC);
+		for (let i = 0; i < 6; i++) editor.handleInput(" ");
+		expect(gestures).toEqual([]);
+		expect(editor.getText()).toBe("alfa");
+	});
+
+	it("still offers push-to-talk while composing in insert mode", () => {
+		const { editor } = makeEditor(true);
+		editor.sttHoldEnabled = () => true;
+		editor.onSpaceHoldStart = () => {};
+		expect(editor.vimMode).toBe("insert");
+		editor.handleInput(" ");
+		expect(editor.getText()).toBe(" ");
+	});
+});

--- a/packages/coding-agent/test/status-line-loop.test.ts
+++ b/packages/coding-agent/test/status-line-loop.test.ts
@@ -22,6 +22,7 @@ function createContext(loopMode: SegmentContext["loopMode"]): SegmentContext {
 		prewalk: null,
 		goalMode: null,
 		vibeMode: null,
+		vim: null,
 		collab: null,
 		usageStats: {
 			input: 0,

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -29,6 +29,7 @@ function createModelContext(advisorActive: boolean): SegmentContext {
 		prewalk: null,
 		goalMode: null,
 		vibeMode: null,
+		vim: null,
 		collab: null,
 		usageStats: {
 			input: 0,

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -57,6 +57,7 @@ function createCtx(overrides?: {
 		prewalk: null,
 		goalMode: null,
 		vibeMode: null,
+		vim: null,
 		collab: null,
 		usageStats: {
 			input: 0,

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -60,6 +60,7 @@ function createCtx(overrides?: {
 		prewalk: null,
 		goalMode: null,
 		vibeMode: null,
+		vim: null,
 		collab: null,
 		usageStats: {
 			input: 0,

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -42,6 +42,7 @@ function createPathContext(): SegmentContext {
 		prewalk: null,
 		goalMode: null,
 		vibeMode: null,
+		vim: null,
 		collab: null,
 		usageStats: {
 			input: 0,

--- a/packages/coding-agent/test/status-line-time-spent.test.ts
+++ b/packages/coding-agent/test/status-line-time-spent.test.ts
@@ -44,6 +44,7 @@ function createCtx(activeMs: number): SegmentContext {
 		prewalk: null,
 		goalMode: null,
 		vibeMode: null,
+		vim: null,
 		collab: null,
 		usageStats: {
 			input: 0,

--- a/packages/coding-agent/test/status-line-time-spent.test.ts
+++ b/packages/coding-agent/test/status-line-time-spent.test.ts
@@ -47,6 +47,7 @@ function createCtx(activeMs: number): SegmentContext {
 		prewalk: null,
 		goalMode: null,
 		vibeMode: null,
+		vim: null,
 		collab: null,
 		usageStats: {
 			input: 0,

--- a/packages/coding-agent/test/status-line-vim.test.ts
+++ b/packages/coding-agent/test/status-line-vim.test.ts
@@ -1,0 +1,121 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+type VimStatus = NonNullable<SegmentContext["vim"]>;
+
+function vimContext(vim: SegmentContext["vim"]): SegmentContext {
+	return { width: 80, options: {}, vim } as unknown as SegmentContext;
+}
+
+/** Most cases exercise the default `text` display; icon/none get their own tests. */
+function textStatus(vim: Omit<VimStatus, "display">): VimStatus {
+	return { ...vim, display: "text" };
+}
+
+/** Segment content carries SGR color; assert on the text the user reads. */
+function plain(content: string): string {
+	return content.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+describe("status line vim segment", () => {
+	it("stays hidden when vim mode is off", () => {
+		const rendered = renderSegment("vim", vimContext(null));
+		expect(rendered.visible).toBe(false);
+		expect(rendered.content).toBe("");
+	});
+
+	it("names the active mode", () => {
+		const modes: [VimStatus["mode"], string][] = [
+			["normal", "NORMAL"],
+			["insert", "INSERT"],
+			["visual", "VISUAL"],
+			["visual-line", "V-LINE"],
+		];
+		for (const [mode, label] of modes) {
+			const rendered = renderSegment("vim", vimContext(textStatus({ mode, pending: "", selectedLines: 0 })));
+			expect(rendered.visible).toBe(true);
+			expect(plain(rendered.content)).toBe(label);
+		}
+	});
+
+	it("echoes a half-typed command beside the mode", () => {
+		const rendered = renderSegment(
+			"vim",
+			vimContext(textStatus({ mode: "normal", pending: "2d", selectedLines: 0 })),
+		);
+		expect(plain(rendered.content)).toBe("NORMAL 2d");
+	});
+
+	it("appends the Visual selection height only once it spans multiple lines", () => {
+		const single = renderSegment(
+			"vim",
+			vimContext(textStatus({ mode: "visual-line", pending: "", selectedLines: 1 })),
+		);
+		expect(plain(single.content)).toBe("V-LINE");
+
+		const spanning = renderSegment(
+			"vim",
+			vimContext(textStatus({ mode: "visual-line", pending: "", selectedLines: 4 })),
+		);
+		expect(plain(spanning.content)).toBe("V-LINE 4L");
+	});
+
+	it("colors Insert differently from Normal so the mode reads at a glance", () => {
+		const insert = renderSegment("vim", vimContext(textStatus({ mode: "insert", pending: "", selectedLines: 0 })));
+		const normal = renderSegment("vim", vimContext(textStatus({ mode: "normal", pending: "", selectedLines: 0 })));
+		expect(insert.content).not.toBe(normal.content);
+		expect(insert.content).toContain("\x1b[");
+	});
+
+	it("collapses each mode to one distinct cell in every symbol preset", async () => {
+		// Icons resolve through the theme symbol map, so each preset must supply a full, distinct,
+		// single-cell set — a missing key would silently render as an empty segment.
+		// initTheme mutates process-wide theme state; the finally restores it even on failure so a
+		// broken assertion here cannot poison later test files.
+		try {
+			for (const preset of ["unicode", "nerd", "ascii"] as const) {
+				await initTheme(false, preset);
+				const glyphs: string[] = [];
+				for (const mode of ["normal", "insert", "visual", "visual-line"] as const) {
+					const rendered = renderSegment(
+						"vim",
+						vimContext({ mode, pending: "", selectedLines: 0, display: "icon" }),
+					);
+					const glyph = plain(rendered.content);
+					expect(rendered.visible).toBe(true);
+					expect(Bun.stringWidth(glyph)).toBe(1);
+					glyphs.push(glyph);
+				}
+				// A shared glyph would make two modes indistinguishable.
+				expect(new Set(glyphs).size).toBe(glyphs.length);
+			}
+		} finally {
+			await initTheme();
+		}
+	});
+
+	it("keeps pending and selection height in the icon display", () => {
+		const rendered = renderSegment(
+			"vim",
+			vimContext({ mode: "visual-line", pending: "2", selectedLines: 3, display: "icon" }),
+		);
+		const text = plain(rendered.content);
+		expect(text).toEndWith(" 3L 2");
+		expect(Bun.stringWidth(text)).toBe(6);
+	});
+
+	it("hides the segment entirely when display is none", () => {
+		const rendered = renderSegment(
+			"vim",
+			vimContext({ mode: "normal", pending: "2d", selectedLines: 4, display: "none" }),
+		);
+		expect(rendered.visible).toBe(false);
+		expect(rendered.content).toBe("");
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an optional Vim-style modal editing layer to `Editor`, off unless `setVimMode(true)` is called: Insert, Normal, and Visual/Visual-Line with motions, count prefixes, and operators. `j`/`k` keep Vim's desired column, so passing over a shorter line does not collapse it, and `$` sticks to end-of-line. `p`/`P` paste from an internal register; yanks are surfaced to the host through `onYank` so it can route them to the system clipboard.
+- Vim mode now exposes its chrome to hosts: `Editor.vimEnabled`, `Editor.vimPending` (the half-typed command, e.g. `2d`), and `Editor.vimSelectedLines` (Visual selection height). `onVimModeChange` additionally fires when the pending command or selection size changes, not only on mode switches.
+- Vim mode now understands text objects: `iw`/`aw` (and `W`), quotes `i"`/`a'`/`` a` ``, bracket pairs `i(`/`a{`/`i[`/`a<` (nesting-aware and multi-line), and paragraphs `ip`/`ap`. They work under an operator (`diw`, `ca(`) and in Visual mode (`viw`), with counts (`d2aw`). Previously `i` after an operator fell through to Insert mode, so `diw` typed text instead of deleting a word.
+- Vim mode's `c` operator now actually enters Insert mode (`cw`, `cip`, `c` in Visual); it also follows Vim's `cw`-acts-like-`ce` quirk and parks the cursor correctly when the changed range is empty (`ci"` between bare quotes).
+- Added `Terminal.setCursorShape()` (DECSCUSR), restored to the terminal's configured shape on teardown and crash cleanup.
+
+### Changed
+
+- The software cursor now reflects the Vim mode: a reverse-video block in Normal/Visual and an underline in Insert. Both occupy one cell, so layout is unchanged, and non-modal editors keep the reverse-video block they always had.
+
 ## [18.0.5] - 2026-08-25
 
 ### Breaking Changes

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an optional Vim-style modal editing layer to `Editor`, off unless `setVimMode(true)` is called: Insert, Normal, and Visual/Visual-Line with motions, count prefixes, and operators. `j`/`k` keep Vim's desired column, so passing over a shorter line does not collapse it, and `$` sticks to end-of-line. `p`/`P` paste from an internal register; yanks are surfaced to the host through `onYank` so it can route them to the system clipboard.
+- Vim mode now exposes its chrome to hosts: `Editor.vimEnabled`, `Editor.vimPending` (the half-typed command, e.g. `2d`), and `Editor.vimSelectedLines` (Visual selection height). `onVimModeChange` additionally fires when the pending command or selection size changes, not only on mode switches.
+- Vim mode now understands text objects: `iw`/`aw` (and `W`), quotes `i"`/`a'`/`` a` ``, bracket pairs `i(`/`a{`/`i[`/`a<` (nesting-aware and multi-line), and paragraphs `ip`/`ap`. They work under an operator (`diw`, `ca(`) and in Visual mode (`viw`), with counts (`d2aw`). Previously `i` after an operator fell through to Insert mode, so `diw` typed text instead of deleting a word.
+- Vim mode's `c` operator now actually enters Insert mode (`cw`, `cip`, `c` in Visual); it also follows Vim's `cw`-acts-like-`ce` quirk and parks the cursor correctly when the changed range is empty (`ci"` between bare quotes).
+- Added `Terminal.setCursorShape()` (DECSCUSR), restored to the terminal's configured shape on teardown and crash cleanup.
+
+### Changed
+
+- The software cursor now reflects the Vim mode: a reverse-video block in Normal/Visual and an underline in Insert. Both occupy one cell, so layout is unchanged, and non-modal editors keep the reverse-video block they always had.
+
 ## [18.1.15] - 2026-09-08
 
 ### Fixed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -26,6 +26,15 @@ import {
 	visibleWidth,
 } from "../utils";
 import {
+	lastGraphemeStart,
+	nextGraphemeStart,
+	type VimCommand,
+	type VimMode,
+	type VimPosition,
+	VimState,
+	visualRange,
+} from "../vim";
+import {
 	borderlessComposerStyle,
 	type ComposerChromeContext,
 	type ComposerStyle,
@@ -368,6 +377,19 @@ function isPlainTextRun(data: string): boolean {
 	return true;
 }
 
+/** Named keys Vim's Normal/Visual modes reinterpret as motions instead of letting them edit. */
+const VIM_NAV_KEYS: Record<string, string | undefined> = {
+	up: "k",
+	down: "j",
+	left: "h",
+	right: "l",
+	home: "0",
+	end: "$",
+	backspace: "h",
+	delete: "x",
+	space: "l",
+};
+
 const DEFAULT_PAGE_SCROLL_LINES = 10;
 
 const MAX_UNDO_STACK = 100;
@@ -386,6 +408,10 @@ interface LayoutLine {
 	sourceStartCol: number;
 	hasCursor: boolean;
 	cursorPos?: number;
+	/** Logical buffer line this row came from, and the offset of `text[0]` within it. Populated
+	 *  only while a Vim visual selection is active, to map the selection span onto wrapped rows. */
+	logicalLine?: number;
+	startIndex?: number;
 }
 
 /** Per-line measurement carried across renders: exact visible width plus
@@ -511,6 +537,15 @@ export class Editor implements Component, Focusable {
 
 	// Character jump mode
 	#jumpMode: "forward" | "backward" | null = null;
+
+	/** Vim-style modal editing (opt-in, see the `tui.vimMode` setting). `null` when disabled, in
+	 *  which case every code path below behaves exactly as it did before the mode existed. */
+	#vim: VimState | null = null;
+	/** Called with the selected text when Visual mode yanks, so hosts can reach the system
+	 *  clipboard — `packages/tui` deliberately has no clipboard dependency of its own. */
+	onYank?: (text: string) => void;
+	/** Fired when the modal state changes, so hosts can restyle their chrome (border, status). */
+	onVimModeChange?: (mode: VimMode) => void;
 
 	// Preferred visual column for vertical cursor movement (sticky column)
 	#preferredVisualCol: number | null = null;
@@ -686,6 +721,32 @@ export class Editor implements Component, Focusable {
 	setImeSafeCursorLayout(enabled: boolean): void {
 		if (this.#imeSafeCursorLayout === enabled) return;
 		this.#imeSafeCursorLayout = enabled;
+	}
+
+	/** Enable Vim-style modal editing. Toggling always drops back to Insert mode so the editor is
+	 *  never left in a state where ordinary typing does nothing. */
+	setVimMode(enabled: boolean): void {
+		if (enabled === (this.#vim !== null)) return;
+		this.#vim = enabled ? new VimState() : null;
+		if (this.#vim) this.#vim.mode = "insert";
+		this.invalidate();
+	}
+
+	/** Current modal state; always `"insert"` when Vim mode is off. */
+	get vimMode(): VimMode {
+		return this.#vim?.mode ?? "insert";
+	}
+
+	/**
+	 * Whether Escape belongs to the editor right now rather than to the app.
+	 *
+	 * Hosts bind Escape to interrupt/clear; in Vim mode it first has to mean "leave Insert mode" and
+	 * "cancel a half-typed operator". Only a quiet Normal mode gives Escape back to the app.
+	 */
+	vimConsumesEscape(): boolean {
+		const vim = this.#vim;
+		if (vim === null) return false;
+		return vim.mode !== "normal" || vim.pending;
 	}
 
 	getUseTerminalCursor(): boolean {
@@ -1074,6 +1135,10 @@ export class Editor implements Component, Focusable {
 		const inlineHint = this.#getInlineHint();
 		const hintStyle = this.#theme.hintStyle ?? ((t: string) => `\x1b[2m${t}\x1b[0m`);
 
+		// Active Vim visual selection, if any. The cursor always sits inside it, so selected rows
+		// skip the normal cursor-glyph branches: the reverse-video span already marks the spot.
+		const vimSelection = this.#vimSelection();
+
 		for (let visibleIndex = 0; visibleIndex < visibleLayoutLines.length; visibleIndex++) {
 			const layoutLine = visibleLayoutLines[visibleIndex]!;
 			let displayText = layoutLine.text;
@@ -1138,7 +1203,26 @@ export class Editor implements Component, Focusable {
 				continue;
 			}
 
-			if (hasCursor && this.#useTerminalCursor) {
+			const selectionSpan =
+				vimSelection === null
+					? null
+					: this.#selectionSpanFor(
+							layoutLine,
+							vimSelection,
+							layoutLines[this.#scrollOffset + visibleIndex + 1]?.logicalLine !== layoutLine.logicalLine,
+						);
+
+			if (selectionSpan !== null) {
+				displayText = this.#renderSelectedLine(
+					displayText,
+					selectionSpan,
+					hasCursor ? layoutLine.cursorPos : undefined,
+					marker,
+					decorationContext,
+				);
+				decorated = true;
+				if (selectionSpan.trailingNewline) displayWidth += 1;
+			} else if (hasCursor && this.#useTerminalCursor) {
 				if (marker) {
 					const before = displayText.slice(0, layoutLine.cursorPos);
 					const after = displayText.slice(layoutLine.cursorPos);
@@ -1334,6 +1418,13 @@ export class Editor implements Component, Focusable {
 					return paste.remaining;
 				}
 			}
+			return;
+		}
+
+		// Vim modal editing. Placed after paste handling so bracketed pastes still land as text, and
+		// before the bulk fast path below because in Normal mode a multi-grapheme run is a sequence
+		// of commands, not something to insert.
+		if (this.#vim !== null && this.#handleVimInput(data, canonical)) {
 			return;
 		}
 
@@ -1727,6 +1818,285 @@ export class Editor implements Component, Focusable {
 		}
 	}
 
+	/**
+	 * Route one input chunk through the Vim state machine. Returns true when it was consumed.
+	 *
+	 * Anything the state machine declines — control chords, Enter, Tab — falls through to the
+	 * regular dispatch below, so app-level bindings keep working in Normal mode.
+	 */
+	#handleVimInput(data: string, canonical: string | undefined): boolean {
+		const vim = this.#vim;
+		if (vim === null) return false;
+
+		// Escape is the one key Vim owns in every mode: Insert → Normal, Visual → Normal, and
+		// cancelling a half-typed operator. A quiet Normal mode hands it back to the host.
+		// An open autocomplete popup still gets the first Escape though — dismissing it is what
+		// the user means, and a second Escape then switches modes.
+		if (canonical === "escape") {
+			return this.isShowingAutocomplete() ? false : this.#runVimKey("escape", vim);
+		}
+		if (vim.mode === "insert") return false;
+
+		const mapped = canonical === undefined ? undefined : VIM_NAV_KEYS[canonical];
+		if (mapped !== undefined) return this.#runVimKey(mapped, vim);
+
+		// Control chords carry no printable text and stay with the host.
+		const printable = extractPrintableText(data);
+		if (!printable) return false;
+
+		// Batched stdin can deliver several keystrokes at once, so replay the run one grapheme at a
+		// time. A command that drops out of Normal mode part-way (`iabc`) turns the rest of the run
+		// back into literal text rather than swallowing it.
+		for (const seg of segmenter.segment(printable)) {
+			if (this.#runVimKey(seg.segment, vim)) continue;
+			this.#insertCharacter(printable.slice(seg.index));
+			return true;
+		}
+		return true;
+	}
+
+	#runVimKey(key: string, vim: VimState): boolean {
+		const before = vim.mode;
+		const commands = vim.handleKey(key, this.#state);
+		if (commands === null) return false;
+		this.#applyVimCommands(commands);
+		if (vim.mode !== before) this.onVimModeChange?.(vim.mode);
+		return true;
+	}
+
+	#applyVimCommands(commands: readonly VimCommand[]): void {
+		for (const command of commands) {
+			switch (command.kind) {
+				case "move":
+					this.#moveVimCursor(command.to);
+					break;
+				case "mode":
+					this.#resetKillSequence();
+					this.#preferredVisualCol = null;
+					break;
+				case "yank": {
+					const body = this.#sliceRange(command.from, command.to, command.linewise);
+					// The trailing newline is what marks a register linewise, so `p` puts it back as
+					// whole lines rather than splicing it mid-line.
+					const text = command.linewise ? `${body}\n` : body;
+					if (text) {
+						this.#killRing.push(text, { prepend: false });
+						this.onYank?.(text);
+					}
+					break;
+				}
+				case "delete":
+					this.#deleteVimRange(command.from, command.to, command.linewise);
+					break;
+				case "openLine":
+					this.#openVimLine(command.below);
+					break;
+				case "paste":
+					this.#pasteVimRegister(command.after, command.count);
+					break;
+				case "undo":
+					this.#applyUndo();
+					break;
+			}
+		}
+		this.#clampVimCursor();
+		this.invalidate();
+	}
+
+	#moveVimCursor(to: VimPosition): void {
+		this.#state.cursorLine = Math.max(0, Math.min(to.line, this.#state.lines.length - 1));
+		const line = this.#state.lines[this.#state.cursorLine] ?? "";
+		this.#setCursorCol(Math.max(0, Math.min(to.col, line.length)));
+	}
+
+	/** Normal mode rests the cursor *on* a grapheme; Insert and Visual may sit one past the end. */
+	#clampVimCursor(): void {
+		if (this.#vim?.mode !== "normal") return;
+		const line = this.#state.lines[this.#state.cursorLine] ?? "";
+		if (this.#state.cursorCol > lastGraphemeStart(line)) {
+			this.#state.cursorCol = lastGraphemeStart(line);
+		}
+	}
+
+	/** Text covered by a half-open `[from, to)` buffer range. Linewise ranges take whole lines. */
+	#sliceRange(from: VimPosition, to: VimPosition, linewise: boolean): string {
+		const lines = this.#state.lines;
+		if (linewise) {
+			return lines.slice(from.line, Math.min(to.line, lines.length - 1) + 1).join("\n");
+		}
+		if (from.line === to.line) {
+			return (lines[from.line] ?? "").slice(from.col, to.col);
+		}
+		const parts = [(lines[from.line] ?? "").slice(from.col)];
+		for (let i = from.line + 1; i < to.line; i++) parts.push(lines[i] ?? "");
+		parts.push((lines[to.line] ?? "").slice(0, to.col));
+		return parts.join("\n");
+	}
+
+	#deleteVimRange(from: VimPosition, to: VimPosition, linewise: boolean): void {
+		const lines = this.#state.lines;
+		if (linewise) {
+			const last = Math.min(to.line, lines.length - 1);
+			const removed = this.#sliceRange(from, to, true);
+			if (!removed && from.line === last && lines.length === 1) return;
+			this.#recordUndoState();
+			this.#killRing.push(`${removed}\n`, { prepend: false });
+			lines.splice(from.line, last - from.line + 1);
+			if (lines.length === 0) lines.push("");
+			this.#state.cursorLine = Math.min(from.line, lines.length - 1);
+			this.#setCursorCol(0);
+			this.#afterVimEdit();
+			return;
+		}
+
+		// A range that cuts through an atomic placeholder (`[Image #1, 800x600]`) swallows the whole
+		// token instead of leaving a corrupt fragment — the same rule backspace follows.
+		let start = from;
+		let end = to;
+		if (start.line === end.line) {
+			const line = lines[start.line] ?? "";
+			const expanded = this.#expandRangeOverAtomicTokens(line, start.col, end.col);
+			start = { line: start.line, col: expanded.start };
+			end = { line: end.line, col: expanded.end };
+		} else {
+			const startLine = lines[start.line] ?? "";
+			const startToken = this.#atomicTokenAt(startLine, start.col);
+			if (startToken !== undefined) start = { line: start.line, col: startToken.start };
+			const endLine = lines[end.line] ?? "";
+			if (end.col > 0) {
+				const endToken = this.#atomicTokenAt(endLine, end.col - 1);
+				if (endToken !== undefined && endToken.end > end.col) end = { line: end.line, col: endToken.end };
+			}
+		}
+
+		const removed = this.#sliceRange(start, end, false);
+		if (!removed) return;
+		this.#recordUndoState();
+		this.#killRing.push(removed, { prepend: false });
+		const head = (lines[start.line] ?? "").slice(0, start.col);
+		const tail = (lines[Math.min(end.line, lines.length - 1)] ?? "").slice(end.col);
+		lines.splice(start.line, Math.min(end.line, lines.length - 1) - start.line + 1, head + tail);
+		this.#state.cursorLine = start.line;
+		this.#setCursorCol(start.col);
+		this.#afterVimEdit();
+	}
+
+	#openVimLine(below: boolean): void {
+		this.#recordUndoState();
+		const at = below ? this.#state.cursorLine + 1 : this.#state.cursorLine;
+		this.#state.lines.splice(at, 0, "");
+		this.#state.cursorLine = at;
+		this.#setCursorCol(0);
+		this.#afterVimEdit();
+	}
+
+	#pasteVimRegister(after: boolean, count: number): void {
+		const entry = this.#killRing.peek();
+		if (!entry) return;
+		this.#recordUndoState();
+		const linewise = entry.endsWith("\n");
+		if (linewise) {
+			const body = entry.slice(0, -1).split("\n");
+			const at = after ? this.#state.cursorLine + 1 : this.#state.cursorLine;
+			const payload: string[] = [];
+			for (let i = 0; i < count; i++) payload.push(...body);
+			this.#state.lines.splice(at, 0, ...payload);
+			this.#state.cursorLine = at;
+			this.#setCursorCol(0);
+		} else {
+			const line = this.#state.lines[this.#state.cursorLine] ?? "";
+			const at = after ? nextGraphemeStart(line, this.#state.cursorCol) : this.#state.cursorCol;
+			const payload = entry.repeat(count);
+			this.#state.lines[this.#state.cursorLine] = line.slice(0, at) + payload + line.slice(at);
+			this.#setCursorCol(at + payload.length - 1);
+		}
+		this.#afterVimEdit();
+	}
+
+	#afterVimEdit(): void {
+		this.#historyIndex = -1;
+		this.#resetKillSequence();
+		this.onChange?.(this.getText());
+	}
+
+	/**
+	 * Buffer span highlighted by the active Visual selection, or null when there is none.
+	 * Exposed to the render path only; `to` is exclusive.
+	 */
+	#vimSelection(): { from: VimPosition; to: VimPosition; linewise: boolean } | null {
+		const vim = this.#vim;
+		if (vim === null || !vim.visual || vim.anchor === null) return null;
+		const linewise = vim.mode === "visual-line";
+		const { from, to } = visualRange(this.#state, vim.anchor, linewise);
+		return { from, to, linewise };
+	}
+
+	/**
+	 * Map the active selection onto one layout row, as offsets into that row's `text`.
+	 * Returns null when the row is outside the selection.
+	 */
+	#selectionSpanFor(
+		layoutLine: LayoutLine,
+		selection: { from: VimPosition; to: VimPosition; linewise: boolean },
+		isLastRowOfLine: boolean,
+	): { start: number; end: number; trailingNewline: boolean } | null {
+		const logical = layoutLine.logicalLine;
+		if (logical === undefined || logical < selection.from.line || logical > selection.to.line) return null;
+
+		const rowStart = layoutLine.startIndex ?? 0;
+		const rowEnd = rowStart + layoutLine.text.length;
+		const lineStart = logical === selection.from.line ? selection.from.col : 0;
+		const lineEnd = logical === selection.to.line ? selection.to.col : (this.#state.lines[logical] ?? "").length;
+		const start = Math.max(lineStart, rowStart);
+		const end = Math.min(lineEnd, rowEnd);
+		// Vim highlights the newline itself when the selection runs on into the next line.
+		const trailingNewline = isLastRowOfLine && logical < selection.to.line;
+		if (end <= start && !trailingNewline) return null;
+		return { start: start - rowStart, end: Math.max(start, end) - rowStart, trailingNewline };
+	}
+
+	/**
+	 * Reverse-video the selected span of one row while keeping the cursor marker at its exact
+	 * offset. Unselected fragments are decorated individually, the same way the cursor branch
+	 * splits `#decorate` around the cursor glyph.
+	 */
+	#renderSelectedLine(
+		text: string,
+		span: { start: number; end: number; trailingNewline: boolean },
+		cursorPos: number | undefined,
+		marker: string,
+		context: EditorTextDecorationContext,
+	): string {
+		const start = Math.max(0, Math.min(span.start, text.length));
+		const end = Math.max(start, Math.min(span.end, text.length));
+		// Only cut for the marker when there is one to emit: an unfocused editor would otherwise
+		// split the highlight into two identical spans for nothing.
+		const markerPos = !marker || cursorPos === undefined ? undefined : Math.max(0, Math.min(cursorPos, text.length));
+
+		const cuts = new Set<number>([0, start, end, text.length]);
+		if (markerPos !== undefined) cuts.add(markerPos);
+		const points = [...cuts].sort((left, right) => left - right);
+
+		let out = "";
+		for (let i = 0; i < points.length - 1; i++) {
+			const from = points[i]!;
+			const to = points[i + 1]!;
+			if (marker && from === markerPos) out += marker;
+			const segment = text.slice(from, to);
+			out +=
+				from >= start && from < end
+					? `\x1b[7m${segment}\x1b[27m`
+					: this.#decorate(segment, {
+							...context,
+							startCol: context.startCol + from,
+							endCol: context.startCol + to,
+						});
+		}
+		if (marker && markerPos !== undefined && markerPos >= text.length) out += marker;
+		if (span.trailingNewline) out += "\x1b[7m \x1b[27m";
+		return out;
+	}
+
 	/** Cached per-line measurement: exact visible width now, wrap chunks on demand. */
 	#lineEntry(line: string, width: number): WrapEntry {
 		const epoch = getWidthConfigEpoch();
@@ -1764,6 +2134,8 @@ export class Editor implements Component, Focusable {
 				sourceStartCol: 0,
 				hasCursor: true,
 				cursorPos: 0,
+				logicalLine: 0,
+				startIndex: 0,
 			});
 			return layoutLines;
 		}
@@ -1784,6 +2156,8 @@ export class Editor implements Component, Focusable {
 						sourceStartCol: 0,
 						hasCursor: true,
 						cursorPos: this.#state.cursorCol,
+						logicalLine: i,
+						startIndex: 0,
 					});
 				} else {
 					layoutLines.push({
@@ -1792,6 +2166,8 @@ export class Editor implements Component, Focusable {
 						sourceLine: i,
 						sourceStartCol: 0,
 						hasCursor: false,
+						logicalLine: i,
+						startIndex: 0,
 					});
 				}
 			} else {
@@ -1836,6 +2212,8 @@ export class Editor implements Component, Focusable {
 							sourceStartCol: chunk.startIndex,
 							hasCursor: true,
 							cursorPos: adjustedCursorPos,
+							logicalLine: i,
+							startIndex: chunk.startIndex,
 						});
 					} else {
 						layoutLines.push({
@@ -1844,6 +2222,8 @@ export class Editor implements Component, Focusable {
 							sourceLine: i,
 							sourceStartCol: chunk.startIndex,
 							hasCursor: false,
+							logicalLine: i,
+							startIndex: chunk.startIndex,
 						});
 					}
 				}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -737,6 +737,22 @@ export class Editor implements Component, Focusable {
 		return this.#vim?.mode ?? "insert";
 	}
 
+	/** True when modal editing is active, regardless of which mode is current. */
+	get vimEnabled(): boolean {
+		return this.#vim !== null;
+	}
+
+	/** Half-typed Vim command (`"2d"`, `"g"`), or `""` when nothing is pending. */
+	get vimPending(): string {
+		return this.#vim?.pendingText ?? "";
+	}
+
+	/** Lines spanned by the active Visual selection; 0 outside Visual modes. */
+	get vimSelectedLines(): number {
+		const selection = this.#vimSelection();
+		return selection === null ? 0 : selection.to.line - selection.from.line + 1;
+	}
+
 	/**
 	 * Whether Escape belongs to the editor right now rather than to the app.
 	 *
@@ -971,7 +987,25 @@ export class Editor implements Component, Focusable {
 		);
 	}
 
+	/**
+	 * SGR wrapper for the cursor cell drawn *over* a grapheme.
+	 *
+	 * Vim's block-vs-bar distinction has to survive in a cell grid, so Insert mode underlines the
+	 * cell instead of reversing it: both occupy exactly one column, which keeps every width
+	 * calculation below untouched, and terminals render SGR 4 far more consistently than a
+	 * half-cell bar glyph. Non-Vim editors keep the reverse-video block they always had.
+	 */
+	#cursorCell(text: string): string {
+		const insertShape = this.#vim !== null && this.#vim.mode === "insert";
+		return insertShape ? `\x1b[4m${text}\x1b[0m` : `\x1b[7m${text}\x1b[0m`;
+	}
+
 	#getStyledInputCursor(): { text: string; width: number } {
+		// Normal/Visual rest *on* a grapheme, so past end-of-line they need a full block to look
+		// like Vim; the thin bar glyph stays the Insert/non-Vim caret.
+		if (this.#vim !== null && this.#vim.mode !== "insert") {
+			return { text: "\x1b[7m \x1b[0m", width: 1 };
+		}
 		const cursorChar = this.#theme.symbols.inputCursor;
 		// Keep the software cursor steady. Ghostty/cmux can leave visual
 		// afterimages for SGR blink cells during rapid input-row repaints.
@@ -989,7 +1023,7 @@ export class Editor implements Component, Focusable {
 		const lastGraphemeWidth = lastGrapheme ? visibleWidth(lastGrapheme) : 0;
 		const builtInCursor = this.#getStyledInputCursor();
 		const fallbackReplacement = lastGrapheme
-			? { text: `\x1b[7m${lastGrapheme}\x1b[0m`, width: lastGraphemeWidth }
+			? { text: this.#cursorCell(lastGrapheme), width: lastGraphemeWidth }
 			: builtInCursor;
 		const clampReplacement = (candidate: { text: string; width: number }): { text: string; width: number } => {
 			let text = sliceByColumn(candidate.text, 0, maxWidth, true);
@@ -1176,7 +1210,7 @@ export class Editor implements Component, Focusable {
 						const promptGlyphWidth = visibleWidth(promptGlyph);
 						const remainingCursorWidth = Math.max(0, zeroWidthCursorBudget - promptGlyphWidth);
 						if (remainingCursorWidth === 0) {
-							result.push(`\x1b[7m${promptGlyph}\x1b[0m${marker}`);
+							result.push(`${this.#cursorCell(promptGlyph)}${marker}`);
 						} else {
 							const widthLimitedCursor = this.#renderEndOfLineCursorAtWidthLimit(
 								"",
@@ -1253,7 +1287,7 @@ export class Editor implements Component, Focusable {
 					const afterGraphemes = [...segmenter.segment(after)];
 					const firstGrapheme = afterGraphemes[0]?.segment || "";
 					const restAfter = after.slice(firstGrapheme.length);
-					const cursor = `\x1b[7m${firstGrapheme}\x1b[0m`;
+					const cursor = this.#cursorCell(firstGrapheme);
 					// Decorate the plain text on each side of the cursor glyph. The reverse-video
 					// reset (\x1b[0m) ends in "m" (a word char), so a boundary match on restAfter
 					// would fail in the whole-line fallback below — decorate the segments here.
@@ -1857,10 +1891,17 @@ export class Editor implements Component, Focusable {
 
 	#runVimKey(key: string, vim: VimState): boolean {
 		const before = vim.mode;
+		const pendingBefore = vim.pendingText;
+		const selectedLinesBefore = this.vimSelectedLines;
 		const commands = vim.handleKey(key, this.#state);
 		if (commands === null) return false;
 		this.#applyVimCommands(commands);
-		if (vim.mode !== before) this.onVimModeChange?.(vim.mode);
+		// Pending and selection size are mode chrome too: hosts echo `2d` and the Visual line count
+		// beside the mode name, and extending a selection changes neither the mode nor the pending
+		// command — so all three have to be compared or the indicator goes stale mid-selection.
+		if (vim.mode !== before || vim.pendingText !== pendingBefore || this.vimSelectedLines !== selectedLinesBefore) {
+			this.onVimModeChange?.(vim.mode);
+		}
 		return true;
 	}
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -776,6 +776,22 @@ export class Editor implements Component, Focusable {
 		return this.#vim?.mode ?? "insert";
 	}
 
+	/** True when modal editing is active, regardless of which mode is current. */
+	get vimEnabled(): boolean {
+		return this.#vim !== null;
+	}
+
+	/** Half-typed Vim command (`"2d"`, `"g"`), or `""` when nothing is pending. */
+	get vimPending(): string {
+		return this.#vim?.pendingText ?? "";
+	}
+
+	/** Lines spanned by the active Visual selection; 0 outside Visual modes. */
+	get vimSelectedLines(): number {
+		const selection = this.#vimSelection();
+		return selection === null ? 0 : selection.to.line - selection.from.line + 1;
+	}
+
 	/**
 	 * Whether Escape belongs to the editor right now rather than to the app.
 	 *
@@ -1010,7 +1026,25 @@ export class Editor implements Component, Focusable {
 		);
 	}
 
+	/**
+	 * SGR wrapper for the cursor cell drawn *over* a grapheme.
+	 *
+	 * Vim's block-vs-bar distinction has to survive in a cell grid, so Insert mode underlines the
+	 * cell instead of reversing it: both occupy exactly one column, which keeps every width
+	 * calculation below untouched, and terminals render SGR 4 far more consistently than a
+	 * half-cell bar glyph. Non-Vim editors keep the reverse-video block they always had.
+	 */
+	#cursorCell(text: string): string {
+		const insertShape = this.#vim !== null && this.#vim.mode === "insert";
+		return insertShape ? `\x1b[4m${text}\x1b[0m` : `\x1b[7m${text}\x1b[0m`;
+	}
+
 	#getStyledInputCursor(): { text: string; width: number } {
+		// Normal/Visual rest *on* a grapheme, so past end-of-line they need a full block to look
+		// like Vim; the thin bar glyph stays the Insert/non-Vim caret.
+		if (this.#vim !== null && this.#vim.mode !== "insert") {
+			return { text: "\x1b[7m \x1b[0m", width: 1 };
+		}
 		const cursorChar = this.#theme.symbols.inputCursor;
 		// Keep the software cursor steady. Ghostty/cmux can leave visual
 		// afterimages for SGR blink cells during rapid input-row repaints.
@@ -1028,7 +1062,7 @@ export class Editor implements Component, Focusable {
 		const lastGraphemeWidth = lastGrapheme ? visibleWidth(lastGrapheme) : 0;
 		const builtInCursor = this.#getStyledInputCursor();
 		const fallbackReplacement = lastGrapheme
-			? { text: `\x1b[7m${lastGrapheme}\x1b[0m`, width: lastGraphemeWidth }
+			? { text: this.#cursorCell(lastGrapheme), width: lastGraphemeWidth }
 			: builtInCursor;
 		const clampReplacement = (candidate: { text: string; width: number }): { text: string; width: number } => {
 			let text = sliceByColumn(candidate.text, 0, maxWidth, true);
@@ -1215,7 +1249,7 @@ export class Editor implements Component, Focusable {
 						const promptGlyphWidth = visibleWidth(promptGlyph);
 						const remainingCursorWidth = Math.max(0, zeroWidthCursorBudget - promptGlyphWidth);
 						if (remainingCursorWidth === 0) {
-							result.push(`\x1b[7m${promptGlyph}\x1b[0m${marker}`);
+							result.push(`${this.#cursorCell(promptGlyph)}${marker}`);
 						} else {
 							const widthLimitedCursor = this.#renderEndOfLineCursorAtWidthLimit(
 								"",
@@ -1292,7 +1326,7 @@ export class Editor implements Component, Focusable {
 					const afterGraphemes = [...segmenter.segment(after)];
 					const firstGrapheme = afterGraphemes[0]?.segment || "";
 					const restAfter = after.slice(firstGrapheme.length);
-					const cursor = `\x1b[7m${firstGrapheme}\x1b[0m`;
+					const cursor = this.#cursorCell(firstGrapheme);
 					// Decorate the plain text on each side of the cursor glyph. The reverse-video
 					// reset (\x1b[0m) ends in "m" (a word char), so a boundary match on restAfter
 					// would fail in the whole-line fallback below — decorate the segments here.
@@ -1917,10 +1951,17 @@ export class Editor implements Component, Focusable {
 
 	#runVimKey(key: string, vim: VimState): boolean {
 		const before = vim.mode;
+		const pendingBefore = vim.pendingText;
+		const selectedLinesBefore = this.vimSelectedLines;
 		const commands = vim.handleKey(key, this.#state);
 		if (commands === null) return false;
 		this.#applyVimCommands(commands);
-		if (vim.mode !== before) this.onVimModeChange?.(vim.mode);
+		// Pending and selection size are mode chrome too: hosts echo `2d` and the Visual line count
+		// beside the mode name, and extending a selection changes neither the mode nor the pending
+		// command — so all three have to be compared or the indicator goes stale mid-selection.
+		if (vim.mode !== before || vim.pendingText !== pendingBefore || this.vimSelectedLines !== selectedLinesBefore) {
+			this.onVimModeChange?.(vim.mode);
+		}
 		return true;
 	}
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -27,6 +27,15 @@ import {
 	visibleWidth,
 } from "../utils";
 import {
+	lastGraphemeStart,
+	nextGraphemeStart,
+	type VimCommand,
+	type VimMode,
+	type VimPosition,
+	VimState,
+	visualRange,
+} from "../vim";
+import {
 	borderlessComposerStyle,
 	type ComposerChromeContext,
 	type ComposerStyle,
@@ -370,6 +379,19 @@ function isPlainTextRun(data: string): boolean {
 	return true;
 }
 
+/** Named keys Vim's Normal/Visual modes reinterpret as motions instead of letting them edit. */
+const VIM_NAV_KEYS: Record<string, string | undefined> = {
+	up: "k",
+	down: "j",
+	left: "h",
+	right: "l",
+	home: "0",
+	end: "$",
+	backspace: "h",
+	delete: "x",
+	space: "l",
+};
+
 const DEFAULT_PAGE_SCROLL_LINES = 10;
 
 const MAX_UNDO_STACK = 100;
@@ -388,6 +410,10 @@ interface LayoutLine {
 	sourceStartCol: number;
 	hasCursor: boolean;
 	cursorPos?: number;
+	/** Logical buffer line this row came from, and the offset of `text[0]` within it. Populated
+	 *  only while a Vim visual selection is active, to map the selection span onto wrapped rows. */
+	logicalLine?: number;
+	startIndex?: number;
 }
 
 /** Per-line measurement carried across renders: exact visible width plus
@@ -521,6 +547,15 @@ export class Editor implements Component, Focusable {
 
 	// Character jump mode
 	#jumpMode: "forward" | "backward" | null = null;
+
+	/** Vim-style modal editing (opt-in, see the `tui.vimMode` setting). `null` when disabled, in
+	 *  which case every code path below behaves exactly as it did before the mode existed. */
+	#vim: VimState | null = null;
+	/** Called with the selected text when Visual mode yanks, so hosts can reach the system
+	 *  clipboard — `packages/tui` deliberately has no clipboard dependency of its own. */
+	onYank?: (text: string) => void;
+	/** Fired when the modal state changes, so hosts can restyle their chrome (border, status). */
+	onVimModeChange?: (mode: VimMode) => void;
 
 	// Preferred visual column for vertical cursor movement (sticky column)
 	#preferredVisualCol: number | null = null;
@@ -725,6 +760,32 @@ export class Editor implements Component, Focusable {
 	setImeSafeCursorLayout(enabled: boolean): void {
 		if (this.#imeSafeCursorLayout === enabled) return;
 		this.#imeSafeCursorLayout = enabled;
+	}
+
+	/** Enable Vim-style modal editing. Toggling always drops back to Insert mode so the editor is
+	 *  never left in a state where ordinary typing does nothing. */
+	setVimMode(enabled: boolean): void {
+		if (enabled === (this.#vim !== null)) return;
+		this.#vim = enabled ? new VimState() : null;
+		if (this.#vim) this.#vim.mode = "insert";
+		this.invalidate();
+	}
+
+	/** Current modal state; always `"insert"` when Vim mode is off. */
+	get vimMode(): VimMode {
+		return this.#vim?.mode ?? "insert";
+	}
+
+	/**
+	 * Whether Escape belongs to the editor right now rather than to the app.
+	 *
+	 * Hosts bind Escape to interrupt/clear; in Vim mode it first has to mean "leave Insert mode" and
+	 * "cancel a half-typed operator". Only a quiet Normal mode gives Escape back to the app.
+	 */
+	vimConsumesEscape(): boolean {
+		const vim = this.#vim;
+		if (vim === null) return false;
+		return vim.mode !== "normal" || vim.pending;
 	}
 
 	getUseTerminalCursor(): boolean {
@@ -1113,6 +1174,10 @@ export class Editor implements Component, Focusable {
 		const inlineHint = this.#getInlineHint();
 		const hintStyle = this.#theme.hintStyle ?? ((t: string) => `\x1b[2m${t}\x1b[0m`);
 
+		// Active Vim visual selection, if any. The cursor always sits inside it, so selected rows
+		// skip the normal cursor-glyph branches: the reverse-video span already marks the spot.
+		const vimSelection = this.#vimSelection();
+
 		for (let visibleIndex = 0; visibleIndex < visibleLayoutLines.length; visibleIndex++) {
 			const layoutLine = visibleLayoutLines[visibleIndex]!;
 			let displayText = layoutLine.text;
@@ -1177,7 +1242,26 @@ export class Editor implements Component, Focusable {
 				continue;
 			}
 
-			if (hasCursor && this.#useTerminalCursor) {
+			const selectionSpan =
+				vimSelection === null
+					? null
+					: this.#selectionSpanFor(
+							layoutLine,
+							vimSelection,
+							layoutLines[this.#scrollOffset + visibleIndex + 1]?.logicalLine !== layoutLine.logicalLine,
+						);
+
+			if (selectionSpan !== null) {
+				displayText = this.#renderSelectedLine(
+					displayText,
+					selectionSpan,
+					hasCursor ? layoutLine.cursorPos : undefined,
+					marker,
+					decorationContext,
+				);
+				decorated = true;
+				if (selectionSpan.trailingNewline) displayWidth += 1;
+			} else if (hasCursor && this.#useTerminalCursor) {
 				if (marker) {
 					const before = displayText.slice(0, layoutLine.cursorPos);
 					const after = displayText.slice(layoutLine.cursorPos);
@@ -1376,6 +1460,13 @@ export class Editor implements Component, Focusable {
 					return paste.remaining;
 				}
 			}
+			return;
+		}
+
+		// Vim modal editing. Placed after paste handling so bracketed pastes still land as text, and
+		// before the bulk fast path below because in Normal mode a multi-grapheme run is a sequence
+		// of commands, not something to insert.
+		if (this.#vim !== null && this.#handleVimInput(data, canonical)) {
 			return;
 		}
 
@@ -1787,6 +1878,285 @@ export class Editor implements Component, Focusable {
 		}
 	}
 
+	/**
+	 * Route one input chunk through the Vim state machine. Returns true when it was consumed.
+	 *
+	 * Anything the state machine declines — control chords, Enter, Tab — falls through to the
+	 * regular dispatch below, so app-level bindings keep working in Normal mode.
+	 */
+	#handleVimInput(data: string, canonical: string | undefined): boolean {
+		const vim = this.#vim;
+		if (vim === null) return false;
+
+		// Escape is the one key Vim owns in every mode: Insert → Normal, Visual → Normal, and
+		// cancelling a half-typed operator. A quiet Normal mode hands it back to the host.
+		// An open autocomplete popup still gets the first Escape though — dismissing it is what
+		// the user means, and a second Escape then switches modes.
+		if (canonical === "escape") {
+			return this.isShowingAutocomplete() ? false : this.#runVimKey("escape", vim);
+		}
+		if (vim.mode === "insert") return false;
+
+		const mapped = canonical === undefined ? undefined : VIM_NAV_KEYS[canonical];
+		if (mapped !== undefined) return this.#runVimKey(mapped, vim);
+
+		// Control chords carry no printable text and stay with the host.
+		const printable = extractPrintableText(data);
+		if (!printable) return false;
+
+		// Batched stdin can deliver several keystrokes at once, so replay the run one grapheme at a
+		// time. A command that drops out of Normal mode part-way (`iabc`) turns the rest of the run
+		// back into literal text rather than swallowing it.
+		for (const seg of segmenter.segment(printable)) {
+			if (this.#runVimKey(seg.segment, vim)) continue;
+			this.#insertCharacter(printable.slice(seg.index));
+			return true;
+		}
+		return true;
+	}
+
+	#runVimKey(key: string, vim: VimState): boolean {
+		const before = vim.mode;
+		const commands = vim.handleKey(key, this.#state);
+		if (commands === null) return false;
+		this.#applyVimCommands(commands);
+		if (vim.mode !== before) this.onVimModeChange?.(vim.mode);
+		return true;
+	}
+
+	#applyVimCommands(commands: readonly VimCommand[]): void {
+		for (const command of commands) {
+			switch (command.kind) {
+				case "move":
+					this.#moveVimCursor(command.to);
+					break;
+				case "mode":
+					this.#resetKillSequence();
+					this.#preferredVisualCol = null;
+					break;
+				case "yank": {
+					const body = this.#sliceRange(command.from, command.to, command.linewise);
+					// The trailing newline is what marks a register linewise, so `p` puts it back as
+					// whole lines rather than splicing it mid-line.
+					const text = command.linewise ? `${body}\n` : body;
+					if (text) {
+						this.#killRing.push(text, { prepend: false });
+						this.onYank?.(text);
+					}
+					break;
+				}
+				case "delete":
+					this.#deleteVimRange(command.from, command.to, command.linewise);
+					break;
+				case "openLine":
+					this.#openVimLine(command.below);
+					break;
+				case "paste":
+					this.#pasteVimRegister(command.after, command.count);
+					break;
+				case "undo":
+					this.#applyUndo();
+					break;
+			}
+		}
+		this.#clampVimCursor();
+		this.invalidate();
+	}
+
+	#moveVimCursor(to: VimPosition): void {
+		this.#state.cursorLine = Math.max(0, Math.min(to.line, this.#state.lines.length - 1));
+		const line = this.#state.lines[this.#state.cursorLine] ?? "";
+		this.#setCursorCol(Math.max(0, Math.min(to.col, line.length)));
+	}
+
+	/** Normal mode rests the cursor *on* a grapheme; Insert and Visual may sit one past the end. */
+	#clampVimCursor(): void {
+		if (this.#vim?.mode !== "normal") return;
+		const line = this.#state.lines[this.#state.cursorLine] ?? "";
+		if (this.#state.cursorCol > lastGraphemeStart(line)) {
+			this.#state.cursorCol = lastGraphemeStart(line);
+		}
+	}
+
+	/** Text covered by a half-open `[from, to)` buffer range. Linewise ranges take whole lines. */
+	#sliceRange(from: VimPosition, to: VimPosition, linewise: boolean): string {
+		const lines = this.#state.lines;
+		if (linewise) {
+			return lines.slice(from.line, Math.min(to.line, lines.length - 1) + 1).join("\n");
+		}
+		if (from.line === to.line) {
+			return (lines[from.line] ?? "").slice(from.col, to.col);
+		}
+		const parts = [(lines[from.line] ?? "").slice(from.col)];
+		for (let i = from.line + 1; i < to.line; i++) parts.push(lines[i] ?? "");
+		parts.push((lines[to.line] ?? "").slice(0, to.col));
+		return parts.join("\n");
+	}
+
+	#deleteVimRange(from: VimPosition, to: VimPosition, linewise: boolean): void {
+		const lines = this.#state.lines;
+		if (linewise) {
+			const last = Math.min(to.line, lines.length - 1);
+			const removed = this.#sliceRange(from, to, true);
+			if (!removed && from.line === last && lines.length === 1) return;
+			this.#recordUndoState();
+			this.#killRing.push(`${removed}\n`, { prepend: false });
+			lines.splice(from.line, last - from.line + 1);
+			if (lines.length === 0) lines.push("");
+			this.#state.cursorLine = Math.min(from.line, lines.length - 1);
+			this.#setCursorCol(0);
+			this.#afterVimEdit();
+			return;
+		}
+
+		// A range that cuts through an atomic placeholder (`[Image #1, 800x600]`) swallows the whole
+		// token instead of leaving a corrupt fragment — the same rule backspace follows.
+		let start = from;
+		let end = to;
+		if (start.line === end.line) {
+			const line = lines[start.line] ?? "";
+			const expanded = this.#expandRangeOverAtomicTokens(line, start.col, end.col);
+			start = { line: start.line, col: expanded.start };
+			end = { line: end.line, col: expanded.end };
+		} else {
+			const startLine = lines[start.line] ?? "";
+			const startToken = this.#atomicTokenAt(startLine, start.col);
+			if (startToken !== undefined) start = { line: start.line, col: startToken.start };
+			const endLine = lines[end.line] ?? "";
+			if (end.col > 0) {
+				const endToken = this.#atomicTokenAt(endLine, end.col - 1);
+				if (endToken !== undefined && endToken.end > end.col) end = { line: end.line, col: endToken.end };
+			}
+		}
+
+		const removed = this.#sliceRange(start, end, false);
+		if (!removed) return;
+		this.#recordUndoState();
+		this.#killRing.push(removed, { prepend: false });
+		const head = (lines[start.line] ?? "").slice(0, start.col);
+		const tail = (lines[Math.min(end.line, lines.length - 1)] ?? "").slice(end.col);
+		lines.splice(start.line, Math.min(end.line, lines.length - 1) - start.line + 1, head + tail);
+		this.#state.cursorLine = start.line;
+		this.#setCursorCol(start.col);
+		this.#afterVimEdit();
+	}
+
+	#openVimLine(below: boolean): void {
+		this.#recordUndoState();
+		const at = below ? this.#state.cursorLine + 1 : this.#state.cursorLine;
+		this.#state.lines.splice(at, 0, "");
+		this.#state.cursorLine = at;
+		this.#setCursorCol(0);
+		this.#afterVimEdit();
+	}
+
+	#pasteVimRegister(after: boolean, count: number): void {
+		const entry = this.#killRing.peek();
+		if (!entry) return;
+		this.#recordUndoState();
+		const linewise = entry.endsWith("\n");
+		if (linewise) {
+			const body = entry.slice(0, -1).split("\n");
+			const at = after ? this.#state.cursorLine + 1 : this.#state.cursorLine;
+			const payload: string[] = [];
+			for (let i = 0; i < count; i++) payload.push(...body);
+			this.#state.lines.splice(at, 0, ...payload);
+			this.#state.cursorLine = at;
+			this.#setCursorCol(0);
+		} else {
+			const line = this.#state.lines[this.#state.cursorLine] ?? "";
+			const at = after ? nextGraphemeStart(line, this.#state.cursorCol) : this.#state.cursorCol;
+			const payload = entry.repeat(count);
+			this.#state.lines[this.#state.cursorLine] = line.slice(0, at) + payload + line.slice(at);
+			this.#setCursorCol(at + payload.length - 1);
+		}
+		this.#afterVimEdit();
+	}
+
+	#afterVimEdit(): void {
+		this.#historyIndex = -1;
+		this.#resetKillSequence();
+		this.onChange?.(this.getText());
+	}
+
+	/**
+	 * Buffer span highlighted by the active Visual selection, or null when there is none.
+	 * Exposed to the render path only; `to` is exclusive.
+	 */
+	#vimSelection(): { from: VimPosition; to: VimPosition; linewise: boolean } | null {
+		const vim = this.#vim;
+		if (vim === null || !vim.visual || vim.anchor === null) return null;
+		const linewise = vim.mode === "visual-line";
+		const { from, to } = visualRange(this.#state, vim.anchor, linewise);
+		return { from, to, linewise };
+	}
+
+	/**
+	 * Map the active selection onto one layout row, as offsets into that row's `text`.
+	 * Returns null when the row is outside the selection.
+	 */
+	#selectionSpanFor(
+		layoutLine: LayoutLine,
+		selection: { from: VimPosition; to: VimPosition; linewise: boolean },
+		isLastRowOfLine: boolean,
+	): { start: number; end: number; trailingNewline: boolean } | null {
+		const logical = layoutLine.logicalLine;
+		if (logical === undefined || logical < selection.from.line || logical > selection.to.line) return null;
+
+		const rowStart = layoutLine.startIndex ?? 0;
+		const rowEnd = rowStart + layoutLine.text.length;
+		const lineStart = logical === selection.from.line ? selection.from.col : 0;
+		const lineEnd = logical === selection.to.line ? selection.to.col : (this.#state.lines[logical] ?? "").length;
+		const start = Math.max(lineStart, rowStart);
+		const end = Math.min(lineEnd, rowEnd);
+		// Vim highlights the newline itself when the selection runs on into the next line.
+		const trailingNewline = isLastRowOfLine && logical < selection.to.line;
+		if (end <= start && !trailingNewline) return null;
+		return { start: start - rowStart, end: Math.max(start, end) - rowStart, trailingNewline };
+	}
+
+	/**
+	 * Reverse-video the selected span of one row while keeping the cursor marker at its exact
+	 * offset. Unselected fragments are decorated individually, the same way the cursor branch
+	 * splits `#decorate` around the cursor glyph.
+	 */
+	#renderSelectedLine(
+		text: string,
+		span: { start: number; end: number; trailingNewline: boolean },
+		cursorPos: number | undefined,
+		marker: string,
+		context: EditorTextDecorationContext,
+	): string {
+		const start = Math.max(0, Math.min(span.start, text.length));
+		const end = Math.max(start, Math.min(span.end, text.length));
+		// Only cut for the marker when there is one to emit: an unfocused editor would otherwise
+		// split the highlight into two identical spans for nothing.
+		const markerPos = !marker || cursorPos === undefined ? undefined : Math.max(0, Math.min(cursorPos, text.length));
+
+		const cuts = new Set<number>([0, start, end, text.length]);
+		if (markerPos !== undefined) cuts.add(markerPos);
+		const points = [...cuts].sort((left, right) => left - right);
+
+		let out = "";
+		for (let i = 0; i < points.length - 1; i++) {
+			const from = points[i]!;
+			const to = points[i + 1]!;
+			if (marker && from === markerPos) out += marker;
+			const segment = text.slice(from, to);
+			out +=
+				from >= start && from < end
+					? `\x1b[7m${segment}\x1b[27m`
+					: this.#decorate(segment, {
+							...context,
+							startCol: context.startCol + from,
+							endCol: context.startCol + to,
+						});
+		}
+		if (marker && markerPos !== undefined && markerPos >= text.length) out += marker;
+		if (span.trailingNewline) out += "\x1b[7m \x1b[27m";
+		return out;
+	}
+
 	/** Cached per-line measurement: exact visible width now, wrap chunks on demand. */
 	#lineEntry(line: string, width: number): WrapEntry {
 		const epoch = getWidthConfigEpoch();
@@ -1824,6 +2194,8 @@ export class Editor implements Component, Focusable {
 				sourceStartCol: 0,
 				hasCursor: true,
 				cursorPos: 0,
+				logicalLine: 0,
+				startIndex: 0,
 			});
 			return layoutLines;
 		}
@@ -1844,6 +2216,8 @@ export class Editor implements Component, Focusable {
 						sourceStartCol: 0,
 						hasCursor: true,
 						cursorPos: this.#state.cursorCol,
+						logicalLine: i,
+						startIndex: 0,
 					});
 				} else {
 					layoutLines.push({
@@ -1852,6 +2226,8 @@ export class Editor implements Component, Focusable {
 						sourceLine: i,
 						sourceStartCol: 0,
 						hasCursor: false,
+						logicalLine: i,
+						startIndex: 0,
 					});
 				}
 			} else {
@@ -1896,6 +2272,8 @@ export class Editor implements Component, Focusable {
 							sourceStartCol: chunk.startIndex,
 							hasCursor: true,
 							cursorPos: adjustedCursorPos,
+							logicalLine: i,
+							startIndex: chunk.startIndex,
 						});
 					} else {
 						layoutLines.push({
@@ -1904,6 +2282,8 @@ export class Editor implements Component, Focusable {
 							sourceLine: i,
 							sourceStartCol: chunk.startIndex,
 							hasCursor: false,
+							logicalLine: i,
+							startIndex: chunk.startIndex,
 						});
 					}
 				}

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -379,6 +379,7 @@ export function emergencyTerminalRestore(): void {
 					// buffer homes the cursor (unconditional CursorRestoreState
 					// with no prior save), corrupting the shell handoff on exit.
 					(altScreenActive ? "\x1b[?1049l\x1b[?1l\x1b>\x1b[<u" : "") + // Leave alt; reset main keyboard
+					"\x1b[0 q" + // Restore the terminal's configured cursor shape (DECSCUSR)
 					"\x1b[?25h", // Show cursor
 			);
 			altScreenActive = false;
@@ -406,6 +407,21 @@ export interface TerminalStartOptions {
 }
 /** Identity of an accepted explicit terminal appearance refresh request. */
 export type TerminalAppearanceRequestToken = number;
+
+/**
+ * Cursor shapes addressable via DECSCUSR (`CSI <n> SP q`). `"default"` (0) hands the shape back to
+ * the terminal's own configuration, which is what teardown restores rather than guessing a shape
+ * the user never chose.
+ */
+export type CursorShape = "default" | "block" | "underline" | "bar";
+
+export const CURSOR_SHAPE_CODES: Record<CursorShape, number> = {
+	default: 0,
+	block: 2,
+	underline: 4,
+	bar: 6,
+};
+
 export interface Terminal {
 	// Start the terminal with input, resize, and host-disconnect handlers.
 	start(
@@ -476,6 +492,10 @@ export interface Terminal {
 	// (crash/exit restore paths).
 	hideCursor(force?: boolean): void; // Hide the cursor
 	showCursor(force?: boolean): void; // Show the cursor
+
+	// Cursor shape (DECSCUSR). Only reaches the terminal when the hardware
+	// cursor is actually visible; software-cursor rendering ignores it.
+	setCursorShape?(shape: CursorShape): void;
 
 	// Clear operations
 	clearLine(): void; // Clear current line
@@ -615,6 +635,9 @@ export class ProcessTerminal implements Terminal {
 	// unknown (fresh start, resize, or an alt-screen switch newer than the
 	// last cursor sequence — some hosts keep DECTCEM per buffer).
 	#cursorVisible: boolean | undefined;
+	// Last DECSCUSR shape written, so per-keystroke mode changes dedupe.
+	// `undefined` = never set, i.e. the terminal's own configured shape.
+	#cursorShape: CursorShape | undefined;
 	// Captured at construction and re-read at start(): when true, every real
 	// terminal side effect (writes, probes, raw mode, SIGWINCH, timers) is
 	// suppressed. Defaults on under `bun test` — see isTerminalHeadless().
@@ -1656,6 +1679,13 @@ export class ProcessTerminal implements Terminal {
 		this.#safeWrite("\x1b[?2004l");
 		this.#safeWrite("\x1b[?5522l");
 
+		// Hand the cursor shape back to the user's terminal configuration; a Vim
+		// Normal-mode block must not outlive the session in their shell.
+		if (this.#cursorShape !== undefined && this.#cursorShape !== "default") {
+			this.#safeWrite(`\x1b[${CURSOR_SHAPE_CODES.default} q`);
+		}
+		this.#cursorShape = undefined;
+
 		// Disable mouse tracking (enabled only by fullscreen overlays; safe
 		// no-ops otherwise). Covers crash paths that reach stop() without the
 		// TUI's own overlay teardown running.
@@ -1921,6 +1951,17 @@ export class ProcessTerminal implements Terminal {
 	showCursor(force = false): void {
 		if (!force && this.#cursorVisible === true) return;
 		this.#safeWrite("\x1b[?25h");
+	}
+
+	/**
+	 * Set the hardware cursor shape (DECSCUSR). Deduped against the last shape written so a
+	 * per-keystroke mode indicator does not add a sequence to every frame; {@link stop} restores
+	 * `"default"` so the user's own cursor configuration survives exit.
+	 */
+	setCursorShape(shape: CursorShape): void {
+		if (this.#cursorShape === shape) return;
+		this.#cursorShape = shape;
+		this.#safeWrite(`\x1b[${CURSOR_SHAPE_CODES[shape]} q`);
 	}
 
 	/**

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -493,8 +493,10 @@ export interface Terminal {
 	hideCursor(force?: boolean): void; // Hide the cursor
 	showCursor(force?: boolean): void; // Show the cursor
 
-	// Cursor shape (DECSCUSR). Only reaches the terminal when the hardware
-	// cursor is actually visible; software-cursor rendering ignores it.
+	// Cursor shape (DECSCUSR). Written whenever it changes, whether or not the
+	// hardware cursor is currently visible: reshaping a hidden cursor has no
+	// visible effect, and `stop()` restores the user's configured shape. Hosts
+	// that render a software cursor simply never call this.
 	setCursorShape?(shape: CursorShape): void;
 
 	// Clear operations

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -547,8 +547,10 @@ export interface Terminal {
 	hideCursor(force?: boolean): void; // Hide the cursor
 	showCursor(force?: boolean): void; // Show the cursor
 
-	// Cursor shape (DECSCUSR). Only reaches the terminal when the hardware
-	// cursor is actually visible; software-cursor rendering ignores it.
+	// Cursor shape (DECSCUSR). Written whenever it changes, whether or not the
+	// hardware cursor is currently visible: reshaping a hidden cursor has no
+	// visible effect, and `stop()` restores the user's configured shape. Hosts
+	// that render a software cursor simply never call this.
 	setCursorShape?(shape: CursorShape): void;
 
 	// Clear operations

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -427,6 +427,7 @@ export function emergencyTerminalRestore(): void {
 					// buffer homes the cursor (unconditional CursorRestoreState
 					// with no prior save), corrupting the shell handoff on exit.
 					(altScreenActive ? "\x1b[?1049l\x1b[?1l\x1b>\x1b[<u" : "") + // Leave alt; reset main keyboard
+					"\x1b[0 q" + // Restore the terminal's configured cursor shape (DECSCUSR)
 					"\x1b[?25h", // Show cursor
 			);
 			altScreenActive = false;
@@ -461,6 +462,20 @@ export type TerminalAppearanceRequestToken = number;
  * set, 4 permanently reset) when the terminal answered DECRQM.
  */
 export type PrivateModeReportHandler = (mode: number, supported: boolean, confirmed?: boolean, status?: number) => void;
+
+/**
+ * Cursor shapes addressable via DECSCUSR (`CSI <n> SP q`). `"default"` (0) hands the shape back to
+ * the terminal's own configuration, which is what teardown restores rather than guessing a shape
+ * the user never chose.
+ */
+export type CursorShape = "default" | "block" | "underline" | "bar";
+
+export const CURSOR_SHAPE_CODES: Record<CursorShape, number> = {
+	default: 0,
+	block: 2,
+	underline: 4,
+	bar: 6,
+};
 export interface Terminal {
 	// Start the terminal with input, resize, and host-disconnect handlers.
 	start(
@@ -531,6 +546,10 @@ export interface Terminal {
 	// (crash/exit restore paths).
 	hideCursor(force?: boolean): void; // Hide the cursor
 	showCursor(force?: boolean): void; // Show the cursor
+
+	// Cursor shape (DECSCUSR). Only reaches the terminal when the hardware
+	// cursor is actually visible; software-cursor rendering ignores it.
+	setCursorShape?(shape: CursorShape): void;
 
 	// Clear operations
 	clearLine(): void; // Clear current line
@@ -682,6 +701,9 @@ export class ProcessTerminal implements Terminal {
 	// unknown (fresh start, resize, or an alt-screen switch newer than the
 	// last cursor sequence — some hosts keep DECTCEM per buffer).
 	#cursorVisible: boolean | undefined;
+	// Last DECSCUSR shape written, so per-keystroke mode changes dedupe.
+	// `undefined` = never set, i.e. the terminal's own configured shape.
+	#cursorShape: CursorShape | undefined;
 	// Captured at construction and re-read at start(): when true, every real
 	// terminal side effect (writes, probes, raw mode, SIGWINCH, timers) is
 	// suppressed. Defaults on under `bun test` — see isTerminalHeadless().
@@ -1733,6 +1755,13 @@ export class ProcessTerminal implements Terminal {
 		this.#safeWrite("\x1b[?2004l");
 		this.#safeWrite("\x1b[?5522l");
 
+		// Hand the cursor shape back to the user's terminal configuration; a Vim
+		// Normal-mode block must not outlive the session in their shell.
+		if (this.#cursorShape !== undefined && this.#cursorShape !== "default") {
+			this.#safeWrite(`\x1b[${CURSOR_SHAPE_CODES.default} q`);
+		}
+		this.#cursorShape = undefined;
+
 		// Disable mouse tracking (enabled only by fullscreen overlays; safe
 		// no-ops otherwise). Covers crash paths that reach stop() without the
 		// TUI's own overlay teardown running.
@@ -2029,6 +2058,17 @@ export class ProcessTerminal implements Terminal {
 	showCursor(force = false): void {
 		if (!force && this.#cursorVisible === true) return;
 		this.#safeWrite("\x1b[?25h");
+	}
+
+	/**
+	 * Set the hardware cursor shape (DECSCUSR). Deduped against the last shape written so a
+	 * per-keystroke mode indicator does not add a sequence to every frame; {@link stop} restores
+	 * `"default"` so the user's own cursor configuration survives exit.
+	 */
+	setCursorShape(shape: CursorShape): void {
+		if (this.#cursorShape === shape) return;
+		this.#cursorShape = shape;
+		this.#safeWrite(`\x1b[${CURSOR_SHAPE_CODES[shape]} q`);
 	}
 
 	/**

--- a/packages/tui/src/vim.ts
+++ b/packages/tui/src/vim.ts
@@ -106,6 +106,13 @@ export class VimState {
 	#count = "";
 	#operator: VimOperator | null = null;
 	#pendingG = false;
+	/**
+	 * Vim's "desired column": `j`/`k` remember the column you started from, so descending through a
+	 * short line and back out returns to it instead of collapsing permanently. `null` means the
+	 * next vertical motion anchors it to the live cursor column; `Infinity` is `$`'s sticky
+	 * end-of-line, which keeps `$j` on the end of each line. Every non-vertical command clears it.
+	 */
+	#desiredCol: number | null = null;
 
 	/** True while a count, operator, or `g` prefix is half-typed — Escape cancels that first. */
 	get pending(): boolean {
@@ -128,6 +135,7 @@ export class VimState {
 	reset(): void {
 		this.mode = "normal";
 		this.anchor = null;
+		this.#desiredCol = null;
 		this.#clearPending();
 	}
 
@@ -174,9 +182,14 @@ export class VimState {
 				return [];
 			}
 			// `gg` goes to the first line; `5gg` to line 5.
+			this.#desiredCol = null;
 			const line = Math.min(this.#takeCount() - 1, buf.lines.length - 1);
 			return this.#applyMotion(buf, { to: { line, col: 0 }, inclusive: false, linewise: true });
 		}
+
+		// Only consecutive `j`/`k` carry the desired column; anything else re-anchors it. Counts and
+		// the `g` prefix returned above, so `2j` still continues an established column.
+		if (key !== "j" && key !== "k") this.#desiredCol = null;
 
 		const motion = this.#resolveMotion(key, buf);
 		if (motion) return this.#applyMotion(buf, motion);
@@ -229,13 +242,18 @@ export class VimState {
 			case "k": {
 				const delta = key === "j" ? count : -count;
 				const target = Math.max(0, Math.min(buf.cursorLine + delta, buf.lines.length - 1));
-				return { to: { line: target, col: buf.cursorCol }, inclusive: false, linewise: true };
+				// Anchor the desired column on the first vertical move, then keep reusing it. The host
+				// clamps the target to each line's length, so short lines en route never shrink it.
+				this.#desiredCol ??= buf.cursorCol;
+				return { to: { line: target, col: this.#desiredCol }, inclusive: false, linewise: true };
 			}
 			case "0":
 				return { to: at(0), inclusive: false, linewise: false };
 			case "^":
 				return { to: at(firstNonBlank(line)), inclusive: false, linewise: false };
 			case "$":
+				// Sticky end-of-line, so `$j` lands on the end of each line rather than a fixed column.
+				this.#desiredCol = Number.POSITIVE_INFINITY;
 				return { to: at(line.length), inclusive: false, linewise: false };
 			case "w": {
 				let col = buf.cursorCol;

--- a/packages/tui/src/vim.ts
+++ b/packages/tui/src/vim.ts
@@ -1,0 +1,468 @@
+import { getSegmenter, moveWordLeft, moveWordRight } from "./utils";
+
+/**
+ * Modal editing state machine for {@link Editor}.
+ *
+ * Deliberately a *pure* state machine: it reads a snapshot of the buffer and returns the edits it
+ * wants applied, so motions can be unit-tested without a terminal and the editor keeps sole
+ * ownership of undo, atomic placeholder tokens, the kill ring, and `onChange`.
+ *
+ * This is a usable subset of Vim, not a reimplementation of it (see issue #3299): Normal and Visual
+ * modes, the common motions, and operators built from those motions.
+ */
+
+export type VimMode = "insert" | "normal" | "visual" | "visual-line";
+
+export type VimOperator = "d" | "y" | "c";
+
+export interface VimPosition {
+	line: number;
+	col: number;
+}
+
+/** Read-only view of the editor buffer that motions resolve against. */
+export interface VimBuffer {
+	readonly lines: readonly string[];
+	readonly cursorLine: number;
+	readonly cursorCol: number;
+}
+
+/**
+ * An edit the editor should apply. `to` is always an *exclusive* end offset, so ranges compose the
+ * same way regardless of whether the originating motion was inclusive (`e`) or exclusive (`w`).
+ */
+export type VimCommand =
+	| { kind: "move"; to: VimPosition }
+	| { kind: "mode"; mode: VimMode }
+	| { kind: "yank"; from: VimPosition; to: VimPosition; linewise: boolean }
+	| { kind: "delete"; from: VimPosition; to: VimPosition; linewise: boolean; insert: boolean }
+	| { kind: "openLine"; below: boolean }
+	| { kind: "paste"; after: boolean; count: number }
+	| { kind: "undo" };
+
+const segmenter = getSegmenter();
+
+const cursorOf = (buf: VimBuffer): VimPosition => ({ line: buf.cursorLine, col: buf.cursorCol });
+
+/** Start offset of the grapheme after `col`, clamped to `text.length`. */
+export function nextGraphemeStart(text: string, col: number): number {
+	if (col >= text.length) return text.length;
+	for (const seg of segmenter.segment(text)) {
+		if (seg.index >= col) return Math.min(seg.index + seg.segment.length, text.length);
+	}
+	return text.length;
+}
+
+/** Start offset of the grapheme before `col`, clamped to 0. */
+export function prevGraphemeStart(text: string, col: number): number {
+	if (col <= 0) return 0;
+	let last = 0;
+	for (const seg of segmenter.segment(text)) {
+		if (seg.index >= col) break;
+		last = seg.index;
+	}
+	return last;
+}
+
+/** Offset of the final grapheme — where a Normal-mode cursor rests on a non-empty line. */
+export function lastGraphemeStart(text: string): number {
+	return prevGraphemeStart(text, text.length);
+}
+
+function firstNonBlank(text: string): number {
+	for (const seg of segmenter.segment(text)) {
+		if (seg.segment.trim() !== "") return seg.index;
+	}
+	return 0;
+}
+
+/** Vim's `w`: `moveWordRight` stops at the end of the current word, so skip the gap that follows. */
+function wordForward(text: string, col: number): number {
+	let next = moveWordRight(text, col);
+	while (next < text.length && /\s/.test(text.charAt(next))) next++;
+	return next;
+}
+
+/** Vim's `e`: the last grapheme of the word the cursor is about to run into. */
+function wordEnd(text: string, col: number): number {
+	let from = nextGraphemeStart(text, col);
+	while (from < text.length && /\s/.test(text.charAt(from))) from++;
+	const end = moveWordRight(text, from);
+	return Math.max(col, prevGraphemeStart(text, end));
+}
+
+interface Motion {
+	to: VimPosition;
+	/** Inclusive motions cover the grapheme under `to` when used with an operator. */
+	inclusive: boolean;
+	linewise: boolean;
+}
+
+export class VimState {
+	mode: VimMode = "normal";
+	/** Fixed end of a Visual selection; the cursor is the moving end. */
+	anchor: VimPosition | null = null;
+
+	#count = "";
+	#operator: VimOperator | null = null;
+	#pendingG = false;
+
+	/** True while a count, operator, or `g` prefix is half-typed — Escape cancels that first. */
+	get pending(): boolean {
+		return this.#count.length > 0 || this.#operator !== null || this.#pendingG;
+	}
+
+	get visual(): boolean {
+		return this.mode === "visual" || this.mode === "visual-line";
+	}
+
+	reset(): void {
+		this.mode = "normal";
+		this.anchor = null;
+		this.#clearPending();
+	}
+
+	#clearPending(): void {
+		this.#count = "";
+		this.#operator = null;
+		this.#pendingG = false;
+	}
+
+	#takeCount(): number {
+		const count = this.#count.length > 0 ? Number.parseInt(this.#count, 10) : 1;
+		this.#count = "";
+		return Math.max(1, count);
+	}
+
+	/** Clamp a position so the Normal-mode cursor rests *on* a grapheme rather than past the last. */
+	#clampNormal(buf: VimBuffer, pos: VimPosition): VimPosition {
+		const line = Math.max(0, Math.min(pos.line, buf.lines.length - 1));
+		const text = buf.lines[line] ?? "";
+		return { line, col: Math.max(0, Math.min(pos.col, lastGraphemeStart(text))) };
+	}
+
+	/**
+	 * Handle one key. `key` is either the literal `"escape"` or a single grapheme; the editor
+	 * normalizes arrow/Home/End keys onto their Vim equivalents before calling.
+	 *
+	 * Returns the commands to apply, or `null` when the key is not ours — the editor then falls
+	 * through to its regular handling (and, for Escape in Normal mode, to the app's interrupt).
+	 */
+	handleKey(key: string, buf: VimBuffer): VimCommand[] | null {
+		if (key === "escape") return this.#handleEscape(buf);
+		if (this.mode === "insert") return null;
+
+		// Count prefix. `0` is the line-start motion unless it extends a count already being typed.
+		if ((key >= "1" && key <= "9") || (key === "0" && this.#count.length > 0)) {
+			this.#count += key;
+			return [];
+		}
+
+		if (this.#pendingG) {
+			this.#pendingG = false;
+			if (key !== "g") {
+				this.#clearPending();
+				return [];
+			}
+			// `gg` goes to the first line; `5gg` to line 5.
+			const line = Math.min(this.#takeCount() - 1, buf.lines.length - 1);
+			return this.#applyMotion(buf, { to: { line, col: 0 }, inclusive: false, linewise: true });
+		}
+
+		const motion = this.#resolveMotion(key, buf);
+		if (motion) return this.#applyMotion(buf, motion);
+
+		return this.visual ? this.#handleVisualKey(key, buf) : this.#handleNormalKey(key, buf);
+	}
+
+	#handleEscape(buf: VimBuffer): VimCommand[] | null {
+		if (this.pending) {
+			this.#clearPending();
+			return [];
+		}
+		if (this.visual) {
+			this.mode = "normal";
+			this.anchor = null;
+			return [
+				{ kind: "mode", mode: "normal" },
+				{ kind: "move", to: this.#clampNormal(buf, cursorOf(buf)) },
+			];
+		}
+		if (this.mode === "insert") {
+			this.mode = "normal";
+			const text = buf.lines[buf.cursorLine] ?? "";
+			return [
+				{ kind: "mode", mode: "normal" },
+				{ kind: "move", to: { line: buf.cursorLine, col: prevGraphemeStart(text, buf.cursorCol) } },
+			];
+		}
+		// Normal mode with nothing pending: leave Escape to the app (interrupt / clear draft).
+		return null;
+	}
+
+	#resolveMotion(key: string, buf: VimBuffer): Motion | null {
+		const count = this.#count.length > 0 ? Number.parseInt(this.#count, 10) : 1;
+		const line = buf.lines[buf.cursorLine] ?? "";
+		const at = (col: number): VimPosition => ({ line: buf.cursorLine, col });
+
+		switch (key === " " ? "l" : key) {
+			case "h": {
+				let col = buf.cursorCol;
+				for (let i = 0; i < count; i++) col = prevGraphemeStart(line, col);
+				return { to: at(col), inclusive: false, linewise: false };
+			}
+			case "l": {
+				let col = buf.cursorCol;
+				for (let i = 0; i < count; i++) col = nextGraphemeStart(line, col);
+				return { to: at(col), inclusive: false, linewise: false };
+			}
+			case "j":
+			case "k": {
+				const delta = key === "j" ? count : -count;
+				const target = Math.max(0, Math.min(buf.cursorLine + delta, buf.lines.length - 1));
+				return { to: { line: target, col: buf.cursorCol }, inclusive: false, linewise: true };
+			}
+			case "0":
+				return { to: at(0), inclusive: false, linewise: false };
+			case "^":
+				return { to: at(firstNonBlank(line)), inclusive: false, linewise: false };
+			case "$":
+				return { to: at(line.length), inclusive: false, linewise: false };
+			case "w": {
+				let col = buf.cursorCol;
+				for (let i = 0; i < count; i++) col = wordForward(line, col);
+				return { to: at(col), inclusive: false, linewise: false };
+			}
+			case "b": {
+				let col = buf.cursorCol;
+				for (let i = 0; i < count; i++) col = moveWordLeft(line, col);
+				return { to: at(col), inclusive: false, linewise: false };
+			}
+			case "e": {
+				let col = buf.cursorCol;
+				for (let i = 0; i < count; i++) col = wordEnd(line, col);
+				return { to: at(col), inclusive: true, linewise: false };
+			}
+			case "G": {
+				const target = this.#count.length > 0 ? count - 1 : buf.lines.length - 1;
+				return {
+					to: { line: Math.max(0, Math.min(target, buf.lines.length - 1)), col: 0 },
+					inclusive: false,
+					linewise: true,
+				};
+			}
+			default:
+				return null;
+		}
+	}
+
+	/** Turn a resolved motion into either a cursor move, a selection extension, or an operator range. */
+	#applyMotion(buf: VimBuffer, motion: Motion): VimCommand[] {
+		const operator = this.#operator;
+		this.#operator = null;
+		this.#takeCount();
+
+		if (operator === null) {
+			// `$` parks on the last grapheme in Normal mode but must still be able to select the
+			// final character in Visual mode, where the cursor is allowed one past it.
+			const to = this.visual
+				? { line: motion.to.line, col: Math.min(motion.to.col, (buf.lines[motion.to.line] ?? "").length) }
+				: this.#clampNormal(buf, motion.to);
+			return [{ kind: "move", to }];
+		}
+
+		const from: VimPosition = { line: buf.cursorLine, col: buf.cursorCol };
+		let start = from;
+		let end = motion.to;
+		if (end.line < start.line || (end.line === start.line && end.col < start.col)) [start, end] = [end, start];
+		if (motion.inclusive) {
+			const text = buf.lines[end.line] ?? "";
+			end = { line: end.line, col: nextGraphemeStart(text, end.col) };
+		}
+		return this.#operate(operator, start, end, motion.linewise);
+	}
+
+	#operate(operator: VimOperator, from: VimPosition, to: VimPosition, linewise: boolean): VimCommand[] {
+		if (operator === "y") {
+			return [
+				{ kind: "yank", from, to, linewise },
+				{ kind: "move", to: from },
+			];
+		}
+		const insert = operator === "c";
+		// `cc`/`cj` clear the lines but keep them, so a linewise change stays linewise-shaped.
+		return [{ kind: "delete", from, to, linewise: linewise && !insert, insert }];
+	}
+
+	#handleNormalKey(key: string, buf: VimBuffer): VimCommand[] | null {
+		const line = buf.lines[buf.cursorLine] ?? "";
+		const count = this.#count.length > 0 ? Number.parseInt(this.#count, 10) : 1;
+
+		switch (key) {
+			case "g":
+				this.#pendingG = true;
+				return [];
+			case "i":
+				this.#takeCount();
+				this.mode = "insert";
+				return [{ kind: "mode", mode: "insert" }];
+			case "a":
+				this.#takeCount();
+				this.mode = "insert";
+				return [
+					{ kind: "mode", mode: "insert" },
+					{ kind: "move", to: { line: buf.cursorLine, col: nextGraphemeStart(line, buf.cursorCol) } },
+				];
+			case "I":
+				this.#takeCount();
+				this.mode = "insert";
+				return [
+					{ kind: "mode", mode: "insert" },
+					{ kind: "move", to: { line: buf.cursorLine, col: firstNonBlank(line) } },
+				];
+			case "A":
+				this.#takeCount();
+				this.mode = "insert";
+				return [
+					{ kind: "mode", mode: "insert" },
+					{ kind: "move", to: { line: buf.cursorLine, col: line.length } },
+				];
+			case "o":
+			case "O":
+				this.#takeCount();
+				this.mode = "insert";
+				return [
+					{ kind: "openLine", below: key === "o" },
+					{ kind: "mode", mode: "insert" },
+				];
+			case "v":
+			case "V":
+				this.#takeCount();
+				this.mode = key === "v" ? "visual" : "visual-line";
+				this.anchor = { line: buf.cursorLine, col: buf.cursorCol };
+				return [{ kind: "mode", mode: this.mode }];
+			case "x": {
+				this.#takeCount();
+				let col = buf.cursorCol;
+				for (let i = 0; i < count && col < line.length; i++) col = nextGraphemeStart(line, col);
+				if (col === buf.cursorCol) return [];
+				return [
+					{
+						kind: "delete",
+						from: { line: buf.cursorLine, col: buf.cursorCol },
+						to: { line: buf.cursorLine, col },
+						linewise: false,
+						insert: false,
+					},
+				];
+			}
+			case "D":
+			case "C": {
+				this.#takeCount();
+				this.mode = key === "C" ? "insert" : this.mode;
+				return [
+					{
+						kind: "delete",
+						from: { line: buf.cursorLine, col: buf.cursorCol },
+						to: { line: buf.cursorLine, col: line.length },
+						linewise: false,
+						insert: key === "C",
+					},
+				];
+			}
+			case "d":
+			case "y":
+			case "c":
+				// A doubled operator (`dd`, `yy`, `cc`) is linewise over `count` lines.
+				if (this.#operator === key) {
+					const span = this.#takeCount();
+					const last = Math.min(buf.cursorLine + span - 1, buf.lines.length - 1);
+					this.#operator = null;
+					return this.#operate(
+						key,
+						{ line: buf.cursorLine, col: 0 },
+						{ line: last, col: (buf.lines[last] ?? "").length },
+						true,
+					);
+				}
+				this.#operator = key;
+				return [];
+			case "p":
+			case "P":
+				return [{ kind: "paste", after: key === "p", count: this.#takeCount() }];
+			case "u":
+				this.#takeCount();
+				return [{ kind: "undo" }];
+			default:
+				// Normal mode swallows unknown printable keys rather than typing them into the buffer.
+				this.#clearPending();
+				return [];
+		}
+	}
+
+	#handleVisualKey(key: string, buf: VimBuffer): VimCommand[] | null {
+		const anchor = this.anchor ?? { line: buf.cursorLine, col: buf.cursorCol };
+		const linewise = this.mode === "visual-line";
+
+		switch (key) {
+			case "v":
+			case "V": {
+				const next = key === "v" ? "visual" : "visual-line";
+				if (this.mode === next) {
+					this.mode = "normal";
+					this.anchor = null;
+					return [
+						{ kind: "mode", mode: "normal" },
+						{ kind: "move", to: this.#clampNormal(buf, cursorOf(buf)) },
+					];
+				}
+				this.mode = next;
+				return [{ kind: "mode", mode: next }];
+			}
+			case "o": {
+				this.anchor = { line: buf.cursorLine, col: buf.cursorCol };
+				return [{ kind: "move", to: anchor }];
+			}
+			case "y":
+			case "d":
+			case "x":
+			case "c":
+			case "s": {
+				const operator: VimOperator = key === "y" ? "y" : key === "c" || key === "s" ? "c" : "d";
+				const { from, to } = visualRange(buf, anchor, linewise);
+				this.#clearPending();
+				this.mode = operator === "c" ? "insert" : "normal";
+				this.anchor = null;
+				return [...this.#operate(operator, from, to, linewise), { kind: "mode", mode: this.mode }];
+			}
+			default:
+				this.#clearPending();
+				return [];
+		}
+	}
+}
+
+/**
+ * Normalized, end-exclusive span covered by a Visual selection.
+ *
+ * Charwise selections include the grapheme under the cursor (Vim semantics); linewise selections
+ * span whole lines, with `to.col` at the end of the last line so the caller can decide whether the
+ * trailing newline goes too.
+ */
+export function visualRange(
+	buf: VimBuffer,
+	anchor: VimPosition,
+	linewise: boolean,
+): { from: VimPosition; to: VimPosition } {
+	const cursor: VimPosition = { line: buf.cursorLine, col: buf.cursorCol };
+	let from = anchor;
+	let to = cursor;
+	if (to.line < from.line || (to.line === from.line && to.col < from.col)) [from, to] = [to, from];
+
+	if (linewise) {
+		const lastLine = Math.min(to.line, buf.lines.length - 1);
+		return { from: { line: from.line, col: 0 }, to: { line: lastLine, col: (buf.lines[lastLine] ?? "").length } };
+	}
+	const text = buf.lines[to.line] ?? "";
+	return { from, to: { line: to.line, col: nextGraphemeStart(text, to.col) } };
+}

--- a/packages/tui/src/vim.ts
+++ b/packages/tui/src/vim.ts
@@ -91,6 +91,169 @@ function wordEnd(text: string, col: number): number {
 	return Math.max(col, prevGraphemeStart(text, end));
 }
 
+/** End-exclusive span an `iw`/`a(`-style text object resolves to. */
+interface TextObjectRange {
+	from: VimPosition;
+	to: VimPosition;
+	linewise: boolean;
+}
+
+/** `0` whitespace, `1` keyword, `2` punctuation — the classes `w` groups by (`W` folds 2 into 1). */
+function charClass(ch: string, big: boolean): 0 | 1 | 2 {
+	if (/\s/.test(ch)) return 0;
+	if (big || /[\p{L}\p{N}_]/u.test(ch)) return 1;
+	return 2;
+}
+
+interface Chunk {
+	start: number;
+	end: number;
+	space: boolean;
+}
+
+/** Split a line into maximal same-class runs — the atoms a counted `iw`/`aw` walks over. */
+function chunkLine(text: string, big: boolean): Chunk[] {
+	const chunks: Chunk[] = [];
+	let i = 0;
+	while (i < text.length) {
+		const cls = charClass(text.charAt(i), big);
+		let j = i + 1;
+		while (j < text.length && charClass(text.charAt(j), big) === cls) j++;
+		chunks.push({ start: i, end: j, space: cls === 0 });
+		i = j;
+	}
+	return chunks;
+}
+
+/**
+ * `iw`/`aw`/`iW`/`aW`, line-local like Vim's. `aw` takes the trailing whitespace run, or the
+ * leading one when the word ends the line; starting on whitespace instead takes it plus the
+ * following word.
+ */
+function wordObject(text: string, col: number, around: boolean, big: boolean, count: number): [number, number] | null {
+	const chunks = chunkLine(text, big);
+	if (chunks.length === 0) return null;
+	const last = chunks.length - 1;
+	let first = chunks.findIndex(chunk => col < chunk.end);
+	if (first < 0) first = last;
+	let end = first;
+	if (!around) {
+		end = Math.min(first + count - 1, last);
+	} else if (chunks[first]!.space) {
+		end = Math.min(first + 2 * count - 1, last);
+	} else {
+		for (let n = 0; n < count; n++) {
+			if (n > 0 && end < last) end++;
+			if (end < last && chunks[end + 1]!.space) end++;
+		}
+		if (!chunks[end]!.space && first > 0 && chunks[first - 1]!.space) first--;
+	}
+	return [chunks[first]!.start, chunks[end]!.end];
+}
+
+/**
+ * `i"`/`a"` and friends, line-local like Vim's: quotes pair off left to right, and the cursor
+ * selects the first pair that ends at or after it. `a` swallows the trailing whitespace, or the
+ * leading run when there is none.
+ */
+function quoteObject(text: string, col: number, quote: string, around: boolean): [number, number] | null {
+	const marks: number[] = [];
+	for (let i = 0; i < text.length; i++) {
+		if (text.charAt(i) === "\\") i++;
+		else if (text.charAt(i) === quote) marks.push(i);
+	}
+	for (let p = 0; p + 1 < marks.length; p += 2) {
+		const open = marks[p]!;
+		const close = marks[p + 1]!;
+		if (col > close) continue;
+		if (!around) return [open + 1, close];
+		let end = close + 1;
+		let start = open;
+		while (end < text.length && /\s/.test(text.charAt(end))) end++;
+		if (end === close + 1) while (start > 0 && /\s/.test(text.charAt(start - 1))) start--;
+		return [start, end];
+	}
+	return null;
+}
+
+/** Buffer flattened to one string plus the cursor's offset in it, so scans can cross lines. */
+function flatten(buf: VimBuffer): { text: string; cursor: number } {
+	let cursor = buf.cursorCol;
+	for (let i = 0; i < buf.cursorLine; i++) cursor += (buf.lines[i] ?? "").length + 1;
+	return { text: buf.lines.join("\n"), cursor };
+}
+
+function offsetToPos(lines: readonly string[], offset: number): VimPosition {
+	let remaining = offset;
+	for (let line = 0; line < lines.length; line++) {
+		const width = (lines[line] ?? "").length;
+		if (remaining <= width) return { line, col: remaining };
+		remaining -= width + 1;
+	}
+	const line = Math.max(0, lines.length - 1);
+	return { line, col: (lines[line] ?? "").length };
+}
+
+/**
+ * `i(`/`a{`… — the innermost pair enclosing the cursor, counting nesting and spanning lines. A
+ * cursor sitting on either delimiter counts as being on that pair. Charwise in both variants;
+ * Vim's linewise-ish `i{` reshaping is deliberately not reproduced.
+ */
+function bracketObject(buf: VimBuffer, open: string, close: string, around: boolean): TextObjectRange | null {
+	const { text, cursor } = flatten(buf);
+	let depth = 0;
+	let openAt = -1;
+	for (let i = Math.min(cursor, text.length - 1); i >= 0; i--) {
+		const ch = text.charAt(i);
+		if (ch === close && i !== cursor) depth++;
+		else if (ch === open) {
+			if (depth === 0) {
+				openAt = i;
+				break;
+			}
+			depth--;
+		}
+	}
+	if (openAt < 0) return null;
+	depth = 0;
+	let closeAt = -1;
+	for (let i = openAt + 1; i < text.length; i++) {
+		const ch = text.charAt(i);
+		if (ch === open) depth++;
+		else if (ch === close) {
+			if (depth === 0) {
+				closeAt = i;
+				break;
+			}
+			depth--;
+		}
+	}
+	if (closeAt < 0) return null;
+	const from = offsetToPos(buf.lines, around ? openAt : openAt + 1);
+	const to = offsetToPos(buf.lines, around ? closeAt + 1 : closeAt);
+	return { from, to, linewise: false };
+}
+
+/**
+ * `ip`/`ap`: the run of lines matching the cursor line's blankness. `ap` also takes the run that
+ * follows, or the one before it when the paragraph ends the buffer. Always linewise.
+ */
+function paragraphObject(buf: VimBuffer, around: boolean): TextObjectRange {
+	const last = buf.lines.length - 1;
+	const blank = (line: number): boolean => (buf.lines[line] ?? "").trim() === "";
+	const target = blank(buf.cursorLine);
+	let first = buf.cursorLine;
+	let end = buf.cursorLine;
+	while (first > 0 && blank(first - 1) === target) first--;
+	while (end < last && blank(end + 1) === target) end++;
+	if (around) {
+		const stop = end;
+		while (end < last && blank(end + 1) !== target) end++;
+		if (end === stop) while (first > 0 && blank(first - 1) !== target) first--;
+	}
+	return { from: { line: first, col: 0 }, to: { line: end, col: (buf.lines[end] ?? "").length }, linewise: true };
+}
+
 interface Motion {
 	to: VimPosition;
 	/** Inclusive motions cover the grapheme under `to` when used with an operator. */
@@ -106,6 +269,8 @@ export class VimState {
 	#count = "";
 	#operator: VimOperator | null = null;
 	#pendingG = false;
+	/** `i` or `a` typed after an operator or in Visual mode — waiting for the object key. */
+	#textObject: "i" | "a" | null = null;
 	/**
 	 * Vim's "desired column": `j`/`k` remember the column you started from, so descending through a
 	 * short line and back out returns to it instead of collapsing permanently. `null` means the
@@ -114,18 +279,18 @@ export class VimState {
 	 */
 	#desiredCol: number | null = null;
 
-	/** True while a count, operator, or `g` prefix is half-typed — Escape cancels that first. */
+	/** True while a count, operator, `g`, or text-object prefix is half-typed — Escape cancels it. */
 	get pending(): boolean {
-		return this.#count.length > 0 || this.#operator !== null || this.#pendingG;
+		return this.#count.length > 0 || this.#operator !== null || this.#pendingG || this.#textObject !== null;
 	}
 
 	/**
-	 * The half-typed command as Vim would echo it (`"2"`, `"d"`, `"2d"`, `"g"`) — empty when
+	 * The half-typed command as Vim would echo it (`"2"`, `"d"`, `"2d"`, `"di"`) — empty when
 	 * nothing is pending. Hosts render this next to the mode so a partially entered operator is
 	 * visible instead of silently swallowing the next keystroke.
 	 */
 	get pendingText(): string {
-		return `${this.#count}${this.#operator ?? ""}${this.#pendingG ? "g" : ""}`;
+		return `${this.#count}${this.#operator ?? ""}${this.#pendingG ? "g" : ""}${this.#textObject ?? ""}`;
 	}
 
 	get visual(): boolean {
@@ -143,6 +308,7 @@ export class VimState {
 		this.#count = "";
 		this.#operator = null;
 		this.#pendingG = false;
+		this.#textObject = null;
 	}
 
 	#takeCount(): number {
@@ -185,6 +351,18 @@ export class VimState {
 			this.#desiredCol = null;
 			const line = Math.min(this.#takeCount() - 1, buf.lines.length - 1);
 			return this.#applyMotion(buf, { to: { line, col: 0 }, inclusive: false, linewise: true });
+		}
+
+		if (this.#textObject !== null) {
+			this.#desiredCol = null;
+			return this.#applyTextObject(key, buf);
+		}
+
+		// `i`/`a` only introduce a text object where they cannot mean "insert": after an operator,
+		// or in Visual mode. Bare `i` in Normal mode still enters Insert.
+		if ((key === "i" || key === "a") && (this.#operator !== null || this.visual)) {
+			this.#textObject = key;
+			return [];
 		}
 
 		// Only consecutive `j`/`k` carry the desired column; anything else re-anchors it. Counts and
@@ -257,6 +435,12 @@ export class VimState {
 				return { to: at(line.length), inclusive: false, linewise: false };
 			case "w": {
 				let col = buf.cursorCol;
+				// Vim's `cw` quirk: standing on a non-blank, it changes to the end of the word like
+				// `ce` rather than swallowing the whitespace that follows it.
+				if (this.#operator === "c" && !/\s/.test(line.charAt(col))) {
+					for (let i = 0; i < count; i++) col = wordEnd(line, col);
+					return { to: at(col), inclusive: true, linewise: false };
+				}
 				for (let i = 0; i < count; i++) col = wordForward(line, col);
 				return { to: at(col), inclusive: false, linewise: false };
 			}
@@ -316,9 +500,89 @@ export class VimState {
 				{ kind: "move", to: from },
 			];
 		}
-		const insert = operator === "c";
+		if (operator !== "c") {
+			return [{ kind: "delete", from, to, linewise, insert: false }];
+		}
+		// `c` always lands in Insert mode. The leading move matters when the range is empty
+		// (`ci"` between bare quotes): the delete is a no-op, so nothing else would park the cursor.
 		// `cc`/`cj` clear the lines but keep them, so a linewise change stays linewise-shaped.
-		return [{ kind: "delete", from, to, linewise: linewise && !insert, insert }];
+		this.mode = "insert";
+		return [
+			{ kind: "move", to: from },
+			{ kind: "delete", from, to, linewise: false, insert: true },
+			{ kind: "mode", mode: "insert" },
+		];
+	}
+
+	/** `iw`, `a(`, `i"`, `ap`, … — resolved around the cursor rather than from a motion endpoint. */
+	#resolveTextObject(key: string, around: boolean, buf: VimBuffer, count: number): TextObjectRange | null {
+		const line = buf.lines[buf.cursorLine] ?? "";
+		const onLine = (range: [number, number] | null): TextObjectRange | null =>
+			range === null
+				? null
+				: {
+						from: { line: buf.cursorLine, col: range[0] },
+						to: { line: buf.cursorLine, col: range[1] },
+						linewise: false,
+					};
+
+		switch (key) {
+			case "w":
+			case "W":
+				return onLine(wordObject(line, buf.cursorCol, around, key === "W", count));
+			case '"':
+			case "'":
+			case "`":
+				return onLine(quoteObject(line, buf.cursorCol, key, around));
+			case "(":
+			case ")":
+			case "b":
+				return bracketObject(buf, "(", ")", around);
+			case "[":
+			case "]":
+				return bracketObject(buf, "[", "]", around);
+			case "{":
+			case "}":
+			case "B":
+				return bracketObject(buf, "{", "}", around);
+			case "<":
+			case ">":
+				return bracketObject(buf, "<", ">", around);
+			case "p":
+				return paragraphObject(buf, around);
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Consume the object key that follows a pending `i`/`a`. Under an operator the object becomes
+	 * the operated range (`diw`); in Visual mode it becomes the selection instead (`viw`).
+	 */
+	#applyTextObject(key: string, buf: VimBuffer): VimCommand[] {
+		const around = this.#textObject === "a";
+		const operator = this.#operator;
+		this.#textObject = null;
+		this.#operator = null;
+		const range = this.#resolveTextObject(key, around, buf, this.#takeCount());
+		if (range === null) return [];
+		if (operator !== null) return this.#operate(operator, range.from, range.to, range.linewise);
+
+		this.anchor = range.from;
+		const commands: VimCommand[] = [];
+		// A linewise object in charwise Visual mode promotes the selection, as Vim's `vip` does.
+		if (range.linewise && this.mode === "visual") {
+			this.mode = "visual-line";
+			commands.push({ kind: "mode", mode: this.mode });
+		}
+		// The selection's moving end sits *on* the object's last grapheme, not one past it.
+		let to = range.to;
+		if (to.col > 0) to = { line: to.line, col: prevGraphemeStart(buf.lines[to.line] ?? "", to.col) };
+		else if (to.line > range.from.line)
+			to = { line: to.line - 1, col: lastGraphemeStart(buf.lines[to.line - 1] ?? "") };
+		else to = range.from;
+		commands.push({ kind: "move", to });
+		return commands;
 	}
 
 	#handleNormalKey(key: string, buf: VimBuffer): VimCommand[] | null {
@@ -386,16 +650,12 @@ export class VimState {
 			case "D":
 			case "C": {
 				this.#takeCount();
-				this.mode = key === "C" ? "insert" : this.mode;
-				return [
-					{
-						kind: "delete",
-						from: { line: buf.cursorLine, col: buf.cursorCol },
-						to: { line: buf.cursorLine, col: line.length },
-						linewise: false,
-						insert: key === "C",
-					},
-				];
+				return this.#operate(
+					key === "C" ? "c" : "d",
+					{ line: buf.cursorLine, col: buf.cursorCol },
+					{ line: buf.cursorLine, col: line.length },
+					false,
+				);
 			}
 			case "d":
 			case "y":
@@ -458,9 +718,11 @@ export class VimState {
 				const operator: VimOperator = key === "y" ? "y" : key === "c" || key === "s" ? "c" : "d";
 				const { from, to } = visualRange(buf, anchor, linewise);
 				this.#clearPending();
-				this.mode = operator === "c" ? "insert" : "normal";
 				this.anchor = null;
-				return [...this.#operate(operator, from, to, linewise), { kind: "mode", mode: this.mode }];
+				// `#operate` switches to Insert itself for `c`; everything else drops back to Normal.
+				if (operator !== "c") this.mode = "normal";
+				const commands = this.#operate(operator, from, to, linewise);
+				return operator === "c" ? commands : [...commands, { kind: "mode", mode: "normal" }];
 			}
 			default:
 				this.#clearPending();

--- a/packages/tui/src/vim.ts
+++ b/packages/tui/src/vim.ts
@@ -112,6 +112,15 @@ export class VimState {
 		return this.#count.length > 0 || this.#operator !== null || this.#pendingG;
 	}
 
+	/**
+	 * The half-typed command as Vim would echo it (`"2"`, `"d"`, `"2d"`, `"g"`) — empty when
+	 * nothing is pending. Hosts render this next to the mode so a partially entered operator is
+	 * visible instead of silently swallowing the next keystroke.
+	 */
+	get pendingText(): string {
+		return `${this.#count}${this.#operator ?? ""}${this.#pendingG ? "g" : ""}`;
+	}
+
 	get visual(): boolean {
 		return this.mode === "visual" || this.mode === "visual-line";
 	}

--- a/packages/tui/src/vim.ts
+++ b/packages/tui/src/vim.ts
@@ -649,11 +649,14 @@ export class VimState {
 			}
 			case "D":
 			case "C": {
-				this.#takeCount();
+				// Like Vim, `D`/`C` take a count: `2D` deletes to the end of the next line, not just
+				// this one (`:h D` — "and [count]-1 more lines").
+				const span = this.#takeCount();
+				const last = Math.min(buf.cursorLine + span - 1, buf.lines.length - 1);
 				return this.#operate(
 					key === "C" ? "c" : "d",
 					{ line: buf.cursorLine, col: buf.cursorCol },
-					{ line: buf.cursorLine, col: line.length },
+					{ line: last, col: (buf.lines[last] ?? "").length },
 					false,
 				);
 			}

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -1,0 +1,439 @@
+import { describe, expect, it } from "bun:test";
+import { Editor } from "@oh-my-pi/pi-tui/components/editor";
+import { defaultEditorTheme } from "./test-themes";
+
+const ESC = "\x1b";
+const UP = "\x1b[A";
+const DOWN = "\x1b[B";
+
+function vimEditor(text = "", options: { cursorToStart?: boolean } = {}): Editor {
+	const editor = new Editor(defaultEditorTheme);
+	editor.setVimMode(true);
+	editor.setText(text);
+	// `setText` parks the cursor at the end; most tests want to drive from the top of the buffer.
+	if (options.cursorToStart !== false) {
+		editor.handleInput(ESC);
+		editor.handleInput("g");
+		editor.handleInput("g");
+	}
+	return editor;
+}
+
+/** Buffer offset of the cursor, derived from the rendered CURSOR_MARKER-free text. */
+function cursor(editor: Editor): { line: number; col: number } {
+	const state = editor as unknown as { getCursorPosition?: () => { line: number; col: number } };
+	if (state.getCursorPosition) return state.getCursorPosition();
+	throw new Error("cursor probe unavailable");
+}
+
+describe("Editor vim mode", () => {
+	describe("disabled by default", () => {
+		it("types vim command letters as ordinary text", () => {
+			const editor = new Editor(defaultEditorTheme);
+			for (const key of "hjkldwvyGx") editor.handleInput(key);
+			expect(editor.getText()).toBe("hjkldwvyGx");
+			expect(editor.vimMode).toBe("insert");
+		});
+
+		it("never claims Escape", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("draft");
+			editor.handleInput(ESC);
+			expect(editor.vimConsumesEscape()).toBe(false);
+			expect(editor.getText()).toBe("draft");
+		});
+	});
+
+	describe("mode switching", () => {
+		it("starts in insert mode so typing still works when the setting is flipped on", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setVimMode(true);
+			editor.handleInput("hi");
+			expect(editor.getText()).toBe("hi");
+			expect(editor.vimMode).toBe("insert");
+		});
+
+		it("enters normal mode on Escape and stops inserting text", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setVimMode(true);
+			editor.handleInput("abc");
+			editor.handleInput(ESC);
+			expect(editor.vimMode).toBe("normal");
+			editor.handleInput("z");
+			expect(editor.getText()).toBe("abc");
+		});
+
+		it("hands Escape back to the app once normal mode is quiet", () => {
+			const editor = vimEditor("abc");
+			expect(editor.vimMode).toBe("normal");
+			expect(editor.vimConsumesEscape()).toBe(false);
+		});
+
+		it("claims Escape while a count or operator is half-typed", () => {
+			const editor = vimEditor("abc");
+			editor.handleInput("2");
+			expect(editor.vimConsumesEscape()).toBe(true);
+			editor.handleInput(ESC);
+			expect(editor.vimConsumesEscape()).toBe(false);
+
+			editor.handleInput("d");
+			expect(editor.vimConsumesEscape()).toBe(true);
+		});
+
+		it("returns to insert mode via i/a/I/A", () => {
+			const editor = vimEditor("ab");
+			editor.handleInput("i");
+			expect(editor.vimMode).toBe("insert");
+			editor.handleInput("X");
+			expect(editor.getText()).toBe("Xab");
+
+			editor.handleInput(ESC);
+			editor.handleInput("A");
+			editor.handleInput("Z");
+			expect(editor.getText()).toBe("XabZ");
+		});
+
+		it("opens a line below with o and above with O", () => {
+			const editor = vimEditor("one");
+			editor.handleInput("o");
+			editor.handleInput("two");
+			expect(editor.getText()).toBe("one\ntwo");
+
+			editor.handleInput(ESC);
+			editor.handleInput("O");
+			editor.handleInput("mid");
+			expect(editor.getText()).toBe("one\nmid\ntwo");
+		});
+	});
+
+	describe("motions", () => {
+		it("moves with h/j/k/l without editing the buffer", () => {
+			const editor = vimEditor("alfa\nbeta");
+			for (const key of "lljhk") editor.handleInput(key);
+			expect(editor.getText()).toBe("alfa\nbeta");
+		});
+
+		it("0 and $ jump to the line edges", () => {
+			const editor = vimEditor("alfa beta");
+			editor.handleInput("$");
+			editor.handleInput("a");
+			editor.handleInput("!");
+			expect(editor.getText()).toBe("alfa beta!");
+
+			editor.handleInput(ESC);
+			editor.handleInput("0");
+			editor.handleInput("i");
+			editor.handleInput(">");
+			expect(editor.getText()).toBe(">alfa beta!");
+		});
+
+		it("w lands on the start of the next word", () => {
+			const editor = vimEditor("alfa beta gamma");
+			editor.handleInput("w");
+			editor.handleInput("i");
+			editor.handleInput("<");
+			expect(editor.getText()).toBe("alfa <beta gamma");
+		});
+
+		it("b steps back to the start of the previous word", () => {
+			const editor = vimEditor("alfa beta gamma");
+			editor.handleInput("w");
+			editor.handleInput("w");
+			editor.handleInput("b");
+			editor.handleInput("i");
+			editor.handleInput(">");
+			expect(editor.getText()).toBe("alfa >beta gamma");
+		});
+
+		it("applies a count prefix to a motion", () => {
+			const editor = vimEditor("alfa beta gamma delta");
+			editor.handleInput("3");
+			editor.handleInput("w");
+			editor.handleInput("i");
+			editor.handleInput("|");
+			expect(editor.getText()).toBe("alfa beta gamma |delta");
+		});
+
+		it("gg and G jump to the buffer edges", () => {
+			const editor = vimEditor("one\ntwo\nthree");
+			editor.handleInput("G");
+			editor.handleInput("A");
+			editor.handleInput("!");
+			expect(editor.getText()).toBe("one\ntwo\nthree!");
+
+			editor.handleInput(ESC);
+			editor.handleInput("g");
+			editor.handleInput("g");
+			editor.handleInput("I");
+			editor.handleInput(">");
+			expect(editor.getText()).toBe(">one\ntwo\nthree!");
+		});
+
+		it("k on the first line moves the cursor instead of loading prompt history", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.addToHistory("an older prompt");
+			editor.setVimMode(true);
+			editor.setText("current draft");
+			editor.handleInput(ESC);
+			editor.handleInput("k");
+			editor.handleInput("k");
+			expect(editor.getText()).toBe("current draft");
+		});
+
+		it("arrow keys act as motions in normal mode and never browse history", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.addToHistory("an older prompt");
+			editor.setVimMode(true);
+			editor.setText("current draft");
+			editor.handleInput(ESC);
+			editor.handleInput(UP);
+			editor.handleInput(DOWN);
+			expect(editor.getText()).toBe("current draft");
+		});
+
+		it("backspace moves left in normal mode rather than deleting", () => {
+			const editor = vimEditor("alfa", { cursorToStart: false });
+			editor.handleInput(ESC);
+			editor.handleInput("\x7f");
+			expect(editor.getText()).toBe("alfa");
+		});
+	});
+
+	describe("normal-mode edits", () => {
+		it("x deletes the character under the cursor", () => {
+			const editor = vimEditor("abcd");
+			editor.handleInput("x");
+			expect(editor.getText()).toBe("bcd");
+			editor.handleInput("2");
+			editor.handleInput("x");
+			expect(editor.getText()).toBe("d");
+		});
+
+		it("D deletes to end of line and C changes to end of line", () => {
+			const editor = vimEditor("alfa beta");
+			editor.handleInput("w");
+			editor.handleInput("D");
+			expect(editor.getText()).toBe("alfa ");
+
+			editor.handleInput("0");
+			editor.handleInput("C");
+			expect(editor.vimMode).toBe("insert");
+			editor.handleInput("new");
+			expect(editor.getText()).toBe("new");
+		});
+
+		it("dw deletes a word and dd deletes a line", () => {
+			const editor = vimEditor("alfa beta\nsecond line");
+			editor.handleInput("d");
+			editor.handleInput("w");
+			expect(editor.getText()).toBe("beta\nsecond line");
+
+			editor.handleInput("d");
+			editor.handleInput("d");
+			expect(editor.getText()).toBe("second line");
+		});
+
+		it("u undoes the previous edit", () => {
+			const editor = vimEditor("alfa beta");
+			editor.handleInput("d");
+			editor.handleInput("w");
+			expect(editor.getText()).toBe("beta");
+			editor.handleInput("u");
+			expect(editor.getText()).toBe("alfa beta");
+		});
+
+		it("yy then p duplicates a line", () => {
+			const editor = vimEditor("alfa\nbeta");
+			editor.handleInput("y");
+			editor.handleInput("y");
+			editor.handleInput("p");
+			expect(editor.getText()).toBe("alfa\nalfa\nbeta");
+		});
+	});
+
+	describe("visual mode", () => {
+		it("v + motion + d deletes the selection", () => {
+			const editor = vimEditor("alfa beta");
+			editor.handleInput("v");
+			expect(editor.vimMode).toBe("visual");
+			for (let i = 0; i < 4; i++) editor.handleInput("l");
+			editor.handleInput("d");
+			expect(editor.getText()).toBe("beta");
+			expect(editor.vimMode).toBe("normal");
+		});
+
+		it("v + motion + y copies without changing the buffer", () => {
+			const yanked: string[] = [];
+			const editor = vimEditor("alfa beta");
+			editor.onYank = text => yanked.push(text);
+			editor.handleInput("v");
+			for (let i = 0; i < 3; i++) editor.handleInput("l");
+			editor.handleInput("y");
+			expect(editor.getText()).toBe("alfa beta");
+			expect(yanked).toEqual(["alfa"]);
+			expect(editor.vimMode).toBe("normal");
+		});
+
+		it("yanked text comes back through p", () => {
+			const editor = vimEditor("alfa beta");
+			editor.handleInput("v");
+			for (let i = 0; i < 3; i++) editor.handleInput("l");
+			editor.handleInput("y");
+			editor.handleInput("$");
+			editor.handleInput("p");
+			expect(editor.getText()).toBe("alfa betaalfa");
+		});
+
+		it("selects across lines and deletes the joined range", () => {
+			const editor = vimEditor("alfa\nbeta\ngamma");
+			editor.handleInput("v");
+			editor.handleInput("j");
+			// Charwise selection is inclusive of the grapheme under the cursor, so this covers
+			// "alfa\nb" and the surviving halves join.
+			editor.handleInput("d");
+			expect(editor.getText()).toBe("eta\ngamma");
+		});
+
+		it("V selects whole lines", () => {
+			const editor = vimEditor("alfa\nbeta\ngamma");
+			editor.handleInput("l");
+			editor.handleInput("V");
+			expect(editor.vimMode).toBe("visual-line");
+			editor.handleInput("j");
+			editor.handleInput("d");
+			expect(editor.getText()).toBe("gamma");
+		});
+
+		it("Escape leaves visual mode without editing", () => {
+			const editor = vimEditor("alfa beta");
+			editor.handleInput("v");
+			editor.handleInput("l");
+			expect(editor.vimConsumesEscape()).toBe(true);
+			editor.handleInput(ESC);
+			expect(editor.vimMode).toBe("normal");
+			expect(editor.getText()).toBe("alfa beta");
+		});
+
+		it("renders the selection in reverse video", () => {
+			const editor = vimEditor("alfa beta");
+			editor.handleInput("v");
+			for (let i = 0; i < 3; i++) editor.handleInput("l");
+			const frame = editor.render(40).join("\n");
+			expect(frame).toContain("\x1b[7malfa\x1b[27m");
+		});
+
+		it("highlights the newline when the selection runs onto the next line", () => {
+			const editor = vimEditor("alfa\nbeta");
+			editor.handleInput("v");
+			editor.handleInput("j");
+			const frame = editor.render(40).join("\n");
+			// The first row keeps its whole text plus a highlighted cell standing in for the newline.
+			expect(frame).toContain("\x1b[7malfa\x1b[27m\x1b[7m \x1b[27m");
+			// The second row highlights only the grapheme under the cursor.
+			expect(frame).toContain("\x1b[7mb\x1b[27m");
+		});
+
+		it("renders an empty buffer without a selection artifact", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setVimMode(true);
+			editor.handleInput(ESC);
+			editor.handleInput("v");
+			expect(() => editor.render(40)).not.toThrow();
+		});
+	});
+
+	describe("batched input", () => {
+		it("replays a multi-key run as separate commands", () => {
+			const editor = vimEditor("alfa beta gamma");
+			// Batched stdin can deliver a whole run at once; each grapheme is still one command.
+			editor.handleInput("wwx");
+			expect(editor.getText()).toBe("alfa beta amma");
+		});
+
+		it("types the tail of a run that switched back to insert mode", () => {
+			const editor = vimEditor("xyz");
+			editor.handleInput("iabc");
+			expect(editor.getText()).toBe("abcxyz");
+			expect(editor.vimMode).toBe("insert");
+		});
+	});
+
+	describe("autocomplete", () => {
+		it("spends the first Escape dismissing the popup, the second leaving insert mode", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setVimMode(true);
+			const { promise: shown, resolve: resolveShown } = Promise.withResolvers<void>();
+			editor.setAutocompleteProvider({
+				async getSuggestions() {
+					return { items: [{ label: "/help", value: "/help" }], prefix: "/" };
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+			editor.onAutocompleteUpdate = resolveShown;
+
+			editor.handleInput("/");
+			await shown;
+			expect(editor.isShowingAutocomplete()).toBe(true);
+
+			editor.handleInput(ESC);
+			expect(editor.isShowingAutocomplete()).toBe(false);
+			expect(editor.vimMode).toBe("insert");
+
+			editor.handleInput(ESC);
+			expect(editor.vimMode).toBe("normal");
+		});
+	});
+
+	describe("protected regions", () => {
+		it("a visual delete that clips an atomic token removes the whole token", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.atomicTokenPattern = /\[Image #\d+, \d+x\d+\]/g;
+			editor.setVimMode(true);
+			editor.setText("see [Image #1, 800x600] here");
+			editor.handleInput(ESC);
+			editor.handleInput("g");
+			editor.handleInput("g");
+			// Select "see [Ima" — the tail lands inside the placeholder.
+			editor.handleInput("v");
+			for (let i = 0; i < 7; i++) editor.handleInput("l");
+			editor.handleInput("d");
+			// The partially covered token went with it rather than leaving a corrupt fragment.
+			expect(editor.getText()).toBe(" here");
+		});
+
+		it("x never splits an atomic token", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.atomicTokenPattern = /\[Image #\d+, \d+x\d+\]/g;
+			editor.setVimMode(true);
+			editor.setText("[Image #1, 800x600]!");
+			editor.handleInput(ESC);
+			editor.handleInput("g");
+			editor.handleInput("g");
+			editor.handleInput("x");
+			expect(editor.getText()).toBe("!");
+		});
+	});
+
+	describe("toggling the setting", () => {
+		it("drops back to insert mode so typing always works after a toggle", () => {
+			const editor = vimEditor("alfa");
+			expect(editor.vimMode).toBe("normal");
+			// `gg` left the cursor at the head of the buffer, so plain typing inserts there.
+			editor.setVimMode(false);
+			expect(editor.vimMode).toBe("insert");
+			editor.handleInput("x");
+			expect(editor.getText()).toBe("xalfa");
+
+			editor.setVimMode(true);
+			expect(editor.vimMode).toBe("insert");
+			editor.handleInput("y");
+			expect(editor.getText()).toBe("xyalfa");
+		});
+	});
+});
+
+// Keep the helper referenced so an unused-import lint never fires while it stays available
+// for future cursor-position assertions.
+void cursor;

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -231,6 +231,25 @@ describe("Editor vim mode", () => {
 			expect(editor.getText()).toBe("second line");
 		});
 
+		it("cw changes to the end of the word and enters insert mode", () => {
+			const editor = vimEditor("alfa beta");
+			editor.handleInput("c");
+			editor.handleInput("w");
+			expect(editor.vimMode).toBe("insert");
+			editor.handleInput("new");
+			// `cw` on a non-blank behaves like `ce`, so the separating space survives.
+			expect(editor.getText()).toBe("new beta");
+		});
+
+		it("cc clears the line and enters insert mode", () => {
+			const editor = vimEditor("alfa beta\nsecond");
+			editor.handleInput("c");
+			editor.handleInput("c");
+			expect(editor.vimMode).toBe("insert");
+			editor.handleInput("fresh");
+			expect(editor.getText()).toBe("fresh\nsecond");
+		});
+
 		it("u undoes the previous edit", () => {
 			const editor = vimEditor("alfa beta");
 			editor.handleInput("d");
@@ -246,6 +265,105 @@ describe("Editor vim mode", () => {
 			editor.handleInput("y");
 			editor.handleInput("p");
 			expect(editor.getText()).toBe("alfa\nalfa\nbeta");
+		});
+	});
+
+	describe("text objects", () => {
+		it("diw deletes the word under the cursor instead of entering insert mode", () => {
+			const editor = vimEditor("alfa beta gamma");
+			editor.handleInput("w");
+			editor.handleInput("d");
+			editor.handleInput("i");
+			expect(editor.vimMode).toBe("normal");
+			editor.handleInput("w");
+			expect(editor.getText()).toBe("alfa  gamma");
+			expect(editor.vimMode).toBe("normal");
+		});
+
+		it("daw takes the trailing whitespace with the word", () => {
+			const editor = vimEditor("alfa beta gamma");
+			editor.handleInput("w");
+			for (const key of "daw") editor.handleInput(key);
+			expect(editor.getText()).toBe("alfa gamma");
+		});
+
+		it("daw falls back to the leading whitespace at the end of a line", () => {
+			const editor = vimEditor("alfa beta");
+			editor.handleInput("w");
+			for (const key of "daw") editor.handleInput(key);
+			expect(editor.getText()).toBe("alfa");
+		});
+
+		it("a counted aw takes that many words", () => {
+			const editor = vimEditor("alfa beta gamma");
+			for (const key of "d2aw") editor.handleInput(key);
+			expect(editor.getText()).toBe("gamma");
+		});
+
+		it("ciw replaces the word and enters insert mode", () => {
+			const editor = vimEditor("alfa beta");
+			for (const key of "ciw") editor.handleInput(key);
+			expect(editor.vimMode).toBe("insert");
+			editor.handleInput("x");
+			expect(editor.getText()).toBe("x beta");
+		});
+
+		it("iw and aw over quoted spans", () => {
+			const inner = vimEditor('say "hello there" now');
+			for (const key of 'di"') inner.handleInput(key);
+			expect(inner.getText()).toBe('say "" now');
+
+			const around = vimEditor('say "hello there" now');
+			for (const key of 'da"') around.handleInput(key);
+			expect(around.getText()).toBe("say now");
+		});
+
+		it('ci" parks the cursor between empty quotes', () => {
+			const editor = vimEditor('say "" now');
+			for (const key of 'ci"') editor.handleInput(key);
+			expect(editor.vimMode).toBe("insert");
+			editor.handleInput("hi");
+			expect(editor.getText()).toBe('say "hi" now');
+		});
+
+		it("di( takes the innermost pair around the cursor", () => {
+			const editor = vimEditor("call(one, nest(two), three)");
+			for (let i = 0; i < 15; i++) editor.handleInput("l");
+			for (const key of "di(") editor.handleInput(key);
+			expect(editor.getText()).toBe("call(one, nest(), three)");
+		});
+
+		it("da{ spans the lines the block covers", () => {
+			const editor = vimEditor("fn {\n  body\n}\ntail");
+			editor.handleInput("j");
+			for (const key of "da{") editor.handleInput(key);
+			expect(editor.getText()).toBe("fn \ntail");
+		});
+
+		it("dip deletes the paragraph under the cursor linewise", () => {
+			const editor = vimEditor("one\ntwo\n\nthree");
+			for (const key of "dip") editor.handleInput(key);
+			expect(editor.getText()).toBe("\nthree");
+		});
+
+		it("viw selects the word so the next operator applies to it", () => {
+			const editor = vimEditor("alfa beta");
+			for (const key of "viw") editor.handleInput(key);
+			expect(editor.vimMode).toBe("visual");
+			editor.handleInput("d");
+			expect(editor.getText()).toBe(" beta");
+		});
+
+		it("echoes the half-typed object and cancels it with Escape", () => {
+			const editor = vimEditor("alfa beta");
+			editor.handleInput("d");
+			editor.handleInput("i");
+			expect(editor.vimPending).toBe("di");
+			expect(editor.vimConsumesEscape()).toBe(true);
+			editor.handleInput(ESC);
+			expect(editor.vimPending).toBe("");
+			editor.handleInput("w");
+			expect(editor.getText()).toBe("alfa beta");
 		});
 	});
 

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -432,6 +432,64 @@ describe("Editor vim mode", () => {
 			expect(editor.getText()).toBe("xyalfa");
 		});
 	});
+
+	describe("mode chrome", () => {
+		it("reports the half-typed command so hosts can echo it", () => {
+			const editor = vimEditor("alfa bravo charlie");
+			expect(editor.vimPending).toBe("");
+			editor.handleInput("2");
+			expect(editor.vimPending).toBe("2");
+			editor.handleInput("d");
+			expect(editor.vimPending).toBe("2d");
+			editor.handleInput(ESC);
+			expect(editor.vimPending).toBe("");
+		});
+
+		it("reports the Visual selection height as it grows", () => {
+			const editor = vimEditor("one\ntwo\nthree");
+			expect(editor.vimSelectedLines).toBe(0);
+			editor.handleInput("V");
+			expect(editor.vimSelectedLines).toBe(1);
+			editor.handleInput("j");
+			expect(editor.vimSelectedLines).toBe(2);
+			editor.handleInput(ESC);
+			expect(editor.vimSelectedLines).toBe(0);
+		});
+
+		it("notifies on pending and selection changes, not just mode switches", () => {
+			const editor = vimEditor("one\ntwo\nthree");
+			const seen: string[] = [];
+			editor.onVimModeChange = () => seen.push(`${editor.vimMode}:${editor.vimPending}:${editor.vimSelectedLines}`);
+
+			editor.handleInput("2"); // pending only — mode unchanged
+			editor.handleInput(ESC); // pending cleared — mode unchanged
+			editor.handleInput("V"); // mode switch
+			editor.handleInput("j"); // selection grows — mode and pending unchanged
+
+			expect(seen).toEqual(["normal:2:0", "normal::0", "visual-line::1", "visual-line::2"]);
+		});
+
+		it("draws a block cursor in Normal and an underline cursor in Insert", () => {
+			const editor = vimEditor("alfa");
+			editor.focused = true;
+			expect(editor.render(20).join("\n")).toContain("\x1b[7m");
+
+			editor.handleInput("i");
+			expect(editor.vimMode).toBe("insert");
+			const insertFrame = editor.render(20).join("\n");
+			expect(insertFrame).toContain("\x1b[4m");
+			expect(insertFrame).not.toContain("\x1b[7m");
+		});
+
+		it("keeps the reverse-video cursor for non-modal editors", () => {
+			const editor = new Editor(defaultEditorTheme);
+			editor.setText("alfa");
+			editor.focused = true;
+			const frame = editor.render(20).join("\n");
+			expect(frame).not.toContain("\x1b[4m");
+			expect(editor.vimEnabled).toBe(false);
+		});
+	});
 });
 
 // Keep the helper referenced so an unused-import lint never fires while it stays available

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -19,11 +19,9 @@ function vimEditor(text = "", options: { cursorToStart?: boolean } = {}): Editor
 	return editor;
 }
 
-/** Buffer offset of the cursor, derived from the rendered CURSOR_MARKER-free text. */
+/** Cursor position, via the editor's public accessor. */
 function cursor(editor: Editor): { line: number; col: number } {
-	const state = editor as unknown as { getCursorPosition?: () => { line: number; col: number } };
-	if (state.getCursorPosition) return state.getCursorPosition();
-	throw new Error("cursor probe unavailable");
+	return editor.getCursor();
 }
 
 describe("Editor vim mode", () => {
@@ -490,8 +488,56 @@ describe("Editor vim mode", () => {
 			expect(editor.vimEnabled).toBe(false);
 		});
 	});
-});
 
-// Keep the helper referenced so an unused-import lint never fires while it stays available
-// for future cursor-position assertions.
-void cursor;
+	describe("desired column across vertical motions", () => {
+		// Vim remembers the column you left, so passing over a short line does not permanently
+		// collapse it. The middle line is deliberately shorter than the cursor column.
+		const buf = "alfa bravo charlie\nxy\ndelta echo foxtrot";
+
+		it("restores the column after descending through a shorter line", () => {
+			const editor = vimEditor(buf);
+			for (let i = 0; i < 12; i++) editor.handleInput("l");
+			expect(cursor(editor)).toEqual({ line: 0, col: 12 });
+
+			editor.handleInput("j");
+			// Clamped to the short line, but the desired column is remembered.
+			expect(cursor(editor)).toEqual({ line: 1, col: 1 });
+
+			editor.handleInput("j");
+			expect(cursor(editor)).toEqual({ line: 2, col: 12 });
+		});
+
+		it("re-anchors the column after a horizontal motion", () => {
+			const editor = vimEditor(buf);
+			for (let i = 0; i < 12; i++) editor.handleInput("l");
+			editor.handleInput("j");
+			// `0` is a horizontal motion, so the remembered column is dropped.
+			editor.handleInput("0");
+			editor.handleInput("j");
+			expect(cursor(editor)).toEqual({ line: 2, col: 0 });
+		});
+
+		it("keeps the column across a counted vertical motion", () => {
+			const editor = vimEditor(buf);
+			for (let i = 0; i < 12; i++) editor.handleInput("l");
+			editor.handleInput("j");
+			// The count prefix must not clear the column `j` established.
+			editor.handleInput("1");
+			editor.handleInput("j");
+			expect(cursor(editor)).toEqual({ line: 2, col: 12 });
+		});
+
+		it("makes `$` a sticky end-of-line column", () => {
+			const editor = vimEditor(buf);
+			editor.handleInput("$");
+			expect(cursor(editor)).toEqual({ line: 0, col: 17 });
+
+			editor.handleInput("j");
+			expect(cursor(editor)).toEqual({ line: 1, col: 1 });
+
+			// Not the 17 from line 0 — the end of *this* line.
+			editor.handleInput("j");
+			expect(cursor(editor)).toEqual({ line: 2, col: 17 });
+		});
+	});
+});

--- a/packages/tui/test/editor-vim.test.ts
+++ b/packages/tui/test/editor-vim.test.ts
@@ -220,6 +220,22 @@ describe("Editor vim mode", () => {
 			expect(editor.getText()).toBe("new");
 		});
 
+		it("D and C honor a count across lines", () => {
+			const deleter = vimEditor("alfa beta\ngamma delta\nepsilon");
+			deleter.handleInput("w");
+			deleter.handleInput("2");
+			deleter.handleInput("D");
+			expect(deleter.getText()).toBe("alfa \nepsilon");
+
+			const changer = vimEditor("alfa beta\ngamma delta\nepsilon");
+			changer.handleInput("w");
+			changer.handleInput("2");
+			changer.handleInput("C");
+			expect(changer.vimMode).toBe("insert");
+			changer.handleInput("new");
+			expect(changer.getText()).toBe("alfa new\nepsilon");
+		});
+
 		it("dw deletes a word and dd deletes a line", () => {
 			const editor = vimEditor("alfa beta\nsecond line");
 			editor.handleInput("d");


### PR DESCRIPTION
I like this project and wanted to contribute this feature: I reviewed the full diff
and have been using this vim mode myself since I implemented it (rebasing it onto
upstream constantly), so it is exercised daily on my own machine.

## What

Adds an opt-in Vim-style modal editing layer to the prompt (`tui.vimMode`, off by
default) and makes the mode visible.

- **Modal editing** — Insert / Normal / Visual / Visual-Line. Normal has `hjkl`, `0`,
  `^`, `$`, `w`, `b`, `e`, `gg`, `G`, count prefixes, `x`/`D`/`C`, `dd`/`yy`, `p`/`P`
  and `u`; `v`/`V` start a Visual selection that `y` copies and `d` deletes.
- **Text objects** — `iw`/`aw` (and `W`), quotes `i"`/`a'`/`` a` ``, bracket pairs
  `i(`/`a{`/`i[`/`a<` (nesting-aware, multi-line), and paragraphs `ip`/`ap`. They work
  under an operator (`diw`, `ca(`, `dap`) and in Visual mode (`viw`), with counts
  (`d2aw`). `c` now actually enters Insert mode (`cw`, `cip`, `c` in Visual), follows
  Vim's `cw`-acts-like-`ce` quirk, and parks the cursor correctly when the changed
  range is empty (`ci"` between bare quotes).
- **Mode indicator** — a `vim` status-line segment showing the mode, the half-typed
  command beside it (Vim's `showcmd`, e.g. `2d`), and the Visual selection height
  (`V-LINE 4L`). Hidden entirely when `tui.vimMode` is off, so nothing changes for
  everyone else.
- **`tui.vimModeDisplay`** (`text` / `icon` / `none`) picks the presentation. The
  `icon` display resolves through the theme symbol map, so it follows the active
  symbol preset (nerd / unicode / ascii) and honours per-theme `symbols` overrides
  like every other status-line icon.
- **Cursor shape** tracks the mode: block in Normal/Visual, thin/underline in Insert,
  for the software cursor and for the real terminal cursor (DECSCUSR) under
  `PI_HARDWARE_CURSOR`. `Terminal.setCursorShape()` restores the user's configured
  shape on teardown and on the crash path, so a Normal-mode block can't outlive the
  session in their shell.
- **Prompt border** now colors Insert (green). Normal and Visual were already colored,
  so Insert fell through to the session accent — on themes whose accent matches it,
  Insert and Normal were byte-identical.
- Toggling `tui.vimMode` / `tui.vimModeDisplay` in `/settings` applies immediately
  instead of requiring a restart, through the existing `handleSettingChange`
  live-apply path.

## Why

Implements #3299. That issue's discussion left three questions for a maintainer; how
this PR answers them, so they're easy to accept or reject:

1. **Where does the toggle live?** A persisted setting (`tui.vimMode`), exposed in
   `/settings` under Input, off by default. No install-time prompt, no slash command.
2. **Mode indicator.** Status-line segment as the primary signal, plus border color and
   cursor shape. The thread noted DECSCUSR isn't universally honored, so it is only an
   additional signal under `PI_HARDWARE_CURSOR` — never the only one.
3. **Collision with existing keybindings.** Normal mode claims printable graphemes,
   navigation keys, and Escape. Control chords carry no printable text and stay with
   the host, so the configurable `AppKeybinding`s keep working in Normal. An open
   autocomplete popup gets the first Escape (dismiss); a second switches mode.

## Testing

`bun check` clean. Vim/status-line/theme suites pass (228 tests across the vim, custom-editor-vim and status-line files). Full `packages/tui`
and `packages/coding-agent` suites show **zero new failures** versus `upstream/main`
(5 and 2 pre-existing failures respectively, identical before and after).

Exercised end to end in a real PTY, driving keystrokes and reading the rendered bytes
back off the wire:

- Typed text, then Escape → indicator `INSERT` → `NORMAL`; typed `2d` → `NORMAL 2d`;
  Escape cancels the pending operator; `V` → `V-LINE`.
- Icon display, per symbol preset, captured from the rendered frame:
  Insert `U+F246`, Normal `U+F0C8`, Visual `U+F06E`, V-Line `U+F0C9` under `nerd`;
  `▎ ■ ◉ ≡` under unicode; `I N V L` under ascii. All width-1, so column math is
  unchanged.
- Border color, captured as raw SGR: Insert `rgb(0,255,136)` green vs Normal
  `rgb(0,180,255)` — previously both were the session accent and byte-identical.
- Cursor shape traced through a stdout tap: `CSI 6 q` (bar/Insert) → `CSI 2 q`
  (block/Normal) → `CSI 0 q` on exit, confirming the shape is handed back.
- Toggled `tui.vimMode` off and on again from `/settings` mid-session and confirmed the
  indicator and modal keys follow without a restart.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

---

## Visual examples

Normal mode
<img width="374" height="53" alt="image" src="https://github.com/user-attachments/assets/5041fd77-d8f9-4aea-a237-8aa7a4552269" />

Insert mode
<img width="366" height="54" alt="image" src="https://github.com/user-attachments/assets/60b4b1f6-7a46-4572-bbe4-21d0de23d129" />

Visual mode
<img width="362" height="49" alt="image" src="https://github.com/user-attachments/assets/9d832e0e-ed7b-42b2-b708-bfc4b50fc14b" />

Setting options
<img width="350" height="129" alt="image" src="https://github.com/user-attachments/assets/17eb7f73-7464-43fb-b8ef-97852ed89c7f" />

Mode indicatiors
<img width="848" height="206" alt="image" src="https://github.com/user-attachments/assets/465644f6-12f7-4107-8acb-6a2ea343b45c" />

Icon modes
<img width="309" height="51" alt="image" src="https://github.com/user-attachments/assets/e3473488-222f-470a-92f9-d18ffb559f18" />
<img width="310" height="55" alt="image" src="https://github.com/user-attachments/assets/878ba849-13e4-476b-972d-470366ec8439" />
<img width="312" height="53" alt="image" src="https://github.com/user-attachments/assets/91efcc75-64c4-42f8-b7df-747c2b3c03e3" />



