### PR TITLE
refactor(coding-agent): reuse pi-utils asRecord in web scrapers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Removed a duplicate local `asRecord` type guard from the web scrapers, re-exporting the shared implementation from `@oh-my-pi/pi-utils`. The name, signature, `null`-on-non-record contract, and `./utils` import path are unchanged.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/web/scrapers/utils.ts
+++ b/packages/coding-agent/src/web/scrapers/utils.ts
@@ -1,14 +1,10 @@
-import { isRecord, ptree } from "@oh-my-pi/pi-utils";
+import { asRecord, isRecord, ptree } from "@oh-my-pi/pi-utils";
 
-export { isRecord };
+export { asRecord, isRecord };
 
 import { ToolAbortError } from "../../tools/tool-errors";
 import { convertBufferWithMarkit } from "../../utils/markit";
 import { MAX_BYTES } from "./types";
-
-export function asRecord(value: unknown): Record<string, unknown> | null {
-	return isRecord(value) ? value : null;
-}
 
 export function asString(value: unknown): string | null {
 	if (typeof value !== "string") return null;


### PR DESCRIPTION
`web/scrapers/utils.ts` defined `asRecord` with a body identical to the one
already exported from `@oh-my-pi/pi-utils` (`packages/utils/src/type-guards.ts`),
and the file already imported from that package. The two are equivalent by
construction: the local copy called the same `isRecord` that the shared one
calls, with the same body and the same signature.

The local definition is replaced by a re-export, so the name, the signature and
the module path are unchanged for `w3c.ts` and for anyone importing through the
package's `./*` export map.

The private, unexported copies in `web/search/providers/` are intentionally left
alone, as is `packages/ai/src/dialect/coercion.ts`, whose `asRecord` is a
different contract that returns `{}` rather than `null` for a non-record.

Verified with `bun run check`, exit 0, plus a contract probe confirming the
`null` return survives:

    asRecord({a:1}) -> { a: 1 }
    asRecord(null)  -> null
    asRecord(42)    -> null
    asRecord([1])   -> null
