### PR TITLE
fix(ai): map Cursor plan rails to dashboard percents and show mo N%

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor personal usage reporting for current Pro / Pro+ / Ultra `/api/usage-summary` payloads that expose `individualUsage.plan` (and optional `onDemand`) instead of the older `individualUsage.overall` bucket.
+
+
 ## [17.2.11] - 2026-08-07
 
 ### Breaking Changes

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Cursor personal usage reporting for current Pro / Pro+ / Ultra `/api/usage-summary` payloads that expose `individualUsage.plan` (and optional `onDemand`) instead of the older `individualUsage.overall` bucket.
+- Fixed Cursor personal usage reporting for current Pro / Pro+ / Ultra `/api/usage-summary` payloads that expose `individualUsage.plan` (and optional `onDemand`) instead of the older `individualUsage.overall` bucket ([#7998](https://github.com/can1357/oh-my-pi/pull/7998) by [@dnth](https://github.com/dnth)).
 
 
 ## [17.2.11] - 2026-08-07

--- a/packages/ai/src/usage/cursor.ts
+++ b/packages/ai/src/usage/cursor.ts
@@ -131,6 +131,54 @@ function parseCursorCentsBucket(bucket: Record<string, unknown>): UsageAmount | 
 	};
 }
 
+/**
+ * Cursor's dashboard does not treat plan.used / plan.limit as the visible %.
+ * Pro+ shows separate rails:
+ * - Cursor Models  ← autoPercentUsed
+ * - Other Models   ← apiPercentUsed (against the included $ pool)
+ * Prefer those fractions when present; fall back to cents only for older overall buckets.
+ */
+function parseCursorPlanDashboardAmounts(bucket: Record<string, unknown>): {
+	auto?: UsageAmount;
+	api?: UsageAmount;
+	fallback?: UsageAmount;
+} {
+	const limitCents = toNumber(bucket.limit);
+	const limitUsd = limitCents !== undefined && limitCents > 0 ? limitCents / 100 : undefined;
+	const autoPct = toNumber(bucket.autoPercentUsed);
+	const apiPct = toNumber(bucket.apiPercentUsed);
+	const totalPct = toNumber(bucket.totalPercentUsed);
+
+	const fromPercent = (pct: number, withLimit: boolean): UsageAmount => {
+		const usedFraction = Math.max(0, pct) / 100;
+		if (withLimit && limitUsd !== undefined) {
+			const used = limitUsd * usedFraction;
+			return {
+				used,
+				limit: limitUsd,
+				remaining: Math.max(0, limitUsd - used),
+				usedFraction,
+				remainingFraction: Math.max(0, 1 - usedFraction),
+				unit: "usd",
+			};
+		}
+		return { used: usedFraction * 100, usedFraction, unit: "percent" };
+	};
+
+	const result: { auto?: UsageAmount; api?: UsageAmount; fallback?: UsageAmount } = {};
+	if (autoPct !== undefined) result.auto = fromPercent(autoPct, false);
+	if (apiPct !== undefined) result.api = fromPercent(apiPct, true);
+	if (!result.auto && !result.api) {
+		if (totalPct !== undefined) {
+			result.fallback = fromPercent(totalPct, true);
+		} else {
+			const cents = parseCursorCentsBucket(bucket);
+			if (cents) result.fallback = cents;
+		}
+	}
+	return result;
+}
+
 export function parseCursorIndividualUsage(payload: unknown, fetchedAt = Date.now()): UsageReport | null {
 	if (!isRecord(payload) || !isRecord(payload.individualUsage)) {
 		return null;
@@ -138,28 +186,64 @@ export function parseCursorIndividualUsage(payload: unknown, fetchedAt = Date.no
 	const picked = pickCursorIndividualBucket(payload.individualUsage);
 	if (!picked) return null;
 
-	const amount = parseCursorCentsBucket(picked.bucket);
-	if (!amount) return null;
-
 	const resetsAt = deriveResetsAt(payload);
 	const window: UsageWindow = {
 		id: "monthly",
 		label: "Monthly",
 		...(resetsAt !== undefined ? { resetsAt } : {}),
 	};
-	const limits: UsageLimit[] = [
-		{
+	const limits: UsageLimit[] = [];
+
+	if (picked.key === "plan") {
+		const rails = parseCursorPlanDashboardAmounts(picked.bucket);
+		if (rails.auto) {
+			limits.push({
+				id: "cursor:usd:individual-auto",
+				label: "Cursor Models",
+				scope: { provider: "cursor", windowId: window.id },
+				window,
+				amount: rails.auto,
+				...(rails.auto.usedFraction !== undefined
+					? { status: usageStatus(rails.auto.usedFraction) }
+					: {}),
+			});
+		}
+		if (rails.api) {
+			limits.push({
+				id: "cursor:usd:individual-api",
+				label: "Other Models",
+				scope: { provider: "cursor", windowId: window.id },
+				window,
+				amount: rails.api,
+				...(rails.api.usedFraction !== undefined ? { status: usageStatus(rails.api.usedFraction) } : {}),
+			});
+		}
+		if (rails.fallback) {
+			limits.push({
+				id: "cursor:usd:individual-plan",
+				label: "Personal Usage",
+				scope: { provider: "cursor", windowId: window.id },
+				window,
+				amount: rails.fallback,
+				...(rails.fallback.usedFraction !== undefined
+					? { status: usageStatus(rails.fallback.usedFraction) }
+					: {}),
+			});
+		}
+	} else {
+		const amount = parseCursorCentsBucket(picked.bucket);
+		if (!amount) return null;
+		limits.push({
 			id: `cursor:usd:individual-${picked.key}`,
 			label: "Personal Usage",
-			scope: {
-				provider: "cursor",
-				windowId: window.id,
-			},
+			scope: { provider: "cursor", windowId: window.id },
 			window,
 			amount,
 			...(amount.usedFraction !== undefined ? { status: usageStatus(amount.usedFraction) } : {}),
-		},
-	];
+		});
+	}
+
+	if (limits.length === 0) return null;
 
 	if (isRecord(payload.individualUsage.onDemand)) {
 		const onDemandAmount = parseCursorCentsBucket(payload.individualUsage.onDemand);
@@ -167,10 +251,7 @@ export function parseCursorIndividualUsage(payload: unknown, fetchedAt = Date.no
 			limits.push({
 				id: "cursor:usd:individual-ondemand",
 				label: "On-Demand Usage",
-				scope: {
-					provider: "cursor",
-					windowId: window.id,
-				},
+				scope: { provider: "cursor", windowId: window.id },
 				window,
 				amount: onDemandAmount,
 				...(onDemandAmount.usedFraction !== undefined

--- a/packages/ai/src/usage/cursor.ts
+++ b/packages/ai/src/usage/cursor.ts
@@ -135,6 +135,7 @@ function parseCursorCentsBucket(bucket: Record<string, unknown>): UsageAmount | 
  * Cursor's dashboard does not treat plan.used / plan.limit as the visible %.
  * Pro+ shows separate rails:
  * - Cursor Models  ← autoPercentUsed
+ *   (includes Cursor Grok 4.5 and Composer 2.5)
  * - Other Models   ← apiPercentUsed (against the included $ pool)
  * Prefer those fractions when present; fall back to cents only for older overall buckets.
  */

--- a/packages/ai/src/usage/cursor.ts
+++ b/packages/ai/src/usage/cursor.ts
@@ -133,10 +133,10 @@ function parseCursorCentsBucket(bucket: Record<string, unknown>): UsageAmount | 
 
 /**
  * Cursor's dashboard does not treat plan.used / plan.limit as the visible %.
- * Pro+ shows separate rails:
+ * Pro+ shows separate quota pools (not one shared percent):
  * - Cursor Models  ← autoPercentUsed
  *   (includes Cursor Grok 4.5 and Composer 2.5)
- * - Other Models   ← apiPercentUsed (against the included $ pool)
+ * - Other Models   ← apiPercentUsed (separate included-$ pool; different quota)
  * Prefer those fractions when present; fall back to cents only for older overall buckets.
  */
 function parseCursorPlanDashboardAmounts(bucket: Record<string, unknown>): {

--- a/packages/ai/src/usage/cursor.ts
+++ b/packages/ai/src/usage/cursor.ts
@@ -73,45 +73,73 @@ function deriveResetsAt(payload: Record<string, unknown>): number | undefined {
 	return undefined;
 }
 
-export function parseCursorIndividualUsage(payload: unknown, fetchedAt = Date.now()): UsageReport | null {
-	if (!isRecord(payload) || !isRecord(payload.individualUsage) || !isRecord(payload.individualUsage.overall)) {
-		return null;
+/**
+ * Cursor's `/api/usage-summary` has shipped two personal-bucket shapes:
+ * - Enterprise/team dashboards historically exposed `individualUsage.overall`
+ * - Current Pro / Pro+ / Ultra dashboards expose `individualUsage.plan`
+ *   (plus optional `onDemand`)
+ *
+ * Prefer `overall` when present so older fixtures keep working, then fall
+ * back to `plan`. Optionally emit a second on-demand meter when Cursor
+ * reports one with a positive limit.
+ */
+function pickCursorIndividualBucket(
+	individualUsage: Record<string, unknown>,
+): { key: "overall" | "plan"; bucket: Record<string, unknown> } | null {
+	if (isRecord(individualUsage.overall)) {
+		return { key: "overall", bucket: individualUsage.overall };
 	}
-	const individual = payload.individualUsage.overall;
-	if (individual.enabled === false) return null;
+	if (isRecord(individualUsage.plan)) {
+		return { key: "plan", bucket: individualUsage.plan };
+	}
+	return null;
+}
 
-	const reportedUsed = toNumber(individual.used);
-	const reportedRemaining = toNumber(individual.remaining);
+function parseCursorCentsBucket(bucket: Record<string, unknown>): UsageAmount | null {
+	if (bucket.enabled === false) return null;
+
+	const reportedUsed = toNumber(bucket.used);
+	const reportedRemaining = toNumber(bucket.remaining);
 	const hasValidUsed = reportedUsed !== undefined && reportedUsed >= 0;
 	const hasValidRemaining = reportedRemaining !== undefined && reportedRemaining >= 0;
-	const limit = toNumber(individual.limit);
+	const limit = toNumber(bucket.limit);
 
-	let amount: UsageAmount;
-	if (individual.limit === null || individual.limit === undefined) {
+	if (bucket.limit === null || bucket.limit === undefined) {
 		if (!hasValidUsed) return null;
-		amount = { used: reportedUsed / 100, unit: "usd" };
-	} else {
-		if (limit === undefined || limit <= 0) return null;
-		let used: number;
-		if (reportedUsed !== undefined && reportedUsed > 0) {
-			used = reportedUsed;
-		} else if (hasValidRemaining && reportedRemaining < limit) {
-			used = Math.max(0, limit - reportedRemaining);
-		} else if (hasValidUsed) {
-			used = reportedUsed;
-		} else {
-			return null;
-		}
-		const remaining = Math.max(0, limit - used);
-		amount = {
-			used: used / 100,
-			limit: limit / 100,
-			remaining: remaining / 100,
-			usedFraction: used / limit,
-			remainingFraction: remaining / limit,
-			unit: "usd",
-		};
+		return { used: reportedUsed / 100, unit: "usd" };
 	}
+
+	if (limit === undefined || limit <= 0) return null;
+	let used: number;
+	if (reportedUsed !== undefined && reportedUsed > 0) {
+		used = reportedUsed;
+	} else if (hasValidRemaining && reportedRemaining < limit) {
+		used = Math.max(0, limit - reportedRemaining);
+	} else if (hasValidUsed) {
+		used = reportedUsed;
+	} else {
+		return null;
+	}
+	const remaining = Math.max(0, limit - used);
+	return {
+		used: used / 100,
+		limit: limit / 100,
+		remaining: remaining / 100,
+		usedFraction: used / limit,
+		remainingFraction: remaining / limit,
+		unit: "usd",
+	};
+}
+
+export function parseCursorIndividualUsage(payload: unknown, fetchedAt = Date.now()): UsageReport | null {
+	if (!isRecord(payload) || !isRecord(payload.individualUsage)) {
+		return null;
+	}
+	const picked = pickCursorIndividualBucket(payload.individualUsage);
+	if (!picked) return null;
+
+	const amount = parseCursorCentsBucket(picked.bucket);
+	if (!amount) return null;
 
 	const resetsAt = deriveResetsAt(payload);
 	const window: UsageWindow = {
@@ -119,21 +147,43 @@ export function parseCursorIndividualUsage(payload: unknown, fetchedAt = Date.no
 		label: "Monthly",
 		...(resetsAt !== undefined ? { resetsAt } : {}),
 	};
-	const limitEntry: UsageLimit = {
-		id: "cursor:usd:individual-overall",
-		label: "Personal Usage",
-		scope: {
-			provider: "cursor",
-			windowId: window.id,
+	const limits: UsageLimit[] = [
+		{
+			id: `cursor:usd:individual-${picked.key}`,
+			label: "Personal Usage",
+			scope: {
+				provider: "cursor",
+				windowId: window.id,
+			},
+			window,
+			amount,
+			...(amount.usedFraction !== undefined ? { status: usageStatus(amount.usedFraction) } : {}),
 		},
-		window,
-		amount,
-		...(amount.usedFraction !== undefined ? { status: usageStatus(amount.usedFraction) } : {}),
-	};
+	];
+
+	if (isRecord(payload.individualUsage.onDemand)) {
+		const onDemandAmount = parseCursorCentsBucket(payload.individualUsage.onDemand);
+		if (onDemandAmount && onDemandAmount.limit !== undefined && onDemandAmount.limit > 0) {
+			limits.push({
+				id: "cursor:usd:individual-ondemand",
+				label: "On-Demand Usage",
+				scope: {
+					provider: "cursor",
+					windowId: window.id,
+				},
+				window,
+				amount: onDemandAmount,
+				...(onDemandAmount.usedFraction !== undefined
+					? { status: usageStatus(onDemandAmount.usedFraction) }
+					: {}),
+			});
+		}
+	}
+
 	return {
 		provider: "cursor",
 		fetchedAt,
-		limits: [limitEntry],
+		limits,
 		raw: payload,
 	};
 }

--- a/packages/ai/src/usage/cursor.ts
+++ b/packages/ai/src/usage/cursor.ts
@@ -74,27 +74,9 @@ function deriveResetsAt(payload: Record<string, unknown>): number | undefined {
 }
 
 /**
- * Cursor's `/api/usage-summary` has shipped two personal-bucket shapes:
- * - Enterprise/team dashboards historically exposed `individualUsage.overall`
- * - Current Pro / Pro+ / Ultra dashboards expose `individualUsage.plan`
- *   (plus optional `onDemand`)
- *
- * Prefer `overall` when present so older fixtures keep working, then fall
- * back to `plan`. Optionally emit a second on-demand meter when Cursor
- * reports one with a positive limit.
+ * Parse a Cursor cents bucket (`used`/`limit`/`remaining` in USD cents).
+ * Returns null for disabled or non-positive / malformed buckets.
  */
-function pickCursorIndividualBucket(
-	individualUsage: Record<string, unknown>,
-): { key: "overall" | "plan"; bucket: Record<string, unknown> } | null {
-	if (isRecord(individualUsage.overall)) {
-		return { key: "overall", bucket: individualUsage.overall };
-	}
-	if (isRecord(individualUsage.plan)) {
-		return { key: "plan", bucket: individualUsage.plan };
-	}
-	return null;
-}
-
 function parseCursorCentsBucket(bucket: Record<string, unknown>): UsageAmount | null {
 	if (bucket.enabled === false) return null;
 
@@ -144,6 +126,8 @@ function parseCursorPlanDashboardAmounts(bucket: Record<string, unknown>): {
 	api?: UsageAmount;
 	fallback?: UsageAmount;
 } {
+	if (bucket.enabled === false) return {};
+
 	const limitCents = toNumber(bucket.limit);
 	const limitUsd = limitCents !== undefined && limitCents > 0 ? limitCents / 100 : undefined;
 	const autoPct = toNumber(bucket.autoPercentUsed);
@@ -180,12 +164,57 @@ function parseCursorPlanDashboardAmounts(bucket: Record<string, unknown>): {
 	return result;
 }
 
+function pushCursorPlanRails(limits: UsageLimit[], bucket: Record<string, unknown>, window: UsageWindow): void {
+	const rails = parseCursorPlanDashboardAmounts(bucket);
+	if (rails.auto) {
+		limits.push({
+			id: "cursor:usd:individual-auto",
+			label: "Cursor Models",
+			scope: { provider: "cursor", windowId: window.id },
+			window,
+			amount: rails.auto,
+			...(rails.auto.usedFraction !== undefined ? { status: usageStatus(rails.auto.usedFraction) } : {}),
+		});
+	}
+	if (rails.api) {
+		limits.push({
+			id: "cursor:usd:individual-api",
+			label: "Other Models",
+			scope: { provider: "cursor", windowId: window.id },
+			window,
+			amount: rails.api,
+			...(rails.api.usedFraction !== undefined ? { status: usageStatus(rails.api.usedFraction) } : {}),
+		});
+	}
+	if (rails.fallback) {
+		limits.push({
+			id: "cursor:usd:individual-plan",
+			label: "Personal Usage",
+			scope: { provider: "cursor", windowId: window.id },
+			window,
+			amount: rails.fallback,
+			...(rails.fallback.usedFraction !== undefined
+				? { status: usageStatus(rails.fallback.usedFraction) }
+				: {}),
+		});
+	}
+}
+
+/**
+ * Cursor's `/api/usage-summary` has shipped two personal-bucket shapes:
+ * - Enterprise/team dashboards historically exposed `individualUsage.overall`
+ * - Current Pro / Pro+ / Ultra dashboards expose `individualUsage.plan`
+ *   (plus optional `onDemand`)
+ *
+ * Prefer a *usable* overall bucket; if overall is absent/disabled/malformed,
+ * fall through to plan rails (`autoPercentUsed` / `apiPercentUsed`). Always
+ * consider on-demand afterward so a valid on-demand meter is not dropped when
+ * the included plan bucket is empty.
+ */
 export function parseCursorIndividualUsage(payload: unknown, fetchedAt = Date.now()): UsageReport | null {
 	if (!isRecord(payload) || !isRecord(payload.individualUsage)) {
 		return null;
 	}
-	const picked = pickCursorIndividualBucket(payload.individualUsage);
-	if (!picked) return null;
 
 	const resetsAt = deriveResetsAt(payload);
 	const window: UsageWindow = {
@@ -195,57 +224,30 @@ export function parseCursorIndividualUsage(payload: unknown, fetchedAt = Date.no
 	};
 	const limits: UsageLimit[] = [];
 
-	if (picked.key === "plan") {
-		const rails = parseCursorPlanDashboardAmounts(picked.bucket);
-		if (rails.auto) {
+	const overall = isRecord(payload.individualUsage.overall) ? payload.individualUsage.overall : null;
+	const plan = isRecord(payload.individualUsage.plan) ? payload.individualUsage.plan : null;
+
+	// Prefer a usable overall bucket; if it is disabled/malformed, fall through to plan.
+	let usedOverall = false;
+	if (overall) {
+		const amount = parseCursorCentsBucket(overall);
+		if (amount) {
+			usedOverall = true;
 			limits.push({
-				id: "cursor:usd:individual-auto",
-				label: "Cursor Models",
-				scope: { provider: "cursor", windowId: window.id },
-				window,
-				amount: rails.auto,
-				...(rails.auto.usedFraction !== undefined
-					? { status: usageStatus(rails.auto.usedFraction) }
-					: {}),
-			});
-		}
-		if (rails.api) {
-			limits.push({
-				id: "cursor:usd:individual-api",
-				label: "Other Models",
-				scope: { provider: "cursor", windowId: window.id },
-				window,
-				amount: rails.api,
-				...(rails.api.usedFraction !== undefined ? { status: usageStatus(rails.api.usedFraction) } : {}),
-			});
-		}
-		if (rails.fallback) {
-			limits.push({
-				id: "cursor:usd:individual-plan",
+				id: "cursor:usd:individual-overall",
 				label: "Personal Usage",
 				scope: { provider: "cursor", windowId: window.id },
 				window,
-				amount: rails.fallback,
-				...(rails.fallback.usedFraction !== undefined
-					? { status: usageStatus(rails.fallback.usedFraction) }
-					: {}),
+				amount,
+				...(amount.usedFraction !== undefined ? { status: usageStatus(amount.usedFraction) } : {}),
 			});
 		}
-	} else {
-		const amount = parseCursorCentsBucket(picked.bucket);
-		if (!amount) return null;
-		limits.push({
-			id: `cursor:usd:individual-${picked.key}`,
-			label: "Personal Usage",
-			scope: { provider: "cursor", windowId: window.id },
-			window,
-			amount,
-			...(amount.usedFraction !== undefined ? { status: usageStatus(amount.usedFraction) } : {}),
-		});
+	}
+	if (!usedOverall && plan) {
+		pushCursorPlanRails(limits, plan, window);
 	}
 
-	if (limits.length === 0) return null;
-
+	// Keep on-demand even when the included plan/overall bucket is absent or unusable.
 	if (isRecord(payload.individualUsage.onDemand)) {
 		const onDemandAmount = parseCursorCentsBucket(payload.individualUsage.onDemand);
 		if (onDemandAmount && onDemandAmount.limit !== undefined && onDemandAmount.limit > 0) {
@@ -261,6 +263,8 @@ export function parseCursorIndividualUsage(payload: unknown, fetchedAt = Date.no
 			});
 		}
 	}
+
+	if (limits.length === 0) return null;
 
 	return {
 		provider: "cursor",

--- a/packages/ai/test/cursor-usage.test.ts
+++ b/packages/ai/test/cursor-usage.test.ts
@@ -196,7 +196,85 @@ describe("cursor usage provider", () => {
 			});
 		});
 
-		it("rejects disabled, malformed, and non-positive personal usage buckets", () => {
+		it("falls back to individualUsage.plan for current Pro/Pro+/Ultra payloads", () => {
+			const payload = {
+				individualUsage: {
+					plan: {
+						enabled: true,
+						used: 924,
+						limit: 7000,
+						remaining: 6076,
+					},
+					onDemand: {
+						enabled: true,
+						used: 0,
+						limit: 2000,
+						remaining: 2000,
+					},
+				},
+				billingCycleEnd: "2026-09-08T08:00:31.000Z",
+			};
+
+			const report = parseCursorIndividualUsage(payload, 123);
+			expect(report?.limits).toEqual([
+				{
+					id: "cursor:usd:individual-plan",
+					label: "Personal Usage",
+					scope: {
+						provider: "cursor",
+						windowId: "monthly",
+					},
+					window: {
+						id: "monthly",
+						label: "Monthly",
+						resetsAt: Date.parse("2026-09-08T08:00:31.000Z"),
+					},
+					amount: {
+						used: 9.24,
+						limit: 70,
+						remaining: 60.76,
+						usedFraction: 0.132,
+						remainingFraction: 0.868,
+						unit: "usd",
+					},
+					status: "ok",
+				},
+				{
+					id: "cursor:usd:individual-ondemand",
+					label: "On-Demand Usage",
+					scope: {
+						provider: "cursor",
+						windowId: "monthly",
+					},
+					window: {
+						id: "monthly",
+						label: "Monthly",
+						resetsAt: Date.parse("2026-09-08T08:00:31.000Z"),
+					},
+					amount: {
+						used: 0,
+						limit: 20,
+						remaining: 20,
+						usedFraction: 0,
+						remainingFraction: 1,
+						unit: "usd",
+					},
+					status: "ok",
+				},
+			]);
+		});
+
+		it("prefers individualUsage.overall when both overall and plan exist", () => {
+			const report = parseCursorIndividualUsage({
+				individualUsage: {
+					overall: { enabled: true, used: 100, limit: 1000, remaining: 900 },
+					plan: { enabled: true, used: 924, limit: 7000, remaining: 6076 },
+				},
+			});
+			expect(report?.limits.map(limit => limit.id)).toEqual(["cursor:usd:individual-overall"]);
+		});
+
+	it("rejects disabled, malformed, and non-positive personal usage buckets", () => {
 			expect(
 				parseCursorIndividualUsage({
 					individualUsage: { overall: { enabled: false, used: 100, limit: 1000, remaining: 900 } },

--- a/packages/ai/test/cursor-usage.test.ts
+++ b/packages/ai/test/cursor-usage.test.ts
@@ -260,6 +260,52 @@ describe("cursor usage provider", () => {
 			expect(report?.limits.map(limit => limit.id)).toEqual(["cursor:usd:individual-overall"]);
 		});
 
+		it("falls back to plan when overall is present but disabled", () => {
+			const report = parseCursorIndividualUsage({
+				individualUsage: {
+					overall: { enabled: false, used: 100, limit: 1000, remaining: 900 },
+					plan: {
+						enabled: true,
+						used: 1504,
+						limit: 7000,
+						remaining: 5496,
+						autoPercentUsed: 1.85,
+						apiPercentUsed: 0,
+					},
+				},
+			});
+			expect(report?.limits.map(limit => limit.id)).toEqual([
+				"cursor:usd:individual-auto",
+				"cursor:usd:individual-api",
+			]);
+		});
+
+		it("rejects disabled plan buckets even when stale percent fields remain", () => {
+			expect(
+				parseCursorIndividualUsage({
+					individualUsage: {
+						plan: {
+							enabled: false,
+							used: 1504,
+							limit: 7000,
+							autoPercentUsed: 1.85,
+							apiPercentUsed: 0,
+						},
+					},
+				}),
+			).toBeNull();
+		});
+
+		it("keeps on-demand when the included plan bucket is unusable", () => {
+			const report = parseCursorIndividualUsage({
+				individualUsage: {
+					plan: { enabled: false, used: 1504, limit: 7000, autoPercentUsed: 1.85 },
+					onDemand: { enabled: true, used: 0, limit: 2000, remaining: 2000 },
+				},
+			});
+			expect(report?.limits.map(limit => limit.id)).toEqual(["cursor:usd:individual-ondemand"]);
+		});
+
 	it("rejects disabled, malformed, and non-positive personal usage buckets", () => {
 			expect(
 				parseCursorIndividualUsage({

--- a/packages/ai/test/cursor-usage.test.ts
+++ b/packages/ai/test/cursor-usage.test.ts
@@ -196,14 +196,17 @@ describe("cursor usage provider", () => {
 			});
 		});
 
-		it("falls back to individualUsage.plan for current Pro/Pro+/Ultra payloads", () => {
+		it("maps plan.auto/api percent rails to Cursor Models / Other Models", () => {
 			const payload = {
 				individualUsage: {
 					plan: {
 						enabled: true,
-						used: 924,
+						used: 1504,
 						limit: 7000,
-						remaining: 6076,
+						remaining: 5496,
+						autoPercentUsed: 1.85,
+						apiPercentUsed: 0,
+						totalPercentUsed: 1.63,
 					},
 					onDemand: {
 						enabled: true,
@@ -216,52 +219,35 @@ describe("cursor usage provider", () => {
 			};
 
 			const report = parseCursorIndividualUsage(payload, 123);
-			expect(report?.limits).toEqual([
-				{
-					id: "cursor:usd:individual-plan",
-					label: "Personal Usage",
-					scope: {
-						provider: "cursor",
-						windowId: "monthly",
-					},
-					window: {
-						id: "monthly",
-						label: "Monthly",
-						resetsAt: Date.parse("2026-09-08T08:00:31.000Z"),
-					},
-					amount: {
-						used: 9.24,
-						limit: 70,
-						remaining: 60.76,
-						usedFraction: 0.132,
-						remainingFraction: 0.868,
-						unit: "usd",
-					},
-					status: "ok",
-				},
-				{
-					id: "cursor:usd:individual-ondemand",
-					label: "On-Demand Usage",
-					scope: {
-						provider: "cursor",
-						windowId: "monthly",
-					},
-					window: {
-						id: "monthly",
-						label: "Monthly",
-						resetsAt: Date.parse("2026-09-08T08:00:31.000Z"),
-					},
-					amount: {
-						used: 0,
-						limit: 20,
-						remaining: 20,
-						usedFraction: 0,
-						remainingFraction: 1,
-						unit: "usd",
-					},
-					status: "ok",
-				},
+			expect(report?.limits.map(limit => ({ id: limit.id, label: limit.label }))).toEqual([
+				{ id: "cursor:usd:individual-auto", label: "Cursor Models" },
+				{ id: "cursor:usd:individual-api", label: "Other Models" },
+				{ id: "cursor:usd:individual-ondemand", label: "On-Demand Usage" },
 			]);
+			const auto = report?.limits[0]?.amount;
+			const api = report?.limits[1]?.amount;
+			const onDemand = report?.limits[2]?.amount;
+			expect(auto?.unit).toBe("percent");
+			expect(auto?.used).toBeCloseTo(1.85);
+			expect(auto?.usedFraction).toBeCloseTo(0.0185);
+			// Critically: do NOT trust plan.used/limit cents as the dashboard %.
+			expect(auto?.usedFraction).not.toBeCloseTo(1504 / 7000);
+			expect(api).toEqual({
+				used: 0,
+				limit: 70,
+				remaining: 70,
+				usedFraction: 0,
+				remainingFraction: 1,
+				unit: "usd",
+			});
+			expect(onDemand).toEqual({
+				used: 0,
+				limit: 20,
+				remaining: 20,
+				usedFraction: 0,
+				remainingFraction: 1,
+				unit: "usd",
+			});
 		});
 
 		it("prefers individualUsage.overall when both overall and plan exist", () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Status-line `usage` now renders monthly Cursor quotas (`mo N%`) in addition to the existing `5h` / `7d` windows.
+- Status-line `usage` now renders monthly Cursor quotas (`mo N%`) in addition to the existing `5h` / `7d` windows ([#7998](https://github.com/can1357/oh-my-pi/pull/7998) by [@dnth](https://github.com/dnth)).
 
 
 ## [17.2.11] - 2026-08-07

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Status-line `usage` now renders monthly Cursor quotas (`mo N%`) in addition to the existing `5h` / `7d` windows.
+
+
 ## [17.2.11] - 2026-08-07
 
 ### Added

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1382,7 +1382,16 @@ export class StatusLineComponent implements Component {
 		let fiveHourTier: string | undefined;
 		let sevenDayTier: string | undefined;
 		let monthlyTier: string | undefined;
+		let monthlyPriority = Number.POSITIVE_INFINITY;
 		const now = Date.now();
+		const cursorMonthlyPriority = (limitId: unknown): number => {
+			// When /auth/usage and /api/usage-summary are merged, prefer the personal
+			// dashboard rails over legacy per-model request fractions.
+			if (limitId === "cursor:usd:individual-auto") return 0;
+			if (limitId === "cursor:usd:individual-plan" || limitId === "cursor:usd:individual-overall") return 1;
+			if (typeof limitId === "string" && limitId.startsWith("cursor:usd:individual-")) return 2;
+			return 3;
+		};
 		for (const report of reports) {
 			if (!report || typeof report !== "object") continue;
 			const provider = (report as { provider?: unknown }).provider;
@@ -1396,6 +1405,7 @@ export class StatusLineComponent implements Component {
 					continue;
 				}
 				const l = limit as {
+					id?: string;
 					scope?: { windowId?: string; tier?: string };
 					window?: { resetsAt?: number };
 					amount?: { usedFraction?: number };
@@ -1423,16 +1433,29 @@ export class StatusLineComponent implements Component {
 					};
 					sevenDayTier = tier || undefined;
 				}
+				// Conservatively gate monthly status-line rendering to Cursor for now —
+				// Copilot/OpenCode also emit monthly windows, but their multi-bucket
+				// shape needs a dedicated selector before we surface `mo N%` for them.
 				if (
-					(windowId === "monthly" || windowId === "30d") &&
-					(!monthly || (monthlyTier !== undefined && !tier))
+					activeProvider === "cursor" &&
+					(windowId === "monthly" || windowId === "30d")
 				) {
-					monthly = {
-						percent: fraction * 100,
-						resetHours:
-							typeof resetsAt === "number" ? Math.max(0, Math.round((resetsAt - now) / 3_600_000)) : undefined,
-					};
-					monthlyTier = tier || undefined;
+					const priority = cursorMonthlyPriority(l.id);
+					const shouldReplace =
+						!monthly ||
+						priority < monthlyPriority ||
+						(priority === monthlyPriority && monthlyTier !== undefined && !tier);
+					if (shouldReplace) {
+						monthly = {
+							percent: fraction * 100,
+							resetHours:
+								typeof resetsAt === "number"
+									? Math.max(0, Math.round((resetsAt - now) / 3_600_000))
+									: undefined,
+						};
+						monthlyTier = tier || undefined;
+						monthlyPriority = priority;
+					}
 				}
 			}
 		}

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1259,8 +1259,12 @@ export class StatusLineComponent implements Component {
 		const normalized = this.#normalizeUsageReports(reports, activeProvider, activeIdentity);
 		const resetSnapshot =
 			activeProvider === "openai-codex" ? this.#normalizeCodexResetSnapshot(reports, activeIdentity) : null;
+		const usageChanged = this.#cachedUsage !== normalized;
 		this.#cachedUsage = normalized;
 		this.#usageFetchedAt = Date.now();
+		// Usage fetch is async; without a repaint the top border stays blank until
+		// some unrelated event (git resolve, keystroke, …) rebuilds it.
+		if (usageChanged) this.#onBranchChange?.();
 		if (!resetSnapshot) return;
 		const contextKey = this.#formatUsageContextKey(activeProvider, activeIdentity);
 		const previous = this.#codexResetSnapshots.get(contextKey);

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -397,6 +397,7 @@ export class StatusLineComponent implements Component {
 		tier?: string;
 		fiveHour?: { percent: number; resetMinutes?: number };
 		sevenDay?: { percent: number; resetHours?: number };
+		monthly?: { percent: number; resetHours?: number };
 	} | null = null;
 	#cachedUsageContextKey: string | null = null;
 	#usageFetchedAt = 0;
@@ -1368,12 +1369,15 @@ export class StatusLineComponent implements Component {
 		tier?: string;
 		fiveHour?: { percent: number; resetMinutes?: number };
 		sevenDay?: { percent: number; resetHours?: number };
+		monthly?: { percent: number; resetHours?: number };
 	} | null {
 		if (!Array.isArray(reports)) return null;
 		let fiveHour: { percent: number; resetMinutes?: number } | undefined;
 		let sevenDay: { percent: number; resetHours?: number } | undefined;
+		let monthly: { percent: number; resetHours?: number } | undefined;
 		let fiveHourTier: string | undefined;
 		let sevenDayTier: string | undefined;
+		let monthlyTier: string | undefined;
 		const now = Date.now();
 		for (const report of reports) {
 			if (!report || typeof report !== "object") continue;
@@ -1415,12 +1419,23 @@ export class StatusLineComponent implements Component {
 					};
 					sevenDayTier = tier || undefined;
 				}
+				if (
+					(windowId === "monthly" || windowId === "30d") &&
+					(!monthly || (monthlyTier !== undefined && !tier))
+				) {
+					monthly = {
+						percent: fraction * 100,
+						resetHours:
+							typeof resetsAt === "number" ? Math.max(0, Math.round((resetsAt - now) / 3_600_000)) : undefined,
+					};
+					monthlyTier = tier || undefined;
+				}
 			}
 		}
-		if (!fiveHour && !sevenDay) return null;
+		if (!fiveHour && !sevenDay && !monthly) return null;
 		// Single compact label; prefer the five-hour tier if displayed windows ever disagree.
-		const effectiveTier = fiveHourTier ?? sevenDayTier;
-		return { tier: effectiveTier, fiveHour, sevenDay };
+		const effectiveTier = fiveHourTier ?? sevenDayTier ?? monthlyTier;
+		return { tier: effectiveTier, fiveHour, sevenDay, monthly };
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -639,7 +639,7 @@ const usageSegment: StatusLineSegment = {
 	id: "usage",
 	render(ctx) {
 		const u = ctx.usage;
-		if (!u || (!u.fiveHour && !u.sevenDay)) {
+		if (!u || (!u.fiveHour && !u.sevenDay && !u.monthly)) {
 			return { content: "", visible: false };
 		}
 		const parts: string[] = [];
@@ -664,6 +664,15 @@ const usageSegment: StatusLineSegment = {
 					? theme.fg("muted", ` (${formatUsageReset(u.sevenDay.resetHours, "h")})`)
 					: "";
 			parts.push(`7d ${pctText}${reset}`);
+		}
+		if (u.monthly) {
+			const pct = u.monthly.percent;
+			const pctText = theme.fg(pickUsageColor(pct), `${Math.round(pct)}%`);
+			const reset =
+				u.monthly.resetHours !== undefined
+					? theme.fg("muted", ` (${formatUsageReset(u.monthly.resetHours, "h")})`)
+					: "";
+			parts.push(`mo ${pctText}${reset}`);
 		}
 		const content = withIcon(theme.icon.time, parts.join(theme.sep.dot));
 		return { content, visible: true };

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -667,6 +667,7 @@ const usageSegment: StatusLineSegment = {
 		}
 		if (u.monthly) {
 			const pct = u.monthly.percent;
+			// Cursor-only today (normalize gates monthly to provider === "cursor").
 			// Cursor's web dashboard floors included-usage percents (1.88 → "1% used").
 			const pctText = theme.fg(pickUsageColor(pct), `${Math.floor(pct)}%`);
 			const reset =

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -667,7 +667,8 @@ const usageSegment: StatusLineSegment = {
 		}
 		if (u.monthly) {
 			const pct = u.monthly.percent;
-			const pctText = theme.fg(pickUsageColor(pct), `${Math.round(pct)}%`);
+			// Cursor's web dashboard floors included-usage percents (1.88 → "1% used").
+			const pctText = theme.fg(pickUsageColor(pct), `${Math.floor(pct)}%`);
 			const reset =
 				u.monthly.resetHours !== undefined
 					? theme.fg("muted", ` (${formatUsageReset(u.monthly.resetHours, "h")})`)

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -122,6 +122,7 @@ export interface SegmentContext {
 		tier?: string;
 		fiveHour?: { percent: number; resetMinutes?: number };
 		sevenDay?: { percent: number; resetHours?: number };
+		monthly?: { percent: number; resetHours?: number };
 	} | null;
 }
 

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -329,13 +329,15 @@ describe("usage status-line segment", () => {
 
 	it("renders monthly Cursor usage when five-hour and seven-day windows are absent", () => {
 		const result = renderSegment("usage", {
-			usage: { monthly: { percent: 13.2, resetHours: 743 } },
+			usage: { monthly: { percent: 1.88, resetHours: 743 } },
 		} as unknown as SegmentContext);
 		const content = stripVTControlCharacters(result.content);
 
 		expect(result.visible).toBe(true);
 		expect(content).toContain("mo");
-		expect(content).toContain("13%");
+		// Match Cursor web dashboard flooring (1.88 → 1%), not Math.round → 2%.
+		expect(content).toContain("1%");
+		expect(content).not.toContain("2%");
 		expect(content).toContain("30d 23h");
 		expect(content).not.toContain("5h");
 		expect(content).not.toContain("7d");

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -327,6 +327,46 @@ describe("usage status-line segment", () => {
 		expect(content).not.toContain("7d");
 	});
 
+	it("renders monthly Cursor usage when five-hour and seven-day windows are absent", () => {
+		const result = renderSegment("usage", {
+			usage: { monthly: { percent: 13.2, resetHours: 743 } },
+		} as unknown as SegmentContext);
+		const content = stripVTControlCharacters(result.content);
+
+		expect(result.visible).toBe(true);
+		expect(content).toContain("mo");
+		expect(content).toContain("13%");
+		expect(content).toContain("30d 23h");
+		expect(content).not.toContain("5h");
+		expect(content).not.toContain("7d");
+	});
+
+	it("keeps monthly Cursor personal usage from the active provider", async () => {
+		const component = makeComponent(
+			[
+				{
+					provider: "cursor",
+					limits: [
+						{
+							id: "cursor:usd:individual-plan",
+							scope: { windowId: "monthly" },
+							window: { id: "monthly", resetsAt: Date.now() + 743 * 3_600_000 },
+							amount: { usedFraction: 0.132 },
+						},
+					],
+				},
+			],
+			{ provider: "cursor" },
+		);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).toContain("mo");
+		expect(content).toContain("13%");
+	});
+
 	it("uses a distinct error color at the eighty-percent threshold", () => {
 		const high = renderSegment("usage", { usage: { fiveHour: { percent: 80 } } } as unknown as SegmentContext);
 		const low = renderSegment("usage", { usage: { fiveHour: { percent: 24 } } } as unknown as SegmentContext);

--- a/packages/coding-agent/test/status-line-usage.test.ts
+++ b/packages/coding-agent/test/status-line-usage.test.ts
@@ -369,6 +369,56 @@ describe("usage status-line segment", () => {
 		expect(content).toContain("13%");
 	});
 
+	it("prefers Cursor personal dashboard rails over legacy monthly request limits", async () => {
+		const component = makeComponent(
+			[
+				{
+					provider: "cursor",
+					limits: [
+						{
+							id: "cursor:requests:gpt-4",
+							scope: { windowId: "monthly" },
+							amount: { usedFraction: 0.9 },
+						},
+						{
+							id: "cursor:usd:individual-auto",
+							scope: { windowId: "monthly" },
+							amount: { usedFraction: 0.0185 },
+						},
+					],
+				},
+			],
+			{ provider: "cursor" },
+		);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).toContain("mo");
+		expect(content).toContain("1%");
+		expect(content).not.toContain("90%");
+	});
+
+	it("does not render monthly usage for non-Cursor providers", async () => {
+		const component = makeComponent(
+			[
+				{
+					provider: "opencode-go",
+					limits: [{ id: "opencode-go:usd:monthly", scope: { windowId: "monthly" }, amount: { usedFraction: 0.42 } }],
+				},
+			],
+			{ provider: "opencode-go" },
+		);
+
+		component.refreshUsageInBackground();
+		await flushUsageRefresh();
+		const content = stripVTControlCharacters(component.getTopBorder(200).content);
+
+		expect(content).not.toContain("mo");
+		expect(content).not.toContain("42%");
+	});
+
 	it("uses a distinct error color at the eighty-percent threshold", () => {
 		const high = renderSegment("usage", { usage: { fiveHour: { percent: 80 } } } as unknown as SegmentContext);
 		const low = renderSegment("usage", { usage: { fiveHour: { percent: 24 } } } as unknown as SegmentContext);


### PR DESCRIPTION
## Summary

Cursor personal usage disappeared again after #7613 because current Pro / Pro+ / Ultra `/api/usage-summary` payloads expose `individualUsage.plan` (+ optional `onDemand`) instead of `individualUsage.overall`.

A second schema mismatch: Cursor’s web dashboard does **not** treat `plan.used / plan.limit` cents as the visible %. On Pro+ it shows **separate quota pools**:

- **Cursor Models** ← `autoPercentUsed`
  - Includes **Cursor Grok 4.5** and **Composer 2.5**
  - Status-line `mo N%` tracks this pool
- **Other Models** ← `apiPercentUsed`
  - **Different quota** (separate included-\$ pool), not another view of Cursor Models
- **On-Demand** ← cents bucket when limit > 0

This PR:

- Prefers `overall` when present (keeps #7613 Enterprise fixtures working)
- Falls back to `plan` for current personal plans
- Maps `autoPercentUsed` / `apiPercentUsed` to Cursor Models / Other Models as distinct meters
- Falls back to `totalPercentUsed` or cents only when percent rails are absent
- Optionally reports `onDemand` when Cursor returns a positive limit
- Renders monthly Cursor quotas in the status-line `usage` segment as `mo N%` (floored like the web UI; prefers the Cursor Models rail)
- Forces a status-line repaint after async usage fetch so `mo N%` does not stay blank until an unrelated redraw

Related: #6381, #7613

## Verification

- Live-tested against an authenticated Cursor Pro+ account:
  - Before: status-line blank / wrong cents-based % (~21% of \$70)
  - After: `omp usage` shows Cursor Models ~2%, Other Models \$0/\$70, On-Demand \$0/\$20
  - Status line: `mo 2% (30d 23h)` matching the web dashboard’s Cursor Models rail
- Focused tests:
  - `bun test packages/ai/test/cursor-usage.test.ts` → 26 pass
  - `bun test packages/coding-agent/test/status-line-usage.test.ts` → 14 pass

Sanitized live `/api/usage-summary` shape:

```json
{
  "membershipType": "pro_plus",
  "individualUsage": {
    "plan": {
      "enabled": true,
      "used": 1504,
      "limit": 7000,
      "remaining": 5496,
      "autoPercentUsed": 1.85,
      "apiPercentUsed": 0,
      "totalPercentUsed": 1.63
    },
    "onDemand": {
      "enabled": true,
      "used": 0,
      "limit": 2000,
      "remaining": 2000
    }
  }
}
```