### PR TITLE
fix(catalog): mark Baseten GLM-5.2-Fast as reasoning with high/max effort

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Marked Baseten `zai-org/GLM-5.2-Fast` as a reasoning model with high/max thinking effort, matching the sibling `zai-org/GLM-5.2` ([#7950](https://github.com/can1357/oh-my-pi/pull/7950) by [@jcfrancisco](https://github.com/jcfrancisco)).
+
 ## [17.2.10] - 2026-08-06
 
 ### Changed

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3516,7 +3516,8 @@ export function basetenModelManagerOptions(
 						const isBasetenNativeReasoning =
 							defaults.id === "openai/gpt-oss-120b" ||
 							defaults.id === "deepseek-ai/DeepSeek-V4-Pro" ||
-							defaults.id === "zai-org/GLM-5.2";
+							defaults.id === "zai-org/GLM-5.2" ||
+							defaults.id === "zai-org/GLM-5.2-Fast";
 						const reasoning =
 							isBasetenNativeReasoning &&
 							(features.includes("reasoning") || features.includes("reasoning_effort"));
@@ -3544,7 +3545,10 @@ export function basetenModelManagerOptions(
 
 						// Baseten's reasoning router accepts only the high/max
 						// effort tiers for its GLM-5.2 and gpt-oss routes.
-						const isEffortReasoning = defaults.id === "openai/gpt-oss-120b" || defaults.id === "zai-org/GLM-5.2";
+						const isEffortReasoning =
+							defaults.id === "openai/gpt-oss-120b" ||
+							defaults.id === "zai-org/GLM-5.2" ||
+							defaults.id === "zai-org/GLM-5.2-Fast";
 						const thinking = isEffortReasoning
 							? {
 									mode: "effort" as const,

--- a/packages/catalog/test/baseten-provider.test.ts
+++ b/packages/catalog/test/baseten-provider.test.ts
@@ -108,8 +108,6 @@ describe("Baseten provider discovery", () => {
 			},
 		});
 
-		// GLM-5.2-Fast shares GLM-5.2's weights and reasoning API: Baseten
-		// documents reasoning_effort none|high|max for both routes.
 		const glmFast = models?.find(model => model.id === "zai-org/GLM-5.2-Fast");
 		expect(glmFast).toBeDefined();
 		expect(glmFast).toMatchObject({

--- a/packages/catalog/test/baseten-provider.test.ts
+++ b/packages/catalog/test/baseten-provider.test.ts
@@ -42,6 +42,20 @@ describe("Baseten provider discovery", () => {
 								input_cache_read: "0.000000145",
 							},
 						},
+						{
+							id: "zai-org/GLM-5.2-Fast",
+							object: "model",
+							name: "GLM 5.2 Fast",
+							context_length: 524288,
+							max_completion_tokens: 262144,
+							supported_features: ["tools", "json_mode", "structured_outputs", "reasoning"],
+							input_modalities: ["text"],
+							pricing: {
+								prompt: "0.0000021",
+								completion: "0.0000066",
+								input_cache_read: "0.00000021",
+							},
+						},
 					],
 				}),
 				{ status: 200, headers: { "content-type": "application/json" } },
@@ -91,6 +105,20 @@ describe("Baseten provider discovery", () => {
 				output: 3.48,
 				cacheRead: 0.145,
 				cacheWrite: 0,
+			},
+		});
+
+		// GLM-5.2-Fast shares GLM-5.2's weights and reasoning API: Baseten
+		// documents reasoning_effort none|high|max for both routes.
+		const glmFast = models?.find(model => model.id === "zai-org/GLM-5.2-Fast");
+		expect(glmFast).toBeDefined();
+		expect(glmFast).toMatchObject({
+			provider: "baseten",
+			api: "openai-completions",
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				efforts: ["high", "max"],
 			},
 		});
 	});


### PR DESCRIPTION
## Problem

Noticed that GLM 5.2 Fast from Baseten doesn't let you select a thinking level. In reality, it has the same "high" and "max" thinking levels as the regular GLM 5.2.

## Root cause

The repo has a couple of allowlists that include `zai-org/GLM-5.2` but not `zai-org/GLM-5.2-Fast`.

## Fix

Add `zai-org/GLM-5.2-Fast` to both allowlists!

## Verification

- Live `GET /v1/models` confirms GLM-5.2-Fast reports the `reasoning` feature (same as GLM-5.2), so the existing feature gate passes.