### PR TITLE
feat(tui): visual marker for final assistant reply vs intermediate steps

### DIFF
--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -504,9 +504,11 @@ export class AssistantMessageComponent extends Container {
 	markTranscriptBlockFinalized(): void {
 		this.#transcriptBlockFinalized = true;
 		this.#stopThinkingAnimation();
-		// If the live pulse was on screen when the block sealed, drop the fast path
-		// and rebuild so the placeholder is removed — finalized blocks never animate.
-		if (this.#thinkingDots) {
+		// Rebuild to apply final-answer visual marker (accent left-border for
+		// stopReason=stop messages). The fast path bypasses updateContent, so
+		// drop it to force a full rebuild with the new style. Also rebuild if
+		// the live thinking pulse was on screen — finalized blocks never animate.
+		if (this.#thinkingDots || this.#lastMessage?.stopReason === "stop") {
 			this.#fastPathKey = undefined;
 			this.#fastPathItems = undefined;
 			if (this.#lastMessage) this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
@@ -874,12 +876,32 @@ export class AssistantMessageComponent extends Container {
 		for (let i = 0; i < message.content.length; i++) {
 			const content = message.content[i];
 			if (content.type === "text" && canonicalizeMessage(content.text)) {
-				// Set paddingY=0 to avoid extra spacing before tool executions
 				const trimmed = content.text.trim();
-				const mdOptions = this.#textColorTransform ? { color: this.#textColorTransform } : undefined;
-				const md = new Markdown(trimmed, 1, 0, getMarkdownTheme(), mdOptions, 0);
-				this.#contentContainer.addChild(md);
-				captureItems?.push({ md, contentIndex: i, blockType: "text", lastText: trimmed });
+				// Final assistant reply (stopReason=stop, no tool calls): tinted
+				// background + accent inline prefix, mirroring user-message style.
+				const isFinalAnswer =
+					this.#transcriptBlockFinalized &&
+					message.stopReason === "stop" &&
+					!message.content.some(c => c.type === "toolCall");
+				if (isFinalAnswer) {
+					const finalBg = (value: string) => theme.bg("finalAnswerBg", value);
+					const finalFg = (value: string) => theme.fg("finalAnswerText", value);
+					const marked = theme.fg("accent", "▌ ") + trimmed;
+					const md = new Markdown(marked, 1, 1, getMarkdownTheme(), {
+						bgColor: finalBg,
+						color: finalFg,
+					}, 0);
+					md.setIgnoreTight(true);
+					this.#contentContainer.addChild(md);
+					captureItems?.push({ md, contentIndex: i, blockType: "text", lastText: marked });
+				} else {
+					const mdOptions = this.#textColorTransform
+						? { color: this.#textColorTransform }
+						: undefined;
+					const md = new Markdown(trimmed, 1, 0, getMarkdownTheme(), mdOptions, 0);
+					this.#contentContainer.addChild(md);
+					captureItems?.push({ md, contentIndex: i, blockType: "text", lastText: trimmed });
+				}
 				hasRenderedContent = true;
 			} else if (content.type === "thinking" && resolveThinkingDisplay(content, this.proseOnlyThinking).visible) {
 				const thinkingText = resolveThinkingDisplay(content, this.proseOnlyThinking).text;

--- a/packages/coding-agent/src/modes/theme/loader.ts
+++ b/packages/coding-agent/src/modes/theme/loader.ts
@@ -149,6 +149,7 @@ export function createTheme(themeJson: ThemeJson, options: CreateThemeOptions = 
 		"toolSuccessBg",
 		"toolErrorBg",
 		"statusLineBg",
+		"finalAnswerBg",
 	]);
 	for (const [key, value] of Object.entries(resolvedColors)) {
 		if (bgColorKeys.has(key)) {

--- a/packages/coding-agent/src/modes/theme/schema.ts
+++ b/packages/coding-agent/src/modes/theme/schema.ts
@@ -75,6 +75,8 @@ const themeColorsSchema = type({
 	statusLineOutput: "string | number",
 	statusLineCost: "string | number",
 	statusLineSubagents: "string | number",
+	"finalAnswerBg?": "string | number",
+	"finalAnswerText?": "string | number",
 });
 const spinnerFramesSchema = type("unknown").narrow((value): value is SpinnerFramesOverride => {
 	if (Array.isArray(value)) {
@@ -176,9 +178,8 @@ export type ThemeColor =
 	| "statusLineStaged"
 	| "statusLineDirty"
 	| "statusLineUntracked"
-	| "statusLineOutput"
-	| "statusLineCost"
-	| "statusLineSubagents";
+	| "statusLineSubagents"
+	| "finalAnswerText";
 
 /** Set of all valid ThemeColor string values for runtime validation */
 const THEME_COLOR_RECORD = {
@@ -258,6 +259,7 @@ export type ThemeBg =
 	| "toolPendingBg"
 	| "toolSuccessBg"
 	| "toolErrorBg"
-	| "statusLineBg";
+	| "statusLineBg"
+	| "finalAnswerBg";
 
 export type ColorMode = "truecolor" | "256color";


### PR DESCRIPTION
## Problem

The terminal assistant reply (`stopReason=stop`) and intermediate tool-use steps (`stopReason=toolUse`) render identically — no visual distinction in the TUI transcript. The theme system has no `assistantMessage` color keys at all (assistant text inherits the default terminal foreground).

This makes it hard to scan a long multi-step conversation and quickly locate the final answer.

## Solution

Distinguish the final reply with an accent-colored inline prefix (`▌`) and an optional tinted background — mirroring the existing `userMessageBg` bubble style:

```
▌ Final answer text (bright, tinted background)

  Intermediate step text (default, no background)
```

## Changes

| File | Change |
|---|---|
| `assistant-message.ts` | Detect `isFinalAnswer` (`finalized && stopReason=stop && no toolCall`); apply `theme.bg("finalAnswerBg")` + `theme.fg("finalAnswerText")` via Markdown options; prepend accent `▌` marker inline |
| `assistant-message.ts` | `markTranscriptBlockFinalized`: force rebuild on `stopReason=stop` so the marker applies immediately after streaming |
| `schema.ts` | Add `finalAnswerBg` to `ThemeBg` union, `finalAnswerText` to `ThemeColor` union; add both as optional fields in `themeColorsSchema` |
| `loader.ts` | Add `finalAnswerBg` to `bgColorKeys` set so it routes to `theme.bg()` instead of `theme.fg()` |

## Backward compatibility

Both theme keys are **optional**. Existing themes work unchanged — they simply get no visual marker. Themes that define `finalAnswerBg` / `finalAnswerText` get the enhancement automatically.

## Verification

Tested on GLM-5.2 via `zhipu-coding-plan` provider with a custom `titanium` variant:
- `finalAnswerBg: "#15233a"` (blue-tinted, distinct from `userMessageBg: "#1e242e"`)
- `finalAnswerText: "#f0f4ff"` (bright white)

Confirmed: final replies show the accent `▌` prefix + tinted background; intermediate steps (tool calls) remain unstyled. Streaming renders without the marker; it appears on finalize.