### PR TITLE
fix(ai,catalog): widen Bedrock stream-stall watchdog via model compat

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed lazy provider streams (Amazon Bedrock, Google, Cursor, Devin, Ollama) ignoring the model's catalog `compat.streamIdleTimeoutMs`, which pinned Bedrock reasoning models to the generic 300s idle watchdog and killed healthy-but-quiet plan-writing/todo-execution turns with `Provider stream stalled while waiting for the next event`; Bedrock ConverseStream sends no ping keepalives, so long thinking gaps read as dead streams. The terminal message now also carries the watchdog's structural transient+timeout `errorId`, so session-level auto-retry classifies these stalls without depending on message text ([#7892](https://github.com/can1357/oh-my-pi/pull/7892) by [@voonfoo](https://github.com/voonfoo)).
+
 ## [17.2.10] - 2026-08-06
 
 ### Breaking Changes

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -11,6 +11,7 @@
  * loading that can be integrated when stream.ts is refactored.
  */
 
+import type { CompatOf } from "@oh-my-pi/pi-catalog/types";
 import * as AIError from "../error";
 import type {
 	Api,
@@ -243,9 +244,13 @@ function forwardStream<TApi extends Api>(
 			// Per-model catalog compat can widen the fallback watchdog for hosts
 			// with no keepalive events (e.g. Bedrock reasoning models that go
 			// quiet for minutes mid-thinking, issue #4758). Caller options and
-			// env overrides still take precedence over the compat fallback.
-			const compatIdleTimeoutMs = (model.compat as { streamIdleTimeoutMs?: number } | undefined)
-				?.streamIdleTimeoutMs;
+			// env overrides still take precedence over the compat fallback. The
+			// annotated local up-casts the generic CompatOf<TApi> by assignment,
+			// so any compat shape redeclaring `streamIdleTimeoutMs` with another
+			// type is a compile error here.
+			const compat: CompatOf<Api> | undefined = model.compat;
+			const compatIdleTimeoutMs =
+				compat !== undefined && "streamIdleTimeoutMs" in compat ? compat.streamIdleTimeoutMs : undefined;
 			const idleTimeoutFallbackMs = compatIdleTimeoutMs ?? limits?.defaultIdleTimeoutMs;
 			const idleTimeoutMs = providerHandlesStreamTimeouts
 				? undefined

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -240,12 +240,19 @@ function forwardStream<TApi extends Api>(
 	(async () => {
 		try {
 			const providerHandlesStreamTimeouts = limits?.providerHandlesStreamTimeouts === true;
+			// Per-model catalog compat can widen the fallback watchdog for hosts
+			// with no keepalive events (e.g. Bedrock reasoning models that go
+			// quiet for minutes mid-thinking, issue #4758). Caller options and
+			// env overrides still take precedence over the compat fallback.
+			const compatIdleTimeoutMs = (model.compat as { streamIdleTimeoutMs?: number } | undefined)
+				?.streamIdleTimeoutMs;
+			const idleTimeoutFallbackMs = compatIdleTimeoutMs ?? limits?.defaultIdleTimeoutMs;
 			const idleTimeoutMs = providerHandlesStreamTimeouts
 				? undefined
 				: (options.streamIdleTimeoutMs ??
 					(limits?.openAIIdleEnvFloorsFirstEvent
-						? getOpenAIStreamIdleTimeoutMs(limits.defaultIdleTimeoutMs)
-						: getStreamIdleTimeoutMs(limits?.defaultIdleTimeoutMs)));
+						? getOpenAIStreamIdleTimeoutMs(idleTimeoutFallbackMs)
+						: getStreamIdleTimeoutMs(idleTimeoutFallbackMs)));
 			const firstItemTimeoutMs = providerHandlesStreamTimeouts
 				? 0
 				: (options.streamFirstEventTimeoutMs ??
@@ -311,6 +318,7 @@ function createLazyLoadErrorMessage<TApi extends Api>(
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		},
 		stopReason,
+		errorId: stopReason === "error" ? AIError.classify(error, model.api) || undefined : undefined,
 		errorMessage:
 			stopReason === "aborted" ? "Request was aborted" : error instanceof Error ? error.message : String(error),
 		timestamp: Date.now(),

--- a/packages/ai/test/register-builtins.test.ts
+++ b/packages/ai/test/register-builtins.test.ts
@@ -1,21 +1,25 @@
 import { describe, expect, it } from "bun:test";
+import * as AIError from "@oh-my-pi/pi-ai/error";
 import { setBedrockProviderModule, streamBedrock } from "@oh-my-pi/pi-ai/providers/register-builtins";
 import type { AssistantMessage, Context, Model } from "@oh-my-pi/pi-ai/types";
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
-function createModel(): Model<"bedrock-converse-stream"> {
+function createModel(
+	overrides: { reasoning?: boolean; compat?: { streamIdleTimeoutMs?: number } } = {},
+): Model<"bedrock-converse-stream"> {
 	return buildModel({
 		id: "mock-bedrock",
 		name: "Mock Bedrock",
 		api: "bedrock-converse-stream",
 		provider: "amazon-bedrock",
 		baseUrl: "https://example.invalid",
-		reasoning: false,
+		reasoning: overrides.reasoning ?? false,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 8192,
 		maxTokens: 2048,
+		compat: overrides.compat,
 	});
 }
 
@@ -125,6 +129,57 @@ describe("register-builtins lazy streams", () => {
 		expect(result).not.toBe("timeout");
 		if (result === "timeout") {
 			throw new Error("Timed out waiting for forwarded stream stall result");
+		}
+		expect(providerSignal?.aborted).toBe(true);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Provider stream stalled while waiting for the next event");
+		// The watchdog's StreamTimeoutError classification must survive onto the
+		// message so session-level auto-retry can classify it structurally.
+		expect(AIError.is(result.errorId, AIError.Flag.Transient)).toBe(true);
+		expect(AIError.is(result.errorId, AIError.Flag.Timeout)).toBe(true);
+		expect(AIError.retriable(result.errorId)).toBe(true);
+	});
+
+	it("honors model.compat.streamIdleTimeoutMs as the lazy watchdog fallback", async () => {
+		const partialMessage = createAssistantMessage("stop");
+		let providerSignal: AbortSignal | undefined;
+		const source = {
+			async *[Symbol.asyncIterator]() {
+				yield { type: "start", partial: partialMessage } as const;
+				yield { type: "text_delta", contentIndex: 0, delta: "hello", partial: partialMessage } as const;
+				const { promise, reject } = Promise.withResolvers<never>();
+				if (providerSignal?.aborted) {
+					reject(new Error("Request was aborted"));
+				}
+				providerSignal?.addEventListener("abort", () => reject(new Error("Request was aborted")), {
+					once: true,
+				});
+				await promise;
+			},
+		} as unknown as AssistantMessageEventStream;
+
+		setBedrockProviderModule({
+			streamBedrock: (_model, _context, options) => {
+				providerSignal = options.signal;
+				return source;
+			},
+		});
+
+		// No per-call option: the catalog compat override must reach the lazy
+		// watchdog (a stalled Bedrock stream previously waited the generic 300s
+		// default because model.compat was ignored on this path).
+		const model = createModel({ reasoning: true, compat: { streamIdleTimeoutMs: 20 } });
+		expect(model.compat.streamIdleTimeoutMs).toBe(20);
+		const stream = streamBedrock(model, baseContext, {});
+		// Real-clock race guard (matching this file's other lazy-stream tests):
+		// the lazy watchdog runs on the platform clock, so fake timers cannot
+		// drive it; the 20ms compat deadline settles the result long before the
+		// bound, which exists only to fail fast instead of hanging the test.
+		const result = await Promise.race([stream.result(), Bun.sleep(2_000).then(() => "timeout" as const)]);
+
+		expect(result).not.toBe("timeout");
+		if (result === "timeout") {
+			throw new Error("Timed out waiting for compat-driven stream stall result");
 		}
 		expect(providerSignal?.aborted).toBe(true);
 		expect(result.stopReason).toBe("error");

--- a/packages/ai/test/register-builtins.test.ts
+++ b/packages/ai/test/register-builtins.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, vi } from "bun:test";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { setBedrockProviderModule, streamBedrock } from "@oh-my-pi/pi-ai/providers/register-builtins";
 import type { AssistantMessage, Context, Model } from "@oh-my-pi/pi-ai/types";
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+async function drainMicrotasksUntil(predicate: () => boolean, errorMessage: string): Promise<void> {
+	for (let i = 0; i < 1000; i++) {
+		if (predicate()) return;
+		await Promise.resolve();
+	}
+	throw new Error(errorMessage);
+}
 
 function createModel(
 	overrides: { reasoning?: boolean; compat?: { streamIdleTimeoutMs?: number } } = {},
@@ -184,6 +192,81 @@ describe("register-builtins lazy streams", () => {
 		expect(providerSignal?.aborted).toBe(true);
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toBe("Provider stream stalled while waiting for the next event");
+	});
+
+	it("disables the lazy watchdog when model.compat.streamIdleTimeoutMs is 0", async () => {
+		vi.useFakeTimers();
+		try {
+			const partialMessage = createAssistantMessage("stop");
+			const abortController = new AbortController();
+			let providerSignal: AbortSignal | undefined;
+			let steadyState = false;
+			const source = {
+				async *[Symbol.asyncIterator]() {
+					yield { type: "start", partial: partialMessage } as const;
+					yield { type: "text_delta", contentIndex: 0, delta: "hello", partial: partialMessage } as const;
+					steadyState = true;
+					const { promise, reject } = Promise.withResolvers<never>();
+					if (providerSignal?.aborted) {
+						reject(new Error("Request was aborted"));
+					}
+					providerSignal?.addEventListener("abort", () => reject(new Error("Request was aborted")), {
+						once: true,
+					});
+					await promise;
+				},
+			} as unknown as AssistantMessageEventStream;
+
+			setBedrockProviderModule({
+				streamBedrock: (_model, _context, options) => {
+					providerSignal = options.signal;
+					return source;
+				},
+			});
+
+			// reasoning:true would floor the watchdog at 600s for this id — the
+			// explicit 0 override must disable it entirely through the lazy
+			// wrapper, not fall back to any default (e.g. via a `||` regression).
+			const model = createModel({ reasoning: true, compat: { streamIdleTimeoutMs: 0 } });
+			expect(model.compat.streamIdleTimeoutMs).toBe(0);
+			let settled = false;
+			// First-event watchdog stays out of this case's scope (mirrors the
+			// direct-Anthropic 0-disable test): fake-timer advancement could
+			// otherwise outrun the microtask that consumes the first event.
+			const resultPromise = streamBedrock(model, baseContext, {
+				signal: abortController.signal,
+				streamFirstEventTimeoutMs: 0,
+			}).result();
+			void resultPromise.then(
+				() => {
+					settled = true;
+				},
+				() => {
+					settled = true;
+				},
+			);
+
+			await drainMicrotasksUntil(
+				() => steadyState,
+				"Bedrock mock stream did not reach steady-state idle for the compat-disabled watchdog test",
+			);
+			// Well past the generic 300s idle budget: the disabled watchdog must
+			// not classify the post-first-event silence as a stall.
+			vi.advanceTimersByTime(400_000);
+			await drainMicrotasksUntil(
+				() => vi.getTimerCount() === 0,
+				"lazy watchdog timer did not drain after advancing past the idle budget",
+			);
+			expect(settled).toBe(false);
+			expect(providerSignal?.aborted).toBe(false);
+
+			abortController.abort();
+			const result = await resultPromise;
+			expect(result.stopReason).toBe("aborted");
+			expect(result.errorMessage).toBe("Request was aborted");
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("preserves caller aborts while forwarding lazy provider streams", async () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Widened the Amazon Bedrock stream idle-timeout floor for reasoning models (600s, matching the GLM coding-plan floor) and for adaptive-thinking Claude — Opus 4.7+, Sonnet/Opus 5, and Fable/Mythos 5, where stalls were most frequent — to 900s, matching the tolerance direct Anthropic gets from ping keepalives. Bedrock ConverseStream sends no keepalive events, so long quiet reasoning stretches previously tripped the generic 300s watchdog with `Provider stream stalled while waiting for the next event` during plan writing and todo execution. Explicit `compat.streamIdleTimeoutMs` overrides still win (`0` disables the watchdog) ([#7892](https://github.com/can1357/oh-my-pi/pull/7892) by [@voonfoo](https://github.com/voonfoo)).
+
 ## [17.2.10] - 2026-08-06
 
 ### Changed

--- a/packages/catalog/src/compat/bedrock.ts
+++ b/packages/catalog/src/compat/bedrock.ts
@@ -1,3 +1,4 @@
+import { supportsAdaptiveThinkingDisplay } from "../identity/family";
 import type { ModelSpec, ResolvedBedrockCompat } from "../types";
 import { applyCompatOverrides } from "./apply";
 
@@ -118,9 +119,35 @@ function detectedBedrockCompat(modelId: string): ResolvedBedrockCompat {
 	return NO_EXPLICIT_CHECKPOINTS;
 }
 
-/** Resolve Bedrock Converse prompt-cache capabilities once per model. */
+/**
+ * Bedrock ConverseStream sends no ping/keepalive events, so a reasoning model
+ * that goes quiet mid-thinking (summarized-display gaps, `omitted` thinking,
+ * or the wedged long tool-call generation of issue #4900) reads as a dead
+ * stream to the generic 300s idle watchdog and dies with "Provider stream
+ * stalled while waiting for the next event" (issue #4758's Bedrock variant).
+ * Widen the floor to 600s for reasoning models, mirroring the GLM coding-plan
+ * floor; explicit `spec.compat.streamIdleTimeoutMs` overrides still win.
+ */
+const BEDROCK_REASONING_STREAM_IDLE_TIMEOUT_MS = 600_000;
+/**
+ * Adaptive-thinking Claude (Opus 4.7+, Sonnet/Opus 5, Fable/Mythos 5) reasons
+ * for much longer stretches, and starting with Opus 4.7 / Fable 5 the
+ * Anthropic-side display default is `omitted` (issue #1373), so quiet gaps run
+ * longest on exactly this family — Fable 5 being the worst offender in the
+ * field. Direct Anthropic keeps these streams alive with ping keepalives and
+ * tolerates up to 3x the 300s idle budget of real-event silence (#4900);
+ * pingless Bedrock needs the same 900s tolerance in the raw idle floor.
+ */
+const BEDROCK_ADAPTIVE_THINKING_STREAM_IDLE_TIMEOUT_MS = 900_000;
+
+/** Resolve Bedrock Converse prompt-cache and stream-watchdog compat once per model. */
 export function buildBedrockCompat(spec: ModelSpec<"bedrock-converse-stream">): ResolvedBedrockCompat {
 	const compat = { ...detectedBedrockCompat(spec.id) };
+	compat.streamIdleTimeoutMs = spec.reasoning
+		? supportsAdaptiveThinkingDisplay(spec.id)
+			? BEDROCK_ADAPTIVE_THINKING_STREAM_IDLE_TIMEOUT_MS
+			: BEDROCK_REASONING_STREAM_IDLE_TIMEOUT_MS
+		: undefined;
 	applyCompatOverrides(compat, spec.compat);
 	return compat;
 }

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -518,6 +518,12 @@ export interface BedrockCompat {
 	 * Capability metadata only; zero means no explicit checkpoints.
 	 */
 	promptCacheMaximumCheckpoints?: number;
+	/**
+	 * Stream-watchdog idle-timeout fallback in ms; 0 disables the idle watchdog.
+	 * Undefined defers to `PI_STREAM_IDLE_TIMEOUT_MS`, then the legacy
+	 * `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` alias, then the 300s default.
+	 */
+	streamIdleTimeoutMs?: number;
 }
 
 /** Fully-resolved Bedrock Converse prompt-cache capabilities, materialized once by `buildModel`. */
@@ -526,6 +532,13 @@ export interface ResolvedBedrockCompat {
 	supportsLongPromptCacheRetention: boolean;
 	promptCacheMinimumTokens: number;
 	promptCacheMaximumCheckpoints: number;
+	/**
+	 * Stream-watchdog idle-timeout fallback in ms for hosts with no keepalive
+	 * events; 0 disables the idle watchdog. Undefined defers to
+	 * `PI_STREAM_IDLE_TIMEOUT_MS`, then the legacy
+	 * `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` alias, then the 300s default.
+	 */
+	streamIdleTimeoutMs?: number;
 }
 
 /**

--- a/packages/catalog/test/amazon-bedrock-opus-5.test.ts
+++ b/packages/catalog/test/amazon-bedrock-opus-5.test.ts
@@ -142,6 +142,8 @@ describe("Amazon Bedrock Claude Opus 5", () => {
 				supportsLongPromptCacheRetention: true,
 				promptCacheMinimumTokens: 512,
 				promptCacheMaximumCheckpoints: 4,
+				// reasoning:true adaptive-thinking family → 900s keepalive-free idle floor.
+				streamIdleTimeoutMs: 900_000,
 			});
 		}
 	});

--- a/packages/catalog/test/bedrock-prompt-cache.test.ts
+++ b/packages/catalog/test/bedrock-prompt-cache.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { supportsAdaptiveThinkingDisplay } from "@oh-my-pi/pi-catalog/identity";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
@@ -90,6 +91,9 @@ describe("Bedrock prompt-cache compat", () => {
 				supportsLongPromptCacheRetention: supportsLongRetention,
 				promptCacheMinimumTokens: minimumTokens,
 				promptCacheMaximumCheckpoints: minimumTokens === 0 ? 0 : 4,
+				// bedrockSpec is reasoning:true → keepalive-free idle floor applies
+				// (900s for the adaptive-thinking family, 600s otherwise).
+				streamIdleTimeoutMs: supportsAdaptiveThinkingDisplay(id) ? 900_000 : 600_000,
 			});
 		}
 	});
@@ -109,7 +113,11 @@ describe("Bedrock prompt-cache compat", () => {
 			"us.amazon.nova-premier-v1:0",
 			"global.amazon.nova-2-lite-v1:0",
 		] as const) {
-			expect(getBundledModel<"bedrock-converse-stream">("amazon-bedrock", id)?.compat).toEqual(expected);
+			const model = getBundledModel<"bedrock-converse-stream">("amazon-bedrock", id);
+			expect(model?.compat).toEqual({
+				...expected,
+				streamIdleTimeoutMs: model?.reasoning ? 600_000 : undefined,
+			});
 		}
 
 		// AWS documents in-region model IDs plus geo/global inference-profile IDs.
@@ -125,7 +133,7 @@ describe("Bedrock prompt-cache compat", () => {
 			"jp.amazon.nova-2-lite-v1:0",
 			"global.amazon.nova-2-lite-v1:0",
 		] as const) {
-			expect(buildModel(bedrockSpec({ id })).compat).toEqual(expected);
+			expect(buildModel(bedrockSpec({ id })).compat).toEqual({ ...expected, streamIdleTimeoutMs: 600_000 });
 		}
 	});
 

--- a/packages/catalog/test/bedrock-stream-idle-timeout.test.ts
+++ b/packages/catalog/test/bedrock-stream-idle-timeout.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+function bedrockSpec(
+	overrides: Partial<ModelSpec<"bedrock-converse-stream">> = {},
+): ModelSpec<"bedrock-converse-stream"> {
+	return {
+		id: "global.anthropic.claude-fable-5",
+		name: "Claude Fable 5",
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+		...overrides,
+	};
+}
+
+// Bedrock ConverseStream sends no ping keepalives, so reasoning models that go
+// quiet mid-thinking previously fell back to the generic 300s idle watchdog and
+// died with "Provider stream stalled while waiting for the next event" during
+// long plan-writing/reasoning phases (issue #4758's Bedrock variant, worst on
+// the adaptive-thinking Fable/Opus 4.7+ family).
+describe("Bedrock stream idle-timeout compat", () => {
+	test("widens the idle timeout to 900s for adaptive-thinking Claude", () => {
+		for (const id of [
+			"global.anthropic.claude-fable-5",
+			"global.anthropic.claude-fable-5-20260120-v1:0",
+			"us.anthropic.claude-opus-4-8",
+			"us.anthropic.claude-sonnet-5",
+			"us.anthropic.claude-opus-5",
+		]) {
+			expect(buildModel(bedrockSpec({ id })).compat.streamIdleTimeoutMs).toBe(900_000);
+		}
+	});
+
+	test("widens the idle timeout to 600s for other reasoning models", () => {
+		for (const id of [
+			"anthropic.claude-opus-4-6-v1",
+			"anthropic.claude-3-7-sonnet-20250219-v1:0",
+			"us.amazon.nova-premier-v1:0",
+		]) {
+			expect(buildModel(bedrockSpec({ id })).compat.streamIdleTimeoutMs).toBe(600_000);
+		}
+	});
+
+	test("leaves non-reasoning models on the generic default", () => {
+		expect(
+			buildModel(bedrockSpec({ id: "anthropic.claude-3-5-haiku-20241022-v1:0", reasoning: false })).compat
+				.streamIdleTimeoutMs,
+		).toBeUndefined();
+	});
+
+	test("explicit compat overrides win over the reasoning floors", () => {
+		expect(buildModel(bedrockSpec({ compat: { streamIdleTimeoutMs: 120_000 } })).compat.streamIdleTimeoutMs).toBe(
+			120_000,
+		);
+		// 0 disables the idle watchdog entirely.
+		expect(buildModel(bedrockSpec({ compat: { streamIdleTimeoutMs: 0 } })).compat.streamIdleTimeoutMs).toBe(0);
+	});
+});


### PR DESCRIPTION
## What

Fixes `Provider stream stalled while waiting for the next event` killing healthy AWS Bedrock turns (plan mode and todo execution), worst on Claude Fable 5.

- **catalog**: `BedrockCompat`/`ResolvedBedrockCompat` gain `streamIdleTimeoutMs`. `buildBedrockCompat` floors it at **600s for reasoning models** (GLM coding-plan precedent, #4758) and **900s for adaptive-thinking Claude** (Opus 4.7+, Sonnet/Opus 5, Fable/Mythos 5) — matching the tolerance direct Anthropic gets from ping keepalives (3× the 300s idle budget, #4900). Explicit `compat.streamIdleTimeoutMs` overrides win; `0` disables the watchdog.
- **ai**: the lazy provider wrapper (`register-builtins.ts`) resolves the idle watchdog as `options → env → model.compat → default` instead of ignoring model compat; terminal watchdog errors now carry the structural `errorId` (Transient|Timeout) onto the assistant message so session-level auto-retry classifies them without depending on error-message text.

## Why

Bedrock ConverseStream sends no ping/keepalive events, and Bedrock streams run through the lazy wrapper whose watchdog never consulted `model.compat.streamIdleTimeoutMs` — `BedrockCompat` did not even have the field. Long quiet reasoning stretches (summarized-display gaps, the `omitted` display default starting with Opus 4.7/Fable 5 per #1373, or wedged long tool-call generation per #4900) read as dead streams at the generic 300s deadline, and every auto-retry hit the same wall. Same failure family as the GLM coding-plan fix in #4758, which could not reach Bedrock because no compat plumbing existed for `bedrock-converse-stream`.

## Testing

- New `packages/catalog/test/bedrock-stream-idle-timeout.test.ts`: 900s adaptive tier (incl. Fable 5 across Bedrock id shapes), 600s reasoning tier, non-reasoning untouched, explicit override + `0`-disable.
- `packages/ai/test/register-builtins.test.ts`: lazy watchdog driven by a compat value with no per-call option (previously ignored → generic 300s), and stall results carry a retryable Transient|Timeout `errorId`.
- Compat `streamIdleTimeoutMs: 0` disables the watchdog end-to-end through the lazy wrapper: fake-timer test advances 400s past the generic budget, asserts no watchdog abort, then cancels cleanly (mirrors the direct-Anthropic `0`-disable test).
- Updated compat expectations in `bedrock-prompt-cache.test.ts` and `amazon-bedrock-opus-5.test.ts`.
- Full `packages/catalog` suite (567 pass) and `packages/ai` suite (3699 pass) green on this branch; `bun run check:ts` green across workspaces.
- Smoke: bundled `amazon-bedrock/global.anthropic.claude-fable-5` resolves `compat.streamIdleTimeoutMs = 900000`.

---

- [x] `bun check` passes (TS side; no Rust changes)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
