### PR TITLE
test: fix Windows portability of bash ACP, Warp capability, and logger closure tests

### DIFF
--- a/packages/coding-agent/test/bash-acp-terminal.test.ts
+++ b/packages/coding-agent/test/bash-acp-terminal.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import * as os from "node:os";
 import type { ClientBridge, ClientBridgeTerminalHandle } from "@oh-my-pi/pi-coding-agent/session/client-bridge";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { BashTool } from "@oh-my-pi/pi-coding-agent/tools/bash";
 
 function makeSession(bridge: ClientBridge): ToolSession {
 	return {
-		cwd: "/tmp",
+		cwd: os.tmpdir(),
 		hasUI: false,
 		skills: [],
 		getSessionFile: () => null,

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -159,12 +159,14 @@ console.log(JSON.stringify({ id: TERMINAL_ID, imageProtocol: TERMINAL.imageProto
 		expect(exitCode).toBe(0);
 		const resolved = JSON.parse(stdout) as { id: string; imageProtocol: string | null; expected: string };
 		expect(resolved.id).toBe("warp");
-		expect(resolved.imageProtocol).toBe(resolved.expected);
+		// Warp for Windows lacks Kitty graphics support.
+		expect(resolved.imageProtocol).toBe(process.platform === "win32" ? null : resolved.expected);
 	});
 
 	it("is Kitty-capable with true color but no OSC 8 hyperlinks", () => {
 		const warp = getTerminalInfo("warp");
-		expect(warp.imageProtocol).toBe(ImageProtocol.Kitty);
+		// Warp for Windows lacks Kitty graphics support.
+		expect(warp.imageProtocol).toBe(process.platform === "win32" ? null : ImageProtocol.Kitty);
 		expect(warp.trueColor).toBe(true);
 		expect(warp.hyperlinks).toBe(false);
 		expect(warp.notifyProtocol).toBe(NotifyProtocol.Osc9);

--- a/packages/tui/test/terminal-capabilities.test.ts
+++ b/packages/tui/test/terminal-capabilities.test.ts
@@ -165,8 +165,11 @@ console.log(JSON.stringify({ id: TERMINAL_ID, imageProtocol: TERMINAL.imageProto
 
 	it("is Kitty-capable with true color but no OSC 8 hyperlinks", () => {
 		const warp = getTerminalInfo("warp");
-		// Warp for Windows lacks Kitty graphics support.
-		expect(warp.imageProtocol).toBe(process.platform === "win32" ? null : ImageProtocol.Kitty);
+		// Warp lacks Kitty graphics on Windows hosts, including WSL.
+		const windowsHost =
+			process.platform === "win32" ||
+			(process.platform === "linux" && Boolean(Bun.env.WSL_DISTRO_NAME || Bun.env.WSL_INTEROP));
+		expect(warp.imageProtocol).toBe(windowsHost ? null : ImageProtocol.Kitty);
 		expect(warp.trueColor).toBe(true);
 		expect(warp.hyperlinks).toBe(false);
 		expect(warp.notifyProtocol).toBe(NotifyProtocol.Osc9);

--- a/packages/utils/test/logger-runtime-closure.test.ts
+++ b/packages/utils/test/logger-runtime-closure.test.ts
@@ -105,8 +105,8 @@ describe("central logger runtime closure", () => {
 			await fs.readFile(path.resolve(import.meta.dir, "../../..", "package.json"), "utf8"),
 		) as { workspaces?: { catalog?: Record<string, string> } };
 		expect(rootPackage.workspaces?.catalog?.["winston-daily-rotate-file"]).toBe("5.0.0");
-		expect(Bun.resolveSync("winston-daily-rotate-file/daily-rotate-file.js", import.meta.dir)).toEndWith(
-			"/winston-daily-rotate-file/daily-rotate-file.js",
-		);
+		expect(
+			Bun.resolveSync("winston-daily-rotate-file/daily-rotate-file.js", import.meta.dir).replaceAll("\\", "/"),
+		).toEndWith("/winston-daily-rotate-file/daily-rotate-file.js");
 	});
 });


### PR DESCRIPTION
## What

Three test-only Windows portability fixes (no product code changes):

1. `packages/coding-agent/test/bash-acp-terminal.test.ts` — the mock session hardcoded `cwd: "/tmp"`, so all 9 tests failed on Windows with `Working directory does not exist: /tmp` before reaching the behavior under test. Now uses `os.tmpdir()`.

2. `packages/utils/test/logger-runtime-closure.test.ts` — `Bun.resolveSync(...)` returns backslash paths on Windows, failing the `toEndWith("/winston-daily-rotate-file/daily-rotate-file.js")` assertion. Separators are normalized before the assertion.

3. `packages/tui/test/terminal-capabilities.test.ts` — two Warp tests asserted `ImageProtocol.Kitty` unconditionally, but the product intentionally disables Kitty images on Windows (already covered by the passing "uses Kitty images on macOS/Linux and disables them on Windows" test). The host-platform assertions now expect `null` on win32.

## Why

These tests fail on any Windows machine for environmental reasons, hiding real regressions in the noise. Each fix asserts the same contract as before on POSIX.

## Testing

On Windows Server 2022:
- `bun test test/bash-acp-terminal.test.ts` (coding-agent): 9 pass, 0 fail (was 9 fail).
- `bun test test/logger-runtime-closure.test.ts` (utils): 0 fail.
- `bun test test/terminal-capabilities.test.ts` (tui): 37 pass, 0 fail.
- `bun run check` passes in all three packages.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — test-only, not user-facing
