### PR TITLE
fix(coding-agent): display subagent registration time locally

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Agent Hub lineage registration timestamps displaying in UTC instead of the user's local timezone.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -829,7 +829,19 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			`Spawned by ${sanitizeDisplayText(ref.parentId ?? MAIN_AGENT_ID)}${children.length > 0 ? ` · ${children.length} children` : ""}`,
 		);
 		if (children.length > 0) add(theme.fg("dim", formatChildIds(children, width)));
-		add(theme.fg("dim", `Registered ${new Date(ref.createdAt).toISOString().slice(0, 16).replace("T", " ")}Z`));
+		add(
+			theme.fg(
+				"dim",
+				`Registered ${new Date(ref.createdAt).toLocaleString(undefined, {
+					year: "numeric",
+					month: "short",
+					day: "2-digit",
+					hour: "2-digit",
+					minute: "2-digit",
+					timeZoneName: "short",
+				})}`,
+			),
+		);
 
 		section("Changes");
 		add(

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -36,6 +36,7 @@ import { type AgentRef, AgentRegistry, type AgentStatus, MAIN_AGENT_ID } from ".
 import { registerPersistedSubagents } from "../../registry/persisted-agents";
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
 import { shortenPath, truncateToWidth } from "../../tools/render-utils";
+import { formatLocalDateTimeWithOffset } from "../../utils/local-date";
 import type { ObservableSession, SessionObserverRegistry } from "../session-observer-registry";
 import { theme } from "../theme/theme";
 import { matchesSelectDown, matchesSelectUp } from "../utils/keybinding-matchers";
@@ -829,19 +830,7 @@ export class AgentHubOverlayComponent extends Container implements SelectListMou
 			`Spawned by ${sanitizeDisplayText(ref.parentId ?? MAIN_AGENT_ID)}${children.length > 0 ? ` · ${children.length} children` : ""}`,
 		);
 		if (children.length > 0) add(theme.fg("dim", formatChildIds(children, width)));
-		add(
-			theme.fg(
-				"dim",
-				`Registered ${new Date(ref.createdAt).toLocaleString(undefined, {
-					year: "numeric",
-					month: "short",
-					day: "2-digit",
-					hour: "2-digit",
-					minute: "2-digit",
-					timeZoneName: "short",
-				})}`,
-			),
-		);
+		add(theme.fg("dim", `Registered ${formatLocalDateTimeWithOffset(new Date(ref.createdAt))}`));
 
 		section("Changes");
 		add(

--- a/packages/coding-agent/src/utils/local-date.ts
+++ b/packages/coding-agent/src/utils/local-date.ts
@@ -5,3 +5,16 @@ export function formatLocalCalendarDate(date: Date = new Date()): string {
 	const day = String(date.getDate()).padStart(2, "0");
 	return `${year}-${month}-${day}`;
 }
+
+/** Format a local date and minute with a compact numeric UTC offset. */
+export function formatLocalDateTimeWithOffset(date: Date): string {
+	const offsetMinutes = date.getTimezoneOffset();
+	const offsetSign = offsetMinutes <= 0 ? "+" : "-";
+	const absoluteOffset = Math.abs(offsetMinutes);
+	const offsetHours = Math.floor(absoluteOffset / 60);
+	const offsetRemainderMinutes = absoluteOffset % 60;
+	const pad2 = (value: number): string => String(value).padStart(2, "0");
+	return `${formatLocalCalendarDate(date)} ${pad2(date.getHours())}:${pad2(date.getMinutes())} ${offsetSign}${pad2(
+		offsetHours,
+	)}:${pad2(offsetRemainderMinutes)}`;
+}

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -529,6 +529,7 @@ describe("Agent hub row ordering", () => {
 	it("renders aggregate usage and a selected-agent inspector without inventing change attribution", () => {
 		geometry = stubStdoutGeometry(140);
 		geometry.setRows(28);
+		const createdAt = Date.parse("2026-08-09T20:15:00Z");
 		const agents = new AgentRegistry();
 		agents.register({
 			id: "Reviewer",
@@ -541,6 +542,7 @@ describe("Agent hub row ordering", () => {
 				patchPath: "/tmp/Reviewer.patch",
 				branchName: "omp/task/Reviewer",
 			},
+			createdAt,
 		});
 		const observers = new SessionObserverRegistry();
 		vi.spyOn(observers, "getSessions").mockReturnValue([
@@ -584,7 +586,16 @@ describe("Agent hub row ordering", () => {
 			expect(rendered).toContain("Security Reviewer");
 			expect(rendered).toContain("read · src/session/agent-session.ts");
 			expect(rendered).toContain("31K/128K 24%");
-			expect(rendered).toContain("Registered ");
+			expect(rendered).toContain(
+				`Registered ${new Date(createdAt).toLocaleString(undefined, {
+					year: "numeric",
+					month: "short",
+					day: "2-digit",
+					hour: "2-digit",
+					minute: "2-digit",
+					timeZoneName: "short",
+				})}`,
+			);
 			expect(rendered).toContain("Shared workspace · per-agent LoC not attributable");
 			expect(rendered).toContain("Output /tmp/Reviewer.md");
 			expect(rendered).toContain("Patch /tmp/Reviewer.patch");

--- a/packages/coding-agent/test/agent-hub-ordering.test.ts
+++ b/packages/coding-agent/test/agent-hub-ordering.test.ts
@@ -586,16 +586,24 @@ describe("Agent hub row ordering", () => {
 			expect(rendered).toContain("Security Reviewer");
 			expect(rendered).toContain("read · src/session/agent-session.ts");
 			expect(rendered).toContain("31K/128K 24%");
-			expect(rendered).toContain(
-				`Registered ${new Date(createdAt).toLocaleString(undefined, {
-					year: "numeric",
-					month: "short",
-					day: "2-digit",
-					hour: "2-digit",
-					minute: "2-digit",
-					timeZoneName: "short",
-				})}`,
-			);
+			const createdDate = new Date(createdAt);
+			const localDateTime = createdDate.toLocaleString("sv-SE", {
+				year: "numeric",
+				month: "2-digit",
+				day: "2-digit",
+				hour: "2-digit",
+				minute: "2-digit",
+			});
+			const offsetMinutes = -createdDate.getTimezoneOffset();
+			const offsetSign = offsetMinutes >= 0 ? "+" : "-";
+			const absoluteOffset = Math.abs(offsetMinutes);
+			const offset = `${offsetSign}${String(Math.floor(absoluteOffset / 60)).padStart(2, "0")}:${String(
+				absoluteOffset % 60,
+			).padStart(2, "0")}`;
+			const registeredLine = `Registered ${localDateTime} ${offset}`;
+			expect(rendered).toContain(registeredLine);
+			expect(rendered).not.toMatch(/Registered \d{4}-\d{2}-\d{2} \d{2}:\d{2}Z/u);
+			expect(Bun.stripANSI(hub.render(96).join("\n"))).toContain(registeredLine);
 			expect(rendered).toContain("Shared workspace · per-agent LoC not attributable");
 			expect(rendered).toContain("Output /tmp/Reviewer.md");
 			expect(rendered).toContain("Patch /tmp/Reviewer.patch");


### PR DESCRIPTION
## Summary

- render Agent Hub lineage registration timestamps in the user's local timezone
- use a compact numeric UTC offset that remains visible at the minimum detail width
- add regression coverage for the local timestamp, legacy UTC shape, and narrow split layout

## Verification

- `bun test packages/coding-agent/test/agent-hub-ordering.test.ts`
- `TZ=Asia/Kathmandu bun test packages/coding-agent/test/agent-hub-ordering.test.ts`
- `bun check` in `packages/coding-agent`