### PR TITLE
perf(extensions): import extension modules concurrently

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -310,12 +310,13 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 	};
 }
 
-async function loadExtension(
-	extensionPath: string,
-	cwd: string,
-	eventBus: EventBus,
-	runtime: IExtensionRuntime,
-): Promise<{ extension: Extension | null; error: string | null }> {
+interface ImportedExtensionModule {
+	factory: ExtensionFactory | null;
+	resolvedPath: string;
+	error: string | null;
+}
+
+async function importExtensionModule(extensionPath: string, cwd: string): Promise<ImportedExtensionModule> {
 	const resolvedPath = resolvePath(extensionPath, cwd);
 	try {
 		const module = (await withHostGuard(() => loadLegacyPiModule(resolvedPath))) as LoadedExtensionModule;
@@ -323,12 +324,32 @@ async function loadExtension(
 
 		if (typeof factory !== "function") {
 			return {
-				extension: null,
+				factory: null,
+				resolvedPath,
 				error: `Extension does not export a valid factory function: ${extensionPath}`,
 			};
 		}
 
-		const extension = createExtension(extensionPath, resolvedPath);
+		return { factory, resolvedPath, error: null };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { factory: null, resolvedPath, error: `Failed to load extension: ${message}` };
+	}
+}
+
+async function bindExtension(
+	extensionPath: string,
+	imported: ImportedExtensionModule,
+	cwd: string,
+	eventBus: EventBus,
+	runtime: IExtensionRuntime,
+): Promise<{ extension: Extension | null; error: string | null }> {
+	const factory = imported.factory;
+	if (imported.error !== null || factory === null) {
+		return { extension: null, error: imported.error };
+	}
+	try {
+		const extension = createExtension(extensionPath, imported.resolvedPath);
 		const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, eventBus);
 		await withHostGuard(async () => {
 			await factory(api);
@@ -359,6 +380,11 @@ export async function loadExtensionFromFactory(
 
 /**
  * Load extensions from paths.
+ *
+ * Module import (the dominant cold-start cost — file I/O plus module
+ * evaluation) runs concurrently across extensions; factory binding then runs
+ * sequentially in the original path order, so registration semantics
+ * (last-wins collisions, shared runtime flag defaults) stay deterministic.
  */
 export async function loadExtensions(paths: string[], cwd: string, eventBus?: EventBus): Promise<LoadExtensionsResult> {
 	const extensions: Extension[] = [];
@@ -366,8 +392,11 @@ export async function loadExtensions(paths: string[], cwd: string, eventBus?: Ev
 	const resolvedEventBus = eventBus ?? new EventBus();
 	const runtime = new ExtensionRuntime();
 
-	for (const extPath of paths) {
-		const { extension, error } = await loadExtension(extPath, cwd, resolvedEventBus, runtime);
+	const imported = await Promise.all(paths.map(extPath => importExtensionModule(extPath, cwd)));
+
+	for (let i = 0; i < paths.length; i++) {
+		const extPath = paths[i]!;
+		const { extension, error } = await bindExtension(extPath, imported[i]!, cwd, resolvedEventBus, runtime);
 
 		if (error) {
 			errors.push({ path: extPath, error });

--- a/packages/coding-agent/test/extension-loader-concurrency.test.ts
+++ b/packages/coding-agent/test/extension-loader-concurrency.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression test for #7615: extension module imports must run concurrently
+ * (cold-start cost was linear in the number of installed extensions), while
+ * factory binding stays sequential in path order so registration semantics
+ * (last-wins collisions, shared runtime flag defaults) remain deterministic.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const EVENTS_KEY = "__ompExtensionLoaderConcurrencyEvents";
+
+interface EventsGlobal {
+	__ompExtensionLoaderConcurrencyEvents?: string[];
+}
+
+const eventsGlobal = globalThis as EventsGlobal;
+
+describe("extension loader concurrency (#7615)", () => {
+	let project: TempDir | undefined;
+
+	beforeEach(() => {
+		project = TempDir.createSync("@omp-ext-concurrency-");
+		eventsGlobal[EVENTS_KEY] = [];
+	});
+
+	afterEach(() => {
+		project?.removeSync();
+		project = undefined;
+		delete eventsGlobal[EVENTS_KEY];
+	});
+
+	const writeModule = (relativePath: string, source: string): string => {
+		expect(project).toBeDefined();
+		const filePath = path.join(project!.path(), relativePath);
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, source);
+		return filePath;
+	};
+
+	it("imports modules concurrently but binds factories in path order", async () => {
+		const slowPath = writeModule(
+			"slow.ts",
+			`const events = (globalThis as { ${EVENTS_KEY}?: string[] }).${EVENTS_KEY}!;
+events.push("slow:eval:start");
+await Bun.sleep(250);
+events.push("slow:eval:end");
+export default function slowExtension() {
+	events.push("slow:factory");
+}
+`,
+		);
+		const fastPath = writeModule(
+			"fast.ts",
+			`const events = (globalThis as { ${EVENTS_KEY}?: string[] }).${EVENTS_KEY}!;
+events.push("fast:eval");
+export default function fastExtension() {
+	events.push("fast:factory");
+}
+`,
+		);
+
+		const result = await loadExtensions([slowPath, fastPath], project!.path());
+
+		expect(result.errors).toEqual([]);
+		expect(result.extensions.map(ext => ext.path)).toEqual([slowPath, fastPath]);
+
+		const events = eventsGlobal[EVENTS_KEY]!;
+		// Concurrent import: the fast module evaluates while the slow module's
+		// top-level await is still pending. Sequential loading would force
+		// "fast:eval" after "slow:eval:end".
+		expect(events.indexOf("fast:eval")).toBeLessThan(events.indexOf("slow:eval:end"));
+		// Deterministic binding: factories run in the original path order even
+		// though the fast module finished importing first.
+		expect(events.indexOf("slow:factory")).toBeLessThan(events.indexOf("fast:factory"));
+		expect(events.indexOf("slow:eval:end")).toBeLessThan(events.indexOf("slow:factory"));
+	});
+
+	it("isolates per-extension import failures without blocking the batch", async () => {
+		const brokenPath = writeModule(
+			"broken.ts",
+			`throw new Error("boom at import time");
+`,
+		);
+		const okPath = writeModule(
+			"ok.ts",
+			`const events = (globalThis as { ${EVENTS_KEY}?: string[] }).${EVENTS_KEY}!;
+export default function okExtension() {
+	events.push("ok:factory");
+}
+`,
+		);
+
+		const result = await loadExtensions([brokenPath, okPath], project!.path());
+
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]!.path).toBe(brokenPath);
+		expect(result.errors[0]!.error).toContain("boom at import time");
+		expect(result.extensions.map(ext => ext.path)).toEqual([okPath]);
+		expect(eventsGlobal[EVENTS_KEY]).toContain("ok:factory");
+	});
+});


### PR DESCRIPTION
## What

`loadExtensions` now imports all extension modules concurrently (`Promise.all` over a new import phase), then runs each extension's factory sequentially in the original path order:

```
loadExtensions(paths):
  imported = await Promise.all(paths.map(importExtensionModule))   // parallel I/O + module eval
  for each path (original order):
    bindExtension(imported[i])                                      // sequential factory calls
```

Import failures are captured per path (same error strings as before), so one broken extension still doesn't affect the others.

## Why

Extension loading was fully sequential — each module's file I/O, transpile, and top-level await completed before the next began — making cold start scale linearly with extension count (issue #7615). Module import is the parallel-safe part; factory execution stays sequential so registration order, last-wins semantics, and the shared runtime default remain deterministic.

## Testing

- New `test/extension-loader-concurrency.test.ts`: proves a fast module's evaluation finishes while a slow (250ms top-level await) module is still importing, that factories still run in path order, and that a broken module's error stays isolated.
- Existing extension loader/regression tests pass; `bun run check` (biome + tsgo) and `omp --smoke-test` pass.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
