### PR TITLE
fix(extensibility): restore custom command arktype namespace

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored the omptype module namespace exposed as `api.arktype` to custom commands, preserving `api.arktype.type(...)` compatibility ([#7968](https://github.com/can1357/oh-my-pi/issues/7968)).
+
 ## [17.2.11] - 2026-08-07
 
 ### Added

--- a/packages/coding-agent/src/extensibility/custom-commands/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/loader.ts
@@ -6,7 +6,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { type } from "@oh-my-pi/omptype";
+import * as arktype from "@oh-my-pi/omptype";
 import * as zod from "@oh-my-pi/omptype/zod";
 import { getAgentDir, getProjectDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import { getConfigDirs } from "../../config";
@@ -187,7 +187,7 @@ export async function loadCustomCommands(options: LoadCustomCommandsOptions = {}
 		exec: (command: string, args: string[], execOptions) =>
 			execCommand(command, args, execOptions?.cwd ?? cwd, execOptions),
 		typebox,
-		arktype: type,
+		arktype,
 		zod,
 		pi: PiCodingAgent,
 	};

--- a/packages/coding-agent/src/extensibility/custom-commands/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/types.ts
@@ -5,7 +5,7 @@
  * Unlike markdown commands which expand to prompts, custom commands can execute
  * arbitrary logic with full access to the hook context.
  */
-import type { type as ArkType } from "@oh-my-pi/omptype";
+import type * as arktype from "@oh-my-pi/omptype";
 import type * as TypeBox from "@oh-my-pi/omptype/typebox";
 import type * as zod from "@oh-my-pi/omptype/zod";
 import type { ExecOptions, ExecResult, HookCommandContext } from "../../extensibility/hooks/types";
@@ -25,8 +25,8 @@ export interface CustomCommandAPI {
 	exec(command: string, args: string[], options?: ExecOptions): Promise<ExecResult>;
 	/** Injected TypeBox shim (legacy/compat). */
 	typebox: typeof TypeBox;
-	/** Injected omptype schema builder for custom commands. */
-	arktype: typeof ArkType;
+	/** Injected omptype module for custom command schemas. */
+	arktype: typeof arktype;
 	/** Injected Zod-compatible omptype builder for custom commands. */
 	zod: typeof zod;
 	/** Injected pi-coding-agent exports */

--- a/packages/coding-agent/test/extensibility/custom-command-loader.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-command-loader.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadCustomCommands } from "../../src/extensibility/custom-commands/loader";
+
+let tempRoot: string | undefined;
+
+afterEach(async () => {
+	if (tempRoot) {
+		await fs.rm(tempRoot, { recursive: true, force: true });
+		tempRoot = undefined;
+	}
+});
+
+it("preserves the omptype module namespace in the custom command API", async () => {
+	tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-custom-command-loader-"));
+	const commandDir = path.join(tempRoot, "commands", "namespace-schema");
+	await fs.mkdir(commandDir, { recursive: true });
+	await Bun.write(
+		path.join(commandDir, "index.ts"),
+		`export default api => {
+	const schema = api.arktype.type({ note: api.arktype.type("string") });
+	const parsed = schema.assert({ note: "schema built through namespace" });
+	return {
+		name: "namespace_schema",
+		description: parsed.note,
+		async execute() {
+			const next = schema.assert({ note: "ok" });
+			return next.note;
+		},
+	};
+};`,
+	);
+
+	const result = await loadCustomCommands({ cwd: tempRoot, agentDir: tempRoot });
+	const loaded = result.commands.find(entry => entry.command.name === "namespace_schema");
+
+	expect(result.errors).toEqual([]);
+	expect(loaded?.command.description).toBe("schema built through namespace");
+});

--- a/packages/coding-agent/test/extensibility/custom-commands/ci-green.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/ci-green.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { type } from "@oh-my-pi/omptype";
+import * as arktype from "@oh-my-pi/omptype";
 import type * as TypeBox from "@oh-my-pi/omptype/typebox";
 import * as zod from "@oh-my-pi/omptype/zod";
 import * as piCodingAgent from "@oh-my-pi/pi-coding-agent";
@@ -22,7 +22,7 @@ function createApi(): CustomCommandAPI {
 			killed: false,
 		}),
 		typebox: {} as unknown as typeof TypeBox,
-		arktype: type,
+		arktype,
 		zod,
 		pi: piCodingAgent,
 	};


### PR DESCRIPTION
## Repro
A temporary custom command loaded through `loadCustomCommands()` calls `api.arktype.type({ note: api.arktype.type("string") })`; `bun /tmp/omp-repro-7968.ts` failed on the pre-fix tree with `TypeError: api.arktype.type is not a function` and exit code 1.

## Cause
`packages/coding-agent/src/extensibility/custom-commands/loader.ts` changed `loadCustomCommands()` from injecting the `@oh-my-pi/omptype` module namespace to injecting only its `type` builder in the 17.2.10 dependency migration. `CustomCommandAPI.arktype` changed with it, removing the established `.type` member at runtime and in declarations.

## Fix
- Restore the omptype module namespace in `loadCustomCommands()` and `CustomCommandAPI`.
- Add a loader regression test that constructs and executes schema validation through `api.arktype.type(...)`.
- Document the restored compatibility in the coding-agent changelog.

## Verification
`bun test test/extensibility/custom-command-loader.test.ts test/extensibility/custom-commands/ci-green.test.ts` passed 3 tests with 0 failures. `bun run check` passed in `packages/coding-agent`. The original `bun /tmp/omp-repro-7968.ts` scenario completed successfully after the fix.

Fixes #7968