### PR TITLE
feat(ai): enable Azure explicit prompt caching

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Added opt-in implicit and explicit 30-minute prompt caching for Azure OpenAI GPT-5.6+ Responses requests, including stable-history breakpoint markers, while preserving the existing prompt-cache key.
 
 ## [17.2.12] - 2026-08-08
 

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -37,6 +37,7 @@ import {
 	createInitialResponsesAssistantMessage,
 	getOpenAIPromptCacheKey,
 	isOpenAIResponsesProgressEvent,
+	markLatestStableResponsesCacheBreakpoint,
 	parseAzureDeploymentNameMap,
 	processResponsesStream,
 } from "./openai-shared";
@@ -83,11 +84,6 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 	context: Context,
 	options?: AzureOpenAIResponsesOptions,
 ): AssistantMessageEventStream => {
-	if (options?.promptCache?.mode === "explicit" && resolveCacheRetention(options.cacheRetention) !== "none") {
-		throw new AIError.ConfigurationError(
-			`OpenAI explicit prompt caching is unsupported for ${model.provider}/${model.id}; Azure Responses does not emit explicit cache controls.`,
-		);
-	}
 	const stream = new AssistantMessageEventStream();
 
 	// Start async processing
@@ -370,19 +366,23 @@ function buildParams(
 		preserveAssistantMessageIds: true,
 	});
 
+	const promptCache = options?.promptCache;
+	const cacheEnabled = promptCache && resolveCacheRetention(options?.cacheRetention) !== "none";
 	const params: AzureOpenAIResponsesSamplingParams = {
 		model: deploymentName,
 		input: messages,
 		stream: true,
 		prompt_cache_key: getOpenAIPromptCacheKey(options),
+		...(cacheEnabled ? { prompt_cache_options: { mode: promptCache.mode, ttl: promptCache.ttl ?? "30m" } } : {}),
 		// Encrypted reasoning replay (applyResponsesReasoningParams) requires
 		// stateless responses, matching the openai provider.
 		store: false,
 	};
-
+	if (cacheEnabled && promptCache.mode === "explicit" && promptCache.breakpoint !== "none") {
+		markLatestStableResponsesCacheBreakpoint(messages);
+	}
 	applyCommonResponsesSamplingParams(params, options, model);
 	if (options?.include?.length) params.include = Array.from(new Set(options.include));
-
 	if (context.tools) {
 		const serializedTools: NonNullable<AzureOpenAIResponsesSamplingParams["tools"]> = [];
 		for (const tool of context.tools) {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -88,6 +88,7 @@ import {
 	isOpenAIResponsesProgressEvent,
 	isOpenRouterAnthropicModel,
 	isStrictToolsDisabledForScope,
+	markLatestStableResponsesCacheBreakpoint as markLatestStableResponsesCacheBreakpointShared,
 	type OpenAIPromptCacheOptions,
 	type OpenAIStrictToolsScope,
 	type OpenAIStrictToolsState,
@@ -1015,46 +1016,10 @@ function markLatestStableResponsesCacheBreakpoint(
 	if (statefulBaseline) {
 		if (restoreResponsesCacheBreakpointsFromBaseline(input, statefulBaseline)) return true;
 		// A prior marker whose content no longer matches means chaining will
-		// reset to a full replay. Recompute a fresh boundary for that replay.
-		// Markerless baselines stay markerless so appends do not mutate them.
+		// reset to a full replay. Markerless baselines stay markerless.
 		if (!hasResponsesCacheBreakpoint(statefulBaseline)) return false;
 	}
-
-	let latestInputMessage = -1;
-	for (let i = input.length - 1; i >= 0; i--) {
-		const message = input[i];
-		if (!("role" in message)) continue;
-		if (message.role === "user" || message.role === "developer") {
-			latestInputMessage = i;
-			break;
-		}
-	}
-	if (latestInputMessage <= 0) return false;
-
-	for (let i = latestInputMessage - 1; i >= 0; i--) {
-		const message = input[i];
-		if (isStableStringResponsesInstruction(message)) {
-			const text = message.content;
-			Object.assign(message, {
-				content: [
-					{
-						type: "input_text",
-						text,
-						prompt_cache_breakpoint: { mode: "explicit" },
-					},
-				],
-			});
-			return true;
-		}
-		if (!isResponsesPromptCacheableMessage(message)) continue;
-		for (let j = message.content.length - 1; j >= 0; j--) {
-			const block = message.content[j];
-			if (!isResponsesPromptCacheableContentBlock(block)) continue;
-			Object.assign(block, { prompt_cache_breakpoint: { mode: "explicit" } });
-			return true;
-		}
-	}
-	return false;
+	return markLatestStableResponsesCacheBreakpointShared(input);
 }
 
 function applyOpenAIResponsesPromptCachePolicy(

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -114,6 +114,46 @@ import type {
 import { transformMessages } from "./transform-messages";
 import { joinTextWithImagePlaceholder, NON_VISION_IMAGE_PLACEHOLDER, partitionVisionContent } from "./vision-guard";
 
+/** Mark the latest stable Responses input prefix for explicit prompt caching. */
+export function markLatestStableResponsesCacheBreakpoint(input: ResponseInput | undefined): boolean {
+	if (!input) return false;
+	let latestInputMessage = -1;
+	for (let i = input.length - 1; i >= 0; i--) {
+		const message = input[i];
+		if (!message || !("role" in message)) continue;
+		if (message.role === "user" || message.role === "developer") {
+			latestInputMessage = i;
+			break;
+		}
+	}
+	if (latestInputMessage <= 0) return false;
+
+	for (let i = latestInputMessage - 1; i >= 0; i--) {
+		const message = input[i];
+		if (
+			message &&
+			"role" in message &&
+			"content" in message &&
+			(message.role === "developer" || message.role === "system") &&
+			typeof message.content === "string" &&
+			message.content.length > 0
+		) {
+			Object.assign(message, {
+				content: [{ type: "input_text", text: message.content, prompt_cache_breakpoint: { mode: "explicit" } }],
+			});
+			return true;
+		}
+		if (!message || !("content" in message) || !Array.isArray(message.content)) continue;
+		for (let j = message.content.length - 1; j >= 0; j--) {
+			const block = message.content[j];
+			if (!block || typeof block !== "object" || !("type" in block)) continue;
+			if (block.type !== "input_text" && block.type !== "input_image" && block.type !== "input_file") continue;
+			Object.assign(block, { prompt_cache_breakpoint: { mode: "explicit" } });
+			return true;
+		}
+	}
+	return false;
+}
 /**
  * Keyless-provider sentinel. Custom providers configured with `auth: none`
  * (models.yml) have no credential, so the coding-agent resolves their API key

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import {
-	type AzureOpenAIResponsesOptions,
-	streamAzureOpenAIResponses,
-} from "@oh-my-pi/pi-ai/providers/azure-openai-responses";
+import { streamAzureOpenAIResponses } from "@oh-my-pi/pi-ai/providers/azure-openai-responses";
 import {
 	buildParams,
 	type OpenAIResponsesOptions,
@@ -442,7 +439,7 @@ describe("OpenAI Responses explicit prompt cache policy", () => {
 		}
 	});
 
-	it("rejects explicit policy through streamSimple before sending unsupported Responses requests", () => {
+	it("rejects explicit policy for unsupported OpenAI Responses models", () => {
 		const unsupportedModel: Model<"openai-responses"> = {
 			...openAI56ResponsesModel,
 			id: "gpt-5.5",
@@ -468,32 +465,73 @@ describe("OpenAI Responses explicit prompt cache policy", () => {
 		expect(() => streamSimple(unsupportedModel, context, options)).toThrow(
 			"OpenAI explicit prompt caching is unsupported",
 		);
-		expect(() => streamSimple(azureOpenAI56ResponsesModel, context, options)).toThrow(
-			"OpenAI explicit prompt caching is unsupported",
-		);
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
-	it("rejects explicit policy through typed and direct Azure Responses dispatch", () => {
-		const fetchMock: FetchImpl = vi.fn(async () => {
-			throw new Error("Unsupported Azure Responses requests must not reach fetch");
+	it("sends Azure explicit policy with a stable-prefix breakpoint", async () => {
+		let body: Record<string, unknown> | undefined;
+		const fetchMock: FetchImpl = vi.fn(async (_input, init) => {
+			body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			return createSseResponse([{ type: "response.completed", response: { status: "completed" } }]);
 		});
-		const context: Context = {
-			messages: [{ role: "user", content: [{ type: "text", text: "prompt" }], timestamp: 0 }],
-		};
-		const options: AzureOpenAIResponsesOptions = {
+
+		await streamModel(azureOpenAI56ResponsesModel, historicalContext, {
 			apiKey: "test-key",
+			sessionId: "session-key",
 			promptCache: { mode: "explicit" },
 			fetch: fetchMock,
-		};
+		}).result();
 
-		expect(() => streamModel(azureOpenAI56ResponsesModel, context, options)).toThrow(
-			"OpenAI explicit prompt caching is unsupported",
-		);
-		expect(() => streamAzureOpenAIResponses(azureOpenAI56ResponsesModel, context, options)).toThrow(
-			"OpenAI explicit prompt caching is unsupported",
-		);
-		expect(fetchMock).not.toHaveBeenCalled();
+		expect(body?.prompt_cache_key).toBe("session-key");
+		expect(body?.prompt_cache_options).toEqual({ mode: "explicit", ttl: "30m" });
+		const input = body?.input;
+		if (!Array.isArray(input)) throw new Error("Expected Responses input");
+		expect(input[0]).toMatchObject({
+			content: [{ prompt_cache_breakpoint: { mode: "explicit" } }],
+		});
+		expect(input[1]).not.toMatchObject({
+			content: [{ prompt_cache_breakpoint: expect.anything() }],
+		});
+	});
+	it("omits Azure explicit breakpoints when opted out", async () => {
+		let body: Record<string, unknown> | undefined;
+		const fetchMock: FetchImpl = vi.fn(async (_input, init) => {
+			body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			return createSseResponse([{ type: "response.completed", response: { status: "completed" } }]);
+		});
+
+		await streamModel(azureOpenAI56ResponsesModel, historicalContext, {
+			apiKey: "test-key",
+			promptCache: { mode: "explicit", breakpoint: "none" },
+			fetch: fetchMock,
+		}).result();
+
+		expect(body?.prompt_cache_options).toEqual({ mode: "explicit", ttl: "30m" });
+		expect(JSON.stringify(body?.input)).not.toContain("prompt_cache_breakpoint");
+	});
+
+	it("sends the implicit 30-minute cache policy for Azure Responses", async () => {
+		let body: Record<string, unknown> | undefined;
+		const fetchMock: FetchImpl = vi.fn(async (_input, init) => {
+			body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			return createSseResponse([{ type: "response.completed", response: { status: "completed" } }]);
+		});
+
+		await streamAzureOpenAIResponses(
+			azureOpenAI56ResponsesModel,
+			{
+				messages: [{ role: "user", content: [{ type: "text", text: "prompt" }], timestamp: 0 }],
+			},
+			{
+				apiKey: "test-key",
+				sessionId: "session-key",
+				promptCache: { mode: "implicit" },
+				fetch: fetchMock,
+			},
+		).result();
+
+		expect(body?.prompt_cache_key).toBe("session-key");
+		expect(body?.prompt_cache_options).toEqual({ mode: "implicit", ttl: "30m" });
 	});
 
 	it("defers explicit policy validation to the gateway-resolved model for pi-native transport", async () => {

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -135,12 +135,13 @@ function isOfficialOpenAIEndpoint(provider: string, baseUrl: string): boolean {
 }
 
 /**
- * Explicit prompt-cache breakpoints are a GPT-5.6+ first-party contract. Keep
- * this intentionally narrow: compatible gateways and older OpenAI models
- * reject the new request fields unless their catalog compat opts in.
+ * Explicit prompt-cache breakpoints are a GPT-5.6+ first-party OpenAI/Azure contract. Keep
+ * this intentionally narrow: compatible gateways and older models reject the new request
+ * fields unless their catalog compat opts in.
  */
 function supportsOfficialOpenAIPromptCacheBreakpoints(provider: string, modelId: string, baseUrl: string): boolean {
-	if (!isOfficialOpenAIEndpoint(provider, baseUrl)) return false;
+	const isAzure = provider === "azure" || provider === "azure-openai";
+	if (!isAzure && !isOfficialOpenAIEndpoint(provider, baseUrl)) return false;
 	const model = parseOpenAIModel(bareModelId(modelId));
 	return model !== null && semverGte(model.version, "5.6");
 }

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -541,6 +541,15 @@ describe("OpenAI explicit prompt-cache breakpoint compat", () => {
 		expect(responses.supportsPromptCacheBreakpoints).toBe(true);
 		expect(responses.promptCacheBreakpointTtl).toBe("30m");
 
+		const azure = buildOpenAIResponsesCompat({
+			id: "gpt-5.6-luna",
+			provider: "azure",
+			name: "GPT 5.6 Luna",
+			baseUrl: "",
+		});
+		expect(azure.supportsPromptCacheBreakpoints).toBe(true);
+		expect(azure.promptCacheBreakpointTtl).toBe("30m");
+
 		expect(
 			buildOpenAICompat(
 				completionsSpec({ id: "gpt-5.6-preview", provider: "openai", baseUrl: "https://api.openai.com/v1" }),


### PR DESCRIPTION
## Summary

- Enable implicit and explicit 30-minute prompt caching for Azure OpenAI Responses models that pass the GPT-5.6+ capability gate.
- Mark the latest stable Responses input prefix for explicit caching.
- Share breakpoint marking between OpenAI and Azure Responses providers.

## Verification

- `bun install --frozen-lockfile`
- `bun run --workspaces --if-present check`
- Live Azure Responses request with `gpt-5.6-luna` accepted the explicit cache controls and breakpoint marker.

Focused provider tests require the platform native addon; this checkout cannot build it because Bazel/Bazelisk is unavailable.