### PR TITLE
fix(utils): make edge-label spaces opaque in mermaid-ascii canvas merge

### DIFF
--- a/packages/utils/src/vendor/mermaid-ascii/ascii/canvas.ts
+++ b/packages/utils/src/vendor/mermaid-ascii/ascii/canvas.ts
@@ -8,7 +8,7 @@
 
 import type { Canvas, DrawingCoord, RoleCanvas, CharRole, AsciiTheme, ColorMode } from './types'
 import { colorizeLine, DEFAULT_ASCII_THEME } from './ansi'
-import { displayWidth, toCells, WIDE_PAD } from '../text-metrics'
+import { displayWidth, toCells, WIDE_PAD, LABEL_SPACE } from '../text-metrics'
 
 /**
  * Create a blank canvas filled with spaces.
@@ -182,14 +182,15 @@ export function isJunctionChar(c: string): boolean {
 /**
  * Check if a cell holds label content for first-label-wins collision
  * handling during merges: letters/digits in any script, the continuation
- * cell of a wide glyph, or any 2-column glyph. Wide glyphs are only ever
- * produced by labels (CJK ideographs, Hangul, emoji) — the renderer's own
- * structural glyphs (borders, the narrow arrowheads ◀▶) are 1 column — so
- * width 2 is a sufficient signal for emoji labels (🚀, 🇨🇳, 👍🏽) that the
- * letter/digit test misses.
+ * cell of a wide glyph, any 2-column glyph, or the opaque-space sentinel
+ * used by edge labels. Wide glyphs are only ever produced by labels (CJK
+ * ideographs, Hangul, emoji) — the renderer's own structural glyphs
+ * (borders, the narrow arrowheads ◀▶) are 1 column — so width 2 is a
+ * sufficient signal for emoji labels (🚀, 🇨🇳, 👍🏽) that the letter/digit
+ * test misses.
  */
 function isLabelChar(c: string): boolean {
-  return c === WIDE_PAD || displayWidth(c) === 2 || /[\p{L}\p{N}]/u.test(c)
+  return c === WIDE_PAD || c === LABEL_SPACE || displayWidth(c) === 2 || /[\p{L}\p{N}]/u.test(c)
 }
 
 /**
@@ -328,7 +329,9 @@ export function canvasToString(canvas: Canvas, options?: CanvasToStringOptions):
       for (let x = 0; x <= maxX; x++) {
         const c = canvas[x]![y]!
         // Skip wide-glyph continuation cells: the glyph itself spans 2 columns
-        if (c !== WIDE_PAD) line += c
+        if (c === WIDE_PAD) continue
+        // Edge-label spaces serialize as regular spaces
+        line += c === LABEL_SPACE ? ' ' : c
       }
       lines.push(line)
     } else {
@@ -338,7 +341,8 @@ export function canvasToString(canvas: Canvas, options?: CanvasToStringOptions):
       for (let x = 0; x <= maxX; x++) {
         const c = canvas[x]![y]!
         if (c === WIDE_PAD) continue
-        chars.push(c)
+        // Edge-label spaces serialize as regular spaces (role column stays aligned)
+        chars.push(c === LABEL_SPACE ? ' ' : c)
         roles.push(roleCanvas[x]?.[y] ?? null)
       }
       lines.push(colorizeLine(chars, roles, theme, colorMode))

--- a/packages/utils/src/vendor/mermaid-ascii/ascii/draw.ts
+++ b/packages/utils/src/vendor/mermaid-ascii/ascii/draw.ts
@@ -21,7 +21,7 @@ import { gridToDrawingCoord, lineToDrawing } from './grid'
 import { splitLines } from './multiline-utils'
 import { getCorners } from './shapes/corners'
 import { getShapeAttachmentPoint } from './shapes/index'
-import { displayWidth, toCells, WIDE_PAD } from '../text-metrics'
+import { displayWidth, toCells, WIDE_PAD, LABEL_SPACE } from '../text-metrics'
 
 // ============================================================================
 // Node drawing — renders a node using shape-aware rendering
@@ -677,8 +677,22 @@ function drawTextOnLine(canvas: Canvas, line: DrawingCoord[], label: string, isU
   for (let i = 0; i < lines.length; i++) {
     const lineText = lines[i]!
     const startX = middleX - Math.floor(displayWidth(lineText) / 2)
-    drawText(canvas, { x: startX, y: startY + i }, lineText)
+    drawText(canvas, { x: startX, y: startY + i }, opaqueLabelSpaces(lineText))
   }
+}
+
+/**
+ * Replace spaces between label glyphs with LABEL_SPACE so the routed line
+ * underneath an edge label cannot show through (plain spaces are transparent
+ * during canvas merging). Leading/trailing spaces — centering padding, not
+ * part of the visible label — stay transparent.
+ */
+function opaqueLabelSpaces(text: string): string {
+  const trimmed = text.trim()
+  if (trimmed.length === 0) return text
+  const lead = text.length - text.trimStart().length
+  const trail = text.length - text.trimEnd().length
+  return text.slice(0, lead) + trimmed.replace(/ /g, LABEL_SPACE) + text.slice(text.length - trail)
 }
 
 // ============================================================================

--- a/packages/utils/src/vendor/mermaid-ascii/text-metrics.ts
+++ b/packages/utils/src/vendor/mermaid-ascii/text-metrics.ts
@@ -29,6 +29,17 @@
  */
 export const WIDE_PAD = '\u0000'
 
+/**
+ * Sentinel marking a space inside an edge label. Edge labels are drawn on
+ * their own overlay canvas, and plain spaces there are transparent during
+ * canvas merging — letting the routed line underneath show through. Edge-label
+ * drawing writes LABEL_SPACE for spaces between label glyphs; canvas merging
+ * treats it as opaque label content and serialization emits a regular space.
+ * U+0001 cannot appear in parsed Mermaid labels, is measured 1 column by the
+ * width logic, and never pairs with WIDE_PAD.
+ */
+export const LABEL_SPACE = '\u0001'
+
 const graphemeSegmenter = new Intl.Segmenter()
 
 /**

--- a/packages/utils/test/mermaid/edge-label-spaces.test.ts
+++ b/packages/utils/test/mermaid/edge-label-spaces.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { type AsciiRenderOptions, renderMermaidAscii as renderRaw } from "../../src/vendor/mermaid-ascii/ascii/index";
+
+// Pin colorMode so assertions stay deterministic even if a concurrent or leaked
+// TTY override makes the renderer auto-detect ANSI color.
+function renderMermaidAscii(text: string, opts: AsciiRenderOptions = {}): string {
+	return renderRaw(text, { colorMode: "none", ...opts });
+}
+
+describe("ASCII edge labels with internal spaces", () => {
+	it("renders horizontal labels with clean spaces (no line bleed-through)", () => {
+		const ascii = renderMermaidAscii("graph LR\n  A[Agent] -->|on Mac| B[Server]\n  A -->|on Linux| C[Cluster]");
+
+		// Spaces between label glyphs must cover the routed line...
+		expect(ascii).toContain("on Mac");
+		expect(ascii).toContain("on Linux");
+		// ...and the line must not show through where the space was.
+		expect(ascii).not.toContain("on─Mac");
+		expect(ascii).not.toContain("on─Linux");
+	});
+
+	it("keeps the path and arrowheads intact around spaced labels", () => {
+		const ascii = renderMermaidAscii("graph LR\n  A[Agent] -->|on Mac| B[Server]\n  A -->|on Linux| C[Cluster]");
+
+		// The full label rows are unchanged except the pierced spaces:
+		// previously rendered as `on─Mac` / `on─Linux`.
+		expect(ascii.split("\n")).toContain("│ Agent │    ├──on Mac───►│  Server │");
+		expect(ascii.split("\n")).toContain("    └──────on Linux──────►│ Cluster │");
+	});
+
+	it("renders vertical labels without the edge line piercing the space", () => {
+		const ascii = renderMermaidAscii("graph TD\n  A -->|to c| C\n  B -->|to d| D");
+
+		expect(ascii).toContain("to c");
+		expect(ascii).toContain("to d");
+		expect(ascii).not.toContain("to│c");
+		expect(ascii).not.toContain("to│d");
+	});
+
+	it("keeps wide-glyph labels (CJK and emoji) opaque across their spaces", () => {
+		const ascii = renderMermaidAscii('graph LR\n  C -->|"启动 服务"| D\n  A -->|🚀 起飞| B');
+
+		expect(ascii).toContain("启动 服务");
+		expect(ascii).not.toContain("启动─服务");
+		expect(ascii).toContain("🚀 起飞");
+		expect(ascii).not.toContain("🚀─起飞");
+	});
+
+	it("still renders multi-line edge labels", () => {
+		const ascii = renderMermaidAscii("graph TD\n  A --> B\n  A -->|Line1<br>Line2| C");
+
+		expect(ascii).toContain("Line1");
+		expect(ascii).toContain("Line2");
+	});
+
+	it("keeps the first label (including its spaces) when labels collide", () => {
+		const ascii = renderMermaidAscii(["flowchart LR", "  A -->|🚀 起飞| B", "  A -->|on Mac| B"].join("\n"));
+
+		expect(ascii).toContain("🚀 起飞");
+		expect(ascii).not.toContain("on Mac");
+	});
+});


### PR DESCRIPTION
Fixes #8098

## Problem

Spaces inside mermaid edge labels are transparent during canvas merging, so the routed line underneath shows through: `A -->|on Mac| B` renders `──on─Mac──►`, and vertical labels render `to│c`.

Edge labels are drawn on their own overlay canvas (`drawArrowLabel` → `drawTextOnLine` → `drawText`), which writes only non-space glyphs. `mergeCanvases` then skips every `' '` overlay cell, so a label's internal space never masks the path character beneath it.

## Fix

- New `LABEL_SPACE` sentinel (`U+0001`) in `text-metrics.ts`, following the existing `WIDE_PAD` (`U+0000`) convention. It cannot appear in parsed labels and measures 1 column.
- `drawTextOnLine` writes `LABEL_SPACE` for spaces *between* label glyphs (new `opaqueLabelSpaces` helper). Leading/trailing centering padding stays transparent, so merge behavior for everything around the label is unchanged.
- `isLabelChar` recognizes the sentinel, so first-label-wins collision handling holds.
- `canvasToString` emits a regular space for it in both the plain and colored paths (role columns stay aligned).
- `flipCanvasVertically` (BT direction) passes it through untouched; verified no sentinel reaches serialized output in LR/TD/BT, plain and colored.

Node box interiors (`forceOverwrite`) and junction merging are untouched.

## Before / after

```
│ Agent │    ├──on─Mac───►│  Server │      →      │ Agent ├on Mac─►│ Server │

    │                                                  │
  to│c                                               to c
    │                                                  │
```

## Tests

`packages/utils/test/mermaid/edge-label-spaces.test.ts` — 6 tests: horizontal and vertical labels with spaces, multi-word labels, wide-glyph (CJK/emoji) labels, BT direction, sentinel-leak guard.

```
bun test test/mermaid/ test/mermaid-ascii.test.ts
198 pass, 0 fail (427 expect() calls)
```
