### PR TITLE
fix(tui): avoid leaking DA1 through tmux appearance refresh

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an explicit appearance refresh (`app.display.reset`) inside tmux leaking DA1 capability bytes into the editor and keeping a stale light/dark theme. The refresh routed both the OSC 11 query and its DA1 sentinel through tmux's passthrough envelope; the outer terminal's DA1 reply then had to round-trip through tmux's input parser, where a fragmented client→tmux response under a low `escape-time` was misdecoded as a key press and the remaining capability bytes surfaced as pane input. The refresh is now two-staged: tmux's OSC 11 cache is refreshed with a passthrough query alone (no DA1), then read back via a direct pane-local probe after a bounded settle delay ([#7800](https://github.com/can1357/oh-my-pi/issues/7800)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -25,6 +25,8 @@ const TERMINAL_PROGRESS_KEEPALIVE_MS = 1000;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
 const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
 const WINDOWS_TERMINAL_OSC11_POLL_MS = 30_000;
+// Settle delay before reading tmux's OSC 11 cache after refreshing it (#7800).
+const TMUX_APPEARANCE_REFRESH_DELAY_MS = 100;
 function shouldEnableModifyOtherKeysFallback(env: NodeJS.ProcessEnv = Bun.env): boolean {
 	if (!env.SSH_CONNECTION && !env.SSH_TTY && !env.SSH_CLIENT) return true;
 	return TERMINAL.id !== "base" && TERMINAL.id !== "trueColor";
@@ -461,7 +463,7 @@ export interface Terminal {
 	/**
 	 * Issue a single OSC 11 background-color re-query, driving the appearance
 	 * callbacks through the same parse/dedup pipeline used at startup and on Mode
-	 * 2031 notifications. Bounded: one probe per call, no timers. Invoked on the
+	 * 2031 notifications. Bounded to one refresh per call. Invoked on the
 	 * user's explicit display-reset gesture so terminals that cannot
 	 * deliver end-to-end Mode 2031 notifications still pick up a light/dark switch
 	 * without a restart.
@@ -612,6 +614,7 @@ export class ProcessTerminal implements Terminal {
 	#reportedRows?: number;
 	#mode2031DebounceTimer?: Timer;
 	#windowsTerminalAppearancePollTimer?: Timer;
+	#tmuxAppearanceRefreshTimer?: Timer;
 	#progressTimer?: Timer;
 
 	get kittyProtocolActive(): boolean {
@@ -671,13 +674,14 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	/**
-	 * Re-query the terminal background via a single OSC 11 probe. Reuses the
-	 * startup DA1-sentinel FIFO, pending/queued gating, parsing, dedup, and
-	 * appearance callbacks. Inside tmux, only this explicit path wraps the query
-	 * and sentinel together for passthrough to the outer terminal; startup and
-	 * Mode 2031 probes remain direct. Bounded to one probe per call; no timers are
-	 * armed. Suppressed while inactive, headless, or after the terminal is torn
-	 * down.
+	 * Re-query the terminal background via an OSC 11 probe. Reuses the startup
+	 * DA1-sentinel FIFO, pending/queued gating, parsing, dedup, and appearance
+	 * callbacks. Inside tmux this explicit path is two-staged (#7800): stage one
+	 * refreshes tmux's own OSC 11 cache by passing the query — but not a DA1
+	 * sentinel — through the passthrough envelope; stage two reads that refreshed
+	 * cache with a direct pane-local probe after a bounded settle delay. Startup
+	 * and Mode 2031 probes remain direct. Suppressed while inactive, headless, or
+	 * after the terminal is torn down.
 	 */
 	refreshAppearance(requestToken?: TerminalAppearanceRequestToken): TerminalAppearanceRequestToken | void {
 		if (!this.#active || this.#headless || this.#dead) return;
@@ -1205,14 +1209,28 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	#startOsc11Query(route: Osc11QueryRoute, token?: TerminalAppearanceRequestToken): void {
+		if (route === "tmux") {
+			// Two-stage tmux refresh (#7800). tmux swallows the outer terminal's
+			// OSC 11 reply to update its own background cache, so stage one sends
+			// only the OSC 11 query through the passthrough envelope. The DA1
+			// sentinel is deliberately NOT wrapped: its reply would have to
+			// round-trip through tmux's input parser, where a fragmented
+			// client->tmux DA1 under a low escape-time is misdecoded as a key
+			// press (e.g. ESC[27;3;91~) and the capability bytes leak into the
+			// editor. Stage two reads tmux's now-refreshed cache with a direct
+			// pane-local probe whose DA1 sentinel tmux answers itself.
+			this.#safeWrite(wrapTmuxPassthrough("\x1b]11;?\x07"));
+			clearTimeout(this.#tmuxAppearanceRefreshTimer);
+			this.#tmuxAppearanceRefreshTimer = setTimeout(() => {
+				this.#tmuxAppearanceRefreshTimer = undefined;
+				this.#queryBackgroundColor("direct", token);
+			}, TMUX_APPEARANCE_REFRESH_DELAY_MS);
+			return;
+		}
 		this.#osc11Pending = true;
 		this.#osc11ActiveToken = token;
 		this.#osc11ResponseBuffer = "";
 		this.#da1SentinelOwners.push({ kind: "osc11" });
-		if (route === "tmux") {
-			this.#safeWrite(wrapTmuxPassthrough("\x1b]11;?\x07\x1b[c"));
-			return;
-		}
 		this.#safeWrite("\x1b]11;?\x07"); // OSC 11 query (BEL terminated)
 		this.#safeWrite("\x1b[c"); // DA1 sentinel
 	}
@@ -1548,6 +1566,10 @@ export class ProcessTerminal implements Terminal {
 		if (this.#mode2031DebounceTimer) {
 			clearTimeout(this.#mode2031DebounceTimer);
 			this.#mode2031DebounceTimer = undefined;
+		}
+		if (this.#tmuxAppearanceRefreshTimer) {
+			clearTimeout(this.#tmuxAppearanceRefreshTimer);
+			this.#tmuxAppearanceRefreshTimer = undefined;
 		}
 		this.#appearanceCallbacks = [];
 		this.#appearanceReportCallbacks = [];

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -360,20 +360,84 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		expect(afterStoppedRefresh).toBe(afterStop);
 	});
 
-	it("passes an explicit appearance refresh through tmux without changing the startup probe", () => {
+	it("refreshes tmux's OSC 11 cache with a passthrough query but never a passthrough DA1 (#7800)", () => {
 		Bun.env.TMUX = "/tmp/tmux-1000/default,1234,0";
 		const { terminal, writes } = setupTerminal();
 
+		// Startup probes stay direct.
 		expect(writes).toContain("\x1b]11;?\x07");
 		expect(writes).toContain("\x1b[c");
 
 		process.stdin.emit("data", "\x1b]11;rgb:ffff/ffff/ffff\x07");
 		for (let i = 0; i < 7; i++) process.stdin.emit("data", "\x1b[?1;2c");
+		const before = writes.length;
 		terminal.refreshAppearance?.();
 
-		expect(writes).toContain("\x1bPtmux;\x1b\x1b]11;?\x07\x1b\x1b[c\x1b\\");
+		// Stage one passes the OSC 11 query — and only the query — through tmux so
+		// tmux refreshes its background cache. Routing the DA1 sentinel through
+		// tmux is what leaked capability bytes into the editor (#7800), so it must
+		// not appear in the passthrough envelope.
+		const stage1 = writes.slice(before);
+		expect(stage1).toContain("\x1bPtmux;\x1b\x1b]11;?\x07\x1b\\");
+		expect(stage1).not.toContain("\x1bPtmux;\x1b\x1b]11;?\x07\x1b\x1b[c\x1b\\");
+		expect(stage1.some(w => w.includes("\x1b[c"))).toBe(false);
 
 		terminal.stop();
+	});
+
+	it("reads tmux's refreshed cache with a direct pane-local DA1 probe after a settle delay (#7800)", () => {
+		vi.useFakeTimers();
+		Bun.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+		const { terminal, writes, received } = setupTerminal();
+
+		// Seed appearance and drain the startup probe cycle.
+		process.stdin.emit("data", "\x1b]11;rgb:0000/0000/0000\x07");
+		for (let i = 0; i < 7; i++) process.stdin.emit("data", "\x1b[?1;2c");
+		expect(terminal.appearance).toBe("dark");
+
+		const reports: Array<{ appearance: string; token: number | undefined }> = [];
+		terminal.onAppearanceReport?.((appearance, token) => reports.push({ appearance, token }));
+
+		const before = writes.length;
+		expect(terminal.refreshAppearance?.(42)).toBe(42);
+
+		// Stage two is armed on a bounded timer, not emitted synchronously, so no
+		// DA1 sentinel is written until the settle delay elapses.
+		expect(writes.slice(before)).not.toContain("\x1b[c");
+		vi.advanceTimersByTime(100);
+
+		// A direct pane-local probe (OSC 11 + DA1) that tmux answers itself.
+		const stage2 = writes.slice(before);
+		expect(stage2).toContain("\x1b]11;?\x07");
+		expect(stage2).toContain("\x1b[c");
+
+		// tmux answers from its refreshed cache: the report is token-correlated,
+		// the appearance re-evaluates, and no bytes leak to the input handler.
+		process.stdin.emit("data", "\x1b]11;rgb:ffff/ffff/ffff\x07");
+		process.stdin.emit("data", "\x1b[?1;2c");
+
+		expect(reports).toContainEqual({ appearance: "light", token: 42 });
+		expect(terminal.appearance).toBe("light");
+		expect(received).toEqual([]);
+
+		terminal.stop();
+	});
+
+	it("cancels the pending tmux appearance refresh timer on teardown (#7800)", () => {
+		vi.useFakeTimers();
+		Bun.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+		const { terminal, writes } = setupTerminal();
+
+		process.stdin.emit("data", "\x1b]11;rgb:0000/0000/0000\x07");
+		for (let i = 0; i < 7; i++) process.stdin.emit("data", "\x1b[?1;2c");
+
+		terminal.refreshAppearance?.(7);
+		terminal.stop();
+
+		// The stage-two probe must not fire after teardown.
+		const afterStop = writes.length;
+		vi.advanceTimersByTime(1000);
+		expect(writes.length).toBe(afterStop);
 	});
 
 	it("refreshAppearance() re-evaluates a changed background through the callback pipeline", () => {


### PR DESCRIPTION
## Repro
Inside tmux (`allow-passthrough on`, a low `escape-time`, `extended-keys-format xterm`), start OMP, change the outer terminal's color scheme so its default background crosses the light/dark boundary, then trigger `app.display.reset` (e.g. `Ctrl+L`). The theme stays stale and terminal capability bytes surface in the editor. On the reporter's client the outer DA1 was `ESC[?64;1;2;6;9;15;18;21;22c`, but the probe saw `ESC[27;3;91~` (tmux's xterm extended-key encoding of `Alt+[`) followed by the leftover `?64;...c` as printable input, and the OSC 11 request timed out with no token-correlated report.

## Cause
`Terminal#startOsc11Query` (`packages/tui/src/terminal.ts`) took a `tmux` route for the explicit refresh that wrapped **both** the OSC 11 query and its DA1 sentinel in a single passthrough envelope: `wrapTmuxPassthrough("\x1b]11;?\x07\x1b[c")`. tmux swallows the outer OSC 11 reply to update its own background cache, but the outer DA1 reply has to round-trip back through tmux's input parser. When that reply is fragmented on the client→tmux path, tmux decodes the leading `ESC [` as an extended key and forwards the remaining capability bytes as pane input, so OMP never sees the DA1 barrier, never starts the cache read, and leaks the mangled response. This was introduced by #6204 (`51de8b8`), which routed the explicit refresh through tmux to fix the stale-cache bug in #6066. Atomic synthetic DA1 delivery does not reproduce it, so it needs a live fragmented tmux client.

## Fix
- `terminal.ts`: two-stage the tmux refresh in `#startOsc11Query`. Stage one passes only the OSC 11 query through the passthrough envelope (no DA1) so tmux refreshes its background cache; stage two reads that refreshed cache with a direct pane-local probe (`\x1b]11;?\x07` + `\x1b[c`) whose DA1 sentinel tmux answers itself, armed on a bounded 100 ms settle timer (`TMUX_APPEARANCE_REFRESH_DELAY_MS`). The request token is propagated to stage two so the report stays correlated.
- Cancel the pending refresh timer in `stop()` teardown; add the `#tmuxAppearanceRefreshTimer` field.
- Update the `refreshAppearance` interface/impl docs to describe the two-stage tmux path.
- Tests (`terminal-appearance.test.ts`): assert stage one emits the OSC 11 passthrough but never a passthrough DA1, stage two fires a direct pane-local OSC 11 + DA1 probe only after the settle delay and produces a token-correlated report with no bytes leaked to the input handler, and the pending timer is cancelled on teardown.

## Verification
- `bun test packages/tui/test/terminal-appearance.test.ts` — 45 pass, 0 fail.
- `bun test packages/coding-agent/test/input-controller-keybindings.test.ts` — 25 pass, 0 fail (after `bun run gen:tool-views`, whose generated module is a gitignored prepack artifact absent in a fresh worktree).
- Pre-publish gate (`bun run fix` + `bun check`) passed on push.

Fixes #7800