### PR TITLE
fix(anthropic): honor ANTHROPIC_BASE_URL for chat requests

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `ANTHROPIC_BASE_URL` being ignored for Anthropic chat requests, which sent gateway-scoped keys to `api.anthropic.com` (401 `invalid x-api-key`, and a credential disclosure) instead of the configured host. Chat now resolves the base URL to `ANTHROPIC_BASE_URL` (after Foundry, ahead of the official default) and forwards `ANTHROPIC_CUSTOM_HEADERS` to non-official gateways, matching the documented behavior and the web-search fix from #1693 ([#7874](https://github.com/can1357/oh-my-pi/issues/7874)).
+
 ## [17.2.10] - 2026-08-06
 
 ### Breaking Changes

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1212,7 +1212,14 @@ function resolveAnthropicBaseUrl(model: Model<"anthropic-messages">, apiKey?: st
 		}
 	}
 	if (model.provider === "anthropic") {
-		return normalizeAnthropicBaseUrl(model.baseUrl) ?? "https://api.anthropic.com";
+		const configured = normalizeAnthropicBaseUrl(model.baseUrl);
+		// An explicitly configured non-official baseUrl (e.g. a models.yml provider
+		// override) is more specific than the generic env fallback and wins.
+		if (configured && !isOfficialAnthropicApiUrl(configured)) return configured;
+		// Otherwise ANTHROPIC_BASE_URL routes chat through an enterprise gateway
+		// (docs/environment-variables.md), ahead of the official default. The
+		// Foundry redirect is already handled above.
+		return normalizeAnthropicBaseUrl($env.ANTHROPIC_BASE_URL) ?? configured ?? "https://api.anthropic.com";
 	}
 	return normalizeAnthropicBaseUrl(model.baseUrl);
 }
@@ -1272,9 +1279,12 @@ export function resolveAnthropicCustomHeadersForBaseUrl(
 	return parseAnthropicCustomHeaders($env.ANTHROPIC_CUSTOM_HEADERS);
 }
 
-function resolveAnthropicCustomHeaders(model: Model<"anthropic-messages">): Record<string, string> | undefined {
+function resolveAnthropicCustomHeaders(
+	model: Model<"anthropic-messages">,
+	baseUrl: string | undefined,
+): Record<string, string> | undefined {
 	if (model.provider !== "anthropic") return undefined;
-	return resolveAnthropicCustomHeadersForBaseUrl(model.baseUrl);
+	return resolveAnthropicCustomHeadersForBaseUrl(baseUrl);
 }
 
 function looksLikeFilePath(value: string): boolean {
@@ -2944,7 +2954,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 	const supportsEagerToolInputStreaming = resolveEagerToolInputStreamingSupport(model, baseUrl);
 	const needsFineGrainedToolStreamingBeta =
 		hasTools && isOfficialAnthropicApiUrl(baseUrl) && !supportsEagerToolInputStreaming;
-	const foundryCustomHeaders = resolveAnthropicCustomHeaders(model);
+	const foundryCustomHeaders = resolveAnthropicCustomHeaders(model, baseUrl);
 	const tlsFetchOptions = buildCoworkTlsFetchOptions(model, baseUrl);
 	// Disable Bun's native ~300s pre-response fetch timeout (issue #2422).
 	// `AnthropicMessagesClient` already arms its own DEFAULT_TIMEOUT_MS timer

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -112,10 +112,18 @@ function isGoogleVertexAuthenticatedModel(model: Model<Api>): boolean {
  */
 function isLeakedThinkingHealExempt(model: Model<Api>): boolean {
 	switch (model.provider) {
-		case "anthropic":
-			// Mirror resolveAnthropicBaseUrl: Foundry redirects an empty baseUrl to
-			// FOUNDRY_BASE_URL, so exempt only when the effective endpoint is official.
-			return isOfficialAnthropicApiUrl((isFoundryEnabled() && $env.FOUNDRY_BASE_URL?.trim()) || model.baseUrl);
+		case "anthropic": {
+			// Mirror resolveAnthropicBaseUrl's effective endpoint: Foundry redirects
+			// an empty baseUrl to FOUNDRY_BASE_URL; otherwise an explicit non-official
+			// model.baseUrl wins, then the ANTHROPIC_BASE_URL gateway fallback, then
+			// the official default. Exempt only when the effective endpoint is official.
+			if (isFoundryEnabled()) {
+				const foundry = $env.FOUNDRY_BASE_URL?.trim();
+				if (foundry) return isOfficialAnthropicApiUrl(foundry);
+			}
+			if (model.baseUrl && !isOfficialAnthropicApiUrl(model.baseUrl)) return false;
+			return isOfficialAnthropicApiUrl($env.ANTHROPIC_BASE_URL?.trim() || model.baseUrl);
+		}
 		case "openai":
 			return isOfficialOpenAIApiUrl(model.baseUrl);
 		case "openai-codex":

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -2237,6 +2237,59 @@ describe("Anthropic request fingerprint alignment", () => {
 		);
 	});
 
+	it("routes chat through ANTHROPIC_BASE_URL for the stock Anthropic provider (#7874)", async () => {
+		await withEnv(
+			{
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				FOUNDRY_BASE_URL: undefined,
+				ANTHROPIC_BASE_URL: "https://my-gateway.example.com",
+				ANTHROPIC_CUSTOM_HEADERS: "x-api-key: gateway-key",
+			},
+			() => {
+				const options = buildAnthropicClientOptions({
+					model: ANTHROPIC_MODEL,
+					apiKey: "sk-ant-api-gateway-key",
+					extraBetas: [],
+					stream: true,
+					interleavedThinking: false,
+					dynamicHeaders: {},
+				});
+
+				// Chat no longer leaks a gateway-scoped key to api.anthropic.com.
+				expect(options.baseURL).toBe("https://my-gateway.example.com");
+				// A non-official gateway forwards ANTHROPIC_CUSTOM_HEADERS, so gateways
+				// that require x-api-key work without enabling Foundry mode.
+				expect(options.defaultHeaders["X-Api-Key"]).toBe("gateway-key");
+			},
+		);
+	});
+
+	it("keeps an explicit non-official model.baseUrl ahead of ANTHROPIC_BASE_URL (#7874)", async () => {
+		const configuredModel: Model<"anthropic-messages"> = buildModel({
+			...ANTHROPIC_MODEL_SPEC,
+			baseUrl: "https://configured.example.com",
+		});
+		await withEnv(
+			{
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				FOUNDRY_BASE_URL: undefined,
+				ANTHROPIC_BASE_URL: "https://my-gateway.example.com",
+			},
+			() => {
+				const options = buildAnthropicClientOptions({
+					model: configuredModel,
+					apiKey: "sk-ant-api-test",
+					extraBetas: [],
+					stream: true,
+					interleavedThinking: false,
+					dynamicHeaders: {},
+				});
+
+				expect(options.baseURL).toBe("https://configured.example.com");
+			},
+		);
+	});
+
 	it("loads Foundry mTLS and CA material from file paths", async () => {
 		const tmpDir = path.join(os.tmpdir(), `pi-ai-foundry-${Date.now()}-${Math.random().toString(16).slice(2)}`);
 		fs.mkdirSync(tmpDir, { recursive: true });


### PR DESCRIPTION
## Repro
With `ANTHROPIC_BASE_URL` set to an enterprise gateway (no Foundry), Anthropic chat requests still go to `https://api.anthropic.com`, so a gateway-scoped key is rejected `401 invalid x-api-key` and, worse, leaves the network for a third-party host it was never meant to reach. Reproduced by building a stock Anthropic chat client and inspecting the resolved base URL:

```
ANTHROPIC_BASE_URL env : https://my-gateway.example.com
resolved chat baseURL  : https://api.anthropic.com   <-- ignored
X-Api-Key header       : sk-ant-api-gateway-key       <-- sent to api.anthropic.com
```

## Cause
`resolveAnthropicBaseUrl()` (`packages/ai/src/providers/anthropic.ts`) resolves the chat base URL from the github-copilot special case, `FOUNDRY_BASE_URL` (Foundry mode), then `model.baseUrl` → hardcoded `https://api.anthropic.com`, and never reads `$env.ANTHROPIC_BASE_URL`. The stock `anthropic` descriptor pins `model.baseUrl` to `https://api.anthropic.com`, so even a `model.baseUrl`-based fallback is unreachable. `ANTHROPIC_BASE_URL` is read only by `resolveAnthropicBaseUrlFromEnv()` (`utils/anthropic-auth.ts`), which serves the web-search/auth-config path — the chat-path counterpart to #1693, which fixed the same class of bug for web search. This contradicts `docs/environment-variables.md` (“Generic fallback base URL for Anthropic requests”; “keep chat routed through an enterprise gateway (`ANTHROPIC_BASE_URL` ...)”; `ANTHROPIC_CUSTOM_HEADERS` forwarded when `ANTHROPIC_BASE_URL` is non-Anthropic).

## Fix
- `resolveAnthropicBaseUrl()`: for provider `anthropic`, return `ANTHROPIC_BASE_URL` after the Foundry redirect and ahead of the official default; an explicitly configured non-official `model.baseUrl` (e.g. a `models.yml` override) remains more specific and wins.
- `resolveAnthropicCustomHeaders()` now keys off the resolved base URL instead of the raw `model.baseUrl`, so `ANTHROPIC_CUSTOM_HEADERS` reach env-configured non-official gateways (gateways requiring `x-api-key` work without Foundry mode).
- `stream.ts` `isLeakedThinkingHealExempt()` mirror updated to the same effective-endpoint precedence (Foundry → explicit non-official `model.baseUrl` → `ANTHROPIC_BASE_URL` → official default), so an env gateway is not wrongly treated as the official endpoint.

## Verification
`bun test test/anthropic-alignment.test.ts test/anthropic-oauth.test.ts` (117 pass) and `bun test test/stream-markup-healing.test.ts test/leaked-thinking-stream.test.ts` (79 pass). Added two regression tests in `anthropic-alignment.test.ts`: env `ANTHROPIC_BASE_URL` now routes the stock provider's chat `baseURL` and forwards `ANTHROPIC_CUSTOM_HEADERS`; an explicit non-official `model.baseUrl` still wins over the env fallback. Manually reproduced pre-fix (`baseURL = api.anthropic.com`) and confirmed post-fix (`baseURL = gateway`, no key leak). Fixes #7874