### PR TITLE
fix(task): reload agent definitions without a restart

### DIFF
--- a/docs/task-agent-discovery.md
+++ b/docs/task-agent-discovery.md
@@ -196,6 +196,13 @@ A missing name fails preflight with `Unknown agent "...". Available: ...`; no su
 
 `TaskTool.create()` memoizes discovery per resolved working directory when building the model-facing tool description. Execution rediscovers agents, so the runtime set can differ from the earlier description if agent or extension files changed mid-session. Blocking behavior is determined after policy resolution rather than from a stale description-time agent object.
 
+`refreshAgentDiscovery(cwd?)` (`src/task/index.ts`) drops that memo and re-scans, then republishes the result to every live `TaskTool` — the description getter reads the refreshed per-cwd snapshot, not the array the tool was constructed with. Without it, an edited, added, or deleted `.omp/agents/*.md` stays invisible to the model for the life of the process, because the built-in tool slate is only built once at session start. It runs from:
+
+- `/reload-plugins` and its ACP twin (`#reloadPluginState`), whose documented scope includes agents
+- the Agent Control Center after it writes a generated agent definition
+
+Every cwd already scanned in the process is refreshed, plus the supplied one, so subagent sessions rooted in other directories also pick the edit up.
+
 ## Model and structured-output precedence
 
 For task dispatch, model precedence is:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 
+- Fixed agent definition edits requiring a restart. `.omp/agents/*.md` was scanned once per cwd per process (`discoveryMemo`) and the resulting list was frozen into the `task` tool at session start, so an edited, added, or deleted agent never reached the model — not even through `/reload-plugins`, whose description advertises agents in its scope. `refreshAgentDiscovery()` now re-scans and republishes to live `task` tools from `/reload-plugins`, its ACP equivalent, and the Agent Control Center after it writes a generated agent ([#7940](https://github.com/can1357/oh-my-pi/issues/7940)).
 - Fixed proxy discovery preferring the bundled catalog name over the proxy-reported name, so `omp models refresh` now updates stale display names (e.g. a proxy serving `longcat-2.0` as `"LongCat"` no longer shows the raw id).
 - Fixed the compiled binary build on Windows: `Bun.Glob.scan` yields backslash-separated paths, which the legacy Pi virtual module used verbatim for export keys and generated identifiers, producing invalid JavaScript.
 - Fixed Ctrl+O (`app.tools.expand`) not expanding truncated tool output while a tool-approval prompt or other selection dialog held keyboard focus, by promoting the shortcut to a global input listener that fires regardless of focus (it still defers to fullscreen overlays and the tree selector's own Ctrl+O filter cycle) ([#7837](https://github.com/can1357/oh-my-pi/issues/7837)).

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -70,6 +70,7 @@ import { SessionManager } from "../../session/session-manager";
 import { executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
 import { buildAvailableSlashCommands, toAcpAvailableCommands } from "../../slash-commands/available-commands";
 import { DEFAULT_STT_MODEL_KEY, STT_MODEL_OPTIONS } from "../../stt/models";
+import { refreshAgentDiscovery } from "../../task";
 import { AUTO_THINKING, parseConfiguredThinkingLevel } from "../../thinking";
 import { normalizeLocalScheme } from "../../tools/path-utils";
 import { ToolError } from "../../tools/tool-errors";
@@ -1939,6 +1940,7 @@ export class AcpAgent implements Agent {
 		const projectPath = await resolveActiveProjectRegistryPath(cwd);
 		clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
 		resetCapabilities();
+		await refreshAgentDiscovery(cwd);
 		await record.session.refreshSkills();
 		const fileCommands = await loadSlashCommands({ cwd });
 		record.session.setSlashCommands(fileCommands);

--- a/packages/coding-agent/src/modes/components/agent-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/agent-dashboard.ts
@@ -48,6 +48,7 @@ import { Settings } from "../../config/settings";
 import agentCreationArchitectPrompt from "../../prompts/system/agent-creation-architect.md" with { type: "text" };
 import agentCreationUserPrompt from "../../prompts/system/agent-creation-user.md" with { type: "text" };
 import { createAgentSession } from "../../sdk";
+import { refreshAgentDiscovery } from "../../task";
 import { discoverAgents } from "../../task/discovery";
 import { resolveAgentPrewalkDefault } from "../../task/prewalk";
 import type { AgentDefinition, AgentSource } from "../../task/types";
@@ -824,6 +825,10 @@ export class AgentDashboard extends Container {
 		).trimEnd();
 		const content = `---\n${frontmatter}\n---\n\n${spec.systemPrompt.trim()}\n`;
 		await Bun.write(filePath, content);
+		// Republish to the running session's `task` tool: agents are scanned once
+		// per cwd per process, so a fresh definition would otherwise stay invisible
+		// to the model until restart.
+		await refreshAgentDiscovery(this.cwd);
 		await this.#reloadData();
 		this.#clearCreateFlow();
 		this.#notice = `Created agent ${spec.identifier} at ${shortenPath(filePath)}`;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -44,6 +44,7 @@ import type { SessionOAuthAccountList } from "../session/agent-session-types";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
 import { resolveResumableSession } from "../session/session-listing";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
+import { refreshAgentDiscovery } from "../task";
 import type { ComputerTool } from "../tools/computer";
 import { computerExposureMode } from "../tools/computer/exposure";
 import { expandTilde, resolveToCwd } from "../tools/path-utils";
@@ -3078,6 +3079,7 @@ async function reloadTuiPluginState(ctx: InteractiveModeContext): Promise<void> 
 	const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
 	clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
 	await ctx.refreshSkillState();
+	await refreshAgentDiscovery(ctx.sessionManager.getCwd());
 	await ctx.refreshSlashCommandState();
 	resetCapabilities();
 	if (ctx.mcpManager) {

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -449,8 +449,14 @@ class TaskJobError extends Error {}
  * (`#runSpawn`) intentionally stays fresh. The memo also tracks the live
  * `discoverAgents` binding: test spies swap that binding, which invalidates
  * the memo automatically.
+ *
+ * `discoverySnapshots` holds the settled agent list per cwd. A live `TaskTool`
+ * renders its description from the snapshot rather than the array it was
+ * constructed with, so {@link refreshAgentDiscovery} can republish edited
+ * `.omp/agents/*.md` definitions to sessions that are already running.
  */
 const discoveryMemo = new Map<string, Promise<DiscoveryResult>>();
+const discoverySnapshots = new Map<string, AgentDefinition[]>();
 let discoveryMemoFn: typeof discoverAgents | undefined;
 
 function discoverAgentsForCreate(cwd: string): Promise<DiscoveryResult> {
@@ -458,17 +464,49 @@ function discoverAgentsForCreate(cwd: string): Promise<DiscoveryResult> {
 	if (discoveryMemoFn !== fn) {
 		discoveryMemoFn = fn;
 		discoveryMemo.clear();
+		discoverySnapshots.clear();
 	}
 	const key = path.resolve(cwd);
 	let pending = discoveryMemo.get(key);
 	if (!pending) {
 		pending = fn(cwd);
 		discoveryMemo.set(key, pending);
-		pending.catch(() => {
-			if (discoveryMemo.get(key) === pending) discoveryMemo.delete(key);
-		});
+		pending.then(
+			result => {
+				if (discoveryMemo.get(key) === pending) discoverySnapshots.set(key, result.agents);
+			},
+			() => {
+				if (discoveryMemo.get(key) === pending) discoveryMemo.delete(key);
+			},
+		);
 	}
 	return pending;
+}
+
+/**
+ * Re-read agent definitions from disk and republish them to live `TaskTool`
+ * instances.
+ *
+ * Agent files are only scanned once per cwd per process, and the built-in tool
+ * slate is built once at session start — so without this, an edited, added, or
+ * removed `.omp/agents/*.md` only reached the model after a restart. Called by
+ * `/reload-plugins` (which advertises agents in its scope), its ACP twin, and
+ * the Agent Control Center after it writes a new definition.
+ *
+ * Every cwd already scanned in this process is refreshed, plus `cwd` when
+ * given, so subagent sessions rooted elsewhere pick the edit up too.
+ */
+export async function refreshAgentDiscovery(cwd?: string): Promise<void> {
+	const keys = new Set(discoveryMemo.keys());
+	if (cwd !== undefined) keys.add(path.resolve(cwd));
+	discoveryMemo.clear();
+	await Promise.all(
+		[...keys].map(key =>
+			discoverAgentsForCreate(key).catch(error => {
+				logger.warn("Agent discovery refresh failed", { cwd: key, error });
+			}),
+		),
+	);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -554,7 +592,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	// so the task renders as ONE block that transitions in place — not a pending
 	// call frame stacked above the result frame. Mirrors `taskToolRenderer`.
 	readonly mergeCallAndResult = true;
-	readonly #discoveredAgents: AgentDefinition[];
+	readonly #discoveryKey: string;
+	readonly #seededAgents: AgentDefinition[];
 	readonly #blockedAgent: string | undefined;
 	/**
 	 * One semaphore per TaskTool instance (i.e. per session): bounds concurrent
@@ -587,7 +626,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const planMode = this.session.getPlanModeState?.()?.enabled === true;
 		const isolationMode = this.session.settings.get("task.isolation.mode");
 		return renderDescription({
-			agents: this.#discoveredAgents,
+			// Live snapshot, not the create-time list: `/reload-plugins` (and an
+			// Agent Control Center write) republishes edited definitions to a
+			// session that is already running. Falls back to the seed if a failed
+			// refresh dropped the entry.
+			agents: discoverySnapshots.get(this.#discoveryKey) ?? this.#seededAgents,
 			isolationEnabled: !planMode && isolationMode !== "none",
 			applyIsolatedChanges: this.session.settings.get("task.isolation.apply"),
 			disabledAgents,
@@ -603,7 +646,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		discoveredAgents: AgentDefinition[],
 	) {
 		this.#blockedAgent = $env.PI_BLOCKED_AGENT;
-		this.#discoveredAgents = discoveredAgents;
+		this.#discoveryKey = path.resolve(session.cwd);
+		this.#seededAgents = discoveredAgents;
 	}
 
 	#isBatchEnabled(): boolean {

--- a/packages/coding-agent/test/task/create-memo.test.ts
+++ b/packages/coding-agent/test/task/create-memo.test.ts
@@ -1,6 +1,9 @@
-import { afterEach, describe, expect, it, vi } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { TaskTool } from "@oh-my-pi/pi-coding-agent/task";
+import { refreshAgentDiscovery, TaskTool } from "@oh-my-pi/pi-coding-agent/task";
 import * as discoveryModule from "@oh-my-pi/pi-coding-agent/task/discovery";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 
@@ -62,5 +65,50 @@ describe("TaskTool.create discovery memo", () => {
 
 		expect(tool.description).toContain("task");
 		expect(spy).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("refreshAgentDiscovery", () => {
+	let projectDir: string;
+	let agentFile: string;
+
+	const agentMd = (description: string) =>
+		["---", "name: reload-probe", `description: ${description}`, "---", "", "Probe body."].join("\n");
+
+	beforeAll(async () => {
+		projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-agent-reload-"));
+		agentFile = path.join(projectDir, ".omp", "agents", "reload-probe.md");
+	});
+
+	afterAll(async () => {
+		await fs.rm(projectDir, { recursive: true, force: true });
+	});
+
+	it("republishes edited agent definitions to a live TaskTool", async () => {
+		await Bun.write(agentFile, agentMd("PROBE_BEFORE"));
+		const tool = await TaskTool.create(createSession(projectDir));
+		expect(tool.description).toContain("PROBE_BEFORE");
+
+		await Bun.write(agentFile, agentMd("PROBE_AFTER"));
+		// Without a refresh the create-time scan is memoized for the process.
+		expect((await TaskTool.create(createSession(projectDir))).description).toContain("PROBE_BEFORE");
+
+		await refreshAgentDiscovery(projectDir);
+
+		// The already-constructed tool — the one the running session holds — sees it.
+		expect(tool.description).toContain("PROBE_AFTER");
+		expect(tool.description).not.toContain("PROBE_BEFORE");
+	});
+
+	it("drops agents whose definition file was deleted", async () => {
+		await Bun.write(agentFile, agentMd("PROBE_DOOMED"));
+		await refreshAgentDiscovery(projectDir);
+		const tool = await TaskTool.create(createSession(projectDir));
+		expect(tool.description).toContain("reload-probe");
+
+		await fs.rm(agentFile);
+		await refreshAgentDiscovery(projectDir);
+
+		expect(tool.description).not.toContain("reload-probe");
 	});
 });


### PR DESCRIPTION
Fixes #7940.

## Problem

Edits to `.omp/agents/*.md` only reach the model after restarting `omp`, including after `/reload-plugins` — whose own description advertises agents in its scope:

```
reload-plugins    Reload all plugins (skills, commands, hooks, tools, agents, MCP)
```

Two layers pin the list for the process lifetime:

1. `discoveryMemo` (`src/task/index.ts`) memoizes `discoverAgents(cwd)` per resolved cwd and is only invalidated when the `discoverAgents` binding itself is swapped (a test spy).
2. `createTools` builds the built-in slate once at session start and `TaskTool` froze the discovered array into `readonly #discoveredAgents`, so clearing the memo alone would not reach the instance the running session holds.

`reloadTuiPluginState` and the ACP twin `#reloadPluginState` touched neither. The Agent Control Center had the same gap: writing a generated agent refreshed the dashboard's own view but not the session's `task` tool.

Execution-time discovery was already fresh (`resolveEffectiveSubagentPolicy` re-scans on every spawn), so this is purely the advertisement gap — but the model can't spawn an agent it was never told about.

## Change

- `refreshAgentDiscovery(cwd?)` in `src/task/index.ts`: drops the memo, re-scans every cwd already seen in the process plus the supplied one, and publishes results into a per-cwd `discoverySnapshots` map.
- `TaskTool`'s `description` getter reads that snapshot, falling back to its create-time seed if a refresh failed and dropped the entry. Discovery failures are logged and do not poison the snapshot.
- Wired into `reloadTuiPluginState`, ACP `#reloadPluginState`, and the Agent Control Center after `#saveGeneratedAgent` writes.

No behavior change for execution-time resolution, `task.agentModelOverrides`, or `task.disabledAgents` — those were already live.

## Tests

Two cases added to `test/task/create-memo.test.ts`, driving real files on disk:

- an already-constructed `TaskTool` picks up an edited `description` after `refreshAgentDiscovery` (and the same test pins the pre-refresh staleness, so the memo behavior stays covered);
- a deleted definition disappears from the advertised set.

Both fail against the pre-fix `description` getter and pass after.

Verified: `bun run check:ts` clean; `bun test test/task/ test/discovery/agent-discovery-disabled-providers.test.ts test/agent-dashboard-create-editor.test.ts` → 360 pass, 1 fail (`task-progress-render.test.ts > renders the task brief markdown inside the result frame`, which fails identically on a stashed tree — pre-existing, unrelated); `omp --smoke-test` ok.

## Docs

`docs/task-agent-discovery.md` "Description vs execution-time discovery" now describes the refresh contract and its call sites.

Draft while maintainers weigh the scope: the refresh currently re-scans *every* cwd seen in the process rather than just the caller's, which is the behavior a shared reload command wants but costs a few extra directory walks for sessions with isolated-worktree subagents. Happy to narrow it to the caller's cwd if preferred.
