### PR TITLE
feat(tui): deliver Windows toast notifications for BEL-only terminals

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Native Windows toast notifications for BEL-only terminals: when the chosen notify protocol is BEL on a local Windows desktop, notifications now also fan out as WinRT toasts via Windows PowerShell (`-EncodedCommand`, fire-and-forget), mirroring the existing Linux D-Bus fallback. Opt out with `PI_NO_DESKTOP_NOTIFY=1` ([#7272](https://github.com/can1357/oh-my-pi/issues/7272)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Fixed

--- a/packages/tui/src/desktop-notify.ts
+++ b/packages/tui/src/desktop-notify.ts
@@ -61,14 +61,18 @@ export function hasLinuxDesktopSession(
 
 /**
  * Whether the current process can surface a native Windows toast: win32
- * platform and not an SSH session (a toast on a remote host the user is not
- * looking at is noise; the BEL still reaches the local terminal in-band).
+ * platform, an interactive logon session (`SESSIONNAME` is set for console
+ * and RDP sessions but not for services / session-0 hosts, the analog of the
+ * `DBUS_SESSION_BUS_ADDRESS` gate on Linux), and not an SSH session (a toast
+ * on a remote host the user is not looking at is noise; the BEL still
+ * reaches the local terminal in-band).
  */
 export function hasWindowsDesktopSession(
 	platform: NodeJS.Platform = process.platform,
 	env: NodeJS.ProcessEnv = Bun.env,
 ): boolean {
 	if (platform !== "win32") return false;
+	if (!env.SESSIONNAME) return false;
 	return !env.SSH_CONNECTION && !env.SSH_CLIENT && !env.SSH_TTY;
 }
 
@@ -184,10 +188,10 @@ const POWERSHELL_AUMID = "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerSh
 /**
  * Build the PowerShell script that raises a WinRT toast for `message`. Pure
  * helper so tests assert the exact script without spawning a child. Title and
- * body are XML-escaped into the toast payload; the payload is embedded as a
- * single-quoted PowerShell string (with `'` doubled) so no interpolation runs.
- * Critical urgency maps to the `urgent` toast scenario, which keeps the toast
- * on screen until dismissed.
+ * body are XML-escaped into the toast payload, which leaves no `'` in the
+ * XML, so embedding it as a single-quoted PowerShell string runs no
+ * interpolation. Critical urgency maps to the `urgent` toast scenario, which
+ * keeps the toast on screen until dismissed.
  */
 export function buildWindowsToastScript(message: string | TerminalNotification): string {
 	const { title, body, urgency } = resolveFields(message);
@@ -196,12 +200,11 @@ export function buildWindowsToastScript(message: string | TerminalNotification):
 		`<toast${scenario}><visual><binding template="ToastGeneric">` +
 		`<text>${escapeXml(title)}</text><text>${escapeXml(body)}</text>` +
 		`</binding></visual></toast>`;
-	const quoted = xml.replace(/'/g, "''");
 	return [
 		"[void][Windows.UI.Notifications.ToastNotificationManager,Windows.UI.Notifications,ContentType=WindowsRuntime]",
 		"[void][Windows.Data.Xml.Dom.XmlDocument,Windows.Data.Xml.Dom.XmlDocument,ContentType=WindowsRuntime]",
 		"$xml=New-Object Windows.Data.Xml.Dom.XmlDocument",
-		`$xml.LoadXml('${quoted}')`,
+		`$xml.LoadXml('${xml}')`,
 		`[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('${POWERSHELL_AUMID}').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`,
 	].join("\n");
 }

--- a/packages/tui/src/desktop-notify.ts
+++ b/packages/tui/src/desktop-notify.ts
@@ -1,4 +1,5 @@
-// Linux desktop notification delivery via D-Bus.
+// Desktop notification delivery for BEL-only terminals: D-Bus on Linux,
+// WinRT toasts (via PowerShell) on Windows.
 //
 // Several terminal families — most notably the VTE-based stack (Ptyxis,
 // GNOME Terminal, Tilix, Terminator) but also Alacritty and bare xterm — have
@@ -15,19 +16,30 @@
 // libnotify CLI present on every modern Linux desktop) and fall back to
 // `gdbus call` when libnotify is absent but GLib is installed.
 //
+// On Windows (#7272) no console host maps BEL to a toast either, and there is
+// no session bus. The only dependency-free path to a native toast for an
+// unpackaged console app is the WinRT `ToastNotificationManager`, which
+// Windows PowerShell 5.1 (always present at `%SystemRoot%\System32\
+// WindowsPowerShell\v1.0\powershell.exe`) can project in-process. We spawn it
+// hidden with an `-EncodedCommand` (UTF-16LE base64) so title/body never pass
+// through cmd-style argv quoting, and reuse PowerShell's registered
+// AppUserModelId so the toast works without app registration or packaging.
+//
 // Delivery is fire-and-forget: a failed spawn or missing binary is treated as
 // a silent no-op so terminals that already deliver toasts in-band (Kitty,
 // iTerm2, WezTerm, …) keep working unchanged and the BEL emission still fires
 // for tmux `monitor-bell`, X11 urgency hints, and audible-bell handlers.
 
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { $which } from "@oh-my-pi/pi-utils";
 import type { TerminalId, TerminalNotification } from "./terminal-capabilities";
 
 /** Application name surfaced as the notification source. */
 const APP_NAME = "Oh My Pi";
 
-/** Resolved notifier binary used to fan a notification out to D-Bus. */
-export type DesktopNotifierKind = "notify-send" | "gdbus";
+/** Resolved notifier binary used to fan a notification out of process. */
+export type DesktopNotifierKind = "notify-send" | "gdbus" | "powershell";
 
 export interface DesktopNotifier {
 	kind: DesktopNotifierKind;
@@ -48,12 +60,25 @@ export function hasLinuxDesktopSession(
 }
 
 /**
- * Whether `sendNotification` should also dispatch a D-Bus toast for this
+ * Whether the current process can surface a native Windows toast: win32
+ * platform and not an SSH session (a toast on a remote host the user is not
+ * looking at is noise; the BEL still reaches the local terminal in-band).
+ */
+export function hasWindowsDesktopSession(
+	platform: NodeJS.Platform = process.platform,
+	env: NodeJS.ProcessEnv = Bun.env,
+): boolean {
+	if (platform !== "win32") return false;
+	return !env.SSH_CONNECTION && !env.SSH_CLIENT && !env.SSH_TTY;
+}
+
+/**
+ * Whether `sendNotification` should also dispatch a desktop toast for this
  * terminal. Returns true only when (1) the chosen `notifyProtocol` is BEL,
- * which cannot carry arbitrary toast text, (2) the host exposes a Linux desktop
- * session, and (3) the user has not opted out via `PI_NO_DESKTOP_NOTIFY=1`.
- * Terminals that genuinely speak OSC 9 / OSC 99 pass
- * `notifyProtocolIsBell=false` and are filtered before the D-Bus fallback can
+ * which cannot carry arbitrary toast text, (2) the host exposes a Linux or
+ * Windows desktop session, and (3) the user has not opted out via
+ * `PI_NO_DESKTOP_NOTIFY=1`. Terminals that genuinely speak OSC 9 / OSC 99
+ * pass `notifyProtocolIsBell=false` and are filtered before the fallback can
  * run. Pure helper for tests and the singleton path.
  */
 export function shouldDeliverDesktopNotification(
@@ -63,9 +88,8 @@ export function shouldDeliverDesktopNotification(
 	env: NodeJS.ProcessEnv = Bun.env,
 ): boolean {
 	if (!notifyProtocolIsBell) return false;
-	if (!hasLinuxDesktopSession(platform, env)) return false;
 	if (env.PI_NO_DESKTOP_NOTIFY === "1") return false;
-	return true;
+	return hasLinuxDesktopSession(platform, env) || hasWindowsDesktopSession(platform, env);
 }
 
 let cachedNotifier: DesktopNotifier | null | undefined;
@@ -81,8 +105,28 @@ export function resetDesktopNotifierCache(): void {
  * for hosts where libnotify is not installed but GLib is. Result is cached so
  * repeated notifications do not hit `$which` again.
  */
-export function resolveDesktopNotifier(): DesktopNotifier | null {
+export function resolveDesktopNotifier(platform: NodeJS.Platform = process.platform): DesktopNotifier | null {
 	if (cachedNotifier !== undefined) return cachedNotifier;
+	if (platform === "win32") {
+		// Windows PowerShell 5.1 only: it ships with every Windows 10/11 install
+		// and projects WinRT types in-process. pwsh (PowerShell 7+) cannot load
+		// `Windows.UI.Notifications` without the Microsoft.Windows.SDK.NET
+		// assemblies, so it is not a usable fallback.
+		const onPath = $which("powershell.exe") ?? $which("powershell");
+		if (onPath) {
+			cachedNotifier = { kind: "powershell", path: onPath };
+			return cachedNotifier;
+		}
+		const canonical = path.join(
+			Bun.env.SystemRoot ?? "C:\\Windows",
+			"System32",
+			"WindowsPowerShell",
+			"v1.0",
+			"powershell.exe",
+		);
+		cachedNotifier = fs.existsSync(canonical) ? { kind: "powershell", path: canonical } : null;
+		return cachedNotifier;
+	}
 	const notifySend = $which("notify-send");
 	if (notifySend) {
 		cachedNotifier = { kind: "notify-send", path: notifySend };
@@ -119,6 +163,49 @@ const URGENCY_BYTE: Record<ResolvedNotificationFields["urgency"], number> = {
 	critical: 2,
 };
 
+function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&apos;");
+}
+
+/**
+ * AppUserModelId the toast is attributed to. Unpackaged console apps have no
+ * registered AUMID of their own, and `CreateToastNotifier()` (parameterless)
+ * throws outside a packaged app — reusing Windows PowerShell's shortcut AUMID
+ * is the standard way for an unpackaged process to surface a toast without
+ * touching the registry.
+ */
+const POWERSHELL_AUMID = "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe";
+
+/**
+ * Build the PowerShell script that raises a WinRT toast for `message`. Pure
+ * helper so tests assert the exact script without spawning a child. Title and
+ * body are XML-escaped into the toast payload; the payload is embedded as a
+ * single-quoted PowerShell string (with `'` doubled) so no interpolation runs.
+ * Critical urgency maps to the `urgent` toast scenario, which keeps the toast
+ * on screen until dismissed.
+ */
+export function buildWindowsToastScript(message: string | TerminalNotification): string {
+	const { title, body, urgency } = resolveFields(message);
+	const scenario = urgency === "critical" ? ' scenario="urgent"' : "";
+	const xml =
+		`<toast${scenario}><visual><binding template="ToastGeneric">` +
+		`<text>${escapeXml(title)}</text><text>${escapeXml(body)}</text>` +
+		`</binding></visual></toast>`;
+	const quoted = xml.replace(/'/g, "''");
+	return [
+		"[void][Windows.UI.Notifications.ToastNotificationManager,Windows.UI.Notifications,ContentType=WindowsRuntime]",
+		"[void][Windows.Data.Xml.Dom.XmlDocument,Windows.Data.Xml.Dom.XmlDocument,ContentType=WindowsRuntime]",
+		"$xml=New-Object Windows.Data.Xml.Dom.XmlDocument",
+		`$xml.LoadXml('${quoted}')`,
+		`[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('${POWERSHELL_AUMID}').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`,
+	].join("\n");
+}
+
 /**
  * Build the argv that delivers `message` through the resolved notifier. Pure
  * helper so tests assert exact wire shape without spawning a child. Notes:
@@ -128,8 +215,23 @@ const URGENCY_BYTE: Record<ResolvedNotificationFields["urgency"], number> = {
  *   `s u s s s as a{sv} i`: app_name, replaces_id, app_icon, summary, body,
  *   actions, hints, expire_timeout. We feed hints with the urgency byte so
  *   the daemon classifies the toast identically to `notify-send`.
+ * - `powershell` runs the WinRT toast script via `-EncodedCommand` (UTF-16LE
+ *   base64) so the payload survives argv intact with no shell re-quoting.
  */
 export function buildDesktopNotifyCommand(notifier: DesktopNotifier, message: string | TerminalNotification): string[] {
+	if (notifier.kind === "powershell") {
+		const encoded = Buffer.from(buildWindowsToastScript(message), "utf16le").toString("base64");
+		return [
+			notifier.path,
+			"-NoLogo",
+			"-NoProfile",
+			"-NonInteractive",
+			"-WindowStyle",
+			"Hidden",
+			"-EncodedCommand",
+			encoded,
+		];
+	}
 	const { title, body, urgency } = resolveFields(message);
 	if (notifier.kind === "notify-send") {
 		return [notifier.path, "--app-name", APP_NAME, `--urgency=${urgency}`, "--expire-time=5000", title, body];
@@ -157,14 +259,17 @@ export function buildDesktopNotifyCommand(notifier: DesktopNotifier, message: st
 }
 
 /**
- * Fire-and-forget D-Bus desktop notification. Resolves a notifier, spawns it
+ * Fire-and-forget desktop notification. Resolves a notifier, spawns it
  * with stdio fully detached, and never throws — terminal notifications are
  * best-effort and must not block the renderer or interleave bytes onto
  * stdout. Caller is responsible for the gating check
  * ({@link shouldDeliverDesktopNotification}).
  */
-export function sendDesktopNotification(message: string | TerminalNotification): void {
-	const notifier = resolveDesktopNotifier();
+export function sendDesktopNotification(
+	message: string | TerminalNotification,
+	platform: NodeJS.Platform = process.platform,
+): void {
+	const notifier = resolveDesktopNotifier(platform);
 	if (!notifier) return;
 	try {
 		// `.unref()` lets the event loop exit while the notifier is still running.

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -175,10 +175,12 @@ export class TerminalInfo {
 		process.stdout.write(formatted);
 		// VTE-family terminals (Ptyxis, GNOME Terminal, Tilix, …) plus Alacritty
 		// and bare xterm-on-Wayland have no in-band escape that surfaces an
-		// arbitrary desktop toast (#3685). When the chosen `notifyProtocol` is
-		// BEL on a Linux session bus, also fan the notification out via
-		// libnotify so users see the toast and the BEL still fires for tmux
-		// `monitor-bell` / X11 urgency hints / audible bell.
+		// arbitrary desktop toast (#3685), and no Windows console host maps BEL
+		// to a toast either (#7272). When the chosen `notifyProtocol` is BEL on
+		// a Linux session bus or a local Windows desktop, also fan the
+		// notification out via libnotify / WinRT toast so users see the toast
+		// and the BEL still fires for tmux `monitor-bell` / X11 urgency hints /
+		// audible bell.
 		if (this.notifyProtocol === NotifyProtocol.Bell && shouldDeliverDesktopNotification(this.id, true)) {
 			sendDesktopNotification(message);
 		}

--- a/packages/tui/test/desktop-notify.test.ts
+++ b/packages/tui/test/desktop-notify.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import {
 	buildDesktopNotifyCommand,
+	buildWindowsToastScript,
 	type DesktopNotifier,
 	hasLinuxDesktopSession,
+	hasWindowsDesktopSession,
 	resetDesktopNotifierCache,
 	resolveDesktopNotifier,
 	sendDesktopNotification,
@@ -51,10 +53,25 @@ describe("shouldDeliverDesktopNotification", () => {
 		).toBe(false);
 	});
 
-	it("requires a Linux desktop session — silent on macOS / Windows / headless Linux", () => {
+	it("requires a desktop session — silent on macOS / headless Linux", () => {
 		expect(shouldDeliverDesktopNotification("trueColor", true, "darwin", LINUX_ENV)).toBe(false);
-		expect(shouldDeliverDesktopNotification("trueColor", true, "win32", LINUX_ENV)).toBe(false);
 		expect(shouldDeliverDesktopNotification("trueColor", true, "linux", {})).toBe(false);
+	});
+
+	it("fires for Bell-only terminals on a local Windows desktop, but not over SSH", () => {
+		expect(shouldDeliverDesktopNotification("trueColor", true, "win32", {})).toBe(true);
+		expect(shouldDeliverDesktopNotification("trueColor", true, "win32", { SSH_CONNECTION: "1.2.3.4" })).toBe(false);
+		expect(shouldDeliverDesktopNotification("trueColor", true, "win32", { PI_NO_DESKTOP_NOTIFY: "1" })).toBe(false);
+		expect(shouldDeliverDesktopNotification("kitty", false, "win32", {})).toBe(false);
+	});
+});
+
+describe("hasWindowsDesktopSession", () => {
+	it("requires win32 + no SSH markers", () => {
+		expect(hasWindowsDesktopSession("win32", {})).toBe(true);
+		expect(hasWindowsDesktopSession("win32", { SSH_CLIENT: "1.2.3.4 5 22" })).toBe(false);
+		expect(hasWindowsDesktopSession("win32", { SSH_TTY: "/dev/pts/0" })).toBe(false);
+		expect(hasWindowsDesktopSession("linux", {})).toBe(false);
 	});
 });
 
@@ -72,32 +89,43 @@ describe("resolveDesktopNotifier", () => {
 		vi.spyOn(utils, "$which").mockImplementation(name =>
 			name === "notify-send" ? "/usr/bin/notify-send" : "/usr/bin/gdbus",
 		);
-		expect(resolveDesktopNotifier()).toEqual({ kind: "notify-send", path: "/usr/bin/notify-send" });
+		expect(resolveDesktopNotifier("linux")).toEqual({ kind: "notify-send", path: "/usr/bin/notify-send" });
 	});
 
 	it("falls back to gdbus when notify-send is missing", () => {
 		vi.spyOn(utils, "$which").mockImplementation(name => (name === "gdbus" ? "/usr/bin/gdbus" : null));
-		expect(resolveDesktopNotifier()).toEqual({ kind: "gdbus", path: "/usr/bin/gdbus" });
+		expect(resolveDesktopNotifier("linux")).toEqual({ kind: "gdbus", path: "/usr/bin/gdbus" });
 	});
 
 	it("returns null when neither binary is installed", () => {
 		vi.spyOn(utils, "$which").mockReturnValue(null);
-		expect(resolveDesktopNotifier()).toBeNull();
+		expect(resolveDesktopNotifier("linux")).toBeNull();
 	});
 
 	it("caches the resolution so repeat calls do not re-probe PATH", () => {
 		const spy = vi.spyOn(utils, "$which").mockReturnValue("/usr/bin/notify-send");
-		resolveDesktopNotifier();
-		resolveDesktopNotifier();
-		resolveDesktopNotifier();
+		resolveDesktopNotifier("linux");
+		resolveDesktopNotifier("linux");
+		resolveDesktopNotifier("linux");
 		// One call per probed binary on the first invocation, zero on cache hits.
 		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it("resolves Windows PowerShell on win32", () => {
+		vi.spyOn(utils, "$which").mockImplementation(name =>
+			name === "powershell.exe" ? "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" : null,
+		);
+		expect(resolveDesktopNotifier("win32")).toEqual({
+			kind: "powershell",
+			path: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+		});
 	});
 });
 
 describe("buildDesktopNotifyCommand", () => {
 	const notifySend: DesktopNotifier = { kind: "notify-send", path: "/usr/bin/notify-send" };
 	const gdbus: DesktopNotifier = { kind: "gdbus", path: "/usr/bin/gdbus" };
+	const powershell: DesktopNotifier = { kind: "powershell", path: "C:\\pwsh\\powershell.exe" };
 
 	it("encodes string messages as title=app + body=message for notify-send", () => {
 		expect(buildDesktopNotifyCommand(notifySend, "ping")).toEqual([
@@ -162,6 +190,37 @@ describe("buildDesktopNotifyCommand", () => {
 			"5000",
 		]);
 	});
+
+	it("runs the WinRT toast script through -EncodedCommand for powershell", () => {
+		const argv = buildDesktopNotifyCommand(powershell, { title: "Session", body: "Complete" });
+		expect(argv.slice(0, 7)).toEqual([
+			"C:\\pwsh\\powershell.exe",
+			"-NoLogo",
+			"-NoProfile",
+			"-NonInteractive",
+			"-WindowStyle",
+			"Hidden",
+			"-EncodedCommand",
+		]);
+		const decoded = Buffer.from(argv[7], "base64").toString("utf16le");
+		expect(decoded).toBe(buildWindowsToastScript({ title: "Session", body: "Complete" }));
+	});
+});
+
+describe("buildWindowsToastScript", () => {
+	it("XML-escapes title/body and embeds them in a ToastGeneric payload", () => {
+		const script = buildWindowsToastScript({ title: "a<b> & 'c'", body: 'say "hi"' });
+		expect(script).toContain("<text>a&lt;b&gt; &amp; &apos;c&apos;</text>");
+		expect(script).toContain("<text>say &quot;hi&quot;</text>");
+		expect(script).toContain("CreateToastNotifier");
+	});
+
+	it("maps critical urgency to the urgent toast scenario", () => {
+		expect(buildWindowsToastScript({ title: "t", body: "b", urgency: "critical" })).toContain(
+			'<toast scenario="urgent">',
+		);
+		expect(buildWindowsToastScript({ title: "t", body: "b" })).toContain("<toast>");
+	});
 });
 
 describe("sendDesktopNotification", () => {
@@ -179,7 +238,7 @@ describe("sendDesktopNotification", () => {
 		const unref = vi.fn();
 		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref }) as never);
 
-		sendDesktopNotification({ title: "Session", body: "Complete" });
+		sendDesktopNotification({ title: "Session", body: "Complete" }, "linux");
 
 		expect(spawn).toHaveBeenCalledTimes(1);
 		const opts = spawn.mock.calls[0]?.[0] as unknown as {
@@ -210,7 +269,7 @@ describe("sendDesktopNotification", () => {
 		vi.spyOn(utils, "$which").mockReturnValue(null);
 		const spawn = vi.spyOn(Bun, "spawn").mockImplementation((..._args: unknown[]) => ({ unref: vi.fn() }) as never);
 
-		sendDesktopNotification("ping");
+		sendDesktopNotification("ping", "linux");
 
 		expect(spawn).not.toHaveBeenCalled();
 	});
@@ -221,6 +280,6 @@ describe("sendDesktopNotification", () => {
 			throw new Error("ENOENT");
 		});
 
-		expect(() => sendDesktopNotification("ping")).not.toThrow();
+		expect(() => sendDesktopNotification("ping", "linux")).not.toThrow();
 	});
 });

--- a/packages/tui/test/desktop-notify.test.ts
+++ b/packages/tui/test/desktop-notify.test.ts
@@ -59,19 +59,27 @@ describe("shouldDeliverDesktopNotification", () => {
 	});
 
 	it("fires for Bell-only terminals on a local Windows desktop, but not over SSH", () => {
-		expect(shouldDeliverDesktopNotification("trueColor", true, "win32", {})).toBe(true);
-		expect(shouldDeliverDesktopNotification("trueColor", true, "win32", { SSH_CONNECTION: "1.2.3.4" })).toBe(false);
-		expect(shouldDeliverDesktopNotification("trueColor", true, "win32", { PI_NO_DESKTOP_NOTIFY: "1" })).toBe(false);
-		expect(shouldDeliverDesktopNotification("kitty", false, "win32", {})).toBe(false);
+		const WIN_ENV: NodeJS.ProcessEnv = { SESSIONNAME: "Console" };
+		expect(shouldDeliverDesktopNotification("trueColor", true, "win32", WIN_ENV)).toBe(true);
+		expect(
+			shouldDeliverDesktopNotification("trueColor", true, "win32", { ...WIN_ENV, SSH_CONNECTION: "1.2.3.4" }),
+		).toBe(false);
+		expect(
+			shouldDeliverDesktopNotification("trueColor", true, "win32", { ...WIN_ENV, PI_NO_DESKTOP_NOTIFY: "1" }),
+		).toBe(false);
+		expect(shouldDeliverDesktopNotification("kitty", false, "win32", WIN_ENV)).toBe(false);
 	});
 });
 
 describe("hasWindowsDesktopSession", () => {
-	it("requires win32 + no SSH markers", () => {
-		expect(hasWindowsDesktopSession("win32", {})).toBe(true);
-		expect(hasWindowsDesktopSession("win32", { SSH_CLIENT: "1.2.3.4 5 22" })).toBe(false);
-		expect(hasWindowsDesktopSession("win32", { SSH_TTY: "/dev/pts/0" })).toBe(false);
-		expect(hasWindowsDesktopSession("linux", {})).toBe(false);
+	it("requires win32 + an interactive logon session + no SSH markers", () => {
+		expect(hasWindowsDesktopSession("win32", { SESSIONNAME: "Console" })).toBe(true);
+		expect(hasWindowsDesktopSession("win32", { SESSIONNAME: "RDP-Tcp#3" })).toBe(true);
+		// Services / session-0 hosts have no SESSIONNAME — a toast can never surface there.
+		expect(hasWindowsDesktopSession("win32", {})).toBe(false);
+		expect(hasWindowsDesktopSession("win32", { SESSIONNAME: "Console", SSH_CLIENT: "1.2.3.4 5 22" })).toBe(false);
+		expect(hasWindowsDesktopSession("win32", { SESSIONNAME: "Console", SSH_TTY: "/dev/pts/0" })).toBe(false);
+		expect(hasWindowsDesktopSession("linux", { SESSIONNAME: "Console" })).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## What

First increment for #7272: one-way native Windows toast notifications, mirroring the existing Linux D-Bus fallback for BEL-only terminals.

- `hasWindowsDesktopSession()`: win32 + not an SSH session.
- `shouldDeliverDesktopNotification()` now fires on a local Windows desktop as well as a Linux session bus (same BEL-only + `PI_NO_DESKTOP_NOTIFY=1` gating).
- `resolveDesktopNotifier()` resolves Windows PowerShell 5.1 on win32 (PATH, then the canonical `%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe`). pwsh 7+ is deliberately not a fallback — it cannot project `Windows.UI.Notifications` without the Windows SDK assemblies.
- `buildWindowsToastScript()` builds a `ToastGeneric` WinRT payload (title/body XML-escaped, `urgency: critical` → `scenario="urgent"`), attributed to PowerShell's registered AppUserModelId so it works for unpackaged installs (source, npm bundle, compiled binary) with no registry writes.
- Delivery runs `powershell -NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -EncodedCommand <UTF-16LE base64>` so title/body never pass through argv re-quoting, spawned fire-and-forget and `unref()`ed like the Linux path.

## Why

Fixes the first-increment scope of #7272: no console host on Windows maps BEL to a toast, so omp completion/error/ask notifications are silently dropped for Windows users. Interactive actions/click-to-focus are intentionally out of scope pending the activation-lifecycle design discussed on the issue.

## Testing

- New unit tests in `packages/tui/test/desktop-notify.test.ts`: win32 gating (incl. SSH exclusion), PowerShell notifier resolution, `-EncodedCommand` argv shape, XML escaping, urgent scenario mapping. Existing Linux tests updated to pass an explicit platform (also makes them host-independent).
- Manual smoke on Windows Server 2022: the generated argv exits 0 and dispatches the toast.
- `bun test` for `packages/tui` notification suites, `biome check`, `bun check` clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
