### PR TITLE
fix(read): stop advertising memory:// when memory.backend=off

### DIFF
--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -721,6 +721,11 @@ const readSchema = type({
 	),
 });
 
+/** Variant used when `memory.backend=off`: does not advertise `memory://`. */
+const readSchemaWithoutMemory: typeof readSchema = type({
+	path: type("string").describe("Local path, internal URI (e.g. skill://), or URL. Inline selectors are supported."),
+});
+
 export type ReadToolInput = typeof readSchema.infer;
 
 export interface ReadToolDetails {
@@ -866,7 +871,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	readonly label = "Read";
 	readonly loadMode = "essential";
 	description: string;
-	readonly parameters = readSchema;
+	readonly parameters: typeof readSchema;
 	readonly strict = true;
 
 	readonly #autoResizeImages: boolean;
@@ -874,6 +879,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 	#inspectImageActive: boolean;
 
 	constructor(private readonly session: ToolSession) {
+		this.parameters = session.settings.get("memory.backend") === "off" ? readSchemaWithoutMemory : readSchema;
 		this.#autoResizeImages = session.settings.get("images.autoResize");
 		this.#defaultLimit = Math.max(
 			1,

--- a/packages/coding-agent/test/memory-backend-off.test.ts
+++ b/packages/coding-agent/test/memory-backend-off.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+
+function createSession(backend: "off" | "local"): ToolSession {
+	return {
+		cwd: process.cwd(),
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		settings: Settings.isolated({ "memory.backend": backend }),
+	};
+}
+
+function pathDescription(tool: ReadTool): string {
+	const schema = tool.parameters.toJsonSchema() as {
+		properties?: { path?: { description?: string } };
+	};
+	return schema.properties?.path?.description ?? "";
+}
+
+// Regression for issue #7673: with memory.backend=off, the Read tool schema
+// must not advertise memory:// as an example URI.
+describe("memory.backend=off (issue #7673)", () => {
+	it("omits memory:// from the Read schema when the backend is off", () => {
+		const description = pathDescription(new ReadTool(createSession("off")));
+		expect(description).not.toContain("memory://");
+		expect(description).toContain("skill://");
+	});
+
+	it("keeps memory:// in the Read schema when a backend is active", () => {
+		const description = pathDescription(new ReadTool(createSession("local")));
+		expect(description).toContain("memory://");
+	});
+});


### PR DESCRIPTION
## What

The Read tool schema unconditionally listed `memory://` as an example internal URI:

```
Local path, internal URI (e.g. memory://, skill://), or URL. Inline selectors are supported.
```

`ReadTool` now selects a schema variant per session: when `memory.backend=off` (the default), the `path` description omits `memory://`; any active backend keeps the original text.

## Why

With the memory subsystem deliberately disabled, the schema still steered models into probing `memory://` URLs, wasting turns on dead-end reads (issue #7673). The system prompt already gates memory instructions on the backend; the tool schema now matches.

## Testing

- New `test/memory-backend-off.test.ts`: asserts the JSON-schema `path` description omits `memory://` (but keeps `skill://`) with backend `off`, and retains it with backend `local`.
- Existing memory-protocol / read tool tests pass; `bun run check` (biome + tsgo) and `omp --smoke-test` pass.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
