### PR TITLE
docs(coding-agent): clarify js-debug-adapter install is not an npm package

### DIFF
--- a/docs/tools/debug.md
+++ b/docs/tools/debug.md
@@ -330,7 +330,16 @@ Example `.omp/dap.json`:
 
 ## Notes
 - `packages/coding-agent/src/prompts/tools/debug.md` tells the model only one active root session is supported. Adapter-requested child sessions belong to that root tree.
-- The default JavaScript/TypeScript adapter runs vscode-js-debug’s `dapDebugServer.js` over TCP. Install it with Mason or set `JS_DEBUG_DAP_SERVER` to a release-tarball server path.
+- The default JavaScript/TypeScript adapter runs vscode-js-debug's `dapDebugServer.js` over TCP. It is **not** an npm package — `npm i -g js-debug-adapter` 404s (`js-debug-adapter` is the omp adapter id, not an installable package). Install `dapDebugServer.js` (requires `node` on `PATH`) one of these ways; the first two are auto-discovered by `resolveJsDebugServerPath()` in `packages/coding-agent/src/dap/config.ts`:
+  - Mason (`:MasonInstall js-debug-adapter`) → discovered at `~/.local/share/nvim/mason/packages/js-debug-adapter/js-debug/src/dapDebugServer.js`.
+  - Standalone release tarball, extracted so `dapDebugServer.js` lands at `~/.local/opt/js-debug/src/dapDebugServer.js`:
+    ```sh
+    curl -sL -o js-debug-dap.tar.gz \
+      https://github.com/microsoft/vscode-js-debug/releases/download/v1.117.0/js-debug-dap-v1.117.0.tar.gz
+    mkdir -p ~/.local/opt && tar -xzf js-debug-dap.tar.gz -C ~/.local/opt
+    ```
+    Replace `v1.117.0` with the latest tag from the [releases page](https://github.com/microsoft/vscode-js-debug/releases).
+  - Any other location via `JS_DEBUG_DAP_SERVER=<path-to-dapDebugServer.js>`.
 - `configurationDone` is sent automatically during root and child launch/attach handshakes and lazily before later requests if the initial handshake did not complete.
 - `startDebugging` reverse requests create recursive child sessions on the same TCP server; a stopped child becomes the target for thread-level actions.
 - `output` exposes the active session’s merged `output` event stream only; the tool does not distinguish stdout, stderr, and console categories.

--- a/docs/tools/debug.md
+++ b/docs/tools/debug.md
@@ -330,7 +330,7 @@ Example `.omp/dap.json`:
 
 ## Notes
 - `packages/coding-agent/src/prompts/tools/debug.md` tells the model only one active root session is supported. Adapter-requested child sessions belong to that root tree.
-- The default JavaScript/TypeScript adapter runs vscode-js-debug's `dapDebugServer.js` over TCP. It is **not** an npm package — `npm i -g js-debug-adapter` 404s (`js-debug-adapter` is the omp adapter id, not an installable package). Install `dapDebugServer.js` (requires `node` on `PATH`) one of these ways; the first two are auto-discovered by `resolveJsDebugServerPath()` in `packages/coding-agent/src/dap/config.ts`:
+- The default JavaScript/TypeScript adapter runs vscode-js-debug's `dapDebugServer.js` over TCP. It is **not** an npm package — `npm i -g js-debug-adapter` 404s (`js-debug-adapter` is the omp adapter id, not an installable package). Install `dapDebugServer.js` one of these ways; the first two are auto-discovered by `resolveJsDebugServerPath()` in `packages/coding-agent/src/dap/config.ts`:
   - Mason (`:MasonInstall js-debug-adapter`) → discovered at `~/.local/share/nvim/mason/packages/js-debug-adapter/js-debug/src/dapDebugServer.js`.
   - Standalone release tarball, extracted so `dapDebugServer.js` lands at `~/.local/opt/js-debug/src/dapDebugServer.js`:
     ```sh
@@ -340,6 +340,7 @@ Example `.omp/dap.json`:
     ```
     Replace `v1.117.0` with the latest tag from the [releases page](https://github.com/microsoft/vscode-js-debug/releases).
   - Any other location via `JS_DEBUG_DAP_SERVER=<path-to-dapDebugServer.js>`.
+- The adapter runs under `node` if on `PATH`, otherwise under the omp host (Bun); `resolveDefaultJsDebugAdapter()` falls back to `process.execPath`, so a Bun-only setup is supported.
 - `configurationDone` is sent automatically during root and child launch/attach handshakes and lazily before later requests if the initial handshake did not complete.
 - `startDebugging` reverse requests create recursive child sessions on the same TCP server; a stopped child becomes the target for thread-level actions.
 - `output` exposes the active session’s merged `output` event stream only; the tool does not distinguish stdout, stderr, and console categories.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Clarified the JavaScript/TypeScript debug adapter install path: `js-debug-adapter` is the omp adapter id, not an npm package, so `npm i -g js-debug-adapter` 404s. The docs and the "adapter not available" message now point to the supported installs — Mason, the standalone release tarball extracted to `~/.local/opt/js-debug/` (auto-discovered), or `JS_DEBUG_DAP_SERVER` ([#7757](https://github.com/can1357/oh-my-pi/issues/7757)).
+- Clarified the JavaScript/TypeScript debug adapter install path: `js-debug-adapter` is the omp adapter id, not an npm package, so `npm i -g js-debug-adapter` 404s. The docs and the "adapter not available" message now point to the supported installs — Mason, the standalone release tarball extracted under `~/.local/opt` (auto-discovered), or `JS_DEBUG_DAP_SERVER`. The docs also note the adapter runs under `node` if available, else the omp Bun host ([#7757](https://github.com/can1357/oh-my-pi/issues/7757)).
 
 ## [17.2.9] - 2026-08-05
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Clarified the JavaScript/TypeScript debug adapter install path: `js-debug-adapter` is the omp adapter id, not an npm package, so `npm i -g js-debug-adapter` 404s. The docs and the "adapter not available" message now point to the supported installs — Mason, the standalone release tarball extracted to `~/.local/opt/js-debug/` (auto-discovered), or `JS_DEBUG_DAP_SERVER` ([#7757](https://github.com/can1357/oh-my-pi/issues/7757)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/debug.ts
+++ b/packages/coding-agent/src/tools/debug.ts
@@ -505,7 +505,7 @@ const ADAPTER_UNAVAILABLE_MESSAGES: Readonly<Record<string, string>> = {
 	dlv: "adapter 'dlv' is not available: install with 'go install github.com/go-delve/delve/cmd/dlv@latest'",
 	rdbg: "adapter 'rdbg' is not available: install with 'gem install debug'",
 	"js-debug-adapter":
-		"adapter 'js-debug-adapter' is not available: install vscode-js-debug with Mason or set JS_DEBUG_DAP_SERVER to dapDebugServer.js",
+		"adapter 'js-debug-adapter' is not available: vscode-js-debug is not an npm package — install via Mason (`:MasonInstall js-debug-adapter`), extract the release tarball (https://github.com/microsoft/vscode-js-debug/releases) to ~/.local/opt/js-debug/, or set JS_DEBUG_DAP_SERVER to dapDebugServer.js",
 };
 
 const ADAPTER_CANONICAL_COMMANDS: Readonly<Record<string, string>> = {

--- a/packages/coding-agent/src/tools/debug.ts
+++ b/packages/coding-agent/src/tools/debug.ts
@@ -505,7 +505,7 @@ const ADAPTER_UNAVAILABLE_MESSAGES: Readonly<Record<string, string>> = {
 	dlv: "adapter 'dlv' is not available: install with 'go install github.com/go-delve/delve/cmd/dlv@latest'",
 	rdbg: "adapter 'rdbg' is not available: install with 'gem install debug'",
 	"js-debug-adapter":
-		"adapter 'js-debug-adapter' is not available: vscode-js-debug is not an npm package — install via Mason (`:MasonInstall js-debug-adapter`), extract the release tarball (https://github.com/microsoft/vscode-js-debug/releases) to ~/.local/opt/js-debug/, or set JS_DEBUG_DAP_SERVER to dapDebugServer.js",
+		"adapter 'js-debug-adapter' is not available: vscode-js-debug is not an npm package — install via Mason (`:MasonInstall js-debug-adapter`), extract the release tarball (https://github.com/microsoft/vscode-js-debug/releases) under ~/.local/opt, or set JS_DEBUG_DAP_SERVER to dapDebugServer.js",
 };
 
 const ADAPTER_CANONICAL_COMMANDS: Readonly<Record<string, string>> = {


### PR DESCRIPTION
## What & why

Issue #7757 reports that `omp.sh/docs/debugging` tells users to `npm i -g js-debug-adapter`, which 404s — `js-debug-adapter` is omp's adapter _id_, not an npm package. That broken copy lives on the website (a closed-source SPA, not tracked in this repo), so the issue is wontfix for the page itself.

But the in-tree surfaces were thin enough to steer people toward the same dead end: the "js-debug-adapter not available" error and `docs/tools/debug.md` only mentioned Mason + `JS_DEBUG_DAP_SERVER`, never the standalone release tarball — even though `resolveJsDebugServerPath()` (`packages/coding-agent/src/dap/config.ts`) already auto-discovers `~/.local/opt/js-debug/src/dapDebugServer.js`. This PR surfaces the real install path in both places.

I reviewed the full diff; this makes the working js-debug install method discoverable in the shipped docs and the adapter-unavailable message, and explicitly calls out that `npm i -g js-debug-adapter` is not a real package.

## Changes
- `packages/coding-agent/src/tools/debug.ts` — the `js-debug-adapter` unavailable message now states vscode-js-debug is **not** an npm package and lists Mason / release-tarball / `JS_DEBUG_DAP_SERVER`.
- `docs/tools/debug.md` — replaced the one-line install note with the three supported installs, including copy-paste tarball commands that land on the auto-discovered path.
- `packages/coding-agent/CHANGELOG.md` — `[Unreleased] → Changed` entry.

## Verification
- `npm`: `GET https://registry.npmjs.org/js-debug-adapter` → **404** (package doesn't exist).
- Downloaded the real `js-debug-dap-v1.117.0.tar.gz`; top-level dir is `js-debug/` containing `src/dapDebugServer.js`, so `tar -xzf ... -C ~/.local/opt` lands exactly at the `config.ts` search path (`~/.local/opt/js-debug/src/dapDebugServer.js`).
- `bunx biome check` on all three changed files → exit 0.
- `tsgo -p tsconfig.json --noEmit` on `packages/coding-agent` → exit 0.

Refs #7757. The broken website copy itself remains out of scope for this repo.
