### PR TITLE
fix(catalog): restore max effort tier for opencode-go deepseek-v4-flash

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored the `max` thinking-effort tier for `opencode-go/deepseek-v4-flash`. Rerouting the model to the responses API in 17.2.12 caused effort derivation to fall through to the generic `[minimal, low, medium, high, xhigh]` responses default; the wire-exact `[low, high, max]` ladder is now applied regardless of API ([#8063](https://github.com/can1357/oh-my-pi/issues/8063)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -366,14 +366,17 @@ function getModelDefinedEfforts<TApi extends Api>(
 	if (spec.provider === "ollama") {
 		return OLLAMA_REASONING_EFFORTS;
 	}
+	// DeepSeek V4 Flash accepts the wire-exact low/high/max ladder on every
+	// host and every wire — the direct API, aggregators, and the opencode-go
+	// responses route alike (medium/xhigh map to high). Ungated by api: the
+	// responses route must keep this ladder, not fall through to the generic
+	// responses default.
+	if (isDeepseekV4FlashModelId(spec.id)) {
+		return LOW_HIGH_MAX_REASONING_EFFORTS;
+	}
 	if (isOpenAICompatReasoningApi(spec.api) && isDeepseekReasoningModel(spec)) {
-		// DeepSeek V4 Flash accepts the wire-exact low/high/max ladder on every
-		// host — the direct API and aggregators alike (medium/xhigh map to
-		// high). V4 Pro and the older reasoners top out at high/max, and
-		// OpenRouter's non-flash DeepSeek route exposes only high.
-		if (isDeepseekV4FlashModelId(spec.id)) {
-			return LOW_HIGH_MAX_REASONING_EFFORTS;
-		}
+		// V4 Pro and the older reasoners top out at high/max, and OpenRouter's
+		// non-flash DeepSeek route exposes only high.
 		return isOpenRouterThinkingFormat(compat) ? HIGH_ONLY_REASONING_EFFORTS : HIGH_MAX_REASONING_EFFORTS;
 	}
 	if (spec.provider === "baseten" && isOpenAIGptOssModelId(spec.id)) {

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -366,21 +366,21 @@ function getModelDefinedEfforts<TApi extends Api>(
 	if (spec.provider === "ollama") {
 		return OLLAMA_REASONING_EFFORTS;
 	}
-	// DeepSeek V4 Flash accepts the wire-exact low/high/max ladder on every
-	// host and every wire — the direct API, aggregators, and the opencode-go
-	// responses route alike. Ungated by api: the responses route must keep
-	// this ladder, not fall through to the generic responses default.
-	//
-	// DeepSeek's official Responses API contract collapses seven effort
-	// spellings onto three distinct strengths (see
-	// https://api-docs.deepseek.com/api/create-response, reasoning.effort):
-	// none=off, minimal/low=low, medium/high/xhigh=high, max=max. Exposing
-	// only the three distinct tiers keeps every selector value 1:1 with a wire
-	// strength — no UI tier silently collapses onto another.
-	if (isDeepseekV4FlashModelId(spec.id)) {
-		return LOW_HIGH_MAX_REASONING_EFFORTS;
-	}
-	if (isOpenAICompatReasoningApi(spec.api) && isDeepseekReasoningModel(spec)) {
+	// DeepSeek reasoning routes that speak a wire `reasoning.effort` ladder:
+	// OpenAI chat/completions, OpenRouter, and the responses API (the
+	// opencode-go route). Gated by api — anthropic-messages and Ollama-cloud
+	// treat these same models as budget-token controls, not an effort ladder,
+	// so they must fall through to their own budget tiers, not this ladder.
+	if ((isOpenAICompatReasoningApi(spec.api) || spec.api === "openai-responses") && isDeepseekReasoningModel(spec)) {
+		// DeepSeek V4 Flash uses the wire-exact low/high/max ladder. DeepSeek's
+		// Responses contract (https://api-docs.deepseek.com/api/create-response,
+		// reasoning.effort) collapses seven spellings onto three strengths:
+		// none=off, minimal/low=low, medium/high/xhigh=high, max=max — so only
+		// these three tiers are wire-exact and every selector maps 1:1 to a
+		// strength (no UI tier silently collapses onto another).
+		if (isDeepseekV4FlashModelId(spec.id)) {
+			return LOW_HIGH_MAX_REASONING_EFFORTS;
+		}
 		// V4 Pro and the older reasoners top out at high/max, and OpenRouter's
 		// non-flash DeepSeek route exposes only high.
 		return isOpenRouterThinkingFormat(compat) ? HIGH_ONLY_REASONING_EFFORTS : HIGH_MAX_REASONING_EFFORTS;

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -368,9 +368,15 @@ function getModelDefinedEfforts<TApi extends Api>(
 	}
 	// DeepSeek V4 Flash accepts the wire-exact low/high/max ladder on every
 	// host and every wire — the direct API, aggregators, and the opencode-go
-	// responses route alike (medium/xhigh map to high). Ungated by api: the
-	// responses route must keep this ladder, not fall through to the generic
-	// responses default.
+	// responses route alike. Ungated by api: the responses route must keep
+	// this ladder, not fall through to the generic responses default.
+	//
+	// DeepSeek's official Responses API contract collapses seven effort
+	// spellings onto three distinct strengths (see
+	// https://api-docs.deepseek.com/api/create-response, reasoning.effort):
+	// none=off, minimal/low=low, medium/high/xhigh=high, max=max. Exposing
+	// only the three distinct tiers keeps every selector value 1:1 with a wire
+	// strength — no UI tier silently collapses onto another.
 	if (isDeepseekV4FlashModelId(spec.id)) {
 		return LOW_HIGH_MAX_REASONING_EFFORTS;
 	}

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -73183,11 +73183,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
-					"medium",
 					"high",
-					"xhigh"
+					"max"
 				]
 			}
 		},

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -66,6 +66,31 @@ describe("model thinking derivation", () => {
 		expect(requireSupportedEffort(model, Effort.XHigh)).toBe(Effort.XHigh);
 	});
 
+	it("scopes the DeepSeek V4 Flash low/high/max ladder to wire-effort routes (#8064 review)", () => {
+		// OpenAI-compatible reasoning routes (chat/completions, OpenRouter) and
+		// the responses API (opencode-go) speak a wire reasoning.effort ladder:
+		// low/high/max.
+		const responses = createModel({ id: "deepseek-v4-flash", api: "openai-responses", provider: "opencode-go" });
+		const completions = createModel({ id: "deepseek-v4-flash", api: "openai-completions", provider: "deepseek" });
+		expect(responses.thinking?.efforts).toEqual([Effort.Low, Effort.High, Effort.Max]);
+		expect(completions.thinking?.efforts).toEqual([Effort.Low, Effort.High, Effort.Max]);
+
+		// anthropic-messages and Ollama-cloud host the same model as budget-token
+		// controls, not an effort ladder — the override must NOT reach them, so
+		// their [minimal, low, medium, high, xhigh] budget tiers survive.
+		const budget = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
+		const umans = createModel({ id: "umans-deepseek-v4-flash-0731", api: "anthropic-messages", provider: "umans" });
+		const vercel = createModel({
+			id: "deepseek/deepseek-v4-flash",
+			api: "anthropic-messages",
+			provider: "vercel-ai-gateway",
+		});
+		const ollama = createModel({ id: "deepseek-v4-flash", api: "ollama-chat", provider: "ollama-cloud" });
+		expect(umans.thinking?.efforts).toEqual(budget);
+		expect(vercel.thinking?.efforts).toEqual(budget);
+		expect(ollama.thinking?.efforts).toEqual(budget);
+	});
+
 	it("stores MiniMax M2 and GPT-OSS OpenAI-compatible effort limits in model metadata", () => {
 		const minimax = createModel({
 			id: "minimax-m2.7",

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
 import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
 import {
@@ -52,6 +54,30 @@ describe("OpenCode provider discovery", () => {
 			api: "openai-completions",
 			baseUrl: "https://opencode.ai/zen/go/v1",
 		});
+	});
+
+	test("keeps the low/high/max ladder for deepseek-v4-flash on the responses route (#8063)", () => {
+		const descriptor = MODELS_DEV_PROVIDER_DESCRIPTORS.find(item => item.providerId === "opencode-go");
+		const routed = descriptor?.resolveApi?.("deepseek-v4-flash", { tool_call: true });
+		expect(routed?.api).toBe("openai-responses");
+		// bf04fbfc8 rerouted this model to the responses API; the effort ladder
+		// must survive the switch. DSV4-Flash uses the wire-exact low/high/max
+		// scale on every host (medium/xhigh map to high). Before the fix the
+		// responses route fell through to the generic responses default
+		// [minimal, low, medium, high, xhigh] and silently dropped `max`.
+		const model = buildModel({
+			id: "deepseek-v4-flash",
+			name: "DeepSeek V4 Flash (2x usage)",
+			api: "openai-responses",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0.07, output: 0.14, cacheRead: 0.0014, cacheWrite: 0 },
+			contextWindow: 1_000_000,
+			maxTokens: 384_000,
+		});
+		expect(model.thinking?.efforts).toEqual([Effort.Low, Effort.High, Effort.Max]);
 	});
 
 	test("replaces stale bundled Zen models with each credential's live endpoint list", async () => {


### PR DESCRIPTION
## Repro
Since 17.2.12, `opencode-go/deepseek-v4-flash` lost its `max` thinking-effort tier: the bundled ladder became `[minimal, low, medium, high, xhigh]` instead of `[low, high, max]`. Feeding the model's spec through `deriveThinking()` on each API isolates it:

```
cd packages/catalog && bun repro.ts  # deriveThinking() for the opencode-go deepseek-v4-flash spec
openai-completions (pre-bf04fbfc8): ["low","high","max"]
openai-responses  (current main)  : ["minimal","low","medium","high","xhigh"]
```

## Cause
Commit `bf04fbfc8` rerouted this model from `openai-completions` to `openai-responses` (legitimate — the Go gateway only serves it at `/zen/go/v1/responses`). In `getModelDefinedEfforts` (`packages/catalog/src/model-thinking.ts`) the DeepSeek V4 Flash `[low, high, max]` ladder was gated behind `isOpenAICompatReasoningApi(spec.api)`, which is true only for `openai-completions`/`openrouter`. On the responses route that branch is skipped, so derivation falls through to `inferFallbackEfforts` and the generic responses default `DEFAULT_REASONING_EFFORTS_WITH_XHIGH` (`[minimal, low, medium, high, xhigh]`), silently dropping `max`.

## Fix
- Hoisted the `isDeepseekV4FlashModelId` special-case out of the `isOpenAICompatReasoningApi` gate in `getModelDefinedEfforts`, so the wire-exact `[low, high, max]` ladder applies on every route (completions, aggregators, and the opencode-go responses route alike). The remaining API-gated branch still handles non-flash DeepSeek reasoners (`high`/`max`, OpenRouter `high`-only).
- Regenerated the `opencode-go/deepseek-v4-flash` entry in `models.json` — `efforts` is now `[low, high, max]`.
- Extended `test/opencode-provider.test.ts`: a new case builds the model on the responses route and asserts `thinking.efforts === [low, high, max]`, closing the coverage gap the routing commit left.

Restored `[low, high, max]` rather than the reporter's suggested 7-tier contract: the maintainer established in #7668 that DSV4-Flash has no genuine `medium` tier (medium/xhigh map to high), and the code already documents this wire-exact ladder for the model "on every host".

## Verification
`cd packages/catalog && bun test` → 572 pass, 0 fail. The new `opencode-provider` test fails on pre-fix `main` (derivation yields the generic responses default) and passes after the fix. Fixes #8063