### PR TITLE
fix(bash): constrain leading cd extraction to a single path token

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the leading `cd <path> && ...` extraction absorbing shell syntax into the structured `cwd`, so `cd /tmp 2>/dev/null && echo ok` died with "Working directory does not exist: /tmp 2>/dev/null" before the shell ran. Extraction now captures a single path token via a quote-aware scanner and defers to the shell when anything else (redirects, extra arguments, shell expansion) precedes the top-level `&&` ([#7883](https://github.com/can1357/oh-my-pi/issues/7883)).
+
 ## [17.2.10] - 2026-08-06
 
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -49,7 +49,7 @@ import {
 	previewWindowRows,
 	replaceTabs,
 } from "./render-utils";
-import { tokenizeShellSegments } from "./shell-tokenize";
+import { extractLeadingCdTarget, tokenizeShellSegments } from "./shell-tokenize";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout, TOOL_TIMEOUTS } from "./tool-timeouts";
@@ -960,17 +960,16 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		let command = rawCommand;
 		const env = normalizeBashEnv(rawEnv);
 
-		// Extract leading `cd <path> && ...` into cwd when the model ignores the cwd parameter.
-		// Constrained to a single line so a `&&` that sits on a later line of a multiline
-		// script can't pull the entire script into the "cwd" capture.
+		// Extract a leading `cd <path> && ...` into cwd when the model ignores the
+		// cwd parameter. The scanner captures only a single path token and defers
+		// to the shell for anything else (redirects, extra args, shell expansion),
+		// so it never absorbs shell syntax like `cd /tmp 2>/dev/null && ...` into
+		// the structured cwd. Constrained to a top-level `&&` on the first line.
 		if (!cwd) {
-			const cdMatch = command.match(/^cd[ \t]+((?:[^&\\\n\r]|\\.)+?)[ \t]*&&[ \t]*/);
-			// Skip extraction when the path needs shell expansion ($VAR, $(...),
-			// backticks) — resolveToCwd only expands `~`, so routing those through
-			// cwd would reject commands the shell itself handles fine.
-			if (cdMatch && !/[$`(]/.test(cdMatch[1])) {
-				cwd = cdMatch[1].trim().replace(/^["']|["']$/g, "");
-				command = command.slice(cdMatch[0].length);
+			const cd = extractLeadingCdTarget(command);
+			if (cd) {
+				cwd = cd.path;
+				command = cd.rest;
 			}
 		}
 		if (asyncRequested && !this.#asyncEnabled) {

--- a/packages/coding-agent/src/tools/shell-tokenize.ts
+++ b/packages/coding-agent/src/tools/shell-tokenize.ts
@@ -211,3 +211,96 @@ export function extractFlatShellCommandSegments(command: string): FlatShellComma
 	pushSegment(command.length);
 	return segments;
 }
+
+/**
+ * Shell metacharacters that end an unquoted `cd` target token. A redirect,
+ * extra argument, or any operator in this set means the leading construct is
+ * more than a bare `cd <path>`, so extraction must bail.
+ */
+const CD_TARGET_TERMINATORS: Record<string, true> = {
+	" ": true,
+	"\t": true,
+	"\n": true,
+	"\r": true,
+	"&": true,
+	"|": true,
+	";": true,
+	"<": true,
+	">": true,
+	"(": true,
+	")": true,
+};
+
+/**
+ * Parses a leading `cd <path> && ...` prefix so the bash tool can route the
+ * target through its structured `cwd` parameter when the model omits it.
+ *
+ * Returns the single path token (quotes and backslash escapes resolved to their
+ * literal value) and the command remainder after the top-level `&&`, or `null`
+ * when the command does not begin with exactly `cd`, one path token, and a
+ * top-level `&&`. The scanner deliberately bails on anything else in the prefix
+ * — redirects (`cd /tmp 2>/dev/null && ...`), extra arguments, or paths needing
+ * shell expansion (`$`, backticks, `(`) — leaving the whole command for the
+ * shell instead of absorbing shell syntax into `cwd`.
+ */
+export function extractLeadingCdTarget(command: string): { path: string; rest: string } | null {
+	const prefix = /^cd[ \t]+/.exec(command);
+	if (!prefix) return null;
+	let i = prefix[0].length;
+	let path = "";
+	let inSingle = false;
+	let inDouble = false;
+	for (; i < command.length; i++) {
+		const ch = command[i];
+		if (inSingle) {
+			if (ch === "'") {
+				inSingle = false;
+				continue;
+			}
+			path += ch;
+			continue;
+		}
+		if (inDouble) {
+			if (ch === "\\" && i + 1 < command.length) {
+				const next = command[i + 1];
+				if (next === '"' || next === "\\" || next === "$" || next === "`") {
+					path += next;
+					i++;
+					continue;
+				}
+			}
+			if (ch === '"') {
+				inDouble = false;
+				continue;
+			}
+			path += ch;
+			continue;
+		}
+		if (ch === "'") {
+			inSingle = true;
+			continue;
+		}
+		if (ch === '"') {
+			inDouble = true;
+			continue;
+		}
+		if (ch === "\\" && i + 1 < command.length) {
+			path += command[i + 1];
+			i++;
+			continue;
+		}
+		if (CD_TARGET_TERMINATORS[ch]) break;
+		path += ch;
+	}
+	// Unterminated quote or empty target: leave the command for the shell.
+	if (inSingle || inDouble || path.length === 0) return null;
+	// A path needing shell expansion can't be resolved literally through cwd.
+	if (/[$`(]/.test(path)) return null;
+	// Skip inter-token whitespace, then require a top-level `&&` (a single `&`,
+	// `||`, `;`, `|`, or a redirect all mean this is not a bare `cd <path>`).
+	while (command[i] === " " || command[i] === "\t") i++;
+	if (command[i] !== "&" || command[i + 1] !== "&") return null;
+	i += 2;
+	while (command[i] === " " || command[i] === "\t") i++;
+	return { path, rest: command.slice(i) };
+}

--- a/packages/coding-agent/test/tools/shell-tokenize.test.ts
+++ b/packages/coding-agent/test/tools/shell-tokenize.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { extractLeadingCdTarget } from "@oh-my-pi/pi-coding-agent/tools/shell-tokenize";
+
+describe("extractLeadingCdTarget", () => {
+	it("extracts a bare cd target and returns the remainder", () => {
+		expect(extractLeadingCdTarget("cd /some/dir && echo ok")).toEqual({
+			path: "/some/dir",
+			rest: "echo ok",
+		});
+	});
+
+	it("resolves quoted and escaped path tokens", () => {
+		expect(extractLeadingCdTarget('cd "/my dir" && ls')).toEqual({ path: "/my dir", rest: "ls" });
+		expect(extractLeadingCdTarget("cd '/a b' && ls")).toEqual({ path: "/a b", rest: "ls" });
+		expect(extractLeadingCdTarget("cd /a\\ b && ls")).toEqual({ path: "/a b", rest: "ls" });
+	});
+
+	it("preserves ~ so resolveToCwd can expand it", () => {
+		expect(extractLeadingCdTarget("cd ~/proj && make")).toEqual({ path: "~/proj", rest: "make" });
+	});
+
+	it("accepts a && with no leading whitespace", () => {
+		expect(extractLeadingCdTarget("cd /tmp&& echo ok")).toEqual({ path: "/tmp", rest: "echo ok" });
+	});
+
+	// Regression for #7883: a redirect between the path and `&&` must not be
+	// absorbed into the cwd token — the command belongs to the shell intact.
+	it("bails when a redirect follows the path", () => {
+		expect(extractLeadingCdTarget("cd /tmp 2>/dev/null && echo ok")).toBeNull();
+		expect(extractLeadingCdTarget("cd /tmp >/dev/null && echo ok")).toBeNull();
+		expect(extractLeadingCdTarget("cd /tmp >/dev/null 2>&1 && echo ok")).toBeNull();
+	});
+
+	it("bails when an extra argument follows the path", () => {
+		expect(extractLeadingCdTarget("cd /tmp extra && echo ok")).toBeNull();
+	});
+
+	it("bails on paths that need shell expansion", () => {
+		expect(extractLeadingCdTarget("cd $HOME && ls")).toBeNull();
+		expect(extractLeadingCdTarget('cd "$(git rev-parse --show-toplevel)" && make')).toBeNull();
+		expect(extractLeadingCdTarget("cd `pwd` && ls")).toBeNull();
+	});
+
+	it("requires a top-level && separator", () => {
+		expect(extractLeadingCdTarget("cd /tmp; echo ok")).toBeNull();
+		expect(extractLeadingCdTarget("cd /foo || echo fail")).toBeNull();
+		expect(extractLeadingCdTarget("cd /tmp &echo")).toBeNull();
+	});
+
+	it("bails when there is no cd target", () => {
+		expect(extractLeadingCdTarget("cd  && echo")).toBeNull();
+		expect(extractLeadingCdTarget("ls -la")).toBeNull();
+		expect(extractLeadingCdTarget("cdx /tmp && ls")).toBeNull();
+	});
+});


### PR DESCRIPTION
## Repro

With `cwd` omitted, the bash tool rewrites a leading `cd <path> && ...` into its structured `cwd`. When any shell syntax sits between the path and the `&&`, the whole span is captured as the working directory, which fails `fs.stat` and kills the command before the shell is ever invoked:

```bash
cd /tmp 2>/dev/null && echo ok   # Working directory does not exist: /tmp 2>/dev/null
cd /tmp >/dev/null && echo ok    # cwd becomes "/tmp >/dev/null"
```

`cd /tmp >/dev/null 2>&1 && echo ok` happened to survive only because the `&` in `2>&1` broke the old regex.

## Cause

`BashTool.execute` (`packages/coding-agent/src/tools/bash.ts:967`) used `/^cd[ \t]+((?:[^&\\\n\r]|\\.)+?)[ \t]*&&[ \t]*/`. The capture group consumes every character up to the first `&&`, including redirects and extra arguments, then routes the entire span to `cwd`, which `resolveToCwd` + `fs.stat` reject. This is tool-layer parsing, independent of the underlying shell.

## Fix

- Added `extractLeadingCdTarget` to `packages/coding-agent/src/tools/shell-tokenize.ts`: a quote/escape-aware scanner (mirroring the module's existing tokenizer conventions) that captures exactly one path token, resolves quoting, and bails to the shell when anything else precedes a top-level `&&` — redirects, extra arguments, paths needing shell expansion (`$`, backticks, `(`), or a non-`&&` separator (`;`, `||`, single `&`).
- Replaced the hand-rolled regex in `bash.ts` with a call to the new helper; the existing `$`/backtick/`(` expansion guard is now folded into the scanner.
- Added `packages/coding-agent/test/tools/shell-tokenize.test.ts` covering the redirect regression, extra-arg bail, quoting/escaping, `~` passthrough, shell-expansion bail, separator requirement, and no-target cases.

## Verification

`bun test test/tools/shell-tokenize.test.ts` → 9 pass. `bun test test/tools/bash-interceptor.test.ts` → 36 pass (cd-normalization path unchanged). `bun check` passes via the pre-publish gate.

Fixes #7883