### PR TITLE
fix(eval/python): serialize stdin reads in the Python runner

### DIFF
--- a/packages/coding-agent/src/eval/py/runner.py
+++ b/packages/coding-agent/src/eval/py/runner.py
@@ -1347,11 +1347,28 @@ def _emit_error(rid: str, exc: BaseException) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _read_stdin(loop: asyncio.AbstractEventLoop, queue: asyncio.Queue, stdin) -> None:
-    for raw_line in stdin:
+async def _main_async() -> None:
+    sys.stdout = _StreamProxy("stdout")
+    sys.stderr = _StreamProxy("stderr")
+    _install_idle_sigint()
+    _start_parent_watchdog()
+    _start_capture_drain()
+
+    stdin = sys.__stdin__
+    if stdin is None:
+        return
+
+    _STATE.loop = asyncio.get_running_loop()
+
+    while True:
+        raw_line = stdin.readline()
+        if not raw_line:
+            break
+
         line = raw_line.strip()
         if not line:
             continue
+
         try:
             req = json.loads(line)
         except json.JSONDecodeError as exc:
@@ -1365,56 +1382,23 @@ def _read_stdin(loop: asyncio.AbstractEventLoop, queue: asyncio.Queue, stdin) ->
                 }
             )
             continue
-        loop.call_soon_threadsafe(queue.put_nowait, req)
-    loop.call_soon_threadsafe(queue.put_nowait, {"type": "exit"})
 
+        if not isinstance(req, dict):
+            _emit(
+                {
+                    "type": "error",
+                    "id": "",
+                    "ename": "ProtocolError",
+                    "evalue": "Invalid JSON request: expected an object",
+                    "traceback": [],
+                }
+            )
+            continue
 
-async def _main_async() -> None:
-    sys.stdout = _StreamProxy("stdout")
-    sys.stderr = _StreamProxy("stderr")
-    _install_idle_sigint()
-    _start_parent_watchdog()
-    _start_capture_drain()
+        if req.get("type") == "exit":
+            break
 
-    stdin = sys.__stdin__
-    if stdin is None:
-        return
-
-    loop = asyncio.get_running_loop()
-    _STATE.loop = loop
-    queue: asyncio.Queue = asyncio.Queue()
-    reader = threading.Thread(
-        target=_read_stdin,
-        args=(loop, queue, stdin),
-        name="omp-stdin-reader",
-        daemon=True,
-    )
-    reader.start()
-
-    tasks: set[asyncio.Task] = set()
-
-    def _task_done(task: asyncio.Task) -> None:
-        tasks.discard(task)
-        try:
-            exc = task.exception()
-        except asyncio.CancelledError:
-            return
-        if exc is not None:
-            _emit_error("", exc)
-
-    try:
-        while True:
-            req = await queue.get()
-            if req.get("type") == "exit":
-                break
-            task = asyncio.create_task(_handle_request_async(req))
-            tasks.add(task)
-            task.add_done_callback(_task_done)
-    finally:
-        for task in tasks:
-            task.cancel()
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+        await _handle_request_async(req)
 
 
 def main() -> None:


### PR DESCRIPTION
## What

Remove the Python eval runner's background stdin reader and process NDJSON requests serially on the main loop. Fix https://github.com/can1357/oh-my-pi/issues/7985

## Why

This is the smallest fix that removes the Windows NumPy deadlock trigger without changing the outer eval protocol.

The bug only appears when the runner is launched as a pipe-backed subprocess and a separate thread is reading `sys.stdin` while NumPy loads native extension modules. That combination matches NumPy upstream issue [#24290](https://github.com/numpy/numpy/issues/24290). In practice, the host is already using the runner in a request/response pattern: send one JSON request, wait for `done`, then send the next one. So the background stdin thread is not providing a meaningful parallelism benefit here; it is only introducing the exact concurrency shape that can wedge Windows imports.

Serializing request intake in the main loop keeps the protocol simpler and removes the concurrent stdin reader entirely. That avoids the deadlock trigger, preserves the same request/response behavior the host already relies on, and limits the change to the runner instead of widening the fix across the kernel transport.

## Testing

- `python -m py_compile packages/coding-agent/src/eval/py/runner.py`
- Manual Windows repro before/after:
  - before: runner hung on `import numpy`
  - after: runner emits `started`, `stdout`, and `done`
- Manual pipe-based harness against the modified runner confirmed `import numpy` completes when stdin remains open

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
