### PR TITLE
feat(ai,coding-agent): add interactive API-key logins for env-only providers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added interactive API-key paste logins (`/login`) for providers that previously only accepted environment variables: OpenAI, Google Gemini, Groq, Mistral, MiniMax, AIML API, and Azure OpenAI. Pasting a key stores it as a login credential that takes precedence over the matching env var.
+
+### Fixed
+
+- Fixed `getProxyForProvider` tests failing in the full suite: the provider-proxy memo cache is shared across test files in the same worker, so a stale `undefined` entry from another file poisoned assertions. The proxy tests now clear the cache per case.
+
 ## [17.2.9] - 2026-08-05
 
 ### Fixed

--- a/packages/ai/src/registry/aimlapi.ts
+++ b/packages/ai/src/registry/aimlapi.ts
@@ -1,6 +1,23 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
+
+/** AIML API login flow (API key paste, validated via the models endpoint). */
+export const loginAimlApi = createApiKeyLogin({
+	providerLabel: "AIML API",
+	authUrl: "https://aimlapi.com/app/keys",
+	instructions: "Create or copy your API key from the AIML API dashboard",
+	promptMessage: "Paste your AIML API key",
+	placeholder: "sk-...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "AIML API",
+		modelsUrl: "https://api.aimlapi.com/v1/models",
+	},
+});
 
 export const aimlApiProvider = {
 	id: "aimlapi",
 	name: "AIML API",
+	login: (cb: OAuthLoginCallbacks) => loginAimlApi(cb),
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/azure.ts
+++ b/packages/ai/src/registry/azure.ts
@@ -1,6 +1,24 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
+
+/**
+ * Azure OpenAI login flow (API key paste). No validation endpoint is possible:
+ * the request base URL is user-configured (AZURE_OPENAI_BASE_URL /
+ * AZURE_OPENAI_RESOURCE_NAME + deployment), so the key is stored and validated
+ * at request time.
+ */
+export const loginAzure = createApiKeyLogin({
+	providerLabel: "Azure OpenAI",
+	authUrl: "https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub/~/AllServices",
+	instructions: "Copy your Azure OpenAI API key from the Azure portal resource's Keys and Endpoint page",
+	promptMessage: "Paste your Azure OpenAI API key",
+	placeholder: "azure-...",
+	validation: null,
+});
 
 export const azureProvider = {
 	id: "azure",
 	name: "Azure OpenAI",
+	login: (cb: OAuthLoginCallbacks) => loginAzure(cb),
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/brave.ts
+++ b/packages/ai/src/registry/brave.ts
@@ -1,0 +1,45 @@
+import * as AIError from "../error";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+const AUTH_URL = "https://api.search.brave.com/app/keys";
+
+/**
+ * Login to Brave Search.
+ *
+ * Opens the Brave Search API keys page and prompts the user to paste their
+ * API key. Returns the key directly (no OAuth involved).
+ */
+export async function loginBrave(options: OAuthLoginCallbacks): Promise<string> {
+	if (!options.onPrompt) {
+		throw new AIError.OnPromptRequiredError("Brave");
+	}
+
+	options.onAuth?.({
+		url: AUTH_URL,
+		instructions: "Copy your Brave Search API key from the API keys page.",
+	});
+
+	const apiKey = await options.onPrompt({
+		message: "Paste your Brave Search API key",
+		placeholder: "BSA_...",
+	});
+
+	if (options.signal?.aborted) {
+		throw new AIError.LoginCancelledError();
+	}
+
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new AIError.ApiKeyRequiredError();
+	}
+
+	return trimmed;
+}
+
+export const braveProvider = {
+	id: "brave",
+	name: "Brave",
+	envKeys: "BRAVE_API_KEY",
+	login: (cb: OAuthLoginCallbacks) => loginBrave(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/firecrawl.ts
+++ b/packages/ai/src/registry/firecrawl.ts
@@ -1,0 +1,46 @@
+import * as AIError from "../error";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+const AUTH_URL = "https://firecrawl.dev/settings/api-keys";
+
+/**
+ * Login to Firecrawl.
+ *
+ * Opens the Firecrawl API keys page and prompts the user to paste their API
+ * key. Returns the key directly (no OAuth involved). Firecrawl also works
+ * keyless; this flow only stores a key when the user supplies one.
+ */
+export async function loginFirecrawl(options: OAuthLoginCallbacks): Promise<string> {
+	if (!options.onPrompt) {
+		throw new AIError.OnPromptRequiredError("Firecrawl");
+	}
+
+	options.onAuth?.({
+		url: AUTH_URL,
+		instructions: "Copy your Firecrawl API key from the API keys page.",
+	});
+
+	const apiKey = await options.onPrompt({
+		message: "Paste your Firecrawl API key",
+		placeholder: "fc-...",
+	});
+
+	if (options.signal?.aborted) {
+		throw new AIError.LoginCancelledError();
+	}
+
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new AIError.ApiKeyRequiredError();
+	}
+
+	return trimmed;
+}
+
+export const firecrawlProvider = {
+	id: "firecrawl",
+	name: "Firecrawl",
+	envKeys: "FIRECRAWL_API_KEY",
+	login: (cb: OAuthLoginCallbacks) => loginFirecrawl(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/google.ts
+++ b/packages/ai/src/registry/google.ts
@@ -1,6 +1,23 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
+
+/** Google Gemini login flow (API key paste, validated via the OpenAI-compat models endpoint). */
+export const loginGoogle = createApiKeyLogin({
+	providerLabel: "Google Gemini",
+	authUrl: "https://aistudio.google.com/app/apikey",
+	instructions: "Create or copy your API key from Google AI Studio",
+	promptMessage: "Paste your Google Gemini API key",
+	placeholder: "AIza...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "Google Gemini",
+		modelsUrl: "https://generativelanguage.googleapis.com/v1beta/openai/models",
+	},
+});
 
 export const googleProvider = {
 	id: "google",
 	name: "Google Gemini",
+	login: (cb: OAuthLoginCallbacks) => loginGoogle(cb),
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/groq.ts
+++ b/packages/ai/src/registry/groq.ts
@@ -1,6 +1,23 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
+
+/** Groq login flow (API key paste, validated via the models endpoint). */
+export const loginGroq = createApiKeyLogin({
+	providerLabel: "Groq",
+	authUrl: "https://console.groq.com/keys",
+	instructions: "Create or copy your API key from the Groq console",
+	promptMessage: "Paste your Groq API key",
+	placeholder: "gsk_...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "Groq",
+		modelsUrl: "https://api.groq.com/openai/v1/models",
+	},
+});
 
 export const groqProvider = {
 	id: "groq",
 	name: "Groq",
+	login: (cb: OAuthLoginCallbacks) => loginGroq(cb),
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/jina.ts
+++ b/packages/ai/src/registry/jina.ts
@@ -1,0 +1,45 @@
+import * as AIError from "../error";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+const AUTH_URL = "https://jina.ai/api-dashboard/";
+
+/**
+ * Login to Jina Reader.
+ *
+ * Opens the Jina API dashboard and prompts the user to paste their API key.
+ * Returns the key directly (no OAuth involved).
+ */
+export async function loginJina(options: OAuthLoginCallbacks): Promise<string> {
+	if (!options.onPrompt) {
+		throw new AIError.OnPromptRequiredError("Jina");
+	}
+
+	options.onAuth?.({
+		url: AUTH_URL,
+		instructions: "Copy your Jina Reader API key from the API dashboard.",
+	});
+
+	const apiKey = await options.onPrompt({
+		message: "Paste your Jina Reader API key",
+		placeholder: "jina_...",
+	});
+
+	if (options.signal?.aborted) {
+		throw new AIError.LoginCancelledError();
+	}
+
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new AIError.ApiKeyRequiredError();
+	}
+
+	return trimmed;
+}
+
+export const jinaProvider = {
+	id: "jina",
+	name: "Jina",
+	envKeys: "JINA_API_KEY",
+	login: (cb: OAuthLoginCallbacks) => loginJina(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/minimax.ts
+++ b/packages/ai/src/registry/minimax.ts
@@ -1,6 +1,24 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
+
+/** MiniMax login flow (API key paste, validated via the anthropic-compatible messages endpoint). */
+export const loginMiniMax = createApiKeyLogin({
+	providerLabel: "MiniMax",
+	authUrl: "https://platform.minimaxi.com/user-center/basic-information/interface-key",
+	instructions: "Create or copy your API key from the MiniMax platform",
+	promptMessage: "Paste your MiniMax API key",
+	placeholder: "sk-...",
+	validation: {
+		kind: "anthropic-messages",
+		provider: "MiniMax",
+		baseUrl: "https://api.minimax.io/anthropic",
+		model: "MiniMax-M3",
+	},
+});
 
 export const minimaxProvider = {
 	id: "minimax",
 	name: "MiniMax",
+	login: (cb: OAuthLoginCallbacks) => loginMiniMax(cb),
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/mistral.ts
+++ b/packages/ai/src/registry/mistral.ts
@@ -1,6 +1,23 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
+
+/** Mistral login flow (API key paste, validated via the models endpoint). */
+export const loginMistral = createApiKeyLogin({
+	providerLabel: "Mistral",
+	authUrl: "https://console.mistral.ai/api-keys/",
+	instructions: "Create or copy your API key from the Mistral console",
+	promptMessage: "Paste your Mistral API key",
+	placeholder: "gsk_...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "Mistral",
+		modelsUrl: "https://api.mistral.ai/v1/models",
+	},
+});
 
 export const mistralProvider = {
 	id: "mistral",
 	name: "Mistral",
+	login: (cb: OAuthLoginCallbacks) => loginMistral(cb),
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/openai.ts
+++ b/packages/ai/src/registry/openai.ts
@@ -1,6 +1,23 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
+
+/** OpenAI login flow (API key paste, validated via the models endpoint). */
+export const loginOpenAI = createApiKeyLogin({
+	providerLabel: "OpenAI",
+	authUrl: "https://platform.openai.com/api-keys",
+	instructions: "Create or copy your API key from the OpenAI platform dashboard",
+	promptMessage: "Paste your OpenAI API key",
+	placeholder: "sk-...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "OpenAI",
+		modelsUrl: "https://api.openai.com/v1/models",
+	},
+});
 
 export const openaiProvider = {
 	id: "openai",
 	name: "OpenAI",
+	login: (cb: OAuthLoginCallbacks) => loginOpenAI(cb),
 } as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -8,6 +8,7 @@ import { anthropicProvider } from "./anthropic";
 import { azureProvider } from "./azure";
 import { basetenProvider } from "./baseten";
 import { bedrockMantleProvider } from "./bedrock-mantle";
+import { braveProvider } from "./brave";
 import { cerebrasProvider } from "./cerebras";
 import { cloudflareAiGatewayProvider } from "./cloudflare-ai-gateway";
 import { coreWeaveProvider } from "./coreweave";
@@ -15,6 +16,7 @@ import { cursorProvider } from "./cursor";
 import { deepseekProvider } from "./deepseek";
 import { devinProvider } from "./devin";
 import { exaProvider } from "./exa";
+import { firecrawlProvider } from "./firecrawl";
 import { firepassProvider } from "./firepass";
 import { fireworksProvider } from "./fireworks";
 import { githubCopilotProvider } from "./github-copilot";
@@ -27,6 +29,7 @@ import { googleGeminiCliProvider } from "./google-gemini-cli";
 import { googleVertexProvider } from "./google-vertex";
 import { groqProvider } from "./groq";
 import { huggingfaceProvider } from "./huggingface";
+import { jinaProvider } from "./jina";
 import { kagiProvider } from "./kagi";
 import { kiloProvider } from "./kilo";
 import { kimiCodeProvider } from "./kimi-code";
@@ -59,6 +62,7 @@ import { siliconflowProvider } from "./siliconflow";
 import { siliconflowCnProvider } from "./siliconflow-cn";
 import { syntheticProvider } from "./synthetic";
 import { tavilyProvider } from "./tavily";
+import { tinyfishProvider } from "./tinyfish";
 import { togetherProvider } from "./together";
 import type { ProviderDefinition } from "./types";
 import { umansProvider } from "./umans";
@@ -146,6 +150,10 @@ const ALL = [
 	kagiProvider,
 	exaProvider,
 	parallelProvider,
+	braveProvider,
+	jinaProvider,
+	tinyfishProvider,
+	firecrawlProvider,
 	ollamaProvider,
 	ollamaCloudProvider,
 	lmStudioProvider,

--- a/packages/ai/src/registry/tinyfish.ts
+++ b/packages/ai/src/registry/tinyfish.ts
@@ -1,0 +1,45 @@
+import * as AIError from "../error";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+const AUTH_URL = "https://tinyfish.ai/";
+
+/**
+ * Login to TinyFish.
+ *
+ * Opens the TinyFish site and prompts the user to paste their API key.
+ * Returns the key directly (no OAuth involved).
+ */
+export async function loginTinyFish(options: OAuthLoginCallbacks): Promise<string> {
+	if (!options.onPrompt) {
+		throw new AIError.OnPromptRequiredError("TinyFish");
+	}
+
+	options.onAuth?.({
+		url: AUTH_URL,
+		instructions: "Copy your TinyFish API key.",
+	});
+
+	const apiKey = await options.onPrompt({
+		message: "Paste your TinyFish API key",
+		placeholder: "tf-...",
+	});
+
+	if (options.signal?.aborted) {
+		throw new AIError.LoginCancelledError();
+	}
+
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new AIError.ApiKeyRequiredError();
+	}
+
+	return trimmed;
+}
+
+export const tinyfishProvider = {
+	id: "tinyfish",
+	name: "TinyFish",
+	envKeys: "TINYFISH_API_KEY",
+	login: (cb: OAuthLoginCallbacks) => loginTinyFish(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/test/env-key-model-login.test.ts
+++ b/packages/ai/test/env-key-model-login.test.ts
@@ -1,0 +1,94 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { getOAuthProviders } from "@oh-my-pi/pi-ai/registry/oauth";
+import { getEnvApiKey } from "@oh-my-pi/pi-ai/stream";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+
+const ENV_KEYS = [
+	"OPENAI_API_KEY",
+	"GEMINI_API_KEY",
+	"GROQ_API_KEY",
+	"MISTRAL_API_KEY",
+	"MINIMAX_API_KEY",
+	"AIMLAPI_API_KEY",
+	"AZURE_OPENAI_API_KEY",
+] as const;
+const originalEnv = new Map(ENV_KEYS.map(key => [key, Bun.env[key]]));
+
+afterEach(() => {
+	for (const key of ENV_KEYS) {
+		const original = originalEnv.get(key);
+		if (original === undefined) {
+			delete Bun.env[key];
+		} else {
+			Bun.env[key] = original;
+		}
+	}
+	vi.restoreAllMocks();
+});
+
+/** Endpoints the mocked validators expect; mirrors each provider's login def. */
+const VALIDATION_URLS: Record<string, string> = {
+	openai: "https://api.openai.com/v1/models",
+	google: "https://generativelanguage.googleapis.com/v1beta/openai/models",
+	groq: "https://api.groq.com/openai/v1/models",
+	mistral: "https://api.mistral.ai/v1/models",
+	minimax: "https://api.minimax.io/anthropic/v1/messages",
+	aimlapi: "https://api.aimlapi.com/v1/models",
+};
+
+function mockValidatingFetch(provider: string): FetchImpl {
+	return vi.fn(async (input: string | URL | Request) => {
+		const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : (input as Request).url;
+		if (url === VALIDATION_URLS[provider]) {
+			return new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+		throw new Error(`unexpected fetch: ${url}`);
+	});
+}
+
+function newStorage(): { store: SqliteAuthCredentialStore; storage: AuthStorage } {
+	const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+	const storage = new AuthStorage(store);
+	void storage.reload();
+	return { store, storage };
+}
+
+describe("env-key model provider login wiring", () => {
+	for (const provider of ["openai", "google", "groq", "mistral", "minimax", "aimlapi"] as const) {
+		test(`${provider} appears in the login selector`, () => {
+			const entry = getOAuthProviders().find(item => item.id === provider);
+			expect(entry).toBeDefined();
+			expect(entry?.available).toBe(true);
+		});
+
+		test(`${provider} login validates and stores the pasted key`, async () => {
+			const { store, storage } = newStorage();
+			await storage.login(provider, {
+				onAuth: () => {},
+				onPrompt: async () => "sk-test-key",
+				fetch: mockValidatingFetch(provider),
+			});
+			expect(await storage.get(provider)).toEqual({ type: "api_key", key: "sk-test-key", source: "login" });
+			store.close();
+		});
+	}
+
+	test("azure login stores the key without validation (endpoint is user-configured)", async () => {
+		const { store, storage } = newStorage();
+		await storage.login("azure", { onAuth: () => {}, onPrompt: async () => "azure-test-key" });
+		expect(await storage.get("azure")).toEqual({ type: "api_key", key: "azure-test-key", source: "login" });
+		store.close();
+	});
+
+	test("env keys still resolve for providers with no stored credential", () => {
+		Bun.env.OPENAI_API_KEY = "sk-env-key";
+		Bun.env.GEMINI_API_KEY = "AIza-env-key";
+		expect(getEnvApiKey("openai")).toBe("sk-env-key");
+		expect(getEnvApiKey("google")).toBe("AIza-env-key");
+	});
+});

--- a/packages/ai/test/provider-registry.test.ts
+++ b/packages/ai/test/provider-registry.test.ts
@@ -61,15 +61,26 @@ describe("provider registry auth surface", () => {
 		expect(getEnvApiKey("coreweave")).toBe("coreweave-env");
 	});
 
-	test("login list contains loginable providers and excludes env-only model providers", () => {
+	test("login list contains loginable providers including env-key model and search providers", () => {
 		const ids = getOAuthProviders().map(provider => provider.id);
 		expect(ids).toContain("zenmux");
 		expect(ids).toContain("kagi");
 		expect(ids).toContain("exa");
 		expect(ids).toContain("umans");
 		expect(ids).toContain("llama.cpp");
-		// openai has no interactive login flow.
-		expect(ids).not.toContain("openai");
+		// Env-key-only providers now ship interactive API-key paste logins, so
+		// they appear in the /login list instead of requiring manual env setup.
+		expect(ids).toContain("openai");
+		expect(ids).toContain("google");
+		expect(ids).toContain("groq");
+		expect(ids).toContain("mistral");
+		expect(ids).toContain("minimax");
+		expect(ids).toContain("aimlapi");
+		expect(ids).toContain("azure");
+		expect(ids).toContain("brave");
+		expect(ids).toContain("jina");
+		expect(ids).toContain("tinyfish");
+		expect(ids).toContain("firecrawl");
 	});
 
 	test("paste-code login set is derived from pasteCodeFlow", () => {

--- a/packages/ai/test/proxy.test.ts
+++ b/packages/ai/test/proxy.test.ts
@@ -3,6 +3,7 @@ import * as net from "node:net";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
 import {
+	__resetProxyCache,
 	connectProxiedSocket,
 	getProxyForProvider,
 	getProxyForUrl,
@@ -106,6 +107,11 @@ beforeEach(() => {
 		saved[key] = Bun.env[key];
 		delete Bun.env[key];
 	}
+	// `getProxyForProvider` memoizes per provider id. Other test files share
+	// this module-level cache in the same worker (e.g. `github-copilot` is
+	// exercised by the copilot suites), so clear it or a stale `undefined`
+	// entry poisons this file's assertions.
+	__resetProxyCache();
 });
 
 afterEach(() => {

--- a/packages/ai/test/search-provider-login.test.ts
+++ b/packages/ai/test/search-provider-login.test.ts
@@ -1,0 +1,60 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { getOAuthProviders } from "@oh-my-pi/pi-ai/registry/oauth";
+import { getEnvApiKey } from "@oh-my-pi/pi-ai/stream";
+
+const ENV_KEYS = ["BRAVE_API_KEY", "JINA_API_KEY", "TINYFISH_API_KEY", "FIRECRAWL_API_KEY"] as const;
+const originalEnv = new Map(ENV_KEYS.map(key => [key, Bun.env[key]]));
+
+afterEach(() => {
+	for (const key of ENV_KEYS) {
+		const original = originalEnv.get(key);
+		if (original === undefined) {
+			delete Bun.env[key];
+		} else {
+			Bun.env[key] = original;
+		}
+	}
+	vi.restoreAllMocks();
+});
+
+function newStorage(): { store: SqliteAuthCredentialStore; storage: AuthStorage } {
+	const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+	const storage = new AuthStorage(store);
+	void storage.reload();
+	return { store, storage };
+}
+
+describe("search provider login wiring", () => {
+	for (const provider of ["brave", "jina", "tinyfish", "firecrawl"] as const) {
+		test(`${provider} appears in the login selector`, () => {
+			const entry = getOAuthProviders().find(item => item.id === provider);
+			expect(entry).toBeDefined();
+			expect(entry?.available).toBe(true);
+		});
+
+		test(`${provider} login stores the pasted key as a login credential`, async () => {
+			const { store, storage } = newStorage();
+			await storage.login(provider, { onAuth: () => {}, onPrompt: async () => `${provider}-test-key` });
+			expect(await storage.get(provider)).toEqual({
+				type: "api_key",
+				key: `${provider}-test-key`,
+				source: "login",
+			});
+			store.close();
+		});
+	}
+
+	test("stored login key beats env key for search providers", async () => {
+		const { storage } = newStorage();
+		Bun.env.BRAVE_API_KEY = "BSA_env_key";
+		await storage.login("brave", { onAuth: () => {}, onPrompt: async () => "BSA_login_key" });
+		expect(await storage.getApiKey("brave")).toBe("BSA_login_key");
+	});
+
+	test("env key resolves when no credential is stored", () => {
+		Bun.env.JINA_API_KEY = "jina_env_key";
+		expect(getEnvApiKey("jina")).toBe("jina_env_key");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added interactive API-key paste logins (`/login`) for the web search providers Brave, Jina, TinyFish, and Firecrawl, so their keys can be entered in the TUI instead of manually setting `BRAVE_API_KEY`/`JINA_API_KEY`/`TINYFISH_API_KEY`/`FIRECRAWL_API_KEY`; Brave and Jina now resolve keys through the shared auth-storage pipeline (login credential takes precedence over env).
+
+### Fixed
+
+- Fixed the collab read-only test (`keeps a remotely killed subagent tombstoned`) timing out in the full suite: `CollabHost` now binds the agent registry and lifecycle manager at construction instead of re-reading the process-wide singletons on every request, so a parallel test file resetting those singletons can no longer make a remote `kill` silently target a different registry instance.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/collab/host.ts
+++ b/packages/coding-agent/src/collab/host.ts
@@ -138,14 +138,29 @@ export class CollabHost {
 	#agentsDebounce: Timer | null = null;
 	#busUnsubscribers: (() => void)[] = [];
 	#registryUnsubscribe?: () => void;
+	/** Agent registry bound at construction: the wire snapshot/kill paths and
+	 * the subscription below must address the same instance even if a parallel
+	 * test resets the process-wide singleton mid-flight. */
+	#registry: AgentRegistry;
+	/** Lifecycle manager bound to {@link #registry} so kill/revive resolve the
+	 * same refs the registry queries (a global `AgentLifecycleManager` reset by
+	 * a parallel test would otherwise wrap a different registry instance). */
+	#lifecycle: AgentLifecycleManager;
 	#stopped = false;
 
 	constructor(ctx: InteractiveModeContext) {
 		this.#ctx = ctx;
+		this.#registry = AgentRegistry.global();
+		this.#lifecycle = new AgentLifecycleManager(this.#registry);
 	}
 
 	get link(): string {
 		return this.#link;
+	}
+
+	/** Agent registry this host reads/writes (bound at construction). */
+	get registry(): AgentRegistry {
+		return this.#registry;
 	}
 
 	/** Browser deep link for the configured collab web UI. */
@@ -277,7 +292,7 @@ export class CollabHost {
 				this.#busUnsubscribers.push(bus.on(channel, data => this.#broadcast({ t: "bus", channel, data })));
 			}
 		}
-		this.#registryUnsubscribe = AgentRegistry.global().onChange(() => this.#scheduleAgentsBroadcast());
+		this.#registryUnsubscribe = this.#registry.onChange(() => this.#scheduleAgentsBroadcast());
 		this.#ctx.sessionManager.onEntryAppended = entry => {
 			if (isWireSessionEntry(entry)) this.#broadcast({ t: "entry", entry: shrinkForReplication(entry) });
 			// Model/thinking/title changes land as entries while idle; refresh
@@ -304,6 +319,9 @@ export class CollabHost {
 		this.#busUnsubscribers = [];
 		this.#registryUnsubscribe?.();
 		this.#registryUnsubscribe = undefined;
+		// Detach the bound lifecycle manager's registry listener so a stopped
+		// host cannot keep reacting to registry events (its instance is private).
+		this.#lifecycle.detach();
 		clearTimeout(this.#stateDebounce ?? undefined);
 		this.#stateDebounce = null;
 		clearTimeout(this.#agentsDebounce ?? undefined);
@@ -556,7 +574,7 @@ export class CollabHost {
 
 	#snapshotAgents(): AgentSnapshot[] {
 		return (
-			AgentRegistry.global()
+			this.#registry
 				.list()
 				// Advisor transcripts are local observability only; never mirror them to
 				// guests (the wire AgentSnapshot kind has no `advisor`, and guests must not
@@ -590,7 +608,7 @@ export class CollabHost {
 		}
 		// Advisor refs are excluded from snapshots, but reject control by id defensively:
 		// a stale/malicious client must never chat/kill/revive a read-only advisor transcript.
-		if (AgentRegistry.global().get(agentId)?.kind === "advisor") {
+		if (this.#registry.get(agentId)?.kind === "advisor") {
 			this.#socket?.send({ t: "error", message: `agent ${agentId}: advisor transcripts are read-only` }, fromPeer);
 			return;
 		}
@@ -606,7 +624,7 @@ export class CollabHost {
 					return;
 				}
 				// Mirrors the hub's #submitChatMessage: revive if parked, steer if mid-turn.
-				AgentLifecycleManager.global()
+				this.#lifecycle
 					.ensureLive(agentId)
 					.then(session => session.prompt(trimmed, { streamingBehavior: "steer" }))
 					.catch(fail);
@@ -614,18 +632,18 @@ export class CollabHost {
 			}
 			case "kill": {
 				const kill = async () => {
-					const ref = AgentRegistry.global().get(agentId);
+					const ref = this.#registry.get(agentId);
 					if (!ref) return;
 					if (ref.status === "running" && ref.session) {
 						await ref.session.abort({ reason: USER_INTERRUPT_LABEL });
 					}
-					await AgentLifecycleManager.global().release(agentId, ref, { tombstone: true });
+					await this.#lifecycle.release(agentId, ref, { tombstone: true });
 				};
 				kill().catch(fail);
 				break;
 			}
 			case "revive":
-				AgentLifecycleManager.global().ensureLive(agentId).catch(fail);
+				this.#lifecycle.ensureLive(agentId).catch(fail);
 				break;
 		}
 	}
@@ -634,7 +652,7 @@ export class CollabHost {
 	async #handleFetchTranscript(reqId: number, agentId: string, fromByte: number, fromPeer: number): Promise<void> {
 		const reply = (text: string, newSize: number, error?: string) =>
 			this.#socket?.send({ t: "transcript", reqId, text, newSize, error }, fromPeer);
-		const file = AgentRegistry.global().get(agentId)?.sessionFile;
+		const file = this.#registry.get(agentId)?.sessionFile;
 		if (!file) {
 			reply("", fromByte, "no transcript available");
 			return;

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -134,6 +134,17 @@ export class AgentLifecycleManager {
 	}
 
 	/**
+	 * Detach this manager's registry listener without releasing any agents.
+	 * Used when a consumer (e.g. CollabHost) owns a private manager instance
+	 * and stops reacting to registry events; `dispose()` also releases adopted
+	 * agents and is not appropriate for that teardown path.
+	 */
+	detach(): void {
+		this.#unsubscribe?.();
+		this.#unsubscribe = undefined;
+	}
+
+	/**
 	 * Install the factory used to cold-revive `parked` refs restored from disk
 	 * (Agent Hub scan, collab mirror, resumed process) — they carry a sessionFile
 	 * but no adoption. Set by the top-level session, which owns the ambient deps

--- a/packages/coding-agent/src/web/search/providers/brave.ts
+++ b/packages/coding-agent/src/web/search/providers/brave.ts
@@ -4,7 +4,7 @@
  * Calls Brave's web search REST API and maps results into the unified
  * SearchResponse shape used by the web search tool.
  */
-import { type AuthStorage, type FetchImpl, getEnvApiKey } from "@oh-my-pi/pi-ai";
+import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
 import type { SearchResponse, SearchSource } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import type { QuerySyntax, StructuredQuery } from "../query";
@@ -54,6 +54,8 @@ export interface BraveSearchParams {
 	signal?: AbortSignal;
 	timeoutMs?: number;
 	fetch?: FetchImpl;
+	authStorage: AuthStorage;
+	sessionId?: string;
 }
 
 interface BraveSearchResult {
@@ -70,9 +72,13 @@ interface BraveSearchResponse {
 	};
 }
 
-/** Find BRAVE_API_KEY from environment or .env files. */
-export function findApiKey(): string | null {
-	return getEnvApiKey("brave") ?? null;
+/** Resolve Brave API key through the shared auth storage pipeline. */
+export function findApiKey(
+	authStorage: AuthStorage,
+	sessionId?: string,
+	signal?: AbortSignal,
+): Promise<string | undefined> {
+	return authStorage.getApiKey("brave", sessionId, { signal });
 }
 
 function buildSnippet(result: BraveSearchResult): string | undefined {
@@ -132,9 +138,11 @@ async function callBraveSearch(
 /** Execute Brave web search. */
 export async function searchBrave(params: BraveSearchParams): Promise<SearchResponse> {
 	const numResults = clampNumResults(params.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
-	const apiKey = findApiKey();
+	const apiKey = await findApiKey(params.authStorage, params.sessionId, params.signal);
 	if (!apiKey) {
-		throw new Error("BRAVE_API_KEY not found. Set it in environment or .env file.");
+		throw new Error(
+			"Brave credentials not found. Set BRAVE_API_KEY or login with 'omp /login brave' or 'omp /login' and pick Brave.",
+		);
 	}
 
 	const { response, requestId } = await callBraveSearch(apiKey, params);
@@ -163,8 +171,8 @@ export class BraveProvider extends SearchProvider {
 	readonly id = "brave";
 	readonly label = "Brave";
 
-	isAvailable(_authStorage: AuthStorage): boolean {
-		return !!findApiKey();
+	isAvailable(authStorage: AuthStorage): boolean {
+		return authStorage.hasAuth("brave");
 	}
 
 	search(params: SearchParams): Promise<SearchResponse> {
@@ -176,6 +184,8 @@ export class BraveProvider extends SearchProvider {
 			signal: params.signal,
 			timeoutMs: params.timeoutMs,
 			fetch: params.fetch,
+			authStorage: params.authStorage,
+			sessionId: params.sessionId,
 		});
 	}
 }

--- a/packages/coding-agent/src/web/search/providers/jina.ts
+++ b/packages/coding-agent/src/web/search/providers/jina.ts
@@ -5,7 +5,7 @@
  * cleaned content.
  */
 
-import { type AuthStorage, type FetchImpl, getEnvApiKey } from "@oh-my-pi/pi-ai";
+import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
 import type { SearchResponse, SearchSource } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import { formatQuery, parseSearchQuery } from "../query";
@@ -24,6 +24,8 @@ export interface JinaSearchParams {
 	signal?: AbortSignal;
 	timeoutMs?: number;
 	fetch?: FetchImpl;
+	authStorage: AuthStorage;
+	sessionId?: string;
 }
 
 interface JinaSearchResult {
@@ -34,9 +36,13 @@ interface JinaSearchResult {
 
 type JinaSearchResponse = JinaSearchResult[];
 
-/** Find JINA_API_KEY from environment or .env files. */
-export function findApiKey(): string | null {
-	return getEnvApiKey("jina") ?? null;
+/** Resolve Jina API key through the shared auth storage pipeline. */
+export function findApiKey(
+	authStorage: AuthStorage,
+	sessionId?: string,
+	signal?: AbortSignal,
+): Promise<string | undefined> {
+	return authStorage.getApiKey("jina", sessionId, { signal });
 }
 
 /** Call Jina Reader search API. */
@@ -72,9 +78,11 @@ async function callJinaSearch(
 
 /** Execute Jina web search. */
 export async function searchJina(params: JinaSearchParams): Promise<SearchResponse> {
-	const apiKey = findApiKey();
+	const apiKey = await findApiKey(params.authStorage, params.sessionId, params.signal);
 	if (!apiKey) {
-		throw new Error("JINA_API_KEY not found. Set it in environment or .env file.");
+		throw new Error(
+			"Jina credentials not found. Set JINA_API_KEY or login with 'omp /login jina' or 'omp /login' and pick Jina.",
+		);
 	}
 
 	const response = await callJinaSearch(
@@ -109,8 +117,8 @@ export class JinaProvider extends SearchProvider {
 	readonly id = "jina";
 	readonly label = "Jina";
 
-	isAvailable(_authStorage: AuthStorage): boolean {
-		return !!findApiKey();
+	isAvailable(authStorage: AuthStorage): boolean {
+		return authStorage.hasAuth("jina");
 	}
 
 	search(params: SearchParamsWithFetch): Promise<SearchResponse> {
@@ -139,6 +147,8 @@ export class JinaProvider extends SearchProvider {
 			signal: params.signal,
 			timeoutMs: params.timeoutMs,
 			fetch: params.fetch,
+			authStorage: params.authStorage,
+			sessionId: params.sessionId,
 		});
 	}
 }

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -38,16 +38,21 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	},
 	{ value: "zai", label: "Z.AI", description: "Calls Z.AI webSearchPrime MCP" },
 	{ value: "exa", label: "Exa", description: "API via /login exa or EXA_API_KEY; explicit keyless fallback via MCP" },
-	{ value: "tinyfish", label: "TinyFish", description: "Requires TINYFISH_API_KEY" },
-	{ value: "jina", label: "Jina", description: "Requires JINA_API_KEY" },
-	{ value: "kagi", label: "Kagi", description: "Requires KAGI_API_KEY and Kagi Search API beta access" },
-	{ value: "tavily", label: "Tavily", description: "Requires TAVILY_API_KEY" },
+	{ value: "tinyfish", label: "TinyFish", description: "API via /login tinyfish or TINYFISH_API_KEY" },
+	{ value: "jina", label: "Jina", description: "API via /login jina or JINA_API_KEY" },
+	{
+		value: "kagi",
+		label: "Kagi",
+		description: "API via /login kagi or KAGI_API_KEY (requires Kagi Search API beta access)",
+	},
+	{ value: "tavily", label: "Tavily", description: "API via /login tavily or TAVILY_API_KEY" },
 	{
 		value: "firecrawl",
 		label: "Firecrawl",
-		description: "Uses Firecrawl API when FIRECRAWL_API_KEY is set; falls back to keyless mode",
+		description:
+			"Uses Firecrawl API when configured (via /login firecrawl or FIRECRAWL_API_KEY); falls back to keyless mode",
 	},
-	{ value: "brave", label: "Brave", description: "Requires BRAVE_API_KEY" },
+	{ value: "brave", label: "Brave", description: "API via /login brave or BRAVE_API_KEY" },
 	{
 		value: "kimi",
 		label: "Kimi",

--- a/packages/coding-agent/test/collab/read-only.test.ts
+++ b/packages/coding-agent/test/collab/read-only.test.ts
@@ -146,11 +146,19 @@ async function joinAsGuest(link: string, name: string, writeTokenOverride?: stri
 const guestCleanups: (() => void)[] = [];
 let harness: HostHarness;
 let host: CollabHost;
+/**
+ * Registry instance the host bound at construction. Test registrations MUST
+ * use this exact instance — another test file resets the process-wide
+ * `AgentRegistry.global()` singleton mid-flight, so re-reading the global
+ * here would register the kill target on a registry the host never queries.
+ */
+let registry: AgentRegistry;
 
 beforeAll(async () => {
 	installInMemoryRelay();
 	harness = makeHostContext();
 	host = new CollabHost(harness.ctx);
+	registry = host.registry;
 	// Port is irrelevant: the fake transport routes by the `role` query param.
 	await host.start("ws://localhost:8787");
 });
@@ -220,7 +228,6 @@ describe("collab read-only links", () => {
 		if (welcome.t !== "welcome") throw new Error(`expected welcome, got ${welcome.t}`);
 
 		const id = "Remote-Killed-Sub";
-		const registry = AgentRegistry.global();
 		let aborts = 0;
 		const session = {
 			abort: async () => {

--- a/packages/coding-agent/test/web/search/abort-and-timeout.test.ts
+++ b/packages/coding-agent/test/web/search/abort-and-timeout.test.ts
@@ -155,7 +155,13 @@ describe("Brave provider hard-timeout wiring", () => {
 			});
 		};
 
-		await searchBrave({ query: "ping", fetch: fetchMock });
+		await searchBrave({
+			query: "ping",
+			fetch: fetchMock,
+			authStorage: {
+				getApiKey: async () => "brave-test-key",
+			} as unknown as AuthStorage,
+		});
 
 		expect(capturedSignal).toBeInstanceOf(AbortSignal);
 		expect(capturedSignal?.aborted).toBe(false);

--- a/packages/coding-agent/test/web/search/provider-chain.test.ts
+++ b/packages/coding-agent/test/web/search/provider-chain.test.ts
@@ -1,5 +1,6 @@
+import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it } from "bun:test";
-import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
 import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
 import {
 	resolveProviderCandidates,
@@ -9,7 +10,8 @@ import {
 } from "@oh-my-pi/pi-coding-agent/web/search/provider";
 import { SEARCH_PROVIDER_ORDER } from "@oh-my-pi/pi-coding-agent/web/search/types";
 
-const authStorage = {} as AuthStorage;
+/** Real in-memory storage so `isAvailable`'s `hasAuth` env check behaves authentically. */
+const authStorage = new AuthStorage(new SqliteAuthCredentialStore(new Database(":memory:")));
 const originalBraveApiKey = process.env.BRAVE_API_KEY;
 const originalJinaApiKey = process.env.JINA_API_KEY;
 


### PR DESCRIPTION
## What

Providers that previously only accepted API keys through **manually set environment variables** now ship interactive paste logins via `/login`, so keys can be entered directly in the TUI and stored as login credentials with precedence over the matching env var.

### Model providers (new `login` entries, validated)
- OpenAI (`OPENAI_API_KEY`)
- Google Gemini (`GEMINI_API_KEY`)
- Groq (`GROQ_API_KEY`)
- Mistral (`MISTRAL_API_KEY`)
- MiniMax (`MINIMAX_API_KEY`)
- AIML API (`AIMLAPI_API_KEY`)
- Azure OpenAI (`AZURE_OPENAI_API_KEY`, stored unvalidated — endpoint is user-configured)

### Web search providers (new registry definitions + login)
- Brave, Jina, TinyFish, Firecrawl — previously absent from the `/login` list entirely

Brave and Jina now resolve keys through the shared auth-storage pipeline (`authStorage.getApiKey`) instead of reading `process.env` directly, matching tinyfish/firecrawl; `isAvailable` uses `hasAuth`. `SEARCH_PROVIDER_OPTIONS` descriptions updated to point at `/login`.

## Also fixes two full-suite test failures
- `ai/test/proxy.test.ts` — the provider-proxy memo cache is shared across test files in the same worker; tests now clear it per case
- `collab read-only > keeps a remotely killed subagent tombstoned` — `CollabHost` now binds the `AgentRegistry` + `AgentLifecycleManager` instances at construction instead of re-reading the process-wide singletons per request, so a parallel test file resetting those singletons no longer makes a remote `kill` silently target a different registry instance (5s timeout in the full suite)

## Verification
- `bun check` passes in `packages/ai` and `packages/coding-agent`
- Full suites green: ai **3745 pass / 0 fail**, coding-agent **11807 pass / 0 fail** (both previously had 1 pre-existing failure each)
- New tests: 24 login-wiring tests (`env-key-model-login`, `search-provider-login`) + updated `provider-registry`/`provider-chain`/`abort-and-timeout` tests