### PR TITLE
fix(task): record subagent model performance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed task subagent assistant turns being omitted from the per-model TPS/TTFT aggregates shown by `/models`. ([#8022](https://github.com/can1357/oh-my-pi/issues/8022))
+
 ## [17.2.11] - 2026-08-07
 
 ### Added

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -442,11 +442,15 @@ export class Settings {
 	}
 
 	/**
-	 * Create an isolated instance for testing.
-	 * Does not affect the global singleton.
+	 * Create an in-memory settings instance without affecting the global singleton.
+	 * A supplied storage handle remains shared for runtime data while setting overrides stay non-persistent.
 	 */
-	static isolated(overrides: Partial<Record<SettingPath, unknown>> = {}): Settings {
+	static isolated(
+		overrides: Partial<Record<SettingPath, unknown>> = {},
+		options: { storage?: AgentStorage | null } = {},
+	): Settings {
 		const instance = new Settings({ inMemory: true, overrides });
+		instance.#storage = options.storage ?? null;
 		instance.#rebuildMerged();
 		return instance;
 	}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -876,20 +876,23 @@ export function createSubagentSettings(
 	snapshot["tier.openai"] = subagentTiers.openai ?? "none";
 	snapshot["tier.anthropic"] = subagentTiers.anthropic ?? "none";
 	snapshot["tier.google"] = subagentTiers.google ?? "none";
-	return Settings.isolated({
-		...snapshot,
-		// Async jobs and bash auto-backgrounding are inherited from the parent:
-		// background jobs are owner-routed to the subagent's own session, and
-		// the run driver's quiescence barrier + teardown reap guarantee no
-		// owner job outlives the run, so worktree capture/cleanup stays
-		// race-free (previously both were force-disabled here).
+	return Settings.isolated(
+		{
+			...snapshot,
+			// Async jobs and bash auto-backgrounding are inherited from the parent:
+			// background jobs are owner-routed to the subagent's own session, and
+			// the run driver's quiescence barrier + teardown reap guarantee no
+			// owner job outlives the run, so worktree capture/cleanup stays
+			// race-free (previously both were force-disabled here).
 
-		// Subagents run headless — there is no UI to confirm prompts against, so
-		// the parent task approval is the authorization boundary. Use yolo mode
-		// to preserve unattended subagent execution. User `tools.approval` policies still apply.
-		"tools.approvalMode": "yolo",
-		...overrides,
-	});
+			// Subagents run headless — there is no UI to confirm prompts against, so
+			// the parent task approval is the authorization boundary. Use yolo mode
+			// to preserve unattended subagent execution. User `tools.approval` policies still apply.
+			"tools.approvalMode": "yolo",
+			...overrides,
+		},
+		{ storage: baseSettings.getStorage() },
+	);
 }
 
 export type AbortReason = "signal" | "terminate" | "timeout" | "budget";

--- a/packages/coding-agent/test/agent-storage-model-perf.test.ts
+++ b/packages/coding-agent/test/agent-storage-model-perf.test.ts
@@ -1,7 +1,9 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import { createSubagentSettings } from "@oh-my-pi/pi-coding-agent/task/executor";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("AgentStorage model perf aggregates", () => {
@@ -36,6 +38,23 @@ describe("AgentStorage model perf aggregates", () => {
 		expect(stats?.samples).toBe(2);
 		expect(stats?.tps).toBeCloseTo(1500000 / 9000, 5);
 		expect(stats?.ttftMs).toBeCloseTo(750, 5);
+	});
+
+	it("records task subagent samples in the shared model performance aggregate", async () => {
+		tempDir = TempDir.createSync("@omp-subagent-perf-");
+		const parent = await Settings.loadIsolated({ cwd: tempDir.path(), agentDir: tempDir.path() });
+		const subagent = createSubagentSettings(parent);
+
+		await subagent.getStorage()?.recordModelPerf("opencode-go/deepseek-v4-flash", {
+			outputTokens: 130,
+			durationMs: 2989.23775,
+			ttftMs: 2324.873,
+		});
+
+		const stats = parent.getStorage()?.getModelPerf().get("opencode-go/deepseek-v4-flash");
+		expect(stats?.samples).toBe(1);
+		expect(stats?.tps).toBeCloseTo(130000 / 2989.23775, 5);
+		expect(stats?.ttftMs).toBeCloseTo(2324.873, 5);
 	});
 
 	it("keeps TTFT null when no sample reported one and uses full duration for TPS", async () => {


### PR DESCRIPTION
## Repro

A persisted parent `Settings` instance followed by `createSubagentSettings(parent)` reproduced the omission: recording the issue's `130`-token, `2989.23775`-ms sample through the child path printed `{"parentHasStorage":true,"childHasStorage":false,"recorded":false}`. The executable regression scenario is `bun test packages/coding-agent/test/agent-storage-model-perf.test.ts`; without the fix, its task-subagent aggregate assertion receives no row.

## Cause

`createSubagentSettings` in `packages/coding-agent/src/task/executor.ts` copied effective values into `Settings.isolated`, while `Settings.isolated` in `packages/coding-agent/src/config/settings.ts` always left `#storage` null. `AgentSession` records completed-turn timing through `settings.getStorage()?.recordModelPerf(...)`, so every task-subagent call became a silent no-op before `/models` read the aggregate.

## Fix

- Allow isolated settings to retain an explicitly supplied shared `AgentStorage` handle without enabling settings persistence.
- Forward the parent storage when constructing task-subagent settings.
- Cover the task sample path with a real aggregate assertion and document the fix in the coding-agent changelog.

## Verification

`bun test packages/coding-agent/test/agent-storage-model-perf.test.ts` passes 9 tests with 0 failures. A post-fix one-off smoke records one sample with `tps: 43.489347744253536` and `ttftMs: 2324.873` through child settings; the pre-publish `bun check` gate also passed.

Fixes #8022