### PR TITLE
test(coding-agent): flush immediate before asserting tiny-title prewarm

### DIFF
--- a/packages/coding-agent/test/interactive-mode-title-prewarm.test.ts
+++ b/packages/coding-agent/test/interactive-mode-title-prewarm.test.ts
@@ -87,6 +87,14 @@ describe("InteractiveMode tiny-title prewarm", () => {
 		const prewarm = vi.spyOn(tinyTitleClient, "prewarm").mockImplementation(() => {});
 
 		await mode.init();
+		// The prewarm call is deferred behind a setImmediate queued during
+		// init() (see interactive-mode.ts); init()'s own awaits are promise
+		// microtasks that can resolve without yielding to the immediate
+		// queue, so the prewarm may not have fired yet when init() settles.
+		// Flush one immediate tick before asserting.
+		const immediateFlushed = Promise.withResolvers<void>();
+		setImmediate(immediateFlushed.resolve);
+		await immediateFlushed.promise;
 
 		expect(prewarm).toHaveBeenCalledWith("lfm2-350m");
 	});


### PR DESCRIPTION
## Problem

`interactive-mode-title-prewarm.test.ts` has a flaky assertion race: `InteractiveMode.init()` defers the tiny-title prewarm call behind `setImmediate` (see `modes/interactive-mode.ts`), but `init()`'s own awaits are promise microtasks that can resolve without yielding to the immediate queue. Asserting `prewarm` was called immediately after `await mode.init()` therefore depends on scheduling luck — under CI's parallel chunked load the immediate can still be pending and the test fails with "expected tinyTitleClient.prewarm to have been called, but it wasn't".

This is a re-application of the fix from 7b21716754 (which fixed CI run 30534203707 job 90843506186) that was later dropped as "unrelated" in 563f00fe31. The race is still present in main.

## Fix

Flush one `setImmediate` tick before asserting, so the assertion no longer depends on whether `init()`'s microtasks happened to yield to the check phase. Uses `Promise.withResolvers()` per AGENTS.md.

## Verification

- `bun test test/interactive-mode-title-prewarm.test.ts` — 3/3 pass
- Full coding-agent test dir — 88 pass, 0 fail
- `bun check` — TS checks all green (Rust `check:rs` fails on clean upstream main too: `audiopus_sys` build script needs system opus dev libs; unrelated to this change)