### PR TITLE
ci: ran the mnemopi suite in the workspace bucket

### DIFF
--- a/scripts/ci-test-ts.ts
+++ b/scripts/ci-test-ts.ts
@@ -82,9 +82,6 @@ const codingAgentBucketPlans: Record<CodingAgentBucket, { label: string; paralle
 // Smaller workspace packages stay separate from native/TUI/integration suites so
 // their short TS suites can run together. CI still downloads the Linux x64 native
 // addon before this bucket: shared utility barrels may load native-backed modules.
-// mnemopi is intentionally excluded — its embedding suites depend on a ~270MB
-// fastembed model absent from CI runners, so they flake/time out under the parallel
-// bucket; run `bun --cwd=packages/mnemopi test` locally instead.
 const fastWorkspacePackages = [
 	"packages/hashline",
 	"packages/wire",
@@ -94,6 +91,7 @@ const fastWorkspacePackages = [
 	"packages/ai",
 	"packages/snapcompact",
 	"packages/agent",
+	"packages/mnemopi",
 ];
 
 // These suites cover the native package, TUI/browser-ish behavior, local servers,
@@ -107,10 +105,8 @@ const nativeAndIntegrationPackages = [
 ];
 
 // Packages the CI buckets deliberately skip but a local full run should still
-// cover. mnemopi's embedding suites need a ~270MB fastembed model absent from CI
-// runners (so it flakes/times out there); robomp-web lives under python/robomp
-// and is outside every CI TS bucket.
-const localOnlyWorkspacePackages = ["packages/mnemopi", "python/robomp/web"];
+// cover. robomp-web lives under python/robomp and is outside every CI TS bucket.
+const localOnlyWorkspacePackages = ["python/robomp/web"];
 
 const codingAgentNativePathPatterns = [
 	/(^|\/)[^/]*(bash|native|browser|cmux|mnemopi|hindsight|memory)[^/]*\.test\.ts$/i,


### PR DESCRIPTION
## What

Moves `packages/mnemopi` from `localOnlyWorkspacePackages` into `fastWorkspacePackages`, and drops the two comments explaining the exclusion.

## Why

I ran into this on #7084 — mnemopi was failing 72 tests on Windows. Those turned out to be Windows-only, but while checking whether CI would have caught them I found it doesn't run mnemopi at all.

The exclusion says the embedding suites need a ~270MB fastembed model absent from CI runners, so they flake or time out. That no longer describes the suite: the tests that touch embeddings inject a provider through `setEmbeddingProviderForTests`, `fastembed-model-cache.test.ts` mocks `globalThis.fetch`, and nothing reads `FASTEMBED_CACHE_DIR`.

## Testing

WSL, Ubuntu 22.04, no model cached. `~/.hermes/cache` didn't exist before the run or after. 448 tests across 73 files.

Ran the `workspace` bucket seven times: `✓ packages/mnemopi` every time, 5.3-6.3s. Its other failures are the same 12 test names with this change reverted, and wall clock doesn't move (22.3s on `main`, 22.3-23.1s here). `local-ts --dry-run` still lists mnemopi exactly once.

`check:ts` passes; no `check:rs`, no Rust toolchain on that box, and this only touches `scripts/`.

If the flaking was something you saw on the macOS runners, say so and I'll drop this.

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
