### PR TITLE
fix(catalog): enrich Alibaba Token Plan discovered model limits

### DIFF
--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2834,6 +2834,64 @@ export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-comple
 	},
 ];
 
+/**
+ * Metadata for Alibaba Token Plan models that are dynamically discovered but not
+ * in the static catalog. Context window and max tokens are sourced from
+ * official model documentation and provider catalogs. Unknown future models
+ * remain available with null limits instead of assigning unsafe guessed limits.
+ */
+export interface AlibabaTokenPlanModelLimits {
+	contextWindow: number;
+	maxTokens: number;
+}
+
+export const ALIBABA_TOKEN_PLAN_DISCOVERED_MODEL_LIMITS: Readonly<Record<string, AlibabaTokenPlanModelLimits>> = {
+	"qwen3.6-plus": {
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+	},
+	"qwen3.8-max": {
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+	},
+	"deepseek-v4-flash": {
+		contextWindow: 1_000_000,
+		maxTokens: 384_000,
+	},
+	"deepseek-v4-flash-0731": {
+		contextWindow: 1_000_000,
+		maxTokens: 384_000,
+	},
+	"deepseek-v3.2": {
+		contextWindow: 131_072,
+		maxTokens: 65_536,
+	},
+	"glm-5.1": {
+		contextWindow: 202_752,
+		maxTokens: 128_000,
+	},
+	"glm-5": {
+		contextWindow: 202_752,
+		maxTokens: 16_384,
+	},
+	"kimi-k2.7-code": {
+		contextWindow: 262_144,
+		maxTokens: 262_144,
+	},
+	"kimi-k2.6": {
+		contextWindow: 262_144,
+		maxTokens: 262_144,
+	},
+	"kimi-k2.5": {
+		contextWindow: 262_144,
+		maxTokens: 98_304,
+	},
+	"minimax-m2.5": {
+		contextWindow: 196_608,
+		maxTokens: 32_768,
+	},
+};
+
 const ALIBABA_TOKEN_PLAN_NON_CHAT_MODEL_PREFIXES = [
 	"fun-asr",
 	"happyhorse-",
@@ -2888,10 +2946,18 @@ export function alibabaTokenPlanModelManagerOptions(
 								baseUrl: defaults.baseUrl,
 							};
 						}
-						// DeepSeek V4 family models discovered dynamically need reasoning config
-						if (defaults.id.startsWith("deepseek-v4")) {
+						const limits = ALIBABA_TOKEN_PLAN_DISCOVERED_MODEL_LIMITS[defaults.id.trim().toLowerCase()];
+						const enriched = limits
+							? {
+									...defaults,
+									contextWindow: limits.contextWindow,
+									maxTokens: limits.maxTokens,
+								}
+							: defaults;
+
+						if (defaults.id.trim().toLowerCase().startsWith("deepseek-v4")) {
 							return {
-								...defaults,
+								...enriched,
 								reasoning: true,
 								thinking: {
 									mode: "effort" as const,
@@ -2899,7 +2965,7 @@ export function alibabaTokenPlanModelManagerOptions(
 								},
 							};
 						}
-						return defaults;
+						return enriched;
 					},
 					fetch: config?.fetch,
 				}),

--- a/packages/catalog/test/alibaba-token-plan.test.ts
+++ b/packages/catalog/test/alibaba-token-plan.test.ts
@@ -66,6 +66,7 @@ describe("QwenCloud Token Plan provider", () => {
 						{ id: "deepseek-v4-flash-0731", owned_by: "qwencloud" },
 						{ id: "kimi-k2.7-code", owned_by: "qwencloud" },
 						{ id: "MiniMax-M2.5", owned_by: "qwencloud" },
+						{ id: "future-chat-model", owned_by: "qwencloud" },
 						{ id: "fun-asr", owned_by: "qwencloud" },
 						{ id: "qwen-image-2.0-pro", owned_by: "qwencloud" },
 						{ id: "qwen-audio-3.0-tts-plus", owned_by: "qwencloud" },
@@ -86,11 +87,14 @@ describe("QwenCloud Token Plan provider", () => {
 		expect(models?.map(model => model.id)).toEqual([
 			"deepseek-v4-flash",
 			"deepseek-v4-flash-0731",
+			"future-chat-model",
 			"kimi-k2.7-code",
 			"MiniMax-M2.5",
 			"qwen3.7-plus",
 		]);
 		expect(models?.find(model => model.id === "deepseek-v4-flash")).toMatchObject({
+			contextWindow: 1_000_000,
+			maxTokens: 384_000,
 			reasoning: true,
 			thinking: {
 				mode: "effort",
@@ -98,11 +102,26 @@ describe("QwenCloud Token Plan provider", () => {
 			},
 		});
 		expect(models?.find(model => model.id === "deepseek-v4-flash-0731")).toMatchObject({
+			contextWindow: 1_000_000,
+			maxTokens: 384_000,
 			reasoning: true,
 			thinking: {
 				mode: "effort",
 				efforts: ["high", "max"],
 			},
+		});
+		expect(models?.find(model => model.id === "kimi-k2.7-code")).toMatchObject({
+			contextWindow: 262_144,
+			maxTokens: 262_144,
+		});
+		expect(models?.find(model => model.id === "MiniMax-M2.5")).toMatchObject({
+			contextWindow: 196_608,
+			maxTokens: 32_768,
+		});
+		expect(models?.find(model => model.id === "future-chat-model")).toMatchObject({
+			id: "future-chat-model",
+			contextWindow: null,
+			maxTokens: null,
 		});
 		expect(models?.find(model => model.id === "qwen3.7-plus")).toMatchObject({
 			id: "qwen3.7-plus",


### PR DESCRIPTION
## Summary

I reviewed the Alibaba Token Plan provider discovery path and added curated `contextWindow` and `maxTokens` metadata for known dynamically discovered models whose `/models` endpoint does not return these fields.

The change keeps dynamic discovery authoritative:
- Known discovered models receive curated `contextWindow` and `maxTokens`
- Existing static models continue using their complete curated definitions
- Unknown future chat models remain visible with `null` limits
- Non-chat models remain filtered
- DeepSeek V4 models retain their reasoning configuration

Fixes #7486.

## Bug Details

**Problem**: The Alibaba Token Plan `/models` endpoint returns model identifiers but does not include `context_length` or `max_completion_tokens` for many subscribed models. This caused the model selector in the UI to display `?` for these models because the catalog fell back to `null` limits.

**Root Cause**: In `alibabaTokenPlanModelManagerOptions`, the `mapModel` handler only applied curated metadata when a model existed in `ALIBABA_TOKEN_PLAN_STATIC_MODELS`. Dynamically discovered models like `deepseek-v4-flash`, `kimi-k2.7-code`, `MiniMax-M2.5`, etc., fell through to the default branch returning `defaults` with `contextWindow: null` and `maxTokens: null`.

## Fix Design

1. **Added `ALIBABA_TOKEN_PLAN_DISCOVERED_MODEL_LIMITS`** — a `Readonly<Record<string, AlibabaTokenPlanModelLimits>>` mapping normalized model IDs to their verified context window and max token values (sourced from official model documentation and provider catalogs).

2. **Updated `mapModel` logic**:
   - Static reference models (`ALIBABA_TOKEN_PLAN_STATIC_MODELS`) continue to use their full curated definitions (preserves name, reasoning config, compat, etc.)
   - Discovered models lookup limits in `ALIBABA_TOKEN_PLAN_DISCOVERED_MODEL_LIMITS` using normalized case-insensitive ID matching (`defaults.id.trim().toLowerCase()`)
   - Unknown future models remain available with `null` limits instead of assigning unsafe guessed limits
   - DeepSeek V4 family models still receive their reasoning overlay (`reasoning: true`, `thinking: { mode: "effort", efforts: [Effort.High, Effort.Max] }`)

3. **Test Coverage**:
   - Assertions for enriched limits on `deepseek-v4-flash`, `deepseek-v4-flash-0731`, `kimi-k2.7-code`, `MiniMax-M2.5`
   - Verification that unknown future models (`future-chat-model`) remain available with `null` limits
   - Verification that non-chat filtering (`fun-asr`, `qwen-image-*`, etc.) remains enforced
   - Verification that existing static model metadata is preserved (`qwen3.7-plus`)

## Verification

- **Package-level CI checks** (`packages/catalog`):
  - `bun --cwd=packages/catalog test` — 563 tests pass, 0 fail
  - `bun --cwd=packages/catalog run check` — biome + tsgo pass
  - `bun --cwd=packages/catalog run lint` — biome lint pass
  - `bun --cwd=packages/catalog run check:types` — tsgo pass
  - `git diff --check` — no whitespace errors

- **Manual verification**: Reproduced the provider's mocked `/models` response in `alibaba-token-plan.test.ts`. Before the fix, the new assertions failed because `contextWindow` and `maxTokens` were `null`. After the fix, known dynamic models were enriched, an unknown model remained available with `null` limits, and non-chat models remained filtered.

- **Scope**: Only two files modified. No changes to `bun.lock`, `Cargo.lock`, generated model catalogs, authentication, or other providers.

## Files Changed

- `packages/catalog/src/provider-models/openai-compat.ts` — Added metadata map and enrichment logic (+74 lines)
- `packages/catalog/test/alibaba-token-plan.test.ts` — Added regression assertions (+19 lines)

## Notes

- Full-repo `bun check` was not completed due to `check:rs` triggering a Rust toolchain bootstrap in the test environment (not a code issue). The `check:ts` phase (biome + tsgo) passed cleanly for all packages including `pi-catalog`.
- Live Alibaba Token Plan verification was not performed (no credentials available). Unit tests reproduce the provider response contract and verify enrichment behavior.