### PR TITLE
test(coding-agent): fix pre-existing session-manager legacy migration test failure

### DIFF
--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -255,6 +255,10 @@ describe("SessionManager temp cwd session dirs", () => {
 
 describe("SessionManager legacy session migration persistence", () => {
 	let tempDir: string;
+	let testAgentDir: string;
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const originalTmuxPane = process.env.TMUX_PANE;
+	const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
 
 	function makeAssistantMessage() {
 		return {
@@ -281,11 +285,28 @@ describe("SessionManager legacy session migration persistence", () => {
 	}
 
 	beforeEach(() => {
+		// Deterministic, non-TTY terminal id so the per-terminal breadcrumb
+		// (written by newSession/continueRecent) is scoped to this test and
+		// cannot leak across files in the same suite run. Without it, a real
+		// terminal id (WT_SESSION/TMUX_PANE) points continueRecent at stale
+		// breadcrumb state from earlier tests in this file.
+		process.env.TMUX_PANE = "%legacy-migration-test";
+		testAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-session-manager-legacy-agent-"));
+		setAgentDir(testAgentDir);
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-session-manager-legacy-"));
 	});
 
 	afterEach(() => {
+		if (originalTmuxPane === undefined) delete process.env.TMUX_PANE;
+		else process.env.TMUX_PANE = originalTmuxPane;
+		if (originalAgentDir) {
+			setAgentDir(originalAgentDir);
+		} else {
+			setAgentDir(fallbackAgentDir);
+			delete process.env.PI_CODING_AGENT_DIR;
+		}
 		removeSyncWithRetries(tempDir);
+		removeSyncWithRetries(testAgentDir);
 	});
 
 	it("keeps legacy migration in memory until later persisted activity rewrites the file", async () => {
@@ -413,10 +434,18 @@ describe("SessionManager legacy session migration persistence", () => {
 		const freshSessionFile = await session.newSession();
 		expect(freshSessionFile).toBeDefined();
 		expect(fs.existsSync(freshSessionFile!)).toBe(false);
+		// Lazy new-session persistence: nothing on disk yet, so materialize the
+		// fresh session the way assistant output would (issue #5730).
+		session.appendMessage({ role: "user", content: "first message of fresh session", timestamp: Date.now() });
+		session.appendMessage(makeAssistantMessage());
+		await session.flush();
+		expect(fs.existsSync(freshSessionFile!)).toBe(true);
 
 		const resumed = await SessionManager.continueRecent(tempDir, tempDir);
 		try {
-			expect(resumed.getSessionFile()).toBe(previousSessionFile);
+			// The `/new` boundary is durable: once materialized, relaunch resumes
+			// the fresh session, not the pre-`/new` transcript.
+			expect(resumed.getSessionFile()).toBe(freshSessionFile);
 		} finally {
 			await resumed.close();
 			await session.close();


### PR DESCRIPTION
## What

Fixes a pre-existing failure in `packages/coding-agent/test/session-manager/file-operations.test.ts` that breaks the coding-agent suite on every developer machine with a terminal id set (`WT_SESSION`/`TMUX_PANE`).

Root cause: #5730 ("persist /new boundary") deliberately changed `continueRecent` to honor fresh `/new` breadcrumbs — a materialized fresh session is resumed instead of the pre-`/new` transcript. The legacy migration test still asserted the pre-#5730 behavior, and ran against the real terminal id, so it failed deterministically whenever a terminal id env var was present (e.g. under WSL/Windows Terminal).

## Change

- Scope the test's terminal breadcrumb to a deterministic id (`TMUX_PANE=%legacy-migration-test`) and a temp agent dir, so it cannot leak or read stale breadcrumb state from earlier tests in the same suite run.
- Update the `/new` boundary contract test: materialize the fresh session the way assistant output would (append user + assistant message, flush), then assert `continueRecent` resumes the **fresh** session, not the pre-`/new` transcript.

## Testing

- `bun test packages/coding-agent/test/session-manager/ packages/coding-agent/test/session/`: 336 pass / 0 fail
- `bun run check:ts`: passes
