### PR TITLE
feat(coding-agent): add /heartbeat slash command for timer-based recurring prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `/heartbeat` slash command for timer-based recurring prompt injection. Set an interval and instruction (e.g. `/heartbeat every 10m Check the deployment status`) and the prompt is automatically injected into the session at each interval. Supports pause, resume, status, and clear subcommands.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -350,6 +350,7 @@ export class StatusLineComponent implements Component {
 	#loopModeStatus: SegmentContext["loopMode"] = null;
 	#goalModeStatus: { enabled: boolean; paused: boolean } | null = null;
 	#vibeModeStatus: { enabled: boolean } | null = null;
+	#heartbeatStatus: SegmentContext["heartbeat"] = null;
 	/**
 	 * Injected aggregator that returns the aggregate tok/s of this session's
 	 * live vibe worker sessions, or null when no workers are streaming. Kept as
@@ -609,6 +610,10 @@ export class StatusLineComponent implements Component {
 
 	setVibeModeStatus(status: { enabled: boolean } | undefined): void {
 		this.#vibeModeStatus = status ?? null;
+	}
+
+	setHeartbeatStatus(status: SegmentContext["heartbeat"] | undefined): void {
+		this.#heartbeatStatus = status ?? null;
 	}
 
 	/**
@@ -1568,6 +1573,7 @@ export class StatusLineComponent implements Component {
 					? { enabled: true }
 					: null,
 			goalMode: this.#goalModeStatus,
+			heartbeat: this.#heartbeatStatus,
 			vibeMode: this.#vibeModeStatus,
 			collab: this.#collabStatus,
 			usageStats,

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -225,47 +225,63 @@ function formatLoopLimit(limit: NonNullable<SegmentContext["loopMode"]>["limit"]
 	return `${seconds}s left`;
 }
 
+function renderPrimaryModeSegment(ctx: SegmentContext): RenderedSegment {
+	const pauseSuffix = theme.icon.pause ? ` ${theme.icon.pause}` : " (paused)";
+
+	const plan = ctx.planMode;
+	if (plan && (plan.enabled || plan.paused)) {
+		const label = plan.paused ? `Plan${pauseSuffix}` : "Plan";
+		const content = withIcon(theme.icon.plan, label);
+		const color = plan.paused ? "warning" : "accent";
+		return { content: theme.fg(color, content), visible: true };
+	}
+
+	const prewalk = ctx.prewalk;
+	if (prewalk?.enabled) {
+		const content = withIcon(theme.icon.prewalk, "Prewalk");
+		return { content: theme.fg("accent", content), visible: true };
+	}
+
+	const goal = ctx.goalMode;
+	if (goal && (goal.enabled || goal.paused)) {
+		return renderGoalMode(ctx, goal);
+	}
+
+	const vibe = ctx.vibeMode;
+	if (vibe?.enabled) {
+		const content = withIcon(theme.icon.agents, "Vibe");
+		return { content: theme.fg("accent", content), visible: true };
+	}
+
+	const loop = ctx.loopMode;
+	if (loop) {
+		const icon = loop.state === "paused" ? theme.icon.pause || theme.icon.loop : theme.icon.loop;
+		const color: ThemeColor = loop.state === "paused" ? "warning" : "customMessageLabel";
+		const parts = [withIcon(icon, `Loop ${loop.state}`)];
+		const limit = formatLoopLimit(loop.limit);
+		if (limit) parts.push(limit);
+		return { content: theme.fg(color, parts.join(" ")), visible: true };
+	}
+
+	return { content: "", visible: false };
+}
+
 const modeSegment: StatusLineSegment = {
 	id: "mode",
 	render(ctx) {
-		const pauseSuffix = theme.icon.pause ? ` ${theme.icon.pause}` : " (paused)";
+		const primary = renderPrimaryModeSegment(ctx);
 
-		const plan = ctx.planMode;
-		if (plan && (plan.enabled || plan.paused)) {
-			const label = plan.paused ? `Plan${pauseSuffix}` : "Plan";
-			const content = withIcon(theme.icon.plan, label);
-			const color = plan.paused ? "warning" : "accent";
-			return { content: theme.fg(color, content), visible: true };
+		const heartbeat = ctx.heartbeat;
+		if (heartbeat) {
+			const color: ThemeColor = heartbeat.status === "paused" ? "warning" : "customMessageLabel";
+			const hbContent = theme.fg(color, `♥ ${heartbeat.intervalLabel}`);
+			if (primary.visible) {
+				return { content: `${primary.content} ${hbContent}`, visible: true };
+			}
+			return { content: hbContent, visible: true };
 		}
 
-		const prewalk = ctx.prewalk;
-		if (prewalk?.enabled) {
-			const content = withIcon(theme.icon.prewalk, "Prewalk");
-			return { content: theme.fg("accent", content), visible: true };
-		}
-
-		const goal = ctx.goalMode;
-		if (goal && (goal.enabled || goal.paused)) {
-			return renderGoalMode(ctx, goal);
-		}
-
-		const vibe = ctx.vibeMode;
-		if (vibe?.enabled) {
-			const content = withIcon(theme.icon.agents, "Vibe");
-			return { content: theme.fg("accent", content), visible: true };
-		}
-
-		const loop = ctx.loopMode;
-		if (loop) {
-			const icon = loop.state === "paused" ? theme.icon.pause || theme.icon.loop : theme.icon.loop;
-			const color: ThemeColor = loop.state === "paused" ? "warning" : "customMessageLabel";
-			const parts = [withIcon(icon, `Loop ${loop.state}`)];
-			const limit = formatLoopLimit(loop.limit);
-			if (limit) parts.push(limit);
-			return { content: theme.fg(color, parts.join(" ")), visible: true };
-		}
-
-		return { content: "", visible: false };
+		return primary;
 	},
 };
 

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -77,6 +77,10 @@ export interface SegmentContext {
 	vibeMode: {
 		enabled: boolean;
 	} | null;
+	heartbeat: {
+		status: "active" | "paused";
+		intervalLabel: string;
+	} | null;
 	collab: CollabStatus | null;
 	// Cached values for performance (computed once per render)
 	usageStats: {

--- a/packages/coding-agent/src/modes/heartbeat.ts
+++ b/packages/coding-agent/src/modes/heartbeat.ts
@@ -1,0 +1,192 @@
+/**
+ * Heartbeat: a timer-based recurring prompt injection for the interactive mode.
+ *
+ * Unlike loop mode (which re-submits after every agent yield), a heartbeat
+ * fires on a fixed interval — e.g. "every 10 minutes, check the deployment."
+ * When the timer fires, the instruction is injected into the session queue.
+ * If the agent is busy the injection is deferred until the current turn ends.
+ */
+
+const TIME_UNITS_MS: Record<string, number> = {
+	s: 1_000,
+	sec: 1_000,
+	secs: 1_000,
+	second: 1_000,
+	seconds: 1_000,
+	m: 60_000,
+	min: 60_000,
+	mins: 60_000,
+	minute: 60_000,
+	minutes: 60_000,
+	h: 3_600_000,
+	hr: 3_600_000,
+	hrs: 3_600_000,
+	hour: 3_600_000,
+	hours: 3_600_000,
+};
+
+/** Minimum heartbeat interval to prevent excessive token burn. */
+export const MIN_HEARTBEAT_INTERVAL_MS = 10_000;
+
+export type HeartbeatStatus = "active" | "paused";
+
+export interface HeartbeatState {
+	/** Interval in milliseconds between heartbeat injections. */
+	intervalMs: number;
+	/** The instruction injected each tick. */
+	instruction: string;
+	/** Current lifecycle status. */
+	status: HeartbeatStatus;
+}
+
+export type ParsedHeartbeatCommand =
+	| { type: "status" }
+	| { type: "pause" }
+	| { type: "resume" }
+	| { type: "clear" }
+	| { type: "set"; intervalMs: number; instruction: string };
+
+const HEARTBEAT_USAGE =
+	"Usage: /heartbeat <every INTERVAL> <instruction>\n" +
+	"  /heartbeat every 10m Check the build status\n" +
+	"  /heartbeat status\n" +
+	"  /heartbeat pause\n" +
+	"  /heartbeat resume\n" +
+	"  /heartbeat clear";
+
+/**
+ * Parse a heartbeat interval token like `10m`, `90s`, `1h30m`, or `10 minutes`.
+ * Returns the interval in milliseconds, or an error message string.
+ */
+export function parseHeartbeatInterval(token: string): number | string {
+	const lower = token.toLowerCase();
+
+	// Compound duration: "10m", "1h30m"
+	if (/^(?:\d+[a-z]+)+$/.test(lower)) {
+		const segments = lower.match(/\d+[a-z]+/g);
+		if (!segments) return HEARTBEAT_USAGE;
+		let totalMs = 0;
+		for (const segment of segments) {
+			const match = /^(\d+)([a-z]+)$/.exec(segment);
+			if (!match) return HEARTBEAT_USAGE;
+			const unitMs = TIME_UNITS_MS[match[2]];
+			if (unitMs === undefined) {
+				return "Heartbeat interval unit must be seconds, minutes, or hours.";
+			}
+			const amount = Number(match[1]);
+			if (!Number.isSafeInteger(amount) || amount <= 0) {
+				return "Heartbeat interval must be positive.";
+			}
+			totalMs += amount * unitMs;
+		}
+		if (totalMs < MIN_HEARTBEAT_INTERVAL_MS) {
+			return `Heartbeat interval must be at least ${MIN_HEARTBEAT_INTERVAL_MS / 1_000} seconds.`;
+		}
+		return totalMs;
+	}
+
+	// Bare number + space + unit: "10 minutes", "5 seconds"
+	const spaceMatch = /^(\d+)\s+([a-z]+)$/.exec(lower);
+	if (spaceMatch) {
+		const unitMs = TIME_UNITS_MS[spaceMatch[2]];
+		if (unitMs === undefined) {
+			return "Heartbeat interval unit must be seconds, minutes, or hours.";
+		}
+		const amount = Number(spaceMatch[1]);
+		if (!Number.isSafeInteger(amount) || amount <= 0) {
+			return "Heartbeat interval must be positive.";
+		}
+		const totalMs = amount * unitMs;
+		if (totalMs < MIN_HEARTBEAT_INTERVAL_MS) {
+			return `Heartbeat interval must be at least ${MIN_HEARTBEAT_INTERVAL_MS / 1_000} seconds.`;
+		}
+		return totalMs;
+	}
+
+	return HEARTBEAT_USAGE;
+}
+
+/**
+ * Parse the arguments to `/heartbeat`.
+ *
+ * Subcommands: status, pause, resume, clear.
+ * Set form: `/heartbeat every <INTERVAL> <instruction>` or
+ *           `/heartbeat <INTERVAL> <instruction>`.
+ *
+ * Returns an error string on parse failure.
+ */
+export function parseHeartbeatCommand(args: string): ParsedHeartbeatCommand | string {
+	const trimmed = args.trim();
+
+	if (!trimmed) return HEARTBEAT_USAGE;
+
+	const firstSpace = trimmed.search(/\s/);
+	const firstToken = firstSpace === -1 ? trimmed : trimmed.slice(0, firstSpace);
+	const rest = firstSpace === -1 ? "" : trimmed.slice(firstSpace + 1).trim();
+	const lower = firstToken.toLowerCase();
+
+	// Subcommands
+	if (firstSpace === -1 || lower === "status" || lower === "pause" || lower === "resume" || lower === "clear") {
+		switch (lower) {
+			case "status":
+				return { type: "status" };
+			case "pause":
+				return { type: "pause" };
+			case "resume":
+				return { type: "resume" };
+			case "clear":
+			case "off":
+			case "stop":
+				return { type: "clear" };
+		}
+	}
+
+	// Strip optional leading "every"
+	let intervalToken: string;
+	let instructionText: string;
+
+	if (lower === "every") {
+		// /heartbeat every 10m <instruction>
+		const nextSpace = rest.search(/\s/);
+		if (nextSpace === -1) {
+			return "Heartbeat requires an instruction. Example: /heartbeat every 10m Check the build status";
+		}
+		intervalToken = rest.slice(0, nextSpace);
+		instructionText = rest.slice(nextSpace + 1).trim();
+	} else {
+		// /heartbeat 10m <instruction>
+		intervalToken = firstToken;
+		instructionText = rest;
+	}
+
+	if (!instructionText) {
+		return "Heartbeat requires an instruction. Example: /heartbeat every 10m Check the build status";
+	}
+
+	const intervalMs = parseHeartbeatInterval(intervalToken);
+	if (typeof intervalMs === "string") return intervalMs;
+
+	return { type: "set", intervalMs, instruction: instructionText };
+}
+
+/** Human-readable description of an interval in milliseconds. */
+export function describeHeartbeatInterval(intervalMs: number): string {
+	if (intervalMs % 3_600_000 === 0) {
+		const hours = intervalMs / 3_600_000;
+		return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+	}
+	if (intervalMs % 60_000 === 0) {
+		const minutes = intervalMs / 60_000;
+		return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+	}
+	const seconds = Math.round(intervalMs / 1_000);
+	return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+}
+
+/** Multi-line status report for `/heartbeat status`. */
+export function formatHeartbeatStatus(state: HeartbeatState | undefined): string {
+	if (!state) return "No heartbeat set. Use /heartbeat every <INTERVAL> <instruction> to create one.";
+	const interval = describeHeartbeatInterval(state.intervalMs);
+	const lines = [`Heartbeat: ${state.status}`, `Interval: every ${interval}`, `Instruction: ${state.instruction}`];
+	return lines.join("\n");
+}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -178,6 +178,12 @@ import { SSHCommandController } from "./controllers/ssh-command-controller";
 import { TanCommandController } from "./controllers/tan-command-controller";
 import { TodoCommandController } from "./controllers/todo-command-controller";
 import {
+	describeHeartbeatInterval,
+	formatHeartbeatStatus,
+	type HeartbeatState,
+	parseHeartbeatCommand,
+} from "./heartbeat";
+import {
 	consumeLoopLimitIteration,
 	createLoopLimitRuntime,
 	describeLoopLimit,
@@ -477,6 +483,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	#modelCycleClearTimer: NodeJS.Timeout | undefined;
 	#nextAppearanceRequestToken = 1;
 	#appearanceRefreshRequest: { token: TerminalAppearanceRequestToken; deadline: number } | undefined;
+	heartbeatState: HeartbeatState | undefined = undefined;
+	#heartbeatTimer: NodeJS.Timeout | undefined;
 	todoPhases: TodoPhase[] = [];
 	hideThinkingBlock = false;
 	#sessionsWithDisplayableThinkingContent = new WeakSet<AgentSession>();
@@ -1532,6 +1540,127 @@ export class InteractiveMode implements InteractiveModeContext {
 		// auto-resubmits it after each yield, identical to typing the prompt right
 		// after enabling loop mode.
 		return parsed.prompt;
+	}
+
+	async handleHeartbeatCommand(args: string): Promise<void> {
+		const parsed = parseHeartbeatCommand(args);
+		if (typeof parsed === "string") {
+			this.showError(parsed);
+			return;
+		}
+
+		switch (parsed.type) {
+			case "status":
+				this.showStatus(formatHeartbeatStatus(this.heartbeatState));
+				return;
+
+			case "pause":
+				if (!this.heartbeatState) {
+					this.showStatus("No heartbeat set.");
+					return;
+				}
+				if (this.heartbeatState.status === "paused") {
+					this.showStatus("Heartbeat already paused.");
+					return;
+				}
+				this.heartbeatState = { ...this.heartbeatState, status: "paused" };
+				this.#cancelHeartbeatTimer();
+				this.#syncHeartbeatStatus();
+				this.showStatus("Heartbeat paused.");
+				return;
+
+			case "resume":
+				if (!this.heartbeatState) {
+					this.showStatus("No heartbeat set.");
+					return;
+				}
+				if (this.heartbeatState.status === "active") {
+					this.showStatus("Heartbeat already active.");
+					return;
+				}
+				this.heartbeatState = { ...this.heartbeatState, status: "active" };
+				this.#startHeartbeatTimer();
+				this.#syncHeartbeatStatus();
+				this.showStatus("Heartbeat resumed.");
+				return;
+
+			case "clear":
+				this.#clearHeartbeat();
+				this.showStatus("Heartbeat cleared.");
+				return;
+
+			case "set": {
+				this.heartbeatState = {
+					intervalMs: parsed.intervalMs,
+					instruction: parsed.instruction,
+					status: "active",
+				};
+				this.#startHeartbeatTimer();
+				this.#syncHeartbeatStatus();
+				const label = describeHeartbeatInterval(parsed.intervalMs);
+				this.showStatus(
+					`Heartbeat set: every ${label}. Instruction: ${parsed.instruction} Use /heartbeat pause, /heartbeat status, or /heartbeat clear to manage.`,
+				);
+				return;
+			}
+		}
+	}
+
+	#clearHeartbeat(): void {
+		this.heartbeatState = undefined;
+		this.#cancelHeartbeatTimer();
+		this.#syncHeartbeatStatus();
+	}
+
+	#startHeartbeatTimer(): void {
+		this.#cancelHeartbeatTimer();
+		if (this.heartbeatState?.status !== "active") return;
+		this.#heartbeatTimer = setInterval(() => {
+			this.#fireHeartbeat();
+		}, this.heartbeatState.intervalMs);
+		this.#heartbeatTimer.unref?.();
+	}
+
+	#cancelHeartbeatTimer(): void {
+		if (this.#heartbeatTimer) {
+			clearInterval(this.#heartbeatTimer);
+			this.#heartbeatTimer = undefined;
+		}
+	}
+
+	#fireHeartbeat(): void {
+		const state = this.heartbeatState;
+		if (state?.status !== "active") return;
+		// If the agent is busy, skip this tick — the next interval will fire
+		// when the session is likely idle. This prevents stacking queued
+		// prompts and avoids AgentBusyError from submitInteractiveInput.
+		if (this.#isAutoSubmitBlocked()) return;
+		if (this.#pendingSubmittedInput) return;
+		if (!this.onInputCallback) return;
+		if (this.editor.getText().trim().length > 0) return;
+		if ((this.editor.pendingImages?.length ?? 0) > 0) return;
+
+		const instruction = state.instruction;
+		this.onInputCallback(
+			this.startPendingSubmission({
+				text: instruction,
+				customType: "heartbeat",
+				display: false,
+			}),
+		);
+	}
+
+	#syncHeartbeatStatus(): void {
+		const state = this.heartbeatState;
+		this.statusLine.setHeartbeatStatus(
+			state
+				? {
+						status: state.status,
+						intervalLabel: describeHeartbeatInterval(state.intervalMs),
+					}
+				: undefined,
+		);
+		this.ui.requestRender();
 	}
 
 	recordLocalSubmission(text: string, imageCount = 0): () => void {
@@ -3978,6 +4107,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#cancelTodoAutoClearTimer();
 		this.#cancelObserverUiSyncTimer();
 		this.#cancelGoalContinuation();
+		this.#cancelHeartbeatTimer();
 		if (this.#sttController) {
 			this.#sttController.dispose();
 			this.#sttController = undefined;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -38,6 +38,7 @@ import type { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import type { TranscriptContainer } from "./components/transcript-container";
 import type { EventController } from "./controllers/event-controller";
+import type { HeartbeatState } from "./heartbeat";
 import type { LoopLimitRuntime } from "./loop-limit";
 import type { OAuthManualInputManager } from "./oauth-manual-input";
 import type { Theme } from "./theme/theme";
@@ -172,6 +173,7 @@ export interface InteractiveModeContext {
 	loopModePaused: boolean;
 	loopPrompt?: string;
 	loopLimit?: LoopLimitRuntime;
+	heartbeatState?: HeartbeatState;
 	planModePlanFilePath?: string;
 	hideThinkingBlock: boolean;
 	/**
@@ -446,6 +448,7 @@ export interface InteractiveModeContext {
 	setLoopPrompt(prompt: string): void;
 	disableLoopMode(): void;
 	pauseLoop(): void;
+	handleHeartbeatCommand(args: string): Promise<void>;
 	handlePlanApproval(details: PlanApprovalDetails): Promise<void>;
 	openPlanReview(): Promise<void>;
 

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -6,6 +6,7 @@ import {
 	resolveCliModel,
 } from "../config/model-resolver";
 import type { SettingPath } from "../config/settings";
+import { describeHeartbeatInterval } from "../modes/heartbeat";
 import { describeLoopLimitRuntime } from "../modes/loop-limit";
 import type { InteractiveModeContext } from "../modes/types";
 import type { AgentSession } from "../session/agent-session";
@@ -277,6 +278,29 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
 			await runtime.ctx.handleQueueCommand(command.args);
+		},
+	},
+	{
+		name: "heartbeat",
+		description: "Set a recurring prompt that fires on a timer",
+		subcommands: [
+			{ name: "every", description: "Set interval and instruction", usage: "<INTERVAL> <instruction>" },
+			{ name: "status", description: "Show heartbeat details" },
+			{ name: "pause", description: "Pause the heartbeat" },
+			{ name: "resume", description: "Resume a paused heartbeat" },
+			{ name: "clear", description: "Clear the heartbeat" },
+		],
+		inlineHint: "every <INTERVAL> <instruction>",
+		allowArgs: true,
+		getTuiAutocompleteDescription: runtime => {
+			const state = runtime.ctx.heartbeatState;
+			if (!state) return "Heartbeat: off";
+			if (state.status === "paused") return "Heartbeat: paused";
+			return `Heartbeat: every ${describeHeartbeatInterval(state.intervalMs)}`;
+		},
+		handleTui: async (command, runtime) => {
+			await runtime.ctx.handleHeartbeatCommand(command.args || "");
+			runtime.ctx.editor.setText("");
 		},
 	},
 	{

--- a/packages/coding-agent/test/heartbeat.test.ts
+++ b/packages/coding-agent/test/heartbeat.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test, vi } from "bun:test";
+import {
+	describeHeartbeatInterval,
+	formatHeartbeatStatus,
+	type HeartbeatState,
+	MIN_HEARTBEAT_INTERVAL_MS,
+	parseHeartbeatCommand,
+	parseHeartbeatInterval,
+} from "@oh-my-pi/pi-coding-agent/modes/heartbeat";
+import type { BuiltinSlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+
+describe("heartbeat interval parsing", () => {
+	test("parses compound durations like 10m, 90s, 1h30m", () => {
+		expect(parseHeartbeatInterval("10m")).toBe(600_000);
+		expect(parseHeartbeatInterval("90s")).toBe(90_000);
+		expect(parseHeartbeatInterval("1h30m")).toBe(5_400_000);
+	});
+
+	test("parses space-separated amounts with unit words", () => {
+		expect(parseHeartbeatInterval("15 seconds")).toBe(15_000);
+		expect(parseHeartbeatInterval("1 hour")).toBe(3_600_000);
+	});
+
+	test("rejects intervals below the minimum", () => {
+		expect(typeof parseHeartbeatInterval("5s")).toBe("string");
+		expect(parseHeartbeatInterval("5s")).toContain("at least");
+	});
+
+	test("rejects unknown units", () => {
+		expect(typeof parseHeartbeatInterval("10x")).toBe("string");
+		expect(parseHeartbeatInterval("10x")).toContain("unit must be");
+	});
+
+	test("rejects zero or negative amounts", () => {
+		expect(typeof parseHeartbeatInterval("0m")).toBe("string");
+	});
+});
+
+describe("heartbeat command parsing", () => {
+	test("parses subcommands", () => {
+		expect(parseHeartbeatCommand("status")).toEqual({ type: "status" });
+		expect(parseHeartbeatCommand("pause")).toEqual({ type: "pause" });
+		expect(parseHeartbeatCommand("resume")).toEqual({ type: "resume" });
+		expect(parseHeartbeatCommand("clear")).toEqual({ type: "clear" });
+		expect(parseHeartbeatCommand("off")).toEqual({ type: "clear" });
+		expect(parseHeartbeatCommand("stop")).toEqual({ type: "clear" });
+	});
+
+	test("parses set form with 'every' prefix", () => {
+		expect(parseHeartbeatCommand("every 10m Check the build")).toEqual({
+			type: "set",
+			intervalMs: 600_000,
+			instruction: "Check the build",
+		});
+	});
+
+	test("parses set form without 'every' prefix", () => {
+		expect(parseHeartbeatCommand("15m Check deployment status")).toEqual({
+			type: "set",
+			intervalMs: 900_000,
+			instruction: "Check deployment status",
+		});
+	});
+
+	test("rejects set without instruction", () => {
+		const result = parseHeartbeatCommand("every 10m");
+		expect(typeof result).toBe("string");
+		expect(result).toContain("requires an instruction");
+	});
+
+	test("rejects empty args", () => {
+		expect(typeof parseHeartbeatCommand("")).toBe("string");
+		expect(typeof parseHeartbeatCommand("   ")).toBe("string");
+	});
+
+	test("rejects invalid interval", () => {
+		const result = parseHeartbeatCommand("every abc Check builds");
+		expect(typeof result).toBe("string");
+	});
+});
+
+describe("describeHeartbeatInterval", () => {
+	test("formats common intervals in human-readable units", () => {
+		expect(describeHeartbeatInterval(3_600_000)).toBe("1 hour");
+		expect(describeHeartbeatInterval(7_200_000)).toBe("2 hours");
+		expect(describeHeartbeatInterval(60_000)).toBe("1 minute");
+		expect(describeHeartbeatInterval(600_000)).toBe("10 minutes");
+		expect(describeHeartbeatInterval(30_000)).toBe("30 seconds");
+		expect(describeHeartbeatInterval(90_000)).toBe("90 seconds");
+	});
+});
+
+describe("formatHeartbeatStatus", () => {
+	test("reports active heartbeat", () => {
+		const state: HeartbeatState = {
+			intervalMs: 600_000,
+			instruction: "Check the deployment",
+			status: "active",
+		};
+		const text = formatHeartbeatStatus(state);
+		expect(text).toContain("active");
+		expect(text).toContain("10 minutes");
+		expect(text).toContain("Check the deployment");
+	});
+
+	test("reports paused heartbeat", () => {
+		const state: HeartbeatState = {
+			intervalMs: 3_600_000,
+			instruction: "Review open PRs",
+			status: "paused",
+		};
+		const text = formatHeartbeatStatus(state);
+		expect(text).toContain("paused");
+		expect(text).toContain("1 hour");
+	});
+
+	test("reports no heartbeat when undefined", () => {
+		const text = formatHeartbeatStatus(undefined);
+		expect(text).toContain("No heartbeat set");
+	});
+});
+
+describe("/heartbeat slash command forwarding", () => {
+	test("forwards args to handleHeartbeatCommand", async () => {
+		const handleHeartbeatCommand = vi.fn(async (_args: string) => undefined);
+		const runtime = {
+			ctx: { handleHeartbeatCommand, editor: { setText: vi.fn() } },
+		} as unknown as BuiltinSlashCommandRuntime;
+		const result = await executeBuiltinSlashCommand("/heartbeat every 10m Check builds", runtime);
+
+		expect(result).toBe(true);
+		expect(handleHeartbeatCommand).toHaveBeenCalledWith("every 10m Check builds");
+	});
+
+	test("clears the editor after handling", async () => {
+		const handleHeartbeatCommand = vi.fn(async (_args: string) => undefined);
+		const setText = vi.fn();
+		const runtime = {
+			ctx: { handleHeartbeatCommand, editor: { setText } },
+		} as unknown as BuiltinSlashCommandRuntime;
+		await executeBuiltinSlashCommand("/heartbeat status", runtime);
+
+		expect(setText).toHaveBeenCalledWith("");
+	});
+});
+
+describe("MIN_HEARTBEAT_INTERVAL_MS", () => {
+	test("is at least 10 seconds", () => {
+		expect(MIN_HEARTBEAT_INTERVAL_MS).toBeGreaterThanOrEqual(10_000);
+	});
+});

--- a/packages/coding-agent/test/status-line-loop.test.ts
+++ b/packages/coding-agent/test/status-line-loop.test.ts
@@ -22,6 +22,7 @@ function createContext(loopMode: SegmentContext["loopMode"]): SegmentContext {
 		prewalk: null,
 		goalMode: null,
 		vibeMode: null,
+		heartbeat: null,
 		collab: null,
 		usageStats: {
 			input: 0,

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -29,6 +29,7 @@ function createModelContext(advisorActive: boolean): SegmentContext {
 		prewalk: null,
 		goalMode: null,
 		vibeMode: null,
+		heartbeat: null,
 		collab: null,
 		usageStats: {
 			input: 0,

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -55,6 +55,7 @@ function createCtx(overrides?: {
 		prewalk: null,
 		goalMode: null,
 		vibeMode: null,
+		heartbeat: null,
 		collab: null,
 		usageStats: {
 			input: 0,

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -34,6 +34,7 @@ function createPathContext(): SegmentContext {
 		prewalk: null,
 		goalMode: null,
 		vibeMode: null,
+		heartbeat: null,
 		collab: null,
 		usageStats: {
 			input: 0,

--- a/packages/coding-agent/test/status-line-time-spent.test.ts
+++ b/packages/coding-agent/test/status-line-time-spent.test.ts
@@ -44,6 +44,7 @@ function createCtx(activeMs: number): SegmentContext {
 		prewalk: null,
 		goalMode: null,
 		vibeMode: null,
+		heartbeat: null,
 		collab: null,
 		usageStats: {
 			input: 0,


### PR DESCRIPTION
## Summary

Adds a new `/heartbeat` slash command that injects a user-specified instruction into the session on a fixed timer — a feature complementary to the existing `/loop` (re-submit after every yield) and `/goal` (persistent autonomous objective) modes.

While `/loop` fires immediately after each agent yield, a **heartbeat** fires on a wall-clock interval regardless of agent state. This is ideal for monitoring and periodic check-in workflows:

```
/heartbeat every 10m Check the deployment and report meaningful changes
/heartbeat every 30s Run the test suite and summarize failures
```

## Usage

```text
/heartbeat every 10m Check the build status
/heartbeat status
/heartbeat pause
/heartbeat resume
/heartbeat clear
```

The shorthand form (omitting `every`) also works:
```
/heartbeat 10m Check the build status
```

Interval accepts seconds, minutes, and hours in compact (`10m`, `1h30m`) or word (`10 minutes`) form. Minimum interval is 10 seconds.

## Implementation

- **`modes/heartbeat.ts`** — Core parsing, state, and formatting logic. Interval parsing reuses the same duration-unit vocabulary as loop-limit.
- **`slash-commands/builtin-modes.ts`** — `/heartbeat` command spec with subcommands and autocomplete.
- **`modes/interactive-mode.ts`** — Timer lifecycle (`setInterval` with `unref`), prompt injection via `startPendingSubmission` with `customType: "heartbeat"`, status line sync, and disposal cleanup.
- **Status line** — A `♥` indicator that co-renders alongside any active mode (plan/goal/vibe/loop), so heartbeat is always visible when active. Extracted the existing mode chain into `renderPrimaryModeSegment` for clean composition.

### Design decisions

- **Ticks skip when busy**: If the agent is streaming, compacting, or has post-prompt work, the tick is silently dropped rather than queued. This prevents stacking prompts and avoids `AgentBusyError`.
- **`unref`-ed timer**: `setInterval(...).unref()` ensures the timer never keeps the process alive.
- **No custom message rendering**: Heartbeat injections use `display: false` so the instruction text isn't echoed in the chat — the model's response is visible, the raw instruction is not (similar to goal continuations).

## Test plan

- [x] `heartbeat.test.ts` — 18 tests covering interval parsing (compact, compound, word form), command parsing (all subcommands, set forms, error cases), status formatting, and slash-command forwarding.
- [x] All 46 existing status-line tests pass (updated 5 fixtures for the new `heartbeat` SegmentContext field).
- [x] `bun check` passes with no new errors.

## Changelog

Added under `[Unreleased]` in `packages/coding-agent/CHANGELOG.md`.