### PR TITLE
fix(tui): render all session tree entry types

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/tree` rendering blank rows for session bookkeeping and lifecycle entries, while keeping noisy bookkeeping hidden from the default filter ([#7778](https://github.com/can1357/oh-my-pi/issues/7778)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -291,7 +291,13 @@ class TreeList implements Component {
 				entry.type === "label" ||
 				entry.type === "custom" ||
 				entry.type === "model_change" ||
-				entry.type === "thinking_level_change";
+				entry.type === "thinking_level_change" ||
+				entry.type === "title_change" ||
+				entry.type === "mode_change" ||
+				entry.type === "service_tier_change" ||
+				entry.type === "session_init" ||
+				entry.type === "ttsr_injection" ||
+				entry.type === "credential_pin";
 
 			switch (this.#filterMode) {
 				case "user-only":
@@ -646,6 +652,36 @@ class TreeList implements Component {
 			case "branch_summary":
 				result = theme.fg("warning", `[branch summary]: `) + normalize(entry.summary);
 				break;
+			case "title_change":
+				result = theme.fg("dim", `[title: ${normalize(entry.title)}]`);
+				break;
+			case "mode_change":
+				result = theme.fg("dim", `[mode: ${entry.mode}]`);
+				break;
+			case "reset_boundary":
+				result = theme.fg("dim", "[reset]");
+				break;
+			case "service_tier_change": {
+				let tiers = "";
+				if (entry.serviceTier?.openai) tiers = `openai=${entry.serviceTier.openai}`;
+				if (entry.serviceTier?.anthropic) {
+					tiers += `${tiers ? ", " : ""}anthropic=${entry.serviceTier.anthropic}`;
+				}
+				if (entry.serviceTier?.google) tiers += `${tiers ? ", " : ""}google=${entry.serviceTier.google}`;
+				result = theme.fg("dim", `[service tier: ${tiers || "default"}]`);
+				break;
+			}
+			case "session_init": {
+				const agent = entry.agent ?? entry.modelRole ?? entry.resolvedModel ?? "agent";
+				result = theme.fg("dim", `[session init: ${agent}] `) + normalize(entry.task);
+				break;
+			}
+			case "ttsr_injection":
+				result = theme.fg("dim", `[ttsr: ${entry.injectedRules.join(", ") || "(none)"}]`);
+				break;
+			case "credential_pin":
+				result = theme.fg("dim", `[credential pin: ${entry.provider}]`);
+				break;
 			case "model_change":
 				result = theme.fg("dim", `[model: ${entry.model}]`);
 				break;
@@ -659,7 +695,8 @@ class TreeList implements Component {
 				result = theme.fg("dim", `[label: ${entry.label ?? "(cleared)"}]`);
 				break;
 			default:
-				result = "";
+				entry satisfies never;
+				result = theme.fg("dim", "[unknown session entry]");
 		}
 
 		return isSelected ? theme.bold(result) : result;

--- a/packages/coding-agent/test/modes/components/tree-selector-session-entries.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-session-entries.test.ts
@@ -1,0 +1,116 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SessionEntry, SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+
+const timestamp = "2026-08-06T00:00:00.000Z";
+
+function makeEntries(): SessionEntry[] {
+	return [
+		{
+			type: "title_change",
+			id: "title",
+			parentId: null,
+			timestamp,
+			title: "Renamed session",
+			source: "auto",
+		},
+		{
+			type: "mode_change",
+			id: "mode",
+			parentId: "title",
+			timestamp,
+			mode: "plan",
+		},
+		{
+			type: "reset_boundary",
+			id: "reset",
+			parentId: "mode",
+			timestamp,
+		},
+		{
+			type: "service_tier_change",
+			id: "tier",
+			parentId: "reset",
+			timestamp,
+			serviceTier: { openai: "priority" },
+		},
+		{
+			type: "session_init",
+			id: "init",
+			parentId: "tier",
+			timestamp,
+			systemPrompt: "System prompt",
+			task: "Investigate the tree",
+			tools: ["read"],
+			agent: "scout",
+		},
+		{
+			type: "ttsr_injection",
+			id: "ttsr",
+			parentId: "init",
+			timestamp,
+			injectedRules: ["review-rule"],
+		},
+		{
+			type: "credential_pin",
+			id: "credential",
+			parentId: "ttsr",
+			timestamp,
+			provider: "anthropic",
+			hash: "secret-hash",
+		},
+	];
+}
+
+function chain(entries: SessionEntry[]): SessionTreeNode[] {
+	let child: SessionTreeNode | undefined;
+	for (let index = entries.length - 1; index >= 0; index--) {
+		child = { entry: entries[index], children: child ? [child] : [] };
+	}
+	return child ? [child] : [];
+}
+
+function render(entries: SessionEntry[], filter: "default" | "all"): string {
+	const selector = new TreeSelectorComponent(
+		chain(entries),
+		entries.at(-1)?.id ?? null,
+		80,
+		() => {},
+		() => {},
+		undefined,
+		filter,
+	);
+	return Bun.stripANSI(selector.render(160).join("\n"));
+}
+
+describe("TreeSelectorComponent session entry rendering", () => {
+	beforeAll(async () => {
+		await initTheme(false, undefined, undefined, "dark", "light");
+	});
+
+	it("renders informative rows for every SessionEntry variant in the all filter", () => {
+		const output = render(makeEntries(), "all");
+
+		expect(output).toContain("[title: Renamed session]");
+		expect(output).toContain("[mode: plan]");
+		expect(output).toContain("[reset]");
+		expect(output).toContain("[service tier: openai=priority]");
+		expect(output).toContain("[session init: scout] Investigate the tree");
+		expect(output).toContain("[ttsr: review-rule]");
+		expect(output).toContain("[credential pin: anthropic]");
+		expect(output).not.toContain("secret-hash");
+	});
+
+	it("hides bookkeeping entries by default while keeping reset boundaries visible", () => {
+		const output = render(makeEntries(), "default");
+
+		expect(output).toContain("[reset]");
+		expect(output).not.toContain("[title:");
+		expect(output).not.toContain("[mode:");
+		expect(output).not.toContain("[service tier:");
+		expect(output).not.toContain("[session init:");
+		expect(output).not.toContain("[ttsr:");
+		expect(output).not.toContain("[credential pin:");
+	});
+});


### PR DESCRIPTION
## Repro

A seven-entry session tree containing `title_change`, `mode_change`, `reset_boundary`, `service_tier_change`, `session_init`, `ttsr_injection`, and `credential_pin` rendered connector/bullet-only rows in `/tree`. Run `bun test packages/coding-agent/test/modes/components/tree-selector-session-entries.test.ts` against the pre-fix code; both the all-filter display and default-filter expectations fail.

## Cause

`TreeSelectorComponent` in `packages/coding-agent/src/modes/components/tree-selector.ts` returned an empty string from `TreeList.#getEntryDisplayText()` for seven valid `SessionEntry` variants, while `TreeList.#applyFilter()` classified a disjoint set as bookkeeping, so those empty rows remained visible.

## Fix

- Render informative, privacy-safe labels for all seven lifecycle and bookkeeping variants.
- Hide title, mode, service-tier, session-init, TTSR, and credential-pin bookkeeping in default/no-tools views while keeping reset boundaries visible.
- Make the display switch exhaustive and add regression coverage for all-filter rendering, default filtering, and credential-hash redaction.
- Document the fix under the coding-agent changelog's Unreleased section.

## Verification

`bun test packages/coding-agent/test/modes/components/tree-selector-*.test.ts` passes: 13 tests, 171 assertions. The publish gate also completed `bun run fix` and `bun check` successfully.

Fixes #7778