### PR TITLE
fix(plugins): resolve createRequire deps in legacy-pi shim

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy Pi extensions failing to install/load in compiled binaries when they resolve a bundled dependency through the `createRequire(base)(spec)` factory form (e.g. `gentle-pi` loading `@heyhuynhgiabuu/pi-pretty`): the shim only rewrote static `require()`/`import` specifiers, so the `createRequire` argument stayed bare and fell through to native `node_modules` resolution, which is unavailable under `--compile`. The load-time rewriter now pins the invoked bare dependency to an absolute path like a plain `require()` ([#7728](https://github.com/can1357/oh-my-pi/issues/7728)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -423,6 +423,26 @@ function isGlobalRequireCall(node: StructuralAstNode | null, scope: BindingScope
 	);
 }
 
+/**
+ * Whether `node` is a `createRequire(...)` factory call — either the bare
+ * `createRequire` identifier (as imported from `node:module`) or a
+ * `<ns>.createRequire(...)` member call. The invoked result is a CommonJS
+ * `require`, so `createRequire(base)(spec)` must be rewritten like a plain
+ * `require(spec)`: a compiled binary cannot resolve runtime `node_modules`
+ * from the returned require (see file header), so the specifier is pinned to
+ * an absolute path at load time. Not shadow-tracked — the legitimate
+ * `import { createRequire }` binds the name, so treating that as a shadow
+ * would defeat the detection.
+ */
+function isCreateRequireInvocation(node: StructuralAstNode | null): boolean {
+	if (node?.type !== "CallExpression") return false;
+	const callee = asAstNode(node.callee);
+	return (
+		isIdentifier(callee, "createRequire") ||
+		(callee?.type === "MemberExpression" && staticMemberPropertyName(callee) === "createRequire")
+	);
+}
+
 function staticMemberPropertyName(node: StructuralAstNode): string | null {
 	const property = asAstNode(node.property);
 	if (node.computed !== true && property?.type === "Identifier" && typeof property.name === "string") {
@@ -478,6 +498,18 @@ function collectExtensionSpecifierReferences(
 				record("import", nodeArgument(node, 0));
 			} else if (isIdentifier(callee, "require") && !scopeHasBinding(scope, REQUIRE_BINDING)) {
 				record("require", nodeArgument(node, 0));
+			} else if (isCreateRequireInvocation(callee)) {
+				// `createRequire(base)(spec)` — pin the invoked bare dependency so it
+				// loads without a runtime `node_modules` lookup. Relative specifiers
+				// resolve against `base`, which is not rewritten, so restrict to bare.
+				const argument = nodeArgument(node, 0);
+				if (
+					argument?.type === "StringLiteral" &&
+					typeof argument.value === "string" &&
+					isBareExtensionDependencySpecifier(argument.value)
+				) {
+					record("require", argument);
+				}
 			}
 		}
 	}

--- a/packages/coding-agent/test/legacy-pi-ast-behavior.test.ts
+++ b/packages/coding-agent/test/legacy-pi-ast-behavior.test.ts
@@ -241,6 +241,24 @@ const rewriteCases: RewriteCase[] = [
 				`require(${JSON.stringify(requirePath)});`,
 			].join("\n"),
 	},
+	{
+		name: "createRequire factory invocation pins its bare dependency, leaving relative and non-createRequire calls alone",
+		source: [
+			'import { createRequire } from "node:module";',
+			'const direct = createRequire(import.meta.url)("tracked-dep");',
+			'const viaModule = module.createRequire("./anchor")("tracked-dep");',
+			'const relative = createRequire(import.meta.url)("./sibling");',
+			'const other = makeRequire(import.meta.url)("tracked-dep");',
+		].join("\n"),
+		expected: (_importPath, requirePath) =>
+			[
+				'import { createRequire } from "node:module";',
+				`const direct = createRequire(import.meta.url)(${JSON.stringify(requirePath)});`,
+				`const viaModule = module.createRequire("./anchor")(${JSON.stringify(requirePath)});`,
+				'const relative = createRequire(import.meta.url)("./sibling");',
+				'const other = makeRequire(import.meta.url)("tracked-dep");',
+			].join("\n"),
+	},
 ];
 
 async function loadCommonJsCase(testCase: CommonJsCase): Promise<{ keys: string[]; named: Record<string, unknown> }> {


### PR DESCRIPTION
## Repro
`omp install npm:gentle-pi@0.14.0` fails extension validation on a compiled omp binary with `ResolveMessage: Cannot find module '@heyhuynhgiabuu/pi-pretty' from '.../node_modules/gentle-pi/package.json'`, and the same plugin cannot load at session start. `gentle-pi`'s `extensions/pi-pretty.ts` loads its dependency through `createRequire(realpathSync('.../package.json'))('@heyhuynhgiabuu/pi-pretty')`; the dependency is installed at `plugins/node_modules/@heyhuynhgiabuu/pi-pretty` and resolves fine under plain `bun`.

Deterministic in-process repro of the omp-side defect: feed the `createRequire(base)(spec)` form to the shim's load-time rewriter (`__rewriteLegacyExtensionSourceForTests`) with the dependency present in a temp `node_modules`. A plain `require('@heyhuynhgiabuu/pi-pretty')` is pinned to the resolved absolute path, but `createRequire(...)('@heyhuynhgiabuu/pi-pretty')` keeps the bare specifier untouched.

## Cause
`collectExtensionSpecifierReferences` in `packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` only recognizes static `import`/`export from`/dynamic `import()`/global `require()`/TS import-equals specifiers. The `createRequire(base)(spec)` factory-call form is invisible to it, so the specifier is never rewritten. At runtime the extension's returned `require` performs a native `node_modules` lookup, which is unavailable in a `--compile` binary (documented at the top of the same file: Bun 1.3.14 stopped exposing filesystem-style resolution for compiled targets) — hence the `ResolveMessage`. Same class as the compiled-binary shim resolution bugs #3442 (fixed via #3446) and #4763.

## Fix
- Added `isCreateRequireInvocation()` to detect `createRequire(...)` factory calls (bare `createRequire` identifier or a `<ns>.createRequire(...)` member call).
- Extended the `CallExpression` branch of `collectExtensionSpecifierReferences` to record the invoked **bare** specifier of a `createRequire(base)(spec)` call as a `require` reference, so the existing resolve/rewrite pipeline pins it to an absolute path (loads directly, no runtime `node_modules` walk).
- Restricted to bare specifiers: relative specifiers resolve against the `createRequire` base, which is not rewritten, so they are intentionally left alone. Not shadow-tracked because the legitimate `import { createRequire }` binds the name.
- Added a changelog entry.

## Verification
`bun test test/legacy-pi-ast-behavior.test.ts` — pass (new regression case covers the inline form, the `module.createRequire(...)` member form, an untouched relative specifier, and an untouched non-`createRequire` factory). Full legacy-pi suites (`bun test test/extensibility/ test/legacy-pi-ast-behavior.test.ts test/issue-1215-legacy-pi-ai-import.test.ts test/issue-6449-legacy-pi-cjs-double-instance.test.ts`) — 177 pass, 0 fail. (These require the generated `src/export/html/tool-views.generated.js` bundle produced by `bun run gen:tool-views`; without it the in-place-load tests fail on a missing generated module, unrelated to this diff.) Fixes #7728