### PR TITLE
feat(advisor): add minimal context mode (advisor-light)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ _[Watch the capture ↗](https://omp.sh/clips/irc.mp4)_
 
 Pair a reviewer model to the 'advisor' role and it reads every turn the main agent takes, injecting notes inline — a quiet aside, a concern, or a hard blocker. It runs on its own context and its own model, so it catches what the doer rushed past. The main agent sees the note and course-corrects, or tells you why it won't.
 
-![omp TUI: /advisor status shows the advisor running on openai-codex/gpt-5.5; after the main agent scopes a catch to ENOENT instead of swallowing every error, an amber 'Advisor 1 note (concern)' card warns the fix no longer matches the user's literal acceptance criterion.](https://omp.sh/clips/advisor-poster.webp)
+![omp TUI: /advisor status shows a dedicated advisor; after the main agent scopes a catch to ENOENT instead of swallowing every error, an amber 'Advisor 1 note (concern)' card warns the fix no longer matches the user's literal acceptance criterion.](https://omp.sh/clips/advisor-poster.webp)
 
 _[Watch the capture ↗](https://omp.sh/clips/advisor.mp4)_
 

--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -53,9 +53,14 @@ If `advisor.enabled` is true but no `modelRoles.advisor` value resolves to an av
 
 ## What the advisor sees
 
-At each primary turn end, `AdvisorRuntime` receives only the new transcript delta since the last advisor update. Deltas are rendered with `formatSessionHistoryMarkdown(..., { includeThinking: true, includeToolIntent: true, watchedRoles: true, expandPrimaryContext: true })`, so the advisor can review assistant reasoning as well as user-visible text, tool calls, and tool results.
+At each primary turn end, `AdvisorRuntime` receives only the new transcript delta since the last advisor update. In the default `full` mode, each delta is rendered with `formatSessionHistoryMarkdown(..., { includeThinking: true, includeToolIntent: true, watchedRoles: true, expandPrimaryContext: true })`, so the advisor can review assistant reasoning as well as user-visible text, tool calls, and tool results.
 
-Most hidden `custom` messages collapse to a one-line summary in the delta. The exception is the primary agent's injected constraint context — the types in `PRIMARY_CONTEXT_CUSTOM_TYPES` (`plan-mode-context`, `plan-mode-reference`). `expandPrimaryContext` renders these verbatim inside a `<primary-context kind="…">` wrapper (XML-escaped, so plan/objective text cannot break out or read as advisor instructions). Without this the advisor only saw a 120-char truncation of the plan-mode rules — which cut off mid-sentence at `NEVER create, edit, or delete files — excep…`, hiding the "except the single plan file" carve-out and producing false blockers against the agent writing its own plan file. Because these prompts are re-injected verbatim every primary turn, `AdvisorRuntime` dedupes them: a byte-identical re-injection collapses to a `(unchanged — still in effect)` marker, and the full body re-expands whenever the content changes or the advisor re-primes. `goal-mode-context` is deliberately excluded — its live budget counters change every turn, so it can neither dedupe nor expand cheaply.
+Per-advisor `context` settings in `WATCHDOG.yml` change that view:
+
+- `full` (default): append each rendered primary delta to the advisor's private conversation. This is usually the cheapest mode on providers with prefix-based prompt caching, because the growing prefix is cached once and only the new delta is re-tokenized each turn.
+- `minimal`: also append each delta, but omit reasoning, tool intent, and expanded edit diffs. Like `full`, it keeps a stable, growing prefix, so it reduces per-delta size without breaking cache. Use this when the goal is to reduce token usage per turn while keeping full advisor history.
+
+Most hidden `custom` messages collapse to a one-line summary in the delta. The exception is the primary agent's injected constraint context — the types in `PRIMARY_CONTEXT_CUSTOM_TYPES` (`plan-mode-context`, `plan-mode-reference`) — plus hidden companions such as `image-attachment-description` that describe visible transcript entries. `expandPrimaryContext` renders plan/goal constraints verbatim inside a `<primary-context kind="…">` wrapper (XML-escaped, so plan/objective text cannot break out or read as advisor instructions); image descriptions render normally. Because these prompts are re-injected verbatim every primary turn, `AdvisorRuntime` collapses an unchanged copy to a short marker until the advisor is re-primed.
 
 Advisor messages already injected into the primary transcript are filtered out before the next delta is rendered. This prevents the advisor from recursively reviewing its own advice.
 
@@ -66,9 +71,9 @@ When the primary transcript is rewritten, the advisor runtime is reset:
 - branch/fork style history replacement
 - context-maintenance re-prime when the advisor's own context cannot fit
 
-Reset clears the advisor's private in-memory transcript and rewinds its cursor. The next advisor update replays the current bounded primary transcript instead of continuing from stale pre-rewrite context.
+Reset clears the advisor's private in-memory transcript and rewinds its cursor. The next advisor update replays the configured current primary view instead of continuing from stale pre-rewrite context.
 
-When the advisor is enabled mid-session, the cursor seeds to the current primary transcript length. That avoids replaying the whole old conversation on the first enabled turn.
+When the advisor is enabled mid-session, the runtime seeds the cursor to the current primary transcript length so the next update only sends the new delta.
 
 ## Tools and isolation
 
@@ -218,6 +223,7 @@ advisors:
   - name: Architecture
     model: anthropic/claude-sonnet-4-5:medium
     tools: [read, grep, glob]
+    context: minimal
     instructions: |
       Watch cross-module coupling and public-API growth.
 
@@ -235,6 +241,7 @@ Fields:
 - `advisors[].model`: optional model selector with optional `:level` thinking suffix (e.g. `x-ai/grok-code-fast:high`). Omitted → the advisor uses `modelRoles.advisor`.
 - `advisors[].tools`: optional list of built-in tool names to grant. Omitted or empty → the default `read`/`grep`/`glob` subset. Any name in [`BUILTIN_TOOL_NAMES`](../packages/coding-agent/src/tools/builtin-names.ts) is accepted, including mutating tools (`edit`, `write`, `bash`, `eval`, `browser`, `debug`, `ast_edit`, `task`, `job`, and the memory tools). Legacy aliases (`search`→`grep`, `find`→`glob`) are normalized. Unknown names are dropped with a warning. See [Tools and isolation](#tools-and-isolation) for the safety implications of granting mutating tools.
 - `advisors[].instructions`: this advisor's specialization, appended after the shared baseline. Both instruction fields expand `@path` imports like `WATCHDOG.md`.
+- `advisors[].context`: optional primary-context policy: `full` (default) or `minimal`. `minimal` reduces each rendered delta but retains the normal append-only advisor history.
 
 ### Discovery locations
 
@@ -253,13 +260,11 @@ Subagent advisors remain isolated from the subagent's primary tool session in th
 
 Advisor usage is separate model usage. `/advisor status` reports advisor token counts and cost from the advisor agent's own transcript.
 
-The advisor has its own append-only context. Before each advisor prompt, `AgentSession` estimates incoming tokens and may maintain advisor context:
+In `full` and `minimal` modes, the advisor has its own append-only context. Before each advisor prompt, `AgentSession` estimates incoming tokens and may maintain that context:
 
 1. try model-level context promotion when enabled and a larger compatible model is available
 2. if promotion cannot fit enough context, compact the advisor's own message history
-3. if compaction has no candidates or still cannot fit, re-prime from the current bounded primary transcript
-
-The advisor's live context is in-memory and append-only; it is retained while the session runs so `/advisor dump` can inspect it, and is independently promoted/compacted/re-primed (above). It is not a replacement for the primary persisted transcript.
+3. if compaction has no candidates or still cannot fit, re-prime from the configured current primary view
 
 ## Transcript persistence and observability
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added per-advisor primary-context policies in `WATCHDOG.yml`: `context: full | minimal`. `minimal` mode keeps append-only history but omits verbose reasoning, tool intent, and expanded edit diffs from each primary delta, giving the advisor a lighter view of the session without changing the append-only delivery model.
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -1572,6 +1572,54 @@ describe("advisor", () => {
 			expect(promptInputs[1]).toContain("new-conversation");
 			expect(promptInputs[1]).not.toContain("old-conversation");
 		});
+
+		it("full context mode includes the entire delta by default", async () => {
+			const promptInputs: string[] = [];
+			const agent = makeAgent(promptInputs);
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "first", timestamp: 1 } as AgentMessage,
+				{ role: "assistant", content: "reply first", timestamp: 2 } as unknown as AgentMessage,
+				{ role: "user", content: "second", timestamp: 3 } as AgentMessage,
+				{ role: "assistant", content: "reply second", timestamp: 4 } as unknown as AgentMessage,
+			];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+			runtime.onTurnEnd();
+			await Promise.resolve();
+			expect(promptInputs).toHaveLength(1);
+			expect(promptInputs[0]).toContain("first");
+			expect(promptInputs[0]).toContain("second");
+		});
+
+		it("minimal context mode strips thinking from the advisor prompt", async () => {
+			const promptInputs: string[] = [];
+			const agent = makeAgent(promptInputs);
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "hello", timestamp: 1 } as AgentMessage,
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "I should check the edge case first." },
+						{ type: "text", text: "ok" },
+					],
+					timestamp: 2,
+				} as AgentMessage,
+			];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0, { mode: "minimal" });
+			runtime.onTurnEnd();
+			await Promise.resolve();
+			expect(promptInputs).toHaveLength(1);
+			expect(promptInputs[0]).not.toContain("I should check the edge case first");
+			expect(promptInputs[0]).not.toContain("_thinking:_");
+			expect(promptInputs[0]).toContain("hello");
+		});
 	});
 
 	describe("advisor default tools", () => {
@@ -1851,6 +1899,19 @@ describe("advisor", () => {
 			const text = strip(overlay.render(120));
 			expect(text).toContain("Editing");
 			expect(text).toContain("Architecture");
+		});
+
+		it("exposes a minimal-context policy in the detail editor", async () => {
+			const uiTheme = await getThemeByName("dark");
+			if (!uiTheme) throw new Error("theme unavailable");
+			setThemeInstance(uiTheme);
+			const overlay = make({ advisors: [{ name: "Architecture", context: "minimal" }] });
+			overlay.render(120);
+			overlay.handleInput("\x1b[<0;4;2M");
+
+			const text = strip(overlay.render(120));
+			expect(text).toContain("Context");
+			expect(text).toContain("minimal");
 		});
 
 		it("seeds a visible default advisor (labeled with the role model) when the config is empty", async () => {

--- a/packages/coding-agent/src/advisor/__tests__/config.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/config.test.ts
@@ -35,6 +35,7 @@ describe("discoverAdvisorConfigs", () => {
 			"  - name: Architecture",
 			"    model: x-ai/grok-code-fast:high",
 			"    instructions: Watch module boundaries.",
+			"    context: minimal",
 			"  - name: Security Reviewer",
 			"    tools: [read, definitely-not-a-tool]",
 		].join("\n");
@@ -48,6 +49,7 @@ describe("discoverAdvisorConfigs", () => {
 		// resolution happens later in the session, not here.
 		expect(arch.model).toBe("x-ai/grok-code-fast:high");
 		expect(arch.instructions).toBe("Watch module boundaries.");
+		expect(arch.context).toBe("minimal");
 		expect(sec.name).toBe("Security Reviewer");
 		expect(sec.model).toBeUndefined();
 		// The unknown/non-read-only tool is dropped; only `read` survives.
@@ -98,7 +100,12 @@ describe("WATCHDOG.yml file round-trip", () => {
 	const doc: WatchdogConfigDoc = {
 		instructions: 'Shared baseline.\nSecond line with: a colon and "quotes".',
 		advisors: [
-			{ name: "Architecture", model: "x-ai/grok-code-fast:high", instructions: "Watch module boundaries." },
+			{
+				name: "Architecture",
+				model: "x-ai/grok-code-fast:high",
+				instructions: "Watch module boundaries.",
+				context: "minimal",
+			},
 			{ name: "Security", tools: ["read", "grep"] },
 		],
 	};

--- a/packages/coding-agent/src/advisor/config.ts
+++ b/packages/coding-agent/src/advisor/config.ts
@@ -15,12 +15,18 @@ import { collectConfigCandidates } from "./watchdog";
  * `edit`/`write`/`bash` (the advisor is a full agent). Omitted or empty falls
  * back to the default `read`/`grep`/`glob` subset. `instructions` is the
  * advisor's specialization, appended to the shared baseline.
+ *
+ * `context` controls the advisor's retained primary-session context. `full`
+ * (default) keeps the normal append-only behavior; `minimal` strips verbose
+ * reasoning and diffs from each update, reducing the per-delta size without
+ * invalidating provider prefix caching.
  */
 export interface AdvisorConfig {
 	name: string;
 	model?: string;
 	tools?: string[];
 	instructions?: string;
+	context?: "full" | "minimal";
 }
 
 /**
@@ -38,6 +44,7 @@ const advisorEntrySchema = type({
 	"model?": "string",
 	"tools?": "string[]",
 	"instructions?": "string",
+	"context?": "'full' | 'minimal'",
 });
 
 const watchdogYamlSchema = type({
@@ -125,6 +132,7 @@ export async function discoverAdvisorConfigs(cwd: string, agentDir?: string): Pr
 				model: entry.model?.trim() || undefined,
 				tools: filterAdvisorTools(entry.tools, item.path),
 				instructions,
+				context: entry.context,
 			});
 		}
 	}
@@ -212,6 +220,7 @@ export async function loadWatchdogConfigFile(filePath: string): Promise<Watchdog
 			model: a.model?.trim() || undefined,
 			tools: a.tools?.length ? [...a.tools] : undefined,
 			instructions: a.instructions?.trim() ? a.instructions : undefined,
+			context: a.context,
 		})),
 	};
 }
@@ -231,6 +240,7 @@ export function serializeWatchdogConfig(doc: WatchdogConfigDoc): string {
 			if (a.model?.trim()) entry.model = a.model;
 			if (a.tools?.length) entry.tools = [...a.tools];
 			if (a.instructions?.trim()) entry.instructions = a.instructions;
+			if (a.context) entry.context = a.context;
 			return entry;
 		});
 	}

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -63,9 +63,25 @@ export interface AdvisorRuntimeHost {
 	notifyFailure?(error: unknown): void;
 }
 
+/** Controls how much primary-session context an advisor retains. */
+export type AdvisorContextMode = "full" | "minimal";
+
+/** Per-advisor controls for how much of the primary transcript the advisor sees. */
+export interface AdvisorContextConfig {
+	/**
+	 * `full` appends each primary delta; `minimal` omits verbose reasoning and
+	 * diffs from each delta while keeping the same append-only history.
+	 */
+	mode?: AdvisorContextMode;
+}
+
 interface PendingDelta {
 	text: string;
 	turns: number;
+}
+
+interface RenderedDelta {
+	text: string;
 }
 
 interface CatchupWaiter {
@@ -101,6 +117,7 @@ export class AdvisorRuntime {
 		private readonly agent: AdvisorAgent,
 		private readonly host: AdvisorRuntimeHost,
 		private readonly retryDelayMs = 1000,
+		private readonly contextConfig: AdvisorContextConfig = {},
 	) {}
 
 	get backlog(): number {
@@ -111,9 +128,9 @@ export class AdvisorRuntime {
 		if (this.disposed) return;
 		const all = messages ?? this.host.snapshotMessages();
 		this.#latestMessages = all;
-		const render = this.#renderDelta(all);
-		if (render) {
-			this.#pending.push({ text: render, turns: 1 });
+		const rendered = this.#renderDelta(all);
+		if (rendered) {
+			this.#pending.push({ text: rendered.text, turns: 1 });
 			this.#backlog++;
 			this.#notifyWaiters();
 			void this.#drain();
@@ -200,7 +217,7 @@ export class AdvisorRuntime {
 		this.#wakeAllWaiters();
 	}
 
-	#renderDelta(messages?: AgentMessage[]): string | null {
+	#renderDelta(messages?: AgentMessage[]): RenderedDelta | null {
 		const all = messages ?? this.#latestMessages ?? this.host.snapshotMessages();
 		if (all.length < this.#lastCount) {
 			this.#lastCount = all.length;
@@ -213,17 +230,19 @@ export class AdvisorRuntime {
 			.map(m => this.#dedupContextMessage(m));
 		this.#lastCount = all.length;
 		if (delta.length === 0) return null;
+
+		const mode = this.contextConfig.mode ?? "full";
 		const obfuscator = this.host.obfuscator;
 		const formattedDelta = obfuscator?.hasSecrets() ? obfuscateAdvisorDelta(obfuscator, delta) : delta;
 		const md = formatSessionHistoryMarkdown(formattedDelta, {
-			includeThinking: true,
-			includeToolIntent: true,
+			includeThinking: mode !== "minimal",
+			includeToolIntent: mode !== "minimal",
 			watchedRoles: true,
 			expandPrimaryContext: true,
-			expandEditDiffs: true,
+			expandEditDiffs: mode !== "minimal",
 		});
 		if (!md.trim()) return null;
-		return `### Session update\n\n${md}`;
+		return { text: `### Session update\n\n${md}` };
 	}
 
 	/**
@@ -291,10 +310,9 @@ export class AdvisorRuntime {
 			while (!this.disposed && this.#pending.length) {
 				const popped = this.#pending.splice(0);
 				const epoch = this.#epoch;
-				// Each delta already opens with a `### Session update` heading, so
-				// join with a blank line rather than a `---` rule.
 				const candidateBatch = popped.map(b => b.text).join("\n\n");
 				const turnsCovered = popped.reduce((sum, b) => sum + b.turns, 0);
+
 				const incomingTokens = estimateTokens({
 					role: "user",
 					content: candidateBatch,
@@ -318,7 +336,7 @@ export class AdvisorRuntime {
 					// Promotion could not fit the advisor's context — re-prime.
 					const newTurns = this.#pending.reduce((sum, b) => sum + b.turns, 0);
 					this.#resetAdvisorContext(false, false);
-					batch = this.#renderDelta(this.#latestMessages);
+					batch = this.#renderDelta(this.#latestMessages)?.text ?? null;
 					finalTurns = turnsCovered + newTurns;
 				} else {
 					batch = candidateBatch;

--- a/packages/coding-agent/src/modes/components/advisor-config.ts
+++ b/packages/coding-agent/src/modes/components/advisor-config.ts
@@ -104,7 +104,7 @@ function wrap(text: string, width: number): string[] {
 	return Bun.wrapAnsi(text, Math.max(1, width), { trim: false }).split("\n");
 }
 
-type Screen = "list" | "detail" | "name" | "model" | "tools" | "thinking" | "instructions";
+type Screen = "list" | "detail" | "name" | "model" | "tools" | "context" | "thinking" | "instructions";
 
 /**
  * Fullscreen advisor-configuration overlay. Implements {@link Component} directly
@@ -267,11 +267,13 @@ export class AdvisorConfigOverlayComponent implements Component {
 	#advisorPreview(advisor: AdvisorConfig, bodyWidth: number): string[] {
 		const model = advisor.model?.trim() || this.#defaultModelLabel || "advisor role default";
 		const tools = advisor.tools?.length ? advisor.tools.join(", ") : "read, grep, glob (default)";
+		const context = advisor.context ?? "full";
 		const lines = [
 			theme.bold(advisor.name || "(unnamed)"),
 			"",
 			`${theme.fg("dim", "Model:")} ${model}`,
 			`${theme.fg("dim", "Tools:")} ${tools}`,
+			`${theme.fg("dim", "Context:")} ${context}`,
 			"",
 			theme.fg("dim", "Instructions:"),
 		];
@@ -303,14 +305,19 @@ export class AdvisorConfigOverlayComponent implements Component {
 		const advisor = doc.advisors[0];
 		if (!advisor) return false;
 		return (
-			advisor.name === "default" && !advisor.model?.trim() && !advisor.tools?.length && !advisor.instructions?.trim()
+			advisor.name === "default" &&
+			!advisor.model?.trim() &&
+			!advisor.tools?.length &&
+			!advisor.instructions?.trim() &&
+			!advisor.context
 		);
 	}
 
 	#advisorSummary(advisor: AdvisorConfig): string {
 		const model = advisor.model?.trim() || this.#defaultModelLabel || "advisor role default";
 		const tools = advisor.tools?.length ? advisor.tools.join(", ") : "(default: read/grep/glob)";
-		return `${model} · ${tools}`;
+		const context = advisor.context ?? "full";
+		return `${model} · ${tools} · ${context}`;
 	}
 
 	#showList(): void {
@@ -385,6 +392,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 		}
 		const modelDescription = advisor.model?.trim() || this.#defaultModelLabel || "advisor role default";
 		const toolsDescription = advisor.tools?.length ? advisor.tools.join(", ") : "(default: read/grep/glob)";
+		const context = advisor.context ?? "full";
 		const items: SelectItem[] = [
 			{ value: "name", label: "Name", description: advisor.name },
 			{ value: "model", label: "Model", description: modelDescription },
@@ -394,6 +402,9 @@ export class AdvisorConfigOverlayComponent implements Component {
 		}
 		items.push(
 			{ value: "tools", label: "Tools", description: toolsDescription },
+			{ value: "context", label: "Context", description: context },
+		);
+		items.push(
 			{ value: "instructions", label: "Instructions", description: previewLine(advisor.instructions) },
 			{ value: "delete", label: "Delete this advisor" },
 			{ value: "back", label: "Back" },
@@ -418,6 +429,9 @@ export class AdvisorConfigOverlayComponent implements Component {
 					new Set(this.#doc.advisors[index].tools ?? [...ADVISOR_DEFAULT_TOOL_NAMES]),
 					0,
 				);
+				return;
+			case "context":
+				this.#showContextPicker(index);
 				return;
 			case "resetModel":
 				this.#doc.advisors[index].model = undefined;
@@ -526,6 +540,24 @@ export class AdvisorConfigOverlayComponent implements Component {
 			list,
 			"Enter / click toggle · select Done or Esc to apply (empty or read/grep/glob = default)",
 		);
+	}
+
+	#showContextPicker(index: number): void {
+		const items: SelectItem[] = [
+			{ value: "full", label: "Full", description: "Append each primary transcript delta (default)" },
+			{ value: "minimal", label: "Minimal", description: "Omit reasoning, tool intent, and expanded edit diffs" },
+		];
+		const current = this.#doc.advisors[index].context ?? "full";
+		const list = new SelectList(items, Math.max(1, items.length), getSelectListTheme());
+		list.setSelectedIndex(items.findIndex(item => item.value === current));
+		list.onSelect = item => {
+			this.#doc.advisors[index].context =
+				item.value === "full" ? undefined : (item.value as AdvisorConfig["context"]);
+			this.#dirty = true;
+			this.#showDetail(index);
+		};
+		list.onCancel = () => this.#showDetail(index);
+		this.#setScreen("context", list, "Select a primary-context policy · Enter / click apply · Esc cancel");
 	}
 
 	/** `index === -1` edits the shared top-level instructions; otherwise advisor[index]. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2416,7 +2416,8 @@ export class AgentSession {
 	#advisorRuntimeSignature(config: AdvisorConfig, slug: string, model: Model, thinkingLevel: ThinkingLevel): string {
 		const tools = config.tools?.length ? config.tools.join("\u001e") : "";
 		const instructions = config.instructions?.trim() ?? "";
-		return [config.name, slug, formatModelStringWithRouting(model), thinkingLevel, tools, instructions].join(
+		const context = config.context ?? "";
+		return [config.name, slug, formatModelStringWithRouting(model), thinkingLevel, tools, instructions, context].join(
 			"\u001f",
 		);
 	}
@@ -2560,36 +2561,41 @@ export class AgentSession {
 				// so two SessionManagers never hold the same file at once.
 				this.#advisorRecorderClosed,
 			);
-			const runtime = new AdvisorRuntime(advisorAgentFacade, {
-				snapshotMessages: () => this.agent.state.messages,
-				enqueueAdvice: (note, severity) => this.#routeAdvice(advisorRef, note, severity),
-				maintainContext: incomingTokens => this.#maintainAdvisorContext(advisorRef, incomingTokens),
-				obfuscator: this.#obfuscator,
-				beginAdvisorUpdate: () => advisorRef.emissionGuard.beginUpdate(),
-				onTurnError: async error => {
-					// Mirror the auth-gateway's usage-limit remedy: the in-stream a/b/c
-					// auth retry rotates through siblings within one request but never
-					// blocks the LAST failing credential, so without this the advisor
-					// re-picks the same exhausted account every retry. Usage limits
-					// only — other failures keep the plain retry/notify path (never
-					// suspect-mark a credential on a transient advisor error).
-					const message = error instanceof Error ? error.message : String(error);
-					if (!isUsageLimitOutcome(extractHttpStatusFromError(error), message)) return;
-					await this.#modelRegistry.authStorage.markUsageLimitReached(advisorModel.provider, advisorSessionId, {
-						retryAfterMs: extractRetryHint(undefined, message),
-						baseUrl: advisorModel.baseUrl,
-						modelId: advisorModel.id,
-					});
+			const runtime = new AdvisorRuntime(
+				advisorAgentFacade,
+				{
+					snapshotMessages: () => this.agent.state.messages,
+					enqueueAdvice: (note, severity) => this.#routeAdvice(advisorRef, note, severity),
+					maintainContext: incomingTokens => this.#maintainAdvisorContext(advisorRef, incomingTokens),
+					obfuscator: this.#obfuscator,
+					beginAdvisorUpdate: () => advisorRef.emissionGuard.beginUpdate(),
+					onTurnError: async error => {
+						// Mirror the auth-gateway's usage-limit remedy: the in-stream a/b/c
+						// auth retry rotates through siblings within one request but never
+						// blocks the LAST failing credential, so without this the advisor
+						// re-picks the same usage-limited account on every retry. Usage limits
+						// only — other failures keep the plain retry/notify path (never
+						// suspect-mark a credential on a transient advisor error).
+						const message = error instanceof Error ? error.message : String(error);
+						if (!isUsageLimitOutcome(extractHttpStatusFromError(error), message)) return;
+						await this.#modelRegistry.authStorage.markUsageLimitReached(advisorModel.provider, advisorSessionId, {
+							retryAfterMs: extractRetryHint(undefined, message),
+							baseUrl: advisorModel.baseUrl,
+							modelId: advisorModel.id,
+						});
+					},
+					notifyFailure: error => {
+						const message = error instanceof Error ? error.message : String(error);
+						this.emitNotice(
+							"warning",
+							`Advisor${slug ? ` "${advisorName}"` : ""} unavailable for ${formatModelString(advisorModel)}: ${message}`,
+							"advisor",
+						);
+					},
 				},
-				notifyFailure: error => {
-					const message = error instanceof Error ? error.message : String(error);
-					this.emitNotice(
-						"warning",
-						`Advisor${slug ? ` "${advisorName}"` : ""} unavailable for ${formatModelString(advisorModel)}: ${message}`,
-						"advisor",
-					);
-				},
-			});
+				undefined,
+				{ mode: config.context },
+			);
 
 			const advisorRef: ActiveAdvisor = {
 				name: advisorName,

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -234,6 +234,14 @@ const CONTEXTUAL_NON_PRIMARY_HIDDEN_CUSTOM_TYPES: Record<string, true> = {
 	"image-attachment-description": true,
 };
 
+/** Combined set of hidden custom-message types that should be retained when a
+ *  rolling advisor context window starts after them, because they describe or
+ *  constrain the visible transcript that follows. */
+export const CONTEXTUAL_HIDDEN_CUSTOM_TYPES: ReadonlySet<string> = new Set([
+	...PRIMARY_CONTEXT_CUSTOM_TYPES,
+	...Object.keys(CONTEXTUAL_NON_PRIMARY_HIDDEN_CUSTOM_TYPES),
+]);
+
 /** One-liner for custom/hook messages: `[irc] A → B: body…`. */
 function customOneLiner(msg: CustomMessage | HookMessage): string {
 	const details = (msg.details ?? {}) as Record<string, unknown>;
@@ -360,11 +368,7 @@ export function formatSessionHistoryMarkdown(messages: unknown[], opts?: History
 			case "custom":
 			case "hookMessage": {
 				const custom = msg as CustomMessage | HookMessage;
-				if (
-					custom.display === false &&
-					!PRIMARY_CONTEXT_CUSTOM_TYPES.has(custom.customType) &&
-					CONTEXTUAL_NON_PRIMARY_HIDDEN_CUSTOM_TYPES[custom.customType] !== true
-				) {
+				if (custom.display === false && !CONTEXTUAL_HIDDEN_CUSTOM_TYPES.has(custom.customType)) {
 					break;
 				}
 				if (opts?.expandPrimaryContext && PRIMARY_CONTEXT_CUSTOM_TYPES.has(custom.customType)) {


### PR DESCRIPTION
## Summary

Adds a per-advisor `context: full | minimal` policy in `WATCHDOG.yml` that reduces the token cost of the advisor feature by feeding less context to the advisor model.

## Modes

- **`full`** (default): unchanged behavior — appends each rendered primary transcript delta to the advisor's private conversation.
- **`minimal`**: also appends each delta, but omits verbose reasoning, tool intent, and expanded edit diffs. Keeps the same stable, growing prefix as `full`, so it reduces per-delta size **without breaking provider prefix caching**.

## Why not a rolling window

An earlier draft of this PR included a `recent` mode that retained a rolling window of primary turns. Major providers (OpenAI, Anthropic) cache prompts by matching the start of the request; resetting and re-priming the advisor on every window advance invalidated the cached prefix, which could make `recent` **more** expensive than `full` even though the window was smaller. That mode and its `contextBudget` field have been removed entirely. `minimal` is the clean cost-saving path.

## Config

```yaml
advisors:
  - name: Architecture
    model: anthropic/claude-sonnet-4-5:medium
    tools: [read, grep, glob]
    context: minimal
    instructions: |
      Watch cross-module coupling and public-API growth.
```

## Changes

- `AdvisorContextMode` is now `"full" | "minimal"`; `contextBudget` is removed from `AdvisorConfig`, the schema, the runtime, the session signature, and the `/advisor configure` UI.
- `AdvisorRuntime` renders deltas with `includeThinking`/`includeToolIntent`/`expandEditDiffs` disabled in `minimal` mode; the append-only delivery model and context-maintenance re-prime path are unchanged.
- `/advisor configure` shows a two-option context picker (Full / Minimal).
- Docs and changelog updated to describe only `full`/`minimal`.

## Verification

- `bun test src/advisor/__tests__/config.test.ts src/advisor/__tests__/advisor.test.ts` → 88 pass
- `bun run check:ts` → pass