### PR TITLE
feat(catalog,ai): add Chutes provider with dynamic model discovery

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ## [17.2.11] - 2026-08-07
+### Added
+
+- Added Chutes provider with API-key authentication and model discovery via `https://llm.chutes.ai/v1/models`.
 
 ### Breaking Changes
 

--- a/packages/ai/src/registry/chutes.ts
+++ b/packages/ai/src/registry/chutes.ts
@@ -1,0 +1,22 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+export const loginChutes = createApiKeyLogin({
+	providerLabel: "Chutes",
+	authUrl: "https://chutes.ai/app/settings/api-keys",
+	instructions: "Create or copy your API key from the Chutes dashboard",
+	promptMessage: "Paste your Chutes API key",
+	placeholder: "cpk_...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "Chutes",
+		modelsUrl: "https://llm.chutes.ai/v1/models",
+	},
+});
+
+export const chutesProvider = {
+	id: "chutes",
+	name: "Chutes",
+	login: (cb: OAuthLoginCallbacks) => loginChutes(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -9,6 +9,7 @@ import { azureProvider } from "./azure";
 import { basetenProvider } from "./baseten";
 import { bedrockMantleProvider } from "./bedrock-mantle";
 import { cerebrasProvider } from "./cerebras";
+import { chutesProvider } from "./chutes";
 import { cloudflareAiGatewayProvider } from "./cloudflare-ai-gateway";
 import { coreWeaveProvider } from "./coreweave";
 import { cursorProvider } from "./cursor";
@@ -120,6 +121,7 @@ const ALL = [
 	metaProvider,
 	moonshotProvider,
 	cerebrasProvider,
+	chutesProvider,
 	basetenProvider,
 	fireworksProvider,
 	togetherProvider,

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ## [17.2.11] - 2026-08-07
+### Added
+
+- Added Chutes provider catalog entry with dynamic model discovery, custom pricing mapper for Chutes-specific `/v1/models` fields, and default model `deepseek-ai/DeepSeek-V4-Flash-0731-TEE`.
 
 ### Fixed
 

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -17,6 +17,7 @@ import {
 	basetenModelManagerOptions,
 	bedrockMantleModelManagerOptions,
 	cerebrasModelManagerOptions,
+	chutesModelManagerOptions,
 	cloudflareAiGatewayModelManagerOptions,
 	coreWeaveModelManagerOptions,
 	deepseekModelManagerOptions,
@@ -135,6 +136,13 @@ export const CATALOG_PROVIDERS = [
 		envVars: ["CEREBRAS_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => cerebrasModelManagerOptions(config),
 		catalogDiscovery: { label: "Cerebras" },
+	},
+	{
+		id: "chutes",
+		defaultModel: "deepseek-ai/DeepSeek-V4-Flash-0731-TEE",
+		envVars: ["CHUTES_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => chutesModelManagerOptions(config),
+		catalogDiscovery: { label: "Chutes" },
 	},
 	{
 		id: "cloudflare-ai-gateway",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1060,6 +1060,69 @@ export function cerebrasModelManagerOptions(
 }
 
 // ---------------------------------------------------------------------------
+// 3a. Chutes
+// ---------------------------------------------------------------------------
+
+export interface ChutesModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+function mapChutesModel(
+	entry: OpenAICompatibleModelRecord,
+	defaults: ModelSpec<"openai-completions">,
+): ModelSpec<"openai-completions"> {
+	const price = isRecord(entry.pricing) ? entry.pricing : {};
+	const inputCost = toPositiveNumber(price.prompt, defaults.cost.input);
+	const output = toPositiveNumber(price.completion, defaults.cost.output);
+	const cacheRead = toPositiveNumber(price.input_cache_read, defaults.cost.cacheRead);
+	const contextWindow = toPositiveNumber(entry.context_length, defaults.contextWindow ?? null);
+	const maxTokens = toPositiveNumber(entry.max_output_length, defaults.maxTokens ?? null);
+
+	const supportedFeatures = Array.isArray(entry.supported_features)
+		? entry.supported_features.filter((f): f is string => typeof f === "string")
+		: [];
+	const reasoning = supportedFeatures.includes("reasoning");
+
+	const inputModalities = Array.isArray(entry.input_modalities)
+		? entry.input_modalities.filter((m): m is string => typeof m === "string")
+		: [];
+	const inputCapabilities: ("text" | "image")[] = inputModalities.includes("image") ? ["text", "image"] : ["text"];
+
+	return {
+		...defaults,
+		name: typeof entry.name === "string" && entry.name.length > 0 ? entry.name : defaults.id,
+		reasoning,
+		input: inputCapabilities,
+		cost: { input: inputCost, output, cacheRead, cacheWrite: defaults.cost.cacheWrite },
+		contextWindow,
+		maxTokens,
+	};
+}
+
+export function chutesModelManagerOptions(
+	config?: ChutesModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? "https://llm.chutes.ai/v1";
+	return {
+		providerId: "chutes",
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "chutes",
+					baseUrl,
+					apiKey,
+					mapModel: (entry, defaults) => mapChutesModel(entry, defaults),
+					fetch: config?.fetch,
+				}),
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
 // 4. Hugging Face
 // ---------------------------------------------------------------------------
 

--- a/packages/catalog/test/chutes-provider.test.ts
+++ b/packages/catalog/test/chutes-provider.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { chutesModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
+
+describe("Chutes provider discovery", () => {
+	const makeFetchMock = (models: unknown[]): FetchImpl => {
+		return async () =>
+			new Response(JSON.stringify({ data: models }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+	};
+
+	test("maps pricing, context, reasoning, and modalities from Chutes /v1/models", async () => {
+		const fetchMock = makeFetchMock([
+			{
+				id: "moonshotai/Kimi-K2.6-TEE",
+				name: "Kimi K2.6 TEE",
+				pricing: { prompt: 0.58, completion: 3.4, input_cache_read: 0.058 },
+				context_length: 262144,
+				max_output_length: 65535,
+				supported_features: ["reasoning", "tools", "json_mode"],
+				input_modalities: ["text", "image"],
+			},
+			{
+				id: "Qwen/Qwen3-32B-TEE",
+				pricing: { prompt: 0.104, completion: 0.416, input_cache_read: 0.0104 },
+				context_length: 40960,
+				max_output_length: 40960,
+				supported_features: ["tools"],
+				input_modalities: ["text"],
+			},
+		]);
+
+		const options = chutesModelManagerOptions({ apiKey: "test-key", fetch: fetchMock });
+		const models = await options.fetchDynamicModels?.();
+
+		const kimi = models?.find(m => m.id === "moonshotai/Kimi-K2.6-TEE");
+		expect(kimi).toMatchObject({
+			provider: "chutes",
+			name: "Kimi K2.6 TEE",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0.58, output: 3.4, cacheRead: 0.058 },
+			contextWindow: 262144,
+			maxTokens: 65535,
+		});
+
+		const qwen = models?.find(m => m.id === "Qwen/Qwen3-32B-TEE");
+		expect(qwen).toMatchObject({
+			provider: "chutes",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0.104, output: 0.416, cacheRead: 0.0104 },
+			contextWindow: 40960,
+			maxTokens: 40960,
+		});
+	});
+
+	test("falls back to defaults when Chutes fields are absent", async () => {
+		const fetchMock = makeFetchMock([
+			{
+				id: "gemma-4-31B-turbo-TEE",
+			},
+		]);
+
+		const options = chutesModelManagerOptions({ apiKey: "test-key", fetch: fetchMock });
+		const models = await options.fetchDynamicModels?.();
+
+		expect(models?.find(m => m.id === "gemma-4-31B-turbo-TEE")).toMatchObject({
+			provider: "chutes",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0 },
+			contextWindow: null,
+			maxTokens: null,
+		});
+	});
+});


### PR DESCRIPTION
> After i burned some tokens to create a custom models.yaml for Chutes, I realized this would possibly help out others: I burned more tokens to add Chutes support to oh-my-pi. It works on my machine, code seems straight forward to me.
<img width="1633" height="676" alt="grafik" src="https://github.com/user-attachments/assets/4f5a7f28-fe0b-4be3-a62b-d41bb7e2029d" />

## What

- Add `chutes` provider registry entry with API-key paste login (`/login chutes`).
- Add catalog descriptor with dynamic model discovery via `https://llm.chutes.ai/v1/models`.
- Add custom `mapChutesModel` mapper for Chutes' non-standard `/v1/models` fields:
  - `pricing.prompt` / `pricing.completion` / `pricing.input_cache_read` → cost
  - `context_length` → contextWindow
  - `max_output_length` → maxTokens
  - `supported_features` → reasoning flag
  - `input_modalities` → image/text input capabilities
- Default model: `deepseek-ai/DeepSeek-V4-Flash-0731-TEE` (1M context, $0.14/$0.28).
- No `models.json` change — runtime discovery populates `models.db`; models.json will be seeded by a future `bun run gen:models` run (same pattern as GMI Cloud).

## Why

Chutes is an OpenAI-compatible inference host with 13+ models. Previously users had to hand-maintain a static `models.yaml` with costs and context lengths, which goes stale. Native
support enables:
- `/login chutes` with key validation against live `/v1/models`
- `/model` → refresh pulls current pricing + capabilities from Chutes API
- No manual cost/context updates when the provider changes prices or adds models

## Testing

- Removed `~/.omp/agent/models.yaml` and ran a custom-built binary with this change.
- `/login chutes` → prompted for API key → validated against `https://llm.chutes.ai/v1/models`.
- Selected a discovered Chutes model and successfully sent this prompt through it.

---

- [x] `bun check` passes (tsgo across all 12 packages — Rust check skipped locally as no Rust code was touched)
- [x] Tested locally
- [x] CHANGELOG updated (packages/ai and packages/catalog `[Unreleased]` Added entries)
