### PR TITLE
fix(coding-agent): let a classifier refusal cascade when its tool calls never ran

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 
+- Fixed a content refusal that arrives after the model already emitted a tool call ending the turn outright instead of consulting the model fallback chain. When the refused turn produced nothing visible and every emitted tool call provably never executed (each paired with a synthetic `executed: false` result), the turn is now retryable and the configured `retry.fallbackChains` entry gets its chance, matching how a refusal with no tool calls already behaves.
 - Fixed proxy discovery preferring the bundled catalog name over the proxy-reported name, so `omp models refresh` now updates stale display names (e.g. a proxy serving `longcat-2.0` as `"LongCat"` no longer shows the raw id).
 - Fixed the compiled binary build on Windows: `Bun.Glob.scan` yields backslash-separated paths, which the legacy Pi virtual module used verbatim for export keys and generated identifiers, producing invalid JavaScript.
 - Fixed Ctrl+O (`app.tools.expand`) not expanding truncated tool output while a tool-approval prompt or other selection dialog held keyboard focus, by promoting the shortcut to a global input listener that fires regardless of focus (it still defers to fullscreen overlays and the tree selector's own Ctrl+O filter cycle) ([#7837](https://github.com/can1357/oh-my-pi/issues/7837)).

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -935,10 +935,81 @@ export class TurnRecovery {
 		// A classifier refusal/sensitivity stop is the model's decision, not a route
 		// failure, but only after we confirm no replay-unsafe output has already
 		// streamed. Committed text, images, tool calls, or server tools must not be
-		// discarded and replayed.
-		if (this.#hasReplayUnsafeOutput(message)) return false;
+		// discarded and replayed. The one exception is a refusal whose ONLY
+		// replay-unsafe output is tool calls the agent loop proved never ran
+		// (`#refusalReplaySafe`): nothing reached the user and no side effect
+		// happened, so discarding the turn duplicates nothing and the fallback
+		// chain gets its chance.
+		if (this.#hasReplayUnsafeOutput(message) && !this.#refusalReplaySafe(message)) return false;
 		if (this.isClassifierRefusal(message)) return true;
 		return AIError.retriable(id);
+	}
+
+	/**
+	 * True when a classifier refusal is replay-safe *despite* having emitted tool
+	 * calls, because every emitted call provably never executed.
+	 *
+	 * Anthropic's request classifier can fire after the model has already streamed
+	 * a tool call, which used to strand the turn: `#hasReplayUnsafeOutput` sees the
+	 * `toolCall` block and vetoes retry one line before the refusal could reach the
+	 * fallback-chain consult, so a refusal that a different model family would very
+	 * likely have served just ended the turn.
+	 *
+	 * That veto exists to protect against duplicating work or visible output. Neither
+	 * risk is present here: the agent loop pairs each emitted-but-unrun call with a
+	 * synthetic `executed: false` result (see {@link isSyntheticToolResultMessage}),
+	 * which is a positive record that `tool.execute()` never ran. So the veto is
+	 * lifted only when ALL of the following hold, and any uncertainty (assistant
+	 * message missing from state, a call with no result, a non-synthetic result, an
+	 * `executed` that is not exactly `false`) keeps it in place:
+	 *
+	 * - the stop is a classifier refusal/sensitivity stop;
+	 * - the only replay-unsafe blocks are tool calls — an `image`, an
+	 *   `anthropicServerTool`, or committed non-whitespace text has already rendered
+	 *   or has side effects, so replaying would duplicate it;
+	 * - at least one tool call was emitted (otherwise the plain refusal path already
+	 *   handles it);
+	 * - every emitted call id has a result after the assistant message in state, and
+	 *   every such result is synthetic with `executed === false`.
+	 */
+	#refusalReplaySafe(message: AssistantMessage): boolean {
+		if (!this.isClassifierRefusal(message)) return false;
+
+		const emittedToolCallIds = new Set<string>();
+		for (const block of message.content) {
+			if (block.type === "toolCall") {
+				emittedToolCallIds.add(block.id);
+				continue;
+			}
+			if (block.type === "image" || block.type === "anthropicServerTool") return false;
+			if (block.type === "text" && this.#host.textOutputCommitted() && hasNonWhitespace(block.text)) return false;
+		}
+		if (emittedToolCallIds.size === 0) return false;
+
+		// The refused assistant message is NOT the tail of state: the agent loop
+		// appends the synthetic results after it before the turn ends, so locate it
+		// by walking backwards exactly as `classifyResolvedInterruptedToolTurn` does.
+		const messages = this.#host.agent.state.messages;
+		let assistantIndex = -1;
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const candidate = messages[i];
+			if (candidate.role === "assistant" && this.#isSameAssistantMessage(candidate, message)) {
+				assistantIndex = i;
+				break;
+			}
+		}
+		if (assistantIndex < 0) return false;
+
+		const unexecutedToolCallIds = new Set<string>();
+		for (let i = assistantIndex + 1; i < messages.length; i++) {
+			const candidate = messages[i];
+			if (candidate.role !== "toolResult" || !emittedToolCallIds.has(candidate.toolCallId)) continue;
+			// Every result for an emitted call is inspected, not just the first: a
+			// real result anywhere in the tail means the tool ran.
+			if (!isSyntheticToolResultMessage(candidate) || candidate.details?.executed !== false) return false;
+			unexecutedToolCallIds.add(candidate.toolCallId);
+		}
+		return unexecutedToolCallIds.size === emittedToolCallIds.size;
 	}
 
 	/**

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { AgentMessage, SyntheticToolResultDetails } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import type { Model, Usage } from "@oh-my-pi/pi-catalog/types";
@@ -43,11 +44,12 @@ function createHost(
 	options: {
 		fallbackChains?: Record<string, string[]>;
 		textOutputCommitted?: boolean;
+		messages?: readonly AgentMessage[];
 	} = {},
 ): TurnRecoveryHost {
 	const settings = Settings.isolated(options.fallbackChains ? { "retry.fallbackChains": options.fallbackChains } : {});
 	return {
-		agent: undefined as never,
+		agent: (options.messages ? { state: { messages: options.messages } } : undefined) as never,
 		sessionManager: undefined as never,
 		persistedAssistantEntryId: () => undefined,
 		settings,
@@ -415,5 +417,89 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 		const recovery = new TurnRecovery(createHost(model, modelRegistry));
 		const message = createProviderErrorMessage(model, new Error("fetch failed"));
 		expect(recovery.isRetryableError(message)).toBe(true);
+	});
+
+	// Anthropic's request classifier can refuse AFTER the model streamed a tool
+	// call. Production shape (omp.2026-08-07 log): `stopDetails.type === "refusal"`,
+	// `errorId: 0` (no AIError flag, so `AIError.retriable` cannot rescue it), and
+	// the agent loop appends a synthetic `executed: false` result AFTER the refused
+	// assistant message, so state ends with `lastRole: "toolResult"`.
+	describe("classifier refusal with emitted tool calls", () => {
+		function makeRefusal(content: AssistantMessage["content"]): AssistantMessage {
+			const message = makeMessage(content, model);
+			message.errorMessage =
+				"Refusal (cyber): This request triggered restrictions on violative cyber content and was blocked under Anthropic's Usage Policy.";
+			message.stopDetails = { type: "refusal" };
+			message.errorId = 0;
+			return message;
+		}
+
+		function toolCall(id: string): AssistantMessage["content"][number] {
+			return { type: "toolCall", id, name: "read", arguments: { path: "https://developer.android.com/reference" } };
+		}
+
+		function syntheticResult(toolCallId: string): ToolResultMessage<SyntheticToolResultDetails> {
+			return {
+				role: "toolResult",
+				toolCallId,
+				toolName: "read",
+				content: [{ type: "text", text: "Tool call was not executed." }],
+				isError: true,
+				details: { __synthetic: true, source: "assistant_stop_error", executed: false },
+				timestamp: Date.now(),
+			};
+		}
+
+		function realResult(toolCallId: string): ToolResultMessage {
+			return {
+				role: "toolResult",
+				toolCallId,
+				toolName: "read",
+				content: [{ type: "text", text: "# Android reference" }],
+				isError: false,
+				timestamp: Date.now(),
+			};
+		}
+
+		function recoveryFor(message: AssistantMessage, tail: readonly AgentMessage[]): TurnRecovery {
+			return new TurnRecovery(createHost(model, modelRegistry, { messages: [message as AgentMessage, ...tail] }));
+		}
+
+		it("retries a refusal whose only tool call provably never executed", () => {
+			const message = makeRefusal([toolCall("call-1")]);
+			expect(message.errorId).toBe(0);
+			expect(recoveryFor(message, [syntheticResult("call-1")]).isRetryableError(message)).toBe(true);
+		});
+
+		it("does not retry a refusal whose tool call produced a real result", () => {
+			const message = makeRefusal([toolCall("call-1")]);
+			expect(recoveryFor(message, [realResult("call-1")]).isRetryableError(message)).toBe(false);
+		});
+
+		it("does not retry a refusal when only some tool calls went unexecuted", () => {
+			const message = makeRefusal([toolCall("call-1"), toolCall("call-2")]);
+			const recovery = recoveryFor(message, [realResult("call-1"), syntheticResult("call-2")]);
+			expect(recovery.isRetryableError(message)).toBe(false);
+		});
+
+		it("does not retry a refusal that also committed visible text", () => {
+			const message = makeRefusal([{ type: "text", text: "Let me fetch that page." }, toolCall("call-1")]);
+			expect(recoveryFor(message, [syntheticResult("call-1")]).isRetryableError(message)).toBe(false);
+		});
+
+		it("does not retry a refusal whose tool call has no result at all", () => {
+			const message = makeRefusal([toolCall("call-1")]);
+			expect(recoveryFor(message, []).isRetryableError(message)).toBe(false);
+		});
+
+		it("keeps a refusal with no tool calls retriable (baseline)", () => {
+			const message = makeRefusal([{ type: "thinking", thinking: "reasoning before refusal" }]);
+			expect(recoveryFor(message, []).isRetryableError(message)).toBe(true);
+		});
+
+		it("keeps a non-refusal error with an unexecuted tool call non-retriable", () => {
+			const message = makeMessage([toolCall("call-1")], model);
+			expect(recoveryFor(message, [syntheticResult("call-1")]).isRetryableError(message)).toBe(false);
+		});
 	});
 });

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -492,6 +492,16 @@ describe("TurnRecovery replay-unsafe output classification", () => {
 			expect(recoveryFor(message, []).isRetryableError(message)).toBe(false);
 		});
 
+		it("does not retry a refusal when one call is synthetic-paired and another has no result", () => {
+			// Reachable in practice: the agent loop skips Cursor server-resolved calls
+			// when pairing synthetic results, so a turn can carry one accounted-for
+			// call beside one it never paired. Accounting for only some of them is
+			// not proof that none ran.
+			const message = makeRefusal([toolCall("call-1"), toolCall("call-2")]);
+			const recovery = recoveryFor(message, [syntheticResult("call-1")]);
+			expect(recovery.isRetryableError(message)).toBe(false);
+		});
+
 		it("keeps a refusal with no tool calls retriable (baseline)", () => {
 			const message = makeRefusal([{ type: "thinking", thinking: "reasoning before refusal" }]);
 			expect(recoveryFor(message, []).isRetryableError(message)).toBe(true);


### PR DESCRIPTION
## Summary

A content refusal that lands *after* the model emits a tool call currently ends the turn terminally, with no consult of `retry.fallbackChains`, even though the tool provably never executed and nothing reached the user.

Observed in production. Same process, same refusal text, three minutes apart:

```
09:39:30.257 warn  agent turn ended with provider error
                   provider=anthropic model=claude-opus-5 errorId=0
                   errorMessage="Refusal (cyber): This request triggered restrictions on
                   violative cyber content and was blocked under Anthropic's Usage Policy."
09:39:30.258 debug agent active context assistant removal missed  lastRole=toolResult

09:42:59.618 debug advisor turn failed  err="Refusal (cyber): ...same text..."
09:42:59.619 debug advisor refusal recovered by model fallback
```

The advisor path recovers from this exact refusal by model fallback (#7745). The main session path dies. The request that triggered it was reading an Android API reference page, so the classifier fired on the request itself, which means retrying the same model is futile and switching family is the only recovery that helps — precisely the one that was skipped.

## Root cause

`isRetryableError` (`turn-recovery.ts:927`) evaluates the replay-safety bail one line before the refusal branch:

```
940:  if (this.#hasReplayUnsafeOutput(message)) return false;   ← exits here
941:  if (this.isClassifierRefusal(message)) return true;       ← unreachable
```

`#hasReplayUnsafeOutput` treats any `toolCall` block as unsafe unconditionally. But `agent-loop.ts:1236-1265` has already paired every unrun call with a synthetic result carrying `{ __synthetic: true, source: "assistant_stop_error", executed: false }` — a discriminator introduced in #4321 for exactly this shape — and pushes it into context (line 1251) before `emitTurnEnd`. The information needed to prove replay safety is present and ignored.

## Change

New `#refusalReplaySafe(message)` narrows the bail. It returns true only when every one of these holds, and is conservative on every uncertainty:

- the stop is a classifier refusal or sensitivity stop;
- the only replay-unsafe blocks are tool calls (an `image`, an `anthropicServerTool`, or committed non-whitespace text still vetoes, since replaying would duplicate rendered output);
- at least one tool call was emitted;
- every emitted call id has a result after the assistant message in state, and every such result is synthetic with `executed === false`.

The assistant message is located by the same backwards `#isSameAssistantMessage` walk `classifyResolvedInterruptedToolTurn` uses, not a tail check, because the synthetic results are appended after it (`lastRole=toolResult` in the log above).

Non-refusals short-circuit on the first clause, so every other retry path keeps today's behavior. `isHardErrorFallbackEligible` is deliberately untouched: it declines refusals by design and its docstring says the consult happens on the retryable path via `pinFallback`, which `turn-recovery.ts:1669-1673` confirms.

## Testing

`test/turn-recovery-replay-unsafe.test.ts`, 8 new cases in a nested describe. Fixtures carry the real logged `errorMessage`, `stopDetails: { type: "refusal" }`, and `errorId: 0`, so they match the production event rather than an easier synthetic one.

Baseline confirmed before writing the fix: a refusal with no tool calls is already retryable today; the same refusal with an emitted call is not, and is not hard-error-fallback eligible either.

Mutation-checked, one mutation per clause:

| mutation | result |
|---|---|
| drop the refusal-only gate | 3 fail |
| ignore committed text | 1 fail |
| trust any result, not just synthetic `executed: false` | 2 fail |
| accept partial accounting | 1 fail |

The last mutation initially **survived**: a turn with one synthetic-paired call beside one with no result at all was indistinguishable. That shape is reachable, since the agent loop skips Cursor server-resolved calls when pairing, so a case was added to pin the size equality.

`bun run check:ts` clean; `bun run ci:test:coding-agent:runtime` fully green.

## Noted, not fixed here

`removeAssistantMessageFromActiveContext` (`turn-recovery.ts:691-712`) only matches when the assistant is the last message, so a trailing synthetic tool result makes the prune a silent no-op and the refused turn stays in active context. That is the `removal missed` line in the log above. Separate defect, out of scope for this PR.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)