### PR TITLE
feat(statusline): show upstream ahead/behind in the git segment

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -363,6 +363,7 @@ export class StatusLineComponent implements Component {
 
 	// Git status caching (1s TTL)
 	#cachedGitStatus: { staged: number; unstaged: number; untracked: number } | null = null;
+	#cachedGitRemote: { ahead: number; behind: number } | null = null;
 	#cachedGitStatusCwd: string | undefined = undefined;
 	#gitStatusLastFetch = 0;
 	#gitStatusInFlightCwd: string | undefined = undefined;
@@ -918,18 +919,32 @@ export class StatusLineComponent implements Component {
 
 		(async () => {
 			let nextStatus: { staged: number; unstaged: number; untracked: number } | null = null;
+			let nextRemote: { ahead: number; behind: number } | null = null;
 			try {
 				nextStatus = await git.status.summary(gitCwd);
+				// Upstream divergence is only meaningful where git itself found a
+				// repository, and only worth computing if the segment option is
+				// enabled; skip the subprocess otherwise.
+				const showRemote = this.#resolveSettings().segmentOptions?.git?.showRemote ?? true;
+				nextRemote = nextStatus !== null && showRemote ? await git.status.divergence(gitCwd) : null;
 			} catch {
 				nextStatus = null;
+				nextRemote = null;
 			} finally {
 				if (this.#gitStatusInFlightCwd === gitCwd) {
 					const prev = this.#cachedGitStatusCwd === gitCwd ? this.#cachedGitStatus : null;
+					const prevRemote = this.#cachedGitStatusCwd === gitCwd ? this.#cachedGitRemote : null;
 					this.#cachedGitStatus = nextStatus;
+					this.#cachedGitRemote = nextRemote;
 					this.#cachedGitStatusCwd = gitCwd;
 					this.#gitStatusLastFetch = Date.now();
 					this.#gitStatusInFlightCwd = undefined;
-					if (!this.#disposed && this.#onBranchChange && JSON.stringify(prev) !== JSON.stringify(nextStatus)) {
+					if (
+						!this.#disposed &&
+						this.#onBranchChange &&
+						(JSON.stringify(prev) !== JSON.stringify(nextStatus) ||
+							JSON.stringify(prevRemote) !== JSON.stringify(nextRemote))
+					) {
 						this.#onBranchChange();
 					}
 				}
@@ -937,6 +952,17 @@ export class StatusLineComponent implements Component {
 		})();
 
 		return this.#cachedGitStatusCwd === gitCwd ? this.#cachedGitStatus : null;
+	}
+
+	/**
+	 * Upstream divergence for the effective git cwd, from the same throttled
+	 * fetch as {@link #getGitStatus} (never spawns its own subprocess; returns
+	 * the cached value once the status refresh has resolved it).
+	 */
+	#getGitRemote(effectiveGitCwd?: string): { ahead: number; behind: number } | null {
+		if (!this.#gitEnabled()) return null;
+		const gitCwd = effectiveGitCwd ?? this.#resolveActiveRepoCache().effectiveGitCwd;
+		return this.#cachedGitStatusCwd === gitCwd ? this.#cachedGitRemote : null;
 	}
 
 	// Resolve (and cache per cwd) the jj workspace root, resetting both jj caches
@@ -1552,6 +1578,9 @@ export class StatusLineComponent implements Component {
 			? ((gitHeadIsJjLike ? this.#getJjStatus(activeRepoCache.effectiveGitCwd) : null) ??
 				this.#getGitStatus(activeRepoCache.effectiveGitCwd))
 			: null;
+		// Upstream divergence rides the git-status refresh; jj workspaces have no
+		// tracking branch to compare against, so they report null.
+		const gitRemote = includeGit && !gitHeadIsJjLike ? this.#getGitRemote(activeRepoCache.effectiveGitCwd) : null;
 		const gitPr = includePr ? this.#lookupPr(activeRepoCache.effectiveGitCwd) : null;
 		return {
 			session: this.session,
@@ -1580,6 +1609,7 @@ export class StatusLineComponent implements Component {
 			git: {
 				branch: gitBranch,
 				status: gitStatus,
+				remote: gitRemote,
 				pr: gitPr,
 			},
 			worktree: activeRepoCache.worktree,

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -315,8 +315,8 @@ const pathSegment: StatusLineSegment = {
 const gitSegment: StatusLineSegment = {
 	id: "git",
 	render(ctx) {
-		const { branch, status } = ctx.git;
-		if (!branch && !status) return { content: "", visible: false };
+		const { branch, status, remote } = ctx.git;
+		if (!branch && !status && !remote) return { content: "", visible: false };
 
 		const opts = ctx.options.git ?? {};
 		const gitStatus = status;
@@ -326,6 +326,24 @@ const gitSegment: StatusLineSegment = {
 		let content = "";
 		if (showBranch && branch) {
 			content = withIcon(theme.icon.branch, branch);
+		}
+
+		// Upstream divergence markers (`↑N` ahead / `↓N` behind) — a few extra
+		// glyphs after the branch so un-pushed / un-pulled state is visible at a
+		// glance. Only rendered when non-zero; adds nothing for in-sync branches.
+		if (opts.showRemote !== false && ctx.git.remote) {
+			const { ahead, behind } = ctx.git.remote;
+			const markers: string[] = [];
+			if (ahead > 0) markers.push(theme.fg("statusLineGitClean", `↑${ahead}`));
+			if (behind > 0) markers.push(theme.fg("statusLineGitDirty", `↓${behind}`));
+			if (markers.length > 0) {
+				const markerText = markers.join(" ");
+				if (!content && showBranch === false) {
+					content = withIcon(theme.icon.git, markerText);
+				} else {
+					content += content ? ` ${markerText}` : markerText;
+				}
+			}
 		}
 
 		// Add status indicators

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -17,7 +17,14 @@ export interface CollabStatus {
 export interface StatusLineSegmentOptions {
 	model?: { showThinkingLevel?: boolean };
 	path?: { abbreviate?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
-	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
+	git?: {
+		showBranch?: boolean;
+		showStaged?: boolean;
+		showUnstaged?: boolean;
+		showUntracked?: boolean;
+		/** Appends compact upstream divergence (`↑N`/`↓N`) after the branch name. */
+		showRemote?: boolean;
+	};
 	time?: { format?: "12h" | "24h"; showSeconds?: boolean };
 }
 
@@ -109,6 +116,9 @@ export interface SegmentContext {
 	git: {
 		branch: string | null;
 		status: { staged: number; unstaged: number; untracked: number } | null;
+		/** Upstream divergence (`@{upstream}` diff). Absent when unknown (no
+		 *  upstream, jj workspace, or the refresh has not resolved). */
+		remote?: { ahead: number; behind: number } | null;
 		pr: { number: number; url: string } | null;
 	};
 	/**

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -37,6 +37,16 @@ export interface GitStatusSummary {
 	untracked: number;
 }
 
+/**
+ * How many commits the current branch has drifted from its configured upstream
+ * (`@{upstream}`): `ahead` = local commits not on the remote, `behind` =
+ * remote commits not yet pulled. Both are 0 when the branch is in sync.
+ */
+export interface GitDivergence {
+	ahead: number;
+	behind: number;
+}
+
 export type HunkSelection = {
 	path: string;
 	hunks: { type: "all" } | { type: "indices"; indices: number[] } | { type: "lines"; start: number; end: number };
@@ -1318,6 +1328,28 @@ export const status = Object.assign(
 		},
 		/** Parse porcelain status text into counts. */
 		parse: parseStatusPorcelain,
+		/**
+		 * Divergence of HEAD from its configured upstream (`@{upstream}`), or
+		 * `null` when the branch has no upstream, HEAD is detached, or the repo
+		 * is bare — cases where there is nothing to compare against. This is a
+		 * local plumbing query (no network), so it is safe on the status-line
+		 * refresh cadence.
+		 */
+		async divergence(cwd: string, signal?: AbortSignal): Promise<GitDivergence | null> {
+			const result = await git(cwd, ["rev-list", "--left-right", "--count", "@{upstream}...HEAD"], {
+				readOnly: true,
+				signal,
+			});
+			if (result.exitCode !== 0) return null;
+			// `--left-right --count A...B` prints "<A-only> <B-only>" (one line):
+			// the first number counts commits reachable from the first listed
+			// ref but not the second, and vice versa. With A=`@{upstream}`,
+			// B=`HEAD`: first = behind, second = ahead. (Verified: an
+			// ahead=2/behind=0 branch prints "0 2".)
+			const [behind, ahead] = result.stdout.trim().split(/\s+/).map(Number);
+			if (!Number.isFinite(behind) || !Number.isFinite(ahead)) return null;
+			return ahead > 0 || behind > 0 ? { ahead, behind } : null;
+		},
 	},
 );
 

--- a/packages/coding-agent/test/autoresearch-state.test.ts
+++ b/packages/coding-agent/test/autoresearch-state.test.ts
@@ -432,7 +432,7 @@ function createCommandHarness(
 			if (result.code !== 0) throw new Error(result.stderr || "git status failed");
 			return result.stdout;
 		},
-		{ parse: git.status.parse, summary: git.status.summary },
+		{ parse: git.status.parse, summary: git.status.summary, divergence: () => Promise.resolve(null) },
 	);
 	vi.spyOn(git, "status").mockImplementation(mockStatus);
 	vi.spyOn(git.ref, "exists").mockImplementation(async (_workDir, refName) => {

--- a/packages/coding-agent/test/status-line-remote.test.ts
+++ b/packages/coding-agent/test/status-line-remote.test.ts
@@ -1,0 +1,179 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
+import { $ } from "bun";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
+
+/** Minimal SegmentContext factory — only the fields the git segment reads. */
+function createContext(overrides?: {
+	branch?: string | null;
+	remote?: { ahead: number; behind: number } | null;
+	showRemote?: boolean;
+	dirty?: boolean;
+}): SegmentContext {
+	return {
+		session: {} as SegmentContext["session"],
+		width: 120,
+		compactThinkingLevel: false,
+		options: {
+			git: overrides?.showRemote === undefined ? {} : { showRemote: overrides.showRemote },
+		},
+		planMode: null,
+		loopMode: null,
+		prewalk: null,
+		goalMode: null,
+		vibeMode: null,
+		collab: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			orchestrationInput: 0,
+			orchestrationOutput: 0,
+			orchestrationCacheRead: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		},
+		contextPercent: 0,
+		contextTokens: 0,
+		contextWindow: 0,
+		autoCompactEnabled: false,
+		subagentCount: 0,
+		activeMs: 0,
+		activeRepo: null,
+		worktree: null,
+		git: {
+			branch: overrides?.branch ?? null,
+			status: overrides?.dirty ? { staged: 0, unstaged: 1, untracked: 0 } : null,
+			remote: overrides?.remote ?? null,
+			pr: null,
+		},
+		usage: null,
+	};
+}
+
+function withIcon(icon: string, text: string): string {
+	return icon ? `${icon} ${text}` : text;
+}
+
+describe("status line git segment: upstream divergence markers", () => {
+	it("appends an ahead marker after the branch when only ahead", () => {
+		const rendered = renderSegment("git", createContext({ branch: "main", remote: { ahead: 2, behind: 0 } }));
+		expect(rendered.visible).toBe(true);
+		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.branch, "main ↑2"));
+	});
+
+	it("appends a behind marker when only behind", () => {
+		const rendered = renderSegment("git", createContext({ branch: "main", remote: { ahead: 0, behind: 3 } }));
+		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.branch, "main ↓3"));
+	});
+
+	it("shows both markers when diverged, positioned before the dirty counts", () => {
+		const rendered = renderSegment(
+			"git",
+			createContext({ branch: "main", remote: { ahead: 2, behind: 1 }, dirty: true }),
+		);
+		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.branch, "main ↑2 ↓1 *1"));
+	});
+
+	it("adds nothing for an in-sync branch (remote null)", () => {
+		const rendered = renderSegment("git", createContext({ branch: "main", remote: null }));
+		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.branch, "main"));
+	});
+
+	it("is hidden by git.showRemote: false", () => {
+		const rendered = renderSegment(
+			"git",
+			createContext({ branch: "main", remote: { ahead: 5, behind: 0 }, showRemote: false }),
+		);
+		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.branch, "main"));
+	});
+
+	it("renders markers alone when the branch label is hidden", () => {
+		const ctx = createContext({ remote: { ahead: 4, behind: 2 } });
+		ctx.options = { git: { showBranch: false } };
+		const rendered = renderSegment("git", ctx);
+		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.git, "↑4 ↓2"));
+	});
+
+	it("combines markers and dirty counts under a git icon when the branch label is hidden", () => {
+		const ctx = createContext({ remote: { ahead: 4, behind: 0 }, dirty: true });
+		ctx.options = { git: { showBranch: false } };
+		const rendered = renderSegment("git", ctx);
+		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.git, "↑4 *1"));
+	});
+});
+
+describe("git.status.divergence against a real repository", () => {
+	it("reports ahead / behind / in-sync /.upstream-less", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-statusline-remote-"));
+		const origin = path.join(dir, "origin.git");
+		const work1 = path.join(dir, "work1");
+		const work2 = path.join(dir, "work2");
+		try {
+			await $`git init --bare --initial-branch=main origin.git`.cwd(dir).quiet();
+			await $`git init --initial-branch=main work1`.cwd(dir).quiet();
+			await $`git config user.email tester@example.com`.cwd(work1).quiet();
+			await $`git config user.name Tester`.cwd(work1).quiet();
+			await $`git config commit.gpgsign false`.cwd(work1).quiet();
+			await $`git remote add origin ${origin}`.cwd(work1).quiet();
+			const commit = async (msg: string) => {
+				await $`git add -A`.cwd(work1).quiet();
+				await $`git commit -qm ${msg}`.cwd(work1).quiet();
+			};
+
+			// Baseline: one commit pushed with an upstream set -> in sync -> null.
+			await fs.writeFile(path.join(work1, "a.txt"), "a");
+			await commit("base");
+			await $`git push -q -u origin HEAD:main`.cwd(work1).quiet();
+			expect(await git.status.divergence(work1)).toBeNull();
+
+			// Two unpushed local commits -> ahead.
+			await fs.writeFile(path.join(work1, "b.txt"), "b");
+			await commit("one");
+			await fs.writeFile(path.join(work1, "c.txt"), "c");
+			await commit("two");
+			expect(await git.status.divergence(work1)).toEqual({ ahead: 2, behind: 0 });
+
+			// A remote-only commit (pushed from a sibling clone) -> diverged.
+			await $`git clone -q origin.git work2`.cwd(dir).quiet();
+			await $`git config user.email tester2@example.com`.cwd(work2).quiet();
+			await $`git config user.name Tester2`.cwd(work2).quiet();
+			await $`git config commit.gpgsign false`.cwd(work2).quiet();
+			await fs.writeFile(path.join(work2, "d.txt"), "d");
+			await $`git add -A`.cwd(work2).quiet();
+			await $`git commit -qm remote`.cwd(work2).quiet();
+			await $`git push -q origin HEAD:main`.cwd(work2).quiet();
+			await $`git fetch -q origin`.cwd(work1).quiet();
+			expect(await git.status.divergence(work1)).toEqual({ ahead: 2, behind: 1 });
+
+			// A branch without any upstream -> nothing to compare -> null.
+			await $`git checkout -q -b feature`.cwd(work1).quiet();
+			expect(await git.status.divergence(work1)).toBeNull();
+
+			// Detached HEAD (@{upstream} has no meaning) -> null.
+			await $`git checkout -q --detach`.cwd(work1).quiet();
+			expect(await git.status.divergence(work1)).toBeNull();
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	}, 30_000);
+});

--- a/packages/coding-agent/test/status-line-vcs-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-vcs-refresh.test.ts
@@ -11,7 +11,7 @@
  * requests a repaint via #onBranchChange. (Post-dispose suppression of the
  * same callback is covered by status-line-dispose-async-leak.test.ts.)
  */
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import { EventEmitter } from "node:events";
 import * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
@@ -25,10 +25,18 @@ import type { GitHeadState, GitRefHead, GitRepository } from "@oh-my-pi/pi-codin
 import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
 import * as jj from "@oh-my-pi/pi-coding-agent/utils/jj";
 import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+import { $ } from "bun";
 
 type GitStatus = { staged: number; unstaged: number; untracked: number };
 
 const originalProjectDir = getProjectDir();
+
+beforeEach(() => {
+	// upstream-divergence rides the same throttled git refresh; resolved here so
+	// the controlled-promise timing of each test is not perturbed by a real
+	// subprocess. (Its value is not asserted in this file.)
+	vi.spyOn(git.status, "divergence").mockResolvedValue(null);
+});
 
 beforeAll(async () => {
 	resetSettingsForTest();
@@ -119,6 +127,107 @@ describe("StatusLineComponent repaints when an async VCS fetch resolves", () => 
 		expect(onBranchChange).toHaveBeenCalled();
 		component.dispose();
 	});
+
+	it("fires #onBranchChange when upstream divergence changes while git status stays identical", async () => {
+		// The divergence cache participates in the repaint decision on its own: a
+		// fetch that only moves the ahead/behind counters (git status unchanged)
+		// must still request a repaint so the new `↑N` reaches the screen
+		// without an unrelated re-render.
+		vi.spyOn(git.head, "resolveSync").mockReturnValue(fakeRefHead);
+		vi.spyOn(git.branch, "default").mockReturnValue(Promise.withResolvers<string | null>().promise);
+		const fixedStatus: GitStatus = { staged: 0, unstaged: 0, untracked: 0 };
+		vi.spyOn(git.status, "summary").mockResolvedValue(fixedStatus);
+		vi.spyOn(git.status, "divergence")
+			.mockResolvedValueOnce(null) // in sync on the cold paint
+			.mockResolvedValueOnce({ ahead: 2, behind: 0 }); // a later fetch introduced commits
+
+		let now = 1_000_000;
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const onBranchChange = vi.fn();
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(onBranchChange);
+
+		component.getTopBorder(80); // cold paint: status same, divergence null
+		await Promise.resolve();
+		await Promise.resolve();
+		const callsAfterColdPaint = onBranchChange.mock.calls.length;
+
+		now += 1_001; // step past the 1s status-line throttle
+		component.getTopBorder(80); // refresh #2: status identical, divergence changed
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onBranchChange.mock.calls.length).toBeGreaterThan(callsAfterColdPaint);
+		component.dispose();
+	});
+
+	it("skips the divergence subprocess when git.showRemote is disabled", async () => {
+		vi.spyOn(git.head, "resolveSync").mockReturnValue(fakeRefHead);
+		vi.spyOn(git.branch, "default").mockReturnValue(Promise.withResolvers<string | null>().promise);
+		const statusSpy = vi.spyOn(git.status, "summary").mockResolvedValue({ staged: 0, unstaged: 0, untracked: 0 });
+		const divSpy = vi.spyOn(git.status, "divergence").mockResolvedValue(null);
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings({ ...gitSegment, segmentOptions: { git: { showRemote: false } } });
+		component.watchBranch(vi.fn());
+		component.getTopBorder(80);
+		// Flush the (stubbed) status fetch: it must resolve and complete the
+		// throttled block *without* ever reaching the divergence subprocess.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(statusSpy).toHaveBeenCalled();
+		expect(divSpy).not.toHaveBeenCalled();
+		component.dispose();
+	});
+
+	it("renders upstream divergence from a real repository in the top border", async () => {
+		// Real end-to-end (no mocks): a repo with unpushed commits must show `↑N`
+		// in the rendered top border once the throttled refresh resolves. Covers
+		// git.status.divergence -> component cache -> gitSegment.render together.
+		// We await #onBranchChange (the real git-fetch signal) rather than fake
+		// timers: completion depends on OS subprocesses that fake time cannot
+		// advance, so this is the rare case where an event-driven wait is right.
+		vi.restoreAllMocks(); // lift the beforeEach divergence stub for a real fetch
+
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-statusline-vcs-div-"));
+		const origin = path.join(dir, "origin.git");
+		const work = path.join(dir, "work");
+		try {
+			await $`git init --bare --initial-branch=main origin.git`.cwd(dir).quiet();
+			await $`git init --initial-branch=main work`.cwd(dir).quiet();
+			await $`git config user.email tester@example.com`.cwd(work).quiet();
+			await $`git config user.name Tester`.cwd(work).quiet();
+			await $`git config commit.gpgsign false`.cwd(work).quiet();
+			await $`git remote add origin ${origin}`.cwd(work).quiet();
+			await fs.writeFile(path.join(work, "a.txt"), "a");
+			await $`git add -A`.cwd(work).quiet();
+			await $`git commit -qm base`.cwd(work).quiet();
+			await $`git push -qu origin HEAD:main`.cwd(work).quiet();
+			await fs.writeFile(path.join(work, "b.txt"), "b");
+			await $`git add -A`.cwd(work).quiet();
+			await $`git commit -qm one`.cwd(work).quiet();
+			await fs.writeFile(path.join(work, "c.txt"), "c");
+			await $`git add -A`.cwd(work).quiet();
+			await $`git commit -qm two`.cwd(work).quiet();
+
+			setProjectDir(work);
+			const refreshDone = Promise.withResolvers<void>();
+			const component = new StatusLineComponent(makeSession());
+			component.updateSettings(gitSegment);
+			component.watchBranch(() => refreshDone.resolve());
+			component.getTopBorder(80); // cold paint starts the real refresh
+			await refreshDone.promise; // the real git fetch has resolved + cached
+			const border = Bun.stripANSI(component.getTopBorder(80).content);
+			expect(border).toContain("↑2");
+			component.dispose();
+		} finally {
+			setProjectDir(originalProjectDir);
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	}, 15_000);
 
 	it("fires #onBranchChange when the jj label resolves on the cold paint", async () => {
 		vi.spyOn(git.head, "resolveSync").mockReturnValue(null); // no git branch -> jj overlay


### PR DESCRIPTION
## Summary

Implements #7971: the git status segment now shows upstream divergence right after the branch name.

- ` main ↑2` — 2 commits not yet pushed (ahead)
- ` main ↓3` — 3 commits not yet pulled (behind)
- ` main ↑1 ↓4` — both

## How it works

`git.status.divergence()` runs a single local `rev-list --left-right --count @{upstream}...HEAD` — no network traffic, and it reuses the existing 1s-sampled status refresh instead of adding a new timer. It returns `null` (and nothing renders) when there is no upstream (fresh branch), HEAD is detached, the repo is bare, or the upstream branch is gone.

Rendering: the markers go after the branch and before the existing `*N +N ?N` working-tree counters, reusing the `statusLineGitClean` / `statusLineGitDirty` theme colors. In-sync branches render exactly as before. The upstream query is gated to when git actually reported a repository and `statusLine.segmentOptions.git.showRemote` isn't `false` — a new option, default **on**.

## Notes

- Default is on; set `git.showRemote: false` to hide it. If a quieter default is preferred for `minimal`-style setups, that's a one-line change — happy to flip it (see the issue thread).
- The divergence cache rides the existing throttled refresh and requests a repaint when divergence changes even if the working-tree status stays identical.

## Tests

The full status-line suite is green locally: marker rendering (ahead / behind / diverged / hidden-branch / disabled), real-repo git integration (ahead, diverged, in-sync, no-upstream, detached HEAD), and component behavior (repaint on divergence change, fetch skipped when not a repo or when `showRemote` is off). Package type-check and linter pass.
