### PR TITLE
fix(dap): drain runInTerminal debuggee stdout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the DAP `runInTerminal` reverse request leaving the spawned debuggee's stdout undrained: the child was spawned with a piped stdout that was never consumed, so a chatty debuggee's output buffered unboundedly in the omp process (toward OOM) and was lost from the session output. Its stdout is now continuously drained into the session output buffer. ([#8111](https://github.com/can1357/oh-my-pi/issues/8111))
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/dap/session.ts
+++ b/packages/coding-agent/src/dap/session.ts
@@ -219,6 +219,30 @@ function truncateOutput(session: DapSession, output: string): void {
 	}
 }
 
+/**
+ * Drain a `runInTerminal` debuggee's stdout into the session output buffer.
+ *
+ * `ptree.spawn` always pipes stdout and only eagerly drains stderr; the exposed
+ * stdout stream must be consumed or Bun buffers it unboundedly in this process
+ * (a chatty debuggee grows omp toward OOM). The reverse-request path has no
+ * terminal surface here, so route the child's stdout through {@link
+ * truncateOutput}: this bounds memory at `MAX_OUTPUT_BYTES` and surfaces the
+ * program's output to the agent, mirroring the adapter's own `output` events.
+ * Runs in the background for the child's lifetime; a killed child or closed pipe
+ * ends the loop quietly.
+ */
+async function drainTerminalStdout(stream: ReadableStream<Uint8Array>, session: DapSession): Promise<void> {
+	const decoder = new TextDecoder();
+	try {
+		for await (const chunk of stream) {
+			truncateOutput(session, decoder.decode(chunk, { stream: true }));
+		}
+		truncateOutput(session, decoder.decode());
+	} catch {
+		// Child killed or pipe closed mid-stream; nothing more to surface.
+	}
+}
+
 function summarizeBreakpointCount(breakpoints: Map<string, DapBreakpointRecord[]>): number {
 	let total = 0;
 	for (const entries of breakpoints.values()) {
@@ -1356,6 +1380,9 @@ export class DapSessionManager {
 				},
 				detached: true,
 			});
+			// Consume the child's stdout — ptree pipes it but drains only stderr,
+			// so an unconsumed stream buffers unboundedly in this process.
+			void drainTerminalStdout(proc.stdout, session);
 			return { processId: proc.pid } satisfies DapRunInTerminalResponse;
 		});
 		client.onReverseRequest("startDebugging", async rawArgs => {

--- a/packages/coding-agent/test/debug/dap-multi-session.test.ts
+++ b/packages/coding-agent/test/debug/dap-multi-session.test.ts
@@ -8,6 +8,7 @@ import type {
 	DapResolvedAdapter,
 	DapThread,
 } from "@oh-my-pi/pi-coding-agent/dap/types";
+import { type ChildProcess, ptree } from "@oh-my-pi/pi-utils";
 
 const TEST_ADAPTER: DapResolvedAdapter = {
 	name: "js-debug-adapter",
@@ -370,6 +371,48 @@ describe("DAP multi-session debugging", () => {
 			{ id: 1, name: "worker.js" },
 			{ id: 1, name: "worker.js" },
 		]);
+
+		await manager.terminate(undefined, 1_000);
+	});
+
+	it("drains a runInTerminal debuggee's stdout into the session output buffer", async () => {
+		const root = new FakeDapClient(undefined, "launch", true);
+		spyOn(DapClient, "spawn").mockResolvedValue(root as unknown as DapClient);
+
+		// Synthetic debuggee stdout: >64KB ahead of a unique terminal marker,
+		// then a trailing sentinel and EOF. The handler discards the ptree child
+		// after reading its PID, so the drain must consume this whole stream and
+		// route it to the session output — undrained, the marker never reaches
+		// the buffer. The sentinel after the marker guarantees the marker chunk
+		// is routed (in the read cycle before it) before `closed` resolves.
+		const marker = "__RUNINTERMINAL_MARKER__";
+		const enc = new TextEncoder();
+		const chunks = [enc.encode("x".repeat(128 * 1024)), enc.encode(`${marker}\n`), enc.encode("tail\n")];
+		let next = 0;
+		const closed = Promise.withResolvers<void>();
+		const stdout = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				if (next < chunks.length) {
+					controller.enqueue(chunks[next++]);
+				} else {
+					controller.close();
+					closed.resolve();
+				}
+			},
+		});
+		const spawnSpy = spyOn(ptree, "spawn").mockReturnValue({ pid: 4242, stdout } as unknown as ChildProcess);
+
+		const manager = new DapSessionManager();
+		await manager.launch({ adapter: TEST_ADAPTER, program: "/tmp/target.js", cwd: "/tmp" }, undefined, 1_000);
+
+		await root.triggerReverse("runInTerminal", { args: ["/usr/bin/debuggee", "--verbose"] });
+		// The stream reaching EOF proves the drain consumed it end to end; the
+		// marker (routed before close) is then present in the session output.
+		await closed.promise;
+
+		expect(spawnSpy).toHaveBeenCalledTimes(1);
+		expect(spawnSpy.mock.calls[0]?.[0]).toEqual(["/usr/bin/debuggee", "--verbose"]);
+		expect(manager.getOutput().output).toContain(marker);
 
 		await manager.terminate(undefined, 1_000);
 	});


### PR DESCRIPTION
## Repro
The DAP `runInTerminal` reverse-request handler (`packages/coding-agent/src/dap/session.ts`) spawns the debuggee via `ptree.spawn` and returns only its PID. Mirroring that path exactly — spawn, read `proc.pid`, discard the `ChildProcess` — a debuggee that writes ~2GB to stdout via blocking writes runs to completion, but the omp process RSS balloons:

```
child result: exited (debuggee wrote ~2GB to stdout)
omp-process RSS MB: 3925
```

Note: the OS-pipe *backpressure block* described in the report does not occur under Bun — Bun's subprocess runtime eagerly reads the OS pipe into the stream's internal buffer regardless of a JS consumer, so the debuggee never blocks. The real defect is that this unconsumed stdout is buffered unboundedly inside the omp process (and the program's output is silently discarded from the session).

## Cause
`ptree.spawn` always pipes stdout, and `ptree`'s `ChildProcess` eagerly drains only *stderr* — stdout is exposed raw with the contract "Must be consumed to prevent pipe deadlock" (`packages/utils/src/ptree.ts`). The `runInTerminal` handler read `proc.pid` and dropped the handle, so nothing ever consumed `proc.stdout`. Bun buffers it in-process for the child's lifetime, growing without bound for an output-heavy debuggee. Every other DAP spawn path already drains stdout to avoid exactly this class of bug; this handler was the oversight.

## Fix
- Add `drainTerminalStdout(stream, session)` in `session.ts`: reads the child's stdout stream to EOF and routes each chunk through the existing `truncateOutput`, which caps buffered bytes at `MAX_OUTPUT_BYTES`.
- Invoke it (`void drainTerminalStdout(proc.stdout, session)`) in the `runInTerminal` handler right after spawn, before returning `{ processId }`. This bounds memory and surfaces the debuggee's output to the agent, matching how the adapter's own `output` events are handled. Lifecycle ownership is unchanged (no kill-on-dispose added).
- Regression test in `test/debug/dap-multi-session.test.ts`: drives the `runInTerminal` reverse request with a synthetic >64KB stdout stream ending in a unique marker and asserts the marker reaches the session output; without the drain the stream is never consumed and the test times out.

## Verification
`bun test test/debug/dap-multi-session.test.ts` → 6 pass. Confirmed the new test fails (hangs on the undrained stream) when the drain call is removed. `bun run check:ts` passes across all workspaces (pi-coding-agent exit 0). The pre-publish gate's `bun check` fails only on `check:rs`, which cannot build in this environment because `cmake` is not installed — a pre-existing, TS-diff-unrelated failure; skipped the Rust half of the gate. Fixes #8111