### PR TITLE
feat(coding-agent): add quality gates for goal mode completion

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added quality gates for goal mode. Configure verification commands via `goal.gates` (e.g. `["npm test", "cargo clippy"]`) and they run automatically when the agent calls `goal({op:"complete"})`. A failing gate blocks completion and returns the failure output to the agent. Gates are bypassed after `goal.gateMaxRetries` (default: 3) failed attempts to prevent permanent blocking.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4434,6 +4434,40 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"goal.gates": {
+		type: "array",
+		default: [],
+		ui: {
+			tab: "tasks",
+			group: "Modes",
+			label: "Goal Quality Gates",
+			description:
+				"Shell commands that must exit 0 before a goal can be completed (e.g. 'npm test', 'cargo clippy')",
+		},
+	},
+
+	"goal.gateMaxRetries": {
+		type: "number",
+		default: 3,
+		ui: {
+			tab: "tasks",
+			group: "Modes",
+			label: "Goal Gate Max Retries",
+			description: "Maximum failed attempts per gate command before bypassing it",
+		},
+	},
+
+	"goal.gateTimeoutMs": {
+		type: "number",
+		default: 300000,
+		ui: {
+			tab: "tasks",
+			group: "Modes",
+			label: "Goal Gate Timeout",
+			description: "Timeout in milliseconds for each gate command (default: 5 minutes)",
+		},
+	},
+
 	"title.refreshOnReplan": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/goals/gates.ts
+++ b/packages/coding-agent/src/goals/gates.ts
@@ -1,0 +1,110 @@
+/**
+ * Quality gates for goal mode: verification commands that must pass before a
+ * goal can be completed. When the agent calls `goal({op: "complete"})`, each
+ * configured gate command runs sequentially. A non-zero exit code blocks
+ * completion and feeds the failure output back to the agent.
+ *
+ * Gate attempts are tracked per command. After `maxRetries` failed attempts
+ * for a command, the gate is bypassed so the agent is never permanently
+ * blocked by a gate it cannot satisfy.
+ */
+
+import { logger } from "@oh-my-pi/pi-utils";
+import { execCommand } from "../exec/exec";
+
+const MAX_GATE_OUTPUT_CHARS = 6_000;
+
+export interface GoalGateConfig {
+	commands: string[];
+	maxRetries: number;
+	timeoutMs: number;
+}
+
+export interface GoalGateFailure {
+	command: string;
+	attempt: number;
+	maxRetries: number;
+	exitText: string;
+	output: string;
+}
+
+export interface GoalGateResult {
+	passed: boolean;
+	failure?: GoalGateFailure;
+}
+
+export const DEFAULT_GATE_MAX_RETRIES = 3;
+export const DEFAULT_GATE_TIMEOUT_MS = 5 * 60 * 1_000;
+
+/**
+ * Run all gate commands sequentially. Returns after the first failure or after
+ * all commands pass.
+ *
+ * `attempts` is a mutable map of command → current attempt count. It is
+ * incremented and read in place so callers can track state across invocations.
+ */
+export async function runGoalGates(
+	config: GoalGateConfig,
+	cwd: string,
+	attempts: Map<string, number>,
+	signal?: AbortSignal,
+): Promise<GoalGateResult> {
+	if (config.commands.length === 0) return { passed: true };
+
+	for (const command of config.commands) {
+		signal?.throwIfAborted();
+
+		const currentAttempts = attempts.get(command) ?? 0;
+
+		// After maxRetries, bypass this gate — the agent has had enough chances.
+		if (currentAttempts >= config.maxRetries) {
+			logger.warn("goal gate: max retries exhausted, bypassing", { command, attempts: currentAttempts });
+			continue;
+		}
+
+		const result = await execCommand("sh", ["-c", command], cwd, {
+			signal,
+			timeout: config.timeoutMs,
+		});
+		signal?.throwIfAborted();
+
+		if (result.code === 0 && !result.killed) {
+			attempts.set(command, 0);
+			continue;
+		}
+
+		const attempt = currentAttempts + 1;
+		attempts.set(command, attempt);
+
+		const exitText = result.killed ? "timed out or aborted" : `exit code ${result.code}`;
+		const output = truncateOutput([result.stdout, result.stderr].filter(Boolean).join("\n").trim());
+
+		return {
+			passed: false,
+			failure: { command, attempt, maxRetries: config.maxRetries, exitText, output },
+		};
+	}
+
+	return { passed: true };
+}
+
+/** Format a gate failure into a message suitable for the agent. */
+export function formatGateFailureMessage(failure: GoalGateFailure): string {
+	const lines = [
+		`Quality gate failed (attempt ${failure.attempt}/${failure.maxRetries}):`,
+		`  Command: \`${failure.command}\``,
+		`  Result: ${failure.exitText}`,
+	];
+	if (failure.output) {
+		lines.push("  Output:", failure.output);
+	}
+	lines.push("", 'Fix the failure, then call goal({op: "complete"}) again.');
+	return lines.join("\n");
+}
+
+function truncateOutput(combined: string): string {
+	if (combined.length > MAX_GATE_OUTPUT_CHARS) {
+		return `${combined.slice(0, MAX_GATE_OUTPUT_CHARS)}\n...(output truncated)`;
+	}
+	return combined;
+}

--- a/packages/coding-agent/src/goals/tools/goal-tool.ts
+++ b/packages/coding-agent/src/goals/tools/goal-tool.ts
@@ -11,6 +11,7 @@ import type { ToolSession } from "../../tools";
 import { formatErrorDetail, TRUNCATE_LENGTHS } from "../../tools/render-utils";
 import { ToolError } from "../../tools/tool-errors";
 import { framedBlock, renderStatusLine, truncateToWidth } from "../../tui";
+import { DEFAULT_GATE_MAX_RETRIES, DEFAULT_GATE_TIMEOUT_MS, formatGateFailureMessage, runGoalGates } from "../gates";
 import { completionBudgetReport, remainingTokens } from "../runtime";
 import type { Goal, GoalStatus, GoalToolDetails } from "../state";
 
@@ -64,6 +65,8 @@ export class GoalTool implements AgentTool<typeof goalSchema, GoalToolDetails> {
 	readonly intent = "omit" as const;
 	readonly #session: ToolSession;
 
+	#gateAttempts = new Map<string, number>();
+
 	constructor(session: ToolSession) {
 		this.#session = session;
 	}
@@ -94,6 +97,7 @@ export class GoalTool implements AgentTool<typeof goalSchema, GoalToolDetails> {
 			const dropped = await runtime.dropGoal();
 			response = buildGoalToolResponse(dropped ?? null);
 		} else {
+			await this.#runGatesBeforeCompletion(_signal);
 			const completed = await runtime.completeGoalFromTool();
 			response = buildGoalToolResponse(completed, { includeCompletionReport: true });
 		}
@@ -121,6 +125,29 @@ export class GoalTool implements AgentTool<typeof goalSchema, GoalToolDetails> {
 				completionBudgetReport: response.completionBudgetReport,
 			},
 		};
+	}
+
+	/**
+	 * Run quality gate commands before allowing goal completion. If any gate
+	 * fails (non-zero exit), throw a ToolError with the failure output so the
+	 * agent continues working. Gates are configured via `goal.gates` in
+	 * settings. After `goal.gateMaxRetries` failed attempts for a command, the
+	 * gate is bypassed to avoid permanent blocking.
+	 */
+	async #runGatesBeforeCompletion(signal?: AbortSignal): Promise<void> {
+		const commands = this.#session.settings.get("goal.gates");
+		if (!commands || commands.length === 0) return;
+		const maxRetries = this.#session.settings.get("goal.gateMaxRetries") ?? DEFAULT_GATE_MAX_RETRIES;
+		const timeoutMs = this.#session.settings.get("goal.gateTimeoutMs") ?? DEFAULT_GATE_TIMEOUT_MS;
+		const result = await runGoalGates(
+			{ commands: [...commands], maxRetries, timeoutMs },
+			this.#session.cwd,
+			this.#gateAttempts,
+			signal,
+		);
+		if (!result.passed && result.failure) {
+			throw new ToolError(formatGateFailureMessage(result.failure));
+		}
 	}
 }
 

--- a/packages/coding-agent/src/prompts/goals/goal-continuation.md
+++ b/packages/coding-agent/src/prompts/goals/goal-continuation.md
@@ -25,4 +25,6 @@ Before calling `goal({op:"complete"})`, you MUST perform a completion audit agai
 
 Call `goal({op:"complete"})` only when every deliverable has direct, current-state evidence proving it is satisfied. The completion call is a load-bearing claim; it ends the autonomous loop and surfaces a "done" report to the user.
 
+If quality gates are configured (`goal.gates` setting), they run automatically when you call `goal({op:"complete"})`. A failing gate blocks completion and returns the failure output — fix it and try again. Gates are bypassed after `goal.gateMaxRetries` failed attempts.
+
 If the work is not done, just keep working. NEVER narrate that you are continuing — execute.

--- a/packages/coding-agent/test/gates.test.ts
+++ b/packages/coding-agent/test/gates.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import {
+	DEFAULT_GATE_MAX_RETRIES,
+	DEFAULT_GATE_TIMEOUT_MS,
+	formatGateFailureMessage,
+	type GoalGateConfig,
+	type GoalGateFailure,
+	runGoalGates,
+} from "@oh-my-pi/pi-coding-agent/goals/gates";
+
+const PASS_CONFIG: GoalGateConfig = {
+	commands: ["true"],
+	maxRetries: 3,
+	timeoutMs: 5_000,
+};
+
+const FAIL_CONFIG: GoalGateConfig = {
+	commands: ["false"],
+	maxRetries: 3,
+	timeoutMs: 5_000,
+};
+
+describe("runGoalGates", () => {
+	test("passes when all commands exit 0", async () => {
+		const attempts = new Map<string, number>();
+		const result = await runGoalGates(PASS_CONFIG, process.cwd(), attempts);
+		expect(result.passed).toBe(true);
+		expect(result.failure).toBeUndefined();
+		// Attempt counter reset to 0 on pass
+		expect(attempts.get("true")).toBe(0);
+	});
+
+	test("fails when a command exits non-zero", async () => {
+		const attempts = new Map<string, number>();
+		const result = await runGoalGates(FAIL_CONFIG, process.cwd(), attempts);
+		expect(result.passed).toBe(false);
+		expect(result.failure).toBeDefined();
+		expect(result.failure!.command).toBe("false");
+		expect(result.failure!.attempt).toBe(1);
+		expect(result.failure!.maxRetries).toBe(3);
+		expect(result.failure!.exitText).toContain("exit code");
+	});
+
+	test("increments attempt counter across invocations", async () => {
+		const attempts = new Map<string, number>();
+		await runGoalGates(FAIL_CONFIG, process.cwd(), attempts);
+		expect(attempts.get("false")).toBe(1);
+		await runGoalGates(FAIL_CONFIG, process.cwd(), attempts);
+		expect(attempts.get("false")).toBe(2);
+	});
+
+	test("bypasses gate after maxRetries exhausted", async () => {
+		const attempts = new Map<string, number>([["false", 3]]);
+		const result = await runGoalGates(FAIL_CONFIG, process.cwd(), attempts);
+		// Should pass because the gate is bypassed after maxRetries
+		expect(result.passed).toBe(true);
+	});
+
+	test("returns passed immediately when no commands configured", async () => {
+		const config: GoalGateConfig = { commands: [], maxRetries: 3, timeoutMs: 5_000 };
+		const result = await runGoalGates(config, process.cwd(), new Map());
+		expect(result.passed).toBe(true);
+	});
+
+	test("stops at first failing command", async () => {
+		const config: GoalGateConfig = {
+			commands: ["false", "true"],
+			maxRetries: 3,
+			timeoutMs: 5_000,
+		};
+		const attempts = new Map<string, number>();
+		const result = await runGoalGates(config, process.cwd(), attempts);
+		expect(result.passed).toBe(false);
+		expect(result.failure!.command).toBe("false");
+		// Second command never ran
+		expect(attempts.has("true")).toBe(false);
+	});
+
+	test("captures stdout from failing command", async () => {
+		const config: GoalGateConfig = {
+			commands: ["echo 'gate output here' && false"],
+			maxRetries: 3,
+			timeoutMs: 5_000,
+		};
+		const attempts = new Map<string, number>();
+		const result = await runGoalGates(config, process.cwd(), attempts);
+		expect(result.passed).toBe(false);
+		expect(result.failure!.output).toContain("gate output here");
+	});
+
+	test("resets attempt counter after a successful run", async () => {
+		const attempts = new Map<string, number>([["true", 2]]);
+		const result = await runGoalGates(PASS_CONFIG, process.cwd(), attempts);
+		expect(result.passed).toBe(true);
+		expect(attempts.get("true")).toBe(0);
+	});
+});
+
+describe("formatGateFailureMessage", () => {
+	test("formats failure with command, exit text, and output", () => {
+		const failure: GoalGateFailure = {
+			command: "npm test",
+			attempt: 2,
+			maxRetries: 3,
+			exitText: "exit code 1",
+			output: "FAIL  src/app.test.ts\n  ● app > should work",
+		};
+		const message = formatGateFailureMessage(failure);
+		expect(message).toContain("attempt 2/3");
+		expect(message).toContain("`npm test`");
+		expect(message).toContain("exit code 1");
+		expect(message).toContain("FAIL  src/app.test.ts");
+		expect(message).toContain('goal({op: "complete"})');
+	});
+
+	test("omits output section when empty", () => {
+		const failure: GoalGateFailure = {
+			command: "exit 1",
+			attempt: 1,
+			maxRetries: 3,
+			exitText: "exit code 1",
+			output: "",
+		};
+		const message = formatGateFailureMessage(failure);
+		expect(message).not.toContain("Output:");
+	});
+});
+
+describe("defaults", () => {
+	test("DEFAULT_GATE_MAX_RETRIES is at least 1", () => {
+		expect(DEFAULT_GATE_MAX_RETRIES).toBeGreaterThanOrEqual(1);
+	});
+
+	test("DEFAULT_GATE_TIMEOUT_MS is at least 30 seconds", () => {
+		expect(DEFAULT_GATE_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
+	});
+});


### PR DESCRIPTION
## Summary

Adds verification **quality gates** to goal mode. Configure shell commands that must exit 0 before the agent can complete a goal. When the agent calls `goal({op:"complete"})`, each gate runs sequentially — a non-zero exit blocks completion and feeds the failure output back to the agent.

This is ideal for autonomous workflows where you want objective verification that the work is actually done:

```json
{
  "goal.gates": ["npm test", "npm run build", "cargo clippy"],
  "goal.gateMaxRetries": 3,
  "goal.gateTimeoutMs": 300000
}
```

## How it works

1. The agent works on a goal as usual (goal mode continuation loop)
2. When it calls `goal({op:"complete"})`, quality gates run first
3. If a gate fails, a `ToolError` is thrown with the command, exit code, and output
4. The agent sees the failure and continues working — the goal stays active
5. After `gateMaxRetries` failed attempts for a command, the gate is bypassed to prevent permanent blocking

## Settings

| Setting | Type | Default | Description |
|---|---|---|---|
| `goal.gates` | `string[]` | `[]` | Shell commands that must exit 0 before goal completion |
| `goal.gateMaxRetries` | `number` | `3` | Max failed attempts per command before bypassing |
| `goal.gateTimeoutMs` | `number` | `300000` (5 min) | Per-command timeout in milliseconds |

## Implementation

- **`goals/gates.ts`** (new) — `runGoalGates()` runs commands via the sanctioned `execCommand` helper (`ptree.exec`), tracks attempts per command in a mutable `Map`, and returns structured results. `formatGateFailureMessage()` formats failures for agent consumption.
- **`goals/tools/goal-tool.ts`** — Added `#gateAttempts` tracking and `#runGatesBeforeCompletion()` that runs before `completeGoalFromTool()`. Throws `ToolError` on failure.
- **`config/settings-schema.ts`** — Three new settings under the `Modes` group.
- **`prompts/goals/goal-continuation.md`** — Informs the agent that quality gates run automatically.

### Design decisions

- **Uses sanctioned `execCommand`** (not raw `Bun.spawn`) — gets timeout, abort, exit code, and output capture for free.
- **Per-command attempt tracking** — each command has its own retry counter, so a flaky gate doesn't exhaust retries for a stable one.
- **Bypass after maxRetries** — prevents permanent blocking if a gate is fundamentally unsatisfiable. The agent gets enough chances to fix it, then is allowed to proceed.
- **Attempt counter resets on pass** — if a gate passes after previous failures, the counter resets so future completions aren't penalized.

## Test plan

- [x] `gates.test.ts` — 12 tests covering: all-pass, first-failure, attempt incrementing, max-retry bypass, empty config, first-failure-stops-chain, stdout capture, attempt reset on pass, failure message formatting, and defaults.
- [x] `bun check` passes with no new errors.
- [x] CHANGELOG updated under `[Unreleased]`.