### PR TITLE
chore: optional buildbuddy log+cache support for natives

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -76,6 +76,11 @@ build:cache-ro --remote_retries=2
 build:cache-rw --remote_timeout=60s
 build:cache-ro --remote_timeout=60s
 
+# --- BuildBuddy support ------------------------------------------------------
+# Adds the configuration `buildbuddy` which reports build events via Bazel's
+# event protocol. Usage: `bazel [build|test] --config=buildbuddy ...`.
+import %workspace%/bazel/buildbuddy.bazelrc
+
 # --- Local development ---------------------------------------------------------
 # Optional user overrides (remote cache endpoint, disk cache, etc.).
 try-import %workspace%/.bazelrc.user

--- a/bazel/buildbuddy.bazelrc
+++ b/bazel/buildbuddy.bazelrc
@@ -1,0 +1,11 @@
+# Build Event Service endpoint/results URL prefix.
+build:buildbuddy --bes_results_url=https://oh-my-pi.buildbuddy.io/invocation/
+build:buildbuddy --bes_backend=grpcs://oh-my-pi.buildbuddy.io
+build:buildbuddy --noslim_profile
+build:buildbuddy --experimental_profile_include_target_label
+build:buildbuddy --experimental_profile_include_primary_output
+
+# Remote cache.
+common:buildbuddy --remote_cache=grpcs://oh-my-pi.buildbuddy.io
+common:buildbuddy --remote_cache_compression
+common:buildbuddy --remote_timeout=10m


### PR DESCRIPTION
## What

Adds minimal opt-in support for [BuildBuddy](https://buildbuddy.io). There is an accompanying [instance](https://oh-my-pi.buildbuddy.io/) as well. Admin + keys can be handed over/communicated on Discord for CI. For now, this does **not** change where builds take place: only the cache/UI are enabled when a developer opts in.

### Usage

**`.bazelrc.user`**
```
common --remote_header=x-buildbuddy-api-key=<key>
common --config=buildbuddy
```

## Why

- Strong [MCP support](https://www.buildbuddy.io/changelog/buildbuddy-mcp-server/) for easier diagnosis
- Centralized [remote Bazel cache](https://www.buildbuddy.io/docs/config-cache/) which can be shared across devs/CI
- Eventually, [remote build execution (RBE)](https://www.buildbuddy.io/docs/remote-build-execution) would further leverage caching + allow devs to contribute with fewer resources

## Testing

With and without BuildBuddy enabled:

- I've run [`bazel build //:natives-linux-x64-modern`](https://oh-my-pi.buildbuddy.io/invocation/25f775c9-e6e7-43f1-aab4-acd886708c83) (my host platform)
- I've run [`bazel test -- //crates/... -//crates/pi-shell:pi-shell_test`](https://oh-my-pi.buildbuddy.io/invocation/3c04f651-4b51-4ee5-9486-ee1f6dab9b32)

---

- [x] `bun check` passes
- [x] Tested locally
- [x] ~~CHANGELOG updated (if user-facing)~~ (not user facing)
