### PR TITLE
feat(coding-agent): mark child processes as agent-driven

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `AGENT=1` to coding-agent child-process environments so downstream tools can detect agent-driven execution ([#7847](https://github.com/can1357/oh-my-pi/issues/7847)).
+
 ## [17.2.10] - 2026-08-06
 
 ### Breaking Changes

--- a/packages/coding-agent/src/exec/non-interactive-env.ts
+++ b/packages/coding-agent/src/exec/non-interactive-env.ts
@@ -24,6 +24,7 @@ export const NON_INTERACTIVE_ENV: Readonly<Record<string, string>> = {
 	GIT_TERMINAL_PROMPT: "0",
 	SSH_ASKPASS: "/usr/bin/false",
 	CI: "1",
+	AGENT: "1",
 	// Package manager defaults for unattended execution.
 	npm_config_yes: "true",
 	npm_config_update_notifier: "false",

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -231,12 +231,12 @@ describe("executeBash", () => {
 	});
 
 	it("applies non-interactive environment defaults", async () => {
-		const result = await executeBash('echo "$GIT_TERMINAL_PROMPT:$PI_TEST_ENV"', {
+		const result = await executeBash('echo "$AGENT:$GIT_TERMINAL_PROMPT:$PI_TEST_ENV"', {
 			cwd: tempDir,
 			timeout: 5000,
 			env: { PI_TEST_ENV: "hello" },
 		});
-		expect(result.output.trim()).toBe("0:hello");
+		expect(result.output.trim()).toBe("1:0:hello");
 	});
 
 	it("runs non-bash shellPath commands through the configured shell", async () => {


### PR DESCRIPTION
## Repro
Run a command through `executeBash` that prints `AGENT`, for example `bun --eval 'import { executeBash } from "./packages/coding-agent/src/exec/bash-executor.ts"; const result = await executeBash("printf %s \"$AGENT\"", { cwd: process.cwd(), timeout: 5000 }); process.stdout.write(result.output);'`. Before this change, the shared child environment did not define the marker, so downstream tools could not identify agent-driven execution.

## Cause
`NON_INTERACTIVE_ENV` in `packages/coding-agent/src/exec/non-interactive-env.ts` defined `CI=1` and other unattended-execution defaults but omitted the emerging `AGENT` marker. Every bash executor, PTY, and ACP terminal command already consumes this shared environment.

## Fix
- Add `AGENT=1` to the shared non-interactive child-process environment.
- Extend the bash executor integration coverage to assert the marker reaches an actual spawned command.
- Document the new child-process contract in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/non-interactive-env.test.ts packages/coding-agent/test/bash-executor.test.ts` — 79 passed, 0 failed. Manual `executeBash` smoke command printed `1` and exited 0.

Fixes #7847