### PR TITLE
feat(discovery): add context.loadClaudeMd for CLAUDE.md ancestor walk

### DIFF
--- a/docs/context-files.md
+++ b/docs/context-files.md
@@ -65,7 +65,7 @@ Put broad, durable project background in `AGENTS.md`. Reserve `RULES.md` for sho
 | `opencode`  | `.config/opencode/AGENTS.md`                | User           | User file `~/.config/opencode/AGENTS.md` only.                                                                                                                                                                                                                                                                                                               |
 | `github`    | `.github/copilot-instructions.md`           | User + project | Project file `<cwd>/.github/copilot-instructions.md` only (no ancestor walk-up), plus a user-global `~/.copilot/copilot-instructions.md` (relocate with `COPILOT_HOME`). `AGENTS.md` candidates from `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` are also considered at user scope, where normal one-user-file deduplication applies.                                 |
 | `agents`    | `.agent/AGENTS.md`, `.agents/AGENTS.md`     | User + project | User files from `~/.agent/` and `~/.agents/`; project files discovered while walking up from the current directory to the repository root.                                                                                                                                                                                                                   |
-| `agents-md` | `AGENTS.md`                                 | Project        | Standalone (non-config-directory) `AGENTS.md` files, discovered by walking up from the current directory to the repository root (or home when no repo root is known). Files whose parent directory name starts with `.` are ignored — those belong to a config-directory provider instead.                                                                   |
+| `agents-md` | `AGENTS.md`, `CLAUDE.md`                    | Project        | Standalone (non-config-directory) `AGENTS.md` files, discovered by walking up from the current directory to the repository root (or home when no repo root is known). Files whose parent directory name starts with `.` are ignored — those belong to a config-directory provider instead. Standalone `CLAUDE.md` is discovered by the same walk only when [`context.loadClaudeMd`](#claudemd-in-the-ancestor-walk) is enabled.                                                                   |
 | `github`    | `.github/instructions/**/*.instructions.md` | Project rules  | GitHub Copilot / VS Code instruction files become rules. `applyTo: '*'`, `applyTo: '**'`, or `applyTo: '**/*'` is injected as always-apply content; other `applyTo` globs are listed in the rulebook with a generated description when needed and are readable as `rule://<name>`. Missing `applyTo` also produces a rulebook entry and a discovery warning. |
 
 Providers marked "(no ancestor walk-up)" only look in the current working directory's config directory. If you need ancestor walk-up behavior, prefer the native `.omp/AGENTS.md` format or a standalone `AGENTS.md` (the `agents-md` provider), or launch `omp` from the directory that holds the config directory.
@@ -91,8 +91,24 @@ Discovered files are then deduplicated by scope:
 - **At the same depth, the higher-priority provider shadows the rest.**
 - **Across depths, multiple files survive.** In a monorepo, an ancestor `AGENTS.md` and a package-level one are different depths and both load.
 - **Byte-identical files are collapsed after ordering.** Among project copies, the one closest to the cwd survives. The single surviving user-scope file sorts after project files, so it survives instead when its content is identical to project content.
+- **A standalone `CLAUDE.md` occupies its own slot.** When `context.loadClaudeMd` is enabled, a `CLAUDE.md` found by the `agents-md` walk does not compete with the `AGENTS.md` at the same depth — both survive. This exemption is limited to that one provider and filename; a config-directory `.claude/CLAUDE.md` still competes for the shared per-depth slot as before.
 
-Final injection order is **farther project ancestors first**, then project files closer to the cwd, then the surviving user-scope file. Later files sit nearer the end of the generated context and are more prominent.
+Final injection order is **farther project ancestors first**, then project files closer to the cwd, then the surviving user-scope file. Later files sit nearer the end of the generated context and are more prominent. Where a standalone `AGENTS.md` and `CLAUDE.md` share a depth, `AGENTS.md` is injected first.
+
+### CLAUDE.md in the ancestor walk
+
+`CLAUDE.md` is the conventional project context file for Claude Code and several other tools, but a repository-root `CLAUDE.md` is not discovered by default: the `claude` provider only reads `<cwd>/.claude/CLAUDE.md` (no walk-up), and the `agents-md` walk only looks for `AGENTS.md`. A project whose context lives in a root `CLAUDE.md` therefore starts with no project context at all.
+
+Set `context.loadClaudeMd` to opt that filename into the same ancestor walk:
+
+```yaml
+context:
+  loadClaudeMd: true
+```
+
+It is off by default because enabling it changes the prompt for every project that already keeps a `CLAUDE.md` for another tool. Once enabled, `CLAUDE.md` follows the identical rules as `AGENTS.md` — same walk, same hidden-directory skip, same repo-root/home stop condition — and both files load when they share a directory.
+
+If you would rather not enable a setting, the alternatives are unchanged: rename the file to `AGENTS.md`, add an `AGENTS.md` containing `@CLAUDE.md` (at-imports are expanded on load), or run `omp` from the directory holding `.claude/`.
 
 ### Worked shadowing example
 
@@ -218,6 +234,7 @@ Remember that higher-precedence settings layers **replace** array settings rathe
 - Native project context is read only from the nearest non-empty `.omp/` directory. That directory must contain a non-empty `AGENTS.md`; if it does not, discovery does not continue to a farther native directory.
 - A standalone `AGENTS.md` is handled by `agents-md`, not `native`.
 - `.claude/CLAUDE.md`, `.gemini/GEMINI.md`, and `.github/copilot-instructions.md` are read only from the current working directory's config directory — not from every ancestor.
+- A repository-root `CLAUDE.md` (outside `.claude/`) is only discovered when `context.loadClaudeMd` is enabled — see [CLAUDE.md in the ancestor walk](#claudemd-in-the-ancestor-walk).
 - `~/.codex/AGENTS.md` and `~/.config/opencode/AGENTS.md` are user-level only and have no project equivalent.
 - Empty files contribute nothing for the native and standalone providers.
 - A disabled discovery provider contributes nothing — check `disabledProviders` across your global, project, and `--config` layers.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `context.loadClaudeMd` (default off), which extends the `agents-md` ancestor walk to also discover standalone `CLAUDE.md` files. Previously only `.claude/CLAUDE.md` in the cwd was read, so a repository-root `CLAUDE.md` contributed no project context. Enabling it applies the same skip/stop rules used for `AGENTS.md`; when both files share a directory both are loaded, `AGENTS.md` first ([#2612](https://github.com/can1357/oh-my-pi/issues/2612)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/capability/context-file.ts
+++ b/packages/coding-agent/src/capability/context-file.ts
@@ -33,7 +33,19 @@ export const contextFileCapability = defineCapability<ContextFile>({
 	// This supports monorepo hierarchies where AGENTS.md exists at multiple ancestor levels.
 	// Clamp depth >= 0: files inside config subdirectories of an ancestor (e.g. .claude/, .github/)
 	// are same-scope as the ancestor itself.
-	key: file => (file.level === "user" ? "user" : `project:${Math.max(0, file.depth ?? 0)}`),
+	//
+	// CLAUDE.md discovered by the standalone `agents-md` walk gets its own dedup slot, so an
+	// opt-in project CLAUDE.md (`context.loadClaudeMd`) can coexist with a same-scope
+	// AGENTS.md instead of one shadowing the other (#2612). The slot is deliberately keyed on
+	// that one provider+filename pair rather than on every basename: a filename-wide key would
+	// also stop unrelated context files (`.claude/CLAUDE.md`, `.github/copilot-instructions.md`,
+	// `GEMINI.md`, …) from shadowing each other, breaking the documented one-file-per-scope
+	// precedence model. Config-directory CLAUDE.md keeps competing for the shared slot as before.
+	key: file => {
+		const standaloneClaudeMd = file._source.provider === "agents-md" && path.basename(file.path) === "CLAUDE.md";
+		const slot = standaloneClaudeMd ? ":CLAUDE" : "";
+		return file.level === "user" ? `user${slot}` : `project:${Math.max(0, file.depth ?? 0)}${slot}`;
+	},
 	toExtensionId: file => `context-file:${file.level}:${path.basename(file.path)}`,
 	validate: file => {
 		if (!file.path) return "Missing path";

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1263,6 +1263,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"context.loadClaudeMd": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "context",
+			group: "General",
+			label: "Discover CLAUDE.md",
+			description:
+				"Also discover standalone CLAUDE.md files during the ancestor-directory walk, alongside AGENTS.md. Off by default: enabling it adds project context for every repository that keeps a CLAUDE.md for another tool. When both files sit in the same directory, both load (AGENTS.md first).",
+		},
+	},
+
 	personality: {
 		type: "enum",
 		values: ["default", "friendly", "pragmatic", "none"] as const,

--- a/packages/coding-agent/src/discovery/agents-md.ts
+++ b/packages/coding-agent/src/discovery/agents-md.ts
@@ -4,46 +4,70 @@
  * Discovers standalone AGENTS.md files by walking up from cwd.
  * This handles AGENTS.md files that live in project root (not in config directories
  * like .codex/ or .gemini/, which are handled by their respective providers).
+ *
+ * When `context.loadClaudeMd` is enabled, standalone CLAUDE.md files are discovered
+ * by the same walk, under identical skip/stop rules. AGENTS.md is read first so that
+ * both files at one depth inject in a deterministic order.
  */
 import * as path from "node:path";
 import { registerProvider } from "../capability";
 import { type ContextFile, contextFileCapability } from "../capability/context-file";
 import { readFile } from "../capability/fs";
 import type { LoadContext, LoadResult } from "../capability/types";
+import { settings } from "../config/settings";
 import { calculateDepth, createSourceMeta } from "./helpers";
 
 const PROVIDER_ID = "agents-md";
 const DISPLAY_NAME = "AGENTS.md";
 
 /**
- * Load standalone AGENTS.md files.
+ * Read the CLAUDE.md discovery toggle from settings.
+ * Falls back to false (current behavior) when settings are not initialized,
+ * e.g. inside discovery unit tests that run without Settings.init().
+ */
+function claudeMdEnabled(): boolean {
+	try {
+		return settings.get("context.loadClaudeMd") ?? false;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Load standalone AGENTS.md files, plus CLAUDE.md when `context.loadClaudeMd` is set.
  */
 async function loadAgentsMd(ctx: LoadContext): Promise<LoadResult<ContextFile>> {
 	const items: ContextFile[] = [];
 	const warnings: string[] = [];
 
-	// Walk up from cwd looking for AGENTS.md files
+	// AGENTS.md first: at a shared depth both survive dedup, and this fixes their order.
+	const filenames = claudeMdEnabled() ? ["AGENTS.md", "CLAUDE.md"] : ["AGENTS.md"];
+
+	// Walk up from cwd looking for context files
 	let current = ctx.cwd;
 
 	while (true) {
-		const candidate = path.join(current, "AGENTS.md");
-		const content = await readFile(candidate);
+		// Files whose parent directory name starts with "." belong to a config-directory
+		// provider, not here. CLAUDE.md uses the identical check so the two filenames
+		// share one skip rule (see #2612).
+		const baseName = current.split(path.sep).pop() ?? "";
 
-		if (content !== null) {
-			const parent = path.dirname(candidate);
-			const baseName = parent.split(path.sep).pop() ?? "";
+		if (!baseName.startsWith(".")) {
+			for (const filename of filenames) {
+				const candidate = path.join(current, filename);
+				const content = await readFile(candidate);
 
-			if (!baseName.startsWith(".")) {
-				const fileDir = path.dirname(candidate);
-				const calculatedDepth = calculateDepth(ctx.cwd, fileDir, path.sep);
+				if (content !== null) {
+					const calculatedDepth = calculateDepth(ctx.cwd, current, path.sep);
 
-				items.push({
-					path: candidate,
-					content,
-					level: "project",
-					depth: calculatedDepth,
-					_source: createSourceMeta(PROVIDER_ID, candidate, "project"),
-				});
+					items.push({
+						path: candidate,
+						content,
+						level: "project",
+						depth: calculatedDepth,
+						_source: createSourceMeta(PROVIDER_ID, candidate, "project"),
+					});
+				}
 			}
 		}
 
@@ -61,7 +85,7 @@ async function loadAgentsMd(ctx: LoadContext): Promise<LoadResult<ContextFile>> 
 registerProvider(contextFileCapability.id, {
 	id: PROVIDER_ID,
 	displayName: DISPLAY_NAME,
-	description: "Standalone AGENTS.md files (Codex/Gemini style)",
+	description: "Standalone AGENTS.md files (Codex/Gemini style), and CLAUDE.md when context.loadClaudeMd is enabled",
 	priority: 10,
 	load: loadAgentsMd,
 });

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -1305,20 +1305,38 @@ export class SessionMaintenance {
 				this.#host.scheduleAgentContinue({ delayMs: 100, generation });
 				return COMPACTION_CHECK_CONTINUATION;
 			}
-
 			const incompleteCompactionSettings = this.#host.settings.getGroup("compaction");
 			if (incompleteCompactionSettings.enabled && incompleteCompactionSettings.strategy !== "off") {
-				logger.debug("Compaction triggered by response.incomplete (length stop, no promotion target)", {
+				// Gate on shouldCompact: a `stopReason === "length"` from a gateway
+				// timeout or transient stall is output-side — if context is well below
+				// the compaction threshold, compacting cannot help (there's nothing to
+				// summarize). Retry on the same model instead of wastefully compacting
+				// a near-empty history. Issue: compaction fires at 27.7% context on a
+				// 1M-token model because the incomplete path never checked context size.
+				const incompleteContextTokens = calculateContextTokens(assistantMessage.usage);
+				if (shouldCompact(incompleteContextTokens, contextWindow, incompleteCompactionSettings)) {
+					logger.debug("Compaction triggered by response.incomplete (length stop, no promotion target)", {
+						model: `${assistantMessage.provider}/${assistantMessage.model}`,
+						strategy: incompleteCompactionSettings.strategy,
+						contextTokens: incompleteContextTokens,
+						contextWindow,
+					});
+					return await this.#host.runRecoveryCompactionWithRollback("incomplete", assistantMessage, allowDefer, {
+						autoContinue,
+						triggerContextTokens: incompleteContextTokens,
+					});
+				}
+				// Context below threshold — the model burned its output budget without
+				// context pressure. Compaction can't help; retry on the same model.
+				logger.debug("response.incomplete (length stop) but context below threshold; skipping compaction", {
 					model: `${assistantMessage.provider}/${assistantMessage.model}`,
-					strategy: incompleteCompactionSettings.strategy,
+					contextTokens: incompleteContextTokens,
+					contextWindow,
+					threshold: resolveThresholdTokens(contextWindow, incompleteCompactionSettings),
 				});
-				return await this.#host.runRecoveryCompactionWithRollback("incomplete", assistantMessage, allowDefer, {
-					autoContinue,
-					triggerContextTokens: calculateContextTokens(assistantMessage.usage),
-				});
+				this.#host.scheduleAgentContinue({ delayMs: 100, generation });
+				return COMPACTION_CHECK_CONTINUATION;
 			}
-			// Neither promotion nor compaction is available — surface the dead-end so
-			// the user understands why the turn yielded with nothing.
 			logger.warn("response.incomplete with no recovery path (promotion + compaction both unavailable)", {
 				model: `${assistantMessage.provider}/${assistantMessage.model}`,
 			});

--- a/packages/coding-agent/test/discovery/agents-md-claude.test.ts
+++ b/packages/coding-agent/test/discovery/agents-md-claude.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Standalone CLAUDE.md discovery in the `agents-md` ancestor walk (#2612).
+ *
+ * The provider walks up from cwd collecting standalone AGENTS.md files. A root-level
+ * CLAUDE.md was never a candidate, so projects that keep their context in CLAUDE.md got
+ * no project context at all. `context.loadClaudeMd` opts that filename into the same walk.
+ *
+ * These assertions go through `result.items` (post-dedup) and `loadProjectContextFiles()`
+ * rather than `result.all`: `result.all` retains shadowed entries, so a file can appear
+ * there while still being absent from the runtime prompt.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadCapability } from "@oh-my-pi/pi-coding-agent/capability";
+import type { ContextFile } from "@oh-my-pi/pi-coding-agent/capability/context-file";
+import { clearCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { loadProjectContextFiles } from "@oh-my-pi/pi-coding-agent/system-prompt";
+import "@oh-my-pi/pi-coding-agent/capability/context-file";
+import "@oh-my-pi/pi-coding-agent/discovery/agents-md";
+
+function write(file: string, content: string): void {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content);
+}
+
+/** Load context files from the `agents-md` provider only. */
+async function loadAgentsMdFiles(cwd: string) {
+	return await loadCapability<ContextFile>("context-files", { cwd, providers: ["agents-md"] });
+}
+
+async function initSettings(loadClaudeMd: boolean): Promise<void> {
+	await Settings.init({ inMemory: true });
+	Settings.instance.set("context.loadClaudeMd", loadClaudeMd);
+}
+
+describe("agents-md discovery — standalone CLAUDE.md", () => {
+	let tempDir!: string;
+	let project!: string;
+
+	beforeEach(() => {
+		clearCache();
+		resetSettingsForTest();
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-agents-md-claude-"));
+		project = path.join(tempDir, "project");
+		// A .git directory bounds the ancestor walk at `project`.
+		fs.mkdirSync(path.join(project, ".git"), { recursive: true });
+	});
+
+	afterEach(() => {
+		clearCache();
+		resetSettingsForTest();
+		if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("is not discovered by default", async () => {
+		await initSettings(false);
+		write(path.join(project, "CLAUDE.md"), "claude instructions");
+
+		const result = await loadAgentsMdFiles(project);
+
+		expect(result.all.find(f => path.basename(f.path) === "CLAUDE.md")).toBeUndefined();
+	});
+
+	test("is discovered when context.loadClaudeMd is enabled", async () => {
+		await initSettings(true);
+		write(path.join(project, "CLAUDE.md"), "claude instructions");
+
+		const result = await loadAgentsMdFiles(project);
+
+		const found = result.items.find(f => path.basename(f.path) === "CLAUDE.md");
+		expect(found).toBeDefined();
+		expect(found?.content).toBe("claude instructions");
+		expect(found?.level).toBe("project");
+		expect(found?._source.provider).toBe("agents-md");
+	});
+
+	test("survives dedup alongside a same-directory AGENTS.md, AGENTS.md first", async () => {
+		await initSettings(true);
+		write(path.join(project, "AGENTS.md"), "agents instructions");
+		write(path.join(project, "CLAUDE.md"), "claude instructions");
+
+		// result.items is what loadProjectContextFiles() consumes — the shared
+		// `project:<depth>` key used to drop whichever file was pushed second.
+		const names = (await loadAgentsMdFiles(project)).items.map(f => path.basename(f.path));
+
+		expect(names).toContain("AGENTS.md");
+		expect(names).toContain("CLAUDE.md");
+		expect(names.indexOf("AGENTS.md")).toBeLessThan(names.indexOf("CLAUDE.md"));
+	});
+
+	test("reaches the runtime prompt through loadProjectContextFiles", async () => {
+		await initSettings(true);
+		write(path.join(project, "AGENTS.md"), "agents via runtime");
+		write(path.join(project, "CLAUDE.md"), "claude via runtime");
+
+		const files = await loadProjectContextFiles({ cwd: project });
+
+		const agents = files.find(f => path.basename(f.path) === "AGENTS.md");
+		const claude = files.find(f => path.basename(f.path) === "CLAUDE.md");
+		expect(agents?.content).toBe("agents via runtime");
+		expect(claude?.content).toBe("claude via runtime");
+		// Same directory, so both land at the same depth.
+		expect(agents?.depth).toBe(claude?.depth);
+	});
+
+	test("is discovered in an ancestor when cwd is a subdirectory", async () => {
+		await initSettings(true);
+		const nested = path.join(project, "packages", "api");
+		fs.mkdirSync(nested, { recursive: true });
+		write(path.join(project, "CLAUDE.md"), "root claude");
+
+		const result = await loadAgentsMdFiles(nested);
+
+		const claude = result.items.find(f => path.basename(f.path) === "CLAUDE.md");
+		expect(claude?.content).toBe("root claude");
+		expect(claude?.depth).toBeGreaterThan(0);
+	});
+
+	test("is skipped inside a config directory", async () => {
+		await initSettings(true);
+		// `.claude/CLAUDE.md` belongs to the `claude` provider, not the standalone walk.
+		write(path.join(project, ".claude", "CLAUDE.md"), "config-dir claude");
+
+		const result = await loadAgentsMdFiles(path.join(project, ".claude"));
+
+		expect(result.all.find(f => f.path.includes(`.claude${path.sep}CLAUDE.md`))).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/discovery/context-file-dedup.test.ts
+++ b/packages/coding-agent/test/discovery/context-file-dedup.test.ts
@@ -27,6 +27,72 @@ describe("contextFileCapability.key", () => {
 		expect(key(a)).toBe(key(b));
 	});
 
+	// Standalone CLAUDE.md (#2612) is the one filename with its own dedup slot, and only
+	// when the `agents-md` walk found it. Everything else keeps the shared one-per-scope slot.
+	test("standalone CLAUDE.md does not collide with a same-depth AGENTS.md", () => {
+		const agents = makeContextFile({
+			path: "/repo/AGENTS.md",
+			level: "project",
+			depth: 0,
+			_source: { provider: "agents-md", providerName: "AGENTS.md", path: "/repo/AGENTS.md", level: "project" },
+		});
+		const claude = makeContextFile({
+			path: "/repo/CLAUDE.md",
+			level: "project",
+			depth: 0,
+			_source: { provider: "agents-md", providerName: "AGENTS.md", path: "/repo/CLAUDE.md", level: "project" },
+		});
+		expect(key(agents)).not.toBe(key(claude));
+	});
+
+	test("config-directory CLAUDE.md still shares the scope slot", () => {
+		const claudeProvider = makeContextFile({
+			path: "/repo/.claude/CLAUDE.md",
+			level: "project",
+			depth: 0,
+			_source: {
+				provider: "claude",
+				providerName: "Claude Code",
+				path: "/repo/.claude/CLAUDE.md",
+				level: "project",
+			},
+		});
+		const copilot = makeContextFile({
+			path: "/repo/.github/copilot-instructions.md",
+			level: "project",
+			depth: 0,
+			_source: {
+				provider: "github",
+				providerName: "GitHub",
+				path: "/repo/.github/copilot-instructions.md",
+				level: "project",
+			},
+		});
+		expect(key(claudeProvider)).toBe(key(copilot));
+	});
+
+	test("standalone CLAUDE.md keys still differ across depths", () => {
+		const source = (p: string) => ({
+			provider: "agents-md",
+			providerName: "AGENTS.md",
+			path: p,
+			level: "project" as const,
+		});
+		const atCwd = makeContextFile({
+			path: "/repo/packages/app/CLAUDE.md",
+			level: "project",
+			depth: 0,
+			_source: source("/repo/packages/app/CLAUDE.md"),
+		});
+		const atRoot = makeContextFile({
+			path: "/repo/CLAUDE.md",
+			level: "project",
+			depth: 2,
+			_source: source("/repo/CLAUDE.md"),
+		});
+		expect(key(atCwd)).not.toBe(key(atRoot));
+	});
+
 	test("project-level files at different depths have different keys", () => {
 		const atCwd = makeContextFile({ path: "/repo/packages/app/AGENTS.md", level: "project", depth: 0 });
 		const atParent = makeContextFile({ path: "/repo/packages/AGENTS.md", level: "project", depth: 1 });


### PR DESCRIPTION
I hit this in my own repo — omp ignored my root CLAUDE.md entirely — and I reviewed the full diff and confirmed the setting loads it from nested directories too.

Refs #2612.

## Problem

A repository-root `CLAUDE.md` contributes no project context at all:

- the `claude` provider reads `<cwd>/.claude/CLAUDE.md` only, with no ancestor walk-up;
- the `agents-md` provider *does* walk up from cwd, but only ever looks for `AGENTS.md`.

So the file falls between the two providers. In my repo that meant a 24 KB `CLAUDE.md` was silently absent from the prompt.

## Approach

`context.loadClaudeMd`, **default off**. When enabled, the `agents-md` walk also picks up standalone `CLAUDE.md` under identical skip/stop rules.

Default-off is deliberate. #2764 attempted always-load and was held because it changes default context for every project that already keeps a `CLAUDE.md` for another tool; that objection still has no maintainer sign-off. An opt-in setting sidesteps it entirely — nothing changes for anyone who does not turn it on.

## Same-depth dedup

`AGENTS.md` and `CLAUDE.md` in one directory previously collided on the shared `project:<depth>` key, so the second was shadowed out of `result.items` and never reached the runtime prompt — the blocking finding on #2764.

The slot here is keyed on `provider === "agents-md" && basename === "CLAUDE.md"`, not on every basename. A filename-wide key (what #2764 did) would also stop unrelated context files from shadowing each other — `.claude/CLAUDE.md`, `.github/copilot-instructions.md`, `GEMINI.md` — which breaks the one-file-per-scope precedence model in `docs/context-files.md`. Config-directory `CLAUDE.md` keeps competing for the shared slot exactly as before.

Also hoisted the hidden-directory check out of the read so it guards both filenames rather than only the one.

## Verification

Tests assert through `result.items` and `loadProjectContextFiles()`, not `result.all` — `result.all` retains shadowed entries, so a file can appear there while still being absent from the prompt.

**The tests catch the actual bug.** Reverting only the dedup key (keeping discovery) makes 2 of them fail with `CLAUDE.md → undefined`, reproducing the #2764 blocker. Restored, 16/16 pass across the two files.

Exercised end to end against a real repo, not just tests:

```
context.loadClaudeMd=false -> 1 file(s)
   /Users/rahul/.omp/agent/AGENTS.md
context.loadClaudeMd=true  -> 2 file(s)
   <repo>/CLAUDE.md  (depth 0, 23939 bytes)
   /Users/rahul/.omp/agent/AGENTS.md
```

Walk-up from nested directories, including through a config dir:

```
cwd=<repo>/.claude/skills/splunk  -> <repo>/CLAUDE.md (depth 3)
cwd=<repo>/memory/services        -> <repo>/CLAUDE.md (depth 2)
```

Full `test/discovery/` suite: 181 pass. The 2 failures + 1 error there are pre-existing — clean `main` produces the same three on my machine (a stray local MCP server in a plugin fixture, and a missing generated `tool-views.generated.js`).

**Not run:** `bun run check`. biome and tsgo are devDependencies and my network blocks the npm registry, so lint and typecheck are unverified — I checked line width and tab indentation against `biome.json` by hand. Worth a CI run.

## Notes

Authored with AI assistance. I reviewed the full diff and ran the verification above myself.

Happy to change the default, the setting name, or drop the setting for always-load if maintainers prefer that direction — the dedup and hidden-directory fixes stand either way.
