### PR TITLE
fix(coding-agent): preserve ArkType command API compatibility

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed custom commands losing the documented `api.arktype.type(...)` compatibility surface while retaining the callable `api.arktype(...)` builder. ([#7968](https://github.com/can1357/oh-my-pi/issues/7968))
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/extensibility/custom-commands/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/loader.ts
@@ -10,6 +10,7 @@ import { type } from "@oh-my-pi/omptype";
 import * as zod from "@oh-my-pi/omptype/zod";
 import { getAgentDir, getProjectDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import { getConfigDirs } from "../../config";
+
 import { execCommand } from "../../exec/exec";
 // Runtime self-reference: dereference this namespace only inside loader functions to keep the index.ts cycle safe.
 import * as PiCodingAgent from "../../index";
@@ -24,6 +25,8 @@ import type {
 	CustomCommandsLoadResult,
 	LoadedCustomCommand,
 } from "./types";
+
+const arktype = Object.assign(type, { type });
 
 /**
  * Load a single command module using native Bun import.
@@ -187,7 +190,7 @@ export async function loadCustomCommands(options: LoadCustomCommandsOptions = {}
 		exec: (command: string, args: string[], execOptions) =>
 			execCommand(command, args, execOptions?.cwd ?? cwd, execOptions),
 		typebox,
-		arktype: type,
+		arktype,
 		zod,
 		pi: PiCodingAgent,
 	};

--- a/packages/coding-agent/src/extensibility/custom-commands/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/types.ts
@@ -26,7 +26,7 @@ export interface CustomCommandAPI {
 	/** Injected TypeBox shim (legacy/compat). */
 	typebox: typeof TypeBox;
 	/** Injected omptype schema builder for custom commands. */
-	arktype: typeof ArkType;
+	arktype: typeof ArkType & { type: typeof ArkType };
 	/** Injected Zod-compatible omptype builder for custom commands. */
 	zod: typeof zod;
 	/** Injected pi-coding-agent exports */

--- a/packages/coding-agent/test/extensibility/custom-commands/ci-green.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/ci-green.test.ts
@@ -22,7 +22,7 @@ function createApi(): CustomCommandAPI {
 			killed: false,
 		}),
 		typebox: {} as unknown as typeof TypeBox,
-		arktype: type,
+		arktype: Object.assign(type, { type }),
 		zod,
 		pi: piCodingAgent,
 	};

--- a/packages/coding-agent/test/extensibility/custom-commands/loader.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/loader.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadCustomCommands } from "../../../src/extensibility/custom-commands/loader";
+
+let tempRoot: string | undefined;
+
+afterEach(async () => {
+	if (tempRoot) {
+		await fs.rm(tempRoot, { recursive: true, force: true });
+		tempRoot = undefined;
+	}
+});
+
+describe("custom command loader", () => {
+	it("supports legacy and callable ArkType injection", async () => {
+		tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-custom-command-loader-"));
+		const commandDir = path.join(tempRoot, "commands", "arktype-compat");
+		await fs.mkdir(commandDir, { recursive: true });
+		const commandPath = path.join(commandDir, "index.js");
+		await Bun.write(
+			commandPath,
+			[
+				"export default api => {",
+				'\tconst legacy = api.arktype.type("string");',
+				'\tconst current = api.arktype("string");',
+				'\tif (legacy("ok") !== "ok" || current("ok") !== "ok") throw new Error("ArkType schema failed");',
+				"\treturn {",
+				'\t\tname: "arktype-compat",',
+				'\t\tdescription: "Checks both ArkType injection forms",',
+				"\t\texecute() {},",
+				"\t};",
+				"};",
+			].join("\n"),
+		);
+
+		const result = await loadCustomCommands({ cwd: tempRoot, agentDir: tempRoot });
+
+		expect(result.errors.find(error => error.path === commandPath)).toBeUndefined();
+		expect(result.commands.map(({ command }) => command.name)).toContain("arktype-compat");
+	});
+});


### PR DESCRIPTION
## What

Restore the documented `api.arktype.type(...)` compatibility surface while retaining callable `api.arktype(...)` custom-command schemas, with a real loader regression test covering both forms.

## Why

Fixes #7968. Custom commands using the legacy ArkType namespace form failed at load time after the callable builder was injected directly.

## Testing

- `bun test packages/coding-agent/test/extensibility/custom-commands/loader.test.ts packages/coding-agent/test/extensibility/custom-commands/ci-green.test.ts` — 3 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — passed
- Full repository `bun test` was attempted; unrelated baseline failures remain in `scripts/fix-changelogs.test.ts` and `scripts/musl-release.test.ts` (neither file is changed here).

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
