### PR TITLE
fix(coding-agent): detect non-English questions in todo reminder guard

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the todo completion reminder still firing while the agent was waiting on a user question asked in a non-English language. The `isAwaitingUserAnswer` guard only recognized English question words and pronouns, so a `？`/`?`-terminated Chinese, Japanese, Korean, or Spanish prompt (e.g. `我应该继续吗？`) went undetected and the `<system-reminder>` interrupted the pause — which the model then misread as the user's answer and acted on. A trailing question mark plus any non-ASCII character in the line now counts as a pending question ([#7803](https://github.com/can1357/oh-my-pi/issues/7803)).
+
 ## [17.2.9] - 2026-08-05
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/todo-tracker.ts
+++ b/packages/coding-agent/src/session/todo-tracker.ts
@@ -27,6 +27,15 @@ const QUESTION_PROMPT_RE =
 const USER_DIRECTED_PROMPT_RE = /\b(?:you|your|we|our)\b/i;
 const USER_RESPONSE_CUE_RE =
 	/^(?:please\s+)?(?:confirm|reply|choose|pick|decide|advise)\b|^(?:please\s+)?answer\b|^(?:please\s+)?(?:let\s+me\s+know|tell\s+me)\b/i;
+/**
+ * A trailing question mark is the universal signal that a line is a question, but
+ * the English word/pronoun gates above exist to filter incidental "?" out of prose
+ * (e.g. a TypeScript `foo?: string` tail). Non-English text has no cheap word list,
+ * yet any non-ASCII character in a "?"/"？"-terminated line reliably marks it as
+ * genuine prose — CJK/Japanese/Korean, Spanish `¿…?`, accented Latin — so treat it
+ * as a real user-directed question. Fixes non-Latin prompts going undetected (#7803).
+ */
+const NON_ASCII_TEXT_RE = /[^\x00-\x7F]/;
 
 interface PromptLine {
 	text: string;
@@ -361,7 +370,8 @@ function isQuestionPromptLine(line: string): boolean {
 	return (
 		candidate.hadPromptLabel ||
 		QUESTION_PROMPT_RE.test(candidate.text) ||
-		USER_DIRECTED_PROMPT_RE.test(candidate.text)
+		USER_DIRECTED_PROMPT_RE.test(candidate.text) ||
+		NON_ASCII_TEXT_RE.test(candidate.text)
 	);
 }
 

--- a/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
@@ -186,6 +186,17 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 		expect(continueSpy).not.toHaveBeenCalled();
 	});
 
+	it("does not remind or continue when the assistant yields with a non-English (Chinese) question", async () => {
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		emitTextOnlyStop("我遇到一个需要你决定的问题：是否应该继续删除旧的配置文件？");
+		await session.waitForIdle();
+
+		expect(reminderAttempts).toEqual([]);
+		expect(todoReminderTranscriptEntry()).toBeUndefined();
+		expect(continueSpy).not.toHaveBeenCalled();
+	});
+
 	it("still reminds when the assistant answers its own prompt-shaped question", async () => {
 		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
 


### PR DESCRIPTION
## Repro
When the agent stops with incomplete todos while asking the user a yes/no question written in a non-English language (e.g. Chinese `我遇到一个需要你决定的问题：是否应该继续删除旧的配置文件？`), the todo completion reminder still fires and auto-continues the turn. The model then misreads the injected `<system-reminder>` as the user's answer and proceeds with a decision the user never confirmed. Reproduced with a new case in `packages/coding-agent`:

`bun test test/agent-session-todo-reminder-loop.test.ts -t "non-English"` → fails on current code: `expect(reminderAttempts).toEqual([])` receives `[1]` (reminder fired + `agent.continue` scheduled).

## Cause
`TodoTracker.checkCompletion` (`src/session/todo-tracker.ts`) skips the reminder when `isAwaitingUserAnswer(message)` is true. That guard's `isQuestionPromptLine` requires the assistant's last line to end with `?`/`？` **and** either start with an English question word (`QUESTION_PROMPT_RE`), contain an English pronoun (`USER_DIRECTED_PROMPT_RE`), or carry a `Q:`-style label. A `？`/`?`-terminated Chinese/Japanese/Korean/Spanish prompt matches none of those, so the guard returns `false` and the reminder interrupts the pause. This is the non-English gap left by the English-only heuristic added in #5097.

## Fix
- Added `NON_ASCII_TEXT_RE` and a fourth branch to `isQuestionPromptLine`: a question-mark-terminated line containing any non-ASCII character now counts as a pending user question. Non-ASCII content reliably marks genuine non-English prose (CJK/JP/KO, Spanish `¿…?`, accented Latin), while pure-ASCII English lines keep the existing word/pronoun gates — so the `foo?: string` false-positive guard is unchanged.
- Added a regression test in `agent-session-todo-reminder-loop.test.ts` asserting a Chinese question yields no `todo_reminder` and no `agent.continue`.
- Changelog entry under `[Unreleased]`.

Did not touch the reminder's wording (a system prompt / maintainer-owned); this fix addresses the root cause of the interruption in code.

## Verification
`bun test test/agent-session-todo-reminder-loop.test.ts` → 8 pass / 0 fail (7 existing + new non-English case). `bun test test/agent-session-todo-reminder-async-jobs.test.ts test/agent-session-todo-mid-run-nudge.test.ts` → 14 pass / 0 fail. Pre-publish `bun check` gate passed.

Fixes #7803