### PR TITLE
fix(mnemopi): drop /i flag defeating extractLocation's capital-letter intent

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the heuristic gist `extractLocation` regex applying the `/i` flag over its `[A-Z]` proper-noun requirement, which nullified the capital-letter signal and let arbitrary lowercase mid-sentence prose (e.g. `"...in your loaded context plus"`) be stored as a location. ([#7917](https://github.com/can1357/oh-my-pi/issues/7917))
+
 ## [17.2.10] - 2026-08-06
 
 ### Changed

--- a/packages/mnemopi/src/core/episodic-graph.ts
+++ b/packages/mnemopi/src/core/episodic-graph.ts
@@ -590,7 +590,7 @@ export class EpisodicGraph {
 
 	private extractLocation(content: string): string | null {
 		const properPlace =
-			/\b(?:at|in|from)\s+([A-Z][a-zA-Z\s]+?)(?:\s+(?:yesterday|today|tomorrow|now|last|next|on|at)\b|$)/i.exec(
+			/\b(?:at|in|from)\s+([A-Z][a-zA-Z\s]+?)(?:\s+(?:yesterday|today|tomorrow|now|last|next|on|at)\b|$)/.exec(
 				content,
 			);
 		if (properPlace?.[1] !== undefined) return properPlace[1].trim();

--- a/packages/mnemopi/test/graph-tools.test.ts
+++ b/packages/mnemopi/test/graph-tools.test.ts
@@ -50,6 +50,19 @@ describe("EpisodicGraph CRUD", () => {
 	});
 });
 
+describe("EpisodicGraph gist location extraction", () => {
+	it("captures capitalized proper-noun places and ignores lowercase prose", () => {
+		withGraph(graph => {
+			expect(graph.extractGist("Met Bob in Paris yesterday.", "mem_loc_1").location).toBe("Paris");
+			// Regression for #7917: the /i flag made [A-Z] match lowercase mid-sentence
+			// prose, so ordinary text like "...in your loaded context plus" leaked in as a location.
+			expect(graph.extractGist("We stored the summary in your loaded context plus.", "mem_loc_2").location).toBe(
+				null,
+			);
+		});
+	});
+});
+
 describe("EpisodicGraph links and traversal", () => {
 	it("creates idempotent weighted links and traverses neighborhoods", () => {
 		withGraph(graph => {


### PR DESCRIPTION
## Repro
The heuristic gist layer's `extractLocation` in `packages/mnemopi/src/core/episodic-graph.ts` requires a capitalized proper-noun place via `[A-Z]` but applies the `/i` flag, nullifying the class. Ordinary lowercase mid-sentence prose then matches, so `"...in your loaded context plus..."` is stored as `location: "your loaded context plus"`. Reproduced:

```
$ bun -e "const re=/\b(?:at|in|from)\s+([A-Z][a-zA-Z\s]+?)(?:\s+(?:yesterday|today|tomorrow|now|last|next|on|at)\b|$)/i; console.log(re.exec('We stored the summary in your loaded context plus')?.[1])"
your loaded context plus
```

## Cause
`EpisodicGraph.extractLocation` (`packages/mnemopi/src/core/episodic-graph.ts:591-599`) used a regex whose `[A-Z]` first-character class is the entire signal that the token after `at|in|from` is a proper noun, but the trailing `/i` flag made `[A-Z]` case-insensitive, so any lowercase word qualified. The sibling proper-noun heuristics in the same file (`extractParticipants`, `extractFacts`) are already case-sensitive without `/i`.

## Fix
- Dropped the `/i` flag from the `properPlace` regex in `extractLocation`, restoring the capital-letter proper-noun requirement and matching the file's existing case-sensitive convention. Lowercase connectives (`at|in|from`) and trailing temporal words remain lowercase in normal prose, so recall is unaffected; capitalized proper nouns (`"...in Paris yesterday"` -> `Paris`) still match.
- Added a regression test in `packages/mnemopi/test/graph-tools.test.ts` asserting proper nouns are captured and lowercase prose yields `null`.
- Added an `[Unreleased]` changelog entry.

## Verification
`bun test test/graph-tools.test.ts` in `packages/mnemopi` — 6 pass, 0 fail (including the pre-existing "at the office" gist test). The new test fails on the old `/i` regex and passes after the fix.

Fixes #7917