### PR TITLE
fix(coding-agent): preserve shell quoting in POSIX $EDITOR commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed POSIX `$EDITOR` commands with quoted arguments or executable paths containing spaces being parsed incorrectly.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/utils/external-editor.ts
+++ b/packages/coding-agent/src/utils/external-editor.ts
@@ -53,8 +53,10 @@ export async function openInEditor(
 
 		const [editor, ...editorArgs] = editorCmd.split(" ");
 		const stdio = options?.stdio ?? ["inherit", "inherit", "inherit"];
-
-		const child = spawn(editor, [...editorArgs, tmpFile], { stdio, shell: process.platform === "win32" });
+		const child =
+			process.platform === "win32"
+				? spawn(editor, [...editorArgs, tmpFile], { stdio, shell: true })
+				: spawn("/bin/sh", ["-c", `${editorCmd} "$1"`, "sh", tmpFile], { stdio });
 		const { promise, reject, resolve } = Promise.withResolvers<number>();
 		child.once("exit", (code, signal) => resolve(code ?? (signal ? -1 : 0)));
 		child.once("error", error => reject(error));

--- a/packages/coding-agent/test/external-editor.test.ts
+++ b/packages/coding-agent/test/external-editor.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { getEditorCommand } from "../src/utils/external-editor";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { getEditorCommand, openInEditor } from "../src/utils/external-editor";
 
 interface MutableProcess {
 	platform: NodeJS.Platform;
@@ -59,5 +62,23 @@ describe("getEditorCommand", () => {
 		delete Bun.env.EDITOR;
 		setPlatform("linux");
 		expect(getEditorCommand()).toBeUndefined();
+	});
+});
+
+describe("openInEditor", () => {
+	it.skipIf(process.platform === "win32")("supports quoted editor paths containing spaces", async () => {
+		const tempDir = TempDir.createSync("@external-editor-");
+		try {
+			const editorPath = path.join(tempDir.path(), "My Editor", "edit");
+			fs.mkdirSync(path.dirname(editorPath), { recursive: true });
+			await Bun.write(editorPath, '#!/bin/sh\nprintf "edited" > "$1"\n');
+			fs.chmodSync(editorPath, 0o755);
+
+			const result = await openInEditor(`"${editorPath}"`, "original");
+
+			expect(result).toBe("edited");
+		} finally {
+			await tempDir.remove();
+		}
 	});
 });


### PR DESCRIPTION
## What

`openInEditor()` now runs `$VISUAL`/`$EDITOR` through the shell on POSIX:

```
/bin/sh -c '<editorCmd> "$1"' sh <tmpFile>
```

The temp file is passed as `$1` so its path is never re-parsed by the shell. Windows keeps the existing split + `shell: true` behavior.

## Why

The previous `editorCmd.split(" ")` broke any editor command that relies on shell quoting — e.g. `EDITOR='"/opt/My Editor/bin/edit" -w'` or quoted arguments — because quotes were passed through literally as argv. POSIX convention is that `$EDITOR` is interpreted by the shell (this is what git, crontab, etc. do), so `sh -c` restores the expected semantics for spaces, quotes, and flags.

## Testing

- New regression test in `test/external-editor.test.ts`: a quoted editor executable in a path containing spaces edits and returns the buffer correctly (skipped on win32).
- `bun test test/external-editor.test.ts`: 7 pass, 0 fail.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
