### PR TITLE
fix(tui): detect systemd user bus for Linux desktop notifications

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Linux desktop notifications being disabled when `DBUS_SESSION_BUS_ADDRESS` is unset but the systemd user bus is available at `$XDG_RUNTIME_DIR/bus`.
+- hasLinuxDesktopSession() now also treats the session as reachable via the systemd user-bus socket `$XDG_RUNTIME_DIR/bus` when `DBUS_SESSION_BUS_ADDRESS` is unset, so BEL-only terminals in systemd/tmux/SSH-attached graphical sessions get desktop notifications again.
 
 ## [17.2.9] - 2026-08-05
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Linux desktop notifications being disabled when `DBUS_SESSION_BUS_ADDRESS` is unset but the systemd user bus is available at `$XDG_RUNTIME_DIR/bus`.
+
 ## [17.2.9] - 2026-08-05
 
 ### Fixed

--- a/packages/tui/src/desktop-notify.ts
+++ b/packages/tui/src/desktop-notify.ts
@@ -39,7 +39,7 @@ export interface DesktopNotifier {
 /**
  * Whether the current process can reach a freedesktop notification daemon:
  * Linux platform plus either a session bus address in env or the
- * `$XDG_RUNTIME_DIR/bus` user bus socket. Caller is still responsible for
+ * systemd user-bus socket at `$XDG_RUNTIME_DIR/bus`. Caller is still responsible for
  * resolving a delivery binary via {@link resolveDesktopNotifier}.
  */
 export function hasLinuxDesktopSession(

--- a/packages/tui/src/desktop-notify.ts
+++ b/packages/tui/src/desktop-notify.ts
@@ -20,6 +20,8 @@
 // iTerm2, WezTerm, …) keep working unchanged and the BEL emission still fires
 // for tmux `monitor-bell`, X11 urgency hints, and audible-bell handlers.
 
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { $which } from "@oh-my-pi/pi-utils";
 import type { TerminalId, TerminalNotification } from "./terminal-capabilities";
 
@@ -42,9 +44,12 @@ export interface DesktopNotifier {
 export function hasLinuxDesktopSession(
 	platform: NodeJS.Platform = process.platform,
 	env: NodeJS.ProcessEnv = Bun.env,
+	fileExists: (path: string) => boolean = fs.existsSync,
 ): boolean {
 	if (platform !== "linux") return false;
-	return Boolean(env.DBUS_SESSION_BUS_ADDRESS);
+	if (env.DBUS_SESSION_BUS_ADDRESS) return true;
+	const runtimeDir = env.XDG_RUNTIME_DIR;
+	return Boolean(runtimeDir && fileExists(path.join(runtimeDir, "bus")));
 }
 
 /**

--- a/packages/tui/src/desktop-notify.ts
+++ b/packages/tui/src/desktop-notify.ts
@@ -38,8 +38,9 @@ export interface DesktopNotifier {
 
 /**
  * Whether the current process can reach a freedesktop notification daemon:
- * Linux platform + a session bus address in env. Caller is still responsible
- * for resolving a delivery binary via {@link resolveDesktopNotifier}.
+ * Linux platform plus either a session bus address in env or the
+ * `$XDG_RUNTIME_DIR/bus` user bus socket. Caller is still responsible for
+ * resolving a delivery binary via {@link resolveDesktopNotifier}.
  */
 export function hasLinuxDesktopSession(
 	platform: NodeJS.Platform = process.platform,

--- a/packages/tui/test/desktop-notify.test.ts
+++ b/packages/tui/test/desktop-notify.test.ts
@@ -19,6 +19,14 @@ describe("hasLinuxDesktopSession", () => {
 		expect(hasLinuxDesktopSession("darwin", LINUX_ENV)).toBe(false);
 		expect(hasLinuxDesktopSession("win32", LINUX_ENV)).toBe(false);
 	});
+
+	it("accepts the systemd user bus socket when the address is not exported", () => {
+		const env = { XDG_RUNTIME_DIR: "/run/user/1000" };
+		const fileExists = (path: string) => path === "/run/user/1000/bus";
+
+		expect(hasLinuxDesktopSession("linux", env, fileExists)).toBe(true);
+		expect(hasLinuxDesktopSession("linux", env, () => false)).toBe(false);
+	});
 });
 
 describe("shouldDeliverDesktopNotification", () => {


### PR DESCRIPTION
## What

`hasLinuxDesktopSession()` in `pi-tui` now also treats the session as reachable when `DBUS_SESSION_BUS_ADDRESS` is unset but the systemd user bus socket `$XDG_RUNTIME_DIR/bus` exists. The existence check is injectable, consistent with the existing `platform`/`env` parameters.

## Why

Desktop notification delivery was gated solely on `DBUS_SESSION_BUS_ADDRESS`. That variable can be absent in perfectly working sessions (systemd user sessions where the terminal wasn't launched via a D-Bus activated environment, tmux/SSH-attached graphical sessions, some containerized desktops) even though a notification daemon is reachable: GLib/libnotify — and therefore `notify-send` and `gdbus` — fall back to `unix:path=$XDG_RUNTIME_DIR/bus` by default. In those sessions BEL-only terminals silently lost toasts.

## Testing

- New tests in `test/desktop-notify.test.ts`: session detected via the user bus socket without the env var, and negative coverage when the socket is absent.
- `bun test test/desktop-notify.test.ts`: 18 pass, 0 fail.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
