### PR TITLE
fix(catalog): correct qwen3.8 max discovery metadata

### DIFF
--- a/packages/ai/test/openai-compat-policy.test.ts
+++ b/packages/ai/test/openai-compat-policy.test.ts
@@ -175,4 +175,18 @@ describe("OpenAI compat policy", () => {
 			expect(params.chat_template_kwargs).toBeUndefined();
 		}
 	});
+
+	it("keeps Token Plan qwen3.8-max-preview on the enable_thinking dialect", () => {
+		// The preview rides Alibaba's binary enable_thinking toggle, not the
+		// OpenAI reasoning_effort control, so effort selections must not leak an
+		// unsupported reasoning_effort onto the wire.
+		const model = getBundledModel<"openai-completions">("alibaba-token-plan", "qwen3.8-max-preview");
+		const params = chatParams();
+		applyChatCompletionsCompatPolicy(
+			params,
+			resolveOpenAICompatPolicy(model, { endpoint: "chat-completions", reasoning: Effort.High }),
+		);
+		expect(params.enable_thinking).toBe(true);
+		expect(params.reasoning_effort).toBeUndefined();
+	});
 });

--- a/packages/ai/test/openai-compat-policy.test.ts
+++ b/packages/ai/test/openai-compat-policy.test.ts
@@ -9,6 +9,7 @@ import {
 import type { Model, ModelSpec, OpenAICompat } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 function chatModel(compat: OpenAICompat): Model<"openai-completions"> {
 	return buildModel({
@@ -159,5 +160,19 @@ describe("OpenAI compat policy", () => {
 		expect(responsesPolicy.tools.toolCallIdKind).toBe("mistral-9-alnum");
 		expect(chatPolicy.stream.reasoningDeltasMayBeCumulative).toBe(true);
 		expect(responsesPolicy.stream.reasoningDeltasMayBeCumulative).toBe(true);
+	});
+
+	it("routes Token Plan qwen3.8-max effort selections onto the wire", () => {
+		const model = getBundledModel<"openai-completions">("alibaba-token-plan", "qwen3.8-max");
+		for (const effort of [Effort.Low, Effort.Medium, Effort.XHigh]) {
+			const params = chatParams();
+			applyChatCompletionsCompatPolicy(
+				params,
+				resolveOpenAICompatPolicy(model, { endpoint: "chat-completions", reasoning: effort }),
+			);
+			expect(params.reasoning_effort).toBe(effort);
+			expect(params.enable_thinking).toBeUndefined();
+			expect(params.chat_template_kwargs).toBeUndefined();
+		}
 	});
 });

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed dynamically discovered `alibaba-token-plan/qwen3.8-max` metadata so thinking controls and image input are available ([#8019](https://github.com/can1357/oh-my-pi/issues/8019)).
+
 ## [17.2.11] - 2026-08-07
 
 ### Fixed

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -546,12 +546,6 @@ async function generateModels() {
 	// persisted `modelRoles.default = "xai-oauth/<id>"` is honored before the
 	// async refresh fires (interactive boot does not await refresh).
 	allModels.push(...buildXaiOAuthStaticSeed());
-	// Seed QwenCloud's documented Token Plan models when credentialed
-	// discovery is unavailable. A successful `/models` response is authoritative
-	// for the subscribed edition and must not be widened by the fallback.
-	if (!authoritativeCatalogProviders.has("alibaba-token-plan")) {
-		allModels.push(...ALIBABA_TOKEN_PLAN_STATIC_MODELS);
-	}
 	// Seed Anthropic models that are live on the first-party API or in limited
 	// release but that stencil.so has not catalogued yet (e.g. Claude Fable 5 /
 	// Mythos 5). Deduped behind upstream entries; metadata is pinned in
@@ -656,6 +650,14 @@ async function generateModels() {
 	}
 
 	allModels = applyGlobalModelsDevFallback(allModels, modelsDevModels);
+	// Seed QwenCloud's documented Token Plan models when credentialed
+	// discovery is unavailable. A successful `/models` response is authoritative
+	// for the subscribed edition and must not be widened by the fallback.
+	// Deduplication keeps earlier rows, so prepend the curated seed to prevent
+	// incomplete upstream metadata from replacing its capabilities.
+	if (!authoritativeCatalogProviders.has("alibaba-token-plan")) {
+		allModels.unshift(...ALIBABA_TOKEN_PLAN_STATIC_MODELS);
+	}
 	allModels = applyUmansPricingFallback(allModels, modelsDevModels);
 	allModels = applyPremiumMultiplierOverrides(allModels);
 	allModels = applyCodexPricingFallback(allModels);

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -172,7 +172,13 @@ export function applyGeneratedModelPolicies(models: ModelSpec<Api>[]): void {
  */
 export function rebakeModelThinking(model: ModelSpec<Api>): void {
 	if (isVariantCollapsedSpec(model)) return;
-	if (model.provider === "alibaba-token-plan" && model.id === "qwen3.8-max-preview" && model.thinking) return;
+	if (
+		model.provider === "alibaba-token-plan" &&
+		(model.id === "qwen3.8-max-preview" || model.id === "qwen3.8-max") &&
+		model.thinking
+	) {
+		return;
+	}
 	const requiresProviderAuthoredEffort =
 		model.provider === "umans" && (model.thinking?.requiresEffort === true || model.id === "umans-kimi-k2.7");
 	const thinking = resolveModelThinking({ ...model, thinking: undefined }, buildCompat(model));

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -8070,8 +8070,7 @@
 			},
 			"compat": {
 				"supportsDeveloperRole": false,
-				"supportsReasoningEffort": true,
-				"thinkingFormat": "openai"
+				"supportsReasoningEffort": true
 			}
 		}
 	},

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -8048,7 +8048,8 @@
 			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -29404,7 +29405,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 8192,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-3.5-sonnet": {
 			"id": "anthropic/claude-3.5-sonnet",
@@ -29690,7 +29692,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-opus-4.7": {
 			"id": "anthropic/claude-opus-4.7",
@@ -30176,7 +30179,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"arcee-ai/virtuoso-large": {
 			"id": "arcee-ai/virtuoso-large",
@@ -30225,7 +30229,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"baidu/ernie-4.5-21b-a3b": {
 			"id": "baidu/ernie-4.5-21b-a3b",
@@ -30245,7 +30250,8 @@
 			},
 			"contextWindow": 120000,
 			"maxTokens": 8000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"baidu/ernie-4.5-300b-a47b": {
 			"id": "baidu/ernie-4.5-300b-a47b",
@@ -30297,7 +30303,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"baidu/ernie-4.5-vl-424b-a47b": {
 			"id": "baidu/ernie-4.5-vl-424b-a47b",
@@ -31160,7 +31167,8 @@
 			},
 			"contextWindow": 32768,
 			"maxTokens": 6554,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"giga-potato": {
 			"id": "giga-potato",
@@ -31220,7 +31228,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 8192,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-2.0-flash-lite-001": {
 			"id": "google/gemini-2.0-flash-lite-001",
@@ -31241,7 +31250,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 8192,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-2.5-flash": {
 			"id": "google/gemini-2.5-flash",
@@ -31349,7 +31359,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-2.5-pro": {
 			"id": "google/gemini-2.5-pro",
@@ -32911,7 +32922,8 @@
 			},
 			"contextWindow": 8192,
 			"maxTokens": 16384,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"meta-llama/llama-3.1-405b": {
 			"id": "meta-llama/llama-3.1-405b",
@@ -33607,7 +33619,8 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"mistralai/devstral-medium": {
 			"id": "mistralai/devstral-medium",
@@ -33627,7 +33640,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 26215,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"mistralai/devstral-small": {
 			"id": "mistralai/devstral-small",
@@ -33647,7 +33661,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 26215,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"mistralai/ministral-14b-2512": {
 			"id": "mistralai/ministral-14b-2512",
@@ -33828,7 +33843,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 26215,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"mistralai/mistral-large-2512": {
 			"id": "mistralai/mistral-large-2512",
@@ -34128,7 +34144,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"mistralai/voxtral-small-24b-2507": {
 			"id": "mistralai/voxtral-small-24b-2507",
@@ -34524,7 +34541,8 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 163840,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"nex-agi/nex-n2-mini": {
 			"id": "nex-agi/nex-n2-mini",
@@ -34788,7 +34806,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"nvidia/nemotron-3-nano-30b-a3b": {
 			"id": "nvidia/nemotron-3-nano-30b-a3b",
@@ -35046,7 +35065,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-3.5-turbo": {
 			"id": "openai/gpt-3.5-turbo",
@@ -35162,7 +35182,8 @@
 			},
 			"contextWindow": 8191,
 			"maxTokens": 4096,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4-1106-preview": {
 			"id": "openai/gpt-4-1106-preview",
@@ -35182,7 +35203,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4-turbo": {
 			"id": "openai/gpt-4-turbo",
@@ -35381,7 +35403,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4o-mini": {
 			"id": "openai/gpt-4o-mini",
@@ -35564,7 +35587,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5-image": {
 			"id": "openai/gpt-5-image",
@@ -35761,7 +35785,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.1-codex": {
 			"id": "openai/gpt-5.1-codex",
@@ -36652,7 +36677,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/o3-mini": {
 			"id": "openai/o3-mini",
@@ -36806,7 +36832,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/o4-mini-high": {
 			"id": "openai/o4-mini-high",
@@ -37071,7 +37098,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openrouter/pareto-code": {
 			"id": "openrouter/pareto-code",
@@ -37270,7 +37298,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"poolside/laguna-s-2.1": {
 			"id": "poolside/laguna-s-2.1",
@@ -37447,7 +37476,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"prime-intellect/intellect-3": {
 			"id": "prime-intellect/intellect-3",
@@ -37477,7 +37507,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"qwen/qwen-2.5-72b-instruct": {
 			"id": "qwen/qwen-2.5-72b-instruct",
@@ -39132,7 +39163,8 @@
 			},
 			"contextWindow": 8192,
 			"maxTokens": 8192,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"sao10k/l3-lunaris-8b": {
 			"id": "sao10k/l3-lunaris-8b",
@@ -40332,7 +40364,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"xiaomi/mimo-v2-omni": {
 			"id": "xiaomi/mimo-v2-omni",
@@ -40361,7 +40394,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"xiaomi/mimo-v2-omni:free": {
 			"id": "xiaomi/mimo-v2-omni:free",
@@ -40410,7 +40444,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"xiaomi/mimo-v2-pro:free": {
 			"id": "xiaomi/mimo-v2-pro:free",
@@ -40506,7 +40541,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"z-ai/glm-4.5": {
 			"id": "z-ai/glm-4.5",
@@ -64252,7 +64288,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"inclusionai/ring-2.6-1t": {
 			"id": "inclusionai/ring-2.6-1t",
@@ -65818,7 +65855,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"sao10k/l3-70b-euryale-v2.1": {
 			"id": "sao10k/l3-70b-euryale-v2.1",
@@ -77611,7 +77649,8 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
@@ -77765,7 +77804,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-sonnet-5": {
 			"id": "anthropic/claude-sonnet-5",
@@ -79944,7 +79984,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"inclusionai/ling-3.0-flash:free": {
 			"id": "inclusionai/ling-3.0-flash:free",
@@ -80003,7 +80044,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"inclusionai/ring-2.6-1t": {
 			"id": "inclusionai/ring-2.6-1t",
@@ -80460,7 +80502,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"minimax/minimax-m1": {
 			"id": "minimax/minimax-m1",
@@ -81529,7 +81572,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -82000,7 +82044,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"nvidia/nemotron-3-ultra-550b-a55b:free": {
 			"id": "nvidia/nemotron-3-ultra-550b-a55b:free",
@@ -82204,7 +82249,8 @@
 			},
 			"contextWindow": 16385,
 			"maxTokens": 4096,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4": {
 			"id": "openai/gpt-4",
@@ -82331,7 +82377,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4.1": {
 			"id": "openai/gpt-4.1",
@@ -82396,7 +82443,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
@@ -82439,7 +82487,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4.1:batch": {
 			"id": "openai/gpt-4.1:batch",
@@ -82460,7 +82509,8 @@
 			},
 			"contextWindow": 1047576,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4o": {
 			"id": "openai/gpt-4o",
@@ -82634,7 +82684,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4o:batch": {
 			"id": "openai/gpt-4o:batch",
@@ -82655,7 +82706,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-4o:extended": {
 			"id": "openai/gpt-4o:extended",
@@ -82769,7 +82821,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5-image": {
 			"id": "openai/gpt-5-image",
@@ -83016,7 +83069,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5:batch": {
 			"id": "openai/gpt-5:batch",
@@ -83367,7 +83421,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.2:batch": {
 			"id": "openai/gpt-5.2:batch",
@@ -83667,7 +83722,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.4:batch": {
 			"id": "openai/gpt-5.4:batch",
@@ -83793,7 +83849,8 @@
 				]
 			},
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "openrouter/openai/gpt-5.4"
+			"contextPromotionTarget": "openrouter/openai/gpt-5.4",
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.5:batch": {
 			"id": "openai/gpt-5.5:batch",
@@ -83920,7 +83977,8 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.6-luna:batch": {
 			"id": "openai/gpt-5.6-luna:batch",
@@ -83951,7 +84009,8 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.6-sol": {
 			"id": "openai/gpt-5.6-sol",
@@ -84046,7 +84105,8 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.6-sol:batch": {
 			"id": "openai/gpt-5.6-sol:batch",
@@ -84077,7 +84137,8 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.6-terra": {
 			"id": "openai/gpt-5.6-terra",
@@ -84172,7 +84233,8 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.6-terra:batch": {
 			"id": "openai/gpt-5.6-terra:batch",
@@ -84203,7 +84265,8 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-audio": {
 			"id": "openai/gpt-audio",
@@ -84513,7 +84576,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/o3": {
 			"id": "openai/o3",
@@ -84669,7 +84733,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/o3-mini:batch": {
 			"id": "openai/o3-mini:batch",
@@ -84699,7 +84764,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/o3-pro": {
 			"id": "openai/o3-pro",
@@ -84762,7 +84828,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/o3:batch": {
 			"id": "openai/o3:batch",
@@ -84793,7 +84860,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/o4-mini": {
 			"id": "openai/o4-mini",
@@ -84920,7 +84988,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/o4-mini:batch": {
 			"id": "openai/o4-mini:batch",
@@ -84951,7 +85020,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openrouter/aurora-alpha": {
 			"id": "openrouter/aurora-alpha",
@@ -86992,7 +87062,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"qwen/qwq-32b": {
 			"id": "qwen/qwq-32b",
@@ -87514,7 +87585,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"tngtech/deepseek-r1t2-chimera": {
 			"id": "tngtech/deepseek-r1t2-chimera",
@@ -88545,13 +88617,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.2212,
-				"output": 0.6952,
-				"cacheRead": 0.04108,
+				"input": 0.2198,
+				"output": 0.6908,
+				"cacheRead": 0.040819999999999995,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 128000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -88593,7 +88665,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"z-ai/glm-5v-turbo": {
 			"id": "z-ai/glm-5v-turbo",
@@ -90133,6 +90206,7 @@
 			"contextWindow": 1048576,
 			"maxTokens": 393215,
 			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
 			"compat": {
 				"escapeBuiltinToolNames": true
 			}

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -16,16 +16,16 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"deepseek-ai/deepseek-v4-pro": {
 			"id": "deepseek-ai/deepseek-v4-pro",
@@ -43,7 +43,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
@@ -51,12 +51,11 @@
 					"high",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "openai-completions",
 			"provider": "aiand",
 			"baseUrl": "https://api.aiand.com/v1",
@@ -72,7 +71,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 131072,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -82,8 +81,37 @@
 					"high",
 					"xhigh"
 				]
+			}
+		},
+		"moonshotai/kimi-k2.6": {
+			"id": "moonshotai/kimi-k2.6",
+			"name": "Kimi K2.6",
+			"api": "openai-completions",
+			"provider": "aiand",
+			"baseUrl": "https://api.aiand.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.85,
+				"output": 3.5,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"moonshotai/kimi-k2.7-code": {
 			"id": "moonshotai/kimi-k2.7-code",
@@ -113,8 +141,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -175,8 +202,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"qwen/qwen3.6-27b": {
 			"id": "qwen/qwen3.6-27b",
@@ -190,13 +216,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.32,
-				"output": 3.2,
+				"input": 0,
+				"output": 0,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -205,8 +231,36 @@
 					"medium",
 					"high"
 				]
+			}
+		},
+		"zai-org/glm-5.1": {
+			"id": "zai-org/glm-5.1",
+			"name": "GLM 5.1",
+			"api": "openai-completions",
+			"provider": "aiand",
+			"baseUrl": "https://api.aiand.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false
+			"contextWindow": 202752,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"zai-org/glm-5.2": {
 			"id": "zai-org/glm-5.2",
@@ -224,7 +278,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -235,8 +289,7 @@
 					"high",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		}
 	},
 	"aimlapi": {
@@ -2266,11 +2319,11 @@
 		},
 		"claude-opus-4-1-20250805": {
 			"id": "claude-opus-4-1-20250805",
-			"name": "Claude Opus 4.1",
+			"name": "Claude 4.1 Opus",
 			"api": "openai-completions",
 			"provider": "aimlapi",
 			"baseUrl": "https://api.aimlapi.com/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text",
 				"image"
@@ -2282,17 +2335,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 32000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
+			"maxTokens": 32000
 		},
 		"claude-opus-4-20250514": {
 			"id": "claude-opus-4-20250514",
@@ -2649,6 +2692,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -2727,7 +2771,7 @@
 		},
 		"deepseek/deepseek-r1": {
 			"id": "deepseek/deepseek-r1",
-			"name": "R1",
+			"name": "DeepSeek-R1",
 			"api": "openai-completions",
 			"provider": "aimlapi",
 			"baseUrl": "https://api.aimlapi.com/v1",
@@ -5182,7 +5226,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "aimlapi",
 			"baseUrl": "https://api.aimlapi.com/v1",
@@ -7427,7 +7471,7 @@
 		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
-			"name": "MiMo V2.5 Pro",
+			"name": "MiMo-V2.5-Pro",
 			"api": "openai-completions",
 			"provider": "aimlapi",
 			"baseUrl": "https://api.aimlapi.com/v1",
@@ -7962,6 +8006,40 @@
 				"supportsDeveloperRole": false
 			}
 		},
+		"qwen3.8-max": {
+			"id": "qwen3.8-max",
+			"name": "Qwen3.8 Max",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"xhigh"
+				],
+				"defaultLevel": "xhigh"
+			},
+			"compat": {
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": true,
+				"thinkingFormat": "openai"
+			}
+		},
 		"qwen3.8-max-preview": {
 			"id": "qwen3.8-max-preview",
 			"name": "Qwen3.8 Max Preview",
@@ -7970,8 +8048,7 @@
 			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -7992,7 +8069,8 @@
 			},
 			"compat": {
 				"supportsDeveloperRole": false,
-				"supportsReasoningEffort": true
+				"supportsReasoningEffort": true,
+				"thinkingFormat": "openai"
 			}
 		}
 	},
@@ -11942,8 +12020,7 @@
 					"max"
 				],
 				"supportsDisplay": true
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"claude-opus-4-0": {
 			"id": "claude-opus-4-0",
@@ -12009,11 +12086,11 @@
 		},
 		"claude-opus-4-1-20250805": {
 			"id": "claude-opus-4-1-20250805",
-			"name": "Claude Opus 4.1",
+			"name": "Claude 4.1 Opus",
 			"api": "anthropic-messages",
 			"provider": "anthropic",
 			"baseUrl": "https://api.anthropic.com",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text",
 				"image"
@@ -12025,17 +12102,7 @@
 				"cacheWrite": 18.75
 			},
 			"contextWindow": 200000,
-			"maxTokens": 32000,
-			"thinking": {
-				"mode": "budget",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
+			"maxTokens": 32000
 		},
 		"claude-opus-4-20250514": {
 			"id": "claude-opus-4-20250514",
@@ -13214,10 +13281,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.2,
-				"output": 1.2,
-				"cacheRead": 0.02,
-				"cacheWrite": 0
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -13274,10 +13341,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 12,
-				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -15453,6 +15520,34 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			}
+		},
+		"deepseek-ai/DeepSeek-V4-Flash-0731": {
+			"id": "deepseek-ai/DeepSeek-V4-Flash-0731",
+			"name": "DeepSeek V4 Flash 0731",
+			"api": "openai-completions",
+			"provider": "coreweave",
+			"baseUrl": "https://api.inference.wandb.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.13,
+				"output": 0.28,
+				"cacheRead": 0.07,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -15469,9 +15564,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.74,
-				"output": 3.48,
-				"cacheRead": 0.14,
+				"input": 1.15,
+				"output": 2.55,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -15962,7 +16057,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-			"name": "Qwen3 235B A22B-2507",
+			"name": "Qwen3 235B-A22B Instruct 2507",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -15981,7 +16076,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-			"name": "Qwen3 235B A22B Thinking-2507",
+			"name": "Qwen3-235B-A22B-Thinking-2507",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -16048,7 +16143,7 @@
 		},
 		"Qwen/Qwen3.5-27B": {
 			"id": "Qwen/Qwen3.5-27B",
-			"name": "Qwen3.5-27B",
+			"name": "Qwen3.5 27B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -20939,6 +21034,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -21063,6 +21159,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -21094,6 +21191,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -22430,6 +22528,45 @@
 				"requiresEffort": true
 			}
 		},
+		"gemini-3.6-flash": {
+			"id": "gemini-3.6-flash",
+			"name": "Gemini 3.6 Flash",
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.5,
+				"output": 7.5,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15",
+				"X-GitHub-Api-Version": "2026-06-01"
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
+		},
 		"gpt-4.1": {
 			"id": "gpt-4.1",
 			"name": "GPT-4.1",
@@ -22923,10 +23060,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -22991,10 +23128,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 3.125
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -23010,6 +23147,40 @@
 					"high",
 					"xhigh",
 					"max"
+				]
+			}
+		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-responses",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15",
+				"X-GitHub-Api-Version": "2026-06-01"
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
 				]
 			}
 		},
@@ -23085,6 +23256,48 @@
 					"medium",
 					"high"
 				]
+			}
+		},
+		"kimi-k3": {
+			"id": "kimi-k3",
+			"name": "Kimi K3",
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"headers": {
+				"User-Agent": "opencode/1.3.15",
+				"X-GitHub-Api-Version": "2026-06-01"
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"effortMap": {
+					"max": "max"
+				},
+				"requiresEffort": true
 			}
 		},
 		"mai-code-1-flash-picker": {
@@ -23686,6 +23899,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -26672,7 +26886,7 @@
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
-			"name": "Qwen3-32B",
+			"name": "Qwen3 32B",
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
@@ -26702,6 +26916,35 @@
 					"medium": "default",
 					"high": "default"
 				}
+			}
+		},
+		"qwen/qwen3.6-27b": {
+			"id": "qwen/qwen3.6-27b",
+			"name": "Qwen3.6 27B",
+			"api": "openai-completions",
+			"provider": "groq",
+			"baseUrl": "https://api.groq.com/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 3,
+				"cacheRead": 0.3,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
 			}
 		}
 	},
@@ -26758,9 +27001,9 @@
 				]
 			}
 		},
-		"deepseek-ai/DeepSeek-V3.1": {
-			"id": "deepseek-ai/DeepSeek-V3.1",
-			"name": "DeepSeek V3.1",
+		"deepseek-ai/DeepSeek-V3": {
+			"id": "deepseek-ai/DeepSeek-V3",
+			"name": "DeepSeek-V3",
 			"api": "openai-completions",
 			"provider": "huggingface",
 			"baseUrl": "https://router.huggingface.co/v1",
@@ -26769,13 +27012,39 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 1.25,
-				"cacheRead": 0.6,
-				"cacheWrite": 0.6
+				"input": 0.4,
+				"output": 1.3,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 64000,
+			"maxTokens": 8192
+		},
+		"deepseek-ai/DeepSeek-V3.1": {
+			"id": "deepseek-ai/DeepSeek-V3.1",
+			"name": "DeepSeek-V3.1",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.27,
+				"output": 1,
+				"cacheRead": 0,
+				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				]
+			}
 		},
 		"deepseek-ai/DeepSeek-V3.2": {
 			"id": "deepseek-ai/DeepSeek-V3.2",
@@ -26824,6 +27093,34 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			}
+		},
+		"deepseek-ai/DeepSeek-V4-Flash-0731": {
+			"id": "deepseek-ai/DeepSeek-V4-Flash-0731",
+			"name": "DeepSeek V4 Flash 0731",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -27368,6 +27665,25 @@
 				]
 			}
 		},
+		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
+			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+			"name": "Qwen3 235B-A22B Instruct 2507",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.855,
+				"output": 2.565,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384
+		},
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
 			"name": "Qwen3-235B-A22B-Thinking-2507",
@@ -27841,6 +28157,36 @@
 				]
 			}
 		},
+		"thinkingmachines/Inkling-Small": {
+			"id": "thinkingmachines/Inkling-Small",
+			"name": "Inkling Small",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.5,
+				"output": 1.2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 1048576,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"XiaomiMiMo/MiMo-V2-Flash": {
 			"id": "XiaomiMiMo/MiMo-V2-Flash",
 			"name": "MiMo-V2-Flash",
@@ -28192,23 +28538,33 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"~anthropic/claude-haiku-latest": {
 			"id": "~anthropic/claude-haiku-latest",
-			"name": "Claude Haiku Latest",
+			"name": "Anthropic Claude Haiku Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28268,7 +28624,7 @@
 		},
 		"~anthropic/claude-sonnet-latest": {
 			"id": "~anthropic/claude-sonnet-latest",
-			"name": "Claude Sonnet Latest",
+			"name": "Anthropic Claude Sonnet Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28278,10 +28634,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 3,
-				"output": 15,
-				"cacheRead": 0.3,
-				"cacheWrite": 3.75
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -28302,23 +28658,30 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.09,
+				"output": 0.18,
+				"cacheRead": 0.018,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
-			"supportsComputerUse": false
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			}
 		},
 		"~google/gemini-flash-latest": {
 			"id": "~google/gemini-flash-latest",
-			"name": "Gemini Flash Latest",
+			"name": "Google Gemini Flash Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28329,9 +28692,9 @@
 			],
 			"cost": {
 				"input": 1.5,
-				"output": 9,
+				"output": 7.5,
 				"cacheRead": 0.15,
-				"cacheWrite": 0.08333333333333334
+				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -28348,7 +28711,7 @@
 		},
 		"~google/gemini-pro-latest": {
 			"id": "~google/gemini-pro-latest",
-			"name": "Gemini Pro Latest",
+			"name": "Google Gemini Pro Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28378,7 +28741,7 @@
 		},
 		"~moonshotai/kimi-latest": {
 			"id": "~moonshotai/kimi-latest",
-			"name": "Kimi Latest",
+			"name": "MoonshotAI Kimi Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28388,13 +28751,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.74,
-				"output": 3.49,
-				"cacheRead": 0.14,
+				"input": 2.5,
+				"output": 14,
+				"cacheRead": 0.29,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262142,
-			"maxTokens": 262142,
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -28408,7 +28771,7 @@
 		},
 		"~openai/gpt-latest": {
 			"id": "~openai/gpt-latest",
-			"name": "GPT Latest",
+			"name": "OpenAI GPT Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28421,7 +28784,7 @@
 				"input": 5,
 				"output": 30,
 				"cacheRead": 0.5,
-				"cacheWrite": 0
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -28438,7 +28801,7 @@
 		},
 		"~openai/gpt-mini-latest": {
 			"id": "~openai/gpt-mini-latest",
-			"name": "GPT Mini Latest",
+			"name": "OpenAI GPT Mini Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28472,19 +28835,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"ai21/jamba-large-1.7": {
 			"id": "ai21/jamba-large-1.7",
@@ -28553,19 +28926,28 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.8,
+				"output": 1.6,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"aion-labs/aion-3.0": {
 			"id": "aion-labs/aion-3.0",
@@ -28573,19 +28955,28 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 6,
+				"cacheRead": 0.75,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"aion-labs/aion-3.0-mini": {
 			"id": "aion-labs/aion-3.0-mini",
@@ -28593,19 +28984,28 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.7,
+				"output": 1.4,
+				"cacheRead": 0.18,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"aion-labs/aion-rp-llama-3.1-8b": {
 			"id": "aion-labs/aion-rp-llama-3.1-8b",
@@ -28919,7 +29319,7 @@
 			"cost": {
 				"input": 2.5,
 				"output": 12.5,
-				"cacheRead": 0,
+				"cacheRead": 0.625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -29003,7 +29403,8 @@
 				"cacheWrite": 1
 			},
 			"contextWindow": 200000,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-3.5-sonnet": {
 			"id": "anthropic/claude-3.5-sonnet",
@@ -29092,10 +29493,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -29108,8 +29509,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
@@ -29289,7 +29689,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.7": {
 			"id": "anthropic/claude-opus-4.7",
@@ -29323,7 +29724,7 @@
 		},
 		"anthropic/claude-opus-4.7-fast": {
 			"id": "anthropic/claude-opus-4.7-fast",
-			"name": "Claude Opus 4.7 (Fast)",
+			"name": "Claude Opus 4.7",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -29363,10 +29764,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -29379,28 +29780,37 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"anthropic/claude-opus-4.8-fast": {
 			"id": "anthropic/claude-opus-4.8-fast",
-			"name": "Claude Opus 4.8 (Fast)",
+			"name": "Claude Opus 4.8",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"anthropic/claude-opus-5": {
 			"id": "anthropic/claude-opus-5",
@@ -29414,14 +29824,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -29435,23 +29844,33 @@
 		},
 		"anthropic/claude-opus-5-fast": {
 			"id": "anthropic/claude-opus-5-fast",
-			"name": "Claude Opus 5 (Fast)",
+			"name": "Claude Opus 5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
@@ -29527,8 +29946,8 @@
 			"cost": {
 				"input": 3,
 				"output": 15,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -29555,10 +29974,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -29571,8 +29990,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"arcee-ai/coder-large": {
 			"id": "arcee-ai/coder-large",
@@ -29692,7 +30110,7 @@
 			"cost": {
 				"input": 0.22,
 				"output": 0.85,
-				"cacheRead": 0,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -29757,7 +30175,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"arcee-ai/virtuoso-large": {
 			"id": "arcee-ai/virtuoso-large",
@@ -29805,7 +30224,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"baidu/ernie-4.5-21b-a3b": {
 			"id": "baidu/ernie-4.5-21b-a3b",
@@ -29824,7 +30244,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 120000,
-			"maxTokens": 8000
+			"maxTokens": 8000,
+			"supportsComputerUse": false
 		},
 		"baidu/ernie-4.5-300b-a47b": {
 			"id": "baidu/ernie-4.5-300b-a47b",
@@ -29875,7 +30296,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"baidu/ernie-4.5-vl-424b-a47b": {
 			"id": "baidu/ernie-4.5-vl-424b-a47b",
@@ -30142,7 +30564,7 @@
 		},
 		"cohere/command-r-08-2024": {
 			"id": "cohere/command-r-08-2024",
-			"name": "Command R (08-2024)",
+			"name": "Command R",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -30161,7 +30583,7 @@
 		},
 		"cohere/command-r-plus-08-2024": {
 			"id": "cohere/command-r-plus-08-2024",
-			"name": "Command R+ (08-2024)",
+			"name": "Command R+",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -30195,7 +30617,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4000
+			"maxTokens": 4000,
+			"supportsComputerUse": false
 		},
 		"cohere/north-mini-code:free": {
 			"id": "cohere/north-mini-code:free",
@@ -30203,7 +30626,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -30215,7 +30638,16 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 64000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"corethink:free": {
 			"id": "corethink:free",
@@ -30260,7 +30692,7 @@
 		},
 		"deepseek/deepseek-chat": {
 			"id": "deepseek/deepseek-chat",
-			"name": "DeepSeek V3",
+			"name": "DeepSeek Chat",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -30269,13 +30701,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.32,
-				"output": 0.89,
-				"cacheRead": 0.15,
+				"input": 0.4,
+				"output": 1.3,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
-			"maxTokens": 163840
+			"contextWindow": 128000,
+			"maxTokens": 16000
 		},
 		"deepseek/deepseek-chat-v3-0324": {
 			"id": "deepseek/deepseek-chat-v3-0324",
@@ -30288,9 +30720,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.2,
-				"output": 0.77,
-				"cacheRead": 0.095,
+				"input": 0.27,
+				"output": 1.12,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
@@ -30307,13 +30739,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.75,
-				"cacheRead": 0,
+				"input": 0.27,
+				"output": 1,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
-			"maxTokens": 7168,
+			"contextWindow": 163840,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -30324,7 +30756,7 @@
 		},
 		"deepseek/deepseek-r1": {
 			"id": "deepseek/deepseek-r1",
-			"name": "R1",
+			"name": "DeepSeek-R1",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -30359,13 +30791,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.45,
-				"output": 2.15,
-				"cacheRead": 0.2,
+				"input": 0.7,
+				"output": 2.5,
+				"cacheRead": 0.35,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 65536,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -30426,12 +30858,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.21,
-				"output": 0.79,
-				"cacheRead": 0.13,
+				"input": 0.27,
+				"output": 1,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
+			"contextWindow": 131072,
 			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
@@ -30473,13 +30905,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 0.38,
-				"cacheRead": 0.125,
+				"input": 0.269,
+				"output": 0.4,
+				"cacheRead": 0.1345,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 65536,
+			"maxTokens": 163840,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -30548,14 +30980,15 @@
 			"cost": {
 				"input": 0.14,
 				"output": 0.28,
-				"cacheRead": 0.0028,
+				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -30567,19 +31000,26 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			}
 		},
 		"deepseek/deepseek-v4-flash:discounted": {
 			"id": "deepseek/deepseek-v4-flash:discounted",
@@ -30587,19 +31027,26 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.0028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			}
 		},
 		"deepseek/deepseek-v4-flash:free": {
 			"id": "deepseek/deepseek-v4-flash:free",
@@ -30633,9 +31080,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.435,
-				"output": 0.87,
-				"cacheRead": 0.003625,
+				"input": 1.6,
+				"output": 3.2,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -30654,19 +31101,25 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.435,
+				"output": 0.87,
+				"cacheRead": 0.003625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				]
+			}
 		},
 		"eleutherai/llemma_7b": {
 			"id": "eleutherai/llemma_7b",
@@ -30706,7 +31159,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
-			"maxTokens": 6554
+			"maxTokens": 6554,
+			"supportsComputerUse": false
 		},
 		"giga-potato": {
 			"id": "giga-potato",
@@ -30765,7 +31219,8 @@
 				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.0-flash-lite-001": {
 			"id": "google/gemini-2.0-flash-lite-001",
@@ -30785,7 +31240,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.5-flash": {
 			"id": "google/gemini-2.5-flash",
@@ -30838,7 +31294,7 @@
 		},
 		"google/gemini-2.5-flash-lite": {
 			"id": "google/gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -30892,7 +31348,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.5-pro": {
 			"id": "google/gemini-2.5-pro",
@@ -31016,23 +31473,31 @@
 		},
 		"google/gemini-3-pro-image": {
 			"id": "google/gemini-3-pro-image",
-			"name": "Nano Banana Pro (Gemini 3 Pro Image)",
+			"name": "Nano Banana Pro",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 65536,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high"
+				],
+				"requiresEffort": true
+			}
 		},
 		"google/gemini-3-pro-image-preview": {
 			"id": "google/gemini-3-pro-image-preview",
@@ -31148,7 +31613,7 @@
 				"input": 0.25,
 				"output": 1.5,
 				"cacheRead": 0.025,
-				"cacheWrite": 0.08333
+				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -31197,8 +31662,8 @@
 			"cost": {
 				"input": 0.25,
 				"output": 1.5,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheRead": 0.025,
+				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -31227,8 +31692,8 @@
 			"cost": {
 				"input": 2,
 				"output": 12,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheRead": 0.2,
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -31255,8 +31720,8 @@
 			"cost": {
 				"input": 2,
 				"output": 12,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheRead": 0.2,
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -31284,7 +31749,7 @@
 				"input": 1.5,
 				"output": 9,
 				"cacheRead": 0.15,
-				"cacheWrite": 0.08333
+				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -31305,19 +31770,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.3,
+				"output": 2.5,
+				"cacheRead": 0.03,
+				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
 		},
 		"google/gemini-3.6-flash": {
 			"id": "google/gemini-3.6-flash",
@@ -31325,19 +31800,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 1.5,
+				"output": 7.5,
+				"cacheRead": 0.15,
+				"cacheWrite": 0.083333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
 		},
 		"google/gemma-2-27b-it": {
 			"id": "google/gemma-2-27b-it",
@@ -31382,7 +31867,7 @@
 		},
 		"google/gemma-3-12b-it": {
 			"id": "google/gemma-3-12b-it",
-			"name": "Gemma 3 12B IT",
+			"name": "Gemma 3 12B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31392,14 +31877,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
+				"input": 0.05,
+				"output": 0.15,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 16384,
-			"supportsComputerUse": false
+			"maxTokens": 16384
 		},
 		"google/gemma-3-27b-it": {
 			"id": "google/gemma-3-27b-it",
@@ -31413,13 +31897,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.03,
-				"output": 0.11,
-				"cacheRead": 0.02,
+				"input": 0.08,
+				"output": 0.16,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 65536
+			"contextWindow": 131072,
+			"maxTokens": 131072
 		},
 		"google/gemma-3-4b-it": {
 			"id": "google/gemma-3-4b-it",
@@ -31465,7 +31949,7 @@
 		},
 		"google/gemma-4-26b-a4b-it": {
 			"id": "google/gemma-4-26b-a4b-it",
-			"name": "Gemma 4 26B A4B",
+			"name": "Gemma 4 26B A4B IT",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31475,13 +31959,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.12,
-				"output": 0.4,
+				"input": 0.07,
+				"output": 0.34,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -31495,7 +31979,7 @@
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31505,13 +31989,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.4,
-				"cacheRead": 0,
+				"input": 0.08,
+				"output": 0.35,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 131072,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -31735,7 +32219,7 @@
 		},
 		"inclusionai/ling-2.6-flash": {
 			"id": "inclusionai/ling-2.6-flash",
-			"name": "Ling-2.6 Flash",
+			"name": "Ling-2.6-flash",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31744,9 +32228,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.24,
-				"cacheRead": 0.016,
+				"input": 0.1,
+				"output": 0.3,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -31773,6 +32257,35 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"inclusionai/ling-3.0-flash": {
+			"id": "inclusionai/ling-3.0-flash",
+			"name": "Ling-3.0-flash",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.06,
+				"output": 0.18,
+				"cacheRead": 0.012,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"inclusionai/ling-3.0-flash:free": {
 			"id": "inclusionai/ling-3.0-flash:free",
 			"name": "Ling-3.0-flash (free)",
@@ -31791,7 +32304,37 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
+		},
+		"inclusionai/ling-3.0-tiny:free": {
+			"id": "inclusionai/ling-3.0-tiny:free",
+			"name": "Ling 3.0 Tiny (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"inclusionai/ring-2.6-1t": {
 			"id": "inclusionai/ring-2.6-1t",
@@ -31804,9 +32347,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.075,
-				"output": 0.625,
-				"cacheRead": 0.015,
+				"input": 0.3,
+				"output": 2.5,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -31887,22 +32430,23 @@
 		},
 		"kilo-auto/balanced": {
 			"id": "kilo-auto/balanced",
-			"name": "Kilo Auto Balanced",
+			"name": "Auto Balanced",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 3,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.325,
+				"output": 1.95,
+				"cacheRead": 0.0325,
+				"cacheWrite": 0.40625
 			},
-			"contextWindow": 204800,
-			"maxTokens": 131072,
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -31920,23 +32464,33 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.325,
+				"output": 1.95,
+				"cacheRead": 0.0325,
+				"cacheWrite": 0.40625
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"kilo-auto/free": {
 			"id": "kilo-auto/free",
-			"name": "Kilo Auto Free",
+			"name": "Auto Free",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31950,8 +32504,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
-			"maxTokens": 131072,
+			"contextWindow": 256000,
+			"maxTokens": 10000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -31965,7 +32519,7 @@
 		},
 		"kilo-auto/frontier": {
 			"id": "kilo-auto/frontier",
-			"name": "Kilo Auto Frontier",
+			"name": "Auto Frontier",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -31977,8 +32531,8 @@
 			"cost": {
 				"input": 5,
 				"output": 25,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -31995,7 +32549,7 @@
 		},
 		"kilo-auto/small": {
 			"id": "kilo-auto/small",
-			"name": "Kilo Auto Small",
+			"name": "Auto Small",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32007,11 +32561,11 @@
 			"cost": {
 				"input": 0.05,
 				"output": 0.4,
-				"cacheRead": 0,
+				"cacheRead": 0.005,
 				"cacheWrite": 0
 			},
-			"contextWindow": 400000,
-			"maxTokens": 128000,
+			"contextWindow": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -32097,14 +32651,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 256000,
+			"maxTokens": 80000
 		},
 		"kwaipilot/kat-coder-pro": {
 			"id": "kwaipilot/kat-coder-pro",
@@ -32157,14 +32710,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.74,
+				"output": 2.96,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 256000,
+			"maxTokens": 80000
 		},
 		"kwaipilot/kat-coder-pro-v2.5:free": {
 			"id": "kwaipilot/kat-coder-pro-v2.5:free",
@@ -32276,19 +32828,28 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.75,
+				"output": 3,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 1048756,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"meituan/longcat-flash-chat": {
 			"id": "meituan/longcat-flash-chat",
@@ -32349,7 +32910,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 8192,
-			"maxTokens": 16384
+			"maxTokens": 16384,
+			"supportsComputerUse": false
 		},
 		"meta-llama/llama-3.1-405b": {
 			"id": "meta-llama/llama-3.1-405b",
@@ -32410,7 +32972,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 26215
+			"maxTokens": 16384
 		},
 		"meta-llama/llama-3.1-8b-instruct": {
 			"id": "meta-llama/llama-3.1-8b-instruct",
@@ -32424,12 +32986,12 @@
 			],
 			"cost": {
 				"input": 0.02,
-				"output": 0.05,
+				"output": 0.04,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 16384,
-			"maxTokens": 16384
+			"contextWindow": 131072,
+			"maxTokens": 131072
 		},
 		"meta-llama/llama-3.2-11b-vision-instruct": {
 			"id": "meta-llama/llama-3.2-11b-vision-instruct",
@@ -32494,7 +33056,7 @@
 		},
 		"meta-llama/llama-3.3-70b-instruct": {
 			"id": "meta-llama/llama-3.3-70b-instruct",
-			"name": "Llama 3.3 70B Instruct",
+			"name": "Llama-3.3-70B-Instruct",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32523,8 +33085,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.6,
+				"input": 0.2,
+				"output": 0.696,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -32543,7 +33105,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.08,
+				"input": 0.1,
 				"output": 0.3,
 				"cacheRead": 0,
 				"cacheWrite": 0
@@ -32640,19 +33202,59 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.25,
+				"output": 4.25,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 1048576,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"meta/muse-spark-1.2": {
+			"id": "meta/muse-spark-1.2",
+			"name": "Muse Spark 1.2",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 4.25,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"microsoft/phi-4": {
 			"id": "microsoft/phi-4",
@@ -32766,7 +33368,7 @@
 		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
-			"name": "MiniMax M2",
+			"name": "MiniMax-M2",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32775,13 +33377,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.255,
-				"output": 1,
-				"cacheRead": 0.03,
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
-			"maxTokens": 196608,
+			"contextWindow": 204800,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -32814,7 +33416,7 @@
 		},
 		"minimax/minimax-m2.1": {
 			"id": "minimax/minimax-m2.1",
-			"name": "MiniMax M2.1",
+			"name": "MiniMax-M2.1",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32823,13 +33425,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.27,
-				"output": 0.95,
+				"input": 0.3,
+				"output": 1.2,
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
-			"maxTokens": 39322,
+			"contextWindow": 204800,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -32842,7 +33444,7 @@
 		},
 		"minimax/minimax-m2.5": {
 			"id": "minimax/minimax-m2.5",
-			"name": "MiniMax M2.5",
+			"name": "MiniMax-M2.5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32851,9 +33453,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
+				"input": 0.3,
 				"output": 1.2,
-				"cacheRead": 0.029,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
@@ -32891,7 +33493,7 @@
 		},
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
-			"name": "MiniMax M2.7",
+			"name": "MiniMax-M2.7",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32919,7 +33521,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -32934,7 +33536,7 @@
 				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 524288,
 			"maxTokens": 512000,
 			"thinking": {
 				"mode": "effort",
@@ -32981,7 +33583,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 0.9,
-				"cacheRead": 0,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -33004,7 +33606,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536
+			"maxTokens": 65536,
+			"supportsComputerUse": false
 		},
 		"mistralai/devstral-medium": {
 			"id": "mistralai/devstral-medium",
@@ -33023,7 +33626,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 26215
+			"maxTokens": 26215,
+			"supportsComputerUse": false
 		},
 		"mistralai/devstral-small": {
 			"id": "mistralai/devstral-small",
@@ -33042,7 +33646,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 26215
+			"maxTokens": 26215,
+			"supportsComputerUse": false
 		},
 		"mistralai/ministral-14b-2512": {
 			"id": "mistralai/ministral-14b-2512",
@@ -33058,7 +33663,7 @@
 			"cost": {
 				"input": 0.2,
 				"output": 0.2,
-				"cacheRead": 0,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -33078,7 +33683,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -33098,7 +33703,7 @@
 			"cost": {
 				"input": 0.15,
 				"output": 0.15,
-				"cacheRead": 0,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -33180,7 +33785,7 @@
 			"cost": {
 				"input": 2,
 				"output": 6,
-				"cacheRead": 0,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -33199,7 +33804,7 @@
 			"cost": {
 				"input": 2,
 				"output": 6,
-				"cacheRead": 0,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -33222,11 +33827,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 26215
+			"maxTokens": 26215,
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-large-2512": {
 			"id": "mistralai/mistral-large-2512",
-			"name": "Mistral Large 3 2512",
+			"name": "Mistral Large 3",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -33238,7 +33844,7 @@
 			"cost": {
 				"input": 0.5,
 				"output": 1.5,
-				"cacheRead": 0,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -33258,7 +33864,7 @@
 			"cost": {
 				"input": 0.4,
 				"output": 2,
-				"cacheRead": 0,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -33308,7 +33914,7 @@
 			"cost": {
 				"input": 0.4,
 				"output": 2,
-				"cacheRead": 0,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -33325,8 +33931,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.02,
-				"output": 0.04,
+				"input": 0.019,
+				"output": 0.03,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -33346,7 +33952,7 @@
 			"cost": {
 				"input": 0.2,
 				"output": 0.6,
-				"cacheRead": 0,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
@@ -33369,7 +33975,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
-			"maxTokens": 16384
+			"maxTokens": 16384,
+			"supportsComputerUse": false
 		},
 		"mistralai/mistral-small-2603": {
 			"id": "mistralai/mistral-small-2603",
@@ -33433,13 +34040,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.06,
-				"output": 0.18,
-				"cacheRead": 0.03,
+				"input": 0.09375,
+				"output": 0.25,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 131072
+			"contextWindow": 256000,
+			"maxTokens": 16384
 		},
 		"mistralai/mistral-small-creative": {
 			"id": "mistralai/mistral-small-creative",
@@ -33475,7 +34082,7 @@
 			"cost": {
 				"input": 2,
 				"output": 6,
-				"cacheRead": 0,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 65536,
@@ -33520,7 +34127,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 32768
+			"maxTokens": 32768,
+			"supportsComputerUse": false
 		},
 		"mistralai/voxtral-small-24b-2507": {
 			"id": "mistralai/voxtral-small-24b-2507",
@@ -33535,7 +34143,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.3,
-				"cacheRead": 0,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 32000,
@@ -33552,13 +34160,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.55,
-				"output": 2.2,
+				"input": 0.57,
+				"output": 2.3,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131000,
-			"maxTokens": 26215
+			"contextWindow": 131072,
+			"maxTokens": 100352
 		},
 		"moonshotai/kimi-k2-0905": {
 			"id": "moonshotai/kimi-k2-0905",
@@ -33571,13 +34179,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.4,
-				"output": 2,
-				"cacheRead": 0.15,
+				"input": 0.6,
+				"output": 2.5,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 26215
+			"contextWindow": 262144,
+			"maxTokens": 100352
 		},
 		"moonshotai/kimi-k2-0905:exacto": {
 			"id": "moonshotai/kimi-k2-0905:exacto",
@@ -33611,13 +34219,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.47,
-				"output": 2,
-				"cacheRead": 0.2,
+				"input": 0.6,
+				"output": 2.5,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 65535,
+			"contextWindow": 262144,
+			"maxTokens": 100352,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -33642,13 +34250,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.45,
-				"output": 2.2,
-				"cacheRead": 0,
+				"input": 0.6,
+				"output": 3,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65535,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -33693,13 +34301,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
-				"output": 3.5,
-				"cacheRead": 0.375,
+				"input": 0.8,
+				"output": 3.4,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65535,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -33744,9 +34352,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.19,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -33760,8 +34368,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -33775,13 +34382,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -33794,8 +34401,7 @@
 					"max": "max"
 				},
 				"requiresEffort": true
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"morph-warp-grep-v2": {
 			"id": "morph-warp-grep-v2",
@@ -33917,7 +34523,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 163840
+			"maxTokens": 163840,
+			"supportsComputerUse": false
 		},
 		"nex-agi/nex-n2-mini": {
 			"id": "nex-agi/nex-n2-mini",
@@ -33925,19 +34532,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.025,
+				"output": 0.1,
+				"cacheRead": 0.0025,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
@@ -33945,19 +34562,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.25,
+				"output": 1,
+				"cacheRead": 0.025,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nex-agi/nex-n2-pro:free": {
 			"id": "nex-agi/nex-n2-pro:free",
@@ -34135,7 +34762,7 @@
 		},
 		"nvidia/llama-3.3-nemotron-super-49b-v1.5": {
 			"id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
-			"name": "Llama 3.3 Nemotron Super 49B V1.5",
+			"name": "Llama 3.3 Nemotron Super 49B v1.5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34160,7 +34787,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"nvidia/nemotron-3-nano-30b-a3b": {
 			"id": "nvidia/nemotron-3-nano-30b-a3b",
@@ -34175,11 +34803,11 @@
 			"cost": {
 				"input": 0.05,
 				"output": 0.2,
-				"cacheRead": 0,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 52429,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -34224,7 +34852,7 @@
 		},
 		"nvidia/nemotron-3-super-120b-a12b": {
 			"id": "nvidia/nemotron-3-super-120b-a12b",
-			"name": "Nemotron 3 Super",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34233,13 +34861,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.1,
-				"output": 0.5,
-				"cacheRead": 0.1,
+				"input": 0.085,
+				"output": 0.4,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -34291,6 +34919,35 @@
 				"text"
 			],
 			"cost": {
+				"input": 0.5,
+				"output": 2.2,
+				"cacheRead": 0.1,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512288,
+			"maxTokens": 512288,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"nvidia/nemotron-3-ultra-550b-a55b:free": {
+			"id": "nvidia/nemotron-3-ultra-550b-a55b:free",
+			"name": "Nemotron 3 Ultra (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
 				"input": 0,
 				"output": 0,
 				"cacheRead": 0,
@@ -34307,28 +34964,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
-		},
-		"nvidia/nemotron-3-ultra-550b-a55b:free": {
-			"id": "nvidia/nemotron-3-ultra-550b-a55b:free",
-			"name": "Nemotron 3 Ultra (free)",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			}
 		},
 		"nvidia/nemotron-3.5-content-safety:free": {
 			"id": "nvidia/nemotron-3.5-content-safety:free",
@@ -34409,11 +35045,12 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-3.5-turbo": {
 			"id": "openai/gpt-3.5-turbo",
-			"name": "GPT-3.5 Turbo",
+			"name": "GPT-3.5-turbo",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34524,7 +35161,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 8191,
-			"maxTokens": 4096
+			"maxTokens": 4096,
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4-1106-preview": {
 			"id": "openai/gpt-4-1106-preview",
@@ -34543,7 +35181,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4096
+			"maxTokens": 4096,
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4-turbo": {
 			"id": "openai/gpt-4-turbo",
@@ -34606,7 +35245,7 @@
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
-			"name": "GPT-4.1 Mini",
+			"name": "GPT-4.1 mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34626,7 +35265,7 @@
 		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
-			"name": "GPT-4.1 Nano",
+			"name": "GPT-4.1 nano",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34741,11 +35380,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 16384
+			"maxTokens": 16384,
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o-mini": {
 			"id": "openai/gpt-4o-mini",
-			"name": "GPT-4o-mini",
+			"name": "GPT-4o mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -34777,7 +35417,7 @@
 			"cost": {
 				"input": 0.15,
 				"output": 0.6,
-				"cacheRead": 0,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -34923,7 +35563,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-image": {
 			"id": "openai/gpt-5-image",
@@ -34952,7 +35593,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-image-mini": {
 			"id": "openai/gpt-5-image-mini",
@@ -34981,7 +35623,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-mini": {
 			"id": "openai/gpt-5-mini",
@@ -35117,11 +35760,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 16384
+			"maxTokens": 16384,
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1-codex": {
 			"id": "openai/gpt-5.1-codex",
-			"name": "GPT-5.1-Codex",
+			"name": "GPT-5.1 Codex",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35133,7 +35777,7 @@
 			"cost": {
 				"input": 1.25,
 				"output": 10,
-				"cacheRead": 0.125,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -35150,7 +35794,7 @@
 		},
 		"openai/gpt-5.1-codex-max": {
 			"id": "openai/gpt-5.1-codex-max",
-			"name": "GPT-5.1-Codex-Max",
+			"name": "GPT-5.1 Codex Max",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35179,7 +35823,7 @@
 		},
 		"openai/gpt-5.1-codex-mini": {
 			"id": "openai/gpt-5.1-codex-mini",
-			"name": "GPT-5.1-Codex-Mini",
+			"name": "GPT-5.1 Codex mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35191,11 +35835,11 @@
 			"cost": {
 				"input": 0.25,
 				"output": 2,
-				"cacheRead": 0.025,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 100000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -35255,7 +35899,7 @@
 		},
 		"openai/gpt-5.2-codex": {
 			"id": "openai/gpt-5.2-codex",
-			"name": "GPT-5.2-Codex",
+			"name": "GPT-5.2 Codex",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35325,7 +35969,7 @@
 			"cost": {
 				"input": 1.75,
 				"output": 14,
-				"cacheRead": 0,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -35333,7 +35977,7 @@
 		},
 		"openai/gpt-5.3-codex": {
 			"id": "openai/gpt-5.3-codex",
-			"name": "GPT-5.3-Codex",
+			"name": "GPT-5.3 Codex",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35345,7 +35989,7 @@
 			"cost": {
 				"input": 1.75,
 				"output": 14,
-				"cacheRead": 0,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -35374,7 +36018,7 @@
 			"cost": {
 				"input": 2.5,
 				"output": 15,
-				"cacheRead": 0,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1050000,
@@ -35411,7 +36055,7 @@
 		},
 		"openai/gpt-5.4-mini": {
 			"id": "openai/gpt-5.4-mini",
-			"name": "GPT-5.4 Mini",
+			"name": "GPT-5.4 mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35440,7 +36084,7 @@
 		},
 		"openai/gpt-5.4-nano": {
 			"id": "openai/gpt-5.4-nano",
-			"name": "GPT-5.4 Nano",
+			"name": "GPT-5.4 nano",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35568,12 +36212,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
-			"contextWindow": 372000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -35584,28 +36228,37 @@
 					"xhigh",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"openai/gpt-5.6-luna-pro": {
 			"id": "openai/gpt-5.6-luna-pro",
-			"name": "GPT-5.6 Luna Pro",
+			"name": "GPT-5.6 Luna",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		},
 		"openai/gpt-5.6-sol": {
 			"id": "openai/gpt-5.6-sol",
@@ -35619,12 +36272,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
-			"contextWindow": 372000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -35635,28 +36288,37 @@
 					"xhigh",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"openai/gpt-5.6-sol-pro": {
 			"id": "openai/gpt-5.6-sol-pro",
-			"name": "GPT-5.6 Sol Pro",
+			"name": "GPT-5.6 Sol",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		},
 		"openai/gpt-5.6-terra": {
 			"id": "openai/gpt-5.6-terra",
@@ -35670,12 +36332,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
-			"contextWindow": 372000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -35686,28 +36348,37 @@
 					"xhigh",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"openai/gpt-5.6-terra-pro": {
 			"id": "openai/gpt-5.6-terra-pro",
-			"name": "GPT-5.6 Terra Pro",
+			"name": "GPT-5.6 Terra",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		},
 		"openai/gpt-audio": {
 			"id": "openai/gpt-audio",
@@ -35720,14 +36391,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
+				"input": 2.5,
+				"output": 10,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 128000,
+			"maxTokens": 16384
 		},
 		"openai/gpt-audio-mini": {
 			"id": "openai/gpt-audio-mini",
@@ -35740,14 +36410,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
+				"input": 0.6,
+				"output": 2.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false
+			"contextWindow": 128000,
+			"maxTokens": 16384
 		},
 		"openai/gpt-chat-latest": {
 			"id": "openai/gpt-chat-latest",
@@ -35755,7 +36424,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text",
 				"image"
@@ -35767,21 +36436,11 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 400000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
+			"maxTokens": 128000
 		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
-			"name": "gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35790,13 +36449,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.039,
-				"output": 0.19,
-				"cacheRead": 0,
+				"input": 0.03,
+				"output": 0.17,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 26215,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -35829,7 +36488,7 @@
 		},
 		"openai/gpt-oss-20b": {
 			"id": "openai/gpt-oss-20b",
-			"name": "gpt-oss-20b",
+			"name": "GPT OSS 20B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35839,12 +36498,12 @@
 			],
 			"cost": {
 				"input": 0.03,
-				"output": 0.14,
-				"cacheRead": 0,
+				"output": 0.13,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 26215,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -35867,7 +36526,7 @@
 			"cost": {
 				"input": 0.075,
 				"output": 0.3,
-				"cacheRead": 0.037,
+				"cacheRead": 0.0375,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -35887,7 +36546,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -35899,7 +36558,18 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 100000
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"requiresEffort": true
+			}
 		},
 		"openai/o1-pro": {
 			"id": "openai/o1-pro",
@@ -35981,15 +36651,16 @@
 					"xhigh"
 				],
 				"requiresEffort": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o3-mini": {
 			"id": "openai/o3-mini",
-			"name": "o3 Mini",
+			"name": "o3-mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -36000,7 +36671,18 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 100000
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"requiresEffort": true
+			}
 		},
 		"openai/o3-mini-high": {
 			"id": "openai/o3-mini-high",
@@ -36008,7 +36690,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -36019,11 +36701,22 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 100000
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"requiresEffort": true
+			}
 		},
 		"openai/o3-pro": {
 			"id": "openai/o3-pro",
-			"name": "o3 Pro",
+			"name": "o3-pro",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -36054,7 +36747,7 @@
 		},
 		"openai/o4-mini": {
 			"id": "openai/o4-mini",
-			"name": "o4 Mini",
+			"name": "o4-mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -36112,7 +36805,8 @@
 					"xhigh"
 				],
 				"requiresEffort": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o4-mini-high": {
 			"id": "openai/o4-mini-high",
@@ -36128,7 +36822,7 @@
 			"cost": {
 				"input": 1.1,
 				"output": 4.4,
-				"cacheRead": 0,
+				"cacheRead": 0.275,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -36259,7 +36953,7 @@
 		},
 		"openrouter/free": {
 			"id": "openrouter/free",
-			"name": "Free Models Router",
+			"name": "OpenRouter Free Models Router",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -36376,7 +37070,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"openrouter/pareto-code": {
 			"id": "openrouter/pareto-code",
@@ -36574,7 +37269,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"poolside/laguna-s-2.1": {
 			"id": "poolside/laguna-s-2.1",
@@ -36582,43 +37278,32 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.1,
+				"output": 0.2,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"poolside/laguna-s-2.1:free": {
 			"id": "poolside/laguna-s-2.1:free",
 			"name": "Laguna S 2.1 (free)",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
-			"supportsComputerUse": false
-		},
-		"poolside/laguna-xs-2.1": {
-			"id": "poolside/laguna-xs-2.1",
-			"name": "Laguna XS 2.1",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -36634,7 +37319,35 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"supportsComputerUse": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"poolside/laguna-xs-2.1": {
+			"id": "poolside/laguna-xs-2.1",
+			"name": "Laguna XS 2.1",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.2,
+				"cacheRead": 0.05,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -36652,7 +37365,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -36664,7 +37377,16 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"poolside/laguna-xs.2": {
 			"id": "poolside/laguna-xs.2",
@@ -36724,7 +37446,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"prime-intellect/intellect-3": {
 			"id": "prime-intellect/intellect-3",
@@ -36753,7 +37476,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen-2.5-72b-instruct": {
 			"id": "qwen/qwen-2.5-72b-instruct",
@@ -36766,8 +37490,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.12,
-				"output": 0.39,
+				"input": 0.36,
+				"output": 0.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -36785,13 +37509,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.04,
-				"output": 0.1,
+				"input": 0.1,
+				"output": 0.2,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
-			"maxTokens": 6554
+			"maxTokens": 32768
 		},
 		"qwen/qwen-2.5-coder-32b-instruct": {
 			"id": "qwen/qwen-2.5-coder-32b-instruct",
@@ -36857,7 +37581,7 @@
 		},
 		"qwen/qwen-plus": {
 			"id": "qwen/qwen-plus",
-			"name": "Qwen-Plus",
+			"name": "Qwen Plus",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -36866,10 +37590,10 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.4,
-				"output": 1.2,
-				"cacheRead": 0.08,
-				"cacheWrite": 0
+				"input": 0.26,
+				"output": 0.78,
+				"cacheRead": 0.052,
+				"cacheWrite": 0.325
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768
@@ -36904,10 +37628,10 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 0.78,
+				"input": 0.4,
+				"output": 1.2,
 				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheWrite": 0.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768,
@@ -37057,13 +37781,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06,
-				"output": 0.24,
-				"cacheRead": 0.025,
+				"input": 0.2275,
+				"output": 0.91,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
-			"maxTokens": 40960,
+			"contextWindow": 131072,
+			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37076,7 +37800,7 @@
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3 235B A22B",
+			"name": "Qwen3 235B-A22B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37087,7 +37811,7 @@
 			"cost": {
 				"input": 0.455,
 				"output": 1.82,
-				"cacheRead": 0.15,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -37113,13 +37837,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.071,
-				"output": 0.1,
+				"input": 0.1495,
+				"output": 0.598,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 52429
+			"maxTokens": 16384
 		},
 		"qwen/qwen3-235b-a22b-thinking-2507": {
 			"id": "qwen/qwen3-235b-a22b-thinking-2507",
@@ -37132,12 +37856,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.11,
-				"output": 0.6,
+				"input": 0.23,
+				"output": 2.3,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 131072,
 			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
@@ -37161,13 +37885,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.28,
-				"cacheRead": 0.03,
+				"input": 0.13,
+				"output": 0.52,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 40960,
-			"maxTokens": 40960,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37189,13 +37913,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 0.3,
-				"cacheRead": 0.04,
+				"input": 0.13,
+				"output": 0.52,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144
+			"contextWindow": 128000,
+			"maxTokens": 32000
 		},
 		"qwen/qwen3-30b-a3b-thinking-2507": {
 			"id": "qwen/qwen3-30b-a3b-thinking-2507",
@@ -37208,13 +37932,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.051,
-				"output": 0.34,
+				"input": 0.2,
+				"output": 2.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
-			"maxTokens": 6554,
+			"contextWindow": 81920,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37237,13 +37961,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.24,
-				"cacheRead": 0.04,
+				"input": 0.104,
+				"output": 0.416,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 40960,
-			"maxTokens": 40960,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37265,12 +37989,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.05,
-				"output": 0.4,
-				"cacheRead": 0.05,
+				"input": 0.117,
+				"output": 0.455,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
+			"contextWindow": 131072,
 			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
@@ -37293,17 +38017,17 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.22,
-				"output": 1,
-				"cacheRead": 0.022,
+				"input": 0.975,
+				"output": 4.875,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 52429
+			"maxTokens": 65536
 		},
 		"qwen/qwen3-coder-30b-a3b-instruct": {
 			"id": "qwen/qwen3-coder-30b-a3b-instruct",
-			"name": "Qwen3 Coder 30B A3B Instruct",
+			"name": "Qwen3-Coder 30B-A3B Instruct",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37312,8 +38036,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.07,
-				"output": 0.27,
+				"input": 0.2925,
+				"output": 1.4625,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -37333,8 +38057,8 @@
 			"cost": {
 				"input": 0.195,
 				"output": 0.975,
-				"cacheRead": 0.06,
-				"cacheWrite": 0
+				"cacheRead": 0.039,
+				"cacheWrite": 0.24375
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536
@@ -37350,13 +38074,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.12,
-				"output": 0.75,
-				"cacheRead": 0.035,
+				"input": 0.3,
+				"output": 1.5,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536
+			"maxTokens": 262144
 		},
 		"qwen/qwen3-coder-plus": {
 			"id": "qwen/qwen3-coder-plus",
@@ -37371,8 +38095,8 @@
 			"cost": {
 				"input": 0.65,
 				"output": 3.25,
-				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheRead": 0.13,
+				"cacheWrite": 0.8125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536
@@ -37409,13 +38133,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.2,
-				"output": 6,
-				"cacheRead": 0.24,
-				"cacheWrite": 0
+				"input": 0.78,
+				"output": 3.9,
+				"cacheRead": 0.156,
+				"cacheWrite": 0.975
 			},
 			"contextWindow": 262144,
-			"maxTokens": 32768
+			"maxTokens": 65536
 		},
 		"qwen/qwen3-max-thinking": {
 			"id": "qwen/qwen3-max-thinking",
@@ -37434,7 +38158,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 32768,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37448,30 +38172,11 @@
 		},
 		"qwen/qwen3-next-80b-a3b-instruct": {
 			"id": "qwen/qwen3-next-80b-a3b-instruct",
-			"name": "Qwen3 Next 80B A3B Instruct",
+			"name": "Qwen3-Next 80B-A3B Instruct",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
 			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.09,
-				"output": 1.1,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 131072,
-			"maxTokens": 52429
-		},
-		"qwen/qwen3-next-80b-a3b-thinking": {
-			"id": "qwen/qwen3-next-80b-a3b-thinking",
-			"name": "Qwen3 Next 80B A3B Thinking",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -37481,8 +38186,27 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 32768,
+			"contextWindow": 262144,
+			"maxTokens": 16384
+		},
+		"qwen/qwen3-next-80b-a3b-thinking": {
+			"id": "qwen/qwen3-next-80b-a3b-thinking",
+			"name": "Qwen3-Next 80B-A3B (Thinking)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 1.2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37506,13 +38230,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.2,
-				"output": 0.88,
-				"cacheRead": 0.11,
+				"input": 0.26,
+				"output": 1.04,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 52429
+			"contextWindow": 131072,
+			"maxTokens": 32768
 		},
 		"qwen/qwen3-vl-235b-a22b-thinking": {
 			"id": "qwen/qwen3-vl-235b-a22b-thinking",
@@ -37526,8 +38250,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 2.6,
+				"input": 0.4,
+				"output": 4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -37561,8 +38285,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 32768
+			"contextWindow": 262144,
+			"maxTokens": 16384
 		},
 		"qwen/qwen3-vl-30b-a3b-thinking": {
 			"id": "qwen/qwen3-vl-30b-a3b-thinking",
@@ -37576,8 +38300,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 1.56,
+				"input": 0.2,
+				"output": 2.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -37626,8 +38350,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.5,
+				"input": 0.117,
+				"output": 0.455,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -37646,8 +38370,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.117,
-				"output": 1.365,
+				"input": 0.18,
+				"output": 2.1,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -37666,7 +38390,7 @@
 		},
 		"qwen/qwen3.5-122b-a10b": {
 			"id": "qwen/qwen3.5-122b-a10b",
-			"name": "Qwen3.5-122B-A10B",
+			"name": "Qwen3.5 122B-A10B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37682,7 +38406,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 81920,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37695,7 +38419,7 @@
 		},
 		"qwen/qwen3.5-27b": {
 			"id": "qwen/qwen3.5-27b",
-			"name": "Qwen3.5-27B",
+			"name": "Qwen3.5 27B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37724,7 +38448,7 @@
 		},
 		"qwen/qwen3.5-35b-a3b": {
 			"id": "qwen/qwen3.5-35b-a3b",
-			"name": "Qwen3.5-35B-A3B",
+			"name": "Qwen3.5 35B-A3B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37740,7 +38464,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37753,7 +38477,7 @@
 		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
-			"name": "Qwen3.5 397B A17B",
+			"name": "Qwen3.5 397B-A17B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37782,7 +38506,7 @@
 		},
 		"qwen/qwen3.5-9b": {
 			"id": "qwen/qwen3.5-9b",
-			"name": "Qwen3.5-9B",
+			"name": "Qwen3.5 9B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -37792,13 +38516,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.05,
+				"input": 0.1,
 				"output": 0.15,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 32768,
+			"contextWindow": 262144,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37821,8 +38545,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.1,
-				"output": 0.4,
+				"input": 0.065,
+				"output": 0.26,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -37879,10 +38603,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.4,
-				"output": 2.4,
+				"input": 0.3,
+				"output": 1.8,
 				"cacheRead": 0,
-				"cacheWrite": 0
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
@@ -37908,13 +38632,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.325,
-				"output": 3.25,
+				"input": 0.45,
+				"output": 2.7,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 65536,
+			"contextWindow": 262144,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -37927,23 +38651,32 @@
 		},
 		"qwen/qwen3.6-35b-a3b": {
 			"id": "qwen/qwen3.6-35b-a3b",
-			"name": "Qwen3.6 35B A3B",
+			"name": "Qwen3.6 35B-A3B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.14,
+				"output": 1,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 65536,
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"qwen/qwen3.6-flash": {
 			"id": "qwen/qwen3.6-flash",
@@ -37957,10 +38690,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1.5,
+				"input": 0.1875,
+				"output": 1.125,
 				"cacheRead": 0,
-				"cacheWrite": 0.3125
+				"cacheWrite": 0.234375
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
@@ -37985,10 +38718,10 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.04,
-				"output": 6.24,
+				"input": 1.027,
+				"output": 6.162,
 				"cacheRead": 0,
-				"cacheWrite": 1.3
+				"cacheWrite": 1.28375
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
@@ -38016,7 +38749,7 @@
 			"cost": {
 				"input": 0.325,
 				"output": 1.95,
-				"cacheRead": 0.0325,
+				"cacheRead": 0,
 				"cacheWrite": 0.40625
 			},
 			"contextWindow": 1000000,
@@ -38079,19 +38812,28 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.03,
+				"output": 0.13,
+				"cacheRead": 0.006,
+				"cacheWrite": 0.038
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"qwen/qwen3.7-max": {
 			"id": "qwen/qwen3.7-max",
@@ -38104,13 +38846,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.625,
-				"output": 4.875,
-				"cacheRead": 0.1625,
-				"cacheWrite": 2.03125
+				"input": 1.25,
+				"output": 3.75,
+				"cacheRead": 0.125,
+				"cacheWrite": 1.5625
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 65536,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -38133,13 +38875,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.32,
+				"output": 1.28,
+				"cacheRead": 0.032,
+				"cacheWrite": 0.4
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 64000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -38148,8 +38890,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"qwen/qwen3.7-plus:free": {
 			"id": "qwen/qwen3.7-plus:free",
@@ -38171,6 +38912,35 @@
 			"maxTokens": 65536,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"qwen/qwen3.8-max": {
+			"id": "qwen/qwen3.8-max",
+			"name": "Qwen3.8 Max",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"qwen/qwq-32b": {
 			"id": "qwen/qwq-32b",
@@ -38320,20 +39090,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": null,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"sao10k/l3-euryale-70b": {
 			"id": "sao10k/l3-euryale-70b",
@@ -38352,7 +39131,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 8192,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"supportsComputerUse": false
 		},
 		"sao10k/l3-lunaris-8b": {
 			"id": "sao10k/l3-lunaris-8b",
@@ -38500,19 +39280,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 4,
+				"output": 20,
+				"cacheRead": 0.4,
+				"cacheWrite": 5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"stealth/claude-sonnet-4.6": {
 			"id": "stealth/claude-sonnet-4.6",
@@ -38550,19 +39340,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 4,
+				"output": 24,
+				"cacheRead": 0.4,
+				"cacheWrite": 5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		},
 		"stealth/qwen3.6-plus": {
 			"id": "stealth/qwen3.6-plus",
@@ -38570,19 +39370,28 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0.025,
+				"cacheWrite": 0.3125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"stepfun/step-3.5-flash": {
 			"id": "stepfun/step-3.5-flash",
@@ -38597,11 +39406,11 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.3,
-				"cacheRead": 0.02,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 256000,
+			"contextWindow": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -38646,9 +39455,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.2,
+				"output": 1.15,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -38662,8 +39471,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"stepfun/step-3.7-flash:free": {
 			"id": "stepfun/step-3.7-flash:free",
@@ -38671,9 +39479,10 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -38681,9 +39490,18 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 256000,
-			"supportsComputerUse": false
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"switchpoint/router": {
 			"id": "switchpoint/router",
@@ -38732,23 +39550,32 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.14,
+				"output": 0.58,
+				"cacheRead": 0.035,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"supportsComputerUse": false
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
-			"name": "Hy3 Preview",
+			"name": "Hy3 preview",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -38757,9 +39584,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.066,
-				"output": 0.26,
-				"cacheRead": 0.029,
+				"input": 0.18,
+				"output": 0.6,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -38802,7 +39629,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -38813,9 +39640,17 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"thedrummer/cydonia-24b-v4.1": {
 			"id": "thedrummer/cydonia-24b-v4.1",
@@ -38854,7 +39689,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
-			"maxTokens": 32768
+			"maxTokens": 32768,
+			"supportsComputerUse": false
 		},
 		"thedrummer/skyfall-36b-v2": {
 			"id": "thedrummer/skyfall-36b-v2",
@@ -38892,8 +39728,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
-			"maxTokens": 32768
+			"contextWindow": 1024000,
+			"maxTokens": 1024000
 		},
 		"thinkingmachines/inkling": {
 			"id": "thinkingmachines/inkling",
@@ -38907,14 +39743,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.95,
+				"output": 4.05,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 65536,
-			"supportsComputerUse": false,
+			"contextWindow": 524288,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -38932,19 +39767,29 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.45,
+				"output": 1.2,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"contextWindow": 524288,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"tngtech/deepseek-r1t2-chimera": {
 			"id": "tngtech/deepseek-r1t2-chimera",
@@ -39000,11 +39845,11 @@
 			"cost": {
 				"input": 0.15,
 				"output": 0.6,
-				"cacheRead": 0,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 32768,
+			"contextWindow": 131072,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39228,8 +40073,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 6,
+				"input": 1.25,
+				"output": 2.5,
 				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
@@ -39361,9 +40206,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 500000,
@@ -39377,8 +40222,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"x-ai/grok-build-0.1": {
 			"id": "x-ai/grok-build-0.1",
@@ -39487,11 +40331,12 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2-omni": {
 			"id": "xiaomi/mimo-v2-omni",
-			"name": "MiMo-V2-Omni",
+			"name": "MiMo V2 Omni",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39515,7 +40360,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2-omni:free": {
 			"id": "xiaomi/mimo-v2-omni:free",
@@ -39540,7 +40386,7 @@
 		},
 		"xiaomi/mimo-v2-pro": {
 			"id": "xiaomi/mimo-v2-pro",
-			"name": "MiMo-V2-Pro",
+			"name": "MiMo V2 Pro",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39563,7 +40409,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"xiaomi/mimo-v2-pro:free": {
 			"id": "xiaomi/mimo-v2-pro:free",
@@ -39598,9 +40445,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.4,
-				"output": 2,
-				"cacheRead": 0.08,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.0028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -39616,7 +40463,7 @@
 		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
-			"name": "MiMo V2.5 Pro",
+			"name": "MiMo-V2.5-Pro",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39625,9 +40472,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 3,
-				"cacheRead": 0.2,
+				"input": 0.4,
+				"output": 1.5,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -39658,11 +40505,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 32768
+			"maxTokens": 32768,
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-4.5": {
 			"id": "z-ai/glm-4.5",
-			"name": "GLM 4.5",
+			"name": "GLM-4.5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39673,7 +40521,7 @@
 			"cost": {
 				"input": 0.6,
 				"output": 2.2,
-				"cacheRead": 0.175,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -39691,7 +40539,7 @@
 		},
 		"z-ai/glm-4.5-air": {
 			"id": "z-ai/glm-4.5-air",
-			"name": "GLM 4.5 Air",
+			"name": "GLM-4.5-Air",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39720,7 +40568,7 @@
 		},
 		"z-ai/glm-4.5v": {
 			"id": "z-ai/glm-4.5v",
-			"name": "GLM 4.5V",
+			"name": "GLM-4.5V",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39750,7 +40598,7 @@
 		},
 		"z-ai/glm-4.6": {
 			"id": "z-ai/glm-4.6",
-			"name": "GLM 4.6",
+			"name": "GLM-4.6",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39759,13 +40607,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.39,
-				"output": 1.9,
-				"cacheRead": 0.175,
+				"input": 0.55,
+				"output": 2.2,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
-			"maxTokens": 204800,
+			"contextWindow": 202752,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39800,7 +40648,7 @@
 		},
 		"z-ai/glm-4.6v": {
 			"id": "z-ai/glm-4.6v",
-			"name": "GLM 4.6V",
+			"name": "GLM-4.6V",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39812,11 +40660,11 @@
 			"cost": {
 				"input": 0.3,
 				"output": 0.9,
-				"cacheRead": 0,
+				"cacheRead": 0.055,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131072,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39830,7 +40678,7 @@
 		},
 		"z-ai/glm-4.7": {
 			"id": "z-ai/glm-4.7",
-			"name": "GLM 4.7",
+			"name": "GLM-4.7",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39839,13 +40687,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.38,
-				"output": 1.98,
-				"cacheRead": 0.2,
+				"input": 0.6,
+				"output": 2.2,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
-			"maxTokens": 65535,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39859,7 +40707,7 @@
 		},
 		"z-ai/glm-4.7-flash": {
 			"id": "z-ai/glm-4.7-flash",
-			"name": "GLM 4.7 Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39868,13 +40716,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06,
+				"input": 0.07,
 				"output": 0.4,
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
-			"maxTokens": 40551,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -39888,7 +40736,7 @@
 		},
 		"z-ai/glm-5": {
 			"id": "z-ai/glm-5",
-			"name": "GLM 5",
+			"name": "GLM-5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39897,12 +40745,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.72,
-				"output": 2.3,
-				"cacheRead": 0,
+				"input": 1,
+				"output": 3.2,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202752,
+			"contextWindow": 204800,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -39917,7 +40765,7 @@
 		},
 		"z-ai/glm-5-turbo": {
 			"id": "z-ai/glm-5-turbo",
-			"name": "GLM 5 Turbo",
+			"name": "GLM-5-Turbo",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39946,7 +40794,7 @@
 		},
 		"z-ai/glm-5.1": {
 			"id": "z-ai/glm-5.1",
-			"name": "GLM 5.1",
+			"name": "GLM-5.1",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -39955,9 +40803,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.26,
-				"output": 3.96,
-				"cacheRead": 0,
+				"input": 1.38,
+				"output": 4.4,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
@@ -39984,9 +40832,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -40000,12 +40848,11 @@
 					"high",
 					"max"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"z-ai/glm-5v-turbo": {
 			"id": "z-ai/glm-5v-turbo",
-			"name": "GLM 5V Turbo",
+			"name": "GLM-5V-Turbo",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -42074,6 +42921,25 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000
+		},
+		"voxtral-small-latest": {
+			"id": "voxtral-small-latest",
+			"name": "Voxtral Small",
+			"api": "openai-completions",
+			"provider": "mistral",
+			"baseUrl": "https://api.mistral.ai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.3,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 32000,
+			"maxTokens": 32000
 		}
 	},
 	"moonshot": {
@@ -42544,11 +43410,11 @@
 		},
 		"aion-labs/aion-2.0": {
 			"id": "aion-labs/aion-2.0",
-			"name": "aion-labs/aion-2.0",
+			"name": "Aion-2.0",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -42558,10 +43424,20 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"aion-labs/aion-2.5": {
 			"id": "aion-labs/aion-2.5",
@@ -42586,11 +43462,11 @@
 		},
 		"aion-labs/aion-3.0": {
 			"id": "aion-labs/aion-3.0",
-			"name": "aion-labs/aion-3.0",
+			"name": "Aion-3.0",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -42600,18 +43476,28 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"aion-labs/aion-3.0-mini": {
 			"id": "aion-labs/aion-3.0-mini",
-			"name": "aion-labs/aion-3.0-mini",
+			"name": "Aion-3.0-Mini",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -42621,10 +43507,20 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"aion-labs/aion-rp-llama-3.1-8b": {
 			"id": "aion-labs/aion-rp-llama-3.1-8b",
@@ -42979,30 +43875,37 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			}
 		},
 		"anthropic/claude-fable-latest": {
 			"id": "anthropic/claude-fable-latest",
-			"name": "anthropic/claude-fable-latest",
+			"name": "Claude Fable Latest",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"anthropic/claude-haiku-latest": {
 			"id": "anthropic/claude-haiku-latest",
@@ -43046,9 +43949,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -43076,9 +43979,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -43106,9 +44009,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -43136,9 +44039,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -43166,9 +44069,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -43196,9 +44099,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0.4998,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -43226,9 +44129,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0.4998,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -43256,9 +44159,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0.4998,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -43286,9 +44189,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0.4998,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -43316,14 +44219,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -43333,8 +44235,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUseConfig": false
+			}
 		},
 		"anthropic/claude-opus-latest": {
 			"id": "anthropic/claude-opus-latest",
@@ -43348,10 +44249,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0.4998,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -43372,19 +44273,29 @@
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
 			],
 			"cost": {
-				"input": 2.992,
-				"output": 14.993999999999998,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 128000
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"anthropic/claude-sonnet-4.6:thinking": {
 			"id": "anthropic/claude-sonnet-4.6:thinking",
@@ -43398,9 +44309,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.992,
-				"output": 14.993999999999998,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -43422,16 +44333,36 @@
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000
+		},
+		"anthropic/claude-sonnet-5:thinking": {
+			"id": "anthropic/claude-sonnet-5:thinking",
+			"name": "Claude Sonnet 5 Thinking",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
 			"reasoning": true,
 			"input": [
 				"text",
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -43444,9 +44375,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			}
 		},
 		"anthropic/claude-sonnet-latest": {
 			"id": "anthropic/claude-sonnet-latest",
@@ -43460,10 +44389,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.992,
-				"output": 14.994,
-				"cacheRead": 0.2992,
-				"cacheWrite": 0
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -43707,9 +44636,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.499,
-				"output": 9.996,
-				"cacheRead": 0,
+				"input": 2.5,
+				"output": 10,
+				"cacheRead": 1.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -43727,9 +44656,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.1496,
-				"output": 0.595,
-				"cacheRead": 0,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -44342,26 +45271,6 @@
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 1,
-				"output": 5,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000
-		},
-		"claude-haiku-4-5-20251001-thinking": {
-			"id": "claude-haiku-4-5-20251001-thinking",
-			"name": "Claude Haiku 4.5 Thinking",
-			"api": "openai-completions",
-			"provider": "nanogpt",
-			"baseUrl": "https://nano-gpt.com/api/v1",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -44384,7 +45293,14 @@
 					"high",
 					"xhigh"
 				],
-				"requiresEffort": true
+				"effortRouting": {
+					"off": "claude-haiku-4-5-20251001",
+					"minimal": "claude-haiku-4-5-20251001-thinking",
+					"low": "claude-haiku-4-5-20251001-thinking",
+					"medium": "claude-haiku-4-5-20251001-thinking",
+					"high": "claude-haiku-4-5-20251001-thinking",
+					"xhigh": "claude-haiku-4-5-20251001-thinking"
+				}
 			}
 		},
 		"claude-opus-4-1-20250805": {
@@ -44399,9 +45315,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 14.994,
-				"output": 75.004,
-				"cacheRead": 0,
+				"input": 15,
+				"output": 75,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44419,9 +45335,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 14.994,
-				"output": 75.004,
-				"cacheRead": 0,
+				"input": 15,
+				"output": 75,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44450,9 +45366,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 14.994,
-				"output": 75.004,
-				"cacheRead": 0,
+				"input": 15,
+				"output": 75,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44481,9 +45397,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 14.994,
-				"output": 75.004,
-				"cacheRead": 0,
+				"input": 15,
+				"output": 75,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44512,9 +45428,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 14.994,
-				"output": 75.004,
-				"cacheRead": 0,
+				"input": 15,
+				"output": 75,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44543,9 +45459,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 14.994,
-				"output": 75.004,
-				"cacheRead": 0,
+				"input": 15,
+				"output": 75,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44574,9 +45490,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 14.994,
-				"output": 75.004,
-				"cacheRead": 0,
+				"input": 15,
+				"output": 75,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44594,9 +45510,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44624,9 +45540,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44654,9 +45570,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 14.994,
-				"output": 75.004,
-				"cacheRead": 0,
+				"input": 15,
+				"output": 75,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44685,9 +45601,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 14.994,
-				"output": 75.004,
-				"cacheRead": 0,
+				"input": 15,
+				"output": 75,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44716,9 +45632,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 14.994,
-				"output": 75.004,
-				"cacheRead": 0,
+				"input": 15,
+				"output": 75,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44747,9 +45663,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 14.994,
-				"output": 75.004,
-				"cacheRead": 0,
+				"input": 15,
+				"output": 75,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44778,9 +45694,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 14.994,
-				"output": 75.004,
-				"cacheRead": 0,
+				"input": 15,
+				"output": 75,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44809,9 +45725,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.992,
-				"output": 14.994,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -44829,9 +45745,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.992,
-				"output": 14.994,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -44867,9 +45783,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.992,
-				"output": 14.994,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -44898,9 +45814,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.992,
-				"output": 14.994,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -44929,9 +45845,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.992,
-				"output": 14.994,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -44960,9 +45876,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.992,
-				"output": 14.994,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -44991,9 +45907,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.992,
-				"output": 14.994,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -45022,9 +45938,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 2.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -45055,7 +45971,7 @@
 				"input": 0.25,
 				"output": 1.5,
 				"cacheRead": 0.025,
-				"cacheWrite": 0
+				"cacheWrite": 0.08333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -45081,9 +45997,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1.2,
-				"cacheRead": 0,
+				"input": 0.315,
+				"output": 1.26,
+				"cacheRead": 0.1575,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -45225,7 +46141,7 @@
 		},
 		"crofai/greg-2-super": {
 			"id": "crofai/greg-2-super",
-			"name": "crofai/greg-2-super",
+			"name": "Greg 2 Super",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -45234,19 +46150,17 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.5,
+				"output": 5,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 229376,
+			"maxTokens": 229376
 		},
 		"crofai/greg-2-ultra": {
 			"id": "crofai/greg-2-ultra",
-			"name": "crofai/greg-2-ultra",
+			"name": "Greg 2 Ultra",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -45255,15 +46169,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 10,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 229376,
+			"maxTokens": 229376
 		},
 		"CrucibleLab/L3.3-70B-Loki-V2.0": {
 			"id": "CrucibleLab/L3.3-70B-Loki-V2.0",
@@ -45411,7 +46323,7 @@
 			"cost": {
 				"input": 0.25,
 				"output": 0.7,
-				"cacheRead": 0,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -45430,7 +46342,7 @@
 			"cost": {
 				"input": 0.25,
 				"output": 0.7,
-				"cacheRead": 0,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -45488,9 +46400,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 0.7,
-				"cacheRead": 0,
+				"input": 0.1,
+				"output": 0.425,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -45507,9 +46419,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 0.7,
-				"cacheRead": 0,
+				"input": 0.1,
+				"output": 0.425,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -45631,9 +46543,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 0.7,
-				"cacheRead": 0,
+				"input": 0.2,
+				"output": 0.77,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -45697,9 +46609,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.27999999999999997,
-				"output": 0.42000000000000004,
-				"cacheRead": 0,
+				"input": 0.28,
+				"output": 0.42,
+				"cacheRead": 0.14,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163000,
@@ -45737,9 +46649,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.27999999999999997,
-				"output": 0.42000000000000004,
-				"cacheRead": 0,
+				"input": 0.28,
+				"output": 0.42,
+				"cacheRead": 0.14,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163000,
@@ -45763,9 +46675,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.028,
+				"input": 0.07,
+				"output": 0.14,
+				"cacheRead": 0.014,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -45773,6 +46685,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -45780,7 +46693,7 @@
 		},
 		"deepseek/deepseek-v4-flash-0731": {
 			"id": "deepseek/deepseek-v4-flash-0731",
-			"name": "deepseek/deepseek-v4-flash-0731",
+			"name": "DeepSeek V4 Flash 0731",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -45789,18 +46702,125 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.014,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			}
+		},
+		"deepseek/deepseek-v4-flash-0731-cheaper": {
+			"id": "deepseek/deepseek-v4-flash-0731-cheaper",
+			"name": "DeepSeek V4 Flash 0731 Cheaper",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.014,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			}
+		},
+		"deepseek/deepseek-v4-flash-0731-cheaper:thinking": {
+			"id": "deepseek/deepseek-v4-flash-0731-cheaper:thinking",
+			"name": "DeepSeek V4 Flash 0731 Cheaper (Thinking)",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.014,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			}
+		},
+		"deepseek/deepseek-v4-flash-0731:thinking": {
+			"id": "deepseek/deepseek-v4-flash-0731:thinking",
+			"name": "DeepSeek V4 Flash 0731 (Thinking)",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.014,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			}
+		},
+		"deepseek/deepseek-v4-flash-latest": {
+			"id": "deepseek/deepseek-v4-flash-latest",
+			"name": "DeepSeek V4 Flash Latest",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.014,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -45817,9 +46837,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.028,
+				"input": 0.07,
+				"output": 0.14,
+				"cacheRead": 0.014,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -45827,6 +46847,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -46995,7 +48016,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.4,
-				"cacheRead": 0,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048756,
@@ -47114,7 +48135,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 2.5,
-				"cacheRead": 0,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048756,
@@ -47486,6 +48507,26 @@
 			"maxTokens": null,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"gemma-4-12b-it": {
+			"id": "gemma-4-12b-it",
+			"name": "Gemma 4 12B Instruct",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.06,
+				"output": 0.3,
+				"cacheRead": 0.03,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768
 		},
 		"Gemma-4-31B-Agares-v1": {
 			"id": "Gemma-4-31B-Agares-v1",
@@ -48264,6 +49305,46 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"gemma-4-e2b-it": {
+			"id": "gemma-4-e2b-it",
+			"name": "Gemma 4 E2B Instruct",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.02,
+				"output": 0.1,
+				"cacheRead": 0.01,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 16384
+		},
+		"gemma-4-e4b-it": {
+			"id": "gemma-4-e4b-it",
+			"name": "Gemma 4 E4B Instruct",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.04,
+				"output": 0.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 16384
+		},
 		"glm-4": {
 			"id": "glm-4",
 			"name": "glm-4",
@@ -48676,7 +49757,7 @@
 			"cost": {
 				"input": 0.07,
 				"output": 0.07,
-				"cacheRead": 0,
+				"cacheRead": 0.035,
 				"cacheWrite": 0
 			},
 			"contextWindow": 32000,
@@ -48695,7 +49776,7 @@
 			"cost": {
 				"input": 0.7,
 				"output": 0.7,
-				"cacheRead": 0,
+				"cacheRead": 0.35,
 				"cacheWrite": 0
 			},
 			"contextWindow": 32000,
@@ -48736,7 +49817,7 @@
 			"cost": {
 				"input": 0.5,
 				"output": 3,
-				"cacheRead": 0,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048756,
@@ -48767,7 +49848,7 @@
 				"input": 0.25,
 				"output": 1.5,
 				"cacheRead": 0.025,
-				"cacheWrite": 0
+				"cacheWrite": 0.08333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -48819,7 +49900,7 @@
 				"input": 2,
 				"output": 12,
 				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 1048756,
 			"maxTokens": 65536,
@@ -48847,7 +49928,7 @@
 				"input": 2,
 				"output": 12,
 				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 1048756,
 			"maxTokens": 65536,
@@ -48875,7 +49956,7 @@
 				"input": 2,
 				"output": 12,
 				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 1048756,
 			"maxTokens": 65536,
@@ -48903,7 +49984,7 @@
 				"input": 2,
 				"output": 12,
 				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 1048756,
 			"maxTokens": 65536,
@@ -48948,45 +50029,63 @@
 		},
 		"google/gemini-3.5-flash-lite": {
 			"id": "google/gemini-3.5-flash-lite",
-			"name": "google/gemini-3.5-flash-lite",
+			"name": "Gemini 3.5 Flash Lite",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.3,
+				"output": 2.5,
+				"cacheRead": 0.03,
+				"cacheWrite": 0.08333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
 		},
 		"google/gemini-3.6-flash": {
 			"id": "google/gemini-3.6-flash",
-			"name": "google/gemini-3.6-flash",
+			"name": "Gemini 3.6 Flash",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.5,
+				"output": 7.5,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
 		},
 		"google/gemini-flash-1.5": {
 			"id": "google/gemini-flash-1.5",
@@ -49051,10 +50150,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1.5,
-				"cacheRead": 0.025,
-				"cacheWrite": 0
+				"input": 0.3,
+				"output": 2.5,
+				"cacheRead": 0.03,
+				"cacheWrite": 0.08333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -49084,7 +50183,7 @@
 				"input": 2,
 				"output": 12,
 				"cacheRead": 0.2,
-				"cacheWrite": 0
+				"cacheWrite": 0.375
 			},
 			"contextWindow": 1048756,
 			"maxTokens": 65536,
@@ -49101,7 +50200,7 @@
 		},
 		"google/gemma-4-26b-a4b-it": {
 			"id": "google/gemma-4-26b-a4b-it",
-			"name": "Gemma 4 26B A4B",
+			"name": "Gemma 4 26B A4B IT",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -49133,7 +50232,7 @@
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -49280,9 +50379,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 4.998,
-				"output": 25.007,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 25,
+				"cacheRead": 2.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -49313,7 +50412,7 @@
 				"input": 0.25,
 				"output": 1.5,
 				"cacheRead": 0.025,
-				"cacheWrite": 0
+				"cacheWrite": 0.08333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -49339,9 +50438,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1.2,
-				"cacheRead": 0,
+				"input": 0.315,
+				"output": 1.26,
+				"cacheRead": 0.1575,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -49371,7 +50470,7 @@
 			"cost": {
 				"input": 0.25,
 				"output": 1.8,
-				"cacheRead": 0,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 65536,
@@ -49401,7 +50500,7 @@
 			"cost": {
 				"input": 0.25,
 				"output": 1.8,
-				"cacheRead": 0,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 65536,
@@ -49613,9 +50712,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.24,
-				"cacheRead": 0,
+				"input": 0.1,
+				"output": 0.3,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -49623,7 +50722,26 @@
 		},
 		"inclusionai/ling-3.0-flash": {
 			"id": "inclusionai/ling-3.0-flash",
-			"name": "inclusionai/ling-3.0-flash",
+			"name": "Ling 3.0 Flash",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.075,
+				"output": 0.22,
+				"cacheRead": 0.015,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768
+		},
+		"inclusionai/ling-3.0-flash:thinking": {
+			"id": "inclusionai/ling-3.0-flash:thinking",
+			"name": "Ling 3.0 Flash Thinking",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -49632,9 +50750,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.075,
+				"output": 0.22,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -49648,9 +50766,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			}
 		},
 		"inclusionai/ring-2.6-1t": {
 			"id": "inclusionai/ring-2.6-1t",
@@ -49663,9 +50779,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 3,
-				"cacheRead": 0,
+				"input": 0.3,
+				"output": 2.5,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -49998,7 +51114,7 @@
 		},
 		"kwaipilot/kat-coder-air-v2.5": {
 			"id": "kwaipilot/kat-coder-air-v2.5",
-			"name": "kwaipilot/kat-coder-air-v2.5",
+			"name": "KAT Coder Air V2.5",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -50007,15 +51123,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 256000,
+			"maxTokens": 80000
 		},
 		"kwaipilot/kat-coder-pro-v2": {
 			"id": "kwaipilot/kat-coder-pro-v2",
@@ -50040,7 +51154,7 @@
 		},
 		"kwaipilot/kat-coder-pro-v2.5": {
 			"id": "kwaipilot/kat-coder-pro-v2.5",
-			"name": "kwaipilot/kat-coder-pro-v2.5",
+			"name": "KAT Coder Pro V2.5",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -50049,15 +51163,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.74,
+				"output": 2.96,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 256000,
+			"maxTokens": 80000
 		},
 		"LatitudeGames/Wayfarer-Large-70B-Llama-3.3": {
 			"id": "LatitudeGames/Wayfarer-Large-70B-Llama-3.3",
@@ -51132,7 +52244,26 @@
 		},
 		"longcat-2.0": {
 			"id": "longcat-2.0",
-			"name": "longcat-2.0",
+			"name": "LongCat 2.0",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 3,
+				"cacheRead": 0.015,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048756,
+			"maxTokens": 262144
+		},
+		"longcat-2.0:thinking": {
+			"id": "longcat-2.0:thinking",
+			"name": "LongCat 2.0 Thinking",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -51141,13 +52272,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.75,
+				"output": 3,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 1048756,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -51157,9 +52288,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			}
 		},
 		"Magistral-Small-2506": {
 			"id": "Magistral-Small-2506",
@@ -51434,7 +52563,7 @@
 			"cost": {
 				"input": 0.05,
 				"output": 0.23,
-				"cacheRead": 0,
+				"cacheRead": 0.025,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -51474,7 +52603,7 @@
 			"cost": {
 				"input": 0.085,
 				"output": 0.46,
-				"cacheRead": 0,
+				"cacheRead": 0.0425,
 				"cacheWrite": 0
 			},
 			"contextWindow": 328000,
@@ -51482,13 +52611,14 @@
 		},
 		"meta/muse-spark-1.1": {
 			"id": "meta/muse-spark-1.1",
-			"name": "meta/muse-spark-1.1",
+			"name": "Muse Spark 1.1",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -51499,7 +52629,77 @@
 			"contextWindow": 1048576,
 			"maxTokens": 1048576,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"meta/muse-spark-1.2": {
+			"id": "meta/muse-spark-1.2",
+			"name": "Muse Spark 1.2",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 4.25,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"meta/muse-spark-1.2-contributor": {
+			"id": "meta/muse-spark-1.2-contributor",
+			"name": "Muse Spark 1.2 Contributor (Data Used for Training)",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.2,
+				"cacheRead": 0.002,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"microsoft/MAI-DS-R1-FP8": {
 			"id": "microsoft/MAI-DS-R1-FP8",
@@ -51682,7 +52882,7 @@
 			"cost": {
 				"input": 0.33,
 				"output": 1.32,
-				"cacheRead": 0,
+				"cacheRead": 0.165,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -51710,7 +52910,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 1.2,
-				"cacheRead": 0,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -51736,9 +52936,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1.2,
-				"cacheRead": 0,
+				"input": 0.315,
+				"output": 1.26,
+				"cacheRead": 0.1575,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -51766,7 +52966,7 @@
 			"cost": {
 				"input": 0.6,
 				"output": 2.4,
-				"cacheRead": 0,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -51928,7 +53128,7 @@
 			"cost": {
 				"input": 0.4,
 				"output": 2,
-				"cacheRead": 0,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -51947,7 +53147,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 0.9,
-				"cacheRead": 0,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -52009,7 +53209,7 @@
 			"cost": {
 				"input": 1.5,
 				"output": 7.5,
-				"cacheRead": 0,
+				"cacheRead": 0.75,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -52039,7 +53239,7 @@
 			"cost": {
 				"input": 1.5,
 				"output": 7.5,
-				"cacheRead": 0,
+				"cacheRead": 0.75,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -52401,7 +53601,7 @@
 			"cost": {
 				"input": 0.4,
 				"output": 1.4,
-				"cacheRead": 0,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -52431,7 +53631,7 @@
 			"cost": {
 				"input": 0.4,
 				"output": 1.4,
-				"cacheRead": 0,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -52584,9 +53784,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.1,
-				"output": 2,
-				"cacheRead": 0,
+				"input": 0.4,
+				"output": 1.8,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -52603,9 +53803,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.1,
-				"output": 2,
-				"cacheRead": 0,
+				"input": 0.4,
+				"output": 1.8,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -52623,8 +53823,8 @@
 			],
 			"cost": {
 				"input": 0.4,
-				"output": 2,
-				"cacheRead": 0,
+				"output": 1.8,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -52636,18 +53836,29 @@
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1.2,
-				"cacheRead": 0,
+				"input": 0.6,
+				"output": 2.5,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 262144
+			"contextWindow": 262144,
+			"maxTokens": 98304,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"requiresEffort": true
+			}
 		},
 		"moonshotai/kimi-k2-thinking-original": {
 			"id": "moonshotai/kimi-k2-thinking-original",
@@ -52705,7 +53916,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 1.9,
-				"cacheRead": 0,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -52725,7 +53936,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 1.9,
-				"cacheRead": 0,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -52753,9 +53964,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.53,
-				"output": 2.73,
-				"cacheRead": 0,
+				"input": 0.5,
+				"output": 2.6,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -52773,9 +53984,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.53,
-				"output": 2.73,
-				"cacheRead": 0,
+				"input": 0.5,
+				"output": 2.6,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -52803,13 +54014,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.19,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -52819,30 +54030,37 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			}
 		},
 		"moonshotai/kimi-k2.7-code-highspeed": {
 			"id": "moonshotai/kimi-k2.7-code-highspeed",
-			"name": "moonshotai/kimi-k2.7-code-highspeed",
+			"name": "Kimi K2.7 Code High-Speed",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.9,
+				"output": 8,
+				"cacheRead": 0.32,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -52856,13 +54074,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2.5,
+				"output": 13.5,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -52875,9 +54093,7 @@
 					"max": "max"
 				},
 				"requiresEffort": true
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			}
 		},
 		"moonshotai/kimi-latest": {
 			"id": "moonshotai/kimi-latest",
@@ -52891,13 +54107,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.5,
-				"output": 2.6,
-				"cacheRead": 0.125,
+				"input": 2.5,
+				"output": 13.5,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 65536,
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -53140,45 +54356,63 @@
 		},
 		"nex-agi/nex-n2-mini": {
 			"id": "nex-agi/nex-n2-mini",
-			"name": "nex-agi/nex-n2-mini",
+			"name": "Nex N2 Mini",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.025,
+				"output": 0.1,
+				"cacheRead": 0.0025,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
-			"name": "nex-agi/nex-n2-pro",
+			"name": "Nex N2 Pro",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.5,
+				"output": 2.5,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nothingiisreal/L3.1-70B-Celeste-V0.1-BF16": {
 			"id": "nothingiisreal/L3.1-70B-Celeste-V0.1-BF16",
@@ -53434,7 +54668,7 @@
 			"cost": {
 				"input": 0.105,
 				"output": 0.42,
-				"cacheRead": 0,
+				"cacheRead": 0.0525,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -53464,7 +54698,7 @@
 			"cost": {
 				"input": 0.05,
 				"output": 0.25,
-				"cacheRead": 0,
+				"cacheRead": 0.025,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -53493,7 +54727,7 @@
 			"cost": {
 				"input": 0.05,
 				"output": 0.25,
-				"cacheRead": 0,
+				"cacheRead": 0.025,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -53511,7 +54745,7 @@
 		},
 		"nvidia/nemotron-3-ultra-550b-a55b": {
 			"id": "nvidia/nemotron-3-ultra-550b-a55b",
-			"name": "Nemotron 3 Ultra 550B A55B",
+			"name": "Nvidia Nemotron 3 Ultra 550B",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -53520,9 +54754,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.5,
+				"output": 2.5,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -53536,9 +54770,36 @@
 					"high",
 					"xhigh"
 				]
+			}
+		},
+		"nvidia/nemotron-3-ultra-550b-a55b:thinking": {
+			"id": "nvidia/nemotron-3-ultra-550b-a55b:thinking",
+			"name": "Nvidia Nemotron 3 Ultra 550B Thinking",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.5,
+				"output": 2.5,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-TEE": {
 			"id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-TEE",
@@ -53615,7 +54876,7 @@
 		},
 		"openai/gpt-3.5-turbo": {
 			"id": "openai/gpt-3.5-turbo",
-			"name": "GPT-3.5 Turbo",
+			"name": "GPT-3.5-turbo",
 			"api": "openai-completions",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
@@ -53691,7 +54952,7 @@
 			"cost": {
 				"input": 2,
 				"output": 8,
-				"cacheRead": 0,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1047576,
@@ -53699,7 +54960,7 @@
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
-			"name": "GPT-4.1 Mini",
+			"name": "GPT-4.1 mini",
 			"api": "openai-completions",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
@@ -53721,7 +54982,7 @@
 		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
-			"name": "GPT-4.1 Nano",
+			"name": "GPT-4.1 nano",
 			"api": "openai-completions",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
@@ -53885,7 +55146,7 @@
 			"cost": {
 				"input": 1.25,
 				"output": 10,
-				"cacheRead": 0,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 400000,
@@ -53925,12 +55186,11 @@
 			"id": "openai/gpt-5-codex",
 			"name": "GPT-5 Codex",
 			"api": "openai-completions",
-			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 1.25,
@@ -53939,7 +55199,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -53948,9 +55208,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			}
 		},
 		"openai/gpt-5-mini": {
 			"id": "openai/gpt-5-mini",
@@ -54059,7 +55317,7 @@
 			"cost": {
 				"input": 1.25,
 				"output": 10,
-				"cacheRead": 0,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 400000,
@@ -54076,24 +55334,31 @@
 		},
 		"openai/gpt-5.1-2025-11-13": {
 			"id": "openai/gpt-5.1-2025-11-13",
-			"name": "openai/gpt-5.1-2025-11-13",
+			"name": "GPT-5.1 (2025-11-13)",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.25,
+				"output": 10,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 16384,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 1000000,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"openai/gpt-5.1-chat": {
 			"id": "openai/gpt-5.1-chat",
@@ -54183,7 +55448,7 @@
 			"cost": {
 				"input": 2.5,
 				"output": 20,
-				"cacheRead": 0,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -54200,7 +55465,7 @@
 		},
 		"openai/gpt-5.1-codex-mini": {
 			"id": "openai/gpt-5.1-codex-mini",
-			"name": "GPT-5.1-Codex-Mini",
+			"name": "GPT-5.1 Codex mini",
 			"api": "openai-completions",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
@@ -54241,7 +55506,7 @@
 			"cost": {
 				"input": 1.75,
 				"output": 14,
-				"cacheRead": 0,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 400000,
@@ -54292,7 +55557,7 @@
 			"cost": {
 				"input": 1.75,
 				"output": 14,
-				"cacheRead": 0,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -54309,7 +55574,7 @@
 		},
 		"openai/gpt-5.2-pro": {
 			"id": "openai/gpt-5.2-pro",
-			"name": "GPT 5.2 Pro",
+			"name": "GPT-5.2 Pro",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -54476,7 +55741,7 @@
 		},
 		"openai/gpt-5.4-pro": {
 			"id": "openai/gpt-5.4-pro",
-			"name": "GPT 5.4 Pro",
+			"name": "GPT-5.4 Pro",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -54535,7 +55800,127 @@
 		},
 		"openai/gpt-5.6-luna": {
 			"id": "openai/gpt-5.6-luna",
-			"name": "GPT-5.6 Luna",
+			"name": "GPT 5.6 Luna",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.6,
+				"cacheRead": 0.01,
+				"cacheWrite": 0.125
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
+		},
+		"openai/gpt-5.6-luna-pro": {
+			"id": "openai/gpt-5.6-luna-pro",
+			"name": "GPT 5.6 Luna Pro",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.6,
+				"cacheRead": 0.01,
+				"cacheWrite": 0.125
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
+		},
+		"openai/gpt-5.6-sol": {
+			"id": "openai/gpt-5.6-sol",
+			"name": "GPT 5.6 Sol",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
+		},
+		"openai/gpt-5.6-sol-pro": {
+			"id": "openai/gpt-5.6-sol-pro",
+			"name": "GPT 5.6 Sol Pro",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
+		},
+		"openai/gpt-5.6-terra": {
+			"id": "openai/gpt-5.6-terra",
+			"name": "GPT 5.6 Terra",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -54547,8 +55932,8 @@
 			"cost": {
 				"input": 1,
 				"output": 6,
-				"cacheRead": 0.09999999999999999,
-				"cacheWrite": 0
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -54561,136 +55946,37 @@
 					"xhigh",
 					"max"
 				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"openai/gpt-5.6-luna-pro": {
-			"id": "openai/gpt-5.6-luna-pro",
-			"name": "GPT-5.6 Luna Pro",
-			"api": "openai-completions",
-			"provider": "nanogpt",
-			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1050000,
-			"maxTokens": 128000,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"openai/gpt-5.6-sol": {
-			"id": "openai/gpt-5.6-sol",
-			"name": "GPT-5.6 Sol",
-			"api": "openai-completions",
-			"provider": "nanogpt",
-			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 5,
-				"output": 30,
-				"cacheRead": 0.5,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1050000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max"
-				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"openai/gpt-5.6-sol-pro": {
-			"id": "openai/gpt-5.6-sol-pro",
-			"name": "GPT-5.6 Sol Pro",
-			"api": "openai-completions",
-			"provider": "nanogpt",
-			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1050000,
-			"maxTokens": 128000,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"openai/gpt-5.6-terra": {
-			"id": "openai/gpt-5.6-terra",
-			"name": "GPT-5.6 Terra",
-			"api": "openai-completions",
-			"provider": "nanogpt",
-			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1050000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max"
-				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			}
 		},
 		"openai/gpt-5.6-terra-pro": {
 			"id": "openai/gpt-5.6-terra-pro",
-			"name": "GPT-5.6 Terra Pro",
+			"name": "GPT 5.6 Terra Pro",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
 		},
 		"openai/gpt-chat-latest": {
 			"id": "openai/gpt-chat-latest",
@@ -54698,7 +55984,7 @@
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -54707,10 +55993,20 @@
 				"input": 5,
 				"output": 30,
 				"cacheRead": 0.5,
-				"cacheWrite": 0
+				"cacheWrite": 6.25
 			},
-			"contextWindow": 400000,
-			"maxTokens": 128000
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"openai/gpt-latest": {
 			"id": "openai/gpt-latest",
@@ -54727,9 +56023,9 @@
 				"input": 5,
 				"output": 30,
 				"cacheRead": 0.5,
-				"cacheWrite": 0
+				"cacheWrite": 6.25
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -54753,8 +56049,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.05,
-				"output": 0.25,
+				"input": 0.35,
+				"output": 0.75,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -54981,7 +56277,7 @@
 			"cost": {
 				"input": 1.1,
 				"output": 4.4,
-				"cacheRead": 0,
+				"cacheRead": 0.55,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -55009,9 +56305,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.64,
-				"output": 2.588,
-				"cacheRead": 0,
+				"input": 1.1,
+				"output": 4.4,
+				"cacheRead": 0.55,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -55039,9 +56335,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 9.996,
-				"output": 19.992,
-				"cacheRead": 0,
+				"input": 1.1,
+				"output": 4.4,
+				"cacheRead": 0.55,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -55069,9 +56365,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 9.996,
-				"output": 19.992,
-				"cacheRead": 0,
+				"input": 22,
+				"output": 88,
+				"cacheRead": 11,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -55101,7 +56397,7 @@
 			"cost": {
 				"input": 1.1,
 				"output": 4.4,
-				"cacheRead": 0,
+				"cacheRead": 0.55,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -55164,7 +56460,7 @@
 			"cost": {
 				"input": 1.1,
 				"output": 4.4,
-				"cacheRead": 0,
+				"cacheRead": 0.55,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -55347,6 +56643,35 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"pokee-isaac": {
+			"id": "pokee-isaac",
+			"name": "Pokee-Isaac 28B",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 1,
+				"cacheRead": 0.075,
+				"cacheWrite": 0
+			},
+			"contextWindow": 10000000,
+			"maxTokens": 60000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"poolside/laguna-m.1": {
 			"id": "poolside/laguna-m.1",
 			"name": "Laguna M.1",
@@ -55378,7 +56703,7 @@
 		},
 		"poolside/laguna-s-2.1": {
 			"id": "poolside/laguna-s-2.1",
-			"name": "poolside/laguna-s-2.1",
+			"name": "Laguna S 2.1",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -55387,9 +56712,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.1,
+				"output": 0.2,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -55403,9 +56728,36 @@
 					"high",
 					"xhigh"
 				]
+			}
+		},
+		"poolside/laguna-s-2.1:thinking": {
+			"id": "poolside/laguna-s-2.1:thinking",
+			"name": "Laguna S 2.1 Thinking",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.2,
+				"cacheRead": 0.01,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"poolside/laguna-xs.2": {
 			"id": "poolside/laguna-xs.2",
@@ -55647,7 +56999,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 0.5,
-				"cacheRead": 0,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 41000,
@@ -55696,7 +57048,7 @@
 			"cost": {
 				"input": 0.13,
 				"output": 0.5,
-				"cacheRead": 0,
+				"cacheRead": 0.065,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -55704,7 +57056,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-			"name": "Qwen3 235B A22B-2507",
+			"name": "Qwen3 235B-A22B Instruct 2507",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -55736,7 +57088,7 @@
 			"cost": {
 				"input": 0.13,
 				"output": 0.5,
-				"cacheRead": 0,
+				"cacheRead": 0.065,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -55765,7 +57117,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-			"name": "Qwen3 235B A22B Thinking-2507",
+			"name": "Qwen3-235B-A22B-Thinking-2507",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -55826,7 +57178,7 @@
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
-			"name": "Qwen3-32B",
+			"name": "Qwen3 32B",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -55888,7 +57240,7 @@
 			"cost": {
 				"input": 0.13,
 				"output": 0.5,
-				"cacheRead": 0,
+				"cacheRead": 0.065,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262000,
@@ -55926,9 +57278,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.15,
+				"input": 0.2,
 				"output": 1.5,
-				"cacheRead": 0,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -55989,7 +57341,7 @@
 			"cost": {
 				"input": 0.15,
 				"output": 0.65,
-				"cacheRead": 0,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -56018,7 +57370,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
-			"name": "Qwen3 Next 80B A3B Thinking",
+			"name": "Qwen3-Next 80B-A3B (Thinking)",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -56070,7 +57422,7 @@
 		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
-			"name": "Qwen3.5 397B A17B",
+			"name": "Qwen3.5 397B-A17B",
 			"api": "openai-completions",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
@@ -56108,7 +57460,7 @@
 		},
 		"qwen/qwen3.5-9b": {
 			"id": "qwen/qwen3.5-9b",
-			"name": "Qwen3.5-9B",
+			"name": "Qwen3.5 9B",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -56303,7 +57655,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.4,
-				"cacheRead": 0,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -56374,7 +57726,26 @@
 		},
 		"qwen3.5-122b-a10b": {
 			"id": "qwen3.5-122b-a10b",
-			"name": "qwen3.5-122b-a10b",
+			"name": "Qwen3.5 122B A10B",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.437,
+				"output": 3.496,
+				"cacheRead": 0.103788,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768
+		},
+		"qwen3.5-122b-a10b:thinking": {
+			"id": "qwen3.5-122b-a10b:thinking",
+			"name": "Qwen3.5 122B A10B Thinking",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -56383,13 +57754,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.437,
+				"output": 3.496,
+				"cacheRead": 0.103788,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -56398,9 +57769,7 @@
 					"medium",
 					"high"
 				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			}
 		},
 		"qwen3.5-27b": {
 			"id": "qwen3.5-27b",
@@ -57502,21 +58871,22 @@
 		},
 		"qwen3.7-flash": {
 			"id": "qwen3.7-flash",
-			"name": "qwen3.7-flash",
+			"name": "Qwen3.7 Flash",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 0.03,
+				"output": 0.13,
+				"cacheRead": 0.006,
+				"cacheWrite": 0.038
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 991808,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -57526,9 +58896,36 @@
 					"medium",
 					"high"
 				]
+			}
+		},
+		"qwen3.7-flash:thinking": {
+			"id": "qwen3.7-flash:thinking",
+			"name": "Qwen3.7 Flash Thinking",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.03,
+				"output": 0.13,
+				"cacheRead": 0.006,
+				"cacheWrite": 0.038
 			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 983616,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"qwen3.7-max": {
 			"id": "qwen3.7-max",
@@ -57591,26 +58988,82 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
-		"qwen3.8-max-preview": {
-			"id": "qwen3.8-max-preview",
-			"name": "qwen3.8-max-preview",
+		"qwen3.8-max": {
+			"id": "qwen3.8-max",
+			"name": "Qwen3.8 Max",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"reasoning": false,
 			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 991000,
+			"maxTokens": 65536
+		},
+		"qwen3.8-max-preview": {
+			"id": "qwen3.8-max-preview",
+			"name": "Qwen3.8 Max Preview",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 1.5,
+				"output": 5,
+				"cacheRead": 0.15,
+				"cacheWrite": 2
 			},
-			"contextWindow": 983616,
+			"contextWindow": 991000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"qwen3.8-max:thinking": {
+			"id": "qwen3.8-max:thinking",
+			"name": "Qwen3.8 Max Thinking",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 991000,
 			"maxTokens": 131072,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"qwq-32b": {
 			"id": "qwq-32b",
@@ -57719,45 +59172,63 @@
 		},
 		"sakana/fugu-ultra": {
 			"id": "sakana/fugu-ultra",
-			"name": "sakana/fugu-ultra",
+			"name": "Fugu Ultra",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 5.25,
+				"output": 31.5,
+				"cacheRead": 0.525,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": null,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"sakana/fugu-ultra-v1.1": {
 			"id": "sakana/fugu-ultra-v1.1",
-			"name": "sakana/fugu-ultra-v1.1",
+			"name": "Fugu Ultra v1.1",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 5.25,
+				"output": 31.5,
+				"cacheRead": 0.525,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 1000000,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"Salesforce/Llama-xLAM-2-70b-fc-r": {
 			"id": "Salesforce/Llama-xLAM-2-70b-fc-r",
@@ -58450,7 +59921,7 @@
 				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 262144,
 			"maxTokens": 256000,
 			"thinking": {
 				"mode": "effort",
@@ -58655,7 +60126,7 @@
 			"cost": {
 				"input": 0.15,
 				"output": 0.7,
-				"cacheRead": 0,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 65536,
@@ -58674,7 +60145,7 @@
 			"cost": {
 				"input": 0.15,
 				"output": 0.46,
-				"cacheRead": 0,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -58885,7 +60356,7 @@
 		},
 		"TEE/glm-5.2": {
 			"id": "TEE/glm-5.2",
-			"name": "TEE/glm-5.2",
+			"name": "GLM 5.2 TEE",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -58894,9 +60365,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.4,
+				"output": 4.6,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -58910,9 +60381,36 @@
 					"high",
 					"max"
 				]
+			}
+		},
+		"TEE/glm-5.2:thinking": {
+			"id": "TEE/glm-5.2:thinking",
+			"name": "GLM 5.2 Thinking TEE",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.4,
+				"output": 4.6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
+			}
 		},
 		"TEE/gpt-oss-120b": {
 			"id": "TEE/gpt-oss-120b",
@@ -59038,24 +60536,36 @@
 		},
 		"TEE/kimi-k3": {
 			"id": "TEE/kimi-k3",
-			"name": "TEE/kimi-k3",
+			"name": "Kimi K3 TEE",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 1.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"maxTokens": 65535,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"effortMap": {
+					"max": "max"
+				},
+				"requiresEffort": true
+			}
 		},
 		"TEE/llama3-3-70b": {
 			"id": "TEE/llama3-3-70b",
@@ -59133,7 +60643,7 @@
 			"cost": {
 				"input": 0.2,
 				"output": 1.38,
-				"cacheRead": 0,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
@@ -59245,7 +60755,7 @@
 			"cost": {
 				"input": 0.46,
 				"output": 3.68,
-				"cacheRead": 0,
+				"cacheRead": 0.23,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -59358,7 +60868,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 1.5,
-				"cacheRead": 0,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -59396,28 +60906,36 @@
 		},
 		"tencent/hy3": {
 			"id": "tencent/hy3",
-			"name": "tencent/hy3",
+			"name": "Tencent Hy3",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.066,
+				"output": 0.26,
+				"cacheRead": 0.029,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
-			"name": "Hy3 Preview",
+			"name": "Hy3 preview",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -59683,6 +61201,76 @@
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 4.05,
+				"cacheRead": 0.17,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048000,
+			"maxTokens": 32768
+		},
+		"thinkingmachines/Inkling-Small": {
+			"id": "thinkingmachines/Inkling-Small",
+			"name": "Inkling Small",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.5,
+				"output": 1.2,
+				"cacheRead": 0.1,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 32768
+		},
+		"thinkingmachines/Inkling-Small:thinking": {
+			"id": "thinkingmachines/Inkling-Small:thinking",
+			"name": "Inkling Small Thinking",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.5,
+				"output": 1.2,
+				"cacheRead": 0.1,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"thinkingmachines/inkling:thinking": {
+			"id": "thinkingmachines/inkling:thinking",
+			"name": "Inkling Thinking",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -59691,10 +61279,10 @@
 			"cost": {
 				"input": 1,
 				"output": 4.05,
-				"cacheRead": 0.16999999999999998,
+				"cacheRead": 0.17,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1048000,
 			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
@@ -59705,40 +61293,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"thinkingmachines/Inkling-Small": {
-			"id": "thinkingmachines/Inkling-Small",
-			"name": "thinkingmachines/Inkling-Small",
-			"api": "openai-completions",
-			"provider": "nanogpt",
-			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 32768,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			}
 		},
 		"THUDM/GLM-4-32B-0414": {
 			"id": "THUDM/GLM-4-32B-0414",
@@ -60332,7 +61887,7 @@
 			"cost": {
 				"input": 2,
 				"output": 6,
-				"cacheRead": 0,
+				"cacheRead": 1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 2000000,
@@ -60483,9 +62038,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 500000,
@@ -60499,9 +62054,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			}
 		},
 		"x-ai/grok-build-0.1": {
 			"id": "x-ai/grok-build-0.1",
@@ -60576,13 +62129,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.2,
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 1000000,
+			"contextWindow": 500000,
+			"maxTokens": 500000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -60786,7 +62339,7 @@
 		},
 		"xiaomi/mimo-v2.5-pro-crof": {
 			"id": "xiaomi/mimo-v2.5-pro-crof",
-			"name": "xiaomi/mimo-v2.5-pro-crof",
+			"name": "MiMo V2.5 Pro (Crof)",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -60795,13 +62348,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.4,
+				"output": 0.8,
+				"cacheRead": 0.003,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -60809,9 +62362,34 @@
 					"medium",
 					"high"
 				]
+			}
+		},
+		"xiaomi/mimo-v2.5-pro-crof:thinking": {
+			"id": "xiaomi/mimo-v2.5-pro-crof:thinking",
+			"name": "MiMo V2.5 Pro Thinking (Crof)",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 0.8,
+				"cacheRead": 0.003,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"xiaomi/mimo-v2.5-pro-ultraspeed": {
 			"id": "xiaomi/mimo-v2.5-pro-ultraspeed",
@@ -60833,6 +62411,61 @@
 			"maxTokens": 131072,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"xiaomi/mimo-v2.5-pro:thinking": {
+			"id": "xiaomi/mimo-v2.5-pro:thinking",
+			"name": "MiMo V2.5 Pro Thinking",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.435,
+				"output": 0.87,
+				"cacheRead": 0.0036,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"xiaomi/mimo-v2.5:thinking": {
+			"id": "xiaomi/mimo-v2.5:thinking",
+			"name": "MiMo V2.5 Thinking",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.0028,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"yi-large": {
 			"id": "yi-large",
@@ -60899,7 +62532,7 @@
 		},
 		"z-ai/glm-4.5v": {
 			"id": "z-ai/glm-4.5v",
-			"name": "GLM 4.5V",
+			"name": "GLM-4.5V",
 			"api": "openai-completions",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"provider": "nanogpt",
@@ -60940,9 +62573,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.4,
-				"output": 1.5,
-				"cacheRead": 0,
+				"input": 0.35,
+				"output": 1.4,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -60969,9 +62602,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.4,
-				"output": 1.5,
-				"cacheRead": 0,
+				"input": 0.35,
+				"output": 1.4,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -61024,7 +62657,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 202800,
-			"maxTokens": 131100
+			"maxTokens": 131072
 		},
 		"z-ai/glm-5v-turbo:thinking": {
 			"id": "z-ai/glm-5v-turbo:thinking",
@@ -61044,7 +62677,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 202800,
-			"maxTokens": 131100,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61090,7 +62723,7 @@
 			"cost": {
 				"input": 0.12,
 				"output": 0.8,
-				"cacheRead": 0,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -61109,7 +62742,7 @@
 			"cost": {
 				"input": 0.12,
 				"output": 0.8,
-				"cacheRead": 0,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -61251,13 +62884,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.15,
+				"input": 0.2,
 				"output": 0.8,
-				"cacheRead": 0,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 128000,
+			"maxTokens": 65535,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61282,7 +62915,7 @@
 			"cost": {
 				"input": 0.07,
 				"output": 0.4,
-				"cacheRead": 0,
+				"cacheRead": 0.035,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -61311,7 +62944,7 @@
 			"cost": {
 				"input": 0.07,
 				"output": 0.4,
-				"cacheRead": 0,
+				"cacheRead": 0.035,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -61398,7 +63031,7 @@
 			"cost": {
 				"input": 0.2,
 				"output": 0.8,
-				"cacheRead": 0,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -61425,9 +63058,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
+				"input": 0.5,
 				"output": 2.55,
-				"cacheRead": 0,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -61533,9 +63166,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
+				"input": 0.5,
 				"output": 2.55,
-				"cacheRead": 0,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -61562,9 +63195,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 2.55,
-				"cacheRead": 0,
+				"input": 0.75,
+				"output": 2.6,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -61591,9 +63224,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 2.55,
-				"cacheRead": 0,
+				"input": 0.75,
+				"output": 2.6,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -61611,7 +63244,7 @@
 		},
 		"zai-org/glm-5.2": {
 			"id": "zai-org/glm-5.2",
-			"name": "zai-org/glm-5.2",
+			"name": "GLM 5.2",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -61620,9 +63253,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.42,
+				"output": 1.32,
+				"cacheRead": 0.078,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -61636,9 +63269,36 @@
 					"high",
 					"max"
 				]
+			}
+		},
+		"zai-org/glm-5.2:thinking": {
+			"id": "zai-org/glm-5.2:thinking",
+			"name": "GLM 5.2 Thinking",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.42,
+				"output": 1.32,
+				"cacheRead": 0.078,
+				"cacheWrite": 0
 			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
+			}
 		},
 		"zai-org/glm-latest": {
 			"id": "zai-org/glm-latest",
@@ -61651,12 +63311,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.75,
-				"output": 2.6,
-				"cacheRead": 0.15,
+				"input": 0.42,
+				"output": 1.32,
+				"cacheRead": 0.078,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1048576,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -61872,7 +63532,7 @@
 		},
 		"deepseek/deepseek-r1": {
 			"id": "deepseek/deepseek-r1",
-			"name": "R1",
+			"name": "DeepSeek-R1",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62241,6 +63901,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -62250,7 +63911,7 @@
 		},
 		"deepseek/deepseek-v4-flash-0731": {
 			"id": "deepseek/deepseek-v4-flash-0731",
-			"name": "Deepseek V4 Flash 0731",
+			"name": "DeepSeek V4 Flash 0731",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62270,6 +63931,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -62376,7 +64038,7 @@
 		},
 		"google/gemma-4-26b-a4b-it": {
 			"id": "google/gemma-4-26b-a4b-it",
-			"name": "Gemma 4 26B A4B",
+			"name": "Gemma 4 26B A4B IT",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62409,7 +64071,7 @@
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62509,7 +64171,7 @@
 		},
 		"inclusionai/ling-2.6-flash": {
 			"id": "inclusionai/ling-2.6-flash",
-			"name": "Ling-2.6 Flash",
+			"name": "Ling-2.6-flash",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62540,6 +64202,38 @@
 				"text"
 			],
 			"cost": {
+				"input": 0.06,
+				"output": 0.18,
+				"cacheRead": 0.012,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
+		},
+		"inclusionai/ling-3.0-tiny": {
+			"id": "inclusionai/ling-3.0-tiny",
+			"name": "Ling 3.0 Tiny",
+			"api": "openai-completions",
+			"provider": "novita",
+			"baseUrl": "https://api.novita.ai/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
 				"input": 0,
 				"output": 0,
 				"cacheRead": 0,
@@ -62558,8 +64252,7 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUse": false
 		},
 		"inclusionai/ring-2.6-1t": {
 			"id": "inclusionai/ring-2.6-1t",
@@ -62659,31 +64352,9 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
-		"meta-llama/llama-3.2-3b-instruct": {
-			"id": "meta-llama/llama-3.2-3b-instruct",
-			"name": "Llama 3.2 3B Instruct",
-			"api": "openai-completions",
-			"provider": "novita",
-			"baseUrl": "https://api.novita.ai/openai/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.03,
-				"output": 0.05,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 32768,
-			"maxTokens": 32000,
-			"supportsTools": false,
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
 		"meta-llama/llama-3.3-70b-instruct": {
 			"id": "meta-llama/llama-3.3-70b-instruct",
-			"name": "Llama 3.3 70B Instruct",
+			"name": "Llama-3.3-70B-Instruct",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62697,8 +64368,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 6000,
-			"maxTokens": 120000,
+			"contextWindow": 12288,
+			"maxTokens": 12288,
 			"supportsTools": true,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
@@ -62728,7 +64399,7 @@
 		},
 		"meta-llama/llama-4-scout-17b-16e-instruct": {
 			"id": "meta-llama/llama-4-scout-17b-16e-instruct",
-			"name": "Llama 4 Scout 17B 16E",
+			"name": "Llama 4 Scout Instruct",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62814,9 +64485,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.5,
+				"output": 4.5,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -62837,7 +64508,7 @@
 		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
-			"name": "MiniMax M2",
+			"name": "MiniMax-M2",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62868,7 +64539,7 @@
 		},
 		"minimax/minimax-m2.1": {
 			"id": "minimax/minimax-m2.1",
-			"name": "MiniMax M2.1",
+			"name": "MiniMax-M2.1",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -62961,7 +64632,7 @@
 		},
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
-			"name": "MiniMax M2.7",
+			"name": "MiniMax-M2.7",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -63023,7 +64694,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -63588,7 +65259,7 @@
 		},
 		"qwen/qwen3-coder-30b-a3b-instruct": {
 			"id": "qwen/qwen3-coder-30b-a3b-instruct",
-			"name": "Qwen3 Coder 30B A3B Instruct",
+			"name": "Qwen3-Coder 30B-A3B Instruct",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -63865,7 +65536,7 @@
 		},
 		"qwen/qwen3.5-27b": {
 			"id": "qwen/qwen3.5-27b",
-			"name": "Qwen3.5-27B",
+			"name": "Qwen3.5 27B",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -63897,7 +65568,7 @@
 		},
 		"qwen/qwen3.5-35b-a3b": {
 			"id": "qwen/qwen3.5-35b-a3b",
-			"name": "Qwen3.5-35B-A3B",
+			"name": "Qwen3.5 35B-A3B",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -63929,7 +65600,7 @@
 		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
-			"name": "Qwen3.5 397B A17B",
+			"name": "Qwen3.5 397B-A17B",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -64025,7 +65696,7 @@
 		},
 		"qwen/qwen3.6-35b-a3b": {
 			"id": "qwen/qwen3.6-35b-a3b",
-			"name": "Qwen3.6-35B-A3B",
+			"name": "Qwen3.6 35B-A3B",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -64117,6 +65788,37 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"qwen/qwen3.8-max": {
+			"id": "qwen/qwen3.8-max",
+			"name": "Qwen3.8 Max",
+			"api": "openai-completions",
+			"provider": "novita",
+			"baseUrl": "https://api.novita.ai/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"sao10k/l3-70b-euryale-v2.1": {
 			"id": "sao10k/l3-70b-euryale-v2.1",
@@ -64251,7 +65953,7 @@
 		},
 		"tencent/hy3": {
 			"id": "tencent/hy3",
-			"name": "Hy3",
+			"name": "Tencent Hy3",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -65110,6 +66812,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -67792,7 +69495,7 @@
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3 235B A22B",
+			"name": "Qwen3 235B-A22B",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -67858,7 +69561,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
-			"name": "Qwen3 Next 80B A3B Thinking",
+			"name": "Qwen3-Next 80B-A3B (Thinking)",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -68205,7 +69908,7 @@
 		},
 		"z-ai/glm-5.1": {
 			"id": "z-ai/glm-5.1",
-			"name": "GLM 5.1",
+			"name": "GLM-5.1",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -68465,21 +70168,11 @@
 		},
 		"deepseek-v4-flash:0731": {
 			"id": "deepseek-v4-flash:0731",
-			"name": "deepseek-v4-flash:0731",
+			"name": "DeepSeek V4 Flash 0731",
 			"api": "ollama-chat",
 			"provider": "ollama-cloud",
 			"baseUrl": "https://ollama.com",
 			"reasoning": true,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
 			"input": [
 				"text"
 			],
@@ -68492,7 +70185,15 @@
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
 			"omitMaxOutputTokens": true,
-			"supportsComputerUse": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"deepseek-v4-pro": {
 			"id": "deepseek-v4-pro",
@@ -71448,7 +73149,7 @@
 	"opencode-go": {
 		"deepseek-v4-flash": {
 			"id": "deepseek-v4-flash",
-			"name": "DeepSeek V4 Flash (New)",
+			"name": "DeepSeek V4 Flash (2x usage)",
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -71457,9 +73158,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.0028,
+				"input": 0.07,
+				"output": 0.14,
+				"cacheRead": 0.0014,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -71473,6 +73174,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -72141,6 +73843,36 @@
 					"xhigh"
 				]
 			}
+		},
+		"qwen3.8-max": {
+			"id": "qwen3.8-max",
+			"name": "Qwen3.8 Max",
+			"api": "anthropic-messages",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		}
 	},
 	"opencode-zen": {
@@ -72573,6 +74305,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -72580,7 +74313,7 @@
 		},
 		"deepseek-v4-flash-free": {
 			"id": "deepseek-v4-flash-free",
-			"name": "DeepSeek V4 Flash Free (New)",
+			"name": "DeepSeek V4 Flash Free",
 			"api": "openai-completions",
 			"provider": "opencode-zen",
 			"baseUrl": "https://opencode.ai/zen/v1",
@@ -72599,6 +74332,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -73567,7 +75301,7 @@
 		"grok-build-0.1": {
 			"id": "grok-build-0.1",
 			"name": "Grok Build 0.1",
-			"api": "openai-completions",
+			"api": "openai-responses",
 			"provider": "opencode-zen",
 			"baseUrl": "https://opencode.ai/zen/v1",
 			"reasoning": true,
@@ -73878,6 +75612,64 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"ling-3.0-tiny-free": {
+			"id": "ling-3.0-tiny-free",
+			"name": "Ling-3.0-tiny Free",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"longcat-2.0-free": {
+			"id": "longcat-2.0-free",
+			"name": "LongCat-2.0 Free",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -74434,7 +76226,7 @@
 		},
 		"~anthropic/claude-haiku-latest": {
 			"id": "~anthropic/claude-haiku-latest",
-			"name": "Claude Haiku Latest",
+			"name": "Anthropic Claude Haiku Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74496,7 +76288,7 @@
 		},
 		"~anthropic/claude-sonnet-latest": {
 			"id": "~anthropic/claude-sonnet-latest",
-			"name": "Claude Sonnet Latest",
+			"name": "Anthropic Claude Sonnet Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74542,11 +76334,13 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 65536,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"high"
+					"low",
+					"high",
+					"max"
 				]
 			},
 			"supportsComputerUse": false,
@@ -74554,7 +76348,7 @@
 		},
 		"~google/gemini-flash-latest": {
 			"id": "~google/gemini-flash-latest",
-			"name": "Gemini Flash Latest",
+			"name": "Google Gemini Flash Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74567,7 +76361,7 @@
 				"input": 1.5,
 				"output": 7.5,
 				"cacheRead": 0.15,
-				"cacheWrite": 0.08333333333333334
+				"cacheWrite": 0.0833333333333333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -74585,7 +76379,7 @@
 		},
 		"~google/gemini-pro-latest": {
 			"id": "~google/gemini-pro-latest",
-			"name": "Gemini Pro Latest",
+			"name": "Google Gemini Pro Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74616,7 +76410,7 @@
 		},
 		"~moonshotai/kimi-latest": {
 			"id": "~moonshotai/kimi-latest",
-			"name": "Kimi Latest",
+			"name": "MoonshotAI Kimi Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74626,7 +76420,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.9000000000000004,
+				"input": 2.5,
 				"output": 14,
 				"cacheRead": 0.29,
 				"cacheWrite": 0
@@ -74647,7 +76441,7 @@
 		},
 		"~openai/gpt-latest": {
 			"id": "~openai/gpt-latest",
-			"name": "GPT Latest",
+			"name": "OpenAI GPT Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74678,7 +76472,7 @@
 		},
 		"~openai/gpt-mini-latest": {
 			"id": "~openai/gpt-mini-latest",
-			"name": "GPT Mini Latest",
+			"name": "OpenAI GPT Mini Latest",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -74725,7 +76519,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 500000,
-			"maxTokens": null,
+			"maxTokens": 500000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -75566,7 +77360,7 @@
 		},
 		"anthropic/claude-opus-4.7-fast": {
 			"id": "anthropic/claude-opus-4.7-fast",
-			"name": "Claude Opus 4.7 (Fast)",
+			"name": "Claude Opus 4.7",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -75662,7 +77456,7 @@
 		},
 		"anthropic/claude-opus-4.8-fast": {
 			"id": "anthropic/claude-opus-4.8-fast",
-			"name": "Claude Opus 4.8 (Fast)",
+			"name": "Claude Opus 4.8",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -75758,7 +77552,7 @@
 		},
 		"anthropic/claude-opus-5-fast": {
 			"id": "anthropic/claude-opus-5-fast",
-			"name": "Claude Opus 5 (Fast)",
+			"name": "Claude Opus 5",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -75787,6 +77581,37 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"anthropic/claude-opus-5:batch": {
+			"id": "anthropic/claude-opus-5:batch",
+			"name": "Claude Opus 5 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 12.5,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
@@ -75911,6 +77736,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"anthropic/claude-sonnet-4.6:batch": {
+			"id": "anthropic/claude-sonnet-4.6:batch",
+			"name": "Claude Sonnet 4.6 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.5,
+				"output": 7.5,
+				"cacheRead": 0.15,
+				"cacheWrite": 1.875
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-sonnet-5": {
 			"id": "anthropic/claude-sonnet-5",
@@ -76409,7 +78264,7 @@
 		},
 		"cohere/command-r-08-2024": {
 			"id": "cohere/command-r-08-2024",
-			"name": "Command R (08-2024)",
+			"name": "Command R",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -76481,7 +78336,7 @@
 		},
 		"deepseek/deepseek-chat": {
 			"id": "deepseek/deepseek-chat",
-			"name": "DeepSeek V3",
+			"name": "DeepSeek-V3.2 (Non-thinking Mode)",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -76550,7 +78405,7 @@
 		},
 		"deepseek/deepseek-r1": {
 			"id": "deepseek/deepseek-r1",
-			"name": "R1",
+			"name": "DeepSeek-R1",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -76667,13 +78522,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.26899999999999996,
-				"output": 0.39999999999999997,
-				"cacheRead": 0.13449999999999998,
+				"input": 0.26,
+				"output": 0.38,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 65536,
+			"maxTokens": 163840,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -76731,7 +78586,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"high"
+					"low",
+					"high",
+					"max"
 				]
 			},
 			"supportsComputerUse": false,
@@ -76754,7 +78611,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 65536,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -76787,7 +78644,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"high"
+					"low",
+					"high",
+					"max"
 				]
 			},
 			"supportsComputerUse": false,
@@ -76900,7 +78759,7 @@
 				"input": 0.3,
 				"output": 2.5,
 				"cacheRead": 0.03,
-				"cacheWrite": 0.08333333333333334
+				"cacheWrite": 0.0833333333333333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65535,
@@ -76918,7 +78777,7 @@
 		},
 		"google/gemini-2.5-flash-lite": {
 			"id": "google/gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -76931,7 +78790,7 @@
 				"input": 0.09999999999999999,
 				"output": 0.39999999999999997,
 				"cacheRead": 0.01,
-				"cacheWrite": 0.08333333333333334
+				"cacheWrite": 0.0833333333333333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65535,
@@ -77214,10 +79073,10 @@
 				"input": 0.5,
 				"output": 3,
 				"cacheRead": 0.049999999999999996,
-				"cacheWrite": 0.08333333333333334
+				"cacheWrite": 0.0833333333333333
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 65535,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -77249,7 +79108,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 65535,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -77265,7 +79124,7 @@
 		},
 		"google/gemini-3-pro-image": {
 			"id": "google/gemini-3-pro-image",
-			"name": "Nano Banana Pro (Gemini 3 Pro Image)",
+			"name": "Nano Banana Pro",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -77338,7 +79197,7 @@
 				"input": 0.25,
 				"output": 1.5,
 				"cacheRead": 0.024999999999999998,
-				"cacheWrite": 0.08333333333333334
+				"cacheWrite": 0.0833333333333333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -77370,7 +79229,7 @@
 				"input": 0.25,
 				"output": 1.5,
 				"cacheRead": 0.024999999999999998,
-				"cacheWrite": 0.08333333333333334
+				"cacheWrite": 0.0833333333333333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -77514,7 +79373,7 @@
 				"input": 1.5,
 				"output": 9,
 				"cacheRead": 0.15,
-				"cacheWrite": 0.08333333333333334
+				"cacheWrite": 0.0833333333333333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -77546,7 +79405,7 @@
 				"input": 0.3,
 				"output": 2.5,
 				"cacheRead": 0.03,
-				"cacheWrite": 0.08333333333333334
+				"cacheWrite": 0.0833333333333333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -77642,7 +79501,7 @@
 				"input": 1.5,
 				"output": 7.5,
 				"cacheRead": 0.15,
-				"cacheWrite": 0.08333333333333334
+				"cacheWrite": 0.0833333333333333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -77674,7 +79533,7 @@
 				"input": 0.75,
 				"output": 3.75,
 				"cacheRead": 0.075,
-				"cacheWrite": 0.08333333333333334
+				"cacheWrite": 0.0833333333333333
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -77759,7 +79618,7 @@
 		},
 		"google/gemma-4-26b-a4b-it": {
 			"id": "google/gemma-4-26b-a4b-it",
-			"name": "Gemma 4 26B A4B",
+			"name": "Gemma 4 26B A4B IT",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -77821,7 +79680,7 @@
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -78018,7 +79877,7 @@
 		},
 		"inclusionai/ling-2.6-flash": {
 			"id": "inclusionai/ling-2.6-flash",
-			"name": "Ling-2.6 Flash",
+			"name": "Ling-2.6-flash",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -78058,6 +79917,35 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"inclusionai/ling-3.0-flash": {
+			"id": "inclusionai/ling-3.0-flash",
+			"name": "Ling-3.0-flash",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.020999999999999998,
+				"output": 0.063,
+				"cacheRead": 0.004200000000000001,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"inclusionai/ling-3.0-flash:free": {
 			"id": "inclusionai/ling-3.0-flash:free",
 			"name": "Ling-3.0-flash (free)",
@@ -78087,6 +79975,35 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"inclusionai/ling-3.0-tiny:free": {
+			"id": "inclusionai/ling-3.0-tiny:free",
+			"name": "Ling 3.0 Tiny (free)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"inclusionai/ring-2.6-1t": {
 			"id": "inclusionai/ring-2.6-1t",
@@ -78400,7 +80317,7 @@
 		},
 		"meta-llama/llama-3.3-70b-instruct": {
 			"id": "meta-llama/llama-3.3-70b-instruct",
-			"name": "Llama 3.3 70B Instruct",
+			"name": "Llama-3.3-70B-Instruct",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -78409,13 +80326,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 0.39999999999999997,
+				"input": 0.09999999999999999,
+				"output": 0.32,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 128000,
+			"maxTokens": 16384,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -78515,6 +80432,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"meta/muse-spark-1.2": {
+			"id": "meta/muse-spark-1.2",
+			"name": "Muse Spark 1.2",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 4.25,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"minimax/minimax-m1": {
 			"id": "minimax/minimax-m1",
 			"name": "MiniMax M1",
@@ -78547,7 +80494,7 @@
 		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
-			"name": "MiniMax M2",
+			"name": "MiniMax-M2",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -78577,7 +80524,7 @@
 		},
 		"minimax/minimax-m2.1": {
 			"id": "minimax/minimax-m2.1",
-			"name": "MiniMax M2.1",
+			"name": "MiniMax-M2.1",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -78616,7 +80563,7 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.15,
+				"input": 0.22,
 				"output": 0.8999999999999999,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
@@ -78670,7 +80617,7 @@
 		},
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
-			"name": "MiniMax M2.7",
+			"name": "MiniMax-M2.7",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -78679,9 +80626,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1,
-				"cacheRead": 0.049999999999999996,
+				"input": 0.27,
+				"output": 1.08,
+				"cacheRead": 0.054,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -78700,7 +80647,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -78975,7 +80922,7 @@
 		},
 		"mistralai/mistral-large-2512": {
 			"id": "mistralai/mistral-large-2512",
-			"name": "Mistral Large 3 2512",
+			"name": "Mistral Large 3",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -79220,8 +81167,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.075,
-				"output": 0.19999999999999998,
+				"input": 0.09375,
+				"output": 0.25,
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
@@ -79473,9 +81420,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 3.41,
-				"cacheRead": 0.19999999999999998,
+				"input": 0.5795,
+				"output": 2.44,
+				"cacheRead": 0.0976,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -79535,7 +81482,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.73,
+				"input": 0.7,
 				"output": 3.5,
 				"cacheRead": 0.15,
 				"cacheWrite": 0
@@ -79553,6 +81500,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"moonshotai/kimi-k2.7-code:batch": {
+			"id": "moonshotai/kimi-k2.7-code:batch",
+			"name": "Kimi K2.7 Code (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.475,
+				"output": 2,
+				"cacheRead": 0.095,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"moonshotai/kimi-k3": {
 			"id": "moonshotai/kimi-k3",
@@ -79996,6 +81973,35 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"nvidia/nemotron-3-ultra-550b-a55b:batch": {
+			"id": "nvidia/nemotron-3-ultra-550b-a55b:batch",
+			"name": "Nemotron 3 Ultra (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.7999999999999998,
+				"cacheRead": 0.09999999999999999,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512288,
+			"maxTokens": null,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"nvidia/nemotron-3-ultra-550b-a55b:free": {
 			"id": "nvidia/nemotron-3-ultra-550b-a55b:free",
 			"name": "Nemotron 3 Ultra (free)",
@@ -80119,7 +82125,7 @@
 		},
 		"openai/gpt-3.5-turbo": {
 			"id": "openai/gpt-3.5-turbo",
-			"name": "GPT-3.5 Turbo",
+			"name": "GPT-3.5-turbo",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -80179,6 +82185,26 @@
 			"maxTokens": 4096,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"openai/gpt-3.5-turbo:batch": {
+			"id": "openai/gpt-3.5-turbo:batch",
+			"name": "GPT-3.5 Turbo (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 0.75,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 16385,
+			"maxTokens": 4096,
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4": {
 			"id": "openai/gpt-4",
@@ -80286,6 +82312,27 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-4-turbo:batch": {
+			"id": "openai/gpt-4-turbo:batch",
+			"name": "GPT-4 Turbo (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 15,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 4096,
+			"supportsComputerUse": false
+		},
 		"openai/gpt-4.1": {
 			"id": "openai/gpt-4.1",
 			"name": "GPT-4.1",
@@ -80310,7 +82357,7 @@
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
-			"name": "GPT-4.1 Mini",
+			"name": "GPT-4.1 mini",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -80330,9 +82377,30 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-4.1-mini:batch": {
+			"id": "openai/gpt-4.1-mini:batch",
+			"name": "GPT-4.1 Mini (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.19999999999999998,
+				"output": 0.7999999999999999,
+				"cacheRead": 0.049999999999999996,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1047576,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
-			"name": "GPT-4.1 Nano",
+			"name": "GPT-4.1 nano",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -80351,6 +82419,48 @@
 			"maxTokens": 32768,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"openai/gpt-4.1-nano:batch": {
+			"id": "openai/gpt-4.1-nano:batch",
+			"name": "GPT-4.1 Nano (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.049999999999999996,
+				"output": 0.19999999999999998,
+				"cacheRead": 0.012499999999999999,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1047576,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"openai/gpt-4.1:batch": {
+			"id": "openai/gpt-4.1:batch",
+			"name": "GPT-4.1 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 4,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1047576,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
 		},
 		"openai/gpt-4o": {
 			"id": "openai/gpt-4o",
@@ -80505,6 +82615,48 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-4o-mini:batch": {
+			"id": "openai/gpt-4o-mini:batch",
+			"name": "GPT-4o-mini (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.075,
+				"output": 0.3,
+				"cacheRead": 0.0375,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384,
+			"supportsComputerUse": false
+		},
+		"openai/gpt-4o:batch": {
+			"id": "openai/gpt-4o:batch",
+			"name": "GPT-4o (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 5,
+				"cacheRead": 0.625,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384,
+			"supportsComputerUse": false
+		},
 		"openai/gpt-4o:extended": {
 			"id": "openai/gpt-4o:extended",
 			"name": "GPT-4o (extended)",
@@ -80588,6 +82740,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"openai/gpt-5-codex:batch": {
+			"id": "openai/gpt-5-codex:batch",
+			"name": "GPT-5 Codex (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.625,
+				"output": 5,
+				"cacheRead": 0.0625,
+				"cacheWrite": 0
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5-image": {
 			"id": "openai/gpt-5-image",
@@ -80806,6 +82988,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-5-pro:batch": {
+			"id": "openai/gpt-5-pro:batch",
+			"name": "GPT-5 Pro (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 7.5,
+				"output": 60,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"openai/gpt-5:batch": {
 			"id": "openai/gpt-5:batch",
 			"name": "GPT-5 (batch)",
@@ -80923,7 +83135,7 @@
 		},
 		"openai/gpt-5.1-codex-max": {
 			"id": "openai/gpt-5.1-codex-max",
-			"name": "GPT-5.1-Codex-Max",
+			"name": "GPT-5.1 Codex Max",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -80954,7 +83166,7 @@
 		},
 		"openai/gpt-5.1-codex-mini": {
 			"id": "openai/gpt-5.1-codex-mini",
-			"name": "GPT-5.1-Codex-Mini",
+			"name": "GPT-5.1 Codex mini",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -81127,6 +83339,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-5.2-pro:batch": {
+			"id": "openai/gpt-5.2-pro:batch",
+			"name": "GPT-5.2 Pro (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10.5,
+				"output": 84,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"openai/gpt-5.2:batch": {
 			"id": "openai/gpt-5.2:batch",
 			"name": "GPT-5.2 (batch)",
@@ -81244,7 +83486,7 @@
 		},
 		"openai/gpt-5.4-mini": {
 			"id": "openai/gpt-5.4-mini",
-			"name": "GPT-5.4 Mini",
+			"name": "GPT-5.4 mini",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -81306,7 +83548,7 @@
 		},
 		"openai/gpt-5.4-nano": {
 			"id": "openai/gpt-5.4-nano",
-			"name": "GPT-5.4 Nano",
+			"name": "GPT-5.4 nano",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -81396,6 +83638,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"openai/gpt-5.4-pro:batch": {
+			"id": "openai/gpt-5.4-pro:batch",
+			"name": "GPT-5.4 Pro (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 15,
+				"output": 90,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.4:batch": {
 			"id": "openai/gpt-5.4:batch",
@@ -81492,6 +83764,37 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-5.5-pro:batch": {
+			"id": "openai/gpt-5.5-pro:batch",
+			"name": "GPT-5.5 Pro (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 15,
+				"output": 90,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "openrouter/openai/gpt-5.4"
+		},
 		"openai/gpt-5.5:batch": {
 			"id": "openai/gpt-5.5:batch",
 			"name": "GPT-5.5 (batch)",
@@ -81537,9 +83840,9 @@
 			],
 			"cost": {
 				"input": 0.09999999999999999,
-				"output": 0.6000000000000001,
+				"output": 0.6,
 				"cacheRead": 0.01,
-				"cacheWrite": 0.12500000000000003
+				"cacheWrite": 0.125
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -81558,7 +83861,7 @@
 		},
 		"openai/gpt-5.6-luna-pro": {
 			"id": "openai/gpt-5.6-luna-pro",
-			"name": "GPT-5.6 Luna Pro",
+			"name": "GPT-5.6 Luna",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -81569,9 +83872,9 @@
 			],
 			"cost": {
 				"input": 0.09999999999999999,
-				"output": 0.6000000000000001,
+				"output": 0.6,
 				"cacheRead": 0.01,
-				"cacheWrite": 0.12500000000000003
+				"cacheWrite": 0.125
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -81587,6 +83890,68 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"openai/gpt-5.6-luna-pro:batch": {
+			"id": "openai/gpt-5.6-luna-pro:batch",
+			"name": "GPT-5.6 Luna Pro (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.09999999999999999,
+				"output": 0.6,
+				"cacheRead": 0.01,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-5.6-luna:batch": {
+			"id": "openai/gpt-5.6-luna:batch",
+			"name": "GPT-5.6 Luna (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.09999999999999999,
+				"output": 0.6,
+				"cacheRead": 0.01,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.6-sol": {
 			"id": "openai/gpt-5.6-sol",
@@ -81622,7 +83987,7 @@
 		},
 		"openai/gpt-5.6-sol-pro": {
 			"id": "openai/gpt-5.6-sol-pro",
-			"name": "GPT-5.6 Sol Pro",
+			"name": "GPT-5.6 Sol",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -81652,6 +84017,68 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-5.6-sol-pro:batch": {
+			"id": "openai/gpt-5.6-sol-pro:batch",
+			"name": "GPT-5.6 Sol Pro (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-5.6-sol:batch": {
+			"id": "openai/gpt-5.6-sol:batch",
+			"name": "GPT-5.6 Sol (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"openai/gpt-5.6-terra": {
 			"id": "openai/gpt-5.6-terra",
 			"name": "GPT-5.6 Terra",
@@ -81664,7 +84091,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.0000000000000002,
+				"input": 1,
 				"output": 6,
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 1.25
@@ -81686,7 +84113,7 @@
 		},
 		"openai/gpt-5.6-terra-pro": {
 			"id": "openai/gpt-5.6-terra-pro",
-			"name": "GPT-5.6 Terra Pro",
+			"name": "GPT-5.6 Terra",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -81696,7 +84123,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.0000000000000002,
+				"input": 1,
 				"output": 6,
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 1.25
@@ -81715,6 +84142,68 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"openai/gpt-5.6-terra-pro:batch": {
+			"id": "openai/gpt-5.6-terra-pro:batch",
+			"name": "GPT-5.6 Terra Pro (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.09999999999999999,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"supportsComputerUse": false
+		},
+		"openai/gpt-5.6-terra:batch": {
+			"id": "openai/gpt-5.6-terra:batch",
+			"name": "GPT-5.6 Terra (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.09999999999999999,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-audio": {
 			"id": "openai/gpt-audio",
@@ -81995,6 +84484,37 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/o1:batch": {
+			"id": "openai/o1:batch",
+			"name": "o1 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 7.5,
+				"output": 30,
+				"cacheRead": 3.75,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
+		},
 		"openai/o3": {
 			"id": "openai/o3",
 			"name": "o3",
@@ -82096,7 +84616,7 @@
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -82109,7 +84629,77 @@
 			"contextWindow": 200000,
 			"maxTokens": 100000,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
+		},
+		"openai/o3-mini-high:batch": {
+			"id": "openai/o3-mini-high:batch",
+			"name": "o3 Mini High (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.55,
+				"output": 2.2,
+				"cacheRead": 0.275,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
+		},
+		"openai/o3-mini:batch": {
+			"id": "openai/o3-mini:batch",
+			"name": "o3 Mini (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.55,
+				"output": 2.2,
+				"cacheRead": 0.275,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o3-pro": {
 			"id": "openai/o3-pro",
@@ -82142,6 +84732,68 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"openai/o3-pro:batch": {
+			"id": "openai/o3-pro:batch",
+			"name": "o3 Pro (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 10,
+				"output": 40,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
+		},
+		"openai/o3:batch": {
+			"id": "openai/o3:batch",
+			"name": "o3 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 4,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
 		},
 		"openai/o4-mini": {
 			"id": "openai/o4-mini",
@@ -82238,6 +84890,68 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"openai/o4-mini-high:batch": {
+			"id": "openai/o4-mini-high:batch",
+			"name": "o4 Mini High (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.55,
+				"output": 2.2,
+				"cacheRead": 0.1375,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
+		},
+		"openai/o4-mini:batch": {
+			"id": "openai/o4-mini:batch",
+			"name": "o4 Mini (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.55,
+				"output": 2.2,
+				"cacheRead": 0.1375,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
 		},
 		"openrouter/aurora-alpha": {
 			"id": "openrouter/aurora-alpha",
@@ -82354,7 +85068,7 @@
 		},
 		"openrouter/free": {
 			"id": "openrouter/free",
-			"name": "Free Models Router",
+			"name": "OpenRouter Free Models Router",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -82812,7 +85526,7 @@
 		},
 		"qwen/qwen-plus": {
 			"id": "qwen/qwen-plus",
-			"name": "Qwen-Plus",
+			"name": "Qwen Plus",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -82957,7 +85671,7 @@
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3 235B A22B",
+			"name": "Qwen3 235B-A22B",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -83121,7 +85835,7 @@
 		},
 		"qwen/qwen3-32b": {
 			"id": "qwen/qwen3-32b",
-			"name": "Qwen3-32B",
+			"name": "Qwen3 32B",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -83262,7 +85976,7 @@
 		},
 		"qwen/qwen3-coder-30b-a3b-instruct": {
 			"id": "qwen/qwen3-coder-30b-a3b-instruct",
-			"name": "Qwen3 Coder 30B A3B Instruct",
+			"name": "Qwen3-Coder 30B-A3B Instruct",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -83272,12 +85986,12 @@
 			],
 			"cost": {
 				"input": 0.07,
-				"output": 0.28,
+				"output": 0.27,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 32768,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -83449,13 +86163,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
+				"input": 0.09,
 				"output": 1.1,
 				"cacheRead": 0.07,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 16384,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -83482,7 +86196,7 @@
 		},
 		"qwen/qwen3-next-80b-a3b-thinking": {
 			"id": "qwen/qwen3-next-80b-a3b-thinking",
-			"name": "Qwen3 Next 80B A3B Thinking",
+			"name": "Qwen3-Next 80B-A3B (Thinking)",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -83497,7 +86211,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 32768,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -83577,13 +86291,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 0.52,
+				"input": 0.15,
+				"output": 0.6,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 32768,
+			"maxTokens": 16384,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -83707,13 +86421,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 2.08,
+				"input": 0.29,
+				"output": 2.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 81920,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -83728,7 +86442,7 @@
 		},
 		"qwen/qwen3.5-27b": {
 			"id": "qwen/qwen3.5-27b",
-			"name": "Qwen3.5-27B",
+			"name": "Qwen3.5 27B",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -83759,7 +86473,7 @@
 		},
 		"qwen/qwen3.5-35b-a3b": {
 			"id": "qwen/qwen3.5-35b-a3b",
-			"name": "Qwen3.5-35B-A3B",
+			"name": "Qwen3.5 35B-A3B",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -83790,7 +86504,7 @@
 		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
-			"name": "Qwen3.5 397B A17B",
+			"name": "Qwen3.5 397B-A17B",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -83821,7 +86535,7 @@
 		},
 		"qwen/qwen3.5-9b": {
 			"id": "qwen/qwen3.5-9b",
-			"name": "Qwen3.5-9B",
+			"name": "Qwen3.5 9B",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -83955,13 +86669,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 2,
-				"cacheRead": 0.15,
+				"input": 0.6,
+				"output": 3.5999999999999996,
+				"cacheRead": 0.12,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -83976,7 +86690,7 @@
 		},
 		"qwen/qwen3.6-35b-a3b": {
 			"id": "qwen/qwen3.6-35b-a3b",
-			"name": "Qwen3.6 35B A3B",
+			"name": "Qwen3.6 35B-A3B",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -84250,6 +86964,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"qwen/qwen3.8-max": {
+			"id": "qwen/qwen3.8-max",
+			"name": "Qwen3.8 Max",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"qwen/qwq-32b": {
 			"id": "qwen/qwq-32b",
 			"name": "QwQ 32B",
@@ -84520,7 +87264,7 @@
 		},
 		"tencent/hy3": {
 			"id": "tencent/hy3",
-			"name": "Hy3",
+			"name": "Tencent Hy3",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -84550,7 +87294,7 @@
 		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
-			"name": "Hy3 Preview",
+			"name": "Hy3 preview",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -84676,7 +87420,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1024000,
-			"maxTokens": 32768,
+			"maxTokens": 1024000,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -84692,13 +87436,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
+				"input": 0.95,
 				"output": 4.05,
-				"cacheRead": 0.16999999999999998,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -84723,13 +87467,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.5,
+				"input": 0.44999999999999996,
 				"output": 1.2,
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
 			"contextWindow": 524288,
-			"maxTokens": 32768,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -84741,6 +87485,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"thinkingmachines/inkling:batch": {
+			"id": "thinkingmachines/inkling:batch",
+			"name": "Inkling (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.5,
+				"output": 2.025,
+				"cacheRead": 0.08499999999999999,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": null,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"tngtech/deepseek-r1t2-chimera": {
 			"id": "tngtech/deepseek-r1t2-chimera",
@@ -84815,8 +87589,8 @@
 				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 32768,
+			"contextWindow": 131072,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -85300,7 +88074,7 @@
 		},
 		"xiaomi/mimo-v2-pro": {
 			"id": "xiaomi/mimo-v2-pro",
-			"name": "MiMo-V2-Pro",
+			"name": "MiMo V2 Pro",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -85359,7 +88133,7 @@
 		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
-			"name": "MiMo V2.5 Pro",
+			"name": "MiMo-V2.5-Pro",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -85409,7 +88183,7 @@
 		},
 		"z-ai/glm-4.5": {
 			"id": "z-ai/glm-4.5",
-			"name": "GLM 4.5",
+			"name": "GLM-4.5",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85439,7 +88213,7 @@
 		},
 		"z-ai/glm-4.5-air": {
 			"id": "z-ai/glm-4.5-air",
-			"name": "GLM 4.5 Air",
+			"name": "GLM-4.5-Air",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85499,7 +88273,7 @@
 		},
 		"z-ai/glm-4.5v": {
 			"id": "z-ai/glm-4.5v",
-			"name": "GLM 4.5V",
+			"name": "GLM-4.5V",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85530,7 +88304,7 @@
 		},
 		"z-ai/glm-4.6": {
 			"id": "z-ai/glm-4.6",
-			"name": "GLM 4.6",
+			"name": "GLM-4.6",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85621,7 +88395,7 @@
 		},
 		"z-ai/glm-4.7": {
 			"id": "z-ai/glm-4.7",
-			"name": "GLM 4.7",
+			"name": "GLM-4.7",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85651,7 +88425,7 @@
 		},
 		"z-ai/glm-4.7-flash": {
 			"id": "z-ai/glm-4.7-flash",
-			"name": "GLM 4.7 Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85681,7 +88455,7 @@
 		},
 		"z-ai/glm-5": {
 			"id": "z-ai/glm-5",
-			"name": "GLM 5",
+			"name": "GLM-5",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -85732,7 +88506,7 @@
 		},
 		"z-ai/glm-5.1": {
 			"id": "z-ai/glm-5.1",
-			"name": "GLM 5.1",
+			"name": "GLM-5.1",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -85741,13 +88515,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.966,
-				"output": 3.036,
-				"cacheRead": 0.1794,
+				"input": 0.952,
+				"output": 2.992,
+				"cacheRead": 0.17679999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 128000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -85771,9 +88545,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.42,
-				"output": 1.32,
-				"cacheRead": 0.078,
+				"input": 0.2212,
+				"output": 0.6952,
+				"cacheRead": 0.04108,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -85790,6 +88564,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"z-ai/glm-5.2:batch": {
+			"id": "z-ai/glm-5.2:batch",
+			"name": "GLM 5.2 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.7,
+				"output": 2.2,
+				"cacheRead": 0.13,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"z-ai/glm-5v-turbo": {
 			"id": "z-ai/glm-5v-turbo",
@@ -85976,9 +88780,69 @@
 		}
 	},
 	"synthetic": {
+		"hf:MiniMaxAI/MiniMax-M3": {
+			"id": "hf:MiniMaxAI/MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 1.2,
+				"cacheRead": 0.6,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"hf:moonshotai/Kimi-K2.7-Code": {
+			"id": "hf:moonshotai/Kimi-K2.7-Code",
+			"name": "Kimi K2.7 Code",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.95,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"hf:moonshotai/Kimi-K3": {
 			"id": "hf:moonshotai/Kimi-K3",
-			"name": "moonshotai/Kimi-K3",
+			"name": "Kimi K3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -86007,12 +88871,11 @@
 					"max": "max"
 				},
 				"requiresEffort": true
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-			"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -86023,7 +88886,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 1,
-				"cacheRead": 0.06,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -86037,12 +88900,11 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:openai/gpt-oss-120b": {
 			"id": "hf:openai/gpt-oss-120b",
-			"name": "openai/gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -86053,11 +88915,11 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0.02,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -86065,12 +88927,11 @@
 					"medium",
 					"high"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:Qwen/Qwen3.6-27B": {
 			"id": "hf:Qwen/Qwen3.6-27B",
-			"name": "Qwen/Qwen3.6-27B",
+			"name": "Qwen3.6 27B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -86081,8 +88942,8 @@
 			],
 			"cost": {
 				"input": 0.45,
-				"output": 2.2,
-				"cacheRead": 0.09,
+				"output": 3.6,
+				"cacheRead": 0.45,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -86095,12 +88956,11 @@
 					"medium",
 					"high"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:zai-org/GLM-4.7-Flash": {
 			"id": "hf:zai-org/GLM-4.7-Flash",
-			"name": "zai-org/GLM-4.7-Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -86111,7 +88971,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.5,
-				"cacheRead": 0.02,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
@@ -86125,12 +88985,11 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"hf:zai-org/GLM-5.2": {
 			"id": "hf:zai-org/GLM-5.2",
-			"name": "zai-org/GLM-5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -86139,9 +88998,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1,
-				"output": 3,
-				"cacheRead": 0.16,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 1.4,
 				"cacheWrite": 0
 			},
 			"contextWindow": 524288,
@@ -86155,8 +89014,7 @@
 					"high",
 					"xhigh"
 				]
-			},
-			"supportsComputerUse": false
+			}
 		},
 		"syn:large:text": {
 			"id": "syn:large:text",
@@ -86375,6 +89233,33 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 8192
+		},
+		"deepseek-ai/DeepSeek-V4-Flash-0731": {
+			"id": "deepseek-ai/DeepSeek-V4-Flash-0731",
+			"name": "DeepSeek V4 Flash 0731",
+			"api": "openai-completions",
+			"provider": "together",
+			"baseUrl": "https://api.together.xyz/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.03,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				]
+			}
 		},
 		"deepseek-ai/DeepSeek-V4-Pro": {
 			"id": "deepseek-ai/DeepSeek-V4-Pro",
@@ -87187,7 +90072,41 @@
 		},
 		"umans-deepseek-v4-flash-0731": {
 			"id": "umans-deepseek-v4-flash-0731",
-			"name": "Umans DeepSeek V4 Flash (experimental)",
+			"name": "Umans DeepSeek V4 Flash",
+			"api": "anthropic-messages",
+			"provider": "umans",
+			"baseUrl": "https://api.code.umans.ai",
+			"reasoning": true,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.028,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 393215,
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
+			"compat": {
+				"escapeBuiltinToolNames": true
+			}
+		},
+		"umans-deepseek-v4-flash-0731-lab": {
+			"id": "umans-deepseek-v4-flash-0731-lab",
+			"name": "Umans DeepSeek V4 Flash (lab)",
 			"api": "anthropic-messages",
 			"provider": "umans",
 			"baseUrl": "https://api.code.umans.ai",
@@ -87214,7 +90133,6 @@
 			"contextWindow": 1048576,
 			"maxTokens": 393215,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false,
 			"compat": {
 				"escapeBuiltinToolNames": true
 			}
@@ -87343,9 +90261,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -88023,7 +90941,7 @@
 		},
 		"deepseek-v4-flash": {
 			"id": "deepseek-v4-flash",
-			"name": "DeepSeek V4 Flash",
+			"name": "DeepSeek V4 Flash 0423",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
@@ -88042,6 +90960,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -88068,6 +90987,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -89359,6 +92279,39 @@
 				"requiresEffort": true
 			}
 		},
+		"kimi-k3-fast-api": {
+			"id": "kimi-k3-fast-api",
+			"name": "Kimi K3 Fast",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 4.5,
+				"output": 22.5,
+				"cacheRead": 0.45,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"effortMap": {
+					"max": "max"
+				},
+				"requiresEffort": true
+			}
+		},
 		"llama-3.2-3b": {
 			"id": "llama-3.2-3b",
 			"name": "Llama 3.2 3B",
@@ -90324,6 +93277,35 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"qwen-3-8-max": {
+			"id": "qwen-3-8-max",
+			"name": "Qwen 3.8 Max",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 7.5,
+				"cacheRead": 0.3125,
+				"cacheWrite": 3.125
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -91726,6 +94708,37 @@
 			},
 			"supportsComputerUse": false
 		},
+		"alibaba/qwen3.8-max": {
+			"id": "alibaba/qwen3.8-max",
+			"name": "Qwen 3.8 Max",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.25,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"amazon/nova-2-lite": {
 			"id": "amazon/nova-2-lite",
 			"name": "Nova 2 Lite",
@@ -92061,7 +95074,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
@@ -92158,7 +95172,7 @@
 		},
 		"anthropic/claude-opus-4.7-fast": {
 			"id": "anthropic/claude-opus-4.7-fast",
-			"name": "Claude Opus 4.7 (Fast)",
+			"name": "Claude Opus 4.7",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -92223,7 +95237,7 @@
 		},
 		"anthropic/claude-opus-4.8-fast": {
 			"id": "anthropic/claude-opus-4.8-fast",
-			"name": "Claude Opus 4.8 (Fast)",
+			"name": "Claude Opus 4.8",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -92287,7 +95301,7 @@
 		},
 		"anthropic/claude-opus-5-fast": {
 			"id": "anthropic/claude-opus-5-fast",
-			"name": "Claude Opus 5 (Fast)",
+			"name": "Claude Opus 5",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -92315,7 +95329,8 @@
 				],
 				"supportsDisplay": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
@@ -92606,7 +95621,7 @@
 		},
 		"deepseek/deepseek-r1": {
 			"id": "deepseek/deepseek-r1",
-			"name": "R1",
+			"name": "DeepSeek-R1",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -92787,9 +95802,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.0028,
+				"input": 0.19999999999999998,
+				"output": 0.39999999999999997,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -92817,9 +95832,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 0.26,
-				"cacheRead": 0.028,
+				"input": 0.19999999999999998,
+				"output": 0.39999999999999997,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -92847,13 +95862,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.435,
-				"output": 0.87,
-				"cacheRead": 0.0036,
+				"input": 1.74,
+				"output": 3.48,
+				"cacheRead": 0.14,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 384000,
+			"contextWindow": 1048600,
+			"maxTokens": 1048600,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -92942,7 +95957,7 @@
 		},
 		"google/gemini-2.5-flash-lite": {
 			"id": "google/gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -93301,7 +96316,7 @@
 		},
 		"google/gemma-4-26b-a4b-it": {
 			"id": "google/gemma-4-26b-a4b-it",
-			"name": "Gemma 4 26B A4B",
+			"name": "Gemma 4 26B A4B IT",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -93332,7 +96347,7 @@
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -93347,7 +96362,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 256000,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "budget",
@@ -93411,6 +96426,36 @@
 			"maxTokens": 16384,
 			"supportsComputerUse": false
 		},
+		"inclusionai/ling-3.0-flash": {
+			"id": "inclusionai/ling-3.0-flash",
+			"name": "Ling-3.0-flash",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.06,
+				"output": 0.18,
+				"cacheRead": 0.012,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"inclusionai/ling-3.0-flash-free": {
 			"id": "inclusionai/ling-3.0-flash-free",
 			"name": "Ling 3.0 Flash",
@@ -93429,6 +96474,37 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
+		},
+		"inclusionai/ling-3.0-tiny-free": {
+			"id": "inclusionai/ling-3.0-tiny-free",
+			"name": "Ling 3.0 Tiny (Free)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32000,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -93474,14 +96550,13 @@
 		},
 		"kwaipilot/kat-coder-air-v2.5": {
 			"id": "kwaipilot/kat-coder-air-v2.5",
-			"name": "Kat Coder Air V2.5",
+			"name": "KAT-Coder-Air V2.5",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0.15,
@@ -93491,16 +96566,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 80000,
-			"thinking": {
-				"mode": "budget",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
 			"supportsComputerUse": false
 		},
 		"kwaipilot/kat-coder-pro-v1": {
@@ -93545,14 +96610,13 @@
 		},
 		"kwaipilot/kat-coder-pro-v2.5": {
 			"id": "kwaipilot/kat-coder-pro-v2.5",
-			"name": "Kat Coder Pro V2.5",
+			"name": "KAT-Coder-Pro V2.5",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0.74,
@@ -93562,16 +96626,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 80000,
-			"thinking": {
-				"mode": "budget",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
 			"supportsComputerUse": false
 		},
 		"meituan/longcat-flash-chat": {
@@ -93836,9 +96890,71 @@
 			},
 			"supportsComputerUse": false
 		},
+		"meta/muse-spark-1.2": {
+			"id": "meta/muse-spark-1.2",
+			"name": "Muse Spark 1.2",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 4.25,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
+		"meta/muse-spark-1.2-contributor": {
+			"id": "meta/muse-spark-1.2-contributor",
+			"name": "Muse Spark 1.2 Contributor (Data Used for Training)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.09999999999999999,
+				"output": 0.19999999999999998,
+				"cacheRead": 0.002,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
-			"name": "MiniMax M2",
+			"name": "MiniMax-M2",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -93872,7 +96988,7 @@
 		},
 		"minimax/minimax-m2.1": {
 			"id": "minimax/minimax-m2.1",
-			"name": "MiniMax M2.1",
+			"name": "MiniMax-M2.1",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -94009,7 +97125,7 @@
 		},
 		"minimax/minimax-m2.7": {
 			"id": "minimax/minimax-m2.7",
-			"name": "MiniMax M2.7",
+			"name": "MiniMax-M2.7",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -94077,7 +97193,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -94683,7 +97799,7 @@
 		},
 		"moonshotai/kimi-k2.7-code-highspeed": {
 			"id": "moonshotai/kimi-k2.7-code-highspeed",
-			"name": "Kimi K2.7 Code High Speed",
+			"name": "Kimi K2.7 Code High-Speed",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -94897,7 +98013,7 @@
 		},
 		"nvidia/nemotron-nano-9b-v2": {
 			"id": "nvidia/nemotron-nano-9b-v2",
-			"name": "Nemotron Nano 9B V2",
+			"name": "Nvidia Nemotron Nano 9B V2",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -94959,7 +98075,7 @@
 		},
 		"openai/gpt-3.5-turbo": {
 			"id": "openai/gpt-3.5-turbo",
-			"name": "GPT-3.5 Turbo",
+			"name": "GPT-3.5-turbo",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -95021,7 +98137,7 @@
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
-			"name": "GPT-4.1 Mini",
+			"name": "GPT-4.1 mini",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -95042,7 +98158,7 @@
 		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
-			"name": "GPT-4.1 Nano",
+			"name": "GPT-4.1 nano",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -95316,7 +98432,7 @@
 		},
 		"openai/gpt-5.1-codex-max": {
 			"id": "openai/gpt-5.1-codex-max",
-			"name": "GPT-5.1-Codex-Max",
+			"name": "GPT-5.1 Codex Max",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -95346,7 +98462,7 @@
 		},
 		"openai/gpt-5.1-codex-mini": {
 			"id": "openai/gpt-5.1-codex-mini",
-			"name": "GPT-5.1-Codex-Mini",
+			"name": "GPT-5.1 Codex mini",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -95628,7 +98744,7 @@
 		},
 		"openai/gpt-5.4-mini": {
 			"id": "openai/gpt-5.4-mini",
-			"name": "GPT-5.4 Mini",
+			"name": "GPT-5.4 mini",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -95658,7 +98774,7 @@
 		},
 		"openai/gpt-5.4-nano": {
 			"id": "openai/gpt-5.4-nano",
-			"name": "GPT-5.4 Nano",
+			"name": "GPT-5.4 nano",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -96027,7 +99143,7 @@
 		},
 		"openai/o3-deep-research": {
 			"id": "openai/o3-deep-research",
-			"name": "o3 Deep Research",
+			"name": "o3-deep-research",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -96381,7 +99497,7 @@
 		},
 		"tencent/hy3": {
 			"id": "tencent/hy3",
-			"name": "Hy3",
+			"name": "Tencent Hy3",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -97086,7 +100202,7 @@
 		},
 		"xiaomi/mimo-v2-pro": {
 			"id": "xiaomi/mimo-v2-pro",
-			"name": "MiMo-V2-Pro",
+			"name": "MiMo V2 Pro",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -97148,7 +100264,7 @@
 		},
 		"xiaomi/mimo-v2.5-pro": {
 			"id": "xiaomi/mimo-v2.5-pro",
-			"name": "MiMo V2.5 Pro",
+			"name": "MiMo-V2.5-Pro",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -97526,8 +100642,8 @@
 				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202000,
-			"maxTokens": 202000,
+			"contextWindow": 202800,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -97654,6 +100770,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -98872,7 +101989,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"supportsComputerUse": false,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -98903,7 +102019,6 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
-			"supportsComputerUse": false,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -98933,6 +102048,16 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98945,17 +102070,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"supportsComputerUse": false,
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
 			}
 		},
 		"grok-4.3": {
@@ -98977,6 +102091,16 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -98989,17 +102113,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"supportsComputerUse": false,
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
 			}
 		},
 		"grok-4.5": {
@@ -99021,6 +102134,16 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -99033,17 +102156,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"supportsComputerUse": false,
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"supportsImageDetailOriginal": false,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true
 			}
 		},
 		"grok-build": {
@@ -99065,7 +102177,6 @@
 			},
 			"contextWindow": 512000,
 			"maxTokens": 512000,
-			"supportsComputerUse": false,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -99096,7 +102207,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
-			"supportsComputerUse": false,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -99126,7 +102236,6 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 200000,
-			"supportsComputerUse": false,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -100671,8 +103780,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.424593036,
-				"output": 1.910668662,
+				"input": 0.588,
+				"output": 2.646,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -100887,10 +103996,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.422571632,
-				"output": 2.11285816,
-				"cacheRead": 0.08453343,
-				"cacheWrite": 0.001193975
+				"input": 0.8848,
+				"output": 4.424,
+				"cacheRead": 0.177,
+				"cacheWrite": 0.0025
 			},
 			"contextWindow": 256000,
 			"maxTokens": null,
@@ -100918,10 +104027,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.422571632,
-				"output": 2.11285816,
-				"cacheRead": 0.08453343,
-				"cacheWrite": 0.00238795
+				"input": 0.4424,
+				"output": 2.212,
+				"cacheRead": 0.0885,
+				"cacheWrite": 0.0025
 			},
 			"contextWindow": 256000,
 			"maxTokens": null,
@@ -101011,10 +104120,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.422571632,
-				"output": 2.11285816,
-				"cacheRead": 0.08453343,
-				"cacheWrite": 0.001193975
+				"input": 0.8848,
+				"output": 4.424,
+				"cacheRead": 0.177,
+				"cacheWrite": 0.0025
 			},
 			"contextWindow": 256000,
 			"maxTokens": null,
@@ -101205,6 +104314,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -101231,6 +104341,7 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"low",
 					"high",
 					"max"
 				]
@@ -101748,6 +104859,37 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"google/gemma-4-26b-a4b-it": {
+			"id": "google/gemma-4-26b-a4b-it",
+			"name": "Gemma 4 26B A4B IT",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.015,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"inclusionai/ling-1t": {
 			"id": "inclusionai/ling-1t",
 			"name": "Ling-1T",
@@ -101778,9 +104920,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.1318155,
-				"output": 1.0984625,
-				"cacheRead": 0.0263631,
+				"input": 0.3,
+				"output": 2.5,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -101789,7 +104931,7 @@
 		},
 		"inclusionai/ling-2.6-flash": {
 			"id": "inclusionai/ling-2.6-flash",
-			"name": "Ling-2.6 Flash",
+			"name": "Ling-2.6-flash",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -101813,19 +104955,29 @@
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.021,
+				"output": 0.063,
+				"cacheRead": 0.0042,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"inclusionai/ling-flash-2.0": {
 			"id": "inclusionai/ling-flash-2.0",
@@ -102063,9 +105215,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.135,
-				"output": 0.54,
-				"cacheRead": 0.027,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -102144,9 +105296,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.444,
-				"output": 1.776,
-				"cacheRead": 0.09,
+				"input": 0.74,
+				"output": 2.96,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -102155,7 +105307,7 @@
 		},
 		"meituan/longcat-2.0": {
 			"id": "meituan/longcat-2.0",
-			"name": "LongCat-2.0",
+			"name": "LongCat 2.0",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -102164,13 +105316,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1.18,
-				"cacheRead": 0.006,
+				"input": 0.75,
+				"output": 2.95,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": null,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -102238,11 +105390,42 @@
 			"cost": {
 				"input": 1.25,
 				"output": 4.25,
-				"cacheRead": 0.125,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
+		"meta/muse-spark-1.2": {
+			"id": "meta/muse-spark-1.2",
+			"name": "Muse Spark 1.2",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 4.25,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -102475,7 +105658,7 @@
 		},
 		"mistralai/mistral-large-2512": {
 			"id": "mistralai/mistral-large-2512",
-			"name": "Mistral Large 3 2512",
+			"name": "Mistral Large 3",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -102716,7 +105899,7 @@
 		},
 		"moonshotai/kimi-k2.7-code-highspeed": {
 			"id": "moonshotai/kimi-k2.7-code-highspeed",
-			"name": "Kimi K2.7 Code HighSpeed",
+			"name": "Kimi K2.7 Code High-Speed",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -102855,7 +106038,7 @@
 		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
-			"name": "GPT-4.1 Mini",
+			"name": "GPT-4.1 mini",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -102876,7 +106059,7 @@
 		},
 		"openai/gpt-4.1-nano": {
 			"id": "openai/gpt-4.1-nano",
-			"name": "GPT-4.1 Nano",
+			"name": "GPT-4.1 nano",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -104072,10 +107255,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.134717,
-				"output": 0.808302,
-				"cacheRead": 0.0134717,
-				"cacheWrite": 0.16839625
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0.025,
+				"cacheWrite": 0.3125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
@@ -104149,7 +107332,7 @@
 		},
 		"qwen/qwen3.7-flash": {
 			"id": "qwen/qwen3.7-flash",
-			"name": "Qwen3.7-Flash",
+			"name": "Qwen3.7 Flash",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -104233,6 +107416,36 @@
 					"high"
 				]
 			}
+		},
+		"qwen/qwen3.8-max": {
+			"id": "qwen/qwen3.8-max",
+			"name": "Qwen3.8 Max",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.17,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"sapiens-ai/agnes-1.5-flash": {
 			"id": "sapiens-ai/agnes-1.5-flash",
@@ -104520,7 +107733,7 @@
 		},
 		"tencent/hy3": {
 			"id": "tencent/hy3",
-			"name": "Hy3",
+			"name": "Tencent Hy3",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -104529,9 +107742,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.1323,
-				"output": 0.5301,
-				"cacheRead": 0.0333,
+				"input": 0.147,
+				"output": 0.589,
+				"cacheRead": 0.037,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2714,7 +2714,10 @@ export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-comple
 			efforts: [Effort.Low, Effort.High, Effort.XHigh],
 			requiresEffort: true,
 		},
-		compat: ALIBABA_TOKEN_PLAN_QWEN_EFFORT_COMPAT,
+		compat: {
+			...ALIBABA_TOKEN_PLAN_COMPAT,
+			supportsReasoningEffort: true,
+		},
 	},
 	{
 		id: "qwen3.8-max",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2689,6 +2689,13 @@ const ALIBABA_TOKEN_PLAN_REASONING: ThinkingConfig = {
 	mode: "effort",
 	efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
 };
+// Qwen3.8-Max uses the OpenAI `reasoning_effort` dialect; the generic Qwen
+// dialect emits only the legacy binary `enable_thinking` toggle.
+const ALIBABA_TOKEN_PLAN_QWEN_EFFORT_COMPAT: OpenAICompat = {
+	...ALIBABA_TOKEN_PLAN_COMPAT,
+	supportsReasoningEffort: true,
+	thinkingFormat: "openai",
+};
 
 export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
 	{
@@ -2707,10 +2714,25 @@ export const ALIBABA_TOKEN_PLAN_STATIC_MODELS: readonly ModelSpec<"openai-comple
 			efforts: [Effort.Low, Effort.High, Effort.XHigh],
 			requiresEffort: true,
 		},
-		compat: {
-			...ALIBABA_TOKEN_PLAN_COMPAT,
-			supportsReasoningEffort: true,
+		compat: ALIBABA_TOKEN_PLAN_QWEN_EFFORT_COMPAT,
+	},
+	{
+		id: "qwen3.8-max",
+		name: "Qwen3.8 Max",
+		api: "openai-completions",
+		provider: "alibaba-token-plan",
+		baseUrl: ALIBABA_TOKEN_PLAN_BASE_URL,
+		reasoning: true,
+		input: ["text", "image"],
+		cost: ALIBABA_TOKEN_PLAN_COST,
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+		thinking: {
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.XHigh],
+			defaultLevel: Effort.XHigh,
 		},
+		compat: ALIBABA_TOKEN_PLAN_QWEN_EFFORT_COMPAT,
 	},
 	{
 		id: "qwen3.7-max",

--- a/packages/catalog/test/alibaba-token-plan.test.ts
+++ b/packages/catalog/test/alibaba-token-plan.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { CATALOG_PROVIDERS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
 import {
 	ALIBABA_TOKEN_PLAN_BASE_URL,
@@ -45,6 +46,15 @@ describe("QwenCloud Token Plan provider", () => {
 			Effort.High,
 			Effort.Max,
 		]);
+	});
+
+	test("bundles curated capabilities before dynamic discovery", () => {
+		expect(getBundledModel<"openai-completions">("alibaba-token-plan", "qwen3.8-max-preview")).toMatchObject({
+			reasoning: true,
+			input: ["text", "image"],
+			contextWindow: 983_616,
+			maxTokens: 131_072,
+		});
 	});
 
 	test("discovers subscribed chat models from the native models endpoint", async () => {

--- a/packages/catalog/test/alibaba-token-plan.test.ts
+++ b/packages/catalog/test/alibaba-token-plan.test.ts
@@ -13,6 +13,7 @@ describe("QwenCloud Token Plan provider", () => {
 	test("ships the documented Individual text-model allowlist", () => {
 		expect(ALIBABA_TOKEN_PLAN_STATIC_MODELS.map(model => model.id)).toEqual([
 			"qwen3.8-max-preview",
+			"qwen3.8-max",
 			"qwen3.7-max",
 			"qwen3.7-plus",
 			"qwen3.6-flash",
@@ -142,6 +143,23 @@ describe("QwenCloud Token Plan provider", () => {
 			name: "Qwen3.7 Plus",
 			contextWindow: 1_000_000,
 			maxTokens: 64_000,
+		});
+		expect(models?.find(model => model.id === "qwen3.8-max")).toMatchObject({
+			id: "qwen3.8-max",
+			provider: "alibaba-token-plan",
+			reasoning: true,
+			input: ["text", "image"],
+			contextWindow: 1_000_000,
+			maxTokens: 131_072,
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Low, Effort.Medium, Effort.XHigh],
+				defaultLevel: Effort.XHigh,
+			},
+			compat: {
+				supportsReasoningEffort: true,
+				thinkingFormat: "openai",
+			},
 		});
 		expect(options.dynamicModelsAuthoritative).toBe(true);
 	});

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -145,7 +145,7 @@ describe("generated model policies", () => {
 		});
 	});
 
-	it("preserves QwenCloud's mandatory qwen3.8 effort ladder", () => {
+	it("preserves QwenCloud's provider-authored qwen3.8 effort ladders", () => {
 		const models: ModelSpec<Api>[] = [
 			createSpec({
 				id: "qwen3.8-max-preview",
@@ -157,15 +157,32 @@ describe("generated model policies", () => {
 					requiresEffort: true,
 				},
 			}),
+			createSpec({
+				id: "qwen3.8-max",
+				api: "openai-completions",
+				provider: "alibaba-token-plan",
+				thinking: {
+					mode: "effort",
+					efforts: [Effort.Low, Effort.Medium, Effort.XHigh],
+					defaultLevel: Effort.XHigh,
+				},
+			}),
 		];
 
 		applyGeneratedModelPolicies(models);
 
-		expect(models[0]?.thinking).toEqual({
-			mode: "effort",
-			efforts: [Effort.Low, Effort.High, Effort.XHigh],
-			requiresEffort: true,
-		});
+		expect(models.map(model => model.thinking)).toEqual([
+			{
+				mode: "effort",
+				efforts: [Effort.Low, Effort.High, Effort.XHigh],
+				requiresEffort: true,
+			},
+			{
+				mode: "effort",
+				efforts: [Effort.Low, Effort.Medium, Effort.XHigh],
+				defaultLevel: Effort.XHigh,
+			},
+		]);
 	});
 
 	it("pins zai glm-5.2 base id to 1M context", () => {


### PR DESCRIPTION
## Repro
A mocked Alibaba Token Plan `/models` response containing `{ id: "qwen3.8-max" }` reproduces the bug with `alibabaTokenPlanModelManagerOptions`: the discovered model returned `reasoning: false`, `input: ["text"]`, no `thinking`, a 1,000,000-token context window, and 131,072 max output tokens.

## Cause
`ALIBABA_TOKEN_PLAN_STATIC_MODELS` in `packages/catalog/src/provider-models/openai-compat.ts` did not contain `qwen3.8-max`, so `alibabaTokenPlanModelManagerOptions` could not merge curated capabilities into the generic `/models` defaults and applied only `ALIBABA_TOKEN_PLAN_DISCOVERED_MODEL_LIMITS`.

## Fix
- Add the curated `qwen3.8-max` static reference with reasoning, image input, the `low`/`medium`/`xhigh` effort ladder, and OpenAI effort transport metadata.
- Preserve the provider-authored ladder during catalog generation and regenerate `models.json`.
- Cover discovery metadata, generation policy, and reasoning-effort wire encoding with regressions.

## Verification
`bun test packages/catalog/test/alibaba-token-plan.test.ts packages/catalog/test/generated-policies.test.ts packages/ai/test/openai-compat-policy.test.ts` passed 32 tests with 0 failures. `bun run check` passed in both `packages/catalog` and `packages/ai`. A manual discovery smoke check now returns `reasoning: true`, `input: ["text","image"]`, and `low`/`medium`/`xhigh` thinking metadata. `bun run fix` fails identically on `origin/main` because this environment lacks `cmake` while `audiopus_sys` falls back to a source build; skipped the pre-publish gate.

Fixes #8019