### PR TITLE
test(coding-agent): hermeticize agent dir in claude-plugins discovery tests

### DIFF
--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { loadSlashCommands } from "@oh-my-pi/pi-coding-agent/extensibility/slash-commands";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
-import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { getConfigRootDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
 import { type MCPServer, mcpCapability } from "@oh-my-pi/pi-coding-agent/capability/mcp";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
@@ -62,27 +62,41 @@ describe("parseClaudePluginsRegistry", () => {
 
 describe("listClaudePluginRoots", () => {
 	let tempDir: string;
+	let testAgentDir: string;
 	let originalHome: string | undefined;
+	const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+	const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
 
 	beforeEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
 		originalHome = process.env.HOME;
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-plugins-test-"));
+		testAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-plugins-test-agent-"));
 		process.env.HOME = tempDir;
 		vi.spyOn(os, "homedir").mockReturnValue(tempDir);
+		// Point the agent dir at a temp dir so user-scope discovery (native MCP
+		// config, skills, etc.) cannot read the real ~/.omp/agent profile.
+		setAgentDir(testAgentDir);
 	});
 
 	afterEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
 		vi.restoreAllMocks();
+		if (originalAgentDirEnv) {
+			setAgentDir(originalAgentDirEnv);
+		} else {
+			setAgentDir(fallbackAgentDir);
+			delete process.env.PI_CODING_AGENT_DIR;
+		}
 		if (originalHome === undefined) {
 			delete process.env.HOME;
 		} else {
 			process.env.HOME = originalHome;
 		}
 		await removeWithRetries(tempDir);
+		await removeWithRetries(testAgentDir);
 	});
 
 	test("returns empty roots when no registry file exists", async () => {

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { loadSlashCommands } from "@oh-my-pi/pi-coding-agent/extensibility/slash-commands";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
-import { getConfigRootDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+import { __resetDirsFromEnvForTests, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
 import { type MCPServer, mcpCapability } from "@oh-my-pi/pi-coding-agent/capability/mcp";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
@@ -60,17 +60,31 @@ describe("parseClaudePluginsRegistry", () => {
 	});
 });
 
+function restoreEnvValue(key: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[key];
+		delete Bun.env[key];
+		return;
+	}
+	process.env[key] = value;
+	Bun.env[key] = value;
+}
+
 describe("listClaudePluginRoots", () => {
 	let tempDir: string;
 	let testAgentDir: string;
 	let originalHome: string | undefined;
-	const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
-	const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+	let originalAgentDirEnv: string | undefined;
+	let originalOmpProfileEnv: string | undefined;
+	let originalPiProfileEnv: string | undefined;
 
 	beforeEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
 		originalHome = process.env.HOME;
+		originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+		originalOmpProfileEnv = process.env.OMP_PROFILE;
+		originalPiProfileEnv = process.env.PI_PROFILE;
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-plugins-test-"));
 		testAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-plugins-test-agent-"));
 		process.env.HOME = tempDir;
@@ -84,17 +98,13 @@ describe("listClaudePluginRoots", () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
 		vi.restoreAllMocks();
-		if (originalAgentDirEnv) {
-			setAgentDir(originalAgentDirEnv);
-		} else {
-			setAgentDir(fallbackAgentDir);
-			delete process.env.PI_CODING_AGENT_DIR;
-		}
-		if (originalHome === undefined) {
-			delete process.env.HOME;
-		} else {
-			process.env.HOME = originalHome;
-		}
+		// setAgentDir() clears the profile env vars and snapshots the agent dir,
+		// so restore every env var it can touch before rebuilding the resolver.
+		restoreEnvValue("HOME", originalHome);
+		restoreEnvValue("OMP_PROFILE", originalOmpProfileEnv);
+		restoreEnvValue("PI_PROFILE", originalPiProfileEnv);
+		restoreEnvValue("PI_CODING_AGENT_DIR", originalAgentDirEnv);
+		__resetDirsFromEnvForTests();
 		await removeWithRetries(tempDir);
 		await removeWithRetries(testAgentDir);
 	});


### PR DESCRIPTION
## What

`listClaudePluginRoots` tests point `HOME` at a temp dir but left the agent dir at the real profile (`~/.omp/agent`). User-scope discovery — the native MCP provider reads `getAgentDir()/mcp.json` — then loads the machine's real `mcp.json`, leaking its servers into `loadCapability` results.

## Symptom

`claude-plugins.test.ts > deduplicates a plugin alias of a directly configured MCP connection` fails deterministically on any machine whose real agent dir has an `mcp.json`:

```
expect(result.items.map(server => server.name)).toEqual(["context7"])
Received: ["context7", "WebMCP"]
```

It also intermittently produced 5s timeouts in sibling tests (`ignores manifest slash commands directory that resolves outside plugin root`) when the leaked server tried to spawn a process.

## Fix

Point the agent dir at a temp dir in `beforeEach` and restore the previous value (or unset `PI_CODING_AGENT_DIR` and fall back to `getConfigRootDir()/agent`) in `afterEach` — the established hermetic pattern from `mcp-profile.test.ts` / `autolearn-discovery.test.ts`.

## Testing

- `claude-plugins.test.ts`: 36 pass / 0 fail (was 35/1 + intermittent timeouts)
- Full `test/discovery/` dir: 221 pass / 0 fail
- `bun run check:ts`: clean
- `ci-test-ts.ts coding-agent-native` bucket (CI's native bucket): 45 pass / 0 fail