### PR TITLE
fix(coding-agent): prefer proxy-reported model name over bundled catalog name

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed proxy discovery preferring the bundled catalog name over the proxy-reported name, so `omp models refresh` now updates stale display names (e.g. a proxy serving `longcat-2.0` as `"LongCat"` no longer shows the raw id).
+
 
 ## [17.2.10] - 2026-08-06
 

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -974,8 +974,8 @@ export async function discoverProxyModels(
 		const reference = resolveModelReference(id, getBundledModelReferenceIndex());
 		const discoveryName = typeof item.name === "string" ? item.name.trim() : "";
 		const displayName =
-			reference?.name ??
 			(discoveryName && discoveryName !== id ? discoveryName : undefined) ??
+			reference?.name ??
 			stripBracketedModelIdAffixes(id) ??
 			id;
 		discovered.push(

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -2285,6 +2285,73 @@ providers:
 		expect(zeroCtx?.contextWindow).toBe(128000);
 	});
 
+	test("proxy discovery uses proxy-reported name over bundled placeholder", async () => {
+		writeRawModelsJson({
+			"proxy-test": {
+				baseUrl: "http://127.0.0.1:9998",
+				auth: "none",
+				discovery: { type: "proxy" },
+			},
+		});
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:9998/v1/models") {
+				return new Response(
+					JSON.stringify({
+						data: [
+							{
+								id: "act_two",
+								name: "Act Two",
+								supported_endpoint_types: ["openai"],
+								context_length: 65536,
+							},
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+		const model = registry.find("proxy-test", "act_two");
+		expect(model).toBeDefined();
+		expect(model?.name).toBe("Act Two");
+	});
+
+	test("proxy discovery falls back to bundled name when proxy reports none", async () => {
+		writeRawModelsJson({
+			"proxy-test": {
+				baseUrl: "http://127.0.0.1:9998",
+				auth: "none",
+				discovery: { type: "proxy" },
+			},
+		});
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:9998/v1/models") {
+				return new Response(
+					JSON.stringify({
+						data: [
+							{
+								id: "gpt-5",
+								supported_endpoint_types: ["openai"],
+								context_length: 128000,
+							},
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+		const model = registry.find("proxy-test", "gpt-5");
+		expect(model).toBeDefined();
+		expect(model?.name).toBe("GPT-5");
+	});
+
 	test("litellm discovery maps rich model metadata and keeps runtime /v1 baseUrl", async () => {
 		writeRawModelsJson({
 			"litellm-test": {


### PR DESCRIPTION
## Problem

When a proxy (new-api / one-api style) reports a display name for a model, `omp models refresh` does not update the displayed name if the bundled catalog has a placeholder name equal to the model id. For example, a proxy serving `longcat-2.0` with name `"LongCat"` continues to show `longcat-2.0` after refresh because the bundled catalog reference (`packages/catalog/src/models.json`) has `"name": "longcat-2.0"` — and that placeholder always won the nullish chain in `discoverProxyModels`.

## Fix

Swap the priority in `discoverProxyModels` so the proxy-reported name is preferred, with the bundled catalog name as fallback:

```diff
 const displayName =
-    reference?.name ??
     (discoveryName && discoveryName !== id ? discoveryName : undefined) ??
+    reference?.name ??
     stripBracketedModelIdAffixes(id) ??
     id;
```

The proxy is the source of truth for what models it actually serves. The bundled catalog is a static reference that often contains placeholder names equal to the id.

## Tests

- `proxy discovery uses proxy-reported name over bundled placeholder` — proxy reports `"Act Two"` for `act_two`; assert it wins over the bundled `"act_two"` placeholder.
- `proxy discovery falls back to bundled name when proxy reports none` — proxy reports no name; assert the bundled fallback still works.

## Verification

```
bun test ./packages/coding-agent/test/model-discovery.test.ts
# 67 pass, 0 fail
```

Related: bundled catalog entry for `longcat-2.0` in `packages/catalog/src/models.json` still has `"name": "longcat-2.0"` — a catalog-data fix there would be complementary but the code change is defensive against all such placeholders.