### PR TITLE
fix(model-hub): separate status glyph from role label

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `nerd`-preset role chips overhanging into the label and swallowing its first character (`efault` instead of `default`) by inserting a separator after the status glyph in the model browser and model hub ([#7664](https://github.com/can1357/oh-my-pi/issues/7664)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/model-browser.ts
+++ b/packages/coding-agent/src/modes/components/model-browser.ts
@@ -254,8 +254,16 @@ export function thinkingLevelGlyph(level: ConfiguredThinkingLevel): string {
 }
 
 /**
- * A slim role chip: `●default ◉` — solid dot for configured assignments,
+ * A slim role chip: `● default ◉` — solid dot for configured assignments,
  * hollow for auto-selected fallbacks, thinking glyph attached when set.
+ *
+ * The space after the status glyph is load-bearing. Under the `nerd` preset
+ * these are Nerd Font private-use icons (U+F111 / U+F10C) whose glyphs are
+ * drawn two cells wide, while `visibleWidth` counts them as one
+ * (`ambiguousIsNarrow: true` in tui/utils.ts — the PUA block is
+ * East_Asian_Width=Ambiguous). Without a separator the icon overhangs and
+ * eats the label's first character (`● default` renders as `●efault`).
+ * Mirrors the spacing already used for `status.success` in model-hub.
  */
 export function formatRoleChip(role: string, assignment: RoleAssignment, settings: Settings): string {
 	const info = getRoleInfo(role, settings);
@@ -263,9 +271,9 @@ export function formatRoleChip(role: string, assignment: RoleAssignment, setting
 	const glyph = thinkingLevelGlyph(assignment.thinkingLevel);
 	const suffix = glyph ? ` ${theme.fg("dim", glyph)}` : "";
 	if (assignment.autoSelected) {
-		return theme.fg("dim", `${theme.status.shadowed}${label}`) + suffix;
+		return theme.fg("dim", `${theme.status.shadowed} ${label}`) + suffix;
 	}
-	return theme.fg(info.color ?? "muted", `${theme.status.enabled}${label}`) + suffix;
+	return theme.fg(info.color ?? "muted", `${theme.status.enabled} ${label}`) + suffix;
 }
 
 /** `$in/out` per-million cost pair; `free` when both legs are zero. */

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -837,7 +837,10 @@ export class ModelHubComponent implements Component {
 				chips.push({
 					label,
 					styled: assignedHere
-						? theme.fg(info.color ?? "muted", `${theme.status.enabled}${label}`) +
+						? // Separator required: under the `nerd` preset this glyph is a
+							// two-cell-wide PUA icon that `visibleWidth` counts as one, so
+							// without it the icon overhangs and eats `label`'s first char.
+							theme.fg(info.color ?? "muted", `${theme.status.enabled} ${label}`) +
 							theme.fg("dim", ` ${theme.status.success}`)
 						: theme.fg(info.color ?? "muted", label),
 					role,

--- a/packages/coding-agent/test/model-hub.test.ts
+++ b/packages/coding-agent/test/model-hub.test.ts
@@ -167,11 +167,11 @@ describe("ModelHub", () => {
 			installTestTheme();
 
 			const rendered = normalize(hub.render(220));
-			expect(rendered).toContain("●default");
-			expect(rendered).toContain("●custom-fast");
+			expect(rendered).toContain("● default");
+			expect(rendered).toContain("● custom-fast");
 			// Explicit :low suffix surfaces as the low thinking glyph on the chip.
 			expect(rendered).toContain("◔");
-			expect(rendered).toContain("●smol");
+			expect(rendered).toContain("● smol");
 		});
 
 		test("list rows carry no role chips; only the selected model's detail line is tagged", () => {
@@ -185,9 +185,9 @@ describe("ModelHub", () => {
 			// Auto-selection tags smol → haiku and slow → codex, but only the
 			// selected model's chips render (in the detail line). With row
 			// chips both would appear at once.
-			const hollow = ["○smol", "○slow"].filter(chip => rendered.includes(chip));
+			const hollow = ["○ smol", "○ slow"].filter(chip => rendered.includes(chip));
 			expect(hollow).toHaveLength(1);
-			expect(rendered).not.toContain("●smol");
+			expect(rendered).not.toContain("● smol");
 		});
 
 		test("roles view reflects auto thinking from defaultThinkingLevel and :auto suffixes", () => {
@@ -446,7 +446,7 @@ describe("ModelHub", () => {
 				expect(settings.getProjectModelRole("default")).toBe(selector);
 
 				const projectDefault = createHub({ models: [model], scoped: true, settings });
-				expect(normalize(projectDefault.hub.render(220))).toContain("○smol");
+				expect(normalize(projectDefault.hub.render(220))).toContain("○ smol");
 				projectDefault.hub.handleInput("\n");
 				projectDefault.hub.handleInput("\n");
 				expect(projectDefault.onUnassign).toHaveBeenCalledWith("default", "project");
@@ -484,7 +484,7 @@ describe("ModelHub", () => {
 			const model = makeModel("test", "claude-haiku-4.5");
 			const settings = Settings.isolated({ modelRoleStorage: "project" });
 			const { hub, onAssign, onUnassign } = createHub({ models: [model], scoped: true, settings });
-			expect(normalize(hub.render(220))).toContain("○smol");
+			expect(normalize(hub.render(220))).toContain("○ smol");
 
 			hub.handleInput("\n");
 			hub.handleInput(DOWN);


### PR DESCRIPTION
Fixes #7664.

## Problem

With `symbolPreset: nerd`, role chips render as `efault` / `ision` / `lan` / `ask` / `dvisor` — the status glyph eats the label's first character.

`status.enabled` / `status.shadowed` are Nerd Font private-use icons (U+F111 / U+F10C). Their glyphs are drawn two cells wide, but `visibleWidth` counts them as one: `packages/tui/src/utils.ts:236` pins `ambiguousIsNarrow: true`, and the PUA block is `East_Asian_Width=Ambiguous`. With no separator the icon overhangs into the next cell.

## Why this is the separator and not the glyph

`model-hub.ts` had both forms on one line — the space-prefixed `status.success` renders correctly, the bare `status.enabled` does not. Non-PUA symbols in the same table (`status.success` U+2714, `status.error` U+2718, `status.running` U+27F3) are all `EAW=N` and unaffected.

## Change

Add the separator at the two call sites, matching the spacing already used for `status.success`:

- `model-browser.ts` — `formatRoleChip`, both the assigned and auto-selected branches
- `model-hub.ts` — the assigned-here chip

Comments at both sites record why the space is load-bearing, so it does not get "tidied up" later.

## Scope

This is the minimal fix for the two visible regressions. The complete fix — extending the existing Hangul-Compatibility-Jamo width-correction mechanism (`utils.ts:238-268`) to the PUA range so every `theme.symbol()` consumer measures correctly — is described in #7664 and deliberately left out: it reaches into `pi-natives`, and I would rather agree on the shape first.

## Verification

- `bun run check:ts` — all workspaces exit 0, including `pi-coding-agent` (2512 files)
- `bun.lock` intentionally not committed
