### PR TITLE
feat(coding-agent): add unified agent activity view

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -855,6 +855,9 @@
 
 - Removed the `resolveAgentModelSource` model-resolver export, whose only use was being fed to `resolveExplicitModelRole`. Replaced by `resolveAgentModelSelection`, which returns the expanded `patterns` and the pre-expansion `role` together so a spawn path cannot derive one without the other ([#7910](https://github.com/can1357/oh-my-pi/pull/7910) by [@enieuwy](https://github.com/enieuwy)).
 - A run is now attributed to the model that actually produced its output, not whichever model the session was last pointed at. A retry fallback that errored on its first request — an exhausted quota, a hard provider error — was credited with the whole run in the Agent Hub row and the settled task result, even when the previous model did every turn. Sessions expose the serving model directly, holding the last model that produced output while a candidate is armed but unproven, and transcript-derived history stops at the newest turn that produced output.
+### Added
+
+- Added an Activity view to the Agent Hub: a bounded, searchable, filterable multi-agent timeline over live progress and persisted transcripts, with `/hub` as the live-operations entry point while `/agents` keeps Control Center semantics.
 
 ## [17.2.12] - 2026-08-08
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an Activity view to the Agent Hub: a bounded, searchable, filterable multi-agent timeline over live progress and persisted transcripts, with `/hub` as the live-operations entry point while `/agents` keeps Control Center semantics.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/activity/index.ts
+++ b/packages/coding-agent/src/activity/index.ts
@@ -156,12 +156,21 @@ function compareRows(a: AgentActivityRow, b: AgentActivityRow): number {
 	return a.timestamp - b.timestamp || a.id.localeCompare(b.id);
 }
 
-function boundedPush(rows: AgentActivityRow[], row: AgentActivityRow): void {
+function boundedPush(rows: AgentActivityRow[], row: AgentActivityRow): AgentActivityRow[] {
 	const existing = rows.findIndex(candidate => candidate.id === row.id);
 	if (existing >= 0) rows[existing] = row;
 	else rows.push(row);
 	rows.sort(compareRows);
-	if (rows.length > MAX_ROWS_PER_AGENT) rows.splice(0, rows.length - MAX_ROWS_PER_AGENT);
+	if (rows.length <= MAX_ROWS_PER_AGENT) return [];
+	return rows.splice(0, rows.length - MAX_ROWS_PER_AGENT);
+}
+
+function pruneToolRows(state: TranscriptState, evicted: readonly AgentActivityRow[]): void {
+	if (evicted.length === 0) return;
+	const retained = new Set(state.rows.map(row => row.id));
+	for (const [toolCallId, row] of state.toolRows) {
+		if (!retained.has(row.id)) state.toolRows.delete(toolCallId);
+	}
 }
 
 export function activityRowsFromProgress(progress: AgentProgress, lastUpdate = Date.now()): AgentActivityRow[] {
@@ -260,6 +269,11 @@ export class AgentActivityIndex {
 		await this.#syncLocal(agentId, sessionFile);
 	}
 
+	/** Test/diag helper: number of toolCallId mappings retained for an agent. */
+	retainedToolMappings(agentId: string): number {
+		return this.#states.get(agentId)?.toolRows.size ?? 0;
+	}
+
 	recent(agentId: string, limit = 12): AgentActivityRow[] {
 		const persisted = this.#states.get(agentId)?.rows ?? [];
 		const live = this.#liveRows.get(agentId) ?? [];
@@ -348,7 +362,12 @@ export class AgentActivityIndex {
 			state = { offset: 0, mtimeMs: 0, pending: "", rows: [], toolRows: new Map() };
 			this.#states.set(agentId, state);
 		}
-		const result = await this.#remote?.readTranscript(agentId, state.offset);
+		let result: AgentActivityTranscript | null | undefined;
+		try {
+			result = await this.#remote?.readTranscript(agentId, state.offset);
+		} catch {
+			return;
+		}
 		if (!result || result.error) return;
 		if (result.newSize < state.offset) {
 			state.offset = 0;
@@ -387,17 +406,20 @@ export class AgentActivityIndex {
 			if (message.role === "assistant") {
 				const response = textContent(message.content);
 				if (response) {
-					boundedPush(state.rows, {
-						id: `${agentId}:response:${entry.id}`,
-						agentId,
-						timestamp,
-						kind: "response",
-						title: "Response",
-						summary: response,
-						status: message.isError ? "error" : "success",
-						entryId: entry.id,
-						source: "transcript",
-					});
+					pruneToolRows(
+						state,
+						boundedPush(state.rows, {
+							id: `${agentId}:response:${entry.id}`,
+							agentId,
+							timestamp,
+							kind: "response",
+							title: "Response",
+							summary: response,
+							status: message.isError ? "error" : "success",
+							entryId: entry.id,
+							source: "transcript",
+						}),
+					);
 					changed = true;
 				}
 				for (const call of toolBlocks(message.content)) {
@@ -415,7 +437,7 @@ export class AgentActivityIndex {
 						source: "transcript",
 					};
 					state.toolRows.set(call.id, row);
-					boundedPush(state.rows, row);
+					pruneToolRows(state, boundedPush(state.rows, row));
 					changed = true;
 				}
 				continue;
@@ -425,7 +447,8 @@ export class AgentActivityIndex {
 				if (!row) continue;
 				row.status = message.isError ? "error" : "success";
 				row.timestamp = Math.max(row.timestamp, timestamp);
-				if (!state.rows.includes(row)) boundedPush(state.rows, row);
+				if (!state.rows.includes(row)) pruneToolRows(state, boundedPush(state.rows, row));
+				state.toolRows.delete(message.toolCallId);
 				changed = true;
 			}
 		}

--- a/packages/coding-agent/src/activity/index.ts
+++ b/packages/coding-agent/src/activity/index.ts
@@ -1,0 +1,438 @@
+import type { Stats } from "node:fs";
+import * as fs from "node:fs/promises";
+import type { AgentProgress } from "../task/types";
+
+export type AgentActivityKind = "response" | "tool" | "irc" | "lifecycle";
+export type AgentActivityStatus = "pending" | "success" | "error" | "aborted";
+
+export interface AgentActivityRow {
+	id: string;
+	agentId: string;
+	timestamp: number;
+	kind: AgentActivityKind;
+	title: string;
+	summary: string;
+	status?: AgentActivityStatus;
+	entryId?: string;
+	toolCallId?: string;
+	toolName?: string;
+	from?: string;
+	to?: string;
+	replyTo?: string;
+	source: "live" | "transcript" | "irc";
+}
+
+export interface AgentActivityQuery {
+	agentIds?: ReadonlySet<string>;
+	kinds?: ReadonlySet<AgentActivityKind>;
+	search?: string;
+	before?: { timestamp: number; id: string };
+	limit?: number;
+}
+
+export interface AgentActivityTranscript {
+	text: string;
+	newSize: number;
+	error?: string;
+}
+
+export interface AgentActivityRemote {
+	readTranscript(agentId: string, fromByte: number): Promise<AgentActivityTranscript | null>;
+}
+
+interface TranscriptState {
+	path?: string;
+	offset: number;
+	mtimeMs: number;
+	pending: string;
+	rows: AgentActivityRow[];
+	toolRows: Map<string, AgentActivityRow>;
+}
+
+interface ActivityMessage {
+	role?: string;
+	timestamp?: number;
+	content?: unknown;
+	toolCallId?: string;
+	toolName?: string;
+	isError?: boolean;
+	customType?: string;
+	details?: unknown;
+}
+
+const INITIAL_TAIL_BYTES = 256 * 1024;
+const MAX_ROWS_PER_AGENT = 256;
+const DEFAULT_QUERY_LIMIT = 200;
+const MAX_QUERY_LIMIT = 2_000;
+
+function recordOf(value: unknown): Record<string, unknown> | undefined {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function timestampOf(value: unknown, fallback: number): number {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value !== "string") return fallback;
+	const parsed = Date.parse(value);
+	return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function oneLine(value: string): string {
+	return value
+		.replace(/[\r\n\t]+/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function textContent(content: unknown): string {
+	if (typeof content === "string") return oneLine(content);
+	if (!Array.isArray(content)) return "";
+	const parts: string[] = [];
+	for (const blockValue of content) {
+		const block = recordOf(blockValue);
+		if (block?.type === "text" && typeof block.text === "string") parts.push(block.text);
+	}
+	return oneLine(parts.join(" "));
+}
+
+function firstString(value: Record<string, unknown>, ...keys: string[]): string | undefined {
+	for (const key of keys) {
+		const candidate = value[key];
+		if (typeof candidate === "string" && candidate.trim()) return oneLine(candidate);
+	}
+	return undefined;
+}
+
+function argumentsSummary(toolName: string, value: unknown): string {
+	const args = recordOf(value) ?? {};
+	const intent = firstString(args, "i", "intent");
+	if (intent) return intent;
+	switch (toolName) {
+		case "read":
+			return firstString(args, "path") ?? "Read resource";
+		case "grep": {
+			const pattern = firstString(args, "pattern");
+			const path = firstString(args, "path");
+			return [pattern, path].filter(Boolean).join(" · ") || "Search text";
+		}
+		case "glob":
+			return firstString(args, "path") ?? "Map files";
+		case "bash":
+			return firstString(args, "command") ?? "Run command";
+		case "write":
+		case "edit":
+			return firstString(args, "path") ?? `${toolName === "write" ? "Write" : "Edit"} files`;
+		case "hub": {
+			const op = firstString(args, "op") ?? "operate";
+			const target = firstString(args, "to", "name", "from");
+			return target ? `${op} · ${target}` : op;
+		}
+		default: {
+			const common = firstString(args, "path", "query", "name", "task", "title");
+			if (common) return common;
+			try {
+				const encoded = oneLine(JSON.stringify(args));
+				return encoded === "{}" ? toolName : encoded;
+			} catch {
+				return toolName;
+			}
+		}
+	}
+}
+
+function toolBlocks(content: unknown): Array<{ id: string; name: string; args: unknown }> {
+	if (!Array.isArray(content)) return [];
+	const calls: Array<{ id: string; name: string; args: unknown }> = [];
+	for (const blockValue of content) {
+		const block = recordOf(blockValue);
+		if (block?.type !== "toolCall" || typeof block.id !== "string" || typeof block.name !== "string") continue;
+		calls.push({ id: block.id, name: block.name, args: block.arguments });
+	}
+	return calls;
+}
+
+function compareRows(a: AgentActivityRow, b: AgentActivityRow): number {
+	return a.timestamp - b.timestamp || a.id.localeCompare(b.id);
+}
+
+function boundedPush(rows: AgentActivityRow[], row: AgentActivityRow): void {
+	const existing = rows.findIndex(candidate => candidate.id === row.id);
+	if (existing >= 0) rows[existing] = row;
+	else rows.push(row);
+	rows.sort(compareRows);
+	if (rows.length > MAX_ROWS_PER_AGENT) rows.splice(0, rows.length - MAX_ROWS_PER_AGENT);
+}
+
+export function activityRowsFromProgress(progress: AgentProgress, lastUpdate = Date.now()): AgentActivityRow[] {
+	const rows: AgentActivityRow[] = [];
+	const recentTools = progress.recentTools ?? [];
+	for (let index = recentTools.length - 1; index >= 0; index--) {
+		const tool = recentTools[index]!;
+		rows.push({
+			id: `live:${progress.id}:tool:${tool.endMs}:${index}`,
+			agentId: progress.id,
+			timestamp: tool.endMs,
+			kind: "tool",
+			title: tool.tool,
+			summary: tool.args || tool.tool,
+			status: "success",
+			toolName: tool.tool,
+			source: "live",
+		});
+	}
+	if (progress.currentTool) {
+		rows.push({
+			id: `live:${progress.id}:current-tool`,
+			agentId: progress.id,
+			timestamp: progress.currentToolStartMs ?? lastUpdate,
+			kind: "tool",
+			title: progress.currentTool,
+			summary: progress.lastIntent ?? progress.currentToolArgs ?? progress.currentTool,
+			status: "pending",
+			toolName: progress.currentTool,
+			source: "live",
+		});
+	}
+	rows.push({
+		id: `live:${progress.id}:lifecycle`,
+		agentId: progress.id,
+		timestamp: lastUpdate,
+		kind: "lifecycle",
+		title: progress.status ?? "running",
+		summary: progress.task ?? progress.description ?? "Agent activity",
+		status:
+			progress.status === "completed"
+				? "success"
+				: progress.status === "failed"
+					? "error"
+					: progress.status === "aborted"
+						? "aborted"
+						: "pending",
+		source: "live",
+	});
+	const response = oneLine((progress.recentOutput ?? []).join(" "));
+	if (response) {
+		rows.push({
+			id: `live:${progress.id}:response`,
+			agentId: progress.id,
+			timestamp: lastUpdate,
+			kind: "response",
+			title: "Response",
+			summary: response,
+			status: progress.status === "failed" ? "error" : progress.status === "aborted" ? "aborted" : "pending",
+			source: "live",
+		});
+	}
+	return rows.sort(compareRows);
+}
+
+export class AgentActivityIndex {
+	#states = new Map<string, TranscriptState>();
+	#liveRows = new Map<string, AgentActivityRow[]>();
+	#listeners = new Set<() => void>();
+	#remote: AgentActivityRemote | undefined;
+
+	constructor(options?: { remote?: AgentActivityRemote }) {
+		this.#remote = options?.remote;
+	}
+
+	onChange(listener: () => void): () => void {
+		this.#listeners.add(listener);
+		return () => this.#listeners.delete(listener);
+	}
+
+	setLive(agentId: string, rows: readonly AgentActivityRow[]): void {
+		const next = [...rows];
+		const current = this.#liveRows.get(agentId);
+		if (JSON.stringify(current) === JSON.stringify(next)) return;
+		if (next.length > 0) this.#liveRows.set(agentId, next);
+		else this.#liveRows.delete(agentId);
+		this.#notify();
+	}
+
+	async sync(agentId: string, sessionFile?: string | null): Promise<void> {
+		if (this.#remote) {
+			await this.#syncRemote(agentId);
+			return;
+		}
+		if (!sessionFile) return;
+		await this.#syncLocal(agentId, sessionFile);
+	}
+
+	recent(agentId: string, limit = 12): AgentActivityRow[] {
+		const persisted = this.#states.get(agentId)?.rows ?? [];
+		const live = this.#liveRows.get(agentId) ?? [];
+		const liveKeys = new Set(live.map(row => `${row.kind}:${row.toolName ?? row.title}:${row.summary}`));
+		const merged = persisted.filter(row => !liveKeys.has(`${row.kind}:${row.toolName ?? row.title}:${row.summary}`));
+		merged.push(...live);
+		merged.sort(compareRows);
+		return merged.slice(-Math.max(0, limit));
+	}
+
+	query(query: AgentActivityQuery = {}): AgentActivityRow[] {
+		const search = query.search?.trim().toLowerCase();
+		const rows: AgentActivityRow[] = [];
+		const ids = new Set([...this.#states.keys(), ...this.#liveRows.keys()]);
+		for (const agentId of ids) {
+			if (query.agentIds && !query.agentIds.has(agentId)) continue;
+			for (const row of this.recent(agentId, MAX_ROWS_PER_AGENT)) {
+				if (query.kinds && !query.kinds.has(row.kind)) continue;
+				if (query.before) {
+					const afterCursor =
+						row.timestamp > query.before.timestamp ||
+						(row.timestamp === query.before.timestamp && row.id >= query.before.id);
+					if (afterCursor) continue;
+				}
+				if (
+					search &&
+					!`${row.agentId} ${row.title} ${row.summary} ${row.from ?? ""} ${row.to ?? ""}`
+						.toLowerCase()
+						.includes(search)
+				)
+					continue;
+				rows.push(row);
+			}
+		}
+		rows.sort(compareRows);
+		const limit = Math.max(0, Math.min(MAX_QUERY_LIMIT, query.limit ?? DEFAULT_QUERY_LIMIT));
+		return rows.slice(-limit);
+	}
+
+	clear(): void {
+		this.#states.clear();
+		this.#liveRows.clear();
+		this.#notify();
+	}
+
+	async #syncLocal(agentId: string, sessionFile: string): Promise<void> {
+		let stat: Stats;
+		try {
+			stat = await fs.stat(sessionFile);
+		} catch {
+			return;
+		}
+		let state = this.#states.get(agentId);
+		if (
+			!state ||
+			state.path !== sessionFile ||
+			stat.size < state.offset ||
+			(stat.size === state.offset && stat.mtimeMs !== state.mtimeMs)
+		) {
+			state = {
+				path: sessionFile,
+				offset: Math.max(0, stat.size - INITIAL_TAIL_BYTES),
+				mtimeMs: 0,
+				pending: "",
+				rows: [],
+				toolRows: new Map(),
+			};
+			this.#states.set(agentId, state);
+		}
+		if (stat.size === state.offset && stat.mtimeMs === state.mtimeMs) return;
+		const start = state.offset;
+		let text: string;
+		try {
+			text = await Bun.file(sessionFile).slice(start, stat.size).text();
+		} catch {
+			return;
+		}
+		state.offset = stat.size;
+		state.mtimeMs = stat.mtimeMs;
+		this.#consume(agentId, state, text, start > 0 && state.rows.length === 0);
+	}
+
+	async #syncRemote(agentId: string): Promise<void> {
+		let state = this.#states.get(agentId);
+		if (!state) {
+			state = { offset: 0, mtimeMs: 0, pending: "", rows: [], toolRows: new Map() };
+			this.#states.set(agentId, state);
+		}
+		const result = await this.#remote?.readTranscript(agentId, state.offset);
+		if (!result || result.error) return;
+		if (result.newSize < state.offset) {
+			state.offset = 0;
+			state.pending = "";
+			state.rows = [];
+			state.toolRows.clear();
+			return;
+		}
+		if (result.newSize === state.offset && !result.text) return;
+		this.#consume(agentId, state, result.text, false);
+		state.offset = result.newSize;
+	}
+
+	#consume(agentId: string, state: TranscriptState, chunk: string, dropLeadingPartial: boolean): void {
+		let text = state.pending + chunk;
+		if (dropLeadingPartial) {
+			const newline = text.indexOf("\n");
+			text = newline >= 0 ? text.slice(newline + 1) : "";
+		}
+		const complete = text.endsWith("\n");
+		const lines = text.split("\n");
+		state.pending = complete ? "" : (lines.pop() ?? "");
+		let changed = false;
+		for (const line of lines) {
+			if (!line.trim()) continue;
+			let entry: Record<string, unknown> | undefined;
+			try {
+				entry = recordOf(JSON.parse(line));
+			} catch {
+				continue;
+			}
+			if (entry?.type !== "message" || typeof entry.id !== "string") continue;
+			const message = recordOf(entry.message) as ActivityMessage | undefined;
+			if (!message) continue;
+			const timestamp = timestampOf(message.timestamp, timestampOf(entry.timestamp, Date.now()));
+			if (message.role === "assistant") {
+				const response = textContent(message.content);
+				if (response) {
+					boundedPush(state.rows, {
+						id: `${agentId}:response:${entry.id}`,
+						agentId,
+						timestamp,
+						kind: "response",
+						title: "Response",
+						summary: response,
+						status: message.isError ? "error" : "success",
+						entryId: entry.id,
+						source: "transcript",
+					});
+					changed = true;
+				}
+				for (const call of toolBlocks(message.content)) {
+					const row: AgentActivityRow = {
+						id: `${agentId}:tool:${call.id}`,
+						agentId,
+						timestamp,
+						kind: "tool",
+						title: call.name,
+						summary: argumentsSummary(call.name, call.args),
+						status: "pending",
+						entryId: entry.id,
+						toolCallId: call.id,
+						toolName: call.name,
+						source: "transcript",
+					};
+					state.toolRows.set(call.id, row);
+					boundedPush(state.rows, row);
+					changed = true;
+				}
+				continue;
+			}
+			if (message.role === "toolResult" && typeof message.toolCallId === "string") {
+				const row = state.toolRows.get(message.toolCallId);
+				if (!row) continue;
+				row.status = message.isError ? "error" : "success";
+				row.timestamp = Math.max(row.timestamp, timestamp);
+				if (!state.rows.includes(row)) boundedPush(state.rows, row);
+				changed = true;
+			}
+		}
+		if (changed) this.#notify();
+	}
+
+	#notify(): void {
+		for (const listener of this.#listeners) listener();
+	}
+}

--- a/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
@@ -186,6 +186,8 @@ export function formatChildIds(children: readonly AgentRef[], width: number): st
 	}
 	return text;
 }
+const TREE_SEGMENT_WIDTH = 4;
+const TREE_DETAIL_BASE_INDENT = 4;
 
 /** Build one bash `tree`-style ancestry prefix. Continuation rows replace the
  * node's own branch with a rail only when a later sibling still needs it. */
@@ -211,7 +213,7 @@ function treePrefix(
 		segments.push(lastSiblingById.get(parent) ? "    " : "│   ");
 		parent = grandparent;
 	}
-	const maxSegments = Math.max(1, Math.floor(Math.max(4, maxWidth - 2) / 4));
+	const maxSegments = Math.max(1, Math.floor(Math.max(TREE_SEGMENT_WIDTH, maxWidth - 2) / TREE_SEGMENT_WIDTH));
 	const omitted = Math.max(0, segments.length - maxSegments);
 	const prefix = segments.slice(0, maxSegments).reverse().join("");
 	const omittedPrefix = omitted > 0 ? (continuation ? "  " : "… ") : "";
@@ -238,6 +240,10 @@ export function treeContinuation(
 	lastSiblingById: ReadonlyMap<string, boolean>,
 ): string {
 	return treePrefix(ref, maxWidth, depthById, parentById, lastSiblingById, true);
+}
+/** One roster-wide origin for metric columns, independent of tree depth. */
+export function treeMetadataIndent(maxWidth: number, maxDepth: number): number {
+	return Math.min(Math.max(0, maxWidth - 1), TREE_DETAIL_BASE_INDENT + Math.max(0, maxDepth) * TREE_SEGMENT_WIDTH);
 }
 
 /** Higher is better: exact > prefix > substring > scattered subsequence. */

--- a/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
@@ -200,7 +200,7 @@ export function treeBranch(
 	const segments: string[] = [lastSiblingById.get(ref.id) ? "└── " : "├── "];
 	const ancestry = new Set<string>();
 	let parent = parentById.get(ref.id);
-	while (parent && parentById.get(parent) !== MAIN_AGENT_ID && !ancestry.has(parent)) {
+	while (parent && parent !== MAIN_AGENT_ID && !ancestry.has(parent)) {
 		ancestry.add(parent);
 		segments.push(lastSiblingById.get(parent) ? "    " : "│   ");
 		parent = parentById.get(parent);

--- a/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
@@ -1,5 +1,5 @@
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import { Ellipsis, visibleWidth } from "@oh-my-pi/pi-tui";
+import { Ellipsis, padding, visibleWidth } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, sanitizeText } from "@oh-my-pi/pi-utils";
 import { getRoleInfo } from "../../config/model-roles";
 import type { Settings } from "../../config/settings";
@@ -172,13 +172,15 @@ export function formatChildIds(children: readonly AgentRef[], width: number): st
 	return text;
 }
 
-/** Bash `tree`-style ancestry prefix, clipped from the left on pathological depth. */
+/** Bash `tree`-style ancestry connector. With a gutter it right-aligns inside the
+ * reserved gutter so agent ids share one column; without, it clips from the left. */
 export function treeBranch(
 	ref: AgentRef,
 	maxWidth: number,
 	depthById: ReadonlyMap<string, number>,
 	parentById: ReadonlyMap<string, string>,
 	lastSiblingById: ReadonlyMap<string, boolean>,
+	gutterWidth = 0,
 ): string {
 	if ((depthById.get(ref.id) ?? 0) === 0) return "";
 	const segments: string[] = [lastSiblingById.get(ref.id) ? "└── " : "├── "];
@@ -189,8 +191,50 @@ export function treeBranch(
 		segments.push(lastSiblingById.get(parent) ? "    " : "│   ");
 		parent = parentById.get(parent);
 	}
-	const maxSegments = Math.max(1, Math.floor(Math.max(4, maxWidth - 2) / 4));
+	const maxSegments =
+		gutterWidth > 0 ? Math.floor(gutterWidth / 4) : Math.max(1, Math.floor(Math.max(4, maxWidth - 2) / 4));
 	const omitted = Math.max(0, segments.length - maxSegments);
 	const prefix = segments.slice(0, maxSegments).reverse().join("");
-	return theme.fg("dim", `${omitted > 0 ? "… " : ""}${prefix}`);
+	const text = `${omitted > 0 ? "… " : ""}${prefix}`;
+	return theme.fg("dim", gutterWidth > 0 ? `${padding(gutterWidth - text.length)}${text}` : text);
+}
+
+/** Higher is better: exact > prefix > substring > scattered subsequence. */
+export function fuzzyAgentScore(query: string, target: string): number {
+	if (query.length === 0) return 1;
+	if (target === query) return 100;
+	if (target.startsWith(query)) return 80;
+	if (target.includes(query)) return 60;
+	let q = 0;
+	let gaps = 0;
+	let last = -1;
+	for (let t = 0; t < target.length && q < query.length; t += 1) {
+		if (query[q] === target[t]) {
+			if (last >= 0 && t - last > 1) gaps += 1;
+			last = t;
+			q += 1;
+		}
+	}
+	if (q !== query.length) return 0;
+	return Math.max(1, 40 - gaps * 5);
+}
+
+/** Case-insensitive scattered-subsequence match used by the agent filter. */
+export function fuzzyAgentMatch(query: string, target: string): boolean {
+	const q = query.toLowerCase();
+	const t = target.toLowerCase();
+	if (q.length === 0) return true;
+	if (q.length > t.length) return false;
+	let i = 0;
+	for (let j = 0; j < t.length && i < q.length; j += 1) {
+		if (q[i] === t[j]) i += 1;
+	}
+	return i === q.length;
+}
+
+/** Right-align `text` inside a fixed-width cell, truncating overflow. */
+export function alignRightCell(text: string, width: number): string {
+	const visible = visibleWidth(text);
+	if (visible > width) return truncateToWidth(text, width);
+	return `${" ".repeat(width - visible)}${text}`;
 }

--- a/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
@@ -145,6 +145,19 @@ export function formatMetrics(metrics: AgentMetrics): string {
 	].join(theme.sep.dot);
 }
 
+/** Row-grid variant of {@link formatMetrics}: fixed-width right-aligned cells so every
+ * agent's metadata line shares one column layout instead of flowing after wrapped text. */
+export function formatMetricColumns(metrics: AgentMetrics, age: string): string {
+	return [
+		alignRightCell(formatCost(metrics.cost), 8),
+		alignRightCell(formatMetricDuration(metrics) ?? "—", 11),
+		alignRightCell(`${formatNumber(metrics.requests)} req`, 8),
+		alignRightCell(`${formatNumber(metrics.tools)} tools`, 9),
+		alignRightCell(`${formatNumber(metrics.tokens)} tok`, 8),
+		alignRightCell(age, 7),
+	].join("  ");
+}
+
 export function contextGauge(tokens: number, window: number): string {
 	const ratio = Math.max(0, Math.min(1, tokens / window));
 	const filled = Math.round(ratio * 10);
@@ -182,7 +195,8 @@ export function treeBranch(
 	lastSiblingById: ReadonlyMap<string, boolean>,
 	gutterWidth = 0,
 ): string {
-	if ((depthById.get(ref.id) ?? 0) === 0) return "";
+	// Depth-0 rows are Main's direct children — the top level of the tree — so they draw
+	// a connector too (like `tree` printing a root's children), never a blank gutter.
 	const segments: string[] = [lastSiblingById.get(ref.id) ? "└── " : "├── "];
 	const ancestry = new Set<string>();
 	let parent = parentById.get(ref.id);

--- a/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
@@ -145,17 +145,19 @@ export function formatMetrics(metrics: AgentMetrics): string {
 	].join(theme.sep.dot);
 }
 
-/** Row-grid variant of {@link formatMetrics}: fixed-width right-aligned cells so every
- * agent's metadata line shares one column layout instead of flowing after wrapped text. */
+/** Row-grid variant of {@link formatMetrics}: fixed-width cells so every agent's metadata
+ * line shares one column layout instead of flowing after wrapped text. Cost is left-aligned
+ * so the line starts flush; the numeric cells are right-aligned so units line up. */
 export function formatMetricColumns(metrics: AgentMetrics, age: string): string {
+	const cost = formatCost(metrics.cost);
 	return [
-		alignRightCell(formatCost(metrics.cost), 8),
-		alignRightCell(formatMetricDuration(metrics) ?? "—", 11),
+		cost + padding(8 - visibleWidth(cost)),
+		alignRightCell(formatMetricDuration(metrics) ?? "—", 13),
 		alignRightCell(`${formatNumber(metrics.requests)} req`, 8),
 		alignRightCell(`${formatNumber(metrics.tools)} tools`, 9),
 		alignRightCell(`${formatNumber(metrics.tokens)} tok`, 8),
-		alignRightCell(age, 7),
-	].join("  ");
+		alignRightCell(age, 8),
+	].join(" ");
 }
 
 export function contextGauge(tokens: number, window: number): string {

--- a/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
@@ -187,18 +187,19 @@ export function formatChildIds(children: readonly AgentRef[], width: number): st
 	return text;
 }
 
-/** Bash `tree`-style ancestry connector. The prefix sits at the status-glyph column so
- * rails descend from the parent's dot: top-level rows (Main's direct children) render
- * bare, and each deeper level shifts one 4-char connector right. */
-export function treeBranch(
+/** Build one bash `tree`-style ancestry prefix. Continuation rows replace the
+ * node's own branch with a rail only when a later sibling still needs it. */
+function treePrefix(
 	ref: AgentRef,
 	maxWidth: number,
 	depthById: ReadonlyMap<string, number>,
 	parentById: ReadonlyMap<string, string>,
 	lastSiblingById: ReadonlyMap<string, boolean>,
+	continuation: boolean,
 ): string {
 	if ((depthById.get(ref.id) ?? 0) === 0) return "";
-	const segments: string[] = [lastSiblingById.get(ref.id) ? "└── " : "├── "];
+	const lastSibling = lastSiblingById.get(ref.id);
+	const segments: string[] = [continuation ? (lastSibling ? "    " : "│   ") : lastSibling ? "└── " : "├── "];
 	const ancestry = new Set<string>();
 	let parent = parentById.get(ref.id);
 	while (parent && parent !== MAIN_AGENT_ID && !ancestry.has(parent)) {
@@ -213,7 +214,30 @@ export function treeBranch(
 	const maxSegments = Math.max(1, Math.floor(Math.max(4, maxWidth - 2) / 4));
 	const omitted = Math.max(0, segments.length - maxSegments);
 	const prefix = segments.slice(0, maxSegments).reverse().join("");
-	return theme.fg("dim", `${omitted > 0 ? "… " : ""}${prefix}`);
+	const omittedPrefix = omitted > 0 ? (continuation ? "  " : "… ") : "";
+	return theme.fg("dim", `${omittedPrefix}${prefix}`);
+}
+
+/** Bash `tree`-style branch for an agent's identity row. */
+export function treeBranch(
+	ref: AgentRef,
+	maxWidth: number,
+	depthById: ReadonlyMap<string, number>,
+	parentById: ReadonlyMap<string, string>,
+	lastSiblingById: ReadonlyMap<string, boolean>,
+): string {
+	return treePrefix(ref, maxWidth, depthById, parentById, lastSiblingById, false);
+}
+
+/** Ancestry rails for the task and metrics rows beneath an agent identity. */
+export function treeContinuation(
+	ref: AgentRef,
+	maxWidth: number,
+	depthById: ReadonlyMap<string, number>,
+	parentById: ReadonlyMap<string, string>,
+	lastSiblingById: ReadonlyMap<string, boolean>,
+): string {
+	return treePrefix(ref, maxWidth, depthById, parentById, lastSiblingById, true);
 }
 
 /** Higher is better: exact > prefix > substring > scattered subsequence. */

--- a/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub-renderer.ts
@@ -187,32 +187,33 @@ export function formatChildIds(children: readonly AgentRef[], width: number): st
 	return text;
 }
 
-/** Bash `tree`-style ancestry connector. With a gutter it right-aligns inside the
- * reserved gutter so agent ids share one column; without, it clips from the left. */
+/** Bash `tree`-style ancestry connector. The prefix sits at the status-glyph column so
+ * rails descend from the parent's dot: top-level rows (Main's direct children) render
+ * bare, and each deeper level shifts one 4-char connector right. */
 export function treeBranch(
 	ref: AgentRef,
 	maxWidth: number,
 	depthById: ReadonlyMap<string, number>,
 	parentById: ReadonlyMap<string, string>,
 	lastSiblingById: ReadonlyMap<string, boolean>,
-	gutterWidth = 0,
 ): string {
-	// Depth-0 rows are Main's direct children — the top level of the tree — so they draw
-	// a connector too (like `tree` printing a root's children), never a blank gutter.
+	if ((depthById.get(ref.id) ?? 0) === 0) return "";
 	const segments: string[] = [lastSiblingById.get(ref.id) ? "└── " : "├── "];
 	const ancestry = new Set<string>();
 	let parent = parentById.get(ref.id);
 	while (parent && parent !== MAIN_AGENT_ID && !ancestry.has(parent)) {
+		const grandparent = parentById.get(parent);
+		// A bare top-level parent (drawn without a connector, just its dot) has no
+		// rail column — its children's connectors sit directly under that dot.
+		if (!grandparent || grandparent === MAIN_AGENT_ID) break;
 		ancestry.add(parent);
 		segments.push(lastSiblingById.get(parent) ? "    " : "│   ");
-		parent = parentById.get(parent);
+		parent = grandparent;
 	}
-	const maxSegments =
-		gutterWidth > 0 ? Math.floor(gutterWidth / 4) : Math.max(1, Math.floor(Math.max(4, maxWidth - 2) / 4));
+	const maxSegments = Math.max(1, Math.floor(Math.max(4, maxWidth - 2) / 4));
 	const omitted = Math.max(0, segments.length - maxSegments);
 	const prefix = segments.slice(0, maxSegments).reverse().join("");
-	const text = `${omitted > 0 ? "… " : ""}${prefix}`;
-	return theme.fg("dim", gutterWidth > 0 ? `${padding(gutterWidth - text.length)}${text}` : text);
+	return theme.fg("dim", `${omitted > 0 ? "… " : ""}${prefix}`);
 }
 
 /** Higher is better: exact > prefix > substring > scattered subsequence. */

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -55,6 +55,7 @@ import {
 	STATUS_ORDER,
 } from "./agent-hub-projection";
 import {
+	alignRightCell,
 	clampHubLine,
 	contextGauge,
 	formatChildIds,
@@ -62,6 +63,7 @@ import {
 	formatMetricDuration,
 	formatMetrics,
 	formatRoleBadge,
+	fuzzyAgentMatch,
 	modelBadge,
 	type RosterRender,
 	sanitizeDisplayText,
@@ -222,9 +224,6 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	/** Per-render screen-line to agent-row map, shared by click and hover routing. */
 	#hitRows: Array<number | undefined> = [];
 	#notice: string | undefined;
-	/** Captured row order from the first refresh; keeps the hub stable while open. */
-	#rowOrder: Map<string, number> | undefined;
-	#nextRowOrder = 0;
 	/** Double-tap window state for the table's left-left "close hub" gesture. */
 	#lastLeftTap = 0;
 	/** Operational ordering by default; tree mode groups descendants under their spawner. */
@@ -232,6 +231,11 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#treeDepthById = new Map<string, number>();
 	#treeParentById = new Map<string, string>();
 	#treeLastSiblingById = new Map<string, boolean>();
+	/** Reserved connector column width in tree mode so agent ids align vertically. */
+	#treeGutterWidth = 0;
+	/** Fuzzy agent filter (`/`), applied to id and display name. */
+	#agentFilter = "";
+	#agentFilterEditing = false;
 	/** Current observer index and summary data, rebuilt on source changes rather than every paint. */
 	#observedById = new Map<string, ObservableSession>();
 	#aggregate: AggregateMetrics = {
@@ -501,24 +505,32 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		const refs = this.#registry.list().filter(ref => ref.id !== MAIN_AGENT_ID);
 		this.#observedById = new Map();
 		for (const session of this.#observers.getSessions()) this.#observedById.set(session.id, session);
-		const rowOrder = this.#rowOrder;
-		let rosterRows: AgentRef[];
-		if (!rowOrder) {
-			rosterRows = refs.sort(
-				(a, b) =>
-					STATUS_ORDER[a.status] - STATUS_ORDER[b.status] ||
-					b.lastActivity - a.lastActivity ||
-					a.id.localeCompare(b.id),
-			);
-			this.#rowOrder = new Map();
-			for (const ref of rosterRows) this.#rowOrder.set(ref.id, this.#nextRowOrder++);
+		const query = this.#agentFilter.trim();
+		const filtered =
+			query.length > 0 ? refs.filter(ref => fuzzyAgentMatch(query, `${ref.id} ${ref.displayName ?? ""}`)) : refs;
+		// Live recency ordering: the most recently active agent surfaces first and
+		// rows move as activity changes, matching the recency-first tree summary.
+		const rosterRows = filtered.sort(
+			(a, b) =>
+				STATUS_ORDER[a.status] - STATUS_ORDER[b.status] ||
+				b.lastActivity - a.lastActivity ||
+				a.id.localeCompare(b.id),
+		);
+
+		if (this.#viewMode === "tree") {
+			const tree = projectAgentTree(rosterRows);
+			this.#rows = tree.rows;
+			this.#treeDepthById = tree.depthById;
+			this.#treeParentById = tree.parentById;
+			this.#treeLastSiblingById = tree.lastSiblingById;
+			const maxDepth = Math.max(0, ...tree.depthById.values());
+			this.#treeGutterWidth = Math.min(24, maxDepth * 4);
 		} else {
-			rosterRows = refs.sort(
-				(a, b) => (rowOrder.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (rowOrder.get(b.id) ?? Number.MAX_SAFE_INTEGER),
-			);
-			for (const ref of rosterRows) {
-				if (!rowOrder.has(ref.id)) rowOrder.set(ref.id, this.#nextRowOrder++);
-			}
+			this.#rows = rosterRows;
+			this.#treeDepthById.clear();
+			this.#treeParentById.clear();
+			this.#treeLastSiblingById.clear();
+			this.#treeGutterWidth = 0;
 		}
 
 		if (this.#viewMode === "tree") {
@@ -787,18 +799,20 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 
 	#footer(showingNarrowDetails: boolean, availableWidth: number): string {
 		const nextView = this.#viewMode === "roster" ? "by parent" : "flat";
+		const filter =
+			this.#agentFilter.length > 0 ? `/${this.#agentFilter}${this.#agentFilterEditing ? "▌" : ""}  ·  ` : "";
 		if (showingNarrowDetails) {
 			return theme.fg(
 				"dim",
-				`1:agents  2:activity  Tab:roster  PgUp/PgDn:scroll  Enter:open  t:${nextView}  Esc:roster`,
+				`${filter}1:agents  2:activity  Tab:roster  PgUp/PgDn:scroll  Enter:open  t:${nextView}  Esc:roster`,
 			);
 		}
 		if (availableWidth < 96) {
-			return theme.fg("dim", `j/k:select  Enter:open  t:${nextView}  Tab:details  r/x:manage  Esc:close`);
+			return theme.fg("dim", `${filter}j/k:select  Enter:open  t:${nextView}  Tab:details  r/x:manage  Esc:close`);
 		}
 		return theme.fg(
 			"dim",
-			`1:agents  2:activity  j/k/wheel:select  PgUp/PgDn:details  Enter/click:open  t:${nextView}  r:revive  x:kill  Esc:close`,
+			`${filter}1:agents  2:activity  j/k/wheel:select  PgUp/PgDn:details  Enter/click:open  t:${nextView}  r:revive  x:kill  Esc:close`,
 		);
 	}
 
@@ -1115,9 +1129,18 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		const max = Math.max(1, width);
 		const cursor = selected ? theme.fg("accent", theme.nav.cursor) : " ";
 		const depth = this.#viewMode === "tree" ? (this.#treeDepthById.get(ref.id) ?? 0) : 0;
+		// Tree connectors render inside a reserved gutter so ids align vertically
+		// across depths instead of shifting the whole row right.
 		const branch =
 			this.#viewMode === "tree"
-				? treeBranch(ref, max, this.#treeDepthById, this.#treeParentById, this.#treeLastSiblingById)
+				? treeBranch(
+						ref,
+						max,
+						this.#treeDepthById,
+						this.#treeParentById,
+						this.#treeLastSiblingById,
+						this.#treeGutterWidth,
+					)
 				: "";
 		const id = sanitizeDisplayText(ref.id);
 		const styledId = selected ? theme.bold(theme.fg("accent", id)) : theme.bold(id);
@@ -1137,6 +1160,10 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		}
 		const left = fields.join("  ");
 
+		// Fixed-width numeric columns pinned to the right edge: spend, turns,
+		// age. Badges (variable width) sit before the columns so every row's
+		// numeric cells share the same grid.
+		const metrics = this.#metricsFor(ref, observed);
 		const meta: string[] = [];
 		const modelRole = observed?.progress?.modelRole ?? ref.history?.modelRole;
 		if (modelRole && this.#settings) {
@@ -1144,13 +1171,16 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		}
 		const badge = modelBadge(ref, observed);
 		if (badge) meta.push(badge);
-		meta.push(theme.fg("dim", formatAge(Math.max(1, Math.round((Date.now() - ref.lastActivity) / 1000)))));
-		const right = meta.join(theme.sep.dot);
+		const spend = theme.fg("dim", metrics ? formatCost(metrics.cost) : "—");
+		const turns = theme.fg("dim", metrics ? `${formatNumber(metrics.requests)} req` : "—");
+		const age = theme.fg("dim", formatAge(Math.max(1, Math.round((Date.now() - ref.lastActivity) / 1000))));
+		const columns = [alignRightCell(spend, 9), alignRightCell(turns, 8), alignRightCell(age, 7)].join("  ");
+		const right = meta.length > 0 ? `${meta.join(theme.sep.dot)}  ${columns}` : columns;
 
 		const leftWidth = visibleWidth(left);
 		const rightWidth = visibleWidth(right);
 		const entry: string[] = [];
-		const detailIndent = Math.min(max - 1, 4 + depth * 2);
+		const detailIndent = Math.min(max - 1, 4 + (this.#viewMode === "tree" ? this.#treeGutterWidth : depth * 2));
 		if (leftWidth + 2 + rightWidth <= max) {
 			entry.push(left + padding(max - leftWidth - rightWidth) + right);
 		} else {
@@ -1158,7 +1188,6 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			entry.push(`${padding(Math.max(0, detailIndent))}${truncateToWidth(right, Math.max(1, max - detailIndent))}`);
 		}
 
-		const metrics = this.#metricsFor(ref, observed);
 		const usage = metrics ? theme.fg("dim", formatMetrics(metrics)) : theme.fg("dim", "usage —");
 		const task = observed?.description ?? observed?.progress?.task ?? ref.activity;
 		const detailWidth = Math.max(1, max - detailIndent);
@@ -1322,13 +1351,37 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	}
 
 	#handleTableInput(keyData: string): void {
+		if (this.#agentFilterEditing) {
+			if (matchesKey(keyData, "escape") || matchesKey(keyData, "enter") || keyData === "\r" || keyData === "\n") {
+				this.#agentFilterEditing = false;
+				if (matchesKey(keyData, "escape")) this.#agentFilter = "";
+			} else if (matchesKey(keyData, "backspace")) {
+				this.#agentFilter = this.#agentFilter.slice(0, -1);
+			} else if (keyData.length === 1 && keyData >= " " && keyData !== "\u007f") {
+				this.#agentFilter += keyData;
+			} else {
+				return;
+			}
+			this.#refreshRows();
+			this.#requestRender();
+			return;
+		}
 		if (matchesKey(keyData, "escape")) {
-			if (this.#narrowDetailsOpen && !this.#lastRenderWasSplit) {
+			if (this.#agentFilter) {
+				this.#agentFilter = "";
+				this.#refreshRows();
+				this.#requestRender();
+			} else if (this.#narrowDetailsOpen && !this.#lastRenderWasSplit) {
 				this.#narrowDetailsOpen = false;
 				this.#requestRender();
 			} else {
 				this.#onDone();
 			}
+			return;
+		}
+		if (keyData === "/") {
+			this.#agentFilterEditing = true;
+			this.#requestRender();
 			return;
 		}
 		if ((matchesKey(keyData, "tab") || keyData === "\t") && !this.#lastRenderWasSplit) {

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -232,8 +232,6 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#treeDepthById = new Map<string, number>();
 	#treeParentById = new Map<string, string>();
 	#treeLastSiblingById = new Map<string, boolean>();
-	/** Reserved connector column width in tree mode so agent ids align vertically. */
-	#treeGutterWidth = 0;
 	/** Fuzzy agent filter (`/`), applied to id and display name. */
 	#agentFilter = "";
 	#agentFilterEditing = false;
@@ -517,22 +515,6 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 				b.lastActivity - a.lastActivity ||
 				a.id.localeCompare(b.id),
 		);
-
-		if (this.#viewMode === "tree") {
-			const tree = projectAgentTree(rosterRows);
-			this.#rows = tree.rows;
-			this.#treeDepthById = tree.depthById;
-			this.#treeParentById = tree.parentById;
-			this.#treeLastSiblingById = tree.lastSiblingById;
-			const maxDepth = Math.max(0, ...tree.depthById.values());
-			this.#treeGutterWidth = Math.min(28, (maxDepth + 1) * 4);
-		} else {
-			this.#rows = rosterRows;
-			this.#treeDepthById.clear();
-			this.#treeParentById.clear();
-			this.#treeLastSiblingById.clear();
-			this.#treeGutterWidth = 0;
-		}
 
 		if (this.#viewMode === "tree") {
 			const tree = projectAgentTree(rosterRows);
@@ -1130,25 +1112,15 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		const max = Math.max(1, width);
 		const cursor = selected ? theme.fg("accent", theme.nav.cursor) : " ";
 		const depth = this.#viewMode === "tree" ? (this.#treeDepthById.get(ref.id) ?? 0) : 0;
-		// Tree connectors render inside a reserved gutter so ids align vertically
-		// across depths instead of shifting the whole row right.
+		// Tree rails descend from the status dot: the connector sits between the
+		// cursor and the glyph, so child rows hang under their parent's dot.
 		const branch =
 			this.#viewMode === "tree"
-				? treeBranch(
-						ref,
-						max,
-						this.#treeDepthById,
-						this.#treeParentById,
-						this.#treeLastSiblingById,
-						this.#treeGutterWidth,
-					)
+				? treeBranch(ref, max, this.#treeDepthById, this.#treeParentById, this.#treeLastSiblingById)
 				: "";
 		const id = sanitizeDisplayText(ref.id);
 		const styledId = selected ? theme.bold(theme.fg("accent", id)) : theme.bold(id);
-		const fields: string[] = [`${cursor} ${statusGlyph(ref.status)} ${branch}${styledId}`];
-		if (ref.displayName && ref.displayName !== ref.id) {
-			fields.push(theme.fg("dim", sanitizeDisplayText(ref.displayName)));
-		}
+		const fields: string[] = [`${cursor} ${branch}${statusGlyph(ref.status)} ${styledId}`];
 		if (this.#viewMode === "roster" && ref.parentId && ref.parentId !== MAIN_AGENT_ID) {
 			fields.push(theme.fg("dim", `↳ ${sanitizeDisplayText(ref.parentId)}`));
 		}
@@ -1175,7 +1147,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		const right = meta.join(theme.sep.dot);
 
 		const entry: string[] = [];
-		const detailIndent = Math.min(max - 1, 4 + (this.#viewMode === "tree" ? this.#treeGutterWidth : depth * 2));
+		const detailIndent = Math.min(max - 1, 4 + (this.#viewMode === "tree" ? visibleWidth(branch) : depth * 2));
 		const leftWidth = visibleWidth(left);
 		const rightWidth = visibleWidth(right);
 		if (rightWidth > 0 && leftWidth + 2 + rightWidth <= max) {

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -82,6 +82,15 @@ import {
 	topBorderSplit,
 } from "./overlay-box";
 
+/** Two-pane mode needs a useful roster and a readable inspector. */
+const SPLIT_MIN_WIDTH = 96;
+const DETAIL_MIN_WIDTH = 34;
+const ROSTER_MIN_WIDTH = 48;
+
+export type AgentHubSection = "agents" | "activity";
+type ActivityFilter = "all" | "errors" | "responses" | "tools";
+type ActivityScope = "all" | "agent" | "subtree";
+
 type HubViewMode = "roster" | "tree";
 
 /** Refresh cadence for the relative-time column. */
@@ -107,7 +116,12 @@ function activityGlyph(row: AgentActivityRow): string {
 }
 
 function activityClock(timestamp: number): string {
-	return new Date(timestamp).toISOString().slice(11, 19);
+	return new Date(timestamp).toLocaleTimeString(undefined, {
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		hour12: false,
+	});
 }
 /** Result of one host-backed transcript read for the Agent Hub viewer. */
 export interface AgentHubRemoteTranscript {
@@ -160,6 +174,10 @@ export interface AgentHubDeps {
 	focusAgent?: (id: string) => Promise<void>;
 	/** Current main session file; used to seed parked historical subagents after restart. */
 	sessionFile?: string | null;
+	/** Initial top-level projection; slash commands deep-link into this surface. */
+	initialSection?: AgentHubSection;
+	/** Injectable unified activity source; production creates one from local or remote transcripts. */
+	activity?: AgentActivityIndex;
 
 	/** Collab guest: route actions/transcripts to the host instead of local sessions. */
 	remote?: AgentHubRemote;
@@ -183,6 +201,18 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	readonly persistedSubagentsReady: Promise<void>;
 	/** Prevent the async persisted-session scan from flashing a false empty state. */
 	#loadingPersistedSubagents = false;
+	#section: AgentHubSection;
+	#activity: AgentActivityIndex;
+	#manageActivityLive: boolean;
+	#activityRows: AgentActivityRow[] = [];
+	#selectedActivityRow = 0;
+	#activityFilter: ActivityFilter = "all";
+	#activityScope: ActivityScope = "all";
+	#activitySearch = "";
+	#activitySearchEditing = false;
+	#activityFollow = true;
+	#activitySyncGeneration = 0;
+	#activitySyncStamp = new Map<string, string>();
 
 	// Table state
 	#rows: AgentRef[] = [];
@@ -244,6 +274,9 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 
 	constructor(deps: AgentHubDeps) {
 		super();
+		this.#section = deps.initialSection ?? "agents";
+		this.#activity = deps.activity ?? new AgentActivityIndex({ remote: deps.remote });
+		this.#manageActivityLive = !deps.activity;
 		this.#registry = deps.registry ?? AgentRegistry.global();
 		this.#observers = deps.observers;
 		this.#settings = deps.settings;
@@ -326,7 +359,11 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 
 	override render(width: number): readonly string[] {
 		const termHeight = this.#ui.terminal?.rows || process.stdout.rows || 40;
-		const frame = this.#renderTable(width, termHeight).map(line => clampHubLine(line, width));
+		const frame = (
+			this.#section === "activity"
+				? this.#renderActivityTable(width, termHeight)
+				: this.#renderTable(width, termHeight)
+		).map(line => clampHubLine(line, width));
 		if (frame.length <= termHeight) return frame;
 
 		// A tiny terminal can leave less room than the fixed chrome needs. Keep
@@ -354,7 +391,20 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 				return;
 			}
 		}
-		this.#handleTableInput(keyData);
+		if (this.#section === "activity" && this.#activitySearchEditing) {
+			this.#handleActivitySearchInput(keyData);
+			return;
+		}
+		if (keyData === "1") {
+			this.#switchSection("agents");
+			return;
+		}
+		if (keyData === "2") {
+			this.#switchSection("activity");
+			return;
+		}
+		if (this.#section === "activity") this.#handleActivityInput(keyData);
+		else this.#handleTableInput(keyData);
 	}
 
 	/**
@@ -384,6 +434,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		let viewer: AgentTranscriptViewer;
 		viewer = new AgentTranscriptViewer({
 			agentId: id,
+			initialEntryId: entryId,
 			registry: this.#registry,
 			remote: this.#remote,
 			observers: this.#observers,
@@ -529,11 +580,15 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			pending.push(this.#activity.sync(ref.id, ref.sessionFile));
 		}
 		if (pending.length === 0) return;
-		void Promise.all(pending).then(() => {
-			if (this.#disposed || generation !== this.#activitySyncGeneration) return;
-			this.#refreshActivityRows();
-			this.#requestRender();
-		});
+		void Promise.all(pending)
+			.then(() => {
+				if (this.#disposed || generation !== this.#activitySyncGeneration) return;
+				this.#refreshActivityRows();
+				this.#requestRender();
+			})
+			.catch(() => {
+				// Individual sync paths already guard I/O failures; keep the hub render loop alive.
+			});
 	}
 
 	#activityAgentIds(): ReadonlySet<string> | undefined {
@@ -733,7 +788,10 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#footer(showingNarrowDetails: boolean, availableWidth: number): string {
 		const nextView = this.#viewMode === "roster" ? "by parent" : "flat";
 		if (showingNarrowDetails) {
-		return theme.fg("dim", `1:agents  2:activity  Tab:roster  PgUp/PgDn:scroll  Enter:open  t:${nextView}  Esc:roster`);
+			return theme.fg(
+				"dim",
+				`1:agents  2:activity  Tab:roster  PgUp/PgDn:scroll  Enter:open  t:${nextView}  Esc:roster`,
+			);
 		}
 		if (availableWidth < 96) {
 			return theme.fg("dim", `j/k:select  Enter:open  t:${nextView}  Tab:details  r/x:manage  Esc:close`);
@@ -1174,6 +1232,93 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		this.#selectRow(index);
 		this.#requestRender();
 		this.#activateAgent(selected);
+	}
+
+	#switchSection(section: AgentHubSection): void {
+		if (this.#section === section) return;
+		this.#section = section;
+		this.#hoveredRow = null;
+		this.#narrowDetailsOpen = false;
+		if (section === "activity") this.#refreshActivityRows();
+		this.#requestRender();
+	}
+
+	#handleActivitySearchInput(keyData: string): void {
+		if (matchesKey(keyData, "escape") || matchesKey(keyData, "enter") || keyData === "\r" || keyData === "\n") {
+			this.#activitySearchEditing = false;
+		} else if (matchesKey(keyData, "backspace")) {
+			this.#activitySearch = this.#activitySearch.slice(0, -1);
+		} else if (keyData.length === 1 && keyData >= " " && keyData !== "\u007f") {
+			this.#activitySearch += keyData;
+		} else {
+			return;
+		}
+		this.#refreshActivityRows();
+		this.#requestRender();
+	}
+
+	#handleActivityInput(keyData: string): void {
+		if (matchesKey(keyData, "escape")) {
+			if (this.#activitySearch) {
+				this.#activitySearch = "";
+				this.#refreshActivityRows();
+				this.#requestRender();
+			} else {
+				this.#onDone();
+			}
+			return;
+		}
+		if (matchesKey(keyData, "left")) {
+			this.#switchSection("agents");
+			return;
+		}
+		if (keyData === "/") {
+			this.#activitySearchEditing = true;
+			this.#requestRender();
+			return;
+		}
+		if (keyData === " ") {
+			this.#activityFollow = !this.#activityFollow;
+			if (this.#activityFollow && this.#activityRows.length > 0) {
+				this.#selectedActivityRow = this.#activityRows.length - 1;
+			}
+			this.#requestRender();
+			return;
+		}
+		if (keyData === "f") {
+			const filters: ActivityFilter[] = ["all", "errors", "responses", "tools"];
+			this.#activityFilter = filters[(filters.indexOf(this.#activityFilter) + 1) % filters.length]!;
+			this.#refreshActivityRows();
+			this.#requestRender();
+			return;
+		}
+		if (keyData === "s") {
+			const scopes: ActivityScope[] = ["all", "agent", "subtree"];
+			this.#activityScope = scopes[(scopes.indexOf(this.#activityScope) + 1) % scopes.length]!;
+			this.#refreshActivityRows();
+			this.#requestRender();
+			return;
+		}
+		if (matchesKey(keyData, "j") || matchesSelectDown(keyData)) {
+			if (this.#activityRows.length > 0) {
+				this.#activityFollow = false;
+				this.#selectedActivityRow = Math.min(this.#selectedActivityRow + 1, this.#activityRows.length - 1);
+			}
+			this.#requestRender();
+			return;
+		}
+		if (matchesKey(keyData, "k") || matchesSelectUp(keyData)) {
+			if (this.#activityRows.length > 0) {
+				this.#activityFollow = false;
+				this.#selectedActivityRow = Math.max(this.#selectedActivityRow - 1, 0);
+			}
+			this.#requestRender();
+			return;
+		}
+		if (matchesKey(keyData, "enter") || keyData === "\r" || keyData === "\n") {
+			const activity = this.#activityRows[this.#selectedActivityRow];
+			if (activity) this.openChat(activity.agentId, activity.entryId);
+		}
 	}
 
 	#handleTableInput(keyData: string): void {

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -27,6 +27,12 @@ import {
 	wrapTextWithAnsi,
 } from "@oh-my-pi/pi-tui";
 import { formatAge, formatNumber, getProjectDir, logger } from "@oh-my-pi/pi-utils";
+import {
+	AgentActivityIndex,
+	type AgentActivityKind,
+	type AgentActivityRow,
+	activityRowsFromProgress,
+} from "../../activity";
 import type { KeyId } from "../../config/keybindings";
 import type { Settings } from "../../config/settings";
 import type { MessageRenderer } from "../../extensibility/extensions/types";
@@ -83,7 +89,6 @@ const AGE_TICK_MS = 5_000;
 const DATA_CHANGE_RENDER_COALESCE_MS = 100;
 /** Double-tap window for the table's left-left "close hub" gesture. */
 const LEFT_TAP_WINDOW_MS = 500;
-
 
 function activityGlyph(row: AgentActivityRow): string {
 	if (row.status === "error") return theme.fg("error", theme.status.error);
@@ -371,7 +376,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	 * owns the alternate screen; the hub table stays mounted underneath and is
 	 * restored when the viewer closes. No-op without a real TUI (render-only test stub).
 	 */
-	openChat(id: string): void {
+	openChat(id: string, entryId?: string): void {
 		if (this.#disposed || !this.#registry.get(id)) return;
 		if (typeof this.#ui.showOverlay !== "function") return;
 		this.#closeTranscriptOverlay();
@@ -495,6 +500,77 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		this.#statusCounts = { running: 0, idle: 0, parked: 0, aborted: 0 };
 		for (const ref of rosterRows) this.#statusCounts[ref.status]++;
 		this.#refreshAggregate();
+		this.#refreshActivityData(rosterRows);
+		this.#refreshActivityRows();
+	}
+
+	#refreshActivityData(refs: readonly AgentRef[]): void {
+		if (this.#manageActivityLive) {
+			const liveIds = new Set<string>();
+			for (const ref of refs) {
+				const observed = this.#observedById.get(ref.id);
+				if (observed?.progress) {
+					liveIds.add(ref.id);
+					this.#activity.setLive(ref.id, activityRowsFromProgress(observed.progress, observed.lastUpdate));
+				}
+			}
+			for (const ref of refs) {
+				if (!liveIds.has(ref.id)) this.#activity.setLive(ref.id, []);
+			}
+		}
+
+		const generation = ++this.#activitySyncGeneration;
+		const pending: Promise<void>[] = [];
+		for (const ref of refs) {
+			if (!this.#remote && !ref.sessionFile) continue;
+			const stamp = `${ref.sessionFile ?? ""}:${ref.lastActivity}`;
+			if (this.#activitySyncStamp.get(ref.id) === stamp) continue;
+			this.#activitySyncStamp.set(ref.id, stamp);
+			pending.push(this.#activity.sync(ref.id, ref.sessionFile));
+		}
+		if (pending.length === 0) return;
+		void Promise.all(pending).then(() => {
+			if (this.#disposed || generation !== this.#activitySyncGeneration) return;
+			this.#refreshActivityRows();
+			this.#requestRender();
+		});
+	}
+
+	#activityAgentIds(): ReadonlySet<string> | undefined {
+		if (this.#activityScope === "all") return undefined;
+		const selected = this.#rows[this.#selectedRow]?.id;
+		if (!selected) return new Set();
+		const ids = new Set([selected]);
+		if (this.#activityScope === "agent") return ids;
+		const queue = [selected];
+		for (let index = 0; index < queue.length; index++) {
+			for (const child of this.#childrenByParent.get(queue[index]!) ?? []) {
+				if (ids.has(child.id)) continue;
+				ids.add(child.id);
+				queue.push(child.id);
+			}
+		}
+		return ids;
+	}
+
+	#refreshActivityRows(): void {
+		const kinds: ReadonlySet<AgentActivityKind> | undefined =
+			this.#activityFilter === "responses"
+				? new Set(["response"])
+				: this.#activityFilter === "tools"
+					? new Set(["tool"])
+					: undefined;
+		let rows = this.#activity.query({
+			agentIds: this.#activityAgentIds(),
+			kinds,
+			search: this.#activitySearch,
+			limit: 2_000,
+		});
+		if (this.#activityFilter === "errors") rows = rows.filter(row => row.status === "error");
+		this.#activityRows = rows;
+		if (rows.length === 0) this.#selectedActivityRow = 0;
+		else if (this.#activityFollow) this.#selectedActivityRow = rows.length - 1;
+		else this.#selectedActivityRow = Math.min(this.#selectedActivityRow, rows.length - 1);
 	}
 
 	#metricsFor(ref: AgentRef, observed: ObservableSession | undefined): AgentMetrics | undefined {
@@ -517,6 +593,91 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	// Table view
 	// ========================================================================
 
+	#sectionTabs(): string {
+		const tab = (section: AgentHubSection, label: string): string =>
+			this.#section === section
+				? theme.bg("selectedBg", theme.bold(theme.fg("accent", ` ${label} `)))
+				: theme.fg("muted", ` ${label} `);
+		return `${tab("agents", "1 Agents")}${theme.fg("dim", theme.sep.dot)}${tab("activity", "2 Activity")}`;
+	}
+
+	#renderActivityTable(width: number, termHeight: number): string[] {
+		this.#hitRows.length = 0;
+		const innerWidth = Math.max(1, width - 4);
+		const contentRows = Math.max(1, termHeight - 4);
+		const body: string[] = [this.#sectionTabs()];
+		const selectedAgent = this.#rows[this.#selectedRow]?.id;
+		const scope =
+			this.#activityScope === "all"
+				? "all agents"
+				: this.#activityScope === "agent"
+					? (selectedAgent ?? "selected agent")
+					: `${selectedAgent ?? "selected"} subtree`;
+		const search = this.#activitySearchEditing
+			? theme.fg("accent", `search: ${this.#activitySearch}▌`)
+			: this.#activitySearch
+				? `search: ${this.#activitySearch}`
+				: "search: —";
+		body.push(
+			theme.fg(
+				"dim",
+				`${scope}${theme.sep.dot}${this.#activityFilter}${theme.sep.dot}${this.#activityFollow ? "following" : "paused"}${theme.sep.dot}${search}`,
+			),
+		);
+		if (contentRows >= 8) body.push("");
+
+		const budget = Math.max(0, contentRows - body.length);
+		if (this.#activityRows.length === 0 && budget > 0) {
+			body.push(theme.fg("muted", this.#activitySearch ? "No matching activity" : "No agent activity recorded yet"));
+		} else if (budget > 0) {
+			const selected = Math.min(this.#selectedActivityRow, this.#activityRows.length - 1);
+			const start = this.#activityFollow
+				? Math.max(0, this.#activityRows.length - budget)
+				: Math.max(0, Math.min(selected - Math.floor(budget / 2), this.#activityRows.length - budget));
+			const end = Math.min(this.#activityRows.length, start + budget);
+			if (start > 0) {
+				body.push(theme.fg("dim", `… ${start} earlier`));
+			}
+			for (let index = start + Number(start > 0); index < end; index++) {
+				this.#hitRows[1 + body.length] = index;
+				body.push(this.#formatActivityRow(this.#activityRows[index]!, index === selected, innerWidth));
+			}
+		}
+		while (body.length < contentRows) body.push("");
+
+		const lines = [topBorder(width, "Agent Hub")];
+		for (const line of body.slice(0, contentRows)) lines.push(row(line, width));
+		lines.push(divider(width));
+		lines.push(
+			row(
+				theme.fg(
+					"dim",
+					"1:agents  j/k:select  Enter:transcript  Space:follow  f:filter  s:scope  /:search  Esc:close",
+				),
+				width,
+			),
+		);
+		lines.push(bottomBorder(width));
+		return lines;
+	}
+
+	#formatActivityRow(activity: AgentActivityRow, selected: boolean, width: number): string {
+		const cursor = selected ? theme.fg("accent", theme.nav.cursor) : " ";
+		const ref = this.#registry.get(activity.agentId);
+		const observed = this.#observedById.get(activity.agentId);
+		const role = observed?.progress?.modelRole ?? ref?.history?.modelRole;
+		const roleBadge = role && this.#settings ? `${formatRoleBadge(role, this.#settings)} ` : "";
+		const agent = sanitizeLine(activity.agentId, Math.max(8, Math.min(18, Math.floor(width * 0.18))));
+		const title = sanitizeLine(
+			activity.kind === "tool" ? (activity.toolName ?? activity.title) : activity.title,
+			width,
+		);
+		const prefix =
+			`${cursor} ${theme.fg("dim", activityClock(activity.timestamp))} ${activityGlyph(activity)} ` +
+			`${roleBadge}${theme.bold(agent)} ${theme.fg(activity.kind === "response" ? "success" : "muted", title)}`;
+		const available = Math.max(1, width - visibleWidth(prefix) - visibleWidth(theme.sep.dot));
+		return `${prefix}${theme.fg("dim", theme.sep.dot)}${sanitizeLine(activity.summary, available)}`;
+	}
 	#renderTable(width: number, termHeight: number): string[] {
 		this.#hitRows.length = 0;
 		const contentRows = Math.max(1, termHeight - 4);
@@ -572,14 +733,14 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#footer(showingNarrowDetails: boolean, availableWidth: number): string {
 		const nextView = this.#viewMode === "roster" ? "by parent" : "flat";
 		if (showingNarrowDetails) {
-			return theme.fg("dim", `Tab:roster  PgUp/PgDn:scroll  Enter:open  t:${nextView}  Esc:roster`);
++		return theme.fg("dim", `1:agents  2:activity  Tab:roster  PgUp/PgDn:scroll  Enter:open  t:${nextView}  Esc:roster`);
 		}
 		if (availableWidth < 96) {
 			return theme.fg("dim", `j/k:select  Enter:open  t:${nextView}  Tab:details  r/x:manage  Esc:close`);
 		}
 		return theme.fg(
 			"dim",
-			`j/k/wheel:select  PgUp/PgDn:details  Enter/click:open  t:${nextView}  r:revive  x:kill  Esc:close`,
+			`1:agents  2:activity  j/k/wheel:select  PgUp/PgDn:details  Enter/click:open  t:${nextView}  r:revive  x:kill  Esc:close`,
 		);
 	}
 
@@ -846,7 +1007,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			`Spawned by ${sanitizeDisplayText(ref.parentId ?? MAIN_AGENT_ID)}${children.length > 0 ? ` · ${children.length} children` : ""}`,
 		);
 		if (children.length > 0) add(theme.fg("dim", formatChildIds(children, width)));
-		add(theme.fg("dim", `Registered ${formatLocalDateTimeWithOffset(new Date(ref.createdAt))}`));
++		add(theme.fg("dim", `Registered ${formatLocalDateTimeWithOffset(new Date(ref.createdAt))}`));
 
 		section("Changes");
 		add(
@@ -862,6 +1023,18 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		if (artifacts?.patchPath) addWrapped(`Patch ${shortenPath(artifacts.patchPath)}`);
 		if (artifacts?.branchName) addWrapped(`Worktree branch ${artifacts.branchName}`);
 
+		if (lines.length < rows) add();
+		if (lines.length < rows) add(theme.bold(theme.fg("accent", "Recent activity")));
+		const activityBudget = Math.max(0, rows - lines.length);
+		const activity = this.#activity.recent(ref.id, activityBudget);
+		if (activity.length === 0 && activityBudget > 0) add(theme.fg("muted", "No response or tool activity yet"));
+		else {
+			for (const event of activity) {
+				const title = sanitizeLine(event.kind === "tool" ? (event.toolName ?? event.title) : event.title, width);
+				const prefix = `${theme.fg("dim", activityClock(event.timestamp))} ${activityGlyph(event)} ${theme.fg("muted", title)} `;
+				add(`${prefix}${sanitizeLine(event.summary, Math.max(1, width - visibleWidth(prefix)))}`);
+			}
+		}
 		const maxScroll = Math.max(0, lines.length - rows);
 		this.#detailScrollOffset = Math.min(this.#detailScrollOffset, maxScroll);
 		const visible = lines.slice(this.#detailScrollOffset, this.#detailScrollOffset + rows);
@@ -959,9 +1132,6 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 
 	handleWheel(delta: -1 | 1): void {
 		this.#hoveredRow = null;
-<<<<<<< HEAD
-		if (this.#rows.length > 0) {
-=======
 		if (this.#section === "activity") {
 			if (this.#activityRows.length > 0) {
 				this.#activityFollow = false;
@@ -971,7 +1141,6 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 				);
 			}
 		} else if (this.#rows.length > 0) {
->>>>>>> 3c47d2238 (fix(coding-agent): resolve upstream Agent Hub merge)
 			this.#selectRow(Math.max(0, Math.min(this.#selectedRow + delta, this.#rows.length - 1)));
 		}
 		this.#requestRender();
@@ -988,8 +1157,19 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	}
 
 	clickItem(index: number): void {
-		const selected = this.#rows[index];
-		if (!selected) return;
++		if (this.#section === "activity") {
++			if (index === this.#selectedActivityRow) {
++				const activity = this.#activityRows[index];
++				if (activity) this.openChat(activity.agentId, activity.entryId);
++				return;
++			}
++			this.#activityFollow = false;
++			this.#selectedActivityRow = index;
++			this.#requestRender();
++			return;
++		}
++		const selected = this.#rows[index];
++		if (!selected) return;
 		this.#hoveredRow = index;
 		this.#selectRow(index);
 		this.#requestRender();

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -60,6 +60,7 @@ import {
 	contextGauge,
 	formatChildIds,
 	formatCost,
+	formatMetricColumns,
 	formatMetricDuration,
 	formatMetrics,
 	formatRoleBadge,
@@ -524,7 +525,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			this.#treeParentById = tree.parentById;
 			this.#treeLastSiblingById = tree.lastSiblingById;
 			const maxDepth = Math.max(0, ...tree.depthById.values());
-			this.#treeGutterWidth = Math.min(24, maxDepth * 4);
+			this.#treeGutterWidth = Math.min(28, (maxDepth + 1) * 4);
 		} else {
 			this.#rows = rosterRows;
 			this.#treeDepthById.clear();
@@ -1160,9 +1161,9 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		}
 		const left = fields.join("  ");
 
-		// Fixed-width numeric columns pinned to the right edge: spend, turns,
-		// age. Badges (variable width) sit before the columns so every row's
-		// numeric cells share the same grid.
+		// Line 1 right side carries variable-width badges only. Cost/turns/time
+		// get their own always-present metadata line below so wrapping task text
+		// can never mix with them.
 		const metrics = this.#metricsFor(ref, observed);
 		const meta: string[] = [];
 		const modelRole = observed?.progress?.modelRole ?? ref.history?.modelRole;
@@ -1171,32 +1172,27 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		}
 		const badge = modelBadge(ref, observed);
 		if (badge) meta.push(badge);
-		const spend = theme.fg("dim", metrics ? formatCost(metrics.cost) : "—");
-		const turns = theme.fg("dim", metrics ? `${formatNumber(metrics.requests)} req` : "—");
-		const age = theme.fg("dim", formatAge(Math.max(1, Math.round((Date.now() - ref.lastActivity) / 1000))));
-		const columns = [alignRightCell(spend, 9), alignRightCell(turns, 8), alignRightCell(age, 7)].join("  ");
-		const right = meta.length > 0 ? `${meta.join(theme.sep.dot)}  ${columns}` : columns;
+		const right = meta.join(theme.sep.dot);
 
-		const leftWidth = visibleWidth(left);
-		const rightWidth = visibleWidth(right);
 		const entry: string[] = [];
 		const detailIndent = Math.min(max - 1, 4 + (this.#viewMode === "tree" ? this.#treeGutterWidth : depth * 2));
-		if (leftWidth + 2 + rightWidth <= max) {
+		const leftWidth = visibleWidth(left);
+		const rightWidth = visibleWidth(right);
+		if (rightWidth > 0 && leftWidth + 2 + rightWidth <= max) {
 			entry.push(left + padding(max - leftWidth - rightWidth) + right);
 		} else {
 			entry.push(truncateToWidth(left.replace(/[\r\n]+/g, " "), max));
-			entry.push(`${padding(Math.max(0, detailIndent))}${truncateToWidth(right, Math.max(1, max - detailIndent))}`);
 		}
 
-		const usage = metrics ? theme.fg("dim", formatMetrics(metrics)) : theme.fg("dim", "usage —");
-		const task = observed?.description ?? observed?.progress?.task ?? ref.activity;
+		const indent = padding(Math.max(0, detailIndent));
 		const detailWidth = Math.max(1, max - detailIndent);
-		const details = task
-			? `${theme.fg("muted", sanitizeLine(task, detailWidth))}${theme.fg("dim", theme.sep.dot)}${usage}`
-			: usage;
-		for (const wrapped of wrapTextWithAnsi(details, detailWidth)) {
-			entry.push(`${padding(Math.max(0, detailIndent))}${wrapped}`);
+		const task = observed?.description ?? observed?.progress?.task ?? ref.activity;
+		if (task) {
+			entry.push(`${indent}${theme.fg("muted", truncateToWidth(sanitizeLine(task, detailWidth), detailWidth))}`);
 		}
+		const age = formatAge(Math.max(1, Math.round((Date.now() - ref.lastActivity) / 1000)));
+		const metadata = metrics ? formatMetricColumns(metrics, age) : `usage ${theme.sep.dot} ${age}`;
+		entry.push(`${indent}${theme.fg("dim", metadata)}`);
 		if (!hovered) return entry;
 		return entry.map(lineRow => {
 			const rowWidth = visibleWidth(lineRow);

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -55,7 +55,6 @@ import {
 	STATUS_ORDER,
 } from "./agent-hub-projection";
 import {
-	alignRightCell,
 	clampHubLine,
 	contextGauge,
 	formatChildIds,
@@ -72,6 +71,7 @@ import {
 	statusGlyph,
 	statusText,
 	treeBranch,
+	treeContinuation,
 } from "./agent-hub-renderer";
 import { AgentTranscriptViewer } from "./agent-transcript-viewer";
 import {
@@ -1111,13 +1111,12 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	): string[] {
 		const max = Math.max(1, width);
 		const cursor = selected ? theme.fg("accent", theme.nav.cursor) : " ";
-		const depth = this.#viewMode === "tree" ? (this.#treeDepthById.get(ref.id) ?? 0) : 0;
+		const treeMode = this.#viewMode === "tree";
 		// Tree rails descend from the status dot: the connector sits between the
 		// cursor and the glyph, so child rows hang under their parent's dot.
-		const branch =
-			this.#viewMode === "tree"
-				? treeBranch(ref, max, this.#treeDepthById, this.#treeParentById, this.#treeLastSiblingById)
-				: "";
+		const branch = treeMode
+			? treeBranch(ref, max, this.#treeDepthById, this.#treeParentById, this.#treeLastSiblingById)
+			: "";
 		const id = sanitizeDisplayText(ref.id);
 		const styledId = selected ? theme.bold(theme.fg("accent", id)) : theme.bold(id);
 		const fields: string[] = [`${cursor} ${branch}${statusGlyph(ref.status)} ${styledId}`];
@@ -1147,7 +1146,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		const right = meta.join(theme.sep.dot);
 
 		const entry: string[] = [];
-		const detailIndent = Math.min(max - 1, 4 + (this.#viewMode === "tree" ? visibleWidth(branch) : depth * 2));
+		const detailIndent = Math.min(max - 1, 4 + visibleWidth(branch));
 		const leftWidth = visibleWidth(left);
 		const rightWidth = visibleWidth(right);
 		if (rightWidth > 0 && leftWidth + 2 + rightWidth <= max) {
@@ -1156,7 +1155,10 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			entry.push(truncateToWidth(left.replace(/[\r\n]+/g, " "), max));
 		}
 
-		const indent = padding(Math.max(0, detailIndent));
+		const continuation = treeMode
+			? `  ${treeContinuation(ref, max, this.#treeDepthById, this.#treeParentById, this.#treeLastSiblingById)}  `
+			: "";
+		const indent = treeMode && visibleWidth(continuation) === detailIndent ? continuation : padding(detailIndent);
 		const detailWidth = Math.max(1, max - detailIndent);
 		const task = observed?.description ?? observed?.progress?.task ?? ref.activity;
 		if (task) {

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -1173,7 +1173,6 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		this.#hoveredRow = index;
 		this.#selectRow(index);
 		this.#requestRender();
-		this.#activateAgent(selected);
 	}
 
 	#handleTableInput(keyData: string): void {

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -72,6 +72,7 @@ import {
 	statusText,
 	treeBranch,
 	treeContinuation,
+	treeMetadataIndent,
 } from "./agent-hub-renderer";
 import { AgentTranscriptViewer } from "./agent-transcript-viewer";
 import {
@@ -232,6 +233,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#treeDepthById = new Map<string, number>();
 	#treeParentById = new Map<string, string>();
 	#treeLastSiblingById = new Map<string, boolean>();
+	#treeMaxDepth = 0;
 	/** Fuzzy agent filter (`/`), applied to id and display name. */
 	#agentFilter = "";
 	#agentFilterEditing = false;
@@ -522,11 +524,14 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			this.#treeDepthById = tree.depthById;
 			this.#treeParentById = tree.parentById;
 			this.#treeLastSiblingById = tree.lastSiblingById;
+			this.#treeMaxDepth = 0;
+			for (const depth of tree.depthById.values()) this.#treeMaxDepth = Math.max(this.#treeMaxDepth, depth);
 		} else {
 			this.#rows = rosterRows;
 			this.#treeDepthById.clear();
 			this.#treeParentById.clear();
 			this.#treeLastSiblingById.clear();
+			this.#treeMaxDepth = 0;
 		}
 		const keptIndex = selectedId ? this.#rows.findIndex(ref => ref.id === selectedId) : -1;
 		this.#selectedRow = keptIndex >= 0 ? keptIndex : Math.min(this.#selectedRow, Math.max(0, this.#rows.length - 1));
@@ -1155,10 +1160,16 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			entry.push(truncateToWidth(left.replace(/[\r\n]+/g, " "), max));
 		}
 
+		const ownChildRail = this.#childrenByParent.has(ref.id) ? theme.fg("dim", "│ ") : "  ";
 		const continuation = treeMode
-			? `  ${treeContinuation(ref, max, this.#treeDepthById, this.#treeParentById, this.#treeLastSiblingById)}  `
+			? `  ${treeContinuation(ref, max, this.#treeDepthById, this.#treeParentById, this.#treeLastSiblingById)}${ownChildRail}`
 			: "";
 		const indent = treeMode && visibleWidth(continuation) === detailIndent ? continuation : padding(detailIndent);
+		const metadataIndent = treeMode ? treeMetadataIndent(max, this.#treeMaxDepth) : detailIndent;
+		const metadataPrefix =
+			treeMode && visibleWidth(continuation) === detailIndent
+				? continuation + padding(metadataIndent - detailIndent)
+				: padding(metadataIndent);
 		const detailWidth = Math.max(1, max - detailIndent);
 		const task = observed?.description ?? observed?.progress?.task ?? ref.activity;
 		if (task) {
@@ -1166,7 +1177,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		}
 		const age = formatAge(Math.max(1, Math.round((Date.now() - ref.lastActivity) / 1000)));
 		const metadata = metrics ? formatMetricColumns(metrics, age) : `usage ${theme.sep.dot} ${age}`;
-		entry.push(`${indent}${theme.fg("dim", metadata)}`);
+		entry.push(`${metadataPrefix}${theme.fg("dim", metadata)}`);
 		if (!hovered) return entry;
 		return entry.map(lineRow => {
 			const rowWidth = visibleWidth(lineRow);

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -733,7 +733,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#footer(showingNarrowDetails: boolean, availableWidth: number): string {
 		const nextView = this.#viewMode === "roster" ? "by parent" : "flat";
 		if (showingNarrowDetails) {
-+		return theme.fg("dim", `1:agents  2:activity  Tab:roster  PgUp/PgDn:scroll  Enter:open  t:${nextView}  Esc:roster`);
+		return theme.fg("dim", `1:agents  2:activity  Tab:roster  PgUp/PgDn:scroll  Enter:open  t:${nextView}  Esc:roster`);
 		}
 		if (availableWidth < 96) {
 			return theme.fg("dim", `j/k:select  Enter:open  t:${nextView}  Tab:details  r/x:manage  Esc:close`);
@@ -1007,7 +1007,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			`Spawned by ${sanitizeDisplayText(ref.parentId ?? MAIN_AGENT_ID)}${children.length > 0 ? ` · ${children.length} children` : ""}`,
 		);
 		if (children.length > 0) add(theme.fg("dim", formatChildIds(children, width)));
-+		add(theme.fg("dim", `Registered ${formatLocalDateTimeWithOffset(new Date(ref.createdAt))}`));
+		add(theme.fg("dim", `Registered ${formatLocalDateTimeWithOffset(new Date(ref.createdAt))}`));
 
 		section("Changes");
 		add(
@@ -1157,22 +1157,23 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	}
 
 	clickItem(index: number): void {
-+		if (this.#section === "activity") {
-+			if (index === this.#selectedActivityRow) {
-+				const activity = this.#activityRows[index];
-+				if (activity) this.openChat(activity.agentId, activity.entryId);
-+				return;
-+			}
-+			this.#activityFollow = false;
-+			this.#selectedActivityRow = index;
-+			this.#requestRender();
-+			return;
-+		}
-+		const selected = this.#rows[index];
-+		if (!selected) return;
+		if (this.#section === "activity") {
+			if (index === this.#selectedActivityRow) {
+				const activity = this.#activityRows[index];
+				if (activity) this.openChat(activity.agentId, activity.entryId);
+				return;
+			}
+			this.#activityFollow = false;
+			this.#selectedActivityRow = index;
+			this.#requestRender();
+			return;
+		}
+		const selected = this.#rows[index];
+		if (!selected) return;
 		this.#hoveredRow = index;
 		this.#selectRow(index);
 		this.#requestRender();
+		this.#activateAgent(selected);
 	}
 
 	#handleTableInput(keyData: string): void {

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -84,10 +84,26 @@ const DATA_CHANGE_RENDER_COALESCE_MS = 100;
 /** Double-tap window for the table's left-left "close hub" gesture. */
 const LEFT_TAP_WINDOW_MS = 500;
 
-/** Two-pane mode needs a useful roster and a readable inspector. */
-const SPLIT_MIN_WIDTH = 96;
-const DETAIL_MIN_WIDTH = 34;
-const ROSTER_MIN_WIDTH = 48;
+
+function activityGlyph(row: AgentActivityRow): string {
+	if (row.status === "error") return theme.fg("error", theme.status.error);
+	if (row.status === "aborted") return theme.fg("warning", theme.status.aborted);
+	if (row.status === "pending") return theme.fg("accent", theme.status.running);
+	switch (row.kind) {
+		case "response":
+			return theme.fg("success", "◆");
+		case "tool":
+			return theme.fg("success", theme.status.success);
+		case "irc":
+			return theme.fg("accent", "→");
+		case "lifecycle":
+			return theme.fg("muted", "○");
+	}
+}
+
+function activityClock(timestamp: number): string {
+	return new Date(timestamp).toISOString().slice(11, 19);
+}
 /** Result of one host-backed transcript read for the Agent Hub viewer. */
 export interface AgentHubRemoteTranscript {
 	text: string;
@@ -943,7 +959,19 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 
 	handleWheel(delta: -1 | 1): void {
 		this.#hoveredRow = null;
+<<<<<<< HEAD
 		if (this.#rows.length > 0) {
+=======
+		if (this.#section === "activity") {
+			if (this.#activityRows.length > 0) {
+				this.#activityFollow = false;
+				this.#selectedActivityRow = Math.max(
+					0,
+					Math.min(this.#selectedActivityRow + delta, this.#activityRows.length - 1),
+				);
+			}
+		} else if (this.#rows.length > 0) {
+>>>>>>> 3c47d2238 (fix(coding-agent): resolve upstream Agent Hub merge)
 			this.#selectRow(Math.max(0, Math.min(this.#selectedRow + delta, this.#rows.length - 1)));
 		}
 		this.#requestRender();

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -26,7 +26,13 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@oh-my-pi/pi-tui";
-import { formatAge, formatNumber, getProjectDir, logger } from "@oh-my-pi/pi-utils";
+import { formatAge, formatDuration, formatNumber, getProjectDir, logger } from "@oh-my-pi/pi-utils";
+import {
+	AgentActivityIndex,
+	type AgentActivityKind,
+	type AgentActivityRow,
+	activityRowsFromProgress,
+} from "../../activity";
 import type { KeyId } from "../../config/keybindings";
 import type { Settings } from "../../config/settings";
 import type { MessageRenderer } from "../../extensibility/extensions/types";
@@ -75,7 +81,15 @@ import {
 	topBorderSplit,
 } from "./overlay-box";
 
+/** Two-pane mode needs a useful roster and a readable inspector. */
+const SPLIT_MIN_WIDTH = 96;
+const DETAIL_MIN_WIDTH = 34;
+const ROSTER_MIN_WIDTH = 48;
+
+export type AgentHubSection = "agents" | "activity";
 type HubViewMode = "roster" | "tree";
+type ActivityFilter = "all" | "errors" | "responses" | "tools";
+type ActivityScope = "all" | "agent" | "subtree";
 
 /** Refresh cadence for the relative-time column. */
 const AGE_TICK_MS = 5_000;
@@ -87,6 +101,26 @@ const LEFT_TAP_WINDOW_MS = 500;
 const SPLIT_MIN_WIDTH = 96;
 const DETAIL_MIN_WIDTH = 34;
 const ROSTER_MIN_WIDTH = 48;
+
+function activityGlyph(row: AgentActivityRow): string {
+	if (row.status === "error") return theme.fg("error", theme.status.error);
+	if (row.status === "aborted") return theme.fg("warning", theme.status.aborted);
+	if (row.status === "pending") return theme.fg("accent", theme.status.running);
+	switch (row.kind) {
+		case "response":
+			return theme.fg("success", "◆");
+		case "tool":
+			return theme.fg("success", theme.status.success);
+		case "irc":
+			return theme.fg("accent", "→");
+		case "lifecycle":
+			return theme.fg("muted", "○");
+	}
+}
+
+function activityClock(timestamp: number): string {
+	return new Date(timestamp).toISOString().slice(11, 19);
+}
 /** Result of one host-backed transcript read for the Agent Hub viewer. */
 export interface AgentHubRemoteTranscript {
 	text: string;
@@ -138,6 +172,10 @@ export interface AgentHubDeps {
 	focusAgent?: (id: string) => Promise<void>;
 	/** Current main session file; used to seed parked historical subagents after restart. */
 	sessionFile?: string | null;
+	/** Initial top-level projection; slash commands deep-link into this surface. */
+	initialSection?: AgentHubSection;
+	/** Injectable unified activity source; production creates one from local or remote transcripts. */
+	activity?: AgentActivityIndex;
 
 	/** Collab guest: route actions/transcripts to the host instead of local sessions. */
 	remote?: AgentHubRemote;
@@ -161,6 +199,18 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	readonly persistedSubagentsReady: Promise<void>;
 	/** Prevent the async persisted-session scan from flashing a false empty state. */
 	#loadingPersistedSubagents = false;
+	#section: AgentHubSection;
+	#activity: AgentActivityIndex;
+	#manageActivityLive: boolean;
+	#activityRows: AgentActivityRow[] = [];
+	#selectedActivityRow = 0;
+	#activityFilter: ActivityFilter = "all";
+	#activityScope: ActivityScope = "all";
+	#activitySearch = "";
+	#activitySearchEditing = false;
+	#activityFollow = true;
+	#activitySyncGeneration = 0;
+	#activitySyncStamp = new Map<string, string>();
 
 	// Table state
 	#rows: AgentRef[] = [];
@@ -233,6 +283,9 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		this.#requestRender = deps.requestRender;
 		this.#hubKeys = deps.hubKeys;
 		this.#remote = deps.remote;
+		this.#section = deps.initialSection ?? "agents";
+		this.#activity = deps.activity ?? new AgentActivityIndex({ remote: deps.remote });
+		this.#manageActivityLive = !deps.activity;
 		this.#loadingPersistedSubagents = !this.#remote && Boolean(deps.sessionFile?.endsWith(".jsonl"));
 		this.#ui =
 			deps.ui ??
@@ -251,6 +304,14 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 
 		this.#unsubscribers.push(this.#registry.onChange(() => this.#scheduleDataChange()));
 		this.#unsubscribers.push(this.#observers.onChange(() => this.#scheduleDataChange()));
+		if (!this.#manageActivityLive) {
+			this.#unsubscribers.push(
+				this.#activity.onChange(() => {
+					this.#refreshActivityRows();
+					this.#requestRender();
+				}),
+			);
+		}
 		this.#ageTimer = setInterval(() => {
 			if (this.#hasFallbackLiveSessions) {
 				this.#refreshAggregate(true);
@@ -304,7 +365,11 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 
 	override render(width: number): readonly string[] {
 		const termHeight = this.#ui.terminal?.rows || process.stdout.rows || 40;
-		const frame = this.#renderTable(width, termHeight).map(line => clampHubLine(line, width));
+		const frame = (
+			this.#section === "activity"
+				? this.#renderActivityTable(width, termHeight)
+				: this.#renderTable(width, termHeight)
+		).map(line => clampHubLine(line, width));
 		if (frame.length <= termHeight) return frame;
 
 		// A tiny terminal can leave less room than the fixed chrome needs. Keep
@@ -325,14 +390,26 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			return;
 		}
 
-		// The hub/observe keys always close the overlay (toggle semantics)
 		for (const key of this.#hubKeys) {
 			if (matchesKey(keyData, key)) {
 				this.#onDone();
 				return;
 			}
 		}
-		this.#handleTableInput(keyData);
+		if (this.#section === "activity" && this.#activitySearchEditing) {
+			this.#handleActivitySearchInput(keyData);
+			return;
+		}
+		if (keyData === "1") {
+			this.#switchSection("agents");
+			return;
+		}
+		if (keyData === "2") {
+			this.#switchSection("activity");
+			return;
+		}
+		if (this.#section === "activity") this.#handleActivityInput(keyData);
+		else this.#handleTableInput(keyData);
 	}
 
 	/**
@@ -354,7 +431,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	 * owns the alternate screen; the hub table stays mounted underneath and is
 	 * restored when the viewer closes. No-op without a real TUI (render-only test stub).
 	 */
-	openChat(id: string): void {
+openChat(id: string, entryId?: string): void {
 		if (this.#disposed || !this.#registry.get(id)) return;
 		if (typeof this.#ui.showOverlay !== "function") return;
 		this.#closeTranscriptOverlay();
@@ -362,6 +439,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		let viewer: AgentTranscriptViewer;
 		viewer = new AgentTranscriptViewer({
 			agentId: id,
+			initialEntryId: entryId,
 			registry: this.#registry,
 			remote: this.#remote,
 			observers: this.#observers,
@@ -477,7 +555,78 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		}
 		this.#statusCounts = { running: 0, idle: 0, parked: 0, aborted: 0 };
 		for (const ref of rosterRows) this.#statusCounts[ref.status]++;
-		this.#refreshAggregate();
+this.#refreshAggregate();
+		this.#refreshActivityData(rosterRows);
+		this.#refreshActivityRows();
+	}
+
+	#refreshActivityData(refs: readonly AgentRef[]): void {
+		if (this.#manageActivityLive) {
+			const liveIds = new Set<string>();
+			for (const ref of refs) {
+				const observed = this.#observedById.get(ref.id);
+				if (observed?.progress) {
+					liveIds.add(ref.id);
+					this.#activity.setLive(ref.id, activityRowsFromProgress(observed.progress, observed.lastUpdate));
+				}
+			}
+			for (const ref of refs) {
+				if (!liveIds.has(ref.id)) this.#activity.setLive(ref.id, []);
+			}
+		}
+
+		const generation = ++this.#activitySyncGeneration;
+		const pending: Promise<void>[] = [];
+		for (const ref of refs) {
+			if (!this.#remote && !ref.sessionFile) continue;
+			const stamp = `${ref.sessionFile ?? ""}:${ref.lastActivity}`;
+			if (this.#activitySyncStamp.get(ref.id) === stamp) continue;
+			this.#activitySyncStamp.set(ref.id, stamp);
+			pending.push(this.#activity.sync(ref.id, ref.sessionFile));
+		}
+		if (pending.length === 0) return;
+		void Promise.all(pending).then(() => {
+			if (this.#disposed || generation !== this.#activitySyncGeneration) return;
+			this.#refreshActivityRows();
+			this.#requestRender();
+		});
+	}
+
+	#activityAgentIds(): ReadonlySet<string> | undefined {
+		if (this.#activityScope === "all") return undefined;
+		const selected = this.#rows[this.#selectedRow]?.id;
+		if (!selected) return new Set();
+		const ids = new Set([selected]);
+		if (this.#activityScope === "agent") return ids;
+		const queue = [selected];
+		for (let index = 0; index < queue.length; index++) {
+			for (const child of this.#childrenByParent.get(queue[index]!) ?? []) {
+				if (ids.has(child.id)) continue;
+				ids.add(child.id);
+				queue.push(child.id);
+			}
+		}
+		return ids;
+	}
+
+	#refreshActivityRows(): void {
+		const kinds: ReadonlySet<AgentActivityKind> | undefined =
+			this.#activityFilter === "responses"
+				? new Set(["response"])
+				: this.#activityFilter === "tools"
+					? new Set(["tool"])
+					: undefined;
+		let rows = this.#activity.query({
+			agentIds: this.#activityAgentIds(),
+			kinds,
+			search: this.#activitySearch,
+			limit: 2_000,
+		});
+		if (this.#activityFilter === "errors") rows = rows.filter(row => row.status === "error");
+		this.#activityRows = rows;
+		if (rows.length === 0) this.#selectedActivityRow = 0;
+		else if (this.#activityFollow) this.#selectedActivityRow = rows.length - 1;
+		else this.#selectedActivityRow = Math.min(this.#selectedActivityRow, rows.length - 1);
 	}
 
 	#metricsFor(ref: AgentRef, observed: ObservableSession | undefined): AgentMetrics | undefined {
@@ -499,6 +648,89 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	// ========================================================================
 	// Table view
 	// ========================================================================
+
+	#sectionTabs(): string {
+		const tab = (section: AgentHubSection, label: string): string =>
+			this.#section === section
+				? theme.bg("selectedBg", theme.bold(theme.fg("accent", ` ${label} `)))
+				: theme.fg("muted", ` ${label} `);
+		return `${tab("agents", "1 Agents")}${theme.fg("dim", theme.sep.dot)}${tab("activity", "2 Activity")}`;
+	}
+
+	#renderActivityTable(width: number, termHeight: number): string[] {
+		this.#hitRows.length = 0;
+		const innerWidth = Math.max(1, width - 4);
+		const contentRows = Math.max(1, termHeight - 4);
+		const body: string[] = [this.#sectionTabs()];
+		const selectedAgent = this.#rows[this.#selectedRow]?.id;
+		const scope =
+			this.#activityScope === "all"
+				? "all agents"
+				: this.#activityScope === "agent"
+					? (selectedAgent ?? "selected agent")
+					: `${selectedAgent ?? "selected"} subtree`;
+		const search = this.#activitySearchEditing
+			? theme.fg("accent", `search: ${this.#activitySearch}▌`)
+			: this.#activitySearch
+				? `search: ${this.#activitySearch}`
+				: "search: —";
+		body.push(
+			theme.fg(
+				"dim",
+				`${scope}${theme.sep.dot}${this.#activityFilter}${theme.sep.dot}${this.#activityFollow ? "following" : "paused"}${theme.sep.dot}${search}`,
+			),
+		);
+		if (contentRows >= 8) body.push("");
+
+		const budget = Math.max(0, contentRows - body.length);
+		if (this.#activityRows.length === 0 && budget > 0) {
+			body.push(theme.fg("muted", this.#activitySearch ? "No matching activity" : "No agent activity recorded yet"));
+		} else if (budget > 0) {
+			const selected = Math.min(this.#selectedActivityRow, this.#activityRows.length - 1);
+			const start = this.#activityFollow
+				? Math.max(0, this.#activityRows.length - budget)
+				: Math.max(0, Math.min(selected - Math.floor(budget / 2), this.#activityRows.length - budget));
+			const end = Math.min(this.#activityRows.length, start + budget);
+			if (start > 0) {
+				body.push(theme.fg("dim", `… ${start} earlier`));
+			}
+			for (let index = start + Number(start > 0); index < end; index++) {
+				this.#hitRows[1 + body.length] = index;
+				body.push(this.#formatActivityRow(this.#activityRows[index]!, index === selected, innerWidth));
+			}
+		}
+		while (body.length < contentRows) body.push("");
+
+		const lines = [topBorder(width, "Agent Hub")];
+		for (const line of body.slice(0, contentRows)) lines.push(row(line, width));
+		lines.push(divider(width));
+		lines.push(
+			row(
+				theme.fg(
+					"dim",
+					"1:agents  j/k:select  Enter:transcript  Space:follow  f:filter  s:scope  /:search  Esc:close",
+				),
+				width,
+			),
+		);
+		lines.push(bottomBorder(width));
+		return lines;
+	}
+
+	#formatActivityRow(activity: AgentActivityRow, selected: boolean, width: number): string {
+		const cursor = selected ? theme.fg("accent", theme.nav.cursor) : " ";
+		const ref = this.#registry.get(activity.agentId);
+		const observed = this.#observedById.get(activity.agentId);
+		const role = observed?.progress?.modelRole ?? ref?.history?.modelRole;
+		const roleBadge = role && this.#settings ? `${formatRoleBadge(role, this.#settings)} ` : "";
+		const agent = truncateToWidth(replaceTabs(activity.agentId), Math.max(8, Math.min(18, Math.floor(width * 0.18))));
+		const title = activity.kind === "tool" ? (activity.toolName ?? activity.title) : activity.title;
+		const prefix =
+			`${cursor} ${theme.fg("dim", activityClock(activity.timestamp))} ${activityGlyph(activity)} ` +
+			`${roleBadge}${theme.bold(agent)} ${theme.fg(activity.kind === "response" ? "success" : "muted", title)}`;
+		const available = Math.max(1, width - visibleWidth(prefix) - visibleWidth(theme.sep.dot));
+		return `${prefix}${theme.fg("dim", theme.sep.dot)}${truncateToWidth(activity.summary, available)}`;
+	}
 
 	#renderTable(width: number, termHeight: number): string[] {
 		this.#hitRows.length = 0;
@@ -555,14 +787,14 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	#footer(showingNarrowDetails: boolean, availableWidth: number): string {
 		const nextView = this.#viewMode === "roster" ? "by parent" : "flat";
 		if (showingNarrowDetails) {
-			return theme.fg("dim", `Tab:roster  PgUp/PgDn:scroll  Enter:open  t:${nextView}  Esc:roster`);
+return theme.fg("dim", `1:agents  2:activity  Tab:roster  PgUp/PgDn:scroll  Enter:open  Esc:roster`);
 		}
 		if (availableWidth < 96) {
-			return theme.fg("dim", `j/k:select  Enter:open  t:${nextView}  Tab:details  r/x:manage  Esc:close`);
+			return theme.fg("dim", `1:agents  2:activity  j/k:select  t:${nextView}  Tab:details  r/x:manage`);
 		}
 		return theme.fg(
 			"dim",
-			`j/k/wheel:select  PgUp/PgDn:details  Enter/click:open  t:${nextView}  r:revive  x:kill  Esc:close`,
+`1:agents  2:activity  j/k/wheel:select  PgUp/PgDn:details  Enter/click:open  t:${nextView}  r:revive  x:kill  Esc:close`
 		);
 	}
 
@@ -706,7 +938,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 				: `${inactive("Flat")}${theme.fg("dim", "/")}${active("By parent")}`;
 		const counts = this.#statusSummary();
 		const header = `${theme.bold("Roster")}${theme.fg("dim", theme.sep.dot)}${projection}${counts ? theme.fg("dim", theme.sep.dot) + counts : ""}`;
-		const lines = wrapTextWithAnsi(header, Math.max(1, width));
+		const lines = [this.#sectionTabs(), ...wrapTextWithAnsi(header, Math.max(1, width))];
 
 		const metrics = this.#aggregate;
 		if (metrics.reportedAgents === 0) {
@@ -773,23 +1005,25 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		const add = (line = ""): void => {
 			lines.push(truncateToWidth(line, width));
 		};
-		const addWrapped = (text: string, maxRows = 2): void => {
+const addWrapped = (text: string, maxRows = 2): void => {
 			for (const wrapped of wrapTextWithAnsi(sanitizeLine(text), Math.max(1, width)).slice(0, maxRows)) add(wrapped);
 		};
-		const section = (label: string, contentRows = 0): void => {
+		const section = (sectionLabel: string, contentRows = 0): void => {
 			if (lines.length > 0 && lines.length + 1 + contentRows < rows) add();
-			add(theme.bold(theme.fg("accent", label)));
+			add(theme.bold(theme.fg("accent", sectionLabel)));
 		};
+		const label = (name: string, value: string): string =>
+			`${theme.bold(theme.fg("accent", name))} ${truncateToWidth(sanitizeLine(value), Math.max(1, width - name.length - 1))}`;
 
 		add(`${statusGlyph(ref.status)} ${theme.bold(sanitizeDisplayText(ref.displayName || ref.id))}`);
 		if (ref.displayName && ref.displayName !== ref.id) add(theme.fg("dim", sanitizeDisplayText(ref.id)));
-		const lifecycleDetails = [
+		const lifecycle = [
+			statusText(ref.status, ref.status),
 			metrics ? formatMetricDuration(metrics) : undefined,
 			`active ${formatAge(Math.max(1, Math.round((Date.now() - ref.lastActivity) / 1000)))}`,
 		].filter(Boolean);
-		add(
-			`${statusText(ref.status, ref.status)}${theme.fg("dim", `${theme.sep.dot}${lifecycleDetails.join(theme.sep.dot)}`)}`,
-		);
+		add(lifecycle.join(theme.fg("dim", theme.sep.dot)));
+		add(`Registered ${formatAge(Math.max(1, Math.round((Date.now() - ref.createdAt) / 1000)))}`);
 		const modelDetails: string[] = [];
 		const modelRole = progress?.modelRole ?? ref.history?.modelRole;
 		if (modelRole && this.#settings) modelDetails.push(formatRoleBadge(modelRole, this.#settings));
@@ -798,20 +1032,14 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		if (modelDetails.length > 0) add(modelDetails.join(theme.sep.dot));
 
 		const task = observed?.description ?? progress?.task ?? ref.activity;
-		if (task) {
-			section("Task");
-			addWrapped(task);
-		}
-
+		if (task) add(label("Task", task));
 		const current = progress?.currentTool
 			? `${progress.currentTool}${progress.currentToolArgs ? ` · ${progress.currentToolArgs}` : ""}`
-			: (progress?.lastIntent ?? ref.activity);
-		if (current) {
-			section("Current");
-			addWrapped(current);
-			if (progress?.retryState) {
-				add(theme.fg("warning", `retry ${progress.retryState.attempt}/${progress.retryState.maxAttempts}`));
-			}
+			: progress?.lastIntent;
+		if (current) add(label("Current", current));
+		add(label("Usage", metrics ? formatMetrics(metrics) : "—"));
+		if (metrics?.contextTokens !== undefined && metrics.contextWindow && rows >= 18) {
+			add(contextGauge(metrics.contextTokens, metrics.contextWindow));
 		}
 
 		section("Usage", 1);
@@ -828,10 +1056,6 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		add(
 			`Spawned by ${sanitizeDisplayText(ref.parentId ?? MAIN_AGENT_ID)}${children.length > 0 ? ` · ${children.length} children` : ""}`,
 		);
-		if (children.length > 0) add(theme.fg("dim", formatChildIds(children, width)));
-		add(theme.fg("dim", `Registered ${new Date(ref.createdAt).toISOString().slice(0, 16).replace("T", " ")}Z`));
-
-		section("Changes");
 		add(
 			theme.fg(
 				"dim",
@@ -844,6 +1068,19 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		if (artifacts?.outputPath) addWrapped(`Output ${shortenPath(artifacts.outputPath)}`);
 		if (artifacts?.patchPath) addWrapped(`Patch ${shortenPath(artifacts.patchPath)}`);
 		if (artifacts?.branchName) addWrapped(`Worktree branch ${artifacts.branchName}`);
+
+if (lines.length < rows) add();
+		if (lines.length < rows) add(theme.bold(theme.fg("accent", "Recent activity")));
+		const activityBudget = Math.max(0, rows - lines.length);
+		const activity = this.#activity.recent(ref.id, activityBudget);
+		if (activity.length === 0 && activityBudget > 0) add(theme.fg("muted", "No response or tool activity yet"));
+		else {
+			for (const event of activity) {
+				const title = event.kind === "tool" ? (event.toolName ?? event.title) : event.title;
+				const prefix = `${theme.fg("dim", activityClock(event.timestamp))} ${activityGlyph(event)} ${theme.fg("muted", title)} `;
+				add(`${prefix}${truncateToWidth(event.summary, Math.max(1, width - visibleWidth(prefix)))}`);
+			}
+		}
 
 		const maxScroll = Math.max(0, lines.length - rows);
 		this.#detailScrollOffset = Math.min(this.#detailScrollOffset, maxScroll);
@@ -942,8 +1179,17 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 
 	handleWheel(delta: -1 | 1): void {
 		this.#hoveredRow = null;
-		if (this.#rows.length > 0) {
-			this.#selectRow(Math.max(0, Math.min(this.#selectedRow + delta, this.#rows.length - 1)));
+if (this.#section === "activity") {
+			if (this.#activityRows.length > 0) {
+				this.#activityFollow = false;
+				this.#selectedActivityRow = Math.max(
+					0,
+					Math.min(this.#selectedActivityRow + delta, this.#activityRows.length - 1),
+				);
+			}
+		} else if (this.#rows.length > 0) {
+				this.#selectRow(Math.max(0, Math.min(this.#selectedRow + delta, this.#rows.length - 1)));
+			}
 		}
 		this.#requestRender();
 	}
@@ -953,18 +1199,121 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	}
 
 	setHoverIndex(index: number | null): void {
+		if (this.#section === "activity") return;
 		if (index === this.#hoveredRow) return;
 		this.#hoveredRow = index;
 		this.#requestRender();
 	}
 
 	clickItem(index: number): void {
-		const selected = this.#rows[index];
-		if (!selected) return;
+if (this.#section === "activity") {
+			if (index === this.#selectedActivityRow) {
+				const activity = this.#activityRows[index];
+				if (activity) this.openChat(activity.agentId, activity.entryId);
+				return;
+			}
+			this.#activityFollow = false;
+			this.#selectedActivityRow = index;
+			this.#requestRender();
+			return;
+		}
 		this.#hoveredRow = index;
+		if (index === this.#selectedRow) {
+			const selected = this.#rows[index];
+			if (selected) this.#activateAgent(selected);
+			return;
+		}
 		this.#selectRow(index);
+		this.#refreshActivityRows();
 		this.#requestRender();
 		this.#activateAgent(selected);
+	}
+
+	#switchSection(section: AgentHubSection): void {
+		if (this.#section === section) return;
+		this.#section = section;
+		this.#hoveredRow = null;
+		this.#narrowDetailsOpen = false;
+		if (section === "activity") this.#refreshActivityRows();
+		this.#requestRender();
+	}
+
+	#handleActivitySearchInput(keyData: string): void {
+		if (matchesKey(keyData, "escape") || matchesKey(keyData, "enter") || keyData === "\r" || keyData === "\n") {
+			this.#activitySearchEditing = false;
+		} else if (matchesKey(keyData, "backspace")) {
+			this.#activitySearch = this.#activitySearch.slice(0, -1);
+		} else if (keyData.length === 1 && keyData >= " " && keyData !== "\u007f") {
+			this.#activitySearch += keyData;
+		} else {
+			return;
+		}
+		this.#refreshActivityRows();
+		this.#requestRender();
+	}
+
+	#handleActivityInput(keyData: string): void {
+		if (matchesKey(keyData, "escape")) {
+			if (this.#activitySearch) {
+				this.#activitySearch = "";
+				this.#refreshActivityRows();
+				this.#requestRender();
+			} else {
+				this.#onDone();
+			}
+			return;
+		}
+		if (matchesKey(keyData, "left")) {
+			this.#switchSection("agents");
+			return;
+		}
+		if (keyData === "/") {
+			this.#activitySearchEditing = true;
+			this.#requestRender();
+			return;
+		}
+		if (keyData === " ") {
+			this.#activityFollow = !this.#activityFollow;
+			if (this.#activityFollow && this.#activityRows.length > 0) {
+				this.#selectedActivityRow = this.#activityRows.length - 1;
+			}
+			this.#requestRender();
+			return;
+		}
+		if (keyData === "f") {
+			const filters: ActivityFilter[] = ["all", "errors", "responses", "tools"];
+			this.#activityFilter = filters[(filters.indexOf(this.#activityFilter) + 1) % filters.length]!;
+			this.#refreshActivityRows();
+			this.#requestRender();
+			return;
+		}
+		if (keyData === "s") {
+			const scopes: ActivityScope[] = ["all", "agent", "subtree"];
+			this.#activityScope = scopes[(scopes.indexOf(this.#activityScope) + 1) % scopes.length]!;
+			this.#refreshActivityRows();
+			this.#requestRender();
+			return;
+		}
+		if (matchesKey(keyData, "j") || matchesSelectDown(keyData)) {
+			if (this.#activityRows.length > 0) {
+				this.#activityFollow = false;
+				this.#selectedActivityRow = Math.min(this.#selectedActivityRow + 1, this.#activityRows.length - 1);
+			}
+			this.#requestRender();
+			return;
+		}
+		if (matchesKey(keyData, "k") || matchesSelectUp(keyData)) {
+			if (this.#activityRows.length > 0) {
+				this.#activityFollow = false;
+				this.#selectedActivityRow = Math.max(this.#selectedActivityRow - 1, 0);
+			}
+			this.#requestRender();
+			return;
+		}
+		if (matchesKey(keyData, "enter") || keyData === "\r" || keyData === "\n") {
+			const activity = this.#activityRows[this.#selectedActivityRow];
+			if (activity) this.openChat(activity.agentId, activity.entryId);
+		}
 	}
 
 	#handleTableInput(keyData: string): void {
@@ -999,6 +1348,10 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			this.#requestRender();
 			return;
 		}
+		if (matchesKey(keyData, "right")) {
+			this.#switchSection("activity");
+			return;
+		}
 		if (matchesKey(keyData, "left")) {
 			if (this.#narrowDetailsOpen && !this.#lastRenderWasSplit) {
 				this.#narrowDetailsOpen = false;
@@ -1019,6 +1372,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			if (this.#rows.length > 0) {
 				this.#selectRow(Math.min(this.#selectedRow + 1, this.#rows.length - 1));
 			}
+			this.#refreshActivityRows();
 			this.#requestRender();
 			return;
 		}
@@ -1026,6 +1380,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			if (this.#rows.length > 0) {
 				this.#selectRow(Math.max(this.#selectedRow - 1, 0));
 			}
+			this.#refreshActivityRows();
 			this.#requestRender();
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -1221,15 +1221,13 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			this.#requestRender();
 			return;
 		}
+		const selected = this.#rows[index];
+		if (!selected) return;
 		this.#hoveredRow = index;
-		if (index === this.#selectedRow) {
-			const selected = this.#rows[index];
-			if (selected) this.#activateAgent(selected);
-			return;
-		}
 		this.#selectRow(index);
 		this.#refreshActivityRows();
 		this.#requestRender();
+		this.#activateAgent(selected);
 	}
 
 	#switchSection(section: AgentHubSection): void {

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -114,7 +114,12 @@ function activityGlyph(row: AgentActivityRow): string {
 }
 
 function activityClock(timestamp: number): string {
-	return new Date(timestamp).toISOString().slice(11, 19);
+	return new Date(timestamp).toLocaleTimeString(undefined, {
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		hour12: false,
+	});
 }
 /** Result of one host-backed transcript read for the Agent Hub viewer. */
 export interface AgentHubRemoteTranscript {
@@ -580,11 +585,15 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			pending.push(this.#activity.sync(ref.id, ref.sessionFile));
 		}
 		if (pending.length === 0) return;
-		void Promise.all(pending).then(() => {
-			if (this.#disposed || generation !== this.#activitySyncGeneration) return;
-			this.#refreshActivityRows();
-			this.#requestRender();
-		});
+		void Promise.all(pending)
+			.then(() => {
+				if (this.#disposed || generation !== this.#activitySyncGeneration) return;
+				this.#refreshActivityRows();
+				this.#requestRender();
+			})
+			.catch(() => {
+				// Individual sync paths already guard I/O failures; keep the hub render loop alive.
+			});
 	}
 
 	#activityAgentIds(): ReadonlySet<string> | undefined {

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -936,7 +936,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 				: `${inactive("Flat")}${theme.fg("dim", "/")}${active("By parent")}`;
 		const counts = this.#statusSummary();
 		const header = `${theme.bold("Roster")}${theme.fg("dim", theme.sep.dot)}${projection}${counts ? theme.fg("dim", theme.sep.dot) + counts : ""}`;
-		const lines = [this.#sectionTabs(), ...wrapTextWithAnsi(header, Math.max(1, width))];
+		const lines = wrapTextWithAnsi(header, Math.max(1, width));
 
 		const metrics = this.#aggregate;
 		if (metrics.reportedAgents === 0) {
@@ -1019,7 +1019,6 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			`active ${formatAge(Math.max(1, Math.round((Date.now() - ref.lastActivity) / 1000)))}`,
 		].filter(Boolean);
 		add(lifecycle.join(theme.fg("dim", theme.sep.dot)));
-		add(`Registered ${formatAge(Math.max(1, Math.round((Date.now() - ref.createdAt) / 1000)))}`);
 		const modelDetails: string[] = [];
 		const modelRole = progress?.modelRole ?? ref.history?.modelRole;
 		if (modelRole && this.#settings) modelDetails.push(formatRoleBadge(modelRole, this.#settings));
@@ -1231,7 +1230,6 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 		this.#selectRow(index);
 		this.#refreshActivityRows();
 		this.#requestRender();
-		this.#activateAgent(selected);
 	}
 
 	#switchSection(section: AgentHubSection): void {

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -97,10 +97,6 @@ const DATA_CHANGE_RENDER_COALESCE_MS = 100;
 /** Double-tap window for the table's left-left "close hub" gesture. */
 const LEFT_TAP_WINDOW_MS = 500;
 
-/** Two-pane mode needs a useful roster and a readable inspector. */
-const SPLIT_MIN_WIDTH = 96;
-const DETAIL_MIN_WIDTH = 34;
-const ROSTER_MIN_WIDTH = 48;
 
 function activityGlyph(row: AgentActivityRow): string {
 	if (row.status === "error") return theme.fg("error", theme.status.error);
@@ -1179,7 +1175,7 @@ if (lines.length < rows) add();
 
 	handleWheel(delta: -1 | 1): void {
 		this.#hoveredRow = null;
-if (this.#section === "activity") {
+		if (this.#section === "activity") {
 			if (this.#activityRows.length > 0) {
 				this.#activityFollow = false;
 				this.#selectedActivityRow = Math.max(
@@ -1188,8 +1184,7 @@ if (this.#section === "activity") {
 				);
 			}
 		} else if (this.#rows.length > 0) {
-				this.#selectRow(Math.max(0, Math.min(this.#selectedRow + delta, this.#rows.length - 1)));
-			}
+			this.#selectRow(Math.max(0, Math.min(this.#selectedRow + delta, this.#rows.length - 1)));
 		}
 		this.#requestRender();
 	}

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -26,7 +26,7 @@ import {
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@oh-my-pi/pi-tui";
-import { formatAge, formatDuration, formatNumber, getProjectDir, logger } from "@oh-my-pi/pi-utils";
+import { formatAge, formatNumber, getProjectDir, logger } from "@oh-my-pi/pi-utils";
 import {
 	AgentActivityIndex,
 	type AgentActivityKind,
@@ -96,7 +96,6 @@ const AGE_TICK_MS = 5_000;
 const DATA_CHANGE_RENDER_COALESCE_MS = 100;
 /** Double-tap window for the table's left-left "close hub" gesture. */
 const LEFT_TAP_WINDOW_MS = 500;
-
 
 function activityGlyph(row: AgentActivityRow): string {
 	if (row.status === "error") return theme.fg("error", theme.status.error);
@@ -427,7 +426,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 	 * owns the alternate screen; the hub table stays mounted underneath and is
 	 * restored when the viewer closes. No-op without a real TUI (render-only test stub).
 	 */
-openChat(id: string, entryId?: string): void {
+	openChat(id: string, entryId?: string): void {
 		if (this.#disposed || !this.#registry.get(id)) return;
 		if (typeof this.#ui.showOverlay !== "function") return;
 		this.#closeTranscriptOverlay();
@@ -551,7 +550,7 @@ openChat(id: string, entryId?: string): void {
 		}
 		this.#statusCounts = { running: 0, idle: 0, parked: 0, aborted: 0 };
 		for (const ref of rosterRows) this.#statusCounts[ref.status]++;
-this.#refreshAggregate();
+		this.#refreshAggregate();
 		this.#refreshActivityData(rosterRows);
 		this.#refreshActivityRows();
 	}
@@ -719,13 +718,16 @@ this.#refreshAggregate();
 		const observed = this.#observedById.get(activity.agentId);
 		const role = observed?.progress?.modelRole ?? ref?.history?.modelRole;
 		const roleBadge = role && this.#settings ? `${formatRoleBadge(role, this.#settings)} ` : "";
-		const agent = truncateToWidth(replaceTabs(activity.agentId), Math.max(8, Math.min(18, Math.floor(width * 0.18))));
-		const title = activity.kind === "tool" ? (activity.toolName ?? activity.title) : activity.title;
+		const agent = sanitizeLine(activity.agentId, Math.max(8, Math.min(18, Math.floor(width * 0.18))));
+		const title = sanitizeLine(
+			activity.kind === "tool" ? (activity.toolName ?? activity.title) : activity.title,
+			width,
+		);
 		const prefix =
 			`${cursor} ${theme.fg("dim", activityClock(activity.timestamp))} ${activityGlyph(activity)} ` +
 			`${roleBadge}${theme.bold(agent)} ${theme.fg(activity.kind === "response" ? "success" : "muted", title)}`;
 		const available = Math.max(1, width - visibleWidth(prefix) - visibleWidth(theme.sep.dot));
-		return `${prefix}${theme.fg("dim", theme.sep.dot)}${truncateToWidth(activity.summary, available)}`;
+		return `${prefix}${theme.fg("dim", theme.sep.dot)}${sanitizeLine(activity.summary, available)}`;
 	}
 
 	#renderTable(width: number, termHeight: number): string[] {
@@ -783,14 +785,14 @@ this.#refreshAggregate();
 	#footer(showingNarrowDetails: boolean, availableWidth: number): string {
 		const nextView = this.#viewMode === "roster" ? "by parent" : "flat";
 		if (showingNarrowDetails) {
-return theme.fg("dim", `1:agents  2:activity  Tab:roster  PgUp/PgDn:scroll  Enter:open  Esc:roster`);
+			return theme.fg("dim", `1:agents  2:activity  Tab:roster  PgUp/PgDn:scroll  Enter:open  Esc:roster`);
 		}
 		if (availableWidth < 96) {
 			return theme.fg("dim", `1:agents  2:activity  j/k:select  t:${nextView}  Tab:details  r/x:manage`);
 		}
 		return theme.fg(
 			"dim",
-`1:agents  2:activity  j/k/wheel:select  PgUp/PgDn:details  Enter/click:open  t:${nextView}  r:revive  x:kill  Esc:close`
+			`1:agents  2:activity  j/k/wheel:select  PgUp/PgDn:details  Enter/click:open  t:${nextView}  r:revive  x:kill  Esc:close`,
 		);
 	}
 
@@ -1001,15 +1003,13 @@ return theme.fg("dim", `1:agents  2:activity  Tab:roster  PgUp/PgDn:scroll  Ente
 		const add = (line = ""): void => {
 			lines.push(truncateToWidth(line, width));
 		};
-const addWrapped = (text: string, maxRows = 2): void => {
+		const addWrapped = (text: string, maxRows = 2): void => {
 			for (const wrapped of wrapTextWithAnsi(sanitizeLine(text), Math.max(1, width)).slice(0, maxRows)) add(wrapped);
 		};
-		const section = (sectionLabel: string, contentRows = 0): void => {
+		const section = (label: string, contentRows = 0): void => {
 			if (lines.length > 0 && lines.length + 1 + contentRows < rows) add();
-			add(theme.bold(theme.fg("accent", sectionLabel)));
+			add(theme.bold(theme.fg("accent", label)));
 		};
-		const label = (name: string, value: string): string =>
-			`${theme.bold(theme.fg("accent", name))} ${truncateToWidth(sanitizeLine(value), Math.max(1, width - name.length - 1))}`;
 
 		add(`${statusGlyph(ref.status)} ${theme.bold(sanitizeDisplayText(ref.displayName || ref.id))}`);
 		if (ref.displayName && ref.displayName !== ref.id) add(theme.fg("dim", sanitizeDisplayText(ref.id)));
@@ -1028,14 +1028,20 @@ const addWrapped = (text: string, maxRows = 2): void => {
 		if (modelDetails.length > 0) add(modelDetails.join(theme.sep.dot));
 
 		const task = observed?.description ?? progress?.task ?? ref.activity;
-		if (task) add(label("Task", task));
+		if (task) {
+			section("Task");
+			addWrapped(task);
+		}
+
 		const current = progress?.currentTool
 			? `${progress.currentTool}${progress.currentToolArgs ? ` · ${progress.currentToolArgs}` : ""}`
-			: progress?.lastIntent;
-		if (current) add(label("Current", current));
-		add(label("Usage", metrics ? formatMetrics(metrics) : "—"));
-		if (metrics?.contextTokens !== undefined && metrics.contextWindow && rows >= 18) {
-			add(contextGauge(metrics.contextTokens, metrics.contextWindow));
+			: (progress?.lastIntent ?? ref.activity);
+		if (current) {
+			section("Current");
+			addWrapped(current);
+			if (progress?.retryState) {
+				add(theme.fg("warning", `retry ${progress.retryState.attempt}/${progress.retryState.maxAttempts}`));
+			}
 		}
 
 		section("Usage", 1);
@@ -1052,6 +1058,10 @@ const addWrapped = (text: string, maxRows = 2): void => {
 		add(
 			`Spawned by ${sanitizeDisplayText(ref.parentId ?? MAIN_AGENT_ID)}${children.length > 0 ? ` · ${children.length} children` : ""}`,
 		);
+		if (children.length > 0) add(theme.fg("dim", formatChildIds(children, width)));
+		add(theme.fg("dim", `Registered ${new Date(ref.createdAt).toISOString().slice(0, 16).replace("T", " ")}Z`));
+
+		section("Changes");
 		add(
 			theme.fg(
 				"dim",
@@ -1065,16 +1075,16 @@ const addWrapped = (text: string, maxRows = 2): void => {
 		if (artifacts?.patchPath) addWrapped(`Patch ${shortenPath(artifacts.patchPath)}`);
 		if (artifacts?.branchName) addWrapped(`Worktree branch ${artifacts.branchName}`);
 
-if (lines.length < rows) add();
+		if (lines.length < rows) add();
 		if (lines.length < rows) add(theme.bold(theme.fg("accent", "Recent activity")));
 		const activityBudget = Math.max(0, rows - lines.length);
 		const activity = this.#activity.recent(ref.id, activityBudget);
 		if (activity.length === 0 && activityBudget > 0) add(theme.fg("muted", "No response or tool activity yet"));
 		else {
 			for (const event of activity) {
-				const title = event.kind === "tool" ? (event.toolName ?? event.title) : event.title;
+				const title = sanitizeLine(event.kind === "tool" ? (event.toolName ?? event.title) : event.title, width);
 				const prefix = `${theme.fg("dim", activityClock(event.timestamp))} ${activityGlyph(event)} ${theme.fg("muted", title)} `;
-				add(`${prefix}${truncateToWidth(event.summary, Math.max(1, width - visibleWidth(prefix)))}`);
+				add(`${prefix}${sanitizeLine(event.summary, Math.max(1, width - visibleWidth(prefix)))}`);
 			}
 		}
 
@@ -1201,7 +1211,7 @@ if (lines.length < rows) add();
 	}
 
 	clickItem(index: number): void {
-if (this.#section === "activity") {
+		if (this.#section === "activity") {
 			if (index === this.#selectedActivityRow) {
 				const activity = this.#activityRows[index];
 				if (activity) this.openChat(activity.agentId, activity.entryId);

--- a/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
+++ b/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
@@ -34,6 +34,8 @@ import { formatContextUsage } from "./status-line/context-thresholds";
 
 export interface AgentTranscriptViewerDeps {
 	agentId: string;
+	/** Persisted entry to reveal on first paint when opened from an activity row. */
+	initialEntryId?: string;
 	registry: AgentRegistry;
 	/** Collab guest: read transcript from the host instead of a local file. */
 	remote?: AgentHubRemote;
@@ -158,8 +160,10 @@ export class AgentTranscriptViewer implements Component {
 	#model: string | undefined;
 	#pollTimer: NodeJS.Timeout | undefined;
 	#disposed = false;
+	#initialEntryId: string | undefined;
 
 	constructor(private readonly deps: AgentTranscriptViewerDeps) {
+		this.#initialEntryId = deps.initialEntryId;
 		this.#builder = new ChatTranscriptBuilder({
 			ui: deps.ui,
 			getTool: deps.getTool,
@@ -580,7 +584,16 @@ export class AgentTranscriptViewer implements Component {
 			: this.#builder.container.render(contentWidth);
 		this.#scrollView.setLines(contentLines);
 		this.#scrollView.setHeight(viewportHeight);
-		if (this.#followBottom) this.#scrollView.scrollToBottom();
+		if (this.#initialEntryId) {
+			const targetRow = this.#builder.rowForEntry(this.#initialEntryId);
+			if (targetRow !== undefined) {
+				this.#followBottom = false;
+				this.#scrollView.setScrollOffset(Math.max(0, targetRow - 1));
+				this.#initialEntryId = undefined;
+			}
+		} else if (this.#followBottom) {
+			this.#scrollView.scrollToBottom();
+		}
 
 		const lines: string[] = [];
 		lines.push(...new DynamicBorder().render(width));

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -13,7 +13,7 @@
  */
 import type { AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { Usage } from "@oh-my-pi/pi-ai";
-import type { TUI } from "@oh-my-pi/pi-tui";
+import type { Component, TUI } from "@oh-my-pi/pi-tui";
 import type { AdvisorMessageDetails } from "../../advisor";
 import { COLLAB_PROMPT_MESSAGE_TYPE, type CollabPromptDetails } from "../../collab/protocol";
 import { settings } from "../../config/settings";
@@ -99,6 +99,7 @@ export class ChatTranscriptBuilder {
 	#todoSnapshot: ToolExecutionComponent | null = null;
 	#expandables: Array<{ setExpanded(expanded: boolean): void }> = [];
 	#expanded = false;
+	#entryComponents = new Map<string, Component>();
 
 	constructor(private readonly deps: ChatTranscriptBuilderDeps) {
 		this.container.setToolActivityVisible(!settings.get("display.hideToolActivity"));
@@ -112,7 +113,7 @@ export class ChatTranscriptBuilder {
 	/** Discard all components and rebuild the whole transcript from `entries`. */
 	rebuild(entries: SessionMessageEntry[]): void {
 		this.reset();
-		for (const entry of entries) this.#appendChatMessage(entry.message);
+		for (const entry of entries) this.#appendEntry(entry);
 		// Flush the trailing turn's usage row only once its tools are materialized
 		// (a read whose result has not arrived stays pending); otherwise the row
 		// would sit above its tools. The drain happens here at the end of the pass.
@@ -121,7 +122,7 @@ export class ChatTranscriptBuilder {
 
 	/** Append newly persisted entries without rebuilding already rendered rows. */
 	append(entries: SessionMessageEntry[]): void {
-		for (const entry of entries) this.#appendChatMessage(entry.message);
+		for (const entry of entries) this.#appendEntry(entry);
 		if (this.#readArgs.size === 0 && this.#pendingTools.size === 0) this.#flushPendingUsage();
 	}
 
@@ -133,6 +134,12 @@ export class ChatTranscriptBuilder {
 
 	get expanded(): boolean {
 		return this.#expanded;
+	}
+
+	/** Rendered row where a persisted entry begins, after the container has painted once. */
+	rowForEntry(entryId: string): number | undefined {
+		const component = this.#entryComponents.get(entryId);
+		return component ? this.container.getChildStartRow(component) : undefined;
 	}
 
 	/** Tear down components (sealing pending spinners) and clear build state. */
@@ -152,12 +159,20 @@ export class ChatTranscriptBuilder {
 		this.#waitingPoll = null;
 		this.#todoSnapshot = null;
 		this.#expandables = [];
+		this.#entryComponents.clear();
 		this.container.dispose();
 		this.container.clear();
 	}
 
 	dispose(): void {
 		this.reset();
+	}
+
+	#appendEntry(entry: SessionMessageEntry): void {
+		const before = this.container.children.length;
+		this.#appendChatMessage(entry.message);
+		const component = this.container.children[before];
+		if (component) this.#entryComponents.set(entry.id, component);
 	}
 
 	#trackExpandable(component: { setExpanded(expanded: boolean): void }): void {

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -13,7 +13,7 @@
  */
 import type { AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { Usage } from "@oh-my-pi/pi-ai";
-import type { TUI } from "@oh-my-pi/pi-tui";
+import type { Component, TUI } from "@oh-my-pi/pi-tui";
 import type { AdvisorMessageDetails } from "../../advisor";
 import { COLLAB_PROMPT_MESSAGE_TYPE, type CollabPromptDetails } from "../../collab/protocol";
 import { settings } from "../../config/settings";
@@ -94,6 +94,7 @@ export class ChatTranscriptBuilder {
 	#todoSnapshot: ToolExecutionComponent | null = null;
 	#expandables: Array<{ setExpanded(expanded: boolean): void }> = [];
 	#expanded = false;
+	#entryComponents = new Map<string, Component>();
 
 	constructor(private readonly deps: ChatTranscriptBuilderDeps) {}
 
@@ -105,7 +106,7 @@ export class ChatTranscriptBuilder {
 	/** Discard all components and rebuild the whole transcript from `entries`. */
 	rebuild(entries: SessionMessageEntry[]): void {
 		this.reset();
-		for (const entry of entries) this.#appendChatMessage(entry.message);
+		for (const entry of entries) this.#appendEntry(entry);
 		// Flush the trailing turn's usage row only once its tools are materialized
 		// (a read whose result has not arrived stays pending); otherwise the row
 		// would sit above its tools. The drain happens here at the end of the pass.
@@ -114,7 +115,7 @@ export class ChatTranscriptBuilder {
 
 	/** Append newly persisted entries without rebuilding already rendered rows. */
 	append(entries: SessionMessageEntry[]): void {
-		for (const entry of entries) this.#appendChatMessage(entry.message);
+		for (const entry of entries) this.#appendEntry(entry);
 		if (this.#readArgs.size === 0 && this.#pendingTools.size === 0) this.#flushPendingUsage();
 	}
 
@@ -126,6 +127,12 @@ export class ChatTranscriptBuilder {
 
 	get expanded(): boolean {
 		return this.#expanded;
+	}
+
+	/** Rendered row where a persisted entry begins, after the container has painted once. */
+	rowForEntry(entryId: string): number | undefined {
+		const component = this.#entryComponents.get(entryId);
+		return component ? this.container.getChildStartRow(component) : undefined;
 	}
 
 	/** Tear down components (sealing pending spinners) and clear build state. */
@@ -143,12 +150,20 @@ export class ChatTranscriptBuilder {
 		this.#waitingPoll = null;
 		this.#todoSnapshot = null;
 		this.#expandables = [];
+		this.#entryComponents.clear();
 		this.container.dispose();
 		this.container.clear();
 	}
 
 	dispose(): void {
 		this.reset();
+	}
+
+	#appendEntry(entry: SessionMessageEntry): void {
+		const before = this.container.children.length;
+		this.#appendChatMessage(entry.message);
+		const component = this.container.children[before];
+		if (component) this.#entryComponents.set(entry.id, component);
 	}
 
 	#trackExpandable(component: { setExpanded(expanded: boolean): void }): void {

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -132,6 +132,8 @@ export class TranscriptContainer extends Container {
 	#replayRequested = false;
 	#toolActivityVisible = true;
 	#lastFrame: AnimationFrame = { tick: 0, now: 0 };
+	// Start rows from the last full render(), keyed by child component (transcript deep-links).
+	#childStartRows = new Map<Component, number>();
 
 	override addChild(component: Component): void {
 		if (isToolActivityComponent(component)) component.setToolActivityVisible(this.#toolActivityVisible);
@@ -152,6 +154,7 @@ export class TranscriptContainer extends Container {
 		super.removeChild(component);
 		this.#entries = this.#entries.filter(candidate => candidate.component !== component);
 		this.#frontier = Math.min(this.#frontier, this.#entries.length);
+		this.#childStartRows.delete(component);
 	}
 
 	override clear(): void {
@@ -159,6 +162,7 @@ export class TranscriptContainer extends Container {
 		this.#entries = [];
 		this.#frontier = 0;
 		this.#offered = undefined;
+		this.#childStartRows.clear();
 		this.#replayPending = false;
 		this.#replayRequested = false;
 	}
@@ -454,15 +458,22 @@ export class TranscriptContainer extends Container {
 	/** Full semantic render used by exports and non-terminal commands. */
 	override render(width: number): readonly string[] {
 		this.#syncEntries();
+		this.#childStartRows.clear();
 		const rows: string[] = [];
 		for (const entry of this.#entries) {
 			this.#setAllocation(entry.component, Number.MAX_SAFE_INTEGER, this.#lastFrame);
 			const block = this.#renderEntry(entry, width);
 			if (block.length === 0) continue;
 			if (rows.length > 0) rows.push("");
+			this.#childStartRows.set(entry.component, rows.length);
 			rows.push(...block);
 		}
 		return rows;
+	}
+
+	/** Rendered row where a child's block begins in the last full render() (transcript deep-links). */
+	getChildStartRow(child: Component): number | undefined {
+		return this.#childStartRows.get(child);
 	}
 
 	#renderEntry(entry: TranscriptEntry, width: number): readonly string[] {

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -177,6 +177,12 @@ export class TranscriptContainer
 	// Finalized blocks wholly before this boundary are immutable on-screen history;
 	// their previous contribution can be replayed without calling render().
 	#committedRows = 0;
+
+	/** Row where a rendered child begins, used by transcript deep-links. */
+	getChildStartRow(child: Component): number | undefined {
+		const segment = this.#segments.find(candidate => candidate.component === child);
+		return segment ? segment.startRow + segment.sep : undefined;
+	}
 	// Stable-prefix floor accumulated across renders since the last
 	// getRenderStablePrefixRows() read (see RenderStablePrefix: reading
 	// consumes the report and re-bases the baseline). Out-of-band renders

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -41,7 +41,7 @@ import {
 	setTheme,
 	theme,
 } from "../../modes/theme/theme";
-import type { InteractiveModeContext } from "../../modes/types";
+import type { AgentHubOpenOptions, InteractiveModeContext } from "../../modes/types";
 import type { SessionOAuthAccountList } from "../../session/agent-session-types";
 import type { ResetCreditAccountStatus, ResetCreditRedeemOutcome } from "../../session/auth-storage";
 import {
@@ -2131,10 +2131,7 @@ export class SelectorController {
 		});
 	}
 
-	showAgentHub(
-		observers: SessionObserverRegistry,
-		options?: { requireContent?: boolean; armCloseTap?: boolean },
-	): void {
+	showAgentHub(observers: SessionObserverRegistry, options?: AgentHubOpenOptions): void {
 		const hubKeys = [
 			...this.ctx.keybindings.getKeys("app.agents.hub"),
 			...this.ctx.keybindings.getKeys("app.session.observe"),
@@ -2158,6 +2155,7 @@ export class SelectorController {
 			settings: this.ctx.settings,
 			hubKeys,
 			expandKeys: this.ctx.keybindings.getKeys("app.tools.expand"),
+			initialSection: options?.initialSection,
 			onDone: done,
 			requestRender: () => this.ctx.ui.requestRender(),
 			registry: this.ctx.collabGuest?.agentRegistry,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -40,7 +40,7 @@ import {
 	setTheme,
 	theme,
 } from "../../modes/theme/theme";
-import type { InteractiveModeContext } from "../../modes/types";
+import type { AgentHubOpenOptions, InteractiveModeContext } from "../../modes/types";
 import type { SessionOAuthAccountList } from "../../session/agent-session-types";
 import type { ResetCreditAccountStatus, ResetCreditRedeemOutcome } from "../../session/auth-storage";
 import {
@@ -1993,10 +1993,7 @@ export class SelectorController {
 		});
 	}
 
-	showAgentHub(
-		observers: SessionObserverRegistry,
-		options?: { requireContent?: boolean; armCloseTap?: boolean },
-	): void {
+	showAgentHub(observers: SessionObserverRegistry, options?: AgentHubOpenOptions): void {
 		const hubKeys = [
 			...this.ctx.keybindings.getKeys("app.agents.hub"),
 			...this.ctx.keybindings.getKeys("app.session.observe"),
@@ -2020,6 +2017,7 @@ export class SelectorController {
 			settings: this.ctx.settings,
 			hubKeys,
 			expandKeys: this.ctx.keybindings.getKeys("app.tools.expand"),
+			initialSection: options?.initialSection,
 			onDone: done,
 			requestRender: () => this.ctx.ui.requestRender(),
 			registry: this.ctx.collabGuest?.agentRegistry,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -227,6 +227,7 @@ import {
 } from "./theme/theme";
 import { getSlashCommandTypeIcon } from "./theme/tui-adapters";
 import type {
+	AgentHubOpenOptions,
 	CompactionQueuedMessage,
 	InteractiveModeContext,
 	InteractiveModeInitOptions,
@@ -5420,7 +5421,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		await this.#selectorController.showDebugSelector();
 	}
 
-	showAgentHub(options?: { requireContent?: boolean; armCloseTap?: boolean }): void {
+	showAgentHub(options?: AgentHubOpenOptions): void {
 		this.#selectorController.showAgentHub(this.#observerRegistry, options);
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -210,6 +210,7 @@ import {
 	theme,
 } from "./theme/theme";
 import type {
+	AgentHubOpenOptions,
 	CompactionQueuedMessage,
 	InteractiveModeContext,
 	InteractiveModeInitOptions,
@@ -4652,7 +4653,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		await this.#selectorController.showDebugSelector();
 	}
 
-	showAgentHub(options?: { requireContent?: boolean; armCloseTap?: boolean }): void {
+	showAgentHub(options?: AgentHubOpenOptions): void {
 		this.#selectorController.showAgentHub(this.#observerRegistry, options);
 	}
 

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -104,6 +104,12 @@ export interface RenderSessionContextOptions {
 	preservedLiveToolCallIds?: ReadonlySet<string>;
 }
 
+export interface AgentHubOpenOptions {
+	requireContent?: boolean;
+	armCloseTap?: boolean;
+	initialSection?: "agents" | "activity";
+}
+
 export interface InteractiveModeContext {
 	// UI access
 	ui: TUI;
@@ -434,7 +440,7 @@ export interface InteractiveModeContext {
 	showProviderSetup(): Promise<void>;
 	showHookConfirm(title: string, message: string): Promise<boolean>;
 	showDebugSelector(): Promise<void>;
-	showAgentHub(options?: { requireContent?: boolean; armCloseTap?: boolean }): void;
+	showAgentHub(options?: AgentHubOpenOptions): void;
 	resetObserverRegistry(): void;
 
 	// Input handling

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -101,6 +101,12 @@ export interface RenderSessionContextOptions {
 	preservedLiveToolCallIds?: ReadonlySet<string>;
 }
 
+export interface AgentHubOpenOptions {
+	requireContent?: boolean;
+	armCloseTap?: boolean;
+	initialSection?: "agents" | "activity";
+}
+
 export interface InteractiveModeContext {
 	// UI access
 	ui: TUI;
@@ -400,7 +406,7 @@ export interface InteractiveModeContext {
 	showProviderSetup(): Promise<void>;
 	showHookConfirm(title: string, message: string): Promise<boolean>;
 	showDebugSelector(): Promise<void>;
-	showAgentHub(options?: { requireContent?: boolean; armCloseTap?: boolean }): void;
+	showAgentHub(options?: AgentHubOpenOptions): void;
 	resetObserverRegistry(): void;
 
 	// Input handling

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -472,6 +472,15 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "hub",
+		icon: "agents",
+		description: "Open the live Agent Hub",
+		handleTui: (_command, runtime) => {
+			runtime.ctx.showAgentHub({ initialSection: "activity" });
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
 		name: "branch",
 		icon: "branch",
 		description: "Create a new branch from a previous message",

--- a/packages/coding-agent/src/slash-commands/builtin-session.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-session.ts
@@ -449,6 +449,14 @@ export const BUILTIN_SESSION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "hub",
+		description: "Open the live Agent Hub",
+		handleTui: (_command, runtime) => {
+			runtime.ctx.showAgentHub({ initialSection: "activity" });
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
 		name: "branch",
 		description: "Create a new branch from a previous message",
 		handleTui: (_command, runtime) => {

--- a/packages/coding-agent/test/activity-index.test.ts
+++ b/packages/coding-agent/test/activity-index.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { AgentActivityIndex, activityRowsFromProgress } from "../src/activity";
+
+function messageEntry(id: string, timestamp: number, message: Record<string, unknown>): string {
+	return JSON.stringify({ type: "message", id, timestamp, message: { timestamp, ...message } });
+}
+
+describe("AgentActivityIndex", () => {
+	it("normalizes transcript responses and paired tool calls without duplicating terminal rows", async () => {
+		using tempDir = TempDir.createSync("activity-index-");
+		const sessionFile = path.join(tempDir.path(), "worker.jsonl");
+		await Bun.write(
+			sessionFile,
+			`${[
+				messageEntry("response-1", 1_000, {
+					role: "assistant",
+					content: [{ type: "text", text: "Reviewed the parser\nand found one issue." }],
+				}),
+				messageEntry("tool-call", 2_000, {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "src/a.ts" } }],
+				}),
+				messageEntry("tool-result", 3_000, {
+					role: "toolResult",
+					toolCallId: "call-1",
+					toolName: "read",
+					content: [{ type: "text", text: "file contents" }],
+				}),
+			].join("\n")}\n`,
+		);
+		const activity = new AgentActivityIndex();
+		await activity.sync("Worker", sessionFile);
+
+		const rows = activity.query();
+		expect(rows).toHaveLength(2);
+		expect(rows[0]).toMatchObject({
+			agentId: "Worker",
+			kind: "response",
+			entryId: "response-1",
+			summary: "Reviewed the parser and found one issue.",
+		});
+		expect(rows[1]).toMatchObject({
+			agentId: "Worker",
+			kind: "tool",
+			toolName: "read",
+			status: "success",
+			entryId: "tool-call",
+		});
+		expect(activity.query({ kinds: new Set(["tool"]) })).toHaveLength(1);
+		expect(activity.query({ search: "SRC/A.TS" })).toHaveLength(1);
+	});
+
+	it("tails appended JSONL incrementally and scopes rows by agent subtree", async () => {
+		using tempDir = TempDir.createSync("activity-index-tail-");
+		const parentFile = path.join(tempDir.path(), "parent.jsonl");
+		const childFile = path.join(tempDir.path(), "child.jsonl");
+		await Bun.write(parentFile, `${messageEntry("p1", 1_000, { role: "assistant", content: "Parent result" })}\n`);
+		await Bun.write(childFile, `${messageEntry("c1", 2_000, { role: "assistant", content: "Child result" })}\n`);
+		const activity = new AgentActivityIndex();
+		await Promise.all([activity.sync("Parent", parentFile), activity.sync("Child", childFile)]);
+		expect(activity.query({ agentIds: new Set(["Parent"]) }).map(row => row.agentId)).toEqual(["Parent"]);
+
+		await fs.appendFile(
+			childFile,
+			`${messageEntry("c2", 3_000, { role: "assistant", content: "New child result" })}\n`,
+		);
+		await Promise.all([activity.sync("Parent", parentFile), activity.sync("Child", childFile)]);
+		expect(activity.query({ agentIds: new Set(["Parent", "Child"]) }).map(row => row.entryId)).toEqual([
+			"p1",
+			"c1",
+			"c2",
+		]);
+	});
+
+	it("normalizes live progress into lifecycle, tool, and response rows", () => {
+		const rows = activityRowsFromProgress(
+			{
+				id: "Worker",
+				task: "Audit auth",
+				status: "running",
+				lastUpdate: 4_000,
+				currentTool: "read",
+				currentToolArgs: "src/auth.ts",
+				currentToolStartMs: 3_900,
+				recentOutput: ["Found unsafe redirect"],
+				recentTools: [{ tool: "grep", args: "redirect", endMs: 3_800 }],
+			} as never,
+			4_000,
+		);
+		expect(rows.map(row => row.kind)).toEqual(["tool", "tool", "lifecycle", "response"]);
+		expect(rows.at(-1)?.summary).toBe("Found unsafe redirect");
+	});
+});

--- a/packages/coding-agent/test/activity-index.test.ts
+++ b/packages/coding-agent/test/activity-index.test.ts
@@ -93,4 +93,47 @@ describe("AgentActivityIndex", () => {
 		expect(rows.map(row => row.kind)).toEqual(["tool", "tool", "lifecycle", "response"]);
 		expect(rows.at(-1)?.summary).toBe("Found unsafe redirect");
 	});
+
+	it("bounds retained rows and drops terminal tool mappings after eviction", async () => {
+		using tempDir = TempDir.createSync("activity-index-bound-");
+		const sessionFile = path.join(tempDir.path(), "worker.jsonl");
+		const lines: string[] = [];
+		for (let index = 0; index < 300; index++) {
+			const callId = `call-${index}`;
+			lines.push(
+				messageEntry(`tool-call-${index}`, index * 2 + 1_000, {
+					role: "assistant",
+					content: [{ type: "toolCall", id: callId, name: "read", arguments: { path: `src/${index}.ts` } }],
+				}),
+			);
+			lines.push(
+				messageEntry(`tool-result-${index}`, index * 2 + 1_001, {
+					role: "toolResult",
+					toolCallId: callId,
+					toolName: "read",
+					content: [{ type: "text", text: "ok" }],
+				}),
+			);
+		}
+		await Bun.write(sessionFile, `${lines.join("\n")}\n`);
+		const activity = new AgentActivityIndex();
+		await activity.sync("Worker", sessionFile);
+		const rows = activity.query({ agentIds: new Set(["Worker"]), limit: 2_000 });
+		expect(rows.length).toBe(256);
+		expect(rows[0]?.toolCallId).toBe("call-44");
+		expect(rows.at(-1)?.toolCallId).toBe("call-299");
+		expect(activity.retainedToolMappings("Worker")).toBe(0);
+	});
+
+	it("swallows rejecting remote transcript reads without throwing", async () => {
+		const activity = new AgentActivityIndex({
+			remote: {
+				readTranscript: async () => {
+					throw new Error("host unavailable");
+				},
+			},
+		});
+		await expect(activity.sync("Guest")).resolves.toBeUndefined();
+		expect(activity.query()).toEqual([]);
+	});
 });

--- a/packages/coding-agent/test/agent-hub-activate.test.ts
+++ b/packages/coding-agent/test/agent-hub-activate.test.ts
@@ -303,7 +303,7 @@ describe("Agent hub Enter activation", () => {
 		});
 		const workerEntry = renderedRosterEntry(hub, "Worker", 120);
 		expect(workerEntry).toContain("Inspect dependency boundaries and report unsafe coupling.");
-		expect(workerEntry.replace(/\s+/g, " ")).toContain("usage —");
+		expect(workerEntry.replace(/\s+/g, " ")).toContain("usage ·");
 		expect(workerEntry).not.toContain("$0.000");
 		hub.dispose();
 	});

--- a/packages/coding-agent/test/agent-hub-activate.test.ts
+++ b/packages/coding-agent/test/agent-hub-activate.test.ts
@@ -68,7 +68,7 @@ function makeHub(focusAgent: (id: string) => Promise<void>) {
 	return { hub, doneCalls: () => doneCalls, done: done.promise, renderRequested: renderRequested.promise };
 }
 
-const ROSTER_ENTRY_PATTERN = /^(❯| ) (\S+) (?:(?:(?:│ {3}| {4})*)(?:├── |└── ))?(\S+)/u;
+const ROSTER_ENTRY_PATTERN = /^(❯| ) (?:(?:(?:│ {3}| {4})*)(?:├── |└── ))?(\S+) (\S+)/u;
 
 function renderedRosterEntry(hub: AgentHubOverlayComponent, id: string, width: number): string {
 	const cells = hub.render(width).map(raw => {
@@ -255,7 +255,7 @@ describe("Agent hub Enter activation", () => {
 		expect(agents.get("Parent")?.parentId).toBe("Main");
 		expect(agents.get("Child")?.parentId).toBe("Parent");
 		hub.handleInput("t");
-		expect(Bun.stripANSI(renderedRosterEntry(hub, "Child", 120))).toContain("└── Child");
+		expect(Bun.stripANSI(renderedRosterEntry(hub, "Child", 120))).toContain("└── ○ Child");
 		hub.dispose();
 	});
 

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -977,6 +977,31 @@ describe("Agent hub row ordering", () => {
 			hub.dispose();
 		}
 	});
+	it("keeps tree rails continuous across task and metrics rows", () => {
+		geometry = stubStdoutGeometry(120);
+		geometry.setRows(32);
+		const agents = new AgentRegistry();
+		agents.register({ id: "Parent", displayName: "Parent", kind: "sub", parentId: "Main", session: null });
+		agents.register({ id: "First", displayName: "First", kind: "sub", parentId: "Parent", session: null });
+		agents.setActivity("First", "First task");
+		agents.register({ id: "Grandchild", displayName: "Grandchild", kind: "sub", parentId: "First", session: null });
+		agents.setActivity("Grandchild", "Grandchild task");
+		agents.register({ id: "Last", displayName: "Last", kind: "sub", parentId: "Parent", session: null });
+		agents.setActivity("Last", "Last task");
+		const hub = makeHub(agents);
+
+		try {
+			hub.handleInput("t");
+			const firstDetails = renderedRosterEntry(hub, "First", 120).split("\n").slice(1);
+			const grandchildDetails = renderedRosterEntry(hub, "Grandchild", 120).split("\n").slice(1);
+			const lastDetails = renderedRosterEntry(hub, "Last", 120).split("\n").slice(1);
+			expect(firstDetails.every(line => line.startsWith("  │     "))).toBe(true);
+			expect(grandchildDetails.every(line => line.startsWith("  │         "))).toBe(true);
+			expect(lastDetails.every(line => line.startsWith("        ") && !line.includes("│"))).toBe(true);
+		} finally {
+			hub.dispose();
+		}
+	});
 
 	it("keeps cyclic parent links renderable in tree mode", () => {
 		const agents = new AgentRegistry();

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -770,7 +770,7 @@ describe("Agent hub row ordering", () => {
 
 			const historical = renderedRosterEntry(hub, "Historical", 160);
 			expect(historical).toContain("Restored task");
-			expect(historical).toContain("usage —");
+			expect(historical).toMatch(/usage\s+·/);
 			expect(historical).not.toContain("$0.000");
 		} finally {
 			hub.dispose();
@@ -833,8 +833,8 @@ describe("Agent hub row ordering", () => {
 		try {
 			const rendered = Bun.stripANSI(hub.render(160).join("\n"));
 			expect(rendered).toContain("0/2 measured");
-			expect(renderedRosterEntry(hub, "Incomplete", 160)).toContain("usage —");
-			expect(renderedRosterEntry(hub, "NonFinite", 160)).toContain("usage —");
+			expect(renderedRosterEntry(hub, "Incomplete", 160)).toMatch(/usage\s+·/);
+			expect(renderedRosterEntry(hub, "NonFinite", 160)).toMatch(/usage\s+·/);
 			expect(getSessionStats).not.toHaveBeenCalled();
 		} finally {
 			hub.dispose();

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -157,7 +157,7 @@ describe("Agent hub row ordering", () => {
 		}
 	});
 
-	it("freezes the initial lastActivity order while the hub is open", () => {
+	it("re-sorts rows by most-recent activity while the hub is open", () => {
 		vi.useFakeTimers();
 		let hub: AgentHubOverlayComponent | undefined;
 		try {
@@ -177,22 +177,44 @@ describe("Agent hub row ordering", () => {
 
 			hub = makeHub(agents);
 			expect(renderedAgentIds(hub)).toEqual(["C", "B", "A"]);
-			// Bump A's lastActivity far ahead of the others; captured order wins.
+			// Bump A's lastActivity far ahead of the others; recency wins live.
 			setSystemTime(4000);
 			agents.setActivity("A", "still running");
 
-			// Status changes must not reorder the captured roster either.
-			agents.setStatus("B", "idle");
-
-			// Registering a new agent schedules a coalesced row refresh; even a
-			// different status is appended after all rows captured on open.
+			// A parked agent sorts below live ones by status order.
 			setSystemTime(5000);
 			const sessionD = {} as AgentSession;
 			agents.register({ id: "D", displayName: "Delta", kind: "sub", session: sessionD, status: "parked" });
-
+			// Renders coalesce: the immediate frame still shows the captured order.
 			expect(renderedAgentIds(hub)).toEqual(["C", "B", "A"]);
 			vi.advanceTimersByTime(100);
-			expect(renderedAgentIds(hub)).toEqual(["C", "B", "A", "D"]);
+			expect(renderedAgentIds(hub)).toEqual(["A", "C", "B", "D"]);
+		} finally {
+			hub?.dispose();
+			vi.useRealTimers();
+			setSystemTime();
+		}
+	});
+
+	it("filters agents with a fuzzy query and clears on Escape", () => {
+		vi.useFakeTimers();
+		let hub: AgentHubOverlayComponent | undefined;
+		try {
+			geometry = stubStdoutGeometry(120);
+			const agents = new AgentRegistry();
+			const sessionA = {} as AgentSession;
+			agents.register({ id: "alpha-one", displayName: "Alpha", kind: "sub", session: sessionA });
+			const sessionB = {} as AgentSession;
+			agents.register({ id: "beta-two", displayName: "Beta", kind: "sub", session: sessionB });
+
+			hub = makeHub(agents);
+			expect(renderedAgentIds(hub)).toEqual(["alpha-one", "beta-two"]);
+			hub.handleInput("/");
+			hub.handleInput("a");
+			hub.handleInput("p");
+			expect(renderedAgentIds(hub)).toEqual(["alpha-one"]);
+			hub.handleInput("\u001b");
+			expect(renderedAgentIds(hub)).toEqual(["alpha-one", "beta-two"]);
 		} finally {
 			hub?.dispose();
 			vi.useRealTimers();

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -62,7 +62,7 @@ interface RenderedAgentRow {
 	selected: boolean;
 }
 
-const ROSTER_ENTRY_PATTERN = /^(❯| ) (\S+) (?:(?:(?:│ {3}| {4})*)(?:├── |└── ))?(\S+)/u;
+const ROSTER_ENTRY_PATTERN = /^(❯| ) (?:(?:(?:│ {3}| {4})*)(?:├── |└── ))?(\S+) (\S+)/u;
 
 function rosterCell(raw: string): string | undefined {
 	const line = Bun.stripANSI(raw);
@@ -970,9 +970,9 @@ describe("Agent hub row ordering", () => {
 
 		try {
 			hub.handleInput("t");
-			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "First", 120))).toContain("├── First");
-			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "Grandchild", 120))).toContain("│   └── Grandchild");
-			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "Last", 120))).toContain("└── Last");
+			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "First", 120))).toContain("├── ⟳ First");
+			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "Grandchild", 120))).toContain("│   └── ⟳ Grandchild");
+			expect(Bun.stripANSI(renderedRosterHeaderLineRaw(hub, "Last", 120))).toContain("└── ⟳ Last");
 		} finally {
 			hub.dispose();
 		}

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -15,6 +15,7 @@ import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { visibleWidth } from "@oh-my-pi/pi-tui/utils";
+import { AgentActivityIndex, type AgentActivityRow } from "../src/activity";
 
 interface GeometryStub {
 	setRows(n: number): void;
@@ -1017,6 +1018,71 @@ describe("Agent hub row ordering", () => {
 
 			hub.handleInput("\x1b");
 			expect(Bun.stripANSI(hub.render(80).join("\n"))).toContain("Roster");
+		} finally {
+			hub.dispose();
+		}
+	});
+
+	it("renders and operates the unified Activity view with transcript deep-links", () => {
+		geometry = stubStdoutGeometry(120);
+		geometry.setRows(28);
+		const agents = new AgentRegistry();
+		agents.register({ id: "Worker", displayName: "Worker", kind: "sub", parentId: "Main", session: null });
+		const activity = new AgentActivityIndex();
+		activity.setLive("Worker", [
+			{
+				id: "tool-error",
+				agentId: "Worker",
+				timestamp: 1_000,
+				kind: "tool",
+				title: "read",
+				summary: "src/auth.ts",
+				status: "error",
+				toolName: "read",
+				source: "live",
+			},
+			{
+				id: "response",
+				agentId: "Worker",
+				timestamp: 2_000,
+				kind: "response",
+				title: "Response",
+				summary: "Reviewed the authentication boundary",
+				status: "success",
+				entryId: "entry-42",
+				source: "transcript",
+			},
+		] satisfies AgentActivityRow[]);
+		const hub = makeHub(agents, { activity, initialSection: "activity" });
+
+		try {
+			const initial = Bun.stripANSI(hub.render(120).join("\n"));
+			expect(initial).toContain("2 Activity");
+			expect(initial).toContain("src/auth.ts");
+			expect(initial).toContain("Reviewed the authentication boundary");
+
+			hub.handleInput("f");
+			const errors = Bun.stripANSI(hub.render(120).join("\n"));
+			expect(errors).toContain("errors");
+			expect(errors).toContain("src/auth.ts");
+			expect(errors).not.toContain("Reviewed the authentication boundary");
+
+			hub.handleInput("f");
+			hub.handleInput("/");
+			for (const key of "authentication") hub.handleInput(key);
+			hub.handleInput("\r");
+			const searched = Bun.stripANSI(hub.render(120).join("\n"));
+			expect(searched).toContain("responses");
+			expect(searched).toContain("authentication");
+			expect(searched).not.toContain("src/auth.ts");
+
+			const open = vi.spyOn(hub, "openChat");
+			hub.handleInput("\r");
+			expect(open).toHaveBeenCalledWith("Worker", "entry-42");
+			hub.handleInput(" ");
+			expect(Bun.stripANSI(hub.render(120).join("\n"))).toContain("paused");
+			hub.handleInput("1");
+			expect(Bun.stripANSI(hub.render(120).join("\n"))).toContain("Roster");
 		} finally {
 			hub.dispose();
 		}

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -63,6 +63,11 @@ interface RenderedAgentRow {
 }
 
 const ROSTER_ENTRY_PATTERN = /^(❯| ) (?:(?:(?:│ {3}| {4})*)(?:├── |└── ))?(\S+) (\S+)/u;
+function rosterEntryMatch(cell: string | undefined): RegExpExecArray | null {
+	if (!cell) return null;
+	const match = ROSTER_ENTRY_PATTERN.exec(cell);
+	return match?.[2] === "│" ? null : match;
+}
 
 function rosterCell(raw: string): string | undefined {
 	const line = Bun.stripANSI(raw);
@@ -73,13 +78,11 @@ function rosterCell(raw: string): string | undefined {
 }
 
 function renderedAgentRows(hub: AgentHubOverlayComponent, width = 120): RenderedAgentRow[] {
-	// Roster entry first cells are
-	// `<cursor> <status-glyph> [tree-prefix] <id> …`; task cells are
-	// indented deeper and never match the cursor/status slots.
+	// `<cursor> <status-glyph> [tree-prefix] <id> …`; continuation rows may
+	// carry `│` in the status column and are rejected by rosterEntryMatch.
 	const rows: RenderedAgentRow[] = [];
 	for (const raw of hub.render(width)) {
-		const cell = rosterCell(raw);
-		const match = cell ? ROSTER_ENTRY_PATTERN.exec(cell) : null;
+		const match = rosterEntryMatch(rosterCell(raw));
 		if (match) rows.push({ id: match[3]!, selected: match[1] === "❯" });
 	}
 	return rows;
@@ -95,26 +98,19 @@ function selectedAgentId(hub: AgentHubOverlayComponent): string | undefined {
 
 function renderedRosterEntry(hub: AgentHubOverlayComponent, id: string, width: number): string {
 	const cells = hub.render(width).map(rosterCell);
-	const start = cells.findIndex(cell => {
-		const match = cell ? ROSTER_ENTRY_PATTERN.exec(cell) : null;
-		return match?.[3] === id;
-	});
+	const start = cells.findIndex(cell => rosterEntryMatch(cell)?.[3] === id);
 	expect(start).toBeGreaterThanOrEqual(0);
 	const entry: string[] = [];
 	for (let i = start; i < cells.length; i++) {
 		const cell = cells[i];
 		if (cell === undefined || cell.trim().length === 0) break;
-		if (i > start && ROSTER_ENTRY_PATTERN.test(cell)) break;
+		if (i > start && rosterEntryMatch(cell)) break;
 		entry.push(cell.trimEnd());
 	}
 	return entry.join("\n");
 }
 function renderedRosterHeaderLineRaw(hub: AgentHubOverlayComponent, id: string, width: number): string {
-	const line = hub.render(width).find(raw => {
-		const cell = rosterCell(raw);
-		const match = cell ? ROSTER_ENTRY_PATTERN.exec(cell) : null;
-		return match?.[3] === id;
-	});
+	const line = hub.render(width).find(raw => rosterEntryMatch(rosterCell(raw))?.[3] === id);
 	if (!line) throw new Error(`No rendered roster header for ${id}`);
 	return line;
 }
@@ -982,6 +978,7 @@ describe("Agent hub row ordering", () => {
 		geometry.setRows(32);
 		const agents = new AgentRegistry();
 		agents.register({ id: "Parent", displayName: "Parent", kind: "sub", parentId: "Main", session: null });
+		agents.setActivity("Parent", "Parent task");
 		agents.register({ id: "First", displayName: "First", kind: "sub", parentId: "Parent", session: null });
 		agents.setActivity("First", "First task");
 		agents.register({ id: "Grandchild", displayName: "Grandchild", kind: "sub", parentId: "First", session: null });
@@ -992,12 +989,23 @@ describe("Agent hub row ordering", () => {
 
 		try {
 			hub.handleInput("t");
+			const parentDetails = renderedRosterEntry(hub, "Parent", 120).split("\n").slice(1);
 			const firstDetails = renderedRosterEntry(hub, "First", 120).split("\n").slice(1);
 			const grandchildDetails = renderedRosterEntry(hub, "Grandchild", 120).split("\n").slice(1);
 			const lastDetails = renderedRosterEntry(hub, "Last", 120).split("\n").slice(1);
-			expect(firstDetails.every(line => line.startsWith("  │     "))).toBe(true);
+			expect(parentDetails).toHaveLength(2);
+			expect(firstDetails).toHaveLength(2);
+			expect(grandchildDetails).toHaveLength(2);
+			expect(lastDetails).toHaveLength(2);
+			expect(parentDetails.every(line => line.startsWith("  │ "))).toBe(true);
+			expect(firstDetails.every(line => line.startsWith("  │   │ "))).toBe(true);
 			expect(grandchildDetails.every(line => line.startsWith("  │         "))).toBe(true);
 			expect(lastDetails.every(line => line.startsWith("        ") && !line.includes("│"))).toBe(true);
+			const metadataOrigins = [parentDetails, firstDetails, grandchildDetails, lastDetails].map(lines =>
+				lines[1]!.indexOf("usage"),
+			);
+			expect(new Set(metadataOrigins)).toEqual(new Set([metadataOrigins[0]]));
+			expect(metadataOrigins[0]).toBeGreaterThan(0);
 		} finally {
 			hub.dispose();
 		}

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -15,6 +15,7 @@ import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { visibleWidth } from "@oh-my-pi/pi-tui/utils";
+import { AgentActivityIndex, type AgentActivityRow } from "../src/activity";
 
 interface GeometryStub {
 	setRows(n: number): void;
@@ -952,6 +953,71 @@ describe("Agent hub row ordering", () => {
 
 			hub.handleInput("\x1b");
 			expect(Bun.stripANSI(hub.render(80).join("\n"))).toContain("Roster");
+		} finally {
+			hub.dispose();
+		}
+	});
+
+	it("renders and operates the unified Activity view with transcript deep-links", () => {
+		geometry = stubStdoutGeometry(120);
+		geometry.setRows(28);
+		const agents = new AgentRegistry();
+		agents.register({ id: "Worker", displayName: "Worker", kind: "sub", parentId: "Main", session: null });
+		const activity = new AgentActivityIndex();
+		activity.setLive("Worker", [
+			{
+				id: "tool-error",
+				agentId: "Worker",
+				timestamp: 1_000,
+				kind: "tool",
+				title: "read",
+				summary: "src/auth.ts",
+				status: "error",
+				toolName: "read",
+				source: "live",
+			},
+			{
+				id: "response",
+				agentId: "Worker",
+				timestamp: 2_000,
+				kind: "response",
+				title: "Response",
+				summary: "Reviewed the authentication boundary",
+				status: "success",
+				entryId: "entry-42",
+				source: "transcript",
+			},
+		] satisfies AgentActivityRow[]);
+		const hub = makeHub(agents, { activity, initialSection: "activity" });
+
+		try {
+			const initial = Bun.stripANSI(hub.render(120).join("\n"));
+			expect(initial).toContain("2 Activity");
+			expect(initial).toContain("src/auth.ts");
+			expect(initial).toContain("Reviewed the authentication boundary");
+
+			hub.handleInput("f");
+			const errors = Bun.stripANSI(hub.render(120).join("\n"));
+			expect(errors).toContain("errors");
+			expect(errors).toContain("src/auth.ts");
+			expect(errors).not.toContain("Reviewed the authentication boundary");
+
+			hub.handleInput("f");
+			hub.handleInput("/");
+			for (const key of "authentication") hub.handleInput(key);
+			hub.handleInput("\r");
+			const searched = Bun.stripANSI(hub.render(120).join("\n"));
+			expect(searched).toContain("responses");
+			expect(searched).toContain("authentication");
+			expect(searched).not.toContain("src/auth.ts");
+
+			const open = vi.spyOn(hub, "openChat");
+			hub.handleInput("\r");
+			expect(open).toHaveBeenCalledWith("Worker", "entry-42");
+			hub.handleInput(" ");
+			expect(Bun.stripANSI(hub.render(120).join("\n"))).toContain("paused");
+			hub.handleInput("1");
+			expect(Bun.stripANSI(hub.render(120).join("\n"))).toContain("Roster");
 		} finally {
 			hub.dispose();
 		}


### PR DESCRIPTION
## Summary
- Add a bounded incremental activity index over live progress and persisted transcripts.
- Add an Activity projection to Agent Hub with filters, search, scopes, follow-tail, and transcript deep-links.
- Add `/hub` as the live-operations entry point while preserving `/agents` configuration semantics.
- Keep Bash-style tree ancestry rails continuous through every agent's task and metrics rows; multiline entries no longer leave broken gaps between `├──`, `│`, and `└──`.

This is the first PR in a 2-PR stack. Follow-up: durable Agent Hub messages / IRC in #7975 (`staging/agent-hub-messages`).

## Context
Restaged onto current `main` after the fullscreen Agent Hub merge (#7551). Conflict resolution preserves upstream inspector semantics (viewport capacity, click activation, section routing) while integrating the activity surface.

The showcase session exposed a multiline tree defect: identity rows rendered the branch connector, but task and metrics rows replaced the ancestry scaffold with spaces. Commit `eed90f276` adds continuation prefixes that preserve both ancestor rails and last-sibling closure, with a dedicated regression.

## Verification
- Activity-tip `test/agent-hub-ordering.test.ts` — **23 pass / 0 fail**
- Current stacked-tip Agent Hub ordering suite — **30 pass / 0 fail**
- `bun check` on both Activity and stacked Messages tips — pass
- Actual `omp-dev --resume` smoke on the stacked tip (`omp/18.0.8`):
  - 10 persisted agents across three nesting levels
  - 28 transcript-backed Activity rows
  - response/tool filtering, success/error states, role badges, and transcript summaries rendered in the real TUI
  - isolated showcase fork confirmed continuous rails across nested task and metrics rows

## Performance note
A pathological legacy validation session contains a 2.0GB root transcript plus 5.6GB of nested agent transcripts and 1,942 agents. Agent Hub's existing eager persisted-agent restoration takes **22.1s warm / 27.1s cold observed**; the root scan alone takes **8.9s**. Source-mode startup itself is ~90ms.

The scaling cost is the existing O(total transcript bytes) roster/history restore, not the bounded Activity tail index. Recommended follow-up: hydrate metrics only for visible/selected rows, then add a compact roster sidecar with transcript fallback.

## Test plan
- [ ] Open Agent Hub via `/hub` and confirm Activity is the default live view
- [ ] Confirm `/agents` still opens configuration semantics
- [ ] Toggle `By parent`; nested task/metrics rows retain continuous ancestry rails
- [ ] Filter / search / scope activity; follow-tail stays pinned
- [ ] Deep-link from an activity row into the matching transcript
- [ ] Resize / narrow layouts without overflow
