### PR TITLE
fix(ai): retry replay-safe OpenAI stream failures

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Retried transient mid-stream socket closures for OpenAI Responses, Chat Completions, Azure OpenAI Responses, and Codex SSE when no replay-unsafe output was emitted ([#7979](https://github.com/can1357/oh-my-pi/issues/7979)).
+
 ## [17.2.11] - 2026-08-07
 
 ### Breaking Changes

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Renamed the internal stream-retry helper `withEmptyCompletionRetry` to `withReplaySafeStreamRetry` (module `@oh-my-pi/pi-ai/utils/empty-completion-retry`), now taking a policy argument (`retryEmptyCompletion` / `retryProviderErrors`). Callers of the old export must migrate ([#7979](https://github.com/can1357/oh-my-pi/issues/7979)).
+
 ### Fixed
 
 - Retried transient mid-stream socket closures for OpenAI Responses, Chat Completions, Azure OpenAI Responses, and Codex SSE when no replay-unsafe output was emitted ([#7979](https://github.com/can1357/oh-my-pi/issues/7979)).

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -54,7 +54,7 @@ import {
 	kStreamingLastParseLen,
 	kStreamingPartialJson,
 } from "../utils/block-symbols";
-import { withEmptyCompletionRetry } from "../utils/empty-completion-retry";
+import { withReplaySafeStreamRetry } from "../utils/empty-completion-retry";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { isFoundryEnabled } from "../utils/foundry";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
@@ -2795,14 +2795,13 @@ const streamAnthropicOnce = (
 };
 
 /**
- * Public entry: wrap the single-attempt streamer with bounded empty-completion
- * retries (a benign terminal stop carrying no content/usage would otherwise
- * stall the agent loop). The inner attempt keeps its own provider-failure retry
- * loop; this layer only re-issues a fresh request on an empty success. Shared
- * with the OpenAI-completions provider via `withEmptyCompletionRetry`.
+ * Public entry: retry benign empty completions before they reach the agent
+ * loop. The inner attempt owns Anthropic provider-failure retries.
  */
 export const streamAnthropic: StreamFunction<"anthropic-messages"> = (model, context, options) =>
-	withEmptyCompletionRetry(model, context, options, streamAnthropicOnce);
+	withReplaySafeStreamRetry(model, context, options, streamAnthropicOnce, {
+		retryEmptyCompletion: true,
+	});
 
 export type AnthropicSystemBlock = {
 	type: "text";

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -13,6 +13,7 @@ import type {
 } from "../types";
 import { resolveCacheRetention } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
+import { withReplaySafeStreamRetry } from "../utils/empty-completion-retry";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import type { RawHttpRequestDump } from "../utils/http-inspector";
 import {
@@ -75,10 +76,8 @@ type AzureOpenAIResponsesSamplingParams = ResponseCreateParamsStreaming & {
 	repetition_penalty?: number;
 };
 
-/**
- * Generate function for Azure OpenAI Responses API
- */
-export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"> = (
+/** Runs one Azure OpenAI Responses request and decodes its event stream. */
+const streamAzureOpenAIResponsesOnce = (
 	model: Model<"azure-openai-responses">,
 	context: Context,
 	options?: AzureOpenAIResponsesOptions,
@@ -263,6 +262,13 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 
 	return stream;
 };
+
+/** Retries transient Azure stream failures only before assistant output commits the attempt. */
+export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"> = (model, context, options) =>
+	withReplaySafeStreamRetry(model, context, options, streamAzureOpenAIResponsesOnce, {
+		retryProviderErrors: true,
+		maxProviderErrorRetries: 1,
+	});
 
 function resolveAzureConfig(
 	model: Model<"azure-openai-responses">,

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -82,11 +82,6 @@ const streamAzureOpenAIResponsesOnce = (
 	context: Context,
 	options?: AzureOpenAIResponsesOptions,
 ): AssistantMessageEventStream => {
-	if (options?.promptCache?.mode === "explicit" && resolveCacheRetention(options.cacheRetention) !== "none") {
-		throw new AIError.ConfigurationError(
-			`OpenAI explicit prompt caching is unsupported for ${model.provider}/${model.id}; Azure Responses does not emit explicit cache controls.`,
-		);
-	}
 	const stream = new AssistantMessageEventStream();
 
 	// Start async processing
@@ -263,12 +258,23 @@ const streamAzureOpenAIResponsesOnce = (
 	return stream;
 };
 
-/** Retries transient Azure stream failures only before assistant output commits the attempt. */
-export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"> = (model, context, options) =>
-	withReplaySafeStreamRetry(model, context, options, streamAzureOpenAIResponsesOnce, {
+/**
+ * Retries transient Azure stream failures only before assistant output commits
+ * the attempt. The unsupported explicit prompt-cache config is rejected
+ * synchronously here — callers of the direct entrypoint get the immediate
+ * `ConfigurationError` rather than a stream whose `.result()` rejects later.
+ */
+export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"> = (model, context, options) => {
+	if (options?.promptCache?.mode === "explicit" && resolveCacheRetention(options.cacheRetention) !== "none") {
+		throw new AIError.ConfigurationError(
+			`OpenAI explicit prompt caching is unsupported for ${model.provider}/${model.id}; Azure Responses does not emit explicit cache controls.`,
+		);
+	}
+	return withReplaySafeStreamRetry(model, context, options, streamAzureOpenAIResponsesOnce, {
 		retryProviderErrors: true,
 		maxProviderErrorRetries: 1,
 	});
+};
 
 function resolveAzureConfig(
 	model: Model<"azure-openai-responses">,

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -16,7 +16,7 @@ import type {
 } from "../types";
 import { normalizeSystemPrompts } from "../utils";
 import { clearStreamingPartialJson, kStreamingPartialJson } from "../utils/block-symbols";
-import { withEmptyCompletionRetry } from "../utils/empty-completion-retry";
+import { withReplaySafeStreamRetry } from "../utils/empty-completion-retry";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import type { CapturedHttpErrorResponse, RawHttpRequestDump } from "../utils/http-inspector";
 import {
@@ -773,4 +773,6 @@ const streamOllamaOnce = (
 
 /** Retry EOS-only Ollama completions before the agent loop sees an empty stop. */
 export const streamOllama: StreamFunction<"ollama-chat"> = (model, context, options) =>
-	withEmptyCompletionRetry(model, context, options, streamOllamaOnce);
+	withReplaySafeStreamRetry(model, context, options, streamOllamaOnce, {
+		retryEmptyCompletion: true,
+	});

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -2722,8 +2722,12 @@ class CodexStreamProcessor {
 	}
 
 	async #tryRetryProviderError(error: unknown): Promise<boolean> {
+		const retryable =
+			error instanceof CodexProviderStreamError
+				? error.retryable
+				: AIError.isProviderRetryableError(error, { provider: this.model.provider });
 		if (
-			!(error instanceof CodexProviderStreamError && error.retryable) ||
+			!retryable ||
 			this.output.content.length > 0 ||
 			this.runtime.providerRetryAttempt >= CODEX_MAX_RETRIES ||
 			this.options?.signal?.aborted

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -2756,17 +2756,22 @@ class CodexStreamProcessor {
 				? error.retryable
 				: AIError.isProviderRetryableError(error, { provider: this.model.provider });
 		// A leading `response.output_item.added` opens an empty block and emits only
-		// a `*_start` before any delta; that is replay-safe. But once a visible
-		// text/tool block or any non-empty thinking delta has streamed, replaying
-		// would duplicate/reorder those already-delivered events (and drop the
-		// streamed thinking from the reset message), so treat that as committed.
-		const streamedThinking = this.output.content.some(
-			block => block.type === "thinking" && block.thinking.length > 0,
+		// a `*_start` before any delta; that is replay-safe. But once any text or
+		// thinking delta has streamed — including a whitespace-only
+		// `output_text.delta`, which still reaches consumers as `text_delta` — or a
+		// visible tool/image block exists, replaying would duplicate/reorder those
+		// already-delivered events, so treat the attempt as committed. Emptiness is
+		// measured by the streamed block length (whitespace counts), not by visible
+		// final content.
+		const streamedContent = this.output.content.some(
+			block =>
+				(block.type === "text" && block.text.length > 0) ||
+				(block.type === "thinking" && block.thinking.length > 0),
 		);
 		if (
 			!retryable ||
 			hasVisibleAssistantContent(this.output) ||
-			streamedThinking ||
+			streamedContent ||
 			!this.runtime.canSafelyReplayWebsocketOverSse ||
 			this.runtime.providerRetryAttempt >= CODEX_MAX_RETRIES ||
 			this.options?.signal?.aborted

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -2727,13 +2727,18 @@ class CodexStreamProcessor {
 			error instanceof CodexProviderStreamError
 				? error.retryable
 				: AIError.isProviderRetryableError(error, { provider: this.model.provider });
+		// A leading `response.output_item.added` opens an empty block and emits only
+		// a `*_start` before any delta; that is replay-safe. But once a visible
+		// text/tool block or any non-empty thinking delta has streamed, replaying
+		// would duplicate/reorder those already-delivered events (and drop the
+		// streamed thinking from the reset message), so treat that as committed.
+		const streamedThinking = this.output.content.some(
+			block => block.type === "thinking" && block.thinking.length > 0,
+		);
 		if (
 			!retryable ||
-			// A leading `response.output_item.added` opens an empty block and emits
-			// only a `*_start` before any delta; that is replay-safe. Gate on
-			// actually-committed visible output, not an open-but-empty block, or a
-			// pre-delta socket close would be misclassified as committed.
 			hasVisibleAssistantContent(this.output) ||
+			streamedThinking ||
 			!this.runtime.canSafelyReplayWebsocketOverSse ||
 			this.runtime.providerRetryAttempt >= CODEX_MAX_RETRIES ||
 			this.options?.signal?.aborted

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -54,6 +54,7 @@ import {
 	stripOpenAIResponsesComputerLinkedReasoningIdsForReplay,
 } from "../utils";
 import { clearStreamingPartialJson, kStreamingLastParseLen, kStreamingPartialJson } from "../utils/block-symbols";
+import { hasVisibleAssistantContent } from "../utils/empty-completion-retry";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { escapeHarmonyControlTokens, isHarmonyDialectModel } from "../utils/harmony-leak";
 import type { RawHttpRequestDump } from "../utils/http-inspector";
@@ -2728,7 +2729,12 @@ class CodexStreamProcessor {
 				: AIError.isProviderRetryableError(error, { provider: this.model.provider });
 		if (
 			!retryable ||
-			this.output.content.length > 0 ||
+			// A leading `response.output_item.added` opens an empty block and emits
+			// only a `*_start` before any delta; that is replay-safe. Gate on
+			// actually-committed visible output, not an open-but-empty block, or a
+			// pre-delta socket close would be misclassified as committed.
+			hasVisibleAssistantContent(this.output) ||
+			!this.runtime.canSafelyReplayWebsocketOverSse ||
 			this.runtime.providerRetryAttempt >= CODEX_MAX_RETRIES ||
 			this.options?.signal?.aborted
 		) {

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -2722,6 +2722,34 @@ class CodexStreamProcessor {
 		return true;
 	}
 
+	/**
+	 * Emit balancing `*_end` events for every block that opened (pushed a
+	 * `*_start`) but never committed visible content, so a retry that resets
+	 * `output` and replays cannot leave the consumer with an orphaned
+	 * `text_start`/`thinking_start` from the abandoned attempt. Only reachable
+	 * blocks are empty text/reasoning ones — a committed tool/text block blocks
+	 * the retry upstream.
+	 */
+	#closeOpenBlocksForReplay(): void {
+		const { runtime, output, stream } = this;
+		const open = new Set<CodexOpenItem>(runtime.openItems.values());
+		for (const entry of runtime.openItemsByOutputIndex.values()) open.add(entry);
+		if (runtime.currentEntry) open.add(runtime.currentEntry);
+		for (const entry of open) {
+			const block = entry.block;
+			if (block?.type === "thinking") {
+				stream.push({
+					type: "thinking_end",
+					contentIndex: entry.contentIndex,
+					content: block.thinking,
+					partial: output,
+				});
+			} else if (block?.type === "text") {
+				stream.push({ type: "text_end", contentIndex: entry.contentIndex, content: block.text, partial: output });
+			}
+		}
+	}
+
 	async #tryRetryProviderError(error: unknown): Promise<boolean> {
 		const retryable =
 			error instanceof CodexProviderStreamError
@@ -2746,6 +2774,10 @@ class CodexStreamProcessor {
 			return false;
 		}
 
+		// A leading `output_item.added` already pushed a `*_start` for the (empty)
+		// open block; balance it with the matching end before the reset+replay so
+		// consumers never see an orphaned start from the abandoned attempt.
+		this.#closeOpenBlocksForReplay();
 		this.runtime.providerRetryAttempt += 1;
 		const websocketState = this.requestContext.websocketState;
 		if (websocketState) {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -30,7 +30,7 @@ import type {
 import { normalizeSystemPrompts, resolveCacheRetention } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
 import { isDemotedThinking, kStreamingLastParseLen } from "../utils/block-symbols";
-import { hasVisibleAssistantContent, withEmptyCompletionRetry } from "../utils/empty-completion-retry";
+import { hasVisibleAssistantContent, withReplaySafeStreamRetry } from "../utils/empty-completion-retry";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import type { RawHttpRequestDump } from "../utils/http-inspector";
 import {
@@ -1382,13 +1382,15 @@ const streamOpenAICompletionsOnce = (
 };
 
 /**
- * Public entry: wrap the single-attempt streamer with bounded empty-completion
- * retries — flaky gateways occasionally 200 with `delta: {}` + `finish_reason:
- * "stop"` and no usage, which would otherwise stall the agent loop. Shared with
- * the Anthropic provider via `withEmptyCompletionRetry`.
+ * Retries benign empty completions and transient provider failures only before
+ * assistant output commits the attempt.
  */
 export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (model, context, options) =>
-	withEmptyCompletionRetry(model, context, options, streamOpenAICompletionsOnce);
+	withReplaySafeStreamRetry(model, context, options, streamOpenAICompletionsOnce, {
+		retryEmptyCompletion: true,
+		retryProviderErrors: true,
+		maxProviderErrorRetries: 1,
+	});
 
 function createRequestSetup(
 	model: Model<"openai-completions">,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -24,7 +24,7 @@ import {
 	sanitizeOpenAIResponsesAssistantHistoryItemsForReplay,
 } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
-import { withEmptyCompletionRetry } from "../utils/empty-completion-retry";
+import { withReplaySafeStreamRetry } from "../utils/empty-completion-retry";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import type { RawHttpRequestDump } from "../utils/http-inspector";
 import {
@@ -186,7 +186,8 @@ function isOpenAIResponsesReplayUnsafeEvent(event: ResponseStreamEvent): boolean
 function isRetryableOpenAIResponsesStreamFailure(error: unknown): boolean {
 	return (
 		AIError.isTransientStreamParseError(error) ||
-		(error instanceof AIError.ProviderResponseError && error.kind === "incomplete-stream")
+		(error instanceof AIError.ProviderResponseError && error.kind === "incomplete-stream") ||
+		AIError.isProviderRetryableError(error)
 	);
 }
 
@@ -881,13 +882,14 @@ const streamOpenAIResponsesOnce = (
 };
 
 /**
- * Public entry: wrap the single-attempt Responses streamer with bounded
- * empty-completion retries — a `response.completed` carrying no content/usage
- * would otherwise stall the agent loop. Shared with the OpenAI-completions and
- * Anthropic providers via `withEmptyCompletionRetry`.
+ * Public entry: retry benign empty completions before they reach the agent
+ * loop. Transient stream failures are retried inside the attempt so stateful
+ * Responses request metadata remains stable.
  */
 export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (model, context, options) =>
-	withEmptyCompletionRetry(model, context, options, streamOpenAIResponsesOnce);
+	withReplaySafeStreamRetry(model, context, options, streamOpenAIResponsesOnce, {
+		retryEmptyCompletion: true,
+	});
 
 function isOfficialOpenAIResponsesEndpoint(model: Model<"openai-responses">): boolean {
 	if (model.provider !== "openai") return false;

--- a/packages/ai/src/utils/empty-completion-retry.ts
+++ b/packages/ai/src/utils/empty-completion-retry.ts
@@ -1,23 +1,18 @@
 /**
- * Bounded retries for an empty assistant completion.
+ * Replay-safe retries for provider streams.
  *
- * Some providers — and especially flaky OpenAI-/Anthropic-compatible gateways —
- * intermittently return a benign terminal stop carrying no content and no usage
- * (e.g. a single OpenAI `delta: {}` + `finish_reason: "stop"` chunk). Delivered
- * as-is the agent loop has nothing to act on and silently halts mid-task, so the
- * request must be retried instead of surfaced.
+ * A provider attempt can be discarded only until meaningful assistant output is
+ * emitted. Pre-output markers are buffered so transient transport failures and
+ * benign empty completions can re-issue a fresh request without duplicating
+ * content; the first text, thinking, image, or tool event commits the attempt
+ * and restores live streaming.
  *
- * This wraps a single-attempt provider stream and re-invokes it (a fresh request
- * with its own message state) when an attempt produces no meaningful content.
- * Only a stream that streamed nothing meaningful is retried: the moment any
- * text/thinking/tool delta is forwarded the attempt is committed, so live
- * streaming (including thinking) is never delayed, retried, or duplicated.
- *
- * Mirrors the Gemini empty-response policy in `google-shared` (which keeps its
- * own integrated loop) and is shared by the OpenAI-completions and
- * Anthropic-messages providers.
+ * Empty-completion retries remain opt-in because a normal empty stop can be a
+ * valid provider result. Transient-error retries use the shared provider error
+ * classifier and are separately bounded by the caller's policy.
  */
 import { scheduler } from "node:timers/promises";
+import * as AIError from "../error";
 import type { AssistantMessage, AssistantMessageEvent, Context } from "../types";
 import { AssistantMessageEventStream } from "./event-stream";
 
@@ -60,26 +55,49 @@ function isMeaningfulCompletionEvent(event: AssistantMessageEvent): boolean {
 	}
 }
 
-interface EmptyCompletionRetryOptions {
+interface StreamRetryOptions {
 	signal?: AbortSignal;
 	providerRetryWait?: (delayMs: number, signal?: AbortSignal) => Promise<void>;
 }
 
+/** Controls which replay-safe provider results may issue a fresh request. */
+export interface ReplaySafeStreamRetryPolicy {
+	/** Retry benign terminal stops that contain no visible output. */
+	retryEmptyCompletion?: boolean;
+	/** Retry transient provider errors before output is committed. */
+	retryProviderErrors?: boolean;
+	/** Maximum transient provider-error retries; empty completions keep their shared fixed budget. */
+	maxProviderErrorRetries?: number;
+}
+
+class FinalizedProviderStreamError extends Error {
+	readonly status?: number;
+
+	constructor(message: string, status: number | undefined) {
+		super(message);
+		this.name = "FinalizedProviderStreamError";
+		this.status = status;
+	}
+}
+
 /**
- * Wrap a single-attempt provider stream with bounded empty-completion retries.
- * `attempt` MUST create a fresh request (and its own output message) on each
- * call so a retry never inherits stale metadata from an empty attempt.
+ * Re-issues a fresh provider request only while the current attempt remains
+ * replay-safe. Buffered pre-output events from discarded attempts never reach
+ * consumers.
  */
-export function withEmptyCompletionRetry<M, O extends EmptyCompletionRetryOptions>(
+export function withReplaySafeStreamRetry<M, O extends StreamRetryOptions>(
 	model: M,
 	context: Context,
 	options: O | undefined,
 	attempt: (model: M, context: Context, options?: O) => AssistantMessageEventStream,
+	policy: ReplaySafeStreamRetryPolicy,
 ): AssistantMessageEventStream {
 	const outer = new AssistantMessageEventStream();
 	const signal = options?.signal;
 	void (async () => {
-		for (let emptyAttempt = 0; ; emptyAttempt++) {
+		let emptyRetries = 0;
+		let providerErrorRetries = 0;
+		while (true) {
 			const inner = attempt(model, context, options);
 			const buffered: AssistantMessageEvent[] = [];
 			let committed = false;
@@ -94,8 +112,6 @@ export function withEmptyCompletionRetry<M, O extends EmptyCompletionRetryOption
 						terminal = event;
 						break;
 					}
-					// Buffer pre-content events (start/*_start) so an empty attempt can
-					// be discarded; commit the moment real content streams.
 					if (!committed && !isMeaningfulCompletionEvent(event)) {
 						buffered.push(event);
 						continue;
@@ -111,27 +127,42 @@ export function withEmptyCompletionRetry<M, O extends EmptyCompletionRetryOption
 				return;
 			}
 
-			// Retry only a genuinely degenerate completion: a normal stop that
-			// produced no visible content and reported no generated content tokens.
-			// Some providers count the terminal EOS as one output token, so a
-			// one-token invisible stop is still the same empty-completion failure.
-			const message = terminal?.type === "done" ? terminal.message : undefined;
-			const isRetryableEmpty =
+			const completedMessage = terminal?.type === "done" ? terminal.message : undefined;
+			const retryEmpty =
+				policy.retryEmptyCompletion === true &&
 				!committed &&
-				message !== undefined &&
-				message.stopReason === "stop" &&
-				!message.errorMessage &&
-				(message.usage?.output ?? 0) <= 1 &&
-				!hasVisibleAssistantContent(message);
+				completedMessage !== undefined &&
+				completedMessage.stopReason === "stop" &&
+				!completedMessage.errorMessage &&
+				(completedMessage.usage?.output ?? 0) <= 1 &&
+				!hasVisibleAssistantContent(completedMessage) &&
+				emptyRetries < MAX_EMPTY_COMPLETION_RETRIES;
+			const failedMessage = terminal?.type === "error" ? terminal.error : undefined;
+			const retryProviderError =
+				policy.retryProviderErrors === true &&
+				!committed &&
+				failedMessage?.stopReason === "error" &&
+				failedMessage.errorMessage !== undefined &&
+				providerErrorRetries < (policy.maxProviderErrorRetries ?? 0) &&
+				AIError.isProviderRetryableError(
+					new FinalizedProviderStreamError(failedMessage.errorMessage, failedMessage.errorStatus),
+					{ provider: failedMessage.provider },
+				);
 
-			if (isRetryableEmpty && emptyAttempt < MAX_EMPTY_COMPLETION_RETRIES && !signal?.aborted) {
-				const delayMs = EMPTY_COMPLETION_BASE_DELAY_MS * 2 ** emptyAttempt;
+			let delayMs: number | undefined;
+			if (retryEmpty) {
+				delayMs = EMPTY_COMPLETION_BASE_DELAY_MS * 2 ** emptyRetries;
+				emptyRetries++;
+			} else if (retryProviderError) {
+				delayMs = EMPTY_COMPLETION_BASE_DELAY_MS * 2 ** providerErrorRetries;
+				providerErrorRetries++;
+			}
+
+			if (delayMs !== undefined && !signal?.aborted) {
 				try {
 					if (options?.providerRetryWait) await options.providerRetryWait(delayMs, signal);
 					else await scheduler.wait(delayMs, { signal });
 				} catch (waitError) {
-					// Aborted during backoff: deliver the empty result rather than hang.
-					// Any other wait failure is a real error and must surface.
 					flush();
 					if (signal?.aborted) {
 						if (terminal) outer.push(terminal);
@@ -140,7 +171,6 @@ export function withEmptyCompletionRetry<M, O extends EmptyCompletionRetryOption
 					}
 					return;
 				}
-				// Discard the buffered `start` from this empty attempt and retry.
 				continue;
 			}
 

--- a/packages/ai/src/utils/empty-completion-retry.ts
+++ b/packages/ai/src/utils/empty-completion-retry.ts
@@ -98,7 +98,6 @@ export function withReplaySafeStreamRetry<M, O extends StreamRetryOptions>(
 		let emptyRetries = 0;
 		let providerErrorRetries = 0;
 		while (true) {
-			const inner = attempt(model, context, options);
 			const buffered: AssistantMessageEvent[] = [];
 			let committed = false;
 			let terminal: AssistantMessageEvent | undefined;
@@ -106,7 +105,12 @@ export function withReplaySafeStreamRetry<M, O extends StreamRetryOptions>(
 				for (const event of buffered) outer.push(event);
 				buffered.length = 0;
 			};
+			let inner: AssistantMessageEventStream;
 			try {
+				// The attempt factory can throw synchronously (e.g. a config error
+				// raised before it creates its stream); surface it on the outer stream
+				// rather than leaking an unhandled rejection that never settles.
+				inner = attempt(model, context, options);
 				for await (const event of inner) {
 					if (event.type === "done" || event.type === "error") {
 						terminal = event;

--- a/packages/ai/test/empty-completion-retry.test.ts
+++ b/packages/ai/test/empty-completion-retry.test.ts
@@ -1,13 +1,11 @@
 /**
- * Contracts for `withEmptyCompletionRetry` (shared by the OpenAI-completions and
- * Anthropic-messages providers): a benign terminal stop with no content/usage is
- * retried a bounded number of times; once any content streams the attempt is
- * committed (no retry, no duplicate `start`); the cap delivers the empty result;
- * backoff failures surface unless the caller aborted.
+ * Contracts for replay-safe provider retries: empty and transient pre-output
+ * attempts are bounded and discarded, while emitted content commits an attempt
+ * so output is never duplicated.
  */
 import { describe, expect, it } from "bun:test";
 import type { AssistantMessage, AssistantMessageEvent, Context, Usage } from "@oh-my-pi/pi-ai/types";
-import { MAX_EMPTY_COMPLETION_RETRIES, withEmptyCompletionRetry } from "@oh-my-pi/pi-ai/utils/empty-completion-retry";
+import { MAX_EMPTY_COMPLETION_RETRIES, withReplaySafeStreamRetry } from "@oh-my-pi/pi-ai/utils/empty-completion-retry";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 
 const CTX = {} as Context;
@@ -79,14 +77,20 @@ async function drain(stream: AssistantMessageEventStream): Promise<AssistantMess
 	return events;
 }
 
-describe("withEmptyCompletionRetry", () => {
+describe("withReplaySafeStreamRetry", () => {
 	it("retries past empty attempts and delivers the first non-empty one", async () => {
 		let attempts = 0;
 		const waits: number[] = [];
-		const stream = withEmptyCompletionRetry({}, CTX, { providerRetryWait: async ms => void waits.push(ms) }, () => {
-			attempts++;
-			return attempts <= MAX_EMPTY_COMPLETION_RETRIES ? emptyAttempt() : contentAttempt();
-		});
+		const stream = withReplaySafeStreamRetry(
+			{},
+			CTX,
+			{ providerRetryWait: async ms => void waits.push(ms) },
+			() => {
+				attempts++;
+				return attempts <= MAX_EMPTY_COMPLETION_RETRIES ? emptyAttempt() : contentAttempt();
+			},
+			{ retryEmptyCompletion: true },
+		);
 
 		const events = await drain(stream);
 		const result = await stream.result();
@@ -103,10 +107,16 @@ describe("withEmptyCompletionRetry", () => {
 	it("retries an EOS-only empty stop that reports one output token", async () => {
 		let attempts = 0;
 		const waits: number[] = [];
-		const stream = withEmptyCompletionRetry({}, CTX, { providerRetryWait: async ms => void waits.push(ms) }, () => {
-			attempts++;
-			return attempts === 1 ? eosOnlyAttempt() : contentAttempt();
-		});
+		const stream = withReplaySafeStreamRetry(
+			{},
+			CTX,
+			{ providerRetryWait: async ms => void waits.push(ms) },
+			() => {
+				attempts++;
+				return attempts === 1 ? eosOnlyAttempt() : contentAttempt();
+			},
+			{ retryEmptyCompletion: true },
+		);
 
 		const events = await drain(stream);
 		const result = await stream.result();
@@ -120,10 +130,16 @@ describe("withEmptyCompletionRetry", () => {
 	it("delivers the empty result after exhausting the retry cap", async () => {
 		let attempts = 0;
 		const waits: number[] = [];
-		const stream = withEmptyCompletionRetry({}, CTX, { providerRetryWait: async ms => void waits.push(ms) }, () => {
-			attempts++;
-			return emptyAttempt();
-		});
+		const stream = withReplaySafeStreamRetry(
+			{},
+			CTX,
+			{ providerRetryWait: async ms => void waits.push(ms) },
+			() => {
+				attempts++;
+				return emptyAttempt();
+			},
+			{ retryEmptyCompletion: true },
+		);
 
 		const events = await drain(stream);
 		const result = await stream.result();
@@ -138,7 +154,7 @@ describe("withEmptyCompletionRetry", () => {
 	it("does not retry when the first attempt streams content", async () => {
 		let attempts = 0;
 		let waited = false;
-		const stream = withEmptyCompletionRetry(
+		const stream = withReplaySafeStreamRetry(
 			{},
 			CTX,
 			{
@@ -150,6 +166,7 @@ describe("withEmptyCompletionRetry", () => {
 				attempts++;
 				return contentAttempt();
 			},
+			{ retryEmptyCompletion: true },
 		);
 
 		await drain(stream);
@@ -160,15 +177,21 @@ describe("withEmptyCompletionRetry", () => {
 
 	it("commits on streamed thinking and does not retry a thinking-only stop", async () => {
 		let attempts = 0;
-		const stream = withEmptyCompletionRetry({}, CTX, {}, () => {
-			attempts++;
-			const message = assistant(); // no visible content; only thinking streams
-			return streamFromEvents([
-				{ type: "start", partial: message },
-				{ type: "thinking_delta", contentIndex: 0, delta: "pondering", partial: message },
-				{ type: "done", reason: "stop", message },
-			] as unknown as AssistantMessageEvent[]);
-		});
+		const stream = withReplaySafeStreamRetry(
+			{},
+			CTX,
+			{},
+			() => {
+				attempts++;
+				const message = assistant(); // no visible content; only thinking streams
+				return streamFromEvents([
+					{ type: "start", partial: message },
+					{ type: "thinking_delta", contentIndex: 0, delta: "pondering", partial: message },
+					{ type: "done", reason: "stop", message },
+				] as unknown as AssistantMessageEvent[]);
+			},
+			{ retryEmptyCompletion: true },
+		);
 
 		const events = await drain(stream);
 
@@ -177,7 +200,7 @@ describe("withEmptyCompletionRetry", () => {
 	});
 
 	it("propagates a non-abort backoff failure instead of masking the empty result", async () => {
-		const stream = withEmptyCompletionRetry(
+		const stream = withReplaySafeStreamRetry(
 			{},
 			CTX,
 			{
@@ -186,6 +209,7 @@ describe("withEmptyCompletionRetry", () => {
 				},
 			},
 			() => emptyAttempt(),
+			{ retryEmptyCompletion: true },
 		);
 
 		let caught: unknown;
@@ -200,7 +224,7 @@ describe("withEmptyCompletionRetry", () => {
 	it("delivers the empty result when aborted during backoff", async () => {
 		const controller = new AbortController();
 		let attempts = 0;
-		const stream = withEmptyCompletionRetry(
+		const stream = withReplaySafeStreamRetry(
 			{},
 			CTX,
 			{
@@ -214,6 +238,7 @@ describe("withEmptyCompletionRetry", () => {
 				attempts++;
 				return emptyAttempt();
 			},
+			{ retryEmptyCompletion: true },
 		);
 
 		const events = await drain(stream);
@@ -226,18 +251,24 @@ describe("withEmptyCompletionRetry", () => {
 
 	it("discards buffered pre-content markers from a retried empty attempt", async () => {
 		let attempts = 0;
-		const stream = withEmptyCompletionRetry({}, CTX, { providerRetryWait: async () => {} }, () => {
-			attempts++;
-			if (attempts === 1) {
-				const message = assistant();
-				return streamFromEvents([
-					{ type: "start", partial: message },
-					{ type: "thinking_start", contentIndex: 0, partial: message },
-					{ type: "done", reason: "stop", message },
-				] as unknown as AssistantMessageEvent[]);
-			}
-			return contentAttempt();
-		});
+		const stream = withReplaySafeStreamRetry(
+			{},
+			CTX,
+			{ providerRetryWait: async () => {} },
+			() => {
+				attempts++;
+				if (attempts === 1) {
+					const message = assistant();
+					return streamFromEvents([
+						{ type: "start", partial: message },
+						{ type: "thinking_start", contentIndex: 0, partial: message },
+						{ type: "done", reason: "stop", message },
+					] as unknown as AssistantMessageEvent[]);
+				}
+				return contentAttempt();
+			},
+			{ retryEmptyCompletion: true },
+		);
 
 		const events = await drain(stream);
 
@@ -253,7 +284,7 @@ describe("withEmptyCompletionRetry", () => {
 		let waited = false;
 		const message = assistant(["streamed"]);
 		const inner = new AssistantMessageEventStream();
-		const stream = withEmptyCompletionRetry(
+		const stream = withReplaySafeStreamRetry(
 			{},
 			CTX,
 			{
@@ -262,6 +293,7 @@ describe("withEmptyCompletionRetry", () => {
 				},
 			},
 			() => inner,
+			{ retryEmptyCompletion: true },
 		);
 
 		const iterator = stream[Symbol.asyncIterator]();
@@ -282,5 +314,63 @@ describe("withEmptyCompletionRetry", () => {
 		inner.push({ type: "done", reason: "stop", message } as unknown as AssistantMessageEvent);
 		expect((await iterator.next()).value?.type).toBe("done");
 		expect(waited).toBe(false);
+	});
+
+	it("retries a transient provider error before output commits", async () => {
+		let attempts = 0;
+		const stream = withReplaySafeStreamRetry(
+			{},
+			CTX,
+			{ providerRetryWait: async () => {} },
+			() => {
+				attempts++;
+				if (attempts > 1) return contentAttempt();
+				const message = assistant();
+				message.stopReason = "error";
+				message.errorMessage = "The socket connection was closed unexpectedly";
+				return streamFromEvents([
+					{ type: "start", partial: message },
+					{ type: "error", reason: "error", error: message },
+				]);
+			},
+			{ retryProviderErrors: true, maxProviderErrorRetries: 1 },
+		);
+
+		const events = await drain(stream);
+		const result = await stream.result();
+
+		expect(attempts).toBe(2);
+		expect(events.filter(event => event.type === "start")).toHaveLength(1);
+		expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+	});
+
+	it("does not retry a transient provider error after output commits", async () => {
+		let attempts = 0;
+		const message = assistant(["partial"]);
+		message.stopReason = "error";
+		message.errorMessage = "The socket connection was closed unexpectedly";
+		const stream = withReplaySafeStreamRetry(
+			{},
+			CTX,
+			{ providerRetryWait: async () => {} },
+			() => {
+				attempts++;
+				return streamFromEvents([
+					{ type: "start", partial: message },
+					{ type: "text_start", contentIndex: 0, partial: message },
+					{ type: "text_delta", contentIndex: 0, delta: "partial", partial: message },
+					{ type: "error", reason: "error", error: message },
+				]);
+			},
+			{ retryProviderErrors: true, maxProviderErrorRetries: 1 },
+		);
+
+		const events = await drain(stream);
+		const result = await stream.result();
+
+		expect(attempts).toBe(1);
+		expect(events.at(-1)?.type).toBe("error");
+		expect(result.stopReason).toBe("error");
+		expect(result.content).toEqual([{ type: "text", text: "partial" }]);
 	});
 });

--- a/packages/ai/test/empty-completion-retry.test.ts
+++ b/packages/ai/test/empty-completion-retry.test.ts
@@ -373,4 +373,19 @@ describe("withReplaySafeStreamRetry", () => {
 		expect(result.stopReason).toBe("error");
 		expect(result.content).toEqual([{ type: "text", text: "partial" }]);
 	});
+
+	it("settles the outer stream when the attempt factory throws synchronously", async () => {
+		const configError = new Error("explicit prompt caching is unsupported");
+		const stream = withReplaySafeStreamRetry(
+			{},
+			CTX,
+			{ providerRetryWait: async () => {} },
+			() => {
+				throw configError;
+			},
+			{ retryProviderErrors: true, maxProviderErrorRetries: 1 },
+		);
+
+		await expect(stream.result()).rejects.toBe(configError);
+	});
 });

--- a/packages/ai/test/openai-stream-socket-retry.test.ts
+++ b/packages/ai/test/openai-stream-socket-retry.test.ts
@@ -311,6 +311,33 @@ describe("OpenAI-family mid-stream socket-close retry", () => {
 		expect(result.content.find(block => block.type === "text")?.text).toBe("partial");
 	});
 
+	it("does not retry Codex SSE after a whitespace-only text delta commits", async () => {
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let requests = 0;
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			requests++;
+			// A whitespace-only delta still reached the consumer as text_delta;
+			// replaying would duplicate it, so the socket close must surface.
+			return createSocketCloseResponse([
+				{
+					type: "response.output_item.added",
+					item: { type: "message", id: "msg_ws", role: "assistant", status: "in_progress", content: [] },
+				},
+				{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+				{ type: "response.output_text.delta", delta: "  \n" },
+			]);
+		});
+
+		const result = await streamOpenAICodexResponses(codexModel, context, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(requests).toBe(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.content.find(block => block.type === "text")?.text).toBe("  \n");
+	});
+
 	it("does not retry Codex SSE after thinking output commits", async () => {
 		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 		let requests = 0;

--- a/packages/ai/test/openai-stream-socket-retry.test.ts
+++ b/packages/ai/test/openai-stream-socket-retry.test.ts
@@ -268,14 +268,22 @@ describe("OpenAI-family mid-stream socket-close retry", () => {
 				: completedCodexSse("codex recovered after empty block");
 		});
 
-		const result = await streamOpenAICodexResponses(codexModel, context, {
+		const events: string[] = [];
+		const stream = streamOpenAICodexResponses(codexModel, context, {
 			apiKey: "test-key",
 			fetch: fetchMock,
-		}).result();
+		});
+		for await (const event of stream) events.push(event.type);
+		const result = await stream.result();
 
 		expect(requests).toBe(2);
 		expect(result.stopReason).toBe("stop");
 		expect(result.content.find(block => block.type === "text")?.text).toBe("codex recovered after empty block");
+		// The abandoned attempt's text_start is balanced by a text_end before the
+		// replay: no orphaned block-start reaches the consumer.
+		expect(events.filter(type => type === "text_start")).toHaveLength(
+			events.filter(type => type === "text_end").length,
+		);
 	});
 
 	it("does not retry Codex SSE after text output commits", async () => {

--- a/packages/ai/test/openai-stream-socket-retry.test.ts
+++ b/packages/ai/test/openai-stream-socket-retry.test.ts
@@ -250,6 +250,34 @@ describe("OpenAI-family mid-stream socket-close retry", () => {
 		expect(result.content.find(block => block.type === "text")?.text).toBe("codex recovered");
 	});
 
+	it("retries Codex SSE when a socket close follows an empty opened block", async () => {
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let requests = 0;
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			requests++;
+			// First attempt opens a message block (emits text_start) but closes the
+			// socket before any output_text delta — replay-safe, must retry.
+			return requests === 1
+				? createSocketCloseResponse([
+						{
+							type: "response.output_item.added",
+							item: { type: "message", id: "msg_empty", role: "assistant", status: "in_progress", content: [] },
+						},
+						{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+					])
+				: completedCodexSse("codex recovered after empty block");
+		});
+
+		const result = await streamOpenAICodexResponses(codexModel, context, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(requests).toBe(2);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.find(block => block.type === "text")?.text).toBe("codex recovered after empty block");
+	});
+
 	it("does not retry Codex SSE after text output commits", async () => {
 		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 		let requests = 0;

--- a/packages/ai/test/openai-stream-socket-retry.test.ts
+++ b/packages/ai/test/openai-stream-socket-retry.test.ts
@@ -302,4 +302,27 @@ describe("OpenAI-family mid-stream socket-close retry", () => {
 		expect(result.stopReason).toBe("error");
 		expect(result.content.find(block => block.type === "text")?.text).toBe("partial");
 	});
+
+	it("does not retry Codex SSE after thinking output commits", async () => {
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let requests = 0;
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			requests++;
+			// A reasoning delta already reached the consumer as thinking_delta;
+			// replaying would duplicate it, so the socket close must surface.
+			return createSocketCloseResponse([
+				{ type: "response.output_item.added", item: { type: "reasoning", id: "rs_partial", summary: [] } },
+				{ type: "response.reasoning_text.delta", item_id: "rs_partial", delta: "deliberating" },
+			]);
+		});
+
+		const result = await streamOpenAICodexResponses(codexModel, context, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(requests).toBe(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.content.find(block => block.type === "thinking")?.thinking).toBe("deliberating");
+	});
 });

--- a/packages/ai/test/openai-stream-socket-retry.test.ts
+++ b/packages/ai/test/openai-stream-socket-retry.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { scheduler } from "node:timers/promises";
+import { streamAzureOpenAIResponses } from "@oh-my-pi/pi-ai/providers/azure-openai-responses";
+import { streamOpenAICodexResponses } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
+import type { Context, FetchImpl, Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const SOCKET_CLOSE_MESSAGE =
+	"The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()";
+const context: Context = {
+	messages: [{ role: "user", content: "Say hello", timestamp: 1_000 }],
+};
+
+const modelDefaults: Pick<ModelSpec, "id" | "name" | "reasoning" | "input" | "cost" | "contextWindow" | "maxTokens"> = {
+	id: "gpt-test",
+	name: "GPT test",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 16_384,
+};
+
+const completionsModel: Model<"openai-completions"> = buildModel({
+	...modelDefaults,
+	api: "openai-completions",
+	provider: "openai",
+	baseUrl: "https://api.openai.test/v1",
+});
+
+const responsesModel: Model<"openai-responses"> = buildModel({
+	...modelDefaults,
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://api.openai.test/v1",
+});
+
+const azureModel: Model<"azure-openai-responses"> = buildModel({
+	...modelDefaults,
+	api: "azure-openai-responses",
+	provider: "azure",
+	baseUrl: "https://example.openai.azure.com/openai/v1",
+});
+
+const codexModel: Model<"openai-codex-responses"> = buildModel({
+	...modelDefaults,
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	preferWebsockets: false,
+});
+
+function createSseResponse(events: unknown[], done = false): Response {
+	const frames = events.map(event => `data: ${JSON.stringify(event)}`);
+	if (done) frames.push("data: [DONE]");
+	return new Response(`${frames.join("\n\n")}\n\n`, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function createSocketCloseResponse(events: unknown[]): Response {
+	const bytes = new TextEncoder().encode(`${events.map(event => `data: ${JSON.stringify(event)}`).join("\n\n")}\n\n`);
+	let sentPrefix = false;
+	return new Response(
+		new ReadableStream<Uint8Array>(
+			{
+				pull(controller) {
+					if (!sentPrefix) {
+						sentPrefix = true;
+						controller.enqueue(bytes);
+						return;
+					}
+					controller.error(new TypeError(SOCKET_CLOSE_MESSAGE));
+				},
+			},
+			{ highWaterMark: 0 },
+		),
+		{ status: 200, headers: { "content-type": "text/event-stream" } },
+	);
+}
+
+function completedResponsesSse(text: string): Response {
+	return createSseResponse([
+		{ type: "response.created", response: { id: "resp_recovered", status: "in_progress" } },
+		{
+			type: "response.output_item.added",
+			output_index: 0,
+			item: { type: "message", id: "msg_recovered", role: "assistant", status: "in_progress", content: [] },
+		},
+		{ type: "response.output_text.delta", output_index: 0, item_id: "msg_recovered", delta: text },
+		{
+			type: "response.output_item.done",
+			output_index: 0,
+			item: {
+				type: "message",
+				id: "msg_recovered",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text }],
+			},
+		},
+		{
+			type: "response.completed",
+			response: {
+				id: "resp_recovered",
+				status: "completed",
+				usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7, input_tokens_details: { cached_tokens: 0 } },
+			},
+		},
+	]);
+}
+
+function completedCompletionsSse(text: string): Response {
+	return createSseResponse(
+		[
+			{ id: "chatcmpl_recovered", choices: [{ index: 0, delta: { content: text }, finish_reason: null }] },
+			{
+				id: "chatcmpl_recovered",
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+				usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+			},
+		],
+		true,
+	);
+}
+
+function completedCodexSse(text: string): Response {
+	return createSseResponse([
+		{
+			type: "response.output_item.added",
+			item: { type: "message", id: "msg_recovered", role: "assistant", status: "in_progress", content: [] },
+		},
+		{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+		{ type: "response.output_text.delta", delta: text },
+		{
+			type: "response.output_item.done",
+			item: {
+				type: "message",
+				id: "msg_recovered",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text }],
+			},
+		},
+		{
+			type: "response.completed",
+			response: {
+				status: "completed",
+				usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7, input_tokens_details: { cached_tokens: 0 } },
+			},
+		},
+	]);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("OpenAI-family mid-stream socket-close retry", () => {
+	it("retries OpenAI Responses before replay-unsafe output", async () => {
+		let requests = 0;
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			requests++;
+			return requests === 1
+				? createSocketCloseResponse([
+						{ type: "response.created", response: { id: "resp_failed", status: "in_progress" } },
+					])
+				: completedResponsesSse("responses recovered");
+		});
+
+		const result = await streamOpenAIResponses(responsesModel, context, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			providerRetryWait: async () => {},
+		}).result();
+
+		expect(requests).toBe(2);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.find(block => block.type === "text")?.text).toBe("responses recovered");
+	});
+
+	it("retries OpenAI Completions before replay-unsafe output", async () => {
+		let requests = 0;
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			requests++;
+			return requests === 1
+				? createSocketCloseResponse([
+						{ id: "chatcmpl_failed", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+					])
+				: completedCompletionsSse("completions recovered");
+		});
+
+		const result = await streamOpenAICompletions(completionsModel, context, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			providerRetryWait: async () => {},
+		}).result();
+
+		expect(requests).toBe(2);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.find(block => block.type === "text")?.text).toBe("completions recovered");
+	});
+
+	it("retries Azure OpenAI Responses before replay-unsafe output", async () => {
+		let requests = 0;
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			requests++;
+			return requests === 1
+				? createSocketCloseResponse([
+						{ type: "response.created", response: { id: "resp_failed", status: "in_progress" } },
+					])
+				: completedResponsesSse("azure recovered");
+		});
+
+		const result = await streamAzureOpenAIResponses(azureModel, context, {
+			apiKey: "test-key",
+			azureBaseUrl: azureModel.baseUrl,
+			azureApiVersion: "v1",
+			fetch: fetchMock,
+			providerRetryWait: async () => {},
+		}).result();
+
+		expect(requests).toBe(2);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.find(block => block.type === "text")?.text).toBe("azure recovered");
+	});
+
+	it("retries Codex SSE before replay-unsafe output", async () => {
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let requests = 0;
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			requests++;
+			return requests === 1
+				? createSocketCloseResponse([
+						{ type: "response.created", response: { id: "resp_failed", status: "in_progress" } },
+					])
+				: completedCodexSse("codex recovered");
+		});
+
+		const result = await streamOpenAICodexResponses(codexModel, context, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(requests).toBe(2);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.find(block => block.type === "text")?.text).toBe("codex recovered");
+	});
+
+	it("does not retry Codex SSE after text output commits", async () => {
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let requests = 0;
+		const fetchMock: FetchImpl = vi.fn(async () => {
+			requests++;
+			return createSocketCloseResponse([
+				{
+					type: "response.output_item.added",
+					item: { type: "message", id: "msg_partial", role: "assistant", status: "in_progress", content: [] },
+				},
+				{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+				{ type: "response.output_text.delta", delta: "partial" },
+			]);
+		});
+
+		const result = await streamOpenAICodexResponses(codexModel, context, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(requests).toBe(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.content.find(block => block.type === "text")?.text).toBe("partial");
+	});
+});


### PR DESCRIPTION
## Repro
A 200 SSE response that emits only a pre-output frame and then closes its body with Bun's `The socket connection was closed unexpectedly` TypeError terminates OpenAI Responses, Chat Completions, Azure OpenAI Responses, and Codex SSE after one request. Reproduce with `bun test packages/ai/test/openai-stream-socket-retry.test.ts`; before the fix all four retry assertions failed with one observed request.

## Cause
`streamOpenAIResponsesOnce` in `packages/ai/src/providers/openai-responses.ts` limited its mid-stream classifier to parse/incomplete-stream errors, `streamOpenAICompletionsOnce` and `streamAzureOpenAIResponses` finalized body-read failures without a replay-safe provider retry, and `CodexStreamProcessor.#tryRetryProviderError` in `packages/ai/src/providers/openai-codex-responses.ts` accepted only structured `CodexProviderStreamError` instances. Raw transport errors after response headers therefore bypassed `AIError.isProviderRetryableError`.

## Fix
- Generalize the empty-completion staging wrapper into bounded replay-safe stream retries, and enable one transient pre-output retry for Chat Completions and Azure Responses.
- Route OpenAI Responses and raw Codex SSE body failures through the shared provider retry classifier.
- Preserve caller-abort and replay guards once text, thinking, image, or tool output commits; add provider and wrapper regression coverage.
- Document the fix in the AI package changelog.

## Verification
`bun test packages/ai/test/openai-stream-socket-retry.test.ts packages/ai/test/empty-completion-retry.test.ts packages/ai/test/openai-responses-stream-retry.test.ts packages/ai/test/openai-codex-stream.test.ts packages/ai/test/azure-openai-responses-stream.test.ts` passed: 115 tests, 588 assertions. `bun run check` passed in `packages/ai`. `bun check` fails on `main` for the unrelated missing system `cmake` executable while building `audiopus_sys`; the identical `bun run check:rs` failure was confirmed in a clean `origin/main` checkout, so the pre-publish gate was skipped. Fixes #7979