### PR TITLE
fix(extensions): roll back providers after load failure

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -311,6 +311,26 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 	};
 }
 
+/**
+ * Runs an extension factory with provider registration rollback on failure.
+ * Records the number of pending provider registrations before the factory runs,
+ * and restores that checkpoint if the factory throws.
+ */
+async function runExtensionFactory(
+	factory: ExtensionFactory,
+	api: ExtensionAPI,
+	runtime: IExtensionRuntime,
+): Promise<void> {
+	const providerRegistrationCheckpoint = runtime.pendingProviderRegistrations.length;
+
+	try {
+		await factory(api);
+	} catch (error) {
+		runtime.pendingProviderRegistrations.length = providerRegistrationCheckpoint;
+		throw error;
+	}
+}
+
 async function loadExtension(
 	extensionPath: string,
 	cwd: string,
@@ -331,9 +351,7 @@ async function loadExtension(
 
 		const extension = createExtension(extensionPath, resolvedPath);
 		const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, eventBus);
-		await withHostGuard(async () => {
-			await factory(api);
-		});
+		await withHostGuard(() => runExtensionFactory(factory, api, runtime));
 
 		return { extension, error: null };
 	} catch (err) {
@@ -354,7 +372,7 @@ export async function loadExtensionFromFactory(
 ): Promise<Extension> {
 	const extension = createExtension(name, name);
 	const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, eventBus);
-	await factory(api);
+	await runExtensionFactory(factory, api, runtime);
 	return extension;
 }
 

--- a/packages/coding-agent/test/extension-provider-registration-rollback.test.ts
+++ b/packages/coding-agent/test/extension-provider-registration-rollback.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import type { ProviderConfig } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
+
+const testProviderConfig: ProviderConfig = {
+	baseUrl: "https://example.invalid/v1",
+	apiKey: "TEST_PROVIDER_API_KEY",
+	api: "openai-completions",
+	models: [
+		{
+			id: "test-model",
+			name: "Test Model",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 16_384,
+			maxTokens: 4_096,
+		},
+	],
+};
+
+describe("extension provider registration rollback", () => {
+	test("removes provider registrations when inline extension initialization fails", async () => {
+		const runtime = new ExtensionRuntime();
+		const events = new EventBus();
+
+		await expect(
+			loadExtensionFromFactory(
+				pi => {
+					pi.registerProvider("should-not-survive", testProviderConfig);
+					throw new Error("intentional initialization failure");
+				},
+				process.cwd(),
+				events,
+				runtime,
+				"broken-inline-extension",
+			),
+		).rejects.toThrow("intentional initialization failure");
+
+		expect(runtime.pendingProviderRegistrations).toEqual([]);
+	});
+
+	test("preserves provider registrations from earlier successful extensions", async () => {
+		const runtime = new ExtensionRuntime();
+		const events = new EventBus();
+
+		await loadExtensionFromFactory(
+			pi => {
+				pi.registerProvider("working-provider", testProviderConfig);
+			},
+			process.cwd(),
+			events,
+			runtime,
+			"working-extension",
+		);
+
+		await expect(
+			loadExtensionFromFactory(
+				pi => {
+					pi.registerProvider("broken-provider", testProviderConfig);
+					throw new Error("second extension failed");
+				},
+				process.cwd(),
+				events,
+				runtime,
+				"broken-extension",
+			),
+		).rejects.toThrow("second extension failed");
+
+		expect(runtime.pendingProviderRegistrations.map(r => r.name)).toEqual(["working-provider"]);
+	});
+
+	test("keeps provider registrations when extension initialization succeeds", async () => {
+		const runtime = new ExtensionRuntime();
+		const events = new EventBus();
+
+		await loadExtensionFromFactory(
+			pi => {
+				pi.registerProvider("provider-one", {
+					baseUrl: "https://one.example.invalid/v1",
+				});
+				pi.registerProvider("provider-two", {
+					baseUrl: "https://two.example.invalid/v1",
+				});
+			},
+			process.cwd(),
+			events,
+			runtime,
+			"working-extension",
+		);
+
+		expect(runtime.pendingProviderRegistrations.map(r => r.name)).toEqual(["provider-one", "provider-two"]);
+	});
+
+	test("rolls back every provider added by the failed extension", async () => {
+		const runtime = new ExtensionRuntime();
+		const events = new EventBus();
+
+		await expect(
+			loadExtensionFromFactory(
+				pi => {
+					pi.registerProvider("broken-provider-one", testProviderConfig);
+					pi.registerProvider("broken-provider-two", testProviderConfig);
+					throw new Error("failed after multiple registrations");
+				},
+				process.cwd(),
+				events,
+				runtime,
+				"broken-multi-provider-extension",
+			),
+		).rejects.toThrow("failed after multiple registrations");
+
+		expect(runtime.pendingProviderRegistrations).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

I traced the failed-extension state leak to provider registrations being written directly into the shared extension runtime before initialization completed.

The loader now restores provider registration state when a factory throws. Registrations from earlier successful extensions remain intact, while successful extension registrations continue to work normally.

Fixes #7472.

## Bug Details

**Problem**: When an extension registers a provider via `pi.registerProvider()` and then throws during initialization, the provider registration remains in the shared `ExtensionRuntime.pendingProviderRegistrations` array even though the extension itself is rejected. This allows a "failed" extension to still affect model routing and provider availability.

**Root Cause**: In `ConcreteExtensionAPI.registerProvider()`, registrations are pushed directly to `this.runtime.pendingProviderRegistrations` (the shared runtime). When the extension factory throws, the temporary `Extension` object is discarded (along with tools, commands, handlers, etc.), but the provider registrations already mutated the shared runtime and survive.

## Fix Design

1. **Added `runExtensionFactory()` helper** - Records the length of `pendingProviderRegistrations` before executing the factory, and restores that checkpoint if the factory throws.

2. **Applied to both loading paths**:
   - `loadExtensionFromFactory()` - inline factory loading
   - `loadExtension()` - file-based extension loading (called by `loadExtensions()`)

3. **Rollback semantics**:
   - Only rolls back registrations added by the failed factory
   - Preserves registrations from earlier successful extensions
   - Preserves all registrations from successful extensions
   - Original exception is rethrown (doesn't convert failure to success)

## Test Coverage

Added `packages/coding-agent/test/extension-provider-registration-rollback.test.ts` with 4 regression tests:

1. **`removes provider registrations when inline extension initialization fails`** - Core regression test proving the leak is fixed
2. **`preserves provider registrations from earlier successful extensions`** - Protects against clearing the entire queue
3. **`keeps provider registrations when extension initialization succeeds`** - Normal path still works
4. **`rolls back every provider added by the failed extension`** - Multiple registrations from one failed extension are all removed

All 4 tests pass.

## Verification

- **Regression tests**: `bun test packages/coding-agent/test/extension-provider-registration-rollback.test.ts` — 4 pass, 0 fail
- **Existing loader tests**: `bun test packages/coding-agent/test/extension-loader-self-import.test.ts`, `extension-loader-graph-read-dedup.test.ts`, `extension-loader-process-exit.test.ts`, `cli-extension-path.test.ts` — all pass
- **Catalog tests**: `bun --cwd=packages/catalog test` — 563 pass, 0 fail
- **Manual verification**: Created temporary broken extension that registers `should-not-survive` and throws; extension failure reported, provider does not appear in provider/model selection; separate valid extension still registers normally.

## Files Changed

- `packages/coding-agent/src/extensibility/extensions/loader.ts` — Added `runExtensionFactory()` helper, updated both `loadExtension()` and `loadExtensionFromFactory()` to use it
- `packages/coding-agent/test/extension-provider-registration-rollback.test.ts` — New regression test file

No changes to `bun.lock`, `Cargo.lock`, generated catalogs, authentication, or other providers.