### PR TITLE
feat(session): add /prune to drop empty conversation branches

### DIFF
--- a/bazel-oh-my-pi
+++ b/bazel-oh-my-pi
@@ -1,0 +1,1 @@
+/home/lime/.cache/bazel/_bazel_lime/1bf02ea2bd21106999c8a6708f331f06/execroot/_main

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `/prune` slash command that deletes conversation branches with nothing to read in them: an entry survives only if an answered assistant reply sits at or below it, so unanswered prompts, replies that errored or were aborted, replies left waiting on a tool call that never came back, and the tool traffic under them all go. The active branch is always kept intact.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1306,6 +1306,27 @@ export class CommandController {
 		this.ctx.showStatus(formatShakeSummary(result));
 	}
 
+	/**
+	 * TUI handler for `/prune`. Prunes empty branches from the session history.
+	 */
+	async handlePruneCommand(): Promise<void> {
+		let count: number;
+		try {
+			count = await this.ctx.session.pruneEmptyBranches();
+		} catch (error) {
+			this.ctx.showError(`Prune failed: ${error instanceof Error ? error.message : String(error)}`);
+			return;
+		}
+
+		if (count === 0) {
+			this.ctx.showStatus("No empty branches to prune.");
+			return;
+		}
+		this.ctx.statusLine.invalidate();
+		this.ctx.ui.requestRender();
+		this.ctx.showStatus(`Pruned ${count} empty branch ${count === 1 ? "entry" : "entries"}.`);
+	}
+
 	async executeCompaction(
 		customInstructionsOrOptions?: string | CompactOptions,
 		isAuto = false,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4685,6 +4685,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleShakeCommand(mode);
 	}
 
+	handlePruneCommand(): Promise<void> {
+		return this.#commandController.handlePruneCommand();
+	}
+
 	executeCompaction(
 		customInstructionsOrOptions?: string | CompactOptions,
 		isAuto?: boolean,

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -364,6 +364,7 @@ export interface InteractiveModeContext {
 	): Promise<CompactionOutcome>;
 	handleHandoffCommand(customInstructions?: string): Promise<void>;
 	handleShakeCommand(mode: ShakeMode): Promise<void>;
+	handlePruneCommand(): Promise<void>;
 	handleMoveCommand(targetPath?: string): Promise<void>;
 	handleRenameCommand(title: string): Promise<void>;
 	handleMemoryCommand(text: string): Promise<void>;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4334,6 +4334,12 @@ export class AgentSession {
 		this.#maintenance.abortCompaction();
 	}
 
+	/** Prune all empty branches (ones with no AI assistant messages) from the session history. */
+	async pruneEmptyBranches(): Promise<number> {
+		// SessionManager rewrites the session file itself when it prunes anything.
+		return this.sessionManager.pruneEmptyBranches();
+	}
+
 	/** Trigger idle compaction through the automatic maintenance flow. */
 	async runIdleCompaction(): Promise<void> {
 		await this.#maintenance.runIdleCompaction();

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2312,6 +2312,122 @@ export class SessionManager {
 	}
 
 	/**
+	 * Prune every branch with nothing to read in it.
+	 *
+	 * An entry is kept when an answered assistant reply sits at or below it — so
+	 * a prompt survives on the strength of what came back, and everything on the
+	 * way down to that reply survives with it. A reply that errored, was
+	 * aborted, or stopped waiting on a tool call is not an answer: it records a
+	 * request that never landed, so a branch holding nothing else is as empty as
+	 * one holding no reply at all and goes whole, prompt included. A tool call
+	 * mid-conversation is answered by the reply that follows it, so it survives
+	 * on that reply the same way the prompt above it does; only the call left
+	 * dangling at the tail of an abandoned branch goes. The failure itself is
+	 * kept only when the retry that finally worked hangs below it.
+	 *
+	 * That leaves nothing behind at the tail of a branch: a prompt that was never
+	 * answered, a summary of a branch you abandoned, or the metadata
+	 * stranded at its head all go with it. Tool results are the exception, kept
+	 * with the reply that called them — nothing answers a tool result, and it is
+	 * not what you came back to the branch to read. The active path is always
+	 * kept, so pruning can never delete the conversation you are in, including a
+	 * failure or an unanswered prompt you are still looking at. A label is kept
+	 * when its target is.
+	 *
+	 * Runs in linear tree passes — no per-entry ancestor walks — so it stays
+	 * usable on deep sessions. Returns the number of pruned entries, and rewrites
+	 * the session file when anything was pruned.
+	 */
+	async pruneEmptyBranches(): Promise<number> {
+		// A reply that stopped on `toolUse` is mid-turn by construction: the model
+		// asked for a tool and the answer, if it ever came, is the reply below it.
+		// Counting it as an answer would strand every abandoned branch whose last
+		// act was a tool call — the prompt reads as answered when nothing came
+		// back. It still survives whenever a real reply hangs underneath, since
+		// the verdict propagates up from the children.
+		const isUnansweredAssistant = (entry: SessionEntry): boolean =>
+			entry.type === "message" &&
+			entry.message.role === "assistant" &&
+			(entry.message.stopReason === "error" ||
+				entry.message.stopReason === "aborted" ||
+				entry.message.stopReason === "toolUse");
+		const isAnsweringAssistant = (entry: SessionEntry): boolean =>
+			entry.type === "message" && entry.message.role === "assistant" && !isUnansweredAssistant(entry);
+		const isToolResult = (entry: SessionEntry): boolean =>
+			entry.type === "message" && entry.message.role === "toolResult";
+
+		const kept = new Set<string>();
+		for (const entry of this.getBranch()) kept.add(entry.id);
+
+		const roots = this.getTree();
+
+		// Post-order: does an answered reply sit at or below this entry? Children
+		// are visited first, so a node's verdict only reads settled state.
+		const replyBelow = new Set<string>();
+		const preOrder: SessionTreeNode[] = [];
+		const stack = [...roots];
+		while (stack.length > 0) {
+			const node = stack.pop() as SessionTreeNode;
+			preOrder.push(node);
+			for (const child of node.children) stack.push(child);
+		}
+		for (let i = preOrder.length - 1; i >= 0; i--) {
+			const node = preOrder[i] as SessionTreeNode;
+			const id = node.entry.id;
+			if (isAnsweringAssistant(node.entry) || node.children.some(child => replyBelow.has(child.entry.id))) {
+				replyBelow.add(id);
+				kept.add(id);
+			}
+		}
+
+		// Pre-order: tool results belong to the reply that called them, so they
+		// live and die with their parent rather than earning a verdict of their
+		// own — nothing answers a tool result, and it is not what you came back to
+		// the branch to read. The same pass drops the children of anything else we
+		// dropped: they would reload as orphan roots, leaving a detached stub of a
+		// message that no longer exists. A parent is always visited first, so each
+		// verdict is final when it is read.
+		for (const node of preOrder) {
+			const { id, parentId } = node.entry;
+			if (!parentId) continue;
+			if (!kept.has(parentId)) kept.delete(id);
+			else if (isToolResult(node.entry)) kept.add(id);
+		}
+
+		// Labels live outside the parent chain: they follow their target.
+		for (const entry of this.#entries) {
+			if (entry.type === "label" && kept.has(entry.targetId)) kept.add(entry.id);
+		}
+
+		// Records that are not tree nodes — the session header, the title — carry
+		// no id the tree ever sees, so a verdict was never computed for them and
+		// dropping them would take the session's own metadata with the branches.
+		const inTree = new Set<string>();
+		for (const node of preOrder) inTree.add(node.entry.id);
+
+		const oldLength = this.#entries.length;
+		const activeLeafId = this.#index.leafId();
+
+		this.#entries = this.#entries.filter(entry => !inTree.has(entry.id) || kept.has(entry.id));
+		this.#index.rebuild(this.#entries);
+		this.#setLeaf(activeLeafId);
+
+		const prunedCount = oldLength - this.#entries.length;
+		if (prunedCount > 0) {
+			// Deleting entries can only be published by rewriting the whole file:
+			// the append path never removes lines, and close() marks the file
+			// current without rewriting, so without this the prune would be lost
+			// on reload.
+			this.#fileIsCurrent = false;
+			this.#rewriteRequired = true;
+			this.#atomicRewriteDirty = true;
+			await this.#rewriteAtomically();
+		}
+
+		return prunedCount;
+	}
+
+	/**
 	 * Move the leaf to an earlier entry so the next append forms a new branch.
 	 * Existing entries are never modified or deleted.
 	 */

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1812,6 +1812,20 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "prune",
+		description: "Prune all empty branches (no assistant reply, or only a failed one)",
+		acpDescription: "Prune empty conversation branches",
+		handle: async (_command, runtime) => {
+			const count = await runtime.session.pruneEmptyBranches();
+			await runtime.output(`Pruned ${count} empty branch ${count === 1 ? "entry" : "entries"}.`);
+			return commandConsumed();
+		},
+		handleTui: async (_command, runtime) => {
+			runtime.ctx.editor.setText("");
+			await runtime.ctx.handlePruneCommand();
+		},
+	},
+	{
 		name: "handoff",
 		description: "Hand off session context to a new session",
 		inlineHint: "[focus instructions]",

--- a/packages/coding-agent/test/session-manager/tree-traversal.test.ts
+++ b/packages/coding-agent/test/session-manager/tree-traversal.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, spyOn } from "bun:test";
 import type { CustomEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { assistantMsg, userMsg } from "../utilities";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { assistantMsg, failedAssistantMsg, toolCallMsg, toolResultMsg, userMsg } from "../utilities";
 
 describe("SessionManager append and tree traversal", () => {
 	describe("append operations", () => {
@@ -485,5 +486,317 @@ describe("createBranchedSession", () => {
 		const entries = session.getEntries();
 		expect(entries).toHaveLength(4);
 		expect(entries.map(e => e.id)).toEqual([id1, id2, id4, id5]);
+	});
+});
+
+describe("pruneEmptyBranches", () => {
+	it("prunes empty abandoned branches and keeps active path and branches with assistant messages", async () => {
+		const session = SessionManager.inMemory();
+
+		// Active branch: Root (user) -> Assistant -> user1 (active, no assistant response yet)
+		const idRoot = session.appendMessage(userMsg("Root"));
+		const idAsst = session.appendMessage(assistantMsg("Assistant"));
+		const idUser1 = session.appendMessage(userMsg("user1")); // active leaf
+
+		// Abandoned empty branch (no assistant messages): Root -> user2
+		session.branch(idRoot);
+		const idUser2 = session.appendMessage(userMsg("user2"));
+
+		// Abandoned non-empty branch (has assistant message): Root -> user3 -> asst3 -> user3_sub
+		session.branch(idRoot);
+		const idUser3 = session.appendMessage(userMsg("user3"));
+		const idAsst3 = session.appendMessage(assistantMsg("asst3"));
+		const idUser3Sub = session.appendMessage(userMsg("user3_sub"));
+
+		// Add a label to a kept entry
+		const labelId1 = session.appendLabelChange(idAsst3, "milestone");
+
+		// Add a label to an empty/prunable entry
+		const labelId2 = session.appendLabelChange(idUser2, "useless");
+
+		// Active leaf is still user1
+		session.branch(idUser1);
+
+		const prunedCount = await session.pruneEmptyBranches();
+		expect(prunedCount).toBe(3); // user2, labelId2, and the unanswered user3_sub
+
+		const entries = session.getEntries();
+		const entryIds = entries.map(e => e.id);
+
+		// Kept entries
+		expect(entryIds).toContain(idRoot);
+		expect(entryIds).toContain(idAsst);
+		expect(entryIds).toContain(idUser1);
+		expect(entryIds).toContain(idUser3);
+		expect(entryIds).toContain(idAsst3);
+		expect(entryIds).toContain(labelId1);
+
+		// Pruned entries
+		expect(entryIds).not.toContain(idUser2);
+		expect(entryIds).not.toContain(labelId2);
+		// Nothing answered user3_sub and it is not the branch we are in, so it is
+		// the same dead end as user2 — one row deeper.
+		expect(entryIds).not.toContain(idUser3Sub);
+	});
+
+	it("never prunes the active branch, even with no assistant message anywhere", async () => {
+		const session = SessionManager.inMemory();
+		session.appendMessage(userMsg("only"));
+		session.appendMessage(userMsg("still talking"));
+
+		expect(await session.pruneEmptyBranches()).toBe(0);
+		expect(session.getEntries()).toHaveLength(2);
+	});
+
+	it("keeps a branch whose only assistant message is below the fork", async () => {
+		const session = SessionManager.inMemory();
+		const idRoot = session.appendMessage(userMsg("root"));
+		const idAsst = session.appendMessage(assistantMsg("answer"));
+
+		// Abandoned branch: two user turns before the assistant finally replies.
+		session.branch(idRoot);
+		const idDeepUser = session.appendMessage(userMsg("retry"));
+		const idDeepUser2 = session.appendMessage(userMsg("retry harder"));
+		const idDeepAsst = session.appendMessage(assistantMsg("late answer"));
+		session.branch(idAsst);
+
+		expect(await session.pruneEmptyBranches()).toBe(0);
+		const ids = session.getEntries().map(e => e.id);
+		expect(ids).toContain(idDeepUser);
+		expect(ids).toContain(idDeepUser2);
+		expect(ids).toContain(idDeepAsst);
+	});
+
+	it("drops bookkeeping entries on a pruned branch but keeps them on a kept one", async () => {
+		const session = SessionManager.inMemory();
+		const idRoot = session.appendMessage(userMsg("root"));
+		session.appendMessage(assistantMsg("answer"));
+		const idKeptThinking = session.appendThinkingLevelChange("high");
+
+		session.branch(idRoot);
+		const idDoomedThinking = session.appendThinkingLevelChange("low");
+		const idDoomedUser = session.appendMessage(userMsg("abandoned"));
+		session.branch(idKeptThinking);
+
+		expect(await session.pruneEmptyBranches()).toBe(2);
+		const ids = session.getEntries().map(e => e.id);
+		expect(ids).toContain(idKeptThinking);
+		expect(ids).not.toContain(idDoomedThinking);
+		expect(ids).not.toContain(idDoomedUser);
+	});
+
+	it("is idempotent: a second prune finds nothing", async () => {
+		const session = SessionManager.inMemory();
+		const idRoot = session.appendMessage(userMsg("root"));
+		const idAsst = session.appendMessage(assistantMsg("answer"));
+		session.branch(idRoot);
+		session.appendMessage(userMsg("abandoned"));
+		session.branch(idAsst);
+
+		expect(await session.pruneEmptyBranches()).toBe(1);
+		expect(await session.pruneEmptyBranches()).toBe(0);
+	});
+
+	it("prunes a branch whose only reply errored or was aborted", async () => {
+		const session = SessionManager.inMemory();
+		const idRoot = session.appendMessage(userMsg("root"));
+		const idAsst = session.appendMessage(assistantMsg("answer"));
+
+		// Both attempts fork off the prompt itself, so nothing but the failure ever
+		// answered them.
+		session.branch(idRoot);
+		const idErrorPrompt = session.appendMessage(userMsg("try this"));
+		const idError = session.appendMessage(failedAssistantMsg("half a th", "error"));
+
+		session.branch(idRoot);
+		const idAbortPrompt = session.appendMessage(userMsg("no, this"));
+		const idAborted = session.appendMessage(failedAssistantMsg("stopp", "aborted"));
+
+		session.branch(idAsst);
+
+		expect(await session.pruneEmptyBranches()).toBe(4);
+		const ids = session.getEntries().map(e => e.id);
+		expect(ids).not.toContain(idError);
+		expect(ids).not.toContain(idErrorPrompt);
+		expect(ids).not.toContain(idAborted);
+		expect(ids).not.toContain(idAbortPrompt);
+		expect(ids).toContain(idAsst);
+	});
+
+	it("keeps a failure that the retry below it hangs off", async () => {
+		const session = SessionManager.inMemory();
+		session.appendMessage(userMsg("root"));
+		const idFailed = session.appendMessage(failedAssistantMsg("half a th", "error"));
+		const idRetry = session.appendMessage(assistantMsg("answer"));
+		session.branch(idRetry);
+
+		expect(await session.pruneEmptyBranches()).toBe(0);
+		expect(session.getEntries().map(e => e.id)).toContain(idFailed);
+	});
+
+	it("drops a dead-end failure hanging off an answered branch", async () => {
+		const session = SessionManager.inMemory();
+		session.appendMessage(userMsg("root"));
+		const idAsst = session.appendMessage(assistantMsg("answer"));
+		const idPrompt = session.appendMessage(userMsg("and now this"));
+		const idFailed = session.appendMessage(failedAssistantMsg("half a th", "error"));
+		session.branch(idAsst);
+
+		// Nothing answered the prompt, so the whole dead end goes — an answer
+		// further up the branch does not vouch for what came after it.
+		expect(await session.pruneEmptyBranches()).toBe(2);
+		const ids = session.getEntries().map(e => e.id);
+		expect(ids).not.toContain(idPrompt);
+		expect(ids).not.toContain(idFailed);
+	});
+
+	it("takes the tool traffic under a pruned failure with it", async () => {
+		const session = SessionManager.inMemory();
+		const idRoot = session.appendMessage(userMsg("root"));
+		const idAsst = session.appendMessage(assistantMsg("answer"));
+		session.branch(idAsst);
+		const idPrompt = session.appendMessage(userMsg("run the thing"));
+		const idFailed = session.appendMessage(failedAssistantMsg("calling", "aborted"));
+		const idToolResult = session.appendMessage(toolResultMsg("cancelled"));
+		session.branch(idRoot);
+
+		expect(await session.pruneEmptyBranches()).toBe(3);
+		const ids = session.getEntries().map(e => e.id);
+		// A surviving tool result would reload as an orphan root: a detached stub
+		// of a message that no longer exists. Its content also must not be what
+		// keeps the failure alive — that is the wreckage of the failed turn.
+		expect(ids).not.toContain(idToolResult);
+		expect(ids).not.toContain(idFailed);
+		expect(ids).not.toContain(idPrompt);
+	});
+
+	it("drops an unanswered prompt at the tail of an abandoned branch", async () => {
+		const session = SessionManager.inMemory();
+		const idRoot = session.appendMessage(userMsg("root"));
+		const idAsst = session.appendMessage(assistantMsg("answer"));
+		const idDangling = session.appendMessage(userMsg("and one more thing"));
+		session.branch(idRoot);
+		const idOther = session.appendMessage(assistantMsg("elsewhere"));
+		session.branch(idOther);
+
+		// The reply above it answered the prompt before it, not this one.
+		expect(await session.pruneEmptyBranches()).toBe(1);
+		const ids = session.getEntries().map(e => e.id);
+		expect(ids).not.toContain(idDangling);
+		expect(ids).toContain(idAsst);
+	});
+
+	it("keeps the tool results of a reply that was never followed up", async () => {
+		const session = SessionManager.inMemory();
+		const idRoot = session.appendMessage(userMsg("root"));
+		const idAsst = session.appendMessage(assistantMsg("running it"));
+		const idToolResult = session.appendMessage(toolResultMsg("output"));
+		session.branch(idRoot);
+		session.appendMessage(assistantMsg("elsewhere"));
+
+		// Nothing answers a tool result, so it cannot earn its own verdict — it
+		// belongs to the reply that called it.
+		expect(await session.pruneEmptyBranches()).toBe(0);
+		expect(session.getEntries().map(e => e.id)).toContain(idToolResult);
+		expect(session.getEntries().map(e => e.id)).toContain(idAsst);
+	});
+
+	it("drops a prompt whose only reply stopped on a tool call that never came back", async () => {
+		const session = SessionManager.inMemory();
+		const idRoot = session.appendMessage(userMsg("root"));
+		session.appendMessage(assistantMsg("answer"));
+		session.branch(idRoot);
+		const idPrompt = session.appendMessage(userMsg("Or are they something else?"));
+		const idCall = session.appendMessage(toolCallMsg("looking it up"));
+		session.branch(idRoot);
+
+		// A reply that stopped waiting on a tool is a request, not an answer:
+		// nothing came back, so the prompt reads as unanswered and goes with it.
+		expect(await session.pruneEmptyBranches()).toBe(2);
+		const ids = session.getEntries().map(e => e.id);
+		expect(ids).not.toContain(idPrompt);
+		expect(ids).not.toContain(idCall);
+	});
+
+	it("keeps a tool call that the reply below it answers", async () => {
+		const session = SessionManager.inMemory();
+		const idRoot = session.appendMessage(userMsg("root"));
+		const idPrompt = session.appendMessage(userMsg("run the thing"));
+		const idCall = session.appendMessage(toolCallMsg("running it"));
+		const idResult = session.appendMessage(toolResultMsg("output"));
+		const idAnswer = session.appendMessage(assistantMsg("here is what it said"));
+		session.branch(idRoot);
+
+		expect(await session.pruneEmptyBranches()).toBe(0);
+		const ids = session.getEntries().map(e => e.id);
+		for (const id of [idPrompt, idCall, idResult, idAnswer]) expect(ids).toContain(id);
+	});
+
+	it("never prunes a failure you are still looking at", async () => {
+		const session = SessionManager.inMemory();
+		session.appendMessage(userMsg("root"));
+		session.appendMessage(userMsg("try this"));
+		const idFailed = session.appendMessage(failedAssistantMsg("half a th", "error"));
+
+		expect(await session.pruneEmptyBranches()).toBe(0);
+		expect(session.getEntries().map(e => e.id)).toContain(idFailed);
+	});
+
+	it("keeps the session's own metadata, which is not part of the tree", async () => {
+		using tempDir = TempDir.createSync("@pi-session-prune-meta-");
+		const session = SessionManager.create(tempDir.path(), tempDir.path());
+		await session.setSessionName("irv extremism", "user");
+		const idRoot = session.appendMessage(userMsg("root"));
+		const idAsst = session.appendMessage(assistantMsg("answer"));
+		session.branch(idRoot);
+		session.appendMessage(userMsg("abandoned"));
+		session.branch(idAsst);
+		await session.flush();
+
+		expect(await session.pruneEmptyBranches()).toBe(1);
+		await session.flush();
+
+		// The header and title carry no id the tree ever sees, so there is no
+		// verdict on them to obey — dropping them would rename the session.
+		const reloaded = await SessionManager.open(session.getSessionFile() as string);
+		expect(reloaded.getSessionName()).toBe("irv extremism");
+	});
+
+	it("stays linear on a deep chain", async () => {
+		const session = SessionManager.inMemory();
+		const idRoot = session.appendMessage(userMsg("root"));
+		session.appendMessage(assistantMsg("answer"));
+		for (let i = 0; i < 20_000; i++) session.appendMessage(userMsg(`turn ${i}`));
+
+		// One abandoned empty branch off the root, so pruning has real work to do.
+		session.branch(idRoot);
+		session.appendMessage(userMsg("abandoned"));
+		session.branch(session.getBranch()[0]?.id ?? idRoot);
+
+		const started = performance.now();
+		await session.pruneEmptyBranches();
+		// A per-entry ancestor walk needs ~2x10^8 lookups here and blows past this;
+		// the linear passes land in single-digit milliseconds.
+		expect(performance.now() - started).toBeLessThan(2_000);
+	});
+
+	it("persists the prune: reloading from disk does not resurrect the branch", async () => {
+		using tempDir = TempDir.createSync("@pi-session-prune-");
+		const session = SessionManager.create(tempDir.path(), tempDir.path());
+		const idRoot = session.appendMessage(userMsg("root"));
+		const idAsst = session.appendMessage(assistantMsg("answer"));
+		session.branch(idRoot);
+		const idAbandoned = session.appendMessage(userMsg("abandoned"));
+		session.branch(idAsst);
+		await session.flush();
+
+		expect(await session.pruneEmptyBranches()).toBe(1);
+		await session.flush();
+
+		const reloaded = await SessionManager.open(session.getSessionFile() as string);
+		const ids = reloaded.getEntries().map(e => e.id);
+		expect(ids).toContain(idRoot);
+		expect(ids).toContain(idAsst);
+		expect(ids).not.toContain(idAbandoned);
 	});
 });

--- a/packages/coding-agent/test/slash-commands/prune.test.ts
+++ b/packages/coding-agent/test/slash-commands/prune.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import {
+	ACP_BUILTIN_SLASH_COMMANDS,
+	executeAcpBuiltinSlashCommand,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/acp-builtins";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
+
+function acpRuntime() {
+	const pruneEmptyBranches = vi.fn(async () => 5);
+	const output = vi.fn();
+	const runtime = { session: { pruneEmptyBranches }, output } as unknown as SlashCommandRuntime;
+	return { pruneEmptyBranches, output, runtime };
+}
+
+function tuiRuntime() {
+	const handlePruneCommand = vi.fn(async () => {});
+	const setText = vi.fn();
+	const runtime = {
+		ctx: {
+			editor: { setText } as unknown as InteractiveModeContext["editor"],
+			handlePruneCommand,
+		} as unknown as InteractiveModeContext,
+	};
+	return { handlePruneCommand, setText, runtime };
+}
+
+describe("/prune dispatch (ACP)", () => {
+	it("invokes pruneEmptyBranches and outputs the count", async () => {
+		const h = acpRuntime();
+		await executeAcpBuiltinSlashCommand("/prune", h.runtime);
+		expect(h.pruneEmptyBranches).toHaveBeenCalled();
+		expect(h.output.mock.calls[0]?.[0] as string).toContain("Pruned 5 empty branch entries.");
+	});
+
+	it("is advertised to ACP clients", () => {
+		const advertised = ACP_BUILTIN_SLASH_COMMANDS.find(c => c.name === "prune");
+		expect(advertised).toBeDefined();
+		expect(advertised?.description).toContain("Prune empty conversation branches");
+	});
+});
+
+describe("/prune dispatch (TUI)", () => {
+	it("routes to handlePruneCommand and clears the editor", async () => {
+		const h = tuiRuntime();
+		const handled = await executeBuiltinSlashCommand("/prune", h.runtime);
+		expect(handled).toBe(true);
+		expect(h.setText).toHaveBeenCalledWith("");
+		expect(h.handlePruneCommand).toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/utilities.ts
+++ b/packages/coding-agent/test/utilities.ts
@@ -76,6 +76,39 @@ export function assistantMsg(text: string) {
 }
 
 /**
+ * An assistant message that never landed — the shape the agent loop writes when
+ * a turn dies mid-flight ("error") or the user interrupts it ("aborted").
+ */
+export function failedAssistantMsg(text: string, stopReason: "error" | "aborted" = "error") {
+	return { ...assistantMsg(text), stopReason, errorMessage: "boom" };
+}
+
+/**
+ * A mid-turn assistant reply: the model asked for a tool and stopped. Whatever
+ * it answers with, if anything, is the reply that follows below it.
+ */
+export function toolCallMsg(text: string, toolName = "bash") {
+	const base = assistantMsg(text);
+	return {
+		...base,
+		content: [...base.content, { type: "toolCall" as const, id: `call-${text}`, name: toolName, arguments: {} }],
+		stopReason: "toolUse" as const,
+	};
+}
+
+/** A tool result entry — the traffic that hangs under an assistant tool call. */
+export function toolResultMsg(text: string, toolName = "bash") {
+	return {
+		role: "toolResult" as const,
+		toolCallId: `call-${text}`,
+		toolName,
+		content: [{ type: "text" as const, text }],
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+/**
  * Create an AgentSession for testing with proper setup and cleanup.
  * Use this for e2e tests that need real LLM calls.
  */


### PR DESCRIPTION
Abandoned branches accumulate in a long session: a prompt that was retried, a reply that errored out, the tool traffic hanging under it. `/tree` fills with rows nobody will read again and nothing removes them.

`/prune` rewrites the session file, keeping an entry only when an assistant reply that actually *answered* sits at or below it. So:

- unanswered prompts go;
- replies that errored or were aborted go, unless a working retry hangs below them (then the failure is part of a real thread);
- tool results go with the reply that called them;
- dropping an entry drops its descendants, or they reload as orphan roots;
- the active branch is never touched, and records outside the tree (session header, title) are left alone.

Validated against a real 7081-entry session: 29 entries pruned, 0 orphans, reload clean, a second prune a no-op.

Tests: `test/session-manager/tree-traversal.test.ts`, `test/slash-commands/prune.test.ts`.