### PR TITLE
fix(tui): keep display-math fractions intact across source newlines

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed display-math (`$$…$$`) fractions rendering as fragmented text when the numerator and denominator are written on separate source lines: `latexToBlock` treated the top-level newline between `\frac{num}` and `{den}` as a row break, severing `\frac` from its denominator. Such argument-continuation newlines are now preserved so the fraction stays stacked ([#7996](https://github.com/can1357/oh-my-pi/issues/7996)).
+
 ## [17.2.11] - 2026-08-07
 
 ### Fixed

--- a/packages/tui/src/latex-block.ts
+++ b/packages/tui/src/latex-block.ts
@@ -1285,13 +1285,22 @@ for (const name in HBRACE_COMMANDS) COMMAND_ARITY[name] = 1;
 /**
  * Count the `{…}` arguments still owed at the end of `seg` — non-zero when the
  * row ends mid-construct (`\frac{a}` awaiting its denominator, or `\frac`/`x^`
- * awaiting any argument). Nested commands and their braces are consumed as whole
- * units, so only the outermost pending count is reported. Used to keep a command
- * joined to an argument written on the next source line while still treating a
- * row that merely opens with a braced group (`a\n{b+c}`) as a real row break.
+ * awaiting any argument). Pending arities form a stack: an unbraced nested
+ * command consumes one outer argument, then retains its own pending arguments
+ * without discarding the outer command's remaining arity. Used to keep a
+ * command joined to an argument written on the next source line while still
+ * treating a row that merely opens with a braced group (`a\n{b+c}`) as a real
+ * row break.
  */
 function bracesOwed(seg: string): number {
-	let owed = 0;
+	const pending: number[] = [];
+	const consumeArg = (): void => {
+		const top = pending.length - 1;
+		if (top < 0) return;
+		if (pending[top] === 1) pending.pop();
+		else pending[top]--;
+	};
+
 	let i = 0;
 	while (i < seg.length) {
 		const c = seg[i];
@@ -1299,18 +1308,39 @@ function bracesOwed(seg: string): number {
 			let j = i + 1;
 			let name = "";
 			while (j < seg.length && /[A-Za-z]/.test(seg[j])) name += seg[j++];
-			if (name) owed = COMMAND_ARITY[name] ?? 0;
-			else j = i + 2; // escaped char (`\{`, `\,`) — takes no argument
+			// A command plus its immediately attached `[…]`/`{…}` groups is one
+			// atom for an enclosing argument, matching readArg. Consume that outer
+			// argument first, then retain only the command's own missing arguments
+			// in a nested frame. Attached groups beyond the known arity still stay
+			// part of the atom and cannot consume another outer argument.
+			consumeArg();
+			const arity = name ? (COMMAND_ARITY[name] ?? 0) : 0;
+			let attached = 0;
+			if (name) {
+				while (seg[j] === "[" || seg[j] === "{") {
+					if (seg[j] === "{") {
+						j = readBraceGroup(seg, j).end;
+						if (attached < arity) attached++;
+					} else {
+						const close = seg.indexOf("]", j);
+						j = close === -1 ? seg.length : close + 1;
+					}
+				}
+			} else {
+				j = i + 2; // non-letter command (`\,`, `\{`, …)
+			}
+			const missing = arity - attached;
+			if (missing > 0) pending.push(missing);
 			i = j;
 			continue;
 		}
 		if (c === "{") {
 			i = readBraceGroup(seg, i).end;
-			if (owed > 0) owed--;
+			consumeArg();
 			continue;
 		}
 		if (c === "^" || c === "_") {
-			owed += 1;
+			pending.push(1);
 			i++;
 			continue;
 		}
@@ -1318,9 +1348,12 @@ function bracesOwed(seg: string): number {
 			i++;
 			continue;
 		}
-		if (owed > 0) owed--; // a bare atom satisfies one pending argument
+		consumeArg(); // a bare atom satisfies one pending argument
 		i++;
 	}
+
+	let owed = 0;
+	for (const remaining of pending) owed += remaining;
 	return owed;
 }
 

--- a/packages/tui/src/latex-block.ts
+++ b/packages/tui/src/latex-block.ts
@@ -146,6 +146,16 @@ const HBRACE_COMMANDS: Record<string, HBraceSpec> = {
 	underparen: { left: "╰", mid: "─", center: "─", right: "╯", over: false },
 };
 
+/**
+ * Number of required arguments each display command consumes. Shared by
+ * {@link readArg} and {@link splitLines} so nested command atoms consume exactly
+ * their own arguments while preserving any outer command's pending arity.
+ */
+const COMMAND_ARITY: Record<string, number> = { overset: 2, underset: 2, stackrel: 2, sqrt: 1 };
+for (const name in FRAC_COMMANDS) COMMAND_ARITY[name] = 2;
+for (const name in BINOM_COMMANDS) COMMAND_ARITY[name] = 2;
+for (const name in HBRACE_COMMANDS) COMMAND_ARITY[name] = 1;
+
 // Vertical delimiter piece characters: `only` for single-line content, then
 // top/mid/bot columns for stretched forms; `axis` replaces `mid` at the
 // baseline row (the brace point).
@@ -516,11 +526,13 @@ function readBraceGroup(src: string, i: number): Span {
 
 /**
  * Read one command argument: a `{…}` group, a single char, or a `\command`
- * together with its attached `[…]`/`{…}` arguments (or whole `\begin…\end`
- * block), so e.g. `\frac\sqrt{a}{b}` reads `\sqrt{a}` as the numerator.
+ * together with its arguments (or whole `\begin…\end` block). Commands whose
+ * arity is known consume exactly that many arguments, including across source
+ * whitespace, so `\frac\sqrt {a} {b}` reads `\sqrt {a}` as the numerator and
+ * leaves `{b}` for the denominator.
  */
 function readArg(src: string, i: number): Span {
-	while (src[i] === " ") i++;
+	while (src[i] === " " || src[i] === "\t" || src[i] === "\n") i++;
 	if (i >= src.length) return { text: "", end: i };
 	if (src[i] === "{") return readBraceGroup(src, i);
 	if (src[i] !== "\\") return { text: src[i], end: i + 1 };
@@ -535,6 +547,22 @@ function readArg(src: string, i: number): Span {
 		if (env) return env;
 	}
 	if (!name) return { text: src.slice(i, i + 2), end: i + 2 }; // non-letter command (\,, \{, …)
+
+	const arity = COMMAND_ARITY[name];
+	if (arity !== undefined) {
+		let end = j;
+		// Optional command arguments (e.g. the degree in `\sqrt[3]{x}`) do not
+		// consume a required-argument slot.
+		for (;;) {
+			while (src[end] === " " || src[end] === "\t" || src[end] === "\n") end++;
+			if (src[end] !== "[") break;
+			const close = src.indexOf("]", end);
+			end = close === -1 ? src.length : close + 1;
+		}
+		for (let arg = 0; arg < arity; arg++) end = readArg(src, end).end;
+		return { text: src.slice(i, end), end };
+	}
+
 	let end = j;
 	while (src[end] === "[" || src[end] === "{") {
 		if (src[end] === "{") end = readBraceGroup(src, end).end;
@@ -1270,17 +1298,6 @@ function parseExpr(src: string, ctx: Ctx = ROOT_CTX): Box {
 	if (boxes.length === 0) return textBox("");
 	return hconcat(boxes);
 }
-
-/**
- * Number of `{…}` arguments each display command consumes, used to tell an
- * argument continuation from a genuine row break in {@link splitLines}. Only
- * commands whose arguments this engine reads with {@link readArg} appear here;
- * anything else contributes no pending argument.
- */
-const COMMAND_ARITY: Record<string, number> = { overset: 2, underset: 2, stackrel: 2, sqrt: 1 };
-for (const name in FRAC_COMMANDS) COMMAND_ARITY[name] = 2;
-for (const name in BINOM_COMMANDS) COMMAND_ARITY[name] = 2;
-for (const name in HBRACE_COMMANDS) COMMAND_ARITY[name] = 1;
 
 /**
  * Count the `{…}` arguments still owed at the end of `seg` — non-zero when the

--- a/packages/tui/src/latex-block.ts
+++ b/packages/tui/src/latex-block.ts
@@ -1308,8 +1308,17 @@ function splitLines(src: string): string[] {
 		if (c === "{") braceDepth++;
 		else if (c === "}") braceDepth--;
 		else if (c === "\n" && braceDepth === 0 && envDepth === 0) {
-			lines.push(src.slice(last, i));
-			last = i + 1;
+			// A top-level newline is a row break UNLESS the next non-space token
+			// opens a `{…}` argument group (e.g. `\frac{num}\n{den}` or a command
+			// whose braces are written on the following line). Splitting there
+			// would sever a command from a pending argument, so keep both in the
+			// same segment; latexToBlock collapses the interior newline to a space.
+			let k = i + 1;
+			while (k < src.length && (src[k] === " " || src[k] === "\t" || src[k] === "\n")) k++;
+			if (src[k] !== "{") {
+				lines.push(src.slice(last, i));
+				last = i + 1;
+			}
 		}
 		i++;
 	}
@@ -1327,7 +1336,7 @@ function splitLines(src: string): string[] {
 export function latexToBlock(src: string): string[] {
 	if (typeof src !== "string" || src.trim() === "") return [];
 	const rows = splitLines(src.trim())
-		.map(line => line.trim())
+		.map(line => line.replace(/[ \t]*\n[ \t]*/g, " ").trim())
 		.filter(line => line !== "")
 		.map(line => parseExpr(line));
 	if (rows.length === 0) return [];

--- a/packages/tui/src/latex-block.ts
+++ b/packages/tui/src/latex-block.ts
@@ -1271,6 +1271,59 @@ function parseExpr(src: string, ctx: Ctx = ROOT_CTX): Box {
 	return hconcat(boxes);
 }
 
+/**
+ * Number of `{…}` arguments each display command consumes, used to tell an
+ * argument continuation from a genuine row break in {@link splitLines}. Only
+ * commands whose arguments this engine reads with {@link readArg} appear here;
+ * anything else contributes no pending argument.
+ */
+const COMMAND_ARITY: Record<string, number> = { overset: 2, underset: 2, stackrel: 2, sqrt: 1 };
+for (const name in FRAC_COMMANDS) COMMAND_ARITY[name] = 2;
+for (const name in BINOM_COMMANDS) COMMAND_ARITY[name] = 2;
+for (const name in HBRACE_COMMANDS) COMMAND_ARITY[name] = 1;
+
+/**
+ * Count the `{…}` arguments still owed at the end of `seg` — non-zero when the
+ * row ends mid-construct (`\frac{a}` awaiting its denominator, or `\frac`/`x^`
+ * awaiting any argument). Nested commands and their braces are consumed as whole
+ * units, so only the outermost pending count is reported. Used to keep a command
+ * joined to an argument written on the next source line while still treating a
+ * row that merely opens with a braced group (`a\n{b+c}`) as a real row break.
+ */
+function bracesOwed(seg: string): number {
+	let owed = 0;
+	let i = 0;
+	while (i < seg.length) {
+		const c = seg[i];
+		if (c === "\\") {
+			let j = i + 1;
+			let name = "";
+			while (j < seg.length && /[A-Za-z]/.test(seg[j])) name += seg[j++];
+			if (name) owed = COMMAND_ARITY[name] ?? 0;
+			else j = i + 2; // escaped char (`\{`, `\,`) — takes no argument
+			i = j;
+			continue;
+		}
+		if (c === "{") {
+			i = readBraceGroup(seg, i).end;
+			if (owed > 0) owed--;
+			continue;
+		}
+		if (c === "^" || c === "_") {
+			owed += 1;
+			i++;
+			continue;
+		}
+		if (c === " " || c === "\t" || c === "\n") {
+			i++;
+			continue;
+		}
+		if (owed > 0) owed--; // a bare atom satisfies one pending argument
+		i++;
+	}
+	return owed;
+}
+
 /** Split on top-level `\n` and `\\` row separators (outside braces and environments). */
 function splitLines(src: string): string[] {
 	const lines: string[] = [];
@@ -1308,14 +1361,15 @@ function splitLines(src: string): string[] {
 		if (c === "{") braceDepth++;
 		else if (c === "}") braceDepth--;
 		else if (c === "\n" && braceDepth === 0 && envDepth === 0) {
-			// A top-level newline is a row break UNLESS the next non-space token
-			// opens a `{…}` argument group (e.g. `\frac{num}\n{den}` or a command
-			// whose braces are written on the following line). Splitting there
-			// would sever a command from a pending argument, so keep both in the
-			// same segment; latexToBlock collapses the interior newline to a space.
+			// A top-level newline is a row break UNLESS the current row ends with a
+			// command still awaiting a brace argument that the next row opens (e.g.
+			// `\frac{num}\n{den}`, `\frac\n{a}{b}`, `x^\n{2}`). Splitting there would
+			// sever the command from its argument, so keep both in one segment;
+			// latexToBlock collapses the interior newline to a space before parsing.
+			// A row that merely opens with a braced group (`a\n{b+c}`) stays a break.
 			let k = i + 1;
 			while (k < src.length && (src[k] === " " || src[k] === "\t" || src[k] === "\n")) k++;
-			if (src[k] !== "{") {
+			if (src[k] !== "{" || bracesOwed(src.slice(last, i)) === 0) {
 				lines.push(src.slice(last, i));
 				last = i + 1;
 			}

--- a/packages/tui/test/latex-block.test.ts
+++ b/packages/tui/test/latex-block.test.ts
@@ -268,11 +268,16 @@ describe("latexToBlock (2-D layout)", () => {
 	});
 
 	it("preserves outer arity when an unbraced command is itself an argument", () => {
-		// `readArg` accepts a command plus its attached arguments as one outer
-		// argument. Completing `\sqrt{a}` must therefore leave `\frac` waiting for
-		// its denominator on the next source line, rather than resetting its arity.
-		expect(latexToBlock("\\frac\\sqrt{a}\n{b}")).toEqual(["  ┌── ", " ╲│ a ", "──────", "  b   "]);
+		// `readArg` accepts a command plus its arguments as one outer argument.
+		// Whitespace introduced by preserved source newlines must stay inside the
+		// nested command rather than turning its first argument into the outer
+		// denominator.
+		const sqrtFraction = ["  ┌── ", " ╲│ a ", "──────", "  b   "];
+		expect(latexToBlock("\\frac\\sqrt{a}{b}")).toEqual(sqrtFraction);
+		expect(latexToBlock("\\frac\\sqrt {a} {b}")).toEqual(sqrtFraction);
+		expect(latexToBlock("\\frac\\sqrt\n{a}\n{b}")).toEqual(sqrtFraction);
 		expect(latexToBlock("\\frac\\frac{a}{b}\n{c}")).toEqual(["  a  ", " ─── ", "  b  ", "─────", "  c  "]);
+		expect(latexToBlock("\\frac\\frac\n{a}\n{b}\n{c}")).toEqual(["  a  ", " ─── ", "  b  ", "─────", "  c  "]);
 		expect(latexToBlock("\\frac\\hat{a}\n{b}")).toEqual([" â ", "───", " b "]);
 	});
 

--- a/packages/tui/test/latex-block.test.ts
+++ b/packages/tui/test/latex-block.test.ts
@@ -267,6 +267,15 @@ describe("latexToBlock (2-D layout)", () => {
 		expect(latexToBlock("\\frac\n{a}{b}")).toEqual([" a ", "───", " b "]);
 	});
 
+	it("preserves outer arity when an unbraced command is itself an argument", () => {
+		// `readArg` accepts a command plus its attached arguments as one outer
+		// argument. Completing `\sqrt{a}` must therefore leave `\frac` waiting for
+		// its denominator on the next source line, rather than resetting its arity.
+		expect(latexToBlock("\\frac\\sqrt{a}\n{b}")).toEqual(["  ┌── ", " ╲│ a ", "──────", "  b   "]);
+		expect(latexToBlock("\\frac\\frac{a}{b}\n{c}")).toEqual(["  a  ", " ─── ", "  b  ", "─────", "  c  "]);
+		expect(latexToBlock("\\frac\\hat{a}\n{b}")).toEqual([" â ", "───", " b "]);
+	});
+
 	it("still treats a top-level newline as a row break when it is not an argument continuation", () => {
 		// `lhs =` on its own source line stays a row above its block; two fractions
 		// on separate lines each start with `\frac`, so they stack as two rows.

--- a/packages/tui/test/latex-block.test.ts
+++ b/packages/tui/test/latex-block.test.ts
@@ -272,6 +272,11 @@ describe("latexToBlock (2-D layout)", () => {
 		// on separate lines each start with `\frac`, so they stack as two rows.
 		expect(latexToBlock("y =\n\\frac{1}{2}")).toEqual(["y =", " 1 ", "───", " 2 "]);
 		expect(latexToBlock("\\frac{a}{b}\n\\frac{c}{d}")).toEqual([" a ", "───", " b ", " c ", "───", " d "]);
+		// A row that merely *opens* with a braced group is a real row break: no
+		// preceding command owes it an argument, so it must not fold into the row
+		// above (regression for PR #7997 review).
+		expect(latexToBlock("a\n{b+c}")).toEqual(["a  ", "b+c"]);
+		expect(latexToBlock("x+1\n{y+2}")).toEqual(["x+1", "y+2"]);
 	});
 
 	it("keeps \\color scope across a stacked fraction, painting the bar", () => {

--- a/packages/tui/test/latex-block.test.ts
+++ b/packages/tui/test/latex-block.test.ts
@@ -259,6 +259,21 @@ describe("latexToBlock (2-D layout)", () => {
 		expect(latexToBlock("a \\\\ b")).toEqual(["a", "b"]);
 	});
 
+	it("keeps a \\frac intact when numerator and denominator are on separate source lines", () => {
+		// A top-level newline between `\frac{num}` and `{den}` is an argument
+		// continuation, not a row break — the fraction must stay stacked with a
+		// single bar between numerator and denominator (issue #7996).
+		expect(latexToBlock("\\frac{a}\n{b}")).toEqual([" a ", "───", " b "]);
+		expect(latexToBlock("\\frac\n{a}{b}")).toEqual([" a ", "───", " b "]);
+	});
+
+	it("still treats a top-level newline as a row break when it is not an argument continuation", () => {
+		// `lhs =` on its own source line stays a row above its block; two fractions
+		// on separate lines each start with `\frac`, so they stack as two rows.
+		expect(latexToBlock("y =\n\\frac{1}{2}")).toEqual(["y =", " 1 ", "───", " 2 "]);
+		expect(latexToBlock("\\frac{a}{b}\n\\frac{c}{d}")).toEqual([" a ", "───", " b ", " c ", "───", " d "]);
+	});
+
 	it("keeps \\color scope across a stacked fraction, painting the bar", () => {
 		Object.assign(TERMINAL, { trueColor: true });
 		const lines = latexToBlock("\\color{red} x + \\frac{a}{b}");


### PR DESCRIPTION
## Repro
Asking a model for a non-trivial display formula whose `\frac` numerator and denominator are written on separate source lines renders the fraction as fragmented text: the numerator gets a bar over an empty denominator and the denominator floats below as a disconnected group. Repro command:

```
bun -e 'import {latexToBlock} from "@oh-my-pi/pi-tui/latex-block"; console.log(latexToBlock(`\\frac{q_{c,h}^{2023} + \\lambda_c \\pi_{c,h}}\n     {Q_c^{2023} + \\lambda_c}`).join("\n"))'
```

## Cause
`latexToBlock` (`packages/tui/src/latex-block.ts`) calls `splitLines`, which turns every top-level newline (brace-depth 0, env-depth 0) into a vertical row so a `lhs =` line stacks above its block. When a `\frac` is formatted with its numerator and denominator on separate source lines, the newline between `\frac{num}` and `{den}` sits at brace-depth 0, so it was treated as a row break — `\frac` lost its denominator and `readArg` (which only skips spaces, not newlines) could not rejoin them.

## Fix
- In `splitLines`, a top-level newline whose next non-space/tab/newline token is `{` is an argument continuation (e.g. `\frac{num}\n{den}`, or a command whose braces are on the next line), not a row break; such newlines are kept in the same segment.
- In `latexToBlock`, collapse those preserved interior newlines (and surrounding horizontal whitespace) to a single space before `parseExpr`, so the argument reader parses both brace groups.
- Genuine row breaks are unaffected: `\\`, and newlines not followed by `{` (a `lhs =` line, two `\frac`s on separate lines) still stack.

## Verification
`bun test packages/tui/test/latex-block.test.ts packages/tui/test/latex-to-unicode.test.ts` → 58 pass, 0 fail. Added two regression tests: `\frac{a}\n{b}` / `\frac\n{a}{b}` stay stacked, and `y =\n\frac{1}{2}` / two stacked `\frac`s still split into rows. Manually confirmed the reporter's formula now renders as a single stacked fraction. Fixes #7996