### PR TITLE
feat(tui): add ignored-file autocomplete setting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `autocomplete.includeIgnoredFiles` to include git-ignored files in `@` file autocomplete.
+
 ## [17.2.11] - 2026-08-07
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1747,6 +1747,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"autocomplete.includeIgnoredFiles": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			group: "Input",
+			label: "Include Git-Ignored Files",
+			description: "Include files excluded by .gitignore in @ file autocomplete",
+		},
+	},
+
 	emojiAutocomplete: {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1797,6 +1797,7 @@ export class InputController {
 		return createPromptActionAutocompleteProvider({
 			commands,
 			basePath,
+			includeIgnoredFiles: this.ctx.settings.get("autocomplete.includeIgnoredFiles"),
 			keybindings: this.ctx.keybindings,
 			copyCurrentLine: () => this.handleCopyCurrentLine(),
 			copyPrompt: () => this.handleCopyPrompt(),

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -32,6 +32,7 @@ interface PromptActionAutocompleteItem extends AutocompleteItem {
 interface PromptActionAutocompleteOptions {
 	commands: SlashCommand[];
 	basePath: string;
+	includeIgnoredFiles?: boolean;
 	keybindings: KeybindingsManager;
 	copyCurrentLine: () => void;
 	copyPrompt: () => void;
@@ -131,9 +132,16 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 	#actions: PromptActionDefinition[];
 	#basePath: string;
 
-	constructor(commands: SlashCommand[], basePath: string, actions: PromptActionDefinition[]) {
+	constructor(
+		commands: SlashCommand[],
+		basePath: string,
+		actions: PromptActionDefinition[],
+		includeIgnoredFiles: boolean = false,
+	) {
 		this.#commands = commands;
-		this.#baseProvider = new CombinedAutocompleteProvider(commands, basePath);
+		this.#baseProvider = new CombinedAutocompleteProvider(commands, basePath, {
+			fuzzyFind: { gitignore: !includeIgnoredFiles },
+		});
 		this.#basePath = basePath;
 		this.#actions = actions;
 	}
@@ -318,5 +326,10 @@ export function createPromptActionAutocompleteProvider(
 		},
 	];
 
-	return new PromptActionAutocompleteProvider(options.commands, options.basePath, actions);
+	return new PromptActionAutocompleteProvider(
+		options.commands,
+		options.basePath,
+		actions,
+		options.includeIgnoredFiles,
+	);
 }

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added configurable fuzzy-discovery options to `CombinedAutocompleteProvider`, including support for git-ignored files.
+
 ## [17.2.11] - 2026-08-07
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -1,29 +1,28 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { fuzzyFind } from "@oh-my-pi/pi-natives";
+import { type FuzzyFindOptions, fuzzyFind } from "@oh-my-pi/pi-natives";
 import { getProjectDir } from "@oh-my-pi/pi-utils";
 
 const PATH_DELIMITERS = new Set([" ", "\t", '"', "'", "="]);
 
+export type AutocompleteFuzzyFindOptions = Partial<
+	Pick<FuzzyFindOptions, "maxResults" | "hidden" | "gitignore" | "cache" | "timeoutMs">
+>;
+
 function buildAutocompleteFuzzyDiscoveryProfile(
 	query: string,
 	basePath: string,
-): {
-	query: string;
-	path: string;
-	maxResults: number;
-	hidden: boolean;
-	gitignore: boolean;
-	cache: boolean;
-} {
+	overrides: AutocompleteFuzzyFindOptions = {},
+): FuzzyFindOptions {
 	return {
-		query,
-		path: basePath,
 		maxResults: 100,
 		hidden: true,
 		gitignore: true,
 		cache: true,
+		...overrides,
+		query,
+		path: basePath,
 	};
 }
 
@@ -397,19 +396,29 @@ function buildMidPromptSkillCompletions(commands: CommandEntry[], lowerPrefix: s
 	);
 }
 
+export interface CombinedAutocompleteProviderOptions {
+	fuzzyFind?: AutocompleteFuzzyFindOptions;
+}
+
 // Combined provider that handles both slash commands and file paths.
 export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	#commands: CommandEntry[];
 	#basePath: string;
+	#fuzzyFindOptions: AutocompleteFuzzyFindOptions;
 	// Intentionally separate from pi-natives cache: this cache is a local,
 	// per-directory readdir fast-path for prefix completions. Global fuzzy
 	// discovery continues to use native fuzzyFind + shared scan cache.
 	#dirCache: Map<string, { entries: fs.Dirent[]; timestamp: number }> = new Map();
 	readonly #DIR_CACHE_TTL = 2000; // 2 seconds
 
-	constructor(commands: CommandEntry[] = [], basePath: string = getProjectDir()) {
+	constructor(
+		commands: CommandEntry[] = [],
+		basePath: string = getProjectDir(),
+		options: CombinedAutocompleteProviderOptions = {},
+	) {
 		this.#commands = commands;
 		this.#basePath = basePath;
+		this.#fuzzyFindOptions = options.fuzzyFind ?? {};
 	}
 
 	async getSuggestions(
@@ -956,7 +965,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			const scopedQuery = await this.#resolveScopedFuzzyQuery(query);
 			const searchPath = scopedQuery?.baseDir ?? this.#basePath;
 			const fuzzyQuery = scopedQuery?.query ?? query;
-			const result = await fuzzyFind(buildAutocompleteFuzzyDiscoveryProfile(fuzzyQuery, searchPath));
+			const result = await fuzzyFind(
+				buildAutocompleteFuzzyDiscoveryProfile(fuzzyQuery, searchPath, this.#fuzzyFindOptions),
+			);
 			const lowerQuery = fuzzyQuery.toLowerCase();
 			const filteredMatches = result.matches.filter(entry => {
 				const p = entry.path.endsWith("/") ? entry.path.slice(0, -1) : entry.path;

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -577,6 +577,25 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values.some(value => value === "@.git" || value.startsWith("@.git/"))).toBe(false);
 		});
 
+		it("includes git-ignored hidden paths when opted in", async () => {
+			fs.mkdirSync(path.join(baseDir, ".private"), { recursive: true });
+			fs.writeFileSync(path.join(baseDir, ".gitignore"), ".private/\n");
+			fs.writeFileSync(path.join(baseDir, ".private", "token.txt"), "secret");
+			const line = "@token";
+
+			const defaultResult = await new CombinedAutocompleteProvider([], baseDir).getSuggestions(
+				[line],
+				0,
+				line.length,
+			);
+			const includedResult = await new CombinedAutocompleteProvider([], baseDir, {
+				fuzzyFind: { gitignore: false },
+			}).getSuggestions([line], 0, line.length);
+
+			expect(defaultResult?.items.map(item => item.value) ?? []).not.toContain("@.private/token.txt");
+			expect(includedResult?.items.map(item => item.value) ?? []).toContain("@.private/token.txt");
+		});
+
 		it("returns more than 20 fuzzy matches when the project contains them", async () => {
 			// Regression: previously hard-capped at 20 by `slice(0, 20)`.
 			const total = 30;


### PR DESCRIPTION
## What

Adds the opt-in `autocomplete.includeIgnoredFiles` setting for including git-ignored files in `@` file autocomplete.

The setting defaults to `false`, preserving the existing behavior. Internally, `CombinedAutocompleteProvider` now accepts constrained fuzzy-discovery overrides so options such as `gitignore`,
`hidden`, `cache`, and `maxResults` can be customized without adding one-off constructor parameters.

Enable it permanently with:

```sh
omp config set autocomplete.includeIgnoredFiles true
 ```

## Why

I had some git-ignored files that I wanted to reference and thought it was useful to add an option for this.

## Testing

- `bun test packages/tui/test/autocomplete.test.ts` — 61 tests passed, including a case confirming that a hidden, git-ignored file is excluded by default and included when opted in.
- `bun run check` passed in packages/tui.
- `bun run check` passed in packages/coding-agent.
- Manually confirmed `@ignored-auto` suggests `.private/ignored-autocomplete.txt` when `autocomplete.includeIgnoredFiles` is enabled.
- Manually confirmed the same ignored file is absent when the setting is disabled.

### Manual test steps

Prepare:

```sh
repo="/path/to/oh-my-pi"
tmp="$(mktemp -d)"

mkdir -p "$tmp/project/.private" "$tmp/agent"
git -C "$tmp/project" init
printf '.private/\n' > "$tmp/project/.gitignore"
printf 'test\n' > "$tmp/project/.private/ignored-autocomplete.txt"

PI_CODING_AGENT_DIR="$tmp/agent" \
  bun "$repo/packages/coding-agent/src/cli.ts" \
  config set autocomplete.includeIgnoredFiles true

cd "$tmp/project"

PI_CODING_AGENT_DIR="$tmp/agent" \
  bun "$repo/packages/coding-agent/src/cli.ts"
 ```

Then, inside OMP, type:

 ```text
@ignored-auto
 ```

**Expected**: @.private/ignored-autocomplete.txt appears in autocomplete.

Then quit OMP, disable the setting, and relaunch:

 ```sh
PI_CODING_AGENT_DIR="$tmp/agent" \
  bun "$repo/packages/coding-agent/src/cli.ts" \
  config set autocomplete.includeIgnoredFiles false

PI_CODING_AGENT_DIR="$tmp/agent" \
  bun "$repo/packages/coding-agent/src/cli.ts"
 ```

Type @ignored-auto again.
**Expected**: the ignored file does not appear.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
