### PR TITLE
feat(mcp): add per-server enabledTools/disabledTools tool filtering (#6299)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "omp",
       "dependencies": {
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1",
         "sherpa-onnx": "1.13.2",
         "sherpa-onnx-darwin-arm64": "1.13.3",
         "sherpa-onnx-node": "1.13.2",
@@ -963,6 +965,10 @@
 
     "adm-zip": ["adm-zip@0.5.18", "", {}, "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng=="],
 
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
@@ -1085,9 +1091,13 @@
 
     "exit": ["exit@0.1.2", "", {}, "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
@@ -1146,6 +1156,8 @@
     "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
 
@@ -1272,6 +1284,8 @@
     "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
 

--- a/docs/mcp-config.md
+++ b/docs/mcp-config.md
@@ -103,6 +103,10 @@ Shared fields for every transport:
 - `requestIdFormat?: "number" | "string"` — outgoing JSON-RPC request-id encoding; defaults to per-transport integers. `"string"` uses collision-resistant snowflake IDs. This OMP-specific field is read only from OMP-native files, root `mcp.json` / `.mcp.json`, and OMP extension packages; configs translated from other tools ignore it.
 - `auth?: { ... }` — stored-credential metadata; managed credential injection is implemented for OAuth
 - `oauth?: { ... }` — explicit OAuth client and callback settings used during auth/reauth
+- `enabledTools?: string[]` — allowlist of raw server-advertised tool names to register; entries may be literal names or glob patterns (`"search"`, `"channel_*"`). Excluded tools never reach the model context.
+- `disabledTools?: string[]` — denylist of raw server-advertised tool names to exclude; same glob support. When both `enabledTools` and `disabledTools` are set, the denylist wins (deny subtracts from allow).
+
+Tool filters are OMP-specific: like `requestIdFormat`, they are read only from OMP-native files, root `mcp.json` / `.mcp.json`, and OMP extension packages; configs translated from other tools ignore them. Filter entries that match no advertised tool are warned about and ignored, and a filter that excludes every advertised tool is reported as an error — the server stays connected but contributes no tools.
 
 `OMP_MCP_TIMEOUT_MS` has process-wide precedence over every per-server `timeout`. Set it to `0` to disable client-side timeouts, or to a positive millisecond value such as `120000`. If it is unset or invalid, OMP uses the server value and then the 30-second default; invalid values are logged and ignored.
 

--- a/docs/mcp-server-tool-authoring.md
+++ b/docs/mcp-server-tool-authoring.md
@@ -22,7 +22,7 @@ Config sources (.omp/.claude/.cursor/.vscode/mcp.json, mcp.json, etc.)
 - `stdio` (default when `type` missing): requires `command`, optional `args`, `env`, `cwd`
 - `http`: requires `url`, optional `headers`
 - `sse`: requires `url`, optional `headers` (kept for compatibility)
-- shared fields: `enabled`, `timeout`, `requestIdFormat` (`"number"` or `"string"`), `auth`, `oauth`
+- shared fields: `enabled`, `timeout`, `requestIdFormat` (`"number"` or `"string"`), `auth`, `oauth`, and the per-server tool filter fields `enabledTools` / `disabledTools` (allowlist/denylist of raw advertised tool names, globs allowed; denylist wins when both are set) (OMP-native configs only; translated configs ignore these — see mcp-config.md)
 
 `validateServerConfig()` (`src/mcp/config.ts`) enforces transport basics:
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "test:scripts": "bun test scripts/ci-test-ts.test.ts scripts/ci-release-build-binaries.test.ts scripts/musl-release.test.ts scripts/ci-release-publish.test.ts scripts/release.test.ts",
     "test:rs": "bun scripts/run-rs-task.ts test:rs",
     "check": "bun run --parallel check:ts check:rs",
-"check:ts": "bun run check:tools && bun run --workspaces --if-present check",
+    "check:ts": "bun run check:tools && bun run --workspaces --if-present check",
     "check:tools": "biome check . --no-errors-on-unmatched",
     "check:rs": "bun scripts/run-rs-task.ts check:rs",
     "lint": "bun run --parallel lint:ts lint:rs",
@@ -187,6 +187,8 @@
     "*.{js,ts,jsx,tsx,json,jsonc,css}": "biome check --write --no-errors-on-unmatched"
   },
   "dependencies": {
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1",
     "sherpa-onnx": "1.13.2",
     "sherpa-onnx-darwin-arm64": "1.13.3",
     "sherpa-onnx-node": "1.13.2"

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added per-server MCP tool filtering via `enabledTools`/`disabledTools` config fields with fnmatch glob support ([#6299](https://github.com/can1357/oh-my-pi/issues/6299))
+
 ## [18.0.3] - 2026-08-23
 
 ### Added

--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -62,6 +62,10 @@ export interface MCPServer {
 		callbackPath?: string;
 		prompt?: string;
 	};
+	/** Allowlist of raw server-advertised tool names (literal or glob, e.g. "channel_*"). */
+	enabledTools?: string[];
+	/** Denylist of raw server-advertised tool names; wins over enabledTools when both are set. */
+	disabledTools?: string[];
 	/** Transport type */
 	transport?: "stdio" | "sse" | "http";
 	/** Source metadata (added by loader) */
@@ -74,6 +78,10 @@ function isSameMCPConnection(left: MCPServer, right: MCPServer): boolean {
 	// Normalize against the allocator's own default so an explicit "number" is
 	// equivalent to leaving the option unset, not a distinct connection.
 	if ((left.requestIdFormat ?? "number") !== (right.requestIdFormat ?? "number")) return false;
+	// Tool filters change which tools the server exposes to the model, so two
+	// aliases with the same transport but different filters are distinct.
+	if (!Bun.deepEquals(left.enabledTools, right.enabledTools)) return false;
+	if (!Bun.deepEquals(left.disabledTools, right.disabledTools)) return false;
 
 	const leftTransport = left.transport ?? (left.command ? "stdio" : left.url ? "http" : "stdio");
 	const rightTransport = right.transport ?? (right.command ? "stdio" : right.url ? "http" : "stdio");

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -4,7 +4,6 @@
   "title": "OMP MCP configuration",
   "description": "Schema for mcp.json, .mcp.json, .omp/mcp.json, and ~/.omp/agent/mcp.json used by the OMP coding agent.",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "$schema": {
       "type": "string",
@@ -39,6 +38,7 @@
       "uniqueItems": true
     }
   },
+  "additionalProperties": false,
   "$defs": {
     "stringMap": {
       "type": "object",
@@ -123,6 +123,22 @@
           "enum": ["string", "number"],
           "description": "Encoding for outgoing JSON-RPC request ids (default: \"number\"). Use \"string\" for servers that need collision-resistant snowflake string ids instead of per-transport integers. OMP-specific: set it in an OMP-owned config (`.omp/mcp.json`, `~/.omp/agent/mcp.json`, a project `mcp.json`/`.mcp.json`, or an OMP plugin). Servers imported from another tool's config (Claude, Cursor, VS Code, Gemini, OpenCode, Windsurf) ignore it, since that key is not part of those formats."
         },
+        "enabledTools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Allowlist of raw server-advertised tool names to register (default: all tools). Entries may be literal names or glob patterns (e.g. \"search\", \"channel_*\"). Excluded tools never reach the model context."
+        },
+        "disabledTools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Denylist of raw server-advertised tool names to exclude. Entries may be literal names or glob patterns. When both enabledTools and disabledTools are set, the denylist wins."
+        },
         "auth": {
           "$ref": "#/$defs/authConfig"
         },
@@ -132,13 +148,13 @@
       }
     },
     "stdioServer": {
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/serverBase"
         },
         {
           "type": "object",
-          "additionalProperties": false,
           "required": ["command"],
           "properties": {
             "type": {
@@ -174,13 +190,13 @@
       ]
     },
     "httpServer": {
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/serverBase"
         },
         {
           "type": "object",
-          "additionalProperties": false,
           "required": ["type", "url"],
           "properties": {
             "type": {
@@ -205,13 +221,13 @@
       ]
     },
     "sseServer": {
+      "unevaluatedProperties": false,
       "allOf": [
         {
           "$ref": "#/$defs/serverBase"
         },
         {
           "type": "object",
-          "additionalProperties": false,
           "required": ["type", "url"],
           "properties": {
             "type": {

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -32,6 +32,7 @@ import {
 	getExtensionNameFromPath,
 	loadFilesFromDir,
 	parseRequestIdFormat,
+	parseStringArray,
 	SOURCE_PATHS,
 	scanSkillsFromDir,
 } from "./helpers";
@@ -163,11 +164,16 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 				);
 			}
 
+			const enabledTools = parseStringArray(serverConfig.enabledTools);
+			const disabledTools = parseStringArray(serverConfig.disabledTools);
+
 			result.push({
 				name: serverName,
 				enabled,
 				timeout,
 				requestIdFormat,
+				enabledTools,
+				disabledTools,
 				command: serverConfig.command as string | undefined,
 				args: serverConfig.args as string[] | undefined,
 				env: serverConfig.env as Record<string, string> | undefined,

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -178,6 +178,20 @@ export function parseArrayOrCSV(value: unknown): string[] | undefined {
 }
 
 /**
+ * Parse a value that must be an array of non-empty strings.
+ *
+ * Unlike {@link parseArrayOrCSV}, a string input is rejected (not split on
+ * commas): entries may contain commas inside brace globs (e.g.
+ * `"{create,delete}_*"`), so a CSV split would silently break them. Non-string
+ * array items are dropped; an empty result yields undefined.
+ */
+export function parseStringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const filtered = value.filter((item): item is string => typeof item === "string" && item.length > 0);
+	return filtered.length > 0 ? filtered : undefined;
+}
+
+/**
  * Build a canonical rule item from a markdown/markdown-frontmatter document.
  */
 export function buildRuleFromMarkdown(

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -12,7 +12,7 @@ import { registerProvider } from "../capability";
 import { readFile } from "../capability/fs";
 import { type MCPServer, mcpCapability } from "../capability/mcp";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
-import { createSourceMeta, expandEnvVarsDeep, parseRequestIdFormat } from "./helpers";
+import { createSourceMeta, expandEnvVarsDeep, parseRequestIdFormat, parseStringArray } from "./helpers";
 
 const PROVIDER_ID = "mcp-json";
 const DISPLAY_NAME = "MCP Config";
@@ -27,6 +27,8 @@ interface MCPConfigFile {
 			enabled?: boolean;
 			timeout?: number;
 			requestIdFormat?: "string" | "number";
+			enabledTools?: unknown;
+			disabledTools?: unknown;
 			command?: string;
 			args?: string[];
 			env?: Record<string, string>;
@@ -97,6 +99,8 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 				enabled,
 				timeout,
 				requestIdFormat,
+				enabledTools: parseStringArray(serverConfig.enabledTools),
+				disabledTools: parseStringArray(serverConfig.disabledTools),
 				command: serverConfig.command,
 				args: serverConfig.args,
 				env: serverConfig.env,

--- a/packages/coding-agent/src/discovery/omp-plugins.ts
+++ b/packages/coding-agent/src/discovery/omp-plugins.ts
@@ -35,6 +35,7 @@ import {
 	expandEnvVarsDeep,
 	loadFilesFromDir,
 	parseRequestIdFormat,
+	parseStringArray,
 	scanSkillsFromDir,
 } from "./helpers";
 import { listOmpExtensionRoots, type OmpExtensionRoot } from "./omp-extension-roots";
@@ -278,6 +279,8 @@ interface RawMcpServer {
 	enabled?: boolean;
 	timeout?: number;
 	requestIdFormat?: unknown;
+	enabledTools?: unknown;
+	disabledTools?: unknown;
 	command?: string;
 	args?: string[];
 	env?: Record<string, string>;
@@ -327,11 +330,15 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 			// session cwd (MCP stdio spawning resolves relative values there).
 			const rooted = resolvePluginStdioPaths({ command: cfg.command, cwd: cfg.cwd }, root.path);
 			const requestIdFormat = parseRequestIdFormat(cfg.requestIdFormat);
+			const enabledTools = parseStringArray(cfg.enabledTools);
+			const disabledTools = parseStringArray(cfg.disabledTools);
 			items.push({
 				name: serverName,
 				...(cfg.enabled !== undefined && { enabled: cfg.enabled }),
 				...(cfg.timeout !== undefined && { timeout: cfg.timeout }),
 				...(requestIdFormat !== undefined && { requestIdFormat }),
+				...(enabledTools !== undefined && { enabledTools }),
+				...(disabledTools !== undefined && { disabledTools }),
 				...(rooted.command !== undefined && { command: rooted.command }),
 				...(cfg.args !== undefined && { args: cfg.args }),
 				...(cfg.env !== undefined && { env: cfg.env }),

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -44,6 +44,8 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 		requestIdFormat: server.requestIdFormat,
 		auth: server.auth,
 		oauth: server.oauth,
+		enabledTools: server.enabledTools,
+		disabledTools: server.disabledTools,
 	};
 
 	if (transport === "stdio") {

--- a/packages/coding-agent/src/mcp/index.ts
+++ b/packages/coding-agent/src/mcp/index.ts
@@ -22,6 +22,8 @@ export * from "./oauth-discovery";
 export * from "./tool-bridge";
 // Tool cache
 export * from "./tool-cache";
+// Tool filter
+export * from "./tool-filter";
 // Transports
 export * from "./transports/http";
 export * from "./transports/stdio";

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -82,6 +82,14 @@ function createMcpStartupFailure(serverName: string, error: string, source?: Sou
 		: { type: "failed", serverName, error };
 }
 
+/** Failure message when a configured filter excludes every advertised tool, else null. */
+function mcpFilterEmptyMessage(name: string, config: MCPServerConfig, toolCount: number): string | null {
+	if (!config.enabledTools?.length && !config.disabledTools?.length) return null;
+	// A zero-tool server has nothing to exclude; never claim the filter excluded 0 tools.
+	if (toolCount === 0) return null;
+	return `MCP server "${name}": tool filter excludes all ${toolCount} advertised tools; the server contributes no tools. Remove the filter or widen it.`;
+}
+
 /**
  * Per-server reconnect-storm circuit breaker.
  *
@@ -581,7 +589,17 @@ export class MCPManager {
 					void this.#onToolsChanged?.(this.#tools);
 					void this.toolCache?.set(name, config, serverTools);
 
-					onStatus?.({ type: "connected", serverName: name });
+					// When the server was slow (>250 ms startup window) the synchronous
+					// errors.set branch below was skipped; surface the filter-empty
+					// condition here too so the user sees a per-server failure instead
+					// of a silently connected server with no tools.
+					const filterMsg =
+						customTools.length === 0 ? mcpFilterEmptyMessage(name, config, serverTools.length) : null;
+					if (filterMsg) {
+						onStatus?.(createMcpStartupFailure(name, filterMsg, sources[name]));
+					} else {
+						onStatus?.({ type: "connected", serverName: name });
+					}
 					await this.#loadServerResourcesAndPrompts(name, connection);
 				})
 				.catch(error => {
@@ -638,7 +656,17 @@ export class MCPManager {
 					const { connection, serverTools } = value;
 					connectedServers.add(name);
 					const reconnect = () => this.reconnectServer(name);
-					allTools.push(...MCPTool.fromTools(connection, serverTools, reconnect));
+					const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
+					allTools.push(...customTools);
+					// The filter excluded every advertised tool (MCPTool.fromTools
+					// already logged the detail); surface it as a per-server error
+					// so the user sees why the server contributes no tools.
+					const filterMsg =
+						customTools.length === 0 ? mcpFilterEmptyMessage(name, task.config, serverTools.length) : null;
+					if (filterMsg) {
+						errors.set(name, filterMsg);
+						reportedErrors.add(name);
+					}
 				} else if (task.tracked.status === "rejected") {
 					const message =
 						task.tracked.reason instanceof Error ? task.tracked.reason.message : String(task.tracked.reason);
@@ -650,7 +678,14 @@ export class MCPManager {
 						const source = this.#sources.get(name);
 						const reconnect = () => this.reconnectServer(name);
 						allTools.push(
-							...DeferredMCPTool.fromTools(name, cached, () => this.waitForConnection(name), source, reconnect),
+							...DeferredMCPTool.fromTools(
+								name,
+								task.config,
+								cached,
+								() => this.waitForConnection(name),
+								source,
+								reconnect,
+							),
 						);
 					}
 				}

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -22,9 +22,11 @@ import { normalizeLocalScheme } from "../tools/path-utils";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
 import { callTool } from "./client";
 import { renderMCPCall, renderMCPResult } from "./render";
+import { applyMCPToolFilter } from "./tool-filter";
 import type {
 	MCPAuthChallenge,
 	MCPContent,
+	MCPServerConfig,
 	MCPServerConnection,
 	MCPToolCallParams,
 	MCPToolCallResult,
@@ -476,6 +478,21 @@ export function parseMCPToolName(name: string): { serverName: string; toolName: 
 }
 
 /**
+ * Apply the server's tool filter and resolve surviving names to definitions.
+ */
+function filteredToolDefs(
+	byName: Map<string, MCPToolDefinition>,
+	serverName: string,
+	config: MCPServerConfig,
+): MCPToolDefinition[] {
+	return applyMCPToolFilter(serverName, {
+		toolNames: [...byName.keys()],
+		enabledTools: config.enabledTools,
+		disabledTools: config.disabledTools,
+	}).map(name => byName.get(name)!);
+}
+
+/**
  * CustomTool wrapping an MCP tool with an active connection.
  */
 export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
@@ -500,7 +517,10 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 
 	/** Create MCPTool instances for all tools from an MCP server connection */
 	static fromTools(connection: MCPServerConnection, tools: MCPToolDefinition[], reconnect?: MCPReconnect): MCPTool[] {
-		return tools.map(tool => new MCPTool(connection, tool, reconnect));
+		const byName = new Map(tools.map(tool => [tool.name, tool]));
+		return filteredToolDefs(byName, connection.name, connection.config).map(
+			tool => new MCPTool(connection, tool, reconnect),
+		);
 	}
 
 	constructor(
@@ -611,12 +631,16 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	/** Create DeferredMCPTool instances for all tools from an MCP server */
 	static fromTools(
 		serverName: string,
+		config: MCPServerConfig,
 		tools: MCPToolDefinition[],
 		getConnection: () => Promise<MCPServerConnection>,
 		source?: SourceMeta,
 		reconnect?: MCPReconnect,
 	): DeferredMCPTool[] {
-		return tools.map(tool => new DeferredMCPTool(serverName, tool, getConnection, source, reconnect));
+		const byName = new Map(tools.map(tool => [tool.name, tool]));
+		return filteredToolDefs(byName, serverName, config).map(
+			tool => new DeferredMCPTool(serverName, tool, getConnection, source, reconnect),
+		);
 	}
 
 	constructor(

--- a/packages/coding-agent/src/mcp/tool-filter.ts
+++ b/packages/coding-agent/src/mcp/tool-filter.ts
@@ -1,0 +1,200 @@
+/**
+ * Per-server MCP tool filtering (`enabledTools` / `disabledTools`).
+ *
+ * Tool names are matched against the raw names the server advertises via
+ * `tools/list` (not the `mcp__server_`-prefixed session names). Entries may be
+ * literal tool names or fnmatch-style glob patterns (`"search"`, `"channel_*"`),
+ * matching the wildcard vocabulary used by LangChain's MCP adapters and
+ * Claude Code's `mcp__server__*` permissions deny patterns.
+ *
+ * Semantics, mirroring the server-level `enabledServers` / `disabledServers`
+ * pair: an allowlist registers only matching tools, a denylist registers
+ * everything except matching tools, and when both are set the denylist wins
+ * (deny subtracts from allow).
+ */
+import { logger } from "@oh-my-pi/pi-utils";
+
+/** A tool filter rule set for one server, with the raw advertised tool names. */
+export interface MCPToolFilterInput {
+	/** Raw tool names advertised by the server (from `tools/list`). */
+	toolNames: string[];
+	/** `enabledTools` from the server config, if any. */
+	enabledTools?: readonly string[];
+	/** `disabledTools` from the server config, if any. */
+	disabledTools?: readonly string[];
+}
+
+/** Result of applying a tool filter. */
+export interface MCPToolFilterResult {
+	/** The subset of `toolNames` that passed the filter, in original order. */
+	allowed: string[];
+	/** Config entries that matched no advertised tool name, in config order. */
+	unmatched: string[];
+	/** True when a configured filter excluded every advertised tool; the healthy
+	 * connection's stale tools must be cleared, not kept for transport-failure recovery. */
+	filterEmpty: boolean;
+}
+/**
+ * Translate an fnmatch-style glob pattern (over opaque tool names) into an
+ * anchored `RegExp`. Unlike `Bun.Glob` (filesystem path semantics, where `*`
+ * and `?` do not cross `/`), `*` and `?` here match any character including
+ * `/`, because MCP tool names are opaque strings that may contain slashes.
+ * Supports `*`, `?`, `[...]` (with `[!...]` negation), and non-nested
+ * `{a,b,c}` brace alternation (wildcards inside alternatives are honored).
+ */
+function fnmatchRegex(pattern: string): RegExp {
+	const escapeOutsideClass = (ch: string) => ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const translate = (start: number, end: number): string => {
+		let out = "";
+		let i = start;
+		while (i < end) {
+			const ch = pattern[i];
+			if (ch === "*") {
+				out += ".*";
+				i++;
+			} else if (ch === "?") {
+				out += ".";
+				i++;
+			} else if (ch === "[") {
+				const classStart = i;
+				i++;
+				let cls = "";
+				if (pattern[i] === "!") {
+					cls += "^";
+					i++;
+				}
+				// a leading ] is a literal member
+				if (pattern[i] === "]") {
+					cls += "\\]";
+					i++;
+				}
+				while (i < end && pattern[i] !== "]") {
+					cls += pattern[i] === "\\" ? "\\\\" : pattern[i];
+					i++;
+				}
+				if (i >= end) {
+					// unterminated — treat the literal `[` (and body) as escaped text
+					out += escapeOutsideClass(pattern.slice(classStart, end));
+					i = end;
+				} else {
+					out += `[${cls}]`;
+					i++; // consume ]
+				}
+			} else if (ch === "{") {
+				const close = pattern.indexOf("}", i + 1);
+				if (close === -1 || close >= end || pattern.slice(i + 1, close).includes("{")) {
+					out += "\\{";
+					i++;
+					continue;
+				}
+				// Split the body on top-level commas (commas inside a `[...]` class
+				// don't split). Translate each alternative so wildcards stay active.
+				const parts: string[] = [];
+				let segStart = i + 1;
+				let classDepth = 0;
+				for (let j = i + 1; j < close; j++) {
+					const c = pattern[j];
+					if (c === "[") classDepth++;
+					else if (c === "]" && classDepth > 0) classDepth--;
+					else if (c === "," && classDepth === 0) {
+						parts.push(translate(segStart, j));
+						segStart = j + 1;
+					}
+				}
+				// Expand only real alternation; braces without a comma are literal
+				// (`{delete}` matches `admin_{delete}`, not `admin_delete`).
+				if (parts.length === 0) {
+					out += "\\{";
+					i++;
+				} else {
+					parts.push(translate(segStart, close));
+					out += `(?:${parts.join("|")})`;
+					i = close + 1;
+				}
+			} else {
+				out += escapeOutsideClass(ch);
+				i++;
+			}
+		}
+		return out;
+	};
+	return new RegExp(`^${translate(0, pattern.length)}$`);
+}
+
+/**
+ * Apply a per-server tool filter.
+ *
+ * Literal entries match exactly; entries containing glob metacharacters
+ * (`*`, `?`, `[...]`, `{...}`) are matched with fnmatch semantics where
+ * `*` and `?` cross `/` — MCP tool names are opaque strings, not paths, so a
+ * denylist entry like `*` must match a tool named `admin/delete`. Denylist
+ * entries subtract from the allowlist when both are set.
+ */
+export function filterMCPTools(input: MCPToolFilterInput): MCPToolFilterResult {
+	const { toolNames, enabledTools, disabledTools } = input;
+	const filterConfigured = Boolean(enabledTools?.length || disabledTools?.length);
+	if (!filterConfigured) {
+		return { allowed: [...toolNames], unmatched: [], filterEmpty: false };
+	}
+
+	const matches = (name: string, pattern: string): boolean => {
+		if (pattern === name) return true;
+		if (!/[*?[\]{}]/.test(pattern)) return false;
+		try {
+			return fnmatchRegex(pattern).test(name);
+		} catch {
+			return false;
+		}
+	};
+
+	let allowed: string[];
+	let unmatched: string[];
+
+	if (enabledTools?.length) {
+		allowed = toolNames.filter(name => enabledTools.some(pattern => matches(name, pattern)));
+		unmatched = enabledTools.filter(pattern => !toolNames.some(name => matches(name, pattern)));
+	} else {
+		allowed = [...toolNames];
+		unmatched = [];
+	}
+
+	if (disabledTools?.length) {
+		allowed = allowed.filter(name => !disabledTools.some(pattern => matches(name, pattern)));
+		unmatched = [...unmatched, ...disabledTools.filter(pattern => !toolNames.some(name => matches(name, pattern)))];
+	}
+
+	return { allowed, unmatched, filterEmpty: allowed.length === 0 && toolNames.length > 0 };
+}
+
+/**
+ * Apply a per-server tool filter and surface diagnostics.
+ *
+ * Unknown entries (patterns matching no advertised tool) are warned about —
+ * a typo is a config bug, but a server renaming tools upstream must degrade
+ * to "filter ignored" rather than disabling an otherwise usable server.
+ *
+ * Never throws: an all-excluding filter logs once and returns `[]`, so callers
+ * clear stale tools instead of treating a healthy connection as a failure.
+ */
+export function applyMCPToolFilter(serverName: string, input: MCPToolFilterInput): string[] {
+	const { allowed, unmatched, filterEmpty } = filterMCPTools(input);
+	const { toolNames, enabledTools, disabledTools } = input;
+
+	if (unmatched.length > 0) {
+		logger.warn(`MCP server "${serverName}": tool filter entries matched no advertised tool; ignoring them`, {
+			path: `mcp:${serverName}`,
+			unmatched,
+			advertised: toolNames,
+		});
+	}
+
+	if (filterEmpty) {
+		logger.error(
+			`MCP server "${serverName}": tool filter (enabledTools=${JSON.stringify(enabledTools)}, disabledTools=${JSON.stringify(disabledTools)}) excludes all ${toolNames.length} advertised tools; the server would contribute nothing to the session. Remove the filter or widen it.`,
+			{ path: `mcp:${serverName}` },
+		);
+		return [];
+	}
+
+	return allowed;
+}

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -82,6 +82,14 @@ interface MCPServerConfigBase {
 	requestIdFormat?: MCPRequestIdFormat;
 	/** Authentication configuration (optional) */
 	auth?: MCPAuthConfig;
+	/**
+	 * Allowlist of raw server-advertised tool names (literal or glob, e.g. `"search"`, `"channel_*"`); excluded tools never consume schema context.
+	 */
+	enabledTools?: string[];
+	/**
+	 * Denylist of raw server-advertised tool names (literal or glob); wins over `enabledTools` when both are set (deny subtracts from allow).
+	 */
+	disabledTools?: string[];
 	/** OAuth configuration for servers requiring explicit client credentials */
 	oauth?: {
 		clientId?: string;

--- a/packages/coding-agent/test/discovery/mcp-json.test.ts
+++ b/packages/coding-agent/test/discovery/mcp-json.test.ts
@@ -125,4 +125,44 @@ describe("standalone mcp.json oauth env expansion", () => {
 		});
 		expect(server?.auth).toBeUndefined();
 	});
+
+	test("parses enabledTools/disabledTools arrays, preserving brace globs", async () => {
+		await fs.writeFile(
+			path.join(tempDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					slack: {
+						url: "https://slack.example.com/mcp",
+						enabledTools: ["search", "{create,delete}_*"],
+						disabledTools: ["schedule_message"],
+					},
+				},
+			}),
+		);
+
+		const [server] = await loadStandaloneMcpConfig(tempDir);
+		expect(server?.enabledTools).toEqual(["search", "{create,delete}_*"]);
+		expect(server?.disabledTools).toEqual(["schedule_message"]);
+	});
+
+	test("ignores non-array enabledTools/disabledTools values", async () => {
+		// The schema mandates arrays; a string is not comma-split so a brace
+		// glob can never be silently broken by CSV parsing.
+		await fs.writeFile(
+			path.join(tempDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					slack: {
+						url: "https://slack.example.com/mcp",
+						enabledTools: "search,read",
+						disabledTools: "{create,delete}_*",
+					},
+				},
+			}),
+		);
+
+		const [server] = await loadStandaloneMcpConfig(tempDir);
+		expect(server?.enabledTools).toBeUndefined();
+		expect(server?.disabledTools).toBeUndefined();
+	});
 });

--- a/packages/coding-agent/test/fixtures/tool-list-change-mcp.ts
+++ b/packages/coding-agent/test/fixtures/tool-list-change-mcp.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env bun
+/**
+ * Test fixture: a minimal stdio MCP server whose advertised tool list CHANGES
+ * between `tools/list` calls — first call serves [alpha, beta], every later
+ * call serves [beta]. Used by `mcp-tool-filter-manager.test.ts` to prove that
+ * when a server's toolset shrinks (a `tools/list_changed` refresh) and the
+ * configured tool filter empties the advertised set, previously-registered
+ * tools are cleared rather than left stale in the session.
+ */
+import * as readline from "node:readline";
+
+export const FIRST_TOOL = "alpha";
+export const SECOND_TOOL = "beta";
+
+type JsonRpcRequest = {
+	jsonrpc: "2.0";
+	id?: string | number;
+	method: string;
+	params?: Record<string, unknown>;
+};
+
+let toolsListCalls = 0;
+
+function buildResult(method: string): Record<string, unknown> {
+	switch (method) {
+		case "initialize":
+			return {
+				protocolVersion: "2025-03-26",
+				serverInfo: { name: "tool-change-fixture", version: "1.0.0" },
+				capabilities: { tools: { listChanged: true } },
+			};
+		case "tools/list":
+			toolsListCalls += 1;
+			if (toolsListCalls === 1) {
+				return {
+					tools: [
+						{ name: FIRST_TOOL, description: "First advertised tool", inputSchema: { type: "object" } },
+						{ name: SECOND_TOOL, description: "Second advertised tool", inputSchema: { type: "object" } },
+					],
+				};
+			}
+			return {
+				tools: [{ name: SECOND_TOOL, description: "Second advertised tool", inputSchema: { type: "object" } }],
+			};
+		default:
+			return {};
+	}
+}
+
+function startServer(): void {
+	const rl = readline.createInterface({ input: process.stdin });
+	rl.on("line", line => {
+		void (async () => {
+			const trimmed = line.trim();
+			if (trimmed.length === 0) return;
+			let msg: JsonRpcRequest;
+			try {
+				msg = JSON.parse(trimmed) as JsonRpcRequest;
+			} catch {
+				return;
+			}
+			if (msg.id === undefined || msg.id === null) return;
+			if (!msg.method) return;
+			const response = { jsonrpc: "2.0" as const, id: msg.id, result: buildResult(msg.method) };
+			process.stdout.write(`${JSON.stringify(response)}\n`);
+		})();
+	});
+	rl.on("close", () => process.exit(0));
+}
+
+if (import.meta.main) {
+	startServer();
+}

--- a/packages/coding-agent/test/mcp-connection-status-events.test.ts
+++ b/packages/coding-agent/test/mcp-connection-status-events.test.ts
@@ -88,4 +88,42 @@ describe("MCPManager connection status events", () => {
 			await manager.disconnectAll();
 		}
 	});
+
+	it("surfaces a filter-empty failure (not connected) when tools/list lands after the startup window", async () => {
+		// A server whose initialize stalls past the 250 ms startup window
+		// resolves in the background continuation. When its filter excludes
+		// every advertised tool, that path must emit a `failed` status (not a
+		// silent `connected` with no tools) so the user sees the per-server error.
+		const manager = new MCPManager(workDir);
+		const events: McpConnectionStatusEvent[] = [];
+		const slowFiltered: MCPServerConfig = {
+			type: "stdio",
+			command: BUN_EXEC,
+			args: [FIXTURE_PATH, "--delay", "400"],
+			enabledTools: ["never_advertised"],
+		};
+
+		try {
+			const result = await manager.connectServers({ slow: slowFiltered }, {}, event => events.push(event));
+			// The synchronous result sees the server still pending (no error set).
+			expect(result.errors.has("slow")).toBe(false);
+			expect(result.connectedServers).not.toContain("slow");
+
+			// Wait for the background continuation to settle.
+			const deadline = Date.now() + 10_000;
+			while (Date.now() < deadline && !events.some(e => e.type === "failed" || e.type === "connected")) {
+				await Bun.sleep(25);
+			}
+
+			const terminal = events.filter(e => e.type === "failed" || e.type === "connected");
+			expect(terminal).toHaveLength(1);
+			expect(terminal[0].type).toBe("failed");
+			if (terminal[0].type === "failed") {
+				expect(terminal[0].serverName).toBe("slow");
+				expect(terminal[0].error).toMatch(/tool filter excludes all 45 advertised tools/);
+			}
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
 });

--- a/packages/coding-agent/test/mcp-tool-filter-manager.test.ts
+++ b/packages/coding-agent/test/mcp-tool-filter-manager.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import type { MCPStdioServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { manyToolName } from "./fixtures/many-tools-mcp";
+import { FIRST_TOOL } from "./fixtures/tool-list-change-mcp";
+
+const FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "many-tools-mcp.ts");
+const CHANGE_FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "tool-list-change-mcp.ts");
+const BUN_EXEC = process.execPath;
+
+// Issue #6299: per-server `enabledTools`/`disabledTools` filter raw advertised
+// tool names before they reach the model context, on EVERY registration path
+// (initial connect, reconnect, refresh) so excluded tools can never be
+// restored into the session. The fixture advertises `tool_aa`..`tool_bs`
+// (45 tools): `tool_a*` matches indices 0-25, `tool_b*` indices 26-44.
+
+function config(tools?: { enabledTools?: string[]; disabledTools?: string[] }) {
+	return {
+		type: "stdio" as const,
+		command: BUN_EXEC,
+		args: [FIXTURE_PATH],
+		...tools,
+	};
+}
+
+/** Tool names currently registered under a server, in `#tools` order. */
+function registeredToolNames(manager: MCPManager): string[] {
+	return manager.getTools().map(tool => tool.mcpToolName ?? "");
+}
+
+/**
+ * `connectServers` returns after a 250ms startup window; a server slower than
+ * that registers its (filtered) tools via a background continuation. Wait for
+ * the expected registration instead of racing it.
+ */
+async function waitForRegistered(manager: MCPManager, expected: string[], timeoutMs = 10_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const names = registeredToolNames(manager);
+		if (names.length === expected.length) {
+			expect(names).toEqual(expected);
+			return;
+		}
+		await Bun.sleep(25);
+	}
+	expect(registeredToolNames(manager)).toEqual(expected);
+}
+
+describe("per-server MCP tool filtering", () => {
+	let workDir: string;
+	let manager: MCPManager;
+
+	beforeEach(async () => {
+		workDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-tool-filter-"));
+		manager = new MCPManager(workDir);
+	});
+
+	afterEach(async () => {
+		await manager.disconnectAll();
+		await fs.rm(workDir, { recursive: true, force: true });
+	});
+
+	it("registers only allowlisted tools (literals and globs) on initial connect", async () => {
+		const result = await manager.connectServers({ many: config({ enabledTools: [manyToolName(0), "tool_b*"] }) }, {});
+		expect(result.errors.size).toBe(0);
+		// `tool_b*` matches tool_ba..tool_bs (indices 26-44); tool_aa sorts first.
+		await waitForRegistered(manager, [
+			manyToolName(0),
+			...Array.from({ length: 19 }, (_, i) => manyToolName(26 + i)),
+		]);
+	});
+
+	it("registers all tools except denylisted ones (denylist subtracts from allow)", async () => {
+		const result = await manager.connectServers(
+			{
+				many: config({
+					enabledTools: ["tool_*"],
+					disabledTools: ["tool_a*", manyToolName(44)],
+				}),
+			},
+			{},
+		);
+		expect(result.errors.size).toBe(0);
+		// All 45 minus tool_aa..tool_az (26) minus tool_bs (1) = 18.
+		await waitForRegistered(
+			manager,
+			Array.from({ length: 18 }, (_, i) => manyToolName(26 + i)),
+		);
+	});
+
+	it("keeps excluded tools out after a reconnect (tools/list_changed path)", async () => {
+		await manager.connectServers({ many: config({ enabledTools: [manyToolName(0)] }) }, {});
+		await waitForRegistered(manager, [manyToolName(0)]);
+
+		// The fixture restarts the tool list identically; a reconnect must not
+		// restore tools the allowlist excludes.
+		await manager.reconnectServer("many");
+		await waitForRegistered(manager, [manyToolName(0)]);
+	});
+
+	it("keeps excluded tools out after a refresh", async () => {
+		await manager.connectServers({ many: config({ enabledTools: [manyToolName(0)] }) }, {});
+		await waitForRegistered(manager, [manyToolName(0)]);
+
+		await manager.refreshServerTools("many");
+		await waitForRegistered(manager, [manyToolName(0)]);
+	});
+
+	it("clears previously-registered tools when a refresh empties the filtered set", async () => {
+		// The fixture advertises [alpha, beta] on the first tools/list and only
+		// [beta] afterwards, and fires tools/list_changed right after
+		// initialize. With enabledTools ["alpha"], the initial connect
+		// registers alpha; the refresh (auto-triggered by list_changed or our
+		// explicit call below) then filters the shrunk set down to nothing, so
+		// alpha must be cleared rather than left stale for the model.
+		const changeConfig: MCPStdioServerConfig = {
+			type: "stdio",
+			command: BUN_EXEC,
+			args: [CHANGE_FIXTURE_PATH],
+			enabledTools: [FIRST_TOOL],
+		};
+		await manager.connectServers({ change: changeConfig }, {});
+		await manager.refreshServerTools("change");
+		await waitForRegistered(manager, []);
+	});
+
+	it("reports a server whose filter excludes every tool without failing the batch", async () => {
+		const result = await manager.connectServers(
+			{ empty: config({ enabledTools: ["never_advertised"] }), many: config() },
+			{},
+		);
+		expect(result.errors.has("empty")).toBe(true);
+		expect(result.errors.get("empty")).toMatch(/excludes all 45 advertised tools/);
+		// The sibling server still connects and contributes its tools.
+		await waitForRegistered(
+			manager,
+			Array.from({ length: 45 }, (_, i) => manyToolName(i)),
+		);
+	});
+});

--- a/packages/coding-agent/test/mcp-tool-filter.test.ts
+++ b/packages/coding-agent/test/mcp-tool-filter.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "bun:test";
+import { applyMCPToolFilter, filterMCPTools } from "@oh-my-pi/pi-coding-agent/mcp/tool-filter";
+import { logger } from "@oh-my-pi/pi-utils";
+
+// `filterMCPTools`/`applyMCPToolFilter` implement the per-server
+// `enabledTools`/`disabledTools` contract from issue #6299: filter before
+// tools reach the model context, fnmatch globs, denylist subtracts from
+// allowlist, unknown entries warn-and-drop, all-excluding filters return no tools.
+
+describe("filterMCPTools", () => {
+	const tools = ["search", "read", "schedule_message", "create_canvas", "channel_read", "channel_write"];
+
+	it("returns every tool unchanged when no filter is configured", () => {
+		expect(filterMCPTools({ toolNames: tools })).toEqual({ allowed: tools, unmatched: [], filterEmpty: false });
+	});
+
+	it("allowlists literal names and glob patterns against raw advertised names", () => {
+		expect(filterMCPTools({ toolNames: tools, enabledTools: ["search", "channel_*"] }).allowed).toEqual([
+			"search",
+			"channel_read",
+			"channel_write",
+		]);
+	});
+
+	it("denylist excludes literal names and glob patterns", () => {
+		expect(filterMCPTools({ toolNames: tools, disabledTools: ["schedule_message", "create_*"] }).allowed).toEqual([
+			"search",
+			"read",
+			"channel_read",
+			"channel_write",
+		]);
+	});
+
+	it("denylist subtracts from the allowlist when both are set", () => {
+		const result = filterMCPTools({
+			toolNames: tools,
+			enabledTools: ["*_*", "search"],
+			disabledTools: ["schedule_*"],
+		});
+		// "search" matches the literal allowlist entry; schedule_* is denied.
+		expect(result.allowed).toEqual(["search", "create_canvas", "channel_read", "channel_write"]);
+	});
+
+	it("reports config entries that matched no advertised tool, keeping config order", () => {
+		const result = filterMCPTools({
+			toolNames: tools,
+			enabledTools: ["search", "typo_tool", "nope_*"],
+			disabledTools: ["missing_*"],
+		});
+		expect(result.allowed).toEqual(["search"]);
+		expect(result.unmatched).toEqual(["typo_tool", "nope_*", "missing_*"]);
+	});
+
+	it("does not treat an unset filter as an allowlist of zero entries", () => {
+		expect(filterMCPTools({ toolNames: tools, enabledTools: [] }).allowed).toEqual(tools);
+		expect(filterMCPTools({ toolNames: tools, disabledTools: [] }).allowed).toEqual(tools);
+	});
+
+	it("matches a tool name even when another entry is an invalid glob", () => {
+		const result = filterMCPTools({ toolNames: ["search"], enabledTools: ["[", "search"] });
+		expect(result.allowed).toEqual(["search"]);
+		expect(result.unmatched).toEqual(["["]);
+	});
+
+	// MCP tool names are opaque strings, not filesystem paths: `*` and `?`
+	// must cross `/` so a denylist like ["*"] cannot leak a tool named "admin/delete".
+	it("globs match `/` in opaque tool names (not path semantics)", () => {
+		const namespaced = ["search", "admin/delete", "admin/create", "a/c"];
+		// denylist `*` removes everything including slash-bearing names
+		expect(filterMCPTools({ toolNames: namespaced, disabledTools: ["*"] }).allowed).toEqual([]);
+		// allowlist `admin*` admits slash-bearing names
+		expect(filterMCPTools({ toolNames: namespaced, enabledTools: ["admin*"] }).allowed).toEqual([
+			"admin/delete",
+			"admin/create",
+		]);
+		// `?` crosses `/`
+		expect(filterMCPTools({ toolNames: namespaced, enabledTools: ["a?c"] }).allowed).toEqual(["a/c"]);
+		// brace alternation and char classes still work
+		expect(filterMCPTools({ toolNames: namespaced, enabledTools: ["{search,admin/*}"] }).allowed).toEqual([
+			"search",
+			"admin/delete",
+			"admin/create",
+		]);
+	});
+
+	it("braces without a comma are literal, not regex groups", () => {
+		// `{delete}` has no comma, so it must NOT become a regex group `(?:delete)`
+		// that matches `admin_delete`. It should match the literal `admin_{delete}`.
+		expect(
+			filterMCPTools({
+				toolNames: ["admin_{delete}", "admin_delete"],
+				enabledTools: ["admin_{delete}"],
+			}).allowed,
+		).toEqual(["admin_{delete}"]);
+	});
+});
+
+describe("applyMCPToolFilter", () => {
+	it("warns about unknown entries but keeps the server usable", () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const allowed = applyMCPToolFilter("slack", {
+				toolNames: ["search", "read"],
+				enabledTools: ["search", "renamed_tool"],
+			});
+			expect(allowed).toEqual(["search"]);
+			expect(warn).toHaveBeenCalled();
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("does not warn when every filter entry matches", () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const allowed = applyMCPToolFilter("slack", {
+				toolNames: ["search", "read"],
+				enabledTools: ["search", "read"],
+			});
+			expect(allowed).toEqual(["search", "read"]);
+			expect(warn).not.toHaveBeenCalled();
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("returns [] without throwing when the filter excludes every advertised tool", () => {
+		const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+		try {
+			expect(applyMCPToolFilter("slack", { toolNames: ["search"], enabledTools: ["read"] })).toEqual([]);
+			expect(applyMCPToolFilter("slack", { toolNames: ["search", "read"], disabledTools: ["*"] })).toEqual([]);
+		} finally {
+			error.mockRestore();
+		}
+	});
+
+	it("marks the result filter-empty when a configured filter excludes every tool", () => {
+		expect(filterMCPTools({ toolNames: ["search"], enabledTools: ["read"] }).filterEmpty).toBe(true);
+		expect(filterMCPTools({ toolNames: ["search", "read"], disabledTools: ["*"] }).filterEmpty).toBe(true);
+	});
+
+	it("is not filter-empty when no filter is configured or some tools pass", () => {
+		expect(filterMCPTools({ toolNames: ["search", "read"] }).filterEmpty).toBe(false);
+		expect(filterMCPTools({ toolNames: ["search", "read"], enabledTools: ["search"] }).filterEmpty).toBe(false);
+		expect(
+			filterMCPTools({ toolNames: ["search", "read"], enabledTools: ["*"], disabledTools: ["read"] }).filterEmpty,
+		).toBe(false);
+	});
+
+	it("is not filter-empty for a zero-tool server even with a filter configured", () => {
+		expect(filterMCPTools({ toolNames: [], enabledTools: ["search"] }).filterEmpty).toBe(false);
+		expect(filterMCPTools({ toolNames: [], disabledTools: ["*"] }).filterEmpty).toBe(false);
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+		try {
+			expect(applyMCPToolFilter("slack", { toolNames: [], enabledTools: ["search"] })).toEqual([]);
+			// entries match no advertised tool, so the warn fires — but the
+			// error message must never claim a filter excluded 0 tools
+			expect(warn).toHaveBeenCalled();
+			expect(error).not.toHaveBeenCalled();
+		} finally {
+			warn.mockRestore();
+			error.mockRestore();
+		}
+	});
+
+	it("returns all tools without warnings when no filter is configured", () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			expect(applyMCPToolFilter("slack", { toolNames: ["search", "read"] })).toEqual(["search", "read"]);
+			expect(warn).not.toHaveBeenCalled();
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("passes a server that advertises no tools through unchanged when no filter is configured", () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			expect(applyMCPToolFilter("slack", { toolNames: [] })).toEqual([]);
+			expect(warn).not.toHaveBeenCalled();
+		} finally {
+			warn.mockRestore();
+		}
+	});
+});

--- a/packages/coding-agent/test/mcp/config-request-id-format.test.ts
+++ b/packages/coding-agent/test/mcp/config-request-id-format.test.ts
@@ -121,3 +121,27 @@ test('an explicit "number" is the default, so dedup collapses it with an unset a
 	// same connection and only one survives.
 	expect(Object.keys(configs)).toHaveLength(1);
 });
+
+test("differing enabledTools prevents equivalence dedup from collapsing two aliases", async () => {
+	const configs = await loadFrom(path.join(".omp", "mcp.json"), {
+		"fs-read": { type: "stdio", command: "/usr/bin/fs-mcp", enabledTools: ["read_file"] },
+		"fs-write": { type: "stdio", command: "/usr/bin/fs-mcp", enabledTools: ["write_file"] },
+	});
+
+	// Same command but different tool filters — both must survive so each
+	// filter subset reaches the model context. If dedup collapsed them, one
+	// server's selected tools would never be registered.
+	expect(Object.keys(configs).sort()).toEqual(["fs-read", "fs-write"]);
+	expect(configs["fs-read"]?.enabledTools).toEqual(["read_file"]);
+	expect(configs["fs-write"]?.enabledTools).toEqual(["write_file"]);
+});
+
+test("matching enabledTools and disabledTools still allows dedup to collapse aliases", async () => {
+	const configs = await loadFrom(path.join(".omp", "mcp.json"), {
+		"fs-a": { type: "stdio", command: "/usr/bin/fs-mcp", enabledTools: ["read_file"], disabledTools: ["dangerous"] },
+		"fs-b": { type: "stdio", command: "/usr/bin/fs-mcp", enabledTools: ["read_file"], disabledTools: ["dangerous"] },
+	});
+
+	// Identical transport AND identical filters → same connection, only one survives.
+	expect(Object.keys(configs)).toHaveLength(1);
+});


### PR DESCRIPTION
## What

Adds per-server, tool-level filtering to MCP server configs: `enabledTools` / `disabledTools`. A server now contributes only the chosen subset of its advertised tools to the model context — persistently, across every session.

```jsonc
{
  "mcpServers": {
    "slack": {
      "type": "http",
      "url": "https://mcp.slack.com/mcp",
      "enabledTools": ["search", "read", "channel_*"],
      "disabledTools": ["schedule_message", "create_*"]
    }
  }
}
```

## Why — context pollution

Many hosted MCP servers expose large toolsets where a user only needs a couple of tools. The hosted Slack server advertises ~40 tools (canvas, schedule, reactions, drafts, member listing, …); a user who only does `search` + `read` still pays the full ~40-schema context cost **on every turn of every session**. Today the only lever is all-or-nothing at the server level (`disabledServers` / `enabled: false`) — "40 tools" or "0 tools".

A tool-level filter keeps a heavy server available at a fraction of its context footprint — directly the "keep the tools you use, drop the rest" reduction.

Competition status (field naming and semantics deliberately aligned with the family of harnesses that already ship this):

| Harness | Syntax | Notes |
|---|---|---|
| **OMP (this PR)** | per-server `enabledTools` / `disabledTools`, fnmatch globs | deny subtracts from allow; unknown entries warn-and-drop; empty result errors |
| LangChain | `allowedTools` / `disabledTools`, fnmatch globs | only harness with globs until now |
| Qwen Code / Gemini CLI | per-server `includeTools` / `excludeTools`, exact names | no globs |
| Roo / Windsurf / Antigravity | `enabledTools` / `disabledTools` | family naming |
| Copilot CLI | per-server `"tools": ["*"]` / literal names | no globs beyond `*` |
| Claude Code | no per-server config filter | `permissions.deny` with `mcp__server__*` globs only |
| OpenCode | `tools` map `"mcp__server__*": false` | wildcard visibility map |
| Cline / Cursor | not shipped | open requests |

`enabledTools`/`disabledTools` matches the issue title, the Roo/Cline family, and OMP's existing `enabledServers`/`disabledServers` pair — one vocabulary across server and tool levels. Globs close the flexibility gap only LangChain had.

## Semantics

- Entries are matched against **raw server-advertised tool names** (from `tools/list`), not the `mcp__server_`-prefixed session names — a server rename never silently breaks the filter, and a filter survives name-sanitization collisions.
- Literal entries match exactly; entries with glob metacharacters (`*`, `?`, `[...]`, `{...}`) use fnmatch semantics via `Bun.Glob`.
- Both set → `disabledTools` wins (deny subtracts from allow), mirroring the server level where `disabledServers` beats `enabledServers`.
- Unknown entries (matching no advertised tool) are warned about and ignored — a typo is loud, but an upstream tool rename degrades to "filter ignored" instead of disabling an otherwise usable server.
- A filter that excludes every advertised tool is reported as an error for that server without failing the whole discovery batch: on initial connect the server stays connected but contributes no tools, and on refresh/reconnect any previously-registered tools are cleared (the healthy connection is kept, so `tools/list_changed` can never leave a stale, now-filtered tool visible to the model).
- The filter applies on **every registration path**: initial connect, reconnect, `tools/list_changed` refresh, and the deferred cached-tool fallback — excluded tools can never be restored into the session.
- OMP-specific fields, read from OMP-owned config sources (`.omp/mcp.json`, `~/.omp/agent/mcp.json`, root `mcp.json`/`.mcp.json`, OMP plugins) following the existing `requestIdFormat` scoping convention; configs translated from other tools' formats ignore them.

## Implementation

- `src/mcp/tool-filter.ts` — new `filterMCPTools` / `applyMCPToolFilter` helpers (pure, unit-tested).
- `src/mcp/types.ts` — `enabledTools` / `disabledTools` on `MCPServerConfigBase`.
- `src/mcp/tool-bridge.ts` — `MCPTool.fromTools` and `DeferredMCPTool.fromTools` apply the filter at registration.
- `src/mcp/manager.ts` — deferred fallback passes config through; per-server filter errors are isolated per server.
- Discovery: `capability/mcp.ts` canonical type + native / standalone `mcp-json` / OMP-plugins providers parse the fields.
- `config/mcp-schema.json`, docs (`mcp-config.md`, `mcp-server-tool-authoring.md`), CHANGELOG.

## Tests

- `test/mcp-tool-filter.test.ts` — unit: allowlist, denylist, deny-subtracts-from-allow, unmatched reporting, invalid-glob resilience, zero-tool passthrough, warn/error diagnostics.
- `test/mcp-tool-filter-manager.test.ts` — integration against the real `many-tools-mcp` fixture (45 tools): initial connect, reconnect, refresh, and all-filtered error isolation.

## Notes

- Reuses the vocabulary reserved for the deferred per-tool CLI granularity of #5589 — config and a future `--mcp=X:a:b` will share the same tool-scoping terms.
- Follows the issue's roboomp suggestion (warn on unknowns, not hard error) with one deviation, per maintainer-adjacent precedent: the issue suggested rejecting simultaneous `enabledTools` + `disabledTools`; OMP's server level already resolves `disabledServers` > `enabledServers`, and LangChain/Qwen both let deny subtract from allow — so this PR makes the denylist win instead of rejecting the config.

Closes #6299