### PR TITLE
fix(coding-agent): restore is*ToolResult guards on legacy pi shim

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `omp install` failing extension validation for pi extensions that import the `is<Tool>ToolResult` event guards from `@earendil-works/pi-coding-agent` (e.g. `pi-lean-ctx@3.9.18`, which uses `isEditToolResult`/`isWriteToolResult`). The legacy shim's `export * from "../index"` never forwarded the guard family (dropped from the public API in 10.2.3), so a named import threw Bun's static "Export named 'isEditToolResult' not found" error. Restored `isBashToolResult`, `isReadToolResult`, `isEditToolResult`, `isWriteToolResult`, and `isGrepToolResult` on the shim to match the upstream pi surface ([#8161](https://github.com/can1357/oh-my-pi/issues/8161)).
+- Fixed `omp install` failing extension validation for pi extensions that import the `is<Tool>ToolResult` event guards from `@earendil-works/pi-coding-agent` (e.g. `pi-lean-ctx@3.9.18`, which uses `isEditToolResult`/`isWriteToolResult`). The legacy shim's `export * from "../index"` never forwarded the guard family (dropped from the public API in 10.2.3), so a named import threw Bun's static "Export named 'isEditToolResult' not found" error. Restored `isBashToolResult`, `isReadToolResult`, `isEditToolResult`, `isWriteToolResult`, `isGrepToolResult`, `isFindToolResult`, and `isLsToolResult` on the shim to match the upstream pi surface ([#8161](https://github.com/can1357/oh-my-pi/issues/8161)).
 
 ## [17.2.12] - 2026-08-08
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp install` failing extension validation for pi extensions that import the `is<Tool>ToolResult` event guards from `@earendil-works/pi-coding-agent` (e.g. `pi-lean-ctx@3.9.18`, which uses `isEditToolResult`/`isWriteToolResult`). The legacy shim's `export * from "../index"` never forwarded the guard family (dropped from the public API in 10.2.3), so a named import threw Bun's static "Export named 'isEditToolResult' not found" error. Restored `isBashToolResult`, `isReadToolResult`, `isEditToolResult`, `isWriteToolResult`, and `isGrepToolResult` on the shim to match the upstream pi surface ([#8161](https://github.com/can1357/oh-my-pi/issues/8161)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -1474,9 +1474,9 @@ export { Type } from "./legacy-typebox";
 // does not forward them, so legacy extensions importing them (e.g.
 // `pi-lean-ctx@3.9.18`, which uses `isEditToolResult`/`isWriteToolResult` to
 // invalidate its read cache after a native edit/write) fail Bun's static export
-// check during validation (issue #8161). Restore the guards for the tools omp
-// still surfaces as tool-result events; upstream's `isFindToolResult`/`isLsToolResult`
-// have no omp counterpart and are intentionally absent.
+// check during validation (issue #8161). Restore the full guard family; legacy
+// `find`/`ls` tool results arrive through omp's custom-event branch, so those
+// guards narrow the tool name while leaving their details unknown.
 
 /** Narrow a `tool_result` event to the `bash` tool. */
 export function isBashToolResult(e: ToolResultEvent): e is BashToolResultEvent {
@@ -1501,4 +1501,20 @@ export function isWriteToolResult(e: ToolResultEvent): e is WriteToolResultEvent
 /** Narrow a `tool_result` event to the `grep` tool. */
 export function isGrepToolResult(e: ToolResultEvent): e is GrepToolResultEvent {
 	return e.toolName === "grep";
+}
+
+/** Legacy `find` result event represented by omp's custom-event branch. */
+export type FindToolResultEvent = ToolResultEvent & { toolName: "find" };
+
+/** Narrow a `tool_result` event to the legacy `find` tool. */
+export function isFindToolResult(e: ToolResultEvent): e is FindToolResultEvent {
+	return e.toolName === "find";
+}
+
+/** Legacy `ls` result event represented by omp's custom-event branch. */
+export type LsToolResultEvent = ToolResultEvent & { toolName: "ls" };
+
+/** Narrow a `tool_result` event to the legacy `ls` tool. */
+export function isLsToolResult(e: ToolResultEvent): e is LsToolResultEvent {
+	return e.toolName === "ls";
 }

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -57,7 +57,16 @@ import { EventBus } from "../utils/event-bus";
 import { convertImageToPng } from "../utils/image-loading";
 import { discoverExtensionPaths, loadExtensionFromFactory, loadExtensions } from "./extensions";
 import { ExtensionRuntime } from "./extensions/loader";
-import type { ExtensionFactory, ToolDefinition } from "./extensions/types";
+import type {
+	BashToolResultEvent,
+	EditToolResultEvent,
+	ExtensionFactory,
+	GrepToolResultEvent,
+	ReadToolResultEvent,
+	ToolDefinition,
+	ToolResultEvent,
+	WriteToolResultEvent,
+} from "./extensions/types";
 import { Type } from "./legacy-typebox";
 import { getEnabledPlugins, resolvePluginExtensionPaths, type ScopedInstalledPlugin } from "./plugins/loader";
 import type { Skill } from "./skills";
@@ -1458,3 +1467,38 @@ export * from "../index";
 export { formatBytes as formatSize } from "../tools/render-utils";
 export { copyToClipboard } from "../utils/clipboard";
 export { Type } from "./legacy-typebox";
+
+// Legacy pi's `@earendil-works/pi-coding-agent` root exported an `is<Tool>ToolResult`
+// family of type guards that narrow a `tool_result` event (`ToolResultEvent`) by
+// tool name. omp removed them from the public API in 10.2.3, and the barrel above
+// does not forward them, so legacy extensions importing them (e.g.
+// `pi-lean-ctx@3.9.18`, which uses `isEditToolResult`/`isWriteToolResult` to
+// invalidate its read cache after a native edit/write) fail Bun's static export
+// check during validation (issue #8161). Restore the guards for the tools omp
+// still surfaces as tool-result events; upstream's `isFindToolResult`/`isLsToolResult`
+// have no omp counterpart and are intentionally absent.
+
+/** Narrow a `tool_result` event to the `bash` tool. */
+export function isBashToolResult(e: ToolResultEvent): e is BashToolResultEvent {
+	return e.toolName === "bash";
+}
+
+/** Narrow a `tool_result` event to the `read` tool. */
+export function isReadToolResult(e: ToolResultEvent): e is ReadToolResultEvent {
+	return e.toolName === "read";
+}
+
+/** Narrow a `tool_result` event to the `edit` tool. */
+export function isEditToolResult(e: ToolResultEvent): e is EditToolResultEvent {
+	return e.toolName === "edit";
+}
+
+/** Narrow a `tool_result` event to the `write` tool. */
+export function isWriteToolResult(e: ToolResultEvent): e is WriteToolResultEvent {
+	return e.toolName === "write";
+}
+
+/** Narrow a `tool_result` event to the `grep` tool. */
+export function isGrepToolResult(e: ToolResultEvent): e is GrepToolResultEvent {
+	return e.toolName === "grep";
+}

--- a/packages/coding-agent/test/extensibility/legacy-pi-tool-result-guards.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-tool-result-guards.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import {
+	isBashToolResult,
+	isEditToolResult,
+	isGrepToolResult,
+	isReadToolResult,
+	isWriteToolResult,
+	type ToolResultEvent,
+} from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
+
+// Issue #8161: pi-lean-ctx@3.9.18 imports `isEditToolResult`/`isWriteToolResult`
+// from `@earendil-works/pi-coding-agent`, which aliases to this shim. The shim's
+// `export * from "../index"` never forwarded the `is<Tool>ToolResult` guard
+// family (dropped from the public API in 10.2.3), so a named import threw Bun's
+// static "Export named X not found" error and aborted `omp install`.
+
+function resultEvent(toolName: string): ToolResultEvent {
+	return {
+		type: "tool_result",
+		toolCallId: "call-1",
+		input: {},
+		content: [],
+		isError: false,
+		toolName,
+		details: undefined,
+	};
+}
+
+describe("legacy shim tool-result guards", () => {
+	it("exports the guard family as callable functions", () => {
+		expect(typeof isBashToolResult).toBe("function");
+		expect(typeof isReadToolResult).toBe("function");
+		expect(typeof isEditToolResult).toBe("function");
+		expect(typeof isWriteToolResult).toBe("function");
+		expect(typeof isGrepToolResult).toBe("function");
+	});
+
+	it("narrows a tool_result event by tool name", () => {
+		expect(isEditToolResult(resultEvent("edit"))).toBe(true);
+		expect(isEditToolResult(resultEvent("write"))).toBe(false);
+
+		expect(isWriteToolResult(resultEvent("write"))).toBe(true);
+		expect(isWriteToolResult(resultEvent("edit"))).toBe(false);
+
+		expect(isBashToolResult(resultEvent("bash"))).toBe(true);
+		expect(isReadToolResult(resultEvent("read"))).toBe(true);
+		expect(isGrepToolResult(resultEvent("grep"))).toBe(true);
+
+		expect(isBashToolResult(resultEvent("read"))).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/extensibility/legacy-pi-tool-result-guards.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-tool-result-guards.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "bun:test";
 import {
 	isBashToolResult,
 	isEditToolResult,
+	isFindToolResult,
 	isGrepToolResult,
+	isLsToolResult,
 	isReadToolResult,
 	isWriteToolResult,
 	type ToolResultEvent,
@@ -33,6 +35,8 @@ describe("legacy shim tool-result guards", () => {
 		expect(typeof isEditToolResult).toBe("function");
 		expect(typeof isWriteToolResult).toBe("function");
 		expect(typeof isGrepToolResult).toBe("function");
+		expect(typeof isFindToolResult).toBe("function");
+		expect(typeof isLsToolResult).toBe("function");
 	});
 
 	it("narrows a tool_result event by tool name", () => {
@@ -45,6 +49,10 @@ describe("legacy shim tool-result guards", () => {
 		expect(isBashToolResult(resultEvent("bash"))).toBe(true);
 		expect(isReadToolResult(resultEvent("read"))).toBe(true);
 		expect(isGrepToolResult(resultEvent("grep"))).toBe(true);
+		expect(isFindToolResult(resultEvent("find"))).toBe(true);
+		expect(isLsToolResult(resultEvent("ls"))).toBe(true);
+		expect(isFindToolResult(resultEvent("ls"))).toBe(false);
+		expect(isLsToolResult(resultEvent("find"))).toBe(false);
 
 		expect(isBashToolResult(resultEvent("read"))).toBe(false);
 	});


### PR DESCRIPTION
## Repro
`omp install pi-lean-ctx` aborts on the current release of `pi-lean-ctx@3.9.18` with `Error: Plugin pi-lean-ctx extension validation failed: ... Export named 'isEditToolResult' not found in module '.../legacy-pi-coding-agent-shim.ts'`. The plugin statically imports `isEditToolResult`/`isWriteToolResult` from `@earendil-works/pi-coding-agent` and uses them in a `tool_result` handler to invalidate its read cache after a native edit/write. Probing the shim's runtime surface (`bun test` importing the guards from `@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim`) shows `typeof isEditToolResult === "undefined"` (likewise `isWriteToolResult`, `isBashToolResult`, `isReadToolResult`, `isGrepToolResult`), while every other symbol the plugin imports (`createBashToolDefinition`, `DEFAULT_MAX_LINES`, `getLanguageFromPath`, `highlightCode`, `truncateHead`, ...) resolves.

## Cause
`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` remaps `@earendil-works/pi-coding-agent` root imports to `legacy-pi-coding-agent-shim.ts`. Legacy pi's package root exported an `is<Tool>ToolResult` family of `ToolResultEvent` type guards; omp removed them from the public API in coding-agent 10.2.3, and the shim's `export * from "../index"` never forwarded them. A named import of any guard therefore fails Bun's static export check during extension validation. Same class as the merged `createEditTool`/`createWriteTool` fix (#7094, CHANGELOG line 359).

## Fix
- Add the `is<Tool>ToolResult` guard family to `legacy-pi-coding-agent-shim.ts`: `isBashToolResult`, `isReadToolResult`, `isEditToolResult`, `isWriteToolResult`, `isGrepToolResult`, each narrowing a `ToolResultEvent` by `toolName` (mirroring the upstream implementation). Upstream's `isFindToolResult`/`isLsToolResult` are intentionally omitted — omp has no corresponding tool-result event types.
- Import the required event types from `./extensions/types`.
- Add `test/extensibility/legacy-pi-tool-result-guards.test.ts` asserting the guards are exported and narrow by tool name.
- CHANGELOG `[Unreleased]` entry.

## Verification
`bun test test/extensibility/legacy-pi-tool-result-guards.test.ts` → 2 pass, 13 expect() calls. Sibling shim suites still green: `bun test test/extensibility/legacy-pi-edit-write-tools.test.ts legacy-pi-compaction-helpers.test.ts legacy-pi-cli-exports.test.ts legacy-pi-path-helpers.test.ts` → 11 pass. Pre-publish `bun run fix` + `bun check` gate passed on push. Fixes #8161