### PR TITLE
fix(natives): share one runtime across wayland portal paths

### DIFF
--- a/crates/pi-natives/src/desktop/linux/wayland/capture.rs
+++ b/crates/pi-natives/src/desktop/linux/wayland/capture.rs
@@ -245,10 +245,7 @@ fn grab_pipewire_frame(node: u32, fd: OwnedFd) -> Result<RgbaImage, String> {
 }
 
 pub(super) fn capture() -> CoreResult<RgbaImage> {
-	let runtime = tokio::runtime::Builder::new_current_thread()
-		.enable_all()
-		.build()
-		.map_err(|err| DesktopError::capture_failed(format!("wayland screencast runtime: {err}")))?;
+	let runtime = super::portal::portal_runtime()?;
 	let (node, fd) = runtime.block_on(open_screencast()).map_err(|err| {
 		DesktopError::capture_failed(format!("wayland screencast unavailable: {err}"))
 	})?;

--- a/crates/pi-natives/src/desktop/linux/wayland/libei.rs
+++ b/crates/pi-natives/src/desktop/linux/wayland/libei.rs
@@ -52,12 +52,7 @@ impl Libei {
 	}
 
 	fn portal_context() -> CoreResult<ei::Context> {
-		let runtime = tokio::runtime::Builder::new_current_thread()
-			.enable_all()
-			.build()
-			.map_err(|err| {
-				DesktopError::input_failed(format!("RemoteDesktop portal runtime: {err}"))
-			})?;
+		let runtime = super::portal::portal_runtime()?;
 		let fd = runtime
 			.block_on(async {
 				let portal = RemoteDesktop::new()

--- a/crates/pi-natives/src/desktop/linux/wayland/portal.rs
+++ b/crates/pi-natives/src/desktop/linux/wayland/portal.rs
@@ -1,6 +1,37 @@
-use std::{fs, path::PathBuf};
+use std::{fs, path::PathBuf, sync::LazyLock};
+
+use tokio::runtime::{Builder, Runtime};
+
+use crate::desktop::error::{CoreResult, DesktopError};
 
 pub(super) const REMOTE_DESKTOP_TOKEN: &str = "remote-desktop-token";
+
+/// Process-wide Tokio runtime shared by every xdg-desktop-portal call.
+///
+/// `ashpd` caches a single process-global D-Bus connection whose background
+/// I/O tasks are bound to whichever runtime first creates it
+/// (`ashpd::proxy::SESSION`). If each portal user spun up its own short-lived
+/// runtime, that connection's tasks would be orphaned the moment the runtime
+/// was dropped, silently breaking every later portal call made from a
+/// different runtime — this is why libei input init poisoned PipeWire capture
+/// (issue #7886). Routing all portal work through one long-lived runtime keeps
+/// the cached connection's I/O alive for the life of the process. A
+/// multi-thread runtime drives that I/O on its own worker even while the
+/// caller blocks the calling thread on PipeWire's main loop.
+static PORTAL_RUNTIME: LazyLock<Result<Runtime, String>> = LazyLock::new(|| {
+	Builder::new_multi_thread()
+		.worker_threads(1)
+		.enable_all()
+		.build()
+		.map_err(|err| err.to_string())
+});
+
+/// Borrow the shared portal runtime, surfacing a one-time build failure.
+pub(super) fn portal_runtime() -> CoreResult<&'static Runtime> {
+	PORTAL_RUNTIME
+		.as_ref()
+		.map_err(|err| DesktopError::internal(format!("xdg-desktop-portal runtime: {err}")))
+}
 
 fn token_path(name: &str) -> Option<PathBuf> {
 	let base = std::env::var_os("XDG_STATE_HOME")
@@ -25,5 +56,23 @@ pub(super) fn store_token(name: &str, token: Option<&str>) {
 	};
 	if fs::create_dir_all(parent).is_ok() {
 		let _ = fs::write(path, token);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Every portal caller (libei input init and PipeWire capture) must borrow
+	/// one persistent runtime; a regression to per-call runtimes would return
+	/// distinct instances and re-open the orphaned-connection bug (#7886).
+	#[test]
+	fn portal_runtime_is_shared_across_calls() {
+		let first = portal_runtime().expect("portal runtime builds");
+		let second = portal_runtime().expect("portal runtime builds");
+		assert!(
+			std::ptr::eq(first, second),
+			"portal_runtime must hand back one long-lived runtime, not a fresh per-call instance"
+		);
 	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Wayland `libei` input initialization poisoning PipeWire screen capture: both paths now share one long-lived Tokio runtime so `ashpd`'s process-global D-Bus connection is never orphaned by a dropped runtime ([#7886](https://github.com/can1357/oh-my-pi/issues/7886)).
+
 ## [17.2.10] - 2026-08-06
 
 ### Fixed


### PR DESCRIPTION
## Repro
On a GNOME Wayland session with the `wayland-pipewire` feature compiled in, screen capture never delivers a frame under omp's default configuration: the PipeWire stream reaches `streaming` with a fully negotiated format but the `process` callback never fires, and the call hits the outer timeout. Forcing libei to fail (`LIBEI_SOCKET=/nonexistent`) makes the exact same capture return a real frame within ~0.04s of injected damage. The only variable is whether `Libei::new()` runs first. The end-to-end repro requires the reporter's hardware (live Wayland + PipeWire portal) and the compile patch from #7885, neither of which the CI sandbox has. The underlying mechanism was reproduced in isolation with plain Tokio: a task spawned on a `current_thread` runtime that is then dropped is orphaned, so a second runtime cannot drive it — control (shared long-lived runtime) `reply received`; bug (runtime dropped before reuse) `orphaned: reader gone, channel closed`.

## Cause
`ashpd` caches a single process-global D-Bus connection in `ashpd-0.11.1/src/proxy.rs:27` (`static SESSION: OnceLock<zbus::Connection>`), and its background I/O tasks bind to whichever Tokio runtime first creates it. `Libei::portal_context()` (`crates/pi-natives/src/desktop/linux/wayland/libei.rs:55`) built a short-lived `current_thread` runtime, initialized that connection during `Libei::new()`, then dropped the runtime on return — orphaning the connection's I/O tasks. `capture()` (`crates/pi-natives/src/desktop/linux/wayland/capture.rs:248`) later built its *own* runtime and reused the now-dead cached connection, so the PipeWire capture path never completed. Input init and capture could not coexist in one process.

## Fix
- Added `portal::portal_runtime()` in `crates/pi-natives/src/desktop/linux/wayland/portal.rs`: one process-wide, long-lived multi-thread Tokio runtime held in a `LazyLock`, so the cached ashpd connection's I/O stays alive for the process lifetime (and a dedicated worker drives it even while the caller blocks on PipeWire's main loop).
- Routed `Libei::portal_context()` (`libei.rs`) and `capture()` (`capture.rs`) through the shared runtime instead of each building and dropping its own.
- Added a regression test asserting `portal_runtime()` hands back one persistent runtime across calls, guarding against a revert to the per-call runtimes that caused the orphaning.

## Verification
`cargo build` (default features) and `cargo test desktop::linux::wayland` both pass (5/5, including the new `portal_runtime_is_shared_across_calls`). The `wayland-pipewire` feature cannot be compiled in this sandbox — its build stops at the `libspa-sys` build script because system `libpipewire-0.3` is absent (independent of #7886), so the `capture.rs` edit is a hand-reviewed, type-identical mirror of the `libei.rs` change (`&'static Runtime` + `block_on`). The push pre-publish gate (`bun run fix` + `bun check`) passed. Fixes #7886