### PR TITLE
feat(utils): prefer PowerShell over cmd.exe as Windows shell fallback

### DIFF
--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -132,7 +132,8 @@ const BASH_PATTERN_APPROVAL_VALUES = new Set(["allow", "deny", "prompt"]);
  *
  * The wrap reuses the same shell binary + args the local `bash-executor` would
  * pick via `settings.getShellConfig()` — Git Bash / `bash.exe` on Windows
- * (`cmd.exe /c` as the last-resort fallback when no bash exists on the host),
+ * (PowerShell `-Command`, then `cmd.exe /c`, as fallbacks when no bash
+ * exists on the host),
  * `$SHELL` (bash/zsh) with the `sh` fallback on POSIX — so the ACP path
  * preserves `bash` tool semantics (`$VAR`, `$(...)`, `source`, POSIX quoting,
  * `-l`) wherever a POSIX shell is available. The agent host's shell path is

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Support PowerShell (`powershell.exe` / `pwsh`) as a custom `shellPath`: spawn paths now pass `-NoLogo -Command` (plus `-NoProfile` under `PI_BASH_NO_LOGIN`) instead of the POSIX `-l -c` pair, which PowerShell rejected with `The term '-l' is not recognized`.
+
 ## [17.2.9] - 2026-08-05
 
 ### Added

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Windows shell discovery now prefers PowerShell (`pwsh.exe`, then `powershell.exe`) over cmd.exe as the last-resort fallback when no bash/sh is installed, and `resolveWindowsShell` honors an injected `env.PATH` for its on-PATH lookups so the fallback chain is deterministic in tests.
+
 ### Fixed
 
 - Support PowerShell (`powershell.exe` / `pwsh`) as a custom `shellPath`: spawn paths now pass `-NoLogo -Command` (plus `-NoProfile` under `PI_BASH_NO_LOGIN`) instead of the POSIX `-l -c` pair, which PowerShell rejected with `The term '-l' is not recognized`.

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -50,12 +50,19 @@ function buildSpawnEnv(shell: string): Record<string, string> {
 
 /**
  * Get shell args for the resolved shell.
- * cmd.exe takes `/c`; POSIX shells take `-c`, with `-l` unless
- * PI_BASH_NO_LOGIN / CLAUDE_BASH_NO_LOGIN is set.
+ * cmd.exe takes `/c`; PowerShell (powershell.exe / pwsh) takes
+ * `-NoLogo -Command`, with `-NoProfile` when PI_BASH_NO_LOGIN /
+ * CLAUDE_BASH_NO_LOGIN is set (profile scripts are PowerShell's login-shell
+ * analog); POSIX shells take `-c`, with `-l` unless the same env is set.
+ *
+ * Exported for tests; `env` overrides the process env gate.
  */
-function getShellArgs(shell: string): string[] {
+export function getShellArgs(shell: string, env: Record<string, string | undefined> = $env): string[] {
 	if (isCmdShell(shell)) return ["/c"];
-	const noLogin = $env.PI_BASH_NO_LOGIN || $env.CLAUDE_BASH_NO_LOGIN;
+	const noLogin = env.PI_BASH_NO_LOGIN || env.CLAUDE_BASH_NO_LOGIN;
+	if (isPowerShell(shell)) {
+		return noLogin ? ["-NoLogo", "-NoProfile", "-Command"] : ["-NoLogo", "-Command"];
+	}
 	return noLogin ? ["-c"] : ["-l", "-c"];
 }
 
@@ -63,6 +70,16 @@ function getShellArgs(shell: string): string[] {
 export function isCmdShell(shell: string): boolean {
 	const basename = shell.replace(/\\/g, "/").split("/").pop()?.toLowerCase();
 	return basename === "cmd.exe" || basename === "cmd";
+}
+
+/**
+ * Whether the shell is Windows PowerShell or PowerShell Core (pwsh). Spawn
+ * paths must use `-Command`: passing the POSIX `-l -c` pair makes PowerShell
+ * parse `-l` as the command and fail with `The term '-l' is not recognized`.
+ */
+export function isPowerShell(shell: string): boolean {
+	const basename = shell.replace(/\\/g, "/").split("/").pop()?.toLowerCase();
+	return basename === "powershell.exe" || basename === "powershell" || basename === "pwsh.exe" || basename === "pwsh";
 }
 
 /**

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -141,11 +141,17 @@ export function resolveBasicShell(): string | undefined {
  * 3. bash.exe on PATH (Cygwin, MSYS2, ...)
  * 4. sh.exe on PATH (Git for Windows' sh.exe is bash; prefer a sibling
  *    bash.exe when present)
- * 5. cmd.exe from ComSpec
+ * 5. pwsh.exe / powershell.exe on PATH — a far more capable interactive
+ *    shell than cmd.exe for the spawn paths, and the native PTY layer
+ *    already speaks its `-Command` convention
+ * 6. cmd.exe from ComSpec
  *
- * Exported for tests; `env` overrides Bun.env-based discovery.
+ * Exported for tests; `env` overrides Bun.env-based discovery, including
+ * `env.PATH` for the on-PATH lookups so the fallback chain is testable on
+ * hosts that have a real bash/PowerShell installed.
  */
 export function resolveWindowsShell(env: Record<string, string | undefined> = Bun.env): string {
+	const whichOnEnvPath = (name: string): string | null => $which(name, { PATH: env.PATH ?? "" });
 	const gitRoots = [
 		env.ProgramFiles && path.join(env.ProgramFiles, "Git"),
 		env["ProgramFiles(x86)"] && path.join(env["ProgramFiles(x86)"], "Git"),
@@ -160,13 +166,18 @@ export function resolveWindowsShell(env: Record<string, string | undefined> = Bu
 		if (fs.existsSync(candidate)) return candidate;
 	}
 
-	const bashOnPath = $which("bash.exe");
+	const bashOnPath = whichOnEnvPath("bash.exe");
 	if (bashOnPath) return bashOnPath;
 
-	const shOnPath = $which("sh.exe");
+	const shOnPath = whichOnEnvPath("sh.exe");
 	if (shOnPath) {
 		const siblingBash = path.join(path.dirname(shOnPath), "bash.exe");
 		return fs.existsSync(siblingBash) ? siblingBash : shOnPath;
+	}
+
+	for (const name of ["pwsh.exe", "powershell.exe"]) {
+		const psOnPath = whichOnEnvPath(name);
+		if (psOnPath) return psOnPath;
 	}
 
 	return env.ComSpec || env.COMSPEC || "C:\\Windows\\System32\\cmd.exe";
@@ -176,8 +187,8 @@ export function resolveWindowsShell(env: Record<string, string | undefined> = Bu
  * Get shell configuration based on platform.
  * Resolution order:
  * 1. User-specified shellPath from the active settings source
- * 2. On Windows: Git Bash / bash / sh discovery, then cmd.exe (see
- *    {@link resolveWindowsShell}) — never fails
+ * 2. On Windows: Git Bash / bash / sh discovery, then PowerShell, then
+ *    cmd.exe (see {@link resolveWindowsShell}) — never fails
  * 3. On Unix: $SHELL if bash/zsh, then fallback paths
  * 4. Fallback: sh
  */

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -132,7 +132,7 @@ export function resolveBasicShell(): string | undefined {
  * brush-core shell. The resolved binary only serves the spawn-a-shell paths
  * (interactive PTY sessions, ACP client terminals, SHELL env), so this
  * prefers a real Git Bash when one exists and otherwise falls back to
- * cmd.exe — it never fails.
+ * PowerShell, then cmd.exe — it never fails.
  *
  * Search order:
  * 1. Git for Windows install roots (machine + per-user installers)

--- a/packages/utils/test/procmgr.test.ts
+++ b/packages/utils/test/procmgr.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, MAIN_CONFIG_FILENAMES } from "../src/dirs";
-import { getShellConfig, resolveWindowsShell } from "../src/procmgr";
+import { getShellArgs, getShellConfig, resolveWindowsShell } from "../src/procmgr";
 
 describe("getShellConfig", () => {
 	it("directs invalid custom shell paths to the canonical config file", () => {
@@ -12,6 +12,30 @@ describe("getShellConfig", () => {
 		expect(() => getShellConfig(missingShell)).toThrow(
 			`Custom shell path not found: ${missingShell}\nPlease update shellPath in ${configPath}`,
 		);
+	});
+});
+
+describe("getShellArgs", () => {
+	it("uses -Command for PowerShell shells instead of the POSIX -l -c pair", () => {
+		// `powershell -l -c <cmd>` parses `-l` as the command and fails with
+		// `The term '-l' is not recognized`, breaking every spawn path for a
+		// shellPath pointed at PowerShell.
+		expect(getShellArgs("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", {})).toEqual([
+			"-NoLogo",
+			"-Command",
+		]);
+		expect(getShellArgs("C:\\Program Files\\PowerShell\\7\\pwsh.exe", {})).toEqual(["-NoLogo", "-Command"]);
+		expect(getShellArgs("/usr/bin/pwsh", {})).toEqual(["-NoLogo", "-Command"]);
+	});
+
+	it("maps the no-login env gate to -NoProfile for PowerShell", () => {
+		expect(getShellArgs("pwsh.exe", { PI_BASH_NO_LOGIN: "1" })).toEqual(["-NoLogo", "-NoProfile", "-Command"]);
+	});
+
+	it("keeps cmd.exe and POSIX shell args unchanged", () => {
+		expect(getShellArgs("C:\\Windows\\System32\\cmd.exe", {})).toEqual(["/c"]);
+		expect(getShellArgs("/bin/bash", {})).toEqual(["-l", "-c"]);
+		expect(getShellArgs("/bin/bash", { PI_BASH_NO_LOGIN: "1" })).toEqual(["-c"]);
 	});
 });
 

--- a/packages/utils/test/procmgr.test.ts
+++ b/packages/utils/test/procmgr.test.ts
@@ -81,11 +81,38 @@ describe("resolveWindowsShell", () => {
 		expect(resolveWindowsShell({ ProgramFiles: programFiles, ComSpec: "C:\\Windows\\System32\\cmd.exe" })).toBe(bash);
 	});
 
-	// On a real Windows host bash.exe/sh.exe may resolve from PATH before the
-	// cmd.exe fallback is reached, so the fallback contract is only
-	// deterministic off-Windows.
-	it.skipIf(process.platform === "win32")("falls back to cmd.exe instead of failing when no bash exists", () => {
+	it("falls back to cmd.exe instead of failing when no bash or PowerShell exists", () => {
 		expect(resolveWindowsShell({})).toBe("C:\\Windows\\System32\\cmd.exe");
 		expect(resolveWindowsShell({ ComSpec: "D:\\win\\cmd.exe" })).toBe("D:\\win\\cmd.exe");
+	});
+
+	function makeExecutable(dir: string, name: string): string {
+		const file = path.join(dir, name);
+		fs.writeFileSync(file, "");
+		fs.chmodSync(file, 0o755);
+		return file;
+	}
+
+	it("prefers PowerShell on PATH over the cmd.exe fallback when no bash exists", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-ps-path-"));
+		tempDirs.push(dir);
+		const powershell = makeExecutable(dir, "powershell.exe");
+		expect(resolveWindowsShell({ PATH: dir, ComSpec: "C:\\Windows\\System32\\cmd.exe" })).toBe(powershell);
+	});
+
+	it("prefers pwsh over Windows PowerShell, and any bash over both", () => {
+		// Separate dirs per assertion: $which caches misses per (command, PATH).
+		const psDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-ps-priority-"));
+		tempDirs.push(psDir);
+		makeExecutable(psDir, "powershell.exe");
+		const pwsh = makeExecutable(psDir, "pwsh.exe");
+		expect(resolveWindowsShell({ PATH: psDir })).toBe(pwsh);
+
+		const bashDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-bash-priority-"));
+		tempDirs.push(bashDir);
+		makeExecutable(bashDir, "powershell.exe");
+		makeExecutable(bashDir, "pwsh.exe");
+		const bash = makeExecutable(bashDir, "bash.exe");
+		expect(resolveWindowsShell({ PATH: bashDir })).toBe(bash);
 	});
 });


### PR DESCRIPTION
## What

Stacked on #7691 (its commit appears here until it lands; this PR's own change is the `resolveWindowsShell` commit).

When a Windows host has no Git Bash / bash / sh, `resolveWindowsShell()` fell straight through to cmd.exe. This inserts PowerShell into the fallback chain — `pwsh.exe`, then `powershell.exe` on PATH — before the ComSpec last resort. The resolved shell only serves the spawn-a-shell paths (interactive PTY, ACP client terminals, `SHELL` env); the native PTY layer already speaks PowerShell's `-Command` convention, and #7691 gives the spawn paths the right args.

The on-PATH lookups now also honor the injected `env.PATH` (`$which(name, { PATH: env.PATH ?? "" })`), which makes the whole fallback chain deterministic under test — the previous ComSpec test was impossible to run on any Windows host with Git installed (real PATH leaked in) and is now un-skipped.

## Why

cmd.exe is a hostile interactive target (no ANSI-aware line editing, no sane quoting, batch-only syntax). Every Windows box ships Windows PowerShell, so hosts without Git Bash get a materially better PTY/terminal shell for free, while bash-first resolution is unchanged.

## Testing

- New unit tests: PowerShell preferred over ComSpec when no bash exists; `pwsh.exe` preferred over `powershell.exe`; any bash still wins over both; ComSpec fallback when nothing is on PATH (now deterministic on Windows too).
- `bun test test/procmgr.test.ts`: 10 pass / 0 fail on Windows Server 2022; `bun run check` (biome + tsgo) clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)