### PR TITLE
fix(install): make install.ps1 compatible with Windows PowerShell 5.1

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -128,11 +128,16 @@ function Configure-BashShell {
                 New-Item -ItemType Directory -Force -Path $settingsDir | Out-Null
             }
 
-            # Read existing settings or create new
+            # Read existing settings or create new. ConvertFrom-Json -AsHashtable
+            # requires PowerShell 6+; build the hashtable manually so Windows
+            # PowerShell 5.1 merges instead of clobbering existing settings.
             $settings = @{}
             if (Test-Path $settingsFile) {
                 try {
-                    $settings = Get-Content $settingsFile -Raw | ConvertFrom-Json -AsHashtable
+                    $parsed = Get-Content $settingsFile -Raw | ConvertFrom-Json
+                    foreach ($prop in $parsed.PSObject.Properties) {
+                        $settings[$prop.Name] = $prop.Value
+                    }
                 } catch {
                     $settings = @{}
                 }
@@ -143,7 +148,7 @@ function Configure-BashShell {
 
             # Write settings
             $settings | ConvertTo-Json -Depth 10 | Set-Content $settingsFile -Encoding UTF8
-            Write-Host "✓ Configured shell path in $settingsFile" -ForegroundColor Green
+            Write-Host "[OK] Configured shell path in $settingsFile" -ForegroundColor Green
         } else {
             Write-Host ""
             Write-Host "No bash shell found - OMP will use its built-in shell." -ForegroundColor Cyan
@@ -154,7 +159,7 @@ function Configure-BashShell {
             Write-Host '    { "shellPath": "C:\\path\\to\\bash.exe" }' -ForegroundColor Cyan
         }
     } catch {
-        Write-Host "⚠ Could not configure bash shell: $_" -ForegroundColor Yellow
+        Write-Host "[WARN] Could not configure bash shell: $_" -ForegroundColor Yellow
     }
 }
 
@@ -226,7 +231,7 @@ function Install-ViaBun {
     }
 
     Write-Host ""
-    Write-Host "✓ Installed omp via bun" -ForegroundColor Green
+    Write-Host "[OK] Installed omp via bun" -ForegroundColor Green
 
     Configure-BashShell
 
@@ -261,7 +266,7 @@ function Install-Binary {
     Invoke-WebRequest -Uri $BinaryUrl -OutFile $OutPath -TimeoutSec 900
 
     Write-Host ""
-    Write-Host "✓ Installed omp to $OutPath" -ForegroundColor Green
+    Write-Host "[OK] Installed omp to $OutPath" -ForegroundColor Green
 
     # Add to PATH if not already there
     $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")


### PR DESCRIPTION
## What

Two Windows PowerShell 5.1 compatibility fixes in `scripts/install.ps1`:

1. `Configure-BashShell` used `ConvertFrom-Json -AsHashtable`, a PowerShell 6+ parameter. On stock Windows PowerShell 5.1 the call throws, the `catch` resets `$settings = @{}`, and the merge-and-write step silently **clobbers any existing `settings.json`**, keeping only `shellPath`. Replaced with a 5.1-compatible `PSObject.Properties` loop.

2. Replaced the non-ASCII `✓`/`⚠` glyphs in `Write-Host` strings with `[OK]`/`[WARN]`. The file is UTF-8 without BOM, so PowerShell 5.1 decodes it as ANSI when run from a local file (`powershell -File install.ps1`): the `✓` bytes decode to cp1252 mojibake whose trailing smart quote acts as a string delimiter, and the script **fails to parse** with cascading "Unexpected token"/"missing terminator" errors. (`irm | iex` was unaffected because HTTP responses are decoded as UTF-8.)

## Why

Windows PowerShell 5.1 is the default shell on all supported Windows versions; both bugs break the documented Windows install path — silently losing user settings in the best case, failing to parse at all when run from disk.

## Testing

On Windows Server 2022 / PowerShell 5.1.20348:
- Reproduced both bugs pre-fix: `[System.Management.Automation.Language.Parser]::ParseFile` reports syntax errors, and the settings merge rewrites a pre-seeded `settings.json` down to only `shellPath`.
- Post-fix: parser reports no errors; the merge preserves existing keys (including nested objects) while adding `shellPath`.

---

- [x] `bun check` passes (no TS/Rust changes)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — installer script; no package changelog covers it
