### PR TITLE
fix(session): surface real handoff errors instead of false cancel

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Remote MCP transports now enforce header precedence and origin policy: client-generated HTTP/MCP/authorization headers win over configured headers case-insensitively, and Agent Plugins servers never forward configured headers across a redirect to a different origin (method-changing redirects of JSON-RPC POSTs are refused). Agent Plugins stdio `env` values and remote `headers` are likewise exempt from config-value resolution (no ambient env-name lookup, no `!command` execution, empty values preserved).
 - Added `omp share <session>`: share a saved session by id prefix or `.jsonl` path without launching the agent — same encrypted upload, store selection, and `share.redactSecrets` handling as the `/share` slash command.
 
+### Fixed
+
+- Fixed `/handoff` reporting "Handoff cancelled" for real generation failures. A provider error named `AbortError` (e.g. a stalled/idle-timed-out stream) no longer masquerades as a user cancellation; the actual error now surfaces unless the handoff was genuinely aborted ([#7903](https://github.com/can1357/oh-my-pi/issues/7903)).
+
 ## [17.2.10] - 2026-08-06
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1436,7 +1436,10 @@ export class CommandController {
 			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			if (message === "Handoff cancelled" || (error instanceof Error && error.name === "AbortError")) {
+			// `session.handoff()` normalizes genuine cancellations to this exact message; a
+			// provider error (even one named AbortError) is re-thrown verbatim so it surfaces
+			// as a real failure instead of a false "cancelled".
+			if (message === "Handoff cancelled") {
 				this.ctx.showError("Handoff cancelled");
 			} else {
 				this.ctx.showError(`Handoff failed: ${message}`);

--- a/packages/coding-agent/src/session/session-handoff.ts
+++ b/packages/coding-agent/src/session/session-handoff.ts
@@ -309,7 +309,11 @@ export class SessionHandoff {
 
 			return { document: handoffText, savedPath };
 		} catch (error) {
-			if (handoffSignal.aborted || (error instanceof Error && error.name === "AbortError")) {
+			// Only a genuine abort (user Esc or the source turn cancelling) is a
+			// cancellation. A provider that throws a name==="AbortError" error without the
+			// handoff signal being aborted (stall/idle timeout, nested resolution failure)
+			// is a real failure and must surface verbatim, not be masked as "cancelled".
+			if (handoffSignal.aborted) {
 				throw new Error("Handoff cancelled");
 			}
 			throw error;

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -2010,4 +2010,19 @@ describe("AgentSession handoff", () => {
 		expect(generateHandoffSpy).toHaveBeenCalledTimes(1);
 		expect(generateHandoffSpy.mock.calls[0]?.[2]?.streamOptions?.signal?.aborted).toBe(true);
 	});
+
+	it("surfaces the real error when generation fails without a user abort", async () => {
+		// Providers throw name==="AbortError" errors on non-user conditions (stalls,
+		// nested resolution failures). The handoff signal is never aborted here, so the
+		// failure must surface verbatim instead of being masked as "Handoff cancelled".
+		const providerError = new Error("Deepseek stream stalled");
+		providerError.name = "AbortError";
+		const generateHandoffSpy = vi
+			.spyOn(compactionModule, "generateHandoffFromContext")
+			.mockRejectedValue(providerError);
+
+		await expect(session.handoff()).rejects.toThrow("Deepseek stream stalled");
+		expect(generateHandoffSpy).toHaveBeenCalledTimes(1);
+		expect(session.isGeneratingHandoff).toBe(false);
+	});
 });

--- a/packages/coding-agent/test/modes/controllers/handoff-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/handoff-command.test.ts
@@ -90,6 +90,42 @@ describe("/handoff command", () => {
 		expect(ctx.session.handoff).toHaveBeenCalledWith("focus on tests");
 	});
 
+	it("surfaces a provider failure named AbortError as a real error, not a cancellation", async () => {
+		// Regression: the catch used to map any name==="AbortError" error to
+		// "Handoff cancelled". session.handoff() now normalizes genuine cancellations
+		// to the exact "Handoff cancelled" message and re-throws real provider failures
+		// verbatim, so the controller must report those as a failure.
+		const providerError = new Error("Deepseek stream stalled");
+		providerError.name = "AbortError";
+		const showError = vi.fn();
+		const statusContainer = createContainer();
+		const ctx = {
+			sessionManager: {
+				getEntries: () => [{ type: "message" }, { type: "message" }],
+			},
+			session: {
+				handoff: vi.fn(async () => {
+					throw providerError;
+				}),
+				abortHandoff: vi.fn(),
+			},
+			loadingAnimation: undefined,
+			statusContainer,
+			chatContainer: createContainer(),
+			ui: { requestRender: vi.fn(), requestComponentRender: vi.fn() },
+			editor: { onEscape: vi.fn() },
+			showError,
+			showStatus: vi.fn(),
+			showWarning: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new CommandController(ctx);
+
+		await controller.handleHandoffCommand();
+
+		expect(showError).toHaveBeenCalledTimes(1);
+		expect(showError).toHaveBeenCalledWith("Handoff failed: Deepseek stream stalled");
+	});
+
 	it("refuses to hand off while a response is streaming", async () => {
 		// Bug: /handoff dispatches before the streaming-queue branch, so without a
 		// guard it resets the agent mid-turn and the live stream keeps emitting into

--- a/packages/utils/src/frontmatter.ts
+++ b/packages/utils/src/frontmatter.ts
@@ -126,7 +126,15 @@ export function parseFrontmatter(
 	content: string,
 	options?: FrontmatterOptions,
 ): { frontmatter: Record<string, unknown>; body: string } {
-	const { location, source, fallback, normalize = true, level = "warn", repair = true, rawKeys = false } = options ?? {};
+	const {
+		location,
+		source,
+		fallback,
+		normalize = true,
+		level = "warn",
+		repair = true,
+		rawKeys = false,
+	} = options ?? {};
 	const finalizeKeys = (fm: Record<string, unknown>): Record<string, unknown> =>
 		rawKeys ? fm : normalizeFrontmatterKeys(fm);
 	const loc = location ?? source;


### PR DESCRIPTION
## Repro
Running `/handoff` against a provider that stalls or otherwise fails during generation shows "Handoff cancelled" even though the user never cancelled, giving no clue why it failed (reported with Deepseek Flash 0731). Reproduced with a unit test that rejects generation with an `AbortError`-named error while the handoff signal is not aborted:

```
bun test test/agent-session-handoff.test.ts -t "surfaces the real error when generation fails without a user abort"
# before fix: Expected substring "Deepseek stream stalled" / Received message "Handoff cancelled"
```

## Cause
Both `SessionHandoff.handoff()` (`packages/coding-agent/src/session/session-handoff.ts`) and `CommandController.handleHandoffCommand()` (`packages/coding-agent/src/modes/controllers/command-controller.ts`) mapped any error with `name === "AbortError"` to "Handoff cancelled" regardless of whether `handoffSignal.aborted` was set. Providers throw name-`AbortError` errors on non-user conditions (stalls, idle timeouts, nested resolution failures — see `packages/ai/src/error/abort.ts` and its throw sites), so genuine generation failures were reported as user cancellations and the real message was discarded.

## Fix
- `session-handoff.ts`: in the final `catch`, only rewrite to "Handoff cancelled" when `handoffSignal.aborted` is truly set; otherwise re-throw the original error verbatim.
- `command-controller.ts`: drop the redundant `error.name === "AbortError"` branch and trust the normalized `"Handoff cancelled"` message, so a re-thrown provider failure renders as `Handoff failed: <message>`.
- Added regression tests at both layers (session and controller); changelog entry under `[Unreleased]`.
- Out of scope: automatic retry (the reporter's other ask) is a behavior change with design decisions left to a maintainer.

## Verification
`bun test test/agent-session-handoff.test.ts test/modes/controllers/handoff-command.test.ts` — 40 pass, 0 fail. The new session-level test now rejects with the real message and the controller test surfaces `Handoff failed: Deepseek stream stalled`; existing cancellation tests still assert "Handoff cancelled" for genuine aborts.

Fixes #7903