### PR TITLE
fix(extensions): restore before-agent-start prompt options

### DIFF
--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -761,6 +761,10 @@ export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any
 	loadMode?: ToolLoadMode;
 	/** Short one-line summary used for tool discovery indexes. */
 	summary?: string;
+	/** Optional one-line summary used by Pi-compatible system-prompt reconstruction. */
+	promptSnippet?: string;
+	/** Optional prompt guidelines included while this tool is active. */
+	promptGuidelines?: readonly string[];
 	/**
 	 * Concurrency mode for tool scheduling when multiple calls are in one turn.
 	 * - "shared": can run alongside other shared tools (default)

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Fixed legacy Pi extensions receiving an incompatible `before_agent_start` payload: the event now includes resolved `systemPromptOptions`, exposes `systemPrompt` as a string, and chains string prompt overrides as required by the upstream Pi contract. ([#8058](https://github.com/can1357/oh-my-pi/issues/8058))
+
 - Fixed shell minimization replacing meaningful `rustc --print` output with `OK`.
 - Fixed shell minimization altering outputs shorter than 1,000 characters; these now pass through unchanged.
 - Fixed primary and advisor Codex sessions falling back to another provider before trying sibling accounts when an account lacks Trusted Access for Cyber approval.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## [Unreleased]
 
-## [17.2.12] - 2026-08-08
-
 ### Fixed
 
 - Fixed legacy Pi extensions receiving an incompatible `before_agent_start` payload: the event now includes resolved `systemPromptOptions`, exposes `systemPrompt` as a string, and chains string prompt overrides as required by the upstream Pi contract. ([#8058](https://github.com/can1357/oh-my-pi/issues/8058))
+
+## [17.2.12] - 2026-08-08
+
+### Fixed
 
 - Fixed shell minimization replacing meaningful `rustc --print` output with `OK`.
 - Fixed shell minimization altering outputs shorter than 1,000 characters; these now pass through unchanged.

--- a/packages/coding-agent/src/autoresearch/index.ts
+++ b/packages/coding-agent/src/autoresearch/index.ts
@@ -320,11 +320,7 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 		runtime.lastRunDuration = pendingRun?.durationSeconds ?? runtime.lastRunDuration;
 		runtime.lastRunAsi = pendingRun?.parsedAsi ?? runtime.lastRunAsi;
 		const state = runtime.state;
-		// `event.systemPrompt` is typed `string[]`, but upstream code paths can leave
-		// it unset (issue #3665). Coerce defensively so the autoresearch block still
-		// renders — the model just loses the upstream prefix for this turn, which is
-		// strictly better than crashing the handler.
-		const basePrompt = Array.isArray(event.systemPrompt) ? event.systemPrompt.join("\n\n") : "";
+		const basePrompt = event.systemPrompt ?? "";
 		const currentSegmentResults = currentResults(state.results, state.currentSegment);
 		const baselineMetric = findBaselineMetric(state.results, state.currentSegment);
 		const baselineRunNumber = findBaselineRunNumber(state.results, state.currentSegment);
@@ -361,58 +357,54 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 				? null
 				: "Heads up: you are not on a dedicated `autoresearch/*` branch. `log_experiment discard` will only revert run-modified files, not reset to baseline — so harness files written before `init_experiment` may not survive a discard. Clean the worktree and re-run `/autoresearch` if you want full revert safety.";
 			return {
-				systemPrompt: [
-					prompt.render(setupPromptTemplate, {
-						base_system_prompt: basePrompt,
-						has_goal: goal.trim().length > 0,
-						goal,
-						working_dir: ctx.cwd,
-						has_branch: Boolean(currentBranch),
-						branch: currentBranch ?? "",
-						has_baseline_warning: baselineWarning !== null,
-						baseline_warning: baselineWarning ?? "",
-					}),
-				],
-			};
-		}
-		return {
-			systemPrompt: [
-				prompt.render(promptTemplate, {
+				systemPrompt: prompt.render(setupPromptTemplate, {
 					base_system_prompt: basePrompt,
 					has_goal: goal.trim().length > 0,
 					goal,
 					working_dir: ctx.cwd,
-					default_metric_name: state.metricName,
-					metric_name: state.metricName,
-					has_branch: Boolean(state.branch),
-					branch: state.branch,
-					has_baseline_commit: Boolean(state.baselineCommit),
-					baseline_commit: state.baselineCommit ? state.baselineCommit.slice(0, 12) : "",
-					has_notes: state.notes.trim().length > 0,
-					notes: state.notes,
-					current_segment: state.currentSegment + 1,
-					current_segment_run_count: currentSegmentResults.length,
-					has_baseline_metric: baselineMetric !== null,
-					baseline_metric_display: formatNum(baselineMetric, state.metricUnit),
-					baseline_run_number: baselineRunNumber,
-					has_best_result: bestResult !== null && bestMetric !== null,
-					best_metric_display: bestMetric !== null ? formatNum(bestMetric, state.metricUnit) : "-",
-					best_run_number: bestResult ? (bestResult.runNumber ?? state.results.indexOf(bestResult) + 1) : null,
-					has_recent_results: recentResults.length > 0,
-					recent_results: recentResults,
-					has_unjustified_runs: unjustifiedRuns.length > 0,
-					unjustified_runs: unjustifiedRuns,
-					has_pending_run: Boolean(pendingRun),
-					pending_run_number: pendingRun?.runNumber,
-					pending_run_command: pendingRun?.command,
-					pending_run_passed: pendingRun?.passed ?? false,
-					has_pending_run_metric: pendingRun?.parsedPrimary !== null && pendingRun?.parsedPrimary !== undefined,
-					pending_run_metric_display:
-						pendingRun?.parsedPrimary !== null && pendingRun?.parsedPrimary !== undefined
-							? formatNum(pendingRun.parsedPrimary, state.metricUnit)
-							: null,
+					has_branch: Boolean(currentBranch),
+					branch: currentBranch ?? "",
+					has_baseline_warning: baselineWarning !== null,
+					baseline_warning: baselineWarning ?? "",
 				}),
-			],
+			};
+		}
+		return {
+			systemPrompt: prompt.render(promptTemplate, {
+				base_system_prompt: basePrompt,
+				has_goal: goal.trim().length > 0,
+				goal,
+				working_dir: ctx.cwd,
+				default_metric_name: state.metricName,
+				metric_name: state.metricName,
+				has_branch: Boolean(state.branch),
+				branch: state.branch,
+				has_baseline_commit: Boolean(state.baselineCommit),
+				baseline_commit: state.baselineCommit ? state.baselineCommit.slice(0, 12) : "",
+				has_notes: state.notes.trim().length > 0,
+				notes: state.notes,
+				current_segment: state.currentSegment + 1,
+				current_segment_run_count: currentSegmentResults.length,
+				has_baseline_metric: baselineMetric !== null,
+				baseline_metric_display: formatNum(baselineMetric, state.metricUnit),
+				baseline_run_number: baselineRunNumber,
+				has_best_result: bestResult !== null && bestMetric !== null,
+				best_metric_display: bestMetric !== null ? formatNum(bestMetric, state.metricUnit) : "-",
+				best_run_number: bestResult ? (bestResult.runNumber ?? state.results.indexOf(bestResult) + 1) : null,
+				has_recent_results: recentResults.length > 0,
+				recent_results: recentResults,
+				has_unjustified_runs: unjustifiedRuns.length > 0,
+				unjustified_runs: unjustifiedRuns,
+				has_pending_run: Boolean(pendingRun),
+				pending_run_number: pendingRun?.runNumber,
+				pending_run_command: pendingRun?.command,
+				pending_run_passed: pendingRun?.passed ?? false,
+				has_pending_run_metric: pendingRun?.parsedPrimary !== null && pendingRun?.parsedPrimary !== undefined,
+				pending_run_metric_display:
+					pendingRun?.parsedPrimary !== null && pendingRun?.parsedPrimary !== undefined
+						? formatNum(pendingRun.parsedPrimary, state.metricUnit)
+						: null,
+			}),
 		};
 	});
 

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -206,6 +206,10 @@ export interface CustomTool<TParams extends TSchema = TSchema, TDetails = any> {
 	strict?: boolean;
 	/** Description for LLM */
 	description: string;
+	/** Optional one-line snippet exposed for Pi-compatible prompt reconstruction while active. */
+	promptSnippet?: string;
+	/** Optional guideline bullets exposed for Pi-compatible prompt reconstruction while active. */
+	promptGuidelines?: string[];
 	/** Parameter schema (arktype, TypeBox, or legacy formats). */
 	parameters: TParams;
 	/** If true, tool is excluded unless explicitly listed in --tools or agent's tools field */

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1385,7 +1385,11 @@ export class ExtensionRunner {
 						messages.push(result.message);
 					}
 					if (result.systemPrompt !== undefined) {
-						currentSystemPrompt = result.systemPrompt;
+						// Upstream Pi returns a string; omp extensions predating this
+						// contract still return string[]. Normalize both to the string
+						// the event now carries so the wrapped result is never nested.
+						const override = result.systemPrompt as string | readonly string[];
+						currentSystemPrompt = typeof override === "string" ? override : override.join("\n\n");
 						systemPromptModified = true;
 					}
 				}

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -26,6 +26,7 @@ import type {
 	AssistantThinkingRenderer,
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
+	BeforeAgentStartSystemPromptOptions,
 	BeforeProviderRequestEvent,
 	BeforeProviderRequestEventResult,
 	CompactOptions,
@@ -1351,10 +1352,11 @@ export class ExtensionRunner {
 		prompt: string,
 		images: ImageContent[] | undefined,
 		systemPrompt: string[],
+		systemPromptOptions: BeforeAgentStartSystemPromptOptions,
 	): Promise<BeforeAgentStartCombinedResult | undefined> {
 		const ctx = this.createContext();
 		const messages: NonNullable<BeforeAgentStartEventResult["message"]>[] = [];
-		let currentSystemPrompt = systemPrompt;
+		let currentSystemPrompt = systemPrompt.join("\n\n");
 		let systemPromptModified = false;
 
 		for (const ext of this.extensions) {
@@ -1367,6 +1369,7 @@ export class ExtensionRunner {
 					prompt,
 					images,
 					systemPrompt: currentSystemPrompt,
+					systemPromptOptions,
 				};
 				const handlerResult = await this.#runHandlerWithTimeout(
 					handler,
@@ -1382,8 +1385,7 @@ export class ExtensionRunner {
 						messages.push(result.message);
 					}
 					if (result.systemPrompt !== undefined) {
-						currentSystemPrompt =
-							typeof result.systemPrompt === "string" ? [result.systemPrompt] : result.systemPrompt;
+						currentSystemPrompt = result.systemPrompt;
 						systemPromptModified = true;
 					}
 				}
@@ -1393,7 +1395,7 @@ export class ExtensionRunner {
 		if (messages.length > 0 || systemPromptModified) {
 			return {
 				messages: messages.length > 0 ? messages : undefined,
-				systemPrompt: systemPromptModified ? currentSystemPrompt : undefined,
+				systemPrompt: systemPromptModified ? [currentSystemPrompt] : undefined,
 			};
 		}
 

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -552,6 +552,10 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	label: string;
 	/** Description for LLM */
 	description: string;
+	/** Optional one-line snippet exposed for Pi-compatible prompt reconstruction while active. */
+	promptSnippet?: string;
+	/** Optional guideline bullets exposed for Pi-compatible prompt reconstruction while active. */
+	promptGuidelines?: string[];
 	/** Parameter schema (Zod, or TypeBox for legacy/extension compat). */
 	parameters: TParams;
 	/** If true, tool is excluded unless explicitly listed in --tools or agent's tools field */

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -103,6 +103,7 @@ import type {
 	TurnEndEvent,
 	TurnStartEvent,
 } from "../shared-events";
+import type { Skill } from "../skills";
 import type { SlashCommandInfo } from "../slash-commands";
 
 export type { AppKeybinding, KeybindingsManager } from "../../config/keybindings";
@@ -681,12 +682,25 @@ export interface AfterProviderResponseEvent extends ProviderResponseMetadata {
 	type: "after_provider_response";
 }
 
+/** Structured inputs used to build the system prompt exposed to Pi-compatible extensions. */
+export interface BeforeAgentStartSystemPromptOptions {
+	customPrompt?: string;
+	selectedTools?: string[];
+	toolSnippets?: Record<string, string>;
+	promptGuidelines?: string[];
+	appendSystemPrompt?: string;
+	cwd: string;
+	contextFiles?: Array<{ path: string; content: string }>;
+	skills?: readonly Skill[];
+}
+
 /** Fired after user submits prompt but before agent loop. */
 export interface BeforeAgentStartEvent {
 	type: "before_agent_start";
 	prompt: string;
 	images?: ImageContent[];
-	systemPrompt: string[];
+	systemPrompt: string;
+	systemPromptOptions: BeforeAgentStartSystemPromptOptions;
 }
 
 export type {
@@ -1063,7 +1077,7 @@ export type { ToolResultEventResult } from "../shared-events";
 export interface BeforeAgentStartEventResult {
 	message?: CustomMessagePayload;
 	/** Replace the system prompt for this turn. If multiple extensions return this, they are chained. */
-	systemPrompt?: string[];
+	systemPrompt?: string;
 }
 
 export type {

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -103,7 +103,6 @@ import type {
 	TurnEndEvent,
 	TurnStartEvent,
 } from "../shared-events";
-import type { Skill } from "../skills";
 import type { SlashCommandInfo } from "../slash-commands";
 
 export type { AppKeybinding, KeybindingsManager } from "../../config/keybindings";
@@ -686,6 +685,21 @@ export interface AfterProviderResponseEvent extends ProviderResponseMetadata {
 	type: "after_provider_response";
 }
 
+/**
+ * Skill projected into the upstream Pi `Skill` shape for
+ * {@link BeforeAgentStartSystemPromptOptions}. Pi extensions filter on the
+ * required `disableModelInvocation` flag (never omp's `hide`), so the host maps
+ * `hide === true` onto it here rather than leaking the native skill object.
+ */
+export interface BeforeAgentStartSkill {
+	name: string;
+	description: string;
+	filePath: string;
+	baseDir: string;
+	disableModelInvocation: boolean;
+	sourceInfo: SourceInfo;
+}
+
 /** Structured inputs used to build the system prompt exposed to Pi-compatible extensions. */
 export interface BeforeAgentStartSystemPromptOptions {
 	customPrompt?: string;
@@ -695,7 +709,7 @@ export interface BeforeAgentStartSystemPromptOptions {
 	appendSystemPrompt?: string;
 	cwd: string;
 	contextFiles?: Array<{ path: string; content: string }>;
-	skills?: readonly Skill[];
+	skills?: BeforeAgentStartSkill[];
 }
 
 /** Fired after user submits prompt but before agent loop. */

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -15,6 +15,7 @@ import autoloadTemplate from "../prompts/skills/autoload.md" with { type: "text"
 import userInvocationTemplate from "../prompts/skills/user-invocation.md" with { type: "text" };
 import type { SkillPromptDetails } from "../session/messages";
 import { expandTilde } from "../tools/path-utils";
+import type { BeforeAgentStartSkill } from "./extensions/types";
 export interface Skill {
 	name: string;
 	description: string;
@@ -64,6 +65,29 @@ export function setActiveSkills(value: readonly Skill[]): void {
 /** Reset the active skill snapshot. Test-only. */
 export function resetActiveSkillsForTests(): void {
 	activeSkills = [];
+}
+
+/**
+ * Project omp skills into the upstream Pi `Skill` shape for the
+ * `before_agent_start` event options. Pi extensions filter on the required
+ * `disableModelInvocation` flag, so `hide === true` maps onto it; `sourceInfo`
+ * is synthesized best-effort from the skill's capability metadata.
+ */
+export function projectSkillsForBeforeAgentStart(skills: readonly Skill[]): BeforeAgentStartSkill[] {
+	return skills.map(skill => ({
+		name: skill.name,
+		description: skill.description,
+		filePath: skill.filePath,
+		baseDir: skill.baseDir,
+		disableModelInvocation: skill.hide === true,
+		sourceInfo: {
+			path: skill._source?.path ?? skill.filePath,
+			source: skill.source,
+			scope: skill._source?.level === "user" ? "user" : skill._source?.level === "native" ? "temporary" : "project",
+			origin: skill.containRoot ? "package" : "top-level",
+			baseDir: skill.baseDir,
+		},
+	}));
 }
 
 /**

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -81,6 +81,7 @@ import {
 import { discoverCustomToolPaths, loadCustomTools, type ToolPathWithSource } from "./extensibility/custom-tools";
 import type { CustomTool, CustomToolContext, CustomToolSessionEvent } from "./extensibility/custom-tools/types";
 import {
+	type BeforeAgentStartSystemPromptOptions,
 	discoverAndLoadExtensions,
 	discoverExtensionPaths,
 	type ExtensionContext,
@@ -2781,6 +2782,11 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		const eagerTasksAlways = settings.get("task.eager") === "always";
 		const intentField = $flag("PI_INTENT_TRACING", settings.get("tools.intentTracing")) ? INTENT_FIELD : undefined;
 		const includeWorkspaceTree = settings.get("includeWorkspaceTree") ?? false;
+		let currentSystemPromptOptions: BeforeAgentStartSystemPromptOptions = {
+			cwd: sessionManager.getCwd(),
+			selectedTools: [],
+			skills,
+		};
 		const rebuildSystemPrompt = async (
 			toolNames: string[],
 			tools: Map<string, AgentTool>,
@@ -2865,6 +2871,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					? `${appendPrompt}\n\n${options.appendSystemPrompt}`
 					: options.appendSystemPrompt;
 			}
+			const promptSkills = session?.skills ?? skills;
 			const defaultPrompt = await buildSystemPromptInternal({
 				cwd: promptCwd,
 				additionalWorkspaceRoots: sessionManager.getAdditionalDirectories(),
@@ -2873,7 +2880,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					? xdevDocsAll(toolSession.xdev, settings.get("tools.xdevDocs"), settings.get("tools.xdevInlineDevices"))
 					: "",
 				resolvedCustomPrompt: options.customSystemPrompt,
-				skills: session?.skills ?? skills,
+				skills: promptSkills,
 				contextFiles,
 				tools: promptTools,
 				toolNames,
@@ -2905,6 +2912,14 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				renderMermaid: settings.get("tui.renderMermaid"),
 				activeRepoContext,
 			});
+			currentSystemPromptOptions = {
+				customPrompt: options.customSystemPrompt,
+				selectedTools: toolNames,
+				appendSystemPrompt: appendPrompt,
+				cwd: promptCwd,
+				contextFiles,
+				skills: promptSkills,
+			};
 
 			if (options.systemPrompt === undefined) {
 				return defaultPrompt;
@@ -3388,6 +3403,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			preferWebsockets: preferOpenAICodexWebsockets,
 			convertToLlm: convertToLlmFinal,
 			rebuildSystemPrompt,
+			getSystemPromptOptions: () => currentSystemPromptOptions,
 			getXdevToolEntries: () => (toolSession.xdev ? xdevEntries(toolSession.xdev) : []),
 			xdev: toolSession.xdev,
 			presentationPinnedToolNames: explicitlyRequestedToolNameSet,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -97,6 +97,7 @@ import {
 } from "./extensibility/extensions";
 import {
 	loadSkills as loadSkillsInternal,
+	projectSkillsForBeforeAgentStart,
 	type Skill,
 	type SkillWarning,
 	setActiveSkills,
@@ -2785,7 +2786,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		let currentSystemPromptOptions: BeforeAgentStartSystemPromptOptions = {
 			cwd: sessionManager.getCwd(),
 			selectedTools: [],
-			skills,
+			skills: projectSkillsForBeforeAgentStart(skills),
 		};
 		const rebuildSystemPrompt = async (
 			toolNames: string[],
@@ -2924,26 +2925,41 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				renderMermaid: settings.get("tui.renderMermaid"),
 				activeRepoContext,
 			});
-			currentSystemPromptOptions = {
-				customPrompt: options.customSystemPrompt,
-				selectedTools: toolNames,
-				toolSnippets: Object.fromEntries(toolSnippetEntries),
-				promptGuidelines,
-				appendSystemPrompt: appendPrompt,
-				cwd: promptCwd,
-				contextFiles: defaultPrompt.contextFiles,
-				skills: promptSkills,
-			};
-
 			if (options.systemPrompt === undefined) {
+				// The default builder output IS the emitted prompt: expose its
+				// resolved inputs. `appendSystemPrompt` is the caller/user input
+				// only — host-generated memory/MCP/auto-learn sections (folded into
+				// `appendPrompt`) are deliberately excluded so a Pi extension does
+				// not treat changing host state as a cache-stable prefix.
+				currentSystemPromptOptions = {
+					customPrompt: options.customSystemPrompt,
+					selectedTools: toolNames,
+					toolSnippets: Object.fromEntries(toolSnippetEntries),
+					promptGuidelines,
+					appendSystemPrompt: options.appendSystemPrompt,
+					cwd: promptCwd,
+					contextFiles: defaultPrompt.contextFiles,
+					skills: projectSkillsForBeforeAgentStart(promptSkills),
+				};
 				return defaultPrompt;
 			}
+			// A full SDK `systemPrompt` override replaces the built prompt. The
+			// default builder's context files, skills, snippets, and guidelines are
+			// NOT in the emitted prompt, so exposing them would misrepresent it.
+			// Surface the override as the Pi `customPrompt` and drop the discarded
+			// structured inputs.
 			const customPrompt =
 				typeof options.systemPrompt === "function"
 					? options.systemPrompt(defaultPrompt.systemPrompt)
 					: options.systemPrompt;
+			const customBlocks = typeof customPrompt === "string" ? [customPrompt] : customPrompt;
+			currentSystemPromptOptions = {
+				customPrompt: customBlocks.join("\n\n"),
+				selectedTools: toolNames,
+				cwd: promptCwd,
+			};
 			return {
-				systemPrompt: typeof customPrompt === "string" ? [customPrompt] : customPrompt,
+				systemPrompt: customBlocks,
 				contextFiles: defaultPrompt.contextFiles,
 			};
 		};

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2931,7 +2931,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				promptGuidelines,
 				appendSystemPrompt: appendPrompt,
 				cwd: promptCwd,
-				contextFiles,
+				contextFiles: defaultPrompt.contextFiles,
 				skills: promptSkills,
 			};
 
@@ -2944,6 +2944,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					: options.systemPrompt;
 			return {
 				systemPrompt: typeof customPrompt === "string" ? [customPrompt] : customPrompt,
+				contextFiles: defaultPrompt.contextFiles,
 			};
 		};
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2866,6 +2866,18 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				tools,
 				nativeTools && !inlineToolDescriptors ? { mode: "compact", toolNames } : { mode: "full" },
 			);
+			const toolSnippetEntries: Array<[string, string]> = [];
+			const promptGuidelines: string[] = [];
+			const seenPromptGuidelines = new Set<string>();
+			for (const name of toolNames) {
+				const metadata = promptTools.get(name);
+				if (metadata?.promptSnippet) toolSnippetEntries.push([name, metadata.promptSnippet]);
+				for (const guideline of metadata?.promptGuidelines ?? []) {
+					if (seenPromptGuidelines.has(guideline)) continue;
+					seenPromptGuidelines.add(guideline);
+					promptGuidelines.push(guideline);
+				}
+			}
 			if (options.appendSystemPrompt) {
 				appendPrompt = appendPrompt
 					? `${appendPrompt}\n\n${options.appendSystemPrompt}`
@@ -2915,6 +2927,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			currentSystemPromptOptions = {
 				customPrompt: options.customSystemPrompt,
 				selectedTools: toolNames,
+				toolSnippets: Object.fromEntries(toolSnippetEntries),
+				promptGuidelines,
 				appendSystemPrompt: appendPrompt,
 				cwd: promptCwd,
 				contextFiles,

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -28,8 +28,7 @@ import type { CursorMcpResourceAdapter } from "../cursor";
 import type { RawSseDebugBuffer } from "../debug/raw-sse-buffer";
 import type { TtsrManager } from "../export/ttsr";
 import type { LoadedCustomCommand } from "../extensibility/custom-commands";
-import type { ExtensionRunner } from "../extensibility/extensions";
-import type { ContextUsage } from "../extensibility/extensions/types";
+import type { BeforeAgentStartSystemPromptOptions, ContextUsage, ExtensionRunner } from "../extensibility/extensions";
 import type { Skill, SkillWarning } from "../extensibility/skills";
 import type { FileSlashCommand } from "../extensibility/slash-commands";
 import type { SecretObfuscator } from "../secrets/obfuscator";
@@ -207,6 +206,8 @@ export interface AgentSessionConfig {
 		toolNames: string[],
 		tools: Map<string, AgentTool>,
 	) => Promise<{ systemPrompt: string[]; xdevCatalogNames?: readonly string[] }>;
+	/** Current resolved inputs for Pi-compatible `before_agent_start` events. */
+	getSystemPromptOptions?: () => BeforeAgentStartSystemPromptOptions;
 	/** Local calendar date provider used by prompt-cache invalidation. */
 	getLocalCalendarDate?: () => string;
 	/** Tools mounted under `xd://`, for `/tools` display. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1245,6 +1245,7 @@ export class AgentSession {
 			presentationPinnedToolNames: config.presentationPinnedToolNames,
 			ensureWriteRegistered: config.ensureWriteRegistered,
 			rebuildSystemPrompt: config.rebuildSystemPrompt,
+			getSystemPromptOptions: config.getSystemPromptOptions,
 			getLocalCalendarDate: config.getLocalCalendarDate,
 			getMcpServerInstructions: config.getMcpServerInstructions,
 			xdev: config.xdev,
@@ -5363,6 +5364,7 @@ export class AgentSession {
 					expandedText,
 					options?.images,
 					beforeAgentStartSystemPrompt,
+					this.#tools.getSystemPromptOptions(),
 				);
 				if (result?.messages) {
 					const promptAttribution: "user" | "agent" | undefined =

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1252,14 +1252,16 @@ export class SessionTools {
 	 *      `tool.customWireName` and overrides the internal name on the model wire
 	 *      (e.g. `edit` exposes itself as `apply_patch` to GPT-5 in apply_patch mode);
 	 *      a stale wire name would desync prompt guidance from actual tool routing.
-	 *   3. The bounded mounted-MCP projection: escaped original-name labels,
+	 *   3. Active tool prompt snippets and guideline bullets. These feed both the
+	 *      rendered prompt and the Pi-compatible `systemPromptOptions` snapshot,
+	 *      so a metadata-only tool replacement must refresh both.
+	 *   4. The bounded mounted-MCP projection: escaped original-name labels,
 	 *      actual `xd://` paths, and the omission flag in catalog order. These are
 	 *      the exact values rendered by the global transport guidance; catalog
 	 *      churn wholly behind the fallback does not change the prompt.
-	 *   4. MCP server instructions text (per server), since `rebuildSystemPrompt`
+	 *   5. MCP server instructions text (per server), since `rebuildSystemPrompt`
 	 *      embeds these in the appended prompt under "## MCP Server Instructions".
 	 *      A server upgrade can change instructions while keeping tools identical.
-	 *
 	 * Settings-driven tool metadata is covered automatically: built-in tools that
 	 * depend on settings expose `description`/`label` via getters (see `TaskTool`,
 	 * `SearchToolBm25Tool`, `EditTool`), and the signature reads them live on every
@@ -1286,6 +1288,9 @@ export class SessionTools {
 		const describeTool = (tool: AgentTool): string =>
 			`${tool.name}=${tool.label ?? ""}|${tool.description ?? ""}|${tool.customWireName ?? ""}`;
 		const descriptionSegment = tools.map(describeTool).join("\u0002");
+		const promptMetadataSegment =
+			JSON.stringify(tools.map(tool => [tool.name, tool.promptSnippet ?? null, tool.promptGuidelines ?? null])) ??
+			"[]";
 		const mountedMCPProjection = projectMountedMCPXdevGuidance(
 			collectMountedMCPToolRoutes(this.#xdev ? listXdevTools(this.#xdev) : []),
 		);
@@ -1312,7 +1317,7 @@ export class SessionTools {
 		// exception above, bounded to the exact projection rendered in the global
 		// route guidance so churn wholly behind its fallback does not rebuild.
 		const date = this.#getLocalCalendarDate();
-		return `${nameSegment}\u0003${descriptionSegment}\u0007${instructionsSegment}\u0008${mountedMCPRouteSegment}|${date}`;
+		return `${nameSegment}\u0003${descriptionSegment}\u0007${promptMetadataSegment}\u0009${instructionsSegment}\u0008${mountedMCPRouteSegment}|${date}`;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -7,7 +7,12 @@ import { formatModelString } from "../config/model-resolver";
 import type { Settings, SkillsSettings } from "../config/settings";
 import type { CustomTool, CustomToolContext } from "../extensibility/custom-tools/types";
 import { CustomToolAdapter } from "../extensibility/custom-tools/wrapper";
-import type { ExtensionRunner, SourceInfo, ToolInfo } from "../extensibility/extensions";
+import type {
+	BeforeAgentStartSystemPromptOptions,
+	ExtensionRunner,
+	SourceInfo,
+	ToolInfo,
+} from "../extensibility/extensions";
 import { ExtensionToolWrapper } from "../extensibility/extensions/wrapper";
 import { loadSkills, type Skill, type SkillWarning, setActiveSkills } from "../extensibility/skills";
 import { type LocalProtocolOptions, XD_URL_PREFIX } from "../internal-urls";
@@ -76,6 +81,7 @@ interface SessionToolsOptions {
 		toolNames: string[],
 		tools: Map<string, AgentTool>,
 	) => Promise<{ systemPrompt: string[]; xdevCatalogNames?: readonly string[] }>;
+	getSystemPromptOptions?: () => BeforeAgentStartSystemPromptOptions;
 	getLocalCalendarDate?: () => string;
 	getMcpServerInstructions?: () => Map<string, string> | undefined;
 	xdev?: XdevState;
@@ -219,6 +225,7 @@ export class SessionTools {
 	#mcpRefreshTail: Promise<void> = Promise.resolve();
 	#promptModelKey: string | undefined;
 	#rebuildSystemPrompt: SessionToolsOptions["rebuildSystemPrompt"];
+	#getSystemPromptOptions: SessionToolsOptions["getSystemPromptOptions"];
 	#getLocalCalendarDate: () => string;
 	#getMcpServerInstructions: SessionToolsOptions["getMcpServerInstructions"];
 	#setActiveToolNames: SessionToolsOptions["setActiveToolNames"];
@@ -240,6 +247,7 @@ export class SessionTools {
 		this.#presentationPinnedToolNames = options.presentationPinnedToolNames;
 		this.#ensureWriteRegistered = options.ensureWriteRegistered;
 		this.#rebuildSystemPrompt = options.rebuildSystemPrompt;
+		this.#getSystemPromptOptions = options.getSystemPromptOptions;
 		this.#getLocalCalendarDate = options.getLocalCalendarDate ?? formatLocalCalendarDate;
 		this.#getMcpServerInstructions = options.getMcpServerInstructions;
 		this.#xdev = options.xdev;
@@ -264,6 +272,16 @@ export class SessionTools {
 	/** Current stable base system prompt. */
 	get baseSystemPrompt(): string[] {
 		return this.#baseSystemPrompt;
+	}
+	/** Current resolved inputs for Pi-compatible `before_agent_start` events. */
+	getSystemPromptOptions(): BeforeAgentStartSystemPromptOptions {
+		return (
+			this.#getSystemPromptOptions?.() ?? {
+				cwd: this.#host.sessionManager.getCwd(),
+				selectedTools: this.getActiveToolNames(),
+				skills: this.#skills,
+			}
+		);
 	}
 
 	/** Replaces the controller-owned base prompt without applying it to the agent. */

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -14,7 +14,13 @@ import type {
 	ToolInfo,
 } from "../extensibility/extensions";
 import { ExtensionToolWrapper } from "../extensibility/extensions/wrapper";
-import { loadSkills, type Skill, type SkillWarning, setActiveSkills } from "../extensibility/skills";
+import {
+	loadSkills,
+	projectSkillsForBeforeAgentStart,
+	type Skill,
+	type SkillWarning,
+	setActiveSkills,
+} from "../extensibility/skills";
 import { type LocalProtocolOptions, XD_URL_PREFIX } from "../internal-urls";
 import { deduplicateMCPToolsByName } from "../mcp/tool-bridge";
 import { resolveMemoryBackend } from "../memory-backend/resolve";
@@ -279,7 +285,7 @@ export class SessionTools {
 			this.#getSystemPromptOptions?.() ?? {
 				cwd: this.#host.sessionManager.getCwd(),
 				selectedTools: this.getActiveToolNames(),
-				skills: this.#skills,
+				skills: projectSkillsForBeforeAgentStart(this.#skills),
 			}
 		);
 	}

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -470,9 +470,10 @@ export function projectSystemPromptToolMetadata(
 		const wireNameValue = override?.wireName ?? tool.customWireName;
 		const label = typeof labelValue === "string" ? labelValue : "";
 		const wireName = typeof wireNameValue === "string" ? wireNameValue : undefined;
-		const promptSnippet = normalizeToolPromptSnippet(
-			override?.promptSnippet ?? tool.promptSnippet ?? tool.summary ?? tool.description,
-		);
+		// Pi's `toolSnippets` map carries only an explicit one-line `promptSnippet`.
+		// NEVER fall back to `summary`/`description`: compact projection MUST NOT
+		// read the lazy descriptor getters (system-prompt-inventory contract).
+		const promptSnippet = normalizeToolPromptSnippet(override?.promptSnippet ?? tool.promptSnippet);
 		const promptGuidelines = normalizeToolPromptGuidelines(override?.promptGuidelines ?? tool.promptGuidelines);
 
 		if (projection.mode === "compact") {

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -595,12 +595,18 @@ export interface BuildSystemPromptResult {
 	 * a catalog the prompt already carries (issue #7139).
 	 */
 	xdevCatalogNames?: readonly string[];
+	/**
+	 * Fully resolved context files rendered into the prompt, including entries
+	 * discovered for `additionalWorkspaceRoots`. Lets callers expose the exact
+	 * set the builder used (e.g. Pi's `before_agent_start.systemPromptOptions`).
+	 */
+	contextFiles: Array<{ path: string; content: string; depth?: number }>;
 }
 
 /** Build the system prompt with tools, guidelines, and context */
 export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}): Promise<BuildSystemPromptResult> {
 	if ($env.NULL_PROMPT === "true") {
-		return { systemPrompt: [] };
+		return { systemPrompt: [], contextFiles: [] };
 	}
 
 	const {
@@ -941,5 +947,5 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	// default template; a resolved custom prompt uses a template that omits it.
 	const xdevCatalogNames =
 		!resolvedCustomPrompt && xdevTools.length > 0 ? xdevTools.map(mounted => mounted.name) : undefined;
-	return { systemPrompt, xdevCatalogNames };
+	return { systemPrompt, xdevCatalogNames, contextFiles };
 }

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -420,6 +420,24 @@ export interface SystemPromptToolMetadata {
 	parameters?: TSchema;
 	/** Illustrative examples rendered into the verbose inventory. */
 	examples?: readonly ToolExample[];
+	/** One-line Pi-compatible tool summary for system-prompt reconstruction. */
+	promptSnippet?: string;
+	/** Pi-compatible guideline bullets active with this tool. */
+	promptGuidelines?: readonly string[];
+}
+
+function normalizeToolPromptSnippet(value: string | undefined): string | undefined {
+	const normalized = value
+		?.replace(/[\r\n]+/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+	return normalized || undefined;
+}
+
+function normalizeToolPromptGuidelines(values: readonly string[] | undefined): readonly string[] | undefined {
+	if (!values) return undefined;
+	const normalized = [...new Set(values.map(value => value.trim()).filter(value => value.length > 0))];
+	return normalized.length > 0 ? normalized : undefined;
 }
 
 export type SystemPromptToolMetadataProjection =
@@ -452,9 +470,13 @@ export function projectSystemPromptToolMetadata(
 		const wireNameValue = override?.wireName ?? tool.customWireName;
 		const label = typeof labelValue === "string" ? labelValue : "";
 		const wireName = typeof wireNameValue === "string" ? wireNameValue : undefined;
+		const promptSnippet = normalizeToolPromptSnippet(
+			override?.promptSnippet ?? tool.promptSnippet ?? tool.summary ?? tool.description,
+		);
+		const promptGuidelines = normalizeToolPromptGuidelines(override?.promptGuidelines ?? tool.promptGuidelines);
 
 		if (projection.mode === "compact") {
-			metadata.set(name, { label, description: "", wireName });
+			metadata.set(name, { label, description: "", wireName, promptSnippet, promptGuidelines });
 			return;
 		}
 
@@ -465,6 +487,8 @@ export function projectSystemPromptToolMetadata(
 			parameters: tool.parameters,
 			examples: tool.examples,
 			wireName,
+			promptSnippet,
+			promptGuidelines,
 		});
 	};
 

--- a/packages/coding-agent/test/agent-session-before-agent-start-prompt-override.test.ts
+++ b/packages/coding-agent/test/agent-session-before-agent-start-prompt-override.test.ts
@@ -54,12 +54,11 @@ describe("AgentSession before_agent_start system prompt override", () => {
 	 * re-reads `state.systemPrompt` for the request — reproducing a rebuild that
 	 * lands in the window between the hook and the provider request.
 	 */
-	function createSession(
-		responses: MockResponseSource,
-		options: { rebuildInWindow?: boolean } = {},
-	): { session: AgentSession; systemPrompts: string[][] } {
+	function createSession(responses: MockResponseSource, options: { rebuildInWindow?: boolean } = {}) {
 		const mock = createMockModel({ responses });
 		const systemPrompts: string[][] = [];
+		const systemPromptOptions = { cwd: "/workspace", selectedTools: ["read"] };
+		const emitBeforeAgentStart = vi.fn(async () => ({ systemPrompt: [OVERRIDE] }));
 
 		const agent = new Agent({
 			getApiKey: () => "test-key",
@@ -82,10 +81,11 @@ describe("AgentSession before_agent_start system prompt override", () => {
 			settings: Settings.isolated({ "compaction.enabled": false, "todo.enabled": false }),
 			modelRegistry: { getApiKey: async () => "test-key" } as never,
 			extensionRunner: {
-				emitBeforeAgentStart: async () => ({ systemPrompt: [OVERRIDE] }),
+				emitBeforeAgentStart,
 				emit: async () => undefined,
 			} as unknown as ExtensionRunner,
 			rebuildSystemPrompt: async () => ({ systemPrompt: [REBUILT_BASE] }),
+			getSystemPromptOptions: () => systemPromptOptions,
 		});
 		const activeSession = session;
 
@@ -98,7 +98,7 @@ describe("AgentSession before_agent_start system prompt override", () => {
 			});
 		}
 
-		return { session, systemPrompts };
+		return { session, systemPrompts, emitBeforeAgentStart, systemPromptOptions };
 	}
 
 	it("keeps the override when a base rebuild fires in the prompt window", async () => {
@@ -111,6 +111,15 @@ describe("AgentSession before_agent_start system prompt override", () => {
 		// override must still reach the provider instead of the rebuilt base.
 		expect(systemPrompts).toHaveLength(1);
 		expect(systemPrompts[0]).toEqual([OVERRIDE]);
+	});
+
+	it("forwards resolved system prompt options to before_agent_start", async () => {
+		const { session, emitBeforeAgentStart, systemPromptOptions } = createSession([{ content: ["Done"] }]);
+
+		await session.prompt("hello");
+		await session.waitForIdle();
+
+		expect(emitBeforeAgentStart).toHaveBeenCalledWith("hello", undefined, ["initial-base"], systemPromptOptions);
 	});
 
 	it("falls back to the rebuilt base once the turn ends", async () => {

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -50,11 +50,18 @@ function createBasicTool(name: string, label: string, description = `${label} to
 	};
 }
 
-function createMcpCustomTool(name: string, serverName: string, mcpToolName: string, description: string): CustomTool {
+function createMcpCustomTool(
+	name: string,
+	serverName: string,
+	mcpToolName: string,
+	description: string,
+	promptMetadata: { promptSnippet?: string; promptGuidelines?: string[] } = {},
+): CustomTool {
 	return {
 		name,
 		label: `${serverName}/${mcpToolName}`,
 		description,
+		...promptMetadata,
 		parameters: type({ q: "string" }),
 		strict: true,
 		mcpServerName: serverName,
@@ -213,6 +220,37 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 
 		await session.refreshMCPTools([initialMcp]);
 		expect(rebuildCount).toBe(1);
+	});
+
+	it("rebuilds when active tool prompt metadata changes", async () => {
+		let rebuildCount = 0;
+		const { session } = newSession(async toolNames => {
+			rebuildCount++;
+			return `tools:${toolNames.join(",")}`;
+		});
+		const makeSearch = (promptMetadata: { promptSnippet: string; promptGuidelines: string[] }): CustomTool =>
+			createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus", promptMetadata);
+
+		await session.refreshMCPTools([
+			makeSearch({ promptSnippet: "Search v1", promptGuidelines: ["Use stable queries."] }),
+		]);
+		expect(rebuildCount).toBe(1);
+
+		await session.refreshMCPTools([
+			makeSearch({ promptSnippet: "Search v2", promptGuidelines: ["Use stable queries."] }),
+		]);
+		expect(rebuildCount).toBe(2);
+
+		await session.refreshMCPTools([
+			makeSearch({ promptSnippet: "Search v2", promptGuidelines: ["Prefer exact queries."] }),
+		]);
+		expect(rebuildCount).toBe(3);
+
+		// Byte-identical metadata still preserves the provider prompt cache.
+		await session.refreshMCPTools([
+			makeSearch({ promptSnippet: "Search v2", promptGuidelines: ["Prefer exact queries."] }),
+		]);
+		expect(rebuildCount).toBe(3);
 	});
 
 	it("warns and keeps the stable winner when distinct MCP tools mint the same name", async () => {

--- a/packages/coding-agent/test/autoresearch-before-agent-start.test.ts
+++ b/packages/coding-agent/test/autoresearch-before-agent-start.test.ts
@@ -106,13 +106,10 @@ describe("autoresearch before_agent_start handler", () => {
 
 		const result = (await handlers.before_agent_start(event, ctx)) as BeforeAgentStartEventResult;
 		expect(result).toBeDefined();
-		expect(Array.isArray(result.systemPrompt)).toBe(true);
-		const blocks = result.systemPrompt as string[];
-		expect(blocks).toHaveLength(1);
-		expect(blocks[0]).toContain("Autoresearch Mode");
+		expect(result.systemPrompt).toContain("Autoresearch Mode");
 	});
 
-	it("joins event.systemPrompt blocks into the rendered base prompt", async () => {
+	it("preserves event.systemPrompt at the start of the rendered prompt", async () => {
 		const { handlers } = buildHarness();
 		if (!handlers.session_start || !handlers.before_agent_start) {
 			throw new Error("Autoresearch extension should register both session_start and before_agent_start");
@@ -124,12 +121,12 @@ describe("autoresearch before_agent_start handler", () => {
 		const event: BeforeAgentStartEvent = {
 			type: "before_agent_start",
 			prompt: "kick off",
-			systemPrompt: ["alpha block", "beta block"],
+			systemPrompt: "alpha block\n\nbeta block",
+			systemPromptOptions: { cwd: cwdDir.path() },
 		};
 
 		const result = (await handlers.before_agent_start(event, ctx)) as BeforeAgentStartEventResult;
 		expect(result).toBeDefined();
-		const rendered = (result.systemPrompt as string[])[0];
-		expect(rendered.startsWith("alpha block\n\nbeta block")).toBe(true);
+		expect(result.systemPrompt?.startsWith("alpha block\n\nbeta block")).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -173,6 +173,35 @@ describe("ExtensionRunner", () => {
 		});
 	});
 
+	it("flattens legacy array systemPrompt overrides so the result is never nested", async () => {
+		const extCode = `
+			export default function(pi) {
+				pi.on("before_agent_start", () => ({
+					systemPrompt: ["legacy block one", "legacy block two"],
+				}));
+			}
+		`;
+		fs.writeFileSync(path.join(extensionsDir, "legacy-array-override.ts"), extCode);
+		const result = await loadTestExtensions();
+		const runner = new ExtensionRunner(
+			result.extensions,
+			result.runtime,
+			tempDir.path(),
+			sessionManager,
+			modelRegistry,
+		);
+
+		const emitted = await runner.emitBeforeAgentStart("hello", undefined, ["base prompt"], {
+			cwd: tempDir.path(),
+			selectedTools: ["read"],
+			skills: [],
+		});
+
+		// A pre-contract extension returning string[] must be joined into a single
+		// string block, not stored as a nested array the provider cannot consume.
+		expect(emitted?.systemPrompt).toEqual(["legacy block one\n\nlegacy block two"]);
+	});
+
 	describe("shortcut conflicts", () => {
 		it("warns when extension shortcut conflicts with built-in", async () => {
 			const extCode = `

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -118,6 +118,61 @@ describe("ExtensionRunner", () => {
 		expect(runner.createContext().cwd).toBe(dirB);
 	});
 
+	it("emits Pi-compatible before_agent_start prompt inputs and chains string overrides", async () => {
+		const extCode = `
+			export default function(pi) {
+				pi.on("before_agent_start", event => ({
+					systemPrompt: event.systemPrompt + "\\nfirst override",
+				}));
+				pi.on("before_agent_start", event => ({
+					message: {
+						customType: "capture",
+						content: JSON.stringify({
+							systemPrompt: event.systemPrompt,
+							systemPromptOptions: event.systemPromptOptions,
+						}),
+						display: false,
+					},
+				}));
+			}
+		`;
+		fs.writeFileSync(path.join(extensionsDir, "before-agent-start.ts"), extCode);
+		const result = await loadTestExtensions();
+		const runner = new ExtensionRunner(
+			result.extensions,
+			result.runtime,
+			tempDir.path(),
+			sessionManager,
+			modelRegistry,
+		);
+		const systemPromptOptions = {
+			cwd: tempDir.path(),
+			selectedTools: ["read"],
+			contextFiles: [{ path: "AGENTS.md", content: "Project rules" }],
+			skills: [],
+		};
+
+		const emitted = await runner.emitBeforeAgentStart(
+			"hello",
+			undefined,
+			["base prompt", "project context"],
+			systemPromptOptions,
+		);
+
+		expect(emitted?.systemPrompt).toEqual(["base prompt\n\nproject context\nfirst override"]);
+		const message = emitted?.messages?.[0];
+		if (!message || typeof message !== "object" || Array.isArray(message)) {
+			throw new Error("Expected captured event message");
+		}
+		const { content } = message;
+		expect(typeof content).toBe("string");
+		if (typeof content !== "string") throw new Error("Expected captured event JSON");
+		expect(JSON.parse(content)).toEqual({
+			systemPrompt: "base prompt\n\nproject context\nfirst override",
+			systemPromptOptions,
+		});
+	});
+
 	describe("shortcut conflicts", () => {
 		it("warns when extension shortcut conflicts with built-in", async () => {
 			const extCode = `

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -10,6 +10,7 @@ import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { CursorExecHandlers } from "@oh-my-pi/pi-coding-agent/cursor";
+import type { BeforeAgentStartSystemPromptOptions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import type { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import {
 	type CreateAgentSessionOptions,
@@ -673,6 +674,47 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			for (const provider of providers) modelRegistry.authStorage.removeRuntimeApiKey(provider);
 		}
 	};
+
+	it("forwards active tool snippets and guidelines in before_agent_start prompt options", async () => {
+		const tempDir = makeTempDir();
+		let captured: BeforeAgentStartSystemPromptOptions | undefined;
+		const metadataExtension: ExtensionFactory = pi => {
+			pi.registerTool({
+				name: "prompt_metadata_probe",
+				label: "Prompt Metadata Probe",
+				description: "Fallback description that should not replace the explicit snippet.",
+				promptSnippet: "  Inspect\n prompt metadata   safely. ",
+				promptGuidelines: [" Keep prompt metadata stable. ", "", "Keep prompt metadata stable."],
+				loadMode: "essential",
+				parameters: type({}),
+				async execute() {
+					return { content: [{ type: "text", text: "done" }] };
+				},
+			});
+			pi.on("before_agent_start", event => {
+				captured = event.systemPromptOptions;
+			});
+		};
+
+		await withProviderAuth(["openai"], async () => {
+			const { session } = await createAgentSession({
+				...baseOptions(tempDir),
+				extensions: [metadataExtension],
+			});
+			const mock = createMockModel({ responses: [{ content: [{ type: "text", text: "done" }] }] });
+			vi.spyOn(session.agent, "streamFn").mockImplementation(mock.stream);
+			try {
+				await session.prompt("inspect metadata");
+				const promptOptions = captured;
+				if (!promptOptions) throw new Error("before_agent_start did not expose prompt options");
+				expect(promptOptions.selectedTools).toContain("prompt_metadata_probe");
+				expect(promptOptions.toolSnippets?.prompt_metadata_probe).toBe("Inspect prompt metadata safely.");
+				expect(promptOptions.promptGuidelines).toEqual(["Keep prompt metadata stable."]);
+			} finally {
+				await session.dispose();
+			}
+		});
+	});
 
 	it("answers a native pi_edit after a session switches onto Cursor", async () => {
 		const tempDir = makeTempDir();

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -716,6 +716,47 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		});
 	});
 
+	it("exposes additional-root context files in before_agent_start prompt options", async () => {
+		const tempDir = makeTempDir();
+		const extraRoot = makeTempDir();
+		const extraAgentsPath = path.join(extraRoot, "AGENTS.md");
+		fs.writeFileSync(extraAgentsPath, "# Extra Root Rules\n\nMulti-root marker directive.\n");
+
+		const sessionManager = SessionManager.inMemory(tempDir);
+		await sessionManager.setAdditionalDirectories([extraRoot]);
+		expect(sessionManager.getAdditionalDirectories()).toContain(extraRoot);
+
+		let captured: BeforeAgentStartSystemPromptOptions | undefined;
+		const captureExtension: ExtensionFactory = pi => {
+			pi.on("before_agent_start", event => {
+				captured = event.systemPromptOptions;
+			});
+		};
+
+		await withProviderAuth(["openai"], async () => {
+			const { session } = await createAgentSession({
+				...baseOptions(tempDir),
+				// Let the builder discover context files for both roots instead of
+				// the empty override, so the snapshot reflects the merged set.
+				contextFiles: undefined,
+				sessionManager,
+				extensions: [captureExtension],
+			});
+			const mock = createMockModel({ responses: [{ content: [{ type: "text", text: "done" }] }] });
+			vi.spyOn(session.agent, "streamFn").mockImplementation(mock.stream);
+			try {
+				await session.prompt("inspect context");
+				const promptOptions = captured;
+				if (!promptOptions) throw new Error("before_agent_start did not expose prompt options");
+				const extraEntry = promptOptions.contextFiles?.find(file => file.path === extraAgentsPath);
+				expect(extraEntry).toBeDefined();
+				expect(extraEntry?.content).toContain("Multi-root marker directive.");
+			} finally {
+				await session.dispose();
+			}
+		});
+	});
+
 	it("answers a native pi_edit after a session switches onto Cursor", async () => {
 		const tempDir = makeTempDir();
 		const cursorModel = getBundledModel("cursor", "composer-1.5");

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -757,6 +757,99 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		});
 	});
 
+	it("projects skills into the Pi shape with disableModelInvocation", async () => {
+		const tempDir = makeTempDir();
+		const visibleSkill = {
+			name: "visible-skill",
+			description: "A visible skill.",
+			filePath: path.join(tempDir, "visible", "SKILL.md"),
+			baseDir: path.join(tempDir, "visible"),
+			source: "project",
+		};
+		const hiddenSkill = {
+			name: "hidden-skill",
+			description: "A hidden skill.",
+			filePath: path.join(tempDir, "hidden", "SKILL.md"),
+			baseDir: path.join(tempDir, "hidden"),
+			source: "project",
+			hide: true,
+		};
+
+		let captured: BeforeAgentStartSystemPromptOptions | undefined;
+		const captureExtension: ExtensionFactory = pi => {
+			pi.on("before_agent_start", event => {
+				captured = event.systemPromptOptions;
+			});
+		};
+
+		await withProviderAuth(["openai"], async () => {
+			const { session } = await createAgentSession({
+				...baseOptions(tempDir),
+				skills: [visibleSkill, hiddenSkill],
+				extensions: [captureExtension],
+			});
+			const mock = createMockModel({ responses: [{ content: [{ type: "text", text: "done" }] }] });
+			vi.spyOn(session.agent, "streamFn").mockImplementation(mock.stream);
+			try {
+				await session.prompt("inspect skills");
+				const promptOptions = captured;
+				if (!promptOptions) throw new Error("before_agent_start did not expose prompt options");
+				const projected = promptOptions.skills ?? [];
+				const visible = projected.find(skill => skill.name === "visible-skill");
+				const hidden = projected.find(skill => skill.name === "hidden-skill");
+				expect(visible?.disableModelInvocation).toBe(false);
+				expect(hidden?.disableModelInvocation).toBe(true);
+				// The Pi shape omits omp's `hide`/`source` fields in favor of the
+				// required flag and a synthesized sourceInfo.
+				expect(hidden).not.toHaveProperty("hide");
+				expect(hidden?.sourceInfo.path).toBe(hiddenSkill.filePath);
+			} finally {
+				await session.dispose();
+			}
+		});
+	});
+
+	it("describes the emitted custom prompt, not discarded builder inputs, when systemPrompt overrides", async () => {
+		const tempDir = makeTempDir();
+		const override = "CUSTOM SYSTEM PROMPT OVERRIDE";
+		let captured: BeforeAgentStartSystemPromptOptions | undefined;
+		const captureExtension: ExtensionFactory = pi => {
+			pi.on("before_agent_start", event => {
+				captured = event.systemPromptOptions;
+			});
+		};
+
+		await withProviderAuth(["openai"], async () => {
+			const { session } = await createAgentSession({
+				...baseOptions(tempDir),
+				systemPrompt: [override],
+				skills: [
+					{
+						name: "discarded-skill",
+						description: "Present only in the discarded default prompt.",
+						filePath: path.join(tempDir, "discarded", "SKILL.md"),
+						baseDir: path.join(tempDir, "discarded"),
+						source: "project",
+					},
+				],
+				extensions: [captureExtension],
+			});
+			const mock = createMockModel({ responses: [{ content: [{ type: "text", text: "done" }] }] });
+			vi.spyOn(session.agent, "streamFn").mockImplementation(mock.stream);
+			try {
+				await session.prompt("inspect override");
+				const promptOptions = captured;
+				if (!promptOptions) throw new Error("before_agent_start did not expose prompt options");
+				expect(promptOptions.customPrompt).toBe(override);
+				// The default builder's skills/context are not in the emitted prompt.
+				expect(promptOptions.skills).toBeUndefined();
+				expect(promptOptions.contextFiles).toBeUndefined();
+			} finally {
+				await session.dispose();
+			}
+		});
+	});
+
 	it("answers a native pi_edit after a session switches onto Cursor", async () => {
 		const tempDir = makeTempDir();
 		const cursorModel = getBundledModel("cursor", "composer-1.5");


### PR DESCRIPTION
## Repro
A legacy Pi extension whose `before_agent_start` handler throws when `event.systemPromptOptions` is absent fails on the first turn with `omp -e /tmp/omp-8058-repro.ts -p "reply with exactly: ok"`; 17.2.12 logs `Extension error (...): before_agent_start: systemPromptOptions is missing`.

## Cause
`ExtensionRunner.emitBeforeAgentStart` in `packages/coding-agent/src/extensibility/extensions/runner.ts` built the host event with only `prompt`, `images`, and the array-valued `systemPrompt`. `AgentSession.prompt` had no path for the resolved inputs assembled by `rebuildSystemPrompt` in `packages/coding-agent/src/sdk.ts`, so the legacy import remap could load upstream Pi extensions but could not provide their required event shape.

## Fix
- Capture the current resolved cwd, selected tools, context files, skills, custom prompt, and appended prompt during each system-prompt rebuild.
- Forward those inputs through `AgentSession` and include them as `systemPromptOptions` on every `before_agent_start` event.
- Emit and chain the upstream string-valued `systemPrompt` contract, converting the final override back to the host's internal prompt-block array.
- Update autoresearch and add runner/session regression coverage for the event payload and chained override.

## Verification
`bun test packages/coding-agent/test/extensions-runner.test.ts packages/coding-agent/test/autoresearch-before-agent-start.test.ts packages/coding-agent/test/agent-session-before-agent-start-prompt-override.test.ts` — 78 passed, 0 failed. `bun run check:types` in `packages/coding-agent` passed. `bun packages/coding-agent/src/cli.ts -e /tmp/omp-8058-repro.ts -p "reply with exactly: ok"` completed with `ok` and no extension error.

Fixes #8058