### PR TITLE
fix(lsp): stop idle checker during shutdown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `shutdownAll()` leaving the configured LSP idle checker alive and preventing short-lived SDK hosts from exiting ([#8115](https://github.com/can1357/oh-my-pi/issues/8115)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -1405,6 +1405,7 @@ export async function sendNotification(
  * Shutdown all LSP clients.
  */
 export async function shutdownAll(): Promise<void> {
+	stopIdleChecker();
 	const clientsToShutdown = Array.from(clients.values());
 	clients.clear();
 	// Mid-initialize clients live only in clientLocks (publication is deferred

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -353,7 +353,7 @@ describe("lsp regressions", () => {
 		}
 	});
 
-	it("sends the LSP exit notification after shutdown completes", async () => {
+	it("sends the LSP exit notification and releases the idle checker after shutdown", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-shutdown-");
 		try {
 			const server = installFakeLsp((message, srv) => {
@@ -385,6 +385,24 @@ describe("lsp regressions", () => {
 			expect(shutdownIndex).toBeGreaterThanOrEqual(0);
 			expect(exitIndex).toBeGreaterThan(shutdownIndex);
 			expect(server.killed).toBe(false);
+
+			const clientModule = new URL("../../src/lsp/client.ts", import.meta.url).href;
+			const shutdownProbe = Bun.spawn(
+				[
+					process.execPath,
+					"-e",
+					`import { setIdleTimeout, shutdownAll } from ${JSON.stringify(clientModule)}; setIdleTimeout(60_000); await shutdownAll();`,
+				],
+				{ stdout: "ignore", stderr: "inherit" },
+			);
+			// Real time is required because fake timers cannot advance a separate Bun process.
+			// The process exit itself proves shutdown released the event loop.
+			const probeExit = await Promise.race([shutdownProbe.exited, Bun.sleep(1_000).then(() => null)]);
+			if (probeExit === null) {
+				shutdownProbe.kill();
+				await shutdownProbe.exited;
+			}
+			expect(probeExit).toBe(0);
 		} finally {
 			await lspClient.shutdownAll();
 			tempDir.removeSync();


### PR DESCRIPTION
## What

I reviewed this change and confirmed that `shutdownAll()` now stops the global LSP idle checker before teardown so shutdown can complete without leaving an event-loop timer behind.

- Stop the LSP manager idle checker during global shutdown.
- Preserve idle-timeout configuration so later session setup can rearm the checker.
- Extend the existing child-process lifecycle test to assert process exit after shutdown.

## Why

Global shutdown previously did not clear the idle checker interval, which could keep the event loop alive after clients were closed. Stopping it at shutdown makes teardown complete while retaining configurable rearm behavior for later sessions.

## Testing

- Ran focused LSP regression suite with no behavior regressions and shutdown lifecycle checks passing.
- Ran `bun --silent --cwd=packages/coding-agent run check`; Biome checked 2,575 files and `tsgo` passed.
- Verified child-process exit behavior improved when idle timeout had been enabled.

I checked the relevant issues, comments, pull requests, and discussions; this pull request is not a duplicate.