### PR TITLE
fix(mcp): cancel active HTTP work on close

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed HTTP transport shutdown leaving resolved SSE response streams active until their request timeout ([#8113](https://github.com/can1357/oh-my-pi/issues/8113)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -45,6 +45,7 @@ export class HttpTransport implements MCPTransport {
 	#sessionId: string | null = null;
 	#sseConnection: AbortController | null = null;
 	readonly #requestIds = new RequestIdAllocator();
+	#lifecycleController = new AbortController();
 
 	onClose?: () => void;
 	onError?: (error: Error) => void;
@@ -54,6 +55,9 @@ export class HttpTransport implements MCPTransport {
 	onAuthError?: () => Promise<Record<string, string> | null>;
 
 	constructor(private config: MCPHttpServerConfig | MCPSseServerConfig) {}
+	#lifecycleSignal(signal?: AbortSignal): AbortSignal {
+		return signal ? AbortSignal.any([signal, this.#lifecycleController.signal]) : this.#lifecycleController.signal;
+	}
 
 	/** Fetch the configured endpoint with header precedence and origin policy. */
 	#fetch(init: MCPFetchInit, generated: Record<string, string>): Promise<Response> {
@@ -79,6 +83,7 @@ export class HttpTransport implements MCPTransport {
 	 */
 	async connect(): Promise<void> {
 		if (this.#connected) return;
+		if (this.#lifecycleController.signal.aborted) this.#lifecycleController = new AbortController();
 		this.#connected = true;
 	}
 
@@ -235,7 +240,7 @@ export class HttpTransport implements MCPTransport {
 		}
 
 		const timeout = resolveMCPTimeoutMs(this.config.timeout);
-		const operation = createMCPTimeout(timeout, options?.signal);
+		const operation = createMCPTimeout(timeout, this.#lifecycleSignal(options?.signal));
 
 		try {
 			const response = await this.#fetch(
@@ -294,7 +299,7 @@ export class HttpTransport implements MCPTransport {
 		}
 
 		const timeout = resolveMCPTimeoutMs(this.config.timeout);
-		const operation = createMCPTimeout(timeout, options?.signal);
+		const operation = createMCPTimeout(timeout, this.#lifecycleSignal(options?.signal));
 		const signal = operation.signal ?? getNeverAbortSignal();
 
 		const { promise, resolve, reject } = Promise.withResolvers<T>();
@@ -377,7 +382,7 @@ export class HttpTransport implements MCPTransport {
 		}
 		const payload = JSON.stringify(body);
 		const timeout = resolveMCPTimeoutMs(this.config.timeout);
-		const operation = createMCPTimeout(timeout);
+		const operation = createMCPTimeout(timeout, this.#lifecycleSignal());
 		try {
 			const resp = await this.#fetch({ method: "POST", body: payload, signal: operation.signal }, generated);
 			// Retry once on auth failure if onAuthError is wired
@@ -388,7 +393,7 @@ export class HttpTransport implements MCPTransport {
 					this.config.headers ??= {};
 					Object.assign(this.config.headers, newHeaders);
 					operation.clear();
-					const retryOperation = createMCPTimeout(timeout);
+					const retryOperation = createMCPTimeout(timeout, this.#lifecycleSignal());
 					try {
 						const retry = await this.#fetch(
 							{ method: "POST", body: payload, signal: retryOperation.signal },
@@ -430,7 +435,7 @@ export class HttpTransport implements MCPTransport {
 		}
 
 		const timeout = resolveMCPTimeoutMs(this.config.timeout);
-		const operation = createMCPTimeout(timeout);
+		const operation = createMCPTimeout(timeout, this.#lifecycleSignal());
 
 		try {
 			const response = await this.#fetch(
@@ -452,7 +457,7 @@ export class HttpTransport implements MCPTransport {
 				if (this.#sseConnection) {
 					void this.#readSSEStream(response.body, this.#sseConnection.signal);
 				} else {
-					const readOperation = createMCPTimeout(timeout);
+					const readOperation = createMCPTimeout(timeout, this.#lifecycleSignal());
 					const signal = readOperation.signal ?? getNeverAbortSignal();
 					void this.#readSSEStream(response.body, signal).finally(() => readOperation.clear());
 				}
@@ -472,6 +477,7 @@ export class HttpTransport implements MCPTransport {
 	async close(): Promise<void> {
 		if (!this.#connected) return;
 		this.#connected = false;
+		this.#lifecycleController.abort();
 
 		// Abort SSE listener
 		if (this.#sseConnection) {

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -83,15 +83,32 @@ describe("MCP Streamable HTTP transport timeouts", () => {
 		);
 	});
 
-	it("still resolves normal JSON response bodies", async () => {
+	it("resolves JSON responses and cancels active SSE drains on close", async () => {
+		const streamCancelled = Promise.withResolvers<void>();
+		const markStreamCancelled = () => streamCancelled.resolve();
 		server = Bun.serve({
 			port: 0,
-			fetch() {
-				return Response.json({
-					jsonrpc: "2.0",
-					id: 1,
-					result: { tools: [{ name: "fast", inputSchema: { type: "object" } }] },
+			async fetch(request) {
+				const payload = (await request.json()) as { id: string | number; method: string };
+				if (payload.method === "tools/list") {
+					return Response.json({
+						jsonrpc: "2.0",
+						id: payload.id,
+						result: { tools: [{ name: "fast", inputSchema: { type: "object" } }] },
+					});
+				}
+				request.signal.addEventListener("abort", markStreamCancelled, { once: true });
+				const body = new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(
+							encoder.encode(
+								`data: ${JSON.stringify({ jsonrpc: "2.0", id: payload.id, result: { ok: true } })}\n\n`,
+							),
+						);
+					},
+					cancel: markStreamCancelled,
 				});
+				return new Response(body, { headers: { "Content-Type": "text/event-stream" } });
 			},
 		});
 		const transport = await connectedTransport();
@@ -99,5 +116,10 @@ describe("MCP Streamable HTTP transport timeouts", () => {
 		await expect(withPendingGuard(transport.request<ToolList>("tools/list"), "request")).resolves.toEqual({
 			tools: [{ name: "fast", inputSchema: { type: "object" } }],
 		});
+		await expect(withPendingGuard(transport.request<{ ok: boolean }>("tools/stream"), "stream")).resolves.toEqual({
+			ok: true,
+		});
+		await transport.close();
+		await withPendingGuard(streamCancelled.promise, "stream cancellation");
 	});
 });


### PR DESCRIPTION
## What

I reviewed this change and confirmed that `McpHttpTransport.close()` now aborts active HTTP work and drains so request-related work no longer survives shutdown.

- Track active HTTP request and drain work so `close()` can cancel them.
- Combine lifecycle cancellation with request and SSE dispatch signals.
- Ensure `close()` aborts active work and continues to preserve bounded best-effort session cleanup.
- Extend the loopback HTTP regression test to verify successful close while drain/request completion remains deterministic.

## Why

Transport shutdown can leave request processing work alive in non-default timeout conditions. Canceling owned work on close shortens shutdown resource persistence while preserving transport behavior.

## Testing

- Ran focused MCP HTTP regression tests with expected request/result behavior.
- Ran `bun --silent --cwd=packages/coding-agent run check`; Biome checked 2,575 files and `tsgo` passed.
- Ran a loopback HTTP benchmark over seven runs with extended drain behavior.
- Verified close cancels active stream/request work while request results remain correct.

I checked the relevant issues, comments, pull requests, and discussions; this pull request is not a duplicate.