### PR TITLE
fix(stats): restore configurable dashboard bind host

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp stats` and `/stats` dashboards being unreachable from container hosts by accepting an explicit `--host` bind address while preserving the `127.0.0.1` default.
+
 ## [17.3.5] - 2026-08-16
 
 ### Added

--- a/packages/coding-agent/src/cli/stats-cli.ts
+++ b/packages/coding-agent/src/cli/stats-cli.ts
@@ -5,7 +5,7 @@
  */
 
 import { truncateToWidth } from "@oh-my-pi/pi-tui/utils";
-import { APP_NAME, formatDuration, formatNumber, formatPercent } from "@oh-my-pi/pi-utils";
+import { formatDuration, formatNumber, formatPercent } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
 import { openPath } from "../utils/open";
 
@@ -57,43 +57,9 @@ function shortenSessionFile(p: string): string {
 
 export interface StatsCommandArgs {
 	port: number;
+	host: string;
 	json: boolean;
 	summary: boolean;
-}
-
-// =============================================================================
-// Argument Parser
-// =============================================================================
-
-/**
- * Parse stats subcommand arguments.
- * Returns undefined if not a stats command.
- */
-export function parseStatsArgs(args: string[]): StatsCommandArgs | undefined {
-	if (args.length === 0 || args[0] !== "stats") {
-		return undefined;
-	}
-
-	const result: StatsCommandArgs = {
-		port: 3847,
-		json: false,
-		summary: false,
-	};
-
-	for (let i = 1; i < args.length; i++) {
-		const arg = args[i];
-		if (arg === "--json" || arg === "-j") {
-			result.json = true;
-		} else if (arg === "--summary" || arg === "-s") {
-			result.summary = true;
-		} else if ((arg === "--port" || arg === "-p") && i + 1 < args.length) {
-			result.port = parseInt(args[++i], 10);
-		} else if (arg.startsWith("--port=")) {
-			result.port = parseInt(arg.split("=")[1], 10);
-		}
-	}
-
-	return result;
 }
 
 function formatCost(n: number): string {
@@ -112,9 +78,8 @@ function normalizePremiumRequests(n: number): number {
 
 export async function runStatsCommand(cmd: StatsCommandArgs): Promise<void> {
 	// Lazy import to avoid loading stats module when not needed
-	const { getDashboardStats, syncAllSessions, getTotalMessageCount, startServer, closeDb } = await import(
-		"@oh-my-pi/omp-stats"
-	);
+	const { closeDb, formatStatsDashboardUrl, getDashboardStats, getTotalMessageCount, startServer, syncAllSessions } =
+		await import("@oh-my-pi/omp-stats");
 
 	// Sync session files first
 	const progress = createSyncProgressReporter();
@@ -136,8 +101,8 @@ export async function runStatsCommand(cmd: StatsCommandArgs): Promise<void> {
 	}
 
 	// Start the dashboard server
-	const { hostname, port } = await startServer(cmd.port);
-	const url = `http://${hostname}:${port}`;
+	const { hostname, port } = await startServer(cmd.port, cmd.host);
+	const url = formatStatsDashboardUrl(hostname, port);
 	console.log(chalk.green(`Dashboard available at: ${url}`));
 
 	// Open browser
@@ -196,35 +161,4 @@ async function printStatsSummary(): Promise<void> {
 	}
 
 	console.log("");
-}
-
-// =============================================================================
-// Help
-// =============================================================================
-
-export function printStatsHelp(): void {
-	console.log(`${chalk.bold(`${APP_NAME} stats`)} - AI Usage Statistics Dashboard
-
-${chalk.bold("Usage:")}
-  ${APP_NAME} stats [options]
-
-${chalk.bold("Options:")}
-  -p, --port <port>  Port for the dashboard server (default: 3847)
-  -j, --json         Output stats as JSON and exit
-  -s, --summary      Print summary to console and exit
-  -h, --help         Show this help message
-
-${chalk.bold("Examples:")}
-  ${APP_NAME} stats              # Start dashboard server
-  ${APP_NAME} stats --json       # Print stats as JSON
-  ${APP_NAME} stats --summary    # Print summary to console
-  ${APP_NAME} stats --port 8080  # Start on custom port
-
-${chalk.bold("Metrics:")}
-  - Total requests and error rate
-  - Token usage (input, output, cache)
-  - Cost breakdown
-  - Average duration and time to first token (TTFT)
-  - Tokens per second throughput
-`);
 }

--- a/packages/coding-agent/src/commands/stats.ts
+++ b/packages/coding-agent/src/commands/stats.ts
@@ -4,13 +4,15 @@
 
 import { Command, Flags } from "@oh-my-pi/pi-utils/cli";
 import { statsHelp as commandHelp } from "../cli/command-help";
-import { runStatsCommand, type StatsCommandArgs } from "../cli/stats-cli";
-import { initTheme } from "../modes/theme/theme";
+import type { StatsCommandArgs } from "../cli/stats-cli";
+import * as statsCli from "../cli/stats-cli";
+import * as theme from "../modes/theme/theme";
 
 export default class Stats extends Command {
 	static description = commandHelp.description;
 	static flags = {
 		port: Flags.integer({ char: "p", description: "Port for the dashboard server", default: 3847 }),
+		host: Flags.string({ description: "Host to bind", default: "127.0.0.1" }),
 		json: Flags.boolean({ char: "j", description: "Output stats as JSON", default: false }),
 		summary: Flags.boolean({ char: "s", description: "Print summary to console", default: false }),
 	};
@@ -20,11 +22,12 @@ export default class Stats extends Command {
 
 		const cmd: StatsCommandArgs = {
 			port: flags.port,
+			host: flags.host ?? "127.0.0.1",
 			json: flags.json,
 			summary: flags.summary,
 		};
 
-		await initTheme();
-		await runStatsCommand(cmd);
+		await theme.initTheme();
+		await statsCli.runStatsCommand(cmd);
 	}
 }

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -336,7 +336,7 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "stats",
 		description: "Launch the local stats dashboard",
-		inlineHint: "[--port <port>]",
+		inlineHint: "[--port <port>] [--host <host>]",
 		allowArgs: true,
 		handle: async (command, runtime) => {
 			const parsed = parseStatsDashboardArgs(command.args);

--- a/packages/coding-agent/src/slash-commands/helpers/stats-dashboard.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/stats-dashboard.ts
@@ -11,6 +11,7 @@ interface StatsDashboardServer {
 
 export interface StatsDashboardArgs {
 	port: number;
+	host: string;
 }
 
 export interface StatsDashboardLaunchResult {
@@ -20,7 +21,7 @@ export interface StatsDashboardLaunchResult {
 
 let activeStatsServer: StatsDashboardServer | undefined;
 
-const STATS_DASHBOARD_USAGE = "Usage: /stats [--port <port>]";
+const STATS_DASHBOARD_USAGE = "Usage: /stats [--port <port>] [--host <host>]";
 
 function parsePort(value: string | undefined): number | string {
 	if (!value) return `Missing port. ${STATS_DASHBOARD_USAGE}`;
@@ -33,6 +34,7 @@ function parsePort(value: string | undefined): number | string {
 export function parseStatsDashboardArgs(args: string): StatsDashboardArgs | { error: string } {
 	const tokens = args.split(/\s+/).filter(Boolean);
 	let port = DEFAULT_STATS_DASHBOARD_PORT;
+	let host = "127.0.0.1";
 
 	for (let i = 0; i < tokens.length; i++) {
 		const token = tokens[i];
@@ -48,28 +50,40 @@ export function parseStatsDashboardArgs(args: string): StatsDashboardArgs | { er
 			port = parsed;
 			continue;
 		}
+		if (token === "--host") {
+			const value = tokens[++i];
+			if (!value) return { error: `Missing host. ${STATS_DASHBOARD_USAGE}` };
+			host = value;
+			continue;
+		}
+		if (token.startsWith("--host=")) {
+			const value = token.slice("--host=".length);
+			if (!value) return { error: `Missing host. ${STATS_DASHBOARD_USAGE}` };
+			host = value;
+			continue;
+		}
 		return { error: `Unknown option: ${token}. ${STATS_DASHBOARD_USAGE}` };
 	}
 
-	return { port };
+	return { port, host };
 }
 
 export async function launchStatsDashboard(args: StatsDashboardArgs): Promise<StatsDashboardLaunchResult> {
 	const { processed, files } = await stats.syncAllSessions();
 	const total = await stats.getTotalMessageCount();
-	let requestedPortIgnored = false;
+	let requestedAddressIgnored = false;
 
 	if (!activeStatsServer) {
-		activeStatsServer = await stats.startServer(args.port);
-	} else if (args.port !== activeStatsServer.port) {
-		requestedPortIgnored = true;
+		activeStatsServer = await stats.startServer(args.port, args.host);
+	} else if (args.port !== activeStatsServer.port || args.host !== activeStatsServer.hostname) {
+		requestedAddressIgnored = true;
 	}
 
-	const url = `http://${activeStatsServer.hostname}:${activeStatsServer.port}`;
+	const url = stats.formatStatsDashboardUrl(activeStatsServer.hostname, activeStatsServer.port);
 	openUtils.openPath(url);
 
-	const serverLine = requestedPortIgnored
-		? `Dashboard already running at: ${url} (requested port ${args.port} ignored)`
+	const serverLine = requestedAddressIgnored
+		? `Dashboard already running at: ${url} (requested ${args.host}:${args.port} ignored)`
 		: `Dashboard available at: ${url}`;
 
 	return {

--- a/packages/coding-agent/test/stats-cli.test.ts
+++ b/packages/coding-agent/test/stats-cli.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as statsCli from "../src/cli/stats-cli";
+import Stats from "../src/commands/stats";
+import * as theme from "../src/modes/theme/theme";
+import { parseStatsDashboardArgs } from "../src/slash-commands/helpers/stats-dashboard";
+
+const TEST_CONFIG = { bin: "omp", version: "0.0.0-test", commands: new Map() };
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("stats dashboard host arguments", () => {
+	it("forwards the real omp stats flags to the dashboard runner", async () => {
+		vi.spyOn(theme, "initTheme").mockResolvedValue();
+		const runStatsCommand = vi.spyOn(statsCli, "runStatsCommand").mockResolvedValue();
+		const command = new Stats(["--host", "::", "--port", "3850"], TEST_CONFIG);
+
+		await command.run();
+
+		expect(runStatsCommand).toHaveBeenCalledWith({
+			port: 3850,
+			host: "::",
+			json: false,
+			summary: false,
+		});
+	});
+
+	it("keeps the slash command loopback-only unless a host is requested", () => {
+		expect(parseStatsDashboardArgs("")).toEqual({ port: 3847, host: "127.0.0.1" });
+		expect(parseStatsDashboardArgs("--host 0.0.0.0")).toEqual({ port: 3847, host: "0.0.0.0" });
+	});
+});

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the stats dashboard being unreachable from container hosts by accepting an explicit `--host` bind address while preserving loopback-only binding and same-origin API access by default.
+
 ## [17.3.0] - 2026-08-13
 
 ### Added

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -4,7 +4,7 @@ import { parseArgs } from "node:util";
 import { formatDuration, formatNumber, formatPercent } from "@oh-my-pi/pi-utils";
 import { getDashboardStats, getTotalMessageCount, syncAllSessions } from "./aggregator";
 import { closeDb } from "./db";
-import { startServer } from "./server";
+import { formatStatsDashboardUrl, startServer } from "./server";
 
 export {
 	getDashboardStats,
@@ -17,7 +17,7 @@ export {
 } from "./aggregator";
 export { closeDb } from "./db";
 export { getGainDashboardStats } from "./gain-aggregator";
-export { startServer } from "./server";
+export { formatStatsDashboardUrl, startServer } from "./server";
 export type {
 	GainDashboardStats,
 	GainSource,
@@ -96,19 +96,42 @@ async function printStats(): Promise<void> {
 	console.log("");
 }
 
-/**
- * Main CLI entry point.
- */
-async function main(): Promise<void> {
+/** Parsed arguments for the standalone `omp-stats` entry point. */
+export interface StandaloneStatsArgs {
+	port: number;
+	host: string;
+	json: boolean;
+	sync: boolean;
+	help: boolean;
+}
+
+/** Parse the standalone `omp-stats` arguments used by the production entry point. */
+export function parseStandaloneStatsArgs(args: string[]): StandaloneStatsArgs {
 	const { values } = parseArgs({
+		args,
 		options: {
 			port: { type: "string", short: "p", default: "3847" },
+			host: { type: "string", default: "127.0.0.1" },
 			json: { type: "boolean", short: "j", default: false },
 			sync: { type: "boolean", short: "s", default: false },
 			help: { type: "boolean", short: "h", default: false },
 		},
 		allowPositionals: true,
 	});
+	return {
+		port: parseInt(values.port || "3847", 10),
+		host: values.host || "127.0.0.1",
+		json: values.json ?? false,
+		sync: values.sync ?? false,
+		help: values.help ?? false,
+	};
+}
+
+/**
+ * Main CLI entry point.
+ */
+async function main(): Promise<void> {
+	const values = parseStandaloneStatsArgs(process.argv.slice(2));
 
 	if (values.help) {
 		console.log(`
@@ -119,6 +142,7 @@ Usage:
 
 Options:
   -p, --port <port>  Port for the dashboard server (default: 3847)
+  --host <host>       Host to bind (default: 127.0.0.1)
   -j, --json         Output stats as JSON and exit
   -s, --sync         Sync session files and show summary
   -h, --help         Show this help message
@@ -126,7 +150,7 @@ Options:
 Examples:
   omp-stats              # Start dashboard server
   omp-stats --json       # Print stats as JSON
-  omp-stats --port 8080  # Start on custom port
+  omp-stats --host 0.0.0.0 # Explicitly expose on all IPv4 interfaces
   omp-stats --sync       # Sync and show summary
 `);
 		return;
@@ -171,9 +195,8 @@ Examples:
 		}
 
 		// Start server
-		const port = parseInt(values.port || "3847", 10);
-		const { hostname, port: actualPort } = await startServer(port);
-		console.log(`Dashboard available at: http://${hostname}:${actualPort}`);
+		const { port: actualPort } = await startServer(values.port, values.host);
+		console.log(`Dashboard available at: ${formatStatsDashboardUrl(values.host, actualPort)}`);
 		console.log("Press Ctrl+C to stop\n");
 
 		// Keep process running

--- a/packages/stats/src/port-conflict.ts
+++ b/packages/stats/src/port-conflict.ts
@@ -17,23 +17,28 @@ interface PortHolder {
 
 /** Header stamped on every dashboard response so reuse probes can identify us. */
 export const STATS_DASHBOARD_HEADER = "x-omp-stats-dashboard";
+/** Header recording the server's requested bind host so reuse cannot change its exposure scope. */
+export const STATS_DASHBOARD_HOSTNAME_HEADER = "x-omp-stats-hostname";
 
-/** Identity-header value for dashboards enforcing loopback-only, same-origin access. */
-export const STATS_DASHBOARD_SECURITY_VERSION = "2";
+/** Identity-header value for dashboards enforcing an explicit bind host and same-origin access. */
+export const STATS_DASHBOARD_SECURITY_VERSION = "3";
 
 /** IPv4 loopback address shared by the dashboard server and reuse probe. */
 export const STATS_DASHBOARD_HOSTNAME = "127.0.0.1";
 
 type StatsDashboardProbe = "reusable" | "occupied" | "unreachable";
 
-async function probeStatsDashboard(port: number): Promise<StatsDashboardProbe> {
+async function probeStatsDashboard(port: number, hostname: string): Promise<StatsDashboardProbe> {
+	const probeHostname = hostname === "0.0.0.0" ? STATS_DASHBOARD_HOSTNAME : hostname === "::" ? "::1" : hostname;
+	const urlHostname = probeHostname.includes(":") ? `[${probeHostname}]` : probeHostname;
 	try {
-		const response = await fetch(`http://${STATS_DASHBOARD_HOSTNAME}:${port}/api/stats/models`, {
+		const response = await fetch(`http://${urlHostname}:${port}/api/stats/models`, {
 			signal: AbortSignal.timeout(STATS_PROBE_TIMEOUT_MS),
 		});
 		const reusable =
 			response.status === 200 &&
 			response.headers.get(STATS_DASHBOARD_HEADER) === STATS_DASHBOARD_SECURITY_VERSION &&
+			response.headers.get(STATS_DASHBOARD_HOSTNAME_HEADER) === hostname &&
 			!response.headers.has("Access-Control-Allow-Origin");
 		await response.body?.cancel();
 		return reusable ? "reusable" : "occupied";
@@ -248,16 +253,16 @@ async function reclaimStatsPort(port: number): Promise<"retry"> {
  * The preflight is needed on platforms that permit wildcard and loopback-specific
  * listeners to coexist on one port.
  */
-export async function prepareStatsPort(port: number): Promise<"retry" | "reuse"> {
+export async function prepareStatsPort(port: number, hostname = STATS_DASHBOARD_HOSTNAME): Promise<"retry" | "reuse"> {
 	if (port === 0) return "retry";
-	const probe = await probeStatsDashboard(port);
+	const probe = await probeStatsDashboard(port, hostname);
 	if (probe === "reusable") return "reuse";
 	if (probe === "occupied") return reclaimStatsPort(port);
 	return "retry";
 }
 
 /** Reuse or reclaim a listener found after the server bind reports EADDRINUSE. */
-export async function recoverStatsPort(port: number): Promise<"retry" | "reuse"> {
-	if ((await probeStatsDashboard(port)) === "reusable") return "reuse";
+export async function recoverStatsPort(port: number, hostname = STATS_DASHBOARD_HOSTNAME): Promise<"retry" | "reuse"> {
+	if ((await probeStatsDashboard(port, hostname)) === "reusable") return "reuse";
 	return reclaimStatsPort(port);
 }

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -26,6 +26,7 @@ import {
 	recoverStatsPort,
 	STATS_DASHBOARD_HEADER,
 	STATS_DASHBOARD_HOSTNAME,
+	STATS_DASHBOARD_HOSTNAME_HEADER,
 	STATS_DASHBOARD_SECURITY_VERSION,
 } from "./port-conflict";
 
@@ -306,10 +307,16 @@ async function handleStatic(requestPath: string): Promise<Response> {
 	return new Response("Not Found", { status: 404 });
 }
 
-function createDashboardServer(port: number) {
+/** Format a dashboard origin, including brackets required by IPv6 literals. */
+export function formatStatsDashboardUrl(hostname: string, port: number): string {
+	const urlHostname = hostname.includes(":") && !hostname.startsWith("[") ? `[${hostname}]` : hostname;
+	return `http://${urlHostname}:${port}`;
+}
+
+function createDashboardServer(port: number, hostname: string) {
 	const server = Bun.serve({
 		port,
-		hostname: STATS_DASHBOARD_HOSTNAME,
+		hostname,
 		async fetch(req) {
 			const url = new URL(req.url);
 			const path = url.pathname;
@@ -318,6 +325,7 @@ function createDashboardServer(port: number) {
 			// recognize this dashboard without allowing cross-origin API reads.
 			const dashboardHeaders: Record<string, string> = {
 				[STATS_DASHBOARD_HEADER]: STATS_DASHBOARD_SECURITY_VERSION,
+				[STATS_DASHBOARD_HOSTNAME_HEADER]: hostname,
 			};
 
 			if (req.method === "OPTIONS") {
@@ -358,37 +366,40 @@ function createDashboardServer(port: number) {
 /**
  * Start the HTTP server, reusing a live dashboard or reclaiming a stale omp listener.
  */
-export async function startServer(port = 3847): Promise<{ hostname: string; port: number; stop: () => void }> {
+export async function startServer(
+	port = 3847,
+	hostname = STATS_DASHBOARD_HOSTNAME,
+): Promise<{ hostname: string; port: number; stop: () => void }> {
 	await ensureClientBuild();
-	const preparation = await prepareStatsPort(port);
+	const preparation = await prepareStatsPort(port, hostname);
 	if (preparation === "reuse") {
-		return { hostname: STATS_DASHBOARD_HOSTNAME, port, stop: () => {} };
+		return { hostname, port, stop: () => {} };
 	}
 
 	try {
-		const server = createDashboardServer(port);
+		const server = createDashboardServer(port, hostname);
 		return {
-			hostname: STATS_DASHBOARD_HOSTNAME,
+			hostname,
 			port: server.port ?? port,
 			stop: () => server.stop(),
 		};
 	} catch (error) {
 		if (!(error instanceof Error && "code" in error && error.code === "EADDRINUSE")) throw error;
 
-		const recovery = await recoverStatsPort(port);
+		const recovery = await recoverStatsPort(port, hostname);
 		if (recovery === "reuse") {
-			return { hostname: STATS_DASHBOARD_HOSTNAME, port, stop: () => {} };
+			return { hostname, port, stop: () => {} };
 		}
 
 		try {
-			const server = createDashboardServer(port);
+			const server = createDashboardServer(port, hostname);
 			return {
-				hostname: STATS_DASHBOARD_HOSTNAME,
+				hostname,
 				port: server.port ?? port,
 				stop: () => server.stop(),
 			};
 		} catch (retryError) {
-			throw new Error(`Failed to start stats dashboard on port ${port} after reclaiming it.`, {
+			throw new Error(`Failed to start stats dashboard on ${hostname}:${port} after reclaiming it.`, {
 				cause: retryError,
 			});
 		}

--- a/packages/stats/test/server-port-conflict.test.ts
+++ b/packages/stats/test/server-port-conflict.test.ts
@@ -4,6 +4,7 @@ import { connect, type Subprocess } from "bun";
 import {
 	STATS_DASHBOARD_HEADER,
 	STATS_DASHBOARD_HOSTNAME,
+	STATS_DASHBOARD_HOSTNAME_HEADER,
 	STATS_DASHBOARD_SECURITY_VERSION,
 } from "../src/port-conflict";
 import { startServer } from "../src/server";
@@ -24,6 +25,15 @@ async function tcpConnects(hostname: string, port: number): Promise<boolean> {
 	} catch {
 		return false;
 	}
+}
+function getNonLoopbackHostname(): string | undefined {
+	const interfaces = networkInterfaces();
+	for (const name in interfaces) {
+		for (const address of interfaces[name] ?? []) {
+			if (address.family === "IPv4" && !address.internal) return address.address;
+		}
+	}
+	return undefined;
 }
 
 const holderProcesses: Array<Subprocess<"ignore", "pipe", "pipe">> = [];
@@ -77,26 +87,34 @@ describe("startServer access", () => {
 			const response = await fetch(`http://${server.hostname}:${server.port}/api/stats/models`);
 			expect(response.status).toBe(200);
 			expect(response.headers.get(STATS_DASHBOARD_HEADER)).toBe(STATS_DASHBOARD_SECURITY_VERSION);
+			expect(response.headers.get(STATS_DASHBOARD_HOSTNAME_HEADER)).toBe(STATS_DASHBOARD_HOSTNAME);
 			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
 			await response.body?.cancel();
 
-			let nonLoopbackHostname: string | undefined;
-			const interfaces = networkInterfaces();
-			for (const name in interfaces) {
-				const addresses = interfaces[name] ?? [];
-				for (const address of addresses) {
-					if (address.family === "IPv4" && !address.internal) {
-						nonLoopbackHostname = address.address;
-						break;
-					}
-				}
-				if (nonLoopbackHostname) break;
-			}
-			expect(nonLoopbackHostname).toBeDefined();
+			const nonLoopbackHostname = getNonLoopbackHostname();
 			expect(await tcpConnects(server.hostname, server.port)).toBe(true);
-			if (nonLoopbackHostname) {
-				expect(await tcpConnects(nonLoopbackHostname, server.port)).toBe(false);
-			}
+			if (nonLoopbackHostname) expect(await tcpConnects(nonLoopbackHostname, server.port)).toBe(false);
+		} finally {
+			server.stop();
+		}
+	});
+
+	it("serves non-loopback requests only when explicitly requested", async () => {
+		const nonLoopbackHostname = getNonLoopbackHostname();
+		if (!nonLoopbackHostname) return;
+
+		const server = await startServer(0, "0.0.0.0");
+
+		try {
+			expect(server.hostname).toBe("0.0.0.0");
+			expect(await tcpConnects(nonLoopbackHostname, server.port)).toBe(true);
+
+			const response = await fetch(`http://${STATS_DASHBOARD_HOSTNAME}:${server.port}/api/stats/models`);
+			expect(response.status).toBe(200);
+			expect(response.headers.get(STATS_DASHBOARD_HEADER)).toBe(STATS_DASHBOARD_SECURITY_VERSION);
+			expect(response.headers.get(STATS_DASHBOARD_HOSTNAME_HEADER)).toBe("0.0.0.0");
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+			await response.body?.cancel();
 		} finally {
 			server.stop();
 		}
@@ -110,7 +128,12 @@ describe("startServer port conflicts", () => {
 			hostname: STATS_DASHBOARD_HOSTNAME,
 			fetch: request =>
 				new URL(request.url).pathname === "/api/stats/models"
-					? Response.json([], { headers: { [STATS_DASHBOARD_HEADER]: STATS_DASHBOARD_SECURITY_VERSION } })
+					? Response.json([], {
+							headers: {
+								[STATS_DASHBOARD_HEADER]: STATS_DASHBOARD_SECURITY_VERSION,
+								[STATS_DASHBOARD_HOSTNAME_HEADER]: STATS_DASHBOARD_HOSTNAME,
+							},
+						})
 					: new Response("dashboard"),
 		});
 

--- a/packages/stats/test/stats-cli.test.ts
+++ b/packages/stats/test/stats-cli.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { parseStandaloneStatsArgs } from "../src/index";
+import { formatStatsDashboardUrl } from "../src/server";
+
+describe("standalone stats CLI", () => {
+	it("keeps the production parser loopback-only by default", () => {
+		expect(parseStandaloneStatsArgs([])).toEqual({
+			port: 3847,
+			host: "127.0.0.1",
+			json: false,
+			sync: false,
+			help: false,
+		});
+	});
+
+	it("forwards explicit bind hosts and formats IPv6 dashboard URLs", () => {
+		expect(parseStandaloneStatsArgs(["--host", "::", "--port", "3850"])).toMatchObject({
+			port: 3850,
+			host: "::",
+		});
+		expect(formatStatsDashboardUrl("::", 3850)).toBe("http://[::]:3850");
+		expect(formatStatsDashboardUrl("2001:db8::1", 3850)).toBe("http://[2001:db8::1]:3850");
+	});
+});


### PR DESCRIPTION
## What

Restore access to the stats dashboard from container hosts by adding an optional `--host <address>` bind parameter to:

- `omp stats`
- standalone `omp-stats`
- `/stats`

The default remains `127.0.0.1`, preserving the loopback-only security hardening from #7634. Users who need Docker port forwarding or another explicit interface can opt in with `--host 0.0.0.0` or a specific address.

## Why

Binding unconditionally to loopback fixed unsafe default exposure, but also made the dashboard unreachable through container port forwarding. This restores that workflow without weakening the default.

## Details

- Keep dashboard reuse host-aware so an existing loopback listener is never reported as externally reachable.
- Format advertised IPv4 and IPv6 dashboard URLs correctly.
- Preserve same-origin API behavior and record the bind hostname in the dashboard identity response.
- Validate the real CLI and slash-command parsing paths, including missing host values and isolated CI environments without a non-loopback interface.

## Verification

- `bun test packages/stats/test/server-port-conflict.test.ts packages/stats/test/stats-cli.test.ts`
- `bun test packages/coding-agent/test/stats-cli.test.ts`
- `bun run check` in `packages/stats`
- `bun run check` in `packages/coding-agent`