### PR TITLE
feat(omp): load only explicitly trusted extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Added
 
 - Added automatic detection of common Ungoogled Chromium Linux installations for the browser tool.
+- Added turn-aware `/tree` navigation: Alt+Up/Alt+Down traverses previous/next user or assistant turns while skipping tool and bookkeeping entries, Home/End jumps to the first/last visible item, and PageUp/PageDown moves by a visible page.
+- Added `--trusted-extension <absolute-path>` for loading an exact extension-module allowlist without ambient extension discovery.
 
 ### Changed
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -1,6 +1,7 @@
 /**
  * CLI argument parsing and help display
  */
+import * as path from "node:path";
 import { $env, APP_NAME, logger } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import type { ServiceTierOpenAISettingValue } from "../config/service-tier";
@@ -68,6 +69,7 @@ export interface Args {
 	noPty?: boolean;
 	hooks?: string[];
 	extensions?: string[];
+	trustedExtensions?: string[];
 	noExtensions?: boolean;
 	pluginDirs?: string[];
 	print?: boolean;
@@ -110,7 +112,7 @@ const PARSE_DEPS: ParseDeps = {
 	thinkingEfforts: CLI_THINKING_LEVELS,
 };
 
-const WINDOWS_PATH_VALUE_FLAGS: ReadonlySet<string> = new Set(["--extension", "-e", "--hook"]);
+const WINDOWS_PATH_VALUE_FLAGS = new Set(["--extension", "-e", "--hook", "--trusted-extension"]);
 const WINDOWS_PATH_START_RE =
 	/^(?:[A-Za-z]:[\\/]|\\\\[?]\\(?:[A-Za-z]:[\\/]|UNC[\\/])|\\\\[^\\/]+[\\/][^\\/]+[\\/]|\/\/[?]\/(?:[A-Za-z]:\/|UNC\/)|\/\/[^/]+\/[^/]+\/)/;
 const WINDOWS_MODULE_PATH_SUFFIX_RE = /\.(?:[cm]?[jt]sx?)$/i;
@@ -156,6 +158,7 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 	// `--` ends option parsing (POSIX end-of-options). Everything after it is
 	// literal positional text, so flag-shaped messages are not parsed or rejected.
 	let sawSeparator = false;
+	let trustedFlagCount = 0;
 	for (let i = 0; i < args.length; i++) {
 		let arg = args[i];
 		if (sawSeparator) {
@@ -200,6 +203,7 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 				}
 			}
 		} else if (STRING_VALUE_FLAGS.has(arg)) {
+			if (arg === "--trusted-extension") trustedFlagCount++;
 			// Built-in string flags consume the next token even when it is flag-looking
 			// (`--system-prompt --profile foo` ⇒ the prompt is the literal "--profile").
 			// The one token they must never absorb is the profile bootstrap's internal
@@ -301,6 +305,24 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 		// through to a later iteration and become a positional message.
 		if (equalsValueIndex !== -1 && i === flagIndex) {
 			args.splice(equalsValueIndex, 1);
+		}
+	}
+
+	const swallowedTrustedFlag = [...(result.extensions ?? []), ...(result.hooks ?? [])].some(
+		value => value === "--trusted-extension" || value.startsWith("--trusted-extension="),
+	);
+	if ((result.trustedExtensions?.length ?? 0) !== trustedFlagCount || swallowedTrustedFlag) {
+		throw new CliUsageError("--trusted-extension requires a non-empty, non-flag value");
+	}
+	if (trustedFlagCount > 0 && ((result.extensions?.length ?? 0) > 0 || (result.hooks?.length ?? 0) > 0)) {
+		throw new CliUsageError("--trusted-extension cannot be combined with --extension, -e, or --hook");
+	}
+	for (const trustedPath of result.trustedExtensions ?? []) {
+		if (trustedPath.length === 0) {
+			throw new CliUsageError("--trusted-extension requires a non-empty, non-flag value");
+		}
+		if (!path.isAbsolute(trustedPath)) {
+			throw new CliUsageError(`--trusted-extension requires an absolute path: ${trustedPath}`);
 		}
 	}
 

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -220,6 +220,10 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 	},
 	"--extension": setExtension,
 	"-e": setExtension,
+	"--trusted-extension": (result, value) => {
+		result.trustedExtensions = result.trustedExtensions ?? [];
+		result.trustedExtensions.push(value);
+	},
 	"--plugin-dir": (result, value) => {
 		result.pluginDirs = result.pluginDirs ?? [];
 		result.pluginDirs.push(value);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -358,7 +358,7 @@ export interface AcpSessionFactoryOptions {
 	sessionDir?: string;
 	authStorage: AuthStorage;
 	modelRegistry: ModelRegistry;
-	parsedArgs: Pick<Args, "apiKey">;
+	parsedArgs: Pick<Args, "apiKey" | "trustedExtensions">;
 	rawArgs: string[];
 	createSession: (options: CreateAgentSessionOptions) => Promise<CreateAgentSessionResult>;
 }
@@ -385,6 +385,16 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 		// policy (PR #3736 follow-up).
 		const titleSystemPromptSource = discoverTitleSystemPromptFile(cwd);
 		const titleSystemPrompt = await resolvePromptInput(titleSystemPromptSource, "title system prompt");
+		const eventBus = new EventBus();
+		const trustedExtensions =
+			args.parsedArgs.trustedExtensions && args.parsedArgs.trustedExtensions.length > 0
+				? await loadSessionExtensions(args.baseOptions, cwd, nextSettings, eventBus)
+				: undefined;
+		if (trustedExtensions && trustedExtensions.errors.length > 0) {
+			throw new Error(
+				`Trusted extension failed to load: ${trustedExtensions.errors.map(item => item.error).join("; ")}`,
+			);
+		}
 		const { session: nextSession } = await args.createSession({
 			...args.baseOptions,
 			cwd,
@@ -398,6 +408,8 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 			deferUsageReserveConfirmation: true,
 			enableMCP: false,
 			titleSystemPrompt,
+			eventBus,
+			preloadedExtensions: trustedExtensions,
 		});
 		if (args.parsedArgs.apiKey && !args.baseOptions.model && nextSession.model) {
 			args.authStorage.setRuntimeApiKey(nextSession.model.provider, args.parsedArgs.apiKey);
@@ -1114,14 +1126,31 @@ export async function buildSessionOptions(
 		options.rules = [];
 	}
 
-	// Additional extension paths from CLI
-	const cliExtensionPaths = [...(parsed.extensions ?? []), ...(parsed.hooks ?? [])];
-	if (cliExtensionPaths.length > 0) {
-		options.additionalExtensionPaths = cliExtensionPaths;
-	}
-
-	if (parsed.noExtensions) {
+	// Trusted extension paths are an exact allowlist for extension modules.
+	if (parsed.trustedExtensions && parsed.trustedExtensions.length > 0) {
+		for (const trustedPath of parsed.trustedExtensions) {
+			let stat: fsSync.Stats;
+			try {
+				stat = fsSync.statSync(trustedPath);
+			} catch {
+				throw new Error(`Trusted extension must be an existing module file: ${trustedPath}`);
+			}
+			if (!stat.isFile()) {
+				throw new Error(`Trusted extension must be a module file, not a directory: ${trustedPath}`);
+			}
+		}
 		options.disableExtensionDiscovery = true;
+		options.additionalExtensionPaths = parsed.trustedExtensions;
+	} else {
+		// Additional extension paths from CLI
+		const cliExtensionPaths = [...(parsed.extensions ?? []), ...(parsed.hooks ?? [])];
+		if (cliExtensionPaths.length > 0) {
+			options.additionalExtensionPaths = cliExtensionPaths;
+		}
+
+		if (parsed.noExtensions) {
+			options.disableExtensionDiscovery = true;
+		}
 	}
 
 	return options;
@@ -1194,16 +1223,20 @@ export async function runRootCommand(
 	// warning before we reach the await site below.
 	pluginPreloadPromise.catch(() => {});
 
-	// Register CLI-provided extension package paths (`--extension`, `--hook`) so
-	// the `omp-plugins` discovery provider can surface their `skills/`, `hooks/`,
-	// `tools/`, `commands/`, `rules/`, `prompts/`, and `.mcp.json` sub-trees.
-	// Explicit roots remain authorized under `--no-extensions`; only ambient
-	// extension discovery is disabled.
-	const cliExtensions = [...(parsedArgs.extensions ?? []), ...(parsedArgs.hooks ?? [])];
-	injectOmpExtensionCliRoots(cliExtensions, home, getProjectDir(), {
-		mode: parsedArgs.noExtensions ? "explicit-only" : "merge",
-		replace: true,
-	});
+	// Trusted files load as exact module paths, never as package roots whose
+	// sibling hooks/tools/commands/MCP content could be discovered implicitly.
+	if (!parsedArgs.trustedExtensions?.length) {
+		// Register CLI-provided extension package paths (`--extension`, `--hook`) so
+		// the `omp-plugins` discovery provider can surface their `skills/`, `hooks/`,
+		// `tools/`, `commands/`, `rules/`, `prompts/`, and `.mcp.json` sub-trees.
+		// Explicit roots remain authorized under `--no-extensions`; only ambient
+		// extension discovery is disabled.
+		const cliExtensions = [...(parsedArgs.extensions ?? []), ...(parsedArgs.hooks ?? [])];
+		injectOmpExtensionCliRoots(cliExtensions, home, getProjectDir(), {
+			mode: parsedArgs.noExtensions ? "explicit-only" : "merge",
+			replace: true,
+		});
+	}
 
 	let cwd = getProjectDir();
 	// Classify the host before opening auth or settings storage so every
@@ -1542,7 +1575,7 @@ export async function runRootCommand(
 		// string-flag value such as `--target @notes.md` is the flag's value, not a
 		// file — and the same result is handed to createAgentSession via
 		// `preloadedExtensions` so the discovery work is not repeated.
-		if (isInteractive) {
+		if (isInteractive && !parsedArgs.trustedExtensions?.length) {
 			sessionOptions.extensions = [...(sessionOptions.extensions ?? []), createWarpEventBridgeExtension()];
 		}
 
@@ -1556,6 +1589,11 @@ export async function runRootCommand(
 		};
 		const initialArgs = applyExtensionFlags(extensionFlagSink, rawArgs) ?? parsedArgs;
 		normalizeContinueSessionArgs(initialArgs, rawArgs);
+		if ((parsedArgs.trustedExtensions?.length ?? 0) > 0 && extensionsResult.errors.length > 0) {
+			throw new Error(
+				`Trusted extension failed to load: ${extensionsResult.errors.map(item => item.error).join("; ")}`,
+			);
+		}
 		for (const message of formatExtensionLoadNotifications(extensionsResult.errors)) {
 			if (isInteractive) {
 				notifs.push({ kind: "warn", message });

--- a/packages/coding-agent/test/acp-mcp-isolation.test.ts
+++ b/packages/coding-agent/test/acp-mcp-isolation.test.ts
@@ -74,6 +74,90 @@ describe("createAcpSessionFactory MCP isolation (issue #1234)", () => {
 			}
 		}
 	});
+
+	it("shares the trusted extension EventBus with the ACP session", async () => {
+		const tempDir = TempDir.createSync("@pi-acp-trusted-extension-");
+		let authStorage: AuthStorage | undefined;
+		try {
+			authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+			const modelRegistry = new ModelRegistry(authStorage);
+			const settings = Settings.isolated({});
+			const trustedPath = tempDir.join("trusted.ts");
+			await Bun.write(trustedPath, 'export default function (pi) { pi.on("agent_start", async () => {}); }');
+			let captured: CreateAgentSessionOptions | undefined;
+			const fakeSession = {} as AgentSession;
+			const factory = createAcpSessionFactory({
+				baseOptions: {
+					disableExtensionDiscovery: true,
+					additionalExtensionPaths: [trustedPath],
+				} as CreateAgentSessionOptions,
+				settings,
+				sessionDir: tempDir.join("sessions"),
+				authStorage,
+				modelRegistry,
+				parsedArgs: { trustedExtensions: [trustedPath] },
+				rawArgs: [],
+				createSession: async options => {
+					captured = options;
+					return {
+						session: fakeSession,
+						extensionsResult: options.preloadedExtensions,
+						setToolUIContext: () => {},
+						eventBus: options.eventBus,
+					} as CreateAgentSessionResult;
+				},
+			});
+
+			await factory(tempDir.path());
+
+			expect(captured?.eventBus).toBeDefined();
+			expect(captured?.preloadedExtensions?.extensions).toHaveLength(1);
+		} finally {
+			try {
+				authStorage?.close();
+			} finally {
+				await tempDir.remove();
+			}
+		}
+	});
+
+	it("fails before ACP session creation when a trusted extension cannot load", async () => {
+		const tempDir = TempDir.createSync("@pi-acp-trusted-extension-failure-");
+		let authStorage: AuthStorage | undefined;
+		try {
+			authStorage = await AuthStorage.create(tempDir.join("auth.db"));
+			const modelRegistry = new ModelRegistry(authStorage);
+			const settings = Settings.isolated({});
+			const trustedPath = tempDir.join("throwing.ts");
+			await Bun.write(trustedPath, 'throw new Error("trusted extension fixture");');
+			let createCalls = 0;
+			const factory = createAcpSessionFactory({
+				baseOptions: {
+					disableExtensionDiscovery: true,
+					additionalExtensionPaths: [trustedPath],
+				} as CreateAgentSessionOptions,
+				settings,
+				sessionDir: tempDir.join("sessions"),
+				authStorage,
+				modelRegistry,
+				parsedArgs: { trustedExtensions: [trustedPath] },
+				rawArgs: [],
+				createSession: async () => {
+					createCalls++;
+					throw new Error("must not create ACP session");
+				},
+			});
+
+			await expect(factory(tempDir.path())).rejects.toThrow(/Trusted extension failed to load.*fixture/);
+			expect(createCalls).toBe(0);
+		} finally {
+			try {
+				authStorage?.close();
+			} finally {
+				await tempDir.remove();
+			}
+		}
+	});
 });
 
 describe("createAcpSessionFactory TITLE_SYSTEM.md per-cwd resolution (PR #3736)", () => {

--- a/packages/coding-agent/test/cli-explicit-extension-isolation.test.ts
+++ b/packages/coding-agent/test/cli-explicit-extension-isolation.test.ts
@@ -32,3 +32,26 @@ test("buildSessionOptions retains explicit extensions and hooks under --no-exten
 	expect(options.disableExtensionDiscovery).toBe(true);
 	expect(options.additionalExtensionPaths).toEqual([extensionPath, hookPath]);
 });
+
+test("buildSessionOptions uses trusted extensions as the exact module allowlist", async () => {
+	const trustedPath = tempDir.join("trusted.ts");
+	await Bun.write(trustedPath, "export default function () {}");
+	const parsed = parseArgs(["--trusted-extension", trustedPath]);
+	const settings = Settings.isolated();
+	const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+
+	const options = await buildSessionOptions(parsed, [], SessionManager.inMemory(), modelRegistry, settings);
+
+	expect(options.disableExtensionDiscovery).toBe(true);
+	expect(options.additionalExtensionPaths).toEqual([trustedPath]);
+});
+
+test("buildSessionOptions rejects trusted extension directories", async () => {
+	const parsed = parseArgs(["--trusted-extension", tempDir.path()]);
+	const settings = Settings.isolated();
+	const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+
+	await expect(buildSessionOptions(parsed, [], SessionManager.inMemory(), modelRegistry, settings)).rejects.toThrow(
+		/module file, not a directory/,
+	);
+});

--- a/packages/coding-agent/test/cli-extension-path.test.ts
+++ b/packages/coding-agent/test/cli-extension-path.test.ts
@@ -18,3 +18,28 @@ describe("parseArgs — Windows extension paths", () => {
 		expect(parsed.mode).toBe("rpc");
 	});
 });
+
+describe("parseArgs — trusted extension allowlist", () => {
+	it("accepts repeatable native absolute paths", () => {
+		const parsed = parseArgs(["--trusted-extension", "/opt/omp/policy.ts", "--trusted-extension=/opt/omp/audit.ts"]);
+
+		expect(parsed.trustedExtensions).toEqual(["/opt/omp/policy.ts", "/opt/omp/audit.ts"]);
+	});
+
+	it("ignores trusted-looking tokens outside trusted flag dispatch", () => {
+		expect(parseArgs(["--", "--trusted-extension"]).messages).toEqual(["--trusted-extension"]);
+		expect(parseArgs(["--system-prompt", "--trusted-extension"]).systemPrompt).toBe("--trusted-extension");
+	});
+
+	it("fails closed on missing, relative, swallowed, or mixed values", () => {
+		expect(() => parseArgs(["--trusted-extension"])).toThrow(/requires a non-empty/);
+		expect(() => parseArgs(["--trusted-extension="])).toThrow(/requires a non-empty/);
+		expect(() => parseArgs(["--trusted-extension", "relative.ts"])).toThrow(/absolute path/);
+		expect(() => parseArgs(["--extension", "--trusted-extension", "/opt/omp/policy.ts"])).toThrow(
+			/requires a non-empty/,
+		);
+		expect(() => parseArgs(["--trusted-extension", "/opt/omp/policy.ts", "--hook", "/tmp/hook.ts"])).toThrow(
+			/cannot be combined/,
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- add repeatable `--trusted-extension <absolute-path>` for an exact root-session extension-module allowlist
- disable ambient extension-module discovery and avoid treating trusted files as plugin package roots
- reject malformed, relative, missing, directory, or mixed trusted/ordinary extension arguments and fail closed when an allowed module cannot load

## Screenshots
No visual change.

## Testing
- `bun run check:types`
- `bun test test/cli-extension-path.test.ts test/cli-explicit-extension-isolation.test.ts test/acp-mcp-isolation.test.ts` — 11 pass, 0 fail
- `bunx biome check src/cli/args.ts src/cli/flag-tables.ts src/main.ts test/cli-extension-path.test.ts test/cli-explicit-extension-isolation.test.ts test/acp-mcp-isolation.test.ts`
- smoke-tested an existing but throwing trusted extension; startup exited before session creation

## Risk
- Low and opt-in: existing extension behavior is unchanged unless `--trusted-extension` is supplied.
- This is an extension-module loading primitive, not a sandbox. It does not constrain tools, MCP, LSP/DAP, commands, child sessions, or code imported by an explicitly trusted module.

## Notes
- Trusted paths must be native absolute paths to existing module files; directories are rejected.
- Ordinary `--extension`, `-e`, and `--hook` inputs cannot be mixed with the trusted allowlist.

## AI Review Report
- Independent review identified and verified fixes for ACP EventBus identity, parser false positives, and directory expansion beyond the exact module allowlist.
- Added coverage for exact session options, ACP EventBus sharing, fail-closed ACP loading, directory rejection, and parser separator/value handling.
- Final focused rereview found no remaining blocker/high/medium finding within the intentionally narrow extension-module contract.

## Security Audit
- Independent security audit approved the narrow primitive with no blocker/high findings.
- Explicit limitation: allowed modules execute in-process with host authority and may import other code; this change is not a security sandbox.