### PR TITLE
feat(ai): surface Antigravity quota summary windows

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Antigravity's authoritative Gemini and shared Claude/GPT five-hour and weekly quota windows to `omp usage`, with compatibility fallback to legacy model quotas ([#8061](https://github.com/can1357/oh-my-pi/pull/8061) by [@paolomazzitti](https://github.com/paolomazzitti)).
+
 ## [17.3.4] - 2026-08-14
 
 ### Fixed

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -66,7 +66,11 @@ interface AntigravityQuotaSummaryGroup {
 
 interface AntigravityQuotaSummaryResponse {
 	groups?: AntigravityQuotaSummaryGroup[];
-	response?: { groups?: AntigravityQuotaSummaryGroup[] };
+	buckets?: AntigravityQuotaSummaryBucket[];
+	response?: {
+		groups?: AntigravityQuotaSummaryGroup[];
+		buckets?: AntigravityQuotaSummaryBucket[];
+	};
 }
 
 const DEFAULT_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
@@ -264,7 +268,11 @@ function normalizeQuotaInfos(info: AntigravityModelInfo): AntigravityQuotaInfo[]
 }
 
 function quotaSummaryGroups(data: AntigravityQuotaSummaryResponse): AntigravityQuotaSummaryGroup[] {
-	return data.response?.groups ?? data.groups ?? [];
+	const groups = data.response?.groups ?? data.groups;
+	if (groups && groups.length > 0) return groups;
+	const buckets = data.response?.buckets ?? data.buckets;
+	if (buckets && buckets.length > 0) return [{ buckets }];
+	return [];
 }
 
 function quotaSummaryRemainingFraction(bucket: AntigravityQuotaSummaryBucket): number | undefined {

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -12,7 +12,7 @@ import type {
 	UsageStatus,
 	UsageWindow,
 } from "../usage";
-import { DAY_MS, parseIsoTimestamp, WEEK_MS } from "./shared";
+import { DAY_MS, HOUR_MS, parseIsoTimestamp, WEEK_MS } from "./shared";
 
 // (Refresh is the sole responsibility of AuthStorage; no provider-direct refresh here.)
 
@@ -72,7 +72,7 @@ interface AntigravityQuotaSummaryResponse {
 const DEFAULT_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
 const FETCH_AVAILABLE_MODELS_PATH = "/v1internal:fetchAvailableModels";
 const RETRIEVE_USER_QUOTA_SUMMARY_PATH = "/v1internal:retrieveUserQuotaSummary";
-const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
+const FIVE_HOURS_MS = 5 * HOUR_MS;
 
 interface AntigravityWindowDescriptor {
 	id: string;
@@ -410,7 +410,7 @@ async function fetchAntigravityUsage(params: UsageFetchParams, ctx: UsageFetchCo
 				if (response.ok) return { response, endpoint };
 				if (!AIError.isTransientStatus(response.status)) break;
 			} catch (error) {
-				if (endpoint === endpoints[endpoints.length - 1]) throw error;
+				if (params.signal?.aborted || endpoint === endpoints[endpoints.length - 1]) throw error;
 			}
 		}
 		return response ? { response, endpoint: attemptedEndpoint } : undefined;
@@ -420,26 +420,33 @@ async function fetchAntigravityUsage(params: UsageFetchParams, ctx: UsageFetchCo
 	// account-wide pools: Gemini and third-party models, each with 5h and weekly
 	// buckets. The legacy per-model response below does not identify those pools
 	// reliably, so use it only when the summary endpoint is unavailable.
-	const summaryResult = await requestEndpoint(RETRIEVE_USER_QUOTA_SUMMARY_PATH);
-	if (summaryResult?.response.ok) {
-		const summaryData = (await summaryResult.response.json()) as AntigravityQuotaSummaryResponse;
-		const summaryLimits = buildQuotaSummaryLimits(summaryData, params);
-		if (summaryLimits.length > 0) {
-			const metadata: UsageReport["metadata"] = {
-				endpoint: summaryResult.endpoint,
-				usageSource: "retrieveUserQuotaSummary",
-				projectId: credential.projectId,
-			};
-			if (credential.email) metadata.email = credential.email;
-			if (credential.accountId) metadata.accountId = credential.accountId;
-			return {
-				provider: params.provider,
-				fetchedAt: nowMs,
-				limits: summaryLimits,
-				metadata,
-				raw: summaryData,
-			};
+	try {
+		const summaryResult = await requestEndpoint(RETRIEVE_USER_QUOTA_SUMMARY_PATH);
+		if (summaryResult?.response.ok) {
+			const summaryData = (await summaryResult.response.json()) as AntigravityQuotaSummaryResponse;
+			const summaryLimits = buildQuotaSummaryLimits(summaryData, params);
+			if (summaryLimits.length > 0) {
+				const metadata: UsageReport["metadata"] = {
+					endpoint: summaryResult.endpoint,
+					usageSource: "retrieveUserQuotaSummary",
+					projectId: credential.projectId,
+				};
+				if (credential.email) metadata.email = credential.email;
+				if (credential.accountId) metadata.accountId = credential.accountId;
+				return {
+					provider: params.provider,
+					fetchedAt: nowMs,
+					limits: summaryLimits,
+					metadata,
+					raw: summaryData,
+				};
+			}
 		}
+	} catch (error) {
+		if (params.signal?.aborted) throw error;
+		ctx.logger?.debug("Antigravity quota summary unavailable; falling back to model quotas", {
+			error: String(error),
+		});
 	}
 
 	const modelsResult = await requestEndpoint(FETCH_AVAILABLE_MODELS_PATH);
@@ -577,13 +584,28 @@ export const antigravityUsageProvider: UsageProvider = {
 	supports: params => params.provider === "google-antigravity",
 };
 
-function getAntigravityCounterKeysForModel(context: CredentialRankingContext | undefined): string[] {
+type AntigravityModelFamily = "anthropic" | "google" | "openai";
+
+function getAntigravityModelFamily(context: CredentialRankingContext | undefined): AntigravityModelFamily | undefined {
 	const modelId = context?.modelId?.toLowerCase();
-	if (!modelId) return [];
-	if (modelId.startsWith("claude-")) return ["third-party", "anthropic"];
-	if (modelId.startsWith("gemini-") || modelId.startsWith("gemma-")) return ["google"];
-	if (modelId.startsWith("gpt-") || modelId.startsWith("openai/")) return ["third-party", "openai"];
-	return [];
+	if (!modelId) return undefined;
+	if (modelId.startsWith("claude-")) return "anthropic";
+	if (modelId.startsWith("gemini-") || modelId.startsWith("gemma-")) return "google";
+	if (modelId.startsWith("gpt-") || modelId.startsWith("openai/")) return "openai";
+	return undefined;
+}
+
+function getAntigravityCounterKeysForModel(context: CredentialRankingContext | undefined): string[] {
+	switch (getAntigravityModelFamily(context)) {
+		case "anthropic":
+			return ["third-party", "anthropic"];
+		case "google":
+			return ["google"];
+		case "openai":
+			return ["third-party", "openai"];
+		default:
+			return [];
+	}
 }
 
 function getAntigravityCounterLimits(report: UsageReport, counterKey: string): UsageLimit[] {
@@ -629,11 +651,12 @@ export const antigravityRankingStrategy: CredentialRankingStrategy = {
 		return { primary: rankAntigravityLimits(report, context)[0] };
 	},
 	scopeLimits: scopeAntigravityLimitsForModel,
-	// Always return a scope for Antigravity so missing/unknown model context
-	// cannot fall through to AuthStorage's provider-wide block bucket.
+	// Reactive backoff remains family-specific because the legacy report has
+	// separate Anthropic and OpenAI counters, while blockScope has no report
+	// source. Summary exhaustion still reaches both through model-scoped usage.
+	// Unknown context gets a local scope rather than a provider-wide block.
 	blockScope(context) {
-		const counterKey = getAntigravityCounterKeysForModel(context)[0];
-		return `counter:${counterKey ?? "unknown"}`;
+		return `counter:${getAntigravityModelFamily(context) ?? "unknown"}`;
 	},
 	// Summary windows carry `durationMs`; fall back to daily only for legacy
 	// unlabelled quotaInfo entries from `fetchAvailableModels`.

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -45,8 +45,34 @@ interface AntigravityUsageResponse {
 	models: Record<string, AntigravityModelInfo>;
 }
 
+interface AntigravityQuotaSummaryBucket {
+	bucketId?: string;
+	displayName?: string;
+	window?: string;
+	remainingFraction?: number;
+	remaining?: {
+		remainingFraction?: number;
+		case?: string;
+		value?: number;
+	};
+	resetTime?: string;
+	disabled?: boolean;
+}
+
+interface AntigravityQuotaSummaryGroup {
+	displayName?: string;
+	buckets?: AntigravityQuotaSummaryBucket[];
+}
+
+interface AntigravityQuotaSummaryResponse {
+	groups?: AntigravityQuotaSummaryGroup[];
+	response?: { groups?: AntigravityQuotaSummaryGroup[] };
+}
+
 const DEFAULT_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
 const FETCH_AVAILABLE_MODELS_PATH = "/v1internal:fetchAvailableModels";
+const RETRIEVE_USER_QUOTA_SUMMARY_PATH = "/v1internal:retrieveUserQuotaSummary";
+const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
 
 interface AntigravityWindowDescriptor {
 	id: string;
@@ -58,6 +84,9 @@ function classifyWindow(id: string | undefined, label: string | undefined): Anti
 	const source = `${id ?? ""} ${label ?? ""}`.toLowerCase();
 	if (source.includes("week") || source.includes("7d") || /7[\s_-]*day/.test(source)) {
 		return { id: "weekly", label: "Weekly", durationMs: WEEK_MS };
+	}
+	if (source.includes("5h") || source.includes("five hour") || /5[\s_-]*hour/.test(source)) {
+		return { id: "5h", label: "Five Hour", durationMs: FIVE_HOURS_MS };
 	}
 	if (source.includes("day") || source.includes("daily") || source.includes("24h")) {
 		return { id: "daily", label: "Daily", durationMs: DAY_MS };
@@ -234,6 +263,106 @@ function normalizeQuotaInfos(info: AntigravityModelInfo): AntigravityQuotaInfo[]
 	return results;
 }
 
+function quotaSummaryGroups(data: AntigravityQuotaSummaryResponse): AntigravityQuotaSummaryGroup[] {
+	return data.response?.groups ?? data.groups ?? [];
+}
+
+function quotaSummaryRemainingFraction(bucket: AntigravityQuotaSummaryBucket): number | undefined {
+	if (bucket.remainingFraction !== undefined) return bucket.remainingFraction;
+	if (bucket.remaining?.remainingFraction !== undefined) return bucket.remaining.remainingFraction;
+	if (bucket.remaining?.case === "remainingFraction") return bucket.remaining.value;
+	return undefined;
+}
+
+function quotaSummaryCounter(
+	group: AntigravityQuotaSummaryGroup,
+	bucket: AntigravityQuotaSummaryBucket,
+): { key: string; label: string } | undefined {
+	const bucketId = bucket.bucketId?.toLowerCase();
+	const groupName = group.displayName?.toLowerCase() ?? "";
+	if (bucketId === "gemini-5h" || bucketId === "gemini-weekly") {
+		return { key: "google", label: group.displayName ?? "Gemini Models" };
+	}
+	if (bucketId === "3p-5h" || bucketId === "3p-weekly") {
+		return { key: "third-party", label: group.displayName ?? "Claude and GPT Models" };
+	}
+	if (bucketId) return undefined;
+	if (groupName.includes("gemini")) return { key: "google", label: group.displayName ?? "Gemini Models" };
+	if (groupName.includes("claude") || groupName.includes("gpt") || groupName.includes("third party")) {
+		return { key: "third-party", label: group.displayName ?? "Claude and GPT Models" };
+	}
+	return undefined;
+}
+
+function quotaSummaryWindow(bucket: AntigravityQuotaSummaryBucket): AntigravityWindowDescriptor | undefined {
+	switch (bucket.bucketId?.toLowerCase()) {
+		case "gemini-5h":
+		case "3p-5h":
+			return classifyWindow("5h", bucket.displayName);
+		case "gemini-weekly":
+		case "3p-weekly":
+			return classifyWindow("weekly", bucket.displayName);
+		default:
+			return bucket.bucketId ? undefined : classifyWindow(bucket.window, bucket.displayName);
+	}
+}
+
+function buildQuotaSummaryLimits(data: AntigravityQuotaSummaryResponse, params: UsageFetchParams): UsageLimit[] {
+	const credential = params.credential;
+	const deduped = new Map<string, UsageLimit>();
+
+	for (const group of quotaSummaryGroups(data)) {
+		for (const bucket of group.buckets ?? []) {
+			if (bucket.disabled) continue;
+			const counter = quotaSummaryCounter(group, bucket);
+			const descriptor = quotaSummaryWindow(bucket);
+			if (!counter || !descriptor) continue;
+
+			const quotaInfo: AntigravityQuotaInfo = {
+				remainingFraction: quotaSummaryRemainingFraction(bucket),
+				resetTime: bucket.resetTime,
+				windowId: descriptor.id,
+				windowLabel: descriptor.label,
+			};
+			if (quotaInfo.remainingFraction === undefined && quotaInfo.resetTime === undefined) continue;
+
+			const amount = buildAmount(quotaInfo);
+			const window = parseWindow(quotaInfo, descriptor);
+			const key = `${counter.key}|${descriptor.id}`;
+			const limit: UsageLimit = {
+				id: `${params.provider}:${counter.key}:default:${descriptor.id}`,
+				label: counter.label,
+				scope: {
+					provider: params.provider,
+					accountId: credential.accountId,
+					projectId: credential.projectId,
+					windowId: descriptor.id,
+				},
+				window,
+				amount,
+				status: getUsageStatus(amount.remainingFraction),
+			};
+
+			const existing = deduped.get(key);
+			const existingFraction = existing?.amount.remainingFraction;
+			const nextFraction = amount.remainingFraction;
+			if (
+				!existing ||
+				(existingFraction === undefined && nextFraction !== undefined) ||
+				(existingFraction !== undefined && nextFraction !== undefined && nextFraction < existingFraction)
+			) {
+				deduped.set(key, limit);
+			}
+		}
+	}
+
+	return [...deduped.values()].sort((a, b) => {
+		const aFraction = a.amount.remainingFraction ?? 1;
+		const bFraction = b.amount.remainingFraction ?? 1;
+		return aFraction - bFraction;
+	});
+}
+
 /**
  * Return the OAuth access token to use against `/v1internal:*`. AuthStorage is
  * the sole refresh authority (broker-aware, single-flighted, rotation-safe);
@@ -261,46 +390,68 @@ async function fetchAntigravityUsage(params: UsageFetchParams, ctx: UsageFetchCo
 	const baseUrl = params.baseUrl?.replace(/\/+$/, "");
 	const endpoints = baseUrl ? [baseUrl] : [DEFAULT_ENDPOINT, "https://daily-cloudcode-pa.sandbox.googleapis.com"];
 
-	let response: Response | undefined;
-	let successfulEndpoint = DEFAULT_ENDPOINT;
-	for (const endpoint of endpoints) {
-		try {
-			const url = `${endpoint}${FETCH_AVAILABLE_MODELS_PATH}`;
-			response = await ctx.fetch(url, {
-				method: "POST",
-				headers: {
-					Authorization: `Bearer ${accessToken}`,
-					"Content-Type": "application/json",
-					"User-Agent": getAntigravityUserAgent(),
-				},
-				body: JSON.stringify({ project: credential.projectId }),
-				signal: params.signal,
-			});
+	const requestEndpoint = async (path: string): Promise<{ response: Response; endpoint: string } | undefined> => {
+		let response: Response | undefined;
+		let attemptedEndpoint = DEFAULT_ENDPOINT;
+		for (const endpoint of endpoints) {
+			attemptedEndpoint = endpoint;
+			try {
+				response = await ctx.fetch(`${endpoint}${path}`, {
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${accessToken}`,
+						"Content-Type": "application/json",
+						"User-Agent": getAntigravityUserAgent(),
+					},
+					body: JSON.stringify({ project: credential.projectId }),
+					signal: params.signal,
+				});
 
-			if (response.ok) {
-				successfulEndpoint = endpoint;
-				break;
+				if (response.ok) return { response, endpoint };
+				if (!AIError.isTransientStatus(response.status)) break;
+			} catch (error) {
+				if (endpoint === endpoints[endpoints.length - 1]) throw error;
 			}
+		}
+		return response ? { response, endpoint: attemptedEndpoint } : undefined;
+	};
 
-			if (AIError.isTransientStatus(response.status)) {
-				continue;
-			}
-			break;
-		} catch (error) {
-			if (endpoint === endpoints[endpoints.length - 1]) {
-				throw error;
-			}
+	// This endpoint backs the Antigravity usage screen and exposes the real
+	// account-wide pools: Gemini and third-party models, each with 5h and weekly
+	// buckets. The legacy per-model response below does not identify those pools
+	// reliably, so use it only when the summary endpoint is unavailable.
+	const summaryResult = await requestEndpoint(RETRIEVE_USER_QUOTA_SUMMARY_PATH);
+	if (summaryResult?.response.ok) {
+		const summaryData = (await summaryResult.response.json()) as AntigravityQuotaSummaryResponse;
+		const summaryLimits = buildQuotaSummaryLimits(summaryData, params);
+		if (summaryLimits.length > 0) {
+			const metadata: UsageReport["metadata"] = {
+				endpoint: summaryResult.endpoint,
+				usageSource: "retrieveUserQuotaSummary",
+				projectId: credential.projectId,
+			};
+			if (credential.email) metadata.email = credential.email;
+			if (credential.accountId) metadata.accountId = credential.accountId;
+			return {
+				provider: params.provider,
+				fetchedAt: nowMs,
+				limits: summaryLimits,
+				metadata,
+				raw: summaryData,
+			};
 		}
 	}
 
-	if (!response?.ok) {
+	const modelsResult = await requestEndpoint(FETCH_AVAILABLE_MODELS_PATH);
+	if (!modelsResult?.response.ok) {
 		ctx.logger?.warn("Antigravity usage fetch failed", {
-			status: response?.status ?? 0,
-			statusText: response?.statusText ?? "unknown",
+			status: modelsResult?.response.status ?? 0,
+			statusText: modelsResult?.response.statusText ?? "unknown",
 		});
 		return null;
 	}
-	const data = (await response.json()) as AntigravityUsageResponse;
+	const successfulEndpoint = modelsResult.endpoint;
+	const data = (await modelsResult.response.json()) as AntigravityUsageResponse;
 
 	// The API returns per-model quota entries, but quota is shared across
 	// models within the same backend counter, tier, and reset window. Keep
@@ -426,13 +577,13 @@ export const antigravityUsageProvider: UsageProvider = {
 	supports: params => params.provider === "google-antigravity",
 };
 
-function getAntigravityCounterKeyForModel(context: CredentialRankingContext | undefined): string | undefined {
+function getAntigravityCounterKeysForModel(context: CredentialRankingContext | undefined): string[] {
 	const modelId = context?.modelId?.toLowerCase();
-	if (!modelId) return undefined;
-	if (modelId.startsWith("claude-")) return "anthropic";
-	if (modelId.startsWith("gemini-") || modelId.startsWith("gemma-")) return "google";
-	if (modelId.startsWith("gpt-") || modelId.startsWith("openai/")) return "openai";
-	return undefined;
+	if (!modelId) return [];
+	if (modelId.startsWith("claude-")) return ["third-party", "anthropic"];
+	if (modelId.startsWith("gemini-") || modelId.startsWith("gemma-")) return ["google"];
+	if (modelId.startsWith("gpt-") || modelId.startsWith("openai/")) return ["third-party", "openai"];
+	return [];
 }
 
 function getAntigravityCounterLimits(report: UsageReport, counterKey: string): UsageLimit[] {
@@ -447,22 +598,23 @@ function scopeAntigravityLimitsForModel(
 	report: UsageReport,
 	context: CredentialRankingContext | undefined,
 ): UsageLimit[] {
-	const counterKey = getAntigravityCounterKeyForModel(context);
-	if (!counterKey) return [];
-	const backendLimits = getAntigravityCounterLimits(report, counterKey);
-	if (backendLimits.length > 0) return backendLimits;
-	return getAntigravityCounterLimits(report, "default");
+	const counterKeys = getAntigravityCounterKeysForModel(context);
+	for (const counterKey of counterKeys) {
+		const backendLimits = getAntigravityCounterLimits(report, counterKey);
+		if (backendLimits.length > 0) return backendLimits;
+	}
+	return counterKeys.length > 0 ? getAntigravityCounterLimits(report, "default") : [];
 }
 
 function rankAntigravityLimits(report: UsageReport, context: CredentialRankingContext | undefined): UsageLimit[] {
-	const counterKey = getAntigravityCounterKeyForModel(context);
-	if (!counterKey) return report.limits;
+	if (getAntigravityCounterKeysForModel(context).length === 0) return report.limits;
 	return scopeAntigravityLimitsForModel(report, context);
 }
 
 /**
- * Antigravity quotas are returned per backend counter (Anthropic / Google /
- * OpenAI) and can include both daily and weekly windows. `fetchAntigravityUsage`
+ * Antigravity quota summaries return a Google pool plus a shared third-party
+ * pool for Claude and GPT, each with 5-hour and weekly windows. Legacy fallback
+ * reports can still expose separate Anthropic/OpenAI counters. `fetchAntigravityUsage`
  * sorts `limits` ascending by `remainingFraction`; after model-family scoping,
  * the most-pressured relevant counter/window is index 0.
  *
@@ -480,11 +632,10 @@ export const antigravityRankingStrategy: CredentialRankingStrategy = {
 	// Always return a scope for Antigravity so missing/unknown model context
 	// cannot fall through to AuthStorage's provider-wide block bucket.
 	blockScope(context) {
-		const counterKey = getAntigravityCounterKeyForModel(context);
+		const counterKey = getAntigravityCounterKeysForModel(context)[0];
 		return `counter:${counterKey ?? "unknown"}`;
 	},
-	// Antigravity windows carry `durationMs` when the response identifies them
-	// as daily/weekly. Fall back to daily for legacy unlabelled quotaInfo
-	// entries from `daily-cloudcode-pa.googleapis.com`.
+	// Summary windows carry `durationMs`; fall back to daily only for legacy
+	// unlabelled quotaInfo entries from `fetchAvailableModels`.
 	windowDefaults: { primaryMs: DAY_MS, secondaryMs: DAY_MS },
 };

--- a/packages/ai/test/google-antigravity-usage.test.ts
+++ b/packages/ai/test/google-antigravity-usage.test.ts
@@ -70,6 +70,74 @@ function makeApiModel(
 // ── tests ────────────────────────────────────────────────────────────
 
 describe("antigravity usage provider", () => {
+	it("uses the authoritative 5-hour and weekly quota summary", async () => {
+		const now = Date.now();
+		const urls: string[] = [];
+		const payload = {
+			groups: [
+				{
+					displayName: "Gemini Models",
+					buckets: [
+						{
+							bucketId: "gemini-weekly",
+							displayName: "Weekly Limit Remaining",
+							window: "weekly",
+							remaining: { case: "remainingFraction", value: 0.85 },
+							resetTime: new Date(now + 5 * 24 * 3600_000).toISOString(),
+						},
+						{
+							bucketId: "gemini-5h",
+							displayName: "Five Hour Limit Remaining",
+							window: "5h",
+							remainingFraction: 0.9,
+							resetTime: new Date(now + 4 * 3600_000).toISOString(),
+						},
+						{
+							bucketId: "gemini-image-5h",
+							displayName: "Future image quota",
+							remainingFraction: 0.01,
+						},
+					],
+				},
+				{
+					displayName: "Claude and GPT Models",
+					buckets: [
+						{ bucketId: "3p-weekly", window: "weekly", remainingFraction: 1 },
+						{ bucketId: "3p-5h", window: "5h", remainingFraction: 1 },
+					],
+				},
+			],
+		};
+		const fetchImpl: FetchImpl = async input => {
+			urls.push(String(input));
+			return new Response(JSON.stringify(payload), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		};
+
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential(), signal: undefined },
+			makeCtx(fetchImpl),
+		);
+
+		expect(urls).toHaveLength(1);
+		expect(urls[0]).toEndWith("/v1internal:retrieveUserQuotaSummary");
+		expect(report?.metadata?.usageSource).toBe("retrieveUserQuotaSummary");
+		expect(report?.limits).toHaveLength(4);
+		const geminiWeekly = report?.limits.find(limit => limit.id === "google-antigravity:google:default:weekly");
+		const geminiFiveHour = report?.limits.find(limit => limit.id === "google-antigravity:google:default:5h");
+		const thirdPartyWeekly = report?.limits.find(
+			limit => limit.id === "google-antigravity:third-party:default:weekly",
+		);
+		expect(geminiWeekly?.label).toBe("Gemini Models");
+		expect(geminiWeekly?.window?.durationMs).toBe(7 * 24 * 60 * 60 * 1000);
+		expect(geminiWeekly?.amount.remainingFraction).toBe(0.85);
+		expect(geminiFiveHour?.window?.durationMs).toBe(5 * 60 * 60 * 1000);
+		expect(geminiFiveHour?.amount.remainingFraction).toBe(0.9);
+		expect(thirdPartyWeekly?.label).toBe("Claude and GPT Models");
+	});
+
 	it("merges two models with same tier into one limit", async () => {
 		const payload = {
 			models: {
@@ -373,6 +441,23 @@ describe("antigravity ranking strategy", () => {
 		const { primary, secondary } = antigravityRankingStrategy.findWindowLimits(report);
 		expect(primary).toBe(weekly);
 		expect(secondary).toBeUndefined();
+	});
+
+	it("scopes Claude and GPT models to the shared third-party pool", () => {
+		const thirdParty = makeLimit(0.2, "Claude and GPT Models");
+		thirdParty.id = "google-antigravity:third-party:default:weekly";
+		const google = makeLimit(0.05, "Gemini Models");
+		google.id = "google-antigravity:google:default:weekly";
+		const report = {
+			provider: "google-antigravity" as const,
+			fetchedAt: Date.now(),
+			limits: [google, thirdParty],
+		};
+
+		expect(antigravityRankingStrategy.findWindowLimits(report, { modelId: "claude-sonnet-4-6" }).primary).toBe(
+			thirdParty,
+		);
+		expect(antigravityRankingStrategy.findWindowLimits(report, { modelId: "gpt-oss-120b" }).primary).toBe(thirdParty);
 	});
 
 	it("returns undefined windows when the credential has no usage limits", () => {

--- a/packages/ai/test/google-antigravity-usage.test.ts
+++ b/packages/ai/test/google-antigravity-usage.test.ts
@@ -138,6 +138,83 @@ describe("antigravity usage provider", () => {
 		expect(thirdPartyWeekly?.label).toBe("Claude and GPT Models");
 	});
 
+	it("falls back to model quotas when the summary response is malformed", async () => {
+		let requestCount = 0;
+		const payload = { models: { gemini: makeApiModel("Gemini", { remainingFraction: 0.6 }) } };
+		const fetchImpl: FetchImpl = async input => {
+			requestCount += 1;
+			if (String(input).endsWith("/v1internal:retrieveUserQuotaSummary")) {
+				return new Response("{", { status: 200, headers: { "content-type": "application/json" } });
+			}
+			return new Response(JSON.stringify(payload), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		};
+
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential(), signal: undefined },
+			makeCtx(fetchImpl),
+		);
+
+		expect(requestCount).toBe(2);
+		expect(report?.metadata?.usageSource).toBeUndefined();
+		expect(report?.limits).toHaveLength(1);
+		expect(report?.limits[0]?.amount.remainingFraction).toBe(0.6);
+	});
+
+	it("falls back to model quotas when the summary request fails", async () => {
+		let requestCount = 0;
+		const payload = { models: { gemini: makeApiModel("Gemini", { remainingFraction: 0.7 }) } };
+		const fetchImpl: FetchImpl = async input => {
+			requestCount += 1;
+			if (String(input).endsWith("/v1internal:retrieveUserQuotaSummary")) {
+				throw new Error("summary unavailable");
+			}
+			return new Response(JSON.stringify(payload), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		};
+
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{
+				provider: "google-antigravity",
+				credential: makeCredential(),
+				baseUrl: "https://antigravity.test",
+				signal: undefined,
+			},
+			makeCtx(fetchImpl),
+		);
+
+		expect(requestCount).toBe(2);
+		expect(report?.metadata?.usageSource).toBeUndefined();
+		expect(report?.limits[0]?.amount.remainingFraction).toBe(0.7);
+	});
+
+	it("does not turn cancellation into a legacy fallback request", async () => {
+		const controller = new AbortController();
+		const abortReason = new Error("cancelled");
+		controller.abort(abortReason);
+		let requestCount = 0;
+		const fetchImpl: FetchImpl = async () => {
+			requestCount += 1;
+			throw abortReason;
+		};
+
+		const result = antigravityUsageProvider.fetchUsage!(
+			{
+				provider: "google-antigravity",
+				credential: makeCredential(),
+				signal: controller.signal,
+			},
+			makeCtx(fetchImpl),
+		);
+
+		await expect(result).rejects.toBe(abortReason);
+		expect(requestCount).toBe(1);
+	});
+
 	it("merges two models with same tier into one limit", async () => {
 		const payload = {
 			models: {
@@ -458,6 +535,13 @@ describe("antigravity ranking strategy", () => {
 			thirdParty,
 		);
 		expect(antigravityRankingStrategy.findWindowLimits(report, { modelId: "gpt-oss-120b" }).primary).toBe(thirdParty);
+	});
+
+	it("keeps reactive Claude and GPT blocks family-specific for legacy quotas", () => {
+		expect(antigravityRankingStrategy.blockScope?.({ modelId: "claude-sonnet-4-6" })).toBe("counter:anthropic");
+		expect(antigravityRankingStrategy.blockScope?.({ modelId: "gpt-oss-120b" })).toBe("counter:openai");
+		expect(antigravityRankingStrategy.blockScope?.({ modelId: "gemini-3.5-flash" })).toBe("counter:google");
+		expect(antigravityRankingStrategy.blockScope?.({})).toBe("counter:unknown");
 	});
 
 	it("returns undefined windows when the credential has no usage limits", () => {

--- a/packages/ai/test/google-antigravity-usage.test.ts
+++ b/packages/ai/test/google-antigravity-usage.test.ts
@@ -138,6 +138,58 @@ describe("antigravity usage provider", () => {
 		expect(thirdPartyWeekly?.label).toBe("Claude and GPT Models");
 	});
 
+	it("uses flat top-level quota summary buckets", async () => {
+		const now = Date.now();
+		const urls: string[] = [];
+		const payload = {
+			buckets: [
+				{
+					bucketId: "gemini-weekly",
+					displayName: "Weekly Limit Remaining",
+					remainingFraction: 0.4,
+					resetTime: new Date(now + 5 * 24 * 3600_000).toISOString(),
+				},
+				{
+					bucketId: "gemini-5h",
+					displayName: "Five Hour Limit Remaining",
+					remainingFraction: 0.2,
+					resetTime: new Date(now + 4 * 3600_000).toISOString(),
+				},
+				{ bucketId: "3p-weekly", remainingFraction: 0.7 },
+				{ bucketId: "3p-5h", remainingFraction: 0.5 },
+			],
+		};
+		const fetchImpl: FetchImpl = async input => {
+			urls.push(String(input));
+			return new Response(JSON.stringify(payload), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		};
+
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential(), signal: undefined },
+			makeCtx(fetchImpl),
+		);
+
+		expect(urls).toHaveLength(1);
+		expect(urls[0]).toEndWith("/v1internal:retrieveUserQuotaSummary");
+		expect(report?.metadata?.usageSource).toBe("retrieveUserQuotaSummary");
+		expect(report?.limits).toHaveLength(4);
+		const geminiWeekly = report?.limits.find(limit => limit.id === "google-antigravity:google:default:weekly");
+		const geminiFiveHour = report?.limits.find(limit => limit.id === "google-antigravity:google:default:5h");
+		const thirdPartyWeekly = report?.limits.find(
+			limit => limit.id === "google-antigravity:third-party:default:weekly",
+		);
+		const thirdPartyFiveHour = report?.limits.find(limit => limit.id === "google-antigravity:third-party:default:5h");
+		expect(geminiWeekly?.label).toBe("Gemini Models");
+		expect(geminiWeekly?.amount.remainingFraction).toBe(0.4);
+		expect(geminiFiveHour?.amount.remainingFraction).toBe(0.2);
+		expect(thirdPartyWeekly?.label).toBe("Claude and GPT Models");
+		expect(thirdPartyWeekly?.amount.remainingFraction).toBe(0.7);
+		expect(thirdPartyFiveHour?.amount.remainingFraction).toBe(0.5);
+	});
+
 	it("falls back to model quotas when the summary response is malformed", async () => {
 		let requestCount = 0;
 		const payload = { models: { gemini: makeApiModel("Gemini", { remainingFraction: 0.6 }) } };


### PR DESCRIPTION
## Summary
- prefer Antigravity's authoritative `retrieveUserQuotaSummary` endpoint over inferred per-model windows
- surface the shared Gemini and Claude/GPT five-hour and weekly quota pools in `omp usage`
- retain `fetchAvailableModels` as a compatibility fallback and keep model-aware credential ranking aligned with the shared third-party pool

## Test plan
- [x] `bun test packages/ai/test/google-antigravity-usage.test.ts`
- [x] `bun run check:types` in `packages/ai`
- [x] `bun x biome check packages/ai/src/usage/google-antigravity.ts packages/ai/test/google-antigravity-usage.test.ts`
- [x] live `omp usage --provider google-antigravity` source run shows all four 5h/weekly windows