### PR TITLE
fix(coding-agent): render approved-plan execution live off the dispatch chain

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plan approval freezing the TUI for the whole approved-plan run: the `xd://propose` completion started `handlePlanApproval` inside the event controller's serialized dispatch chain, so the operator's review choice and the blocking synthetic execution turn parked every subsequent agent event (streamed deltas, tool cards) behind an in-chain `await` — the agent executed with zero live rendering and the transcript only materialized after the run settled. The approval flow now runs off-chain, so events render in real time while the review is open and while the plan executes.
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1605,11 +1605,28 @@ export class EventController {
 				typeof details.title === "string" &&
 				typeof details.planExists === "boolean"
 			) {
-				await this.ctx.handlePlanApproval({
-					planFilePath: details.planFilePath,
-					title: details.title,
-					planExists: details.planExists,
-				});
+				// Fire-and-forget off the serialized dispatch chain: the approval
+				// flow awaits the operator's review choice AND then blocks on the
+				// synthetic execution `session.prompt` for the whole run. An
+				// in-chain await would park every subsequent agent event behind
+				// that blocking prompt — the TUI freezes with zero streaming
+				// feedback (message deltas, tool cards) while the agent executes,
+				// and the transcript only materializes after the run settles.
+				// The flow aborts the proposing turn at its top, so nothing
+				// meaningful can render in the gap before the review overlay;
+				// rejections are surfaced by the flow's own error handling, with
+				// a logger catch as the last-resort backstop.
+				void this.ctx
+					.handlePlanApproval({
+						planFilePath: details.planFilePath,
+						title: details.title,
+						planExists: details.planExists,
+					})
+					.catch(error => {
+						logger.warn("Plan approval flow failed", {
+							error: error instanceof Error ? error.message : String(error),
+						});
+					});
 			}
 		}
 	}

--- a/packages/coding-agent/test/plan-approval-dispatch-chain.test.ts
+++ b/packages/coding-agent/test/plan-approval-dispatch-chain.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { setKeybindings } from "@oh-my-pi/pi-tui";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Plan approval must not block the event controller's serialized dispatch
+ * chain. `#handleToolExecutionEnd` detects a completed `xd://propose` write and
+ * starts the approval flow; when that flow awaited `handlePlanApproval`
+ * in-chain, the operator's review choice and the blocking synthetic execution
+ * `session.prompt` parked every subsequent agent event behind it — the TUI
+ * froze with zero streaming feedback for the whole approved-plan run.
+ *
+ * These tests drive the propose completion through the real agent pipeline and
+ * assert that events emitted while the review is open render immediately.
+ */
+
+/** Complete `write` result carrying the xd://propose dispatch envelope. */
+function proposeResult(planFilePath: string, title: string): unknown {
+	return {
+		content: [{ type: "text", text: "Plan submitted" }],
+		details: {
+			xdev: {
+				tool: "propose",
+				mode: "execute",
+				inner: { planFilePath, title, planExists: true },
+			},
+		},
+	};
+}
+
+describe("plan approval dispatch chain", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let mode: InteractiveMode;
+	let sharedTempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	beforeAll(async () => {
+		initTheme();
+		resetSettingsForTest();
+		sharedTempDir = TempDir.createSync("@plan-approval-chain-shared-");
+		await Settings.init({ inMemory: true, cwd: sharedTempDir.path() });
+		authStorage = await AuthStorage.create(path.join(sharedTempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterAll(() => {
+		authStorage?.close();
+		sharedTempDir?.removeSync();
+	});
+
+	beforeEach(async () => {
+		// Prevent ProcessTerminal.start() from talking to the real terminal; the
+		// assertions read rendered output via mode.ui.render().
+		vi.spyOn(process.stdout, "write").mockReturnValue(true);
+		vi.spyOn(process.stdin, "resume").mockReturnValue(process.stdin);
+		vi.spyOn(process.stdin, "pause").mockReturnValue(process.stdin);
+		vi.spyOn(process.stdin, "setEncoding").mockReturnValue(process.stdin);
+		if (typeof process.stdin.setRawMode === "function") {
+			vi.spyOn(process.stdin, "setRawMode").mockReturnValue(process.stdin);
+		}
+
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@plan-approval-chain-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+		await mode.init({ suppressWelcomeIntro: true });
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		mode?.stop();
+		await session?.dispose();
+		tempDir?.removeSync();
+		setKeybindings(KeybindingsManager.inMemory());
+		resetSettingsForTest();
+	});
+
+	async function flushMicrotasks(): Promise<void> {
+		for (let i = 0; i < 50; i++) await Promise.resolve();
+	}
+
+	it("renders agent events live while the plan review is open", async () => {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nBody.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		// Hold the review open: the approval flow is parked awaiting the choice.
+		const { promise: reviewChoice, resolve: resolveReview } = Promise.withResolvers<string>();
+		vi.spyOn(mode, "showPlanReview").mockReturnValue(reviewChoice);
+		vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+		// The propose completion rides the normal agent pipeline; the event
+		// controller picks it up and starts the approval flow.
+		session.agent.emitExternalEvent({
+			type: "tool_execution_end",
+			toolCallId: "toolu_propose_live",
+			toolName: "write",
+			args: { path: "xd://propose", content: "plan" },
+			result: proposeResult(planFilePath, "PLAN"),
+			isError: false,
+		} as never);
+		await flushMicrotasks();
+
+		// While the review overlay is still awaiting the operator, an unrelated
+		// agent event must render immediately — the dispatch chain is not parked
+		// behind the approval flow.
+		session.agent.emitExternalEvent({
+			type: "message_start",
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "live during review" }],
+				synthetic: true,
+				timestamp: Date.now(),
+			},
+		} as never);
+		await flushMicrotasks();
+		expect(Bun.stripANSI(mode.ui.render(120).join("\n"))).toContain("live during review");
+
+		// Cancel cleanly: the flow must settle without a session clear so the
+		// test leaves nothing running.
+		resolveReview(undefined);
+		await flushMicrotasks();
+	});
+});


### PR DESCRIPTION
## Problem

When plan mode submits a plan via `xd://propose`, the completed `write` tool's `tool_execution_end` event starts `handlePlanApproval` **inside the event controller's serialized dispatch chain** (`#handleToolExecutionEnd` awaited it). The approval flow then blocks twice:

1. awaiting the operator's choice in the plan-review overlay, and
2. awaiting the synthetic execution `session.prompt` for the **entire approved-plan run**.

While either is in flight, every subsequent agent event (`message_start`/`message_update`, tool cards) is parked behind the in-chain `await` by `#runSerialized` — the TUI freezes with **zero live rendering** while the agent executes, and the transcript only materializes after the run settles. Requests run, the session tree records events, but the screen shows nothing.

## Fix

Run the approval flow off the serialized dispatch chain (fire-and-forget with a logger backstop):

```ts
void this.ctx
    .handlePlanApproval({ ... })
    .catch(error => logger.warn("Plan approval flow failed", { error: ... }));
```

The flow aborts the proposing turn at its very top, so nothing meaningful can render in the gap before the review overlay appears; rejections are surfaced by the flow's own `showError` handling. With the chain free, streamed deltas and tool cards render in real time while the review is open and while the approved plan executes.

## Verification

New regression test `test/plan-approval-dispatch-chain.test.ts` drives the `xd://propose` completion through the real agent pipeline, holds the review open, and asserts that an agent event emitted mid-approval renders **immediately** (before the review choice resolves). It fails on `main` and passes with the fix.

- `bun test test/plan-approval-dispatch-chain.test.ts test/interactive-mode-plan-review.test.ts test/event-controller-{message-update-coalesce,mixed-assistant-render,abort-render}.test.ts` — 71 pass
- `bun run check:types` and `biome check` clean