### PR TITLE
fix(prompts): disambiguate the grep tool from shell grep in the system prompt

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -120,7 +120,7 @@ You MUST use the specialized tool over its shell equivalent:
 {{#has tools "edit"}}- Surgical edits → `{{toolRefs.edit}}`.{{/has}}
 {{#has tools "write"}}- Create or overwrite → `{{toolRefs.write}}`.{{/has}}
 {{#has tools "lsp"}}- When a language server is available, MUST use `{{toolRefs.lsp}}` for definition, type_definition, implementation, references, and hover; for refactors, imports, and fixes, list code actions then apply one. NEVER use search or manual edits for code intelligence.{{/has}}
-{{#has tools "grep"}}- Regex search or locating targets → `{{toolRefs.grep}}`, not `grep`, `rg`, or `awk`.{{/has}}
+{{#has tools "grep"}}- Regex search or locating targets → `{{toolRefs.grep}}`, not shell `grep`, `rg`, or `awk`.{{/has}}
 {{#has tools "glob"}}- Mapping structure or globbing → `{{toolRefs.glob}}`, not `ls **/*.ext` or `fd`.{{/has}}
 {{#has tools "bash"}}- `{{toolRefs.bash}}`: real binaries and short fact pipelines only. Commands shadowing the specialized tools above are blocked.{{/has}}
 {{#has tools "bash"}}- Litmus: one external-CLI call or short pipeline returning a count, frequency, set difference, or checksum → bash. Merely moves, pages, or trims bytes a tool can fetch → use the tool.{{/has}}


### PR DESCRIPTION
## Summary

When `{{toolRefs.grep}}` resolves to `grep`, the system prompt line rendered as:

> `Regex search or locating targets → grep, not grep, rg, or awk.`

— a self-contradiction that confuses the model. This disambiguates shell `grep` from the specialized tool, matching the surrounding convention (e.g. line 124's "not `ls **/*.ext` or `fd`").

## Test plan

Prompt-only change; no behavior beyond the emitted instruction text. Verified by inspection of the rendered line.

Fixes #8032

I am a full-stack developer intern, passionate about contributing to the open-source community and giving back to the tools I love. I have reviewed and understood all the code changes in this PR.