### PR TITLE
feat(advisor): add dynamic model map support to WATCHDOG.yml advisor roster

### DIFF
--- a/docs/advisor-watchdog.md
+++ b/docs/advisor-watchdog.md
@@ -284,7 +284,22 @@ Fields:
 - `instructions` (top level): shared prompt prepended to every advisor's system prompt alongside `WATCHDOG.md`. Concatenated across all discovered `WATCHDOG.yml` files.
 - `advisors[].name`: human label; slugified for the session id and its `__advisor.<slug>.jsonl` filename. Duplicate slugs across files are resolved by the same specificity rule as `WATCHDOG.md` discovery (project leaf > project ancestor > user).
 - `advisors[].enabled`: optional per-advisor switch, default `true`. `false` leaves the advisor visible as paused in status/configuration.
-- `advisors[].model`: optional model selector with optional `:level` thinking suffix (e.g. `x-ai/grok-code-fast:high`). Omitted → the advisor uses `modelRoles.advisor`.
+- `advisors[].model`: optional model selector, or a **dynamic model map** that selects the model based on the primary session's driving model.
+
+  **Static selector** (string):
+  ```
+  model: anthropic/claude-sonnet-4-5:medium
+  ```
+  A model selector with optional `:level` thinking suffix (e.g. `x-ai/grok-code-fast:high`). Omitted → the advisor uses `modelRoles.advisor`.
+
+  **Dynamic model map** (mapping):
+  ```yaml
+  model:
+    "anthropic/claude-sonnet-4-5": anthropic/claude-terra-6|deepseek/deepseek-v4-flash
+    "anthropic/claude-terra-6": anthropic/claude-sonnet-4-5|deepseek/deepseek-v4-flash
+    default: deepseek/deepseek-v4-flash
+  ```
+  Keys are model patterns matched against the primary session's driving model (exact `provider/id` match first, then model-resolver pattern resolution). The value for the matching key becomes this advisor's model selector — it supports fallback chains (`|`) and thinking suffixes just like a static selector. The `default` key is used when no other key matches, or before a driving model is set. If no key matches and no `default` exists, the advisor reports `no_model`.
 - `advisors[].tools`: optional list of built-in tool names to grant. Omitted → the default `read`/`grep`/`glob` subset; explicit `[]` → no investigative tools. Any name in [`BUILTIN_TOOL_NAMES`](../packages/coding-agent/src/tools/builtin-names.ts) is accepted, including mutating tools. Legacy aliases (`search`→`grep`, `find`→`glob`) are normalized. Unknown names are dropped with a warning; if that leaves a nonempty input with no valid names, the implementation currently treats the result as omitted and uses the default subset.
 - `advisors[].instructions`: this advisor's specialization, appended after the shared baseline. Both instruction fields expand `@path` imports like `WATCHDOG.md`.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added dynamic model map support to `WATCHDOG.yml` advisor roster entries. The `model` field now accepts a `Record<string, string>` mapping keyed by primary driving model pattern (e.g. `"anthropic/claude-sonnet-4-5": ...`) with a `default` fallback, enabling advisors to automatically switch models when the user changes their driving model.
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/advisor/config.ts
+++ b/packages/coding-agent/src/advisor/config.ts
@@ -39,8 +39,9 @@ export interface AdvisorConfig {
 
 /**
  * Format an advisor's model field for display. A static string is shown
- * verbatim; a dynamic map is shown as a summary of its keys. Returns the
- * fallback when the field is absent or empty.
+ * verbatim; a dynamic map is shown as a summary of its keyed patterns
+ * (excluding the `default` fallback). Returns the fallback when the field
+ * is absent or empty.
  */
 export function formatAdvisorModel(
 	model: string | DynamicAdvisorModelMap | undefined,
@@ -51,18 +52,20 @@ export function formatAdvisorModel(
 		const trimmed = model.trim();
 		return trimmed || fallback;
 	}
-	const keys = Object.keys(model);
+	const keys = Object.keys(model).filter(k => k !== "default");
 	if (keys.length === 0) return fallback;
-	// Show "dynamic (n entries)" for maps
 	return `dynamic (${keys.length} pattern${keys.length === 1 ? "" : "s"})`;
 }
 
 /**
  * Whether the model field contains a reference to a specific provider/id pair
  * (i.e. it includes a `/` character). Only meaningful for string model
- * selectors; dynamic maps always return false.
+ * selectors; dynamic maps always return false. Acts as a type guard:
+ * when this returns true, the model is known to be a string.
  */
-export function advisorModelHasSlashSeparator(model: string | DynamicAdvisorModelMap | undefined): boolean {
+export function advisorModelHasSlashSeparator(
+	model: string | DynamicAdvisorModelMap | undefined,
+): model is string {
 	if (typeof model !== "string") return false;
 	return model.includes("/");
 }

--- a/packages/coding-agent/src/advisor/config.ts
+++ b/packages/coding-agent/src/advisor/config.ts
@@ -8,24 +8,63 @@ import { BUILTIN_TOOL_NAMES, normalizeToolNames } from "../tools/builtin-names";
 import { collectConfigCandidates } from "./watchdog";
 
 /**
- * One advisor declared in a `WATCHDOG.yml` file. `model` is a model selector
- * with an optional `:level` thinking suffix (e.g. `x-ai/grok-code-fast:high`),
- * resolved exactly like any other model override; `tools` is a subset of
- * `BUILTIN_TOOL_NAMES` — any built-in name, including mutating tools such as
- * `edit`/`write`/`bash` (the advisor is a full agent). Omitted falls back to
- * the default `read`/`grep`/`glob` subset; an explicit empty list grants no
- * tools. `instructions` is the advisor's specialization, appended to the shared
- * baseline.
+ * A map from primary-model pattern to advisor-model selector for dynamic model
+ * assignment. Keys are model patterns (e.g. `anthropic/claude-sonnet-4-5`),
+ * values are model selectors with optional `:level` suffix. The `default` key
+ * serves as the fallback when no other key matches the primary session model.
+ */
+export type DynamicAdvisorModelMap = Record<string, string>;
+
+/**
+ * One advisor declared in a `WATCHDOG.yml` file. `model` is either a static
+ * model selector with an optional `:level` thinking suffix (e.g.
+ * `x-ai/grok-code-fast:high`), or a {@link DynamicAdvisorModelMap} that selects
+ * the model based on the primary session's driving model. Resolved exactly like
+ * any other model override; `tools` is a subset of `BUILTIN_TOOL_NAMES` — any
+ * built-in name, including mutating tools such as `edit`/`write`/`bash` (the
+ * advisor is a full agent). Omitted falls back to the default `read`/`grep`/`glob`
+ * subset; an explicit empty list grants no tools. `instructions` is the advisor's
+ * specialization, appended to the shared baseline.
  */
 export interface AdvisorConfig {
 	name: string;
-	model?: string;
+	model?: string | DynamicAdvisorModelMap;
 	tools?: string[];
 	instructions?: string;
 	/** Per-advisor on/off toggle (default `true`). When `false`, the advisor
 	 *  stays in the roster but its runtime is never built — it shows `○` in
 	 *  the status line and `/advisor status` rather than disappearing. */
 	enabled?: boolean;
+}
+
+/**
+ * Format an advisor's model field for display. A static string is shown
+ * verbatim; a dynamic map is shown as a summary of its keys. Returns the
+ * fallback when the field is absent or empty.
+ */
+export function formatAdvisorModel(
+	model: string | DynamicAdvisorModelMap | undefined,
+	fallback: string,
+): string {
+	if (!model) return fallback;
+	if (typeof model === "string") {
+		const trimmed = model.trim();
+		return trimmed || fallback;
+	}
+	const keys = Object.keys(model);
+	if (keys.length === 0) return fallback;
+	// Show "dynamic (n entries)" for maps
+	return `dynamic (${keys.length} pattern${keys.length === 1 ? "" : "s"})`;
+}
+
+/**
+ * Whether the model field contains a reference to a specific provider/id pair
+ * (i.e. it includes a `/` character). Only meaningful for string model
+ * selectors; dynamic maps always return false.
+ */
+export function advisorModelHasSlashSeparator(model: string | DynamicAdvisorModelMap | undefined): boolean {
+	if (typeof model !== "string") return false;
+	return model.includes("/");
 }
 
 /**
@@ -51,7 +90,7 @@ export interface DiscoveredAdvisors {
 
 const advisorEntrySchema = type({
 	name: "string",
-	"model?": "string",
+	"model?": "string | Record<string, string>",
 	"tools?": "string[]",
 	"instructions?": "string",
 	"enabled?": "boolean",
@@ -167,9 +206,24 @@ export async function discoverAdvisorConfigs(cwd: string, agentDir?: string): Pr
 			const instructions = entry.instructions?.trim()
 				? (await expandAtImports(entry.instructions, item.path)).trim() || undefined
 				: undefined;
+			// Normalize the model field: string → trimmed string or undefined,
+			// object (dynamic map) → strip empty/whitespace-only values.
+			let model: string | Record<string, string> | undefined;
+			if (typeof entry.model === "string") {
+				model = entry.model.trim() || undefined;
+			} else if (entry.model && typeof entry.model === "object" && !Array.isArray(entry.model)) {
+				const map: Record<string, string> = {};
+				for (const [key, value] of Object.entries(entry.model as Record<string, unknown>)) {
+					if (typeof value === "string" && value.trim()) {
+						map[key] = value.trim();
+					}
+				}
+				// Only use the map if it has at least one valid entry (including `default`)
+				if (Object.keys(map).length > 0) model = map;
+			}
 			advisors.set(slug, {
 				name: entry.name,
-				model: entry.model?.trim() || undefined,
+				model,
 				tools: filterAdvisorTools(entry.tools, item.path),
 				instructions,
 				enabled: entry.enabled,
@@ -255,7 +309,13 @@ export async function loadWatchdogConfigFile(filePath: string): Promise<Watchdog
 	}
 	const advisors = (result.advisors ?? []).map(a => {
 		const advisor: AdvisorConfig = { name: a.name };
-		if (a.model?.trim()) advisor.model = a.model;
+		if (typeof a.model === "string") {
+			if (a.model.trim()) advisor.model = a.model;
+		} else if (a.model && typeof a.model === "object" && !Array.isArray(a.model)) {
+			// Dynamic model map — pass through as-is for round-trip editing
+			const map = a.model as Record<string, unknown>;
+			if (Object.keys(map).length > 0) advisor.model = a.model;
+		}
 		if (a.tools !== undefined) advisor.tools = [...a.tools];
 		if (a.instructions?.trim()) advisor.instructions = a.instructions;
 		if (a.enabled !== undefined) advisor.enabled = a.enabled;
@@ -302,7 +362,17 @@ export function serializeWatchdogConfig(doc: WatchdogConfigDoc): string {
 		lines.push("advisors:");
 		for (const advisor of doc.advisors) {
 			lines.push(`  - name: ${YAML.stringify(advisor.name)}`);
-			if (advisor.model?.trim()) lines.push(`    model: ${YAML.stringify(advisor.model)}`);
+			if (advisor.model) {
+				if (typeof advisor.model === "string") {
+					lines.push(`    model: ${YAML.stringify(advisor.model)}`);
+				} else {
+					// Dynamic model map — serialize as a YAML mapping
+					lines.push("    model:");
+					for (const [key, value] of Object.entries(advisor.model)) {
+						lines.push(`      ${YAML.stringify(key)}: ${YAML.stringify(value)}`);
+					}
+				}
+			}
 			if (advisor.tools !== undefined) {
 				if (advisor.tools.length === 0) {
 					lines.push("    tools: []");

--- a/packages/coding-agent/src/modes/components/advisor-config.ts
+++ b/packages/coding-agent/src/modes/components/advisor-config.ts
@@ -33,6 +33,8 @@ import {
 	ADVISOR_DEFAULT_TOOL_NAMES,
 	type AdvisorConfig,
 	type AdvisorConfigScope,
+	advisorModelHasSlashSeparator,
+	formatAdvisorModel,
 	type WatchdogConfigDoc,
 } from "../../advisor";
 import type { ModelRegistry } from "../../config/model-registry";
@@ -290,7 +292,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 	}
 
 	#advisorPreview(advisor: AdvisorConfig, bodyWidth: number): string[] {
-		const model = advisor.model?.trim() || this.#defaultModelLabel || "advisor role default";
+		const model = formatAdvisorModel(advisor.model, this.#defaultModelLabel || "advisor role default");
 		const tools = formatAdvisorTools(advisor.tools, "no tools");
 		const lines = [
 			theme.bold(advisor.name || "(unnamed)"),
@@ -324,8 +326,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 				);
 			}
 		}
-		const quotaProvider =
-			(advisor.model?.includes("/") ? advisor.model.split("/")[0] : null) ?? liveStat?.model?.provider;
+		const quotaProvider = advisorModelHasSlashSeparator(advisor.model) ? (advisor.model as string).split("/")[0] : liveStat?.model?.provider;
 		if (this.#cachedReports && quotaProvider) {
 			const activeAccount = this.#cb.resolveActiveAccount?.(quotaProvider, liveStat?.sessionId);
 			const quota = formatCompactQuota(quotaProvider, this.#cachedReports, Date.now(), activeAccount);
@@ -358,7 +359,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 		if (!advisor) return false;
 		return (
 			advisor.name === "default" &&
-			!advisor.model?.trim() &&
+			!advisor.model &&
 			advisor.tools === undefined &&
 			!advisor.instructions?.trim() &&
 			advisor.enabled !== false
@@ -366,7 +367,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 	}
 
 	#advisorSummary(advisor: AdvisorConfig): string {
-		const model = advisor.model?.trim() || this.#defaultModelLabel || "advisor role default";
+		const model = formatAdvisorModel(advisor.model, this.#defaultModelLabel || "advisor role default");
 		const tools = formatAdvisorTools(advisor.tools, "no tools");
 		return `${model} · ${tools}`;
 	}
@@ -441,7 +442,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 			this.#showList();
 			return;
 		}
-		const modelDescription = advisor.model?.trim() || this.#defaultModelLabel || "advisor role default";
+		const modelDescription = formatAdvisorModel(advisor.model, this.#defaultModelLabel || "advisor role default");
 		const toolsDescription = formatAdvisorTools(advisor.tools, "no tools");
 		const items: SelectItem[] = [
 			{ value: "name", label: "Name", description: advisor.name },
@@ -452,7 +453,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 			},
 			{ value: "model", label: "Model", description: modelDescription },
 		];
-		if (advisor.model?.trim()) {
+		if (advisor.model) {
 			items.push({ value: "resetModel", label: "Reset model to advisor-role default" });
 		}
 		items.push(

--- a/packages/coding-agent/src/modes/components/advisor-config.ts
+++ b/packages/coding-agent/src/modes/components/advisor-config.ts
@@ -326,7 +326,7 @@ export class AdvisorConfigOverlayComponent implements Component {
 				);
 			}
 		}
-		const quotaProvider = advisorModelHasSlashSeparator(advisor.model) ? (advisor.model as string).split("/")[0] : liveStat?.model?.provider;
+		const quotaProvider = advisorModelHasSlashSeparator(advisor.model) ? advisor.model.split("/")[0] : liveStat?.model?.provider;
 		if (this.#cachedReports && quotaProvider) {
 			const activeAccount = this.#cb.resolveActiveAccount?.(quotaProvider, liveStat?.sessionId);
 			const quota = formatCompactQuota(quotaProvider, this.#cachedReports, Date.now(), activeAccount);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1402,6 +1402,7 @@ export class AgentSession {
 			onSseEvent: this.#onSseEvent,
 			agentKind: () => this.#agentKind,
 			isDisposed: () => this.#isDisposed,
+			model: () => this.model,
 			abortInProgress: () => this.#abortInProgress,
 			allowAgentInitiatedTurns: () => this.#allowAcpAgentInitiatedTurns,
 			planModeState: () => this.#planModeState,
@@ -6973,6 +6974,9 @@ export class AgentSession {
 		// retry-fallback on the error path.
 		if (isChanging) {
 			this.#emit({ type: "model_changed" });
+			// Dynamic advisor models keyed on the primary driving model
+			// must be re-evaluated when the driver changes.
+			this.#advisors.onPrimaryModelChanged();
 		}
 
 		// Re-evaluate append-only context mode — provider or setting may have changed

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -357,15 +357,28 @@ export class SessionAdvisors {
 
 	/**
 	 * Re-evaluates advisor model assignments when the primary driving model
-	 * changes. Only advisors with a dynamic model map (
-	 * {@link DynamicAdvisorModelMap}) are affected — static model selectors
-	 * and role-based resolution are unchanged. Rebuilds the runtime when at
-	 * least one dynamic advisor would select a different model under the new
-	 * primary model, which the signature check in
-	 * {@link #advisorRuntimeMatchesCurrentConfig} detects automatically.
+	 * changes, but **only before the first primary turn completes**. After the
+	 * first turn, dynamic model bindings are sticky — advisors build context
+	 * over the session and swapping their model mid-session would destroy it.
+	 *
+	 * This preserves the carve-out where a user can launch with one model,
+	 * see the default advisor resolve from it, then switch to a different
+	 * model before issuing any prompt — the advisors re-resolve to match
+	 * the final driving model. Subagents are independent sessions (their own
+	 * `SessionAdvisors`), so each subagent resolves its dynamic advisors
+	 * fresh for the model assigned to it.
+	 *
+	 * Only advisors with a dynamic model map (
+	 * {@link DynamicAdvisorModelMap}) are affected. The signature check in
+	 * {@link #advisorRuntimeMatchesCurrentConfig} detects when the resolved
+	 * model has actually changed, avoiding a rebuild when it hasn't.
 	 */
 	onPrimaryModelChanged(): void {
 		if (!this.#advisorEnabled || this.#host.isDisposed()) return;
+		// After the first primary turn, dynamic model bindings are sticky.
+		// Retry-fallback, model cycling, and user-driven model changes mid-
+		// session must not tear down advisor runtimes and lose context.
+		if (this.#advisorPrimaryTurnsCompleted > 0) return;
 		// Fast path: skip if no advisor uses a dynamic model map
 		if (!this.#advisorConfigs?.some(c => c.model && typeof c.model === "object")) return;
 		if (this.#advisors.length > 0 && !this.#advisorRuntimeMatchesCurrentConfig()) this.#stopAdvisorRuntime();
@@ -565,7 +578,7 @@ export class SessionAdvisors {
 		this.#advisorAutoResumeSuppressed = false;
 		this.#host.yieldQueue.clear("advisor");
 		this.#host.extractQueuedAdvisorCards();
-		this.#host.dropPendingAdvisorCards();
+this.#host.dropPendingAdvisorCards();
 	}
 
 	#resolveDynamicAdvisorModel(
@@ -584,35 +597,19 @@ export class SessionAdvisors {
 
 		// Dynamic model map — resolve based on the primary session's driving model
 		const primaryModel = this.#host.model();
-		if (!primaryModel) {
-			// No primary model yet; try the `default` key or fail
-			const defaultSelector = modelMap["default"];
-			if (!defaultSelector) return undefined;
-			const resolved = resolveModelOverride([defaultSelector], this.#host.modelRegistry, this.#host.settings);
-			const model = resolved.model;
-			if (!model) return undefined;
-			return { model, thinkingLevel: concreteThinkingLevel(resolved.thinkingLevel) };
-		}
+		const primaryModelStr = primaryModel ? formatModelString(primaryModel) : undefined;
 
-		const primaryModelStr = formatModelString(primaryModel);
-
-		// Find the best-matching key: try exact match first, then fuzzy match using
-		// the model resolution pipeline, falling back to `default`.
 		let matchedSelector: string | undefined;
 
 		// Phase 1: exact-string match against the primary model string
-		for (const [key, value] of Object.entries(modelMap)) {
-			if (key === "default") continue;
-			if (key === primaryModelStr) {
-				matchedSelector = value;
-				break;
-			}
+		if (primaryModelStr) {
+			matchedSelector = matchDynamicModelMapEntryExact(modelMap, primaryModelStr);
 		}
 
-		// Phase 2: resolve each key as a model pattern and check if it matches
-		// the primary model. This supports provider-prefixed ids, bare ids,
-		// aliases, globs, and any other pattern the model resolver accepts.
-		if (!matchedSelector) {
+		// Phase 2: resolve each key as a model pattern against the registry,
+		// which supports aliases, globs, bare ids, etc. Only runs when the
+		// exact string match didn't find a hit.
+		if (!matchedSelector && primaryModel) {
 			for (const [key, value] of Object.entries(modelMap)) {
 				if (key === "default") continue;
 				const resolved = resolveModelOverride([key], this.#host.modelRegistry, this.#host.settings);
@@ -1986,4 +1983,21 @@ export class SessionAdvisors {
 			.map(a => `### Advisor: ${a.name} (${a.agent.state.model.provider}/${a.agent.state.model.id})\n\n${dump(a)}`)
 			.join("\n\n");
 	}
+}
+
+/**
+ * Find an exact string match for a primary model string in a dynamic model
+ * map. Returns the matched selector value, or `undefined`. Does NOT consult
+ * the `default` key — the caller runs fuzzy resolution (Phase 2) before
+ * falling back to `default` (Phase 3). Pure function, no registry access.
+ */
+export function matchDynamicModelMapEntryExact(
+	modelMap: Record<string, string>,
+	primaryModelStr: string,
+): string | undefined {
+	for (const [key, value] of Object.entries(modelMap)) {
+		if (key === "default") continue;
+		if (key === primaryModelStr) return value;
+	}
+	return undefined;
 }

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -52,6 +52,7 @@ import {
 	AdvisorTranscriptRecorder,
 	advisorTranscriptFilename,
 	buildAdvisorQuarantineSourceText,
+	type DynamicAdvisorModelMap,
 	formatAdvisorBatchContent,
 	getOrCreateAdvisorProviderSessionId,
 	isAdvisorInterruptImmuneTurnActive,
@@ -244,6 +245,8 @@ export interface SessionAdvisorsHost {
 	onSseEvent: SimpleStreamOptions["onSseEvent"] | undefined;
 	agentKind(): "main" | "sub";
 	isDisposed(): boolean;
+	/** Returns the primary session's current driving model, or undefined. */
+	model(): Model | undefined;
 	abortInProgress(): boolean;
 	allowAgentInitiatedTurns(): boolean;
 	planModeState(): PlanModeState | undefined;
@@ -348,6 +351,23 @@ export class SessionAdvisors {
 	/** Rebuilds live advisors when role assignments alter their resolved runtime inputs. */
 	onModelRolesChanged(): void {
 		if (!this.#advisorEnabled || this.#host.isDisposed()) return;
+		if (this.#advisors.length > 0 && !this.#advisorRuntimeMatchesCurrentConfig()) this.#stopAdvisorRuntime();
+		this.#buildAdvisorRuntime(true);
+	}
+
+	/**
+	 * Re-evaluates advisor model assignments when the primary driving model
+	 * changes. Only advisors with a dynamic model map (
+	 * {@link DynamicAdvisorModelMap}) are affected — static model selectors
+	 * and role-based resolution are unchanged. Rebuilds the runtime when at
+	 * least one dynamic advisor would select a different model under the new
+	 * primary model, which the signature check in
+	 * {@link #advisorRuntimeMatchesCurrentConfig} detects automatically.
+	 */
+	onPrimaryModelChanged(): void {
+		if (!this.#advisorEnabled || this.#host.isDisposed()) return;
+		// Fast path: skip if no advisor uses a dynamic model map
+		if (!this.#advisorConfigs?.some(c => c.model && typeof c.model === "object")) return;
 		if (this.#advisors.length > 0 && !this.#advisorRuntimeMatchesCurrentConfig()) this.#stopAdvisorRuntime();
 		this.#buildAdvisorRuntime(true);
 	}
@@ -548,6 +568,74 @@ export class SessionAdvisors {
 		this.#host.dropPendingAdvisorCards();
 	}
 
+	#resolveDynamicAdvisorModel(
+		config: AdvisorConfig,
+	): { model: Model; thinkingLevel?: ThinkingLevel } | undefined {
+		if (!config.model) return undefined;
+
+		const modelMap = config.model;
+		if (typeof modelMap === "string") {
+			// Static model selector — current behaviour
+			const resolved = resolveModelOverride([modelMap], this.#host.modelRegistry, this.#host.settings);
+			const model = resolved.model;
+			if (!model) return undefined;
+			return { model, thinkingLevel: concreteThinkingLevel(resolved.thinkingLevel) };
+		}
+
+		// Dynamic model map — resolve based on the primary session's driving model
+		const primaryModel = this.#host.model();
+		if (!primaryModel) {
+			// No primary model yet; try the `default` key or fail
+			const defaultSelector = modelMap["default"];
+			if (!defaultSelector) return undefined;
+			const resolved = resolveModelOverride([defaultSelector], this.#host.modelRegistry, this.#host.settings);
+			const model = resolved.model;
+			if (!model) return undefined;
+			return { model, thinkingLevel: concreteThinkingLevel(resolved.thinkingLevel) };
+		}
+
+		const primaryModelStr = formatModelString(primaryModel);
+
+		// Find the best-matching key: try exact match first, then fuzzy match using
+		// the model resolution pipeline, falling back to `default`.
+		let matchedSelector: string | undefined;
+
+		// Phase 1: exact-string match against the primary model string
+		for (const [key, value] of Object.entries(modelMap)) {
+			if (key === "default") continue;
+			if (key === primaryModelStr) {
+				matchedSelector = value;
+				break;
+			}
+		}
+
+		// Phase 2: resolve each key as a model pattern and check if it matches
+		// the primary model. This supports provider-prefixed ids, bare ids,
+		// aliases, globs, and any other pattern the model resolver accepts.
+		if (!matchedSelector) {
+			for (const [key, value] of Object.entries(modelMap)) {
+				if (key === "default") continue;
+				const resolved = resolveModelOverride([key], this.#host.modelRegistry, this.#host.settings);
+				if (resolved.model && modelsAreEqual(resolved.model, primaryModel)) {
+					matchedSelector = value;
+					break;
+				}
+			}
+		}
+
+		// Phase 3: fallback to `default`
+		if (!matchedSelector) {
+			matchedSelector = modelMap["default"];
+		}
+
+		if (!matchedSelector) return undefined;
+
+		const resolved = resolveModelOverride([matchedSelector], this.#host.modelRegistry, this.#host.settings);
+		const model = resolved.model;
+		if (!model) return undefined;
+		return { model, thinkingLevel: concreteThinkingLevel(resolved.thinkingLevel) };
+	}
+
 	#resolveAdvisorRuntimeDescriptors(emitWarnings: boolean): AdvisorRuntimeDescriptor[] {
 		const legacy = !this.#advisorConfigs?.length;
 		const roster: AdvisorConfig[] = legacy ? [{ name: "default" }] : this.#advisorConfigs!;
@@ -569,20 +657,27 @@ export class SessionAdvisors {
 				continue;
 			}
 
-			// Resolve the advisor's model: an explicit `model` override wins; else the
-			// `advisor` role chain. A model that fails to resolve skips just this advisor.
+			// Resolve the advisor's model: a dynamic map keys on the primary
+			// driving model, a static string is used directly, omitted falls
+			// back to the `advisor` role chain. A model that fails to resolve
+			// skips just this advisor.
 			let model: Model | undefined;
 			let thinkingLevel: ThinkingLevel | undefined;
 			if (config.model) {
-				const resolved = resolveModelOverride([config.model], this.#host.modelRegistry, this.#host.settings);
-				model = resolved.model;
-				thinkingLevel = concreteThinkingLevel(resolved.thinkingLevel);
+				const dynamicResult = this.#resolveDynamicAdvisorModel(config);
+				if (dynamicResult) {
+					model = dynamicResult.model;
+					thinkingLevel = dynamicResult.thinkingLevel;
+				}
 				if (!model) {
+					const modelDesc = typeof config.model === "string"
+						? config.model
+						: `${Object.keys(config.model as Record<string, string>).join(", ")} (dynamic map)`;
 					this.#advisorStatuses.set(slug, { name: config.name, status: "no_model" });
 					if (emitWarnings) {
 						this.#host.emitNotice(
 							"warning",
-							`Advisor "${config.name}": no model matched "${config.model}"`,
+							`Advisor "${config.name}": no model matched from ${modelDesc}`,
 							"advisor",
 						);
 					}

--- a/packages/coding-agent/test/advisor/config.test.ts
+++ b/packages/coding-agent/test/advisor/config.test.ts
@@ -13,6 +13,7 @@ import {
 	slugifyAdvisorName,
 	type WatchdogConfigDoc,
 } from "../../src/advisor/config";
+import { matchDynamicModelMapEntryExact } from "../../src/session/session-advisors";
 
 describe("discoverAdvisorConfigs", () => {
 	let tmp: string;
@@ -383,8 +384,53 @@ describe("per-advisor enabled field", () => {
 				{ name: "Default" },
 			],
 		});
-		expect(text).toContain("enabled: true");
+expect(text).toContain("enabled: true");
 		expect(text).toContain("enabled: false");
 		expect(text.match(/enabled:/g)).toHaveLength(2);
+	});
+});
+
+describe("dynamic model map matching", () => {
+	it("matches exact provider/id string", () => {
+		const map = {
+			"anthropic/claude-sonnet-4-5": "anthropic/claude-terra-6|deepseek/deepseek-v4-flash",
+			"anthropic/claude-terra-6": "anthropic/claude-sonnet-4-5|deepseek/deepseek-v4-flash",
+			default: "deepseek/deepseek-v4-flash",
+		};
+		expect(matchDynamicModelMapEntryExact(map, "anthropic/claude-sonnet-4-5")).toBe(
+			"anthropic/claude-terra-6|deepseek/deepseek-v4-flash",
+		);
+		expect(matchDynamicModelMapEntryExact(map, "anthropic/claude-terra-6")).toBe(
+			"anthropic/claude-sonnet-4-5|deepseek/deepseek-v4-flash",
+		);
+	});
+
+	it("returns undefined for unmatched key (does NOT fall back to default)", () => {
+		const map = {
+			"anthropic/claude-sonnet-4-5": "terra",
+			default: "fallback",
+		};
+		expect(matchDynamicModelMapEntryExact(map, "deepseek/deepseek-v4-flash")).toBeUndefined();
+	});
+
+	it("returns undefined when only default key exists", () => {
+		const map = { default: "fallback" };
+		expect(matchDynamicModelMapEntryExact(map, "any/model")).toBeUndefined();
+	});
+
+	it("ignores the default key during exact match but matches non-default keys", () => {
+		const map = { default: "fallback", "provider/model": "selected" };
+		expect(matchDynamicModelMapEntryExact(map, "provider/model")).toBe("selected");
+		expect(matchDynamicModelMapEntryExact(map, "unknown/model")).toBeUndefined();
+	});
+
+	it("returns undefined for empty map", () => {
+		expect(matchDynamicModelMapEntryExact({}, "any/model")).toBeUndefined();
+	});
+
+	it("handles keys with special characters", () => {
+		const map = { "a/b@c": "value", default: "fallback" };
+		expect(matchDynamicModelMapEntryExact(map, "a/b@c")).toBe("value");
+		expect(matchDynamicModelMapEntryExact(map, "x/y")).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/advisor/config.test.ts
+++ b/packages/coding-agent/test/advisor/config.test.ts
@@ -260,6 +260,47 @@ describe("WATCHDOG.yml file round-trip", () => {
 		expect(advisors.find(a => a.name === "Default Tools")?.tools).toBeUndefined();
 	});
 
+	it("round-trips a dynamic model map and falls back to legacy empty-file path", async () => {
+		const file = path.join(tmp, "WATCHDOG.yml");
+		const dynamicDoc: WatchdogConfigDoc = {
+			advisors: [
+				{
+					name: "Dynamic Watchdog",
+					model: {
+						"anthropic/claude-sonnet-4-5": "anthropic/claude-terra-6|deepseek/deepseek-v4-flash",
+						"anthropic/claude-terra-6": "anthropic/claude-sonnet-4-5|deepseek/deepseek-v4-flash",
+						default: "deepseek/deepseek-v4-flash",
+					},
+					tools: ["read", "grep"],
+					instructions: "Dynamic model selection.",
+				},
+			],
+		};
+
+		await saveWatchdogConfigFile(file, dynamicDoc);
+		// Verify YAML output contains the mapping, not flow-style
+		const text = await Bun.file(file).text();
+		expect(text).toContain("    model:");
+		expect(text).toContain("anthropic/claude-sonnet-4-5");
+		expect(text).toContain("default:");
+		expect(text).toContain("deepseek/deepseek-v4-flash");
+
+		// Verify round-trip loads the map as an object
+		const loaded = await loadWatchdogConfigFile(file);
+		expect(loaded.advisors[0].name).toBe("Dynamic Watchdog");
+		expect(typeof loaded.advisors[0].model).toBe("object");
+		expect((loaded.advisors[0].model as Record<string, string>)["default"]).toBe("deepseek/deepseek-v4-flash");
+
+		// Verify discovery also parses the map correctly
+		const { advisors } = await discoverAdvisorConfigs(tmp, tmp);
+		const discovered = advisors.find(a => a.name === "Dynamic Watchdog");
+		expect(discovered).toBeDefined();
+		expect(typeof discovered!.model).toBe("object");
+		const map = discovered!.model as Record<string, string>;
+		expect(map["anthropic/claude-sonnet-4-5"]).toBe("anthropic/claude-terra-6|deepseek/deepseek-v4-flash");
+		expect(map.default).toBe("deepseek/deepseek-v4-flash");
+	});
+
 	it("removes the file when the doc is empty so legacy discovery resumes", async () => {
 		const file = path.join(tmp, "WATCHDOG.yml");
 		await saveWatchdogConfigFile(file, doc);


### PR DESCRIPTION
## Summary

The `model` field on `WATCHDOG.yml` advisor roster entries now accepts either a static model selector string (existing behavior) or a `Record<string, string>` mapping keyed by primary driving model pattern, with a `default` fallback.

## Example

```yaml
advisors:
  - name: watchdog
    model:
      "anthropic/claude-sonnet-4-5": anthropic/claude-terra-6|deepseek/deepseek-v4-flash
      "anthropic/claude-terra-6": anthropic/claude-sonnet-4-5|deepseek/deepseek-v4-flash
      default: deepseek/deepseek-v4-flash
```

## How it works

When the primary session model changes, advisors with dynamic maps automatically re-resolve and switch models if the mapped selector differs from the current one. Three-phase matching:

1. **Exact string match** — `provider/id` against the formatted primary model string
2. **Model-resolver pattern** — resolve each key through the full model resolution pipeline (supports aliases, globs, provider-prefixed ids, etc.)
3. **`default` fallback** — used when no other key matches, or before a driving model is set

## Files changed

- `packages/coding-agent/src/advisor/config.ts` — new `DynamicAdvisorModelMap` type, `formatAdvisorModel()` / `advisorModelHasSlashSeparator()` helpers, schema updated to accept `string | Record<string, string>`, serialization/parsing for both forms
- `packages/coding-agent/src/modes/components/advisor-config.ts` — TUI editor handles map form safely
- `packages/coding-agent/src/session/agent-session.ts` — wires `onPrimaryModelChanged()` into the model-change path
- `packages/coding-agent/src/session/session-advisors.ts` — new `#resolveDynamicAdvisorModel()`, `onPrimaryModelChanged()`, imported `DynamicAdvisorModelMap`
- `packages/coding-agent/test/advisor/config.test.ts` — round-trip test for dynamic map serialization/parsing
- `docs/advisor-watchdog.md` — documented the new YAML syntax