### PR TITLE
feat(cli): add --reduced-resources — strip unnecessary UI resources, keep full harness power

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -67,7 +67,7 @@ export interface Args {
 	noTools?: boolean;
 	noLsp?: boolean;
 	noPty?: boolean;
-	reducedResource?: boolean;
+	reducedResources?: boolean;
 	hooks?: string[];
 	extensions?: string[];
 	trustedExtensions?: string[];
@@ -252,8 +252,8 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			result.noLsp = true;
 		} else if (arg === "--no-pty") {
 			result.noPty = true;
-		} else if (arg === "--reduced-resource") {
-			result.reducedResource = true;
+		} else if (arg === "--reduced-resources") {
+			result.reducedResources = true;
 		} else if (arg === "--hide-thinking") {
 			result.hideThinking = true;
 		} else if (arg === "--advisor") {

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -67,6 +67,7 @@ export interface Args {
 	noTools?: boolean;
 	noLsp?: boolean;
 	noPty?: boolean;
+	reducedResource?: boolean;
 	hooks?: string[];
 	extensions?: string[];
 	trustedExtensions?: string[];
@@ -251,6 +252,8 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			result.noLsp = true;
 		} else if (arg === "--no-pty") {
 			result.noPty = true;
+		} else if (arg === "--reduced-resource") {
+			result.reducedResource = true;
 		} else if (arg === "--hide-thinking") {
 			result.hideThinking = true;
 		} else if (arg === "--advisor") {

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -309,7 +309,7 @@ export const VALUELESS_FLAGS: ReadonlySet<string> = new Set([
 	"--no-tools",
 	"--no-lsp",
 	"--no-pty",
-	"--reduced-resource",
+	"--reduced-resources",
 	"--hide-thinking",
 	"--advisor",
 	"--prewalk",

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -309,6 +309,7 @@ export const VALUELESS_FLAGS: ReadonlySet<string> = new Set([
 	"--no-tools",
 	"--no-lsp",
 	"--no-pty",
+	"--reduced-resource",
 	"--hide-thinking",
 	"--advisor",
 	"--prewalk",

--- a/packages/coding-agent/src/commands/launch-help.ts
+++ b/packages/coding-agent/src/commands/launch-help.ts
@@ -62,9 +62,9 @@ export const launchHelp = {
 		"no-tools": Flags.boolean({ description: "Disable all built-in tools" }),
 		"no-lsp": Flags.boolean({ description: "Disable LSP tools, formatting, and diagnostics" }),
 		"no-pty": Flags.boolean({ description: "Disable PTY-based interactive bash execution" }),
-		"reduced-resource": Flags.boolean({
+		"reduced-resources": Flags.boolean({
 			description:
-				"Resource-light interactive mode: static UI (no spinner/shimmer/title animations), no memory embeddings, tighter layout. Usable inside herdr panes.",
+				"Reduce unnecessary UI resources: static rendering (no spinner/shimmer/title animations), tighter layout. Keeps all harness power (tools, memory, LSP).",
 		}),
 		tools: Flags.string({ description: "Comma-separated list of tools to enable (default: all)" }),
 		thinking: Flags.string({

--- a/packages/coding-agent/src/commands/launch-help.ts
+++ b/packages/coding-agent/src/commands/launch-help.ts
@@ -62,6 +62,10 @@ export const launchHelp = {
 		"no-tools": Flags.boolean({ description: "Disable all built-in tools" }),
 		"no-lsp": Flags.boolean({ description: "Disable LSP tools, formatting, and diagnostics" }),
 		"no-pty": Flags.boolean({ description: "Disable PTY-based interactive bash execution" }),
+		"reduced-resource": Flags.boolean({
+			description:
+				"Resource-light interactive mode: static UI (no spinner/shimmer/title animations), no memory embeddings, tighter layout. Usable inside herdr panes.",
+		}),
 		tools: Flags.string({ description: "Comma-separated list of tools to enable (default: all)" }),
 		thinking: Flags.string({
 			description: `Set thinking level: ${CLI_THINKING_LEVELS.join(", ")}`,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1334,14 +1334,14 @@ export async function runRootCommand(
 	if (parsedArgs.advisor) {
 		settingsInstance.override("advisor.enabled", true);
 	}
-	// --reduced-resource: resource-light interactive profile. Static UI (no
-	// spinner/shimmer/title animations), no memory embeddings, tighter layout.
-	// Each knob is individually revertible via config.yml; the flag additionally
+	// --reduced-resources: reduce unnecessary UI resources. Static rendering
+	// (no spinner/shimmer/title animations) and a tighter layout. All harness
+	// power is preserved — tools, memory backend, and LSP stay enabled. Each
+	// knob is individually revertible via config.yml; the flag additionally
 	// arms the reduce-motion switch the animation components read.
-	if (parsedArgs.reducedResource) {
+	if (parsedArgs.reducedResources) {
 		setReduceMotion(true);
 		settingsInstance.override("display.shimmer", "disabled");
-		settingsInstance.override("memory.backend", "off");
 		settingsInstance.override("tui.tight", true);
 	}
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -22,6 +22,7 @@ import {
 	VERSION,
 } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
+import { setReduceMotion } from "@oh-my-pi/pi-tui";
 import { reset as resetCapabilities } from "./capability";
 import { type Args, reportUnrecognizedFlags } from "./cli/args";
 import { applyExtensionFlags, type ExtensionFlagSink } from "./cli/extension-flags";
@@ -1332,6 +1333,16 @@ export async function runRootCommand(
 	// Apply --advisor CLI flag (ephemeral, not persisted)
 	if (parsedArgs.advisor) {
 		settingsInstance.override("advisor.enabled", true);
+	}
+	// --reduced-resource: resource-light interactive profile. Static UI (no
+	// spinner/shimmer/title animations), no memory embeddings, tighter layout.
+	// Each knob is individually revertible via config.yml; the flag additionally
+	// arms the reduce-motion switch the animation components read.
+	if (parsedArgs.reducedResource) {
+		setReduceMotion(true);
+		settingsInstance.override("display.shimmer", "disabled");
+		settingsInstance.override("memory.backend", "off");
+		settingsInstance.override("tui.tight", true);
 	}
 
 	await logger.time(

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -385,7 +385,7 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	#startThinkingAnimation(): void {
-		// --reduced-resource: render a static thinking glyph, no pulse timer.
+		// --reduced-resources: render a static thinking glyph, no pulse timer.
 		if (isReduceMotion()) return;
 		if (this.#thinkingDotsTimer) return;
 		this.#scheduleThinkingFrame();

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -4,6 +4,7 @@ import {
 	Image,
 	type ImageBudget,
 	ImageProtocol,
+	isReduceMotion,
 	Markdown,
 	replaceTabs,
 	Spacer,
@@ -384,6 +385,8 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	#startThinkingAnimation(): void {
+		// --reduced-resource: render a static thinking glyph, no pulse timer.
+		if (isReduceMotion()) return;
 		if (this.#thinkingDotsTimer) return;
 		this.#scheduleThinkingFrame();
 	}

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -516,7 +516,7 @@ export class CustomEditor extends Editor {
 	 *  once they are loaded. An explicit `magicKeywordsEnabledOverride` overrides
 	 *  both paths. */
 	#shimmerEnabled(): boolean {
-		// --reduced-resource: suppress the magic-keyword shimmer entirely.
+		// --reduced-resources: suppress the magic-keyword shimmer entirely.
 		if (isReduceMotion()) return false;
 		if (this.magicKeywordsEnabledOverride !== undefined) return this.magicKeywordsEnabledOverride;
 		return isSettingsInitialized() ? settings.get("magicKeywords.enabled") : true;

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -6,6 +6,7 @@ import {
 	Editor,
 	type EditorTheme,
 	type KeyId,
+	isReduceMotion,
 	parseKey,
 	parseKittySequence,
 	TUI,
@@ -515,6 +516,8 @@ export class CustomEditor extends Editor {
 	 *  once they are loaded. An explicit `magicKeywordsEnabledOverride` overrides
 	 *  both paths. */
 	#shimmerEnabled(): boolean {
+		// --reduced-resource: suppress the magic-keyword shimmer entirely.
+		if (isReduceMotion()) return false;
 		if (this.magicKeywordsEnabledOverride !== undefined) return this.magicKeywordsEnabledOverride;
 		return isSettingsInitialized() ? settings.get("magicKeywords.enabled") : true;
 	}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -703,7 +703,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 			const frame = sharedSpinnerFrame(frameCount);
 			this.#spinnerFrame = frame;
 			this.#renderState.spinnerFrame = frame;
-			// --reduced-resource: paint one static spinner frame, no 80ms interval.
+			// --reduced-resources: paint one static spinner frame, no 80ms interval.
 			if (isReduceMotion()) return;
 			this.#spinnerInterval = setInterval(() => {
 				// If a detached task interval from an older render path is still live,
@@ -773,7 +773,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 
 		this.#spinnerFrame = 0;
 		this.#renderState.spinnerFrame = 0;
-		// --reduced-resource: static first strike frame, no 65ms interval.
+		// --reduced-resources: static first strike frame, no 65ms interval.
 		if (isReduceMotion()) return;
 		this.#todoStrikeInterval = setInterval(() => {
 			const nextFrame = (this.#spinnerFrame ?? 0) + 1;

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -27,6 +27,7 @@ import { type FirstResultViewportRepaint, type ToolRenderer, toolRenderers } fro
 import { TODO_STRIKE_TOTAL_FRAMES, type TodoToolDetails } from "../../tools/todo";
 import type { XdevState } from "../../tools/xdev";
 import { isFramedBlockComponent, markFramedBlockComponent, renderStatusLine, WidthAwareText } from "../../tui";
+import { isReduceMotion } from "@oh-my-pi/pi-tui";
 import { convertImageToPng } from "../../utils/image-loading";
 import { sanitizeWithOptionalSixelPassthrough } from "../../utils/sixel";
 import { renderDiff } from "./diff";
@@ -702,6 +703,8 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 			const frame = sharedSpinnerFrame(frameCount);
 			this.#spinnerFrame = frame;
 			this.#renderState.spinnerFrame = frame;
+			// --reduced-resource: paint one static spinner frame, no 80ms interval.
+			if (isReduceMotion()) return;
 			this.#spinnerInterval = setInterval(() => {
 				// If a detached task interval from an older render path is still live,
 				// stop it the instant the block leaves the repaintable region.
@@ -770,6 +773,8 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 
 		this.#spinnerFrame = 0;
 		this.#renderState.spinnerFrame = 0;
+		// --reduced-resource: static first strike frame, no 65ms interval.
+		if (isReduceMotion()) return;
 		this.#todoStrikeInterval = setInterval(() => {
 			const nextFrame = (this.#spinnerFrame ?? 0) + 1;
 			if (nextFrame > TODO_STRIKE_TOTAL_FRAMES) {

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -6,7 +6,7 @@ import * as path from "node:path";
 
 import { type Api, type AssistantMessage, completeSimple, type Model } from "@oh-my-pi/pi-ai";
 import { StreamMarkupHealing } from "@oh-my-pi/pi-ai/utils/stream-markup-healing";
-import { isConPTYHosted } from "@oh-my-pi/pi-tui";
+import { isConPTYHosted, isReduceMotion } from "@oh-my-pi/pi-tui";
 import { isTerminalHeadless, logger, prompt } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
 
@@ -515,7 +515,7 @@ export function buildTerminalTitleWithState(
 	if (!enabled) return label ? `${DEFAULT_TERMINAL_TITLE}: ${label}` : DEFAULT_TERMINAL_TITLE;
 	const separator =
 		state === "working"
-			? platform === "win32"
+			? platform === "win32" || isReduceMotion()
 				? WINDOWS_TITLE_WORKING_SEPARATOR
 				: TITLE_SPINNER_FRAMES[frame % TITLE_SPINNER_FRAMES.length]
 			: state === "attention"
@@ -545,7 +545,7 @@ function stopTerminalTitleSpinner(): void {
 }
 
 function startTerminalTitleSpinner(): void {
-	if (isConPTYHosted() || terminalTitleRuntime.timer || !process.stdout.isTTY) return;
+	if (isReduceMotion() || isConPTYHosted() || terminalTitleRuntime.timer || !process.stdout.isTTY) return;
 	terminalTitleRuntime.timer = setInterval(() => {
 		terminalTitleRuntime.frame = (terminalTitleRuntime.frame + 1) % TITLE_SPINNER_FRAMES.length;
 		emitTerminalTitle();

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -99,7 +99,7 @@ export class Loader extends Text {
 		this.#lastSpinnerTick = performance.now();
 		this.#syncText();
 		this.#requestPaint();
-		// --reduced-resource: paint the static status line once, no animation timer.
+		// --reduced-resources: paint the static status line once, no animation timer.
 		if (isReduceMotion()) return;
 		const intervalMs = this.messageColorFn.animated === true ? RENDER_INTERVAL_MS : SPINNER_ADVANCE_MS;
 		this.#scheduleTick(intervalMs, intervalMs);

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -1,5 +1,6 @@
 import type { TUI } from "../tui";
 import { getPaddingX, sliceByColumn, visibleWidth } from "../utils";
+import { isReduceMotion } from "../reduce-motion";
 import { Text } from "./text";
 
 const RENDER_INTERVAL_MS = 1000 / 30;
@@ -98,6 +99,8 @@ export class Loader extends Text {
 		this.#lastSpinnerTick = performance.now();
 		this.#syncText();
 		this.#requestPaint();
+		// --reduced-resource: paint the static status line once, no animation timer.
+		if (isReduceMotion()) return;
 		const intervalMs = this.messageColorFn.animated === true ? RENDER_INTERVAL_MS : SPINNER_ADVANCE_MS;
 		this.#scheduleTick(intervalMs, intervalMs);
 	}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -1,6 +1,6 @@
 // Core TUI interfaces and classes
 
-// Reduce-motion flag for --reduced-resource
+// Reduce-motion flag for --reduced-resources
 export * from "./reduce-motion";
 // Autocomplete support
 export * from "./autocomplete";

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -1,5 +1,7 @@
 // Core TUI interfaces and classes
 
+// Reduce-motion flag for --reduced-resource
+export * from "./reduce-motion";
 // Autocomplete support
 export * from "./autocomplete";
 // Components

--- a/packages/tui/src/reduce-motion.ts
+++ b/packages/tui/src/reduce-motion.ts
@@ -1,5 +1,5 @@
 /**
- * Reduce-motion flag for `--reduced-resource` mode.
+ * Reduce-motion flag for `--reduced-resources` mode.
  *
  * When enabled, interactive components render a static status line instead of
  * driving spinner/shimmer/thinking timers, and the terminal title stops
@@ -9,11 +9,12 @@
  *
  * This is deliberately a lightweight module-level switch (mirroring the
  * module-scoped runtime state used by the terminal-title spinner) rather than
- * threading an option through every component constructor.
+ * threading an option through every component constructor. It only suppresses
+ * visual animation; all harness power (tools, memory, LSP) is preserved.
  */
 let reduceMotion = false;
 
-/** Whether UI animations should be suppressed (--reduced-resource). */
+/** Whether UI animations should be suppressed (--reduced-resources). */
 export function isReduceMotion(): boolean {
 	return reduceMotion;
 }

--- a/packages/tui/src/reduce-motion.ts
+++ b/packages/tui/src/reduce-motion.ts
@@ -1,0 +1,24 @@
+/**
+ * Reduce-motion flag for `--reduced-resource` mode.
+ *
+ * When enabled, interactive components render a static status line instead of
+ * driving spinner/shimmer/thinking timers, and the terminal title stops
+ * rotating its working glyph. The flag is set once at startup from the CLI
+ * option; animation components read it at start/render time, so no reload is
+ * needed and the observable UI stays identical apart from the absent motion.
+ *
+ * This is deliberately a lightweight module-level switch (mirroring the
+ * module-scoped runtime state used by the terminal-title spinner) rather than
+ * threading an option through every component constructor.
+ */
+let reduceMotion = false;
+
+/** Whether UI animations should be suppressed (--reduced-resource). */
+export function isReduceMotion(): boolean {
+	return reduceMotion;
+}
+
+/** Enable or disable reduce-motion. Called once at startup from the CLI flag. */
+export function setReduceMotion(enabled: boolean): void {
+	reduceMotion = enabled;
+}


### PR DESCRIPTION
# feat(cli): add `--reduced-resources` — strip unnecessary UI resources, keep full harness power

## What

New interactive-mode flag `--reduced-resources` that removes **unnecessary resources spent on visual elements** while keeping the agent every bit as powerful as a harness. It is aimed at running omp comfortably inside lightweight terminals / multiplexer panes (herdr, tmux, qutebrowser-style embedding) where idle animation timers are pure overhead.

## Scope — visual only

The flag:

- **Static rendering.** Arms a `reduce-motion` switch (`packages/tui/src/reduce-motion.ts`, exported from the TUI index) that the animation components read at start/render time. When enabled, the wait-spinner, tool spinner, magic-keyword shimmer, thinking-dots, todo-strike animation, and the rotating terminal-title working glyph each render **one static frame** — no interval timers, no repeated paints.
- **Tighter layout.** `tui.tight=true` override for a denser, multiplexer-friendly layout.
- **`display.shimmer=disabled`** override.

**Crucially, it disables nothing that affects harness capability:**

- ❌ does **not** disable the memory backend (`mnemopi` / `hindsight` / `local` all stay active; recall/retain/reflect and the embedding subprocess keep working).
- ❌ does **not** disable tools, LSP, MCP, or any agent capability.
- `hasUI` stays `true`, so herdr agent-state reporting (idle/working/done) keeps working.

Each knob is an individual `settingsInstance.override`, so every piece is independently revertible via `config.yml`; the flag additionally arms the module-level reduce-motion switch that the animation components read.

## Why

The **software factory / kingdom** run a fleet of omp agents inside herdr multiplexer panes. When idle, the spinner/shimmer/title animation timers drive continuous repaints and keep the event loop hot for no user value. `--reduced-resources` gives those deployments a static-UI, tight-layout profile without trading away any of omp's harness power (memory, tools, LSP all remain enabled).

## Implementation notes

- `reduce-motion` is a lightweight module-level switch (mirroring the existing module-scoped runtime state used by the terminal-title spinner) rather than threading an option through every component constructor — components read it at start/render time, so no reload is needed and the UI is identical apart from the absent motion.
- Gates added in:
  - `packages/tui/src/components/loader.ts` (wait spinner)
  - `packages/coding-agent/src/modes/components/tool-execution.ts` (tool spinner + todo-strike)
  - `packages/coding-agent/src/modes/components/custom-editor.ts` (magic-keyword shimmer)
  - `packages/coding-agent/src/modes/components/assistant-message.ts` (thinking-dots)
  - `packages/coding-agent/src/utils/title-generator.ts` (terminal title glyph + title spinner)
- Flag plumbing in `packages/coding-agent/src/cli/{args,flag-tables}.ts`, `commands/launch-help.ts`, and `main.ts`.

## Verification

- `bun run check:types` clean for `packages/tui` and `packages/coding-agent`.
- `bun run gen:bundle` builds `dist/cli.js`; bundle carries the flag and **no** `memory.backend=off` override.
- Live smoke: `dist/cli.js --reduced-resources -p "Reply: OK"` → exit 0; `--help` lists the flag.
