### PR TITLE
feat(tui): show serving model and thinking level in per-turn usage row

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -54,6 +54,9 @@
 - Fixed the status-line `session_name` segment to honor the `statusLine.sessionAccent` setting, falling back to the theme's accent color when disabled.
 - Fixed automatic `agent.continue()` paths failing to run context-fit maintenance when reverting to a smaller-context model after a cooldown expiry.
 - Fixed `/handoff` reporting "Handoff cancelled" for actual generation or stream timeout errors, ensuring the real error is surfaced.
+### Added
+
+- Added the serving model (`provider/id`) and the effective thinking level to per-turn token-usage rows, including the compact grouped-read row. The model renders on live, rebuilt, and exported transcripts; the thinking level renders on live rows only, since it is not persisted per message.
 
 ## [17.2.10] - 2026-08-06
 

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -88,6 +88,7 @@ export class ChatTranscriptBuilder {
 	#pendingUsageDuration: number | undefined;
 	#pendingUsageTtft: number | undefined;
 	#pendingUsageTimestamp: number | undefined;
+	#pendingUsageModel: string | undefined;
 	#pendingReadUsageCallIds: string[] | undefined;
 	#lastAssistantUsage: Usage | undefined;
 	#waitingPoll: ToolExecutionComponent | null = null;
@@ -138,6 +139,7 @@ export class ChatTranscriptBuilder {
 		this.#pendingUsageDuration = undefined;
 		this.#pendingUsageTtft = undefined;
 		this.#pendingUsageTimestamp = undefined;
+		this.#pendingUsageModel = undefined;
 		this.#pendingReadUsageCallIds = undefined;
 		this.#lastAssistantUsage = undefined;
 		this.#waitingPoll = null;
@@ -212,6 +214,7 @@ export class ChatTranscriptBuilder {
 				this.#pendingUsageDuration,
 				this.#pendingUsageTtft,
 				this.#pendingUsageTimestamp,
+				this.#pendingUsageModel,
 			) ??
 				false);
 		if (!usageAttached) {
@@ -223,6 +226,7 @@ export class ChatTranscriptBuilder {
 					this.#pendingUsageDuration,
 					this.#pendingUsageTtft,
 					this.#pendingUsageTimestamp,
+					this.#pendingUsageModel,
 				),
 			);
 		}
@@ -230,6 +234,7 @@ export class ChatTranscriptBuilder {
 		this.#pendingUsageDuration = undefined;
 		this.#pendingUsageTtft = undefined;
 		this.#pendingUsageTimestamp = undefined;
+		this.#pendingUsageModel = undefined;
 		this.#pendingReadUsageCallIds = undefined;
 	}
 
@@ -428,6 +433,7 @@ export class ChatTranscriptBuilder {
 		this.#pendingUsageDuration = message.duration;
 		this.#pendingUsageTtft = message.ttft;
 		this.#pendingUsageTimestamp = message.timestamp;
+		this.#pendingUsageModel = this.#pendingUsage ? `${message.provider}/${message.model}` : undefined;
 		this.#pendingReadUsageCallIds = this.#pendingUsage ? groupedReadUsageCallIds(message) : undefined;
 	}
 

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Usage } from "@oh-my-pi/pi-ai";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Container, Text } from "@oh-my-pi/pi-tui";
@@ -131,7 +132,7 @@ type ReadUsageRow = {
 	ttftMs?: number;
 	timestamp?: number;
 	model?: string;
-	thinkingLevel?: string;
+	thinkingLevel?: ThinkingLevel;
 };
 
 /** Number of code lines to show in collapsed preview mode */
@@ -478,7 +479,7 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		ttftMs?: number,
 		timestamp?: number,
 		model?: string,
-		thinkingLevel?: string,
+		thinkingLevel?: ThinkingLevel,
 	): boolean {
 		const attachedToolCallIds: string[] = [];
 		let anchorId: string | undefined;

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -130,6 +130,8 @@ type ReadUsageRow = {
 	durationMs?: number;
 	ttftMs?: number;
 	timestamp?: number;
+	model?: string;
+	thinkingLevel?: string;
 };
 
 /** Number of code lines to show in collapsed preview mode */
@@ -475,6 +477,8 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		durationMs?: number,
 		ttftMs?: number,
 		timestamp?: number,
+		model?: string,
+		thinkingLevel?: string,
 	): boolean {
 		const attachedToolCallIds: string[] = [];
 		let anchorId: string | undefined;
@@ -487,7 +491,15 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		for (const toolCallId of attachedToolCallIds) {
 			this.#usageBatchByToolCallId.set(toolCallId, anchorId);
 		}
-		this.#usageRows.set(anchorId, { toolCallIds: attachedToolCallIds, usage, durationMs, ttftMs, timestamp });
+		this.#usageRows.set(anchorId, {
+			toolCallIds: attachedToolCallIds,
+			usage,
+			durationMs,
+			ttftMs,
+			timestamp,
+			model,
+			thinkingLevel,
+		});
 		this.#updateDisplay();
 		return true;
 	}
@@ -684,7 +696,7 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 			lines.push(
 				theme.fg(
 					"dim",
-					`${prefix}${formatUsageRow(usageRow.usage, usageRow.durationMs, usageRow.ttftMs, usageRow.timestamp)}`,
+					`${prefix}${formatUsageRow(usageRow.usage, usageRow.durationMs, usageRow.ttftMs, usageRow.timestamp, usageRow.model, usageRow.thinkingLevel)}`,
 				),
 			);
 		}
@@ -830,7 +842,17 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		if (!usageRow) return;
 		this.addChild(
 			new Text(
-				theme.fg("dim", formatUsageRow(usageRow.usage, usageRow.durationMs, usageRow.ttftMs, usageRow.timestamp)),
+				theme.fg(
+					"dim",
+					formatUsageRow(
+						usageRow.usage,
+						usageRow.durationMs,
+						usageRow.ttftMs,
+						usageRow.timestamp,
+						usageRow.model,
+						usageRow.thinkingLevel,
+					),
+				),
 				3,
 				0,
 			),

--- a/packages/coding-agent/src/modes/components/usage-row.ts
+++ b/packages/coding-agent/src/modes/components/usage-row.ts
@@ -1,3 +1,4 @@
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Usage } from "@oh-my-pi/pi-ai";
 import { Container, Spacer, Text } from "@oh-my-pi/pi-tui";
 import { formatNumber } from "@oh-my-pi/pi-utils";
@@ -16,7 +17,14 @@ function formatUsageTimestamp(ms: number): string {
 }
 
 /** Format the metrics shared by standalone usage blocks and compact tool groups. */
-export function formatUsageRow(usage: Usage, durationMs?: number, ttftMs?: number, timestamp?: number): string {
+export function formatUsageRow(
+	usage: Usage,
+	durationMs?: number,
+	ttftMs?: number,
+	timestamp?: number,
+	model?: string,
+	thinkingLevel?: string,
+): string {
 	const totalInput = usage.input + usage.cacheWrite;
 	const parts: string[] = [];
 	// Lead with the turn's local wall-clock time (down to the second), log-line style.
@@ -38,15 +46,31 @@ export function formatUsageRow(usage: Usage, durationMs?: number, ttftMs?: numbe
 		const tokPerSec = (usage.output / durationMs) * 1000;
 		parts.push(`${theme.icon.throughput} ${tokPerSec.toFixed(1)}/s`);
 	}
+	if (model) {
+		parts.push(model);
+	}
+	if (thinkingLevel !== undefined && thinkingLevel !== ThinkingLevel.Off) {
+		parts.push(thinkingLevel);
+	}
 	return parts.join("  ");
 }
 
 // `timestamp` is optional and trails the throughput args to preserve the existing
-// (usage, durationMs, ttftMs) call contract — this function is part of the package's
+// (usage, durationMs, ttftMs) call contract; `model` and `thinkingLevel` trail
+// `timestamp` for the same reason — this function is part of the package's
 // public export surface (./modes/components/*).
-export function createUsageRowBlock(usage: Usage, durationMs?: number, ttftMs?: number, timestamp?: number): Container {
+export function createUsageRowBlock(
+	usage: Usage,
+	durationMs?: number,
+	ttftMs?: number,
+	timestamp?: number,
+	model?: string,
+	thinkingLevel?: string,
+): Container {
 	const block = new Container();
 	block.addChild(new Spacer(1));
-	block.addChild(new Text(theme.fg("dim", formatUsageRow(usage, durationMs, ttftMs, timestamp)), 1, 0));
+	block.addChild(
+		new Text(theme.fg("dim", formatUsageRow(usage, durationMs, ttftMs, timestamp, model, thinkingLevel)), 1, 0),
+	);
 	return block;
 }

--- a/packages/coding-agent/src/modes/components/usage-row.ts
+++ b/packages/coding-agent/src/modes/components/usage-row.ts
@@ -23,7 +23,7 @@ export function formatUsageRow(
 	ttftMs?: number,
 	timestamp?: number,
 	model?: string,
-	thinkingLevel?: string,
+	thinkingLevel?: ThinkingLevel,
 ): string {
 	const totalInput = usage.input + usage.cacheWrite;
 	const parts: string[] = [];
@@ -65,7 +65,7 @@ export function createUsageRowBlock(
 	ttftMs?: number,
 	timestamp?: number,
 	model?: string,
-	thinkingLevel?: string,
+	thinkingLevel?: ThinkingLevel,
 ): Container {
 	const block = new Container();
 	block.addChild(new Spacer(1));

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1249,6 +1249,7 @@ export class EventController {
 			}
 			this.#lastAssistantComponent = lastPostToolAssistantComponent ?? this.ctx.streamingComponent;
 			if (settings.get("display.showTokenUsage") && assistantUsageIsBilled(event.message.usage)) {
+				const usageRowModel = `${event.message.provider}/${event.message.model}`;
 				const readCallIds = groupedReadUsageCallIds(event.message);
 				const usageAttached =
 					readCallIds !== undefined &&
@@ -1258,6 +1259,8 @@ export class EventController {
 						event.message.duration,
 						event.message.ttft,
 						event.message.timestamp,
+						usageRowModel,
+						this.ctx.session.thinkingLevel,
 					) ??
 						false);
 				if (!usageAttached) {
@@ -1268,6 +1271,8 @@ export class EventController {
 							event.message.duration,
 							event.message.ttft,
 							event.message.timestamp,
+							usageRowModel,
+							this.ctx.session.thinkingLevel,
 						),
 					);
 				}

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -320,6 +320,7 @@ export class UiHelpers {
 		let pendingUsageDuration: number | undefined;
 		let pendingUsageTtft: number | undefined;
 		let pendingUsageTimestamp: number | undefined;
+		let pendingUsageModel: string | undefined;
 		let pendingReadUsageCallIds: string[] | undefined;
 		const flushPendingUsage = () => {
 			if (!pendingUsage) return;
@@ -331,19 +332,27 @@ export class UiHelpers {
 					pendingUsageDuration,
 					pendingUsageTtft,
 					pendingUsageTimestamp,
+					pendingUsageModel,
 				) ??
 					false);
 			if (!usageAttached) {
 				readGroup?.seal();
 				readGroup = null;
 				this.ctx.chatContainer.addChild(
-					createUsageRowBlock(pendingUsage, pendingUsageDuration, pendingUsageTtft, pendingUsageTimestamp),
+					createUsageRowBlock(
+						pendingUsage,
+						pendingUsageDuration,
+						pendingUsageTtft,
+						pendingUsageTimestamp,
+						pendingUsageModel,
+					),
 				);
 			}
 			pendingUsage = undefined;
 			pendingUsageDuration = undefined;
 			pendingUsageTtft = undefined;
 			pendingUsageTimestamp = undefined;
+			pendingUsageModel = undefined;
 			pendingReadUsageCallIds = undefined;
 		};
 		// Rebuild-time mirror of the event controller's displaceable-poll
@@ -546,6 +555,7 @@ export class UiHelpers {
 				pendingUsageDuration = message.duration;
 				pendingUsageTtft = message.ttft;
 				pendingUsageTimestamp = message.timestamp;
+				pendingUsageModel = pendingUsage ? `${message.provider}/${message.model}` : undefined;
 				pendingReadUsageCallIds = pendingUsage ? groupedReadUsageCallIds(message) : undefined;
 			} else if (message.role === "toolResult") {
 				if (options.preservedLiveToolCallIds?.has(message.toolCallId)) continue;

--- a/packages/coding-agent/test/modes/components/usage-row.test.ts
+++ b/packages/coding-agent/test/modes/components/usage-row.test.ts
@@ -1,0 +1,83 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { Usage } from "@oh-my-pi/pi-ai";
+import { ReadToolGroupComponent } from "../../../src/modes/components/read-tool-group";
+import { createUsageRowBlock, formatUsageRow } from "../../../src/modes/components/usage-row";
+import { initTheme } from "../../../src/modes/theme/theme";
+
+const usage: Usage = {
+	input: 1_000,
+	output: 50,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 1_050,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function plain(rendered: readonly string[]): string {
+	return Bun.stripANSI(rendered.join("\n"));
+}
+
+beforeAll(async () => {
+	await initTheme(false);
+});
+
+describe("formatUsageRow", () => {
+	it("appends the serving model and thinking level after the metrics", () => {
+		const row = formatUsageRow(
+			usage,
+			undefined,
+			undefined,
+			undefined,
+			"openrouter/deepseek/deepseek-v4-pro",
+			"xhigh",
+		);
+		expect(row.endsWith("openrouter/deepseek/deepseek-v4-pro  xhigh")).toBe(true);
+	});
+
+	it("omits the level when it is off or undefined", () => {
+		const withLevel = formatUsageRow(
+			usage,
+			undefined,
+			undefined,
+			undefined,
+			"openrouter/deepseek/deepseek-v4-pro",
+			"off",
+		);
+		expect(withLevel.endsWith("openrouter/deepseek/deepseek-v4-pro")).toBe(true);
+		expect(withLevel).not.toContain("off");
+		const withoutLevel = formatUsageRow(
+			usage,
+			undefined,
+			undefined,
+			undefined,
+			"openrouter/deepseek/deepseek-v4-pro",
+			undefined,
+		);
+		expect(withoutLevel).toBe(withLevel);
+	});
+
+	it("renders nothing extra without a model", () => {
+		const bare = formatUsageRow(usage);
+		expect(formatUsageRow(usage, undefined, undefined, undefined, undefined, undefined)).toBe(bare);
+	});
+});
+
+describe("createUsageRowBlock", () => {
+	it("renders model and level in the block text", () => {
+		const text = plain(createUsageRowBlock(usage, undefined, undefined, undefined, "p/m", "high").render(120));
+		expect(text).toContain("p/m");
+		expect(text).toContain("high");
+	});
+});
+
+describe("ReadToolGroupComponent attachUsage", () => {
+	it("renders model and level on the compact group row", () => {
+		const group = new ReadToolGroupComponent({ showContentPreview: false });
+		group.updateArgs({ path: "file.ts" }, "c1");
+		group.updateResult({ content: [{ type: "text", text: "ok" }], isError: false }, false, "c1");
+		expect(group.attachUsage(["c1"], usage, undefined, undefined, undefined, "p/m", "high")).toBe(true);
+		const text = plain(group.render(120));
+		expect(text).toContain("p/m");
+		expect(text).toContain("high");
+	});
+});

--- a/packages/coding-agent/test/modes/components/usage-row.test.ts
+++ b/packages/coding-agent/test/modes/components/usage-row.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "bun:test";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Usage } from "@oh-my-pi/pi-ai";
 import { ReadToolGroupComponent } from "../../../src/modes/components/read-tool-group";
 import { createUsageRowBlock, formatUsageRow } from "../../../src/modes/components/usage-row";
@@ -29,7 +30,7 @@ describe("formatUsageRow", () => {
 			undefined,
 			undefined,
 			"openrouter/deepseek/deepseek-v4-pro",
-			"xhigh",
+			ThinkingLevel.XHigh,
 		);
 		expect(row.endsWith("openrouter/deepseek/deepseek-v4-pro  xhigh")).toBe(true);
 	});
@@ -41,7 +42,7 @@ describe("formatUsageRow", () => {
 			undefined,
 			undefined,
 			"openrouter/deepseek/deepseek-v4-pro",
-			"off",
+			ThinkingLevel.Off,
 		);
 		expect(withLevel.endsWith("openrouter/deepseek/deepseek-v4-pro")).toBe(true);
 		expect(withLevel).not.toContain("off");
@@ -64,7 +65,9 @@ describe("formatUsageRow", () => {
 
 describe("createUsageRowBlock", () => {
 	it("renders model and level in the block text", () => {
-		const text = plain(createUsageRowBlock(usage, undefined, undefined, undefined, "p/m", "high").render(120));
+		const text = plain(
+			createUsageRowBlock(usage, undefined, undefined, undefined, "p/m", ThinkingLevel.High).render(120),
+		);
 		expect(text).toContain("p/m");
 		expect(text).toContain("high");
 	});
@@ -75,7 +78,7 @@ describe("ReadToolGroupComponent attachUsage", () => {
 		const group = new ReadToolGroupComponent({ showContentPreview: false });
 		group.updateArgs({ path: "file.ts" }, "c1");
 		group.updateResult({ content: [{ type: "text", text: "ok" }], isError: false }, false, "c1");
-		expect(group.attachUsage(["c1"], usage, undefined, undefined, undefined, "p/m", "high")).toBe(true);
+		expect(group.attachUsage(["c1"], usage, undefined, undefined, undefined, "p/m", ThinkingLevel.High)).toBe(true);
 		const text = plain(group.render(120));
 		expect(text).toContain("p/m");
 		expect(text).toContain("high");

--- a/packages/coding-agent/test/modes/controllers/event-controller-read-grouping.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-read-grouping.test.ts
@@ -13,6 +13,7 @@
  * one-entry block).
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, ImageContent } from "@oh-my-pi/pi-ai";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
@@ -76,7 +77,12 @@ function assistantMessage(content: Block[]): AssistantMessage {
 
 function createFixture() {
 	const chatContainer = new Container();
-	const sessionMock = { getToolByName: () => undefined, hasBuiltInTool: () => true, extensionRunner: undefined };
+	const sessionMock = {
+		getToolByName: () => undefined,
+		hasBuiltInTool: () => true,
+		extensionRunner: undefined,
+		thinkingLevel: ThinkingLevel.XHigh,
+	};
 	const ctx = {
 		isInitialized: true,
 		init: vi.fn(async () => {}),
@@ -161,6 +167,9 @@ describe("EventController read-group accretion", () => {
 			Bun.stripANSI(component.render(120).join("\n")).includes("2026-01-02 03:04:05"),
 		);
 		expect(usageBlocks).toEqual([group!]);
+		const groupText = Bun.stripANSI(group!.render(120).join("\n"));
+		expect(groupText).toContain("openai-codex/gpt-5.5");
+		expect(groupText).toContain(ThinkingLevel.XHigh);
 	});
 
 	it("keeps usage standalone when visible content follows a read", async () => {
@@ -188,6 +197,9 @@ describe("EventController read-group accretion", () => {
 		);
 		expect(usageBlocks).toHaveLength(1);
 		expect(usageBlocks[0]).not.toBe(group!);
+		const standaloneText = Bun.stripANSI(usageBlocks[0]!.render(120).join("\n"));
+		expect(standaloneText).toContain("openai-codex/gpt-5.5");
+		expect(standaloneText).toContain(ThinkingLevel.XHigh);
 	});
 
 	it("starts a fresh group after standalone usage for a mixed-tool turn ending in read", async () => {

--- a/packages/coding-agent/test/usage-row-placement.test.ts
+++ b/packages/coding-agent/test/usage-row-placement.test.ts
@@ -8,6 +8,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { ChatTranscriptBuilder } from "@oh-my-pi/pi-coding-agent/modes/components/chat-transcript-builder";
 import { ReadToolGroupComponent } from "@oh-my-pi/pi-coding-agent/modes/components/read-tool-group";
+import { formatUsageRow } from "@oh-my-pi/pi-coding-agent/modes/components/usage-row";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
@@ -18,6 +19,8 @@ import { formatNumber } from "@oh-my-pi/pi-utils";
 // 4242 → "4.2K": distinctive enough not to collide with a read group's render.
 const USAGE_INPUT = 4242;
 const USAGE_LABEL = formatNumber(USAGE_INPUT);
+// Persisted serving-model identity (provider/id) shown on rebuilt rows.
+const USAGE_MODEL = "anthropic/claude-sonnet-4-5";
 // Fixed local wall-clock time so the rendered stamp is deterministic across time zones.
 // Single-digit month/day/hour/minute/second exercise the formatter's zero-padding.
 const USAGE_TS = new Date(2026, 0, 2, 3, 4, 5).getTime();
@@ -56,6 +59,27 @@ function readTurn(
 		timestamp,
 	} as unknown as AgentMessage;
 	return [assistant, toolResult];
+}
+
+/** A text-only assistant turn: its usage stays standalone (no read group to attach to). */
+function textTurn(): AgentMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "done" }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		stopReason: "stop",
+		usage: {
+			input: USAGE_INPUT,
+			output: 7,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: USAGE_INPUT + 7,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: USAGE_TS,
+	} as unknown as AgentMessage;
 }
 
 function makeHarness(showTokenUsage: boolean): { ctx: InteractiveModeContext; helpers: UiHelpers } {
@@ -103,6 +127,7 @@ describe("UiHelpers.renderSessionContext token-usage row placement", () => {
 		const rendered = group!.render(120).join("\n");
 		expect(rendered).toContain(USAGE_LABEL);
 		expect(rendered).toContain(USAGE_TS_LABEL);
+		expect(rendered).toContain(USAGE_MODEL);
 		expect(children[children.length - 1]).toBe(group!);
 		expect(children.filter(component => component.render(120).join("\n").includes(USAGE_LABEL))).toHaveLength(1);
 	});
@@ -134,6 +159,21 @@ describe("UiHelpers.renderSessionContext token-usage row placement", () => {
 		expect(children.some(c => c.render(120).join("\n").includes(USAGE_LABEL))).toBe(false);
 		// Last block is the read group, not a usage row.
 		expect(children[children.length - 1]).toBeInstanceOf(ReadToolGroupComponent);
+	});
+
+	it("renders the serving model on the standalone rebuilt row without a thinking level", () => {
+		const { ctx, helpers } = makeHarness(true);
+		const message = textTurn();
+		helpers.renderSessionContext({ messages: [message] } as SessionContext);
+
+		const children = ctx.chatContainer.children;
+		const last = children[children.length - 1]!;
+		const rendered = Bun.stripANSI(last.render(120).join("\n"));
+		// Rebuilt rows carry the persisted provider/model but never a thinking
+		// level — the level is not persisted per message.
+		const usage = (message as Extract<AgentMessage, { role: "assistant" }>).usage;
+		expect(rendered).toContain(formatUsageRow(usage, undefined, undefined, USAGE_TS, USAGE_MODEL));
+		expect(rendered).toContain(USAGE_MODEL);
 	});
 });
 
@@ -175,6 +215,7 @@ describe("ChatTranscriptBuilder token-usage row timestamp", () => {
 		const rendered = last.render(120).join("\n");
 		expect(rendered).toContain(USAGE_TS_LABEL);
 		expect(rendered).toContain(USAGE_LABEL);
+		expect(rendered).toContain(USAGE_MODEL);
 	});
 
 	it("keeps grouped read metrics nested on the reusable transcript-builder path", () => {
@@ -201,6 +242,7 @@ describe("ChatTranscriptBuilder token-usage row timestamp", () => {
 		const rendered = groups[0]!.render(120).join("\n");
 		expect(rendered).toContain(USAGE_TS_LABEL);
 		expect(rendered).toContain(SECOND_USAGE_TS_LABEL);
+		expect(rendered).toContain(USAGE_MODEL);
 		expect(
 			builder.container.children.filter(component => component.render(120).join("\n").includes(USAGE_LABEL)),
 		).toEqual([groups[0]!]);


### PR DESCRIPTION
Appends the serving model (persisted per-message `provider/id`, exact on live, rebuilt, and exported transcripts) and the effective thinking level (live path only; omitted when off/undefined and on rebuilt/exported transcripts, where the level is not persisted per message) to the per-turn usage row, including the compact read-tool-group row. Trailing optional params keep the existing formatUsageRow/createUsageRowBlock/attachUsage call contract. Reuses the `display.showTokenUsage` gate

<img width="1727" height="783" alt="image" src="https://github.com/user-attachments/assets/8d4e982e-0853-47dd-aa91-16aef4f8a5b5" />
