### PR TITLE
fix(tui): show edit previews before approval

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `always-ask` approval prompts opening before large edit previews finish rendering, preventing blind approvals ([#7957](https://github.com/can1357/oh-my-pi/issues/7957)).
+
 ## [17.2.11] - 2026-08-07
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -334,6 +334,7 @@ const noOpUIContext: ExtensionUIContext = {
 
 export class ExtensionRunner {
 	#uiContext: ExtensionUIContext;
+	#toolApprovalPreviewWaiter?: (toolCallId: string) => Promise<void>;
 	#errorListeners: Set<ExtensionErrorListener> = new Set();
 	#getModel: () => Model | undefined = () => undefined;
 	#isIdleFn: () => boolean = () => true;
@@ -649,6 +650,18 @@ export class ExtensionRunner {
 	async emitSessionStop(event: Omit<SessionStopEvent, "type">): Promise<SessionStopEventResult | undefined> {
 		if (event.signal.aborted) return undefined;
 		return await this.emit({ type: "session_stop", ...event });
+	}
+	/** Registers the interactive transcript gate that must settle before a tool approval is presented. */
+	setToolApprovalPreviewWaiter(waiter: (toolCallId: string) => Promise<void>): () => void {
+		this.#toolApprovalPreviewWaiter = waiter;
+		return () => {
+			if (this.#toolApprovalPreviewWaiter === waiter) this.#toolApprovalPreviewWaiter = undefined;
+		};
+	}
+
+	/** Waits until the interactive transcript can show the tool call being approved. */
+	async waitForToolApprovalPreview(toolCallId: string): Promise<void> {
+		await this.#toolApprovalPreviewWaiter?.(toolCallId);
 	}
 
 	getUIContext(): ExtensionUIContext {

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -9,7 +9,7 @@ import type {
 	ToolLoadMode,
 } from "@oh-my-pi/pi-agent-core";
 import type { ComputerSafetyCheck, ImageContent, Static, TextContent, TSchema } from "@oh-my-pi/pi-ai";
-import { sanitizeText } from "@oh-my-pi/pi-utils";
+import { sanitizeText, untilAborted } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../../config/settings";
 import type { Theme } from "../../modes/theme/theme";
 import { type ApprovalMode, formatApprovalPrompt, resolveApproval, truncateForPrompt } from "../../tools/approval";
@@ -263,6 +263,11 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		};
 
 		if (approvalCheck.required) {
+			const scheduledCall = context?.toolCall?.toolCalls[context.toolCall.index];
+			if (scheduledCall?.id === toolCallId && scheduledCall.name === this.tool.name) {
+				await untilAborted(signal, () => this.runner.waitForToolApprovalPreview(toolCallId));
+			}
+
 			const hasApprovalHandlers =
 				this.runner.hasHandlers("tool_approval_requested") || this.runner.hasHandlers("tool_approval_resolved");
 			const sessionId = context?.sessionManager?.getSessionId() ?? "";

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -72,6 +72,12 @@ function exposesRawPartialJson(toolName: string, rawInput: boolean, tool: unknow
 type AgentSessionEventHandlers = {
 	[E in AgentSessionEventKind]: (event: Extract<AgentSessionEvent, { type: E }>) => Promise<void>;
 };
+interface ApprovalPreviewGate {
+	promise: Promise<void>;
+	resolve(): void;
+	reject(reason?: unknown): void;
+	started: boolean;
+}
 
 export class EventController {
 	#lastReadGroup: ReadToolGroupComponent | undefined = undefined;
@@ -88,6 +94,8 @@ export class EventController {
 	/** Tool calls whose approval prompt drove the title into `attention`; cleared
 	 *  at their tool_execution_end so the title returns to `working`. */
 	#approvalAttentionToolCallIds = new Set<string>();
+	#approvalPreviewGates = new Map<string, ApprovalPreviewGate>();
+	#detachToolApprovalPreviewWaiter: (() => void) | undefined;
 	#readToolCallArgs = new Map<string, Record<string, unknown>>();
 	#readToolCallAssistantComponents = new Map<string, AssistantMessageComponent>();
 	#toolTimelineComponents = new Map<string, Component>();
@@ -197,6 +205,9 @@ export class EventController {
 		// vocalizer falls back to mechanical cleanup when unset. Tolerates
 		// partial contexts (tests, minimal embeddings) by wiring null.
 		const session = ctx.session;
+		this.#detachToolApprovalPreviewWaiter = session?.extensionRunner?.setToolApprovalPreviewWaiter(toolCallId =>
+			this.#waitForToolApprovalPreview(toolCallId),
+		);
 		vocalizer.setEnhancer(
 			session?.modelRegistry && session.agent && session.settings
 				? new SpeechEnhancer({
@@ -273,6 +284,9 @@ export class EventController {
 	}
 
 	dispose(): void {
+		this.#detachToolApprovalPreviewWaiter?.();
+		this.#detachToolApprovalPreviewWaiter = undefined;
+		this.#clearApprovalPreviewGates();
 		if (this.#messageUpdateTimer) {
 			clearTimeout(this.#messageUpdateTimer);
 			this.#messageUpdateTimer = undefined;
@@ -293,6 +307,36 @@ export class EventController {
 	#resetReadGroup(): void {
 		this.#lastReadGroup?.finalize();
 		this.#lastReadGroup = undefined;
+	}
+	#approvalPreviewGate(toolCallId: string): ApprovalPreviewGate {
+		let gate = this.#approvalPreviewGates.get(toolCallId);
+		if (!gate) {
+			const deferred = Promise.withResolvers<void>();
+			gate = { ...deferred, started: false };
+			this.#approvalPreviewGates.set(toolCallId, gate);
+		}
+		return gate;
+	}
+
+	async #waitForToolApprovalPreview(toolCallId: string): Promise<void> {
+		await this.#approvalPreviewGate(toolCallId).promise;
+	}
+
+	#startToolApprovalPreview(toolCallId: string): void {
+		const gate = this.#approvalPreviewGate(toolCallId);
+		if (gate.started) return;
+		gate.started = true;
+		const component = this.ctx.pendingTools.get(toolCallId);
+		const ready = component instanceof ToolExecutionComponent ? component.whenPreviewSettled() : Promise.resolve();
+		void ready.then(() => {
+			this.ctx.ui.requestRender();
+			gate.resolve();
+		}, gate.reject);
+	}
+
+	#clearApprovalPreviewGates(): void {
+		for (const gate of this.#approvalPreviewGates.values()) gate.resolve();
+		this.#approvalPreviewGates.clear();
 	}
 
 	#getReadGroup(): ReadToolGroupComponent {
@@ -687,6 +731,7 @@ export class EventController {
 	}
 
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
+		this.#clearApprovalPreviewGates();
 		this.#toolTimelineComponents.clear();
 		this.#streamedToolCallIdByIndex.clear();
 		this.#retractedToolCallIds.clear();
@@ -1313,6 +1358,7 @@ export class EventController {
 					this.ctx.pendingTools.set(event.toolCallId, group);
 					this.#toolTimelineComponents.set(event.toolCallId, group);
 				}
+				this.#startToolApprovalPreview(event.toolCallId);
 				this.ctx.ui.requestRender();
 				return;
 			}
@@ -1336,6 +1382,7 @@ export class EventController {
 				this.ctx.sessionManager.getCwd(),
 				event.toolCallId,
 			);
+			component.setArgsComplete(event.toolCallId);
 			component.setExpanded(this.ctx.toolOutputExpanded);
 			component.setToolActivityVisible(!this.ctx.hideToolActivity);
 			this.ctx.chatContainer.addChild(component);
@@ -1363,6 +1410,7 @@ export class EventController {
 				this.ctx.ui.requestRender();
 			}
 		}
+		this.#startToolApprovalPreview(event.toolCallId);
 	}
 
 	/**

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1789,6 +1789,56 @@ describe("ExtensionRunner", () => {
 			delete globalState.__approvalEvents;
 		});
 
+		it("does not present approval before the tool preview is ready", async () => {
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const preview = Promise.withResolvers<void>();
+			const order: string[] = [];
+			runner.setToolApprovalPreviewWaiter(async toolCallId => {
+				order.push(`preview_wait:${toolCallId}`);
+				await preview.promise;
+				order.push("preview_ready");
+			});
+			initializeRunner(
+				runner,
+				vi.fn(async () => {
+					order.push("ui_select");
+					return "Approve";
+				}),
+			);
+
+			const wrapper = new ExtensionToolWrapper(approvalTool, runner);
+			const execution = (wrapper as ExtensionToolWrapper<any>).execute("call-preview", {}, undefined, undefined, {
+				sessionManager,
+				modelRegistry,
+				model: undefined,
+				isIdle: () => true,
+				hasQueuedMessages: () => false,
+				abort: () => {},
+				settings: {
+					get: (key: string) => (key === "tools.approvalMode" ? "always-ask" : {}),
+				} as never,
+				toolCall: {
+					batchId: "batch-preview",
+					index: 0,
+					total: 1,
+					toolCalls: [{ id: "call-preview", name: "dangerous_tool" }],
+				},
+			});
+			await Promise.resolve();
+			expect(order).toEqual(["preview_wait:call-preview"]);
+
+			preview.resolve();
+			await execution;
+			expect(order).toEqual(["preview_wait:call-preview", "preview_ready", "ui_select"]);
+		});
+
 		it("emits resolved false when approval is denied", async () => {
 			const events: Array<{ type: string; approved?: boolean; reason?: string }> = [];
 			const extCode = `

--- a/packages/coding-agent/test/modes/controllers/event-controller-args-reveal.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-args-reveal.test.ts
@@ -6,9 +6,11 @@
  * how assistant text snaps at message_end.
  */
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { kStreamingPartialJson } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { EDIT_MODE_STRATEGIES } from "@oh-my-pi/pi-coding-agent/edit";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
 import { STREAMING_REVEAL_FRAME_MS } from "@oh-my-pi/pi-coding-agent/modes/controllers/streaming-reveal";
@@ -40,8 +42,17 @@ function makeStreamingMessage(content: AssistantMessage["content"]): AssistantMe
 	};
 }
 
-function createFixture(streamingMessage: AssistantMessage) {
+function createFixture(streamingMessage: AssistantMessage, tool?: AgentTool) {
 	const pendingTools = new Map<string, ToolExecutionComponent>();
+	let approvalWaiter: ((toolCallId: string) => Promise<void>) | undefined;
+	const extensionRunner = {
+		setToolApprovalPreviewWaiter(waiter: (toolCallId: string) => Promise<void>) {
+			approvalWaiter = waiter;
+			return () => {
+				if (approvalWaiter === waiter) approvalWaiter = undefined;
+			};
+		},
+	};
 	const ctx = {
 		isInitialized: true,
 		init: vi.fn(async () => {}),
@@ -56,12 +67,16 @@ function createFixture(streamingMessage: AssistantMessage) {
 		noteDisplayableThinkingContent: vi.fn(() => false),
 		chatContainer: { addChild: vi.fn() },
 		toolOutputExpanded: false,
-		session: { getToolByName: () => undefined, hasBuiltInTool: () => true },
-		viewSession: { getToolByName: () => undefined, hasBuiltInTool: () => true },
+		session: { getToolByName: () => tool, hasBuiltInTool: () => true, extensionRunner },
+		viewSession: { getToolByName: () => tool, hasBuiltInTool: () => true },
 		sessionManager: { getCwd: () => process.cwd() },
 	} as unknown as InteractiveModeContext;
 
-	return { controller: new EventController(ctx), pendingTools };
+	return {
+		controller: new EventController(ctx),
+		pendingTools,
+		getApprovalWaiter: () => approvalWaiter,
+	};
 }
 
 async function dispatch(controller: EventController, message: AssistantMessage) {
@@ -214,5 +229,47 @@ describe("EventController paces streamed tool args", () => {
 		// back to a streaming prefix.
 		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS * 5);
 		expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("/tmp/exec.ts");
+	});
+	it("holds approval until the final edit preview is ready", async () => {
+		await Settings.init({ inMemory: true, cwd: process.cwd() });
+		const compute = Promise.withResolvers<void>();
+		vi.spyOn(EDIT_MODE_STRATEGIES.replace, "computeDiffPreview").mockImplementation(async () => {
+			await compute.promise;
+			return [
+				{
+					path: "/tmp/approval.ts",
+					diff: "@@ -1 +1 @@\n-old\n+ISSUE_7957_PROPOSED_EDIT",
+					firstChangedLine: 1,
+				},
+			];
+		});
+		const args = {
+			path: "/tmp/approval.ts",
+			old_string: "old",
+			new_string: "ISSUE_7957_PROPOSED_EDIT",
+		};
+		const streaming = makeStreamingMessage([{ type: "toolCall", id: "tc-approval", name: "edit", arguments: args }]);
+		const tool = { mode: "replace" } as unknown as AgentTool;
+		const { controller, pendingTools, getApprovalWaiter } = createFixture(streaming, tool);
+		await dispatch(controller, streaming);
+
+		const waiter = getApprovalWaiter();
+		if (!waiter) throw new Error("expected the TUI approval-preview waiter");
+		let approvalReady = false;
+		const waiting = waiter("tc-approval").then(() => {
+			approvalReady = true;
+		});
+		await dispatchToolStart(controller, {
+			toolCallId: "tc-approval",
+			toolName: "edit",
+			args,
+		});
+		await Promise.resolve();
+		expect(approvalReady).toBe(false);
+
+		compute.resolve();
+		await waiting;
+		const rendered = pendingTools.get("tc-approval")?.render(100).join("\n") ?? "";
+		expect(Bun.stripANSI(rendered)).toContain("ISSUE_7957_PROPOSED_EDIT");
 	});
 });


### PR DESCRIPTION
## Repro

Under `tools.approvalMode: always-ask`, construct a 50,000-line `edit` and render its tool card immediately, as the approval wrapper can do. `bun /tmp/repro-7957.ts` reported `beforeApprovalShowsEdit: false` and only reported `afterPreviewShowsEdit: true` after the asynchronous diff settled (4.85s).

## Cause

`ExtensionToolWrapper.execute()` opened the approval selector as soon as execution began, while `EventController.#handleToolExecutionStart()` only scheduled `ToolExecutionComponent`'s asynchronous final diff. Nothing connected the approval lifecycle to `ToolExecutionComponent.whenPreviewSettled()`, so large diffs could remain blank until the user answered.

## Fix

- Register an interactive approval-preview gate between `EventController` and `ExtensionRunner`.
- Finalize authoritative edit arguments at `tool_execution_start`, then release the approval only after the resulting preview settles.
- Limit the wait to model-scheduled calls so nested/direct tool dispatches cannot deadlock.
- Cover both TUI preview readiness and approval-selector ordering.

## Verification

- `bun test packages/coding-agent/test/modes/controllers/event-controller-args-reveal.test.ts packages/coding-agent/test/extensions-runner.test.ts` — 77 passed, 0 failed.
- `bun run check` in `packages/coding-agent` — passed.
- Large-edit smoke probe — `approvalShownBeforePreview: false`, `approvalShownAfterPreview: true`, and `approvalCardShowsEdit: true`.
- Skipped the repository-wide pre-publish gate: `bun run fix` fails identically on clean `origin/main` because this workstation lacks `cmake` while `audiopus_sys` builds bundled Opus; TypeScript formatting completed successfully before that unrelated Rust failure.

Fixes #7957