### PR TITLE
fix(tui): make Ctrl+O expand tool output regardless of focus

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ctrl+O (`app.tools.expand`) not expanding truncated tool output while a tool-approval prompt or other selection dialog held keyboard focus, by promoting the shortcut to a global input listener that fires regardless of focus (it still defers to fullscreen overlays and the tree selector's own Ctrl+O filter cycle) ([#7837](https://github.com/can1357/oh-my-pi/issues/7837)).
+
 ## [17.2.10] - 2026-08-06
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -30,7 +30,6 @@ type ConfigurableEditorAction = Extract<
 	| "app.model.cycleBackward"
 	| "app.model.select"
 	| "app.model.selectTemporary"
-	| "app.tools.expand"
 	| "app.tools.toggleVisibility"
 	| "app.thinking.toggle"
 	| "app.editor.external"
@@ -53,7 +52,6 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.model.cycleBackward": ["shift+ctrl+p"],
 	"app.model.select": ["alt+m"],
 	"app.model.selectTemporary": ["alt+p"],
-	"app.tools.expand": ["ctrl+o"],
 	"app.tools.toggleVisibility": ["ctrl+shift+o"],
 	"app.thinking.toggle": ["ctrl+t"],
 	"app.editor.external": ["ctrl+g"],
@@ -551,7 +549,6 @@ export class CustomEditor extends Editor {
 	onCycleModelForward?: () => void;
 	onCycleModelBackward?: () => void;
 	onSelectModel?: () => void;
-	onExpandTools?: () => void;
 	onToggleToolActivity?: () => void;
 	onToggleThinking?: () => void;
 	onExternalEditor?: () => void;
@@ -904,12 +901,6 @@ export class CustomEditor extends Editor {
 			// Intercept configured history search shortcut
 			if (this.#matchesAction(canonical, "app.history.search") && this.onHistorySearch) {
 				this.onHistorySearch();
-				return;
-			}
-
-			// Intercept configured tool output expansion shortcut
-			if (this.#matchesAction(canonical, "app.tools.expand") && this.onExpandTools) {
-				this.onExpandTools();
 				return;
 			}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -13,6 +13,7 @@ import { renderSegmentTrack } from "../../modes/components/segment-track";
 import { StrippedToolCallsPlaceholder } from "../../modes/components/stripped-tool-calls-placeholder";
 import { TinyTitleDownloadProgressComponent } from "../../modes/components/tiny-title-download-progress";
 import { ToolExecutionComponent } from "../../modes/components/tool-execution";
+import { TreeSelectorComponent } from "../../modes/components/tree-selector";
 import { expandEmoticons } from "../../modes/emoji-autocomplete";
 import { materializeImageReferenceLinks, shiftImageMarkers } from "../../modes/image-references";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
@@ -177,6 +178,7 @@ export class InputController {
 	#focusedPasteListenerInstalled = false;
 	#btwBranchListenerInstalled = false;
 	#btwCopyListenerInstalled = false;
+	#expandToolsListenerInstalled = false;
 	// Tap counter for the double-← gesture; reset whenever a quiet gap
 	// (>= LEFT_DOUBLE_TAP_MAX_GAP_MS) starts a fresh sequence. See
 	// #detectLeftDoubleTap.
@@ -275,6 +277,23 @@ export class InputController {
 				if (!focused || focused === this.ctx.editor || !hasPasteText(focused)) return undefined;
 				if (!this.ctx.keybindings.matches(data, "app.clipboard.pasteImage")) return undefined;
 				void this.handleImagePaste();
+				return { consume: true };
+			});
+		}
+		if (!this.#expandToolsListenerInstalled) {
+			this.#expandToolsListenerInstalled = true;
+			// `app.tools.expand` (Ctrl+O) toggles the transcript's tool-output
+			// preview. It must fire regardless of focus so a truncated edit stays
+			// expandable while an approval prompt / select dialog holds keyboard
+			// focus (#7837). Defers when the main transcript is not the active
+			// surface (a fullscreen/anchored overlay — agent hub, transcript
+			// viewer, log viewer, model picker) or when the focused component
+			// rebinds Ctrl+O for its own use (the tree selector's filter cycle).
+			this.ctx.ui.addInputListener(data => {
+				if (!this.ctx.keybindings.matches(data, "app.tools.expand")) return undefined;
+				if (this.ctx.ui.hasOverlay()) return undefined;
+				if (this.ctx.ui.getFocused() instanceof TreeSelectorComponent) return undefined;
+				this.toggleToolOutputExpansion();
 				return { consume: true };
 			});
 		}
@@ -456,8 +475,6 @@ export class InputController {
 			this.ctx.keybindings.getKeys("app.clipboard.copyPrompt"),
 		);
 		this.ctx.editor.onCopyPrompt = () => this.handleCopyPrompt();
-		this.ctx.editor.setActionKeys("app.tools.expand", this.ctx.keybindings.getKeys("app.tools.expand"));
-		this.ctx.editor.onExpandTools = () => this.toggleToolOutputExpansion();
 		this.ctx.editor.setActionKeys(
 			"app.tools.toggleVisibility",
 			this.ctx.keybindings.getKeys("app.tools.toggleVisibility"),

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it, type Mock, vi } from "bun:test";
+import { beforeAll, describe, expect, it, type Mock, vi } from "bun:test";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { type KeyId, matchesKey } from "@oh-my-pi/pi-tui";
 import manualContinuePrompt from "../src/prompts/system/manual-continue.md" with { type: "text" };
 
@@ -64,6 +67,7 @@ async function createContext() {
 		"app.retry": ["alt+r"],
 		"app.clipboard.pasteImage": ["ctrl+v"],
 		"app.tools.toggleVisibility": ["ctrl+shift+o"],
+		"app.tools.expand": ["ctrl+o"],
 	};
 	const customHandlers = new Map<string, () => void>();
 	const setActionKeys = vi.fn();
@@ -79,6 +83,7 @@ async function createContext() {
 	const requestRender = vi.fn();
 	const showError = vi.fn();
 	let focused: unknown;
+	let overlayVisible = false;
 	const addInputListener = vi.fn((listener: InputListener) => {
 		void listener;
 	});
@@ -149,6 +154,7 @@ async function createContext() {
 			addInputListener,
 			addStartListener,
 			getFocused: vi.fn(() => focused),
+			hasOverlay: vi.fn(() => overlayVisible),
 			terminal: { write: terminalWrite, refreshAppearance },
 		} as unknown as InteractiveModeContext["ui"],
 		loadingAnimation: undefined,
@@ -229,6 +235,9 @@ async function createContext() {
 		customHandlers,
 		setFocused(target: unknown) {
 			focused = target;
+		},
+		setOverlayVisible(visible: boolean) {
+			overlayVisible = visible;
 		},
 		spies: {
 			setActionKeys,
@@ -659,5 +668,67 @@ describe("InputController keybinding setup", () => {
 				userInitiated: true,
 			});
 		}
+	});
+});
+
+describe("InputController global tool-output expand (ctrl+o)", () => {
+	const CTRL_O = "\x0f";
+
+	beforeAll(async () => {
+		await initTheme(false);
+	});
+
+	async function setup() {
+		const context = await createContext();
+		const controller = new context.InputController(context.ctx);
+		controller.setupKeyHandlers();
+		return { ...context, listeners: registeredInputListeners(context.spies.addInputListener) };
+	}
+
+	it("toggles tool-output expansion when a non-editor prompt holds focus (#7837)", async () => {
+		const { ctx, listeners, setFocused } = await setup();
+		// An approval / select prompt owns keyboard focus, not the editor.
+		setFocused({ handleInput() {} });
+		expect(ctx.toolOutputExpanded).toBe(false);
+
+		expect(dispatchInput(listeners, CTRL_O)).toEqual({ consume: true });
+		expect(ctx.toolOutputExpanded).toBe(true);
+	});
+
+	it("still toggles when the editor holds focus", async () => {
+		const { ctx, listeners } = await setup();
+		// The editor is the default focus target in the harness.
+		expect(dispatchInput(listeners, CTRL_O)).toEqual({ consume: true });
+		expect(ctx.toolOutputExpanded).toBe(true);
+	});
+
+	it("defers while a fullscreen/anchored overlay owns the surface", async () => {
+		const { ctx, listeners, setOverlayVisible } = await setup();
+		setOverlayVisible(true);
+
+		expect(dispatchInput(listeners, CTRL_O)).toBeUndefined();
+		expect(ctx.toolOutputExpanded).toBe(false);
+	});
+
+	it("defers to the tree selector's own ctrl+o filter cycle", async () => {
+		const { ctx, listeners, setFocused } = await setup();
+		const tree = [
+			{
+				entry: { id: "root", type: "message", parentId: null, message: { role: "user", content: "hi" } },
+				children: [],
+			},
+		] as unknown as SessionTreeNode[];
+		setFocused(
+			new TreeSelectorComponent(
+				tree,
+				"root",
+				20,
+				() => {},
+				() => {},
+			),
+		);
+
+		expect(dispatchInput(listeners, CTRL_O)).toBeUndefined();
+		expect(ctx.toolOutputExpanded).toBe(false);
 	});
 });


### PR DESCRIPTION
## Repro
With an always-ask approval policy, the agent shows a large edit and waits for approve/deny. The edit preview is truncated, but pressing Ctrl+O (`app.tools.expand`) does nothing, so the full edit can't be reviewed before deciding — a safety concern (#7837). A minimal reproduction against the real TUI focus dispatch (expand handler wired to the editor only, then a prompt takes focus) prints `Ctrl+O expand handled while prompt focused: 0`, confirming the key is lost.

## Cause
`app.tools.expand` was wired exclusively through the editor's input path: `input-controller.ts` set `editor.onExpandTools`, intercepted inside `CustomEditor.handleInput`. The TUI's `#handleInput` dispatches keys to the focused component, so when a tool-approval prompt (`HookSelectorComponent`) — or any selection dialog — takes focus via `setFocus`, Ctrl+O is delivered to that component (which ignores it) and never reaches the editor. Toggling tool-output expansion is a transcript-wide action, not an editor-local one, so scoping it to editor focus was the defect.

## Fix
- `input-controller.ts`: register `app.tools.expand` as a global `ui.addInputListener` in `setupKeyHandlers` (mirroring the existing debug and branch/copy shortcuts), so it fires before focus dispatch and consumes the key. It defers (`return undefined`) when `ui.hasOverlay()` is true — a fullscreen/anchored overlay (agent hub, transcript viewer, log viewer, model picker) owns the surface and the main transcript isn't visible — or when the focused component is the `TreeSelectorComponent`, which rebinds Ctrl+O to cycle its own filter.
- `custom-editor.ts`: remove the now-dead editor-scoped `app.tools.expand` action key, `onExpandTools` field, and `handleInput` interception (clean cutover; the action stays a first-class app keybinding defined in `config/keybindings.ts`).
- `input-controller-keybindings.test.ts`: regression tests covering the listener's decision logic.

## Verification
`bun test test/input-controller-keybindings.test.ts` → 29 pass (adds: toggles when a non-editor prompt holds focus (#7837), still toggles when the editor holds focus, defers under an overlay, defers to the tree selector's Ctrl+O filter cycle). `bun test test/custom-editor-keybindings.test.ts test/custom-editor-buffered-double-esc.test.ts` → 11 pass. `bun check` passes via the pre-publish gate. Fixes #7837