### PR TITLE
fix(compaction): manual /shake keeps a recent tail of tool results

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Manual `/shake` now keeps a small recent tail of tool results instead of stripping every eligible result, so the agent does not lose the context it is currently working from ([#7776](https://github.com/can1357/oh-my-pi/issues/7776)).
+
 ## [17.2.10] - 2026-08-06
 
 ### Fixed

--- a/packages/agent/src/compaction/shake.ts
+++ b/packages/agent/src/compaction/shake.ts
@@ -52,11 +52,13 @@ export const DEFAULT_SHAKE_CONFIG: ShakeConfig = {
 };
 
 /**
- * Manual `/shake`: aggressive — drops every eligible region across history,
- * artifact recovery reads included (the user's full escape hatch).
+ * Manual `/shake`: aggressive — no savings threshold and drops eligible
+ * regions across history, artifact recovery reads included (the user's full
+ * escape hatch). Still keeps a small recent tail so it cannot strip the tool
+ * results the agent is currently working from (#7776).
  */
 export const AGGRESSIVE_SHAKE_CONFIG: ShakeConfig = {
-	protectTokens: 0,
+	protectTokens: 4_000,
 	minSavings: 0,
 	protectedTools: ["skill", isSkillReadToolResult],
 	fenceMinTokens: 400,

--- a/packages/agent/src/compaction/shake.ts
+++ b/packages/agent/src/compaction/shake.ts
@@ -67,6 +67,10 @@ export const AGGRESSIVE_SHAKE_CONFIG: ShakeConfig = {
 /** Compaction dead-end rescue: aggressive reach, but artifact recovery reads stay protected. */
 export const RESCUE_SHAKE_CONFIG: ShakeConfig = {
 	...AGGRESSIVE_SHAKE_CONFIG,
+	// Rescue must be able to elide the newest oversized result even inside the
+	// manual preset's recent-tail window (#7776) — a dead-end recovery that
+	// cannot drop its blocker is not a recovery.
+	protectTokens: 0,
 	protectedTools: [...AGGRESSIVE_SHAKE_CONFIG.protectedTools, isArtifactRecoveryToolResult],
 };
 

--- a/packages/agent/test/shake.test.ts
+++ b/packages/agent/test/shake.test.ts
@@ -204,10 +204,21 @@ describe("applyShakeRegions — multi-region ordering", () => {
 });
 
 describe("shake config presets", () => {
-	test("aggressive preset protects skill and drops everything else", () => {
-		expect(AGGRESSIVE_SHAKE_CONFIG.protectTokens).toBe(0);
+	test("aggressive preset protects skill and keeps a small recent tail", () => {
+		expect(AGGRESSIVE_SHAKE_CONFIG.protectTokens).toBeGreaterThan(0);
 		expect(AGGRESSIVE_SHAKE_CONFIG.minSavings).toBe(0);
 		expect(AGGRESSIVE_SHAKE_CONFIG.protectedTools).toContain("skill");
+	});
+
+	test("manual shake preserves the recent tool-result tail instead of stripping everything", () => {
+		const older = messageEntry(toolResultMessage("bash", "old-result ".repeat(300)));
+		const recent = messageEntry(toolResultMessage("bash", "recent-result ".repeat(3000)));
+		const regions = collectShakeRegions([older, recent], AGGRESSIVE_SHAKE_CONFIG);
+
+		// The recent result sits inside the preserved tail; the older one is
+		// still shaken aggressively.
+		expect(regions).toHaveLength(1);
+		expect(regions[0].entry).toBe(older);
 	});
 
 	test("default preset keeps a protect window", () => {

--- a/packages/agent/test/shake.test.ts
+++ b/packages/agent/test/shake.test.ts
@@ -8,6 +8,7 @@ import {
 	collectShakeRegions,
 	DEFAULT_SHAKE_CONFIG,
 	estimateTokens,
+	RESCUE_SHAKE_CONFIG,
 } from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage, TextContent, ToolCall, ToolResultMessage } from "@oh-my-pi/pi-ai";
 
@@ -224,6 +225,13 @@ describe("shake config presets", () => {
 	test("default preset keeps a protect window", () => {
 		expect(DEFAULT_SHAKE_CONFIG.protectTokens).toBeGreaterThan(0);
 		expect(DEFAULT_SHAKE_CONFIG.protectedTools).toContain("skill");
+	});
+
+	test("rescue preset overrides the manual tail so it can elide the newest result", () => {
+		const recent = messageEntry(toolResultMessage("bash", "oversized-result ".repeat(2000)));
+		const regions = collectShakeRegions([recent], RESCUE_SHAKE_CONFIG);
+		expect(regions).toHaveLength(1);
+		expect(regions[0].entry).toBe(recent);
 	});
 
 	test("empty branch yields no regions", () => {

--- a/packages/agent/test/tool-protection.test.ts
+++ b/packages/agent/test/tool-protection.test.ts
@@ -84,7 +84,9 @@ describe("conditional tool-result protection", () => {
 			fileResult,
 		];
 
-		const regions = collectShakeRegions(entries, AGGRESSIVE_SHAKE_CONFIG);
+		// protectTokens: 0 isolates the matcher behavior from the aggressive
+		// preset's recent-tail window (covered by shake.test.ts).
+		const regions = collectShakeRegions(entries, { ...AGGRESSIVE_SHAKE_CONFIG, protectTokens: 0 });
 
 		expect(regions).toHaveLength(1);
 		expect(regions[0]?.kind).toBe("toolResult");

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fixed shell minimization replacing meaningful `rustc --print` output with `OK`.
 - Fixed shell minimization altering outputs shorter than 1,000 characters; these now pass through unchanged.
+- Manual `/shake` now keeps a small recent tail of tool results instead of stripping every eligible result, so the agent does not lose the context it is currently working from ([#7776](https://github.com/can1357/oh-my-pi/issues/7776)).
 - Fixed primary and advisor Codex sessions falling back to another provider before trying sibling accounts when an account lacks Trusted Access for Cyber approval.
 - Fixed task subagent assistant turns being omitted from the per-model TPS/TTFT aggregates shown by `/models`. ([#8022](https://github.com/can1357/oh-my-pi/issues/8022))
 - Fixed terminal-title spinner writes consuming CPU during WSL/ConPTY agent waits by using the same static working separator as native Windows ([#8012](https://github.com/can1357/oh-my-pi/issues/8012)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Manual `/shake` now keeps a small recent tail of tool results instead of stripping every eligible result, so the agent does not lose the context it is currently working from ([#7776](https://github.com/can1357/oh-my-pi/issues/7776)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed
 
 - Fixed shell minimization replacing meaningful `rustc --print` output with `OK`.
 - Fixed shell minimization altering outputs shorter than 1,000 characters; these now pass through unchanged.
-- Manual `/shake` now keeps a small recent tail of tool results instead of stripping every eligible result, so the agent does not lose the context it is currently working from ([#7776](https://github.com/can1357/oh-my-pi/issues/7776)).
 - Fixed primary and advisor Codex sessions falling back to another provider before trying sibling accounts when an account lacks Trusted Access for Cyber approval.
 - Fixed task subagent assistant turns being omitted from the per-model TPS/TTFT aggregates shown by `/models`. ([#8022](https://github.com/can1357/oh-my-pi/issues/8022))
 - Fixed terminal-title spinner writes consuming CPU during WSL/ConPTY agent waits by using the same static working separator as native Windows ([#8012](https://github.com/can1357/oh-my-pi/issues/8012)).

--- a/packages/coding-agent/test/plan-mode/plan-protection.test.ts
+++ b/packages/coding-agent/test/plan-mode/plan-protection.test.ts
@@ -155,6 +155,7 @@ describe("plan-read protection in compaction", () => {
 
 		const regions = collectShakeRegions(entries, {
 			...AGGRESSIVE_SHAKE_CONFIG,
+			protectTokens: 0,
 			protectedTools: [...AGGRESSIVE_SHAKE_CONFIG.protectedTools, matcher],
 		});
 


### PR DESCRIPTION
## Summary

Manual `/shake` used `AGGRESSIVE_SHAKE_CONFIG` with `protectTokens: 0`, so it stripped **every** eligible tool result — including the ones the agent is still working from, destroying the live tail of context.

This keeps the aggressive preset's escape-hatch semantics (no savings threshold, artifact-recovery reads droppable) but adds a small 4k-token recent window, the same protect mechanism automatic shake uses (at a quarter of its 16k budget). The agent keeps the tool results it is currently relying on; older results are still shaken.

## Test plan

- `shake.test.ts`: preset assertion updated (protectTokens > 0); new test verifies manual shake preserves the recent tool-result tail while still shaking older results.
- `tool-protection.test.ts` / `plan-protection.test.ts`: two matcher-focused tests that implicitly relied on the zero window now pin `protectTokens: 0` explicitly so they keep testing the matcher, not the window.
- Full shake/compaction suites pass (30 agent + 7 plan tests), plus oxlint and TypeScript.

Fixes #7776

I am a full-stack developer intern, passionate about contributing to the open-source community and giving back to the tools I love. I have reviewed and understood all the code changes in this PR, which I verified with unit tests, type checks, and lint.