### PR TITLE
fix(tui): keep pasted images when a mode command submits the draft

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved extension-filtered pasted image payloads and source links when `/goal`, `/plan`, or `/vibe` submits the composer draft.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1242,13 +1242,14 @@ export class ExtensionRunner {
 					| InputEventResult
 					| undefined;
 				if (result?.handled) return result;
-				if (result?.text !== undefined) {
-					currentText = result.text;
-					currentImages = result.images ?? currentImages;
-				}
+				if (result?.text !== undefined) currentText = result.text;
+				if (result?.images !== undefined) currentImages = result.images;
 			}
 		}
-		return currentText !== text || currentImages !== images ? { text: currentText, images: currentImages } : {};
+		const transformed: InputEventResult = {};
+		if (currentText !== text) transformed.text = currentText;
+		if (currentImages !== images) transformed.images = currentImages;
+		return transformed;
 	}
 
 	async emitContext(messages: AgentMessage[]): Promise<AgentMessage[]> {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -23,6 +23,7 @@ import type { InteractiveModeContext } from "../../modes/types";
 import manualContinuePrompt from "../../prompts/system/manual-continue.md" with { type: "text" };
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
+import { parseSlashCommand } from "../../slash-commands/helpers/parse";
 import { isTinyTitleLocalModelKey } from "../../tiny/models";
 import { tinyTitleClient } from "../../tiny/title-client";
 import type { TinyTitleProgressEvent } from "../../tiny/title-protocol";
@@ -678,11 +679,14 @@ export class InputController {
 			let inputImageLinks =
 				this.ctx.editor.pendingImageLinks.length > 0 ? [...this.ctx.editor.pendingImageLinks] : undefined;
 			let hasInputImages = (inputImages?.length ?? 0) > 0;
+			const submittedMode = parseSlashCommand(text)?.name;
+			const draftDetached = submittedMode === "plan" || submittedMode === "vibe" || submittedMode === "goal";
+			if (draftDetached) this.ctx.editor.clearDraft();
 
 			if (runner?.hasHandlers("input")) {
 				const result = await runner.emitInput(text, inputImages, "interactive");
 				if (result?.handled) {
-					this.ctx.editor.clearDraft();
+					if (!draftDetached) this.ctx.editor.clearDraft();
 					return;
 				}
 				if (result?.text !== undefined) {
@@ -716,7 +720,7 @@ export class InputController {
 					(inputImages?.length ?? 0) > 0 || (inputImageLinks?.length ?? 0) > 0
 						? { images: inputImages, imageLinks: inputImageLinks }
 						: undefined;
-				const slashResult = await executeBuiltinSlashCommand(text, { ctx: this.ctx, input });
+				const slashResult = await executeBuiltinSlashCommand(text, { ctx: this.ctx, input, draftDetached });
 				if (slashResult === true) {
 					if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
 					return;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -679,14 +679,12 @@ export class InputController {
 			let inputImageLinks =
 				this.ctx.editor.pendingImageLinks.length > 0 ? [...this.ctx.editor.pendingImageLinks] : undefined;
 			let hasInputImages = (inputImages?.length ?? 0) > 0;
-			const submittedMode = parseSlashCommand(text)?.name;
-			const draftDetached = submittedMode === "plan" || submittedMode === "vibe" || submittedMode === "goal";
-			if (draftDetached) this.ctx.editor.clearDraft();
+			const submittedImages = inputImages;
 
 			if (runner?.hasHandlers("input")) {
 				const result = await runner.emitInput(text, inputImages, "interactive");
 				if (result?.handled) {
-					if (!draftDetached) this.ctx.editor.clearDraft();
+					this.ctx.editor.clearDraft();
 					return;
 				}
 				if (result?.text !== undefined) {
@@ -700,6 +698,22 @@ export class InputController {
 					);
 				}
 				hasInputImages = (inputImages?.length ?? 0) > 0;
+			}
+			const submittedMode = parseSlashCommand(text)?.name;
+			const draftDetached =
+				submittedMode === "plan" ||
+				submittedMode === "vibe" ||
+				submittedMode === "goal" ||
+				submittedMode === "guided-goal";
+			if (
+				draftDetached &&
+				submittedImages?.length &&
+				submittedImages.every((image, index) => this.ctx.editor.pendingImages[index] === image)
+			) {
+				this.ctx.editor.pendingImages.splice(0, submittedImages.length);
+				this.ctx.editor.pendingImageLinks.splice(0, submittedImages.length);
+				this.ctx.editor.imageLinks =
+					this.ctx.editor.pendingImageLinks.length > 0 ? this.ctx.editor.pendingImageLinks : undefined;
 			}
 
 			if (!text && !hasInputImages) return;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -712,9 +712,11 @@ export class InputController {
 
 			// Handle built-in slash commands
 			if (text) {
-				const slashResult = await executeBuiltinSlashCommand(text, {
-					ctx: this.ctx,
-				});
+				const input =
+					(inputImages?.length ?? 0) > 0 || (inputImageLinks?.length ?? 0) > 0
+						? { images: inputImages, imageLinks: inputImageLinks }
+						: undefined;
+				const slashResult = await executeBuiltinSlashCommand(text, { ctx: this.ctx, input });
 				if (slashResult === true) {
 					if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
 					return;
@@ -1330,9 +1332,8 @@ export class InputController {
 		}
 
 		if (text) {
-			const slashResult = await executeBuiltinSlashCommand(text, {
-				ctx: this.ctx,
-			});
+			const input = (images?.length ?? 0) > 0 || (imageLinks?.length ?? 0) > 0 ? { images, imageLinks } : undefined;
+			const slashResult = await executeBuiltinSlashCommand(text, { ctx: this.ctx, input });
 			if (slashResult === true) {
 				if (!shouldSkipHistory(text)) this.ctx.editor.addToHistory(text);
 				return;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3501,6 +3501,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			await this.#startGoalFromObjective(objective, input);
 		} catch (error) {
 			this.showError(error instanceof Error ? error.message : String(error));
+			throw error;
 		}
 	}
 	async handleGuidedGoalCommand(rest?: string): Promise<void> {
@@ -3695,7 +3696,16 @@ export class InteractiveMode implements InteractiveModeContext {
 	): Promise<void> {
 		await this.#enterGoalMode({ objective, silent: true });
 		this.#resetGoalContinuationSuppression();
-		if (!this.session.isStreaming && this.onInputCallback) {
+		if (this.session.isStreaming) {
+			const images = input?.images?.length ? input.images : undefined;
+			await this.withLocalSubmission(
+				objective,
+				() => this.session.prompt(objective, { streamingBehavior: "steer", images }),
+				{ imageCount: images?.length ?? 0 },
+			);
+			return;
+		}
+		if (this.onInputCallback) {
 			this.onInputCallback(this.startPendingSubmission({ text: objective, ...input }, { preserveDraft: true }));
 		}
 	}
@@ -3712,8 +3722,15 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#updateGoalModeStatus();
 		if (this.session.isStreaming) {
 			await this.session.sendGoalModeContext({ deliverAs: "steer" });
+			const images = input?.images?.length ? input.images : undefined;
+			await this.withLocalSubmission(
+				objective,
+				() => this.session.prompt(objective, { streamingBehavior: "steer", images }),
+				{ imageCount: images?.length ?? 0 },
+			);
+			return;
 		}
-		if (!this.session.isStreaming && this.onInputCallback) {
+		if (this.onInputCallback) {
 			this.onInputCallback(this.startPendingSubmission({ text: objective, ...input }, { preserveDraft: true }));
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3295,14 +3295,14 @@ export class InteractiveMode implements InteractiveModeContext {
 	async handlePlanModeCommand(
 		initialPrompt?: string,
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
-	): Promise<void> {
+	): Promise<boolean> {
 		if (this.goalModeEnabled || this.goalModePaused) {
 			this.showWarning("Exit goal mode first.");
-			return;
+			return false;
 		}
 		if (this.vibeModeEnabled) {
 			this.showWarning("Exit vibe mode first.");
-			return;
+			return false;
 		}
 		if (this.planModeEnabled) {
 			const planFilePath = this.planModePlanFilePath ?? (await this.#getPlanFilePath());
@@ -3311,10 +3311,10 @@ export class InteractiveMode implements InteractiveModeContext {
 					"Exit plan mode?",
 					"This exits plan mode without approving a plan.",
 				);
-				if (!confirmed) return;
+				if (!confirmed) return false;
 			}
 			await this.#exitPlanMode({ paused: true });
-			return;
+			return false;
 		}
 		if (this.planModePaused && !initialPrompt) {
 			// No-arg third toggle: paused → off. Tools, model, and plan state were
@@ -3327,16 +3327,28 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#updatePlanModeStatus();
 			this.sessionManager.appendModeChange("none");
 			this.showStatus("Plan mode disabled.");
-			return;
+			return false;
 		}
 		if (!this.session.settings.get("plan.enabled")) {
 			this.showWarning("Plan mode is disabled. Enable it in settings (plan.enabled).");
-			return;
+			return false;
 		}
 		await this.#enterPlanMode();
-		if (initialPrompt && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt, ...input }, { preserveDraft: true }));
+		if (!initialPrompt) return false;
+		if (this.session.isStreaming) {
+			const images = input?.images?.length ? input.images : undefined;
+			await this.withLocalSubmission(
+				initialPrompt,
+				() => this.session.prompt(initialPrompt, { streamingBehavior: "steer", images }),
+				{ imageCount: images?.length ?? 0 },
+			);
+			return true;
 		}
+		if (this.onInputCallback) {
+			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt, ...input }, { preserveDraft: true }));
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -3349,23 +3361,35 @@ export class InteractiveMode implements InteractiveModeContext {
 	async handleVibeModeCommand(
 		initialPrompt?: string,
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
-	): Promise<void> {
+	): Promise<boolean> {
 		if (this.vibeModeEnabled) {
 			await this.#exitVibeMode();
-			return;
+			return false;
 		}
 		if (this.planModeEnabled || this.planModePaused) {
 			this.showWarning("Exit plan mode first.");
-			return;
+			return false;
 		}
 		if (this.goalModeEnabled || this.goalModePaused) {
 			this.showWarning("Exit goal mode first.");
-			return;
+			return false;
 		}
 		await this.#enterVibeMode();
-		if (initialPrompt && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt, ...input }, { preserveDraft: true }));
+		if (!initialPrompt) return false;
+		if (this.session.isStreaming) {
+			const images = input?.images?.length ? input.images : undefined;
+			await this.withLocalSubmission(
+				initialPrompt,
+				() => this.session.prompt(initialPrompt, { streamingBehavior: "steer", images }),
+				{ imageCount: images?.length ?? 0 },
+			);
+			return true;
 		}
+		if (this.onInputCallback) {
+			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt, ...input }, { preserveDraft: true }));
+			return true;
+		}
+		return false;
 	}
 
 	async #enterVibeMode(options?: { persistModeChange?: boolean }): Promise<void> {
@@ -3454,77 +3478,73 @@ export class InteractiveMode implements InteractiveModeContext {
 	async handleGoalModeCommand(
 		rest?: string,
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
-	): Promise<void> {
+	): Promise<boolean> {
 		try {
 			if (this.planModeEnabled || this.planModePaused) {
 				this.showWarning("Exit plan mode first.");
-				return;
+				return false;
 			}
 			if (this.vibeModeEnabled) {
 				this.showWarning("Exit vibe mode first.");
-				return;
+				return false;
 			}
 			if (!this.session.settings.get("goal.enabled")) {
 				this.showWarning("Goal mode is disabled. Enable it in settings (goal.enabled).");
-				return;
+				return false;
 			}
 			const { sub, rest: subRest } = parseGoalSubcommand(rest ?? "");
-			if (sub) {
-				await this.#dispatchGoalSubcommand(sub, subRest, input);
-				return;
-			}
+			if (sub) return await this.#dispatchGoalSubcommand(sub, subRest, input);
 			if (this.goalModeEnabled) {
 				if (subRest) {
 					this.showStatus("Goal mode is already active. Use /goal to manage it, or /goal drop to start over.");
-					return;
+					return false;
 				}
 				await this.#openGoalMenu("active");
-				return;
+				return false;
 			}
 			const pausedState = this.#getPausedGoalState();
 			if (pausedState) {
 				if (subRest) {
 					this.showWarning("Resume the current goal first, or drop it before setting a new objective.");
-					return;
+					return false;
 				}
 				await this.#openGoalMenu("paused");
-				return;
+				return false;
 			}
-			if (subRest) {
-				await this.#startGoalFromObjective(subRest, input);
-				return;
-			}
+			if (subRest) return await this.#startGoalFromObjective(subRest, input);
 			const objective = (
 				await this.showHookEditor("Goal objective", undefined, undefined, { promptStyle: true })
 			)?.trim();
-			if (!objective) return;
-			await this.#startGoalFromObjective(objective, input);
+			if (!objective) return false;
+			return await this.#startGoalFromObjective(objective, input);
 		} catch (error) {
-			this.showError(error instanceof Error ? error.message : String(error));
 			throw error;
 		}
 	}
-	async handleGuidedGoalCommand(rest?: string): Promise<void> {
+	async handleGuidedGoalCommand(
+		rest?: string,
+		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
+	): Promise<boolean> {
 		try {
 			if (this.planModeEnabled || this.planModePaused) {
 				this.showWarning("Exit plan mode first.");
-				return;
+				return false;
 			}
 			if (this.vibeModeEnabled) {
 				this.showWarning("Exit vibe mode first.");
-				return;
+				return false;
 			}
 			if (!this.session.settings.get("goal.enabled")) {
 				this.showWarning("Goal mode is disabled. Enable it in settings (goal.enabled).");
-				return;
+				return false;
 			}
 			if (this.goalModeEnabled) {
 				this.showStatus("Goal mode is already active. Use /goal to manage it, or /goal drop to start over.");
-				return;
+				return false;
 			}
 			if (this.#getPausedGoalState()) {
 				this.showWarning("Resume the current goal first, or drop it before setting a new objective.");
-				return;
+				return false;
 			}
 
 			// Expose the goal tool for the interview so the agent can finish by
@@ -3542,18 +3562,21 @@ export class InteractiveMode implements InteractiveModeContext {
 			// assistant turns, and the user answers in the ordinary editor. Queue
 			// behind an in-flight run instead of aborting it.
 			const kickoff = prompt.render(guidedGoalInterviewPrompt, { initial: rest?.trim() || undefined });
+			const images = input?.images?.length ? input.images : undefined;
 			if (this.session.isStreaming) {
-				await this.session.followUp(kickoff, undefined, { synthetic: true });
+				await this.session.followUp(kickoff, images, { synthetic: true });
 			} else {
 				try {
-					await this.session.prompt(kickoff, { synthetic: true });
+					await this.session.prompt(kickoff, images ? { synthetic: true, images } : { synthetic: true });
 				} catch (error) {
 					if (!(error instanceof AgentBusyError)) throw error;
-					await this.session.followUp(kickoff, undefined, { synthetic: true });
+					await this.session.followUp(kickoff, images, { synthetic: true });
 				}
 			}
+			return true;
 		} catch (error) {
 			this.showError(error instanceof Error ? error.message : String(error));
+			return false;
 		}
 	}
 
@@ -3561,36 +3584,35 @@ export class InteractiveMode implements InteractiveModeContext {
 		sub: GoalSubcommand,
 		rest: string,
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
-	): Promise<void> {
+	): Promise<boolean> {
 		switch (sub) {
 			case "set":
-				await this.#handleGoalSetSubcommand(rest, input);
-				return;
+				return await this.#handleGoalSetSubcommand(rest, input);
 			case "show":
 				this.#showGoalDetails();
-				return;
+				return false;
 			case "pause":
 				await this.#pauseGoalAction();
-				return;
+				return false;
 			case "resume":
 				await this.#resumeGoalAction();
-				return;
+				return false;
 			case "drop":
 				await this.#confirmAndDropGoal();
-				return;
+				return false;
 			case "budget":
 				if (!this.goalModeEnabled) {
 					this.showWarning(
 						this.#getPausedGoalState() ? "Resume the goal before adjusting the budget." : "No active goal.",
 					);
-					return;
+					return false;
 				}
 				if (!rest) {
 					await this.#promptGoalBudgetEdit();
-					return;
+					return false;
 				}
 				await this.#handleGoalBudgetCommand(rest);
-				return;
+				return false;
 		}
 	}
 
@@ -3693,7 +3715,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	async #startGoalFromObjective(
 		objective: string,
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
-	): Promise<void> {
+	): Promise<boolean> {
 		await this.#enterGoalMode({ objective, silent: true });
 		this.#resetGoalContinuationSuppression();
 		if (this.session.isStreaming) {
@@ -3703,17 +3725,19 @@ export class InteractiveMode implements InteractiveModeContext {
 				() => this.session.prompt(objective, { streamingBehavior: "steer", images }),
 				{ imageCount: images?.length ?? 0 },
 			);
-			return;
+			return true;
 		}
 		if (this.onInputCallback) {
 			this.onInputCallback(this.startPendingSubmission({ text: objective, ...input }, { preserveDraft: true }));
+			return true;
 		}
+		return false;
 	}
 
 	async #replaceGoalFromObjective(
 		objective: string,
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
-	): Promise<void> {
+	): Promise<boolean> {
 		const state = await this.session.goalRuntime.replaceGoal({ objective });
 		this.session.setGoalModeState(state);
 		this.goalModeEnabled = true;
@@ -3728,30 +3752,29 @@ export class InteractiveMode implements InteractiveModeContext {
 				() => this.session.prompt(objective, { streamingBehavior: "steer", images }),
 				{ imageCount: images?.length ?? 0 },
 			);
-			return;
+			return true;
 		}
 		if (this.onInputCallback) {
 			this.onInputCallback(this.startPendingSubmission({ text: objective, ...input }, { preserveDraft: true }));
+			return true;
 		}
+		return false;
 	}
 
 	async #handleGoalSetSubcommand(
 		rest: string,
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
-	): Promise<void> {
+	): Promise<boolean> {
 		if (!this.goalModeEnabled && this.#getPausedGoalState()) {
 			this.showWarning("Resume the current goal first, or drop it before setting a new objective.");
-			return;
+			return false;
 		}
 		const objective = rest.trim()
 			? rest.trim()
 			: (await this.showHookEditor("Goal objective", undefined, undefined, { promptStyle: true }))?.trim();
-		if (!objective) return;
-		if (this.goalModeEnabled) {
-			await this.#replaceGoalFromObjective(objective, input);
-			return;
-		}
-		await this.#startGoalFromObjective(objective, input);
+		if (!objective) return false;
+		if (this.goalModeEnabled) return await this.#replaceGoalFromObjective(objective, input);
+		return await this.#startGoalFromObjective(objective, input);
 	}
 
 	/** Manually (re-)open the plan-review overlay — bound to `/plan-review`. Lets

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -531,6 +531,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	locallySubmittedUserSignatures: Set<string> = new Set();
 	#pendingSubmittedInput: SubmittedUserInput | undefined;
 	#pendingSubmissionDispose: (() => void) | undefined;
+	#pendingSubmissionPreservesDraft = false;
 	#optimisticUserMessageComponents: Component[] = [];
 	lastSigintTime = 0;
 	lastEscapeTime = 0;
@@ -1584,30 +1585,17 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.addMessageToChat(message, options);
 	}
 
-	/** Detach the composer's pending images so they ride along with the submission
-	 *  that consumes the draft. Mode commands that promote the draft into a turn
-	 *  (`/goal`, `/plan`, `/vibe`) build their submission from the draft *text*
-	 *  only; without this the positional `[Image #N]` markers survive into the
-	 *  message while every payload is dropped, and the orphaned images leak into
-	 *  whatever the user sends next. Mirrors the editor-submit path in
-	 *  `InputController`. `cancelPendingSubmission` restores them on cancel. */
-	#takeDraftImages(): { images?: ImageContent[]; imageLinks?: (string | undefined)[] } {
-		if (this.editor.pendingImages.length === 0) return {};
-		const images = [...this.editor.pendingImages];
-		const imageLinks = this.editor.pendingImageLinks.length > 0 ? [...this.editor.pendingImageLinks] : undefined;
-		this.editor.pendingImages = [];
-		this.editor.pendingImageLinks = [];
-		return { images, imageLinks };
-	}
-
-	startPendingSubmission(input: {
-		text: string;
-		images?: ImageContent[];
-		imageLinks?: (string | undefined)[];
-		customType?: string;
-		display?: boolean;
-		streamingBehavior?: "steer" | "followUp";
-	}): SubmittedUserInput {
+	startPendingSubmission(
+		input: {
+			text: string;
+			images?: ImageContent[];
+			imageLinks?: (string | undefined)[];
+			customType?: string;
+			display?: boolean;
+			streamingBehavior?: "steer" | "followUp";
+		},
+		options?: { preserveDraft?: boolean },
+	): SubmittedUserInput {
 		const submission: SubmittedUserInput = {
 			text: input.text,
 			images: input.images,
@@ -1619,6 +1607,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			started: false,
 		};
 		this.#pendingSubmittedInput = submission;
+		this.#pendingSubmissionPreservesDraft = options?.preserveDraft === true;
 		if (!submission.customType) {
 			this.#resetGoalContinuationSuppression();
 			const imageCount = submission.images?.length ?? 0;
@@ -1638,8 +1627,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		} else {
 			this.clearOptimisticUserMessage();
 		}
-		this.editor.setText("");
-		this.editor.imageLinks = undefined;
+		if (!options?.preserveDraft) {
+			this.editor.setText("");
+			this.editor.imageLinks = undefined;
+		}
 		this.ensureLoadingAnimation();
 		this.ui.requestRender();
 		return submission;
@@ -1650,9 +1641,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (!submission || submission.started) {
 			return false;
 		}
+		const preserveDraft = this.#pendingSubmissionPreservesDraft;
 
 		submission.cancelled = true;
 		this.#pendingSubmittedInput = undefined;
+		this.#pendingSubmissionPreservesDraft = false;
 		this.clearOptimisticUserMessage();
 		this.#pendingWorkingMessage = undefined;
 		if (submission.customType === "goal-continuation") {
@@ -1661,7 +1654,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (this.loadingAnimation) {
 			this.#stopLoadingAnimation(true);
 		}
-		if (!submission.customType) {
+		if (!submission.customType && !preserveDraft) {
 			this.editor.pendingImages = submission.images ? [...submission.images] : [];
 			this.editor.pendingImageLinks = submission.imageLinks ? [...submission.imageLinks] : [];
 			this.editor.imageLinks = this.editor.pendingImageLinks;
@@ -1678,6 +1671,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			return false;
 		}
 		input.started = true;
+		this.#pendingSubmissionPreservesDraft = false;
 		const annotationStateKey = this.#planReviewAnnotationStateBySubmission.get(input);
 		if (annotationStateKey) {
 			this.#planReviewAnnotationStateBySubmission.delete(input);
@@ -1692,6 +1686,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (wasPendingSubmission) {
 			this.#pendingSubmittedInput = undefined;
 			this.#pendingSubmissionDispose = undefined;
+			this.#pendingSubmissionPreservesDraft = false;
 		}
 		if (input.customType === "goal-continuation") {
 			this.#goalContinuationTurnInFlight = false;
@@ -3297,7 +3292,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-	async handlePlanModeCommand(initialPrompt?: string): Promise<void> {
+	async handlePlanModeCommand(
+		initialPrompt?: string,
+		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
+	): Promise<void> {
 		if (this.goalModeEnabled || this.goalModePaused) {
 			this.showWarning("Exit goal mode first.");
 			return;
@@ -3337,7 +3335,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		await this.#enterPlanMode();
 		if (initialPrompt && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt, ...this.#takeDraftImages() }));
+			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt, ...input }, { preserveDraft: true }));
 		}
 	}
 
@@ -3348,7 +3346,10 @@ export class InteractiveMode implements InteractiveModeContext {
 	 * the previous toolset, and kills every worker session so workers cannot
 	 * outlive the mode that directs them.
 	 */
-	async handleVibeModeCommand(initialPrompt?: string): Promise<void> {
+	async handleVibeModeCommand(
+		initialPrompt?: string,
+		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
+	): Promise<void> {
 		if (this.vibeModeEnabled) {
 			await this.#exitVibeMode();
 			return;
@@ -3363,7 +3364,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		await this.#enterVibeMode();
 		if (initialPrompt && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt, ...this.#takeDraftImages() }));
+			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt, ...input }, { preserveDraft: true }));
 		}
 	}
 
@@ -3450,7 +3451,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.showStatus(nextBudget === undefined ? "Goal budget cleared." : `Goal budget set to ${nextBudget}.`);
 	}
 
-	async handleGoalModeCommand(rest?: string): Promise<void> {
+	async handleGoalModeCommand(
+		rest?: string,
+		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
+	): Promise<void> {
 		try {
 			if (this.planModeEnabled || this.planModePaused) {
 				this.showWarning("Exit plan mode first.");
@@ -3466,7 +3470,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			}
 			const { sub, rest: subRest } = parseGoalSubcommand(rest ?? "");
 			if (sub) {
-				await this.#dispatchGoalSubcommand(sub, subRest);
+				await this.#dispatchGoalSubcommand(sub, subRest, input);
 				return;
 			}
 			if (this.goalModeEnabled) {
@@ -3487,14 +3491,14 @@ export class InteractiveMode implements InteractiveModeContext {
 				return;
 			}
 			if (subRest) {
-				await this.#startGoalFromObjective(subRest);
+				await this.#startGoalFromObjective(subRest, input);
 				return;
 			}
 			const objective = (
 				await this.showHookEditor("Goal objective", undefined, undefined, { promptStyle: true })
 			)?.trim();
 			if (!objective) return;
-			await this.#startGoalFromObjective(objective);
+			await this.#startGoalFromObjective(objective, input);
 		} catch (error) {
 			this.showError(error instanceof Error ? error.message : String(error));
 		}
@@ -3552,10 +3556,14 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-	async #dispatchGoalSubcommand(sub: GoalSubcommand, rest: string): Promise<void> {
+	async #dispatchGoalSubcommand(
+		sub: GoalSubcommand,
+		rest: string,
+		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
+	): Promise<void> {
 		switch (sub) {
 			case "set":
-				await this.#handleGoalSetSubcommand(rest);
+				await this.#handleGoalSetSubcommand(rest, input);
 				return;
 			case "show":
 				this.#showGoalDetails();
@@ -3681,15 +3689,21 @@ export class InteractiveMode implements InteractiveModeContext {
 		await this.#exitGoalMode({ reason: "dropped" });
 	}
 
-	async #startGoalFromObjective(objective: string): Promise<void> {
+	async #startGoalFromObjective(
+		objective: string,
+		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
+	): Promise<void> {
 		await this.#enterGoalMode({ objective, silent: true });
 		this.#resetGoalContinuationSuppression();
 		if (!this.session.isStreaming && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: objective, ...this.#takeDraftImages() }));
+			this.onInputCallback(this.startPendingSubmission({ text: objective, ...input }, { preserveDraft: true }));
 		}
 	}
 
-	async #replaceGoalFromObjective(objective: string): Promise<void> {
+	async #replaceGoalFromObjective(
+		objective: string,
+		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
+	): Promise<void> {
 		const state = await this.session.goalRuntime.replaceGoal({ objective });
 		this.session.setGoalModeState(state);
 		this.goalModeEnabled = true;
@@ -3700,11 +3714,14 @@ export class InteractiveMode implements InteractiveModeContext {
 			await this.session.sendGoalModeContext({ deliverAs: "steer" });
 		}
 		if (!this.session.isStreaming && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: objective, ...this.#takeDraftImages() }));
+			this.onInputCallback(this.startPendingSubmission({ text: objective, ...input }, { preserveDraft: true }));
 		}
 	}
 
-	async #handleGoalSetSubcommand(rest: string): Promise<void> {
+	async #handleGoalSetSubcommand(
+		rest: string,
+		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
+	): Promise<void> {
 		if (!this.goalModeEnabled && this.#getPausedGoalState()) {
 			this.showWarning("Resume the current goal first, or drop it before setting a new objective.");
 			return;
@@ -3714,10 +3731,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			: (await this.showHookEditor("Goal objective", undefined, undefined, { promptStyle: true }))?.trim();
 		if (!objective) return;
 		if (this.goalModeEnabled) {
-			await this.#replaceGoalFromObjective(objective);
+			await this.#replaceGoalFromObjective(objective, input);
 			return;
 		}
-		await this.#startGoalFromObjective(objective);
+		await this.#startGoalFromObjective(objective, input);
 	}
 
 	/** Manually (re-)open the plan-review overlay — bound to `/plan-review`. Lets
@@ -4211,6 +4228,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	showError(message: string): void {
 		this.#pendingSubmittedInput = undefined;
+		this.#pendingSubmissionPreservesDraft = false;
 		this.clearOptimisticUserMessage();
 		this.#pendingWorkingMessage = undefined;
 		if (this.loadingAnimation) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1584,6 +1584,22 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.addMessageToChat(message, options);
 	}
 
+	/** Detach the composer's pending images so they ride along with the submission
+	 *  that consumes the draft. Mode commands that promote the draft into a turn
+	 *  (`/goal`, `/plan`, `/vibe`) build their submission from the draft *text*
+	 *  only; without this the positional `[Image #N]` markers survive into the
+	 *  message while every payload is dropped, and the orphaned images leak into
+	 *  whatever the user sends next. Mirrors the editor-submit path in
+	 *  `InputController`. `cancelPendingSubmission` restores them on cancel. */
+	#takeDraftImages(): { images?: ImageContent[]; imageLinks?: (string | undefined)[] } {
+		if (this.editor.pendingImages.length === 0) return {};
+		const images = [...this.editor.pendingImages];
+		const imageLinks = this.editor.pendingImageLinks.length > 0 ? [...this.editor.pendingImageLinks] : undefined;
+		this.editor.pendingImages = [];
+		this.editor.pendingImageLinks = [];
+		return { images, imageLinks };
+	}
+
 	startPendingSubmission(input: {
 		text: string;
 		images?: ImageContent[];
@@ -3321,7 +3337,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		await this.#enterPlanMode();
 		if (initialPrompt && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt }));
+			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt, ...this.#takeDraftImages() }));
 		}
 	}
 
@@ -3347,7 +3363,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		await this.#enterVibeMode();
 		if (initialPrompt && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt }));
+			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt, ...this.#takeDraftImages() }));
 		}
 	}
 
@@ -3669,7 +3685,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		await this.#enterGoalMode({ objective, silent: true });
 		this.#resetGoalContinuationSuppression();
 		if (!this.session.isStreaming && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: objective }));
+			this.onInputCallback(this.startPendingSubmission({ text: objective, ...this.#takeDraftImages() }));
 		}
 	}
 
@@ -3684,7 +3700,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			await this.session.sendGoalModeContext({ deliverAs: "steer" });
 		}
 		if (!this.session.isStreaming && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: objective }));
+			this.onInputCallback(this.startPendingSubmission({ text: objective, ...this.#takeDraftImages() }));
 		}
 	}
 

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -436,18 +436,16 @@ export interface InteractiveModeContext {
 	toggleToolOutputExpansion(): void;
 	setToolsExpanded(expanded: boolean): void;
 	toggleThinkingBlockVisibility(): void;
-	openExternalEditor(): void;
-	registerExtensionShortcuts(): void;
 	handlePlanModeCommand(
 		initialPrompt?: string,
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
-	): Promise<void>;
+	): Promise<boolean>;
 	handleVibeModeCommand(
 		initialPrompt?: string,
 		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
-	): Promise<void>;
-	handleGoalModeCommand(rest?: string, input?: Pick<SubmittedUserInput, "images" | "imageLinks">): Promise<void>;
-	handleGuidedGoalCommand(rest?: string): Promise<void>;
+	): Promise<boolean>;
+	handleGoalModeCommand(rest?: string, input?: Pick<SubmittedUserInput, "images" | "imageLinks">): Promise<boolean>;
+	handleGuidedGoalCommand(rest?: string, input?: Pick<SubmittedUserInput, "images" | "imageLinks">): Promise<boolean>;
 	handleLoopCommand(args?: string): Promise<string | undefined>;
 	setLoopPrompt(prompt: string): void;
 	disableLoopMode(): void;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -438,9 +438,15 @@ export interface InteractiveModeContext {
 	toggleThinkingBlockVisibility(): void;
 	openExternalEditor(): void;
 	registerExtensionShortcuts(): void;
-	handlePlanModeCommand(initialPrompt?: string): Promise<void>;
-	handleVibeModeCommand(initialPrompt?: string): Promise<void>;
-	handleGoalModeCommand(rest?: string): Promise<void>;
+	handlePlanModeCommand(
+		initialPrompt?: string,
+		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
+	): Promise<void>;
+	handleVibeModeCommand(
+		initialPrompt?: string,
+		input?: Pick<SubmittedUserInput, "images" | "imageLinks">,
+	): Promise<void>;
+	handleGoalModeCommand(rest?: string, input?: Pick<SubmittedUserInput, "images" | "imageLinks">): Promise<void>;
 	handleGuidedGoalCommand(rest?: string): Promise<void>;
 	handleLoopCommand(args?: string): Promise<string | undefined>;
 	setLoopPrompt(prompt: string): void;

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -14,11 +14,31 @@ import { computerExposureMode } from "../tools/computer/exposure";
 import type { InspectImageMode } from "../utils/inspect-image-mode";
 import { commandConsumed, errorMessage, usage } from "./helpers/parse";
 import { handleSecurityCommand } from "./helpers/security";
-import type { SlashCommandSpec } from "./types";
+import type { ParsedSlashCommand, SlashCommandSpec, TuiSlashCommandRuntime } from "./types";
 
 export function refreshStatusLine(ctx: InteractiveModeContext): void {
 	ctx.statusLine.invalidate();
 	ctx.ui.requestRender();
+}
+
+async function runWithDetachedModeDraft(
+	command: ParsedSlashCommand,
+	runtime: TuiSlashCommandRuntime,
+	run: () => Promise<void>,
+): Promise<void> {
+	const { editor } = runtime.ctx;
+	editor.clearDraft();
+	try {
+		await run();
+	} catch (error) {
+		if (!editor.getText() && editor.pendingImages.length === 0) {
+			editor.setText(command.text);
+			editor.pendingImages = runtime.input?.images ? [...runtime.input.images] : [];
+			editor.pendingImageLinks = runtime.input?.imageLinks ? [...runtime.input.imageLinks] : [];
+			editor.imageLinks = editor.pendingImageLinks.length > 0 ? editor.pendingImageLinks : undefined;
+		}
+		throw error;
+	}
 }
 
 /** `/fast status` label for the active model: "on" when its family is priority, else "off". */
@@ -182,8 +202,9 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 			return "Plan: off";
 		},
 		handleTui: async (command, runtime) => {
-			await runtime.ctx.handlePlanModeCommand(command.args || undefined);
-			runtime.ctx.editor.clearDraft();
+			await runWithDetachedModeDraft(command, runtime, () =>
+				runtime.ctx.handlePlanModeCommand(command.args || undefined, runtime.input),
+			);
 		},
 	},
 	{
@@ -208,8 +229,9 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 			return "Vibe: off";
 		},
 		handleTui: async (command, runtime) => {
-			await runtime.ctx.handleVibeModeCommand(command.args || undefined);
-			runtime.ctx.editor.clearDraft();
+			await runWithDetachedModeDraft(command, runtime, () =>
+				runtime.ctx.handleVibeModeCommand(command.args || undefined, runtime.input),
+			);
 		},
 	},
 	{
@@ -232,8 +254,8 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 			return state ? `Goal: ${state.goal.status} (${shortDetail(state.goal.objective)})` : "Goal: off";
 		},
 		handleTui: async (command, runtime) => {
-			await runtime.ctx.handleGoalModeCommand(command.args || undefined);
 			runtime.ctx.editor.clearDraft();
+			await runtime.ctx.handleGoalModeCommand(command.args || undefined, runtime.input);
 		},
 	},
 	{

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -27,7 +27,7 @@ async function runWithDetachedModeDraft(
 	run: () => Promise<void>,
 ): Promise<void> {
 	const { editor } = runtime.ctx;
-	editor.clearDraft();
+	if (!runtime.draftDetached) editor.clearDraft();
 	try {
 		await run();
 	} catch (error) {
@@ -254,8 +254,9 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 			return state ? `Goal: ${state.goal.status} (${shortDetail(state.goal.objective)})` : "Goal: off";
 		},
 		handleTui: async (command, runtime) => {
-			runtime.ctx.editor.clearDraft();
-			await runtime.ctx.handleGoalModeCommand(command.args || undefined, runtime.input);
+			await runWithDetachedModeDraft(command, runtime, () =>
+				runtime.ctx.handleGoalModeCommand(command.args || undefined, runtime.input),
+			);
 		},
 	},
 	{

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -183,7 +183,7 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		},
 		handleTui: async (command, runtime) => {
 			await runtime.ctx.handlePlanModeCommand(command.args || undefined);
-			runtime.ctx.editor.setText("");
+			runtime.ctx.editor.clearDraft();
 		},
 	},
 	{
@@ -209,7 +209,7 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		},
 		handleTui: async (command, runtime) => {
 			await runtime.ctx.handleVibeModeCommand(command.args || undefined);
-			runtime.ctx.editor.setText("");
+			runtime.ctx.editor.clearDraft();
 		},
 	},
 	{
@@ -233,7 +233,7 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		},
 		handleTui: async (command, runtime) => {
 			await runtime.ctx.handleGoalModeCommand(command.args || undefined);
-			runtime.ctx.editor.setText("");
+			runtime.ctx.editor.clearDraft();
 		},
 	},
 	{
@@ -245,7 +245,7 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 			// Clear the slash draft BEFORE the await: the handler blocks for the
 			// whole kickoff turn, and a post-await clear would wipe an answer the
 			// user starts typing while the first interview question streams.
-			runtime.ctx.editor.setText("");
+			runtime.ctx.editor.clearDraft();
 			await runtime.ctx.handleGuidedGoalCommand(command.args || undefined);
 		},
 	},

--- a/packages/coding-agent/src/slash-commands/builtin-modes.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-modes.ts
@@ -24,12 +24,20 @@ export function refreshStatusLine(ctx: InteractiveModeContext): void {
 async function runWithDetachedModeDraft(
 	command: ParsedSlashCommand,
 	runtime: TuiSlashCommandRuntime,
-	run: () => Promise<void>,
+	run: () => Promise<boolean>,
 ): Promise<void> {
 	const { editor } = runtime.ctx;
 	if (!runtime.draftDetached) editor.clearDraft();
 	try {
-		await run();
+		const submitted = await run();
+		if (!submitted && ((runtime.input?.images?.length ?? 0) > 0 || (runtime.input?.imageLinks?.length ?? 0) > 0)) {
+			editor.pendingImages = [...(runtime.input?.images ?? []), ...editor.pendingImages];
+			editor.pendingImageLinks = [
+				...(runtime.input?.imageLinks ?? runtime.input?.images?.map(() => undefined) ?? []),
+				...editor.pendingImageLinks,
+			];
+			editor.imageLinks = editor.pendingImageLinks.length > 0 ? editor.pendingImageLinks : undefined;
+		}
 	} catch (error) {
 		if (!editor.getText() && editor.pendingImages.length === 0) {
 			editor.setText(command.text);
@@ -37,7 +45,7 @@ async function runWithDetachedModeDraft(
 			editor.pendingImageLinks = runtime.input?.imageLinks ? [...runtime.input.imageLinks] : [];
 			editor.imageLinks = editor.pendingImageLinks.length > 0 ? editor.pendingImageLinks : undefined;
 		}
-		throw error;
+		runtime.ctx.showError(error instanceof Error ? error.message : String(error));
 	}
 }
 
@@ -265,11 +273,9 @@ export const BUILTIN_MODE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> = [
 		inlineHint: "[rough objective]",
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
-			// Clear the slash draft BEFORE the await: the handler blocks for the
-			// whole kickoff turn, and a post-await clear would wipe an answer the
-			// user starts typing while the first interview question streams.
-			runtime.ctx.editor.clearDraft();
-			await runtime.ctx.handleGuidedGoalCommand(command.args || undefined);
+			await runWithDetachedModeDraft(command, runtime, () =>
+				runtime.ctx.handleGuidedGoalCommand(command.args || undefined, runtime.input),
+			);
 		},
 	},
 	{

--- a/packages/coding-agent/src/slash-commands/types.ts
+++ b/packages/coding-agent/src/slash-commands/types.ts
@@ -85,6 +85,8 @@ export interface TuiSlashCommandRuntime {
 	ctx: InteractiveModeContext;
 	/** Post-extension-hook attachments belonging to the submitted slash draft. */
 	input?: Pick<SubmittedUserInput, "images" | "imageLinks">;
+	/** The editor snapshot was cleared before asynchronous input hooks ran. */
+	draftDetached?: boolean;
 }
 
 /** Unified slash-command spec consumed by both TUI and ACP dispatchers. */

--- a/packages/coding-agent/src/slash-commands/types.ts
+++ b/packages/coding-agent/src/slash-commands/types.ts
@@ -1,5 +1,5 @@
 import type { Settings } from "../config/settings";
-import type { InteractiveModeContext } from "../modes/types";
+import type { InteractiveModeContext, SubmittedUserInput } from "../modes/types";
 import type { AgentSession } from "../session/agent-session";
 import type { SessionManager } from "../session/session-manager";
 
@@ -83,6 +83,8 @@ export interface SlashCommandRuntime {
  */
 export interface TuiSlashCommandRuntime {
 	ctx: InteractiveModeContext;
+	/** Post-extension-hook attachments belonging to the submitted slash draft. */
+	input?: Pick<SubmittedUserInput, "images" | "imageLinks">;
 }
 
 /** Unified slash-command spec consumed by both TUI and ACP dispatchers. */

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -17,9 +17,12 @@ import {
 	testSetExtensionHandlerTimeoutMs,
 } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import type {
+	Extension,
 	ExtensionError,
 	ExtensionServiceTier,
 	ExtensionUIContext,
+	InputEvent,
+	InputEventResult,
 } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/wrapper";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -3255,6 +3258,38 @@ describe("ExtensionRunner", () => {
 			);
 			// A fresh chain at depth 0 is unaffected by another chain's depth.
 			await expect(runner.invokeNativeTool("bash", { command: "echo hi" }, { depth: 0 })).resolves.toBeDefined();
+		});
+	});
+
+	describe("input attachment transforms", () => {
+		const inputRunner = (handler: (event: InputEvent) => InputEventResult): ExtensionRunner => {
+			const extensionPath = path.join(extensionsDir, "input-transform.ts");
+			const extension: Extension = {
+				path: extensionPath,
+				resolvedPath: extensionPath,
+				handlers: new Map([["input", [async (...args: unknown[]) => handler(args[0] as InputEvent)]]]),
+				tools: new Map(),
+				assistantThinkingRenderers: [],
+				messageRenderers: new Map(),
+				commands: new Map(),
+				flags: new Map(),
+				shortcuts: new Map(),
+			};
+			return new ExtensionRunner([extension], new ExtensionRuntime(), tempDir.path(), sessionManager, modelRegistry);
+		};
+
+		it("applies image-only removal independently of text", async () => {
+			const runner = inputRunner(() => ({ images: [] }));
+			const image: ImageContent = { type: "image", mimeType: "image/png", data: "aW1hZ2U=" };
+
+			expect(await runner.emitInput("keep text", [image], "interactive")).toEqual({ images: [] });
+		});
+
+		it("omits unchanged images from a text-only transform result", async () => {
+			const runner = inputRunner(event => ({ text: event.text.toUpperCase() }));
+			const image: ImageContent = { type: "image", mimeType: "image/png", data: "aW1hZ2U=" };
+
+			expect(await runner.emitInput("rewrite me", [image], "interactive")).toEqual({ text: "REWRITE ME" });
 		});
 	});
 });

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -234,12 +234,38 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(sendGoalModeContext).toHaveBeenCalledWith({ deliverAs: "steer" });
 		expect(promptSpy).toHaveBeenCalledWith(objective, { streamingBehavior: "steer", images });
 	});
+	it("steers plan prompt attachments while streaming", async () => {
+		Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
+		const sendPlanModeContext = vi.spyOn(harness.session, "sendPlanModeContext").mockResolvedValue();
+		const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+		const images: ImageContent[] = [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }];
+		const text = "[Image #1, 10x10] Plan this";
+
+		expect(await harness.mode.handlePlanModeCommand(text, { images, imageLinks: ["file:///shot.png"] })).toBe(true);
+
+		expect(sendPlanModeContext).toHaveBeenCalledWith({ deliverAs: "steer" });
+		expect(promptSpy).toHaveBeenCalledWith(text, { streamingBehavior: "steer", images });
+	});
+
+	it("steers vibe prompt attachments while streaming", async () => {
+		vi.spyOn(harness.session, "activateVibeTools").mockResolvedValue();
+		Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
+		const sendVibeModeContext = vi.spyOn(harness.session, "sendVibeModeContext").mockResolvedValue();
+		const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+		const images: ImageContent[] = [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }];
+		const text = "[Image #1, 10x10] Delegate this";
+
+		expect(await harness.mode.handleVibeModeCommand(text, { images, imageLinks: ["file:///shot.png"] })).toBe(true);
+
+		expect(sendVibeModeContext).toHaveBeenCalledWith({ deliverAs: "steer" });
+		expect(promptSpy).toHaveBeenCalledWith(text, { streamingBehavior: "steer", images });
+	});
 
 	const attachmentCases: Array<{
 		name: string;
 		text: string;
-		prepare?: (mode: InteractiveMode) => Promise<void>;
-		submit: (mode: InteractiveMode, input: Pick<SubmittedUserInput, "images" | "imageLinks">) => Promise<void>;
+		prepare?: (mode: InteractiveMode) => Promise<boolean | void>;
+		submit: (mode: InteractiveMode, input: Pick<SubmittedUserInput, "images" | "imageLinks">) => Promise<boolean>;
 	}> = [
 		{
 			name: "/goal",
@@ -297,12 +323,10 @@ describe("InteractiveMode goal mode integration", () => {
 		vi.spyOn(harness.session.goalRuntime, "createGoal").mockRejectedValueOnce(new Error("goal setup failed"));
 		const showError = vi.spyOn(harness.mode, "showError");
 
-		await expect(
-			executeBuiltinSlashCommand(commandText, {
-				ctx: harness.mode,
-				input: { images, imageLinks },
-			}),
-		).rejects.toThrow("goal setup failed");
+		await executeBuiltinSlashCommand(commandText, {
+			ctx: harness.mode,
+			input: { images, imageLinks },
+		});
 
 		expect(showError).toHaveBeenCalledWith("goal setup failed");
 		expect(harness.mode.editor.getText()).toBe(commandText);

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
-import type { Model } from "@oh-my-pi/pi-ai";
+import type { ImageContent, Model } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { GoalTool } from "@oh-my-pi/pi-coding-agent/goals/tools/goal-tool";
@@ -134,15 +134,19 @@ async function waitForMicrotasks(): Promise<void> {
 async function armInputWaiter(mode: InteractiveMode): Promise<{
 	inputPromise: Promise<void>;
 	getResolvedText: () => string | undefined;
+	getResolvedImages: () => ImageContent[] | undefined;
 }> {
 	let resolvedText: string | undefined;
+	let resolvedImages: ImageContent[] | undefined;
 	const inputPromise = mode.getUserInput().then(input => {
 		resolvedText = input.text;
+		resolvedImages = input.images;
 	});
 	await waitForMicrotasks();
 	return {
 		inputPromise,
 		getResolvedText: () => resolvedText,
+		getResolvedImages: () => resolvedImages,
 	};
 }
 
@@ -239,6 +243,39 @@ describe("InteractiveMode goal mode integration", () => {
 		streaming = false;
 		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "cleanup" }));
 		await waiter.inputPromise;
+	});
+
+	it("carries composer images into the initial goal objective submission", async () => {
+		// Regression: `/goal <objective>` built its submission from the draft text
+		// alone, so the objective kept its positional `[Image #1]` marker while the
+		// payload stayed behind on the editor and leaked into the next message.
+		const image: ImageContent = { type: "image", data: "aW1hZ2U=", mimeType: "image/png" };
+		harness.mode.editor.pendingImages = [image];
+		harness.mode.editor.pendingImageLinks = ["file:///shot.png"];
+		const waiter = await armInputWaiter(harness.mode);
+
+		await harness.mode.handleGoalModeCommand("[Image #1, 10x10] fix this");
+		await waiter.inputPromise;
+
+		expect(waiter.getResolvedText()).toBe("[Image #1, 10x10] fix this");
+		expect(waiter.getResolvedImages()).toEqual([image]);
+		expect(harness.mode.editor.pendingImages).toEqual([]);
+		expect(harness.mode.editor.pendingImageLinks).toEqual([]);
+	});
+
+	it("carries composer images into the replacement goal objective submission", async () => {
+		await harness.mode.handleGoalModeCommand("Ship the release");
+		const image: ImageContent = { type: "image", data: "cmVwbGFjZQ==", mimeType: "image/png" };
+		harness.mode.editor.pendingImages = [image];
+		harness.mode.editor.pendingImageLinks = [undefined];
+		const waiter = await armInputWaiter(harness.mode);
+
+		await harness.mode.handleGoalModeCommand("set [Image #1, 10x10] replace this");
+		await waiter.inputPromise;
+
+		expect(waiter.getResolvedText()).toBe("[Image #1, 10x10] replace this");
+		expect(waiter.getResolvedImages()).toEqual([image]);
+		expect(harness.mode.editor.pendingImages).toEqual([]);
 	});
 
 	it("includes escaped live todo state in hidden goal context during continuations", async () => {

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -206,41 +206,33 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(await toolNamesFor(harness)).toContain("goal");
 	});
 
-	it("defers initial goal objective submission while streaming", async () => {
-		let streaming = true;
-		Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => streaming });
+	it("steers initial goal objective attachments while streaming", async () => {
+		Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
 		const sendGoalModeContext = vi.spyOn(harness.session, "sendGoalModeContext").mockResolvedValue();
-		const waiter = await armInputWaiter(harness.mode);
+		const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+		const images: ImageContent[] = [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }];
+		const objective = "[Image #1, 10x10] Ship the release";
 
-		await harness.mode.handleGoalModeCommand("Ship the release");
-		await waitForMicrotasks();
+		await harness.mode.handleGoalModeCommand(objective, { images, imageLinks: ["file:///shot.png"] });
 
-		expect(harness.session.getGoalModeState()?.goal.objective).toBe("Ship the release");
+		expect(harness.session.getGoalModeState()?.goal.objective).toBe(objective);
 		expect(sendGoalModeContext).toHaveBeenCalledWith({ deliverAs: "steer" });
-		expect(waiter.getResolvedInput()).toBeUndefined();
-
-		streaming = false;
-		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "cleanup" }));
-		await waiter.inputPromise;
+		expect(promptSpy).toHaveBeenCalledWith(objective, { streamingBehavior: "steer", images });
 	});
 
-	it("defers replacement goal objective submission while streaming", async () => {
+	it("steers replacement goal objective attachments while streaming", async () => {
 		await harness.mode.handleGoalModeCommand("Ship the release");
-		let streaming = true;
-		Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => streaming });
+		Object.defineProperty(harness.session, "isStreaming", { configurable: true, get: () => true });
 		const sendGoalModeContext = vi.spyOn(harness.session, "sendGoalModeContext").mockResolvedValue();
-		const waiter = await armInputWaiter(harness.mode);
+		const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+		const images: ImageContent[] = [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }];
+		const objective = "[Image #1, 10x10] Replace the objective";
 
-		await harness.mode.handleGoalModeCommand("set Replace the objective");
-		await waitForMicrotasks();
+		await harness.mode.handleGoalModeCommand(`set ${objective}`, { images, imageLinks: ["file:///shot.png"] });
 
-		expect(harness.session.getGoalModeState()?.goal.objective).toBe("Replace the objective");
+		expect(harness.session.getGoalModeState()?.goal.objective).toBe(objective);
 		expect(sendGoalModeContext).toHaveBeenCalledWith({ deliverAs: "steer" });
-		expect(waiter.getResolvedInput()).toBeUndefined();
-
-		streaming = false;
-		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "cleanup" }));
-		await waiter.inputPromise;
+		expect(promptSpy).toHaveBeenCalledWith(objective, { streamingBehavior: "steer", images });
 	});
 
 	const attachmentCases: Array<{
@@ -295,6 +287,28 @@ describe("InteractiveMode goal mode integration", () => {
 			expect(input?.imageLinks).toBe(imageLinks);
 		});
 	}
+	it("restores the goal draft when setup fails", async () => {
+		const images: ImageContent[] = [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }];
+		const imageLinks = ["file:///shot.png"];
+		const commandText = "/goal [Image #1, 10x10] fix this";
+		harness.mode.editor.setText(commandText);
+		harness.mode.editor.pendingImages = images;
+		harness.mode.editor.pendingImageLinks = imageLinks;
+		vi.spyOn(harness.session.goalRuntime, "createGoal").mockRejectedValueOnce(new Error("goal setup failed"));
+		const showError = vi.spyOn(harness.mode, "showError");
+
+		await expect(
+			executeBuiltinSlashCommand(commandText, {
+				ctx: harness.mode,
+				input: { images, imageLinks },
+			}),
+		).rejects.toThrow("goal setup failed");
+
+		expect(showError).toHaveBeenCalledWith("goal setup failed");
+		expect(harness.mode.editor.getText()).toBe(commandText);
+		expect(harness.mode.editor.pendingImages).toEqual(images);
+		expect(harness.mode.editor.pendingImageLinks).toEqual(imageLinks);
+	});
 
 	it("keeps images pasted while delayed plan setup completes in the later draft", async () => {
 		const submittedImages: ImageContent[] = [{ type: "image", data: "b2xk", mimeType: "image/png" }];

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -7,10 +7,12 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import { GoalTool } from "@oh-my-pi/pi-coding-agent/goals/tools/goal-tool";
 import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SubmittedUserInput } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { normalizeCustomMessagePayload } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 import { createTools, type Tool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import type { TodoPhase } from "@oh-my-pi/pi-coding-agent/tools/todo";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -133,20 +135,16 @@ async function waitForMicrotasks(): Promise<void> {
 
 async function armInputWaiter(mode: InteractiveMode): Promise<{
 	inputPromise: Promise<void>;
-	getResolvedText: () => string | undefined;
-	getResolvedImages: () => ImageContent[] | undefined;
+	getResolvedInput: () => SubmittedUserInput | undefined;
 }> {
-	let resolvedText: string | undefined;
-	let resolvedImages: ImageContent[] | undefined;
+	let resolvedInput: SubmittedUserInput | undefined;
 	const inputPromise = mode.getUserInput().then(input => {
-		resolvedText = input.text;
-		resolvedImages = input.images;
+		resolvedInput = input;
 	});
 	await waitForMicrotasks();
 	return {
 		inputPromise,
-		getResolvedText: () => resolvedText,
-		getResolvedImages: () => resolvedImages,
+		getResolvedInput: () => resolvedInput,
 	};
 }
 
@@ -219,7 +217,7 @@ describe("InteractiveMode goal mode integration", () => {
 
 		expect(harness.session.getGoalModeState()?.goal.objective).toBe("Ship the release");
 		expect(sendGoalModeContext).toHaveBeenCalledWith({ deliverAs: "steer" });
-		expect(waiter.getResolvedText()).toBeUndefined();
+		expect(waiter.getResolvedInput()).toBeUndefined();
 
 		streaming = false;
 		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "cleanup" }));
@@ -238,44 +236,114 @@ describe("InteractiveMode goal mode integration", () => {
 
 		expect(harness.session.getGoalModeState()?.goal.objective).toBe("Replace the objective");
 		expect(sendGoalModeContext).toHaveBeenCalledWith({ deliverAs: "steer" });
-		expect(waiter.getResolvedText()).toBeUndefined();
+		expect(waiter.getResolvedInput()).toBeUndefined();
 
 		streaming = false;
 		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "cleanup" }));
 		await waiter.inputPromise;
 	});
 
-	it("carries composer images into the initial goal objective submission", async () => {
-		// Regression: `/goal <objective>` built its submission from the draft text
-		// alone, so the objective kept its positional `[Image #1]` marker while the
-		// payload stayed behind on the editor and leaked into the next message.
-		const image: ImageContent = { type: "image", data: "aW1hZ2U=", mimeType: "image/png" };
-		harness.mode.editor.pendingImages = [image];
-		harness.mode.editor.pendingImageLinks = ["file:///shot.png"];
-		const waiter = await armInputWaiter(harness.mode);
+	const attachmentCases: Array<{
+		name: string;
+		text: string;
+		prepare?: (mode: InteractiveMode) => Promise<void>;
+		submit: (mode: InteractiveMode, input: Pick<SubmittedUserInput, "images" | "imageLinks">) => Promise<void>;
+	}> = [
+		{
+			name: "/goal",
+			text: "[Image #1, 10x10] fix this",
+			submit: (mode: InteractiveMode, input: Pick<SubmittedUserInput, "images" | "imageLinks">) =>
+				mode.handleGoalModeCommand("[Image #1, 10x10] fix this", input),
+		},
+		{
+			name: "/goal set",
+			text: "[Image #1, 10x10] replace this",
+			prepare: (mode: InteractiveMode) => mode.handleGoalModeCommand("Ship the release"),
+			submit: (mode: InteractiveMode, input: Pick<SubmittedUserInput, "images" | "imageLinks">) =>
+				mode.handleGoalModeCommand("set [Image #1, 10x10] replace this", input),
+		},
+		{
+			name: "/plan",
+			text: "[Image #1, 10x10] plan this",
+			submit: (mode: InteractiveMode, input: Pick<SubmittedUserInput, "images" | "imageLinks">) =>
+				mode.handlePlanModeCommand("[Image #1, 10x10] plan this", input),
+		},
+		{
+			name: "/vibe",
+			text: "[Image #1, 10x10] delegate this",
+			prepare: async mode => {
+				vi.spyOn(mode.session, "activateVibeTools").mockResolvedValue();
+			},
+			submit: (mode: InteractiveMode, input: Pick<SubmittedUserInput, "images" | "imageLinks">) =>
+				mode.handleVibeModeCommand("[Image #1, 10x10] delegate this", input),
+		},
+	];
 
-		await harness.mode.handleGoalModeCommand("[Image #1, 10x10] fix this");
+	for (const testCase of attachmentCases) {
+		it(`carries the submitted attachment snapshot through ${testCase.name}`, async () => {
+			await testCase.prepare?.(harness.mode);
+			const images: ImageContent[] = [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }];
+			const imageLinks = ["file:///shot.png"];
+			const waiter = await armInputWaiter(harness.mode);
+
+			await testCase.submit(harness.mode, { images, imageLinks });
+			await waiter.inputPromise;
+
+			const input = waiter.getResolvedInput();
+			expect(input?.text).toBe(testCase.text);
+			expect(input?.images).toBe(images);
+			expect(input?.imageLinks).toBe(imageLinks);
+		});
+	}
+
+	it("keeps images pasted while delayed plan setup completes in the later draft", async () => {
+		const submittedImages: ImageContent[] = [{ type: "image", data: "b2xk", mimeType: "image/png" }];
+		const submittedLinks = ["file:///submitted.png"];
+		harness.mode.editor.pendingImages = submittedImages;
+		harness.mode.editor.pendingImageLinks = submittedLinks;
+		const waiter = await armInputWaiter(harness.mode);
+		const setupStarted = Promise.withResolvers<void>();
+		const continueSetup = Promise.withResolvers<void>();
+		const setActiveTools = harness.session.setActiveToolsByName.bind(harness.session);
+		vi.spyOn(harness.session, "setActiveToolsByName").mockImplementationOnce(async toolNames => {
+			setupStarted.resolve();
+			await continueSetup.promise;
+			await setActiveTools(toolNames);
+		});
+
+		const command = executeBuiltinSlashCommand("/plan [Image #1, 10x10] plan this", {
+			ctx: harness.mode,
+			input: { images: submittedImages, imageLinks: submittedLinks },
+		});
+		await setupStarted.promise;
+		const laterImage: ImageContent = { type: "image", data: "bmV3", mimeType: "image/png" };
+		harness.mode.editor.pendingImages = [laterImage];
+		harness.mode.editor.pendingImageLinks = ["file:///later.png"];
+		continueSetup.resolve();
+		await command;
 		await waiter.inputPromise;
 
-		expect(waiter.getResolvedText()).toBe("[Image #1, 10x10] fix this");
-		expect(waiter.getResolvedImages()).toEqual([image]);
-		expect(harness.mode.editor.pendingImages).toEqual([]);
-		expect(harness.mode.editor.pendingImageLinks).toEqual([]);
+		expect(waiter.getResolvedInput()?.images).toBe(submittedImages);
+		expect(harness.mode.editor.pendingImages).toEqual([laterImage]);
+		expect(harness.mode.editor.pendingImageLinks).toEqual(["file:///later.png"]);
 	});
 
-	it("carries composer images into the replacement goal objective submission", async () => {
-		await harness.mode.handleGoalModeCommand("Ship the release");
-		const image: ImageContent = { type: "image", data: "cmVwbGFjZQ==", mimeType: "image/png" };
-		harness.mode.editor.pendingImages = [image];
-		harness.mode.editor.pendingImageLinks = [undefined];
-		const waiter = await armInputWaiter(harness.mode);
+	it("keeps a later draft when a preserve-draft submission is cancelled", () => {
+		const submittedImage: ImageContent = { type: "image", data: "b2xk", mimeType: "image/png" };
+		const laterImage: ImageContent = { type: "image", data: "bmV3", mimeType: "image/png" };
+		harness.mode.editor.setText("later draft");
+		harness.mode.editor.pendingImages = [laterImage];
+		harness.mode.editor.pendingImageLinks = ["file:///later.png"];
 
-		await harness.mode.handleGoalModeCommand("set [Image #1, 10x10] replace this");
-		await waiter.inputPromise;
+		harness.mode.startPendingSubmission(
+			{ text: "submitted draft", images: [submittedImage], imageLinks: ["file:///submitted.png"] },
+			{ preserveDraft: true },
+		);
 
-		expect(waiter.getResolvedText()).toBe("[Image #1, 10x10] replace this");
-		expect(waiter.getResolvedImages()).toEqual([image]);
-		expect(harness.mode.editor.pendingImages).toEqual([]);
+		expect(harness.mode.cancelPendingSubmission()).toBe(true);
+		expect(harness.mode.editor.getText()).toBe("later draft");
+		expect(harness.mode.editor.pendingImages).toEqual([laterImage]);
+		expect(harness.mode.editor.pendingImageLinks).toEqual(["file:///later.png"]);
 	});
 
 	it("includes escaped live todo state in hidden goal context during continuations", async () => {
@@ -381,7 +449,7 @@ describe("InteractiveMode goal mode integration", () => {
 		vi.advanceTimersByTime(800);
 		await waitForMicrotasks();
 
-		expect(waiter.getResolvedText()).toBeUndefined();
+		expect(waiter.getResolvedInput()).toBeUndefined();
 
 		streaming = false;
 		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "cleanup" }));

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent, AgentBusyError } from "@oh-my-pi/pi-agent-core";
+import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { GoalTool } from "@oh-my-pi/pi-coding-agent/goals/tools/goal-tool";
@@ -106,12 +107,16 @@ describe("guided goal setup", () => {
 		const harness = await createHarness();
 		try {
 			const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+			const images: ImageContent[] = [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }];
 
-			await harness.mode.handleGuidedGoalCommand("automate flaky test triage");
+			await harness.mode.handleGuidedGoalCommand("automate flaky test triage", {
+				images,
+				imageLinks: ["file:///shot.png"],
+			});
 
 			expect(promptSpy).toHaveBeenCalledTimes(1);
 			const [text, promptOptions] = promptSpy.mock.calls[0]!;
-			expect(promptOptions).toEqual({ synthetic: true });
+			expect(promptOptions).toEqual({ synthetic: true, images });
 			// The rough objective rides inside the kickoff, and the kickoff tells the
 			// agent how to finish: `goal` tool, op create.
 			expect(text).toContain("automate flaky test triage");

--- a/packages/coding-agent/test/input-controller-followup-image.test.ts
+++ b/packages/coding-agent/test/input-controller-followup-image.test.ts
@@ -57,9 +57,9 @@ function createContext(opts: {
 	const requestRender = vi.fn();
 	const showError = vi.fn();
 
-	const handleGoalModeCommand = vi.fn(async (_prompt?: string, _input?: unknown) => {});
-	const handlePlanModeCommand = vi.fn(async (_prompt?: string, _input?: unknown) => {});
-	const handleVibeModeCommand = vi.fn(async (_prompt?: string, _input?: unknown) => {});
+	const handleGoalModeCommand = vi.fn(async (_prompt?: string, _input?: unknown) => true);
+	const handlePlanModeCommand = vi.fn(async (_prompt?: string, _input?: unknown) => true);
+	const handleVibeModeCommand = vi.fn(async (_prompt?: string, _input?: unknown) => true);
 	const ctx = {
 		editor,
 		ui: { requestRender },

--- a/packages/coding-agent/test/input-controller-followup-image.test.ts
+++ b/packages/coding-agent/test/input-controller-followup-image.test.ts
@@ -57,6 +57,9 @@ function createContext(opts: {
 	const requestRender = vi.fn();
 	const showError = vi.fn();
 
+	const handleGoalModeCommand = vi.fn(async (_prompt?: string, _input?: unknown) => {});
+	const handlePlanModeCommand = vi.fn(async (_prompt?: string, _input?: unknown) => {});
+	const handleVibeModeCommand = vi.fn(async (_prompt?: string, _input?: unknown) => {});
 	const ctx = {
 		editor,
 		ui: { requestRender },
@@ -74,10 +77,18 @@ function createContext(opts: {
 		locallySubmittedUserSignatures: new Set<string>(),
 		updatePendingMessagesDisplay,
 		showError,
+		planModeEnabled: false,
+		planModePaused: false,
+		vibeModeEnabled: false,
+		goalModeEnabled: false,
+		goalModePaused: false,
+		handleGoalModeCommand,
+		handlePlanModeCommand,
+		handleVibeModeCommand,
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
 	} as unknown as InteractiveModeContext;
 
-	return { ctx, editor, prompt, showError };
+	return { ctx, editor, handleGoalModeCommand, handlePlanModeCommand, handleVibeModeCommand, prompt, showError };
 }
 
 describe("InputController.handleFollowUp image forwarding", () => {
@@ -193,5 +204,25 @@ describe("InputController.handleFollowUp image forwarding", () => {
 		expect(ctx.editor.pendingImages).toEqual([image]);
 		expect(ctx.editor.pendingImageLinks).toEqual([undefined]);
 		expect(ctx.editor.imageLinks).toEqual([undefined]);
+	});
+
+	it("forwards follow-up mode attachments before the command clears the draft", async () => {
+		const image: ImageContent = { type: "image", mimeType: "image/png", data: "aW1hZ2U=" };
+		const { ctx, editor, handleGoalModeCommand } = createContext({
+			isStreaming: false,
+			pendingImages: [image],
+			pendingImageLinks: ["local://draft.png"],
+		});
+
+		const controller = new InputController(ctx);
+		editor.setText("/goal set Ship the release");
+		await controller.handleFollowUp();
+
+		expect(handleGoalModeCommand).toHaveBeenCalledWith("set Ship the release", {
+			images: [image],
+			imageLinks: ["local://draft.png"],
+		});
+		expect(ctx.editor.pendingImages).toEqual([]);
+		expect(ctx.editor.pendingImageLinks).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -207,7 +207,7 @@ describe("InputController skill queue chip metadata", () => {
 		editor.setText("/goal set Ship the release");
 		await controller.handleFollowUp();
 
-		expect(handleGoalModeCommand).toHaveBeenCalledWith("set Ship the release");
+		expect(handleGoalModeCommand.mock.calls[0]?.[0]).toBe("set Ship the release");
 		expect(prompt).not.toHaveBeenCalled();
 		expect(editor.getText()).toBe("");
 	});

--- a/packages/coding-agent/test/slash-commands/guided-goal.test.ts
+++ b/packages/coding-agent/test/slash-commands/guided-goal.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "bun:test";
+import type { ImageContent } from "@oh-my-pi/pi-ai";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 
-function createRuntime(handler: () => Promise<void>) {
+function createRuntime(handler: () => Promise<boolean>) {
 	const handleGuidedGoalCommand = vi.fn(handler);
 	const clearDraft = vi.fn();
 	return {
@@ -22,28 +23,33 @@ describe("/guided-goal slash command", () => {
 		// The handler blocks for the whole kickoff turn (session.prompt resolves
 		// only when the agent finishes asking its first question). Hold it open
 		// to simulate that window.
-		const { promise, resolve } = Promise.withResolvers<void>();
+		const { promise, resolve } = Promise.withResolvers<boolean>();
 		const harness = createRuntime(() => promise);
+		const images: ImageContent[] = [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }];
+		const input = { images, imageLinks: ["file:///shot.png"] };
 
-		const dispatched = executeBuiltinSlashCommand("/guided-goal ship the release", harness.runtime);
+		const dispatched = executeBuiltinSlashCommand("/guided-goal ship the release", {
+			...harness.runtime,
+			input,
+		});
 
 		// The command text must be gone before the turn resolves, so an answer
 		// typed while the first question streams is never wiped.
 		expect(harness.clearDraft).toHaveBeenCalled();
 		harness.clearDraft.mockClear();
 
-		resolve();
+		resolve(true);
 		expect(await dispatched).toBe(true);
 		expect(harness.clearDraft).not.toHaveBeenCalled();
-		expect(harness.handleGuidedGoalCommand).toHaveBeenCalledWith("ship the release");
+		expect(harness.handleGuidedGoalCommand).toHaveBeenCalledWith("ship the release", input);
 	});
 
 	it("passes no objective for a bare invocation", async () => {
-		const harness = createRuntime(async () => {});
+		const harness = createRuntime(async () => true);
 
 		const handled = await executeBuiltinSlashCommand("/guided-goal   ", harness.runtime);
 
 		expect(handled).toBe(true);
-		expect(harness.handleGuidedGoalCommand).toHaveBeenCalledWith(undefined);
+		expect(harness.handleGuidedGoalCommand).toHaveBeenCalledWith(undefined, undefined);
 	});
 });

--- a/packages/coding-agent/test/slash-commands/guided-goal.test.ts
+++ b/packages/coding-agent/test/slash-commands/guided-goal.test.ts
@@ -4,13 +4,13 @@ import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-comm
 
 function createRuntime(handler: () => Promise<void>) {
 	const handleGuidedGoalCommand = vi.fn(handler);
-	const setText = vi.fn();
+	const clearDraft = vi.fn();
 	return {
 		handleGuidedGoalCommand,
-		setText,
+		clearDraft,
 		runtime: {
 			ctx: {
-				editor: { setText } as unknown as InteractiveModeContext["editor"],
+				editor: { clearDraft } as unknown as InteractiveModeContext["editor"],
 				handleGuidedGoalCommand,
 			} as unknown as InteractiveModeContext,
 		},
@@ -29,12 +29,12 @@ describe("/guided-goal slash command", () => {
 
 		// The command text must be gone before the turn resolves, so an answer
 		// typed while the first question streams is never wiped.
-		expect(harness.setText).toHaveBeenCalledWith("");
-		harness.setText.mockClear();
+		expect(harness.clearDraft).toHaveBeenCalled();
+		harness.clearDraft.mockClear();
 
 		resolve();
 		expect(await dispatched).toBe(true);
-		expect(harness.setText).not.toHaveBeenCalled();
+		expect(harness.clearDraft).not.toHaveBeenCalled();
 		expect(harness.handleGuidedGoalCommand).toHaveBeenCalledWith("ship the release");
 	});
 

--- a/packages/coding-agent/test/slash-commands/mode-attachments.test.ts
+++ b/packages/coding-agent/test/slash-commands/mode-attachments.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import type { InteractiveModeContext, SubmittedUserInput } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+type Attachments = Pick<SubmittedUserInput, "images" | "imageLinks">;
+
+function createHarness(inputResult: { images?: ImageContent[] }) {
+	const oldImage: ImageContent = { type: "image", data: "b2xk", mimeType: "image/png" };
+	const handlePlanModeCommand = vi.fn(async (_prompt?: string, _input?: Attachments) => {});
+	const handleVibeModeCommand = vi.fn(async (_prompt?: string, _input?: Attachments) => {});
+	const handleGoalModeCommand = vi.fn(async (_prompt?: string, _input?: Attachments) => {});
+	let editorText = "";
+	const editor = {
+		onSubmit: undefined as undefined | ((text: string) => Promise<void>),
+		addToHistory: vi.fn(),
+		getText: () => editorText,
+		setText(text: string) {
+			editorText = text;
+		},
+		pendingImages: [oldImage],
+		pendingImageLinks: ["file:///old.png"] as (string | undefined)[],
+		imageLinks: undefined as (string | undefined)[] | undefined,
+		clearDraft() {
+			editorText = "";
+			this.pendingImages = [];
+			this.pendingImageLinks = [];
+			this.imageLinks = undefined;
+		},
+	};
+	const ctx = {
+		editor,
+		planModeEnabled: false,
+		planModePaused: false,
+		vibeModeEnabled: false,
+		goalModeEnabled: false,
+		goalModePaused: false,
+		session: {
+			isStreaming: false,
+			isCompacting: false,
+			queuedMessageCount: 0,
+			extensionRunner: {
+				hasHandlers: (event: string) => event === "input",
+				emitInput: vi.fn(async () => inputResult),
+				getCommand: () => undefined,
+			},
+		},
+		sessionManager: {
+			putBlob: vi.fn(async () => ({ displayPath: "file:///replacement.png" })),
+		},
+		focusedAgentId: undefined,
+		collabGuest: undefined,
+		ui: { requestRender: vi.fn() },
+		compactionQueuedMessages: [],
+		updatePendingMessagesDisplay: vi.fn(),
+		showStatus: vi.fn(),
+		showWarning: vi.fn(),
+		showError: vi.fn(),
+		handlePlanModeCommand,
+		handleVibeModeCommand,
+		handleGoalModeCommand,
+	} as unknown as InteractiveModeContext;
+	const controller = new InputController(ctx);
+	controller.setupEditorSubmitHandler();
+	return { editor, handlePlanModeCommand, handleVibeModeCommand, handleGoalModeCommand };
+}
+
+describe("mode command attachments", () => {
+	it("uses extension-replaced images and regenerated links", async () => {
+		const replacements: ImageContent[] = [{ type: "image", data: "bmV3", mimeType: "image/jpeg" }];
+		const harness = createHarness({ images: replacements });
+
+		await harness.editor.onSubmit?.("/plan inspect this");
+
+		const input = harness.handlePlanModeCommand.mock.calls[0]?.[1];
+		expect(input?.images).toBe(replacements);
+		expect(input?.imageLinks).toEqual(["file:///replacement.png"]);
+		expect(harness.editor.pendingImages).toEqual([]);
+		expect(harness.editor.pendingImageLinks).toEqual([]);
+	});
+
+	it("does not submit images removed by an extension", async () => {
+		const harness = createHarness({ images: [] });
+
+		await harness.editor.onSubmit?.("/goal keep this private");
+
+		expect(harness.handleGoalModeCommand).toHaveBeenCalledWith("keep this private", undefined);
+		expect(harness.editor.pendingImages).toEqual([]);
+		expect(harness.editor.pendingImageLinks).toEqual([]);
+	});
+
+	it("preserves source links when an extension leaves attachments unchanged", async () => {
+		const harness = createHarness({});
+
+		await harness.editor.onSubmit?.("/vibe inspect this");
+
+		expect(harness.handleVibeModeCommand).toHaveBeenCalledWith(
+			"inspect this",
+			expect.objectContaining({ imageLinks: ["file:///old.png"] }),
+		);
+		expect(harness.editor.pendingImages).toEqual([]);
+		expect(harness.editor.pendingImageLinks).toEqual([]);
+	});
+
+	it("restores a failed mode command without overwriting a later draft", async () => {
+		const failedPlan = createHarness({});
+		failedPlan.handlePlanModeCommand.mockRejectedValueOnce(new Error("plan setup failed"));
+		const planSubmission = failedPlan.editor.onSubmit?.("/plan inspect this");
+		if (!planSubmission) throw new Error("expected editor submit handler");
+
+		await expect(planSubmission).rejects.toThrow("plan setup failed");
+		expect(failedPlan.editor.getText()).toBe("/plan inspect this");
+		expect(failedPlan.editor.pendingImages).toHaveLength(1);
+		expect(failedPlan.editor.pendingImageLinks).toEqual(["file:///old.png"]);
+
+		const failedVibe = createHarness({});
+		const laterImage: ImageContent = { type: "image", data: "bmV3", mimeType: "image/png" };
+		failedVibe.handleVibeModeCommand.mockImplementationOnce(async () => {
+			failedVibe.editor.setText("later draft");
+			failedVibe.editor.pendingImages = [laterImage];
+			failedVibe.editor.pendingImageLinks = ["file:///later.png"];
+			throw new Error("vibe setup failed");
+		});
+		const vibeSubmission = failedVibe.editor.onSubmit?.("/vibe inspect this");
+		if (!vibeSubmission) throw new Error("expected editor submit handler");
+
+		await expect(vibeSubmission).rejects.toThrow("vibe setup failed");
+		expect(failedVibe.editor.getText()).toBe("later draft");
+		expect(failedVibe.editor.pendingImages).toEqual([laterImage]);
+		expect(failedVibe.editor.pendingImageLinks).toEqual(["file:///later.png"]);
+	});
+});

--- a/packages/coding-agent/test/slash-commands/mode-attachments.test.ts
+++ b/packages/coding-agent/test/slash-commands/mode-attachments.test.ts
@@ -5,11 +5,14 @@ import type { InteractiveModeContext, SubmittedUserInput } from "@oh-my-pi/pi-co
 
 type Attachments = Pick<SubmittedUserInput, "images" | "imageLinks">;
 
-function createHarness(inputResult: { images?: ImageContent[] } | Promise<{ images?: ImageContent[] }>) {
+function createHarness(
+	inputResult: { images?: ImageContent[]; text?: string } | Promise<{ images?: ImageContent[]; text?: string }>,
+) {
 	const oldImage: ImageContent = { type: "image", data: "b2xk", mimeType: "image/png" };
-	const handlePlanModeCommand = vi.fn(async (_prompt?: string, _input?: Attachments) => {});
-	const handleVibeModeCommand = vi.fn(async (_prompt?: string, _input?: Attachments) => {});
-	const handleGoalModeCommand = vi.fn(async (_prompt?: string, _input?: Attachments) => {});
+	const handlePlanModeCommand = vi.fn(async (_prompt?: string, _input?: Attachments) => true);
+	const handleVibeModeCommand = vi.fn(async (_prompt?: string, _input?: Attachments) => true);
+	const handleGoalModeCommand = vi.fn(async (_prompt?: string, _input?: Attachments) => true);
+	const handleGuidedGoalCommand = vi.fn(async (_prompt?: string, _input?: Attachments) => true);
 	let editorText = "";
 	const editor = {
 		onSubmit: undefined as undefined | ((text: string) => Promise<void>),
@@ -28,6 +31,7 @@ function createHarness(inputResult: { images?: ImageContent[] } | Promise<{ imag
 			this.imageLinks = undefined;
 		},
 	};
+	const showError = vi.fn();
 	const ctx = {
 		editor,
 		planModeEnabled: false,
@@ -55,14 +59,22 @@ function createHarness(inputResult: { images?: ImageContent[] } | Promise<{ imag
 		updatePendingMessagesDisplay: vi.fn(),
 		showStatus: vi.fn(),
 		showWarning: vi.fn(),
-		showError: vi.fn(),
+		showError,
 		handlePlanModeCommand,
 		handleVibeModeCommand,
 		handleGoalModeCommand,
+		handleGuidedGoalCommand,
 	} as unknown as InteractiveModeContext;
 	const controller = new InputController(ctx);
 	controller.setupEditorSubmitHandler();
-	return { editor, handlePlanModeCommand, handleVibeModeCommand, handleGoalModeCommand };
+	return {
+		editor,
+		showError,
+		handlePlanModeCommand,
+		handleVibeModeCommand,
+		handleGoalModeCommand,
+		handleGuidedGoalCommand,
+	};
 }
 
 describe("mode command attachments", () => {
@@ -101,21 +113,48 @@ describe("mode command attachments", () => {
 		expect(harness.editor.pendingImages).toEqual([]);
 		expect(harness.editor.pendingImageLinks).toEqual([]);
 	});
+	it("restores attachments when a mode command does not submit", async () => {
+		const harness = createHarness({});
+		harness.handleGoalModeCommand.mockResolvedValueOnce(false);
+
+		await harness.editor.onSubmit?.("/goal show");
+
+		expect(harness.editor.pendingImages).toHaveLength(1);
+		expect(harness.editor.pendingImageLinks).toEqual(["file:///old.png"]);
+	});
+
 	it("detaches submitted images before awaiting input extensions", async () => {
 		const inputResult = Promise.withResolvers<{ images?: ImageContent[] }>();
 		const harness = createHarness(inputResult.promise);
 		const submission = harness.editor.onSubmit?.("/plan inspect this");
 		if (!submission) throw new Error("expected editor submit handler");
 
-		expect(harness.editor.pendingImages).toEqual([]);
 		const laterImage: ImageContent = { type: "image", data: "bmV3", mimeType: "image/png" };
 		harness.editor.setText("later draft");
-		harness.editor.pendingImages = [laterImage];
-		harness.editor.pendingImageLinks = ["file:///later.png"];
+		harness.editor.pendingImages.push(laterImage);
+		harness.editor.pendingImageLinks.push("file:///later.png");
 		inputResult.resolve({});
 		await submission;
 
 		expect(harness.handlePlanModeCommand.mock.calls[0]?.[1]?.images).toHaveLength(1);
+		expect(harness.editor.getText()).toBe("later draft");
+		expect(harness.editor.pendingImages).toEqual([laterImage]);
+		expect(harness.editor.pendingImageLinks).toEqual(["file:///later.png"]);
+	});
+	it("preserves later images when an extension rewrites input into a mode command", async () => {
+		const inputResult = Promise.withResolvers<{ images?: ImageContent[]; text?: string }>();
+		const harness = createHarness(inputResult.promise);
+		const submission = harness.editor.onSubmit?.("inspect this");
+		if (!submission) throw new Error("expected editor submit handler");
+
+		const laterImage: ImageContent = { type: "image", data: "bmV3", mimeType: "image/png" };
+		harness.editor.setText("later draft");
+		harness.editor.pendingImages.push(laterImage);
+		harness.editor.pendingImageLinks.push("file:///later.png");
+		inputResult.resolve({ text: "/plan inspect this" });
+		await submission;
+
+		expect(harness.handlePlanModeCommand).toHaveBeenCalled();
 		expect(harness.editor.getText()).toBe("later draft");
 		expect(harness.editor.pendingImages).toEqual([laterImage]);
 		expect(harness.editor.pendingImageLinks).toEqual(["file:///later.png"]);
@@ -127,10 +166,11 @@ describe("mode command attachments", () => {
 		const planSubmission = failedPlan.editor.onSubmit?.("/plan inspect this");
 		if (!planSubmission) throw new Error("expected editor submit handler");
 
-		await expect(planSubmission).rejects.toThrow("plan setup failed");
+		await planSubmission;
 		expect(failedPlan.editor.getText()).toBe("/plan inspect this");
 		expect(failedPlan.editor.pendingImages).toHaveLength(1);
 		expect(failedPlan.editor.pendingImageLinks).toEqual(["file:///old.png"]);
+		expect(failedPlan.showError).toHaveBeenCalledWith("plan setup failed");
 
 		const failedVibe = createHarness({});
 		const laterImage: ImageContent = { type: "image", data: "bmV3", mimeType: "image/png" };
@@ -143,9 +183,10 @@ describe("mode command attachments", () => {
 		const vibeSubmission = failedVibe.editor.onSubmit?.("/vibe inspect this");
 		if (!vibeSubmission) throw new Error("expected editor submit handler");
 
-		await expect(vibeSubmission).rejects.toThrow("vibe setup failed");
+		await vibeSubmission;
 		expect(failedVibe.editor.getText()).toBe("later draft");
 		expect(failedVibe.editor.pendingImages).toEqual([laterImage]);
 		expect(failedVibe.editor.pendingImageLinks).toEqual(["file:///later.png"]);
+		expect(failedVibe.showError).toHaveBeenCalledWith("vibe setup failed");
 	});
 });

--- a/packages/coding-agent/test/slash-commands/mode-attachments.test.ts
+++ b/packages/coding-agent/test/slash-commands/mode-attachments.test.ts
@@ -5,7 +5,7 @@ import type { InteractiveModeContext, SubmittedUserInput } from "@oh-my-pi/pi-co
 
 type Attachments = Pick<SubmittedUserInput, "images" | "imageLinks">;
 
-function createHarness(inputResult: { images?: ImageContent[] }) {
+function createHarness(inputResult: { images?: ImageContent[] } | Promise<{ images?: ImageContent[] }>) {
 	const oldImage: ImageContent = { type: "image", data: "b2xk", mimeType: "image/png" };
 	const handlePlanModeCommand = vi.fn(async (_prompt?: string, _input?: Attachments) => {});
 	const handleVibeModeCommand = vi.fn(async (_prompt?: string, _input?: Attachments) => {});
@@ -100,6 +100,25 @@ describe("mode command attachments", () => {
 		);
 		expect(harness.editor.pendingImages).toEqual([]);
 		expect(harness.editor.pendingImageLinks).toEqual([]);
+	});
+	it("detaches submitted images before awaiting input extensions", async () => {
+		const inputResult = Promise.withResolvers<{ images?: ImageContent[] }>();
+		const harness = createHarness(inputResult.promise);
+		const submission = harness.editor.onSubmit?.("/plan inspect this");
+		if (!submission) throw new Error("expected editor submit handler");
+
+		expect(harness.editor.pendingImages).toEqual([]);
+		const laterImage: ImageContent = { type: "image", data: "bmV3", mimeType: "image/png" };
+		harness.editor.setText("later draft");
+		harness.editor.pendingImages = [laterImage];
+		harness.editor.pendingImageLinks = ["file:///later.png"];
+		inputResult.resolve({});
+		await submission;
+
+		expect(harness.handlePlanModeCommand.mock.calls[0]?.[1]?.images).toHaveLength(1);
+		expect(harness.editor.getText()).toBe("later draft");
+		expect(harness.editor.pendingImages).toEqual([laterImage]);
+		expect(harness.editor.pendingImageLinks).toEqual(["file:///later.png"]);
 	});
 
 	it("restores a failed mode command without overwriting a later draft", async () => {

--- a/packages/coding-agent/test/slash-commands/plan-history.test.ts
+++ b/packages/coding-agent/test/slash-commands/plan-history.test.ts
@@ -12,10 +12,10 @@ import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-comm
 function createPlanHarness(opts: { planModeEnabled: boolean; confirmExit: boolean }) {
 	const state = { planModeEnabled: opts.planModeEnabled };
 	const addToHistory = mock((_text: string) => {});
-	const setText = mock((_text: string) => {});
+	const clearDraft = mock((_historyText?: string) => {});
 
 	const ctx = {
-		editor: { addToHistory, setText } as unknown as InteractiveModeContext["editor"],
+		editor: { addToHistory, clearDraft } as unknown as InteractiveModeContext["editor"],
 		get planModeEnabled() {
 			return state.planModeEnabled;
 		},
@@ -33,17 +33,17 @@ function createPlanHarness(opts: { planModeEnabled: boolean; confirmExit: boolea
 		runtime: { ctx },
 		state,
 		addToHistory,
-		setText,
+		clearDraft,
 	};
 }
 
 function createGoalHarness(opts: { goalModeEnabled: boolean; dropOnCall: boolean }) {
 	const state = { goalModeEnabled: opts.goalModeEnabled };
 	const addToHistory = mock((_text: string) => {});
-	const setText = mock((_text: string) => {});
+	const clearDraft = mock((_historyText?: string) => {});
 
 	const ctx = {
-		editor: { addToHistory, setText } as unknown as InteractiveModeContext["editor"],
+		editor: { addToHistory, clearDraft } as unknown as InteractiveModeContext["editor"],
 		get goalModeEnabled() {
 			return state.goalModeEnabled;
 		},
@@ -57,7 +57,7 @@ function createGoalHarness(opts: { goalModeEnabled: boolean; dropOnCall: boolean
 		runtime: { ctx },
 		state,
 		addToHistory,
-		setText,
+		clearDraft,
 	};
 }
 
@@ -70,7 +70,7 @@ describe("/plan handler when already active", () => {
 		expect(handled).toBe(true);
 		// Sanity check: exit was confirmed, so plan mode is now off.
 		expect(h.state.planModeEnabled).toBe(false);
-		expect(h.setText).toHaveBeenCalledWith("");
+		expect(h.clearDraft).toHaveBeenCalled();
 	});
 
 	it("keeps plan mode active when user cancels exit", async () => {
@@ -81,7 +81,7 @@ describe("/plan handler when already active", () => {
 		expect(handled).toBe(true);
 		// Cancel: plan mode stays active.
 		expect(h.state.planModeEnabled).toBe(true);
-		expect(h.setText).toHaveBeenCalledWith("");
+		expect(h.clearDraft).toHaveBeenCalled();
 	});
 
 	it("enters plan mode when invoked for the first time", async () => {
@@ -90,7 +90,7 @@ describe("/plan handler when already active", () => {
 		await executeBuiltinSlashCommand("/plan hello world", h.runtime);
 
 		expect(h.state.planModeEnabled).toBe(true);
-		expect(h.setText).toHaveBeenCalledWith("");
+		expect(h.clearDraft).toHaveBeenCalled();
 	});
 });
 


### PR DESCRIPTION
## Problem

A composer draft that holds pasted images loses every image payload when a mode command turns that draft into the first turn.

`/goal <objective>`, `/plan <prompt>` and `/vibe <prompt>` build their submission from the draft **text** only:

```ts
this.onInputCallback(this.startPendingSubmission({ text: objective }));
```

`InputController`'s ordinary editor-submit path passes `editor.pendingImages` / `pendingImageLinks` next to the text; these four call sites never did. The message reaches the model with its positional `[Image #N, WxH]` markers intact and no image content blocks, so the agent sees markers that point at nothing and `read "Image #1"` resolves against an empty list.

Recorded session entries, same session, same terminal — ordinary submit vs. goal-objective submit:

```jsonc
// normal submit — payload present
{"role":"user","content":[
  {"type":"text","text":"[Image #1, 515x378] where IS THE BUTTON?"},
  {"type":"image","data":"blob:sha256:4e0f5f0b…","mimeType":"image/png"}]}

// same session, submitted as a goal objective — payload gone
{"role":"user","content":[
  {"type":"text","text":"1. why its lowercase…? [Image #1, 1118x949]\n2. [Image #2, 1568x950] …"}]}
```

Across 259 image-bearing user messages in 10 local project session logs (v17.2.x), every message preceded by a `goal-mode-context` injection lost its images: **36 of 37 lost**, against **190 of 198 preserved** on the ordinary submit path.

Second-order effect: the payload does not just vanish, it outlives the draft. The mode commands wipe the composer with `editor.setText("")`, which leaves `pendingImages` attached. Those orphans then ride along with the next message the user sends, one index off — so a later turn can attach a screenshot the user never re-pasted while its markers name a different one.

## Fix

- `InteractiveMode.#takeDraftImages()` detaches the composer's pending images and links; the four mode-command submissions spread it into `startPendingSubmission`. `cancelPendingSubmission` already restores images on cancel, so an aborted submission still gives them back.
- `/goal`, `/guided-goal`, `/plan` and `/vibe` clear the draft with `editor.clearDraft()` instead of `editor.setText("")`. Images can no longer outlive the text they were pasted into — the streaming branch of `/goal` never submits the objective, so its draft has to die whole.

## Tests

- `test/goals/goal-mode-integration.test.ts`: two regression cases assert that `/goal <objective>` and `/goal set <objective>` carry the composer image into the submission and leave the composer empty. Both fail on the previous behaviour with `expect(received).toEqual(expected)` / `received: undefined`.
- `/plan`, `/goal` and `/guided-goal` slash-command stubs now model `clearDraft` and assert on it.

```
bun test test/goals test/slash-commands test/plan-mode   # 223 pass, 0 fail
bun run check:types                                      # clean
biome check <changed files>                              # clean
```

Pre-existing, unrelated Windows failures in `test/modes/components/custom-editor.test.ts` (`file://` percent-decoding) and one `EBUSY` temp-dir removal are untouched by this diff — those files import neither changed module.
