### PR TITLE
feat(coding-agent): accept combined /shake modes in one invocation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- `/shake` now accepts multiple modes in one invocation (`/shake elide images` runs both, in the order given) plus a new `all` subcommand (images, then elide) and reports one merged summary; `image` is accepted as an alias of `images`.
+- `/shake` now accepts multiple modes in one invocation (`/shake elide images` runs both, in the order given) plus a new `all` subcommand (images, then elide) and reports one merged summary; `image` is accepted as an alias of `images`. Elide now counts image blocks embedded in the tool results it drops instead of discarding them silently; `/shake images` remains the only mode that clears user-attached images.
 
 ## [17.2.12] - 2026-08-08
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added combined `/shake` modes: `/shake elide images` runs both passes in the order given, `/shake all` runs the full cleanse (images, then elide), and `image` is accepted as an alias of `images`; one merged summary reports everything dropped ([#8102](https://github.com/can1357/oh-my-pi/issues/8102)).
+
 ### Changed
 
-- `/shake` now accepts multiple modes in one invocation (`/shake elide images` runs both, in the order given) plus a new `all` subcommand (images, then elide) and reports one merged summary; `image` is accepted as an alias of `images`. Elide now counts image blocks embedded in the tool results it drops instead of discarding them silently; `/shake images` remains the only mode that clears user-attached images.
+- `/shake elide` now counts image blocks embedded in the tool results it drops instead of discarding them silently; `/shake images` remains the only mode that clears user-attached images, and the subcommand descriptions state the split ([#8102](https://github.com/can1357/oh-my-pi/issues/8102)).
+
+### Fixed
+
+- Fixed a combined `/shake` run that fails mid-sequence leaving the TUI transcript showing content the session had already dropped; the chat now rebuilds before the error is surfaced ([#8102](https://github.com/can1357/oh-my-pi/issues/8102)).
 
 ## [17.2.12] - 2026-08-08
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `/shake` now accepts multiple modes in one invocation (`/shake elide images` runs both, in the order given) and reports one merged summary; `image` is accepted as an alias of `images`.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- `/shake` now accepts multiple modes in one invocation (`/shake elide images` runs both, in the order given) and reports one merged summary; `image` is accepted as an alias of `images`.
+- `/shake` now accepts multiple modes in one invocation (`/shake elide images` runs both, in the order given) plus a new `all` subcommand (images, then elide) and reports one merged summary; `image` is accepted as an alias of `images`.
 
 ## [17.2.12] - 2026-08-08
 

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -16,7 +16,7 @@ Press alt+p (or /switch) to switch provider, and ctrl+p to cycle role models smo
 Press ctrl+r to search your prompt history and reuse a past message
 `/force read` pins the next turn to one specific tool when the model keeps reaching for the wrong one
 `/copy code` grabs the last code block to your clipboard — `/copy cmd` grabs the last shell/python command
-`/shake` rips heavy tool results out of context to reclaim tokens without a full /compact — `/shake images` drops just images
+`/shake` rips heavy tool results out of context to reclaim tokens without a full /compact — `/shake images` drops just images, `/shake elide images` does both
 Pair up live: `/collab` shares your session through an end-to-end encrypted relay link — a teammate runs `/join <link>` to watch tool calls stream and prompt the agent from their own omp
 Press ← ← to drill into a running or finished agent and inspect its tool calls and transcript
 Hit a Codex rate limit? `/usage reset` spends a saved reset credit to immediately restore your quota

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -16,7 +16,7 @@ Press alt+p (or /switch) to switch provider, and ctrl+p to cycle role models smo
 Press ctrl+r to search your prompt history and reuse a past message
 `/force read` pins the next turn to one specific tool when the model keeps reaching for the wrong one
 `/copy code` grabs the last code block to your clipboard — `/copy cmd` grabs the last shell/python command
-`/shake` rips heavy tool results out of context to reclaim tokens without a full /compact — `/shake images` drops just images, `/shake elide images` does both
+`/shake` rips heavy tool results out of context to reclaim tokens without a full /compact — `/shake images` drops just images, `/shake all` does both
 Pair up live: `/collab` shares your session through an end-to-end encrypted relay link — a teammate runs `/join <link>` to watch tool calls stream and prompt the agent from their own omp
 Press ← ← to drill into a running or finished agent and inspect its tool calls and transcript
 Hit a Codex rate limit? `/usage reset` spends a saved reset credit to immediately restore your quota

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -16,7 +16,7 @@ Press alt+p (or /switch) to switch provider, and ctrl+p to cycle role models smo
 Press ctrl+r to search your prompt history and reuse a past message
 `/force read` pins the next turn to one specific tool when the model keeps reaching for the wrong one
 `/copy code` grabs the last code block to your clipboard — `/copy cmd` grabs the last shell/python command
-`/shake` rips heavy tool results out of context to reclaim tokens without a full /compact — `/shake images` drops just images, `/shake all` does both
+`/shake` rips heavy tool results out of context to reclaim tokens without a full /compact — `/shake images` also clears user-attached images elide can't reach, `/shake all` does both
 Pair up live: `/collab` shares your session through an end-to-end encrypted relay link — a teammate runs `/join <link>` to watch tool calls stream and prompt the agent from their own omp
 Press ← ← to drill into a running or finished agent and inspect its tool calls and transcript
 Hit a Codex rate limit? `/usage reset` spends a saved reset credit to immediately restore your quota

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1285,16 +1285,19 @@ export class CommandController {
 	/**
 	 * TUI handler for `/shake`. `elide` drops heavy structural content and
 	 * `images` strips image blocks; modes run in order when combined.
-	 * Rebuilds the chat and reports merged counts.
+	 * Rebuilds the chat and reports merged counts. A mid-sequence failure
+	 * still rebuilds first when an earlier mode already mutated the session,
+	 * so the transcript never shows content the active context dropped.
 	 */
 	async handleShakeCommand(modes: readonly ShakeMode[]): Promise<void> {
 		const results: ShakeResult[] = [];
+		let failure: string | undefined;
 		for (const mode of modes) {
 			try {
 				results.push(await this.ctx.session.shake(mode));
 			} catch (error) {
-				this.ctx.showError(`Shake failed: ${error instanceof Error ? error.message : String(error)}`);
-				return;
+				failure = error instanceof Error ? error.message : String(error);
+				break;
 			}
 		}
 
@@ -1302,13 +1305,19 @@ export class CommandController {
 			(total, result) => total + result.toolResultsDropped + result.blocksDropped + (result.imagesDropped ?? 0),
 			0,
 		);
+		if (dropped > 0) {
+			this.ctx.rebuildChatFromMessages();
+			this.ctx.statusLine.invalidate();
+			this.ctx.ui.requestRender();
+		}
+		if (failure !== undefined) {
+			this.ctx.showError(`Shake failed: ${failure}`);
+			return;
+		}
 		if (dropped === 0) {
 			this.ctx.showStatus("Nothing to shake.");
 			return;
 		}
-		this.ctx.rebuildChatFromMessages();
-		this.ctx.statusLine.invalidate();
-		this.ctx.ui.requestRender();
 		this.ctx.showStatus(formatShakeSummary(results));
 	}
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1284,18 +1284,24 @@ export class CommandController {
 
 	/**
 	 * TUI handler for `/shake`. `elide` drops heavy structural content and
-	 * `images` strips image blocks. Rebuilds the chat and reports counts.
+	 * `images` strips image blocks; modes run in order when combined.
+	 * Rebuilds the chat and reports merged counts.
 	 */
-	async handleShakeCommand(mode: ShakeMode): Promise<void> {
-		let result: ShakeResult;
-		try {
-			result = await this.ctx.session.shake(mode);
-		} catch (error) {
-			this.ctx.showError(`Shake failed: ${error instanceof Error ? error.message : String(error)}`);
-			return;
+	async handleShakeCommand(modes: readonly ShakeMode[]): Promise<void> {
+		const results: ShakeResult[] = [];
+		for (const mode of modes) {
+			try {
+				results.push(await this.ctx.session.shake(mode));
+			} catch (error) {
+				this.ctx.showError(`Shake failed: ${error instanceof Error ? error.message : String(error)}`);
+				return;
+			}
 		}
 
-		const dropped = result.toolResultsDropped + result.blocksDropped + (result.imagesDropped ?? 0);
+		const dropped = results.reduce(
+			(total, result) => total + result.toolResultsDropped + result.blocksDropped + (result.imagesDropped ?? 0),
+			0,
+		);
 		if (dropped === 0) {
 			this.ctx.showStatus("Nothing to shake.");
 			return;
@@ -1303,7 +1309,7 @@ export class CommandController {
 		this.ctx.rebuildChatFromMessages();
 		this.ctx.statusLine.invalidate();
 		this.ctx.ui.requestRender();
-		this.ctx.showStatus(formatShakeSummary(result));
+		this.ctx.showStatus(formatShakeSummary(results));
 	}
 
 	async executeCompaction(

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4692,8 +4692,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleHandoffCommand(customInstructions);
 	}
 
-	handleShakeCommand(mode: ShakeMode): Promise<void> {
-		return this.#commandController.handleShakeCommand(mode);
+	handleShakeCommand(modes: readonly ShakeMode[]): Promise<void> {
+		return this.#commandController.handleShakeCommand(modes);
 	}
 
 	executeCompaction(

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -363,7 +363,7 @@ export interface InteractiveModeContext {
 		beforeFlush?: (outcome: CompactionOutcome) => void | Promise<void>,
 	): Promise<CompactionOutcome>;
 	handleHandoffCommand(customInstructions?: string): Promise<void>;
-	handleShakeCommand(mode: ShakeMode): Promise<void>;
+	handleShakeCommand(modes: readonly ShakeMode[]): Promise<void>;
 	handleMoveCommand(targetPath?: string): Promise<void>;
 	handleRenameCommand(title: string): Promise<void>;
 	handleMemoryCommand(text: string): Promise<void>;

--- a/packages/coding-agent/src/session/session-maintenance.ts
+++ b/packages/coding-agent/src/session/session-maintenance.ts
@@ -46,7 +46,14 @@ import {
 	readToolSupersedeKey,
 } from "@oh-my-pi/pi-agent-core/compaction/pruning";
 import type { ProtectedToolMatcher } from "@oh-my-pi/pi-agent-core/compaction/tool-protection";
-import type { AssistantMessage, CodexCompactionContext, Message, Model, ProviderSessionState } from "@oh-my-pi/pi-ai";
+import type {
+	AssistantMessage,
+	CodexCompactionContext,
+	Message,
+	Model,
+	ProviderSessionState,
+	ToolResultMessage,
+} from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
@@ -450,6 +457,9 @@ export class SessionMaintenance {
 	 * - `images` delegates to {@link dropImages}.
 	 * - `elide` replaces whole tool-call results and large fenced/XML blocks
 	 *   with short placeholders that embed an `artifact://` recovery link.
+	 *   Image blocks inside a dropped tool result go with it and are counted
+	 *   in `imagesDropped`; user-message images are only reachable via
+	 *   `images` mode.
 	 *
 	 * Mutates the branch in place, persists via `rewriteEntries`, replays the
 	 * rebuilt context through the agent, and tears down provider sessions that
@@ -500,12 +510,25 @@ export class SessionMaintenance {
 
 		let toolResultsDropped = 0;
 		let blocksDropped = 0;
+		let imagesDropped = 0;
 		let originalTokens = 0;
 		let replacementTokens = 0;
 		let anchoredTokensRemoved = 0;
+		const countedEntries = new Set<SessionEntry>();
 		const items = regions.map((region, index) => {
-			if (region.kind === "toolResult") toolResultsDropped++;
-			else blocksDropped++;
+			if (region.kind === "toolResult") {
+				toolResultsDropped++;
+				// Replacing the whole tool result discards any image blocks it
+				// carried; count them so the summary reports what actually left.
+				if (!countedEntries.has(region.entry)) {
+					countedEntries.add(region.entry);
+					// kind === "toolResult" guarantees the message shape (same cast applyShakeRegion relies on).
+					const toolResult = region.entry.message as ToolResultMessage;
+					for (const block of toolResult.content) {
+						if (block.type === "image") imagesDropped++;
+					}
+				}
+			} else blocksDropped++;
 			originalTokens += region.tokens;
 			const replacement = replacements[index];
 			const replacementTokenCount = replacement.length > 0 ? countTokens(replacement) : 0;
@@ -534,6 +557,7 @@ export class SessionMaintenance {
 			mode,
 			toolResultsDropped,
 			blocksDropped,
+			imagesDropped,
 			tokensFreed: Math.max(0, originalTokens - replacementTokens),
 			artifactId,
 		};

--- a/packages/coding-agent/src/session/shake-types.ts
+++ b/packages/coding-agent/src/session/shake-types.ts
@@ -23,21 +23,29 @@ export interface ShakeResult {
 	artifactId?: string;
 }
 
-/** One-line operator summary of a {@link ShakeResult} (shared by TUI + ACP). */
-export function formatShakeSummary(result: ShakeResult): string {
-	if (result.mode === "images") {
-		const n = result.imagesDropped ?? 0;
-		return n === 0
+/** One-line operator summary of one `/shake` run's {@link ShakeResult}s (shared by TUI + ACP). */
+export function formatShakeSummary(results: readonly ShakeResult[]): string {
+	let toolResults = 0;
+	let blocks = 0;
+	let images = 0;
+	let tokensFreed = 0;
+	let ranElide = false;
+	for (const result of results) {
+		toolResults += result.toolResultsDropped;
+		blocks += result.blocksDropped;
+		images += result.imagesDropped ?? 0;
+		tokensFreed += result.tokensFreed;
+		if (result.mode === "elide") ranElide = true;
+	}
+	if (!ranElide) {
+		return images === 0
 			? "No images found in this session."
-			: `Dropped ${n} image${n === 1 ? "" : "s"} from this session.`;
+			: `Dropped ${images} image${images === 1 ? "" : "s"} from this session.`;
 	}
 	const parts: string[] = [];
-	if (result.toolResultsDropped > 0) {
-		parts.push(`${result.toolResultsDropped} tool result${result.toolResultsDropped === 1 ? "" : "s"}`);
-	}
-	if (result.blocksDropped > 0) {
-		parts.push(`${result.blocksDropped} block${result.blocksDropped === 1 ? "" : "s"}`);
-	}
+	if (toolResults > 0) parts.push(`${toolResults} tool result${toolResults === 1 ? "" : "s"}`);
+	if (blocks > 0) parts.push(`${blocks} block${blocks === 1 ? "" : "s"}`);
+	if (images > 0) parts.push(`${images} image${images === 1 ? "" : "s"}`);
 	if (parts.length === 0) return "Nothing to shake.";
-	return `Shook ${parts.join(" + ")} (~${result.tokensFreed} tokens freed).`;
+	return `Shook ${parts.join(" + ")} (~${tokensFreed} tokens freed).`;
 }

--- a/packages/coding-agent/src/session/shake-types.ts
+++ b/packages/coding-agent/src/session/shake-types.ts
@@ -15,7 +15,7 @@ export interface ShakeResult {
 	toolResultsDropped: number;
 	/** Large fenced/XML blocks dropped. */
 	blocksDropped: number;
-	/** Image blocks removed (images mode only). */
+	/** Image blocks removed — by images mode, or embedded in elide-dropped tool results. */
 	imagesDropped?: number;
 	/** Estimated context tokens reclaimed. */
 	tokensFreed: number;

--- a/packages/coding-agent/src/session/shake-types.ts
+++ b/packages/coding-agent/src/session/shake-types.ts
@@ -37,15 +37,13 @@ export function formatShakeSummary(results: readonly ShakeResult[]): string {
 		tokensFreed += result.tokensFreed;
 		if (result.mode === "elide") ranElide = true;
 	}
-	if (!ranElide) {
-		return images === 0
-			? "No images found in this session."
-			: `Dropped ${images} image${images === 1 ? "" : "s"} from this session.`;
+	if (toolResults === 0 && blocks === 0) {
+		if (images > 0) return `Dropped ${images} image${images === 1 ? "" : "s"} from this session.`;
+		return ranElide ? "Nothing to shake." : "No images found in this session.";
 	}
 	const parts: string[] = [];
 	if (toolResults > 0) parts.push(`${toolResults} tool result${toolResults === 1 ? "" : "s"}`);
 	if (blocks > 0) parts.push(`${blocks} block${blocks === 1 ? "" : "s"}`);
 	if (images > 0) parts.push(`${images} image${images === 1 ? "" : "s"}`);
-	if (parts.length === 0) return "Nothing to shake.";
 	return `Shook ${parts.join(" + ")} (~${tokensFreed} tokens freed).`;
 }

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -198,7 +198,17 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 			const modes = parseShakeModes(command.args);
 			if (!Array.isArray(modes)) return usage(modes.error, runtime);
 			const results: ShakeResult[] = [];
-			for (const mode of modes) results.push(await runtime.session.shake(mode));
+			for (const mode of modes) {
+				try {
+					results.push(await runtime.session.shake(mode));
+				} catch (error) {
+					// Earlier modes already mutated and persisted the session;
+					// report that state change before surfacing the failure so
+					// the client never assumes nothing happened.
+					if (results.length > 0) await runtime.output(formatShakeSummary(results));
+					throw error;
+				}
+			}
 			await runtime.output(formatShakeSummary(results));
 			return commandConsumed();
 		},

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -35,8 +35,9 @@ export const shutdownHandlerTui = (
 /**
  * Parse `/shake` args into one or more {@link ShakeMode}s; empty defaults to
  * elide. Modes combine (`/shake elide images`), run in the order given, and
- * duplicates collapse. `all` expands to images-then-elide: stripping image
- * blocks first counts them before elide swallows whole tool results.
+ * duplicates collapse. `all` expands to images-then-elide. Only images mode
+ * reaches user-attached images; elide takes tool-result images with the
+ * results it drops and reports them.
  */
 function parseShakeModes(args: string): ShakeMode[] | { error: string } {
 	const verbs = args.trim().toLowerCase().split(/\s+/).filter(Boolean);
@@ -187,8 +188,8 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		description: "Drop heavy content from context (tool results, large blocks)",
 		acpDescription: "Shake heavy content out of the conversation context",
 		subcommands: [
-			{ name: "elide", description: "Strip tool results + large blocks (default)" },
-			{ name: "images", description: "Strip image blocks" },
+			{ name: "elide", description: "Strip tool results + large blocks, embedded images included (default)" },
+			{ name: "images", description: "Strip all image blocks, including user-attached ones elide never touches" },
 			{ name: "all", description: "Strip images, then elide" },
 		],
 		acpInputHint: "[elide|images|all ...]",

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -6,7 +6,7 @@ import { memoryStatsUnavailableMessage, resolveMemoryBackend } from "../memory-b
 import type { FreshSessionResult } from "../session/agent-session";
 import { COMPACT_MODES, parseCompactArgs } from "../session/compact-modes";
 import { resolveResumableSession } from "../session/session-listing";
-import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
+import { formatShakeSummary, type ShakeMode, type ShakeResult } from "../session/shake-types";
 import { resolveToCwd } from "../tools/path-utils";
 import { commandConsumed, errorMessage, usage } from "./helpers/parse";
 import { handleSshAcp } from "./helpers/ssh";
@@ -32,12 +32,21 @@ export const shutdownHandlerTui = (
 	return commandConsumed();
 };
 
-/** Parse the `/shake` subcommand into a {@link ShakeMode}; empty defaults to elide. */
-function parseShakeMode(args: string): ShakeMode | { error: string } {
-	const verb = args.trim().toLowerCase();
-	if (verb === "" || verb === "elide") return "elide";
-	if (verb === "images") return "images";
-	return { error: `Unknown /shake mode "${verb}". Use elide or images.` };
+/**
+ * Parse `/shake` args into one or more {@link ShakeMode}s; empty defaults to
+ * elide. Modes combine (`/shake elide images`), run in the order given, and
+ * duplicates collapse.
+ */
+function parseShakeModes(args: string): ShakeMode[] | { error: string } {
+	const verbs = args.trim().toLowerCase().split(/\s+/).filter(Boolean);
+	if (verbs.length === 0) return ["elide"];
+	const modes: ShakeMode[] = [];
+	for (const verb of verbs) {
+		const mode = verb === "elide" ? "elide" : verb === "images" || verb === "image" ? "images" : undefined;
+		if (!mode) return { error: `Unknown /shake mode "${verb}". Use elide, images, or both.` };
+		if (!modes.includes(mode)) modes.push(mode);
+	}
+	return modes;
 }
 
 /** Format the session's workspace directories (cwd + additional) for display. */
@@ -174,23 +183,24 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 			{ name: "elide", description: "Strip tool results + large blocks (default)" },
 			{ name: "images", description: "Strip image blocks" },
 		],
-		acpInputHint: "[elide|images]",
+		acpInputHint: "[elide|images ...]",
 		allowArgs: true,
 		handle: async (command, runtime) => {
-			const mode = parseShakeMode(command.args);
-			if (typeof mode !== "string") return usage(mode.error, runtime);
-			const result = await runtime.session.shake(mode);
-			await runtime.output(formatShakeSummary(result));
+			const modes = parseShakeModes(command.args);
+			if (!Array.isArray(modes)) return usage(modes.error, runtime);
+			const results: ShakeResult[] = [];
+			for (const mode of modes) results.push(await runtime.session.shake(mode));
+			await runtime.output(formatShakeSummary(results));
 			return commandConsumed();
 		},
 		handleTui: async (command, runtime) => {
 			runtime.ctx.editor.setText("");
-			const mode = parseShakeMode(command.args);
-			if (typeof mode !== "string") {
-				runtime.ctx.showWarning(mode.error);
+			const modes = parseShakeModes(command.args);
+			if (!Array.isArray(modes)) {
+				runtime.ctx.showWarning(modes.error);
 				return;
 			}
-			await runtime.ctx.handleShakeCommand(mode);
+			await runtime.ctx.handleShakeCommand(modes);
 		},
 	},
 	{

--- a/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-lifecycle.ts
@@ -35,16 +35,23 @@ export const shutdownHandlerTui = (
 /**
  * Parse `/shake` args into one or more {@link ShakeMode}s; empty defaults to
  * elide. Modes combine (`/shake elide images`), run in the order given, and
- * duplicates collapse.
+ * duplicates collapse. `all` expands to images-then-elide: stripping image
+ * blocks first counts them before elide swallows whole tool results.
  */
 function parseShakeModes(args: string): ShakeMode[] | { error: string } {
 	const verbs = args.trim().toLowerCase().split(/\s+/).filter(Boolean);
 	if (verbs.length === 0) return ["elide"];
 	const modes: ShakeMode[] = [];
-	for (const verb of verbs) {
-		const mode = verb === "elide" ? "elide" : verb === "images" || verb === "image" ? "images" : undefined;
-		if (!mode) return { error: `Unknown /shake mode "${verb}". Use elide, images, or both.` };
+	const add = (mode: ShakeMode) => {
 		if (!modes.includes(mode)) modes.push(mode);
+	};
+	for (const verb of verbs) {
+		if (verb === "elide") add("elide");
+		else if (verb === "images" || verb === "image") add("images");
+		else if (verb === "all") {
+			add("images");
+			add("elide");
+		} else return { error: `Unknown /shake mode "${verb}". Use elide, images, all, or a combination.` };
 	}
 	return modes;
 }
@@ -182,8 +189,9 @@ export const BUILTIN_LIFECYCLE_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpec> =
 		subcommands: [
 			{ name: "elide", description: "Strip tool results + large blocks (default)" },
 			{ name: "images", description: "Strip image blocks" },
+			{ name: "all", description: "Strip images, then elide" },
 		],
-		acpInputHint: "[elide|images ...]",
+		acpInputHint: "[elide|images|all ...]",
 		allowArgs: true,
 		handle: async (command, runtime) => {
 			const modes = parseShakeModes(command.args);

--- a/packages/coding-agent/test/modes/controllers/shake-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/shake-command.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "bun:test";
+import { CommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { ShakeMode, ShakeResult } from "@oh-my-pi/pi-coding-agent/session/shake-types";
+
+function createShakeContext(shake: (mode: ShakeMode) => Promise<ShakeResult>) {
+	const shakeMock = vi.fn(shake);
+	const rebuildChatFromMessages = vi.fn();
+	const invalidate = vi.fn();
+	const requestRender = vi.fn();
+	const showStatus = vi.fn();
+	const showError = vi.fn();
+	const ctx = {
+		session: { shake: shakeMock },
+		rebuildChatFromMessages,
+		statusLine: { invalidate },
+		ui: { requestRender },
+		showStatus,
+		showError,
+	} as unknown as InteractiveModeContext;
+	return { ctx, shake: shakeMock, rebuildChatFromMessages, showStatus, showError };
+}
+
+function elideResult(): ShakeResult {
+	return { mode: "elide", toolResultsDropped: 2, blocksDropped: 1, tokensFreed: 500 };
+}
+
+describe("handleShakeCommand (combined modes)", () => {
+	it("runs modes in order, rebuilds once, and reports one merged summary", async () => {
+		const h = createShakeContext(async mode =>
+			mode === "elide"
+				? elideResult()
+				: { mode, toolResultsDropped: 0, blocksDropped: 0, imagesDropped: 3, tokensFreed: 0 },
+		);
+		await new CommandController(h.ctx).handleShakeCommand(["elide", "images"]);
+
+		expect(h.shake.mock.calls.map(c => c[0])).toEqual(["elide", "images"]);
+		expect(h.rebuildChatFromMessages).toHaveBeenCalledTimes(1);
+		expect(h.showStatus).toHaveBeenCalledWith("Shook 2 tool results + 1 block + 3 images (~500 tokens freed).");
+		expect(h.showError).not.toHaveBeenCalled();
+	});
+
+	it("rebuilds the chat before surfacing a mid-sequence failure when an earlier mode already mutated the session", async () => {
+		const h = createShakeContext(async mode => {
+			if (mode === "elide") return elideResult();
+			throw new Error("persistence rewrite failed");
+		});
+		await new CommandController(h.ctx).handleShakeCommand(["elide", "images"]);
+
+		expect(h.rebuildChatFromMessages).toHaveBeenCalledTimes(1);
+		expect(h.showError).toHaveBeenCalledWith("Shake failed: persistence rewrite failed");
+		expect(h.showStatus).not.toHaveBeenCalled();
+	});
+
+	it("skips the rebuild when the failing mode was the first to run", async () => {
+		const h = createShakeContext(async () => {
+			throw new Error("boom");
+		});
+		await new CommandController(h.ctx).handleShakeCommand(["elide", "images"]);
+
+		expect(h.shake).toHaveBeenCalledTimes(1);
+		expect(h.rebuildChatFromMessages).not.toHaveBeenCalled();
+		expect(h.showError).toHaveBeenCalledWith("Shake failed: boom");
+	});
+
+	it("reports nothing to shake without rebuilding when no mode dropped content", async () => {
+		const h = createShakeContext(async mode => ({
+			mode,
+			toolResultsDropped: 0,
+			blocksDropped: 0,
+			imagesDropped: mode === "images" ? 0 : undefined,
+			tokensFreed: 0,
+		}));
+		await new CommandController(h.ctx).handleShakeCommand(["elide", "images"]);
+
+		expect(h.rebuildChatFromMessages).not.toHaveBeenCalled();
+		expect(h.showStatus).toHaveBeenCalledWith("Nothing to shake.");
+	});
+});

--- a/packages/coding-agent/test/shake.test.ts
+++ b/packages/coding-agent/test/shake.test.ts
@@ -242,6 +242,44 @@ describe("AgentSession shake", () => {
 			expect(result.blocksDropped).toBe(0);
 			expect(result.tokensFreed).toBe(0);
 		});
+
+		it("counts image blocks embedded in dropped tool results", async () => {
+			const toolCallId = `call_read_${Math.random().toString(36).slice(2)}`;
+			sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "read the diagram" }],
+				timestamp: Date.now() - 3,
+			});
+			sessionManager.appendMessage({
+				role: "assistant",
+				content: [
+					{ type: "text", text: "reading" },
+					{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: "diagram.png" } },
+				],
+				...apiInfo,
+				stopReason: "toolUse",
+				usage,
+				timestamp: Date.now() - 2,
+			});
+			sessionManager.appendMessage({
+				role: "toolResult",
+				toolCallId,
+				toolName: "read",
+				content: [
+					{ type: "text", text: "D".repeat(4000) },
+					{ type: "image", data: "iVBORw0KGgo", mimeType: "image/png" } satisfies ImageContent,
+				],
+				isError: false,
+				timestamp: Date.now() - 1,
+			});
+
+			const result = await session.shake("elide");
+
+			expect(result.toolResultsDropped).toBe(1);
+			expect(result.imagesDropped).toBe(1);
+			const blockTypes = branchToolResults().flatMap(m => m.content.map(c => c.type));
+			expect(blockTypes).not.toContain("image");
+		});
 	});
 
 	describe("images", () => {

--- a/packages/coding-agent/test/slash-commands/shake.test.ts
+++ b/packages/coding-agent/test/slash-commands/shake.test.ts
@@ -64,6 +64,12 @@ describe("/shake dispatch (ACP)", () => {
 		expect(h.shake.mock.calls.map(c => c[0])).toEqual(["images", "elide"]);
 	});
 
+	it("expands all to images-then-elide", async () => {
+		const h = acpRuntime();
+		await executeAcpBuiltinSlashCommand("/shake all", h.runtime);
+		expect(h.shake.mock.calls.map(c => c[0])).toEqual(["images", "elide"]);
+	});
+
 	it("rejects an unknown mode without invoking shake", async () => {
 		const h = acpRuntime();
 		const result = await executeAcpBuiltinSlashCommand("/shake bogus", h.runtime);
@@ -75,7 +81,7 @@ describe("/shake dispatch (ACP)", () => {
 	it("is advertised to ACP clients with the mode hint", () => {
 		const advertised = ACP_BUILTIN_SLASH_COMMANDS.find(c => c.name === "shake");
 		expect(advertised).toBeDefined();
-		expect(advertised?.input?.hint).toBe("[elide|images ...]");
+		expect(advertised?.input?.hint).toBe("[elide|images|all ...]");
 	});
 
 	it("advertises /shake images as the image-stripping path and no longer advertises /drop-images", () => {

--- a/packages/coding-agent/test/slash-commands/shake.test.ts
+++ b/packages/coding-agent/test/slash-commands/shake.test.ts
@@ -8,14 +8,17 @@ import {
 import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-commands/types";
 
-function acpRuntime() {
-	const shake = vi.fn(async (mode: ShakeMode) => ({
-		mode,
-		toolResultsDropped: mode === "elide" ? 1 : 0,
-		blocksDropped: 0,
-		imagesDropped: mode === "images" ? 1 : undefined,
-		tokensFreed: mode === "elide" ? 100 : 0,
-	}));
+function acpRuntime(shakeImpl?: (mode: ShakeMode) => Promise<unknown>) {
+	const shake = vi.fn(
+		shakeImpl ??
+			(async (mode: ShakeMode) => ({
+				mode,
+				toolResultsDropped: mode === "elide" ? 1 : 0,
+				blocksDropped: 0,
+				imagesDropped: mode === "images" ? 1 : undefined,
+				tokensFreed: mode === "elide" ? 100 : 0,
+			})),
+	);
 	const output = vi.fn();
 	const runtime = { session: { shake }, output } as unknown as SlashCommandRuntime;
 	return { shake, output, runtime };
@@ -68,6 +71,37 @@ describe("/shake dispatch (ACP)", () => {
 		const h = acpRuntime();
 		await executeAcpBuiltinSlashCommand("/shake all", h.runtime);
 		expect(h.shake.mock.calls.map(c => c[0])).toEqual(["images", "elide"]);
+	});
+
+	it("keeps the image-only wording when all drops images but nothing elidable", async () => {
+		const h = acpRuntime(async (mode: ShakeMode) => ({
+			mode,
+			toolResultsDropped: 0,
+			blocksDropped: 0,
+			imagesDropped: mode === "images" ? 1 : 0,
+			tokensFreed: 0,
+		}));
+		await executeAcpBuiltinSlashCommand("/shake all", h.runtime);
+		expect(h.output).toHaveBeenCalledWith("Dropped 1 image from this session.");
+	});
+
+	it("reports completed modes before surfacing a mid-sequence failure", async () => {
+		const h = acpRuntime(async (mode: ShakeMode) => {
+			if (mode === "elide") throw new Error("persistence rewrite failed");
+			return { mode, toolResultsDropped: 0, blocksDropped: 0, imagesDropped: 2, tokensFreed: 0 };
+		});
+		await expect(executeAcpBuiltinSlashCommand("/shake images elide", h.runtime)).rejects.toThrow(
+			"persistence rewrite failed",
+		);
+		expect(h.output).toHaveBeenCalledWith("Dropped 2 images from this session.");
+	});
+
+	it("does not report partial state when the first mode fails", async () => {
+		const h = acpRuntime(async () => {
+			throw new Error("boom");
+		});
+		await expect(executeAcpBuiltinSlashCommand("/shake elide images", h.runtime)).rejects.toThrow("boom");
+		expect(h.output).not.toHaveBeenCalled();
 	});
 
 	it("rejects an unknown mode without invoking shake", async () => {

--- a/packages/coding-agent/test/slash-commands/shake.test.ts
+++ b/packages/coding-agent/test/slash-commands/shake.test.ts
@@ -11,10 +11,10 @@ import type { SlashCommandRuntime } from "@oh-my-pi/pi-coding-agent/slash-comman
 function acpRuntime() {
 	const shake = vi.fn(async (mode: ShakeMode) => ({
 		mode,
-		toolResultsDropped: 1,
+		toolResultsDropped: mode === "elide" ? 1 : 0,
 		blocksDropped: 0,
 		imagesDropped: mode === "images" ? 1 : undefined,
-		tokensFreed: 100,
+		tokensFreed: mode === "elide" ? 100 : 0,
 	}));
 	const output = vi.fn();
 	const runtime = { session: { shake }, output } as unknown as SlashCommandRuntime;
@@ -46,8 +46,22 @@ describe("/shake dispatch (ACP)", () => {
 		for (const mode of ["elide", "images"] as const) {
 			const h = acpRuntime();
 			await executeAcpBuiltinSlashCommand(`/shake ${mode}`, h.runtime);
+			expect(h.shake).toHaveBeenCalledTimes(1);
 			expect(h.shake).toHaveBeenCalledWith(mode);
 		}
+	});
+
+	it("runs combined modes in the order given and reports one merged summary", async () => {
+		const h = acpRuntime();
+		await executeAcpBuiltinSlashCommand("/shake elide images", h.runtime);
+		expect(h.shake.mock.calls.map(c => c[0])).toEqual(["elide", "images"]);
+		expect(h.output).toHaveBeenCalledWith("Shook 1 tool result + 1 image (~100 tokens freed).");
+	});
+
+	it("accepts the singular image alias and collapses duplicate modes", async () => {
+		const h = acpRuntime();
+		await executeAcpBuiltinSlashCommand("/shake image images elide elide", h.runtime);
+		expect(h.shake.mock.calls.map(c => c[0])).toEqual(["images", "elide"]);
 	});
 
 	it("rejects an unknown mode without invoking shake", async () => {
@@ -61,7 +75,7 @@ describe("/shake dispatch (ACP)", () => {
 	it("is advertised to ACP clients with the mode hint", () => {
 		const advertised = ACP_BUILTIN_SLASH_COMMANDS.find(c => c.name === "shake");
 		expect(advertised).toBeDefined();
-		expect(advertised?.input?.hint).toBe("[elide|images]");
+		expect(advertised?.input?.hint).toBe("[elide|images ...]");
 	});
 
 	it("advertises /shake images as the image-stripping path and no longer advertises /drop-images", () => {
@@ -71,18 +85,24 @@ describe("/shake dispatch (ACP)", () => {
 });
 
 describe("/shake dispatch (TUI)", () => {
-	it("routes the parsed mode to handleShakeCommand and clears the editor", async () => {
+	it("routes the parsed modes to handleShakeCommand and clears the editor", async () => {
 		const h = tuiRuntime();
 		const handled = await executeBuiltinSlashCommand("/shake images", h.runtime);
 		expect(handled).toBe(true);
 		expect(h.setText).toHaveBeenCalledWith("");
-		expect(h.handleShakeCommand).toHaveBeenCalledWith("images");
+		expect(h.handleShakeCommand).toHaveBeenCalledWith(["images"]);
+	});
+
+	it("routes combined modes as one call", async () => {
+		const h = tuiRuntime();
+		await executeBuiltinSlashCommand("/shake elide images", h.runtime);
+		expect(h.handleShakeCommand).toHaveBeenCalledWith(["elide", "images"]);
 	});
 
 	it("defaults to elide for a bare /shake", async () => {
 		const h = tuiRuntime();
 		await executeBuiltinSlashCommand("/shake", h.runtime);
-		expect(h.handleShakeCommand).toHaveBeenCalledWith("elide");
+		expect(h.handleShakeCommand).toHaveBeenCalledWith(["elide"]);
 	});
 
 	it("warns on an unknown mode and does not run a shake", async () => {


### PR DESCRIPTION
Closes #8102.

hi there, got a little carried away with the contribution path, and had the agent read prior to me. wont happen again.
well here we are.

I made this because I found myself constantly running both /shake [elide images] constantly.

I don't like typing fewer commands = happy
I didn't like the docs or messages output by elide because it led to a fundamental misunderstanding of how the tool worked and what it did, so I fixed them = happy.

I tried to emulate the house style in the code. I hope this is helpful to others as it is now to me

## What

`/shake` accepted exactly one mode per invocation, and the two modes' division of labor was invisible: elide silently discarded image blocks embedded in the tool results it dropped, so `/shake images` afterwards printed `Nothing to shake.` and read as broken. This PR makes the modes combinable and the accounting honest:

- **Combined modes.** `parseShakeModes` (was `parseShakeMode`) parses ordered, deduplicated modes; bare `/shake` keeps its elide-only meaning (auto-shake rescue paths call `shake("elide")` internally, so the default's blast radius is unchanged). `image` is accepted as an alias of `images`, and a new `all` subcommand expands to images-then-elide.
- **Elide reports the images it drops.** Replacing a whole tool result already discarded any embedded image blocks on `main` — silently. Elide now counts them into `ShakeResult.imagesDropped`, so the summary says what actually left: `Shook 3 tool results + 1 image (~27764 tokens freed).` The split is now stated where users see it: `images` is the only mode that reaches user-attached images; elide takes tool-result images with the results it drops.
- **One merged summary.** `formatShakeSummary` takes `readonly ShakeResult[]` and folds all counts into one sentence; single-mode images wording is unchanged.
- **Partial-failure honesty.** ACP: a mid-sequence failure reports the completed modes via `runtime.output` before rethrowing, so clients never assume nothing changed. TUI: `handleShakeCommand` takes `readonly ShakeMode[]`; a mid-sequence failure rebuilds the chat first whenever an earlier mode already mutated the session, so the transcript never shows content the active context dropped.
- Subcommand descriptions, ACP hint (`[elide|images|all ...]`), tip line, and changelog updated to state the elide/images split explicitly.

Core `AgentSession.shake` stays single-mode; auto-shake/rescue paths are untouched apart from the added image count in elide results.

## Verification

- `bun run check` (biome + tsgo) — exit 0.
- `bun test test/shake.test.ts test/slash-commands/shake.test.ts test/modes/controllers/shake-command.test.ts` — 37 pass, 0 fail. New coverage: combined-order dispatch, merged summary text, alias + dedupe, `all` expansion, elide counting embedded images (block gone from the branch, `imagesDropped === 1`), the partial-failure rebuild contract (rebuild before `showError` when an earlier mode mutated the session; no rebuild when the first mode fails), the ACP partial-failure report (completed modes surfaced via output before the error rethrows; nothing reported when the first mode fails), and image-only wording for `/shake all` when nothing elidable dropped.
- Live TUI from this branch against a fixture session holding three fat `read` results (one with an embedded image) plus a user-attached image:
  - `/shake elide` → `Shook 3 tool results + 1 image (~27764 tokens freed).` — embedded image reported, user-attached image untouched
  - `/shake images` (after elide) → `Dropped 1 image from this session.` — the image only this mode can reach
  - `/shake all` on a fresh copy → `Shook 3 tool results + 2 images (~26565 tokens freed).`
  - `/shake elide bogus` → `Warning: Unknown /shake mode "bogus". Use elide, images, all, or a combination.` with no shake executed.
