### PR TITLE
fix(prompts): resolve system prompt contradictions for grep tool and clean cutover

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -120,7 +120,7 @@ You MUST use the specialized tool over its shell equivalent:
 {{#has tools "edit"}}- Surgical edits → `{{toolRefs.edit}}`.{{/has}}
 {{#has tools "write"}}- Create or overwrite → `{{toolRefs.write}}`.{{/has}}
 {{#has tools "lsp"}}- When a language server is available, MUST use `{{toolRefs.lsp}}` for definition, type_definition, implementation, references, and hover; for refactors, imports, and fixes, list code actions then apply one. NEVER use search or manual edits for code intelligence.{{/has}}
-{{#has tools "grep"}}- Regex search or locating targets → `{{toolRefs.grep}}`, not `grep`, `rg`, or `awk`.{{/has}}
+{{#has tools "grep"}}- Regex search or locating targets → `{{toolRefs.grep}}`, not shell `grep`, `rg`, or `awk`.{{/has}}
 {{#has tools "glob"}}- Mapping structure or globbing → `{{toolRefs.glob}}`, not `ls **/*.ext` or `fd`.{{/has}}
 {{#has tools "bash"}}- `{{toolRefs.bash}}`: real binaries and short fact pipelines only. Commands shadowing the specialized tools above are blocked.{{/has}}
 {{#has tools "bash"}}- Litmus: one external-CLI call or short pipeline returning a count, frequency, set difference, or checksum → bash. Merely moves, pages, or trims bytes a tool can fetch → use the tool.{{/has}}
@@ -198,7 +198,7 @@ EXECUTION WORKFLOW
 - Clean cutover: migrate every caller; remove obsolete code, comments, aliases, re-exports, and deprecated paths.
 - Prefer updating existing files over creating new ones.
 - Review changes from the user's perspective.
-{{#has tools "ask"}}- Ask before destructive commands or deleting code you didn't write.{{else}}- NEVER run destructive git commands or delete code you didn't write.{{/has}}
+{{#has tools "ask"}}- Ask before destructive commands or deleting unrelated code you didn't write.{{else}}- NEVER run destructive git commands or delete unrelated code you didn't write.{{/has}}
 
 # 5. Verify
 - NEVER yield non-trivial work without proof that the deliverable works. The proof method depends on the ask:


### PR DESCRIPTION
## Summary of Fixes

This PR addresses two S0/high-severity logical contradictions in `packages/coding-agent/src/prompts/system/system-prompt.md`:

### 1. Fix 'grep, not grep' Contradiction (Line 123)
- **Problem**: When `{{toolRefs.grep}}` resolves to `"grep"`, the system prompt renders as: `Regex search or locating targets → grep, not grep, rg, or awk.`, creating a direct contradiction.
- **Fix**: Clarify that the restriction applies to shell `grep` when the specialized `{{toolRefs.grep}}` tool is active.
- **Closes**: #8035

### 2. Fix 'Clean Cutover' vs 'Never Delete Code' Contradiction (Line 201)
- **Problem**: Line 198 & 229 demand a **Clean cutover** (removing obsolete code, aliases, shims), while line 201 strictly forbids deleting code not written by the agent (`NEVER ... delete code you didn't write`). In existing codebases, replaced legacy code was written by prior authors, trapping agents in an impossible dilemma.
- **Fix**: Clarify that the safety guardrail forbids deleting **unrelated** code you didn't write, permitting the removal of obsolete legacy code replaced as part of an authorized clean cutover.
- **Closes**: #8036