### PR TITLE
feat(coding-agent): add OpenAI reasoning summary setting

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -248,6 +248,9 @@
 ### Fixed
 
 - Fixed account-scoped Codex cyber-policy denials bypassing sibling credential rotation; replay-safe requests now try every configured account before surfacing the error.
+### Added
+
+- Added explicit reasoning-summary controls to unified OpenAI Responses and Codex stream options, preserving provider defaults unless callers opt into `auto`, `concise`, or `detailed` summaries. ([#8006](https://github.com/can1357/oh-my-pi/issues/8006))
 
 ## [17.2.11] - 2026-08-07
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -210,6 +210,9 @@
 ### Removed
 
 - Removed legacy local request-cost estimation machinery and database schemas previously used for OpenCode Go estimates.
+### Added
+
+- Added explicit reasoning-summary controls to unified OpenAI Responses and Codex stream options, preserving provider defaults unless callers opt into `auto`, `concise`, or `detailed` summaries. ([#8006](https://github.com/can1357/oh-my-pi/issues/8006))
 
 ## [17.2.15] - 2026-08-12
 
@@ -248,9 +251,6 @@
 ### Fixed
 
 - Fixed account-scoped Codex cyber-policy denials bypassing sibling credential rotation; replay-safe requests now try every configured account before surfacing the error.
-### Added
-
-- Added explicit reasoning-summary controls to unified OpenAI Responses and Codex stream options, preserving provider defaults unless callers opt into `auto`, `concise`, or `detailed` summaries. ([#8006](https://github.com/can1357/oh-my-pi/issues/8006))
 
 ## [17.2.11] - 2026-08-07
 

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -43,6 +43,16 @@ import {
 
 export { parseAzureDeploymentNameMap } from "./openai-shared";
 
+export function isOfficialAzureOpenAIResponsesUrl(baseUrl: string | undefined): boolean {
+	if (!baseUrl) return false;
+	try {
+		const hostname = new URL(baseUrl).hostname.toLowerCase();
+		return hostname.endsWith(".openai.azure.com") || hostname === "models.inference.ai.azure.com";
+	} catch {
+		return false;
+	}
+}
+
 const DEFAULT_AZURE_API_VERSION = "v1";
 const AZURE_OPENAI_RESPONSES_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"Azure OpenAI responses stream timed out while waiting for the first event";
@@ -134,7 +144,11 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
 			const { url, headers, baseUrl } = buildAzureResponsesRequest(model, apiKey, options);
 			const requestModel = modelForAzureEndpoint(model, baseUrl);
-			let params = buildParams(requestModel, context, options, deploymentName);
+			const requestOptions =
+				options?.reasoningSummary && !isOfficialAzureOpenAIResponsesUrl(baseUrl)
+					? { ...options, reasoningSummary: null }
+					: options;
+			let params = buildParams(requestModel, context, requestOptions, deploymentName);
 			const replacementPayload = await options?.onPayload?.(params, requestModel);
 			if (replacementPayload !== undefined) {
 				params = replacementPayload as typeof params;

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -164,7 +164,7 @@ function getReasoningConfig(
 		effort: effort === "none" ? "none" : mapCodexWireEffort(model, effort),
 	};
 	if (
-		model.compat.supportsReasoningSummary &&
+		model.compat.supportsReasoningSummary !== false &&
 		options.reasoningSummary !== undefined &&
 		options.reasoningSummary !== null &&
 		supportsCodexReasoningSummary(model.id)

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -455,20 +455,24 @@ export async function transformRequestBody(
 		applyCodexResponsesLiteShape(body);
 	}
 
+	const reasoningSummary =
+		options.reasoningSummary != null &&
+		model.compat.supportsReasoningSummary !== false &&
+		supportsCodexReasoningSummary(model.id)
+			? options.reasoningSummary
+			: undefined;
 	if (
 		options.reasoningOff ||
 		options.reasoningEffort !== undefined ||
-		options.reasoningSummary != null ||
+		reasoningSummary !== undefined ||
 		responsesLite
 	) {
 		const reasoningConfig: Partial<ReasoningConfig> = options.reasoningOff
 			? { effort: "none" }
 			: options.reasoningEffort !== undefined
 				? getReasoningConfig(model, options.reasoningEffort, options)
-				: options.reasoningSummary != null &&
-						model.compat.supportsReasoningSummary !== false &&
-						supportsCodexReasoningSummary(model.id)
-					? { summary: options.reasoningSummary }
+				: reasoningSummary !== undefined
+					? { summary: reasoningSummary }
 					: {};
 		body.reasoning = {
 			...body.reasoning,

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -455,12 +455,21 @@ export async function transformRequestBody(
 		applyCodexResponsesLiteShape(body);
 	}
 
-	if (options.reasoningOff || options.reasoningEffort !== undefined || responsesLite) {
+	if (
+		options.reasoningOff ||
+		options.reasoningEffort !== undefined ||
+		options.reasoningSummary != null ||
+		responsesLite
+	) {
 		const reasoningConfig: Partial<ReasoningConfig> = options.reasoningOff
 			? { effort: "none" }
 			: options.reasoningEffort !== undefined
 				? getReasoningConfig(model, options.reasoningEffort, options)
-				: {};
+				: options.reasoningSummary != null &&
+						model.compat.supportsReasoningSummary !== false &&
+						supportsCodexReasoningSummary(model.id)
+					? { summary: options.reasoningSummary }
+					: {};
 		body.reasoning = {
 			...body.reasoning,
 			...reasoningConfig,

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -163,14 +163,13 @@ function getReasoningConfig(
 	const config: ReasoningConfig = {
 		effort: effort === "none" ? "none" : mapCodexWireEffort(model, effort),
 	};
-	// The backend only emits reasoning summaries when `reasoning.summary` is
-	// present: omitting it yields zero `response.reasoning_summary_text.*`
-	// events (measured against gpt-5.5, gpt-5.6-sol and gpt-5.6-terra). So
-	// `undefined` means "default on" — matching `applyResponsesCompatPolicy`
-	// on the plain Responses path — and only an explicit `null` (the caller
-	// hiding thinking) opts out.
-	if (options.reasoningSummary !== null && supportsCodexReasoningSummary(model.id)) {
-		config.summary = options.reasoningSummary ?? "auto";
+	if (
+		model.compat.supportsReasoningSummary &&
+		options.reasoningSummary !== undefined &&
+		options.reasoningSummary !== null &&
+		supportsCodexReasoningSummary(model.id)
+	) {
+		config.summary = options.reasoningSummary;
 	}
 	return config;
 }

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -1291,11 +1291,12 @@ export function buildParams(
 		filterReasoningHistory: options?.filterReasoningHistory,
 		omitReasoningEffort: options?.omitReasoningEffort,
 	});
-	const reasoningSummary = model.compat.supportsReasoningSummary
-		? options?.reasoningSummary
-		: options?.reasoning === undefined
-			? undefined
-			: null;
+	const reasoningSummary =
+		model.compat.supportsReasoningSummary === false
+			? options?.reasoning === undefined
+				? undefined
+				: null
+			: options?.reasoningSummary;
 	applyResponsesCompatPolicy(params, reasoningPolicy, {
 		reasoningSummary,
 		forceReasoningOff: options?.forceReasoningOff,

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -3583,7 +3583,7 @@ export function applyResponsesCompatPolicy<P extends ResponseCreateParamsStreami
 		return;
 	}
 
-	if (reasoning.requestedEffort !== undefined || options?.reasoningSummary !== undefined) {
+	if (reasoning.requestedEffort !== undefined || options?.reasoningSummary != null) {
 		if (reasoning.omitReasoningEffort) {
 			if (options?.reasoningSummary !== undefined && options.reasoningSummary !== null) {
 				type ReasoningParam = NonNullable<ResponseCreateParamsStreaming["reasoning"]>;

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -3628,7 +3628,10 @@ export function applyResponsesReasoningParams<P extends ResponseCreateParamsStre
 			includeEncryptedReasoning,
 			omitReasoningEffort,
 		}),
-		{ reasoningSummary: model.compat.supportsReasoningSummary ? options?.reasoningSummary : null, mapEffort },
+		{
+			reasoningSummary: model.compat.supportsReasoningSummary !== false ? options?.reasoningSummary : null,
+			mapEffort,
+		},
 	);
 }
 

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -3628,7 +3628,7 @@ export function applyResponsesReasoningParams<P extends ResponseCreateParamsStre
 			includeEncryptedReasoning,
 			omitReasoningEffort,
 		}),
-		{ reasoningSummary: options?.reasoningSummary, mapEffort },
+		{ reasoningSummary: model.compat.supportsReasoningSummary ? options?.reasoningSummary : null, mapEffort },
 	);
 }
 

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -3583,27 +3583,29 @@ export function applyResponsesCompatPolicy<P extends ResponseCreateParamsStreami
 		return;
 	}
 
-	if (reasoning.requestedEffort !== undefined || options?.reasoningSummary != null) {
-		if (reasoning.omitReasoningEffort) {
-			if (options?.reasoningSummary !== undefined && options.reasoningSummary !== null) {
-				type ReasoningParam = NonNullable<ResponseCreateParamsStreaming["reasoning"]>;
-				params.reasoning = { summary: options.reasoningSummary || "auto" } as P["reasoning"] & ReasoningParam;
-			}
-			return;
+	type ReasoningParam = NonNullable<ResponseCreateParamsStreaming["reasoning"]>;
+	if (reasoning.requestedEffort === undefined) {
+		if (options?.reasoningSummary != null) {
+			params.reasoning = { summary: options.reasoningSummary || "auto" } as P["reasoning"] & ReasoningParam;
 		}
-
-		const requested = reasoning.requestedEffort ?? "medium";
-		const wireEffort = reasoning.wireEffort ?? options?.mapEffort?.(requested) ?? requested;
-		type ReasoningParam = NonNullable<ResponseCreateParamsStreaming["reasoning"]>;
-		const reasoningParams: ReasoningParam = {
-			effort: wireEffort as ReasoningParam["effort"],
-		};
-		if (options?.reasoningSummary !== null) {
-			reasoningParams.summary = options?.reasoningSummary || "auto";
-		}
-		params.reasoning = reasoningParams as P["reasoning"];
 		return;
 	}
+	if (reasoning.omitReasoningEffort) {
+		if (options?.reasoningSummary != null) {
+			params.reasoning = { summary: options.reasoningSummary || "auto" } as P["reasoning"] & ReasoningParam;
+		}
+		return;
+	}
+
+	const requested = reasoning.requestedEffort;
+	const wireEffort = reasoning.wireEffort ?? options?.mapEffort?.(requested) ?? requested;
+	const reasoningParams: ReasoningParam = {
+		effort: wireEffort as ReasoningParam["effort"],
+	};
+	if (options?.reasoningSummary !== null) {
+		reasoningParams.summary = options?.reasoningSummary || "auto";
+	}
+	params.reasoning = reasoningParams as P["reasoning"];
 }
 
 /**

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1875,7 +1875,11 @@ function resolveOpenAiReasoningSummary<TApi extends Api>(
 	if (requested === undefined) return undefined;
 	const parsed = parseOpenAIModel(model.id);
 	const isCodexVariant = parsed?.variant.startsWith("codex") === true;
-	return isCodexVariant && !supportsCodexReasoningSummary(model.id) ? null : requested;
+	return isCodexVariant && !supportsCodexReasoningSummary(model.id)
+		? options?.reasoning === undefined
+			? undefined
+			: null
+		: requested;
 }
 
 const castApi = <TApi extends Api>(api: OptionsForApi<TApi>): OptionsForApi<Api> => api as OptionsForApi<Api>;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1872,7 +1872,12 @@ function resolveOpenAiReasoningSummary<TApi extends Api>(
 ): SimpleStreamOptions["reasoningSummary"] {
 	if (options?.hideThinkingSummary) return null;
 	const requested = options?.reasoningSummary;
-	if (requested === undefined) return undefined;
+	if (requested === undefined) {
+		const suppressImplicitSummary =
+			(model.api === "openai-responses" && model.provider === "openai" && isOfficialOpenAIApiUrl(model.baseUrl)) ||
+			(model.api === "azure-openai-responses" && model.provider === "azure");
+		return suppressImplicitSummary ? null : undefined;
+	}
 	const parsed = parseOpenAIModel(model.id);
 	const isCodexVariant = parsed?.variant.startsWith("codex") === true;
 	return isCodexVariant && !supportsCodexReasoningSummary(model.id)

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1865,6 +1865,7 @@ function resolveGoogleThinkingOff<TApi extends Api>(model: Model<TApi>): NonNull
 		thinking.level = "MINIMAL";
 	}
 	return thinking;
+}
 
 function resolveOpenAiReasoningSummary<TApi extends Api>(
 	model: Model<TApi>,

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1876,7 +1876,7 @@ function resolveOpenAiReasoningSummary<TApi extends Api>(
 	if (requested === undefined) {
 		const suppressImplicitSummary =
 			(model.api === "openai-responses" && model.provider === "openai" && isOfficialOpenAIApiUrl(model.baseUrl)) ||
-			(model.api === "azure-openai-responses" && model.provider === "azure");
+			(model.api === "azure-openai-responses" && (model.provider === "azure" || model.provider === "azure-openai"));
 		return suppressImplicitSummary ? null : undefined;
 	}
 	const isCodexModel = isOpenAICodexModelId(model.id);

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -6,7 +6,7 @@ import { scheduler } from "node:timers/promises";
 import { isOfficialAnthropicApiUrl } from "@oh-my-pi/pi-catalog/compat/anthropic";
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { isVertexExpressOpenAIUrl, isVertexRawPredictUrl, resolveVertexEndpointHost } from "@oh-my-pi/pi-catalog/hosts";
-import { parseOpenAIModel, supportsCodexReasoningSummary } from "@oh-my-pi/pi-catalog/identity";
+import { isOpenAICodexModelId, supportsCodexReasoningSummary } from "@oh-my-pi/pi-catalog/identity";
 import {
 	defaultSupportedEffort,
 	mapEffortToAnthropicAdaptiveEffort,
@@ -1878,9 +1878,8 @@ function resolveOpenAiReasoningSummary<TApi extends Api>(
 			(model.api === "azure-openai-responses" && model.provider === "azure");
 		return suppressImplicitSummary ? null : undefined;
 	}
-	const parsed = parseOpenAIModel(model.id);
-	const isCodexVariant = parsed?.variant.startsWith("codex") === true;
-	return isCodexVariant && !supportsCodexReasoningSummary(model.id)
+	const isCodexModel = isOpenAICodexModelId(model.id);
+	return isCodexModel && !supportsCodexReasoningSummary(model.id)
 		? options?.reasoning === undefined
 			? undefined
 			: null

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -6,6 +6,7 @@ import { scheduler } from "node:timers/promises";
 import { isOfficialAnthropicApiUrl } from "@oh-my-pi/pi-catalog/compat/anthropic";
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { isVertexExpressOpenAIUrl, isVertexRawPredictUrl, resolveVertexEndpointHost } from "@oh-my-pi/pi-catalog/hosts";
+import { parseOpenAIModel, supportsCodexReasoningSummary } from "@oh-my-pi/pi-catalog/identity";
 import {
 	defaultSupportedEffort,
 	mapEffortToAnthropicAdaptiveEffort,
@@ -1864,6 +1865,17 @@ function resolveGoogleThinkingOff<TApi extends Api>(model: Model<TApi>): NonNull
 		thinking.level = "MINIMAL";
 	}
 	return thinking;
+
+function resolveOpenAiReasoningSummary<TApi extends Api>(
+	model: Model<TApi>,
+	options?: SimpleStreamOptions,
+): SimpleStreamOptions["reasoningSummary"] {
+	if (options?.hideThinkingSummary) return null;
+	const requested = options?.reasoningSummary;
+	if (requested === undefined) return undefined;
+	const parsed = parseOpenAIModel(model.id);
+	const isCodexVariant = parsed?.variant.startsWith("codex") === true;
+	return isCodexVariant && !supportsCodexReasoningSummary(model.id) ? null : requested;
 }
 
 const castApi = <TApi extends Api>(api: OptionsForApi<TApi>): OptionsForApi<Api> => api as OptionsForApi<Api>;
@@ -2112,7 +2124,7 @@ function mapOptionsForApi<TApi extends Api>(
 					reasoning: resolveOpenAiReasoningEffort(model, options),
 					toolChoice: mapOpenAiToolChoice(options?.toolChoice),
 					serviceTier: options?.serviceTier,
-					reasoningSummary: options?.hideThinkingSummary ? null : undefined,
+					reasoningSummary: resolveOpenAiReasoningSummary(model, options),
 					openrouterVariant: options?.openrouterVariant,
 					maxTokensExplicit: rawOptions?.maxTokens !== undefined,
 					disableReasoning: options?.disableReasoning,
@@ -2151,7 +2163,7 @@ function mapOptionsForApi<TApi extends Api>(
 				reasoning: resolveOpenAiReasoningEffort(model, options),
 				toolChoice: mapOpenAiToolChoice(options?.toolChoice),
 				serviceTier: options?.serviceTier,
-				reasoningSummary: options?.hideThinkingSummary ? null : undefined,
+				reasoningSummary: resolveOpenAiReasoningSummary(model, options),
 				openrouterVariant: options?.openrouterVariant,
 				maxTokensExplicit: rawOptions?.maxTokens !== undefined,
 				disableReasoning: options?.disableReasoning,
@@ -2167,7 +2179,7 @@ function mapOptionsForApi<TApi extends Api>(
 				reasoning: resolveOpenAiReasoningEffort(model, options),
 				toolChoice: mapOpenAiToolChoice(options?.toolChoice),
 				serviceTier: options?.serviceTier,
-				reasoningSummary: options?.hideThinkingSummary ? null : undefined,
+				reasoningSummary: resolveOpenAiReasoningSummary(model, options),
 				promptCache: options?.promptCache,
 				statefulResponses: options?.statefulResponses,
 				disableReasoning: options?.disableReasoning || options?.forceReasoningOff,
@@ -2182,7 +2194,7 @@ function mapOptionsForApi<TApi extends Api>(
 				serviceTier: options?.serviceTier,
 				preferWebsockets: options?.preferWebsockets,
 				codexCompaction: options?.codexCompaction,
-				reasoningSummary: options?.hideThinkingSummary ? null : undefined,
+				reasoningSummary: resolveOpenAiReasoningSummary(model, options),
 				textVerbosity: options?.textVerbosity,
 				forceReasoningOff: options?.forceReasoningOff,
 			});

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -620,6 +620,12 @@ export interface SimpleStreamOptions extends Omit<StreamOptions, "apiKey"> {
 	 * Useful when the UI hides thinking blocks anyway and the summary is wasted bandwidth.
 	 */
 	hideThinkingSummary?: boolean;
+	/**
+	 * OpenAI Responses/Codex reasoning-summary level. `undefined` preserves the
+	 * provider/model default; `null` suppresses summaries. Ignored by APIs that
+	 * do not expose OpenAI reasoning-summary controls.
+	 */
+	reasoningSummary?: "auto" | "concise" | "detailed" | null;
 	/** OpenAI Responses/Codex `text.verbosity` response detail level. */
 	textVerbosity?: "low" | "medium" | "high";
 	/** Custom token budgets for thinking levels (token-based providers only) */

--- a/packages/ai/test/azure-openai-responses-stream.test.ts
+++ b/packages/ai/test/azure-openai-responses-stream.test.ts
@@ -47,6 +47,20 @@ const versionlessAzureCodexModel: Model<"azure-openai-responses"> = buildModel({
 	maxTokens: 100_000,
 });
 
+const incompatibleAzureCodexModel: Model<"azure-openai-responses"> = buildModel({
+	id: "gpt-5.6-codex",
+	name: "GPT-5.6 Codex",
+	api: "azure-openai-responses",
+	provider: "azure",
+	baseUrl: azureModel.baseUrl,
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 400_000,
+	maxTokens: 128_000,
+	compat: { supportsReasoningSummary: false },
+});
+
 function createAbortedSignal(): AbortSignal {
 	const controller = new AbortController();
 	controller.abort();
@@ -175,6 +189,15 @@ describe("azure openai responses streaming", () => {
 		const payload = await captureAzureCodexPayload(
 			{ reasoning: Effort.High, reasoningSummary: "detailed" },
 			versionlessAzureCodexModel,
+		);
+
+		expect(payload.reasoning).toEqual({ effort: "high" });
+	});
+
+	it("omits explicitly requested summaries when endpoint compatibility disables them", async () => {
+		const payload = await captureAzureCodexPayload(
+			{ reasoning: Effort.High, reasoningSummary: "detailed" },
+			incompatibleAzureCodexModel,
 		);
 
 		expect(payload.reasoning).toEqual({ effort: "high" });

--- a/packages/ai/test/azure-openai-responses-stream.test.ts
+++ b/packages/ai/test/azure-openai-responses-stream.test.ts
@@ -34,6 +34,19 @@ const legacyAzureCodexModel: Model<"azure-openai-responses"> = buildModel({
 	maxTokens: 128_000,
 });
 
+const versionlessAzureCodexModel: Model<"azure-openai-responses"> = buildModel({
+	id: "codex-mini",
+	name: "Codex Mini",
+	api: "azure-openai-responses",
+	provider: "azure",
+	baseUrl: azureModel.baseUrl,
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 100_000,
+});
+
 function createAbortedSignal(): AbortSignal {
 	const controller = new AbortController();
 	controller.abort();
@@ -55,8 +68,9 @@ function createSseResponse(events: unknown[]): Response {
 	});
 }
 
-async function captureLegacyAzureCodexPayload(
+async function captureAzureCodexPayload(
 	options: Pick<SimpleStreamOptions, "reasoning" | "reasoningSummary">,
+	model = legacyAzureCodexModel,
 ): Promise<Record<string, unknown>> {
 	let capturedBody: Record<string, unknown> | undefined;
 	const fetchMock: FetchImpl = async (_input, init) => {
@@ -73,7 +87,7 @@ async function captureLegacyAzureCodexPayload(
 	};
 
 	await streamSimple(
-		legacyAzureCodexModel,
+		model,
 		{ messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }] },
 		{ apiKey: "test-key", fetch: fetchMock, ...options },
 	).result();
@@ -137,7 +151,7 @@ describe("azure openai responses streaming", () => {
 	});
 
 	it("omits explicitly requested summaries for legacy Azure Codex models", async () => {
-		const payload = await captureLegacyAzureCodexPayload({
+		const payload = await captureAzureCodexPayload({
 			reasoning: Effort.High,
 			reasoningSummary: "detailed",
 		});
@@ -146,15 +160,24 @@ describe("azure openai responses streaming", () => {
 	});
 
 	it("omits the summary field for an unconfigured legacy Azure Codex reasoning request", async () => {
-		const payload = await captureLegacyAzureCodexPayload({ reasoning: Effort.High });
+		const payload = await captureAzureCodexPayload({ reasoning: Effort.High });
 
 		expect(payload.reasoning).toEqual({ effort: "high" });
 	});
 
 	it("does not synthesize reasoning effort when only an unsupported summary is requested", async () => {
-		const payload = await captureLegacyAzureCodexPayload({ reasoningSummary: "detailed" });
+		const payload = await captureAzureCodexPayload({ reasoningSummary: "detailed" });
 
 		expect(payload.reasoning).toBeUndefined();
+	});
+
+	it("omits explicitly requested summaries for versionless Azure Codex models", async () => {
+		const payload = await captureAzureCodexPayload(
+			{ reasoning: Effort.High, reasoningSummary: "detailed" },
+			versionlessAzureCodexModel,
+		);
+
+		expect(payload.reasoning).toEqual({ effort: "high" });
 	});
 
 	it("sends an async onPayload replacement body", async () => {

--- a/packages/ai/test/azure-openai-responses-stream.test.ts
+++ b/packages/ai/test/azure-openai-responses-stream.test.ts
@@ -4,7 +4,7 @@ import {
 	type AzureOpenAIResponsesOptions,
 	streamAzureOpenAIResponses,
 } from "@oh-my-pi/pi-ai/providers/azure-openai-responses";
-import type { Context, FetchImpl, Model, ModelSpec, Tool } from "@oh-my-pi/pi-ai/types";
+import type { Context, FetchImpl, Model, ModelSpec, SimpleStreamOptions, Tool } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 
@@ -19,6 +19,19 @@ const azureModel: Model<"azure-openai-responses"> = buildModel({
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 	contextWindow: 400000,
 	maxTokens: 128000,
+});
+
+const legacyAzureCodexModel: Model<"azure-openai-responses"> = buildModel({
+	id: "gpt-5.3-codex",
+	name: "GPT-5.3 Codex",
+	api: "azure-openai-responses",
+	provider: "azure",
+	baseUrl: azureModel.baseUrl,
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 400_000,
+	maxTokens: 128_000,
 });
 
 function createAbortedSignal(): AbortSignal {
@@ -40,6 +53,32 @@ function createSseResponse(events: unknown[]): Response {
 		status: 200,
 		headers: { "content-type": "text/event-stream" },
 	});
+}
+
+async function captureLegacyAzureCodexPayload(
+	options: Pick<SimpleStreamOptions, "reasoning" | "reasoningSummary">,
+): Promise<Record<string, unknown>> {
+	let capturedBody: Record<string, unknown> | undefined;
+	const fetchMock: FetchImpl = async (_input, init) => {
+		capturedBody = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
+		return createSseResponse([
+			{
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+				},
+			},
+		]);
+	};
+
+	await streamSimple(
+		legacyAzureCodexModel,
+		{ messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }] },
+		{ apiKey: "test-key", fetch: fetchMock, ...options },
+	).result();
+	if (!capturedBody) throw new Error("Azure Responses request body was not captured");
+	return capturedBody;
 }
 
 function createAssistantMessage(text: string, textSignature?: string) {
@@ -97,87 +136,25 @@ describe("azure openai responses streaming", () => {
 		]);
 	});
 
-	it("omits reasoning summaries for pre-5.4 Azure Codex models through streamSimple", async () => {
-		const unsupportedModel: Model<"azure-openai-responses"> = buildModel({
-			id: "gpt-5.3-codex",
-			name: "GPT-5.3 Codex",
-			api: "azure-openai-responses",
-			provider: "azure",
-			baseUrl: azureModel.baseUrl,
-			reasoning: true,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 400_000,
-			maxTokens: 128_000,
+	it("omits explicitly requested summaries for legacy Azure Codex models", async () => {
+		const payload = await captureLegacyAzureCodexPayload({
+			reasoning: Effort.High,
+			reasoningSummary: "detailed",
 		});
-		let capturedBody: Record<string, unknown> | undefined;
-		const fetchMock: FetchImpl = async (_input, init) => {
-			capturedBody = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
-			return createSseResponse([
-				{
-					type: "response.completed",
-					response: {
-						status: "completed",
-						usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
-					},
-				},
-			]);
-		};
 
-		const result = await streamSimple(
-			unsupportedModel,
-			{ messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }] },
-			{
-				apiKey: "test-key",
-				fetch: fetchMock,
-				reasoning: Effort.High,
-				reasoningSummary: "detailed",
-			},
-		).result();
+		expect(payload.reasoning).toEqual({ effort: "high" });
+	});
 
-		expect(result.stopReason).toBe("stop");
-		expect(capturedBody?.reasoning).toEqual({ effort: "high" });
+	it("omits the summary field for an unconfigured legacy Azure Codex reasoning request", async () => {
+		const payload = await captureLegacyAzureCodexPayload({ reasoning: Effort.High });
+
+		expect(payload.reasoning).toEqual({ effort: "high" });
 	});
 
 	it("does not synthesize reasoning effort when only an unsupported summary is requested", async () => {
-		const unsupportedModel: Model<"azure-openai-responses"> = buildModel({
-			id: "gpt-5.3-codex",
-			name: "GPT-5.3 Codex",
-			api: "azure-openai-responses",
-			provider: "azure",
-			baseUrl: azureModel.baseUrl,
-			reasoning: true,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 400_000,
-			maxTokens: 128_000,
-		});
-		let capturedBody: Record<string, unknown> | undefined;
-		const fetchMock: FetchImpl = async (_input, init) => {
-			capturedBody = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
-			return createSseResponse([
-				{
-					type: "response.completed",
-					response: {
-						status: "completed",
-						usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
-					},
-				},
-			]);
-		};
+		const payload = await captureLegacyAzureCodexPayload({ reasoningSummary: "detailed" });
 
-		const result = await streamSimple(
-			unsupportedModel,
-			{ messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }] },
-			{
-				apiKey: "test-key",
-				fetch: fetchMock,
-				reasoningSummary: "detailed",
-			},
-		).result();
-
-		expect(result.stopReason).toBe("stop");
-		expect(capturedBody?.reasoning).toBeUndefined();
+		expect(payload.reasoning).toBeUndefined();
 	});
 
 	it("sends an async onPayload replacement body", async () => {

--- a/packages/ai/test/azure-openai-responses-stream.test.ts
+++ b/packages/ai/test/azure-openai-responses-stream.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import { streamSimple } from "@oh-my-pi/pi-ai";
 import {
 	type AzureOpenAIResponsesOptions,
 	streamAzureOpenAIResponses,
 } from "@oh-my-pi/pi-ai/providers/azure-openai-responses";
 import type { Context, FetchImpl, Model, ModelSpec, Tool } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 
 const azureModel: Model<"azure-openai-responses"> = buildModel({
 	id: "gpt-5-mini",
@@ -93,6 +95,48 @@ describe("azure openai responses streaming", () => {
 			{ role: "system", content: "Second instruction" },
 			{ role: "user", content: [{ type: "input_text", text: "Say hello" }] },
 		]);
+	});
+
+	it("omits reasoning summaries for pre-5.4 Azure Codex models through streamSimple", async () => {
+		const unsupportedModel: Model<"azure-openai-responses"> = buildModel({
+			id: "gpt-5.3-codex",
+			name: "GPT-5.3 Codex",
+			api: "azure-openai-responses",
+			provider: "azure",
+			baseUrl: azureModel.baseUrl,
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400_000,
+			maxTokens: 128_000,
+		});
+		let capturedBody: Record<string, unknown> | undefined;
+		const fetchMock: FetchImpl = async (_input, init) => {
+			capturedBody = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
+			return createSseResponse([
+				{
+					type: "response.completed",
+					response: {
+						status: "completed",
+						usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+					},
+				},
+			]);
+		};
+
+		const result = await streamSimple(
+			unsupportedModel,
+			{ messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }] },
+			{
+				apiKey: "test-key",
+				fetch: fetchMock,
+				reasoning: Effort.High,
+				reasoningSummary: "detailed",
+			},
+		).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(capturedBody?.reasoning).toEqual({ effort: "high" });
 	});
 
 	it("sends an async onPayload replacement body", async () => {

--- a/packages/ai/test/azure-openai-responses-stream.test.ts
+++ b/packages/ai/test/azure-openai-responses-stream.test.ts
@@ -139,6 +139,47 @@ describe("azure openai responses streaming", () => {
 		expect(capturedBody?.reasoning).toEqual({ effort: "high" });
 	});
 
+	it("does not synthesize reasoning effort when only an unsupported summary is requested", async () => {
+		const unsupportedModel: Model<"azure-openai-responses"> = buildModel({
+			id: "gpt-5.3-codex",
+			name: "GPT-5.3 Codex",
+			api: "azure-openai-responses",
+			provider: "azure",
+			baseUrl: azureModel.baseUrl,
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400_000,
+			maxTokens: 128_000,
+		});
+		let capturedBody: Record<string, unknown> | undefined;
+		const fetchMock: FetchImpl = async (_input, init) => {
+			capturedBody = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
+			return createSseResponse([
+				{
+					type: "response.completed",
+					response: {
+						status: "completed",
+						usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+					},
+				},
+			]);
+		};
+
+		const result = await streamSimple(
+			unsupportedModel,
+			{ messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }] },
+			{
+				apiKey: "test-key",
+				fetch: fetchMock,
+				reasoningSummary: "detailed",
+			},
+		).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(capturedBody?.reasoning).toBeUndefined();
+	});
+
 	it("sends an async onPayload replacement body", async () => {
 		let capturedBody: Record<string, unknown> | undefined;
 		const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {

--- a/packages/ai/test/azure-openai-responses-stream.test.ts
+++ b/packages/ai/test/azure-openai-responses-stream.test.ts
@@ -199,6 +199,19 @@ describe("azure openai responses streaming", () => {
 			{ reasoning: Effort.High, reasoningSummary: "detailed" },
 			incompatibleAzureCodexModel,
 		);
+		expect(payload.reasoning).toEqual({ effort: "high" });
+	});
+
+	it("omits requested summaries when Azure routes through a compatible gateway", async () => {
+		const payload = await captureAzurePayload(
+			{ messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }] },
+			legacyAzureCodexModel,
+			{
+				azureBaseUrl: "https://gateway.example/openai/v1",
+				reasoning: "high",
+				reasoningSummary: "detailed",
+			},
+		);
 
 		expect(payload.reasoning).toEqual({ effort: "high" });
 	});

--- a/packages/ai/test/openai-codex-responses-lite.test.ts
+++ b/packages/ai/test/openai-codex-responses-lite.test.ts
@@ -174,6 +174,17 @@ describe("openai-codex optional response controls", () => {
 		expect(body.reasoning).toEqual({ effort: "none" });
 	});
 
+	it("omits reasoning.summary when endpoint compatibility disables it", async () => {
+		const model = createCodexModel("gpt-5.5", { compat: { supportsReasoningSummary: false } });
+		const transformed = await transformRequestBody({ model: model.id }, model, {
+			reasoningEffort: "medium",
+			reasoningSummary: "detailed",
+		});
+
+		expect(transformed.reasoning).toEqual({ effort: "medium" });
+		expect("stream_options" in transformed).toBe(false);
+	});
+
 	it("forces reasoning.context to all_turns for Responses Lite", async () => {
 		const model = createCodexModel("gpt-5.5");
 

--- a/packages/ai/test/openai-codex-responses-lite.test.ts
+++ b/packages/ai/test/openai-codex-responses-lite.test.ts
@@ -129,13 +129,11 @@ function createCodexFetchMock(sse: string, onRequest: (captured: CapturedCodexRe
 }
 
 describe("openai-codex optional response controls", () => {
-	it("defaults reasoning.summary on and forwards explicit controls", async () => {
+	it("preserves provider-default summary omission and forwards explicit controls", async () => {
 		const model = createCodexModel("gpt-5.5");
 
-		// The backend emits no reasoning summaries at all unless `summary` is
-		// sent, so an unset `reasoningSummary` must still request one.
 		const defaulted = await transformRequestBody({ model: model.id }, model, { reasoningEffort: "medium" });
-		expect(defaulted.reasoning).toEqual({ effort: "medium", summary: "auto" });
+		expect(defaulted.reasoning).toEqual({ effort: "medium" });
 		expect("context" in (defaulted.reasoning ?? {})).toBe(false);
 		expect("text" in defaulted).toBe(false);
 		expect("stream_options" in defaulted).toBe(false);
@@ -198,7 +196,7 @@ describe("openai-codex optional response controls", () => {
 			responsesLite: true,
 			reasoningContext: "current_turn",
 		});
-		expect(noneEffort.reasoning).toEqual({ effort: "none", summary: "auto", context: "all_turns" });
+		expect(noneEffort.reasoning).toEqual({ effort: "none", context: "all_turns" });
 
 		const plainRequest = await transformRequestBody({ model: model.id }, model, {
 			responsesLite: false,

--- a/packages/ai/test/openai-codex-responses-lite.test.ts
+++ b/packages/ai/test/openai-codex-responses-lite.test.ts
@@ -161,6 +161,15 @@ describe("openai-codex optional response controls", () => {
 
 		expect(transformed.reasoning).toEqual({ summary: "detailed" });
 	});
+
+	it("omits unsupported summary-only requests without emitting an empty reasoning object", async () => {
+		const model = createCodexModel("gpt-5.3-codex");
+		const transformed = await transformRequestBody({ model: model.id }, model, {
+			reasoningSummary: "detailed",
+		});
+
+		expect(transformed.reasoning).toBeUndefined();
+	});
 	it("omits reasoning.summary when explicitly suppressed", async () => {
 		const model = createCodexModel("gpt-5.5");
 		const suppressed = await transformRequestBody({ model: model.id }, model, {

--- a/packages/ai/test/openai-codex-responses-lite.test.ts
+++ b/packages/ai/test/openai-codex-responses-lite.test.ts
@@ -153,6 +153,14 @@ describe("openai-codex optional response controls", () => {
 		expect("stream_options" in explicit).toBe(false);
 	});
 
+	it("forwards a supported summary request without synthesizing effort", async () => {
+		const model = createCodexModel("gpt-5.5");
+		const transformed = await transformRequestBody({ model: model.id }, model, {
+			reasoningSummary: "detailed",
+		});
+
+		expect(transformed.reasoning).toEqual({ summary: "detailed" });
+	});
 	it("omits reasoning.summary when explicitly suppressed", async () => {
 		const model = createCodexModel("gpt-5.5");
 		const suppressed = await transformRequestBody({ model: model.id }, model, {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -620,6 +620,43 @@ describe("openai-codex streaming", () => {
 		expect(capturedText).toEqual({ verbosity: "low" });
 	});
 
+	it("forwards SimpleStreamOptions reasoningSummary into supported Codex request bodies", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-stream-");
+		setAgentDir(tempDir.path());
+		const token = createCodexTestToken();
+		const context = createCodexTestContext();
+		const model = {
+			...createCodexTestModel("https://chatgpt.com/backend-api"),
+			id: "gpt-5.6-sol",
+			name: "GPT-5.6 Sol",
+			preferWebsockets: false,
+			useResponsesLite: true,
+		};
+		let capturedBody: Record<string, unknown> | undefined;
+		const fetchMock: FetchImpl = async (_input, init) => {
+			capturedBody = JSON.parse(decodeCodexRequestBody(init?.body)) as Record<string, unknown>;
+			return new Response(createCompletedCodexSse("Hello"), {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			});
+		};
+
+		const result = await streamSimple(model, context, {
+			apiKey: token,
+			fetch: fetchMock,
+			reasoning: Effort.XHigh,
+			reasoningSummary: "detailed",
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(capturedBody?.reasoning).toEqual({
+			effort: "xhigh",
+			summary: "detailed",
+			context: "all_turns",
+		});
+		expect(capturedBody?.stream_options).toEqual({ reasoning_summary_delivery: "sequential_cutoff" });
+	});
+
 	it("omits optional response controls from default SimpleStreamOptions", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
 		setAgentDir(tempDir.path());

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -641,20 +641,22 @@ describe("openai-codex streaming", () => {
 			});
 		};
 
-		const result = await streamSimple(model, context, {
-			apiKey: token,
-			fetch: fetchMock,
-			reasoning: Effort.XHigh,
-			reasoningSummary: "detailed",
-		}).result();
+		await withEnv({ PI_CODEX_CONCURRENT_SUMMARIES: "1" }, async () => {
+			const result = await streamSimple(model, context, {
+				apiKey: token,
+				fetch: fetchMock,
+				reasoning: Effort.XHigh,
+				reasoningSummary: "detailed",
+			}).result();
 
-		expect(result.stopReason).toBe("stop");
-		expect(capturedBody?.reasoning).toEqual({
-			effort: "xhigh",
-			summary: "detailed",
-			context: "all_turns",
+			expect(result.stopReason).toBe("stop");
+			expect(capturedBody?.reasoning).toEqual({
+				effort: "xhigh",
+				summary: "detailed",
+				context: "all_turns",
+			});
+			expect(capturedBody?.stream_options).toEqual({ reasoning_summary_delivery: "sequential_cutoff" });
 		});
-		expect(capturedBody?.stream_options).toEqual({ reasoning_summary_delivery: "sequential_cutoff" });
 	});
 
 	it("omits optional response controls from default SimpleStreamOptions", async () => {

--- a/packages/ai/test/openai-responses-sampling-params.test.ts
+++ b/packages/ai/test/openai-responses-sampling-params.test.ts
@@ -107,6 +107,25 @@ describe("openai-responses reasoning-summary defaults", () => {
 		expect(body.reasoning).toEqual({ effort: "high" });
 	});
 
+	it("forwards summary-only requests without inventing a reasoning effort", async () => {
+		const model: Model<"openai-responses"> = buildModel({
+			id: "gpt-5-pro",
+			name: "GPT-5 Pro",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400_000,
+			maxTokens: 128_000,
+		});
+
+		const body = await drain(model, { reasoningSummary: "detailed" });
+
+		expect(body.reasoning).toEqual({ summary: "detailed" });
+	});
+
 	it("omits explicitly requested summaries when endpoint compatibility disables them", async () => {
 		const model: Model<"openai-responses"> = buildModel({
 			id: "gpt-5.4",

--- a/packages/ai/test/openai-responses-sampling-params.test.ts
+++ b/packages/ai/test/openai-responses-sampling-params.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { Context, FetchImpl, Model, SimpleStreamOptions } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
@@ -84,6 +85,26 @@ describe("openai-responses reasoning-summary defaults", () => {
 		const model = getBundledModel("openai", "gpt-5.4") as Model<"openai-responses">;
 
 		const body = await drain(model, { reasoning: Effort.High });
+
+		expect(body.reasoning).toEqual({ effort: "high" });
+	});
+
+	it("omits explicitly requested summaries when endpoint compatibility disables them", async () => {
+		const model: Model<"openai-responses"> = buildModel({
+			id: "gpt-5.4",
+			name: "GPT-5.4 via incompatible gateway",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://gateway.example/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400_000,
+			maxTokens: 128_000,
+			compat: { supportsReasoningSummary: false },
+		});
+
+		const body = await drain(model, { reasoning: Effort.High, reasoningSummary: "detailed" });
 
 		expect(body.reasoning).toEqual({ effort: "high" });
 	});

--- a/packages/ai/test/openai-responses-sampling-params.test.ts
+++ b/packages/ai/test/openai-responses-sampling-params.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { streamSimple } from "@oh-my-pi/pi-ai/stream";
-import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
+import type { Context, FetchImpl, Model, SimpleStreamOptions } from "@oh-my-pi/pi-ai/types";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 function mockSseFetch(): { fetchMock: FetchImpl; captured: Record<string, unknown> } {
@@ -35,7 +36,7 @@ const ctx: Context = {
 
 async function drain(
 	model: Model<"openai-responses">,
-	options: { forceReasoningOff?: boolean } = {},
+	options: SimpleStreamOptions = {},
 ): Promise<Record<string, unknown>> {
 	const { fetchMock, captured } = mockSseFetch();
 	const stream = streamSimple(model, ctx, { apiKey: "k", fetch: fetchMock, temperature: 0, ...options });
@@ -75,5 +76,15 @@ describe("openai-responses sampling-param gating (#5606)", () => {
 		const model = getBundledModel("openai", "gpt-5") as Model<"openai-responses">;
 		const body = await drain(model, { forceReasoningOff: true });
 		expect(body.reasoning).toEqual({ effort: "none" });
+	});
+});
+
+describe("openai-responses reasoning-summary defaults", () => {
+	it("omits the summary field for an unconfigured official OpenAI reasoning request", async () => {
+		const model = getBundledModel("openai", "gpt-5.4") as Model<"openai-responses">;
+
+		const body = await drain(model, { reasoning: Effort.High });
+
+		expect(body.reasoning).toEqual({ effort: "high" });
 	});
 });

--- a/packages/ai/test/openai-responses-sampling-params.test.ts
+++ b/packages/ai/test/openai-responses-sampling-params.test.ts
@@ -35,8 +35,8 @@ const ctx: Context = {
 	messages: [{ role: "user", content: "ping", timestamp: Date.now() }],
 };
 
-async function drain(
-	model: Model<"openai-responses">,
+async function drain<TApi extends "openai-responses" | "azure-openai-responses">(
+	model: Model<TApi>,
 	options: SimpleStreamOptions = {},
 ): Promise<Record<string, unknown>> {
 	const { fetchMock, captured } = mockSseFetch();
@@ -83,6 +83,24 @@ describe("openai-responses sampling-param gating (#5606)", () => {
 describe("openai-responses reasoning-summary defaults", () => {
 	it("omits the summary field for an unconfigured official OpenAI reasoning request", async () => {
 		const model = getBundledModel("openai", "gpt-5.4") as Model<"openai-responses">;
+
+		const body = await drain(model, { reasoning: Effort.High });
+
+		expect(body.reasoning).toEqual({ effort: "high" });
+	});
+	it("omits the summary field for the Azure OpenAI provider alias", async () => {
+		const model: Model<"azure-openai-responses"> = buildModel({
+			id: "gpt-5.4",
+			name: "GPT-5.4 on Azure OpenAI",
+			api: "azure-openai-responses",
+			provider: "azure-openai",
+			baseUrl: "https://example.openai.azure.com/openai/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400_000,
+			maxTokens: 128_000,
+		});
 
 		const body = await drain(model, { reasoning: Effort.High });
 

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -125,7 +125,7 @@ function detectStreamMarkupHealingPattern(
 }
 
 /** Strict official-OpenAI check: provider id `openai` and an `api.openai.com` host (missing baseUrl defaults there). */
-function isOfficialOpenAIEndpoint(provider: string, baseUrl: string): boolean {
+export function isOfficialOpenAIEndpoint(provider: string, baseUrl: string): boolean {
 	if (provider !== "openai") return false;
 	if (!baseUrl) return true;
 	try {

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -125,7 +125,7 @@ function detectStreamMarkupHealingPattern(
 }
 
 /** Strict official-OpenAI check: provider id `openai` and an `api.openai.com` host (missing baseUrl defaults there). */
-export function isOfficialOpenAIEndpoint(provider: string, baseUrl: string): boolean {
+function isOfficialOpenAIEndpoint(provider: string, baseUrl: string): boolean {
 	if (provider !== "openai") return false;
 	if (!baseUrl) return true;
 	try {
@@ -846,6 +846,7 @@ type ResponsesOnlyCompat = Omit<ResolvedOpenAIResponsesCompat, keyof ResolvedOpe
 function pickResponsesOnly(compat: ResolvedOpenAIResponsesCompat): ResponsesOnlyCompat {
 	return {
 		supportsLongPromptCacheRetention: compat.supportsLongPromptCacheRetention,
+		supportsReasoningSummary: compat.supportsReasoningSummary,
 		strictResponsesPairing: compat.strictResponsesPairing,
 		supportsImageDetailOriginal: compat.supportsImageDetailOriginal,
 		supportsObfuscationOptOut: compat.supportsObfuscationOptOut,

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -850,7 +850,6 @@ function pickResponsesOnly(compat: ResolvedOpenAIResponsesCompat): ResponsesOnly
 		strictResponsesPairing: compat.strictResponsesPairing,
 		supportsImageDetailOriginal: compat.supportsImageDetailOriginal,
 		supportsObfuscationOptOut: compat.supportsObfuscationOptOut,
-		supportsReasoningSummary: compat.supportsReasoningSummary,
 		isVercelGatewayHost: compat.isVercelGatewayHost,
 	} satisfies ResponsesOnlyCompat;
 }

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -228,6 +228,11 @@ export const isOpenAIModelId = memo((modelId: string): boolean => {
 	);
 });
 
+/** OpenAI Codex ids, including versionless aliases such as `codex-mini` and `codex-mini-latest`. */
+export const isOpenAICodexModelId = memo((modelId: string): boolean => {
+	return /(^|[-._])codex(?:[-.:_]|$)/i.test(bareModelId(modelId));
+});
+
 /** OpenAI models at or above the gpt-5.4 wire generation, keyed off the parsed version. */
 const isOpenAIWireGen54Plus = memo((modelId: string): boolean => {
 	const parsed = parseOpenAIModel(bareModelId(modelId));

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -188,6 +188,8 @@ export interface OpenAICompat {
 	supportsMultipleSystemMessages?: boolean;
 	/** Whether the provider supports `reasoning_effort`. Default: auto-detected from URL. */
 	supportsReasoningEffort?: boolean;
+	/** Whether Responses requests accept `reasoning.summary`. Default: true; set false for incompatible endpoints. */
+	supportsReasoningSummary?: boolean;
 	/** Optional mapping from pi-ai reasoning levels to provider/model-specific `reasoning_effort` values. */
 	reasoningEffortMap?: Partial<Record<Effort, string>>;
 	/** Whether the provider supports `stream_options: { include_usage: true }` for token usage in streaming responses. Default: true. */
@@ -660,6 +662,7 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 			OpenAICompat,
 			| "supportsDeveloperRole"
 			| "supportsReasoningEffort"
+			| "supportsReasoningSummary"
 			| "reasoningEffortMap"
 			| "supportsReasoningParams"
 			| "supportsSamplingParams"

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -372,6 +372,25 @@ describe("xAI Responses reasoning-effort suppression", () => {
 	});
 });
 
+describe("Responses reasoning-summary compatibility", () => {
+	it("defaults support on and honors an explicit opt-out", () => {
+		const spec = {
+			id: "gpt-5.6-sol",
+			provider: "openai-codex",
+			name: "GPT-5.6 Sol",
+			baseUrl: "https://gateway.example/codex",
+		};
+
+		expect(buildOpenAIResponsesCompat(spec).supportsReasoningSummary).toBe(true);
+		expect(
+			buildOpenAIResponsesCompat({
+				...spec,
+				compat: { supportsReasoningSummary: false },
+			}).supportsReasoningSummary,
+		).toBe(false);
+	});
+});
+
 describe("openai-completions wire-quirk compat detection", () => {
 	it("derives wireModelIdMode from provider/host", () => {
 		expect(buildOpenAICompat(completionsSpec({ provider: "firepass" })).wireModelIdMode).toBe("firepass");

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -613,6 +613,7 @@
 - Fixed retry-fallback selection switching to a fallback model with a context window too small to hold the current session context.
 - Fixed OpenCode discovery ignoring `opencode.jsonc` files and rejecting comments in `opencode.json`.
 - Fixed WSL2 startup hanging forever when the Windows interop pipe is wedged: the WSL host-home discovery probes (`cmd.exe`, `wslpath`) now run under a 500ms hard timeout and fall back to the Linux `$HOME`/`~/.omp` candidates ([#8402](https://github.com/can1357/oh-my-pi/issues/8402)).
+- Added an OpenAI reasoning-summary setting with provider-default, none, auto, concise, and detailed modes, allowing supported Responses and Codex models to opt back into visible reasoning titles without restoring incompatible request defaults globally. ([#8006](https://github.com/can1357/oh-my-pi/issues/8006))
 
 ## [17.2.15] - 2026-08-12
 
@@ -713,9 +714,6 @@
 - Fixed long-running sessions leaking memory for every completed keep-alive `task`/scout subagent: a disposed (parked) subagent's `AgentSession` stayed pinned through the lifecycle adoption record's reviver closure, and `dispose()` never released the message array, append-only provider transcript, session-manager entries, or the raw-SSE debug buffer, so heavy transcripts and captured provider wire frames accumulated for the process lifetime ([#8003](https://github.com/can1357/oh-my-pi/issues/8003)).
 - Fixed Z.AI web search dropping sources and exposing raw JSON when MCP responses double-encode content text ([#8000](https://github.com/can1357/oh-my-pi/issues/8000)).
 - Fixed `/handoff` masking empty/whitespace-only generation and harness-initiated aborts as "Handoff cancelled"; manual empty generation now surfaces a logged failure, harness aborts preserve their reason (or report "Handoff aborted by session"), and auto-handoff still falls back to context-full compaction ([#7993](https://github.com/can1357/oh-my-pi/issues/7993)).
-### Added
-
-- Added an OpenAI reasoning-summary setting with provider-default, none, auto, concise, and detailed modes, allowing supported Responses and Codex models to opt back into visible reasoning titles without restoring incompatible request defaults globally. ([#8006](https://github.com/can1357/oh-my-pi/issues/8006))
 
 ## [17.2.11] - 2026-08-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -713,6 +713,9 @@
 - Fixed long-running sessions leaking memory for every completed keep-alive `task`/scout subagent: a disposed (parked) subagent's `AgentSession` stayed pinned through the lifecycle adoption record's reviver closure, and `dispose()` never released the message array, append-only provider transcript, session-manager entries, or the raw-SSE debug buffer, so heavy transcripts and captured provider wire frames accumulated for the process lifetime ([#8003](https://github.com/can1357/oh-my-pi/issues/8003)).
 - Fixed Z.AI web search dropping sources and exposing raw JSON when MCP responses double-encode content text ([#8000](https://github.com/can1357/oh-my-pi/issues/8000)).
 - Fixed `/handoff` masking empty/whitespace-only generation and harness-initiated aborts as "Handoff cancelled"; manual empty generation now surfaces a logged failure, harness aborts preserve their reason (or report "Handoff aborted by session"), and auto-handoff still falls back to context-full compaction ([#7993](https://github.com/can1357/oh-my-pi/issues/7993)).
+### Added
+
+- Added an OpenAI reasoning-summary setting with provider-default, none, auto, concise, and detailed modes, allowing supported Responses and Codex models to opt back into visible reasoning titles without restoring incompatible request defaults globally. ([#8006](https://github.com/can1357/oh-my-pi/issues/8006))
 
 ## [17.2.11] - 2026-08-07
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1409,6 +1409,29 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	openaiReasoningSummary: {
+		type: "enum",
+		values: ["provider-default", "none", "auto", "concise", "detailed"] as const,
+		default: "provider-default",
+		ui: {
+			tab: "model",
+			group: "Thinking",
+			label: "OpenAI Reasoning Summary",
+			description: "Summary detail requested from OpenAI Responses and Codex models",
+			options: [
+				{
+					value: "provider-default",
+					label: "Provider Default",
+					description: "Omit the request field and use the provider/model default",
+				},
+				{ value: "none", label: "None", description: "Do not request a reasoning summary" },
+				{ value: "auto", label: "Auto", description: "Let the model choose summary detail" },
+				{ value: "concise", label: "Concise", description: "Request a short reasoning summary" },
+				{ value: "detailed", label: "Detailed", description: "Request the most detailed available summary" },
+			],
+		},
+	},
+
 	"model.loopGuard.enabled": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -11,8 +11,7 @@
  * and OpenRouter response-cache hits across advisor calls.
  */
 import type { StreamFn } from "@oh-my-pi/pi-agent-core";
-import { isOfficialCodexApiUrl, type SimpleStreamOptions, streamSimple } from "@oh-my-pi/pi-ai";
-import { isOfficialOpenAIEndpoint } from "@oh-my-pi/pi-catalog/compat/openai";
+import { type SimpleStreamOptions, streamSimple } from "@oh-my-pi/pi-ai";
 import { isAnthropicFableOrMythosModel } from "@oh-my-pi/pi-catalog/identity";
 import { type Settings, validateProviderMaxInFlightRequests } from "../config/settings";
 
@@ -50,12 +49,18 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 		// implicitly disables the short-entry keep-alive refresh loop).
 		const cacheRetentionSetting = settings.get("providers.cacheRetention");
 		const cacheRetention = cacheRetentionSetting === "auto" ? undefined : cacheRetentionSetting;
+		const supportsReasoningSummary =
+			(model.api === "openai-responses" ||
+				model.api === "azure-openai-responses" ||
+				model.api === "openai-codex-responses") &&
+			model.compat !== undefined &&
+			"supportsReasoningSummary" in model.compat &&
+			model.compat.supportsReasoningSummary === true;
 		const usesOpenAIReasoningSummaries =
-			(model.api === "openai-responses" && isOfficialOpenAIEndpoint(model.provider, model.baseUrl)) ||
-			(model.api === "azure-openai-responses" && model.provider === "azure") ||
-			(model.api === "openai-codex-responses" &&
-				model.provider === "openai-codex" &&
-				isOfficialCodexApiUrl(model.baseUrl));
+			supportsReasoningSummary &&
+			((model.api === "openai-responses" && model.provider === "openai") ||
+				(model.api === "azure-openai-responses" && model.provider === "azure") ||
+				(model.api === "openai-codex-responses" && model.provider === "openai-codex"));
 		const summarySetting = settings.get("openaiReasoningSummary");
 		const configuredReasoningSummary =
 			!usesOpenAIReasoningSummaries || summarySetting === "provider-default"

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -59,7 +59,8 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 		const usesOpenAIReasoningSummaries =
 			supportsReasoningSummary &&
 			((model.api === "openai-responses" && isOfficialOpenAIEndpoint(model.provider, model.baseUrl)) ||
-				(model.api === "azure-openai-responses" && model.provider === "azure") ||
+				(model.api === "azure-openai-responses" &&
+					(model.provider === "azure" || model.provider === "azure-openai")) ||
 				(model.api === "openai-codex-responses" &&
 					model.provider === "openai-codex" &&
 					isOfficialCodexApiUrl(model.baseUrl)));

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -12,6 +12,7 @@
  */
 import type { StreamFn } from "@oh-my-pi/pi-agent-core";
 import { type SimpleStreamOptions, streamSimple } from "@oh-my-pi/pi-ai";
+import { isOfficialOpenAIEndpoint } from "@oh-my-pi/pi-catalog/compat/openai";
 import { isAnthropicFableOrMythosModel } from "@oh-my-pi/pi-catalog/identity";
 import { type Settings, validateProviderMaxInFlightRequests } from "../config/settings";
 
@@ -50,7 +51,7 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 		const cacheRetentionSetting = settings.get("providers.cacheRetention");
 		const cacheRetention = cacheRetentionSetting === "auto" ? undefined : cacheRetentionSetting;
 		const usesOpenAIReasoningSummaries =
-			(model.api === "openai-responses" && model.provider === "openai") ||
+			(model.api === "openai-responses" && isOfficialOpenAIEndpoint(model.provider, model.baseUrl)) ||
 			(model.api === "azure-openai-responses" && model.provider === "azure") ||
 			(model.api === "openai-codex-responses" && model.provider === "openai-codex");
 		const summarySetting = settings.get("openaiReasoningSummary");

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -54,8 +54,7 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 				model.api === "azure-openai-responses" ||
 				model.api === "openai-codex-responses") &&
 			model.compat !== undefined &&
-			"supportsReasoningSummary" in model.compat &&
-			model.compat.supportsReasoningSummary === true;
+			(!("supportsReasoningSummary" in model.compat) || model.compat.supportsReasoningSummary !== false);
 		const usesOpenAIReasoningSummaries =
 			supportsReasoningSummary &&
 			((model.api === "openai-responses" && model.provider === "openai") ||

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -11,7 +11,7 @@
  * and OpenRouter response-cache hits across advisor calls.
  */
 import type { StreamFn } from "@oh-my-pi/pi-agent-core";
-import { type SimpleStreamOptions, streamSimple } from "@oh-my-pi/pi-ai";
+import { isOfficialCodexApiUrl, type SimpleStreamOptions, streamSimple } from "@oh-my-pi/pi-ai";
 import { isOfficialOpenAIEndpoint } from "@oh-my-pi/pi-catalog/compat/openai";
 import { isAnthropicFableOrMythosModel } from "@oh-my-pi/pi-catalog/identity";
 import { type Settings, validateProviderMaxInFlightRequests } from "../config/settings";
@@ -53,7 +53,9 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 		const usesOpenAIReasoningSummaries =
 			(model.api === "openai-responses" && isOfficialOpenAIEndpoint(model.provider, model.baseUrl)) ||
 			(model.api === "azure-openai-responses" && model.provider === "azure") ||
-			(model.api === "openai-codex-responses" && model.provider === "openai-codex");
+			(model.api === "openai-codex-responses" &&
+				model.provider === "openai-codex" &&
+				isOfficialCodexApiUrl(model.baseUrl));
 		const summarySetting = settings.get("openaiReasoningSummary");
 		const configuredReasoningSummary =
 			!usesOpenAIReasoningSummaries || summarySetting === "provider-default"

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -2,9 +2,9 @@
  * Settings-aware stream wrapper shared by the main agent (sdk.ts) and the
  * advisor agent (AgentSession.#buildAdvisorRuntime).
  *
- * verbosity, stream watchdog budgets, per-provider in-flight caps, and the loop
- * guard out of `Settings`
- * per request, layering them onto whatever options the caller passed. Before
+ * It reads provider routing, OpenAI response controls, stream watchdog budgets,
+ * per-provider in-flight caps, and the loop guard from `Settings` per request,
+ * layering them onto whatever options the caller passed. Before
  * this helper existed, advisor turns called bare `streamSimple` while the main
  * turn went through an inline closure that read these settings — so an advisor on
  * OpenRouter never saw `providers.openrouterVariant`, breaking sticky routing
@@ -25,7 +25,9 @@ function timeoutSecondsToMs(value: number): number | undefined {
  * Build a {@link StreamFn} that reads provider routing/guard settings from
  * `settings` per call and forwards to `base` (defaults to `streamSimple`).
  *
- * Caller-supplied `streamOptions` always win — the helper only fills holes.
+ * Caller-supplied `streamOptions` win when filling ordinary settings. The
+ * cross-provider `omitThinking` suppressor is the deliberate exception: once
+ * enabled, a per-call summary option cannot turn provider summaries back on.
  */
 export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn = streamSimple): StreamFn {
 	return (model, context, streamOptions) => {
@@ -47,6 +49,23 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 		// implicitly disables the short-entry keep-alive refresh loop).
 		const cacheRetentionSetting = settings.get("providers.cacheRetention");
 		const cacheRetention = cacheRetentionSetting === "auto" ? undefined : cacheRetentionSetting;
+		const usesOpenAIReasoningSummaries =
+			(model.api === "openai-responses" && model.provider === "openai") ||
+			(model.api === "azure-openai-responses" && model.provider === "azure") ||
+			(model.api === "openai-codex-responses" && model.provider === "openai-codex");
+		const summarySetting = settings.get("openaiReasoningSummary");
+		const configuredReasoningSummary =
+			!usesOpenAIReasoningSummaries || summarySetting === "provider-default"
+				? undefined
+				: summarySetting === "none"
+					? null
+					: summarySetting;
+		const hideThinkingSummary = settings.get("omitThinking") || streamOptions?.hideThinkingSummary === true;
+		const reasoningSummary = hideThinkingSummary
+			? null
+			: streamOptions?.reasoningSummary !== undefined
+				? streamOptions.reasoningSummary
+				: configuredReasoningSummary;
 		const streamFirstEventTimeoutMs = timeoutSecondsToMs(settings.get("providers.streamFirstEventTimeoutSeconds"));
 		const streamIdleTimeoutMs = timeoutSecondsToMs(settings.get("providers.streamIdleTimeoutSeconds"));
 		// Server-side fallback (opt-in): when the user enables it AND the
@@ -67,6 +86,7 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 			antigravityEndpointMode: streamOptions?.antigravityEndpointMode ?? antigravityEndpointMode,
 			textVerbosity: streamOptions?.textVerbosity ?? textVerbosity,
 			cacheRetention: streamOptions?.cacheRetention ?? cacheRetention,
+			reasoningSummary,
 			streamFirstEventTimeoutMs: streamOptions?.streamFirstEventTimeoutMs ?? streamFirstEventTimeoutMs,
 			streamIdleTimeoutMs: streamOptions?.streamIdleTimeoutMs ?? streamIdleTimeoutMs,
 			maxRetryDelayMs: streamOptions?.maxRetryDelayMs ?? settings.get("retry.maxDelayMs"),
@@ -78,7 +98,7 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 				checkAssistantContent: settings.get("model.loopGuard.checkAssistantContent"),
 				...streamOptions?.loopGuard,
 			},
-			hideThinkingSummary: streamOptions?.hideThinkingSummary ?? settings.get("omitThinking"),
+			hideThinkingSummary,
 			...(fallbacks !== undefined ? { fallbacks } : {}),
 		};
 		return base(model, context, merged);

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -11,7 +11,8 @@
  * and OpenRouter response-cache hits across advisor calls.
  */
 import type { StreamFn } from "@oh-my-pi/pi-agent-core";
-import { type SimpleStreamOptions, streamSimple } from "@oh-my-pi/pi-ai";
+import { isOfficialCodexApiUrl, type SimpleStreamOptions, streamSimple } from "@oh-my-pi/pi-ai";
+import { isOfficialOpenAIEndpoint } from "@oh-my-pi/pi-catalog/compat/openai";
 import { isAnthropicFableOrMythosModel } from "@oh-my-pi/pi-catalog/identity";
 import { type Settings, validateProviderMaxInFlightRequests } from "../config/settings";
 
@@ -57,9 +58,11 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 			(!("supportsReasoningSummary" in model.compat) || model.compat.supportsReasoningSummary !== false);
 		const usesOpenAIReasoningSummaries =
 			supportsReasoningSummary &&
-			((model.api === "openai-responses" && model.provider === "openai") ||
+			((model.api === "openai-responses" && isOfficialOpenAIEndpoint(model.provider, model.baseUrl)) ||
 				(model.api === "azure-openai-responses" && model.provider === "azure") ||
-				(model.api === "openai-codex-responses" && model.provider === "openai-codex"));
+				(model.api === "openai-codex-responses" &&
+					model.provider === "openai-codex" &&
+					isOfficialCodexApiUrl(model.baseUrl)));
 		const summarySetting = settings.get("openaiReasoningSummary");
 		const configuredReasoningSummary =
 			!usesOpenAIReasoningSummaries || summarySetting === "provider-default"

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -24,7 +24,11 @@ function captureBase(): { fn: StreamFn; calls: Array<{ options?: SimpleStreamOpt
 }
 
 const stubModel = {} as unknown as Model;
-const stubCodexModel = { api: "openai-codex-responses", provider: "openai-codex" } as unknown as Model;
+const stubCodexModel = {
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+} as unknown as Model;
 const stubResponsesModel = {
 	api: "openai-responses",
 	provider: "openai",
@@ -35,6 +39,11 @@ const stubOpenAICompatibleResponsesModel = {
 	api: "openai-responses",
 	provider: "openai",
 	baseUrl: "https://gateway.example/v1",
+} as unknown as Model;
+const stubCompatibleCodexModel = {
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://gateway.example/codex",
 } as unknown as Model;
 const stubContext = { messages: [], tools: [], systemPrompt: [] } as unknown as Context;
 
@@ -100,6 +109,7 @@ describe("createSettingsAwareStreamFn", () => {
 		wrapped(stubResponsesModel, stubContext, undefined);
 		wrapped(stubCompatibleResponsesModel, stubContext, undefined);
 		wrapped(stubOpenAICompatibleResponsesModel, stubContext, undefined);
+		wrapped(stubCompatibleCodexModel, stubContext, undefined);
 		wrapped(stubModel, stubContext, undefined);
 
 		expect(calls[0]?.options?.reasoningSummary).toBe("detailed");
@@ -107,6 +117,7 @@ describe("createSettingsAwareStreamFn", () => {
 		expect(calls[2]?.options?.reasoningSummary).toBeUndefined();
 		expect(calls[3]?.options?.reasoningSummary).toBeUndefined();
 		expect(calls[4]?.options?.reasoningSummary).toBeUndefined();
+		expect(calls[5]?.options?.reasoningSummary).toBeUndefined();
 	});
 
 	it("lets omitThinking suppress configured and caller-supplied OpenAI summaries", () => {

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -24,26 +24,48 @@ function captureBase(): { fn: StreamFn; calls: Array<{ options?: SimpleStreamOpt
 }
 
 const stubModel = {} as unknown as Model;
+const reasoningSummaryCompat = { supportsReasoningSummary: true };
+const unsupportedReasoningSummaryCompat = { supportsReasoningSummary: false };
 const stubCodexModel = {
 	api: "openai-codex-responses",
 	provider: "openai-codex",
 	baseUrl: "https://chatgpt.com/backend-api",
+	compat: reasoningSummaryCompat,
 } as unknown as Model;
 const stubResponsesModel = {
 	api: "openai-responses",
 	provider: "openai",
 	baseUrl: "https://api.openai.com/v1",
+	compat: reasoningSummaryCompat,
 } as unknown as Model;
-const stubCompatibleResponsesModel = { api: "openai-responses", provider: "ollama" } as unknown as Model;
+const stubCompatibleResponsesModel = {
+	api: "openai-responses",
+	provider: "ollama",
+	compat: reasoningSummaryCompat,
+} as unknown as Model;
 const stubOpenAICompatibleResponsesModel = {
 	api: "openai-responses",
 	provider: "openai",
 	baseUrl: "https://gateway.example/v1",
+	compat: reasoningSummaryCompat,
 } as unknown as Model;
 const stubCompatibleCodexModel = {
 	api: "openai-codex-responses",
 	provider: "openai-codex",
 	baseUrl: "https://gateway.example/codex",
+	compat: reasoningSummaryCompat,
+} as unknown as Model;
+const stubUnsupportedResponsesModel = {
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://gateway.example/v1",
+	compat: unsupportedReasoningSummaryCompat,
+} as unknown as Model;
+const stubUnsupportedCodexModel = {
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://gateway.example/codex",
+	compat: unsupportedReasoningSummaryCompat,
 } as unknown as Model;
 const stubContext = { messages: [], tools: [], systemPrompt: [] } as unknown as Context;
 
@@ -100,7 +122,7 @@ describe("createSettingsAwareStreamFn", () => {
 		expect(calls[0]?.options?.hideThinkingSummary).toBe(true);
 	});
 
-	it("forwards configured OpenAI reasoning summaries only to official Responses-family providers", () => {
+	it("forwards configured OpenAI reasoning summaries only to capable Responses-family providers", () => {
 		const settings = Settings.isolated({ openaiReasoningSummary: "detailed" });
 		const { fn: base, calls } = captureBase();
 		const wrapped = createSettingsAwareStreamFn(settings, base);
@@ -110,14 +132,18 @@ describe("createSettingsAwareStreamFn", () => {
 		wrapped(stubCompatibleResponsesModel, stubContext, undefined);
 		wrapped(stubOpenAICompatibleResponsesModel, stubContext, undefined);
 		wrapped(stubCompatibleCodexModel, stubContext, undefined);
+		wrapped(stubUnsupportedResponsesModel, stubContext, undefined);
+		wrapped(stubUnsupportedCodexModel, stubContext, undefined);
 		wrapped(stubModel, stubContext, undefined);
 
 		expect(calls[0]?.options?.reasoningSummary).toBe("detailed");
 		expect(calls[1]?.options?.reasoningSummary).toBe("detailed");
 		expect(calls[2]?.options?.reasoningSummary).toBeUndefined();
-		expect(calls[3]?.options?.reasoningSummary).toBeUndefined();
-		expect(calls[4]?.options?.reasoningSummary).toBeUndefined();
+		expect(calls[3]?.options?.reasoningSummary).toBe("detailed");
+		expect(calls[4]?.options?.reasoningSummary).toBe("detailed");
 		expect(calls[5]?.options?.reasoningSummary).toBeUndefined();
+		expect(calls[6]?.options?.reasoningSummary).toBeUndefined();
+		expect(calls[7]?.options?.reasoningSummary).toBeUndefined();
 	});
 
 	it("lets omitThinking suppress configured and caller-supplied OpenAI summaries", () => {

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -38,6 +38,11 @@ const stubResponsesModel = {
 	baseUrl: "https://api.openai.com/v1",
 	compat: reasoningSummaryCompat,
 } as unknown as Model;
+const stubAzureOpenAIResponsesModel = {
+	api: "azure-openai-responses",
+	provider: "azure-openai",
+	compat: reasoningSummaryCompat,
+} as unknown as Model;
 const stubCompatibleResponsesModel = {
 	api: "openai-responses",
 	provider: "ollama",
@@ -129,6 +134,7 @@ describe("createSettingsAwareStreamFn", () => {
 
 		wrapped(stubCodexModel, stubContext, undefined);
 		wrapped(stubResponsesModel, stubContext, undefined);
+		wrapped(stubAzureOpenAIResponsesModel, stubContext, undefined);
 		wrapped(stubCompatibleResponsesModel, stubContext, undefined);
 		wrapped(stubOpenAICompatibleResponsesModel, stubContext, undefined);
 		wrapped(stubCompatibleCodexModel, stubContext, undefined);
@@ -138,12 +144,13 @@ describe("createSettingsAwareStreamFn", () => {
 
 		expect(calls[0]?.options?.reasoningSummary).toBe("detailed");
 		expect(calls[1]?.options?.reasoningSummary).toBe("detailed");
-		expect(calls[2]?.options?.reasoningSummary).toBeUndefined();
+		expect(calls[2]?.options?.reasoningSummary).toBe("detailed");
 		expect(calls[3]?.options?.reasoningSummary).toBeUndefined();
 		expect(calls[4]?.options?.reasoningSummary).toBeUndefined();
 		expect(calls[5]?.options?.reasoningSummary).toBeUndefined();
 		expect(calls[6]?.options?.reasoningSummary).toBeUndefined();
 		expect(calls[7]?.options?.reasoningSummary).toBeUndefined();
+		expect(calls[8]?.options?.reasoningSummary).toBeUndefined();
 	});
 
 	it("lets omitThinking suppress configured and caller-supplied OpenAI summaries", () => {

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -24,8 +24,9 @@ function captureBase(): { fn: StreamFn; calls: Array<{ options?: SimpleStreamOpt
 }
 
 const stubModel = {} as unknown as Model;
-const stubCodexModel = { api: "openai-codex-responses" } as unknown as Model;
-const stubResponsesModel = { api: "openai-responses" } as unknown as Model;
+const stubCodexModel = { api: "openai-codex-responses", provider: "openai-codex" } as unknown as Model;
+const stubResponsesModel = { api: "openai-responses", provider: "openai" } as unknown as Model;
+const stubCompatibleResponsesModel = { api: "openai-responses", provider: "ollama" } as unknown as Model;
 const stubContext = { messages: [], tools: [], systemPrompt: [] } as unknown as Context;
 
 describe("createSettingsAwareStreamFn", () => {
@@ -79,6 +80,39 @@ describe("createSettingsAwareStreamFn", () => {
 		wrapped(stubModel, stubContext, undefined);
 
 		expect(calls[0]?.options?.hideThinkingSummary).toBe(true);
+	});
+
+	it("forwards configured OpenAI reasoning summaries only to official Responses-family providers", () => {
+		const settings = Settings.isolated({ openaiReasoningSummary: "detailed" });
+		const { fn: base, calls } = captureBase();
+		const wrapped = createSettingsAwareStreamFn(settings, base);
+
+		wrapped(stubCodexModel, stubContext, undefined);
+		wrapped(stubResponsesModel, stubContext, undefined);
+		wrapped(stubCompatibleResponsesModel, stubContext, undefined);
+		wrapped(stubModel, stubContext, undefined);
+
+		expect(calls[0]?.options?.reasoningSummary).toBe("detailed");
+		expect(calls[1]?.options?.reasoningSummary).toBe("detailed");
+		expect(calls[2]?.options?.reasoningSummary).toBeUndefined();
+		expect(calls[3]?.options?.reasoningSummary).toBeUndefined();
+	});
+
+	it("lets omitThinking suppress configured and caller-supplied OpenAI summaries", () => {
+		const settings = Settings.isolated({
+			omitThinking: true,
+			openaiReasoningSummary: "detailed",
+		});
+		const { fn: base, calls } = captureBase();
+		const wrapped = createSettingsAwareStreamFn(settings, base);
+
+		wrapped(stubCodexModel, stubContext, {
+			hideThinkingSummary: false,
+			reasoningSummary: "auto",
+		});
+
+		expect(calls[0]?.options?.hideThinkingSummary).toBe(true);
+		expect(calls[0]?.options?.reasoningSummary).toBeNull();
 	});
 
 	it("applies Codex text verbosity only when settings or caller options configure it", () => {

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -25,8 +25,17 @@ function captureBase(): { fn: StreamFn; calls: Array<{ options?: SimpleStreamOpt
 
 const stubModel = {} as unknown as Model;
 const stubCodexModel = { api: "openai-codex-responses", provider: "openai-codex" } as unknown as Model;
-const stubResponsesModel = { api: "openai-responses", provider: "openai" } as unknown as Model;
+const stubResponsesModel = {
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://api.openai.com/v1",
+} as unknown as Model;
 const stubCompatibleResponsesModel = { api: "openai-responses", provider: "ollama" } as unknown as Model;
+const stubOpenAICompatibleResponsesModel = {
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://gateway.example/v1",
+} as unknown as Model;
 const stubContext = { messages: [], tools: [], systemPrompt: [] } as unknown as Context;
 
 describe("createSettingsAwareStreamFn", () => {
@@ -90,12 +99,14 @@ describe("createSettingsAwareStreamFn", () => {
 		wrapped(stubCodexModel, stubContext, undefined);
 		wrapped(stubResponsesModel, stubContext, undefined);
 		wrapped(stubCompatibleResponsesModel, stubContext, undefined);
+		wrapped(stubOpenAICompatibleResponsesModel, stubContext, undefined);
 		wrapped(stubModel, stubContext, undefined);
 
 		expect(calls[0]?.options?.reasoningSummary).toBe("detailed");
 		expect(calls[1]?.options?.reasoningSummary).toBe("detailed");
 		expect(calls[2]?.options?.reasoningSummary).toBeUndefined();
 		expect(calls[3]?.options?.reasoningSummary).toBeUndefined();
+		expect(calls[4]?.options?.reasoningSummary).toBeUndefined();
 	});
 
 	it("lets omitThinking suppress configured and caller-supplied OpenAI summaries", () => {

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -139,8 +139,8 @@ describe("createSettingsAwareStreamFn", () => {
 		expect(calls[0]?.options?.reasoningSummary).toBe("detailed");
 		expect(calls[1]?.options?.reasoningSummary).toBe("detailed");
 		expect(calls[2]?.options?.reasoningSummary).toBeUndefined();
-		expect(calls[3]?.options?.reasoningSummary).toBe("detailed");
-		expect(calls[4]?.options?.reasoningSummary).toBe("detailed");
+		expect(calls[3]?.options?.reasoningSummary).toBeUndefined();
+		expect(calls[4]?.options?.reasoningSummary).toBeUndefined();
 		expect(calls[5]?.options?.reasoningSummary).toBeUndefined();
 		expect(calls[6]?.options?.reasoningSummary).toBeUndefined();
 		expect(calls[7]?.options?.reasoningSummary).toBeUndefined();


### PR DESCRIPTION
## What

- Add an `openaiReasoningSummary` setting with `provider-default`, `none`, `auto`, `concise`, and `detailed` modes.
- Forward explicit summary requests to supported official OpenAI Responses, Codex, and Azure Responses models while preserving provider defaults when unset.
- Keep `omitThinking` as the highest-priority suppressor and omit unsupported summary parameters for older Codex variants.

## Why

Restore an explicit, fail-safe opt-in path for visible reasoning summaries without reintroducing request defaults that unsupported models reject.

Closes #8006.

## Testing

- `bun test packages/coding-agent/test/settings-stream-fn.test.ts packages/ai/test/openai-codex-stream.test.ts packages/ai/test/openai-codex-responses-lite.test.ts packages/ai/test/azure-openai-responses-stream.test.ts` — 143 pass
- `bun check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)