### PR TITLE
fix(advisor): preserve advisor fallback role ownership

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed advisor recovery selecting another role's fallback chain when both roles use the same model. ([#8075](https://github.com/can1357/oh-my-pi/issues/8075))
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1421,7 +1421,8 @@ export class AgentSession {
 				this.#maintenance.resolveContextPromotionTarget(model, contextWindow, signal),
 			resolveCompactionModelCandidates: (model, availableModels) =>
 				this.#maintenance.resolveCompactionModelCandidates(model, availableModels),
-			resolveRetryFallbackRole: (selector, model) => this.#recovery.resolveRetryFallbackRole(selector, model),
+			resolveRetryFallbackRole: (selector, model, roleHint) =>
+				this.#recovery.resolveRetryFallbackRole(selector, model, roleHint),
 			findRetryFallbackCandidates: (role, selector, model) =>
 				this.#recovery.findRetryFallbackCandidates(role, selector, model),
 			isRetryFallbackSelectorSuppressed: selector => this.#recovery.isRetryFallbackSelectorSuppressed(selector),

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -263,7 +263,11 @@ export interface SessionAdvisorsHost {
 		signal: AbortSignal,
 	): Promise<Model | undefined>;
 	resolveCompactionModelCandidates(preferredModel: Model | null | undefined, availableModels: Model[]): Model[];
-	resolveRetryFallbackRole(currentSelector: string, currentModel?: Model | null): string | undefined;
+	resolveRetryFallbackRole(
+		currentSelector: string,
+		currentModel?: Model | null,
+		roleHint?: string,
+	): string | undefined;
 	findRetryFallbackCandidates(
 		role: string,
 		currentSelector: string,
@@ -1221,7 +1225,8 @@ export class SessionAdvisors {
 
 		const retrySettings = this.#host.settings.getGroup("retry");
 		if (!retrySettings.enabled || !retrySettings.modelFallback) return false;
-		const role = advisor.retryFallback?.role ?? this.#host.resolveRetryFallbackRole(currentSelector, currentModel);
+		const role =
+			advisor.retryFallback?.role ?? this.#host.resolveRetryFallbackRole(currentSelector, currentModel, "advisor");
 		if (!role || this.#host.findRetryFallbackCandidates(role, currentSelector, currentModel).length === 0)
 			return false;
 

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -1099,8 +1099,14 @@ export class TurnRecovery {
 	resolveRetryFallbackRole(
 		currentSelector: string,
 		currentModel: Model | null | undefined = this.#host.model(),
+		roleHint?: string,
 	): string | undefined {
-		return resolveRetryFallbackChainKey(this.#getRetryFallbackResolutionContext(), currentSelector, currentModel);
+		return resolveRetryFallbackChainKey(
+			this.#getRetryFallbackResolutionContext(),
+			currentSelector,
+			currentModel,
+			roleHint,
+		);
 	}
 
 	/** Finds fallback candidates that follow the active selector. */

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -1268,11 +1268,12 @@ describe("AgentSession retry fallback", () => {
 		]);
 	});
 
-	it("applies a model-keyed fallback chain to advisor quota failures", async () => {
+	it("keeps advisor fallback recovery on its role chain when another role shares its model", async () => {
 		const mainModel = getBundledModel("openai", "gpt-4o-mini");
 		const advisorPrimary = getBundledModel("anthropic", "claude-sonnet-4-5");
-		const advisorFallback = getBundledModel("openai", "gpt-4o");
-		if (!mainModel || !advisorPrimary || !advisorFallback) {
+		const unrelatedFallback = getBundledModel("openai", "gpt-4o");
+		const advisorFallback = getBundledModel("google", "gemini-2.5-flash");
+		if (!mainModel || !advisorPrimary || !unrelatedFallback || !advisorFallback) {
 			throw new Error("Expected bundled advisor fallback models to exist");
 		}
 
@@ -1287,6 +1288,8 @@ describe("AgentSession retry fallback", () => {
 		const fallbackSucceeded = Promise.withResolvers<void>();
 		const advisorFailures: string[] = [];
 		const advisorPrimarySelector = `${advisorPrimary.provider}/${advisorPrimary.id}`;
+		const advisorRoleSelector = `${advisorPrimarySelector}:high`;
+		const unrelatedFallbackSelector = `${unrelatedFallback.provider}/${unrelatedFallback.id}`;
 		const advisorFallbackSelector = `${advisorFallback.provider}/${advisorFallback.id}`;
 
 		const agent = new Agent({
@@ -1303,11 +1306,13 @@ describe("AgentSession retry fallback", () => {
 			"compaction.enabled": false,
 			"retry.baseDelayMs": 5,
 			"retry.fallbackChains": {
-				[advisorPrimarySelector]: [advisorFallbackSelector],
+				commit: [unrelatedFallbackSelector],
+				advisor: [advisorFallbackSelector],
 			},
 			"advisor.syncBacklog": "1",
 		});
-		settings.setModelRole("advisor", advisorPrimarySelector);
+		settings.setModelRole("commit", `${advisorPrimarySelector}:medium`);
+		settings.setModelRole("advisor", advisorRoleSelector);
 		vi.spyOn(modelRegistry.authStorage, "markUsageLimitReached").mockResolvedValue({ switched: false });
 
 		session = new AgentSession({
@@ -1316,7 +1321,7 @@ describe("AgentSession retry fallback", () => {
 			settings,
 			modelRegistry,
 			advisorTools: [],
-			advisorConfigs: [{ name: "fallback-test", model: advisorPrimarySelector }],
+			advisorConfigs: [{ name: "fallback-test", model: advisorRoleSelector }],
 			advisorStreamFn: (model, context, options) => {
 				const selector = `${model.provider}/${model.id}`;
 				requestedAdvisorModels.push(selector);
@@ -1326,6 +1331,8 @@ describe("AgentSession retry fallback", () => {
 					});
 				} else if (selector === advisorPrimarySelector) {
 					advisorMock.push({ content: ["Advisor primary restored"] });
+				} else if (selector === unrelatedFallbackSelector) {
+					advisorMock.push({ content: ["Unrelated fallback answered"] });
 				} else if (selector === advisorFallbackSelector) {
 					advisorMock.push({ content: ["Advisor recovered"] });
 				} else {
@@ -1361,16 +1368,16 @@ describe("AgentSession retry fallback", () => {
 		expect(fallbackAppliedEvents).toEqual([
 			{
 				type: "retry_fallback_applied",
-				from: `${advisorPrimarySelector}:medium`,
+				from: advisorRoleSelector,
 				to: advisorFallbackSelector,
-				role: advisorPrimarySelector,
+				role: "advisor",
 			},
 		]);
 		expect(fallbackSucceededEvents).toEqual([
 			{
 				type: "retry_fallback_succeeded",
-				model: advisorFallbackSelector,
-				role: advisorPrimarySelector,
+				model: `${advisorFallbackSelector}:high`,
+				role: "advisor",
 			},
 		]);
 		expect(advisorFailures).toEqual([]);


### PR DESCRIPTION
## Repro
With `commit` and `advisor` assigned the same model at different thinking levels and separate role-keyed chains, `bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts -t "keeps advisor fallback recovery on its role chain when another role shares its model"` failed because the advisor requested the earlier `commit` fallback (`openai/gpt-4o`) instead of its own (`google/gemini-2.5-flash`).

## Cause
`SessionAdvisors.#recoverAdvisorTurn` in `packages/coding-agent/src/session/session-advisors.ts` called the host's `resolveRetryFallbackRole` without the known `advisor` role. `TurnRecovery.resolveRetryFallbackRole` therefore invoked `resolveRetryFallbackChainKey` without a role hint, allowing the first base-model role match to own recovery when thinking suffixes differed.

## Fix
- Thread an optional role hint through the advisor host and `TurnRecovery` delegation.
- Resolve advisor recovery with the explicit `advisor` hint while preserving exact model-key and provider-wildcard precedence.
- Replace the advisor integration scenario with shared-model role chains and assert the selected model plus fallback lifecycle role.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts` passed: 60 tests, 0 failures. `cd packages/coding-agent && bun run check` passed. The pre-publish formatter and repository checks passed during branch publication. Fixes #8075