### PR TITLE
fix(setup): suppress stale post-onboarding model warning

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed first-run setup displaying a stale no-model warning after provider sign-in and model selection completed in the same session ([#8053](https://github.com/can1357/oh-my-pi/issues/8053)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -8,7 +8,8 @@ import * as fsSync from "node:fs";
 import * as os from "node:os";
 import { createInterface } from "node:readline/promises";
 import { EventLoopKeepalive } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent } from "@oh-my-pi/pi-ai";
+import type { ImageContent, Model } from "@oh-my-pi/pi-ai";
+import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import {
 	$env,
 	directoryExists,
@@ -271,6 +272,21 @@ export interface InteractiveModeNotify {
 	message: string;
 }
 
+interface InteractiveStartupNotifications {
+	queued: (InteractiveModeNotify | null)[];
+	modelFallbackMessage?: string;
+}
+
+/** Builds a startup model warning only while setup has not replaced the model that produced it. */
+export function buildPostSetupModelFallbackNotification(
+	message: string | undefined,
+	modelBeforeSetup: Model | undefined,
+	modelAfterSetup: Model | undefined,
+): InteractiveModeNotify | null {
+	if (!message || (modelAfterSetup && !modelsAreEqual(modelBeforeSetup, modelAfterSetup))) return null;
+	return { kind: "warn", message };
+}
+
 export function buildModelScopeNotification(
 	scopedModelsForDisplay: readonly Pick<ScopedModel, "model" | "thinkingLevel" | "explicitThinkingLevel">[],
 	startupQuiet: boolean,
@@ -444,7 +460,7 @@ async function runInteractiveMode(
 	session: AgentSession,
 	version: string,
 	startupChangelog: StartupChangelogSelection | undefined,
-	notifs: (InteractiveModeNotify | null)[],
+	notifications: InteractiveStartupNotifications,
 	versionCheckPromise: Promise<string | undefined>,
 	initialMessages: string[],
 	setExtensionUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void,
@@ -458,6 +474,7 @@ async function runInteractiveMode(
 	initialImages?: ImageContent[],
 	joinLink?: string,
 ): Promise<void> {
+	const modelBeforeSetup = session.model;
 	const mode = new InteractiveMode(
 		session,
 		version,
@@ -519,7 +536,16 @@ async function runInteractiveMode(
 	// transcript above the fresh one.
 	mode.renderInitialMessages({ preserveExistingChat: true, clearTerminalHistory: true });
 
-	for (const notify of notifs) {
+	const modelFallbackNotification = buildPostSetupModelFallbackNotification(
+		notifications.modelFallbackMessage,
+		modelBeforeSetup,
+		session.model,
+	);
+	if (modelFallbackNotification) {
+		mode.showWarning(modelFallbackNotification.message);
+	}
+
+	for (const notify of notifications.queued) {
 		if (!notify) {
 			continue;
 		}
@@ -1207,7 +1233,7 @@ export async function runRootCommand(
 	const parsedArgs = parsed;
 	await logger.time("applyStartupCwd", applyStartupCwd, parsedArgs);
 
-	const notifs: (InteractiveModeNotify | null)[] = [];
+	const notifications: InteractiveStartupNotifications = { queued: [] };
 
 	if (parsedArgs.version) {
 		writeStartupNotice(parsedArgs, `${VERSION}\n`);
@@ -1513,7 +1539,7 @@ export async function runRootCommand(
 				sessionFile: sessionManager.getSessionFile(),
 			});
 			if (isInteractive) {
-				notifs.push({ kind: "warn", message: pendingToolWarning });
+				notifications.queued.push({ kind: "warn", message: pendingToolWarning });
 			} else {
 				process.stderr.write(`${chalk.yellow(`${pendingToolWarning}\n`)}`);
 			}
@@ -1623,7 +1649,7 @@ export async function runRootCommand(
 		}
 		for (const message of formatExtensionLoadNotifications(extensionsResult.errors)) {
 			if (isInteractive) {
-				notifs.push({ kind: "warn", message });
+				notifications.queued.push({ kind: "warn", message });
 			} else {
 				process.stderr.write(`${chalk.yellow(`${message}\n`)}`);
 			}
@@ -1703,12 +1729,12 @@ export async function runRootCommand(
 		}
 
 		if (modelFallbackMessage) {
-			notifs.push({ kind: "warn", message: modelFallbackMessage });
+			notifications.modelFallbackMessage = modelFallbackMessage;
 		}
 
 		const modelRegistryError = modelRegistry.getError();
 		if (modelRegistryError) {
-			notifs.push({ kind: "error", message: modelRegistryError.message });
+			notifications.queued.push({ kind: "error", message: modelRegistryError.message });
 		}
 
 		if (!isInteractive && !session.model) {
@@ -1743,7 +1769,7 @@ export async function runRootCommand(
 				// Routed through the TUI (not stdout): the startup capture owns the
 				// terminal in raw mode here, and the TUI's first clearScrollback paint
 				// would wipe a pre-TUI line anyway.
-				notifs.push(modelScopeNotification);
+				notifications.queued.push(modelScopeNotification);
 			}
 
 			if ($env.PI_TIMING) {
@@ -1759,7 +1785,7 @@ export async function runRootCommand(
 				session,
 				VERSION,
 				startupChangelog,
-				notifs,
+				notifications,
 				versionCheckPromise,
 				initialArgs.messages,
 				setToolUIContext,

--- a/packages/coding-agent/test/main-model-scope-notification.test.ts
+++ b/packages/coding-agent/test/main-model-scope-notification.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import type { ScopedModel } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
-import { buildModelScopeNotification } from "@oh-my-pi/pi-coding-agent/main";
+import { buildModelScopeNotification, buildPostSetupModelFallbackNotification } from "@oh-my-pi/pi-coding-agent/main";
 
 function scopedModel(id: string): ScopedModel {
 	return {
@@ -57,6 +57,23 @@ describe("buildModelScopeNotification", () => {
 		expect(buildModelScopeNotification([withDefault], false)).toEqual({
 			kind: "info",
 			message: "Model scope: claude-sonnet-4-5 (Ctrl+P to cycle)",
+		});
+	});
+});
+
+describe("buildPostSetupModelFallbackNotification", () => {
+	const message = "No models available. Use /login.";
+
+	it("drops the pre-setup warning after onboarding selects a model", () => {
+		expect(
+			buildPostSetupModelFallbackNotification(message, undefined, scopedModel("claude-sonnet-4-5").model),
+		).toBeNull();
+	});
+
+	it("retains the warning when onboarding leaves the session without a model", () => {
+		expect(buildPostSetupModelFallbackNotification(message, undefined, undefined)).toEqual({
+			kind: "warn",
+			message,
 		});
 	});
 });


### PR DESCRIPTION
## Repro
A one-off SDK probe run with `bun run gen:tool-views && bun test .tmp-issue-8053-repro.test.ts` created a credential-free session, captured its `No models available. Use /login...` fallback warning, then simulated onboarding by adding Anthropic auth and calling `session.setModel()`. The session changed from no model to `anthropic/claude-3-5-sonnet-20240620`, but the captured warning remained and the interactive startup path rendered it after setup.

## Cause
`runRootCommand()` in `packages/coding-agent/src/main.ts` queued `createAgentSession()`'s `modelFallbackMessage` before `runInteractiveMode()` ran the setup wizard. `runInteractiveMode()` then rendered every queued notification after onboarding without checking whether the wizard had selected a model and invalidated the pre-setup warning.

## Fix
- Keep the model fallback message separate from ordinary startup notifications until setup completes.
- Suppress that message when onboarding replaced the model state that produced it; retain it when setup still leaves the session without a model.
- Add regression coverage for both post-setup outcomes and document the fix in the coding-agent changelog.

## Verification
`cd packages/coding-agent && bun test test/main-model-scope-notification.test.ts` → 6 pass, 0 fail. A public-API smoke probe selected `anthropic/claude-3-5-sonnet-20240620` after session creation and reported `post-setup warning: none`. `cd packages/coding-agent && bun run check` → passed. Skipped the pre-publish gate: root `bun check` fails identically on a clean `origin/main` checkout because CMake is unavailable while `audiopus_sys` builds.

Fixes #8053