### PR TITLE
fix(coding-agent): fall back to xsel for Linux X11 clipboard reads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Linux/X11 clipboard reads failing when `xclip` is unavailable but `xsel` is installed.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -259,6 +259,14 @@ async function readTextViaPowerShell(): Promise<string | null> {
 	}
 }
 
+async function readTextFromX11Clipboard(): Promise<string> {
+	try {
+		return await spawnCapture(["xclip", "-selection", "clipboard", "-o"]);
+	} catch {
+		return await spawnCapture(["xsel", "--clipboard", "--output"]);
+	}
+}
+
 /**
  * Read an image from the system clipboard.
  *
@@ -340,11 +348,11 @@ export async function readTextFromClipboard(): Promise<string> {
 				return await spawnCapture(["wl-paste", "--type", "text/plain", "--no-newline"]);
 			} catch {
 				if (hasX11Display) {
-					return await spawnCapture(["xclip", "-selection", "clipboard", "-o"]);
+					return await readTextFromX11Clipboard();
 				}
 			}
 		} else if (hasX11Display) {
-			return await spawnCapture(["xclip", "-selection", "clipboard", "-o"]);
+			return await readTextFromX11Clipboard();
 		}
 	} catch (error) {
 		logger.warn("clipboard: failed to read clipboard text", { error: String(error) });

--- a/packages/coding-agent/test/utils/clipboard.test.ts
+++ b/packages/coding-agent/test/utils/clipboard.test.ts
@@ -33,7 +33,7 @@ function fakeProcess(stdout: SpawnOutput, exitCode = 0): Subprocess {
 	} as unknown as Subprocess;
 }
 
-function spySpawn(calls: SpawnCall[], stdout: SpawnOutput | SpawnOutput[], exitCode = 0) {
+function spySpawn(calls: SpawnCall[], stdout: SpawnOutput | SpawnOutput[], exitCode: number | number[] = 0) {
 	function mockSpawn(opts: SpawnOptions & { cmd: string[] }): Subprocess;
 	function mockSpawn(cmd: string[], opts?: SpawnOptions): Subprocess;
 	function mockSpawn(first: string[] | (SpawnOptions & { cmd: string[] }), second?: SpawnOptions): Subprocess {
@@ -41,7 +41,8 @@ function spySpawn(calls: SpawnCall[], stdout: SpawnOutput | SpawnOutput[], exitC
 		const options = Array.isArray(first) ? (second ?? ({} as SpawnOptions)) : (first as SpawnOptions);
 		calls.push({ cmd, options });
 		const output = Array.isArray(stdout) ? (stdout[calls.length - 1] ?? "") : stdout;
-		return fakeProcess(output, exitCode);
+		const code = Array.isArray(exitCode) ? (exitCode[calls.length - 1] ?? 0) : exitCode;
+		return fakeProcess(output, code);
 	}
 	return vi.spyOn(Bun, "spawn").mockImplementation(mockSpawn);
 }
@@ -264,6 +265,34 @@ describe("readMacFileUrlsFromClipboard", () => {
 });
 
 describe("readTextFromClipboard", () => {
+	it("falls back to xsel when xclip is unavailable on X11", async () => {
+		setPlatform("linux");
+		process.env.DISPLAY = ":0";
+		const calls: SpawnCall[] = [];
+		spySpawn(calls, ["", "from xsel"], [1, 0]);
+
+		expect(await readTextFromClipboard()).toBe("from xsel");
+		expect(calls.map(call => call.cmd)).toEqual([
+			["xclip", "-selection", "clipboard", "-o"],
+			["xsel", "--clipboard", "--output"],
+		]);
+	});
+
+	it("uses the xsel fallback when wl-paste fails in a mixed Wayland/X11 session", async () => {
+		setPlatform("linux");
+		process.env.WAYLAND_DISPLAY = "wayland-0";
+		process.env.DISPLAY = ":0";
+		const calls: SpawnCall[] = [];
+		spySpawn(calls, ["", "", "from xsel"], [1, 1, 0]);
+
+		expect(await readTextFromClipboard()).toBe("from xsel");
+		expect(calls.map(call => call.cmd)).toEqual([
+			["wl-paste", "--type", "text/plain", "--no-newline"],
+			["xclip", "-selection", "clipboard", "-o"],
+			["xsel", "--clipboard", "--output"],
+		]);
+	});
+
 	it("returns pbpaste stdout on darwin without touching execSync", async () => {
 		setPlatform("darwin");
 		const calls: SpawnCall[] = [];


### PR DESCRIPTION
## What

`readTextFromClipboard()` on Linux/X11 now falls back to `xsel --clipboard --output` when `xclip` is unavailable, via a small shared helper used by both the pure-X11 path and the Wayland-with-X11-fallback path.

## Why

X11-only Linux environments that ship `xsel` but not `xclip` (both are common, and distros package either) previously reported an empty clipboard: the `xclip` spawn threw and the read silently returned `""`. There is no text write path via xclip (writes go through the native bridge), so only the read path needed the fallback.

## Testing

- New tests in `test/utils/clipboard.test.ts` covering the X11 fallback and the mixed Wayland/X11 session fallback chain (`wl-paste` → `xclip` → `xsel`).
- `bun test test/utils/clipboard.test.ts`: 21 pass, 0 fail.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
