### PR TITLE
fix(memory): hide disabled memory protocol

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped the Read tool from advertising or resolving `memory://` when `memory.backend` is `off`, preventing agents from probing a disabled subsystem ([#7673](https://github.com/can1357/oh-my-pi/issues/7673)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -290,6 +290,10 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 	readonly immutable = true;
 
 	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
+		const backend = memoryBackendFromContext(context);
+		if (backend === "off") {
+			throw new Error("Unknown protocol: memory://");
+		}
 		const namespace = url.rawHost || url.hostname;
 		if (!namespace) {
 			throw new Error("memory:// URL requires a namespace: memory://root or memory://<memory-id>");
@@ -303,7 +307,7 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 		if (namespace !== MEMORY_NAMESPACE) {
 			const mnemopiStates = mnemopiSessionStatesFromRegistry();
 			const hindsightActive =
-				memoryBackendFromContext(context) === "hindsight" ||
+				backend === "hindsight" ||
 				(mnemopiStates.length === 0 &&
 					AgentRegistry.global()
 						.list()

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -721,6 +721,10 @@ const readSchema = type({
 	),
 });
 
+const readSchemaWithoutMemory = type({
+	path: type("string").describe("Local path, internal URI (e.g. skill://), or URL. Inline selectors are supported."),
+});
+
 export type ReadToolInput = typeof readSchema.infer;
 
 export interface ReadToolDetails {
@@ -866,7 +870,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	readonly label = "Read";
 	readonly loadMode = "essential";
 	description: string;
-	readonly parameters = readSchema;
+	get parameters(): typeof readSchema {
+		return this.session.settings.get("memory.backend") === "off" ? readSchemaWithoutMemory : readSchema;
+	}
 	readonly strict = true;
 
 	readonly #autoResizeImages: boolean;

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -15,6 +15,7 @@ import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { GlobTool } from "@oh-my-pi/pi-coding-agent/tools/glob";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 import { getAgentDir, removeWithRetries, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 
 // Mnemopi state is loaded lazily; preload so `new MnemopiSessionState(...)` can
@@ -62,7 +63,7 @@ function createGlobTool(cwd: string): GlobTool {
 	const session: ToolSession = {
 		cwd,
 		hasUI: false,
-		settings: Settings.isolated({}),
+		settings: Settings.isolated({ "memory.backend": "local" }),
 		getSessionFile: () => null,
 		getSessionSpawns: () => null,
 	};
@@ -78,6 +79,31 @@ describe("MemoryProtocolHandler", () => {
 	afterEach(() => {
 		AgentRegistry.resetGlobalForTests();
 		InternalUrlRouter.resetForTests();
+	});
+
+	it("rejects memory URLs when the calling session disables memory", async () => {
+		const router = InternalUrlRouter.instance();
+		const settings = Settings.isolated({ "memory.backend": "off" });
+
+		await expect(router.resolve("memory://", { settings })).rejects.toThrow("Unknown protocol: memory://");
+		await expect(router.resolve("memory://root", { settings })).rejects.toThrow("Unknown protocol: memory://");
+	});
+
+	it("advertises memory URLs only while a memory backend is enabled", () => {
+		const settings = Settings.isolated();
+		const session: ToolSession = {
+			cwd: process.cwd(),
+			hasUI: false,
+			settings,
+			getSessionFile: () => null,
+			getSessionSpawns: () => null,
+		};
+		const tool = new ReadTool(session);
+
+		expect(JSON.stringify(tool.parameters.toJsonSchema())).not.toContain("memory://");
+
+		settings.override("memory.backend", "local");
+		expect(JSON.stringify(tool.parameters.toJsonSchema())).toContain("memory://");
 	});
 
 	it("resolves memory://root to memory_summary.md", async () => {


### PR DESCRIPTION
## Repro

Run `bun -e '<instantiate ReadTool with memory.backend=off; print its wire schema; read memory:// and memory://root>'`; before this fix the schema advertised `memory://` and both probes returned hints toward the disabled subsystem.

## Cause

`packages/coding-agent/src/tools/read.ts` exposed one process-static `readSchema` whose path description always listed `memory://`, while `MemoryProtocolHandler.resolve` in `packages/coding-agent/src/internal-urls/memory-protocol.ts` routed every memory URL before consulting the calling session backend.

## Fix

- Select the Read path schema from the live session setting, omitting `memory://` when `memory.backend` is `off`.
- Reject stray memory URL resolutions as an unknown protocol for callers with memory disabled.
- Cover disabled and live-enabled schema behavior plus both reported probe forms.
- Document the fix under the coding-agent changelog Unreleased section.

## Verification

`bun test packages/coding-agent/test/internal-urls/memory-protocol.test.ts` passed: 26 tests, 0 failures. A direct `ReadTool` smoke probe omitted `memory://` from the schema and returned `Unknown protocol: memory://` for both `memory://` and `memory://root`. `bun run fix && bun check` passed.

Fixes #7673