### PR TITLE
docs(collab): clarify relay self-hosting availability

### DIFF
--- a/docs/collab.md
+++ b/docs/collab.md
@@ -112,6 +112,10 @@ Set `collab.webUrl` when the browser UI is hosted separately from the websocket 
 
 ## Self-hosting the relay
 
+The production relay is not currently distributed for self-hosting: its Go source and standalone binaries are not published. The endpoint list below documents the hosted service's network contract, not an installable release.
+
+For local protocol development, this repository includes a source-available, WebSocket-only stand-in at [`packages/collab-web/scripts/local-relay.ts`](../packages/collab-web/scripts/local-relay.ts). Run `bun run relay` from `packages/collab-web` to listen on `ws://localhost:7466`. It implements `/r/<roomId>` but does not serve the browser client, `/share` blobs, or `/healthz`, so it is not a replacement for the production service.
+
 The relay is a small content-blind Go service. It keeps no state beyond live connections and exposes:
 
 - `GET /` — the static collab-web guest client (target of the `/collab` deep link),

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Clarified that the production collab relay source and binaries are not currently published, and documented the source-available local protocol relay ([#8165](https://github.com/can1357/oh-my-pi/issues/8165)).
+
 ## [17.2.12] - 2026-08-08
 
 ### Fixed


### PR DESCRIPTION
## Repro

On current `main`, extracting the self-hosting section with `bun -e 'const text=await Bun.file("docs/collab.md").text(); const section=text.split("## Self-hosting the relay\n")[1].split("\n## ")[0]; console.log(section.trim())'` shows only the hosted relay endpoint list; it provides no source, binary, build, or deployment path.

## Cause

`docs/collab.md` labeled the hosted Go relay contract as self-hosting documentation even though the production source and standalone binaries are not published, and it omitted the separate development relay already available at `packages/collab-web/scripts/local-relay.ts`.

## Fix

- State explicitly that the hosted Go relay is not currently distributed for self-hosting.
- Link the source-available local WebSocket relay, its `bun run relay` startup command, and its production-relevant limitations.
- Record the documentation correction in the coding-agent changelog.

## Verification

`bun run relay` from `packages/collab-web` started successfully at `ws://localhost:7466` and stopped cleanly; the pre-publish `bun check` gate passed.

Fixes #8165