### PR TITLE
fix(coding-agent): interpret inline /skill in mode-command prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a `/skill:<name>` token embedded in a `/plan` or `/vibe` inline prompt being sent to the agent as literal text instead of loading the skill; mode-command inline prompts now dispatch skill invocations through the same custom-message path as the editor submit flow ([#8137](https://github.com/can1357/oh-my-pi/issues/8137)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -196,6 +196,7 @@ import {
 import { createSessionTeardown, type SessionTeardown } from "./session-teardown";
 import { runProviderSetupWizard } from "./setup-wizard/lazy";
 import { interruptHint } from "./shared";
+import { invokeSkillCommandFromText, isKnownSkillCommand } from "./skill-command";
 import { clearMermaidCache } from "./theme/mermaid-cache";
 import { type ShimmerPalette, shimmerEnabled, shimmerSegments, shimmerText } from "./theme/shimmer";
 import type { Theme } from "./theme/theme";
@@ -3320,9 +3321,26 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 		await this.#enterPlanMode();
-		if (initialPrompt && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt }));
+		if (initialPrompt) {
+			await this.#submitModeInitialPrompt(initialPrompt);
 		}
+	}
+
+	/**
+	 * Submit a mode command's inline `[prompt]` (`/plan`, `/vibe`) as the first
+	 * turn after entering the mode. A prompt that invokes a registered skill —
+	 * `/skill:<name>` at the start or embedded mid-prompt — is dispatched through
+	 * the skill custom-message path (mirroring the editor submit flow in
+	 * `InputController`); otherwise the raw text is submitted as a normal prompt.
+	 * Without this the skill token reached the agent as literal text (issue #8137).
+	 */
+	async #submitModeInitialPrompt(initialPrompt: string): Promise<void> {
+		if (!this.onInputCallback) return;
+		if (isKnownSkillCommand(this, initialPrompt)) {
+			await invokeSkillCommandFromText(this, initialPrompt, "steer");
+			return;
+		}
+		this.onInputCallback(this.startPendingSubmission({ text: initialPrompt }));
 	}
 
 	/**
@@ -3346,8 +3364,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 		await this.#enterVibeMode();
-		if (initialPrompt && this.onInputCallback) {
-			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt }));
+		if (initialPrompt) {
+			await this.#submitModeInitialPrompt(initialPrompt);
 		}
 	}
 

--- a/packages/coding-agent/test/issue-8137-repro.test.ts
+++ b/packages/coding-agent/test/issue-8137-repro.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { Skill } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { HistoryStorage } from "@oh-my-pi/pi-coding-agent/session/history-storage";
+import { SKILL_PROMPT_MESSAGE_TYPE } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Issue #8137 — a `/skill:<name>` token embedded in a `/plan [prompt]` (or
+ * `/vibe [prompt]`) inline prompt was delivered to the agent as literal text
+ * instead of loading the skill.
+ *
+ * Contract: entering plan/vibe mode with an inline prompt whose text invokes a
+ * registered skill dispatches the skill as a user-attributed
+ * SKILL_PROMPT_MESSAGE (surrounding prose collapsed into the skill args),
+ * rather than submitting the raw `.../skill:<name>` text as a normal prompt.
+ */
+describe("issue #8137 — inline /skill in mode-command prompts", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let mode: InteractiveMode;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-issue-8137-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const defaultModel = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!defaultModel) throw new Error("Expected claude-sonnet-4-5 in registry");
+
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model: defaultModel,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+
+		const skillPath = path.join(tempDir.path(), "grilling.md");
+		await Bun.write(skillPath, "---\nname: grilling\n---\nGrill the steak thoroughly.\n");
+		const skill: Skill = {
+			name: "grilling",
+			description: "Grilling skill",
+			filePath: skillPath,
+			baseDir: tempDir.path(),
+			source: "test",
+		};
+		mode.skillCommands.set("skill:grilling", skill);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		mode?.stop();
+		HistoryStorage.resetInstance();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	it("dispatches an inline /skill invocation from a /plan prompt as a skill message", async () => {
+		const promptCustomMessage = vi.spyOn(session, "promptCustomMessage").mockResolvedValue(undefined);
+		let submitted: { text: string } | undefined;
+		mode.onInputCallback = input => {
+			submitted = input;
+		};
+
+		await mode.handlePlanModeCommand("do X /skill:grilling");
+
+		expect(mode.planModeEnabled).toBe(true);
+		// The skill goes through the custom-message path, NOT a raw prompt.
+		expect(submitted).toBeUndefined();
+		expect(promptCustomMessage).toHaveBeenCalledTimes(1);
+		const [message] = promptCustomMessage.mock.calls[0] ?? [];
+		expect(message?.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
+		expect(message?.details).toMatchObject({ name: "grilling", args: "do X" });
+	});
+
+	it("still submits a non-skill /plan prompt as a normal prompt", async () => {
+		const promptCustomMessage = vi.spyOn(session, "promptCustomMessage").mockResolvedValue(undefined);
+		let submitted: { text: string } | undefined;
+		mode.onInputCallback = input => {
+			submitted = input;
+		};
+
+		await mode.handlePlanModeCommand("just plan the migration");
+
+		expect(mode.planModeEnabled).toBe(true);
+		expect(promptCustomMessage).not.toHaveBeenCalled();
+		expect(submitted?.text).toBe("just plan the migration");
+	});
+});


### PR DESCRIPTION
## Repro
Typing `/plan <prompt> /skill:grilling` (same for `/vibe`) delivered the `/skill:grilling` token to the agent as literal text instead of loading the grilling skill. Reproduced with `bun test test/issue-8137-repro.test.ts` (packages/coding-agent): `handlePlanModeCommand("do X /skill:grilling")` submitted a normal prompt carrying the raw string `do X /skill:grilling` rather than dispatching a skill message.

## Cause
Mid-prompt and leading `/skill:<name>` invocations are dispatched only in the TUI editor-submit path (`InputController.handleSubmit` → `isKnownSkillCommand`/`invokeSkillCommandFromText`). Mode commands with an inline `[prompt]` take a different route: `InteractiveMode.handlePlanModeCommand`/`handleVibeModeCommand` strip the `/plan` (or `/vibe`) prefix and resubmit the remaining prompt via `onInputCallback` → `submitInteractiveInput` (`main.ts`) → `session.prompt()`, which performs `@file`, slash-command-alias, and prompt-template expansion but has no skill dispatch. So the skill token reached the model unparsed. The `parseSkillInvocation` guard that suppresses mid-prompt skills after a leading slash command does not apply, because the slash command is already stripped before resubmission.

## Fix
- Added `InteractiveMode.#submitModeInitialPrompt(initialPrompt)`: dispatches a registered skill invocation (leading or mid-prompt) through `invokeSkillCommandFromText` (the same custom-message path as the editor submit flow), otherwise submits the raw text as a normal prompt via `onInputCallback`.
- Routed both `handlePlanModeCommand` and `handleVibeModeCommand` inline-prompt submission through the new helper.
- Added `test/issue-8137-repro.test.ts` covering: inline `/skill` in a `/plan` prompt dispatches a `SKILL_PROMPT_MESSAGE` with the surrounding prose collapsed into the skill args, and a non-skill `/plan` prompt still submits as a normal prompt.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/issue-8137-repro.test.ts` → 2 pass (failed before the fix). Adjacent suites green: `bun test test/issue-2510-repro.test.ts test/interactive-mode-plan-review.test.ts test/interactive-mode-vibe-toggle.test.ts test/issue-816-repro.test.ts` → 75 pass. `bun check` clean. Fixes #8137