### PR TITLE
fix(tui): trigger autocomplete for Windows drive-absolute paths

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed prompt autocomplete never triggering for Windows drive-absolute paths (`C:/Users/...`, `C:\Users\...`); only `/`, `./`, `../`, and `~/` prefixes were recognized.
+
 ## [17.2.9] - 2026-08-05
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -687,7 +687,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			pathPrefix.startsWith("/") ||
 			pathPrefix.startsWith("./") ||
 			pathPrefix.startsWith("../") ||
-			pathPrefix.startsWith("~/")
+			pathPrefix.startsWith("~/") ||
+			// Windows drive-absolute paths (C:/Users, C:\Users).
+			/^[A-Za-z]:[\\/]/.test(pathPrefix)
 		) {
 			return pathPrefix;
 		}

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -368,6 +368,27 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(result?.items.map(item => item.value)).toContain(`${normalizedBaseDir}/alpha.ts`);
 		});
 
+		it("triggers automatic completion for a drive-letter path token on every platform", async () => {
+			// On Windows `C:/` is a real drive root; on POSIX it is a relative
+			// directory literally named `C:`, created here so the same drive-style
+			// token exercises the trigger without platform branching downstream.
+			if (process.platform !== "win32") {
+				fs.mkdirSync(path.join(baseDir, "C:"));
+				fs.writeFileSync(path.join(baseDir, "C:", "alpha.ts"), "export {};\n");
+			}
+			const provider = new CombinedAutocompleteProvider([{ name: "model", description: "Switch model" }], baseDir);
+			const line = "see C:/";
+
+			const result = await provider.getSuggestions([line], 0, line.length);
+
+			expect(result).not.toBeNull();
+			expect(result?.prefix).toBe("C:/");
+			expect(result?.items.length).toBeGreaterThan(0);
+			if (process.platform !== "win32") {
+				expect(result?.items.map(item => item.value)).toContain("C:/alpha.ts");
+			}
+		});
+
 		it("keeps slash command matches ahead of file suggestions", async () => {
 			const provider = new CombinedAutocompleteProvider([{ name: "model", description: "Switch model" }], baseDir);
 			const line = "/mod";

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -105,19 +105,23 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(result).toBeNull();
 		});
 
-		it("falls back to path suggestions for an unmatched mid-prompt slash token", async () => {
-			const provider = new CombinedAutocompleteProvider(
-				[{ name: "skill:security-scan", description: "Security scan" }],
-				"/tmp",
-			);
-			const line = "see /tmp";
+		// Requires a real `/tmp` directory at the filesystem root.
+		it.skipIf(process.platform === "win32")(
+			"falls back to path suggestions for an unmatched mid-prompt slash token",
+			async () => {
+				const provider = new CombinedAutocompleteProvider(
+					[{ name: "skill:security-scan", description: "Security scan" }],
+					"/tmp",
+				);
+				const line = "see /tmp";
 
-			const result = await provider.getSuggestions([line], 0, line.length);
+				const result = await provider.getSuggestions([line], 0, line.length);
 
-			expect(result).not.toBeNull();
-			expect(result?.prefix).toBe("/tmp");
-			expect(result?.items.map(item => item.value)).toContain("/tmp/");
-		});
+				expect(result).not.toBeNull();
+				expect(result?.prefix).toBe("/tmp");
+				expect(result?.items.map(item => item.value)).toContain("/tmp/");
+			},
+		);
 
 		it("returns nothing for a prose token that only fuzzy-matches skill text", async () => {
 			const provider = new CombinedAutocompleteProvider(


### PR DESCRIPTION
## What

`CombinedAutocompleteProvider.#extractPathPrefix` only auto-triggered file completion for tokens starting with `/`, `./`, `../`, or `~/`, so typing a Windows drive-absolute path (`C:/Users/...` or `C:\Users\...`) into the prompt never opened path suggestions. Added a drive-letter check:

```ts
pathPrefix.startsWith("~/") ||
// Windows drive-absolute paths (C:/Users, C:\Users).
/^[A-Za-z]:[\\/]/.test(pathPrefix)
```

The downstream suggestion machinery (`#getFileSuggestions`) already handles `C:/` paths — only the trigger was missing.

Also makes the `test/autocomplete.test.ts` suite pass on Windows:
- the two `absolute path completion` tests that exercise real drive paths (via `os.tmpdir()`) now pass with the fix;
- the mid-prompt `/tmp` fallback test is skipped on win32, since it requires a real `/tmp` directory at the filesystem root.

## Why

Windows users cannot autocomplete absolute paths in the TUI prompt at all — one of the most common completion shapes on that platform.

## Testing

- `cd packages/tui && bun test test/autocomplete.test.ts` on Windows Server 2022: 0 fail (2 previously-failing drive-path tests pass; 1 win32 skip).
- `bun run check` (biome + tsgo) passes in `packages/tui`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
