### PR TITLE
WIP: fix(coding-agent): bound advisor review spend

### DIFF
--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -316,28 +316,35 @@ The advisor's live context is in-memory and append-only; it is retained while th
 
 ### Per-review safety limits
 
-One advisor update can make several provider requests: the first request may
-call an investigative tool, and the advisor's private agent loop continues
-until the model stops calling tools. OMP bounds each update independently:
+One advisor update is one logical review (`agent.prompt(batch)`). It can make
+several provider requests while the advisor investigates, and each advisor
+runtime has its own counters:
 
-- `advisor.maxRequestsPerReview` defaults to `32`. This is a hard request cap:
-  the gate runs before every provider request, so the refused request is not
-  sent or billed. Set it to `0` to disable the cap.
-- `advisor.maxCostPerReview` defaults to `10` USD. This sums finalized advisor
-  responses in the current update and refuses the next request once completed
-  spend reaches the ceiling. It is exact for completed requests but may
-  overshoot by the cost of one in-flight request; it is a backstop, not a
-  dollar-precise cutoff. Set it to `0` to disable the ceiling.
+- `advisor.maxRequestsPerReview` defaults to `0` (disabled). When set to a
+  positive value, the gate runs before each provider request, so the refused
+  request is not sent or billed.
+- `advisor.maxCostPerReview` defaults to `0` (disabled). When set, it sums
+  finalized advisor responses in the current review and refuses the next
+  request once completed spend reaches the ceiling. It may overshoot by one
+  in-flight request, so it is a backstop rather than a dollar-precise cutoff.
+- `advisor.maxToolCallsPerTurn` defaults to `10`. It limits investigative tool
+  executions in one provider turn; further investigative calls in that response
+  are blocked, while the next provider turn gets a fresh allowance.
+  `advise` remains available after the investigative allowance is exhausted.
+  The same gate covers ordinary advisor tools and Cursor-resolved direct
+  resource/delete handlers. Set it to `0` to disable the per-turn gate.
 - `advisor.maxIdenticalToolCalls` defaults to `2`. The first identical
   `(tool name, arguments)` call runs; its first repeat is refused with guidance
   to use the existing result and finish the review. Object-key order does not
   change call identity. Set it to `0` to disable the repeat guard.
 
-Limits reset for every new advisor update, remain in force when that update is
-retried after a provider failure, and apply independently to every advisor
-runtime. Setting changes are read by already-running advisors before each gate.
-A limit ending a review does not mark the advisor unavailable, invoke provider
-recovery, or affect the primary agent's work.
+The request, cost, and repeat limits reset for every new logical review, remain
+in force when that review is retried after a provider failure, and apply
+independently to every advisor runtime. The per-turn tool allowance resets at
+each provider turn. Setting changes are read by already-running advisors
+before each gate. A request or cost ceiling ending a review does not mark the
+advisor unavailable, invoke provider recovery, or affect the primary agent's
+work.
 
 ## Transcript persistence and observability
 

--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -9,6 +9,7 @@ An advisor does not approve actions or mutate primary session state directly. It
 - [`src/advisor/runtime.ts`](../packages/coding-agent/src/advisor/runtime.ts)
 - [`src/advisor/advise-tool.ts`](../packages/coding-agent/src/advisor/advise-tool.ts)
 - [`src/advisor/emission-guard.ts`](../packages/coding-agent/src/advisor/emission-guard.ts)
+- [`src/advisor/review-budget.ts`](../packages/coding-agent/src/advisor/review-budget.ts)
 - [`src/advisor/watchdog.ts`](../packages/coding-agent/src/advisor/watchdog.ts)
 - [`src/advisor/config.ts`](../packages/coding-agent/src/advisor/config.ts)
 - [`src/advisor/transcript-recorder.ts`](../packages/coding-agent/src/advisor/transcript-recorder.ts)
@@ -312,6 +313,31 @@ The advisor has its own append-only context. Before each advisor prompt, `AgentS
 3. if compaction has no candidates or still cannot fit, re-prime from the current bounded primary transcript
 
 The advisor's live context is in-memory and append-only; it is retained while the session runs so `/advisor dump` can inspect it, and is independently promoted/compacted/re-primed (above). It is not a replacement for the primary persisted transcript.
+
+### Per-review safety limits
+
+One advisor update can make several provider requests: the first request may
+call an investigative tool, and the advisor's private agent loop continues
+until the model stops calling tools. OMP bounds each update independently:
+
+- `advisor.maxRequestsPerReview` defaults to `32`. This is a hard request cap:
+  the gate runs before every provider request, so the refused request is not
+  sent or billed. Set it to `0` to disable the cap.
+- `advisor.maxCostPerReview` defaults to `10` USD. This sums finalized advisor
+  responses in the current update and refuses the next request once completed
+  spend reaches the ceiling. It is exact for completed requests but may
+  overshoot by the cost of one in-flight request; it is a backstop, not a
+  dollar-precise cutoff. Set it to `0` to disable the ceiling.
+- `advisor.maxIdenticalToolCalls` defaults to `2`. The first identical
+  `(tool name, arguments)` call runs; its first repeat is refused with guidance
+  to use the existing result and finish the review. Object-key order does not
+  change call identity. Set it to `0` to disable the repeat guard.
+
+Limits reset for every new advisor update, remain in force when that update is
+retried after a provider failure, and apply independently to every advisor
+runtime. Setting changes are read by already-running advisors before each gate.
+A limit ending a review does not mark the advisor unavailable, invoke provider
+recovery, or affect the primary agent's work.
 
 ## Transcript persistence and observability
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added configurable per-review advisor request, completed-cost, and identical-tool-call safety limits.
+
+### Fixed
+
+- Fixed advisor reviews being able to issue unbounded provider requests or repeatedly execute the same tool call, causing runaway context growth and cost.
+
 ## [17.2.11] - 2026-08-07
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Added
 
-- Added configurable per-review advisor request, completed-cost, and identical-tool-call safety limits.
+- Added configurable per-review advisor request, completed-cost, repeated-tool-call, and per-provider-turn investigative-tool safety limits. Request and cost ceilings are disabled by default; the per-turn tool cap defaults to ten.
 
 ### Fixed
 
-- Fixed advisor reviews being able to issue unbounded provider requests or repeatedly execute the same tool call, causing runaway context growth and cost.
+- Fixed advisor reviews being able to issue unbounded provider requests or repeatedly execute the same tool call, causing runaway context growth and cost; investigative tool execution is now bounded per provider turn without limiting later turns by default, including Cursor-resolved direct resource/delete handlers.
 
 ## [17.2.11] - 2026-08-07
 

--- a/packages/coding-agent/src/advisor/index.ts
+++ b/packages/coding-agent/src/advisor/index.ts
@@ -1,6 +1,7 @@
 export * from "./advise-tool";
 export * from "./config";
 export * from "./emission-guard";
+export * from "./review-budget";
 export * from "./runtime";
 export * from "./transcript-recorder";
 export * from "./watchdog";

--- a/packages/coding-agent/src/advisor/review-budget.ts
+++ b/packages/coding-agent/src/advisor/review-budget.ts
@@ -1,0 +1,181 @@
+import type { AgentPreModelCallStop, AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+
+/**
+ * Per-review spend guard for one advisor.
+ *
+ * A "review" is one `agent.prompt(batch)` cycle: the advisor reads a transcript
+ * delta, investigates with its tools, and (optionally) calls `advise`. That
+ * cycle is an ordinary agent loop with no upper bound — the loop continues
+ * while the model keeps emitting tool calls — so a single review can issue an
+ * unbounded number of provider requests, each one re-sending the advisor's
+ * whole append-only context. Observed worst case: 95 requests for one review.
+ *
+ * Two independent limiters, both scoped to the current review:
+ *
+ * - **Request cap** — a counter this class owns, so it is exact. Enforced from
+ *   `beforeModelCall`, which ends the loop *before* the request is prepared;
+ *   the loop records a zero-usage `stopReason: "aborted"` message, so nothing
+ *   is billed and the advisor's failure ladder sees a normal completed turn.
+ * - **Cost ceiling** — compares the summed cost of requests that have already
+ *   **completed** in this review, fed by {@link recordCompletedCost} from the
+ *   advisor's live `message_end` subscription. It is exact for completed work
+ *   and lags by at most the in-flight request: the ceiling refuses to dispatch
+ *   the *next* request, it cannot cut off the current one. It is a backstop for
+ *   very large contexts, not a dollar-precise cutoff.
+ *
+ * Separately, {@link guardTool} short-circuits a tool call whose `(name, args)`
+ * pair already ran in this review. A degenerate reviewer can otherwise spend
+ * dozens of requests re-reading the same range and re-globbing the same
+ * pattern, and every repeated result stays in the append-only context and
+ * inflates every later request in the session.
+ *
+ * Each limit is disabled by a non-positive value.
+ */
+export interface AdvisorReviewBudgetLimits {
+	/** Max provider requests per review; `0` disables the cap. */
+	maxRequests: number;
+	/** Max USD of completed requests per review; `0` disables the ceiling. */
+	maxCostUsd: number;
+	/** Occurrence at which an identical `(tool, args)` call is refused; `0` disables the guard. */
+	maxIdenticalToolCalls: number;
+}
+
+export interface AdvisorReviewBudgetStop {
+	kind: "requests" | "cost";
+	reason: string;
+}
+
+/** Stable key for a tool call: object key order must not create a new identity. */
+function canonicalize(value: unknown): string {
+	if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+	if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+	const entries = Object.entries(value as Record<string, unknown>)
+		.filter(([, v]) => v !== undefined)
+		.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+	return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(",")}}`;
+}
+
+export class AdvisorReviewBudget {
+	readonly #resolveLimits: () => AdvisorReviewBudgetLimits;
+	readonly #onStop: ((stop: AdvisorReviewBudgetStop) => void) | undefined;
+	#reviewId: number | undefined;
+	#requests = 0;
+	#costUsd = 0;
+	#toolCalls = new Map<string, number>();
+	#stop: AdvisorReviewBudgetStop | undefined;
+
+	constructor(
+		limits: AdvisorReviewBudgetLimits | (() => AdvisorReviewBudgetLimits),
+		onStop?: (stop: AdvisorReviewBudgetStop) => void,
+	) {
+		this.#resolveLimits = typeof limits === "function" ? limits : () => limits;
+		this.#onStop = onStop;
+	}
+
+	/**
+	 * Reset counters for a new logical review. Retrying the same review id keeps
+	 * the original budget, so provider recovery cannot multiply the cap.
+	 */
+	beginReview(reviewId?: number): void {
+		if (reviewId !== undefined && reviewId === this.#reviewId) return;
+		this.#reviewId = reviewId;
+		this.#requests = 0;
+		this.#costUsd = 0;
+		this.#toolCalls.clear();
+		this.#stop = undefined;
+	}
+
+	/** Fold one finished advisor request's cost into the current review. */
+	recordCompletedCost(usd: number): void {
+		if (Number.isFinite(usd) && usd > 0) this.#costUsd += usd;
+	}
+
+	/** Why the current review was cut short, or `undefined` if it ran free. */
+	get stop(): AdvisorReviewBudgetStop | undefined {
+		return this.#stop;
+	}
+
+	/** Requests dispatched so far in the current review. */
+	get requests(): number {
+		return this.#requests;
+	}
+
+	/** Cost of requests that have completed in the current review. */
+	get costUsd(): number {
+		return this.#costUsd;
+	}
+
+	/**
+	 * Pre-model-call gate. Returns a stop verdict to refuse the next provider
+	 * request, or `undefined` to let it through (counting it).
+	 */
+	beforeModelCall(): AgentPreModelCallStop | undefined {
+		const { maxRequests, maxCostUsd } = this.#resolveLimits();
+		if (maxRequests > 0 && this.#requests >= maxRequests) {
+			return this.#halt("requests", `advisor review reached ${maxRequests} provider requests`);
+		}
+		if (maxCostUsd > 0 && this.#costUsd >= maxCostUsd) {
+			return this.#halt(
+				"cost",
+				`advisor review spent $${this.#costUsd.toFixed(2)} of its $${maxCostUsd.toFixed(2)} ceiling`,
+			);
+		}
+		this.#requests++;
+		return undefined;
+	}
+
+	/**
+	 * Record one tool call and return a refusal message when this exact
+	 * `(name, args)` pair has already run in this review, or `undefined` to let
+	 * it execute.
+	 */
+	noteToolCall(name: string, args: unknown): string | undefined {
+		const max = this.#resolveLimits().maxIdenticalToolCalls;
+		if (max <= 0) return undefined;
+		const key = `${name}\u001f${canonicalize(args)}`;
+		const seen = (this.#toolCalls.get(key) ?? 0) + 1;
+		this.#toolCalls.set(key, seen);
+		if (seen < max) return undefined;
+		return `Refused: this exact \`${name}\` call already ran in this review (attempt ${seen}). The earlier result stands unchanged — re-running it cannot return anything new. Act on what you already have: call \`advise\`, or end the review without advice.`;
+	}
+
+	/**
+	 * Wrap a tool so repeated identical calls short-circuit instead of
+	 * re-executing. The proxy preserves the original receiver: real tools use
+	 * ES `#private` fields, which throw when an extracted method is called with
+	 * a clone as `this`.
+	 */
+	guardTool<T extends AgentTool<any>>(tool: T, identity?: unknown): T {
+		return new Proxy(tool, {
+			get: (target, prop) => {
+				if (prop !== "execute") return target[prop as keyof T];
+				return (
+					toolCallId: string,
+					params: unknown,
+					signal: AbortSignal | undefined,
+					onUpdate: never,
+					context: never,
+				) => {
+					const refusal = this.noteToolCall(target.name, identity === undefined ? params : { identity, params });
+					if (refusal !== undefined) {
+						// Not `isError`: an error result feeds the advisor failure
+						// ladder, and a refused repeat is a healthy outcome.
+						return Promise.resolve({
+							content: [{ type: "text", text: refusal }],
+							useless: true,
+						} satisfies AgentToolResult);
+					}
+					return target.execute(toolCallId, params as never, signal, onUpdate, context);
+				};
+			},
+		}) as T;
+	}
+
+	#halt(kind: AdvisorReviewBudgetStop["kind"], reason: string): AgentPreModelCallStop {
+		if (!this.#stop) {
+			this.#stop = { kind, reason };
+			this.#onStop?.(this.#stop);
+		}
+		return { stop: true, reason };
+	}
+}

--- a/packages/coding-agent/src/advisor/review-budget.ts
+++ b/packages/coding-agent/src/advisor/review-budget.ts
@@ -1,4 +1,4 @@
-import type { AgentPreModelCallStop, AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import type { AgentPreModelCallStop, AgentTool, AgentToolResult, BeforeToolCallResult } from "@oh-my-pi/pi-agent-core";
 
 /**
  * Per-review spend guard for one advisor.
@@ -10,18 +10,19 @@ import type { AgentPreModelCallStop, AgentTool, AgentToolResult } from "@oh-my-p
  * unbounded number of provider requests, each one re-sending the advisor's
  * whole append-only context. Observed worst case: 95 requests for one review.
  *
- * Two independent limiters, both scoped to the current review:
+ * Three independent limiters are scoped to the current review:
  *
- * - **Request cap** — a counter this class owns, so it is exact. Enforced from
+ * - **Request cap** — an optional exact counter. Enforced from
  *   `beforeModelCall`, which ends the loop *before* the request is prepared;
  *   the loop records a zero-usage `stopReason: "aborted"` message, so nothing
- *   is billed and the advisor's failure ladder sees a normal completed turn.
- * - **Cost ceiling** — compares the summed cost of requests that have already
- *   **completed** in this review, fed by {@link recordCompletedCost} from the
- *   advisor's live `message_end` subscription. It is exact for completed work
- *   and lags by at most the in-flight request: the ceiling refuses to dispatch
- *   the *next* request, it cannot cut off the current one. It is a backstop for
- *   very large contexts, not a dollar-precise cutoff.
+ *   is billed.
+ * - **Cost ceiling** — an optional backstop that compares the summed cost of
+ *   requests that have already **completed** in this review. It is exact for
+ *   completed work and lags by at most the in-flight request.
+ * - **Per-provider-turn tool cap** — an execution cap for investigative tools
+ *   in one assistant response. The first `N` tools can execute; later tools
+ *   in that response are blocked. The next provider turn gets a fresh allowance;
+ *   `advise` is not an investigative tool and remains available.
  *
  * Separately, {@link guardTool} short-circuits a tool call whose `(name, args)`
  * pair already ran in this review. A degenerate reviewer can otherwise spend
@@ -29,15 +30,20 @@ import type { AgentPreModelCallStop, AgentTool, AgentToolResult } from "@oh-my-p
  * pattern, and every repeated result stays in the append-only context and
  * inflates every later request in the session.
  *
- * Each limit is disabled by a non-positive value.
+ * A review is one `agent.prompt(batch)` cycle for one transcript delta. It may
+ * contain several provider turns/requests. These counters are not session-wide.
+ * Each limit is disabled by a non-positive value except the per-turn tool
+ * default, which is configured by the caller.
  */
 export interface AdvisorReviewBudgetLimits {
-	/** Max provider requests per review; `0` disables the cap. */
+	/** Max provider requests per logical review; `0` disables the cap. */
 	maxRequests: number;
-	/** Max USD of completed requests per review; `0` disables the ceiling. */
+	/** Max USD of completed requests per logical review; `0` disables it. */
 	maxCostUsd: number;
-	/** Occurrence at which an identical `(tool, args)` call is refused; `0` disables the guard. */
+	/** Occurrence at which an identical `(tool, args)` call is refused; `0` disables. */
 	maxIdenticalToolCalls: number;
+	/** Max investigative tool executions per provider turn; `0` disables. */
+	maxToolCallsPerTurn: number;
 }
 
 export interface AdvisorReviewBudgetStop {
@@ -61,6 +67,7 @@ export class AdvisorReviewBudget {
 	#reviewId: number | undefined;
 	#requests = 0;
 	#costUsd = 0;
+	#turnToolCalls = 0;
 	#toolCalls = new Map<string, number>();
 	#stop: AdvisorReviewBudgetStop | undefined;
 
@@ -81,6 +88,7 @@ export class AdvisorReviewBudget {
 		this.#reviewId = reviewId;
 		this.#requests = 0;
 		this.#costUsd = 0;
+		this.#turnToolCalls = 0;
 		this.#toolCalls.clear();
 		this.#stop = undefined;
 	}
@@ -120,15 +128,22 @@ export class AdvisorReviewBudget {
 				`advisor review spent $${this.#costUsd.toFixed(2)} of its $${maxCostUsd.toFixed(2)} ceiling`,
 			);
 		}
+		this.#turnToolCalls = 0;
 		this.#requests++;
 		return undefined;
 	}
 
 	/**
-	 * Record one tool call and return a refusal message when this exact
-	 * `(name, args)` pair has already run in this review, or `undefined` to let
-	 * it execute.
+	 * Hook for ordinary model-facing tools. Cursor's resolved registry tools use
+	 * `guardTool`, while its direct non-registry handlers use the same hook
+	 * through `CursorExecBridgeOptions`.
 	 */
+	beforeToolCall(name: string, args: unknown): BeforeToolCallResult | undefined {
+		const refusal = this.#prepareToolCall(name, args);
+		return refusal === undefined ? undefined : { block: true, reason: refusal };
+	}
+
+	/** Record a tool call and return a refusal when its exact identity repeats. */
 	noteToolCall(name: string, args: unknown): string | undefined {
 		const max = this.#resolveLimits().maxIdenticalToolCalls;
 		if (max <= 0) return undefined;
@@ -156,7 +171,10 @@ export class AdvisorReviewBudget {
 					onUpdate: never,
 					context: never,
 				) => {
-					const refusal = this.noteToolCall(target.name, identity === undefined ? params : { identity, params });
+					const refusal = this.#prepareToolCall(
+						target.name,
+						identity === undefined ? params : { identity, params },
+					);
 					if (refusal !== undefined) {
 						// Not `isError`: an error result feeds the advisor failure
 						// ladder, and a refused repeat is a healthy outcome.
@@ -169,6 +187,18 @@ export class AdvisorReviewBudget {
 				};
 			},
 		}) as T;
+	}
+
+	#prepareToolCall(name: string, args: unknown): string | undefined {
+		if (name === "advise") return undefined;
+		const { maxToolCallsPerTurn } = this.#resolveLimits();
+		if (maxToolCallsPerTurn > 0 && this.#turnToolCalls >= maxToolCallsPerTurn) {
+			return `Refused: this advisor provider turn already used ${maxToolCallsPerTurn} investigative tool calls. Use the results you have and call \`advise\`, or end this provider turn.`;
+		}
+		const refusal = this.noteToolCall(name, args);
+		if (refusal !== undefined) return refusal;
+		if (maxToolCallsPerTurn > 0) this.#turnToolCalls++;
+		return undefined;
 	}
 
 	#halt(kind: AdvisorReviewBudgetStop["kind"], reason: string): AgentPreModelCallStop {

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -52,10 +52,12 @@ export interface AdvisorRuntimeHost {
 	/**
 	 * Called immediately before each `agent.prompt(batch)` cycle. Lets the host
 	 * clear per-update advisor state and apply the in-progress delivery policy.
+	 * `reviewId` stays stable when the same logical batch is retried, so
+	 * per-review safety budgets are not reset by provider recovery.
 	 * The host owns these gates because it routes `advise()` results back to the
 	 * primary.
 	 */
-	beginAdvisorUpdate?(inProgress: boolean): void;
+	beginAdvisorUpdate?(inProgress: boolean, reviewId: number): void;
 	/**
 	 * Called with the error of every failed advisor turn, before the retry sleep
 	 * or the dropped-after-3 path. Lets the host apply credential-level remedies
@@ -243,6 +245,7 @@ interface PendingDelta {
 	rawMessages: AgentMessage[];
 	renderRevision: number;
 	turns: number;
+	reviewId: number;
 	/** Whether the primary was mid-turn (willContinue:true) when this delta was rendered. */
 	wip: boolean;
 	overflowRecovery?: boolean;
@@ -287,6 +290,7 @@ export class AdvisorRuntime {
 	/** Regex secret values observed in primary deltas and retained until advisor context resets. */
 	#advisorRegexSecretValues = new Set<string>();
 	#pending: PendingDelta[] = [];
+	#nextReviewId = 1;
 	#busy = false;
 	#sessionTransitionPaused = false;
 	#promptInFlight: Promise<void> | undefined;
@@ -372,7 +376,7 @@ export class AdvisorRuntime {
 		const all = messages ?? this.host.snapshotMessages();
 		this.#latestMessages = all;
 		const wip = opts?.willContinue ?? false;
-		let rendered: Omit<PendingDelta, "turns" | "overflowRecovery"> | null = null;
+		let rendered: Omit<PendingDelta, "turns" | "overflowRecovery" | "reviewId"> | null = null;
 		// #renderDelta advances the cursor/prefix/dedup state before formatting
 		// can throw; snapshot them so a formatter bug loses NOTHING — the next
 		// turn re-renders this delta (a prefix change mid-render self-heals via
@@ -395,7 +399,7 @@ export class AdvisorRuntime {
 			logger.warn("advisor delta render failed", { err: String(err) });
 		}
 		if (rendered) {
-			this.#pending.push({ ...rendered, turns: 1 });
+			this.#pending.push({ ...rendered, turns: 1, reviewId: this.#nextReviewId++ });
 			this.#backlog++;
 			this.#notifyWaiters();
 			void this.#drain();
@@ -634,7 +638,10 @@ export class AdvisorRuntime {
 		return `${heading}\n\n${md}`;
 	}
 
-	#renderDelta(messages?: AgentMessage[], wip = false): Omit<PendingDelta, "turns" | "overflowRecovery"> | null {
+	#renderDelta(
+		messages?: AgentMessage[],
+		wip = false,
+	): Omit<PendingDelta, "turns" | "overflowRecovery" | "reviewId"> | null {
 		const all = messages ?? this.#latestMessages ?? this.host.snapshotMessages();
 		let prefixChanged = all.length < this.#lastCount;
 		for (let i = 0; !prefixChanged && i < this.#lastCount; i++) {
@@ -876,6 +883,7 @@ export class AdvisorRuntime {
 				} else {
 					popped = this.#pending.splice(0);
 				}
+				const reviewId = popped[0]!.reviewId;
 				const iterationAbort = new AbortController();
 				this.#iterationAbort = iterationAbort;
 				const epoch = this.#epoch;
@@ -919,7 +927,7 @@ export class AdvisorRuntime {
 				try {
 					// Reset the host's per-update advisor state (one-advise-per-update
 					// gate) and pass through whether this batch reviews partial work.
-					this.host.beginAdvisorUpdate?.(wip);
+					this.host.beginAdvisorUpdate?.(wip, reviewId);
 					const prompt = this.agent.prompt(batch);
 					this.#promptInFlight = prompt;
 					try {
@@ -998,6 +1006,7 @@ export class AdvisorRuntime {
 									rawMessages,
 									renderRevision: this.#renderRevision,
 									turns: finalTurns,
+									reviewId,
 									wip,
 									overflowRecovery: recoveringOverflow || undefined,
 								});
@@ -1040,6 +1049,7 @@ export class AdvisorRuntime {
 								rawMessages,
 								renderRevision: this.#renderRevision,
 								turns: finalTurns,
+								reviewId,
 								wip,
 								overflowRecovery: recoveringOverflow || undefined,
 							});
@@ -1100,6 +1110,7 @@ export class AdvisorRuntime {
 							rawMessages,
 							renderRevision: this.#renderRevision,
 							turns: finalTurns,
+							reviewId,
 							wip,
 							overflowRecovery: recoveringOverflow || undefined,
 						});
@@ -1120,6 +1131,7 @@ export class AdvisorRuntime {
 							rawMessages,
 							renderRevision: this.#renderRevision,
 							turns: finalTurns,
+							reviewId,
 							wip,
 							overflowRecovery: recoveringOverflow || undefined,
 						});
@@ -1158,6 +1170,7 @@ export class AdvisorRuntime {
 								rawMessages,
 								renderRevision: this.#renderRevision,
 								turns: finalTurns,
+								reviewId,
 								wip,
 								overflowRecovery: true,
 							});
@@ -1180,6 +1193,7 @@ export class AdvisorRuntime {
 								rawMessages,
 								renderRevision: this.#renderRevision,
 								turns: finalTurns,
+								reviewId,
 								wip,
 								overflowRecovery: recoveringOverflow || undefined,
 							});

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -510,6 +510,42 @@ export const SETTINGS_SCHEMA = {
 			condition: "advisorEnabled",
 		},
 	},
+	"advisor.maxRequestsPerReview": {
+		type: "number",
+		default: 32,
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Advisor Request Limit",
+			description:
+				"Maximum provider requests in one advisor review. The hard gate runs before each request; 0 disables it.",
+			condition: "advisorEnabled",
+		},
+	},
+	"advisor.maxCostPerReview": {
+		type: "number",
+		default: 10,
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Advisor Cost Ceiling",
+			description:
+				"Stop before the next request after completed requests in one review reach this USD cost. The current request may cross the ceiling; 0 disables it.",
+			condition: "advisorEnabled",
+		},
+	},
+	"advisor.maxIdenticalToolCalls": {
+		type: "number",
+		default: 2,
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Advisor Repeated Tool Limit",
+			description:
+				"Refuse this occurrence of an identical tool call within one review. 2 refuses the first repeat; 0 disables it.",
+			condition: "advisorEnabled",
+		},
+	},
 	shellPath: { type: "string", default: undefined },
 	"git.enabled": {
 		type: "boolean",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -512,25 +512,37 @@ export const SETTINGS_SCHEMA = {
 	},
 	"advisor.maxRequestsPerReview": {
 		type: "number",
-		default: 32,
+		default: 0,
 		ui: {
 			tab: "model",
 			group: "Advisor",
 			label: "Advisor Request Limit",
 			description:
-				"Maximum provider requests in one advisor review. The hard gate runs before each request; 0 disables it.",
+				"Optional maximum provider requests in one logical advisor review (not the whole session). The gate runs before each request; 0 leaves it unset.",
 			condition: "advisorEnabled",
 		},
 	},
 	"advisor.maxCostPerReview": {
 		type: "number",
-		default: 10,
+		default: 0,
 		ui: {
 			tab: "model",
 			group: "Advisor",
 			label: "Advisor Cost Ceiling",
 			description:
-				"Stop before the next request after completed requests in one review reach this USD cost. The current request may cross the ceiling; 0 disables it.",
+				"Optional USD ceiling for completed requests in one logical advisor review (not the whole session). The current request may cross it; 0 leaves it unset.",
+			condition: "advisorEnabled",
+		},
+	},
+	"advisor.maxToolCallsPerTurn": {
+		type: "number",
+		default: 10,
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Advisor Tool Calls Per Turn",
+			description:
+				"Maximum investigative tool executions in one provider turn. Further investigative tools in that response are blocked; the next provider turn gets a fresh allowance. 0 disables it.",
 			condition: "advisorEnabled",
 		},
 	},
@@ -542,7 +554,7 @@ export const SETTINGS_SCHEMA = {
 			group: "Advisor",
 			label: "Advisor Repeated Tool Limit",
 			description:
-				"Refuse this occurrence of an identical tool call within one review. 2 refuses the first repeat; 0 disables it.",
+				"Refuse this occurrence of an identical investigative tool call within one review. 2 refuses the first repeat; 0 disables it.",
 			condition: "advisorEnabled",
 		},
 	},

--- a/packages/coding-agent/src/cursor.ts
+++ b/packages/coding-agent/src/cursor.ts
@@ -76,6 +76,12 @@ interface CursorExecBridgeOptions {
 	 */
 	getEditReplaceTool?: () => CursorBridgeTool | undefined;
 	getToolContext?: () => AgentToolContext | undefined;
+	/**
+	 * Gate Cursor-resolved calls that bypass the model-facing tool registry.
+	 * A refusal is thrown so the provider returns an error/rejected result
+	 * without executing the underlying handler.
+	 */
+	beforeToolCall?: (name: string, args: unknown) => string | undefined;
 	emitEvent?: (event: AgentEvent) => void;
 	/**
 	 * Whether frames that mutate the filesystem WITHOUT running a registry tool
@@ -316,6 +322,8 @@ async function executeDelete(options: CursorExecBridgeOptions, pathArg: string, 
 		const result = buildToolErrorResult(`Tool "${toolName}" not available`);
 		return createToolResultMessage(toolCallId, toolName, result, true);
 	}
+	const budgetRefusal = options.beforeToolCall?.(toolName, { path: pathArg });
+	if (budgetRefusal) throw new Error(budgetRefusal);
 
 	// Unlike every other frame, this one mutates the filesystem directly instead
 	// of running a registry tool, so no approval wrapper sits in front of it.
@@ -731,6 +739,8 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 	 * it came from. An absent `server` filter means "all of them".
 	 */
 	async listMcpResources({ server }: { server?: string }): Promise<CursorMcpResource[]> {
+		const budgetRefusal = this.options.beforeToolCall?.("list_mcp_resources", { server });
+		if (budgetRefusal) throw new Error(budgetRefusal);
 		const mcp = this.options.mcpResources;
 		if (!mcp) return [];
 		const names = server ? [server] : mcp.serverNames();
@@ -777,6 +787,12 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 		uri: string;
 		downloadPath?: string;
 	}): Promise<CursorMcpResourceContent | null> {
+		const budgetRefusal = this.options.beforeToolCall?.("read_mcp_resource", {
+			server,
+			uri,
+			downloadPath,
+		});
+		if (budgetRefusal) throw new Error(budgetRefusal);
 		if (downloadPath) {
 			if (this.options.allowDirectFileMutation === false) {
 				throw new Error('Tool "write" not available: this session cannot download resources to disk.');

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -157,6 +157,10 @@ const HOST_DEFAULTED_SETTING_PATHS: SettingPath[] = [
 	"advisor.subagents",
 	"advisor.syncBacklog",
 	"advisor.immuneTurns",
+	"advisor.maxRequestsPerReview",
+	"advisor.maxCostPerReview",
+	"advisor.maxToolCallsPerTurn",
+	"advisor.maxIdenticalToolCalls",
 	"tier.advisor",
 ];
 

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -696,6 +696,7 @@ export class SessionAdvisors {
 					maxRequests: this.#host.settings.get("advisor.maxRequestsPerReview"),
 					maxCostUsd: this.#host.settings.get("advisor.maxCostPerReview"),
 					maxIdenticalToolCalls: this.#host.settings.get("advisor.maxIdenticalToolCalls"),
+					maxToolCallsPerTurn: this.#host.settings.get("advisor.maxToolCallsPerTurn"),
 				}),
 				stop => logger.warn("advisor review budget reached", { advisor: advisorName, ...stop }),
 			);
@@ -709,7 +710,7 @@ export class SessionAdvisors {
 			if (config.instructions?.trim()) systemPrompt.push(config.instructions.trim());
 
 			const names = config.tools === undefined ? ADVISOR_DEFAULT_TOOL_NAMES : new Set(config.tools);
-			const tools = (this.#advisorTools ?? []).filter(t => names.has(t.name)).map(t => reviewBudget.guardTool(t));
+			const tools = (this.#advisorTools ?? []).filter(t => names.has(t.name));
 			const advisorLoopTools: AgentTool<any>[] = [adviseTool, ...tools];
 			const advisorToolMap = new Map<string, AgentTool<any>>();
 			const availableAdvisorToolNames = new Set<string>();
@@ -721,6 +722,9 @@ export class SessionAdvisors {
 					advisorToolMap.set(tool.customWireName, tool);
 				}
 			}
+			const advisorBridgeToolMap = new Map(
+				[...advisorToolMap.entries()].map(([name, tool]) => [name, reviewBudget.guardTool(tool)] as const),
+			);
 			let quarantinedAdvisorOutput: string | undefined;
 			let currentAdvisorInput = "";
 
@@ -785,10 +789,11 @@ export class SessionAdvisors {
 			const advisorCursorExecHandlers = new CursorExecHandlers({
 				cwd: this.#host.sessionManager.getCwd(),
 				getCwd: () => this.#host.sessionManager.getCwd(),
-				tools: bridgeToolMap(advisorToolMap, createGuardedBridgeEditTool),
+				tools: bridgeToolMap(advisorBridgeToolMap, createGuardedBridgeEditTool),
 				// Approval mode, per-tool policies and `autoApprove` live only on
 				// this context; without it every bridge tool resolves as `yolo`.
 				getToolContext: this.#advisorGetToolContext,
+				beforeToolCall: (name, args) => reviewBudget.beforeToolCall(name, args)?.reason,
 				allowDirectFileMutation: advisorCanMutateFiles,
 				// Gated on the advisor's own grant: the factory builds a fresh
 				// tool, so handing it over unconditionally would give a roster
@@ -834,6 +839,7 @@ export class SessionAdvisors {
 				onResponse: this.#host.onResponse,
 				onSseEvent: this.#host.onSseEvent,
 				transformProviderContext: this.#transformProviderContext,
+				beforeToolCall: ({ tool, args }) => reviewBudget.beforeToolCall(tool.name, args),
 				intentTracing: false,
 				transformAssistantMessage: message => {
 					quarantinedAdvisorOutput = quarantineAdvisorUnsafeOutput(

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -46,6 +46,7 @@ import {
 	type AdvisorMessageDetails,
 	type AdvisorNote,
 	AdvisorOutputQuarantinedError,
+	AdvisorReviewBudget,
 	AdvisorRuntime,
 	type AdvisorRuntimeStatus,
 	type AdvisorSeverity,
@@ -152,6 +153,7 @@ interface ActiveAdvisor {
 	runtime: AdvisorRuntime;
 	adviseTool: AdviseTool;
 	emissionGuard: AdvisorEmissionGuard;
+	reviewBudget: AdvisorReviewBudget;
 	recorder: AdvisorTranscriptRecorder;
 	recorderClosed: Promise<void>;
 	agentUnsubscribe?: () => void;
@@ -689,6 +691,14 @@ export class SessionAdvisors {
 
 			const emissionGuard = new AdvisorEmissionGuard();
 			const adviseTool = new AdviseTool((note, severity) => this.#routeAdvice(advisorRef, note, severity));
+			const reviewBudget = new AdvisorReviewBudget(
+				() => ({
+					maxRequests: this.#host.settings.get("advisor.maxRequestsPerReview"),
+					maxCostUsd: this.#host.settings.get("advisor.maxCostPerReview"),
+					maxIdenticalToolCalls: this.#host.settings.get("advisor.maxIdenticalToolCalls"),
+				}),
+				stop => logger.warn("advisor review budget reached", { advisor: advisorName, ...stop }),
+			);
 
 			// `#advisorWatchdogPrompt` already carries WATCHDOG.md + YAML shared
 			// instructions; `config.instructions` adds this advisor's specialization.
@@ -699,7 +709,7 @@ export class SessionAdvisors {
 			if (config.instructions?.trim()) systemPrompt.push(config.instructions.trim());
 
 			const names = config.tools === undefined ? ADVISOR_DEFAULT_TOOL_NAMES : new Set(config.tools);
-			const tools = (this.#advisorTools ?? []).filter(t => names.has(t.name));
+			const tools = (this.#advisorTools ?? []).filter(t => names.has(t.name)).map(t => reviewBudget.guardTool(t));
 			const advisorLoopTools: AgentTool<any>[] = [adviseTool, ...tools];
 			const advisorToolMap = new Map<string, AgentTool<any>>();
 			const availableAdvisorToolNames = new Set<string>();
@@ -766,10 +776,16 @@ export class SessionAdvisors {
 			// swaps in a `replace` instance for the exec channel only — the
 			// advisor's own loop keeps the tool it was given — and only when
 			// `edit` was actually granted.
+			const createGuardedBridgeEditTool = this.#advisorCreateEditTool
+				? () => {
+						const tool = this.#advisorCreateEditTool?.();
+						return tool ? reviewBudget.guardTool(tool) : undefined;
+					}
+				: undefined;
 			const advisorCursorExecHandlers = new CursorExecHandlers({
 				cwd: this.#host.sessionManager.getCwd(),
 				getCwd: () => this.#host.sessionManager.getCwd(),
-				tools: bridgeToolMap(advisorToolMap, this.#advisorCreateEditTool),
+				tools: bridgeToolMap(advisorToolMap, createGuardedBridgeEditTool),
 				// Approval mode, per-tool policies and `autoApprove` live only on
 				// this context; without it every bridge tool resolves as `yolo`.
 				getToolContext: this.#advisorGetToolContext,
@@ -777,7 +793,12 @@ export class SessionAdvisors {
 				// Gated on the advisor's own grant: the factory builds a fresh
 				// tool, so handing it over unconditionally would give a roster
 				// without `grep` a search tool it was denied.
-				createGrepTool: advisorToolMap.has("grep") ? this.#advisorCreateGrepTool : undefined,
+				createGrepTool: advisorToolMap.has("grep")
+					? options => {
+							const tool = this.#advisorCreateGrepTool?.(options);
+							return tool ? reviewBudget.guardTool(tool, options) : undefined;
+						}
+					: undefined,
 				// Advisors share the session's live MCP connections, so their
 				// resource frames answer from the same catalog the primary sees.
 				// Not gated on a tool grant: reading what a server advertises is
@@ -826,6 +847,7 @@ export class SessionAdvisors {
 				serviceTierResolver: advisorServiceTierResolver,
 			});
 			advisorAgent.setDisableReasoning(shouldDisableReasoning(advisorThinkingLevel));
+			advisorAgent.addBeforeModelCall(() => reviewBudget.beforeModelCall());
 
 			const advisorAgentFacade: AdvisorAgent = {
 				prompt: async input => {
@@ -877,8 +899,9 @@ export class SessionAdvisors {
 					this.#maintainAdvisorContext(advisorRef, incomingTokens, signal),
 				obfuscator: this.#host.obfuscator,
 				getModelIdentity: () => formatModelString(advisorRef.agent.state.model),
-				beginAdvisorUpdate: inProgress => {
+				beginAdvisorUpdate: (inProgress, reviewId) => {
 					advisorRef.adviseTool.beginUpdate(inProgress);
+					advisorRef.reviewBudget.beginReview(reviewId);
 					advisorRef.emissionGuard.beginUpdate();
 				},
 				onTurnError: (error, failedMessages, signal) =>
@@ -919,6 +942,7 @@ export class SessionAdvisors {
 				runtime,
 				adviseTool,
 				emissionGuard,
+				reviewBudget,
 				recorder,
 				recorderClosed: Promise.resolve(),
 				model: advisorModel,
@@ -1082,7 +1106,9 @@ export class SessionAdvisors {
 	}
 
 	#recordAdvisorCost(advisor: ActiveAdvisor, message: AssistantMessage): void {
-		this.#advisorCosts.set(advisor.slug, (this.#advisorCosts.get(advisor.slug) ?? 0) + message.usage.cost.total);
+		const cost = message.usage.cost.total;
+		this.#advisorCosts.set(advisor.slug, (this.#advisorCosts.get(advisor.slug) ?? 0) + cost);
+		advisor.reviewBudget.recordCompletedCost(cost);
 	}
 
 	/** Subscribe the advisor agent's finalized messages into the transcript recorder.

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -266,6 +266,10 @@ describe("ACP lazy startup", () => {
 			"advisor.subagents": true,
 			"advisor.syncBacklog": "5",
 			"advisor.immuneTurns": 7,
+			"advisor.maxRequestsPerReview": 41,
+			"advisor.maxCostPerReview": 42,
+			"advisor.maxToolCallsPerTurn": 43,
+			"advisor.maxIdenticalToolCalls": 44,
 		} as const;
 		const rpcOnlyExplicit = {
 			"async.enabled": false,

--- a/packages/coding-agent/test/advisor/advisor.test.ts
+++ b/packages/coding-agent/test/advisor/advisor.test.ts
@@ -3960,6 +3960,7 @@ describe("advisor", () => {
 			const promptInputs: string[] = [];
 			const turnErrors: unknown[] = [];
 			const events: string[] = [];
+			const reviewIds: number[] = [];
 			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
 			let promptCalls = 0;
 			const agent: AdvisorAgent = {
@@ -3979,6 +3980,7 @@ describe("advisor", () => {
 			const host: AdvisorRuntimeHost = {
 				snapshotMessages: () => messages,
 				enqueueAdvice: () => {},
+				beginAdvisorUpdate: (_inProgress, reviewId) => reviewIds.push(reviewId),
 				onTurnError: error => {
 					turnErrors.push(error);
 					events.push(`hook:${error instanceof Error ? error.message : String(error)}`);
@@ -3995,6 +3997,8 @@ describe("advisor", () => {
 			if (!(error instanceof Error)) throw new Error("expected advisor turn error");
 			expect(error.message).toBe("provider failed");
 			expect(events).toEqual(["prompt:1", "hook:provider failed", "prompt:2"]);
+			expect(reviewIds).toHaveLength(2);
+			expect(new Set(reviewIds).size).toBe(1);
 			expect(runtime.backlog).toBe(0);
 		});
 

--- a/packages/coding-agent/test/advisor/review-budget.test.ts
+++ b/packages/coding-agent/test/advisor/review-budget.test.ts
@@ -6,9 +6,10 @@ import { AdvisorReviewBudget } from "../../src/advisor/review-budget";
 import { Settings } from "../../src/config/settings";
 
 const defaults = {
-	maxRequests: 32,
-	maxCostUsd: 10,
+	maxRequests: 0,
+	maxCostUsd: 0,
 	maxIdenticalToolCalls: 2,
+	maxToolCallsPerTurn: 10,
 };
 
 function createReadTool(execute: (params: { path?: string; line?: number }) => string): AgentTool {
@@ -44,9 +45,10 @@ describe("AdvisorReviewBudget", () => {
 	it("uses conservative configurable defaults", () => {
 		const settings = Settings.isolated();
 
-		expect(settings.get("advisor.maxRequestsPerReview")).toBe(32);
-		expect(settings.get("advisor.maxCostPerReview")).toBe(10);
+		expect(settings.get("advisor.maxRequestsPerReview")).toBe(0);
+		expect(settings.get("advisor.maxCostPerReview")).toBe(0);
 		expect(settings.get("advisor.maxIdenticalToolCalls")).toBe(2);
+		expect(settings.get("advisor.maxToolCallsPerTurn")).toBe(10);
 	});
 
 	it("hard-stops before the request after the configured request count", () => {
@@ -82,6 +84,7 @@ describe("AdvisorReviewBudget", () => {
 			maxRequests: settings.get("advisor.maxRequestsPerReview"),
 			maxCostUsd: settings.get("advisor.maxCostPerReview"),
 			maxIdenticalToolCalls: settings.get("advisor.maxIdenticalToolCalls"),
+			maxToolCallsPerTurn: settings.get("advisor.maxToolCallsPerTurn"),
 		}));
 		budget.beginReview(1);
 		expect(budget.beforeModelCall()).toBeUndefined();
@@ -188,7 +191,12 @@ describe("AdvisorReviewBudget", () => {
 
 	it("disables each limiter independently with a non-positive value", async () => {
 		let executions = 0;
-		const budget = new AdvisorReviewBudget({ maxRequests: 0, maxCostUsd: 0, maxIdenticalToolCalls: 0 });
+		const budget = new AdvisorReviewBudget({
+			maxRequests: 0,
+			maxCostUsd: 0,
+			maxIdenticalToolCalls: 0,
+			maxToolCallsPerTurn: 0,
+		});
 		const tool = budget.guardTool(
 			createReadTool(() => {
 				executions++;
@@ -202,6 +210,79 @@ describe("AdvisorReviewBudget", () => {
 		await tool.execute("tc-1", { path: "a.ts" });
 		await tool.execute("tc-2", { path: "a.ts" });
 		expect(executions).toBe(2);
+	});
+
+	it("refreshes the investigative allowance for each provider turn", () => {
+		const budget = new AdvisorReviewBudget({ ...defaults, maxToolCallsPerTurn: 2 });
+		budget.beginReview(1);
+
+		expect(budget.beforeModelCall()).toBeUndefined();
+		expect(budget.beforeToolCall("read", { path: "a.ts" })).toBeUndefined();
+		expect(budget.beforeToolCall("read", { path: "b.ts" })).toBeUndefined();
+		expect(budget.beforeToolCall("read", { path: "c.ts" })).toEqual({
+			block: true,
+			reason:
+				"Refused: this advisor provider turn already used 2 investigative tool calls. Use the results you have and call `advise`, or end this provider turn.",
+		});
+		expect(budget.beforeToolCall("advise", {})).toBeUndefined();
+
+		expect(budget.beforeModelCall()).toBeUndefined();
+		expect(budget.beforeToolCall("read", { path: "c.ts" })).toBeUndefined();
+		expect(budget.stop).toBeUndefined();
+	});
+	it("does not charge refused repeats against the per-turn execution allowance", () => {
+		const budget = new AdvisorReviewBudget({ ...defaults, maxToolCallsPerTurn: 2 });
+		budget.beginReview(1);
+		expect(budget.beforeModelCall()).toBeUndefined();
+
+		expect(budget.beforeToolCall("read", { path: "a.ts" })).toBeUndefined();
+		expect(budget.beforeToolCall("read", { path: "a.ts" })?.reason).toContain("already ran");
+		expect(budget.beforeToolCall("read", { path: "b.ts" })).toBeUndefined();
+		expect(budget.beforeToolCall("read", { path: "c.ts" })?.reason).toContain("already used 2");
+	});
+
+	it("applies the per-turn gate to ordinary Agent tool dispatch", async () => {
+		const executed: number[] = [];
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{ type: "toolCall", name: "read", arguments: { path: "a.ts", line: 1 } },
+						{ type: "toolCall", name: "read", arguments: { path: "a.ts", line: 2 } },
+						{ type: "toolCall", name: "read", arguments: { path: "a.ts", line: 3 } },
+					],
+				},
+				{
+					content: [{ type: "toolCall", name: "read", arguments: { path: "a.ts", line: 4 } }],
+				},
+				{ content: ["done"] },
+			],
+		});
+		const budget = new AdvisorReviewBudget({ ...defaults, maxToolCallsPerTurn: 2 });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: mock.model,
+				systemPrompt: ["Test"],
+				tools: [
+					createReadTool(params => {
+						executed.push(params.line ?? -1);
+						return "ok";
+					}),
+				],
+			},
+			beforeToolCall: ({ tool, args }) => budget.beforeToolCall(tool.name, args),
+			streamFn: mock.stream,
+		});
+		agent.addBeforeModelCall(() => budget.beforeModelCall());
+		budget.beginReview(1);
+
+		await agent.prompt("Review this change");
+
+		expect(mock.calls).toHaveLength(3);
+		expect(executed).toEqual([1, 2, 4]);
+		expect(budget.requests).toBe(3);
+		expect(budget.stop).toBeUndefined();
 	});
 
 	it("enforces completed cost between provider calls in one Agent.prompt loop", async () => {

--- a/packages/coding-agent/test/advisor/review-budget.test.ts
+++ b/packages/coding-agent/test/advisor/review-budget.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "bun:test";
+import { type } from "@oh-my-pi/omptype";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { AdvisorReviewBudget } from "../../src/advisor/review-budget";
+import { Settings } from "../../src/config/settings";
+
+const defaults = {
+	maxRequests: 32,
+	maxCostUsd: 10,
+	maxIdenticalToolCalls: 2,
+};
+
+function createReadTool(execute: (params: { path?: string; line?: number }) => string): AgentTool {
+	return {
+		name: "read",
+		label: "Read",
+		description: "Read a file",
+		parameters: type({ "path?": "string", "line?": "number" }),
+		execute: async (_id, params) => ({
+			content: [{ type: "text", text: execute(params as { path?: string; line?: number }) }],
+		}),
+	};
+}
+
+class PrivateFieldReadTool {
+	readonly name = "read";
+	readonly label = "Read";
+	readonly description = "Read a file";
+	readonly parameters = type({ "path?": "string" });
+	#executions = 0;
+
+	get executions(): number {
+		return this.#executions;
+	}
+
+	async execute(): Promise<{ content: [{ type: "text"; text: string }] }> {
+		this.#executions++;
+		return { content: [{ type: "text", text: `execution ${this.#executions}` }] };
+	}
+}
+
+describe("AdvisorReviewBudget", () => {
+	it("uses conservative configurable defaults", () => {
+		const settings = Settings.isolated();
+
+		expect(settings.get("advisor.maxRequestsPerReview")).toBe(32);
+		expect(settings.get("advisor.maxCostPerReview")).toBe(10);
+		expect(settings.get("advisor.maxIdenticalToolCalls")).toBe(2);
+	});
+
+	it("hard-stops before the request after the configured request count", () => {
+		const budget = new AdvisorReviewBudget({ ...defaults, maxRequests: 3 });
+		budget.beginReview();
+
+		expect(budget.beforeModelCall()).toBeUndefined();
+		expect(budget.beforeModelCall()).toBeUndefined();
+		expect(budget.beforeModelCall()).toBeUndefined();
+		expect(budget.beforeModelCall()).toEqual({
+			stop: true,
+			reason: "advisor review reached 3 provider requests",
+		});
+		expect(budget.requests).toBe(3);
+	});
+
+	it("keeps one budget when the same logical review is retried", () => {
+		const budget = new AdvisorReviewBudget({ ...defaults, maxRequests: 2 });
+		budget.beginReview(7);
+		expect(budget.beforeModelCall()).toBeUndefined();
+		budget.beginReview(7);
+		expect(budget.beforeModelCall()).toBeUndefined();
+		expect(budget.beforeModelCall()?.stop).toBe(true);
+
+		budget.beginReview(8);
+		expect(budget.requests).toBe(0);
+		expect(budget.beforeModelCall()).toBeUndefined();
+	});
+
+	it("reads changed limits without rebuilding the budget", () => {
+		const settings = Settings.isolated();
+		const budget = new AdvisorReviewBudget(() => ({
+			maxRequests: settings.get("advisor.maxRequestsPerReview"),
+			maxCostUsd: settings.get("advisor.maxCostPerReview"),
+			maxIdenticalToolCalls: settings.get("advisor.maxIdenticalToolCalls"),
+		}));
+		budget.beginReview(1);
+		expect(budget.beforeModelCall()).toBeUndefined();
+
+		settings.set("advisor.maxRequestsPerReview", 1);
+		expect(budget.beforeModelCall()?.stop).toBe(true);
+	});
+
+	it("checks completed cost before dispatch and can lag by one completed request", () => {
+		const budget = new AdvisorReviewBudget({ ...defaults, maxCostUsd: 1 });
+		budget.beginReview();
+
+		expect(budget.beforeModelCall()).toBeUndefined();
+		budget.recordCompletedCost(0.6);
+		expect(budget.beforeModelCall()).toBeUndefined();
+		budget.recordCompletedCost(0.6);
+		expect(budget.beforeModelCall()).toEqual({
+			stop: true,
+			reason: "advisor review spent $1.20 of its $1.00 ceiling",
+		});
+		expect(budget.costUsd).toBeCloseTo(1.2);
+	});
+
+	it("resets request, cost, repeat, and stop state for the next review", () => {
+		const budget = new AdvisorReviewBudget({ ...defaults, maxRequests: 1 });
+		budget.beginReview();
+		expect(budget.beforeModelCall()).toBeUndefined();
+		budget.recordCompletedCost(2);
+		expect(budget.noteToolCall("read", { path: "a.ts" })).toBeUndefined();
+		expect(budget.noteToolCall("read", { path: "a.ts" })).toContain("Refused");
+		expect(budget.beforeModelCall()?.stop).toBe(true);
+
+		budget.beginReview();
+		expect(budget.requests).toBe(0);
+		expect(budget.costUsd).toBe(0);
+		expect(budget.stop).toBeUndefined();
+		expect(budget.noteToolCall("read", { path: "a.ts" })).toBeUndefined();
+		expect(budget.beforeModelCall()).toBeUndefined();
+	});
+
+	it("canonicalizes object key order while allowing different arguments", () => {
+		const budget = new AdvisorReviewBudget(defaults);
+		budget.beginReview();
+
+		expect(budget.noteToolCall("read", { path: "a.ts", line: 1 })).toBeUndefined();
+		expect(budget.noteToolCall("read", { line: 1, path: "a.ts" })).toContain("attempt 2");
+		expect(budget.noteToolCall("read", { path: "a.ts", line: 2 })).toBeUndefined();
+		expect(budget.noteToolCall("glob", { path: "a.ts", line: 1 })).toBeUndefined();
+	});
+
+	it("short-circuits a repeated guarded tool without re-executing it", async () => {
+		const executed: string[] = [];
+		const budget = new AdvisorReviewBudget(defaults);
+		const guarded = budget.guardTool(
+			createReadTool(params => {
+				executed.push(params.path ?? "");
+				return "file contents";
+			}),
+		);
+		budget.beginReview();
+
+		const first = await guarded.execute("tc-1", { path: "a.ts" });
+		const repeat = await guarded.execute("tc-2", { path: "a.ts" });
+
+		expect(first.content).toEqual([{ type: "text", text: "file contents" }]);
+		expect(repeat.content[0]).toMatchObject({ type: "text", text: expect.stringContaining("Refused") });
+		expect(repeat.useless).toBe(true);
+		expect(repeat.isError).toBeUndefined();
+		expect(executed).toEqual(["a.ts"]);
+	});
+
+	it("includes dynamic bridge options in repeated-call identity", async () => {
+		let executions = 0;
+		const budget = new AdvisorReviewBudget(defaults);
+		const original = createReadTool(() => {
+			executions++;
+			return "ok";
+		});
+		const noContext = budget.guardTool(original, { context: 0 });
+		const wideContext = budget.guardTool(original, { context: 5 });
+		budget.beginReview();
+
+		await noContext.execute("tc-1", { path: "a.ts" });
+		await wideContext.execute("tc-2", { path: "a.ts" });
+		const repeat = await noContext.execute("tc-3", { path: "a.ts" });
+
+		expect(executions).toBe(2);
+		expect(repeat.content[0]).toMatchObject({ type: "text", text: expect.stringContaining("Refused") });
+	});
+
+	it("preserves the original receiver for class tools with private fields", async () => {
+		const original = new PrivateFieldReadTool();
+		const budget = new AdvisorReviewBudget(defaults);
+		const guarded = budget.guardTool(original as AgentTool);
+		budget.beginReview();
+
+		const first = await guarded.execute("tc-1", { path: "a.ts" });
+		const repeat = await guarded.execute("tc-2", { path: "a.ts" });
+
+		expect(first.content).toEqual([{ type: "text", text: "execution 1" }]);
+		expect(repeat.content[0]).toMatchObject({ type: "text", text: expect.stringContaining("Refused") });
+		expect(original.executions).toBe(1);
+	});
+
+	it("disables each limiter independently with a non-positive value", async () => {
+		let executions = 0;
+		const budget = new AdvisorReviewBudget({ maxRequests: 0, maxCostUsd: 0, maxIdenticalToolCalls: 0 });
+		const tool = budget.guardTool(
+			createReadTool(() => {
+				executions++;
+				return "ok";
+			}),
+		);
+		budget.beginReview();
+		budget.recordCompletedCost(1_000);
+
+		for (let i = 0; i < 100; i++) expect(budget.beforeModelCall()).toBeUndefined();
+		await tool.execute("tc-1", { path: "a.ts" });
+		await tool.execute("tc-2", { path: "a.ts" });
+		expect(executions).toBe(2);
+	});
+
+	it("enforces completed cost between provider calls in one Agent.prompt loop", async () => {
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [{ type: "toolCall", name: "read", arguments: { path: "a.ts", line: 1 } }],
+					usage: { cost: { total: 0.6 } },
+				},
+				{
+					content: [{ type: "toolCall", name: "read", arguments: { path: "a.ts", line: 2 } }],
+					usage: { cost: { total: 0.6 } },
+				},
+				{ content: ["this third request must never be sent"] },
+			],
+		});
+		const budget = new AdvisorReviewBudget({ ...defaults, maxCostUsd: 1 });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [createReadTool(() => "ok")] },
+			streamFn: mock.stream,
+		});
+		agent.addBeforeModelCall(() => budget.beforeModelCall());
+		agent.subscribe(event => {
+			if (event.type === "message_end" && event.message.role === "assistant") {
+				budget.recordCompletedCost(event.message.usage.cost.total);
+			}
+		});
+		budget.beginReview();
+
+		await agent.prompt("Review this change");
+
+		expect(mock.calls).toHaveLength(2);
+		expect(budget.requests).toBe(2);
+		expect(budget.costUsd).toBeCloseTo(1.2);
+		expect(budget.stop?.kind).toBe("cost");
+		expect(agent.state.error).toBeUndefined();
+		expect(agent.state.messages.filter(message => message.role === "assistant")).toHaveLength(2);
+	});
+});

--- a/packages/coding-agent/test/cursor-exec.test.ts
+++ b/packages/coding-agent/test/cursor-exec.test.ts
@@ -33,6 +33,7 @@ import { BashTool } from "@oh-my-pi/pi-coding-agent/tools/bash";
 import type { TruncationMeta } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import { AdviseTool } from "../src/advisor/advise-tool";
+import { AdvisorReviewBudget } from "../src/advisor/review-budget";
 
 function createTestSession(cwd: string, overrides: Partial<ToolSession> = {}): ToolSession {
 	return {
@@ -796,6 +797,41 @@ describe("CursorExecHandlers mounted tool bridge", () => {
 		]);
 		// A server filter narrows to that server alone.
 		expect((await handlers.listMcpResources({ server: "issues" })).map(r => r.uri)).toEqual(["issues://open"]);
+	});
+
+	it("gates advisor-resolved resource calls before executing them", async () => {
+		const budget = new AdvisorReviewBudget({
+			maxRequests: 0,
+			maxCostUsd: 0,
+			maxIdenticalToolCalls: 2,
+			maxToolCallsPerTurn: 2,
+		});
+		budget.beginReview(1);
+		expect(budget.beforeModelCall()).toBeUndefined();
+
+		let listed = 0;
+		const handlers = new CursorExecHandlers({
+			cwd: ".",
+			tools: new Map(),
+			beforeToolCall: (name, args) => budget.beforeToolCall(name, args)?.reason,
+			mcpResources: {
+				serverNames: () => [],
+				getServerResources: async () => {
+					listed++;
+					return { resources: [] };
+				},
+				readServerResource: async () => undefined,
+			},
+		});
+
+		await handlers.listMcpResources({ server: "one" });
+		await handlers.listMcpResources({ server: "two" });
+		await expect(handlers.listMcpResources({ server: "three" })).rejects.toThrow(/already used 2/);
+		expect(listed).toBe(2);
+
+		expect(budget.beforeModelCall()).toBeUndefined();
+		await handlers.listMcpResources({ server: "three" });
+		expect(listed).toBe(3);
 	});
 
 	it("waits for a server's catalog instead of reporting it empty", async () => {


### PR DESCRIPTION
## What

- Add an optional per-logical-review request cap and completed-cost ceiling for advisors. Both default to `0` (disabled), so long-running sessions are not silently capped; positive values stop the next provider request before it is sent, while the cost ceiling is a completed-cost backstop that may lag one in-flight request.
- Add `advisor.maxToolCallsPerTurn`, defaulting to `10`. The first ten investigative tools in one provider response can execute; later calls are refused, the next provider request gets a fresh allowance, and `advise` remains available. `0` disables this turn-level gate.
- Keep the repeated `(tool name, arguments)` guard at `2` by default, with `0` disabling it. Refused repeats do not execute or consume a per-turn execution slot. Review counters reset for a new logical review, remain stable when the same review is retried, and read live setting changes at each gate.
- Apply the same advisor-only guard to ordinary Agent tools, Cursor bridge tools, and Cursor-resolved direct `list_mcp_resources`, `read_mcp_resource`, and native `delete` handlers. The primary agent is unchanged.
- Include all four advisor budget settings in RPC/ACP host default handling so protocol startup does not accidentally inherit interactive host tuning, while explicit host settings remain respected.

## Why

The incident was not a provider billing defect. In the first transcript, one advisor made 479 provider requests across 59 reviews, with a 95-request single-review tail; 421 tool calls included about 240 exact repeats, and only three advice notes were delivered. The advisor sent about 55.4M prompt tokens, ended near a 186k-token context, and showed $62.04 of catalog-equivalent usage, $54.90 of it cache reads. The primary made 224 requests and showed $35.87. A second incident made 226 requests across 56 updates with zero advisor calls and still showed $19.40 of catalog-equivalent usage, disproving a theory that only advice delivery was looping.

The common failure was structural: an advisor review was an unbounded `agent.prompt` loop, and each provider request resent the advisor's append-only context plus tool results. Repeated reads/re-globs amplified that context. The displayed dollar figures are catalog-equivalent usage (the affected Codex path used OAuth/subscription credentials), not evidence of an unexpected cash charge; the real risks were quota consumption, latency, and runaway context growth. Priority service tier pricing also explained the observed per-token multiplier.

## Testing

- `bun test test/acp-lazy-startup.test.ts test/advisor/*.test.ts test/cursor-exec.test.ts` — 282 passed, 0 failed.
- `bun run check:ts` — passed across all workspace TypeScript packages.
- `git diff --check` — passed.

---

- [ ] `bun check` passes (not run; the affected TypeScript validation is recorded above)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
