### PR TITLE
fix(task): ignore Claude marketplace model aliases

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Claude marketplace task agents treating provider-specific model aliases as OMP selectors, allowing them to inherit the parent model ([#7966](https://github.com/can1357/oh-my-pi/issues/7966)).
+
 ## [17.2.11] - 2026-08-07
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1380,6 +1380,9 @@
 - Fixed long-running sessions leaking memory for every completed keep-alive `task`/scout subagent: a disposed (parked) subagent's `AgentSession` stayed pinned through the lifecycle adoption record's reviver closure, and `dispose()` never released the message array, append-only provider transcript, session-manager entries, or the raw-SSE debug buffer, so heavy transcripts and captured provider wire frames accumulated for the process lifetime ([#8003](https://github.com/can1357/oh-my-pi/issues/8003)).
 - Fixed Z.AI web search dropping sources and exposing raw JSON when MCP responses double-encode content text ([#8000](https://github.com/can1357/oh-my-pi/issues/8000)).
 - Fixed `/handoff` masking empty/whitespace-only generation and harness-initiated aborts as "Handoff cancelled"; manual empty generation now surfaces a logged failure, harness aborts preserve their reason (or report "Handoff aborted by session"), and auto-handoff still falls back to context-full compaction ([#7993](https://github.com/can1357/oh-my-pi/issues/7993)).
+### Fixed
+
+- Fixed Claude marketplace task agents treating provider-specific model aliases as OMP selectors, allowing them to inherit the parent model ([#7966](https://github.com/can1357/oh-my-pi/issues/7966)).
 
 ## [17.2.11] - 2026-08-07
 

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -36,10 +36,16 @@ export interface DiscoveryResult {
 	projectAgentsDir: string | null;
 }
 
+interface AgentDirectory {
+	dir: string;
+	source: AgentSource;
+	ignoreModel?: boolean;
+}
+
 /**
  * Load agents from a directory.
  */
-async function loadAgentsFromDir(dir: string, source: AgentSource): Promise<AgentDefinition[]> {
+async function loadAgentsFromDir({ dir, source, ignoreModel }: AgentDirectory): Promise<AgentDefinition[]> {
 	const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
 	const files = entries
 		.filter(entry => (entry.isFile() || entry.isSymbolicLink()) && entry.name.endsWith(".md"))
@@ -48,7 +54,11 @@ async function loadAgentsFromDir(dir: string, source: AgentSource): Promise<Agen
 			const filePath = path.join(dir, file.name);
 			return fs
 				.readFile(filePath, "utf-8")
-				.then(content => parseAgent(filePath, content, source, "warn"))
+				.then(content => {
+					const agent = parseAgent(filePath, content, source, "warn");
+					if (ignoreModel) agent.model = undefined;
+					return agent;
+				})
 				.catch(error => {
 					logger.warn("Failed to read agent file", { filePath, error });
 					return null;
@@ -84,7 +94,7 @@ export async function discoverAgents(cwd: string, home: string = os.homedir()): 
 			path: path.resolve(entry.path),
 		}));
 
-	const orderedDirs: Array<{ dir: string; source: AgentSource }> = [];
+	const orderedDirs: AgentDirectory[] = [];
 	const project = projectDirs[0];
 	if (project) orderedDirs.push({ dir: project.path, source: "project" });
 	const user = userDirs[0];
@@ -113,18 +123,22 @@ export async function discoverAgents(cwd: string, home: string = os.homedir()): 
 		return a.scope === "project" ? -1 : 1;
 	});
 	for (const plugin of sortedPluginRoots) {
+		// Claude aliases such as "sonnet" and "opus" are not OMP model selectors.
+		// Leave the model unset so settings overrides or the parent session choose it.
 		const agentsDir = path.join(plugin.path, "agents");
-		orderedDirs.push({ dir: agentsDir, source: plugin.scope === "project" ? "project" : "user" });
+		orderedDirs.push({
+			dir: agentsDir,
+			source: plugin.scope === "project" ? "project" : "user",
+			ignoreModel: true,
+		});
 	}
 
 	const seen = new Set<string>();
-	const loadedAgents = (await Promise.all(orderedDirs.map(({ dir, source }) => loadAgentsFromDir(dir, source))))
-		.flat()
-		.filter(agent => {
-			if (seen.has(agent.name)) return false;
-			seen.add(agent.name);
-			return true;
-		});
+	const loadedAgents = (await Promise.all(orderedDirs.map(loadAgentsFromDir))).flat().filter(agent => {
+		if (seen.has(agent.name)) return false;
+		seen.add(agent.name);
+		return true;
+	});
 
 	const bundledAgents = loadBundledAgents().filter(agent => {
 		if (seen.has(agent.name)) return false;

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -37,10 +37,16 @@ export interface DiscoveryResult {
 	projectAgentsDir: string | null;
 }
 
+interface AgentDirectory {
+	dir: string;
+	source: AgentSource;
+	ignoreModel?: boolean;
+}
+
 /**
  * Load agents from a directory.
  */
-async function loadAgentsFromDir(dir: string, source: AgentSource): Promise<AgentDefinition[]> {
+async function loadAgentsFromDir({ dir, source, ignoreModel }: AgentDirectory): Promise<AgentDefinition[]> {
 	const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
 	const files = entries
 		.filter(entry => (entry.isFile() || entry.isSymbolicLink()) && entry.name.endsWith(".md"))
@@ -49,7 +55,11 @@ async function loadAgentsFromDir(dir: string, source: AgentSource): Promise<Agen
 			const filePath = path.join(dir, file.name);
 			return fs
 				.readFile(filePath, "utf-8")
-				.then(content => parseAgent(filePath, content, source, "warn"))
+				.then(content => {
+					const agent = parseAgent(filePath, content, source, "warn");
+					if (ignoreModel) agent.model = undefined;
+					return agent;
+				})
 				.catch(error => {
 					logger.warn("Failed to read agent file", { filePath, error });
 					return null;
@@ -90,7 +100,7 @@ export async function discoverAgents(
 			path: path.resolve(entry.path),
 		}));
 
-	const orderedDirs: Array<{ dir: string; source: AgentSource }> = [];
+	const orderedDirs: AgentDirectory[] = [];
 	const project = projectDirs[0];
 	if (project) orderedDirs.push({ dir: project.path, source: "project" });
 	const user = userDirs[0];
@@ -116,18 +126,22 @@ export async function discoverAgents(
 		return a.scope === "project" ? -1 : 1;
 	});
 	for (const plugin of sortedPluginRoots) {
+		// Claude aliases such as "sonnet" and "opus" are not OMP model selectors.
+		// Leave the model unset so settings overrides or the parent session choose it.
 		const agentsDir = path.join(plugin.path, "agents");
-		orderedDirs.push({ dir: agentsDir, source: plugin.scope === "project" ? "project" : "user" });
+		orderedDirs.push({
+			dir: agentsDir,
+			source: plugin.scope === "project" ? "project" : "user",
+			ignoreModel: true,
+		});
 	}
 
 	const seen = new Set<string>();
-	const loadedAgents = (await Promise.all(orderedDirs.map(({ dir, source }) => loadAgentsFromDir(dir, source))))
-		.flat()
-		.filter(agent => {
-			if (seen.has(agent.name)) return false;
-			seen.add(agent.name);
-			return true;
-		});
+	const loadedAgents = (await Promise.all(orderedDirs.map(loadAgentsFromDir))).flat().filter(agent => {
+		if (seen.has(agent.name)) return false;
+		seen.add(agent.name);
+		return true;
+	});
 
 	const bundledAgents = loadBundledAgents().filter(agent => {
 		if (seen.has(agent.name)) return false;

--- a/packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts
+++ b/packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts
@@ -8,6 +8,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { disableProvider, enableProvider } from "@oh-my-pi/pi-coding-agent/capability";
 import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { resolveAgentModelPatterns } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import { clearClaudePluginRootsCache } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
@@ -16,6 +17,7 @@ const PLUGIN_AGENT_MD = [
 	"---",
 	"name: simplifier",
 	"description: A code simplifier agent from a Claude plugin",
+	"model: opus",
 	"---",
 	"Simplify code.",
 ].join("\n");
@@ -69,7 +71,14 @@ describe("discoverAgents — claude-plugins disabled provider", () => {
 
 	test("includes plugin agents when claude-plugins is enabled", async () => {
 		const { agents } = await discoverAgents(tempHome, tempHome);
-		expect(agents.map(a => a.name)).toContain("simplifier");
+		const agent = agents.find(candidate => candidate.name === "simplifier");
+		expect(agent).toBeDefined();
+		expect(
+			resolveAgentModelPatterns({
+				agentModel: agent?.model,
+				activeModelPattern: "openai-codex/gpt-5.6-sol",
+			}),
+		).toEqual(["openai-codex/gpt-5.6-sol"]);
 	});
 
 	test("excludes plugin agents when claude-plugins is disabled", async () => {

--- a/packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts
+++ b/packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts
@@ -15,6 +15,7 @@ import {
 	enableUserSource,
 } from "@oh-my-pi/pi-coding-agent/capability";
 import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { resolveAgentModelPatterns } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import { clearClaudePluginRootsCache } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
@@ -23,6 +24,7 @@ const PLUGIN_AGENT_MD = [
 	"---",
 	"name: simplifier",
 	"description: A code simplifier agent from a Claude plugin",
+	"model: opus",
 	"---",
 	"Simplify code.",
 ].join("\n");
@@ -89,7 +91,14 @@ describe("discoverAgents — claude-plugins disabled provider", () => {
 	test("includes plugin agents once claude-plugins is opted in", async () => {
 		enableUserSource("claude-plugins");
 		const { agents } = await discoverAgents(tempHome, tempHome);
-		expect(agents.map(a => a.name)).toContain("simplifier");
+		const agent = agents.find(candidate => candidate.name === "simplifier");
+		expect(agent).toBeDefined();
+		expect(
+			resolveAgentModelPatterns({
+				agentModel: agent?.model,
+				activeModelPattern: "openai-codex/gpt-5.6-sol",
+			}),
+		).toEqual(["openai-codex/gpt-5.6-sol"]);
 	});
 
 	test("disabledProviders wins over the opt-in", async () => {


### PR DESCRIPTION
## Repro
A Claude marketplace registry fixture exposing an agent with `model: opus` reproduced the override on current `main`: `bun test packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts` failed because discovery returned `["opus"]` instead of leaving the imported model unset.

## Cause
`discoverAgents()` in `packages/coding-agent/src/task/discovery.ts` loaded marketplace `agents/*.md` through the generic `loadAgentsFromDir()` path, so `parseAgent()` preserved Claude Code’s provider-specific model frontmatter and `resolveAgentModelPatterns()` treated it as an OMP selector ahead of the active parent model.

## Fix
- Mark Claude marketplace agent directories as foreign-model sources and discard their imported model field during discovery.
- Preserve the existing settings-override and active-parent fallback path for the resulting agent.
- Extend the marketplace discovery regression fixture and changelog.

## Verification
`bun test packages/coding-agent/test/discovery/agent-discovery-disabled-providers.test.ts packages/coding-agent/test/task/discovery.test.ts packages/coding-agent/test/model-resolver.test.ts` — 153 passed, 0 failed. LSP diagnostics are clean for both changed TypeScript files.

Fixes #7966