### PR TITLE
fix(coding-agent): validate Linux browser executables before launch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Hardened Linux Chromium executable detection to reject non-executable files, non-browser wrappers, and candidates that hang during the version probe.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -214,8 +214,7 @@ async function isChromiumExecutable(p: string): Promise<boolean> {
 		});
 		const stdout = await Promise.race([
 			new Response(proc.stdout).text(),
-			proc.exited.then(() => null),
-			Bun.sleep(probeTimeoutMs).then(() => null),
+			Bun.sleep(probeTimeoutMs + 500).then(() => null),
 		]);
 		if (stdout === null) return false;
 		await proc.exited;

--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -205,11 +205,19 @@ function isExecutableFile(p: string): boolean {
 async function isChromiumExecutable(p: string): Promise<boolean> {
 	if (!isExecutableFile(p)) return false;
 	try {
+		const probeTimeoutMs = 3000;
 		const proc = Bun.spawn([p, "--version"], {
 			stdout: "pipe",
 			stderr: "ignore",
+			signal: AbortSignal.timeout(probeTimeoutMs),
+			killSignal: "SIGKILL",
 		});
-		const stdout = await new Response(proc.stdout).text();
+		const stdout = await Promise.race([
+			new Response(proc.stdout).text(),
+			proc.exited.then(() => null),
+			Bun.sleep(probeTimeoutMs).then(() => null),
+		]);
+		if (stdout === null) return false;
 		await proc.exited;
 		return proc.exitCode === 0 && /Chrom|Edg/i.test(stdout);
 	} catch {

--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -133,7 +133,7 @@ let chromiumExecutablePromise: Promise<string | undefined> | undefined;
 export async function ensureChromiumExecutable(): Promise<string | undefined> {
 	const envPath = process.env.PUPPETEER_EXECUTABLE_PATH;
 	if (envPath) return envPath;
-	const sysChrome = resolveSystemChromium();
+	const sysChrome = await resolveSystemChromium();
 	if (sysChrome) return sysChrome;
 	if (chromiumExecutablePromise) return chromiumExecutablePromise;
 
@@ -193,7 +193,25 @@ let resolvedChromium: string | null | undefined; // undefined = unchecked; null 
 function isExecutableFile(p: string): boolean {
 	try {
 		const st = fs.statSync(p);
-		return st.isFile();
+		if (!st.isFile()) return false;
+		if (process.platform === "win32") return true;
+		fs.accessSync(p, fs.constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function isChromiumExecutable(p: string): Promise<boolean> {
+	if (!isExecutableFile(p)) return false;
+	try {
+		const proc = Bun.spawn([p, "--version"], {
+			stdout: "pipe",
+			stderr: "ignore",
+		});
+		const stdout = await new Response(proc.stdout).text();
+		await proc.exited;
+		return proc.exitCode === 0 && /Chrom|Edg/i.test(stdout);
 	} catch {
 		return false;
 	}
@@ -278,13 +296,13 @@ function systemChromiumCandidates(
 	return candidates;
 }
 
-function resolveSystemChromium(): string | undefined {
+async function resolveSystemChromium(): Promise<string | undefined> {
 	if (resolvedChromium !== undefined) return resolvedChromium ?? undefined;
 	const seen = new Set<string>();
 	for (const candidate of systemChromiumCandidates()) {
 		if (!candidate || seen.has(candidate)) continue;
 		seen.add(candidate);
-		if (isExecutableFile(candidate)) {
+		if (await isChromiumExecutable(candidate)) {
 			resolvedChromium = candidate;
 			logger.debug("Using system Chrome/Chromium", { path: candidate });
 			return candidate;
@@ -892,6 +910,10 @@ export function systemChromiumCandidatesForTest(
 	which?: (name: string) => string | null | undefined,
 ): string[] {
 	return systemChromiumCandidates(platform, home, which);
+}
+
+export async function chromiumExecutableProbeForTest(executablePath: string): Promise<boolean> {
+	return isChromiumExecutable(executablePath);
 }
 
 export function stealthIgnoreDefaultArgsForTest(executablePath: string | undefined): string[] {

--- a/packages/coding-agent/test/tools/browser-launch.test.ts
+++ b/packages/coding-agent/test/tools/browser-launch.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
+import * as fs from "node:fs";
 import * as path from "node:path";
 import {
+	chromiumExecutableProbeForTest,
 	stealthIgnoreDefaultArgsForTest,
 	systemChromiumCandidatesForTest,
 } from "@oh-my-pi/pi-coding-agent/tools/browser/launch";
@@ -97,6 +99,26 @@ describe("system Chromium candidates", () => {
 });
 
 describe("browser executable selection", () => {
+	it.skipIf(process.platform === "win32")(
+		"rejects executable wrappers that are not Chromium-family browsers",
+		async () => {
+			const tempDir = TempDir.createSync("@browser-probe-");
+			try {
+				const wrapper = path.join(tempDir.path(), "google-chrome");
+				const chromium = path.join(tempDir.path(), "chromium");
+				await Bun.write(wrapper, "#!/bin/sh\necho browser bridge\n");
+				await Bun.write(chromium, "#!/bin/sh\necho Chromium 123.0\n");
+				fs.chmodSync(wrapper, 0o755);
+				fs.chmodSync(chromium, 0o755);
+
+				await expect(chromiumExecutableProbeForTest(wrapper)).resolves.toBe(false);
+				await expect(chromiumExecutableProbeForTest(chromium)).resolves.toBe(true);
+			} finally {
+				await tempDir.remove();
+			}
+		},
+	);
+
 	it("honors PUPPETEER_EXECUTABLE_PATH before a detected Windows system Chrome", async () => {
 		const tempDir = TempDir.createSync("@browser-executable-");
 		try {

--- a/packages/coding-agent/test/tools/browser-launch.test.ts
+++ b/packages/coding-agent/test/tools/browser-launch.test.ts
@@ -106,18 +106,37 @@ describe("browser executable selection", () => {
 			try {
 				const wrapper = path.join(tempDir.path(), "google-chrome");
 				const chromium = path.join(tempDir.path(), "chromium");
+				const nonExecutable = path.join(tempDir.path(), "not-executable");
 				await Bun.write(wrapper, "#!/bin/sh\necho browser bridge\n");
 				await Bun.write(chromium, "#!/bin/sh\necho Chromium 123.0\n");
+				await Bun.write(nonExecutable, "#!/bin/sh\necho Chromium 123.0\n");
 				fs.chmodSync(wrapper, 0o755);
 				fs.chmodSync(chromium, 0o755);
+				fs.chmodSync(nonExecutable, 0o644);
 
 				await expect(chromiumExecutableProbeForTest(wrapper)).resolves.toBe(false);
 				await expect(chromiumExecutableProbeForTest(chromium)).resolves.toBe(true);
+				await expect(chromiumExecutableProbeForTest(nonExecutable)).resolves.toBe(false);
 			} finally {
 				await tempDir.remove();
 			}
 		},
 	);
+
+	it.skipIf(process.platform === "win32")("rejects wrappers that hang during the version probe", async () => {
+		const tempDir = TempDir.createSync("@browser-probe-hanging-");
+		try {
+			const hangingWrapper = path.join(tempDir.path(), "google-chrome");
+			await Bun.write(hangingWrapper, "#!/bin/sh\nsleep 60\n");
+			fs.chmodSync(hangingWrapper, 0o755);
+
+			const startedAt = performance.now();
+			await expect(chromiumExecutableProbeForTest(hangingWrapper)).resolves.toBe(false);
+			expect(performance.now() - startedAt).toBeLessThan(5000);
+		} finally {
+			await tempDir.remove();
+		}
+	});
 
 	it("honors PUPPETEER_EXECUTABLE_PATH before a detected Windows system Chrome", async () => {
 		const tempDir = TempDir.createSync("@browser-executable-");


### PR DESCRIPTION
## What

Hardens system Chromium resolution in `tools/browser/launch.ts`:
- `isExecutableFile()` now requires execute permission on POSIX (`fs.accessSync(p, X_OK)`); win32 behavior unchanged.
- Candidates are probed with `--version` and accepted only when the output looks like a Chromium-family browser (`/Chrom|Edg/i`); `resolveSystemChromium()` becomes async accordingly.

## Why

On Linux, a PATH entry named `google-chrome` can be a non-browser wrapper/launcher script (e.g. a remote-browser bridge shim that exits 0 for `--version`). The previous check only verified the path was a regular file, so such a shim was selected and Puppeteer failed with `Failed to launch the browser process: Code: 0` with empty stderr — instead of falling through to other candidates or the downloaded browser. Non-executable regular files could also be selected.

## Testing

- New regression test in `test/tools/browser-launch.test.ts`: a `google-chrome`-named shell wrapper is rejected while a Chromium-like binary is accepted.
- `bun test test/tools/browser-launch.test.ts`: 8 pass, 0 fail.
- Reproduced the original failure on Ubuntu (browser-attach / browser-tab-evaluate test chunks failing because a wrapper shim on PATH was selected as Chrome).

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
