### PR TITLE
fix(eval): re-validate memoized kernel runner path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Python/Julia/Ruby eval kernels failing to start after their staged runner script was cleared mid-session (e.g. a macOS tmpdir sweep): the memoized runner path is now re-validated so a long-lived process self-heals instead of only recovering on restart ([#8140](https://github.com/can1357/oh-my-pi/issues/8140)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/eval/jl/kernel.ts
+++ b/packages/coding-agent/src/eval/jl/kernel.ts
@@ -5,8 +5,6 @@
  * Ruby runners via BaseKernel; this module supplies the Julia binary, runner
  * script, and the runner's TSV/Base64 wire protocol.
  */
-import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { $flag, Snowflake } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
@@ -14,6 +12,7 @@ import { Settings } from "../../config/settings";
 import { BaseKernel, getRemainingTimeMs, type KernelStartOptions } from "../kernel-base";
 import type { KernelDisplayOutput } from "../py/display";
 import { hostHasInheritableConsole, shouldDetachKernel, shouldHideKernelWindow } from "../py/spawn-options";
+import { stageRunnerScript } from "../runner-cache";
 import { JULIA_PRELUDE } from "./prelude";
 import RUNNER_SCRIPT from "./runner.jl" with { type: "text" };
 import {
@@ -29,23 +28,6 @@ export { renderKernelDisplay } from "../py/display";
 export type { KernelDisplayOutput };
 
 const TRACE_IPC = $flag("PI_JULIA_IPC_TRACE");
-
-// Cache the runner script on disk so the subprocess loads it normally. Cached
-// per script hash so installs don't race across versions.
-const RUNNER_CACHE_DIR = path.join(os.tmpdir(), "omp-julia-runner");
-let RUNNER_SCRIPT_PATH: string | null = null;
-
-async function ensureRunnerScript(): Promise<string> {
-	if (RUNNER_SCRIPT_PATH) return RUNNER_SCRIPT_PATH;
-	await fs.promises.mkdir(RUNNER_CACHE_DIR, { recursive: true });
-	const hash = Bun.hash(RUNNER_SCRIPT).toString(36);
-	const target = path.join(RUNNER_CACHE_DIR, `runner-${hash}.jl`);
-	if (!fs.existsSync(target)) {
-		await Bun.write(target, RUNNER_SCRIPT);
-	}
-	RUNNER_SCRIPT_PATH = target;
-	return target;
-}
 
 const SHUTDOWN_GRACE_MS = 1_000;
 const STARTUP_TIMEOUT_MS = 15_000; // Julia compile/warmup can be slightly slower
@@ -180,7 +162,7 @@ export class JuliaKernel extends BaseKernel<KernelExecuteOptions> {
 			if (typeof value === "string") spawnEnv[key] = value;
 		}
 
-		const scriptPath = await ensureRunnerScript();
+		const scriptPath = await stageRunnerScript("omp-julia-runner", "jl", RUNNER_SCRIPT);
 		const kernel = new JuliaKernel(Snowflake.next());
 
 		const proc = Bun.spawn(

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -7,13 +7,12 @@
  * code. Shutdown writes `{"type":"exit"}` and escalates to SIGTERM/SIGKILL on
  * timeout.
  */
-import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { $flag, isBunTestRuntime, logger, Snowflake } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import { Settings } from "../../config/settings";
 import { BaseKernel, getRemainingTimeMs, type KernelStartOptions } from "../kernel-base";
+import { stageRunnerScript } from "../runner-cache";
 import { PYTHON_PRELUDE } from "./prelude";
 import RUNNER_SCRIPT from "./runner.py" with { type: "text" };
 import {
@@ -37,23 +36,6 @@ export type { KernelDisplayOutput, PythonStatusEvent } from "./display";
 export { renderKernelDisplay } from "./display";
 
 const TRACE_IPC = $flag("PI_PYTHON_IPC_TRACE");
-
-// Cache the runner script on disk so the subprocess loads it normally. Cached
-// per script hash so installs don't race across versions.
-const RUNNER_CACHE_DIR = path.join(os.tmpdir(), "omp-python-runner");
-let RUNNER_SCRIPT_PATH: string | null = null;
-
-async function ensureRunnerScript(): Promise<string> {
-	if (RUNNER_SCRIPT_PATH) return RUNNER_SCRIPT_PATH;
-	await fs.promises.mkdir(RUNNER_CACHE_DIR, { recursive: true });
-	const hash = Bun.hash(RUNNER_SCRIPT).toString(36);
-	const target = path.join(RUNNER_CACHE_DIR, `runner-${hash}.py`);
-	if (!fs.existsSync(target)) {
-		await Bun.write(target, RUNNER_SCRIPT);
-	}
-	RUNNER_SCRIPT_PATH = target;
-	return target;
-}
 
 const SHUTDOWN_GRACE_MS = 1_000;
 const STARTUP_TIMEOUT_MS = 10_000;
@@ -189,7 +171,7 @@ export class PythonKernel extends BaseKernel {
 		spawnEnv.PYTHONUNBUFFERED = "1";
 		spawnEnv.PYTHONIOENCODING = "utf-8";
 
-		const scriptPath = await ensureRunnerScript();
+		const scriptPath = await stageRunnerScript("omp-python-runner", "py", RUNNER_SCRIPT);
 		const kernel = new PythonKernel(Snowflake.next());
 
 		const proc = Bun.spawn([runtime.pythonPath, "-u", scriptPath], {

--- a/packages/coding-agent/src/eval/rb/kernel.ts
+++ b/packages/coding-agent/src/eval/rb/kernel.ts
@@ -8,8 +8,6 @@
  * (eval/py/kernel.ts); the IPC loop, lifecycle, and display rendering are shared
  * with it via BaseKernel.
  */
-import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { $flag, isBunTestRuntime, logger, Snowflake } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
@@ -17,6 +15,7 @@ import { Settings } from "../../config/settings";
 import { BaseKernel, getRemainingTimeMs, type KernelRuntimeEnv, type KernelStartOptions } from "../kernel-base";
 import type { KernelDisplayOutput } from "../py/display";
 import { hostHasInheritableConsole, shouldDetachKernel, shouldHideKernelWindow } from "../py/spawn-options";
+import { stageRunnerScript } from "../runner-cache";
 import { RUBY_PRELUDE } from "./prelude";
 import RUNNER_SCRIPT from "./runner.rb" with { type: "text" };
 import {
@@ -32,23 +31,6 @@ export type { KernelDisplayOutput, PythonStatusEvent } from "../py/display";
 export { renderKernelDisplay } from "../py/display";
 
 const TRACE_IPC = $flag("PI_RUBY_IPC_TRACE");
-
-// Cache the runner script on disk so the subprocess loads it normally. Cached
-// per script hash so installs don't race across versions.
-const RUNNER_CACHE_DIR = path.join(os.tmpdir(), "omp-ruby-runner");
-let RUNNER_SCRIPT_PATH: string | null = null;
-
-async function ensureRunnerScript(): Promise<string> {
-	if (RUNNER_SCRIPT_PATH) return RUNNER_SCRIPT_PATH;
-	await fs.promises.mkdir(RUNNER_CACHE_DIR, { recursive: true });
-	const hash = Bun.hash(RUNNER_SCRIPT).toString(36);
-	const target = path.join(RUNNER_CACHE_DIR, `runner-${hash}.rb`);
-	if (!fs.existsSync(target)) {
-		await Bun.write(target, RUNNER_SCRIPT);
-	}
-	RUNNER_SCRIPT_PATH = target;
-	return target;
-}
 
 const SHUTDOWN_GRACE_MS = 1_000;
 const STARTUP_TIMEOUT_MS = 10_000;
@@ -181,7 +163,7 @@ export class RubyKernel extends BaseKernel<KernelExecuteOptions> {
 			if (typeof value === "string") spawnEnv[key] = value;
 		}
 
-		const scriptPath = await ensureRunnerScript();
+		const scriptPath = await stageRunnerScript("omp-ruby-runner", "rb", RUNNER_SCRIPT);
 		const kernel = new RubyKernel(Snowflake.next());
 
 		const proc = Bun.spawn([runtime.rubyPath, scriptPath], {

--- a/packages/coding-agent/src/eval/runner-cache.ts
+++ b/packages/coding-agent/src/eval/runner-cache.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared on-disk staging for subprocess kernel runner scripts.
+ *
+ * Each language kernel (Python/Julia/Ruby) ships its runner as a compiled-in
+ * text asset, then stages it under `os.tmpdir()` so the interpreter can load it
+ * as a normal file. Staging is cached per language directory so repeated kernel
+ * starts within a process avoid redundant writes.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// Memoized staged path per cache directory. The value is re-validated on every
+// call: a tmpdir sweep (e.g. macOS `periodic daily clean_tmps`) or any external
+// clear must self-heal within a long-lived process, not only across restarts.
+const stagedPaths = new Map<string, string>();
+
+/**
+ * Stage `script` under `os.tmpdir()/<dirName>` and return the runner path.
+ *
+ * The staged path is memoized per `dirName` but re-checked with `fs.existsSync`
+ * before reuse, so a runner deleted mid-session is re-written on the next call
+ * instead of handing back a path to a missing file (issue #8140).
+ *
+ * @param dirName Cache subdirectory under the OS temp dir (unique per language).
+ * @param ext Runner file extension without the dot (e.g. `py`, `jl`, `rb`).
+ * @param script Runner source, hashed to key the cached file per version.
+ */
+export async function stageRunnerScript(dirName: string, ext: string, script: string): Promise<string> {
+	const memoized = stagedPaths.get(dirName);
+	if (memoized && fs.existsSync(memoized)) return memoized;
+	const dir = path.join(os.tmpdir(), dirName);
+	await fs.promises.mkdir(dir, { recursive: true });
+	const hash = Bun.hash(script).toString(36);
+	const target = path.join(dir, `runner-${hash}.${ext}`);
+	if (!fs.existsSync(target)) {
+		await Bun.write(target, script);
+	}
+	stagedPaths.set(dirName, target);
+	return target;
+}

--- a/packages/coding-agent/test/runner-cache-restage.test.ts
+++ b/packages/coding-agent/test/runner-cache-restage.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { stageRunnerScript } from "../src/eval/runner-cache";
+
+// stageRunnerScript memoizes the staged path per cache directory, but the warm
+// path must re-validate with fs.existsSync so a tmpdir sweep (macOS periodic
+// `clean_tmps`) or any external clear self-heals within a long-lived process
+// instead of returning a path to a missing file (issue #8140).
+describe("stageRunnerScript re-validation", () => {
+	const dirs: string[] = [];
+
+	function uniqueDir() {
+		const name = `omp-runner-cache-test-${process.pid}-${dirs.length}-${Date.now()}`;
+		dirs.push(name);
+		return name;
+	}
+
+	afterEach(() => {
+		for (const name of dirs) {
+			fs.rmSync(path.join(os.tmpdir(), name), { recursive: true, force: true });
+		}
+		dirs.length = 0;
+	});
+
+	it("re-stages the runner after the cached file is deleted mid-session", async () => {
+		const dirName = uniqueDir();
+		const script = "print('staged runner')\n";
+
+		const first = await stageRunnerScript(dirName, "py", script);
+		expect(fs.existsSync(first)).toBe(true);
+
+		// Simulate a mid-session tmpdir sweep clearing the whole cache dir.
+		fs.rmSync(path.join(os.tmpdir(), dirName), { recursive: true, force: true });
+		expect(fs.existsSync(first)).toBe(false);
+
+		// Same process, memo still set: the warm path must fall through and
+		// re-stage instead of handing back the now-missing path.
+		const second = await stageRunnerScript(dirName, "py", script);
+		expect(second).toBe(first);
+		expect(fs.existsSync(second)).toBe(true);
+		expect(await Bun.file(second).text()).toBe(script);
+	});
+
+	it("reuses the memoized path while the file still exists", async () => {
+		const dirName = uniqueDir();
+		const script = "puts 'hi'\n";
+
+		const first = await stageRunnerScript(dirName, "rb", script);
+		const second = await stageRunnerScript(dirName, "rb", script);
+
+		expect(second).toBe(first);
+		expect(first.endsWith(".rb")).toBe(true);
+		expect(fs.existsSync(second)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Repro
Once a process staged the runner, `ensureRunnerScript()` returned the module-level `RUNNER_SCRIPT_PATH` memo with no existence check, so if the `os.tmpdir()/omp-<lang>-runner` cache was cleared mid-session (e.g. a macOS `periodic daily clean_tmps` sweep) the process kept handing back a path to a deleted file and every later Python/Julia/Ruby kernel start failed to spawn until restart. Reproduced with `bun run /tmp/repro-runner-memo.ts` (stage runner → delete cache dir → restage in same state): buggy body resolves `eval#2 path resolves=false`, guarded body resolves `true`.

## Cause
`packages/coding-agent/src/eval/py/kernel.ts` (and the identical copies in `eval/jl/kernel.ts` and `eval/rb/kernel.ts`) short-circuited on `if (RUNNER_SCRIPT_PATH) return RUNNER_SCRIPT_PATH;` before the cold path's own self-heal (`if (!fs.existsSync(target))`) could run. The in-memory memo was never invalidated, so the process only recovered a missing runner across a restart.

## Fix
- Add `packages/coding-agent/src/eval/runner-cache.ts` exporting `stageRunnerScript(dirName, ext, script)`, which re-checks `fs.existsSync` on the memoized path before reuse and re-stages when the file is gone.
- Route the Python, Julia, and Ruby kernels through it, deleting the three copy-pasted `ensureRunnerScript`/`RUNNER_CACHE_DIR`/`RUNNER_SCRIPT_PATH` blocks and their now-unused `fs`/`os` imports.
- Add `test/runner-cache-restage.test.ts` covering the mid-session re-stage and the still-present memoized reuse.

## Verification
`bun test test/runner-cache-restage.test.ts` → 2 pass. Confirmed the re-stage test fails (1 fail) when the `fs.existsSync(memoized)` guard is reverted, proving it defends the regression. `bun check` → clean (biome + tsgo). Fixes #8140