### PR TITLE
fix(natives): gate wayland capture capability on pipewire feature

### DIFF
--- a/crates/pi-natives/src/desktop/linux/wayland/mod.rs
+++ b/crates/pi-natives/src/desktop/linux/wayland/mod.rs
@@ -106,12 +106,19 @@ impl Backend for WaylandBackend {
 		DesktopCapabilities {
 			backend: "wayland".to_string(),
 			display_server: Some("wayland".to_string()),
-			capture: true,
+			// The PipeWire screencast path is compiled in only under the
+			// wayland-pipewire feature; without it capture() hard-errors, so the
+			// capability report must not advertise a capture the binary cannot do.
+			capture: cfg!(feature = "wayland-pipewire"),
 			input: self.input.is_some(),
 			ax: self.ax.is_some(),
 			background_window_input: false,
 			delivery_modes: vec!["foreground".to_string(), "background".to_string()],
-			capture_permission: "prompt-or-granted".to_string(),
+			capture_permission: if cfg!(feature = "wayland-pipewire") {
+				"prompt-or-granted".to_string()
+			} else {
+				"unavailable".to_string()
+			},
 			input_permission: if self.input.is_some() {
 				"granted".to_string()
 			} else {
@@ -262,5 +269,27 @@ mod tests {
 			.expect_err("window background input must fail");
 		assert_eq!(err.code.as_str(), "BackgroundUnavailable");
 		assert!(err.message.contains("wayland-compositor-focus-only"));
+	}
+
+	#[test]
+	#[cfg(not(feature = "wayland-pipewire"))]
+	fn capabilities_report_no_capture_without_pipewire_feature() {
+		let mut backend = WaylandBackend {
+			display:     DisplaySelector::All,
+			ax:          None,
+			ax_error:    None,
+			input:       None,
+			input_error: None,
+			displays:    Vec::new(),
+		};
+		let caps = backend.capabilities();
+		// Shipped builds compile without wayland-pipewire, so the capture path is
+		// absent; capabilities() must not advertise capture the binary cannot do.
+		assert!(!caps.capture, "capture must be false when the pipewire feature is off");
+		assert_eq!(caps.capture_permission, "unavailable");
+		let err = backend
+			.capture(&Target::Desktop, &CaptureCaps::default())
+			.expect_err("capture must fail without the pipewire feature");
+		assert_eq!(err.code.as_str(), "CaptureFailed");
 	}
 }

--- a/docs/computer-use.md
+++ b/docs/computer-use.md
@@ -131,11 +131,11 @@ await wait(
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | macOS x64/arm64         | ScreenCapture/Quartz plus native AX and input. Grant Screen Recording for capture and Accessibility for input/AX, then restart the launching host.                                                                          |
 | Linux X11 x64/arm64     | X11 capture/input and AT-SPI accessibility. Requires a readable display plus RandR/XTEST.                                                                                                                                   |
-| Linux Wayland x64/arm64 | ScreenCast portal/PipeWire capture, RemoteDesktop portal or `LIBEI_SOCKET` input, and AT-SPI accessibility. Portal permission prompts and compositor restrictions apply; background per-window native input is unavailable. |
+| Linux Wayland x64/arm64 | RemoteDesktop portal or `LIBEI_SOCKET` input and AT-SPI accessibility. ScreenCast portal/PipeWire capture ships only in builds compiled with the `wayland-pipewire` Cargo feature; released binaries omit it, so `capabilities()` reports `capture: false` there. Portal permission prompts and compositor restrictions apply; background per-window native input is unavailable. |
 | Windows x64             | Native display/window capture, Win32 input, and UI Automation accessibility.                                                                                                                                                |
 | Other published targets | Unsupported unless the native addon reports capabilities.                                                                                                                                                                   |
 
-Inspect `desktop.capabilities()` rather than assuming capture, input, AX, or permission state. On Wayland, a missing portal/PipeWire feature or denied RemoteDesktop portal is reported as a capture/input/permission failure rather than falling back to X11.
+Inspect `desktop.capabilities()` rather than assuming capture, input, AX, or permission state. On Wayland, released builds are compiled without the `wayland-pipewire` feature, so `capabilities()` reports `capture: false`; where the feature is present, a missing portal/PipeWire feature or denied RemoteDesktop portal is reported as a capture/input/permission failure rather than falling back to X11.
 
 ## Safety and troubleshooting
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Wayland `desktop.capabilities()` reporting `capture: true` on builds compiled without the `wayland-pipewire` feature (all released binaries), where every capture call hard-fails with `CaptureFailed`. The `capture` flag and `capture_permission` now reflect the compiled-in feature ([#7700](https://github.com/can1357/oh-my-pi/issues/7700)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Changed


### PR DESCRIPTION
## Repro
On a Wayland session with `computer.enabled: true`, `desktop.capabilities()` reports `capture: true`, but `desktop.screenshot()` then fails with `CaptureFailed: Wayland capture requires the wayland-pipewire feature`. A model that trusts the capability report retries into a guaranteed failure. Reproduced headlessly by constructing `WaylandBackend` without the feature and comparing the report to the actual capture path:

```
cargo test -p pi-natives --lib capabilities_report_no_capture_without_pipewire_feature
# pre-fix: panicked "capture must be false when the pipewire feature is off"
```

## Cause
`WaylandBackend::capabilities()` (`crates/pi-natives/src/desktop/linux/wayland/mod.rs`) hardcoded `capture: true` (and `capture_permission: "prompt-or-granted"`) unconditionally. The PipeWire screencast path in `capture()` is `#[cfg(not(feature = "wayland-pipewire"))]` and returns `CaptureFailed`. The `wayland-pipewire` feature is off by default (`Cargo.toml`) and the shipped Bazel addon builds with `crate_features = []` (`BUILD.bazel`), so released binaries never contain the capture path yet the capability report claimed they did.

## Fix
- `capabilities()`: gate `capture` and `capture_permission` on `cfg!(feature = "wayland-pipewire")` — `false`/`"unavailable"` when the feature is absent, unchanged when present.
- `docs/computer-use.md`: the Wayland platform row and the capabilities note now state that ScreenCast/PipeWire capture ships only in builds compiled with `wayland-pipewire` and that released binaries report `capture: false`.
- Added a regression test that constructs the backend without the feature and asserts the report agrees with the erroring capture path.
- Changelog entry under `packages/natives` `[Unreleased]`.

## Verification
`cargo test -p pi-natives --lib wayland::tests` — 2 passed, 0 failed (the new test fails before the fix, passes after). Fixes #7700