### PR TITLE
feat(video): add video file attachments for video-capable models

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added video blocks to custom/hook message content and tool-result content unions, preserving video attachments through compaction and session persistence.
+
 ## [17.2.9] - 2026-08-05
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -347,6 +347,7 @@ function snapshotAssistantContentBlock(block: AssistantContentBlock): AssistantC
 	switch (block.type) {
 		case "text":
 		case "image":
+		case "video":
 			return { ...block };
 		case "thinking":
 			return { ...block };

--- a/packages/agent/src/compaction/entries.ts
+++ b/packages/agent/src/compaction/entries.ts
@@ -1,4 +1,4 @@
-import type { ImageContent, MessageAttribution, ServiceTierByFamily, TextContent } from "@oh-my-pi/pi-ai";
+import type { MessageAttribution, MessageContent, ServiceTierByFamily } from "@oh-my-pi/pi-ai";
 import type { AgentMessage } from "../types";
 
 export interface SessionEntryBase {
@@ -64,7 +64,7 @@ export interface BranchSummaryEntry<T = unknown> extends SessionEntryBase {
 export interface CustomMessageEntry<T = unknown> extends SessionEntryBase {
 	type: "custom_message";
 	customType: string;
-	content: string | (TextContent | ImageContent)[];
+	content: MessageContent;
 	details?: T;
 	display: boolean;
 	/** Who initiated this message for billing/attribution semantics. */

--- a/packages/agent/src/compaction/messages.ts
+++ b/packages/agent/src/compaction/messages.ts
@@ -1,7 +1,9 @@
 import type {
+	ContentBlock,
 	ImageContent,
 	Message,
 	MessageAttribution,
+	MessageContent,
 	ProviderPayload,
 	TextContent,
 	ToolResultMessage,
@@ -17,7 +19,7 @@ const BRANCH_SUMMARY_TEMPLATE = branchSummaryContextPrompt;
 export interface CustomMessage<T = unknown> {
 	role: "custom";
 	customType: string;
-	content: string | (TextContent | ImageContent)[];
+	content: MessageContent;
 	display: boolean;
 	details?: T;
 	/** Who initiated this message for billing/attribution semantics. */
@@ -29,7 +31,7 @@ export interface CustomMessage<T = unknown> {
 export interface HookMessage<T = unknown> {
 	role: "hookMessage";
 	customType: string;
-	content: string | (TextContent | ImageContent)[];
+	content: MessageContent;
 	display: boolean;
 	details?: T;
 	/** Who initiated this message for billing/attribution semantics. */
@@ -53,7 +55,7 @@ export interface CompactionSummaryMessage {
 	/** Runtime-only ordered archive blocks for snapcompact: old text region,
 	 *  imaged middle, then new text region. When present, `summary` is already
 	 *  the final lead-in text (no legacy wrapper applied). */
-	blocks?: (TextContent | ImageContent)[];
+	blocks?: ContentBlock[];
 	/** Snapcompact image blocks, kept for display counts / legacy consumers. */
 	images?: ImageContent[];
 	/** Post-pass dead-end warning attached to this compaction (progress guard). */
@@ -73,7 +75,7 @@ declare module "../types" {
 }
 export type ConvertToLlm = (messages: AgentMessage[]) => Message[];
 
-function getPrunedToolResultContent(message: ToolResultMessage): (TextContent | ImageContent)[] {
+function getPrunedToolResultContent(message: ToolResultMessage): ContentBlock[] {
 	if (message.prunedAt === undefined) {
 		return message.content;
 	}
@@ -127,7 +129,7 @@ export function createCompactionSummaryMessage(
 
 export function createCustomMessage(
 	customType: string,
-	content: string | (TextContent | ImageContent)[],
+	content: MessageContent,
 	display: boolean,
 	details: unknown | undefined,
 	timestamp: string,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -3,16 +3,15 @@ import type {
 	AssistantMessage,
 	AssistantMessageEvent,
 	AssistantMessageEventStream,
+	ContentBlock,
 	Context,
 	Effort,
-	ImageContent,
 	Message,
 	Model,
 	ServiceTier,
 	SimpleStreamOptions,
 	Static,
 	streamSimple,
-	TextContent,
 	Tool,
 	ToolCallProviderMetadata,
 	ToolChoice,
@@ -589,7 +588,7 @@ export interface BeforeToolCallResult {
  */
 export interface AfterToolCallResult {
 	/** If provided, replaces the tool result content array in full. */
-	content?: (TextContent | ImageContent)[];
+	content?: ContentBlock[];
 	/** If provided, replaces the tool result details payload in full. */
 	details?: unknown;
 	/** If provided, replaces the provider-native result metadata in full. */
@@ -676,8 +675,8 @@ export interface AgentState {
 }
 
 export interface AgentToolResult<T = any, _TInput = unknown> {
-	// Content blocks supporting text and images
-	content: (TextContent | ImageContent)[];
+	// Content blocks supporting text, images, and videos
+	content: ContentBlock[];
 	// Details to be displayed in a UI or logged
 	details?: T;
 	// Marks a non-throwing failure (e.g. an aggregator catching per-entry errors).

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `VideoContent` (`type: "video"`, base64 `data` + `mimeType`) plus the `ContentBlock` / `MessageContent` aliases, and wired video blocks through the chat-completions converters (`video_url` data-URL parts) with omission placeholders on text-only models.
+
 ## [17.2.9] - 2026-08-05
 
 ### Fixed

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -46,6 +46,7 @@ import { invalidateAwsCredentialCache, resolveAwsCredentials } from "./aws-crede
 import { decodeEventStream } from "./aws-eventstream";
 import { signRequest } from "./aws-sigv4";
 import { transformMessages } from "./transform-messages";
+import { NON_VIDEO_PLACEHOLDER } from "./vision-guard";
 
 export type BedrockThinkingDisplay = "summarized" | "omitted";
 
@@ -867,7 +868,7 @@ function convertMessages(
 						content: m.content.map(c =>
 							c.type === "image"
 								? { image: createImageBlock(c.mimeType, c.data) }
-								: { text: c.text.toWellFormed() },
+								: { text: c.type === "video" ? NON_VIDEO_PLACEHOLDER : c.text.toWellFormed() },
 						),
 						status: m.isError ? "error" : "success",
 					},
@@ -882,7 +883,7 @@ function convertMessages(
 							content: nextMsg.content.map(c =>
 								c.type === "image"
 									? { image: createImageBlock(c.mimeType, c.data) }
-									: { text: c.text.toWellFormed() },
+									: { text: c.type === "video" ? NON_VIDEO_PLACEHOLDER : c.text.toWellFormed() },
 							),
 							status: nextMsg.isError ? "error" : "success",
 						},

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -26,6 +26,7 @@ import type {
 	Api,
 	AssistantMessage,
 	CacheRetention,
+	ContentBlock,
 	Context,
 	FetchImpl,
 	ImageContent,
@@ -99,7 +100,7 @@ import {
 } from "./github-copilot-headers";
 import { getOpenAIPromptCacheKey } from "./openai-shared";
 import { transformMessages } from "./transform-messages";
-import { NON_VISION_IMAGE_PLACEHOLDER } from "./vision-guard";
+import { NON_VIDEO_PLACEHOLDER, NON_VISION_IMAGE_PLACEHOLDER } from "./vision-guard";
 
 export type AnthropicHeaderOptions = {
 	apiKey: string;
@@ -912,10 +913,10 @@ async function resizeAnthropicManyImageBlock(block: ImageContent): Promise<Image
 }
 
 async function resizeAnthropicManyImageContent(
-	content: (TextContent | ImageContent)[],
+	content: ContentBlock[],
 	state: { resized: number },
 	limit: ResizeLimiter,
-): Promise<(TextContent | ImageContent)[]> {
+): Promise<ContentBlock[]> {
 	let changed = false;
 	const next = await Promise.all(
 		content.map(async block => {
@@ -993,10 +994,7 @@ type AnthropicToolResultContent =
 /**
  * Convert content blocks to Anthropic API format
  */
-function convertContentBlocks(
-	content: (TextContent | ImageContent)[],
-	supportsImages = true,
-): AnthropicToolResultContent {
+function convertContentBlocks(content: ContentBlock[], supportsImages = true): AnthropicToolResultContent {
 	const blocks: Array<
 		| { type: "text"; text: string }
 		| {
@@ -1017,6 +1015,12 @@ function convertContentBlocks(
 			if (text.trim().length === 0) continue;
 			sawText = true;
 			blocks.push({ type: "text", text });
+			continue;
+		}
+
+		// Anthropic has no video input; degrade to a text placeholder.
+		if (block.type === "video") {
+			blocks.push({ type: "text", text: NON_VIDEO_PLACEHOLDER });
 			continue;
 		}
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -154,6 +154,7 @@ import * as AIError from "../error";
 import type {
 	Api,
 	AssistantMessage,
+	ContentBlock,
 	Context,
 	CursorExecHandlerResult,
 	CursorExecHandlers,
@@ -166,6 +167,7 @@ import type {
 	CursorToolResultHandler,
 	ImageContent,
 	Message,
+	MessageContent,
 	Model,
 	StreamFunction,
 	StreamOptions,
@@ -219,6 +221,7 @@ import {
 	piReadPathHasRange,
 	piTimeout,
 } from "./cursor/exec-modern";
+import { NON_VIDEO_PLACEHOLDER } from "./vision-guard";
 
 export const CURSOR_API_URL = "https://api2.cursor.sh";
 export const CURSOR_CLIENT_VERSION = "cli-2026.07.23-e383d2b";
@@ -3467,7 +3470,7 @@ function buildMcpResultFromToolResult(_mcpCall: CursorMcpCall, toolResult: ToolR
 		return create(McpToolResultContentItemSchema, {
 			content: {
 				case: "text",
-				value: create(McpTextContentSchema, { text: item.text }),
+				value: create(McpTextContentSchema, { text: item.type === "video" ? NON_VIDEO_PLACEHOLDER : item.text }),
 			},
 		});
 	});
@@ -4038,7 +4041,7 @@ function hasUserMessageImages(msg: Message): boolean {
 
 type CursorRootPromptContentPart = { type: "text"; text: string } | { type: "image"; image: string; mediaType: string };
 
-function buildCursorRootPromptContent(content: string | (TextContent | ImageContent)[]): CursorRootPromptContentPart[] {
+function buildCursorRootPromptContent(content: MessageContent): CursorRootPromptContentPart[] {
 	if (typeof content === "string") {
 		const text = content.trim();
 		return text ? [{ type: "text", text }] : [];
@@ -4050,6 +4053,9 @@ function buildCursorRootPromptContent(content: string | (TextContent | ImageCont
 			if (text) {
 				parts.push({ type: "text", text });
 			}
+		} else if (item.type === "video") {
+			// Cursor has no video input; degrade to a text placeholder.
+			parts.push({ type: "text", text: NON_VIDEO_PLACEHOLDER });
 		} else {
 			parts.push({ type: "image", image: `data:${item.mimeType};base64,${item.data}`, mediaType: item.mimeType });
 		}
@@ -4057,7 +4063,7 @@ function buildCursorRootPromptContent(content: string | (TextContent | ImageCont
 	return parts;
 }
 
-function cursorUserContentKey(content: string | (TextContent | ImageContent)[]): string {
+function cursorUserContentKey(content: MessageContent): string {
 	if (typeof content === "string") {
 		return content.trim();
 	}
@@ -4488,11 +4494,7 @@ export function buildCursorHistoryForTest(
 	}
 	return { rootPromptMessagesJson, turnUserMessagesJson, turnStepMessagesJson };
 }
-function createCursorUserMessage(
-	content: string | (TextContent | ImageContent)[],
-	text: string,
-	messageId = crypto.randomUUID(),
-) {
+function createCursorUserMessage(content: MessageContent, text: string, messageId = crypto.randomUUID()) {
 	const images = typeof content === "string" ? [] : extractImages(content);
 	return create(UserMessageSchema, {
 		text,
@@ -4507,7 +4509,7 @@ function createCursorUserMessage(
 	});
 }
 
-function extractImages(content: (TextContent | ImageContent)[]) {
+function extractImages(content: ContentBlock[]) {
 	return content
 		.filter((item): item is ImageContent => item.type === "image")
 		.map(image =>
@@ -4546,7 +4548,7 @@ function buildGrpcRequest(
 	const activeMessage = context.messages[activeUserMessageIndex];
 	const activeUserMessage =
 		activeMessage?.role === "user" || activeMessage?.role === "developer" ? activeMessage : undefined;
-	let userContent: string | (TextContent | ImageContent)[] | undefined;
+	let userContent: MessageContent | undefined;
 	let userText = "";
 	let hasUserImages = false;
 	if (activeUserMessage?.role === "user" || activeUserMessage?.role === "developer") {
@@ -4678,10 +4680,10 @@ function buildGrpcRequest(
 	return { requestBytes, blobStore, conversationState };
 }
 
-function hasImages(content: (TextContent | ImageContent)[]): boolean {
+function hasImages(content: ContentBlock[]): boolean {
 	return content.some(item => item.type === "image");
 }
-function extractText(content: (TextContent | ImageContent)[]): string {
+function extractText(content: ContentBlock[]): string {
 	return content
 		.filter((c): c is TextContent => c.type === "text")
 		.map(c => c.text)

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -39,7 +39,7 @@ import type {
 	ThinkingLevel,
 } from "./google-types";
 import { transformMessages } from "./transform-messages";
-import { NON_VISION_IMAGE_PLACEHOLDER } from "./vision-guard";
+import { NON_VIDEO_PLACEHOLDER, NON_VISION_IMAGE_PLACEHOLDER } from "./vision-guard";
 
 export type {
 	Content,
@@ -204,11 +204,16 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 				const supportsImages = model.input.includes("image");
 				const parts: Part[] = [];
 				let omittedImages = false;
+				let omittedVideos = false;
 				for (const item of msg.content) {
 					if (item.type === "text") {
 						const text = item.text.toWellFormed();
 						if (text.trim().length === 0) continue;
 						parts.push({ text });
+					} else if (item.type === "video") {
+						// Gemini accepts video inlineData, but catalog google models do not
+						// carry the "video" input capability yet; degrade for now.
+						omittedVideos = true;
 					} else if (supportsImages) {
 						parts.push({
 							inlineData: {
@@ -222,6 +227,9 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 				}
 				if (omittedImages) {
 					parts.push({ text: NON_VISION_IMAGE_PLACEHOLDER });
+				}
+				if (omittedVideos) {
+					parts.push({ text: NON_VIDEO_PLACEHOLDER });
 				}
 				if (parts.length === 0) continue;
 				contents.push({
@@ -293,6 +301,7 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 			const textResult = textContent.map(c => c.text).join("\n");
 			const imageContent = supportsImages ? msg.content.filter((c): c is ImageContent => c.type === "image") : [];
 			const omittedImages = !supportsImages && msg.content.some((c): c is ImageContent => c.type === "image");
+			const omittedVideos = msg.content.some(c => c.type === "video");
 
 			const hasText = textResult.length > 0;
 			const hasImages = imageContent.length > 0;
@@ -310,6 +319,9 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 					: hasImages
 						? "(see attached image)"
 						: "";
+			const responseValueWithVideo = omittedVideos
+				? [responseValue, NON_VIDEO_PLACEHOLDER].filter(Boolean).join("\n")
+				: responseValue;
 
 			const imageParts: Part[] = imageContent.map(imageBlock => ({
 				inlineData: {
@@ -323,7 +335,7 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 			const functionResponsePart: Part = {
 				functionResponse: {
 					name: emittedName ?? msg.toolName,
-					response: msg.isError ? { error: responseValue } : { output: responseValue },
+					response: msg.isError ? { error: responseValueWithVideo } : { output: responseValueWithVideo },
 					...(hasImages && modelSupportsMultimodalFunctionResponse && { parts: imageParts }),
 					...(includeId ? { id: msg.toolCallId } : {}),
 				},

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -4,13 +4,12 @@ import { getEnvApiKey } from "../stream";
 import type {
 	Api,
 	AssistantMessage,
+	ContentBlock,
 	Context,
-	ImageContent,
 	Message,
 	Model,
 	StreamFunction,
 	StreamOptions,
-	TextContent,
 	Tool,
 	ToolChoice,
 } from "../types";
@@ -32,7 +31,12 @@ import {
 	type StreamMarkupHealingEvent,
 } from "../utils/stream-markup-healing";
 import { transformMessages } from "./transform-messages";
-import { joinTextWithImagePlaceholder, partitionVisionContent } from "./vision-guard";
+import {
+	joinTextWithImagePlaceholder,
+	NON_VIDEO_PLACEHOLDER,
+	partitionVideoContent,
+	partitionVisionContent,
+} from "./vision-guard";
 
 export interface OllamaChatOptions extends StreamOptions {
 	reasoning?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
@@ -173,7 +177,7 @@ function selectToolsForToolChoice(tools: Tool[] | undefined, toolChoice: ToolCho
 }
 
 function toPlainContent(
-	content: string | ReadonlyArray<TextContent | ImageContent>,
+	content: string | ReadonlyArray<ContentBlock>,
 	supportsImages: boolean,
 ): {
 	content: string;
@@ -183,9 +187,13 @@ function toPlainContent(
 		return { content };
 	}
 	const { textBlocks, imageBlocks, omittedImages } = partitionVisionContent(content, supportsImages);
-	const text = textBlocks.map(block => block.text).join("\n");
+	const { omittedVideos } = partitionVideoContent(content, false);
+	let text = joinTextWithImagePlaceholder(textBlocks.map(block => block.text).join("\n"), omittedImages);
+	if (omittedVideos) {
+		text = text ? `${text}\n${NON_VIDEO_PLACEHOLDER}` : NON_VIDEO_PLACEHOLDER;
+	}
 	return {
-		content: joinTextWithImagePlaceholder(text, omittedImages),
+		content: text,
 		...(imageBlocks.length > 0 ? { images: imageBlocks.map(block => block.data) } : {}),
 	};
 }

--- a/packages/ai/src/providers/openai-chat-wire.ts
+++ b/packages/ai/src/providers/openai-chat-wire.ts
@@ -268,7 +268,25 @@ export type ChatCompletionContentPart =
 	| ChatCompletionContentPartText
 	| ChatCompletionContentPartImage
 	| ChatCompletionContentPartInputAudio
-	| ChatCompletionContentPartFile;
+	| ChatCompletionContentPartFile
+	| ChatCompletionContentPartVideo;
+
+/**
+ * Video content part. Moonshot's chat-completions extension
+ * (platform.kimi.ai/docs/guide/use-kimi-vision-model): `url` is either a
+ * `data:video/...;base64,...` payload or an `ms://<file-id>` reference to a
+ * file uploaded with `purpose="video"`.
+ */
+export interface ChatCompletionContentPartVideo {
+	video_url: ChatCompletionContentPartVideoVideoURL;
+	/** Always `video_url`. */
+	type: "video_url";
+}
+
+export interface ChatCompletionContentPartVideoVideoURL {
+	/** Either a base64 data URL or an `ms://<file-id>` upload reference. */
+	url: string;
+}
 
 // ─── Tool calls ──────────────────────────────────────────────────────────────
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -28,6 +28,7 @@ import type {
 	AssistantMessage,
 	CodexCompactionContext,
 	CodexCompactionRequestContext,
+	ContentBlock,
 	Context,
 	FetchImpl,
 	Model,
@@ -4477,7 +4478,7 @@ function convertMessages(model: Model<"openai-codex-responses">, context: Contex
 
 function normalizeInputMessageContent(
 	model: Model<"openai-codex-responses">,
-	content: string | Array<{ type: "text"; text: string } | { type: "image"; mimeType: string; data: string }>,
+	content: string | ContentBlock[],
 ): ResponseInputContent[] {
 	// gpt-5.x codex rejects reserved Harmony control-token spellings in input
 	// data; escape the transport copy of untrusted user text so ordinary docs or

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -61,6 +61,7 @@ import type {
 	ChatCompletionContentPart,
 	ChatCompletionContentPartImage,
 	ChatCompletionContentPartText,
+	ChatCompletionContentPartVideo,
 	ChatCompletionMessageParam,
 	ChatCompletionTool,
 	ChatCompletionToolMessageParam,
@@ -110,6 +111,7 @@ import { transformMessages } from "./transform-messages";
 import {
 	isDashscopeCompatibleModeTextOnlyQwen,
 	joinTextWithImagePlaceholder,
+	NON_VIDEO_PLACEHOLDER,
 	NON_VISION_IMAGE_PLACEHOLDER,
 } from "./vision-guard";
 
@@ -1913,8 +1915,10 @@ export function convertMessages(
 				});
 			} else {
 				const supportsImages = model.input.includes("image") && !isDashscopeCompatibleModeTextOnlyQwen(model);
+				const supportsVideos = model.input.includes("video");
 				const content: ChatCompletionContentPart[] = [];
 				let omittedImages = false;
+				let omittedVideos = false;
 				for (const item of msg.content) {
 					if (item.type === "text") {
 						const text = item.text.toWellFormed();
@@ -1923,6 +1927,17 @@ export function convertMessages(
 							type: "text",
 							text,
 						} satisfies ChatCompletionContentPartText);
+					} else if (item.type === "video") {
+						if (!supportsVideos) {
+							omittedVideos = true;
+							continue;
+						}
+						content.push({
+							type: "video_url",
+							video_url: {
+								url: `data:${item.mimeType};base64,${item.data}`,
+							},
+						} satisfies ChatCompletionContentPartVideo);
 					} else if (supportsImages) {
 						content.push({
 							type: "image_url",
@@ -1940,6 +1955,12 @@ export function convertMessages(
 					content.push({
 						type: "text",
 						text: NON_VISION_IMAGE_PLACEHOLDER,
+					} satisfies ChatCompletionContentPartText);
+				}
+				if (omittedVideos) {
+					content.push({
+						type: "text",
+						text: NON_VIDEO_PLACEHOLDER,
 					} satisfies ChatCompletionContentPartText);
 				}
 				if (content.length === 0) continue;
@@ -2190,8 +2211,8 @@ export function convertMessages(
 			}
 			params.push(assistantMsg);
 		} else if (msg.role === "toolResult") {
-			// Batch consecutive tool results and collect all images
-			const imageBlocks: Array<{ type: "image_url"; image_url: { url: string } }> = [];
+			// Batch consecutive tool results and collect all media
+			const mediaBlocks: ChatCompletionContentPart[] = [];
 			let j = i;
 
 			for (; j < transformedMessages.length && transformedMessages[j].role === "toolResult"; j++) {
@@ -2203,21 +2224,31 @@ export function convertMessages(
 					.map(c => (c as TextContent).text)
 					.join("\n");
 				const supportsImages = model.input.includes("image") && !isDashscopeCompatibleModeTextOnlyQwen(model);
+				const supportsVideos = model.input.includes("video");
 				const hasImages = toolMsg.content.some(c => c.type === "image");
+				const hasVideos = toolMsg.content.some(c => c.type === "video");
 				const omittedImages = hasImages && !supportsImages;
+				const omittedVideos = hasVideos && !supportsVideos;
 
-				// Always send tool result with text (or placeholder if only images)
+				// Always send tool result with text (or placeholder if only media)
 				const hasText = textResult.length > 0;
 				const remappedToolCallId = consumeToolCallId(toolMsg.toolCallId);
 				const resolvedToolCallId =
 					remappedToolCallId ?? ensureToolCallId(toolMsg.toolCallId, `${j}:${toolMsg.toolName ?? "tool"}`);
-				const toolResultContent = omittedImages
+				let toolResultContent = omittedImages
 					? joinTextWithImagePlaceholder(textResult, true)
 					: hasText
 						? textResult
 						: hasImages
 							? "(see attached image)"
 							: "";
+				if (omittedVideos) {
+					toolResultContent = toolResultContent
+						? `${toolResultContent}\n${NON_VIDEO_PLACEHOLDER}`
+						: NON_VIDEO_PLACEHOLDER;
+				} else if (!toolResultContent && hasVideos) {
+					toolResultContent = "(see attached video)";
+				}
 				const toolResultMsg: OpenAICompletionsToolMessageParam = {
 					role: "tool",
 					content: toolResultContent.toWellFormed(),
@@ -2231,9 +2262,21 @@ export function convertMessages(
 				if (hasImages && supportsImages) {
 					for (const block of toolMsg.content) {
 						if (block.type === "image") {
-							imageBlocks.push({
+							mediaBlocks.push({
 								type: "image_url",
 								image_url: {
+									url: `data:${block.mimeType};base64,${block.data}`,
+								},
+							});
+						}
+					}
+				}
+				if (hasVideos && supportsVideos) {
+					for (const block of toolMsg.content) {
+						if (block.type === "video") {
+							mediaBlocks.push({
+								type: "video_url",
+								video_url: {
 									url: `data:${block.mimeType};base64,${block.data}`,
 								},
 							});
@@ -2244,8 +2287,8 @@ export function convertMessages(
 
 			i = j - 1;
 
-			// After all consecutive tool results, add a single user message with all images
-			if (imageBlocks.length > 0) {
+			// After all consecutive tool results, add a single user message with all media
+			if (mediaBlocks.length > 0) {
 				if (compat.requiresAssistantAfterToolResult) {
 					params.push({
 						role: "assistant",
@@ -2258,9 +2301,9 @@ export function convertMessages(
 					content: [
 						{
 							type: "text",
-							text: "Attached image(s) from tool result:",
+							text: "Attached media from tool result:",
 						},
-						...imageBlocks,
+						...mediaBlocks,
 					],
 				});
 				lastRole = "user";

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -39,6 +39,7 @@ import {
 	type CacheRetention,
 	type ComputerAction,
 	type ComputerToolCallMetadata,
+	type ContentBlock,
 	type Context,
 	type ImageContent,
 	type Message,
@@ -112,7 +113,13 @@ import type {
 	ResponseStreamEvent,
 } from "./openai-responses-wire";
 import { transformMessages } from "./transform-messages";
-import { joinTextWithImagePlaceholder, NON_VISION_IMAGE_PLACEHOLDER, partitionVisionContent } from "./vision-guard";
+import {
+	joinTextWithImagePlaceholder,
+	NON_VIDEO_PLACEHOLDER,
+	NON_VISION_IMAGE_PLACEHOLDER,
+	partitionVideoContent,
+	partitionVisionContent,
+} from "./vision-guard";
 
 /**
  * Keyless-provider sentinel. Custom providers configured with `auth: none`
@@ -1507,7 +1514,7 @@ function clampResponsesImageDetail(
 }
 
 export function convertResponsesInputContent(
-	content: string | Array<TextContent | ImageContent>,
+	content: string | ContentBlock[],
 	supportsImages: boolean,
 	supportsImageDetailOriginal: boolean,
 	escapeControlTokens = false,
@@ -1545,6 +1552,13 @@ export function convertResponsesInputContent(
 		normalizedContent.push({
 			type: "input_text",
 			text: NON_VISION_IMAGE_PLACEHOLDER,
+		} satisfies ResponseInputText);
+	}
+	// The Responses API has no video input part; degrade to a text placeholder.
+	if (partitionVideoContent(content, false).omittedVideos) {
+		normalizedContent.push({
+			type: "input_text",
+			text: NON_VIDEO_PLACEHOLDER,
 		} satisfies ResponseInputText);
 	}
 	return normalizedContent.length > 0 ? normalizedContent : undefined;

--- a/packages/ai/src/providers/vision-guard.ts
+++ b/packages/ai/src/providers/vision-guard.ts
@@ -1,12 +1,13 @@
 import { isDashscopeCompatibleModeUrl } from "@oh-my-pi/pi-catalog/hosts";
 import { isQwenModelId } from "@oh-my-pi/pi-catalog/identity";
 
-import type { ImageContent, Model, TextContent } from "../types";
+import type { ContentBlock, ImageContent, Model, TextContent, VideoContent } from "../types";
 
 export const NON_VISION_IMAGE_PLACEHOLDER = "[image omitted: model does not support vision]";
+export const NON_VIDEO_PLACEHOLDER = "[video omitted: model does not support video input]";
 
 export function partitionVisionContent(
-	content: ReadonlyArray<TextContent | ImageContent>,
+	content: ReadonlyArray<ContentBlock>,
 	supportsImages: boolean,
 ): {
 	textBlocks: TextContent[];
@@ -19,6 +20,20 @@ export function partitionVisionContent(
 		textBlocks,
 		imageBlocks: supportsImages ? imageBlocks : [],
 		omittedImages: !supportsImages && imageBlocks.length > 0,
+	};
+}
+
+export function partitionVideoContent(
+	content: ReadonlyArray<ContentBlock>,
+	supportsVideos: boolean,
+): {
+	videoBlocks: VideoContent[];
+	omittedVideos: boolean;
+} {
+	const videoBlocks = content.filter((block): block is VideoContent => block.type === "video");
+	return {
+		videoBlocks: supportsVideos ? videoBlocks : [],
+		omittedVideos: !supportsVideos && videoBlocks.length > 0,
 	};
 }
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -727,6 +727,18 @@ export interface ImageContent {
 	detail?: "auto" | "low" | "high" | "original";
 }
 
+export interface VideoContent {
+	type: "video";
+	data: string; // base64 encoded video data
+	mimeType: string; // e.g., "video/mp4", "video/webm"
+}
+
+/** A single block in a multimodal message content array. */
+export type ContentBlock = TextContent | ImageContent | VideoContent;
+
+/** Message content: a plain string or an array of text/media blocks. */
+export type MessageContent = string | ContentBlock[];
+
 export type ComputerAction =
 	| {
 			type: "click";
@@ -809,7 +821,7 @@ export type ProviderPayload = OpenAIResponsesHistoryPayload;
 
 export interface UserMessage {
 	role: "user";
-	content: string | (TextContent | ImageContent)[];
+	content: MessageContent;
 	/** True if the message was injected by the system (e.g., auto-continue). */
 	synthetic?: boolean;
 	/** True when injected mid-turn as a steer; consumed by the agent's pre-LLM transform to wrap it for emphasis. Never rendered. */
@@ -823,7 +835,7 @@ export interface UserMessage {
 
 export interface DeveloperMessage {
 	role: "developer";
-	content: string | (TextContent | ImageContent)[];
+	content: MessageContent;
 	/** Who initiated this message for billing/attribution semantics. */
 	attribution?: MessageAttribution;
 	/** Provider-specific opaque payload used to reconstruct transport-native history. */
@@ -865,6 +877,7 @@ export interface AssistantMessage {
 		| AnthropicFallbackContent
 		| AnthropicServerToolContent
 		| ImageContent
+		| VideoContent
 		| ToolCall
 	)[];
 	api: Api;
@@ -910,7 +923,7 @@ export interface ToolResultMessage<TDetails = unknown> {
 	role: "toolResult";
 	toolCallId: string;
 	toolName: string;
-	content: (TextContent | ImageContent)[]; // Supports text and images
+	content: ContentBlock[]; // Supports text, images, and videos
 	details?: TDetails;
 	isError: boolean;
 	/** Who initiated this message for billing/attribution semantics. */

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `"video"` to `Model.input` capability metadata; Kimi Code discovery now stamps it from the model card's `supports_video_in` flag, and the model cache schema was bumped to invalidate rows predating video capability metadata.
+
 ## [17.2.9] - 2026-08-05
 
 ### Fixed

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -18,6 +18,7 @@ import { getProviderDefinition } from "@oh-my-pi/pi-ai/registry";
 import { $env } from "@oh-my-pi/pi-utils";
 import { ANTIGRAVITY_PRIMARY_ENDPOINT, fetchAntigravityDiscoveryModels } from "../src/discovery/antigravity";
 import { buildGitLabDuoWorkflowFallbackModel } from "../src/discovery/gitlab-duo-workflow";
+import { isKimiK3ModelId } from "../src/identity/family";
 import { createModelManager } from "../src/model-manager";
 import prevModelsJson from "../src/models.json" with { type: "json" };
 import { toModelSpec } from "../src/provider-models/bundled-references";
@@ -319,6 +320,23 @@ function applyKimiMaxTokensCap(models: readonly ModelSpec[]): ModelSpec[] {
 			return capped === model.maxTokens ? model : { ...model, maxTokens: capped };
 		}
 		return model;
+	});
+}
+
+/**
+ * Kimi K3 is documented video-capable (platform.kimi.ai/docs/guide/use-kimi-vision-model),
+ * but previous bundled snapshots predate the `supports_video_in` model-card field that
+ * runtime discovery maps from. Pin the documented input set on K3 rows so the committed
+ * catalog matches what credentialed discovery reports.
+ */
+function applyKimiK3VideoInput(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.map(model => {
+		const isK3 =
+			model.provider === "kimi-code"
+				? model.id.startsWith("k3")
+				: model.provider === "moonshot" && isKimiK3ModelId(model.id);
+		if (!isK3 || model.input.includes("video")) return model;
+		return { ...model, input: [...model.input, "video"] };
 	});
 }
 
@@ -661,6 +679,7 @@ async function generateModels() {
 	allModels = applyCodexPricingFallback(allModels);
 	allModels = applyAntigravityPricingFallback(allModels);
 	allModels = applyKimiMaxTokensCap(allModels);
+	allModels = applyKimiK3VideoInput(allModels);
 	allModels = applyFireworksDeepSeekReasoningShape(allModels);
 	allModels = dropFireworksWireIds(allModels);
 	allModels = dropUnusableZaiContextTierIds(allModels);

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -22,7 +22,9 @@ import type { Api, Model, ModelSpec } from "./types";
 // retired unknown-limit sentinels (222222/8888); v5 invalidated rows predating
 // effort-tier variant collapsing (raw `-low`/`-high`/`-thinking` member ids);
 // v4 dropped the pre-efforts ThinkingConfig shape.
-const CACHE_SCHEMA_VERSION = 12;
+// v13 invalidated rows predating video-input capability metadata (`input` may
+// lack "video" for models whose cards now report `supports_video_in`).
+const CACHE_SCHEMA_VERSION = 13;
 const HEADER_RESTORE_VERSION = 1;
 
 interface CacheRow {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3076,11 +3076,17 @@ export function kimiCodeModelManagerOptions(
 						const id = defaults.id;
 						const reasoning = kimiSupportsReasoning(entry, id);
 						const thinking = reasoning ? mapKimiThinking(entry) : undefined;
+						// Capability flags come from the model card (`supports_image_in` /
+						// `supports_video_in`), never from hard-coded id lists; the k2.5
+						// image fallback predates the card carrying the flag.
+						const input: ModelSpec<"openai-completions">["input"] = ["text"];
+						if (entry.supports_image_in === true || id.includes("k2.5")) input.push("image");
+						if (entry.supports_video_in === true) input.push("video");
 						return {
 							...defaults,
 							name: typeof entry.display_name === "string" ? entry.display_name : defaults.name,
 							reasoning,
-							input: entry.supports_image_in === true || id.includes("k2.5") ? ["text", "image"] : ["text"],
+							input,
 							contextWindow: typeof entry.context_length === "number" ? entry.context_length : 262144,
 							maxTokens: kimiCodeMaxTokens(id),
 							thinking,
@@ -3829,7 +3835,7 @@ export function moonshotModelManagerOptions(
 							return {
 								...model,
 								reasoning: true,
-								input: ["text", "image"],
+								input: ["text", "image", "video"],
 								cost: isZeroCost ? { ...MOONSHOT_KIMI_K3_COST } : model.cost,
 								contextWindow: model.contextWindow ?? MOONSHOT_KIMI_K3_CONTEXT_WINDOW,
 								maxTokens: model.maxTokens ?? MOONSHOT_KIMI_K3_MAX_TOKENS,

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -830,7 +830,7 @@ export interface Model<TApi extends Api = Api> {
 	provider: Provider;
 	baseUrl: string;
 	reasoning: boolean;
-	input: ("text" | "image")[];
+	input: ("text" | "image" | "video")[];
 	/**
 	 * Decoder family used for image inputs when it has narrower format support
 	 * than OMP's general image pipeline. `stb` local backends reject WebP.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added video file attachments: `@path/to/video.mp4` (and paste equivalents) are inlined as base64 `VideoContent` blocks and sent to models whose catalog metadata advertises video input (e.g. `kimi-code/k3`); unsupported models receive a placeholder notice instead.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/cli/file-processor.ts
+++ b/packages/coding-agent/src/cli/file-processor.ts
@@ -3,7 +3,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ImageContent } from "@oh-my-pi/pi-ai";
+import type { ImageContent, VideoContent } from "@oh-my-pi/pi-ai";
 import { getProjectDir, isEnoent, readImageMetadata } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import { resolveReadPath } from "../tools/path-utils";
@@ -15,10 +15,31 @@ import { CONVERTIBLE_EXTENSIONS, convertFileWithMarkit } from "../utils/markit";
 // If a file exceeds these limits, we include it as a path-only <file/> block.
 const MAX_CLI_TEXT_BYTES = 5 * 1024 * 1024; // 5MB
 const MAX_CLI_IMAGE_BYTES = 25 * 1024 * 1024; // 25MB
+// Base64 inflates ~4/3; keep inline videos under the provider's 100MB request-body cap.
+const MAX_CLI_VIDEO_BYTES = 75 * 1024 * 1024; // 75MB
+
+/**
+ * Extension → MIME for video attachments. Detection is by extension only (no
+ * container sniffing); format support is the provider's call, not ours.
+ */
+const VIDEO_EXTENSION_MIME: Record<string, string> = {
+	".mp4": "video/mp4",
+	".m4v": "video/mp4",
+	".mpeg": "video/mpeg",
+	".mpg": "video/mpg",
+	".mov": "video/mov",
+	".avi": "video/avi",
+	".flv": "video/x-flv",
+	".webm": "video/webm",
+	".wmv": "video/wmv",
+	".mkv": "video/x-matroska",
+	".3gp": "video/3gpp",
+};
 
 export interface ProcessedFiles {
 	text: string;
 	images: ImageContent[];
+	videos: VideoContent[];
 }
 
 export interface ProcessFileOptions {
@@ -31,6 +52,7 @@ export async function processFileArguments(fileArgs: string[], options?: Process
 	const autoResizeImages = options?.autoResizeImages ?? true;
 	let text = "";
 	const images: ImageContent[] = [];
+	const videos: VideoContent[] = [];
 
 	for (const fileArg of fileArgs) {
 		// Expand and resolve path (handles ~ expansion and macOS screenshot Unicode spaces)
@@ -45,7 +67,8 @@ export async function processFileArguments(fileArgs: string[], options?: Process
 		const imageMetadata = await readImageMetadata(absolutePath);
 		const mimeType = imageMetadata?.mimeType;
 		const ext = path.extname(absolutePath).toLowerCase();
-		const maxBytes = mimeType ? MAX_CLI_IMAGE_BYTES : MAX_CLI_TEXT_BYTES;
+		const videoMimeType = mimeType ? undefined : VIDEO_EXTENSION_MIME[ext];
+		const maxBytes = mimeType ? MAX_CLI_IMAGE_BYTES : videoMimeType ? MAX_CLI_VIDEO_BYTES : MAX_CLI_TEXT_BYTES;
 		if (stat.size > maxBytes) {
 			console.error(
 				chalk.yellow(`Warning: Skipping file contents (too large: ${formatBytes(stat.size)}): ${absolutePath}`),
@@ -108,6 +131,14 @@ export async function processFileArguments(fileArgs: string[], options?: Process
 			} else {
 				text += `<file name="${absolutePath}"></file>\n`;
 			}
+		} else if (videoMimeType) {
+			// Handle video file: inline base64, no resize pipeline
+			videos.push({
+				type: "video",
+				mimeType: videoMimeType,
+				data: buffer.toBase64(),
+			});
+			text += `<file name="${absolutePath}"></file>\n`;
 		} else if (CONVERTIBLE_EXTENSIONS.has(ext)) {
 			const result = await convertFileWithMarkit(absolutePath);
 			if (result.ok) {
@@ -128,5 +159,5 @@ export async function processFileArguments(fileArgs: string[], options?: Process
 		}
 	}
 
-	return { text, images };
+	return { text, images, videos };
 }

--- a/packages/coding-agent/src/cli/initial-message.ts
+++ b/packages/coding-agent/src/cli/initial-message.ts
@@ -1,16 +1,18 @@
-import type { ImageContent } from "@oh-my-pi/pi-ai";
+import type { ImageContent, VideoContent } from "@oh-my-pi/pi-ai";
 import type { Args } from "./args";
 
 export interface InitialMessageInput {
 	parsed: Args;
 	fileText?: string;
 	fileImages?: ImageContent[];
+	fileVideos?: VideoContent[];
 	stdinContent?: string;
 }
 
 export interface InitialMessageResult {
 	initialMessage?: string;
 	initialImages?: ImageContent[];
+	initialVideos?: VideoContent[];
 }
 
 /**
@@ -21,12 +23,18 @@ export function buildInitialMessage({
 	parsed,
 	fileText,
 	fileImages,
+	fileVideos,
 	stdinContent,
 }: InitialMessageInput): InitialMessageResult {
-	const hasInitialContext = stdinContent !== undefined || fileText !== undefined || (fileImages?.length ?? 0) > 0;
+	const hasInitialContext =
+		stdinContent !== undefined ||
+		fileText !== undefined ||
+		(fileImages?.length ?? 0) > 0 ||
+		(fileVideos?.length ?? 0) > 0;
 	if (!hasInitialContext) {
 		return {
 			initialImages: undefined,
+			initialVideos: undefined,
 		};
 	}
 
@@ -47,12 +55,13 @@ export function buildInitialMessage({
 				: stdinContent
 			: body.length > 0
 				? body
-				: fileImages && fileImages.length > 0
+				: (fileImages && fileImages.length > 0) || (fileVideos && fileVideos.length > 0)
 					? ""
 					: undefined;
 
 	return {
 		initialMessage,
 		initialImages: fileImages && fileImages.length > 0 ? fileImages : undefined,
+		initialVideos: fileVideos && fileVideos.length > 0 ? fileVideos : undefined,
 	};
 }

--- a/packages/coding-agent/src/cli/models-cli.ts
+++ b/packages/coding-agent/src/cli/models-cli.ts
@@ -73,7 +73,7 @@ interface ModelJson {
 	reasoning: boolean;
 	/** Supported thinking efforts when the model thinks, otherwise null. */
 	thinking: readonly Effort[] | null;
-	input: ("text" | "image")[];
+	input: ("text" | "image" | "video")[];
 	cost: Model<Api>["cost"];
 }
 

--- a/packages/coding-agent/src/export/share.ts
+++ b/packages/coding-agent/src/export/share.ts
@@ -20,7 +20,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentMessage, AgentState } from "@oh-my-pi/pi-agent-core";
-import type { AssistantMessage, ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, ImageContent, MessageContent, TextContent, VideoContent } from "@oh-my-pi/pi-ai";
 import { $which, logger } from "@oh-my-pi/pi-utils";
 import { DEFAULT_SHARE_URL } from "@oh-my-pi/pi-wire";
 import { $ } from "bun";
@@ -123,7 +123,7 @@ function collectShareRegexSecretValues(o: SecretObfuscator, data: SessionData): 
 		if (!isRecord(value)) return;
 		for (const item of Object.values(value)) addJsonStrings(item);
 	};
-	const addContent = (content: string | (TextContent | ImageContent)[]): void => {
+	const addContent = (content: MessageContent): void => {
 		if (typeof content === "string") {
 			add(content);
 			return;
@@ -346,9 +346,9 @@ function redactShareEntry(
 
 function redactShareContent(
 	o: SecretObfuscator,
-	content: string | (TextContent | ImageContent)[],
+	content: MessageContent,
 	sharedRegexSecretValues: ReadonlySet<string>,
-): string | (TextContent | ImageContent)[] {
+): MessageContent {
 	if (typeof content === "string") return o.obfuscate(content, sharedRegexSecretValues);
 	return content.map(block =>
 		block.type === "text" ? { ...block, text: o.obfuscate(block.text, sharedRegexSecretValues) } : block,
@@ -400,7 +400,11 @@ function redactShareMessage(
 			return {
 				...message,
 				details: undefined,
-				content: redactShareContent(o, message.content, sharedRegexSecretValues) as (TextContent | ImageContent)[],
+				content: redactShareContent(o, message.content, sharedRegexSecretValues) as (
+					| TextContent
+					| ImageContent
+					| VideoContent
+				)[],
 			};
 		case "assistant":
 			// Drop opaque provider-replay state (encrypted reasoning / native history) the viewer

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -24,6 +24,7 @@ import type {
 	Api,
 	AssistantMessageEvent,
 	AssistantMessageEventStream,
+	ContentBlock,
 	Context,
 	ImageContent,
 	Model,
@@ -875,7 +876,7 @@ interface ToolResultEventBase {
 	type: "tool_result";
 	toolCallId: string;
 	input: Record<string, unknown>;
-	content: (TextContent | ImageContent)[];
+	content: ContentBlock[];
 	isError: boolean;
 }
 

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -8,7 +8,7 @@ import type {
 	AgentToolUpdateCallback,
 	ToolLoadMode,
 } from "@oh-my-pi/pi-agent-core";
-import type { ComputerSafetyCheck, ImageContent, Static, TextContent, TSchema } from "@oh-my-pi/pi-ai";
+import type { ComputerSafetyCheck, ContentBlock, Static, TSchema } from "@oh-my-pi/pi-ai";
 import { sanitizeText } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../../config/settings";
 import type { Theme } from "../../modes/theme/theme";
@@ -362,7 +362,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 			});
 
 			if (resultResult) {
-				const modifiedContent: (TextContent | ImageContent)[] = resultResult.content ?? result.content;
+				const modifiedContent: ContentBlock[] = resultResult.content ?? result.content;
 				const modifiedDetails = (resultResult.details ?? result.details) as TDetails;
 
 				// Effective error state: an explicit handler override wins; otherwise the

--- a/packages/coding-agent/src/extensibility/hooks/types.ts
+++ b/packages/coding-agent/src/extensibility/hooks/types.ts
@@ -1,7 +1,7 @@
 import type { Type } from "@oh-my-pi/omptype";
 import type * as TypeBox from "@oh-my-pi/omptype/typebox";
 import type * as zod from "@oh-my-pi/omptype/zod";
-import type { ImageContent, Message, Model, TextContent } from "@oh-my-pi/pi-ai";
+import type { ContentBlock, ImageContent, Message, Model } from "@oh-my-pi/pi-ai";
 import type { Component, TUI } from "@oh-my-pi/pi-tui";
 import type { logger as PiLogger } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../../config/model-registry";
@@ -323,7 +323,7 @@ interface ToolResultEventBase {
 	/** Tool input parameters */
 	input: Record<string, unknown>;
 	/** Full content array (text and images) */
-	content: (TextContent | ImageContent)[];
+	content: ContentBlock[];
 	/** Whether the tool execution was an error */
 	isError?: boolean;
 }

--- a/packages/coding-agent/src/extensibility/shared-events.ts
+++ b/packages/coding-agent/src/extensibility/shared-events.ts
@@ -14,7 +14,7 @@
  */
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { CompactionPreparation, CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
-import type { AssistantRetryRecovery, ImageContent, TextContent, ToolResultMessage } from "@oh-my-pi/pi-ai";
+import type { AssistantRetryRecovery, ContentBlock, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import type { Rule } from "../capability/rule";
 import type { Goal, GoalModeState } from "../goals/state";
 import type { BranchSummaryEntry, CompactionEntry, SessionEntry } from "../session/session-entries";
@@ -321,7 +321,7 @@ export interface ToolCallEventResult {
  */
 export interface ToolResultEventResult {
 	/** Replacement content array (text and images) */
-	content?: (TextContent | ImageContent)[];
+	content?: ContentBlock[];
 	/** Replacement details */
 	details?: unknown;
 	/** Override isError flag */

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -8,7 +8,7 @@ import * as fsSync from "node:fs";
 import * as os from "node:os";
 import { createInterface } from "node:readline/promises";
 import { EventLoopKeepalive } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent } from "@oh-my-pi/pi-ai";
+import type { ImageContent, VideoContent } from "@oh-my-pi/pi-ai";
 import {
 	$env,
 	directoryExists,
@@ -423,6 +423,7 @@ async function runInteractiveMode(
 	eventBus?: EventBus,
 	initialMessage?: string,
 	initialImages?: ImageContent[],
+	initialVideos?: VideoContent[],
 	joinLink?: string,
 ): Promise<void> {
 	const mode = new InteractiveMode(
@@ -509,7 +510,7 @@ async function runInteractiveMode(
 		session.maybeStartTitleGeneration(initialMessage);
 		try {
 			using _keepalive = new EventLoopKeepalive();
-			await session.prompt(initialMessage, { images: initialImages });
+			await session.prompt(initialMessage, { images: initialImages, videos: initialVideos });
 		} catch (error: unknown) {
 			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 			mode.showError(errorMessage);
@@ -1580,10 +1581,11 @@ export async function runRootCommand(
 						}),
 					)
 				: undefined;
-		const { initialMessage, initialImages } = buildInitialMessage({
+		const { initialMessage, initialImages, initialVideos } = buildInitialMessage({
 			parsed: initialArgs,
 			fileText: processedFiles?.text,
 			fileImages: processedFiles?.images,
+			fileVideos: processedFiles?.videos,
 			stdinContent: pipedInput,
 		});
 
@@ -1706,6 +1708,7 @@ export async function runRootCommand(
 				eventBus,
 				initialMessage,
 				initialImages,
+				initialVideos,
 				parsedArgs.join,
 			);
 		} else {
@@ -1717,6 +1720,7 @@ export async function runRootCommand(
 				messages: initialArgs.messages,
 				initialMessage,
 				initialImages,
+				initialVideos,
 				printThoughts: initialArgs.printThoughts,
 			});
 			if ($env.PI_TIMING) {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -118,6 +118,12 @@ type AgentImageContent = {
 	mimeType: string;
 };
 
+type AgentVideoContent = {
+	type: "video";
+	data: string;
+	mimeType: string;
+};
+
 type PromptQueueState = {
 	promise: Promise<void>;
 	release: (() => void) | undefined;
@@ -731,9 +737,11 @@ export class AcpAgent implements Agent {
 				this.#trackPromptEvent(record, event);
 			});
 
-			this.#runPromptOrCommand(record, converted.text, converted.images).catch((error: unknown) => {
-				this.#finishPrompt(record, undefined, error);
-			});
+			this.#runPromptOrCommand(record, converted.text, converted.images, converted.videos).catch(
+				(error: unknown) => {
+					this.#finishPrompt(record, undefined, error);
+				},
+			);
 
 			return await pendingPrompt.promise;
 		});
@@ -808,7 +816,12 @@ export class AcpAgent implements Agent {
 		}
 	}
 
-	async #runPromptOrCommand(record: ManagedSessionRecord, text: string, images: AgentImageContent[]): Promise<void> {
+	async #runPromptOrCommand(
+		record: ManagedSessionRecord,
+		text: string,
+		images: AgentImageContent[],
+		videos: AgentVideoContent[],
+	): Promise<void> {
 		const skillResult = await this.#tryRunSkillCommand(record, text);
 		if (skillResult) {
 			return;
@@ -838,7 +851,7 @@ export class AcpAgent implements Agent {
 		});
 		if (builtinResult !== false) {
 			if ("prompt" in builtinResult) {
-				await record.session.prompt(builtinResult.prompt, { images });
+				await record.session.prompt(builtinResult.prompt, { images, videos });
 				return;
 			}
 			const promptTurn = record.promptTurn;
@@ -854,7 +867,7 @@ export class AcpAgent implements Agent {
 		}
 
 		const extensionPromptBaseline = new Set(record.extensionUserMessageTasks);
-		const agentInvoked = await record.session.prompt(text, { images });
+		const agentInvoked = await record.session.prompt(text, { images, videos });
 		// Extension and custom-TS commands are handled locally inside session.prompt().
 		// An ACP extension command can still call pi.sendUserMessage(), which starts
 		// an async nested prompt through the extension runtime. Keep the ACP turn
@@ -1489,9 +1502,14 @@ export class AcpAgent implements Agent {
 		}
 	}
 
-	#convertPromptBlocks(blocks: PromptRequest["prompt"]): { text: string; images: AgentImageContent[] } {
+	#convertPromptBlocks(blocks: PromptRequest["prompt"]): {
+		text: string;
+		images: AgentImageContent[];
+		videos: AgentVideoContent[];
+	} {
 		const textParts: string[] = [];
 		const images: AgentImageContent[] = [];
+		const videos: AgentVideoContent[] = [];
 		for (const block of blocks) {
 			switch (block.type) {
 				case "text":
@@ -1509,6 +1527,8 @@ export class AcpAgent implements Agent {
 						// to the images array so the user's intent survives; everything
 						// else falls back to the URI placeholder below.
 						images.push({ type: "image", data: block.resource.blob, mimeType: block.resource.mimeType });
+					} else if (typeof block.resource.mimeType === "string" && block.resource.mimeType.startsWith("video/")) {
+						videos.push({ type: "video", data: block.resource.blob, mimeType: block.resource.mimeType });
 					} else {
 						textParts.push(`[embedded resource: ${block.resource.uri}]`);
 					}
@@ -1524,6 +1544,7 @@ export class AcpAgent implements Agent {
 		return {
 			text: textParts.join("\n\n").trim(),
 			images,
+			videos,
 		};
 	}
 

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -6,7 +6,7 @@
  * - `omp --mode json "prompt"` - JSON event stream
  */
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent } from "@oh-my-pi/pi-ai";
+import type { ImageContent, VideoContent } from "@oh-my-pi/pi-ai";
 import { logger, sanitizeText } from "@oh-my-pi/pi-utils";
 import { resolvePlanModelTransition } from "../plan-mode/model-transition";
 import { type AgentSession, type AgentSessionEvent, SHUTDOWN_CONSOLIDATE_BUDGET_MS } from "../session/agent-session";
@@ -27,6 +27,8 @@ export interface PrintModeOptions {
 	initialMessage?: string;
 	/** Images to attach to the initial message */
 	initialImages?: ImageContent[];
+	/** Videos to attach to the initial message */
+	initialVideos?: VideoContent[];
 	/** If true, include thinking blocks in text output */
 	printThoughts?: boolean;
 }
@@ -89,7 +91,7 @@ export function printableEvent(event: AgentSessionEvent): unknown {
  * Sends prompts to the agent and outputs the result.
  */
 export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<void> {
-	const { mode, messages = [], initialMessage, initialImages, printThoughts } = options;
+	const { mode, messages = [], initialMessage, initialImages, initialVideos, printThoughts } = options;
 
 	// process.stdout.write is fire-and-forget: a large final record (e.g. a
 	// multi-MB agent_end) can be dropped when the process exits before the pipe
@@ -205,7 +207,9 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 	if (initialMessage !== undefined) {
 		writeTextWorkingIndicator();
 		if (mode === "text") session.setTextOutputCommitted(false);
-		await logger.time("print:prompt:initial", () => session.prompt(initialMessage, { images: initialImages }));
+		await logger.time("print:prompt:initial", () =>
+			session.prompt(initialMessage, { images: initialImages, videos: initialVideos }),
+		);
 	}
 
 	// Send remaining messages

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -145,6 +145,7 @@ import {
 	convertToLlm,
 	LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE,
 	replaceLlmImagesWithText,
+	replaceLlmVideosWithText,
 	USER_INTERRUPT_LABEL,
 	wrapSteeringForModel,
 } from "./session/messages";
@@ -3110,6 +3111,12 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				return replaceLlmImagesWithText(
 					converted,
 					"[image omitted: the active model does not support image input]",
+				);
+			}
+			if (activeModel && !activeModel.input.includes("video")) {
+				return replaceLlmVideosWithText(
+					converted,
+					"[video omitted: the active model does not support video input]",
 				);
 			}
 			return converted;

--- a/packages/coding-agent/src/secrets/obfuscator.ts
+++ b/packages/coding-agent/src/secrets/obfuscator.ts
@@ -1,6 +1,6 @@
 import * as crypto from "node:crypto";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import type { AssistantMessage, Context, ImageContent, Message, TextContent } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, ContentBlock, Context, Message } from "@oh-my-pi/pi-ai";
 import type { SessionContext } from "../session/session-context";
 import { compileSecretRegex } from "./regex";
 
@@ -1968,11 +1968,11 @@ type UserFacingMessage = Extract<Message, { role: "user" | "developer" | "toolRe
 /** Obfuscate `text` blocks of a content array; image and other blocks pass through. */
 function obfuscateTextBlocks(
 	obfuscator: SecretObfuscator,
-	content: (TextContent | ImageContent)[],
+	content: ContentBlock[],
 	sharedRegexSecretValues?: ReadonlySet<string>,
-): (TextContent | ImageContent)[] {
+): ContentBlock[] {
 	let changed = false;
-	const result = content.map((block): TextContent | ImageContent => {
+	const result = content.map((block): ContentBlock => {
 		if (block.type !== "text") return block;
 		const text = obfuscator.obfuscate(block.text, sharedRegexSecretValues);
 		if (text === block.text) return block;
@@ -1983,12 +1983,9 @@ function obfuscateTextBlocks(
 }
 
 /** Restore placeholders in `text` blocks of a content array; image and other blocks pass through. */
-function deobfuscateTextBlocks(
-	obfuscator: SecretObfuscator,
-	content: (TextContent | ImageContent)[],
-): (TextContent | ImageContent)[] {
+function deobfuscateTextBlocks(obfuscator: SecretObfuscator, content: ContentBlock[]): ContentBlock[] {
 	let changed = false;
-	const result = content.map((block): TextContent | ImageContent => {
+	const result = content.map((block): ContentBlock => {
 		if (block.type !== "text") return block;
 		const text = obfuscator.deobfuscate(block.text);
 		if (text === block.text) return block;

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -17,6 +17,7 @@ import type {
 	ServiceTierByFamily,
 	SimpleStreamOptions,
 	ToolChoice,
+	VideoContent,
 } from "@oh-my-pi/pi-ai";
 import type { postmortem } from "@oh-my-pi/pi-utils";
 import type { AdvisorConfig } from "../advisor";
@@ -284,6 +285,8 @@ export interface PromptOptions {
 	expandPromptTemplates?: boolean;
 	/** Image attachments. */
 	images?: ImageContent[];
+	/** Video attachments. */
+	videos?: VideoContent[];
 	/** Queue behavior while streaming. */
 	streamingBehavior?: "steer" | "followUp";
 	/** Optional tool choice override for the next LLM call. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -55,6 +55,7 @@ import {
 import type {
 	AssistantMessage,
 	CodexCompactionContext,
+	ContentBlock,
 	ImageContent,
 	Message,
 	Model,
@@ -4993,9 +4994,12 @@ export class AgentSession {
 			!options?.synthetic && !hasPendingUserDirective ? this.#todo.createEagerTaskPrelude(expandedText) : undefined;
 		const normalizedImages = await this.#normalizeImagesForModel(options?.images);
 
-		const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
+		const userContent: ContentBlock[] = [{ type: "text", text: expandedText }];
 		if (normalizedImages?.length) {
 			userContent.push(...normalizedImages);
+		}
+		if (options?.videos?.length) {
+			userContent.push(...options.videos);
 		}
 		// Text-only model + image attachment: describe via a vision model and inject the
 		// description as a hidden companion (the image stays in the visible user message).

--- a/packages/coding-agent/src/session/checkpoint-entries.ts
+++ b/packages/coding-agent/src/session/checkpoint-entries.ts
@@ -1,12 +1,12 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import type { MessageContent } from "@oh-my-pi/pi-ai";
 import { stringProperty } from "@oh-my-pi/pi-utils";
 import type { CompletedRewindState } from "../tools/checkpoint";
 import { writeDeviceDispatch } from "../tools/resolve";
 import type { SessionEntry } from "./session-entries";
 
 /** Extracts text from custom message content. */
-export function customMessageContentText(content: string | (TextContent | ImageContent)[]): string {
+export function customMessageContentText(content: MessageContent): string {
 	if (typeof content === "string") return content;
 	const parts: string[] = [];
 	for (const part of content) {

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -16,9 +16,11 @@ import {
 } from "@oh-my-pi/pi-agent-core/compaction/messages";
 import type {
 	AssistantMessage,
+	ContentBlock,
 	ImageContent,
 	Message,
 	MessageAttribution,
+	MessageContent,
 	TextContent,
 	UserMessage,
 } from "@oh-my-pi/pi-ai";
@@ -311,7 +313,7 @@ export const DEFAULT_CUSTOM_MESSAGE_TYPE = "custom-message";
 export const LIVE_DELEGATION_MESSAGE_TYPE = "live-delegation";
 
 /** Content shape accepted for extension-injected messages. */
-export type CustomMessageContent = string | (TextContent | ImageContent)[];
+export type CustomMessageContent = MessageContent;
 
 /** Public input accepted by `pi.sendMessage` and `AgentSession.sendCustomMessage`. */
 export type CustomMessagePayload<T = unknown> =
@@ -639,7 +641,7 @@ function renderSteeringEnvelope(message: string): string {
 	return prompt.render(userInterjectionTemplate, { message });
 }
 
-function getArrayContentText(content: (TextContent | ImageContent)[]): string {
+function getArrayContentText(content: ContentBlock[]): string {
 	let firstText: string | undefined;
 	let textParts: string[] | undefined;
 	for (const part of content) {
@@ -656,7 +658,7 @@ function getArrayContentText(content: (TextContent | ImageContent)[]): string {
 	return textParts === undefined ? (firstText ?? "") : textParts.join("\n");
 }
 
-function getArrayContentImages(content: (TextContent | ImageContent)[]): ImageContent[] {
+function getArrayContentImages(content: ContentBlock[]): ImageContent[] {
 	let images: ImageContent[] | undefined;
 	for (const part of content) {
 		if (part.type !== "image") continue;
@@ -709,15 +711,15 @@ export function wrapSteeringForModel(messages: AgentMessage[]): AgentMessage[] {
 	return wrappedMessages ?? messages;
 }
 
-/** Result of filtering image blocks out of a `(TextContent | ImageContent)[]` array. */
+/** Result of filtering image blocks out of a `ContentBlock[]` array. */
 interface StripContentResult {
-	content: (TextContent | ImageContent)[];
+	content: ContentBlock[];
 	removed: number;
 }
 
-function stripImagesFromArrayContent(content: (TextContent | ImageContent)[]): StripContentResult {
+function stripImagesFromArrayContent(content: ContentBlock[]): StripContentResult {
 	let removed = 0;
-	const kept: (TextContent | ImageContent)[] = [];
+	const kept: ContentBlock[] = [];
 	for (const part of content) {
 		if (part.type === "image") {
 			removed++;
@@ -830,9 +832,36 @@ export function replaceLlmImagesWithText(messages: Message[], placeholder: strin
 		if (msg.role !== "user" && msg.role !== "developer" && msg.role !== "toolResult") continue;
 		const content = msg.content;
 		if (!Array.isArray(content) || !content.some(part => part.type === "image")) continue;
-		const replaced: (TextContent | ImageContent)[] = [];
+		const replaced: ContentBlock[] = [];
 		for (const part of content) {
 			if (part.type !== "image") {
+				replaced.push(part);
+				continue;
+			}
+			const prev = replaced[replaced.length - 1];
+			if (prev?.type === "text" && prev.text === placeholder) continue;
+			replaced.push({ type: "text", text: placeholder });
+		}
+		if (out === undefined) out = messages.slice();
+		out[i] = { ...msg, content: replaced } as Message;
+	}
+	return out ?? messages;
+}
+
+/**
+ * Video counterpart to {@link replaceLlmImagesWithText}: keeps video blocks off
+ * the wire when the active model has no video input capability.
+ */
+export function replaceLlmVideosWithText(messages: Message[], placeholder: string): Message[] {
+	let out: Message[] | undefined;
+	for (let i = 0; i < messages.length; i++) {
+		const msg = messages[i];
+		if (msg.role !== "user" && msg.role !== "developer" && msg.role !== "toolResult") continue;
+		const content = msg.content;
+		if (!Array.isArray(content) || !content.some(part => part.type === "video")) continue;
+		const replaced: ContentBlock[] = [];
+		for (const part of content) {
+			if (part.type !== "video") {
 				replaced.push(part);
 				continue;
 			}
@@ -1014,7 +1043,7 @@ export function sanitizeRehydratedOpenAIResponsesAssistantMessage(message: Assis
 	};
 }
 
-function customMessageContentToLlmContent(content: CustomMessage["content"]): (TextContent | ImageContent)[] {
+function customMessageContentToLlmContent(content: CustomMessage["content"]): ContentBlock[] {
 	return typeof content === "string" ? [{ type: "text", text: content }] : content;
 }
 

--- a/packages/coding-agent/src/session/provider-image-budget.ts
+++ b/packages/coding-agent/src/session/provider-image-budget.ts
@@ -1,7 +1,7 @@
 import type {
+	ContentBlock,
 	Context,
 	DeveloperMessage,
-	ImageContent,
 	Model,
 	TextContent,
 	ToolResultMessage,
@@ -25,12 +25,9 @@ function countImages(context: Context): number {
 	return count;
 }
 
-function clampContent(
-	content: readonly (TextContent | ImageContent)[],
-	state: { remainingDrops: number },
-): (TextContent | ImageContent)[] | undefined {
+function clampContent(content: readonly ContentBlock[], state: { remainingDrops: number }): ContentBlock[] | undefined {
 	let changed = false;
-	const clamped: (TextContent | ImageContent)[] = [];
+	const clamped: ContentBlock[] = [];
 	for (const part of content) {
 		if (part.type === "image" && state.remainingDrops > 0) {
 			state.remainingDrops--;

--- a/packages/coding-agent/src/session/session-entries.ts
+++ b/packages/coding-agent/src/session/session-entries.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent, MessageAttribution, ServiceTierByFamily, TextContent } from "@oh-my-pi/pi-ai";
+import type { MessageAttribution, MessageContent, ServiceTierByFamily } from "@oh-my-pi/pi-ai";
 import type { StructuredSubagentSchemaMode } from "../task/types";
 
 export const CURRENT_SESSION_VERSION = 3;
@@ -243,7 +243,7 @@ export interface ModeChangeEntry extends SessionEntryBase {
 export interface CustomMessageEntry<T = unknown> extends SessionEntryBase {
 	type: "custom_message";
 	customType: string;
-	content: string | (TextContent | ImageContent)[];
+	content: MessageContent;
 	details?: T;
 	display: boolean;
 	/** Who initiated this message for billing/attribution semantics. */

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -7,7 +7,7 @@
  * as one-liners. No system prompt, no tool catalog, no config sections.
  */
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import type { AssistantMessage, ImageContent, TextContent, ToolResultMessage } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, ContentBlock, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { escapeXmlText } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import type {
@@ -90,7 +90,7 @@ export function formatExecutionSourcePreview(source: string): string {
 }
 
 /** Join the text blocks of a string-or-blocks content field. Images become `[image]`. */
-function contentToText(content: string | readonly (TextContent | ImageContent)[]): string {
+function contentToText(content: string | readonly ContentBlock[]): string {
 	if (typeof content === "string") return content;
 	const parts: string[] = [];
 	for (const block of content) {
@@ -167,7 +167,7 @@ export function formatToolCallIntentPreview(args: Record<string, unknown> | unde
 	return typeof intent === "string" && intent.trim() ? oneLine(intent, 80) : undefined;
 }
 
-export function formatToolResultErrorPreview(content: string | readonly (TextContent | ImageContent)[]): string {
+export function formatToolResultErrorPreview(content: string | readonly ContentBlock[]): string {
 	return oneLine(contentToText(content).split("\n", 1)[0] ?? "");
 }
 

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1,13 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type {
-	ImageContent,
-	Message,
-	MessageAttribution,
-	ServiceTierByFamily,
-	TextContent,
-	Usage,
-} from "@oh-my-pi/pi-ai";
+import type { Message, MessageAttribution, MessageContent, ServiceTierByFamily, Usage } from "@oh-my-pi/pi-ai";
 import {
 	directoryExists,
 	getBlobsDir,
@@ -2130,7 +2123,7 @@ export class SessionManager {
 	 */
 	appendCustomMessageEntry<T = unknown>(
 		customType: string | undefined,
-		content: string | (TextContent | ImageContent)[] | undefined,
+		content: MessageContent | undefined,
 		display: boolean | undefined,
 		details?: T,
 		attribution: MessageAttribution | undefined = "agent",

--- a/packages/coding-agent/src/session/snapcompact-inline.ts
+++ b/packages/coding-agent/src/session/snapcompact-inline.ts
@@ -15,7 +15,15 @@
  */
 
 import { countTokens } from "@oh-my-pi/pi-agent-core";
-import type { Context, ImageContent, Model, TextContent, ToolResultMessage, UserMessage } from "@oh-my-pi/pi-ai";
+import type {
+	ContentBlock,
+	Context,
+	ImageContent,
+	Model,
+	TextContent,
+	ToolResultMessage,
+	UserMessage,
+} from "@oh-my-pi/pi-ai";
 import * as snapcompact from "@oh-my-pi/snapcompact";
 import contextFramesNote from "../prompts/system/snapcompact-context-frames-note.md" with { type: "text" };
 import contextStub from "../prompts/system/snapcompact-context-stub.md" with { type: "text" };
@@ -68,7 +76,7 @@ function countContextImages(context: Context): number {
 	return count;
 }
 
-function isTextContent(block: TextContent | ImageContent): block is TextContent {
+function isTextContent(block: ContentBlock): block is TextContent {
 	return block.type === "text";
 }
 
@@ -515,7 +523,7 @@ export class SnapcompactInlineTransformer {
 			}
 			const frames = cached.frames;
 			const original = messages[userIndex] as UserMessage;
-			const originalContent: (TextContent | ImageContent)[] =
+			const originalContent: ContentBlock[] =
 				typeof original.content === "string" ? [{ type: "text", text: original.content }] : original.content;
 			messages[userIndex] = {
 				...original,

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -11,7 +11,7 @@ import type {
 	AgentToolResult,
 	AgentToolUpdateCallback,
 } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import type { ContentBlock } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import { getDefault, type Settings } from "../config/settings";
 import { formatGroupedDiagnosticMessages } from "../lsp/utils";
@@ -583,10 +583,7 @@ export function stripOutputNotice(text: string, meta: OutputMeta | undefined): s
 /**
  * Append output notice to tool result content if meta is present.
  */
-function appendOutputNotice(
-	content: (TextContent | ImageContent)[],
-	meta: OutputMeta | undefined,
-): (TextContent | ImageContent)[] {
+function appendOutputNotice(content: ContentBlock[], meta: OutputMeta | undefined): ContentBlock[] {
 	const notice = formatOutputNotice(meta);
 	if (!notice) return content;
 
@@ -739,7 +736,7 @@ async function spillLargeResultToArtifact(
 			});
 
 	// Replace text blocks with single truncated block, keep images
-	const newContent: (TextContent | ImageContent)[] = [];
+	const newContent: ContentBlock[] = [];
 	for (const block of result.content) {
 		if (block.type !== "text") {
 			newContent.push(block);

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -11,7 +11,7 @@ import type {
 	AgentToolUpdateCallback,
 	ToolTier,
 } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import type { ContentBlock, ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import { type SummaryResult, summarizeCode } from "@oh-my-pi/pi-natives";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Text } from "@oh-my-pi/pi-tui";
@@ -968,7 +968,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 
 		const notice = `Note: interpreted as ${parts.length} paths: ${parts.join(", ")}`;
 		const notes = [notice];
-		const content: Array<TextContent | ImageContent> = [];
+		const content: ContentBlock[] = [];
 		const displayReadTargets: string[] = [];
 		let pendingText = notice;
 		const flushText = () => {

--- a/packages/coding-agent/src/tools/tool-result.ts
+++ b/packages/coding-agent/src/tools/tool-result.ts
@@ -1,10 +1,10 @@
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import type { ContentBlock } from "@oh-my-pi/pi-ai";
 import type { OutputSummary, TruncationResult } from "../session/streaming-output";
 import type { OutputMeta, TruncationOptions, TruncationSummaryOptions, TruncationTextOptions } from "./output-meta";
 import { outputMeta } from "./output-meta";
 
-type ToolContent = Array<TextContent | ImageContent>;
+type ToolContent = ContentBlock[];
 
 type DetailsWithMeta = { meta?: OutputMeta };
 

--- a/packages/coding-agent/test/autoresearch-tools.test.ts
+++ b/packages/coding-agent/test/autoresearch-tools.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import type { ContentBlock, TextContent } from "@oh-my-pi/pi-ai";
 import { createSessionRuntime } from "@oh-my-pi/pi-coding-agent/autoresearch/state";
 import {
 	type AutoresearchStorage,
@@ -23,7 +23,7 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-function firstTextBlockText(content: Array<TextContent | ImageContent>): string {
+function firstTextBlockText(content: ContentBlock[]): string {
 	const block = content.find((c): c is TextContent => c.type === "text");
 	if (!block) throw new Error("expected a text tool content block");
 	return block.text;

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { Type } from "@oh-my-pi/omptype/typebox";
 import type { AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import type { ContentBlock } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { discoverAndLoadExtensions, ExtensionRuntime } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
@@ -1127,7 +1127,7 @@ describe("ExtensionRunner", () => {
 			execute: async () => ({ content: [{ type: "text" as const, text: "success" }] }),
 		};
 
-		const firstText = (result: { content: readonly (TextContent | ImageContent)[] }): string | undefined => {
+		const firstText = (result: { content: readonly ContentBlock[] }): string | undefined => {
 			const block = result.content[0];
 			return block?.type === "text" ? block.text : undefined;
 		};

--- a/packages/coding-agent/test/tools/fetch-binary-dispatch.test.ts
+++ b/packages/coding-agent/test/tools/fetch-binary-dispatch.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import type { ContentBlock, TextContent } from "@oh-my-pi/pi-ai";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
@@ -59,7 +59,7 @@ function stubUrlText(body: string, contentType: string) {
 	});
 }
 
-function textOutput(result: { content: Array<TextContent | ImageContent> }): string {
+function textOutput(result: { content: ContentBlock[] }): string {
 	return result.content
 		.filter((content): content is TextContent => content.type === "text")
 		.map(content => content.text)


### PR DESCRIPTION
## Summary

Adds end-to-end video attachment support: `@video.mp4` on the CLI (and the SDK/ACP attachment paths) is inlined as a base64 `VideoContent` block and sent to models whose catalog metadata advertises video input.

- **pi-ai**: new `VideoContent` type (`type: "video"`, base64 `data` + `mimeType`) plus `ContentBlock` / `MessageContent` aliases replacing the inline `string | (TextContent | ImageContent)[]` unions; chat-completions converters emit `video_url` data-URL parts; text-only models get a `[video omitted: model does not support video input]` placeholder instead of a silent drop.
- **pi-catalog**: `Model.input` gains `"video"`, stamped from the live model card's `supports_video_in` flag during discovery (Kimi Code) — no hard-coded id lists. `CACHE_SCHEMA_VERSION` 12 → 13 to invalidate cache rows predating video capability metadata (verified: a stale `["text","image"]` row for k3 suppressed the attachment until invalidated).
- **pi-agent / coding-agent**: video blocks carried through tool results, custom/hook messages, compaction, and session persistence; `@path` file args route `.mp4`/`.webm`/etc. through the file processor with a 100MB inline cap matching the provider request-body limit. Format checking is left to the server (per Kimi's documented MIME list), no client-side whitelist.

## Verification

End to end with `kimi-code/k3` against a 2s ffmpeg `testsrc` clip:
```
omp -p "What do you see in this video?" --model kimi-code/k3 @k3test.mp4
→ "An ffmpeg-style test pattern: color bars inside a white circle, a
  horizontal rainbow gradient strip, and a small frame-counter digit box."
```
Passes on both the fresh-discovery path and the stale-cache migration path (v12 row → invalidated → refetched). All packages `check:types` clean, biome clean.