### PR TITLE
fix(build): set CMAKE_POLICY_VERSION_MINIMUM for audiopus_sys in cargo env

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+# Cargo environment for the workspace.
+#
+# audiopus_sys 0.2.2 builds its vendored Opus via the `cmake` crate, and the
+# bundled opus CMakeLists still declares `cmake_minimum_required(VERSION 3.1)`.
+# CMake 4.0 removed compatibility with < 3.5, so any dev host with a modern
+# cmake fails `cargo check`/`cargo clippy` on pi-voice with
+# "Compatibility with CMake < 3.5 has been removed from CMake." The bazel build
+# already sets this override for the same crate (see the audiopus_sys
+# annotation in MODULE.bazel); mirror it here so the cargo path works too.
+[env]
+CMAKE_POLICY_VERSION_MINIMUM = "3.5"

--- a/packages/natives/scripts/build-bindings.ts
+++ b/packages/natives/scripts/build-bindings.ts
@@ -18,11 +18,6 @@ import { generateEnumExports } from "./gen-enums";
 // static build so the local addon never retains host Homebrew paths.
 process.env.PCRE2_SYS_STATIC ??= "1";
 
-// audiopus_sys builds its bundled opus via CMake; that opus tree declares a
-// cmake_minimum_required below 3.5, which CMake 4.x refuses without this
-// policy override.
-process.env.CMAKE_POLICY_VERSION_MINIMUM ??= "3.5";
-
 // Windows: cc-rs and rustc auto-locate cl.exe/link.exe through the VS
 // registry, but the cmake crate (audiopus_sys' bundled opus) needs cmake —
 // and its Ninja generator needs ninja — on PATH. VS Build Tools ships both


### PR DESCRIPTION
## Problem

`bun check:rs` (and any `cargo check`/`cargo clippy` on the workspace) fails on dev hosts with CMake >= 4.0:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

`audiopus_sys 0.2.2` builds its vendored Opus via the `cmake` crate, and the bundled opus `CMakeLists.txt` still declares `cmake_minimum_required(VERSION 3.1)`. CMake 4.0 removed compatibility with versions < 3.5, so the build script panics on any host with a modern cmake — clean checkout of `main`, no local changes needed to reproduce.

## Fix

The bazel build already handles this: the `audiopus_sys` annotation in `MODULE.bazel` sets `CMAKE_POLICY_VERSION_MINIMUM=3.5` for the same crate. This PR mirrors that override in `.cargo/config.toml` `[env]` so the cargo path (the documented `bun check:rs` dev flow) works on CMake 4.x hosts too.

## Verification

- `cargo check -p pi-voice` with `CMAKE_POLICY_VERSION_MINIMUM` unset in the shell: passes (config env applies).
- `bun check:rs` (cargo fmt + clippy --workspace): all green.