### PR TITLE
feat(coding-agent): routed provider-native models past snapcompact

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Remote MCP transports now enforce header precedence and origin policy: client-generated HTTP/MCP/authorization headers win over configured headers case-insensitively, and Agent Plugins servers never forward configured headers across a redirect to a different origin (method-changing redirects of JSON-RPC POSTs are refused). Agent Plugins stdio `env` values and remote `headers` are likewise exempt from config-value resolution (no ambient env-name lookup, no `!command` execution, empty values preserved).
 - Added `omp share <session>`: share a saved session by id prefix or `.jsonl` path without launching the agent — same encrypted upload, store selection, and `share.redactSecrets` handling as the `/share` slash command.
 
+### Changed
+
+- Auto-compaction and a bare `/compact` now use provider-native compaction instead of a local snapcompact archive when the active model supports it. The backend compacts server-side and keeps the encrypted history it replays into later turns, which a local image archive cannot preserve. An explicit `/compact snapcompact` still produces a local archive, and `compaction.remoteEnabled: false` opts out.
+
 ## [17.2.10] - 2026-08-06
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -689,13 +689,12 @@ export class SessionMaintenance {
 			// A bare `/compact` follows the same provider-native preference as auto
 			// compaction. An explicit `/compact snapcompact` is a deliberate local-only
 			// archive request and keeps its contract.
-			if (
-				wantsSnapcompact &&
-				!explicitSnapcompact &&
-				this.#model &&
-				shouldUseProviderNativeCompaction(this.#model, effectiveSettings)
-			) {
-				this.#host.emitNotice("info", nativeOverSnapcompactNotice(this.#model.provider), "compaction");
+			const manualNativeTarget =
+				wantsSnapcompact && !explicitSnapcompact
+					? this.#nativeCompactionTarget(compactionCandidates, effectiveSettings)
+					: undefined;
+			if (manualNativeTarget) {
+				this.#host.emitNotice("info", nativeOverSnapcompactNotice(manualNativeTarget.provider), "compaction");
 				wantsSnapcompact = false;
 			}
 			let snapcompactReady = wantsSnapcompact;
@@ -1499,6 +1498,24 @@ export class SessionMaintenance {
 		return this.resolveCompactionModelCandidates(this.#model, availableModels, filter);
 	}
 
+	/**
+	 * The compaction candidate that provider-native compaction would actually run
+	 * on, or undefined when the summary will be an ordinary LLM call.
+	 *
+	 * Keyed on the head of the candidate chain rather than on `#model`: both
+	 * summary paths consume `#getCompactionModelCandidates()`, whose first entry is
+	 * the active model's configured `compactionModel`. A native-capable active
+	 * model with a non-native `compactionModel` would otherwise skip snapcompact,
+	 * announce native replay, and then hand the work to the configured summarizer.
+	 */
+	#nativeCompactionTarget(
+		candidates: Model[],
+		settings: Pick<CompactionSettings, "remoteEnabled" | "remoteStreamingV2Enabled">,
+	): Model | undefined {
+		const target = candidates[0] ?? this.#model;
+		return target && shouldUseProviderNativeCompaction(target, settings) ? target : undefined;
+	}
+
 	resolveCompactionModelCandidates(
 		preferredModel: Model | null | undefined,
 		availableModels: Model[],
@@ -2230,12 +2247,15 @@ export class SessionMaintenance {
 				: compactionSettings.strategy === "handoff" && reason !== "overflow" && !suppressHandoff
 					? "handoff"
 					: "context-full";
-		if (
-			action === "snapcompact" &&
-			this.#model &&
-			shouldUseProviderNativeCompaction(this.#model, compactionSettings)
-		) {
-			this.#host.emitNotice("info", nativeOverSnapcompactNotice(this.#model.provider), "compaction");
+		const autoNativeTarget =
+			action === "snapcompact"
+				? this.#nativeCompactionTarget(
+						this.#getCompactionModelCandidates(this.#host.modelRegistry.getAvailable()),
+						compactionSettings,
+					)
+				: undefined;
+		if (autoNativeTarget) {
+			this.#host.emitNotice("info", nativeOverSnapcompactNotice(autoNativeTarget.provider), "compaction");
 			action = "context-full";
 		}
 		if (action === "snapcompact" && this.#model && !this.#model.input.includes("image")) {

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -165,6 +165,15 @@ const PRUNE_IDLE_FLUSH_MS = 90 * 60_000;
  */
 const COMPACTION_RECOVERY_BAND = 0.8;
 
+/**
+ * Provider-native compaction supersedes a local snapcompact archive: the
+ * backend compacts server-side and keeps the encrypted history it replays
+ * into later turns, which a local image archive cannot preserve.
+ */
+function nativeOverSnapcompactNotice(provider: string): string {
+	return `${provider} compacts server-side; using provider-native compaction instead of snapcompact.`;
+}
+
 function mergeLlmCompactionPreserveData(
 	hookPreserveData: Record<string, unknown> | undefined,
 	resultPreserveData: Record<string, unknown> | undefined,
@@ -662,14 +671,6 @@ export class SessionMaintenance {
 
 			const compactionPrep = await this.#prepareCompactionFromHooks(preparation, hookCompaction);
 
-			// Strategy honored on manual /compact too. Custom instructions (public
-			// user focus OR internal plan-mode guidance) imply a directed LLM
-			// summary; a text-only model cannot read snapcompact frames.
-			const wantsSnapcompact =
-				compactionPrep.kind !== "fromHook" &&
-				effectiveSettings.strategy === "snapcompact" &&
-				!customInstructions &&
-				!options?.internalGuidance;
 			// `/compact snapcompact` is an explicit no-LLM archive request: honor
 			// its contract by failing locally rather than silently shipping the
 			// transcript to a provider. The default-configured snapcompact
@@ -677,6 +678,26 @@ export class SessionMaintenance {
 			// auto-compaction path) so a routine /compact still completes on a
 			// text-only model (issue #5064).
 			const explicitSnapcompact = compactMode?.name === "snapcompact";
+			// Strategy honored on manual /compact too. Custom instructions (public
+			// user focus OR internal plan-mode guidance) imply a directed LLM
+			// summary; a text-only model cannot read snapcompact frames.
+			let wantsSnapcompact =
+				compactionPrep.kind !== "fromHook" &&
+				effectiveSettings.strategy === "snapcompact" &&
+				!customInstructions &&
+				!options?.internalGuidance;
+			// A bare `/compact` follows the same provider-native preference as auto
+			// compaction. An explicit `/compact snapcompact` is a deliberate local-only
+			// archive request and keeps its contract.
+			if (
+				wantsSnapcompact &&
+				!explicitSnapcompact &&
+				this.#model &&
+				shouldUseProviderNativeCompaction(this.#model, effectiveSettings)
+			) {
+				this.#host.emitNotice("info", nativeOverSnapcompactNotice(this.#model.provider), "compaction");
+				wantsSnapcompact = false;
+			}
 			let snapcompactReady = wantsSnapcompact;
 			const snapcompactShapeSetting = this.#host.settings.get("snapcompact.shape");
 			let snapcompactShape: snapcompact.Shape | undefined;
@@ -2209,6 +2230,14 @@ export class SessionMaintenance {
 				: compactionSettings.strategy === "handoff" && reason !== "overflow" && !suppressHandoff
 					? "handoff"
 					: "context-full";
+		if (
+			action === "snapcompact" &&
+			this.#model &&
+			shouldUseProviderNativeCompaction(this.#model, compactionSettings)
+		) {
+			this.#host.emitNotice("info", nativeOverSnapcompactNotice(this.#model.provider), "compaction");
+			action = "context-full";
+		}
 		if (action === "snapcompact" && this.#model && !this.#model.input.includes("image")) {
 			this.#host.emitNotice(
 				"warning",

--- a/packages/coding-agent/test/agent-session-manual-snapcompact-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-manual-snapcompact-fallback.test.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import type { Message, Model } from "@oh-my-pi/pi-ai";
-import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -43,19 +43,23 @@ describe("AgentSession manual snapcompact text-only fallback", () => {
 		}
 	});
 
-	async function createHarness(): Promise<{
+	async function createHarness(
+		modelRef: { provider: GeneratedProvider; id: string } = {
+			provider: "aimlapi",
+			id: "alibaba/qwen3-coder-480b-a35b-instruct",
+		},
+	): Promise<{
 		session: AgentSession;
 		sessionManager: SessionManager;
 		activeModel: Model;
 		notices: string[];
 	}> {
-		const activeModel = getBundledModel("aimlapi", "alibaba/qwen3-coder-480b-a35b-instruct");
-		if (!activeModel) throw new Error("Expected bundled text-only model");
-		expect(activeModel.input).not.toContain("image");
+		const activeModel = getBundledModel(modelRef.provider, modelRef.id);
+		if (!activeModel) throw new Error(`Missing bundled model ${modelRef.provider}/${modelRef.id}`);
 
-		tempDir = TempDir.createSync("@pi-manual-snapcompact-text-only-");
+		tempDir = TempDir.createSync("@pi-manual-snapcompact-");
 		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
-		authStorage.setRuntimeApiKey("aimlapi", "test-key");
+		authStorage.setRuntimeApiKey(modelRef.provider, "test-key");
 		const modelRegistry = new ModelRegistry(authStorage);
 
 		const agent = new Agent({
@@ -101,6 +105,7 @@ describe("AgentSession manual snapcompact text-only fallback", () => {
 
 	it("falls back to LLM compaction instead of throwing on a text-only active model", async () => {
 		const harness = await createHarness();
+		expect(harness.activeModel.input).not.toContain("image");
 
 		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async (preparation, model) => ({
 			summary: "llm summary",
@@ -130,6 +135,7 @@ describe("AgentSession manual snapcompact text-only fallback", () => {
 
 	it("still fails locally for explicit /compact snapcompact on a text-only model (no-LLM contract)", async () => {
 		const harness = await createHarness();
+		expect(harness.activeModel.input).not.toContain("image");
 
 		const compactSpy = vi.spyOn(compactionModule, "compact");
 
@@ -143,5 +149,39 @@ describe("AgentSession manual snapcompact text-only fallback", () => {
 			`snapcompact needs a vision-capable model (${harness.activeModel.id} is text-only)`,
 		);
 		expect(harness.sessionManager.getBranch().find(entry => entry.type === "compaction")).toBeUndefined();
+	});
+
+	it("uses provider-native compaction for a bare /compact on codex", async () => {
+		const harness = await createHarness({ provider: "openai-codex", id: "gpt-5.5" });
+
+		const compactSpy = vi.spyOn(compactionModule, "compact").mockImplementation(async (preparation, model) => ({
+			summary: "llm summary",
+			shortSummary: "llm",
+			firstKeptEntryId: preparation.firstKeptEntryId,
+			tokensBefore: 42,
+			details: { provider: model.provider, model: model.id },
+		}));
+
+		await harness.session.compact();
+
+		expect(compactSpy).toHaveBeenCalled();
+		expect(harness.notices).toContain(
+			"openai-codex compacts server-side; using provider-native compaction instead of snapcompact.",
+		);
+		expect(harness.sessionManager.getBranch().find(entry => entry.type === "compaction")).toMatchObject({
+			type: "compaction",
+			summary: "llm summary",
+		});
+	});
+
+	it("keeps the local-only contract for explicit /compact snapcompact on codex", async () => {
+		const harness = await createHarness({ provider: "openai-codex", id: "gpt-5.3-codex-spark" });
+
+		await expect(harness.session.compact(undefined, { mode: "snapcompact" })).rejects.toThrow(
+			"snapcompact cannot run locally: gpt-5.3-codex-spark is text-only.",
+		);
+		expect(harness.notices).not.toContain(
+			"openai-codex compacts server-side; using provider-native compaction instead of snapcompact.",
+		);
 	});
 });

--- a/packages/coding-agent/test/agent-session-snapcompact-auto-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-auto-fallback.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import type { Message } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -23,13 +24,29 @@ interface Harness {
 
 interface HarnessOptions {
 	activeModel: { provider: GeneratedProvider; id: string };
+	/** Configured `compactionModel` for the active model, as `provider/id`. */
+	compactionModel?: { provider: GeneratedProvider; id: string };
 	seedMessages?: Message[];
 }
 
 async function createHarness(tempDir: TempDir, authStorage: AuthStorage, options: HarnessOptions): Promise<Harness> {
-	const activeModel = getBundledModel(options.activeModel.provider, options.activeModel.id);
-	if (!activeModel) throw new Error(`Missing bundled model ${options.activeModel.provider}/${options.activeModel.id}`);
+	const bundledModel = getBundledModel(options.activeModel.provider, options.activeModel.id);
+	if (!bundledModel)
+		throw new Error(`Missing bundled model ${options.activeModel.provider}/${options.activeModel.id}`);
 	authStorage.setRuntimeApiKey(options.activeModel.provider, "test-key");
+	let activeModel = bundledModel;
+	if (options.compactionModel) {
+		const target = getBundledModel(options.compactionModel.provider, options.compactionModel.id);
+		if (!target) {
+			throw new Error(`Missing bundled model ${options.compactionModel.provider}/${options.compactionModel.id}`);
+		}
+		authStorage.setRuntimeApiKey(target.provider, "test-key");
+		activeModel = buildModel({
+			...bundledModel,
+			compactionModel: `${target.provider}/${target.id}`,
+			compat: bundledModel.compatConfig,
+		});
+	}
 
 	const modelRegistry = new ModelRegistry(authStorage);
 	const agent = new Agent({
@@ -214,5 +231,34 @@ describe("AgentSession auto-compaction provider-native override", () => {
 		expect(harness.notices).toContain(
 			"openai-codex compacts server-side; using provider-native compaction instead of snapcompact.",
 		);
+	});
+
+	it("keeps snapcompact when a configured compactionModel is not provider-native", async () => {
+		tempDir = TempDir.createSync("@pi-codex-native-compaction-model-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		// The summary runs on the head of the candidate chain, which is the
+		// configured compactionModel — not the codex active model. Announcing
+		// provider-native replay here would skip snapcompact and then hand the
+		// work to an ordinary LLM summary, losing both.
+		const harness = await createHarness(tempDir, authStorage, {
+			activeModel: { provider: "openai-codex", id: "gpt-5.5" },
+			compactionModel: { provider: "aimlapi", id: "claude-sonnet-4-5-20250929" },
+			seedMessages: [{ role: "user", content: UNRENDERABLE_SNAPCOMPACT_TEXT.repeat(10), timestamp: Date.now() }],
+		});
+		session = harness.session;
+		harness.triggerThreshold();
+
+		const result = await harness.awaitCompactionEnd();
+		expect(harness.notices).not.toContain(
+			"openai-codex compacts server-side; using provider-native compaction instead of snapcompact.",
+		);
+		// snapcompact was still attempted: it is the unrenderable-glyph preflight,
+		// not the native guard, that produced the context-full downgrade.
+		expect(
+			harness.notices.find(message =>
+				message.startsWith("snapcompact disabled: unsupported characters for selected snapcompact font"),
+			),
+		).toBeDefined();
+		expect(result.action).toBe("context-full");
 	});
 });

--- a/packages/coding-agent/test/agent-session-snapcompact-auto-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-auto-fallback.test.ts
@@ -172,9 +172,47 @@ describe("AgentSession auto-snapcompact local-blocker fallback", () => {
 		);
 		expect(unsupportedGlyphNotice).toBeDefined();
 		expect(unsupportedGlyphNotice).toContain("using context-full auto-compaction instead.");
+		expect(harness.notices).not.toContain(
+			"aimlapi compacts server-side; using provider-native compaction instead of snapcompact.",
+		);
 		expect(harness.sessionManager.getBranch().find(entry => entry.type === "compaction")).toMatchObject({
 			type: "compaction",
 			summary: "compacted",
 		});
+	});
+});
+
+describe("AgentSession auto-compaction provider-native override", () => {
+	let session: AgentSession | undefined;
+	let authStorage: AuthStorage | undefined;
+	let tempDir: TempDir | undefined;
+
+	afterEach(async () => {
+		try {
+			await session?.dispose();
+		} finally {
+			authStorage?.close();
+			await tempDir?.remove();
+			vi.restoreAllMocks();
+			session = undefined;
+			authStorage = undefined;
+			tempDir = undefined;
+		}
+	});
+
+	it("routes a codex session to provider-native compaction instead of snapcompact", async () => {
+		tempDir = TempDir.createSync("@pi-codex-native-compaction-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const harness = await createHarness(tempDir, authStorage, {
+			activeModel: { provider: "openai-codex", id: "gpt-5.5" },
+		});
+		session = harness.session;
+		harness.triggerThreshold();
+
+		const result = await harness.awaitCompactionEnd();
+		expect(result.action).toBe("context-full");
+		expect(harness.notices).toContain(
+			"openai-codex compacts server-side; using provider-native compaction instead of snapcompact.",
+		);
 	});
 });


### PR DESCRIPTION
Fixes #7898

## What

Auto-compaction and a bare `/compact` now route past a local snapcompact archive when the active model supports provider-native compaction, so the backend compacts server-side instead.

Two guards in `packages/coding-agent/src/session/session-maintenance.ts`, both keyed on the existing `shouldUseProviderNativeCompaction` predicate:

| Path | Before | After |
| --- | --- | --- |
| auto-compaction | `action = "snapcompact"` | `action = "context-full"` + info notice |
| bare `/compact` | `wantsSnapcompact = true` | `wantsSnapcompact = false` + info notice |
| explicit `/compact snapcompact` | local archive | unchanged |
| `compaction.remoteEnabled: false` | local archive | unchanged — documented opt-out |

## Why

A model that compacts server-side keeps encrypted history that the backend replays into every later turn. A local snapcompact archive cannot preserve that history, so a Codex session on the default `snapcompact` strategy silently traded its native replay for an image archive, and paid local render cost to do it. The provider-native branch is reachable only through the summarizer path, which a successful local snapcompact never reaches.

The auto guard is placed ahead of the existing text-only vision check on purpose. A text-only native model (`gpt-5.3-codex-spark`) already landed on `context-full`, but via the misleading `snapcompact needs a vision-capable active model` warning. Both paths still reach `context-full`; only one states the real reason. The notice is `info`, not `warning` — this is the preferred path, not a degradation.

Gating on `shouldUseProviderNativeCompaction` rather than a provider name is deliberate: it already covers both the Codex and V2-streaming paths, and it already honors `compaction.remoteEnabled: false`. All seven bundled `openai-codex` models return true from it and from `shouldUseOpenAiRemoteCompaction`, and false under `remoteEnabled: false`; `aimlapi/alibaba/qwen3-coder-480b-a35b-instruct` returns false throughout.

## Testing

Verified on this branch rebased onto `main` at `ab78d3091e`.

- `bun test packages/coding-agent/test/*compact*.test.ts` — 201 pass, 13 skip, 0 fail across 25 files.
- New `routes a codex session to provider-native compaction instead of snapcompact` asserts `action === "context-full"` plus the exact notice on `openai-codex/gpt-5.5`. That model is vision-capable, so neither the text-only guard nor a glyph blocker can produce that result — the assertion isolates the new guard.
- New `uses provider-native compaction for a bare /compact on codex` and `keeps the local-only contract for explicit /compact snapcompact on codex` (the latter on `gpt-5.3-codex-spark`, the one bundled text-only Codex model, so the local-only contract is provable through the existing throw without rendering frames).
- Control: the existing `aimlapi` unsupported-glyph test now asserts the new notice is absent.
- Mutation-checked: negating the auto guard makes its test fail with `action` `"snapcompact"`; negating the manual guard makes the bare-`/compact` test fail with `compact` never called. Both restored.
- Review fix (43ac0450b5): both guards now resolve the head of the compaction candidate chain rather than the active model, because a configured `compactionModel` is that head. New `keeps snapcompact when a configured compactionModel is not provider-native` covers a Codex session with `aimlapi/claude-sonnet-4-5-20250929` as `compactionModel`: it asserts the native notice is absent *and* the glyph-preflight warning present, proving snapcompact was attempted rather than skipped. Mutation-checked — resolving back to `this.#model` reproduces the reported symptom exactly.

`packages/coding-agent/test/agent-session-manual-snapcompact-fallback.test.ts` gained a model parameter on its local `createHarness`. Its harness-internal `expect(activeModel.input).not.toContain("image")` moved into the two tests that rely on it, so the guarantee stays where it is load-bearing.

Pre-existing check debt, untouched by this PR: `biome check` reports one formatter error in `packages/utils/src/frontmatter.ts`, which reproduces on a pristine `upstream/main` worktree at `ab78d3091e`. Every other workspace `check` exits 0. Not folded in here — a formatting sweep does not belong in a behavioral change.

---

- [ ] `bun check` passes — every workspace check exits 0 except the inherited `packages/utils/src/frontmatter.ts` format error described above
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

