### PR TITLE
fix(tui): emit OSC 133;C to release the sticky prompt-input cursor

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed user-message OSC 133 prompt zones never emitting the `;C` (command-output start) marker, which left Ghostty-family terminals with a sticky `.input` cursor semantic so their default `cursor-click-to-move` injected arrow-key bursts into the editor on every left-click (caret jumping to column 0) ([#8030](https://github.com/can1357/oh-my-pi/issues/8030)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -4,12 +4,17 @@ import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { imageReferenceHyperlink, renderPlaceholders } from "../image-references";
 import { highlightMagicKeywords } from "../magic-keywords";
 
-// OSC 133 shell integration: marks prompt zones for terminal multiplexers
-// Do not emit OSC 133 C ("command start") here: the transcript has no matching
-// command-finished marker, so terminals can group later assistant/tool output
-// under the first submitted prompt.
+// OSC 133 shell integration: marks prompt zones for terminal multiplexers.
+// Per the FinalTerm/OSC 133 spec the markers are A=prompt-start,
+// B=command-input-start, C=command-output-start, D=command-finished. We wrap
+// each user bubble in A…B and MUST close it with C: C is the "output starts
+// here" marker terminals group the following assistant/tool output under, and
+// — critically — it clears the sticky `.input` cursor semantic that B sets in
+// Ghostty-family terminals. Omitting C leaves the cursor permanently "inside
+// prompt input", so Ghostty's default cursor-click-to-move injects arrow-key
+// bursts into the pty on every left-click (#8030).
 const OSC133_ZONE_START = "\x1b]133;A\x07";
-const OSC133_ZONE_END = "\x1b]133;B\x07";
+const OSC133_ZONE_END = "\x1b]133;B\x07\x1b]133;C\x07";
 
 /**
  * Component that renders a user message

--- a/packages/coding-agent/test/modes/components/user-message-keywords.test.ts
+++ b/packages/coding-agent/test/modes/components/user-message-keywords.test.ts
@@ -49,11 +49,14 @@ describe("UserMessageComponent magic-keyword highlighting", () => {
 		expect(raw).toContain("orchestrate");
 	});
 
-	it("closes OSC 133 prompt zones without opening a command-output zone", () => {
+	it("closes the OSC 133 prompt zone with a command-output start so the cursor leaves .input", () => {
 		const raw = render("first line\nsecond line");
 		expect(raw).toContain("\x1b]133;A\x07");
 		expect(raw).toContain("\x1b]133;B\x07");
-		expect(raw).not.toContain("\x1b]133;C\x07");
+		// ;C (output-start) MUST follow ;B: it clears the sticky `.input` cursor
+		// semantic in Ghostty-family terminals (#8030). Missing ;C leaves click-to-move
+		// injecting arrow keys into the editor on every left-click.
+		expect(raw).toContain("\x1b]133;B\x07\x1b]133;C\x07");
 	});
 
 	it("bolds and underlines image references in the rendered message bubble", () => {


### PR DESCRIPTION
## Repro
Start omp in Ghostty (or cmux/libghostty) with the default `cursor-click-to-move = true` and zsh shell integration, send one message so a `UserMessageComponent` renders, type into the input and move the caret into the middle, then left-click anywhere in the transcript — the caret snaps to column 0. Locally the root cause reproduces without a terminal: instantiating `UserMessageComponent("hello world")` and rendering shows the emitted zone bytes are `\e]133;A\a … \e]133;B\a` with **no** `\e]133;C\a` (`has 133;C : false`).

## Cause
`packages/coding-agent/src/modes/components/user-message.ts` wrapped every user bubble in `OSC133_ZONE_START = "\x1b]133;A\x07"` … `OSC133_ZONE_END = "\x1b]133;B\x07"` and deliberately never emitted `;C` (see `render()`, lines 63-64). Per the FinalTerm/OSC 133 spec the markers are A=prompt-start, B=command-input-start, C=command-output-start, D=command-finished. `;B` sets a sticky `.input` cursor semantic in Ghostty-family terminals that only `;C` clears, so omitting it left `cursorIsAtPrompt()` permanently true. Ghostty's default `cursor-click-to-move` then translated left-clicks into arrow-key bursts (`\x1b[D`/`\x1b[C`) counted over the `.input` cells, which omp's editor obeys — slamming the caret to column 0. The prior code comment's grouping rationale was inverted: `;C` *is* the output-start marker terminals group following output under.

## Fix
- `user-message.ts`: terminate the zone with `\x1b]133;B\x07\x1b]133;C\x07` so `;C` immediately follows `;B`, clearing the sticky `.input` state and marking where assistant/tool output starts.
- Rewrote the inverted OSC 133 comment to state the correct A/B/C/D semantics and why `;C` is required.
- Updated the existing regression test (which asserted the buggy "no `;C`" behavior) to assert the zone closes with `;B;C`.
- Added a CHANGELOG entry under `[Unreleased]`.

## Verification
`cd packages/coding-agent && bun test test/modes/components/user-message-keywords.test.ts` → 10 pass / 0 fail (28 expect calls). The pre-fix render probe showed `has 133;C : false`; post-fix the render output contains `\x1b]133;B\x07\x1b]133;C\x07`. Fixes #8030