### PR TITLE
fix(mnemopi): make episodic participant extraction Unicode-aware

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Made episodic gist participant extraction Unicode-aware so proper nouns in non-Latin cased scripts (Greek, Cyrillic, …) are captured; the previous ASCII-only `[A-Z][a-z]+`/`\b` regex extracted zero participants from any non-English memory. ([#7918](https://github.com/can1357/oh-my-pi/issues/7918))
+
 ## [17.2.10] - 2026-08-06
 
 ### Changed

--- a/packages/mnemopi/src/core/episodic-graph.ts
+++ b/packages/mnemopi/src/core/episodic-graph.ts
@@ -565,7 +565,14 @@ export class EpisodicGraph {
 	}
 
 	private extractParticipants(content: string): string[] {
-		const names = Array.from(content.matchAll(/\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)\b/g), match => match[1] ?? "");
+		// Match capitalized proper nouns across cased scripts (Latin, Greek, Cyrillic, …).
+		// `[A-Z][a-z]+` plus ASCII `\b` matched no non-Latin token, so any non-English
+		// memory produced zero participants (issue #7918). Unicode property escapes with
+		// the `u` flag, and `\p{L}`-based lookaround boundaries in place of `\b`, fix that.
+		const names = Array.from(
+			content.matchAll(/(?<![\p{L}\p{N}_])(\p{Lu}\p{Ll}+(?:\s+\p{Lu}\p{Ll}+)?)(?![\p{L}\p{N}_])/gu),
+			match => match[1] ?? "",
+		);
 		const pronouns = Array.from(
 			content.matchAll(/\b(I|you|we|they|he|she|it|me|us|them|him|her)\b/gi),
 			match => match[1] ?? "",

--- a/packages/mnemopi/test/graph-tools.test.ts
+++ b/packages/mnemopi/test/graph-tools.test.ts
@@ -50,6 +50,23 @@ describe("EpisodicGraph CRUD", () => {
 	});
 });
 
+describe("EpisodicGraph non-Latin participants", () => {
+	it("extracts proper nouns from Greek and Cyrillic content (issue #7918)", () => {
+		withGraph(graph => {
+			const greek = graph.extractGist("Ο Βασίλης συνάντησε τη Μαρία στην Αθήνα.", "mem_el");
+			expect(greek.participants).toContain("Βασίλης");
+			expect(greek.participants).toContain("Μαρία");
+
+			const cyrillic = graph.extractGist("Иван встретил Анну в Москве.", "mem_ru");
+			expect(cyrillic.participants).toContain("Иван");
+			expect(cyrillic.participants).toContain("Анну");
+
+			graph.storeGist(greek, "mem_el");
+			expect(graph.findGistsByParticipant("Βασίλης")).toHaveLength(1);
+		});
+	});
+});
+
 describe("EpisodicGraph links and traversal", () => {
 	it("creates idempotent weighted links and traverses neighborhoods", () => {
 		withGraph(graph => {


### PR DESCRIPTION
## Repro
On a bilingual vault the episodic gist layer extracts no participants from non-Latin content. Driving `EpisodicGraph.extractGist` directly reproduces it: `extractGist("Ο Βασίλης συνάντησε τη Μαρία στην Αθήνα.", …).participants` returns `[]`, while ordinary English prose yields sentence-initial garbage (`["Two","Where","List","Revenue","They"]`). Command: `bun packages/mnemopi/repro7918.ts` (a throwaway script calling `extractGist` on Greek and English strings).

## Cause
`extractParticipants` (`packages/mnemopi/src/core/episodic-graph.ts:568`) matched names with `/\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)\b/g`. `[A-Z][a-z]+` is ASCII-only and JS `\b` is defined against `\w` (also ASCII), so no Greek/Cyrillic/other non-Latin token can ever match. `extractGist` is the sole populator of `gist.participants`, so every non-English memory got a permanently-empty participant set — inconsistent with the package's multilingual embedding variant and its multilingual LLM extraction path.

## Fix
- Replaced the ASCII regex in `extractParticipants` with Unicode property escapes under the `u` flag: `\p{Lu}\p{Ll}+(?:\s+\p{Lu}\p{Ll}+)?`.
- Swapped ASCII `\b` for Unicode-aware lookaround boundaries `(?<![\p{L}\p{N}_])` / `(?![\p{L}\p{N}_])`.
- Added a regression test in `packages/mnemopi/test/graph-tools.test.ts` asserting Greek (`Βασίλης`, `Μαρία`) and Cyrillic (`Иван`, `Анну`) proper nouns are extracted and are queryable via `findGistsByParticipant`.
- CHANGELOG entry under `[Unreleased]`.

Scope note: `extractLocation`'s Latin-capital/`/i` behavior is tracked separately in #7917 and is left untouched here; emotion remains keyword-based (an inherent heuristic-layer limitation the reporter acknowledged is unenumerable per-language). English participant output is byte-identical, so the sentence-initial false positives are unchanged — that is the separate heuristic limitation, not this fix's concern.

## Verification
`bun test test/graph-tools.test.ts test/beam-store.test.ts test/orchestrator.test.ts test/polyphonic-recall.test.ts test/entities.test.ts` → 34 pass, 0 fail. New test confirms Greek/Cyrillic extraction; existing English assertions (`Alice`, `Bob`) still pass. Fixes #7918