### PR TITLE
feat(coding-agent): add Grok live voice mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,19 @@
 ## [Unreleased]
 
 ## [17.2.12] - 2026-08-08
+### Added
+- Added xAI Grok Voice support for `/live` mode (`grok-voice-think-fast-2.0`) using xAI Realtime WebSockets, with automatic or per-invocation provider selection (`/live grok|codex`) and separate Codex/Grok voice settings.
+
+- Added support for the [Agent Plugins 1.0.0 standard](https://agent-plugins.org): plugin packages with a root `plugin.json` targeting the canonical schema are discovered from marketplace installs, `--plugin-dir`, and configured extension roots, with `skills/` and `mcp.json` loaded per the specification (closed-schema validation per skills-ref, `${PLUGIN_ROOT}`/`${PLUGIN_DATA}` expansion, reserved subprocess environment, instance-keyed persistent data directories, and per-component failure isolation). Package-boundary containment is enforced before every read — including `skill://` resource access from the read tool and bash, where plugin skill files must realpath-resolve inside the plugin root.
+- Remote MCP transports now enforce header precedence and origin policy: client-generated HTTP/MCP/authorization headers win over configured headers case-insensitively, and Agent Plugins servers never forward configured headers across a redirect to a different origin (method-changing redirects of JSON-RPC POSTs are refused). Agent Plugins stdio `env` values and remote `headers` are likewise exempt from config-value resolution (no ambient env-name lookup, no `!command` execution, empty values preserved).
+- Added `omp share <session>`: share a saved session by id prefix or `.jsonl` path without launching the agent — same encrypted upload, store selection, and `share.redactSecrets` handling as the `/share` slash command.
+- Added `AGENT=1` to coding-agent child-process environments so downstream tools can detect agent-driven execution ([#7847](https://github.com/can1357/oh-my-pi/issues/7847)).
+
+### Changed
+
+- Consolidated Exa web-search enablement on `exa.enabled`; legacy `exa.enableSearch` values migrate automatically, and the obsolete Researcher and Websets settings have been removed.
+- Removed stale `computer.backend` values during config migration.
+- Clarified the JavaScript/TypeScript debug adapter install path: `js-debug-adapter` is the omp adapter id, not an npm package, so `npm i -g js-debug-adapter` 404s. The docs and the "adapter not available" message now point to the supported installs — Mason, the standalone release tarball extracted under `~/.local/opt` (auto-discovered), or `JS_DEBUG_DAP_SERVER`. The docs also note the adapter runs under `node` if available, else the omp Bun host ([#7757](https://github.com/can1357/oh-my-pi/issues/7757)).
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [17.2.12] - 2026-08-08
 ### Added
-- Added xAI Grok Voice support for `/live` mode (`grok-voice-think-fast-2.0`) using xAI Realtime WebSockets, with automatic or per-invocation provider selection (`/live grok|codex`) and separate Codex/Grok voice settings.
+- Added xAI Grok Voice support for `/live` mode (`grok-voice-think-fast-2.0`) using xAI Realtime WebSockets, with ranked voice providers configured by `providers.voiceOrder`, per-invocation `/live grok|codex` overrides, and separate Codex/Grok voice settings.
 
 - Added support for the [Agent Plugins 1.0.0 standard](https://agent-plugins.org): plugin packages with a root `plugin.json` targeting the canonical schema are discovered from marketplace installs, `--plugin-dir`, and configured extension roots, with `skills/` and `mcp.json` loaded per the specification (closed-schema validation per skills-ref, `${PLUGIN_ROOT}`/`${PLUGIN_DATA}` expansion, reserved subprocess environment, instance-keyed persistent data directories, and per-component failure isolation). Package-boundary containment is enforced before every read — including `skill://` resource access from the read tool and bash, where plugin skill files must realpath-resolve inside the plugin root.
 - Remote MCP transports now enforce header precedence and origin policy: client-generated HTTP/MCP/authorization headers win over configured headers case-insensitively, and Agent Plugins servers never forward configured headers across a redirect to a different origin (method-changing redirects of JSON-RPC POSTs are refused). Agent Plugins stdio `env` values and remote `headers` are likewise exempt from config-value resolution (no ambient env-name lookup, no `!command` execution, empty values preserved).

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2,7 +2,14 @@ import { THINKING_EFFORTS } from "@oh-my-pi/pi-ai";
 import { DEFAULT_SHARE_URL } from "@oh-my-pi/pi-wire";
 import { SHAPE_VARIANT_NAMES } from "@oh-my-pi/snapcompact";
 import { DEFAULT_RELAY_URL } from "../collab/protocol";
-import { DEFAULT_LIVE_VOICE, LIVE_VOICE_OPTIONS, LIVE_VOICE_VALUES } from "../live/voices";
+import {
+	CODEX_LIVE_VOICE_OPTIONS,
+	CODEX_LIVE_VOICE_VALUES,
+	DEFAULT_CODEX_LIVE_VOICE,
+	DEFAULT_GROK_LIVE_VOICE,
+	GROK_LIVE_VOICE_OPTIONS,
+	GROK_LIVE_VOICE_VALUES,
+} from "../live/voices";
 import { DEFAULT_STT_MODEL_KEY, STT_MODEL_OPTIONS, STT_MODEL_VALUES } from "../stt/models";
 import { STT_SUBMIT_TRIGGER_OPTIONS, STT_SUBMIT_TRIGGER_VALUES } from "../stt/submit-trigger";
 import { AUTO_THINKING, getConfiguredThinkingLevelMetadata, getThinkingLevelMetadata } from "../thinking";
@@ -4992,16 +4999,56 @@ export const SETTINGS_SCHEMA = {
 			],
 		},
 	},
-	"live.voice": {
+	"live.provider": {
 		type: "enum",
-		values: LIVE_VOICE_VALUES,
-		default: DEFAULT_LIVE_VOICE,
+		values: ["auto", "openai-codex", "xai-grok"] as const,
+		default: "auto",
 		ui: {
 			tab: "providers",
 			group: "Services",
-			label: "Live Voice",
+			label: "Live Voice Provider",
+			description: "Realtime backend for /live mode: Auto, OpenAI Codex, or xAI Grok Voice",
+			options: [
+				{
+					value: "auto",
+					label: "Auto",
+					description: "Prefer Codex when configured; otherwise use an available xAI API key",
+				},
+				{
+					value: "openai-codex",
+					label: "OpenAI Codex",
+					description: "Codex WebRTC realtime API",
+				},
+				{
+					value: "xai-grok",
+					label: "xAI Grok Voice",
+					description: "xAI Grok Realtime WebSocket API (grok-voice-think-fast-2.0)",
+				},
+			],
+		},
+	},
+	"live.codexVoice": {
+		type: "enum",
+		values: CODEX_LIVE_VOICE_VALUES,
+		default: DEFAULT_CODEX_LIVE_VOICE,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "Codex Live Voice",
 			description: "Voice used by Codex-backed realtime voice sessions",
-			options: LIVE_VOICE_OPTIONS,
+			options: CODEX_LIVE_VOICE_OPTIONS,
+		},
+	},
+	"live.grokVoice": {
+		type: "enum",
+		values: GROK_LIVE_VOICE_VALUES,
+		default: DEFAULT_GROK_LIVE_VOICE,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "Grok Live Voice",
+			description: "Voice used by xAI Grok-backed realtime voice sessions",
+			options: GROK_LIVE_VOICE_OPTIONS,
 		},
 	},
 	"providers.tts": {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2,6 +2,7 @@ import { THINKING_EFFORTS } from "@oh-my-pi/pi-ai";
 import { DEFAULT_SHARE_URL } from "@oh-my-pi/pi-wire";
 import { SHAPE_VARIANT_NAMES } from "@oh-my-pi/snapcompact";
 import { DEFAULT_RELAY_URL } from "../collab/protocol";
+import { VOICE_PROVIDER_CHOICES, type VoiceProviderId } from "../live/providers/base";
 import {
 	CODEX_LIVE_VOICE_OPTIONS,
 	CODEX_LIVE_VOICE_VALUES,
@@ -4999,32 +5000,16 @@ export const SETTINGS_SCHEMA = {
 			],
 		},
 	},
-	"live.provider": {
-		type: "enum",
-		values: ["auto", "openai-codex", "xai-grok"] as const,
-		default: "auto",
+	"providers.voiceOrder": {
+		type: "array",
+		default: [] as VoiceProviderId[],
 		ui: {
 			tab: "providers",
 			group: "Services",
-			label: "Live Voice Provider",
-			description: "Realtime backend for /live mode: Auto, OpenAI Codex, or xAI Grok Voice",
-			options: [
-				{
-					value: "auto",
-					label: "Auto",
-					description: "Prefer Codex when configured; otherwise use an available xAI API key",
-				},
-				{
-					value: "openai-codex",
-					label: "OpenAI Codex",
-					description: "Codex WebRTC realtime API",
-				},
-				{
-					value: "xai-grok",
-					label: "xAI Grok Voice",
-					description: "xAI Grok Realtime WebSocket API (grok-voice-think-fast-2.0)",
-				},
-			],
+			label: "Voice Provider Order",
+			description: "Prioritized providers for /live mode; unlisted providers follow the built-in order",
+			options: VOICE_PROVIDER_CHOICES,
+			ordered: true,
 		},
 	},
 	"live.codexVoice": {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2,7 +2,7 @@ import { THINKING_EFFORTS } from "@oh-my-pi/pi-ai";
 import { DEFAULT_SHARE_URL } from "@oh-my-pi/pi-wire";
 import { SHAPE_VARIANT_NAMES } from "@oh-my-pi/snapcompact";
 import { DEFAULT_RELAY_URL } from "../collab/protocol";
-import { VOICE_PROVIDER_CHOICES, type VoiceProviderId } from "../live/providers/base";
+import { VOICE_PROVIDER_OPTIONS, type VoiceProviderId } from "../live/provider";
 import {
 	CODEX_LIVE_VOICE_OPTIONS,
 	CODEX_LIVE_VOICE_VALUES,
@@ -5008,7 +5008,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Services",
 			label: "Voice Provider Order",
 			description: "Prioritized providers for /live mode; unlisted providers follow the built-in order",
-			options: VOICE_PROVIDER_CHOICES,
+			options: VOICE_PROVIDER_OPTIONS,
 			ordered: true,
 		},
 	},

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -36,6 +36,7 @@ import { invalidate as invalidateCapabilityFsCache } from "../capability/fs";
 import { type Settings as SettingsCapabilityItem, settingsCapability } from "../capability/settings";
 import type { ModelRole } from "../config/model-roles";
 import { loadCapability } from "../discovery";
+import { isVoiceProviderId, VOICE_PROVIDER_ORDER } from "../live/providers/base";
 import { isLightTheme, setAutoThemeMapping, setColorBlindMode, setSymbolPreset } from "../modes/theme/theme";
 import { AgentStorage } from "../session/agent-storage";
 import { AUTO_IMAGE_PROVIDER_ORDER, isImageProviderId } from "../tools/image-providers";
@@ -1392,6 +1393,31 @@ export class Settings {
 		}
 		delete raw["live.voice"];
 		delete raw["live.codexVoice"];
+
+		// live.provider -> providers.voiceOrder. Provider IDs were also shortened
+		// when voice selection moved to the shared ranked-provider contract.
+		const legacyVoiceProvider = liveObj?.provider ?? raw["live.provider"];
+		const voiceProvidersObj = isRecord(raw.providers) ? raw.providers : undefined;
+		const existingVoiceOrder = voiceProvidersObj?.voiceOrder ?? raw["providers.voiceOrder"];
+		if (
+			(!Array.isArray(existingVoiceOrder) || existingVoiceOrder.length === 0) &&
+			typeof legacyVoiceProvider === "string" &&
+			legacyVoiceProvider !== "auto"
+		) {
+			const id =
+				legacyVoiceProvider === "openai-codex"
+					? "codex"
+					: legacyVoiceProvider === "xai-grok"
+						? "grok"
+						: legacyVoiceProvider;
+			if (isVoiceProviderId(id)) {
+				const target = voiceProvidersObj ?? {};
+				target.voiceOrder = [id, ...VOICE_PROVIDER_ORDER.filter(providerId => providerId !== id)];
+				raw.providers = target;
+			}
+		}
+		if (liveObj) delete liveObj.provider;
+		delete raw["live.provider"];
 
 		// ask.timeout: ms -> seconds (if value > 1000, it's old ms format)
 		if (raw.ask && typeof (raw.ask as Record<string, unknown>).timeout === "number") {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -36,7 +36,6 @@ import { invalidate as invalidateCapabilityFsCache } from "../capability/fs";
 import { type Settings as SettingsCapabilityItem, settingsCapability } from "../capability/settings";
 import type { ModelRole } from "../config/model-roles";
 import { loadCapability } from "../discovery";
-import { isVoiceProviderId, VOICE_PROVIDER_ORDER } from "../live/providers/base";
 import { isLightTheme, setAutoThemeMapping, setColorBlindMode, setSymbolPreset } from "../modes/theme/theme";
 import { AgentStorage } from "../session/agent-storage";
 import { AUTO_IMAGE_PROVIDER_ORDER, isImageProviderId } from "../tools/image-providers";
@@ -1377,47 +1376,19 @@ export class Settings {
 		delete raw["startup.changelogMode"];
 		// live.voice -> live.codexVoice. `/live` now keeps provider-specific
 		// voice preferences so selecting a Grok voice never overwrites Codex.
-		// Preserve an explicit new key and normalize flat dotted sources.
+		// Preserve an explicit new key and handle nested or quoted-dotted legacy sources.
 		const liveObj = isRecord(raw.live) ? (raw.live as Record<string, unknown>) : undefined;
 		const nestedLegacyVoice = typeof liveObj?.voice === "string" ? liveObj.voice : undefined;
 		const flatLegacyVoice = typeof raw["live.voice"] === "string" ? (raw["live.voice"] as string) : undefined;
-		const flatCodexVoice =
-			typeof raw["live.codexVoice"] === "string" ? (raw["live.codexVoice"] as string) : undefined;
-		if (nestedLegacyVoice !== undefined || flatLegacyVoice !== undefined || flatCodexVoice !== undefined) {
+		if (nestedLegacyVoice !== undefined || flatLegacyVoice !== undefined) {
 			if (!liveObj) raw.live = {};
 			const target = raw.live as Record<string, unknown>;
 			if (target.codexVoice === undefined) {
-				target.codexVoice = flatCodexVoice ?? nestedLegacyVoice ?? flatLegacyVoice;
+				target.codexVoice = nestedLegacyVoice ?? flatLegacyVoice;
 			}
 			delete target.voice;
 		}
 		delete raw["live.voice"];
-		delete raw["live.codexVoice"];
-
-		// live.provider -> providers.voiceOrder. Provider IDs were also shortened
-		// when voice selection moved to the shared ranked-provider contract.
-		const legacyVoiceProvider = liveObj?.provider ?? raw["live.provider"];
-		const voiceProvidersObj = isRecord(raw.providers) ? raw.providers : undefined;
-		const existingVoiceOrder = voiceProvidersObj?.voiceOrder ?? raw["providers.voiceOrder"];
-		if (
-			(!Array.isArray(existingVoiceOrder) || existingVoiceOrder.length === 0) &&
-			typeof legacyVoiceProvider === "string" &&
-			legacyVoiceProvider !== "auto"
-		) {
-			const id =
-				legacyVoiceProvider === "openai-codex"
-					? "codex"
-					: legacyVoiceProvider === "xai-grok"
-						? "grok"
-						: legacyVoiceProvider;
-			if (isVoiceProviderId(id)) {
-				const target = voiceProvidersObj ?? {};
-				target.voiceOrder = [id, ...VOICE_PROVIDER_ORDER.filter(providerId => providerId !== id)];
-				raw.providers = target;
-			}
-		}
-		if (liveObj) delete liveObj.provider;
-		delete raw["live.provider"];
 
 		// ask.timeout: ms -> seconds (if value > 1000, it's old ms format)
 		if (raw.ask && typeof (raw.ask as Record<string, unknown>).timeout === "number") {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -1374,6 +1374,24 @@ export class Settings {
 		}
 		delete raw.collapseChangelog;
 		delete raw["startup.changelogMode"];
+		// live.voice -> live.codexVoice. `/live` now keeps provider-specific
+		// voice preferences so selecting a Grok voice never overwrites Codex.
+		// Preserve an explicit new key and normalize flat dotted sources.
+		const liveObj = isRecord(raw.live) ? (raw.live as Record<string, unknown>) : undefined;
+		const nestedLegacyVoice = typeof liveObj?.voice === "string" ? liveObj.voice : undefined;
+		const flatLegacyVoice = typeof raw["live.voice"] === "string" ? (raw["live.voice"] as string) : undefined;
+		const flatCodexVoice =
+			typeof raw["live.codexVoice"] === "string" ? (raw["live.codexVoice"] as string) : undefined;
+		if (nestedLegacyVoice !== undefined || flatLegacyVoice !== undefined || flatCodexVoice !== undefined) {
+			if (!liveObj) raw.live = {};
+			const target = raw.live as Record<string, unknown>;
+			if (target.codexVoice === undefined) {
+				target.codexVoice = flatCodexVoice ?? nestedLegacyVoice ?? flatLegacyVoice;
+			}
+			delete target.voice;
+		}
+		delete raw["live.voice"];
+		delete raw["live.codexVoice"];
 
 		// ask.timeout: ms -> seconds (if value > 1000, it's old ms format)
 		if (raw.ask && typeof (raw.ask as Record<string, unknown>).timeout === "number") {

--- a/packages/coding-agent/src/live/controller.ts
+++ b/packages/coding-agent/src/live/controller.ts
@@ -21,6 +21,11 @@ import type { LivePhase } from "./visualizer";
 
 const OUTPUT_ACTIVE_LEVEL = 0.015;
 
+interface PendingDelegation {
+	id: string;
+	request: string;
+}
+
 /** Incremental or final transcript for one realtime conversational turn. */
 export interface LiveTranscript {
 	role: "user" | "assistant";
@@ -113,6 +118,7 @@ export class LiveSessionController {
 	#inputLevel = 0;
 	#outputLevel = 0;
 	#activeDelegationId: string | undefined;
+	readonly #delegationQueue: PendingDelegation[] = [];
 	#userTranscript = "";
 	#assistantTranscript = "";
 	#userTranscriptFinal = false;
@@ -247,6 +253,8 @@ export class LiveSessionController {
 		this.#stopped = true;
 		this.#unsubscribeSession?.();
 		this.#unsubscribeSession = undefined;
+		this.#activeDelegationId = undefined;
+		this.#delegationQueue.length = 0;
 		let cleanupError: Error | undefined;
 
 		const recorder = this.#recorder;
@@ -323,13 +331,24 @@ export class LiveSessionController {
 		}
 		request = request.trim();
 		if (!request) return;
-		this.#activeDelegationId = event.item.id;
+		this.#delegationQueue.push({ id: event.item.id, request });
+		this.#startNextDelegation();
+	}
+
+	#startNextDelegation(): void {
+		if (this.#activeDelegationId || this.#stopped) return;
+		const delegation = this.#delegationQueue.shift();
+		if (!delegation) {
+			this.#refreshAudioPhase();
+			return;
+		}
+		this.#activeDelegationId = delegation.id;
 		this.#emitPhase("working");
 		void this.#session
 			.sendCustomMessage(
 				{
 					customType: LIVE_DELEGATION_MESSAGE_TYPE,
-					content: request,
+					content: delegation.request,
 					display: true,
 					attribution: "agent",
 				},
@@ -360,20 +379,20 @@ export class LiveSessionController {
 	#appendFinalResponse(messages: readonly AgentMessage[]): void {
 		const delegationId = this.#activeDelegationId;
 		if (!delegationId) return;
+		let text = "";
 		for (let index = messages.length - 1; index >= 0; index -= 1) {
 			const message = messages[index];
 			if (message?.role !== "assistant") continue;
-			const text = this.#extractAssistantText(message).trim();
-			if (!text) continue;
-			const finalContext = chunkLiveContext(prompt.render(agentFinalMessageTemplate, { message: text }));
-			for (const [chunkIndex, chunk] of finalContext.entries()) {
-				const channel = chunkIndex === finalContext.length - 1 ? "speakable" : "commentary";
-				this.#queueSend(buildDelegationContextAppend(delegationId, chunk, channel));
-			}
-			break;
+			text = this.#extractAssistantText(message).trim();
+			if (text) break;
+		}
+		const finalContext = chunkLiveContext(prompt.render(agentFinalMessageTemplate, { message: text }));
+		for (const [chunkIndex, chunk] of finalContext.entries()) {
+			const channel = chunkIndex === finalContext.length - 1 ? "speakable" : "commentary";
+			this.#queueSend(buildDelegationContextAppend(delegationId, chunk, channel));
 		}
 		this.#activeDelegationId = undefined;
-		this.#refreshAudioPhase();
+		this.#startNextDelegation();
 	}
 
 	#handleOutputLevel(level: number): void {
@@ -386,6 +405,7 @@ export class LiveSessionController {
 		if (this.#stopped || !this.#transport || this.#muted) return;
 		this.#inputLevel = microphoneLevel(samples);
 		this.#emitLevels();
+		if (!this.#transport.shouldStreamAudio(this.#inputLevel, this.#outputLevel)) return;
 		try {
 			this.#transport.pushAudio(samples);
 		} catch (cause) {

--- a/packages/coding-agent/src/live/controller.ts
+++ b/packages/coding-agent/src/live/controller.ts
@@ -2,10 +2,11 @@ import * as os from "node:os";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { AudioCapture } from "@oh-my-pi/pi-natives";
-import { prompt } from "@oh-my-pi/pi-utils";
+import { $env, prompt } from "@oh-my-pi/pi-utils";
 import type { AgentSession } from "../session/agent-session";
 import type { AgentSessionEvent } from "../session/agent-session-events";
 import { LIVE_DELEGATION_MESSAGE_TYPE } from "../session/messages";
+import { GrokLiveTransport } from "./grok-transport";
 import agentFinalMessageTemplate from "./prompts/agent-final-message.md" with { type: "text" };
 import liveInstructionsTemplate from "./prompts/live-instructions.md" with { type: "text" };
 import {
@@ -16,12 +17,43 @@ import {
 	type LiveServerEvent,
 } from "./protocol";
 import { CodexLiveTransport } from "./transport";
+import type { ILiveTransport, LiveProvider, LiveTransportOptions, ResolvedLiveProvider } from "./transport-types";
 import type { LivePhase } from "./visualizer";
-import { DEFAULT_LIVE_VOICE } from "./voices";
+import { DEFAULT_CODEX_LIVE_VOICE, DEFAULT_GROK_LIVE_VOICE } from "./voices";
 
+async function createLiveTransport(options: LiveTransportOptions): Promise<ILiveTransport> {
+	const requested = options.provider ?? "auto";
+	if (requested === "xai-grok") {
+		return new GrokLiveTransport({
+			...options,
+			voice: options.grokVoice || options.voice || DEFAULT_GROK_LIVE_VOICE,
+		});
+	}
+	if (requested === "openai-codex") {
+		return new CodexLiveTransport({
+			...options,
+			voice: options.codexVoice || options.voice || DEFAULT_CODEX_LIVE_VOICE,
+		});
+	}
+
+	const hasXaiKey = $env.XAI_API_KEY ?? (await options.authStorage.getApiKey("xai", options.sessionId));
+
+	const hasCodexKey =
+		options.authStorage.hasNonEnvCredential("openai-codex") ||
+		Boolean($env.OPENAI_OAUTH_TOKEN || $env.CODEX_OAUTH_TOKEN);
+
+	if (hasXaiKey && !hasCodexKey) {
+		return new GrokLiveTransport({
+			...options,
+			voice: options.grokVoice || options.voice || DEFAULT_GROK_LIVE_VOICE,
+		});
+	}
+	return new CodexLiveTransport({
+		...options,
+		voice: options.codexVoice || options.voice || DEFAULT_CODEX_LIVE_VOICE,
+	});
+}
 const OUTPUT_ACTIVE_LEVEL = 0.015;
-const MIN_BARGE_IN_LEVEL = 0.04;
-const OUTPUT_ECHO_RATIO = 0.65;
 
 /** Incremental or final transcript for one realtime conversational turn. */
 export interface LiveTranscript {
@@ -52,8 +84,14 @@ export interface LiveSessionControllerOptions {
 	callbacks: LiveSessionCallbacks;
 	/** Extracts visible assistant text using the caller's normal UI rules. */
 	extractAssistantText(message: AssistantMessage): string;
-	/** Realtime output voice, defaulting to sol. */
-	voice?: string;
+	/** Codex realtime output voice. */
+	codexVoice?: string;
+	/** Grok realtime output voice. */
+	grokVoice?: string;
+	/** Provider selection override (auto, openai-codex, or xai-grok). */
+	provider?: LiveProvider;
+	/** Custom Grok model name (e.g. grok-voice-think-fast-2.0). */
+	grokModel?: string;
 }
 
 function errorFrom(cause: unknown): Error {
@@ -92,9 +130,12 @@ export class LiveSessionController {
 	readonly #session: AgentSession;
 	readonly #callbacks: LiveSessionCallbacks;
 	readonly #extractAssistantText: (message: AssistantMessage) => string;
-	readonly #voice: string;
+	readonly #codexVoice: string;
+	readonly #grokVoice: string;
+	readonly #provider: LiveProvider | undefined;
+	readonly #grokModel: string | undefined;
 
-	#transport: CodexLiveTransport | undefined;
+	#transport: ILiveTransport | undefined;
 	#recorder: AudioCapture | undefined;
 	#unsubscribeSession: (() => void) | undefined;
 	#sendChain: Promise<void> = Promise.resolve();
@@ -120,12 +161,24 @@ export class LiveSessionController {
 		this.#session = options.session;
 		this.#callbacks = options.callbacks;
 		this.#extractAssistantText = options.extractAssistantText;
-		this.#voice = options.voice?.trim() || DEFAULT_LIVE_VOICE;
+		this.#codexVoice = options.codexVoice?.trim() || DEFAULT_CODEX_LIVE_VOICE;
+		this.#grokVoice = options.grokVoice?.trim() || DEFAULT_GROK_LIVE_VOICE;
+		this.#provider = options.provider;
+		this.#grokModel = options.grokModel;
 	}
-
 	/** Current realtime call phase. */
 	get phase(): LivePhase {
 		return this.#phase;
+	}
+
+	/** Provider selected for the active transport. */
+	get provider(): ResolvedLiveProvider | undefined {
+		return this.#transport?.provider;
+	}
+
+	/** Model selected for the active transport. */
+	get model(): string | undefined {
+		return this.#transport?.model;
 	}
 
 	/** Whether microphone input is currently muted. */
@@ -151,16 +204,24 @@ export class LiveSessionController {
 		try {
 			const user = currentUser();
 			const instructions = prompt.render(liveInstructionsTemplate, user);
-			const transport = new CodexLiveTransport({
+			const transport = await createLiveTransport({
 				authStorage: this.#session.modelRegistry.authStorage,
 				sessionId: this.#session.sessionId,
 				instructions,
-				voice: this.#voice,
+				voice: this.#codexVoice,
+				codexVoice: this.#codexVoice,
+				grokVoice: this.#grokVoice,
+				provider: this.#provider,
+				grokModel: this.#grokModel,
 				callbacks: {
 					onEvent: event => this.#guardEvent(() => this.#handleLiveEvent(event)),
 					onOutputLevel: level => this.#guardEvent(() => this.#handleOutputLevel(level)),
 				},
 			});
+			if (this.#stopped) {
+				await transport.close();
+				throw this.#failure ?? new Error("The live session stopped while selecting a provider.");
+			}
 			this.#transport = transport;
 			await transport.connect();
 			if (this.#stopped) {
@@ -172,6 +233,11 @@ export class LiveSessionController {
 			if (this.#muted) await transport.setMuted(true);
 			if (this.#stopped) {
 				throw this.#failure ?? new Error("The live session stopped before recording began.");
+			}
+			if (typeof AudioCapture !== "function") {
+				throw new Error(
+					"Microphone capture is unavailable because the installed native bindings do not include AudioCapture.",
+				);
 			}
 			const recorder = new AudioCapture(16_000, (error, samples) => {
 				if (error) {
@@ -341,9 +407,10 @@ export class LiveSessionController {
 			if (message?.role !== "assistant") continue;
 			const text = this.#extractAssistantText(message).trim();
 			if (!text) continue;
-			const finalContext = prompt.render(agentFinalMessageTemplate, { message: text });
-			for (const chunk of chunkLiveContext(finalContext)) {
-				this.#queueSend(buildDelegationContextAppend(delegationId, chunk));
+			const finalContext = chunkLiveContext(prompt.render(agentFinalMessageTemplate, { message: text }));
+			for (const [chunkIndex, chunk] of finalContext.entries()) {
+				const channel = chunkIndex === finalContext.length - 1 ? "speakable" : "commentary";
+				this.#queueSend(buildDelegationContextAppend(delegationId, chunk, channel));
 			}
 			break;
 		}
@@ -358,13 +425,9 @@ export class LiveSessionController {
 	}
 
 	#handleMicrophoneAudio(samples: Float32Array): void {
-		if (this.#stopped || !this.#transport) return;
-		if (this.#muted) return;
+		if (this.#stopped || !this.#transport || this.#muted) return;
 		this.#inputLevel = microphoneLevel(samples);
 		this.#emitLevels();
-		const outputActive = this.#outputLevel > OUTPUT_ACTIVE_LEVEL;
-		const echoThreshold = Math.max(MIN_BARGE_IN_LEVEL, this.#outputLevel * OUTPUT_ECHO_RATIO);
-		if (outputActive && this.#inputLevel < echoThreshold) return;
 		try {
 			this.#transport.pushAudio(samples);
 		} catch (cause) {

--- a/packages/coding-agent/src/live/controller.ts
+++ b/packages/coding-agent/src/live/controller.ts
@@ -2,11 +2,10 @@ import * as os from "node:os";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { AudioCapture } from "@oh-my-pi/pi-natives";
-import { $env, prompt } from "@oh-my-pi/pi-utils";
+import { prompt } from "@oh-my-pi/pi-utils";
 import type { AgentSession } from "../session/agent-session";
 import type { AgentSessionEvent } from "../session/agent-session-events";
 import { LIVE_DELEGATION_MESSAGE_TYPE } from "../session/messages";
-import { GrokLiveTransport } from "./grok-transport";
 import agentFinalMessageTemplate from "./prompts/agent-final-message.md" with { type: "text" };
 import liveInstructionsTemplate from "./prompts/live-instructions.md" with { type: "text" };
 import {
@@ -16,43 +15,10 @@ import {
 	type LiveClientMessage,
 	type LiveServerEvent,
 } from "./protocol";
-import { CodexLiveTransport } from "./transport";
-import type { ILiveTransport, LiveProvider, LiveTransportOptions, ResolvedLiveProvider } from "./transport-types";
+import { resolveVoiceProvider, type VoiceProviderConfig, type VoiceProviderId } from "./provider";
+import type { ILiveTransport, LiveTransportIdentity } from "./transport-types";
 import type { LivePhase } from "./visualizer";
-import { DEFAULT_CODEX_LIVE_VOICE, DEFAULT_GROK_LIVE_VOICE } from "./voices";
 
-async function createLiveTransport(options: LiveTransportOptions): Promise<ILiveTransport> {
-	const requested = options.provider ?? "auto";
-	if (requested === "xai-grok") {
-		return new GrokLiveTransport({
-			...options,
-			voice: options.grokVoice || options.voice || DEFAULT_GROK_LIVE_VOICE,
-		});
-	}
-	if (requested === "openai-codex") {
-		return new CodexLiveTransport({
-			...options,
-			voice: options.codexVoice || options.voice || DEFAULT_CODEX_LIVE_VOICE,
-		});
-	}
-
-	const hasXaiKey = $env.XAI_API_KEY ?? (await options.authStorage.getApiKey("xai", options.sessionId));
-
-	const hasCodexKey =
-		options.authStorage.hasNonEnvCredential("openai-codex") ||
-		Boolean($env.OPENAI_OAUTH_TOKEN || $env.CODEX_OAUTH_TOKEN);
-
-	if (hasXaiKey && !hasCodexKey) {
-		return new GrokLiveTransport({
-			...options,
-			voice: options.grokVoice || options.voice || DEFAULT_GROK_LIVE_VOICE,
-		});
-	}
-	return new CodexLiveTransport({
-		...options,
-		voice: options.codexVoice || options.voice || DEFAULT_CODEX_LIVE_VOICE,
-	});
-}
 const OUTPUT_ACTIVE_LEVEL = 0.015;
 
 /** Incremental or final transcript for one realtime conversational turn. */
@@ -62,6 +28,7 @@ export interface LiveTranscript {
 	/** Monotonic role-local turn number used to coalesce streaming updates. */
 	turn: number;
 	final: boolean;
+	identity: LiveTransportIdentity;
 }
 
 /** UI notifications emitted during a live session. */
@@ -84,14 +51,12 @@ export interface LiveSessionControllerOptions {
 	callbacks: LiveSessionCallbacks;
 	/** Extracts visible assistant text using the caller's normal UI rules. */
 	extractAssistantText(message: AssistantMessage): string;
-	/** Codex realtime output voice. */
-	codexVoice?: string;
-	/** Grok realtime output voice. */
-	grokVoice?: string;
-	/** Provider selection override (auto, openai-codex, or xai-grok). */
-	provider?: LiveProvider;
-	/** Custom Grok model name (e.g. grok-voice-think-fast-2.0). */
-	grokModel?: string;
+	/** Ranked provider preference; unlisted providers retain built-in fallback order. */
+	providerOrder?: readonly VoiceProviderId[];
+	/** Optional one-session provider override. */
+	provider?: VoiceProviderId;
+	/** Provider-owned voice and model settings. */
+	providerConfigs?: Partial<Record<VoiceProviderId, VoiceProviderConfig>>;
 }
 
 function errorFrom(cause: unknown): Error {
@@ -130,10 +95,9 @@ export class LiveSessionController {
 	readonly #session: AgentSession;
 	readonly #callbacks: LiveSessionCallbacks;
 	readonly #extractAssistantText: (message: AssistantMessage) => string;
-	readonly #codexVoice: string;
-	readonly #grokVoice: string;
-	readonly #provider: LiveProvider | undefined;
-	readonly #grokModel: string | undefined;
+	readonly #providerOrder: readonly VoiceProviderId[];
+	readonly #provider: VoiceProviderId | undefined;
+	readonly #providerConfigs: Partial<Record<VoiceProviderId, VoiceProviderConfig>>;
 
 	#transport: ILiveTransport | undefined;
 	#recorder: AudioCapture | undefined;
@@ -161,24 +125,13 @@ export class LiveSessionController {
 		this.#session = options.session;
 		this.#callbacks = options.callbacks;
 		this.#extractAssistantText = options.extractAssistantText;
-		this.#codexVoice = options.codexVoice?.trim() || DEFAULT_CODEX_LIVE_VOICE;
-		this.#grokVoice = options.grokVoice?.trim() || DEFAULT_GROK_LIVE_VOICE;
+		this.#providerOrder = options.providerOrder ?? [];
 		this.#provider = options.provider;
-		this.#grokModel = options.grokModel;
+		this.#providerConfigs = options.providerConfigs ?? {};
 	}
 	/** Current realtime call phase. */
 	get phase(): LivePhase {
 		return this.#phase;
-	}
-
-	/** Provider selected for the active transport. */
-	get provider(): ResolvedLiveProvider | undefined {
-		return this.#transport?.provider;
-	}
-
-	/** Model selected for the active transport. */
-	get model(): string | undefined {
-		return this.#transport?.model;
 	}
 
 	/** Whether microphone input is currently muted. */
@@ -204,15 +157,20 @@ export class LiveSessionController {
 		try {
 			const user = currentUser();
 			const instructions = prompt.render(liveInstructionsTemplate, user);
-			const transport = await createLiveTransport({
+			const provider = await resolveVoiceProvider({
+				authStorage: this.#session.modelRegistry.authStorage,
+				sessionId: this.#session.sessionId,
+				order: this.#providerOrder,
+				forced: this.#provider,
+			});
+			if (this.#stopped) {
+				throw this.#failure ?? new Error("The live session stopped while selecting a provider.");
+			}
+			const transport = provider.createTransport({
 				authStorage: this.#session.modelRegistry.authStorage,
 				sessionId: this.#session.sessionId,
 				instructions,
-				voice: this.#codexVoice,
-				codexVoice: this.#codexVoice,
-				grokVoice: this.#grokVoice,
-				provider: this.#provider,
-				grokModel: this.#grokModel,
+				config: this.#providerConfigs[provider.id],
 				callbacks: {
 					onEvent: event => this.#guardEvent(() => this.#handleLiveEvent(event)),
 					onOutputLevel: level => this.#guardEvent(() => this.#handleOutputLevel(level)),
@@ -220,7 +178,7 @@ export class LiveSessionController {
 			});
 			if (this.#stopped) {
 				await transport.close();
-				throw this.#failure ?? new Error("The live session stopped while selecting a provider.");
+				throw this.#failure ?? new Error("The live session stopped while creating a provider transport.");
 			}
 			this.#transport = transport;
 			await transport.connect();
@@ -481,7 +439,8 @@ export class LiveSessionController {
 
 	#storeTranscript(role: LiveTranscript["role"], text: string, final: boolean): void {
 		const normalized = text.trim();
-		if (!normalized) return;
+		const identity = this.#transport?.identity;
+		if (!normalized || !identity) return;
 		const turn = role === "user" ? this.#userTranscriptTurn : this.#assistantTranscriptTurn;
 		if (role === "user") {
 			this.#userTranscript = normalized;
@@ -498,7 +457,7 @@ export class LiveSessionController {
 		) {
 			return;
 		}
-		this.#emitTranscript({ role, turn, text: normalized, final });
+		this.#emitTranscript({ role, turn, text: normalized, final, identity });
 	}
 
 	#queueSend(message: LiveClientMessage): void {

--- a/packages/coding-agent/src/live/grok-transport.ts
+++ b/packages/coding-agent/src/live/grok-transport.ts
@@ -12,6 +12,11 @@ const OUTPUT_SAMPLE_RATE = 24_000;
 const INPUT_SAMPLE_RATE = 16_000;
 
 type Lifecycle = "idle" | "connecting" | "connected" | "closing" | "closed";
+
+interface PendingFunctionCall {
+	callId: string;
+	request: string;
+}
 /** Build the xAI session configuration sent when the realtime socket opens. */
 export function buildGrokSessionUpdate(instructions: string, requestedVoice: string): Record<string, unknown> {
 	const rawVoice = requestedVoice.trim().toLowerCase();
@@ -71,6 +76,8 @@ export class GrokLiveTransport implements ILiveTransport {
 	#outputActiveUntil = 0;
 	#outputIdleTimer: NodeJS.Timeout | undefined;
 	readonly #delegationContext = new Map<string, string[]>();
+	readonly #queuedFunctionCalls: PendingFunctionCall[] = [];
+	readonly #pendingFunctionOutputIds = new Set<string>();
 	readonly #abortListener: () => void;
 
 	constructor(options: LiveTransportOptions) {
@@ -145,6 +152,7 @@ export class GrokLiveTransport implements ILiveTransport {
 
 		const socket: Bun.WebSocket = Reflect.construct(WebSocket, [url, socketOptions]);
 		socket.binaryType = "nodebuffer";
+		this.#socket = socket;
 
 		const { promise, resolve, reject } = Promise.withResolvers<void>();
 		let opened = false;
@@ -175,14 +183,13 @@ export class GrokLiveTransport implements ILiveTransport {
 		};
 
 		socket.onopen = () => {
-			if (settled) {
+			if (settled || this.#state !== "connecting" || this.#socket !== socket) {
 				socket.close(1000, "stale");
 				return;
 			}
 			opened = true;
 			settled = true;
 			cleanup();
-			this.#socket = socket;
 			this.#state = "connected";
 
 			// Initialize session parameters
@@ -334,21 +341,12 @@ export class GrokLiveTransport implements ILiveTransport {
 					const args = JSON.parse(String(payload.arguments ?? "{}"));
 					request = String(args.request ?? "").trim();
 				} catch {}
-
-				if (request) {
-					this.#options.callbacks.onEvent({
-						type: "delegation.created",
-						item: {
-							type: "delegation",
-							target: "client",
-							id: callId,
-							content: [{ type: "input_text", text: request }],
-						},
-					});
-					this.#delegationContext.set(callId, []);
-				}
+				this.#queuedFunctionCalls.push({ callId, request });
 				break;
 			}
+			case "response.done":
+				this.#dispatchFunctionCalls();
+				break;
 			case "error": {
 				const errObj =
 					typeof payload.error === "object" && payload.error ? (payload.error as Record<string, unknown>) : {};
@@ -357,6 +355,49 @@ export class GrokLiveTransport implements ILiveTransport {
 				break;
 			}
 		}
+	}
+
+	#dispatchFunctionCalls(): void {
+		if (this.#queuedFunctionCalls.length === 0) return;
+		if (this.#pendingFunctionOutputIds.size > 0) {
+			this.#reportFailure("Grok issued new function calls before the previous function-call batch completed.");
+			return;
+		}
+
+		const calls = this.#queuedFunctionCalls.splice(0);
+		if (calls.some(call => !call.request)) {
+			this.#reportFailure("Grok function call omitted the required delegation request.");
+			return;
+		}
+		for (const { callId } of calls) {
+			this.#pendingFunctionOutputIds.add(callId);
+			this.#delegationContext.set(callId, []);
+		}
+		for (const { callId, request } of calls) {
+			this.#options.callbacks.onEvent({
+				type: "delegation.created",
+				item: {
+					type: "delegation",
+					target: "client",
+					id: callId,
+					content: [{ type: "input_text", text: request }],
+				},
+			});
+		}
+	}
+
+	#completeFunctionCall(callId: string, output: string): void {
+		if (!this.#pendingFunctionOutputIds.delete(callId)) return;
+		this.#delegationContext.delete(callId);
+		this.#sendRaw({
+			type: "conversation.item.create",
+			item: {
+				type: "function_call_output",
+				call_id: callId,
+				output,
+			},
+		});
+		if (this.#pendingFunctionOutputIds.size === 0) this.#sendRaw({ type: "response.create" });
 	}
 
 	#handleAudioOutput(base64Pcm: string): void {
@@ -456,16 +497,7 @@ export class GrokLiveTransport implements ILiveTransport {
 				if (!context) return;
 				context.push(text);
 				if (message.channel !== "speakable") return;
-				this.#delegationContext.delete(message.delegation_item_id);
-				this.#sendRaw({
-					type: "conversation.item.create",
-					item: {
-						type: "function_call_output",
-						call_id: message.delegation_item_id,
-						output: context.join("\n"),
-					},
-				});
-				this.#sendRaw({ type: "response.create" });
+				this.#completeFunctionCall(message.delegation_item_id, context.join("\n"));
 				return;
 			}
 
@@ -481,6 +513,11 @@ export class GrokLiveTransport implements ILiveTransport {
 		});
 		this.#sendTail = operation.catch(() => {});
 		return operation;
+	}
+
+	/** xAI server VAD receives every unmuted frame, including while output is playing. */
+	shouldStreamAudio(_inputLevel: number, _outputLevel: number): boolean {
+		return true;
 	}
 
 	/** Stream unscaled 16 kHz mono PCM for provider-managed VAD and interruption handling. */
@@ -521,6 +558,9 @@ export class GrokLiveTransport implements ILiveTransport {
 		const playback = this.#playback;
 		this.#socket = undefined;
 		this.#playback = undefined;
+		this.#queuedFunctionCalls.length = 0;
+		this.#pendingFunctionOutputIds.clear();
+		this.#delegationContext.clear();
 
 		if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) {
 			try {

--- a/packages/coding-agent/src/live/grok-transport.ts
+++ b/packages/coding-agent/src/live/grok-transport.ts
@@ -1,0 +1,533 @@
+import { getProxyForUrl } from "@oh-my-pi/pi-ai/utils/proxy";
+import { AudioPlayback } from "@oh-my-pi/pi-natives";
+import { $env } from "@oh-my-pi/pi-utils";
+import type { LiveClientMessage } from "./protocol";
+import type { ILiveTransport, LiveTransportOptions } from "./transport-types";
+import { DEFAULT_GROK_LIVE_VOICE, GROK_LIVE_VOICE_LOOKUP } from "./voices";
+
+const DEFAULT_GROK_REALTIME_MODEL = "grok-voice-think-fast-2.0";
+const REALTIME_BASE_URL = "wss://api.x.ai/v1/realtime";
+const CONNECT_TIMEOUT_MS = 15_000;
+const OUTPUT_SAMPLE_RATE = 24_000;
+const INPUT_SAMPLE_RATE = 16_000;
+
+type Lifecycle = "idle" | "connecting" | "connected" | "closing" | "closed";
+/** Build the xAI session configuration sent when the realtime socket opens. */
+export function buildGrokSessionUpdate(instructions: string, requestedVoice: string): Record<string, unknown> {
+	const rawVoice = requestedVoice.trim().toLowerCase();
+	const voice = GROK_LIVE_VOICE_LOOKUP[rawVoice] ? rawVoice : DEFAULT_GROK_LIVE_VOICE;
+	return {
+		type: "session.update",
+		session: {
+			modalities: ["text", "audio"],
+			voice,
+			instructions,
+			turn_detection: { type: "server_vad" },
+			audio: {
+				input: {
+					format: { type: "audio/pcm", rate: INPUT_SAMPLE_RATE },
+					transcription: { model: "grok-transcribe" },
+				},
+				output: {
+					format: { type: "audio/pcm", rate: OUTPUT_SAMPLE_RATE },
+				},
+			},
+			tools: [
+				{
+					type: "function",
+					name: "client_delegate",
+					description:
+						"Delegate repository work, coding, tool use, command execution, or investigation to the client backend.",
+					parameters: {
+						type: "object",
+						properties: {
+							request: {
+								type: "string",
+								description: "The complete plain-language user request or task to execute.",
+							},
+						},
+						required: ["request"],
+					},
+				},
+			],
+		},
+	};
+}
+
+/** Native WebSocket transport powering Grok Realtime voice sessions (`grok-voice-think-fast-2.0`). */
+export class GrokLiveTransport implements ILiveTransport {
+	readonly provider = "xai-grok";
+	readonly model: string;
+	readonly #options: LiveTransportOptions;
+	#socket: Bun.WebSocket | undefined;
+	#playback: AudioPlayback | undefined;
+	#state: Lifecycle = "idle";
+	#connectPromise: Promise<void> | undefined;
+	#closePromise: Promise<void> | undefined;
+	#sendTail: Promise<void> = Promise.resolve();
+	#muted = false;
+	#unexpectedFailureReported = false;
+	#assistantTranscript = "";
+	#realtimeSessionId: string | undefined;
+	#outputActiveUntil = 0;
+	#outputIdleTimer: NodeJS.Timeout | undefined;
+	readonly #delegationContext = new Map<string, string[]>();
+	readonly #abortListener: () => void;
+
+	constructor(options: LiveTransportOptions) {
+		this.#options = options;
+		this.#abortListener = () => {
+			void this.close();
+		};
+		this.model = options.grokModel?.trim() || DEFAULT_GROK_REALTIME_MODEL;
+		if (!options.signal?.aborted) {
+			options.signal?.addEventListener("abort", this.#abortListener, { once: true });
+		}
+	}
+
+	/** Resolve credentials and establish the WebSocket connection to xAI Realtime API. */
+	connect(): Promise<void> {
+		if (this.#state === "connected") return Promise.resolve();
+		if (this.#connectPromise) return this.#connectPromise;
+		if (this.#state === "closing" || this.#state === "closed") {
+			return Promise.reject(new Error("Grok live transport is closed"));
+		}
+		if (this.#options.signal?.aborted) {
+			const signal = this.#options.signal;
+			const reason =
+				signal.reason instanceof Error ? signal.reason : new DOMException("Live connection aborted", "AbortError");
+			return Promise.reject(reason);
+		}
+		this.#state = "connecting";
+		const operation = this.#connect().catch(async error => {
+			await this.close();
+			throw error;
+		});
+		this.#connectPromise = operation;
+		return operation;
+	}
+
+	async #connect(): Promise<void> {
+		const apiKey = $env.XAI_API_KEY ?? (await this.#options.authStorage.getApiKey("xai", this.#options.sessionId));
+
+		if (!apiKey) {
+			throw new Error(
+				"Grok Voice realtime mode requires an xAI Console API key. Set XAI_API_KEY or configure an API key for provider xai; consumer xAI OAuth tokens are not accepted by the Realtime API.",
+			);
+		}
+
+		const url = `${REALTIME_BASE_URL}?model=${encodeURIComponent(this.model)}`;
+
+		if (typeof AudioPlayback !== "function") {
+			throw new Error(
+				"Speaker playback is unavailable because the installed native bindings do not include AudioPlayback.",
+			);
+		}
+		try {
+			this.#playback = new AudioPlayback(OUTPUT_SAMPLE_RATE);
+		} catch (cause) {
+			const detail = cause instanceof Error ? cause.message : String(cause);
+			throw new Error(`Speaker output initialization failed: ${detail}`, { cause });
+		}
+
+		const socketOptions = {
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				"User-Agent": "oh-my-pi/grok-live",
+			},
+			proxy: getProxyForUrl("xai", new URL(url)),
+		} satisfies Bun.WebSocketOptions;
+
+		const socket: Bun.WebSocket = Reflect.construct(WebSocket, [url, socketOptions]);
+		socket.binaryType = "nodebuffer";
+
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+		let opened = false;
+		let settled = false;
+		let timeout: NodeJS.Timeout | undefined;
+
+		const cleanup = (): void => {
+			if (timeout) {
+				clearTimeout(timeout);
+				timeout = undefined;
+			}
+			this.#options.signal?.removeEventListener("abort", onAbort);
+		};
+
+		const rejectConnect = (error: Error): void => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			reject(error);
+		};
+
+		const onAbort = (): void => {
+			socket.close(1000, "aborted");
+			const signal = this.#options.signal;
+			const reason =
+				signal?.reason instanceof Error ? signal.reason : new DOMException("Live connection aborted", "AbortError");
+			rejectConnect(reason);
+		};
+
+		socket.onopen = () => {
+			if (settled) {
+				socket.close(1000, "stale");
+				return;
+			}
+			opened = true;
+			settled = true;
+			cleanup();
+			this.#socket = socket;
+			this.#state = "connected";
+
+			// Initialize session parameters
+			this.#sendSessionUpdate();
+			resolve();
+		};
+
+		socket.onmessage = event => {
+			if (typeof event.data !== "string") {
+				this.#reportFailure("Grok realtime API returned an unexpected binary WebSocket frame.");
+				return;
+			}
+			this.handleServerMessage(event.data);
+		};
+
+		socket.onerror = event => {
+			const detail = event instanceof ErrorEvent && event.message ? `: ${event.message}` : "";
+			if (!opened) {
+				rejectConnect(new Error(`Grok realtime connection failed${detail}`));
+				socket.close(1011, "connection failed");
+				return;
+			}
+			this.#reportFailure(`Grok realtime WebSocket failed${detail}`);
+		};
+
+		socket.onclose = event => {
+			if (!opened) {
+				rejectConnect(new Error(`Grok realtime closed before connecting (${event.code})`));
+				return;
+			}
+			if (this.#socket !== socket) return;
+			this.#socket = undefined;
+			if (this.#state === "connecting" || this.#state === "connected") {
+				const detail = event.reason ? `: ${event.reason}` : "";
+				this.#reportFailure(`Grok realtime WebSocket closed (${event.code})${detail}`);
+			}
+		};
+
+		if (this.#options.signal?.aborted) {
+			onAbort();
+		} else {
+			this.#options.signal?.addEventListener("abort", onAbort, { once: true });
+			timeout = setTimeout(() => {
+				socket.close(1000, "connect timeout");
+				rejectConnect(new Error("Grok realtime connection timed out"));
+			}, CONNECT_TIMEOUT_MS);
+			timeout.unref?.();
+		}
+
+		await promise;
+	}
+
+	#sendSessionUpdate(): void {
+		this.#sendRaw(buildGrokSessionUpdate(this.#options.instructions, this.#options.voice));
+	}
+
+	handleServerMessage(raw: string): void {
+		if (this.#state === "closing" || this.#state === "closed") return;
+		let payload: Record<string, unknown>;
+		try {
+			payload = JSON.parse(raw);
+		} catch {
+			return;
+		}
+
+		const type = String(payload.type ?? "");
+
+		switch (type) {
+			case "session.created": {
+				const sessionObj =
+					typeof payload.session === "object" && payload.session
+						? (payload.session as Record<string, unknown>)
+						: {};
+				this.#realtimeSessionId = String(sessionObj.id ?? crypto.randomUUID());
+				this.#options.callbacks.onEvent({
+					type: "session.started",
+					session: { id: this.#realtimeSessionId },
+				});
+				break;
+			}
+			case "session.updated": {
+				const sessionObj =
+					typeof payload.session === "object" && payload.session
+						? (payload.session as Record<string, unknown>)
+						: {};
+				const instructions = typeof sessionObj.instructions === "string" ? sessionObj.instructions : undefined;
+				this.#options.callbacks.onEvent({
+					type: "session.updated",
+					session: {
+						id: this.#realtimeSessionId ?? crypto.randomUUID(),
+						...(instructions === undefined ? {} : { instructions }),
+					},
+				});
+				break;
+			}
+			case "input_audio_buffer.speech_started": {
+				this.#clearPlayback();
+				break;
+			}
+			case "conversation.item.input_audio_transcription.completed": {
+				const transcript = String(payload.transcript ?? "").trim();
+				if (transcript) {
+					this.#options.callbacks.onEvent({
+						type: "input_transcript.added",
+						item: { text: transcript },
+					});
+					this.#options.callbacks.onEvent({
+						type: "turn.done",
+						turn: { role: "user", transcript },
+					});
+				}
+				break;
+			}
+			case "response.output_audio_transcript.delta": {
+				const delta = String(payload.delta ?? "");
+				if (delta) {
+					this.#assistantTranscript += delta;
+					this.#options.callbacks.onEvent({
+						type: "output_transcript.added",
+						item: { text: delta },
+					});
+				}
+				break;
+			}
+			case "response.output_audio_transcript.done": {
+				const transcript = (String(payload.transcript ?? "") || this.#assistantTranscript).trim();
+				this.#assistantTranscript = "";
+				if (transcript) {
+					this.#options.callbacks.onEvent({
+						type: "turn.done",
+						turn: { role: "assistant", transcript },
+					});
+				}
+				break;
+			}
+			case "response.output_audio.delta": {
+				const delta = String(payload.delta ?? "");
+				if (delta) {
+					this.#handleAudioOutput(delta);
+				}
+				break;
+			}
+			case "response.output_audio.done":
+				break;
+			case "response.function_call_arguments.done": {
+				const callId = String(payload.call_id ?? payload.item_id ?? crypto.randomUUID());
+				let request = "";
+				try {
+					const args = JSON.parse(String(payload.arguments ?? "{}"));
+					request = String(args.request ?? "").trim();
+				} catch {}
+
+				if (request) {
+					this.#options.callbacks.onEvent({
+						type: "delegation.created",
+						item: {
+							type: "delegation",
+							target: "client",
+							id: callId,
+							content: [{ type: "input_text", text: request }],
+						},
+					});
+					this.#delegationContext.set(callId, []);
+				}
+				break;
+			}
+			case "error": {
+				const errObj =
+					typeof payload.error === "object" && payload.error ? (payload.error as Record<string, unknown>) : {};
+				const message = String(errObj.message ?? payload.message ?? "Grok realtime error");
+				this.#reportFailure(message);
+				break;
+			}
+		}
+	}
+
+	#handleAudioOutput(base64Pcm: string): void {
+		let pcmBuffer: Buffer;
+		try {
+			pcmBuffer = Buffer.from(base64Pcm, "base64");
+		} catch {
+			return;
+		}
+
+		const numSamples = Math.floor(pcmBuffer.length / 2);
+		if (numSamples === 0) return;
+
+		const float32Samples = new Float32Array(numSamples);
+		let sumSq = 0;
+		for (let i = 0; i < numSamples; i++) {
+			const sample = pcmBuffer.readInt16LE(i * 2) / 32768.0;
+			float32Samples[i] = sample;
+			sumSq += sample * sample;
+		}
+
+		const rms = Math.sqrt(sumSq / numSamples);
+		this.#options.callbacks.onOutputLevel(Math.min(1, Math.max(0, rms * 3.5)));
+		const now = performance.now();
+		this.#outputActiveUntil = Math.max(now, this.#outputActiveUntil) + (numSamples / OUTPUT_SAMPLE_RATE) * 1_000;
+		clearTimeout(this.#outputIdleTimer);
+		this.#outputIdleTimer = setTimeout(() => {
+			this.#outputIdleTimer = undefined;
+			this.#outputActiveUntil = 0;
+			this.#options.callbacks.onOutputLevel(0);
+		}, this.#outputActiveUntil - now);
+		this.#outputIdleTimer.unref?.();
+
+		if (this.#playback) {
+			try {
+				this.#playback.write(float32Samples);
+			} catch {}
+		}
+	}
+
+	#clearPlayback(): void {
+		if (this.#outputIdleTimer) {
+			clearTimeout(this.#outputIdleTimer);
+			this.#outputIdleTimer = undefined;
+		}
+		this.#outputActiveUntil = 0;
+		this.#options.callbacks.onOutputLevel(0);
+		if (this.#playback) {
+			try {
+				this.#playback.stop();
+			} catch {}
+			if (typeof AudioPlayback === "function") {
+				try {
+					this.#playback = new AudioPlayback(OUTPUT_SAMPLE_RATE);
+				} catch {}
+			}
+		}
+	}
+
+	#sendRaw(payload: Record<string, unknown>): void {
+		const socket = this.#socket;
+		if (!socket || socket.readyState !== WebSocket.OPEN) return;
+		try {
+			socket.send(JSON.stringify(payload));
+		} catch {}
+	}
+
+	#reportFailure(message: string): void {
+		if ((this.#state !== "connecting" && this.#state !== "connected") || this.#unexpectedFailureReported) {
+			return;
+		}
+		this.#unexpectedFailureReported = true;
+		try {
+			this.#options.callbacks.onEvent({ type: "error", message });
+		} catch {}
+	}
+
+	/** Send context appends or close message to Grok realtime session. */
+	send(message: LiveClientMessage): Promise<void> {
+		const operation = this.#sendTail.then(() => {
+			if (this.#state !== "connected") throw new Error("Grok live transport is not connected");
+
+			if (message.type === "session.close") {
+				void this.close();
+				return;
+			}
+
+			const text = message.content
+				.filter(item => item.type === "input_text")
+				.map(item => item.text)
+				.join("\n")
+				.trim();
+			if (!text) return;
+
+			if (message.type === "delegation.context.append") {
+				const context = this.#delegationContext.get(message.delegation_item_id);
+				if (!context) return;
+				context.push(text);
+				if (message.channel !== "speakable") return;
+				this.#delegationContext.delete(message.delegation_item_id);
+				this.#sendRaw({
+					type: "conversation.item.create",
+					item: {
+						type: "function_call_output",
+						call_id: message.delegation_item_id,
+						output: context.join("\n"),
+					},
+				});
+				this.#sendRaw({ type: "response.create" });
+				return;
+			}
+
+			this.#sendRaw({
+				type: "conversation.item.create",
+				item: {
+					type: "message",
+					role: "user",
+					content: [{ type: "input_text", text }],
+				},
+			});
+			this.#sendRaw({ type: "response.create" });
+		});
+		this.#sendTail = operation.catch(() => {});
+		return operation;
+	}
+
+	/** Stream unscaled 16 kHz mono PCM for provider-managed VAD and interruption handling. */
+	pushAudio(samples: Float32Array): void {
+		if (this.#state !== "connected" || this.#muted || samples.length === 0) return;
+		const int16Buffer = Buffer.allocUnsafe(samples.length * 2);
+		for (let i = 0; i < samples.length; i++) {
+			const sample = Math.max(-1, Math.min(1, samples[i] ?? 0));
+			int16Buffer.writeInt16LE(sample < 0 ? sample * 0x8000 : sample * 0x7fff, i * 2);
+		}
+		this.#sendRaw({
+			type: "input_audio_buffer.append",
+			audio: int16Buffer.toString("base64"),
+		});
+	}
+
+	/** Mute or unmute microphone audio. */
+	async setMuted(muted: boolean): Promise<void> {
+		this.#muted = muted;
+	}
+
+	/** Close WebSocket and speaker playback cleanly. */
+	close(): Promise<void> {
+		if (this.#closePromise) return this.#closePromise;
+		this.#state = "closing";
+		const operation = this.#close();
+		this.#closePromise = operation;
+		return operation;
+	}
+
+	async #close(): Promise<void> {
+		this.#options.signal?.removeEventListener("abort", this.#abortListener);
+		if (this.#outputIdleTimer) {
+			clearTimeout(this.#outputIdleTimer);
+			this.#outputIdleTimer = undefined;
+		}
+		const socket = this.#socket;
+		const playback = this.#playback;
+		this.#socket = undefined;
+		this.#playback = undefined;
+
+		if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) {
+			try {
+				socket.close(1000, "done");
+			} catch {}
+		}
+
+		if (playback) {
+			try {
+				playback.stop();
+			} catch {}
+		}
+		this.#state = "closed";
+	}
+}

--- a/packages/coding-agent/src/live/grok-transport.ts
+++ b/packages/coding-agent/src/live/grok-transport.ts
@@ -2,7 +2,7 @@ import { getProxyForUrl } from "@oh-my-pi/pi-ai/utils/proxy";
 import { AudioPlayback } from "@oh-my-pi/pi-natives";
 import { $env } from "@oh-my-pi/pi-utils";
 import type { LiveClientMessage } from "./protocol";
-import type { ILiveTransport, LiveTransportOptions } from "./transport-types";
+import type { ILiveTransport, LiveTransportIdentity, LiveTransportOptions } from "./transport-types";
 import { DEFAULT_GROK_LIVE_VOICE, GROK_LIVE_VOICE_LOOKUP } from "./voices";
 
 const DEFAULT_GROK_REALTIME_MODEL = "grok-voice-think-fast-2.0";
@@ -56,8 +56,7 @@ export function buildGrokSessionUpdate(instructions: string, requestedVoice: str
 
 /** Native WebSocket transport powering Grok Realtime voice sessions (`grok-voice-think-fast-2.0`). */
 export class GrokLiveTransport implements ILiveTransport {
-	readonly provider = "xai-grok";
-	readonly model: string;
+	readonly identity: LiveTransportIdentity;
 	readonly #options: LiveTransportOptions;
 	#socket: Bun.WebSocket | undefined;
 	#playback: AudioPlayback | undefined;
@@ -79,7 +78,13 @@ export class GrokLiveTransport implements ILiveTransport {
 		this.#abortListener = () => {
 			void this.close();
 		};
-		this.model = options.grokModel?.trim() || DEFAULT_GROK_REALTIME_MODEL;
+		const model = options.model?.trim() || DEFAULT_GROK_REALTIME_MODEL;
+		this.identity = {
+			voiceProvider: "grok",
+			api: "openai-completions",
+			provider: "xai",
+			model,
+		};
 		if (!options.signal?.aborted) {
 			options.signal?.addEventListener("abort", this.#abortListener, { once: true });
 		}
@@ -116,7 +121,7 @@ export class GrokLiveTransport implements ILiveTransport {
 			);
 		}
 
-		const url = `${REALTIME_BASE_URL}?model=${encodeURIComponent(this.model)}`;
+		const url = `${REALTIME_BASE_URL}?model=${encodeURIComponent(this.identity.model)}`;
 
 		if (typeof AudioPlayback !== "function") {
 			throw new Error(

--- a/packages/coding-agent/src/live/provider.ts
+++ b/packages/coding-agent/src/live/provider.ts
@@ -1,22 +1,40 @@
-import {
-	isVoiceProviderId,
-	VOICE_PROVIDER_ORDER,
-	type VoiceProvider,
-	type VoiceProviderAvailability,
-	type VoiceProviderId,
-} from "./providers/base";
+import type { VoiceProvider, VoiceProviderAvailability } from "./providers/base";
 import { CodexVoiceProvider } from "./providers/codex";
 import { GrokVoiceProvider } from "./providers/grok";
 
 export * from "./providers/base";
 
-const PROVIDERS: Record<VoiceProviderId, VoiceProvider> = {
-	codex: new CodexVoiceProvider(),
-	grok: new GrokVoiceProvider(),
-};
+const VOICE_PROVIDERS = [new CodexVoiceProvider(), new GrokVoiceProvider()] as const;
 
+/** IDs of the realtime voice providers registered in this build. */
+export type VoiceProviderId = (typeof VOICE_PROVIDERS)[number]["id"];
+
+/** Settings metadata derived from each registered provider implementation. */
+export const VOICE_PROVIDER_OPTIONS = VOICE_PROVIDERS.map(({ id, label, description }) => ({
+	value: id,
+	label,
+	description,
+}));
+
+/** Built-in automatic-selection order before user ranking is applied. */
+export const VOICE_PROVIDER_ORDER: readonly VoiceProviderId[] = VOICE_PROVIDERS.map(({ id }) => id);
+
+function getVoiceProvider(id: VoiceProviderId): VoiceProvider<VoiceProviderId> {
+	const provider = VOICE_PROVIDERS.find(candidate => candidate.id === id);
+	if (!provider) throw new Error(`Unknown voice provider: ${id}`);
+	return provider;
+}
+
+/** Return whether a runtime string names a registered voice provider. */
+export function isVoiceProviderId(value: string): value is VoiceProviderId {
+	return VOICE_PROVIDER_ORDER.includes(value as VoiceProviderId);
+}
+
+/** Inputs controlling automatic or explicit provider resolution. */
 export interface ResolveVoiceProviderOptions extends VoiceProviderAvailability {
+	/** User-ranked providers; omitted providers retain built-in relative order. */
 	order?: readonly VoiceProviderId[];
+	/** One-session override that bypasses automatic availability filtering. */
 	forced?: VoiceProviderId;
 }
 
@@ -27,15 +45,17 @@ export function resolveVoiceProviderOrder(order: readonly VoiceProviderId[] = []
 }
 
 /** Resolve a forced provider or the first available provider in configured priority order. */
-export async function resolveVoiceProvider(options: ResolveVoiceProviderOptions): Promise<VoiceProvider> {
-	if (options.forced) return PROVIDERS[options.forced];
+export async function resolveVoiceProvider(
+	options: ResolveVoiceProviderOptions,
+): Promise<VoiceProvider<VoiceProviderId>> {
+	if (options.forced) return getVoiceProvider(options.forced);
 
 	for (const id of resolveVoiceProviderOrder(options.order)) {
-		const provider = PROVIDERS[id];
+		const provider = getVoiceProvider(id);
 		if (await provider.isAvailable(options)) return provider;
 	}
 
 	throw new Error(
-		"No realtime voice provider is configured. Sign in to OpenAI Codex or configure an xAI Console API key.",
+		`No realtime voice provider is configured. Configure credentials for ${VOICE_PROVIDERS.map(provider => provider.label).join(" or ")}.`,
 	);
 }

--- a/packages/coding-agent/src/live/provider.ts
+++ b/packages/coding-agent/src/live/provider.ts
@@ -1,0 +1,41 @@
+import {
+	isVoiceProviderId,
+	VOICE_PROVIDER_ORDER,
+	type VoiceProvider,
+	type VoiceProviderAvailability,
+	type VoiceProviderId,
+} from "./providers/base";
+import { CodexVoiceProvider } from "./providers/codex";
+import { GrokVoiceProvider } from "./providers/grok";
+
+export * from "./providers/base";
+
+const PROVIDERS: Record<VoiceProviderId, VoiceProvider> = {
+	codex: new CodexVoiceProvider(),
+	grok: new GrokVoiceProvider(),
+};
+
+export interface ResolveVoiceProviderOptions extends VoiceProviderAvailability {
+	order?: readonly VoiceProviderId[];
+	forced?: VoiceProviderId;
+}
+
+/** Prioritize configured providers while retaining unlisted providers in built-in order. */
+export function resolveVoiceProviderOrder(order: readonly VoiceProviderId[] = []): VoiceProviderId[] {
+	const prioritized = new Set(order.filter(isVoiceProviderId));
+	return [...prioritized, ...VOICE_PROVIDER_ORDER.filter(id => !prioritized.has(id))];
+}
+
+/** Resolve a forced provider or the first available provider in configured priority order. */
+export async function resolveVoiceProvider(options: ResolveVoiceProviderOptions): Promise<VoiceProvider> {
+	if (options.forced) return PROVIDERS[options.forced];
+
+	for (const id of resolveVoiceProviderOrder(options.order)) {
+		const provider = PROVIDERS[id];
+		if (await provider.isAvailable(options)) return provider;
+	}
+
+	throw new Error(
+		"No realtime voice provider is configured. Sign in to OpenAI Codex or configure an xAI Console API key.",
+	);
+}

--- a/packages/coding-agent/src/live/providers/base.ts
+++ b/packages/coding-agent/src/live/providers/base.ts
@@ -1,0 +1,49 @@
+import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import type { ILiveTransport, LiveTransportBaseOptions } from "../transport-types";
+
+/** Realtime voice providers in their built-in fallback order. */
+export const VOICE_PROVIDER_OPTIONS = [
+	{
+		value: "codex",
+		label: "OpenAI Codex",
+		description: "Codex WebRTC realtime API",
+	},
+	{
+		value: "grok",
+		label: "xAI Grok Voice",
+		description: "xAI Grok Realtime WebSocket API (grok-voice-think-fast-2.0)",
+	},
+] as const;
+
+export type VoiceProviderId = (typeof VOICE_PROVIDER_OPTIONS)[number]["value"];
+
+export const VOICE_PROVIDER_ORDER: readonly VoiceProviderId[] = VOICE_PROVIDER_OPTIONS.map(option => option.value);
+export const VOICE_PROVIDER_CHOICES = VOICE_PROVIDER_OPTIONS;
+
+export function isVoiceProviderId(value: string): value is VoiceProviderId {
+	return VOICE_PROVIDER_ORDER.includes(value as VoiceProviderId);
+}
+
+/** Provider-specific configuration kept outside the shared live-session controller. */
+export interface VoiceProviderConfig {
+	voice?: string;
+	model?: string;
+}
+
+export interface VoiceProviderAvailability {
+	authStorage: AuthStorage;
+	sessionId: string;
+}
+
+export interface VoiceProviderCreateOptions extends LiveTransportBaseOptions {
+	config?: VoiceProviderConfig;
+}
+
+/** Provider boundary for credential admission, voice defaults, and transport construction. */
+export abstract class VoiceProvider {
+	abstract readonly id: VoiceProviderId;
+	abstract readonly label: string;
+
+	abstract isAvailable(options: VoiceProviderAvailability): Promise<boolean> | boolean;
+	abstract createTransport(options: VoiceProviderCreateOptions): ILiveTransport;
+}

--- a/packages/coding-agent/src/live/providers/base.ts
+++ b/packages/coding-agent/src/live/providers/base.ts
@@ -1,49 +1,39 @@
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import type { ILiveTransport, LiveTransportBaseOptions } from "../transport-types";
 
-/** Realtime voice providers in their built-in fallback order. */
-export const VOICE_PROVIDER_OPTIONS = [
-	{
-		value: "codex",
-		label: "OpenAI Codex",
-		description: "Codex WebRTC realtime API",
-	},
-	{
-		value: "grok",
-		label: "xAI Grok Voice",
-		description: "xAI Grok Realtime WebSocket API (grok-voice-think-fast-2.0)",
-	},
-] as const;
-
-export type VoiceProviderId = (typeof VOICE_PROVIDER_OPTIONS)[number]["value"];
-
-export const VOICE_PROVIDER_ORDER: readonly VoiceProviderId[] = VOICE_PROVIDER_OPTIONS.map(option => option.value);
-export const VOICE_PROVIDER_CHOICES = VOICE_PROVIDER_OPTIONS;
-
-export function isVoiceProviderId(value: string): value is VoiceProviderId {
-	return VOICE_PROVIDER_ORDER.includes(value as VoiceProviderId);
-}
-
-/** Provider-specific configuration kept outside the shared live-session controller. */
+/** Provider-owned voice and model overrides for one live session. */
 export interface VoiceProviderConfig {
+	/** Realtime output voice requested for this provider. */
 	voice?: string;
+	/** Provider-specific realtime model override. */
 	model?: string;
 }
 
+/** Credential context used to decide whether a provider may join automatic selection. */
 export interface VoiceProviderAvailability {
+	/** Shared credential broker; providers must not open independent credential stores. */
 	authStorage: AuthStorage;
+	/** Active agent session used for credential affinity and refresh. */
 	sessionId: string;
 }
 
+/** Shared live-call inputs plus the selected provider's configuration. */
 export interface VoiceProviderCreateOptions extends LiveTransportBaseOptions {
+	/** Voice and model overrides owned by the selected provider. */
 	config?: VoiceProviderConfig;
 }
 
-/** Provider boundary for credential admission, voice defaults, and transport construction. */
-export abstract class VoiceProvider {
-	abstract readonly id: VoiceProviderId;
+/** Provider boundary for credential admission, settings metadata, and transport construction. */
+export abstract class VoiceProvider<Id extends string = string> {
+	/** Stable provider ID persisted in ranked settings and accepted by `/live`. */
+	abstract readonly id: Id;
+	/** Human-readable provider name shown in settings and errors. */
 	abstract readonly label: string;
+	/** Short transport description shown in ranked-provider settings. */
+	abstract readonly description: string;
 
+	/** Whether credentials required for automatic selection are currently available. */
 	abstract isAvailable(options: VoiceProviderAvailability): Promise<boolean> | boolean;
+	/** Create a disconnected transport configured for this provider. */
 	abstract createTransport(options: VoiceProviderCreateOptions): ILiveTransport;
 }

--- a/packages/coding-agent/src/live/providers/codex.ts
+++ b/packages/coding-agent/src/live/providers/codex.ts
@@ -3,9 +3,11 @@ import { CodexLiveTransport } from "../transport";
 import { DEFAULT_CODEX_LIVE_VOICE } from "../voices";
 import { VoiceProvider, type VoiceProviderAvailability, type VoiceProviderCreateOptions } from "./base";
 
-export class CodexVoiceProvider extends VoiceProvider {
+/** Codex realtime provider using OAuth-authenticated WebRTC and sideband control. */
+export class CodexVoiceProvider extends VoiceProvider<"codex"> {
 	readonly id = "codex";
 	readonly label = "OpenAI Codex";
+	readonly description = "Codex WebRTC realtime API";
 
 	isAvailable({ authStorage }: VoiceProviderAvailability): boolean {
 		return (

--- a/packages/coding-agent/src/live/providers/codex.ts
+++ b/packages/coding-agent/src/live/providers/codex.ts
@@ -1,0 +1,22 @@
+import { $env } from "@oh-my-pi/pi-utils";
+import { CodexLiveTransport } from "../transport";
+import { DEFAULT_CODEX_LIVE_VOICE } from "../voices";
+import { VoiceProvider, type VoiceProviderAvailability, type VoiceProviderCreateOptions } from "./base";
+
+export class CodexVoiceProvider extends VoiceProvider {
+	readonly id = "codex";
+	readonly label = "OpenAI Codex";
+
+	isAvailable({ authStorage }: VoiceProviderAvailability): boolean {
+		return (
+			authStorage.hasNonEnvCredential("openai-codex") || Boolean($env.OPENAI_OAUTH_TOKEN || $env.CODEX_OAUTH_TOKEN)
+		);
+	}
+
+	createTransport({ config, ...options }: VoiceProviderCreateOptions): CodexLiveTransport {
+		return new CodexLiveTransport({
+			...options,
+			voice: config?.voice?.trim() || DEFAULT_CODEX_LIVE_VOICE,
+		});
+	}
+}

--- a/packages/coding-agent/src/live/providers/grok.ts
+++ b/packages/coding-agent/src/live/providers/grok.ts
@@ -3,9 +3,11 @@ import { GrokLiveTransport } from "../grok-transport";
 import { DEFAULT_GROK_LIVE_VOICE } from "../voices";
 import { VoiceProvider, type VoiceProviderAvailability, type VoiceProviderCreateOptions } from "./base";
 
-export class GrokVoiceProvider extends VoiceProvider {
+/** xAI Grok Voice provider using the Realtime WebSocket API. */
+export class GrokVoiceProvider extends VoiceProvider<"grok"> {
 	readonly id = "grok";
 	readonly label = "xAI Grok Voice";
+	readonly description = "xAI Grok Realtime WebSocket API (grok-voice-think-fast-2.0)";
 
 	async isAvailable({ authStorage, sessionId }: VoiceProviderAvailability): Promise<boolean> {
 		return Boolean($env.XAI_API_KEY || (await authStorage.getApiKey("xai", sessionId)));

--- a/packages/coding-agent/src/live/providers/grok.ts
+++ b/packages/coding-agent/src/live/providers/grok.ts
@@ -1,0 +1,21 @@
+import { $env } from "@oh-my-pi/pi-utils";
+import { GrokLiveTransport } from "../grok-transport";
+import { DEFAULT_GROK_LIVE_VOICE } from "../voices";
+import { VoiceProvider, type VoiceProviderAvailability, type VoiceProviderCreateOptions } from "./base";
+
+export class GrokVoiceProvider extends VoiceProvider {
+	readonly id = "grok";
+	readonly label = "xAI Grok Voice";
+
+	async isAvailable({ authStorage, sessionId }: VoiceProviderAvailability): Promise<boolean> {
+		return Boolean($env.XAI_API_KEY || (await authStorage.getApiKey("xai", sessionId)));
+	}
+
+	createTransport({ config, ...options }: VoiceProviderCreateOptions): GrokLiveTransport {
+		return new GrokLiveTransport({
+			...options,
+			voice: config?.voice?.trim() || DEFAULT_GROK_LIVE_VOICE,
+			model: config?.model?.trim() || undefined,
+		});
+	}
+}

--- a/packages/coding-agent/src/live/transport-types.ts
+++ b/packages/coding-agent/src/live/transport-types.ts
@@ -1,8 +1,6 @@
-import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import type { Api, AuthStorage } from "@oh-my-pi/pi-ai";
 import type { LiveClientMessage, LiveServerEvent } from "./protocol";
-
-export type LiveProvider = "auto" | "openai-codex" | "xai-grok";
-export type ResolvedLiveProvider = Exclude<LiveProvider, "auto">;
+import type { VoiceProviderId } from "./providers/base";
 
 /** Callbacks emitted by a live transport implementation. */
 export interface LiveTransportCallbacks {
@@ -10,24 +8,32 @@ export interface LiveTransportCallbacks {
 	onOutputLevel(level: number): void;
 }
 
-/** Configuration required to establish a live call. */
-export interface LiveTransportOptions {
+/** Shared configuration passed from the live-session controller to a provider. */
+export interface LiveTransportBaseOptions {
 	authStorage: AuthStorage;
 	sessionId: string;
 	instructions: string;
-	voice: string;
-	codexVoice?: string;
-	grokVoice?: string;
-	provider?: LiveProvider;
-	grokModel?: string;
 	callbacks: LiveTransportCallbacks;
 	signal?: AbortSignal;
 }
 
+/** Provider-resolved configuration required to establish a live transport. */
+export interface LiveTransportOptions extends LiveTransportBaseOptions {
+	voice: string;
+	model?: string;
+}
+
+/** Message identity attached to transcripts emitted by a live transport. */
+export interface LiveTransportIdentity {
+	voiceProvider: VoiceProviderId;
+	api: Api;
+	provider: string;
+	model: string;
+}
+
 /** Unified real-time transport interface powering `/live` mode. */
 export interface ILiveTransport {
-	readonly provider: ResolvedLiveProvider;
-	readonly model: string;
+	readonly identity: LiveTransportIdentity;
 
 	/** Connect to the realtime backend. */
 	connect(): Promise<void>;

--- a/packages/coding-agent/src/live/transport-types.ts
+++ b/packages/coding-agent/src/live/transport-types.ts
@@ -1,6 +1,6 @@
 import type { Api, AuthStorage } from "@oh-my-pi/pi-ai";
 import type { LiveClientMessage, LiveServerEvent } from "./protocol";
-import type { VoiceProviderId } from "./providers/base";
+import type { VoiceProviderId } from "./provider";
 
 /** Callbacks emitted by a live transport implementation. */
 export interface LiveTransportCallbacks {
@@ -40,6 +40,9 @@ export interface ILiveTransport {
 
 	/** Send a control or context message to the realtime session. */
 	send(message: LiveClientMessage): Promise<void>;
+
+	/** Decide whether the current microphone frame should reach this provider. */
+	shouldStreamAudio(inputLevel: number, outputLevel: number): boolean;
 
 	/** Push Float32 PCM audio samples (16 kHz mono) from microphone. */
 	pushAudio(samples: Float32Array): void;

--- a/packages/coding-agent/src/live/transport-types.ts
+++ b/packages/coding-agent/src/live/transport-types.ts
@@ -1,0 +1,46 @@
+import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import type { LiveClientMessage, LiveServerEvent } from "./protocol";
+
+export type LiveProvider = "auto" | "openai-codex" | "xai-grok";
+export type ResolvedLiveProvider = Exclude<LiveProvider, "auto">;
+
+/** Callbacks emitted by a live transport implementation. */
+export interface LiveTransportCallbacks {
+	onEvent(event: LiveServerEvent): void;
+	onOutputLevel(level: number): void;
+}
+
+/** Configuration required to establish a live call. */
+export interface LiveTransportOptions {
+	authStorage: AuthStorage;
+	sessionId: string;
+	instructions: string;
+	voice: string;
+	codexVoice?: string;
+	grokVoice?: string;
+	provider?: LiveProvider;
+	grokModel?: string;
+	callbacks: LiveTransportCallbacks;
+	signal?: AbortSignal;
+}
+
+/** Unified real-time transport interface powering `/live` mode. */
+export interface ILiveTransport {
+	readonly provider: ResolvedLiveProvider;
+	readonly model: string;
+
+	/** Connect to the realtime backend. */
+	connect(): Promise<void>;
+
+	/** Send a control or context message to the realtime session. */
+	send(message: LiveClientMessage): Promise<void>;
+
+	/** Push Float32 PCM audio samples (16 kHz mono) from microphone. */
+	pushAudio(samples: Float32Array): void;
+
+	/** Set muted state. */
+	setMuted(muted: boolean): Promise<void>;
+
+	/** Gracefully stop and close the transport. */
+	close(): Promise<void>;
+}

--- a/packages/coding-agent/src/live/transport.ts
+++ b/packages/coding-agent/src/live/transport.ts
@@ -1,4 +1,4 @@
-import { type AuthStorage, isAuthRetryableError, type OAuthAccess, withOAuthAccess } from "@oh-my-pi/pi-ai";
+import { isAuthRetryableError, type OAuthAccess, withOAuthAccess } from "@oh-my-pi/pi-ai";
 import { getProxyForUrl, wrapFetchForProxy } from "@oh-my-pi/pi-ai/utils/proxy";
 import {
 	CODEX_BASE_URL,
@@ -8,12 +8,7 @@ import {
 } from "@oh-my-pi/pi-catalog/wire/codex";
 import { LiveWebRtcPeer } from "@oh-my-pi/pi-natives";
 import { generateCodexAttestation } from "./attestation";
-import {
-	buildLiveSessionPayload,
-	type LiveClientMessage,
-	type LiveServerEvent,
-	parseLiveServerEvent,
-} from "./protocol";
+import { buildLiveSessionPayload, LIVE_MODEL, type LiveClientMessage, parseLiveServerEvent } from "./protocol";
 
 const SIGNALING_URL = `${CODEX_BASE_URL}/codex/realtime/calls?intent=quicksilver&architecture=avas`;
 const MAX_ERROR_BODY_LENGTH = 2_048;
@@ -44,21 +39,9 @@ class LiveSignalingError extends Error {
 	}
 }
 
-/** Callbacks emitted by the live WebRTC transport. */
-export interface LiveTransportCallbacks {
-	onEvent(event: LiveServerEvent): void;
-	onOutputLevel(level: number): void;
-}
+export * from "./transport-types";
 
-/** Configuration required to establish a Codex live call. */
-export interface LiveTransportOptions {
-	authStorage: AuthStorage;
-	sessionId: string;
-	instructions: string;
-	voice: string;
-	callbacks: LiveTransportCallbacks;
-	signal?: AbortSignal;
-}
+import type { ILiveTransport, LiveTransportOptions } from "./transport-types";
 
 /** Extracts the server-assigned `rtc_*` call ID from a signaling Location header. */
 export function parseLiveCallId(location: string | null): string | undefined {
@@ -115,7 +98,9 @@ function abortReason(signal: AbortSignal | undefined): Error {
 }
 
 /** Native WebRTC transport for a Codex Frameless Bidi live session. */
-export class CodexLiveTransport {
+export class CodexLiveTransport implements ILiveTransport {
+	readonly provider = LIVE_PROVIDER;
+	readonly model = LIVE_MODEL;
 	readonly #options: LiveTransportOptions;
 	#peer: LiveWebRtcPeer | undefined;
 	readonly #realtimeSessionId = crypto.randomUUID();

--- a/packages/coding-agent/src/live/transport.ts
+++ b/packages/coding-agent/src/live/transport.ts
@@ -17,6 +17,9 @@ const SIDEBAND_CONNECT_TIMEOUT_MS = 15_000;
 const LIVE_PROVIDER = "openai-codex";
 const LIVE_ORIGINATOR = "Codex Desktop";
 const LIVE_CALL_ID_PATTERN = /^rtc_[\w-]+$/;
+const MIN_BARGE_IN_LEVEL = 0.04;
+const OUTPUT_ACTIVE_LEVEL = 0.015;
+const OUTPUT_ECHO_RATIO = 0.65;
 
 type Lifecycle = "idle" | "connecting" | "connected" | "closing" | "closed";
 
@@ -369,6 +372,13 @@ export class CodexLiveTransport implements ILiveTransport {
 		});
 		this.#sendTail = operation.catch(() => {});
 		return operation;
+	}
+
+	/** Preserve Codex's client-side speaker-echo gate while output audio is active. */
+	shouldStreamAudio(inputLevel: number, outputLevel: number): boolean {
+		if (outputLevel <= OUTPUT_ACTIVE_LEVEL) return true;
+		const echoThreshold = Math.max(MIN_BARGE_IN_LEVEL, outputLevel * OUTPUT_ECHO_RATIO);
+		return inputLevel >= echoThreshold;
 	}
 
 	/** Queue 16 kHz mono Float32 PCM for native Opus transmission. */

--- a/packages/coding-agent/src/live/transport.ts
+++ b/packages/coding-agent/src/live/transport.ts
@@ -41,7 +41,7 @@ class LiveSignalingError extends Error {
 
 export * from "./transport-types";
 
-import type { ILiveTransport, LiveTransportOptions } from "./transport-types";
+import type { ILiveTransport, LiveTransportIdentity, LiveTransportOptions } from "./transport-types";
 
 /** Extracts the server-assigned `rtc_*` call ID from a signaling Location header. */
 export function parseLiveCallId(location: string | null): string | undefined {
@@ -99,8 +99,12 @@ function abortReason(signal: AbortSignal | undefined): Error {
 
 /** Native WebRTC transport for a Codex Frameless Bidi live session. */
 export class CodexLiveTransport implements ILiveTransport {
-	readonly provider = LIVE_PROVIDER;
-	readonly model = LIVE_MODEL;
+	readonly identity = {
+		voiceProvider: "codex",
+		api: "openai-codex-responses",
+		provider: LIVE_PROVIDER,
+		model: LIVE_MODEL,
+	} satisfies LiveTransportIdentity;
 	readonly #options: LiveTransportOptions;
 	#peer: LiveWebRtcPeer | undefined;
 	readonly #realtimeSessionId = crypto.randomUUID();

--- a/packages/coding-agent/src/live/voices.ts
+++ b/packages/coding-agent/src/live/voices.ts
@@ -1,5 +1,5 @@
-/** Voices accepted by Codex-backed realtime sessions and exposed in settings. */
-export const LIVE_VOICE_OPTIONS = [
+/** Voices accepted by Codex-backed realtime sessions. */
+export const CODEX_LIVE_VOICE_OPTIONS = [
 	{ value: "arbor", label: "Arbor" },
 	{ value: "breeze", label: "Breeze" },
 	{ value: "cove", label: "Cove" },
@@ -11,8 +11,25 @@ export const LIVE_VOICE_OPTIONS = [
 	{ value: "vale", label: "Vale" },
 ] as const;
 
-/** Accepted values for the live voice setting. */
-export const LIVE_VOICE_VALUES = LIVE_VOICE_OPTIONS.map(({ value }) => value);
+/** Voices accepted by Grok-backed realtime sessions. */
+export const GROK_LIVE_VOICE_OPTIONS = [
+	{ value: "eve", label: "Eve" },
+	{ value: "ara", label: "Ara" },
+	{ value: "rex", label: "Rex" },
+	{ value: "sal", label: "Sal" },
+	{ value: "leo", label: "Leo" },
+] as const;
 
-/** Voice used when no live voice preference is configured. */
-export const DEFAULT_LIVE_VOICE = "sol";
+export const CODEX_LIVE_VOICE_VALUES = CODEX_LIVE_VOICE_OPTIONS.map(({ value }) => value);
+export const GROK_LIVE_VOICE_VALUES = GROK_LIVE_VOICE_OPTIONS.map(({ value }) => value);
+
+export const GROK_LIVE_VOICE_LOOKUP: Readonly<Record<string, true>> = {
+	eve: true,
+	ara: true,
+	rex: true,
+	sal: true,
+	leo: true,
+};
+
+export const DEFAULT_CODEX_LIVE_VOICE = "sol";
+export const DEFAULT_GROK_LIVE_VOICE = "eve";

--- a/packages/coding-agent/src/modes/controllers/live-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/live-command-controller.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import { LiveSessionController, type LiveSessionControllerOptions, type LiveTranscript } from "../../live/controller";
 import { LIVE_MODEL } from "../../live/protocol";
+import type { LiveProvider } from "../../live/transport-types";
 import { LiveVisualizer } from "../../live/visualizer";
 import { vocalizer } from "../../tts/vocalizer";
 import type { AssistantMessageComponent } from "../components/assistant-message";
@@ -52,14 +53,14 @@ export class LiveCommandController {
 		return this.#session !== undefined || this.#settling !== undefined;
 	}
 
-	/** Start live mode, or stop the currently active session. */
-	async handleCommand(): Promise<void> {
+	/** Start live mode with an optional one-session provider override, or stop the active session. */
+	async handleCommand(provider?: LiveProvider): Promise<void> {
 		if (this.#session) {
 			await this.stop();
 			return;
 		}
 		if (this.#settling) await this.#settling;
-		await this.#start();
+		await this.#start(provider);
 	}
 
 	/** Stop the active live session and restore the editor. */
@@ -91,7 +92,7 @@ export class LiveCommandController {
 		}
 	}
 
-	async #start(): Promise<void> {
+	async #start(provider?: LiveProvider): Promise<void> {
 		this.#assistantTranscriptTurn = 0;
 		this.#assistantTranscriptStartedAt = 0;
 		const visualizer = new LiveVisualizer({
@@ -107,7 +108,9 @@ export class LiveCommandController {
 		const options: LiveSessionControllerOptions = {
 			session: this.#ctx.session,
 			extractAssistantText: message => this.#ctx.extractAssistantText(message),
-			voice: this.#ctx.settings.get("live.voice"),
+			codexVoice: this.#ctx.settings.get("live.codexVoice"),
+			grokVoice: this.#ctx.settings.get("live.grokVoice"),
+			provider: provider ?? this.#ctx.settings.get("live.provider"),
 			callbacks: {
 				onPhase: phase => {
 					if (this.#visualizer !== visualizer) return;
@@ -166,12 +169,13 @@ export class LiveCommandController {
 			this.#assistantTranscriptComponent = component;
 			this.#assistantTranscriptStartedAt = Date.now();
 		}
+		const isGrok = this.#session?.provider === "xai-grok";
 		const message: AssistantMessage = {
 			role: "assistant",
 			content: [{ type: "text", text: transcript.text }],
-			api: "openai-codex-responses",
-			provider: "openai-codex",
-			model: LIVE_MODEL,
+			api: isGrok ? "openai-completions" : "openai-codex-responses",
+			provider: isGrok ? "xai" : "openai-codex",
+			model: this.#session?.model ?? LIVE_MODEL,
 			usage: { ...LIVE_MESSAGE_USAGE },
 			stopReason: "stop",
 			timestamp: this.#assistantTranscriptStartedAt,

--- a/packages/coding-agent/src/modes/controllers/live-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/live-command-controller.ts
@@ -1,7 +1,7 @@
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import { LiveSessionController, type LiveSessionControllerOptions, type LiveTranscript } from "../../live/controller";
-import type { VoiceProviderId } from "../../live/providers/base";
+import type { VoiceProviderId } from "../../live/provider";
 import { LiveVisualizer } from "../../live/visualizer";
 import { vocalizer } from "../../tts/vocalizer";
 import type { AssistantMessageComponent } from "../components/assistant-message";

--- a/packages/coding-agent/src/modes/controllers/live-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/live-command-controller.ts
@@ -1,8 +1,7 @@
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import { LiveSessionController, type LiveSessionControllerOptions, type LiveTranscript } from "../../live/controller";
-import { LIVE_MODEL } from "../../live/protocol";
-import type { LiveProvider } from "../../live/transport-types";
+import type { VoiceProviderId } from "../../live/providers/base";
 import { LiveVisualizer } from "../../live/visualizer";
 import { vocalizer } from "../../tts/vocalizer";
 import type { AssistantMessageComponent } from "../components/assistant-message";
@@ -54,7 +53,7 @@ export class LiveCommandController {
 	}
 
 	/** Start live mode with an optional one-session provider override, or stop the active session. */
-	async handleCommand(provider?: LiveProvider): Promise<void> {
+	async handleCommand(provider?: VoiceProviderId): Promise<void> {
 		if (this.#session) {
 			await this.stop();
 			return;
@@ -92,7 +91,7 @@ export class LiveCommandController {
 		}
 	}
 
-	async #start(provider?: LiveProvider): Promise<void> {
+	async #start(provider?: VoiceProviderId): Promise<void> {
 		this.#assistantTranscriptTurn = 0;
 		this.#assistantTranscriptStartedAt = 0;
 		const visualizer = new LiveVisualizer({
@@ -108,9 +107,12 @@ export class LiveCommandController {
 		const options: LiveSessionControllerOptions = {
 			session: this.#ctx.session,
 			extractAssistantText: message => this.#ctx.extractAssistantText(message),
-			codexVoice: this.#ctx.settings.get("live.codexVoice"),
-			grokVoice: this.#ctx.settings.get("live.grokVoice"),
-			provider: provider ?? this.#ctx.settings.get("live.provider"),
+			providerOrder: this.#ctx.settings.get("providers.voiceOrder"),
+			provider,
+			providerConfigs: {
+				codex: { voice: this.#ctx.settings.get("live.codexVoice") },
+				grok: { voice: this.#ctx.settings.get("live.grokVoice") },
+			},
 			callbacks: {
 				onPhase: phase => {
 					if (this.#visualizer !== visualizer) return;
@@ -169,13 +171,12 @@ export class LiveCommandController {
 			this.#assistantTranscriptComponent = component;
 			this.#assistantTranscriptStartedAt = Date.now();
 		}
-		const isGrok = this.#session?.provider === "xai-grok";
 		const message: AssistantMessage = {
 			role: "assistant",
 			content: [{ type: "text", text: transcript.text }],
-			api: isGrok ? "openai-completions" : "openai-codex-responses",
-			provider: isGrok ? "xai" : "openai-codex",
-			model: this.#session?.model ?? LIVE_MODEL,
+			api: transcript.identity.api,
+			provider: transcript.identity.provider,
+			model: transcript.identity.model,
 			usage: { ...LIVE_MESSAGE_USAGE },
 			stopReason: "stop",
 			timestamp: this.#assistantTranscriptStartedAt,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -81,7 +81,7 @@ import type { Skill } from "../extensibility/skills";
 import { loadSlashCommands } from "../extensibility/slash-commands";
 import type { Goal, GoalModeState } from "../goals/state";
 import { resolveLocalUrlToPath } from "../internal-urls";
-import type { LiveProvider } from "../live/transport-types";
+import type { VoiceProviderId } from "../live/providers/base";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
 import type { MCPManager } from "../mcp";
 import {
@@ -4593,7 +4593,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	/** Start or stop the realtime voice surface, optionally overriding its provider for this session. */
-	async handleLiveCommand(provider?: LiveProvider): Promise<void> {
+	async handleLiveCommand(provider?: VoiceProviderId): Promise<void> {
 		if (this.#sttController && this.#sttController.state !== "idle") {
 			this.showWarning("Finish the current speech-to-text capture before starting live mode.");
 			return;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -81,6 +81,7 @@ import type { Skill } from "../extensibility/skills";
 import { loadSlashCommands } from "../extensibility/slash-commands";
 import type { Goal, GoalModeState } from "../goals/state";
 import { resolveLocalUrlToPath } from "../internal-urls";
+import type { LiveProvider } from "../live/transport-types";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
 import type { MCPManager } from "../mcp";
 import {
@@ -4591,13 +4592,13 @@ export class InteractiveMode implements InteractiveModeContext {
 		});
 	}
 
-	/** Start or stop the Codex-backed realtime voice surface. */
-	async handleLiveCommand(): Promise<void> {
+	/** Start or stop the realtime voice surface, optionally overriding its provider for this session. */
+	async handleLiveCommand(provider?: LiveProvider): Promise<void> {
 		if (this.#sttController && this.#sttController.state !== "idle") {
 			this.showWarning("Finish the current speech-to-text capture before starting live mode.");
 			return;
 		}
-		await this.#liveCommandController.handleCommand();
+		await this.#liveCommandController.handleCommand(provider);
 	}
 
 	#setMicCursor(color: { r: number; g: number; b: number }): void {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -81,7 +81,7 @@ import type { Skill } from "../extensibility/skills";
 import { loadSlashCommands } from "../extensibility/slash-commands";
 import type { Goal, GoalModeState } from "../goals/state";
 import { resolveLocalUrlToPath } from "../internal-urls";
-import type { VoiceProviderId } from "../live/providers/base";
+import type { VoiceProviderId } from "../live/provider";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
 import type { MCPManager } from "../mcp";
 import {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -16,7 +16,7 @@ import type {
 } from "../extensibility/extensions";
 import type { CompactOptions } from "../extensibility/extensions/types";
 import type { Skill } from "../extensibility/skills";
-import type { VoiceProviderId } from "../live/providers/base";
+import type { VoiceProviderId } from "../live/provider";
 import type { MCPManager } from "../mcp";
 import type { PlanApprovalDetails } from "../plan-mode/approved-plan";
 import type { AgentSession } from "../session/agent-session";

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -16,7 +16,7 @@ import type {
 } from "../extensibility/extensions";
 import type { CompactOptions } from "../extensibility/extensions/types";
 import type { Skill } from "../extensibility/skills";
-import type { LiveProvider } from "../live/transport-types";
+import type { VoiceProviderId } from "../live/providers/base";
 import type { MCPManager } from "../mcp";
 import type { PlanApprovalDetails } from "../plan-mode/approved-plan";
 import type { AgentSession } from "../session/agent-session";
@@ -370,7 +370,7 @@ export interface InteractiveModeContext {
 	handleMemoryCommand(text: string): Promise<void>;
 	handleSTTToggle(): Promise<void>;
 	/** Start or stop realtime voice, optionally overriding its provider for this session. */
-	handleLiveCommand(provider?: LiveProvider): Promise<void>;
+	handleLiveCommand(provider?: VoiceProviderId): Promise<void>;
 	executeCompaction(
 		customInstructionsOrOptions?: string | CompactOptions,
 		isAuto?: boolean,

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -16,6 +16,7 @@ import type {
 } from "../extensibility/extensions";
 import type { CompactOptions } from "../extensibility/extensions/types";
 import type { Skill } from "../extensibility/skills";
+import type { LiveProvider } from "../live/transport-types";
 import type { MCPManager } from "../mcp";
 import type { PlanApprovalDetails } from "../plan-mode/approved-plan";
 import type { AgentSession } from "../session/agent-session";
@@ -368,8 +369,8 @@ export interface InteractiveModeContext {
 	handleRenameCommand(title: string): Promise<void>;
 	handleMemoryCommand(text: string): Promise<void>;
 	handleSTTToggle(): Promise<void>;
-	/** Start or stop the Codex-backed realtime voice session. */
-	handleLiveCommand(): Promise<void>;
+	/** Start or stop realtime voice, optionally overriding its provider for this session. */
+	handleLiveCommand(provider?: LiveProvider): Promise<void>;
 	executeCompaction(
 		customInstructionsOrOptions?: string | CompactOptions,
 		isAuto?: boolean,

--- a/packages/coding-agent/src/slash-commands/builtin-control.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-control.ts
@@ -55,10 +55,21 @@ export const BUILTIN_CONTROL_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "live",
-		description: "Start Codex-backed realtime voice mode",
-		handleTui: async (_command, runtime) => {
+		description: "Start or stop realtime voice mode; optionally use Grok or Codex",
+		allowArgs: true,
+		subcommands: [
+			{ name: "grok", description: "Start with xAI Grok Voice for this session" },
+			{ name: "codex", description: "Start with OpenAI Codex Voice for this session" },
+		],
+		handleTui: async (command, runtime) => {
+			const providerName = command.args.trim().toLowerCase();
 			runtime.ctx.editor.setText("");
-			await runtime.ctx.handleLiveCommand();
+			if (providerName && providerName !== "grok" && providerName !== "codex") {
+				runtime.ctx.showError("Usage: /live [grok|codex]");
+				return;
+			}
+			const provider = providerName === "grok" || providerName === "codex" ? providerName : undefined;
+			await runtime.ctx.handleLiveCommand(provider);
 		},
 	},
 	{

--- a/packages/coding-agent/test/live-settings.test.ts
+++ b/packages/coding-agent/test/live-settings.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("live voice settings", () => {
 	test("migrates the legacy shared voice into Codex without changing Grok", () => {
@@ -21,34 +20,5 @@ describe("live voice settings", () => {
 
 		expect(settings.get("live.codexVoice")).toBe("maple");
 		expect(settings.get("live.grokVoice")).toBe("leo");
-	});
-
-	test("migrates a legacy selected provider into a complete priority order", () => {
-		const legacySettings: Record<string, unknown> = { "live.provider": "xai-grok" };
-		const settings = Settings.isolated(legacySettings);
-
-		expect(settings.get("providers.voiceOrder")).toEqual(["grok", "codex"]);
-	});
-
-	test("keeps an explicit voice provider order over a legacy provider", () => {
-		const legacySettings: Record<string, unknown> = {
-			"live.provider": "openai-codex",
-			"providers.voiceOrder": ["grok"],
-		};
-		const settings = Settings.isolated(legacySettings);
-
-		expect(settings.get("providers.voiceOrder")).toEqual(["grok"]);
-	});
-
-	test("normalizes a standalone flat Codex voice from persisted settings", async () => {
-		using tempDir = TempDir.createSync("@omp-live-settings-");
-		await Bun.write(tempDir.join("config.yml"), '"live.codexVoice": vale\n');
-
-		const settings = await Settings.loadReadOnly({
-			agentDir: tempDir.path(),
-			cwd: tempDir.path(),
-		});
-
-		expect(settings.get("live.codexVoice")).toBe("vale");
 	});
 });

--- a/packages/coding-agent/test/live-settings.test.ts
+++ b/packages/coding-agent/test/live-settings.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+describe("live voice settings", () => {
+	test("migrates the legacy shared voice into Codex without changing Grok", () => {
+		const legacySettings: Record<string, unknown> = { "live.voice": "vale" };
+		const settings = Settings.isolated(legacySettings);
+
+		expect(settings.get("live.codexVoice")).toBe("vale");
+		expect(settings.get("live.grokVoice")).toBe("eve");
+	});
+
+	test("keeps explicit provider-specific voices over the legacy value", () => {
+		const legacySettings: Record<string, unknown> = {
+			"live.voice": "vale",
+			"live.codexVoice": "maple",
+			"live.grokVoice": "leo",
+		};
+		const settings = Settings.isolated(legacySettings);
+
+		expect(settings.get("live.codexVoice")).toBe("maple");
+		expect(settings.get("live.grokVoice")).toBe("leo");
+	});
+
+	test("normalizes a standalone flat Codex voice from persisted settings", async () => {
+		using tempDir = TempDir.createSync("@omp-live-settings-");
+		await Bun.write(tempDir.join("config.yml"), '"live.codexVoice": vale\n');
+
+		const settings = await Settings.loadReadOnly({
+			agentDir: tempDir.path(),
+			cwd: tempDir.path(),
+		});
+
+		expect(settings.get("live.codexVoice")).toBe("vale");
+	});
+});

--- a/packages/coding-agent/test/live-settings.test.ts
+++ b/packages/coding-agent/test/live-settings.test.ts
@@ -23,6 +23,23 @@ describe("live voice settings", () => {
 		expect(settings.get("live.grokVoice")).toBe("leo");
 	});
 
+	test("migrates a legacy selected provider into a complete priority order", () => {
+		const legacySettings: Record<string, unknown> = { "live.provider": "xai-grok" };
+		const settings = Settings.isolated(legacySettings);
+
+		expect(settings.get("providers.voiceOrder")).toEqual(["grok", "codex"]);
+	});
+
+	test("keeps an explicit voice provider order over a legacy provider", () => {
+		const legacySettings: Record<string, unknown> = {
+			"live.provider": "openai-codex",
+			"providers.voiceOrder": ["grok"],
+		};
+		const settings = Settings.isolated(legacySettings);
+
+		expect(settings.get("providers.voiceOrder")).toEqual(["grok"]);
+	});
+
 	test("normalizes a standalone flat Codex voice from persisted settings", async () => {
 		using tempDir = TempDir.createSync("@omp-live-settings-");
 		await Bun.write(tempDir.join("config.yml"), '"live.codexVoice": vale\n');

--- a/packages/coding-agent/test/live/codex-transport.test.ts
+++ b/packages/coding-agent/test/live/codex-transport.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { CodexLiveTransport } from "../../src/live/transport";
+import type { LiveTransportOptions } from "../../src/live/transport-types";
+
+function createTransport(): CodexLiveTransport {
+	return new CodexLiveTransport({
+		authStorage: {} as LiveTransportOptions["authStorage"],
+		sessionId: "test-session",
+		instructions: "Test instructions",
+		voice: "sol",
+		callbacks: {
+			onEvent: () => {},
+			onOutputLevel: () => {},
+		},
+	});
+}
+
+describe("CodexLiveTransport", () => {
+	test("rejects likely speaker echo while preserving genuine barge-in", () => {
+		const transport = createTransport();
+
+		expect(transport.shouldStreamAudio(0.01, 0)).toBe(true);
+		expect(transport.shouldStreamAudio(0.02, 0.1)).toBe(false);
+		expect(transport.shouldStreamAudio(0.08, 0.1)).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/live/controller.test.ts
+++ b/packages/coding-agent/test/live/controller.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, test, vi } from "bun:test";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
-import type { LiveSessionCallbacks } from "../../src/live/controller";
-import { LiveSessionController } from "../../src/live/controller";
+import * as natives from "@oh-my-pi/pi-natives";
+import { type LiveSessionCallbacks, LiveSessionController } from "../../src/live/controller";
+import type { GrokLiveTransport } from "../../src/live/grok-transport";
+import type { LiveClientMessage } from "../../src/live/protocol";
 import { GrokVoiceProvider } from "../../src/live/providers/grok";
+import type { ILiveTransport, LiveTransportCallbacks } from "../../src/live/transport-types";
+import type { AgentSessionEvent } from "../../src/session/agent-session-events";
 
 const callbacks: LiveSessionCallbacks = {
 	onPhase: () => {},
@@ -34,5 +38,95 @@ describe("LiveSessionController", () => {
 
 		await expect(starting).rejects.toThrow("stopped while selecting a provider");
 		expect(createTransport).not.toHaveBeenCalled();
+	});
+
+	test("routes two function calls to separate agent turns and returns each result to its caller", async () => {
+		const fakeAudioCapture = () => ({ stop: () => {} });
+		const audioCaptureSpy = vi.spyOn(natives, "AudioCapture") as unknown as {
+			mockImplementation(implementation: typeof fakeAudioCapture): void;
+		};
+		audioCaptureSpy.mockImplementation(fakeAudioCapture);
+
+		const sent: LiveClientMessage[] = [];
+		const resultsRouted = Promise.withResolvers<void>();
+		let transportCallbacks: LiveTransportCallbacks | undefined;
+		const transport = {
+			identity: { voiceProvider: "grok", api: "openai-completions", provider: "xai", model: "grok-voice" },
+			connect: vi.fn(async () => {}),
+			send: vi.fn(async (message: LiveClientMessage) => {
+				sent.push(message);
+				if (sent.length === 2) resultsRouted.resolve();
+			}),
+			shouldStreamAudio: () => true,
+			pushAudio: () => {},
+			setMuted: vi.fn(async () => {}),
+			close: vi.fn(async () => {}),
+		} satisfies ILiveTransport;
+		vi.spyOn(GrokVoiceProvider.prototype, "createTransport").mockImplementation(options => {
+			transportCallbacks = options.callbacks;
+			return transport as unknown as GrokLiveTransport;
+		});
+
+		const requests: string[] = [];
+		const agentResults = ["First result", "Second result"];
+		let sessionListener: ((event: AgentSessionEvent) => void) | undefined;
+		const session = {
+			sessionId: "test-session",
+			modelRegistry: { authStorage: {} },
+			sendCustomMessage: vi.fn(async (message: { content: string }) => {
+				requests.push(message.content);
+			}),
+			subscribe: vi.fn((listener: (event: AgentSessionEvent) => void) => {
+				sessionListener = listener;
+				return () => {};
+			}),
+		} as unknown as AgentSession;
+		const controller = new LiveSessionController({
+			session,
+			extractAssistantText: () => agentResults.shift() ?? "",
+			provider: "grok",
+			callbacks,
+		});
+		await controller.start();
+
+		const onEvent = transportCallbacks?.onEvent;
+		if (!onEvent || !sessionListener) throw new Error("live callbacks were not installed");
+		onEvent({
+			type: "delegation.created",
+			item: {
+				type: "delegation",
+				target: "client",
+				id: "call-1",
+				content: [{ type: "input_text", text: "First request" }],
+			},
+		});
+		onEvent({
+			type: "delegation.created",
+			item: {
+				type: "delegation",
+				target: "client",
+				id: "call-2",
+				content: [{ type: "input_text", text: "Second request" }],
+			},
+		});
+		sessionListener({
+			type: "agent_end",
+			messages: [{ role: "assistant" }],
+		} as unknown as AgentSessionEvent);
+		sessionListener({
+			type: "agent_end",
+			messages: [{ role: "assistant" }],
+		} as unknown as AgentSessionEvent);
+		await resultsRouted.promise;
+
+		expect(requests).toEqual(["First request", "Second request"]);
+		const routedResults = sent.filter(message => message.type === "delegation.context.append");
+		expect(routedResults.map(message => message.delegation_item_id)).toEqual(["call-1", "call-2"]);
+		expect(routedResults.map(message => message.content[0]?.text)).toEqual([
+			expect.stringContaining("First result"),
+			expect.stringContaining("Second result"),
+		]);
+
+		await controller.stop();
 	});
 });

--- a/packages/coding-agent/test/live/controller.test.ts
+++ b/packages/coding-agent/test/live/controller.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test, vi } from "bun:test";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { LiveSessionCallbacks } from "../../src/live/controller";
 import { LiveSessionController } from "../../src/live/controller";
-import { GrokLiveTransport } from "../../src/live/grok-transport";
+import { GrokVoiceProvider } from "../../src/live/providers/grok";
 
 const callbacks: LiveSessionCallbacks = {
 	onPhase: () => {},
@@ -16,9 +16,8 @@ describe("LiveSessionController", () => {
 		vi.restoreAllMocks();
 	});
 
-	test("closes a transport selected after the session stops", async () => {
-		const connect = vi.spyOn(GrokLiveTransport.prototype, "connect").mockResolvedValue();
-		const close = vi.spyOn(GrokLiveTransport.prototype, "close");
+	test("does not create a transport after the session stops during provider selection", async () => {
+		const createTransport = vi.spyOn(GrokVoiceProvider.prototype, "createTransport");
 		const session = {
 			sessionId: "test-session",
 			modelRegistry: { authStorage: {} },
@@ -26,7 +25,7 @@ describe("LiveSessionController", () => {
 		const controller = new LiveSessionController({
 			session,
 			extractAssistantText: () => "",
-			provider: "xai-grok",
+			provider: "grok",
 			callbacks,
 		});
 
@@ -34,7 +33,6 @@ describe("LiveSessionController", () => {
 		await controller.stop();
 
 		await expect(starting).rejects.toThrow("stopped while selecting a provider");
-		expect(close).toHaveBeenCalledTimes(1);
-		expect(connect).not.toHaveBeenCalled();
+		expect(createTransport).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/live/controller.test.ts
+++ b/packages/coding-agent/test/live/controller.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { LiveSessionCallbacks } from "../../src/live/controller";
+import { LiveSessionController } from "../../src/live/controller";
+import { GrokLiveTransport } from "../../src/live/grok-transport";
+
+const callbacks: LiveSessionCallbacks = {
+	onPhase: () => {},
+	onLevels: () => {},
+	onTranscript: () => {},
+	onTerminal: () => {},
+};
+
+describe("LiveSessionController", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test("closes a transport selected after the session stops", async () => {
+		const connect = vi.spyOn(GrokLiveTransport.prototype, "connect").mockResolvedValue();
+		const close = vi.spyOn(GrokLiveTransport.prototype, "close");
+		const session = {
+			sessionId: "test-session",
+			modelRegistry: { authStorage: {} },
+		} as unknown as AgentSession;
+		const controller = new LiveSessionController({
+			session,
+			extractAssistantText: () => "",
+			provider: "xai-grok",
+			callbacks,
+		});
+
+		const starting = controller.start();
+		await controller.stop();
+
+		await expect(starting).rejects.toThrow("stopped while selecting a provider");
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(connect).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/live/grok-transport.test.ts
+++ b/packages/coding-agent/test/live/grok-transport.test.ts
@@ -20,6 +20,27 @@ describe("GrokLiveTransport", () => {
 		});
 	});
 
+	test("owns the transcript identity for its selected model", () => {
+		const transport = new GrokLiveTransport({
+			authStorage: {} as LiveTransportOptions["authStorage"],
+			sessionId: "test-session-123",
+			instructions: "Test instructions",
+			voice: "eve",
+			model: "grok-voice-custom",
+			callbacks: {
+				onEvent: () => {},
+				onOutputLevel: () => {},
+			},
+		});
+
+		expect(transport.identity).toEqual({
+			voiceProvider: "grok",
+			api: "openai-completions",
+			provider: "xai",
+			model: "grok-voice-custom",
+		});
+	});
+
 	test("translates Grok function calls into delegation.created events", () => {
 		const events: LiveServerEvent[] = [];
 		const callbacks: LiveTransportCallbacks = {

--- a/packages/coding-agent/test/live/grok-transport.test.ts
+++ b/packages/coding-agent/test/live/grok-transport.test.ts
@@ -1,10 +1,71 @@
 import { afterEach, describe, expect, test, vi } from "bun:test";
 import { buildGrokSessionUpdate, GrokLiveTransport } from "../../src/live/grok-transport";
-import type { LiveServerEvent } from "../../src/live/protocol";
+import { buildDelegationContextAppend, type LiveServerEvent } from "../../src/live/protocol";
 import type { LiveTransportCallbacks, LiveTransportOptions } from "../../src/live/transport-types";
+
+const ORIGINAL_WEBSOCKET = globalThis.WebSocket;
+
+class ControlledWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static readonly instances: ControlledWebSocket[] = [];
+
+	readyState = ControlledWebSocket.CONNECTING;
+	binaryType = "blob";
+	onopen: ((event: Event) => void) | null = null;
+	onmessage: ((event: MessageEvent) => void) | null = null;
+	onerror: ((event: Event) => void) | null = null;
+	onclose: ((event: CloseEvent) => void) | null = null;
+	readonly sent: string[] = [];
+	closeCalls = 0;
+
+	constructor() {
+		ControlledWebSocket.instances.push(this);
+	}
+
+	send(data: string): void {
+		this.sent.push(data);
+	}
+
+	close(code = 1000, reason = ""): void {
+		this.closeCalls += 1;
+		this.readyState = ControlledWebSocket.CLOSED;
+		this.onclose?.({ code, reason } as CloseEvent);
+	}
+
+	open(): void {
+		this.readyState = ControlledWebSocket.OPEN;
+		this.onopen?.(new Event("open"));
+	}
+}
+
+async function waitForSocket(): Promise<ControlledWebSocket> {
+	for (let attempt = 0; attempt < 20; attempt += 1) {
+		const socket = ControlledWebSocket.instances[0];
+		if (socket) return socket;
+		await Promise.resolve();
+	}
+	throw new Error("Grok transport did not create a WebSocket");
+}
+
+function createTransport(callbacks: LiveTransportCallbacks): GrokLiveTransport {
+	return new GrokLiveTransport({
+		authStorage: {
+			getApiKey: async () => "test-xai-key",
+		} as unknown as LiveTransportOptions["authStorage"],
+		sessionId: "test-session-123",
+		instructions: "Test instructions",
+		voice: "eve",
+		callbacks,
+	});
+}
 
 describe("GrokLiveTransport", () => {
 	afterEach(() => {
+		globalThis.WebSocket = ORIGINAL_WEBSOCKET;
+		ControlledWebSocket.instances.length = 0;
 		vi.useRealTimers();
 		vi.restoreAllMocks();
 	});
@@ -39,6 +100,7 @@ describe("GrokLiveTransport", () => {
 			provider: "xai",
 			model: "grok-voice-custom",
 		});
+		expect(transport.shouldStreamAudio(0, 1)).toBe(true);
 	});
 
 	test("translates Grok function calls into delegation.created events", () => {
@@ -67,6 +129,7 @@ describe("GrokLiveTransport", () => {
 				arguments: JSON.stringify({ request: "Run git status and report back" }),
 			}),
 		);
+		transport.handleServerMessage(JSON.stringify({ type: "response.done" }));
 
 		expect(events).toEqual([
 			{
@@ -79,6 +142,63 @@ describe("GrokLiveTransport", () => {
 				},
 			},
 		]);
+	});
+
+	test("closes a pending socket without allowing a late open to reconnect", async () => {
+		globalThis.WebSocket = ControlledWebSocket as unknown as typeof WebSocket;
+		const transport = createTransport({ onEvent: () => {}, onOutputLevel: () => {} });
+		const connecting = transport.connect();
+		const socket = await waitForSocket();
+
+		await transport.close();
+		await expect(connecting).rejects.toThrow("closed before connecting");
+		socket.open();
+
+		expect(socket.closeCalls).toBeGreaterThanOrEqual(2);
+		await expect(transport.send({ type: "session.close" })).rejects.toThrow("not connected");
+	});
+
+	test("waits for every function output before creating one continuation response", async () => {
+		globalThis.WebSocket = ControlledWebSocket as unknown as typeof WebSocket;
+		const events: LiveServerEvent[] = [];
+		const transport = createTransport({
+			onEvent: event => events.push(event),
+			onOutputLevel: () => {},
+		});
+		const connecting = transport.connect();
+		const socket = await waitForSocket();
+		socket.open();
+		await connecting;
+		socket.sent.length = 0;
+
+		transport.handleServerMessage(
+			JSON.stringify({
+				type: "response.function_call_arguments.done",
+				call_id: "call-1",
+				arguments: JSON.stringify({ request: "First task" }),
+			}),
+		);
+		transport.handleServerMessage(
+			JSON.stringify({
+				type: "response.function_call_arguments.done",
+				call_id: "call-2",
+				arguments: JSON.stringify({ request: "Second task" }),
+			}),
+		);
+		expect(events).toEqual([]);
+		transport.handleServerMessage(JSON.stringify({ type: "response.done" }));
+		expect(events).toHaveLength(2);
+
+		await transport.send(buildDelegationContextAppend("call-1", "First result", "speakable"));
+		expect(socket.sent.map(payload => JSON.parse(payload).type)).toEqual(["conversation.item.create"]);
+
+		await transport.send(buildDelegationContextAppend("call-2", "Second result", "speakable"));
+		expect(socket.sent.map(payload => JSON.parse(payload).type)).toEqual([
+			"conversation.item.create",
+			"conversation.item.create",
+			"response.create",
+		]);
+		await transport.close();
 	});
 
 	test("translates transcript events from Grok server deltas", () => {

--- a/packages/coding-agent/test/live/grok-transport.test.ts
+++ b/packages/coding-agent/test/live/grok-transport.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { buildGrokSessionUpdate, GrokLiveTransport } from "../../src/live/grok-transport";
+import type { LiveServerEvent } from "../../src/live/protocol";
+import type { LiveTransportCallbacks, LiveTransportOptions } from "../../src/live/transport-types";
+
+describe("GrokLiveTransport", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+	test("delegates microphone turn completion to xAI server VAD", () => {
+		expect(buildGrokSessionUpdate("Test instructions", "eve")).toMatchObject({
+			type: "session.update",
+			session: {
+				turn_detection: { type: "server_vad" },
+				audio: {
+					input: { format: { type: "audio/pcm", rate: 16_000 } },
+				},
+			},
+		});
+	});
+
+	test("translates Grok function calls into delegation.created events", () => {
+		const events: LiveServerEvent[] = [];
+		const callbacks: LiveTransportCallbacks = {
+			onEvent: event => events.push(event),
+			onOutputLevel: () => {},
+		};
+
+		const mockAuthStorage = {
+			getApiKey: vi.fn(async () => "test-xai-key"),
+		} as unknown as LiveTransportOptions["authStorage"];
+		const transport = new GrokLiveTransport({
+			authStorage: mockAuthStorage,
+			sessionId: "test-session-123",
+			instructions: "Test instructions",
+			voice: "eve",
+			callbacks,
+		});
+
+		// Simulate server event dispatch internal method via prototype or handler
+		transport.handleServerMessage(
+			JSON.stringify({
+				type: "response.function_call_arguments.done",
+				call_id: "call-99",
+				arguments: JSON.stringify({ request: "Run git status and report back" }),
+			}),
+		);
+
+		expect(events).toEqual([
+			{
+				type: "delegation.created",
+				item: {
+					type: "delegation",
+					target: "client",
+					id: "call-99",
+					content: [{ type: "input_text", text: "Run git status and report back" }],
+				},
+			},
+		]);
+	});
+
+	test("translates transcript events from Grok server deltas", () => {
+		const events: LiveServerEvent[] = [];
+		const callbacks: LiveTransportCallbacks = {
+			onEvent: event => events.push(event),
+			onOutputLevel: () => {},
+		};
+
+		const mockAuthStorage = {
+			getApiKey: vi.fn(async () => "test-xai-key"),
+		} as unknown as LiveTransportOptions["authStorage"];
+
+		const transport = new GrokLiveTransport({
+			authStorage: mockAuthStorage,
+			sessionId: "test-session-123",
+			instructions: "Test instructions",
+			voice: "eve",
+			callbacks,
+		});
+
+		transport.handleServerMessage(
+			JSON.stringify({
+				type: "conversation.item.input_audio_transcription.completed",
+				transcript: "Fix the bug in main.ts",
+			}),
+		);
+
+		transport.handleServerMessage(
+			JSON.stringify({
+				type: "response.output_audio_transcript.delta",
+				delta: "I will check main.ts.",
+			}),
+		);
+
+		transport.handleServerMessage(
+			JSON.stringify({
+				type: "response.output_audio_transcript.done",
+				transcript: "I will check main.ts.",
+			}),
+		);
+
+		expect(events).toEqual([
+			{
+				type: "input_transcript.added",
+				item: { text: "Fix the bug in main.ts" },
+			},
+			{
+				type: "turn.done",
+				turn: { role: "user", transcript: "Fix the bug in main.ts" },
+			},
+			{
+				type: "output_transcript.added",
+				item: { text: "I will check main.ts." },
+			},
+			{
+				type: "turn.done",
+				turn: { role: "assistant", transcript: "I will check main.ts." },
+			},
+		]);
+	});
+
+	test("keeps output active until queued speaker audio has played", () => {
+		vi.useFakeTimers();
+		const levels: number[] = [];
+		const mockAuthStorage = {
+			getApiKey: vi.fn(async () => "test-xai-key"),
+		} as unknown as LiveTransportOptions["authStorage"];
+		const transport = new GrokLiveTransport({
+			authStorage: mockAuthStorage,
+			sessionId: "test-session-123",
+			instructions: "Test instructions",
+			voice: "eve",
+			callbacks: {
+				onEvent: () => {},
+				onOutputLevel: level => levels.push(level),
+			},
+		});
+		const pcm = Buffer.alloc(480);
+		for (let offset = 0; offset < pcm.length; offset += 2) pcm.writeInt16LE(10_000, offset);
+
+		transport.handleServerMessage(
+			JSON.stringify({
+				type: "response.output_audio.delta",
+				delta: pcm.toString("base64"),
+			}),
+		);
+		transport.handleServerMessage(JSON.stringify({ type: "response.output_audio.done" }));
+
+		expect(levels).toHaveLength(1);
+		expect(levels[0]).toBeGreaterThan(0);
+		vi.advanceTimersByTime(20);
+		expect(levels.at(-1)).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/live/provider.test.ts
+++ b/packages/coding-agent/test/live/provider.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import { resolveVoiceProvider, resolveVoiceProviderOrder } from "../../src/live/provider";
+
+const authStorage = {
+	hasNonEnvCredential: () => true,
+	getApiKey: async () => "test-xai-key",
+} as unknown as AuthStorage;
+
+describe("voice provider resolution", () => {
+	test("honors configured ranking when multiple providers are available", async () => {
+		const grokFirst = await resolveVoiceProvider({
+			authStorage,
+			sessionId: "test-session",
+			order: ["grok", "codex"],
+		});
+		const codexFirst = await resolveVoiceProvider({
+			authStorage,
+			sessionId: "test-session",
+			order: ["codex", "grok"],
+		});
+
+		expect(grokFirst.id).toBe("grok");
+		expect(codexFirst.id).toBe("codex");
+	});
+
+	test("appends unlisted providers in built-in order without duplicates", () => {
+		expect(resolveVoiceProviderOrder(["grok", "grok"])).toEqual(["grok", "codex"]);
+	});
+
+	test("allows an explicit unavailable provider override", async () => {
+		const unavailable = {
+			hasNonEnvCredential: () => false,
+			getApiKey: async () => undefined,
+		} as unknown as AuthStorage;
+
+		const provider = await resolveVoiceProvider({
+			authStorage: unavailable,
+			sessionId: "test-session",
+			forced: "grok",
+		});
+
+		expect(provider.id).toBe("grok");
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/live-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/live-command-controller.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { LiveSessionController } from "@oh-my-pi/pi-coding-agent/live/controller";
+import { LiveSessionController, type LiveTranscript } from "@oh-my-pi/pi-coding-agent/live/controller";
 import { LiveVisualizer } from "@oh-my-pi/pi-coding-agent/live/visualizer";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
 import { LiveCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/live-command-controller";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 
 /** Fake InteractiveModeContext plus typed capture channels for focus/mount traffic. */
 interface ContextHarness {
@@ -22,15 +24,26 @@ function createContext(): ContextHarness {
 	const editor = {
 		getUseTerminalCursor: vi.fn(() => true),
 		setUseTerminalCursor: vi.fn(),
+		setText: vi.fn(),
 	};
 	const focused: unknown[] = [];
 	const mounted: unknown[] = [];
 	const refocused = Promise.withResolvers<void>();
 	const ctx = {
-		settings: Settings.isolated({ "live.voice": "vale" }),
+		settings: Settings.isolated({
+			"live.provider": "xai-grok",
+			"live.codexVoice": "vale",
+			"live.grokVoice": "leo",
+		}),
 		keybindings: { getKeys: vi.fn(() => ["ctrl+l"]) },
 		session: {},
 		extractAssistantText: vi.fn(() => ""),
+		handleLiveCommand: vi.fn(async () => {}),
+		effectiveHideThinkingBlock: false,
+		viewSession: {},
+		proseOnlyThinking: false,
+		hideToolActivity: false,
+		toolOutputExpanded: false,
 		editor,
 		editorContainer: {
 			clear: vi.fn(),
@@ -60,11 +73,15 @@ afterEach(() => {
 });
 
 describe("LiveCommandController", () => {
-	it("forwards the selected voice across the live-session boundary", async () => {
+	it("forwards a one-session provider override with separate Codex and Grok voices", async () => {
 		const { ctx } = createContext();
-		let receivedVoice: string | undefined;
+		let receivedProvider: string | undefined;
+		let receivedCodexVoice: string | undefined;
+		let receivedGrokVoice: string | undefined;
 		const controller = new LiveCommandController(ctx, options => {
-			receivedVoice = options.voice;
+			receivedProvider = options.provider;
+			receivedCodexVoice = options.codexVoice;
+			receivedGrokVoice = options.grokVoice;
 			const session = new LiveSessionController(options);
 			vi.spyOn(session, "start").mockResolvedValue();
 			vi.spyOn(session, "stop").mockResolvedValue();
@@ -72,8 +89,43 @@ describe("LiveCommandController", () => {
 		});
 
 		try {
-			await controller.handleCommand();
-			expect(receivedVoice).toBe("vale");
+			await controller.handleCommand("openai-codex");
+			expect(receivedProvider).toBe("openai-codex");
+			expect(receivedCodexVoice).toBe("vale");
+			expect(receivedGrokVoice).toBe("leo");
+		} finally {
+			await controller.stop();
+		}
+	});
+
+	it("labels Grok transcript messages with the effective provider and model", async () => {
+		const { ctx } = createContext();
+		const updateContent = vi.spyOn(AssistantMessageComponent.prototype, "updateContent").mockImplementation(() => {});
+		let emitTranscript: ((transcript: LiveTranscript | undefined) => void) | undefined;
+		const controller = new LiveCommandController(ctx, options => {
+			emitTranscript = options.callbacks.onTranscript;
+			const session = new LiveSessionController(options);
+			Object.defineProperties(session, {
+				provider: { get: () => "xai-grok" },
+				model: { get: () => "grok-voice-think-fast-2.0" },
+			});
+			vi.spyOn(session, "start").mockResolvedValue();
+			vi.spyOn(session, "stop").mockResolvedValue();
+			return session;
+		});
+
+		try {
+			await controller.handleCommand("xai-grok");
+			if (!emitTranscript) throw new Error("expected transcript callback");
+			emitTranscript({ role: "assistant", turn: 1, text: "Hello", final: false });
+			expect(updateContent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					api: "openai-completions",
+					provider: "xai",
+					model: "grok-voice-think-fast-2.0",
+				}),
+				{ transient: true },
+			);
 		} finally {
 			await controller.stop();
 		}
@@ -108,5 +160,19 @@ describe("LiveCommandController", () => {
 		// clears; drain microtasks deterministically instead of sleeping.
 		for (let i = 0; controller.active && i < 20; i++) await Promise.resolve();
 		expect(controller.active).toBe(false);
+	});
+
+	it("maps /live provider arguments and rejects unknown providers", async () => {
+		const { ctx } = createContext();
+
+		expect(await executeBuiltinSlashCommand("/live grok", { ctx })).toBe(true);
+		expect(ctx.handleLiveCommand).toHaveBeenLastCalledWith("xai-grok");
+
+		expect(await executeBuiltinSlashCommand("/live codex", { ctx })).toBe(true);
+		expect(ctx.handleLiveCommand).toHaveBeenLastCalledWith("openai-codex");
+
+		expect(await executeBuiltinSlashCommand("/live unknown", { ctx })).toBe(true);
+		expect(ctx.handleLiveCommand).toHaveBeenCalledTimes(2);
+		expect(ctx.showError).toHaveBeenCalledWith("Usage: /live [grok|codex]");
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/live-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/live-command-controller.test.ts
@@ -31,7 +31,7 @@ function createContext(): ContextHarness {
 	const refocused = Promise.withResolvers<void>();
 	const ctx = {
 		settings: Settings.isolated({
-			"live.provider": "xai-grok",
+			"providers.voiceOrder": ["grok", "codex"],
 			"live.codexVoice": "vale",
 			"live.grokVoice": "leo",
 		}),
@@ -73,15 +73,17 @@ afterEach(() => {
 });
 
 describe("LiveCommandController", () => {
-	it("forwards a one-session provider override with separate Codex and Grok voices", async () => {
+	it("forwards provider ranking, override, and provider-owned voice settings", async () => {
 		const { ctx } = createContext();
 		let receivedProvider: string | undefined;
+		let receivedOrder: readonly string[] | undefined;
 		let receivedCodexVoice: string | undefined;
 		let receivedGrokVoice: string | undefined;
 		const controller = new LiveCommandController(ctx, options => {
 			receivedProvider = options.provider;
-			receivedCodexVoice = options.codexVoice;
-			receivedGrokVoice = options.grokVoice;
+			receivedOrder = options.providerOrder;
+			receivedCodexVoice = options.providerConfigs?.codex?.voice;
+			receivedGrokVoice = options.providerConfigs?.grok?.voice;
 			const session = new LiveSessionController(options);
 			vi.spyOn(session, "start").mockResolvedValue();
 			vi.spyOn(session, "stop").mockResolvedValue();
@@ -89,8 +91,9 @@ describe("LiveCommandController", () => {
 		});
 
 		try {
-			await controller.handleCommand("openai-codex");
-			expect(receivedProvider).toBe("openai-codex");
+			await controller.handleCommand("codex");
+			expect(receivedProvider).toBe("codex");
+			expect(receivedOrder).toEqual(["grok", "codex"]);
 			expect(receivedCodexVoice).toBe("vale");
 			expect(receivedGrokVoice).toBe("leo");
 		} finally {
@@ -105,19 +108,26 @@ describe("LiveCommandController", () => {
 		const controller = new LiveCommandController(ctx, options => {
 			emitTranscript = options.callbacks.onTranscript;
 			const session = new LiveSessionController(options);
-			Object.defineProperties(session, {
-				provider: { get: () => "xai-grok" },
-				model: { get: () => "grok-voice-think-fast-2.0" },
-			});
 			vi.spyOn(session, "start").mockResolvedValue();
 			vi.spyOn(session, "stop").mockResolvedValue();
 			return session;
 		});
 
 		try {
-			await controller.handleCommand("xai-grok");
+			await controller.handleCommand("grok");
 			if (!emitTranscript) throw new Error("expected transcript callback");
-			emitTranscript({ role: "assistant", turn: 1, text: "Hello", final: false });
+			emitTranscript({
+				role: "assistant",
+				turn: 1,
+				text: "Hello",
+				final: false,
+				identity: {
+					voiceProvider: "grok",
+					api: "openai-completions",
+					provider: "xai",
+					model: "grok-voice-think-fast-2.0",
+				},
+			});
 			expect(updateContent).toHaveBeenCalledWith(
 				expect.objectContaining({
 					api: "openai-completions",
@@ -166,10 +176,10 @@ describe("LiveCommandController", () => {
 		const { ctx } = createContext();
 
 		expect(await executeBuiltinSlashCommand("/live grok", { ctx })).toBe(true);
-		expect(ctx.handleLiveCommand).toHaveBeenLastCalledWith("xai-grok");
+		expect(ctx.handleLiveCommand).toHaveBeenLastCalledWith("grok");
 
 		expect(await executeBuiltinSlashCommand("/live codex", { ctx })).toBe(true);
-		expect(ctx.handleLiveCommand).toHaveBeenLastCalledWith("openai-codex");
+		expect(ctx.handleLiveCommand).toHaveBeenLastCalledWith("codex");
 
 		expect(await executeBuiltinSlashCommand("/live unknown", { ctx })).toBe(true);
 		expect(ctx.handleLiveCommand).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary

- add xAI Grok Voice support to `/live` using `grok-voice-think-fast-2.0`
- introduce an abstract voice-provider contract with ranked selection through `providers.voiceOrder`
- keep `/live grok` and `/live codex` as one-session overrides with separate provider-owned voice settings
- attach provider-owned API, provider, and model identity to live transcripts
- use xAI server VAD with continuous unscaled PCM streaming

## Testing

- `bun run check`
- focused live tests: 29 passed, 0 failed
- `bun run ci:test:smoke`
- live xAI session connected and reached the listening state