### PR TITLE
fix(ai): bind the IPv6 loopback so dev servers stop stealing OAuth callbacks

### DIFF
--- a/packages/ai/src/registry/oauth/callback-server.ts
+++ b/packages/ai/src/registry/oauth/callback-server.ts
@@ -17,6 +17,15 @@ import type { OAuthController, OAuthCredentials } from "./types";
 const DEFAULT_TIMEOUT = 300_000;
 const DEFAULT_HOSTNAME = "localhost";
 const CALLBACK_PATH = "/callback";
+const IPV4_LOOPBACK = "127.0.0.1";
+const IPV6_LOOPBACK = "::1";
+/**
+ * How many times a random-port bind may be redrawn when the ephemeral port it
+ * landed on is already held on {@link IPV6_LOOPBACK} by that exact address.
+ * Small on purpose: each redraw picks a fresh port, so a repeat collision is
+ * vanishingly unlikely.
+ */
+const IPV6_COMPANION_ATTEMPTS = 4;
 /**
  * Path served by {@link OAuthCallbackFlow} that 302-redirects to the pending
  * authorization URL. Kept out of {@link OAuthCallbackFlowOptions} because it
@@ -27,6 +36,27 @@ const CALLBACK_PATH = "/callback";
 const LAUNCH_PATH = "/launch";
 
 export type CallbackResult = { code: string; state: string };
+
+/**
+ * Subset of {@link Bun.Server} this flow depends on, so a `localhost` flow can
+ * hand back one listener per loopback address family while still looking like a
+ * single server to callers.
+ */
+interface CallbackServer {
+	readonly port: Bun.Server<unknown>["port"];
+	stop: Bun.Server<unknown>["stop"];
+}
+
+/**
+ * Whether a failed bind means "another process already holds this port".
+ * Bun surfaces `EADDRINUSE` on the error's `code` where the platform reports
+ * it, and otherwise only in the message, so both are checked.
+ */
+function isAddressInUse(error: unknown): boolean {
+	const code = (error as { code?: unknown } | null | undefined)?.code;
+	if (typeof code === "string") return code === "EADDRINUSE";
+	return error instanceof Error && /EADDRINUSE|in use/i.test(error.message);
+}
 
 export interface OAuthCallbackFlowOptions {
 	preferredPort: number;
@@ -192,7 +222,7 @@ export abstract class OAuthCallbackFlow {
 	 */
 	async #startCallbackServer(
 		expectedState: string,
-	): Promise<{ server: Bun.Server<unknown>; redirectUri: string; launchUrl: string | undefined }> {
+	): Promise<{ server: CallbackServer; redirectUri: string; launchUrl: string | undefined }> {
 		try {
 			const server = this.#createServer(this.preferredPort, expectedState);
 			// `preferredPort: 0` opts into a random port — read the actual bound
@@ -233,7 +263,7 @@ export abstract class OAuthCallbackFlow {
 	 * but every callback flow uses TCP; a missing port here indicates a
 	 * configuration error rather than a fallback case.
 	 */
-	#resolveServerPort(server: Bun.Server<unknown>): number {
+	#resolveServerPort(server: CallbackServer): number {
 		const port = server.port;
 		if (typeof port !== "number") {
 			throw new AIError.ConfigurationError(
@@ -277,10 +307,68 @@ export abstract class OAuthCallbackFlow {
 	}
 
 	/**
-	 * Create HTTP server for OAuth callback.
+	 * Create the HTTP listener(s) for the OAuth callback.
+	 *
+	 * `localhost` is not a single endpoint: it resolves to both
+	 * {@link IPV4_LOOPBACK} and {@link IPV6_LOOPBACK}, and clients commonly try
+	 * `::1` first. Binding only the IPv4 literal hands the authorization code to
+	 * whatever holds the IPv6 loopback on the same port — a dev server on
+	 * `*:3000` is the common case — which answers from its own routes while this
+	 * flow waits out the full {@link DEFAULT_TIMEOUT}. Nothing detects it either:
+	 * a specific-address bind coexists with another process's wildcard bind, so
+	 * `Bun.serve` reports the port as free and the random-port fallback in
+	 * {@link #startCallbackServer} never runs.
+	 *
+	 * Binding both loopback literals fixes the delivery rather than dodging it:
+	 * the kernel routes a connection to the most specific matching bind, so our
+	 * `::1` listener receives `localhost` traffic that would otherwise reach a
+	 * process bound to the `::` wildcard. Both listeners answer the same routes,
+	 * so which family the client resolves stops mattering.
+	 *
+	 * A genuine collision — another process on exactly this loopback address and
+	 * port — still raises EADDRINUSE and reaches the caller's in-use policy. A
+	 * host that cannot bind `::1` at all (IPv6 disabled, address unavailable) is
+	 * not a collision: the IPv4 listener is the only reachable endpoint there, so
+	 * it serves alone.
 	 */
-	#createServer(port: number, expectedState: string): Bun.Server<unknown> {
-		const hostname = this.callbackHostname === DEFAULT_HOSTNAME ? "127.0.0.1" : this.callbackHostname;
+	#createServer(port: number, expectedState: string): CallbackServer {
+		if (this.callbackHostname !== DEFAULT_HOSTNAME) {
+			return this.#serve(this.callbackHostname, port, expectedState);
+		}
+		for (let attempt = 0; ; attempt++) {
+			const primary = this.#serve(IPV4_LOOPBACK, port, expectedState);
+			const boundPort = primary.port;
+			// A non-TCP endpoint has no port for the companion to target;
+			// #resolveServerPort reports that case precisely.
+			if (typeof boundPort !== "number") return primary;
+			let companion: Bun.Server<unknown>;
+			try {
+				companion = this.#serve(IPV6_LOOPBACK, boundPort, expectedState);
+			} catch (cause) {
+				if (!isAddressInUse(cause)) return primary;
+				void primary.stop(true);
+				// A pinned port has no alternative, so surface it as in use and let
+				// the caller apply its fallback or diagnostic policy. A random port
+				// can just be redrawn, since only that one number clashed.
+				if (port !== 0 || attempt >= IPV6_COMPANION_ATTEMPTS) throw cause;
+				continue;
+			}
+			// One server to callers. The IPv4 listener stays authoritative for
+			// `port` because the companion was bound to the port it resolved.
+			return {
+				get port() {
+					return primary.port;
+				},
+				stop: (closeActiveConnections?: boolean) => {
+					void companion.stop(closeActiveConnections);
+					return primary.stop(closeActiveConnections);
+				},
+			};
+		}
+	}
+
+	/** Bind one loopback listener serving the callback and launch routes. */
+	#serve(hostname: string, port: number, expectedState: string): Bun.Server<unknown> {
 		return Bun.serve({
 			hostname,
 			port,

--- a/packages/ai/test/callback-server-dual-stack.test.ts
+++ b/packages/ai/test/callback-server-dual-stack.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { OAuthCallbackFlow } from "@oh-my-pi/pi-ai/registry/oauth/callback-server";
+import type { OAuthCredentials } from "@oh-my-pi/pi-ai/registry/oauth/types";
+
+/**
+ * Callback flow that records what `login()` advertised, so a test can assert on
+ * the redirect URI and drive the callback itself.
+ */
+class TestCallbackFlow extends OAuthCallbackFlow {
+	lastRedirectUri?: string;
+	lastState?: string;
+
+	async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string }> {
+		this.lastRedirectUri = redirectUri;
+		this.lastState = state;
+		return { url: `${redirectUri}?started=1` };
+	}
+
+	async exchangeToken(code: string, _state: string, _redirectUri: string): Promise<OAuthCredentials> {
+		return { access: `access-${code}`, refresh: "refresh", expires: Date.now() + 60_000 };
+	}
+}
+
+/** Whether this host can bind the IPv6 loopback at all. */
+const ipv6Loopback = (() => {
+	try {
+		Bun.serve({ hostname: "::1", port: 0, fetch: () => new Response("probe") }).stop(true);
+		return true;
+	} catch {
+		return false;
+	}
+})();
+
+/**
+ * Bind a squatter on `hostname` and return the port it took. `::` reproduces a
+ * dev server (`next dev` binds the IPv6 wildcard); `::1` reproduces a process
+ * holding that exact loopback address. The squatter answers 500 so a response
+ * from it is unmistakable in an assertion.
+ */
+function occupy(hostname: string): { port: number; release: () => void } {
+	const server = Bun.serve({ hostname, port: 0, fetch: () => new Response("squatter", { status: 500 }) });
+	const port = server.port;
+	if (typeof port !== "number") {
+		server.stop(true);
+		throw new Error("Bun.serve({ port: 0 }) did not assign a numeric port");
+	}
+	return { port, release: () => server.stop(true) };
+}
+
+/** Claim and immediately release a port, so a test can pin a known-free one. */
+function freeLoopbackPort(): number {
+	const probe = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("probe") });
+	const port = probe.port;
+	probe.stop(true);
+	if (typeof port !== "number") {
+		throw new Error("Bun.serve({ port: 0 }) did not assign a numeric port");
+	}
+	return port;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("OAuthCallbackFlow loopback address families", () => {
+	it.skipIf(!ipv6Loopback)("takes localhost traffic back from a process on the IPv6 wildcard", async () => {
+		// A dev server on `*:<port>`: the flow's IPv4 bind coexists with it, so
+		// nothing looks wrong, yet `localhost` resolves to `::1` and the browser
+		// would hand the authorization code to that dev server.
+		const devServer = occupy("::");
+		const advertised = Promise.withResolvers<void>();
+		const cancel = new AbortController();
+		const flow = new TestCallbackFlow(
+			{ onAuth: () => advertised.resolve(), signal: cancel.signal },
+			{ preferredPort: devServer.port },
+		);
+
+		const login = flow.login();
+		void login.catch(() => undefined);
+		try {
+			await advertised.promise;
+			// A coexisting wildcard bind is not a conflict, so the preferred port is
+			// kept rather than abandoned.
+			expect(flow.lastRedirectUri).toBe(`http://localhost:${devServer.port}/callback`);
+
+			// The kernel prefers the most specific bind, so our `::1` listener now
+			// answers `localhost` traffic. A 500 body of "squatter" here would mean
+			// the dev server received the authorization code instead.
+			const stray = await fetch(`http://[::1]:${devServer.port}/not-a-callback`);
+			expect(stray.status).toBe(404);
+			expect(await stray.text()).toBe("Not Found");
+
+			const response = await fetch(`http://[::1]:${devServer.port}/callback?code=v6code&state=${flow.lastState}`);
+			expect(response.status).toBe(200);
+			await expect(login).resolves.toMatchObject({ access: "access-v6code" });
+		} finally {
+			cancel.abort("test cleanup");
+			devServer.release();
+		}
+	});
+
+	it.skipIf(!ipv6Loopback)("falls back when the IPv6 loopback address itself is taken", async () => {
+		const squatter = occupy("::1");
+		const progress: string[] = [];
+		// Cancel as soon as the flow publishes its redirect URI: the port it
+		// advertised is the whole assertion, and aborting on that signal keeps this
+		// test off the wall clock.
+		const cancel = new AbortController();
+		const flow = new TestCallbackFlow(
+			{
+				onAuth: () => cancel.abort("advertised"),
+				onProgress: msg => progress.push(msg),
+				signal: cancel.signal,
+			},
+			{ preferredPort: squatter.port },
+		);
+
+		try {
+			await expect(flow.login()).rejects.toThrow();
+			// `::1` cannot be shared, so this port cannot serve both families and the
+			// flow must move rather than advertise a half-reachable URI.
+			expect(flow.lastRedirectUri).toMatch(/^http:\/\/localhost:\d+\/callback$/);
+			expect(flow.lastRedirectUri).not.toContain(`:${squatter.port}/`);
+			expect(progress.some(msg => msg.startsWith(`Preferred port ${squatter.port} unavailable`))).toBe(true);
+		} finally {
+			squatter.release();
+		}
+	});
+
+	it("keeps the preferred port when the host cannot bind ::1", async () => {
+		const realServe = Bun.serve.bind(Bun) as typeof Bun.serve;
+		vi.spyOn(Bun, "serve").mockImplementation(((options: { hostname?: string }) => {
+			if (options.hostname === "::1") {
+				throw Object.assign(new Error("address family not supported by protocol"), { code: "EAFNOSUPPORT" });
+			}
+			return realServe(options as Parameters<typeof Bun.serve>[0]);
+		}) as typeof Bun.serve);
+
+		const port = freeLoopbackPort();
+		const progress: string[] = [];
+		const cancel = new AbortController();
+		const flow = new TestCallbackFlow(
+			{
+				onAuth: () => cancel.abort("advertised"),
+				onProgress: msg => progress.push(msg),
+				signal: cancel.signal,
+			},
+			{ preferredPort: port },
+		);
+
+		await expect(flow.login()).rejects.toThrow();
+		// An unbindable `::1` is not a conflict: the IPv4 listener is the only
+		// reachable endpoint on such a host, so the flow must not fall back.
+		expect(flow.lastRedirectUri).toBe(`http://localhost:${port}/callback`);
+		expect(progress.some(msg => msg.includes("unavailable"))).toBe(false);
+	});
+});

--- a/packages/ai/test/callback-server-security.test.ts
+++ b/packages/ai/test/callback-server-security.test.ts
@@ -86,17 +86,24 @@ describe("OAuthCallbackFlow callback security", () => {
 		}
 	});
 
-	it("binds localhost callback URLs to the IPv4 loopback interface", async () => {
+	it("binds localhost callback URLs to the loopback interfaces only", async () => {
 		const serve = Bun.serve;
-		let hostname: string | undefined;
+		const hostnames: (string | undefined)[] = [];
 		vi.spyOn(Bun, "serve").mockImplementation(options => {
-			hostname = options.hostname;
+			hostnames.push(options.hostname);
 			return serve(options);
 		});
 
 		const { abort, login } = await startFlow();
 		try {
-			expect(hostname).toBe("127.0.0.1");
+			// `localhost` resolves to both loopback families, so the flow binds one
+			// literal per family: IPv4 first (it resolves the port), then the IPv6
+			// companion that keeps a wildcard-bound dev server from receiving the
+			// authorization code. Never the `localhost` name itself, and never a
+			// routable interface.
+			expect(hostnames[0]).toBe("127.0.0.1");
+			expect(hostnames).toContain("::1");
+			expect(hostnames.every(hostname => hostname === "127.0.0.1" || hostname === "::1")).toBe(true);
 		} finally {
 			abort.abort("test cleanup");
 			await login.catch(() => undefined);


### PR DESCRIPTION
I hit this myself: a Next dev server on port 3000 silently ate my MCP OAuth callback, and I reviewed the full diff.

## The bug

`OAuthCallbackFlow` advertises `http://localhost:<port>/callback` but binds only `127.0.0.1`. `localhost` is not a single endpoint: it resolves to both loopback families, and clients try `::1` first. So any process holding the IPv6 loopback on that port receives the authorization code instead of us.

Detection fails too. A specific-address bind coexists with another process's wildcard bind, so `Bun.serve({ hostname: "127.0.0.1" })` succeeds against a `*:<port>` listener, the port looks free, and the `allowPortFallback` path in `#startCallbackServer` never runs. The login then waits out the full 5 minute `DEFAULT_TIMEOUT` while the browser sits on the other process's response.

`next dev` binds the IPv6 wildcard, and `packages/coding-agent/src/mcp/oauth-flow.ts` defaults to `DEFAULT_PORT = 3000`, so a running dev server and an MCP OAuth login collide on the single most contested port on a web developer's machine. The user-visible symptom is an opaque "internal server error" on the redirect, served by an unrelated app.

## The fix

Bind both loopback literals rather than probing for availability. I tried the probe first and it cannot work: under `SO_REUSEADDR` a `::1` bind succeeds even while another process holds `::`, so the probe reports the port free.

Binding fixes delivery instead of merely detecting a conflict. The kernel routes a connection to the most specific matching bind, so the `::1` listener reclaims `localhost` traffic from a wildcard-bound process, and both listeners serve the same routes. Which family the client resolves stops mattering.

Preserved behavior:

- a genuine collision on one exact loopback address still raises `EADDRINUSE` and reaches the existing in-use policy (random-port fallback, or the actionable `ConfigurationError` when `redirectUri` or `allowPortFallback: false` pins the port);
- a host that cannot bind `::1` at all (IPv6 disabled, address unavailable) is not treated as a collision, and keeps serving on IPv4 alone;
- flows that set an explicit `callbackHostname` (Google, per `google-oauth-hostname.test.ts`) are untouched and still bind exactly that address.

## Verification

Beyond the suite, I reproduced the original scenario against the real `MCPOAuthFlow` with a `Bun.serve({ hostname: "::", port: 3000 })` stand-in for `next dev`:

| request | before | after |
| --- | --- | --- |
| `[::1]:3000/nope` | `500` "next dev" (squatter answered) | `404 Not Found` (our listener answered) |
| `[::1]:3000/callback?code=...` | squatter received the code, login hung | `200`, `login()` resolved with the credential |

In both runs the flow advertised `http://localhost:3000/callback`, which is the point: the advertised URI was already correct, and only the listening side was wrong.

Checks, run with bun 1.3.14:

- `packages/ai`: `bun test --parallel` gives 3732 pass, 337 skip (e2e without keys), 0 fail.
- `packages/ai`: `bun run check` (biome + tsgo) clean.
- `packages/coding-agent`: the OAuth and MCP reauth suites give 125 pass, 0 fail.
- The new regression test fails on unpatched code, advertising the squatted port, which is the bug.

## Notes for review

`test/callback-server-dual-stack.test.ts` covers the three cases: a `::` wildcard squatter (port kept, traffic reclaimed), an exact `::1` squatter (falls back to another port), and an unbindable `::1` (port kept, no fallback). Its IPv6 capability guard deliberately probes with `Bun.serve` rather than the shape the flow uses, so a broken probe fails loudly instead of skipping into a false green.

One existing assertion changed. `callback-server-security.test.ts` recorded only the last `Bun.serve` hostname and asserted `127.0.0.1`; with a second bind the last call is now `::1`. It asserts the original intent more precisely: IPv4 is bound first, `::1` is present, and nothing outside those two loopback literals is ever bound.

If you would rather not change the bind topology, the alternative is to advertise the loopback IP literal instead of the `localhost` name (RFC 8252 section 7.3 recommends exactly that, and it is what the Google flow already does). I did not take that route here because it changes the `redirect_uri` sent to providers that have a registered callback, which is a much wider blast radius than this bug warrants.