### PR TITLE
feat(coding-agent): add Windows-tailored shell guidance to system and bash prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Windows hosts now get tailored shell guidance in the system prompt and bash tool description: the model is told the bash tool stays an embedded POSIX bash (bash syntax, forward-slash or quoted backslash paths) and how to invoke cmd.exe / PowerShell explicitly, instead of inferring cmd/PowerShell syntax from the win32 workstation block.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/prompts/system/project-prompt.md
+++ b/packages/coding-agent/src/prompts/system/project-prompt.md
@@ -8,7 +8,7 @@ PROJECT
 
 {{#if isWindows}}
 <windows>
-Windows host; the shell{{#has tools "bash"}} behind `{{toolRefs.bash}}`{{/has}} is an embedded POSIX bash — write bash syntax, never cmd.exe or PowerShell syntax at top level. Invoke native tooling explicitly as a program (`cmd.exe /c "…"`, `powershell -NoProfile -Command "…"`). `C:/fwd/slash` and quoted `'C:\back\slash'` paths both work; `~` is the user profile. `/tmp`, `/usr`, `sudo`, and Unix package managers do not exist — use `mktemp`/`$TMPDIR` and Windows equivalents.
+Windows host; the shell{{#has tools "bash"}} behind `{{toolRefs.bash}}`{{/has}} is an embedded POSIX bash — write bash syntax, never cmd.exe or PowerShell syntax at top level. Invoke native tooling explicitly as a program (`cmd.exe /c "…"`, `powershell -NoProfile -Command "…"`). `C:/fwd/slash` and quoted `'C:\back\slash'` paths both work; `~` is the user profile. `/tmp`, `/usr`, `sudo`, and Unix package managers do not exist — use `mktemp` and Windows equivalents.
 </windows>
 {{/if}}
 

--- a/packages/coding-agent/src/prompts/system/project-prompt.md
+++ b/packages/coding-agent/src/prompts/system/project-prompt.md
@@ -6,6 +6,12 @@ PROJECT
 {{#if model}}- Model: {{model}}{{/if}}
 </workstation>
 
+{{#if isWindows}}
+<windows>
+Windows host; the shell{{#has tools "bash"}} behind `{{toolRefs.bash}}`{{/has}} is an embedded POSIX bash — write bash syntax, never cmd.exe or PowerShell syntax at top level. Invoke native tooling explicitly as a program (`cmd.exe /c "…"`, `powershell -NoProfile -Command "…"`). `C:/fwd/slash` and quoted `'C:\back\slash'` paths both work; `~` is the user profile. `/tmp`, `/usr`, `sudo`, and Unix package managers do not exist — use `mktemp`/`$TMPDIR` and Windows equivalents.
+</windows>
+{{/if}}
+
 {{#if contextFiles.length}}
 <repo-rules>
 You MUST follow the context files below for all tasks:

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -4,7 +4,8 @@ Use ONLY for one binary or a short pipeline that computes a fact (`wc -l`, `sort
 {{#if hasEval}}Inline scripts, heredocs, `$(…)`, complex control flow/quoting, and non-trivial pipelines → `eval`.{{else}}Inline scripts, heredocs, `$(…)`, and complex control flow → a purpose-built tool or checked-in script.{{/if}}
 
 <instruction>
-- Set `cwd` instead of `cd`; use `env: { NAME: "…" }` for multiline/quote-heavy values.
+{{#if isWindows}}- Windows host, but this tool is an embedded POSIX bash: write bash syntax (`&&`, `$VAR`, `C:/fwd/slash` or quoted `'C:\back\slash'` paths). cmd/PowerShell syntax (`%VAR%`, `$env:X`, `-and`) never parses here; run native tooling as a program: `cmd.exe /c "…"`, `powershell -NoProfile -Command "…"`.
+{{/if}}- Set `cwd` instead of `cd`; use `env: { NAME: "…" }` for multiline/quote-heavy values.
 - `pty: true` only for terminal interaction (`sudo`, `ssh`).
 - Order-dependent commands use `&&` in one call; independent calls may run concurrently.
 - Internal URIs (`skill://`, `agent://`, …) auto-resolve to paths.

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -889,6 +889,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		hasMemoryRoot: memoryRootEnabled,
 		securityEnabled,
 		hasObsidian: hasObsidian(),
+		isWindows: os.platform() === "win32",
 		includeWorkspaceTree,
 		renderMermaid,
 		xdevTools,

--- a/packages/coding-agent/test/system-prompt-windows.test.ts
+++ b/packages/coding-agent/test/system-prompt-windows.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildSystemPrompt } from "@oh-my-pi/pi-coding-agent/system-prompt";
+import { prompt } from "@oh-my-pi/pi-utils";
+import bashPrompt from "../src/prompts/tools/bash.md" with { type: "text" };
+import { cleanupTempHome } from "./helpers/temp-home-cleanup";
+
+const EMPTY_TREE = {
+	rootPath: "",
+	rendered: "",
+	truncated: false,
+	totalLines: 0,
+	agentsMdFiles: [],
+};
+
+// Windows hosts run the bash tool through the embedded POSIX shell, so the
+// model must be told to keep emitting bash syntax (not cmd.exe/PowerShell)
+// even though the workstation block reports a win32 OS.
+describe("system prompt Windows guidance", () => {
+	let tempDir = "";
+	let tempHomeDir = "";
+	let originalHome: string | undefined;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-prompt-windows-"));
+		tempHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-prompt-windows-home-"));
+		originalHome = process.env.HOME;
+		process.env.HOME = tempHomeDir;
+	});
+
+	afterEach(cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome })));
+
+	async function renderedPrompt(): Promise<string> {
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: ["bash"],
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+		});
+		return systemPrompt.join("\n\n");
+	}
+
+	it("renders the <windows> host block on win32", async () => {
+		spyOn(os, "platform").mockReturnValue("win32");
+
+		const rendered = await renderedPrompt();
+		expect(rendered).toContain("<windows>");
+		expect(rendered).toContain("embedded POSIX bash");
+		expect(rendered).toContain('cmd.exe /c "…"');
+		expect(rendered).toContain('powershell -NoProfile -Command "…"');
+	});
+
+	it("omits the <windows> host block on other platforms", async () => {
+		spyOn(os, "platform").mockReturnValue("linux");
+
+		expect(await renderedPrompt()).not.toContain("<windows>");
+	});
+});
+
+describe("bash tool description Windows guidance", () => {
+	function renderBash(isWindows: boolean): string {
+		return prompt.render(bashPrompt, { isWindows });
+	}
+
+	it("tells the model the tool stays a POSIX bash on Windows", () => {
+		const rendered = renderBash(true);
+		expect(rendered).toContain("embedded POSIX bash");
+		expect(rendered).toContain('cmd.exe /c "…"');
+		expect(rendered).toContain('powershell -NoProfile -Command "…"');
+	});
+
+	it("carries no Windows guidance elsewhere", () => {
+		expect(renderBash(false)).not.toContain("Windows");
+	});
+});


### PR DESCRIPTION
## What

On Windows the workstation block reports `OS: win32 …`, but the `bash` tool still runs the embedded POSIX shell (brush) — and no prompt text says so. Models routinely infer cmd.exe/PowerShell syntax from the win32 line (`%VAR%`, `$env:X`, `dir`, `-and`) and fail.

This adds Windows-gated guidance in two places:

- `prompts/system/project-prompt.md`: a `<windows>` block after `<workstation>` — the shell is an embedded POSIX bash; write bash syntax; invoke native tooling explicitly (`cmd.exe /c "…"`, `powershell -NoProfile -Command "…"`); `C:/fwd/slash` and quoted `'C:\back\slash'` both work; `/tmp`/`/usr`/`sudo` don't exist.
- `prompts/tools/bash.md`: an equivalent one-line instruction bullet (the tool description already receives `isWindows`; the system prompt render data now gets `isWindows: os.platform() === "win32"`).

`os.platform()` (not `process.platform`) so tests can seam it the same way the existing Kernel-field tests do.

## Why

Windows hosts are first-class for the embedded shell (POSIX pipelines, builtins, `cwd`, timeouts, and `cmd.exe`/`powershell` child invocations all work — verified on Windows Server 2022), but the model was never told which syntax the tool speaks, which is the single biggest source of failed bash calls on Windows.

## Testing

- New `test/system-prompt-windows.test.ts`: `<windows>` block renders on win32 and is absent elsewhere; bash description carries the POSIX-bash note only when `isWindows`.
- Existing prompt suites (`system-prompt-kernel/inventory/dedup/model/personality`, `tool-guidance-efficiency`): 46 pass / 0 fail on Windows.
- Manual QA on Windows Server 2022: exercised `executeBash` with 24 command shapes (pipelines, `cmd.exe /c`, `powershell -Command`, both path styles, timeouts, background jobs) to confirm the guidance matches actual behavior.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)