### PR TITLE
fix(extensibility): restore api.arktype as full omptype module namespace

### DIFF
--- a/packages/coding-agent/src/extensibility/custom-commands/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/loader.ts
@@ -6,7 +6,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { type } from "@oh-my-pi/omptype";
+import * as arktype from "@oh-my-pi/omptype";
 import * as zod from "@oh-my-pi/omptype/zod";
 import { getAgentDir, getProjectDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import { getConfigDirs } from "../../config";
@@ -187,7 +187,7 @@ export async function loadCustomCommands(options: LoadCustomCommandsOptions = {}
 		exec: (command: string, args: string[], execOptions) =>
 			execCommand(command, args, execOptions?.cwd ?? cwd, execOptions),
 		typebox,
-		arktype: type,
+		arktype,
 		zod,
 		pi: PiCodingAgent,
 	};

--- a/packages/coding-agent/src/extensibility/custom-commands/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/types.ts
@@ -5,7 +5,7 @@
  * Unlike markdown commands which expand to prompts, custom commands can execute
  * arbitrary logic with full access to the hook context.
  */
-import type { type as ArkType } from "@oh-my-pi/omptype";
+import type * as ArkTypeNamespace from "@oh-my-pi/omptype";
 import type * as TypeBox from "@oh-my-pi/omptype/typebox";
 import type * as zod from "@oh-my-pi/omptype/zod";
 import type { ExecOptions, ExecResult, HookCommandContext } from "../../extensibility/hooks/types";
@@ -25,8 +25,8 @@ export interface CustomCommandAPI {
 	exec(command: string, args: string[], options?: ExecOptions): Promise<ExecResult>;
 	/** Injected TypeBox shim (legacy/compat). */
 	typebox: typeof TypeBox;
-	/** Injected omptype schema builder for custom commands. */
-	arktype: typeof ArkType;
+	/** Injected omptype module namespace (provides .type() builder and utilities). */
+	arktype: typeof ArkTypeNamespace;
 	/** Injected Zod-compatible omptype builder for custom commands. */
 	zod: typeof zod;
 	/** Injected pi-coding-agent exports */

--- a/packages/coding-agent/src/extensibility/custom-tools/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/loader.ts
@@ -5,7 +5,7 @@
  * directories do not depend on workspace module resolution.
  */
 import * as path from "node:path";
-import { type } from "@oh-my-pi/omptype";
+import * as arktype from "@oh-my-pi/omptype";
 import * as zod from "@oh-my-pi/omptype/zod";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { logger } from "@oh-my-pi/pi-utils";
@@ -148,7 +148,7 @@ export class CustomToolLoader {
 			hasUI: false,
 			logger,
 			typebox,
-			arktype: type,
+			arktype,
 			zod,
 			pi,
 			pushPendingAction: action => {

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -5,7 +5,7 @@
  * They can provide custom rendering for tool calls and results in the TUI.
  */
 
-import type { type as ArkType } from "@oh-my-pi/omptype";
+import type * as ArkTypeNamespace from "@oh-my-pi/omptype";
 import type * as TypeBox from "@oh-my-pi/omptype/typebox";
 import type * as zod from "@oh-my-pi/omptype/zod";
 import type {
@@ -68,8 +68,8 @@ export interface CustomToolAPI {
 	logger: typeof PiLogger;
 	/** Injected typebox shim (legacy/compat — arktype-authored tools are preferred). */
 	typebox: typeof TypeBox;
-	/** Injected arktype module for arktype-authored custom tools. */
-	arktype: typeof ArkType;
+	/** Injected omptype module namespace (provides .type() builder and utilities). */
+	arktype: typeof ArkTypeNamespace;
 	/** Injected Zod-compatible omptype builder for custom tools. */
 	zod: typeof zod;
 	/** Injected pi-coding-agent exports */

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -4,7 +4,7 @@
 import type * as fs1 from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { type } from "@oh-my-pi/omptype";
+import * as arktype from "@oh-my-pi/omptype";
 import * as zod from "@oh-my-pi/omptype/zod";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type {
@@ -142,7 +142,7 @@ export class ExtensionRuntime implements IExtensionRuntime {
 class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	readonly logger = logger;
 	readonly typebox = TypeBox;
-	readonly arktype = type;
+	readonly arktype = arktype;
 	readonly zod = zod;
 	readonly flagValues = new Map<string, boolean | string>();
 	readonly pendingProviderRegistrations: Array<{

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -8,7 +8,7 @@
  * - Interact with the user via UI primitives
  */
 
-import type { type as ArkType } from "@oh-my-pi/omptype";
+import type * as ArkTypeNamespace from "@oh-my-pi/omptype";
 import type * as TypeBox from "@oh-my-pi/omptype/typebox";
 import type * as zod from "@oh-my-pi/omptype/zod";
 import type {
@@ -1142,8 +1142,8 @@ export interface ExtensionAPI {
 	/** Injected TypeBox shim for legacy `Type.Object(...)` parameter authoring. */
 	typebox: typeof TypeBox;
 
-	/** Injected omptype schema builder for extension tools. */
-	arktype: typeof ArkType;
+	/** Injected omptype module namespace (provides .type() builder and utilities). */
+	arktype: typeof ArkTypeNamespace;
 
 	/** Injected Zod-compatible omptype builder for extension tools. */
 	zod: typeof zod;

--- a/packages/coding-agent/src/extensibility/hooks/loader.ts
+++ b/packages/coding-agent/src/extensibility/hooks/loader.ts
@@ -2,7 +2,7 @@
  * Hook loader - loads TypeScript hook modules using native Bun import.
  */
 import * as path from "node:path";
-import { type } from "@oh-my-pi/omptype";
+import * as arktype from "@oh-my-pi/omptype";
 import * as zod from "@oh-my-pi/omptype/zod";
 import { logger } from "@oh-my-pi/pi-utils";
 import { hookCapability } from "../../capability/hook";
@@ -122,7 +122,7 @@ async function createHookAPI(
 		},
 		logger,
 		typebox,
-		arktype: type,
+		arktype,
 		zod,
 		pi: PiCodingAgent,
 	} as HookAPI;

--- a/packages/coding-agent/src/extensibility/hooks/types.ts
+++ b/packages/coding-agent/src/extensibility/hooks/types.ts
@@ -1,4 +1,4 @@
-import type { type as ArkType } from "@oh-my-pi/omptype";
+import type * as ArkTypeNamespace from "@oh-my-pi/omptype";
 import type * as TypeBox from "@oh-my-pi/omptype/typebox";
 import type * as zod from "@oh-my-pi/omptype/zod";
 import type { ImageContent, Message, Model, TextContent } from "@oh-my-pi/pi-ai";
@@ -584,8 +584,8 @@ export interface HookAPI {
 	logger: typeof PiLogger;
 	/** Injected TypeBox shim (legacy/compat — prefer `arktype`). */
 	typebox: typeof TypeBox;
-	/** Injected omptype schema builder for hooks. */
-	arktype: typeof ArkType;
+	/** Injected omptype module namespace (provides .type() builder and utilities). */
+	arktype: typeof ArkTypeNamespace;
 	/** Injected Zod-compatible omptype builder for hooks. */
 	zod: typeof zod;
 	/** Injected pi-coding-agent exports */


### PR DESCRIPTION
## Summary

Commit `e9888367d161` changed the `arktype` injection from the full `@oh-my-pi/omptype` module namespace (`import * as arktype`) to just the `type` builder function (`import { type }`). This broke `api.arktype.type(...)` calls at runtime (`api.arktype.type is not a function`) in all four extensibility surfaces.

This PR restores the module-namespace injection so existing third-party custom commands, custom tools, extensions, and hooks continue to work without migration.

Fixes #7968

## Changes

All four extensibility surfaces, each with import + type declaration + injection changes:

- `packages/coding-agent/src/extensibility/custom-commands/loader.ts`
- `packages/coding-agent/src/extensibility/custom-commands/types.ts`
- `packages/coding-agent/src/extensibility/custom-tools/loader.ts`
- `packages/coding-agent/src/extensibility/custom-tools/types.ts`
- `packages/coding-agent/src/extensibility/extensions/loader.ts`
- `packages/coding-agent/src/extensibility/extensions/types.ts`
- `packages/coding-agent/src/extensibility/hooks/loader.ts`
- `packages/coding-agent/src/extensibility/hooks/types.ts`

8 files changed, 20 insertions(+), 20 deletions(-)