### PR TITLE
feat(coding-agent): add native fail-closed prompt gates

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the machine-readable `omp capabilities --json` command and native `prompt-gate-v1` runtime for profile-scoped, fail-closed prompt review integrations.
+
 ## [17.2.11] - 2026-08-07
 
 ### Added

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -46,6 +46,11 @@ export const commands: CommandEntry[] = [
 		help: commandHelp.browserRelayHelp,
 	},
 	{
+		name: "capabilities",
+		load: () => import("./commands/capabilities").then(m => m.default),
+		help: commandHelp.capabilitiesHelp,
+	},
+	{
 		name: "cleanse",
 		load: () => import("./commands/cleanse").then(m => m.default),
 		help: commandHelp.cleanseHelp,

--- a/packages/coding-agent/src/cli/command-help.ts
+++ b/packages/coding-agent/src/cli/command-help.ts
@@ -18,6 +18,10 @@ export const benchHelp = {
 	description: "Benchmark models with the same prompt: time-to-first-token and generation throughput (tokens/s)",
 } satisfies CommandMetadata;
 
+export const capabilitiesHelp = {
+	description: "Report machine-readable host capabilities",
+} satisfies CommandMetadata;
+
 export const browserRelayHelp = {
 	description: "Run the local CDP relay that lets the browser tool drive your own Chrome tabs",
 } satisfies CommandMetadata;

--- a/packages/coding-agent/src/commands/capabilities.ts
+++ b/packages/coding-agent/src/commands/capabilities.ts
@@ -1,0 +1,15 @@
+import { Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { capabilitiesHelp as commandHelp } from "../cli/command-help";
+import { resolvePromptGateCapability } from "../prompt-gate/capability";
+
+export default class Capabilities extends Command {
+	static description = commandHelp.description;
+	static flags = {
+		json: Flags.boolean({ description: "Output machine-readable JSON", required: true }),
+	};
+
+	async run(): Promise<void> {
+		await this.parse(Capabilities);
+		process.stdout.write(`${JSON.stringify(resolvePromptGateCapability())}\n`);
+	}
+}

--- a/packages/coding-agent/src/prompt-gate/capability.ts
+++ b/packages/coding-agent/src/prompt-gate/capability.ts
@@ -1,0 +1,34 @@
+import * as path from "node:path";
+
+import { getActiveProfile, getAgentDir } from "@oh-my-pi/pi-utils/dirs";
+
+export const PROMPT_GATE_CAPABILITY = "prompt-gate-v1";
+export const PROMPT_GATE_PROTOCOL_VERSION = 1;
+export const PROMPT_GATE_DIRECTORY_NAME = "prompt-gates";
+
+export interface PromptGateCapabilityResponse {
+	capabilities: [typeof PROMPT_GATE_CAPABILITY];
+	profile: string;
+	agent_dir: string;
+	gate_dir: string;
+	cwd: string;
+}
+
+export function getPromptGateDirectory(agentDir = getAgentDir()): string {
+	return path.join(path.resolve(agentDir), PROMPT_GATE_DIRECTORY_NAME);
+}
+
+export function resolvePromptGateCapability(options?: {
+	profile?: string;
+	agentDir?: string;
+	cwd?: string;
+}): PromptGateCapabilityResponse {
+	const agentDir = path.resolve(options?.agentDir ?? getAgentDir());
+	return {
+		capabilities: [PROMPT_GATE_CAPABILITY],
+		profile: options?.profile ?? getActiveProfile() ?? "default",
+		agent_dir: agentDir,
+		gate_dir: getPromptGateDirectory(agentDir),
+		cwd: path.resolve(options?.cwd ?? process.cwd()),
+	};
+}

--- a/packages/coding-agent/src/prompt-gate/runtime.ts
+++ b/packages/coding-agent/src/prompt-gate/runtime.ts
@@ -1,0 +1,418 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { lstat, readdir, readFile } from "node:fs/promises";
+import * as path from "node:path";
+
+import { getActiveProfile, getAgentDir } from "@oh-my-pi/pi-utils/dirs";
+import { isEnoent } from "@oh-my-pi/pi-utils/fs-error";
+import { getPromptGateDirectory, PROMPT_GATE_CAPABILITY, PROMPT_GATE_PROTOCOL_VERSION } from "./capability";
+
+const MAXIMUM_CONFIG_BYTES = 64 * 1024;
+const MAXIMUM_FRAME_BYTES = 1024 * 1024;
+const MAXIMUM_STAGED_REPLACEMENTS = 8;
+const PROCESS_EXIT_TIMEOUT_MS = 10_000;
+
+type GateProcess = Bun.Subprocess<"pipe", "pipe", "pipe">;
+
+interface PromptGateConfig {
+	filePath: string;
+	integrationId: string;
+	command: string[];
+	commandSha256: string;
+	firstDecisionTimeoutMs: number;
+}
+
+interface GateFrame {
+	version: number;
+	event: string;
+	integration_id: string;
+	decision?: string;
+	reason?: string;
+	text?: string;
+	delivery_token?: string;
+}
+
+interface ByteReadResult {
+	done: boolean;
+	value?: Uint8Array;
+}
+
+interface ByteStreamReader {
+	read(): Promise<ByteReadResult>;
+}
+
+type GateDecision =
+	| { decision: "allow" }
+	| { decision: "stage"; text: string; deliveryToken: string; proc: GateProcess };
+
+export interface PromptGateDelivery {
+	acknowledge(): Promise<void>;
+	cancel(): Promise<void>;
+}
+
+export interface PromptGateEvaluation {
+	text: string;
+	delivery?: PromptGateDelivery;
+}
+
+export interface PromptGateRequest {
+	text: string;
+	images?: unknown[];
+	sessionId: string;
+	cwd: string;
+	source: string;
+	profile?: string;
+	gateDirectory?: string;
+}
+
+export class PromptGateBlockedError extends Error {
+	constructor(message: string) {
+		super(`Prompt gate blocked this prompt: ${message}`);
+		this.name = "PromptGateBlockedError";
+	}
+}
+
+class JsonLineReader {
+	readonly #reader: ByteStreamReader;
+	readonly #decoder = new TextDecoder();
+	#buffer = "";
+
+	constructor(stream: GateProcess["stdout"]) {
+		this.#reader = stream.getReader();
+	}
+
+	async read(timeoutMs?: number): Promise<string | undefined> {
+		const deadline = timeoutMs === undefined ? undefined : Date.now() + timeoutMs;
+		while (true) {
+			const newline = this.#buffer.indexOf("\n");
+			if (newline >= 0) {
+				const line = this.#buffer.slice(0, newline).replace(/\r$/, "");
+				this.#buffer = this.#buffer.slice(newline + 1);
+				return line;
+			}
+			if (this.#buffer.length > MAXIMUM_FRAME_BYTES) {
+				throw new Error(`gate output exceeded ${MAXIMUM_FRAME_BYTES} bytes without a newline`);
+			}
+
+			const chunk =
+				deadline === undefined
+					? await this.#readChunk()
+					: await this.#readChunk(Math.max(0, deadline - Date.now()), timeoutMs);
+			if (chunk.value !== undefined) {
+				this.#buffer += this.#decoder.decode(chunk.value, { stream: true });
+			}
+			if (chunk.done) {
+				this.#buffer += this.#decoder.decode();
+				if (this.#buffer.length === 0) return undefined;
+				const line = this.#buffer.replace(/\r$/, "");
+				this.#buffer = "";
+				return line;
+			}
+		}
+	}
+
+	async #readChunk(timeoutMs?: number, timeoutLabelMs = timeoutMs): Promise<ByteReadResult> {
+		if (timeoutMs === undefined) return this.#reader.read();
+		const { promise: timeout, reject } = Promise.withResolvers<never>();
+		const timer = setTimeout(() => reject(new Error(`no decision within ${timeoutLabelMs} ms`)), timeoutMs);
+		try {
+			return await Promise.race([this.#reader.read(), timeout]);
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function parseConfig(filePath: string, value: unknown): PromptGateConfig {
+	const record = asRecord(value);
+	if (!record) throw new Error("configuration must be a JSON object");
+	const command =
+		Array.isArray(record.command) && record.command.every(item => typeof item === "string")
+			? record.command
+			: undefined;
+	if (
+		record.version !== PROMPT_GATE_PROTOCOL_VERSION ||
+		record.event !== PROMPT_GATE_CAPABILITY ||
+		typeof record.integration_id !== "string" ||
+		record.integration_id.length === 0 ||
+		!command ||
+		command.length === 0 ||
+		command.some(part => part.length === 0) ||
+		typeof record.command_sha256 !== "string" ||
+		!/^[a-f0-9]{64}$/.test(record.command_sha256) ||
+		!Number.isSafeInteger(record.first_decision_timeout_ms) ||
+		(record.first_decision_timeout_ms as number) <= 0 ||
+		record.on_error !== "block"
+	) {
+		throw new Error("configuration does not satisfy prompt-gate-v1");
+	}
+	return {
+		filePath,
+		integrationId: record.integration_id,
+		command,
+		commandSha256: record.command_sha256,
+		firstDecisionTimeoutMs: record.first_decision_timeout_ms as number,
+	};
+}
+
+async function loadGateConfigs(directory: string): Promise<PromptGateConfig[]> {
+	const directoryStat = await lstat(directory).catch(error => {
+		if (isEnoent(error)) return undefined;
+		throw error;
+	});
+	if (directoryStat === undefined) return [];
+	if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+		throw new Error("gate path is not a regular directory");
+	}
+
+	const names = (await readdir(directory)).filter(name => name.endsWith(".json")).sort();
+	const configs: PromptGateConfig[] = [];
+	const integrationIds = new Set<string>();
+	for (const name of names) {
+		const filePath = path.join(directory, name);
+		const stat = await lstat(filePath);
+		if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`${name} is not a regular file`);
+		if (stat.size > MAXIMUM_CONFIG_BYTES) throw new Error(`${name} exceeds ${MAXIMUM_CONFIG_BYTES} bytes`);
+		const bytes = await readFile(filePath, "utf8");
+		let decoded: unknown;
+		try {
+			decoded = JSON.parse(bytes);
+		} catch {
+			throw new Error(`${name} is not valid JSON`);
+		}
+		const config = parseConfig(filePath, decoded);
+		if (integrationIds.has(config.integrationId)) {
+			throw new Error(`${name} repeats integration_id ${config.integrationId}`);
+		}
+		integrationIds.add(config.integrationId);
+		configs.push(config);
+	}
+	return configs;
+}
+
+async function sha256File(filePath: string): Promise<string> {
+	const hash = createHash("sha256");
+	const stream = createReadStream(filePath);
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	stream.on("data", chunk => hash.update(chunk));
+	stream.on("error", reject);
+	stream.on("end", resolve);
+	await promise;
+	return hash.digest("hex");
+}
+
+async function verifyCommand(config: PromptGateConfig): Promise<void> {
+	const executable = config.command[0];
+	if (!path.isAbsolute(executable)) throw new Error("gate command executable must be absolute");
+	const stat = await lstat(executable);
+	if (!stat.isFile() || stat.isSymbolicLink()) throw new Error("gate command executable must be a regular file");
+	if (process.platform !== "win32" && (stat.mode & 0o111) === 0) throw new Error("gate command is not executable");
+	if ((await sha256File(executable)) !== config.commandSha256) throw new Error("gate command digest does not match");
+}
+
+function parseFrame(line: string, config: PromptGateConfig): GateFrame {
+	let decoded: unknown;
+	try {
+		decoded = JSON.parse(line);
+	} catch {
+		throw new Error("gate returned malformed JSON");
+	}
+	const frame = asRecord(decoded);
+	if (
+		!frame ||
+		frame.version !== PROMPT_GATE_PROTOCOL_VERSION ||
+		frame.integration_id !== config.integrationId ||
+		typeof frame.event !== "string"
+	) {
+		throw new Error("gate returned a frame for a different protocol or integration");
+	}
+	return frame as unknown as GateFrame;
+}
+
+async function waitForExit(proc: GateProcess): Promise<number> {
+	const { promise: timeout, reject } = Promise.withResolvers<never>();
+	const timer = setTimeout(
+		() => reject(new Error("gate process did not exit after delivery")),
+		PROCESS_EXIT_TIMEOUT_MS,
+	);
+	try {
+		return await Promise.race([proc.exited, timeout]);
+	} catch (error) {
+		proc.kill();
+		await proc.exited;
+		throw error;
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+async function stopProcess(proc: GateProcess): Promise<void> {
+	try {
+		await proc.stdin.end();
+	} catch {}
+	if ((await waitForExit(proc)) !== 0) throw new Error("gate process exited unsuccessfully");
+}
+
+async function evaluateGate(
+	config: PromptGateConfig,
+	request: Omit<PromptGateRequest, "gateDirectory">,
+): Promise<GateDecision> {
+	await verifyCommand(config);
+	const proc = Bun.spawn(config.command, {
+		cwd: request.cwd,
+		env: process.env,
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const stderrReader = proc.stderr.getReader();
+	void (async () => {
+		while (!(await stderrReader.read()).done) {}
+	})().catch(() => {});
+	const reader = new JsonLineReader(proc.stdout);
+	const input = {
+		version: PROMPT_GATE_PROTOCOL_VERSION,
+		event: PROMPT_GATE_CAPABILITY,
+		integration_id: config.integrationId,
+		text: request.text,
+		images: request.images?.map(() => ({})) ?? [],
+		session_id: request.sessionId,
+		cwd: request.cwd,
+		profile: request.profile ?? getActiveProfile() ?? "default",
+		source: request.source,
+	};
+	try {
+		proc.stdin.write(`${JSON.stringify(input)}\n`);
+		await proc.stdin.flush();
+
+		const firstLine = await reader.read(config.firstDecisionTimeoutMs);
+		if (firstLine === undefined) throw new Error("gate exited without a decision");
+		const first = parseFrame(firstLine, config);
+		if (first.event !== PROMPT_GATE_CAPABILITY || (first.decision !== "allow" && first.decision !== "block")) {
+			throw new Error("gate returned an invalid first decision");
+		}
+		if (first.decision === "allow") {
+			await stopProcess(proc);
+			return { decision: "allow" };
+		}
+
+		const stagedLine = await reader.read();
+		if (stagedLine === undefined) {
+			const exitCode = await proc.exited;
+			throw new Error(
+				typeof first.reason === "string" && first.reason.length > 0
+					? first.reason
+					: `gate blocked the prompt and exited with status ${exitCode}`,
+			);
+		}
+		const staged = parseFrame(stagedLine, config);
+		if (staged.event === PROMPT_GATE_CAPABILITY && staged.decision === "block") {
+			throw new Error(
+				typeof staged.reason === "string" && staged.reason.length > 0
+					? staged.reason
+					: "gate could not review the prompt",
+			);
+		}
+		if (
+			staged.event !== "stage_approved" ||
+			typeof staged.text !== "string" ||
+			staged.text.trim().length === 0 ||
+			typeof staged.delivery_token !== "string" ||
+			staged.delivery_token.length === 0
+		) {
+			throw new Error("gate returned an invalid staged approval");
+		}
+		return { decision: "stage", text: staged.text, deliveryToken: staged.delivery_token, proc };
+	} catch (error) {
+		if (proc.exitCode === null) proc.kill();
+		await proc.exited;
+		throw error;
+	}
+}
+
+async function evaluateWithConfigs(
+	configs: PromptGateConfig[],
+	request: Omit<PromptGateRequest, "gateDirectory">,
+	stagedTokens: Set<string>,
+): Promise<PromptGateEvaluation> {
+	for (const config of configs) {
+		let result: GateDecision;
+		try {
+			result = await evaluateGate(config, request);
+		} catch (error) {
+			const detail = error instanceof Error ? error.message : String(error);
+			throw new PromptGateBlockedError(`${path.basename(config.filePath)}: ${detail}`);
+		}
+		if (result.decision === "allow") continue;
+		if (stagedTokens.size >= MAXIMUM_STAGED_REPLACEMENTS || stagedTokens.has(result.deliveryToken)) {
+			result.proc.kill();
+			await result.proc.exited;
+			throw new PromptGateBlockedError("staged approval cycle exceeded the delivery limit");
+		}
+
+		const nextTokens = new Set(stagedTokens).add(result.deliveryToken);
+		let replacement: PromptGateEvaluation;
+		try {
+			replacement = await evaluateWithConfigs(configs, { ...request, text: result.text }, nextTokens);
+		} catch (error) {
+			result.proc.kill();
+			await result.proc.exited;
+			throw error;
+		}
+		let settlement: Promise<void> | undefined;
+		const cancel = async (): Promise<void> => {
+			await replacement.delivery?.cancel();
+			if (result.proc.exitCode === null) result.proc.kill();
+			await result.proc.exited;
+		};
+		return {
+			text: replacement.text,
+			delivery: {
+				acknowledge: () => {
+					settlement ??= (async () => {
+						try {
+							await replacement.delivery?.acknowledge();
+							const frame = {
+								version: PROMPT_GATE_PROTOCOL_VERSION,
+								event: "stage_delivery",
+								integration_id: config.integrationId,
+								delivery_token: result.deliveryToken,
+								status: "delivered",
+							};
+							result.proc.stdin.write(`${JSON.stringify(frame)}\n`);
+							await result.proc.stdin.flush();
+							await stopProcess(result.proc);
+						} catch (error) {
+							await cancel();
+							throw error;
+						}
+					})();
+					return settlement;
+				},
+				cancel: () => {
+					settlement ??= cancel();
+					return settlement;
+				},
+			},
+		};
+	}
+	return { text: request.text };
+}
+
+export async function runPromptGates(request: PromptGateRequest): Promise<PromptGateEvaluation> {
+	const gateDirectory = request.gateDirectory ?? getPromptGateDirectory(getAgentDir());
+	let configs: PromptGateConfig[];
+	try {
+		configs = await loadGateConfigs(gateDirectory);
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new PromptGateBlockedError(detail);
+	}
+	return evaluateWithConfigs(configs, request, new Set());
+}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -157,6 +157,8 @@ import { containsWorkflow, renderWorkflowNotice } from "../modes/workflow";
 import { type PlanApprovalDetails, resolveApprovedPlan } from "../plan-mode/approved-plan";
 import { listPlanFiles, readPlanFile } from "../plan-mode/plan-files";
 import type { PlanModeState } from "../plan-mode/state";
+import type { PromptGateDelivery } from "../prompt-gate/runtime";
+import { runPromptGates } from "../prompt-gate/runtime";
 import goalModeContextPrompt from "../prompts/goals/goal-mode-context.md" with { type: "text" };
 import goalTodoContextPrompt from "../prompts/goals/goal-todo-context.md" with { type: "text" };
 import autoContinuePrompt from "../prompts/system/auto-continue.md" with { type: "text" };
@@ -4981,7 +4983,20 @@ export class AgentSession {
 		}
 
 		// Expand file-based prompt templates if requested
-		const expandedText = expandPromptTemplates ? expandPromptTemplate(text, [...this.#promptTemplates]) : text;
+		let expandedText = expandPromptTemplates ? expandPromptTemplate(text, [...this.#promptTemplates]) : text;
+		const promptAttribution = options?.attribution ?? (options?.synthetic ? "agent" : "user");
+		let promptGateDelivery: PromptGateDelivery | undefined;
+		if (!options?.synthetic && promptAttribution === "user") {
+			const evaluation = await runPromptGates({
+				text: expandedText,
+				images: options?.images,
+				sessionId: this.sessionManager.getSessionId(),
+				cwd: this.sessionManager.getCwd(),
+				source: "prompt",
+			});
+			expandedText = evaluation.text;
+			promptGateDelivery = evaluation.delivery;
+		}
 
 		// Magic keywords ("ultrathink", "orchestrate"): append hidden system notices after the
 		// user's message that steer this turn. User-authored prompts only — synthetic /
@@ -5003,19 +5018,27 @@ export class AgentSession {
 		// If streaming, queue via steer() or followUp() based on option
 		if (this.isStreaming) {
 			const streamingBehavior = options?.streamingBehavior;
-			if (!streamingBehavior) throw new AgentBusyError();
+			if (!streamingBehavior) {
+				await promptGateDelivery?.cancel();
+				throw new AgentBusyError();
+			}
 
-			// Steer/follow-up the keyword notices BEFORE the queued user message so the
-			// model reads the steering notice ahead of the prompt it modifies.
-			for (const notice of keywordNotices) {
-				await this.#queueCustomMessage(notice, streamingBehavior);
+			try {
+				// Steer/follow-up the keyword notices BEFORE the queued user message so the
+				// model reads the steering notice ahead of the prompt it modifies.
+				for (const notice of keywordNotices) {
+					await this.#queueCustomMessage(notice, streamingBehavior);
+				}
+				if (streamingBehavior === "followUp") {
+					await this.#queueUserMessage(expandedText, options?.images, "followUp", promptGateDelivery);
+				} else {
+					await this.#queueUserMessage(expandedText, options?.images, "steer", promptGateDelivery);
+				}
+				return true;
+			} catch (error) {
+				await promptGateDelivery?.cancel();
+				throw error;
 			}
-			if (streamingBehavior === "followUp") {
-				await this.#queueUserMessage(expandedText, options?.images, "followUp");
-			} else {
-				await this.#queueUserMessage(expandedText, options?.images, "steer");
-			}
-			return true;
 		}
 
 		// Skip eager preludes when the user has already queued a directive
@@ -5024,21 +5047,32 @@ export class AgentSession {
 			!options?.synthetic && !hasPendingUserDirective ? this.#todo.createEagerTodoPrelude(expandedText) : undefined;
 		const eagerTaskPrelude =
 			!options?.synthetic && !hasPendingUserDirective ? this.#todo.createEagerTaskPrelude(expandedText) : undefined;
-		const normalizedImages = await this.#normalizeImagesForModel(options?.images);
+		let normalizedImages: ImageContent[] | undefined;
+		let imageDescriptionNotice: CustomMessage | undefined;
+		try {
+			normalizedImages = await this.#normalizeImagesForModel(options?.images);
+			// Text-only model + image attachment: describe via a vision model and inject the
+			// description as a hidden companion (the image stays in the visible user message).
+			imageDescriptionNotice = normalizedImages?.length
+				? await this.#buildImageDescriptionNotice(normalizedImages)
+				: undefined;
+		} catch (error) {
+			await promptGateDelivery?.cancel();
+			throw error;
+		}
 
 		const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
 		if (normalizedImages?.length) {
 			userContent.push(...normalizedImages);
 		}
-		// Text-only model + image attachment: describe via a vision model and inject the
-		// description as a hidden companion (the image stays in the visible user message).
-		const imageDescriptionNotice = normalizedImages?.length
-			? await this.#buildImageDescriptionNotice(normalizedImages)
-			: undefined;
 
-		const promptAttribution = options?.attribution ?? (options?.synthetic ? "agent" : "user");
 		const message = options?.synthetic
-			? { role: "developer" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() }
+			? {
+					role: "developer" as const,
+					content: userContent,
+					attribution: promptAttribution,
+					timestamp: Date.now(),
+				}
 			: { role: "user" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() };
 
 		const preludeMessages: AgentMessage[] = [];
@@ -5058,6 +5092,8 @@ export class AgentSession {
 			await this.#promptWithMessage(message, expandedText, {
 				...options,
 				images: normalizedImages,
+				acknowledgePromptGateDelivery: promptGateDelivery?.acknowledge,
+				cancelPromptGateDelivery: promptGateDelivery?.cancel,
 				prependMessages:
 					preludeMessages.length > 0 || keywordNotices.length > 0 || imageDescriptionNotice
 						? [...preludeMessages, ...keywordNotices, ...(imageDescriptionNotice ? [imageDescriptionNotice] : [])]
@@ -5139,6 +5175,8 @@ export class AgentSession {
 		options?: Pick<PromptOptions, "toolChoice" | "images" | "skipCompactionCheck"> & {
 			prependMessages?: AgentMessage[];
 			skipPostPromptRecoveryWait?: boolean;
+			acknowledgePromptGateDelivery?: () => Promise<void>;
+			cancelPromptGateDelivery?: () => Promise<void>;
 			acceptTerminalEmptyStop?: boolean;
 		},
 	): Promise<void> {
@@ -5339,18 +5377,19 @@ export class AgentSession {
 				nonMessageTokens,
 				cutoffCount: this.messages.length + messages.length,
 			});
-			// Commit the plan-reference delivery flag only now that the message is
-			// actually handed to agent.prompt. Every pre-send setup step above can
-			// return (generation-bail) or throw (@-mention reads, before_agent_start
-			// hooks, pre-prompt compaction) before this point; setting the flag at
-			// construction time (#buildPlanReferenceMessage) stranded it `true` with
-			// nothing delivered, so the retry skipped re-injection and the executor
-			// lost the approved plan (issue #4094). The compaction-success resets
-			// (issue #1246) still clear it for re-injection on the next turn.
-			if (planReferenceMessage) {
-				this.#planReferenceSent = true;
-			}
 			try {
+				await options?.acknowledgePromptGateDelivery?.();
+				// Commit the plan-reference delivery flag only now that the message is
+				// actually handed to agent.prompt. Every pre-send setup step above can
+				// return (generation-bail) or throw (@-mention reads, before_agent_start
+				// hooks, pre-prompt compaction) before this point; setting the flag at
+				// construction time (#buildPlanReferenceMessage) stranded it `true` with
+				// nothing delivered, so the retry skipped re-injection and the executor
+				// lost the approved plan (issue #4094). The compaction-success resets
+				// (issue #1246) still clear it for re-injection on the next turn.
+				if (planReferenceMessage) {
+					this.#planReferenceSent = true;
+				}
 				await this.#recovery.promptAgentWithIdleRetry(messages, agentPromptOptions);
 			} finally {
 				this.#stats.setPendingSnapshot(undefined);
@@ -5359,6 +5398,7 @@ export class AgentSession {
 				await this.#waitForPostPromptRecovery(generation);
 			}
 		} finally {
+			await options?.cancelPromptGateDelivery?.();
 			// The per-turn before_agent_start override lives only for this turn.
 			this.#tools.clearTurnSystemPromptOverride();
 			this.#usagePreflightReadyForNextModelCall = false;
@@ -5575,21 +5615,42 @@ export class AgentSession {
 		text: string,
 		images: ImageContent[] | undefined,
 		mode: "steer" | "followUp",
+		promptGateDelivery?: PromptGateDelivery,
 	): Promise<void> {
+		const evaluation =
+			promptGateDelivery === undefined
+				? await runPromptGates({
+						text,
+						images,
+						sessionId: this.sessionManager.getSessionId(),
+						cwd: this.sessionManager.getCwd(),
+						source: mode,
+					})
+				: { text, delivery: promptGateDelivery };
+		text = evaluation.text;
+		promptGateDelivery = evaluation.delivery;
 		// A queued user message (RPC/SDK/collab steer or follow-up, or a typed message
 		// while streaming) is a deliberate resume; re-enable advisor auto-resume that
 		// a user interrupt suppressed.
 		this.#advisors.autoResumeSuppressed = false;
-		const normalizedImages = await this.#normalizeImagesForModel(images);
+		let normalizedImages: ImageContent[] | undefined;
+		let imageDescriptionNotice: CustomMessage | undefined;
+		try {
+			normalizedImages = await this.#normalizeImagesForModel(images);
+			// Text-only model + image attachment: describe via a vision model and enqueue the
+			// description as a hidden companion immediately before the user message.
+			imageDescriptionNotice = normalizedImages?.length
+				? await this.#buildImageDescriptionNotice(normalizedImages)
+				: undefined;
+			await promptGateDelivery?.acknowledge();
+		} catch (error) {
+			await promptGateDelivery?.cancel();
+			throw error;
+		}
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
 		if (normalizedImages?.length) {
 			content.push(...normalizedImages);
 		}
-		// Text-only model + image attachment: describe via a vision model and enqueue the
-		// description as a hidden companion immediately before the user message.
-		const imageDescriptionNotice = normalizedImages?.length
-			? await this.#buildImageDescriptionNotice(normalizedImages)
-			: undefined;
 		this.#allowQueuedMessageDrainRetry();
 		if (mode === "followUp") {
 			if (imageDescriptionNotice) this.agent.followUp(imageDescriptionNotice);

--- a/packages/coding-agent/test/agent-session-prompt-gate.test.ts
+++ b/packages/coding-agent/test/agent-session-prompt-gate.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { PromptGateBlockedError } from "@oh-my-pi/pi-coding-agent/prompt-gate/runtime";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { getAgentDir, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+
+const originalAgentDir = getAgentDir();
+
+describe("AgentSession prompt gate", () => {
+	let tempDir: TempDir;
+	let session: AgentSession | undefined;
+	let authStorage: AuthStorage | undefined;
+	let gateDirectory: string;
+	let helperPath: string;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@omp-agent-session-prompt-gate-");
+		setAgentDir(path.join(tempDir.path(), "agent"));
+		gateDirectory = path.join(getAgentDir(), "prompt-gates");
+		await mkdir(gateDirectory, { recursive: true });
+		helperPath = path.join(tempDir.path(), "blocking-gate");
+		await writeFile(
+			helperPath,
+			`#!/usr/bin/env bun\nimport { createInterface } from "node:readline";\nconst lines = createInterface({ input: process.stdin, crlfDelay: Infinity });\nfor await (const line of lines) {\n  const input = JSON.parse(line);\n  process.stdout.write(JSON.stringify({ version: 1, event: "prompt-gate-v1", integration_id: input.integration_id, decision: "block", reason: "test blocked" }) + "\\n");\n  process.stdin.destroy();\n  break;\n}\n`,
+		);
+		await chmod(helperPath, 0o755);
+		const digest = Bun.SHA256.hash(new Uint8Array(await Bun.file(helperPath).arrayBuffer()), "hex");
+		await writeFile(
+			path.join(gateDirectory, "test.json"),
+			JSON.stringify({
+				version: 1,
+				event: "prompt-gate-v1",
+				integration_id: "agent-session-test",
+				command: [helperPath],
+				command_sha256: digest,
+				first_decision_timeout_ms: 1_000,
+				on_error: "block",
+			}),
+		);
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage?.close();
+		setAgentDir(originalAgentDir);
+		tempDir.removeSync();
+	});
+
+	it("blocks user prompts before provider dispatch but bypasses agent-attributed synthetic turns", async () => {
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+		let providerCalls = 0;
+		const mock = createMockModel({ responses: [{ content: ["Done"] }] });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (...args) => {
+				providerCalls++;
+				return mock.stream(...args);
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+
+		await expect(session.prompt("must not reach provider")).rejects.toBeInstanceOf(PromptGateBlockedError);
+		expect(providerCalls).toBe(0);
+		await expect(session.steer("must not enter steer queue")).rejects.toBeInstanceOf(PromptGateBlockedError);
+		await expect(session.followUp("must not enter follow-up queue")).rejects.toBeInstanceOf(PromptGateBlockedError);
+		await session.prompt("internal continuation", { synthetic: true });
+		expect(providerCalls).toBe(1);
+	});
+	it("cancels staged gate delivery when local preflight rejects the prompt", async () => {
+		const cancellationRecord = path.join(tempDir.path(), "gate-cancelled");
+		await writeFile(
+			helperPath,
+			`#!/usr/bin/env bun
+import { createInterface } from "node:readline";
+import { writeFileSync } from "node:fs";
+const cancellationRecord = process.argv.at(-1);
+process.on("SIGTERM", () => {
+  writeFileSync(cancellationRecord, "cancelled");
+  process.exit(0);
+});
+const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
+for await (const line of lines) {
+  const input = JSON.parse(line);
+  const frame = value => process.stdout.write(JSON.stringify({ version: 1, integration_id: input.integration_id, ...value }) + "\\n");
+  if (input.text === "original") {
+    frame({ event: "prompt-gate-v1", decision: "block", reason: "reviewing" });
+    frame({ event: "stage_approved", text: "corrected", delivery_token: "delivery-1" });
+  } else {
+    frame({ event: "prompt-gate-v1", decision: "allow" });
+    break;
+  }
+}
+`,
+		);
+		await chmod(helperPath, 0o755);
+		const digest = Bun.SHA256.hash(new Uint8Array(await Bun.file(helperPath).arrayBuffer()), "hex");
+		await writeFile(
+			path.join(gateDirectory, "test.json"),
+			JSON.stringify({
+				version: 1,
+				event: "prompt-gate-v1",
+				integration_id: "agent-session-test",
+				command: [helperPath, cancellationRecord],
+				command_sha256: digest,
+				first_decision_timeout_ms: 1_000,
+				on_error: "block",
+			}),
+		);
+
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+		const agent = new Agent({
+			getApiKey: () => undefined,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: createMockModel({ responses: [{ content: ["unreachable"] }] }).stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+
+		await expect(session.prompt("original")).rejects.toThrow("No API key found");
+		await expect(Bun.file(cancellationRecord).exists()).resolves.toBe(true);
+	});
+});

--- a/packages/coding-agent/test/prompt-gate-runtime.test.ts
+++ b/packages/coding-agent/test/prompt-gate-runtime.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+import { resolvePromptGateCapability } from "../src/prompt-gate/capability";
+import { PromptGateBlockedError, runPromptGates } from "../src/prompt-gate/runtime";
+
+const GATE_SCRIPT = String.raw`
+const { createInterface } = require("node:readline");
+const { writeFile } = require("node:fs/promises");
+const [mode, recordPath] = process.argv.slice(-2);
+const lines = createInterface({ input: process.stdin, crlfDelay: Infinity })[Symbol.asyncIterator]();
+const first = await lines.next();
+const input = JSON.parse(first.value);
+const frame = value => process.stdout.write(JSON.stringify({ version: 1, integration_id: input.integration_id, ...value }) + "\n");
+const sleep = ms => {
+  const { promise, resolve } = Promise.withResolvers();
+  setTimeout(resolve, ms);
+  return promise;
+};
+if (mode === "allow") {
+  await writeFile(recordPath, JSON.stringify({ input }));
+  frame({ event: "prompt-gate-v1", decision: "allow" });
+} else if (mode === "block") {
+  frame({ event: "prompt-gate-v1", decision: "block", reason: "review cancelled" });
+  process.stdin.destroy();
+} else if (mode === "recovery-block") {
+  frame({ event: "prompt-gate-v1", decision: "block", reason: "reviewing" });
+  frame({ event: "prompt-gate-v1", decision: "block", reason: "review unavailable" });
+  process.stdin.destroy();
+} else if (mode === "stage") {
+  if (input.text === "original") {
+    frame({ event: "prompt-gate-v1", decision: "block", reason: "reviewing" });
+    frame({ event: "stage_approved", text: "corrected", delivery_token: "delivery-1" });
+    const second = await lines.next();
+    await writeFile(recordPath, JSON.stringify({ input, acknowledgment: JSON.parse(second.value) }));
+  } else {
+    frame({ event: "prompt-gate-v1", decision: "allow" });
+  }
+} else if (mode === "empty-stage") {
+  frame({ event: "prompt-gate-v1", decision: "block", reason: "reviewing" });
+  frame({ event: "stage_approved", text: " ", delivery_token: "delivery-empty" });
+} else if (mode === "malformed") {
+  process.stdout.write("not-json\n");
+} else if (mode === "timeout") {
+  await lines.next();
+  frame({ event: "prompt-gate-v1", decision: "allow" });
+} else if (mode === "slow") {
+  process.stdout.write('{"version":1,');
+  await sleep(15);
+  process.stdout.write('"event":"prompt-gate-v1",');
+  await sleep(15);
+  process.stdout.write('"integration_id":"omp-test","decision":"allow"}\n');
+}
+`;
+
+const temporaryDirectories: string[] = [];
+let executableDigest: string | undefined;
+
+async function sha256File(filePath: string): Promise<string> {
+	const hash = createHash("sha256");
+	const stream = createReadStream(filePath);
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	stream.on("data", chunk => hash.update(chunk));
+	stream.on("error", reject);
+	stream.on("end", resolve);
+	await promise;
+	return hash.digest("hex");
+}
+
+async function makeFixture(mode: string, options?: { digest?: string; timeoutMs?: number }) {
+	const root = await mkdtemp(path.join(tmpdir(), "omp-prompt-gate-"));
+	temporaryDirectories.push(root);
+	const gateDirectory = path.join(root, "gates");
+	await mkdir(gateDirectory);
+	const recordPath = path.join(root, "record.json");
+	executableDigest ??= await sha256File(process.execPath);
+	await writeFile(
+		path.join(gateDirectory, "bex.json"),
+		JSON.stringify({
+			version: 1,
+			event: "prompt-gate-v1",
+			integration_id: "omp-test",
+			command: [process.execPath, "-e", GATE_SCRIPT, mode, recordPath],
+			command_sha256: options?.digest ?? executableDigest,
+			first_decision_timeout_ms: options?.timeoutMs ?? 1_000,
+			on_error: "block",
+		}),
+	);
+	return { root, gateDirectory, recordPath };
+}
+
+async function evaluate(gateDirectory: string, text = "original") {
+	return runPromptGates({
+		text,
+		sessionId: "session-1",
+		cwd: process.cwd(),
+		source: "prompt",
+		profile: "team",
+		gateDirectory,
+	});
+}
+
+afterEach(async () => {
+	await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { recursive: true, force: true })));
+});
+
+describe("prompt-gate-v1 capability", () => {
+	it("reports canonical profile-scoped paths", () => {
+		expect(
+			resolvePromptGateCapability({ profile: "team", agentDir: "/tmp/omp-team/agent", cwd: "/tmp/workspace" }),
+		).toEqual({
+			capabilities: ["prompt-gate-v1"],
+			profile: "team",
+			agent_dir: "/tmp/omp-team/agent",
+			gate_dir: "/tmp/omp-team/agent/prompt-gates",
+			cwd: "/tmp/workspace",
+		});
+	});
+});
+
+describe("prompt-gate-v1 runtime", () => {
+	it("allows unchanged prompts when no gates are installed", async () => {
+		const root = await mkdtemp(path.join(tmpdir(), "omp-prompt-gate-empty-"));
+		temporaryDirectories.push(root);
+		await expect(evaluate(path.join(root, "missing"))).resolves.toEqual({ text: "original" });
+	});
+
+	it("passes the bound prompt context to an allowing gate", async () => {
+		const fixture = await makeFixture("allow");
+		await expect(evaluate(fixture.gateDirectory)).resolves.toEqual({ text: "original" });
+		const record = JSON.parse(await readFile(fixture.recordPath, "utf8"));
+		expect(record.input).toEqual({
+			version: 1,
+			event: "prompt-gate-v1",
+			integration_id: "omp-test",
+			text: "original",
+			images: [],
+			session_id: "session-1",
+			cwd: process.cwd(),
+			profile: "team",
+			source: "prompt",
+		});
+	});
+
+	it("re-gates staged text and acknowledges only when the host delivers it", async () => {
+		const fixture = await makeFixture("stage");
+		const result = await evaluate(fixture.gateDirectory);
+		expect(result.text).toBe("corrected");
+		expect(result.delivery).toBeDefined();
+		await expect(Bun.file(fixture.recordPath).exists()).resolves.toBe(false);
+		await result.delivery?.acknowledge();
+		const record = JSON.parse(await readFile(fixture.recordPath, "utf8"));
+		expect(record.input.text).toBe("original");
+		expect(record.acknowledgment).toEqual({
+			version: 1,
+			event: "stage_delivery",
+			integration_id: "omp-test",
+			delivery_token: "delivery-1",
+			status: "delivered",
+		});
+	});
+
+	it("cancels an unacknowledged staged delivery", async () => {
+		const fixture = await makeFixture("stage");
+		const result = await evaluate(fixture.gateDirectory);
+		await result.delivery?.cancel();
+		await expect(Bun.file(fixture.recordPath).exists()).resolves.toBe(false);
+	});
+
+	it("fails closed when review is cancelled", async () => {
+		const fixture = await makeFixture("block");
+		await expect(evaluate(fixture.gateDirectory)).rejects.toThrow("review cancelled");
+	});
+
+	it("fails closed with a gate's terminal recovery reason", async () => {
+		const fixture = await makeFixture("recovery-block");
+		await expect(evaluate(fixture.gateDirectory)).rejects.toThrow("review unavailable");
+	});
+
+	it("fails closed on malformed output and decision timeout", async () => {
+		const malformed = await makeFixture("malformed");
+		await expect(evaluate(malformed.gateDirectory)).rejects.toBeInstanceOf(PromptGateBlockedError);
+		const timeout = await makeFixture("timeout", { timeoutMs: 20 });
+		await expect(evaluate(timeout.gateDirectory)).rejects.toThrow("no decision within 20 ms");
+	});
+
+	it("applies the first-decision timeout to the whole frame", async () => {
+		const fixture = await makeFixture("slow", { timeoutMs: 20 });
+		await expect(evaluate(fixture.gateDirectory)).rejects.toThrow("no decision within 20 ms");
+	});
+
+	it("fails closed on an empty staged replacement", async () => {
+		const fixture = await makeFixture("empty-stage");
+		await expect(evaluate(fixture.gateDirectory)).rejects.toThrow("invalid staged approval");
+	});
+
+	it("fails closed when the configured command digest drifts", async () => {
+		const fixture = await makeFixture("allow", { digest: "0".repeat(64) });
+		await expect(evaluate(fixture.gateDirectory)).rejects.toThrow("gate command digest does not match");
+	});
+});


### PR DESCRIPTION
## What

- Add `omp capabilities --json`, reporting the active profile, canonical agent directory, working directory, and profile-scoped `prompt-gate-v1` directory.
- Add a native pre-dispatch prompt gate for user-attributed prompts, steers, and follow-ups. Synthetic agent turns bypass it.
- Load lexically ordered JSON gate configs from `<agent_dir>/prompt-gates`, require absolute executable paths plus a pinned SHA-256 digest, and fail closed on invalid configuration, process failure, malformed output, timeout, or cancellation.
- Re-gate staged replacement text, bound replacement cycles, and acknowledge staged delivery only when the corrected prompt is handed to the agent or queued.
- Cancel unacknowledged gate processes when local preflight prevents delivery.

## Why

Extension `input` handlers are best-effort and time-bounded, so they cannot provide a fail-closed review boundary. A native host gate lets integrations review or replace user prompts before provider dispatch while preserving explicit delivery acknowledgement and deterministic failure behavior.

## Testing

- `bun check`
- `bun test test/prompt-gate-runtime.test.ts test/agent-session-prompt-gate.test.ts test/cli-command-metadata.test.ts` — 14 pass, 0 fail
- `bun run check:types`
- `bun run build`
- Manual capability smoke: `./dist/omp capabilities --json`
- Manual native integration smoke: a Korean prompt passed through a digest-pinned Bex gate, reached the model once, and produced the gate heartbeat

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)