### PR TITLE
fix(auth): purge pre-org OAuth tombstone on org-scoped re-login

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a pre-org OAuth tombstone (`email:<e>`) surviving a later org-scoped login of the same account (`email:<e>|org:<ws>`) for `openai-codex` and `anthropic`, leaving a permanent red row in `omp usage` that re-login could not clear. `#purgeSupersededDisabledRows` now reuses the `matchesReplacementCredential` semantics of the active-replacement path instead of exact identity-key equality, so an org-scoped login claims and hard-deletes its pre-org legacy tombstone ([#7876](https://github.com/can1357/oh-my-pi/issues/7876)).
+
 ## [17.2.10] - 2026-08-06
 
 ### Breaking Changes

--- a/packages/ai/src/auth/sqlite-credential-store.ts
+++ b/packages/ai/src/auth/sqlite-credential-store.ts
@@ -1374,11 +1374,13 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		try {
 			let hasActiveApiKey = false;
 			const activeIdentityKeys = new Set<string>();
+			const activeOAuthCredentials: AuthCredential[] = [];
 			for (const row of activeRows) {
 				if (row.credential.type === "api_key") {
 					hasActiveApiKey = true;
 					continue;
 				}
+				activeOAuthCredentials.push(row.credential);
 				const identityKey = resolveCredentialIdentityKey(provider, row.credential);
 				if (identityKey) activeIdentityKeys.add(identityKey);
 			}
@@ -1393,7 +1395,22 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 				const identityKey = resolveRowCredentialIdentityKey(provider, row);
 				if (identityKey && activeIdentityKeys.has(identityKey)) {
 					this.#hardDeleteStmt.run(row.id);
+					continue;
 				}
+				// Exact key equality misses a tombstone whose key predates a format
+				// the active row now uses (pre-org `<b>` vs `<b>|org:<o>`). An active
+				// credential that WOULD have replaced this row had it still been
+				// active supersedes its tombstone too, so mirror the replacement
+				// matcher rather than restating a weaker rule. The one-way upgrade
+				// and shared-workspace guards in matchesReplacementCredential carry
+				// over, so this never over-deletes another member's or subscription's
+				// row.
+				const disabledCredential = deserializeCredential(row);
+				if (disabledCredential === null) continue;
+				const superseded = activeOAuthCredentials.some(active =>
+					matchesReplacementCredential(provider, disabledCredential, identityKey, active),
+				);
+				if (superseded) this.#hardDeleteStmt.run(row.id);
 			}
 		} catch {
 			// Best-effort cleanup; don't let it break the main operation

--- a/packages/ai/test/auth-storage-codex-workspace-identity.test.ts
+++ b/packages/ai/test/auth-storage-codex-workspace-identity.test.ts
@@ -151,6 +151,50 @@ describe("openai-codex workspace-scoped credential identity", () => {
 		]);
 	});
 
+	it("purges a disabled legacy email-keyed row on the first workspace-scoped login with the same email", async () => {
+		if (!store) throw new Error("test setup failed");
+
+		// Pre-org login → bare email key, then upstream invalidates the refresh
+		// token and the row is auto-disabled (a tombstone).
+		store.upsertAuthCredentialForProvider(
+			"openai-codex",
+			codexCredential({ suffix: "legacy", accountId: PERSONAL_WS }),
+		);
+		const legacyId = store.listAuthCredentials("openai-codex")[0].id;
+		store.deleteAuthCredential(legacyId, "oauth refresh failed: OAuthError: 401 refresh_token_invalidated");
+
+		// Same human logs in again, now workspace-scoped: the org-scoped login
+		// claims and hard-deletes the pre-org tombstone instead of stranding it.
+		store.upsertAuthCredentialForProvider(
+			"openai-codex",
+			codexCredential({ suffix: "team", accountId: TEAM_WS, orgId: TEAM_WS, orgName: "team" }),
+		);
+		expect(readIdentityRows(dbPath)).toEqual([
+			{ identity_key: `email:${EMAIL}|org:${TEAM_WS}`, disabled_cause: null },
+		]);
+		expect(await store.listDisabledCredentials("openai-codex")).toHaveLength(0);
+	});
+
+	it("keeps a disabled row of a different member of the same workspace after a workspace-scoped login", async () => {
+		if (!store) throw new Error("test setup failed");
+
+		// Alice's org-scoped row is disabled (tombstone). Bob, a different member
+		// of the SAME workspace, logs in. The shared-workspace guard must keep
+		// Alice's tombstone — it is not Bob's subscription.
+		store.upsertAuthCredentialForProvider(
+			"openai-codex",
+			codexCredential({ suffix: "alice", accountId: TEAM_WS, orgId: TEAM_WS, email: "alice@example.com" }),
+		);
+		const aliceId = store.listAuthCredentials("openai-codex")[0].id;
+		store.deleteAuthCredential(aliceId, "oauth refresh failed: OAuthError: 401 refresh_token_invalidated");
+
+		store.upsertAuthCredentialForProvider(
+			"openai-codex",
+			codexCredential({ suffix: "bob", accountId: TEAM_WS, orgId: TEAM_WS, email: "bob@example.com" }),
+		);
+		expect(await store.listDisabledCredentials("openai-codex")).toHaveLength(1);
+	});
+
 	it("never clobbers workspace-scoped rows with a workspace-less credential", () => {
 		if (!store) throw new Error("test setup failed");
 


### PR DESCRIPTION
## Repro
A pre-org OAuth login (`identity_key` = `email:<e>`) that is later auto-disabled when its refresh token is invalidated becomes a tombstone. A subsequent org-scoped login of the exact same account (`email:<e>|org:<ws>`) should claim and purge that tombstone, but it survives — rendering forever as a red `✗ <email> … disabled` row in `omp usage` that re-login cannot clear and no CLI/TUI surface can delete. Affects the two providers whose identity keys carry an org qualifier: `openai-codex` and `anthropic`. Reproduced against the real `SqliteAuthCredentialStore`: after the pre-org login → disable → org-scoped re-login sequence, `listDisabledCredentials("openai-codex").length` returns `1`, want `0`.

## Cause
`#purgeSupersededDisabledRows` (`packages/ai/src/auth/sqlite-credential-store.ts:1373`) matched disabled rows against active credentials by exact identity-key string equality (`activeIdentityKeys.has(identityKey)`). But `email:<e>` and `email:<e>|org:<ws>` are two different strings for one account, so `Set.has` misses. The active-replacement path it is meant to mirror, `matchesReplacementCredential` (`:223-285`), already encodes the correct one-way upgrade rule that claims a pre-org legacy row (`:249-251`, implemented `:280`); the purge duplicated a weaker rule instead of reusing it. Disabled rows are invisible to the matcher on the active paths (`#listActiveByProviderStmt` filters `disabled_cause IS NULL`), so the purge is the only place that can reclaim a tombstone — and it couldn't. This is the OAuth half of the class of bug #2943 fixed for api_key rows in the same function.

## Fix
- Collect the active OAuth credentials alongside their identity keys in `#purgeSupersededDisabledRows`.
- After the existing exact-key match fails for a disabled row, deserialize it and hard-delete it when any active OAuth credential `matchesReplacementCredential` against it — the same predicate the active-replacement path uses, so the one-way upgrade guard (`:260-261`) and shared-workspace guard (`:270-279`) carry over unchanged and cannot over-delete another member's or subscription's row.
- Added two regression tests in `auth-storage-codex-workspace-identity.test.ts`: the pre-org tombstone is purged by an org-scoped re-login, and a different member's tombstone in the same workspace survives.

## Verification
`cd packages/ai && bun test test/auth-storage-codex-workspace-identity.test.ts` → 8 pass (both new tests included). `bun test test/auth-storage-api-key-login.test.ts test/auth-broker-disabled-credentials.test.ts` → 12 pass. Full `packages/ai` suite: 3698 pass, 1 unrelated failure in `proxy.test.ts` that passes in isolation (full-suite env pollution from another file, independent of this change). Fixes #7876