### PR TITLE
fix(coding-agent): build WSL mount fallback paths with POSIX semantics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- WSL host-home resolution now builds `/mnt/<drive>/...` fallback paths with POSIX semantics regardless of the host platform, instead of the platform-dependent `path` module ([#3779](https://github.com/can1357/oh-my-pi/issues/3779)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/discovery/agents.ts
+++ b/packages/coding-agent/src/discovery/agents.ts
@@ -44,12 +44,14 @@ function isWsl(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): boolean {
 function convertWindowsPathToDefaultWslMount(windowsPath: string): string | undefined {
 	const trimmed = windowsPath.trim();
 	if (trimmed.length === 0) return undefined;
-	if (path.isAbsolute(trimmed)) return path.normalize(trimmed);
+	// The result is always a WSL (POSIX) path, so build it with posix
+	// semantics regardless of the host platform.
+	if (path.posix.isAbsolute(trimmed)) return path.posix.normalize(trimmed);
 	const match = WINDOWS_DRIVE_PROFILE_PATTERN.exec(trimmed);
 	if (!match) return undefined;
 	const [, drive, rest] = match;
 	const segments = rest.replace(/\\/g, "/").split("/").filter(Boolean);
-	return path.join("/mnt", drive.toLowerCase(), ...segments);
+	return path.posix.join("/mnt", drive.toLowerCase(), ...segments);
 }
 
 function resolveWithWslPath(windowsPath: string): string | undefined {

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -284,7 +284,7 @@ describe("skills", () => {
 				wslPath: () => undefined,
 			});
 
-			expect(resolved).toBe(path.join("/mnt", "c", "Users", "alice"));
+			expect(resolved).toBe("/mnt/c/Users/alice");
 		});
 
 		it("resolves the Windows profile through interop when USERPROFILE is not exported (#3779)", () => {


### PR DESCRIPTION
## What

`convertWindowsPathToDefaultWslMount()` in `src/discovery/agents.ts` built its `/mnt/<drive>/...` fallback with the host-platform `path` module. The result is always a WSL (POSIX) path, so this now uses `path.posix` explicitly:

```diff
-	if (path.isAbsolute(trimmed)) return path.normalize(trimmed);
+	if (path.posix.isAbsolute(trimmed)) return path.posix.normalize(trimmed);
 	...
-	return path.join("/mnt", drive.toLowerCase(), ...segments);
+	return path.posix.join("/mnt", drive.toLowerCase(), ...segments);
```

The corresponding test expectation is pinned to the literal `/mnt/c/Users/alice` (it previously encoded the same host-dependence via `path.join`), so the #3779 suite now passes on Windows hosts too.

## Why

On a win32 host the old code produced `\mnt\c\Users\alice`-style output — wrong for a WSL mount path in any context, and it made `test/skills.test.ts` ("converts Windows USERPROFILE paths to the default WSL mount (#3779)") fail when the suite runs on Windows. Using posix semantics makes the function's contract explicit and host-independent.

## Testing

- `bun test test/skills.test.ts` on Windows Server 2022: 47 pass / 0 fail (previously the #3779 conversion test failed on this host).
- `biome check` and `bun check` clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
