### PR TITLE
fix(mcp): close stale initial connections

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed stale or unhealthy initial MCP connections leaving child processes or sockets open after `disconnectAll()` or a failed `tools/list` request. ([#8112](https://github.com/can1357/oh-my-pi/issues/8112))
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -498,7 +498,8 @@ export class MCPManager {
 					}
 
 					if (this.#epoch !== connectionEpoch || this.#pendingConnections.get(name) !== connectionPromise) {
-						await this.#discardConnection(name, connection).catch(() => {});
+						this.#detachConnection(name, connection);
+						void disconnectServer(connection).catch(() => {});
 						throw new Error(`Server "${name}" was disconnected during initial connection`);
 					}
 
@@ -546,7 +547,13 @@ export class MCPManager {
 					const serverTools = await listTools(connection);
 					return { connection, serverTools };
 				} catch (error) {
-					await this.#discardConnection(name, connection).catch(() => {});
+					// Detach and delete synchronously, then close in the background:
+					// awaiting a slow HTTP close (session DELETE) here would keep
+					// toolsPromise pending past the startup race, so connectServers
+					// would return with no error while #pendingToolLoads stayed set
+					// and future connects for this server were skipped.
+					this.#detachConnection(name, connection);
+					void disconnectServer(connection).catch(() => {});
 					throw error;
 				}
 			});
@@ -864,11 +871,31 @@ export class MCPManager {
 		);
 	}
 
-	async #discardConnection(name: string, connection: MCPServerConnection): Promise<void> {
+	/**
+	 * Drop a connection from the active map and detach its lifecycle hooks.
+	 *
+	 * Synchronous and identity-guarded: only removes the entry when it is still
+	 * the connection registered under `name`, so a stale cleanup never evicts a
+	 * newer connection for the same server. Detaching `onClose` first prevents
+	 * the transport's own `close()` from re-arming reconnect.
+	 */
+	#detachConnection(name: string, connection: MCPServerConnection): void {
 		connection.transport.onClose = undefined;
 		if (this.#connections.get(name) === connection) {
 			this.#connections.delete(name);
 		}
+	}
+
+	/**
+	 * Detach a connection and await its transport close.
+	 *
+	 * Use only where blocking on the close is acceptable (owned disconnects,
+	 * dispose). On reject-fast paths detach synchronously and close in the
+	 * background so a slow `close()` (HTTP session DELETE) cannot delay the
+	 * rejection — see the `tools/list` failure handler in `connectServers`.
+	 */
+	async #discardConnection(name: string, connection: MCPServerConnection): Promise<void> {
+		this.#detachConnection(name, connection);
 		await disconnectServer(connection);
 	}
 
@@ -1103,7 +1130,8 @@ export class MCPManager {
 		// Bail out if the server was disconnected or the manager was reset
 		// while we were connecting (e.g. /mcp reload called disconnectAll).
 		if (!this.#serverConfigs.has(name) || this.#epoch !== reconnectEpoch) {
-			await this.#discardConnection(name, connection).catch(() => {});
+			this.#detachConnection(name, connection);
+			void disconnectServer(connection).catch(() => {});
 			throw new Error(`Server "${name}" was disconnected during reconnection`);
 		}
 
@@ -1134,8 +1162,10 @@ export class MCPManager {
 			void this.#loadServerResourcesAndPrompts(name, connection);
 			return connection;
 		} catch (error) {
-			// Clean up the connection to avoid zombie transports
-			await this.#discardConnection(name, connection).catch(() => {});
+			// Detach synchronously and close in the background so a slow close
+			// cannot delay the rejection (and the retry backoff that follows).
+			this.#detachConnection(name, connection);
+			void disconnectServer(connection).catch(() => {});
 			throw error;
 		}
 	}

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -475,6 +475,7 @@ export class MCPManager {
 			// Save config early so reconnection works even if the initial connect times out
 			// and falls back to cached/deferred tools.
 			this.#serverConfigs.set(name, config);
+			const connectionEpoch = this.#epoch;
 
 			// Resolve auth config before connecting, but do so per-server in parallel.
 			const connectionPromise = (async () => {
@@ -488,18 +489,22 @@ export class MCPManager {
 					},
 				});
 			})().then(
-				connection => {
+				async connection => {
 					// Store original config (without resolved tokens) to keep
 					// cache keys stable and avoid leaking rotating credentials.
 					connection.config = config;
-					this.#serverConfigs.set(name, config);
 					if (sources[name]) {
 						connection._source = sources[name];
 					}
-					if (this.#pendingConnections.get(name) === connectionPromise) {
-						this.#pendingConnections.delete(name);
-						this.#connections.set(name, connection);
+
+					if (this.#epoch !== connectionEpoch || this.#pendingConnections.get(name) !== connectionPromise) {
+						await this.#discardConnection(name, connection).catch(() => {});
+						throw new Error(`Server "${name}" was disconnected during initial connection`);
 					}
+
+					this.#pendingConnections.delete(name);
+					this.#connections.set(name, connection);
+					this.#serverConfigs.set(name, config);
 
 					// Wire auth refresh for HTTP-like transports so 401s trigger token refresh.
 					// Gate on a resolvable managed credential, not on the auth block:
@@ -537,8 +542,13 @@ export class MCPManager {
 			this.#pendingConnections.set(name, connectionPromise);
 
 			const toolsPromise = connectionPromise.then(async connection => {
-				const serverTools = await listTools(connection);
-				return { connection, serverTools };
+				try {
+					const serverTools = await listTools(connection);
+					return { connection, serverTools };
+				} catch (error) {
+					await this.#discardConnection(name, connection).catch(() => {});
+					throw error;
+				}
 			});
 			this.#pendingToolLoads.set(name, toolsPromise);
 
@@ -854,6 +864,14 @@ export class MCPManager {
 		);
 	}
 
+	async #discardConnection(name: string, connection: MCPServerConnection): Promise<void> {
+		connection.transport.onClose = undefined;
+		if (this.#connections.get(name) === connection) {
+			this.#connections.delete(name);
+		}
+		await disconnectServer(connection);
+	}
+
 	/**
 	 * Disconnect from a specific server.
 	 */
@@ -875,10 +893,7 @@ export class MCPManager {
 		this.#subscribedResources.delete(name);
 
 		if (connection) {
-			// Detach onClose to prevent spurious reconnect from close()
-			connection.transport.onClose = undefined;
-			await disconnectServer(connection);
-			this.#connections.delete(name);
+			await this.#discardConnection(name, connection);
 		}
 
 		// Remove tools from this server and notify consumers
@@ -897,11 +912,7 @@ export class MCPManager {
 		// Invalidate any in-flight reconnection attempts that outlive this call.
 		// They captured the old epoch; after increment they'll detect staleness.
 		this.#epoch++;
-		// Detach onClose before closing to prevent spurious reconnect attempts
-		for (const conn of this.#connections.values()) {
-			conn.transport.onClose = undefined;
-		}
-		const promises = Array.from(this.#connections.values()).map(conn => disconnectServer(conn));
+		const promises = Array.from(this.#connections, ([name, connection]) => this.#discardConnection(name, connection));
 		await Promise.allSettled(promises);
 
 		this.#pendingConnections.clear();
@@ -910,7 +921,6 @@ export class MCPManager {
 		this.#pendingResourceRefresh.clear();
 		this.#sources.clear();
 		this.#serverConfigs.clear();
-		this.#connections.clear();
 		this.#tools = [];
 		this.#subscribedResources.clear();
 		this.#reconnectHistory.clear();
@@ -978,9 +988,7 @@ export class MCPManager {
 			// transport's own `close()` cannot re-arm this path.
 			const stale = this.#connections.get(name);
 			if (stale) {
-				stale.transport.onClose = undefined;
-				void stale.transport.close().catch(() => {});
-				this.#connections.delete(name);
+				void this.#discardConnection(name, stale).catch(() => {});
 			}
 			this.#pendingConnections.delete(name);
 			this.#pendingToolLoads.delete(name);
@@ -1022,10 +1030,7 @@ export class MCPManager {
 		// reconnect loop by that amount on every server restart.
 		const reconnectEpoch = this.#epoch;
 		if (oldConnection) {
-			// Detach onClose to prevent re-entrant reconnect from the close itself
-			oldConnection.transport.onClose = undefined;
-			void oldConnection.transport.close().catch(() => {});
-			this.#connections.delete(name);
+			void this.#discardConnection(name, oldConnection).catch(() => {});
 		}
 		this.#pendingConnections.delete(name);
 		this.#pendingToolLoads.delete(name);
@@ -1098,7 +1103,7 @@ export class MCPManager {
 		// Bail out if the server was disconnected or the manager was reset
 		// while we were connecting (e.g. /mcp reload called disconnectAll).
 		if (!this.#serverConfigs.has(name) || this.#epoch !== reconnectEpoch) {
-			await connection.transport.close().catch(() => {});
+			await this.#discardConnection(name, connection).catch(() => {});
 			throw new Error(`Server "${name}" was disconnected during reconnection`);
 		}
 
@@ -1130,9 +1135,7 @@ export class MCPManager {
 			return connection;
 		} catch (error) {
 			// Clean up the connection to avoid zombie transports
-			connection.transport.onClose = undefined;
-			await connection.transport.close().catch(() => {});
-			this.#connections.delete(name);
+			await this.#discardConnection(name, connection).catch(() => {});
 			throw error;
 		}
 	}

--- a/packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts
+++ b/packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts
@@ -12,6 +12,12 @@ class FakeTransport implements MCPTransport {
 	connected = true;
 	closeCalls = 0;
 	onClose?: () => void;
+	#closeGate?: Promise<void>;
+
+	/** Make `close()` hang on the given gate to simulate a slow HTTP session DELETE. */
+	gateClose(gate: Promise<void>): void {
+		this.#closeGate = gate;
+	}
 
 	request<T>(): Promise<T> {
 		throw new Error("Unexpected transport request");
@@ -22,6 +28,7 @@ class FakeTransport implements MCPTransport {
 	async close(): Promise<void> {
 		this.closeCalls += 1;
 		this.connected = false;
+		if (this.#closeGate) await this.#closeGate;
 	}
 }
 
@@ -112,5 +119,30 @@ describe("MCPManager initial connection ownership", () => {
 		expect(current.transport.closeCalls).toBe(0);
 		expect(manager.getConnectedServers()).toEqual(["server"]);
 		await manager.disconnectAll();
+	});
+
+	it("reports a tools/list failure and re-enables connects even when close hangs", async () => {
+		const manager = new MCPManager(process.cwd());
+		const failed = fakeConnection("server");
+		const stuckClose = Promise.withResolvers<void>();
+		failed.transport.gateClose(stuckClose.promise);
+		const connectSpy = vi
+			.spyOn(mcpClient, "connectToServer")
+			.mockResolvedValueOnce(failed.connection)
+			.mockRejectedValue(new Error("second connect refused"));
+		vi.spyOn(mcpClient, "listTools").mockRejectedValueOnce(new Error("initial tools/list failed"));
+
+		// close() never settles, but the failure must still surface and clear
+		// pending state so the server is not silently skipped forever.
+		const result = await manager.connectServers({ server: CONFIG }, {});
+		expect(result.errors.get("server")).toBe("initial tools/list failed");
+		expect(failed.transport.closeCalls).toBe(1);
+		expect(manager.getConnectedServers()).toEqual([]);
+
+		// A subsequent connect is attempted rather than skipped on stale pending state.
+		await manager.connectServers({ server: CONFIG }, {});
+		expect(connectSpy).toHaveBeenCalledTimes(2);
+
+		stuckClose.resolve();
 	});
 });

--- a/packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts
+++ b/packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as mcpClient from "@oh-my-pi/pi-coding-agent/mcp/client";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import type { MCPServerConnection, MCPStdioServerConfig, MCPTransport } from "@oh-my-pi/pi-coding-agent/mcp/types";
+
+const CONFIG: MCPStdioServerConfig = {
+	type: "stdio",
+	command: "fake-mcp-server",
+};
+
+class FakeTransport implements MCPTransport {
+	connected = true;
+	closeCalls = 0;
+	onClose?: () => void;
+
+	request<T>(): Promise<T> {
+		throw new Error("Unexpected transport request");
+	}
+
+	async notify(): Promise<void> {}
+
+	async close(): Promise<void> {
+		this.closeCalls += 1;
+		this.connected = false;
+	}
+}
+
+function fakeConnection(name: string): { connection: MCPServerConnection; transport: FakeTransport } {
+	const transport = new FakeTransport();
+	return {
+		connection: {
+			name,
+			config: CONFIG,
+			transport,
+			serverInfo: { name: "fake", version: "1.0.0" },
+			capabilities: { tools: {} },
+		},
+		transport,
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("MCPManager initial connection ownership", () => {
+	it("closes a connection that resolves after disconnectAll", async () => {
+		const manager = new MCPManager(process.cwd());
+		const deferred = Promise.withResolvers<MCPServerConnection>();
+		const connectStarted = Promise.withResolvers<void>();
+		const stale = fakeConnection("server");
+		vi.spyOn(mcpClient, "connectToServer").mockImplementation(() => {
+			connectStarted.resolve();
+			return deferred.promise;
+		});
+		vi.spyOn(mcpClient, "listTools").mockResolvedValue([]);
+
+		const loading = manager.connectServers({ server: CONFIG }, {});
+		await connectStarted.promise;
+		await manager.disconnectAll();
+		deferred.resolve(stale.connection);
+		await loading;
+
+		expect(stale.transport.closeCalls).toBe(1);
+		expect(manager.getConnectedServers()).toEqual([]);
+	});
+
+	it("closes and forgets a connection whose initial tools/list fails", async () => {
+		const manager = new MCPManager(process.cwd());
+		const failed = fakeConnection("server");
+		vi.spyOn(mcpClient, "connectToServer").mockResolvedValue(failed.connection);
+		vi.spyOn(mcpClient, "listTools").mockRejectedValue(new Error("initial tools/list failed"));
+
+		const result = await manager.connectServers({ server: CONFIG }, {});
+
+		expect(result.errors.get("server")).toBe("initial tools/list failed");
+		expect(failed.transport.closeCalls).toBe(1);
+		expect(manager.getConnectedServers()).toEqual([]);
+	});
+
+	it("does not close a newer connection while cleaning up a stale result", async () => {
+		const manager = new MCPManager(process.cwd());
+		const firstDeferred = Promise.withResolvers<MCPServerConnection>();
+		const secondDeferred = Promise.withResolvers<MCPServerConnection>();
+		const firstStarted = Promise.withResolvers<void>();
+		const secondStarted = Promise.withResolvers<void>();
+		const stale = fakeConnection("server");
+		const current = fakeConnection("server");
+		vi.spyOn(mcpClient, "connectToServer")
+			.mockImplementationOnce(() => {
+				firstStarted.resolve();
+				return firstDeferred.promise;
+			})
+			.mockImplementationOnce(() => {
+				secondStarted.resolve();
+				return secondDeferred.promise;
+			});
+		vi.spyOn(mcpClient, "listTools").mockResolvedValue([]);
+
+		const firstLoad = manager.connectServers({ server: CONFIG }, {});
+		await firstStarted.promise;
+		await manager.disconnectAll();
+		const secondLoad = manager.connectServers({ server: CONFIG }, {});
+		await secondStarted.promise;
+
+		firstDeferred.resolve(stale.connection);
+		await firstLoad;
+		secondDeferred.resolve(current.connection);
+		await secondLoad;
+
+		expect(stale.transport.closeCalls).toBe(1);
+		expect(current.transport.closeCalls).toBe(0);
+		expect(manager.getConnectedServers()).toEqual(["server"]);
+		await manager.disconnectAll();
+	});
+});


### PR DESCRIPTION
## Repro
A controllable fake transport holds the initial connection across `disconnectAll()`, rejects the first `tools/list`, and overlaps an obsolete result with a newer connection. Before the fix, `bun test packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts` failed all three cases because the stale transport’s `close()` call count remained 0.

## Cause
`MCPManager.connectServers()` in `packages/coding-agent/src/mcp/manager.ts` only conditionally published an initial connection; an obsolete result still continued into callback wiring and tool loading. The initial tool-load rejection handler then deleted pending state without closing the already-published connection. Existing close/delete paths also deleted by server name rather than connection identity.

## Fix
- Reject and dispose initial connection results whose epoch or pending-promise identity is obsolete before publishing or wiring them.
- Dispose the owned connection when its initial `tools/list` fails.
- Centralize transport disposal with connection-identity-guarded map deletion so stale cleanup cannot remove a newer connection.
- Add regression coverage for late resolution, initial list failure, and overlapping stale/current connections; record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/mcp-manager-initial-connection-cleanup.test.ts packages/coding-agent/test/mcp-reconnect-storm.test.ts packages/coding-agent/test/mcp-dispose-disconnect-bounded.test.ts packages/coding-agent/test/mcp-connection-status-events.test.ts` passed 6 tests with 18 assertions. `bun run check` in `packages/coding-agent` passed.

Fixes #8112