### PR TITLE
fix(extensions): register lifecycle tools

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Pi-compatible extensions registering tools during asynchronous session startup being omitted from the live model tool registry.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -175,10 +175,12 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	}
 
 	registerTool<TParams extends TSchema = TSchema, TDetails = unknown>(tool: ToolDefinition<TParams, TDetails>): void {
-		this.extension.tools.set(tool.name, {
+		const registered = {
 			definition: tool,
 			extensionPath: this.extension.path,
-		});
+		};
+		this.extension.tools.set(tool.name, registered);
+		for (const listener of this.extension.toolRegistrationListeners ?? []) listener(tool.name);
 	}
 
 	registerCommand(
@@ -316,6 +318,7 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 		resolvedPath,
 		handlers: new Map(),
 		tools: new Map(),
+		toolRegistrationListeners: new Set(),
 		assistantThinkingRenderers: [],
 		messageRenderers: new Map(),
 		commands: new Map(),

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -736,7 +736,10 @@ export class ExtensionRunner {
 				const tool = extension.tools.get(toolName);
 				if (!tool) return;
 				try {
-					const pending = listener(tool, this.#toolRegistrationScope.getStore()?.signal);
+					const scope = this.#toolRegistrationScope.getStore();
+					const registrationSignal =
+						scope && !scope.closed ? scope.signal : AbortSignal.timeout(extensionHandlerTimeoutMs);
+					const pending = listener(tool, registrationSignal);
 					if (pending) trackRegistration(pending);
 				} catch (error) {
 					trackRegistration(Promise.reject(error));

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -62,6 +62,7 @@ import type {
 	SessionStopEventResult,
 	ToolCallEvent,
 	ToolCallEventResult,
+	ToolRegistrationListener,
 	ToolResultEvent,
 	ToolResultEventResult,
 	UserBashEvent,
@@ -352,6 +353,7 @@ export class ExtensionRunner {
 	#shutdownHandler: ShutdownHandler = () => {};
 	#getMemoryFn?: () => MemoryRuntimeContext | undefined;
 	#commandDiagnostics: Array<{ type: string; message: string; path: string }> = [];
+	#pendingToolRegistrations = new Set<Promise<void>>();
 	#initialized = false;
 	/**
 	 * Buffer for `credential_disabled` events received via {@link emitCredentialDisabled}
@@ -674,6 +676,51 @@ export class ExtensionRunner {
 		return tools;
 	}
 
+	/** Get the effective registered tool for a name using normal last-extension-wins precedence. */
+	getRegisteredTool(name: string): RegisteredTool | undefined {
+		for (let index = this.extensions.length - 1; index >= 0; index -= 1) {
+			const tool = this.extensions[index]?.tools.get(name);
+			if (tool) return tool;
+		}
+		return undefined;
+	}
+
+	/**
+	 * Observe tools registered after extension factories have loaded. Listener
+	 * promises are drained before the lifecycle handler that registered them
+	 * completes, keeping the model tool snapshot and system prompt coherent.
+	 */
+	onToolRegistered(listener: (toolName: string) => void | Promise<void>): () => void {
+		const wrapped: ToolRegistrationListener = toolName => {
+			try {
+				const pending = listener(toolName);
+				if (!pending) return;
+				this.#pendingToolRegistrations.add(pending);
+				void pending.then(
+					() => this.#pendingToolRegistrations.delete(pending),
+					() => this.#pendingToolRegistrations.delete(pending),
+				);
+			} catch (error) {
+				const pending = Promise.reject(error);
+				this.#pendingToolRegistrations.add(pending);
+				void pending.catch(() => this.#pendingToolRegistrations.delete(pending));
+			}
+		};
+		for (const extension of this.extensions) {
+			extension.toolRegistrationListeners ??= new Set();
+			extension.toolRegistrationListeners.add(wrapped);
+		}
+		return () => {
+			for (const extension of this.extensions) extension.toolRegistrationListeners?.delete(wrapped);
+		};
+	}
+
+	async #flushToolRegistrations(): Promise<void> {
+		while (this.#pendingToolRegistrations.size > 0) {
+			await Promise.all(this.#pendingToolRegistrations);
+		}
+	}
+
 	/**
 	 * Aggregate the registered CLI flags across a set of extensions (last write
 	 * wins on name collision). Static so callers that need the flag set before a
@@ -940,6 +987,7 @@ export class ExtensionRunner {
 				timeoutMs,
 				signal,
 			);
+			await this.#flushToolRegistrations();
 			if (handlerResult === EXTENSION_HANDLER_ABORTED) return undefined;
 			if (handlerResult === EXTENSION_HANDLER_TIMEOUT) {
 				const error = `handler timed out after ${timeoutMs}ms`;

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1031,10 +1031,31 @@ export class ExtensionRunner {
 		let handlerFailure: { error: unknown } | undefined;
 		try {
 			handlerResult = await raceHandlerWithTimeout(
-				handlerSignal =>
-					this.#toolRegistrationScope.run(registrationScope, () =>
-						handler(event, createHandlerContext(ctx, handlerSignal)),
-					),
+				async handlerSignal => {
+					let result: TResult | undefined;
+					try {
+						result = await this.#toolRegistrationScope.run(registrationScope, () =>
+							handler(event, createHandlerContext(ctx, handlerSignal)),
+						);
+					} catch (error) {
+						handlerFailure = { error };
+					} finally {
+						registrationScope.closed = true;
+					}
+					try {
+						await this.#flushToolRegistrations(registrationScope.pending);
+					} catch (error) {
+						handlerFailure ??= { error };
+					}
+					const registrationBarrier = this.#toolRegistrationBarrier;
+					if (registrationBarrier) {
+						// Also wait for detached registrations that were scheduled before this
+						// handler completed. Their failures are reported at registration time,
+						// not attributed to this unrelated handler.
+						await registrationBarrier;
+					}
+					return result;
+				},
 				timeoutMs,
 				signal,
 			);
@@ -1042,30 +1063,6 @@ export class ExtensionRunner {
 			handlerFailure = { error };
 		} finally {
 			registrationScope.closed = true;
-		}
-		try {
-			await this.#flushToolRegistrations(registrationScope.pending);
-		} catch (error) {
-			handlerFailure ??= { error };
-		}
-		const registrationBarrier = this.#toolRegistrationBarrier;
-		if (registrationBarrier) {
-			// Also wait for detached registrations that were scheduled before this
-			// handler completed. Their failures are reported at registration time,
-			// not attributed to this unrelated handler.
-			await registrationBarrier;
-		}
-		if (handlerFailure) {
-			const message =
-				handlerFailure.error instanceof Error ? handlerFailure.error.message : String(handlerFailure.error);
-			const stack = handlerFailure.error instanceof Error ? handlerFailure.error.stack : undefined;
-			this.emitError({
-				extensionPath: ext.path,
-				event: event.type,
-				error: message,
-				stack,
-			});
-			return undefined;
 		}
 		if (handlerResult === EXTENSION_HANDLER_ABORTED) return undefined;
 		if (handlerResult === EXTENSION_HANDLER_TIMEOUT) {
@@ -1079,6 +1076,18 @@ export class ExtensionRunner {
 				extensionPath: ext.path,
 				event: event.type,
 				error,
+			});
+			return undefined;
+		}
+		if (handlerFailure) {
+			const message =
+				handlerFailure.error instanceof Error ? handlerFailure.error.message : String(handlerFailure.error);
+			const stack = handlerFailure.error instanceof Error ? handlerFailure.error.stack : undefined;
+			this.emitError({
+				extensionPath: ext.path,
+				event: event.type,
+				error: message,
+				stack,
 			});
 			return undefined;
 		}

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1053,13 +1053,6 @@ export class ExtensionRunner {
 					} catch (error) {
 						handlerFailure ??= { error };
 					}
-					const registrationBarrier = this.#toolRegistrationBarrier;
-					if (registrationBarrier) {
-						// Also wait for detached registrations that were scheduled before this
-						// handler completed. Their failures are reported at registration time,
-						// not attributed to this unrelated handler.
-						await registrationBarrier;
-					}
 					return result;
 				},
 				timeoutMs,

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -360,7 +360,7 @@ export class ExtensionRunner {
 	#getMemoryFn?: () => MemoryRuntimeContext | undefined;
 	#commandDiagnostics: Array<{ type: string; message: string; path: string }> = [];
 	#toolRegistrationScope = new AsyncLocalStorage<ToolRegistrationScope>();
-	#toolRegistrationBarrier: Promise<void> = Promise.resolve();
+	#toolRegistrationBarrier: Promise<void> | undefined;
 	#initialized = false;
 	/**
 	 * Buffer for `credential_disabled` events received via {@link emitCredentialDisabled}
@@ -531,7 +531,8 @@ export class ExtensionRunner {
 		this.runtime.getActiveTools = actions.getActiveTools;
 		this.runtime.getAllTools = actions.getAllTools;
 		this.runtime.setActiveTools = async toolNames => {
-			await this.#toolRegistrationBarrier;
+			const registrationBarrier = this.#toolRegistrationBarrier;
+			if (registrationBarrier) await registrationBarrier;
 			await actions.setActiveTools(toolNames);
 		};
 		this.runtime.getCommands = actions.getCommands;
@@ -704,10 +705,14 @@ export class ExtensionRunner {
 		const subscriptions: Array<{ extension: Extension; listener: ToolRegistrationListener }> = [];
 		for (const extension of this.extensions) {
 			const trackRegistration = (pending: Promise<void>): void => {
-				this.#toolRegistrationBarrier = pending.then(
+				const registrationBarrier = pending.then(
 					() => undefined,
 					() => undefined,
 				);
+				this.#toolRegistrationBarrier = registrationBarrier;
+				void registrationBarrier.then(() => {
+					if (this.#toolRegistrationBarrier === registrationBarrier) this.#toolRegistrationBarrier = undefined;
+				});
 				const scope = this.#toolRegistrationScope.getStore();
 				if (scope && !scope.closed) {
 					scope.pending.add(pending);
@@ -1043,10 +1048,13 @@ export class ExtensionRunner {
 		} catch (error) {
 			handlerFailure ??= { error };
 		}
-		// Also wait for detached registrations that were scheduled before this handler
-		// completed. Their failures are reported at registration time, not attributed
-		// to this unrelated handler.
-		await this.#toolRegistrationBarrier;
+		const registrationBarrier = this.#toolRegistrationBarrier;
+		if (registrationBarrier) {
+			// Also wait for detached registrations that were scheduled before this
+			// handler completed. Their failures are reported at registration time,
+			// not attributed to this unrelated handler.
+			await registrationBarrier;
+		}
 		if (handlerFailure) {
 			const message =
 				handlerFailure.error instanceof Error ? handlerFailure.error.message : String(handlerFailure.error);

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1,6 +1,7 @@
 /**
  * Extension runner - executes extensions and manages their lifecycle.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
 import type {
 	AgentMessage,
 	AgentTool,
@@ -333,6 +334,11 @@ const noOpUIContext: ExtensionUIContext = {
 	setToolsExpanded: () => {},
 };
 
+interface ToolRegistrationScope {
+	pending: Set<Promise<void>>;
+	closed: boolean;
+}
+
 export class ExtensionRunner {
 	#uiContext: ExtensionUIContext;
 	#errorListeners: Set<ExtensionErrorListener> = new Set();
@@ -353,7 +359,8 @@ export class ExtensionRunner {
 	#shutdownHandler: ShutdownHandler = () => {};
 	#getMemoryFn?: () => MemoryRuntimeContext | undefined;
 	#commandDiagnostics: Array<{ type: string; message: string; path: string }> = [];
-	#pendingToolRegistrations = new Set<Promise<void>>();
+	#toolRegistrationScope = new AsyncLocalStorage<ToolRegistrationScope>();
+	#toolRegistrationBarrier: Promise<void> = Promise.resolve();
 	#initialized = false;
 	/**
 	 * Buffer for `credential_disabled` events received via {@link emitCredentialDisabled}
@@ -523,7 +530,10 @@ export class ExtensionRunner {
 		this.runtime.appendEntry = actions.appendEntry;
 		this.runtime.getActiveTools = actions.getActiveTools;
 		this.runtime.getAllTools = actions.getAllTools;
-		this.runtime.setActiveTools = actions.setActiveTools;
+		this.runtime.setActiveTools = async toolNames => {
+			await this.#toolRegistrationBarrier;
+			await actions.setActiveTools(toolNames);
+		};
 		this.runtime.getCommands = actions.getCommands;
 		this.runtime.setModel = actions.setModel;
 		this.runtime.getThinkingLevel = actions.getThinkingLevel;
@@ -693,21 +703,37 @@ export class ExtensionRunner {
 	onToolRegistered(listener: (tool: RegisteredTool) => void | Promise<void>): () => void {
 		const subscriptions: Array<{ extension: Extension; listener: ToolRegistrationListener }> = [];
 		for (const extension of this.extensions) {
+			const trackRegistration = (pending: Promise<void>): void => {
+				this.#toolRegistrationBarrier = pending.then(
+					() => undefined,
+					() => undefined,
+				);
+				const scope = this.#toolRegistrationScope.getStore();
+				if (scope && !scope.closed) {
+					scope.pending.add(pending);
+					void pending.then(
+						() => scope.pending.delete(pending),
+						() => {},
+					);
+					return;
+				}
+				void pending.catch(error => {
+					this.emitError({
+						extensionPath: extension.path,
+						event: "tool_registration",
+						error: error instanceof Error ? error.message : String(error),
+						stack: error instanceof Error ? error.stack : undefined,
+					});
+				});
+			};
 			const wrapped: ToolRegistrationListener = toolName => {
 				const tool = extension.tools.get(toolName);
 				if (!tool) return;
 				try {
 					const pending = listener(tool);
-					if (!pending) return;
-					this.#pendingToolRegistrations.add(pending);
-					void pending.then(
-						() => this.#pendingToolRegistrations.delete(pending),
-						() => {},
-					);
+					if (pending) trackRegistration(pending);
 				} catch (error) {
-					const pending = Promise.reject(error);
-					this.#pendingToolRegistrations.add(pending);
-					void pending.catch(() => {});
+					trackRegistration(Promise.reject(error));
 				}
 			};
 			extension.toolRegistrationListeners ??= new Set();
@@ -721,13 +747,13 @@ export class ExtensionRunner {
 		};
 	}
 
-	async #flushToolRegistrations(): Promise<void> {
+	async #flushToolRegistrations(pendingRegistrations: Set<Promise<void>>): Promise<void> {
 		let firstFailure: PromiseRejectedResult | undefined;
-		while (this.#pendingToolRegistrations.size > 0) {
-			const pending = Array.from(this.#pendingToolRegistrations);
+		while (pendingRegistrations.size > 0) {
+			const pending = Array.from(pendingRegistrations);
 			const settled = await Promise.allSettled(pending);
 			for (let index = 0; index < settled.length; index += 1) {
-				this.#pendingToolRegistrations.delete(pending[index]);
+				pendingRegistrations.delete(pending[index]);
 				const result = settled[index];
 				if (!firstFailure && result?.status === "rejected") firstFailure = result;
 			}
@@ -995,22 +1021,32 @@ export class ExtensionRunner {
 				? event.signal
 				: undefined;
 		if (signal?.aborted) return undefined;
+		const registrationScope: ToolRegistrationScope = { pending: new Set(), closed: false };
 		let handlerResult: TResult | typeof EXTENSION_HANDLER_TIMEOUT | typeof EXTENSION_HANDLER_ABORTED | undefined;
 		let handlerFailure: { error: unknown } | undefined;
 		try {
 			handlerResult = await raceHandlerWithTimeout(
-				handlerSignal => handler(event, createHandlerContext(ctx, handlerSignal)),
+				handlerSignal =>
+					this.#toolRegistrationScope.run(registrationScope, () =>
+						handler(event, createHandlerContext(ctx, handlerSignal)),
+					),
 				timeoutMs,
 				signal,
 			);
 		} catch (error) {
 			handlerFailure = { error };
+		} finally {
+			registrationScope.closed = true;
 		}
 		try {
-			await this.#flushToolRegistrations();
+			await this.#flushToolRegistrations(registrationScope.pending);
 		} catch (error) {
 			handlerFailure ??= { error };
 		}
+		// Also wait for detached registrations that were scheduled before this handler
+		// completed. Their failures are reported at registration time, not attributed
+		// to this unrelated handler.
+		await this.#toolRegistrationBarrier;
 		if (handlerFailure) {
 			const message =
 				handlerFailure.error instanceof Error ? handlerFailure.error.message : String(handlerFailure.error);

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -981,32 +981,26 @@ export class ExtensionRunner {
 				? event.signal
 				: undefined;
 		if (signal?.aborted) return undefined;
+		let handlerResult: TResult | typeof EXTENSION_HANDLER_TIMEOUT | typeof EXTENSION_HANDLER_ABORTED | undefined;
+		let handlerFailure: { error: unknown } | undefined;
 		try {
-			const handlerResult = await raceHandlerWithTimeout(
+			handlerResult = await raceHandlerWithTimeout(
 				handlerSignal => handler(event, createHandlerContext(ctx, handlerSignal)),
 				timeoutMs,
 				signal,
 			);
+		} catch (error) {
+			handlerFailure = { error };
+		}
+		try {
 			await this.#flushToolRegistrations();
-			if (handlerResult === EXTENSION_HANDLER_ABORTED) return undefined;
-			if (handlerResult === EXTENSION_HANDLER_TIMEOUT) {
-				const error = `handler timed out after ${timeoutMs}ms`;
-				logger.warn("Extension handler timed out", {
-					extensionPath: ext.path,
-					event: event.type,
-					timeoutMs,
-				});
-				this.emitError({
-					extensionPath: ext.path,
-					event: event.type,
-					error,
-				});
-				return undefined;
-			}
-			return handlerResult as TResult | undefined;
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			const stack = err instanceof Error ? err.stack : undefined;
+		} catch (error) {
+			handlerFailure ??= { error };
+		}
+		if (handlerFailure) {
+			const message =
+				handlerFailure.error instanceof Error ? handlerFailure.error.message : String(handlerFailure.error);
+			const stack = handlerFailure.error instanceof Error ? handlerFailure.error.stack : undefined;
 			this.emitError({
 				extensionPath: ext.path,
 				event: event.type,
@@ -1015,6 +1009,22 @@ export class ExtensionRunner {
 			});
 			return undefined;
 		}
+		if (handlerResult === EXTENSION_HANDLER_ABORTED) return undefined;
+		if (handlerResult === EXTENSION_HANDLER_TIMEOUT) {
+			const error = `handler timed out after ${timeoutMs}ms`;
+			logger.warn("Extension handler timed out", {
+				extensionPath: ext.path,
+				event: event.type,
+				timeoutMs,
+			});
+			this.emitError({
+				extensionPath: ext.path,
+				event: event.type,
+				error,
+			});
+			return undefined;
+		}
+		return handlerResult as TResult | undefined;
 	}
 
 	async emit<TEvent extends RunnerEmitEvent>(event: TEvent): Promise<RunnerEmitResult<TEvent>> {

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -690,28 +690,34 @@ export class ExtensionRunner {
 	 * promises are drained before the lifecycle handler that registered them
 	 * completes, keeping the model tool snapshot and system prompt coherent.
 	 */
-	onToolRegistered(listener: (toolName: string) => void | Promise<void>): () => void {
-		const wrapped: ToolRegistrationListener = toolName => {
-			try {
-				const pending = listener(toolName);
-				if (!pending) return;
-				this.#pendingToolRegistrations.add(pending);
-				void pending.then(
-					() => this.#pendingToolRegistrations.delete(pending),
-					() => this.#pendingToolRegistrations.delete(pending),
-				);
-			} catch (error) {
-				const pending = Promise.reject(error);
-				this.#pendingToolRegistrations.add(pending);
-				void pending.catch(() => this.#pendingToolRegistrations.delete(pending));
-			}
-		};
+	onToolRegistered(listener: (tool: RegisteredTool) => void | Promise<void>): () => void {
+		const subscriptions: Array<{ extension: Extension; listener: ToolRegistrationListener }> = [];
 		for (const extension of this.extensions) {
+			const wrapped: ToolRegistrationListener = toolName => {
+				const tool = extension.tools.get(toolName);
+				if (!tool) return;
+				try {
+					const pending = listener(tool);
+					if (!pending) return;
+					this.#pendingToolRegistrations.add(pending);
+					void pending.then(
+						() => this.#pendingToolRegistrations.delete(pending),
+						() => this.#pendingToolRegistrations.delete(pending),
+					);
+				} catch (error) {
+					const pending = Promise.reject(error);
+					this.#pendingToolRegistrations.add(pending);
+					void pending.catch(() => this.#pendingToolRegistrations.delete(pending));
+				}
+			};
 			extension.toolRegistrationListeners ??= new Set();
 			extension.toolRegistrationListeners.add(wrapped);
+			subscriptions.push({ extension, listener: wrapped });
 		}
 		return () => {
-			for (const extension of this.extensions) extension.toolRegistrationListeners?.delete(wrapped);
+			for (const subscription of subscriptions) {
+				subscription.extension.toolRegistrationListeners?.delete(subscription.listener);
+			}
 		};
 	}
 

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -722,9 +722,14 @@ export class ExtensionRunner {
 	}
 
 	async #flushToolRegistrations(): Promise<void> {
+		let firstFailure: PromiseRejectedResult | undefined;
 		while (this.#pendingToolRegistrations.size > 0) {
-			await Promise.all(this.#pendingToolRegistrations);
+			const settled = await Promise.allSettled(this.#pendingToolRegistrations);
+			for (const result of settled) {
+				if (!firstFailure && result.status === "rejected") firstFailure = result;
+			}
 		}
+		if (firstFailure) throw firstFailure.reason;
 	}
 
 	/**

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -1020,6 +1020,7 @@ export class ExtensionRunner {
 		ctx: ExtensionContext,
 		ext: Extension,
 		timeoutMs: number,
+		onFailure?: (kind: "timeout" | "error", message: string) => TResult,
 	): Promise<TResult | undefined> {
 		const signal =
 			event.type === "session_stop" && "signal" in event && event.signal instanceof AbortSignal
@@ -1077,7 +1078,7 @@ export class ExtensionRunner {
 				event: event.type,
 				error,
 			});
-			return undefined;
+			return onFailure?.("timeout", error);
 		}
 		if (handlerFailure) {
 			const message =
@@ -1089,7 +1090,7 @@ export class ExtensionRunner {
 				error: message,
 				stack,
 			});
-			return undefined;
+			return onFailure?.("error", message);
 		}
 		return handlerResult as TResult | undefined;
 	}
@@ -1225,46 +1226,26 @@ export class ExtensionRunner {
 			if (!handlers || handlers.length === 0) continue;
 
 			for (const handler of handlers) {
-				try {
-					const handlerResult = await raceHandlerWithTimeout(
-						handlerSignal => handler(event, createHandlerContext(ctx, handlerSignal)),
-						timeoutMs,
-					);
+				const handlerResult = await this.#runHandlerWithTimeout(
+					handler,
+					event,
+					ctx,
+					ext,
+					timeoutMs,
+					(kind, message) => ({
+						block: true,
+						reason:
+							kind === "timeout"
+								? `Extension ${ext.path} timed out after ${timeoutMs}ms`
+								: `Extension ${ext.path} failed: ${message}`,
+					}),
+				);
 
-					if (handlerResult === EXTENSION_HANDLER_TIMEOUT) {
-						const error = `handler timed out after ${timeoutMs}ms`;
-						logger.warn("Extension handler timed out", {
-							extensionPath: ext.path,
-							event: "tool_call",
-							timeoutMs,
-						});
-						this.emitError({
-							extensionPath: ext.path,
-							event: "tool_call",
-							error,
-						});
-						return {
-							block: true,
-							reason: `Extension ${ext.path} timed out after ${timeoutMs}ms`,
-						};
+				if (handlerResult) {
+					result = handlerResult;
+					if (result.block) {
+						return result;
 					}
-
-					if (handlerResult) {
-						result = handlerResult as ToolCallEventResult;
-						if (result.block) {
-							return result;
-						}
-					}
-				} catch (err) {
-					const message = err instanceof Error ? err.message : String(err);
-					const stack = err instanceof Error ? err.stack : undefined;
-					this.emitError({
-						extensionPath: ext.path,
-						event: "tool_call",
-						error: message,
-						stack,
-					});
-					return { block: true, reason: `Extension ${ext.path} failed: ${message}` };
 				}
 			}
 		}

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -336,6 +336,7 @@ const noOpUIContext: ExtensionUIContext = {
 
 interface ToolRegistrationScope {
 	pending: Set<Promise<void>>;
+	signal?: AbortSignal;
 	closed: boolean;
 }
 
@@ -701,7 +702,7 @@ export class ExtensionRunner {
 	 * promises are drained before the lifecycle handler that registered them
 	 * completes, keeping the model tool snapshot and system prompt coherent.
 	 */
-	onToolRegistered(listener: (tool: RegisteredTool) => void | Promise<void>): () => void {
+	onToolRegistered(listener: (tool: RegisteredTool, signal?: AbortSignal) => void | Promise<void>): () => void {
 		const subscriptions: Array<{ extension: Extension; listener: ToolRegistrationListener }> = [];
 		for (const extension of this.extensions) {
 			const trackRegistration = (pending: Promise<void>): void => {
@@ -735,7 +736,7 @@ export class ExtensionRunner {
 				const tool = extension.tools.get(toolName);
 				if (!tool) return;
 				try {
-					const pending = listener(tool);
+					const pending = listener(tool, this.#toolRegistrationScope.getStore()?.signal);
 					if (pending) trackRegistration(pending);
 				} catch (error) {
 					trackRegistration(Promise.reject(error));
@@ -1033,6 +1034,7 @@ export class ExtensionRunner {
 		try {
 			handlerResult = await raceHandlerWithTimeout(
 				async handlerSignal => {
+					registrationScope.signal = handlerSignal;
 					let result: TResult | undefined;
 					try {
 						result = await this.#toolRegistrationScope.run(registrationScope, () =>

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -702,12 +702,12 @@ export class ExtensionRunner {
 					this.#pendingToolRegistrations.add(pending);
 					void pending.then(
 						() => this.#pendingToolRegistrations.delete(pending),
-						() => this.#pendingToolRegistrations.delete(pending),
+						() => {},
 					);
 				} catch (error) {
 					const pending = Promise.reject(error);
 					this.#pendingToolRegistrations.add(pending);
-					void pending.catch(() => this.#pendingToolRegistrations.delete(pending));
+					void pending.catch(() => {});
 				}
 			};
 			extension.toolRegistrationListeners ??= new Set();
@@ -724,9 +724,12 @@ export class ExtensionRunner {
 	async #flushToolRegistrations(): Promise<void> {
 		let firstFailure: PromiseRejectedResult | undefined;
 		while (this.#pendingToolRegistrations.size > 0) {
-			const settled = await Promise.allSettled(this.#pendingToolRegistrations);
-			for (const result of settled) {
-				if (!firstFailure && result.status === "rejected") firstFailure = result;
+			const pending = Array.from(this.#pendingToolRegistrations);
+			const settled = await Promise.allSettled(pending);
+			for (let index = 0; index < settled.length; index += 1) {
+				this.#pendingToolRegistrations.delete(pending[index]);
+				const result = settled[index];
+				if (!firstFailure && result?.status === "rejected") firstFailure = result;
 			}
 		}
 		if (firstFailure) throw firstFailure.reason;

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1467,6 +1467,9 @@ export interface RegisteredTool<TParams extends TSchema = TSchema, TDetails = un
 	extensionPath: string;
 }
 
+/** Internal observer invoked when an already-loaded extension registers or replaces a tool. */
+export type ToolRegistrationListener = (toolName: string) => void;
+
 export interface ExtensionFlag {
 	name: string;
 	description?: string;
@@ -1589,6 +1592,7 @@ export interface Extension {
 	label?: string;
 	handlers: Map<string, HandlerFn[]>;
 	tools: Map<string, RegisteredTool<any, any>>;
+	toolRegistrationListeners?: Set<ToolRegistrationListener>;
 	assistantThinkingRenderers: AssistantThinkingRenderer[];
 	messageRenderers: Map<string, MessageRenderer>;
 	commands: Map<string, RegisteredCommand>;

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -357,6 +357,18 @@ export function createMCPToolName(serverName: string, toolName: string): string 
 	return `mcp__${sanitizedServerName}_${normalizedToolName}`;
 }
 
+export interface MCPToolOriginSource {
+	readonly name: string;
+	readonly mcpServerName?: unknown;
+	readonly mcpToolName?: unknown;
+}
+
+/** Stable identity for a tool's original MCP route, before its public name was normalized. */
+export function getMCPToolOriginKey(tool: MCPToolOriginSource): string | undefined {
+	if (typeof tool.mcpServerName !== "string" || typeof tool.mcpToolName !== "string") return undefined;
+	return `${tool.mcpServerName}\u0000${tool.mcpToolName}`;
+}
+
 /**
  * Keeps one MCP tool per minted name and logs collisions between distinct MCP
  * origins. The winner is chosen by a stable origin key (server name + original
@@ -365,19 +377,16 @@ export function createMCPToolName(serverName: string, toolName: string): string 
  * silently flip ownership of the minted name. Non-MCP tools pass through
  * unchanged.
  */
-export function deduplicateMCPToolsByName<T extends { name: string; mcpServerName?: unknown; mcpToolName?: unknown }>(
-	tools: readonly T[],
-): T[] {
+export function deduplicateMCPToolsByName<T extends MCPToolOriginSource>(tools: readonly T[]): T[] {
 	const deduplicated: T[] = [];
 	const registered = new Map<string, { tool: T; originKey: string; index: number }>();
 
 	for (const tool of tools) {
-		if (typeof tool.mcpServerName !== "string" || typeof tool.mcpToolName !== "string") {
+		const originKey = getMCPToolOriginKey(tool);
+		if (originKey === undefined) {
 			deduplicated.push(tool);
 			continue;
 		}
-
-		const originKey = `${tool.mcpServerName}\u0000${tool.mcpToolName}`;
 		const existing = registered.get(tool.name);
 		if (!existing) {
 			registered.set(tool.name, { tool, originKey, index: deduplicated.length });

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3450,14 +3450,30 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			const [wrapped] = wrapRegisteredTools([registered], extensionRunner);
 			if (!wrapped) return dynamicToolRegistrationChain;
 			const name = registered.definition.name;
-			toolRegistry.set(name, new ExtensionToolWrapper(wrapToolWithMetaNotice(wrapped), extensionRunner));
+			const liveTool = new ExtensionToolWrapper(wrapToolWithMetaNotice(wrapped), extensionRunner);
+			toolRegistry.set(name, liveTool);
 			builtInRegistryToolNames.delete(name);
 
 			const activation = dynamicToolRegistrationChain.then(async () => {
 				const enabled = session.getEnabledToolNames();
 				const alreadyEnabled = enabled.includes(name);
-				if (!alreadyEnabled && registered.definition.defaultInactive) return;
-				await session.setActiveToolsByName(alreadyEnabled ? enabled : [...enabled, name]);
+				const explicitlyRequested = explicitlyRequestedToolNameSet?.has(name) === true;
+				if (!alreadyEnabled && registered.definition.defaultInactive && !explicitlyRequested) return;
+
+				const mounted = session.getMountedXdevToolNames();
+				const shouldMount =
+					!alreadyEnabled &&
+					!explicitlyRequested &&
+					toolSession.xdev !== undefined &&
+					builtInRegistryToolNames.has("read") &&
+					builtInRegistryToolNames.has("write") &&
+					enabled.includes("read") &&
+					enabled.includes("write") &&
+					isMountableUnderXdev(liveTool);
+				await session.setActiveToolPresentation(
+					alreadyEnabled ? enabled : [...enabled, name],
+					shouldMount ? [...mounted, name] : mounted,
+				);
 			});
 			dynamicToolRegistrationChain = activation.catch(() => {});
 			return activation;
@@ -3477,6 +3493,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		});
 		session.yieldQueue.register<DeferredDiagnosticsEntry>(LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE, {
 			build: buildLateDiagnosticsBatchMessage,
+			isStale: entry => entry.isStale(),
 		});
 
 		// Attach the live session to the pre-registered ref so peers can route IRC

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2585,7 +2585,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		const nativeToolsByName = new Map<string, Tool>(toolSession.xdev?.tools ?? undefined);
 
 		const registeredTools = restrictToolNames ? [] : extensionRunner.getAllRegisteredTools();
-		const initialRegisteredToolsByName = new Map(registeredTools.map(tool => [tool.definition.name, tool] as const));
+		const initialRegisteredTools = new WeakSet(registeredTools);
 		const sdkCustomTools =
 			restrictToolNames && options.allowRestrictedCustomTools !== true
 				? []
@@ -3441,9 +3441,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// registry and serialize activation so no update can overwrite a sibling.
 		let dynamicToolRegistrationChain = Promise.resolve();
 		const scheduledToolRegistrations = new WeakSet<RegisteredTool>();
-		const scheduleToolRegistration = (toolName: string): Promise<void> => {
-			const registered = extensionRunner.getRegisteredTool(toolName);
-			if (!registered) return dynamicToolRegistrationChain;
+		const scheduleToolRegistration = (registered: RegisteredTool): Promise<void> => {
 			if (scheduledToolRegistrations.has(registered)) return dynamicToolRegistrationChain;
 			scheduledToolRegistrations.add(registered);
 
@@ -3452,11 +3450,18 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			const name = registered.definition.name;
 			const liveTool = new ExtensionToolWrapper(wrapToolWithMetaNotice(wrapped), extensionRunner);
 			const existingTool = toolRegistry.get(name);
+			const isEffectiveRegistrant = extensionRunner.getRegisteredTool(name) === registered;
 			if (existingTool) {
-				// Put the replacement first so same-origin MCP re-registration keeps it; distinct origins still use
-				// the startup path's stable winner, while non-MCP replacements remain last-registration-wins.
+				// Put the replacement first so same-origin MCP re-registration keeps it. Distinct MCP origins still
+				// use the stable winner; ordinary tool collisions retain the extension runner's last-wins precedence.
 				const competingTools = deduplicateMCPToolsByName([liveTool, existingTool]);
-				if (competingTools.length === 1 && competingTools[0] !== liveTool) return dynamicToolRegistrationChain;
+				if (competingTools.length === 1) {
+					if (competingTools[0] !== liveTool) return dynamicToolRegistrationChain;
+				} else if (!isEffectiveRegistrant) {
+					return dynamicToolRegistrationChain;
+				}
+			} else if (!isEffectiveRegistrant) {
+				return dynamicToolRegistrationChain;
 			}
 			toolRegistry.set(name, liveTool);
 			builtInRegistryToolNames.delete(name);
@@ -3475,7 +3480,6 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					return;
 				}
 				const shouldMount =
-					!alreadyEnabled &&
 					!explicitlyRequested &&
 					toolSession.xdev !== undefined &&
 					builtInRegistryToolNames.has("read") &&
@@ -3483,10 +3487,12 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					enabled.includes("read") &&
 					enabled.includes("write") &&
 					isMountableUnderXdev(liveTool);
-				await session.setActiveToolPresentation(
-					alreadyEnabled ? enabled : [...enabled, name],
-					shouldMount ? [...mounted, name] : mounted,
-				);
+				const nextMounted = shouldMount
+					? mounted.includes(name)
+						? mounted
+						: [...mounted, name]
+					: mounted.filter(mountedName => mountedName !== name);
+				await session.setActiveToolPresentation(alreadyEnabled ? enabled : [...enabled, name], nextMounted);
 			});
 			dynamicToolRegistrationChain = activation.catch(() => {});
 			return activation;
@@ -3497,8 +3503,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// Close the construction race: a background registration can land after
 		// the initial snapshot but before the live listener above is attached.
 		for (const registered of extensionRunner.getAllRegisteredTools()) {
-			if (initialRegisteredToolsByName.get(registered.definition.name) !== registered) {
-				await scheduleToolRegistration(registered.definition.name);
+			if (!initialRegisteredTools.has(registered)) {
+				await scheduleToolRegistration(registered);
 			}
 		}
 		session.yieldQueue.register<McpNotificationEntry>("mcp-notification", {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -91,6 +91,7 @@ import {
 	type LoadExtensionsResult,
 	loadExtensionFromFactory,
 	loadExtensions,
+	type RegisteredTool,
 	type ToolDefinition,
 	wrapRegisteredTools,
 } from "./extensibility/extensions";
@@ -2584,6 +2585,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		const nativeToolsByName = new Map<string, Tool>(toolSession.xdev?.tools ?? undefined);
 
 		const registeredTools = restrictToolNames ? [] : extensionRunner.getAllRegisteredTools();
+		const initialRegisteredToolsByName = new Map(registeredTools.map(tool => [tool.definition.name, tool] as const));
 		const sdkCustomTools =
 			restrictToolNames && options.allowRestrictedCustomTools !== true
 				? []
@@ -3433,11 +3435,47 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			titleSystemPrompt: options.titleSystemPrompt,
 		});
 		hasSession = true;
+		// Extension factories normally register tools before session construction,
+		// but Pi-compatible extensions may discover them asynchronously from a
+		// session_start handler. Install those late registrations into the live
+		// registry and serialize activation so no update can overwrite a sibling.
+		let dynamicToolRegistrationChain = Promise.resolve();
+		const scheduledToolRegistrations = new WeakSet<RegisteredTool>();
+		const scheduleToolRegistration = (toolName: string): Promise<void> => {
+			const registered = extensionRunner.getRegisteredTool(toolName);
+			if (!registered) return dynamicToolRegistrationChain;
+			if (scheduledToolRegistrations.has(registered)) return dynamicToolRegistrationChain;
+			scheduledToolRegistrations.add(registered);
+
+			const [wrapped] = wrapRegisteredTools([registered], extensionRunner);
+			if (!wrapped) return dynamicToolRegistrationChain;
+			const name = registered.definition.name;
+			toolRegistry.set(name, new ExtensionToolWrapper(wrapToolWithMetaNotice(wrapped), extensionRunner));
+			builtInRegistryToolNames.delete(name);
+
+			const activation = dynamicToolRegistrationChain.then(async () => {
+				const enabled = session.getEnabledToolNames();
+				const alreadyEnabled = enabled.includes(name);
+				if (!alreadyEnabled && registered.definition.defaultInactive) return;
+				await session.setActiveToolsByName(alreadyEnabled ? enabled : [...enabled, name]);
+			});
+			dynamicToolRegistrationChain = activation.catch(() => {});
+			return activation;
+		};
+		const unsubscribeToolRegistrations = extensionRunner.onToolRegistered(scheduleToolRegistration);
+		disposeCallbacks.add(unsubscribeToolRegistrations);
+
+		// Close the construction race: a background registration can land after
+		// the initial snapshot but before the live listener above is attached.
+		for (const registered of extensionRunner.getAllRegisteredTools()) {
+			if (initialRegisteredToolsByName.get(registered.definition.name) !== registered) {
+				await scheduleToolRegistration(registered.definition.name);
+			}
+		}
 		session.yieldQueue.register<McpNotificationEntry>("mcp-notification", {
 			build: buildMcpNotificationBatchMessage,
 		});
 		session.yieldQueue.register<DeferredDiagnosticsEntry>(LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE, {
-			isStale: entry => entry.isStale(),
 			build: buildLateDiagnosticsBatchMessage,
 		});
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3451,6 +3451,19 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			if (!wrapped) return dynamicToolRegistrationChain;
 			const name = registered.definition.name;
 			const liveTool = new ExtensionToolWrapper(wrapToolWithMetaNotice(wrapped), extensionRunner);
+			// Distinct MCP origins use the startup path's stable winner; re-registering the same origin still replaces it.
+			const existingTool = toolRegistry.get(name);
+			if (
+				existingTool &&
+				typeof existingTool.mcpServerName === "string" &&
+				typeof existingTool.mcpToolName === "string" &&
+				typeof liveTool.mcpServerName === "string" &&
+				typeof liveTool.mcpToolName === "string" &&
+				(existingTool.mcpServerName !== liveTool.mcpServerName || existingTool.mcpToolName !== liveTool.mcpToolName)
+			) {
+				const [winner] = deduplicateMCPToolsByName([existingTool, liveTool]);
+				if (winner !== liveTool) return dynamicToolRegistrationChain;
+			}
 			toolRegistry.set(name, liveTool);
 			builtInRegistryToolNames.delete(name);
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3517,14 +3517,16 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			dynamicToolRegistrationChain = activation.catch(() => {});
 			return activation;
 		};
-		const unsubscribeToolRegistrations = extensionRunner.onToolRegistered(scheduleToolRegistration);
-		disposeCallbacks.add(unsubscribeToolRegistrations);
+		if (!restrictToolNames) {
+			const unsubscribeToolRegistrations = extensionRunner.onToolRegistered(scheduleToolRegistration);
+			disposeCallbacks.add(unsubscribeToolRegistrations);
 
-		// Close the construction race: a background registration can land after
-		// the initial snapshot but before the live listener above is attached.
-		for (const registered of extensionRunner.getAllRegisteredTools()) {
-			if (!initialRegisteredTools.has(registered)) {
-				await scheduleToolRegistration(registered);
+			// Close the construction race: a background registration can land after
+			// the initial snapshot but before the live listener above is attached.
+			for (const registered of extensionRunner.getAllRegisteredTools()) {
+				if (!initialRegisteredTools.has(registered)) {
+					await scheduleToolRegistration(registered);
+				}
 			}
 		}
 		session.yieldQueue.register<McpNotificationEntry>("mcp-notification", {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -110,6 +110,7 @@ import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "./lsp/startup-e
 import {
 	deduplicateMCPToolsByName,
 	discoverAndLoadMCPTools,
+	getMCPToolOriginKey,
 	type MCPLoadResult,
 	MCPManager,
 	MCPToolCache,
@@ -2615,12 +2616,12 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		);
 		const initialMcpManagerToolNames = new Set<string>();
 		for (const tool of wrappedExtensionTools) {
-			const matchesManagerOrigin = initialMcpManagerTools.some(
-				managerTool =>
-					managerTool.name === tool.name &&
-					managerTool.mcpServerName === tool.mcpServerName &&
-					managerTool.mcpToolName === tool.mcpToolName,
-			);
+			const originKey = getMCPToolOriginKey(tool);
+			const matchesManagerOrigin =
+				originKey !== undefined &&
+				initialMcpManagerTools.some(
+					managerTool => managerTool.name === tool.name && getMCPToolOriginKey(managerTool) === originKey,
+				);
 			if (matchesManagerOrigin) initialMcpManagerToolNames.add(tool.name);
 		}
 
@@ -2656,6 +2657,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			for (const name of collectPendingMCPToolNames(options.toolNames)) {
 				if (!toolRegistry.has(name)) {
 					toolRegistry.set(name, createPendingMCPTool(name));
+					initialMcpManagerToolNames.add(name);
 				}
 			}
 		}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -28,17 +28,7 @@ import {
 } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { FALLBACK_DIALECT, preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import type { Component } from "@oh-my-pi/pi-tui";
-import {
-	$env,
-	$flag,
-	getAgentDir,
-	getProjectDir,
-	logger,
-	postmortem,
-	prompt,
-	Snowflake,
-	untilAborted,
-} from "@oh-my-pi/pi-utils";
+import { $env, $flag, getAgentDir, getProjectDir, logger, postmortem, prompt, Snowflake } from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import {
 	discoverAdvisorConfigs,
@@ -3451,27 +3441,26 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// but Pi-compatible extensions may discover them asynchronously from a
 		// session_start handler. Install those late registrations into the live
 		// registry and serialize activation so no update can overwrite a sibling.
-		let dynamicToolRegistrationChain = Promise.resolve();
-		const scheduledToolRegistrations = new WeakSet<RegisteredTool>();
+		const scheduledToolRegistrations = new WeakMap<RegisteredTool, Promise<void>>();
 		const scheduleToolRegistration = (registered: RegisteredTool, signal?: AbortSignal): Promise<void> => {
-			if (scheduledToolRegistrations.has(registered)) return dynamicToolRegistrationChain;
-			scheduledToolRegistrations.add(registered);
+			const scheduled = scheduledToolRegistrations.get(registered);
+			if (scheduled) return scheduled;
 			const activationSignal = signal ?? AbortSignal.timeout(EXTENSION_HANDLER_TIMEOUT_MS);
 
 			const [wrapped] = wrapRegisteredTools([registered], extensionRunner);
-			if (!wrapped) return dynamicToolRegistrationChain;
+			if (!wrapped) return Promise.resolve();
 			const name = registered.definition.name;
 			const liveTool = new ExtensionToolWrapper(wrapToolWithMetaNotice(wrapped), extensionRunner);
 			// Capture ordinary extension precedence while the listener observes this exact registration.
 			// A later same-name registration may replace the extension map before serialized activation runs.
 			const isEffectiveRegistrant = extensionRunner.getRegisteredTool(name) === registered;
-			const serializedActivation = dynamicToolRegistrationChain.then(async () => {
+			const activation = session.runToolRegistryMutation(async () => {
 				activationSignal.throwIfAborted();
 				const existingTool = toolRegistry.get(name);
 				if (existingTool) {
-					// SDK custom tools are installed after extension tools during startup, so they
-					// retain the same precedence when an extension registers the name later.
-					if (sdkCustomToolNames.has(name)) return;
+					// RPC host tools and SDK custom tools retain their startup precedence when an
+					// extension registers the same name later.
+					if (session.hasRpcHostTool(name) || sdkCustomToolNames.has(name)) return;
 					// Put the replacement first so same-origin MCP re-registration keeps it. Distinct MCP origins still
 					// use the stable winner; ordinary tool collisions retain the extension runner's last-wins precedence.
 					const competingTools = deduplicateMCPToolsByName([liveTool, existingTool]);
@@ -3535,9 +3524,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					session.setToolBuiltIn(name, wasBuiltIn);
 					throw error;
 				}
-			});
-			const activation = untilAborted(activationSignal, serializedActivation);
-			dynamicToolRegistrationChain = activation.catch(() => {});
+			}, activationSignal);
+			scheduledToolRegistrations.set(registered, activation);
 			return activation;
 		};
 		if (!restrictToolNames) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3449,50 +3449,70 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			if (!wrapped) return dynamicToolRegistrationChain;
 			const name = registered.definition.name;
 			const liveTool = new ExtensionToolWrapper(wrapToolWithMetaNotice(wrapped), extensionRunner);
-			const existingTool = toolRegistry.get(name);
+			// Capture ordinary extension precedence while the listener observes this exact registration.
+			// A later same-name registration may replace the extension map before serialized activation runs.
 			const isEffectiveRegistrant = extensionRunner.getRegisteredTool(name) === registered;
-			if (existingTool) {
-				// Put the replacement first so same-origin MCP re-registration keeps it. Distinct MCP origins still
-				// use the stable winner; ordinary tool collisions retain the extension runner's last-wins precedence.
-				const competingTools = deduplicateMCPToolsByName([liveTool, existingTool]);
-				if (competingTools.length === 1) {
-					if (competingTools[0] !== liveTool) return dynamicToolRegistrationChain;
-				} else if (!isEffectiveRegistrant) {
-					return dynamicToolRegistrationChain;
-				}
-			} else if (!isEffectiveRegistrant) {
-				return dynamicToolRegistrationChain;
-			}
-			toolRegistry.set(name, liveTool);
-			builtInRegistryToolNames.delete(name);
-
 			const activation = dynamicToolRegistrationChain.then(async () => {
+				const existingTool = toolRegistry.get(name);
+				if (existingTool) {
+					// Put the replacement first so same-origin MCP re-registration keeps it. Distinct MCP origins still
+					// use the stable winner; ordinary tool collisions retain the extension runner's last-wins precedence.
+					const competingTools = deduplicateMCPToolsByName([liveTool, existingTool]);
+					if (competingTools.length === 1) {
+						if (competingTools[0] !== liveTool) return;
+					} else if (!isEffectiveRegistrant) {
+						return;
+					}
+				} else if (!isEffectiveRegistrant) {
+					return;
+				}
+
 				const enabled = session.getEnabledToolNames();
 				const alreadyEnabled = enabled.includes(name);
 				const explicitlyRequested = explicitlyRequestedToolNameSet?.has(name) === true;
 				const mounted = session.getMountedXdevToolNames();
-				if (registered.definition.defaultInactive && !explicitlyRequested) {
-					if (!alreadyEnabled) return;
+				const wasBuiltIn = builtInRegistryToolNames.has(name);
+				toolRegistry.set(name, liveTool);
+				builtInRegistryToolNames.delete(name);
+				session.setToolBuiltIn(name, false);
+				try {
+					if (registered.definition.defaultInactive && !explicitlyRequested) {
+						if (!alreadyEnabled) return;
+						await session.setActiveToolPresentation(
+							enabled.filter(enabledName => enabledName !== name),
+							mounted.filter(mountedName => mountedName !== name),
+							existingTool !== undefined,
+						);
+						return;
+					}
+					const shouldMount =
+						!explicitlyRequested &&
+						toolSession.xdev !== undefined &&
+						builtInRegistryToolNames.has("read") &&
+						builtInRegistryToolNames.has("write") &&
+						enabled.includes("read") &&
+						enabled.includes("write") &&
+						isMountableUnderXdev(liveTool);
+					const nextMounted = shouldMount
+						? mounted.includes(name)
+							? mounted
+							: [...mounted, name]
+						: mounted.filter(mountedName => mountedName !== name);
 					await session.setActiveToolPresentation(
-						enabled.filter(enabledName => enabledName !== name),
-						mounted.filter(mountedName => mountedName !== name),
+						alreadyEnabled ? enabled : [...enabled, name],
+						nextMounted,
+						existingTool !== undefined,
 					);
-					return;
+				} catch (error) {
+					if (existingTool) {
+						toolRegistry.set(name, existingTool);
+					} else {
+						toolRegistry.delete(name);
+					}
+					if (wasBuiltIn) builtInRegistryToolNames.add(name);
+					session.setToolBuiltIn(name, wasBuiltIn);
+					throw error;
 				}
-				const shouldMount =
-					!explicitlyRequested &&
-					toolSession.xdev !== undefined &&
-					builtInRegistryToolNames.has("read") &&
-					builtInRegistryToolNames.has("write") &&
-					enabled.includes("read") &&
-					enabled.includes("write") &&
-					isMountableUnderXdev(liveTool);
-				const nextMounted = shouldMount
-					? mounted.includes(name)
-						? mounted
-						: [...mounted, name]
-					: mounted.filter(mountedName => mountedName !== name);
-				await session.setActiveToolPresentation(alreadyEnabled ? enabled : [...enabled, name], nextMounted);
 			});
 			dynamicToolRegistrationChain = activation.catch(() => {});
 			return activation;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2576,6 +2576,11 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			autoApprove: options.autoApprove ?? false,
 		});
 		const toolContextStore = new ToolContextStore(getSessionContext);
+		const setSessionActiveToolNames = (names: Iterable<string>): void => {
+			const snapshot = Array.from(names);
+			setActiveToolNames(snapshot);
+			toolContextStore.setToolNames(snapshot);
+		};
 		// Native built-in implementations backing same-tool `ctx.invokeTool`, so a tool that
 		// re-registers a built-in (e.g. wrapping `write`) can delegate to the original — reaching the
 		// unwrapped native execute, which inherits the caller's already-granted approval rather than
@@ -2789,7 +2794,6 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			toolNames: string[],
 			tools: Map<string, AgentTool>,
 		): Promise<BuildSystemPromptResult> => {
-			toolContextStore.setToolNames(toolNames);
 			const promptCwd = sessionManager.getCwd();
 			const activeRepoContext = hasSession
 				? await logger.time("resolveActiveRepoContext", resolveRepoContext, promptCwd)
@@ -3042,7 +3046,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			if (mountedNames.length > 0 && !initialToolNames.includes("write")) initialToolNames.push("write");
 		}
 
-		setActiveToolNames(initialToolNames);
+		setSessionActiveToolNames(initialToolNames);
 		const { systemPrompt } = await logger.time(
 			"buildSystemPrompt",
 			rebuildSystemPrompt,
@@ -3395,7 +3399,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			getXdevToolEntries: () => (toolSession.xdev ? xdevEntries(toolSession.xdev) : []),
 			xdev: toolSession.xdev,
 			presentationPinnedToolNames: explicitlyRequestedToolNameSet,
-			setActiveToolNames,
+			setActiveToolNames: setSessionActiveToolNames,
 			ensureWriteRegistered,
 			getMcpServerInstructions: mcpManager
 				? () => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -28,7 +28,17 @@ import {
 } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { FALLBACK_DIALECT, preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import type { Component } from "@oh-my-pi/pi-tui";
-import { $env, $flag, getAgentDir, getProjectDir, logger, postmortem, prompt, Snowflake } from "@oh-my-pi/pi-utils";
+import {
+	$env,
+	$flag,
+	getAgentDir,
+	getProjectDir,
+	logger,
+	postmortem,
+	prompt,
+	Snowflake,
+	untilAborted,
+} from "@oh-my-pi/pi-utils";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import {
 	discoverAdvisorConfigs,
@@ -3442,7 +3452,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		// registry and serialize activation so no update can overwrite a sibling.
 		let dynamicToolRegistrationChain = Promise.resolve();
 		const scheduledToolRegistrations = new WeakSet<RegisteredTool>();
-		const scheduleToolRegistration = (registered: RegisteredTool): Promise<void> => {
+		const scheduleToolRegistration = (registered: RegisteredTool, signal?: AbortSignal): Promise<void> => {
 			if (scheduledToolRegistrations.has(registered)) return dynamicToolRegistrationChain;
 			scheduledToolRegistrations.add(registered);
 
@@ -3453,7 +3463,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			// Capture ordinary extension precedence while the listener observes this exact registration.
 			// A later same-name registration may replace the extension map before serialized activation runs.
 			const isEffectiveRegistrant = extensionRunner.getRegisteredTool(name) === registered;
-			const activation = dynamicToolRegistrationChain.then(async () => {
+			const serializedActivation = dynamicToolRegistrationChain.then(async () => {
+				signal?.throwIfAborted();
 				const existingTool = toolRegistry.get(name);
 				if (existingTool) {
 					// SDK custom tools are installed after extension tools during startup, so they
@@ -3486,6 +3497,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 							enabled.filter(enabledName => enabledName !== name),
 							mounted.filter(mountedName => mountedName !== name),
 							existingTool !== undefined,
+							signal,
 						);
 						return;
 					}
@@ -3509,6 +3521,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						alreadyEnabled ? enabled : [...enabled, name],
 						nextMounted,
 						existingTool !== undefined,
+						signal,
 					);
 				} catch (error) {
 					if (existingTool) {
@@ -3521,6 +3534,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					throw error;
 				}
 			});
+			const activation = untilAborted(signal, serializedActivation);
 			dynamicToolRegistrationChain = activation.catch(() => {});
 			return activation;
 		};

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2590,6 +2590,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			restrictToolNames && options.allowRestrictedCustomTools !== true
 				? []
 				: (options.customTools?.filter(tool => !isLegacyBuiltinToolDefinition(tool)) ?? []);
+		const sdkCustomToolNames = new Set(sdkCustomTools.map(tool => tool.name));
 		const allCustomTools = [
 			...registeredTools,
 			...sdkCustomTools.map(tool => {
@@ -3455,6 +3456,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			const activation = dynamicToolRegistrationChain.then(async () => {
 				const existingTool = toolRegistry.get(name);
 				if (existingTool) {
+					// SDK custom tools are installed after extension tools during startup, so they
+					// retain the same precedence when an extension registers the name later.
+					if (sdkCustomToolNames.has(name)) return;
 					// Put the replacement first so same-origin MCP re-registration keeps it. Distinct MCP origins still
 					// use the stable winner; ordinary tool collisions retain the extension runner's last-wins precedence.
 					const competingTools = deduplicateMCPToolsByName([liveTool, existingTool]);
@@ -3485,6 +3489,9 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						);
 						return;
 					}
+					// Re-registration refreshes the implementation, but it must not reverse an
+					// explicit setActiveTools() decision that disabled the previous definition.
+					if (existingTool && !alreadyEnabled) return;
 					const shouldMount =
 						!explicitlyRequested &&
 						toolSession.xdev !== undefined &&

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -93,6 +93,7 @@ import type { CustomTool, CustomToolContext, CustomToolSessionEvent } from "./ex
 import {
 	discoverAndLoadExtensions,
 	discoverExtensionPaths,
+	EXTENSION_HANDLER_TIMEOUT_MS,
 	type ExtensionContext,
 	type ExtensionFactory,
 	ExtensionRunner,
@@ -3455,6 +3456,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		const scheduleToolRegistration = (registered: RegisteredTool, signal?: AbortSignal): Promise<void> => {
 			if (scheduledToolRegistrations.has(registered)) return dynamicToolRegistrationChain;
 			scheduledToolRegistrations.add(registered);
+			const activationSignal = signal ?? AbortSignal.timeout(EXTENSION_HANDLER_TIMEOUT_MS);
 
 			const [wrapped] = wrapRegisteredTools([registered], extensionRunner);
 			if (!wrapped) return dynamicToolRegistrationChain;
@@ -3464,7 +3466,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			// A later same-name registration may replace the extension map before serialized activation runs.
 			const isEffectiveRegistrant = extensionRunner.getRegisteredTool(name) === registered;
 			const serializedActivation = dynamicToolRegistrationChain.then(async () => {
-				signal?.throwIfAborted();
+				activationSignal.throwIfAborted();
 				const existingTool = toolRegistry.get(name);
 				if (existingTool) {
 					// SDK custom tools are installed after extension tools during startup, so they
@@ -3497,7 +3499,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 							enabled.filter(enabledName => enabledName !== name),
 							mounted.filter(mountedName => mountedName !== name),
 							existingTool !== undefined,
-							signal,
+							activationSignal,
 						);
 						return;
 					}
@@ -3521,7 +3523,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 						alreadyEnabled ? enabled : [...enabled, name],
 						nextMounted,
 						existingTool !== undefined,
-						signal,
+						activationSignal,
 					);
 				} catch (error) {
 					if (existingTool) {
@@ -3534,7 +3536,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					throw error;
 				}
 			});
-			const activation = untilAborted(signal, serializedActivation);
+			const activation = untilAborted(activationSignal, serializedActivation);
 			dynamicToolRegistrationChain = activation.catch(() => {});
 			return activation;
 		};

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1826,6 +1826,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		toolSession.enableMCP = enableMCP;
 		const deferMCPDiscoveryForUI = enableMCP && !mcpManager && options.hasUI === true;
 		const customTools: CustomTool[] = [];
+		const initialMcpManagerTools: CustomTool[] = [];
 		let startDeferredMCPDiscovery: ((liveSession: AgentSession) => void) | undefined;
 		const startupQuiet = settings.get("startup.quiet");
 		const onMCPStatus = (event: McpConnectionStatusEvent) => {
@@ -1897,10 +1898,11 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					logger.error("MCP tool load failed", { path, error });
 				}
 
-				if (mcpResult.tools.length > 0) {
-					// MCP tools are LoadedCustomTool, extract the tool property
-					customTools.push(...mcpResult.tools.map(loaded => loaded.tool));
-				}
+				// MCP tools are LoadedCustomTool, extract the tool property while
+				// retaining their origins for initial registry ownership.
+				const loadedMcpTools = mcpResult.tools.map(loaded => loaded.tool);
+				customTools.push(...loadedMcpTools);
+				initialMcpManagerTools.push(...loadedMcpTools);
 			}
 		}
 		// Only top-level sessions own the global MCPManager. Subagents already
@@ -2611,6 +2613,16 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		const wrappedExtensionTools: Tool[] = deduplicateMCPToolsByName(
 			wrapRegisteredTools(allCustomTools, extensionRunner).map(wrapToolWithMetaNotice),
 		);
+		const initialMcpManagerToolNames = new Set<string>();
+		for (const tool of wrappedExtensionTools) {
+			const matchesManagerOrigin = initialMcpManagerTools.some(
+				managerTool =>
+					managerTool.name === tool.name &&
+					managerTool.mcpServerName === tool.mcpServerName &&
+					managerTool.mcpToolName === tool.mcpToolName,
+			);
+			if (matchesManagerOrigin) initialMcpManagerToolNames.add(tool.name);
+		}
 
 		// All built-in tools are active (conditional tools like git/ask return null from factory if disabled)
 		const builtInRegistryToolNames = toolSession.xdev?.builtInNames ?? new Set(toolRegistry.keys());
@@ -3387,6 +3399,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					? () => createVibeTools(toolSession)
 					: undefined,
 			builtInToolNames: builtInRegistryToolNames,
+			mcpManagerToolNames: initialMcpManagerToolNames,
 			transformContext,
 			transformProviderContext,
 			onPayload,
@@ -3461,6 +3474,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			const activation = session.runToolRegistryMutation(async () => {
 				activationSignal.throwIfAborted();
 				const existingTool = toolRegistry.get(name);
+				const previousExtensionMcpTool = session.getExtensionMCPTool(name);
+				const wasMcpManagerTool = session.hasMCPManagerTool(name);
 				if (existingTool) {
 					// RPC host tools and SDK custom tools retain their startup precedence when an
 					// extension registers the same name later.
@@ -3485,6 +3500,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				toolRegistry.set(name, liveTool);
 				builtInRegistryToolNames.delete(name);
 				session.setToolBuiltIn(name, false);
+				session.setExtensionMCPTool(name, liveTool);
 				try {
 					if (registered.definition.defaultInactive && !explicitlyRequested) {
 						if (!alreadyEnabled) return;
@@ -3526,6 +3542,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 					}
 					if (wasBuiltIn) builtInRegistryToolNames.add(name);
 					session.setToolBuiltIn(name, wasBuiltIn);
+					session.setExtensionMCPTool(name, previousExtensionMcpTool);
+					session.setMCPManagerTool(name, wasMcpManagerTool);
 					throw error;
 				}
 			}, activationSignal);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3465,9 +3465,15 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 				const enabled = session.getEnabledToolNames();
 				const alreadyEnabled = enabled.includes(name);
 				const explicitlyRequested = explicitlyRequestedToolNameSet?.has(name) === true;
-				if (!alreadyEnabled && registered.definition.defaultInactive && !explicitlyRequested) return;
-
 				const mounted = session.getMountedXdevToolNames();
+				if (registered.definition.defaultInactive && !explicitlyRequested) {
+					if (!alreadyEnabled) return;
+					await session.setActiveToolPresentation(
+						enabled.filter(enabledName => enabledName !== name),
+						mounted.filter(mountedName => mountedName !== name),
+					);
+					return;
+				}
 				const shouldMount =
 					!alreadyEnabled &&
 					!explicitlyRequested &&

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3451,18 +3451,12 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			if (!wrapped) return dynamicToolRegistrationChain;
 			const name = registered.definition.name;
 			const liveTool = new ExtensionToolWrapper(wrapToolWithMetaNotice(wrapped), extensionRunner);
-			// Distinct MCP origins use the startup path's stable winner; re-registering the same origin still replaces it.
 			const existingTool = toolRegistry.get(name);
-			if (
-				existingTool &&
-				typeof existingTool.mcpServerName === "string" &&
-				typeof existingTool.mcpToolName === "string" &&
-				typeof liveTool.mcpServerName === "string" &&
-				typeof liveTool.mcpToolName === "string" &&
-				(existingTool.mcpServerName !== liveTool.mcpServerName || existingTool.mcpToolName !== liveTool.mcpToolName)
-			) {
-				const [winner] = deduplicateMCPToolsByName([existingTool, liveTool]);
-				if (winner !== liveTool) return dynamicToolRegistrationChain;
+			if (existingTool) {
+				// Put the replacement first so same-origin MCP re-registration keeps it; distinct origins still use
+				// the startup path's stable winner, while non-MCP replacements remain last-registration-wins.
+				const competingTools = deduplicateMCPToolsByName([liveTool, existingTool]);
+				if (competingTools.length === 1 && competingTools[0] !== liveTool) return dynamicToolRegistrationChain;
 			}
 			toolRegistry.set(name, liveTool);
 			builtInRegistryToolNames.delete(name);

--- a/packages/coding-agent/src/session/agent-session-types.ts
+++ b/packages/coding-agent/src/session/agent-session-types.ts
@@ -174,6 +174,8 @@ export interface AgentSessionConfig {
 	createVibeTools?: () => AgentTool[];
 	/** Names whose current registry entry is the built-in implementation. */
 	builtInToolNames?: Iterable<string>;
+	/** MCP names whose initial registry entries came from the manager snapshot. */
+	mcpManagerToolNames?: Iterable<string>;
 	/** Updates tool-session predicates from the live active tool set. */
 	setActiveToolNames?: (names: Iterable<string>) => void;
 	/** Registers the write transport when runtime xdev mounts first need it. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4354,8 +4354,12 @@ export class AgentSession {
 	}
 
 	/** Restores an exact top-level versus `xd://` tool partition. */
-	setActiveToolPresentation(toolNames: string[], mountedToolNames: string[]): Promise<void> {
-		return this.#tools.setActiveToolPresentation(toolNames, mountedToolNames);
+	setActiveToolPresentation(
+		toolNames: string[],
+		mountedToolNames: string[],
+		forcePromptRefresh = false,
+	): Promise<void> {
+		return this.#tools.setActiveToolPresentation(toolNames, mountedToolNames, forcePromptRefresh);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4358,8 +4358,9 @@ export class AgentSession {
 		toolNames: string[],
 		mountedToolNames: string[],
 		forcePromptRefresh = false,
+		signal?: AbortSignal,
 	): Promise<void> {
-		return this.#tools.setActiveToolPresentation(toolNames, mountedToolNames, forcePromptRefresh);
+		return this.#tools.setActiveToolPresentation(toolNames, mountedToolNames, forcePromptRefresh, signal);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1242,6 +1242,7 @@ export class AgentSession {
 			createComputerTool: config.createComputerTool,
 			createInspectImageTool: config.createInspectImageTool,
 			builtInToolNames: config.builtInToolNames,
+			mcpManagerToolNames: config.mcpManagerToolNames,
 			presentationPinnedToolNames: config.presentationPinnedToolNames,
 			ensureWriteRegistered: config.ensureWriteRegistered,
 			rebuildSystemPrompt: config.rebuildSystemPrompt,
@@ -4304,6 +4305,26 @@ export class AgentSession {
 	/** Whether the live registry entry is owned by the RPC host. */
 	hasRpcHostTool(name: string): boolean {
 		return this.#tools.hasRpcHostTool(name);
+	}
+
+	/** Whether the current MCP entry came from the manager snapshot. */
+	hasMCPManagerTool(name: string): boolean {
+		return this.#tools.hasMCPManagerTool(name);
+	}
+
+	/** Restores manager ownership after a lifecycle registration rollback. */
+	setMCPManagerTool(name: string, managerOwned: boolean): void {
+		this.#tools.setMCPManagerTool(name, managerOwned);
+	}
+
+	/** Current extension-owned MCP entry retained across manager refreshes. */
+	getExtensionMCPTool(name: string): AgentTool | undefined {
+		return this.#tools.getExtensionMCPTool(name);
+	}
+
+	/** Updates extension MCP ownership after a lifecycle registration commit or rollback. */
+	setExtensionMCPTool(name: string, tool: AgentTool | undefined): void {
+		this.#tools.setExtensionMCPTool(name, tool);
 	}
 
 	/** Runs a registry/presentation mutation in this session's shared queue. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4301,6 +4301,16 @@ export class AgentSession {
 		this.#tools.setToolBuiltIn(name, builtIn);
 	}
 
+	/** Whether the live registry entry is owned by the RPC host. */
+	hasRpcHostTool(name: string): boolean {
+		return this.#tools.hasRpcHostTool(name);
+	}
+
+	/** Runs a registry/presentation mutation in this session's shared queue. */
+	runToolRegistryMutation<T>(mutation: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+		return this.#tools.runToolRegistryMutation(mutation, signal);
+	}
+
 	/** Names of every registered tool. */
 	getAllToolNames(): string[] {
 		return this.#tools.getAllToolNames();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4296,6 +4296,11 @@ export class AgentSession {
 		return this.#tools.hasBuiltInTool(name);
 	}
 
+	/** Updates source provenance when a live registry entry is replaced or restored. */
+	setToolBuiltIn(name: string, builtIn: boolean): void {
+		this.#tools.setToolBuiltIn(name, builtIn);
+	}
+
 	/** Names of every registered tool. */
 	getAllToolNames(): string[] {
 		return this.#tools.getAllToolNames();

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1191,12 +1191,14 @@ export class SessionTools {
 			const reconciled = await this.reconcileInspectImageTool();
 			const after = this.getEnabledToolNames().includes("inspect_image");
 			if (!reconciled || before === after) return;
+			const model = this.#host.model();
+			const modelName = model ? formatModelString(model) : "the current model";
 			this.#host.emitNotice(
 				"info",
 				after
-					? "inspect_image is now active for the selected model."
-					: "inspect_image is unavailable for the selected model.",
-				"inspect_image",
+					? `inspect_image is now available: ${modelName} has no native image input.`
+					: `inspect_image is now hidden: ${modelName} supports image input natively. Override with /vision on.`,
+				"vision",
 			);
 		});
 	}

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { Agent, AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { isRecord, logger, prompt, stringProperty, untilAborted } from "@oh-my-pi/pi-utils";
@@ -216,7 +217,8 @@ export class SessionTools {
 	 * prompt carries no catalog (no mounts, or a custom prompt that omits the section).
 	 */
 	#basePromptXdevNames: ReadonlySet<string> = new Set();
-	#mcpRefreshTail: Promise<void> = Promise.resolve();
+	#toolRegistryMutationScope = new AsyncLocalStorage<boolean>();
+	#toolRegistryMutationTail: Promise<void> = Promise.resolve();
 	#promptModelKey: string | undefined;
 	#rebuildSystemPrompt: SessionToolsOptions["rebuildSystemPrompt"];
 	#getLocalCalendarDate: () => string;
@@ -369,6 +371,26 @@ export class SessionTools {
 		} else {
 			this.#builtInToolNames.delete(name);
 		}
+	}
+
+	/** Whether the live registry entry is owned by the RPC host. */
+	hasRpcHostTool(name: string): boolean {
+		return this.#rpcHostToolNames.has(name);
+	}
+
+	/** Serializes every registry and presentation mutation for this session. */
+	runToolRegistryMutation<T>(mutation: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+		if (this.#toolRegistryMutationScope.getStore()) return untilAborted(signal, mutation);
+		const serialized = this.#toolRegistryMutationTail.then(() => {
+			signal?.throwIfAborted();
+			return this.#toolRegistryMutationScope.run(true, mutation);
+		});
+		const operation = untilAborted(signal, serialized);
+		this.#toolRegistryMutationTail = operation.then(
+			() => undefined,
+			() => undefined,
+		);
+		return operation;
 	}
 
 	/** Names of every registered tool. */
@@ -642,7 +664,14 @@ export class SessionTools {
 	}
 
 	/** Applies an enabled tool set and reconciles its `xd://` partition. */
-	async applyActiveToolsByName(toolNames: string[], forcePromptRefresh = false, signal?: AbortSignal): Promise<void> {
+	applyActiveToolsByName(toolNames: string[], forcePromptRefresh = false, signal?: AbortSignal): Promise<void> {
+		return this.runToolRegistryMutation(
+			() => this.#applyActiveToolsByName(toolNames, forcePromptRefresh, signal),
+			signal,
+		);
+	}
+
+	async #applyActiveToolsByName(toolNames: string[], forcePromptRefresh = false, signal?: AbortSignal): Promise<void> {
 		signal?.throwIfAborted();
 		toolNames = normalizeToolNames(toolNames);
 		let builtInWriteAvailable = this.#builtInToolNames.has("write");
@@ -930,15 +959,17 @@ export class SessionTools {
 	}
 
 	/** Selects enabled tools, ignoring names absent from the registry. */
-	async setActiveToolsByName(toolNames: string[]): Promise<void> {
-		const normalized = normalizeToolNames(toolNames);
-		// Transport-write eligibility keys off the *current* active set: an ordinary
-		// selection change should not demote `write` unless it is already active.
-		await this.#applyToolPresentation(
-			normalized,
-			this.#xdev?.mountedNames ?? new Set(),
-			this.getActiveToolNames().includes("write"),
-		);
+	setActiveToolsByName(toolNames: string[]): Promise<void> {
+		return this.runToolRegistryMutation(async () => {
+			const normalized = normalizeToolNames(toolNames);
+			// Transport-write eligibility keys off the *current* active set: an ordinary
+			// selection change should not demote `write` unless it is already active.
+			await this.#applyToolPresentation(
+				normalized,
+				this.#xdev?.mountedNames ?? new Set(),
+				this.getActiveToolNames().includes("write"),
+			);
+		});
 	}
 
 	/**
@@ -958,22 +989,24 @@ export class SessionTools {
 	 * Delegates the actual apply through {@link applyActiveToolsByName} and restores
 	 * the prior runtime selection if that apply throws.
 	 */
-	async setActiveToolPresentation(
+	setActiveToolPresentation(
 		toolNames: string[],
 		mountedToolNames: string[],
 		forcePromptRefresh = false,
 		signal?: AbortSignal,
 	): Promise<void> {
-		const normalized = normalizeToolNames(toolNames);
-		// Restoration targets a snapshot, so write eligibility comes from the
-		// *target* set rather than whatever happens to be active mid-rollback.
-		await this.#applyToolPresentation(
-			normalized,
-			new Set(normalizeToolNames(mountedToolNames)),
-			normalized.includes("write"),
-			forcePromptRefresh,
-			signal,
-		);
+		return this.runToolRegistryMutation(async () => {
+			const normalized = normalizeToolNames(toolNames);
+			// Restoration targets a snapshot, so write eligibility comes from the
+			// *target* set rather than whatever happens to be active mid-rollback.
+			await this.#applyToolPresentation(
+				normalized,
+				new Set(normalizeToolNames(mountedToolNames)),
+				normalized.includes("write"),
+				forcePromptRefresh,
+				signal,
+			);
+		}, signal);
 	}
 
 	/**
@@ -999,7 +1032,7 @@ export class SessionTools {
 			normalized.filter(name => !mounted.has(name) && !(name === "write" && transportWriteActive)),
 		);
 		try {
-			await this.applyActiveToolsByName(normalized, forcePromptRefresh, signal);
+			await this.#applyActiveToolsByName(normalized, forcePromptRefresh, signal);
 		} catch (error) {
 			this.#runtimeSelectedToolNames = previousRuntimeSelectedToolNames;
 			throw error;
@@ -1324,11 +1357,9 @@ export class SessionTools {
 	 */
 	refreshMCPTools(mcpTools: CustomTool[]): Promise<void> {
 		const snapshot = [...mcpTools];
-		const refresh = this.#mcpRefreshTail.then(() =>
-			this.#host.isDisposed() ? undefined : this.#applyMCPToolRefresh(snapshot),
+		return this.runToolRegistryMutation(() =>
+			this.#host.isDisposed() ? Promise.resolve() : this.#applyMCPToolRefresh(snapshot),
 		);
-		this.#mcpRefreshTail = refresh.catch(() => {});
-		return refresh;
 	}
 
 	async #applyMCPToolRefresh(mcpTools: CustomTool[]): Promise<void> {
@@ -1378,7 +1409,7 @@ export class SessionTools {
 		// presentation pins and write-transport activation/removal.
 		const nextActive = [...new Set([...this.#getActiveNonMCPToolNames(), ...uniqueMcpTools.map(tool => tool.name)])];
 		try {
-			await this.applyActiveToolsByName(nextActive);
+			await this.#applyActiveToolsByName(nextActive);
 			if (this.#host.isDisposed()) restorePreviousMcpTools();
 		} catch (error) {
 			restorePreviousMcpTools();
@@ -1387,7 +1418,12 @@ export class SessionTools {
 	}
 
 	/** Replaces RPC host-owned tools and refreshes the active set before the next model call. */
-	async refreshRpcHostTools(rpcTools: AgentTool[]): Promise<void> {
+	refreshRpcHostTools(rpcTools: AgentTool[]): Promise<void> {
+		const snapshot = [...rpcTools];
+		return this.runToolRegistryMutation(() => this.#applyRpcHostToolRefresh(snapshot));
+	}
+
+	async #applyRpcHostToolRefresh(rpcTools: AgentTool[]): Promise<void> {
 		const nextToolNames = rpcTools.map(tool => tool.name);
 		const uniqueToolNames = new Set(nextToolNames);
 		if (uniqueToolNames.size !== nextToolNames.length) {
@@ -1431,7 +1467,7 @@ export class SessionTools {
 			.filter(tool => !tool.hidden && !previousRpcHostToolNames.has(tool.name))
 			.map(tool => tool.name);
 		try {
-			await this.applyActiveToolsByName(
+			await this.#applyActiveToolsByName(
 				Array.from(new Set([...activeNonRpcToolNames, ...preservedRpcToolNames, ...autoActivatedRpcToolNames])),
 			);
 		} catch (error) {

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1,6 +1,6 @@
 import type { Agent, AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
-import { isRecord, logger, prompt, stringProperty } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, prompt, stringProperty, untilAborted } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../capability";
 import type { ModelRegistry } from "../config/model-registry";
 import { formatModelString } from "../config/model-resolver";
@@ -642,11 +642,13 @@ export class SessionTools {
 	}
 
 	/** Applies an enabled tool set and reconciles its `xd://` partition. */
-	async applyActiveToolsByName(toolNames: string[], forcePromptRefresh = false): Promise<void> {
+	async applyActiveToolsByName(toolNames: string[], forcePromptRefresh = false, signal?: AbortSignal): Promise<void> {
+		signal?.throwIfAborted();
 		toolNames = normalizeToolNames(toolNames);
 		let builtInWriteAvailable = this.#builtInToolNames.has("write");
 		if (toolNames.includes("write") && !builtInWriteAvailable) {
-			builtInWriteAvailable = (await this.#ensureWriteRegistered?.()) === true;
+			const writeRegistration = this.#ensureWriteRegistered?.();
+			builtInWriteAvailable = writeRegistration ? (await untilAborted(signal, writeRegistration)) === true : false;
 			if (builtInWriteAvailable) this.#builtInToolNames.add("write");
 		}
 		const selectedTools = toolNames.flatMap(name => {
@@ -678,7 +680,8 @@ export class SessionTools {
 		const activeDeferrableTool = tools.some(tool => tool.deferrable === true);
 		const transportNeeded = mountNames.size > 0 || activeDeferrableTool || this.#host.planModeEnabled();
 		if (transportNeeded && !builtInWriteAvailable) {
-			builtInWriteAvailable = (await this.#ensureWriteRegistered?.()) === true;
+			const writeRegistration = this.#ensureWriteRegistered?.();
+			builtInWriteAvailable = writeRegistration ? (await untilAborted(signal, writeRegistration)) === true : false;
 			if (builtInWriteAvailable) this.#builtInToolNames.add("write");
 		}
 		if (transportNeeded && builtInWriteAvailable) {
@@ -709,12 +712,13 @@ export class SessionTools {
 			if (this.#rebuildSystemPrompt) {
 				const signature = this.#computeAppliedToolSignature(validToolNames, tools);
 				if (forcePromptRefresh || signature !== this.#lastAppliedToolSignature) {
-					const built = await this.#rebuildSystemPrompt(validToolNames, this.#toolRegistry);
+					const built = await untilAborted(signal, this.#rebuildSystemPrompt(validToolNames, this.#toolRegistry));
 					rebuiltSystemPrompt = built.systemPrompt;
 					rebuiltSignature = signature;
 					rebuiltXdevCatalogNames = built.xdevCatalogNames;
 				}
 			}
+			signal?.throwIfAborted();
 		} catch (error) {
 			this.#setMountedNames(previousMounted);
 			this.#setActiveToolNames?.(previousActiveToolNames);
@@ -958,6 +962,7 @@ export class SessionTools {
 		toolNames: string[],
 		mountedToolNames: string[],
 		forcePromptRefresh = false,
+		signal?: AbortSignal,
 	): Promise<void> {
 		const normalized = normalizeToolNames(toolNames);
 		// Restoration targets a snapshot, so write eligibility comes from the
@@ -967,6 +972,7 @@ export class SessionTools {
 			new Set(normalizeToolNames(mountedToolNames)),
 			normalized.includes("write"),
 			forcePromptRefresh,
+			signal,
 		);
 	}
 
@@ -980,6 +986,7 @@ export class SessionTools {
 		mounted: ReadonlySet<string>,
 		writeSelected: boolean,
 		forcePromptRefresh = false,
+		signal?: AbortSignal,
 	): Promise<void> {
 		const transportWriteActive =
 			writeSelected &&
@@ -992,7 +999,7 @@ export class SessionTools {
 			normalized.filter(name => !mounted.has(name) && !(name === "write" && transportWriteActive)),
 		);
 		try {
-			await this.applyActiveToolsByName(normalized, forcePromptRefresh);
+			await this.applyActiveToolsByName(normalized, forcePromptRefresh, signal);
 		} catch (error) {
 			this.#runtimeSelectedToolNames = previousRuntimeSelectedToolNames;
 			throw error;

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -386,7 +386,7 @@ export class SessionTools {
 			return this.#toolRegistryMutationScope.run(true, mutation);
 		});
 		const operation = untilAborted(signal, serialized);
-		this.#toolRegistryMutationTail = operation.then(
+		this.#toolRegistryMutationTail = serialized.then(
 			() => undefined,
 			() => undefined,
 		);

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -1480,7 +1480,7 @@ export class SessionTools {
 		const nextActive = [
 			...new Set([
 				...this.#getActiveNonMCPToolNames(),
-				...managerTools.map(tool => tool.name),
+				...this.#mcpManagerToolNames,
 				...retainedActiveExtensionToolNames,
 			]),
 		];

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -362,6 +362,15 @@ export class SessionTools {
 		return this.#builtInToolNames.has(name);
 	}
 
+	/** Updates source provenance when a live registry entry is replaced or restored. */
+	setToolBuiltIn(name: string, builtIn: boolean): void {
+		if (builtIn) {
+			this.#builtInToolNames.add(name);
+		} else {
+			this.#builtInToolNames.delete(name);
+		}
+	}
+
 	/** Names of every registered tool. */
 	getAllToolNames(): string[] {
 		return Array.from(this.#toolRegistry.keys());
@@ -633,7 +642,7 @@ export class SessionTools {
 	}
 
 	/** Applies an enabled tool set and reconciles its `xd://` partition. */
-	async applyActiveToolsByName(toolNames: string[]): Promise<void> {
+	async applyActiveToolsByName(toolNames: string[], forcePromptRefresh = false): Promise<void> {
 		toolNames = normalizeToolNames(toolNames);
 		let builtInWriteAvailable = this.#builtInToolNames.has("write");
 		if (toolNames.includes("write") && !builtInWriteAvailable) {
@@ -699,7 +708,7 @@ export class SessionTools {
 		try {
 			if (this.#rebuildSystemPrompt) {
 				const signature = this.#computeAppliedToolSignature(validToolNames, tools);
-				if (signature !== this.#lastAppliedToolSignature) {
+				if (forcePromptRefresh || signature !== this.#lastAppliedToolSignature) {
 					const built = await this.#rebuildSystemPrompt(validToolNames, this.#toolRegistry);
 					rebuiltSystemPrompt = built.systemPrompt;
 					rebuiltSignature = signature;
@@ -938,11 +947,18 @@ export class SessionTools {
 	 * `xd://` remain mount-eligible, even when the live mount set has drifted.
 	 *
 	 * Names outside `mountedToolNames` are pinned top-level for this application;
-	 * names in the mounted subset remain eligible for xdev mounting. Delegates the
-	 * actual apply through {@link applyActiveToolsByName} and restores the prior runtime
-	 * selection if that apply throws.
+	 * names in the mounted subset remain eligible for xdev mounting. Set
+	 * `forcePromptRefresh` when an enabled tool's schema or prompt-visible metadata
+	 * changed without changing its name or presentation.
+	 *
+	 * Delegates the actual apply through {@link applyActiveToolsByName} and restores
+	 * the prior runtime selection if that apply throws.
 	 */
-	async setActiveToolPresentation(toolNames: string[], mountedToolNames: string[]): Promise<void> {
+	async setActiveToolPresentation(
+		toolNames: string[],
+		mountedToolNames: string[],
+		forcePromptRefresh = false,
+	): Promise<void> {
 		const normalized = normalizeToolNames(toolNames);
 		// Restoration targets a snapshot, so write eligibility comes from the
 		// *target* set rather than whatever happens to be active mid-rollback.
@@ -950,6 +966,7 @@ export class SessionTools {
 			normalized,
 			new Set(normalizeToolNames(mountedToolNames)),
 			normalized.includes("write"),
+			forcePromptRefresh,
 		);
 	}
 
@@ -962,6 +979,7 @@ export class SessionTools {
 		normalized: string[],
 		mounted: ReadonlySet<string>,
 		writeSelected: boolean,
+		forcePromptRefresh = false,
 	): Promise<void> {
 		const transportWriteActive =
 			writeSelected &&
@@ -974,7 +992,7 @@ export class SessionTools {
 			normalized.filter(name => !mounted.has(name) && !(name === "write" && transportWriteActive)),
 		);
 		try {
-			await this.applyActiveToolsByName(normalized);
+			await this.applyActiveToolsByName(normalized, forcePromptRefresh);
 		} catch (error) {
 			this.#runtimeSelectedToolNames = previousRuntimeSelectedToolNames;
 			throw error;

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -72,6 +72,8 @@ interface SessionToolsOptions {
 	createInspectImageTool?: () => Promise<AgentTool | null>;
 	builtInToolNames?: Iterable<string>;
 	presentationPinnedToolNames?: ReadonlySet<string>;
+	/** MCP tool names whose current registry entries came from the manager snapshot. */
+	mcpManagerToolNames?: Iterable<string>;
 	ensureWriteRegistered?: () => Promise<boolean>;
 	rebuildSystemPrompt?: (
 		toolNames: string[],
@@ -186,6 +188,8 @@ export class SessionTools {
 	#installedVibeToolNames = new Set<string>();
 	#builtInToolNames: Set<string>;
 	#rpcHostToolNames = new Set<string>();
+	#mcpManagerToolNames = new Set<string>();
+	#extensionMcpTools = new Map<string, AgentTool>();
 	#xdev: XdevState | undefined;
 	#pendingXdevMountDelta: { added: Set<string>; removed: Set<string> } | undefined;
 	/**
@@ -239,6 +243,17 @@ export class SessionTools {
 		this.#createComputerTool = options.createComputerTool;
 		this.#createInspectImageTool = options.createInspectImageTool;
 		this.#builtInToolNames = new Set(options.builtInToolNames ?? []);
+		this.#mcpManagerToolNames = new Set(options.mcpManagerToolNames ?? []);
+		if (options.mcpManagerToolNames === undefined) {
+			for (const name of this.#toolRegistry.keys()) {
+				if (isMCPToolName(name)) this.#mcpManagerToolNames.add(name);
+			}
+		}
+		for (const [name, tool] of this.#toolRegistry) {
+			if (isMCPToolName(name) && !this.#mcpManagerToolNames.has(name)) {
+				this.#extensionMcpTools.set(name, tool);
+			}
+		}
 		this.#presentationPinnedToolNames = options.presentationPinnedToolNames;
 		this.#ensureWriteRegistered = options.ensureWriteRegistered;
 		this.#rebuildSystemPrompt = options.rebuildSystemPrompt;
@@ -376,6 +391,36 @@ export class SessionTools {
 	/** Whether the live registry entry is owned by the RPC host. */
 	hasRpcHostTool(name: string): boolean {
 		return this.#rpcHostToolNames.has(name);
+	}
+
+	/** Whether the current MCP entry came from the manager snapshot. */
+	hasMCPManagerTool(name: string): boolean {
+		return this.#mcpManagerToolNames.has(name);
+	}
+
+	/** Restores manager ownership after a lifecycle registration rollback. */
+	setMCPManagerTool(name: string, managerOwned: boolean): void {
+		if (managerOwned) {
+			this.#mcpManagerToolNames.add(name);
+		} else {
+			this.#mcpManagerToolNames.delete(name);
+		}
+	}
+
+	/** Current extension-owned MCP entry retained across manager refreshes. */
+	getExtensionMCPTool(name: string): AgentTool | undefined {
+		return this.#extensionMcpTools.get(name);
+	}
+
+	/** Updates extension ownership when a lifecycle registration commits or rolls back. */
+	setExtensionMCPTool(name: string, tool: AgentTool | undefined): void {
+		if (!isMCPToolName(name)) return;
+		if (tool) {
+			this.#extensionMcpTools.set(name, tool);
+			this.#mcpManagerToolNames.delete(name);
+		} else {
+			this.#extensionMcpTools.delete(name);
+		}
 	}
 
 	/** Serializes every registry and presentation mutation for this session. */
@@ -1383,24 +1428,19 @@ export class SessionTools {
 	}
 
 	async #applyMCPToolRefresh(mcpTools: CustomTool[]): Promise<void> {
-		const existingNames = Array.from(this.#toolRegistry.keys());
-		const previousMcpTools = new Map(
-			existingNames.flatMap(name => {
-				const tool = this.#toolRegistry.get(name);
-				return isMCPToolName(name) && tool ? [[name, tool] as const] : [];
-			}),
-		);
+		const previousMcpTools = new Map<string, AgentTool>();
+		for (const [name, tool] of this.#toolRegistry) {
+			if (isMCPToolName(name)) previousMcpTools.set(name, tool);
+		}
+		const previousMcpManagerToolNames = new Set(this.#mcpManagerToolNames);
+		const previousActiveMcpToolNames = this.getEnabledToolNames().filter(isMCPToolName);
 		const restorePreviousMcpTools = () => {
 			for (const name of this.#toolRegistry.keys()) {
 				if (isMCPToolName(name)) this.#toolRegistry.delete(name);
 			}
 			for (const [name, tool] of previousMcpTools) this.#toolRegistry.set(name, tool);
+			this.#mcpManagerToolNames = previousMcpManagerToolNames;
 		};
-		for (const name of existingNames) {
-			if (isMCPToolName(name)) {
-				this.#toolRegistry.delete(name);
-			}
-		}
 
 		const getCustomToolContext = (): CustomToolContext => ({
 			sessionManager: this.#host.sessionManager,
@@ -1416,18 +1456,34 @@ export class SessionTools {
 		});
 
 		const extensionRunner = this.#host.extensionRunner();
-		const uniqueMcpTools = deduplicateMCPToolsByName(mcpTools);
-		for (const customTool of uniqueMcpTools) {
+		const managerTools = deduplicateMCPToolsByName(mcpTools).map(customTool => {
 			const wrapped = wrapToolWithMetaNotice(CustomToolAdapter.wrap(customTool, getCustomToolContext) as AgentTool);
-			const finalTool = (
-				extensionRunner ? new ExtensionToolWrapper(wrapped, extensionRunner) : wrapped
-			) as AgentTool;
-			this.#toolRegistry.set(finalTool.name, finalTool);
+			return (extensionRunner ? new ExtensionToolWrapper(wrapped, extensionRunner) : wrapped) as AgentTool;
+		});
+		const managerToolSet = new Set(managerTools);
+		const reconciledTools = deduplicateMCPToolsByName([...this.#extensionMcpTools.values(), ...managerTools]);
+
+		for (const name of this.#toolRegistry.keys()) {
+			if (isMCPToolName(name)) this.#toolRegistry.delete(name);
+		}
+		this.#mcpManagerToolNames.clear();
+		for (const tool of reconciledTools) {
+			this.#toolRegistry.set(tool.name, tool);
+			if (managerToolSet.has(tool)) this.#mcpManagerToolNames.add(tool.name);
 		}
 
-		// Every connected MCP tool is selected; centralized repartitioning owns
-		// presentation pins and write-transport activation/removal.
-		const nextActive = [...new Set([...this.#getActiveNonMCPToolNames(), ...uniqueMcpTools.map(tool => tool.name)])];
+		// Connected manager tools become active immediately. Extension-owned MCP
+		// tools retain their prior selection while both sets share one registry.
+		const retainedActiveExtensionToolNames = previousActiveMcpToolNames.filter(
+			name => this.#extensionMcpTools.has(name) && this.#toolRegistry.has(name),
+		);
+		const nextActive = [
+			...new Set([
+				...this.#getActiveNonMCPToolNames(),
+				...managerTools.map(tool => tool.name),
+				...retainedActiveExtensionToolNames,
+			]),
+		];
 		try {
 			await this.#applyActiveToolsByName(nextActive);
 			if (this.#host.isDisposed()) restorePreviousMcpTools();

--- a/packages/coding-agent/src/session/session-tools.ts
+++ b/packages/coding-agent/src/session/session-tools.ts
@@ -432,40 +432,46 @@ export class SessionTools {
 	}
 
 	/** Installs and activates the ephemeral vibe tool set. */
-	async activateVibeTools(baseToolNames: string[]): Promise<void> {
-		const createVibeTools = this.#createVibeTools;
-		if (!createVibeTools) {
-			throw new Error("Vibe tools are unavailable in this session.");
-		}
+	activateVibeTools(baseToolNames: string[]): Promise<void> {
+		return this.runToolRegistryMutation(async () => {
+			const createVibeTools = this.#createVibeTools;
+			if (!createVibeTools) {
+				throw new Error("Vibe tools are unavailable in this session.");
+			}
 
-		const tools = createVibeTools();
-		const vibeToolNames = tools.map(tool => tool.name);
-		if (new Set(vibeToolNames).size !== vibeToolNames.length) {
-			throw new Error("Vibe tool names must be unique.");
-		}
+			const tools = createVibeTools();
+			const vibeToolNames = tools.map(tool => tool.name);
+			if (new Set(vibeToolNames).size !== vibeToolNames.length) {
+				throw new Error("Vibe tool names must be unique.");
+			}
 
-		for (const tool of tools) {
-			if (this.#toolRegistry.has(tool.name)) continue;
-			this.#toolRegistry.set(tool.name, this.#wrapRuntimeTool(tool));
-			this.#builtInToolNames.add(tool.name);
-			this.#installedVibeToolNames.add(tool.name);
-		}
+			for (const tool of tools) {
+				if (this.#toolRegistry.has(tool.name)) continue;
+				this.#toolRegistry.set(tool.name, this.#wrapRuntimeTool(tool));
+				this.#builtInToolNames.add(tool.name);
+				this.#installedVibeToolNames.add(tool.name);
+			}
 
-		await this.applyActiveToolsByName([...new Set([...baseToolNames, ...vibeToolNames])]);
+			await this.#applyActiveToolsByName([...new Set([...baseToolNames, ...vibeToolNames])]);
+		});
 	}
 
 	/** Uninstalls vibe tools and activates the replacement set. */
-	async deactivateVibeTools(nextToolNames: string[]): Promise<void> {
-		this.#uninstallVibeTools();
-		await this.applyActiveToolsByName(nextToolNames);
+	deactivateVibeTools(nextToolNames: string[]): Promise<void> {
+		return this.runToolRegistryMutation(async () => {
+			this.#uninstallVibeTools();
+			await this.#applyActiveToolsByName(nextToolNames);
+		});
 	}
 
 	/** Removes vibe tools without restoring a source-session snapshot. */
-	async removeVibeToolsPreservingActive(): Promise<void> {
-		const removed = new Set(this.#installedVibeToolNames);
-		this.#uninstallVibeTools();
-		const nextActive = this.getActiveToolNames().filter(name => !removed.has(name));
-		await this.applyActiveToolsByName(nextActive);
+	removeVibeToolsPreservingActive(): Promise<void> {
+		return this.runToolRegistryMutation(async () => {
+			const removed = new Set(this.#installedVibeToolNames);
+			this.#uninstallVibeTools();
+			const nextActive = this.getActiveToolNames().filter(name => !removed.has(name));
+			await this.#applyActiveToolsByName(nextActive);
+		});
 	}
 
 	#uninstallVibeTools(): void {
@@ -1040,24 +1046,26 @@ export class SessionTools {
 	}
 
 	/** Replaces memory-backend tools while preserving unrelated selections. */
-	async replaceMemoryTools(tools: AgentTool[]): Promise<void> {
-		const removed = new Set<string>(MEMORY_BACKEND_TOOL_NAMES.filter(name => this.#builtInToolNames.has(name)));
-		const nextActive = this.getEnabledToolNames().filter(name => !removed.has(name));
-		for (const name of removed) {
-			this.#toolRegistry.delete(name);
-			this.#builtInToolNames.delete(name);
-		}
-
-		for (const tool of tools) {
-			if (!MEMORY_BACKEND_TOOL_NAMES.some(name => name === tool.name) || this.#toolRegistry.has(tool.name)) {
-				continue;
+	replaceMemoryTools(tools: AgentTool[]): Promise<void> {
+		return this.runToolRegistryMutation(async () => {
+			const removed = new Set<string>(MEMORY_BACKEND_TOOL_NAMES.filter(name => this.#builtInToolNames.has(name)));
+			const nextActive = this.getEnabledToolNames().filter(name => !removed.has(name));
+			for (const name of removed) {
+				this.#toolRegistry.delete(name);
+				this.#builtInToolNames.delete(name);
 			}
-			const wrapped = this.#wrapRuntimeTool(tool);
-			this.#toolRegistry.set(wrapped.name, wrapped);
-			this.#builtInToolNames.add(wrapped.name);
-			nextActive.push(wrapped.name);
-		}
-		await this.applyActiveToolsByName([...new Set(nextActive)]);
+
+			for (const tool of tools) {
+				if (!MEMORY_BACKEND_TOOL_NAMES.some(name => name === tool.name) || this.#toolRegistry.has(tool.name)) {
+					continue;
+				}
+				const wrapped = this.#wrapRuntimeTool(tool);
+				this.#toolRegistry.set(wrapped.name, wrapped);
+				this.#builtInToolNames.add(wrapped.name);
+				nextActive.push(wrapped.name);
+			}
+			await this.#applyActiveToolsByName([...new Set(nextActive)]);
+		});
 	}
 
 	/**
@@ -1073,34 +1081,36 @@ export class SessionTools {
 	 * @returns false when enabling was requested but this session cannot build the
 	 * tool (e.g. restricted child sessions have no factory).
 	 */
-	async setComputerToolEnabled(enabled: boolean): Promise<boolean> {
-		const logState = (): void => this.#logComputerState("Computer tool state changed", enabled);
-		const active = this.getEnabledToolNames();
-		if (!enabled) {
-			if (active.includes("computer")) {
-				await this.applyActiveToolsByName(active.filter(name => name !== "computer"));
+	setComputerToolEnabled(enabled: boolean): Promise<boolean> {
+		return this.runToolRegistryMutation(async () => {
+			const logState = (): void => this.#logComputerState("Computer tool state changed", enabled);
+			const active = this.getEnabledToolNames();
+			if (!enabled) {
+				if (active.includes("computer")) {
+					await this.#applyActiveToolsByName(active.filter(name => name !== "computer"));
+				}
+				logState();
+				return true;
+			}
+			if (!this.#toolRegistry.has("computer")) {
+				const tool = await this.#createComputerTool?.();
+				if (tool?.name !== "computer") {
+					const model = this.#host.model();
+					logger.warn("Computer tool could not be created", {
+						model: model ? formatModelString(model) : undefined,
+					});
+					return false;
+				}
+				const wrapped = this.#wrapRuntimeTool(tool);
+				this.#toolRegistry.set(wrapped.name, wrapped);
+				this.#builtInToolNames.add(wrapped.name);
+			}
+			if (!active.includes("computer")) {
+				await this.#applyActiveToolsByName([...active, "computer"]);
 			}
 			logState();
 			return true;
-		}
-		if (!this.#toolRegistry.has("computer")) {
-			const tool = await this.#createComputerTool?.();
-			if (tool?.name !== "computer") {
-				const model = this.#host.model();
-				logger.warn("Computer tool could not be created", {
-					model: model ? formatModelString(model) : undefined,
-				});
-				return false;
-			}
-			const wrapped = this.#wrapRuntimeTool(tool);
-			this.#toolRegistry.set(wrapped.name, wrapped);
-			this.#builtInToolNames.add(wrapped.name);
-		}
-		if (!active.includes("computer")) {
-			await this.applyActiveToolsByName([...active, "computer"]);
-		}
-		logState();
-		return true;
+		});
 	}
 
 	/** Current effective inspect_image state for `/vision status`. */
@@ -1123,48 +1133,50 @@ export class SessionTools {
 	 * @returns false when the tool should be active but this session cannot
 	 *   build it (e.g. restricted child sessions have no factory).
 	 */
-	async reconcileInspectImageTool(): Promise<boolean> {
-		const expected = isInspectImageToolActive({
-			settings: this.#host.settings,
-			getActiveModel: () => this.#host.model(),
-			getInspectImageModeOverride: () => this.#host.getInspectImageModeOverride(),
-		});
-		// Keep the read tool's advertised description in sync BEFORE any prompt
-		// rebuild below, passing the post-change availability so the prompt never
-		// lags a flip in either direction. Per-read lazy sync is the backstop.
-		const syncReadDescription = (available: boolean): void => {
-			const readTool = this.#toolRegistry.get("read") as
-				| { syncInspectImageState?: (available?: boolean) => boolean }
-				| undefined;
-			readTool?.syncInspectImageState?.(available);
-		};
-		const active = this.getEnabledToolNames();
-		const isActive = active.includes("inspect_image");
-		if (expected === isActive) {
-			syncReadDescription(isActive);
-			return true;
-		}
-		if (!expected) {
-			syncReadDescription(false);
-			await this.applyActiveToolsByName(active.filter(name => name !== "inspect_image"));
-			return true;
-		}
-		if (!this.#toolRegistry.has("inspect_image")) {
-			const tool = await this.#createInspectImageTool?.();
-			if (tool?.name !== "inspect_image") {
-				logger.warn("inspect_image tool could not be created", {
-					model: this.#host.model()?.id,
-				});
-				syncReadDescription(false);
-				return false;
+	reconcileInspectImageTool(): Promise<boolean> {
+		return this.runToolRegistryMutation(async () => {
+			const expected = isInspectImageToolActive({
+				settings: this.#host.settings,
+				getActiveModel: () => this.#host.model(),
+				getInspectImageModeOverride: () => this.#host.getInspectImageModeOverride(),
+			});
+			// Keep the read tool's advertised description in sync BEFORE any prompt
+			// rebuild below, passing the post-change availability so the prompt never
+			// lags a flip in either direction. Per-read lazy sync is the backstop.
+			const syncReadDescription = (available: boolean): void => {
+				const readTool = this.#toolRegistry.get("read") as
+					| { syncInspectImageState?: (available?: boolean) => boolean }
+					| undefined;
+				readTool?.syncInspectImageState?.(available);
+			};
+			const active = this.getEnabledToolNames();
+			const isActive = active.includes("inspect_image");
+			if (expected === isActive) {
+				syncReadDescription(isActive);
+				return true;
 			}
-			const wrapped = this.#wrapRuntimeTool(tool);
-			this.#toolRegistry.set(wrapped.name, wrapped);
-			this.#builtInToolNames.add(wrapped.name);
-		}
-		syncReadDescription(true);
-		await this.applyActiveToolsByName([...active, "inspect_image"]);
-		return true;
+			if (!expected) {
+				syncReadDescription(false);
+				await this.#applyActiveToolsByName(active.filter(name => name !== "inspect_image"));
+				return true;
+			}
+			if (!this.#toolRegistry.has("inspect_image")) {
+				const tool = await this.#createInspectImageTool?.();
+				if (tool?.name !== "inspect_image") {
+					logger.warn("inspect_image tool could not be created", {
+						model: this.#host.model()?.id,
+					});
+					syncReadDescription(false);
+					return false;
+				}
+				const wrapped = this.#wrapRuntimeTool(tool);
+				this.#toolRegistry.set(wrapped.name, wrapped);
+				this.#builtInToolNames.add(wrapped.name);
+			}
+			syncReadDescription(true);
+			await this.#applyActiveToolsByName([...active, "inspect_image"]);
+			return true;
+		});
 	}
 
 	/**
@@ -1173,20 +1185,20 @@ export class SessionTools {
 	 * path — including retry-fallback switches that bypass
 	 * {@link syncAfterModelChange}.
 	 */
-	async reconcileInspectImageAfterModelChange(): Promise<void> {
-		const before = this.getEnabledToolNames().includes("inspect_image");
-		const reconciled = await this.reconcileInspectImageTool();
-		const after = this.getEnabledToolNames().includes("inspect_image");
-		if (!reconciled || before === after) return;
-		const model = this.#host.model();
-		const modelName = model ? formatModelString(model) : "the current model";
-		this.#host.emitNotice(
-			"info",
-			after
-				? `inspect_image is now available: ${modelName} has no native image input.`
-				: `inspect_image is now hidden: ${modelName} supports image input natively. Override with /vision on.`,
-			"vision",
-		);
+	reconcileInspectImageAfterModelChange(): Promise<void> {
+		return this.runToolRegistryMutation(async () => {
+			const before = this.getEnabledToolNames().includes("inspect_image");
+			const reconciled = await this.reconcileInspectImageTool();
+			const after = this.getEnabledToolNames().includes("inspect_image");
+			if (!reconciled || before === after) return;
+			this.#host.emitNotice(
+				"info",
+				after
+					? "inspect_image is now active for the selected model."
+					: "inspect_image is unavailable for the selected model.",
+				"inspect_image",
+			);
+		});
 	}
 
 	/**
@@ -1197,16 +1209,22 @@ export class SessionTools {
 	 *
 	 * @returns false when `on` was requested but the tool cannot be built here.
 	 */
-	async setInspectImageMode(mode: InspectImageMode): Promise<boolean> {
-		this.#host.setInspectImageModeOverride(mode === "auto" ? undefined : mode);
-		const applied = await this.reconcileInspectImageTool();
-		const { active, model } = this.inspectImageState();
-		logger.debug("inspect_image mode changed", { mode, active, model });
-		return applied;
+	setInspectImageMode(mode: InspectImageMode): Promise<boolean> {
+		return this.runToolRegistryMutation(async () => {
+			this.#host.setInspectImageModeOverride(mode === "auto" ? undefined : mode);
+			const applied = await this.reconcileInspectImageTool();
+			const { active, model } = this.inspectImageState();
+			logger.debug("inspect_image mode changed", { mode, active, model });
+			return applied;
+		});
 	}
 
 	/** Rebuilds the stable base prompt for the current tools and model. */
-	async refreshBaseSystemPrompt(): Promise<void> {
+	refreshBaseSystemPrompt(): Promise<void> {
+		return this.runToolRegistryMutation(() => this.#refreshBaseSystemPrompt());
+	}
+
+	async #refreshBaseSystemPrompt(): Promise<void> {
 		if (this.#host.isDisposed() || !this.#rebuildSystemPrompt) return;
 		const activeToolNames = this.getActiveToolNames();
 		this.#setActiveToolNames?.(activeToolNames);

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -266,6 +266,34 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(session.systemPrompt).toEqual(["tools:read,mcp__nucleus_search,mcp__nucleus_fetch"]);
 	});
 
+	it("serializes explicit prompt refreshes with registry mutations", async () => {
+		const mutationEntered = Promise.withResolvers<void>();
+		const releaseMutation = Promise.withResolvers<void>();
+		const releaseStaleRefresh = Promise.withResolvers<void>();
+		const lateTool = createBasicTool("late_prompt_tool", "Late Prompt Tool");
+		const { session, toolRegistry } = newSession(async toolNames => {
+			if (!toolNames.includes(lateTool.name)) await releaseStaleRefresh.promise;
+			return `tools:${toolNames.join(",")}`;
+		});
+
+		const mutation = session.runToolRegistryMutation(async () => {
+			mutationEntered.resolve();
+			await releaseMutation.promise;
+			toolRegistry.set(lateTool.name, lateTool);
+			await session.setActiveToolsByName([...session.getEnabledToolNames(), lateTool.name]);
+		});
+		await mutationEntered.promise;
+		const explicitRefresh = session.refreshBaseSystemPrompt();
+		await Promise.resolve();
+
+		releaseMutation.resolve();
+		await mutation;
+		releaseStaleRefresh.resolve();
+		await explicitRefresh;
+
+		expect(session.systemPrompt).toEqual(["tools:read,mcp__nucleus_search,late_prompt_tool"]);
+	});
+
 	it("drops queued and in-flight MCP prompt commits when disposal begins", async () => {
 		const firstRebuildStarted = Promise.withResolvers<void>();
 		const releaseFirstRebuild = Promise.withResolvers<void>();

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -294,6 +294,37 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(session.systemPrompt).toEqual(["tools:read,mcp__nucleus_search,late_prompt_tool"]);
 	});
 
+	it("keeps queued mutations serialized when a waiting caller aborts", async () => {
+		const firstMutationEntered = Promise.withResolvers<void>();
+		const releaseFirstMutation = Promise.withResolvers<void>();
+		const { session } = newSession(async toolNames => `tools:${toolNames.join(",")}`);
+		const firstMutation = session.runToolRegistryMutation(async () => {
+			firstMutationEntered.resolve();
+			await releaseFirstMutation.promise;
+		});
+		await firstMutationEntered.promise;
+
+		const controller = new AbortController();
+		let abortedMutationRan = false;
+		const abortedMutation = session.runToolRegistryMutation(async () => {
+			abortedMutationRan = true;
+		}, controller.signal);
+		controller.abort(new Error("cancel queued mutation"));
+		await expect(abortedMutation).rejects.toThrow("cancel queued mutation");
+
+		let thirdMutationRan = false;
+		const thirdMutation = session.runToolRegistryMutation(async () => {
+			thirdMutationRan = true;
+		});
+		await Promise.resolve();
+		expect(thirdMutationRan).toBe(false);
+
+		releaseFirstMutation.resolve();
+		await Promise.all([firstMutation, thirdMutation]);
+		expect(abortedMutationRan).toBe(false);
+		expect(thirdMutationRan).toBe(true);
+	});
+
 	it("drops queued and in-flight MCP prompt commits when disposal begins", async () => {
 		const firstRebuildStarted = Promise.withResolvers<void>();
 		const releaseFirstRebuild = Promise.withResolvers<void>();

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -14,7 +14,9 @@ import { discoverAndLoadExtensions, ExtensionRuntime } from "@oh-my-pi/pi-coding
 import {
 	EXTENSION_HANDLER_TIMEOUT_MS,
 	ExtensionRunner,
+	SESSION_SHUTDOWN_HANDLER_TIMEOUT_MS,
 	testSetExtensionHandlerTimeoutMs,
+	testSetSessionShutdownHandlerTimeoutMs,
 } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import type {
 	ExtensionError,
@@ -58,6 +60,7 @@ describe("ExtensionRunner", () => {
 
 	afterEach(() => {
 		testSetExtensionHandlerTimeoutMs(EXTENSION_HANDLER_TIMEOUT_MS);
+		testSetSessionShutdownHandlerTimeoutMs(SESSION_SHUTDOWN_HANDLER_TIMEOUT_MS);
 		tempDir.removeSync();
 	});
 
@@ -1265,6 +1268,54 @@ describe("ExtensionRunner", () => {
 			]);
 
 			warnSpy.mockRestore();
+		});
+
+		it("keeps a stalled registration inside the session_shutdown deadline", async () => {
+			const extensionPath = path.join(tempDir.path(), "shutdown-registration.ts");
+			fs.writeFileSync(
+				extensionPath,
+				`
+					export default function(pi) {
+						pi.on("session_shutdown", () => {
+							const { Type } = pi.typebox;
+							pi.registerTool({
+								name: "shutdown_tool",
+								label: "Shutdown Tool",
+								description: "Registered while shutting down.",
+								parameters: Type.Object({}),
+								execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+							});
+						});
+					}
+				`,
+			);
+
+			const result = await loadTestExtensions([extensionPath]);
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			runner.onToolRegistered(() => Promise.withResolvers<void>().promise);
+			const errors: ExtensionError[] = [];
+			runner.onError(error => {
+				errors.push(error);
+			});
+			testSetSessionShutdownHandlerTimeoutMs(10);
+
+			const startedAt = performance.now();
+			await runner.emit({ type: "session_shutdown" });
+			const elapsedMs = performance.now() - startedAt;
+
+			expect(elapsedMs).toBeGreaterThanOrEqual(8);
+			expect(elapsedMs).toBeLessThan(150);
+			expect(errors).toContainEqual({
+				extensionPath,
+				event: "session_shutdown",
+				error: "handler timed out after 10ms",
+			});
 		});
 
 		it("times out tool_call handlers with fail-closed policy so a hung extension cannot indefinitely block tool execution (#3948)", async () => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1386,6 +1386,68 @@ describe("ExtensionRunner", () => {
 			warnSpy.mockRestore();
 		});
 
+		it("fails closed when a tool_call handler registration cannot activate", async () => {
+			const extensionPath = path.join(tempDir.path(), "tool-call-registration.ts");
+			fs.writeFileSync(
+				extensionPath,
+				`
+					export default function(pi) {
+						pi.on("tool_call", () => {
+							const { Type } = pi.typebox;
+							pi.registerTool({
+								name: "tool_call_registered",
+								label: "Tool Call Registered",
+								description: "Registered from a tool-call hook.",
+								parameters: Type.Object({}),
+								execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+							});
+						});
+					}
+				`,
+			);
+
+			const result = await loadTestExtensions([extensionPath]);
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			runner.onToolRegistered(async () => {
+				throw new Error("expected tool-call registration failure");
+			});
+			const errors: ExtensionError[] = [];
+			runner.onError(error => {
+				errors.push(error);
+			});
+			const executeCalls: unknown[] = [];
+			const wrapped = new ExtensionToolWrapper(
+				{
+					name: "gated",
+					label: "Gated",
+					description: "Must not execute after a gate registration fails.",
+					parameters: Type.Object({}),
+					execute: async (_id, params) => {
+						executeCalls.push(params);
+						return { content: [{ type: "text", text: "ran" }] };
+					},
+				},
+				runner,
+			);
+
+			await expect(wrapped.execute("tool-call-id", {})).rejects.toThrow(
+				`Extension ${extensionPath} failed: expected tool-call registration failure`,
+			);
+			expect(executeCalls).toEqual([]);
+			expect(errors).toContainEqual({
+				extensionPath,
+				event: "tool_call",
+				error: "expected tool-call registration failure",
+				stack: expect.any(String),
+			});
+		});
+
 		it("aborts a tool_call handler's confirmation before returning its timeout block", async () => {
 			const extensionPath = path.join(tempDir.path(), "confirm-tool-call.ts");
 			const markerPath = path.join(tempDir.path(), "confirm-settled.txt");

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1448,6 +1448,56 @@ describe("ExtensionRunner", () => {
 			});
 		});
 
+		it("does not charge detached registrations to unrelated tool-call handlers", async () => {
+			const extensionPath = path.join(tempDir.path(), "detached-registration-barrier.ts");
+			fs.writeFileSync(
+				extensionPath,
+				`
+					export default function(pi) {
+						const { Type } = pi.typebox;
+						pi.registerTool({
+							name: "detached_source_tool",
+							label: "Detached Source Tool",
+							description: "Provides a registration event for the detached barrier test.",
+							parameters: Type.Object({}),
+							execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+						});
+						pi.on("tool_call", () => undefined);
+					}
+				`,
+			);
+
+			const loaded = await loadTestExtensions([extensionPath]);
+			const runner = new ExtensionRunner(
+				loaded.extensions,
+				loaded.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			runner.onToolRegistered(() => Promise.withResolvers<void>().promise);
+			const extension = loaded.extensions[0];
+			const registrationListener = extension?.toolRegistrationListeners?.values().next().value;
+			if (!registrationListener) throw new Error("expected registration listener");
+			registrationListener("detached_source_tool");
+
+			const errors: ExtensionError[] = [];
+			runner.onError(error => {
+				errors.push(error);
+			});
+			testSetExtensionHandlerTimeoutMs(10);
+
+			const result = await runner.emitToolCall({
+				type: "tool_call",
+				toolName: "unrelated",
+				toolCallId: "unrelated-call",
+				input: {},
+			});
+
+			expect(result).toBeUndefined();
+			expect(errors).toEqual([]);
+		});
+
 		it("aborts a tool_call handler's confirmation before returning its timeout block", async () => {
 			const extensionPath = path.join(tempDir.path(), "confirm-tool-call.ts");
 			const markerPath = path.join(tempDir.path(), "confirm-settled.txt");

--- a/packages/coding-agent/test/nonvision-model-switch.test.ts
+++ b/packages/coding-agent/test/nonvision-model-switch.test.ts
@@ -40,6 +40,10 @@ describe("model switch from vision to text-only", () => {
 				rules: [],
 				contextFiles: [],
 			});
+			const notices: string[] = [];
+			const unsubscribe = session.subscribe(event => {
+				if (event.type === "notice") notices.push(`${event.source}:${event.message}`);
+			});
 			try {
 				await session.prompt("see image", { images: [{ type: "image", data: "aaaa", mimeType: "image/png" }] });
 				await session.setModel(text);
@@ -49,7 +53,12 @@ describe("model switch from vision to text-only", () => {
 				expect(
 					messages.flatMap<unknown>(message => (Array.isArray(message.content) ? message.content : [])),
 				).not.toContainEqual(expect.objectContaining({ type: "image" }));
+
+				await session.setModel(vision);
+				expect(notices.at(-1)).toContain("vision:inspect_image is now hidden:");
+				expect(notices.at(-1)).toContain("supports image input natively. Override with /vision on.");
 			} finally {
+				unsubscribe();
 				await session.dispose();
 			}
 		} finally {

--- a/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
+++ b/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
@@ -546,18 +546,16 @@ describe("createAgentSession credential_disabled subscription", () => {
 
 			// 3. Synchronous onError registration — must land before the deferred flush
 			// invokes the throwing handler. This is the contract this test defends.
-			const errors: ExtensionError[] = [];
+			const receivedError = Promise.withResolvers<ExtensionError>();
 			runner.onError(error => {
-				errors.push(error);
+				receivedError.resolve(error);
 			});
 
-			// 4. Let the deferred flush microtask run, then the handler's async throw,
-			// then emitError, which calls our listener. A handful of microtask turns
-			// covers the await Promise.race inside #runHandlerWithTimeout.
-			for (let i = 0; i < 5; i++) await Promise.resolve();
+			// 4. Await the observable callback instead of assuming a fixed number of
+			// microtask turns inside the lifecycle runner.
+			const error = await receivedError.promise;
 
-			expect(errors).toHaveLength(1);
-			expect(errors[0]).toMatchObject({
+			expect(error).toMatchObject({
 				extensionPath: "test://throwing-credential-disabled",
 				event: "credential_disabled",
 				error: "boom",

--- a/packages/coding-agent/test/sdk-mcp-defer.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-defer.test.ts
@@ -2,11 +2,12 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { type } from "@oh-my-pi/omptype";
 import { AuthStorage } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { type CustomTool, createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
@@ -76,6 +77,20 @@ describe("createAgentSession MCP deferral (B1)", () => {
 			// The explicitly requested MCP tool is a known, resolvable tool even
 			// though no server has connected — deterministic, not "unknown tool".
 			expect(session.getActiveToolNames()).toContain(PENDING_MCP_TOOL);
+			await session.refreshMCPTools([
+				{
+					name: PENDING_MCP_TOOL,
+					label: "Connected MCP tool",
+					description: "Connected replacement.",
+					parameters: type({}),
+					mcpServerName: "pending",
+					mcpToolName: "connectingtool",
+					async execute() {
+						return { content: [{ type: "text", text: "connected" }] };
+					},
+				} satisfies CustomTool,
+			]);
+			expect(session.getToolByName(PENDING_MCP_TOOL)?.label).toBe("Connected MCP tool");
 		} finally {
 			await session.dispose();
 		}

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -141,6 +141,64 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		}
 	});
 
+	it("publishes tools from lazy session startup before the input lifecycle completes", async () => {
+		const tempDir = makeTempDir();
+		const startupGate = Promise.withResolvers<void>();
+		const lateRegistrationExtension: ExtensionFactory = pi => {
+			let startupPromise: Promise<void> | undefined;
+			pi.on("session_start", () => {
+				startupPromise = (async () => {
+					await startupGate.promise;
+					pi.registerTool({
+						name: "late_active_tool",
+						label: "Late Active Tool",
+						description: "Registered after asynchronous session initialization.",
+						parameters: type({}),
+						async execute() {
+							return { content: [{ type: "text", text: "late active" }] };
+						},
+					});
+					pi.registerTool({
+						name: "late_inactive_tool",
+						label: "Late Inactive Tool",
+						description: "Registered late but left disabled by default.",
+						parameters: type({}),
+						defaultInactive: true,
+						async execute() {
+							return { content: [{ type: "text", text: "late inactive" }] };
+						},
+					});
+				})();
+			});
+			pi.on("input", async () => {
+				await startupPromise;
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [lateRegistrationExtension],
+		});
+
+		try {
+			expect(session.getAllToolNames()).not.toContain("late_active_tool");
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			await runner.emit({ type: "session_start" });
+			expect(session.getAllToolNames()).not.toContain("late_active_tool");
+			startupGate.resolve();
+			await runner.emitInput("probe", undefined, "interactive");
+
+			expect(session.getAllToolNames()).toEqual(expect.arrayContaining(["late_active_tool", "late_inactive_tool"]));
+			expect(session.getEnabledToolNames()).toContain("late_active_tool");
+			expect(session.getEnabledToolNames()).not.toContain("late_inactive_tool");
+			expect(session.systemPrompt.join("\n")).toContain("late_active_tool");
+			expect(session.systemPrompt.join("\n")).not.toContain("late_inactive_tool");
+		} finally {
+			await session.dispose();
+		}
+	});
+
 	it("forwards built-in and external xd:// devices to Cursor provider contexts", async () => {
 		const tempDir = makeTempDir();
 		const cursorModel = getBundledModel("cursor", "composer-1.5");

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -585,6 +585,8 @@ describe("createAgentSession defaultInactive tool activation", () => {
 
 	it("restores a built-in tool and its provenance when a replacement prompt rebuild fails", async () => {
 		let rejectReplacementPrompt = false;
+		const releaseHandler = Promise.withResolvers<void>();
+		const replacementRefreshAttempted = Promise.withResolvers<void>();
 		const tempDir = makeTempDir();
 		const replacementExtension: ExtensionFactory = pi => {
 			pi.on("session_start", async () => {
@@ -598,6 +600,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 						return { content: [{ type: "text", text: "rejected" }] };
 					},
 				});
+				await releaseHandler.promise;
 			});
 		};
 
@@ -605,10 +608,14 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			...baseOptions(tempDir),
 			extensions: [replacementExtension],
 			systemPrompt: defaultPrompt => {
-				if (rejectReplacementPrompt) throw new Error("expected replacement prompt failure");
+				if (rejectReplacementPrompt) {
+					replacementRefreshAttempted.resolve();
+					throw new Error("expected replacement prompt failure");
+				}
 				return defaultPrompt;
 			},
 		});
+		let emission: Promise<unknown> | undefined;
 
 		try {
 			const enabledBefore = session.getEnabledToolNames();
@@ -624,7 +631,11 @@ describe("createAgentSession defaultInactive tool activation", () => {
 				errors.push(error.error);
 			});
 			rejectReplacementPrompt = true;
-			await runner.emit({ type: "session_start" });
+			emission = runner.emit({ type: "session_start" });
+			await replacementRefreshAttempted.promise;
+			expect(errors).not.toContain("expected replacement prompt failure");
+			releaseHandler.resolve();
+			await emission;
 			unsubscribe();
 
 			expect(errors).toContain("expected replacement prompt failure");
@@ -634,6 +645,8 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			expect(session.getMountedXdevToolNames()).toEqual(mountedBefore);
 			expect(session.systemPrompt).toEqual(promptBefore);
 		} finally {
+			releaseHandler.resolve();
+			await emission;
 			await session.dispose();
 		}
 	});

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -954,6 +954,84 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		}
 	});
 
+	it("times out detached activations without blocking later registrations", async () => {
+		const tempDir = makeTempDir();
+		const releaseStalledRegistration = Promise.withResolvers<void>();
+		const releaseRecoveredRegistration = Promise.withResolvers<void>();
+		const detachedRegistrationExtension: ExtensionFactory = pi => {
+			pi.on("session_start", () => {
+				void releaseStalledRegistration.promise.then(() => {
+					pi.registerTool({
+						name: "stalled_detached_tool",
+						label: "Stalled Detached Tool",
+						description: "Detached registration whose activation stalls.",
+						parameters: type({}),
+						loadMode: "essential",
+						async execute() {
+							return { content: [{ type: "text", text: "stalled" }] };
+						},
+					});
+				});
+				void releaseRecoveredRegistration.promise.then(() => {
+					pi.registerTool({
+						name: "recovered_detached_tool",
+						label: "Recovered Detached Tool",
+						description: "Detached registration that follows the timeout.",
+						parameters: type({}),
+						loadMode: "essential",
+						async execute() {
+							return { content: [{ type: "text", text: "recovered" }] };
+						},
+					});
+				});
+			});
+		};
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [detachedRegistrationExtension],
+		});
+
+		try {
+			await initializeExtensions(session, {
+				reportSendError: vi.fn(),
+				reportRuntimeError: vi.fn(),
+			});
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			const detachedFailure = Promise.withResolvers<{ event: string; error: string }>();
+			runner.onError(error => {
+				if (error.event === "tool_registration") {
+					detachedFailure.resolve({ event: error.event, error: error.error });
+				}
+			});
+			const recoveredActivation = Promise.withResolvers<void>();
+			const originalSetPresentation = session.setActiveToolPresentation.bind(session);
+			vi.spyOn(session, "setActiveToolPresentation")
+				.mockImplementationOnce((_toolNames, _mountedToolNames, _forcePromptRefresh, signal) =>
+					untilAborted(signal, Promise.withResolvers<void>().promise),
+				)
+				.mockImplementation(async (toolNames, mountedToolNames, forcePromptRefresh, signal) => {
+					await originalSetPresentation(toolNames, mountedToolNames, forcePromptRefresh, signal);
+					if (toolNames.includes("recovered_detached_tool")) recoveredActivation.resolve();
+				});
+			testSetExtensionHandlerTimeoutMs(10);
+
+			releaseStalledRegistration.resolve();
+			const failure = await detachedFailure.promise;
+			releaseRecoveredRegistration.resolve();
+			await recoveredActivation.promise;
+
+			expect(failure.event).toBe("tool_registration");
+			expect(failure.error).toContain("timed out");
+			expect(session.getToolByName("stalled_detached_tool")).toBeUndefined();
+			expect(session.getToolByName("recovered_detached_tool")?.label).toBe("Recovered Detached Tool");
+		} finally {
+			releaseStalledRegistration.resolve();
+			releaseRecoveredRegistration.resolve();
+			await session.dispose();
+		}
+	});
+
 	it("forwards built-in and external xd:// devices to Cursor provider contexts", async () => {
 		const tempDir = makeTempDir();
 		const cursorModel = getBundledModel("cursor", "composer-1.5");

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -384,6 +384,163 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		}
 	});
 
+	it("refreshes an earlier extension's stable MCP winner instead of the later colliding registrant", async () => {
+		const tempDir = makeTempDir();
+		const stableWinnerExtension: ExtensionFactory = pi => {
+			pi.registerTool({
+				name: "mcp__foo_bar_refresh",
+				label: "foo.bar/refresh connected",
+				description: "Initial stable MCP winner.",
+				parameters: type({}),
+				mcpServerName: "foo.bar",
+				mcpToolName: "refresh",
+				async execute() {
+					return { content: [{ type: "text", text: "connected" }] };
+				},
+			});
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				pi.registerTool({
+					name: "mcp__foo_bar_refresh",
+					label: "foo.bar/refresh reconnected",
+					description: "Reconnected stable MCP winner.",
+					parameters: type({}),
+					mcpServerName: "foo.bar",
+					mcpToolName: "refresh",
+					async execute() {
+						return { content: [{ type: "text", text: "reconnected" }] };
+					},
+				});
+			});
+		};
+		const collidingLoserExtension: ExtensionFactory = pi => {
+			pi.registerTool({
+				name: "mcp__foo_bar_refresh",
+				label: "foo_bar/refresh",
+				description: "Later extension with the losing MCP origin.",
+				parameters: type({}),
+				mcpServerName: "foo_bar",
+				mcpToolName: "refresh",
+				async execute() {
+					return { content: [{ type: "text", text: "loser" }] };
+				},
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [stableWinnerExtension, collidingLoserExtension],
+		});
+
+		try {
+			expect(session.getToolByName("mcp__foo_bar_refresh")?.label).toBe("foo.bar/refresh connected");
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			await runner.emit({ type: "session_start" });
+			expect(session.getToolByName("mcp__foo_bar_refresh")?.label).toBe("foo.bar/refresh reconnected");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("retains later-extension precedence when an earlier non-MCP registrant updates", async () => {
+		const tempDir = makeTempDir();
+		const earlierExtension: ExtensionFactory = pi => {
+			pi.registerTool({
+				name: "shared_lifecycle_tool",
+				label: "Earlier Tool",
+				description: "Earlier extension tool.",
+				parameters: type({}),
+				async execute() {
+					return { content: [{ type: "text", text: "earlier" }] };
+				},
+			});
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				pi.registerTool({
+					name: "shared_lifecycle_tool",
+					label: "Updated Earlier Tool",
+					description: "Updated earlier extension tool.",
+					parameters: type({}),
+					async execute() {
+						return { content: [{ type: "text", text: "updated earlier" }] };
+					},
+				});
+			});
+		};
+		const laterExtension: ExtensionFactory = pi => {
+			pi.registerTool({
+				name: "shared_lifecycle_tool",
+				label: "Later Tool",
+				description: "Later extension winner.",
+				parameters: type({}),
+				async execute() {
+					return { content: [{ type: "text", text: "later" }] };
+				},
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [earlierExtension, laterExtension],
+		});
+
+		try {
+			expect(session.getToolByName("shared_lifecycle_tool")?.label).toBe("Later Tool");
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			await runner.emit({ type: "session_start" });
+			expect(session.getToolByName("shared_lifecycle_tool")?.label).toBe("Later Tool");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("reclassifies late replacements when their load modes change", async () => {
+		const tempDir = makeTempDir();
+		const loadModeReplacementExtension: ExtensionFactory = pi => {
+			const registerTransitionTool = (name: string, label: string, loadMode: "essential" | "discoverable"): void => {
+				pi.registerTool({
+					name,
+					label,
+					description: `${label} extension tool.`,
+					parameters: type({}),
+					loadMode,
+					async execute() {
+						return { content: [{ type: "text", text: label }] };
+					},
+				});
+			};
+			registerTransitionTool("late_becomes_discoverable", "Initially Essential", "essential");
+			registerTransitionTool("late_becomes_essential", "Initially Discoverable", "discoverable");
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				registerTransitionTool("late_becomes_discoverable", "Now Discoverable", "discoverable");
+				registerTransitionTool("late_becomes_essential", "Now Essential", "essential");
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [loadModeReplacementExtension],
+		});
+
+		try {
+			expect(session.getActiveToolNames()).toContain("late_becomes_discoverable");
+			expect(session.getMountedXdevToolNames()).toContain("late_becomes_essential");
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			await runner.emit({ type: "session_start" });
+
+			expect(session.getActiveToolNames()).not.toContain("late_becomes_discoverable");
+			expect(session.getMountedXdevToolNames()).toContain("late_becomes_discoverable");
+			expect(session.getActiveToolNames()).toContain("late_becomes_essential");
+			expect(session.getMountedXdevToolNames()).not.toContain("late_becomes_essential");
+		} finally {
+			await session.dispose();
+		}
+	});
+
 	it("forwards built-in and external xd:// devices to Cursor provider contexts", async () => {
 		const tempDir = makeTempDir();
 		const cursorModel = getBundledModel("cursor", "composer-1.5");

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -192,8 +192,49 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			expect(session.getAllToolNames()).toEqual(expect.arrayContaining(["late_active_tool", "late_inactive_tool"]));
 			expect(session.getEnabledToolNames()).toContain("late_active_tool");
 			expect(session.getEnabledToolNames()).not.toContain("late_inactive_tool");
+			expect(session.getXdevToolEntries().map(entry => entry.name)).toContain("late_active_tool");
+			expect(session.getActiveToolNames()).not.toContain("late_active_tool");
 			expect(session.systemPrompt.join("\n")).toContain("late_active_tool");
 			expect(session.systemPrompt.join("\n")).not.toContain("late_inactive_tool");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("activates explicitly requested defaultInactive tools registered during session startup", async () => {
+		const tempDir = makeTempDir();
+		const lateRequestedExtension: ExtensionFactory = pi => {
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				pi.registerTool({
+					name: "late_requested_tool",
+					label: "Late Requested Tool",
+					description: "Registered asynchronously after being explicitly requested.",
+					parameters: type({}),
+					defaultInactive: true,
+					async execute() {
+						return { content: [{ type: "text", text: "late requested" }] };
+					},
+				});
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [lateRequestedExtension],
+			toolNames: ["read", "write", "late_requested_tool"],
+		});
+
+		try {
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			await runner.emit({ type: "session_start" });
+
+			expect(session.getAllToolNames()).toContain("late_requested_tool");
+			expect(session.getEnabledToolNames()).toContain("late_requested_tool");
+			expect(session.getActiveToolNames()).toContain("late_requested_tool");
+			expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain("late_requested_tool");
+			expect(session.systemPrompt.join("\n")).toContain("late_requested_tool");
 		} finally {
 			await session.dispose();
 		}

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -1067,12 +1067,12 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			const unsubscribe = runner.onError(error => {
 				errors.push(error.error);
 			});
-			testSetExtensionHandlerTimeoutMs(10);
+			testSetExtensionHandlerTimeoutMs(250);
 
 			await runner.emit({ type: "session_start" });
 			unsubscribe();
 
-			expect(errors).toContain("handler timed out after 10ms");
+			expect(errors).toContain("handler timed out after 250ms");
 			expect(session.getToolByName("stalled_registration_tool")).toBeUndefined();
 			expect(session.getToolByName("recovered_registration_tool")?.label).toBe("recovered_registration_tool");
 			expect(session.getEnabledToolNames()).toContain("recovered_registration_tool");
@@ -1269,7 +1269,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 					await originalSetPresentation(toolNames, mountedToolNames, forcePromptRefresh, signal);
 					if (toolNames.includes("recovered_detached_tool")) recoveredActivation.resolve();
 				});
-			testSetExtensionHandlerTimeoutMs(10);
+			testSetExtensionHandlerTimeoutMs(250);
 
 			releaseStalledRegistration.resolve();
 			const failure = await detachedFailure.promise;

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -240,6 +240,102 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		}
 	});
 
+	it("deactivates an enabled tool when a late replacement is default-inactive", async () => {
+		const tempDir = makeTempDir();
+		const lateInactiveReplacement: ExtensionFactory = pi => {
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				pi.registerTool({
+					name: "bash",
+					label: "Late Inactive Bash",
+					description: "A late replacement that must remain disabled by default.",
+					parameters: type({}),
+					defaultInactive: true,
+					async execute() {
+						return { content: [{ type: "text", text: "late inactive bash" }] };
+					},
+				});
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [lateInactiveReplacement],
+		});
+
+		try {
+			expect(session.getEnabledToolNames()).toContain("bash");
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			await runner.emit({ type: "session_start" });
+
+			expect(session.getToolByName("bash")?.label).toBe("Late Inactive Bash");
+			expect(session.getEnabledToolNames()).not.toContain("bash");
+			expect(session.getActiveToolNames()).not.toContain("bash");
+			expect(session.getMountedXdevToolNames()).not.toContain("bash");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("publishes late tools before returning from a failing lifecycle handler", async () => {
+		const tempDir = makeTempDir();
+		const activationEntered = Promise.withResolvers<void>();
+		const releaseActivation = Promise.withResolvers<void>();
+		const failingRegistrationExtension: ExtensionFactory = pi => {
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				pi.registerTool({
+					name: "late_tool_before_failure",
+					label: "Late Tool Before Failure",
+					description: "Registered before its lifecycle handler fails.",
+					parameters: type({}),
+					async execute() {
+						return { content: [{ type: "text", text: "late tool before failure" }] };
+					},
+				});
+				throw new Error("expected lifecycle failure");
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [failingRegistrationExtension],
+		});
+		const originalSetPresentation = session.setActiveToolPresentation.bind(session);
+		vi.spyOn(session, "setActiveToolPresentation").mockImplementation(async (toolNames, mountedToolNames) => {
+			activationEntered.resolve();
+			await releaseActivation.promise;
+			await originalSetPresentation(toolNames, mountedToolNames);
+		});
+		const runner = session.extensionRunner;
+		if (!runner) throw new Error("expected extension runner");
+		let emissionCompleted = false;
+		const emission = runner.emit({ type: "session_start" }).finally(() => {
+			emissionCompleted = true;
+		});
+
+		try {
+			await activationEntered.promise;
+			// Drain the handler rejection and outer emit continuations without releasing the registration apply.
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(emissionCompleted).toBe(false);
+
+			releaseActivation.resolve();
+			await emission;
+			expect(session.getAllToolNames()).toContain("late_tool_before_failure");
+			expect(session.getEnabledToolNames()).toContain("late_tool_before_failure");
+			expect(session.systemPrompt.join("\n")).toContain("late_tool_before_failure");
+		} finally {
+			releaseActivation.resolve();
+			await emission;
+			await session.dispose();
+		}
+	});
+
 	it("keeps the stable MCP tool-name collision winner during late registration", async () => {
 		const tempDir = makeTempDir();
 		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -10,6 +10,10 @@ import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { CursorExecHandlers } from "@oh-my-pi/pi-coding-agent/cursor";
+import {
+	EXTENSION_HANDLER_TIMEOUT_MS,
+	testSetExtensionHandlerTimeoutMs,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import type { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import { initializeExtensions } from "@oh-my-pi/pi-coding-agent/modes/runtime-init";
 import {
@@ -22,7 +26,7 @@ import {
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { VIBE_TOOL_NAMES } from "@oh-my-pi/pi-coding-agent/tools/vibe";
-import { logger, removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { logger, removeSyncWithRetries, Snowflake, untilAborted } from "@oh-my-pi/pi-utils";
 
 const toolActivationExtension: ExtensionFactory = pi => {
 	pi.registerTool({
@@ -111,6 +115,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		}
 
 		vi.restoreAllMocks();
+		testSetExtensionHandlerTimeoutMs(EXTENSION_HANDLER_TIMEOUT_MS);
 	});
 
 	afterAll(() => {
@@ -804,6 +809,57 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		} finally {
 			releaseLaterActivation.resolve();
 			await emission;
+			await session.dispose();
+		}
+	});
+
+	it("releases a timed-out activation so later lifecycle registrations can proceed", async () => {
+		const tempDir = makeTempDir();
+		const registrationExtension: ExtensionFactory = pi => {
+			for (const name of ["stalled_registration_tool", "recovered_registration_tool"]) {
+				pi.on("session_start", async () => {
+					await Promise.resolve();
+					pi.registerTool({
+						name,
+						label: name,
+						description: `${name} lifecycle tool.`,
+						parameters: type({}),
+						loadMode: "essential",
+						async execute() {
+							return { content: [{ type: "text", text: name }] };
+						},
+					});
+				});
+			}
+		};
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [registrationExtension],
+		});
+
+		try {
+			const originalSetPresentation = session.setActiveToolPresentation.bind(session);
+			vi.spyOn(session, "setActiveToolPresentation")
+				.mockImplementationOnce((_toolNames, _mountedToolNames, _forcePromptRefresh, signal) =>
+					untilAborted(signal, Promise.withResolvers<void>().promise),
+				)
+				.mockImplementation(originalSetPresentation);
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			const errors: string[] = [];
+			const unsubscribe = runner.onError(error => {
+				errors.push(error.error);
+			});
+			testSetExtensionHandlerTimeoutMs(10);
+
+			await runner.emit({ type: "session_start" });
+			unsubscribe();
+
+			expect(errors).toContain("handler timed out after 10ms");
+			expect(session.getToolByName("stalled_registration_tool")).toBeUndefined();
+			expect(session.getToolByName("recovered_registration_tool")?.label).toBe("recovered_registration_tool");
+			expect(session.getEnabledToolNames()).toContain("recovered_registration_tool");
+		} finally {
 			await session.dispose();
 		}
 	});

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -416,6 +416,49 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		}
 	});
 
+	it("keeps an inactive extension MCP winner disabled when a manager collision loses", async () => {
+		const tempDir = makeTempDir();
+		const inactiveMcpExtension: ExtensionFactory = pi => {
+			pi.registerTool({
+				name: "mcp__foo_bar_inactive",
+				label: "Inactive extension winner",
+				description: "Stable extension winner that starts disabled.",
+				parameters: type({}),
+				mcpServerName: "foo.bar",
+				mcpToolName: "inactive",
+				defaultInactive: true,
+				async execute() {
+					return { content: [{ type: "text", text: "extension" }] };
+				},
+			});
+		};
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [inactiveMcpExtension],
+		});
+
+		try {
+			expect(session.getEnabledToolNames()).not.toContain("mcp__foo_bar_inactive");
+			await session.refreshMCPTools([
+				{
+					name: "mcp__foo_bar_inactive",
+					label: "Losing manager collision",
+					description: "Manager origin loses stable deduplication.",
+					parameters: type({}),
+					mcpServerName: "foo_bar",
+					mcpToolName: "inactive",
+					async execute() {
+						return { content: [{ type: "text", text: "manager" }] };
+					},
+				} satisfies CustomTool,
+			]);
+			expect(session.getToolByName("mcp__foo_bar_inactive")?.label).toBe("Inactive extension winner");
+			expect(session.getEnabledToolNames()).not.toContain("mcp__foo_bar_inactive");
+		} finally {
+			await session.dispose();
+		}
+	});
+
 	it("refreshes an earlier extension's stable MCP winner instead of the later colliding registrant", async () => {
 		const tempDir = makeTempDir();
 		const stableWinnerExtension: ExtensionFactory = pi => {

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -240,6 +240,54 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		}
 	});
 
+	it("keeps the stable MCP tool-name collision winner during late registration", async () => {
+		const tempDir = makeTempDir();
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const lateMcpCollisionExtension: ExtensionFactory = pi => {
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				for (const [serverName, label] of [
+					["foo.bar", "foo.bar/lookup"],
+					["foo_bar", "foo_bar/lookup"],
+				] as const) {
+					pi.registerTool({
+						name: "mcp__foo_bar_lookup",
+						label,
+						description: `Lookup from ${serverName}`,
+						parameters: type({}),
+						mcpServerName: serverName,
+						mcpToolName: "lookup",
+						async execute() {
+							return { content: [{ type: "text", text: serverName }] };
+						},
+					});
+				}
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [lateMcpCollisionExtension],
+		});
+
+		try {
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			await runner.emit({ type: "session_start" });
+
+			expect(session.getToolByName("mcp__foo_bar_lookup")?.label).toBe("foo.bar/lookup");
+			expect(warn).toHaveBeenCalledWith("MCP tool name collision; keeping stable winner", {
+				name: "mcp__foo_bar_lookup",
+				keptServer: "foo.bar",
+				keptTool: "lookup",
+				ignoredServer: "foo_bar",
+				ignoredTool: "lookup",
+			});
+		} finally {
+			await session.dispose();
+		}
+	});
+
 	it("forwards built-in and external xd:// devices to Cursor provider contexts", async () => {
 		const tempDir = makeTempDir();
 		const cursorModel = getBundledModel("cursor", "composer-1.5");

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -498,6 +498,95 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		}
 	});
 
+	it("preserves SDK custom-tool precedence when an extension registers the same name later", async () => {
+		const tempDir = makeTempDir();
+		const lateCollisionExtension: ExtensionFactory = pi => {
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				pi.registerTool({
+					name: sdkCustomTool.name,
+					label: "Late Extension Collision",
+					description: "Extension tool that must not replace the SDK custom tool.",
+					parameters: type({}),
+					async execute() {
+						return { content: [{ type: "text", text: "late extension" }] };
+					},
+				});
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [lateCollisionExtension],
+			customTools: [sdkCustomTool],
+		});
+
+		try {
+			expect(session.getToolByName(sdkCustomTool.name)?.label).toBe(sdkCustomTool.label);
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			await runner.emit({ type: "session_start" });
+			expect(session.getToolByName(sdkCustomTool.name)?.label).toBe(sdkCustomTool.label);
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("keeps an explicitly disabled tool disabled when its extension re-registers it", async () => {
+		const tempDir = makeTempDir();
+		const disabledReplacementExtension: ExtensionFactory = pi => {
+			pi.registerTool({
+				name: "disabled_replacement_tool",
+				label: "Initial Enabled Tool",
+				description: "Initially enabled extension tool.",
+				parameters: type({}),
+				loadMode: "essential",
+				async execute() {
+					return { content: [{ type: "text", text: "initial" }] };
+				},
+			});
+			pi.on("session_start", async () => {
+				await pi.setActiveTools(["read"]);
+				pi.registerTool({
+					name: "disabled_replacement_tool",
+					label: "Disabled Replacement Tool",
+					description: "Replacement that must retain the disabled state.",
+					parameters: type({}),
+					loadMode: "essential",
+					async execute() {
+						return { content: [{ type: "text", text: "replacement" }] };
+					},
+				});
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [disabledReplacementExtension],
+		});
+
+		try {
+			expect(session.getEnabledToolNames()).toContain("disabled_replacement_tool");
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			const errors: string[] = [];
+			const unsubscribe = runner.onError(error => {
+				errors.push(error.error);
+			});
+			await initializeExtensions(session, {
+				reportSendError: vi.fn(),
+				reportRuntimeError: vi.fn(),
+			});
+			unsubscribe();
+			expect(errors).toEqual([]);
+
+			expect(session.getToolByName("disabled_replacement_tool")?.label).toBe("Disabled Replacement Tool");
+			expect(session.getEnabledToolNames()).not.toContain("disabled_replacement_tool");
+		} finally {
+			await session.dispose();
+		}
+	});
+
 	it("reclassifies late replacements when their load modes change", async () => {
 		const tempDir = makeTempDir();
 		const loadModeReplacementExtension: ExtensionFactory = pi => {

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -270,6 +270,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			await runner.emit({ type: "session_start" });
 
 			expect(session.getToolByName("bash")?.label).toBe("Late Inactive Bash");
+			expect(session.hasBuiltInTool("bash")).toBe(false);
 			expect(session.getEnabledToolNames()).not.toContain("bash");
 			expect(session.getActiveToolNames()).not.toContain("bash");
 			expect(session.getMountedXdevToolNames()).not.toContain("bash");
@@ -537,6 +538,168 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			expect(session.getActiveToolNames()).toContain("late_becomes_essential");
 			expect(session.getMountedXdevToolNames()).not.toContain("late_becomes_essential");
 		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("refreshes prompt-visible metadata when a lifecycle registration replaces an enabled tool", async () => {
+		const tempDir = makeTempDir();
+		const replacementExtension: ExtensionFactory = pi => {
+			const register = (label: string, description: string): void => {
+				pi.registerTool({
+					name: "prompt_refresh_tool",
+					label,
+					description,
+					parameters: type({}),
+					async execute() {
+						return { content: [{ type: "text", text: label }] };
+					},
+				});
+			};
+			register("Original Prompt Tool", "Original prompt-visible lifecycle description.");
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				register("Replacement Prompt Tool", "Replacement prompt-visible lifecycle description.");
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [replacementExtension],
+		});
+
+		try {
+			expect(session.systemPrompt.join("\n")).toContain("Original prompt-visible lifecycle description.");
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			await runner.emit({ type: "session_start" });
+
+			const prompt = session.systemPrompt.join("\n");
+			expect(session.getToolByName("prompt_refresh_tool")?.label).toBe("Replacement Prompt Tool");
+			expect(prompt).toContain("Replacement prompt-visible lifecycle description.");
+			expect(prompt).not.toContain("Original prompt-visible lifecycle description.");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("restores a built-in tool and its provenance when a replacement prompt rebuild fails", async () => {
+		let rejectReplacementPrompt = false;
+		const tempDir = makeTempDir();
+		const replacementExtension: ExtensionFactory = pi => {
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				pi.registerTool({
+					name: "bash",
+					label: "Rejected Rollback Bash",
+					description: "Rejected rollback lifecycle description.",
+					parameters: type({ changed: type.string }),
+					async execute() {
+						return { content: [{ type: "text", text: "rejected" }] };
+					},
+				});
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [replacementExtension],
+			systemPrompt: defaultPrompt => {
+				if (rejectReplacementPrompt) throw new Error("expected replacement prompt failure");
+				return defaultPrompt;
+			},
+		});
+
+		try {
+			const enabledBefore = session.getEnabledToolNames();
+			const mountedBefore = session.getMountedXdevToolNames();
+			const promptBefore = session.systemPrompt;
+			const originalTool = session.getToolByName("bash");
+			expect(originalTool).toBeDefined();
+			expect(session.hasBuiltInTool("bash")).toBe(true);
+			const runner = session.extensionRunner;
+			const errors: string[] = [];
+			const unsubscribe = runner.onError(error => {
+				errors.push(error.error);
+			});
+			rejectReplacementPrompt = true;
+			await runner.emit({ type: "session_start" });
+			unsubscribe();
+
+			expect(errors).toContain("expected replacement prompt failure");
+			expect(session.getToolByName("bash")).toBe(originalTool);
+			expect(session.hasBuiltInTool("bash")).toBe(true);
+			expect(session.getEnabledToolNames()).toEqual(enabledBefore);
+			expect(session.getMountedXdevToolNames()).toEqual(mountedBefore);
+			expect(session.systemPrompt).toEqual(promptBefore);
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("waits for later registrations after an earlier activation fails", async () => {
+		const tempDir = makeTempDir();
+		const releaseLaterActivation = Promise.withResolvers<void>();
+		const laterActivationEntered = Promise.withResolvers<void>();
+		const registrationExtension: ExtensionFactory = pi => {
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				for (const name of ["failed_registration_tool", "drained_registration_tool"]) {
+					pi.registerTool({
+						name,
+						label: name,
+						description: `${name} lifecycle description.`,
+						parameters: type({}),
+						async execute() {
+							return { content: [{ type: "text", text: name }] };
+						},
+					});
+				}
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [registrationExtension],
+		});
+		const originalSetPresentation = session.setActiveToolPresentation.bind(session);
+		vi.spyOn(session, "setActiveToolPresentation").mockImplementation(
+			async (toolNames, mountedToolNames, forcePromptRefresh) => {
+				if (toolNames.includes("failed_registration_tool")) throw new Error("expected activation failure");
+				if (toolNames.includes("drained_registration_tool")) {
+					laterActivationEntered.resolve();
+					await releaseLaterActivation.promise;
+				}
+				await originalSetPresentation(toolNames, mountedToolNames, forcePromptRefresh);
+			},
+		);
+		const runner = session.extensionRunner;
+		if (!runner) throw new Error("expected extension runner");
+		const errors: string[] = [];
+		runner.onError(error => {
+			errors.push(error.error);
+		});
+		let emissionCompleted = false;
+		const emission = runner.emit({ type: "session_start" }).finally(() => {
+			emissionCompleted = true;
+		});
+
+		try {
+			await laterActivationEntered.promise;
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(emissionCompleted).toBe(false);
+			expect(errors).toEqual([]);
+
+			releaseLaterActivation.resolve();
+			await emission;
+			expect(errors).toContain("expected activation failure");
+			expect(session.getToolByName("failed_registration_tool")).toBeUndefined();
+			expect(session.getToolByName("drained_registration_tool")).toBeDefined();
+			expect(session.systemPrompt.join("\n")).toContain("drained_registration_tool");
+		} finally {
+			releaseLaterActivation.resolve();
+			await emission;
 			await session.dispose();
 		}
 	});

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { type } from "@oh-my-pi/omptype";
-import type { StreamFn } from "@oh-my-pi/pi-agent-core";
+import type { AgentTool, StreamFn } from "@oh-my-pi/pi-agent-core";
 import type { Model, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
@@ -533,6 +533,109 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			await runner.emit({ type: "session_start" });
 			expect(session.getToolByName(sdkCustomTool.name)?.label).toBe(sdkCustomTool.label);
 		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("preserves RPC host-tool precedence when an extension registers the same name later", async () => {
+		const tempDir = makeTempDir();
+		const rpcHostTool = {
+			name: "rpc_host_collision",
+			label: "RPC Host Tool",
+			description: "Host-owned RPC tool.",
+			parameters: type({}),
+			async execute() {
+				return { content: [{ type: "text", text: "rpc host" }] };
+			},
+		} satisfies AgentTool;
+		const lateCollisionExtension: ExtensionFactory = pi => {
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				pi.registerTool({
+					name: rpcHostTool.name,
+					label: "Late Extension Collision",
+					description: "Extension tool that must not replace the RPC host tool.",
+					parameters: type({}),
+					async execute() {
+						return { content: [{ type: "text", text: "late extension" }] };
+					},
+				});
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [lateCollisionExtension],
+		});
+
+		try {
+			await session.refreshRpcHostTools([rpcHostTool]);
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			await runner.emit({ type: "session_start" });
+			expect(session.getToolByName(rpcHostTool.name)?.label).toBe(rpcHostTool.label);
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("serializes late extension activation with MCP refreshes", async () => {
+		const tempDir = makeTempDir();
+		const activationEntered = Promise.withResolvers<void>();
+		const releaseActivation = Promise.withResolvers<void>();
+		const lateRegistrationExtension: ExtensionFactory = pi => {
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				pi.registerTool({
+					name: "serialized_lifecycle_tool",
+					label: "Serialized Lifecycle Tool",
+					description: "Lifecycle tool activated before an MCP refresh.",
+					parameters: type({}),
+					async execute() {
+						return { content: [{ type: "text", text: "lifecycle" }] };
+					},
+				});
+			});
+		};
+		const mcpTool = {
+			name: "mcp__serialized_refresh_lookup",
+			label: "serialized/refresh lookup",
+			description: "MCP tool refreshed during lifecycle activation.",
+			parameters: type({}),
+			mcpServerName: "serialized",
+			mcpToolName: "refresh_lookup",
+			async execute() {
+				return { content: [{ type: "text", text: "mcp" }] };
+			},
+		} satisfies CustomTool;
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [lateRegistrationExtension],
+		});
+		const originalSetActiveToolPresentation = session.setActiveToolPresentation.bind(session);
+		vi.spyOn(session, "setActiveToolPresentation").mockImplementation(async (...args) => {
+			activationEntered.resolve();
+			await releaseActivation.promise;
+			return originalSetActiveToolPresentation(...args);
+		});
+
+		try {
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			const emission = runner.emit({ type: "session_start" });
+			await activationEntered.promise;
+			const mcpRefresh = session.refreshMCPTools([mcpTool]);
+			await Promise.resolve();
+			expect(session.getToolByName(mcpTool.name)).toBeUndefined();
+
+			releaseActivation.resolve();
+			await Promise.all([emission, mcpRefresh]);
+			expect(session.getEnabledToolNames()).toEqual(
+				expect.arrayContaining(["serialized_lifecycle_tool", mcpTool.name]),
+			);
+		} finally {
+			releaseActivation.resolve();
 			await session.dispose();
 		}
 	});

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -11,6 +11,7 @@ import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { CursorExecHandlers } from "@oh-my-pi/pi-coding-agent/cursor";
 import type { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import { initializeExtensions } from "@oh-my-pi/pi-coding-agent/modes/runtime-init";
 import {
 	type CreateAgentSessionOptions,
 	type CustomTool,
@@ -714,6 +715,96 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		} finally {
 			releaseLaterActivation.resolve();
 			await emission;
+			await session.dispose();
+		}
+	});
+
+	it("applies explicit tool selection after preceding lifecycle registrations", async () => {
+		const tempDir = makeTempDir();
+		const registrationExtension: ExtensionFactory = pi => {
+			pi.on("session_start", async () => {
+				pi.registerTool({
+					name: "register_then_select_tool",
+					label: "Register Then Select Tool",
+					description: "Must not overwrite the explicit selection that follows registration.",
+					parameters: type({}),
+					async execute() {
+						return { content: [{ type: "text", text: "registered" }] };
+					},
+				});
+				await pi.setActiveTools(["read"]);
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [registrationExtension],
+		});
+
+		try {
+			await initializeExtensions(session, {
+				reportSendError: vi.fn(),
+				reportRuntimeError: vi.fn(),
+			});
+
+			expect(session.getAllToolNames()).toContain("register_then_select_tool");
+			expect(session.getEnabledToolNames()).toContain("read");
+			expect(session.getEnabledToolNames()).not.toContain("register_then_select_tool");
+			expect(session.getMountedXdevToolNames()).not.toContain("register_then_select_tool");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("attributes detached registration failures without waiting for another lifecycle handler", async () => {
+		const tempDir = makeTempDir();
+		const releaseDetachedRegistration = Promise.withResolvers<void>();
+		const registrationFailure = Promise.withResolvers<{ event: string; error: string }>();
+		let rejectDetachedPrompt = false;
+		const detachedRegistrationExtension: ExtensionFactory = pi => {
+			pi.on("session_start", () => {
+				void releaseDetachedRegistration.promise.then(() => {
+					pi.registerTool({
+						name: "detached_registration_tool",
+						label: "Detached Registration Tool",
+						description: "Detached tool whose activation intentionally fails.",
+						parameters: type({}),
+						async execute() {
+							return { content: [{ type: "text", text: "detached" }] };
+						},
+					});
+				});
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [detachedRegistrationExtension],
+			systemPrompt: defaultPrompt => {
+				if (rejectDetachedPrompt) throw new Error("expected detached registration failure");
+				return defaultPrompt;
+			},
+		});
+
+		try {
+			await initializeExtensions(session, {
+				reportSendError: vi.fn(),
+				reportRuntimeError: error => {
+					if (error.error === "expected detached registration failure") {
+						registrationFailure.resolve({ event: error.event, error: error.error });
+					}
+				},
+			});
+			rejectDetachedPrompt = true;
+			releaseDetachedRegistration.resolve();
+
+			expect(await registrationFailure.promise).toEqual({
+				event: "tool_registration",
+				error: "expected detached registration failure",
+			});
+			expect(session.getToolByName("detached_registration_tool")).toBeUndefined();
+		} finally {
+			releaseDetachedRegistration.resolve();
 			await session.dispose();
 		}
 	});

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -640,6 +640,52 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		}
 	});
 
+	it("serializes complete memory-tool replacement with late extension activation", async () => {
+		const tempDir = makeTempDir();
+		const activationEntered = Promise.withResolvers<void>();
+		const releaseActivation = Promise.withResolvers<void>();
+		const lateRegistrationExtension: ExtensionFactory = pi => {
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				pi.registerTool({
+					name: "memory_race_lifecycle_tool",
+					label: "Memory Race Lifecycle Tool",
+					description: "Lifecycle tool activated before a memory-tool replacement.",
+					parameters: type({}),
+					async execute() {
+						return { content: [{ type: "text", text: "lifecycle" }] };
+					},
+				});
+			});
+		};
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [lateRegistrationExtension],
+		});
+		const originalSetActiveToolPresentation = session.setActiveToolPresentation.bind(session);
+		vi.spyOn(session, "setActiveToolPresentation").mockImplementation(async (...args) => {
+			activationEntered.resolve();
+			await releaseActivation.promise;
+			return originalSetActiveToolPresentation(...args);
+		});
+
+		try {
+			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
+			const emission = runner.emit({ type: "session_start" });
+			await activationEntered.promise;
+			const memoryRefresh = session.applyMemoryBackend();
+
+			releaseActivation.resolve();
+			await Promise.all([emission, memoryRefresh]);
+			expect(session.getEnabledToolNames()).toContain("memory_race_lifecycle_tool");
+		} finally {
+			releaseActivation.resolve();
+			await session.dispose();
+		}
+	});
+
 	it("keeps an explicitly disabled tool disabled when its extension re-registers it", async () => {
 		const tempDir = makeTempDir();
 		const disabledReplacementExtension: ExtensionFactory = pi => {

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -389,6 +389,21 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			await runner.emit({ type: "session_start" });
 
 			expect(session.getToolByName("mcp__foo_bar_lookup")?.label).toBe("foo.bar/lookup");
+			await session.refreshMCPTools([
+				{
+					name: "mcp__foo_bar_lookup",
+					label: "foo_bar/lookup manager",
+					description: "Colliding manager tool with the losing stable origin.",
+					parameters: type({}),
+					mcpServerName: "foo_bar",
+					mcpToolName: "lookup",
+					async execute() {
+						return { content: [{ type: "text", text: "manager" }] };
+					},
+				} satisfies CustomTool,
+			]);
+			expect(session.getToolByName("mcp__foo_bar_lookup")?.label).toBe("foo.bar/lookup");
+			expect(session.getEnabledToolNames()).toContain("mcp__foo_bar_lookup");
 			expect(warn).toHaveBeenCalledWith("MCP tool name collision; keeping stable winner", {
 				name: "mcp__foo_bar_lookup",
 				keptServer: "foo.bar",

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -178,6 +178,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			});
 			pi.on("input", async () => {
 				await startupPromise;
+				await pi.setActiveTools([...pi.getActiveTools(), "late_active_tool"]);
 			});
 		};
 
@@ -190,10 +191,19 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			expect(session.getAllToolNames()).not.toContain("late_active_tool");
 			const runner = session.extensionRunner;
 			if (!runner) throw new Error("expected extension runner");
-			await runner.emit({ type: "session_start" });
+			const errors: string[] = [];
+			const unsubscribe = runner.onError(error => {
+				errors.push(error.error);
+			});
+			await initializeExtensions(session, {
+				reportSendError: vi.fn(),
+				reportRuntimeError: vi.fn(),
+			});
 			expect(session.getAllToolNames()).not.toContain("late_active_tool");
 			startupGate.resolve();
 			await runner.emitInput("probe", undefined, "interactive");
+			unsubscribe();
+			expect(errors).toEqual([]);
 
 			expect(session.getAllToolNames()).toEqual(expect.arrayContaining(["late_active_tool", "late_inactive_tool"]));
 			expect(session.getEnabledToolNames()).toContain("late_active_tool");

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -1083,6 +1083,17 @@ describe("createAgentSession defaultInactive tool activation", () => {
 
 		const { session } = await createAgentSession({
 			...baseOptions(tempDir),
+			settings: Settings.isolated({
+				"bashInterceptor.enabled": true,
+				"bashInterceptor.patterns": [
+					{
+						pattern: "^\\s*printf\\s+",
+						tool: "detached_registration_tool",
+						message: "Use the detached registration tool.",
+					},
+				],
+			}),
+			autoApprove: true,
 			extensions: [detachedRegistrationExtension],
 			systemPrompt: defaultPrompt => {
 				if (rejectDetachedPrompt) throw new Error("expected detached registration failure");
@@ -1107,6 +1118,33 @@ describe("createAgentSession defaultInactive tool activation", () => {
 				error: "expected detached registration failure",
 			});
 			expect(session.getToolByName("detached_registration_tool")).toBeUndefined();
+			rejectDetachedPrompt = false;
+			const toolCallId = "detached-rollback-bash";
+			const mock = createMockModel({
+				responses: [
+					{
+						content: [
+							{
+								type: "toolCall",
+								id: toolCallId,
+								name: "bash",
+								arguments: { command: "printf rollback-ok" },
+							},
+						],
+					},
+					{ content: [{ type: "text", text: "done" }] },
+				],
+			});
+			vi.spyOn(session.agent, "streamFn").mockImplementation(mock.stream);
+			await withProviderAuth(["openai"], async () => {
+				await session.prompt("verify rollback context");
+				const bashResult = session.messages.find(
+					(message): message is ToolResultMessage =>
+						message.role === "toolResult" && message.toolCallId === toolCallId,
+				);
+				expect(bashResult?.isError).toBe(false);
+				expect(JSON.stringify(bashResult?.content)).toContain("rollback-ok");
+			});
 		} finally {
 			releaseDetachedRegistration.resolve();
 			await session.dispose();

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -618,6 +618,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			expect(originalTool).toBeDefined();
 			expect(session.hasBuiltInTool("bash")).toBe(true);
 			const runner = session.extensionRunner;
+			if (!runner) throw new Error("expected extension runner");
 			const errors: string[] = [];
 			const unsubscribe = runner.onError(error => {
 				errors.push(error.error);

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -1153,10 +1153,25 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			getServerInstructions: () => new Map([["private-server", "must not reach restricted child"]]),
 		} as unknown as MCPManager;
 
+		const restrictedLateExtension: ExtensionFactory = pi => {
+			pi.on("session_start", async () => {
+				await Promise.resolve();
+				pi.registerTool({
+					name: "restricted_late_extension_tool",
+					label: "Restricted Late Extension Tool",
+					description: "Must not enter a caller-restricted session.",
+					parameters: type({}),
+					async execute() {
+						return { content: [{ type: "text", text: "restricted late" }] };
+					},
+				});
+			});
+		};
+
 		const { session: restricted } = await createAgentSession({
 			...baseOptions(restrictedDir),
 			settings: configuredSettings(),
-			extensions: [toolActivationExtension],
+			extensions: [toolActivationExtension, restrictedLateExtension],
 			customTools: [sdkCustomTool],
 			toolNames: ["read", "lsp", "hub"],
 			requireYieldTool: true,
@@ -1168,6 +1183,10 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		});
 
 		try {
+			await initializeExtensions(restricted, {
+				reportSendError: vi.fn(),
+				reportRuntimeError: vi.fn(),
+			});
 			expect(restricted.getAllToolNames()).toEqual(["read", "lsp", "yield"]);
 			expect(restricted.getActiveToolNames()).toEqual(["read", "lsp", "yield"]);
 			for (const name of [
@@ -1181,6 +1200,7 @@ describe("createAgentSession defaultInactive tool activation", () => {
 				"default_active_tool",
 				"default_inactive_tool",
 				"sdk_custom_tool",
+				"restricted_late_extension_tool",
 				"hub",
 			]) {
 				expect(restricted.getToolByName(name)).toBeUndefined();


### PR DESCRIPTION
## What

Pi extensions can register their tools asynchronously to not block on startup. This functionality was broken in omp.

## Why

Enables https://github.com/HexRaysSA/ida-codemode to be used in omp without regressing startup time.

## Testing

I tested it by hand, it didn't work before and now it works fine.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
