### PR TITLE
feat(tui): final-answer visual marker + user-message prompt indicator

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Final assistant replies now render with a distinct themeable background (`finalAnswerBg`/`finalAnswerText`, defaulting to the user-message colors) and an accent gutter marker, applied only on successful completion once the block leaves the live transcript (#8155).
+
 ## [18.0.7] - 2026-08-26
 
 ### Added

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -188,6 +188,13 @@ export class AssistantMessageComponent extends Container {
 	#showToolResultImages = true;
 	#kittyConversionsInFlight = new Set<string>();
 	#transcriptBlockFinalized: boolean;
+	#hasToolTimeline = false;
+	/**
+	 * Rows of this block's latest render already committed to native scrollback
+	 * (fed by the transcript container). Finalize restyling consults it: rows on
+	 * the tape are immutable, so only SGR-equivalent changes are safe there.
+	 */
+	#blockCommittedRows = 0;
 	/**
 	 * When true, the turn-ending `Error: …` line for `stopReason === "error"` is
 	 * suppressed because the same error is currently shown in the pinned banner
@@ -317,6 +324,24 @@ export class AssistantMessageComponent extends Container {
 
 	setProseOnlyThinking(proseOnly: boolean): void {
 		this.proseOnlyThinking = proseOnly;
+	}
+
+	setHasToolTimeline(has: boolean): void {
+		if (this.#hasToolTimeline === has) return;
+		this.#hasToolTimeline = has;
+		if (this.#lastMessage) {
+			this.#fastPathKey = undefined;
+			this.#fastPathItems = undefined;
+			this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
+		}
+	}
+
+	noteTranscriptRowsOnTape(rows: number): void {
+		// Monotonic: a commit ack reports stableRows.length that can be lower
+		// than a prior append ack's emitted count only after a replay retracted
+		// rows — the tape never shrinks, so never lower the watermark.
+		const next = Number.isFinite(rows) ? Math.max(0, Math.trunc(rows)) : 0;
+		this.#blockCommittedRows = Math.max(this.#blockCommittedRows, next);
 	}
 
 	override dispose(): void {
@@ -564,7 +589,14 @@ export class AssistantMessageComponent extends Container {
 	/** Render completed prose rather than an earlier thinking row under emergency viewport pressure. */
 	renderTranscriptBlockEmergencyRow(width: number): string | undefined {
 		if (!this.#transcriptBlockFinalized) return undefined;
-		return this.#emergencyText?.render(width)[0];
+		const rendered = this.#emergencyText?.render(width) ?? [];
+		// The final-answer bubble pads its first row with a blank edge row; the
+		// emergency row must be a representative content row, so skip leading
+		// padding-only rows instead of surfacing a blank under pressure.
+		for (const line of rendered) {
+			if (/\S/.test(line.replace(/\x1b\[[0-9;]*m/g, ""))) return line;
+		}
+		return rendered[0];
 	}
 
 	getTranscriptBlockVersion(): number {
@@ -572,11 +604,22 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	markTranscriptBlockFinalized(): void {
+		const alreadyFinalized = this.#transcriptBlockFinalized;
 		this.#transcriptBlockFinalized = true;
 		this.#stopThinkingAnimation();
-		// If the live pulse was on screen when the block sealed, drop the fast path
-		// and rebuild so the placeholder is removed — finalized blocks never animate.
-		if (this.#thinkingDots) {
+		// Rebuild only on the transition into finalized (to apply the verb visual
+		// marker or drop the live thinking pulse). #handleMessageUpdate re-invokes
+		// this on every tool-arg delta once the message carries a toolCall, and
+		// repeated rebuilds of the already-sealed preamble would tear down the
+		// fast path and bump the block version on every delta.
+		if (alreadyFinalized) return;
+		const hasText = this.#lastMessage?.content.some(c => c.type === "text" && canonicalizeMessage(c.text));
+		// A rebuild re-renders the markdown from scratch, which re-lays-out rows
+		// the engine already committed to native scrollback (streamed renders are
+		// incremental; GFM column widths can grow) — the committed-prefix audit
+		// then re-anchors and duplicates history. Once any row of this block is
+		// on the tape, keep the streamed render and skip the marker restyle.
+		if (this.#thinkingDots || (hasText && this.#blockCommittedRows === 0)) {
 			this.#fastPathKey = undefined;
 			this.#fastPathItems = undefined;
 			if (this.#lastMessage) this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
@@ -931,13 +974,81 @@ export class AssistantMessageComponent extends Container {
 		for (let i = 0; i < message.content.length; i++) {
 			const content = message.content[i];
 			if (content.type === "text" && canonicalizeMessage(content.text)) {
-				// Set paddingY=0 to avoid extra spacing before tool executions
 				const trimmed = content.text.trim();
-				const mdOptions = this.#textColorTransform ? { color: this.#textColorTransform } : undefined;
-				const md = new Markdown(trimmed, 1, 0, getMarkdownTheme(), mdOptions, 0);
-				this.#contentContainer.addChild(md);
-				this.#emergencyText = md;
-				captureItems?.push({ md, contentIndex: i, blockType: "text", lastText: trimmed });
+				// Visual marker applies only to successfully completed text
+				// without a caller-supplied text transform (e.g. /live).
+				// Error/aborted turns keep the ordinary assistant style.
+				const isVerbReply =
+					!this.#textColorTransform &&
+					this.#transcriptBlockFinalized &&
+					(this.#lastMessage?.stopReason === "stop" || this.#lastMessage?.stopReason === undefined);
+				// Rows already committed to native scrollback are immutable: the
+				// streamed markdown renders incrementally, so a finalize-time rebuild
+				// re-lays-out the full text from scratch (GFM column widths, bg
+				// padding, marker glyphs) and diverges the committed prefix — the
+				// engine then re-commits and duplicates history. Only restyle blocks
+				// whose rows have not entered scrollback yet.
+				if (isVerbReply && this.#blockCommittedRows === 0) {
+					const isFinal = !this.#hasToolTimeline && !message.content.some(c => c.type === "toolCall");
+					const md = new Markdown(
+						trimmed,
+						3,
+						1,
+						getMarkdownTheme(),
+						{
+							bgColor: (value: string) => theme.bg("finalAnswerBg", value),
+							color: (value: string) => theme.fg("finalAnswerText", value),
+						},
+						0,
+					);
+					md.setIgnoreTight(true);
+					const origRender = md.render.bind(md);
+					const bgPrefix = theme.getBgAnsi("finalAnswerBg");
+					const markerText = isFinal ? "▌" : "▏";
+					const markerAnsi = theme.fg("accent", markerText);
+					let cachedSource: readonly string[] | undefined;
+					let cachedResult: readonly string[] = [];
+					md.render = (width: number): readonly string[] => {
+						const lines = origRender(width);
+						if (lines === cachedSource) return cachedResult;
+						cachedSource = lines;
+						const bgReset = "\x1b[49m";
+						const bgLineIndices: number[] = [];
+						for (let j = 0; j < lines.length; j++) {
+							if (lines[j]!.startsWith(bgPrefix)) bgLineIndices.push(j);
+						}
+						const firstBg = bgLineIndices[0] ?? -1;
+						const lastBg = bgLineIndices[bgLineIndices.length - 1] ?? -1;
+						cachedResult = lines.map((line, idx) => {
+							if (!bgPrefix || !line.startsWith(bgPrefix)) return line;
+							const stripped = line.replace(/\x1b[[0-9;]*m/g, "");
+							if (stripped.includes("```")) {
+								return line.replace(bgPrefix, "").replace(bgReset, "");
+							}
+							if (idx === firstBg || idx === lastBg) {
+							// Padding-only edge rows emit as true blanks: they keep the
+							// bubble's breathing room at full height, but stay droppable
+							// as blank padding under viewport pressure so the answer's
+							// first text row stays visible (issue: transcript squeeze).
+							const edge = line.replace(/\x1b\[[0-9;]*m/g, "");
+							return /^\s*$/.test(edge) ? "" : line;
+						}
+							return `${bgPrefix} ${markerAnsi} ${line.slice(bgPrefix.length + 3)}`;
+						});
+						return cachedResult;
+					};
+					this.#contentContainer.addChild(md);
+					this.#emergencyText = md;
+					captureItems?.push({ md, contentIndex: i, blockType: "text", lastText: trimmed });
+				} else {
+					// Streaming / error / aborted: same paddingX so layout doesn't
+					// shift when the block finalizes (avoids scrollback mismatch).
+					const mdOptions = this.#textColorTransform ? { color: this.#textColorTransform } : undefined;
+					const md = new Markdown(trimmed, 3, 0, getMarkdownTheme(), mdOptions, 0);
+					this.#contentContainer.addChild(md);
+					this.#emergencyText = md;
+					captureItems?.push({ md, contentIndex: i, blockType: "text", lastText: trimmed });
+				}
 				hasRenderedContent = true;
 			} else if (content.type === "thinking" && resolveThinkingDisplay(content, this.proseOnlyThinking).visible) {
 				const thinkingText = resolveThinkingDisplay(content, this.proseOnlyThinking).text;

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -326,6 +326,7 @@ export class ChatTranscriptBuilder {
 			this.deps.ui.imageBudget,
 			proseOnlyThinking,
 		);
+		assistantComponent.setHasToolTimeline(timeline.hasToolCalls);
 		assistantComponent.setImagesVisible(settings.get("terminal.showImages"));
 		assistantComponent.setToolResultImagesVisible(!settings.get("display.hideToolActivity"));
 		this.#trackExpandable(assistantComponent);
@@ -359,6 +360,7 @@ export class ChatTranscriptBuilder {
 				undefined,
 				proseOnlyThinking,
 			);
+			component.setHasToolTimeline(true);
 			component.setImagesVisible(settings.get("terminal.showImages"));
 			component.setToolResultImagesVisible(!settings.get("display.hideToolActivity"));
 			this.#trackExpandable(component);

--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -67,7 +67,7 @@ export class UserMessageComponent extends Container {
 					return kind === "image" ? imageReferenceHyperlink(label, index, imageLinks, () => styled) : styled;
 				},
 			});
-		const md = new Markdown(text, 1, 1, getMarkdownTheme(), {
+		const md = new Markdown(text, 3, 1, getMarkdownTheme(), {
 			bgColor,
 			color,
 		});
@@ -83,7 +83,28 @@ export class UserMessageComponent extends Container {
 		if (this.#zoneSource === lines && this.#zoneLines !== undefined) {
 			return this.#zoneLines;
 		}
-		const wrapped = lines.slice();
+		// Inject accent marker on every bg line except the first and last
+		// (paddingY blank lines — they form the bubble's top/bottom border).
+		// Fence lines (```) get bg stripped to keep native codeBlockBorder styling.
+		const bgPrefix = theme.getBgAnsi("userMessageBg");
+		const markerAnsi = theme.fg("accent", "▌");
+		const bgReset = "\x1b[49m";
+		const bgLineIndices: number[] = [];
+		for (let j = 0; j < lines.length; j++) {
+			if (lines[j]!.startsWith(bgPrefix)) bgLineIndices.push(j);
+		}
+		const firstBg = bgLineIndices[0] ?? -1;
+		const lastBg = bgLineIndices[bgLineIndices.length - 1] ?? -1;
+		const processed = lines.map((line, idx) => {
+			if (!bgPrefix || !line.startsWith(bgPrefix)) return line;
+			const stripped = line.replace(/\x1b\[[0-9;]*m/g, "");
+			if (stripped.includes("```")) {
+				return line.replace(bgPrefix, "").replace(bgReset, "");
+			}
+			if (idx === firstBg || idx === lastBg) return line;
+			return `${bgPrefix} ${markerAnsi} ${line.slice(bgPrefix.length + 3)}`;
+		});
+		const wrapped = processed.slice();
 		wrapped[0] = OSC133_ZONE_START + wrapped[0];
 		wrapped[wrapped.length - 1] = wrapped[wrapped.length - 1] + OSC133_ZONE_CLOSE;
 		this.#zoneSource = lines;

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -492,10 +492,12 @@ export class EventController {
 		if (!segment || !assistantHasVisibleContent(segment)) return undefined;
 		const existing = this.#postToolAssistantComponents.get(toolCallId);
 		if (existing) {
+			existing.setHasToolTimeline(true);
 			existing.updateContent(segment);
 			return existing;
 		}
 		const component = createAssistantMessageComponent(this.ctx);
+		component.setHasToolTimeline(true);
 		component.updateContent(segment);
 		this.#postToolAssistantComponents.set(toolCallId, component);
 		if (!this.#insertAfterTranscriptComponent(this.#toolTimelineComponents.get(toolCallId), component)) {
@@ -1277,6 +1279,7 @@ export class EventController {
 					}
 				: this.ctx.streamingMessage;
 			const displayTimeline = splitAssistantMessageToolTimeline(displayMessage);
+			this.ctx.streamingComponent.setHasToolTimeline(displayTimeline.hasToolCalls);
 			this.ctx.streamingComponent.updateContent(displayTimeline.beforeTools);
 
 			if (this.ctx.streamingMessage.stopReason !== "aborted" && this.ctx.streamingMessage.stopReason !== "error") {

--- a/packages/coding-agent/src/modes/theme/loader.ts
+++ b/packages/coding-agent/src/modes/theme/loader.ts
@@ -166,6 +166,7 @@ export function createTheme(themeJson: ThemeJson, options: CreateThemeOptions = 
 		"toolSuccessBg",
 		"toolErrorBg",
 		"statusLineBg",
+		"finalAnswerBg",
 	]);
 	for (const [key, value] of Object.entries(resolvedColors)) {
 		if (bgColorKeys.has(key)) {
@@ -173,6 +174,16 @@ export function createTheme(themeJson: ThemeJson, options: CreateThemeOptions = 
 		} else {
 			fgColors[key as ThemeColor] = value;
 		}
+	}
+	// Fallback defaults for optional theme tokens — prevents theme.bg/fg/getBgAnsi
+	// throws when a theme doesn't define finalAnswerBg/finalAnswerText. Only an
+	// absent key falls back: `0` (256-color black) and `""` (terminal default)
+	// are valid values elsewhere in the schema and must survive intact.
+	if (bgColors["finalAnswerBg" as ThemeBg] === undefined) {
+		bgColors["finalAnswerBg" as ThemeBg] = bgColors.userMessageBg ?? "#1a1f2e";
+	}
+	if (fgColors["finalAnswerText" as ThemeColor] === undefined) {
+		fgColors["finalAnswerText" as ThemeColor] = fgColors.text ?? "#e0e0e0";
 	}
 	// Extract symbol configuration - settings override takes precedence over theme
 	const symbolPreset: SymbolPreset = symbolPresetOverride ?? themeJson.symbols?.preset ?? "unicode";

--- a/packages/coding-agent/src/modes/theme/schema.ts
+++ b/packages/coding-agent/src/modes/theme/schema.ts
@@ -75,6 +75,8 @@ const themeColorsSchema = type({
 	statusLineOutput: "string | number",
 	statusLineCost: "string | number",
 	statusLineSubagents: "string | number",
+	"finalAnswerBg?": "string | number",
+	"finalAnswerText?": "string | number",
 });
 const spinnerFramesSchema = type("unknown").narrow((value): value is SpinnerFramesOverride => {
 	if (Array.isArray(value)) {
@@ -178,7 +180,8 @@ export type ThemeColor =
 	| "statusLineUntracked"
 	| "statusLineOutput"
 	| "statusLineCost"
-	| "statusLineSubagents";
+	| "statusLineSubagents"
+	| "finalAnswerText";
 
 /** Set of all valid ThemeColor string values for runtime validation */
 const THEME_COLOR_RECORD = {
@@ -242,6 +245,7 @@ const THEME_COLOR_RECORD = {
 	statusLineOutput: true,
 	statusLineCost: true,
 	statusLineSubagents: true,
+	finalAnswerText: true,
 } satisfies Record<ThemeColor, true>;
 
 const VALID_THEME_COLORS: ReadonlySet<string> = new Set(Object.keys(THEME_COLOR_RECORD));
@@ -258,6 +262,7 @@ export type ThemeBg =
 	| "toolPendingBg"
 	| "toolSuccessBg"
 	| "toolErrorBg"
-	| "statusLineBg";
+	| "statusLineBg"
+	| "finalAnswerBg";
 
 export type ColorMode = "truecolor" | "256color";

--- a/packages/coding-agent/src/modes/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/theme/theme-schema.json
@@ -370,6 +370,14 @@
 				"statusLineSubagents": {
 					"$ref": "#/$defs/colorValue",
 					"description": "Status line subagents segment"
+				},
+				"finalAnswerBg": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Background color for final assistant reply bubble (optional, defaults to userMessageBg)"
+				},
+				"finalAnswerText": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Text color for final assistant reply (optional, defaults to text color)"
 				}
 			},
 			"additionalProperties": false

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -296,10 +296,12 @@ export class UiHelpers {
 				const cached = options?.reuseSettledComponent
 					? this.ctx.transcriptMessageComponents.get(message)
 					: undefined;
+				const timeline = splitAssistantMessageToolTimeline(message);
 				const assistantComponent =
 					cached instanceof AssistantMessageComponent
 						? cached
-						: createAssistantMessageComponent(this.ctx, splitAssistantMessageToolTimeline(message).beforeTools);
+						: createAssistantMessageComponent(this.ctx, timeline.beforeTools);
+				assistantComponent.setHasToolTimeline(timeline.hasToolCalls);
 				if (cached !== assistantComponent) {
 					this.ctx.transcriptMessageComponents.set(message, assistantComponent);
 				}
@@ -486,6 +488,7 @@ export class UiHelpers {
 				const appendAssistantSegment = (segment: AssistantMessage | undefined) => {
 					if (!segment || !assistantHasVisibleContent(segment)) return;
 					const component = createAssistantMessageComponent(this.ctx, segment);
+					component.setHasToolTimeline(true);
 					this.ctx.chatContainer.addChild(component);
 				};
 

--- a/packages/coding-agent/test/event-controller-abort-render.test.ts
+++ b/packages/coding-agent/test/event-controller-abort-render.test.ts
@@ -55,7 +55,7 @@ function createFixture(opts: {
 	const updateContent = vi.fn();
 	const setComplete = vi.fn();
 	const markTranscriptBlockFinalized = vi.fn();
-	const streamingComponent = { updateContent, setComplete, markTranscriptBlockFinalized };
+	const streamingComponent = { updateContent, setComplete, markTranscriptBlockFinalized, setHasToolTimeline: vi.fn() };
 	const requestRender = vi.fn();
 
 	const ctxBase = {

--- a/packages/coding-agent/test/event-controller-error-banner.test.ts
+++ b/packages/coding-agent/test/event-controller-error-banner.test.ts
@@ -58,6 +58,7 @@ function createFixture(streamingMessage?: AssistantMessage) {
 		updateContent: vi.fn(() => componentCalls.push("update")),
 		setComplete: vi.fn(),
 		markTranscriptBlockFinalized: vi.fn(),
+		setHasToolTimeline: vi.fn(),
 		setErrorPinned: vi.fn(),
 		setHideThinkingBlock: vi.fn((hide: boolean) => componentCalls.push(`hide:${hide}`)),
 		messagePersistenceKey: vi.fn(() => "test-persistence-key"),

--- a/packages/coding-agent/test/event-controller-message-update-coalesce.test.ts
+++ b/packages/coding-agent/test/event-controller-message-update-coalesce.test.ts
@@ -55,6 +55,7 @@ function createStreamingFixture() {
 			setHideThinkingBlock: vi.fn(),
 			markTranscriptBlockFinalized: vi.fn(),
 			updateContent: vi.fn(),
+			setHasToolTimeline: vi.fn(),
 		},
 		noteDisplayableThinkingContent: vi.fn(() => false),
 		ensureLoadingAnimation: vi.fn(),

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -370,7 +370,9 @@ describe("TranscriptContainer", () => {
 		expect(transcript.peekFinalizedBatch(80, 3)).toBeUndefined();
 		const rows = transcript.renderViewport(80, 3, frame);
 		expect(rows[0]).toBe("2 more transcript blocks active");
-		expect(Bun.stripANSI(rows[1] ?? "").trim()).toBe("Implemented");
+		// Final-answer rows carry the accent gutter marker (#8155); the answer
+		// text itself must stay visible under pressure.
+		expect(Bun.stripANSI(rows[1] ?? "").trim()).toContain("Implemented");
 		expect(rows[2]).toBe("task running");
 	});
 

--- a/packages/coding-agent/test/modes/controllers/event-controller-toolcall-finalize.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-toolcall-finalize.test.ts
@@ -49,6 +49,7 @@ function createFixture(streamingMessage: AssistantMessage) {
 	const streamingComponent = {
 		updateContent: vi.fn(),
 		markTranscriptBlockFinalized,
+		setHasToolTimeline: vi.fn(),
 	};
 	const ctx = {
 		isInitialized: true,

--- a/packages/coding-agent/test/modes/controllers/event-controller-xdev-queue.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-xdev-queue.test.ts
@@ -56,7 +56,7 @@ function createFixture(streamingMessage: AssistantMessage) {
 		settings,
 		statusLine: { invalidate: vi.fn() },
 		updateEditorTopBorder: vi.fn(),
-		streamingComponent: { updateContent: vi.fn(), markTranscriptBlockFinalized: vi.fn() },
+		streamingComponent: { updateContent: vi.fn(), setHasToolTimeline: vi.fn(), markTranscriptBlockFinalized: vi.fn() },
 		streamingMessage,
 		transcriptMessageComponents: new WeakMap(),
 		pendingTools,

--- a/packages/coding-agent/test/modes/theme/final-answer-fallback.test.ts
+++ b/packages/coding-agent/test/modes/theme/final-answer-fallback.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import type { ThemeJson } from "../../../src/modes/theme/schema";
+import { createTheme } from "../../../src/modes/theme/loader";
+
+const BASE: ThemeJson = { colors: {} } as unknown as ThemeJson;
+
+describe("createTheme final-answer token fallbacks", () => {
+	it("falls back to userMessageBg/text when the tokens are absent", () => {
+		const theme = createTheme({ ...BASE, colors: { userMessageBg: "#101010", text: "#c0c0c0" } } as ThemeJson, {
+			mode: "truecolor",
+		});
+		expect(theme.getBgAnsi("finalAnswerBg")).toBe(theme.getBgAnsi("userMessageBg"));
+		expect(theme.fg("finalAnswerText", "x")).toBe(theme.fg("text", "x"));
+	});
+
+	it("keeps a theme-defined finalAnswerBg/Text even when falsy (review #3750148470)", () => {
+		// `0` is 256-color black and `""` is the terminal default; both are
+		// valid schema values (color.ts resolves "" to the reset escape and
+		// numbers to 256-color escapes), so the fallback must not overwrite
+		// them — only an absent key falls back.
+		const theme = createTheme({ ...BASE, colors: { finalAnswerBg: 0, finalAnswerText: "" } } as ThemeJson, {
+			mode: "truecolor",
+		});
+		expect(theme.getBgAnsi("finalAnswerBg")).toBe("\x1b[48;5;0m");
+		expect(theme.fg("finalAnswerText", "x")).toBe("\x1b[39mx\x1b[39m");
+	});
+
+	it("resolves the literal defaults when the theme defines nothing at all", () => {
+		const theme = createTheme(BASE, { mode: "truecolor" });
+		expect(typeof theme.getBgAnsi("finalAnswerBg")).toBe("string");
+		expect(theme.fg("finalAnswerText", "x")).toContain("x");
+	});
+});


### PR DESCRIPTION
## Summary

Distinguish the terminal assistant reply (stopReason=stop, no tool calls) from intermediate tool-use steps with a tinted background bubble and blue prompt marker. Add a matching purple prompt indicator to user messages.

## Final answer (assistant-message.ts)
- Detect isFinalAnswer (transcriptBlockFinalized + stopReason=stop + no toolCall)
- Render with Markdown paddingX=3 paddingY=1, bgColor=finalAnswerBg, color=finalAnswerText
- Override render to inject blue marker on every bg line (space + marker + space + content)
- Fence lines stripped of bg to keep native codeBlockBorder styling
- Code body lines naturally excluded (literalCode has no bgPrefix)
- markTranscriptBlockFinalized: force rebuild on stopReason=stop so marker applies immediately

## User message prompt indicator (user-message.ts)
- Change Markdown paddingX from 1 to 3
- Override render to inject purple marker on every bg line
- Fence lines stripped of bg — same treatment as final answer

## Theme registration (schema.ts, loader.ts)
- Add finalAnswerBg to ThemeBg union and bgColorKeys Set
- Add finalAnswerText to ThemeColor union
- Both are optional — existing themes work unchanged

## Verification
Tested e2e with GLM-5.2 across 4 content types:
- Plain text: marker on every line, bgColor bubble
- Table: box-drawn table with marker on every line
- Code block: fence lines no bg/marker, code body no bg/marker, surrounding text has marker
- Mixed (text + table + code block): all render correctly, only one pair of top/bottom bg padding lines