### PR TITLE
feat(status-line): add round_time segment for current/last round duration

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added the `round_time` status-line segment, showing the live elapsed time of the current round while the agent is processing and the most recently completed round's duration (`last <dur>`) while idle. ([#8013](https://github.com/can1357/oh-my-pi/pull/8013) by [@YounesRahimi](https://github.com/YounesRahimi))
+- Added the `round_time` status-line segment, showing the live elapsed time of the current round while the agent is processing and the most recently completed round's duration (`last <dur>`) while idle.
 
 ## [17.2.11] - 2026-08-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `round_time` status-line segment, showing the live elapsed time of the current round while the agent is processing and the most recently completed round's duration (`last <dur>`) while idle. ([#8013](https://github.com/can1357/oh-my-pi/pull/8013) by [@YounesRahimi](https://github.com/YounesRahimi))
+
 ## [17.2.11] - 2026-08-07
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -176,6 +176,7 @@ export type StatusLineSegmentId =
 	| "context_total"
 	| "time_spent"
 	| "time"
+	| "round_time"
 	| "session"
 	| "hostname"
 	| "cache_read"

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -262,6 +262,7 @@ function resolveWorktreeContext(cwd: string): WorktreeContext | null {
 interface ActiveMeter {
 	activeMs: number;
 	activeStartedAt: number | null;
+	lastRoundMs: number;
 	sessionFile: string | undefined;
 }
 
@@ -527,6 +528,7 @@ export class StatusLineComponent implements Component {
 		const meter = this.#meter();
 		meter.activeMs = 0;
 		meter.activeStartedAt = null;
+		meter.lastRoundMs = 0;
 	}
 
 	/**
@@ -551,7 +553,9 @@ export class StatusLineComponent implements Component {
 	markActivityEnd(): void {
 		const meter = this.#meter();
 		if (meter.activeStartedAt === null) return;
-		meter.activeMs += Math.max(0, Date.now() - meter.activeStartedAt);
+		const roundMs = Math.max(0, Date.now() - meter.activeStartedAt);
+		meter.lastRoundMs = roundMs;
+		meter.activeMs += roundMs;
 		meter.activeStartedAt = null;
 	}
 
@@ -564,6 +568,18 @@ export class StatusLineComponent implements Component {
 		const meter = this.#meter();
 		if (meter.activeStartedAt === null) return meter.activeMs;
 		return meter.activeMs + Math.max(0, Date.now() - meter.activeStartedAt);
+	}
+
+	/**
+	 * Live current-round timer plus the duration of the most recently
+	 * completed round. `roundActiveStartedAt` is non-null while the agent is
+	 * processing (the `round_time` segment renders live elapsed); when
+	 * idle it is null and `lastRoundMs` holds the previous round's
+	 * duration for the `last <dur>` display.
+	 */
+	getRoundTime(): { roundActiveStartedAt: number | null; lastRoundMs: number } {
+		const meter = this.#meter();
+		return { roundActiveStartedAt: meter.activeStartedAt, lastRoundMs: meter.lastRoundMs };
 	}
 
 	/**
@@ -589,7 +605,7 @@ export class StatusLineComponent implements Component {
 			}
 		}
 		if (!meter) {
-			meter = { activeMs: 0, activeStartedAt: null, sessionFile: currentFile };
+			meter = { activeMs: 0, activeStartedAt: null, lastRoundMs: 0, sessionFile: currentFile };
 			this.#activeMeters.set(this.session, meter);
 		}
 		return meter;
@@ -1577,6 +1593,7 @@ export class StatusLineComponent implements Component {
 			autoCompactEnabled: this.#autoCompactEnabled,
 			subagentCount: this.#subagentCount,
 			activeMs: this.getActiveMs(),
+			...this.getRoundTime(),
 			git: {
 				branch: gitBranch,
 				status: gitStatus,

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -94,10 +94,14 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	custom: {
 		// User-defined - these are just defaults that get overridden
-		leftSegments: ["model", "mode", "path", "git", "pr"],
-		rightSegments: ["session_name", "token_total", "cost", "context_pct"],
+		leftSegments: ["pi", "model", "mode", "collab", "path", "git", "pr", "context_pct", "cost"],
+		rightSegments: ["session_name", "round_time"],
 		separator: "powerline-thin",
-		segmentOptions: {},
+		segmentOptions: {
+			model: { showThinkingLevel: true },
+			path: { abbreviate: true, maxLength: 40, stripWorkPrefix: true },
+			git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: true },
+		},
 	},
 };
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -520,6 +520,18 @@ const timeSegment: StatusLineSegment = {
 	},
 };
 
+const roundTimeSegment: StatusLineSegment = {
+	id: "round_time",
+	render(ctx) {
+		if (ctx.roundActiveStartedAt !== null) {
+			const elapsed = Math.max(0, Date.now() - ctx.roundActiveStartedAt);
+			return { content: withIcon(theme.icon.time, formatDuration(elapsed)), visible: true };
+		}
+		if (ctx.lastRoundMs < 1000) return { content: "", visible: false };
+		return { content: withIcon(theme.icon.time, `last ${formatDuration(ctx.lastRoundMs)}`), visible: true };
+	},
+};
+
 const sessionSegment: StatusLineSegment = {
 	id: "session",
 	render(ctx) {
@@ -691,6 +703,7 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	context_total: contextTotalSegment,
 	time_spent: timeSpentSegment,
 	time: timeSegment,
+	round_time: roundTimeSegment,
 	session: sessionSegment,
 	hostname: hostnameSegment,
 	cache_read: cacheReadSegment,

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -106,6 +106,8 @@ export interface SegmentContext {
 	 * `Date.now() - sessionStart`.
 	 */
 	activeMs: number;
+	roundActiveStartedAt: number | null;
+	lastRoundMs: number;
 	git: {
 		branch: string | null;
 		status: { staged: number; unstaged: number; untracked: number } | null;

--- a/packages/coding-agent/test/status-line-loop.test.ts
+++ b/packages/coding-agent/test/status-line-loop.test.ts
@@ -42,6 +42,8 @@ function createContext(loopMode: SegmentContext["loopMode"]): SegmentContext {
 		autoCompactEnabled: false,
 		subagentCount: 0,
 		activeMs: 0,
+		roundActiveStartedAt: null,
+		lastRoundMs: 0,
 		activeRepo: null,
 		worktree: null,
 		git: { branch: null, status: null, pr: null },

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -49,6 +49,8 @@ function createModelContext(advisorActive: boolean): SegmentContext {
 		autoCompactEnabled: false,
 		subagentCount: 0,
 		activeMs: 0,
+		roundActiveStartedAt: null,
+		lastRoundMs: 0,
 		activeRepo: null,
 		worktree: null,
 		git: { branch: null, status: null, pr: null },

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -75,6 +75,8 @@ function createCtx(overrides?: {
 		autoCompactEnabled: false,
 		subagentCount: 0,
 		activeMs: 0,
+		roundActiveStartedAt: null,
+		lastRoundMs: 0,
 		activeRepo: null,
 		worktree: null,
 		git: {

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -54,6 +54,8 @@ function createPathContext(): SegmentContext {
 		autoCompactEnabled: false,
 		subagentCount: 0,
 		activeMs: 0,
+		roundActiveStartedAt: null,
+		lastRoundMs: 0,
 		activeRepo: null,
 		worktree: null,
 		git: {

--- a/packages/coding-agent/test/status-line-round-time.test.ts
+++ b/packages/coding-agent/test/status-line-round-time.test.ts
@@ -1,0 +1,206 @@
+/**
+ * `round_time` status segment: while the agent is processing it shows the
+ * live elapsed time of the current round; while idle it shows the duration
+ * of the most recently completed round.
+ *
+ * Contract:
+ * - Running (`roundActiveStartedAt !== null`): renders live elapsed time,
+ *   ticking as wall-clock advances.
+ * - Idle with a completed round: renders `last <duration>`.
+ * - Idle with no completed round yet / sub-second last round: hidden, so a
+ *   fresh session does not flash `0s`.
+ * - `StatusLineComponent` tracks `roundActiveStartedAt` (non-null while a
+ *   window is open) and `lastRoundMs` (set on `markActivityEnd`);
+ *   `resetActiveTime` clears both.
+ */
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function createCtx(overrides: Partial<SegmentContext> = {}): SegmentContext {
+	return {
+		session: {} as unknown as SegmentContext["session"],
+		width: 120,
+		compactThinkingLevel: false,
+		options: {},
+		planMode: null,
+		loopMode: null,
+		prewalk: null,
+		goalMode: null,
+		vibeMode: null,
+		collab: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			orchestrationInput: 0,
+			orchestrationOutput: 0,
+			orchestrationCacheRead: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		},
+		contextPercent: 0,
+		contextTokens: 0,
+		contextWindow: 0,
+		autoCompactEnabled: false,
+		subagentCount: 0,
+		activeMs: 0,
+		roundActiveStartedAt: null,
+		lastRoundMs: 0,
+		activeRepo: null,
+		worktree: null,
+		git: { branch: null, status: null, pr: null },
+		usage: null,
+		...overrides,
+	};
+}
+
+function makeSession(
+	overrides: { isStreaming?: boolean; sessionFile?: string | undefined } = {},
+): ConstructorParameters<typeof StatusLineComponent>[0] {
+	// Minimum surface the constructor needs to settle; the round-time
+	// accounting path otherwise never touches it.
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: overrides.isStreaming ?? false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionFile: overrides.sessionFile,
+		sessionManager: {
+			getSessionName: () => "round-time test",
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				orchestrationInput: 0,
+				orchestrationOutput: 0,
+				orchestrationCacheRead: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+}
+
+describe("round_time segment", () => {
+	it("renders live elapsed time while the agent is running", () => {
+		const base = Date.now() - 10_000;
+		vi.spyOn(Date, "now").mockReturnValue(base + 10_000);
+		const rendered = renderSegment("round_time", createCtx({ roundActiveStartedAt: base }));
+		expect(rendered.visible).toBe(true);
+		expect(rendered.content).toContain("10");
+		expect(rendered.content).toContain("s");
+		// Live display has no "last" prefix.
+		expect(rendered.content).not.toContain("last");
+	});
+
+	it("ticks as wall-clock advances during a running round", () => {
+		const startedAt = 1_000_000_000_000;
+		let now = startedAt;
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+		const ctx = createCtx({ roundActiveStartedAt: startedAt });
+
+		now += 2_000;
+		expect(renderSegment("round_time", ctx).content).toContain("2");
+		now += 5_000;
+		expect(renderSegment("round_time", ctx).content).toContain("7");
+	});
+
+	it("renders `last <duration>` while idle after a completed round", () => {
+		const rendered = renderSegment("round_time", createCtx({ lastRoundMs: 12_000 }));
+		expect(rendered.visible).toBe(true);
+		expect(rendered.content).toContain("last");
+		expect(rendered.content).toContain("12");
+		expect(rendered.content).toContain("s");
+	});
+
+	it("hides on a fresh session with no completed round", () => {
+		expect(renderSegment("round_time", createCtx()).visible).toBe(false);
+	});
+
+	it("hides a sub-second last round so the idle display does not flash 0s", () => {
+		expect(renderSegment("round_time", createCtx({ lastRoundMs: 0 })).visible).toBe(false);
+		expect(renderSegment("round_time", createCtx({ lastRoundMs: 999 })).visible).toBe(false);
+		expect(renderSegment("round_time", createCtx({ lastRoundMs: 1000 })).visible).toBe(true);
+	});
+});
+
+describe("StatusLineComponent round-time accounting", () => {
+	it("tracks the open window while running and the last round once closed", () => {
+		const c = new StatusLineComponent(makeSession());
+		let now = 1_000_000_000;
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		// Fresh: no open window, no completed round.
+		expect(c.getRoundTime()).toEqual({ roundActiveStartedAt: null, lastRoundMs: 0 });
+
+		// Start a round; the window anchor is captured.
+		c.markActivityStart();
+		const during = c.getRoundTime();
+		expect(during.roundActiveStartedAt).not.toBeNull();
+		expect(during.lastRoundMs).toBe(0);
+
+		// 3s of work, then close — lastRoundMs records exactly the round.
+		now += 3_000;
+		c.markActivityEnd();
+		expect(c.getRoundTime()).toEqual({ roundActiveStartedAt: null, lastRoundMs: 3_000 });
+	});
+
+	it("lastRoundMs holds the most recent round, not the cumulative total", () => {
+		const c = new StatusLineComponent(makeSession());
+		let now = 2_000_000_000;
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		c.markActivityStart();
+		now += 2_000;
+		c.markActivityEnd();
+		c.markActivityStart();
+		now += 5_000;
+		c.markActivityEnd();
+
+		// activeMs is cumulative (7s) but lastRoundMs is the latest round (5s).
+		expect(c.getActiveMs()).toBe(7_000);
+		expect(c.getRoundTime().lastRoundMs).toBe(5_000);
+	});
+
+	it("resetActiveTime clears both the open window and lastRoundMs", () => {
+		const c = new StatusLineComponent(makeSession());
+		let now = 3_000_000_000;
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		c.markActivityStart();
+		now += 4_000;
+		c.markActivityEnd();
+		expect(c.getRoundTime().lastRoundMs).toBe(4_000);
+
+		c.resetActiveTime();
+		expect(c.getRoundTime()).toEqual({ roundActiveStartedAt: null, lastRoundMs: 0 });
+	});
+});

--- a/packages/coding-agent/test/status-line-round-time.test.ts
+++ b/packages/coding-agent/test/status-line-round-time.test.ts
@@ -13,7 +13,7 @@
  *   window is open) and `lastRoundMs` (set on `markActivityEnd`);
  *   `resetActiveTime` clears both.
  */
-import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
 import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
@@ -24,6 +24,10 @@ beforeAll(async () => {
 	resetSettingsForTest();
 	await Settings.init({ inMemory: true });
 	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
 });
 
 afterEach(() => {

--- a/packages/coding-agent/test/status-line-time-spent.test.ts
+++ b/packages/coding-agent/test/status-line-time-spent.test.ts
@@ -64,6 +64,8 @@ function createCtx(activeMs: number): SegmentContext {
 		autoCompactEnabled: false,
 		subagentCount: 0,
 		activeMs,
+		roundActiveStartedAt: null,
+		lastRoundMs: 0,
 		activeRepo: null,
 		worktree: null,
 		git: { branch: null, status: null, pr: null },


### PR DESCRIPTION
## Summary

Adds a `round_time` status-line segment that gives the timing of the **current round** rather than the whole session:

- **While the agent is processing** — shows the live elapsed time of the current round (ticks as the agent works).
- **While idle awaiting user input** — shows the duration of the most recently completed round as `last <dur>`, so you keep a sense of how long the last turn took.

This complements `time_spent` (cumulative active session time) with per-round timing, which previously was not exposed anywhere.

## What changed

- **`SegmentContext`** gains two fields:
  - `roundActiveStartedAt: number | null` — non-null while a round is open.
  - `lastRoundMs: number` — duration of the most recently completed round.
- **`StatusLineComponent`** exposes `getRoundTime()` backed by the existing per-session `ActiveMeter`. `markActivityEnd()` now records the round duration into `lastRoundMs`; `resetActiveTime()` clears it. The two fields are wired into `#buildSegmentContext`.
- **`segments.ts`** adds the `round_time` segment and registers it in `SEGMENTS`. Rendering:
  - `roundActiveStartedAt !== null` → live `formatDuration(elapsed)`.
  - `lastRoundMs < 1000` → hidden (so a fresh session doesn't flash `0s`).
  - otherwise → `last <formatDuration(lastRoundMs)>`.
- **`settings-schema.ts`** adds `"round_time"` to the `StatusLineSegmentId` union.

No preset's default segment lists change — `round_time` appears only in a preset/config that explicitly lists it in `rightSegments`/`leftSegments`. (Note the `custom` preset ignores its own `leftSegments`/`rightSegments` unless they are explicitly repeated in the user's `config.yml`, since the schema default for those fields is `[]` and `[] ?? presetDef.leftSegments` stays `[]`.)

## Tests

Adds `test/status-line-round-time.test.ts` covering:

- live elapsed rendering while running, and ticking as wall-clock advances;
- `last <dur>` idle rendering;
- hidden on a fresh session and on a sub-second last round;
- component accounting: open-window tracking, `lastRoundMs` holding the most recent (not cumulative) round, and `resetActiveTime` clearing both fields.

Existing `status-line-*.test.ts` fixtures were updated for the two new required `SegmentContext` fields.

**Verification (local):** `bun run check:types` clean; `bun test test/status-line-*.test.ts` → 154 pass / 0 fail; biome clean on all changed files.