### PR TITLE
feat(catalog): add Upstage provider with Solar Pro 4

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an Upstage provider registry entry with a paste-key `/login` flow (`UPSTAGE_API_KEY`), validated against `https://api.upstage.ai/v1/models`.
+
 ## [17.2.10] - 2026-08-06
 
 ### Breaking Changes

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -62,6 +62,7 @@ import { tavilyProvider } from "./tavily";
 import { togetherProvider } from "./together";
 import type { ProviderDefinition } from "./types";
 import { umansProvider } from "./umans";
+import { upstageProvider } from "./upstage";
 import { veniceProvider } from "./venice";
 import { vercelAiGatewayProvider } from "./vercel-ai-gateway";
 import { vllmProvider } from "./vllm";
@@ -128,6 +129,7 @@ const ALL = [
 	huggingfaceProvider,
 	perplexityProvider,
 	qianfanProvider,
+	upstageProvider,
 	veniceProvider,
 	siliconflowProvider,
 	siliconflowCnProvider,

--- a/packages/ai/src/registry/upstage.ts
+++ b/packages/ai/src/registry/upstage.ts
@@ -1,0 +1,22 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+export const loginUpstage = createApiKeyLogin({
+	providerLabel: "Upstage",
+	authUrl: "https://console.upstage.ai/api-keys",
+	instructions: "Create or copy your API key from the Upstage Console",
+	promptMessage: "Paste your Upstage API key",
+	placeholder: "up_...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "upstage",
+		modelsUrl: "https://api.upstage.ai/v1/models",
+	},
+});
+
+export const upstageProvider = {
+	id: "upstage",
+	name: "Upstage",
+	login: (cb: OAuthLoginCallbacks) => loginUpstage(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Upstage as a first-class chat provider: bundled Solar models (`solar-mini`, `solar-pro2`, `solar-pro3`, `solar-pro4`, default `solar-pro4`), `/v1/models` discovery that keeps only chat-capable SKUs and hydrates dated snapshot ids (e.g. `solar-pro4-260806`) from their alias rows, and endpoint compat verified live (`store` and the `developer` role are rejected).
+
+### Fixed
+
+- Corrected Solar Pro thinking-effort tiers to the wire-exact ladders: `solar-pro4` exposes `minimal..max` with lowest-effort disable (the model reasons by default), while `solar-pro2`/`solar-pro3` top out at `high` — the previously derived `xhigh` tier is rejected by the API (also fixes the stale `kilo`/`nanogpt` `upstage/solar-pro-3` gateway rows).
+
 ## [17.2.10] - 2026-08-06
 
 ### Changed

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -98,6 +98,29 @@ export const isMimoModelIdOrName = memo((value: string): boolean => {
 	return value.toLowerCase().includes("mimo");
 });
 
+/**
+ * Upstage Solar Pro family in any namespace form (`solar-pro2`, dated
+ * `solar-pro3-260323`, aggregator `upstage/solar-pro-3`). The reasoning SKUs
+ * are wire-strict about `reasoning_effort`: Pro 2/3 reject `xhigh`/`max` and
+ * top out at `high`, while Pro 4 accepts the full `minimal..max` ladder — see
+ * {@link isSolarPro4ModelId} and the effort rules in model-thinking.
+ */
+export const isSolarProModelId = memo((modelId: string): boolean => {
+	return /(^|\/)solar-pro/i.test(bareModelId(modelId));
+});
+
+/**
+ * Upstage Solar Pro 4 specifically (`solar-pro4`, dated `solar-pro4-260806`,
+ * aggregator `upstage/solar-pro-4`). Pro 4 reasons BY DEFAULT (omitting
+ * `reasoning_effort` leaves thinking on; only `none`/`minimal` turn it off)
+ * and accepts every wire tier from `none` through `max` — verified against
+ * api.upstage.ai; see
+ * https://console.upstage.ai/docs/capabilities/generate/reasoning.
+ */
+export const isSolarPro4ModelId = memo((modelId: string): boolean => {
+	return /(^|\/)solar-pro-?4(?:[-.:]|$)/i.test(bareModelId(modelId));
+});
+
 const GROK_EFFORT_CAPABLE_PREFIXES = ["grok-3-mini", "grok-4.20-multi-agent", "grok-4.3", "grok-4.5"] as const;
 
 /**

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -31,6 +31,8 @@ import {
 	isMinimaxM2FamilyModelId,
 	isMinimaxM3FamilyModelId,
 	isOpenAIGptOssModelId,
+	isSolarPro4ModelId,
+	isSolarProModelId,
 	supportsAdaptiveThinkingDisplay,
 } from "./identity/family";
 import type {
@@ -341,6 +343,13 @@ function getModelDefinedEfforts<TApi extends Api>(
 	}
 	if (isKimiK3ModelId(spec.id)) {
 		return LOW_HIGH_MAX_REASONING_EFFORTS;
+	}
+	if (isOpenAICompatReasoningApi(spec.api) && isSolarProModelId(spec.id)) {
+		// Upstage Solar Pro reasoners are wire-strict about `reasoning_effort`
+		// (verified against api.upstage.ai, 2026-08-07): Pro 4 accepts the full
+		// minimal..max ladder (`none`/`minimal` turn thinking off), while Pro 2/3
+		// 400 on `xhigh`/`max` and top out at `high`.
+		return isSolarPro4ModelId(spec.id) ? THINKING_EFFORTS : DEFAULT_REASONING_EFFORTS;
 	}
 	if (isSakanaFuguReasoningModel(spec)) {
 		return HIGH_MAX_REASONING_EFFORTS;

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -39011,8 +39011,7 @@
 					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			}
 		},
@@ -60089,8 +60088,7 @@
 					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
+					"high"
 				]
 			},
 			"supportsComputerUse": false,
@@ -87389,6 +87387,138 @@
 			"supportsComputerUseConfig": false,
 			"compat": {
 				"escapeBuiltinToolNames": true
+			}
+		}
+	},
+	"upstage": {
+		"solar-mini": {
+			"id": "solar-mini",
+			"name": "solar-mini",
+			"api": "openai-completions",
+			"provider": "upstage",
+			"baseUrl": "https://api.upstage.ai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.15,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 32768,
+			"maxTokens": 4096,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": true,
+				"supportsMultipleSystemMessages": true
+			}
+		},
+		"solar-pro2": {
+			"id": "solar-pro2",
+			"name": "solar-pro2",
+			"api": "openai-completions",
+			"provider": "upstage",
+			"baseUrl": "https://api.upstage.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 0.25,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 65536,
+			"maxTokens": 8192,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": true,
+				"supportsMultipleSystemMessages": true
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"solar-pro3": {
+			"id": "solar-pro3",
+			"name": "solar-pro3",
+			"api": "openai-completions",
+			"provider": "upstage",
+			"baseUrl": "https://api.upstage.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 0.25,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 8192,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": true,
+				"supportsMultipleSystemMessages": true
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"solar-pro4": {
+			"id": "solar-pro4",
+			"name": "Solar Pro 4",
+			"api": "openai-completions",
+			"provider": "upstage",
+			"baseUrl": "https://api.upstage.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.06,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": true,
+				"supportsMultipleSystemMessages": true,
+				"reasoningDisableMode": "lowest-effort"
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
 			}
 		}
 	},

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -49,6 +49,7 @@ import {
 	syntheticModelManagerOptions,
 	togetherModelManagerOptions,
 	umansModelManagerOptions,
+	upstageModelManagerOptions,
 	veniceModelManagerOptions,
 	vercelAiGatewayModelManagerOptions,
 	vllmModelManagerOptions,
@@ -433,6 +434,13 @@ export const CATALOG_PROVIDERS = [
 		createModelManagerOptions: (config: ModelManagerConfig) => umansModelManagerOptions(config),
 		dynamicModelsAuthoritative: true,
 		catalogDiscovery: { label: "Umans AI Coding Plan", allowUnauthenticated: true },
+	},
+	{
+		id: "upstage",
+		defaultModel: "solar-pro4",
+		envVars: ["UPSTAGE_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => upstageModelManagerOptions(config),
+		catalogDiscovery: { label: "Upstage" },
 	},
 	{
 		id: "venice",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1555,6 +1555,47 @@ export function deepseekModelManagerOptions(
 // Upstage
 // ---------------------------------------------------------------------------
 
+const UPSTAGE_BASE_URL = "https://api.upstage.ai/v1";
+
+/**
+ * Upstage serves non-chat SKUs (embeddings, document AI, groundedness
+ * checkers) from the same API base, and `/v1/models` carries no per-model type
+ * field — so non-chat rows are dropped by id to keep the picker usable.
+ */
+const UPSTAGE_NON_CHAT_MODEL_TOKENS = [
+	"embedding",
+	"document",
+	"groundedness",
+	"layout",
+	"ocr",
+	"docvision",
+] as const;
+
+export function isLikelyUpstageChatModelId(id: string): boolean {
+	const normalized = id.trim().toLowerCase();
+	if (!normalized) {
+		return false;
+	}
+	return !UPSTAGE_NON_CHAT_MODEL_TOKENS.some(token => normalized.includes(token));
+}
+
+/** Strip the Upstage dated-snapshot suffix (`solar-pro4-260806` → `solar-pro4`). */
+export function upstageSnapshotAliasId(id: string): string {
+	return id.replace(/-\d{6}$/, "");
+}
+
+/**
+ * Applied to discovered rows with no bundled reference (e.g. `solar-open2`,
+ * `syn-pro`) so they still avoid the wire fields the endpoint rejects; mirrors
+ * the bundled descriptor compat below.
+ */
+const UPSTAGE_DISCOVERY_COMPAT: OpenAICompat = {
+	supportsStore: false,
+	supportsDeveloperRole: false,
+	supportsReasoningEffort: true,
+	supportsMultipleSystemMessages: true,
+};
+
 export interface UpstageModelManagerConfig {
 	apiKey?: string;
 	baseUrl?: string;
@@ -1564,7 +1605,31 @@ export interface UpstageModelManagerConfig {
 export function upstageModelManagerOptions(
 	config?: UpstageModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
-	return createSimpleOpenAICompletionsOptions("upstage", "https://api.upstage.ai/v1", config);
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? UPSTAGE_BASE_URL;
+	const references = createBundledReferenceMap<"openai-completions">("upstage");
+	return {
+		providerId: "upstage",
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "upstage",
+					baseUrl,
+					apiKey,
+					filterModel: (_entry, model) => isLikelyUpstageChatModelId(model.id),
+					mapModel: (entry, defaults) => {
+						// Dated snapshots (`solar-pro4-260806`) hydrate from their alias's
+						// bundled row so they keep reasoning and provider compat metadata.
+						const reference =
+							references.get(defaults.id) ?? references.get(upstageSnapshotAliasId(defaults.id));
+						const model = mapWithBundledReference(entry, defaults, reference);
+						return model.compat ? model : { ...model, compat: { ...UPSTAGE_DISCOVERY_COMPAT } };
+					},
+					fetch: config?.fetch,
+				}),
+		}),
+	};
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -15,6 +15,7 @@ import {
 	isKimiK3ModelId,
 	isKimiModelId,
 	isReasoningGlmModelId,
+	isSolarPro4ModelId,
 } from "../identity/family";
 import { resolveModelReference } from "../identity/reference";
 import type { ModelManagerOptions } from "../model-manager";
@@ -1548,6 +1549,22 @@ export function deepseekModelManagerOptions(
 	config?: DeepSeekModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
 	return createSimpleOpenAICompletionsOptions("deepseek", "https://api.deepseek.com", config);
+}
+
+// ---------------------------------------------------------------------------
+// Upstage
+// ---------------------------------------------------------------------------
+
+export interface UpstageModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+export function upstageModelManagerOptions(
+	config?: UpstageModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	return createSimpleOpenAICompletionsOptions("upstage", "https://api.upstage.ai/v1", config);
 }
 
 // ---------------------------------------------------------------------------
@@ -5872,6 +5889,34 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_SPECIALIZED: readonly ModelsDevProviderDes
 	openAiCompletionsDescriptor("nano-gpt", "nanogpt", "https://nano-gpt.com/api/v1"),
 	// --- Synthetic ---
 	openAiCompletionsDescriptor("synthetic", "synthetic", "https://api.synthetic.new/openai/v1"),
+	// --- Upstage ---
+	openAiCompletionsDescriptor("upstage", "upstage", "https://api.upstage.ai/v1", {
+		compat: {
+			// Verified against api.upstage.ai (2026-08-07): the `store` field and the
+			// `developer` role are rejected with a 400 ("Unrecognized request
+			// arguments supplied: store" / `role` must be system/assistant/user/tool),
+			// while top-level `reasoning_effort`, multiple leading system messages,
+			// and `stream_options.include_usage` are all accepted.
+			supportsStore: false,
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: true,
+			supportsMultipleSystemMessages: true,
+		},
+		transformModel: model => {
+			if (!model.reasoning || !isSolarPro4ModelId(model.id)) {
+				return model;
+			}
+			// solar-pro4 reasons BY DEFAULT: omitting `reasoning_effort` leaves
+			// thinking on, and only `none`/`minimal` turn it off. Disable via
+			// lowest-effort (`minimal`) instead of the omit default, which would
+			// silently fall back to the server-side thinking-on default. The
+			// effort ladder itself is family-derived in model-thinking.
+			return {
+				...model,
+				compat: { ...model.compat, reasoningDisableMode: "lowest-effort" },
+			};
+		},
+	}),
 	// --- Venice AI ---
 	openAiCompletionsDescriptor("venice", "venice", "https://api.venice.ai/api/v1", {
 		transformModel: model => {

--- a/packages/catalog/test/upstage-provider.test.ts
+++ b/packages/catalog/test/upstage-provider.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import {
+	isLikelyUpstageChatModelId,
+	upstageModelManagerOptions,
+	upstageSnapshotAliasId,
+} from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { Api, FetchImpl, Model, ModelSpec, Provider } from "@oh-my-pi/pi-catalog/types";
+
+const SOLAR_PRO_23_EFFORTS = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
+const SOLAR_PRO_4_EFFORTS = [...SOLAR_PRO_23_EFFORTS, Effort.XHigh, Effort.Max];
+
+function createSolarModel<TApi extends Api>(id: string, provider: Provider, api: TApi): Model<TApi> {
+	return buildModel({
+		id,
+		name: id,
+		api,
+		provider,
+		baseUrl: "",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 131072,
+		maxTokens: 8192,
+	} as ModelSpec<TApi>);
+}
+
+describe("Upstage Solar effort ladders", () => {
+	test("bundled solar-pro4 bakes the full minimal..max ladder with lowest-effort disable", () => {
+		const pro4 = getBundledModel("upstage", "solar-pro4") as Model<"openai-completions">;
+		expect(pro4.thinking).toMatchObject({ mode: "effort", efforts: SOLAR_PRO_4_EFFORTS });
+		expect(pro4.compatConfig?.reasoningDisableMode).toBe("lowest-effort");
+	});
+
+	test("bundled solar-pro2/pro3 top out at high (the wire 400s on xhigh/max)", () => {
+		for (const id of ["solar-pro2", "solar-pro3"]) {
+			const model = getBundledModel("upstage", id);
+			expect(model.thinking?.efforts).toEqual(SOLAR_PRO_23_EFFORTS);
+		}
+	});
+
+	test("namespaced aggregator ids derive the same wire-exact ladders", () => {
+		const pro3 = createSolarModel("upstage/solar-pro-3", "openrouter", "openai-completions");
+		expect(pro3.thinking?.efforts).toEqual(SOLAR_PRO_23_EFFORTS);
+
+		const pro4 = createSolarModel("upstage/solar-pro-4", "openrouter", "openai-completions");
+		expect(pro4.thinking?.efforts).toEqual(SOLAR_PRO_4_EFFORTS);
+	});
+
+	test("dated snapshot ids classify like their alias", () => {
+		const dated = createSolarModel("solar-pro4-260806", "upstage", "openai-completions");
+		expect(dated.thinking?.efforts).toEqual(SOLAR_PRO_4_EFFORTS);
+	});
+});
+
+describe("Upstage discovery", () => {
+	test("drops non-chat SKUs by id", () => {
+		expect(isLikelyUpstageChatModelId("solar-pro4")).toBe(true);
+		expect(isLikelyUpstageChatModelId("syn-pro")).toBe(true);
+		expect(isLikelyUpstageChatModelId("solar-embedding-1-large")).toBe(false);
+		expect(isLikelyUpstageChatModelId("solar-embedding-2-query")).toBe(false);
+		expect(isLikelyUpstageChatModelId("solar-docvision-preview")).toBe(false);
+		expect(isLikelyUpstageChatModelId("document-parse-260630")).toBe(false);
+		expect(isLikelyUpstageChatModelId("groundedness-check-240502")).toBe(false);
+	});
+
+	test("strips dated snapshot suffixes to the alias id", () => {
+		expect(upstageSnapshotAliasId("solar-pro4-260806")).toBe("solar-pro4");
+		expect(upstageSnapshotAliasId("solar-pro4")).toBe("solar-pro4");
+		expect(upstageSnapshotAliasId("syn-pro-251021")).toBe("syn-pro");
+	});
+
+	test("hydrates dated snapshots from the alias row and keeps compat on unbundled ids", async () => {
+		const fetchMock: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					data: [
+						{ id: "solar-pro4", object: "model" },
+						{ id: "solar-pro4-260806", object: "model" },
+						{ id: "solar-embedding-1-large", object: "model" },
+						{ id: "syn-pro", object: "model" },
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+
+		const options = upstageModelManagerOptions({ apiKey: "up_test-key", fetch: fetchMock });
+		const models = await options.fetchDynamicModels?.();
+		expect(models?.map(model => model.id)).toEqual(["solar-pro4", "solar-pro4-260806", "syn-pro"]);
+
+		// The dated snapshot inherits the alias's reasoning, pricing, and compat.
+		const dated = models?.find(model => model.id === "solar-pro4-260806");
+		expect(dated).toMatchObject({
+			reasoning: true,
+			cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0 },
+			compat: { supportsStore: false, supportsDeveloperRole: false, reasoningDisableMode: "lowest-effort" },
+		});
+
+		// Unbundled chat ids still avoid the wire fields the endpoint rejects.
+		const synPro = models?.find(model => model.id === "syn-pro");
+		expect(synPro?.reasoning).toBe(false);
+		expect(synPro?.compat).toMatchObject({ supportsStore: false, supportsDeveloperRole: false });
+	});
+});


### PR DESCRIPTION
Adds **Upstage** (`api.upstage.ai`) as a first-class chat provider, with **Solar Pro 4** as the default model. Solar Pro 4 is a strong agentic model (Terminal-Bench 57, AA-LCR 63), so I added first-class Upstage support to oh-my-pi.

## What's included

- **Catalog** (`@oh-my-pi/pi-catalog`): `upstage` entry in `CATALOG_PROVIDERS` (default `solar-pro4`, `UPSTAGE_API_KEY`), a `ModelsDevProviderDescriptor` bundling the stencil.so rows, and an `upstageModelManagerOptions` factory for live `/v1/models` discovery.
- **Registry** (`@oh-my-pi/pi-ai`): `upstageProvider` with a paste-key login validated against `https://api.upstage.ai/v1/models`.
- **Thinking rules** (`model-thinking.ts` + `identity/family.ts`): wire-exact effort ladders for the Solar Pro family (see below). This also corrects the stale `xhigh` tier on the existing `kilo`/`nanogpt` `upstage/solar-pro-3` gateway rows.
- **models.json**: regenerated with `bun run gen:models`, then scoped to the `upstage` block plus the two gateway rows the new effort rule changes — the full regen carried ~7k lines of unrelated stencil-drift churn that I left for a routine snapshot bump.

## Wire behavior (verified live against api.upstage.ai, 2026-08-07)

| Probe | Result | Compat |
| --- | --- | --- |
| `store` field | 400 "Unrecognized request arguments supplied: store" | `supportsStore: false` |
| `developer` role | 400 (role must be system/assistant/user/tool) | `supportsDeveloperRole: false` |
| multiple leading `system` messages | accepted | `supportsMultipleSystemMessages: true` |
| top-level `reasoning_effort` | accepted | `supportsReasoningEffort: true` |
| `stream_options.include_usage` | usage chunk delivered | default |
| `max_tokens` / `max_completion_tokens` | both accepted | default |
| tool calls, `tool_choice: required`, tool-result roundtrip w/o reasoning replay | all work | default |

Effort ladders (each value probed against the live endpoint; [Upstage reasoning docs](https://console.upstage.ai/docs/capabilities/generate/reasoning) agree):

- `solar-pro4`: accepts `none`/`minimal` (thinking **off**) and `low`..`max` (**on**) — and **reasons by default when the param is omitted**, so the model gets the full `minimal..max` ladder plus `reasoningDisableMode: "lowest-effort"`; plain omit would silently leave thinking on.
- `solar-pro2`/`pro3`: 400 on `xhigh`/`max`, top out at `high` → `minimal..high` ladder (the pre-existing derived ladders advertised `xhigh`, which the API rejects).

## Verification

- Exercised end-to-end through the real stack (`getBundledModel` → `stream()` with a logging fetch): reasoning at `max` streams `thinking_delta`s and answers correctly (`17 × 23 → 391`, effort `max` on the wire), `disableReasoning` sends `minimal` and produces no thinking, and a tool-call turn returns `toolUse` with `get_weather {"city":"Seoul"}`. Dynamic discovery with a real key lists all 11 live ids.
- `check:types` and `biome check` clean on both packages; `bun test` — catalog 563 pass, ai 3695 pass / 2 pre-existing local failures (`Bun.Image` missing on Bun 1.3.11 in the anthropic image-resize tests, unrelated).

> Prepared with Claude Code, directed and reviewed by @hunkim. Opened as a draft pending the human-written summary sentence required by CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
