### PR TITLE
fix(mnemopi): preserve proper-place capitalization

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed episodic gist extraction treating lowercase prose after `at`, `in`, or `from` as a proper location by preserving the capitalization check. ([#7917](https://github.com/can1357/oh-my-pi/issues/7917))
+
 ## [17.2.11] - 2026-08-07
 
 ### Fixed

--- a/packages/mnemopi/src/core/episodic-graph.ts
+++ b/packages/mnemopi/src/core/episodic-graph.ts
@@ -590,7 +590,7 @@ export class EpisodicGraph {
 
 	private extractLocation(content: string): string | null {
 		const properPlace =
-			/\b(?:at|in|from)\s+([A-Z][a-zA-Z\s]+?)(?:\s+(?:yesterday|today|tomorrow|now|last|next|on|at)\b|$)/i.exec(
+			/\b(?:at|in|from)\s+([A-Z][a-zA-Z\s]+?)(?:\s+(?:yesterday|today|tomorrow|now|last|next|on|at)\b|$)/.exec(
 				content,
 			);
 		if (properPlace?.[1] !== undefined) return properPlace[1].trim();

--- a/packages/mnemopi/test/graph-tools.test.ts
+++ b/packages/mnemopi/test/graph-tools.test.ts
@@ -48,6 +48,23 @@ describe("EpisodicGraph CRUD", () => {
 			});
 		});
 	});
+	it("requires capitalization for proper-place extraction", () => {
+		withGraph(graph => {
+			expect(
+				graph.extractGist("The agent should reason in your loaded context plus before lunch", "lowercase").location,
+			).toBeNull();
+			expect(
+				graph.extractGist("The agent should reason at your loaded context plus before lunch", "lowercase-at")
+					.location,
+			).toBeNull();
+			expect(
+				graph.extractGist("The agent should reason from your loaded context plus before lunch", "lowercase-from")
+					.location,
+			).toBeNull();
+			expect(graph.extractGist("Alice waited at the office.", "generic").location).toBe("office");
+			expect(graph.extractGist("Alice arrived in Paris yesterday.", "proper").location).toBe("Paris");
+		});
+	});
 });
 
 describe("EpisodicGraph links and traversal", () => {


### PR DESCRIPTION
## What

Preserve capitalization when extracting proper-place names from episodic gists and add regression coverage for lowercase prose after `at`, `in`, and `from`.

## Why

Fixes #7917. The extractor's case-insensitive flag made ordinary lowercase prose look like a proper location.

## Testing

- `bun test packages/mnemopi/test/graph-tools.test.ts` — 6 pass, 0 fail
- `bun --cwd=packages/mnemopi run check` — passed
- Full repository `bun test` was attempted; unrelated baseline failures remain in `scripts/fix-changelogs.test.ts` and `scripts/musl-release.test.ts` (neither file is changed here).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
