### PR TITLE
feat: surface session timestamps and goals

### DIFF
--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -1,11 +1,11 @@
 import { ProcessTerminal, TUI } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
+import { Settings } from "../config/settings";
 import { SessionSelectorComponent } from "../modes/components/session-selector";
 import { HistoryStorage } from "../session/history-storage";
 import type { SessionInfo } from "../session/session-listing";
 import { SessionManager } from "../session/session-manager";
 import { FileSessionStorage } from "../session/session-storage";
-
 /** Presentation and capability controls for the standalone session picker. */
 export interface SessionPickerOptions {
 	allSessions?: SessionInfo[];
@@ -31,7 +31,12 @@ export async function selectSession(
 	const ui = new TUI(new ProcessTerminal());
 	let resolved = false;
 	const storage = new FileSessionStorage();
-
+	let settings: Pick<Settings, "get"> | undefined;
+	try {
+		settings = await Settings.loadReadOnly();
+	} catch (error) {
+		logger.warn("Settings unavailable for session picker", { error: String(error) });
+	}
 	// Rank sessions with prompt-history matches too, recovering prompts the 4KB
 	// session-list prefix never sees. Best-effort: a missing/locked history.db
 	// must not break the picker.
@@ -80,11 +85,11 @@ export async function selectSession(
 				historyMatcher,
 				loadAllSessions: options.allowGlobalScope === false ? undefined : () => SessionManager.listAll(storage),
 				allSessions: options.allSessions,
-				getTerminalRows: () => ui.terminal.rows,
+				showCwd: options.showCwd,
+				settings,
 				fillHeight: true,
 				title: options.title,
 				scopeLabel: options.scopeLabel,
-				showCwd: options.showCwd,
 			},
 		);
 		return selector;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1063,6 +1063,39 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"display.showTimestamps": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Show Timestamps",
+			description: "Show timestamps on session events and transcript messages",
+		},
+	},
+
+	"display.showRecentUserMessages": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Show Recent User Messages",
+			description: "Show user message previews and last-said times in session search and selector views",
+		},
+	},
+
+	"display.showGoalHistory": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Show Goal History",
+			description: "Expose current goal and retained goal history in session views",
+		},
+	},
+
 	showHardwareCursor: {
 		type: "boolean",
 		default: true, // will be computed based on platform if undefined

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -282,9 +282,10 @@ class SessionList implements Component {
 	readonly #getTerminalRows: () => number;
 
 	onDeleteRequest?: (session: SessionInfo) => void;
-
 	#allSessions: SessionInfo[];
 	#showCwd: boolean;
+	#showRecentUserMessages: boolean;
+	#showGoalHistory: boolean;
 	readonly #historyMatcher?: SessionHistoryMatcher;
 	#historyMergeTimer: NodeJS.Timeout | undefined;
 	/** Re-render hook for async list updates (fuzzy scan chunks, history merge). */
@@ -315,12 +316,15 @@ class SessionList implements Component {
 		showCwd = false,
 		historyMatcher?: SessionHistoryMatcher,
 		getTerminalRows: () => number = () => 24,
+		showRecentUserMessages = true,
+		showGoalHistory = true,
 	) {
 		this.#getTerminalRows = getTerminalRows;
 		this.#allSessions = sessions;
 		this.#showCwd = showCwd;
 		this.#historyMatcher = historyMatcher;
-		this.#filteredSessions = sessions;
+		this.#showRecentUserMessages = showRecentUserMessages;
+		this.#showGoalHistory = showGoalHistory;
 		this.#searchInput = new Input();
 
 		// Handle Enter in search input - select current item
@@ -579,7 +583,10 @@ class SessionList implements Component {
 		for (let i = startIndex; i < endIndex; i++) {
 			const session = this.#filteredSessions[i];
 			const blockStart = sessionLines.length;
-			const normalizedMessage = (session.lastUserMessage ?? session.firstMessage).replace(/\n/g, " ").trim();
+			const previewText = this.#showRecentUserMessages
+				? (session.lastUserMessage ?? session.firstMessage)
+				: session.firstMessage;
+			const normalizedMessage = previewText.replace(/\n/g, " ").trim();
 			const isSelected = i === this.#selectedIndex;
 
 			// First line: cursor + title (or first message if no title)
@@ -609,10 +616,15 @@ class SessionList implements Component {
 			const dim = (s: string) => theme.fg("dim", s);
 			const dot = dim(theme.sep.dot);
 			const modified = formatDate(session.modified);
-			const lastSaid = session.lastUserMessageTimestamp
-				? ` ${dot} ${dim(`said ${formatDate(session.lastUserMessageTimestamp)}`)}`
-				: "";
-			let metadata = `  ${dim(modified)}${lastSaid} ${dot} ${dim(formatBytes(session.size))}`;
+			const lastSaid =
+				this.#showRecentUserMessages && session.lastUserMessageTimestamp
+					? ` ${dot} ${dim(`said ${formatDate(session.lastUserMessageTimestamp)}`)}`
+					: "";
+			const goalSummary =
+				this.#showGoalHistory && session.goalHistory?.length
+					? ` ${dot} ${dim(`goals ${session.goalHistory.length}`)}`
+					: "";
+			let metadata = `  ${dim(modified)}${lastSaid}${goalSummary} ${dot} ${dim(formatBytes(session.size))}`;
 			const status = formatSessionStatus(session.status);
 			if (status) {
 				metadata += ` ${dot} ${status}`;
@@ -746,6 +758,9 @@ export interface SessionSelectorOptions {
 	 * in-editor selector leaves it off and renders compactly.
 	 */
 	fillHeight?: boolean;
+	showRecentUserMessages?: boolean;
+	showGoalHistory?: boolean;
+	settings?: { get(key: string): unknown };
 }
 
 /**
@@ -815,11 +830,19 @@ export class SessionSelectorComponent extends Container {
 		// Create session list in folder scope; the empty-state hint invites the
 		// user to Tab into all-projects rather than silently surfacing other
 		// projects' history (issue #3099).
+		const showRecentUserMessages =
+			options.showRecentUserMessages ??
+			(options.settings?.get("display.showRecentUserMessages") as boolean | undefined) ??
+			true;
+		const showGoalHistory =
+			options.showGoalHistory ?? (options.settings?.get("display.showGoalHistory") as boolean | undefined) ?? true;
 		this.#sessionList = new SessionList(
 			sessions,
 			options.showCwd ?? false,
 			options.historyMatcher,
 			options.getTerminalRows,
+			showRecentUserMessages,
+			showGoalHistory,
 		);
 		// Every exit path cancels the list's pending history merge, so a stale
 		// debounce timer can never run its SQLite lookup after the picker closed.

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -53,6 +53,10 @@ function sessionSearchText(session: SessionInfo): string {
 		session.title ?? "",
 		session.cwd ?? "",
 		session.firstMessage ?? "",
+		session.lastUserMessage ?? "",
+		session.userMessages?.map(message => message.text).join(" ") ?? "",
+		session.goal ?? "",
+		session.goalHistory?.map(goal => goal.text).join(" ") ?? "",
 		session.allMessagesText,
 		session.path,
 	];
@@ -573,12 +577,10 @@ class SessionList implements Component {
 		const overflow = this.#filteredSessions.length > maxVisible;
 		const rowWidth = Math.max(0, width - (overflow ? 1 : 0));
 		for (let i = startIndex; i < endIndex; i++) {
-			const blockStart = sessionLines.length;
 			const session = this.#filteredSessions[i];
+			const blockStart = sessionLines.length;
+			const normalizedMessage = (session.lastUserMessage ?? session.firstMessage).replace(/\n/g, " ").trim();
 			const isSelected = i === this.#selectedIndex;
-
-			// Normalize first message to single line
-			const normalizedMessage = session.firstMessage.replace(/\n/g, " ").trim();
 
 			// First line: cursor + title (or first message if no title)
 			const cursorSymbol = `${theme.nav.cursor} `;
@@ -602,13 +604,15 @@ class SessionList implements Component {
 				sessionLines.push(messageLine);
 			}
 
-			// Metadata line: date + file size + lifecycle status (+ project dir in
-			// all-projects scope). The status segment carries its own color, so each
-			// segment is dimmed individually rather than wrapping the whole line.
+			// Metadata line: date + last-said time + file size + lifecycle status
+			// (+ project dir in all-projects scope).
 			const dim = (s: string) => theme.fg("dim", s);
 			const dot = dim(theme.sep.dot);
 			const modified = formatDate(session.modified);
-			let metadata = `  ${dim(modified)} ${dot} ${dim(formatBytes(session.size))}`;
+			const lastSaid = session.lastUserMessageTimestamp
+				? ` ${dot} ${dim(`said ${formatDate(session.lastUserMessageTimestamp)}`)}`
+				: "";
+			let metadata = `  ${dim(modified)}${lastSaid} ${dot} ${dim(formatBytes(session.size))}`;
 			const status = formatSessionStatus(session.status);
 			if (status) {
 				metadata += ` ${dot} ${status}`;

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -676,7 +676,10 @@ class TreeList implements Component {
 			}
 			case "compaction": {
 				const tokens = Math.round(entry.tokensBefore / 1000);
-				result = theme.fg("borderAccent", `[compaction: ${tokens}k tokens]`);
+				const goal = entry.summary.match(/(?:^|\n)##\s*Goal\s*\n([\s\S]*?)(?=\n##\s|\s*$)/i)?.[1]?.trim();
+				result = goal
+					? theme.fg("borderAccent", `[goal: ${normalize(goal)}]`)
+					: theme.fg("borderAccent", `[compaction: ${tokens}k tokens]`);
 				break;
 			}
 			case "branch_summary":

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -794,7 +794,8 @@ export class EventController {
 			const streamingComponent = createAssistantMessageComponent(this.ctx);
 			this.ctx.streamingComponent = streamingComponent;
 			this.ctx.streamingMessage = event.message;
-			const timestamp = createTimestampComponent(event.message.timestamp);
+			const showTimestamps = this.ctx.settings?.get?.("display.showTimestamps") ?? true;
+			const timestamp = createTimestampComponent(event.message.timestamp, showTimestamps);
 			this.ctx.present(timestamp ? [timestamp, streamingComponent] : streamingComponent);
 			this.#streamingReveal.begin(
 				streamingComponent,

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -40,6 +40,7 @@ import {
 	assistantUsageIsBilled,
 	splitAssistantMessageToolTimeline,
 } from "../utils/transcript-render-helpers";
+import { createTimestampComponent } from "../utils/ui-helpers";
 import { isWarpCliAgentProtocolActive } from "../warp-events";
 import { StreamingRevealController } from "./streaming-reveal";
 import { streamingStringKeysForTool, ToolArgsRevealController } from "./tool-args-reveal";
@@ -790,12 +791,13 @@ export class EventController {
 			this.ctx.ui.requestRender();
 		} else if (event.message.role === "assistant") {
 			this.#lastVisibleBlockCount = 0;
-			this.#streamedToolCallIdByIndex.clear();
-			this.ctx.streamingComponent = createAssistantMessageComponent(this.ctx);
+			const streamingComponent = createAssistantMessageComponent(this.ctx);
+			this.ctx.streamingComponent = streamingComponent;
 			this.ctx.streamingMessage = event.message;
-			this.ctx.chatContainer.addChild(this.ctx.streamingComponent);
+			const timestamp = createTimestampComponent(event.message.timestamp);
+			this.ctx.present(timestamp ? [timestamp, streamingComponent] : streamingComponent);
 			this.#streamingReveal.begin(
-				this.ctx.streamingComponent,
+				streamingComponent,
 				splitAssistantMessageToolTimeline(this.ctx.streamingMessage).beforeTools,
 			);
 			this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -790,7 +790,7 @@ export class EventController {
 			this.ctx.addMessageToChat(event.message);
 			this.ctx.ui.requestRender();
 		} else if (event.message.role === "assistant") {
-			this.#lastVisibleBlockCount = 0;
+			this.#streamedToolCallIdByIndex.clear();
 			const streamingComponent = createAssistantMessageComponent(this.ctx);
 			this.ctx.streamingComponent = streamingComponent;
 			this.ctx.streamingMessage = event.message;

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1523,6 +1523,7 @@ export class SelectorController {
 				...selectorOptions,
 				getTerminalRows: () => this.ctx.ui.terminal.rows,
 				fillHeight: true,
+				settings: this.ctx.settings,
 			},
 		);
 		selector.setOnRequestRender(() => this.ctx.ui.requestRender());

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -63,7 +63,7 @@ import {
 } from "./transcript-render-helpers";
 
 type TextBlock = { type: "text"; text: string };
-function timestampComponent(timestamp: number | string | undefined): Text | undefined {
+export function createTimestampComponent(timestamp: number | string | undefined): Text | undefined {
 	if (timestamp === undefined) return undefined;
 	const date = new Date(timestamp);
 	if (Number.isNaN(date.getTime())) return undefined;
@@ -140,10 +140,12 @@ export class UiHelpers {
 	}
 
 	addMessageToChat(message: AgentMessage, options?: AddMessageOptions): Component[] {
-		if (message.role !== "toolResult" && message.role !== "user" && message.role !== "developer") {
-			const timestamp = timestampComponent(message.timestamp);
-			if (timestamp) this.ctx.chatContainer.addChild(timestamp);
-		}
+		const presentTimestamped = (component: Component): Component[] => {
+			const timestamp = createTimestampComponent(message.timestamp);
+			const components = timestamp ? [timestamp, component] : [component];
+			this.ctx.present(components);
+			return components;
+		};
 		switch (message.role) {
 			case "bashExecution": {
 				const component = new BashExecutionComponent(message.command, this.ctx.ui, message.excludeFromContext);
@@ -153,24 +155,25 @@ export class UiHelpers {
 				component.setComplete(message.exitCode, message.cancelled, {
 					truncation: message.meta?.truncation,
 				});
-				this.ctx.chatContainer.addChild(component);
+				presentTimestamped(component);
 				break;
 			}
 			case "pythonExecution": {
 				const component = new EvalExecutionComponent(message.code, this.ctx.ui, message.excludeFromContext);
+				if (message.output) {
+					component.appendOutput(message.output);
+				}
 				component.setComplete(message.exitCode, message.cancelled, {
 					truncation: message.meta?.truncation,
 				});
-				this.ctx.chatContainer.addChild(component);
+				presentTimestamped(component);
 				break;
 			}
 			case "hookMessage":
 			case "custom": {
 				if (message.display) {
-					const timestamp = timestampComponent(message.timestamp);
-					if (timestamp) this.ctx.chatContainer.addChild(timestamp);
 					if (message.customType === "async-result") {
-						this.ctx.chatContainer.addChild(buildAsyncResultBlock(message));
+						presentTimestamped(buildAsyncResultBlock(message));
 						break;
 					}
 					if (message.customType === LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE) {
@@ -181,18 +184,18 @@ export class UiHelpers {
 						).details;
 						const component = new LateDiagnosticsMessageComponent(details?.files ?? []);
 						component.setExpanded(this.ctx.toolOutputExpanded);
-						this.ctx.chatContainer.addChild(component);
+						presentTimestamped(component);
 						break;
 					}
 					if (message.customType === COLLAB_PROMPT_MESSAGE_TYPE) {
 						const component = new CollabPromptMessageComponent(message as CustomMessage<CollabPromptDetails>);
-						this.ctx.chatContainer.addChild(component);
+						presentTimestamped(component);
 						break;
 					}
 					if (message.customType === SKILL_PROMPT_MESSAGE_TYPE) {
 						const component = new SkillMessageComponent(message as CustomMessage<SkillPromptDetails>);
 						component.setExpanded(this.ctx.toolOutputExpanded);
-						this.ctx.chatContainer.addChild(component);
+						presentTimestamped(component);
 						break;
 					}
 					if (
@@ -201,18 +204,15 @@ export class UiHelpers {
 						message.customType === "irc:relay"
 					) {
 						const card = buildIrcMessageCard(message, () => this.ctx.toolOutputExpanded);
-						this.ctx.chatContainer.addChild(card);
-						return [card];
+						return presentTimestamped(card);
 					}
 					if (message.customType === "advisor") {
 						const details = (message as CustomMessage<AdvisorMessageDetails>).details;
-						this.ctx.chatContainer.addChild(
-							createAdvisorMessageCard(details, () => this.ctx.toolOutputExpanded, theme),
-						);
+						presentTimestamped(createAdvisorMessageCard(details, () => this.ctx.toolOutputExpanded, theme));
 						break;
 					}
 					if (message.customType === BACKGROUND_TAN_DISPATCH_MESSAGE_TYPE) {
-						this.ctx.chatContainer.addChild(createBackgroundTanDispatchBlock(message as CustomMessage<unknown>));
+						presentTimestamped(createBackgroundTanDispatchBlock(message as CustomMessage<unknown>));
 						break;
 					}
 					const handoffComponent = createHandoffSummaryMessageComponent(
@@ -220,41 +220,38 @@ export class UiHelpers {
 						this.ctx.toolOutputExpanded,
 					);
 					if (handoffComponent) {
-						this.ctx.chatContainer.addChild(handoffComponent);
+						presentTimestamped(handoffComponent);
 						break;
 					}
 					const renderer = this.ctx.viewSession.extensionRunner?.getMessageRenderer(message.customType);
-					// Both HookMessage and CustomMessage have the same structure, cast for compatibility
 					const component = new CustomMessageComponent(message as CustomMessage<unknown>, renderer);
 					component.setExpanded(this.ctx.toolOutputExpanded);
-					this.ctx.chatContainer.addChild(component);
+					presentTimestamped(component);
 				}
 				break;
 			}
 			case "compactionSummary": {
 				const component = new CompactionSummaryMessageComponent(message);
 				component.setExpanded(this.ctx.toolOutputExpanded);
-				this.ctx.chatContainer.addChild(component);
+				presentTimestamped(component);
 				break;
 			}
 			case "branchSummary": {
 				const component = new BranchSummaryMessageComponent(message);
 				component.setExpanded(this.ctx.toolOutputExpanded);
-				this.ctx.chatContainer.addChild(component);
+				presentTimestamped(component);
 				break;
 			}
 			case "fileMention": {
 				// Render compact file mention display
 				const block = buildFileMentionBlock(message.files, 0);
-				if (block.children.length > 0) this.ctx.chatContainer.addChild(block);
+				if (block.children.length > 0) presentTimestamped(block);
 				break;
 			}
 			case "user":
 			case "developer": {
 				const textContent = this.ctx.getUserMessageText(message);
 				if (textContent) {
-					const timestamp = timestampComponent(message.timestamp);
-					if (timestamp) this.ctx.chatContainer.addChild(timestamp);
 					const isSynthetic = message.role === "developer" ? true : (message.synthetic ?? false);
 					const cached = options?.reuseSettledComponent
 						? this.ctx.transcriptMessageComponents.get(message)
@@ -272,7 +269,7 @@ export class UiHelpers {
 						userComponent = new UserMessageComponent(textContent, isSynthetic, imageLinks);
 						this.ctx.transcriptMessageComponents.set(message, userComponent);
 					}
-					this.ctx.chatContainer.addChild(userComponent);
+					presentTimestamped(userComponent);
 					if (options?.populateHistory && message.role === "user" && !isSynthetic) {
 						this.ctx.editor.addToHistory(textContent);
 					}
@@ -290,7 +287,7 @@ export class UiHelpers {
 				if (cached !== assistantComponent) {
 					this.ctx.transcriptMessageComponents.set(message, assistantComponent);
 				}
-				this.ctx.chatContainer.addChild(assistantComponent);
+				presentTimestamped(assistantComponent);
 				break;
 			}
 			case "toolResult": {

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -63,6 +63,13 @@ import {
 } from "./transcript-render-helpers";
 
 type TextBlock = { type: "text"; text: string };
+function timestampComponent(timestamp: number | string | undefined): Text | undefined {
+	if (timestamp === undefined) return undefined;
+	const date = new Date(timestamp);
+	if (Number.isNaN(date.getTime())) return undefined;
+	return new Text(theme.fg("dim", date.toLocaleString()), 1, 0);
+}
+
 interface RenderInitialMessagesOptions {
 	preserveExistingChat?: boolean;
 	clearTerminalHistory?: boolean;
@@ -133,6 +140,10 @@ export class UiHelpers {
 	}
 
 	addMessageToChat(message: AgentMessage, options?: AddMessageOptions): Component[] {
+		if (message.role !== "toolResult" && message.role !== "user" && message.role !== "developer") {
+			const timestamp = timestampComponent(message.timestamp);
+			if (timestamp) this.ctx.chatContainer.addChild(timestamp);
+		}
 		switch (message.role) {
 			case "bashExecution": {
 				const component = new BashExecutionComponent(message.command, this.ctx.ui, message.excludeFromContext);
@@ -147,9 +158,6 @@ export class UiHelpers {
 			}
 			case "pythonExecution": {
 				const component = new EvalExecutionComponent(message.code, this.ctx.ui, message.excludeFromContext);
-				if (message.output) {
-					component.appendOutput(message.output);
-				}
 				component.setComplete(message.exitCode, message.cancelled, {
 					truncation: message.meta?.truncation,
 				});
@@ -159,6 +167,8 @@ export class UiHelpers {
 			case "hookMessage":
 			case "custom": {
 				if (message.display) {
+					const timestamp = timestampComponent(message.timestamp);
+					if (timestamp) this.ctx.chatContainer.addChild(timestamp);
 					if (message.customType === "async-result") {
 						this.ctx.chatContainer.addChild(buildAsyncResultBlock(message));
 						break;
@@ -243,6 +253,8 @@ export class UiHelpers {
 			case "developer": {
 				const textContent = this.ctx.getUserMessageText(message);
 				if (textContent) {
+					const timestamp = timestampComponent(message.timestamp);
+					if (timestamp) this.ctx.chatContainer.addChild(timestamp);
 					const isSynthetic = message.role === "developer" ? true : (message.synthetic ?? false);
 					const cached = options?.reuseSettledComponent
 						? this.ctx.transcriptMessageComponents.get(message)

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -63,8 +63,11 @@ import {
 } from "./transcript-render-helpers";
 
 type TextBlock = { type: "text"; text: string };
-export function createTimestampComponent(timestamp: number | string | undefined): Text | undefined {
-	if (timestamp === undefined) return undefined;
+export function createTimestampComponent(
+	timestamp: number | string | undefined,
+	enabled: boolean = true,
+): Text | undefined {
+	if (!enabled || timestamp === undefined) return undefined;
 	const date = new Date(timestamp);
 	if (Number.isNaN(date.getTime())) return undefined;
 	return new Text(theme.fg("dim", date.toLocaleString()), 1, 0);
@@ -140,8 +143,9 @@ export class UiHelpers {
 	}
 
 	addMessageToChat(message: AgentMessage, options?: AddMessageOptions): Component[] {
+		const showTimestamps = this.ctx.settings?.get?.("display.showTimestamps") ?? true;
 		const presentTimestamped = (component: Component): Component[] => {
-			const timestamp = createTimestampComponent(message.timestamp);
+			const timestamp = createTimestampComponent(message.timestamp, showTimestamps);
 			const components = timestamp ? [timestamp, component] : [component];
 			this.ctx.present(components);
 			return components;

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -22,6 +22,18 @@ import { FileSessionStorage, type SessionStorage, type SessionStorageStat } from
  */
 export type SessionStatus = "complete" | "interrupted" | "aborted" | "error" | "pending" | "unknown";
 
+export interface SessionUserMessage {
+	entryId: string;
+	text: string;
+	timestamp: string;
+}
+
+export interface SessionGoal {
+	text: string;
+	timestamp: string;
+	source: "initial" | "compaction" | "branch_summary";
+}
+
 export interface SessionInfo {
 	path: string;
 	id: string;
@@ -37,6 +49,11 @@ export interface SessionInfo {
 	size: number;
 	firstMessage: string;
 	allMessagesText: string;
+	userMessages?: SessionUserMessage[];
+	lastUserMessage?: string;
+	lastUserMessageTimestamp?: Date;
+	goalHistory?: SessionGoal[];
+	goal?: string;
 	/**
 	 * Coarse lifecycle status from the session's last persisted message. Optional:
 	 * synthesized {@link SessionInfo}s (cross-project stubs, tests) leave it unset.
@@ -152,6 +169,12 @@ function extractTextFromContent(content: Message["content"]): string {
 		if (block.type === "text") text.push(block.text);
 	}
 	return text.join(" ");
+}
+
+function extractGoalText(summary: string): string | undefined {
+	const match = summary.match(/(?:^|\n)##\s*Goal\s*\n([\s\S]*?)(?=\n##\s|\s*$)/i);
+	const goal = match?.[1]?.trim();
+	return goal && !/^\[[^\]]+\]$/.test(goal) ? goal : undefined;
 }
 
 /**
@@ -402,8 +425,6 @@ async function scanSessionFile(
 		return undefined;
 	}
 	const cache = getSessionScanCache(storage);
-	// `withStatus` changes what a scan reads (tail window) and returns, so the
-	// two variants are cached under distinct keys.
 	const cacheKey = withStatus ? `s\0${file}` : `h\0${file}`;
 	const cached = cache.get(cacheKey);
 	if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
@@ -428,26 +449,49 @@ async function scanSessionFile(
 		let parsedMessageCount = 0;
 		let firstMessage = "";
 		const allMessages: string[] = [];
+		const userMessages: SessionUserMessage[] = [];
+		const goalHistory: SessionGoal[] = [];
 		let shortSummary: string | undefined;
+		const fallbackTimestamp = header.timestamp ?? new Date(0).toISOString();
 
 		for (let i = 1; i < entries.length; i++) {
-			const entry = entries[i] as { type?: string; message?: Message; shortSummary?: string };
+			const entry = entries[i] as {
+				type?: string;
+				message?: Message;
+				shortSummary?: string;
+				summary?: string;
+				timestamp?: string;
+				id?: string;
+			};
 
-			if (entry.type === "compaction" && typeof entry.shortSummary === "string") {
-				shortSummary = entry.shortSummary;
+			if ((entry.type === "compaction" || entry.type === "branch_summary") && entry.summary) {
+				const goal = extractGoalText(entry.summary);
+				if (goal) {
+					goalHistory.push({
+						text: goal,
+						source: entry.type === "compaction" ? "compaction" : "branch_summary",
+						timestamp: entry.timestamp ?? fallbackTimestamp,
+					});
+				}
 			}
 
 			if (entry.type === "message" && entry.message) {
 				parsedMessageCount++;
-
 				if (entry.message.role === "user" || entry.message.role === "assistant") {
 					const textContent = extractTextFromContent(entry.message.content);
-
 					if (textContent) {
 						allMessages.push(textContent);
-
-						if (!firstMessage && entry.message.role === "user") {
-							firstMessage = textContent;
+						if (entry.message.role === "user") {
+							const messageTimestamp = (entry.message as { timestamp?: number }).timestamp;
+							const timestamp =
+								typeof messageTimestamp === "number"
+									? new Date(messageTimestamp).toISOString()
+									: (entry.timestamp ?? fallbackTimestamp);
+							userMessages.push({ entryId: entry.id ?? `message-${i}`, text: textContent, timestamp });
+							if (!firstMessage) {
+								firstMessage = textContent;
+								goalHistory.unshift({ text: textContent, timestamp, source: "initial" });
+							}
 						}
 					}
 				}
@@ -468,6 +512,11 @@ async function scanSessionFile(
 			size,
 			firstMessage: firstMessage || "(no messages)",
 			allMessagesText: allMessages.length > 0 ? allMessages.join(" ") : firstMessage,
+			userMessages,
+			lastUserMessage: userMessages.at(-1)?.text,
+			lastUserMessageTimestamp: userMessages.at(-1) ? new Date(userMessages.at(-1)!.timestamp) : undefined,
+			goalHistory,
+			goal: goalHistory.at(-1)?.text,
 			status: withStatus ? deriveSessionStatus(suffix) : undefined,
 		};
 		// The cache keeps its own shallow copy; hits also hand out copies, so

--- a/packages/coding-agent/test/session-display-settings.test.ts
+++ b/packages/coding-agent/test/session-display-settings.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "bun:test";
+import { getDefault } from "@oh-my-pi/pi-coding-agent/config/settings";
+
+describe("session display settings", () => {
+	it("defaults new session context controls to enabled", () => {
+		expect(getDefault("display.showTimestamps")).toBe(true);
+		expect(getDefault("display.showRecentUserMessages")).toBe(true);
+		expect(getDefault("display.showGoalHistory")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/session-selector-search.test.ts
+++ b/packages/coding-agent/test/session-selector-search.test.ts
@@ -212,4 +212,27 @@ describe("session picker incremental search", () => {
 		expect(ids(rankSessionSearchMatches(sessions, "latest request"))).toEqual(["recent"]);
 		expect(ids(rankSessionSearchMatches(sessions, "ship timestamps"))).toEqual(["recent"]);
 	});
+
+	it("hides recent-message and goal metadata when disabled", () => {
+		const session = makeSession("hidden", {
+			firstMessage: "old request",
+			lastUserMessage: "latest request",
+			lastUserMessageTimestamp: new Date("2026-01-01T00:00:00.000Z"),
+			goalHistory: [{ text: "ship timestamps", timestamp: "2026-01-01T00:00:00.000Z", source: "initial" }],
+		});
+		const selector = new SessionSelectorComponent(
+			[session],
+			() => {},
+			() => {},
+			() => {},
+			{
+				showRecentUserMessages: false,
+				showGoalHistory: false,
+			},
+		);
+		const rendered = selector.render(120).join("\n");
+		expect(rendered).toContain("old request");
+		expect(rendered).not.toContain("latest request");
+		expect(rendered).not.toContain("goals 1");
+	});
 });

--- a/packages/coding-agent/test/session-selector-search.test.ts
+++ b/packages/coding-agent/test/session-selector-search.test.ts
@@ -197,4 +197,19 @@ describe("session picker incremental search", () => {
 		expect(calls).toEqual([]);
 		expect(harness.filtered().length).toBe(partial);
 	});
+
+	it("searches latest user messages and retained goals", () => {
+		const sessions = [
+			makeSession("recent", {
+				firstMessage: "old request",
+				lastUserMessage: "latest request",
+				userMessages: [{ entryId: "u1", text: "latest request", timestamp: "2026-01-01T00:00:00.000Z" }],
+				goal: "ship timestamps",
+				goalHistory: [{ text: "ship timestamps", timestamp: "2026-01-01T00:00:00.000Z", source: "initial" }],
+			}),
+			makeSession("other", { firstMessage: "unrelated" }),
+		];
+		expect(ids(rankSessionSearchMatches(sessions, "latest request"))).toEqual(["recent"]);
+		expect(ids(rankSessionSearchMatches(sessions, "ship timestamps"))).toEqual(["recent"]);
+	});
 });


### PR DESCRIPTION
## Summary
- add session item and last-user timestamps
- expose recent user messages and retained goal history in session search/selector views
- keep timestamps adjacent to visible streamed and non-streamed transcript entries

## Why / Rationale
Users need to find what they last said and recover the goal context of completed sessions without reopening or reconstructing the transcript.

## Verification
- `bun run check:types` passed
- focused Biome checks passed
- `graphify update .` completed
- full coding-agent tests are blocked by the missing darwin-arm64 `pi_natives` addon
- source build is blocked because Bazel/Bazelisk and the native addon are unavailable

## Risk
Legacy session metadata remains optional with deterministic fallbacks.