### PR TITLE
feat(export): collapse conversation branches in the HTML export

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added collapsible branches to the HTML export's session tree: every node with children gets a ▾/▸ toggle that folds its subtree, alongside the existing active-path bullet.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1410,6 +1410,9 @@
 - Fixed parsing of POSIX `$EDITOR` commands that contain quoted arguments or executable paths with spaces.
 - Fixed persisted Agent Hub rows losing the explicit caller model role when a subagent used a model override, preserving role provenance across restarts.
 - Fixed unobserved promise rejections in browser helpers (such as `tab.waitForResponse()`) causing tab workers to hang or crash.
+### Added
+
+- Added collapsible branches to the HTML export's session tree: every node with children gets a ▾/▸ toggle that folds its subtree, alongside the existing active-path bullet.
 
 ## [17.2.9] - 2026-08-05
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added accessible collapse controls to the HTML export’s session tree for folding branches with visible descendants.
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed
@@ -1410,9 +1414,6 @@
 - Fixed parsing of POSIX `$EDITOR` commands that contain quoted arguments or executable paths with spaces.
 - Fixed persisted Agent Hub rows losing the explicit caller model role when a subagent used a model override, preserving role provenance across restarts.
 - Fixed unobserved promise rejections in browser helpers (such as `tab.waitForResponse()`) causing tab workers to hang or crash.
-### Added
-
-- Added collapsible branches to the HTML export's session tree: every node with children gets a ▾/▸ toggle that folds its subtree, alongside the existing active-path bullet.
 
 ## [17.2.9] - 2026-08-05
 

--- a/packages/coding-agent/src/export/html/template.css
+++ b/packages/coding-agent/src/export/html/template.css
@@ -274,6 +274,28 @@
       flex-shrink: 0;
     }
 
+    .tree-collapse {
+      background: none;
+      border: none;
+      color: var(--muted);
+      cursor: pointer;
+      flex-shrink: 0;
+      font: inherit;
+      line-height: 1;
+      padding: 0 0.15rem;
+      width: 1.1em;
+    }
+
+    .tree-collapse:hover {
+      color: var(--accent);
+    }
+
+    /* Childless rows keep the column so the content stays aligned. */
+    .tree-collapse.empty {
+      cursor: default;
+      visibility: hidden;
+    }
+
     .tree-content {
       color: var(--text);
     }

--- a/packages/coding-agent/src/export/html/template.js
+++ b/packages/coding-agent/src/export/html/template.js
@@ -704,12 +704,40 @@
       let currentTargetId = urlTargetId || leafId;
       let currentTargetAnchorId = null;
       let treeRendered = false;
+      const collapsedNodeIds = new Set();
+
+      /**
+       * Drop descendants of collapsed nodes. flatNodes is pre-order, so a node's
+       * parent is always classified before the node itself — one pass, no
+       * per-node ancestor walk (that would be quadratic on deep chains).
+       *
+       * Connector prefixes are left as the layout computed them, so a folded
+       * subtree hides exactly the way a filtered one does.
+       */
+      function hideCollapsedDescendants(flatNodes) {
+        if (collapsedNodeIds.size === 0) return flatNodes;
+        const hiddenIds = new Set();
+        return flatNodes.filter(flatNode => {
+          const parentId = flatNode.node.entry.parentId;
+          if (parentId && (collapsedNodeIds.has(parentId) || hiddenIds.has(parentId))) {
+            hiddenIds.add(flatNode.node.entry.id);
+            return false;
+          }
+          return true;
+        });
+      }
+
+      function toggleTreeNode(entryId) {
+        if (collapsedNodeIds.has(entryId)) collapsedNodeIds.delete(entryId);
+        else collapsedNodeIds.add(entryId);
+        forceTreeRerender();
+      }
 
       function renderTree() {
         const tree = buildTree();
         const activePathIds = buildActivePathIds(currentLeafId);
         const flatNodes = flattenTree(tree, activePathIds);
-        const filtered = filterNodes(flatNodes, currentLeafId);
+        const filtered = filterNodes(hideCollapsedDescendants(flatNodes), currentLeafId);
         const allSidebarRows = projectSidebarRows(flatNodes);
         const sidebarRows = projectSidebarRows(filtered, filterMode !== 'no-tools');
         const container = document.getElementById('tree-container');
@@ -759,6 +787,27 @@
             marker.className = 'tree-marker';
             marker.textContent = isOnPath ? '•' : ' ';
 
+            // The toggle sits beside the path bullet rather than replacing it:
+            // the bullet says "this is your thread", the chevron says "there is
+            // more underneath", and collapsing must not cost you the first.
+            const collapse = document.createElement('button');
+            collapse.className = 'tree-collapse';
+            if (flatNode.node.children.length > 0) {
+              const isCollapsed = collapsedNodeIds.has(entry.id);
+              collapse.textContent = isCollapsed ? '▸' : '▾';
+              collapse.title = isCollapsed ? 'Expand branch' : 'Collapse branch';
+              collapse.setAttribute('aria-label', collapse.title);
+              collapse.setAttribute('aria-expanded', String(!isCollapsed));
+              collapse.addEventListener('click', (event) => {
+                event.stopPropagation();
+                toggleTreeNode(entry.id);
+              });
+            } else {
+              collapse.classList.add('empty');
+              collapse.tabIndex = -1;
+              collapse.setAttribute('aria-hidden', 'true');
+            }
+
             const content = document.createElement('span');
             content.className = 'tree-content';
             if (row.assistantText !== undefined) {
@@ -774,6 +823,7 @@
 
             div.appendChild(prefixSpan);
             div.appendChild(marker);
+            div.appendChild(collapse);
             div.appendChild(content);
             div.addEventListener('click', () => navigateTo(row.navigationId || entry.id, 'target', null, row.anchorId));
 
@@ -1433,7 +1483,7 @@
         let html = `
           <div class="header">
             <h1>Session: ${escapeHtml(header?.id || 'unknown')}</h1>
-            <div class="help-bar">T toggle thinking · O toggle tools</div>
+            <div class="help-bar">T toggle thinking · O toggle tools · ▾ collapse a branch</div>
             <div class="header-info">
               <div class="info-item"><span class="info-label">Date:</span><span class="info-value">${header?.timestamp ? new Date(header.timestamp).toLocaleString() : 'unknown'}</span></div>
               <div class="info-item"><span class="info-label">Models:</span><span class="info-value">${globalStats.models.join(', ') || 'unknown'}</span></div>

--- a/packages/coding-agent/src/export/html/template.js
+++ b/packages/coding-agent/src/export/html/template.js
@@ -567,12 +567,40 @@
       let currentLeafId = leafId;
       let currentTargetId = urlTargetId || leafId;
       let treeRendered = false;
+      const collapsedNodeIds = new Set();
+
+      /**
+       * Drop descendants of collapsed nodes. flatNodes is pre-order, so a node's
+       * parent is always classified before the node itself — one pass, no
+       * per-node ancestor walk (that would be quadratic on deep chains).
+       *
+       * Connector prefixes are left as the layout computed them, so a folded
+       * subtree hides exactly the way a filtered one does.
+       */
+      function hideCollapsedDescendants(flatNodes) {
+        if (collapsedNodeIds.size === 0) return flatNodes;
+        const hiddenIds = new Set();
+        return flatNodes.filter(flatNode => {
+          const parentId = flatNode.node.entry.parentId;
+          if (parentId && (collapsedNodeIds.has(parentId) || hiddenIds.has(parentId))) {
+            hiddenIds.add(flatNode.node.entry.id);
+            return false;
+          }
+          return true;
+        });
+      }
+
+      function toggleTreeNode(entryId) {
+        if (collapsedNodeIds.has(entryId)) collapsedNodeIds.delete(entryId);
+        else collapsedNodeIds.add(entryId);
+        forceTreeRerender();
+      }
 
       function renderTree() {
         const tree = buildTree();
         const activePathIds = buildActivePathIds(currentLeafId);
         const flatNodes = flattenTree(tree, activePathIds);
-        const filtered = filterNodes(flatNodes, currentLeafId);
+        const filtered = filterNodes(hideCollapsedDescendants(flatNodes), currentLeafId);
         const container = document.getElementById('tree-container');
 
         // Full render only on first call or when filter/search changes
@@ -599,12 +627,34 @@
             marker.className = 'tree-marker';
             marker.textContent = isOnPath ? '•' : ' ';
 
+            // The toggle sits beside the path bullet rather than replacing it:
+            // the bullet says "this is your thread", the chevron says "there is
+            // more underneath", and collapsing must not cost you the first.
+            const collapse = document.createElement('button');
+            collapse.className = 'tree-collapse';
+            if (flatNode.node.children.length > 0) {
+              const isCollapsed = collapsedNodeIds.has(entry.id);
+              collapse.textContent = isCollapsed ? '▸' : '▾';
+              collapse.title = isCollapsed ? 'Expand branch' : 'Collapse branch';
+              collapse.setAttribute('aria-label', collapse.title);
+              collapse.setAttribute('aria-expanded', String(!isCollapsed));
+              collapse.addEventListener('click', (event) => {
+                event.stopPropagation();
+                toggleTreeNode(entry.id);
+              });
+            } else {
+              collapse.classList.add('empty');
+              collapse.tabIndex = -1;
+              collapse.setAttribute('aria-hidden', 'true');
+            }
+
             const content = document.createElement('span');
             content.className = 'tree-content';
             content.innerHTML = getTreeNodeDisplayHtml(entry, flatNode.node.label);
 
             div.appendChild(prefixSpan);
             div.appendChild(marker);
+            div.appendChild(collapse);
             div.appendChild(content);
             div.addEventListener('click', () => navigateTo(entry.id));
 
@@ -1255,7 +1305,7 @@
         let html = `
           <div class="header">
             <h1>Session: ${escapeHtml(header?.id || 'unknown')}</h1>
-            <div class="help-bar">T toggle thinking · O toggle tools</div>
+            <div class="help-bar">T toggle thinking · O toggle tools · ▾ collapse a branch</div>
             <div class="header-info">
               <div class="info-item"><span class="info-label">Date:</span><span class="info-value">${header?.timestamp ? new Date(header.timestamp).toLocaleString() : 'unknown'}</span></div>
               <div class="info-item"><span class="info-label">Models:</span><span class="info-value">${globalStats.models.join(', ') || 'unknown'}</span></div>

--- a/packages/coding-agent/src/export/html/template.js
+++ b/packages/coding-agent/src/export/html/template.js
@@ -737,6 +737,14 @@
         const tree = buildTree();
         const activePathIds = buildActivePathIds(currentLeafId);
         const flatNodes = flattenTree(tree, activePathIds);
+        const visibleNodeIds = new Set(filterNodes(flatNodes, currentLeafId).map(flatNode => flatNode.node.entry.id));
+        const nodesWithVisibleDescendants = new Set();
+        for (let i = flatNodes.length - 1; i >= 0; i--) {
+          const entry = flatNodes[i].node.entry;
+          if (entry.parentId && (visibleNodeIds.has(entry.id) || nodesWithVisibleDescendants.has(entry.id))) {
+            nodesWithVisibleDescendants.add(entry.parentId);
+          }
+        }
         const filtered = filterNodes(hideCollapsedDescendants(flatNodes), currentLeafId);
         const allSidebarRows = projectSidebarRows(flatNodes);
         const sidebarRows = projectSidebarRows(filtered, filterMode !== 'no-tools');
@@ -791,8 +799,9 @@
             // the bullet says "this is your thread", the chevron says "there is
             // more underneath", and collapsing must not cost you the first.
             const collapse = document.createElement('button');
+            collapse.type = 'button';
             collapse.className = 'tree-collapse';
-            if (flatNode.node.children.length > 0) {
+            if (nodesWithVisibleDescendants.has(entry.id)) {
               const isCollapsed = collapsedNodeIds.has(entry.id);
               collapse.textContent = isCollapsed ? '▸' : '▾';
               collapse.title = isCollapsed ? 'Expand branch' : 'Collapse branch';

--- a/packages/coding-agent/test/export-html-keyboard-shortcuts.test.ts
+++ b/packages/coding-agent/test/export-html-keyboard-shortcuts.test.ts
@@ -93,3 +93,55 @@ describe("HTML export keyboard shortcuts", () => {
 		});
 	});
 });
+
+describe("export tree collapse", () => {
+	function extractFunctionBody(source: string, signature: string): string {
+		const start = source.indexOf(signature);
+		expect(start).toBeGreaterThanOrEqual(0);
+		const bodyStart = source.indexOf("{", start) + 1;
+		let depth = 1;
+		for (let i = bodyStart; i < source.length; i++) {
+			const ch = source[i];
+			if (ch === "{") depth++;
+			else if (ch === "}") {
+				depth--;
+				if (depth === 0) return source.slice(bodyStart, i);
+			}
+		}
+		throw new Error(`${signature} did not close`);
+	}
+
+	function hideCollapsed(collapsed: string[], tree: Array<[string, string | null]>): string[] {
+		const body = extractFunctionBody(templateJs, "function hideCollapsedDescendants(flatNodes)");
+		const run = new Function("flatNodes", "collapsedNodeIds", body);
+		const flatNodes = tree.map(([id, parentId]) => ({ node: { entry: { id, parentId } } }));
+		const kept = run(flatNodes, new Set(collapsed)) as Array<{ node: { entry: { id: string } } }>;
+		return kept.map(flatNode => flatNode.node.entry.id);
+	}
+
+	// root ─┬─ a ── a2 ── a3
+	//       └─ b
+	const tree: Array<[string, string | null]> = [
+		["root", null],
+		["a", "root"],
+		["a2", "a"],
+		["a3", "a2"],
+		["b", "root"],
+	];
+
+	it("hides a collapsed node's whole subtree, not just its children", () => {
+		expect(hideCollapsed(["a"], tree)).toEqual(["root", "a", "b"]);
+	});
+
+	it("keeps the collapsed node itself, so the fold stays reversible", () => {
+		expect(hideCollapsed(["root"], tree)).toEqual(["root"]);
+	});
+
+	it("leaves sibling branches alone", () => {
+		expect(hideCollapsed(["b"], tree)).toEqual(["root", "a", "a2", "a3", "b"]);
+	});
+
+	it("is a no-op with nothing collapsed", () => {
+		expect(hideCollapsed([], tree)).toEqual(["root", "a", "a2", "a3", "b"]);
+	});
+});

--- a/packages/coding-agent/test/export-html-markdown.test.ts
+++ b/packages/coding-agent/test/export-html-markdown.test.ts
@@ -20,6 +20,16 @@ interface MinimalMessageEntry {
 	};
 }
 
+interface MinimalModelChangeEntry {
+	type: "model_change";
+	id: string;
+	parentId: string | null;
+	timestamp: string;
+	model: string;
+}
+
+type MinimalSessionEntry = MinimalMessageEntry | MinimalModelChangeEntry;
+
 interface MinimalSession {
 	header: {
 		type: "session";
@@ -28,7 +38,7 @@ interface MinimalSession {
 		timestamp: string;
 		cwd: string;
 	};
-	entries: MinimalMessageEntry[];
+	entries: MinimalSessionEntry[];
 	leafId: string;
 }
 
@@ -82,7 +92,7 @@ function renderSession(session: MinimalSession) {
 	return document;
 }
 
-function createSession(entries: MinimalMessageEntry[], leafId: string, id: string): MinimalSession {
+function createSession(entries: MinimalSessionEntry[], leafId: string, id: string): MinimalSession {
 	return {
 		header: {
 			type: "session",
@@ -169,5 +179,34 @@ describe("HTML export Markdown", () => {
 		expect(document.querySelectorAll(".tree-node").length).toBe(1);
 		expect(document.querySelector(".tree-node.active")?.getAttribute("data-id")).toBe("message-0");
 		expect(document.querySelector("#messages")?.textContent).toContain("root");
+	});
+
+	test("omits a collapse toggle when filtering hides every descendant", () => {
+		const document = renderSession(
+			createSession(
+				[
+					{
+						type: "message",
+						id: "root",
+						parentId: null,
+						timestamp: "2026-01-01T00:00:00.000Z",
+						message: { role: "user", content: "root", timestamp: 0 },
+					},
+					{
+						type: "model_change",
+						id: "hidden-child",
+						parentId: "root",
+						timestamp: "2026-01-01T00:00:01.000Z",
+						model: "openai/gpt-5",
+					},
+				],
+				"root",
+				"filtered-collapse-test",
+			),
+		);
+
+		const collapse = document.querySelector('[data-id="root"] .tree-collapse');
+		expect(collapse?.classList.contains("empty")).toBe(true);
+		expect(collapse?.getAttribute("type")).toBe("button");
 	});
 });

--- a/packages/coding-agent/test/export-html-template.test.ts
+++ b/packages/coding-agent/test/export-html-template.test.ts
@@ -19,9 +19,9 @@ interface TemplateProbeResult {
 }
 
 const expectedTemplate: TemplateProbeResult = {
-	chars: 376_316,
-	bytes: 376_472,
-	sha256: "72721b125d8eaa0e995ef0b77e01cf561c9a76e36e745510b19734def07936e0",
+	chars: 378_864,
+	bytes: 379_029,
+	sha256: "04af5dba43f82cab6f51db8494ab4b6c3ddd36981c22b24cfde06c89af225844",
 	stableCache: true,
 	assetsRemoved: 0,
 };


### PR DESCRIPTION
Long exported sessions open as a fully expanded sidebar: the thread you want is buried under every branch abandoned on the way to it, and the export gives you no way to hide one.

Every node with children now renders a `▾`/`▸` toggle that folds its subtree. The fold hides descendants only — the node itself stays, so it remains clickable and the fold is visibly reversible — and it runs *before* the existing filter, so folded rows drop out exactly the way filtered rows do and the connector prefixes of the survivors are untouched.

The toggle sits beside the active-path bullet rather than replacing it: the bullet says "this is your thread", the chevron says "there is more underneath". Childless rows keep an invisible toggle column so content stays aligned.

Verified by opening a real 869-node exported session in a browser: collapsing the root folds 869 rows to 1, expanding restores all 869, a mid-tree fold takes the tree to 301 rows with the collapsed row showing `▸`, and active-path bullets survive every toggle.

Tests: `test/export-html-keyboard-shortcuts.test.ts`. The template golden in `test/export-html-template.test.ts` is updated, since the composed template changed.