### PR TITLE
feat(tui): label Alt and Super with the Apple key glyphs on macOS

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -479,7 +479,7 @@ Provide `renderCall` / `renderResult` on `registerTool` definitions for custom t
 - Runtime actions are unavailable during extension load.
 - `tool_call` errors block execution (fail-closed).
 - Command name conflicts with built-ins are skipped with diagnostics.
-- Reserved shortcuts are ignored (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `ctrl+q`, `alt+m`, `shift+tab`, `shift+ctrl+p`, `alt+enter`, `escape`, `enter`).
+- Reserved shortcuts are ignored (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `ctrl+q`, `alt+m`, `shift+tab`, `ctrl+shift+p`, `alt+enter`, `escape`, `enter`). The chord is canonicalized before the check, so alternate spellings and modifier orders of the same chord (`shift+ctrl+p`, `Option+M`, `⌥+m`) are rejected too.
 - Treat `ctx.reload()` as terminal for the current command handler frame.
 
 ## Extensions vs hooks vs custom-tools

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -16,6 +16,8 @@ app.plan.toggle: Alt+Shift+P
 
 Chord names are case-insensitive and use the same notation shown in the UI, such as `Ctrl+P`, `Alt+Shift+P`, `Shift+Enter`, and `Ctrl+Backspace`.
 
+On macOS the UI labels `alt` and `super` with the glyphs printed on the keys, so `/hotkeys` and the hint bar show `⌥+P` and `⌘+V` where other platforms show `Alt+P` and `Super+V`. Every spelling of a modifier is accepted here — `⌥`, `Option`, and `Alt` all mean the same key, as do `⌘`, `Cmd`, `Command`, and `Super` — so a chord copied out of the UI resolves to the binding it came from. `omp` folds them to the canonical ASCII names internally (and when it rewrites the file), which is what the default column below uses.
+
 Set an action to an empty array to disable it:
 
 ```yaml

--- a/docs/skills/authoring-extensions.md
+++ b/docs/skills/authoring-extensions.md
@@ -254,7 +254,7 @@ The derived name is the filename stem (or directory name for `index.ts`-style en
 - **`tool_call` errors are fail-closed.** If a `tool_call` handler throws, the tool is blocked.
 - **Self-scheduled callbacks run in-process with no isolation.** A raw `setInterval`/`setTimeout`/detached-promise callback that throws escapes the handler-dispatch try/catch and crashes the whole session (`uncaughtException`). Use `ctx.setInterval` / `ctx.setTimeout` for background work — they contain callback throws and auto-clear on `session_shutdown`. With raw timers you must add your own `try/catch` and cleanup.
 - **Command names must not clash with built-ins.** Conflicts are skipped with a diagnostic log.
-- **Reserved shortcuts are ignored** (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `ctrl+q`, `alt+m`, `shift+tab`, `shift+ctrl+p`, `alt+enter`, `escape`, `enter`).
+- **Reserved shortcuts are ignored** (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `ctrl+q`, `alt+m`, `shift+tab`, `ctrl+shift+p`, `alt+enter`, `escape`, `enter`). The chord is canonicalized before the check, so alternate spellings and modifier orders of the same chord (`shift+ctrl+p`, `Option+M`, `⌥+m`) are rejected too.
 
 ## Further reading
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed key hints on macOS to use the modifier glyphs printed on the physical keys: `/hotkeys`, the pending-message and tree-selector hints, the session-model status line, and the sign-in copy hint now render `alt` as `⌥` and `super` as `⌘` (`⌥+P`, `⌘+V`) while other platforms keep `Alt+P` and `Super+V`. `keybindings.yml` accepts every spelling of a modifier (`⌥`/`Option`/`Alt`, `⌘`/`Cmd`/`Command`/`Super`), so a chord copied out of the UI resolves to the binding it came from.
+
+### Fixed
+
+- Fixed the `/hotkeys` navigation and editing rows hardcoding macOS key names on every platform: `Option+Left/Right` and `Option+Backspace` were shown to Linux and Windows users, and the `Cmd+Left`/`Cmd+Right` line-start/line-end rows (which are not bound outside macOS) were listed unconditionally. The rows now follow the host platform.
+- Fixed the session-only model status message, the agent-transcript footer, and the model-hub cycle footer printing raw chord ids (`alt+m`, `ctrl+o`, `ctrl+p`) instead of formatted key hints, because they read `getKeys(...)[0]` rather than going through the hint formatter.
+- Fixed the extension reserved-shortcut guard comparing the chord as written instead of canonically, so an extension could claim a reserved built-in by spelling it differently. The editor builds its match keys from the canonical id, so `ctrl+shift+p` (reserved as `shift+ctrl+p`) — and now any `Option`/`⌘` spelling — really did shadow the built-in while passing the check. `getShortcuts()` canonicalizes before the lookup and the reserved table is keyed canonically.
+- Fixed keybinding conflict detection missing two actions that claim the same chord under different spellings (`alt+x` versus `Option+x`): claims are now keyed by canonical id, so the collision is reported instead of one binding silently shadowing the other.
+- Fixed a chord bound with an alternate modifier spelling collapsing to its bare base key in components that match `getKeys()` output directly. Key normalization only lowercased, so `app.agents.hub: ⌥+A` reached the native matcher — which knows only `ctrl`/`shift`/`super`/`alt` — as an unrecognized modifier plus `a`, making the plain letter `a` close the agent hub while `Alt+A` did nothing. Normalization now folds every modifier onto its canonical name while keeping the authored order the UI label depends on.
+- Fixed key-hint rendering resolving chord parts through `Object.prototype`, so a binding on a key named `constructor` or `toString` printed a function's native-code text instead of the key name.
+
 ## [17.2.7] - 2026-08-03
 
 ### Changed

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -5,6 +5,7 @@ import {
 	type KeybindingDefinitions,
 	type KeybindingsConfig,
 	type KeyId,
+	MODIFIER_SPELLINGS,
 	setKeybindings,
 	TUI_KEYBINDINGS,
 	KeybindingsManager as TuiKeybindingsManager,
@@ -636,9 +637,9 @@ export class KeybindingsManager extends TuiKeybindingsManager {
 	/**
 	 * Get display string for a keybinding (e.g., "ctrl+c/escape").
 	 */
-	getDisplayString(keybinding: Keybinding): string {
+	getDisplayString(keybinding: Keybinding, platform?: NodeJS.Platform): string {
 		const keys = this.getKeys(keybinding);
-		return formatKeyHints(keys.length === 0 ? [] : keys);
+		return formatKeyHints(keys.length === 0 ? [] : keys, platform);
 	}
 
 	/**
@@ -659,6 +660,19 @@ const MODIFIER_LABELS: Record<string, string> = {
 	ctrl: "Ctrl",
 	shift: "Shift",
 	alt: "Alt",
+	super: "Super",
+};
+
+/**
+ * macOS labels Alt and Super with the glyphs printed on the physical keys. The
+ * `+` separator is kept so mixed chords stay unambiguous (`Ctrl+⌥+X`), and
+ * `canonicalKeyId` parses both glyphs back, so a hint copied out of the UI into
+ * `keybindings.yml` still resolves to the same chord.
+ */
+const DARWIN_MODIFIER_LABELS: Record<string, string> = {
+	...MODIFIER_LABELS,
+	alt: "⌥",
+	super: "⌘",
 };
 
 const KEY_LABELS: Record<string, string> = {
@@ -680,23 +694,49 @@ const KEY_LABELS: Record<string, string> = {
 	right: "Right",
 };
 
-function formatKeyPart(part: string): string {
+/**
+ * Resolve a chord part to its canonical modifier name. `Object.hasOwn` rather than
+ * a plain lookup: a part named `constructor`/`toString` would otherwise resolve
+ * through `Object.prototype` to a function and render as native-code text.
+ */
+function canonicalModifierPart(lower: string): string {
+	return Object.hasOwn(MODIFIER_SPELLINGS, lower) ? (MODIFIER_SPELLINGS[lower] as string) : lower;
+}
+
+function formatKeyPart(part: string, labels: Record<string, string>): string {
 	const lower = part.toLowerCase();
-	const modifier = MODIFIER_LABELS[lower];
-	if (modifier) return modifier;
-	const label = KEY_LABELS[lower];
-	if (label) return label;
+	// Fold `option`/`⌥`/`cmd`/`⌘` onto the canonical modifier so a chord authored
+	// with the macOS spelling is relabelled for the active platform, not echoed
+	// verbatim. Modifier order is left as authored.
+	const canonical = canonicalModifierPart(lower);
+	if (Object.hasOwn(labels, canonical)) return labels[canonical] as string;
+	if (Object.hasOwn(KEY_LABELS, lower)) return KEY_LABELS[lower] as string;
 	if (part.length === 1) return part.toUpperCase();
 	return `${part.charAt(0).toUpperCase()}${part.slice(1)}`;
 }
 
-export function formatKeyHint(key: KeyId): string {
-	return key.split("+").map(formatKeyPart).join("+");
+export function formatKeyHint(key: KeyId, platform: NodeJS.Platform = process.platform): string {
+	const labels = platform === "darwin" ? DARWIN_MODIFIER_LABELS : MODIFIER_LABELS;
+	return key
+		.split("+")
+		.map(part => formatKeyPart(part, labels))
+		.join("+");
 }
 
-export function formatKeyHints(keys: KeyId | KeyId[]): string {
+export function formatKeyHints(keys: KeyId | KeyId[], platform: NodeJS.Platform = process.platform): string {
 	const list = Array.isArray(keys) ? keys : [keys];
-	return list.map(formatKeyHint).join("/");
+	return list.map(key => formatKeyHint(key, platform)).join("/");
+}
+
+/**
+ * Label for one modifier (`alt` → `⌥` on darwin, `Alt` elsewhere). Whole chords
+ * go through {@link formatKeyHint}; this exists for the compact hints that list
+ * several keys behind a single modifier, such as `⌥+D/T/U/L/A`.
+ */
+export function modifierLabel(modifier: string, platform: NodeJS.Platform = process.platform): string {
+	const labels = platform === "darwin" ? DARWIN_MODIFIER_LABELS : MODIFIER_LABELS;
+	const canonical = canonicalModifierPart(modifier.toLowerCase());
+	return Object.hasOwn(labels, canonical) ? (labels[canonical] as string) : modifier;
 }
 
 export type { Keybinding, KeybindingsConfig, KeyId };

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -9,7 +9,7 @@ import type {
 	AgentToolUpdateCallback,
 } from "@oh-my-pi/pi-agent-core";
 import type { CredentialDisabledEvent, ImageContent, Model, ProviderResponseMetadata } from "@oh-my-pi/pi-ai";
-import type { KeyId } from "@oh-my-pi/pi-tui";
+import { canonicalKeyId, type KeyId } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../../config/model-registry";
 import type { Settings } from "../../config/settings";
@@ -330,6 +330,33 @@ const noOpUIContext: ExtensionUIContext = {
 	setTheme: (_theme: string | Theme) => Promise.resolve({ success: false, error: "UI not available" }),
 	getToolsExpanded: () => false,
 	setToolsExpanded: () => {},
+};
+
+/**
+ * Chords an extension may not claim, keyed by canonical id. Incoming keys are
+ * canonicalized before the lookup, so alternate spellings of the same chord
+ * (`Option+M`, `⌥+m`, `shift+ctrl+p`) are rejected too — the editor builds its
+ * match keys from the canonical form, so any of them would really shadow the
+ * built-in. Every key here must be a `canonicalKeyId` fixed point or it is dead.
+ */
+export const RESERVED_EXTENSION_SHORTCUTS: Record<string, true> = {
+	"ctrl+c": true,
+	"ctrl+d": true,
+	"ctrl+z": true,
+	"ctrl+k": true,
+	"ctrl+p": true,
+	"ctrl+l": true,
+	"ctrl+o": true,
+	"ctrl+t": true,
+	"ctrl+g": true,
+	"alt+m": true,
+	// Default chord for `app.message.followUp` (Windows Terminal can't deliver Ctrl+Enter; #1903).
+	"ctrl+q": true,
+	"shift+tab": true,
+	"ctrl+shift+p": true,
+	"alt+enter": true,
+	escape: true,
+	enter: true,
 };
 
 export class ExtensionRunner {
@@ -696,33 +723,17 @@ export class ExtensionRunner {
 		this.runtime.flagValues.set(name, value);
 	}
 
-	static readonly #RESERVED_SHORTCUTS: Record<string, true> = {
-		"ctrl+c": true,
-		"ctrl+d": true,
-		"ctrl+z": true,
-		"ctrl+k": true,
-		"ctrl+p": true,
-		"ctrl+l": true,
-		"ctrl+o": true,
-		"ctrl+t": true,
-		"ctrl+g": true,
-		"alt+m": true,
-		// Default chord for `app.message.followUp` (Windows Terminal can't deliver Ctrl+Enter; #1903).
-		"ctrl+q": true,
-		"shift+tab": true,
-		"shift+ctrl+p": true,
-		"alt+enter": true,
-		escape: true,
-		enter: true,
-	};
-
 	getShortcuts(): Map<KeyId, ExtensionShortcut> {
 		const allShortcuts = new Map<KeyId, ExtensionShortcut>();
 		for (const ext of this.extensions) {
 			for (const [key, shortcut] of ext.shortcuts) {
-				const normalizedKey = key.toLowerCase() as KeyId;
+				// Lowercase first, as every other canonicalization site does: a bare
+				// uppercase base letter would otherwise be promoted to Shift, turning
+				// `Ctrl+C` into an unreserved `ctrl+shift+c` and `Alt+K` into a chord
+				// that never fires.
+				const normalizedKey = canonicalKeyId(key.toLowerCase()) as KeyId;
 
-				if (ExtensionRunner.#RESERVED_SHORTCUTS[normalizedKey]) {
+				if (RESERVED_EXTENSION_SHORTCUTS[normalizedKey]) {
 					logger.warn("Extension shortcut conflicts with built-in shortcut", {
 						key,
 						extensionPath: shortcut.extensionPath,

--- a/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
+++ b/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
@@ -17,7 +17,7 @@ import * as fs from "node:fs";
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { type Component, Editor, matchesKey, routeSgrMouseInput, ScrollView, type TUI } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, logger } from "@oh-my-pi/pi-utils";
-import type { KeyId } from "../../config/keybindings";
+import { formatKeyHint, type KeyId } from "../../config/keybindings";
 import type { MessageRenderer } from "../../extensibility/extensions/types";
 import type { AgentLifecycleManager } from "../../registry/agent-lifecycle";
 import type { AgentRegistry, AgentStatus } from "../../registry/agent-registry";
@@ -605,9 +605,10 @@ export class AgentTranscriptViewer implements Component {
 		const lines: string[] = [];
 		const statsLine = this.#statsLine();
 		if (statsLine) lines.push(` ${statsLine}`);
+		const expandKey = formatKeyHint(this.deps.expandKeys[0] ?? "ctrl+o");
 		const hint = this.#editor
-			? `Enter:send  Esc:close  ${this.deps.expandKeys[0] ?? "ctrl+o"}:expand  empty input → j/k:scroll  g/G:top/bottom`
-			: `Esc:close  ${this.deps.expandKeys[0] ?? "ctrl+o"}:expand  j/k:scroll  g/G:top/bottom`;
+			? `Enter:send  Esc:close  ${expandKey}:expand  empty input → j/k:scroll  g/G:top/bottom`
+			: `Esc:close  ${expandKey}:expand  j/k:scroll  g/G:top/bottom`;
 		lines.push(` ${theme.fg("dim", hint)}`);
 		return lines;
 	}

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -27,6 +27,7 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
+import { formatKeyHint, formatKeyHints } from "../../config/keybindings";
 import type { ModelRegistry } from "../../config/model-registry";
 import { type ModelRoleLookup, type ResolvedModelRoleValue, resolveModelRoleValue } from "../../config/model-resolver";
 import { getKnownRoleIds, getRoleInfo } from "../../config/model-roles";
@@ -1803,7 +1804,7 @@ export class ModelHubComponent implements Component {
 		// segment track the ctrl+p status uses; the selected role's chip fills.
 		while (lines.length < rows - 1) lines.push("");
 		if (rows >= 2) {
-			const cycleKey = getKeybindings().getKeys("app.model.cycleForward")[0] ?? "ctrl+p";
+			const cycleKey = formatKeyHints(getKeybindings().getKeys("app.model.cycleForward")) || formatKeyHint("ctrl+p");
 			if (cycleOrder.length > 0) {
 				const selectedRow = this.#rolesRows[this.#roleIndex];
 				const selectedRole =

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -11,6 +11,7 @@ import {
 	TruncatedText,
 	truncateToWidth,
 } from "@oh-my-pi/pi-tui";
+import { formatKeyHint, modifierLabel } from "../../config/keybindings";
 import type { TreeFilterMode } from "../../config/settings-schema";
 import { theme } from "../../modes/theme/theme";
 import {
@@ -457,7 +458,15 @@ class TreeList implements Component {
 						width,
 					),
 				);
-				lines.push(truncateToWidth(theme.fg("muted", "  Press Alt+A to show all, Alt+D for default"), width));
+				lines.push(
+					truncateToWidth(
+						theme.fg(
+							"muted",
+							`  Press ${formatKeyHint("alt+a")} to show all, ${formatKeyHint("alt+d")} for default`,
+						),
+						width,
+					),
+				);
 				lines.push(
 					truncateToWidth(theme.fg("muted", `  (0/${this.#flatNodes.length})${this.#getFilterLabel()}`), width),
 				);
@@ -952,7 +961,7 @@ export class TreeSelectorComponent extends Container {
 			new TruncatedText(
 				theme.fg(
 					"muted",
-					"Enter: switch. Alt+↑/↓: previous/next turn. PgUp/PgDn (←/→): page. Home/End: first/last item. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
+					`Enter: switch. ${modifierLabel("alt")}+↑/↓: previous/next turn. PgUp/PgDn (←/→): page. Home/End: first/last item. Shift+Enter: summarize & switch. Shift+L: label. Ctrl+O: filter. ${modifierLabel("alt")}+D/T/U/L/A: filter. Type to search`,
 				),
 				0,
 				0,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -14,6 +14,7 @@ import {
 	saveWatchdogConfigFile,
 } from "../../advisor";
 import { reset as resetCapabilities } from "../../capability";
+import { formatKeyHint } from "../../config/keybindings";
 import {
 	formatModelSelectorValue,
 	resolveAdvisorRoleSelection,
@@ -724,7 +725,8 @@ export class SelectorController {
 						await this.ctx.session.setModelTemporary(model, roleThinkingLevel);
 						this.ctx.statusLine.invalidate();
 						this.ctx.updateEditorBorderColor();
-						const roleSelectorHint = this.ctx.keybindings.getKeys("app.model.select")[0] ?? "Alt+M";
+						const roleSelectorHint =
+							this.ctx.keybindings.getDisplayString("app.model.select") || formatKeyHint("alt+m");
 						this.ctx.showStatus(`Session-only model: ${selector}. Use ${roleSelectorHint} or /model for roles.`);
 					};
 					try {

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
@@ -10,6 +10,7 @@ import {
 	wrapTextWithAnsi,
 } from "@oh-my-pi/pi-tui";
 import { getAgentDbPath } from "@oh-my-pi/pi-utils";
+import { formatKeyHint } from "../../../config/keybindings";
 import { copyToClipboard } from "../../../utils/clipboard";
 import { OAuthSelectorComponent } from "../../components/oauth-selector";
 import { theme } from "../../theme/theme";
@@ -20,7 +21,7 @@ function loginUrlLink(url: string): string {
 }
 
 function loginCopyHint(): string {
-	return theme.fg("dim", "(clipboard copy attempted; Alt+C retries)");
+	return theme.fg("dim", `(clipboard copy attempted; ${formatKeyHint("alt+c")} retries)`);
 }
 
 class CopyablePromptInput implements Component, Focusable {

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -1,59 +1,65 @@
-import type { AppKeybinding, KeybindingsManager } from "../../config/keybindings";
+import { type AppKeybinding, formatKeyHint, type KeybindingsManager, type KeyId } from "../../config/keybindings";
 
 export interface HotkeysMarkdownBindings {
 	keybindings: Pick<KeybindingsManager, "getDisplayString">;
-}
-
-function appKey(bindings: HotkeysMarkdownBindings, action: AppKeybinding): string {
-	return bindings.keybindings.getDisplayString(action) || "Disabled";
+	/** Host platform deciding the modifier labels; defaults to the running host. */
+	platform?: NodeJS.Platform;
 }
 
 export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string {
+	const platform = bindings.platform ?? process.platform;
+	const appKey = (action: AppKeybinding) => bindings.keybindings.getDisplayString(action, platform) || "Disabled";
+	const key = (id: KeyId) => formatKeyHint(id, platform);
+	// `super+left` / `super+right` are not bound; these rows document the macOS
+	// editing convention the terminal itself provides, so they are omitted rather
+	// than relabelled into a chord that does nothing on other hosts.
+	const lineStart = platform === "darwin" ? `\`Ctrl+A\` / \`Home\` / \`${key("super+left")}\`` : "`Ctrl+A` / `Home`";
+	const lineEnd = platform === "darwin" ? `\`Ctrl+E\` / \`End\` / \`${key("super+right")}\`` : "`Ctrl+E` / `End`";
 	return [
 		"**Navigation**",
 		"| Key | Action |",
 		"|-----|--------|",
 		"| `Arrow keys` | Move cursor / browse history (Up when empty) |",
-		"| `Option+Left/Right` | Move by word |",
-		"| `Ctrl+A` / `Home` / `Cmd+Left` | Start of line |",
-		"| `Ctrl+E` / `End` / `Cmd+Right` | End of line |",
+		`| \`${key("alt+left")}\` / \`${key("alt+right")}\` | Move by word |`,
+		`| ${lineStart} | Start of line |`,
+		`| ${lineEnd} | End of line |`,
 		"",
 		"**Editing**",
 		"| Key | Action |",
 		"|-----|--------|",
 		"| `Enter` | Send message |",
-		"| `Shift+Enter` / `Alt+Enter` | New line |",
-		"| `Ctrl+W` / `Option+Backspace` | Delete word backwards |",
+		`| \`Shift+Enter\` / \`${key("alt+enter")}\` | New line |`,
+		`| \`Ctrl+W\` / \`${key("alt+backspace")}\` | Delete word backwards |`,
 		"| `Ctrl+U` | Delete to start of line |",
 		"| `Ctrl+K` | Delete to end of line |",
-		`| \`${appKey(bindings, "app.clipboard.copyLine")}\` | Copy current line |`,
-		`| \`${appKey(bindings, "app.clipboard.copyPrompt")}\` | Copy whole prompt |`,
+		`| \`${appKey("app.clipboard.copyLine")}\` | Copy current line |`,
+		`| \`${appKey("app.clipboard.copyPrompt")}\` | Copy whole prompt |`,
 		"",
 		"**Other**",
 		"| Key | Action |",
 		"|-----|--------|",
 		"| `Tab` | Path completion / accept autocomplete |",
-		`| \`${appKey(bindings, "app.interrupt")}\` | Cancel autocomplete / interrupt active work |`,
-		`| \`${appKey(bindings, "app.clear")}\` | Clear editor (first) / exit (second) |`,
-		`| \`${appKey(bindings, "app.exit")}\` | Exit (when editor is empty) |`,
-		`| \`${appKey(bindings, "app.suspend")}\` | Suspend to background |`,
-		`| \`${appKey(bindings, "app.display.reset")}\` | Reset terminal display |`,
-		`| \`${appKey(bindings, "app.thinking.cycle")}\` | Cycle thinking level |`,
-		`| \`${appKey(bindings, "app.model.cycleForward")}\` | Cycle role models (slow/default/smol) |`,
-		`| \`${appKey(bindings, "app.model.cycleBackward")}\` | Cycle role models (backward) |`,
-		`| \`${appKey(bindings, "app.model.selectTemporary")}\` | Select model (temporary) |`,
-		`| \`${appKey(bindings, "app.model.select")}\` | Select model (set roles) |`,
-		`| \`${appKey(bindings, "app.plan.toggle")}\` | Toggle plan mode |`,
-		`| \`${appKey(bindings, "app.history.search")}\` | Search prompt history |`,
-		`| \`${appKey(bindings, "app.tools.expand")}\` | Toggle tool output expansion |`,
-		`| \`${appKey(bindings, "app.tools.toggleVisibility")}\` | Toggle tool activity visibility |`,
-		`| \`${appKey(bindings, "app.thinking.toggle")}\` | Toggle thinking block visibility |`,
-		`| \`${appKey(bindings, "app.editor.external")}\` | Edit message in external editor |`,
-		`| \`${appKey(bindings, "app.retry")}\` | Retry last failed assistant turn |`,
-		`| \`${appKey(bindings, "app.clipboard.pasteImage")}\` | Paste image or text from clipboard |`,
+		`| \`${appKey("app.interrupt")}\` | Cancel autocomplete / interrupt active work |`,
+		`| \`${appKey("app.clear")}\` | Clear editor (first) / exit (second) |`,
+		`| \`${appKey("app.exit")}\` | Exit (when editor is empty) |`,
+		`| \`${appKey("app.suspend")}\` | Suspend to background |`,
+		`| \`${appKey("app.display.reset")}\` | Reset terminal display |`,
+		`| \`${appKey("app.thinking.cycle")}\` | Cycle thinking level |`,
+		`| \`${appKey("app.model.cycleForward")}\` | Cycle role models (slow/default/smol) |`,
+		`| \`${appKey("app.model.cycleBackward")}\` | Cycle role models (backward) |`,
+		`| \`${appKey("app.model.selectTemporary")}\` | Select model (temporary) |`,
+		`| \`${appKey("app.model.select")}\` | Select model (set roles) |`,
+		`| \`${appKey("app.plan.toggle")}\` | Toggle plan mode |`,
+		`| \`${appKey("app.history.search")}\` | Search prompt history |`,
+		`| \`${appKey("app.tools.expand")}\` | Toggle tool output expansion |`,
+		`| \`${appKey("app.tools.toggleVisibility")}\` | Toggle tool activity visibility |`,
+		`| \`${appKey("app.thinking.toggle")}\` | Toggle thinking block visibility |`,
+		`| \`${appKey("app.editor.external")}\` | Edit message in external editor |`,
+		`| \`${appKey("app.retry")}\` | Retry last failed assistant turn |`,
+		`| \`${appKey("app.clipboard.pasteImage")}\` | Paste image or text from clipboard |`,
 		"| Hold `Space` | Speech-to-text (push-to-talk): hold to record, release to transcribe |",
-		`| \`${appKey(bindings, "app.live.toggle")}\` | Start/stop live voice mode (/live) |`,
-		`| \`${appKey(bindings, "app.agents.hub")}\` / \`${appKey(bindings, "app.session.observe")}\` / double-tap \`←\` (empty editor) | Open the agent hub |`,
+		`| \`${appKey("app.live.toggle")}\` | Start/stop live voice mode (/live) |`,
+		`| \`${appKey("app.agents.hub")}\` / \`${appKey("app.session.observe")}\` / double-tap \`←\` (empty editor) | Open the agent hub |`,
 		"| `#<number>` | GitHub issue/PR reference (e.g. `#3164` → `pr://`/`issue://`) |",
 		"| `#` / `#<text>` | Prompt actions (copy / undo / move cursor) |",
 		"| `/` | Slash commands |",

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -4,6 +4,7 @@ import { getStreamingPartialJson } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { type Component, Spacer, Text, TruncatedText } from "@oh-my-pi/pi-tui";
 import type { AdvisorMessageDetails } from "../../advisor";
 import { COLLAB_PROMPT_MESSAGE_TYPE, type CollabPromptDetails } from "../../collab/protocol";
+import { formatKeyHint } from "../../config/keybindings";
 import { settings } from "../../config/settings";
 import { getEditClipboard } from "../../edit/edit-clipboard";
 import { getFileSnapshotStore } from "../../edit/file-snapshot-store";
@@ -784,7 +785,7 @@ export class UiHelpers {
 					this.ctx.pendingMessagesContainer.addChild(new TruncatedText(queuedText, 1, 0));
 				}
 			}
-			const dequeueKey = this.ctx.keybindings.getDisplayString("app.message.dequeue") || "Alt+Up";
+			const dequeueKey = this.ctx.keybindings.getDisplayString("app.message.dequeue") || formatKeyHint("alt+up");
 			const hintText = theme.fg("dim", `  ${theme.tree.hook} ${dequeueKey} to edit`);
 			this.ctx.pendingMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
 		}

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -14,6 +14,7 @@ import { discoverAndLoadExtensions, ExtensionRuntime } from "@oh-my-pi/pi-coding
 import {
 	EXTENSION_HANDLER_TIMEOUT_MS,
 	ExtensionRunner,
+	RESERVED_EXTENSION_SHORTCUTS,
 	testSetExtensionHandlerTimeoutMs,
 } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import type {
@@ -24,6 +25,7 @@ import type {
 import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/wrapper";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { canonicalKeyId } from "@oh-my-pi/pi-tui";
 import { getProjectAgentDir, logger, TempDir } from "@oh-my-pi/pi-utils";
 
 describe("ExtensionRunner", () => {
@@ -208,6 +210,123 @@ describe("ExtensionRunner", () => {
 			expect(shortcuts.has("alt+m")).toBe(false);
 
 			warnSpy.mockRestore();
+		});
+
+		it("rejects the macOS spellings of a reserved chord, which resolve to the same key event", async () => {
+			// `canonicalKeyId` folds `Option`/`⌥` onto `alt`, and the editor's match
+			// keys are built from the canonical form — so an extension registering
+			// `⌥+m` would really shadow app.model.select. The reservation check must
+			// canonicalize too, or it waves the alias through. The uppercase bases are
+			// the strings darwin `/hotkeys` prints, and they must not pick up a phantom
+			// Shift from `canonicalKeyId`'s bare-uppercase rule.
+			const extCode = `
+				export default function(pi) {
+					pi.registerShortcut("Option+m", {
+						description: "Tries to bind model select via the Option spelling",
+						handler: async () => {},
+					});
+					pi.registerShortcut("⌥+M", {
+						description: "Same chord as printed by /hotkeys on macOS",
+						handler: async () => {},
+					});
+					pi.registerShortcut("Ctrl+C", {
+						description: "Reserved interrupt with an uppercase base",
+						handler: async () => {},
+					});
+					pi.registerShortcut("⌥+enter", {
+						description: "Tries to bind the follow-up newline chord",
+						handler: async () => {},
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "conflict-alias.ts"), extCode);
+
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const shortcuts = runner.getShortcuts();
+
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("conflicts with built-in"), expect.any(Object));
+			expect([...shortcuts.keys()]).toEqual([]);
+
+			warnSpy.mockRestore();
+		});
+
+		it("reserves a chord regardless of the modifier order the extension writes", async () => {
+			// `shift+ctrl+p` canonicalizes to `ctrl+shift+p`; both spellings must be
+			// rejected for app.model.cycleBackward.
+			const extCode = `
+				export default function(pi) {
+					pi.registerShortcut("ctrl+shift+p", {
+						description: "Tries to bind cycle backward",
+						handler: async () => {},
+					});
+					pi.registerShortcut("shift+ctrl+p", {
+						description: "Tries the other order",
+						handler: async () => {},
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "conflict-order.ts"), extCode);
+
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const shortcuts = runner.getShortcuts();
+
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("conflicts with built-in"), expect.any(Object));
+			expect([...shortcuts.keys()]).toEqual([]);
+
+			warnSpy.mockRestore();
+		});
+
+		it("keeps every reserved chord reachable by the canonicalized lookup", () => {
+			// The lookup at `getShortcuts()` canonicalizes the incoming key, so a table
+			// entry that is not its own canonical form (as `shift+ctrl+p` was) can
+			// never match and silently stops reserving anything.
+			const drifted = Object.keys(RESERVED_EXTENSION_SHORTCUTS).filter(key => canonicalKeyId(key) !== key);
+
+			expect(drifted).toEqual([]);
+		});
+
+		it("keeps an uppercase-spelled non-reserved chord on the chord the author meant", async () => {
+			// `canonicalKeyId` promotes a bare uppercase base letter to Shift, so
+			// `getShortcuts()` must lowercase first or `Alt+K` registers as
+			// `shift+alt+k` and never fires on the real Alt+K event.
+			const extCode = `
+				export default function(pi) {
+					pi.registerShortcut("Alt+K", {
+						description: "Non-reserved chord with an uppercase base",
+						handler: async () => {},
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "uppercase-base.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+
+			expect([...runner.getShortcuts().keys()]).toEqual(["alt+k"]);
 		});
 
 		it("warns when two extensions register same shortcut", async () => {

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { getDefaultPasteImageKeys, KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	formatKeyHints,
+	getDefaultPasteImageKeys,
+	KeybindingsManager,
+	type KeyId,
+	modifierLabel,
+} from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { keyText } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
 import { getKeybindings, setKeybindings, type KeybindingsManager as TuiKeybindingsManager } from "@oh-my-pi/pi-tui";
 
@@ -9,13 +18,13 @@ describe("KeybindingsManager.getDisplayString", () => {
 			"app.message.dequeue": "alt+up",
 		});
 
-		expect(keybindings.getDisplayString("app.message.dequeue")).toBe("Alt+Up");
+		expect(keybindings.getDisplayString("app.message.dequeue", "linux")).toBe("Alt+Up");
 	});
 
 	it("defaults retry to Alt+R", () => {
 		const keybindings = KeybindingsManager.inMemory();
 
-		expect(keybindings.getDisplayString("app.retry")).toBe("Alt+R");
+		expect(keybindings.getDisplayString("app.retry", "linux")).toBe("Alt+R");
 	});
 
 	it("formats multiple bindings with the existing separator", () => {
@@ -23,7 +32,7 @@ describe("KeybindingsManager.getDisplayString", () => {
 			"app.clipboard.copyPrompt": ["alt+shift+c", "ctrl+shift+c"],
 		});
 
-		expect(keybindings.getDisplayString("app.clipboard.copyPrompt")).toBe("Alt+Shift+C/Ctrl+Shift+C");
+		expect(keybindings.getDisplayString("app.clipboard.copyPrompt", "linux")).toBe("Alt+Shift+C/Ctrl+Shift+C");
 	});
 
 	it("returns an empty string when the action has no binding", () => {
@@ -31,25 +40,135 @@ describe("KeybindingsManager.getDisplayString", () => {
 			"app.clipboard.copyPrompt": [],
 		});
 
-		expect(keybindings.getDisplayString("app.clipboard.copyPrompt")).toBe("");
+		expect(keybindings.getDisplayString("app.clipboard.copyPrompt", "linux")).toBe("");
+	});
+});
+
+describe("macOS modifier labels", () => {
+	it("renders Alt and Super with the glyphs printed on the Apple keys", () => {
+		const keybindings = KeybindingsManager.inMemory({
+			"app.model.selectTemporary": "alt+p",
+			"app.clipboard.pasteImage": "super+v",
+			"app.clipboard.copyLine": "alt+shift+l",
+		});
+
+		expect(keybindings.getDisplayString("app.model.selectTemporary", "darwin")).toBe("⌥+P");
+		expect(keybindings.getDisplayString("app.clipboard.pasteImage", "darwin")).toBe("⌘+V");
+		expect(keybindings.getDisplayString("app.clipboard.copyLine", "darwin")).toBe("⌥+Shift+L");
+	});
+
+	it("keeps the ASCII modifier names on every other platform", () => {
+		const keybindings = KeybindingsManager.inMemory({
+			"app.model.selectTemporary": "alt+p",
+			"app.clipboard.pasteImage": "super+v",
+		});
+
+		for (const platform of ["linux", "win32"] as const) {
+			expect(keybindings.getDisplayString("app.model.selectTemporary", platform)).toBe("Alt+P");
+			expect(keybindings.getDisplayString("app.clipboard.pasteImage", platform)).toBe("Super+V");
+		}
+	});
+
+	it("preserves the authored modifier order instead of reordering the chord", () => {
+		const keybindings = KeybindingsManager.inMemory({
+			"app.plan.toggle": "alt+shift+p",
+		});
+
+		expect(keybindings.getDisplayString("app.plan.toggle", "linux")).toBe("Alt+Shift+P");
+		expect(keybindings.getDisplayString("app.plan.toggle", "darwin")).toBe("⌥+Shift+P");
+	});
+
+	it("formats standalone key hints for the requested platform", () => {
+		expect(formatKeyHints(["alt+up", "shift+up"], "darwin")).toBe("⌥+Up/Shift+Up");
+		expect(formatKeyHints(["alt+up", "shift+up"], "linux")).toBe("Alt+Up/Shift+Up");
+		expect(formatKeyHints("ctrl+alt+]", "darwin")).toBe("Ctrl+⌥+]");
+	});
+
+	it("exposes the bare modifier label for compact multi-key hints", () => {
+		expect(modifierLabel("alt", "darwin")).toBe("⌥");
+		expect(modifierLabel("alt", "linux")).toBe("Alt");
+		expect(modifierLabel("option", "darwin")).toBe("⌥");
+		expect(modifierLabel("super", "darwin")).toBe("⌘");
+		expect(modifierLabel("super", "linux")).toBe("Super");
+		expect(modifierLabel("ctrl", "darwin")).toBe("Ctrl");
+	});
+
+	it("treats Object.prototype member names as ordinary key parts", () => {
+		// The label and spelling tables are object literals, so an unguarded lookup
+		// resolves `constructor`/`toString` through the prototype chain and renders
+		// the native-code text of a function.
+		expect(formatKeyHints("ctrl+constructor" as KeyId, "darwin")).toBe("Ctrl+Constructor");
+		expect(modifierLabel("constructor", "darwin")).toBe("constructor");
+		expect(modifierLabel("toString", "linux")).toBe("toString");
+	});
+});
+
+describe("keybindings.yml authored with the macOS spellings", () => {
+	let previous: TuiKeybindingsManager;
+	let agentDir: string;
+
+	beforeEach(() => {
+		previous = getKeybindings();
+		agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-keybindings-"));
+	});
+
+	afterEach(() => {
+		setKeybindings(previous);
+		fs.rmSync(agentDir, { recursive: true, force: true });
+	});
+
+	it("loads Option/⌥/Cmd chords off disk, matches them, and relabels per platform", () => {
+		// The loader parses `keybindings.yml` as plain YAML with no schema, so these
+		// spellings reach the manager verbatim; only `canonicalKeyId` folds them.
+		fs.writeFileSync(
+			path.join(agentDir, "keybindings.yml"),
+			["app.model.selectTemporary: Option+j", "app.retry: ⌥+k", "app.clipboard.pasteImage: Cmd+v", ""].join("\n"),
+			"utf-8",
+		);
+
+		const keybindings = KeybindingsManager.create(agentDir, { inheritedAgentDir: agentDir });
+
+		expect(keybindings.matches("\x1bj", "app.model.selectTemporary")).toBe(true);
+		expect(keybindings.matches("\x1bk", "app.retry")).toBe(true);
+		expect(keybindings.getDisplayString("app.model.selectTemporary", "darwin")).toBe("⌥+J");
+		expect(keybindings.getDisplayString("app.retry", "linux")).toBe("Alt+K");
+		expect(keybindings.getDisplayString("app.clipboard.pasteImage", "darwin")).toBe("⌘+V");
+		expect(keybindings.getDisplayString("app.clipboard.pasteImage", "linux")).toBe("Super+V");
+		// Round-trip contract: the modifier is folded to its canonical name while the
+		// authored order is kept. `getKeys()` output is handed to the native matcher
+		// and `/keybindings` writes it back to disk, so the alias must not survive.
+		expect(keybindings.getKeys("app.model.selectTemporary")).toEqual(["alt+j"]);
+		expect(keybindings.getEffectiveConfig()["app.retry"]).toBe("alt+k");
+		expect(keybindings.getKeys("app.clipboard.pasteImage")).toEqual(["super+v"]);
 	});
 });
 
 describe("legacy keyText", () => {
 	let previous: TuiKeybindingsManager;
+	let platformDescriptor: PropertyDescriptor;
 
 	beforeEach(() => {
 		previous = getKeybindings();
+		platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
 	});
 
 	afterEach(() => {
 		setKeybindings(previous);
+		Object.defineProperty(process, "platform", platformDescriptor);
 	});
 
 	it("formats the active binding for legacy extensions", () => {
+		Object.defineProperty(process, "platform", { ...platformDescriptor, value: "linux" });
 		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "alt+e" }));
 
 		expect(keyText("app.tools.expand")).toBe("Alt+E");
+	});
+
+	it("follows the host platform when no platform is supplied", () => {
+		Object.defineProperty(process, "platform", { ...platformDescriptor, value: "darwin" });
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "alt+e" }));
+
+		expect(keyText("app.tools.expand")).toBe("⌥+E");
 	});
 });
 

--- a/packages/coding-agent/test/modes/components/tree-selector-empty-state-1909.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-empty-state-1909.test.ts
@@ -45,9 +45,22 @@ function userMessageTree(): SessionTreeNode[] {
 	return [{ entry, children: [] }];
 }
 
-function renderSelector(selector: TreeSelectorComponent): string {
-	const lines = (selector as unknown as { render: (w: number) => string[] }).render(120);
-	return Bun.stripANSI(lines.join("\n"));
+function renderSelector(selector: TreeSelectorComponent, width = 120): string {
+	// `render` is an internal Component method the exported class type omits.
+	const renderable = selector as unknown as { render: (w: number) => string[] };
+	return Bun.stripANSI(renderable.render(width).join("\n"));
+}
+
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform") as PropertyDescriptor;
+
+/** The hints are built during construction, so the platform must be set around it. */
+function renderOnPlatform(platform: NodeJS.Platform, build: () => TreeSelectorComponent, width = 120): string {
+	Object.defineProperty(process, "platform", { ...platformDescriptor, value: platform });
+	try {
+		return renderSelector(build(), width);
+	} finally {
+		Object.defineProperty(process, "platform", platformDescriptor);
+	}
 }
 
 describe("issue #1909: tree-selector empty-state messaging", () => {
@@ -65,7 +78,7 @@ describe("issue #1909: tree-selector empty-state messaging", () => {
 		// the panel isn't broken and can widen the view without leaving the screen.
 		expect(text).toContain("hidden by the current filter");
 		expect(text).toContain("[default]");
-		expect(text.toLowerCase()).toContain("alt+a");
+		expect(text.toLowerCase()).toContain("+a to show all");
 		// Total count must reflect the real flatNodes count, not 0/0 (otherwise the
 		// "filter hides things" framing is unconvincing).
 		expect(text).toContain("(0/2)");
@@ -103,5 +116,48 @@ describe("issue #1909: tree-selector empty-state messaging", () => {
 		expect(text).toContain("(0/0)");
 		// Don't tell the user to widen the filter when there's nothing to widen to.
 		expect(text).not.toContain("hidden by the current filter");
+	});
+});
+
+describe("tree-selector modifier labels follow the host platform", () => {
+	it("renders the Option glyph in the empty-state and footer hints on darwin", () => {
+		const text = renderOnPlatform(
+			"darwin",
+			() =>
+				new TreeSelectorComponent(
+					freshSessionTree(),
+					"e2",
+					60,
+					() => {},
+					() => {},
+				),
+			// The footer is a TruncatedText; render wide enough to see the whole hint.
+			280,
+		);
+
+		expect(text).toContain("Press ⌥+A to show all, ⌥+D for default");
+		expect(text).toContain("⌥+↑/↓: previous/next turn");
+		expect(text).toContain("⌥+D/T/U/L/A: filter");
+		expect(text).not.toContain("Alt+");
+	});
+
+	it("keeps the ASCII Alt label in the same hints off darwin", () => {
+		const text = renderOnPlatform(
+			"linux",
+			() =>
+				new TreeSelectorComponent(
+					freshSessionTree(),
+					"e2",
+					60,
+					() => {},
+					() => {},
+				),
+			280,
+		);
+
+		expect(text).toContain("Press Alt+A to show all, Alt+D for default");
+		expect(text).toContain("Alt+↑/↓: previous/next turn");
+		expect(text).toContain("Alt+D/T/U/L/A: filter");
+		expect(text).not.toContain("⌥");
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { buildHotkeysMarkdown } from "@oh-my-pi/pi-coding-agent/modes/utils/hotkeys-markdown";
 
 describe("buildHotkeysMarkdown", () => {
@@ -74,5 +74,64 @@ describe("buildHotkeysMarkdown", () => {
 
 		expect(markdown).toContain("| `Disabled` | Select model (temporary) |");
 		expect(markdown).toContain("| `Alt+M` | Select model (set roles) |");
+	});
+});
+
+describe("buildHotkeysMarkdown static editor chords", () => {
+	const keybindings = { getDisplayString: () => "Ctrl+K" };
+
+	it("labels the static chords with the Apple key glyphs on darwin", () => {
+		const markdown = buildHotkeysMarkdown({ keybindings, platform: "darwin" });
+
+		expect(markdown).toContain("| `⌥+Left` / `⌥+Right` | Move by word |");
+		expect(markdown).toContain("| `Shift+Enter` / `⌥+Enter` | New line |");
+		expect(markdown).toContain("| `Ctrl+W` / `⌥+Backspace` | Delete word backwards |");
+		expect(markdown).toContain("| `Ctrl+A` / `Home` / `⌘+Left` | Start of line |");
+		expect(markdown).toContain("| `Ctrl+E` / `End` / `⌘+Right` | End of line |");
+		// Nothing may fall back to the ASCII names once the host is macOS.
+		for (const ascii of ["Alt+", "Cmd+", "Super+", "Option+"]) {
+			expect(markdown).not.toContain(ascii);
+		}
+	});
+
+	it("uses the ASCII modifier names off darwin and drops the mac-only chords", () => {
+		const markdown = buildHotkeysMarkdown({ keybindings, platform: "linux" });
+
+		expect(markdown).toContain("| `Alt+Left` / `Alt+Right` | Move by word |");
+		expect(markdown).toContain("| `Shift+Enter` / `Alt+Enter` | New line |");
+		expect(markdown).toContain("| `Ctrl+W` / `Alt+Backspace` | Delete word backwards |");
+		// `super+left` / `super+right` are not bound anywhere; the rows only ever
+		// described the macOS editing convention, so they stay off other hosts
+		// instead of being relabelled into a chord that does nothing.
+		expect(markdown).toContain("| `Ctrl+A` / `Home` | Start of line |");
+		expect(markdown).toContain("| `Ctrl+E` / `End` | End of line |");
+		for (const macOnly of ["⌥", "⌘", "Cmd+", "Option+"]) {
+			expect(markdown).not.toContain(macOnly);
+		}
+	});
+
+	// `command-controller.ts` calls `buildHotkeysMarkdown({ keybindings })` with no
+	// `platform`, so the `?? process.platform` fallback is the only path `/hotkeys`
+	// ever takes in production.
+	describe("without an injected platform", () => {
+		let platformDescriptor: PropertyDescriptor;
+
+		beforeEach(() => {
+			platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform") as PropertyDescriptor;
+		});
+
+		afterEach(() => {
+			Object.defineProperty(process, "platform", platformDescriptor);
+		});
+
+		it("follows the host platform", () => {
+			Object.defineProperty(process, "platform", { ...platformDescriptor, value: "darwin" });
+			expect(buildHotkeysMarkdown({ keybindings })).toContain("| `⌥+Left` / `⌥+Right` | Move by word |");
+
+			Object.defineProperty(process, "platform", { ...platformDescriptor, value: "linux" });
+			const linux = buildHotkeysMarkdown({ keybindings });
+			expect(linux).toContain("| `Alt+Left` / `Alt+Right` | Move by word |");
+			expect(linux).toContain("| `Ctrl+A` / `Home` | Start of line |");
+		});
 	});
 });

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -166,12 +166,39 @@ const SHIFTED_SYMBOL_KEYS = new Set<string>([
 
 const MODIFIER_ORDER = ["ctrl", "shift", "alt", "super"] as const;
 
+export type Modifier = (typeof MODIFIER_ORDER)[number];
+
+/**
+ * Spellings accepted on input, mapped to the canonical modifier. macOS chords are
+ * also written with the glyphs printed on the physical keys (and the words Apple
+ * uses for them) because that is what the UI renders on darwin and what
+ * docs/keybindings.md tells users to copy into `keybindings.yml`.
+ */
+export const MODIFIER_SPELLINGS: Record<string, Modifier> = {
+	ctrl: "ctrl",
+	shift: "shift",
+	alt: "alt",
+	option: "alt",
+	"⌥": "alt",
+	super: "super",
+	cmd: "super",
+	command: "super",
+	"⌘": "super",
+};
+
+// Prefix matching needs ordered pairs; hoisted so `canonicalKeyId` (one call per
+// key event) does not re-walk the record on every chord.
+const MODIFIER_SPELLING_ENTRIES = Object.entries(MODIFIER_SPELLINGS);
+
 function startsWithModifier(key: string, offset: number, modifier: string): boolean {
 	if (key.length <= offset + modifier.length || key.charCodeAt(offset + modifier.length) !== 43) return false;
 	for (let i = 0; i < modifier.length; i++) {
 		const actual = key.charCodeAt(offset + i);
 		const expected = modifier.charCodeAt(i);
-		if (actual !== expected && actual !== expected - 32) return false;
+		if (actual === expected) continue;
+		// Spellings are stored lowercase; accept the ASCII uppercase form too. The
+		// glyph spellings are non-ASCII, so they must match exactly.
+		if (expected < 97 || expected > 122 || actual !== expected - 32) return false;
 	}
 	return true;
 }
@@ -189,10 +216,10 @@ export function canonicalKeyId(key: string): string {
 
 	while (foundModifier) {
 		foundModifier = false;
-		for (const modifier of MODIFIER_ORDER) {
-			if (startsWithModifier(key, offset, modifier)) {
-				modifiers.push(modifier);
-				offset += modifier.length + 1;
+		for (const [spelling, modifier] of MODIFIER_SPELLING_ENTRIES) {
+			if (startsWithModifier(key, offset, spelling)) {
+				if (!modifiers.includes(modifier)) modifiers.push(modifier);
+				offset += spelling.length + 1;
 				foundModifier = true;
 				break;
 			}
@@ -222,7 +249,27 @@ export function addKeyAliases(keys: Set<string>, key: KeyId): void {
 	}
 }
 
-const normalizeKeyId = (key: KeyId): KeyId => key.toLowerCase() as KeyId;
+/**
+ * Lowercase a chord and fold every modifier onto its canonical name, keeping the
+ * authored order (which drives the UI label, so `alt+shift+p` must not become
+ * `shift+alt+p`). Folding here rather than only in `canonicalKeyId` is required:
+ * `getKeys()` output is handed straight to `matchesKey`, whose native
+ * `parse_key_id` knows only ctrl/shift/super/alt and silently degrades an
+ * unrecognized modifier to the bare base key.
+ */
+const normalizeKeyId = (key: KeyId): KeyId => {
+	const lower = key.toLowerCase();
+	const lastPlus = lower.lastIndexOf("+");
+	if (lastPlus <= 0) return lower as KeyId;
+	const parts = lower.slice(0, lastPlus).split("+");
+	for (let i = 0; i < parts.length; i++) {
+		const part = parts[i] as string;
+		// `Object.hasOwn`, not `??`: a part named `constructor`/`toString` resolves
+		// through Object.prototype to a truthy function that `??` would keep.
+		if (Object.hasOwn(MODIFIER_SPELLINGS, part)) parts[i] = MODIFIER_SPELLINGS[part] as string;
+	}
+	return `${parts.join("+")}${lower.slice(lastPlus)}` as KeyId;
+};
 
 function normalizeKeys(keys: KeyId | KeyId[] | undefined): KeyId[] {
 	if (keys === undefined) return [];
@@ -260,10 +307,14 @@ export class KeybindingsManager {
 		const userClaims = new Map<KeyId, Set<Keybinding>>();
 		for (const [keybinding, keys] of Object.entries(this.#userBindings)) {
 			if (!(keybinding in this.#definitions)) continue;
+			// Claims are keyed by canonical id, not by the spelling the user typed:
+			// `alt+x` and `Option+x` produce the same match key, so they collide even
+			// though the raw strings differ.
 			for (const key of normalizeKeys(keys)) {
-				const claimants = userClaims.get(key) ?? new Set<Keybinding>();
+				const canonical = canonicalKeyId(key) as KeyId;
+				const claimants = userClaims.get(canonical) ?? new Set<Keybinding>();
 				claimants.add(keybinding as Keybinding);
-				userClaims.set(key, claimants);
+				userClaims.set(canonical, claimants);
 			}
 		}
 

--- a/packages/tui/test/keybindings.test.ts
+++ b/packages/tui/test/keybindings.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "bun:test";
-import { addKeyAliases, canonicalKeyId, KeybindingsManager, parseKey, TUI_KEYBINDINGS } from "@oh-my-pi/pi-tui";
+import {
+	addKeyAliases,
+	canonicalKeyId,
+	KeybindingsManager,
+	type KeyId,
+	matchesKey,
+	parseKey,
+	TUI_KEYBINDINGS,
+} from "@oh-my-pi/pi-tui";
 
 describe("KeybindingsManager", () => {
 	it("does not evict selector confirm when input submit is rebound", () => {
@@ -72,5 +80,169 @@ describe("KeybindingsManager", () => {
 			expect(aliases.has(canonicalKeyId(parsed))).toBe(true);
 			expect(keybindings.matches(input, "tui.input.copy")).toBe(true);
 		}
+	});
+});
+
+describe("canonicalKeyId macOS modifier spellings", () => {
+	it("folds the Option and Command spellings onto the canonical modifiers", () => {
+		for (const spelling of ["Option+p", "option+p", "⌥+p"]) {
+			expect(canonicalKeyId(spelling)).toBe("alt+p");
+		}
+		for (const spelling of ["Command+p", "command+p", "Cmd+p", "cmd+p", "⌘+p"]) {
+			expect(canonicalKeyId(spelling)).toBe("super+p");
+		}
+	});
+
+	it("keeps the canonical ASCII spellings and modifier ordering intact", () => {
+		expect(canonicalKeyId("alt+p")).toBe("alt+p");
+		expect(canonicalKeyId("super+v")).toBe("super+v");
+		expect(canonicalKeyId("alt+ctrl+x")).toBe("ctrl+alt+x");
+		expect(canonicalKeyId("⌥+shift+l")).toBe("shift+alt+l");
+	});
+
+	it("still promotes an uppercase base letter to Shift behind the new spellings", () => {
+		// Terminal input rule: a bare uppercase letter carries Shift (see the
+		// `canonicalKeyId("A") === "shift+a"` case above). Config-authored chords
+		// are lowercased by `normalizeKeys` before they reach here, so `⌥+P` in
+		// `keybindings.yml` still resolves to `alt+p`.
+		expect(canonicalKeyId("⌥+P")).toBe("shift+alt+p");
+		expect(canonicalKeyId("⌘+V")).toBe("shift+super+v");
+	});
+
+	it("collapses a modifier spelled twice instead of emitting a dead chord", () => {
+		expect(canonicalKeyId("alt+option+p")).toBe("alt+p");
+		expect(canonicalKeyId("cmd+⌘+v")).toBe("super+v");
+	});
+
+	it("matches glyph spellings exactly rather than case-folding them", () => {
+		// ⌅ (U+2305) and ⋸ (U+22F8) are ⌥ (U+2325) and ⌘ (U+2318) minus the ASCII
+		// case-fold delta; only ASCII letters may fold, so these stay base keys.
+		expect(canonicalKeyId("⌅+p")).toBe("⌅+p");
+		expect(canonicalKeyId("⋸+v")).toBe("⋸+v");
+	});
+
+	it("resolves a binding authored with the macOS spelling against the real key event", () => {
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			// `KeyId` only spells the canonical chords; the macOS spellings are an
+			// input tolerance for hand-written `keybindings.yml`, which reaches the
+			// manager as an unvalidated YAML string rather than through this type.
+			"tui.input.copy": "Option+P" as KeyId,
+		});
+
+		expect(keybindings.matches("\x1bp", "tui.input.copy")).toBe(true);
+	});
+
+	it("reports a conflict when two actions claim one chord under different spellings", () => {
+		// Both resolve to `alt+x` at match time, so the second binding silently
+		// shadows the first unless conflict detection canonicalizes as well.
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.submit": "alt+x" as KeyId,
+			"tui.select.confirm": "Option+x" as KeyId,
+		});
+
+		expect(keybindings.getConflicts()).toEqual([
+			{
+				key: "alt+x",
+				keybindings: ["tui.input.submit", "tui.select.confirm"],
+			},
+		]);
+	});
+
+	it("reports a conflict when two actions claim one chord in different modifier orders", () => {
+		// Same canonicalization, different defect: folding only the spelling and
+		// leaving the authored order intact would pass the test above and fail here.
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.submit": "alt+ctrl+x" as KeyId,
+			"tui.select.confirm": "ctrl+alt+x" as KeyId,
+		});
+
+		expect(keybindings.getConflicts()).toEqual([
+			{
+				key: "ctrl+alt+x",
+				keybindings: ["tui.input.submit", "tui.select.confirm"],
+			},
+		]);
+	});
+});
+
+describe("getKeys output is safe for the native matcher", () => {
+	// Components match `getKeys()` output directly with `matchesKey`, which routes to
+	// the Rust `parse_key_id`. That parser knows only ctrl/shift/super/alt and
+	// consumes an unrecognized part as the key token, so an unfolded `⌥+a` degrades
+	// to the bare `a` — plain letters would start firing chorded actions.
+	it("folds alias spellings so a chord never degrades to its bare base key", () => {
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.copy": "⌥+a" as KeyId,
+			"tui.editor.yankPop": "Cmd+O" as KeyId,
+			"tui.editor.undo": "Option+l" as KeyId,
+		});
+
+		expect(keybindings.getKeys("tui.input.copy")).toEqual(["alt+a"]);
+		expect(keybindings.getKeys("tui.editor.yankPop")).toEqual(["super+o"]);
+		expect(keybindings.getKeys("tui.editor.undo")).toEqual(["alt+l"]);
+
+		for (const [key, bare, chord] of [
+			[keybindings.getKeys("tui.input.copy")[0], "a", "\x1ba"],
+			[keybindings.getKeys("tui.editor.undo")[0], "l", "\x1bl"],
+		] as const) {
+			expect(matchesKey(bare, key as KeyId)).toBe(false);
+			expect(matchesKey(chord, key as KeyId)).toBe(true);
+		}
+	});
+
+	it("preserves the authored modifier order while folding the spelling", () => {
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.copy": "alt+shift+p" as KeyId,
+			"tui.editor.undo": "⌥+shift+p" as KeyId,
+		});
+
+		// Order is display-relevant (`Alt+Shift+P` is the documented default), so
+		// folding must not reorder the way `canonicalKeyId` does.
+		expect(keybindings.getKeys("tui.input.copy")).toEqual(["alt+shift+p"]);
+		expect(keybindings.getKeys("tui.editor.undo")).toEqual(["alt+shift+p"]);
+	});
+
+	it("folds an alias that is not the leading modifier", () => {
+		// Guards the split point: normalizing around the FIRST `+` would leave every
+		// modifier after it unfolded, and each case here has the alias in second
+		// position where the leading-alias cases above cannot catch it.
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.copy": "shift+⌥+p" as KeyId,
+			"tui.editor.undo": "ctrl+option+m" as KeyId,
+			"tui.editor.yankPop": "shift+cmd+o" as KeyId,
+		});
+
+		expect(keybindings.getKeys("tui.input.copy")).toEqual(["shift+alt+p"]);
+		expect(keybindings.getKeys("tui.editor.undo")).toEqual(["ctrl+alt+m"]);
+		expect(keybindings.getKeys("tui.editor.yankPop")).toEqual(["shift+super+o"]);
+	});
+
+	it("leaves a chord whose base key is itself a plus sign intact", () => {
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.copy": "ctrl++" as KeyId,
+		});
+
+		expect(keybindings.getKeys("tui.input.copy")).toEqual(["ctrl++"]);
+	});
+
+	it("treats Object.prototype member names as ordinary key parts", () => {
+		// The spelling table is an object literal, so a bare `MODIFIER_SPELLINGS[part]`
+		// resolves `constructor`/`toString` through the prototype chain — and `??`
+		// does not catch it, corrupting the chord into native-code text.
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.copy": "constructor+p" as KeyId,
+			"tui.editor.undo": "ctrl+toString+p" as KeyId,
+		});
+
+		expect(keybindings.getKeys("tui.input.copy")).toEqual(["constructor+p" as KeyId]);
+		expect(keybindings.getKeys("tui.editor.undo")).toEqual(["ctrl+tostring+p" as KeyId]);
+	});
+
+	it("leaves an unmodified base key untouched", () => {
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
+			"tui.input.copy": "Enter" as KeyId,
+		});
+
+		expect(keybindings.getKeys("tui.input.copy")).toEqual(["enter"]);
 	});
 });


### PR DESCRIPTION
## What

On macOS, key hints now use the modifier glyphs printed on the physical keys: `alt` renders as `⌥` and `super` as `⌘`. Every other platform keeps `Alt` and `Super`.

```
/hotkeys on darwin              /hotkeys on linux
| `⌥+Left` / `⌥+Right` |        | `Alt+Left` / `Alt+Right` |
| `Ctrl+A` / `Home` / `⌘+Left` | | `Ctrl+A` / `Home` |
| `Shift+Enter` / `⌥+Enter` |    | `Shift+Enter` / `Alt+Enter` |
```

`formatKeyHint`, `formatKeyHints`, `getDisplayString` and the new `modifierLabel` take an optional `platform` defaulting to `process.platform`, so the choice is injectable and testable rather than read from the ambient host inside the formatter.

Two deliberate non-changes:

- **Modifier order is left as authored.** Canonicalizing it would turn the documented `Alt+Shift+P` into `Shift+Alt+P`.
- **The `+` separator stays.** `⌥+P` rather than Apple's `⌥P`, so mixed chords like `Ctrl+⌥+X` stay unambiguous next to the `Ctrl`/`Shift` names that are still words.

`keybindings.yml` now accepts every spelling of a modifier (`⌥`/`Option`/`Alt`, `⌘`/`Cmd`/`Command`/`Super`). This is not scope creep — `docs/keybindings.md` tells users the config uses "the same notation shown in the UI", so rendering a glyph the parser rejects would have shipped a documented lie.

## Bugs found while sweeping the remaining hardcoded labels

- **`/hotkeys` hardcoded macOS key names on every platform.** Linux and Windows users were shown `Option+Left/Right` and `Option+Backspace`, and the `Cmd+Left`/`Cmd+Right` line-start/line-end rows were listed unconditionally even though no `super+left`/`super+right` binding exists (`tui.editor.cursorLineStart` defaults to `["home","ctrl+a"]`). Those two rows are now darwin-only rather than relabelled into a chord that does nothing.
- **Raw chord ids leaked into three UI surfaces.** The session-only model status, the agent-transcript footer and the model-hub cycle footer printed `alt+m` / `ctrl+o` / `ctrl+p` because they read `getKeys(...)[0]` instead of formatting the hint.
- **Alias spellings would have collapsed a chord to its bare base key.** Components match `getKeys()` output directly with `matchesKey`, whose native `parse_key_id` knows only ctrl/shift/super/alt and consumes an unrecognized part as the key token. With `app.agents.hub: ⌥+A`, the plain letter `a` closed the agent hub while Alt+A did nothing. Normalization now folds the modifier and keeps the order.
- **The extension reserved-shortcut guard compared the chord as written.** The editor builds match keys canonically, so `ctrl+shift+p` — reserved as `shift+ctrl+p`, which is not its own canonical form — already shadowed the built-in while passing the check. The lookup and the table are now both canonical, and the lookup lowercases first so an uppercase base letter is not promoted to Shift (`Ctrl+C` was becoming an unreserved `ctrl+shift+c`). A drift test pins every table entry as a `canonicalKeyId` fixed point.
- **Conflict detection keyed claims by the authored spelling,** so `alt+x` and `Option+x` were not reported as colliding.
- **Key-hint rendering resolved chord parts through `Object.prototype`,** so a key named `constructor` or `toString` printed a function's native-code text.

## Verification

- `biome check .` clean (4087 files); `tsgo --noEmit` clean for `pi-tui` and `pi-coding-agent`.
- Affected suites: **2397 pass / 3 skip / 4 fail**. The 4 failures (3 Markdown OSC 8 link tests, 1 WebP/Kitty timeout) reproduce unchanged on `origin/main` with this branch stashed — pre-existing, unrelated.
- Every fix was written test-first with the red run observed before the change.
- Mutation-checked: reverting `lastIndexOf`→`indexOf` in the fold, or dropping `.toLowerCase()` before canonicalization, turns the new guards red.
- Smoke-tested end to end against a real `KeybindingsManager` reading a real `keybindings.yml` off disk: `⌥+A` yields `getKeys() === ["alt+a"]`, `matchesKey("a", …) === false`, `matchesKey(Alt+A, …) === true`, labelled `⌥+A` on darwin and `Alt+A` on linux.
- Glyph width: `tui/src/utils.ts` pins `ambiguousIsNarrow: true`, so `⌥` (U+2325) and `⌘` (U+2318) count as 1 cell and the hint bar stays aligned.

## Deliberately out of scope

The reserved-shortcut table only covers `alt+m` and `ctrl+shift+p`, but `registerExtensionShortcuts()` runs before the app's own `setCustomKeyHandler` calls and the first registration wins — so an extension can still shadow `app.plan.toggle` (`shift+alt+p`), `app.clipboard.copyLine` (`shift+alt+l`) and friends. This predates the change and is not widened by it (the previous `key.toLowerCase()` already fed `buildMatchKeys`, which canonicalized). Closing it means deriving the reserved set from the canonical `defaultKeys` of every action registered as a custom handler — happy to do that here or in a follow-up, whichever you prefer.

`tips.txt` is also left alone: it uses lowercase chord ids (`alt+p`, `ctrl+p`) in the same register as `keybindings.yml`, and templating a static text asset is a change in kind. Worth noting those lines hardcode the default chord and go stale for anyone who rebinds.
