### PR TITLE
fix(tree): recompute connectors against the visible tree

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed session tree connectors being computed from the unfiltered tree, so hiding a branch head via filter or search left dangling connectors and orphan gutters beside the nodes that survived, in both the TUI tree selector and the HTML export.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/export/html/template.js
+++ b/packages/coding-agent/src/export/html/template.js
@@ -410,6 +410,74 @@
         });
       }
 
+      /**
+       * Contract hidden nodes out of the displayed tree and recompute connector
+       * metadata against the visible ancestry. Keeping metadata from the full tree
+       * leaves orphan gutters when a branch head is filtered out.
+       */
+      function projectFilteredNodes(flatNodes, visibleNodes) {
+        const visibleIds = new Set(visibleNodes.map(flatNode => flatNode.node.entry.id));
+        const projectedById = new Map();
+        const nearestVisibleById = new Map();
+        const roots = [];
+
+        // flatNodes is pre-order, so the nearest visible ancestor of each
+        // parent is already known when its children are visited.
+        for (const flatNode of flatNodes) {
+          const id = flatNode.node.entry.id;
+          const parentId = flatNode.node.entry.parentId;
+          const visibleParentId = parentId ? nearestVisibleById.get(parentId) : undefined;
+          if (!visibleIds.has(id)) {
+            if (visibleParentId) nearestVisibleById.set(id, visibleParentId);
+            continue;
+          }
+
+          const projected = { flatNode, children: [] };
+          projectedById.set(id, projected);
+          const parent = visibleParentId ? projectedById.get(visibleParentId) : undefined;
+          if (parent) {
+            parent.children.push(projected);
+          } else {
+            roots.push(projected);
+          }
+          nearestVisibleById.set(id, id);
+        }
+
+        const result = [];
+        const multipleRoots = roots.length > 1;
+        const stack = [];
+        for (let i = roots.length - 1; i >= 0; i--) {
+          stack.push([roots[i], multipleRoots ? 1 : 0, multipleRoots, multipleRoots, i === roots.length - 1, [], multipleRoots]);
+        }
+
+        while (stack.length > 0) {
+          const [projected, indent, justBranched, showConnector, isLast, gutters, isVirtualRootChild] = stack.pop();
+          result.push({ ...projected.flatNode, indent, showConnector, isLast, gutters, isVirtualRootChild, multipleRoots });
+
+          const multipleChildren = projected.children.length > 1;
+          const childIndent = multipleChildren || (justBranched && indent > 0) ? indent + 1 : indent;
+          const connectorDisplayed = showConnector && !isVirtualRootChild;
+          const displayIndent = multipleRoots ? Math.max(0, indent - 1) : indent;
+          const childGutters = connectorDisplayed
+            ? [...gutters, { position: Math.max(0, displayIndent - 1), show: !isLast }]
+            : gutters;
+
+          for (let i = projected.children.length - 1; i >= 0; i--) {
+            stack.push([
+              projected.children[i],
+              childIndent,
+              multipleChildren,
+              multipleChildren,
+              i === projected.children.length - 1,
+              childGutters,
+              false
+            ]);
+          }
+        }
+
+        return result;
+      }
+
       // ============================================================
       // TREE DISPLAY TEXT (pure data -> string)
       // ============================================================
@@ -572,7 +640,7 @@
         const tree = buildTree();
         const activePathIds = buildActivePathIds(currentLeafId);
         const flatNodes = flattenTree(tree, activePathIds);
-        const filtered = filterNodes(flatNodes, currentLeafId);
+        const filtered = projectFilteredNodes(flatNodes, filterNodes(flatNodes, currentLeafId));
         const container = document.getElementById('tree-container');
 
         // Full render only on first call or when filter/search changes

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -146,9 +146,9 @@ class TreeList implements Component {
 		return this.#filteredNodes.length - 1;
 	}
 
-	#flattenTree(roots: SessionTreeNode[]): FlatNode[] {
+	#flattenTree(roots: SessionTreeNode[], collectToolCalls = true): FlatNode[] {
 		const result: FlatNode[] = [];
-		this.#toolCallMap.clear();
+		if (collectToolCalls) this.#toolCallMap.clear();
 
 		// A real branch point adds one indentation level. Linear conversation
 		// chains retain that level so their text stays aligned with the branch
@@ -201,7 +201,7 @@ class TreeList implements Component {
 
 			// Extract tool calls from assistant messages for later lookup
 			const entry = node.entry;
-			if (entry.type === "message" && entry.message.role === "assistant") {
+			if (collectToolCalls && entry.type === "message" && entry.message.role === "assistant") {
 				const content = (entry.message as { content?: unknown }).content;
 				if (Array.isArray(content)) {
 					for (const block of content) {
@@ -243,7 +243,7 @@ class TreeList implements Component {
 			const connectorDisplayed = showConnector && !isVirtualRootChild;
 			// When connector is displayed, add a gutter entry at the connector's position
 			// Connector is at position (displayIndent - 1), so gutter should be there too
-			const currentDisplayIndent = this.#multipleRoots ? Math.max(0, indent - 1) : indent;
+			const currentDisplayIndent = multipleRoots ? Math.max(0, indent - 1) : indent;
 			const connectorPosition = Math.max(0, currentDisplayIndent - 1);
 			const childGutters: GutterInfo[] = connectorDisplayed
 				? [...gutters, { position: connectorPosition, show: !isLast }]
@@ -259,6 +259,50 @@ class TreeList implements Component {
 		return result;
 	}
 
+	/**
+	 * Contract hidden nodes out of the displayed tree and recompute connector
+	 * metadata against the visible ancestry. Keeping metadata from the full tree
+	 * leaves orphan gutters when a branch head is filtered out.
+	 *
+	 * The contracted tree is laid out by {@link #flattenTree} rather than a
+	 * second walk, so filtered rows and unfiltered ones can never disagree about
+	 * indentation, branch ordering or gutters.
+	 */
+	#projectFilteredNodes(visibleNodes: FlatNode[]): FlatNode[] {
+		const visibleIds = new Set(visibleNodes.map(flatNode => flatNode.node.entry.id));
+		const contractedById = new Map<string, SessionTreeNode>();
+		const nearestVisibleById = new Map<string, string>();
+		const roots: SessionTreeNode[] = [];
+
+		// #flatNodes is pre-order, so the nearest visible ancestor of each
+		// parent is already known when its children are visited.
+		for (const flatNode of this.#flatNodes) {
+			const id = flatNode.node.entry.id;
+			const parentId = flatNode.node.entry.parentId;
+			const visibleParentId = parentId ? nearestVisibleById.get(parentId) : undefined;
+			if (!visibleIds.has(id)) {
+				if (visibleParentId) nearestVisibleById.set(id, visibleParentId);
+				continue;
+			}
+
+			// A copy, because the children we hand the layout are the visible ones.
+			const contracted: SessionTreeNode = { ...flatNode.node, children: [] };
+			contractedById.set(id, contracted);
+			const parent = visibleParentId ? contractedById.get(visibleParentId) : undefined;
+			if (parent) {
+				parent.children.push(contracted);
+			} else {
+				roots.push(contracted);
+			}
+			nearestVisibleById.set(id, id);
+		}
+
+		this.#multipleRoots = roots.length > 1;
+		// Tool calls stay indexed off the full tree: a visible tool result can
+		// belong to a call on a row the filter hid.
+		return this.#flattenTree(roots, false);
+	}
+
 	#applyFilter(): void {
 		// Update lastSelectedId only when we have a valid selection (non-empty list)
 		// This preserves the selection when switching through empty filter results
@@ -268,7 +312,7 @@ class TreeList implements Component {
 
 		const searchTokens = this.#searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
 
-		this.#filteredNodes = this.#flatNodes.filter(flatNode => {
+		const visibleNodes = this.#flatNodes.filter(flatNode => {
 			const entry = flatNode.node.entry;
 			const isCurrentLeaf = entry.id === this.currentLeafId;
 
@@ -326,6 +370,7 @@ class TreeList implements Component {
 
 			return true;
 		});
+		this.#filteredNodes = this.#projectFilteredNodes(visibleNodes);
 
 		// Try to preserve cursor on the same node, or find nearest visible ancestor
 		if (this.#lastSelectedId) {

--- a/packages/coding-agent/test/export-html-template.test.ts
+++ b/packages/coding-agent/test/export-html-template.test.ts
@@ -19,9 +19,9 @@ interface TemplateProbeResult {
 }
 
 const expectedTemplate: TemplateProbeResult = {
-	chars: 376_316,
-	bytes: 376_472,
-	sha256: "72721b125d8eaa0e995ef0b77e01cf561c9a76e36e745510b19734def07936e0",
+	chars: 379_228,
+	bytes: 379_384,
+	sha256: "8bdef12f18214d9ae977a3246479f07f3780464faf28c0959a31c5351c5aeb3e",
 	stableCache: true,
 	assetsRemoved: 0,
 };

--- a/packages/coding-agent/test/export-html-tree-connectors.test.ts
+++ b/packages/coding-agent/test/export-html-tree-connectors.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "bun:test";
+import * as vm from "node:vm";
+import { parseHTML } from "linkedom";
+import { Marked } from "marked";
+
+const [templateHtml, templateJs] = await Promise.all([
+	Bun.file(new URL("../src/export/html/template.html", import.meta.url)).text(),
+	Bun.file(new URL("../src/export/html/template.js", import.meta.url)).text(),
+]);
+
+/** Minimal shape of the linkedom elements this test reads; linkedom's query results are untyped. */
+type TreeNodeElement = {
+	getAttribute(name: string): string | null;
+	querySelector(selector: string): { textContent: string | null } | null;
+};
+
+function renderTreePrefixes(entries: unknown[], leafId: string): Map<string, string> {
+	const { document, window } = parseHTML(templateHtml);
+	const session = {
+		header: {
+			type: "session",
+			version: 3,
+			id: "filtered-connectors",
+			timestamp: "2026-01-01T00:00:00.000Z",
+			cwd: "/tmp",
+		},
+		entries,
+		leafId,
+	};
+	const sessionData = document.getElementById("session-data");
+	if (!sessionData) throw new Error("Export template is missing session data");
+	sessionData.textContent = Buffer.from(JSON.stringify(session)).toBase64();
+	Object.defineProperty(window, "location", {
+		value: new URL("https://example.test/export.html"),
+		configurable: true,
+	});
+	Object.defineProperty(window, "matchMedia", {
+		value: () => ({ matches: false, addEventListener() {}, removeEventListener() {} }),
+		configurable: true,
+	});
+	// linkedom's HTMLSelectElement.value is getter-only; template.js assigns it
+	// under 'use strict', which would throw. Shim a writable value like a browser.
+	const themeSelect = document.getElementById("theme-select");
+	if (themeSelect) {
+		let themeValue = "auto";
+		Object.defineProperty(themeSelect, "value", {
+			get: () => themeValue,
+			set: next => {
+				themeValue = String(next);
+			},
+			configurable: true,
+		});
+	}
+	vm.runInContext(
+		templateJs,
+		vm.createContext({
+			window,
+			document,
+			marked: new Marked(),
+			hljs: {
+				getLanguage: () => false,
+				highlight: () => ({ value: "" }),
+				highlightAuto: () => ({ value: "" }),
+			},
+			URL,
+			URLSearchParams,
+			TextDecoder,
+			Uint8Array,
+			atob,
+			navigator: { clipboard: null },
+			localStorage: { getItem: () => null, setItem() {} },
+			setTimeout: () => 0,
+			clearTimeout() {},
+		}),
+	);
+
+	return new Map(
+		(Array.from(document.querySelectorAll(".tree-node")) as TreeNodeElement[]).map(node => [
+			node.getAttribute("data-id") ?? "",
+			node.querySelector(".tree-prefix")?.textContent ?? "",
+		]),
+	);
+}
+
+function assistantEntry(id: string, parentId: string | null, text: string, stopReason: "stop" | "aborted") {
+	return {
+		type: "message",
+		id,
+		parentId,
+		timestamp: "2026-01-01T00:00:00.000Z",
+		message: {
+			role: "assistant",
+			content: text ? [{ type: "text", text }] : [],
+			stopReason,
+			timestamp: 0,
+		},
+	};
+}
+
+describe("HTML export filtered tree connectors", () => {
+	it("projects hidden branch heads before drawing visible sibling connectors", () => {
+		const entries = [
+			assistantEntry("root", null, "common parent", "stop"),
+			{
+				type: "message",
+				id: "side",
+				parentId: "root",
+				timestamp: "2026-01-01T00:00:02.000Z",
+				message: {
+					role: "toolResult",
+					toolCallId: "side-call",
+					toolName: "hub",
+					content: [{ type: "text", text: "side branch" }],
+					isError: false,
+					timestamp: 0,
+				},
+			},
+			{
+				type: "model_change",
+				id: "active-head",
+				parentId: "root",
+				timestamp: "2026-01-01T00:00:03.000Z",
+				model: "fixture/model",
+				role: "temporary",
+			},
+			assistantEntry("aborted", "active-head", "", "aborted"),
+		];
+
+		const prefixes = renderTreePrefixes(entries, "aborted");
+		expect(prefixes.get("active-head")).toBeUndefined();
+		expect(prefixes.get("aborted")).toBe("├─ ");
+		expect(prefixes.get("side")).toBe("└─ ");
+	});
+});

--- a/packages/coding-agent/test/modes/components/tree-selector-filtered-connector.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-filtered-connector.test.ts
@@ -1,0 +1,82 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
+import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SessionEntry, SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+
+function messageNode(
+	id: string,
+	parentId: string | null,
+	role: "assistant" | "toolResult",
+	options: { text?: string; stopReason?: "stop" | "aborted" } = {},
+): SessionTreeNode {
+	const message: AgentMessage =
+		role === "assistant"
+			? ({
+					role,
+					content: options.text ? [{ type: "text", text: options.text }] : [],
+					timestamp: 0,
+					stopReason: options.stopReason ?? "stop",
+				} as AgentMessage)
+			: ({
+					role,
+					toolCallId: `${id}-call`,
+					toolName: "hub",
+					content: [{ type: "text", text: options.text ?? "side branch" }],
+					isError: false,
+					timestamp: 0,
+				} as AgentMessage);
+	return {
+		entry: {
+			type: "message",
+			id,
+			parentId,
+			timestamp: "2026-01-01T00:00:00.000Z",
+			message,
+		},
+		children: [],
+	};
+}
+
+function modelChangeNode(id: string, parentId: string): SessionTreeNode {
+	const entry: SessionEntry = {
+		type: "model_change",
+		id,
+		parentId,
+		timestamp: "2026-01-01T00:00:00.000Z",
+		model: "fixture/model",
+		role: "temporary",
+	};
+	return { entry, children: [] };
+}
+
+describe("filtered tree connector projection", () => {
+	beforeAll(async () => {
+		await themeModule.initTheme(false, undefined, undefined, "dark", "light");
+	});
+
+	it("promotes a visible aborted descendant when its active branch head is hidden", () => {
+		const root = messageNode("root", null, "assistant", { text: "common parent" });
+		const sideBranch = messageNode("side", root.entry.id, "toolResult");
+		const hiddenActiveHead = modelChangeNode("active-head", root.entry.id);
+		const aborted = messageNode("aborted", hiddenActiveHead.entry.id, "assistant", { stopReason: "aborted" });
+		root.children.push(sideBranch, hiddenActiveHead);
+		hiddenActiveHead.children.push(aborted);
+
+		const selector = new TreeSelectorComponent(
+			[root],
+			aborted.entry.id,
+			20,
+			() => {},
+			() => {},
+		);
+		const rows = selector.render(120).map(line => Bun.stripANSI(line));
+		const abortedRow = rows.find(line => line.includes("assistant: Operation aborted"));
+		const sideRow = rows.find(line => line.includes("[hub]"));
+		if (!abortedRow || !sideRow) throw new Error("Expected both visible branches to render");
+
+		expect(abortedRow.slice(2)).toMatch(/^├─ /);
+		expect(sideRow.slice(2)).toMatch(/^└─ /);
+		expect(abortedRow.slice(2)).not.toMatch(/^│/);
+	});
+});


### PR DESCRIPTION
Filtering or searching the session tree hid nodes but kept each surviving node's connector metadata (depth, gutters, last-child flags) from the *unfiltered* tree, so hiding a branch head left dangling connectors and orphan gutters beside the rows that remained. Same bug in both render paths: the TUI `/tree` selector and the HTML export sidebar.

The fix contracts the hidden nodes out — reparenting each visible node onto its nearest visible ancestor — and lays the contracted tree out with the *existing* `#flattenTree`, so filtered and unfiltered rows can never disagree about indentation, branch ordering or gutters. Tool calls stay indexed off the full tree, since a visible tool result can belong to a call on a row the filter hid.

Tests: `test/modes/components/tree-selector-filtered-connector.test.ts` (TUI) and `test/export-html-tree-connectors.test.ts` (export). The existing #7332 gutter/indent tests pass unchanged.