### PR TITLE
fix(sdk): expose retry_fallback events to extensions

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -77,6 +77,8 @@ import type {
 	AutoRetryStartEvent,
 	ContextEvent,
 	GoalUpdatedEvent,
+	RetryFallbackAppliedEvent,
+	RetryFallbackSucceededEvent,
 	SessionBeforeBranchEvent,
 	SessionBeforeBranchResult,
 	SessionBeforeCompactEvent,
@@ -749,6 +751,8 @@ export type {
 	AutoCompactionStartEvent,
 	AutoRetryEndEvent,
 	AutoRetryStartEvent,
+	RetryFallbackAppliedEvent,
+	RetryFallbackSucceededEvent,
 	TodoReminderEvent,
 	TtsrTriggeredEvent,
 } from "../shared-events";
@@ -1011,6 +1015,8 @@ export type ExtensionEvent =
 	| AutoCompactionEndEvent
 	| AutoRetryStartEvent
 	| AutoRetryEndEvent
+	| RetryFallbackAppliedEvent
+	| RetryFallbackSucceededEvent
 	| TtsrTriggeredEvent
 	| TodoReminderEvent
 	| GoalUpdatedEvent
@@ -1198,6 +1204,8 @@ export interface ExtensionAPI {
 	on(event: "auto_compaction_end", handler: ExtensionHandler<AutoCompactionEndEvent>): void;
 	on(event: "auto_retry_start", handler: ExtensionHandler<AutoRetryStartEvent>): void;
 	on(event: "auto_retry_end", handler: ExtensionHandler<AutoRetryEndEvent>): void;
+	on(event: "retry_fallback_applied", handler: ExtensionHandler<RetryFallbackAppliedEvent>): void;
+	on(event: "retry_fallback_succeeded", handler: ExtensionHandler<RetryFallbackSucceededEvent>): void;
 	on(event: "ttsr_triggered", handler: ExtensionHandler<TtsrTriggeredEvent>): void;
 	on(event: "todo_reminder", handler: ExtensionHandler<TodoReminderEvent>): void;
 	on(event: "goal_updated", handler: ExtensionHandler<GoalUpdatedEvent>): void;

--- a/packages/coding-agent/src/extensibility/shared-events.ts
+++ b/packages/coding-agent/src/extensibility/shared-events.ts
@@ -266,6 +266,21 @@ export interface AutoRetryEndEvent {
 	retryErrors?: RetryErrorUpdate[];
 }
 
+/** Fired when a retry fallback has been applied (model switched from -> to) */
+export interface RetryFallbackAppliedEvent {
+	type: "retry_fallback_applied";
+	from: string;
+	to: string;
+	role: string;
+}
+
+/** Fired when a retry fallback succeeded */
+export interface RetryFallbackSucceededEvent {
+	type: "retry_fallback_succeeded";
+	model: string;
+	role: string;
+}
+
 // ============================================================================
 // TTSR / Todo Reminders
 // ============================================================================

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3492,6 +3492,19 @@ export class AgentSession {
 				finalError: event.finalError,
 				retryErrors: event.retryErrors,
 			});
+		} else if (event.type === "retry_fallback_applied") {
+			await this.#extensionRunner.emit({
+				type: "retry_fallback_applied",
+				from: event.from,
+				to: event.to,
+				role: event.role,
+			});
+		} else if (event.type === "retry_fallback_succeeded") {
+			await this.#extensionRunner.emit({
+				type: "retry_fallback_succeeded",
+				model: event.model,
+				role: event.role,
+			});
 		} else if (event.type === "ttsr_triggered") {
 			await this.#extensionRunner.emit({ type: "ttsr_triggered", rules: event.rules });
 		} else if (event.type === "todo_reminder") {


### PR DESCRIPTION
## Description

Exposes `retry_fallback_applied` and `retry_fallback_succeeded` session events to extensions via `pi.on()` handlers, fixing a gap where these events were only forwarded to TUI/RPC consumers.

### Changes

1. **packages/coding-agent/src/extensibility/shared-events.ts**: Added `RetryFallbackAppliedEvent` and `RetryFallbackSucceededEvent` interface definitions.

2. **packages/coding-agent/src/extensibility/extensions/types.ts**:
   - Imported and re-exported both new event types
   - Added them to the `ExtensionEvent` union type
   - Added `ExtensionAPI.on()` overloads for both events

3. **packages/coding-agent/src/session/agent-session.ts**: Added forwarding branches for both events in `#emitExtensionEvent()`.

### Testing

An extension can now observe fallback transitions:

```ts
pi.on("retry_fallback_applied", event => {
  console.log(`Fallback: ${event.from} -> ${event.to} (role: ${event.role})`);
});
pi.on("retry_fallback_succeeded", event => {
  console.log(`Fallback succeeded: ${event.model} (role: ${event.role})`);
});
```

Fixes #8079