### PR TITLE
fix(ai): preserve perplexity otp session cookies

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Perplexity email-OTP login dropping the session cookies required to verify the code ([#8156](https://github.com/can1357/oh-my-pi/issues/8156)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/ai/src/registry/oauth/perplexity.ts
+++ b/packages/ai/src/registry/oauth/perplexity.ts
@@ -13,13 +13,32 @@
  */
 import * as os from "node:os";
 import { $env } from "@oh-my-pi/pi-utils";
-import { $ } from "bun";
+import { $, Cookie, CookieMap } from "bun";
 import * as AIError from "../../error";
 import type { OAuthController, OAuthCredentials } from "./types";
 
 const API_VERSION = "2.18";
 const NATIVE_APP_BUNDLE = "ai.perplexity.mac";
 const APP_USER_AGENT = "Perplexity/641 CFNetwork/1568 Darwin/25.2.0";
+
+function serializeCookies(cookies: CookieMap): string {
+	let header = "";
+	for (const [name, value] of cookies) {
+		header += `${header ? "; " : ""}${name}=${value}`;
+	}
+	return header;
+}
+
+function rememberCookies(cookies: CookieMap, response: Response): void {
+	for (const setCookie of response.headers.getSetCookie()) {
+		const cookie = Cookie.parse(setCookie);
+		if (cookie.isExpired()) {
+			cookies.delete(cookie.name);
+		} else {
+			cookies.set(cookie.name, cookie.value);
+		}
+	}
+}
 
 // ---------------------------------------------------------------------------
 // JWT helpers
@@ -101,9 +120,18 @@ async function httpEmailLogin(ctrl: OAuthController): Promise<OAuthCredentials> 
 			provider: "perplexity",
 		});
 	if (ctrl.signal?.aborted) throw new AIError.LoginCancelledError();
+	const fetchImpl = ctrl.fetch ?? fetch;
+	const cookies = new CookieMap();
+	const request = async (url: string, init: RequestInit = {}): Promise<Response> => {
+		const headers = new Headers(init.headers);
+		if (cookies.size > 0) headers.set("Cookie", serializeCookies(cookies));
+		const response = await fetchImpl(url, { ...init, headers });
+		rememberCookies(cookies, response);
+		return response;
+	};
 
 	ctrl.onProgress?.("Fetching Perplexity CSRF token...");
-	const csrfResponse = await fetch("https://www.perplexity.ai/api/auth/csrf", {
+	const csrfResponse = await request("https://www.perplexity.ai/api/auth/csrf", {
 		headers: {
 			"User-Agent": APP_USER_AGENT,
 			"X-App-ApiVersion": API_VERSION,
@@ -126,7 +154,7 @@ async function httpEmailLogin(ctrl: OAuthController): Promise<OAuthCredentials> 
 		});
 	}
 	ctrl.onProgress?.("Sending login code to your email...");
-	const sendResponse = await fetch("https://www.perplexity.ai/api/auth/signin-email", {
+	const sendResponse = await request("https://www.perplexity.ai/api/auth/signin-email", {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
@@ -156,7 +184,7 @@ async function httpEmailLogin(ctrl: OAuthController): Promise<OAuthCredentials> 
 		throw new AIError.OAuthError("OTP code is required", { kind: "validation", provider: "perplexity" });
 	if (ctrl.signal?.aborted) throw new AIError.LoginCancelledError();
 	ctrl.onProgress?.("Verifying login code...");
-	const verifyResponse = await fetch("https://www.perplexity.ai/api/auth/signin-otp", {
+	const verifyResponse = await request("https://www.perplexity.ai/api/auth/signin-otp", {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",

--- a/packages/ai/test/perplexity-login.test.ts
+++ b/packages/ai/test/perplexity-login.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { loginPerplexity } from "@oh-my-pi/pi-ai/registry/oauth/perplexity";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { withEnv } from "./helpers";
+
+type CapturedRequest = {
+	path: string;
+	cookie: string | null;
+};
+
+function cookiePairs(header: string | null): Set<string> {
+	return new Set(header?.split("; ") ?? []);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("Perplexity email OTP login", () => {
+	it("replays cookies across the CSRF, email, and OTP requests", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Unexpected global fetch"));
+		const requests: CapturedRequest[] = [];
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = new URL(input instanceof Request ? input.url : input.toString());
+			requests.push({ path: url.pathname, cookie: new Headers(init?.headers).get("Cookie") });
+
+			if (url.pathname.endsWith("/csrf")) {
+				const headers = new Headers({ "Content-Type": "application/json" });
+				headers.append("Set-Cookie", "next-auth.csrf-token=csrf-cookie; Path=/; HttpOnly; Secure");
+				headers.append("Set-Cookie", "__cf_bm=cloudflare-cookie; Path=/; Secure");
+				return new Response(JSON.stringify({ csrfToken: "csrf-token" }), { status: 200, headers });
+			}
+			if (url.pathname.endsWith("/signin-email")) {
+				return new Response("{}", {
+					status: 200,
+					headers: { "Set-Cookie": "next-auth.callback-url=callback-cookie; Path=/; HttpOnly; Secure" },
+				});
+			}
+			return new Response(JSON.stringify({ token: "perplexity-jwt", status: "success" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+		const answers = ["user@example.com", "123456"];
+
+		await withEnv({ PI_AUTH_NO_BORROW: "1" }, async () => {
+			const credentials = await loginPerplexity({
+				fetch: fetchMock,
+				onPrompt: async () => answers.shift() ?? "",
+			});
+			expect(credentials.access).toBe("perplexity-jwt");
+		});
+		expect(requests.map(request => request.path)).toEqual([
+			"/api/auth/csrf",
+			"/api/auth/signin-email",
+			"/api/auth/signin-otp",
+		]);
+		expect(requests[0]?.cookie).toBeNull();
+		expect(cookiePairs(requests[1]?.cookie ?? null)).toEqual(
+			new Set(["next-auth.csrf-token=csrf-cookie", "__cf_bm=cloudflare-cookie"]),
+		);
+		expect(cookiePairs(requests[2]?.cookie ?? null)).toEqual(
+			new Set([
+				"next-auth.csrf-token=csrf-cookie",
+				"__cf_bm=cloudflare-cookie",
+				"next-auth.callback-url=callback-cookie",
+			]),
+		);
+	});
+});


### PR DESCRIPTION
## Repro

On `main`, the controlled three-endpoint harness in `packages/ai/test/perplexity-login.test.ts` records no `Cookie` header on the CSRF, email, or OTP request and surfaces `Perplexity OTP verification failed: Bad OTP code`; run it against the pre-fix implementation with `bun test packages/ai/test/perplexity-login.test.ts`.

## Cause

`httpEmailLogin` in `packages/ai/src/registry/oauth/perplexity.ts` called `fetch` independently for `/api/auth/csrf`, `/api/auth/signin-email`, and `/api/auth/signin-otp`. Bun does not persist response cookies between those calls, so NextAuth could not associate OTP verification with the session that requested the code.

## Fix

- Parse each response's `Set-Cookie` headers into a request-local cookie map.
- Replay current cookies on every subsequent Perplexity auth request, including cookies issued while sending the email.
- Cover the complete CSRF/email/OTP exchange with an isolated fetch harness and document the user-visible fix in the AI changelog.

## Verification

`bun test packages/ai/test/perplexity-login.test.ts` passes: 1 test, 5 assertions. `cd packages/ai && bun run check` passes. `bun check` fails identically on clean `main` because `audiopus_sys` cannot execute `cmake` (`ENOENT`); the pre-publish gate was skipped.

Fixes #8156