### PR TITLE
fix(tui): detach plan approval dispatch from serialized event chain

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed approved plans hiding live execution progress: after the fullscreen Plan Review closed, the conversation view stayed blank/stale while the plan executed. The propose write's `tool_execution_end` handler ran inside the event-controller's serialized dispatch chain and awaited `handlePlanApproval`, which awaits `session.prompt` for the entire execution turn — so every later `agent_start`/`message_start`/tool/`message_update` event queued behind it until the run finished. The approval dispatch is now detached from the dispatch chain, so the turn's events render live ([#7684](https://github.com/can1357/oh-my-pi/issues/7684)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1605,11 +1605,29 @@ export class EventController {
 				typeof details.title === "string" &&
 				typeof details.planExists === "boolean"
 			) {
-				await this.ctx.handlePlanApproval({
-					planFilePath: details.planFilePath,
-					title: details.title,
-					planExists: details.planExists,
-				});
+				// Dispatch the approval WITHOUT blocking the serialized event
+				// dispatch chain. `handlePlanApproval` -> `#approvePlan` awaits
+				// `session.prompt` for the ENTIRE approved-execution turn; awaiting
+				// it here (this handler runs inside `#runSerialized`) would hold the
+				// single dispatch link for the whole run, so the run's own
+				// agent_start / message_start / tool / coalesced message_update
+				// events queue behind it on `#dispatchTail` and the chat stays blank
+				// until execution finishes (issue #7684, follow-up to #5688 which
+				// only closed the overlay). Detaching frees the link the moment this
+				// handler returns; the approval overlay and the turn's live events
+				// then render. The approval flow surfaces its own failures via
+				// `showError`, so only an unexpected rejection is logged here.
+				void this.ctx
+					.handlePlanApproval({
+						planFilePath: details.planFilePath,
+						title: details.title,
+						planExists: details.planExists,
+					})
+					.catch(err => {
+						logger.warn("Plan approval dispatch failed", {
+							error: err instanceof Error ? err.message : String(err),
+						});
+					});
 			}
 		}
 	}

--- a/packages/coding-agent/test/modes/controllers/event-controller-plan-approval-dispatch.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-plan-approval-dispatch.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { PROPOSE_DEVICE_NAME } from "@oh-my-pi/pi-coding-agent/tools/resolve";
+
+beforeAll(() => {
+	initTheme();
+});
+
+/**
+ * A completed `write xd://propose` execution with `mode: "execute"` — the event
+ * that drives `#handleToolExecutionEnd` into `ctx.handlePlanApproval`.
+ */
+function proposeExecuteEnd(): AgentSessionEvent {
+	return {
+		type: "tool_execution_end",
+		toolCallId: "propose-1",
+		toolName: "write",
+		isError: false,
+		result: {
+			content: [{ type: "text", text: "Plan ready for approval." }],
+			details: {
+				xdev: {
+					tool: PROPOSE_DEVICE_NAME,
+					mode: "execute",
+					args: { title: "demo" },
+					inner: { planFilePath: "local://demo-plan.md", title: "demo", planExists: true },
+				},
+			},
+		},
+	} as unknown as AgentSessionEvent;
+}
+
+describe("EventController plan-approval dispatch", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("keeps dispatching session events while the approved plan's execution turn runs (issue #7684)", async () => {
+		// Contract: the fullscreen Plan Review closes and the approved plan begins
+		// executing, but `handlePlanApproval` -> `#approvePlan` awaits
+		// `session.prompt` for the WHOLE run. The propose write's
+		// `tool_execution_end` handler runs inside `EventController`'s serialized
+		// dispatch chain (`#runSerialized`), so awaiting the approval there froze
+		// the chain and every later agent_start / message_start / tool /
+		// message_update event queued behind it — the chat stayed blank until
+		// execution finished. The approval must instead be detached so later events
+		// keep dispatching mid-execution.
+		let listener: ((event: AgentSessionEvent) => void | Promise<void>) | undefined;
+		// A pending gate stands in for the still-running execution turn: it never
+		// resolves during the assertions, so a later event that dispatches proves
+		// it did not wait for the run to finish. If a regression re-adds the
+		// blocking await, `dispatch(...)` below never settles and the test times
+		// out — the deadlock IS the failure.
+		const executionTurn = Promise.withResolvers<void>();
+		const handlePlanApproval = vi.fn(() => executionTurn.promise);
+
+		const ctx = {
+			isInitialized: true,
+			session: {
+				subscribe: (fn: (event: AgentSessionEvent) => void | Promise<void>) => {
+					listener = fn;
+					return () => {};
+				},
+			},
+			viewSession: { isStreaming: false },
+			pendingTools: new Map(),
+			ui: { requestRender: vi.fn() },
+			handlePlanApproval,
+		} as unknown as InteractiveModeContext;
+
+		const controller = new EventController(ctx);
+		controller.subscribeToAgent();
+		if (!listener) throw new Error("subscribeToAgent did not register a listener");
+		const dispatch = listener;
+
+		const handleEventSpy = vi.spyOn(controller, "handleEvent");
+
+		// Propose completion approved for execution. Awaiting the callback resolves
+		// only once its `#runSerialized` link settles: after the fix the approval is
+		// detached, so the link settles even though the execution turn is unresolved.
+		await dispatch(proposeExecuteEnd());
+		expect(handlePlanApproval).toHaveBeenCalledTimes(1);
+
+		// A later session event arrives while the execution turn is still running.
+		// `turn_start` rides the exact same `#runSerialized` gate that carries
+		// agent_start / message_start / tool events / the coalesced message_update
+		// flush, so its dispatch proves the gate is open mid-execution.
+		await dispatch({ type: "turn_start" } as AgentSessionEvent);
+		expect(handleEventSpy).toHaveBeenCalledWith(expect.objectContaining({ type: "turn_start" }));
+
+		executionTurn.resolve();
+		await executionTurn.promise;
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/event-controller-plan-approval-dispatch.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-plan-approval-dispatch.test.ts
@@ -38,24 +38,25 @@ describe("EventController plan-approval dispatch", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("keeps dispatching session events while the approved plan's execution turn runs (issue #7684)", async () => {
-		// Contract: the fullscreen Plan Review closes and the approved plan begins
-		// executing, but `handlePlanApproval` -> `#approvePlan` awaits
-		// `session.prompt` for the WHOLE run. The propose write's
+	it("keeps dispatching during approve-and-compact compaction and execution (issue #7684)", async () => {
+		// Contract: "Approve and compact context" first awaits compaction, then
+		// `session.prompt` for the WHOLE execution run. The propose write's
 		// `tool_execution_end` handler runs inside `EventController`'s serialized
-		// dispatch chain (`#runSerialized`), so awaiting the approval there froze
-		// the chain and every later agent_start / message_start / tool /
-		// message_update event queued behind it — the chat stayed blank until
-		// execution finished. The approval must instead be detached so later events
-		// keep dispatching mid-execution.
+		// dispatch chain (`#runSerialized`), so awaiting `handlePlanApproval` there
+		// froze every later agent_start / message_start / tool / message_update
+		// event during BOTH stages. The approval must be detached so events keep
+		// dispatching through compaction and the subsequent execution.
 		let listener: ((event: AgentSessionEvent) => void | Promise<void>) | undefined;
-		// A pending gate stands in for the still-running execution turn: it never
-		// resolves during the assertions, so a later event that dispatches proves
-		// it did not wait for the run to finish. If a regression re-adds the
-		// blocking await, `dispatch(...)` below never settles and the test times
-		// out — the deadlock IS the failure.
+		const compactionStarted = Promise.withResolvers<void>();
+		const compaction = Promise.withResolvers<void>();
+		const executionStarted = Promise.withResolvers<void>();
 		const executionTurn = Promise.withResolvers<void>();
-		const handlePlanApproval = vi.fn(() => executionTurn.promise);
+		const handlePlanApproval = vi.fn(async () => {
+			compactionStarted.resolve();
+			await compaction.promise;
+			executionStarted.resolve();
+			await executionTurn.promise;
+		});
 
 		const ctx = {
 			isInitialized: true,
@@ -78,18 +79,24 @@ describe("EventController plan-approval dispatch", () => {
 
 		const handleEventSpy = vi.spyOn(controller, "handleEvent");
 
-		// Propose completion approved for execution. Awaiting the callback resolves
-		// only once its `#runSerialized` link settles: after the fix the approval is
-		// detached, so the link settles even though the execution turn is unresolved.
+		// The propose completion opens Plan Review; the mocked approval represents
+		// selecting "Approve and compact context" and stopping inside compaction.
+		// The serialized link must settle despite the unresolved compaction.
 		await dispatch(proposeExecuteEnd());
+		await compactionStarted.promise;
 		expect(handlePlanApproval).toHaveBeenCalledTimes(1);
 
-		// A later session event arrives while the execution turn is still running.
-		// `turn_start` rides the exact same `#runSerialized` gate that carries
-		// agent_start / message_start / tool events / the coalesced message_update
-		// flush, so its dispatch proves the gate is open mid-execution.
+		// `turn_start` rides the same `#runSerialized` gate as agent_start /
+		// message_start / tool events / the coalesced message_update flush.
 		await dispatch({ type: "turn_start" } as AgentSessionEvent);
-		expect(handleEventSpy).toHaveBeenCalledWith(expect.objectContaining({ type: "turn_start" }));
+		expect(handleEventSpy.mock.calls.filter(([event]) => event.type === "turn_start")).toHaveLength(1);
+
+		// Finish compaction and hold the approved execution turn open. A second
+		// event must still dispatch before that turn settles.
+		compaction.resolve();
+		await executionStarted.promise;
+		await dispatch({ type: "turn_start" } as AgentSessionEvent);
+		expect(handleEventSpy.mock.calls.filter(([event]) => event.type === "turn_start")).toHaveLength(2);
 
 		executionTurn.resolve();
 		await executionTurn.promise;


### PR DESCRIPTION
## Repro
After approving a plan from the fullscreen Plan Review (Approve and execute), the overlay closes but the conversation view renders no live progress: assistant text, tool calls/results, todo updates, and coalesced `message_update` events do not appear until the whole execution turn finishes, even though the backend is already running and modifying files. Reproduced with a focused event-queue test (`test/modes/controllers/event-controller-plan-approval-dispatch.test.ts`): with the propose completion approved for a still-running execution turn, a later `turn_start` never dispatches while the approval handler is gated — the serialized dispatch chain deadlocks (test times out); it dispatches immediately once the approval is detached.

## Cause
`EventController.subscribeToAgent` serializes every non-`message_update` event through a single dispatch chain (`#runSerialized`). The propose write's `tool_execution_end` handler (`#handleToolExecutionEnd`, `event-controller.ts`) runs inside that chain and `await`ed `ctx.handlePlanApproval(...)`. `handlePlanApproval` -> `#approvePlan` (`interactive-mode.ts`) `await`s `session.prompt(planModePrompt, { synthetic: true })`, and for a non-streaming turn `session.prompt` awaits `#promptWithMessage` — the entire execution run. That await held the one in-flight dispatch link, so the run's own `agent_start`/`message_start`/tool/coalesced `message_update` events queued on `#dispatchTail` and stayed unrendered until the turn settled. This is the follow-up to #5688 (commit `a59f04b5073c`), which only moved the overlay close before the still-blocking dispatch.

## Fix
- `event-controller.ts` `#handleToolExecutionEnd`: dispatch `ctx.handlePlanApproval(...)` detached (`void ...catch(logger.warn)`) instead of `await`ing it, so the dispatch link settles the moment the handler returns and the approved turn's events render live. The approval flow surfaces its own errors via `showError`, so only an unexpected rejection is logged.
- Added `test/modes/controllers/event-controller-plan-approval-dispatch.test.ts`: drives the propose approval through the real subscribe/`#runSerialized` path with a never-resolving execution turn and asserts a later `turn_start` still dispatches mid-execution.
- CHANGELOG entry under `[Unreleased]`.

## Verification
`bun test test/modes/controllers/event-controller-plan-approval-dispatch.test.ts` — passes with the fix; times out (deadlock) when the fix is reverted, confirming it guards the regression. `bun test test/interactive-mode-plan-review.test.ts test/modes/controllers/event-controller-message-start.test.ts test/modes/controllers/event-controller-superseded-agent-end.test.ts test/event-controller-message-update-coalesce.test.ts` — 74 pass, 0 fail. Fixes #7684