### PR TITLE
fix(task): inherit the aliased role's retry fallback chain for subagents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed subagents spawned through a model-role alias (e.g. the bundled `scout`'s `model: "@smol"`) falling back onto the `default` role's `retry.fallbackChains` entry instead of their own role's chain: the child is pinned to a `subagent:<id>` role whose chain shadows every configured role chain, and that pin inherited `default` unconditionally, so a `@smol` scout retried on the default chain's first model instead of the smol chain's.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -185,11 +185,26 @@ function resolveSubagentRetryFallbackCandidates(
 	return candidates;
 }
 
-function resolveSubagentDefaultRetryFallbackChain(
+/**
+ * Chain a single-model subagent inherits when its own model patterns supply no
+ * fallbacks of their own. The child is pinned to a `subagent:<id>` role whose
+ * chain shadows every configured role chain (see
+ * {@link installSubagentRetryFallbackChain}), so a role-alias request (`@smol`)
+ * MUST inherit that role's chain — otherwise the pin silently re-routes the
+ * child onto the `default` role's chain. Explicit model selectors keep
+ * inheriting `default`: they carry no role identity, and a role that happens to
+ * be assigned the same model must not capture the child's fallback routing.
+ */
+function resolveSubagentInheritedRetryFallbackChain(
 	settings: Settings,
 	modelRegistry: ModelRegistry,
+	modelPatterns: string[],
 ): string[] | undefined {
-	const fallbackChain = settings.get("retry.fallbackChains")?.default;
+	const configuredChains = settings.get("retry.fallbackChains");
+	const role = resolveExplicitModelRole(modelPatterns, settings);
+	// An explicitly emptied role chain means "no fallbacks", not "inherit
+	// default" — mirrors expandDefaultRetryFallbackChains.
+	const fallbackChain = (role !== undefined ? configuredChains?.[role] : undefined) ?? configuredChains?.default;
 	if (
 		!Array.isArray(fallbackChain) ||
 		fallbackChain.length === 0 ||
@@ -208,11 +223,11 @@ function installSubagentRetryFallbackChain(args: {
 	settings: Settings;
 	id: string;
 	candidates: SubagentRetryFallbackCandidate[];
-	defaultFallbackChain: string[] | undefined;
+	inheritedFallbackChain: string[] | undefined;
 	model: Model<Api> | undefined;
 	authFallbackUsed: boolean;
 }): string | undefined {
-	const { settings, id, candidates, defaultFallbackChain, model, authFallbackUsed } = args;
+	const { settings, id, candidates, inheritedFallbackChain, model, authFallbackUsed } = args;
 	if (!model || authFallbackUsed || candidates.length === 0) return undefined;
 
 	const selectedIndex = candidates.findIndex(
@@ -221,8 +236,8 @@ function installSubagentRetryFallbackChain(args: {
 	if (selectedIndex < 0) return undefined;
 	const fallbackSelectors = candidates.slice(selectedIndex + 1).map(candidate => candidate.selector);
 	const existingFallbackChains = settings.get("retry.fallbackChains");
-	// A single explicit model may reuse a configured default chain, but never an implicit parent fallback.
-	const fallbackChain = fallbackSelectors.length > 0 ? fallbackSelectors : defaultFallbackChain;
+	// A single configured model may reuse its role's (or the default) configured chain, but never an implicit parent fallback.
+	const fallbackChain = fallbackSelectors.length > 0 ? fallbackSelectors : inheritedFallbackChain;
 	if (
 		!Array.isArray(fallbackChain) ||
 		fallbackChain.length === 0 ||
@@ -2818,9 +2833,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			checkAbort();
 
 			const configuredModelPatterns = resolveConfiguredModelPatterns(modelPatterns, settings);
-			const defaultRetryFallbackChain =
+			const inheritedRetryFallbackChain =
 				configuredModelPatterns.length === 1
-					? resolveSubagentDefaultRetryFallbackChain(subagentSettings, modelRegistry)
+					? resolveSubagentInheritedRetryFallbackChain(subagentSettings, modelRegistry, modelPatterns)
 					: undefined;
 			const {
 				model,
@@ -2855,7 +2870,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				settings: subagentSettings,
 				id,
 				candidates: resolveSubagentRetryFallbackCandidates(modelPatterns, modelRegistry, subagentSettings),
-				defaultFallbackChain: defaultRetryFallbackChain,
+				inheritedFallbackChain: inheritedRetryFallbackChain,
 				model,
 				authFallbackUsed,
 			});
@@ -2998,7 +3013,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				modelPatternFallbackRole:
 					model || modelOverride === undefined ? undefined : `${SUBAGENT_RETRY_FALLBACK_ROLE_PREFIX}${id}`,
 				modelPatternDefaultFallbackChain:
-					model || modelOverride === undefined ? undefined : defaultRetryFallbackChain,
+					model || modelOverride === undefined ? undefined : inheritedRetryFallbackChain,
 				thinkingLevel: effectiveThinkingLevel,
 				thinkingLevelCeiling: spawnEffortCeiling,
 				toolNames,

--- a/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
+++ b/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
@@ -166,6 +166,90 @@ describe("subagent runtime model resolution", () => {
 		expect(childFallbackChains?.["existing-local-role"]).toEqual(["other-provider/other-model"]);
 	});
 
+	it("inherits the aliased role's chain, not the default chain, for a role-alias subagent model", async () => {
+		const fast = model("fast", "hy3");
+		const slow = model("slow", "opus");
+		let childFallbackChains: Record<string, string[]> | undefined;
+		let childModelRole: string | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childFallbackChains = options.settings?.get("retry.fallbackChains") as Record<string, string[]> | undefined;
+			childModelRole = options.settings?.getModelRoles()["subagent:role-alias-chain"];
+			return { session: createYieldingSession(), extensionsResult: {}, setToolUIContext: () => {} } as never;
+		});
+
+		// Mirrors the bundled scout agent (`model: "@smol"`).
+		const agent: AgentDefinition = {
+			name: "scout",
+			description: "test",
+			systemPrompt: "test",
+			source: "bundled",
+			model: ["@smol"],
+		};
+		await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "role-alias-chain",
+			settings: Settings.isolated({
+				modelRoles: { default: "slow/opus", smol: "fast/hy3" },
+				"retry.fallbackChains": {
+					default: ["slow/opus-backup"],
+					smol: ["fast/composer"],
+				},
+			}),
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [fast, slow],
+				getApiKey: async () => "test-key",
+			} as never,
+			enableLsp: false,
+		});
+
+		expect(childModelRole).toBe("fast/hy3");
+		expect(childFallbackChains?.["subagent:role-alias-chain"]).toEqual(["fast/composer"]);
+		expect(childFallbackChains?.default).toEqual(["slow/opus-backup"]);
+	});
+
+	it("inherits the default chain for a role alias whose role configures no chain", async () => {
+		const fast = model("fast", "hy3");
+		const slow = model("slow", "opus");
+		let childFallbackChains: Record<string, string[]> | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childFallbackChains = options.settings?.get("retry.fallbackChains") as Record<string, string[]> | undefined;
+			return { session: createYieldingSession(), extensionsResult: {}, setToolUIContext: () => {} } as never;
+		});
+
+		const agent: AgentDefinition = {
+			name: "scout",
+			description: "test",
+			systemPrompt: "test",
+			source: "bundled",
+			model: ["@smol"],
+		};
+		await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "role-alias-default-chain",
+			settings: Settings.isolated({
+				modelRoles: { default: "slow/opus", smol: "fast/hy3" },
+				"retry.fallbackChains": { default: ["slow/opus-backup"] },
+			}),
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [fast, slow],
+				getApiKey: async () => "test-key",
+			} as never,
+			enableLsp: false,
+		});
+
+		expect(childFallbackChains?.["subagent:role-alias-default-chain"]).toEqual(["slow/opus-backup"]);
+	});
+
 	it("does not inherit the default chain when multiple requested models collapse to one candidate", async () => {
 		const primary = model("lm-studio", "local-reviewer");
 		const fallback = model("openai-codex", "gpt-5.6-sol");


### PR DESCRIPTION
## Problem

Every subagent spawned through a model-role alias retries on the **`default`** role's `retry.fallbackChains` entry instead of its own role's chain.

Concretely, with the bundled `scout` (`model: "@smol"`) and:

```jsonc
"modelRoles": { "default": "anthropic/claude-opus-5", "smol": "orcarouter/tencent/hy3" },
"retry.fallbackChains": {
  "default": ["openai-codex/gpt-5.6-sol", "cursor/cursor-grok-4.5-high"],
  "smol":    ["cursor/composer-2.5", "cursor/cursor-grok-4.5-high", "openai-codex/gpt-5.6-luna"]
}
```

a scout that hits a retryable error lands on `openai-codex/gpt-5.6-sol` — a model that is not in the `smol` chain at all. The Agent Hub row shows `fallback → openai-codex/gpt-5.6-sol`, which is accurate: the routing really did use the wrong chain, so scouts pile onto whichever provider `default` is chained to (an exhausted quota, in the reported case).

## Root cause

`packages/coding-agent/src/task/executor.ts`:

1. A single-model subagent has no fallbacks of its own (`candidates.slice(selectedIndex + 1)` is empty), so it inherits a chain.
2. `installSubagentRetryFallbackChain` pins the child to a synthetic `subagent:<id>` role and inserts it **first** in `retry.fallbackChains`, deliberately, so no other role can capture its routing. `resolveRetryFallbackChainKey` matches role keys in insertion order, so this pin shadows every configured role chain — including `smol`'s.
3. The inherited chain was hardcoded to `chains.default` (`resolveSubagentDefaultRetryFallbackChain`), so the pin re-routes an `@smol` child onto the default chain.

## Fix

Resolve the inherited chain from the role identity still present in the raw pattern — `resolveExplicitModelRole(["@smol"]) === "smol"` — and use `chains[role] ?? chains.default`.

- An explicitly **empty** role chain still means "no fallbacks", not "inherit default", mirroring `expandDefaultRetryFallbackChains`.
- Explicit model selectors (`modelOverride: "lm-studio/local-reviewer"`) keep inheriting `default`: they carry no role identity, and a role that happens to be assigned the same model must not capture the child's routing (existing contract, still covered).
- The disabled-provider filter is unchanged.

## Tests

Two cases added to `test/issue-2750-subagent-runtime-fallback.test.ts`:

- a role-alias subagent inherits the aliased role's chain, not `default`;
- a role alias whose role configures no chain still inherits `default`.

The first fails on `main`:

```
- "fast/composer"      (smol chain — expected)
+ "slow/opus-backup"   (default chain — the bug)
```

## Validation

- `bun --cwd=packages/coding-agent run check` (biome + tsgo) clean.
- Affected-area suites (106 files matching `fallback|task|model|agent-hub|executor|sdk-`): **1233 pass / 5 fail**, versus **1231 pass / 5 fail** on `upstream/main` — the identical 5 failures are environmental on this machine (no `bazelisk`, so `packages/natives` is unbuilt, plus two shell-dependent `executeBash` cases), not caused by this change.