### PR TITLE
fix(mnemopi): recover from partially-extracted embedding model cache

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Recover from a partially-extracted local embedding model cache. An interrupted fastembed model download left `<cacheDir>/<model>/` with sidecars and a truncated `model.onnx_data` but no `model.onnx`, which upstream `retrieveModel` treats as complete forever, so `FlagEmbedding.init` threw `Model file not found at .../model.onnx` every session — semantic recall was silently dead machine-wide and the rebuild queue grew every open. A `Model file not found` init failure now clears the incomplete model directory and the leftover partial `<model>.tar.gz` (which upstream would otherwise reuse) and retries init once, so the next attempt re-downloads cleanly. ([#7916](https://github.com/can1357/oh-my-pi/issues/7916))
+
 ## [17.2.10] - 2026-08-06
 
 ### Changed

--- a/packages/mnemopi/src/core/embeddings.ts
+++ b/packages/mnemopi/src/core/embeddings.ts
@@ -92,6 +92,41 @@ export async function quarantineCorruptModelFile(message: string, cacheDir?: str
 	return true;
 }
 
+/**
+ * Recover from a partially-extracted fastembed model cache. An interrupted
+ * archive download/extraction leaves `<cacheDir>/<model>/` populated with
+ * sidecars and a truncated `model.onnx_data` but WITHOUT the graph file
+ * (`model.onnx` / `model_optimized.onnx`), so `FlagEmbedding.init` throws
+ * `Model file not found at .../model.onnx`. Upstream `retrieveModel`
+ * short-circuits on the existing model dir and never re-downloads, and
+ * `downloadFileFromGCS` reuses a leftover partial `<model>.tar.gz` as-is, so
+ * the cache is stuck broken forever: recall silently dies and the rebuild
+ * queue grows every session. Delete the incomplete model dir AND the leftover
+ * partial archive so the retry re-downloads from scratch. The model path is
+ * error-message CONTENT, so the dir is only removed when it is a direct child
+ * of the fastembed cache root — never touch a directory a dependency merely
+ * names. Returns true when a retry is worth attempting (the incomplete cache
+ * was cleared, or already gone from a concurrent heal).
+ * @internal exported for tests
+ */
+export async function clearIncompleteModelCache(message: string, cacheDir?: string): Promise<boolean> {
+	const match = /Model file not found at (.+?\.onnx)\b/i.exec(message);
+	if (!match) return false;
+	const modelFile = nodePath.resolve(match[1]);
+	const modelDir = nodePath.dirname(modelFile);
+	const cacheRoot = nodePath.resolve(cacheDir ?? getFastembedCacheDir());
+	// Only a direct child of the cache root: `<cacheRoot>/<model>`.
+	if (nodePath.dirname(modelDir) !== cacheRoot) return false;
+	try {
+		await fsp.rm(modelDir, { recursive: true, force: true });
+		await fsp.rm(`${modelDir}.tar.gz`, { force: true });
+		logger.warn("mnemopi: cleared incomplete local embedding model cache; re-downloading", { modelDir });
+	} catch {
+		// Concurrent heal or vanished dir: the single retry stays safe.
+	}
+	return true;
+}
+
 const SIDECAR_ERROR_RE =
 	/(?:Config file not found at .*config|Tokenizer file not found at .*tokenizer|Tokens map file not found at .*special_tokens_map)/u;
 
@@ -122,6 +157,9 @@ export async function defaultLocalModelInitializer(options: LocalModelInitOption
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "";
 		if (/Protobuf parsing failed/i.test(message) && (await quarantineCorruptModelFile(message, cacheDir))) {
+			return initWithSidecarHeal();
+		}
+		if (await clearIncompleteModelCache(message, cacheDir)) {
 			return initWithSidecarHeal();
 		}
 		throw error;

--- a/packages/mnemopi/test/truncated-model-cache-recovery.test.ts
+++ b/packages/mnemopi/test/truncated-model-cache-recovery.test.ts
@@ -1,0 +1,129 @@
+// Contract: an interrupted fastembed download leaves a partial model dir
+// (`<cacheDir>/<model>/` populated with sidecars + a truncated
+// `model.onnx_data` but WITHOUT the graph file), which upstream `retrieveModel`
+// treats as complete forever. `FlagEmbedding.init` then throws
+// `Model file not found at .../model.onnx` every session. `clearIncompleteModelCache`
+// deletes the incomplete dir AND the leftover partial `<model>.tar.gz` so the
+// retry re-downloads cleanly, and `defaultLocalModelInitializer` retries init
+// exactly once — no loop.
+import { describe, expect, spyOn, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	clearIncompleteModelCache,
+	defaultLocalModelInitializer,
+	type LocalEmbeddingModel,
+} from "../src/core/embeddings";
+import * as runtime from "../src/core/fastembed-runtime";
+
+const MODEL = "fast-multilingual-e5-large";
+
+/** Build a partially-extracted cache: sidecars + truncated data, no `model.onnx`, leftover `.tar.gz`. */
+async function partialCache(): Promise<{ cacheDir: string; modelDir: string; tarGz: string; modelFile: string }> {
+	const cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-truncated-"));
+	const modelDir = path.join(cacheDir, MODEL);
+	await fs.mkdir(modelDir, { recursive: true });
+	await fs.writeFile(path.join(modelDir, "config.json"), "{}");
+	await fs.writeFile(path.join(modelDir, "tokenizer.json"), "{}");
+	await fs.writeFile(path.join(modelDir, "model.onnx_data"), "truncated");
+	const tarGz = path.join(cacheDir, `${MODEL}.tar.gz`);
+	await fs.writeFile(tarGz, "partial archive");
+	return { cacheDir, modelDir, tarGz, modelFile: path.join(modelDir, "model.onnx") };
+}
+
+const fakeModel = { embed: async () => [] } as unknown as LocalEmbeddingModel;
+
+describe("truncated fastembed model cache recovery", () => {
+	test("missing model file clears the incomplete cache and retries init exactly once", async () => {
+		const { cacheDir, modelDir, tarGz, modelFile } = await partialCache();
+		let initCalls = 0;
+		const loadSpy = spyOn(runtime, "loadFastembed").mockResolvedValue({
+			FlagEmbedding: {
+				init: async () => {
+					initCalls++;
+					if (initCalls === 1) throw new Error(`Model file not found at ${modelFile}`);
+					return fakeModel;
+				},
+			},
+		} as never);
+		try {
+			const model = await defaultLocalModelInitializer({ model: MODEL as never, cacheDir });
+			expect(model).toBe(fakeModel);
+			expect(initCalls).toBe(2);
+			// Incomplete dir and leftover partial archive both cleared for a clean re-download.
+			await expect(fs.access(modelDir)).rejects.toThrow();
+			await expect(fs.access(tarGz)).rejects.toThrow();
+		} finally {
+			loadSpy.mockRestore();
+			await fs.rm(cacheDir, { recursive: true, force: true });
+		}
+	});
+
+	test("a retry that still cannot find the model surfaces the error without looping", async () => {
+		const { cacheDir, modelDir, tarGz, modelFile } = await partialCache();
+		let initCalls = 0;
+		const loadSpy = spyOn(runtime, "loadFastembed").mockResolvedValue({
+			FlagEmbedding: {
+				init: async () => {
+					initCalls++;
+					throw new Error(`Model file not found at ${modelFile}`);
+				},
+			},
+		} as never);
+		try {
+			await expect(defaultLocalModelInitializer({ model: MODEL as never, cacheDir })).rejects.toThrow(
+				/Model file not found/,
+			);
+			expect(initCalls).toBe(2);
+			// Cache still cleared so the NEXT session re-downloads from scratch.
+			await expect(fs.access(modelDir)).rejects.toThrow();
+			await expect(fs.access(tarGz)).rejects.toThrow();
+		} finally {
+			loadSpy.mockRestore();
+			await fs.rm(cacheDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("clearIncompleteModelCache", () => {
+	test("removes the incomplete model dir and its partial archive", async () => {
+		const { cacheDir, modelDir, tarGz, modelFile } = await partialCache();
+		try {
+			const cleared = await clearIncompleteModelCache(`Model file not found at ${modelFile}`, cacheDir);
+			expect(cleared).toBe(true);
+			await expect(fs.access(modelDir)).rejects.toThrow();
+			await expect(fs.access(tarGz)).rejects.toThrow();
+		} finally {
+			await fs.rm(cacheDir, { recursive: true, force: true });
+		}
+	});
+
+	test("ignores unrelated init errors (protobuf corruption is handled elsewhere)", async () => {
+		const { cacheDir, modelDir, modelFile } = await partialCache();
+		try {
+			const cleared = await clearIncompleteModelCache(
+				`Load model from ${modelFile} failed:Protobuf parsing failed.`,
+				cacheDir,
+			);
+			expect(cleared).toBe(false);
+			expect(await fs.access(modelDir).then(() => true)).toBe(true);
+		} finally {
+			await fs.rm(cacheDir, { recursive: true, force: true });
+		}
+	});
+
+	test("refuses to remove a dir OUTSIDE the fastembed cache root", async () => {
+		const { cacheDir, modelDir, modelFile } = await partialCache();
+		const foreignRoot = await fs.mkdtemp(path.join(os.tmpdir(), "mnemopi-foreign-"));
+		try {
+			// modelFile lives under cacheDir, but we pass a different cache root: containment must reject.
+			const cleared = await clearIncompleteModelCache(`Model file not found at ${modelFile}`, foreignRoot);
+			expect(cleared).toBe(false);
+			expect(await fs.access(modelDir).then(() => true)).toBe(true);
+		} finally {
+			await fs.rm(cacheDir, { recursive: true, force: true });
+			await fs.rm(foreignRoot, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Repro
An interrupted fastembed model download leaves a partial cache: `<cacheDir>/<model>/` populated with sidecars and a truncated `model.onnx_data` but WITHOUT the graph file `model.onnx`, plus a leftover partial `<model>.tar.gz`. Upstream `FlagEmbedding.retrieveModel` (`fastembed@2.1.0`, `fastembed.js` L189-204) returns early whenever the model dir exists and `downloadFileFromGCS` (L128-131) reuses an existing `.tar.gz` as-is, so the broken cache is treated as complete forever — `FlagEmbedding.init` (L74-77) throws `Model file not found at .../model.onnx` every session, semantic recall silently dies machine-wide, and `reconcileEmbeddingModel` re-enqueues the same never-embeddable rows on every store open (monotonic growth). Reproduced with a partial dir + leftover `.tar.gz` and upstream's real error string: `init attempts: 1 (no retry -> no recovery)`, partial `modelDir` and `.tar.gz` both survive.

## Cause
`packages/mnemopi/src/core/embeddings.ts`: `defaultLocalModelInitializer`'s only cache heals were the sidecar re-fetch (`SIDECAR_ERROR_RE`) and `quarantineCorruptModelFile`, which matches **only** `/Load model from (.+?\.onnx) failed:.*Protobuf parsing failed/i`. The `Model file not found` partial-extraction variant matched neither, so nothing ever cleared the incomplete cache and upstream never re-downloaded. (`corrupt-model-quarantine.test.ts` L39 documents that `Model file not found` returns `false` from the corrupt-file quarantine.)

## Fix
- Add `clearIncompleteModelCache(message, cacheDir)` in `embeddings.ts`: matches `Model file not found at (.+?\.onnx)`, and — containment-guarded to a **direct child** of the fastembed cache root — removes the incomplete `<model>/` directory AND the leftover partial `<model>.tar.gz` (which upstream `downloadFileFromGCS` would otherwise reuse).
- Wire it into `defaultLocalModelInitializer`'s catch alongside the existing protobuf quarantine: a `Model file not found` failure clears the cache and retries init exactly once, so the next attempt re-downloads from scratch and recall self-heals (which also drains the rebuild queue).
- Suggestion #1 (integrity-before-extraction) is out of scope: the download/extract happens entirely inside upstream `fastembed`, which this repo never observes. Suggestion #3 (log escalation) is intentionally not taken: #2322 deliberately set local-model load failures to debug-level to avoid noise on transient failures, and making the condition recoverable removes the silent-and-permanent aspect.

## Verification
`bun test test/truncated-model-cache-recovery.test.ts` — 5 pass (recovery + retry-once + containment + protobuf-passthrough). Adjacent contracts unregressed: `bun test test/corrupt-model-quarantine.test.ts test/corrupt-model-retry.test.ts test/embedding-failure-logging.test.ts test/fastembed-model-cache.test.ts` — 11 pass. Fixes #7916