### PR TITLE
fix(acp): resolve session/load across legacy session directories

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ACP `session/load` and `session/resume` failing with `ACP session not found` for sessions created under the legacy/hashed project-directory scheme (17.2.5+, reverted in #7656): the lookup only scanned the directory re-derived from `cwd`, so sessions stored under a differently-named directory were unreachable. It now falls back to a global by-id scan (the same one the fork path already uses) when the cwd-scoped lookup misses ([#7779](https://github.com/can1357/oh-my-pi/issues/7779)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2019,7 +2019,16 @@ export class AcpAgent implements Agent {
 
 	async #findStoredSession(sessionId: string, cwd: string): Promise<StoredSessionInfo | undefined> {
 		const sessions = await this.#listStoredSessions(cwd);
-		return sessions.find(session => session.id === sessionId);
+		const scoped = sessions.find(session => session.id === sessionId);
+		if (scoped) {
+			return scoped;
+		}
+		// The cwd-derived directory only covers sessions stored under the current
+		// naming scheme. Sessions written under a legacy/hashed project directory
+		// (the 17.2.5+ scheme reverted in #7656) live elsewhere, so fall back to a
+		// global by-id scan: the session id is globally unique, and
+		// #openStoredSession reopens the file with the request cwd. See #7779.
+		return this.#findStoredSessionById(sessionId);
 	}
 
 	async #findStoredSessionById(sessionId: string): Promise<StoredSessionInfo | undefined> {

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1104,6 +1104,48 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("loads a session stored under a legacy/hashed project directory (#7779)", async () => {
+		const harness = await createHarness();
+		const stored = new FakeAgentSession(harness.cwdA);
+		harness.sessions.push(stored);
+		stored.sessionManager.appendMessage({ role: "user", content: "legacy hello", timestamp: Date.now() });
+		stored.sessionManager.appendMessage(makeAssistantMessage("legacy reply"));
+		await stored.sessionManager.ensureOnDisk();
+		await stored.sessionManager.flush();
+
+		const sessionFile = stored.sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("session file not persisted");
+		const sessionId = stored.sessionId;
+		// Release the writer so the directory can be renamed out from under it.
+		await stored.dispose();
+
+		// Simulate the hashed-directory era (#7397, reverted in #7656): the
+		// session file lives under a project directory whose name the current
+		// cwd->dir scheme would never produce, so the cwd-scoped scan misses it.
+		const cwdDerivedDir = path.dirname(sessionFile);
+		const sessionsRoot = path.dirname(cwdDerivedDir);
+		const hashedDir = path.join(sessionsRoot, `home-cwd-a-${"a".repeat(64)}`);
+		await fs.promises.rename(cwdDerivedDir, hashedDir);
+
+		const loaded = await harness.agent.loadSession({
+			sessionId,
+			cwd: harness.cwdA,
+			mcpServers: [],
+		});
+		expectAcpStructure(zLoadSessionResponse, loaded);
+
+		const replayChunks = harness.updates.filter(
+			update =>
+				update.sessionId === sessionId &&
+				(update.update.sessionUpdate === "user_message_chunk" ||
+					update.update.sessionUpdate === "agent_message_chunk"),
+		);
+		expect(replayChunks.length).toBeGreaterThan(0);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("delivers the final visible answer when agent_end overtakes the assistant message_end (#4902)", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });


### PR DESCRIPTION
## Repro
A session created under the legacy/hashed project-directory scheme (17.2.5+, reverted in #7656) lives in a directory whose name the current `cwd`->dir scheme never reproduces. Sending `initialize` then `session/load` (or `session/resume`) over `omp acp` with the session's real cwd returns `-32603 Internal error` with `data.details: "ACP session not found: <id>"`, even though the JSONL exists on disk and `agent.db` holds its `rollout_path`. Added regression test in `test/acp-agent.test.ts` ("loads a session stored under a legacy/hashed project directory"): persist a session, rename its cwd-derived directory to a hashed-era name, then `loadSession` with the original cwd. Command: `bun test test/acp-agent.test.ts -t "legacy/hashed"`.

## Cause
`AcpAgent.#loadManagedSession` and `#resumeManagedSession` resolve the session via `#findStoredSession(sessionId, cwd)` (`packages/coding-agent/src/modes/acp/acp-agent.ts:2020`), which lists only `SessionManager.list(cwd)` — the single directory re-derived from `cwd` via `computeDefaultSessionDir` (`session-paths.ts`). Sessions stored under any other directory name are invisible to that scan, so `#findStoredSession` returns `undefined` and `#loadManagedSession` throws `ACP session not found` (`acp-agent.ts:1076`). The fork path already resolves globally (`#findStoredSessionById` -> `SessionManager.listAll()`, globbing `sessions/*/*.jsonl`), and `resolveResumableSession` uses a local->global fallback; load/resume simply never got it.

## Fix
- `#findStoredSession` (`acp-agent.ts`) now falls back to `#findStoredSessionById` (global `listAll()` by-id scan) when the cwd-scoped lookup misses. Session ids are globally unique and `#openStoredSession` reopens the file with the request cwd, so no directory-scheme knowledge is required and it works for any future naming change. This is the on-disk equivalent of the reporter's `rollout_path` suggestion, authoritative from the session files rather than dependent on `agent.db` staying in sync.
- Added a regression test in `test/acp-agent.test.ts` exercising the exact failure.
- Changelog entry under `[Unreleased] > Fixed`.

The separate `data.details`-vs-top-level-`message` error-surfacing aside is a maintainer call on ACP error formatting and is left untouched.

## Verification
`bun test test/acp-agent.test.ts` -> 60 pass, 0 fail (new test fails before the fix with `ACP session not found`, passes after). Fixes #7779