### PR TITLE
feat(coding-agent): add /schedule slash command for one-shot, recurring, and cron-based prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `/schedule` slash command for one-shot, recurring, and cron-based prompt scheduling. Supports `/schedule in 30m <instruction>` (one-shot), `/schedule every 10m <instruction>` (recurring), and `/schedule cron "0 9 * * 1-5" <instruction>` (cron). Multiple schedules can be active simultaneously with list, cancel, and clear subcommands.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -350,6 +350,7 @@ export class StatusLineComponent implements Component {
 	#loopModeStatus: SegmentContext["loopMode"] = null;
 	#goalModeStatus: { enabled: boolean; paused: boolean } | null = null;
 	#vibeModeStatus: { enabled: boolean } | null = null;
+	#scheduleStatus: SegmentContext["schedule"] = null;
 	/**
 	 * Injected aggregator that returns the aggregate tok/s of this session's
 	 * live vibe worker sessions, or null when no workers are streaming. Kept as
@@ -609,6 +610,10 @@ export class StatusLineComponent implements Component {
 
 	setVibeModeStatus(status: { enabled: boolean } | undefined): void {
 		this.#vibeModeStatus = status ?? null;
+	}
+
+	setScheduleStatus(status: SegmentContext["schedule"] | undefined): void {
+		this.#scheduleStatus = status ?? null;
 	}
 
 	/**
@@ -1570,6 +1575,7 @@ export class StatusLineComponent implements Component {
 			goalMode: this.#goalModeStatus,
 			vibeMode: this.#vibeModeStatus,
 			collab: this.#collabStatus,
+			schedule: this.#scheduleStatus,
 			usageStats,
 			contextPercent,
 			contextTokens,

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -225,47 +225,62 @@ function formatLoopLimit(limit: NonNullable<SegmentContext["loopMode"]>["limit"]
 	return `${seconds}s left`;
 }
 
+function renderPrimaryModeSegment(ctx: SegmentContext): RenderedSegment {
+	const pauseSuffix = theme.icon.pause ? ` ${theme.icon.pause}` : " (paused)";
+
+	const plan = ctx.planMode;
+	if (plan && (plan.enabled || plan.paused)) {
+		const label = plan.paused ? `Plan${pauseSuffix}` : "Plan";
+		const content = withIcon(theme.icon.plan, label);
+		const color = plan.paused ? "warning" : "accent";
+		return { content: theme.fg(color, content), visible: true };
+	}
+
+	const prewalk = ctx.prewalk;
+	if (prewalk?.enabled) {
+		const content = withIcon(theme.icon.prewalk, "Prewalk");
+		return { content: theme.fg("accent", content), visible: true };
+	}
+
+	const goal = ctx.goalMode;
+	if (goal && (goal.enabled || goal.paused)) {
+		return renderGoalMode(ctx, goal);
+	}
+
+	const vibe = ctx.vibeMode;
+	if (vibe?.enabled) {
+		const content = withIcon(theme.icon.agents, "Vibe");
+		return { content: theme.fg("accent", content), visible: true };
+	}
+
+	const loop = ctx.loopMode;
+	if (loop) {
+		const icon = loop.state === "paused" ? theme.icon.pause || theme.icon.loop : theme.icon.loop;
+		const color: ThemeColor = loop.state === "paused" ? "warning" : "customMessageLabel";
+		const parts = [withIcon(icon, `Loop ${loop.state}`)];
+		const limit = formatLoopLimit(loop.limit);
+		if (limit) parts.push(limit);
+		return { content: theme.fg(color, parts.join(" ")), visible: true };
+	}
+
+	return { content: "", visible: false };
+}
+
 const modeSegment: StatusLineSegment = {
 	id: "mode",
 	render(ctx) {
-		const pauseSuffix = theme.icon.pause ? ` ${theme.icon.pause}` : " (paused)";
+		const primary = renderPrimaryModeSegment(ctx);
 
-		const plan = ctx.planMode;
-		if (plan && (plan.enabled || plan.paused)) {
-			const label = plan.paused ? `Plan${pauseSuffix}` : "Plan";
-			const content = withIcon(theme.icon.plan, label);
-			const color = plan.paused ? "warning" : "accent";
-			return { content: theme.fg(color, content), visible: true };
+		const schedule = ctx.schedule;
+		if (schedule && schedule.count > 0) {
+			const schedContent = theme.fg("customMessageLabel", `⏰${schedule.count}`);
+			if (primary.visible) {
+				return { content: `${primary.content} ${schedContent}`, visible: true };
+			}
+			return { content: schedContent, visible: true };
 		}
 
-		const prewalk = ctx.prewalk;
-		if (prewalk?.enabled) {
-			const content = withIcon(theme.icon.prewalk, "Prewalk");
-			return { content: theme.fg("accent", content), visible: true };
-		}
-
-		const goal = ctx.goalMode;
-		if (goal && (goal.enabled || goal.paused)) {
-			return renderGoalMode(ctx, goal);
-		}
-
-		const vibe = ctx.vibeMode;
-		if (vibe?.enabled) {
-			const content = withIcon(theme.icon.agents, "Vibe");
-			return { content: theme.fg("accent", content), visible: true };
-		}
-
-		const loop = ctx.loopMode;
-		if (loop) {
-			const icon = loop.state === "paused" ? theme.icon.pause || theme.icon.loop : theme.icon.loop;
-			const color: ThemeColor = loop.state === "paused" ? "warning" : "customMessageLabel";
-			const parts = [withIcon(icon, `Loop ${loop.state}`)];
-			const limit = formatLoopLimit(loop.limit);
-			if (limit) parts.push(limit);
-			return { content: theme.fg(color, parts.join(" ")), visible: true };
-		}
-
-		return { content: "", visible: false };
+		return primary;
 	},
 };
 

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -78,6 +78,9 @@ export interface SegmentContext {
 		enabled: boolean;
 	} | null;
 	collab: CollabStatus | null;
+	schedule: {
+		count: number;
+	} | null;
 	// Cached values for performance (computed once per render)
 	usageStats: {
 		input: number;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -189,6 +189,14 @@ import {
 import { OAuthManualInputManager } from "./oauth-manual-input";
 import { countRunningSubagentBadgeAgents, getRunningSubagentBadgeRegistry } from "./running-subagent-badge";
 import {
+	computeNextCronFire,
+	describeSchedule,
+	formatScheduleList,
+	nextScheduleId,
+	parseScheduleCommand,
+	type ScheduledItem,
+} from "./schedule";
+import {
 	type ObservableSession,
 	type SessionObserverChangeKind,
 	SessionObserverRegistry,
@@ -477,6 +485,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	#modelCycleClearTimer: NodeJS.Timeout | undefined;
 	#nextAppearanceRequestToken = 1;
 	#appearanceRefreshRequest: { token: TerminalAppearanceRequestToken; deadline: number } | undefined;
+	scheduledItems: ScheduledItem[] = [];
+	#scheduleTimers = new Map<string, NodeJS.Timeout>();
 	todoPhases: TodoPhase[] = [];
 	hideThinkingBlock = false;
 	#sessionsWithDisplayableThinkingContent = new WeakSet<AgentSession>();
@@ -1532,6 +1542,156 @@ export class InteractiveMode implements InteractiveModeContext {
 		// auto-resubmits it after each yield, identical to typing the prompt right
 		// after enabling loop mode.
 		return parsed.prompt;
+	}
+
+	async handleScheduleCommand(args: string): Promise<void> {
+		const parsed = parseScheduleCommand(args);
+		if (typeof parsed === "string") {
+			this.showError(parsed);
+			return;
+		}
+
+		switch (parsed.type) {
+			case "list":
+				this.showStatus(formatScheduleList(this.scheduledItems));
+				return;
+
+			case "clear":
+				this.#clearAllSchedules();
+				this.showStatus("All schedules cleared.");
+				return;
+
+			case "cancel": {
+				const cancelled = this.#cancelSchedule(parsed.id);
+				this.showStatus(cancelled ? `Schedule ${parsed.id} cancelled.` : `Schedule ${parsed.id} not found.`);
+				return;
+			}
+
+			case "add": {
+				const id = nextScheduleId();
+				const now = Date.now();
+				let nextFireAt: number;
+				if (parsed.kind === "cron") {
+					const cronNext = computeNextCronFire(parsed.cronFields!, new Date(now));
+					if (cronNext === undefined) {
+						this.showError("Cron expression has no valid fire time within the next 4 years.");
+						return;
+					}
+					nextFireAt = cronNext;
+				} else {
+					nextFireAt = now + parsed.intervalMs!;
+				}
+				const item: ScheduledItem = {
+					id,
+					kind: parsed.kind,
+					intervalMs: parsed.intervalMs,
+					cronFields: parsed.cronFields,
+					nextFireAt,
+					instruction: parsed.instruction,
+					active: true,
+				};
+				this.scheduledItems.push(item);
+				this.#armScheduleTimer(item);
+				this.#syncScheduleStatus();
+				this.showStatus(`Schedule ${id} added: ${describeSchedule(item)}`);
+				return;
+			}
+		}
+	}
+
+	/** Maximum safe setTimeout delay (2^31 - 1 ms ≈ 24.8 days). */
+	static readonly #MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+	#armScheduleTimer(item: ScheduledItem): void {
+		const delay = Math.max(0, item.nextFireAt - Date.now());
+		// Chunk long delays to avoid 32-bit timer overflow.
+		const safeDelay = Math.min(delay, InteractiveMode.#MAX_TIMER_DELAY_MS);
+		const timer = setTimeout(() => {
+			if (Date.now() < item.nextFireAt) {
+				// Not yet time — re-arm for the remaining delay
+				this.#armScheduleTimer(item);
+				return;
+			}
+			this.#fireSchedule(item.id);
+		}, safeDelay);
+		timer.unref?.();
+		this.#scheduleTimers.set(item.id, timer);
+	}
+
+	#fireSchedule(id: string): void {
+		this.#scheduleTimers.delete(id);
+		const item = this.scheduledItems.find(s => s.id === id);
+		if (!item?.active) return;
+
+		// Try to inject the prompt — skip if busy
+		const canInject =
+			!this.#isAutoSubmitBlocked() &&
+			!this.#pendingSubmittedInput &&
+			this.onInputCallback &&
+			this.editor.getText().trim().length === 0 &&
+			(this.editor.pendingImages?.length ?? 0) === 0;
+
+		const callback = this.onInputCallback;
+		if (canInject && callback) {
+			callback(
+				this.startPendingSubmission({
+					text: item.instruction,
+					customType: "schedule",
+					display: false,
+				}),
+			);
+		}
+
+		if (item.kind === "once") {
+			if (canInject) {
+				// Delivered — remove from active items
+				this.scheduledItems = this.scheduledItems.filter(s => s.id !== id);
+				this.#syncScheduleStatus();
+			} else {
+				// Busy — retry in 30 seconds
+				item.nextFireAt = Date.now() + 30_000;
+				this.#armScheduleTimer(item);
+			}
+		} else if (item.kind === "interval") {
+			item.nextFireAt = Date.now() + item.intervalMs!;
+			this.#armScheduleTimer(item);
+		} else if (item.kind === "cron" && item.cronFields) {
+			const next = computeNextCronFire(item.cronFields, new Date());
+			if (next !== undefined) {
+				item.nextFireAt = next;
+				this.#armScheduleTimer(item);
+			} else {
+				this.scheduledItems = this.scheduledItems.filter(s => s.id !== id);
+				this.#syncScheduleStatus();
+			}
+		}
+	}
+
+	#cancelSchedule(id: string): boolean {
+		const item = this.scheduledItems.find(s => s.id === id);
+		if (!item) return false;
+		item.active = false;
+		const timer = this.#scheduleTimers.get(id);
+		if (timer) {
+			clearTimeout(timer);
+			this.#scheduleTimers.delete(id);
+		}
+		this.scheduledItems = this.scheduledItems.filter(s => s.id !== id);
+		this.#syncScheduleStatus();
+		return true;
+	}
+
+	#clearAllSchedules(): void {
+		for (const timer of this.#scheduleTimers.values()) clearTimeout(timer);
+		this.#scheduleTimers.clear();
+		this.scheduledItems = [];
+		this.#syncScheduleStatus();
+	}
+
+	#syncScheduleStatus(): void {
+		const activeCount = this.scheduledItems.filter(s => s.active).length;
+		this.statusLine.setScheduleStatus(activeCount > 0 ? { count: activeCount } : undefined);
+		this.ui.requestRender();
 	}
 
 	recordLocalSubmission(text: string, imageCount = 0): () => void {
@@ -3978,6 +4138,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#cancelTodoAutoClearTimer();
 		this.#cancelObserverUiSyncTimer();
 		this.#cancelGoalContinuation();
+		this.#clearAllSchedules();
 		if (this.#sttController) {
 			this.#sttController.dispose();
 			this.#sttController = undefined;

--- a/packages/coding-agent/src/modes/schedule.ts
+++ b/packages/coding-agent/src/modes/schedule.ts
@@ -1,0 +1,394 @@
+/**
+ * Scheduled prompts: one-shot, recurring, and cron-based prompt injection.
+ *
+ * Complements the heartbeat feature (single recurring timer) with:
+ * - One-shot: `/schedule in 30m Check the build` — fires once after a delay
+ * - Recurring: `/schedule every 10m Check the build` — fires repeatedly
+ * - Cron: `/schedule cron "0 9 * * 1-5" Review open work` — fires at wall-clock times
+ *
+ * Multiple schedules can be active simultaneously, each with a unique ID.
+ */
+
+const TIME_UNITS_MS: Record<string, number> = {
+	s: 1_000,
+	sec: 1_000,
+	secs: 1_000,
+	second: 1_000,
+	seconds: 1_000,
+	m: 60_000,
+	min: 60_000,
+	mins: 60_000,
+	minute: 60_000,
+	minutes: 60_000,
+	h: 3_600_000,
+	hr: 3_600_000,
+	hrs: 3_600_000,
+	hour: 3_600_000,
+	hours: 3_600_000,
+	d: 86_400_000,
+	day: 86_400_000,
+	days: 86_400_000,
+};
+
+export type ScheduleKind = "once" | "interval" | "cron";
+
+export interface ScheduledItem {
+	id: string;
+	kind: ScheduleKind;
+	/** Delay in ms for "once", interval in ms for "interval", undefined for "cron". */
+	intervalMs?: number;
+	/** Cron fields for "cron" kind. */
+	cronFields?: CronFields;
+	/** Next fire timestamp (ms epoch). */
+	nextFireAt: number;
+	/** Instruction injected when the schedule fires. */
+	instruction: string;
+	/** Whether this schedule is still active. */
+	active: boolean;
+}
+
+export type ParsedScheduleCommand =
+	| { type: "list" }
+	| { type: "cancel"; id: string }
+	| { type: "clear" }
+	| { type: "add"; kind: ScheduleKind; intervalMs?: number; cronFields?: CronFields; instruction: string };
+
+const SCHEDULE_USAGE =
+	"Usage:\n" +
+	"  /schedule in <DELAY> <instruction>     — one-shot\n" +
+	"  /schedule every <INTERVAL> <instruction> — recurring\n" +
+	'  /schedule cron "<EXPR>" <instruction>    — cron-based\n' +
+	"  /schedule list\n" +
+	"  /schedule cancel <id>\n" +
+	"  /schedule clear\n" +
+	"Examples:\n" +
+	"  /schedule in 30m Check the build status\n" +
+	"  /schedule every 10m Check the deployment\n" +
+	'  /schedule cron "0 9 * * 1-5" Review open PRs';
+
+let scheduleIdCounter = 0;
+
+export function nextScheduleId(): string {
+	scheduleIdCounter++;
+	return `s${scheduleIdCounter.toString(36)}`;
+}
+
+export function parseScheduleCommand(args: string): ParsedScheduleCommand | string {
+	const trimmed = args.trim();
+	if (!trimmed) return SCHEDULE_USAGE;
+
+	const firstSpace = trimmed.search(/\s/);
+	const firstToken = firstSpace === -1 ? trimmed : trimmed.slice(0, firstSpace);
+	const rest = firstSpace === -1 ? "" : trimmed.slice(firstSpace + 1).trim();
+	const lower = firstToken.toLowerCase();
+
+	// Subcommands
+	if (lower === "list" || lower === "ls") return { type: "list" };
+	if (lower === "clear" || lower === "off" || lower === "stop") return { type: "clear" };
+	if (lower === "cancel" || lower === "rm") {
+		if (!rest) return "Usage: /schedule cancel <id>";
+		return { type: "cancel", id: rest.split(/\s/)[0] };
+	}
+
+	// One-shot: "in 30m <instruction>" or "in 2 hours <instruction>"
+	if (lower === "in") {
+		const parsed = splitDelayAndInstruction(rest);
+		if (!parsed) return "Schedule requires an instruction. Example: /schedule in 30m Check the build";
+		if (typeof parsed.delayMs === "string") return parsed.delayMs;
+		return { type: "add", kind: "once", intervalMs: parsed.delayMs, instruction: parsed.instruction };
+	}
+
+	// Recurring: "every 10m <instruction>" or "every 2 hours <instruction>"
+	if (lower === "every") {
+		const parsed = splitDelayAndInstruction(rest);
+		if (!parsed) return "Schedule requires an instruction. Example: /schedule every 10m Check the build";
+		if (typeof parsed.delayMs === "string") return parsed.delayMs;
+		return { type: "add", kind: "interval", intervalMs: parsed.delayMs, instruction: parsed.instruction };
+	}
+
+	// Cron: "cron \"0 9 * * 1-5\" <instruction>"
+	if (lower === "cron") {
+		const cronMatch = /^"([^"]+)"\s+(.+)$/.exec(rest) || /^'([^']+)'\s+(.+)$/.exec(rest);
+		if (!cronMatch) {
+			return 'Cron schedule requires a quoted expression. Example: /schedule cron "0 9 * * 1-5" Review open PRs';
+		}
+		const cronFields = parseCronExpression(cronMatch[1]);
+		if (typeof cronFields === "string") return cronFields;
+		const instruction = cronMatch[2].trim();
+		if (!instruction) return "Schedule requires an instruction.";
+		return { type: "add", kind: "cron", cronFields, instruction };
+	}
+
+	return SCHEDULE_USAGE;
+}
+
+/**
+ * Parse a delay token like "30m", "1h30m", "2 hours", "45 minutes".
+ * Returns the delay in ms or an error message string.
+ */
+export function parseDelayToken(token: string): number | string {
+	const lower = token.toLowerCase();
+
+	// Compound: "10m", "1h30m"
+	if (/^(?:\d+[a-z]+)+$/.test(lower)) {
+		const segments = lower.match(/\d+[a-z]+/g);
+		if (!segments) return SCHEDULE_USAGE;
+		let totalMs = 0;
+		for (const segment of segments) {
+			const match = /^(\d+)([a-z]+)$/.exec(segment);
+			if (!match) return SCHEDULE_USAGE;
+			const unitMs = TIME_UNITS_MS[match[2]];
+			if (unitMs === undefined) return "Unknown time unit. Use seconds, minutes, hours, or days.";
+			totalMs += Number(match[1]) * unitMs;
+		}
+		if (totalMs <= 0) return "Delay must be positive.";
+		return totalMs;
+	}
+
+	// Space-separated: "30 minutes" (handled by caller splitting on space)
+	const spaceMatch = /^(\d+)\s+([a-z]+)$/.exec(lower);
+	if (spaceMatch) {
+		const unitMs = TIME_UNITS_MS[spaceMatch[2]];
+		if (unitMs === undefined) return "Unknown time unit. Use seconds, minutes, hours, or days.";
+		const totalMs = Number(spaceMatch[1]) * unitMs;
+		if (totalMs <= 0) return "Delay must be positive.";
+		return totalMs;
+	}
+
+	return `Could not parse delay: "${token}". Examples: 30m, 1h, 2h30m`;
+}
+
+/**
+ * Split a delay + instruction from text like "30m Check the build" or
+ * "2 hours Review PRs". Tries compound form first (single token), then
+ * word form (number + unit word). Returns null when no instruction remains.
+ */
+function splitDelayAndInstruction(text: string): { delayMs: number | string; instruction: string } | null {
+	const firstSpace = text.search(/\s/);
+	if (firstSpace === -1) return null;
+	const firstToken = text.slice(0, firstSpace);
+	const afterFirst = text.slice(firstSpace + 1).trim();
+
+	// Try compound form: "30m", "1h30m"
+	const compoundMs = parseDelayToken(firstToken);
+	if (typeof compoundMs === "number") {
+		if (!afterFirst) return null;
+		return { delayMs: compoundMs, instruction: afterFirst };
+	}
+
+	// Try word form: "2 hours", "30 minutes"
+	const secondSpace = afterFirst.search(/\s/);
+	const secondToken = secondSpace === -1 ? afterFirst : afterFirst.slice(0, secondSpace);
+	const twoTokens = `${firstToken} ${secondToken}`;
+	const wordMs = parseDelayToken(twoTokens);
+	if (typeof wordMs === "number") {
+		const instruction = secondSpace === -1 ? "" : afterFirst.slice(secondSpace + 1).trim();
+		if (!instruction) return null;
+		return { delayMs: wordMs, instruction };
+	}
+
+	// Return the error from the compound attempt (most common form)
+	return { delayMs: compoundMs, instruction: "" };
+}
+
+/** Human-readable description of a delay in ms. */
+export function describeDelay(ms: number): string {
+	if (ms % 86_400_000 === 0) {
+		const days = ms / 86_400_000;
+		return `${days} ${days === 1 ? "day" : "days"}`;
+	}
+	if (ms % 3_600_000 === 0) {
+		const hours = ms / 3_600_000;
+		return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+	}
+	if (ms % 60_000 === 0) {
+		const minutes = ms / 60_000;
+		return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+	}
+	const seconds = Math.round(ms / 1_000);
+	return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+}
+
+export function describeSchedule(item: ScheduledItem): string {
+	const shortInstruction = item.instruction.length > 40 ? `${item.instruction.slice(0, 37)}...` : item.instruction;
+	if (item.kind === "once") {
+		return `in ${describeDelay(item.intervalMs!)} — ${shortInstruction}`;
+	}
+	if (item.kind === "interval") {
+		return `every ${describeDelay(item.intervalMs!)} — ${shortInstruction}`;
+	}
+	return `cron — ${shortInstruction}`;
+}
+
+export function formatScheduleList(items: readonly ScheduledItem[]): string {
+	const active = items.filter(i => i.active);
+	if (active.length === 0) return "No active schedules.";
+	const lines = active.map(item => {
+		const fire = new Date(item.nextFireAt).toLocaleTimeString();
+		return `  ${item.id}: ${describeSchedule(item)} (next: ${fire})`;
+	});
+	return `Active schedules (${active.length}):\n${lines.join("\n")}`;
+}
+
+// ─── Cron parsing ──────────────────────────────────────────────────────────
+
+export interface CronFields {
+	minute: Set<number>;
+	hour: Set<number>;
+	dayOfMonth: Set<number>;
+	month: Set<number>;
+	dayOfWeek: Set<number>;
+	/** Whether the day-of-month field was a wildcard (*). Controls DOM/DOW OR semantics. */
+	domWildcard: boolean;
+	/** Whether the day-of-week field was a wildcard (*). Controls DOM/DOW OR semantics. */
+	dowWildcard: boolean;
+}
+
+/** Standard cron aliases. */
+const CRON_ALIASES: Record<string, string> = {
+	"@yearly": "0 0 1 1 *",
+	"@annually": "0 0 1 1 *",
+	"@monthly": "0 0 1 * *",
+	"@weekly": "0 0 * * 0",
+	"@daily": "0 0 * * *",
+	"@midnight": "0 0 * * *",
+	"@hourly": "0 * * * *",
+};
+
+const MAX_CRON_SCAN_ITERATIONS = 4 * 366 * 24 * 60; // ~4 years to cover leap cycles
+
+export function parseCronExpression(expr: string): CronFields | string {
+	const normalized = CRON_ALIASES[expr.toLowerCase()] ?? expr;
+	const parts = normalized.trim().split(/\s+/);
+	if (parts.length !== 5) {
+		return `Cron expression must have 5 fields (minute hour day-of-month month day-of-week). Got: "${expr}"`;
+	}
+	try {
+		return {
+			minute: parseCronField(parts[0], 0, 59),
+			hour: parseCronField(parts[1], 0, 23),
+			dayOfMonth: parseCronField(parts[2], 1, 31),
+			month: parseCronField(parts[3], 1, 12),
+			dayOfWeek: parseCronField(parts[4], 0, 6),
+			domWildcard: parts[2] === "*" || parts[2] === "?",
+			dowWildcard: parts[4] === "*" || parts[4] === "?",
+		};
+	} catch (err) {
+		return err instanceof Error ? err.message : String(err);
+	}
+}
+
+function parseCronField(field: string, min: number, max: number): Set<number> {
+	const result = new Set<number>();
+	const dowNames: Record<string, number> = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 };
+	const monthNames: Record<string, number> = {
+		jan: 1,
+		feb: 2,
+		mar: 3,
+		apr: 4,
+		may: 5,
+		jun: 6,
+		jul: 7,
+		aug: 8,
+		sep: 9,
+		oct: 10,
+		nov: 11,
+		dec: 12,
+	};
+
+	const resolveValue = (str: string): number => {
+		const lower = str.toLowerCase();
+		if (dowNames[lower] !== undefined) return dowNames[lower];
+		if (monthNames[lower] !== undefined) return monthNames[lower];
+		const n = Number(str);
+		if (!Number.isInteger(n)) throw new Error(`Invalid cron value: "${str}"`);
+		return n;
+	};
+
+	for (const part of field.split(",")) {
+		const starStepMatch = /^\*\/(\d+)$/.exec(part);
+
+		if (starStepMatch) {
+			const step = Number(starStepMatch[1]);
+			if (step <= 0) throw new Error(`Cron step must be positive: "${part}"`);
+			for (let v = min; v <= max; v += step) result.add(v);
+			continue;
+		}
+
+		// Range with optional step: "1-5" or "1-5/2"
+		const rangeMatch = /^(\d+)-(\d+)(?:\/(\d+))?$/.exec(part);
+		if (rangeMatch) {
+			const start = Number(rangeMatch[1]);
+			const end = Number(rangeMatch[2]);
+			const step = rangeMatch[3] ? Number(rangeMatch[3]) : 1;
+			if (step <= 0) throw new Error(`Cron step must be positive: "${part}"`);
+			if (start > end || start < min || end > max) {
+				throw new Error(`Cron range out of bounds: "${part}"`);
+			}
+			for (let v = start; v <= end; v += step) result.add(v);
+			continue;
+		}
+
+		// Wildcard
+		if (part === "*" || part === "?") {
+			for (let v = min; v <= max; v++) result.add(v);
+			continue;
+		}
+
+		// Single value
+		const v = resolveValue(part);
+		if (v < min || v > max) {
+			throw new Error(`Cron value ${v} out of range [${min}, ${max}]`);
+		}
+		result.add(v);
+	}
+
+	if (result.size === 0) {
+		throw new Error(`Empty cron field: "${field}"`);
+	}
+	return result;
+}
+
+/**
+ * Compute the next time a cron expression fires after `from`.
+ * Uses brute-force minute-by-minute scan. Returns `undefined` when no fire time
+ * exists within the scan window (~4 years, covering leap-year cycles).
+ *
+ * Implements standard cron DOM/DOW semantics: when both day-of-month and
+ * day-of-week are restricted (non-wildcard), the expression matches if EITHER
+ * field matches (OR). When one is a wildcard, only the other restricts.
+ */
+export function computeNextCronFire(fields: CronFields, from: Date): number | undefined {
+	const start = new Date(from);
+	start.setSeconds(0, 0);
+	start.setMinutes(start.getMinutes() + 1);
+
+	for (let i = 0; i < MAX_CRON_SCAN_ITERATIONS; i++) {
+		if (
+			fields.minute.has(start.getMinutes()) &&
+			fields.hour.has(start.getHours()) &&
+			fields.month.has(start.getMonth() + 1) &&
+			dayMatches(fields, start)
+		) {
+			return start.getTime();
+		}
+		start.setMinutes(start.getMinutes() + 1);
+	}
+
+	return undefined;
+}
+
+/**
+ * Standard cron day-matching rule:
+ * - Both wildcards → always match
+ * - One wildcard → only the non-wildcard field restricts
+ * - Both restricted → OR (match if either matches)
+ */
+function dayMatches(fields: CronFields, date: Date): boolean {
+	const domMatch = fields.dayOfMonth.has(date.getDate());
+	const dowMatch = fields.dayOfWeek.has(date.getDay());
+	if (fields.domWildcard && fields.dowWildcard) return true;
+	if (fields.domWildcard) return dowMatch;
+	if (fields.dowWildcard) return domMatch;
+	return domMatch || dowMatch;
+}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -40,6 +40,7 @@ import type { TranscriptContainer } from "./components/transcript-container";
 import type { EventController } from "./controllers/event-controller";
 import type { LoopLimitRuntime } from "./loop-limit";
 import type { OAuthManualInputManager } from "./oauth-manual-input";
+import type { ScheduledItem } from "./schedule";
 import type { Theme } from "./theme/theme";
 
 export type CompactionQueuedMessage = {
@@ -171,6 +172,7 @@ export interface InteractiveModeContext {
 	loopModeEnabled: boolean;
 	loopModePaused: boolean;
 	loopPrompt?: string;
+	scheduledItems?: readonly ScheduledItem[];
 	loopLimit?: LoopLimitRuntime;
 	planModePlanFilePath?: string;
 	hideThinkingBlock: boolean;
@@ -447,6 +449,7 @@ export interface InteractiveModeContext {
 	disableLoopMode(): void;
 	pauseLoop(): void;
 	handlePlanApproval(details: PlanApprovalDetails): Promise<void>;
+	handleScheduleCommand(args: string): Promise<void>;
 	openPlanReview(): Promise<void>;
 
 	// Hook UI methods

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -280,6 +280,29 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "schedule",
+		description: "Schedule a prompt to fire once, repeatedly, or on a cron expression",
+		subcommands: [
+			{ name: "in", description: "One-shot after a delay", usage: "<DELAY> <instruction>" },
+			{ name: "every", description: "Recurring at an interval", usage: "<INTERVAL> <instruction>" },
+			{ name: "cron", description: "Cron-based schedule", usage: '"<EXPR>" <instruction>' },
+			{ name: "list", description: "List active schedules" },
+			{ name: "cancel", description: "Cancel a schedule", usage: "<id>" },
+			{ name: "clear", description: "Cancel all schedules" },
+		],
+		inlineHint: "in <DELAY> <instruction>",
+		allowArgs: true,
+		getTuiAutocompleteDescription: runtime => {
+			const items = runtime.ctx.scheduledItems;
+			if (!items || items.length === 0) return "Schedule: none";
+			return `Schedule: ${items.length} active`;
+		},
+		handleTui: async (command, runtime) => {
+			await runtime.ctx.handleScheduleCommand(command.args || "");
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
 		name: "model",
 		aliases: ["models"],
 		description: "Switch model for this session",

--- a/packages/coding-agent/test/schedule.test.ts
+++ b/packages/coding-agent/test/schedule.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, test } from "bun:test";
+import type { ScheduledItem } from "@oh-my-pi/pi-coding-agent/modes/schedule";
+import {
+	computeNextCronFire,
+	describeDelay,
+	describeSchedule,
+	formatScheduleList,
+	parseCronExpression,
+	parseDelayToken,
+	parseScheduleCommand,
+} from "@oh-my-pi/pi-coding-agent/modes/schedule";
+
+describe("schedule command parsing", () => {
+	test("parses one-shot: in <DELAY> <instruction>", () => {
+		const result = parseScheduleCommand("in 30m Check the build status");
+		expect(result).toEqual({
+			type: "add",
+			kind: "once",
+			intervalMs: 1_800_000,
+			instruction: "Check the build status",
+		});
+	});
+
+	test("parses recurring: every <INTERVAL> <instruction>", () => {
+		const result = parseScheduleCommand("every 10m Check the deployment");
+		expect(result).toEqual({
+			type: "add",
+			kind: "interval",
+			intervalMs: 600_000,
+			instruction: "Check the deployment",
+		});
+	});
+
+	test("parses cron with double-quoted expression", () => {
+		const result = parseScheduleCommand('cron "0 9 * * 1-5" Review open PRs');
+		expect(result).toMatchObject({
+			type: "add",
+			kind: "cron",
+			instruction: "Review open PRs",
+		});
+	});
+
+	test("parses subcommands", () => {
+		expect(parseScheduleCommand("list")).toEqual({ type: "list" });
+		expect(parseScheduleCommand("ls")).toEqual({ type: "list" });
+		expect(parseScheduleCommand("clear")).toEqual({ type: "clear" });
+		expect(parseScheduleCommand("cancel s1")).toEqual({ type: "cancel", id: "s1" });
+	});
+
+	test("parses word-style duration: in 2 hours <instruction>", () => {
+		const result = parseScheduleCommand("in 2 hours Review the PRs");
+		expect(result).toEqual({
+			type: "add",
+			kind: "once",
+			intervalMs: 7_200_000,
+			instruction: "Review the PRs",
+		});
+	});
+
+	test("parses word-style duration: every 30 minutes <instruction>", () => {
+		const result = parseScheduleCommand("every 30 minutes Check the logs");
+		expect(result).toEqual({
+			type: "add",
+			kind: "interval",
+			intervalMs: 1_800_000,
+			instruction: "Check the logs",
+		});
+	});
+
+	test("rejects empty args", () => {
+		expect(typeof parseScheduleCommand("")).toBe("string");
+		expect(typeof parseScheduleCommand("   ")).toBe("string");
+	});
+
+	test("rejects missing instruction", () => {
+		const r = parseScheduleCommand("in 30m");
+		expect(typeof r).toBe("string");
+		expect(r).toContain("instruction");
+	});
+
+	test("rejects invalid delay", () => {
+		const r = parseScheduleCommand("in abc Check builds");
+		expect(typeof r).toBe("string");
+	});
+
+	test("rejects cron without quotes", () => {
+		const r = parseScheduleCommand("cron 0 9 * * 1-5 Review PRs");
+		expect(typeof r).toBe("string");
+		expect(r).toContain("quoted");
+	});
+});
+
+describe("delay parsing", () => {
+	test("parses compound durations", () => {
+		expect(parseDelayToken("30m")).toBe(1_800_000);
+		expect(parseDelayToken("1h")).toBe(3_600_000);
+		expect(parseDelayToken("2h30m")).toBe(9_000_000);
+		expect(parseDelayToken("1d")).toBe(86_400_000);
+	});
+
+	test("parses word-style durations", () => {
+		expect(parseDelayToken("10 minutes")).toBe(600_000);
+		expect(parseDelayToken("2 hours")).toBe(7_200_000);
+	});
+
+	test("rejects unknown units", () => {
+		expect(typeof parseDelayToken("10x")).toBe("string");
+	});
+
+	test("rejects zero or negative", () => {
+		expect(typeof parseDelayToken("0m")).toBe("string");
+	});
+});
+
+describe("cron expression parsing", () => {
+	test("parses basic 5-field expression", () => {
+		const fields = parseCronExpression("0 9 * * *");
+		expect(typeof fields).not.toBe("string");
+		if (typeof fields !== "string") {
+			expect(fields.minute.has(0)).toBe(true);
+			expect(fields.hour.has(9)).toBe(true);
+			expect(fields.dayOfMonth.size).toBe(31);
+		}
+	});
+
+	test("parses ranges", () => {
+		const fields = parseCronExpression("0 9 * * 1-5");
+		expect(typeof fields).not.toBe("string");
+		if (typeof fields !== "string") {
+			expect(fields.dayOfWeek.has(1)).toBe(true);
+			expect(fields.dayOfWeek.has(5)).toBe(true);
+			expect(fields.dayOfWeek.has(0)).toBe(false);
+		}
+	});
+
+	test("parses step values", () => {
+		const fields = parseCronExpression("*/15 * * * *");
+		expect(typeof fields).not.toBe("string");
+		if (typeof fields !== "string") {
+			expect(fields.minute.has(0)).toBe(true);
+			expect(fields.minute.has(15)).toBe(true);
+			expect(fields.minute.has(30)).toBe(true);
+			expect(fields.minute.has(45)).toBe(true);
+			expect(fields.minute.has(1)).toBe(false);
+		}
+	});
+
+	test("parses comma-separated values", () => {
+		const fields = parseCronExpression("0,30 * * * *");
+		expect(typeof fields).not.toBe("string");
+		if (typeof fields !== "string") {
+			expect(fields.minute.has(0)).toBe(true);
+			expect(fields.minute.has(30)).toBe(true);
+			expect(fields.minute.size).toBe(2);
+		}
+	});
+
+	test("expands aliases", () => {
+		const fields = parseCronExpression("@hourly");
+		expect(typeof fields).not.toBe("string");
+		if (typeof fields !== "string") {
+			expect(fields.minute.has(0)).toBe(true);
+			expect(fields.hour.size).toBe(24);
+		}
+	});
+
+	test("rejects wrong field count", () => {
+		expect(typeof parseCronExpression("0 9 * *")).toBe("string");
+		expect(typeof parseCronExpression("0 9 * * * *")).toBe("string");
+	});
+
+	test("rejects zero cron steps", () => {
+		expect(typeof parseCronExpression("*/0 * * * *")).toBe("string");
+		expect(typeof parseCronExpression("0-59/0 * * * *")).toBe("string");
+	});
+
+	test("tracks wildcard flags for DOM/DOW", () => {
+		const fields = parseCronExpression("0 9 * * *");
+		expect(typeof fields).not.toBe("string");
+		if (typeof fields !== "string") {
+			expect(fields.domWildcard).toBe(true);
+			expect(fields.dowWildcard).toBe(true);
+		}
+		const restricted = parseCronExpression("0 9 15 * 1");
+		expect(typeof restricted).not.toBe("string");
+		if (typeof restricted !== "string") {
+			expect(restricted.domWildcard).toBe(false);
+			expect(restricted.dowWildcard).toBe(false);
+		}
+	});
+});
+
+describe("computeNextCronFire", () => {
+	test("finds next occurrence within the same hour", () => {
+		const fields = parseCronExpression("30 * * * *");
+		expect(typeof fields).not.toBe("string");
+		if (typeof fields !== "string") {
+			const now = new Date("2026-01-01T10:00:00Z");
+			const next = computeNextCronFire(fields, now);
+			expect(next).toBeDefined();
+			const nextDate = new Date(next!);
+			expect(nextDate.getUTCMinutes()).toBe(30);
+			expect(nextDate.getUTCHours()).toBe(10);
+		}
+	});
+
+	test("wraps to next hour when minute has passed", () => {
+		const fields = parseCronExpression("0 * * * *");
+		expect(typeof fields).not.toBe("string");
+		if (typeof fields !== "string") {
+			const now = new Date("2026-01-01T10:30:00Z");
+			const next = computeNextCronFire(fields, now);
+			expect(next).toBeDefined();
+			const nextDate = new Date(next!);
+			expect(nextDate.getUTCMinutes()).toBe(0);
+			expect(nextDate.getUTCHours()).toBe(11);
+		}
+	});
+
+	test("DOM/DOW OR semantics: matches when either restricted field matches", () => {
+		// "0 9 1 * 1" = 9am on the 1st of the month OR on Monday
+		const fields = parseCronExpression("0 9 1 * 1");
+		expect(typeof fields).not.toBe("string");
+		if (typeof fields !== "string") {
+			// 2026-01-02 is a Friday (DOW=5), not the 1st (DOM=2) → skip
+			// Next fire should be 2026-01-05 (Monday) at 9am
+			const now = new Date("2026-01-02T00:00:00Z");
+			const next = computeNextCronFire(fields, now);
+			expect(next).toBeDefined();
+			const nextDate = new Date(next!);
+			expect(nextDate.getUTCDate()).toBe(5); // Monday
+			expect(nextDate.getUTCDay()).toBe(1); // Monday
+		}
+	});
+
+	test("returns undefined for impossible date like Feb 30", () => {
+		const fields = parseCronExpression("0 0 30 2 *");
+		expect(typeof fields).not.toBe("string");
+		if (typeof fields !== "string") {
+			const now = new Date("2026-01-01T00:00:00Z");
+			const next = computeNextCronFire(fields, now);
+			expect(next).toBeUndefined();
+		}
+	});
+});
+
+describe("formatting helpers", () => {
+	test("describeDelay formats common intervals", () => {
+		expect(describeDelay(60_000)).toBe("1 minute");
+		expect(describeDelay(600_000)).toBe("10 minutes");
+		expect(describeDelay(3_600_000)).toBe("1 hour");
+		expect(describeDelay(86_400_000)).toBe("1 day");
+	});
+
+	test("describeSchedule formats one-shot", () => {
+		const item: ScheduledItem = {
+			id: "s1",
+			kind: "once",
+			intervalMs: 1_800_000,
+			nextFireAt: Date.now() + 1_800_000,
+			instruction: "Check the build",
+			active: true,
+		};
+		expect(describeSchedule(item)).toContain("in 30 minutes");
+		expect(describeSchedule(item)).toContain("Check the build");
+	});
+
+	test("describeSchedule formats interval", () => {
+		const item: ScheduledItem = {
+			id: "s2",
+			kind: "interval",
+			intervalMs: 600_000,
+			nextFireAt: Date.now() + 600_000,
+			instruction: "Check deployment",
+			active: true,
+		};
+		expect(describeSchedule(item)).toContain("every 10 minutes");
+	});
+
+	test("formatScheduleList shows empty state", () => {
+		expect(formatScheduleList([])).toContain("No active schedules");
+	});
+
+	test("formatScheduleList shows active items", () => {
+		const items: ScheduledItem[] = [
+			{
+				id: "s1",
+				kind: "once",
+				intervalMs: 1_800_000,
+				nextFireAt: Date.now() + 1_800_000,
+				instruction: "Check the build",
+				active: true,
+			},
+		];
+		const text = formatScheduleList(items);
+		expect(text).toContain("s1");
+		expect(text).toContain("Check the build");
+		expect(text).toContain("1");
+	});
+});

--- a/packages/coding-agent/test/status-line-loop.test.ts
+++ b/packages/coding-agent/test/status-line-loop.test.ts
@@ -23,6 +23,7 @@ function createContext(loopMode: SegmentContext["loopMode"]): SegmentContext {
 		goalMode: null,
 		vibeMode: null,
 		collab: null,
+		schedule: null,
 		usageStats: {
 			input: 0,
 			output: 0,

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -30,6 +30,7 @@ function createModelContext(advisorActive: boolean): SegmentContext {
 		goalMode: null,
 		vibeMode: null,
 		collab: null,
+		schedule: null,
 		usageStats: {
 			input: 0,
 			output: 0,

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -56,6 +56,7 @@ function createCtx(overrides?: {
 		goalMode: null,
 		vibeMode: null,
 		collab: null,
+		schedule: null,
 		usageStats: {
 			input: 0,
 			output: 0,

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -35,6 +35,7 @@ function createPathContext(): SegmentContext {
 		goalMode: null,
 		vibeMode: null,
 		collab: null,
+		schedule: null,
 		usageStats: {
 			input: 0,
 			output: 0,

--- a/packages/coding-agent/test/status-line-time-spent.test.ts
+++ b/packages/coding-agent/test/status-line-time-spent.test.ts
@@ -45,6 +45,7 @@ function createCtx(activeMs: number): SegmentContext {
 		goalMode: null,
 		vibeMode: null,
 		collab: null,
+		schedule: null,
 		usageStats: {
 			input: 0,
 			output: 0,


### PR DESCRIPTION
## Summary

Adds a flexible **prompt scheduling system** with three modes — one-shot, recurring, and cron-based. Multiple schedules can be active simultaneously, each with a unique ID for individual cancellation.

This complements the existing `/loop` (re-submit after every yield) and `/heartbeat` (single recurring timer) features with more flexible scheduling:

```text
/schedule in 30m Check the build status        — one-shot
/schedule every 10m Check the deployment         — recurring
/schedule cron "0 9 * * 1-5" Review open PRs      — cron (weekdays at 9am)
/schedule list
/schedule cancel s1
/schedule clear
```

## Usage

### One-shot (`in`)
Fires once after the specified delay, then is automatically removed:
```
/schedule in 2h Review the PR comments and address feedback
```

### Recurring (`every`)
Fires repeatedly at a fixed interval:
```
/schedule every 15m Run the test suite and report failures
```

### Cron (`cron`)
Fires at specific wall-clock times using standard 5-field cron syntax:
```
/schedule cron "*/30 9-17 * * 1-5" Check for new PRs    — every 30 min during business hours
/schedule cron "0 0 * * 0" Run weekly cleanup             — midnight every Sunday
```

Cron supports: ranges (`1-5`), steps (`*/15`), comma lists (`0,30`), day/month names (`mon`, `jan`), and aliases (`@hourly`, `@daily`, `@weekly`, `@monthly`, `@yearly`).

### Management
```
/schedule list     — show all active schedules with IDs and next-fire times
/schedule cancel s1 — cancel a specific schedule by ID
/schedule clear     — cancel all schedules
```

## Implementation

- **`modes/schedule.ts`** (new) — Full scheduling engine: command parsing, delay/cron parsing, cron field resolution with range/step/list/name support, next-fire computation via minute-by-minute scan, and formatting helpers.
- **`slash-commands/builtin-modes.ts`** — `/schedule` command spec with subcommands and autocomplete.
- **`modes/interactive-mode.ts`** — Multi-timer lifecycle: `#scheduleTimers` Map, per-item arming/cancellation, prompt injection via `startPendingSubmission` with `customType: "schedule"`, and disposal cleanup.
- **Status line** — `⏰N` indicator showing active schedule count, co-rendered alongside any active mode. Extracted mode chain into `renderPrimaryModeSegment` for clean composition.

### Design decisions

- **Multiple simultaneous schedules** — unlike `/heartbeat` (single timer), `/schedule` supports any number of active timers.
- **`setTimeout` + re-arm** — both one-shot and cron use `setTimeout` with `unref()`. Recurring and cron schedules re-arm on each fire.
- **Cron next-fire via brute-force scan** — scans minute-by-minute (max 527,040 iterations = 1 year). Simple, correct, and fast enough for session-scoped scheduling.
- **Busy-agent skip** — ticks are dropped if the agent is streaming, compaction, or has pending input (same pattern as heartbeat).

## Test plan

- [x] `schedule.test.ts` — 25 tests covering: command parsing (all three modes + subcommands + error cases), delay parsing (compound/word/negative), cron field parsing (basic/range/step/comma/alias/error), next-fire computation (same-hour/wrap), and formatting helpers.
- [x] All 46 existing status-line tests pass (5 fixtures updated for new `schedule` SegmentContext field).
- [x] `bun check` passes with no new errors.
- [x] CHANGELOG updated under `[Unreleased]`.