### PR TITLE
perf(rpc): reuse serialized output frames

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed RPC `message_end` frames being serialized more than once before output while preserving v1 and v2 wire bytes ([#8118](https://github.com/can1357/oh-my-pi/issues/8118)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/modes/rpc/rpc-frame.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-frame.ts
@@ -239,9 +239,12 @@ function overflowFrame(frame: object): object {
 	};
 }
 
-/** Serialize a complete JSONL frame while enforcing the transport byte ceiling. */
-export function encodeRpcFrame(frame: object, streamedMessageCount = 0, streamedMessages?: readonly unknown[]): string {
-	let json = JSON.stringify(frame);
+function encodeRpcFrameFromJson(
+	frame: object,
+	json: string,
+	streamedMessageCount: number,
+	streamedMessages?: readonly unknown[],
+): string {
 	if (serializedFrameBytes(json) <= MAX_RPC_FRAME_BYTES) return `${json}\n`;
 	if (isRecord(frame) && frame.type === "response") {
 		return `${JSON.stringify(overflowFrame(frame))}\n`;
@@ -257,6 +260,11 @@ export function encodeRpcFrame(frame: object, streamedMessageCount = 0, streamed
 	}
 
 	return `${JSON.stringify(overflowFrame(compacted))}\n`;
+}
+
+/** Serialize a complete JSONL frame while enforcing the transport byte ceiling. */
+export function encodeRpcFrame(frame: object, streamedMessageCount = 0, streamedMessages?: readonly unknown[]): string {
+	return encodeRpcFrameFromJson(frame, JSON.stringify(frame), streamedMessageCount, streamedMessages);
 }
 
 /** Stateful encoder that tracks which messages a client has already received. */
@@ -292,14 +300,14 @@ export class RpcFrameEncoder {
 				frames = [singleFrame];
 			}
 		} else {
-			singleFrame = encodeRpcFrame(frame, this.#streamedMessages.length, this.#streamedMessages);
+			singleFrame = encodeRpcFrameFromJson(frame, json, this.#streamedMessages.length, this.#streamedMessages);
 			frames = [singleFrame];
 		}
 		if (!isRecord(frame)) return frames;
 		if (frame.type === "message_end") {
 			const snapshot =
 				this.#protocolVersion === 2 && Object.hasOwn(frame, "message")
-					? { message: jsonSnapshot(frame.message) }
+					? (encodedMessageSnapshot(json) ?? { message: jsonSnapshot(frame.message) })
 					: singleFrame !== undefined
 						? encodedMessageSnapshot(singleFrame)
 						: undefined;

--- a/packages/coding-agent/test/rpc-frame.test.ts
+++ b/packages/coding-agent/test/rpc-frame.test.ts
@@ -20,9 +20,26 @@ function oversizedMessageHistory(prefix: string) {
 }
 
 describe("RPC frame encoding", () => {
-	it("preserves frames that already fit", () => {
+	it("preserves fitting frames and serializes stateful message frames once", () => {
 		const frame = { id: "request-1", type: "response", command: "get_state", success: true, data: { ok: true } };
 		expect(encodeRpcFrame(frame)).toBe(`${JSON.stringify(frame)}\n`);
+
+		for (const version of [1, 2] as const) {
+			let messageReads = 0;
+			const message = { role: "assistant", content: [{ type: "text", text: "done" }] };
+			const event = {
+				type: "message_end",
+				get message() {
+					messageReads++;
+					return message;
+				},
+			};
+			const encoder = new RpcFrameEncoder();
+			encoder.setProtocolVersion(version);
+
+			expect(decode(encoder.encode(event))).toEqual({ type: "message_end", message });
+			expect(messageReads).toBe(1);
+		}
 	});
 
 	it("compacts agent_end after message events have streamed", () => {


### PR DESCRIPTION
## What

I reviewed this change and confirmed that normal RPC frames now reuse their precomputed JSON, avoiding duplicate serialization on the hot path while keeping frame bytes stable.

- Reuse already serialized message JSON for normal frame emission.
- Build v2 snapshots from the same wire JSON representation instead of serializing again.
- Keep the exported `encodeRpcFrame()` API unchanged.
- Extend the existing encoder test with a side-effecting getter to verify one serialization path in v1 and v2.

## Why

The normal RPC output path previously serialized each frame more than once. Reusing the precomputed JSON removes this extra overhead on high-volume output paths.

## Testing

- Ran the focused RPC suite with 16 tests passed and 44 assertions.
- Ran `bun --silent --cwd=packages/coding-agent run check`; Biome checked 2,575 files and `tsgo` passed.
- Benchmarked full producer-to-stdout-to-consumer runs over 25 alternating runs for v1 and v2.
- Candidate improved end-to-end performance while preserving all frame behavior and output hashes.

I checked the relevant issues, comments, pull requests, and discussions; this pull request is not a duplicate.