### PR TITLE
fix(coding-agent): make session directory migration lossless

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored collision-safe hashed project session directories with legacy compatibility aliases and dual-read recovery: same-session candidates are compared by entry graph, strict supersets win, and divergent histories remain visible and require an explicit path instead of being deleted or selected by timestamp ([#7593](https://github.com/can1357/oh-my-pi/issues/7593)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Restored collision-safe hashed project session directories with legacy compatibility aliases and dual-read recovery: same-session candidates are compared by entry graph, strict supersets win, and divergent histories remain visible and require an explicit path instead of being deleted or selected by timestamp ([#7593](https://github.com/can1357/oh-my-pi/issues/7593)).
+- Restored collision-safe hashed project session directories while retaining existing legacy buckets for dual-read recovery: lossy legacy names are never aliased to one project, same-session candidates are compared by entry graph, strict supersets win, and divergent or ambiguous histories require an explicit selection instead of being chosen by timestamp ([#7593](https://github.com/can1357/oh-my-pi/issues/7593)).
 
 ## [17.2.9] - 2026-08-05
 

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -613,6 +613,10 @@ class SessionList implements Component {
 			if (status) {
 				metadata += ` ${dot} ${status}`;
 			}
+			if (session.candidateConflict) {
+				const location = session.candidateLocation ?? "unknown";
+				metadata += ` ${dot} ${theme.fg("error", `${theme.status.error} divergent ${location}`)}`;
+			}
 			if (session.parentSessionPath) {
 				metadata += ` ${dot} ${dim(`${theme.icon.branch} fork`)}`;
 			}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -107,7 +107,7 @@ import type { CompactMode } from "../session/compact-modes";
 import type { ForeignSessionSource } from "../session/foreign-session-store";
 import { HistoryStorage } from "../session/history-storage";
 import type { SessionContext } from "../session/session-context";
-import { getRecentSessions } from "../session/session-listing";
+import { getRecentProjectSessions } from "../session/session-listing";
 import type { SessionManager } from "../session/session-manager";
 import type { ShakeMode } from "../session/shake-types";
 import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES, buildTuiBuiltinSlashCommands } from "../slash-commands/builtin-registry";
@@ -922,7 +922,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		// Get recent sessions
 		const recentSessions = await logger.time("InteractiveMode.init:recentSessions", () =>
-			getRecentSessions(this.sessionManager.getSessionDir()).then(sessions =>
+			getRecentProjectSessions(this.sessionManager.getCwd(), this.sessionManager.getSessionDir()).then(sessions =>
 				sessions.map(s => ({
 					name: s.name,
 					timeAgo: s.timeAgo,

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -1,9 +1,21 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Message } from "@oh-my-pi/pi-ai";
-import { getAgentDir as getDefaultAgentDir, logger, parseJsonlLenient, toError } from "@oh-my-pi/pi-utils";
+import {
+	getAgentDir as getDefaultAgentDir,
+	logger,
+	parseJsonlLenient,
+	resolveEquivalentPath,
+	toError,
+} from "@oh-my-pi/pi-utils";
 import { LRUCache } from "lru-cache/raw";
-import { computeDefaultSessionDir } from "./session-paths";
+import type { FileEntry } from "./session-entries";
+import { loadEntriesFromFile } from "./session-loader";
+import {
+	type ManagedSessionDirectoryKind,
+	resolveDefaultSessionDirectories,
+	resolveManagedSessionRoot,
+} from "./session-paths";
 import { FileSessionStorage, type SessionStorage, type SessionStorageStat } from "./session-storage";
 
 /**
@@ -42,6 +54,10 @@ export interface SessionInfo {
 	 * synthesized {@link SessionInfo}s (cross-project stubs, tests) leave it unset.
 	 */
 	status?: SessionStatus;
+	/** Physical bucket carrying this candidate when multiple directory generations coexist. */
+	candidateLocation?: ManagedSessionDirectoryKind;
+	/** True when another candidate for the same session has a divergent entry graph. */
+	candidateConflict?: boolean;
 }
 
 export interface ResolvedSessionMatch {
@@ -517,6 +533,123 @@ async function collectSessionsFromFiles(
 	return sessions;
 }
 
+function comparableSessionEntry(entry: FileEntry): Record<string, unknown> {
+	const comparable = { ...entry } as Record<string, unknown>;
+	if (entry.type === "session") {
+		delete comparable.version;
+		delete comparable.title;
+		delete comparable.titleSource;
+		delete comparable.previousSessionFiles;
+	}
+	return comparable;
+}
+
+function buildSessionEntryGraph(entries: readonly FileEntry[]): Map<string, Record<string, unknown>> | undefined {
+	if (entries.length === 0 || entries[0]?.type !== "session") return undefined;
+	const graph = new Map<string, Record<string, unknown>>();
+	for (let index = 0; index < entries.length; index++) {
+		const entry = entries[index];
+		const id =
+			index === 0 ? "header" : "id" in entry && typeof entry.id === "string" ? `entry:${entry.id}` : undefined;
+		if (!id || graph.has(id)) return undefined;
+		graph.set(id, comparableSessionEntry(entry));
+	}
+	return graph;
+}
+
+function sessionEntryGraphDominates(
+	candidate: ReadonlyMap<string, Record<string, unknown>>,
+	other: ReadonlyMap<string, Record<string, unknown>>,
+): boolean {
+	for (const [id, entry] of other) {
+		const candidateEntry = candidate.get(id);
+		if (!candidateEntry || !Bun.deepEquals(candidateEntry, entry)) return false;
+	}
+	return true;
+}
+
+function candidateLocationFromPath(file: string): ManagedSessionDirectoryKind {
+	const dirName = path.basename(path.dirname(file));
+	return /^(?:home|tmp|abs)-.*-[a-f0-9]{64}$/.test(dirName) ? "hashed" : "legacy";
+}
+
+function physicalSessionPath(file: string): string {
+	try {
+		return resolveEquivalentPath(file);
+	} catch {
+		return path.resolve(file);
+	}
+}
+
+async function resolveSessionCandidates(
+	sessions: readonly SessionInfo[],
+	storage: SessionStorage,
+): Promise<SessionInfo[]> {
+	const groups = new Map<string, SessionInfo[]>();
+	for (const session of sessions) {
+		const candidate = {
+			...session,
+			candidateLocation: session.candidateLocation ?? candidateLocationFromPath(session.path),
+		};
+		const key = candidate.id;
+		const group = groups.get(key);
+		if (group) group.push(candidate);
+		else groups.set(key, [candidate]);
+	}
+
+	const resolved: SessionInfo[] = [];
+	for (const group of groups.values()) {
+		const physicalCandidates = new Map<string, SessionInfo>();
+		for (const candidate of group) {
+			const physicalPath = physicalSessionPath(candidate.path);
+			const existing = physicalCandidates.get(physicalPath);
+			if (!existing || (existing.candidateLocation === "legacy" && candidate.candidateLocation === "hashed")) {
+				physicalCandidates.set(physicalPath, candidate);
+			}
+		}
+		const candidates = Array.from(physicalCandidates.values());
+		if (candidates.length === 1) {
+			resolved.push(candidates[0]);
+			continue;
+		}
+
+		const graphs = await Promise.all(
+			candidates.map(async candidate => {
+				try {
+					return buildSessionEntryGraph(await loadEntriesFromFile(candidate.path, storage));
+				} catch (error) {
+					logger.warn("Failed to compare session directory candidates", {
+						path: candidate.path,
+						error: toError(error).message,
+					});
+					return undefined;
+				}
+			}),
+		);
+		const dominators = candidates.filter((_, candidateIndex) => {
+			const candidateGraph = graphs[candidateIndex];
+			return (
+				candidateGraph !== undefined &&
+				graphs.every(
+					otherGraph => otherGraph !== undefined && sessionEntryGraphDominates(candidateGraph, otherGraph),
+				)
+			);
+		});
+		if (dominators.length > 0) {
+			resolved.push(
+				dominators.find(candidate => candidate.candidateLocation === "hashed") ??
+					dominators.toSorted((a, b) => b.modified.getTime() - a.modified.getTime())[0],
+			);
+			continue;
+		}
+
+		resolved.push(...candidates.map(candidate => ({ ...candidate, candidateConflict: true })));
+	}
+
+	resolved.sort((a, b) => b.modified.getTime() - a.modified.getTime());
+	return resolved;
+}
+
 /**
  * Promote orphaned `<basename>.jsonl.<snowflake>.bak` backups created by the
  * EPERM-rewrite path back to their primary path when the primary is missing.
@@ -602,6 +735,46 @@ async function scanSessionDirReadOnly(
 	}
 }
 
+function sessionBelongsToProject(session: SessionInfo, cwd: string): boolean {
+	if (!session.cwd) return true;
+	try {
+		return resolveEquivalentPath(session.cwd) === resolveEquivalentPath(cwd);
+	} catch {
+		return path.resolve(session.cwd) === path.resolve(cwd);
+	}
+}
+
+async function scanProjectSessionDirs(
+	cwd: string,
+	sessionDir: string | undefined,
+	storage: SessionStorage,
+	withStatus: boolean,
+): Promise<SessionInfo[]> {
+	const sessionsRoot = sessionDir ? resolveManagedSessionRoot(sessionDir, cwd) : undefined;
+	if (sessionDir && sessionsRoot === undefined) {
+		return await scanSessionDir(sessionDir, storage, withStatus);
+	}
+	const directories = resolveDefaultSessionDirectories(cwd, storage, sessionsRoot);
+	const scans = await Promise.all(
+		directories.readableDirs.map(async directory => {
+			const sessions = await scanSessionDir(directory.path, storage, withStatus);
+			const projectSessions =
+				directory.kind === "legacy" ? sessions.filter(session => sessionBelongsToProject(session, cwd)) : sessions;
+			return projectSessions.map(session => ({ ...session, candidateLocation: directory.kind }));
+		}),
+	);
+	return await resolveSessionCandidates(scans.flat(), storage);
+}
+
+/** List every reachable candidate for a project's managed session directories. */
+export function listProjectSessions(
+	cwd: string,
+	sessionDir: string | undefined,
+	storage: SessionStorage = new FileSessionStorage(),
+): Promise<SessionInfo[]> {
+	return scanProjectSessionDirs(cwd, sessionDir, storage, true);
+}
+
 /**
  * List sessions in a resolved session directory (newest first), reading each
  * file's lifecycle {@link SessionStatus}.
@@ -624,7 +797,8 @@ export async function listAllSessions(storage: SessionStorage = new FileSessionS
 		const files = await Array.fromAsync(new Bun.Glob("*/*.jsonl").scan(sessionsRoot), name =>
 			path.join(sessionsRoot, name),
 		);
-		return await collectSessionsFromFiles(files, storage, true);
+		const sessions = await collectSessionsFromFiles(files, storage, true);
+		return await resolveSessionCandidates(sessions, storage);
 	} catch {
 		return [];
 	}
@@ -639,6 +813,24 @@ export async function findMostRecentSession(
 	return sessions[0]?.path ?? null;
 }
 
+/** Find the newest safe candidate across a project's managed directory generations. */
+export async function findMostRecentProjectSession(
+	cwd: string,
+	sessionDir: string | undefined,
+	storage: SessionStorage = new FileSessionStorage(),
+): Promise<string | null> {
+	const sessions = await scanProjectSessionDirs(cwd, sessionDir, storage, false);
+	const newest = sessions[0];
+	if (!newest) return null;
+	if (newest.candidateConflict === true) {
+		throw new SessionCandidateConflictError(
+			newest.id,
+			sessions.filter(session => session.id === newest.id && session.candidateConflict === true),
+		);
+	}
+	return newest.path;
+}
+
 /** Get recent sessions for display in the welcome screen. */
 export async function getRecentSessions(
 	sessionDir: string,
@@ -650,6 +842,23 @@ export async function getRecentSessions(
 	for (let i = 0; i < sessions.length && i < limit; i++) {
 		const info = sessions[i];
 		recent.push({ path: info.path, name: sessionDisplayName(info), timeAgo: formatTimeAgo(info.modified) });
+	}
+	return recent;
+}
+
+/** Get recent safe candidates across a project's managed directory generations. */
+export async function getRecentProjectSessions(
+	cwd: string,
+	sessionDir: string | undefined,
+	limit = 4,
+	storage: SessionStorage = new FileSessionStorage(),
+): Promise<RecentSessionInfo[]> {
+	const sessions = await scanProjectSessionDirs(cwd, sessionDir, storage, false);
+	const recent: RecentSessionInfo[] = [];
+	for (const info of sessions) {
+		if (info.candidateConflict === true) continue;
+		recent.push({ path: info.path, name: sessionDisplayName(info), timeAgo: formatTimeAgo(info.modified) });
+		if (recent.length === limit) break;
 	}
 	return recent;
 }
@@ -675,6 +884,36 @@ function sessionMatchesResumeArg(session: SessionInfo, sessionArg: string): bool
 	return fileSessionId.startsWith(normalizedArg);
 }
 
+export class SessionCandidateConflictError extends Error {
+	readonly candidates: readonly string[];
+
+	constructor(sessionId: string, candidates: readonly SessionInfo[]) {
+		const ordered = candidates.toSorted((left, right) => {
+			if (left.candidateLocation !== right.candidateLocation) {
+				return left.candidateLocation === "hashed" ? -1 : 1;
+			}
+			return left.path.localeCompare(right.path);
+		});
+		const paths = ordered.map(candidate => candidate.path);
+		super(`Session "${sessionId}" has divergent candidates at ${paths.join(" and ")}`);
+		this.name = "SessionCandidateConflictError";
+		this.candidates = paths;
+	}
+}
+
+function findResumableSession(sessions: readonly SessionInfo[], sessionArg: string): SessionInfo | undefined {
+	const exactPath = path.resolve(sessionArg);
+	const exact = sessions.find(session => path.resolve(session.path) === exactPath);
+	if (exact) return exact;
+
+	const matches = sessions.filter(session => sessionMatchesResumeArg(session, sessionArg));
+	const conflicts = matches.filter(session => session.candidateConflict === true);
+	if (conflicts.length > 1 && conflicts.every(session => session.id === conflicts[0].id)) {
+		throw new SessionCandidateConflictError(conflicts[0].id, conflicts);
+	}
+	return matches[0];
+}
+
 /** Controls cross-directory fallback for resumable session lookup. */
 export interface ResolveResumableSessionOptions {
 	/** Search default global session buckets after the active/custom session directory misses. */
@@ -694,9 +933,8 @@ export async function resolveResumableSession(
 ): Promise<ResolvedSessionMatch | undefined> {
 	const storage = isSessionStorage(storageOrOptions) ? storageOrOptions : new FileSessionStorage();
 	const resolvedOptions = isSessionStorage(storageOrOptions) ? options : storageOrOptions;
-	const localSessionDir = sessionDir ?? computeDefaultSessionDir(cwd, storage);
-	const localSessions = await listSessions(localSessionDir, storage);
-	const localMatch = localSessions.find(session => sessionMatchesResumeArg(session, sessionArg));
+	const localSessions = await scanProjectSessionDirs(cwd, sessionDir, storage, true);
+	const localMatch = findResumableSession(localSessions, sessionArg);
 	if (localMatch) {
 		return { session: localMatch, scope: "local" };
 	}
@@ -706,7 +944,7 @@ export async function resolveResumableSession(
 	}
 
 	const globalSessions = await listAllSessions(storage);
-	const globalMatch = globalSessions.find(session => sessionMatchesResumeArg(session, sessionArg));
+	const globalMatch = findResumableSession(globalSessions, sessionArg);
 	if (!globalMatch) {
 		return undefined;
 	}

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -901,17 +901,38 @@ export class SessionCandidateConflictError extends Error {
 	}
 }
 
+export class SessionPrefixAmbiguityError extends Error {
+	readonly sessionIds: readonly string[];
+
+	constructor(sessionArg: string, sessionIds: readonly string[]) {
+		const sortedIds = sessionIds.toSorted();
+		super(`Session prefix "${sessionArg}" matches multiple session IDs: ${sortedIds.join(", ")}`);
+		this.name = "SessionPrefixAmbiguityError";
+		this.sessionIds = sortedIds;
+	}
+}
+
+function selectResumableCandidate(candidates: readonly SessionInfo[]): SessionInfo | undefined {
+	const first = candidates[0];
+	if (!first) return undefined;
+	const conflicts = candidates.filter(session => session.candidateConflict === true);
+	if (conflicts.length > 0) throw new SessionCandidateConflictError(first.id, conflicts);
+	return first;
+}
+
 function findResumableSession(sessions: readonly SessionInfo[], sessionArg: string): SessionInfo | undefined {
 	const exactPath = path.resolve(sessionArg);
 	const exact = sessions.find(session => path.resolve(session.path) === exactPath);
 	if (exact) return exact;
 
+	const normalizedArg = sessionArg.toLowerCase();
+	const exactIdMatches = sessions.filter(session => session.id.toLowerCase() === normalizedArg);
+	if (exactIdMatches.length > 0) return selectResumableCandidate(exactIdMatches);
+
 	const matches = sessions.filter(session => sessionMatchesResumeArg(session, sessionArg));
-	const conflicts = matches.filter(session => session.candidateConflict === true);
-	if (conflicts.length > 1 && conflicts.every(session => session.id === conflicts[0].id)) {
-		throw new SessionCandidateConflictError(conflicts[0].id, conflicts);
-	}
-	return matches[0];
+	const matchingIds = Array.from(new Set(matches.map(session => session.id)));
+	if (matchingIds.length > 1) throw new SessionPrefixAmbiguityError(sessionArg, matchingIds);
+	return selectResumableCandidate(matches);
 }
 
 /** Controls cross-directory fallback for resumable session lookup. */

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -58,7 +58,12 @@ import {
 	type TtsrInjectionEntry,
 	type UsageStatistics,
 } from "./session-entries";
-import { findMostRecentSession, listAllSessions, listSessions, type SessionInfo } from "./session-listing";
+import {
+	findMostRecentProjectSession,
+	listAllSessions,
+	listProjectSessions,
+	type SessionInfo,
+} from "./session-listing";
 import { loadEntriesFromFile, readTitleSlotFromFile, resolveBlobRefsInEntries } from "./session-loader";
 import { generateId, migrateToCurrentVersion } from "./session-migrations";
 import {
@@ -2607,7 +2612,7 @@ export class SessionManager {
 			// A fresh `/new` boundary whose JSONL was never materialized (lazy
 			// new-session persistence, then a process exit before any assistant
 			// output). Honor the boundary: start fresh rather than falling back to
-			// findMostRecentSession(), which would resurrect the pre-`/new`
+			// findMostRecentProjectSession(), which would resurrect the pre-`/new`
 			// transcript. A materialized (or genuinely stale/deleted) crumb reports
 			// exists=false only when fresh, so this never masks a real stale crumb.
 			if (breadcrumb.fresh && !breadcrumb.exists) {
@@ -2628,7 +2633,7 @@ export class SessionManager {
 				// own, re-root the moved session here instead of starting fresh. When an
 				// explicit sessionDir is reused across the move, the stale breadcrumb file
 				// may be the newest entry there; prefer a genuine current-cwd session.
-				let newestInTargetDir = await findMostRecentSession(dir, storage);
+				let newestInTargetDir = await findMostRecentProjectSession(cwd, dir, storage);
 				const breadcrumbFile = path.resolve(breadcrumb.sessionFile);
 				const breadcrumbCwdMissing = !fs.existsSync(breadcrumbCwd);
 				const newestIsBreadcrumb = newestInTargetDir ? path.resolve(newestInTargetDir) === breadcrumbFile : false;
@@ -2666,7 +2671,7 @@ export class SessionManager {
 			}
 		}
 
-		if (chosenSession === undefined) chosenSession = await findMostRecentSession(dir, storage);
+		if (chosenSession === undefined) chosenSession = await findMostRecentProjectSession(cwd, dir, storage);
 
 		const manager = new SessionManager(cwd, dir, true, storage);
 		if (chosenSession) await manager.setSessionFile(chosenSession);
@@ -2693,8 +2698,7 @@ export class SessionManager {
 		sessionDir?: string,
 		storage: SessionStorage = new FileSessionStorage(),
 	): Promise<SessionInfo[]> {
-		const dir = sessionDir ?? SessionManager.getDefaultSessionDir(cwd, undefined, storage);
-		return listSessions(dir, storage);
+		return listProjectSessions(cwd, sessionDir, storage);
 	}
 
 	/** List all sessions across all project directories. */

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -2,34 +2,55 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getTerminalId } from "@oh-my-pi/pi-tui";
-import { getSessionsDir, getTerminalSessionsDir, isEnoent, logger, resolveEquivalentPath } from "@oh-my-pi/pi-utils";
+import {
+	getSessionsDir,
+	getTerminalSessionsDir,
+	hasFsCode,
+	isEnoent,
+	logger,
+	parseJsonlLenient,
+	resolveEquivalentPath,
+} from "@oh-my-pi/pi-utils";
 import type { SessionStorage } from "./session-storage";
-
-const migratedSessionRoots = new Set<string>();
 
 /**
  * Merge or rename a legacy session directory into its canonical target.
- * Best effort: callers decide whether migration failures should surface.
+ * Returns false when a collision leaves reachable source entries behind.
  */
-function migrateSessionDirPath(oldPath: string, newPath: string): void {
+function migrateSessionDirPath(oldPath: string, newPath: string): boolean {
 	const existing = fs.statSync(newPath, { throwIfNoEntry: false });
 	if (existing?.isDirectory()) {
+		let complete = true;
 		for (const file of fs.readdirSync(oldPath)) {
-			const src = path.join(oldPath, file);
-			const dst = path.join(newPath, file);
-			if (fs.existsSync(dst)) {
-				logger.warn("Session directory migration collision; preserving legacy entry", { src, dst });
+			const source = path.join(oldPath, file);
+			const target = path.join(newPath, file);
+			const sourceStat = fs.statSync(source, { throwIfNoEntry: false });
+			if (!sourceStat) continue;
+			const targetStat = fs.statSync(target, { throwIfNoEntry: false });
+			if (!targetStat) {
+				fs.renameSync(source, target);
 				continue;
 			}
-			fs.renameSync(src, dst);
+			if (sourceStat.isDirectory() && targetStat.isDirectory()) {
+				if (!migrateSessionDirPath(source, target)) complete = false;
+				continue;
+			}
+			logger.warn("Session directory migration collision; preserving legacy entry", { source, target });
+			complete = false;
 		}
+		if (!complete) return false;
 		fs.rmdirSync(oldPath);
-		return;
+		return true;
 	}
 	if (existing) {
-		fs.rmSync(newPath, { recursive: true, force: true });
+		logger.warn("Session directory migration collision; preserving legacy directory", {
+			source: oldPath,
+			target: newPath,
+		});
+		return false;
 	}
 	fs.renameSync(oldPath, newPath);
+	return true;
 }
 
 function encodeLegacyAbsoluteSessionDirName(cwd: string): string {
@@ -42,7 +63,11 @@ function encodeRelativeSessionDirName(prefix: string, relative: string): string 
 	return encoded ? (prefix.endsWith("-") ? `${prefix}${encoded}` : `${prefix}-${encoded}`) : prefix;
 }
 
-function getDefaultSessionDirName(cwd: string): { encodedDirName: string; resolvedCwd: string } {
+function getDefaultSessionDirName(cwd: string): {
+	encodedDirName: string;
+	legacyRelativeDirName: string | undefined;
+	resolvedCwd: string;
+} {
 	const resolvedCwd = path.resolve(cwd);
 	const canonicalCwd = resolveEquivalentPath(resolvedCwd);
 	const home = os.homedir();
@@ -51,71 +76,123 @@ function getDefaultSessionDirName(cwd: string): { encodedDirName: string; resolv
 	const canonicalTempRoot = resolveEquivalentPath(tempRoot);
 	const homeRelative = path.relative(canonicalHome, canonicalCwd);
 	const tempRelative = path.relative(canonicalTempRoot, canonicalCwd);
-	const encodedDirName =
-		homeRelative === "" || (!homeRelative.startsWith("..") && !path.isAbsolute(homeRelative))
-			? encodeRelativeSessionDirName("-", homeRelative)
-			: tempRelative === "" || (!tempRelative.startsWith("..") && !path.isAbsolute(tempRelative))
-				? encodeRelativeSessionDirName("-tmp", tempRelative)
-				: encodeLegacyAbsoluteSessionDirName(canonicalCwd);
-	return { encodedDirName, resolvedCwd };
+
+	let scope: "home" | "tmp" | "abs";
+	let legacyRelativeDirName: string | undefined;
+	if (homeRelative === "" || (!homeRelative.startsWith("..") && !path.isAbsolute(homeRelative))) {
+		scope = "home";
+		legacyRelativeDirName = encodeRelativeSessionDirName("-", homeRelative);
+	} else if (tempRelative === "" || (!tempRelative.startsWith("..") && !path.isAbsolute(tempRelative))) {
+		scope = "tmp";
+		legacyRelativeDirName = encodeRelativeSessionDirName("-tmp", tempRelative);
+	} else {
+		scope = "abs";
+	}
+
+	const normalized = canonicalCwd.replaceAll("\\", "/");
+	const readable = path
+		.basename(canonicalCwd)
+		.replace(/[^a-zA-Z0-9._-]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(-80);
+	const digest = Bun.SHA256.hash(normalized, "hex");
+	const encodedDirName = `${scope}-${readable || "project"}-${digest}`;
+	return { encodedDirName, legacyRelativeDirName, resolvedCwd };
 }
 
-/**
- * Migrate old `--<home-encoded>-*--` session dirs to the new `-*` format.
- * Runs once per sessions root on first access, best-effort.
- */
-function migrateHomeSessionDirs(sessionsRoot: string): void {
-	if (migratedSessionRoots.has(sessionsRoot)) return;
-	migratedSessionRoots.add(sessionsRoot);
-
-	const home = os.homedir();
-	const homeEncoded = home.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-");
-	const oldPrefix = `--${homeEncoded}-`;
-	const oldExact = `--${homeEncoded}--`;
-
-	let entries: string[];
+function legacyAliasPointsTo(legacyDir: string, canonicalDir: string): boolean {
+	const legacyStat = fs.lstatSync(legacyDir, { throwIfNoEntry: false });
+	if (!legacyStat?.isSymbolicLink()) return false;
 	try {
-		entries = fs.readdirSync(sessionsRoot);
+		return resolveEquivalentPath(legacyDir) === resolveEquivalentPath(canonicalDir);
 	} catch {
-		return;
-	}
-
-	for (const entry of entries) {
-		let remainder: string;
-		if (entry === oldExact) {
-			remainder = "";
-		} else if (entry.startsWith(oldPrefix) && entry.endsWith("--")) {
-			remainder = entry.slice(oldPrefix.length, -2);
-		} else {
-			continue;
-		}
-
-		const newName = remainder ? `-${remainder}` : "-";
-		const oldPath = path.join(sessionsRoot, entry);
-		const newPath = path.join(sessionsRoot, newName);
-
-		try {
-			migrateSessionDirPath(oldPath, newPath);
-		} catch (error) {
-			logger.warn("Failed to migrate legacy home session directory", {
-				oldPath,
-				newPath,
-				error: String(error),
-			});
-		}
+		return false;
 	}
 }
 
-function migrateLegacyAbsoluteSessionDir(cwd: string, sessionDir: string, sessionsRoot: string): void {
-	const legacyDir = path.join(sessionsRoot, encodeLegacyAbsoluteSessionDirName(cwd));
-	if (legacyDir === sessionDir || !fs.existsSync(legacyDir)) return;
-
+function ensureLegacyAlias(legacyDir: string, canonicalDir: string): void {
 	try {
-		migrateSessionDirPath(legacyDir, sessionDir);
+		if (legacyAliasPointsTo(legacyDir, canonicalDir) || fs.existsSync(legacyDir)) return;
+		const target = process.platform === "win32" ? canonicalDir : path.relative(path.dirname(legacyDir), canonicalDir);
+		fs.symlinkSync(target, legacyDir, process.platform === "win32" ? "junction" : "dir");
+	} catch (error) {
+		if (hasFsCode(error, "EEXIST")) return;
+		logger.warn("Failed to create legacy session directory alias", {
+			legacyDir,
+			canonicalDir,
+			error: String(error),
+		});
+	}
+}
+
+const SESSION_HEADER_PREFIX_BYTES = 4096;
+const utf8Decoder = new TextDecoder();
+
+function pathsReferToSameDirectory(left: string, right: string): boolean {
+	try {
+		return resolveEquivalentPath(left) === resolveEquivalentPath(right);
+	} catch {
+		return path.resolve(left) === path.resolve(right);
+	}
+}
+
+function readRecordedSessionCwd(file: string): string | undefined {
+	const buffer = new Uint8Array(SESSION_HEADER_PREFIX_BYTES);
+	let descriptor: number | undefined;
+	try {
+		descriptor = fs.openSync(file, "r");
+		const bytesRead = fs.readSync(descriptor, buffer, 0, buffer.byteLength, 0);
+		const entries = parseJsonlLenient<Record<string, unknown>>(utf8Decoder.decode(buffer.subarray(0, bytesRead)));
+		const header = entries.find(entry => entry.type === "session");
+		return typeof header?.cwd === "string" ? header.cwd : undefined;
+	} catch {
+		return undefined;
+	} finally {
+		if (descriptor !== undefined) fs.closeSync(descriptor);
+	}
+}
+
+function legacySessionDirBelongsToCwd(legacyDir: string, cwd: string): boolean {
+	const entries = fs.readdirSync(legacyDir, { withFileTypes: true });
+	if (entries.length === 0) return true;
+	const sessionArtifacts = new Set<string>();
+	for (const entry of entries) {
+		if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+		const recordedCwd = readRecordedSessionCwd(path.join(legacyDir, entry.name));
+		if (!recordedCwd || !pathsReferToSameDirectory(recordedCwd, cwd)) return false;
+		sessionArtifacts.add(entry.name.slice(0, -".jsonl".length));
+	}
+	if (sessionArtifacts.size === 0) return false;
+	return entries.every(
+		entry =>
+			(entry.isFile() && entry.name.endsWith(".jsonl")) || (entry.isDirectory() && sessionArtifacts.has(entry.name)),
+	);
+}
+
+function migrateLegacySessionDir(legacyDir: string, canonicalDir: string, cwd: string): void {
+	try {
+		if (legacyDir === canonicalDir || legacyAliasPointsTo(legacyDir, canonicalDir)) return;
+		const legacyStat = fs.lstatSync(legacyDir, { throwIfNoEntry: false });
+		if (!legacyStat) return;
+		if (legacyStat.isSymbolicLink()) {
+			logger.warn("Refusing to migrate an unexpected legacy session directory symlink", {
+				legacyDir,
+				canonicalDir,
+			});
+			return;
+		}
+		if (!legacySessionDirBelongsToCwd(legacyDir, cwd)) {
+			logger.warn("Legacy session directory ownership is ambiguous; preserving directory", {
+				legacyDir,
+				canonicalDir,
+			});
+			return;
+		}
+		if (migrateSessionDirPath(legacyDir, canonicalDir)) ensureLegacyAlias(legacyDir, canonicalDir);
 	} catch (error) {
 		logger.warn("Failed to migrate legacy session directory", {
-			oldPath: legacyDir,
-			newPath: sessionDir,
+			legacyDir,
+			canonicalDir,
 			error: String(error),
 		});
 	}
@@ -123,29 +200,72 @@ function migrateLegacyAbsoluteSessionDir(cwd: string, sessionDir: string, sessio
 
 export function resolveManagedSessionRoot(sessionDir: string, cwd: string): string | undefined {
 	const currentDirName = path.basename(sessionDir);
-	const { encodedDirName } = getDefaultSessionDirName(cwd);
-	if (currentDirName !== encodedDirName && currentDirName !== encodeLegacyAbsoluteSessionDirName(cwd)) {
+	const { encodedDirName, legacyRelativeDirName } = getDefaultSessionDirName(cwd);
+	if (
+		currentDirName !== encodedDirName &&
+		currentDirName !== legacyRelativeDirName &&
+		currentDirName !== encodeLegacyAbsoluteSessionDirName(cwd)
+	) {
 		return undefined;
 	}
 	return path.dirname(sessionDir);
 }
 
+/** A managed session directory that remains part of the project's read set. */
+export type ManagedSessionDirectoryKind = "hashed" | "legacy";
+
+export interface ManagedSessionDirectory {
+	path: string;
+	kind: ManagedSessionDirectoryKind;
+}
+
+export interface DefaultSessionDirectories {
+	canonicalDir: string;
+	readableDirs: readonly ManagedSessionDirectory[];
+}
+
 /**
- * Compute the default session directory for a cwd.
- * Classifies cwd by canonical location so symlink/alias paths resolve to the
- * same home-relative or temp-root directory names as their real targets.
+ * Resolve the canonical session directory and any residual legacy directories
+ * that remain readable because migration could not safely complete.
  */
+export function resolveDefaultSessionDirectories(
+	cwd: string,
+	storage: SessionStorage,
+	sessionsRoot: string = getSessionsDir(),
+): DefaultSessionDirectories {
+	const { encodedDirName, legacyRelativeDirName, resolvedCwd } = getDefaultSessionDirName(cwd);
+	const canonicalDir = path.join(sessionsRoot, encodedDirName);
+	const legacyDirs = [
+		legacyRelativeDirName ? path.join(sessionsRoot, legacyRelativeDirName) : undefined,
+		path.join(sessionsRoot, encodeLegacyAbsoluteSessionDirName(resolvedCwd)),
+	].filter((legacyDir): legacyDir is string => legacyDir !== undefined && legacyDir !== canonicalDir);
+	for (const legacyDir of legacyDirs) migrateLegacySessionDir(legacyDir, canonicalDir, resolvedCwd);
+	storage.ensureDirSync(canonicalDir);
+	for (const legacyDir of legacyDirs) ensureLegacyAlias(legacyDir, canonicalDir);
+
+	const readableDirs: ManagedSessionDirectory[] = [{ path: canonicalDir, kind: "hashed" }];
+	for (const legacyDir of legacyDirs) {
+		try {
+			const stat = fs.lstatSync(legacyDir, { throwIfNoEntry: false });
+			if (stat?.isDirectory()) readableDirs.push({ path: legacyDir, kind: "legacy" });
+		} catch (error) {
+			logger.warn("Failed to inspect legacy session directory", {
+				legacyDir,
+				canonicalDir,
+				error: String(error),
+			});
+		}
+	}
+	return { canonicalDir, readableDirs };
+}
+
+/** Compute the collision-safe canonical session directory for a cwd. */
 export function computeDefaultSessionDir(
 	cwd: string,
 	storage: SessionStorage,
 	sessionsRoot: string = getSessionsDir(),
 ): string {
-	const { encodedDirName, resolvedCwd } = getDefaultSessionDirName(cwd);
-	migrateHomeSessionDirs(sessionsRoot);
-	const sessionDir = path.join(sessionsRoot, encodedDirName);
-	migrateLegacyAbsoluteSessionDir(resolvedCwd, sessionDir, sessionsRoot);
-	storage.ensureDirSync(sessionDir);
-	return sessionDir;
+	return resolveDefaultSessionDirectories(cwd, storage, sessionsRoot).canonicalDir;
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/session/session-paths.ts
+++ b/packages/coding-agent/src/session/session-paths.ts
@@ -2,56 +2,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getTerminalId } from "@oh-my-pi/pi-tui";
-import {
-	getSessionsDir,
-	getTerminalSessionsDir,
-	hasFsCode,
-	isEnoent,
-	logger,
-	parseJsonlLenient,
-	resolveEquivalentPath,
-} from "@oh-my-pi/pi-utils";
+import { getSessionsDir, getTerminalSessionsDir, isEnoent, logger, resolveEquivalentPath } from "@oh-my-pi/pi-utils";
 import type { SessionStorage } from "./session-storage";
-
-/**
- * Merge or rename a legacy session directory into its canonical target.
- * Returns false when a collision leaves reachable source entries behind.
- */
-function migrateSessionDirPath(oldPath: string, newPath: string): boolean {
-	const existing = fs.statSync(newPath, { throwIfNoEntry: false });
-	if (existing?.isDirectory()) {
-		let complete = true;
-		for (const file of fs.readdirSync(oldPath)) {
-			const source = path.join(oldPath, file);
-			const target = path.join(newPath, file);
-			const sourceStat = fs.statSync(source, { throwIfNoEntry: false });
-			if (!sourceStat) continue;
-			const targetStat = fs.statSync(target, { throwIfNoEntry: false });
-			if (!targetStat) {
-				fs.renameSync(source, target);
-				continue;
-			}
-			if (sourceStat.isDirectory() && targetStat.isDirectory()) {
-				if (!migrateSessionDirPath(source, target)) complete = false;
-				continue;
-			}
-			logger.warn("Session directory migration collision; preserving legacy entry", { source, target });
-			complete = false;
-		}
-		if (!complete) return false;
-		fs.rmdirSync(oldPath);
-		return true;
-	}
-	if (existing) {
-		logger.warn("Session directory migration collision; preserving legacy directory", {
-			source: oldPath,
-			target: newPath,
-		});
-		return false;
-	}
-	fs.renameSync(oldPath, newPath);
-	return true;
-}
 
 function encodeLegacyAbsoluteSessionDirName(cwd: string): string {
 	const resolvedCwd = path.resolve(cwd);
@@ -100,104 +52,6 @@ function getDefaultSessionDirName(cwd: string): {
 	return { encodedDirName, legacyRelativeDirName, resolvedCwd };
 }
 
-function legacyAliasPointsTo(legacyDir: string, canonicalDir: string): boolean {
-	const legacyStat = fs.lstatSync(legacyDir, { throwIfNoEntry: false });
-	if (!legacyStat?.isSymbolicLink()) return false;
-	try {
-		return resolveEquivalentPath(legacyDir) === resolveEquivalentPath(canonicalDir);
-	} catch {
-		return false;
-	}
-}
-
-function ensureLegacyAlias(legacyDir: string, canonicalDir: string): void {
-	try {
-		if (legacyAliasPointsTo(legacyDir, canonicalDir) || fs.existsSync(legacyDir)) return;
-		const target = process.platform === "win32" ? canonicalDir : path.relative(path.dirname(legacyDir), canonicalDir);
-		fs.symlinkSync(target, legacyDir, process.platform === "win32" ? "junction" : "dir");
-	} catch (error) {
-		if (hasFsCode(error, "EEXIST")) return;
-		logger.warn("Failed to create legacy session directory alias", {
-			legacyDir,
-			canonicalDir,
-			error: String(error),
-		});
-	}
-}
-
-const SESSION_HEADER_PREFIX_BYTES = 4096;
-const utf8Decoder = new TextDecoder();
-
-function pathsReferToSameDirectory(left: string, right: string): boolean {
-	try {
-		return resolveEquivalentPath(left) === resolveEquivalentPath(right);
-	} catch {
-		return path.resolve(left) === path.resolve(right);
-	}
-}
-
-function readRecordedSessionCwd(file: string): string | undefined {
-	const buffer = new Uint8Array(SESSION_HEADER_PREFIX_BYTES);
-	let descriptor: number | undefined;
-	try {
-		descriptor = fs.openSync(file, "r");
-		const bytesRead = fs.readSync(descriptor, buffer, 0, buffer.byteLength, 0);
-		const entries = parseJsonlLenient<Record<string, unknown>>(utf8Decoder.decode(buffer.subarray(0, bytesRead)));
-		const header = entries.find(entry => entry.type === "session");
-		return typeof header?.cwd === "string" ? header.cwd : undefined;
-	} catch {
-		return undefined;
-	} finally {
-		if (descriptor !== undefined) fs.closeSync(descriptor);
-	}
-}
-
-function legacySessionDirBelongsToCwd(legacyDir: string, cwd: string): boolean {
-	const entries = fs.readdirSync(legacyDir, { withFileTypes: true });
-	if (entries.length === 0) return true;
-	const sessionArtifacts = new Set<string>();
-	for (const entry of entries) {
-		if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
-		const recordedCwd = readRecordedSessionCwd(path.join(legacyDir, entry.name));
-		if (!recordedCwd || !pathsReferToSameDirectory(recordedCwd, cwd)) return false;
-		sessionArtifacts.add(entry.name.slice(0, -".jsonl".length));
-	}
-	if (sessionArtifacts.size === 0) return false;
-	return entries.every(
-		entry =>
-			(entry.isFile() && entry.name.endsWith(".jsonl")) || (entry.isDirectory() && sessionArtifacts.has(entry.name)),
-	);
-}
-
-function migrateLegacySessionDir(legacyDir: string, canonicalDir: string, cwd: string): void {
-	try {
-		if (legacyDir === canonicalDir || legacyAliasPointsTo(legacyDir, canonicalDir)) return;
-		const legacyStat = fs.lstatSync(legacyDir, { throwIfNoEntry: false });
-		if (!legacyStat) return;
-		if (legacyStat.isSymbolicLink()) {
-			logger.warn("Refusing to migrate an unexpected legacy session directory symlink", {
-				legacyDir,
-				canonicalDir,
-			});
-			return;
-		}
-		if (!legacySessionDirBelongsToCwd(legacyDir, cwd)) {
-			logger.warn("Legacy session directory ownership is ambiguous; preserving directory", {
-				legacyDir,
-				canonicalDir,
-			});
-			return;
-		}
-		if (migrateSessionDirPath(legacyDir, canonicalDir)) ensureLegacyAlias(legacyDir, canonicalDir);
-	} catch (error) {
-		logger.warn("Failed to migrate legacy session directory", {
-			legacyDir,
-			canonicalDir,
-			error: String(error),
-		});
-	}
-}
-
 export function resolveManagedSessionRoot(sessionDir: string, cwd: string): string | undefined {
 	const currentDirName = path.basename(sessionDir);
 	const { encodedDirName, legacyRelativeDirName } = getDefaultSessionDirName(cwd);
@@ -225,8 +79,8 @@ export interface DefaultSessionDirectories {
 }
 
 /**
- * Resolve the canonical session directory and any residual legacy directories
- * that remain readable because migration could not safely complete.
+ * Resolve the canonical session directory and any coexisting legacy
+ * directories that may still contain sessions from older versions.
  */
 export function resolveDefaultSessionDirectories(
 	cwd: string,
@@ -239,9 +93,7 @@ export function resolveDefaultSessionDirectories(
 		legacyRelativeDirName ? path.join(sessionsRoot, legacyRelativeDirName) : undefined,
 		path.join(sessionsRoot, encodeLegacyAbsoluteSessionDirName(resolvedCwd)),
 	].filter((legacyDir): legacyDir is string => legacyDir !== undefined && legacyDir !== canonicalDir);
-	for (const legacyDir of legacyDirs) migrateLegacySessionDir(legacyDir, canonicalDir, resolvedCwd);
 	storage.ensureDirSync(canonicalDir);
-	for (const legacyDir of legacyDirs) ensureLegacyAlias(legacyDir, canonicalDir);
 
 	const readableDirs: ManagedSessionDirectory[] = [{ path: canonicalDir, kind: "hashed" }];
 	for (const legacyDir of legacyDirs) {

--- a/packages/coding-agent/test/modes/components/session-selector-status.test.ts
+++ b/packages/coding-agent/test/modes/components/session-selector-status.test.ts
@@ -87,4 +87,16 @@ describe("SessionSelectorComponent status labels", () => {
 			expect(rendered).not.toContain(label);
 		}
 	});
+
+	it("labels divergent directory candidates with their physical location", () => {
+		const rendered = renderPlain([
+			{
+				...createSession("conflict", "complete"),
+				candidateLocation: "legacy",
+				candidateConflict: true,
+			},
+		]);
+
+		expect(rendered).toContain(`${theme.status.error} divergent legacy`);
+	});
 });

--- a/packages/coding-agent/test/session-candidates.test.ts
+++ b/packages/coding-agent/test/session-candidates.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	findMostRecentProjectSession,
+	resolveResumableSession,
+} from "@oh-my-pi/pi-coding-agent/session/session-listing";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { getConfigRootDir, getSessionsDir, removeSyncWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+
+function hashedSessionDir(sessionsRoot: string, cwd: string): string {
+	const resolvedCwd = path.resolve(cwd);
+	const digest = Bun.SHA256.hash(resolvedCwd.replaceAll("\\", "/"), "hex");
+	return path.join(sessionsRoot, `tmp-${path.basename(resolvedCwd)}-${digest}`);
+}
+
+function legacySessionDir(sessionsRoot: string, cwd: string): string {
+	const relative = path.relative(os.tmpdir(), path.resolve(cwd)).replace(/[/\\:]/g, "-");
+	return path.join(sessionsRoot, `-tmp-${relative}`);
+}
+
+function writeSession(
+	file: string,
+	sessionId: string,
+	cwd: string,
+	entryIds: readonly string[],
+	options: { title?: string; contentById?: Readonly<Record<string, string>> } = {},
+): void {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	const entries = [
+		{
+			type: "session",
+			version: 3,
+			id: sessionId,
+			timestamp: "2026-01-01T00:00:00.000Z",
+			cwd,
+			...(options.title ? { title: options.title } : {}),
+		},
+		...entryIds.map((id, index) => ({
+			type: "message",
+			id,
+			parentId: index === 0 ? null : entryIds[index - 1],
+			timestamp: `2026-01-01T00:00:0${index + 1}.000Z`,
+			message: { role: "user", content: options.contentById?.[id] ?? id, timestamp: index + 1 },
+		})),
+	];
+	fs.writeFileSync(file, `${entries.map(entry => JSON.stringify(entry)).join("\n")}\n`);
+}
+
+describe("session candidate resolution", () => {
+	let agentDir: string;
+	let cwd: string;
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+	beforeEach(() => {
+		agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-session-candidates-"));
+		cwd = fs.mkdtempSync(path.join(os.tmpdir(), "omp-session-candidate-cwd-"));
+		setAgentDir(agentDir);
+	});
+
+	afterEach(() => {
+		if (originalAgentDir) {
+			setAgentDir(originalAgentDir);
+		} else {
+			setAgentDir(fallbackAgentDir);
+			delete process.env.PI_CODING_AGENT_DIR;
+		}
+		removeSyncWithRetries(agentDir);
+		removeSyncWithRetries(cwd);
+	});
+
+	test("selects the legacy candidate when it strictly dominates the hashed copy", async () => {
+		const sessionsRoot = getSessionsDir();
+		const sessionId = "019fcandidate-dominates";
+		const fileName = `${sessionId}.jsonl`;
+		const hashedFile = path.join(hashedSessionDir(sessionsRoot, cwd), fileName);
+		const legacyFile = path.join(legacySessionDir(sessionsRoot, cwd), fileName);
+		writeSession(hashedFile, sessionId, cwd, ["entry-1"]);
+		writeSession(legacyFile, sessionId, cwd, ["entry-1", "entry-2"]);
+
+		const sessions = await SessionManager.list(cwd);
+		expect(sessions.map(session => session.path)).toEqual([legacyFile]);
+		expect((await resolveResumableSession(sessionId, cwd))?.session.path).toBe(legacyFile);
+		expect(
+			(await SessionManager.listAll()).filter(session => session.id === sessionId).map(session => session.path),
+		).toEqual([legacyFile]);
+	});
+
+	test("selects the hashed candidate when it strictly dominates the legacy copy", async () => {
+		const sessionsRoot = getSessionsDir();
+		const sessionId = "019fcandidate-hashed-dominates";
+		const fileName = `${sessionId}.jsonl`;
+		const hashedFile = path.join(hashedSessionDir(sessionsRoot, cwd), fileName);
+		const legacyFile = path.join(legacySessionDir(sessionsRoot, cwd), fileName);
+		writeSession(hashedFile, sessionId, cwd, ["entry-1", "entry-2"]);
+		writeSession(legacyFile, sessionId, cwd, ["entry-1"]);
+
+		expect((await SessionManager.list(cwd)).map(session => session.path)).toEqual([hashedFile]);
+	});
+
+	test("treats title-only differences as equivalent and prefers hashed storage", async () => {
+		const sessionsRoot = getSessionsDir();
+		const sessionId = "019fcandidate-title-only";
+		const fileName = `${sessionId}.jsonl`;
+		const hashedFile = path.join(hashedSessionDir(sessionsRoot, cwd), fileName);
+		const legacyFile = path.join(legacySessionDir(sessionsRoot, cwd), fileName);
+		writeSession(hashedFile, sessionId, cwd, ["entry-1"], { title: "New title" });
+		writeSession(legacyFile, sessionId, cwd, ["entry-1"], { title: "Old title" });
+
+		expect((await SessionManager.list(cwd)).map(session => session.path)).toEqual([hashedFile]);
+	});
+
+	test("keeps projects with colliding legacy bucket names isolated", async () => {
+		const sessionsRoot = getSessionsDir();
+		const firstCwd = path.join(cwd, "project", "hail-mary");
+		const secondCwd = path.join(cwd, "project-hail", "mary");
+		fs.mkdirSync(firstCwd, { recursive: true });
+		fs.mkdirSync(secondCwd, { recursive: true });
+		const sharedLegacyDir = legacySessionDir(sessionsRoot, firstCwd);
+		expect(sharedLegacyDir).toBe(legacySessionDir(sessionsRoot, secondCwd));
+		const firstFile = path.join(sharedLegacyDir, "first.jsonl");
+		const secondFile = path.join(sharedLegacyDir, "second.jsonl");
+		writeSession(firstFile, "first-session", firstCwd, ["first-entry"]);
+		writeSession(secondFile, "second-session", secondCwd, ["second-entry"]);
+
+		expect((await SessionManager.list(firstCwd)).map(session => session.path)).toEqual([firstFile]);
+		expect((await SessionManager.list(secondCwd)).map(session => session.path)).toEqual([secondFile]);
+		expect(hashedSessionDir(sessionsRoot, firstCwd)).not.toBe(hashedSessionDir(sessionsRoot, secondCwd));
+	});
+
+	test("keeps divergent candidates visible and refuses to choose one implicitly", async () => {
+		const sessionsRoot = getSessionsDir();
+		const sessionId = "019fcandidate-diverged";
+		const fileName = `${sessionId}.jsonl`;
+		const hashedFile = path.join(hashedSessionDir(sessionsRoot, cwd), fileName);
+		const legacyFile = path.join(legacySessionDir(sessionsRoot, cwd), fileName);
+		writeSession(hashedFile, sessionId, cwd, ["entry-1", "entry-2"], {
+			contentById: { "entry-2": "hashed content" },
+		});
+		writeSession(legacyFile, sessionId, cwd, ["entry-1", "entry-2"], {
+			contentById: { "entry-2": "legacy content" },
+		});
+
+		const sessions = await SessionManager.list(cwd);
+		expect(sessions).toHaveLength(2);
+		expect(sessions.map(session => session.candidateLocation).sort()).toEqual(["hashed", "legacy"]);
+		expect(sessions.every(session => session.candidateConflict === true)).toBe(true);
+		await expect(resolveResumableSession(sessionId, cwd)).rejects.toThrow(
+			`Session "${sessionId}" has divergent candidates at ${hashedFile} and ${legacyFile}`,
+		);
+		await expect(findMostRecentProjectSession(cwd, undefined)).rejects.toThrow(
+			`Session "${sessionId}" has divergent candidates at ${hashedFile} and ${legacyFile}`,
+		);
+		expect((await resolveResumableSession(hashedFile, cwd))?.session.path).toBe(hashedFile);
+	});
+});

--- a/packages/coding-agent/test/session-candidates.test.ts
+++ b/packages/coding-agent/test/session-candidates.test.ts
@@ -130,6 +130,51 @@ describe("session candidate resolution", () => {
 		expect(hashedSessionDir(sessionsRoot, firstCwd)).not.toBe(hashedSessionDir(sessionsRoot, secondCwd));
 	});
 
+	test("rejects a prefix that matches multiple session IDs", async () => {
+		const sessionsRoot = getSessionsDir();
+		const firstId = "019fshared-a";
+		const secondId = "019fshared-b";
+		writeSession(path.join(hashedSessionDir(sessionsRoot, cwd), `${firstId}.jsonl`), firstId, cwd, ["first-entry"]);
+		writeSession(path.join(hashedSessionDir(sessionsRoot, cwd), `${secondId}.jsonl`), secondId, cwd, [
+			"second-entry",
+		]);
+
+		await expect(resolveResumableSession("019fshared", cwd)).rejects.toThrow(
+			'Session prefix "019fshared" matches multiple session IDs: 019fshared-a, 019fshared-b',
+		);
+	});
+
+	test("prefers an exact session ID over a longer ID with the same prefix", async () => {
+		const sessionsRoot = getSessionsDir();
+		const exactId = "019fshared";
+		const longerId = "019fshared-longer";
+		const exactFile = path.join(hashedSessionDir(sessionsRoot, cwd), `${exactId}.jsonl`);
+		writeSession(exactFile, exactId, cwd, ["exact-entry"]);
+		writeSession(path.join(hashedSessionDir(sessionsRoot, cwd), `${longerId}.jsonl`), longerId, cwd, [
+			"longer-entry",
+		]);
+
+		expect((await resolveResumableSession(exactId, cwd))?.session.path).toBe(exactFile);
+	});
+
+	test("rejects a prefix that matches multiple divergent session IDs", async () => {
+		const sessionsRoot = getSessionsDir();
+		const hashedDir = hashedSessionDir(sessionsRoot, cwd);
+		const legacyDir = legacySessionDir(sessionsRoot, cwd);
+		for (const sessionId of ["019fshared-a", "019fshared-b"]) {
+			writeSession(path.join(hashedDir, `${sessionId}.jsonl`), sessionId, cwd, [`${sessionId}-entry`], {
+				contentById: { [`${sessionId}-entry`]: "hashed content" },
+			});
+			writeSession(path.join(legacyDir, `${sessionId}.jsonl`), sessionId, cwd, [`${sessionId}-entry`], {
+				contentById: { [`${sessionId}-entry`]: "legacy content" },
+			});
+		}
+
+		await expect(resolveResumableSession("019fshared", cwd)).rejects.toThrow(
+			'Session prefix "019fshared" matches multiple session IDs: 019fshared-a, 019fshared-b',
+		);
+	});
+
 	test("keeps divergent candidates visible and refuses to choose one implicitly", async () => {
 		const sessionsRoot = getSessionsDir();
 		const sessionId = "019fcandidate-diverged";

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -202,7 +202,7 @@ describe("SessionManager temp cwd session dirs", () => {
 		expect(path.dirname(sessionFile)).toBe(path.join(getSessionsDir(), expectedTempSessionDirName(tempCwd)));
 	});
 
-	it("migrates legacy temp-root absolute session dirs and leaves a compatible alias", () => {
+	it("keeps legacy temp-root absolute sessions readable beside hashed storage", async () => {
 		const tempCwd = path.join(testAgentDir, `legacy-cwd-${Snowflake.next()}`);
 		fs.mkdirSync(tempCwd, { recursive: true });
 
@@ -225,9 +225,11 @@ describe("SessionManager temp cwd session dirs", () => {
 		if (!sessionFile) throw new Error("Expected session file path");
 
 		const expectedDir = path.join(getSessionsDir(), expectedTempSessionDirName(tempCwd));
-		expect(fs.realpathSync(legacyDir)).toBe(fs.realpathSync(expectedDir));
+		expect(fs.lstatSync(legacyDir).isDirectory()).toBe(true);
 		expect(path.dirname(sessionFile)).toBe(expectedDir);
-		expect(fs.existsSync(path.join(expectedDir, "carried.jsonl"))).toBe(true);
+		expect(fs.existsSync(markerFile)).toBe(true);
+		expect(fs.existsSync(path.join(expectedDir, "carried.jsonl"))).toBe(false);
+		expect((await SessionManager.list(tempCwd)).map(info => info.path)).toEqual([markerFile]);
 	});
 });
 

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -6,6 +6,7 @@ import type { FileEntry, SessionHeader } from "@oh-my-pi/pi-coding-agent/session
 import { findMostRecentSession, resolveResumableSession } from "@oh-my-pi/pi-coding-agent/session/session-listing";
 import { loadEntriesFromFile } from "@oh-my-pi/pi-coding-agent/session/session-loader";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import * as tui from "@oh-my-pi/pi-tui";
 import { getConfigRootDir, getSessionsDir, removeSyncWithRetries, Snowflake, setAgentDir } from "@oh-my-pi/pi-utils";
 
 describe("loadEntriesFromFile", () => {
@@ -163,7 +164,9 @@ describe("SessionManager temp cwd session dirs", () => {
 	const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
 
 	function expectedTempSessionDirName(tempCwd: string): string {
-		return `-tmp-${path.relative(os.tmpdir(), path.resolve(tempCwd)).replace(/[/\\:]/g, "-")}`;
+		const resolvedCwd = path.resolve(tempCwd);
+		const digest = Bun.SHA256.hash(resolvedCwd.replaceAll("\\", "/"), "hex");
+		return `tmp-${path.basename(resolvedCwd)}-${digest}`;
 	}
 
 	function toLegacyAbsoluteSessionDirName(cwd: string): string {
@@ -188,7 +191,7 @@ describe("SessionManager temp cwd session dirs", () => {
 		removeSyncWithRetries(testAgentDir);
 	});
 
-	it("stores temp-root cwd sessions under -tmp-prefixed directories", () => {
+	it("stores temp-root cwd sessions under collision-safe hashed directories", () => {
 		const tempCwd = path.join(testAgentDir, `temp-cwd-${Snowflake.next()}`);
 		fs.mkdirSync(tempCwd, { recursive: true });
 
@@ -199,21 +202,30 @@ describe("SessionManager temp cwd session dirs", () => {
 		expect(path.dirname(sessionFile)).toBe(path.join(getSessionsDir(), expectedTempSessionDirName(tempCwd)));
 	});
 
-	it("migrates legacy temp-root absolute session dirs to -tmp prefixes", () => {
+	it("migrates legacy temp-root absolute session dirs and leaves a compatible alias", () => {
 		const tempCwd = path.join(testAgentDir, `legacy-cwd-${Snowflake.next()}`);
 		fs.mkdirSync(tempCwd, { recursive: true });
 
 		const legacyDir = path.join(getSessionsDir(), toLegacyAbsoluteSessionDirName(tempCwd));
 		const markerFile = path.join(legacyDir, "carried.jsonl");
 		fs.mkdirSync(legacyDir, { recursive: true });
-		fs.writeFileSync(markerFile, "marker\n");
+		fs.writeFileSync(
+			markerFile,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: "carried",
+				timestamp: "2026-01-01T00:00:00.000Z",
+				cwd: tempCwd,
+			})}\n`,
+		);
 
 		const session = SessionManager.create(tempCwd);
 		const sessionFile = session.getSessionFile();
 		if (!sessionFile) throw new Error("Expected session file path");
 
 		const expectedDir = path.join(getSessionsDir(), expectedTempSessionDirName(tempCwd));
-		expect(fs.existsSync(legacyDir)).toBe(false);
+		expect(fs.realpathSync(legacyDir)).toBe(fs.realpathSync(expectedDir));
 		expect(path.dirname(sessionFile)).toBe(expectedDir);
 		expect(fs.existsSync(path.join(expectedDir, "carried.jsonl"))).toBe(true);
 	});
@@ -247,10 +259,12 @@ describe("SessionManager legacy session migration persistence", () => {
 	}
 
 	beforeEach(() => {
+		vi.spyOn(tui, "getTerminalId").mockReturnValue(null);
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-session-manager-legacy-"));
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		removeSyncWithRetries(tempDir);
 	});
 

--- a/packages/coding-agent/test/session-paths.test.ts
+++ b/packages/coding-agent/test/session-paths.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { computeDefaultSessionDir } from "@oh-my-pi/pi-coding-agent/session/session-paths";
 import { FileSessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
+import { logger } from "@oh-my-pi/pi-utils";
 
 const cleanup: string[] = [];
 
@@ -21,11 +22,65 @@ function legacySessionDir(sessionsRoot: string, cwd: string): string {
 	return path.join(sessionsRoot, name);
 }
 
+function hashedSessionDir(sessionsRoot: string, cwd: string): string {
+	const resolvedCwd = path.resolve(cwd);
+	const digest = Bun.SHA256.hash(resolvedCwd.replaceAll("\\", "/"), "hex");
+	return path.join(sessionsRoot, `tmp-${path.basename(resolvedCwd)}-${digest}`);
+}
+
+function relativeLegacySessionDir(sessionsRoot: string, cwd: string): string {
+	const relative = path.relative(os.tmpdir(), path.resolve(cwd)).replace(/[/\\:]/g, "-");
+	return path.join(sessionsRoot, `-tmp-${relative}`);
+}
+
+function sessionHeader(cwd: string, id: string): string {
+	return `${JSON.stringify({ type: "session", version: 3, id, timestamp: "2026-01-01T00:00:00.000Z", cwd })}\n`;
+}
+
 afterEach(() => {
+	vi.restoreAllMocks();
 	for (const dir of cleanup.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
 describe("legacy session directory migration", () => {
+	test("recognizes a hashed bucket created before the legacy-name rollback", () => {
+		const sessionsRoot = makeTempDir("omp-session-root-");
+		const cwd = makeTempDir("omp-session-cwd-");
+		const storage = new FileSessionStorage();
+		const hashedDir = hashedSessionDir(sessionsRoot, cwd);
+		fs.mkdirSync(hashedDir, { recursive: true });
+		fs.writeFileSync(path.join(hashedDir, "existing.jsonl"), "hashed session\n");
+
+		expect(computeDefaultSessionDir(cwd, storage, sessionsRoot)).toBe(hashedDir);
+		expect(fs.readFileSync(path.join(hashedDir, "existing.jsonl"), "utf8")).toBe("hashed session\n");
+		expect(fs.realpathSync(relativeLegacySessionDir(sessionsRoot, cwd))).toBe(fs.realpathSync(hashedDir));
+	});
+
+	test("moves an unambiguous legacy bucket to hashed storage and leaves a compatible alias", () => {
+		const sessionsRoot = makeTempDir("omp-session-root-");
+		const cwd = makeTempDir("omp-session-cwd-");
+		const storage = new FileSessionStorage();
+		const hashedDir = hashedSessionDir(sessionsRoot, cwd);
+		const legacyDir = relativeLegacySessionDir(sessionsRoot, cwd);
+		fs.mkdirSync(legacyDir, { recursive: true });
+		const contents = sessionHeader(cwd, "existing");
+		const sessionFile = path.join(legacyDir, "existing.jsonl");
+		const artifactFile = path.join(legacyDir, "existing", "blobs", "payload");
+		fs.writeFileSync(sessionFile, contents);
+		fs.mkdirSync(path.dirname(artifactFile), { recursive: true });
+		fs.writeFileSync(artifactFile, "artifact bytes");
+		const descriptor = fs.openSync(sessionFile, "a");
+
+		expect(computeDefaultSessionDir(cwd, storage, sessionsRoot)).toBe(hashedDir);
+		fs.writeSync(descriptor, "after migration\n");
+		fs.closeSync(descriptor);
+		expect(fs.readFileSync(path.join(hashedDir, "existing.jsonl"), "utf8")).toBe(`${contents}after migration\n`);
+		expect(fs.readFileSync(path.join(hashedDir, "existing", "blobs", "payload"), "utf8")).toBe("artifact bytes");
+		expect(fs.realpathSync(legacyDir)).toBe(fs.realpathSync(hashedDir));
+		expect(computeDefaultSessionDir(cwd, storage, sessionsRoot)).toBe(hashedDir);
+		expect(fs.realpathSync(legacyDir)).toBe(fs.realpathSync(hashedDir));
+	});
+
 	test("keeps a colliding live legacy session reachable through its path", () => {
 		const sessionsRoot = makeTempDir("omp-session-root-");
 		const cwd = makeTempDir("omp-session-cwd-");
@@ -34,17 +89,25 @@ describe("legacy session directory migration", () => {
 		const legacyDir = legacySessionDir(sessionsRoot, cwd);
 		const source = path.join(legacyDir, "active.jsonl");
 		const destination = path.join(canonicalDir, "active.jsonl");
+		fs.rmSync(legacyDir);
 		fs.mkdirSync(legacyDir, { recursive: true });
-		fs.writeFileSync(source, "live-before\n");
-		fs.writeFileSync(destination, "stale\n");
+		const sourceContents = sessionHeader(cwd, "live");
+		const destinationContents = sessionHeader(cwd, "stale");
+		fs.writeFileSync(source, sourceContents);
+		fs.writeFileSync(destination, destinationContents);
 		const fd = fs.openSync(source, "a");
 
+		const warning = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		computeDefaultSessionDir(cwd, storage, sessionsRoot);
 		fs.writeSync(fd, "live-after\n");
 		fs.closeSync(fd);
 
-		expect(fs.readFileSync(source, "utf8")).toBe("live-before\nlive-after\n");
-		expect(fs.readFileSync(destination, "utf8")).toBe("stale\n");
+		expect(fs.readFileSync(source, "utf8")).toBe(`${sourceContents}live-after\n`);
+		expect(fs.readFileSync(destination, "utf8")).toBe(destinationContents);
+		expect(warning).toHaveBeenCalledWith("Session directory migration collision; preserving legacy entry", {
+			source,
+			target: destination,
+		});
 	});
 
 	test("preserves writes when an older process recreates its cached legacy directory", () => {
@@ -54,14 +117,41 @@ describe("legacy session directory migration", () => {
 		const canonicalDir = computeDefaultSessionDir(cwd, storage, sessionsRoot);
 		const legacyDir = legacySessionDir(sessionsRoot, cwd);
 		const destination = path.join(canonicalDir, "active.jsonl");
-		fs.writeFileSync(destination, "canonical\n");
+		const canonicalContents = sessionHeader(cwd, "canonical");
+		fs.writeFileSync(destination, canonicalContents);
 
+		fs.rmSync(legacyDir);
 		fs.mkdirSync(legacyDir, { recursive: true });
 		const recreated = path.join(legacyDir, "active.jsonl");
-		fs.writeFileSync(recreated, "older-process-write\n");
+		const recreatedContents = sessionHeader(cwd, "recreated");
+		fs.writeFileSync(recreated, recreatedContents);
 		computeDefaultSessionDir(cwd, storage, sessionsRoot);
 
-		expect(fs.readFileSync(recreated, "utf8")).toBe("older-process-write\n");
-		expect(fs.readFileSync(destination, "utf8")).toBe("canonical\n");
+		expect(fs.readFileSync(recreated, "utf8")).toBe(recreatedContents);
+		expect(fs.readFileSync(destination, "utf8")).toBe(canonicalContents);
+	});
+
+	test("logs migration failures and leaves the legacy directory reachable", () => {
+		const sessionsRoot = makeTempDir("omp-session-root-");
+		const cwd = makeTempDir("omp-session-cwd-");
+		const storage = new FileSessionStorage();
+		const canonicalDir = hashedSessionDir(sessionsRoot, cwd);
+		const legacyDir = relativeLegacySessionDir(sessionsRoot, cwd);
+		const legacyFile = path.join(legacyDir, "active.jsonl");
+		fs.mkdirSync(legacyDir, { recursive: true });
+		const contents = sessionHeader(cwd, "legacy");
+		fs.writeFileSync(legacyFile, contents);
+		const warning = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		vi.spyOn(fs, "renameSync").mockImplementationOnce(() => {
+			throw new Error("blocked");
+		});
+
+		expect(computeDefaultSessionDir(cwd, storage, sessionsRoot)).toBe(canonicalDir);
+		expect(fs.readFileSync(legacyFile, "utf8")).toBe(contents);
+		expect(warning).toHaveBeenCalledWith("Failed to migrate legacy session directory", {
+			legacyDir,
+			canonicalDir,
+			error: "Error: blocked",
+		});
 	});
 });

--- a/packages/coding-agent/test/session-paths.test.ts
+++ b/packages/coding-agent/test/session-paths.test.ts
@@ -4,7 +4,6 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { computeDefaultSessionDir } from "@oh-my-pi/pi-coding-agent/session/session-paths";
 import { FileSessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
-import { logger } from "@oh-my-pi/pi-utils";
 
 const cleanup: string[] = [];
 
@@ -42,7 +41,7 @@ afterEach(() => {
 	for (const dir of cleanup.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
 
-describe("legacy session directory migration", () => {
+describe("legacy session directory coexistence", () => {
 	test("recognizes a hashed bucket created before the legacy-name rollback", () => {
 		const sessionsRoot = makeTempDir("omp-session-root-");
 		const cwd = makeTempDir("omp-session-cwd-");
@@ -53,10 +52,31 @@ describe("legacy session directory migration", () => {
 
 		expect(computeDefaultSessionDir(cwd, storage, sessionsRoot)).toBe(hashedDir);
 		expect(fs.readFileSync(path.join(hashedDir, "existing.jsonl"), "utf8")).toBe("hashed session\n");
-		expect(fs.realpathSync(relativeLegacySessionDir(sessionsRoot, cwd))).toBe(fs.realpathSync(hashedDir));
+		expect(fs.existsSync(relativeLegacySessionDir(sessionsRoot, cwd))).toBe(false);
 	});
 
-	test("moves an unambiguous legacy bucket to hashed storage and leaves a compatible alias", () => {
+	test("does not claim an absent lossy legacy name for one project", () => {
+		const sessionsRoot = makeTempDir("omp-session-root-");
+		const parent = makeTempDir("omp-session-collision-");
+		const firstCwd = path.join(parent, "project", "hail-mary");
+		const secondCwd = path.join(parent, "project-hail", "mary");
+		fs.mkdirSync(firstCwd, { recursive: true });
+		fs.mkdirSync(secondCwd, { recursive: true });
+		const storage = new FileSessionStorage();
+		const sharedLegacyDir = relativeLegacySessionDir(sessionsRoot, firstCwd);
+		expect(sharedLegacyDir).toBe(relativeLegacySessionDir(sessionsRoot, secondCwd));
+
+		const firstCanonicalDir = computeDefaultSessionDir(firstCwd, storage, sessionsRoot);
+		expect(fs.existsSync(sharedLegacyDir)).toBe(false);
+
+		const oldClientFile = path.join(sharedLegacyDir, "second.jsonl");
+		fs.mkdirSync(sharedLegacyDir, { recursive: true });
+		fs.writeFileSync(oldClientFile, sessionHeader(secondCwd, "second"));
+		expect(fs.existsSync(path.join(firstCanonicalDir, "second.jsonl"))).toBe(false);
+		expect(fs.readFileSync(oldClientFile, "utf8")).toBe(sessionHeader(secondCwd, "second"));
+	});
+
+	test("keeps an existing legacy bucket in place beside hashed storage", () => {
 		const sessionsRoot = makeTempDir("omp-session-root-");
 		const cwd = makeTempDir("omp-session-cwd-");
 		const storage = new FileSessionStorage();
@@ -70,15 +90,17 @@ describe("legacy session directory migration", () => {
 		fs.mkdirSync(path.dirname(artifactFile), { recursive: true });
 		fs.writeFileSync(artifactFile, "artifact bytes");
 		const descriptor = fs.openSync(sessionFile, "a");
+		const rename = vi.spyOn(fs, "renameSync");
 
 		expect(computeDefaultSessionDir(cwd, storage, sessionsRoot)).toBe(hashedDir);
-		fs.writeSync(descriptor, "after migration\n");
+		fs.writeSync(descriptor, "after startup\n");
 		fs.closeSync(descriptor);
-		expect(fs.readFileSync(path.join(hashedDir, "existing.jsonl"), "utf8")).toBe(`${contents}after migration\n`);
-		expect(fs.readFileSync(path.join(hashedDir, "existing", "blobs", "payload"), "utf8")).toBe("artifact bytes");
-		expect(fs.realpathSync(legacyDir)).toBe(fs.realpathSync(hashedDir));
+		expect(fs.readFileSync(sessionFile, "utf8")).toBe(`${contents}after startup\n`);
+		expect(fs.readFileSync(artifactFile, "utf8")).toBe("artifact bytes");
+		expect(fs.existsSync(path.join(hashedDir, "existing.jsonl"))).toBe(false);
+		expect(fs.lstatSync(legacyDir).isDirectory()).toBe(true);
+		expect(rename).not.toHaveBeenCalled();
 		expect(computeDefaultSessionDir(cwd, storage, sessionsRoot)).toBe(hashedDir);
-		expect(fs.realpathSync(legacyDir)).toBe(fs.realpathSync(hashedDir));
 	});
 
 	test("keeps a colliding live legacy session reachable through its path", () => {
@@ -89,25 +111,19 @@ describe("legacy session directory migration", () => {
 		const legacyDir = legacySessionDir(sessionsRoot, cwd);
 		const source = path.join(legacyDir, "active.jsonl");
 		const destination = path.join(canonicalDir, "active.jsonl");
-		fs.rmSync(legacyDir);
 		fs.mkdirSync(legacyDir, { recursive: true });
 		const sourceContents = sessionHeader(cwd, "live");
 		const destinationContents = sessionHeader(cwd, "stale");
 		fs.writeFileSync(source, sourceContents);
 		fs.writeFileSync(destination, destinationContents);
-		const fd = fs.openSync(source, "a");
+		const descriptor = fs.openSync(source, "a");
 
-		const warning = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		computeDefaultSessionDir(cwd, storage, sessionsRoot);
-		fs.writeSync(fd, "live-after\n");
-		fs.closeSync(fd);
+		fs.writeSync(descriptor, "live-after\n");
+		fs.closeSync(descriptor);
 
 		expect(fs.readFileSync(source, "utf8")).toBe(`${sourceContents}live-after\n`);
 		expect(fs.readFileSync(destination, "utf8")).toBe(destinationContents);
-		expect(warning).toHaveBeenCalledWith("Session directory migration collision; preserving legacy entry", {
-			source,
-			target: destination,
-		});
 	});
 
 	test("preserves writes when an older process recreates its cached legacy directory", () => {
@@ -120,7 +136,6 @@ describe("legacy session directory migration", () => {
 		const canonicalContents = sessionHeader(cwd, "canonical");
 		fs.writeFileSync(destination, canonicalContents);
 
-		fs.rmSync(legacyDir);
 		fs.mkdirSync(legacyDir, { recursive: true });
 		const recreated = path.join(legacyDir, "active.jsonl");
 		const recreatedContents = sessionHeader(cwd, "recreated");
@@ -129,29 +144,5 @@ describe("legacy session directory migration", () => {
 
 		expect(fs.readFileSync(recreated, "utf8")).toBe(recreatedContents);
 		expect(fs.readFileSync(destination, "utf8")).toBe(canonicalContents);
-	});
-
-	test("logs migration failures and leaves the legacy directory reachable", () => {
-		const sessionsRoot = makeTempDir("omp-session-root-");
-		const cwd = makeTempDir("omp-session-cwd-");
-		const storage = new FileSessionStorage();
-		const canonicalDir = hashedSessionDir(sessionsRoot, cwd);
-		const legacyDir = relativeLegacySessionDir(sessionsRoot, cwd);
-		const legacyFile = path.join(legacyDir, "active.jsonl");
-		fs.mkdirSync(legacyDir, { recursive: true });
-		const contents = sessionHeader(cwd, "legacy");
-		fs.writeFileSync(legacyFile, contents);
-		const warning = vi.spyOn(logger, "warn").mockImplementation(() => {});
-		vi.spyOn(fs, "renameSync").mockImplementationOnce(() => {
-			throw new Error("blocked");
-		});
-
-		expect(computeDefaultSessionDir(cwd, storage, sessionsRoot)).toBe(canonicalDir);
-		expect(fs.readFileSync(legacyFile, "utf8")).toBe(contents);
-		expect(warning).toHaveBeenCalledWith("Failed to migrate legacy session directory", {
-			legacyDir,
-			canonicalDir,
-			error: "Error: blocked",
-		});
 	});
 });


### PR DESCRIPTION
## Summary

- restore collision-safe hashed project session directories while keeping existing lossy legacy buckets in place for old clients; no legacy name is aliased to a single canonical owner
- dual-read every reachable candidate and compare same-session entry graphs before selecting a strict superset or the equivalent hashed copy
- surface divergent candidates, reject ambiguous session prefixes, and require an explicit full path when automatic selection is unsafe

Fixes #7593

## Verification

- `bun check`
- `bun run ci:test:smoke`
- `bun test packages/coding-agent/test/session-manager` — 221 passed
- session migration/candidate/resume regressions — 52 passed
