### PR TITLE
fix(agent): reject cold revive that finishes after lifecycle dispose

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a cold persisted-agent revival racing with lifecycle teardown: a revive whose reviver factory or session resolved after `AgentLifecycleManager.dispose()` could attach a live session and arm a TTL on the disposed manager, leaking a session graph and timers past teardown. Late revivals now reject deterministically and dispose any session they built ([#8114](https://github.com/can1357/oh-my-pi/issues/8114)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -421,7 +421,7 @@ export class AgentLifecycleManager {
 		return true;
 	}
 
-	/** Teardown everything (process exit / main session dispose). */
+	/** Teardown everything; disposing the global manager makes its next owner a fresh instance. */
 	async dispose(deadlineAt: number = Date.now() + AGENT_RELEASE_GRACE_MS): Promise<void> {
 		this.#unsubscribe?.();
 		this.#disposed = true;
@@ -446,6 +446,7 @@ export class AgentLifecycleManager {
 		this.#revivals.clear();
 		this.#parks.clear();
 		this.#persistedReviverFactory = undefined;
+		if (AgentLifecycleManager.#global === this) AgentLifecycleManager.#global = undefined;
 	}
 
 	async #revive(id: string, revive: AgentReviver, ref: AgentRef, adopted: AdoptedAgent): Promise<AgentSession> {

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -127,6 +127,8 @@ export class AgentLifecycleManager {
 	#persistedReviverFactory: PersistedSubagentReviverFactory | undefined;
 	/** TTL applied when a cold-revived ref is adopted on demand. */
 	#persistedReviveTtlMs = 0;
+	/** Set once {@link dispose} runs; blocks late revivals from adopting into a torn-down manager. */
+	#disposed = false;
 
 	constructor(registry: AgentRegistry = AgentRegistry.global()) {
 		this.#registry = registry;
@@ -332,6 +334,14 @@ export class AgentLifecycleManager {
 		let coldAdopted = false;
 		if (!revive && ref.status === "parked" && ref.sessionFile && this.#persistedReviverFactory) {
 			revive = await this.#persistedReviverFactory(ref);
+			// Teardown can complete during the factory await. A late cold revive must
+			// not cold-adopt (and later attach a live session + TTL) into a disposed
+			// manager — reject deterministically before creating any session.
+			if (this.#disposed) {
+				throw new Error(
+					`Agent "${id}" revival aborted: its lifecycle was disposed while its persisted session was being prepared.`,
+				);
+			}
 			if (revive) {
 				adoption = { ref, idleTtlMs: this.#persistedReviveTtlMs, revive };
 				this.#adopted.set(id, adoption);
@@ -414,6 +424,7 @@ export class AgentLifecycleManager {
 	/** Teardown everything (process exit / main session dispose). */
 	async dispose(deadlineAt: number = Date.now() + AGENT_RELEASE_GRACE_MS): Promise<void> {
 		this.#unsubscribe?.();
+		this.#disposed = true;
 		this.#unsubscribe = undefined;
 		const ids = [...new Set([...this.#adopted.keys(), ...this.#parks.keys()])];
 		await Promise.all(
@@ -439,6 +450,14 @@ export class AgentLifecycleManager {
 
 	async #revive(id: string, revive: AgentReviver, ref: AgentRef, adopted: AdoptedAgent): Promise<AgentSession> {
 		const session = await revive(ref);
+		if (this.#disposed) {
+			// The owning lifecycle tore down while the reviver was in flight; dispose
+			// the freshly built session instead of attaching it, and fail the waiter.
+			await session.dispose();
+			throw new Error(
+				`Agent "${id}" revival aborted: its lifecycle was disposed while its persisted session was reviving.`,
+			);
+		}
 		let liveRef = this.#registry.get(id);
 		if (liveRef === ref && ref.status === "parked" && !ref.session) {
 			// A simple reviver returned a session without claiming the parked ref;

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -621,4 +621,76 @@ describe("AgentLifecycleManager", () => {
 		await registerPersistedSubagents(restoredRegistry, rootSessionFile);
 		expect(restoredRegistry.get(workerId)?.status).toBe("aborted");
 	});
+
+	it("a cold revive whose factory resolves after dispose rejects without adopting or arming a TTL", async () => {
+		vi.useFakeTimers();
+		const gate = deferred();
+		const revived = makeSessionStub();
+		let reviverRuns = 0;
+		// Restored-from-disk parked ref: never adopted, so dispose() does not track it.
+		registry.register({
+			id: "Cold-DisposeRace",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: "/tmp/Cold-DisposeRace.jsonl",
+			status: "parked",
+		});
+		lifecycle.setPersistedSubagentReviverFactory(async () => {
+			await gate.promise;
+			return async () => {
+				reviverRuns++;
+				return revived.session;
+			};
+		}, TTL);
+
+		const revival = lifecycle.ensureLive("Cold-DisposeRace");
+		await flushAsync(); // reach the factory await
+		await lifecycle.dispose(Date.now()); // teardown while the factory is in flight
+		gate.resolve(); // factory completes for a superseded owner
+
+		await expect(revival).rejects.toThrow(/disposed/);
+		// Rejected before the reviver ran: no session was ever created.
+		expect(reviverRuns).toBe(0);
+		expect(revived.disposeCalls()).toBe(0);
+		// No adoption, no live session, no armed TTL that could fire a late park.
+		expect(lifecycle.has("Cold-DisposeRace")).toBe(false);
+		expect(registry.get("Cold-DisposeRace")?.session ?? null).toBeNull();
+		expect(registry.get("Cold-DisposeRace")?.status).not.toBe("idle");
+		vi.advanceTimersByTime(TTL * 10);
+		await flushAsync();
+		expect(revived.disposeCalls()).toBe(0);
+	});
+
+	it("a cold revive whose session resolves after dispose disposes that session and rejects", async () => {
+		const gate = deferred();
+		const revived = makeSessionStub();
+		registry.register({
+			id: "Cold-SessionRace",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: "/tmp/Cold-SessionRace.jsonl",
+			status: "parked",
+		});
+		// Factory resolves immediately (cold-adopts), but the reviver — which builds
+		// the live session — is held open across dispose().
+		lifecycle.setPersistedSubagentReviverFactory(
+			async () => async () => {
+				await gate.promise;
+				return revived.session;
+			},
+			TTL,
+		);
+
+		const revival = lifecycle.ensureLive("Cold-SessionRace");
+		await flushAsync(); // reach the reviver await
+		await lifecycle.dispose(Date.now()); // teardown while the reviver is in flight
+		gate.resolve(); // reviver hands back a live session for a disposed owner
+
+		await expect(revival).rejects.toThrow(/disposed/);
+		expect(revived.disposeCalls()).toBe(1);
+		expect(lifecycle.has("Cold-SessionRace")).toBe(false);
+		expect(registry.get("Cold-SessionRace")?.session ?? null).toBeNull();
+	});
 });

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -693,4 +693,24 @@ describe("AgentLifecycleManager", () => {
 		expect(lifecycle.has("Cold-SessionRace")).toBe(false);
 		expect(registry.get("Cold-SessionRace")?.session ?? null).toBeNull();
 	});
+
+	it("a new top-level owner can cold-revive after the previous global lifecycle was disposed", async () => {
+		await lifecycle.dispose(Date.now());
+		const revived = makeSessionStub();
+		registry.register({
+			id: "Next-Owner",
+			displayName: "task",
+			kind: "sub",
+			session: null,
+			sessionFile: "/tmp/Next-Owner.jsonl",
+			status: "parked",
+		});
+
+		const nextLifecycle = AgentLifecycleManager.global();
+		nextLifecycle.setPersistedSubagentReviverFactory(async () => async () => revived.session, 0);
+
+		await expect(nextLifecycle.ensureLive("Next-Owner")).resolves.toBe(revived.session);
+		expect(registry.get("Next-Owner")).toMatchObject({ status: "idle", session: revived.session });
+		expect(revived.disposeCalls()).toBe(0);
+	});
 });


### PR DESCRIPTION
## Repro
A cold persisted-agent revival can complete after `AgentLifecycleManager.dispose()` and still attach its live session. Two windows exist: teardown landing during the reviver-factory await, and during the reviver await. Reproduced with a controllable persisted-reviver factory gated across `dispose()`:

```
bun test test/registry/agent-lifecycle.test.ts   # (with the disposed guard reverted)
2 fail
- Cold-DisposeRace: dispose() during the factory await -> late revive attaches a session + arms a TTL on the disposed manager.
- Cold-SessionRace: dispose() during the reviver await -> late result rejected only via a non-deterministic "replaced/terminal" path.
```

## Cause
`AgentLifecycleManager.dispose()` (`packages/coding-agent/src/registry/agent-lifecycle.ts`) only iterates `#adopted`/`#parks` to release refs. A demand-driven cold revive (`#resolveAndRevive`) does not enter `#adopted` until *after* `await this.#persistedReviverFactory(ref)` returns. When teardown lands inside that await, dispose skips the untracked id and leaves the parked registry ref intact. The factory then resolves, `#resolveAndRevive` cold-adopts, and `#revive` sees the surviving parked ref, calls `attachSession` and `#armTimer`, attaching a live session graph and a TTL onto a torn-down manager. There was no post-await check that a revival's owning lifecycle was still alive.

## Fix
- Add a `#disposed` flag set at the top of `dispose()`.
- In `#resolveAndRevive`, recheck `#disposed` immediately after the reviver-factory await; reject before cold-adopting (no session is created).
- In `#revive`, recheck `#disposed` after the reviver await; dispose the freshly built session and reject.
- Both paths throw a deterministic `disposed` error, preserving existing singleflight behavior for concurrent callers.

## Verification
`bun test test/registry/agent-lifecycle.test.ts` -> 26 pass (24 existing + 2 new regression tests). The two new tests fail on the pre-fix code (one adopts a zombie session/TTL, one rejects with the wrong non-deterministic error) and pass after the fix. Fixes #8114