### PR TITLE
fix(web-search): parse double-encoded Z.AI results

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Z.AI web search dropping sources and exposing raw JSON when MCP responses double-encode content text ([#8000](https://github.com/can1357/oh-my-pi/issues/8000)).
+
 ## [17.2.11] - 2026-08-07
 
 ### Added

--- a/packages/coding-agent/src/web/search/providers/zai.ts
+++ b/packages/coding-agent/src/web/search/providers/zai.ts
@@ -353,11 +353,20 @@ function parseSearchPayload(rawResult: unknown): {
 			for (const part of content) {
 				const text = isRecord(part) ? asString(part.text) : null;
 				if (!text) continue;
-				textParts.push(text);
 				try {
-					candidates.push(JSON.parse(text));
+					let parsed: unknown = JSON.parse(text);
+					if (typeof parsed === "string") {
+						try {
+							parsed = JSON.parse(parsed);
+						} catch {
+							// The decoded string is answer text rather than another JSON payload.
+						}
+					}
+					candidates.push(parsed);
+					if (getSearchResults(parsed).length === 0) textParts.push(text);
 				} catch {
-					// Not JSON payload; keep as fallback answer text.
+					// Non-JSON content is preserved as answer text.
+					textParts.push(text);
 				}
 			}
 		}

--- a/packages/coding-agent/test/web/search/zai.test.ts
+++ b/packages/coding-agent/test/web/search/zai.test.ts
@@ -9,7 +9,7 @@ interface CapturedRequest {
 }
 
 describe("Z.AI web search provider", () => {
-	it("initializes a Streamable HTTP MCP session before calling web_search_prime", async () => {
+	it("initializes a Streamable HTTP MCP session and parses doubly encoded results", async () => {
 		const capturedRequests: CapturedRequest[] = [];
 		const fetchImpl: FetchImpl = (_input, init) => {
 			const request = {
@@ -53,16 +53,20 @@ describe("Z.AI web search provider", () => {
 							content: [
 								{
 									type: "text",
-									text: JSON.stringify({
-										search_result: [
+									text: JSON.stringify(
+										JSON.stringify([
 											{
 												title: "Z.AI search result",
 												content: "Search result content",
 												link: "https://example.com/zai",
 												media: "Example",
 											},
-										],
-									}),
+										]),
+									),
+								},
+								{
+									type: "text",
+									text: "Plain prose answer.",
 								},
 							],
 						},
@@ -107,6 +111,7 @@ describe("Z.AI web search provider", () => {
 				author: "Example",
 			},
 		]);
+		expect(response.answer).toBe("Plain prose answer.");
 	});
 
 	function createMcpFetch(): { fetchImpl: FetchImpl; capturedRequests: CapturedRequest[] } {


### PR DESCRIPTION
## Repro
A mocked Streamable HTTP MCP response with `content[0].text` encoded as a JSON string containing a JSON results array reproduces the failure with `cd packages/coding-agent && bun test test/web/search/zai.test.ts`: before the fix, `searchZai()` returned `sources: []` and the source assertion failed.

## Cause
`parseSearchPayload()` in `packages/coding-agent/src/web/search/providers/zai.ts` called `JSON.parse(text)` only once. Z.AI's extra encoding layer therefore left a string candidate that `getSearchResults()` could not inspect, while the encoded payload remained in `textParts` and surfaced as answer text.

## Fix
- Decode one additional JSON layer when the first decoded Z.AI content value is a string.
- Exclude decoded result payloads from answer text while preserving separate plain-prose content.
- Cover source extraction and prose preservation with the existing MCP provider test, and add the issue to the coding-agent changelog.

## Verification
`cd packages/coding-agent && bun test test/web/search/zai.test.ts` passes: 3 tests, 0 failures, 11 assertions. The pre-publish `bun run fix` and `bun check` gate also passed.

Fixes #8000