### PR TITLE
test(coding-agent): expect Bedrock idle-timeout floor in registry override compat

### DIFF
--- a/packages/coding-agent/test/model-registry-default-config.test.ts
+++ b/packages/coding-agent/test/model-registry-default-config.test.ts
@@ -46,6 +46,7 @@ describe("ModelRegistry default custom models config", () => {
 			supportsLongPromptCacheRetention: false,
 			promptCacheMinimumTokens: 1024,
 			promptCacheMaximumCheckpoints: 4,
+			streamIdleTimeoutMs: 900_000,
 		});
 	});
 
@@ -126,6 +127,7 @@ interface ModelSnapshot {
 		supportsLongPromptCacheRetention: boolean;
 		promptCacheMinimumTokens: number;
 		promptCacheMaximumCheckpoints: number;
+		streamIdleTimeoutMs: number;
 	};
 }
 


### PR DESCRIPTION
## What

Adds the `streamIdleTimeoutMs: 900_000` field to the expected resolved compat in `model-registry-default-config.test.ts` ("loads Bedrock cache capabilities from a model override"), plus the matching `ModelSnapshot` interface field. Two lines, test-only.

## Why

#7892 added `streamIdleTimeoutMs` to resolved Bedrock compat (900s keepalive-free idle floor for the adaptive-thinking Claude family — `us.anthropic.claude-opus-4-8` qualifies). This test asserts exact compat equality and predates that field; it was missed in #7892's expectation sweep (`bedrock-prompt-cache.test.ts`, `amazon-bedrock-opus-5.test.ts`), and now fails main CI's coding-agent native bucket. Same expectation pattern #7892 used in those catalog tests.

Deliberately **not** fixed here (bisected to other causes, out of scope):

- The `viewSession.hasBuiltInTool is not a function` failures across 11 test files (both coding-agent buckets) — introduced by #7774's renderer-provenance gating; the mock viewSessions lack the new method.
- `agent-session-retry-fallback.test.ts` (2 tests) — fails at the commit *before* the #7892 merge, so it predates it.
- `repro-issue-6879-tool-double-render-retry.test.ts` (5 tests) — passes at both #7774's commit and the #7892 merge; broke somewhere later on main.

So the coding-agent buckets remain red on main until those are addressed; this PR just removes #7892's contribution.

## Testing

- `bun test test/model-registry-default-config.test.ts`: 3 fail → 4/4 pass.
- Bisect evidence: the test passes at `10863ef6b~1` (pre-#7892) and fails at `10863ef6b` (the #7892 merge); with this change it passes on current `main`.
- `bun run check:ts` green across workspaces; biome clean.

---

- [x] `bun check` passes (TS side; no Rust changes)
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing) — test-only, not user-facing
