### PR TITLE
fix(natives): port wayland capture to pipewire 0.9 Rc handle API

### DIFF
--- a/crates/pi-natives/src/desktop/linux/wayland/capture.rs
+++ b/crates/pi-natives/src/desktop/linux/wayland/capture.rs
@@ -147,11 +147,11 @@ fn rgba_from_buffer(
 fn grab_pipewire_frame(node: u32, fd: OwnedFd) -> Result<RgbaImage, String> {
 	pw::init();
 	let mainloop =
-		pw::main_loop::MainLoop::new(None).map_err(|err| format!("PipeWire main loop: {err}"))?;
-	let context =
-		pw::context::Context::new(&mainloop).map_err(|err| format!("PipeWire context: {err}"))?;
+		pw::main_loop::MainLoopRc::new(None).map_err(|err| format!("PipeWire main loop: {err}"))?;
+	let context = pw::context::ContextRc::new(&mainloop, None)
+		.map_err(|err| format!("PipeWire context: {err}"))?;
 	let core = context
-		.connect_fd(fd, None)
+		.connect_fd_rc(fd, None)
 		.map_err(|err| format!("PipeWire remote: {err}"))?;
 	let stream = pw::stream::StreamBox::new(&core, "omp-computer-capture", properties! {
 		*pw::keys::MEDIA_TYPE => "Video",

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `wayland-pipewire` Cargo feature failing to compile: the PipeWire capture path still used the removed 0.8 `MainLoop::new` / `Context::new` / `connect_fd` constructors instead of the 0.9 `MainLoopRc` / `ContextRc` / `connect_fd_rc` handle API ([#7885](https://github.com/can1357/oh-my-pi/issues/7885)).
+
 ## [17.2.10] - 2026-08-06
 
 ### Fixed


### PR DESCRIPTION
## Repro
The `wayland-pipewire` Cargo feature does not compile. `crates/pi-natives/src/desktop/linux/wayland/capture.rs` constructed the PipeWire main loop and context via the 0.8 owning constructors, but the workspace pins `pipewire = "=0.9.2"`, which replaced them with `Rc` handle types. Reproduce with `cargo check -p pi-natives --features wayland-pipewire`, which fails with two `E0599: no associated function ... named 'new'` errors on `MainLoop` and `Context`.

## Cause
`grab_pipewire_frame` in `capture.rs` called `pw::main_loop::MainLoop::new(None)`, `pw::context::Context::new(&mainloop)` and `context.connect_fd(fd, None)`. In pipewire 0.9.2 the bare `MainLoop`/`Context` structs no longer expose `new` (`pipewire-0.9.2/src/main_loop/mod.rs` exposes only `run`/`quit`/`loop_`/`as_raw`; `.../context/mod.rs` exposes `connect`/`connect_fd`), the constructors moved to the `MainLoopRc`/`ContextRc` handles. The migration was partial: `StreamBox::new` one line below was already the 0.9 type, so the breakage bit-rotted unnoticed because nothing in CI compiles this feature (`BUILD.bazel` sets `crate_features = []` and the feature is `default = []`).

## Fix
- `capture.rs`: `MainLoop::new(None)` -> `MainLoopRc::new(None)`, `Context::new(&mainloop)` -> `ContextRc::new(&mainloop, None)`, `context.connect_fd(fd, None)` -> `context.connect_fd_rc(fd, None)`. Downstream call sites are unchanged: `MainLoopRc: Clone + Deref<Target=MainLoop>` (so `mainloop.clone()`, `mainloop.run()`, `callback_loop.quit()` still resolve), `ContextRc: Deref<Target=Context>`, and `CoreRc: Deref<Target=Core>` (so `StreamBox::new(&core, ...)` still coerces) — all confirmed in the 0.9.2 crate source.
- `packages/natives/CHANGELOG.md`: `Fixed` entry under `[Unreleased]`.

## Verification
The full `cargo check -p pi-natives --features wayland-pipewire` cannot run in the CI sandbox: `libpipewire-0.3` is not installed and root is unavailable to install it, so `system-deps` aborts in `libspa-sys`'s `build.rs` before the Rust type-check. The fix is verified structurally against the pinned `pipewire = "=0.9.2"` crate source: the removed symbols (`MainLoop::new`, `Context::new`) are absent and match the reporter's `E0599` output, and every replacement symbol used (`MainLoopRc::new(Option<&DictRef>)`, `ContextRc::new<T: IsLoopRc>(&T, Option<PropertiesBox>)`, `ContextRc::connect_fd_rc(OwnedFd, Option<PropertiesBox>) -> CoreRc`) exists with the required `Deref`/`Clone` impls. The reporter independently confirmed the patched build links `libpipewire-0.3` and captures a real frame. A CI job compiling this opt-in feature on Linux would keep the path honest but adds a `libpipewire` system dep to CI — left as a maintainer call, not included here. `Fixes #7885`