### PR TITLE
feat(tree): collapse conversation branches in the /tree selector

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added collapsible branches to the `/tree` selector: `Space` folds the selected node's subtree behind a `▸` marker with a hidden-entry count, `Shift+Tab` folds every branch off the current thread down to one row each, and `←`/`→` jump to the fork above the cursor or the next fork below it along the branch.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1412,7 +1412,7 @@
 - Fixed unobserved promise rejections in browser helpers (such as `tab.waitForResponse()`) causing tab workers to hang or crash.
 ### Added
 
-- Added collapsible branches to the `/tree` selector: `Space` folds the selected node's subtree behind a `▸` marker with a hidden-entry count, `Shift+Tab` folds every branch off the current thread down to one row each, and `←`/`→` jump to the fork above the cursor or the next fork below it along the branch.
+- Added collapsible branches to the `/tree` selector: `Space` folds the selected node's subtree behind a `▸` marker with a hidden-entry count, and `Shift+Tab` folds every branch off the current thread down to one row each.
 
 ## [17.2.9] - 2026-08-05
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added collapsible `/tree` branches: `Space` folds one visible subtree and `Shift+Tab` focuses the active thread while preserving existing paging keys.
+
 ## [18.1.14] - 2026-09-07
 
 ### Fixed
@@ -1410,9 +1414,6 @@
 - Fixed parsing of POSIX `$EDITOR` commands that contain quoted arguments or executable paths with spaces.
 - Fixed persisted Agent Hub rows losing the explicit caller model role when a subagent used a model override, preserving role provenance across restarts.
 - Fixed unobserved promise rejections in browser helpers (such as `tab.waitForResponse()`) causing tab workers to hang or crash.
-### Added
-
-- Added collapsible branches to the `/tree` selector: `Space` folds the selected node's subtree behind a `▸` marker with a hidden-entry count, and `Shift+Tab` folds every branch off the current thread down to one row each.
 
 ## [17.2.9] - 2026-08-05
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1410,6 +1410,9 @@
 - Fixed parsing of POSIX `$EDITOR` commands that contain quoted arguments or executable paths with spaces.
 - Fixed persisted Agent Hub rows losing the explicit caller model role when a subagent used a model override, preserving role provenance across restarts.
 - Fixed unobserved promise rejections in browser helpers (such as `tab.waitForResponse()`) causing tab workers to hang or crash.
+### Added
+
+- Added collapsible branches to the `/tree` selector: `Space` folds the selected node's subtree behind a `▸` marker with a hidden-entry count, `Shift+Tab` folds every branch off the current thread down to one row each, and `←`/`→` jump to the fork above the cursor or the next fork below it along the branch.
 
 ## [17.2.9] - 2026-08-05
 

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -37,6 +37,8 @@ interface GutterInfo {
 /** Flattened tree node for navigation */
 interface FlatNode {
 	node: SessionTreeNode;
+	/** Nearest visible ancestor in the current projection. */
+	projectedParentId: string | null;
 	/** Indentation level (each level = 3 chars) */
 	indent: number;
 	/** Whether to show connector (├─ or └─) - true if parent has multiple children */
@@ -157,7 +159,11 @@ class TreeList implements Component {
 	#activePathIds: Set<string> = new Set();
 	#lastSelectedId: string | null = null;
 	#collapsedIds: Set<string> = new Set();
+	#bulkCollapsedIds: Set<string> = new Set();
+	#bulkFocusActive = false;
 	#hiddenDescendantCounts: Map<string, number> = new Map();
+	#tree: SessionTreeNode[] = [];
+	#allFlatNodes: FlatNode[] = [];
 
 	onSelect?: (entryId: string, options: { summarize: boolean }) => void;
 	onCancel?: () => void;
@@ -171,8 +177,10 @@ class TreeList implements Component {
 		initialSelectedId?: string,
 	) {
 		this.#filterMode = initialFilterMode;
-		this.#multipleRoots = tree.length > 1;
-		this.#flatNodes = this.#flattenTree(tree);
+		this.#tree = tree;
+		this.#collectToolCalls(tree);
+		this.#flatNodes = this.#flattenTree(tree, () => true);
+		this.#allFlatNodes = this.#flatNodes;
 		this.#buildActivePath();
 		this.#applyFilter();
 
@@ -189,7 +197,7 @@ class TreeList implements Component {
 
 		// Build a map of id -> entry for parent lookup
 		const entryMap = new Map<string, FlatNode>();
-		for (const flatNode of this.#flatNodes) {
+		for (const flatNode of this.#allFlatNodes) {
 			entryMap.set(flatNode.node.entry.id, flatNode);
 		}
 
@@ -212,7 +220,7 @@ class TreeList implements Component {
 
 		// Build a map for parent lookup
 		const entryMap = new Map<string, FlatNode>();
-		for (const flatNode of this.#flatNodes) {
+		for (const flatNode of this.#allFlatNodes) {
 			entryMap.set(flatNode.node.entry.id, flatNode);
 		}
 
@@ -233,16 +241,47 @@ class TreeList implements Component {
 		return this.#filteredNodes.length - 1;
 	}
 
-	#flattenTree(roots: SessionTreeNode[]): FlatNode[] {
-		const result: FlatNode[] = [];
+	/** Tool calls resolve labels for tool results, so collect them before filtering. */
+	#collectToolCalls(roots: SessionTreeNode[]): void {
 		this.#toolCallMap.clear();
+		const stack = [...roots];
+		while (stack.length > 0) {
+			const node = stack.pop()!;
+			for (const child of node.children) stack.push(child);
+			const entry = node.entry;
+			if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+			const content = (entry.message as { content?: unknown }).content;
+			if (!Array.isArray(content)) continue;
+			for (const block of content) {
+				if (typeof block === "object" && block !== null && "type" in block && block.type === "toolCall") {
+					const tc = block as { id: string; name: string; arguments: Record<string, unknown> };
+					this.#toolCallMap.set(tc.id, { name: tc.name, arguments: tc.arguments });
+				}
+			}
+		}
+	}
+
+	/** Promote visible descendants through rows omitted by the current filter. */
+	#visibleDescendants(children: SessionTreeNode[], isVisible: (node: SessionTreeNode) => boolean): SessionTreeNode[] {
+		const visible: SessionTreeNode[] = [];
+		const pending = [...children].reverse();
+		while (pending.length > 0) {
+			const candidate = pending.pop()!;
+			if (isVisible(candidate)) visible.push(candidate);
+			else for (let i = candidate.children.length - 1; i >= 0; i--) pending.push(candidate.children[i]);
+		}
+		return visible;
+	}
+
+	#flattenTree(roots: SessionTreeNode[], isVisible: (node: SessionTreeNode) => boolean): FlatNode[] {
+		const result: FlatNode[] = [];
 
 		// A real branch point adds one indentation level. Linear conversation
 		// chains retain that level so their text stays aligned with the branch
 		// head instead of drifting right after every fork.
 
-		// Stack items: [node, indent, showConnector, isLast, gutters, isVirtualRootChild]
-		type StackItem = [SessionTreeNode, number, boolean, boolean, GutterInfo[], boolean];
+		// Stack items: [node, projectedParentId, indent, showConnector, isLast, gutters, isVirtualRootChild]
+		type StackItem = [SessionTreeNode, string | null, number, boolean, boolean, GutterInfo[], boolean];
 		const stack: StackItem[] = [];
 
 		// Determine which subtrees contain the active leaf (to sort current branch first)
@@ -276,33 +315,23 @@ class TreeList implements Component {
 
 		// Add roots in reverse order, prioritizing the one containing the active leaf
 		// If multiple roots, treat them as children of a virtual root that branches
-		const multipleRoots = roots.length > 1;
-		const orderedRoots = [...roots].sort((a, b) => Number(containsActive.get(b)) - Number(containsActive.get(a)));
+		const visibleRoots = this.#visibleDescendants(roots, isVisible);
+		const multipleRoots = visibleRoots.length > 1;
+		this.#multipleRoots = multipleRoots;
+		const orderedRoots = [...visibleRoots].sort(
+			(a, b) => Number(containsActive.get(b)) - Number(containsActive.get(a)),
+		);
 		for (let i = orderedRoots.length - 1; i >= 0; i--) {
 			const isLast = i === orderedRoots.length - 1;
-			stack.push([orderedRoots[i], multipleRoots ? 1 : 0, multipleRoots, isLast, [], multipleRoots]);
+			stack.push([orderedRoots[i], null, multipleRoots ? 1 : 0, multipleRoots, isLast, [], multipleRoots]);
 		}
 
 		while (stack.length > 0) {
-			const [node, indent, showConnector, isLast, gutters, isVirtualRootChild] = stack.pop()!;
+			const [node, projectedParentId, indent, showConnector, isLast, gutters, isVirtualRootChild] = stack.pop()!;
 
-			// Extract tool calls from assistant messages for later lookup
-			const entry = node.entry;
-			if (entry.type === "message" && entry.message.role === "assistant") {
-				const content = (entry.message as { content?: unknown }).content;
-				if (Array.isArray(content)) {
-					for (const block of content) {
-						if (typeof block === "object" && block !== null && "type" in block && block.type === "toolCall") {
-							const tc = block as { id: string; name: string; arguments: Record<string, unknown> };
-							this.#toolCallMap.set(tc.id, { name: tc.name, arguments: tc.arguments });
-						}
-					}
-				}
-			}
+			result.push({ node, projectedParentId, indent, showConnector, isLast, gutters, isVirtualRootChild });
 
-			result.push({ node, indent, showConnector, isLast, gutters, isVirtualRootChild });
-
-			const children = node.children;
+			const children = this.#visibleDescendants(node.children, isVisible);
 			const multipleChildren = children.length > 1;
 
 			// Order children so the branch containing the active leaf comes first
@@ -339,7 +368,15 @@ class TreeList implements Component {
 			// Add children in reverse order
 			for (let i = orderedChildren.length - 1; i >= 0; i--) {
 				const childIsLast = i === orderedChildren.length - 1;
-				stack.push([orderedChildren[i], childIndent, multipleChildren, childIsLast, childGutters, false]);
+				stack.push([
+					orderedChildren[i],
+					node.entry.id,
+					childIndent,
+					multipleChildren,
+					childIsLast,
+					childGutters,
+					false,
+				]);
 			}
 		}
 
@@ -357,18 +394,19 @@ class TreeList implements Component {
 	 */
 	#hideCollapsedDescendants(flatNodes: FlatNode[]): FlatNode[] {
 		this.#hiddenDescendantCounts.clear();
-		if (this.#collapsedIds.size === 0) return flatNodes;
+		if (this.#collapsedIds.size === 0 && this.#bulkCollapsedIds.size === 0) return flatNodes;
+		const isCollapsed = (id: string): boolean => this.#collapsedIds.has(id) || this.#bulkCollapsedIds.has(id);
 
 		// id -> the collapsed ancestor that hid it, so counts land on the node the
 		// user actually collapsed rather than on intermediate descendants.
 		const hiddenUnder = new Map<string, string>();
 		return flatNodes.filter(flatNode => {
-			const parentId = flatNode.node.entry.parentId;
+			const parentId = flatNode.projectedParentId;
 			if (!parentId) return true;
 			// An already-hidden parent wins over a collapsed one: a collapse nested
 			// inside another collapse is invisible, so its descendants belong to the
 			// outermost fold — the only one whose count the user can see.
-			const collapseRoot = hiddenUnder.get(parentId) ?? (this.#collapsedIds.has(parentId) ? parentId : undefined);
+			const collapseRoot = hiddenUnder.get(parentId) ?? (isCollapsed(parentId) ? parentId : undefined);
 			if (collapseRoot === undefined) return true;
 			hiddenUnder.set(flatNode.node.entry.id, collapseRoot);
 			this.#hiddenDescendantCounts.set(collapseRoot, (this.#hiddenDescendantCounts.get(collapseRoot) ?? 0) + 1);
@@ -381,8 +419,8 @@ class TreeList implements Component {
 	 * collapse. Split out of {@link #applyFilter} because folding a branch has to
 	 * know which of its rows the user can actually see.
 	 */
-	#passesFilter(flatNode: FlatNode, searchTokens: string[]): boolean {
-		const entry = flatNode.node.entry;
+	#passesFilter(node: SessionTreeNode, searchTokens: string[]): boolean {
+		const entry = node.entry;
 		const isCurrentLeaf = entry.id === this.currentLeafId;
 
 		// Skip assistant messages with only tool calls (no text) unless error/aborted
@@ -423,7 +461,7 @@ class TreeList implements Component {
 				break;
 			case "labeled-only":
 				// Just labeled entries
-				passesFilter = flatNode.node.label !== undefined;
+				passesFilter = node.label !== undefined;
 				break;
 			case "all":
 				// Show everything
@@ -439,7 +477,7 @@ class TreeList implements Component {
 
 		// Apply fuzzy search filter
 		if (searchTokens.length > 0) {
-			const nodeText = this.#getSearchableText(flatNode.node);
+			const nodeText = this.#getSearchableText(node);
 			return searchTokens.every(token => fuzzyMatch(token, nodeText).matches);
 		}
 
@@ -453,12 +491,11 @@ class TreeList implements Component {
 			this.#lastSelectedId = this.#filteredNodes[this.#selectedIndex]?.node.entry.id ?? this.#lastSelectedId;
 		}
 
-		// Collapse first, filter second: a collapsed subtree is gone regardless of
-		// which filter mode is active.
 		const searchTokens = this.#searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
-		this.#filteredNodes = this.#hideCollapsedDescendants(this.#flatNodes).filter(flatNode =>
-			this.#passesFilter(flatNode, searchTokens),
-		);
+		// Shape the visible tree first so hidden rows do not own branches,
+		// indentation, collapse anchors, or hidden-descendant counts.
+		this.#flatNodes = this.#flattenTree(this.#tree, node => this.#passesFilter(node, searchTokens));
+		this.#filteredNodes = this.#hideCollapsedDescendants(this.#flatNodes);
 
 		// Try to preserve cursor on the same node, or find nearest visible ancestor
 		if (this.#lastSelectedId) {
@@ -584,7 +621,7 @@ class TreeList implements Component {
 	}
 
 	isCollapsed(entryId: string): boolean {
-		return this.#collapsedIds.has(entryId);
+		return this.#collapsedIds.has(entryId) || this.#bulkCollapsedIds.has(entryId);
 	}
 
 	/**
@@ -594,7 +631,7 @@ class TreeList implements Component {
 	 */
 	toggleCollapse(): void {
 		const selected = this.#filteredNodes[this.#selectedIndex];
-		if (!selected || selected.node.children.length === 0) return;
+		if (!selected || !this.#flatNodes.some(node => node.projectedParentId === selected.node.entry.id)) return;
 		const entryId = selected.node.entry.id;
 		if (!this.#collapsedIds.delete(entryId)) this.#collapsedIds.add(entryId);
 		this.#applyFilter();
@@ -603,22 +640,30 @@ class TreeList implements Component {
 	/**
 	 * Fold every branch that hangs off the current thread, leaving the path to
 	 * the active leaf fully expanded and each abandoned branch showing as a
-	 * single row. Pressing it again expands everything.
+	 * single row. Pressing it again removes these focused-thread folds without
+	 * disturbing branches the user folded manually.
 	 *
 	 * This is the useful shape of a bulk collapse: folding *all* fork points also
 	 * folds the thread you are reading, which is the one thing you never want
 	 * hidden.
 	 */
 	focusCurrentThread(): void {
-		if (this.#collapsedIds.size > 0) {
-			this.#collapsedIds.clear();
+		if (this.#bulkFocusActive) {
+			this.#bulkFocusActive = false;
+			this.#bulkCollapsedIds.clear();
 			this.#applyFilter();
 			return;
 		}
-		const searchTokens = this.#searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
-		const byId = new Map(this.#flatNodes.map(flatNode => [flatNode.node.entry.id, flatNode]));
+		this.#bulkFocusActive = true;
+		this.#bulkCollapsedIds.clear();
+		const visibleChildCounts = new Map<string, number>();
+		for (const node of this.#flatNodes) {
+			if (node.projectedParentId)
+				visibleChildCounts.set(node.projectedParentId, (visibleChildCounts.get(node.projectedParentId) ?? 0) + 1);
+		}
 		for (const flatNode of this.#flatNodes) {
-			const { id, parentId } = flatNode.node.entry;
+			const { id } = flatNode.node.entry;
+			const parentId = flatNode.projectedParentId;
 			// One fold per off-thread branch, anchored at its head — the first node
 			// that leaves the active path. Folding its descendants too would be
 			// invisible (they are already hidden) and would leave stale collapse
@@ -626,92 +671,14 @@ class TreeList implements Component {
 			if (this.#activePathIds.has(id)) continue;
 			if (!parentId || !this.#activePathIds.has(parentId)) continue;
 
-			// The head itself is often filtered away (a bare tool call, say). Folding
-			// it would hide the branch entirely, marker and count included, so the
-			// fold slides down to the first row the user can actually see.
-			let anchor: FlatNode | undefined = flatNode;
-			while (anchor && !this.#passesFilter(anchor, searchTokens)) {
-				anchor = anchor.node.children.length === 1 ? byId.get(anchor.node.children[0]!.entry.id) : undefined;
-			}
-			if (!anchor || anchor.node.children.length === 0) continue;
-			this.#collapsedIds.add(anchor.node.entry.id);
+			if ((visibleChildCounts.get(id) ?? 0) === 0) continue;
+			this.#bulkCollapsedIds.add(id);
 		}
 		this.#applyFilter();
 	}
 
-	/**
-	 * Move the cursor along the branch you are on: `-1` climbs to the nearest
-	 * fork above the selection, `1` descends to the nearest fork below it. Both
-	 * follow parent links rather than screen order, so a fork on a sibling branch
-	 * is never what you land on — with the active branch drawn first, the row
-	 * above the cursor often belongs to another thread entirely. Row depth cannot
-	 * stand in for this: linear continuations share their branch head's indent.
-	 *
-	 * A fork whose branches are hidden (collapsed, or filtered away) is not a
-	 * fork worth stopping at, so what counts is the visible child count. With no
-	 * fork left in the chosen direction the cursor rides the chain to its end.
-	 */
-	jumpToBranchPoint(direction: 1 | -1): void {
-		const nodes = this.#filteredNodes;
-		const current = nodes[this.#selectedIndex];
-		if (!current) return;
-
-		const indexById = new Map<string, number>();
-		const visibleChildCounts = new Map<string, number>();
-		const firstChildByParent = new Map<string, number>();
-		for (let i = 0; i < nodes.length; i++) {
-			indexById.set(nodes[i].node.entry.id, i);
-			const parentId = nodes[i].node.entry.parentId;
-			if (!parentId) continue;
-			visibleChildCounts.set(parentId, (visibleChildCounts.get(parentId) ?? 0) + 1);
-			if (!firstChildByParent.has(parentId)) firstChildByParent.set(parentId, i);
-		}
-		const isFork = (index: number): boolean => (visibleChildCounts.get(nodes[index].node.entry.id) ?? 0) > 1;
-		// Ancestry comes off the full tree: a hidden parent still links its child
-		// to the fork above it.
-		const parentByChild = new Map<string, string | null>(
-			this.#flatNodes.map(flatNode => [flatNode.node.entry.id, flatNode.node.entry.parentId]),
-		);
-
-		if (direction < 0) {
-			// Skip straight over ancestors the filter hid, or the climb would stop
-			// dead at the first gap instead of reaching the fork above it.
-			let parentId = current.node.entry.parentId;
-			let highest = -1;
-			const seen = new Set<string>();
-			while (parentId && !seen.has(parentId)) {
-				seen.add(parentId);
-				const index = indexById.get(parentId);
-				if (index !== undefined) {
-					highest = index;
-					if (isFork(index)) {
-						this.#selectedIndex = index;
-						return;
-					}
-				}
-				parentId = parentByChild.get(parentId) ?? null;
-			}
-			if (highest >= 0) this.#selectedIndex = highest;
-			return;
-		}
-
-		// The first child listed is the one on the active branch, which is the
-		// thread being read.
-		let index = firstChildByParent.get(current.node.entry.id);
-		let deepest = -1;
-		while (index !== undefined) {
-			deepest = index;
-			if (isFork(index)) {
-				this.#selectedIndex = index;
-				return;
-			}
-			index = firstChildByParent.get(nodes[index].node.entry.id);
-		}
-		if (deepest >= 0) this.#selectedIndex = deepest;
-	}
-
 	updateNodeLabel(entryId: string, label: string | undefined): void {
-		for (const flatNode of this.#flatNodes) {
+		for (const flatNode of this.#allFlatNodes) {
 			if (flatNode.node.entry.id === entryId) {
 				flatNode.node.label = label;
 				break;
@@ -745,26 +712,26 @@ class TreeList implements Component {
 			//    how to widen it. Otherwise fresh sessions whose only persisted entries are
 			//    `model_change` + `thinking_level_change` (both hidden by the default filter)
 			//    read as "broken /tree" — see #1909.
-			if (this.#flatNodes.length === 0) {
+			if (this.#allFlatNodes.length === 0) {
 				lines.push(truncateToWidth(theme.fg("muted", "No entries found"), width));
 				lines.push(truncateToWidth(theme.fg("muted", `(0/0)${this.#getFilterLabel()}`), width));
 			} else if (this.#searchQuery.length > 0) {
 				lines.push(truncateToWidth(theme.fg("muted", `No entries match search "${this.#searchQuery}"`), width));
 				lines.push(truncateToWidth(theme.fg("muted", "Press Backspace to clear the search"), width));
 				lines.push(
-					truncateToWidth(theme.fg("muted", `(0/${this.#flatNodes.length})${this.#getFilterLabel()}`), width),
+					truncateToWidth(theme.fg("muted", `(0/${this.#allFlatNodes.length})${this.#getFilterLabel()}`), width),
 				);
 			} else {
 				const filterLabel = this.#getFilterLabel().trim() || "[default]";
 				lines.push(
 					truncateToWidth(
-						theme.fg("muted", `${this.#flatNodes.length} entries hidden by the current filter ${filterLabel}`),
+						theme.fg("muted", `${this.#allFlatNodes.length} entries hidden by the current filter ${filterLabel}`),
 						width,
 					),
 				);
 				lines.push(truncateToWidth(theme.fg("muted", "Press Alt+A to show all, Alt+D for default"), width));
 				lines.push(
-					truncateToWidth(theme.fg("muted", `(0/${this.#flatNodes.length})${this.#getFilterLabel()}`), width),
+					truncateToWidth(theme.fg("muted", `(0/${this.#allFlatNodes.length})${this.#getFilterLabel()}`), width),
 				);
 			}
 			return lines;
@@ -1140,13 +1107,9 @@ class TreeList implements Component {
 			this.#selectedIndex = 0;
 		} else if (matchesKey(keyData, "end")) {
 			this.#selectedIndex = Math.max(0, this.#filteredNodes.length - 1);
-		} else if (matchesKey(keyData, "left")) {
-			this.jumpToBranchPoint(-1);
-		} else if (matchesKey(keyData, "right")) {
-			this.jumpToBranchPoint(1);
-		} else if (matchesSelectPageUp(keyData)) {
+		} else if (matchesSelectPageUp(keyData) || matchesKey(keyData, "left")) {
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - this.maxVisibleLines);
-		} else if (matchesSelectPageDown(keyData)) {
+		} else if (matchesSelectPageDown(keyData) || matchesKey(keyData, "right")) {
 			this.#selectedIndex = Math.min(this.#filteredNodes.length - 1, this.#selectedIndex + this.maxVisibleLines);
 		} else if (
 			matchesKey(keyData, "shift+enter") ||

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -156,6 +156,8 @@ class TreeList implements Component {
 	#multipleRoots = false;
 	#activePathIds: Set<string> = new Set();
 	#lastSelectedId: string | null = null;
+	#collapsedIds: Set<string> = new Set();
+	#hiddenDescendantCounts: Map<string, number> = new Map();
 
 	onSelect?: (entryId: string, options: { summarize: boolean }) => void;
 	onCancel?: () => void;
@@ -344,6 +346,106 @@ class TreeList implements Component {
 		return result;
 	}
 
+	/**
+	 * Drop the descendants of collapsed nodes and record how many each collapse
+	 * hides. `#flatNodes` is pre-order, so a node's parent is always classified
+	 * before the node itself — one linear pass, no per-node ancestor walk.
+	 *
+	 * Connector metadata is deliberately left alone. A collapsed subtree is
+	 * hidden the same way a filtered one is, so the gutters of the rows that
+	 * survive keep describing the real tree they belong to.
+	 */
+	#hideCollapsedDescendants(flatNodes: FlatNode[]): FlatNode[] {
+		this.#hiddenDescendantCounts.clear();
+		if (this.#collapsedIds.size === 0) return flatNodes;
+
+		// id -> the collapsed ancestor that hid it, so counts land on the node the
+		// user actually collapsed rather than on intermediate descendants.
+		const hiddenUnder = new Map<string, string>();
+		return flatNodes.filter(flatNode => {
+			const parentId = flatNode.node.entry.parentId;
+			if (!parentId) return true;
+			// An already-hidden parent wins over a collapsed one: a collapse nested
+			// inside another collapse is invisible, so its descendants belong to the
+			// outermost fold — the only one whose count the user can see.
+			const collapseRoot = hiddenUnder.get(parentId) ?? (this.#collapsedIds.has(parentId) ? parentId : undefined);
+			if (collapseRoot === undefined) return true;
+			hiddenUnder.set(flatNode.node.entry.id, collapseRoot);
+			this.#hiddenDescendantCounts.set(collapseRoot, (this.#hiddenDescendantCounts.get(collapseRoot) ?? 0) + 1);
+			return false;
+		});
+	}
+
+	/**
+	 * Whether a row survives the current filter mode and search, ignoring
+	 * collapse. Split out of {@link #applyFilter} because folding a branch has to
+	 * know which of its rows the user can actually see.
+	 */
+	#passesFilter(flatNode: FlatNode, searchTokens: string[]): boolean {
+		const entry = flatNode.node.entry;
+		const isCurrentLeaf = entry.id === this.currentLeafId;
+
+		// Skip assistant messages with only tool calls (no text) unless error/aborted
+		// Always show current leaf so active position is visible
+		if (entry.type === "message" && entry.message.role === "assistant" && !isCurrentLeaf) {
+			const msg = entry.message as { stopReason?: string; content?: unknown };
+			const hasText = this.#hasTextContent(msg.content);
+			const isErrorOrAborted = msg.stopReason && msg.stopReason !== "stop" && msg.stopReason !== "toolUse";
+			// Only hide if no text AND not an error/aborted message
+			if (!hasText && !isErrorOrAborted) return false;
+		}
+
+		// Entry types hidden in default view (settings/bookkeeping). These carry
+		// no conversation content, so the tree only shows them in "all" mode.
+		const isSettingsEntry =
+			entry.type === "label" ||
+			entry.type === "custom" ||
+			entry.type === "model_change" ||
+			entry.type === "model_usage" ||
+			entry.type === "thinking_level_change" ||
+			entry.type === "service_tier_change" ||
+			entry.type === "title_change" ||
+			entry.type === "credential_pin" ||
+			entry.type === "session_init" ||
+			entry.type === "ttsr_injection" ||
+			entry.type === "mode_change" ||
+			entry.type === "reset_boundary";
+
+		let passesFilter: boolean;
+		switch (this.#filterMode) {
+			case "user-only":
+				// Just user messages
+				passesFilter = entry.type === "message" && entry.message.role === "user";
+				break;
+			case "no-tools":
+				// Default minus tool results
+				passesFilter = !isSettingsEntry && !(entry.type === "message" && entry.message.role === "toolResult");
+				break;
+			case "labeled-only":
+				// Just labeled entries
+				passesFilter = flatNode.node.label !== undefined;
+				break;
+			case "all":
+				// Show everything
+				passesFilter = true;
+				break;
+			default:
+				// Default mode: hide settings/bookkeeping entries
+				passesFilter = !isSettingsEntry;
+				break;
+		}
+
+		if (!passesFilter) return false;
+
+		// Apply fuzzy search filter
+		if (searchTokens.length > 0) {
+			const nodeText = this.#getSearchableText(flatNode.node);
+			return searchTokens.every(token => fuzzyMatch(token, nodeText).matches);
+		}
+
+		return true;
+	}
+
 	#applyFilter(): void {
 		// Update lastSelectedId only when we have a valid selection (non-empty list)
 		// This preserves the selection when switching through empty filter results
@@ -351,75 +453,12 @@ class TreeList implements Component {
 			this.#lastSelectedId = this.#filteredNodes[this.#selectedIndex]?.node.entry.id ?? this.#lastSelectedId;
 		}
 
+		// Collapse first, filter second: a collapsed subtree is gone regardless of
+		// which filter mode is active.
 		const searchTokens = this.#searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
-
-		this.#filteredNodes = this.#flatNodes.filter(flatNode => {
-			const entry = flatNode.node.entry;
-			const isCurrentLeaf = entry.id === this.currentLeafId;
-
-			// Skip assistant messages with only tool calls (no text) unless error/aborted
-			// Always show current leaf so active position is visible
-			if (entry.type === "message" && entry.message.role === "assistant" && !isCurrentLeaf) {
-				const msg = entry.message as { stopReason?: string; content?: unknown };
-				const hasText = this.#hasTextContent(msg.content);
-				const isErrorOrAborted = msg.stopReason && msg.stopReason !== "stop" && msg.stopReason !== "toolUse";
-				// Only hide if no text AND not an error/aborted message
-				if (!hasText && !isErrorOrAborted) {
-					return false;
-				}
-			}
-
-			// Apply filter mode
-			let passesFilter = true;
-			// Entry types hidden in default view (settings/bookkeeping). These carry
-			// no conversation content, so the tree only shows them in "all" mode.
-			const isSettingsEntry =
-				entry.type === "label" ||
-				entry.type === "custom" ||
-				entry.type === "model_change" ||
-				entry.type === "model_usage" ||
-				entry.type === "thinking_level_change" ||
-				entry.type === "service_tier_change" ||
-				entry.type === "title_change" ||
-				entry.type === "credential_pin" ||
-				entry.type === "session_init" ||
-				entry.type === "ttsr_injection" ||
-				entry.type === "mode_change" ||
-				entry.type === "reset_boundary";
-
-			switch (this.#filterMode) {
-				case "user-only":
-					// Just user messages
-					passesFilter = entry.type === "message" && entry.message.role === "user";
-					break;
-				case "no-tools":
-					// Default minus tool results
-					passesFilter = !isSettingsEntry && !(entry.type === "message" && entry.message.role === "toolResult");
-					break;
-				case "labeled-only":
-					// Just labeled entries
-					passesFilter = flatNode.node.label !== undefined;
-					break;
-				case "all":
-					// Show everything
-					passesFilter = true;
-					break;
-				default:
-					// Default mode: hide settings/bookkeeping entries
-					passesFilter = !isSettingsEntry;
-					break;
-			}
-
-			if (!passesFilter) return false;
-
-			// Apply fuzzy search filter
-			if (searchTokens.length > 0) {
-				const nodeText = this.#getSearchableText(flatNode.node);
-				return searchTokens.every(token => fuzzyMatch(token, nodeText).matches);
-			}
-
-			return true;
-		});
+		this.#filteredNodes = this.#hideCollapsedDescendants(this.#flatNodes).filter(flatNode =>
+			this.#passesFilter(flatNode, searchTokens),
+		);
 
 		// Try to preserve cursor on the same node, or find nearest visible ancestor
 		if (this.#lastSelectedId) {
@@ -537,6 +576,138 @@ class TreeList implements Component {
 
 	getSelectedNode(): SessionTreeNode | undefined {
 		return this.#filteredNodes[this.#selectedIndex]?.node;
+	}
+
+	/** Entry ids currently drawn, in display order. */
+	getVisibleEntryIds(): string[] {
+		return this.#filteredNodes.map(flatNode => flatNode.node.entry.id);
+	}
+
+	isCollapsed(entryId: string): boolean {
+		return this.#collapsedIds.has(entryId);
+	}
+
+	/**
+	 * Collapse or expand the selected node's subtree. Childless nodes are left
+	 * alone so the key is a no-op instead of a silent state change the user
+	 * cannot see or undo.
+	 */
+	toggleCollapse(): void {
+		const selected = this.#filteredNodes[this.#selectedIndex];
+		if (!selected || selected.node.children.length === 0) return;
+		const entryId = selected.node.entry.id;
+		if (!this.#collapsedIds.delete(entryId)) this.#collapsedIds.add(entryId);
+		this.#applyFilter();
+	}
+
+	/**
+	 * Fold every branch that hangs off the current thread, leaving the path to
+	 * the active leaf fully expanded and each abandoned branch showing as a
+	 * single row. Pressing it again expands everything.
+	 *
+	 * This is the useful shape of a bulk collapse: folding *all* fork points also
+	 * folds the thread you are reading, which is the one thing you never want
+	 * hidden.
+	 */
+	focusCurrentThread(): void {
+		if (this.#collapsedIds.size > 0) {
+			this.#collapsedIds.clear();
+			this.#applyFilter();
+			return;
+		}
+		const searchTokens = this.#searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
+		const byId = new Map(this.#flatNodes.map(flatNode => [flatNode.node.entry.id, flatNode]));
+		for (const flatNode of this.#flatNodes) {
+			const { id, parentId } = flatNode.node.entry;
+			// One fold per off-thread branch, anchored at its head — the first node
+			// that leaves the active path. Folding its descendants too would be
+			// invisible (they are already hidden) and would leave stale collapse
+			// state behind once the head is reopened.
+			if (this.#activePathIds.has(id)) continue;
+			if (!parentId || !this.#activePathIds.has(parentId)) continue;
+
+			// The head itself is often filtered away (a bare tool call, say). Folding
+			// it would hide the branch entirely, marker and count included, so the
+			// fold slides down to the first row the user can actually see.
+			let anchor: FlatNode | undefined = flatNode;
+			while (anchor && !this.#passesFilter(anchor, searchTokens)) {
+				anchor = anchor.node.children.length === 1 ? byId.get(anchor.node.children[0]!.entry.id) : undefined;
+			}
+			if (!anchor || anchor.node.children.length === 0) continue;
+			this.#collapsedIds.add(anchor.node.entry.id);
+		}
+		this.#applyFilter();
+	}
+
+	/**
+	 * Move the cursor along the branch you are on: `-1` climbs to the nearest
+	 * fork above the selection, `1` descends to the nearest fork below it. Both
+	 * follow parent links rather than screen order, so a fork on a sibling branch
+	 * is never what you land on — with the active branch drawn first, the row
+	 * above the cursor often belongs to another thread entirely. Row depth cannot
+	 * stand in for this: linear continuations share their branch head's indent.
+	 *
+	 * A fork whose branches are hidden (collapsed, or filtered away) is not a
+	 * fork worth stopping at, so what counts is the visible child count. With no
+	 * fork left in the chosen direction the cursor rides the chain to its end.
+	 */
+	jumpToBranchPoint(direction: 1 | -1): void {
+		const nodes = this.#filteredNodes;
+		const current = nodes[this.#selectedIndex];
+		if (!current) return;
+
+		const indexById = new Map<string, number>();
+		const visibleChildCounts = new Map<string, number>();
+		const firstChildByParent = new Map<string, number>();
+		for (let i = 0; i < nodes.length; i++) {
+			indexById.set(nodes[i].node.entry.id, i);
+			const parentId = nodes[i].node.entry.parentId;
+			if (!parentId) continue;
+			visibleChildCounts.set(parentId, (visibleChildCounts.get(parentId) ?? 0) + 1);
+			if (!firstChildByParent.has(parentId)) firstChildByParent.set(parentId, i);
+		}
+		const isFork = (index: number): boolean => (visibleChildCounts.get(nodes[index].node.entry.id) ?? 0) > 1;
+		// Ancestry comes off the full tree: a hidden parent still links its child
+		// to the fork above it.
+		const parentByChild = new Map<string, string | null>(
+			this.#flatNodes.map(flatNode => [flatNode.node.entry.id, flatNode.node.entry.parentId]),
+		);
+
+		if (direction < 0) {
+			// Skip straight over ancestors the filter hid, or the climb would stop
+			// dead at the first gap instead of reaching the fork above it.
+			let parentId = current.node.entry.parentId;
+			let highest = -1;
+			const seen = new Set<string>();
+			while (parentId && !seen.has(parentId)) {
+				seen.add(parentId);
+				const index = indexById.get(parentId);
+				if (index !== undefined) {
+					highest = index;
+					if (isFork(index)) {
+						this.#selectedIndex = index;
+						return;
+					}
+				}
+				parentId = parentByChild.get(parentId) ?? null;
+			}
+			if (highest >= 0) this.#selectedIndex = highest;
+			return;
+		}
+
+		// The first child listed is the one on the active branch, which is the
+		// thread being read.
+		let index = firstChildByParent.get(current.node.entry.id);
+		let deepest = -1;
+		while (index !== undefined) {
+			deepest = index;
+			if (isFork(index)) {
+				this.#selectedIndex = index;
+				return;
+			}
+			index = firstChildByParent.get(nodes[index].node.entry.id);
+		}
+		if (deepest >= 0) this.#selectedIndex = deepest;
 	}
 
 	updateNodeLabel(entryId: string, label: string | undefined): void {
@@ -683,10 +854,18 @@ class TreeList implements Component {
 			const isOnActivePath = this.#activePathIds.has(entry.id);
 			const pathMarker = isOnActivePath ? theme.fg("accent", `${theme.md.bullet} `) : "";
 
+			// Only collapsed rows carry a marker. Reserving a chevron column for
+			// every row would push all content right and stamp one on each link of
+			// every single-child chain — noise on the common case, and it disturbs
+			// the connector geometry the tree is read by.
+			const hidden = this.#hiddenDescendantCounts.get(entry.id) ?? 0;
+			const collapseMarker = hidden > 0 ? theme.fg("warning", `${theme.nav.expand} `) : "";
+			const hiddenCount = hidden > 0 ? theme.fg("muted", ` (+${hidden})`) : "";
+
 			const label = flatNode.node.label ? theme.fg("warning", `[${flatNode.node.label}] `) : "";
 			const content = this.#getEntryDisplayText(flatNode.node, isSelected);
 
-			let line = cursor + theme.fg("dim", prefix) + pathMarker + label + content;
+			let line = cursor + theme.fg("dim", prefix) + collapseMarker + pathMarker + label + content + hiddenCount;
 			if (isSelected) {
 				line = theme.bg("selectedBg", line);
 			}
@@ -961,9 +1140,13 @@ class TreeList implements Component {
 			this.#selectedIndex = 0;
 		} else if (matchesKey(keyData, "end")) {
 			this.#selectedIndex = Math.max(0, this.#filteredNodes.length - 1);
-		} else if (matchesSelectPageUp(keyData) || matchesKey(keyData, "left")) {
+		} else if (matchesKey(keyData, "left")) {
+			this.jumpToBranchPoint(-1);
+		} else if (matchesKey(keyData, "right")) {
+			this.jumpToBranchPoint(1);
+		} else if (matchesSelectPageUp(keyData)) {
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - this.maxVisibleLines);
-		} else if (matchesSelectPageDown(keyData) || matchesKey(keyData, "right")) {
+		} else if (matchesSelectPageDown(keyData)) {
 			this.#selectedIndex = Math.min(this.#filteredNodes.length - 1, this.#selectedIndex + this.maxVisibleLines);
 		} else if (
 			matchesKey(keyData, "shift+enter") ||
@@ -1017,6 +1200,12 @@ class TreeList implements Component {
 		} else if (matchesKey(keyData, "alt+a")) {
 			this.#filterMode = "all";
 			this.#applyFilter();
+		} else if (matchesKey(keyData, "shift+tab")) {
+			this.focusCurrentThread();
+		} else if (matchesKey(keyData, "tab") || (matchesKey(keyData, "space") && !this.#searchQuery)) {
+			// Space is the natural collapse key, but it is also a search character,
+			// so it only collapses while no search is being typed. Tab always works.
+			this.toggleCollapse();
 		} else if (matchesKey(keyData, "backspace")) {
 			if (this.#searchQuery.length > 0) {
 				this.#searchQuery = this.#searchQuery.slice(0, -1);
@@ -1128,13 +1317,12 @@ export class TreeSelectorComponent extends OverlayPanel {
 		this.#treeContainer.addChild(this.#treeList);
 
 		this.#labelInputContainer = new Container();
-
 		this.addChild(new Spacer(1));
 		this.addChild(
 			new TruncatedText(
 				theme.fg(
 					"muted",
-					"Enter: switch. Alt+↑/↓: previous/next turn. PgUp/PgDn (←/→): page. Home/End: first/last item. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
+					"Enter: switch. Space: collapse. Alt+↑/↓: previous/next turn. ←/→: fork above/below. PgUp/PgDn: page. Home/End: first/last item. Shift+Tab: focus thread. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
 				),
 				0,
 				0,

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -71,6 +71,8 @@ class TreeList implements Component {
 	#multipleRoots = false;
 	#activePathIds: Set<string> = new Set();
 	#lastSelectedId: string | null = null;
+	#collapsedIds: Set<string> = new Set();
+	#hiddenDescendantCounts: Map<string, number> = new Map();
 
 	onSelect?: (entryId: string, options: { summarize: boolean }) => void;
 	onCancel?: () => void;
@@ -259,6 +261,97 @@ class TreeList implements Component {
 		return result;
 	}
 
+	/**
+	 * Drop the descendants of collapsed nodes and record how many each collapse
+	 * hides. `#flatNodes` is pre-order, so a node's parent is always classified
+	 * before the node itself — one linear pass, no per-node ancestor walk.
+	 *
+	 * Connector metadata is deliberately left alone. A collapsed subtree is
+	 * hidden the same way a filtered one is, so the gutters of the rows that
+	 * survive keep describing the real tree they belong to.
+	 */
+	#hideCollapsedDescendants(flatNodes: FlatNode[]): FlatNode[] {
+		this.#hiddenDescendantCounts.clear();
+		if (this.#collapsedIds.size === 0) return flatNodes;
+
+		// id -> the collapsed ancestor that hid it, so counts land on the node the
+		// user actually collapsed rather than on intermediate descendants.
+		const hiddenUnder = new Map<string, string>();
+		return flatNodes.filter(flatNode => {
+			const parentId = flatNode.node.entry.parentId;
+			if (!parentId) return true;
+			// An already-hidden parent wins over a collapsed one: a collapse nested
+			// inside another collapse is invisible, so its descendants belong to the
+			// outermost fold — the only one whose count the user can see.
+			const collapseRoot = hiddenUnder.get(parentId) ?? (this.#collapsedIds.has(parentId) ? parentId : undefined);
+			if (collapseRoot === undefined) return true;
+			hiddenUnder.set(flatNode.node.entry.id, collapseRoot);
+			this.#hiddenDescendantCounts.set(collapseRoot, (this.#hiddenDescendantCounts.get(collapseRoot) ?? 0) + 1);
+			return false;
+		});
+	}
+
+	/**
+	 * Whether a row survives the current filter mode and search, ignoring
+	 * collapse. Split out of {@link #applyFilter} because folding a branch has to
+	 * know which of its rows the user can actually see.
+	 */
+	#passesFilter(flatNode: FlatNode, searchTokens: string[]): boolean {
+		const entry = flatNode.node.entry;
+		const isCurrentLeaf = entry.id === this.currentLeafId;
+
+		// Skip assistant messages with only tool calls (no text) unless error/aborted
+		// Always show current leaf so active position is visible
+		if (entry.type === "message" && entry.message.role === "assistant" && !isCurrentLeaf) {
+			const msg = entry.message as { stopReason?: string; content?: unknown };
+			const hasText = this.#hasTextContent(msg.content);
+			const isErrorOrAborted = msg.stopReason && msg.stopReason !== "stop" && msg.stopReason !== "toolUse";
+			// Only hide if no text AND not an error/aborted message
+			if (!hasText && !isErrorOrAborted) return false;
+		}
+
+		// Entry types hidden in default view (settings/bookkeeping)
+		const isSettingsEntry =
+			entry.type === "label" ||
+			entry.type === "custom" ||
+			entry.type === "model_change" ||
+			entry.type === "thinking_level_change";
+
+		let passesFilter: boolean;
+		switch (this.#filterMode) {
+			case "user-only":
+				// Just user messages
+				passesFilter = entry.type === "message" && entry.message.role === "user";
+				break;
+			case "no-tools":
+				// Default minus tool results
+				passesFilter = !isSettingsEntry && !(entry.type === "message" && entry.message.role === "toolResult");
+				break;
+			case "labeled-only":
+				// Just labeled entries
+				passesFilter = flatNode.node.label !== undefined;
+				break;
+			case "all":
+				// Show everything
+				passesFilter = true;
+				break;
+			default:
+				// Default mode: hide settings/bookkeeping entries
+				passesFilter = !isSettingsEntry;
+				break;
+		}
+
+		if (!passesFilter) return false;
+
+		// Apply fuzzy search filter
+		if (searchTokens.length > 0) {
+			const nodeText = this.#getSearchableText(flatNode.node);
+			return searchTokens.every(token => fuzzyMatch(token, nodeText).matches);
+		}
+
+		return true;
+	}
+
 	#applyFilter(): void {
 		// Update lastSelectedId only when we have a valid selection (non-empty list)
 		// This preserves the selection when switching through empty filter results
@@ -266,66 +359,12 @@ class TreeList implements Component {
 			this.#lastSelectedId = this.#filteredNodes[this.#selectedIndex]?.node.entry.id ?? this.#lastSelectedId;
 		}
 
+		// Collapse first, filter second: a collapsed subtree is gone regardless of
+		// which filter mode is active.
 		const searchTokens = this.#searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
-
-		this.#filteredNodes = this.#flatNodes.filter(flatNode => {
-			const entry = flatNode.node.entry;
-			const isCurrentLeaf = entry.id === this.currentLeafId;
-
-			// Skip assistant messages with only tool calls (no text) unless error/aborted
-			// Always show current leaf so active position is visible
-			if (entry.type === "message" && entry.message.role === "assistant" && !isCurrentLeaf) {
-				const msg = entry.message as { stopReason?: string; content?: unknown };
-				const hasText = this.#hasTextContent(msg.content);
-				const isErrorOrAborted = msg.stopReason && msg.stopReason !== "stop" && msg.stopReason !== "toolUse";
-				// Only hide if no text AND not an error/aborted message
-				if (!hasText && !isErrorOrAborted) {
-					return false;
-				}
-			}
-
-			// Apply filter mode
-			let passesFilter = true;
-			// Entry types hidden in default view (settings/bookkeeping)
-			const isSettingsEntry =
-				entry.type === "label" ||
-				entry.type === "custom" ||
-				entry.type === "model_change" ||
-				entry.type === "thinking_level_change";
-
-			switch (this.#filterMode) {
-				case "user-only":
-					// Just user messages
-					passesFilter = entry.type === "message" && entry.message.role === "user";
-					break;
-				case "no-tools":
-					// Default minus tool results
-					passesFilter = !isSettingsEntry && !(entry.type === "message" && entry.message.role === "toolResult");
-					break;
-				case "labeled-only":
-					// Just labeled entries
-					passesFilter = flatNode.node.label !== undefined;
-					break;
-				case "all":
-					// Show everything
-					passesFilter = true;
-					break;
-				default:
-					// Default mode: hide settings/bookkeeping entries
-					passesFilter = !isSettingsEntry;
-					break;
-			}
-
-			if (!passesFilter) return false;
-
-			// Apply fuzzy search filter
-			if (searchTokens.length > 0) {
-				const nodeText = this.#getSearchableText(flatNode.node);
-				return searchTokens.every(token => fuzzyMatch(token, nodeText).matches);
-			}
-
-			return true;
-		});
+		this.#filteredNodes = this.#hideCollapsedDescendants(this.#flatNodes).filter(flatNode =>
+			this.#passesFilter(flatNode, searchTokens),
+		);
 
 		// Try to preserve cursor on the same node, or find nearest visible ancestor
 		if (this.#lastSelectedId) {
@@ -403,6 +442,138 @@ class TreeList implements Component {
 
 	getSelectedNode(): SessionTreeNode | undefined {
 		return this.#filteredNodes[this.#selectedIndex]?.node;
+	}
+
+	/** Entry ids currently drawn, in display order. */
+	getVisibleEntryIds(): string[] {
+		return this.#filteredNodes.map(flatNode => flatNode.node.entry.id);
+	}
+
+	isCollapsed(entryId: string): boolean {
+		return this.#collapsedIds.has(entryId);
+	}
+
+	/**
+	 * Collapse or expand the selected node's subtree. Childless nodes are left
+	 * alone so the key is a no-op instead of a silent state change the user
+	 * cannot see or undo.
+	 */
+	toggleCollapse(): void {
+		const selected = this.#filteredNodes[this.#selectedIndex];
+		if (!selected || selected.node.children.length === 0) return;
+		const entryId = selected.node.entry.id;
+		if (!this.#collapsedIds.delete(entryId)) this.#collapsedIds.add(entryId);
+		this.#applyFilter();
+	}
+
+	/**
+	 * Fold every branch that hangs off the current thread, leaving the path to
+	 * the active leaf fully expanded and each abandoned branch showing as a
+	 * single row. Pressing it again expands everything.
+	 *
+	 * This is the useful shape of a bulk collapse: folding *all* fork points also
+	 * folds the thread you are reading, which is the one thing you never want
+	 * hidden.
+	 */
+	focusCurrentThread(): void {
+		if (this.#collapsedIds.size > 0) {
+			this.#collapsedIds.clear();
+			this.#applyFilter();
+			return;
+		}
+		const searchTokens = this.#searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
+		const byId = new Map(this.#flatNodes.map(flatNode => [flatNode.node.entry.id, flatNode]));
+		for (const flatNode of this.#flatNodes) {
+			const { id, parentId } = flatNode.node.entry;
+			// One fold per off-thread branch, anchored at its head — the first node
+			// that leaves the active path. Folding its descendants too would be
+			// invisible (they are already hidden) and would leave stale collapse
+			// state behind once the head is reopened.
+			if (this.#activePathIds.has(id)) continue;
+			if (!parentId || !this.#activePathIds.has(parentId)) continue;
+
+			// The head itself is often filtered away (a bare tool call, say). Folding
+			// it would hide the branch entirely, marker and count included, so the
+			// fold slides down to the first row the user can actually see.
+			let anchor: FlatNode | undefined = flatNode;
+			while (anchor && !this.#passesFilter(anchor, searchTokens)) {
+				anchor = anchor.node.children.length === 1 ? byId.get(anchor.node.children[0]!.entry.id) : undefined;
+			}
+			if (!anchor || anchor.node.children.length === 0) continue;
+			this.#collapsedIds.add(anchor.node.entry.id);
+		}
+		this.#applyFilter();
+	}
+
+	/**
+	 * Move the cursor along the branch you are on: `-1` climbs to the nearest
+	 * fork above the selection, `1` descends to the nearest fork below it. Both
+	 * follow parent links rather than screen order, so a fork on a sibling branch
+	 * is never what you land on — with the active branch drawn first, the row
+	 * above the cursor often belongs to another thread entirely. Row depth cannot
+	 * stand in for this: linear continuations share their branch head's indent.
+	 *
+	 * A fork whose branches are hidden (collapsed, or filtered away) is not a
+	 * fork worth stopping at, so what counts is the visible child count. With no
+	 * fork left in the chosen direction the cursor rides the chain to its end.
+	 */
+	jumpToBranchPoint(direction: 1 | -1): void {
+		const nodes = this.#filteredNodes;
+		const current = nodes[this.#selectedIndex];
+		if (!current) return;
+
+		const indexById = new Map<string, number>();
+		const visibleChildCounts = new Map<string, number>();
+		const firstChildByParent = new Map<string, number>();
+		for (let i = 0; i < nodes.length; i++) {
+			indexById.set(nodes[i].node.entry.id, i);
+			const parentId = nodes[i].node.entry.parentId;
+			if (!parentId) continue;
+			visibleChildCounts.set(parentId, (visibleChildCounts.get(parentId) ?? 0) + 1);
+			if (!firstChildByParent.has(parentId)) firstChildByParent.set(parentId, i);
+		}
+		const isFork = (index: number): boolean => (visibleChildCounts.get(nodes[index].node.entry.id) ?? 0) > 1;
+		// Ancestry comes off the full tree: a hidden parent still links its child
+		// to the fork above it.
+		const parentByChild = new Map<string, string | null>(
+			this.#flatNodes.map(flatNode => [flatNode.node.entry.id, flatNode.node.entry.parentId]),
+		);
+
+		if (direction < 0) {
+			// Skip straight over ancestors the filter hid, or the climb would stop
+			// dead at the first gap instead of reaching the fork above it.
+			let parentId = current.node.entry.parentId;
+			let highest = -1;
+			const seen = new Set<string>();
+			while (parentId && !seen.has(parentId)) {
+				seen.add(parentId);
+				const index = indexById.get(parentId);
+				if (index !== undefined) {
+					highest = index;
+					if (isFork(index)) {
+						this.#selectedIndex = index;
+						return;
+					}
+				}
+				parentId = parentByChild.get(parentId) ?? null;
+			}
+			if (highest >= 0) this.#selectedIndex = highest;
+			return;
+		}
+
+		// The first child listed is the one on the active branch, which is the
+		// thread being read.
+		let index = firstChildByParent.get(current.node.entry.id);
+		let deepest = -1;
+		while (index !== undefined) {
+			deepest = index;
+			if (isFork(index)) {
+				this.#selectedIndex = index;
+				return;
+			}
+			index = firstChildByParent.get(nodes[index].node.entry.id);
+		}
+		if (deepest >= 0) this.#selectedIndex = deepest;
 	}
 
 	updateNodeLabel(entryId: string, label: string | undefined): void {
@@ -549,10 +720,18 @@ class TreeList implements Component {
 			const isOnActivePath = this.#activePathIds.has(entry.id);
 			const pathMarker = isOnActivePath ? theme.fg("accent", `${theme.md.bullet} `) : "";
 
+			// Only collapsed rows carry a marker. Reserving a chevron column for
+			// every row would push all content right and stamp one on each link of
+			// every single-child chain — noise on the common case, and it disturbs
+			// the connector geometry the tree is read by.
+			const hidden = this.#hiddenDescendantCounts.get(entry.id) ?? 0;
+			const collapseMarker = hidden > 0 ? theme.fg("warning", `${theme.nav.expand} `) : "";
+			const hiddenCount = hidden > 0 ? theme.fg("muted", ` (+${hidden})`) : "";
+
 			const label = flatNode.node.label ? theme.fg("warning", `[${flatNode.node.label}] `) : "";
 			const content = this.#getEntryDisplayText(flatNode.node, isSelected);
 
-			let line = cursor + theme.fg("dim", prefix) + pathMarker + label + content;
+			let line = cursor + theme.fg("dim", prefix) + collapseMarker + pathMarker + label + content + hiddenCount;
 			if (isSelected) {
 				line = theme.bg("selectedBg", line);
 			}
@@ -786,9 +965,13 @@ class TreeList implements Component {
 			this.#selectedIndex = 0;
 		} else if (matchesKey(keyData, "end")) {
 			this.#selectedIndex = Math.max(0, this.#filteredNodes.length - 1);
-		} else if (matchesSelectPageUp(keyData) || matchesKey(keyData, "left")) {
+		} else if (matchesKey(keyData, "left")) {
+			this.jumpToBranchPoint(-1);
+		} else if (matchesKey(keyData, "right")) {
+			this.jumpToBranchPoint(1);
+		} else if (matchesSelectPageUp(keyData)) {
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - this.maxVisibleLines);
-		} else if (matchesSelectPageDown(keyData) || matchesKey(keyData, "right")) {
+		} else if (matchesSelectPageDown(keyData)) {
 			this.#selectedIndex = Math.min(this.#filteredNodes.length - 1, this.#selectedIndex + this.maxVisibleLines);
 		} else if (matchesKey(keyData, "shift+enter") || matchesKey(keyData, "shift+return")) {
 			// Summarize-and-switch: fork with a branch summary without the extra prompt.
@@ -837,6 +1020,12 @@ class TreeList implements Component {
 		} else if (matchesKey(keyData, "alt+a")) {
 			this.#filterMode = "all";
 			this.#applyFilter();
+		} else if (matchesKey(keyData, "shift+tab")) {
+			this.focusCurrentThread();
+		} else if (matchesKey(keyData, "tab") || (matchesKey(keyData, "space") && !this.#searchQuery)) {
+			// Space is the natural collapse key, but it is also a search character,
+			// so it only collapses while no search is being typed. Tab always works.
+			this.toggleCollapse();
 		} else if (matchesKey(keyData, "backspace")) {
 			if (this.#searchQuery.length > 0) {
 				this.#searchQuery = this.#searchQuery.slice(0, -1);
@@ -944,7 +1133,6 @@ export class TreeSelectorComponent extends Container {
 		this.#treeContainer.addChild(this.#treeList);
 
 		this.#labelInputContainer = new Container();
-
 		this.addChild(new Spacer(1));
 		this.addChild(new DynamicBorder());
 		this.addChild(new Text(theme.bold("  Session Tree"), 1, 0));
@@ -952,7 +1140,7 @@ export class TreeSelectorComponent extends Container {
 			new TruncatedText(
 				theme.fg(
 					"muted",
-					"Enter: switch. Alt+↑/↓: previous/next turn. PgUp/PgDn (←/→): page. Home/End: first/last item. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
+					"Enter: switch. Space: collapse. Alt+↑/↓: previous/next turn. ←/→: fork above/below. PgUp/PgDn: page. Home/End: first/last item. Shift+Tab: focus thread. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
 				),
 				0,
 				0,

--- a/packages/coding-agent/test/modes/components/tree-selector-collapse.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-collapse.test.ts
@@ -7,7 +7,6 @@ import type { SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-
 const TAB = "\t";
 const SHIFT_TAB = "\x1b[Z";
 const UP = "\x1b[A";
-const DOWN = "\x1b[B";
 const LEFT = "\x1b[D";
 const RIGHT = "\x1b[C";
 
@@ -20,6 +19,19 @@ function assistantNode(id: string, parentId: string | null, text: string): Sessi
 	} as AgentMessage;
 	return {
 		entry: { type: "message", id, parentId, timestamp: "2026-01-01T00:00:00.000Z", message },
+		children: [],
+	};
+}
+
+function modelNode(id: string, parentId: string | null): SessionTreeNode {
+	return {
+		entry: {
+			type: "model_change",
+			id,
+			parentId,
+			timestamp: "2026-01-01T00:00:00.000Z",
+			model: "test/model",
+		},
 		children: [],
 	};
 }
@@ -162,6 +174,70 @@ describe("tree selector collapse", () => {
 		expect(list.isCollapsed("b1")).toBe(true);
 	});
 
+	it("folds an off-thread branch at its first visible row", () => {
+		const root = assistantNode("root", null, "common parent");
+		const active = link(root, assistantNode("active", "root", "active branch"));
+		const hiddenHead = link(root, modelNode("hidden-head", "root"));
+		const visibleHead = link(hiddenHead, assistantNode("visible-head", "hidden-head", "visible branch head"));
+		link(visibleHead, assistantNode("visible-tail", "visible-head", "visible branch tail"));
+		const selector = new TreeSelectorComponent(
+			[root],
+			active.entry.id,
+			40,
+			() => {},
+			() => {},
+		);
+		const list = selector.getTreeList();
+
+		selector.handleInput(SHIFT_TAB);
+
+		expect(list.getVisibleEntryIds()).toEqual(["root", "active", "visible-head"]);
+		expect(list.isCollapsed("visible-head")).toBe(true);
+		expect(list.isCollapsed("hidden-head")).toBe(false);
+	});
+
+	it("keeps manual folds while activating focused-thread folds", () => {
+		const { roots } = fixture();
+		const b1 = roots[0].children[1];
+		link(b1, assistantNode("b2", "b1", "branch B deep"));
+		const selector = new TreeSelectorComponent(
+			roots,
+			"a1",
+			40,
+			() => {},
+			() => {},
+		);
+		const list = selector.getTreeList();
+
+		selector.handleInput(TAB);
+		selector.handleInput(SHIFT_TAB);
+
+		expect(list.isCollapsed("a1")).toBe(true);
+		expect(list.isCollapsed("b1")).toBe(true);
+		expect(list.getVisibleEntryIds()).toEqual(["root", "a1", "b1"]);
+	});
+
+	it("counts only descendants visible in the current projection", () => {
+		const root = assistantNode("root", null, "common parent");
+		const hidden = link(root, modelNode("hidden", "root"));
+		link(hidden, assistantNode("visible", "hidden", "visible descendant"));
+		const selector = new TreeSelectorComponent(
+			[root],
+			"root",
+			40,
+			() => {},
+			() => {},
+		);
+
+		selector.handleInput(TAB);
+
+		const row = selector
+			.render(120)
+			.map(line => Bun.stripANSI(line))
+			.find(line => line.includes("common parent"));
+		expect(row).toContain("(+1)");
+	});
+
 	it("collapses on space, but types a space into an active search instead", () => {
 		const selector = selectorAt("a1");
 		const list = selector.getTreeList();
@@ -176,68 +252,23 @@ describe("tree selector collapse", () => {
 		expect(list.isCollapsed(list.getSelectedNode()?.entry.id ?? "")).toBe(false);
 	});
 
-	it("climbs the parent chain, not the rows above the cursor", () => {
-		// root ─┬─ a1 ── a2 ─┬─ a3      the active branch, drawn first
-		//       │            └─ a2b
-		//       └─ b1
-		const root = assistantNode("root", null, "common parent");
-		const a1 = link(root, assistantNode("a1", "root", "branch A head"));
-		const a2 = link(a1, assistantNode("a2", "a1", "branch A middle"));
-		link(a2, assistantNode("a3", "a2", "branch A tail"));
-		link(a2, assistantNode("a2b", "a2", "branch A sibling"));
-		link(root, assistantNode("b1", "root", "branch B"));
+	it("preserves Left and Right as page navigation", () => {
+		const root = assistantNode("n0", null, "entry 0");
+		let tip = root;
+		for (let i = 1; i < 12; i++) tip = link(tip, assistantNode(`n${i}`, tip.entry.id, `entry ${i}`));
 		const selector = new TreeSelectorComponent(
 			[root],
-			"a3",
-			40,
+			"n11",
+			10,
 			() => {},
 			() => {},
 		);
 		const list = selector.getTreeList();
-		expect(list.getVisibleEntryIds()).toEqual(["root", "a1", "a2", "a3", "a2b", "b1"]);
-
-		while (list.getSelectedNode()?.entry.id !== "b1") selector.handleInput(DOWN);
-		// a2 forks and sits above b1 on screen, but on another thread entirely —
-		// b1's own fork is the root it hangs off.
-		selector.handleInput(LEFT);
-		expect(list.getSelectedNode()?.entry.id).toBe("root");
-
-		// Descending follows the branch drawn first, so it lands inside thread A
-		// rather than on b1.
-		selector.handleInput(RIGHT);
-		expect(list.getSelectedNode()?.entry.id).toBe("a2");
 
 		selector.handleInput(LEFT);
-		expect(list.getSelectedNode()?.entry.id).toBe("root");
-	});
-
-	it("runs to the end of the chain when no fork is left that way", () => {
-		const selector = selectorAt("a3"); // root ─┬─ a1 ── a2 ── a3 / └─ b1
-		const list = selector.getTreeList();
-
-		// Nothing forks between a3 and the root but the root itself.
-		selector.handleInput(LEFT);
-		expect(list.getSelectedNode()?.entry.id).toBe("root");
-		selector.handleInput(LEFT);
-		expect(list.getSelectedNode()?.entry.id).toBe("root");
-
-		// No fork below the root on thread A, so the cursor rides the chain to its
-		// deepest row instead of stopping short.
+		expect(list.getSelectedNode()?.entry.id).toBe("n6");
 		selector.handleInput(RIGHT);
-		expect(list.getSelectedNode()?.entry.id).toBe("a3");
-		selector.handleInput(RIGHT);
-		expect(list.getSelectedNode()?.entry.id).toBe("a3");
-	});
-
-	it("keeps a collapsed fork reachable as a branch point", () => {
-		const selector = selectorAt("a3");
-		const list = selector.getTreeList();
-		selector.handleInput(LEFT); // cursor on root
-		selector.handleInput(TAB); // fold the whole session behind it
-		expect(list.getVisibleEntryIds()).toEqual(["root"]);
-
-		selector.handleInput(RIGHT);
-		expect(list.getSelectedNode()?.entry.id).toBe("root");
+		expect(list.getSelectedNode()?.entry.id).toBe("n11");
 	});
 
 	it("moves the cursor to the collapsed ancestor when the selection is hidden", () => {

--- a/packages/coding-agent/test/modes/components/tree-selector-collapse.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-collapse.test.ts
@@ -1,0 +1,279 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
+import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+
+const TAB = "\t";
+const SHIFT_TAB = "\x1b[Z";
+const UP = "\x1b[A";
+const DOWN = "\x1b[B";
+const LEFT = "\x1b[D";
+const RIGHT = "\x1b[C";
+
+function assistantNode(id: string, parentId: string | null, text: string): SessionTreeNode {
+	const message = {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		timestamp: 0,
+		stopReason: "stop",
+	} as AgentMessage;
+	return {
+		entry: { type: "message", id, parentId, timestamp: "2026-01-01T00:00:00.000Z", message },
+		children: [],
+	};
+}
+
+function link(parent: SessionTreeNode, child: SessionTreeNode): SessionTreeNode {
+	parent.children.push(child);
+	return child;
+}
+
+/**
+ * root ─┬─ a1 ── a2 ── a3   (branch A, three deep)
+ *       └─ b1             (branch B)
+ */
+function fixture(): { roots: SessionTreeNode[]; ids: Record<string, string> } {
+	const root = assistantNode("root", null, "common parent");
+	const a1 = link(root, assistantNode("a1", "root", "branch A head"));
+	const a2 = link(a1, assistantNode("a2", "a1", "branch A middle"));
+	link(a2, assistantNode("a3", "a2", "branch A tail"));
+	link(root, assistantNode("b1", "root", "branch B"));
+	return { roots: [root], ids: { root: "root", a1: "a1", a2: "a2", a3: "a3", b1: "b1" } };
+}
+
+function selectorAt(leafId: string): TreeSelectorComponent {
+	const { roots } = fixture();
+	return new TreeSelectorComponent(
+		roots,
+		leafId,
+		40,
+		() => {},
+		() => {},
+	);
+}
+
+describe("tree selector collapse", () => {
+	beforeAll(async () => {
+		await themeModule.initTheme(false, undefined, undefined, "dark", "light");
+	});
+
+	it("hides the whole subtree of the selected node, keeping the node itself", () => {
+		const selector = selectorAt("a1");
+		const list = selector.getTreeList();
+		expect(list.getVisibleEntryIds()).toEqual(["root", "a1", "a2", "a3", "b1"]);
+
+		selector.handleInput(TAB);
+
+		expect(list.getVisibleEntryIds()).toEqual(["root", "a1", "b1"]);
+		expect(list.isCollapsed("a1")).toBe(true);
+	});
+
+	it("restores the subtree on a second toggle", () => {
+		const selector = selectorAt("a1");
+		selector.handleInput(TAB);
+		selector.handleInput(TAB);
+
+		expect(selector.getTreeList().getVisibleEntryIds()).toEqual(["root", "a1", "a2", "a3", "b1"]);
+		expect(selector.getTreeList().isCollapsed("a1")).toBe(false);
+	});
+
+	it("counts the entire hidden subtree, not just direct children", () => {
+		const selector = selectorAt("a1");
+		selector.handleInput(TAB);
+
+		const row = selector
+			.render(120)
+			.map(line => Bun.stripANSI(line))
+			.find(line => line.includes("branch A head"));
+		if (!row) throw new Error("Expected the collapsed branch head to stay visible");
+		expect(row).toContain("(+2)");
+		expect(row).toContain("\u25b8"); // ▸ collapsed marker
+	});
+
+	it("attributes a nested collapse's descendants to the outermost fold", () => {
+		const selector = selectorAt("a2");
+		const list = selector.getTreeList();
+		selector.handleInput(TAB); // fold a2, hiding a3
+		selector.handleInput(UP);
+		expect(list.getSelectedNode()?.entry.id).toBe("a1");
+		selector.handleInput(TAB); // fold a1, swallowing the a2 fold
+
+		const row = selector
+			.render(120)
+			.map(line => Bun.stripANSI(line))
+			.find(line => line.includes("branch A head"));
+		if (!row) throw new Error("Expected the collapsed branch head to stay visible");
+		// Both a2 and a3 are hidden by the visible fold, so it must report 2 — the
+		// inner fold is invisible and owns nothing.
+		expect(row).toContain("(+2)");
+	});
+
+	it("is a no-op on a node with nothing below it", () => {
+		const selector = selectorAt("a3");
+		const list = selector.getTreeList();
+		selector.handleInput(TAB);
+
+		expect(list.isCollapsed("a3")).toBe(false);
+		expect(list.getVisibleEntryIds()).toEqual(["root", "a1", "a2", "a3", "b1"]);
+	});
+
+	it("keeps a subtree collapsed across a filter change", () => {
+		const selector = selectorAt("a1");
+		const list = selector.getTreeList();
+		selector.handleInput(TAB);
+		selector.handleInput("\x1ba"); // alt+a — widen to the "all" filter
+
+		expect(list.getVisibleEntryIds()).toEqual(["root", "a1", "b1"]);
+	});
+
+	it("folds only the branches off the current thread, keeping that thread readable", () => {
+		const selector = selectorAt("a3"); // current thread is root → a1 → a2 → a3
+		const list = selector.getTreeList();
+
+		selector.handleInput(SHIFT_TAB);
+		// The thread stays fully expanded; branch b1 survives as a single row.
+		expect(list.getVisibleEntryIds()).toEqual(["root", "a1", "a2", "a3", "b1"]);
+		expect(list.isCollapsed("root")).toBe(false);
+		expect(list.isCollapsed("a1")).toBe(false);
+
+		selector.handleInput(SHIFT_TAB);
+		expect(list.getVisibleEntryIds()).toEqual(["root", "a1", "a2", "a3", "b1"]);
+	});
+
+	it("folds an off-thread branch down to its head row", () => {
+		const { roots } = fixture();
+		// Give branch B its own descendants so folding it is observable.
+		const b1 = roots[0].children[1];
+		link(b1, assistantNode("b2", "b1", "branch B deep"));
+		const selector = new TreeSelectorComponent(
+			roots,
+			"a3",
+			40,
+			() => {},
+			() => {},
+		);
+		const list = selector.getTreeList();
+		expect(list.getVisibleEntryIds()).toContain("b2");
+
+		selector.handleInput(SHIFT_TAB);
+
+		expect(list.getVisibleEntryIds()).toEqual(["root", "a1", "a2", "a3", "b1"]);
+		expect(list.isCollapsed("b1")).toBe(true);
+	});
+
+	it("collapses on space, but types a space into an active search instead", () => {
+		const selector = selectorAt("a1");
+		const list = selector.getTreeList();
+
+		selector.handleInput(" ");
+		expect(list.isCollapsed("a1")).toBe(true);
+
+		selector.handleInput(" "); // expand again, then start searching
+		selector.handleInput("b");
+		selector.handleInput(" ");
+		expect(list.getSearchQuery()).toBe("b ");
+		expect(list.isCollapsed(list.getSelectedNode()?.entry.id ?? "")).toBe(false);
+	});
+
+	it("climbs the parent chain, not the rows above the cursor", () => {
+		// root ─┬─ a1 ── a2 ─┬─ a3      the active branch, drawn first
+		//       │            └─ a2b
+		//       └─ b1
+		const root = assistantNode("root", null, "common parent");
+		const a1 = link(root, assistantNode("a1", "root", "branch A head"));
+		const a2 = link(a1, assistantNode("a2", "a1", "branch A middle"));
+		link(a2, assistantNode("a3", "a2", "branch A tail"));
+		link(a2, assistantNode("a2b", "a2", "branch A sibling"));
+		link(root, assistantNode("b1", "root", "branch B"));
+		const selector = new TreeSelectorComponent(
+			[root],
+			"a3",
+			40,
+			() => {},
+			() => {},
+		);
+		const list = selector.getTreeList();
+		expect(list.getVisibleEntryIds()).toEqual(["root", "a1", "a2", "a3", "a2b", "b1"]);
+
+		while (list.getSelectedNode()?.entry.id !== "b1") selector.handleInput(DOWN);
+		// a2 forks and sits above b1 on screen, but on another thread entirely —
+		// b1's own fork is the root it hangs off.
+		selector.handleInput(LEFT);
+		expect(list.getSelectedNode()?.entry.id).toBe("root");
+
+		// Descending follows the branch drawn first, so it lands inside thread A
+		// rather than on b1.
+		selector.handleInput(RIGHT);
+		expect(list.getSelectedNode()?.entry.id).toBe("a2");
+
+		selector.handleInput(LEFT);
+		expect(list.getSelectedNode()?.entry.id).toBe("root");
+	});
+
+	it("runs to the end of the chain when no fork is left that way", () => {
+		const selector = selectorAt("a3"); // root ─┬─ a1 ── a2 ── a3 / └─ b1
+		const list = selector.getTreeList();
+
+		// Nothing forks between a3 and the root but the root itself.
+		selector.handleInput(LEFT);
+		expect(list.getSelectedNode()?.entry.id).toBe("root");
+		selector.handleInput(LEFT);
+		expect(list.getSelectedNode()?.entry.id).toBe("root");
+
+		// No fork below the root on thread A, so the cursor rides the chain to its
+		// deepest row instead of stopping short.
+		selector.handleInput(RIGHT);
+		expect(list.getSelectedNode()?.entry.id).toBe("a3");
+		selector.handleInput(RIGHT);
+		expect(list.getSelectedNode()?.entry.id).toBe("a3");
+	});
+
+	it("keeps a collapsed fork reachable as a branch point", () => {
+		const selector = selectorAt("a3");
+		const list = selector.getTreeList();
+		selector.handleInput(LEFT); // cursor on root
+		selector.handleInput(TAB); // fold the whole session behind it
+		expect(list.getVisibleEntryIds()).toEqual(["root"]);
+
+		selector.handleInput(RIGHT);
+		expect(list.getSelectedNode()?.entry.id).toBe("root");
+	});
+
+	it("moves the cursor to the collapsed ancestor when the selection is hidden", () => {
+		const selector = selectorAt("a3");
+		const list = selector.getTreeList();
+		expect(list.getSelectedNode()?.entry.id).toBe("a3");
+
+		// Walk up to a1 and collapse from there: the cursor must not be stranded
+		// on a row that no longer exists.
+		selector.handleInput(UP);
+		selector.handleInput(UP);
+		expect(list.getSelectedNode()?.entry.id).toBe("a1");
+
+		selector.handleInput(TAB);
+		expect(list.getSelectedNode()?.entry.id).toBe("a1");
+	});
+
+	it("stays linear on a deep chain", () => {
+		const root = assistantNode("n0", null, "entry 0");
+		let tip = root;
+		for (let i = 1; i < 20_000; i++) {
+			tip = link(tip, assistantNode(`n${i}`, tip.entry.id, `entry ${i}`));
+		}
+		const selector = new TreeSelectorComponent(
+			[root],
+			"n0",
+			40,
+			() => {},
+			() => {},
+		);
+
+		const started = performance.now();
+		selector.handleInput(TAB);
+		const elapsed = performance.now() - started;
+
+		expect(selector.getTreeList().getVisibleEntryIds()).toEqual(["n0"]);
+		expect(elapsed).toBeLessThan(2_000);
+	});
+});

--- a/packages/coding-agent/test/modes/components/tree-selector-collapse.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-collapse.test.ts
@@ -259,7 +259,7 @@ describe("tree selector collapse", () => {
 		const selector = new TreeSelectorComponent(
 			[root],
 			"n11",
-			10,
+			13,
 			() => {},
 			() => {},
 		);


### PR DESCRIPTION
On a session with many forks, `/tree` is a wall of rows and the branch you want is somewhere in it. Filter modes drop entries by *kind*, which is the wrong axis — you want to hide a *subtree*.

- `Space` (or `Tab`) folds the selected node's subtree. The folded node keeps its row, marked `▸` with the number of hidden entries, so the branch stays selectable and the fold is visibly reversible. `Space` only collapses while no search is being typed, since it is also a search character.
- `Shift+Tab` folds every branch off the current thread down to one row each, leaving the active path open end to end — a bulk fold that hid *all* fork points would fold the thread you are reading. The fold anchors on the first row of each branch that survives the current filter: branch heads are frequently filtered away, and folding a hidden row takes the whole branch with it, marker and count included.
- `←`/`→` jump to the fork above the cursor and the next fork below it, following **parent links, not screen order** — the active branch is drawn first, so the row above the cursor often belongs to an unrelated thread. Row depth cannot substitute for ancestry either, since #7333 made linear continuations share their branch head's indent. Paging moves to `PgUp`/`PgDn`, matching every other selector in the TUI.

Collapse is applied as a filter, ahead of the mode and search filters, so folded rows hide exactly the way filtered rows do and connector geometry is left alone.

Tests: `test/modes/components/tree-selector-collapse.test.ts`. Also checked against a real 206-row session that filtered and unfiltered renders stay byte-identical to `main` apart from the hint line.