### PR TITLE
refactor(coding-agent): construct CustomToolAdapter directly

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Removed the `CustomToolAdapter.wrap(tool, getContext)` static factory from `@oh-my-pi/pi-coding-agent/extensibility/custom-tools`. Construct the adapter directly with `new CustomToolAdapter(tool, getContext)`; the arguments and behavior are unchanged.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/extensibility/custom-tools/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/wrapper.ts
@@ -36,15 +36,4 @@ export class CustomToolAdapter<TParams extends TSchema = TSchema, TDetails = any
 	) {
 		return this.tool.execute(toolCallId, params, onUpdate, context ?? this.getContext(), signal);
 	}
-
-	/**
-	 * Backward-compatible export of factory function for existing callers.
-	 * Prefer CustomToolAdapter constructor directly.
-	 */
-	static wrap<TParams extends TSchema = TSchema, TDetails = any, TTheme extends Theme = Theme>(
-		tool: CustomTool<TParams, TDetails>,
-		getContext: () => CustomToolContext,
-	): AgentTool<TParams, TDetails, TTheme> {
-		return new CustomToolAdapter(tool, getContext);
-	}
 }

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1281,7 +1281,7 @@ export class SessionTools {
 		const extensionRunner = this.#host.extensionRunner();
 		const uniqueMcpTools = deduplicateMCPToolsByName(mcpTools);
 		for (const customTool of uniqueMcpTools) {
-			const wrapped = wrapToolWithMetaNotice(CustomToolAdapter.wrap(customTool, getCustomToolContext) as AgentTool);
+			const wrapped = wrapToolWithMetaNotice(new CustomToolAdapter(customTool, getCustomToolContext) as AgentTool);
 			const finalTool = (
 				extensionRunner ? new ExtensionToolWrapper(wrapped, extensionRunner) : wrapped
 			) as AgentTool;


### PR DESCRIPTION
`CustomToolAdapter.wrap` is a one-line static factory forwarding to the
constructor. Its own doc comment says "Backward-compatible export of factory
function for existing callers. Prefer CustomToolAdapter constructor directly."

It has a single callsite, in `session-tools.ts`, which now calls the
constructor. The static method is removed rather than deprecated further, and a
repository-wide search for `CustomToolAdapter.wrap` returns nothing.

Verified with `bun run check`, exit 0, and `bun run ci:test:smoke`, exit 0,
which boots the CLI and builds the session tool registry through the changed
line. The two test files covering this path,
`test/issue-5764-registertool-loadmode.test.ts` and
`test/agent-session-tool-rebuild-skip.test.ts`, pass 40 of 40. The full
`bun run test` run is not cited because this checkout has a stale prebuilt
native addon (`diffLineRuns` is undefined), which makes the same set of hashline
and Settings tests fail identically on the base commit.
